### PR TITLE
ensure slack integration is not required to create an alert

### DIFF
--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -1,5 +1,6 @@
 import Card from '@components/Card/Card'
 import ConfirmModal from '@components/ConfirmModal/ConfirmModal'
+import PersonalNotificationButton from '@components/Header/components/PersonalNotificationButton/PersonalNotificationButton'
 import Input from '@components/Input/Input'
 import Switch from '@components/Switch/Switch'
 import TextHighlighter from '@components/TextHighlighter/TextHighlighter'
@@ -731,81 +732,91 @@ export const AlertConfigurationCard = ({
 								Pick Slack channels or people to message when an
 								alert is created.
 							</p>
-							<Form.Item shouldUpdate>
-								{() => (
-									<Select
-										className={styles.channelSelect}
-										options={channels}
-										mode="multiple"
-										onSearch={(value) => {
-											setSearchQuery(value)
-										}}
-										filterOption={(searchValue, option) => {
-											return (
-												option?.children
-													?.toString()
-													.toLowerCase()
-													.includes(
-														searchValue.toLowerCase(),
-													) || false
-											)
-										}}
-										placeholder={`Select a channel(s) or person(s) to send ${defaultName} to.`}
-										onChange={onChannelsChange}
-										notFoundContent={
-											<SyncWithSlackButton
-												isSlackIntegrated={
-													isSlackIntegrated
-												}
-												slackUrl={slackUrl}
-												refetchQueries={[
-													namedOperations.Query
-														.GetAlertsPagePayload,
-												]}
-											/>
-										}
-										defaultValue={alert?.ChannelsToNotify?.map(
-											(channel: any) =>
-												channel.webhook_channel_id,
-										)}
-										dropdownRender={(menu) => (
-											<div>
-												{menu}
-												{searchQuery.length === 0 &&
-													channelSuggestions.length >
-														0 && (
-														<>
-															<Divider
-																style={{
-																	margin: '4px 0',
-																}}
-															/>
-															<div
-																className={
-																	styles.addContainer
-																}
-															>
-																<SyncWithSlackButton
-																	isSlackIntegrated={
-																		isSlackIntegrated
-																	}
-																	slackUrl={
-																		slackUrl
-																	}
-																	refetchQueries={[
-																		namedOperations
-																			.Query
-																			.GetAlertsPagePayload,
-																	]}
+							{!isSlackIntegrated ? (
+								<PersonalNotificationButton
+									text="Connect Highlight with Slack"
+									type="Organization"
+								/>
+							) : (
+								<Form.Item shouldUpdate>
+									{() => (
+										<Select
+											className={styles.channelSelect}
+											options={channels}
+											mode="multiple"
+											onSearch={(value) => {
+												setSearchQuery(value)
+											}}
+											filterOption={(
+												searchValue,
+												option,
+											) => {
+												return (
+													option?.children
+														?.toString()
+														.toLowerCase()
+														.includes(
+															searchValue.toLowerCase(),
+														) || false
+												)
+											}}
+											placeholder={`Select a channel(s) or person(s) to send ${defaultName} to.`}
+											onChange={onChannelsChange}
+											notFoundContent={
+												<SyncWithSlackButton
+													isSlackIntegrated={
+														isSlackIntegrated
+													}
+													slackUrl={slackUrl}
+													refetchQueries={[
+														namedOperations.Query
+															.GetAlertsPagePayload,
+													]}
+												/>
+											}
+											defaultValue={alert?.ChannelsToNotify?.map(
+												(channel: any) =>
+													channel.webhook_channel_id,
+											)}
+											dropdownRender={(menu) => (
+												<div>
+													{menu}
+													{searchQuery.length === 0 &&
+														channelSuggestions.length >
+															0 && (
+															<>
+																<Divider
+																	style={{
+																		margin: '4px 0',
+																	}}
 																/>
-															</div>
-														</>
-													)}
-											</div>
-										)}
-									/>
-								)}
-							</Form.Item>
+																<div
+																	className={
+																		styles.addContainer
+																	}
+																>
+																	<SyncWithSlackButton
+																		isSlackIntegrated={
+																			isSlackIntegrated
+																		}
+																		slackUrl={
+																			slackUrl
+																		}
+																		refetchQueries={[
+																			namedOperations
+																				.Query
+																				.GetAlertsPagePayload,
+																		]}
+																	/>
+																</div>
+															</>
+														)}
+												</div>
+											)}
+										/>
+									)}
+								</Form.Item>
+							)}
 						</section>
 
 						<section>

--- a/frontend/src/pages/Alerts/Alerts.module.scss
+++ b/frontend/src/pages/Alerts/Alerts.module.scss
@@ -10,14 +10,6 @@
 
 .integrationAlert {
 	margin-bottom: var(--size-xxLarge);
-
-	.integrationButton {
-		margin-top: var(--size-large);
-	}
-}
-
-.hiddenSlackIntegrationButton {
-	display: none;
 }
 
 .cellWithTooltip {

--- a/frontend/src/pages/Alerts/Alerts.module.scss.d.ts
+++ b/frontend/src/pages/Alerts/Alerts.module.scss.d.ts
@@ -5,10 +5,8 @@ export const configurationContainer: string
 export const configureButton: string
 export const emptyContainer: string
 export const frequencyGraphEmptyMessage: string
-export const hiddenSlackIntegrationButton: string
 export const innerChart: string
 export const integrationAlert: string
-export const integrationButton: string
 export const intercomButton: string
 export const nameCell: string
 export const primary: string

--- a/frontend/src/pages/Alerts/Alerts.tsx
+++ b/frontend/src/pages/Alerts/Alerts.tsx
@@ -1,8 +1,6 @@
-import Alert from '@components/Alert/Alert'
 import BarChart from '@components/BarChart/BarChart'
 import ButtonLink from '@components/Button/ButtonLink/ButtonLink'
 import Card from '@components/Card/Card'
-import PersonalNotificationButton from '@components/Header/components/PersonalNotificationButton/PersonalNotificationButton'
 import { CircularSpinner } from '@components/Loading/Loading'
 import { SearchEmptyState } from '@components/SearchEmptyState/SearchEmptyState'
 import Table from '@components/Table/Table'
@@ -406,82 +404,17 @@ function AlertsPageLoaded({
 			<AlertSetupModal />
 			<div className={styles.subTitleContainer}>
 				<p>Manage the alerts for your project.</p>
-				{alertsPayload?.is_integrated_with_slack &&
-					alertsAsTableRows.length > 0 && (
-						<ButtonLink
-							trackingId="NewAlert"
-							className={styles.callToAction}
-							to={`/${project_id}/alerts/new`}
-						>
-							New Alert
-						</ButtonLink>
-					)}
+				{alertsAsTableRows.length > 0 && (
+					<ButtonLink
+						trackingId="NewAlert"
+						className={styles.callToAction}
+						to={`/${project_id}/alerts/new`}
+					>
+						New Alert
+					</ButtonLink>
+				)}
 			</div>
-			{!alertsPayload?.is_integrated_with_slack ? (
-				<Alert
-					trackingId="AlertPageSlackBotIntegration"
-					message={
-						!alertsPayload?.is_integrated_with_slack
-							? "Slack isn't connected"
-							: "Can't find a Slack channel or person?"
-					}
-					type={
-						!alertsPayload?.is_integrated_with_slack
-							? 'error'
-							: 'info'
-					}
-					description={
-						<>
-							{!alertsPayload?.is_integrated_with_slack ? (
-								<>
-									<p>
-										Highlight needs to be connected with
-										Slack in order to send you and your team
-										messages.
-									</p>
-									<p>
-										Once connected, you'll be able to get
-										alerts for things like:
-									</p>
-									<ul>
-										<li>Errors thrown</li>
-										<li>New users</li>
-										<li>A new feature is used</li>
-										<li>User submitted feedback</li>
-									</ul>
-									<PersonalNotificationButton
-										text="Connect Highlight with Slack"
-										className={styles.integrationButton}
-										type="Organization"
-									/>
-								</>
-							) : (
-								<>
-									Channels created and people joined after the
-									last Highlight and Slack sync will not show
-									up automatically.
-									<PersonalNotificationButton
-										text="Sync Highlight with Slack"
-										className={styles.integrationButton}
-										type="Organization"
-									/>
-								</>
-							)}
-						</>
-					}
-					closable={false}
-					className={styles.integrationAlert}
-				/>
-			) : (
-				<PersonalNotificationButton
-					text="Connect Highlight with Slack"
-					className={styles.hiddenSlackIntegrationButton}
-					type="Organization"
-				/>
-			)}
-
-			{((alertsPayload && alertsPayload?.is_integrated_with_slack) ||
-				!alertsPayload) && (
+			{alertsPayload && (
 				<Card noPadding style={{ width: 1200 }}>
 					<Table
 						columns={TABLE_COLUMNS}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Currently, we are blocking the usage of alerts without slack set up. Slack is not a requirement to use alerts (they can always use an email as a notification).


## How did you test this change?

### When slack is not integrated


Before:

There is no way to access alerts

![image](https://user-images.githubusercontent.com/58678/194147185-b532d4c0-514a-44fd-81d1-3a193389504e.png)

After:

Alerts are accessible from the homescreen

![Screen Shot 2022-10-05 at 1 37 28 PM](https://user-images.githubusercontent.com/58678/194147550-cd8b1662-a978-4922-b6af-665f3ac581c0.png)

Creating or modifying presents a call to action to integrate slack:

![Screen Shot 2022-10-05 at 1 37 56 PM](https://user-images.githubusercontent.com/58678/194147697-8403b452-0eed-4eca-8af9-075921ab4508.png)




## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
