### PR TITLE
Revert "[HIG-1388] add getBoundingClientRect to resize dependencies (#1683)"

### DIFF
--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -159,21 +159,11 @@ const Player = ({ integrated }: Props) => {
         };
     }, [resizePlayer, replayer]);
 
-    const playerBoundingClientRectWidth = replayer?.wrapper?.getBoundingClientRect()
-        .width;
-    const playerBoundingClientRectHeight = replayer?.wrapper?.getBoundingClientRect()
-        .height;
-
     // On any change to replayer, 'sizes', or 'showConsole', refresh the size of the player.
     useEffect(() => {
         replayer && resizePlayer(replayer);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [
-        sizes,
-        replayer,
-        playerBoundingClientRectWidth,
-        playerBoundingClientRectHeight,
-    ]);
+    }, [sizes, replayer]);
 
     const showLeftPanel =
         showLeftPanelPreference &&


### PR DESCRIPTION
This reverts commit b2bf38a0d4cd57708cf8cb5597824e550808a798.

Error: https://app.highlight.run/1/errors/bHpQYxsJpzAWcfNRGplf4PCsV21l

Call stack points to `resizePlayer()`. This is the latest change related to that code. 

I'm unable to repro the crash so this is a shot in the dark.

@mayberryzane FYI

edit: Figured out how to repro

1. Keep the reverted code
2. Change the browser zoom (zoom in or out a few times)
3. Browser crashes
