### PR TITLE
Fix typescript compile errors in client

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -44,7 +44,10 @@ import {
 } from './ui/feedback-widget/feedback-widget';
 import { getPerformanceMethods } from './utils/performance/performance';
 import { ERRORS_TO_IGNORE, ERROR_PATTERNS_TO_IGNORE } from './constants/errors';
-import { PerformanceListener } from 'listeners/performance-listener/performance-listener';
+import {
+    PerformanceListener,
+    PerformancePayload,
+} from './listeners/performance-listener/performance-listener';
 
 export const HighlightWarning = (context: string, msg: any) => {
     console.warn(`Highlight Warning: (${context}): `, { output: msg });
@@ -853,7 +856,7 @@ export class Highlight {
             }
 
             this.listeners.push(
-                PerformanceListener((payload) => {
+                PerformanceListener((payload: PerformancePayload) => {
                     addCustomEvent('Performance', stringify(payload));
                 }, this._recordingStartTime)
             );


### PR DESCRIPTION
I think the vscode autofix import uses absolute paths, but our compiler expects relative paths. I wonder if there's a way to change how vscode does imports