### PR TITLE
[HIG-2702] improve spacing of KeyPerformanceIndicators

### DIFF
--- a/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.module.scss
+++ b/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.module.scss
@@ -171,8 +171,3 @@
 .blurChart {
 	filter: blur(2px);
 }
-
-.fixedSize {
-	min-height: 180px;
-	min-width: 600px;
-}

--- a/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.module.scss.d.ts
+++ b/frontend/src/pages/Dashboards/components/DashboardCard/DashboardCard.module.scss.d.ts
@@ -9,7 +9,6 @@ export const componentCard: string
 export const createNewAlertRow: string
 export const description: string
 export const draggable: string
-export const fixedSize: string
 export const formLabel: string
 export const header: string
 export const headerActions: string

--- a/frontend/src/pages/Dashboards/components/DashboardCard/DashboardComponentCard/DashboardComponentCard.tsx
+++ b/frontend/src/pages/Dashboards/components/DashboardCard/DashboardComponentCard/DashboardComponentCard.tsx
@@ -32,12 +32,10 @@ export const PrebuiltComponentMap: {
 			setUpdatingData: React.Dispatch<React.SetStateAction<boolean>>
 		}>
 		hasSearch?: boolean
-		fixedSize?: boolean
 	}
 } = {
 	[MetricViewComponentType.KeyPerformanceGauge]: {
 		fc: KeyPerformanceIndicators,
-		fixedSize: true,
 	},
 	[MetricViewComponentType.SessionCountChart]: { fc: SessionCountGraph },
 	[MetricViewComponentType.ErrorCountChart]: { fc: ErrorCountGraph },
@@ -73,10 +71,7 @@ export const DashboardComponentCard = ({
 	return (
 		<DashboardInnerCard
 			interactable
-			className={classNames(styles.card, {
-				[styles.fixedSize]:
-					PrebuiltComponentMap[componentType].fixedSize,
-			})}
+			className={styles.card}
 			title={
 				<div className={styles.cardHeader}>
 					<div className={styles.mainHeaderContent}>

--- a/frontend/src/pages/Home/components/KeyPerformanceIndicators/KeyPerformanceIndicators.tsx
+++ b/frontend/src/pages/Home/components/KeyPerformanceIndicators/KeyPerformanceIndicators.tsx
@@ -44,7 +44,7 @@ const KeyPerformanceIndicators = ({
 	return (
 		<div
 			className={classNames(
-				'flex flex-wrap gap-8 h-full mb-8 p-6 w-full',
+				'flex flex-wrap justify-between gap-8 h-full mb-8 p-6 w-full',
 				{
 					['blur-xs']: loading,
 				},

--- a/frontend/src/pages/Home/utils/HomePageUtils.ts
+++ b/frontend/src/pages/Home/utils/HomePageUtils.ts
@@ -48,14 +48,15 @@ const DEFAULT_SINGLE_LAYOUT = {
 	x: 0,
 	y: 0,
 	i: '0',
-	minW: 1,
-	minH: 1,
+	minW: 2,
+	minH: 2,
 	static: false,
 }
 export const DEFAULT_HOME_DASHBOARD_LAYOUT = {
 	lg: [
 		{
 			...DEFAULT_SINGLE_LAYOUT,
+			minW: 6,
 			w: 6,
 			h: 2,
 			x: 0,


### PR DESCRIPTION
Improve Home dashboard default layout to make the KeyPerformanceIndicators fit better on small viewports.
Limit the minimum width on the react-grid-layout to ensure the card cannot be too small.

![image](https://user-images.githubusercontent.com/1351531/189411320-c8bedc05-377a-44ee-8542-819a2769402c.png)
Testing: min width is now 1/2 of the grid: https://pr-3036.d25bj3loqvp3nx.amplifyapp.com/1/home