### PR TITLE
update session queries to not sort by id

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1264,7 +1264,7 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 func (r *Resolver) MarkBackendSetupImpl(sessionSecureID string, projectID int) error {
 	if projectID == 0 {
 		session := &model.Session{}
-		if err := r.DB.Model(&session).Where(&model.Session{SecureID: sessionSecureID}).First(&session).Error; err != nil {
+		if err := r.DB.Order("secure_id").Model(&session).Where(&model.Session{SecureID: sessionSecureID}).Find(&session).Error; err != nil || session.ID == 0 {
 			log.Error(e.Wrapf(err, "no session found for mark backend setup: %s", sessionSecureID))
 			return err
 		}
@@ -1411,7 +1411,7 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 	getSessionSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
 		tracer.ResourceName("go.sessions.IdentifySessionImpl.getSession"), tracer.Tag("sessionSecureID", sessionSecureID))
 	session := &model.Session{}
-	if err := r.DB.Where(&model.Session{SecureID: sessionSecureID}).First(&session).Error; err != nil {
+	if err := r.DB.Order("secure_id").Where(&model.Session{SecureID: sessionSecureID}).Find(&session).Error; err != nil || session.ID == 0 {
 		return e.Wrap(err, "[IdentifySession] error querying session by sessionID")
 	}
 	getSessionSpan.Finish()
@@ -1807,7 +1807,7 @@ func (r *Resolver) AddLegacyMetric(ctx context.Context, sessionID int, name stri
 func (r *Resolver) PushMetricsImpl(_ context.Context, sessionSecureID string, sessionID int, projectID int, metrics []*customModels.MetricInput) error {
 	if sessionID == 0 || projectID == 0 {
 		session := &model.Session{}
-		if err := r.DB.Model(&session).Where(&model.Session{SecureID: sessionSecureID}).First(&session).Error; err != nil {
+		if err := r.DB.Order("secure_id").Model(&session).Where(&model.Session{SecureID: sessionSecureID}).Find(&session).Error; err != nil || session.ID == 0 {
 			log.Error(e.Wrapf(err, "no session found for push metrics: %s", sessionSecureID))
 			return err
 		}


### PR DESCRIPTION
gorm adds an implicit `order by id` when `Find` is called