### PR TITLE
[HIG-2194] different topics and consumer groups for dev env

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -96,9 +96,9 @@ func New(topic string, mode Mode) *Queue {
 	pool := &Queue{Topic: topic, ConsumerGroup: groupID}
 	if mode == Producer {
 		pool.kafkaP = &kafka.Writer{
-			Logger:                 kafka.LoggerFunc(log.Debugf),
-			ErrorLogger:            kafka.LoggerFunc(log.Warnf),
-			Addr:                   kafka.TCP(brokers...),
+			Logger:      kafka.LoggerFunc(log.Debugf),
+			ErrorLogger: kafka.LoggerFunc(log.Warnf),
+			Addr:        kafka.TCP(brokers...),
 			Transport: &kafka.Transport{
 				SASL:        mechanism,
 				TLS:         tlsConfig,


### PR DESCRIPTION
Use different topics and consumer groups for the dev environment to 
avoid collisions between different local deployments of the stack.
