### PR TITLE
HIG-1236: update nofile ulimit

### DIFF
--- a/deploy/worker-task.json
+++ b/deploy/worker-task.json
@@ -105,7 +105,9 @@
             "cpu": 0,
             "environment": [],
             "resourceRequirements": null,
-            "ulimits": null,
+            "ulimits": [
+                { "name": "nofile", "softLimit": 65535, "hardLimit": 65535 }
+            ],
             "dnsServers": null,
             "mountPoints": [
                 {


### PR DESCRIPTION
"So you can set the hard and soft limits to 65535 since this is the maximum supported value for Fargate. The hard limit of 65535 is also the default limit for ECS tasks running on EC2 based on my previous observations" - AWS support

related links:
https://docs.aws.amazon.com/eks/latest/userguide/fargate.html#fargate-considerations
https://github.com/aws/containers-roadmap/issues/1013
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_limits