### PR TITLE
fix(HIG-2593): show enriched data only if there is sth of substance to render

### DIFF
--- a/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
+++ b/frontend/src/pages/Player/MetadataBox/MetadataBox.tsx
@@ -390,7 +390,7 @@ const hasEnrichedData = (enhancedData?: GetEnhancedUserDetailsQuery) => {
             enhanced_user_details?.avatar !== '') ||
         (!!enhanced_user_details?.bio && enhanced_user_details?.bio !== '') ||
         (!!enhanced_user_details?.name && enhanced_user_details?.name !== '') ||
-        enhanced_user_details?.socials?.length ||
+        hasDiverseSocialLinks(enhancedData) ||
         0 > 0
     );
 };


### PR DESCRIPTION
Following HIG-2583, we have changed the logic about rendering social links. 