### PR TITLE
ui: make share button purple

### DIFF
--- a/frontend/src/components/Button/ShareButton/ShareButton.module.scss
+++ b/frontend/src/components/Button/ShareButton/ShareButton.module.scss
@@ -1,7 +1,8 @@
 .button {
-    background-color: var(--color-gray-400) !important;
-    border: var(--color-gray-400);
+    background-color: var(--color-purple) !important;
+    border: var(--color-purple);
     border-radius: var(--size-xSmall) !important;
+    color: var(--color-white) !important;
     column-gap: var(--size-small);
     display: flex;
     font-size: 14px !important;
@@ -10,7 +11,7 @@
     width: 113px;
 
     &:focus &:hover {
-        background-color: var(--color-gray-400) !important;
-        border: var(--color-gray-400) !important;
+        background-color: var(--color-purple) !important;
+        border: var(--color-purple) !important;
     }
 }


### PR DESCRIPTION
make `Share` buttons look nicer than the gray.

![image](https://user-images.githubusercontent.com/1351531/161620563-f7886cbc-c175-4c08-870f-fc63e1578ec0.png)
