### PR TITLE
HIG-1084: increase workerpool from 20 to 40 goroutines

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -538,7 +538,7 @@ func (w *Worker) Start() {
 		}
 
 		// process 4 sessions at a time. this number was chosen arbitrarily.
-		wp := workerpool.New(20)
+		wp := workerpool.New(40)
 		for _, session := range sessions {
 			session := session
 			wp.Submit(func() {


### PR DESCRIPTION
memory and cpu are still looking good, we're processing sessions much faster now, increasing worker pool size again