### PR TITLE
Revert "Fix topUsers subquery error"

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1640,37 +1640,11 @@ func (r *queryResolver) TopUsers(ctx context.Context, organizationID int, lookBa
 	var topUsersPayload = []*modelInputs.TopUsersPayload{}
 	topUsersSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal",
 		tracer.ResourceName("db.topUsers"), tracer.Tag("org_id", organizationID))
-	if err := r.DB.Raw(`
-		SELECT identifier, (
-			SELECT id 
-			FROM fields 
-			WHERE organization_id=? 
-				AND type='user' 
-				AND name='identifier' 
-				AND value=identifier
-			LIMIT 1
-		) AS id, SUM(active_length) as total_active_time, SUM(active_length) / (
-			SELECT SUM(active_length) 
-			FROM sessions 
-			WHERE active_length IS NOT NULL 
-				AND organization_id=? 
-				AND identifier <> '' 
-				AND created_at >= NOW() - INTERVAL '? DAY' 
-				AND processed=true
-		) AS active_time_percentage
-		FROM (
-			SELECT identifier, active_length 
-			FROM sessions 
-			WHERE active_length IS NOT NULL 
-				AND organization_id=? 
-				AND identifier <> '' 
-				AND created_at >= NOW() - INTERVAL '? DAY' 
-				AND processed=true
-		) q1
-		GROUP BY identifier
-		ORDER BY total_active_time
-		LIMIT 50`,
-		organizationID, organizationID, lookBackPeriod, organizationID, lookBackPeriod).Scan(&topUsersPayload).Error; err != nil {
+	if err := r.DB.Raw(fmt.Sprintf(`SELECT identifier, (SELECT id FROM fields WHERE organization_id=%d AND type='user' AND name='identifier' AND value=identifier) AS id, SUM(active_length) as total_active_time, SUM(active_length) / (SELECT SUM(active_length) from sessions WHERE active_length IS NOT NULL AND organization_id=%d AND identifier <> '' AND created_at >= NOW() - INTERVAL '%d DAY' AND processed=true) as active_time_percentage
+	FROM (SELECT identifier, active_length from sessions WHERE active_length IS NOT NULL AND organization_id=%d AND identifier <> '' AND created_at >= NOW() - INTERVAL '%d DAY' AND processed=true) q1
+	GROUP BY identifier
+	ORDER BY total_active_time
+	LIMIT 50`, organizationID, organizationID, lookBackPeriod, organizationID, lookBackPeriod)).Scan(&topUsersPayload).Error; err != nil {
 		return nil, e.Wrap(err, "error retrieving top users")
 	}
 	topUsersSpan.Finish()


### PR DESCRIPTION
Reverts highlight-run/highlight#1312

reverting bc of the following error:
```
message: "input: topUsers error retrieving top users: ERROR: could not determine data type of parameter $3 (SQLSTATE 42P18); ERROR: could not determine data type of parameter $3 (SQLSTATE 42P18)"
```