### PR TITLE
parallel consumer workers

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -132,7 +132,7 @@ func New(topic string, mode Mode) *Queue {
 			GroupID:           pool.ConsumerGroup,
 			MinBytes:          prefetchSizeBytes,
 			MaxBytes:          messageSizeBytes,
-			QueueCapacity:     1000,
+			QueueCapacity:     100,
 			// in the future, we would commit only on successful processing of a message.
 			// this means we commit very often to avoid repeating tasks on worker restart.
 			CommitInterval: time.Second,
@@ -219,6 +219,8 @@ func (p *Queue) LogStats() {
 		hlog.Histogram("worker.kafka.produceWaitAvgSec", stats.WaitTime.Avg.Seconds(), nil, 1)
 		hlog.Histogram("worker.kafka.produceBatchSize", float64(stats.BatchSize.Avg), nil, 1)
 		hlog.Histogram("worker.kafka.produceBatchBytes", float64(stats.BatchBytes.Avg), nil, 1)
+		hlog.Histogram("worker.kafka.produceQueueCapacity", float64(stats.QueueCapacity), nil, 1)
+		hlog.Histogram("worker.kafka.produceQueueLength", float64(stats.QueueLength), nil, 1)
 		hlog.Histogram("worker.kafka.produceBytes", float64(stats.Bytes), nil, 1)
 		hlog.Histogram("worker.kafka.produceErrors", float64(stats.Errors), nil, 1)
 	}
@@ -230,6 +232,8 @@ func (p *Queue) LogStats() {
 		hlog.Histogram("worker.kafka.consumeWaitAvgSec", stats.WaitTime.Avg.Seconds(), nil, 1)
 		hlog.Histogram("worker.kafka.consumeFetchSize", float64(stats.FetchSize.Avg), nil, 1)
 		hlog.Histogram("worker.kafka.consumeFetchBytes", float64(stats.FetchBytes.Avg), nil, 1)
+		hlog.Histogram("worker.kafka.consumeQueueCapacity", float64(stats.QueueCapacity), nil, 1)
+		hlog.Histogram("worker.kafka.consumeQueueLength", float64(stats.QueueLength), nil, 1)
 		hlog.Histogram("worker.kafka.consumeBytes", float64(stats.Bytes), nil, 1)
 		hlog.Histogram("worker.kafka.consumeErrors", float64(stats.Errors), nil, 1)
 	}


### PR DESCRIPTION
record more datadog stats about kafka queues
use 8 parallel workers (with a bounded chan) per container for processing tasks
 