### PR TITLE
[HIG-2321] stop storing uncompressed session data

### DIFF
--- a/backend/object-storage/storage.go
+++ b/backend/object-storage/storage.go
@@ -187,7 +187,7 @@ func (s *StorageClient) ReadSessionsFromS3(sessionId int, projectId int) ([]inte
 	}
 
 	var events []interface{}
-	if err := json.Unmarshal([]byte(buf.String()), &events); err != nil {
+	if err := json.Unmarshal(buf.Bytes(), &events); err != nil {
 		return nil, errors.Wrap(err, "error decoding event data")
 	}
 	return events, nil
@@ -214,7 +214,7 @@ func (s *StorageClient) ReadResourcesFromS3(sessionId int, projectId int) ([]int
 	}
 
 	var resources []interface{}
-	if err := json.Unmarshal([]byte(buf.String()), &resources); err != nil {
+	if err := json.Unmarshal(buf.Bytes(), &resources); err != nil {
 		return nil, errors.Wrap(err, "error decoding resource data")
 	}
 	return resources, nil
@@ -241,7 +241,7 @@ func (s *StorageClient) ReadMessagesFromS3(sessionId int, projectId int) ([]inte
 	}
 
 	var messages []interface{}
-	if err := json.Unmarshal([]byte(buf.String()), &messages); err != nil {
+	if err := json.Unmarshal(buf.Bytes(), &messages); err != nil {
 		return nil, errors.Wrap(err, "error decoding message data")
 	}
 	return messages, nil


### PR DESCRIPTION
Only store compressed data and use the compressed data
as a source for other parts of the code that read the uncompressed data.

In the backend, some processing code needs to read the session data, so add
a step after retrieving objects from S3 to decompress.

When the frontend loads a session, we ask the backend for direct URLs
to the compressed payload only. However, the backend only retrieves these
when the browser natively supports brotli. When it does not, the browser calls
`GetSessionPayload` to retrieve decompressed resources.

This will allow us to delete old uncompressed objects from s3 to save storage costs.

Testing: chrome canary with brotli disabled and object storage enabled,
calls `GetSessionPayload` query which decompressed the compressed resources
correctly in the backend.