### PR TITLE
Don't initialize bot sessions

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -558,6 +558,14 @@ export class Highlight {
         }
     }
     async initialize() {
+        if (
+            navigator?.webdriver ||
+            navigator?.userAgent?.includes('Googlebot') ||
+            navigator?.userAgent?.includes('AdsBot')
+        ) {
+            this._firstLoadListeners?.stopListening();
+            return;
+        }
         try {
             if (this.feedbackWidgetOptions.enabled) {
                 const {


### PR DESCRIPTION
Don't return an error, but also don't start recording. Highlight will never shift to ready state, which should mean that nothing will happen. Did it in client so that we can adjust the logic if we need to.