### PR TITLE
remove debug console.logs, stop using deprecated field of lru-cache

### DIFF
--- a/highlight-next/package.json
+++ b/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "1.3.6",
+	"version": "1.3.7",
 	"description": "Client for interfacing with Highlight in next.js",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/highlight-next/src/util/withHighlight.ts
+++ b/highlight-next/src/util/withHighlight.ts
@@ -33,24 +33,13 @@ export const Highlight =
 			try {
 				return (await origHandler(req, res)) as T
 			} catch (e) {
-				console.log('handler caught an error', e)
 				const { secureSessionId, requestId } = processHighlightHeaders()
-				console.log(
-					'secureSessionId:',
-					secureSessionId,
-					'requestId:',
-					requestId,
-				)
 				if (secureSessionId && requestId) {
-					console.log('wrapping error')
 					H.consumeEvent(secureSessionId)
 					if (e instanceof Error) {
-						console.log('consuming error')
 						H.consumeError(e, secureSessionId, requestId)
-						console.log('flushing error')
 						await H.flush()
 					}
-					console.log('done wrapping error')
 				}
 				// Because we're going to finish and send the transaction before passing the error onto nextjs, it won't yet
 				// have had a chance to set the status to 500, so unless we do it ourselves now, we'll incorrectly report that

--- a/highlight-node/package.json
+++ b/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -24,7 +24,7 @@
 		"graphql-request": "3.7.0",
 		"graphql-tag": "2.12.6",
 		"highlight.run": "workspace:*",
-		"lru-cache": "7.3.1",
+		"lru-cache": "^7.14.0",
 		"npm-run-all": "4.1.5"
 	},
 	"devDependencies": {
@@ -32,7 +32,7 @@
 		"@graphql-codegen/typescript": "2.7.2",
 		"@graphql-codegen/typescript-graphql-request": "4.5.2",
 		"@graphql-codegen/typescript-operations": "2.5.2",
-		"@types/lru-cache": "5.1.1",
+		"@types/lru-cache": "^7.10.10",
 		"@types/node": "17.0.13",
 		"tsup": "^6.2.3",
 		"typescript": "^4.8.2"

--- a/highlight-node/src/client.ts
+++ b/highlight-node/src/client.ts
@@ -142,7 +142,6 @@ export class Highlight {
 		if (this.errors.length === 0) {
 			return
 		}
-		console.log('flushing errors', this.errors.length)
 		const variables: PushBackendPayloadMutationVariables = {
 			errors: this.errors,
 		}
@@ -152,7 +151,6 @@ export class Highlight {
 		} catch (e) {
 			console.log('highlight-node pushErrors error: ', e)
 		}
-		console.log('done flushing errors')
 	}
 
 	async flushMetrics() {

--- a/highlight-node/src/errorContext.ts
+++ b/highlight-node/src/errorContext.ts
@@ -47,7 +47,7 @@ export class ErrorContext {
 			maxSize: this._sourceContextCacheSizeMB
 				? this._sourceContextCacheSizeMB * 1000 * 1000
 				: undefined,
-			length: (lines: FileLines, key: string): number => {
+			sizeCalculation: (lines: FileLines, key: string): number => {
 				return lines.size
 			},
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6466,14 +6466,14 @@ __metadata:
     "@graphql-codegen/typescript": 2.7.2
     "@graphql-codegen/typescript-graphql-request": 4.5.2
     "@graphql-codegen/typescript-operations": 2.5.2
-    "@types/lru-cache": 5.1.1
+    "@types/lru-cache": ^7.10.10
     "@types/node": 17.0.13
     error-stack-parser: 2.0.7
     graphql: 15
     graphql-request: 3.7.0
     graphql-tag: 2.12.6
     highlight.run: "workspace:*"
-    lru-cache: 7.3.1
+    lru-cache: ^7.14.0
     npm-run-all: 4.1.5
     tsup: ^6.2.3
     typescript: ^4.8.2
@@ -9032,10 +9032,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lru-cache@npm:5.1.1":
-  version: 5.1.1
-  resolution: "@types/lru-cache@npm:5.1.1"
-  checksum: e1d6c0085f61b16ec5b3073ec76ad1be4844ea036561c3f145fc19f71f084b58a6eb600b14128aa95809d057d28f1d147c910186ae51219f58366ffd2ff2e118
+"@types/lru-cache@npm:^7.10.10":
+  version: 7.10.10
+  resolution: "@types/lru-cache@npm:7.10.10"
+  dependencies:
+    lru-cache: "*"
+  checksum: bf0c9a99b3b954adfd1a63621aeea2c7f9412340ac43fad82f2b1ec257df09efa454e6cc7943518659e112b9d650de0e64c5252de9e449576eeb28449e068a1e
   languageName: node
   linkType: hard
 
@@ -23349,10 +23351,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:7.3.1":
-  version: 7.3.1
-  resolution: "lru-cache@npm:7.3.1"
-  checksum: 34bb50c015ffc29fd83545e912f28cea6e03fbf41c497fa220c4f131b990f9ddf95babac98745b416cbc6c0d835254d61668d09b8a4ecb476934546afc9e51bd
+"lru-cache@npm:*, lru-cache@npm:^7.14.0, lru-cache@npm:^7.7.1":
+  version: 7.14.0
+  resolution: "lru-cache@npm:7.14.0"
+  checksum: efdd329f2c1bb790b71d497c6c59272e6bc2d7dd060ba55fc136becd3dd31fc8346edb446275504d94cb60d3c8385dbf5267b79b23789e409b2bdf302d13f0d7
   languageName: node
   linkType: hard
 
@@ -23362,13 +23364,6 @@ __metadata:
   dependencies:
     yallist: ^4.0.0
   checksum: f97f499f898f23e4585742138a22f22526254fdba6d75d41a1c2526b3b6cc5747ef59c5612ba7375f42aca4f8461950e925ba08c991ead0651b4918b7c978297
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^7.7.1":
-  version: 7.14.0
-  resolution: "lru-cache@npm:7.14.0"
-  checksum: efdd329f2c1bb790b71d497c6c59272e6bc2d7dd060ba55fc136becd3dd31fc8346edb446275504d94cb60d3c8385dbf5267b79b23789e409b2bdf302d13f0d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- the `awaits` fixed the backend error issue, debug statements not needed rn
- upgrade version of `lru-cache` and stop using deprecated `length` property (else there's a console output)
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will test when merged
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
