### PR TITLE
Add option to pull error details from prod with sessions

### DIFF
--- a/scripts/fetch_prod_session.py
+++ b/scripts/fetch_prod_session.py
@@ -84,6 +84,9 @@ def process(bucket, secure_id, copy_errors=False, store=False):
 
     # Get error objects associated with session
     error_objects = run_sql(f"SELECT * FROM error_objects WHERE session_id = '{session['id']}'", prod=True)
+    if not error_objects:
+        print(f"No errors found for session {session['id']}. Skipping copying errors...")
+        return
 
     # Get error groups for error objects
     error_group_ids = map(lambda x: str(x['error_group_id']), error_objects)


### PR DESCRIPTION
Adds an option to pull error details along with session data from production and store it in your local DB + move S3 files so they are accessible in dev.

Here is output from an example run:

```sh
➜  python3 scripts/fetch_prod_session.py wrchh9LvUZPE0PlAA0LhDhp64P9C -e
Copying session 104639701 to your local DB...
Copying session files from prod S3 to dev/1...
Copying error groups & objects to your local DB...
Copying JS and sourcemap files from prod S3 to dev/1...
Finished copying session and associated errors!
```