### PR TITLE
Error sharing - backend permission changes + new mutation

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -626,6 +626,7 @@ type ErrorGroup struct {
 	Fields           []*ErrorField `gorm:"many2many:error_group_fields;"`
 	FieldGroup       *string
 	Environments     string
+	IsPublic         bool `gorm:"default:false"`
 }
 
 type ErrorField struct {

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -197,25 +197,44 @@ func ErrorInputToParams(params *modelInputs.ErrorSearchParamsInput) *model.Error
 	return modelParams
 }
 
-func (r *Resolver) isAdminErrorGroupOwner(ctx context.Context, errorGroupID *int, errorGroupSecureID *string) (*model.ErrorGroup, error) {
+func (r *Resolver) doesAdminOwnErrorGroup(ctx context.Context, errorGroupID *int, errorGroupSecureID *string) (eg *model.ErrorGroup, isOwner bool, err error) {
 	errorGroup := &model.ErrorGroup{}
 	if errorGroupID == nil && errorGroupSecureID == nil {
-		return nil, errors.New("No ID was specified for the error group")
+		return nil, false, errors.New("No ID was specified for the error group")
 	}
 	if errorGroupSecureID != nil {
 		if err := r.DB.Where(&model.ErrorGroup{SecureID: *errorGroupSecureID}).First(&errorGroup).Error; err != nil {
-			return nil, e.Wrap(err, "error querying error group by secureID: "+*errorGroupSecureID)
+			return nil, false, e.Wrap(err, "error querying error group by secureID: "+*errorGroupSecureID)
 		}
 	} else {
 		if err := r.DB.Where(&model.ErrorGroup{Model: model.Model{ID: *errorGroupID}}).First(&errorGroup).Error; err != nil {
-			return nil, e.Wrap(err, fmt.Sprintf("error querying error group by ID: %d", *errorGroupID))
+			return nil, false, e.Wrap(err, fmt.Sprintf("error querying error group by ID: %d", *errorGroupID))
 		}
 	}
-	_, err := r.isAdminInProjectOrDemoProject(ctx, errorGroup.ProjectID)
+	_, err = r.isAdminInProjectOrDemoProject(ctx, errorGroup.ProjectID)
 	if err != nil {
-		return nil, e.Wrap(err, "error validating admin in project")
+		return errorGroup, false, e.Wrap(err, "error validating admin in project")
 	}
-	return errorGroup, nil
+	return errorGroup, true, nil
+}
+
+func (r *Resolver) canAdminViewErrorGroup(ctx context.Context, errorGroupID *int, errorGroupSecureID *string) (*model.ErrorGroup, error) {
+	errorGroup, isOwner, err := r.doesAdminOwnErrorGroup(ctx, errorGroupID, errorGroupSecureID)
+	if err == nil && isOwner {
+		return errorGroup, nil
+	}
+	if errorGroup != nil && errorGroup.IsPublic {
+		return errorGroup, nil
+	}
+	return nil, err
+}
+
+func (r *Resolver) canAdminModifyErrorGroup(ctx context.Context, errorGroupID *int, errorGroupSecureID *string) (*model.ErrorGroup, error) {
+	errorGroup, isOwner, err := r.doesAdminOwnErrorGroup(ctx, errorGroupID, errorGroupSecureID)
+	if err == nil && isOwner {
+		return errorGroup, nil
+	}
+	return nil, err
 }
 
 func (r *Resolver) _doesAdminOwnSession(ctx context.Context, session_id *int, session_secure_id *string) (session *model.Session, ownsSession bool, err error) {
@@ -560,4 +579,20 @@ func (r *Resolver) SendSlackAlertToUser(project *model.Project, admin *model.Adm
 	}
 
 	return nil
+}
+
+// Returns the current Admin or an Admin with ID = 0 if the current Admin is a guest
+func (r *Resolver) getCurrentAdminOrGuest(ctx context.Context) (currentAdmin *model.Admin, isGuest bool) {
+	admin, err := r.getCurrentAdmin(ctx)
+	isGuest = false
+	if admin == nil || err != nil {
+		isGuest = true
+		admin = &model.Admin{
+			// An Admin record was created manually with an ID of 0.
+			Model: model.Model{
+				ID: 0,
+			},
+		}
+	}
+	return admin, isGuest
 }

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -135,6 +135,7 @@ type ErrorGroup {
     state: ErrorState!
     environments: String
     error_frequency: [Int64]!
+    is_public: Boolean!
 }
 
 type ErrorMetadata {
@@ -593,4 +594,9 @@ type Mutation {
         session_secure_id: String
         is_public: Boolean!
     ): Session
+    updateErrorGroupIsPublic(
+        error_group_id: ID
+        error_group_secure_id: String
+        is_public: Boolean!
+    ): ErrorGroup
 }

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -160,6 +160,7 @@ export type ErrorGroup = {
     state: ErrorState;
     environments?: Maybe<Scalars['String']>;
     error_frequency: Array<Maybe<Scalars['Int64']>>;
+    is_public: Scalars['Boolean'];
 };
 
 export type ErrorMetadata = {
@@ -719,6 +720,7 @@ export type Mutation = {
     updateTrackPropertiesAlert?: Maybe<SessionAlert>;
     updateUserPropertiesAlert?: Maybe<SessionAlert>;
     updateSessionIsPublic?: Maybe<Session>;
+    updateErrorGroupIsPublic?: Maybe<ErrorGroup>;
 };
 
 export type MutationCreateProjectArgs = {
@@ -908,5 +910,11 @@ export type MutationUpdateUserPropertiesAlertArgs = {
 export type MutationUpdateSessionIsPublicArgs = {
     session_id?: Maybe<Scalars['ID']>;
     session_secure_id?: Maybe<Scalars['String']>;
+    is_public: Scalars['Boolean'];
+};
+
+export type MutationUpdateErrorGroupIsPublicArgs = {
+    error_group_id?: Maybe<Scalars['ID']>;
+    error_group_secure_id?: Maybe<Scalars['String']>;
     is_public: Scalars['Boolean'];
 };


### PR DESCRIPTION
* committed + squashed backend changes from #1402
* also including frontend/src/graph/generated/schemas.tsx (this is generated from the backend schema.graphqls, right?)
* frontend code depends on backend changes (addition of `IsPublic` and new `UpdateErrorGroupIsPublic` mutation), so deploying this first will prevent downtime
* tested locally to make sure error group features were still working for logged-in admins (adding comments, changing error group state, etc) and there were no visible changes or errors
* will create PR for frontend changes after these are merged in