### PR TITLE
add OnConnect and OnNewNode handlers to redis config

### DIFF
--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -75,6 +75,13 @@ func NewClient() *Client {
 			MaxRetries:   5,
 			MinIdleConns: 16,
 			PoolSize:     256,
+			OnConnect: func(*redis.Conn) error {
+				hlog.Incr("redis.new-conn", nil, 1)
+				return nil
+			},
+			OnNewNode: func(*redis.Client) {
+				hlog.Incr("redis.new-node", nil, 1)
+			},
 		})
 		go func() {
 			for {


### PR DESCRIPTION
- logs some more metrics in these callbacks
- expecting to see `redis.new-conn` matching the Elasticache New Connections
- expecting to see `redis.new-node` on app startup only