### PR TITLE
Cleanup error graph logic

### DIFF
--- a/frontend/src/pages/Errors/ErrorFeed/ErrorFeed.tsx
+++ b/frontend/src/pages/Errors/ErrorFeed/ErrorFeed.tsx
@@ -131,7 +131,7 @@ export const ErrorFeed = () => {
 const ErrorCard = ({ errorGroup }: { errorGroup: Maybe<ErrorGroup> }) => {
     const { organization_id } = useParams<{ organization_id: string }>();
     const [hovered, setHovered] = useState(false);
-    // Represents the last six days i.e. [5 days ago, 5 days ago, 4 days ago, etc..]
+    // Represents the last six days i.e. [5 days ago, 4 days ago, 3 days ago, etc..]
     const [errorDates, setErrorDates] = useState<Array<number>>(
         Array(6).fill(0)
     );


### PR DESCRIPTION
Cleans up the error logic a little. This also adds a transition to the graph so the bars start at 0 and increase as they get populated. 

Check that this actually works 😅 . The graphs that show up for me seem pretty sane, but a sanity check would be appreciated