### PR TITLE
Use sessionSecureID instead of sessionData for network listener

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -920,7 +920,7 @@ export class Highlight {
                         backendUrl: this._backendUrl,
                         tracingOrigins: this.tracingOrigins,
                         urlBlocklist: this.urlBlocklist,
-                        sessionData: this.sessionData,
+                        sessionSecureID: this.sessionData.sessionSecureID,
                     })
                 );
             }

--- a/client/src/listeners/network-listener/network-listener.ts
+++ b/client/src/listeners/network-listener/network-listener.ts
@@ -1,4 +1,3 @@
-import { SessionData } from '../../index';
 import { FetchListener } from './utils/fetch-listener';
 import { RequestResponsePair } from './utils/models';
 import { sanitizeRequest, sanitizeResponse } from './utils/network-sanitizer';
@@ -15,7 +14,7 @@ interface NetworkListenerArguments {
     backendUrl: string;
     tracingOrigins: boolean | (string | RegExp)[];
     urlBlocklist: string[];
-    sessionData: SessionData;
+    sessionSecureID: string;
 }
 
 export const NetworkListener = ({
@@ -25,7 +24,7 @@ export const NetworkListener = ({
     backendUrl,
     tracingOrigins,
     urlBlocklist,
-    sessionData,
+    sessionSecureID,
 }: NetworkListenerArguments) => {
     const removeXHRListener = XHRListener(
         (requestResponsePair) => {
@@ -39,7 +38,7 @@ export const NetworkListener = ({
         backendUrl,
         tracingOrigins,
         urlBlocklist,
-        sessionData,
+        sessionSecureID,
     );
     const removeFetchListener = FetchListener(
         (requestResponsePair) => {
@@ -53,7 +52,7 @@ export const NetworkListener = ({
         backendUrl,
         tracingOrigins,
         urlBlocklist,
-        sessionData,
+        sessionSecureID,
     );
 
     return () => {

--- a/client/src/listeners/network-listener/utils/fetch-listener.ts
+++ b/client/src/listeners/network-listener/utils/fetch-listener.ts
@@ -1,4 +1,3 @@
-import { SessionData } from '../../../index';
 import { NetworkListenerCallback } from '../network-listener';
 import {
     RequestResponsePair,
@@ -36,7 +35,7 @@ export const FetchListener = (
     backendUrl: string,
     tracingOrigins: boolean | (string | RegExp)[],
     urlBlocklist: string[],
-    sessionData: SessionData
+    sessionSecureID: string
 ) => {
     const originalFetch = window._originalFetch || window.fetch;
 
@@ -54,7 +53,7 @@ export const FetchListener = (
             headers.set(
                 HIGHLIGHT_REQUEST_HEADER,
                 getHighlightRequestHeader(
-                    sessionData.sessionSecureID,
+                    sessionSecureID,
                     requestId
                 )
             );

--- a/client/src/listeners/network-listener/utils/xhr-listener.ts
+++ b/client/src/listeners/network-listener/utils/xhr-listener.ts
@@ -1,4 +1,3 @@
-import { SessionData } from '../../../index';
 import { NetworkListenerCallback } from '../network-listener';
 import { Headers, Request, RequestResponsePair, Response } from './models';
 import {
@@ -25,7 +24,7 @@ export const XHRListener = (
     backendUrl: string,
     tracingOrigins: boolean | (string | RegExp)[],
     urlBlocklist: string[],
-    sessionData: SessionData
+    sessionSecureID: string,
 ) => {
     const XHR = XMLHttpRequest.prototype;
 
@@ -76,7 +75,7 @@ export const XHRListener = (
             this.setRequestHeader(
                 HIGHLIGHT_REQUEST_HEADER,
                 getHighlightRequestHeader(
-                    sessionData.sessionSecureID,
+                    sessionSecureID,
                     requestId
                 )
             );


### PR DESCRIPTION
In order for network listener to be moved to firstload, we can't wait for the backend to give us sessionData