### PR TITLE
generate a sourcemap as part of the build

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
 	},
 	build: {
 		outDir: 'build',
-		sourcemap: !!process.env.SOURCEMAP,
+		sourcemap: true,
 	},
 	test: {
 		globals: true,


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Per our morning discussion, we want to make sourcemaps public in production.
Long term, we want to advocate for public sourcemaps ([potential future blog](https://www.notion.so/runhighlight/Should-I-use-sourcemaps-in-production-2b9f7f1d4a90452bb982fffea28aa908)).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Now you can do CMD+p and find files by their name. 

https://www.loom.com/share/987ee4ee0f4c4e749ebacba140d45a2a

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

Sourcemaps will now be public on prod.
