### PR TITLE
improve performance of the session processing query

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -991,13 +991,12 @@ func (w *Worker) Start() {
 									LIMIT ?
 								) s
 								ORDER BY id
-							    LIMIT ?
 								FOR UPDATE SKIP LOCKED
 							)
 							RETURNING *
 						)
 						SELECT * FROM t;
-					`, payloadLookbackPeriod, lockPeriod, MAX_RETRIES, processSessionLimit, processSessionLimit). // why do we get payload_updated_at IS NULL?
+					`, payloadLookbackPeriod, lockPeriod, MAX_RETRIES, processSessionLimit). // why do we get payload_updated_at IS NULL?
 					Find(&sessions).Error; err != nil {
 					errs <- err
 					return


### PR DESCRIPTION
query now takes seconds rather than hours because it does not need to sort the entire unprocessed sessions list.
also adjusts the unprocessed sessions reporting which happens too frequently with many workers and causes unnecessary contention.
```
CTE Scan on t  (cost=12076.85..12096.85 rows=1000 width=1014) (actual time=220.481..1147.397 rows=1000 loops=1)
  CTE t
    ->  Update on sessions  (cost=3479.91..12076.85 rows=1000 width=42) (actual time=220.476..1144.704 rows=1000 loops=1)
          ->  Nested Loop  (cost=3479.91..12076.85 rows=1000 width=42) (actual time=218.383..226.854 rows=1000 loops=1)
                ->  HashAggregate  (cost=3479.35..3489.35 rows=1000 width=32) (actual time=218.364..219.192 rows=1000 loops=1)
                      Group Key: "ANY_subquery".id
                      Batches: 1  Memory Usage: 193kB
                      ->  Subquery Scan on "ANY_subquery"  (cost=3464.35..3476.85 rows=1000 width=32) (actual time=217.685..218.106 rows=1000 loops=1)
                            ->  Limit  (cost=3464.35..3466.85 rows=1000 width=4) (actual time=217.680..217.894 rows=1000 loops=1)
                                  ->  Sort  (cost=3464.35..3466.85 rows=1000 width=4) (actual time=217.679..217.810 rows=1000 loops=1)
                                        Sort Key: s.id
                                        Sort Method: quicksort  Memory: 71kB
                                        ->  Subquery Scan on s  (cost=0.56..3414.52 rows=1000 width=4) (actual time=27.599..217.388 rows=1000 loops=1)
                                              ->  Limit  (cost=0.56..3404.52 rows=1000 width=10) (actual time=27.598..217.253 rows=1000 loops=1)
                                                    ->  LockRows  (cost=0.56..311936.24 rows=91639 width=10) (actual time=27.598..217.152 rows=1000 loops=1)
                                                          ->  Index Scan using idx_sessions_reporting on sessions sessions_1  (cost=0.56..311019.85 rows=91639 width=10) (actual time=27.588..215.889 rows=1000 loops=1)
                                                                Index Cond: ((processed = false) AND (excluded = false))
                                                                Filter: ((COALESCE(retry_count, '0'::bigint) < 5) AND (COALESCE(payload_updated_at, '1970-01-01 00:00:00+00'::timestamp with time zone) < (now() - '00:00:16'::interval)) AND (COALESCE(lock, '1970-01-01 00:00:00+00'::timestamp with time zone) < (now() - '00:01:00'::interval)))
                ->  Index Scan using sessions_pkey on sessions  (cost=0.57..8.59 rows=1 width=10) (actual time=0.007..0.007 rows=1 loops=1000)
                      Index Cond: (id = "ANY_subquery".id)
Planning Time: 0.446 ms
Execution Time: 1147.693 ms
```