### PR TITLE
[HIG-2501] add fields.Key.raw mapping for case sensitive aggregation

### DIFF
--- a/backend/worker/opensearch.go
+++ b/backend/worker/opensearch.go
@@ -183,7 +183,12 @@ const NESTED_FIELD_MAPPINGS = `
 			"properties": {
 				"Key": {
 					"type": "keyword",
-					"normalizer": "lowercase"
+					"normalizer": "lowercase",
+					"fields": {
+						"raw": { 
+						  "type":  "keyword"
+						}
+					}
 				},
 				"KeyValue": {
 					"type": "keyword",


### PR DESCRIPTION
- Without this, an aggregation on fields.Key returns all lowercase results, and subsequent lookups with those fail to return the right data.
- After deploying, need to run the `init-opensearch` command in Prod to reindex sessions