### PR TITLE
add clickTextContent tracked property

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -807,12 +807,18 @@ export class Highlight {
                         this.addCustomEvent('Click', clickTarget);
                     }
                     let selector = null;
+                    let textContent = null;
                     if (event && event.target) {
                         const t = event.target as HTMLElement;
                         selector = getSimpleSelector(t);
+                        textContent = t.textContent;
+                        // avoid sending huge strings here
+                        if (textContent && textContent.length > 2000) {
+                            textContent = textContent.substring(0, 2000);
+                        }
                     }
                     highlightThis.addProperties(
-                        { clickTarget: clickTarget, clickSelector: selector },
+                        { clickTextContent: textContent, clickSelector: selector },
                         { type: 'session' }
                     );
                 })

--- a/firstload/package.json
+++ b/firstload/package.json
@@ -1,6 +1,6 @@
 {
     "name": "highlight.run",
-    "version": "4.2.2",
+    "version": "4.2.3",
     "scripts": {
         "build": "webpack --mode=production --config=./webpack.config.js",
         "dev": "doppler run -- webpack-dev-server --progress --colors --watch",


### PR DESCRIPTION
on element click, record `textContent` and send it as a tracked property in addition to `clickSelector`.
removes the `clickTarget` tracked property which was essentially the same as `clickSelector`.