### PR TITLE
[HIG-2326] remove EFS from worker config

### DIFF
--- a/deploy/worker-task.json
+++ b/deploy/worker-task.json
@@ -301,20 +301,7 @@
     "proxyConfiguration": null,
     "volumes": [
         {
-            "fsxWindowsFileServerVolumeConfiguration": null,
-            "efsVolumeConfiguration": {
-                "transitEncryptionPort": null,
-                "fileSystemId": "fs-976ab3ec",
-                "authorizationConfig": {
-                    "iam": "DISABLED",
-                    "accessPointId": null
-                },
-                "transitEncryption": "DISABLED",
-                "rootDirectory": "/"
-            },
-            "name": "worker-volume",
-            "host": null,
-            "dockerVolumeConfiguration": null
+            "name": "worker-volume"
         }
     ]
 }


### PR DESCRIPTION
- following the example here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html#:~:text=the%20bind%20mount.-,Specifying%20a%20bind%20mount%20in%20your%20task%20definition,-For%20Amazon%20ECS
- we shouldn't need to specify the ephemeral storage size if 20GB is fine (and I think it should be)
- will monitor after this deploys to make sure it's still working, worst case session processing gets backed up for a few minutes while this is reverted