### PR TITLE
HIG-1872: Detect the end of the session

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -377,6 +377,8 @@ type Session struct {
 	BrowserName    string `json:"browser_name"`
 	BrowserVersion string `json:"browser_version"`
 	Language       string `json:"language"`
+	// Tells us if 'beforeunload' was fired on the client - note this is not necessarily fired on every session end
+	HasUnloaded bool `gorm:"default:false"`
 	// Tells us if the session has been parsed by a worker.
 	Processed *bool `json:"processed"`
 	// The length of a session.

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1274,7 +1274,7 @@ func (r *Resolver) processBackendPayload(ctx context.Context, errors []*customMo
 	}
 }
 
-func (r *Resolver) processPayload(ctx context.Context, sessionID int, events customModels.ReplayEventsInput, messages string, resources string, errors []*customModels.ErrorObjectInput, isBeacon bool) {
+func (r *Resolver) processPayload(ctx context.Context, sessionID int, events customModels.ReplayEventsInput, messages string, resources string, errors []*customModels.ErrorObjectInput, isBeacon bool, hasSessionUnloaded bool) {
 	querySessionSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.pushPayload", tracer.ResourceName("db.querySession"))
 	querySessionSpan.SetTag("sessionID", sessionID)
 	querySessionSpan.SetTag("messagesLength", len(messages))
@@ -1527,7 +1527,7 @@ func (r *Resolver) processPayload(ctx context.Context, sessionID int, events cus
 	if isBeacon {
 		beaconTime = &now
 	}
-	if err := r.DB.Model(&model.Session{Model: model.Model{ID: sessionID}}).Select("PayloadUpdatedAt", "BeaconTime").Updates(&model.Session{PayloadUpdatedAt: &now, BeaconTime: beaconTime}).Error; err != nil {
+	if err := r.DB.Model(&model.Session{Model: model.Model{ID: sessionID}}).Select("PayloadUpdatedAt", "BeaconTime", "HasUnloaded").Updates(&model.Session{PayloadUpdatedAt: &now, BeaconTime: beaconTime, HasUnloaded: hasSessionUnloaded}).Error; err != nil {
 		log.Error(e.Wrap(err, "error updating session payload time and beacon time"))
 		return
 	}

--- a/backend/public-graph/graph/schema.graphqls
+++ b/backend/public-graph/graph/schema.graphqls
@@ -86,6 +86,7 @@ type Mutation {
         resources: String!
         errors: [ErrorObjectInput]!
         is_beacon: Boolean
+        has_session_unloaded: Boolean
     ): ID
     pushBackendPayload(errors: [BackendErrorObjectInput]!): Any
     addSessionFeedback(

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -194,9 +194,9 @@ func (r *mutationResolver) AddSessionProperties(ctx context.Context, sessionID i
 	return &sessionID, nil
 }
 
-func (r *mutationResolver) PushPayload(ctx context.Context, sessionID int, events customModels.ReplayEventsInput, messages string, resources string, errors []*customModels.ErrorObjectInput, isBeacon *bool) (*int, error) {
+func (r *mutationResolver) PushPayload(ctx context.Context, sessionID int, events customModels.ReplayEventsInput, messages string, resources string, errors []*customModels.ErrorObjectInput, isBeacon *bool, hasSessionUnloaded *bool) (*int, error) {
 	r.PushPayloadWorkerPool.SubmitRecover(func() {
-		r.processPayload(ctx, sessionID, events, messages, resources, errors, isBeacon != nil && *isBeacon)
+		r.processPayload(ctx, sessionID, events, messages, resources, errors, isBeacon != nil && *isBeacon, hasSessionUnloaded != nil && *hasSessionUnloaded)
 	})
 	return &sessionID, nil
 }

--- a/client/src/graph/generated/operations.ts
+++ b/client/src/graph/generated/operations.ts
@@ -133,6 +133,7 @@ export type MutationPushPayloadArgs = {
   resources: Scalars['String'];
   errors: Array<Maybe<ErrorObjectInput>>;
   is_beacon?: Maybe<Scalars['Boolean']>;
+  has_session_unloaded?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -178,6 +179,7 @@ export type PushPayloadMutationVariables = Types.Exact<{
   resources: Types.Scalars['String'];
   errors: Array<Types.Maybe<Types.ErrorObjectInput>> | Types.Maybe<Types.ErrorObjectInput>;
   is_beacon?: Types.Maybe<Types.Scalars['Boolean']>;
+  has_session_unloaded?: Types.Maybe<Types.Scalars['Boolean']>;
 }>;
 
 
@@ -289,7 +291,7 @@ export type IgnoreQuery = (
 
 
 export const PushPayloadDocument = gql`
-    mutation PushPayload($session_id: ID!, $events: ReplayEventsInput!, $messages: String!, $resources: String!, $errors: [ErrorObjectInput]!, $is_beacon: Boolean) {
+    mutation PushPayload($session_id: ID!, $events: ReplayEventsInput!, $messages: String!, $resources: String!, $errors: [ErrorObjectInput]!, $is_beacon: Boolean, $has_session_unloaded: Boolean) {
   pushPayload(
     session_id: $session_id
     events: $events
@@ -297,6 +299,7 @@ export const PushPayloadDocument = gql`
     resources: $resources
     errors: $errors
     is_beacon: $is_beacon
+    has_session_unloaded: $has_session_unloaded
   )
 }
     `;

--- a/client/src/graph/generated/schemas.ts
+++ b/client/src/graph/generated/schemas.ts
@@ -127,6 +127,7 @@ export type MutationPushPayloadArgs = {
   resources: Scalars['String'];
   errors: Array<Maybe<ErrorObjectInput>>;
   is_beacon?: Maybe<Scalars['Boolean']>;
+  has_session_unloaded?: Maybe<Scalars['Boolean']>;
 };
 
 

--- a/client/src/graph/operators/mutation.gql
+++ b/client/src/graph/operators/mutation.gql
@@ -5,6 +5,7 @@ mutation PushPayload(
     $resources: String!
     $errors: [ErrorObjectInput]!
     $is_beacon: Boolean
+    $has_session_unloaded: Boolean
 ) {
     pushPayload(
         session_id: $session_id
@@ -13,6 +14,7 @@ mutation PushPayload(
         resources: $resources
         errors: $errors
         is_beacon: $is_beacon
+        has_session_unloaded: $has_session_unloaded
     )
 }
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -218,6 +218,7 @@ export class Highlight {
     _onToggleFeedbackFormVisibility: () => void;
     pushPayloadTimerId: ReturnType<typeof setTimeout> | undefined;
     feedbackWidgetOptions: FeedbackWidgetOptions;
+    hasSessionUnloaded: boolean;
 
     static create(options: HighlightClassOptions): Highlight {
         return new Highlight(options);
@@ -342,6 +343,7 @@ export class Highlight {
         this.events = [];
         this.errors = [];
         this.messages = [];
+        this.hasSessionUnloaded = false;
 
         if (window.Intercom) {
             window.Intercom('onShow', () => {
@@ -850,6 +852,9 @@ export class Highlight {
             }
 
             if (this.isRunningOnHighlight) {
+                window.addEventListener('beforeunload', () => {
+                    this.hasSessionUnloaded = true;
+                });
                 // Send the payload every time the page is no longer visible - this includes when the tab is closed, as well
                 // as when switching tabs or apps on mobile. Non-blocking.
                 document.addEventListener('visibilitychange', () => {
@@ -1129,6 +1134,7 @@ export class Highlight {
             resources: resourcesString,
             errors,
             is_beacon: isBeacon,
+            has_session_unloaded: this.hasSessionUnloaded,
         };
     }
 }


### PR DESCRIPTION
Write a flag in the 'beforeunload' handler, then send it to the server on sendBeacon. That way we don't get the blocking perf hit in beforeunload, but we still get to know when a session definitely ended. Note beforeunload is not always fired - for example, if an app is killed in the background on mobile.