### PR TITLE
Remove unused `ErrorType` field from `error_objects`

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -670,7 +670,6 @@ type ErrorObject struct {
 	Payload        *string   `json:"payload"`
 	Environment    string
 	RequestID      *string // From X-Highlight-Request header
-	ErrorType      string  `gorm:"default:FRONTEND"`
 }
 
 type ErrorGroup struct {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -949,7 +949,6 @@ func (r *Resolver) processBackendPayload(ctx context.Context, errors []*customMo
 			Timestamp:   v.Timestamp,
 			Payload:     v.Payload,
 			RequestID:   &v.RequestID,
-			ErrorType:   model.ErrorType.BACKEND,
 		}
 
 		//create error fields array
@@ -1144,7 +1143,6 @@ func (r *Resolver) processPayload(ctx context.Context, sessionID int, events cus
 				Timestamp:    v.Timestamp,
 				Payload:      v.Payload,
 				RequestID:    nil,
-				ErrorType:    model.ErrorType.FRONTEND,
 			}
 
 			//create error fields array


### PR DESCRIPTION
This isn't used anywhere. We use `Type` instead (it has the actual error type (ex `window.onerror`) instead of `Frontend`, which is fine).