### PR TITLE
fix an undefined error in AutoJoinForm

### DIFF
--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -31,7 +31,7 @@ function AutoJoinForm({
 	const { loading } = useGetWorkspaceAdminsQuery({
 		variables: { workspace_id },
 		onCompleted: (d) => {
-			let emailOrigins
+			let emailOrigins: string[] = []
 			if (d.workspace?.allowed_auto_join_email_origins) {
 				emailOrigins = JSON.parse(
 					d.workspace.allowed_auto_join_email_origins,


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

When Auto Join is disabled for the workspace settings, users will get an error when trying to invite a member.



This is due to a type error whereby this line fails:

https://github.com/highlight-run/highlight/blob/eric/hig-2921-workspace-errors-when-there-are-no/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx#L108

because we accidentally set `origins.emailOrigins` to null when `workspace.allowed_auto_join_email_origins` is null. 

This PR handles that scenario gracefully by ensuring that `origins.emailOrigins` is set to an empty array in that scenario (the default value of that state).


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

I disabled Auto Join
![Screen Shot 2022-10-07 at 8 57 16 AM](https://user-images.githubusercontent.com/58678/194584162-cf01ad6c-9715-4942-99c4-452c23c0595a.png)

And validated that I do no get an error when using the Invite Member button.



## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
