### PR TITLE
[HIG-2616] fix auto join workspaces

### DIFF
--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -6272,6 +6272,9 @@ export const GetWorkspacesDocument = gql`
         joinable_workspaces {
             id
             name
+            projects {
+                id
+            }
         }
     }
 `;
@@ -6529,6 +6532,9 @@ export const GetProjectDropdownOptionsDocument = gql`
         joinable_workspaces {
             id
             name
+            projects {
+                id
+            }
         }
     }
 `;
@@ -6598,6 +6604,9 @@ export const GetWorkspaceDropdownOptionsDocument = gql`
         joinable_workspaces {
             id
             name
+            projects {
+                id
+            }
         }
     }
 `;

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2426,7 +2426,16 @@ export type GetWorkspacesQuery = { __typename?: 'Query' } & {
                 { __typename?: 'Workspace' } & Pick<
                     Types.Workspace,
                     'id' | 'name'
-                >
+                > & {
+                        projects: Array<
+                            Types.Maybe<
+                                { __typename?: 'Project' } & Pick<
+                                    Types.Project,
+                                    'id'
+                                >
+                            >
+                        >;
+                    }
             >
         >
     >;
@@ -2527,7 +2536,16 @@ export type GetProjectDropdownOptionsQuery = { __typename?: 'Query' } & {
                 { __typename?: 'Workspace' } & Pick<
                     Types.Workspace,
                     'id' | 'name'
-                >
+                > & {
+                        projects: Array<
+                            Types.Maybe<
+                                { __typename?: 'Project' } & Pick<
+                                    Types.Project,
+                                    'id'
+                                >
+                            >
+                        >;
+                    }
             >
         >
     >;
@@ -2566,7 +2584,16 @@ export type GetWorkspaceDropdownOptionsQuery = { __typename?: 'Query' } & {
                 { __typename?: 'Workspace' } & Pick<
                     Types.Workspace,
                     'id' | 'name'
-                >
+                > & {
+                        projects: Array<
+                            Types.Maybe<
+                                { __typename?: 'Project' } & Pick<
+                                    Types.Project,
+                                    'id'
+                                >
+                            >
+                        >;
+                    }
             >
         >
     >;

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -663,6 +663,9 @@ query GetWorkspaces {
     joinable_workspaces {
         id
         name
+        projects {
+            id
+        }
     }
 }
 
@@ -721,6 +724,9 @@ query GetProjectDropdownOptions($project_id: ID!) {
     joinable_workspaces {
         id
         name
+        projects {
+            id
+        }
     }
 }
 
@@ -740,6 +746,9 @@ query GetWorkspaceDropdownOptions($workspace_id: ID!) {
     joinable_workspaces {
         id
         name
+        projects {
+            id
+        }
     }
 }
 

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -189,11 +189,13 @@ const NewProjectPage = () => {
                                 type="default"
                             >
                                 Already Have a Workspace?{' '}
-                                {!loading && !!data && (
-                                    <Dot className={styles.workspaceCount}>
-                                        {data.workspaces_count}
-                                    </Dot>
-                                )}
+                                {!loading &&
+                                    !!data &&
+                                    data.workspaces_count !== 0 && (
+                                        <Dot className={styles.workspaceCount}>
+                                            {data.workspaces_count}
+                                        </Dot>
+                                    )}
                             </ButtonLink>
                         )}
                         {!isWorkspace &&

--- a/frontend/src/routers/OrgRouter/OrgRouter.tsx
+++ b/frontend/src/routers/OrgRouter/OrgRouter.tsx
@@ -323,7 +323,7 @@ export const ProjectRouter = () => {
 
     // if the user can join this workspace, give them that option via the ErrorState
     const joinableWorkspace = data?.joinable_workspaces
-        ?.filter((w) => w?.id === data?.workspace?.id)
+        ?.filter((w) => w?.projects.map((p) => p?.id).includes(project_id))
         ?.pop();
 
     return (


### PR DESCRIPTION
- load project ids for joinable workspaces and compare against the project id from the URL
  - fixes an issue where `workspace.id` was undefined if the user was not yet added to the workspace
- hide the (0) notification in the workspace selector if there are no joinable workspaces