### PR TITLE
[HIG-2344] errors ui: adjust center and right column padding

### DIFF
--- a/frontend/src/pages/Error/ErrorPage.module.scss
+++ b/frontend/src/pages/Error/ErrorPage.module.scss
@@ -3,6 +3,7 @@
 .errorPageCenterColumn {
     height: calc(100vh - var(--top-padding));
     overflow-y: auto;
+    padding-top: var(--size-large);
 
     &.hidden {
         padding-left: var(--size-xxLarge);
@@ -28,6 +29,7 @@
     height: calc(100vh - var(--top-padding));
     padding-bottom: var(--size-large);
     padding-right: var(--size-medium);
+    padding-top: var(--size-large);
     position: sticky;
     row-gap: var(--size-large);
     top: 120px;


### PR DESCRIPTION
<img width="1727" alt="Screen Shot 2022-06-06 at 9 18 40 AM" src="https://user-images.githubusercontent.com/1351531/172201990-78f33710-fdbb-40d2-b4a4-08a08e48d2e2.png">

instead of 

<img width="1729" alt="Screen Shot 2022-06-06 at 9 19 00 AM" src="https://user-images.githubusercontent.com/1351531/172202063-aa0638ce-9980-4955-a184-06c4bfe92cd4.png">
