### PR TITLE
only send first-time user alert once

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1367,10 +1367,11 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionID int, userI
 	log.WithFields(log.Fields{"session_id": session.ID, "project_id": session.ProjectID, "identifier": session.Identifier}).
 		Infof("identified session: %s", session.Identifier)
 
-	r.AlertWorkerPool.SubmitRecover(func() {
+	func() {
+		defer util.Recover()
 		// Sending New User Alert
 		// if is not new user, return
-		if session.FirstTime == nil || !*session.FirstTime {
+		if !*firstTime {
 			return
 		}
 		var sessionAlerts []*model.SessionAlert
@@ -1418,7 +1419,7 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionID int, userI
 
 			sessionAlert.SendAlerts(r.DB, r.MailClient, &model.SendSlackAlertInput{Workspace: workspace, SessionSecureID: session.SecureID, UserIdentifier: session.Identifier, UserProperties: userProperties, UserObject: session.UserObject})
 		}
-	})
+	}()
 	return nil
 }
 


### PR DESCRIPTION
if a session gets multiple `H.identify` calls, only send the new-user alert once by checking that this is the first time we are updating the `userIdentifier` field.
this is still prone to a race if the two calls happen simultaneously but is a quick fix for now for multiple calls spaced apart (which is what happens with the segment integration).
no need to use the alert worker pool which may further delay the message sending.