### PR TITLE
[HIG-2195] only show default identifier on input

### DIFF
--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/QuickSearch/QuickSearch.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/QuickSearch/QuickSearch.tsx
@@ -385,7 +385,9 @@ const QuickSearch = () => {
                     {
                         label: 'Default',
                         tooltip: 'Search by user identifier.',
-                        options: [getDefaultField(lastTyped)],
+                        options: lastTyped.length
+                            ? [getDefaultField(lastTyped)]
+                            : [],
                     },
                 ]}
                 maxMenuHeight={500}


### PR DESCRIPTION
Wait for user input before showing
the default quick search option.

https://www.loom.com/share/96fdebe03feb485d8a6a3160a0e8f4b7