### PR TITLE
Fix topUsers subquery error

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1591,7 +1591,7 @@ func (r *queryResolver) TopUsers(ctx context.Context, organizationID int, lookBa
 				AND identifier <> '' 
 				AND created_at >= NOW() - INTERVAL '? DAY' 
 				AND processed=true
-		) as active_time_percentage
+		) AS active_time_percentage
 		FROM (
 			SELECT identifier, active_length 
 			FROM sessions 


### PR DESCRIPTION
see linear ticket for info

i added one line to the query and removed fmt.Sprintf so we can use gorms sql sanitization