### PR TITLE
update influx bucket retention

### DIFF
--- a/backend/migrations/cmd/influxdb-update-prod-bucket-retention/main.go
+++ b/backend/migrations/cmd/influxdb-update-prod-bucket-retention/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/highlight-run/highlight/backend/timeseries"
+	"github.com/influxdata/influxdb-client-go/v2/api"
+	"github.com/influxdata/influxdb-client-go/v2/domain"
+	log "github.com/sirupsen/logrus"
+	"strings"
+	"time"
+)
+
+func main() {
+	log.Info("setting up db")
+	tdb := timeseries.New()
+	log.Info("done setting up db")
+
+	offset := 0
+	for true {
+		buckets, _ := tdb.Client.BucketsAPI().GetBuckets(context.Background(), api.PagingWithOffset(offset))
+		if buckets == nil || len(*buckets) == 0 {
+			break
+		}
+		offset += len(*buckets)
+		for _, b := range *buckets {
+			if strings.HasPrefix(b.Name, "prod-") {
+				if !strings.HasSuffix(b.Name, "downsampled") {
+					fmt.Println(b.Name)
+					b.RetentionRules = []domain.RetentionRule{{
+						// short metric expiry for granular data since we will only store downsampled data long term
+						EverySeconds: int64((60 * time.Minute).Seconds()),
+						Type:         domain.RetentionRuleTypeExpire,
+					}}
+					_, _ = tdb.Client.BucketsAPI().UpdateBucket(context.Background(), &b)
+				}
+			}
+		}
+	}
+
+	tdb.Stop()
+}


### PR DESCRIPTION
now that downsampling tasks are working, update the
main incoming data retention to reduce influx costs.