### PR TITLE
[HIG-2274] improve quicksearch history

### DIFF
--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/QuickSearch/QuickSearch.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/QuickSearch/QuickSearch.tsx
@@ -361,11 +361,15 @@ const QuickSearch = () => {
                     loadOptions(input, (options) => {
                         const def = getDefaultField(input);
                         if (def.value.length) {
-                            options.unshift({
-                                label: SESSIONS_SEARCH,
-                                tooltip: 'Search by user identifier.',
-                                options: [def],
-                            });
+                            if (options.length) {
+                                options[0].options.unshift(def);
+                            } else {
+                                options.unshift({
+                                    label: SESSIONS_SEARCH,
+                                    tooltip: 'Search by user identifier.',
+                                    options: [def],
+                                });
+                            }
                         }
                         callback(options);
                     });


### PR DESCRIPTION
Make the history distinguish between session and error searches.

Remove the default label.