### PR TITLE
hotfix: yarn auth

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -33,13 +33,6 @@ jobs:
                   node-version: 16
                   cache: 'yarn'
 
-            - name: Configure yarn npm registry authentication
-              run: |
-                  echo 'npmRegistryServer: "https://npm.pkg.github.com"' >> .yarnrc.yml
-                  echo "npmAuthToken: \"${NPM_TOKEN}\"" >> .yarnrc.yml
-              env:
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
             - name: Install js dependencies
               run: yarn
 
@@ -62,6 +55,13 @@ jobs:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws-region: us-east-2
+
+            - name: Configure yarn npm registry credentials
+              run: |
+                  echo 'npmRegistryServer: "https://npm.pkg.github.com"' >> .yarnrc.yml
+                  echo "npmAuthToken: \"${NPM_TOKEN}\"" >> .yarnrc.yml
+              env:
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Publish npm packages
               if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Summary

Makes sure that yarn auth are written to yarnrc.yml (see [this](https://github.com/highlight-run/highlight/pull/3145) and [this](https://github.com/highlight-run/highlight/pull/3151) for context).

## How did you test this change?

This is a CI change that is only visible when pushed to master. 

## Are there any deployment considerations?

n/a