### PR TITLE
[HIG-1648] start HTTP server for worker for health checks

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -336,7 +336,10 @@ func main() {
 		if handlerFlag != nil && *handlerFlag != "" {
 			w.GetHandler(*handlerFlag)()
 		} else {
-			w.Start()
+			go func() {
+				w.Start()
+			}()
+			log.Fatal(http.ListenAndServe(":"+port, r))
 		}
 	} else if runtimeParsed == util.All {
 		w := &worker.Worker{Resolver: privateResolver, S3Client: storage}


### PR DESCRIPTION
- worker should respond on the `/health` endpoint
- once this is deployed, will add a load balancer to the worker-service in ECS
  - ALB health checks will prevent old worker tasks from being stopped before new tasks are healthy
- can also make the load balancer publicly accessible and set up hyperping