### PR TITLE
scale redis back to 10%

### DIFF
--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -34,8 +34,8 @@ func UseRedis(projectId int, sessionSecureId string) bool {
 		log.Error(errors.Wrap(err, "failed to hash secure id to int"))
 	}
 
-	// Enable redis for 50% of other traffic
-	return lo.Contains(redisProjectIds, projectId) || sidHash.Sum32()%2 == 0
+	// Enable redis for 10% of other traffic
+	return lo.Contains(redisProjectIds, projectId) || sidHash.Sum32()%10 == 0
 }
 
 func EventsKey(sessionId int) string {


### PR DESCRIPTION
- memory usage a little higher than I was expecting
- looking better now that it's compressed (and probably fine)
- scaling back to 10% just to be safe
- need to investigate redis params too - available memory only looks like 50% of what the cluster has