### PR TITLE
switch to cross-fetch

### DIFF
--- a/sourcemap-uploader/package.json
+++ b/sourcemap-uploader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@highlight-run/sourcemap-uploader",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Command line tool to upload source maps to Highlight",
   "bin": "./dist/index.js",
   "author": "Highlight",
@@ -28,9 +28,9 @@
   "dependencies": {
     "@types/node": "17.0.23",
     "aws-sdk": "2.1163.0",
+    "cross-fetch": "^3.1.5",
     "eslint": "8.12.0",
     "glob": "7.2.3",
-    "node-fetch": "3.2.10",
     "typescript": "^4.8.2",
     "yargs": "17.5.1"
   }

--- a/sourcemap-uploader/src/index.ts
+++ b/sourcemap-uploader/src/index.ts
@@ -6,7 +6,7 @@ import { hideBin } from "yargs/helpers";
 import { readFileSync, statSync } from "fs";
 import glob from "glob";
 import AWS from "aws-sdk";
-import fetch from "node-fetch";
+import fetch from "cross-fetch";
 
 const VERIFY_API_KEY_QUERY = `
   query ApiKeyToOrgID($api_key: String!) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6682,9 +6682,9 @@ __metadata:
     "@types/node-fetch": ^2.6.2
     "@types/yargs": ^17.0.0
     aws-sdk: 2.1163.0
+    cross-fetch: ^3.1.5
     eslint: 8.12.0
     glob: 7.2.3
-    node-fetch: 3.2.10
     npm-run-all: 4.1.5
     tsup: ^6.2.3
     typescript: ^4.8.2


### PR DESCRIPTION
- cjs compatible
- tested locally with `yarn sourcemaps:frontend`
- switching over to dynamic import() would mean changing some other flags:
<img width="659" alt="Screen Shot 2022-10-11 at 9 11 11 PM" src="https://user-images.githubusercontent.com/86132398/195248146-17f7df4a-31ca-4349-ab06-ff3b4c00fd52.png">
