### PR TITLE
synchronous kafka consumption

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -334,9 +334,6 @@ func (w *Worker) PublicWorker() {
 		w.KafkaQueue = kafkaqueue.New(os.Getenv("KAFKA_TOPIC"), kafkaqueue.Consumer)
 	}
 
-	wp := workerpool.New(1)
-	wp.SetPanicHandler(util.Recover)
-
 	// receive messages and submit them to worker pool for processing
 	for {
 		task := w.KafkaQueue.Receive()
@@ -344,12 +341,13 @@ func (w *Worker) PublicWorker() {
 			log.Errorf("worker retrieved empty message from kafka")
 			continue
 		}
-		wp.SubmitRecover(func() {
+		func() {
+			defer util.Recover()
 			s := tracer.StartSpan("processPublicWorkerMessage", tracer.ResourceName("worker.kafka.process"), tracer.Tag("taskType", task.Type))
 			defer s.Finish()
 			w.processPublicWorkerMessage(task)
 			hlog.Incr("worker.kafka.processed.total", nil, 1)
-		})
+		}()
 	}
 }
 


### PR DESCRIPTION
don't use worker pool which has a few problems for kafka consumption:
* WP worker queue silently hides backlog of tasks
* WP worker chan which can lead to unbounded RAM consumption