### PR TITLE
Revert "filter solitaired from worker query for now"

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -982,7 +982,6 @@ func (w *Worker) Start() {
 										AND (COALESCE(payload_updated_at, to_timestamp(0)) < NOW() - (? * INTERVAL '1 SECOND'))
 										AND (COALESCE(lock, to_timestamp(0)) < NOW() - (? * INTERVAL '1 MINUTE'))
 										AND (COALESCE(retry_count, 0) < ?)
-										AND project_id <> 1074
 									LIMIT ?
 								) s
 								ORDER BY id


### PR DESCRIPTION
Reverts highlight-run/highlight#2981

Don't think this is helping - events may be being dropped from Redis or this is because of existing Solitaired sessions before the `ProcessWithRedis` flag