### PR TITLE
add index to rage_click_events.secure_session_id

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -899,7 +899,7 @@ type TimelineIndicatorEvent struct {
 type RageClickEvent struct {
 	Model
 	ProjectID       int    `deep:"-"`
-	SessionSecureID string `deep:"-"`
+	SessionSecureID string `gorm:"index" deep:"-"`
 	TotalClicks     int
 	StartTimestamp  time.Time `deep:"-"`
 	EndTimestamp    time.Time `deep:"-"`


### PR DESCRIPTION
- already added index in prod, not expecting adding this statement to do anything extra but good to keep it in sync w/ the state in prod
- will wait til EOD to deploy in case this blocks (index took about 15 mins to add in prod concurrently)