### PR TITLE
show dashboard charts blurred on initial load

### DIFF
--- a/frontend/src/components/LineChart/LineChart.tsx
+++ b/frontend/src/components/LineChart/LineChart.tsx
@@ -10,7 +10,7 @@ import {
 } from '@pages/Player/StreamElement/Renderers/WebVitals/components/Metric';
 import classNames from 'classnames';
 import moment from 'moment';
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
     CartesianGrid,
     Label,
@@ -103,21 +103,23 @@ const LineChart = ({
     onMouseMove,
     onMouseUp,
 }: Props) => {
-    const nonXAxisKeys =
-        data.length > 0
-            ? Object.keys(data[0]).filter(
-                  (keyName) =>
-                      keyName !== xAxisDataKeyName && keyName !== '__typename'
-              )
-            : [];
     const { min, max } = findDataDomain(data);
     const gridColor = 'none';
     const labelColor = 'var(--color-gray-500)';
-    const [dataTypesToShow, setDataTypesToShow] = useState<string[]>(
-        nonXAxisKeys
-    );
+    const [dataTypesToShow, setDataTypesToShow] = useState<string[]>([]);
     const draggableReferenceLines = referenceLines?.filter((rl) => rl.onDrag);
     const [showTooltip, setShowTooltip] = React.useState(false);
+
+    const isNonXAxisKey = useCallback(
+        (keyName) => keyName !== xAxisDataKeyName && keyName !== '__typename',
+        [xAxisDataKeyName]
+    );
+
+    useEffect(() => {
+        if (data.length > 0) {
+            setDataTypesToShow(Object.keys(data[0]).filter(isNonXAxisKey));
+        }
+    }, [data, isNonXAxisKey]);
 
     return (
         <>
@@ -250,7 +252,10 @@ const LineChart = ({
                             )}
                         </ReferenceLine>
                     ))}
-                    {nonXAxisKeys.map((key) => (
+                    {(data.length > 0
+                        ? Object.keys(data[0]).filter(isNonXAxisKey)
+                        : []
+                    ).map((key) => (
                         <Line
                             hide={!dataTypesToShow.includes(key)}
                             key={key}

--- a/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.tsx
+++ b/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.tsx
@@ -549,7 +549,10 @@ const ChartContainer = React.memo(
         return (
             <div
                 className={classNames({
-                    [styles.blurChart]: timelineLoading || histogramLoading,
+                    [styles.blurChart]:
+                        timelineLoading ||
+                        histogramLoading ||
+                        chartInitialLoading,
                 })}
             >
                 <EditMetricModal
@@ -564,10 +567,9 @@ const ChartContainer = React.memo(
                     metricIdx={metricIdx}
                     updateMetric={updateMetric}
                 />
-                {chartInitialLoading ? (
-                    <Skeleton height={235} />
-                ) : !timelineData?.metrics_timeline.length &&
-                  !histogramData?.metrics_histogram?.buckets.length ? (
+                {!chartInitialLoading &&
+                !timelineData?.metrics_timeline.length &&
+                !histogramData?.metrics_histogram?.buckets.length ? (
                     <div className={styles.noDataContainer}>
                         <EmptyCardPlaceholder
                             message={`Doesn't look like we've gotten any ${metricConfig.name} data from your app yet. This is normal! You should start seeing data here a few hours after integrating.`}


### PR DESCRIPTION
When the dashboard charts initially load, use a blur animation with no data rather than a loading skeleton.

### No cached data
https://www.loom.com/share/463fa2e7314c427da067f9207b9513df

### Cached data
https://www.loom.com/share/72db956084ca4fba97370d9553710a3e