### PR TITLE
allow backendUrl to be relative

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@highlight-run/client",
 	"private": true,
-	"version": "1.3.3",
+	"version": "1.3.4",
 	"description": "rollup setup for writing a javascript library and making it available as script or npm package",
 	"main": "dist/index.js",
 	"module": "dist/indexESM.js",

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -351,6 +351,13 @@ export class Highlight {
 		}
 		this._backendUrl =
 			options?.backendUrl || publicGraphURI || 'https://pub.highlight.run'
+
+		// If _backendUrl is a relative URL, convert it to an absolute URL
+		// so that it's usable from a web worker.
+		if (this._backendUrl[0] === '/') {
+			this._backendUrl = new URL(this._backendUrl, document.baseURI).href
+		}
+
 		const client = new GraphQLClient(`${this._backendUrl}`, {
 			headers: {},
 		})


### PR DESCRIPTION
## Summary
- use case: Highlight proxying for Next.js uses a rewrite for `/highlight-events` - for the config to work at the moment, a user would need to have `backendUrl: <their_base_url>/highlight-events`, which is annoying for preview environments and such where the base url is dynamic
- I believe the root issue is in the web worker where it does not have the context of the document's baseUri
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- built new client locally, pointed my local nextjs project at the local client and set `backendUrl: /highlight-events`
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

