### PR TITLE
influxdb: stop writing certain tags

### DIFF
--- a/backend/timeseries/influx.go
+++ b/backend/timeseries/influx.go
@@ -16,6 +16,12 @@ const (
 	Metrics Measurement = "metrics"
 )
 
+var IgnoredTags = map[string]bool{
+	"group_name": true,
+	"request_id": true,
+	"session_id": true,
+}
+
 type Point struct {
 	Measurement Measurement
 	Time        time.Time
@@ -68,6 +74,9 @@ func (i *InfluxDB) Write(points []Point) {
 	for _, point := range points {
 		p := influxdb2.NewPointWithMeasurement(string(point.Measurement))
 		for k, v := range point.Tags {
+			if ok := IgnoredTags[k]; ok {
+				continue
+			}
 			p = p.AddTag(k, v)
 		}
 		for k, v := range point.Fields {


### PR DESCRIPTION
Certain tags are relatively unique (producess little data for the given tag) which
results in influxdb throttling us
for exceeding cardinality limits.

Stop writing those tags to influxdb for now.