### PR TITLE
base path logic in sourcemap uploader

### DIFF
--- a/highlight-next/package.json
+++ b/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "Client for interfacing with Highlight in next.js",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/highlight-next/src/util/highlightWebpackPlugin.ts
+++ b/highlight-next/src/util/highlightWebpackPlugin.ts
@@ -4,11 +4,18 @@ export default class HighlightWebpackPlugin {
 	apiKey: string
 	appVersion: string
 	path: string
+	basePath: string
 
-	constructor(apiKey: string, appVersion: string, path: string) {
+	constructor(
+		apiKey: string,
+		appVersion: string,
+		path: string,
+		basePath: string,
+	) {
 		this.apiKey = apiKey
 		this.appVersion = appVersion
 		this.path = path
+		this.basePath = basePath
 	}
 
 	apply(compiler: any) {
@@ -17,6 +24,7 @@ export default class HighlightWebpackPlugin {
 				apiKey: this.apiKey,
 				appVersion: this.appVersion,
 				path: this.path,
+				basePath: this.basePath,
 			})
 		})
 		return compiler

--- a/highlight-next/src/util/withHighlightConfig.ts
+++ b/highlight-next/src/util/withHighlightConfig.ts
@@ -9,6 +9,7 @@ interface HighlightConfigOptionsDefault {
 	apiKey: string
 	appVersion: string
 	sourceMapsPath: string
+	sourceMapsBasePath: string
 }
 
 export interface HighlightConfigOptions {
@@ -17,6 +18,7 @@ export interface HighlightConfigOptions {
 	apiKey?: string
 	appVersion?: string
 	sourceMapsPath?: string
+	sourceMapsBasePath?: string
 }
 
 const getDefaultOpts = (
@@ -35,6 +37,7 @@ const getDefaultOpts = (
 		apiKey: highlightOpts?.apiKey ?? '',
 		appVersion: highlightOpts?.appVersion ?? '',
 		sourceMapsPath: highlightOpts?.sourceMapsPath ?? '.next/',
+		sourceMapsBasePath: highlightOpts?.sourceMapsBasePath ?? '_next/',
 	}
 }
 
@@ -100,7 +103,8 @@ export const withHighlightConfig = (
 				new HighlightWebpackPlugin(
 					defaultOpts.apiKey,
 					defaultOpts.appVersion,
-					defaultOpts.sourceMapsPath ?? '.next/',
+					defaultOpts.sourceMapsPath,
+					defaultOpts.sourceMapsBasePath,
 				),
 			)
 

--- a/sourcemap-uploader/package.json
+++ b/sourcemap-uploader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@highlight-run/sourcemap-uploader",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Command line tool to upload source maps to Highlight",
   "bin": "./dist/index.js",
   "author": "Highlight",

--- a/sourcemap-uploader/src/index.ts
+++ b/sourcemap-uploader/src/index.ts
@@ -26,10 +26,12 @@ export const uploadSourcemaps = async ({
   apiKey,
   appVersion,
   path,
+  basePath,
 }: {
   apiKey: string;
   appVersion: string;
   path: string;
+  basePath: string;
 }) => {
   if (!apiKey || apiKey === "") {
     if (process.env.HIGHLIGHT_SOURCEMAP_UPLOAD_API_KEY) {
@@ -87,7 +89,7 @@ export const uploadSourcemaps = async ({
 
   await Promise.all(
     fileList.map(({ path, name }) =>
-      uploadFile(organizationId, appVersion, path, name)
+      uploadFile(organizationId, appVersion, path, basePath, name)
     )
   );
 };
@@ -115,6 +117,12 @@ yargs(hideBin(process.argv))
     type: "string",
     default: "/build",
     describe: "Sets the directory of where the sourcemaps are",
+  })
+  .option("basePath", {
+    alias: "bp",
+    type: "string",
+    default: "",
+    describe: "An optional base path for the uploaded sourcemaps",
   })
   .help("help").argv;
 
@@ -160,6 +168,7 @@ async function uploadFile(
   organizationId: string,
   version: string,
   filePath: string,
+  basePath: string,
   fileName: string
 ) {
   const fileContent = readFileSync(filePath);
@@ -168,7 +177,7 @@ async function uploadFile(
   if (version === null || version === undefined || version === "" || !version) {
     version = "unversioned";
   }
-  const bucketPath = `${organizationId}/${version}/${fileName}`;
+  const bucketPath = `${organizationId}/${version}/${basePath}${fileName}`;
 
   const params = {
     Bucket: BUCKET_NAME,
@@ -180,6 +189,6 @@ async function uploadFile(
     if (err) {
       throw err;
     }
-    console.log(`Uploaded ${fileName}`);
+    console.log(`Uploaded ${basePath}${fileName}`);
   });
 }


### PR DESCRIPTION
- instead of trimming paths on the backend with special handling for `_next`, just upload within a `_next` folder
- (after some testing, the previous logic from #3174 didn't quite work and would be a bit more complicated)