### PR TITLE
Scope local storage by org id

### DIFF
--- a/frontend/src/pages/Error/ErrorPage.tsx
+++ b/frontend/src/pages/Error/ErrorPage.tsx
@@ -48,7 +48,10 @@ import styles from './ErrorPage.module.scss';
 import useErrorPageConfiguration from './utils/ErrorPageUIConfiguration';
 
 const ErrorPage = ({ integrated }: { integrated: boolean }) => {
-    const { error_id } = useParams<{ error_id: string }>();
+    const { error_id, organization_id } = useParams<{
+        error_id: string;
+        organization_id: string;
+    }>();
 
     const [getErrorGroupQuery, { data, loading }] = useGetErrorGroupLazyQuery({
         variables: { id: error_id },
@@ -56,7 +59,9 @@ const ErrorPage = ({ integrated }: { integrated: boolean }) => {
     const { isLoggedIn } = useAuthContext();
     const [segmentName, setSegmentName] = useState<string | null>(null);
     const [cachedParams, setCachedParams] = useLocalStorage<ErrorSearchParams>(
-        `cachedErrorParams-v2-${segmentName || 'no-selected-segment'}`,
+        `cachedErrorParams-v2-${
+            segmentName || 'no-selected-segment'
+        }-${organization_id}`,
         {}
     );
     const [searchParams, setSearchParams] = useState<ErrorSearchParams>(

--- a/frontend/src/pages/Error/components/SegmentPickerForErrors/SegmentPickerForErrors.tsx
+++ b/frontend/src/pages/Error/components/SegmentPickerForErrors/SegmentPickerForErrors.tsx
@@ -42,7 +42,10 @@ const SegmentPickerForErrors = () => {
     });
     const [selectedSegment, setSelectedSegment] = useLocalStorage<
         { value: string; id: string } | undefined
-    >('highlightSegmentPickerForErrorsSelectedSegmentId', undefined);
+    >(
+        `highlightSegmentPickerForErrorsSelectedSegmentId-${organization_id}`,
+        undefined
+    );
     const [paramsIsDifferent, setParamsIsDifferent] = useState(false);
     const [showCreateSegmentModal, setShowCreateSegmentModal] = useState(false);
     const [segmentToDelete, setSegmentToDelete] = useState<{

--- a/frontend/src/routers/OrgRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/OrgRouter/ApplicationRouter.tsx
@@ -43,7 +43,10 @@ const ApplicationRouter = ({ integrated }: Props) => {
     );
     const [selectedSegment, setSelectedSegment] = useLocalStorage<
         { value: string; id: string } | undefined
-    >('highlightSegmentPickerForPlayerSelectedSegmentId', undefined);
+    >(
+        `highlightSegmentPickerForPlayerSelectedSegmentId-${organization_id}`,
+        undefined
+    );
     const [
         searchParamsToUrlParams,
         setSearchParamsToUrlParams,


### PR DESCRIPTION
Persist segments/filters by org id rather than across all orgs. This PR will have a side effect that users will have to re-select their filters/segments the next time they view sessions/errors, is this okay?

How I tested: Verified that segments/filters are still persisted, but don't apply to other orgs. Also, it seems like we're not persisting filters for sessions unless stored in a segment, is that right?