### PR TITLE
only check oauth when cookie is set

### DIFF
--- a/backend/oauth/oauth.go
+++ b/backend/oauth/oauth.go
@@ -219,6 +219,13 @@ func (s *Server) HandleValidate(w http.ResponseWriter, r *http.Request) {
 	_ = je.Encode(data)
 }
 
+func (s *Server) HasCookie(r *http.Request) bool {
+	if cookie, err := r.Cookie(CookieName); err == nil {
+		return cookie.Value != ""
+	}
+	return false
+}
+
 // Validate ensures the request is authenticated and configures the context to contain
 // necessary authorization context variables. the function returns the auth token cookie,
 // refreshed if applicable.

--- a/backend/private-graph/graph/middleware.go
+++ b/backend/private-graph/graph/middleware.go
@@ -126,7 +126,7 @@ func PrivateMiddleware(next http.Handler) http.Handler {
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 				return
 			}
-		} else {
+		} else if OAuthServer.HasCookie(r) {
 			span.SetOperationName("oauth")
 			var cookie *http.Cookie
 			ctx, _, cookie, err = OAuthServer.Validate(ctx, r)


### PR DESCRIPTION
## Summary

#3084 made all private graph requests authenticated. This breaks publicly shared sessions since they rely on private graph endpoints where the user is not logged in.

## How did you test this change?

Local sessions set to publicly-shared are viewable without being logged in.

## Are there any deployment considerations?

No
