### PR TITLE
bugfix(HIG-2552): add env to metadata log and backfill mappings

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -27,7 +27,7 @@ import (
 	"github.com/highlight-run/highlight/backend/apolloio"
 	"github.com/highlight-run/highlight/backend/hlog"
 	"github.com/highlight-run/highlight/backend/model"
-	"github.com/highlight-run/highlight/backend/object-storage"
+	storage "github.com/highlight-run/highlight/backend/object-storage"
 	"github.com/highlight-run/highlight/backend/opensearch"
 	"github.com/highlight-run/highlight/backend/pricing"
 	"github.com/highlight-run/highlight/backend/private-graph/graph/generated"
@@ -147,6 +147,7 @@ func (r *errorGroupResolver) MetadataLog(ctx context.Context, obj *model.ErrorGr
 			e.url AS visited_url,
 			s.fingerprint AS fingerprint,
 			s.identifier AS identifier,
+			s.environment,
 			s.user_properties,
 			e.request_id
 		FROM sessions AS s

--- a/scripts/migrations/environment_error_field_to_group.sql
+++ b/scripts/migrations/environment_error_field_to_group.sql
@@ -1,0 +1,28 @@
+WITH eg_id_to_env as (
+    SELECT id AS error_group_id,
+        jsonb_object_keys(environments::jsonb) AS env
+    FROM error_groups
+    WHERE environments IS NOT NULL
+),
+env_fields AS (
+    SELECT id AS error_field_id,
+        value AS env
+    FROM error_fields
+    WHERE name = 'environment'
+),
+ef_to_eg AS (
+    SELECT DISTINCT error_field_id,
+        error_group_id
+    FROM env_fields
+        JOIN eg_id_to_env ON env_fields.env = eg_id_to_env.env
+)
+INSERT INTO error_group_fields (error_field_id, error_group_id)
+SELECT error_field_id,
+    error_group_id
+FROM ef_to_eg
+WHERE NOT EXISTS (
+        SELECT *
+        FROM error_group_fields egf
+        WHERE egf.error_field_id = ef_to_eg.error_field_id
+            AND egf.error_group_id = ef_to_eg.error_group_id
+    )


### PR DESCRIPTION
Makes sure that:
* session cards in the error pane show the actual environment
  <img width="1099" alt="Screen Shot 2022-08-08 at 9 05 13 PM" src="https://user-images.githubusercontent.com/17913919/183547666-b7515014-a314-44b5-ba30-8708d0f2f4e0.png">
* error group fields contain the info about envs in error objects after the previous migration

<img width="405" alt="Screen Shot 2022-08-08 at 9 08 16 PM" src="https://user-images.githubusercontent.com/17913919/183547969-2bebc8c0-2c1b-4b26-8e53-365bff3027d2.png">

