### PR TITLE
HIG-2442: Polish behavior of refresh button

### DIFF
--- a/frontend/src/pages/Error/ErrorPage.tsx
+++ b/frontend/src/pages/Error/ErrorPage.tsx
@@ -97,6 +97,9 @@ const ErrorPage = ({ integrated }: { integrated: boolean }) => {
     const [searchParams, setSearchParams] = useState<ErrorSearchParams>(
         cachedParams || EmptyErrorsSearchParams
     );
+    const [searchResultsLoading, setSearchResultsLoading] = useState<boolean>(
+        false
+    );
     const [existingParams, setExistingParams] = useState<ErrorSearchParams>({});
     const newCommentModalRef = useRef<HTMLDivElement>(null);
     const dateFromSearchParams = new URLSearchParams(location.search).get(
@@ -213,6 +216,8 @@ const ErrorPage = ({ integrated }: { integrated: boolean }) => {
                 setSearchQuery,
                 page,
                 setPage,
+                searchResultsLoading,
+                setSearchResultsLoading,
             }}
         >
             <Helmet>

--- a/frontend/src/pages/Error/components/ErrorQueryBuilder/ErrorQueryBuilder.tsx
+++ b/frontend/src/pages/Error/components/ErrorQueryBuilder/ErrorQueryBuilder.tsx
@@ -115,6 +115,7 @@ const ErrorQueryBuilder = ({ readonly }: { readonly?: boolean }) => {
         setSearchQuery,
         searchParams,
         setSearchParams,
+        searchResultsLoading,
     } = useErrorSearchContext();
     const { refetch } = useGetErrorFieldsOpensearchQuery({
         skip: true,
@@ -132,6 +133,7 @@ const ErrorQueryBuilder = ({ readonly }: { readonly?: boolean }) => {
             searchParams={searchParams}
             setSearchParams={setSearchParams}
             readonly={readonly}
+            searchResultsLoading={searchResultsLoading}
         />
     );
 };

--- a/frontend/src/pages/Errors/ErrorFeedV2/ErrorFeedV2.tsx
+++ b/frontend/src/pages/Errors/ErrorFeedV2/ErrorFeedV2.tsx
@@ -36,20 +36,24 @@ export const ErrorFeedV2 = () => {
         `errorsCount-project-${project_id}`,
         0
     );
-    const { searchQuery, page, setPage } = useErrorSearchContext();
+    const {
+        searchQuery,
+        page,
+        setPage,
+        searchResultsLoading,
+        setSearchResultsLoading,
+    } = useErrorSearchContext();
     const projectHasManyErrors = errorsCount > PAGE_SIZE;
 
     const [
         errorFeedIsInTopScrollPosition,
         setErrorFeedIsInTopScrollPosition,
     ] = useState(true);
-    // Used to determine if we need to show the loading skeleton. The loading skeleton should only be shown on the first load and when searchParams changes. It should not show when loading more sessions via infinite scroll.
-    const [showLoadingSkeleton, setShowLoadingSkeleton] = useState(true);
     useEffect(() => {
         if (searchQuery) {
-            setShowLoadingSkeleton(true);
+            setSearchResultsLoading(true);
         }
-    }, [searchQuery, page]);
+    }, [searchQuery, page, setSearchResultsLoading]);
 
     const { loading } = useGetErrorGroupsOpenSearchQuery({
         variables: {
@@ -66,7 +70,7 @@ export const ErrorFeedV2 = () => {
                 );
                 setErrorsCount(r?.error_groups_opensearch.totalCount);
             }
-            setShowLoadingSkeleton(false);
+            setSearchResultsLoading(false);
         },
         skip: !searchQuery,
         fetchPolicy: projectHasManyErrors ? 'cache-first' : 'no-cache',
@@ -105,7 +109,7 @@ export const ErrorFeedV2 = () => {
                     })}
                     onScroll={onFeedScrollListener}
                 >
-                    {showLoadingSkeleton ? (
+                    {searchResultsLoading ? (
                         <Skeleton
                             height={110}
                             count={3}

--- a/frontend/src/pages/Errors/ErrorSearchContext/ErrorSearchContext.tsx
+++ b/frontend/src/pages/Errors/ErrorSearchContext/ErrorSearchContext.tsx
@@ -24,6 +24,8 @@ type ErrorSearchContext = {
     setSearchQuery: React.Dispatch<React.SetStateAction<string>>;
     page?: number;
     setPage: React.Dispatch<React.SetStateAction<number | undefined>>;
+    searchResultsLoading: boolean;
+    setSearchResultsLoading: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const [

--- a/frontend/src/pages/Sessions/SearchContext/SearchContext.tsx
+++ b/frontend/src/pages/Sessions/SearchContext/SearchContext.tsx
@@ -68,6 +68,8 @@ interface SearchContext {
     setIsQuickSearchOpen: React.Dispatch<React.SetStateAction<boolean>>;
     page?: number;
     setPage: React.Dispatch<React.SetStateAction<number | undefined>>;
+    searchResultsLoading: boolean;
+    setSearchResultsLoading: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const showLiveSessions = (searchParams: SearchParams): boolean => {

--- a/frontend/src/pages/Sessions/SessionsFeedV2/SessionsFeed.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/SessionsFeed.tsx
@@ -83,6 +83,8 @@ export const SessionFeed = React.memo(() => {
         searchQuery,
         page,
         setPage,
+        searchResultsLoading,
+        setSearchResultsLoading,
     } = useSearchContext();
     const { integrated } = useIntegrated();
     const searchParamsChanged = useRef<Date>();
@@ -107,10 +109,9 @@ export const SessionFeed = React.memo(() => {
     });
 
     // Used to determine if we need to show the loading skeleton. The loading skeleton should only be shown on the first load and when searchParams changes. It should not show when loading more sessions via infinite scroll.
-    const [showLoadingSkeleton, setShowLoadingSkeleton] = useState(true);
     useEffect(() => {
-        setShowLoadingSkeleton(true);
-    }, [searchQuery, page]);
+        setSearchResultsLoading(true);
+    }, [searchQuery, page, setSearchResultsLoading]);
 
     // Get the unprocessedSessionsCount from either the SQL or OpenSearch query
     const unprocessedSessionsCount: number | undefined =
@@ -124,7 +125,7 @@ export const SessionFeed = React.memo(() => {
             );
             setSessionsCount(response?.sessions_opensearch.totalCount);
         }
-        setShowLoadingSkeleton(false);
+        setSearchResultsLoading(false);
     };
 
     const { loading, called } = useGetSessionsOpenSearchQuery({
@@ -311,7 +312,7 @@ export const SessionFeed = React.memo(() => {
                         [styles.hasScrolled]: !sessionFeedIsInTopScrollPosition,
                     })}
                 >
-                    {showLoadingSkeleton ? (
+                    {searchResultsLoading ? (
                         <Skeleton
                             height={!showDetailedSessionView ? 74 : 125}
                             count={3}

--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/QueryBuilder.module.scss
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/QueryBuilder.module.scss
@@ -224,6 +224,7 @@ span:last-child {
 }
 
 .syncButton,
+.syncButton[disabled],
 .syncButton:active,
 .syncButton:focus,
 .syncButton:hover {
@@ -235,6 +236,10 @@ span:last-child {
 
 .syncButton:hover {
     opacity: 0.6;
+}
+
+.syncButton[disabled] {
+    opacity: 0.2;
 }
 
 .addFilter {

--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/QueryBuilder.tsx
@@ -1092,6 +1092,7 @@ interface QueryBuilderProps {
     searchParams: any;
     setSearchParams: React.Dispatch<React.SetStateAction<any>>;
     readonly?: boolean;
+    searchResultsLoading: boolean;
 }
 
 const QueryBuilder = ({
@@ -1104,6 +1105,7 @@ const QueryBuilder = ({
     searchParams,
     setSearchParams,
     readonly,
+    searchResultsLoading,
 }: QueryBuilderProps) => {
     const { admin } = useAuthContext();
     const getCustomFieldOptions = useCallback(
@@ -1359,6 +1361,9 @@ const QueryBuilder = ({
         },
     };
     const [rules, setRulesImpl] = useState<RuleProps[]>([defaultTimeRangeRule]);
+    const [syncButtonDisabled, setSyncButtonDisabled] = useState<boolean>(
+        false
+    );
     const timeRangeRule = useMemo<RuleProps | undefined>(
         () => rules.find((rule) => rule.field?.value === timeRangeField.value),
         [rules, timeRangeField.value]
@@ -1507,6 +1512,19 @@ const QueryBuilder = ({
     // Track the current state of the query builder to detect changes
     const [qbState, setQbState] = useState<string | undefined>(undefined);
 
+    useEffect(() => {
+        if (searchResultsLoading === false) {
+            const timer = setTimeout(() => {
+                setSyncButtonDisabled(false);
+            }, 5000);
+            return () => {
+                clearTimeout(timer);
+            };
+        } else {
+            setSyncButtonDisabled(true);
+        }
+    }, [searchResultsLoading]);
+
     // If the search query is updated externally, set the rules and `isAnd` toggle based on it
     useEffect(() => {
         if (!!searchParams.query && searchParams.query !== qbState) {
@@ -1578,6 +1596,7 @@ const QueryBuilder = ({
     if (!timeRangeRule) {
         addRule(defaultTimeRangeRule);
     }
+
     return (
         <div className={styles.builderContainer}>
             {timeRangeRule && (
@@ -1603,7 +1622,7 @@ const QueryBuilder = ({
                                     const query = parseGroup(isAnd, rules);
                                     setSearchQuery(JSON.stringify(query));
                                 }}
-                                loading={false}
+                                disabled={syncButtonDisabled}
                                 trackingId={'RefreshSearchResults'}
                             >
                                 <Tooltip

--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/SessionsQueryBuilder/SessionsQueryBuilder.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/SessionsQueryBuilder/SessionsQueryBuilder.tsx
@@ -218,6 +218,7 @@ const SessionsQueryBuilder = React.memo(
             setSearchQuery,
             searchParams,
             setSearchParams,
+            searchResultsLoading,
         } = useSearchContext();
         const { refetch } = useGetFieldsOpensearchQuery({
             skip: true,
@@ -243,6 +244,7 @@ const SessionsQueryBuilder = React.memo(
                 searchParams={searchParams}
                 setSearchParams={setSearchParams}
                 readonly={readonly}
+                searchResultsLoading={searchResultsLoading}
             />
         );
     }

--- a/frontend/src/routers/OrgRouter/OrgRouter.tsx
+++ b/frontend/src/routers/OrgRouter/OrgRouter.tsx
@@ -163,6 +163,9 @@ export const ProjectRouter = () => {
     const [searchParams, setSearchParams] = useState<SearchParams>(
         EmptySessionsSearchParams
     );
+    const [searchResultsLoading, setSearchResultsLoading] = useState<boolean>(
+        false
+    );
     const [isQuickSearchOpen, setIsQuickSearchOpen] = useState(false);
 
     const [page, setPage] = useState<number>();
@@ -355,6 +358,8 @@ export const ProjectRouter = () => {
                         setIsQuickSearchOpen,
                         page,
                         setPage,
+                        searchResultsLoading,
+                        setSearchResultsLoading,
                     }}
                 >
                     <Header />


### PR DESCRIPTION
https://user-images.githubusercontent.com/696206/180332405-c58bc26d-77ff-4abd-bce0-ae63dd7d69b1.mov

1. Disable the refresh button on search page while search results are loading, and for 5 seconds after
2. Hide the refresh button when the date range is absolute, as results are unlikely to change
3. Round the corners on the date filter input (previously the corners on the right side were square)

To do (1), I had to add `searchResultsLoading` into the searchContext for both sessions and errors.