### PR TITLE
update rrweb@2.0.18 to fix canvas recording crash

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@highlight-run/client",
     "private": true,
-    "version": "1.1.4",
+    "version": "1.1.5",
     "description": "rollup setup for writing a javascript library and making it availabe as script or npm package",
     "main": "dist/index.js",
     "module": "dist/index.mjs",
@@ -44,7 +44,7 @@
         "typescript": "^4.1.3"
     },
     "dependencies": {
-        "@highlight-run/rrweb": "2.0.17",
+        "@highlight-run/rrweb": "2.0.18",
         "@rollup/plugin-commonjs": "^22.0.1",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.3.0",
@@ -54,8 +54,8 @@
         "error-stack-parser": "2.0.6",
         "esbuild": "^0.14.47",
         "graphql": "^16.5.0",
-        "graphql-tag": "^2.12.6",
         "graphql-request": "^4.3.0",
+        "graphql-tag": "^2.12.6",
         "json-stringify-safe": "^5.0.1",
         "rollup": "^2.75.7",
         "rollup-plugin-consts": "^1.1.0",
@@ -69,6 +69,6 @@
     "resolutions": {
         "ansi-regex": "5.0.1",
         "terser": "5.14.2",
-	"json-schema": "0.4.0"
+        "json-schema": "0.4.0"
     }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1405,10 +1405,10 @@
   resolved "https://registry.yarnpkg.com/@highlight-run/rrweb-snapshot/-/rrweb-snapshot-1.1.22.tgz#7a8c3ffea74ede246dba17bf038528b7d3d0947f"
   integrity sha512-w3yWlBA8D4kQ1gKxtI/VG8YyVa98DYmxX0kXKhYOg/HhTIdwuj14OxcUt0u1ZBRuqhZXGdsyAURacFkkZmWpIg==
 
-"@highlight-run/rrweb@2.0.17":
-  version "2.0.17"
-  resolved "https://registry.yarnpkg.com/@highlight-run/rrweb/-/rrweb-2.0.17.tgz#a8a8b28dcc18b08d3db8de52f3e69dcafee37bf8"
-  integrity sha512-SpS7Z1BqYtAalQ3DDOabrBRsxsrYxHThB26lf1VBX40D51O9hcLD85dgh0pmYGdgjwV2WeQi49ouiE4VLt3HGw==
+"@highlight-run/rrweb@2.0.18":
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/@highlight-run/rrweb/-/rrweb-2.0.18.tgz#3a217f0a83c3e10ea9fc0b7a1d8b77f8d9746f39"
+  integrity sha512-Bzlfj811nNwbdRJmUwSQKD4qzQSGv/h58SMzaB+Pjc3BW4qlQjQGXo62n6A+tfjCLAhw9AVlqkGsE2LL0nD7LA==
   dependencies:
     "@highlight-run/rrdom" ">=0.1.14"
     "@highlight-run/rrweb-snapshot" ">=1.1.22"


### PR DESCRIPTION
https://github.com/highlight-run/rrweb/pull/79

slow canvas loading can cause the canvas manager worker to crash.
also fix a merge conflict in rrweb styles file.