### PR TITLE
HIG-1236: reduce `processSession` workerpool size

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -542,7 +542,7 @@ func (w *Worker) Start() {
 			log.Infof("sessions that will be processed: %v", sessionIds)
 		}
 
-		wp := workerpool.New(40)
+		wp := workerpool.New(10)
 		wp.SetPanicHandler(func() {
 			if rec := recover(); rec != nil {
 				buf := make([]byte, 64<<10)


### PR DESCRIPTION
trying to confirm that number of goroutines isn't causing https://app.datadoghq.com/logs?query=source%3Aworker&agg_m=count&agg_q=&agg_t=count&cols=host%2Cservice&index=%2A&messageDisplay=inline&sort_m=&sort_t=&stream_sort=desc&top_n=&top_o=&viz=pattern&from_ts=1633556282860&to_ts=1633559882860&live=true