### PR TITLE
Update highlight-go

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible
 	github.com/go-test/deep v1.0.4
 	github.com/gorilla/sessions v1.2.1 // indirect
-	github.com/highlight-run/highlight-go v0.3.4
+	github.com/highlight-run/highlight-go v0.3.6
 	github.com/highlight-run/workerpool v1.3.0
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -251,6 +251,8 @@ github.com/highlight-run/highlight-go v0.3.2 h1:P1VDmAnaT2XvtarupVlZ/wfd7kvAg2Fj
 github.com/highlight-run/highlight-go v0.3.2/go.mod h1:QMrVFrRIn3VfCsoGszLJRaNayjKGrXXX4CcapYid0AU=
 github.com/highlight-run/highlight-go v0.3.4 h1:pWtXcCeTbqfh0HywL/C6JyWkIdSX3lnq1sohCsV2o6g=
 github.com/highlight-run/highlight-go v0.3.4/go.mod h1:Bpfo9f8hecB/4l3zFszUWnzlpOdmpSSFZ5VhMnpvKaQ=
+github.com/highlight-run/highlight-go v0.3.6 h1:L3DfGpyCBNJIfN7iyNAK1+zVCK/PB1sY5tWDj3rIi0I=
+github.com/highlight-run/highlight-go v0.3.6/go.mod h1:5s0djwmGhlGcM67M8/ZLf2TWd9C5rNkyyRSb4KDQyeo=
 github.com/highlight-run/workerpool v1.2.0 h1:0mLu2hvvgAbgkdjQuBQsmMSVPaIk75Vy3mSK+FavxxY=
 github.com/highlight-run/workerpool v1.2.0/go.mod h1:1iJmXJoC39MnWrqrLa+TaIqdveW4XaxPMoXAMH2wDYU=
 github.com/highlight-run/workerpool v1.3.0 h1:BuOWBJJeGG5ZRpq+IKXDTfASAdJoTkBS0sSH+lvCTgw=


### PR DESCRIPTION
I need to make sure to do this on every release to `highlight-go`, so we're always using the latest version in our app. Perhaps I'll make a github action that creates a high-pri linear ticket on release