### PR TITLE
bump up .ant-picker-dropdown z-index so date picker isn't buried

### DIFF
--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -20,6 +20,10 @@
     font-weight: 300;
 }
 
+.ant-picker-dropdown {
+    z-index: 9999999999 !important;
+}
+
 .ant-dropdown {
     z-index: 999999 !important;
 }

--- a/frontend/src/App.scss.d.ts
+++ b/frontend/src/App.scss.d.ts
@@ -1,5 +1,6 @@
 export const antDropdown: string;
 export const antDropdownMenuItem: string;
+export const antPickerDropdown: string;
 export const antPickerInput: string;
 export const antPickerSuffix: string;
 export const antPopoverInnerContent: string;

--- a/frontend/src/authentication/AuthContext.tsx
+++ b/frontend/src/authentication/AuthContext.tsx
@@ -27,10 +27,7 @@ export const queryBuilderEnabled = (
     project_id: string
 ) => {
     // Projects can be enabled on a one-off basis by adding to the list below:
-    return (
-        isHighlightAdmin ||
-        ['1', '162', '120', '493', '158'].includes(project_id)
-    );
+    return ['1', '162', '120', '493', '158'].includes(project_id);
 };
 
 export const [useAuthContext, AuthContextProvider] = createContext<{


### PR DESCRIPTION
- date picker in old search experience was hidden behind its container popover
- remove `isHighlightAdmin` as a query builder condition so I can validate this in pro
<img width="527" alt="Screen Shot 2022-01-20 at 11 54 35 AM" src="https://user-images.githubusercontent.com/86132398/150385256-326d871e-0c02-4355-bb27-5307031ea225.png">
d