### PR TITLE
Default slack alerts on integration UI

### DIFF
--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -370,6 +370,62 @@ export type DeleteAdminFromOrganizationMutationOptions = Apollo.BaseMutationOpti
     Types.DeleteAdminFromOrganizationMutation,
     Types.DeleteAdminFromOrganizationMutationVariables
 >;
+export const AddDefaultSlackChannelsDocument = gql`
+    mutation AddDefaultSlackChannels(
+        $organization_id: ID!
+        $slack_channels: [SanitizedSlackChannelInput]!
+        $environments: [String]!
+    ) {
+        addDefaultSlackChannels(
+            organization_id: $organization_id
+            slack_channels: $slack_channels
+            environments: $environments
+        )
+    }
+`;
+export type AddDefaultSlackChannelsMutationFn = Apollo.MutationFunction<
+    Types.AddDefaultSlackChannelsMutation,
+    Types.AddDefaultSlackChannelsMutationVariables
+>;
+
+/**
+ * __useAddDefaultSlackChannelsMutation__
+ *
+ * To run a mutation, you first call `useAddDefaultSlackChannelsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddDefaultSlackChannelsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addDefaultSlackChannelsMutation, { data, loading, error }] = useAddDefaultSlackChannelsMutation({
+ *   variables: {
+ *      organization_id: // value for 'organization_id'
+ *      slack_channels: // value for 'slack_channels'
+ *      environments: // value for 'environments'
+ *   },
+ * });
+ */
+export function useAddDefaultSlackChannelsMutation(
+    baseOptions?: Apollo.MutationHookOptions<
+        Types.AddDefaultSlackChannelsMutation,
+        Types.AddDefaultSlackChannelsMutationVariables
+    >
+) {
+    return Apollo.useMutation<
+        Types.AddDefaultSlackChannelsMutation,
+        Types.AddDefaultSlackChannelsMutationVariables
+    >(AddDefaultSlackChannelsDocument, baseOptions);
+}
+export type AddDefaultSlackChannelsMutationHookResult = ReturnType<
+    typeof useAddDefaultSlackChannelsMutation
+>;
+export type AddDefaultSlackChannelsMutationResult = Apollo.MutationResult<Types.AddDefaultSlackChannelsMutation>;
+export type AddDefaultSlackChannelsMutationOptions = Apollo.BaseMutationOptions<
+    Types.AddDefaultSlackChannelsMutation,
+    Types.AddDefaultSlackChannelsMutationVariables
+>;
 export const AddSlackIntegrationToWorkspaceDocument = gql`
     mutation AddSlackIntegrationToWorkspace(
         $organization_id: ID!

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -70,6 +70,20 @@ export type DeleteAdminFromOrganizationMutation = {
     __typename?: 'Mutation';
 } & Pick<Types.Mutation, 'deleteAdminFromOrganization'>;
 
+export type AddDefaultSlackChannelsMutationVariables = Types.Exact<{
+    organization_id: Types.Scalars['ID'];
+    slack_channels:
+        | Array<Types.Maybe<Types.SanitizedSlackChannelInput>>
+        | Types.Maybe<Types.SanitizedSlackChannelInput>;
+    environments:
+        | Array<Types.Maybe<Types.Scalars['String']>>
+        | Types.Maybe<Types.Scalars['String']>;
+}>;
+
+export type AddDefaultSlackChannelsMutation = {
+    __typename?: 'Mutation';
+} & Pick<Types.Mutation, 'addDefaultSlackChannels'>;
+
 export type AddSlackIntegrationToWorkspaceMutationVariables = Types.Exact<{
     organization_id: Types.Scalars['ID'];
     code: Types.Scalars['String'];

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -678,6 +678,7 @@ export type Mutation = {
     deleteSessionComment?: Maybe<Scalars['Boolean']>;
     createErrorComment?: Maybe<ErrorComment>;
     deleteErrorComment?: Maybe<Scalars['Boolean']>;
+    addDefaultSlackChannels?: Maybe<Scalars['Boolean']>;
     updateErrorAlert?: Maybe<ErrorAlert>;
     updateNewUserAlert?: Maybe<SessionAlert>;
     updateTrackPropertiesAlert?: Maybe<SessionAlert>;
@@ -813,6 +814,12 @@ export type MutationCreateErrorCommentArgs = {
 
 export type MutationDeleteErrorCommentArgs = {
     id: Scalars['ID'];
+};
+
+export type MutationAddDefaultSlackChannelsArgs = {
+    organization_id: Scalars['ID'];
+    slack_channels: Array<Maybe<SanitizedSlackChannelInput>>;
+    environments: Array<Maybe<Scalars['String']>>;
 };
 
 export type MutationUpdateErrorAlertArgs = {

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -47,6 +47,18 @@ mutation DeleteAdminFromOrganization($organization_id: ID!, $admin_id: ID!) {
     )
 }
 
+mutation AddDefaultSlackChannels(
+    $organization_id: ID!
+    $slack_channels: [SanitizedSlackChannelInput]!
+    $environments: [String]!
+) {
+    addDefaultSlackChannels(
+        organization_id: $organization_id
+        slack_channels: $slack_channels
+        environments: $environments
+    )
+}
+
 mutation AddSlackIntegrationToWorkspace(
     $organization_id: ID!
     $code: String!

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -9,6 +9,7 @@ import InfoTooltip from '../../../components/InfoTooltip/InfoTooltip';
 import InputNumber from '../../../components/InputNumber/InputNumber';
 import Select from '../../../components/Select/Select';
 import {
+    useAddDefaultSlackChannelsMutation,
     useGetTrackSuggestionQuery,
     useGetUserSuggestionQuery,
     useUpdateErrorAlertMutation,
@@ -57,6 +58,7 @@ export const AlertConfigurationCard = ({
     const [
         updateTrackPropertiesAlert,
     ] = useUpdateTrackPropertiesAlertMutation();
+    const [addDefaultSlackChannels] = useAddDefaultSlackChannelsMutation();
 
     const onSubmit = async () => {
         setLoading(true);
@@ -81,6 +83,26 @@ export const AlertConfigurationCard = ({
             };
 
             switch (type) {
+                case ALERT_TYPE.Default:
+                    await addDefaultSlackChannels({
+                        variables: {
+                            organization_id,
+                            environments: form.getFieldValue(
+                                'excludedEnvironments'
+                            ),
+                            slack_channels: form
+                                .getFieldValue('channels')
+                                .map((webhook_channel_id: string) => ({
+                                    webhook_channel_name: channelSuggestions.find(
+                                        (suggestion) =>
+                                            suggestion.webhook_channel_id ===
+                                            webhook_channel_id
+                                    ).webhook_channel,
+                                    webhook_channel_id,
+                                })),
+                        },
+                    });
+                    break;
                 case ALERT_TYPE.Error:
                     await updateErrorAlert({
                         ...requestBody,

--- a/frontend/src/pages/Alerts/Alerts.tsx
+++ b/frontend/src/pages/Alerts/Alerts.tsx
@@ -14,9 +14,15 @@ export enum ALERT_TYPE {
     FirstTimeUser,
     UserProperties,
     TrackProperties,
+    Default,
 }
 
 const ALERT_CONFIGURATIONS = [
+    {
+        name: 'Default Slack Channels',
+        canControlThreshold: false,
+        type: ALERT_TYPE.Default,
+    },
     {
         name: 'Errors',
         canControlThreshold: true,


### PR DESCRIPTION
ux flow...

will this only be shown once? remove box after they add initial default channels set? should this actually just be another alert object that we check before sending all alerts (leaning towards this, only annoyance would be duplicate channels but that's ez to deal with actually)?