### PR TITLE
fix disabling metric monitors

### DIFF
--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -2331,15 +2331,15 @@ export const UpdateMetricMonitorDocument = gql`
     mutation UpdateMetricMonitor(
         $metric_monitor_id: ID!
         $project_id: ID!
-        $name: String!
-        $aggregator: MetricAggregator!
-        $threshold: Float!
+        $name: String
+        $aggregator: MetricAggregator
+        $threshold: Float
         $units: String
         $periodMinutes: Int
-        $metric_to_monitor: String!
-        $slack_channels: [SanitizedSlackChannelInput]!
-        $emails: [String]!
-        $disabled: Boolean!
+        $metric_to_monitor: String
+        $slack_channels: [SanitizedSlackChannelInput]
+        $emails: [String]
+        $disabled: Boolean
     ) {
         updateMetricMonitor(
             metric_monitor_id: $metric_monitor_id

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -701,19 +701,21 @@ export type CreateMetricMonitorMutation = { __typename?: 'Mutation' } & {
 export type UpdateMetricMonitorMutationVariables = Types.Exact<{
     metric_monitor_id: Types.Scalars['ID'];
     project_id: Types.Scalars['ID'];
-    name: Types.Scalars['String'];
-    aggregator: Types.MetricAggregator;
-    threshold: Types.Scalars['Float'];
+    name?: Types.Maybe<Types.Scalars['String']>;
+    aggregator?: Types.Maybe<Types.MetricAggregator>;
+    threshold?: Types.Maybe<Types.Scalars['Float']>;
     units?: Types.Maybe<Types.Scalars['String']>;
     periodMinutes?: Types.Maybe<Types.Scalars['Int']>;
-    metric_to_monitor: Types.Scalars['String'];
-    slack_channels:
+    metric_to_monitor?: Types.Maybe<Types.Scalars['String']>;
+    slack_channels?: Types.Maybe<
         | Array<Types.Maybe<Types.SanitizedSlackChannelInput>>
-        | Types.Maybe<Types.SanitizedSlackChannelInput>;
-    emails:
+        | Types.Maybe<Types.SanitizedSlackChannelInput>
+    >;
+    emails?: Types.Maybe<
         | Array<Types.Maybe<Types.Scalars['String']>>
-        | Types.Maybe<Types.Scalars['String']>;
-    disabled: Types.Scalars['Boolean'];
+        | Types.Maybe<Types.Scalars['String']>
+    >;
+    disabled?: Types.Maybe<Types.Scalars['Boolean']>;
 }>;
 
 export type UpdateMetricMonitorMutation = { __typename?: 'Mutation' } & {

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -596,15 +596,15 @@ mutation CreateMetricMonitor(
 mutation UpdateMetricMonitor(
     $metric_monitor_id: ID!
     $project_id: ID!
-    $name: String!
-    $aggregator: MetricAggregator!
-    $threshold: Float!
+    $name: String
+    $aggregator: MetricAggregator
+    $threshold: Float
     $units: String
     $periodMinutes: Int
-    $metric_to_monitor: String!
-    $slack_channels: [SanitizedSlackChannelInput]!
-    $emails: [String]!
-    $disabled: Boolean!
+    $metric_to_monitor: String
+    $slack_channels: [SanitizedSlackChannelInput]
+    $emails: [String]
+    $disabled: Boolean
 ) {
     updateMetricMonitor(
         metric_monitor_id: $metric_monitor_id

--- a/frontend/src/pages/Alerts/AlertEnableSwitch/AlertEnableSwitch.tsx
+++ b/frontend/src/pages/Alerts/AlertEnableSwitch/AlertEnableSwitch.tsx
@@ -2,6 +2,7 @@ import InfoTooltip from '@components/InfoTooltip/InfoTooltip';
 import Switch from '@components/Switch/Switch';
 import {
     useUpdateErrorAlertMutation,
+    useUpdateMetricMonitorMutation,
     useUpdateNewSessionAlertMutation,
     useUpdateNewUserAlertMutation,
     useUpdateRageClickAlertMutation,
@@ -25,6 +26,7 @@ export const AlertEnableSwitch: React.FC<{ record: any }> = ({ record }) => {
     const [updateNewUserAlert] = useUpdateNewUserAlertMutation();
     const [updateUserPropertiesAlert] = useUpdateUserPropertiesAlertMutation();
     const [updateRageClickAlert] = useUpdateRageClickAlertMutation();
+    const [updateMetricMonitor] = useUpdateMetricMonitorMutation();
     const [updateNewSessionAlert] = useUpdateNewSessionAlertMutation();
     const [
         updateTrackPropertiesAlert,
@@ -111,6 +113,16 @@ export const AlertEnableSwitch: React.FC<{ record: any }> = ({ record }) => {
                     variables: {
                         project_id,
                         rage_click_alert_id: record.id,
+                        disabled: isDisabled,
+                    },
+                });
+                break;
+            case ALERT_TYPE.MetricMonitor:
+                await updateMetricMonitor({
+                    ...requestBody,
+                    variables: {
+                        metric_monitor_id: record.id,
+                        project_id,
                         disabled: isDisabled,
                     },
                 });

--- a/frontend/src/pages/Alerts/Alerts.module.scss
+++ b/frontend/src/pages/Alerts/Alerts.module.scss
@@ -35,6 +35,10 @@
     .primary {
         font-size: 16px;
         font-weight: 500;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: 500px;
     }
 }
 

--- a/frontend/src/pages/Alerts/Alerts.tsx
+++ b/frontend/src/pages/Alerts/Alerts.tsx
@@ -493,7 +493,7 @@ const AlertsPage = () => {
 
             {((alertsPayload && alertsPayload?.is_integrated_with_slack) ||
                 !alertsPayload) && (
-                <Card noPadding>
+                <Card noPadding style={{ width: 1200 }}>
                     <Table
                         columns={TABLE_COLUMNS}
                         loading={loading}

--- a/frontend/src/pages/Alerts/AlertsRouter.tsx
+++ b/frontend/src/pages/Alerts/AlertsRouter.tsx
@@ -50,7 +50,7 @@ const AlertsRouter = () => {
             <Helmet>
                 <title>Alerts</title>
             </Helmet>
-            <LeadAlignLayout maxWidth={850}>
+            <LeadAlignLayout maxWidth={1200}>
                 <Breadcrumb
                     getBreadcrumbName={(url) =>
                         getAlertsBreadcrumbNames(history.location.state)(url)


### PR DESCRIPTION
Updating metric monitors via the enable/disable switch would crash the UI.
Implement the update mutation to properly save the state.
Also fixes text overflow of long alert names.