### PR TITLE
[HIG-2165] correctly count number of live users

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3276,7 +3276,7 @@ func (r *queryResolver) LiveUsersCount(ctx context.Context, projectID int) (*int
 
 	var count int64
 	if err := r.DB.Raw(`
-		SELECT COUNT(DISTINCT(COALESCE(identifier, CAST(fingerprint AS text))))
+		SELECT COUNT(DISTINCT(COALESCE(NULLIF(identifier, ''), CAST(fingerprint AS text))))
 		FROM sessions
 		WHERE project_id = ?
 		AND processed = false


### PR DESCRIPTION
we fall back to using `fingerprint` to count live users.
however, the SQL syntax to do this (`coalesce`) only falls back if the value is NULL, but `identifier` was "".
use `NULLIF` to correctly fall back to the fingerprint.