### PR TITLE
HIG-113: Move toolbar update time to context/hook

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -48,6 +48,24 @@ export const usePlayer = ({
         }
     }, [eventsData]);
 
+    // "Subscribes" the time with the Replayer when the Player is playing.
+    useEffect(() => {
+        if (state === ReplayerState.Playing) {
+            let timerId: number;
+
+            const frameAction = () => {
+                if (replayer) {
+                    setTime(replayer.getCurrentTime());
+                }
+                timerId = requestAnimationFrame(frameAction);
+            };
+
+            timerId = requestAnimationFrame(frameAction);
+
+            return () => cancelAnimationFrame(timerId);
+        }
+    }, [state, replayer]);
+
     const play = (newTime?: number) => {
         setState(ReplayerState.Playing);
         setTime(newTime ?? time);
@@ -60,11 +78,29 @@ export const usePlayer = ({
         replayer?.pause(newTime);
     };
 
+    /**
+     * Wraps the setTime call so we can also forward the setTime request to the Replayer. Without forwarding time and Replayer.getCurrentTime() would be out of sync.
+     */
+    const setTimeHandler = (newTime?: number) => {
+        switch (state) {
+            case ReplayerState.Playing:
+                play(newTime);
+                return;
+            case ReplayerState.Paused:
+            case ReplayerState.LoadedAndUntouched:
+                pause(newTime);
+                return;
+
+            default:
+                return;
+        }
+    };
+
     return {
         scale,
         setScale,
         time,
-        setTime,
+        setTime: setTimeHandler,
         replayer,
         state,
         events,

--- a/frontend/src/pages/Player/Toolbar/Toolbar.tsx
+++ b/frontend/src/pages/Player/Toolbar/Toolbar.tsx
@@ -34,22 +34,9 @@ export const Toolbar = ({ onResize }: { onResize: () => void }) => {
     );
 
     const [lastCanvasPreview, setLastCanvasPreview] = useState(0);
-    const [isDragged, setIsDragged] = useState(false);
     const isPaused =
         state === ReplayerState.Paused ||
         state === ReplayerState.LoadedAndUntouched;
-
-    // When not paused and not dragged, update the current time.
-    // When the current time is updated, the function calls itself again.
-    useEffect(() => {
-        if (replayer) {
-            if (!isPaused && !isDragged) {
-                setTimeout(() => {
-                    setTime(replayer.getCurrentTime());
-                }, 50);
-            }
-        }
-    }, [replayer, isPaused, isDragged, time, setTime]);
 
     useEffect(() => {
         onResize();
@@ -78,7 +65,6 @@ export const Toolbar = ({ onResize }: { onResize: () => void }) => {
         newTime = Math.min(max, newTime);
 
         setLastCanvasPreview(e.x);
-        setIsDragged(false);
 
         if (isPaused) {
             pause(newTime);
@@ -89,7 +75,6 @@ export const Toolbar = ({ onResize }: { onResize: () => void }) => {
 
     let startDraggable = (e: any, data: any) => {
         setLastCanvasPreview(data.x);
-        setIsDragged(true);
         if (!isPaused) {
             pause();
         }
@@ -164,10 +149,8 @@ export const Toolbar = ({ onResize }: { onResize: () => void }) => {
                         onClick={() => {
                             if (isPaused) {
                                 play(time);
-                                setIsDragged(false);
                             } else {
                                 pause(time);
-                                setIsDragged(false);
                             }
                         }}
                     >


### PR DESCRIPTION
- Moves the time setting from `Toolbar` into `usePlayer`
- Replaces `setTimeout` with `requestAnimationFrame`. This allows us to avoid bombarding the renderer with more requests than it can handle.