### PR TITLE
add backend dlv debug runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ yalc.lock
 **/.nvmrc
 
 backend/backend
+backend/__debug_bin
 
 # Editor Artifacts
 **/.idea

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,5 +1,7 @@
 start:
 		doppler run -- air -c .air.toml
+debug:
+		doppler run -- dlv debug --headless --listen=:2345 --api-version=2 --accept-multiclient
 public-gen:
 		(cd ./public-graph; go run github.com/99designs/gqlgen)
 private-gen:


### PR DESCRIPTION
Adds a backend `Makefile` entry to run the go binary with dlv to make it easy to attach a go debugger.
