### PR TITLE
kafka: reduce worker goroutines to limit RAM usage

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -99,7 +99,7 @@ func New(topic string, mode Mode) *Queue {
 			Async: false,
 			// override batch limit to be our message max size
 			BatchBytes:   messageSizeBytes,
-			BatchSize:    10000,
+			BatchSize:    1000,
 			ReadTimeout:  KafkaOperationTimeout,
 			WriteTimeout: 5 * time.Minute,
 			// low timeout because we don't want to block WriteMessage calls since we are sync mode
@@ -124,7 +124,7 @@ func New(topic string, mode Mode) *Queue {
 			GroupID:           "group-default", // all partitions for this group, auto balanced
 			MinBytes:          prefetchSizeBytes,
 			MaxBytes:          messageSizeBytes,
-			QueueCapacity:     10000,
+			QueueCapacity:     1000,
 			// in the future, we would commit only on successful processing of a message.
 			// this means we commit very often to avoid repeating tasks on worker restart.
 			CommitInterval: 100 * time.Millisecond,

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -289,7 +289,7 @@ func (w *Worker) PublicWorker() {
 		w.KafkaQueue = kafka_queue.New(os.Getenv("KAFKA_TOPIC"), kafka_queue.Consumer)
 	}
 
-	wp := workerpool.New(100)
+	wp := workerpool.New(80)
 	wp.SetPanicHandler(util.Recover)
 
 	// receive messages and submit them to worker pool for processing


### PR DESCRIPTION
also reduce queue size to avoid committing messages that won't be processed