### PR TITLE
[HIG-2173] improve enhanced user details gate

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3008,7 +3008,7 @@ func (r *queryResolver) EnhancedUserDetails(ctx context.Context, sessionSecureID
 	}
 	pt := modelInputs.PlanType(w.PlanTier)
 	if pt != modelInputs.PlanTypeStartup && pt != modelInputs.PlanTypeEnterprise {
-		return nil, fmt.Errorf("%s tier does not include enhanced user details. Click here to see upgrade options", pt)
+		return nil, nil
 	}
 	// preload `Fields` children
 	sessionObj := &model.Session{}

--- a/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
+++ b/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
@@ -160,11 +160,16 @@ export const UserDetailsBox = React.memo(() => {
         project_id: string;
         session_secure_id: string;
     }>();
-    const { data, error, loading } = useGetEnhancedUserDetailsQuery({
+    const { data, loading } = useGetEnhancedUserDetailsQuery({
         variables: { session_secure_id },
+        fetchPolicy: 'no-cache',
     });
 
-    if (error) {
+    if (loading) {
+        return null;
+    }
+
+    if (!data?.enhanced_user_details) {
         return (
             <Tooltip
                 mouseEnterDelay={0.3}
@@ -174,7 +179,8 @@ export const UserDetailsBox = React.memo(() => {
                         target="_blank"
                         rel="noopener noreferrer"
                     >
-                        {error.message}
+                        Workspace tier does not include enhanced user details.
+                        Click here to see upgrade options
                     </a>
                 }
             >
@@ -207,7 +213,7 @@ export const UserDetailsBox = React.memo(() => {
         );
     }
 
-    if (!loading && !hasEnrichedData(data)) {
+    if (!hasEnrichedData(data)) {
         return null;
     }
 


### PR DESCRIPTION
Show the game even when a user has no scraped details.

Don't return errors on the backend because this propagated error is
recorded by highlight when in fact this is expected behavior.