### PR TITLE
exclude `migrations` from air config

### DIFF
--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -1,3 +1,3 @@
 [build]
 include_ext = ["go"]
-exclude_dir = ["node_modules", "build"]
+exclude_dir = ["node_modules", "build", "migrations"]


### PR DESCRIPTION
not really important, just stops air from rebuilding if a change in the `migrations` directory happens.