### PR TITLE
HIG-1361: Log errors from `highlight-go` because we are highlight and that's the responsible thing to do

### DIFF
--- a/backend/util/logging.go
+++ b/backend/util/logging.go
@@ -17,7 +17,10 @@ func GraphQLErrorPresenter(service string) func(ctx context.Context, e error) *g
 			"error": e,
 			"path":  graphql.GetPath(ctx),
 		}).Errorf("%s graphql request failed", service)
-		_ = highlight.ConsumeError(ctx, e)
+		err := highlight.ConsumeError(ctx, e)
+		if err != nil {
+			log.WithError(err).Error("[highlight-go] error consuming error")
+		}
 		gqlerr := gqlerror.Errorf(e.Error())
 		return gqlerr
 	}


### PR DESCRIPTION
also because stack traces aren't getting updated and I wanna make sure `highlight-go` is not the reason why.