### PR TITLE
Fix toggle animation being clipped

### DIFF
--- a/frontend/src/components/Switch/Switch.module.scss
+++ b/frontend/src/components/Switch/Switch.module.scss
@@ -18,4 +18,8 @@
     &.noMarginAroundSwitch {
         margin: 0;
     }
+
+    &.setMarginForAnimation {
+        margin: 6px; // The animation for toggling the switch takes up extra space
+    }
 }

--- a/frontend/src/components/Switch/Switch.module.scss.d.ts
+++ b/frontend/src/components/Switch/Switch.module.scss.d.ts
@@ -1,4 +1,5 @@
 export const checked: string;
 export const label: string;
 export const noMarginAroundSwitch: string;
+export const setMarginForAnimation: string;
 export const spaceBetween: string;

--- a/frontend/src/components/Switch/Switch.tsx
+++ b/frontend/src/components/Switch/Switch.tsx
@@ -16,6 +16,7 @@ type Props = Pick<
     /** Renders the label and the switch with space-between. */
     justifySpaceBetween?: boolean;
     noMarginAroundSwitch?: boolean;
+    setMarginForAnimation?: boolean;
     trackingId: string;
 };
 
@@ -24,6 +25,7 @@ const Switch = ({
     labelFirst,
     justifySpaceBetween,
     noMarginAroundSwitch,
+    setMarginForAnimation,
     className,
     trackingId,
     ...props
@@ -36,6 +38,7 @@ const Switch = ({
                 [styles.checked]: props.checked,
                 [styles.spaceBetween]: justifySpaceBetween,
                 [styles.noMarginAroundSwitch]: noMarginAroundSwitch,
+                [styles.setMarginForAnimation]: setMarginForAnimation,
             })}
         >
             {labelFirst && labelToRender}

--- a/frontend/src/pages/Error/components/ErrorShareButton/ErrorShareButton.tsx
+++ b/frontend/src/pages/Error/components/ErrorShareButton/ErrorShareButton.tsx
@@ -104,6 +104,7 @@ const ExternalSharingToggle = ({ errorGroup }: Props) => {
                 }}
                 label="Allow anyone with the link to view this error."
                 trackingId="ErrorSharingExternal"
+                setMarginForAnimation
             />
         </div>
     );

--- a/frontend/src/pages/Player/SessionShareButton/SessionShareButton.tsx
+++ b/frontend/src/pages/Player/SessionShareButton/SessionShareButton.tsx
@@ -76,6 +76,7 @@ const SessionShareButton = (props: ButtonProps) => {
                         }}
                         label="Include current timestamp"
                         trackingId="SessionShareURLIncludeTimestamp"
+                        setMarginForAnimation
                     />
                 </ModalBody>
             </Modal>
@@ -122,6 +123,7 @@ const ExternalSharingToggle = () => {
                 }}
                 label="Allow anyone with the link to access this session."
                 trackingId="SessionSharingExternal"
+                setMarginForAnimation
             />
         </div>
     );


### PR DESCRIPTION
The AntDesignSwitch has an animation when toggled that can't be disabled. The toggle switch needs extra space around it to account for this - if not given this space, it will be clipped. For the share button, I originally built this margin into the toggle by default, but it was removed in #1160. Instead, I've added a param so that whoever uses the toggle can decide.

Before:

https://user-images.githubusercontent.com/696206/136640455-ab2cc4f4-169e-43f5-b5b1-e0aae956750d.mov

After:

https://user-images.githubusercontent.com/696206/136640459-ef08391c-e707-4a3c-ae8a-cb0dfef4dfcd.mov