### PR TITLE
Process errror.event properly

### DIFF
--- a/backend/util/strings.go
+++ b/backend/util/strings.go
@@ -3,22 +3,9 @@ package util
 import "encoding/json"
 
 func JsonStringToStringArray(s string) []*string {
-	var eventInterface interface{}
+	var eventInterface []*string
 	if err := json.Unmarshal([]byte(s), &eventInterface); err != nil {
-		return nil
+		return []*string{&s}
 	}
-	// the event interface is either in the form 'string' or '[]string':
-	if val, ok := eventInterface.(string); ok {
-		return []*string{&val}
-	}
-	if val, ok := eventInterface.([]interface{}); ok {
-		ret := []*string{}
-		for _, v := range val {
-			if s, ok := v.(string); ok {
-				ret = append(ret, &s)
-			}
-		}
-		return ret
-	}
-	return nil
+	return eventInterface
 }


### PR DESCRIPTION
Custom H.error pushes were pushing strings to the DB so Unmarshal fails returning empty arrays although there is content. This should fix it. 