### PR TITLE
enable recording for 2% of solitaired sessions

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@highlight-run/client",
 	"private": true,
-	"version": "1.2.11",
+	"version": "1.2.12",
 	"description": "rollup setup for writing a javascript library and making it availabe as script or npm package",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -480,8 +480,11 @@ export class Highlight {
 		try {
 			// disable recording for filtered projects while allowing for reloaded sessions
 			if (!this.reloaded && this.organizationID === '6glrjqg9') {
-				this._firstLoadListeners?.stopListening()
-				return
+				// Record 2% of Solitaired sessions
+				if (Math.random() >= 0.02) {
+					this._firstLoadListeners?.stopListening()
+					return
+				}
 			}
 
 			if (this.feedbackWidgetOptions.enabled) {


### PR DESCRIPTION
- Redis memory usage sitting around 10% now
- ramping up again for Solitaired, starting small at 2% because I'm not sure how compression and moving to S3 will affect memory usage for their specific data