### PR TITLE
[HIG-2228] correctly scale screenshot replayer

### DIFF
--- a/render/src/index.ts
+++ b/render/src/index.ts
@@ -22,6 +22,7 @@ export const handler = async (event?: APIGatewayEvent) => {
         statusCode: 200,
         isBase64Encoded: true,
         body: Buffer.from(file).toString('base64'),
+        path: files[0],
         headers: {
             'content-type': 'image/png',
         },


### PR DESCRIPTION
Screenshot puppeteer instance can be resized based on the replayer
viewport, which renders the screenshot
at the resolution at which the session was recorded.

screenshots of different session viewports scaled correctly
![image](https://user-images.githubusercontent.com/1351531/166057339-fec06483-10a4-4a73-8eb9-e4c4c97b5d4c.png)
