### PR TITLE
Getting rid of `addCustomEvent` call temporarily

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -204,10 +204,6 @@ export class Highlight {
                     'currentSessionID',
                     this.sessionID.toString()
                 );
-                addCustomEvent('Viewport', {
-                    height: window.innerHeight,
-                    width: window.innerWidth,
-                });
             }
             setInterval(() => {
                 this._save();


### PR DESCRIPTION
Getting rid of the call to `addCustomEvent` in `initializeSession` because `rrweb` throws an error saying that we must call `addCustomEvent` after `record` starts. 

I believe this waas making recording flaky. @JohnPhamous a fix shouldn't be hard, just have to `addCustomEvent` after the fact.