### PR TITLE
Navigate user back to / if they're not logged in

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import {
     Route,
     BrowserRouter as Router,
     Redirect,
+    useHistory,
 } from 'react-router-dom';
 import { H } from 'highlight.run';
 import { OrgRouter } from './OrgRouter';
@@ -117,6 +118,7 @@ export const AuthAppRouter = () => {
     const [signIn, setSignIn] = useState<boolean>(true);
     const [firebaseError, setFirebaseError] = useState('');
     const [user, loading, error] = useAuthState(auth);
+    const history = useHistory();
 
     const onSubmit = (data: Inputs) => {
         if (signIn) {
@@ -156,6 +158,8 @@ export const AuthAppRouter = () => {
 
     if (user) {
         return <AuthAdminRouter />;
+    } else {
+        history.push('/');
     }
 
     return (


### PR DESCRIPTION
Problem:

- If a user is not logged in and is on `https://app.highlight.run/123/sessions`, after logging in the redirect will take them back to that org which they may not have access to. This shows a non-actionable graphql error.

Sanity checks:

1. `/demo` works while authenticated and not authenticated