### PR TITLE
Fix sessions/error feed queries being issued multiple times

### DIFF
--- a/frontend/src/pages/Errors/ErrorFeedV2/ErrorFeedV2.tsx
+++ b/frontend/src/pages/Errors/ErrorFeedV2/ErrorFeedV2.tsx
@@ -45,8 +45,10 @@ export const ErrorFeedV2 = () => {
 	} = useErrorSearchContext()
 	const projectHasManyErrors = errorsCount > PAGE_SIZE
 
-	const [errorFeedIsInTopScrollPosition, setErrorFeedIsInTopScrollPosition] =
-		useState(true)
+	const [
+		errorFeedIsInTopScrollPosition,
+		setErrorFeedIsInTopScrollPosition,
+	] = useState(true)
 	useEffect(() => {
 		if (backendSearchQuery) {
 			setSearchResultsLoading(true)
@@ -57,7 +59,7 @@ export const ErrorFeedV2 = () => {
 		variables: {
 			query: backendSearchQuery?.searchQuery || '',
 			count: PAGE_SIZE,
-			page,
+			page: page && page > 0 ? page : 1,
 			project_id,
 		},
 		onCompleted: (r) => {

--- a/frontend/src/pages/Sessions/SessionsFeedV2/SessionsFeed.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/SessionsFeed.tsx
@@ -87,21 +87,22 @@ export const SessionFeed = React.memo(() => {
 	const { data: billingDetails } = useGetBillingDetailsForProjectQuery({
 		variables: { project_id },
 	})
-	const { data: unprocessedSessionsOpenSearch } =
-		useGetSessionsOpenSearchQuery({
-			variables: {
-				project_id,
-				count: PAGE_SIZE,
-				page: 1,
-				query: getUnprocessedSessionsQuery(
-					backendSearchQuery?.searchQuery || '',
-				),
-				sort_desc: sessionFeedConfiguration.sortOrder === 'Descending',
-			},
-			skip: !backendSearchQuery,
-			pollInterval: 5000,
-			fetchPolicy: 'network-only',
-		})
+	const {
+		data: unprocessedSessionsOpenSearch,
+	} = useGetSessionsOpenSearchQuery({
+		variables: {
+			project_id,
+			count: PAGE_SIZE,
+			page: 1,
+			query: getUnprocessedSessionsQuery(
+				backendSearchQuery?.searchQuery || '',
+			),
+			sort_desc: sessionFeedConfiguration.sortOrder === 'Descending',
+		},
+		skip: !backendSearchQuery,
+		pollInterval: 5000,
+		fetchPolicy: 'network-only',
+	})
 
 	// Used to determine if we need to show the loading skeleton. The loading skeleton should only be shown on the first load and when searchParams changes. It should not show when loading more sessions via infinite scroll.
 	useEffect(() => {
@@ -127,7 +128,7 @@ export const SessionFeed = React.memo(() => {
 		variables: {
 			query: backendSearchQuery?.searchQuery || '',
 			count: PAGE_SIZE,
-			page: page,
+			page: page && page > 0 ? page : 1,
 			project_id,
 			sort_desc: sessionFeedConfiguration.sortOrder === 'Descending',
 		},

--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/QueryBuilder.tsx
@@ -1233,8 +1233,9 @@ const QueryBuilder = ({
 					case 'is':
 						return {
 							term: {
-								[`${name}${isKeyword ? '.keyword' : ''}`]:
-									value,
+								[`${name}${
+									isKeyword ? '.keyword' : ''
+								}`]: value,
 							},
 						}
 					case 'contains':
@@ -1248,8 +1249,9 @@ const QueryBuilder = ({
 					case 'matches':
 						return {
 							regexp: {
-								[`${name}${isKeyword ? '.keyword' : ''}`]:
-									value,
+								[`${name}${
+									isKeyword ? '.keyword' : ''
+								}`]: value,
 							},
 						}
 					case 'exists':
@@ -1395,10 +1397,11 @@ const QueryBuilder = ({
 						[isAnd ? 'must' : 'should']: [
 							{
 								bool: {
-									[isAnd ? 'must' : 'should']:
-										standardRules.map((rule) =>
-											parseRule(rule),
-										),
+									[isAnd
+										? 'must'
+										: 'should']: standardRules.map((rule) =>
+										parseRule(rule),
+									),
 								},
 							},
 							{
@@ -1406,10 +1409,11 @@ const QueryBuilder = ({
 									type: 'child',
 									query: {
 										bool: {
-											[isAnd ? 'must' : 'should']:
-												errorObjectRules.map((rule) =>
-													parseRule(rule),
-												),
+											[isAnd
+												? 'must'
+												: 'should']: errorObjectRules.map(
+												(rule) => parseRule(rule),
+											),
 										},
 									},
 								},
@@ -1660,7 +1664,6 @@ const QueryBuilder = ({
 		}
 
 		const query = parseGroup(isAnd, rules)
-		setSearchQuery(JSON.stringify(query))
 		const newState = JSON.stringify({
 			isAnd,
 			rules: serializeRules(rules),
@@ -1673,7 +1676,9 @@ const QueryBuilder = ({
 				...params,
 				query: newState,
 			}))
+			return
 		}
+		setSearchQuery(JSON.stringify(query))
 	}, [
 		getQueryFromParams,
 		isAnd,


### PR DESCRIPTION
Before this fix: getSessionsOpenSearch and getErrorGroupsOpenSearch was being issued around 4 times each time the page is loaded (not including the separate query for live sessions). This consumed network bandwidth and caused unnecessary re-renders (and flickering for my upcoming histogram change).

Root causes:
1) Query was being issued twice, once requesting a page of 'undefined' and once requesting a page of 1
2) In QueryBuilder.tsx L1663, we were setting the query and then updating searchParams, and the updated searchParams caused the useEffect hook to be triggered again, causing us to issue a new query with an updated time.