### PR TITLE
Show project secret for sourcemap uploads

### DIFF
--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -6778,6 +6778,7 @@ export const GetProjectDocument = gql`
             rage_click_radius_pixels
             rage_click_count
             backend_domains
+            secret
         }
         workspace: workspace_for_project(project_id: $id) {
             id

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2615,6 +2615,7 @@ export type GetProjectQuery = { __typename?: 'Query' } & {
             | 'rage_click_radius_pixels'
             | 'rage_click_count'
             | 'backend_domains'
+            | 'secret'
         >
     >;
     workspace?: Types.Maybe<

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -777,6 +777,7 @@ query GetProject($id: ID!) {
         rage_click_radius_pixels
         rage_click_count
         backend_domains
+        secret
     }
     workspace: workspace_for_project(project_id: $id) {
         id

--- a/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings.tsx
@@ -5,11 +5,10 @@ import Input from '@components/Input/Input';
 import ProgressBarTable from '@components/ProgressBarTable/ProgressBarTable';
 import Select from '@components/Select/Select';
 import {
+    useGetProjectQuery,
     useGetSourcemapFilesLazyQuery,
     useGetSourcemapVersionsQuery,
-    useGetWorkspaceQuery,
 } from '@graph/hooks';
-import { useApplicationContext } from '@routers/OrgRouter/ApplicationContext';
 import { useParams } from '@util/react-router/useParams';
 import { debounce } from 'lodash';
 import React, { useEffect } from 'react';
@@ -21,11 +20,10 @@ const SourcemapSettings = () => {
     const [query, setQuery] = React.useState<string>('');
     const [versions, setVersions] = React.useState<string[]>([]);
     const [selectedVersion, setSelectedVersion] = React.useState<string>();
-    const { currentWorkspace } = useApplicationContext();
 
-    const { data: workspaceData } = useGetWorkspaceQuery({
+    const { data: projectData } = useGetProjectQuery({
         variables: {
-            id: currentWorkspace?.id || '',
+            id: project_id,
         },
     });
 
@@ -88,7 +86,7 @@ const SourcemapSettings = () => {
         <FieldsBox id={'sourcemaps'}>
             <h3>Sourcemaps</h3>
 
-            {workspaceData?.workspace?.secret && (
+            {projectData?.project?.secret && (
                 <div className={styles.sourcemapInfo}>
                     <p>
                         Sourcemaps can be used to undo JavaScript minification
@@ -105,7 +103,7 @@ const SourcemapSettings = () => {
                     </p>
 
                     <CopyText
-                        text={workspaceData.workspace.secret}
+                        text={projectData.project.secret}
                         onCopyTooltipText="API key copied to your clipboard!"
                     />
                 </div>


### PR DESCRIPTION
https://github.com/highlight-run/highlight/pull/2764 exposed a secret for uploading sourcemaps to S3. Unfortunately, it was the wrong one 🙀 - we want to expose `projects.secret` rather than `workspaces.secret`. This PR contains a fix.