### PR TITLE
set public-graph and worker ECS RAM @ 8GB

### DIFF
--- a/deploy/public-graph-task.json
+++ b/deploy/public-graph-task.json
@@ -276,7 +276,7 @@
     "pidMode": null,
     "requiresCompatibilities": ["FARGATE"],
     "networkMode": "awsvpc",
-    "cpu": "4096",
+    "cpu": "8192",
     "revision": 65,
     "status": "ACTIVE",
     "inferenceAccelerators": null,

--- a/deploy/worker-task.json
+++ b/deploy/worker-task.json
@@ -294,7 +294,7 @@
     "pidMode": null,
     "requiresCompatibilities": ["FARGATE"],
     "networkMode": "awsvpc",
-    "cpu": "4096",
+    "cpu": "8192",
     "revision": 40,
     "status": "ACTIVE",
     "inferenceAccelerators": null,


### PR DESCRIPTION
we're seeing a number of ECS containers OOMing more recently - public graph and worker
![image](https://user-images.githubusercontent.com/1351531/187288648-e0029c0c-b7ec-4dcb-9527-b3c346a6f818.png)
![image](https://user-images.githubusercontent.com/1351531/187288688-a1936a03-efd7-45e3-92bc-d69b33d6a786.png)

![image](https://user-images.githubusercontent.com/1351531/187288737-74699753-2fdb-4aa9-9ca1-f75e94679b9a.png)

to support larger canvas payloads going forward, we should increase the RAM available to both containers