### PR TITLE
remove public graph kafka worker pool

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -157,6 +157,13 @@ func (p *Queue) Stop() {
 		if err := p.kafkaC.Close(); err != nil {
 			log.Error(errors.Wrap(err, "failed to close reader"))
 		}
+		p.kafkaC = nil
+	}
+	if p.kafkaP != nil {
+		if err := p.kafkaP.Close(); err != nil {
+			log.Error(errors.Wrap(err, "failed to close writer"))
+		}
+		p.kafkaP = nil
 	}
 }
 


### PR DESCRIPTION
Since we only want one thread per worker container running kafka tasks,
remove the workerpool to make the code simpler and avoid any performance degredation
by unnecessarily using concurrency concepts.