### PR TITLE
[HIG-1904] separate loop for deleting already-written objects

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -179,7 +179,8 @@ func deleteCompletedSessions(ctx context.Context, db *gorm.DB) {
 				WHERE o.session_id = s.id
 				AND s.object_storage_enabled = True
 				AND s.payload_updated_at < s.lock
-				AND s.created_at < NOW() - (? * INTERVAL '1 MINUTE')`
+				AND s.created_at < NOW() - (? * INTERVAL '1 MINUTE')
+				AND s.created_at > NOW() - INTERVAL '1 WEEK'`
 
 			for _, table := range []string{"events_objects", "resources_objects", "messages_objects"} {
 				deleteSpan, _ := tracer.StartSpanFromContext(ctx, "worker.deleteObjects",


### PR DESCRIPTION
- This is part of the task for reprocessing processed sessions if new data is pushed - I would like to deploy this first to make sure performance is ok and storage growth matches expectations after retaining 4 hours worth of "to delete" objects
- Expecting ~50 GB peak extra data across the 3 objects tables
  - session count 4 hour avg: 544637 / 7 / 24 * 4 = 12968 sessions per 4 hours
  - peak: 2 * avg = 2 * 12968 = 25936 peak sessions per 4 hours
  - s3 storage growth: 1 TB / week = 1836 KB / session
  - 1836 KB / session * 25936 sessions = 47.6 GB
- Stop deleting sessions when writing to s3
- Delete any objects for sessions where:
  - the session was created > 4 hours ago
  - the data has been written to s3
  - `payload_updated_at` < `lock` (the session was processed after the last objects were added)
- there are a few objects present already that match this criteria
  - I think these are mostly from writing additional events up to 10 minutes after processing a session
  - only 7 of these objects in the past week
  - going to set a 1 week lookback period + add an index on created_at to avoid deleting these and to keep the set of records limited
```
SELECT count(*)
 FROM (events|resources|messages)_objects o
 INNER JOIN sessions s
 ON o.session_id = s.id
 AND s.object_storage_enabled = True
 AND s.payload_updated_at < s.lock
 AND s.created_at < NOW() - (240 * INTERVAL '1 MINUTE')
+---------+
| count   |
|---------|
| 26592   |
+---------+
+---------+
| count   |
|---------|
| 79281   |
+---------+
+---------+
| count   |
|---------|
| 9397    |
+---------+