### PR TITLE
[HIG-2212] fix error and comment timeline indicator positions

### DIFF
--- a/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineAnnotation.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineAnnotation.tsx
@@ -1,3 +1,4 @@
+import { TooltipPlacement } from 'antd/lib/tooltip';
 import classNames from 'classnames';
 import { motion } from 'framer-motion';
 import React from 'react';
@@ -6,6 +7,19 @@ import { EventsForTimeline } from '../../PlayerHook/utils';
 import { ParsedEvent } from '../../ReplayerContext';
 import { getAnnotationColor } from '../Toolbar';
 import styles from './TimelineAnnotation.module.scss';
+
+export const getPopoverPlacement = (relativeStartPercent: number) => {
+    let offset = [-10, -10];
+    let placement: TooltipPlacement = 'topLeft';
+    if (relativeStartPercent > 0.67) {
+        offset = [18, -10];
+        placement = 'topRight';
+    } else if (relativeStartPercent > 0.33) {
+        offset = [0, -10];
+        placement = 'top';
+    }
+    return { offset, placement };
+};
 
 interface Props {
     event: ParsedEvent;

--- a/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineCommentAnnotation.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineCommentAnnotation.tsx
@@ -1,25 +1,29 @@
+import { SessionComment } from '@components/Comment/SessionComment/SessionComment';
 import { SessionCommentType } from '@graph/schemas';
 import { getFullScreenPopoverGetPopupContainer } from '@pages/Player/context/PlayerUIContext';
 import { PlayerSearchParameters } from '@pages/Player/PlayerHook/utils';
+import { MillisToMinutesAndSeconds } from '@util/time';
 import { message } from 'antd';
 import React, { ReactElement, useState } from 'react';
 
-import { SessionComment } from '../../../../components/Comment/SessionComment/SessionComment';
 import Popover from '../../../../components/Popover/Popover';
-import { MillisToMinutesAndSeconds } from '../../../../util/time';
 import {
     ParsedSessionComment,
     useReplayerContext,
 } from '../../ReplayerContext';
 import styles from '../Toolbar.module.scss';
-import TimelineAnnotation from './TimelineAnnotation';
+import TimelineAnnotation, { getPopoverPlacement } from './TimelineAnnotation';
 import timelineAnnotationStyles from './TimelineAnnotation.module.scss';
 
 interface Props {
     comment: ParsedSessionComment;
+    relativeStartPercent: number;
 }
 
-function TimelineCommentAnnotation({ comment }: Props): ReactElement {
+function TimelineCommentAnnotation({
+    comment,
+    relativeStartPercent,
+}: Props): ReactElement {
     const { pause, replayer } = useReplayerContext();
     const commentId = new URLSearchParams(location.search).get(
         PlayerSearchParameters.commentId
@@ -29,8 +33,17 @@ function TimelineCommentAnnotation({ comment }: Props): ReactElement {
         comment.type === SessionCommentType.Feedback && commentId === comment.id
     );
 
+    const { offset, placement } = getPopoverPlacement(relativeStartPercent);
     return (
         <Popover
+            align={{
+                overflow: {
+                    adjustY: false,
+                    adjustX: false,
+                },
+                offset: offset,
+            }}
+            placement={placement}
             getPopupContainer={getFullScreenPopoverGetPopupContainer}
             key={comment.id}
             content={

--- a/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineErrorAnnotation.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineErrorAnnotation.tsx
@@ -1,26 +1,30 @@
+import { getHeaderFromError } from '@pages/Error/ErrorPage';
 import { getFullScreenPopoverGetPopupContainer } from '@pages/Player/context/PlayerUIContext';
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration';
 import { DevToolTabType } from '@pages/Player/Toolbar/DevToolsContext/DevToolsContext';
 import { useResourceOrErrorDetailPanel } from '@pages/Player/Toolbar/DevToolsWindow/ResourceOrErrorDetailPanel/ResourceOrErrorDetailPanel';
+import { MillisToMinutesAndSeconds } from '@util/time';
 import { message } from 'antd';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import GoToButton from '../../../../components/Button/GoToButton';
 import Popover from '../../../../components/Popover/Popover';
-import { MillisToMinutesAndSeconds } from '../../../../util/time';
-import { getHeaderFromError } from '../../../Error/ErrorPage';
 import { PlayerSearchParameters } from '../../PlayerHook/utils';
 import { ParsedErrorObject, useReplayerContext } from '../../ReplayerContext';
 import styles from '../Toolbar.module.scss';
-import TimelineAnnotation from './TimelineAnnotation';
+import TimelineAnnotation, { getPopoverPlacement } from './TimelineAnnotation';
 import timelineAnnotationStyles from './TimelineAnnotation.module.scss';
 
 interface Props {
     error: ParsedErrorObject;
+    relativeStartPercent: number;
 }
 
-function TimelineErrorAnnotation({ error }: Props): ReactElement {
+function TimelineErrorAnnotation({
+    error,
+    relativeStartPercent,
+}: Props): ReactElement {
     const location = useLocation();
     const errorId = new URLSearchParams(location.search).get(
         PlayerSearchParameters.errorId
@@ -52,8 +56,17 @@ function TimelineErrorAnnotation({ error }: Props): ReactElement {
         setShowDevTools,
     ]);
 
+    const { offset, placement } = getPopoverPlacement(relativeStartPercent);
     return (
         <Popover
+            align={{
+                overflow: {
+                    adjustY: false,
+                    adjustX: false,
+                },
+                offset: offset,
+            }}
+            placement={placement}
             getPopupContainer={getFullScreenPopoverGetPopupContainer}
             key={error.id}
             defaultVisible={errorId === error.id}

--- a/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineEventAnnotation.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineEventAnnotation.tsx
@@ -3,7 +3,6 @@ import { HighlightEvent } from '@pages/Player/HighlightEvent';
 import { getTimelineEventDisplayName } from '@pages/Player/Toolbar/TimelineAnnotationsSettings/TimelineAnnotationsSettings';
 import { MillisToMinutesAndSeconds } from '@util/time';
 import { message } from 'antd';
-import { TooltipPlacement } from 'antd/lib/tooltip';
 import React, { useState } from 'react';
 
 import Popover from '../../../../components/Popover/Popover';
@@ -16,7 +15,7 @@ import {
 import StreamElementPayload from '../../StreamElement/StreamElementPayload';
 import { TimelineAnnotationColors } from '../Toolbar';
 import styles from '../Toolbar.module.scss';
-import TimelineAnnotation from './TimelineAnnotation';
+import TimelineAnnotation, { getPopoverPlacement } from './TimelineAnnotation';
 import timelineAnnotationStyles from './TimelineAnnotation.module.scss';
 
 interface Props {
@@ -40,17 +39,7 @@ const TimelineEventAnnotation = ({
     const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
     const Icon = getPlayerEventIcon(details.title || '', details.payload);
-
-    let offset = [-10, -10];
-    let placement: TooltipPlacement = 'topLeft';
-    if (relativeStartPercent > 0.67) {
-        offset = [18, -10];
-        placement = 'topRight';
-    } else if (relativeStartPercent > 0.33) {
-        offset = [0, -10];
-        placement = 'top';
-    }
-
+    const { offset, placement } = getPopoverPlacement(relativeStartPercent);
     return (
         <Popover
             align={{


### PR DESCRIPTION
Make all timeline indicators consistent in their popover positioning
relative to where they are in the timeline (left, middle, right sections).
Use consistent placement logic across all timeline Popovers.

https://www.loom.com/share/6b30ba923d8c4d8ba3f223fab77468d8