### PR TITLE
Check if session is nil in `processBackendPayload`

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -937,6 +937,9 @@ func (r *Resolver) processBackendPayload(ctx context.Context, errors []*customMo
 		traceString := string(traceBytes)
 
 		sessionObj := sessionLookup[v.SessionSecureID]
+		if sessionObj == nil {
+			continue
+		}
 		projectID := sessionObj.ProjectID
 
 		errorToInsert := &model.ErrorObject{


### PR DESCRIPTION
there were a couple of panics related to this, I can't figure out why `session` would have been `nil`, but this at least keeps us from losing data that was in the push
https://app.datadoghq.com/logs?cols=host%2Cservice&event&from_ts=1635893885802&index=&live=true&messageDisplay=inline&query=%22highlight-go%22&stream_sort=desc&to_ts=1636066685802