### PR TITLE
[HIG-1866] use new user alert format for new sessions alert

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1749,6 +1749,23 @@ func (obj *Alert) sendSlackAlert(db *gorm.DB, alertID int, input *SendSlackAlert
 	case AlertType.NEW_SESSION:
 		previewText = "Highlight: New Session Created"
 		textBlock = slack.NewTextBlockObject(slack.MarkdownType, "*New Session Created:*\n\n", false, false)
+		if identifier != "" {
+			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*User:*\n"+identifier, false, false))
+		} else {
+			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*User:*\n_unidentified_", false, false))
+		}
+		for k, v := range input.UserProperties {
+			if k == "" {
+				continue
+			}
+			if v == "" {
+				v = "_empty_"
+			}
+			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*%s:*\n%s", strings.Title(strings.ToLower(k)), v), false, false))
+		}
+		if input.URL != nil {
+			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Visited URL:*\n%s", *input.URL), false, false))
+		}
 		blockSet = append(blockSet, slack.NewSectionBlock(textBlock, messageBlock, nil))
 		blockSet = append(blockSet, slack.NewDividerBlock())
 		msg.Blocks = &slack.Blocks{BlockSet: blockSet}


### PR DESCRIPTION
- delay new session alerts by 25 seconds so we can add user properties to the alert after `H.identify` is called
  - at our current rate of ~50 new sessions per second across at least 2 public graph tasks, can expect 50 * 25 / 2 = 625 extra goroutines running per ECS task; I'm not a goroutine expert but the documentation seems to suggest this is fine https://go.dev/doc/faq#:~:text=It%20is%20practical%20to%20create%20hundreds%20of%20thousands%20of%20goroutines
- query DB for that session id and
  - add user properties
  - add visited URL (there's no ordering in the way fields are saved, so this may not be the first visited URL, but since this is only a 25 second window I'm hoping this is still useful)

Unidentified format:
<img width="724" alt="Screen Shot 2022-01-26 at 11 01 29 AM" src="https://user-images.githubusercontent.com/86132398/151202673-3fcf9222-5fe5-40c4-9b6a-51aad4580b4d.png">
Identified format:
<img width="652" alt="Screen Shot 2022-01-26 at 10 52 50 AM" src="https://user-images.githubusercontent.com/86132398/151202675-dffc0361-f802-4b3b-ba33-e2182c52192a.png">
 