### PR TITLE
Get rid of useless associations

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -125,7 +125,6 @@ type EmailSignup struct {
 type User struct {
 	Model
 	OrganizationID int
-	Sessions       []Session
 }
 
 type SessionResults struct {
@@ -156,7 +155,6 @@ type Session struct {
 	BrowserVersion string `json:"browser_version"`
 	Status         string `json:"status"`
 	Language       string `json:"language"`
-	EventsObjects  []EventsObject
 	// Tells us if the session has been parsed by a worker.
 	Processed *bool `json:"processed"`
 	// The length of a session.


### PR DESCRIPTION
My dev environment for running 'automigrate'  is not working; likely because updating gorm made some checks a little more strict. This gets rid of a couple associations in our model. 

Confirm that they're not being use anywhere.