### PR TITLE
remove topic-based retention policies

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -101,10 +100,6 @@ func New(topic string, mode Mode) *Queue {
 				ResourceType: kafka.ResourceTypeTopic,
 				ResourceName: topic,
 				Configs: []kafka.AlterConfigRequestConfig{
-					{
-						Name:  "retention.ms",
-						Value: strconv.FormatInt((time.Hour * 6).Milliseconds(), 10),
-					},
 					{
 						Name:  "cleanup.policy",
 						Value: "delete",


### PR DESCRIPTION
easier to manage retention for the entire server because it is easier to adjust.
removing the topic-based policies so that the retention can be set server-side in terms of max bytes retention.