### PR TITLE
HIG-970: Revert "Revert "Add slack bot for personal im notifs (#1181)""

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -281,13 +281,14 @@ func (u *Organization) BeforeCreate(tx *gorm.DB) (err error) {
 
 type Admin struct {
 	Model
-	Name            *string
-	Email           *string
-	PhotoURL        *string          `json:"photo_url"`
-	UID             *string          `gorm:"unique_index"`
-	Organizations   []Organization   `gorm:"many2many:organization_admins;"`
-	SessionComments []SessionComment `gorm:"many2many:session_comment_admins;"`
-	ErrorComments   []ErrorComment   `gorm:"many2many:error_comment_admins;"`
+	Name             *string
+	Email            *string
+	PhotoURL         *string          `json:"photo_url"`
+	UID              *string          `gorm:"unique_index"`
+	Organizations    []Organization   `gorm:"many2many:organization_admins;"`
+	SessionComments  []SessionComment `gorm:"many2many:session_comment_admins;"`
+	ErrorComments    []ErrorComment   `gorm:"many2many:error_comment_admins;"`
+	SlackIMChannelID *string
 }
 
 type EmailSignup struct {

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -8,7 +8,9 @@ import (
 
 	e "github.com/pkg/errors"
 	"github.com/sendgrid/sendgrid-go"
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
 	log "github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
 	"github.com/stripe/stripe-go/client"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gorm.io/gorm"
@@ -424,4 +426,98 @@ func (r *queryResolver) getFieldFilters(ctx context.Context, organizationID int,
 	}
 
 	return customJoinClause, whereClause, nil
+}
+
+func (r *Resolver) SendEmailAlert(tos []*mail.Email, authorName, viewLink, textForEmail, templateID string, sessionImage *string) error {
+	m := mail.NewV3Mail()
+	from := mail.NewEmail("Highlight", "notifications@highlight.run")
+	m.SetFrom(from)
+	m.SetTemplateID(templateID)
+
+	p := mail.NewPersonalization()
+	p.AddTos(tos...)
+	p.SetDynamicTemplateData("Author_Name", authorName)
+	p.SetDynamicTemplateData("Comment_Link", viewLink)
+	p.SetDynamicTemplateData("Comment_Body", textForEmail)
+
+	if sessionImage != nil {
+		p.SetDynamicTemplateData("Session_Image", sessionImage)
+		a := mail.NewAttachment()
+		a.SetContent(*sessionImage)
+		a.SetFilename("session-image.png")
+		a.SetContentID("sessionImage")
+		a.SetType("image/png")
+		m.AddAttachment(a)
+	}
+
+	m.AddPersonalizations(p)
+
+	_, err := r.MailClient.Send(m)
+	if err != nil {
+		return e.Wrap(err, "error sending sendgrid email for comments mentions")
+	}
+
+	return nil
+}
+
+func (r *Resolver) SendPersonalSlackAlert(org *model.Organization, admin *model.Admin, adminIds []int, viewLink, commentText, subjectScope string) error {
+	// this is needed for posting DMs
+	if org.SlackAccessToken == nil {
+		return e.New("slack access token is nil")
+	}
+
+	var admins []*model.Admin
+	if err := r.DB.Find(&admins, adminIds).Where("slack_im_channel_id IS NOT NULL").Error; err != nil {
+		return e.Wrap(err, "error fetching admins")
+	}
+	// return early if no admins w/ slack_im_channel_id
+	if len(admins) < 1 {
+		return nil
+	}
+
+	var blockSet slack.Blocks
+
+	determiner := "a"
+	if subjectScope == "error" {
+		determiner = "an"
+	}
+	message := fmt.Sprintf("You were tagged in %s %s comment.", determiner, subjectScope)
+	if admin.Email != nil && *admin.Email != "" {
+		message = fmt.Sprintf("%s tagged you in %s %s comment.", *admin.Email, determiner, subjectScope)
+	}
+	if admin.Name != nil && *admin.Name != "" {
+		message = fmt.Sprintf("%s tagged you in %s %s comment.", *admin.Name, determiner, subjectScope)
+	}
+	blockSet.BlockSet = append(blockSet.BlockSet, slack.NewHeaderBlock(&slack.TextBlockObject{Type: slack.PlainTextType, Text: message}))
+
+	button := slack.NewButtonBlockElement(
+		"",
+		"click",
+		slack.NewTextBlockObject(
+			slack.PlainTextType,
+			strings.Title(fmt.Sprintf("Visit %s", subjectScope)),
+			false,
+			false,
+		),
+	)
+	button.URL = viewLink
+	blockSet.BlockSet = append(blockSet.BlockSet,
+		slack.NewSectionBlock(
+			nil,
+			[]*slack.TextBlockObject{{Type: slack.MarkdownType, Text: fmt.Sprintf("> %s", commentText)}}, slack.NewAccessory(button),
+		),
+	)
+
+	blockSet.BlockSet = append(blockSet.BlockSet, slack.NewDividerBlock())
+	slackClient := slack.New(*org.SlackAccessToken)
+	for _, a := range admins {
+		if a.SlackIMChannelID != nil {
+			_, _, err := slackClient.PostMessage(*a.SlackIMChannelID, slack.MsgOptionBlocks(blockSet.BlockSet...))
+			if err != nil {
+				return e.Wrap(err, "error posting slack message")
+			}
+		}
+	}
+
+	return nil
 }

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -264,6 +264,7 @@ type Admin {
     name: String!
     email: String!
     photo_url: String
+    slack_im_channel_id: String
 }
 
 # A subset of Admin. This type will contain fields that are allowed to be exposed to other users.
@@ -530,6 +531,11 @@ type Mutation {
         author_name: String!
     ): ErrorComment
     deleteErrorComment(id: ID!): Boolean
+    openSlackConversation(
+        organization_id: ID!
+        code: String!
+        redirect_path: String!
+    ): Boolean
     updateErrorAlert(
         organization_id: ID!
         error_alert_id: ID!

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -14,6 +14,7 @@ import { CommandBar } from './CommandBar/CommandBar';
 import ApplicationPicker from './components/ApplicationPicker/ApplicationPicker';
 import FeedbackButton from './components/FeedbackButton/FeedbackButton';
 import HeaderActions from './components/HeaderActions';
+import PersonalNotificationButton from './components/PersonalNotificationButton/PersonalNotificationButton';
 import styles from './Header.module.scss';
 import { UserDropdown } from './UserDropdown/UserDropdown';
 
@@ -51,6 +52,7 @@ export const Header = () => {
                     )}
                     <div className={styles.rightHeader}>
                         <HeaderActions />
+                        <PersonalNotificationButton />
                         <FeedbackButton />
                         {isLoggedIn && <UserDropdown />}
                     </div>

--- a/frontend/src/components/Header/components/PersonalNotificationButton/PersonalNotificationButton.module.scss
+++ b/frontend/src/components/Header/components/PersonalNotificationButton/PersonalNotificationButton.module.scss
@@ -1,0 +1,29 @@
+.personalNotificationButton {
+    align-items: center;
+    border: 0;
+    border-radius: var(--size-xSmall);
+    column-gap: var(--size-xSmall);
+    display: flex;
+    height: 32px;
+    padding-bottom: var(--size-xxSmall);
+    padding-top: var(--size-xxSmall);
+
+    &:hover,
+    &:active,
+    &:focus {
+        border: 0;
+    }
+}
+
+.feedbackButtonMenu {
+    a {
+        color: var(--text-primary);
+    }
+
+    a,
+    button {
+        align-items: center;
+        column-gap: var(--size-xSmall);
+        display: flex !important;
+    }
+}

--- a/frontend/src/components/Header/components/PersonalNotificationButton/PersonalNotificationButton.module.scss.d.ts
+++ b/frontend/src/components/Header/components/PersonalNotificationButton/PersonalNotificationButton.module.scss.d.ts
@@ -1,0 +1,2 @@
+export const feedbackButtonMenu: string;
+export const personalNotificationButton: string;

--- a/frontend/src/components/Header/components/PersonalNotificationButton/PersonalNotificationButton.tsx
+++ b/frontend/src/components/Header/components/PersonalNotificationButton/PersonalNotificationButton.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { useAuthContext } from '../../../../AuthContext';
+import Button from '../../../Button/Button/Button';
+import styles from './PersonalNotificationButton.module.scss';
+import { useSlackBot } from './utils/utils';
+
+const PersonalNotificationButton = () => {
+    const { isHighlightAdmin, admin } = useAuthContext();
+
+    let redirectUrl = window.location.pathname;
+    // this doesn't work if we redirect to /alerts
+    redirectUrl = redirectUrl.replace('alerts', 'home');
+    if (redirectUrl.length > 3) {
+        // remove orgid and prepended slash
+        redirectUrl = redirectUrl.substring(redirectUrl.indexOf('/', 1) + 1);
+    }
+    const { slackUrl: slackBotUrl } = useSlackBot(redirectUrl);
+
+    console.log('slack id: ', admin?.slack_im_channel_id);
+    if (!isHighlightAdmin || !!admin?.slack_im_channel_id !== null) return null;
+
+    return (
+        <Button
+            className={styles.personalNotificationButton}
+            type="primary"
+            trackingId="personalNotificationButton"
+            href={slackBotUrl}
+        >
+            Enable Personal Notifications?
+        </Button>
+    );
+};
+
+export default PersonalNotificationButton;

--- a/frontend/src/components/Header/components/PersonalNotificationButton/utils/utils.ts
+++ b/frontend/src/components/Header/components/PersonalNotificationButton/utils/utils.ts
@@ -1,0 +1,63 @@
+import { message } from 'antd';
+import { useEffect, useState } from 'react';
+import { useHistory } from 'react-router';
+import { useParams } from 'react-router-dom';
+
+import { useOpenSlackConversationMutation } from '../../../../../graph/generated/hooks';
+import { GetBaseURL } from '../../../../../util/window';
+
+export const useSlackBot = (redirectPath: string) => {
+    const history = useHistory();
+    const { organization_id } = useParams<{ organization_id: string }>();
+    const [openSlackConversation] = useOpenSlackConversationMutation({
+        refetchQueries: ['GetOrganization'],
+    });
+    const [loading, setLoading] = useState<boolean>(false);
+
+    const redirectUriOrigin = `${GetBaseURL()}/${organization_id}`;
+    const slackUrl = `https://slack.com/oauth/v2/authorize?client_id=1354469824468.1868913469441&scope=channels:manage,groups:write,im:write,mpim:write,chat:write&redirect_uri=${redirectUriOrigin}/${redirectPath}`;
+
+    useEffect(() => {
+        const urlParams = new URLSearchParams(window.location.search);
+        const code = urlParams.get('code');
+        if (!code || loading) return;
+
+        const sideEffect = async () => {
+            try {
+                setLoading(true);
+                await openSlackConversation({
+                    variables: {
+                        organization_id: organization_id,
+                        code,
+                        redirect_path: redirectPath,
+                    },
+                });
+                message.success(
+                    'Personal tagging slack notifications have been setup.',
+                    5
+                );
+            } catch (e) {
+                message.error(
+                    `There was an error with Slack, please try again.: ${e}`,
+                    5
+                );
+            }
+            setLoading(false);
+            // Remove the "code" URL param that Slack adds to the redirect URL.
+            history.replace({ search: '' });
+        };
+
+        sideEffect();
+    }, [
+        openSlackConversation,
+        history,
+        loading,
+        organization_id,
+        redirectPath,
+    ]);
+
+    return {
+        loading,
+        slackUrl,
+    };
+};

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -416,6 +416,62 @@ export type DeleteAdminFromOrganizationMutationOptions = Apollo.BaseMutationOpti
     Types.DeleteAdminFromOrganizationMutation,
     Types.DeleteAdminFromOrganizationMutationVariables
 >;
+export const OpenSlackConversationDocument = gql`
+    mutation OpenSlackConversation(
+        $organization_id: ID!
+        $code: String!
+        $redirect_path: String!
+    ) {
+        openSlackConversation(
+            organization_id: $organization_id
+            code: $code
+            redirect_path: $redirect_path
+        )
+    }
+`;
+export type OpenSlackConversationMutationFn = Apollo.MutationFunction<
+    Types.OpenSlackConversationMutation,
+    Types.OpenSlackConversationMutationVariables
+>;
+
+/**
+ * __useOpenSlackConversationMutation__
+ *
+ * To run a mutation, you first call `useOpenSlackConversationMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useOpenSlackConversationMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [openSlackConversationMutation, { data, loading, error }] = useOpenSlackConversationMutation({
+ *   variables: {
+ *      organization_id: // value for 'organization_id'
+ *      code: // value for 'code'
+ *      redirect_path: // value for 'redirect_path'
+ *   },
+ * });
+ */
+export function useOpenSlackConversationMutation(
+    baseOptions?: Apollo.MutationHookOptions<
+        Types.OpenSlackConversationMutation,
+        Types.OpenSlackConversationMutationVariables
+    >
+) {
+    return Apollo.useMutation<
+        Types.OpenSlackConversationMutation,
+        Types.OpenSlackConversationMutationVariables
+    >(OpenSlackConversationDocument, baseOptions);
+}
+export type OpenSlackConversationMutationHookResult = ReturnType<
+    typeof useOpenSlackConversationMutation
+>;
+export type OpenSlackConversationMutationResult = Apollo.MutationResult<Types.OpenSlackConversationMutation>;
+export type OpenSlackConversationMutationOptions = Apollo.BaseMutationOptions<
+    Types.OpenSlackConversationMutation,
+    Types.OpenSlackConversationMutationVariables
+>;
 export const AddSlackIntegrationToWorkspaceDocument = gql`
     mutation AddSlackIntegrationToWorkspace(
         $organization_id: ID!
@@ -2388,6 +2444,7 @@ export const GetAdminDocument = gql`
             name
             email
             photo_url
+            slack_im_channel_id
         }
     }
 `;

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -79,6 +79,17 @@ export type DeleteAdminFromOrganizationMutation = {
     __typename?: 'Mutation';
 } & Pick<Types.Mutation, 'deleteAdminFromOrganization'>;
 
+export type OpenSlackConversationMutationVariables = Types.Exact<{
+    organization_id: Types.Scalars['ID'];
+    code: Types.Scalars['String'];
+    redirect_path: Types.Scalars['String'];
+}>;
+
+export type OpenSlackConversationMutation = { __typename?: 'Mutation' } & Pick<
+    Types.Mutation,
+    'openSlackConversation'
+>;
+
 export type AddSlackIntegrationToWorkspaceMutationVariables = Types.Exact<{
     organization_id: Types.Scalars['ID'];
     code: Types.Scalars['String'];
@@ -786,7 +797,7 @@ export type GetAdminQuery = { __typename?: 'Query' } & {
     admin?: Types.Maybe<
         { __typename?: 'Admin' } & Pick<
             Types.Admin,
-            'id' | 'name' | 'email' | 'photo_url'
+            'id' | 'name' | 'email' | 'photo_url' | 'slack_im_channel_id'
         >
     >;
 };

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -301,6 +301,7 @@ export type Admin = {
     name: Scalars['String'];
     email: Scalars['String'];
     photo_url?: Maybe<Scalars['String']>;
+    slack_im_channel_id?: Maybe<Scalars['String']>;
 };
 
 export type SanitizedAdmin = {
@@ -665,6 +666,7 @@ export type Mutation = {
     deleteSessionComment?: Maybe<Scalars['Boolean']>;
     createErrorComment?: Maybe<ErrorComment>;
     deleteErrorComment?: Maybe<Scalars['Boolean']>;
+    openSlackConversation?: Maybe<Scalars['Boolean']>;
     updateErrorAlert?: Maybe<ErrorAlert>;
     updateNewUserAlert?: Maybe<SessionAlert>;
     updateTrackPropertiesAlert?: Maybe<SessionAlert>;
@@ -799,6 +801,12 @@ export type MutationCreateErrorCommentArgs = {
 
 export type MutationDeleteErrorCommentArgs = {
     id: Scalars['ID'];
+};
+
+export type MutationOpenSlackConversationArgs = {
+    organization_id: Scalars['ID'];
+    code: Scalars['String'];
+    redirect_path: Scalars['String'];
 };
 
 export type MutationUpdateErrorAlertArgs = {

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -51,6 +51,18 @@ mutation DeleteAdminFromOrganization($organization_id: ID!, $admin_id: ID!) {
     )
 }
 
+mutation OpenSlackConversation(
+    $organization_id: ID!
+    $code: String!
+    $redirect_path: String!
+) {
+    openSlackConversation(
+        organization_id: $organization_id
+        code: $code
+        redirect_path: $redirect_path
+    )
+}
+
 mutation AddSlackIntegrationToWorkspace(
     $organization_id: ID!
     $code: String!

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -232,6 +232,7 @@ query GetAdmin {
         name
         email
         photo_url
+        slack_im_channel_id
     }
 }
 


### PR DESCRIPTION
This reverts commit 883f2e4d23cd125beb70cf1db8c40437dedc6767.

Originally reverted bc `private-graph` [deploy failed with error](https://dashboard.render.com/web/srv-c1r0m5ncq1lqcq6q3va0/deploys/dep-c4bf1bc1nokert3prat0): `error setting up db: Error migrating db: ERROR: permission denied for table awsdms_ddl_audit (SQLSTATE 42501)`

Friday 13? gonna redeploy since it's monday now

@silhouettes what do I need to do about schema changes? I added `slack_im_channel_id` to the `admins` table