### PR TITLE
[HIG-1824] quicksearch errors backend

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3324,7 +3324,7 @@ func (r *queryResolver) QuickFieldsOpensearch(ctx context.Context, projectID int
 		MaxResults: ptr.Int(count),
 	}
 
-	_, err = r.OpenSearch.Search([]opensearch.Index{opensearch.IndexFields}, projectID, q, options, &results)
+	_, err = r.OpenSearch.Search([]opensearch.Index{opensearch.IndexFields, opensearch.IndexErrorFields}, projectID, q, options, &results)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- `QuickFieldsOpensearch` needs to search the `IndexErrorFields` index as well