### PR TITLE
[HIG-2271] improve pagination container styling

### DIFF
--- a/frontend/src/components/Pagination/Pagination.module.scss
+++ b/frontend/src/components/Pagination/Pagination.module.scss
@@ -2,8 +2,10 @@
     display: flex;
     flex-shrink: 0;
     justify-content: flex-end;
+    left: 0;
     margin-top: var(--size-medium);
-    padding-bottom: var(--size-large);
+    position: absolute;
+    top: 86vh;
     width: 100%;
 }
 

--- a/frontend/src/pages/Error/components/ErrorSearchPanel/ErrorSearchPanel.module.scss
+++ b/frontend/src/pages/Error/components/ErrorSearchPanel/ErrorSearchPanel.module.scss
@@ -1,3 +1,5 @@
+@import 'src/static/shared.scss';
+
 .errorSearchPanel {
     background: var(--color-primary-background);
     border-right: 1px solid var(--color-gray-300);
@@ -38,4 +40,11 @@
     &.hidden {
         right: calc(-1 * (var(--sidebar-width) - var(--size-xLarge)));
     }
+}
+
+.searchContainer {
+    @include hide-scrollbar;
+    max-height: 83vh;
+    overflow-x: hidden;
+    overflow-y: auto;
 }

--- a/frontend/src/pages/Error/components/ErrorSearchPanel/ErrorSearchPanel.module.scss.d.ts
+++ b/frontend/src/pages/Error/components/ErrorSearchPanel/ErrorSearchPanel.module.scss.d.ts
@@ -2,3 +2,4 @@ export const errorSearchPanel: string;
 export const filtersContainer: string;
 export const hidden: string;
 export const panelToggleButton: string;
+export const searchContainer: string;

--- a/frontend/src/pages/Error/components/ErrorSearchPanel/ErrorSearchPanel.tsx
+++ b/frontend/src/pages/Error/components/ErrorSearchPanel/ErrorSearchPanel.tsx
@@ -1,8 +1,8 @@
 import ErrorQueryBuilder from '@pages/Error/components/ErrorQueryBuilder/ErrorQueryBuilder';
+import { ErrorFeedV2 } from '@pages/Errors/ErrorFeedV2/ErrorFeedV2';
 import classNames from 'classnames';
 import React from 'react';
 
-import { ErrorFeedV2 } from '../../../Errors/ErrorFeedV2/ErrorFeedV2';
 import PanelToggleButton from '../../../Player/components/PanelToggleButton/PanelToggleButton';
 import useErrorPageConfiguration from '../../utils/ErrorPageUIConfiguration';
 import SegmentPickerForErrors from '../SegmentPickerForErrors/SegmentPickerForErrors';
@@ -18,13 +18,13 @@ const ErrorSearchPanel = () => {
             })}
         >
             {showLeftPanel && (
-                <>
+                <div className={styles.searchContainer}>
                     <div className={styles.filtersContainer}>
                         <SegmentPickerForErrors />
                         <ErrorQueryBuilder />
                     </div>
                     <ErrorFeedV2 />
-                </>
+                </div>
             )}
             <PanelToggleButton
                 direction="left"

--- a/frontend/src/pages/Errors/ErrorFeedV2/ErrorFeedV2.module.scss
+++ b/frontend/src/pages/Errors/ErrorFeedV2/ErrorFeedV2.module.scss
@@ -90,7 +90,7 @@
     border-bottom: 1px solid transparent;
     border-bottom-color: var(--color-gray-300);
     border-top: 1px solid transparent;
-    height: calc(100vh - 350px);
+    height: 67vh;
     overflow: auto;
 
     &.hasScrolled {

--- a/frontend/src/pages/Player/SearchPanel/SearchPanel.module.scss
+++ b/frontend/src/pages/Player/SearchPanel/SearchPanel.module.scss
@@ -1,3 +1,5 @@
+@import 'src/static/shared.scss';
+
 .filtersContainer {
     align-items: center;
     column-gap: var(--size-small);
@@ -12,4 +14,11 @@
     flex-direction: column;
     flex-grow: 1;
     height: 100%;
+}
+
+.searchContainer {
+    @include hide-scrollbar;
+    max-height: 84vh;
+    overflow-x: hidden;
+    overflow-y: auto;
 }

--- a/frontend/src/pages/Player/SearchPanel/SearchPanel.module.scss.d.ts
+++ b/frontend/src/pages/Player/SearchPanel/SearchPanel.module.scss.d.ts
@@ -1,2 +1,3 @@
 export const filtersContainer: string;
+export const searchContainer: string;
 export const searchPanel: string;

--- a/frontend/src/pages/Player/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/Player/SearchPanel/SearchPanel.tsx
@@ -13,13 +13,13 @@ const SearchPanel = React.memo(({ visible }: Props) => {
     return (
         <div className={styles.searchPanel}>
             {visible && (
-                <>
+                <div className={styles.searchContainer}>
                     <div className={styles.filtersContainer}>
                         <SegmentPickerForPlayer />
                         <SessionsQueryBuilder />
                     </div>
                     <SessionFeed />
-                </>
+                </div>
             )}
         </div>
     );

--- a/frontend/src/pages/Sessions/SessionsFeedV2/SessionsFeed.module.scss
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/SessionsFeed.module.scss
@@ -175,7 +175,7 @@
     border-bottom: 1px solid transparent;
     border-bottom-color: var(--color-gray-300);
     border-top: 1px solid transparent;
-    height: calc(100vh - 385px);
+    height: 67vh;
     overflow: auto;
 
     &.hasScrolled {


### PR DESCRIPTION
Fix the position of the pagination container even when the search container expands with more queries.
![image](https://user-images.githubusercontent.com/1351531/168136576-6046aa66-3e9f-49f1-aa29-0ddb333fb7c7.png)
