### PR TITLE
delete more env vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,15 +61,15 @@ jobs:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionIdsByQuery \
-                    --environment "$(doppler secrets download --no-file | jq 'del(.REACT_APP_STRIPE_API_PK) | del(.REACT_APP_FIREBASE_CONFIG_OBJECT) | del(.AWS_CLOUDFRONT_PRIVATE_KEY) | del(.FIREBASE_SECRET) | del(.AWS_ACCESS_KEY_ID) | del(.AWS_SECRET_ACCESS_KEY) | {Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq 'del(.REACT_APP_STRIPE_API_PK) | del(.REACT_APP_FIREBASE_CONFIG_OBJECT) | del(.AWS_CLOUDFRONT_PRIVATE_KEY) | del(.FIREBASE_SECRET) | del(.AWS_ACCESS_KEY_ID) | del(.AWS_SECRET_ACCESS_KEY) | del(.KAFKA_SERVERS) | del(.STRIPE_API_KEY) | {Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromPostgres \
-                    --environment "$(doppler secrets download --no-file | jq 'del(.REACT_APP_STRIPE_API_PK) | del(.REACT_APP_FIREBASE_CONFIG_OBJECT) | del(.AWS_CLOUDFRONT_PRIVATE_KEY) | del(.FIREBASE_SECRET) | del(.AWS_ACCESS_KEY_ID) | del(.AWS_SECRET_ACCESS_KEY) | {Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq 'del(.REACT_APP_STRIPE_API_PK) | del(.REACT_APP_FIREBASE_CONFIG_OBJECT) | del(.AWS_CLOUDFRONT_PRIVATE_KEY) | del(.FIREBASE_SECRET) | del(.AWS_ACCESS_KEY_ID) | del(.AWS_SECRET_ACCESS_KEY) | del(.KAFKA_SERVERS) | del(.STRIPE_API_KEY) | {Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromOpenSearch \
-                    --environment "$(doppler secrets download --no-file | jq 'del(.REACT_APP_STRIPE_API_PK) | del(.REACT_APP_FIREBASE_CONFIG_OBJECT) | del(.AWS_CLOUDFRONT_PRIVATE_KEY) | del(.FIREBASE_SECRET) | del(.AWS_ACCESS_KEY_ID) | del(.AWS_SECRET_ACCESS_KEY) | {Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq 'del(.REACT_APP_STRIPE_API_PK) | del(.REACT_APP_FIREBASE_CONFIG_OBJECT) | del(.AWS_CLOUDFRONT_PRIVATE_KEY) | del(.FIREBASE_SECRET) | del(.AWS_ACCESS_KEY_ID) | del(.AWS_SECRET_ACCESS_KEY) | del(.KAFKA_SERVERS) | del(.STRIPE_API_KEY) | {Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromS3 \
-                    --environment "$(doppler secrets download --no-file | jq 'del(.REACT_APP_STRIPE_API_PK) | del(.REACT_APP_FIREBASE_CONFIG_OBJECT) | del(.AWS_CLOUDFRONT_PRIVATE_KEY) | del(.FIREBASE_SECRET) | del(.AWS_ACCESS_KEY_ID) | del(.AWS_SECRET_ACCESS_KEY) | {Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq 'del(.REACT_APP_STRIPE_API_PK) | del(.REACT_APP_FIREBASE_CONFIG_OBJECT) | del(.AWS_CLOUDFRONT_PRIVATE_KEY) | del(.FIREBASE_SECRET) | del(.AWS_ACCESS_KEY_ID) | del(.AWS_SECRET_ACCESS_KEY) | del(.KAFKA_SERVERS) | del(.STRIPE_API_KEY) | {Variables: .}')"
                   aws lambda update-function-configuration --function-name sendEmail \
-                    --environment "$(doppler secrets download --no-file | jq 'del(.REACT_APP_STRIPE_API_PK) | del(.REACT_APP_FIREBASE_CONFIG_OBJECT) | del(.AWS_CLOUDFRONT_PRIVATE_KEY) | del(.FIREBASE_SECRET) | del(.AWS_ACCESS_KEY_ID) | del(.AWS_SECRET_ACCESS_KEY) | {Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq 'del(.REACT_APP_STRIPE_API_PK) | del(.REACT_APP_FIREBASE_CONFIG_OBJECT) | del(.AWS_CLOUDFRONT_PRIVATE_KEY) | del(.FIREBASE_SECRET) | del(.AWS_ACCESS_KEY_ID) | del(.AWS_SECRET_ACCESS_KEY) | del(.KAFKA_SERVERS) | del(.STRIPE_API_KEY) | {Variables: .}')"
             - name: Deploy getSessionIdsByQuery
               uses: appleboy/lambda-action@master
               with:


### PR DESCRIPTION
- These aren't needed by the lambda functions
- Need to get env variables under 4kb
- Thinking about replacing this with a branched config in Doppler to make this easier to manage + make sure we don't break lambdas by adding more env vars in future