### PR TITLE
convert @highlight-run/sourcemap-uploader to ESM

### DIFF
--- a/sourcemap-uploader/index.js
+++ b/sourcemap-uploader/index.js
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
-const { join, basename } = require("path");
-const { cwd } = require("process");
-const yargs = require("yargs/yargs");
-const { hideBin } = require("yargs/helpers");
-const { statSync, readFileSync } = require("fs");
-const glob = require("glob");
-const AWS = require("aws-sdk");
-const fetch = require("node-fetch");
+import { basename, join } from "path";
+import { cwd } from "process";
+import yargs from "yargs/yargs";
+import { hideBin } from "yargs/helpers";
+import { readFileSync, statSync } from "fs";
+import glob from "glob";
+import AWS from "aws-sdk";
+import fetch from "node-fetch";
+import { default as pjson } from "./package.json" assert { type: "json" };
 
 const VERIFY_API_KEY_QUERY = `
   query ApiKeyToOrgID($api_key: String!) {
@@ -22,7 +23,6 @@ const s3 = new AWS.S3({
   secretAccessKey: "gu/8lcujPd3SEBa2FJHT9Pd4N/5Mm8LA6IbnWBw/",
 });
 
-var pjson = require("./package.json");
 console.log("Running version: ", pjson.version);
 
 yargs(hideBin(process.argv))
@@ -61,7 +61,7 @@ yargs(hideBin(process.argv))
         throw new Error("invalid api key");
       }
 
-      organizationId = res.data.api_key_to_org_id;
+      let organizationId = res.data.api_key_to_org_id;
 
       console.info(`Starting to upload source maps from ${path}`);
 
@@ -149,7 +149,7 @@ async function uploadFile(organizationId, version, filePath, fileName) {
     Body: fileContent,
   };
 
-  s3.upload(params, function (err, data) {
+  s3.upload(params, function (err) {
     if (err) {
       throw err;
     }

--- a/sourcemap-uploader/package.json
+++ b/sourcemap-uploader/package.json
@@ -1,8 +1,10 @@
 {
   "name": "@highlight-run/sourcemap-uploader",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Command line tool to upload source maps to Highlight",
   "main": "index.js",
+  "module": "index.js",
+  "type": "module",
   "author": "Highlight",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
update required for node-fetch security vulnerability fix in v3 which
does not support CJS.

Testing: local invocation
```shell
 ~/w/h/sourcemap-uploader   vadim/hig-2623-fix-highlight-runsourcemap-uploader-node ±  npx --yes . upload --apiKey c87gehq6id334k4apnhg
(node:19290) ExperimentalWarning: Importing JSON modules is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Running version:  0.2.0
Starting to upload source maps from /build
Uploaded foo.map.js
```