### PR TITLE
Reduce the size of modal titles

### DIFF
--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -41,7 +41,7 @@ const Modal: React.FC<Props> = ({ children, title, minimal, ...props }) => {
             closable={!minimal}
             bodyStyle={bodyStyle}
         >
-            {title && <h2 className={styles.title}>{title}</h2>}
+            {title && <h3 className={styles.title}>{title}</h3>}
             <main className={styles.modalContent}>{children}</main>
         </AntDesignModal>
     );


### PR DESCRIPTION
Per Jay's request. Checked existing uses of modal, examples of what it looks like now:
<img width="713" alt="Screen Shot 2021-10-05 at 1 40 01 PM" src="https://user-images.githubusercontent.com/696206/136099475-f1b895e0-31f6-4d9a-8368-edfbbf673566.png">
<img width="780" alt="Screen Shot 2021-10-05 at 1 40 06 PM" src="https://user-images.githubusercontent.com/696206/136099480-a81d5b51-f60a-4b51-8dc2-560e462dfa8f.png">


