### PR TITLE
Detect if payload was received after session is processed

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -381,6 +381,8 @@ type Session struct {
 	HasUnloaded bool `gorm:"default:false"`
 	// Tells us if the session has been parsed by a worker.
 	Processed *bool `json:"processed"`
+	// The timestamp of the first payload received after the session got processed (if applicable)
+	ResumedAfterProcessedTime *time.Time `json:"resumed_after_processed_time"`
 	// The length of a session.
 	Length         int64    `json:"length"`
 	ActiveLength   int64    `json:"active_length"`


### PR DESCRIPTION
This can possibly help us answer a few questions:
- How many sendBeacons are we missing due to sleep?
- If we failed to detect ended sessions from #2137, were they actually prematurely processed?
- Should we increase the threshold to wait before processing a session, and if so by how much? Alternatively should we allow sessions to be re-processed if they resumed?

@mayberryzane Can you check that the query here is correct? We can query locked sessions right?
@jay-khatri / @JohnPhamous I changed some existing code here - does it make sense to drop payloads for all processing/processed sessions, as opposed to payloads received after 10 minutes? We currently don't re-process sessions right?