### PR TITLE
HIG-1132: make `SendSlackAlert` input more organized

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -783,7 +783,26 @@ func (s *Session) GetUserProperties() (map[string]string, error) {
 	return userProperties, nil
 }
 
-func (obj *Alert) SendSlackAlert(organization *Organization, sessionId int, userIdentifier string, group *ErrorGroup, url *string, matchedFields []*Field, userProperties map[string]string, numErrors *int64) error {
+type SendSlackAlertInput struct {
+	// Organization is a required parameter
+	Organization *Organization
+	// SessionID is a required parameter
+	SessionID int
+	// UserIdentifier is a required parameter for New User and Error alerts
+	UserIdentifier string
+	// Group is a required parameter for Error alerts
+	Group *ErrorGroup
+	// URL is an optional parameter for Error alerts
+	URL *string
+	// ErrorsCount is a required parameter for Error alerts
+	ErrorsCount *int64
+	// MatchedFields is a required parameter for Track Properties and User Properties alerts
+	MatchedFields []*Field
+	// UserProperties is a required parameter for User Properties alerts
+	UserProperties map[string]string
+}
+
+func (obj *Alert) SendSlackAlert(input *SendSlackAlertInput) error {
 	if obj == nil {
 		return e.New("alert is nil")
 	}
@@ -793,7 +812,7 @@ func (obj *Alert) SendSlackAlert(organization *Organization, sessionId int, user
 		return e.Wrap(err, "error getting channels to notify from user properties alert")
 	}
 	// get organization's channels
-	integratedSlackChannels, err := organization.IntegratedSlackChannels()
+	integratedSlackChannels, err := input.Organization.IntegratedSlackChannels()
 	if err != nil {
 		return e.Wrap(err, "error getting slack webhook url for alert")
 	}
@@ -807,11 +826,11 @@ func (obj *Alert) SendSlackAlert(organization *Organization, sessionId int, user
 	var messageBlock []*slack.TextBlockObject
 
 	frontendURL := os.Getenv("FRONTEND_URI")
-	sessionLink := fmt.Sprintf("<%s/%d/sessions/%d/>", frontendURL, obj.OrganizationID, sessionId)
+	sessionLink := fmt.Sprintf("<%s/%d/sessions/%d/>", frontendURL, obj.OrganizationID, input.SessionID)
 	messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*Session:*\n"+sessionLink, false, false))
 
 	if obj.Type == nil {
-		if group != nil {
+		if input.Group != nil {
 			obj.Type = &AlertType.ERROR
 		} else {
 			obj.Type = &AlertType.NEW_USER
@@ -819,24 +838,24 @@ func (obj *Alert) SendSlackAlert(organization *Organization, sessionId int, user
 	}
 	switch *obj.Type {
 	case AlertType.ERROR:
-		if group == nil || group.State == ErrorGroupStates.IGNORED {
+		if input.Group == nil || input.Group.State == ErrorGroupStates.IGNORED {
 			return nil
 		}
-		shortEvent := group.Event
-		if len(group.Event) > 50 {
-			shortEvent = group.Event[:50] + "..."
+		shortEvent := input.Group.Event
+		if len(input.Group.Event) > 50 {
+			shortEvent = input.Group.Event[:50] + "..."
 		}
-		errorLink := fmt.Sprintf("%s/%d/errors/%d", frontendURL, obj.OrganizationID, group.ID)
-		// construct slack message
-		textBlock = slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Highlight Error Alert: %d Recent Occurrences*\n\n%s\n<%s/>", *numErrors, shortEvent, errorLink), false, false)
-		messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*User:*\n"+userIdentifier, false, false))
-		if url != nil {
-			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*Visited Url:*\n"+*url, false, false))
+		errorLink := fmt.Sprintf("%s/%d/errors/%d", frontendURL, obj.OrganizationID, input.Group.ID)
+		// construct Slack message
+		textBlock = slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Highlight Error Alert: %d Recent Occurrences*\n\n%s\n<%s/>", *input.ErrorsCount, shortEvent, errorLink), false, false)
+		messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*User:*\n"+input.UserIdentifier, false, false))
+		if input.URL != nil {
+			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*Visited Url:*\n"+*input.URL, false, false))
 		}
 		blockSet = append(blockSet, slack.NewSectionBlock(textBlock, messageBlock, nil))
 		var actionBlock []slack.BlockElement
 		for _, action := range modelInputs.AllErrorState {
-			if group.State == string(action) {
+			if input.Group.State == string(action) {
 				continue
 			}
 
@@ -869,12 +888,12 @@ func (obj *Alert) SendSlackAlert(organization *Organization, sessionId int, user
 			},
 		}
 	case AlertType.NEW_USER:
-		// construct slack message
+		// construct Slack message
 		textBlock = slack.NewTextBlockObject(slack.MarkdownType, "*Highlight New User Alert:*\n\n", false, false)
-		if userIdentifier != "" {
-			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*User:*\n"+userIdentifier, false, false))
+		if input.UserIdentifier != "" {
+			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*User:*\n"+input.UserIdentifier, false, false))
 		}
-		for k, v := range userProperties {
+		for k, v := range input.UserProperties {
 			if k == "" {
 				continue
 			}
@@ -889,10 +908,10 @@ func (obj *Alert) SendSlackAlert(organization *Organization, sessionId int, user
 	case AlertType.TRACK_PROPERTIES:
 		// format matched properties
 		var formattedFields []string
-		for _, addr := range matchedFields {
+		for _, addr := range input.MatchedFields {
 			formattedFields = append(formattedFields, fmt.Sprintf("{name: %s, value: %s}", addr.Name, addr.Value))
 		}
-		// construct slack message
+		// construct Slack message
 		textBlock = slack.NewTextBlockObject(slack.MarkdownType, "*Highlight Track Properties Alert:*\n\n", false, false)
 		messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Matched Track Properties:*\n%+v", formattedFields), false, false))
 		blockSet = append(blockSet, slack.NewSectionBlock(textBlock, messageBlock, nil))
@@ -901,10 +920,10 @@ func (obj *Alert) SendSlackAlert(organization *Organization, sessionId int, user
 	case AlertType.USER_PROPERTIES:
 		// format matched properties
 		var formattedFields []string
-		for _, addr := range matchedFields {
+		for _, addr := range input.MatchedFields {
 			formattedFields = append(formattedFields, fmt.Sprintf("{name: %s, value: %s}", addr.Name, addr.Value))
 		}
-		// construct slack message
+		// construct Slack message
 		textBlock = slack.NewTextBlockObject(slack.MarkdownType, "*Highlight User Properties Alert:*\n\n", false, false)
 		messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Matched User Properties:*\n%+v", formattedFields), false, false))
 		blockSet = append(blockSet, slack.NewSectionBlock(textBlock, messageBlock, nil))
@@ -923,7 +942,7 @@ func (obj *Alert) SendSlackAlert(organization *Organization, sessionId int, user
 				}
 			}
 			if slackWebhookURL == "" {
-				log.WithFields(log.Fields{"org_id": organization.ID}).
+				log.WithFields(log.Fields{"org_id": input.Organization.ID}).
 					Error("requested channel has no matching slackWebhookURL")
 				continue
 			}
@@ -934,7 +953,7 @@ func (obj *Alert) SendSlackAlert(organization *Organization, sessionId int, user
 					&msg,
 				)
 				if err != nil {
-					log.WithFields(log.Fields{"org_id": organization.ID, "slack_webhook_url": slackWebhookURL, "message": fmt.Sprintf("%+v", msg)}).
+					log.WithFields(log.Fields{"org_id": input.Organization.ID, "slack_webhook_url": slackWebhookURL, "message": fmt.Sprintf("%+v", msg)}).
 						Error(e.Wrap(err, "error sending slack msg"))
 				}
 			}()

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -317,7 +317,7 @@ func (r *mutationResolver) PushPayload(ctx context.Context, sessionID int, event
 							if err := r.DB.Model(&model.Organization{}).Where(&model.Organization{Model: model.Model{ID: organizationID}}).First(&org).Error; err != nil {
 								log.Error(e.Wrap(err, "error querying organization"))
 							}
-							err = errorAlert.SendSlackAlert(&org, sessionID, sessionObj.Identifier, group, &errorToInsert.URL, nil, nil, &numErrors)
+							err = errorAlert.SendSlackAlert(&model.SendSlackAlertInput{Organization: &org, SessionID: sessionID, UserIdentifier: sessionObj.Identifier, Group: group, URL: &errorToInsert.URL, ErrorsCount: &numErrors})
 							if err != nil {
 								log.Error(e.Wrap(err, "error sending slack error message"))
 							}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -358,8 +358,8 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 			return e.Wrapf(err, "[org_id: %d] error getting user properties from new user alert", s.OrganizationID)
 		}
 
-		// send slack message
-		err = sessionAlert.SendSlackAlert(org, s.ID, s.Identifier, nil, nil, nil, userProperties, nil)
+		// send Slack message
+		err = sessionAlert.SendSlackAlert(&model.SendSlackAlertInput{Organization: org, SessionID: s.ID, UserIdentifier: s.Identifier, UserProperties: userProperties})
 		if err != nil {
 			return e.Wrapf(err, "[org_id: %d] error sending slack message for new user alert", organizationID)
 		}
@@ -409,8 +409,8 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 			return nil
 		}
 
-		// send slack message
-		err = sessionAlert.SendSlackAlert(org, s.ID, s.Identifier, nil, nil, matchedFields, nil, nil)
+		// send Slack message
+		err = sessionAlert.SendSlackAlert(&model.SendSlackAlertInput{Organization: org, SessionID: s.ID, UserIdentifier: s.Identifier, MatchedFields: matchedFields})
 		if err != nil {
 			return e.Wrap(err, "error sending track properties alert slack message")
 		}
@@ -461,8 +461,8 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 			return nil
 		}
 
-		// send slack message
-		err = sessionAlert.SendSlackAlert(org, s.ID, s.Identifier, nil, nil, matchedFields, nil, nil)
+		// send Slack message
+		err = sessionAlert.SendSlackAlert(&model.SendSlackAlertInput{Organization: org, SessionID: s.ID, UserIdentifier: s.Identifier, MatchedFields: matchedFields})
 		if err != nil {
 			return e.Wrapf(err, "error sending user properties alert slack message")
 		}


### PR DESCRIPTION
this was getting gross, just created a simple input struct to make things clear