### PR TITLE
HIG-1236: Reduce workerpool count to 16

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -542,7 +542,7 @@ func (w *Worker) Start() {
 			log.Infof("sessions that will be processed: %v", sessionIds)
 		}
 
-		wp := workerpool.New(40)
+		wp := workerpool.New(16)
 		wp.SetPanicHandler(func() {
 			if rec := recover(); rec != nil {
 				buf := make([]byte, 64<<10)


### PR DESCRIPTION
we were reaching cpu/memory constraints at 40, 16 looks like the best number 