### PR TITLE
skip property if undefined / null

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -497,6 +497,10 @@ export class Highlight {
         const invalidTypes: any[] = [];
         const tooLong: any[] = [];
         for (const [key, value] of Object.entries(properties_object)) {
+            if (value === undefined || value === null) {
+                continue;
+            }
+
             if (!['number', 'string', 'boolean'].includes(typeof value)) {
                 invalidTypes.push({ [key]: value });
             }


### PR DESCRIPTION
fix for citybldr:
to repro, you can call H.identify with `undefined` values
```{
email: "john@highlight.run"
firstName: undefined
id: "6216bff23bc8ab714b682080"
lastName: undefined
name: "undefined undefined"
}```