### PR TITLE
Fix toggles: Revert "Set session data only once (#1485)"

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -108,7 +108,7 @@ export const usePlayer = (): ReplayerContextInterface => {
 
     const [markSessionAsViewed] = useMarkSessionAsViewedMutation();
 
-    useGetSessionQuery({
+    const { data: sessionData } = useGetSessionQuery({
         variables: {
             secure_id: session_secure_id,
         },
@@ -122,7 +122,6 @@ export const usePlayer = (): ReplayerContextInterface => {
                         },
                     });
                 }
-                setSession(data?.session as Session | undefined);
                 getSessionPayloadQuery({
                     variables: {
                         session_secure_id,
@@ -178,6 +177,10 @@ export const usePlayer = (): ReplayerContextInterface => {
             resetPlayer(ReplayerState.Empty);
         }
     }, [session_secure_id, resetPlayer]);
+
+    useEffect(() => {
+        setSession(sessionData?.session as Session | undefined);
+    }, [sessionData?.session]);
 
     // Reset all state when loading events.
     useEffect(() => {


### PR DESCRIPTION
This reverts commit a2895082e4abee8ebf984ba699bc9448e3a66779.

This seems to have broken the toggles in various places (star/unstar, share/unshare) - the UI no longer updates when you toggle something.

These toggles directly update the apollo cache when toggled. My theory is that when this happens, Apollo updates the `data` state returned by `useGetSessionQuery`, but does not call `onCompleted()` for a second time, hence why the original commit breaks the flow.