### PR TITLE
Make dashboards editable by default

### DIFF
--- a/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.module.scss
+++ b/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.module.scss
@@ -15,10 +15,6 @@
     height: 21px;
     justify-content: center;
     margin-bottom: var(--size-medium);
-
-    &.isEditing {
-        margin-right: -4px;
-    }
 }
 
 .draggable {
@@ -72,7 +68,7 @@
     justify-content: space-between;
     padding-right: var(--size-xSmall);
     padding-top: var(--size-small);
-    width: 225px;
+    width: 245px;
 
     button {
         height: var(--size-xLarge);

--- a/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.module.scss.d.ts
+++ b/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.module.scss.d.ts
@@ -6,7 +6,6 @@ export const description: string;
 export const draggable: string;
 export const headerActions: string;
 export const infoTooltip: string;
-export const isEditing: string;
 export const monitorItem: string;
 export const monitorName: string;
 export const noDataContainer: string;

--- a/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.tsx
+++ b/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.tsx
@@ -38,7 +38,6 @@ interface Props {
     updateMetric: UpdateMetricFn;
     deleteMetric: DeleteMetricFn;
     lookbackMinutes: number;
-    isEditing?: boolean;
 }
 
 const DashboardCard = ({
@@ -47,7 +46,6 @@ const DashboardCard = ({
     updateMetric,
     deleteMetric,
     lookbackMinutes,
-    isEditing,
 }: Props) => {
     const [showEditModal, setShowEditModal] = useState<boolean>(false);
     const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
@@ -94,76 +92,68 @@ const DashboardCard = ({
                                 />
                             )}
                         </h3>
-                        <div
-                            className={classNames(styles.headerActions, {
-                                [styles.isEditing]: isEditing,
-                            })}
-                        >
-                            {isEditing ? (
-                                <div className={styles.draggable}>
-                                    <SvgDragIcon />
-                                </div>
-                            ) : (
-                                <div className={styles.chartButtons}>
-                                    {metricMonitorsLoading ? (
-                                        <Skeleton width={111} />
-                                    ) : metricMonitors?.metric_monitors
-                                          .length ? (
-                                        <StandardDropdown
-                                            data={metricMonitors?.metric_monitors.map(
-                                                (mm) => ({
-                                                    label: mm?.name || '',
-                                                    value: mm?.id || '',
-                                                })
-                                            )}
-                                            onSelect={(mmId) =>
-                                                history.push(
-                                                    `/${project_id}/alerts/monitor/${mmId}`
-                                                )
-                                            }
-                                            className={styles.monitorItem}
-                                            labelClassName={styles.monitorName}
-                                        />
-                                    ) : (
-                                        <Button
-                                            icon={
-                                                <SvgAnnouncementIcon
-                                                    style={{
-                                                        marginRight:
-                                                            'var(--size-xSmall)',
-                                                    }}
-                                                />
-                                            }
-                                            trackingId={
-                                                'DashboardCardCreateMonitor'
-                                            }
-                                            onClick={() => {
-                                                history.push(
-                                                    `/${project_id}/alerts/new/monitor?type=${metricConfig.name}`
-                                                );
-                                            }}
-                                        >
-                                            Create Alert
-                                        </Button>
-                                    )}
+                        <div className={classNames(styles.headerActions)}>
+                            <div className={styles.chartButtons}>
+                                {metricMonitorsLoading ? (
+                                    <Skeleton width={111} />
+                                ) : metricMonitors?.metric_monitors.length ? (
+                                    <StandardDropdown
+                                        data={metricMonitors?.metric_monitors.map(
+                                            (mm) => ({
+                                                label: mm?.name || '',
+                                                value: mm?.id || '',
+                                            })
+                                        )}
+                                        onSelect={(mmId) =>
+                                            history.push(
+                                                `/${project_id}/alerts/monitor/${mmId}`
+                                            )
+                                        }
+                                        className={styles.monitorItem}
+                                        labelClassName={styles.monitorName}
+                                    />
+                                ) : (
                                     <Button
                                         icon={
-                                            <EditIcon
+                                            <SvgAnnouncementIcon
                                                 style={{
                                                     marginRight:
                                                         'var(--size-xSmall)',
                                                 }}
                                             />
                                         }
-                                        trackingId={'DashboardCardEditMetric'}
+                                        trackingId={
+                                            'DashboardCardCreateMonitor'
+                                        }
                                         onClick={() => {
-                                            setShowEditModal(true);
+                                            history.push(
+                                                `/${project_id}/alerts/new/monitor?type=${metricConfig.name}`
+                                            );
                                         }}
                                     >
-                                        Edit
+                                        Create Alert
                                     </Button>
+                                )}
+                                <Button
+                                    icon={
+                                        <EditIcon
+                                            style={{
+                                                marginRight:
+                                                    'var(--size-xSmall)',
+                                            }}
+                                        />
+                                    }
+                                    trackingId={'DashboardCardEditMetric'}
+                                    onClick={() => {
+                                        setShowEditModal(true);
+                                    }}
+                                >
+                                    Edit
+                                </Button>
+                                <div className={styles.draggable}>
+                                    <SvgDragIcon />
                                 </div>
-                            )}
+                            </div>
                         </div>
                         <Modal
                             visible={showDeleteModal}


### PR DESCRIPTION
Makes the default state of our dashboards editable so you can dragand resize by default. Once you drag or resize a card a "Save Changes" button appears to persist your changes.

![](https://p192.p3.n0.cdn.getcloudapp.com/items/04uQExdd/52403603-a974-4039-9336-7129add3dda7.gif?v=17cafaf929a2fadb8da3737b5100bbed)