### PR TITLE
update frontend highlight.run dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
         "firebase": "^7.19.1",
         "framer-motion": "^4.1.17",
         "graphql": "^15.5.0",
-        "highlight.run": "^4.2.7",
+        "highlight.run": "4.2.9",
         "intro.js": "^4.1.0",
         "intro.js-react": "^0.4.0",
         "lottie-react": "^2.1.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9206,10 +9206,10 @@ highlight.js@^10.4.1, highlight.js@~10.7.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
-highlight.run@^4.2.7:
-  version "4.2.7"
-  resolved "https://registry.yarnpkg.com/highlight.run/-/highlight.run-4.2.7.tgz#c1f998defcb09261d57c5bbc754ee072ebb02476"
-  integrity sha512-SBWIUzJQXJaN/L3k47SS6iidYl5pTM2a43xni24XYT/LaVJikQ+bS15sL/+nNO+2yUwhCfsXY/4PGwj4/hyrXw==
+highlight.run@4.2.9:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/highlight.run/-/highlight.run-4.2.9.tgz#81f3fa65cc5a3e1dfc6af2048247765f21c7bb8d"
+  integrity sha512-M5EmEnaL48/LJdJi1gYr+LDkrbPd6ntjWuQOaAjkVfpUz5tzMBT5bMOI1uGsJ7EIE7LBtw/5INrhHjDUS/NA0Q==
 
 history@^4.9.0:
   version "4.10.1"


### PR DESCRIPTION
update to highlight.run@4.2.9 to start using
the new firstload client with fixed error tracing.