### PR TITLE
wrap alter column in exists check

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1032,8 +1032,15 @@ func SetupDB(dbName string) (*gorm.DB, error) {
 	// This is necessary for replacing the error_groups.fingerprints association through GORM
 	// (not sure if this is a GORM bug or due to our GORM / Postgres version)
 	if err := DB.Exec(`
-		ALTER TABLE error_fingerprints
-    		ALTER COLUMN error_group_id DROP NOT NULL
+		DO $$
+		BEGIN
+			IF EXISTS
+				(select * from information_schema.columns where table_name = 'error_fingerprints' and column_name = 'error_group_id' and is_nullable = 'NO')
+			THEN
+				ALTER TABLE error_fingerprints
+    				ALTER COLUMN error_group_id DROP NOT NULL;
+			END IF;
+		END $$;
 	`).Error; err != nil {
 		return nil, e.Wrap(err, "Error dropping null constraint on error_fingerprints.error_group_id")
 	}


### PR DESCRIPTION
- it looked like this could be the culprit for some DB blocking
- when looking at the longest running queries, I saw an autovacuum running on error_fingerprints, followed by this query, followed by many blocked queries querying the error_fingerprints table