### PR TITLE
HIG-1299: Differentiate logs in EnhanceStackTrace

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -582,7 +582,7 @@ func (r *Resolver) processStackFrame(projectId, sessionId int, stackTrace model2
 	// get path from url
 	u, err := url.Parse(stackTraceFileURL)
 	if err != nil {
-		err := e.Wrapf(err, "error parsing url: %v", stackTraceFileURL)
+		err := e.Wrapf(err, "error parsing stack trace file url: %v", stackTraceFileURL)
 		return nil, err
 	}
 	stackTraceFilePath := u.Path
@@ -630,7 +630,7 @@ func (r *Resolver) processStackFrame(projectId, sessionId int, stackTrace model2
 	// get path from url
 	u2, err := url.Parse(sourceMapURL)
 	if err != nil {
-		err := e.Wrapf(err, "error parsing url: %v", sourceMapURL)
+		err := e.Wrapf(err, "error parsing source map url: %v", sourceMapURL)
 		return nil, err
 	}
 	sourceMapFilePath := u2.Path


### PR DESCRIPTION
trying to figure out where this is coming from: https://app.datadoghq.com/logs?cols=host%2Cservice&event&from_ts=1634669780188&index=&live=false&messageDisplay=inline&query=&stream_sort=desc&to_ts=1634669780198