### PR TITLE
Implement worker `sessionsQuery` timeout

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -681,8 +681,7 @@ func (w *Worker) Start() {
 			errs := make(chan error, 1)
 			go func() {
 				defer util.Recover()
-				if err := tx.
-					Raw(`
+				if err := tx.Raw(`
 						WITH t AS (
 							UPDATE sessions
 							SET lock=NOW()


### PR DESCRIPTION
I used a simple goroutine here because each worker will only have one of these at a time, so it doesn't make sense to use a `workerpool` which handles synchronization of multiple goroutines across resolvers.

basically how this works is:
* we start a transaction
* create a context with a 500ms timeout
* in the transaction, run the query in a goroutine
* if the query fails, send the error to an `chan error`
* if the query succeeds, send nil to the same channel
* we wait for a result from the query or the context timeout (whichever comes first)
* returning an error in a transaction reverts any changes made in that transaction (so the `lock` column won't stay updated if some rows got updated before the timeout was hit)

the point of this is to avoid outlier query runs from locking rows for too long. the p99 for this query for the past month is ~112ms vs a max of 4 minutes. 500ms should be sufficient to allow this query to run in a majority of scenarios. The worker dashboard now has a latency distribution chart for this query: https://app.datadoghq.com/dashboard/ziy-zwg-zph/worker-dashboard?from_ts=1634487700776&to_ts=1637079700776&live=true