### PR TITLE
auto-create metric monitors disabled

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2383,7 +2383,7 @@ func (r *Resolver) AutoCreateMetricMonitor(ctx context.Context, metric *model.Da
 		MetricToMonitor:  metric.Name,
 		ChannelsToNotify: channelsString,
 		EmailsToNotify:   emailsString,
-		Disabled:         true,
+		Disabled:         pointy.Bool(true),
 	}
 	if err := r.DB.Create(newMetricMonitor).Error; err != nil {
 		return e.Wrap(err, "failed to auto create metric monitor")


### PR DESCRIPTION
Make it obvious there is a metric monitor available but do not enable it to avoid spamming
with an unvetted threshold.

Adjusts the auto-selected threshold to be P95 to be less spammy.