### PR TITLE
Fixup - Vercel callback modal width

### DIFF
--- a/frontend/src/pages/IntegrationAuthCallback/IntegrationAuthCallbackPage.tsx
+++ b/frontend/src/pages/IntegrationAuthCallback/IntegrationAuthCallbackPage.tsx
@@ -182,9 +182,7 @@ const VercelIntegrationCallback = ({ code }: Props) => {
 			}}
 		>
 			<Landing>
-				<div
-					className={`w-[${VercelSettingsModalWidth}px] rounded-md bg-white px-8 py-6`}
-				>
+				<div className={`w-[672px] rounded-md bg-white px-8 py-6`}>
 					<div className="m-4">
 						<h3>Configuring Vercel Integration</h3>
 						<VercelIntegrationSettings


### PR DESCRIPTION
- Modal is using the default width, which is too small and makes the Highlight icons appear as different sizes
- replace constant with the literal value
- this wasn't working with tailwind otherwise