### PR TITLE
[HIG-2198] fix replayer crash on network pane scrolling

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.module.scss
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.module.scss
@@ -1,4 +1,4 @@
-$columns: 50px 50px 60% 1fr 3fr;
+$columns: 50px 50px 50% 1fr 2fr;
 $right-padding: 12px;
 
 .networkRow {

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.tsx
@@ -302,10 +302,14 @@ export const ResourcePage = React.memo(
         // eslint-disable-next-line react-hooks/exhaustive-deps
         const pauseFunction = useCallback(
             _.debounce((t: number) => {
-                console.log(t);
-                pause(t);
+                if (
+                    state != ReplayerState.Empty &&
+                    state != ReplayerState.Loading
+                ) {
+                    pause(t);
+                }
             }, 300),
-            []
+            [state]
         );
 
         useEffect(() => {
@@ -598,6 +602,7 @@ const ResourceRow = ({
         </div>
     );
 };
+
 interface Request {
     url: string;
     verb: string;


### PR DESCRIPTION
Only scroll based on selected network event if the player has loaded.