### PR TITLE
set session creation timestamp from graphql handler

### DIFF
--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -34,6 +34,7 @@ type PushPayloadArgs struct {
 
 type InitializeSessionArgs struct {
 	SessionSecureID                string
+	CreatedAt                      time.Time
 	ProjectVerboseID               string
 	EnableStrictPrivacy            bool
 	EnableRecordingNetworkContents bool

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -39,6 +39,7 @@ func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureI
 			Type: kafkaqueue.InitializeSession,
 			InitializeSession: &kafkaqueue.InitializeSessionArgs{
 				SessionSecureID:                sessionSecureID,
+				CreatedAt:                      time.Now(),
 				ProjectVerboseID:               organizationVerboseID,
 				EnableStrictPrivacy:            enableStrictPrivacy,
 				EnableRecordingNetworkContents: enableRecordingNetworkContents,


### PR DESCRIPTION
since session creation is asynchronous, we need to have the creation timestamp
come from the client graphql request rather than using the time we receive the message.
backwards compatible since the `model.Model` will
default to now if `CreatedAt` is zero.