### PR TITLE
Add assumeImmutableResults

### DIFF
--- a/frontend/src/util/graph.tsx
+++ b/frontend/src/util/graph.tsx
@@ -21,6 +21,7 @@ const authLink = setContext((_, { headers }) => {
 export const client = new ApolloClient({
     link: authLink.concat(httpLink),
     cache: new InMemoryCache(),
+    assumeImmutableResults: true,
     connectToDevTools:
         process.env.REACT_APP_ENVIRONMENT === 'dev' ? true : false,
 });


### PR DESCRIPTION
Performance gain by telling Apollo Client to do less work. This requires us to not modify the Apollo Client data directly (we need to make a copy either explicitly or implicitly using something like Immer). Apollo Client will throw errors in the console if it detects these changes in the development build.

I spot checked our queries and didn't find anywhere we mutate the data directly.