### PR TITLE
Fix alignment of button text

### DIFF
--- a/frontend/src/components/Header/components/PersonalNotificationButton/PersonalNotificationButton.module.scss
+++ b/frontend/src/components/Header/components/PersonalNotificationButton/PersonalNotificationButton.module.scss
@@ -1,11 +1,11 @@
-.personalNotificationButton {
+a.personalNotificationButton {
     align-items: center;
     border: 0;
     border-radius: var(--size-xSmall);
     column-gap: var(--size-xSmall);
     display: flex;
     height: 32px;
-    padding-bottom: var(--size-xxSmall);
+    padding-bottom: var(--size-xxSmall) !important;
     padding-top: var(--size-xxSmall) !important;
     width: fit-content;
 


### PR DESCRIPTION
Fixed an issue where text isn't vertically centered on `PersonalNotificationButton`s.

https://www.loom.com/share/b6775a6b3e1c43bebf59ae31ccdf2b95

There is a weird `0.01px` padding that is added by antd it's overriding the padding values we attempt to set in `frontend/src/components/Header/components/PersonalNotificationButton/PersonalNotificationButton.module.scss` because our selector's specificity isn't as high.

There might be an opportunity to clean up the CSS a bit more, but I didn't understand all the use cases of this component and didn't want to invest too much time into since I know this was intended to be a quick fix.