### PR TITLE
[HIG-2140] remove space from comment modal

### DIFF
--- a/frontend/src/pages/Error/components/ErrorCreateCommentModal/ErrorCreateCommentModal.tsx
+++ b/frontend/src/pages/Error/components/ErrorCreateCommentModal/ErrorCreateCommentModal.tsx
@@ -33,8 +33,8 @@ export const ErrorCreateCommentModal = ({
             mask={true}
             title={
                 show === CreateModalType.Comment
-                    ? 'Write a Comment'
-                    : 'Create an Issue'
+                    ? 'Add a Comment'
+                    : 'Attach an Issue'
             }
             newCommentModalRef={parentRef ?? pRef}
             commentModalPosition={

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
@@ -1,10 +1,29 @@
+import { useAuthContext } from '@authentication/AuthContext';
+import {
+    AdminSuggestion,
+    parseAdminSuggestions,
+} from '@components/Comment/CommentHeader';
 import Input from '@components/Input/Input';
 import Select from '@components/Select/Select';
 import TextArea from '@components/TextArea/TextArea';
 import {
+    useCreateErrorCommentMutation,
+    useCreateSessionCommentMutation,
+    useGetCommentMentionSuggestionsQuery,
+    useGetCommentTagsForProjectQuery,
+    useGetWorkspaceAdminsByProjectIdQuery,
+} from '@graph/hooks';
+import {
     GetCommentTagsForProjectQuery,
     namedOperations,
 } from '@graph/operations';
+import {
+    Admin,
+    IntegrationType,
+    SanitizedAdminInput,
+    SanitizedSlackChannelInput,
+    Session,
+} from '@graph/schemas';
 import ArrowLeftIcon from '@icons/ArrowLeftIcon';
 import ArrowRightIcon from '@icons/ArrowRightIcon';
 import { useLinearIntegration } from '@pages/IntegrationsPage/components/LinearIntegration/utils';
@@ -24,26 +43,7 @@ import React, { useMemo, useState } from 'react';
 import { OnChangeHandlerFunc } from 'react-mentions';
 import { Link } from 'react-router-dom';
 
-import { useAuthContext } from '../../../../authentication/AuthContext';
 import Button from '../../../../components/Button/Button/Button';
-import {
-    AdminSuggestion,
-    parseAdminSuggestions,
-} from '../../../../components/Comment/CommentHeader';
-import {
-    useCreateErrorCommentMutation,
-    useCreateSessionCommentMutation,
-    useGetCommentMentionSuggestionsQuery,
-    useGetCommentTagsForProjectQuery,
-    useGetWorkspaceAdminsByProjectIdQuery,
-} from '../../../../graph/generated/hooks';
-import {
-    Admin,
-    IntegrationType,
-    SanitizedAdminInput,
-    SanitizedSlackChannelInput,
-    Session,
-} from '../../../../graph/generated/schemas';
 import { Coordinates2D } from '../../PlayerCommentCanvas/PlayerCommentCanvas';
 import usePlayerConfiguration from '../../PlayerHook/utils/usePlayerConfiguration';
 import styles from './NewCommentForm.module.scss';
@@ -459,7 +459,7 @@ export const NewCommentForm = ({
                                 section !== CommentFormSection.CommentForm,
                         })}
                     >
-                        <h3>{modalHeader}</h3>
+                        <h3>{modalHeader ?? 'Add a  Comment'}</h3>
                         <div className={styles.commentInputContainer}>
                             <CommentTextBody
                                 commentText={commentText}
@@ -477,7 +477,7 @@ export const NewCommentForm = ({
                                 aria-label="Comment tags"
                                 allowClear={true}
                                 defaultActiveFirstOption
-                                placeholder={'Create an issue'}
+                                placeholder={'Attach an issue'}
                                 options={issueIntegrationsOptions}
                                 onChange={setSelectedIssueService}
                                 notFoundContent={


### PR DESCRIPTION
Add a header to all comment modals to stay consistent.
Adjust the wording of to be consistent:
`Add a Comment`, `Attach an Issue`
Keeping `Create a Linear Issue` in the dropdown since the context there
is different, where we are choosing to create a new issue rather than
attach an existing one.

![image](https://user-images.githubusercontent.com/1351531/162095557-0e4826c6-5889-4e00-8e09-71d6664ebae2.png)
![image](https://user-images.githubusercontent.com/1351531/162095595-d3fb2571-5405-47d5-9e76-fae1f65fcf52.png)
![image](https://user-images.githubusercontent.com/1351531/162095690-ea841f81-891a-42db-b30c-abb99b508904.png)

