### PR TITLE
Remove explicit font imports in index.html

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -14,41 +14,6 @@
             href="https://cdn.jsdelivr.net/npm/rrweb-player@latest/dist/style.css"
         />
         <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-        <link
-            rel="preload"
-            as="font"
-            href="/font/AvenirNext-Bold.woff2"
-            type="font/woff2"
-            crossorigin="anonymous"
-        />
-        <link
-            rel="preload"
-            as="font"
-            href="/font/AvenirNext-DemiBold.woff2"
-            type="font/woff2"
-            crossorigin="anonymous"
-        />
-        <link
-            rel="preload"
-            as="font"
-            href="/font/AvenirNext-Medium.woff2"
-            type="font/woff2"
-            crossorigin="anonymous"
-        />
-        <link
-            rel="preload"
-            as="font"
-            href="/font/AvenirNext-Regular.woff2"
-            type="font/woff2"
-            crossorigin="anonymous"
-        />
-        <link
-            rel="preload"
-            as="font"
-            href="/font/AvenirNext-UltraLight.woff2"
-            type="font/woff2"
-            crossorigin="anonymous"
-        />
         <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
- Removes the warnings.
- We can do this because the fonts are being loaded through Webpack behind the scenes since we reference the font files directly from the sass files.
- Also added a header for the fonts on Render for `cache-control: public, max-age=31536000`