### PR TITLE
Split out a separate class for the listeners needed in firstload

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -215,6 +215,7 @@ export class FirstLoadListeners {
     }
 
     startListening() {
+        if (this.isListening()) return;
         const highlightThis = this;
         if (!this.disableConsoleRecording) {
             this.listeners.push(

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -6060,6 +6060,9 @@ export const GetErrorGroupDocument = gql`
                 lineNumber
                 functionName
                 columnNumber
+                lineContent
+                linesBefore
+                linesAfter
             }
             mapped_stack_trace
             stack_trace


### PR DESCRIPTION
Allows us to cleanly decide whether to call this from firstload or client