### PR TITLE
Fix error when transitioning to Properties settings

### DIFF
--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -22,6 +22,10 @@ function AutoJoinForm({
     updateOrigins?: (domains: string[]) => void;
     newWorkspace?: boolean;
 }) {
+    const [emailOrigins, setEmailOrigins] = useState<string[]>([]);
+    const [allowedEmailOrigins, setAllowedEmailOrigins] = useState<string[]>(
+        []
+    );
     const { workspace_id } = useParams<{ workspace_id: string }>();
     const { admin } = useAuthContext();
     const { loading } = useGetWorkspaceAdminsQuery({
@@ -46,8 +50,6 @@ function AutoJoinForm({
         },
     });
 
-    const [emailOrigins, setEmailOrigins] = useState<string[]>([]);
-
     const [updateAllowedEmailOrigins] = useUpdateAllowedEmailOriginsMutation();
     const onChangeMsg = (domains: string[], msg: string) => {
         setEmailOrigins(domains);
@@ -68,10 +70,6 @@ function AutoJoinForm({
     const onChange = (domains: string[]) => {
         onChangeMsg(domains, 'Successfully updated auto-join email domains!');
     };
-
-    const [allowedEmailOrigins, setAllowedEmailOrigins] = useState<string[]>(
-        []
-    );
 
     const adminsEmailDomain = getEmailDomain(admin?.email);
 


### PR DESCRIPTION
Linear Issue: https://linear.app/highlight/issue/HIG-2421/add-some-more-filters-to-sessions-search

---

We are running into an issue when transitioning to the workspace settings' Properties tab. We invoke a state setter (`setEmailOrigins`) inside an Apollo Client `onCompleted` callback and it's somehow being invoked before it's defined. You can repro this consistently in prod by going to workspace settings and then clicking into the Properties tab. However, if you load that page directly (`/w/:id/settings`) it will load without an error.

My hypothesis is that the `onCompleted` callback is being invoked immediately when we transition to Properties from Team because the Team tab makes the same query and the data is cached. I set a breakpoint and followed the stack trace up and this seems to be the case. I can set a breakpoint on the `useState` call where we define `emailOrigins` and `setEmailOrigins` and it does not get hit before the callback is executed.

Unfortunately, I was never able to repro this locally. I even tried doing a production build and running that locally, but no luck. However, I think this change is harmless and allows us to test out the hypothesis. I'll click test after this makes its way out to prod.