### PR TITLE
[HIG-2166] commit messages explicitly on processing success

### DIFF
--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -1,6 +1,9 @@
 package kafka_queue
 
-import customModels "github.com/highlight-run/highlight/backend/public-graph/graph/model"
+import (
+	customModels "github.com/highlight-run/highlight/backend/public-graph/graph/model"
+	"github.com/segmentio/kafka-go"
+)
 
 type PayloadType = int
 
@@ -56,6 +59,7 @@ type PushMetricsArgs struct {
 
 type Message struct {
 	Type                 PayloadType
+	KafkaMessage         *kafka.Message
 	PushPayload          *PushPayloadArgs
 	InitializeSession    *InitializeSessionArgs
 	IdentifySession      *IdentifySessionArgs

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -352,6 +352,7 @@ func (w *Worker) PublicWorker() {
 					s := tracer.StartSpan("processPublicWorkerMessage", tracer.ResourceName("worker.kafka.process"), tracer.Tag("taskType", task.Type))
 					defer s.Finish()
 					w.processPublicWorkerMessage(task)
+					w.KafkaQueue.Commit(task.KafkaMessage)
 					hlog.Incr("worker.kafka.processed.total", nil, 1)
 				}()
 			}


### PR DESCRIPTION
Only commit messages to kafka when processing succeeds.
This is useful to ensure we never lose any messages (even ones
in the local worker prefetch queue) when worker containers restart.