### PR TITLE
HIG-1589: HIG-1565: Fix live mode and autoplay interaction

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -630,7 +630,11 @@ export const usePlayer = (): ReplayerContextInterface => {
                         replayer.getCurrentTime() >=
                         replayer.getMetaData().totalTime
                     ) {
-                        setState(ReplayerState.SessionEnded);
+                        setState(
+                            isLiveMode
+                                ? ReplayerState.Paused // Waiting for more data
+                                : ReplayerState.SessionEnded
+                        );
                     }
                 }
                 setTimerId(requestAnimationFrame(frameAction));
@@ -638,6 +642,7 @@ export const usePlayer = (): ReplayerContextInterface => {
 
             setTimerId(requestAnimationFrame(frameAction));
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [state, replayer]);
 
     useEffect(() => {


### PR DESCRIPTION
When we run out of data to play in live mode (for example, if there is a delay in receiving data, or if the user was simply idle), we have to stop the player at that timestamp, otherwise it will get confused about what to render when the data eventually does come in. This is actually the same logic as what happens when we reach the end of a non-live session - the player will stop when the time runs to the end of the available data.

However, when autoplay is on and we reach state 'SessionEnded', we will play the next session. We don't want this for live mode, so we can use the state 'Paused' instead, which is actually more semantically correct.