### PR TITLE
home page components should use the blur + top-bar to indicate loading

### DIFF
--- a/frontend/src/pages/Home/components/ActiveUsersTable/ActiveUsersTable.tsx
+++ b/frontend/src/pages/Home/components/ActiveUsersTable/ActiveUsersTable.tsx
@@ -93,7 +93,7 @@ const ActiveUsersTable = ({
 		<div className={classNames({ [styles.loading]: loading })}>
 			<DashboardInnerTable>
 				<ProgressBarTable
-					loading={loading}
+					loading={false}
 					columns={Columns}
 					data={filteredTableData}
 					onClickHandler={(record) => {

--- a/frontend/src/pages/Home/components/RageClicksForProjectTable/RageClicksForProjectTable.tsx
+++ b/frontend/src/pages/Home/components/RageClicksForProjectTable/RageClicksForProjectTable.tsx
@@ -96,7 +96,7 @@ const RageClicksForProjectTable = ({
 		<div className={classNames({ [styles.loading]: loading })}>
 			<DashboardInnerTable>
 				<ProgressBarTable
-					loading={loading}
+					loading={false}
 					columns={Columns}
 					data={filteredTableData}
 					onClickHandler={(record) => {

--- a/frontend/src/pages/Home/components/ReferrersTable/ReferrersTable.tsx
+++ b/frontend/src/pages/Home/components/ReferrersTable/ReferrersTable.tsx
@@ -76,7 +76,7 @@ const ReferrersTable = ({
 				<ProgressBarTable
 					columns={Columns}
 					data={tableData}
-					loading={loading}
+					loading={false}
 					onClickHandler={(record) => {
 						setSegmentName(null)
 						setSelectedSegment(undefined)

--- a/frontend/src/pages/Home/components/TopRoutesTable/TopRoutesTable.tsx
+++ b/frontend/src/pages/Home/components/TopRoutesTable/TopRoutesTable.tsx
@@ -52,7 +52,7 @@ const TopRoutesTable = ({
 		<div className={classNames({ [styles.loading]: loading })}>
 			<DashboardInnerTable>
 				<ProgressBarTable
-					loading={loading}
+					loading={false}
 					columns={Columns}
 					data={
 						data?.network_histogram?.buckets


### PR DESCRIPTION
remove the antd table spinners.