### PR TITLE
Improve perf/correctness of error groups query

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -318,7 +318,11 @@ func (r *queryResolver) getFieldFilters(ctx context.Context, organizationID int,
 }
 
 func andSessionHasFieldsWhere(fieldConditions string) string {
-	return fmt.Sprintf(`AND EXISTS (
+	return "AND " + SessionHasFieldsWhere(fieldConditions)
+}
+
+func SessionHasFieldsWhere(fieldConditions string) string {
+	return fmt.Sprintf(`EXISTS (
 		SELECT 1
 		FROM session_fields
 		JOIN fields
@@ -351,22 +355,6 @@ func andErrorGroupHasSessionsWhere(fieldConditions string) string {
 		FROM error_objects
 		JOIN sessions
 		ON error_objects.session_id = sessions.id
-		WHERE error_objects.error_group_id = error_groups.id
-		AND (
-			%s
-		)
-		LIMIT 1
-	) `, fieldConditions)
-}
-
-func andErrorGroupHasFieldsWhere(fieldConditions string) string {
-	return fmt.Sprintf(`AND EXISTS (
-		SELECT 1
-		FROM error_objects
-		JOIN session_fields
-		ON error_objects.session_id = session_fields.session_id
-		JOIN fields
-		ON session_fields.field_id = fields.id
 		WHERE error_objects.error_group_id = error_groups.id
 		AND (
 			%s


### PR DESCRIPTION
I've measured this and it has only a minor perf improvement - I think the key next step for me is to add indices. However, this does fix a few issues:

1. Previously, if a filter produced no results, the query would return all error groups, instead of no error groups
2. Previously, selecting two filters would produce no results, causing an outcome similar to (1)
3. Now searches through session fields instead of error group fields