### PR TITLE
[HIG-1590] use setTimeout instead of requestAnimationFrame on first call for addEventsWorker

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -606,7 +606,7 @@ export const usePlayer = (): ReplayerContextInterface => {
                 }
             };
 
-            timerId = requestAnimationFrame(addEventsWorker);
+            setTimeout(addEventsWorker, 0);
 
             return () => {
                 cancelAnimationFrame(timerId);


### PR DESCRIPTION
- not sure if this is the most appropriate way to fix this, but I think the issue is coming from: https://github.com/rrweb-io/rrweb/blob/78526a3aae6ba35016ad2836477ba3186eacf250/packages/rrweb/src/replay/index.ts#L254
  - when the first full snapshot is loaded (with viewport info), it's done in a `setInterval` call
  - this can happen after we call `addEventsWorker`, which will cause the player to resize to the initial size, after we've already called `setPlayerTimestamp`
- calling `addEventsWorker` in `setInterval` instead of `requestAnimationFrame` causes it to be delayed after rrweb has initialized the snapshot