### PR TITLE
[HIG-1797] check against current session id before downloading messages

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ConsolePage/ConsolePage.tsx
@@ -71,7 +71,10 @@ export const ConsolePage = React.memo(({ time }: { time: number }) => {
     // If sessionSecureId is set and equals the current session's (ensures effect is run once)
     // and resources url is defined, fetch using resources url
     useEffect(() => {
-        if (!!session?.messages_url) {
+        if (
+            session_secure_id === session?.secure_id &&
+            !!session?.messages_url
+        ) {
             setLoading(true);
             refetchSession({
                 secure_id: session_secure_id,
@@ -103,7 +106,12 @@ export const ConsolePage = React.memo(({ time }: { time: number }) => {
                 })
                 .finally(() => setLoading(false));
         }
-    }, [session?.messages_url, refetchSession, session_secure_id]);
+    }, [
+        session?.messages_url,
+        session?.secure_id,
+        refetchSession,
+        session_secure_id,
+    ]);
 
     const virtuoso = useRef<VirtuosoHandle>(null);
 


### PR DESCRIPTION
- issue occurs when switching between a completed and a live session - the completed session has a defined `messages_url`, but `session_secure_id` is now the live session's id, and no `messages_url` exists for it
- similar code exists for resources: https://sourcegraph.com/github.com/highlight-run/highlight/-/blob/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx?utm_source=VSCode-1.4.0#L63:16