### PR TITLE
HIG-104: Some DevTools Window Topbar items are not accessible on narrow viewport widths

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/DevToolsWindow.module.scss
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/DevToolsWindow.module.scss
@@ -81,4 +81,5 @@
     background-color: white;
     height: 45px;
     border-bottom: 1px solid #eaeaea;
+    overflow-y: auto;
 }


### PR DESCRIPTION
![Kapture 2021-02-01 at 18 18 08](https://user-images.githubusercontent.com/16027268/106543067-de864180-64b9-11eb-849c-b63afbcb28ce.gif)
