### PR TITLE
add a bare bones pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,19 @@
 ## Summary
 
 <!--
- Explain the **motivation** for making this change. Feel free to link to a Linear ticket.
+ Ideally, there is an attached Linear ticket that will describe the "why".
+
+ If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
 -->
 
 ## How did you test this change?
+
+<!--
+ Frontend - Leave a screencast or a screenshot to visually describe the changes.
+-->
+
+## Are there any deployment considerations?
+
+<!--
+ Backend - Do we need to consider migrations or backfilling data?
+-->


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. Feel free to link to a Linear ticket.
-->

By having a PR template, it helps new developers understand what are the expectations when drafting a new PR. I pulled this template directly from React ([source](https://github.com/facebook/react/blob/main/.github/PULL_REQUEST_TEMPLATE.md)).

## How did you test this change?

[Rendered markdown](https://github.com/highlight-run/highlight/blob/91a0d741f1cdd03144a6b6551ebbc8735e6ccc14/.github/PULL_REQUEST_TEMPLATE.md) looks as expected.


