### PR TITLE
tabbed network resource panel for errors

### DIFF
--- a/frontend/src/components/Tabs/Tabs.module.scss
+++ b/frontend/src/components/Tabs/Tabs.module.scss
@@ -11,9 +11,18 @@
     align-items: center;
     column-gap: var(--size-medium);
     display: flex;
-    padding-right: var(--size-large);
+
+    &.withHeaderPadding {
+        padding-right: var(--size-large);
+    }
 }
 
 .tabs {
     font-family: var(--header-font-family) !important;
+
+    &.noHeaderPadding {
+        :global(.ant-tabs-nav-wrap) {
+            padding: 0;
+        }
+    }
 }

--- a/frontend/src/components/Tabs/Tabs.module.scss.d.ts
+++ b/frontend/src/components/Tabs/Tabs.module.scss.d.ts
@@ -1,4 +1,6 @@
 export const extraContentContainer: string;
+export const noHeaderPadding: string;
 export const tabPane: string;
 export const tabs: string;
+export const withHeaderPadding: string;
 export const withPadding: string;

--- a/frontend/src/components/Tabs/Tabs.tsx
+++ b/frontend/src/components/Tabs/Tabs.tsx
@@ -21,6 +21,8 @@ type Props = Pick<
     id: string;
     /** Whether the tab contents has the default padding. */
     noPadding?: boolean;
+    /** Whether the tab headers have the default padding. */
+    noHeaderPadding?: boolean;
     /** An HTML id to attach to the tabs. */
     tabsHtmlId?: string;
     className?: string;
@@ -30,6 +32,7 @@ const Tabs = ({
     tabs,
     id,
     noPadding = false,
+    noHeaderPadding = false,
     tabBarExtraContent,
     tabsHtmlId,
     className,
@@ -53,13 +56,19 @@ const Tabs = ({
             }}
             tabBarExtraContent={
                 tabBarExtraContent ? (
-                    <div className={styles.extraContentContainer}>
+                    <div
+                        className={classNames(styles.extraContentContainer, {
+                            [styles.withHeaderPadding]: !noHeaderPadding,
+                        })}
+                    >
                         {tabBarExtraContent}
                     </div>
                 ) : null
             }
             id={tabsHtmlId}
-            className={classNames(styles.tabs, className)}
+            className={classNames(styles.tabs, className, {
+                [styles.noHeaderPadding]: noHeaderPadding,
+            })}
         >
             {tabs.map(({ panelContent, title }) => (
                 <TabPane

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.module.scss
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.module.scss
@@ -230,8 +230,18 @@ $canvas-width: calc(
     column-gap: var(--size-medium);
     display: flex;
     justify-content: space-between;
+    padding-bottom: var(--size-xSmall);
 }
 
 .virtuoso {
     overflow-x: hidden;
+}
+
+.tabContainer {
+    height: 100%;
+    padding: var(--size-medium) 0;
+}
+
+.extraContentContainer {
+    margin-right: var(--size-medium);
 }

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.module.scss.d.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.module.scss.d.ts
@@ -1,6 +1,7 @@
 export const canvasNetworkWrapper: string;
 export const current: string;
 export const detailPanelTitle: string;
+export const extraContentContainer: string;
 export const failedResource: string;
 export const filterContainer: string;
 export const goToButton: string;
@@ -21,6 +22,7 @@ export const optionsWrapper: string;
 export const resourcePageWrapper: string;
 export const rightAlign: string;
 export const showingDetails: string;
+export const tabContainer: string;
 export const timingBar: string;
 export const timingBarEmptySection: string;
 export const timingBarWrapper: string;

--- a/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineErrorAnnotation.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineErrorAnnotation.tsx
@@ -23,6 +23,9 @@ function TimelineErrorAnnotation({ error }: Props): ReactElement {
     const errorId = new URLSearchParams(location.search).get(
         PlayerSearchParameters.errorId
     );
+    const requestId = new URLSearchParams(location.search).get(
+        PlayerSearchParameters.resourceErrorRequestHeader
+    );
     const { pause, replayer } = useReplayerContext();
     const {
         setShowDevTools,
@@ -33,7 +36,7 @@ function TimelineErrorAnnotation({ error }: Props): ReactElement {
     const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
     useEffect(() => {
-        if (errorId) {
+        if (errorId && !requestId) {
             setDetailedPanel({
                 title: null,
                 content: <ErrorModal error={error} />,
@@ -43,7 +46,7 @@ function TimelineErrorAnnotation({ error }: Props): ReactElement {
                 id: error.id,
             });
         }
-    }, [error, errorId, setDetailedPanel]);
+    }, [error, errorId, requestId, setDetailedPanel]);
 
     return (
         <Popover


### PR DESCRIPTION
* add option for no padding in tabs header (limited space in network panel)
* `hasError` prop for `ResourceRow` to set the row's color to red (treated the same way as a 4xx error)
* show ("Network Resource", "Error") tabs in network panel ("Error" tab is hidden when no error)