### PR TITLE
redis 100%

### DIFF
--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"os"
 	"sort"
 	"strconv"
@@ -15,8 +14,6 @@ import (
 	"github.com/highlight-run/highlight/backend/util"
 	"github.com/openlyinc/pointy"
 	"github.com/pkg/errors"
-	"github.com/samber/lo"
-	log "github.com/sirupsen/logrus"
 )
 
 type Client struct {
@@ -25,18 +22,10 @@ type Client struct {
 
 var (
 	redisEventsStagingEndpoint = os.Getenv("REDIS_EVENTS_STAGING_ENDPOINT")
-	redisProjectIds            = []int{1, 1074} // Enabled for Highlight and Solitaired
 )
 
 func UseRedis(projectId int, sessionSecureId string) bool {
-	sidHash := fnv.New32a()
-	defer sidHash.Reset()
-	if _, err := sidHash.Write([]byte(sessionSecureId)); err != nil {
-		log.Error(errors.Wrap(err, "failed to hash secure id to int"))
-	}
-
-	// Enable redis for 50% of other traffic
-	return lo.Contains(redisProjectIds, projectId) || sidHash.Sum32()%2 == 0
+	return true
 }
 
 func EventsKey(sessionId int) string {


### PR DESCRIPTION
- turns redis on for all new sessions
- memory usage is still dropping as events are moved to s3 for old sessions, sitting around 25% right now (there will be a large chunk of these that are no longer active and aren't moved until the 8 hour TTL is hit, so true memory usage should be a lot lower once these are all removed)