### PR TITLE
create custom role column on workspace<->admin relationship

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -151,6 +151,7 @@ var Models = []interface{}{
 	&Project{},
 	&RageClickEvent{},
 	&Workspace{},
+	&WorkspaceAdmin{},
 	&WorkspaceInviteLink{},
 	&WorkspaceAccessRequest{},
 	&EnhancedUserDetails{},
@@ -233,6 +234,15 @@ type Workspace struct {
 	EligibleForTrialExtension   bool       `gorm:"default:false"`
 	TrialExtensionEnabled       bool       `gorm:"default:false"`
 	ClearbitEnabled             bool       `gorm:"default:false"`
+}
+
+type WorkspaceAdmin struct {
+	AdminID     int        `gorm:"primaryKey"`
+	WorkspaceID int        `gorm:"primaryKey"`
+	CreatedAt   time.Time  `json:"created_at" deep:"-"`
+	UpdatedAt   time.Time  `json:"updated_at" deep:"-"`
+	DeletedAt   *time.Time `json:"deleted_at" deep:"-"`
+	Role        *string    `json:"role" gorm:"default:ADMIN"`
 }
 
 type WorkspaceInviteLink struct {


### PR DESCRIPTION
Rollout in multiple phases:
1. release the new `workspace_admins` model change
2. migrate role data manually in production
3. release the code changes to reference new role

this change accomplishes #1.