### PR TITLE
fix(hig-2708): enforce max width on identifier container

### DIFF
--- a/frontend/src/components/UserIdentifier/UserIdentifier.module.scss
+++ b/frontend/src/components/UserIdentifier/UserIdentifier.module.scss
@@ -2,12 +2,11 @@
 	align-items: center;
 	display: flex;
 	gap: var(--size-xxSmall);
-	width: 100%;
+	max-width: calc(100% - 1.2em - var(--size-medium));
 }
 
 .identifier {
 	font-weight: 500;
-	max-width: calc(100% - 1.2em - 2 * var(--size-xxSmall));
 	overflow: hidden;
 	text-overflow: ellipsis;
 }


### PR DESCRIPTION
Long identifiers now do not overflow the parent card. 
Example:
<img width="354" alt="Screen Shot 2022-09-09 at 4 26 19 PM" src="https://user-images.githubusercontent.com/17913919/189458504-c94919e8-db44-42af-8eec-fe6e5ac071a2.png">
