### PR TITLE
[HIG-2127] add session and error pagination (backend)

### DIFF
--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -68,6 +68,7 @@ type Client struct {
 
 type SearchOptions struct {
 	MaxResults    *int
+	ResultsFrom   *int
 	SortField     *string
 	SortOrder     *string
 	ReturnCount   *bool
@@ -318,6 +319,11 @@ func (c *Client) Search(indexes []Index, projectID int, query string, options Se
 		count = *options.MaxResults
 	}
 
+	from := 0
+	if options.ResultsFrom != nil {
+		from = *options.ResultsFrom
+	}
+
 	excludesStr := ""
 	for _, e := range options.ExcludeFields {
 		if excludesStr != "" {
@@ -328,8 +334,8 @@ func (c *Client) Search(indexes []Index, projectID int, query string, options Se
 	}
 
 	content := strings.NewReader(
-		fmt.Sprintf(`{"_source": {"excludes": [%s]}, "size": %d, "query": %s%s, "track_total_hits": %s}`,
-			excludesStr, count, q, sort, trackTotalHits))
+		fmt.Sprintf(`{"_source": {"excludes": [%s]}, "size": %d, "from": %d, "query": %s%s, "track_total_hits": %s}`,
+			excludesStr, count, from, q, sort, trackTotalHits))
 
 	searchIndexes := []string{}
 	for _, index := range indexes {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -719,6 +719,7 @@ type Query {
         project_id: ID!
         count: Int!
         query: String!
+        page: Int
     ): ErrorResults!
     error_group(secure_id: String!): ErrorGroup
     messages(session_secure_id: String!): [Any]
@@ -775,6 +776,7 @@ type Query {
         count: Int!
         query: String!
         sort_desc: Boolean!
+        page: Int
     ): SessionResults!
     field_types(project_id: ID!): [Field!]!
     fields_opensearch(

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -2928,7 +2928,7 @@ func (r *queryResolver) RageClicksForProject(ctx context.Context, projectID int,
 	return rageClicks, nil
 }
 
-func (r *queryResolver) ErrorGroupsOpensearch(ctx context.Context, projectID int, count int, query string) (*model.ErrorResults, error) {
+func (r *queryResolver) ErrorGroupsOpensearch(ctx context.Context, projectID int, count int, query string, page *int) (*model.ErrorResults, error) {
 	_, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
 		return nil, nil
@@ -2941,6 +2941,10 @@ func (r *queryResolver) ErrorGroupsOpensearch(ctx context.Context, projectID int
 		SortOrder:     ptr.String("desc"),
 		ReturnCount:   ptr.Bool(true),
 		ExcludeFields: []string{"FieldGroup", "fields"}, // Excluding certain fields for performance
+	}
+	if page != nil {
+		// page param is 1 indexed
+		options.ResultsFrom = ptr.Int((*page - 1) * count)
 	}
 
 	resultCount, err := r.OpenSearch.Search([]opensearch.Index{opensearch.IndexErrorsCombined}, projectID, query, options, &results)
@@ -3680,7 +3684,7 @@ func (r *queryResolver) UserFingerprintCount(ctx context.Context, projectID int,
 	return &modelInputs.UserFingerprintCount{Count: count}, nil
 }
 
-func (r *queryResolver) SessionsOpensearch(ctx context.Context, projectID int, count int, query string, sortDesc bool) (*model.SessionResults, error) {
+func (r *queryResolver) SessionsOpensearch(ctx context.Context, projectID int, count int, query string, sortDesc bool, page *int) (*model.SessionResults, error) {
 	_, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
 		return nil, nil
@@ -3699,6 +3703,10 @@ func (r *queryResolver) SessionsOpensearch(ctx context.Context, projectID int, c
 		SortOrder:     ptr.String(sortOrder),
 		ReturnCount:   ptr.Bool(true),
 		ExcludeFields: []string{"fields", "field_group"}, // Excluding certain fields for performance
+	}
+	if page != nil {
+		// page param is 1 indexed
+		options.ResultsFrom = ptr.Int((*page - 1) * count)
 	}
 	q := fmt.Sprintf(`
 	{"bool": {


### PR DESCRIPTION
Adds pagination to backend sessions / error-groups opensearch queries using opensearch from syntax.
Pagination makes it easier for customers to triage and share their searches because a URL will reflect a consitent
set of cards based on the query and page being viewed. Currently, pages may get shifted if the underlying results
change but a future change to set start and end dates on the query will fix the result set.
