### PR TITLE
[HIG-1719] don't send request if session_id = 0

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -996,7 +996,7 @@ export class Highlight {
 
     _shouldSendRequest(): boolean {
         return (
-            this._recordingStartTime !== 0 ||
+            this._recordingStartTime !== 0 &&
             (this.numberOfFailedRequests < MAX_PUBLIC_GRAPH_RETRY_ATTEMPTS &&
                 this.sessionData.sessionID !== 0)
         );


### PR DESCRIPTION
- this should be an `&&`, errors were happening on our backend from public-graph requests with `session_id = 0`