### PR TITLE
frontend: make selected session more obvious

### DIFF
--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/MinimalSessionCard/MinimalSessionCard.module.scss
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/MinimalSessionCard/MinimalSessionCard.module.scss
@@ -172,11 +172,13 @@
         position: absolute;
         top: 0;
         transition: opacity 0.1s ease-in;
-        width: 6px;
+        width: 8px;
         z-index: 99;
     }
 
     &.selected {
+        border: 1px solid var(--color-purple);
+        box-shadow: 0 0 9px rgba(86, 41, 198, 0.25);
         &::before {
             opacity: 1;
         }


### PR DESCRIPTION
Makes the selected session persist as focused on the session feed.
Also makes the purple bar on the left of a selected session
30% larger to make it more obvious.

![image](https://user-images.githubusercontent.com/1351531/160705738-aa70c707-26c2-4fe7-a937-c8f48d5fdfd1.png)

hovering still accentuates the hovered session
![image](https://user-images.githubusercontent.com/1351531/160705814-b1bad6ca-4f99-41a6-b4af-62b7c52c7305.png)
