### PR TITLE
fix panic in frontend metrics

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/hasura/go-graphql-client v0.3.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.8.0
+	github.com/jackc/pgconn v1.8.0 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.0.6 // indirect

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -328,7 +328,10 @@ func (w *Worker) processPublicWorkerMessage(task *kafkaqueue.Message) {
 		if task.PushMetrics == nil {
 			break
 		}
-		w.PublicResolver.PushMetricsImpl(ctx, task.PushMetrics.SessionID, task.PushMetrics.ProjectID, task.PushMetrics.Metrics)
+		err := w.PublicResolver.PushMetricsImpl(ctx, task.PushMetrics.SessionID, task.PushMetrics.ProjectID, task.PushMetrics.Metrics)
+		if err != nil {
+			log.Error(errors.Wrap(err, "failed to process PushMetricsImpl task"))
+		}
 	default:
 		log.Errorf("Unknown task type %+v", task.Type)
 	}


### PR DESCRIPTION
fix panic that would happen when a transaction
was rolled back due to an error creating a duplicate metric.