### PR TITLE
[HIG-2163] fix comment reply author styling

### DIFF
--- a/frontend/src/components/Comment/CommentHeader.module.scss
+++ b/frontend/src/components/Comment/CommentHeader.module.scss
@@ -43,7 +43,7 @@
     font-weight: 400;
     line-height: initial;
     margin: 0 !important;
-    max-height: 1em;
+    max-height: 1.5em;
     max-width: 180px;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Ensure long names and long 'replied when' strings
do not wrap and make the comments feed look strange. When a name is too long, use eclipses and limit wrapping.