### PR TITLE
[HIG-2237] fix player position reset on network panel open

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.tsx
@@ -61,7 +61,7 @@ export const ResourcePage = React.memo(
             isInteractingWithResources,
             setIsInteractingWithResources,
         ] = useState(false);
-        const [currentActiveIndex, setCurrentActiveIndex] = useState(0);
+        const [currentActiveIndex, setCurrentActiveIndex] = useState<number>();
         const [allResources, setAllResources] = useState<
             Array<NetworkResource> | undefined
         >([]);
@@ -119,7 +119,6 @@ export const ResourcePage = React.memo(
         }, [parsedResources]);
 
         const resourcesToRender = useMemo(() => {
-            setCurrentActiveIndex(0);
             if (!allResources) {
                 return [];
             }
@@ -272,7 +271,7 @@ export const ResourcePage = React.memo(
 
                 if (direction !== undefined) {
                     e.preventDefault();
-                    let nextIndex = currentActiveIndex + direction;
+                    let nextIndex = (currentActiveIndex || 0) + direction;
                     if (nextIndex < 0) {
                         nextIndex = 0;
                     } else if (nextIndex >= resourcesToRender.length) {
@@ -308,13 +307,14 @@ export const ResourcePage = React.memo(
         );
 
         useEffect(() => {
-            if (resourcesToRender?.length) {
-                if (state == ReplayerState.Paused) {
-                    pauseFunction(
-                        resourcesToRender[currentActiveIndex]?.startTime
-                    );
-                }
+            if (
+                resourcesToRender?.length &&
+                currentActiveIndex !== undefined &&
+                state == ReplayerState.Paused
+            ) {
+                pauseFunction(resourcesToRender[currentActiveIndex]?.startTime);
             }
+            // don't want state changes to move the player
             // eslint-disable-next-line react-hooks/exhaustive-deps
         }, [pauseFunction, resourcesToRender, currentActiveIndex]);
 


### PR DESCRIPTION
Avoid resetting the player on network panel open.
Rather, correctly set the active network panel to the request
that matches the current player time.

https://www.loom.com/share/510b3ab299d84be4a587d3702072f425