### PR TITLE
Use regex to get source map url

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -618,11 +618,12 @@ func (r *Resolver) processStackFrame(projectId, sessionId int, stackTrace model2
 		return nil, err
 	}
 
-	sourceMapFileName := string(regexp.MustCompile(`sourceMappingURL=(.*)`).Find(minifiedFileBytes))
+	sourceMapFileName := string(regexp.MustCompile(`//# sourceMappingURL=(.*)`).Find(minifiedFileBytes))
 	if len(sourceMapFileName) < 1 {
 		err := e.Errorf("file does not contain source map url: %v", stackTraceFileURL)
 		return nil, err
 	}
+	sourceMapFileName = strings.Replace(sourceMapFileName, "//# sourceMappingURL=", "", 1)
 
 	// construct sourcemap url from searched file
 	sourceMapURL := (stackTraceFileURL)[:stackFileNameIndex] + sourceMapFileName


### PR DESCRIPTION
this pr handles the case where the users source file has a trailing empty line at the end.