### PR TITLE
fail the vite build if an env var is not defined

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -24,6 +24,7 @@ jobs:
         timeout-minutes: 30
         env:
             ENVIRONMENT: test
+            REACT_APP_COMMIT_SHA: ${{ env.GITHUB_SHA }}
             PGPASSWORD: postgres
             PSQL_HOST: localhost
             PSQL_PORT: 5432

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -13,6 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         # configures turborepo Remote Caching
         env:
+            REACT_APP_COMMIT_SHA: ${{ env.GITHUB_SHA }}
             TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
             TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         # configures turborepo Remote Caching
         env:
-            REACT_APP_COMMIT_SHA: ${{ env.GITHUB_SHA }}
+            REACT_APP_COMMIT_SHA: ${{ github.sha }}
             TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
             TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,6 +25,12 @@ const ENVVAR_ALLOWLIST = js.pipeline.build.env
 // the env vars on the allowlist are actually exposed.
 const validateSafeAllowList = (env: Record<string, string>) => {
 	ENVVAR_ALLOWLIST.forEach((allowListEnvVar) => {
+		if (process.env[allowListEnvVar] === undefined) {
+			throw new Error(
+				`Environment variable, ${allowListEnvVar}, is not defined`,
+			)
+		}
+
 		Object.keys(env).forEach((key) => {
 			if (key === allowListEnvVar) {
 				return


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

As a result of an [incident](https://www.notion.so/runhighlight/Private-Graph-down-due-to-missing-environment-variable-3c12e46a0c32496ca3a728da4cbe0b0e), we want to make our build tooling safer.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->


Referenced an invalid variable locally:

```diff
diff --git a/frontend/vite.config.ts b/frontend/vite.config.ts
index 2c96df74..638535c0 100644
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -28,6 +28,7 @@ const ENVVAR_ALLOWLIST = [
        'SLACK_CLIENT_ID',
        'DD_CLIENT_TOKEN',
        'DD_RUM_APPLICATION_ID',
+       'FAKE_VARIABLE'
 ]
 
 // In order to prevent accidentally env var leakage, Vite only allows the configuration of defining
```

Observe that the build fails:

![Screen Shot 2022-10-04 at 11 45 08 AM](https://user-images.githubusercontent.com/58678/193889611-40b7c144-dc39-4ed0-8e3a-cd58fa4ae12c.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

I did add `REACT_APP_ONPREM` to the dev doppler config. We should verify this exists on the prod doppler config.
