### PR TITLE
fix type error on HomeCharts.tsx

### DIFF
--- a/frontend/src/pages/Home/utils/HomeCharts.tsx
+++ b/frontend/src/pages/Home/utils/HomeCharts.tsx
@@ -215,7 +215,6 @@ const DailyChart = ({
 	return (
 		<ResponsiveContainer width="100%" height={275}>
 			<BarChartV2
-				height={275}
 				barSize={12}
 				data={data}
 				barColorMapping={{


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

The `height` prop is not valid for `BarChartV2`

![Screen Shot 2022-10-07 at 10 39 37 AM](https://user-images.githubusercontent.com/58678/194604573-57dd6e95-a96e-474b-bb5f-4ed0f938ba83.png)

It was removed in this [PR](https://github.com/highlight-run/highlight/pull/3052/files#diff-b2204a32ec97395ea6e8db3dab0390351490837ddd2d8748d222ae5af2545f11L94). 


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Ensured no type errors in `frontend/src/pages/Home/utils/HomeCharts.tsx`

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
