### PR TITLE
HIG-1236: update ulimits for all backend tasks

### DIFF
--- a/deploy/private-graph-task.json
+++ b/deploy/private-graph-task.json
@@ -99,7 +99,9 @@
             "cpu": 0,
             "environment": [],
             "resourceRequirements": null,
-            "ulimits": null,
+            "ulimits": [
+                { "name": "nofile", "softLimit": 65535, "hardLimit": 65535 }
+            ],
             "dnsServers": null,
             "mountPoints": [],
             "workingDirectory": null,

--- a/deploy/public-graph-task.json
+++ b/deploy/public-graph-task.json
@@ -105,7 +105,9 @@
             "cpu": 0,
             "environment": [],
             "resourceRequirements": null,
-            "ulimits": null,
+            "ulimits": [
+                { "name": "nofile", "softLimit": 65535, "hardLimit": 65535 }
+            ],
             "dnsServers": null,
             "mountPoints": [],
             "workingDirectory": null,


### PR DESCRIPTION
this was a bottleneck for the `worker`. There's no reason to keep the `ulimits` at their low default values, so we increase here.

https://www.ibm.com/support/pages/it-safe-increase-operating-system-ulimits
TLDR; yes, increase them proactively so you don't get problems due to not increasing them.