### PR TITLE
Tidy up SVG

### DIFF
--- a/frontend/src/pages/Player/SessionLevelBar/SessionToken/SessionToken.module.scss
+++ b/frontend/src/pages/Player/SessionLevelBar/SessionToken/SessionToken.module.scss
@@ -20,7 +20,7 @@
     }
 
     svg {
-        fill: var(--color-gray-500);
+        color: var(--color-gray-500);
         flex-shrink: 0;
         height: 16px;
         width: 16px;

--- a/frontend/src/static/ActivityIcon.tsx
+++ b/frontend/src/static/ActivityIcon.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-function SvgDimensionsIcon(props: React.SVGProps<SVGSVGElement>) {
+function SvgActivityIcon(props: React.SVGProps<SVGSVGElement>) {
     return (
         <svg
             width="1em"
@@ -11,9 +11,9 @@ function SvgDimensionsIcon(props: React.SVGProps<SVGSVGElement>) {
             {...props}
         >
             <path
-                d="M4.75 11.75H8.25L10.25 4.75L13.75 19.25L15.75 11.75H19.25"
+                d="M4.75 11.75h3.5l2-7 3.5 14.5 2-7.5h3.5"
                 stroke="currentColor"
-                strokeWidth="1.5"
+                strokeWidth={1.5}
                 strokeLinecap="round"
                 strokeLinejoin="round"
             />
@@ -21,4 +21,4 @@ function SvgDimensionsIcon(props: React.SVGProps<SVGSVGElement>) {
     );
 }
 
-export default SvgDimensionsIcon;
+export default SvgActivityIcon;

--- a/frontend/src/static/index.tsx
+++ b/frontend/src/static/index.tsx
@@ -1,3 +1,4 @@
+export { default as ActivityIcon } from './ActivityIcon';
 export { default as AnnotationDotsIcon } from './AnnotationDotsIcon';
 export { default as AnnotationWarningIcon } from './AnnotationWarningIcon';
 export { default as AnnouncementIcon } from './AnnouncementIcon';


### PR DESCRIPTION
The activity icon had some grey fill, which looked slightly wrong. Also, use the svg script instead of manually copy pasting the component.

Before:
![image](https://user-images.githubusercontent.com/696206/146274925-4cac9ace-0be2-40ad-ba78-679a712d663e.png)

Now:
<img width="738" alt="Screen Shot 2021-12-15 at 5 27 18 PM" src="https://user-images.githubusercontent.com/696206/146274857-7db2d47c-9c39-4bcb-a371-0ae9f2625bb2.png">