### PR TITLE
add click to component dev tooling

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
 		"apollo3-cache-persist": "^0.14.0",
 		"babel-plugin-react-wrapped-display-name": "^1.0.0",
 		"classnames": "^2.3.1",
+		"click-to-react-component": "^1.0.8",
 		"color-hash": "^2.0.1",
 		"dinero.js": "^2.0.0-alpha.8",
 		"eslint-plugin-simple-import-sort": "^7.0.0",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -34,6 +34,7 @@ import { HIGHLIGHT_ADMIN_EMAIL_DOMAINS } from '@util/authorization/authorization
 import { showHiringMessage } from '@util/console/hiringMessage'
 import { client } from '@util/graph'
 import { isOnPrem } from '@util/onPrem/onPremUtils'
+import { ClickToComponent } from 'click-to-react-component'
 import { H, HighlightOptions } from 'highlight.run'
 import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom'
@@ -405,6 +406,7 @@ get in contact with us!
 ReactDOM.render(
 	<React.StrictMode>
 		<App />
+		<ClickToComponent />
 	</React.StrictMode>,
 	document.getElementById('root'),
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -4993,6 +4993,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "@floating-ui/core@npm:0.6.2"
+  checksum: b3e1844da852fe141cfa4163026a7c5ffb4399a96105340dffdd5b76dcafea72c6221a06b4674c2b500bc776adc9d9e4ed39dba55e7d844d9507d994c0af743a
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^0.4.5":
+  version: 0.4.5
+  resolution: "@floating-ui/dom@npm:0.4.5"
+  dependencies:
+    "@floating-ui/core": ^0.6.2
+  checksum: 3024aba55fe7ee78b429a6a5d61f5719a6bb2acc79c8a33304b9d30c443efba3a5288acaf9003402e31ee97a533eda97c30a0f2c97e9e54c697df9b80a23dad8
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react-dom-interactions@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@floating-ui/react-dom-interactions@npm:0.3.1"
+  dependencies:
+    "@floating-ui/react-dom": ^0.6.3
+    aria-hidden: ^1.1.3
+    point-in-polygon: ^1.1.0
+    use-isomorphic-layout-effect: ^1.1.1
+  checksum: 398108a415b0d4e3647c58912b967f673e56053e33c8059f9251374a00c0d1d507c0ea45ec3a9cc772f6bc02837e61920062df504aa762ed7f001634e0838d41
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react-dom@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "@floating-ui/react-dom@npm:0.6.3"
+  dependencies:
+    "@floating-ui/dom": ^0.4.5
+    use-isomorphic-layout-effect: ^1.1.1
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 1af930aac4e13ed9a25ea2cf70e629d36363034a70ea407a6f8d8d4bd62979c59d3748b58e1ef31c427fdf21a754f285aabba9f14b9e916ab69eb5212144ef6c
+  languageName: node
+  linkType: hard
+
 "@fontsource/poppins@npm:^4.5.9":
   version: 4.5.9
   resolution: "@fontsource/poppins@npm:4.5.9"
@@ -6341,6 +6382,7 @@ __metadata:
     autoprefixer: ^10.4.8
     babel-plugin-react-wrapped-display-name: ^1.0.0
     classnames: ^2.3.1
+    click-to-react-component: ^1.0.8
     color-hash: ^2.0.1
     dinero.js: ^2.0.0-alpha.8
     eslint: ^7.0.0
@@ -10895,6 +10937,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aria-hidden@npm:^1.1.3":
+  version: 1.2.1
+  resolution: "aria-hidden@npm:1.2.1"
+  dependencies:
+    tslib: ^2.0.0
+  peerDependencies:
+    "@types/react": ^16.9.0 || ^17.0.0 || ^18.0.0
+    react: ^16.9.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: cd8047a0113d5ecc11bce1616ae2772abcb0a6e1da5a70cbfc3555e8da063b0416d62cced3e704b6d424cbf408c1fc21225d69723cd62c3f1f0cf3b41d674c2b
+  languageName: node
+  linkType: hard
+
 "aria-query@npm:^4.2.2":
   version: 4.2.2
   resolution: "aria-query@npm:4.2.2"
@@ -12894,6 +12951,19 @@ __metadata:
   version: 3.0.0
   resolution: "cli-width@npm:3.0.0"
   checksum: 4c94af3769367a70e11ed69aa6095f1c600c0ff510f3921ab4045af961820d57c0233acfa8b6396037391f31b4c397e1f614d234294f979ff61430a6c166c3f6
+  languageName: node
+  linkType: hard
+
+"click-to-react-component@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "click-to-react-component@npm:1.0.8"
+  dependencies:
+    "@floating-ui/react-dom-interactions": ^0.3.1
+    htm: ^3.1.0
+    react-merge-refs: ^1.1.0
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 87f42251fe59b596ce7d2a659b3eb640ad7a69708b5d96a5a6f98e978e01ccfead9a8936161570c1386d914b9af406fac8eaea1f6f74c1e003514205cdf17902
   languageName: node
   linkType: hard
 
@@ -18975,6 +19045,13 @@ __metadata:
   version: 1.0.0
   resolution: "hsla-regex@npm:1.0.0"
   checksum: 9aa6eb9ff6c102d2395435aa5d1d91eae20043c4b1497c543d8db501c05f3edacd9a07fb34a987059d7902dba415af4cb4e610f751859ae8e7525df4ffcd085f
+  languageName: node
+  linkType: hard
+
+"htm@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "htm@npm:3.1.1"
+  checksum: 1827a0cafffcff69690b048a4df59944086d7503fe5eb7c10b40834439205bdf992941e7aa25e92b3c2c086170565b4ed7c365bc072d31067c6e7a4e478776bd
   languageName: node
   linkType: hard
 
@@ -25422,6 +25499,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"point-in-polygon@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "point-in-polygon@npm:1.1.0"
+  checksum: 67a6374f0b79bc872bde8e375d7d5ea011a1419c5f4320dfb7705801cd3a8fcaee8bff385465e075b2ce863bbc86ccd74c63345d9f326981cd0807642bc5199c
+  languageName: node
+  linkType: hard
+
 "popmotion@npm:11.0.3":
   version: 11.0.3
   resolution: "popmotion@npm:11.0.3"
@@ -28432,6 +28516,13 @@ __metadata:
   peerDependencies:
     react: ">=16.8.0"
   checksum: a808e13460749680c3e4f545af367dd0539e9397e85b851fe49c21ac56fd866e1344478405bbf7fa4d9b8859a3304a3e0aeeb35306d7b6ef6af5c8b6497eed46
+  languageName: node
+  linkType: hard
+
+"react-merge-refs@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "react-merge-refs@npm:1.1.0"
+  checksum: 90884352999002d868ab9f1bcfe3222fb0f2178ed629f1da7e98e5a9b02a2c96b4aa72800db92aabd69d2483211b4be57a2088e89a11a0b660e7ada744d4ddf7
   languageName: node
   linkType: hard
 
@@ -33705,6 +33796,18 @@ __metadata:
     "@types/react":
       optional: true
   checksum: fd9061817d4945af37fd79866b1fe96a09cafe873169a66ec699140b609c64db6c60512d94ec3ca90967837026ea6e6d003901c557693708aeee11d392418a9e
+  languageName: node
+  linkType: hard
+
+"use-isomorphic-layout-effect@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "use-isomorphic-layout-effect@npm:1.1.2"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: a6532f7fc9ae222c3725ff0308aaf1f1ddbd3c00d685ef9eee6714fd0684de5cb9741b432fbf51e61a784e2955424864f7ea9f99734a02f237b17ad3e18ea5cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Often times it's a pain to traverse the React devtools to find the correct component. 

This PR adds the [click-to-component](https://github.com/ericclemmons/click-to-component) tool that allows clicking on components to open them in vscode.

TLDR;
- <kbd>Option+Click</kbd> opens the immediate Component's source
- <kbd>Option+Right-click</kbd> opens a context menu with the parent Components' `props`, `fileName`, `columnNumber`, and `lineNumber`

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

https://www.loom.com/share/e666d6550aac4e9db731b0d2da0f37f7

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

n/a