### PR TITLE
remove sourcegraph url to use hosted sourcegraph

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-	"sourcegraph.url": "https://source.highlight.run",
 	"sourcegraph.defaultBranch": "master",
 	"editor.formatOnSave": true,
 	"editor.defaultFormatter": "dbaeumer.vscode-eslint",


### PR DESCRIPTION
- removing `sourcegraph.url` vscode extension setting so it will redirect to hosted sourcegraph instead
- (our sourcegraph EC2 instance will be decomissioned once we all have accounts on hosted sourcegraph)