### PR TITLE
Fix histogram tooltips

### DIFF
--- a/frontend/src/components/Histogram/Histogram.tsx
+++ b/frontend/src/components/Histogram/Histogram.tsx
@@ -217,7 +217,6 @@ const Histogram = React.memo(
                                         visibility: tooltipHidden
                                             ? 'hidden'
                                             : 'visible',
-                                        scale: 1,
                                         pointerEvents: 'inherit',
                                     }}
                                     cursor={{


### PR DESCRIPTION
The tooltip never shows up without this change, and shows up correctly with this change.

I'm not completely sure why this matters, but I think it's related to the fact that recharts has its own mechanism for showing/hiding the tooltip that we seem to be fighting with. The visibility 'hidden' vs 'visible' thing seems to be used by at least some people though based on https://github.com/recharts/recharts/issues/791.