### PR TITLE
remove edit icons from predefined dashboard charts

### DIFF
--- a/frontend/src/pages/Dashboards/components/DashboardCard/DashboardComponentCard/DashboardComponentCard.tsx
+++ b/frontend/src/pages/Dashboards/components/DashboardCard/DashboardComponentCard/DashboardComponentCard.tsx
@@ -1,16 +1,9 @@
-import Button from '@components/Button/Button/Button'
 import InfoTooltip from '@components/InfoTooltip/InfoTooltip'
 import Input from '@components/Input/Input'
 import { LoadingBar } from '@components/Loading/Loading'
 import { DashboardMetricConfig, MetricViewComponentType } from '@graph/schemas'
 import SvgDragIcon from '@icons/DragIcon'
-import EditIcon from '@icons/EditIcon'
-import { DeleteMetricFn } from '@pages/Dashboards/components/DashboardCard/DashboardCard'
 import styles from '@pages/Dashboards/components/DashboardCard/DashboardCard.module.scss'
-import {
-	EditMetricModal,
-	UpdateMetricFn,
-} from '@pages/Dashboards/components/EditMetricModal/EditMetricModal'
 import ActiveUsersTable from '@pages/Home/components/ActiveUsersTable/ActiveUsersTable'
 import KeyPerformanceIndicators from '@pages/Home/components/KeyPerformanceIndicators/KeyPerformanceIndicators'
 import RageClicksForProjectTable from '@pages/Home/components/RageClicksForProjectTable/RageClicksForProjectTable'
@@ -52,17 +45,11 @@ export const PrebuiltComponentMap: {
 }
 
 export const DashboardComponentCard = ({
-	metricIdx,
 	metricConfig,
-	updateMetric,
 }: {
-	metricIdx: number
 	metricConfig: DashboardMetricConfig
-	updateMetric: UpdateMetricFn
-	deleteMetric: DeleteMetricFn
 }) => {
 	const [updatingData, setUpdatingData] = useState<boolean>(false)
-	const [showEditModal, setShowEditModal] = useState<boolean>(false)
 	const [filterSearchTerm, setFilterSearchTerm] = useState<string>('')
 	const componentType = metricConfig.component_type
 	if (!componentType) {
@@ -119,14 +106,9 @@ export const DashboardComponentCard = ({
 									/>
 								</div>
 							)}
-							<Button
+							<div
 								className={'flex justify-center'}
-								icon={<EditIcon />}
-								style={{ width: 40, height: 32 }}
-								trackingId={'DashboardCardEditMetric'}
-								onClick={() => {
-									setShowEditModal(true)
-								}}
+								style={{ width: 1, height: 32 }}
 							/>
 							<div
 								className={classNames(styles.draggable)}
@@ -145,16 +127,6 @@ export const DashboardComponentCard = ({
 			}
 		>
 			<div className={classNames(styles.card, styles.componentCard)}>
-				<EditMetricModal
-					shown={showEditModal}
-					onCancel={() => {
-						setShowEditModal(false)
-					}}
-					metricConfig={metricConfig}
-					metricIdx={metricIdx}
-					updateMetric={updateMetric}
-					canChangeType={false}
-				/>
 				{React.createElement(PrebuiltComponentMap[componentType].fc, {
 					setUpdatingData,
 					filterSearchTerm,

--- a/frontend/src/pages/Dashboards/pages/Dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/Dashboards/pages/Dashboard/DashboardPage.tsx
@@ -381,12 +381,7 @@ export const DashboardGrid = ({
 								editModalShown={index === newDashboardCardIdx}
 							/>
 						) : (
-							<DashboardComponentCard
-								metricIdx={index}
-								metricConfig={metric}
-								updateMetric={updateMetric}
-								deleteMetric={deleteMetric}
-							/>
+							<DashboardComponentCard metricConfig={metric} />
 						)}
 					</div>
 				))}


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. Feel free to link to a Linear ticket.
-->

See the loom video from the [ticket](https://linear.app/highlight/issue/HIG-2751/[ux]-predefined-charts-should-not-have-an-edit-icon)

## How did you test this change?

### Visual test

Before
![Screen_Shot_2022-09-21_at_8_44_10_PM](https://user-images.githubusercontent.com/58678/191646747-eafc2a4d-c42f-4dfb-8b8b-223c5a438e3b.png)

Observe that every dashboard chart has an edit icon.


After
![Screen_Shot_2022-09-21_at_8_42_57_PM](https://user-images.githubusercontent.com/58678/191646856-49851b47-7c71-435e-9b3b-d396d606ac0b.png)

Observe that only non-predefined dashboard charts have an edit icon.
