### PR TITLE
update `node-sass`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
         "intro.js-react": "^0.4.0",
         "lottie-react": "^2.1.0",
         "moment": "^2.29.1",
-        "node-sass": "5.0.0",
+        "node-sass": "6.0.1",
         "query-string": "6.14.1",
         "randomcolor": "^0.6.2",
         "react": "^16.13.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4638,11 +4638,6 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
-array-find-index@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
-  integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
-
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -5575,14 +5570,6 @@ camel-case@4.1.2, camel-case@^4.1.1, camel-case@^4.1.2:
     pascal-case "^3.1.2"
     tslib "^2.0.3"
 
-camelcase-keys@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
-  integrity sha1-MIvur/3ygRkFHvodkyITyRuPkuc=
-  dependencies:
-    camelcase "^2.0.0"
-    map-obj "^1.0.0"
-
 camelcase-keys@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
@@ -5596,11 +5583,6 @@ camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-
-camelcase@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
-  integrity sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=
 
 camelcase@^6.0.0, camelcase@^6.1.0, camelcase@^6.2.0:
   version "6.2.0"
@@ -6678,13 +6660,6 @@ csstype@^3.0.6:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
   integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
-currently-unhandled@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
-  integrity sha1-mI3zP+qxke95mmE2nddsF635V+o=
-  dependencies:
-    array-find-index "^1.0.1"
-
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
@@ -6832,7 +6807,7 @@ decamelize-keys@^1.1.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
+decamelize@^1.1.0, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -8203,14 +8178,6 @@ find-up@4.1.0, find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-find-up@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
-  integrity sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=
-  dependencies:
-    path-exists "^2.0.0"
-    pinkie-promise "^2.0.0"
-
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -9340,13 +9307,6 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
-indent-string@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
-  integrity sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=
-  dependencies:
-    repeating "^2.0.0"
-
 indent-string@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
@@ -9666,11 +9626,6 @@ is-extglob@^2.1.0, is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
-is-finite@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.1.0.tgz#904135c77fb42c0641d6aa1bcdbc4daa8da082f3"
-  integrity sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==
-
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -9896,11 +9851,6 @@ is-upper-case@^2.0.2:
   integrity sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==
   dependencies:
     tslib "^2.0.3"
-
-is-utf8@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
-  integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
 is-what@^3.12.0:
   version "3.14.1"
@@ -10903,17 +10853,6 @@ listr@^0.14.3:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
-load-json-file@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
-  integrity sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^2.2.0"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    strip-bom "^2.0.0"
-
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
@@ -11164,14 +11103,6 @@ lottie-web@^5.7.3:
   resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.7.8.tgz#c7a2e42983bcb42093590a03ccdde8741d3f960e"
   integrity sha512-VxKCZk33GwZac6mVHvT3grUFR/zrMsW85M7vxQPrgpJOP2IhcnjMbuD0h7muBkXgw84K9KmGulmcyzvhpzSMAg==
 
-loud-rejection@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
-  integrity sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=
-  dependencies:
-    currently-unhandled "^0.4.1"
-    signal-exit "^3.0.0"
-
 lower-case-first@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case-first/-/lower-case-first-2.0.2.tgz#64c2324a2250bf7c37c5901e76a5b5309301160b"
@@ -11256,7 +11187,7 @@ map-cache@^0.2.0, map-cache@^0.2.2:
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
-map-obj@^1.0.0, map-obj@^1.0.1:
+map-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
   integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
@@ -11355,22 +11286,6 @@ memory-fs@^0.5.0:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
-
-meow@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
-  integrity sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=
-  dependencies:
-    camelcase-keys "^2.0.0"
-    decamelize "^1.1.2"
-    loud-rejection "^1.0.0"
-    map-obj "^1.0.1"
-    minimist "^1.1.3"
-    normalize-package-data "^2.3.4"
-    object-assign "^4.0.1"
-    read-pkg-up "^1.0.1"
-    redent "^1.0.0"
-    trim-newlines "^1.0.0"
 
 meow@^9.0.0:
   version "9.0.0"
@@ -11560,7 +11475,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -11875,10 +11790,10 @@ node-releases@^1.1.75:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.75.tgz#6dd8c876b9897a1b8e5a02de26afa79bb54ebbfe"
   integrity sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==
 
-node-sass@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-5.0.0.tgz#4e8f39fbef3bac8d2dc72ebe3b539711883a78d2"
-  integrity sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==
+node-sass@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-6.0.1.tgz#cad1ccd0ce63e35c7181f545d8b986f3a9a887fe"
+  integrity sha512-f+Rbqt92Ful9gX0cGtdYwjTrWAaGURgaK5rZCWOgCNyGWusFYHhbqCCBoFBeat+HKETOU02AyTxNhJV0YZf2jQ==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -11887,8 +11802,7 @@ node-sass@5.0.0:
     get-stdin "^4.0.1"
     glob "^7.0.3"
     lodash "^4.17.15"
-    meow "^3.7.0"
-    mkdirp "^0.5.1"
+    meow "^9.0.0"
     nan "^2.13.2"
     node-gyp "^7.1.0"
     npmlog "^4.0.0"
@@ -11904,7 +11818,7 @@ nopt@^5.0.0:
   dependencies:
     abbrev "1"
 
-normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
+normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -12483,13 +12397,6 @@ path-dirname@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
   integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
 
-path-exists@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
-  integrity sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=
-  dependencies:
-    pinkie-promise "^2.0.0"
-
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -12548,15 +12455,6 @@ path-to-regexp@^1.7.0:
   integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
   dependencies:
     isarray "0.0.1"
-
-path-type@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
-  integrity sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=
-  dependencies:
-    graceful-fs "^4.1.2"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -14632,14 +14530,6 @@ react@^16.13.1, react@^16.7.0-alpha.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
-read-pkg-up@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
-  integrity sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=
-  dependencies:
-    find-up "^1.0.0"
-    read-pkg "^1.0.0"
-
 read-pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
@@ -14656,15 +14546,6 @@ read-pkg-up@^7.0.1:
     find-up "^4.1.0"
     read-pkg "^5.2.0"
     type-fest "^0.8.1"
-
-read-pkg@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
-  integrity sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=
-  dependencies:
-    load-json-file "^1.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^1.0.0"
 
 read-pkg@^2.0.0:
   version "2.0.0"
@@ -14755,14 +14636,6 @@ recursive-readdir@2.2.2:
   integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
-
-redent@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
-  integrity sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=
-  dependencies:
-    indent-string "^2.1.0"
-    strip-indent "^1.0.1"
 
 redent@^3.0.0:
   version "3.0.0"
@@ -14971,13 +14844,6 @@ repeat-string@^1.0.0, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
-
-repeating@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
-  integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
-  dependencies:
-    is-finite "^1.0.0"
 
 replaceall@^0.1.6:
   version "0.1.6"
@@ -16213,13 +16079,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-bom@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
-  integrity sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=
-  dependencies:
-    is-utf8 "^0.2.0"
-
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -16247,13 +16106,6 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
-
-strip-indent@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
-  integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
-  dependencies:
-    get-stdin "^4.0.1"
 
 strip-indent@^3.0.0:
   version "3.0.0"
@@ -16800,11 +16652,6 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
-
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
 
 trim-newlines@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
`yarn frontend:install` was failing with the following message until I updated `node-sass`:

```
yarn run v1.22.11
$ concurrently 'cd frontend && yarn' 'cd client && yarn' 'cd firstload && yarn'
warning package.json: No license field
warning highlight.run@2.7.2: No license field
[1/4] Resolving packages...
[1/4] Resolving packages...
[1/4] Resolving packages...
success Already up-to-date.
[2] cd firstload && yarn exited with code 0
success Already up-to-date.
[1] cd client && yarn exited with code 0
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > @typescript-eslint/eslint-plugin@4.15.1" has unmet peer dependency "eslint@^5.0.0 || ^6.0.0 || ^7.0.0".
warning "@typescript-eslint/eslint-plugin > @typescript-eslint/experimental-utils@4.15.1" has unmet peer dependency "eslint@*".
warning " > @typescript-eslint/parser@4.15.1" has unmet peer dependency "eslint@^5.0.0 || ^6.0.0 || ^7.0.0".
warning " > @highlight-run/react@1.0.1" has incorrect peer dependency "react@^17.0.2".
warning " > @highlight-run/react@1.0.1" has incorrect peer dependency "react-dom@^17.0.2".
warning "antd > rc-picker@2.5.5" has unmet peer dependency "dayjs@^1.8.30".
warning " > craco-antd@1.19.0" has incorrect peer dependency "@craco/craco@^5.5.0".
warning " > craco-antd@1.19.0" has incorrect peer dependency "react-scripts@^3.4.3".
warning "craco-antd > craco-less@1.17.0" has incorrect peer dependency "@craco/craco@^5.5.0".
warning "craco-antd > craco-less@1.17.0" has incorrect peer dependency "react-scripts@^3.3.0".
warning "craco-antd > craco-less > less-loader@6.2.0" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
warning " > eslint-plugin-simple-import-sort@7.0.0" has unmet peer dependency "eslint@>=5.0.0".
warning " > intro.js-react@0.4.0" has incorrect peer dependency "intro.js@^2.5.0".
warning " > lottie-react@2.1.0" has unmet peer dependency "prop-types@^15.5.7".
warning " > react-command-palette@0.16.0" has incorrect peer dependency "react@17.x".
warning " > react-command-palette@0.16.0" has incorrect peer dependency "react-dom@17.x".
warning " > eslint-plugin-react@7.22.0" has unmet peer dependency "eslint@^3 || ^4 || ^5 || ^6 || ^7".
warning " > eslint-plugin-react-hooks@4.2.0" has unmet peer dependency "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0".
warning "react-scripts > @svgr/webpack > @babel/preset-env > @babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.14.5" has incorrect peer dependency "@babel/core@^7.13.0".
warning " > @graphql-codegen/named-operations-object@2.1.0" has unmet peer dependency "graphql-tag@^2.0.0".
warning " > @graphql-codegen/typescript-react-apollo@2.2.1" has unmet peer dependency "graphql-tag@^2.0.0".
warning " > eslint-config-prettier@7.2.0" has unmet peer dependency "eslint@>=7.0.0".
warning " > eslint-plugin-prettier@3.3.1" has unmet peer dependency "eslint@>=5.0.0".
[4/4] Building fresh packages...
error /Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-sass: Command failed.
[0] Exit code: 1
[0] Command: node scripts/build.js
[0] Arguments:
[0] Directory: /Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-sass
[0] Output:
[0] Building: /usr/local/Cellar/node/16.9.1/bin/node /Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-gyp/bin/node-gyp.js rebuild --verbose --libsass_ext= --libsass_cflags= --libsass_ldflags= --libsass_library=
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/ast.o ../src/libsass/src/ast.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/ast.o.d.raw   -c
[0] gyp info it worked if it ends with ok
[0] gyp verb cli [
[0] gyp verb cli   '/usr/local/Cellar/node/16.9.1/bin/node',
[0] gyp verb cli   '/Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-gyp/bin/node-gyp.js',
[0] gyp verb cli   'rebuild',
[0] gyp verb cli   '--verbose',
[0] gyp verb cli   '--libsass_ext=',
[0] gyp verb cli   '--libsass_cflags=',
[0] gyp verb cli   '--libsass_ldflags=',
[0] gyp verb cli   '--libsass_library='
[0] gyp verb cli ]
[0] gyp info using node-gyp@7.1.2
[0] gyp info using node@16.9.1 | darwin | x64
[0] gyp verb command rebuild []
[0] gyp verb command clean []
[0] gyp verb clean removing "build" directory
[0] gyp verb command configure []
[0] gyp verb find Python checking Python explicitly set from command line or npm configuration
[0] gyp verb find Python - "--python=" or "npm config get python" is "/usr/bin/python"
[0] gyp verb find Python - executing "/usr/bin/python" to get executable path
[0] gyp verb find Python - executable path is "/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python"
[0] gyp verb find Python - executing "/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python" to get version
[0] gyp verb find Python - version is "2.7.16"
[0] gyp info find Python using Python version 2.7.16 found at "/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python"
[0] gyp verb get node dir no --target version specified, falling back to host node version: 16.9.1
[0] gyp verb command install [ '16.9.1' ]
[0] gyp verb install input version string "16.9.1"
[0] gyp verb install installing version: 16.9.1
[0] gyp verb install --ensure was passed, so won't reinstall if already installed
[0] gyp verb install version is already installed, need to check "installVersion"
[0] gyp verb got "installVersion" 9
[0] gyp verb needs "installVersion" 9
[0] gyp verb install version is good
[0] gyp verb get node dir target node version installed: 16.9.1
[0] gyp verb build dir attempting to create "build" dir: /Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-sass/build
[0] gyp verb build dir "build" dir needed to be created? /Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-sass/build
[0] gyp verb build/config.gypi creating config file
[0] gyp verb build/config.gypi writing out config file: /Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-sass/build/config.gypi
[0] (node:6431) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
[0] (Use `node --trace-deprecation ...` to show where the warning was created)
[0] gyp verb config.gypi checking for gypi file: /Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-sass/config.gypi
[0] gyp verb common.gypi checking for gypi file: /Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-sass/common.gypi
[0] gyp verb gyp gyp format was not specified; forcing "make"
[0] gyp info spawn /System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python
[0] gyp info spawn args [
[0] gyp info spawn args   '/Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-gyp/gyp/gyp_main.py',
[0] gyp info spawn args   'binding.gyp',
[0] gyp info spawn args   '-f',
[0] gyp info spawn args   'make',
[0] gyp info spawn args   '-I',
[0] gyp info spawn args   '/Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-sass/build/config.gypi',
[0] gyp info spawn args   '-I',
[0] gyp info spawn args   '/Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-gyp/addon.gypi',
[0] gyp info spawn args   '-I',
[0] gyp info spawn args   '/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node/common.gypi',
[0] gyp info spawn args   '-Dlibrary=shared_library',
[0] gyp info spawn args   '-Dvisibility=default',
[0] gyp info spawn args   '-Dnode_root_dir=/Users/cameronbrill/Library/Caches/node-gyp/16.9.1',
[0] gyp info spawn args   '-Dnode_gyp_dir=/Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-gyp',
[0] gyp info spawn args   '-Dnode_lib_file=/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/<(target_arch)/node.lib',
[0] gyp info spawn args   '-Dmodule_root_dir=/Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-sass',
[0] gyp info spawn args   '-Dnode_engine=v8',
[0] gyp info spawn args   '--depth=.',
[0] gyp info spawn args   '--no-parallel',
[0] gyp info spawn args   '--generator-output',
[0] gyp info spawn args   'build',
[0] gyp info spawn args   '-Goutput_dir=.'
[0] gyp info spawn args ]
[0] gyp verb command build []
[0] gyp verb build type Release
[0] gyp verb architecture x64
[0] gyp verb node dev dir /Users/cameronbrill/Library/Caches/node-gyp/16.9.1
[0] gyp verb `which` succeeded for `make` /usr/bin/make
[0] gyp info spawn make
[0] gyp info spawn args [ 'V=1', 'BUILDTYPE=Release', '-C', 'build' ]
[0] In file included from ../src/libsass/src/ast.cpp:2:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
  c++ -o Release/obj.target/libsass/src/libsass/src/ast_fwd_decl.o ../src/libsass/src/ast_fwd_decl.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/ast_fwd_decl.o.d.raw   -c
[0] In file included from ../src/libsass/src/ast_fwd_decl.cpp:1:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/backtrace.o ../src/libsass/src/backtrace.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/backtrace.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/base64vlq.o ../src/libsass/src/base64vlq.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/base64vlq.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/bind.o ../src/libsass/src/bind.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/bind.o.d.raw   -c
[0] In file included from ../src/libsass/src/bind.cpp:3:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   cc -o Release/obj.target/libsass/src/libsass/src/cencode.o ../src/libsass/src/cencode.c '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/cencode.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/check_nesting.o ../src/libsass/src/check_nesting.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/check_nesting.o.d.raw   -c
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
[0] n file included from ../src/libsass/src/check_nesting.cpp:4:
[0] In file included from ../src/libsass/src/check_nesting.hpp:4:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/color_maps.o ../src/libsass/src/color_maps.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/color_maps.o.d.raw   -c
[0] In file included from ../src/libsass/src/color_maps.cpp:2:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/constants.o ../src/libsass/src/constants.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/constants.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/context.o ../src/libsass/src/context.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/context.o.d.raw   -c
[0] In file included from ../src/libsass/src/context.cpp:9:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/cssize.o ../src/libsass/src/cssize.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/cssize.o.d.raw   -c
[0] In file included from ../src/libsass/src/cssize.cpp:6:
[0] In file included from ../src/libsass/src/cssize.hpp:4:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
             ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/emitter.o ../src/libsass/src/emitter.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/emitter.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/environment.o ../src/libsass/src/environment.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/environment.o.d.raw   -c
[0] In file included from ../src/libsass/src/environment.cpp:2:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/error_handling.o ../src/libsass/src/error_handling.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/error_handling.o.d.raw   -c
[0] In file included from ../src/libsass/src/error_handling.cpp:2:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/eval.o ../src/libsass/src/eval.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/eval.o.d.raw   -c
[0] In file included from ../src/libsass/src/eval.cpp:10:
[0] In file included from ../src/libsass/src/eval.hpp:4:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
                        &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/expand.o ../src/libsass/src/expand.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/expand.o.d.raw   -c
[0] In file included from ../src/libsass/src/expand.cpp:5:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/extend.o ../src/libsass/src/extend.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/extend.o.d.raw   -c
[0] In file included from ../src/libsass/src/extend.cpp:2:
[0] In file included from ../src/libsass/src/extend.hpp:7:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/file.o ../src/libsass/src/file.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/file.o.d.raw   -c
[0] In file included from ../src/libsass/src/file.cpp:23:
[0] In file included from ../src/libsass/src/sass_functions.hpp:6:
[0] In file included from ../src/libsass/src/functions.hpp:4:
[0] In file included from ../src/libsass/src/listize.hpp:7:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/functions.o ../src/libsass/src/functions.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/functions.o.d.raw   -c
[0] In file included from ../src/libsass/src/functions.cpp:2:
[0] In file included from ../src/libsass/src/functions.hpp:4:
[0] In file included from ../src/libsass/src/listize.hpp:7:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
        for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/inspect.o ../src/libsass/src/inspect.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/inspect.o.d.raw   -c
[0] In file included from ../src/libsass/src/inspect.cpp:9:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/json.o ../src/libsass/src/json.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/json.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/lexer.o ../src/libsass/src/lexer.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/lexer.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/listize.o ../src/libsass/src/listize.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/listize.o.d.raw   -c
[0] In file included from ../src/libsass/src/listize.cpp:6:
[0] In file included from ../src/libsass/src/listize.hpp:7:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
  c++ -o Release/obj.target/libsass/src/libsass/src/memory/SharedPtr.o ../src/libsass/src/memory/SharedPtr.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/memory/SharedPtr.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/node.o ../src/libsass/src/node.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/node.o.d.raw   -c
[0] In file included from ../src/libsass/src/node.cpp:4:
[0] In file included from ../src/libsass/src/node.hpp:7:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/operators.o ../src/libsass/src/operators.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/operators.o.d.raw   -c
[0] In file included from ../src/libsass/src/operators.cpp:2:
[0] In file included from ../src/libsass/src/operators.hpp:4:
[0] In file included from ../src/libsass/src/values.hpp:4:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/output.o ../src/libsass/src/output.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/output.o.d.raw   -c
[0] In file included from ../src/libsass/src/output.cpp:2:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/parser.o ../src/libsass/src/parser.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/parser.o.d.raw   -c
In file included from ../src/libsass/src/parser.cpp:2:
[0] In file included from ../src/libsass/src/parser.hpp:7:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/plugins.o ../src/libsass/src/plugins.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/plugins.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/position.o ../src/libsass/src/position.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/position.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/prelexer.o ../src/libsass/src/prelexer.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/prelexer.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/remove_placeholders.o ../src/libsass/src/remove_placeholders.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/remove_placeholders.o.d.raw   -c
[0] In file included from ../src/libsass/src/remove_placeholders.cpp:2:
[0] In file included from ../src/libsass/src/remove_placeholders.hpp:6:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/sass.o ../src/libsass/src/sass.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/sass.o.d.raw   -c
[0] In file included from ../src/libsass/src/sass.cpp:11:
[0] In file included from ../src/libsass/src/sass_functions.hpp:6:
[0] In file included from ../src/libsass/src/functions.hpp:4:
[0] In file included from ../src/libsass/src/listize.hpp:7:
../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/sass2scss.o ../src/libsass/src/sass2scss.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/sass2scss.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/sass_context.o ../src/libsass/src/sass_context.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/sass_context.o.d.raw   -c
[0] In file included from ../src/libsass/src/sass_context.cpp:9:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/sass_functions.o ../src/libsass/src/sass_functions.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/sass_functions.o.d.raw   -c
[0] In file included from ../src/libsass/src/sass_functions.cpp:5:
[0] In file included from ../src/libsass/src/values.hpp:4:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/sass_util.o ../src/libsass/src/sass_util.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/sass_util.o.d.raw   -c
[0] In file included from ../src/libsass/src/sass_util.cpp:2:
[0] In file included from ../src/libsass/src/node.hpp:7:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/sass_values.o ../src/libsass/src/sass_values.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/sass_values.o.d.raw   -c
[0] In file included from ../src/libsass/src/sass_values.cpp:5:
[0] In file included from ../src/libsass/src/eval.hpp:4:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/source_map.o ../src/libsass/src/source_map.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/source_map.o.d.raw   -c
[0] In file included from ../src/libsass/src/source_map.cpp:7:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/subset_map.o ../src/libsass/src/subset_map.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/subset_map.o.d.raw   -c
[0] In file included from ../src/libsass/src/subset_map.cpp:2:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/to_c.o ../src/libsass/src/to_c.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/to_c.o.d.raw   -c
[0] In file included from ../src/libsass/src/to_c.cpp:3:
../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/to_value.o ../src/libsass/src/to_value.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/to_value.o.d.raw   -c
[0] In file included from ../src/libsass/src/to_value.cpp:2:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/units.o ../src/libsass/src/units.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/units.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/utf8_string.o ../src/libsass/src/utf8_string.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/utf8_string.o.d.raw   -c
[0]   c++ -o Release/obj.target/libsass/src/libsass/src/util.o ../src/libsass/src/util.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/util.o.d.raw   -c
[0] In file included from ../src/libsass/src/util.cpp:3:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
  c++ -o Release/obj.target/libsass/src/libsass/src/values.o ../src/libsass/src/values.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.5.5"' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/values.o.d.raw   -c
[0] In file included from ../src/libsass/src/values.cpp:3:
[0] In file included from ../src/libsass/src/values.hpp:4:
[0] ../src/libsass/src/ast.hpp:1614:25: warning: loop variable 'numerator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto numerator : numerators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1614:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto numerator : numerators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] ../src/libsass/src/ast.hpp:1616:25: warning: loop variable 'denominator' creates a copy from type 'const std::__1::basic_string<char>' [-Wrange-loop-construct]
[0]         for (const auto denominator : denominators)
[0]                         ^
[0] ../src/libsass/src/ast.hpp:1616:14: note: use reference type 'const std::__1::basic_string<char> &' to prevent copying
[0]         for (const auto denominator : denominators)
[0]              ^~~~~~~~~~~~~~~~~~~~~~~~
[0]                         &
[0] 2 warnings generated.
[0]   rm -f Release/sass.a && ./gyp-mac-tool filter-libtool libtool  -static -o Release/sass.a Release/obj.target/libsass/src/libsass/src/ast.o Release/obj.target/libsass/src/libsass/src/ast_fwd_decl.o Release/obj.target/libsass/src/libsass/src/backtrace.o Release/obj.target/libsass/src/libsass/src/base64vlq.o Release/obj.target/libsass/src/libsass/src/bind.o Release/obj.target/libsass/src/libsass/src/cencode.o Release/obj.target/libsass/src/libsass/src/check_nesting.o Release/obj.target/libsass/src/libsass/src/color_maps.o Release/obj.target/libsass/src/libsass/src/constants.o Release/obj.target/libsass/src/libsass/src/context.o Release/obj.target/libsass/src/libsass/src/cssize.o Release/obj.target/libsass/src/libsass/src/emitter.o Release/obj.target/libsass/src/libsass/src/environment.o Release/obj.target/libsass/src/libsass/src/error_handling.o Release/obj.target/libsass/src/libsass/src/eval.o Release/obj.target/libsass/src/libsass/src/expand.o Release/obj.target/libsass/src/libsass/src/extend.o Release/obj.target/libsass/src/libsass/src/file.o Release/obj.target/libsass/src/libsass/src/functions.o Release/obj.target/libsass/src/libsass/src/inspect.o Release/obj.target/libsass/src/libsass/src/json.o Release/obj.target/libsass/src/libsass/src/lexer.o Release/obj.target/libsass/src/libsass/src/listize.o Release/obj.target/libsass/src/libsass/src/memory/SharedPtr.o Release/obj.target/libsass/src/libsass/src/node.o Release/obj.target/libsass/src/libsass/src/operators.o Release/obj.target/libsass/src/libsass/src/output.o Release/obj.target/libsass/src/libsass/src/parser.o Release/obj.target/libsass/src/libsass/src/plugins.o Release/obj.target/libsass/src/libsass/src/position.o Release/obj.target/libsass/src/libsass/src/prelexer.o Release/obj.target/libsass/src/libsass/src/remove_placeholders.o Release/obj.target/libsass/src/libsass/src/sass.o Release/obj.target/libsass/src/libsass/src/sass2scss.o Release/obj.target/libsass/src/libsass/src/sass_context.o Release/obj.target/libsass/src/libsass/src/sass_functions.o Release/obj.target/libsass/src/libsass/src/sass_util.o Release/obj.target/libsass/src/libsass/src/sass_values.o Release/obj.target/libsass/src/libsass/src/source_map.o Release/obj.target/libsass/src/libsass/src/subset_map.o Release/obj.target/libsass/src/libsass/src/to_c.o Release/obj.target/libsass/src/libsass/src/to_value.o Release/obj.target/libsass/src/libsass/src/units.o Release/obj.target/libsass/src/libsass/src/utf8_string.o Release/obj.target/libsass/src/libsass/src/util.o Release/obj.target/libsass/src/libsass/src/values.o
[0]   c++ -o Release/obj.target/binding/src/binding.o ../src/binding.cpp '-DNODE_GYP_MODULE_NAME=binding' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DBUILDING_NODE_EXTENSION' -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/src -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/config -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/openssl/openssl/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/uv/include -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/zlib -I/Users/cameronbrill/Library/Caches/node-gyp/16.9.1/deps/v8/include -I../../nan -I../src/libsass/include  -O3 -gdwarf-2 -mmacosx-version-min=10.7 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -std=c++11 -stdlib=libc++ -fno-rtti -fno-exceptions -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/binding/src/binding.o.d.raw   -c
[0] In file included from ../src/binding.cpp:1:
[0] In file included from ../../nan/nan.h:56:
[0] In file included from /Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node/node.h:63:
[0] In file included from /Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node/v8.h:30:
[0] /Users/cameronbrill/Library/Caches/node-gyp/16.9.1/include/node/v8-internal.h:489:38: error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
[0]             !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
[0]                                 ~~~~~^~~~~~~~~~~
[0]                                      remove_cv
[0] /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/type_traits:776:50: note: 'remove_cv' declared here
[0] template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_cv
[0]                                                  ^
[0] 1 error generated.
[0] make: *** [Release/obj.target/binding/src/binding.o] Error 1
[0] gyp ERR! build error
[0] gyp ERR! stack Error: `make` failed with exit code: 2
[0] gyp ERR! stack     at ChildProcess.onExit (/Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-gyp/lib/build.js:194:23)
[0] gyp ERR! stack     at ChildProcess.emit (node:events:394:28)
[0] gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12)
[0] gyp ERR! System Darwin 20.6.0
[0] gyp ERR! command "/usr/local/Cellar/node/16.9.1/bin/node" "/Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
[0] gyp ERR! cwd /Users/cameronbrill/Projects/work/Highlight/highlight/frontend/node_modules/node-sass
[0] gyp ERR! node -v v16.9.1
[0] gyp ERR! node-gyp -v v7.1.2
[0] gyp ERR! not ok
[0] Build failed with error code: 1
[0] cd frontend && yarn exited with code 1
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```