### PR TITLE
[HIG-1813] session identifier clickthrough

### DIFF
--- a/frontend/src/components/UserIdentifier/UserIdentifier.tsx
+++ b/frontend/src/components/UserIdentifier/UserIdentifier.tsx
@@ -1,5 +1,5 @@
 import Tooltip from '@components/Tooltip/Tooltip';
-import { getDisplayName } from '@pages/Sessions/SessionsFeedV2/components/MinimalSessionCard/utils/utils';
+import { getDisplayNameAndField } from '@pages/Sessions/SessionsFeedV2/components/MinimalSessionCard/utils/utils';
 import classNames from 'classnames';
 import React from 'react';
 
@@ -18,7 +18,7 @@ const UserIdentifier = ({ session, className }: Props) => {
     const { setSearchParams } = useSearchContext();
 
     const hasIdentifier = !!session?.identifier;
-    const displayValue = getDisplayName(session);
+    const [displayValue, field] = getDisplayNameAndField(session);
 
     return (
         <Tooltip title={displayValue} mouseEnterDelay={0}>
@@ -29,12 +29,12 @@ const UserIdentifier = ({ session, className }: Props) => {
                 onClick={() => {
                     const newSearchParams = { ...EmptySessionsSearchParams };
 
-                    if (hasIdentifier) {
+                    if (hasIdentifier && field !== null) {
                         newSearchParams.user_properties = [
                             {
-                                id: '-1',
-                                name: 'contains',
-                                value: session.identifier,
+                                id: '0',
+                                name: field,
+                                value: displayValue,
                             },
                         ];
                     } else if (session?.fingerprint) {

--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/MinimalSessionCard/utils/utils.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/MinimalSessionCard/utils/utils.ts
@@ -23,7 +23,9 @@ export const getIdentifiedUserProfileImage = (
 };
 
 // Fallback logic for the display name shown for the session card
-export const getDisplayName = (session: Maybe<Session>) => {
+export const getDisplayNameAndField = (
+    session: Maybe<Session>
+): [string, string | null] => {
     let userProperties;
     try {
         if (typeof session?.user_properties === 'string') {
@@ -35,13 +37,20 @@ export const getDisplayName = (session: Maybe<Session>) => {
         }
     }
 
-    return (
-        userProperties?.highlightDisplayName ||
-        userProperties?.email ||
-        (session?.identifier && session.identifier !== 'null'
-            ? session.identifier
-            : null) ||
-        (session?.fingerprint && `#${session?.fingerprint}`) ||
-        'unidentified'
-    );
+    if (userProperties?.highlightDisplayName) {
+        return [userProperties?.highlightDisplayName, 'highlightDisplayName'];
+    } else if (userProperties?.email) {
+        return [userProperties?.email, 'email'];
+    } else if (session?.identifier && session.identifier !== 'null') {
+        return [session.identifier, 'identifier'];
+    } else if (session?.fingerprint) {
+        return [`#${session?.fingerprint}`, 'fingerprint'];
+    } else {
+        return ['unidentified', null];
+    }
+};
+
+// Fallback logic for the display name shown for the session card
+export const getDisplayName = (session: Maybe<Session>): string => {
+    return getDisplayNameAndField(session)[0];
 };


### PR DESCRIPTION
- create a new function `getDisplayNameAndField` to also return the field being used
- use this field when clicking through from a session identifier instead of the generic `contains:` query
- https://www.loom.com/share/7bcd1a2fd66441a8b17b79d4b27002d0