### PR TITLE
[HIG-2089] move expired session delete to EventBridge worker

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -26,3 +26,5 @@ backfill-stack-frames:
 		(go build; doppler run -- ./backend -runtime=worker -worker-handler=backfill-stack-frames)
 refresh-materialized-views:
 		(go build; doppler run -- ./backend -runtime=worker -worker-handler=refresh-materialized-views)
+delete-completed-sessions:
+		(go build; doppler run -- ./backend -runtime=worker -worker-handler=delete-completed-sessions)

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -173,16 +173,12 @@ func (w *Worker) scanSessionPayload(ctx context.Context, manager *payload.Payloa
 	return nil
 }
 
-// Every 5 minutes, delete data for any sessions created > 4 hours ago
+// Delete data for any sessions created > 4 hours ago
 // if all session data has been written to s3
-func deleteCompletedSessions(ctx context.Context, db *gorm.DB) {
-	lookbackPeriod := 4 * 60 // 4 hours
+func (w *Worker) DeleteCompletedSessions() {
+	lookbackPeriod := 4*60 + 10 // 4h10m
 
-	for {
-		func() {
-			defer util.Recover()
-
-			baseQuery := `
+	baseQuery := `
 				DELETE
 				FROM %s o
 				USING sessions s
@@ -192,17 +188,13 @@ func deleteCompletedSessions(ctx context.Context, db *gorm.DB) {
 				AND s.created_at < NOW() - (? * INTERVAL '1 MINUTE')
 				AND s.created_at > NOW() - INTERVAL '1 WEEK'`
 
-			for _, table := range []string{"events_objects", "resources_objects", "messages_objects"} {
-				deleteSpan, _ := tracer.StartSpanFromContext(ctx, "worker.deleteObjects",
-					tracer.ResourceName("worker.deleteObjects"), tracer.Tag("table", table))
-				if err := db.Exec(fmt.Sprintf(baseQuery, table), lookbackPeriod).Error; err != nil {
-					log.Error(e.Wrapf(err, "error deleting expired objects from %s", table))
-				}
-				deleteSpan.Finish()
-			}
-
-			time.Sleep(5 * time.Minute)
-		}()
+	for _, table := range []string{"events_objects", "resources_objects", "messages_objects"} {
+		deleteSpan, _ := tracer.StartSpanFromContext(context.Background(), "worker.deleteObjects",
+			tracer.ResourceName("worker.deleteObjects"), tracer.Tag("table", table))
+		if err := w.Resolver.DB.Exec(fmt.Sprintf(baseQuery, table), lookbackPeriod).Error; err != nil {
+			log.Error(e.Wrapf(err, "error deleting expired objects from %s", table))
+		}
+		deleteSpan.Finish()
 	}
 }
 
@@ -581,7 +573,6 @@ func (w *Worker) Start() {
 		lockPeriod = 1
 	}
 
-	go deleteCompletedSessions(ctx, w.Resolver.DB)
 	go reportProcessSessionCount(w.Resolver.DB, payloadLookbackPeriod, lockPeriod)
 	maxWorkerCount := 40
 	processSessionLimit := 10000
@@ -828,6 +819,8 @@ func (w *Worker) GetHandler(handlerFlag string) func() {
 		return w.BackfillStackFrames
 	case "refresh-materialized-views":
 		return w.RefreshMaterializedViews
+	case "delete-completed-sessions":
+		return w.DeleteCompletedSessions
 	default:
 		log.Fatalf("unrecognized worker-handler [%s]", handlerFlag)
 		return nil


### PR DESCRIPTION
- instead of being a loop, `DeleteCompletedSessions` is for a single run and mapped to a `worker-handler` flag
  - this will be run from an EventBridge schedule, will set to 10 mins for now
- add another 10 minutes to the lookback period so that this is less likely to conflict with a read for sessions hitting the 4 hour limit