### PR TITLE
Re-enable backfilling for non-Highlight sessions

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1383,8 +1383,7 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionID int, userI
 		return e.Wrap(err, "[IdentifySession] failed to update session")
 	}
 
-	highlightSession := session.ProjectID == 1
-	if highlightSession && !backfill && len(session.ClientID) > 0 {
+	if !backfill && len(session.ClientID) > 0 {
 		// Find past unidentified sessions and identify them.
 		backfillSessions := []*model.Session{}
 		if err := r.DB.Where(&model.Session{ClientID: session.ClientID, ProjectID: session.ProjectID, Identifier: "", Identified: false}).Not(&model.Session{Model: model.Model{ID: sessionID}}).Find(&backfillSessions).Error; err != nil {


### PR DESCRIPTION
We had to disable this because of some performance issues. [Some recent performance work](https://github.com/highlight-run/highlight/pull/2852) in this area makes me think this will be alright to turn on again. We also have [better visibility](https://github.com/highlight-run/highlight/pull/2834) into where the slowness is now when identifying sessions, so we can troubleshoot more effectively if this ends up being problematic in production.