### PR TITLE
deduplicate pushPayload errors

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2526,7 +2526,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			r.DB.Where(&model.ErrorObject{SessionID: sessionID, IsBeacon: true}).Delete(&model.ErrorObject{})
 		}
 		// filter out empty errors
-		var filteredErrors []*publicModel.ErrorObjectInput
+		seenEvents := map[string]*publicModel.ErrorObjectInput{}
 		for _, errorObject := range errors {
 			if errorObject.Event == "[{}]" {
 				var objString string
@@ -2543,10 +2543,10 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 					"error_object": objString,
 				}).Warn("caught empty error, continuing...")
 			} else {
-				filteredErrors = append(filteredErrors, errorObject)
+				seenEvents[errorObject.Event] = errorObject
 			}
 		}
-		errors = filteredErrors
+		errors = lo.Values(seenEvents)
 
 		// increment daily error table
 		numErrors := int64(len(errors))


### PR DESCRIPTION
## Summary

Some rogue sessions that produce a ton of duplicate errors cause problems for our `ProcessPayload` error ingest.
This can cause a kafka partition to get 'stuck' on a message that takes too long to process.
In the future, it may make sense to have a message processing timeout which will prevent a partition from getting stuck.
https://app.datadoghq.com/apm/trace/3476962497584908341?colorBy=service&env=none&graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=6192398267551147842&spanViewType=infrastructure&timeHint=1664889004569.316

### How I found this problem

Debugged this by noticing that we have a very large `max` kafka offset relative to the `sum`. This means that one partition
has most of the messages that we have not processed.
![image](https://user-images.githubusercontent.com/1351531/193935380-dd0feb91-5b27-4738-9a09-b54def776834.png)

The [kafka UI](http://18.224.246.116:8080/ui/clusters/prod/consumer-groups/group-default) led me to find that partition 747 has 60% of all unread messages.
![image](https://user-images.githubusercontent.com/1351531/193935553-0a3501d2-ba99-4d54-a635-cbe32c7e1786.png)


Looking at the messages at the current 'last read message' (current partition offset), I see a 708 sunsama PushPayload with >1000 messages, all with the same `Event` text.

## How did you test this change?

local backend deploy

## Are there any deployment considerations?

Will monitor kafka backlog.
