### PR TITLE
Handle mappedstacktrace on error page

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -75,24 +75,24 @@ func (r *errorGroupResolver) StackTrace(ctx context.Context, obj *model.ErrorGro
 	if (obj.MappedStackTrace == nil || *obj.MappedStackTrace == "") && obj.StackTrace == "" {
 		return nil, nil
 	}
+	var ret []*modelInputs.ErrorTrace
+	if obj.MappedStackTrace != nil && *obj.MappedStackTrace != "" {
+		if err := json.Unmarshal([]byte(*obj.MappedStackTrace), &ret); err != nil {
+			log.Error(e.Wrap(err, "error unmarshalling MappedStackTrace"))
+			return nil, nil
+		}
+		return ret, nil
+	}
 	var stackTrace []*struct {
 		FileName     *string `json:"fileName"`
 		LineNumber   *int    `json:"lineNumber"`
 		FunctionName *string `json:"functionName"`
 		ColumnNumber *int    `json:"columnNumber"`
 	}
-	if obj.MappedStackTrace != nil && *obj.MappedStackTrace != "" {
-		if err := json.Unmarshal([]byte(*obj.MappedStackTrace), &stackTrace); err != nil {
-			log.Error(e.Wrap(err, "error unmarshalling MappedStackTrace"))
-			return nil, nil
-		}
-	} else {
-		if err := json.Unmarshal([]byte(obj.StackTrace), &stackTrace); err != nil {
-			log.Error(e.Wrap(err, "error unmarshalling StackTrace"))
-			return nil, nil
-		}
+	if err := json.Unmarshal([]byte(obj.StackTrace), &stackTrace); err != nil {
+		log.Error(e.Wrap(err, "error unmarshalling StackTrace"))
+		return nil, nil
 	}
-	var ret []*modelInputs.ErrorTrace
 	for _, t := range stackTrace {
 		val := &modelInputs.ErrorTrace{
 			FileName:     t.FileName,


### PR DESCRIPTION
related to #925 
`MappedStackTrace` is stored in the DB as an `ErrorTrace`, which has a different json signature than `StackTrace` (snake case vs camel case). So, we should unmarshal `MappedStackTrace` into a `[]ErrorTrace` instead of the `stackTrace` struct