### PR TITLE
Get the language and networking recording preference when getting sessions

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -93,15 +93,15 @@ func (r *errorGroupResolver) StackTrace(ctx context.Context, obj *model.ErrorGro
 func (r *errorGroupResolver) MetadataLog(ctx context.Context, obj *model.ErrorGroup) ([]*modelInputs.ErrorMetadata, error) {
 	var metadataLogs []*modelInputs.ErrorMetadata
 	r.DB.Raw(`
-		SELECT s.id AS session_id, 
-			s.secure_id AS session_secure_id, 
-			e.id AS error_id, 
-			e.timestamp, 
-			s.os_name AS os, 
-			s.browser_name AS browser, 
-			e.url AS visited_url, 
-			s.fingerprint AS fingerprint, 
-			s.identifier AS identifier, 
+		SELECT s.id AS session_id,
+			s.secure_id AS session_secure_id,
+			e.id AS error_id,
+			e.timestamp,
+			s.os_name AS os,
+			s.browser_name AS browser,
+			e.url AS visited_url,
+			s.fingerprint AS fingerprint,
+			s.identifier AS identifier,
 			s.user_properties
 		FROM sessions AS s
 		INNER JOIN (
@@ -2051,7 +2051,7 @@ func (r *queryResolver) Sessions(ctx context.Context, projectID int, count int, 
 		return nil, e.Wrap(err, "admin not found in project")
 	}
 
-	sessionsQueryPreamble := "SELECT id, secure_id, project_id, processed, starred, first_time, os_name, os_version, browser_name, browser_version, city, state, postal, identifier, fingerprint, created_at, deleted_at, length, active_length, user_object, viewed, field_group, user_properties"
+	sessionsQueryPreamble := "SELECT id, secure_id, project_id, processed, starred, first_time, os_name, os_version, browser_name, browser_version, city, state, postal, identifier, fingerprint, created_at, deleted_at, length, active_length, user_object, viewed, field_group, user_properties, enable_recording_network_contents, language"
 	joinClause := "FROM sessions"
 
 	fieldFilters, err := r.getFieldFilters(ctx, projectID, params)


### PR DESCRIPTION
1. Checked the Apollo cache, saw the `GetSessions` query was updating the cache for every `Session`. 2 fields were getting set to `null`: `enable_recording_network_contents` and `language`.
2. The reason for this is because we weren't querying the DB for these values, the resolver would set these fields as null

The `Session` query didn't have this problem since we're using the default model to resolver mapping instead of hand-crafting the DB query. There was a race condition here that determined whether the Apollo cache would have `null` for those 2 fields. If `Session` resolves before `GetSessions`, we'll see `null` since the results of `GetSessions` would be used to update the cache. If `GetSessions` resolves then `Session`, the cache will have the non-null values.

FYI and ty @silhouettes 