### PR TITLE
Fix log names for sessions gql

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1800,8 +1800,8 @@ func (r *queryResolver) Sessions(ctx context.Context, organizationID int, count 
 	}
 
 	endpointDuration := time.Since(endpointStart)
-	hlog.Timing("endpoint.sessions", endpointDuration, logTags, 1)
-	hlog.Incr("endpoint.sessions", logTags, 1)
+	hlog.Timing("gql.sessions.duration", endpointDuration, logTags, 1)
+	hlog.Incr("gql.sessions.count", logTags, 1)
 	if endpointDuration.Milliseconds() > 5000 {
 		log.Error(e.New(fmt.Sprintf("endpoint.sessions took %dms: org_id: %d, count: %d, params: %+v", endpointDuration.Milliseconds(), organizationID, count, params)))
 	}


### PR DESCRIPTION
They need to be two different names so they get logged as different metrics