### PR TITLE
Limit client secure ID generation to highlight

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -900,7 +900,7 @@ func InitializeSessionImplementation(r *mutationResolver, ctx context.Context, p
 	}
 
 	// Firstload secureID generation was added in firstload 3.0.1, Feb 2022
-	if sessionSecureID != nil {
+	if sessionSecureID != nil && projectID == 1 {
 		session.SecureID = *sessionSecureID
 	}
 


### PR DESCRIPTION
There are collisions a small percentage of the time - gating this while I investigate.