### PR TITLE
fix type error in MetadataPanel

### DIFF
--- a/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
+++ b/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
@@ -145,7 +145,9 @@ const MetadataPanel = () => {
 		if (session?.object_storage_enabled) {
 			sessionData.push({
 				keyDisplayValue: 'Session Size',
-				valueDisplayValue: `${formatSize(session.payload_size)}`,
+				valueDisplayValue: session?.payload_size
+					? `${formatSize(session.payload_size)}`
+					: 'Unknown',
 				renderType: 'string',
 			})
 		}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Fixes type error in `MetadataPanel.tsx` by providing a fallback when `session.payload_size` is `undefined`.


![Screen Shot 2022-10-04 at 7 54 48 PM](https://user-images.githubusercontent.com/58678/193962647-8dc53271-9ec0-4064-9721-66b4f2baaa04.png)


Falling back to `Unknown` in consistent with what we already do:

https://github.com/highlight-run/highlight/blob/c5c04e28838fb57ac64d263f06b66aa1a9ff01dc/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx#L154-L195


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Observed type error is fixed.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
