### PR TITLE
Create custom slack message previews

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1073,10 +1073,11 @@ func (obj *Alert) SendSlackAlert(input *SendSlackAlertInput) error {
 		blockSet = append(blockSet, slack.NewDividerBlock())
 		msg.Blocks = &slack.Blocks{BlockSet: blockSet}
 	case AlertType.NEW_SESSION:
-		previewText = fmt.Sprintf("Highlight: New Session Created By %s", input.UserIdentifier)
-		if input.UserIdentifier == "" {
-			previewText = fmt.Sprintf("Highlight: New Session Created By %s", "User")
+		identifier := input.UserIdentifier
+		if identifier == "" {
+			identifier = "User"
 		}
+		previewText = fmt.Sprintf("Highlight: New Session Created By %s", identifier)
 		textBlock = slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*New Session Created By User: %s*\n\n", input.UserIdentifier), false, false)
 		blockSet = append(blockSet, slack.NewSectionBlock(textBlock, messageBlock, nil))
 		blockSet = append(blockSet, slack.NewDividerBlock())


### PR DESCRIPTION
`msg.Text` acts as a fallback in case the slack message blocks fail to render. For notifications, however, it serves as the notification preview text. So, we set this for every alert type.

thoughts on the text in the previews? if yes, review, else, approve