### PR TITLE
ensure client always records network requests

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -598,8 +598,8 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			)
 			if (!this._firstLoadListeners.isListening()) {
 				this._firstLoadListeners.startListening()
-			}
-			if (!this._firstLoadListeners.hasNetworkRecording) {
+			} else if (!this._firstLoadListeners.hasNetworkRecording) {
+				// for firstload versions < 3.0. even if they are listening, add network listeners
 				FirstLoadListeners.setupNetworkListener(
 					this._firstLoadListeners,
 					this.options,
@@ -757,7 +757,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 				}
 			}
 		}
-		this.stopRecording()
+		this.stopRecordingEvents()
 	}
 
 	_setupWindowListeners() {
@@ -944,6 +944,11 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 	 * @param manual The end user requested to stop recording.
 	 */
 	stopRecording(manual?: boolean) {
+		this.stopRecordingEvents(manual)
+		this._firstLoadListeners.stopListening()
+	}
+
+	stopRecordingEvents(manual?: boolean) {
 		if (manual) {
 			this.addCustomEvent(
 				'Stop',
@@ -951,7 +956,6 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			)
 		}
 		this.state = 'NotRecording'
-		this._firstLoadListeners.stopListening()
 		if (this.recordStop) {
 			this.recordStop()
 			this.recordStop = undefined


### PR DESCRIPTION
## Summary

tab visibility changes should not stop network request recording, 
since background network requests often happen when a tab is not visible.

## How did you test this change?

observing a local recording with tab switching before and after the change fixes the behavior.
adding a print to the `getRecordedNetworkResources` client function to show whether data is mapped between the performance timing api and the fetch/xhr listeners.

## Are there any deployment considerations?

Confirmed that the new client changes work with old firstload v2