### PR TITLE
disable sourcemap generation through vite

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -84,7 +84,8 @@ export default defineConfig(({ mode }) => {
 		},
 		build: {
 			outDir: 'build',
-			// The sourcemap config option seem to be broken with HMR https://github.com/vitejs/vite/issues/5916
+			// Vite sourcemaps are totally broken
+			// https://github.com/highlight-run/highlight/pull/3171
 			sourcemap: mode !== 'development',
 		},
 		test: {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Sourcemaps are broken in some components such that we cannot set a breakpoint to debug.
Initially, I assumed this issue was isolated onto to development but it's also broken in production.

There's a slew of issues around sourcemaps being broken in vite
* https://github.com/vitejs/vite-plugin-vue/issues/33
* https://github.com/vitejs/vite/issues/5834
* https://github.com/vitejs/vite-plugin-react/issues/23

The overall theme is either:
* Sourcemaps do not play well with HMR
* [Multi-line imports](https://github.com/vitejs/vite/issues/5834#issuecomment-1120254762) break line numbers

I haven't been able to confirm either of these being the root cause for us. 

In #3111, I introduced sourcemaps into production. This is what started breaking development sourcemaps for us. The simplest solution right now to fix this is to disable [build.sourcemaps](https://vitejs.dev/config/build-options.html#build-sourcemap) in development. The docs state `Generate **production** source maps.`. It's unclear what production really means and why it would affect development. However, when this option is turned off line numbers are lined up correctly (see test plan). 

This _does not_ fix line numbers being misaligned in production. I believe we cannot do anything about this because of the linked Vite Github issues. 
An alternative approach would be to turn off production sourcemaps but I believe having some type of debugging that sort of works is better than nothing at all.


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

### In development

I used a problematic code area as my baseline to confirm that I could set a breakpoint:
https://github.com/highlight-run/highlight/blob/eric/fix-broken-sourcemaps/frontend/src/pages/Sessions/SessionsFeedV2/components/QueryBuilder/QueryBuilder.tsx/#L1106-L1110


Before:

![Screen_Shot_2022-10-12_at_8_30_51_AM](https://user-images.githubusercontent.com/58678/195371256-d18c1059-d758-4f9b-967f-38e475550fff.png)


After:
![Screen_Shot_2022-10-12_at_8_32_15_AM](https://user-images.githubusercontent.com/58678/195371273-d3eec8ea-1096-4366-92d0-b69be2cbae9d.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
