### PR TITLE
fixup! [HIG-2279] show banner on failed stripe payment

### DIFF
--- a/frontend/src/pages/Billing/Billing.tsx
+++ b/frontend/src/pages/Billing/Billing.tsx
@@ -64,8 +64,10 @@ export const useBillingHook = ({
         subscriptionData: subscriptionData,
         refetchSubscription: refetchSubscription,
         issues:
-            subscriptionData?.subscription_details.lastInvoice?.status !==
-            'paid',
+            !subscriptionLoading &&
+            subscriptionData?.subscription_details.lastInvoice?.status
+                ?.length &&
+            subscriptionData.subscription_details.lastInvoice.status !== 'paid',
     };
 };
 


### PR DESCRIPTION
Don't show the payment failed banner when the subscription hasn't loaded.