### PR TITLE
[HIG-1850] use replaceIn instead of replace

### DIFF
--- a/frontend/src/routers/OrgRouter/OrgRouter.tsx
+++ b/frontend/src/routers/OrgRouter/OrgRouter.tsx
@@ -209,7 +209,7 @@ export const ProjectRouter = () => {
                     {
                         ...searchParamsToReflectInUrl,
                     },
-                    'replace'
+                    'replaceIn'
                 );
             }
         }


### PR DESCRIPTION
- `replace` removes all URL params, I just need the default behavior without adding another back button history frame
- https://www.npmjs.com/package/use-query-params#:~:text=%27replaceIn%27%3A%20Replace%20just%20a%20single%20parameter%2C%20leaving%20the%20rest%20as%20is