### PR TITLE
disable kafka log compaction

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -106,8 +106,8 @@ func New(topic string, mode Mode) *Queue {
 						Value: strconv.FormatInt((time.Hour * 6).Milliseconds(), 10),
 					},
 					{
-						Name:  "delete.retention.ms",
-						Value: strconv.FormatInt((time.Hour * 6).Milliseconds(), 10),
+						Name:  "cleanup.policy",
+						Value: "delete",
 					},
 				},
 			},


### PR DESCRIPTION
[as it turns out](https://hevodata.com/learn/kafka-log-compaction/#need), log compaction in kafka actually deletes old messages
that have another message with the same key after it. this does not work for our task use case since messages are
keyed by session_secure_id and a session has many messages.
