### PR TITLE
HIG-1092: make chrome extension work

### DIFF
--- a/experiments/chrome-extension/README.md
+++ b/experiments/chrome-extension/README.md
@@ -48,4 +48,12 @@ To learn React, check out the [React documentation](https://reactjs.org/).
 
 ## Instructions for Highlighters
 
-run `yarn build`, open chrome extensions, click developer mode on the top right, click load unpacked extension on the top left, select `{path}/highlight/experiments/chrome-extension/build`, et voila
+steps:
+* `cd experiments/chrome-extension`
+* `yarn build`
+* replace `new window.Highlight` with `Highlight.create` in `firstload/index.tsx`
+* `yarn firstload:update`
+* open chrome extensions page on chrome or sidekick 
+* enable developer mode on the top right 
+* click load unpacked extension on the top left and select `{path}/highlight/experiments/chrome-extension/build`
+* voila, c'est bon

--- a/firstload/src/index.tsx
+++ b/firstload/src/index.tsx
@@ -168,7 +168,7 @@ export const H: HighlightPublicInterface = {
             script.setAttribute('type', 'text/javascript');
             document.getElementsByTagName('head')[0].appendChild(script);
             script.addEventListener('load', () => {
-                highlight_obj = Highlight.create({
+                highlight_obj = new window.Highlight({
                     organizationID: orgID,
                     debug: options?.debug,
                     backendUrl: options?.backendUrl,


### PR DESCRIPTION
@JohnPhamous the chrome extension doesn't work when using `new window.Highlight({...})` but it does work with `Highlight.create({...})` which is essentially a wrapper of `new window.Highlight({...})`. Let me know if there's a reason we should use the constructor directly instead of `Highlight.create()`. 

The error I was getting was `TypeError: window.Highlight is not a constructor`

edit. well it looks like the firstload tests fail with this change, not really sure why...