### PR TITLE
[HIG-1388] fix resizing infinite loop

### DIFF
--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -129,9 +129,12 @@ const Player = ({ integrated }: Props) => {
         }
         const widthScale = (targetWidth - 80) / width;
         const heightScale = (targetHeight - 80) / height;
-        // Rounding scale to prevent infinite looping when the scale differs at the 10+th decimal
-        const scale =
-            Math.round(Math.min(heightScale, widthScale) * 10000) / 10000;
+        const scale = Math.min(heightScale, widthScale);
+        // If calculated scale is close enough to 1, return to avoid
+        // infinite looping caused by small floating point math differences
+        if (scale >= 0.9999 && scale <= 1.0001) {
+            return true;
+        }
 
         if (scale <= 0) {
             return false;


### PR DESCRIPTION
- scale could be close to 1 but differ past the 7th or so decimal due to floating point math - this would cause an infinite loop as the scale value bounced around close to 1
