### PR TITLE
make network call so new download URL is returned, check accept encoding header

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -94,13 +94,15 @@ var ContextKeys = struct {
 	AcceptLanguage contextString
 	UID            contextString
 	// The email for the current user. If the email is a @highlight.run, the email will need to be verified, otherwise `Email` will be an empty string.
-	Email contextString
+	Email          contextString
+	AcceptEncoding contextString
 }{
 	IP:             "ip",
 	UserAgent:      "userAgent",
 	AcceptLanguage: "acceptLanguage",
 	UID:            "uid",
 	Email:          "email",
+	AcceptEncoding: "acceptEncoding",
 }
 
 var Models = []interface{}{

--- a/backend/private-graph/graph/middleware.go
+++ b/backend/private-graph/graph/middleware.go
@@ -63,6 +63,7 @@ func PrivateMiddleware(next http.Handler) http.Handler {
 		}
 		ctx := context.WithValue(r.Context(), model.ContextKeys.UID, uid)
 		ctx = context.WithValue(ctx, model.ContextKeys.Email, email)
+		ctx = context.WithValue(ctx, model.ContextKeys.AcceptEncoding, r.Header.Get("Accept-Encoding"))
 		r = r.WithContext(ctx)
 		next.ServeHTTP(w, r)
 	})

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3328,7 +3328,10 @@ func (r *sessionResolver) UserObject(ctx context.Context, obj *model.Session) (i
 }
 
 func (r *sessionResolver) DirectDownloadURL(ctx context.Context, obj *model.Session) (*string, error) {
-	if !obj.DirectDownloadEnabled {
+	acceptEncodingString := ctx.Value(model.ContextKeys.AcceptEncoding).(string)
+
+	// Direct download only supported for clients that accept Brotli content encoding
+	if !obj.DirectDownloadEnabled || !strings.Contains(acceptEncodingString, "br") {
 		return nil, nil
 	}
 

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -180,6 +180,7 @@ export const usePlayer = (): ReplayerContextInterface => {
             setSessionViewability(SessionViewability.ERROR);
         },
         skip: !session_secure_id,
+        fetchPolicy: 'network-only',
     });
 
     const resetPlayer = useCallback(


### PR DESCRIPTION
* direct download request was failing if session was re-opened after 5 minutes without navigating away as signed URL was cached
* only enable direct download if client accepts Brotli encoding