### PR TITLE
make frontend H.init calls unversioned

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -41,19 +41,13 @@ import { SkeletonTheme } from 'react-loading-skeleton'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import { QueryParamProvider } from 'use-query-params'
 
-import packageJson from '../package.json'
 import LoginForm, { AuthAdminRouter } from './pages/Login/Login'
 
 const dev = import.meta.env.DEV
-let commitSHA = import.meta.env.REACT_APP_COMMIT_SHA || ''
-if (commitSHA.length > 8) {
-	commitSHA = commitSHA.substring(0, 8)
-}
 const options: HighlightOptions = {
 	debug: { clientInteractions: true, domRecording: true },
 	manualStart: true,
 	enableStrictPrivacy: Math.floor(Math.random() * 8) === 0,
-	version: `${packageJson['version']}${commitSHA}`,
 	networkRecording: {
 		enabled: true,
 		recordHeadersAndBody: true,


### PR DESCRIPTION
## Summary

Since sourcemap uploader for frontend does not provide a version and it would be tricky to extract it from our package.json,
do not provide a version to our H.init call so that we will use the unversioned sourcemaps.

Since vite bundles the prod build with hash strings in the js files, it is unlikely we would reuse the same sourcemap file for two versions. If we do though, this will allow testing what happens in the backend if a customer uploads sourcemaps for a different js version.

## How did you test this change?

Loading frontend locally

## Are there any deployment considerations?

N/A