### PR TITLE
HIG-144: Update the cache for viewed sessions

### DIFF
--- a/backend/main-graph/graph/generated/generated.go
+++ b/backend/main-graph/graph/generated/generated.go
@@ -179,7 +179,7 @@ type ComplexityRoot struct {
 type MutationResolver interface {
 	CreateOrganization(ctx context.Context, name string) (*model1.Organization, error)
 	EditOrganization(ctx context.Context, id int, name *string, billingEmail *string) (*model1.Organization, error)
-	MarkSessionAsViewed(ctx context.Context, id int) (*bool, error)
+	MarkSessionAsViewed(ctx context.Context, id int) (*model1.Session, error)
 	DeleteOrganization(ctx context.Context, id int) (*bool, error)
 	SendAdminInvite(ctx context.Context, organizationID int, email string) (*string, error)
 	AddAdminToOrganization(ctx context.Context, organizationID int, inviteID string) (*int, error)
@@ -1187,7 +1187,7 @@ enum Plan {
 type Mutation {
     createOrganization(name: String!): Organization
     editOrganization(id: ID!, name: String, billing_email: String): Organization
-    markSessionAsViewed(id: ID!): Boolean
+    markSessionAsViewed(id: ID!): Session
     deleteOrganization(id: ID!): Boolean
     sendAdminInvite(organization_id: ID!, email: String!): String
     addAdminToOrganization(organization_id: ID!, invite_id: String!): ID
@@ -2456,9 +2456,9 @@ func (ec *executionContext) _Mutation_markSessionAsViewed(ctx context.Context, f
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*bool)
+	res := resTmp.(*model1.Session)
 	fc.Result = res
-	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+	return ec.marshalOSession2ᚖgithubᚗcomᚋjayᚑkhatriᚋfullstoryᚋbackendᚋmodelᚐSession(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_deleteOrganization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {

--- a/backend/main-graph/graph/schema.graphqls
+++ b/backend/main-graph/graph/schema.graphqls
@@ -165,7 +165,7 @@ enum Plan {
 type Mutation {
     createOrganization(name: String!): Organization
     editOrganization(id: ID!, name: String, billing_email: String): Organization
-    markSessionAsViewed(id: ID!): Boolean
+    markSessionAsViewed(id: ID!): Session
     deleteOrganization(id: ID!): Boolean
     sendAdminInvite(organization_id: ID!, email: String!): String
     addAdminToOrganization(organization_id: ID!, invite_id: String!): ID

--- a/backend/main-graph/graph/schema.resolvers.go
+++ b/backend/main-graph/graph/schema.resolvers.go
@@ -74,18 +74,20 @@ func (r *mutationResolver) EditOrganization(ctx context.Context, id int, name *s
 	return org, nil
 }
 
-func (r *mutationResolver) MarkSessionAsViewed(ctx context.Context, id int) (*bool, error) {
+func (r *mutationResolver) MarkSessionAsViewed(ctx context.Context, id int) (*model.Session, error) {
 	_, err := r.isAdminSessionOwner(ctx, id)
 	if err != nil {
 		return nil, e.Wrap(err, "admin not session owner")
 	}
-	if err := r.DB.Model(&model.Session{Model: model.Model{ID: id}}).Updates(&model.Session{
+	session := &model.Session{}
+	res := r.DB.Where(&model.Session{Model: model.Model{ID: id}}).First(&session)
+	if err := res.Update(&model.Session{
 		Viewed: true,
 	}).Error; err != nil {
 		return nil, e.Wrap(err, "error writing session as viewed")
 	}
-	t := true
-	return &t, nil
+
+	return session, nil
 }
 
 func (r *mutationResolver) DeleteOrganization(ctx context.Context, id int) (*bool, error) {

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -5,7 +5,10 @@ import * as Apollo from '@apollo/client';
 
 export const MarkSessionAsViewedDocument = gql`
     mutation MarkSessionAsViewed($id: ID!) {
-        markSessionAsViewed(id: $id)
+        markSessionAsViewed(id: $id) {
+            id
+            viewed
+        }
     }
 `;
 export type MarkSessionAsViewedMutationFn = Apollo.MutationFunction<

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4,10 +4,11 @@ export type MarkSessionAsViewedMutationVariables = Types.Exact<{
     id: Types.Scalars['ID'];
 }>;
 
-export type MarkSessionAsViewedMutation = { __typename?: 'Mutation' } & Pick<
-    Types.Mutation,
-    'markSessionAsViewed'
->;
+export type MarkSessionAsViewedMutation = { __typename?: 'Mutation' } & {
+    markSessionAsViewed?: Types.Maybe<
+        { __typename?: 'Session' } & Pick<Types.Session, 'id' | 'viewed'>
+    >;
+};
 
 export type CreateOrUpdateSubscriptionMutationVariables = Types.Exact<{
     organization_id: Types.Scalars['ID'];

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -240,7 +240,7 @@ export type Mutation = {
     __typename?: 'Mutation';
     createOrganization?: Maybe<Organization>;
     editOrganization?: Maybe<Organization>;
-    markSessionAsViewed?: Maybe<Scalars['Boolean']>;
+    markSessionAsViewed?: Maybe<Session>;
     deleteOrganization?: Maybe<Scalars['Boolean']>;
     sendAdminInvite?: Maybe<Scalars['String']>;
     addAdminToOrganization?: Maybe<Scalars['ID']>;

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -1,5 +1,8 @@
 mutation MarkSessionAsViewed($id: ID!) {
-    markSessionAsViewed(id: $id)
+    markSessionAsViewed(id: $id) {
+        id
+        viewed
+    }
 }
 
 mutation CreateOrUpdateSubscription($organization_id: ID!, $plan: Plan!) {


### PR DESCRIPTION
Learnings:

- Using `refetch` or `refetchQueries` will cause another round trip to get the updated data
   1. 1 round trip for the PUT to update the data
   2. 1 round trip for the GET for the updated data
- To avoid an extra round trip, the mutation will return the edited data
   1. 1 round trip for the PUT to update the data
   2. 0 round trip for getting the new data. Apollo Client will update the client's cache based on the ID and the updated fields