### PR TITLE
[HIG-2126] quick search should support quick paste

### DIFF
--- a/frontend/src/util/string/index.test.ts
+++ b/frontend/src/util/string/index.test.ts
@@ -1,0 +1,17 @@
+import { validateEmail } from './index';
+
+describe('validateEmail', () => {
+    const CASES = [
+        ['', false],
+        ['.@highlight.run', false],
+        ['foo@bar.', false],
+        ['foo', false],
+        ['foo@Æ.run', false],
+        ['¥@highlight.run', true],
+        ['foo@highlight.run', true],
+    ];
+
+    it.each(CASES)('should validate %s as %s', (email, expected) => {
+        expect(validateEmail(email as string)).toBe(expected as Boolean);
+    });
+});

--- a/frontend/src/util/string/index.ts
+++ b/frontend/src/util/string/index.ts
@@ -19,6 +19,13 @@ export const getDisplayNameFromEmail = (email: string) => {
     return titleCaseString(email.split('@')[0]);
 };
 
+export const validateEmail = (email: string) => {
+    // https://stackoverflow.com/a/46181
+    return !!email.match(
+        /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}])|(([a-zA-Z\-\d]+\.)+[a-zA-Z]{2,}))$/
+    );
+};
+
 export const bytesToPrettyString = (
     bytes: number,
     use1024 = false,


### PR DESCRIPTION
When pasting quickly into the quick search box, we may not have time to
query opensearch for the best-match query.
In this case, fall back to a default query based on `identifier`, or email
if the input is an email.

The result is that a quick paste-enter results in a more sensible
query rather than using the default pre-loaded opensearch recommendation
(which ends up being the most-used query).

Testing: new string test

https://www.loom.com/share/d94a74a3da064be2b07c9ea34a56edbb