### PR TITLE
Default project redirect includes query string

### DIFF
--- a/frontend/src/routers/OrgRouter/OrgRedirectionRouter.tsx
+++ b/frontend/src/routers/OrgRouter/OrgRedirectionRouter.tsx
@@ -41,7 +41,9 @@ export const ProjectRedirectionRouter = () => {
     if (adminAboutYouData?.admin?.user_defined_role == null) {
         redirectTo = '/about-you';
     } else if (data?.projects?.length) {
-        redirectTo = `/${data!.projects[0]!.id}${history.location.pathname}`;
+        redirectTo = `/${data!.projects[0]!.id}${history.location.pathname}${
+            history.location.search
+        }`;
     } else if (data?.workspaces?.length) {
         redirectTo = `/w/${data!.workspaces[0]!.id}/new`;
     } else {


### PR DESCRIPTION
Before when a user goes to:
https://app.highlight.run/alerts?foo=bar 
the url is redirected to:
https://app.highlight.run/1/alerts
as to redirect to their default highlight project, but it doesn't preserve the query string

with this pr the query string is preserved so the new redirected url will look like:
https://app.highlight.run/1/alerts?foo=bar 