### PR TITLE
Bug Fix: Send a valid team id when creating a comment with a issue attachment

### DIFF
--- a/frontend/src/components/NewIssueModal/NewIssueModal.tsx
+++ b/frontend/src/components/NewIssueModal/NewIssueModal.tsx
@@ -69,6 +69,12 @@ const NewIssueModal: React.FC<NewIssueModalProps> = ({
         );
     }, [teams]);
 
+    useEffect(() => {
+        if (selectedlinearTeamId === '' && linearTeamsOptions.length > 0) {
+            setLinearTeamId(linearTeamsOptions[0].value);
+        }
+    }, [selectedlinearTeamId, linearTeamsOptions, setLinearTeamId]);
+
     const { project_id } = useParams<{
         project_id: string;
     }>();
@@ -111,7 +117,7 @@ const NewIssueModal: React.FC<NewIssueModalProps> = ({
                         session_comment_id: commentId,
                         text_for_attachment: commentText || 'Open in Highight',
                         issue_title: form.getFieldValue('issueTitle'),
-                        issue_team_id: selectedlinearTeamId,
+                        issue_team_id: selectedlinearTeamId || undefined,
                         issue_description: form.getFieldValue(
                             'issueDescription'
                         ),
@@ -130,7 +136,7 @@ const NewIssueModal: React.FC<NewIssueModalProps> = ({
                         error_comment_id: commentId,
                         text_for_attachment: commentText || 'Open in Highight',
                         issue_title: form.getFieldValue('issueTitle'),
-                        issue_team_id: selectedlinearTeamId,
+                        issue_team_id: selectedlinearTeamId || undefined,
                         issue_description: form.getFieldValue(
                             'issueDescription'
                         ),
@@ -192,16 +198,12 @@ const NewIssueModal: React.FC<NewIssueModalProps> = ({
                             >
                                 <Select
                                     aria-label={`${selectedIntegration.name} Team`}
-                                    defaultActiveFirstOption
                                     placeholder={
                                         'Choose a team to create the issue in'
                                     }
                                     options={linearTeamsOptions}
                                     onChange={setLinearTeamId}
-                                    value={
-                                        selectedlinearTeamId ||
-                                        linearTeamsOptions[0]?.id
-                                    }
+                                    value={selectedlinearTeamId}
                                     notFoundContent={<p>No teams found</p>}
                                 />
                             </Form.Item>

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
@@ -184,7 +184,7 @@ export const NewCommentForm = ({
                         ? [selectedIssueService]
                         : [],
                     issue_title: selectedIssueService ? issueTitle : null,
-                    issue_team_id: selectedlinearTeamId,
+                    issue_team_id: selectedlinearTeamId || undefined,
                     issue_description: selectedIssueService
                         ? issueDescription
                         : null,
@@ -247,7 +247,7 @@ export const NewCommentForm = ({
                     time: commentTime / 1000,
                     author_name: admin?.name || admin?.email || 'Someone',
                     tags: getTags(tags, commentTagsData),
-                    issue_team_id: selectedlinearTeamId,
+                    issue_team_id: selectedlinearTeamId || undefined,
                     integrations: selectedIssueService
                         ? [selectedIssueService]
                         : [],
@@ -427,6 +427,12 @@ export const NewCommentForm = ({
     }, [teams]);
 
     useEffect(() => {
+        if (selectedlinearTeamId === '' && linearTeamsOptions.length > 0) {
+            setLinearTeamId(linearTeamsOptions[0].value);
+        }
+    }, [selectedlinearTeamId, linearTeamsOptions, setLinearTeamId]);
+
+    useEffect(() => {
         const idx = modalHeader?.toLowerCase().indexOf('issue') || -1;
         if (idx !== -1) {
             setSelectedIssueService(IntegrationType.Linear);
@@ -523,16 +529,12 @@ export const NewCommentForm = ({
                         <Form.Item label={`${issueServiceDetail?.name} Team`}>
                             <Select
                                 aria-label={`${issueServiceDetail?.name} Team`}
-                                defaultActiveFirstOption
                                 placeholder={
                                     'Choose a team to create the issue in'
                                 }
                                 options={linearTeamsOptions}
                                 onChange={setLinearTeamId}
-                                value={
-                                    selectedlinearTeamId ||
-                                    linearTeamsOptions[0]?.id
-                                }
+                                value={selectedlinearTeamId}
                                 notFoundContent={<p>No teams found</p>}
                             />
                         </Form.Item>


### PR DESCRIPTION
The preferred linear team is stored in local storage. By default it starts as an empty string. In the case where a user creates an issue without selecting any team option, the empty string is passed to backend which causes the issue to not be properly made.

<img width="705" alt="image" src="https://user-images.githubusercontent.com/7832610/170767231-f3601236-5613-4a5a-9388-c6f15909f694.png">

This makes sure that the local storage option is always in sync with the dropdown selection (even if the user doesn't explicitly change the option).