### PR TITLE
HIG-2442: Fix search refresh button hover color and tooltip

### DIFF
--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/QueryBuilder.module.scss
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/QueryBuilder.module.scss
@@ -241,7 +241,7 @@ span:last-child {
 }
 
 .syncButton:hover {
-    opacity: 60%;
+    opacity: 0.6;
 }
 
 .addFilter {

--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/QueryBuilder.tsx
@@ -1597,7 +1597,7 @@ const QueryBuilder = ({
                         >
                             <Tooltip
                                 title={
-                                    'Refresh the channels & people in your Slack Workspace.'
+                                    'Refetch the latest results of your query.'
                                 }
                             >
                                 <Reload width="12px" height="12px" />


### PR DESCRIPTION
Funnily enough, `opacity: 60%` rendered correctly on localhost but not in prod. `opacity: 0.6` is the correct way to express this in CSS.