### PR TITLE
fix session count for annual billing

### DIFF
--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -364,7 +364,7 @@ func reportUsage(DB *gorm.DB, stripeClient *client.API, workspaceID int, product
 		meter := GetMembersMeter(DB, workspaceID)
 
 		limit := TypeToMemberLimit(backend.PlanType(workspace.PlanTier), workspace.UnlimitedMembers)
-		if workspace.MonthlyMembersLimit != nil {
+		if limit != nil && workspace.MonthlyMembersLimit != nil {
 			limit = workspace.MonthlyMembersLimit
 		}
 


### PR DESCRIPTION
## Summary
- if project is billed annually, session usage should be calculated for the trailing month before `next_invoice_date`
- this is affecting Portal because their session count is starting in May, including a lot more months than it should be
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran select scripts against prod
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
