### PR TITLE
Setup pgclirc and first named query

### DIFF
--- a/pgclirc
+++ b/pgclirc
@@ -1,0 +1,10 @@
+# Named queries are queries you can execute by name.
+[named queries]
+find_blocking_queries = '''SELECT
+    activity.pid,
+    activity.usename,
+    activity.query,
+    blocking.pid AS blocking_id,
+    blocking.query AS blocking_query
+FROM pg_stat_activity AS activity
+JOIN pg_stat_activity AS blocking ON blocking.pid = ANY(pg_blocking_pids(activity.pid))'''

--- a/scripts/db-prod-access.sh
+++ b/scripts/db-prod-access.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-doppler run -c prod_aws --command "PGPASSWORD=\$PSQL_PASSWORD pgcli --auto-vertical-output -h \$PSQL_HOST -U \$PSQL_USER \$PSQL_DB"
+doppler run -c prod_aws --command "PGPASSWORD=\$PSQL_PASSWORD pgcli --pgclirc=./pgclirc --auto-vertical-output -h \$PSQL_HOST -U \$PSQL_USER \$PSQL_DB"


### PR DESCRIPTION
Adds a `pgclirc` configuration file for pgcli and a named query for finding blocking queries.

Here is what I see with this locally:

```sh
➜  highlight git:(pgcli-named-queries) ./scripts/db-prod-access.sh
Server: PostgreSQL 13.4
Version: 3.4.1
Home: http://pgcli.com
postgres@database-1:postgres> \n
-[ RECORD 1 ]-------------------------
Name  | find_blocking_queries
Query | SELECT
    activity.pid,
    activity.usename,
    activity.query,
    blocking.pid AS blocking_id,
    blocking.query AS blocking_query
FROM pg_stat_activity AS activity
JOIN pg_stat_activity AS blocking ON blocking.pid = ANY(pg_blocking_pids(activity.pid))
```