### PR TITLE
Bump webpack memory in CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -87,4 +87,4 @@ jobs:
       - name: Run Tests
         run: cd frontend && yarn test
       - name: Build Bundle
-        run: export NODE_OPTIONS='--max-old-space-size=3072' && cd frontend && CI=false yarn build
+        run: export NODE_OPTIONS='--max-old-space-size=7168' && cd frontend && CI=false yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN --mount=type=secret,id=SENDGRID_API_KEY \
   export SENDGRID_API_KEY=$(cat /run/secrets/SENDGRID_API_KEY) && \
   export SLACK_CLIENT_ID=$(cat /run/secrets/SLACK_CLIENT_ID) && \
   export SLACK_CLIENT_SECRET=$(cat /run/secrets/SLACK_CLIENT_SECRET) && \
+  export NODE_OPTIONS="--max-old-space-size=7168"
   GOOS=linux GOARCH=amd64 go build \
   -ldflags="-w -s -X main.SENDGRID_API_KEY=$SENDGRID_API_KEY -X github.com/highlight-run/highlight/backend/private-graph/graph.SLACK_CLIENT_ID=$SLACK_CLIENT_ID -X github.com/highlight-run/highlight/backend/private-graph/graph.SLACK_CLIENT_SECRET=$SLACK_CLIENT_SECRET" \
   -o /bin/backend


### PR DESCRIPTION
We're hitting errors in our Docker builds: https://github.com/highlight-run/highlight/runs/7413436129?check_suite_focus=true

Talking with @Vadman97 we think bumping the memory we allocate to webpack will resolve this.