### PR TITLE
remove metadata_log from error feed search

### DIFF
--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -6065,11 +6065,6 @@ export const GetErrorGroupsOpenSearchDocument = gql`
                     functionName
                     columnNumber
                 }
-                metadata_log {
-                    error_id
-                    session_secure_id
-                    timestamp
-                }
                 error_frequency
             }
             totalCount

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2339,16 +2339,6 @@ export type GetErrorGroupsOpenSearchQuery = { __typename?: 'Query' } & {
                                 >
                             >
                         >;
-                        metadata_log: Array<
-                            Types.Maybe<
-                                { __typename?: 'ErrorMetadata' } & Pick<
-                                    Types.ErrorMetadata,
-                                    | 'error_id'
-                                    | 'session_secure_id'
-                                    | 'timestamp'
-                                >
-                            >
-                        >;
                     }
             >;
         };

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -617,11 +617,6 @@ query GetErrorGroupsOpenSearch(
                 functionName
                 columnNumber
             }
-            metadata_log {
-                error_id
-                session_secure_id
-                timestamp
-            }
             error_frequency
         }
         totalCount


### PR DESCRIPTION
- for certain errors where an error was thrown many times for the same session, this query is super expensive. this result isn't used in the error feed, so may as well skip it. not sure if it's possible to speed up the `metadata_log` query but this way the impact is isolated to viewing a single error with this property