### PR TITLE
use influxdb for frontend metrics for all projects

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1945,11 +1945,8 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionID int, events cus
 			return nil
 		}
 		if len(resourcesParsed["resources"]) > 0 {
-			// TODO(vkorolik) frontend metrics recording only for highlight project for now to ensure we do not overwhelm our message processing
-			if projectID == 1 {
-				if err := r.submitFrontendNetworkMetric(ctx, sessionObj, resourcesParsed["resources"]); err != nil {
-					return err
-				}
+			if err := r.submitFrontendNetworkMetric(ctx, sessionObj, resourcesParsed["resources"]); err != nil {
+				return err
 			}
 			obj := &model.ResourcesObject{SessionID: sessionID, Resources: resources, IsBeacon: isBeacon}
 			if err := r.DB.Create(obj).Error; err != nil {

--- a/backend/timeseries/influx.go
+++ b/backend/timeseries/influx.go
@@ -18,7 +18,6 @@ const (
 var IgnoredTags = map[string]bool{
 	"group_name": true,
 	"request_id": true,
-	"session_id": true,
 }
 
 type Point struct {


### PR DESCRIPTION
Since influxdb has been stable for project 1 and can't overwhelm
any other parts of our infrastructure
(hitting and influxdb limits or write errors doesn't block our code)
we can enable it for all projects without much concern.

Add session_id tag to metrics recording so that we can ultimately
replace all of our metrics queries with influxdb. Will monitor cardinality
with this tag but seems to be ok with our url recording so far.