### PR TITLE
[HIG-2604] advisory lock around CREATE TABLE

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1122,20 +1122,6 @@ func (w *Worker) RefreshMaterializedViews() {
 	}); err != nil {
 		log.Fatal(e.Wrap(err, "Error refreshing daily_session_counts_view"))
 	}
-
-	if err := w.Resolver.DB.Transaction(func(tx *gorm.DB) error {
-		err := tx.Exec(fmt.Sprintf("SET LOCAL statement_timeout TO %d", REFRESH_MATERIALIZED_VIEW_TIMEOUT)).Error
-		if err != nil {
-			return err
-		}
-
-		return tx.Exec(`
-			REFRESH MATERIALIZED VIEW CONCURRENTLY fields_in_use_view;
-		`).Error
-
-	}); err != nil {
-		log.Fatal(e.Wrap(err, "Error refreshing fields_in_use_view"))
-	}
 }
 
 func (w *Worker) BackfillStackFrames() {


### PR DESCRIPTION
- clean up old references to `fields_in_use_view` (not used anymore)
- wrap `CREATE TABLE events_objects_partitioned_%d` with `pg_try_advisory_xact_lock`
  - if lock is acquired, the acquiring transaction is able to create this partition
  - if the lock is not acquired, this statement will be skipped. this is ok because the partition to be created is 1 million ids away
<img width="1074" alt="Screen Shot 2022-08-18 at 10 28 02 AM" src="https://user-images.githubusercontent.com/86132398/185458489-6a8199d5-fda0-4e9c-93d1-0314a45dfcc9.png">
 