### PR TITLE
add separate job to initialize sessions only

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -20,6 +20,8 @@ test-and-coverage:
 		(ENVIRONMENT=test LOG_LEVEL=debug PSQL_HOST=localhost PSQL_PORT=5432 PSQL_USER=postgres PSQL_PASSWORD=postgres go test -p 1 -covermode=atomic -coverprofile=coverage.out ./... -v)
 init-opensearch:
 		(go build; doppler run -- ./backend -runtime=worker -worker-handler=init-opensearch)
+init-opensearch-sessions:
+		(go build; doppler run -- ./backend -runtime=worker -worker-handler=init-opensearch-sessions)
 update-opensearch:
 		(go build; doppler run -- ./backend -runtime=worker -worker-handler=update-opensearch)
 start-metric-monitor-watch:

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -993,6 +993,24 @@ func (w *Worker) UpdateOpenSearchIndex() {
 	}
 }
 
+func (w *Worker) InitializeOpenSearchSessions() {
+	w.InitIndexMappings()
+	w.IndexSessions(false)
+
+	// Close the indexer channel and flush remaining items
+	if err := w.Resolver.OpenSearch.Close(); err != nil {
+		log.Fatalf("OPENSEARCH_ERROR unexpected error while closing OpenSearch client: %+v", err)
+	}
+
+	// Report the indexer statistics
+	stats := w.Resolver.OpenSearch.BulkIndexer.Stats()
+	if stats.NumFailed > 0 {
+		log.Errorf("Indexed [%d] documents with [%d] errors", stats.NumFlushed, stats.NumFailed)
+	} else {
+		log.Infof("Successfully indexed [%d] documents", stats.NumFlushed)
+	}
+}
+
 func (w *Worker) InitializeOpenSearchIndex() {
 	w.InitIndexMappings()
 	w.IndexTable(opensearch.IndexFields, &model.Field{}, false)
@@ -1115,6 +1133,8 @@ func (w *Worker) GetHandler(handlerFlag string) func() {
 		return w.ReportStripeUsage
 	case "init-opensearch":
 		return w.InitializeOpenSearchIndex
+	case "init-opensearch-sessions":
+		return w.InitializeOpenSearchSessions
 	case "update-opensearch":
 		return w.UpdateOpenSearchIndex
 	case "metric-monitors":


### PR DESCRIPTION
- there were two sessions with >65536 fields, which hit a postgres limit and caused reindexing to fail
- want to rerun session indexing again, don't want to wait for the others
- could probably extend the job runner thing to take extra arguments as inputs
