### PR TITLE
fix(hig-2640): fix metric values in alerts to 4sf

### DIFF
--- a/backend/jobs/metric-monitor/metric-monitor.go
+++ b/backend/jobs/metric-monitor/metric-monitor.go
@@ -3,13 +3,14 @@ package metric_monitor
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/highlight-run/highlight/backend/private-graph/graph"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/timeseries"
 	"github.com/openlyinc/pointy"
-	"os"
-	"strconv"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sendgrid/sendgrid-go"
@@ -18,6 +19,10 @@ import (
 	"github.com/highlight-run/highlight/backend/model"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
+)
+
+const (
+	sigFigs = 4
 )
 
 func WatchMetricMonitors(DB *gorm.DB, TDB timeseries.DB, MailClient *sendgrid.Client) {
@@ -86,16 +91,28 @@ func processMetricMonitors(DB *gorm.DB, TDB timeseries.DB, MailClient *sendgrid.
 				return
 			}
 
-			// This is to remove trailing 0
-			// Example: 0.00100 should only display 0.001.
-			valueWithNoTrailingZeroes := strconv.FormatFloat(value, 'f', -1, 64)
-			thresholdWithNoTrailingZeros := strconv.FormatFloat(metricMonitor.Threshold, 'f', -1, 64)
+			valueRepr := strconv.FormatFloat(value, 'g', sigFigs, 64)
+			thresholdRepr := strconv.FormatFloat(metricMonitor.Threshold, 'g', sigFigs, 64)
+			diffRepr := strconv.FormatFloat(value-metricMonitor.Threshold, 'g', sigFigs, 64)
 			unitsStr := ""
 			if metricMonitor.Units != nil {
 				unitsStr = *metricMonitor.Units
 			}
 
-			message := fmt.Sprintf("🚨 *%s* Fired!\n*%s* is currently `%f%s` over the threshold.\n(Value: `%s%s`, Threshold: `%s%s`)", metricMonitor.Name, metricMonitor.MetricToMonitor, value-metricMonitor.Threshold, unitsStr, valueWithNoTrailingZeroes, unitsStr, thresholdWithNoTrailingZeros, unitsStr)
+			message := fmt.Sprintf(
+				"🚨 *%s* fired!\n*%s* is currently *%s %s* over the threshold.\n"+
+					"_Value_: %s %s | _Threshold_: %s %s",
+				metricMonitor.Name,
+				metricMonitor.MetricToMonitor,
+				diffRepr,
+				unitsStr,
+				valueRepr,
+				unitsStr,
+				thresholdRepr,
+				unitsStr,
+			)
+
+			fmt.Println(message)
 
 			if err := metricMonitor.SendSlackAlert(&model.SendSlackAlertForMetricMonitorInput{Message: message, Workspace: &workspace}); err != nil {
 				log.Error("error sending slack alert for metric monitor", err)
@@ -110,7 +127,20 @@ func processMetricMonitors(DB *gorm.DB, TDB timeseries.DB, MailClient *sendgrid.
 			monitorURL := fmt.Sprintf("%s/%d/alerts/monitor/%d", frontendURL, metricMonitor.ProjectID, metricMonitor.ID)
 
 			for _, email := range emailsToNotify {
-				message = fmt.Sprintf("<b>%s</b> is currently <b>%f%s</b> over the threshold.<br>(Value: <b>%s%s</b>, Threshold: <b>%s%s</b>)<br><br><a href=\"%s\">View Monitor</a>", metricMonitor.Name, value-metricMonitor.Threshold, unitsStr, valueWithNoTrailingZeroes, unitsStr, thresholdWithNoTrailingZeros, unitsStr, monitorURL)
+				message = fmt.Sprintf(
+					"<b>%s</b> is currently <b>%s %s</b> over the threshold.<br>"+
+						"<em>Value</em>: %s <em>%s</em> | <em>Threshold: %s <em>%s</em>"+
+						"<br><br>"+
+						"<a href=\"%s\">View Monitor</a>",
+					metricMonitor.Name,
+					diffRepr,
+					unitsStr,
+					valueRepr,
+					unitsStr,
+					thresholdRepr,
+					unitsStr,
+					monitorURL,
+				)
 				if err := Email.SendAlertEmail(MailClient, *email, message, metricMonitor.MetricToMonitor, metricMonitor.Name); err != nil {
 					log.Error(err)
 


### PR DESCRIPTION
Makes sure that any values beyond 10k are written in a scientific format with fixed precision.
<img width="587" alt="Screen Shot 2022-08-31 at 7 28 59 PM" src="https://user-images.githubusercontent.com/17913919/187819345-bd4f67e0-7611-47e3-80a4-77c054b79e7d.png">
