### PR TITLE
[HIG-2288] only show live sessions if events exist

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1085,6 +1085,7 @@ func InitializeSessionMinimal(ctx context.Context, r *mutationResolver, projectV
 		LastUserInteractionTime:        time.Now(),
 		ViewedByAdmins:                 []model.Admin{},
 		ClientID:                       *clientID,
+		Excluded:                       &model.T, // A session is excluded by default until it receives events
 	}
 
 	// Firstload secureID generation was added in firstload 3.0.1, Feb 2022


### PR DESCRIPTION
- exclude sessions by default
- when a pushpayload is received for the session, excluded is set to false