### PR TITLE
remove events_objects id constaint

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -565,6 +565,7 @@ type Field struct {
 
 type ResourcesObject struct {
 	Model
+	ID        int `json:"id"` // Shadow Model.ID to avoid creating a pkey constraint
 	SessionID int
 	Resources string
 	IsBeacon  bool `gorm:"default:false"`
@@ -667,6 +668,7 @@ type Object interface {
 
 type MessagesObject struct {
 	Model
+	ID        int `json:"id"` // Shadow Model.ID to avoid creating a pkey constraint
 	SessionID int
 	Messages  string
 	IsBeacon  bool `gorm:"default:false"`
@@ -701,6 +703,7 @@ func (m *MessagesObject) Contents() string {
 
 type EventsObject struct {
 	Model
+	ID        int `json:"id"` // Shadow Model.ID to avoid creating a pkey constraint
 	SessionID int
 	Events    string
 	IsBeacon  bool `gorm:"default:false"`


### PR DESCRIPTION
shadow ID field so automigrate won't try to reapply the pkey index.
we need to drop the ID field constaint and autoincrement because
we run out of values for the integer field.
with events_objects, we don't care about querying by id and drop
rows after they are processed.

do this for other object tables where we risk running out of ID values.

checked that these modified tables are not queried by ID.

reference: #2410 

will run the following
```
ALTER TABLE events_objects DROP CONSTRAINT events_objects_pkey;
ALTER TABLE events_objects ALTER COLUMN id SET DEFAULT 0;
ALTER TABLE messages_objects DROP CONSTRAINT messages_objects_pkey;
ALTER TABLE messages_objects ALTER COLUMN id SET DEFAULT 0;
ALTER TABLE resources_objects DROP CONSTRAINT resources_objects_pkey;
ALTER TABLE resources_objects ALTER COLUMN id SET DEFAULT 0;
```