### PR TITLE
reduce worker unprocessed session reporting

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1445,7 +1445,9 @@ func processEventChunk(a EventProcessingAccumulator, eventsChunk model.EventsObj
 func reportProcessSessionCount(db *gorm.DB, lookbackPeriod, lockPeriod int) {
 	defer util.Recover()
 	for {
-		time.Sleep(5 * time.Second)
+		// sleep between 30s and 60s to ensure lots of worker containers do not cause
+		// db contention running this same query
+		time.Sleep(30*time.Second + time.Duration(30*float64(time.Second.Nanoseconds())*rand.Float64()))
 		var count int64
 		if err := db.Raw(`
 			SELECT COUNT(*)


### PR DESCRIPTION
lots of worker threads running the query cause a lot of
db buffermapping blocking. reduce concurrent running of this query
by spreading out the reporting over a random interval.

recently the top source of db contention has been this query
![image](https://user-images.githubusercontent.com/1351531/186209444-7a41a0a5-8547-4532-809f-3bc47dd5c6a8.png)
