### PR TITLE
Revert "HIG-1236: Reduce workerpool count to 16"

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -542,7 +542,7 @@ func (w *Worker) Start() {
 			log.Infof("sessions that will be processed: %v", sessionIds)
 		}
 
-		wp := workerpool.New(16)
+		wp := workerpool.New(40)
 		wp.SetPanicHandler(func() {
 			if rec := recover(); rec != nil {
 				buf := make([]byte, 64<<10)


### PR DESCRIPTION
Reverts highlight-run/highlight#1497

read the cloudwatch metrics wrong