### PR TITLE
add babel-plugin-react-wrapped-display-name

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"dependencies": {
 		"@apollo/client": "3.4.17",
+		"@babel/core": "^7.19.0",
 		"@datadog/browser-logs": "^4.13.0",
 		"@highlight-run/react": "^1.1.12",
 		"@highlight-run/react-mentions": "4.4.1",
@@ -14,6 +15,7 @@
 		"@types/react-virtualized-auto-sizer": "^1.0.1",
 		"antd": "^4.17.0",
 		"apollo3-cache-persist": "^0.14.0",
+		"babel-plugin-react-wrapped-display-name": "^1.0.0",
 		"classnames": "^2.3.1",
 		"color-hash": "^2.0.1",
 		"dinero.js": "^2.0.0-alpha.8",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,7 +13,11 @@ const __dirname = dirname(__filename)
 
 export default defineConfig({
 	plugins: [
-		react(),
+		react({
+			babel: {
+				plugins: ['babel-plugin-react-wrapped-display-name'],
+			},
+		}),
 		tsconfigPaths(),
 		svgr(),
 		vitePluginImp({

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -114,7 +114,7 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/core@^7.12.10":
+"@babel/core@^7.12.10", "@babel/core@^7.19.0":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.19.0.tgz#d2f5f4f2033c00de8096be3c9f45772563e150c3"
   integrity sha512-reM4+U7B9ss148rh2n1Qs9ASS+w94irYXga7c2jaQv9RVzpS7Mv1a9rnYYwuDa45G+DkORt9g6An2k/V4d9LbQ==
@@ -2955,6 +2955,11 @@ babel-plugin-macros@^2.0.0:
     "@babel/runtime" "^7.7.2"
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
+
+babel-plugin-react-wrapped-display-name@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-wrapped-display-name/-/babel-plugin-react-wrapped-display-name-1.0.0.tgz#f2fb70b9d26080333d14371480ee71139cf6f50d"
+  integrity sha512-/P6d0oSh7YTiqplJ1SuwpvOvmJVYezf3SAz0xdLy6/KD2AemLFqDHW6zZooNpNomGmFaFFvHIu/w9z/lSPGD5Q==
 
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"


### PR DESCRIPTION
Take this code:

```js
const Component = React.memo(() => <div />)
```

When using `React.memo` or other similar component wrappers, the display name of the component is lost, and shows up as "Anonymous" in devtools and profiler. This plugin adds the display name of the wrapped component to the display name of the wrapper, for better debugging.

```js
const Component = React.memo(() => <div />)
Component.displayName = "Component"
```
