### PR TITLE
quick fix for thresholded error alerts

### DIFF
--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -270,7 +270,7 @@ func (r *mutationResolver) PushPayload(ctx context.Context, sessionID int, event
 							log.Error(e.Wrapf(err, "error counting errors from past %d minutes", *errorAlert.ThresholdWindow))
 						}
 					}
-					if errorAlert.CountThreshold < 1 || numErrors >= int64(errorAlert.CountThreshold) {
+					if errorAlert.CountThreshold <= 1 || numErrors >= int64(errorAlert.CountThreshold) {
 						if channelsToNotify, err := errorAlert.GetChannelsToNotify(); err != nil {
 							log.Error(e.Wrap(err, "error getting channels to notify from ErrorAlert"))
 						} else {


### PR DESCRIPTION
default threshold is 1, so this should've be <= not <