### PR TITLE
Fix the matching of performance timings to request-response pairs

### DIFF
--- a/client/src/listeners/network-listener/utils/utils.ts
+++ b/client/src/listeners/network-listener/utils/utils.ts
@@ -53,8 +53,8 @@ export const matchPerformanceTimingsWithRequestResponsePair = (
          * first few requests made when a page loads.
          */
         const offset =
-            performanceTimingsForUrl.length -
-            requestResponsePairsForUrl.length;
+            Math.max(performanceTimingsForUrl.length -
+            requestResponsePairsForUrl.length, 0);
         for (
             let i = offset;
             i < performanceTimingsForUrl.length;


### PR DESCRIPTION
It may be easier to look at this PR commit by commit, they loosely correlate to the individual issues addressed:

1) The ordering of the performance timings does not match the ordering of the request response pairs, which throws the correlation off
2) The arithmetic for calculating offsets when the number of performance timings is greater than the number of request response pairs had a mistake
3) In the cases where our monkey-patching doesn't work (e.g. when using graphql), we will be intermittently missing request response pairs, which throws the whole correlation off. My solution here is to match the request-response pairs by URL first, and then timestamp

We can probably do more in the future for robustness/simplicity but I think this is good enough for now