### PR TITLE
reduce kafka dev partitions

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -104,12 +104,16 @@ func New(topic string, mode Mode) *Queue {
 				},
 			},
 		})
-		e := res.Errors[kafka.AlterConfigsResponseResource{
-			Type: int8(kafka.ResourceTypeTopic),
-			Name: topic,
-		}]
-		if err != nil || e != nil {
-			log.Error(errors.Wrapf(err, "failed to update topic retention %s", e))
+		if err != nil {
+			log.Error(errors.Wrap(err, "failed to update topic retention"))
+		} else {
+			err = res.Errors[kafka.AlterConfigsResponseResource{
+				Type: int8(kafka.ResourceTypeTopic),
+				Name: topic,
+			}]
+			if err != nil {
+				log.Error(errors.Wrap(err, "topic retention failed server-side"))
+			}
 		}
 	}
 


### PR DESCRIPTION
because the dev cluster has much less RAM than prod, reduce the number of partitions we create per dev topic (since we create one topic with N partitions per developer).

reduce the replication factor since we don't care about dev data but want to reduce CPU usage on the brokers.