### PR TITLE
save empty JSON array when no content

### DIFF
--- a/backend/payload/payload.go
+++ b/backend/payload/payload.go
@@ -174,6 +174,10 @@ func (w *CompressedJSONArrayWriter) Close() error {
 		if _, err := w.writer.Write([]byte("]")); err != nil {
 			return errors.Wrap(err, "error writing message end")
 		}
+	} else {
+		if _, err := w.writer.Write([]byte("[]")); err != nil {
+			return errors.Wrap(err, "error writing empty message")
+		}
 	}
 	if err := w.writer.Close(); err != nil {
 		return errors.Wrap(err, "error closing writer")


### PR DESCRIPTION
- no user impact, but not doing this causes extra noise for front end errors while parsing JSON (parsing an empty response fails)