### PR TITLE
[HIG-2118] add length slider tooltip

### DIFF
--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/components/LengthInput.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/components/LengthInput.tsx
@@ -65,7 +65,7 @@ export const LengthInput = ({ start, end, onChange }: LengthInputProps) => {
                     range
                     className={styles.slider}
                     tooltipPlacement={'bottom'}
-                    getTooltipPopupContainer={(_) =>
+                    getTooltipPopupContainer={() =>
                         document.querySelector('.ant-slider-step')!
                     }
                     disabled={false}


### PR DESCRIPTION
tooltip was occluded because it would be rendered
underneath the popup query builder.

https://www.loom.com/share/4a176e7576164d88944fe2d9bb5a3cd8