### PR TITLE
[HIG-1659] update live count query based on the current query

### DIFF
--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/utils/utils.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/utils/utils.ts
@@ -1,0 +1,8 @@
+// Return a copy of the current query, replacing any processed sessions filter
+// with a filter that only returns live sessions.
+export const getUnprocessedSessionsQuery = (query: string): string => {
+    return query.replaceAll(
+        '{"term":{"processed":"true"}}',
+        '{"term":{"processed":"false"}}'
+    );
+};


### PR DESCRIPTION
- Instead of getting the total number of live sessions, use the existing query but modify it to include live sessions
  - This only affects the live count for the new query builder search
- https://www.loom.com/share/627237eeb05d4e3e85d33d70ccebcdc6