### PR TITLE
Fix layout on workspace properties settings

### DIFF
--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.module.scss
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.module.scss
@@ -1,3 +1,7 @@
+.container {
+    max-width: 700px;
+}
+
 .subTitle {
     font-size: 18px;
 }

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.module.scss.d.ts
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.module.scss.d.ts
@@ -1,2 +1,3 @@
+export const container: string;
 export const subTitle: string;
 export const titleContainer: string;

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -8,7 +8,7 @@ import styles from './WorkspaceSettings.module.scss';
 
 const WorkspaceSettings = () => {
     return (
-        <>
+        <div className={styles.container}>
             <div className={styles.titleContainer}>
                 <div>
                     <h3>Properties</h3>
@@ -28,7 +28,7 @@ const WorkspaceSettings = () => {
                 </p>
                 <AutoJoinForm />
             </FieldsBox>
-        </>
+        </div>
     );
 };
 


### PR DESCRIPTION
Linear Issue: https://linear.app/highlight/issue/HIG-2436/quick-layout-bug-on-workspace-properties-section

---

Prevents the fields boxes from going full width on the properties tab of the workspace settings.

## Before

<img width="1429" alt="Screen Shot 2022-07-14 at 11 47 27 AM" src="https://user-images.githubusercontent.com/308182/179035426-2a9e7e9e-6a81-456f-a7c8-4326961c0f93.png">

## After

<img width="1440" alt="Screen Shot 2022-07-14 at 11 46 58 AM" src="https://user-images.githubusercontent.com/308182/179035319-e306ee08-4ac8-43bf-9ad7-fcc4f1855ce2.png">