### PR TITLE
try longer lock period

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -949,7 +949,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 func (w *Worker) Start() {
 	ctx := context.Background()
 	payloadLookbackPeriod := 60 // a session must be stale for at least this long to be processed
-	lockPeriod := 10            // time in minutes
+	lockPeriod := 30            // time in minutes
 
 	if util.IsDevEnv() {
 		payloadLookbackPeriod = 16


### PR DESCRIPTION
- lots of locking from this update query on other updates to `retry_count`, etc
- thinking this is caused when session processing takes > 10 mins from when the session was initially queried and cascades as locks make processing take longer