### PR TITLE
Revert "Allow for source maps larger than 5mb"

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -879,6 +879,10 @@ func (r *Resolver) processStackFrame(projectId, sessionId int, stackTrace model2
 			log.Error(e.Wrapf(err, "error pushing file to s3: %v", stackTraceFilePath))
 		}
 	}
+	if len(minifiedFileBytes) > 5000000 {
+		err := e.Errorf("minified source file over 5mb: %v, size: %v", stackTraceFileURL, len(minifiedFileBytes))
+		return nil, err
+	}
 
 	sourceMapFileName := string(regexp.MustCompile(`//# sourceMappingURL=(.*)`).Find(minifiedFileBytes))
 	if len(sourceMapFileName) < 1 {


### PR DESCRIPTION
Reverts highlight-run/highlight#2065

Fieldguide's stacked traces are inlined, causing `mapped_stack_trace` to be huge (41mb)