### PR TITLE
ignore SyntaxError for messages/resources response

### DIFF
--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -88,9 +88,12 @@ export const useResources = (
                         ).sort((a, b) => a.startTime - b.startTime)
                     );
                 })
-                .catch((e) => {
+                .catch((_e) => {
                     setResources([]);
-                    H.consumeError(e, 'Error direct downloading resources');
+                    const e = _e as Error;
+                    if (e.name !== 'SyntaxError') {
+                        H.consumeError(e, 'Error direct downloading resources');
+                    }
                 })
                 .finally(() => setResourcesLoading(false));
         }

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ConsolePage/ConsolePage.tsx
@@ -100,9 +100,12 @@ export const ConsolePage = React.memo(({ time }: { time: number }) => {
                         ) ?? []
                     );
                 })
-                .catch((e) => {
+                .catch((_e) => {
                     setParsedMessages([]);
-                    H.consumeError(e, 'Error direct downloading resources');
+                    const e = _e as Error;
+                    if (e.name !== 'SyntaxError') {
+                        H.consumeError(e, 'Error direct downloading resources');
+                    }
                 })
                 .finally(() => setLoading(false));
         }


### PR DESCRIPTION
- if console messages/resources are empty, the direct download url returns an empty response (causes a SyntaxError when parsing json)
  - no user impact but adds noise
- want to confirm no more "direct downloading" errors after this fix before removing the `isHighlightAdmin` gate from resources/errors