### PR TITLE
limit solitaired sessions on the client side

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1987,15 +1987,6 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionID int, events cus
 	querySessionSpan.SetTag("project_id", sessionObj.ProjectID)
 	querySessionSpan.Finish()
 
-	// we must drop solitaired payloads after kafka because
-	// before kafka, the session object is not yet created and
-	// we have no way to find out if a push payload is for solitaired
-	if sessionObj.ProjectID == 1074 && sessionObj.ID%10 != 0 {
-		// Ingest 10% of Solitaired payloads
-		// Drop solitaired payloads because they are causing ingestion issues
-		return nil
-	}
-
 	// If the session is processing or processed, set ResumedAfterProcessedTime and continue
 	if (sessionObj.Lock.Valid && !sessionObj.Lock.Time.IsZero()) || (sessionObj.Processed != nil && *sessionObj.Processed) {
 		if sessionObj.ResumedAfterProcessedTime == nil {

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -459,6 +459,14 @@ export class Highlight {
             this._firstLoadListeners?.stopListening();
             return;
         }
+
+        if (this.organizationID === '6glrjqg9') {
+            if (Math.random() > 0.1) {
+                this._firstLoadListeners?.stopListening();
+                return;
+            }
+        }
+
         try {
             if (this.feedbackWidgetOptions.enabled) {
                 const {


### PR DESCRIPTION
in the current configuration, kafka is struggling to pipe the amount of bandwidth required
to filter all solitaired messages for push payload on the worker side.

this change moves the filtering logic to the client which will also reduce load on publicGraph.
limits solitaired sessions to 10% 