### PR TITLE
fix(HIG-2586): show right panel with left panel open on small screens

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/utils/usePlayerConfiguration.tsx
+++ b/frontend/src/pages/Player/PlayerHook/utils/usePlayerConfiguration.tsx
@@ -1,6 +1,5 @@
 import useLocalStorage from '@rehooks/local-storage';
-import { useEffect, useMemo } from 'react';
-import { useWindowSize } from 'react-use';
+import { useMemo } from 'react';
 
 import { DevToolTabType } from '../../Toolbar/DevToolsContext/DevToolsContext';
 import { EventsForTimeline } from '.';
@@ -78,16 +77,6 @@ const usePlayerConfiguration = () => {
     const showDetailedSessionView = useMemo(() => _showDetailedSessionView, [
         _showDetailedSessionView,
     ]);
-
-    const { width } = useWindowSize();
-
-    useEffect(() => {
-        if (showLeftPanel && width <= 1300) {
-            setShowRightPanel(false);
-        } else if (width <= 840) {
-            setShowRightPanel(false);
-        }
-    }, [setShowRightPanel, showLeftPanel, width]);
 
     return {
         showLeftPanel,

--- a/frontend/src/pages/Player/RightPlayerPanel/RightPlayerPanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/RightPlayerPanel.tsx
@@ -4,6 +4,7 @@ import { PlayerSearchParameters } from '@pages/Player/PlayerHook/utils';
 import { useGlobalContext } from '@routers/OrgRouter/context/GlobalContext';
 import classNames from 'classnames';
 import React, { useEffect } from 'react';
+import { useWindowSize } from 'react-use';
 
 import Tabs from '../../../components/Tabs/Tabs';
 import PanelToggleButton from '../components/PanelToggleButton/PanelToggleButton';
@@ -19,13 +20,23 @@ import styles from './RightPlayerPanel.module.scss';
 const RightPlayerPanel = React.memo(() => {
     const {
         showRightPanel: showRightPanelPreference,
+        showLeftPanel,
         setShowRightPanel,
+        setShowLeftPanel,
     } = usePlayerConfiguration();
     const { showBanner } = useGlobalContext();
     const { canViewSession } = useReplayerContext();
     const { setSelectedRightPanelTab, detailedPanel } = usePlayerUIContext();
 
     const showRightPanel = showRightPanelPreference && canViewSession;
+
+    const { width } = useWindowSize();
+
+    useEffect(() => {
+        if (showRightPanel && showLeftPanel && width <= 1300) {
+            setShowRightPanel(false);
+        }
+    }, [setShowRightPanel, showLeftPanel, showRightPanel, width]);
 
     useEffect(() => {
         const commentId = new URLSearchParams(location.search).get(
@@ -57,7 +68,11 @@ const RightPlayerPanel = React.memo(() => {
                     direction="right"
                     isOpen={showRightPanel}
                     onClick={() => {
-                        setShowRightPanel(!showRightPanel);
+                        const isOpen = !showRightPanel;
+                        if (isOpen && width <= 1300) {
+                            setShowLeftPanel(false);
+                        }
+                        setShowRightPanel(isOpen);
                     }}
                 />
                 {showRightPanel && (


### PR DESCRIPTION
At the moment we have a useEffect that forbids opening the right pane on small screens.
This PR adds logic that (a) first tries to hide the right pane if both left and right panels are open on a small screen, and (b) hides the left pane if a visitor still tries to open the right panel.