### PR TITLE
drop solitaired payloads after kafka

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1987,6 +1987,15 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionID int, events cus
 	querySessionSpan.SetTag("project_id", sessionObj.ProjectID)
 	querySessionSpan.Finish()
 
+	// we must drop solitaired payloads after kafka because
+	// before kafka, the session object is not yet created and
+	// we have no way to find out if a push payload is for solitaired
+	if sessionObj.ProjectID == 1074 && sessionObj.ID%10 != 0 {
+		// Ingest 10% of Solitaired payloads
+		// Drop solitaired payloads because they are causing ingestion issues
+		return nil
+	}
+
 	// If the session is processing or processed, set ResumedAfterProcessedTime and continue
 	if (sessionObj.Lock.Valid && !sessionObj.Lock.Time.IsZero()) || (sessionObj.Processed != nil && *sessionObj.Processed) {
 		if sessionObj.ResumedAfterProcessedTime == nil {

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -96,16 +96,6 @@ func (r *mutationResolver) AddSessionProperties(ctx context.Context, sessionSecu
 
 // PushPayload is the resolver for the pushPayload field.
 func (r *mutationResolver) PushPayload(ctx context.Context, sessionSecureID string, events customModels.ReplayEventsInput, messages string, resources string, errors []*customModels.ErrorObjectInput, isBeacon *bool, hasSessionUnloaded *bool, highlightLogs *string, payloadID *int) (int, error) {
-	sessionObj := &model.Session{}
-	if err := r.DB.Select("project_id", "id").Where(&model.Session{SecureID: sessionSecureID}).First(&sessionObj).Error; err != nil {
-		// No return because I don't want to change existing behavior - can handle the error the usual way after worker reads from Kafka
-		log.Error(e.Wrapf(err, "PushPayload couldn't find session with secureID %s", sessionSecureID))
-	}
-	if sessionObj.ProjectID == 1074 && sessionObj.ID%10 != 0 { // Ingest 10% of Solitaired payloads
-		// Drop solitaired payloads because they are causing ingestion issues
-		return size.Of(events), nil
-	}
-
 	if payloadID == nil {
 		payloadID = pointy.Int(0)
 	}


### PR DESCRIPTION
we must drop solitaired payloads after kafka because the session object is not yet created before kafka
and we have no way to find out if a push payload is for solitaired.
we have seen kafka been fine with the amount of data from solitaired
so I am not too concerned about the size/cpu limitations of the cluster
with the new retention settings.

this change is required because of the new backend logic from https://github.com/highlight-run/highlight/pull/1974 that makes initializeSession asynchronous