### PR TITLE
Fix session URL's returned by client SDK

### DIFF
--- a/backend/public-graph/graph/generated/generated.go
+++ b/backend/public-graph/graph/generated/generated.go
@@ -60,6 +60,8 @@ type ComplexityRoot struct {
 	Session struct {
 		ID             func(childComplexity int) int
 		OrganizationID func(childComplexity int) int
+		ProjectID      func(childComplexity int) int
+		SecureID       func(childComplexity int) int
 	}
 }
 
@@ -188,6 +190,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Session.OrganizationID(childComplexity), true
 
+	case "Session.project_id":
+		if e.complexity.Session.ProjectID == nil {
+			break
+		}
+
+		return e.complexity.Session.ProjectID(childComplexity), true
+
+	case "Session.secure_id":
+		if e.complexity.Session.SecureID == nil {
+			break
+		}
+
+		return e.complexity.Session.SecureID(childComplexity), true
+
 	}
 	return 0, false
 }
@@ -260,7 +276,9 @@ scalar Int64
 
 type Session {
     id: ID!
+    secure_id: String!
     organization_id: ID!
+    project_id: ID!
 }
 
 input StackFrameInput {
@@ -1056,6 +1074,41 @@ func (ec *executionContext) _Session_id(ctx context.Context, field graphql.Colle
 	return ec.marshalNID2int(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Session_secure_id(ctx context.Context, field graphql.CollectedField, obj *model1.Session) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Session",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SecureID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Session_organization_id(ctx context.Context, field graphql.CollectedField, obj *model1.Session) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -1075,6 +1128,41 @@ func (ec *executionContext) _Session_organization_id(ctx context.Context, field 
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return obj.OrganizationID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNID2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Session_project_id(ctx context.Context, field graphql.CollectedField, obj *model1.Session) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Session",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ProjectID, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -2464,8 +2552,18 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "secure_id":
+			out.Values[i] = ec._Session_secure_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "organization_id":
 			out.Values[i] = ec._Session_organization_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "project_id":
+			out.Values[i] = ec._Session_project_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}

--- a/backend/public-graph/graph/schema.graphqls
+++ b/backend/public-graph/graph/schema.graphqls
@@ -6,7 +6,9 @@ scalar Int64
 
 type Session {
     id: ID!
+    secure_id: String!
     organization_id: ID!
+    project_id: ID!
 }
 
 input StackFrameInput {

--- a/client/src/graph/generated/operations.ts
+++ b/client/src/graph/generated/operations.ts
@@ -26,7 +26,9 @@ export type Scalars = {
 export type Session = {
   __typename?: 'Session';
   id: Scalars['ID'];
+  secure_id: Scalars['String'];
   organization_id: Scalars['ID'];
+  project_id: Scalars['ID'];
 };
 
 export type StackFrameInput = {
@@ -205,7 +207,7 @@ export type InitializeSessionMutation = (
   { __typename?: 'Mutation' }
   & { initializeSession?: Types.Maybe<(
     { __typename?: 'Session' }
-    & Pick<Types.Session, 'id' | 'organization_id'>
+    & Pick<Types.Session, 'id' | 'secure_id' | 'organization_id' | 'project_id'>
   )> }
 );
 
@@ -281,7 +283,9 @@ export const InitializeSessionDocument = gql`
     fingerprint: $id
   ) {
     id
+    secure_id
     organization_id
+    project_id
   }
 }
     `;

--- a/client/src/graph/generated/schemas.ts
+++ b/client/src/graph/generated/schemas.ts
@@ -20,7 +20,9 @@ export type Scalars = {
 export type Session = {
   __typename?: 'Session';
   id: Scalars['ID'];
+  secure_id: Scalars['String'];
   organization_id: Scalars['ID'];
+  project_id: Scalars['ID'];
 };
 
 export type StackFrameInput = {

--- a/client/src/graph/operators/mutation.gql
+++ b/client/src/graph/operators/mutation.gql
@@ -79,7 +79,9 @@ mutation initializeSession(
         fingerprint: $id
     ) {
         id
+        secure_id
         organization_id
+        project_id
     }
 }
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -129,6 +129,8 @@ type Source = 'segment' | undefined;
 
 type SessionData = {
     sessionID: number;
+    sessionSecureID: string;
+    projectID: number;
     sessionStartTime?: number;
     userIdentifier?: string;
     userObject?: Object;
@@ -151,9 +153,12 @@ const MAX_SESSION_LENGTH = 4 * 60 * 60 * 1000;
 
 const MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS = 5;
 
+const HIGHLIGHT_URL = 'app.highlight.run';
+
 export class Highlight {
     /** Determines if the client is running on a Highlight property (e.g. frontend). */
     isRunningOnHighlight: boolean;
+    /** Verbose project ID that is exposed to users. Legacy users may still be using ints. */
     organizationID: string;
     graphqlSDK: Sdk;
     events: eventWithTime[];
@@ -269,6 +274,8 @@ export class Highlight {
         this.firstloadVersion = options.firstloadVersion || 'unknown';
         this.sessionData = {
             sessionID: 0,
+            sessionSecureID: '',
+            projectID: 0,
             sessionStartTime: Date.now(),
         };
         // We only want to store a subset of the options for debugging purposes. Firstload version is stored as another field so we don't need to store it here.
@@ -475,8 +482,11 @@ export class Highlight {
                     this.sessionData.sessionID = parseInt(
                         gr?.initializeSession?.id || '0'
                     );
-                    const organization_id =
-                        gr?.initializeSession?.organization_id;
+                    this.sessionData.sessionSecureID =
+                        gr?.initializeSession?.secure_id || '';
+                    this.sessionData.projectID = parseInt(
+                        gr?.initializeSession?.project_id || '0'
+                    );
                     this.logger.log(
                         `Loaded Highlight
   Remote: ${process.env.PUBLIC_GRAPH_URI}
@@ -688,6 +698,15 @@ export class Highlight {
 
     getCurrentSessionTimestamp() {
         return this._recordingStartTime;
+    }
+
+    getCurrentSessionURL() {
+        const projectID = this.sessionData.projectID;
+        const sessionSecureID = this.sessionData.sessionSecureID;
+        if (projectID && sessionSecureID) {
+            return `https://${HIGHLIGHT_URL}/${projectID}/sessions/${sessionSecureID}`;
+        }
+        return null;
     }
 
     addSessionFeedback({

--- a/firstload/package.json
+++ b/firstload/package.json
@@ -1,6 +1,6 @@
 {
     "name": "highlight.run",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "scripts": {
         "build": "webpack --mode=production --config=./webpack.config.js",
         "dev": "doppler run -- webpack-dev-server --progress --colors --watch",


### PR DESCRIPTION
Fixes:
1. Use secure session ID in URL instead of session ID
2. Use short project ID in URL instead of verbose projectID (or omitting the ID altogether)
3. Always use https:// prefix

This bumps the patch version on firstload.

Testing: I tested `getSessionURL()` and `getSessionDetails()` on localhost - if I took the returned URLs and manually substituted `localhost:3000` for `app.highlight.run`, they worked.