### PR TITLE
HIG-1737: Add retries of failed network requests in client with exponential backoff

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -305,10 +305,7 @@ export class Highlight {
                 throw error;
             }
         };
-        this.graphqlSDK = getSdk(
-            client,
-            async (requestFn) => await graphQLRequestWrapper(requestFn)
-        );
+        this.graphqlSDK = getSdk(client, graphQLRequestWrapper);
         this.environment = options.environment || 'production';
         this.appVersion = options.appVersion;
 


### PR DESCRIPTION
So the `graphql-request` library doesn't have an option to configure retry logic, but I was able to do so by using a wrapper for requests.