### PR TITLE
Revert "[HIG-2541] exclude sessions with no user activity (#2851)"

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -583,11 +583,6 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 		log.Error(e.Wrap(err, "error deleting outdated session intervals"))
 	}
 
-	if len(userInteractionEvents) == 0 {
-		log.WithFields(log.Fields{"session_id": s.ID, "project_id": s.ProjectID}).Infof("excluding session due to no user interaction events")
-		return w.excludeSession(ctx, s)
-	}
-
 	userInteractionEvents = append(userInteractionEvents, []*parse.ReplayEvent{{
 		Timestamp: accumulator.FirstEventTimestamp,
 	}, {


### PR DESCRIPTION
This reverts commit 3a2530331582ec879bd0ddeea1ad323c294686a7.
Reverting until we can validate our logic for finding user events is correct to ensure we aren't missing sessions with real activity.