### PR TITLE
fix onCompleted histogram loading

### DIFF
--- a/frontend/src/components/Histogram/Histogram.tsx
+++ b/frontend/src/components/Histogram/Histogram.tsx
@@ -50,13 +50,7 @@ const Histogram = React.memo(
 
 		const bucketStartTimes = bucketTimes.slice(0, -1)
 		const bucketEndTimes = bucketTimes.slice(1)
-
-		// assert all series have the same length
 		const seriesLength = bucketStartTimes.length
-		if (!seriesList.every((s) => s.counts.length === seriesLength)) {
-			console.log('seriesList', seriesList, seriesLength)
-			throw new Error('all series must have the same length')
-		}
 
 		const chartData: {
 			[key: string]: string | number
@@ -150,6 +144,15 @@ const Histogram = React.memo(
 					{inner}
 				</div>
 			)
+		}
+
+		// assert all series have the same length
+		if (!seriesList.every((s) => s.counts.length === seriesLength)) {
+			console.error('all series must have the same length', {
+				seriesList,
+				bucketStartTimes,
+			})
+			return null
 		}
 
 		return (

--- a/frontend/src/pages/Error/ErrorPage.tsx
+++ b/frontend/src/pages/Error/ErrorPage.tsx
@@ -539,16 +539,22 @@ const timeFilter = [
 export const ErrorFrequencyGraph: React.FC<
 	React.PropsWithChildren<FrequencyGraphProps>
 > = ({ errorGroup }) => {
-	const [errorDates, setErrorDates] = useState<Array<ErrorFrequency>>(
-		Array(LookbackPeriod).fill(0),
-	)
-	const [totalErrors, setTotalErrors] = useState<number>(0)
+	const [errorFrequency, setErrorFrequency] = useState<{
+		errorDates: Array<ErrorFrequency>
+		totalErrors: number
+	}>({
+		errorDates: Array(LookbackPeriod).fill(0),
+		totalErrors: 0,
+	})
 	const [dateRangeLength, setDateRangeLength] = useState<number>(
 		timeFilter[2].value,
 	)
 
 	useEffect(() => {
-		setErrorDates(Array(dateRangeLength).fill(0))
+		setErrorFrequency({
+			errorDates: Array(dateRangeLength).fill(0),
+			totalErrors: 0,
+		})
 	}, [dateRangeLength])
 
 	useGetDailyErrorFrequencyQuery({
@@ -566,10 +572,13 @@ export const ErrorFrequencyGraph: React.FC<
 					.format('D MMM YYYY'),
 				occurrences: val,
 			}))
-			setTotalErrors(
-				response.dailyErrorFrequency.reduce((acc, val) => acc + val, 0),
-			)
-			setErrorDates(errorData)
+			setErrorFrequency({
+				errorDates: errorData,
+				totalErrors: response.dailyErrorFrequency.reduce(
+					(acc, val) => acc + val,
+					0,
+				),
+			})
 		},
 	})
 
@@ -594,7 +603,7 @@ export const ErrorFrequencyGraph: React.FC<
 					<BarChart
 						width={500}
 						height={300}
-						data={errorDates}
+						data={errorFrequency.errorDates}
 						margin={{
 							top: 5,
 							right: 10,
@@ -616,12 +625,15 @@ export const ErrorFrequencyGraph: React.FC<
 						/>
 						<RechartsTooltip content={<RechartTooltip />} />
 						<Bar dataKey="occurrences" radius={[2, 2, 0, 0]}>
-							{errorDates.map((e, i) => (
+							{errorFrequency.errorDates.map((e, i) => (
 								<Cell
 									key={i}
 									fill={
 										e.occurrences >
-										Math.max(totalErrors * 0.1, 10)
+										Math.max(
+											errorFrequency.totalErrors * 0.1,
+											10,
+										)
 											? 'var(--color-red-500)'
 											: 'var(--color-brown)'
 									}
@@ -631,7 +643,7 @@ export const ErrorFrequencyGraph: React.FC<
 					</BarChart>
 				</ResponsiveContainer>
 				<div className={styles.graphLabels}>
-					<div>{`Total Occurrences: ${totalErrors}`}</div>
+					<div>{`Total Occurrences: ${errorFrequency.totalErrors}`}</div>
 				</div>
 			</div>
 		</>

--- a/frontend/src/pages/Errors/ErrorFeedV2/ErrorFeedV2.tsx
+++ b/frontend/src/pages/Errors/ErrorFeedV2/ErrorFeedV2.tsx
@@ -46,10 +46,13 @@ const PAGE_SIZE = 10
 const useHistogram = (projectID: string, projectHasManyErrors: boolean) => {
 	const { backendSearchQuery, searchParams, setSearchParams } =
 		useErrorSearchContext()
-	const [histogramSeriesList, setHistogramSeriesList] = useState<Series[]>([])
-	const [histogramBucketTimes, setHistogramBucketTimes] = useState<number[]>(
-		[],
-	)
+	const [histogram, setHistogram] = useState<{
+		seriesList: Series[]
+		bucketTimes: number[]
+	}>({
+		seriesList: [],
+		bucketTimes: [],
+	})
 	const { loading } = useGetErrorsHistogramQuery({
 		variables: {
 			query: backendSearchQuery?.childSearchQuery as string,
@@ -83,8 +86,10 @@ const useHistogram = (projectID: string, projectHasManyErrors: boolean) => {
 					},
 				]
 			}
-			setHistogramSeriesList(seriesList)
-			setHistogramBucketTimes(bucketTimes)
+			setHistogram({
+				seriesList,
+				bucketTimes,
+			})
 		},
 		skip: !backendSearchQuery?.childSearchQuery,
 		fetchPolicy: projectHasManyErrors ? 'cache-first' : 'no-cache',
@@ -107,8 +112,8 @@ const useHistogram = (projectID: string, projectHasManyErrors: boolean) => {
 
 	return (
 		<SearchResultsHistogram
-			seriesList={histogramSeriesList}
-			bucketTimes={histogramBucketTimes}
+			seriesList={histogram.seriesList}
+			bucketTimes={histogram.bucketTimes}
 			bucketSize={backendSearchQuery?.histogramBucketSize}
 			loading={loading}
 			updateTimeRange={updateTimeRange}

--- a/frontend/src/pages/Sessions/SessionsFeedV2/SessionsFeed.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/SessionsFeed.tsx
@@ -59,10 +59,13 @@ import styles from './SessionsFeed.module.scss'
 const useHistogram = (projectId: string, projectHasManySessions: boolean) => {
 	const { searchParams, setSearchParams, backendSearchQuery } =
 		useSearchContext()
-	const [histogramSeriesList, setHistogramSeriesList] = useState<Series[]>([])
-	const [histogramBucketTimes, setHistogramBucketTimes] = useState<number[]>(
-		[],
-	)
+	const [histogram, setHistogram] = useState<{
+		seriesList: Series[]
+		bucketTimes: number[]
+	}>({
+		seriesList: [],
+		bucketTimes: [],
+	})
 
 	const { loading } = useGetSessionsHistogramQuery({
 		variables: {
@@ -102,8 +105,10 @@ const useHistogram = (projectId: string, projectHasManySessions: boolean) => {
 					},
 				]
 			}
-			setHistogramSeriesList(seriesList)
-			setHistogramBucketTimes(bucketTimes)
+			setHistogram({
+				seriesList,
+				bucketTimes,
+			})
 		},
 		skip: !backendSearchQuery,
 		fetchPolicy: projectHasManySessions ? 'cache-first' : 'no-cache',
@@ -126,8 +131,8 @@ const useHistogram = (projectId: string, projectHasManySessions: boolean) => {
 
 	return (
 		<SearchResultsHistogram
-			seriesList={histogramSeriesList}
-			bucketTimes={histogramBucketTimes}
+			seriesList={histogram.seriesList}
+			bucketTimes={histogram.bucketTimes}
 			bucketSize={backendSearchQuery?.histogramBucketSize}
 			loading={loading}
 			updateTimeRange={updateTimeRange}

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -22,18 +22,20 @@ function AutoJoinForm({
 	updateOrigins?: (domains: string[]) => void
 	newWorkspace?: boolean
 }) {
-	const [emailOrigins, setEmailOrigins] = useState<string[]>([])
-	const [allowedEmailOrigins, setAllowedEmailOrigins] = useState<string[]>([])
+	const [origins, setOrigins] = useState<{
+		emailOrigins: string[]
+		allowedEmailOrigins: string[]
+	}>({ emailOrigins: [], allowedEmailOrigins: [] })
 	const { workspace_id } = useParams<{ workspace_id: string }>()
 	const { admin } = useAuthContext()
 	const { loading } = useGetWorkspaceAdminsQuery({
 		variables: { workspace_id },
 		onCompleted: (d) => {
+			let emailOrigins
 			if (d.workspace?.allowed_auto_join_email_origins) {
-				const emailOrigins = JSON.parse(
+				emailOrigins = JSON.parse(
 					d.workspace.allowed_auto_join_email_origins,
 				)
-				setEmailOrigins(emailOrigins)
 			}
 			const allowedDomains: string[] = []
 			d.admins.forEach((wa) => {
@@ -44,13 +46,16 @@ function AutoJoinForm({
 				)
 					allowedDomains.push(adminDomain)
 			})
-			setAllowedEmailOrigins(allowedDomains)
+			setOrigins({ emailOrigins, allowedEmailOrigins: allowedDomains })
 		},
 	})
 
 	const [updateAllowedEmailOrigins] = useUpdateAllowedEmailOriginsMutation()
 	const onChangeMsg = (domains: string[], msg: string) => {
-		setEmailOrigins(domains)
+		setOrigins((p) => ({
+			emailOrigins: domains,
+			allowedEmailOrigins: p.allowedEmailOrigins,
+		}))
 		if (updateOrigins) {
 			updateOrigins(domains)
 		} else {
@@ -73,7 +78,10 @@ function AutoJoinForm({
 
 	useEffect(() => {
 		if (newWorkspace && adminsEmailDomain.length) {
-			setEmailOrigins([adminsEmailDomain])
+			setOrigins((p) => ({
+				emailOrigins: [adminsEmailDomain],
+				allowedEmailOrigins: p.allowedEmailOrigins,
+			}))
 		}
 	}, [newWorkspace, adminsEmailDomain])
 
@@ -97,7 +105,7 @@ function AutoJoinForm({
 				<Switch
 					trackingId="WorkspaceAutoJoin"
 					label="Enable Auto Join"
-					checked={emailOrigins.length > 0}
+					checked={origins.emailOrigins.length > 0}
 					loading={loading}
 					onChange={(checked) => {
 						if (checked) {
@@ -115,11 +123,15 @@ function AutoJoinForm({
 					placeholder={`${adminsEmailDomain}, acme.corp, piedpiper.com`}
 					className={styles.select}
 					loading={loading}
-					value={newWorkspace ? [adminsEmailDomain] : emailOrigins}
+					value={
+						newWorkspace
+							? [adminsEmailDomain]
+							: origins.emailOrigins
+					}
 					mode="tags"
 					disabled={newWorkspace}
 					onChange={onChange}
-					options={allowedEmailOrigins.map((emailOrigin) => ({
+					options={origins.allowedEmailOrigins.map((emailOrigin) => ({
 						displayValue: emailOrigin,
 						id: emailOrigin,
 						value: emailOrigin,


### PR DESCRIPTION
## Summary

`Histogram.tsx` was failing the params checking because it would experience an intermediate render where one prop was set from the parent component's state but the other prop was not yet set.
`@apollo/client@3.7` `onCompleted` callback behavior changed to cause an intermediate render between the setState operations.
with concurrent rendering, this worked correctly because react would not perform an intermediate render between the state changes.
with the new apollo/client package but without concurrent rendering, the intermediate state would crash the sessions feed.

## How did you test this change?

Local deploy, PR preview

## Are there any deployment considerations?

No