### PR TITLE
Change source of truth for backend error types

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -940,7 +940,7 @@ func (r *Resolver) processBackendPayload(ctx context.Context, errors []*customMo
 			SessionID:   sessionObj.ID,
 			Environment: sessionObj.Environment,
 			Event:       v.Event,
-			Type:        v.Type,
+			Type:        model.ErrorType.BACKEND,
 			URL:         v.URL,
 			Source:      v.Source,
 			OS:          sessionObj.OSName,


### PR DESCRIPTION
rather than using the value sent from the go client, we should use the value in our model package when inserting backend errors into the db.