### PR TITLE
Put landing/exist pages into session fields

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -759,7 +759,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 		"exit_page":    visitFields[len(visitFields)-1].Value,
 	}
 	if err := w.PublicResolver.AppendProperties(ctx, s.ID, sessionProperties, pubgraph.PropertyType.SESSION); err != nil {
-		log.Error(e.Wrapf(err, "[processSession] error appending properties for session %d"), s.ID)
+		log.Error(e.Wrapf(err, "[processSession] error appending properties for session %d", s.ID))
 	}
 
 	// Update session count on dailydb


### PR DESCRIPTION
#2815 introduced the `landing_page` and `exit_page` filters, but after looking at some data in production I'm seeing I made a mistake moving those properties be stored on the session document in OpenSearch rather than as a field on the session. The fields are what populate the options you can select in search, and it's also what we're trying to query against when the filter is applied.

This PR moves those properties back into fields on the sessions.

My bad, this was working for me locally because I had a bunch of sessions where I had called `AppendProperties` with landing/exit page values, so I missed it the first time around.