### PR TITLE
[HIG-2457] adjust session search for top users table

### DIFF
--- a/frontend/src/pages/Home/components/ActiveUsersTable/ActiveUsersTable.tsx
+++ b/frontend/src/pages/Home/components/ActiveUsersTable/ActiveUsersTable.tsx
@@ -14,6 +14,7 @@ import SvgClockIcon from '@icons/ClockIcon';
 import { EmptySessionsSearchParams } from '@pages/Sessions/EmptySessionsSearchParams';
 import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext';
 import { useParams } from '@util/react-router/useParams';
+import { validateEmail } from '@util/string';
 import { message } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import React, { useMemo, useState } from 'react';
@@ -113,7 +114,9 @@ const ActiveUsersTable = () => {
                         user_properties: [
                             {
                                 id: record.id,
-                                name: 'identifer',
+                                name: validateEmail(record.identifier)
+                                    ? 'email'
+                                    : 'identifier',
                                 value: record.identifier,
                             },
                         ],


### PR DESCRIPTION
Top users query does not distinguish between identifier and email for top users.
Do this on the frontend to link to the proper sessions feed query.