### PR TITLE
make loading bars not take up space on dashboard cards

### DIFF
--- a/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.tsx
+++ b/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.tsx
@@ -101,7 +101,7 @@ const DashboardCard = ({
 				interactable
 				className={styles.card}
 				title={
-					<div className={styles.cardHeader}>
+					<div className="relative">
 						<div className={styles.mainHeaderContent}>
 							<div className={styles.headerContainer}>
 								<span className={styles.header}>
@@ -249,7 +249,9 @@ const DashboardCard = ({
 							}}
 						/>
 						{updatingData && (
-							<LoadingBar height={2} width={'100%'} />
+							<div className="absolute inset-x-0 bottom-0">
+								<LoadingBar height={2} width={'100%'} />
+							</div>
 						)}
 					</div>
 				}

--- a/frontend/src/pages/Dashboards/components/DashboardCard/DashboardComponentCard/DashboardComponentCard.tsx
+++ b/frontend/src/pages/Dashboards/components/DashboardCard/DashboardComponentCard/DashboardComponentCard.tsx
@@ -78,7 +78,7 @@ export const DashboardComponentCard = ({
 					PrebuiltComponentMap[componentType].fixedSize,
 			})}
 			title={
-				<div className={styles.cardHeader}>
+				<div className="relative">
 					<div className={styles.mainHeaderContent}>
 						<div className={styles.headerContainer}>
 							<span className={styles.header}>
@@ -141,7 +141,11 @@ export const DashboardComponentCard = ({
 							</div>
 						</div>
 					</div>
-					{updatingData && <LoadingBar height={2} width={'100%'} />}
+					{updatingData && (
+						<div className="absolute inset-x-0 bottom-0">
+							<LoadingBar height={2} width={'100%'} />
+						</div>
+					)}
 				</div>
 			}
 		>


### PR DESCRIPTION
Dashboard Cards have a loading bar that appears beneath the title while data is loading or being updated (e.g. when changing time range). That loading bar nudged the rest of the content down a bit. This PR fixes that by absolute-positioning them