### PR TITLE
Fix user inactivity sometimes not showing on live session

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -500,6 +500,7 @@ type ComplexityRoot struct {
 		Identifier                     func(childComplexity int) int
 		IsPublic                       func(childComplexity int) int
 		Language                       func(childComplexity int) int
+		LastUserInteractionTime        func(childComplexity int) int
 		Length                         func(childComplexity int) int
 		MessagesURL                    func(childComplexity int) int
 		OSName                         func(childComplexity int) int
@@ -3873,6 +3874,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Session.Language(childComplexity), true
 
+	case "Session.last_user_interaction_time":
+		if e.complexity.Session.LastUserInteractionTime == nil {
+			break
+		}
+
+		return e.complexity.Session.LastUserInteractionTime(childComplexity), true
+
 	case "Session.length":
 		if e.complexity.Session.Length == nil {
 			break
@@ -4690,6 +4698,7 @@ type Session {
     resources_url: String
     messages_url: String
     deviceMemory: Int
+    last_user_interaction_time: Timestamp!
 }
 
 type RageClickEvent {
@@ -22233,6 +22242,41 @@ func (ec *executionContext) _Session_deviceMemory(ctx context.Context, field gra
 	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Session_last_user_interaction_time(ctx context.Context, field graphql.CollectedField, obj *model1.Session) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Session",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LastUserInteractionTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTimestamp2timeᚐTime(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _SessionAlert_id(ctx context.Context, field graphql.CollectedField, obj *model1.SessionAlert) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -29490,6 +29534,11 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 				res = ec._Session_deviceMemory(ctx, field, obj)
 				return res
 			})
+		case "last_user_interaction_time":
+			out.Values[i] = ec._Session_last_user_interaction_time(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -50,6 +50,7 @@ type Session {
     resources_url: String
     messages_url: String
     deviceMemory: Int
+    last_user_interaction_time: Timestamp!
 }
 
 type RageClickEvent {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -25,7 +25,7 @@ import (
 	"github.com/highlight-run/highlight/backend/hlog"
 	metricMonitors "github.com/highlight-run/highlight/backend/jobs/metric-monitor"
 	"github.com/highlight-run/highlight/backend/model"
-	storage "github.com/highlight-run/highlight/backend/object-storage"
+	"github.com/highlight-run/highlight/backend/object-storage"
 	"github.com/highlight-run/highlight/backend/opensearch"
 	"github.com/highlight-run/highlight/backend/pricing"
 	"github.com/highlight-run/highlight/backend/private-graph/graph/generated"

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -3788,6 +3788,7 @@ export const GetSessionDocument = gql`
             resources_url
             messages_url
             deviceMemory
+            last_user_interaction_time
         }
     }
 `;
@@ -4758,6 +4759,7 @@ export const GetSessionsOpenSearchDocument = gql`
                 first_time
                 user_properties
                 event_counts
+                last_user_interaction_time
             }
             totalCount
         }
@@ -4948,6 +4950,7 @@ export const GetSessionsDocument = gql`
                 first_time
                 user_properties
                 event_counts
+                last_user_interaction_time
             }
             totalCount
         }

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -1412,6 +1412,7 @@ export type GetSessionQuery = { __typename?: 'Query' } & {
             | 'resources_url'
             | 'messages_url'
             | 'deviceMemory'
+            | 'last_user_interaction_time'
         > & {
                 fields?: Types.Maybe<
                     Array<
@@ -1746,6 +1747,7 @@ export type GetSessionsOpenSearchQuery = { __typename?: 'Query' } & {
                     | 'first_time'
                     | 'user_properties'
                     | 'event_counts'
+                    | 'last_user_interaction_time'
                 > & {
                         fields?: Types.Maybe<
                             Array<
@@ -1851,6 +1853,7 @@ export type GetSessionsQuery = { __typename?: 'Query' } & {
                     | 'first_time'
                     | 'user_properties'
                     | 'event_counts'
+                    | 'last_user_interaction_time'
                 > & {
                         fields?: Types.Maybe<
                             Array<

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -67,6 +67,7 @@ export type Session = {
     resources_url?: Maybe<Scalars['String']>;
     messages_url?: Maybe<Scalars['String']>;
     deviceMemory?: Maybe<Scalars['Int']>;
+    last_user_interaction_time: Scalars['Timestamp'];
 };
 
 export type RageClickEvent = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -171,6 +171,7 @@ query GetSession($secure_id: String!) {
         resources_url
         messages_url
         deviceMemory
+        last_user_interaction_time
     }
 }
 
@@ -430,6 +431,7 @@ query GetSessionsOpenSearch($project_id: ID!, $count: Int!, $query: String!) {
             first_time
             user_properties
             event_counts
+            last_user_interaction_time
         }
         totalCount
     }
@@ -516,6 +518,7 @@ query GetSessions(
             first_time
             user_properties
             event_counts
+            last_user_interaction_time
         }
         totalCount
     }

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -176,6 +176,11 @@ export const usePlayer = (): ReplayerContextInterface => {
                         "btw this session is outside of the project's billing quota."
                     );
                 }
+                if (data.session?.last_user_interaction_time) {
+                    lastActiveTimestampRef.current = new Date(
+                        data.session?.last_user_interaction_time
+                    ).getTime();
+                }
                 if (isLoggedIn && session_secure_id !== 'repro') {
                     markSessionAsViewed({
                         variables: {


### PR DESCRIPTION
Also fetch the last active user time when first loading the session, not just when getting incremental pushes through the subscription.