### PR TITLE
remove order by for performance

### DIFF
--- a/backend/worker/opensearch.go
+++ b/backend/worker/opensearch.go
@@ -34,7 +34,6 @@ func (w *Worker) IndexSessions() {
 	}
 
 	if err := w.Resolver.DB.Preload("Fields").Model(modelProto).
-		Order("created_at asc").
 		FindInBatches(results, BATCH_SIZE, inner).Error; err != nil {
 		log.Fatalf("OPENSEARCH_ERROR error querying objects: %+v", err)
 	}


### PR DESCRIPTION
- `FindInBatches` will already order by `id` (which should be nearly equivalent by ordering by `created_at` plus it's indexed)