### PR TITLE
remove instrumentServer to see if this fixes next12 builds

### DIFF
--- a/highlight-next/package.json
+++ b/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"description": "Client for interfacing with Highlight in next.js",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/highlight-next/src/util/withHighlight.ts
+++ b/highlight-next/src/util/withHighlight.ts
@@ -1,6 +1,5 @@
 import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next'
 import { H, HIGHLIGHT_REQUEST_HEADER, NodeOptions } from '@highlight-run/node'
-import { instrumentServer } from './instrumentServer.js'
 
 export interface HighlightGlobal {
 	__HIGHLIGHT__?: {
@@ -14,8 +13,6 @@ export const Highlight =
 	(
 		origHandler: NextApiHandler<T>,
 	): ((req: NextApiRequest, res: NextApiResponse<T>) => Promise<T>) => {
-		instrumentServer()
-
 		return async (req, res): Promise<any> => {
 			const processHighlightHeaders = () => {
 				if (req.headers && req.headers[HIGHLIGHT_REQUEST_HEADER]) {


### PR DESCRIPTION
## Summary
- getting a warning and error caused by this import
- downgrading seems to fix this so might be a recent Next.js change
<img width="1293" alt="Screen Shot 2022-10-12 at 2 50 28 PM" src="https://user-images.githubusercontent.com/86132398/195454722-5d2aa935-d5dc-4324-a6a0-c5f9d8530858.png">
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- yalc is not working for me locally - after deploying, will check to see if this resolves the backend errors
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
