### PR TITLE
use beta highlight recording client for our frontend app

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -39,7 +39,7 @@ import packageJson from '../package.json';
 import LoginForm, { AuthAdminRouter } from './pages/Login/Login';
 import * as serviceWorker from './serviceWorker';
 
-const dev = process.env.NODE_ENV === 'development' ? true : false;
+const dev = process.env.NODE_ENV === 'development';
 let commitSHA = process.env.REACT_APP_COMMIT_SHA || '';
 if (commitSHA.length > 8) {
     commitSHA = commitSHA.substring(0, 8);
@@ -59,6 +59,7 @@ const options: HighlightOptions = {
             projectToken: 'e70039b6a5b93e7c86b8afb02b6d2300',
         },
     },
+    scriptUrl: 'https://static.highlight.run/beta/index.js',
     sessionShortcut: 'alt+1,command+`,alt+esc',
 };
 const favicon = document.querySelector("link[rel~='icon']") as any;


### PR DESCRIPTION
use beta version of the highlight client with rrweb 2.0.17 for the highlight project.
now that the highlight frontend uses rrweb 2.0.17 for playback ( #2750 ) we can safely start recording
with the new beta client (which is not backwards-compatible with the rrweb 1 replayer).