### PR TITLE
[HIG-1864] check field doesn't exist before update

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -520,9 +520,9 @@ func (r *Resolver) AppendErrorFields(fields []*model.ErrorField, errorGroup *mod
 			KeyValue:   field.Name + "_" + field.Value,
 		}
 	}
-	// if err := r.OpenSearch.AppendToField(opensearch.IndexErrors, errorGroup.ID, "fields", openSearchFields); err != nil {
-	// 	return e.Wrap(err, "error appending error fields")
-	// }
+	if err := r.OpenSearch.AppendToField(opensearch.IndexErrors, errorGroup.ID, "fields", openSearchFields); err != nil {
+		return e.Wrap(err, "error appending error fields")
+	}
 
 	// We append to this session in the join table regardless.
 	if err := r.DB.Model(errorGroup).Association("Fields").Append(fieldsToAppend); err != nil {


### PR DESCRIPTION
- add `append_fields` script (expecting that saving the script ahead of time has some performance benefits over an inline script)
  - script checks for existence of each field to append, removing it from the set
  - if no fields left to append, does a "noop" instead of an update - this is where the improvement comes from

prettier version of the script:
```
      def ids = new ArrayList();
      for (int i = 0; i < ctx._source[params.fieldName].length; i += 1) {
        ids.add(ctx._source[params.fieldName].get(i).id);
      }
      for (def id : ids) {
        int len = params.toAppend.length;
        for (int i = len - 1; i >= 0; i--) {
          def cur_item_id = params.toAppend.get(i).id;
          if (id.equals(cur_item_id)) {
            params.toAppend.remove(i);
          }
        }
      }
      if (params.toAppend.length > 0) {
        ctx._source[params.fieldName].addAll(params.toAppend);
      } else {
        ctx.op = "noop";
      }