### PR TITLE
fix type error in ErrorFeedV2

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -6780,7 +6780,7 @@ type ErrorGroup {
 	fields: [ErrorField]
 	state: ErrorState!
 	environments: String
-	error_frequency: [Int64]!
+	error_frequency: [Int64!]!
 	is_public: Boolean!
 }
 
@@ -18469,7 +18469,7 @@ func (ec *executionContext) _ErrorGroup_error_frequency(ctx context.Context, fie
 	}
 	res := resTmp.([]int64)
 	fc.Result = res
-	return ec.marshalNInt642ᚕint64(ctx, field.Selections, res)
+	return ec.marshalNInt642ᚕint64ᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ErrorGroup_error_frequency(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -55720,32 +55720,6 @@ func (ec *executionContext) marshalNInt642int64(ctx context.Context, sel ast.Sel
 	return res
 }
 
-func (ec *executionContext) unmarshalNInt642ᚕint64(ctx context.Context, v interface{}) ([]int64, error) {
-	var vSlice []interface{}
-	if v != nil {
-		vSlice = graphql.CoerceList(v)
-	}
-	var err error
-	res := make([]int64, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalOInt642int64(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (ec *executionContext) marshalNInt642ᚕint64(ctx context.Context, sel ast.SelectionSet, v []int64) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	for i := range v {
-		ret[i] = ec.marshalOInt642int64(ctx, sel, v[i])
-	}
-
-	return ret
-}
-
 func (ec *executionContext) unmarshalNInt642ᚕint64ᚄ(ctx context.Context, v interface{}) ([]int64, error) {
 	var vSlice []interface{}
 	if v != nil {
@@ -58373,16 +58347,6 @@ func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.Sele
 		return graphql.Null
 	}
 	res := graphql.MarshalInt(*v)
-	return res
-}
-
-func (ec *executionContext) unmarshalOInt642int64(ctx context.Context, v interface{}) (int64, error) {
-	res, err := graphql.UnmarshalInt64(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOInt642int64(ctx context.Context, sel ast.SelectionSet, v int64) graphql.Marshaler {
-	res := graphql.MarshalInt64(v)
 	return res
 }
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -349,7 +349,7 @@ type ErrorGroup {
 	fields: [ErrorField]
 	state: ErrorState!
 	environments: String
-	error_frequency: [Int64]!
+	error_frequency: [Int64!]!
 	is_public: Boolean!
 }
 

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -392,7 +392,7 @@ export type ErrorGroup = {
 	fields?: Maybe<Array<Maybe<ErrorField>>>
 	state: ErrorState
 	environments?: Maybe<Scalars['String']>
-	error_frequency: Array<Maybe<Scalars['Int64']>>
+	error_frequency: Array<Scalars['Int64']>
 	is_public: Scalars['Boolean']
 }
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

There is a type error in `frontend/src/pages/Errors/ErrorFeedV2/ErrorFeedV2.tsx`


<img width="996" alt="Screen Shot 2022-10-05 at 11 54 16 AM" src="https://user-images.githubusercontent.com/58678/194129553-1a319bb9-16e2-4040-9656-a6b3875fbd87.png">

This is because the GQL type definition is incorrect in that it was indicating we have a null error frequency.

Fixing the type definition fixes this issue.


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Observe that the type error is gone.

I did a look up as well as to where we are assigning the error frequency:

https://github.com/highlight-run/highlight/blob/eric/hig-2905-fix-type-error-in-errorfeedv2/backend/private-graph/graph/resolver.go#L430-L456

If one traverses the code, you can see that it builds a map of int64. These values are the doc counts in ES which should never be null:

<img width="770" alt="Screen Shot 2022-10-05 at 12 05 27 PM" src="https://user-images.githubusercontent.com/58678/194130652-72114195-e667-4570-9ed2-faef64144d9e.png">


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
