### PR TITLE
[HIG-2277] adjust worker session process delay

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -807,8 +807,8 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 // Start begins the worker's tasks.
 func (w *Worker) Start() {
 	ctx := context.Background()
-	payloadLookbackPeriod := 60 // a session must be stale for at least this long to be processed
-	lockPeriod := 10            // time in minutes
+	payloadLookbackPeriod := 180 // a session must be stale for at least this long to be processed
+	lockPeriod := 10             // time in minutes
 
 	if util.IsDevEnv() {
 		payloadLookbackPeriod = 8


### PR DESCRIPTION
Increase the lookback period because we may have delays in processing session data from kafka.