### PR TITLE
[HIG-1700] overflow for projects dropdown, add current project

### DIFF
--- a/frontend/src/components/Header/components/ApplicationPicker/ApplicationPicker.tsx
+++ b/frontend/src/components/Header/components/ApplicationPicker/ApplicationPicker.tsx
@@ -44,35 +44,33 @@ const ApplicationPicker = () => {
 
     const projectOptions = [
         ...(allProjects
-            ? allProjects
-                  .filter((project) => project?.id !== project_id)
-                  .map((project) => ({
-                      value: project?.id || '',
-                      displayValue: (
-                          <div>
-                              <span className={styles.existingProjectOption}>
-                                  <MiniWorkspaceIcon
-                                      className={styles.workspaceIcon}
-                                      projectName={
-                                          !isLoggedIn &&
-                                          projectIdRemapped ===
-                                              DEMO_WORKSPACE_PROXY_APPLICATION_ID
-                                              ? DEMO_PROJECT_NAME
-                                              : project?.name || ''
-                                      }
-                                  />
-                                  <span>
-                                      {!isLoggedIn &&
+            ? allProjects.map((project) => ({
+                  value: project?.id || '',
+                  displayValue: (
+                      <div>
+                          <span className={styles.existingProjectOption}>
+                              <MiniWorkspaceIcon
+                                  className={styles.workspaceIcon}
+                                  projectName={
+                                      !isLoggedIn &&
                                       projectIdRemapped ===
                                           DEMO_WORKSPACE_PROXY_APPLICATION_ID
                                           ? DEMO_PROJECT_NAME
-                                          : project?.name || ''}
-                                  </span>
+                                          : project?.name || ''
+                                  }
+                              />
+                              <span>
+                                  {!isLoggedIn &&
+                                  projectIdRemapped ===
+                                      DEMO_WORKSPACE_PROXY_APPLICATION_ID
+                                      ? DEMO_PROJECT_NAME
+                                      : project?.name || ''}
                               </span>
-                          </div>
-                      ),
-                      id: project?.id || '',
-                  }))
+                          </span>
+                      </div>
+                  ),
+                  id: project?.id || '',
+              }))
             : []),
     ];
 
@@ -160,6 +158,7 @@ const ApplicationPicker = () => {
                                     history.push(`/${project.id}/${path}`);
                                 },
                                 icon: null,
+                                active: project?.id === project_id,
                             }))}
                             buttonTrackingId="ApplicationPickerSettings"
                             buttonContentsOverride={

--- a/frontend/src/components/PopoverMenu/PopoverMenu.module.scss
+++ b/frontend/src/components/PopoverMenu/PopoverMenu.module.scss
@@ -18,6 +18,15 @@
         column-gap: var(--size-xSmall);
         display: flex !important;
         width: 100%;
+
+        > div {
+            overflow: hidden;
+        }
+
+        span {
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
     }
 
     .endingIcon {


### PR DESCRIPTION
- use ellipsis when project name overflows the "switch projects" dropdown
- the current project should be in the list and active
<img width="243" alt="Screen Shot 2021-12-20 at 11 10 28 AM" src="https://user-images.githubusercontent.com/86132398/146798023-09bae516-c050-488c-b94a-6ee0f73e6774.png">

