### PR TITLE
Trace all requests to highlight

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -44,7 +44,7 @@ const options: HighlightOptions = {
         enabled: true,
         recordHeadersAndBody: true,
     },
-    tracingOrigins: ['pub.highlight.run', 'localhost'],
+    tracingOrigins: ['highlight.run', 'localhost'],
     integrations: {
         mixpanel: {
             projectToken: 'e70039b6a5b93e7c86b8afb02b6d2300',


### PR DESCRIPTION
Note that the monkey patching fix only allows setting the x-highlight-request header on private graph requests - recording the payload on these requests is something John will do later