### PR TITLE
[HIG-2329] reduce session updated_at write contentntion

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -340,7 +340,7 @@ func (r *Resolver) AppendFields(fields []*model.Field, session *model.Session) e
 	// Constantly writing to `updated_at` is a source of DB contention for session updates.
 	if err := r.DB.Table("session_fields").Clauses(clause.OnConflict{
 		DoNothing: true,
-	}).CreateInBatches(entries, 100).Error; err != nil {
+	}).Create(entries).Error; err != nil {
 		return e.Wrap(err, "error updating fields")
 	}
 	return nil


### PR DESCRIPTION
The primary contention source in the PSQL DB is
updates to session `updated_at` columns.
Many of them come from the `AppendFields` function called
from many parts of session processing.
Avoid updating session `updated_at` when we append
new fields to the session to help reduce this contention.
While this may mean that the session `updated_at` time can
slightly fall behind latest updates, other session operations
like `PushPayload` always update `updated_at`, and `AppendFields`
wouldn't be called on it's own without those operations.

Testing:

verbose SQL logging before for this line produced:
```
INSERT INTO "session_fields" ("session_id","field_id") VALUES (30000028,28) ON CONFLICT DO NOTHING
UPDATE "sessions" SET "updated_at"='2022-05-26 12:49:13.566' WHERE "id" = 30000028"
```

verbose SQL logging after:
```
INSERT INTO "session_fields" ("session_id","field_id") VALUES (30000031,42),(30000031,57) ON CONFLICT DO NOTHING
```