### PR TITLE
adjust frontend source map type

### DIFF
--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -16,7 +16,7 @@ module.exports = {
     webpack: {
         alias: resolvedAliases,
         configure: {
-            devtool: 'source-map-module',
+            devtool: 'source-map',
             output: {
                 sourceMapFilename: '[file].map',
             },


### PR DESCRIPTION
based on https://webpack.js.org/configuration/devtool/
the recommended devtool value is `source-map` for production builds.