### PR TITLE
[HIG-2346] use id asc to match redirection routers

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4260,7 +4260,7 @@ func (r *queryResolver) Projects(ctx context.Context) ([]*model.Project, error) 
 	}
 
 	projects := []*model.Project{}
-	if err := r.DB.Order("name ASC").Model(&model.Project{}).Where(`
+	if err := r.DB.Order("id ASC").Model(&model.Project{}).Where(`
 		id IN (
 			SELECT project_id
 			FROM project_admins
@@ -4286,7 +4286,7 @@ func (r *queryResolver) Workspaces(ctx context.Context) ([]*model.Workspace, err
 	}
 
 	workspaces := []*model.Workspace{}
-	if err := r.DB.Order("name ASC").Model(&admin).Association("Workspaces").Find(&workspaces); err != nil {
+	if err := r.DB.Order("id ASC").Model(&admin).Association("Workspaces").Find(&workspaces); err != nil {
 		return nil, e.Wrap(err, "error getting associated workspaces")
 	}
 


### PR DESCRIPTION
When multiple workspaces or projects are allowed for an admin,
use the one with the smallest ID rather than the first sorted by name.

locally tested to resolve to the right project and with a console log
<img width="481" alt="Screen Shot 2022-06-08 at 1 41 35 PM" src="https://user-images.githubusercontent.com/1351531/172713280-c3102c04-b841-4d61-afe2-1c9699f812af.png">
