### PR TITLE
Remove submodule checkout

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -40,8 +40,6 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
-            - name: Checkout submodules
-              uses: textbook/git-checkout-submodule-action@master
             - name: Format
               uses: Jerome1337/gofmt-action@v1.0.4
               with:


### PR DESCRIPTION
this step is breaking things and is actually useless since our only submodule is `highlight-go` which has it's own checks.