### PR TITLE
fix upgrade-plan page not loading auth correctly

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -38,12 +38,7 @@ import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom'
 import { Helmet } from 'react-helmet'
 import { SkeletonTheme } from 'react-loading-skeleton'
-import {
-	BrowserRouter as Router,
-	Route,
-	Switch,
-	useRouteMatch,
-} from 'react-router-dom'
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import { QueryParamProvider } from 'use-query-params'
 
 import packageJson from '../package.json'
@@ -185,11 +180,8 @@ const App = () => {
 }
 
 const AuthenticationRoleRouter = () => {
-	const workspaceId = useRouteMatch<{ workspaceId: string }>(
-		'/w/:workspaceId(d+)',
-	)?.params.workspaceId
-	const projectId = useRouteMatch<{ projectId: string }>('/:projectId(d+)')
-		?.params.projectId
+	const workspaceId = /^\/w\/(\d+)\/.*$/.exec(window.location.pathname)?.pop()
+	const projectId = /^\/(\d+)\/.*$/.exec(window.location.pathname)?.pop()
 	const [
 		getAdminWorkspaceRoleQuery,
 		{


### PR DESCRIPTION
The `upgrade-plan` route would require a refresh to not load the authorization fallback card.
This occurred because the original load of the frontend on `/` would not have a project/workspace, and would
not be able to load a workspace role for the user. Changes to the URL would not trigger the router updates
due to a bug in react-router 5 with react 18 - https://linear.app/highlight/issue/HIG-2647

Until then, this provides a workaround using window pathname.