### PR TITLE
[HIG-2175] fix session comment timestamp overflow

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -918,6 +918,10 @@ func (r *mutationResolver) CreateSessionComment(ctx context.Context, projectID i
 	if sessionImage != nil {
 		sessionImageStr = *sessionImage
 	}
+	if sessionTimestamp >= math.MaxInt32 {
+		log.Warnf("attempted to create session with invalid timestamp %d", sessionTimestamp)
+		sessionTimestamp = 0
+	}
 	sessionComment := &model.SessionComment{
 		Admins:          admins,
 		ProjectID:       projectID,

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -470,7 +470,7 @@ const Player = ({ integrated }: Props) => {
                         newCommentModalRef={newCommentModalRef}
                         commentModalPosition={commentModalPosition}
                         commentPosition={commentPosition}
-                        commentTime={time}
+                        commentTime={time || 0}
                         session={session}
                         session_secure_id={session_secure_id}
                         onCancel={() => {


### PR DESCRIPTION
Player timestamp for session comments may be invalid.
Ensure backend doesn't error in this case and creates a comment with
a timestamp of the beginning of the session.