### PR TITLE
add additional tracing to InitializeSession

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1185,6 +1185,8 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 			return nil, err
 		}
 		if existingSession != nil {
+			initSpan.SetTag("duplicate", true)
+			initSpan.SetTag("duplicateRace", true)
 			return existingSession, nil
 		}
 		return nil, e.New("failed to find duplicate session: " + input.SessionSecureID)


### PR DESCRIPTION
optimize for the duplicate-session case to make sure we are not retrieving location unnecessarily.