### PR TITLE
[HIG-1247] add word-break for Safari, more specific width conditions to determine when to hide right panel

### DIFF
--- a/frontend/src/components/KeyValueTable/KeyValueTable.module.scss
+++ b/frontend/src/components/KeyValueTable/KeyValueTable.module.scss
@@ -24,14 +24,16 @@
 .value {
     align-items: center;
     color: var(--text-primary) !important;
-    display: flex;
+    display: inline-block;
     font-size: 12px !important;
     font-style: normal;
     line-height: initial;
     overflow-wrap: anywhere;
+    word-break: break-word;
 }
 
 .infoTooltip {
     height: var(--size-medium);
+    vertical-align: bottom;
     width: var(--size-medium);
 }

--- a/frontend/src/pages/Player/PlayerHook/utils/usePlayerConfiguration.tsx
+++ b/frontend/src/pages/Player/PlayerHook/utils/usePlayerConfiguration.tsx
@@ -73,10 +73,16 @@ const usePlayerConfiguration = () => {
     const { width } = useWindowSize();
 
     useEffect(() => {
-        if (width <= 1300) {
+        if (showLeftPanel && showDevTools && width <= 1400) {
+            setShowRightPanel(false);
+        } else if (showLeftPanel && width <= 1335) {
+            setShowRightPanel(false);
+        } else if (showDevTools && width <= 1000) {
+            setShowRightPanel(false);
+        } else if (width <= 875) {
             setShowRightPanel(false);
         }
-    }, [setShowRightPanel, width]);
+    }, [setShowRightPanel, showDevTools, showLeftPanel, width]);
 
     return {
         showLeftPanel,


### PR DESCRIPTION
* `overflow-wrap: anywhere` is not supported in Safari, adding `word-break: break-word`
* change to `display: inline-block` so the tooltip icon is displayed at the end of the text instead of squeezed into a small space to the right
* add more specific conditions to avoid prematurely closing the right panel when there's enough width to display it