### PR TITLE
[HIG-2300] memoize error annotation inputs to see if this helps the Whippy perf issues

### DIFF
--- a/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineErrorAnnotation.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineErrorAnnotation.tsx
@@ -1,17 +1,15 @@
+import { Replayer } from '@highlight-run/rrweb';
+import { playerMetaData } from '@highlight-run/rrweb/dist/types';
 import { getHeaderFromError } from '@pages/Error/ErrorPage';
 import { getFullScreenPopoverGetPopupContainer } from '@pages/Player/context/PlayerUIContext';
-import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration';
 import { DevToolTabType } from '@pages/Player/Toolbar/DevToolsContext/DevToolsContext';
-import { useResourceOrErrorDetailPanel } from '@pages/Player/Toolbar/DevToolsWindow/ResourceOrErrorDetailPanel/ResourceOrErrorDetailPanel';
 import { MillisToMinutesAndSeconds } from '@util/time';
 import { message } from 'antd';
 import React, { ReactElement, useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 
 import GoToButton from '../../../../components/Button/GoToButton';
 import Popover from '../../../../components/Popover/Popover';
-import { PlayerSearchParameters } from '../../PlayerHook/utils';
-import { ParsedErrorObject, useReplayerContext } from '../../ReplayerContext';
+import { ParsedErrorObject } from '../../ReplayerContext';
 import styles from '../Toolbar.module.scss';
 import TimelineAnnotation, { getPopoverPlacement } from './TimelineAnnotation';
 import timelineAnnotationStyles from './TimelineAnnotation.module.scss';
@@ -19,23 +17,26 @@ import timelineAnnotationStyles from './TimelineAnnotation.module.scss';
 interface Props {
     error: ParsedErrorObject;
     relativeStartPercent: number;
+    errorId: string | null;
+    setShowDevTools: (val: boolean) => void;
+    setSelectedDevToolsTab: (val: DevToolTabType) => void;
+    setErrorPanel: (val: ParsedErrorObject) => void;
+    replayer: Replayer;
+    sessionMetadata: playerMetaData;
+    pause: (val: number) => void;
 }
 
 function TimelineErrorAnnotation({
     error,
     relativeStartPercent,
+    errorId,
+    setShowDevTools,
+    setSelectedDevToolsTab,
+    setErrorPanel,
+    replayer,
+    sessionMetadata,
+    pause,
 }: Props): ReactElement {
-    const location = useLocation();
-    const errorId = new URLSearchParams(location.search).get(
-        PlayerSearchParameters.errorId
-    );
-    const { pause, replayer, sessionMetadata } = useReplayerContext();
-    const {
-        setShowDevTools,
-        setSelectedDevToolsTab,
-    } = usePlayerConfiguration();
-    const { setErrorPanel } = useResourceOrErrorDetailPanel();
-
     const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
     useEffect(() => {

--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineIndicators.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineIndicators.tsx
@@ -1,21 +1,30 @@
 import { useAuthContext } from '@authentication/AuthContext';
 import HighlightGate from '@components/HighlightGate/HighlightGate';
+import { Replayer } from '@highlight-run/rrweb';
+import { playerMetaData } from '@highlight-run/rrweb/dist/types';
 import { usePlayerUIContext } from '@pages/Player/context/PlayerUIContext';
 import { HighlightEvent } from '@pages/Player/HighlightEvent';
+import { PlayerSearchParameters } from '@pages/Player/PlayerHook/utils';
+import { useResourceOrErrorDetailPanel } from '@pages/Player/Toolbar/DevToolsWindow/ResourceOrErrorDetailPanel/ResourceOrErrorDetailPanel';
 import RageClickSpan from '@pages/Player/Toolbar/RageClickSpan/RageClickSpan';
 import TimelineIndicatorsBarGraph from '@pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/TimelineIndicatorsBarGraph';
 import classNames from 'classnames';
 import { AnimatePresence } from 'framer-motion';
 import React, { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router';
 
 import usePlayerConfiguration from '../../PlayerHook/utils/usePlayerConfiguration';
 import {
+    ParsedErrorObject,
     ParsedSessionInterval,
     RageClick,
     ReplayerState,
     useReplayerContext,
 } from '../../ReplayerContext';
-import { useDevToolsContext } from '../DevToolsContext/DevToolsContext';
+import {
+    DevToolTabType,
+    useDevToolsContext,
+} from '../DevToolsContext/DevToolsContext';
 import TimelineCommentAnnotation from '../TimelineAnnotation/TimelineCommentAnnotation';
 import TimelineErrorAnnotation from '../TimelineAnnotation/TimelineErrorAnnotation';
 import TimelineEventAnnotation from '../TimelineAnnotation/TimelineEventAnnotation';
@@ -30,6 +39,12 @@ interface Props {
     startTime: number;
     pause: (time?: number | undefined) => void;
     activeEvent: HighlightEvent | undefined;
+    errorId: string | null;
+    setShowDevTools: (val: boolean) => void;
+    setSelectedDevToolsTab: (val: DevToolTabType) => void;
+    setErrorPanel: (val: ParsedErrorObject) => void;
+    replayer: Replayer;
+    sessionMetadata: playerMetaData;
 }
 
 const TimelineIndicatorsMemoized = React.memo(
@@ -41,6 +56,12 @@ const TimelineIndicatorsMemoized = React.memo(
         startTime,
         pause,
         activeEvent,
+        errorId,
+        setShowDevTools,
+        setSelectedDevToolsTab,
+        setErrorPanel,
+        replayer,
+        sessionMetadata,
     }: Props) => {
         const getRelativeStart = (
             sessionInterval: ParsedSessionInterval,
@@ -109,6 +130,15 @@ const TimelineIndicatorsMemoized = React.memo(
                                             sessionInterval,
                                             new Date(error.timestamp).getTime()
                                         )}
+                                        errorId={errorId}
+                                        setShowDevTools={setShowDevTools}
+                                        setSelectedDevToolsTab={
+                                            setSelectedDevToolsTab
+                                        }
+                                        setErrorPanel={setErrorPanel}
+                                        replayer={replayer}
+                                        sessionMetadata={sessionMetadata}
+                                        pause={pause}
                                     />
                                 ))}
                             {selectedTimelineAnnotationTypes.includes(
@@ -151,6 +181,11 @@ const TimelineIndicatorsMemoized = React.memo(
 );
 
 const TimelineIndicators = React.memo(() => {
+    const location = useLocation();
+    const errorId = new URLSearchParams(location.search).get(
+        PlayerSearchParameters.errorId
+    );
+
     const {
         state,
         replayer,
@@ -162,7 +197,10 @@ const TimelineIndicators = React.memo(() => {
     const {
         selectedTimelineAnnotationTypes,
         setSelectedTimelineAnnotationTypes,
+        setShowDevTools,
+        setSelectedDevToolsTab,
     } = usePlayerConfiguration();
+    const { setErrorPanel } = useResourceOrErrorDetailPanel();
     const { openDevTools } = useDevToolsContext();
     const refContainer = useRef<HTMLDivElement>(null);
 
@@ -216,6 +254,12 @@ const TimelineIndicators = React.memo(() => {
                 startTime={sessionMetadata.startTime || 0}
                 pause={pause}
                 activeEvent={activeEvent}
+                errorId={errorId}
+                setShowDevTools={setShowDevTools}
+                setSelectedDevToolsTab={setSelectedDevToolsTab}
+                setErrorPanel={setErrorPanel}
+                replayer={replayer}
+                sessionMetadata={sessionMetadata}
             />
         </>
     );


### PR DESCRIPTION
- Whippy had a session with 3200+ errors, was really slowing things down. This seems to help a lot although it's still kinda slow. Not sure if there is a better way to do this, seems a little messy having to hoist everything out of the inner component.