### PR TITLE
fix test job in github workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -58,4 +58,4 @@ jobs:
             - name: Setup Go
               uses: actions/setup-go@v2
             - name: Run tests
-              run: cd backend && go test ./... -v
+              run: cd backend && go test -p 1 ./... -v


### PR DESCRIPTION
we get race conditions exclusive to parallel tests which makes us rerun the test job sometimes. this will fix it.

eventually, each run will have an internalized db, so this won't be an issue. this is a temporary fix