### PR TITLE
merge user properties from multiple `H.identify` calls

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1142,7 +1142,7 @@ func InitializeSessionMinimal(ctx context.Context, r *mutationResolver, projectV
 			return nil, e.Wrap(err, fmt.Sprintf("error creating session, user agent: %s", userAgent))
 		}
 		// otherwise, it's a retry for a session that already exists. return the existing session.
-		log.Warnf("returning existing session for duplicate secure id %s: %d", *sessionSecureID, session.ID)
+		log.Warnf("returning existing session for duplicate secure id %s: %d", *sessionSecureID, sessionObj.ID)
 		return sessionObj, nil
 	}
 


### PR DESCRIPTION
When H.identify is called more than once (eg. an explicit call and segment integration),
we want to merge the properties and ensure the new user alert is fired with a union of all properties.
subsequent `H.identify` calls with the same property key but different value will replace the previous value.
Because `H.identify` calls are processed serially as kafka messages, there can be no race conditions for
reading/updating/writing the user properties since each message for a partition (based on sessionID) is processed serially.

Testing: calling `H.identify` with a new username multiple times with different properties

before:
![image](https://user-images.githubusercontent.com/1351531/184262594-4c2e37ad-a7d7-40b2-889e-7540ba8a4d80.png)

after:
![image](https://user-images.githubusercontent.com/1351531/184262623-18c513b6-163f-442e-9cdd-2433708e086a.png)
