### PR TITLE
fix type error in TimelineErrorAnnotation

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -6755,7 +6755,7 @@ type ErrorObject {
 	columnNumber: Int
 	stack_trace: String!
 	structured_stack_trace: [ErrorTrace]!
-	timestamp: Timestamp
+	timestamp: Timestamp!
 	payload: String
 	request_id: String
 }
@@ -19676,11 +19676,14 @@ func (ec *executionContext) _ErrorObject_timestamp(ctx context.Context, field gr
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(time.Time)
 	fc.Result = res
-	return ec.marshalOTimestamp2timeᚐTime(ctx, field.Selections, res)
+	return ec.marshalNTimestamp2timeᚐTime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ErrorObject_timestamp(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -48460,6 +48463,9 @@ func (ec *executionContext) _ErrorObject(ctx context.Context, sel ast.SelectionS
 
 			out.Values[i] = ec._ErrorObject_timestamp(ctx, field, obj)
 
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "payload":
 
 			out.Values[i] = ec._ErrorObject_payload(ctx, field, obj)

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -324,7 +324,7 @@ type ErrorObject {
 	columnNumber: Int
 	stack_trace: String!
 	structured_stack_trace: [ErrorTrace]!
-	timestamp: Timestamp
+	timestamp: Timestamp!
 	payload: String
 	request_id: String
 }

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -365,7 +365,7 @@ export type ErrorObject = {
 	columnNumber?: Maybe<Scalars['Int']>
 	stack_trace: Scalars['String']
 	structured_stack_trace: Array<Maybe<ErrorTrace>>
-	timestamp?: Maybe<Scalars['Timestamp']>
+	timestamp: Scalars['Timestamp']
 	payload?: Maybe<Scalars['String']>
 	request_id?: Maybe<Scalars['String']>
 }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

There is a type error in `frontend/src/pages/Player/Toolbar/TimelineAnnotation/TimelineErrorAnnotation.tsx`

<img width="1038" alt="Screen Shot 2022-10-05 at 12 19 41 PM" src="https://user-images.githubusercontent.com/58678/194134182-5a21cf84-b3eb-421b-9552-524d1d2436ca.png">

This is because the GQL definition for `timestamp` is optional. I believe this is a manual type definition that we maintain but it's effectively the same as the gorm model:

https://github.com/highlight-run/highlight/blob/eric/hig-2906-fix-type-error-in/backend/model/model.go/#L874 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed type error is fixed.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
