### PR TITLE
shadowing ID field so automigrate won't try to reapply the pkey index

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -837,6 +837,7 @@ type SessionInterval struct {
 
 type TimelineIndicatorEvent struct {
 	Model
+	ID              int    `json:"id"` // Shadow Model.ID to avoid creating a pkey constraint
 	SessionSecureID string `gorm:"index" json:"secure_id"`
 	Timestamp       float64
 	Type            int


### PR DESCRIPTION
Will be running
```
ALTER TABLE timeline_indicator_events DROP CONSTRAINT timeline_indicator_events_pkey;
ALTER TABLE timeline_indicator_events ALTER COLUMN id SET DEFAULT 0;
```
Tested
Events are created successfully by the worker:
<img width="587" alt="Screen Shot 2022-03-30 at 6 00 07 PM" src="https://user-images.githubusercontent.com/86132398/160955501-b31e996b-fbf3-489c-a266-e845ee6670c3.png">

And read in our frontend:
<img width="708" alt="Screen Shot 2022-03-30 at 6 00 27 PM" src="https://user-images.githubusercontent.com/86132398/160955511-8d348df0-b192-4d83-9bac-3d04e42dda44.png">

