### PR TITLE
add frontend env vars to turbo cache key

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,27 +9,15 @@ import svgr from 'vite-plugin-svgr'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
+import { default as js } from '../turbo.json'
+
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
+// Frontend env vars live in `turbo.json` to ensure the build is not cached.
 // Adding something here? Please update `.env.d.ts` to update our Typescript definitions.
 // *DO NOT* put something in here unless you're positive it's safe to expose this to the world.
-const ENVVAR_ALLOWLIST = [
-	'REACT_APP_COMMIT_SHA',
-	'REACT_APP_ENVIRONMENT',
-	'REACT_APP_FIREBASE_CONFIG_OBJECT',
-	'REACT_APP_FRONT_INTEGRATION_CLIENT_ID',
-	'REACT_APP_FRONTEND_ORG',
-	'REACT_APP_ONPREM',
-	'REACT_APP_PRIVATE_GRAPH_URI',
-	'REACT_APP_STRIPE_API_PK',
-	'REACT_APP_VERCEL_INTEGRATION_NAME',
-
-	'LINEAR_CLIENT_ID',
-	'SLACK_CLIENT_ID',
-	'DD_CLIENT_TOKEN',
-	'DD_RUM_APPLICATION_ID',
-]
+const ENVVAR_ALLOWLIST = js.pipeline.build.env
 
 // In order to prevent accidentally env var leakage, Vite only allows the configuration of defining
 // the environment variable prefix (see: https://vitejs.dev/guide/env-and-mode.html#env-variables-and-modes)

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://turborepo.org/schema.json",
-	"baseBranch": "origin/master",
 	"pipeline": {
 		"codegen": {
 			"inputs": ["./**/*.gql"],
@@ -16,7 +15,23 @@
 		},
 		"build": {
 			"dependsOn": ["codegen", "^prepublish", "^build"],
-			"outputs": ["build/**", "dist/**"]
+			"outputs": ["build/**", "dist/**"],
+			"env": [
+				"REACT_APP_COMMIT_SHA",
+				"REACT_APP_ENVIRONMENT",
+				"REACT_APP_FIREBASE_CONFIG_OBJECT",
+				"REACT_APP_FRONT_INTEGRATION_CLIENT_ID",
+				"REACT_APP_FRONTEND_ORG",
+				"REACT_APP_ONPREM",
+				"REACT_APP_PRIVATE_GRAPH_URI",
+				"REACT_APP_STRIPE_API_PK",
+				"REACT_APP_VERCEL_INTEGRATION_NAME",
+
+				"LINEAR_CLIENT_ID",
+				"SLACK_CLIENT_ID",
+				"DD_CLIENT_TOKEN",
+				"DD_RUM_APPLICATION_ID"
+			]
 		},
 		"test": {
 			"dependsOn": ["prepublish", "build"],
@@ -33,5 +48,5 @@
 			"env": ["HIGHLIGHT_API_KEY"]
 		}
 	},
-	"globalEnv": ["DOPPLER_TOKEN", "REACT_APP_PRIVATE_GRAPH_URI"]
+	"globalEnv": ["DOPPLER_TOKEN"]
 }


### PR DESCRIPTION
## Summary

Moves frontend env vars to the turbo definition to include them in the cache key.
This will ensure that the env var values changing will trigger a new build.

## How did you test this change?

`yarn build:frontend` locally

## Are there any deployment considerations?

No