### PR TITLE
[HIG-2541] exclude sessions with no user activity

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -583,6 +583,11 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 		log.Error(e.Wrap(err, "error deleting outdated session intervals"))
 	}
 
+	if len(userInteractionEvents) == 0 {
+		log.WithFields(log.Fields{"session_id": s.ID, "project_id": s.ProjectID}).Infof("excluding session due to no user interaction events")
+		return w.excludeSession(ctx, s)
+	}
+
 	userInteractionEvents = append(userInteractionEvents, []*parse.ReplayEvent{{
 		Timestamp: accumulator.FirstEventTimestamp,
 	}, {


### PR DESCRIPTION
Brings back changes to exclude sessions with no user activity
since they were correctly excluding sessions.

This reverts commit 15c64c8974c90f8ce6776d7914d3b8d92965326e.