### PR TITLE
update kafka worker concurrency

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -24,7 +24,7 @@ const KafkaOperationTimeout = 25 * time.Second
 const (
 	taskRetries           = 5
 	prefetchQueueCapacity = 64
-	prefetchSizeBytes     = 1 * 1000 * 1000   // 1 MB
+	prefetchSizeBytes     = 16 * 1000 * 1000  // 16 MB
 	messageSizeBytes      = 500 * 1000 * 1000 // 500 MB
 )
 

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -441,7 +441,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 }
 
 func (w *Worker) PublicWorker() {
-	const parallelWorkers = 16
+	const parallelWorkers = 32
 	// creates N parallel kafka message consumers that process messages.
 	// each consumer is considered part of the same consumer group and gets
 	// allocated a slice of all partitions. this ensures that a particular subset of partitions


### PR DESCRIPTION
## Summary

We're seeing an ok overall backlog but a very high max partition offset (most messages are in 5 of 2048 partitions). Want to try upping worker concurrency and prefetch amount to see if that helps.

## How did you test this change?

Local backend deploy.

## Are there any deployment considerations?

Will monitor ECS container memory usage to ensure we do not exceed memory limits.