### PR TITLE
HIG-1525: enable session link from error page if unauthenticated and on demo project

### DIFF
--- a/frontend/src/pages/Error/components/ErrorRightPanel/components/ErrorSessionList/ErrorSessionList.tsx
+++ b/frontend/src/pages/Error/components/ErrorRightPanel/components/ErrorSessionList/ErrorSessionList.tsx
@@ -1,4 +1,9 @@
 import { useAuthContext } from '@authentication/AuthContext';
+import {
+    DEMO_WORKSPACE_APPLICATION_ID,
+    DEMO_WORKSPACE_PROXY_APPLICATION_ID,
+} from '@components/DemoWorkspaceButton/DemoWorkspaceButton';
+import { useParams } from '@util/react-router/useParams';
 import React, { useRef } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 
@@ -14,6 +19,11 @@ interface Props {
 const ErrorSessionList = ({ errorGroup }: Props) => {
     const virtuoso = useRef<VirtuosoHandle>(null);
     const { isLoggedIn } = useAuthContext();
+    const { project_id } = useParams<{ project_id: string }>();
+    const projectIdRemapped =
+        project_id === DEMO_WORKSPACE_APPLICATION_ID
+            ? DEMO_WORKSPACE_PROXY_APPLICATION_ID
+            : project_id;
 
     if (!errorGroup?.error_group?.metadata_log) {
         return null;
@@ -43,7 +53,11 @@ const ErrorSessionList = ({ errorGroup }: Props) => {
                     errorVersion
                     showDetailedViewOverride
                     urlParams={`?${PlayerSearchParameters.errorId}=${session?.error_id}`}
-                    linkDisabled={!isLoggedIn}
+                    linkDisabled={
+                        !isLoggedIn &&
+                        projectIdRemapped !==
+                            DEMO_WORKSPACE_PROXY_APPLICATION_ID
+                    }
                     configuration={{
                         datetimeFormat: 'Relative',
                         countFormat: 'Short',


### PR DESCRIPTION
Session cards on errors page are unclickable if you're unauthenticated. makes them clickable on demo project 