### PR TITLE
Fix Tributi perf - don't use sessions subquery when filtering

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1742,7 +1742,7 @@ func (r *queryResolver) Sessions(ctx context.Context, organizationID int, count 
 
 	sessionsQueryPreamble := "SELECT id, user_id, organization_id, processed, starred, first_time, os_name, os_version, browser_name, browser_version, city, state, postal, identifier, fingerprint, created_at, deleted_at, length, active_length, user_object, viewed"
 	joinClause := "FROM sessions"
-	
+
 	isUnfilteredQuery := len(fieldIds) == 0 && len(visitedIds) == 0 && len(referrerIds) == 0 && len(notFieldIds) == 0 && len(notTrackFieldIds) == 0
 	if !isUnfilteredQuery {
 		fieldsInnerJoinStatement := "INNER JOIN session_fields t ON s.id=t.session_id"


### PR DESCRIPTION
I added some logs that can find all of the slow Tributi queries here: https://app.datadoghq.com/logs?event&index=&query=sessionsQuery+213 . Interestingly they're not actually trying to filter the sessions.

Looking at any sample query shows the issue:

```
 SELECT id,
       user_id,
       organization_id,
       processed,
       starred,
       first_time,
       os_name,
       os_version,
       browser_name,
       browser_version,
       city,
       state,
       postal,
       identifier,
       fingerprint,
       created_at,
       deleted_at,
       length,
       active_length,
       user_object,
       viewed
FROM   (SELECT id,
               user_id,
               organization_id,
               processed,
               starred,
               first_time,
               os_name,
               os_version,
               browser_name,
               browser_version,
               city,
               state,
               postal,
               identifier,
               fingerprint,
               created_at,
               deleted_at,
               length,
               active_length,
               user_object,
               viewed,
               within_billing_quota
        FROM   sessions s
        GROUP  BY s.id) AS rows
WHERE  ( organization_id = 213 )
       AND ( length > 1000 )
       AND ( processed = true )
       AND ( deleted_at IS NULL )
       AND ( within_billing_quota IS NULL
              OR within_billing_quota = true )
       AND NOT (( processed = true
                  AND ( ( active_length IS NOT NULL
                          AND active_length < 1000 )
                         OR ( active_length IS NULL
                              AND length < 1000 ) ) ))
ORDER  BY created_at DESC
LIMIT  20  ;
```

I'm not sure how the subquery scales but I don't think it's good. We talked about this last week but I think we incorrectly attributed the slow performance to the join rather than having the subquery itself. So we can remove that so that it looks like:

```
 SELECT id,
       user_id,
       organization_id,
       processed,
       starred,
       first_time,
       os_name,
       os_version,
       browser_name,
       browser_version,
       city,
       state,
       postal,
       identifier,
       fingerprint,
       created_at,
       deleted_at,
       length,
       active_length,
       user_object,
       viewed
FROM  sessions 
WHERE  ( organization_id = 213 )
       AND ( length > 1000 )
       AND ( processed = true )
       AND ( deleted_at IS NULL )
       AND ( within_billing_quota IS NULL
              OR within_billing_quota = true )
       AND NOT (( processed = true
                  AND ( ( active_length IS NOT NULL
                          AND active_length < 1000 )
                         OR ( active_length IS NULL
                              AND length < 1000 ) ) ))
ORDER  BY created_at DESC
LIMIT  20  ;
```

Testing against prod DB, that drops the runtime from 10s to 300ms. We can monitor whether this fixes Tributi's performance afterwards using this query I added: https://app.datadoghq.com/metric/explorer?from_ts=1627585065126&to_ts=1627671465126&live=false&tile_size=m&exp_metric=db.sessionsQuery.duration.median%2Cdb.sessionsCountQuery.duration.median&exp_scope=org_id%3A122&exp_agg=avg&exp_row_type=metric

Note this only fixes the unfiltered case. Depending on how we feel about the performance of filtered queries in general we may want to fix that too. Note that for filtered queries, removing the subquery and replacing it with a HAVING clause yields the same performance, so it would have to be a different fix.