### PR TITLE
[HIG-2131] improve positioning of timeline popover

### DIFF
--- a/frontend/src/components/Popover/Popover.tsx
+++ b/frontend/src/components/Popover/Popover.tsx
@@ -11,6 +11,7 @@ import styles from './Popover.module.scss';
 
 type PopoverProps = Pick<
     AntDesignPopoverProps,
+    | 'arrowContent'
     | 'content'
     | 'title'
     | 'trigger'

--- a/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineEventAnnotation.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineEventAnnotation.tsx
@@ -1,11 +1,12 @@
 import { getFullScreenPopoverGetPopupContainer } from '@pages/Player/context/PlayerUIContext';
 import { HighlightEvent } from '@pages/Player/HighlightEvent';
 import { getTimelineEventDisplayName } from '@pages/Player/Toolbar/TimelineAnnotationsSettings/TimelineAnnotationsSettings';
+import { MillisToMinutesAndSeconds } from '@util/time';
 import { message } from 'antd';
+import { TooltipPlacement } from 'antd/lib/tooltip';
 import React, { useState } from 'react';
 
 import Popover from '../../../../components/Popover/Popover';
-import { MillisToMinutesAndSeconds } from '../../../../util/time';
 import { EventsForTimeline } from '../../PlayerHook/utils';
 import { ParsedHighlightEvent } from '../../ReplayerContext';
 import {
@@ -21,6 +22,7 @@ import timelineAnnotationStyles from './TimelineAnnotation.module.scss';
 interface Props {
     event: ParsedHighlightEvent;
     startTime: number | undefined;
+    relativeStartPercent: number;
     selectedTimelineAnnotationTypes: string[];
     pause: (time?: number | undefined) => void;
     activeEvent: HighlightEvent | undefined;
@@ -29,6 +31,7 @@ interface Props {
 const TimelineEventAnnotation = ({
     event,
     startTime,
+    relativeStartPercent,
     selectedTimelineAnnotationTypes,
     pause,
     activeEvent,
@@ -38,8 +41,26 @@ const TimelineEventAnnotation = ({
 
     const Icon = getPlayerEventIcon(details.title || '', details.payload);
 
+    let offset = [-10, -10];
+    let placement: TooltipPlacement = 'topLeft';
+    if (relativeStartPercent > 0.67) {
+        offset = [18, -10];
+        placement = 'topRight';
+    } else if (relativeStartPercent > 0.33) {
+        offset = [0, -10];
+        placement = 'top';
+    }
+
     return (
         <Popover
+            align={{
+                overflow: {
+                    adjustY: false,
+                    adjustX: false,
+                },
+                offset: offset,
+            }}
+            placement={placement}
             getPopupContainer={getFullScreenPopoverGetPopupContainer}
             key={event.identifier}
             popoverClassName={timelineAnnotationStyles.popover}


### PR DESCRIPTION
The timeline popover tends to be misaligned on events close to the edge.
To avoid this, configure the popover to have no overflow adjustment, but
change the placement near the left and right sides of the timeline.

https://www.loom.com/share/f2d544e1e46c4c07804fc4b762645868