### PR TITLE
ensure kafka message ordering

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -138,7 +138,7 @@ func New(topic string, mode Mode) *Queue {
 			},
 			Topic:        pool.Topic,
 			Balancer:     &kafka.Hash{},
-			RequiredAcks: kafka.RequireOne,
+			RequiredAcks: kafka.RequireAll,
 			Compression:  kafka.Zstd,
 			// synchronous mode so that we can ensure messages are sent before we return
 			Async: false,

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1695,7 +1695,7 @@ func (r *Resolver) SubmitMetricsMessage(ctx context.Context, metrics []*customMo
 				SessionID: session.ID,
 				ProjectID: session.ProjectID,
 				Metrics:   metrics,
-			}}, strconv.Itoa(session.ID))
+			}}, secureID)
 		if err != nil {
 			log.Error(err)
 		}

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -6,7 +6,6 @@ package graph
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/DmitriyVTitov/size"
@@ -140,7 +139,7 @@ func (r *mutationResolver) PushBackendPayload(ctx context.Context, errors []*cus
 			PushBackendPayload: &kafkaqueue.PushBackendPayloadArgs{
 				SessionSecureID: backendError.SessionSecureID,
 				Errors:          errors,
-			}}, strconv.Itoa(session.ID))
+			}}, backendError.SessionSecureID)
 		if err != nil {
 			log.Error(e.Wrapf(err, "failed to send kafka message for push backend payload %s", backendError.SessionSecureID))
 			continue
@@ -164,7 +163,7 @@ func (r *mutationResolver) MarkBackendSetup(ctx context.Context, sessionSecureID
 		Type: kafkaqueue.MarkBackendSetup,
 		MarkBackendSetup: &kafkaqueue.MarkBackendSetupArgs{
 			ProjectID: session.ProjectID,
-		}}, strconv.Itoa(session.ID))
+		}}, sessionSecureID)
 	return session.ProjectID, err
 }
 


### PR DESCRIPTION
since ordering strictly matters with async initializeSession,
we need to ensure messages in a partition are ordered correctly.
turns out this isn't always the case when the producer is configured as `AcksOne`