### PR TITLE
[HIG-1582] show sessions search toolbar even if 0 sessions are returned

### DIFF
--- a/frontend/src/pages/Sessions/SessionsFeedV2/SessionsFeed.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/SessionsFeed.tsx
@@ -185,70 +185,68 @@ export const SessionFeed = React.memo(() => {
                     {sessionResults.totalCount === -1 ? (
                         <Skeleton width="100px" />
                     ) : (
-                        sessionResults.totalCount > 0 && (
-                            <div className={styles.resultCountValueContainer}>
-                                <span className={styles.countContainer}>
-                                    <Tooltip
-                                        title={`${sessionResults.totalCount.toLocaleString()} sessions`}
-                                    >
-                                        <TextTransition
-                                            inline
-                                            text={`${formatCount(
-                                                sessionResults.totalCount,
+                        <div className={styles.resultCountValueContainer}>
+                            <span className={styles.countContainer}>
+                                <Tooltip
+                                    title={`${sessionResults.totalCount.toLocaleString()} sessions`}
+                                >
+                                    <TextTransition
+                                        inline
+                                        text={`${formatCount(
+                                            sessionResults.totalCount,
+                                            sessionFeedConfiguration.countFormat
+                                        )}`}
+                                    />{' '}
+                                    {`sessions `}
+                                </Tooltip>
+                                {unprocessedSessionsCount?.unprocessedSessionsCount >
+                                    0 &&
+                                    !searchParams.show_live_sessions && (
+                                        <button
+                                            className={
+                                                styles.liveSessionsCountButton
+                                            }
+                                            onClick={() => {
+                                                message.success(
+                                                    'Showing live sessions'
+                                                );
+                                                setSearchParams({
+                                                    ...searchParams,
+                                                    show_live_sessions: !searchParams.show_live_sessions,
+                                                });
+                                            }}
+                                        >
+                                            (
+                                            {formatCount(
+                                                unprocessedSessionsCount?.unprocessedSessionsCount,
                                                 sessionFeedConfiguration.countFormat
-                                            )}`}
-                                        />{' '}
-                                        {`sessions `}
-                                    </Tooltip>
-                                    {unprocessedSessionsCount?.unprocessedSessionsCount >
-                                        0 &&
-                                        !searchParams.show_live_sessions && (
-                                            <button
-                                                className={
-                                                    styles.liveSessionsCountButton
-                                                }
-                                                onClick={() => {
-                                                    message.success(
-                                                        'Showing live sessions'
-                                                    );
-                                                    setSearchParams({
-                                                        ...searchParams,
-                                                        show_live_sessions: !searchParams.show_live_sessions,
-                                                    });
-                                                }}
-                                            >
-                                                (
-                                                {formatCount(
-                                                    unprocessedSessionsCount?.unprocessedSessionsCount,
-                                                    sessionFeedConfiguration.countFormat
-                                                )}{' '}
-                                                live)
-                                            </button>
-                                        )}
-                                </span>
-                                <div className={styles.sessionFeedActions}>
-                                    <Switch
-                                        label="Autoplay"
-                                        checked={autoPlaySessions}
-                                        onChange={(checked) => {
-                                            setAutoPlaySessions(checked);
-                                        }}
-                                        trackingId="SessionFeedAutoplay"
-                                    />
-                                    <Switch
-                                        label="Details"
-                                        checked={showDetailedSessionView}
-                                        onChange={(checked) => {
-                                            setShowDetailedSessionView(checked);
-                                        }}
-                                        trackingId="SessionFeedShowDetails"
-                                    />
-                                    <SessionFeedConfiguration
-                                        configuration={sessionFeedConfiguration}
-                                    />
-                                </div>
+                                            )}{' '}
+                                            live)
+                                        </button>
+                                    )}
+                            </span>
+                            <div className={styles.sessionFeedActions}>
+                                <Switch
+                                    label="Autoplay"
+                                    checked={autoPlaySessions}
+                                    onChange={(checked) => {
+                                        setAutoPlaySessions(checked);
+                                    }}
+                                    trackingId="SessionFeedAutoplay"
+                                />
+                                <Switch
+                                    label="Details"
+                                    checked={showDetailedSessionView}
+                                    onChange={(checked) => {
+                                        setShowDetailedSessionView(checked);
+                                    }}
+                                    trackingId="SessionFeedShowDetails"
+                                />
+                                <SessionFeedConfiguration
+                                    configuration={sessionFeedConfiguration}
+                                />
                             </div>
-                        )
+                        </div>
                     )}
                 </div>
             </div>


### PR DESCRIPTION
Even if no results are returned for a session search, show the toolbar w/ live sessions count so a user can choose to include live sessions.

<img width="445" alt="Screen Shot 2021-11-30 at 4 46 50 PM" src="https://user-images.githubusercontent.com/86132398/144133438-4517fb90-2303-47bb-ad95-7c713d5536a4.png">
<img width="450" alt="Screen Shot 2021-11-30 at 4 47 08 PM" src="https://user-images.githubusercontent.com/86132398/144133437-a6f92d8d-1952-4293-9019-bd8aa522b80d.png">

