### PR TITLE
[HIG-1891] add avatar image to new user / new session alerts

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -6,6 +6,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"reflect"
 	"regexp"
@@ -1562,6 +1563,38 @@ type SendSlackAlertInput struct {
 	Timestamp *time.Time
 }
 
+func getUserPropertiesBlock(identifier string, userProperties map[string]string) ([]*slack.TextBlockObject, *slack.Accessory) {
+	messageBlock := []*slack.TextBlockObject{}
+	if identifier != "" {
+		messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*User:*\n"+identifier, false, false))
+	} else {
+		messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*User:*\n_unidentified_", false, false))
+	}
+	var accessory *slack.Accessory
+	for k, v := range userProperties {
+		if k == "" {
+			continue
+		}
+		if v == "" {
+			v = "_empty_"
+		}
+		key := strings.Title(strings.ToLower(k))
+		if key == "Avatar" {
+			_, err := url.ParseRequestURI(v)
+			if err != nil {
+				// If not a valid URL, append to the body like any other property
+				messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*%s:*\n%s", key, v), false, false))
+			} else {
+				// If it is valid, create an accessory from the image
+				accessory = slack.NewAccessory(slack.NewImageBlockElement(v, "avatar"))
+			}
+		} else {
+			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*%s:*\n%s", key, v), false, false))
+		}
+	}
+	return messageBlock, accessory
+}
+
 func (obj *Alert) sendSlackAlert(db *gorm.DB, alertID int, input *SendSlackAlertInput) error {
 	// TODO: combine `error_alerts` and `session_alerts` tables and create composite index on (project_id, type)
 	if obj == nil {
@@ -1684,19 +1717,9 @@ func (obj *Alert) sendSlackAlert(db *gorm.DB, alertID int, input *SendSlackAlert
 		// construct Slack message
 		previewText = "Highlight: New User Alert"
 		textBlock = slack.NewTextBlockObject(slack.MarkdownType, "*Highlight New User Alert:*\n\n", false, false)
-		if identifier != "" {
-			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*User:*\n"+identifier, false, false))
-		}
-		for k, v := range input.UserProperties {
-			if k == "" {
-				continue
-			}
-			if v == "" {
-				v = "_empty_"
-			}
-			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*%s:*\n%s", strings.Title(strings.ToLower(k)), v), false, false))
-		}
-		blockSet = append(blockSet, slack.NewSectionBlock(textBlock, messageBlock, nil))
+		userPropertiesBlock, accessory := getUserPropertiesBlock(identifier, input.UserProperties)
+		messageBlock = append(messageBlock, userPropertiesBlock...)
+		blockSet = append(blockSet, slack.NewSectionBlock(textBlock, messageBlock, accessory))
 		blockSet = append(blockSet, slack.NewDividerBlock())
 		msg.Blocks = &slack.Blocks{BlockSet: blockSet}
 	case AlertType.TRACK_PROPERTIES:
@@ -1749,24 +1772,12 @@ func (obj *Alert) sendSlackAlert(db *gorm.DB, alertID int, input *SendSlackAlert
 	case AlertType.NEW_SESSION:
 		previewText = "Highlight: New Session Created"
 		textBlock = slack.NewTextBlockObject(slack.MarkdownType, "*New Session Created:*\n\n", false, false)
-		if identifier != "" {
-			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*User:*\n"+identifier, false, false))
-		} else {
-			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*User:*\n_unidentified_", false, false))
-		}
-		for k, v := range input.UserProperties {
-			if k == "" {
-				continue
-			}
-			if v == "" {
-				v = "_empty_"
-			}
-			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*%s:*\n%s", strings.Title(strings.ToLower(k)), v), false, false))
-		}
+		userPropertiesBlock, accessory := getUserPropertiesBlock(identifier, input.UserProperties)
+		messageBlock = append(messageBlock, userPropertiesBlock...)
 		if input.URL != nil {
 			messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Visited URL:*\n%s", *input.URL), false, false))
 		}
-		blockSet = append(blockSet, slack.NewSectionBlock(textBlock, messageBlock, nil))
+		blockSet = append(blockSet, slack.NewSectionBlock(textBlock, messageBlock, accessory))
 		blockSet = append(blockSet, slack.NewDividerBlock())
 		msg.Blocks = &slack.Blocks{BlockSet: blockSet}
 	}


### PR DESCRIPTION
- extract shared code into `getUserPropertiesBlock`
  - returns the identifier and all user properties as text blocks
  - if `Avatar` is a defined user property and its value is a valid URL, create an `accessory` for it (to be added to the slack message section)
<img width="697" alt="Screen Shot 2022-01-26 at 5 10 56 PM" src="https://user-images.githubusercontent.com/86132398/151256044-052634f1-34b8-400e-9b2a-ed3bc53f6b7f.png">