### PR TITLE
client/firstload support for network recording domains as part of H.init call

### DIFF
--- a/client/src/graph/generated/operations.ts
+++ b/client/src/graph/generated/operations.ts
@@ -104,10 +104,10 @@ export type MutationInitializeSessionArgs = {
   environment: Scalars['String'];
   fingerprint: Scalars['String'];
   firstloadVersion: Scalars['String'];
+  network_recording_domains?: InputMaybe<Array<Scalars['String']>>
   organization_verbose_id: Scalars['String'];
   session_secure_id: Scalars['String'];
 };
-
 
 export type MutationMarkBackendSetupArgs = {
   session_secure_id: Scalars['String'];
@@ -238,6 +238,9 @@ export type InitializeSessionMutationVariables = Exact<{
   id: Scalars['String'];
   appVersion?: InputMaybe<Scalars['String']>;
   client_id: Scalars['String'];
+  network_recording_domains?: InputMaybe<
+    Array<Scalars['String']> | Scalars['String']
+  >
 }>;
 
 
@@ -300,19 +303,20 @@ export const AddSessionFeedbackDocument = gql`
 }
     `;
 export const InitializeSessionDocument = gql`
-    mutation initializeSession($session_secure_id: String!, $organization_verbose_id: String!, $enable_strict_privacy: Boolean!, $enable_recording_network_contents: Boolean!, $clientVersion: String!, $firstloadVersion: String!, $clientConfig: String!, $environment: String!, $id: String!, $appVersion: String, $client_id: String!) {
-  initializeSession(
-    session_secure_id: $session_secure_id
-    organization_verbose_id: $organization_verbose_id
-    enable_strict_privacy: $enable_strict_privacy
-    enable_recording_network_contents: $enable_recording_network_contents
-    clientVersion: $clientVersion
-    firstloadVersion: $firstloadVersion
-    clientConfig: $clientConfig
-    environment: $environment
-    appVersion: $appVersion
-    fingerprint: $id
-    client_id: $client_id
+    mutation initializeSession($session_secure_id: String!, $organization_verbose_id: String!, $enable_strict_privacy: Boolean!, $enable_recording_network_contents: Boolean!, $clientVersion: String!, $firstloadVersion: String!, $clientConfig: String!, $environment: String!, $id: String!, $appVersion: String,$client_id: String!, $network_recording_domains: [String!]) {
+		initializeSession(
+			session_secure_id: $session_secure_id
+			organization_verbose_id: $organization_verbose_id
+			enable_strict_privacy: $enable_strict_privacy
+			enable_recording_network_contents: $enable_recording_network_contents
+			clientVersion: $clientVersion
+			firstloadVersion: $firstloadVersion
+			clientConfig: $clientConfig
+			environment: $environment
+			appVersion: $appVersion
+			fingerprint: $id
+			client_id: $client_id
+			network_recording_domains: $network_recording_domains
   ) {
     secure_id
     project_id

--- a/client/src/graph/generated/schemas.ts
+++ b/client/src/graph/generated/schemas.ts
@@ -101,10 +101,10 @@ export type MutationInitializeSessionArgs = {
   environment: Scalars['String'];
   fingerprint: Scalars['String'];
   firstloadVersion: Scalars['String'];
+  network_recording_domains?: InputMaybe<Array<Scalars['String']>>
   organization_verbose_id: Scalars['String'];
   session_secure_id: Scalars['String'];
 };
-
 
 export type MutationMarkBackendSetupArgs = {
   session_secure_id: Scalars['String'];

--- a/client/src/graph/operators/mutation.gql
+++ b/client/src/graph/operators/mutation.gql
@@ -76,6 +76,7 @@ mutation initializeSession(
 	$id: String!
 	$appVersion: String
 	$client_id: String!
+	$network_recording_domains: [String!]
 ) {
 	initializeSession(
 		session_secure_id: $session_secure_id
@@ -89,6 +90,7 @@ mutation initializeSession(
 		appVersion: $appVersion
 		fingerprint: $id
 		client_id: $client_id
+		network_recording_domains: $network_recording_domains
 	) {
 		secure_id
 		project_id

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -531,6 +531,14 @@ export class Highlight {
 
 			const client = await this.fingerprintjs
 			const fingerprint = await client.get()
+			let destinationDomains: string[] = []
+			if (
+				typeof this.options.networkRecording === 'object' &&
+				this.options.networkRecording.destinationDomains?.length
+			) {
+				destinationDomains =
+					this.options.networkRecording.destinationDomains
+			}
 			const gr = await this.graphqlSDK.initializeSession({
 				organization_verbose_id: this.organizationID,
 				enable_strict_privacy: this.enableStrictPrivacy,
@@ -543,6 +551,7 @@ export class Highlight {
 				appVersion: this.appVersion,
 				session_secure_id: this.sessionData.sessionSecureID,
 				client_id: clientID,
+				network_recording_domains: destinationDomains,
 			})
 			if (
 				gr.initializeSession.secure_id !==

--- a/firstload/package.json
+++ b/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "4.3.9",
+	"version": "4.4.0",
 	"scripts": {
 		"build": "tsc && rollup -c",
 		"dev": "doppler run -- rollup -c -w",

--- a/firstload/src/types/client.ts
+++ b/firstload/src/types/client.ts
@@ -81,6 +81,14 @@ export declare type NetworkRecordingOptions = {
 	 * }
 	 */
 	bodyKeysToRecord?: string[]
+	/**
+	 * Record frontend network request metrics that are sent to
+	 * the following list of domains. A domain substring match is used to
+	 * determine if a network request matches one of the following values.
+	 * @example destinationDomains: ['backend.example.com']
+	 * // if your frontend makes requests to `backend.example.com` that you would like to record
+	 */
+	destinationDomains?: string[]
 }
 
 export declare type IntegrationOptions = {


### PR DESCRIPTION
Frontend network request metric require backend domains to be configured.
Allow specifying the domains as part of the H.init call.

The PR is split into 3 commits which will be rolled our separately.
1. backend changes supporting new optional `initializeSession` parameter
2. client/firstload changes passing new options to `initializeSession`
3. frontend change to use new setting

This PR merges part 2. Reviewed in #3020 
