### PR TITLE
[HIG-2345] fix 'must be admin' errors due to billing issues header

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4888,7 +4888,7 @@ func (r *queryResolver) SubscriptionDetails(ctx context.Context, workspaceID int
 	}
 
 	if err := r.validateAdminRole(ctx); err != nil {
-		return nil, e.Wrap(err, "must have ADMIN role to access the subscription details")
+		return nil, nil
 	}
 
 	customerParams := &stripe.CustomerParams{}

--- a/frontend/src/pages/Billing/Billing.tsx
+++ b/frontend/src/pages/Billing/Billing.tsx
@@ -1,3 +1,4 @@
+import { useAuthContext } from '@authentication/AuthContext';
 import Alert from '@components/Alert/Alert';
 import Button from '@components/Button/Button/Button';
 import Switch from '@components/Switch/Switch';
@@ -43,6 +44,7 @@ export const useBillingHook = ({
     workspace_id?: string;
     project_id?: string;
 }) => {
+    const { isAuthLoading, isHighlightAdmin } = useAuthContext();
     const { data: projectData } = useGetProjectQuery({
         variables: { id: project_id || '' },
         skip: !project_id?.length || !!workspace_id?.length,
@@ -56,7 +58,10 @@ export const useBillingHook = ({
         variables: {
             workspace_id: workspace_id || projectData?.workspace?.id || '',
         },
-        skip: !workspace_id?.length && !projectData?.workspace?.id,
+        skip:
+            isAuthLoading ||
+            !isHighlightAdmin ||
+            (!workspace_id?.length && !projectData?.workspace?.id),
     });
 
     return {


### PR DESCRIPTION
adding the header that checks for billing issues
via the subscription details graph has caused unnecessary error tracking.

don't do the query on the frontend if the user is not an admin,
and don't log an error on the backend for non-authenticated access.