### PR TITLE
Trying to speed up Sessions query

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1520,51 +1520,28 @@ func (r *queryResolver) Sessions(ctx context.Context, organizationID int, count 
 	whereClause += "AND (deleted_at IS NULL) "
 
 	if len(fieldIds) > 0 {
-		whereClause += "AND ("
-		for idx, id := range fieldIds {
-			if idx == 0 {
-				whereClause += fmt.Sprintf("(fieldIds @> ARRAY[%d]::int[]) ", id)
-			} else {
-				whereClause += fmt.Sprintf("OR (fieldIds @> ARRAY[%d]::int[]) ", id)
-			}
-		}
-		whereClause += ") "
+		t := strings.Replace(fmt.Sprint(fieldIds), " ", ",", -1)
+		whereClause += fmt.Sprintf("AND (fieldIds && ARRAY%s::integer[])", t)
 	}
 
 	if len(visitedIds) > 0 {
-		whereClause += "AND ("
-		for idx, id := range visitedIds {
-			if idx == 0 {
-				whereClause += fmt.Sprintf("(fieldIds @> ARRAY[%d]::int[]) ", id)
-			} else {
-				whereClause += fmt.Sprintf("OR (fieldIds @> ARRAY[%d]::int[]) ", id)
-			}
-		}
-		whereClause += ") "
+		t := strings.Replace(fmt.Sprint(visitedIds), " ", ",", -1)
+		whereClause += fmt.Sprintf("AND (fieldIds && ARRAY%s::integer[])", t)
 	}
 
 	if len(referrerIds) > 0 {
-		whereClause += "AND ("
-		for idx, id := range referrerIds {
-			if idx == 0 {
-				whereClause += fmt.Sprintf("(fieldIds @> ARRAY[%d]::int[]) ", id)
-			} else {
-				whereClause += fmt.Sprintf("OR (fieldIds @> ARRAY[%d]::int[]) ", id)
-			}
-		}
-		whereClause += ") "
+		t := strings.Replace(fmt.Sprint(referrerIds), " ", ",", -1)
+		whereClause += fmt.Sprintf("AND (fieldIds && ARRAY%s::integer[])", t)
 	}
 
 	if len(notFieldIds) > 0 {
-		for _, id := range notFieldIds {
-			whereClause += fmt.Sprintf("AND NOT (fieldIds @> ARRAY[%d]::int[]) ", id)
-		}
+		t := strings.Replace(fmt.Sprint(notFieldIds), " ", ",", -1)
+		whereClause += fmt.Sprintf("AND NOT (fieldIds && ARRAY%s::integer[])", t)
 	}
 
 	if len(notTrackFieldIds) > 0 {
-		for _, id := range notTrackFieldIds {
-			whereClause += fmt.Sprintf("AND NOT (fieldIds @> ARRAY[%d]::int[]) ", id)
-		}
+		t := strings.Replace(fmt.Sprint(notTrackFieldIds), " ", ",", -1)
+		whereClause += fmt.Sprintf("AND NOT (fieldIds && ARRAY%s::integer[])", t)
 	}
 
 	if d := params.DateRange; d != nil {


### PR DESCRIPTION
should we put an index on every column that you can search by?
so far, the indexes we have on the `sessions` are:
```
indexname
idx_sessions_app_version
idx_sessions_firstload_version
sessions_organization_id_viewed_idx
sessions_payload_updated_at_idx
idx_sessions_within_billing_quota
sessions_organization_id_idx
idx_sessions_client_version
sessions_pkey
```