### PR TITLE
[HIG-1997] try ordering the update to fix deadlocks

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -705,7 +705,7 @@ func (r *Resolver) HandleErrorAndGroup(errorObj *model.ErrorObject, stackTraceSt
 	}
 
 	if err := r.DB.Transaction(func(tx *gorm.DB) error {
-		if err := r.DB.Debug().Model(errorGroup).Association("Fingerprints").Append(fingerprints); err != nil {
+		if err := r.DB.Model(errorGroup).Association("Fingerprints").Append(fingerprints); err != nil {
 			return e.Wrap(err, "error appending new fingerprints")
 		}
 


### PR DESCRIPTION
- GORM association `Replace` method appends and then sets the existing rows' `error_group_ids` to null
- this does the same inside of a transaction, but the update query orders the rows to update