### PR TITLE
[HIG-2241] improve new workspace auto join domain selector

### DIFF
--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -149,6 +149,7 @@ const NewProjectPage = () => {
                     />
                     {isWorkspace && (
                         <AutoJoinForm
+                            newWorkspace
                             updateOrigins={(domains) => {
                                 setAutoJoinDomains(domains);
                             }}

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.scss
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.scss
@@ -14,4 +14,8 @@
 
 .select {
     width: 100%;
+
+  &:global(.ant-select-disabled .ant-select-selector) {
+    background-color: var(--color-primary-background) !important;
+  }
 }

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -1,6 +1,7 @@
 import { useAuthContext } from '@authentication/AuthContext';
 import Select from '@components/Select/Select';
 import Switch from '@components/Switch/Switch';
+import Tooltip from '@components/Tooltip/Tooltip';
 import {
     useGetWorkspaceAdminsQuery,
     useUpdateAllowedEmailOriginsMutation,
@@ -8,14 +9,18 @@ import {
 import { namedOperations } from '@graph/operations';
 import { useParams } from '@util/react-router/useParams';
 import { message } from 'antd';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import styles from './AutoJoinForm.module.scss';
 
+const COMMON_EMAIL_PROVIDERS = ['gmail', 'yahoo', 'hotmail'];
+
 function AutoJoinForm({
     updateOrigins,
+    newWorkspace,
 }: {
     updateOrigins?: (domains: string[]) => void;
+    newWorkspace?: boolean;
 }) {
     const { workspace_id } = useParams<{ workspace_id: string }>();
     const { admin } = useAuthContext();
@@ -70,39 +75,62 @@ function AutoJoinForm({
 
     const adminsEmailDomain = getEmailDomain(admin?.email);
 
+    useEffect(() => {
+        if (newWorkspace && adminsEmailDomain.length) {
+            setEmailOrigins([adminsEmailDomain]);
+        }
+    }, [newWorkspace, adminsEmailDomain]);
+
+    // don't show if this is for workspace creation but admin is not a company email
+    if (
+        newWorkspace &&
+        COMMON_EMAIL_PROVIDERS.some((p) => adminsEmailDomain.indexOf(p) !== -1)
+    ) {
+        return null;
+    }
+
     return (
-        <div className={styles.container}>
-            <Switch
-                trackingId="WorkspaceAutoJoin"
-                label="Enable Auto Join"
-                checked={emailOrigins.length > 0}
-                loading={loading}
-                onChange={(checked) => {
-                    if (checked) {
-                        onChangeMsg(
-                            [adminsEmailDomain],
-                            'Successfully enabled auto-join!'
-                        );
-                    } else {
-                        onChangeMsg([], 'Successfully disabled auto-join!');
-                    }
-                }}
-                className={styles.switchClass}
-            />
-            <Select
-                placeholder={`${adminsEmailDomain}, acme.corp, piedpiper.com`}
-                className={styles.select}
-                loading={loading}
-                value={emailOrigins}
-                mode="tags"
-                onChange={onChange}
-                options={allowedEmailOrigins.map((emailOrigin) => ({
-                    displayValue: emailOrigin,
-                    id: emailOrigin,
-                    value: emailOrigin,
-                }))}
-            />
-        </div>
+        <Tooltip
+            title={
+                'Automatically share the workspace with all users on this domain.'
+            }
+            align={{ offset: [0, 6] }}
+            mouseEnterDelay={0}
+        >
+            <div className={styles.container}>
+                <Switch
+                    trackingId="WorkspaceAutoJoin"
+                    label="Enable Auto Join"
+                    checked={emailOrigins.length > 0}
+                    loading={loading}
+                    onChange={(checked) => {
+                        if (checked) {
+                            onChangeMsg(
+                                [adminsEmailDomain],
+                                'Successfully enabled auto-join!'
+                            );
+                        } else {
+                            onChangeMsg([], 'Successfully disabled auto-join!');
+                        }
+                    }}
+                    className={styles.switchClass}
+                />
+                <Select
+                    placeholder={`${adminsEmailDomain}, acme.corp, piedpiper.com`}
+                    className={styles.select}
+                    loading={loading}
+                    value={newWorkspace ? [adminsEmailDomain] : emailOrigins}
+                    mode="tags"
+                    disabled={newWorkspace}
+                    onChange={onChange}
+                    options={allowedEmailOrigins.map((emailOrigin) => ({
+                        displayValue: emailOrigin,
+                        id: emailOrigin,
+                        value: emailOrigin,
+                    }))}
+                />
+            </div>
+        </Tooltip>
     );
 }
 


### PR DESCRIPTION
On workspace creation, make the auto-join setting on by default
with the admin's email domain (if they use a domain other than gmail,yahoo,hotmail).
Show the domain to provide confirmation of the feature with a tooltip that
describes what this does.

as vadim@highlight.run
![image](https://user-images.githubusercontent.com/1351531/166836057-bf87480b-5248-4929-816e-5af87211fbdb.png)
![image](https://user-images.githubusercontent.com/1351531/166836250-af63071d-d468-442c-8121-b5ec2030d8e0.png)

as vkorolik@gmail.com
![image](https://user-images.githubusercontent.com/1351531/166836105-42527b2d-31a7-46ce-a292-f8caf830bfe8.png)
