### PR TITLE
billing: reduce trial period to 14 days

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -2467,7 +2467,7 @@ func (r *mutationResolver) SubmitRegistrationForm(ctx context.Context, workspace
 	if workspace.EligibleForTrialExtension {
 		if err := r.DB.Model(workspace).Updates(map[string]interface{}{
 			"EligibleForTrialExtension": false,
-			"TrialEndDate":              workspace.TrialEndDate.Add(30 * 24 * time.Hour), // add 30 days to the current end date
+			"TrialEndDate":              workspace.TrialEndDate.Add(7 * 24 * time.Hour), // add 7 days to the current end date
 		}).Error; err != nil {
 			return nil, e.Wrap(err, "error clearing EligibleForTrialExtension flag")
 		}

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -201,7 +201,7 @@ const FreePlanBanner = () => {
                         >
                             Fill this out
                         </Link>{' '}
-                        before your trial ends to extend this by 1 month!
+                        before your trial ends to extend this by another week!
                     </>
                 );
             } else {
@@ -218,7 +218,7 @@ const FreePlanBanner = () => {
                         >
                             Integrate
                         </Link>{' '}
-                        before your trial ends to extend this by 1 month!
+                        before your trial ends to extend this by another week!
                     </>
                 );
             }


### PR DESCRIPTION
Adjust the workspace trial end date
to be 14 days from the workspace
creation date.

Highlight extension continues to add an extra month of trial.

Testing: manual validation of end_date displayed on frontend.

![Screenshot from 2022-03-21 10-31-52](https://user-images.githubusercontent.com/1351531/159330831-108fd9d4-4877-4ff8-9d0e-cca6cc3c0b01.png)
![Screenshot from 2022-03-21 10-32-34](https://user-images.githubusercontent.com/1351531/159330872-99442eee-e99e-4c6a-833a-b72ae7233f66.png)


