### PR TITLE
avoid recording url query strings

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2258,7 +2258,9 @@ func (r *Resolver) submitFrontendNetworkMetric(ctx context.Context, sessionObj *
 		if err == nil {
 			for _, d := range project.BackendDomains {
 				if u.Host == d {
-					categories[modelInputs.NetworkRequestAttributeURL] = re.Name
+					u.RawQuery = ""
+					u.Fragment = ""
+					categories[modelInputs.NetworkRequestAttributeURL] = u.String()
 				}
 			}
 		}


### PR DESCRIPTION
recording query strings or fragments leads to high data cardinality.