### PR TITLE
feat(hig-2612): color code warnings and asserts

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ConsolePage/ConsolePage.module.scss
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ConsolePage/ConsolePage.module.scss
@@ -40,7 +40,7 @@
 
 .consoleMessage {
     border-bottom: 1px solid var(--color-gray-300);
-    border-left: var(--size-xxSmall) solid var(--color-console-message);
+    border-left: var(--size-xxSmall) solid transparent;
     display: grid;
     font-size: 12px;
     font-weight: 400;
@@ -53,6 +53,14 @@
     &:hover .goToButton {
         visibility: visible;
     }
+}
+
+.consoleMessageWarn {
+    border-left-color: var(--color-yellow-300);
+}
+
+.consoleMessageAssert {
+    border-left-color: var(--color-red-400);
 }
 
 .directionIcon {

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ConsolePage/ConsolePage.module.scss.d.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ConsolePage/ConsolePage.module.scss.d.ts
@@ -3,6 +3,8 @@ export const closeIconWrapper: string;
 export const consoleButton: string;
 export const consoleButtonWrapper: string;
 export const consoleMessage: string;
+export const consoleMessageAssert: string;
+export const consoleMessageWarn: string;
 export const consolePageWrapper: string;
 export const consoleStreamWrapper: string;
 export const currentIndicator: string;

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ConsolePage/ConsolePage.tsx
@@ -6,6 +6,7 @@ import { useParams } from '@util/react-router/useParams';
 import { ConsoleMessage } from '@util/shared-types';
 import { MillisToMinutesAndSeconds } from '@util/time';
 import { message as AntDesignMessage } from 'antd';
+import classNames from 'classnames';
 import { H } from 'highlight.run';
 import _ from 'lodash';
 import React, {
@@ -279,17 +280,15 @@ export const ConsolePage = React.memo(({ time }: { time: number }) => {
                         itemContent={(_index, message: ParsedMessage) => (
                             <div key={message.id.toString()}>
                                 <div
-                                    className={styles.consoleMessage}
-                                    style={
+                                    className={classNames(
+                                        styles.consoleMessage,
                                         {
-                                            '--color-console-message':
-                                                message.type === 'warn'
-                                                    ? 'var(--color-yellow-300)'
-                                                    : message.type === 'assert'
-                                                    ? 'var(--color-red-400)'
-                                                    : 'transparent',
-                                        } as React.CSSProperties
-                                    }
+                                            [styles.consoleMessageWarn]:
+                                                message.type === 'warn',
+                                            [styles.consoleMessageAssert]:
+                                                message.type === 'assert',
+                                        }
+                                    )}
                                 >
                                     <Tooltip title="This is the last logged console message. This is based on the current session time.">
                                         <div


### PR DESCRIPTION
Adds color coding for the left border of console log records to highlight asserts and warnings (errors are filtered from the console tab):
<img width="908" alt="Screen Shot 2022-08-31 at 2 45 47 PM" src="https://user-images.githubusercontent.com/17913919/187790839-54c56f42-7b03-4c46-8751-c0bbb802f9b2.png">


[Gist](https://gist.github.com/aptlin/536f70241ab9929603d772c850d9b342) with data for local testing
