### PR TITLE
[HIG-2555] replace clientjs fingerprints with fingerprintjs

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,7 @@
         "typescript": "^4.1.3"
     },
     "dependencies": {
-        "@fingerprintjs/fingerprintjs": "^3.3.4",
+        "@highlight-run/fingerprintjs": "^3.3.5",
         "@highlight-run/rrweb": "2.1.7",
         "@rollup/plugin-commonjs": "^22.0.1",
         "@rollup/plugin-json": "^4.1.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -914,13 +914,6 @@
     readable-stream "^3.4.0"
     send "^0.17.1"
 
-"@fingerprintjs/fingerprintjs@^3.3.4":
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs/-/fingerprintjs-3.3.4.tgz#5d65fe0ab7220195c436851d02b02f92ac3b5bec"
-  integrity sha512-px1imhVDAEp0pI7LBcsUYAMlGsJZxReXVsJbla6e1+hSePZU7oPEtauyGhJH0cSXrQS5w/uhu5btmltkUgvUTw==
-  dependencies:
-    tslib "^2.0.1"
-
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -1399,6 +1392,13 @@
   integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
   dependencies:
     "@hapi/hoek" "^9.0.0"
+
+"@highlight-run/fingerprintjs@^3.3.5":
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/@highlight-run/fingerprintjs/-/fingerprintjs-3.3.5.tgz#24804848c1f9f8436e20f47895d12cd7672af9f2"
+  integrity sha512-y8sB4onoaqoIz7LXDSSL/Npdh4IB8PXAOe9WarxS8r0NYzntuN5SSoVUCPCJ5SrzWtp3eUOaWFR5d2xtgbpJbQ==
+  dependencies:
+    tslib "^2.0.1"
 
 "@highlight-run/rrdom@0.1.17":
   version "0.1.17"


### PR DESCRIPTION
ClientJS `getFingerprint` blocks electron apps UI with a long task. I can reproduce this locally even with a very small electron app. 
Now uses [@highlight-run/fingerprintjs](https://github.com/highlight-run/fingerprintjs), [forked and modified](https://github.com/highlight-run/fingerprintjs/commit/e2704c38d0789549c1ac08d70c377bc012b0eb0d) to allow excluding a set of entropy sources.
I found that certain entropy sources (fonts, canvas, screen size) were very slow (order of seconds blocking the main thread).
I've disabled all that were slow enough to block the UI.

before (long-running task blocks UI render)
![image](https://user-images.githubusercontent.com/1351531/183474473-13808c87-c4e5-444e-a8ab-f2dea8289bab.png)

after (no blocking occurs)
![image](https://user-images.githubusercontent.com/1351531/183533836-d658a134-2422-4991-97c8-aacada32a10e.png)
