### PR TITLE
[HIG-1388] add getBoundingClientRect to resize dependencies

### DIFF
--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -162,11 +162,21 @@ const Player = ({ integrated }: Props) => {
         };
     }, [resizePlayer, replayer]);
 
+    const playerBoundingClientRectWidth = replayer?.wrapper?.getBoundingClientRect()
+        .width;
+    const playerBoundingClientRectHeight = replayer?.wrapper?.getBoundingClientRect()
+        .height;
+
     // On any change to replayer, 'sizes', or 'showConsole', refresh the size of the player.
     useEffect(() => {
         replayer && resizePlayer(replayer);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [sizes, replayer]);
+    }, [
+        sizes,
+        replayer,
+        playerBoundingClientRectWidth,
+        playerBoundingClientRectHeight,
+    ]);
 
     const showLeftPanel =
         showLeftPanelPreference &&


### PR DESCRIPTION
* fixes bug where player wasn't resizing even if the rrweb viewport width/height changed