### PR TITLE
[HIG-1835] only need to index filename from stack trace

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1651,3 +1651,24 @@ func (obj *Alert) sendSlackAlert(db *gorm.DB, alertID int, input *SendSlackAlert
 	}
 	return nil
 }
+
+// Returns the first filename from a stack trace, or nil if
+// the stack trace cannot be unmarshalled or doesn't have a filename.
+func GetFirstFilename(stackTraceString string) *string {
+	var unmarshalled []*modelInputs.ErrorTrace
+	if err := json.Unmarshal([]byte(stackTraceString), &unmarshalled); err != nil {
+		// Stack trace may not be able to be unmarshalled as the format may differ,
+		// should not be treated as an error
+		return nil
+	}
+
+	// Return the first non empty frame's filename
+	empty := modelInputs.ErrorTrace{}
+	for _, frame := range unmarshalled {
+		if frame != nil && *frame != empty {
+			return frame.FileName
+		}
+	}
+
+	return nil
+}

--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/highlight-run/highlight/backend/model"
 	"github.com/openlyinc/pointy"
 	e "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -382,4 +383,39 @@ func (c *Client) Close() error {
 	}
 
 	return c.BulkIndexer.Close(context.Background())
+}
+
+// Common types for indexing in OpenSearch
+// These can differ slightly from the types they're
+// based on in order to support different query patterns
+// or to omit fields for better performance.
+type OpenSearchSession struct {
+	*model.Session
+	Fields []*OpenSearchField `json:"fields"`
+}
+
+type OpenSearchField struct {
+	*model.Field
+	Key      string
+	KeyValue string
+}
+
+type OpenSearchError struct {
+	*model.ErrorGroup
+	Fields   []*OpenSearchErrorField `json:"fields"`
+	Filename *string                 `json:"filename"`
+}
+
+func (oe *OpenSearchError) ToErrorGroup() *model.ErrorGroup {
+	inner := oe.ErrorGroup
+	if oe.Filename != nil {
+		inner.StackTrace = fmt.Sprintf(`[{"fileName":"%s"}]`, *oe.Filename)
+	}
+	return inner
+}
+
+type OpenSearchErrorField struct {
+	*model.ErrorField
+	Key      string
+	KeyValue string
 }

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -2416,7 +2416,7 @@ func (r *queryResolver) ErrorGroupsOpensearch(ctx context.Context, projectID int
 		return nil, nil
 	}
 
-	results := []model.ErrorGroup{}
+	results := []opensearch.OpenSearchError{}
 	options := opensearch.SearchOptions{
 		MaxResults:    ptr.Int(count),
 		SortField:     ptr.String("updated_at"),
@@ -2430,16 +2430,13 @@ func (r *queryResolver) ErrorGroupsOpensearch(ctx context.Context, projectID int
 		return nil, err
 	}
 
-	for _, eg := range results {
-		// Equivalent to what used to be
-		// `stack_trace = coalesce(mapped_stack_trace, stack_trace)`
-		if eg.MappedStackTrace != nil {
-			eg.StackTrace = *eg.MappedStackTrace
-		}
+	asErrorGroups := []model.ErrorGroup{}
+	for _, result := range results {
+		asErrorGroups = append(asErrorGroups, *result.ToErrorGroup())
 	}
 
 	return &model.ErrorResults{
-		ErrorGroups: results,
+		ErrorGroups: asErrorGroups,
 		TotalCount:  resultCount,
 	}, nil
 }

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -278,15 +278,10 @@ func (r *Resolver) AppendFields(fields []*model.Field, session *model.Session) e
 	}
 
 	log.Infof("about to append %v fields [%v] to session %v \n", len(fieldsToAppend), fieldsToAppend, session.ID)
-	type OpenSearchField struct {
-		*model.Field
-		Key      string
-		KeyValue string
-	}
 
 	openSearchFields := make([]interface{}, len(fieldsToAppend))
 	for i, field := range fieldsToAppend {
-		openSearchFields[i] = OpenSearchField{
+		openSearchFields[i] = opensearch.OpenSearchField{
 			Field:    field,
 			Key:      field.Type + "_" + field.Name,
 			KeyValue: field.Type + "_" + field.Name + "_" + field.Value,
@@ -430,7 +425,15 @@ func (r *Resolver) HandleErrorAndGroup(errorObj *model.ErrorObject, stackTraceSt
 			return nil, e.Wrap(err, "Error creating new error group")
 		}
 
-		if err := r.OpenSearch.IndexSynchronous(opensearch.IndexErrors, newErrorGroup.ID, newErrorGroup); err != nil {
+		opensearchErrorGroup := &model.ErrorGroup{
+			Model:     newErrorGroup.Model,
+			ProjectID: errorObj.ProjectID,
+			Event:     errorObj.Event,
+			Type:      errorObj.Type,
+			State:     modelInputs.ErrorStateOpen.String(),
+			Fields:    []*model.ErrorField{},
+		}
+		if err := r.OpenSearch.IndexSynchronous(opensearch.IndexErrors, newErrorGroup.ID, opensearchErrorGroup); err != nil {
 			return nil, e.Wrap(err, "error indexing error group in opensearch")
 		}
 
@@ -472,11 +475,16 @@ func (r *Resolver) HandleErrorAndGroup(errorObj *model.ErrorObject, stackTraceSt
 		}
 	}
 
+	var filename *string
+	if newMappedStackTraceString != nil {
+		filename = model.GetFirstFilename(*newMappedStackTraceString)
+	} else {
+		filename = model.GetFirstFilename(newFrameString)
+	}
+
 	if err := r.OpenSearch.Update(opensearch.IndexErrors, errorGroup.ID, map[string]interface{}{
-		"StackTrace":       newFrameString,
-		"MappedStackTrace": newMappedStackTraceString,
-		"Environments":     environmentsString,
-		"updated_at":       time.Now(),
+		"filename":   filename,
+		"updated_at": time.Now(),
 	}); err != nil {
 		return nil, e.Wrap(err, "error updating error group in opensearch")
 	}
@@ -503,15 +511,9 @@ func (r *Resolver) AppendErrorFields(fields []*model.ErrorField, errorGroup *mod
 		}
 	}
 
-	type OpenSearchErrorField struct {
-		*model.ErrorField
-		Key      string
-		KeyValue string
-	}
-
 	openSearchFields := make([]interface{}, len(fieldsToAppend))
 	for i, field := range fieldsToAppend {
-		openSearchFields[i] = OpenSearchErrorField{
+		openSearchFields[i] = opensearch.OpenSearchErrorField{
 			ErrorField: field,
 			Key:        field.Name,
 			KeyValue:   field.Name + "_" + field.Value,


### PR DESCRIPTION
- when testing error search for `Fieldguide` before trying to onboard them, it was hanging due to some large stack traces (at least one was 41MB)
- we only show the filename in our error feed, and we don't search on this, so there's no need to index at the moment 
  - this is probably also slowing things down while indexing
- `FileName` could probably be a field in `ErrorGroup`, would be cleaner than this but would need a little refactoring to get there