### PR TITLE
Update .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # applying prettier across project
-44bea57277107c4b86780ce5773e2dc5aa0cb840
+50f6fc1ce1a529acd1d1ba2531ccb662200552a7


### PR DESCRIPTION
Because of squashing, the originally entered commit SHA doesn't exist anymore. This is the correct SHA pointing to the squashed commit