### PR TITLE
[HIG-2495] enable stylesheet inlining for clients

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@highlight-run/client",
     "private": true,
-    "version": "1.1.1",
+    "version": "1.1.4",
     "description": "rollup setup for writing a javascript library and making it availabe as script or npm package",
     "main": "dist/index.js",
     "module": "dist/index.mjs",

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -202,6 +202,8 @@ export class Highlight {
             // Firstload versions before 3.0.1 did not have this property
             options.sessionSecureID = GenerateSecureID();
         }
+        // default to inlining stylesheets to help with recording accuracy
+        options.inlineStylesheet = true;
         this.options = options;
         // Old firstLoad versions (Feb 2022) do not pass in FirstLoadListeners, so we have to fallback to creating it
         this._firstLoadListeners =


### PR DESCRIPTION
Default to inlining stylesheets. This was the previous behavior before rolling out new client options that improve the feature.