### PR TITLE
Tweak out of order logging

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -393,9 +393,10 @@ type Session struct {
 	// Tells us if 'beforeunload' was fired on the client - note this is not necessarily fired on every session end
 	HasUnloaded bool `gorm:"default:false"`
 	// Tells us if the session has been parsed by a worker.
-	Processed     *bool `json:"processed"`
-	HasRageClicks *bool `json:"has_rage_clicks"`
-	HasErrors     *bool `json:"has_errors"`
+	Processed           *bool `json:"processed"`
+	HasRageClicks       *bool `json:"has_rage_clicks"`
+	HasErrors           *bool `json:"has_errors"`
+	HasOutOfOrderEvents bool  `gorm:"default:false"`
 	// The timestamp of the first payload received after the session got processed (if applicable)
 	ResumedAfterProcessedTime *time.Time `json:"resumed_after_processed_time"`
 	// The length of a session.


### PR DESCRIPTION
- Store if a session has out of order events as a boolean on the session row
- Allow SID to reset back to 1 (for page refreshes/navigations)
- Standardize logs to log secure ID as an attribute