### PR TITLE
Persist Search Parameters for Segments

### DIFF
--- a/frontend/src/pages/Errors/ErrorSegmentSidebar/SegmentPicker/SegmentPicker.tsx
+++ b/frontend/src/pages/Errors/ErrorSegmentSidebar/SegmentPicker/SegmentPicker.tsx
@@ -11,7 +11,6 @@ import styles from './SegmentPicker.module.scss';
 import { useGetErrorSegmentsQuery } from '../../../../graph/generated/hooks';
 import { gqlSanitize } from '../../../../util/gqlSanitize';
 import classNames from 'classnames';
-import { EmptySessionsSearchParams } from '../../../Sessions/SessionsPage';
 import _ from 'lodash';
 import { EmptyErrorsSearchParams } from '../../ErrorsPage';
 
@@ -57,6 +56,9 @@ export const ErrorSegmentPicker = () => {
                 // Redirect home since the segment doesn't exist anymore.
                 history.replace(`/${organization_id}/errors`);
             }
+        } else {
+            setSearchParams(EmptyErrorsSearchParams);
+            setExistingParams(EmptyErrorsSearchParams);
         }
     }, [
         currentSegment,
@@ -79,7 +81,7 @@ export const ErrorSegmentPicker = () => {
                     <Link
                         to={{
                             pathname: `/${organization_id}/errors`,
-                            state: EmptySessionsSearchParams,
+                            state: EmptyErrorsSearchParams,
                         }}
                         key={'errors'}
                     >

--- a/frontend/src/pages/Errors/ErrorsPage.tsx
+++ b/frontend/src/pages/Errors/ErrorsPage.tsx
@@ -11,10 +11,15 @@ import { useLocalStorage } from '@rehooks/local-storage';
 import { SidebarContext } from '../../components/Sidebar/SidebarContext';
 import { FeedNavigation } from '../Sessions/SearchSidebar/FeedNavigation/FeedNavigation';
 import { IntegrationCard } from '../Sessions/IntegrationCard/IntegrationCard';
+import { Complete } from '../../util/types';
 
-export const EmptyErrorsSearchParams = {
-    user_properties: [],
-    identified: false,
+export const EmptyErrorsSearchParams: Complete<ErrorSearchParams> = {
+    browser: undefined,
+    date_range: undefined,
+    event: undefined,
+    hide_resolved: false,
+    os: undefined,
+    visited_url: undefined,
 };
 
 export const ErrorsPage = ({ integrated }: { integrated: boolean }) => {

--- a/frontend/src/pages/Sessions/SearchSidebar/SegmentPicker/SegmentPicker.tsx
+++ b/frontend/src/pages/Sessions/SearchSidebar/SegmentPicker/SegmentPicker.tsx
@@ -70,6 +70,9 @@ export const SegmentPicker = () => {
                 // Redirect home since the segment doesn't exist anymore.
                 history.replace(`/${organization_id}/sessions`);
             }
+        } else {
+            setSearchParams(EmptySessionsSearchParams);
+            setExistingParams(EmptySessionsSearchParams);
         }
     }, [
         currentSegment,

--- a/frontend/src/pages/Sessions/SessionsPage.tsx
+++ b/frontend/src/pages/Sessions/SessionsPage.tsx
@@ -12,13 +12,23 @@ import { SidebarContext } from '../../components/Sidebar/SidebarContext';
 import { FeedNavigation } from './SearchSidebar/FeedNavigation/FeedNavigation';
 import { useHistory } from 'react-router';
 import { useParams } from 'react-router-dom';
+import { Complete } from '../../util/types';
 
 /**
  * The initial search parameters. This is used when the user has not specified any search parameters.
  */
-export const EmptySessionsSearchParams: SearchParams = {
+export const EmptySessionsSearchParams: Complete<SearchParams> = {
     user_properties: [],
     identified: false,
+    browser: undefined,
+    date_range: undefined,
+    excluded_properties: [],
+    hide_viewed: false,
+    length_range: undefined,
+    os: undefined,
+    referrer: undefined,
+    track_properties: [],
+    visited_url: undefined,
 };
 
 export const SessionsPage = ({ integrated }: { integrated: boolean }) => {

--- a/frontend/src/util/types.ts
+++ b/frontend/src/util/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Makes all properties required. Unlike Typescript's Required utility type, this type allows for fields to be nullish.
+ * This is useful when you want to enforce all properties to be consumed.
+ */
+export type Complete<T> = {
+    [P in keyof Required<T>]: Pick<T, P> extends Required<Pick<T, P>>
+        ? T[P]
+        : T[P] | undefined;
+};


### PR DESCRIPTION
Use cases

1. `All Sessions` segment selected, adds some parameters, goes into session, goes back. Expected: Parameters remain.
1. `All sessions` segment selected, adds some paremeters, switches to another segment. Expected: Selected segment's parameters are applied.
1. `Segment A` selected, goes into session, goes back. Expected: `Segment A`'s parameters are selected.
1. `Segment A` selected, `Segment B` selected. Expected: `Segment B`'s parameters are selected.
1. Opens /1/sessions. Expected: Last used parameters are selected.
1. Opens /1/sessions/segment/1. Expected: Segment 1's parameters are selected. 