### PR TITLE
ungate vercel integration, replace env var with highlight

### DIFF
--- a/frontend/src/pages/IntegrationsPage/Integrations.tsx
+++ b/frontend/src/pages/IntegrationsPage/Integrations.tsx
@@ -83,7 +83,6 @@ export const VERCEL_INTEGRATION: Integration = {
 	key: 'vercel',
 	name: 'Vercel',
 	configurationPath: 'vercel',
-	onlyShowForHighlightAdmin: true,
 	description: 'Configuration for your Vercel projects.',
 	configurationPage: (opts) => <VercelIntegrationConfig {...opts} />,
 	hasSettings: true,

--- a/frontend/src/pages/IntegrationsPage/components/VercelIntegration/VercelIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/VercelIntegration/VercelIntegrationConfig.tsx
@@ -84,9 +84,7 @@ const VercelIntegrationSetup: React.FC<IntegrationConfigProps> = ({
 					className={styles.modalBtn}
 					type="primary"
 					target="_blank"
-					href={`https://vercel.com/integrations/${
-						import.meta.env.REACT_APP_VERCEL_INTEGRATION_NAME
-					}/new`}
+					href={`https://vercel.com/integrations/highlight/new`}
 					rel="noreferrer"
 				>
 					<span className={styles.modalBtnText}>


### PR DESCRIPTION
- `REACT_APP_VERCEL_INTEGRATION_NAME` returns undefined despite being defined in prod, just replacing this for now
- removing admin gate so Vercel can test