### PR TITLE
Compress backend responses

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -130,11 +130,11 @@ func main() {
 		go func() {
 			w.Start()
 		}()
-		log.Fatal(http.ListenAndServe(":"+port, loggedRouter))
+		log.Fatal(http.ListenAndServe(":"+port, handlers.CompressHandler(loggedRouter)))
 	} else if rt == "worker" {
 		w.Start()
 	} else if rt == "server" {
-		log.Fatal(http.ListenAndServe(":"+port, loggedRouter))
+		log.Fatal(http.ListenAndServe(":"+port, handlers.CompressHandler(loggedRouter)))
 	}
 	log.Errorf("invalid runtime")
 }


### PR DESCRIPTION
- Responses are compressed based on the accepted client formats

Before (21.2mb total)

![image](https://user-images.githubusercontent.com/16027268/107173968-ee9c9600-697d-11eb-879d-82079b2321b7.png)


After (3.4mb total)

![image (1)](https://user-images.githubusercontent.com/16027268/107173975-f4927700-697d-11eb-8cce-22b7432d9e7f.png)
