### PR TITLE
set min height on dev tools container

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/DevToolsWindow.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/DevToolsWindow.tsx
@@ -106,7 +106,7 @@ function ResizePanel({
 			if (!element) return
 			setPanel(element)
 
-			let initialHeight = defaultHeight
+			let initialHeight = Math.max(defaultHeight || 0, minHeight || 0)
 			if (heightPersistenceKey) {
 				const storedHeight = Number(
 					localStorage.getItem(heightPersistenceKey),
@@ -120,7 +120,7 @@ function ResizePanel({
 				element.style.height = `${initialHeight}px`
 			}
 		},
-		[defaultHeight, heightPersistenceKey],
+		[defaultHeight, minHeight, heightPersistenceKey],
 	)
 
 	useHTMLElementEvent(handle, 'pointerdown', (event) => {


### PR DESCRIPTION
accept a min height on the `ResizePanel` to ensure that the dev tools container cannot be
dragged where the handle is occluded by the timeline indicators. 
https://highlightcorp.slack.com/archives/C032PQ35D60/p1663355924506699