### PR TITLE
HIG-778: Add session/error secure ID to session and error comments

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -639,17 +639,18 @@ type ErrorField struct {
 
 type SessionComment struct {
 	Model
-	Admins         []Admin `gorm:"many2many:session_comment_admins;"`
-	OrganizationID int
-	ProjectID      int `json:"project_id"`
-	AdminId        int
-	SessionId      int
-	Timestamp      int
-	Text           string
-	XCoordinate    float64
-	YCoordinate    float64
-	Type           string `json:"type" gorm:"default:ADMIN"`
-	Metadata       JSONB  `json:"metadata" gorm:"type:jsonb"`
+	Admins          []Admin `gorm:"many2many:session_comment_admins;"`
+	OrganizationID  int
+	ProjectID       int `json:"project_id"`
+	AdminId         int
+	SessionId       int
+	SessionSecureId string `gorm:"index;not null;default:''"`
+	Timestamp       int
+	Text            string
+	XCoordinate     float64
+	YCoordinate     float64
+	Type            string `json:"type" gorm:"default:ADMIN"`
+	Metadata        JSONB  `json:"metadata" gorm:"type:jsonb"`
 }
 
 type ErrorComment struct {
@@ -659,6 +660,7 @@ type ErrorComment struct {
 	ProjectID      int `json:"project_id"`
 	AdminId        int
 	ErrorId        int
+	ErrorSecureId  string `gorm:"index;not null;default:''"`
 	Text           string
 }
 

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -98,13 +98,14 @@ type ComplexityRoot struct {
 	}
 
 	ErrorComment struct {
-		Author    func(childComplexity int) int
-		CreatedAt func(childComplexity int) int
-		ErrorId   func(childComplexity int) int
-		ID        func(childComplexity int) int
-		ProjectID func(childComplexity int) int
-		Text      func(childComplexity int) int
-		UpdatedAt func(childComplexity int) int
+		Author        func(childComplexity int) int
+		CreatedAt     func(childComplexity int) int
+		ErrorId       func(childComplexity int) int
+		ErrorSecureId func(childComplexity int) int
+		ID            func(childComplexity int) int
+		ProjectID     func(childComplexity int) int
+		Text          func(childComplexity int) int
+		UpdatedAt     func(childComplexity int) int
 	}
 
 	ErrorField struct {
@@ -387,18 +388,19 @@ type ComplexityRoot struct {
 	}
 
 	SessionComment struct {
-		Author      func(childComplexity int) int
-		CreatedAt   func(childComplexity int) int
-		ID          func(childComplexity int) int
-		Metadata    func(childComplexity int) int
-		ProjectID   func(childComplexity int) int
-		SessionId   func(childComplexity int) int
-		Text        func(childComplexity int) int
-		Timestamp   func(childComplexity int) int
-		Type        func(childComplexity int) int
-		UpdatedAt   func(childComplexity int) int
-		XCoordinate func(childComplexity int) int
-		YCoordinate func(childComplexity int) int
+		Author          func(childComplexity int) int
+		CreatedAt       func(childComplexity int) int
+		ID              func(childComplexity int) int
+		Metadata        func(childComplexity int) int
+		ProjectID       func(childComplexity int) int
+		SessionId       func(childComplexity int) int
+		SessionSecureId func(childComplexity int) int
+		Text            func(childComplexity int) int
+		Timestamp       func(childComplexity int) int
+		Type            func(childComplexity int) int
+		UpdatedAt       func(childComplexity int) int
+		XCoordinate     func(childComplexity int) int
+		YCoordinate     func(childComplexity int) int
 	}
 
 	SessionResults struct {
@@ -749,6 +751,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ErrorComment.ErrorId(childComplexity), true
+
+	case "ErrorComment.error_secure_id":
+		if e.complexity.ErrorComment.ErrorSecureId == nil {
+			break
+		}
+
+		return e.complexity.ErrorComment.ErrorSecureId(childComplexity), true
 
 	case "ErrorComment.id":
 		if e.complexity.ErrorComment.ID == nil {
@@ -2676,6 +2685,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SessionComment.SessionId(childComplexity), true
 
+	case "SessionComment.session_secure_id":
+		if e.complexity.SessionComment.SessionSecureId == nil {
+			break
+		}
+
+		return e.complexity.SessionComment.SessionSecureId(childComplexity), true
+
 	case "SessionComment.text":
 		if e.complexity.SessionComment.Text == nil {
 			break
@@ -3192,6 +3208,7 @@ type SessionComment {
     created_at: Time!
     updated_at: Time!
     session_id: Int!
+    session_secure_id: String!
     author: SanitizedAdmin
     text: String!
     x_coordinate: Float
@@ -3205,6 +3222,7 @@ type ErrorComment {
     project_id: ID!
     created_at: Time!
     error_id: Int!
+    error_secure_id: String!
     updated_at: Time!
     author: SanitizedAdmin!
     text: String!
@@ -6434,6 +6452,41 @@ func (ec *executionContext) _ErrorComment_error_id(ctx context.Context, field gr
 	res := resTmp.(int)
 	fc.Result = res
 	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ErrorComment_error_secure_id(ctx context.Context, field graphql.CollectedField, obj *model1.ErrorComment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "ErrorComment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ErrorSecureId, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _ErrorComment_updated_at(ctx context.Context, field graphql.CollectedField, obj *model1.ErrorComment) (ret graphql.Marshaler) {
@@ -14395,6 +14448,41 @@ func (ec *executionContext) _SessionComment_session_id(ctx context.Context, fiel
 	return ec.marshalNInt2int(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _SessionComment_session_secure_id(ctx context.Context, field graphql.CollectedField, obj *model1.SessionComment) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "SessionComment",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SessionSecureId, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _SessionComment_author(ctx context.Context, field graphql.CollectedField, obj *model1.SessionComment) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -16852,6 +16940,11 @@ func (ec *executionContext) _ErrorComment(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		case "error_secure_id":
+			out.Values[i] = ec._ErrorComment_error_secure_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "updated_at":
 			out.Values[i] = ec._ErrorComment_updated_at(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -18651,6 +18744,11 @@ func (ec *executionContext) _SessionComment(ctx context.Context, sel ast.Selecti
 			}
 		case "session_id":
 			out.Values[i] = ec._SessionComment_session_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "session_secure_id":
+			out.Values[i] = ec._SessionComment_session_secure_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -310,6 +310,7 @@ type SessionComment {
     created_at: Time!
     updated_at: Time!
     session_id: Int!
+    session_secure_id: String!
     author: SanitizedAdmin
     text: String!
     x_coordinate: Float
@@ -323,6 +324,7 @@ type ErrorComment {
     project_id: ID!
     created_at: Time!
     error_id: Int!
+    error_secure_id: String!
     updated_at: Time!
     author: SanitizedAdmin!
     text: String!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -644,14 +644,15 @@ func (r *mutationResolver) CreateSessionComment(ctx context.Context, projectID i
 	}
 
 	sessionComment := &model.SessionComment{
-		Admins:      admins,
-		ProjectID:   projectID,
-		AdminId:     admin.Model.ID,
-		SessionId:   session.ID,
-		Timestamp:   sessionTimestamp,
-		Text:        text,
-		XCoordinate: xCoordinate,
-		YCoordinate: yCoordinate,
+		Admins:          admins,
+		ProjectID:       projectID,
+		AdminId:         admin.Model.ID,
+		SessionId:       session.ID,
+		SessionSecureId: session.SecureID,
+		Timestamp:       sessionTimestamp,
+		Text:            text,
+		XCoordinate:     xCoordinate,
+		YCoordinate:     yCoordinate,
 	}
 	createSessionCommentSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.createSessionComment",
 		tracer.ResourceName("db.createSessionComment"), tracer.Tag("project_id", projectID))
@@ -753,11 +754,12 @@ func (r *mutationResolver) CreateErrorComment(ctx context.Context, projectID int
 	}
 
 	errorComment := &model.ErrorComment{
-		Admins:    admins,
-		ProjectID: projectID,
-		AdminId:   admin.Model.ID,
-		ErrorId:   errorGroup.ID,
-		Text:      text,
+		Admins:        admins,
+		ProjectID:     projectID,
+		AdminId:       admin.Model.ID,
+		ErrorId:       errorGroup.ID,
+		ErrorSecureId: errorGroup.SecureID,
+		Text:          text,
 	}
 	createErrorCommentSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.createErrorComment",
 		tracer.ResourceName("db.createErrorComment"), tracer.Tag("project_id", projectID))

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -350,6 +350,7 @@ export type SessionComment = {
     created_at: Scalars['Time'];
     updated_at: Scalars['Time'];
     session_id: Scalars['Int'];
+    session_secure_id: Scalars['String'];
     author?: Maybe<SanitizedAdmin>;
     text: Scalars['String'];
     x_coordinate?: Maybe<Scalars['Float']>;
@@ -364,6 +365,7 @@ export type ErrorComment = {
     project_id: Scalars['ID'];
     created_at: Scalars['Time'];
     error_id: Scalars['Int'];
+    error_secure_id: Scalars['String'];
     updated_at: Scalars['Time'];
     author: SanitizedAdmin;
     text: Scalars['String'];


### PR DESCRIPTION
All new comments will have the secure ID of the session/error group set. All old comments will have it be automatically set to empty string (basically means we can make it non-null and simplify the code). This should be fairly fast because the tables are small.

After this is landed, I'll run a migration script on prod to replace the empty strings on old comments with real values. Everyone on dev will still get empty string. When I eventually cut the frontend over to secure ID's, all comments in prod will still work, but we'll lose old comments on dev.

I verified the automigrate works as expected locally.