### PR TITLE
try flushing after errors / metrics

### DIFF
--- a/highlight-next/package.json
+++ b/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"description": "Client for interfacing with Highlight in next.js",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/highlight-next/src/util/withHighlight.ts
+++ b/highlight-next/src/util/withHighlight.ts
@@ -38,6 +38,7 @@ export const Highlight =
 					H.consumeEvent(secureSessionId)
 					if (e instanceof Error) {
 						H.consumeError(e, secureSessionId, requestId)
+						H.flush()
 					}
 				}
 				// Because we're going to finish and send the transaction before passing the error onto nextjs, it won't yet
@@ -56,6 +57,7 @@ export const Highlight =
 				const { secureSessionId, requestId } = processHighlightHeaders()
 				if (secureSessionId) {
 					H.recordMetric(secureSessionId, 'latency', delta, requestId)
+					H.flush()
 				}
 			}
 		}

--- a/highlight-node/package.json
+++ b/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/highlight-node/src/sdk.ts
+++ b/highlight-node/src/sdk.ts
@@ -18,6 +18,7 @@ export interface HighlightInterface {
 		value: number,
 		requestId?: string,
 	) => void
+	flush: () => void
 }
 
 var highlight_obj: Highlight
@@ -58,6 +59,13 @@ export const H: HighlightInterface = {
 			highlight_obj.recordMetric(secureSessionId, name, value, requestId)
 		} catch (e) {
 			console.log('highlight-node recordMetric error: ', e)
+		}
+	},
+	flush: () => {
+		try {
+			highlight_obj.flush()
+		} catch (e) {
+			console.log('highlight-node flush error: ', e)
 		}
 	},
 }


### PR DESCRIPTION
## Summary
- not seeing backend errors from my Vercel deployment at the moment
- calling flush would trigger these errors to be sent immediately
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- wasn't able to test the whole thing (yalc was picking up my /next changes but not my /node ones...), will revert if this is causing issues
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
