### PR TITLE
Add minimum height for a Bar in a `BarChart`

### DIFF
--- a/frontend/src/components/BarChart/BarChart.tsx
+++ b/frontend/src/components/BarChart/BarChart.tsx
@@ -37,24 +37,29 @@ const BarChart = ({
             style={{ height: height, width: width }}
             className={styles.barChartWrapper}
         >
-            {data.map((num, ind) => (
-                <Tooltip
-                    title={`${
-                        data.length - 1 - ind
-                    } ${xAxis}(s) ago\n ${num} ${yAxis}(s)`}
-                    key={ind}
-                >
-                    <div className={styles.barDiv}>
-                        <div
-                            className={styles.bar}
-                            style={{
-                                height: `${(height - 4) * (num / maxNum)}px`,
-                            }}
-                        />
-                        {showBase && <div className={styles.barBase}></div>}
-                    </div>
-                </Tooltip>
-            ))}
+            {data.map((num, ind) => {
+                const tmpBarHeight = (height - 4) * (num / maxNum);
+                const barHeight =
+                    tmpBarHeight === 0 ? 0 : Math.max(tmpBarHeight, 3);
+                return (
+                    <Tooltip
+                        title={`${
+                            data.length - 1 - ind
+                        } ${xAxis}(s) ago\n ${num} ${yAxis}(s)`}
+                        key={ind}
+                    >
+                        <div className={styles.barDiv}>
+                            <div
+                                className={styles.bar}
+                                style={{
+                                    height: `${barHeight}px`,
+                                }}
+                            />
+                            {showBase && <div className={styles.barBase}></div>}
+                        </div>
+                    </Tooltip>
+                );
+            })}
         </div>
     );
 };


### PR DESCRIPTION
in prod (ugly):
![image](https://user-images.githubusercontent.com/37822869/146619586-dc8a857f-3db6-4f4a-90ee-0e749f519100.png)

before (if bar is too small, it loses border radius and looks gross):
![image](https://user-images.githubusercontent.com/37822869/146619422-49ccac2c-7559-4dcd-9245-71198feda8de.png)

after (minimum bar height is 3px):
![image](https://user-images.githubusercontent.com/37822869/146619404-11ebe570-4bae-4b06-b243-5f34ae922051.png)
