### PR TITLE
add tests to cover other rewrite use cases

### DIFF
--- a/highlight-next/jest.config.js
+++ b/highlight-next/jest.config.js
@@ -1,0 +1,19 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+	extensionsToTreatAsEsm: ['.ts'],
+	moduleNameMapper: {
+		'^(\\.{1,2}/.*)\\.js$': '$1',
+	},
+	transform: {
+		// '^.+\\.[tj]sx?$' to process js/ts with `ts-jest`
+		// '^.+\\.m?[tj]sx?$' to process js/ts/mjs/mts with `ts-jest`
+		'^.+\\.tsx?$': [
+			'ts-jest',
+			{
+				useESM: true,
+			},
+		],
+	},
+	preset: 'ts-jest',
+	testEnvironment: 'node',
+}

--- a/highlight-next/package.json
+++ b/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "Client for interfacing with Highlight in next.js",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -13,7 +13,8 @@
 		}
 	},
 	"scripts": {
-		"build": "tsup src/index.ts --format cjs,esm --dts --clean"
+		"build": "tsup src/index.ts --format cjs,esm --dts --clean",
+		"test": "jest"
 	},
 	"author": "",
 	"license": "ISC",
@@ -27,8 +28,11 @@
 		"npm-run-all": "4.1.5"
 	},
 	"devDependencies": {
+		"@types/jest": "27.4.1",
 		"@types/node": "17.0.23",
 		"eslint": "8.12.0",
+		"jest": "^29.2.0",
+		"ts-jest": "^29.0.3",
 		"tsup": "^6.2.3",
 		"typescript": "^4.8.2"
 	}

--- a/highlight-next/src/util/withHighlightConfig.test.ts
+++ b/highlight-next/src/util/withHighlightConfig.test.ts
@@ -1,0 +1,105 @@
+import { Rewrite } from 'next/dist/lib/load-custom-routes.js'
+import { withHighlightConfig } from './withHighlightConfig.js'
+
+describe('withHighlightConfig', () => {
+	let defaultRewrite: {
+		beforeFiles: Rewrite[]
+		afterFiles: Rewrite[]
+		fallback: Rewrite[]
+	} = {
+		afterFiles: [
+			{
+				destination: 'https://pub.highlight.run',
+				source: '/highlight-events',
+			},
+		],
+		beforeFiles: [],
+		fallback: [],
+	}
+
+	it('creates new rewrites if none exist', async () => {
+		expect(
+			await withHighlightConfig({}, { uploadSourceMaps: true })
+				.rewrites!(),
+		).toMatchObject(defaultRewrite)
+	})
+
+	it('adds to a wrapped rewrites array', async () => {
+		const testEntry = {
+			source: '/test-rewrite',
+			destination: 'http://www.example.com',
+		}
+		const rewrites: () => Promise<Rewrite[]> = () =>
+			Promise.resolve([testEntry])
+
+		const expected = { ...defaultRewrite }
+		expected.afterFiles = [testEntry, ...expected.afterFiles]
+		expect(
+			await withHighlightConfig({ rewrites }).rewrites!(),
+		).toMatchObject(expected)
+	})
+
+	it('adds to a wrapped rewrites object', async () => {
+		const testEntry = {
+			source: '/test-rewrite',
+			destination: 'http://www.example.com',
+		}
+		const rewrites: () => Promise<{
+			beforeFiles: Rewrite[]
+			afterFiles: Rewrite[]
+			fallback: Rewrite[]
+		}> = () =>
+			Promise.resolve({
+				beforeFiles: [testEntry],
+				afterFiles: [],
+				fallback: [testEntry],
+			})
+
+		const expected = { ...defaultRewrite }
+		expected.beforeFiles = [testEntry]
+		expected.fallback = [testEntry]
+		expect(
+			await withHighlightConfig({ rewrites }).rewrites!(),
+		).toMatchObject(expected)
+	})
+
+	it('assumes rewrites may not have all fields defined', async () => {
+		const testEntry = {
+			source: '/test-rewrite',
+			destination: 'http://www.example.com',
+		}
+		const rewrites: () => Promise<{
+			beforeFiles: Rewrite[]
+			afterFiles: Rewrite[]
+			fallback: Rewrite[]
+		}> =
+			// @ts-expect-error
+			() => Promise.resolve({ fallback: [testEntry] })
+
+		const expected = { ...defaultRewrite }
+		// @ts-expect-error
+		expected.beforeFiles = undefined
+		expected.fallback = [testEntry]
+		expect(
+			await withHighlightConfig({ rewrites }).rewrites!(),
+		).toMatchObject(expected)
+	})
+
+	it('assumes rewrites may return undefined', async () => {
+		const testEntry = {
+			source: '/test-rewrite',
+			destination: 'http://www.example.com',
+		}
+		const rewrites: () => Promise<{
+			beforeFiles: Rewrite[]
+			afterFiles: Rewrite[]
+			fallback: Rewrite[]
+		}> =
+			// @ts-expect-error
+			() => Promise.resolve(undefined)
+
+		expect(
+			await withHighlightConfig({ rewrites }).rewrites!(),
+		).toMatchObject(defaultRewrite)
+	})
+})

--- a/highlight-next/src/util/withHighlightConfig.ts
+++ b/highlight-next/src/util/withHighlightConfig.ts
@@ -96,23 +96,23 @@ export const withHighlightConfig = (
 				destination: 'https://pub.highlight.run',
 			}
 
-			if (Array.isArray(re)) {
+			if (!re || Array.isArray(re)) {
 				return {
 					beforeFiles: defaultOpts.uploadSourceMaps
 						? [sourcemapRewrite]
 						: [],
 					afterFiles: defaultOpts.configureHighlightProxy
-						? re.concat(highlightRewrite)
+						? (re ?? []).concat(highlightRewrite)
 						: [],
 					fallback: [],
 				}
 			} else {
 				return {
 					beforeFiles: defaultOpts.uploadSourceMaps
-						? re.beforeFiles.concat(sourcemapRewrite)
+						? (re.beforeFiles ?? []).concat(sourcemapRewrite)
 						: re.beforeFiles,
 					afterFiles: defaultOpts.configureHighlightProxy
-						? re.afterFiles.concat(highlightRewrite)
+						? (re.afterFiles ?? []).concat(highlightRewrite)
 						: re.afterFiles,
 					fallback: re.fallback,
 				}

--- a/highlight-next/tsconfig.json
+++ b/highlight-next/tsconfig.json
@@ -1,6 +1,10 @@
 {
 	"compilerOptions": {
-		"types": ["@highlight-run/sourcemap-uploader", "@highlight-run/node"],
+		"types": [
+			"@highlight-run/sourcemap-uploader",
+			"@highlight-run/node",
+			"jest"
+		],
 		"target": "ES6",
 		"skipLibCheck": true,
 		"allowSyntheticDefaultImports": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1346,7 +1346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.11.1, @babel/core@npm:^7.16.0, @babel/core@npm:^7.8.0":
+"@babel/core@npm:^7.11.1, @babel/core@npm:^7.11.6, @babel/core@npm:^7.16.0, @babel/core@npm:^7.8.0":
   version: 7.19.3
   resolution: "@babel/core@npm:7.19.3"
   dependencies:
@@ -2653,7 +2653,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.18.6":
+"@babel/plugin-syntax-jsx@npm:^7.18.6, @babel/plugin-syntax-jsx@npm:^7.7.2":
   version: 7.18.6
   resolution: "@babel/plugin-syntax-jsx@npm:7.18.6"
   dependencies:
@@ -6447,10 +6447,13 @@ __metadata:
   dependencies:
     "@highlight-run/node": "workspace:*"
     "@highlight-run/sourcemap-uploader": "workspace:*"
+    "@types/jest": 27.4.1
     "@types/node": 17.0.23
     eslint: 8.12.0
+    jest: ^29.2.0
     next: ^12.2.6
     npm-run-all: 4.1.5
+    ts-jest: ^29.0.3
     tsup: ^6.2.3
     typescript: ^4.8.2
   peerDependencies:
@@ -6819,6 +6822,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/console@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/console@npm:29.2.0"
+  dependencies:
+    "@jest/types": ^29.2.0
+    "@types/node": "*"
+    chalk: ^4.0.0
+    jest-message-util: ^29.2.0
+    jest-util: ^29.2.0
+    slash: ^3.0.0
+  checksum: 514b1a3c0d5a3a19cd6ecde3fe5035379398034d27e1ec876d91e58eaab18dba6d7d55b5bfec990df6b0e0e3991ef5078cb422da9b56c1223f850e4e29c85723
+  languageName: node
+  linkType: hard
+
 "@jest/core@npm:^26.6.3":
   version: 26.6.3
   resolution: "@jest/core@npm:26.6.3"
@@ -6896,6 +6913,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/core@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/core@npm:29.2.0"
+  dependencies:
+    "@jest/console": ^29.2.0
+    "@jest/reporters": ^29.2.0
+    "@jest/test-result": ^29.2.0
+    "@jest/transform": ^29.2.0
+    "@jest/types": ^29.2.0
+    "@types/node": "*"
+    ansi-escapes: ^4.2.1
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    exit: ^0.1.2
+    graceful-fs: ^4.2.9
+    jest-changed-files: ^29.2.0
+    jest-config: ^29.2.0
+    jest-haste-map: ^29.2.0
+    jest-message-util: ^29.2.0
+    jest-regex-util: ^29.2.0
+    jest-resolve: ^29.2.0
+    jest-resolve-dependencies: ^29.2.0
+    jest-runner: ^29.2.0
+    jest-runtime: ^29.2.0
+    jest-snapshot: ^29.2.0
+    jest-util: ^29.2.0
+    jest-validate: ^29.2.0
+    jest-watcher: ^29.2.0
+    micromatch: ^4.0.4
+    pretty-format: ^29.2.0
+    slash: ^3.0.0
+    strip-ansi: ^6.0.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: 086791e6f9b7cf3a350e407a414b876bcb37500d7b550a27ccb56f31bb15d9ebbd106aa583a08ac2771e3470cac2badfe063b1f165dde31a213135fba5a12383
+  languageName: node
+  linkType: hard
+
 "@jest/environment@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/environment@npm:26.6.2"
@@ -6917,6 +6975,37 @@ __metadata:
     "@types/node": "*"
     jest-mock: ^27.5.1
   checksum: 2a9e18c35a015508dbec5b90b21c150230fa6c1c8cb8fabe029d46ee2ca4c40eb832fb636157da14c66590d0a4c8a2c053226b041f54a44507d6f6a89abefd66
+  languageName: node
+  linkType: hard
+
+"@jest/environment@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/environment@npm:29.2.0"
+  dependencies:
+    "@jest/fake-timers": ^29.2.0
+    "@jest/types": ^29.2.0
+    "@types/node": "*"
+    jest-mock: ^29.2.0
+  checksum: 1ddac48da360d59efec1e671e9351fbe24c6ec7976b5704e9d4dfe3e31e1af0851b20b05a94cc0a03709a85e3dc9bf6ae66fde6ecc4a6d36d97623a8b0265af0
+  languageName: node
+  linkType: hard
+
+"@jest/expect-utils@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/expect-utils@npm:29.2.0"
+  dependencies:
+    jest-get-type: ^29.2.0
+  checksum: dae6df9292501e5d9380ed26f0dde04761de977aad4d3bcb386feb0055944c1c0b4794e83d1f41f974d5ff51dae0126842ff52ba7c46a59f294bb957b145acda
+  languageName: node
+  linkType: hard
+
+"@jest/expect@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/expect@npm:29.2.0"
+  dependencies:
+    expect: ^29.2.0
+    jest-snapshot: ^29.2.0
+  checksum: 55f54b937973f30355e55085102852d6c524dc300a3046582676760ca5b03d0dbec5709ce2636df865250e1a330a9b47be52a039cd3bc3288b17098a0725447b
   languageName: node
   linkType: hard
 
@@ -6948,6 +7037,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/fake-timers@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/fake-timers@npm:29.2.0"
+  dependencies:
+    "@jest/types": ^29.2.0
+    "@sinonjs/fake-timers": ^9.1.2
+    "@types/node": "*"
+    jest-message-util: ^29.2.0
+    jest-mock: ^29.2.0
+    jest-util: ^29.2.0
+  checksum: f1ff640365695d64440d12f92c55d40e372fa46d9974089bf2a4cbc43464d2f9e04615caecda7c074b0f0abc072e334e11611df8915b323d0010ed9c2d151bf6
+  languageName: node
+  linkType: hard
+
 "@jest/globals@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/globals@npm:26.6.2"
@@ -6967,6 +7070,18 @@ __metadata:
     "@jest/types": ^27.5.1
     expect: ^27.5.1
   checksum: 087f97047e9dcf555f76fe2ce54aee681e005eaa837a0c0c2d251df6b6412c892c9df54cb871b180342114389a5ff895a4e52e6e6d3d0015bf83c02a54f64c3c
+  languageName: node
+  linkType: hard
+
+"@jest/globals@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/globals@npm:29.2.0"
+  dependencies:
+    "@jest/environment": ^29.2.0
+    "@jest/expect": ^29.2.0
+    "@jest/types": ^29.2.0
+    jest-mock: ^29.2.0
+  checksum: bd88c444e26c1448bbf01464ff97acdacd36be382dbc2c812e528b80808edeb474e61d58b71f5e85898ff06bec7bbfc130ecf9a6c638c3556c1d1ebb4dd6ed95
   languageName: node
   linkType: hard
 
@@ -7044,12 +7159,58 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/reporters@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/reporters@npm:29.2.0"
+  dependencies:
+    "@bcoe/v8-coverage": ^0.2.3
+    "@jest/console": ^29.2.0
+    "@jest/test-result": ^29.2.0
+    "@jest/transform": ^29.2.0
+    "@jest/types": ^29.2.0
+    "@jridgewell/trace-mapping": ^0.3.15
+    "@types/node": "*"
+    chalk: ^4.0.0
+    collect-v8-coverage: ^1.0.0
+    exit: ^0.1.2
+    glob: ^7.1.3
+    graceful-fs: ^4.2.9
+    istanbul-lib-coverage: ^3.0.0
+    istanbul-lib-instrument: ^5.1.0
+    istanbul-lib-report: ^3.0.0
+    istanbul-lib-source-maps: ^4.0.0
+    istanbul-reports: ^3.1.3
+    jest-message-util: ^29.2.0
+    jest-util: ^29.2.0
+    jest-worker: ^29.2.0
+    slash: ^3.0.0
+    string-length: ^4.0.1
+    strip-ansi: ^6.0.0
+    v8-to-istanbul: ^9.0.1
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: d9ab36d0dd8a81f5daa1353e20c4fb9b055864742acb196cb28563509b7b6bdffc0df0460f2a1b31362c7742d53544c83236b0bc6641c5b0177c933f55be2128
+  languageName: node
+  linkType: hard
+
 "@jest/schemas@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/schemas@npm:28.1.3"
   dependencies:
     "@sinclair/typebox": ^0.24.1
   checksum: 3cf1d4b66c9c4ffda58b246de1ddcba8e6ad085af63dccdf07922511f13b68c0cc480a7bc620cb4f3099a6f134801c747e1df7bfc7a4ef4dceefbdea3e31e1de
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "@jest/schemas@npm:29.0.0"
+  dependencies:
+    "@sinclair/typebox": ^0.24.1
+  checksum: 41355c78f09eb1097e57a3c5d0ca11c9099e235e01ea5fa4e3953562a79a6a9296c1d300f1ba50ca75236048829e056b00685cd2f1ff8285e56fd2ce01249acb
   languageName: node
   linkType: hard
 
@@ -7072,6 +7233,17 @@ __metadata:
     graceful-fs: ^4.2.9
     source-map: ^0.6.0
   checksum: 4fb1e743b602841babf7e22bd84eca34676cb05d4eb3b604cae57fc59e406099f5ac759ac1a0d04d901237d143f0f4f234417306e823bde732a1d19982230862
+  languageName: node
+  linkType: hard
+
+"@jest/source-map@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/source-map@npm:29.2.0"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.15
+    callsites: ^3.0.0
+    graceful-fs: ^4.2.9
+  checksum: 09f76ab63d15dcf44b3035a79412164f43be34ec189575930f1a00c87e36ea0211ebd6a4fbe2253c2516e19b49b131f348ddbb86223ca7b6bbac9a6bc76ec96e
   languageName: node
   linkType: hard
 
@@ -7111,6 +7283,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/test-result@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/test-result@npm:29.2.0"
+  dependencies:
+    "@jest/console": ^29.2.0
+    "@jest/types": ^29.2.0
+    "@types/istanbul-lib-coverage": ^2.0.0
+    collect-v8-coverage: ^1.0.0
+  checksum: 1c4709754212ccd9c76634537c9ab3433d7fd542893d865eb355068acbfd62c0a7abe5ed96e3f4bda117c2c007075ea42c0956b4921b77c23d35d442f01b3fe8
+  languageName: node
+  linkType: hard
+
 "@jest/test-sequencer@npm:^26.6.3":
   version: 26.6.3
   resolution: "@jest/test-sequencer@npm:26.6.3"
@@ -7133,6 +7317,18 @@ __metadata:
     jest-haste-map: ^27.5.1
     jest-runtime: ^27.5.1
   checksum: f21f9c8bb746847f7f89accfd29d6046eec1446f0b54e4694444feaa4df379791f76ef0f5a4360aafcbc73b50bc979f68b8a7620de404019d3de166be6720cb0
+  languageName: node
+  linkType: hard
+
+"@jest/test-sequencer@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/test-sequencer@npm:29.2.0"
+  dependencies:
+    "@jest/test-result": ^29.2.0
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.2.0
+    slash: ^3.0.0
+  checksum: b65b8cff147d825700628d18ea93e295f07ee218be41e8e35cb2f94d0b35d639d843760afd8d0a11734a02051c3642d38bfd848670baf180da83741f966d4e66
   languageName: node
   linkType: hard
 
@@ -7179,6 +7375,29 @@ __metadata:
     source-map: ^0.6.1
     write-file-atomic: ^3.0.0
   checksum: a22079121aedea0f20a03a9c026be971f7b92adbfb4d5fd1fb67be315741deac4f056936d7c72a53b24aa5a1071bc942c003925fd453bf3f6a0ae5da6384e137
+  languageName: node
+  linkType: hard
+
+"@jest/transform@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/transform@npm:29.2.0"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@jest/types": ^29.2.0
+    "@jridgewell/trace-mapping": ^0.3.15
+    babel-plugin-istanbul: ^6.1.1
+    chalk: ^4.0.0
+    convert-source-map: ^1.4.0
+    fast-json-stable-stringify: ^2.1.0
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.2.0
+    jest-regex-util: ^29.2.0
+    jest-util: ^29.2.0
+    micromatch: ^4.0.4
+    pirates: ^4.0.4
+    slash: ^3.0.0
+    write-file-atomic: ^4.0.1
+  checksum: 8e3794d1b77e6d52d342a692186cd574b2a637ce255f75824a029fc82cad93623d7bc5796566c1632fb51673eea2bf5194f4aac6bbc8cf879a5c29b12dbfb32a
   languageName: node
   linkType: hard
 
@@ -7235,6 +7454,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/types@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/types@npm:29.2.0"
+  dependencies:
+    "@jest/schemas": ^29.0.0
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^3.0.0
+    "@types/node": "*"
+    "@types/yargs": ^17.0.8
+    chalk: ^4.0.0
+  checksum: 6b04cbb23306f16eaf4f0d158cfcb7cc905b352e2e44a0a4618c46cf3bdf7a1da64cea8fbc731a19e8a86dc5b80a75aec985cf8764b3178939b5d850ccc68b57
+  languageName: node
+  linkType: hard
+
 "@jridgewell/gen-mapping@npm:^0.1.0":
   version: 0.1.1
   resolution: "@jridgewell/gen-mapping@npm:0.1.1"
@@ -7256,7 +7489,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.0.3":
+"@jridgewell/resolve-uri@npm:3.1.0, @jridgewell/resolve-uri@npm:^3.0.3":
   version: 3.1.0
   resolution: "@jridgewell/resolve-uri@npm:3.1.0"
   checksum: b5ceaaf9a110fcb2780d1d8f8d4a0bfd216702f31c988d8042e5f8fbe353c55d9b0f55a1733afdc64806f8e79c485d2464680ac48a0d9fcadb9548ee6b81d267
@@ -7280,7 +7513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10":
+"@jridgewell/sourcemap-codec@npm:1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.10":
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
   checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
@@ -7294,6 +7527,16 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
   checksum: d89597752fd88d3f3480845691a05a44bd21faac18e2185b6f436c3b0fd0c5a859fbbd9aaa92050c4052caf325ad3e10e2e1d1b64327517471b7d51babc0ddef
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.15":
+  version: 0.3.17
+  resolution: "@jridgewell/trace-mapping@npm:0.3.17"
+  dependencies:
+    "@jridgewell/resolve-uri": 3.1.0
+    "@jridgewell/sourcemap-codec": 1.4.14
+  checksum: 9d703b859cff5cd83b7308fd457a431387db5db96bd781a63bf48e183418dd9d3d44e76b9e4ae13237f6abeeb25d739ec9215c1d5bfdd08f66f750a50074a339
   languageName: node
   linkType: hard
 
@@ -8029,6 +8272,15 @@ __metadata:
   dependencies:
     "@sinonjs/commons": ^1.7.0
   checksum: 09b5a158ce013a6c37613258bad79ca4efeb99b1f59c41c73cca36cac00b258aefcf46eeea970fccf06b989414d86fe9f54c1102272c0c3bdd51a313cea80949
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:^9.1.2":
+  version: 9.1.2
+  resolution: "@sinonjs/fake-timers@npm:9.1.2"
+  dependencies:
+    "@sinonjs/commons": ^1.7.0
+  checksum: 7d3aef54e17c1073101cb64d953157c19d62a40e261a30923fa1ee337b049c5f29cc47b1f0c477880f42b5659848ba9ab897607ac8ea4acd5c30ddcfac57fca6
   languageName: node
   linkType: hard
 
@@ -8797,7 +9049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/graceful-fs@npm:^4.1.2":
+"@types/graceful-fs@npm:^4.1.2, @types/graceful-fs@npm:^4.1.3":
   version: 4.1.5
   resolution: "@types/graceful-fs@npm:4.1.5"
   dependencies:
@@ -8907,6 +9159,16 @@ __metadata:
     jest-diff: ^27.0.0
     pretty-format: ^27.0.0
   checksum: 972aaae341b83eb608970c93295282f1f9edc056dc8123635456cbaced822702673118d60279c7b889300e7c9a0726c3674d701115915e2e1967db09542389c2
+  languageName: node
+  linkType: hard
+
+"@types/jest@npm:27.4.1":
+  version: 27.4.1
+  resolution: "@types/jest@npm:27.4.1"
+  dependencies:
+    jest-matcher-utils: ^27.0.0
+    pretty-format: ^27.0.0
+  checksum: 5184f3eef4832d01ee8f59bed15eec45ccc8e29c724a5e6ce37bf74396b37bdf04f557000f45ba4fc38ae6075cf9cfcce3d7a75abc981023c61ceb27230a93e4
   languageName: node
   linkType: hard
 
@@ -11398,6 +11660,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-jest@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "babel-jest@npm:29.2.0"
+  dependencies:
+    "@jest/transform": ^29.2.0
+    "@types/babel__core": ^7.1.14
+    babel-plugin-istanbul: ^6.1.1
+    babel-preset-jest: ^29.2.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    slash: ^3.0.0
+  peerDependencies:
+    "@babel/core": ^7.8.0
+  checksum: 1629bc32829d0b6d9b7121538ef1ff8ae577432ff5be9e5102c9211163aa6d2f667a299fca4ffc1a16cd51fc3c32a6b9999afdbb3dca6ae906a01c6ab4e3f222
+  languageName: node
+  linkType: hard
+
 "babel-loader@npm:^8.2.3":
   version: 8.2.5
   resolution: "babel-loader@npm:8.2.5"
@@ -11487,6 +11766,18 @@ __metadata:
     "@types/babel__core": ^7.0.0
     "@types/babel__traverse": ^7.0.6
   checksum: 709c17727aa8fd3be755d256fb514bf945a5c2ea6017f037d80280fc44ae5fe7dfeebf63d8412df53796455c2c216119d628d8cc90b099434fd819005943d058
+  languageName: node
+  linkType: hard
+
+"babel-plugin-jest-hoist@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "babel-plugin-jest-hoist@npm:29.2.0"
+  dependencies:
+    "@babel/template": ^7.3.3
+    "@babel/types": ^7.3.3
+    "@types/babel__core": ^7.1.14
+    "@types/babel__traverse": ^7.0.6
+  checksum: 368d271ceae491ae6b96cd691434859ea589fbe5fd5aead7660df75d02394077273c6442f61f390e9347adffab57a32b564d0fabcf1c53c4b83cd426cb644072
   languageName: node
   linkType: hard
 
@@ -11717,6 +12008,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 251bcea11c18fd9672fec104eadb45b43f117ceeb326fa7345ced778d4c1feab29343cd7a87a1dcfae4997d6c851a8b386d7f7213792da6e23b74f4443a8976d
+  languageName: node
+  linkType: hard
+
+"babel-preset-jest@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "babel-preset-jest@npm:29.2.0"
+  dependencies:
+    babel-plugin-jest-hoist: ^29.2.0
+    babel-preset-current-node-syntax: ^1.0.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 1b09a2db968c36e064daf98082cfffa39c849b63055112ddc56fc2551fd0d4783897265775b1d2f8a257960a3339745de92e74feb01bad86d41c4cecbfa854fc
   languageName: node
   linkType: hard
 
@@ -13026,6 +13329,17 @@ __metadata:
     strip-ansi: ^6.0.0
     wrap-ansi: ^7.0.0
   checksum: ce2e8f578a4813806788ac399b9e866297740eecd4ad1823c27fd344d78b22c5f8597d548adbcc46f0573e43e21e751f39446c5a5e804a12aace402b7a315d7f
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "cliui@npm:8.0.1"
+  dependencies:
+    string-width: ^4.2.0
+    strip-ansi: ^6.0.1
+    wrap-ansi: ^7.0.0
+  checksum: 79648b3b0045f2e285b76fb2e24e207c6db44323581e421c3acbd0e86454cba1b37aea976ab50195a49e7384b871e6dfb2247ad7dec53c02454ac6497394cb56
   languageName: node
   linkType: hard
 
@@ -14838,6 +15152,13 @@ __metadata:
   version: 27.5.1
   resolution: "diff-sequences@npm:27.5.1"
   checksum: a00db5554c9da7da225db2d2638d85f8e41124eccbd56cbaefb3b276dcbb1c1c2ad851c32defe2055a54a4806f030656cbf6638105fd6ce97bb87b90b32a33ca
+  languageName: node
+  linkType: hard
+
+"diff-sequences@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "diff-sequences@npm:29.2.0"
+  checksum: e7b874cc7a4ce76fd199794c4d5fabb099ab4bce069592407ac2933e3a10e05f035111498e2f2c86572f5cfa9668a191b09e79f1d967dc39d9ca0a12aacde41a
   languageName: node
   linkType: hard
 
@@ -17252,6 +17573,19 @@ __metadata:
     jest-matcher-utils: ^27.5.1
     jest-message-util: ^27.5.1
   checksum: b2c66beb52de53ef1872165aace40224e722bca3c2274c54cfa74b6d617d55cf0ccdbf36783ccd64dbea501b280098ed33fd0b207d4f15bc03cd3c7a24364a6a
+  languageName: node
+  linkType: hard
+
+"expect@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "expect@npm:29.2.0"
+  dependencies:
+    "@jest/expect-utils": ^29.2.0
+    jest-get-type: ^29.2.0
+    jest-matcher-utils: ^29.2.0
+    jest-message-util: ^29.2.0
+    jest-util: ^29.2.0
+  checksum: 1d309c5218b514e54afb96b01141829a093ad424f7ba9e0b9fd2b1e08dfb04b39ff57d19e678105a5b7de9111d57f49d89c9c541f6f584a5735af2c31292fe11
   languageName: node
   linkType: hard
 
@@ -21080,6 +21414,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-changed-files@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-changed-files@npm:29.2.0"
+  dependencies:
+    execa: ^5.0.0
+    p-limit: ^3.1.0
+  checksum: 8ad8290324db1de2ee3c9443d3e3fbfdcb6d72ec7054c5796be2854b2bc239dea38a7c797c8c9c2bd959f539d44305790f2f75b18f3046b04317ed77c7480cb1
+  languageName: node
+  linkType: hard
+
 "jest-circus@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-circus@npm:27.5.1"
@@ -21104,6 +21448,33 @@ __metadata:
     stack-utils: ^2.0.3
     throat: ^6.0.1
   checksum: 6192dccbccb3a6acfa361cbb97bdbabe94864ccf3d885932cfd41f19534329d40698078cf9be1489415e8234255d6ea9f9aff5396b79ad842a6fca6e6fc08fd0
+  languageName: node
+  linkType: hard
+
+"jest-circus@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-circus@npm:29.2.0"
+  dependencies:
+    "@jest/environment": ^29.2.0
+    "@jest/expect": ^29.2.0
+    "@jest/test-result": ^29.2.0
+    "@jest/types": ^29.2.0
+    "@types/node": "*"
+    chalk: ^4.0.0
+    co: ^4.6.0
+    dedent: ^0.7.0
+    is-generator-fn: ^2.0.0
+    jest-each: ^29.2.0
+    jest-matcher-utils: ^29.2.0
+    jest-message-util: ^29.2.0
+    jest-runtime: ^29.2.0
+    jest-snapshot: ^29.2.0
+    jest-util: ^29.2.0
+    p-limit: ^3.1.0
+    pretty-format: ^29.2.0
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: 230d420116a8d2704c0444aa1367f05d752a68b0f5306e6b6ec9f231089d99f8fed81cd7b5d951cfb6da175ab4ccac9b0bb88d81e25837649007f9bdd6e8a4b0
   languageName: node
   linkType: hard
 
@@ -21154,6 +21525,33 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: 6c0a69fb48e500241409e09ff743ed72bc6578d7769e2c994724e7ef1e5587f6c1f85dc429e93b98ae38a365222993ee70f0acc2199358992120900984f349e5
+  languageName: node
+  linkType: hard
+
+"jest-cli@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-cli@npm:29.2.0"
+  dependencies:
+    "@jest/core": ^29.2.0
+    "@jest/test-result": ^29.2.0
+    "@jest/types": ^29.2.0
+    chalk: ^4.0.0
+    exit: ^0.1.2
+    graceful-fs: ^4.2.9
+    import-local: ^3.0.2
+    jest-config: ^29.2.0
+    jest-util: ^29.2.0
+    jest-validate: ^29.2.0
+    prompts: ^2.0.1
+    yargs: ^17.3.1
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: f02b6250c52d9f0507060d4fc60362495f8511141e2984ee2d6183abd9d4e0bce099b264d37cb1df3224279564de8e9ecc12a140b0f59b5942ad6ff912a36f95
   languageName: node
   linkType: hard
 
@@ -21225,6 +21623,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-config@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-config@npm:29.2.0"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@jest/test-sequencer": ^29.2.0
+    "@jest/types": ^29.2.0
+    babel-jest: ^29.2.0
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    deepmerge: ^4.2.2
+    glob: ^7.1.3
+    graceful-fs: ^4.2.9
+    jest-circus: ^29.2.0
+    jest-environment-node: ^29.2.0
+    jest-get-type: ^29.2.0
+    jest-regex-util: ^29.2.0
+    jest-resolve: ^29.2.0
+    jest-runner: ^29.2.0
+    jest-util: ^29.2.0
+    jest-validate: ^29.2.0
+    micromatch: ^4.0.4
+    parse-json: ^5.2.0
+    pretty-format: ^29.2.0
+    slash: ^3.0.0
+    strip-json-comments: ^3.1.1
+  peerDependencies:
+    "@types/node": "*"
+    ts-node: ">=9.0.0"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    ts-node:
+      optional: true
+  checksum: 80d3150f7102cca3d31665529b9f3503aeebd944686e9f73b9f2da93bec8723d35f8ba9073c5ee7661dfb2acaedbd4f22dea9b995b5447677b12d7f0e5b62be1
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^23.6.0":
   version: 23.6.0
   resolution: "jest-diff@npm:23.6.0"
@@ -21273,6 +21709,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-diff@npm:29.2.0"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^29.2.0
+    jest-get-type: ^29.2.0
+    pretty-format: ^29.2.0
+  checksum: 149381e8ba41a699a06e01efd650403b8dd2a4bfaea16be463def32a89e3b98bb41e7679b1e9a4b907fdee193c05419ce1d9bf1d6673e612305c32a6387fce07
+  languageName: node
+  linkType: hard
+
 "jest-docblock@npm:^26.0.0":
   version: 26.0.0
   resolution: "jest-docblock@npm:26.0.0"
@@ -21288,6 +21736,15 @@ __metadata:
   dependencies:
     detect-newline: ^3.0.0
   checksum: c0fed6d55b229d8bffdd8d03f121dd1a3be77c88f50552d374f9e1ea3bde57bf6bea017a0add04628d98abcb1bfb48b456438eeca8a74ef0053f4dae3b95d29c
+  languageName: node
+  linkType: hard
+
+"jest-docblock@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-docblock@npm:29.2.0"
+  dependencies:
+    detect-newline: ^3.0.0
+  checksum: b3f1227b7d73fc9e4952180303475cf337b36fa65c7f730ac92f0580f1c08439983262fee21cf3dba11429aa251b4eee1e3bc74796c5777116b400d78f9d2bbe
   languageName: node
   linkType: hard
 
@@ -21314,6 +21771,19 @@ __metadata:
     jest-util: ^27.5.1
     pretty-format: ^27.5.1
   checksum: b5a6d8730fd938982569c9e0b42bdf3c242f97b957ed8155a6473b5f7b540970f8685524e7f53963dc1805319f4b6602abfc56605590ca19d55bd7a87e467e63
+  languageName: node
+  linkType: hard
+
+"jest-each@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-each@npm:29.2.0"
+  dependencies:
+    "@jest/types": ^29.2.0
+    chalk: ^4.0.0
+    jest-get-type: ^29.2.0
+    jest-util: ^29.2.0
+    pretty-format: ^29.2.0
+  checksum: 246e84c03e3d807a5d9cb9a515807742db09a2814fa56111035c6ec29b195d6f84c43b92774d6768f785d37c55dc58b379c274b9b0d6618b9e386aaea374de07
   languageName: node
   linkType: hard
 
@@ -21375,6 +21845,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-environment-node@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-environment-node@npm:29.2.0"
+  dependencies:
+    "@jest/environment": ^29.2.0
+    "@jest/fake-timers": ^29.2.0
+    "@jest/types": ^29.2.0
+    "@types/node": "*"
+    jest-mock: ^29.2.0
+    jest-util: ^29.2.0
+  checksum: f6f35540edc0f44043c2d2b02ad39b9660b8343dbe4864c2d8aeeab0bd80bf54fa7ec0be2974d83cf8103aa83b3cf74899a8d6c65be58f75d2475307e528e954
+  languageName: node
+  linkType: hard
+
 "jest-get-type@npm:^22.1.0":
   version: 22.4.3
   resolution: "jest-get-type@npm:22.4.3"
@@ -21400,6 +21884,13 @@ __metadata:
   version: 27.5.1
   resolution: "jest-get-type@npm:27.5.1"
   checksum: 63064ab70195c21007d897c1157bf88ff94a790824a10f8c890392e7d17eda9c3900513cb291ca1c8d5722cad79169764e9a1279f7c8a9c4cd6e9109ff04bbc0
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-get-type@npm:29.2.0"
+  checksum: e396fd880a30d08940ed8a8e43cd4595db1b8ff09649018eb358ca701811137556bae82626af73459e3c0f8c5e972ed1e57fd3b1537b13a260893dac60a90942
   languageName: node
   linkType: hard
 
@@ -21449,6 +21940,29 @@ __metadata:
     fsevents:
       optional: true
   checksum: e092a1412829a9254b4725531ee72926de530f77fda7b0d9ea18008fb7623c16f72e772d8e93be71cac9e591b2c6843a669610887dd2c89bd9eb528856e3ab47
+  languageName: node
+  linkType: hard
+
+"jest-haste-map@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-haste-map@npm:29.2.0"
+  dependencies:
+    "@jest/types": ^29.2.0
+    "@types/graceful-fs": ^4.1.3
+    "@types/node": "*"
+    anymatch: ^3.0.3
+    fb-watchman: ^2.0.0
+    fsevents: ^2.3.2
+    graceful-fs: ^4.2.9
+    jest-regex-util: ^29.2.0
+    jest-util: ^29.2.0
+    jest-worker: ^29.2.0
+    micromatch: ^4.0.4
+    walker: ^1.0.8
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: f7d398658e94c2289832ce9ec445baf6b1a6ccd5b0861962fcb1d4b6ebe45acfe7577f947273e945cc6652e8725131390b87a45f63c07ace64df5a256ba5a387
   languageName: node
   linkType: hard
 
@@ -21542,6 +22056,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-leak-detector@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-leak-detector@npm:29.2.0"
+  dependencies:
+    jest-get-type: ^29.2.0
+    pretty-format: ^29.2.0
+  checksum: 3bc6d5bf1ce0ae41fc00c4de3d741b4de97e82c245ba76737842c715f45c815a1cc16eefa47944930076f4946ef1fb2f820b1f68e5a201b02ac7313b4bf15ba7
+  languageName: node
+  linkType: hard
+
 "jest-matcher-utils@npm:^23.6.0":
   version: 23.6.0
   resolution: "jest-matcher-utils@npm:23.6.0"
@@ -21574,6 +22098,18 @@ __metadata:
     jest-get-type: ^27.5.1
     pretty-format: ^27.5.1
   checksum: bb2135fc48889ff3fe73888f6cc7168ddab9de28b51b3148f820c89fdfd2effdcad005f18be67d0b9be80eda208ad47290f62f03d0a33f848db2dd0273c8217a
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-matcher-utils@npm:29.2.0"
+  dependencies:
+    chalk: ^4.0.0
+    jest-diff: ^29.2.0
+    jest-get-type: ^29.2.0
+    pretty-format: ^29.2.0
+  checksum: 8beeb95677d6b79a7858cd4c80fd16607cae0367d02fe24054f370fc23298af44844c5fc93a723568a1e23007fff3d086d3e9a9377621182fcaf1db1b01147ca
   languageName: node
   linkType: hard
 
@@ -21641,6 +22177,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-message-util@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-message-util@npm:29.2.0"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@jest/types": ^29.2.0
+    "@types/stack-utils": ^2.0.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    micromatch: ^4.0.4
+    pretty-format: ^29.2.0
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: de74c6aeffbbae736f2be32ffaf238ec8944a213dca2e2f85ef845b92ca0a01496504a007fc5557e9ee8d2f1ead634962a53fe86d4483cd61ea82d6b790bdfb2
+  languageName: node
+  linkType: hard
+
 "jest-mock@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-mock@npm:26.6.2"
@@ -21658,6 +22211,17 @@ __metadata:
     "@jest/types": ^27.5.1
     "@types/node": "*"
   checksum: f5b5904bb1741b4a1687a5f492535b7b1758dc26534c72a5423305f8711292e96a601dec966df81bb313269fb52d47227e29f9c2e08324d79529172f67311be0
+  languageName: node
+  linkType: hard
+
+"jest-mock@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-mock@npm:29.2.0"
+  dependencies:
+    "@jest/types": ^29.2.0
+    "@types/node": "*"
+    jest-util: ^29.2.0
+  checksum: 6c65e89860e5d1a74291c6276b1a12902189f4fa63adb226a811621725bf27487696fb366f3855b84afddbfa6cd36c7d4d0b61f5a05bbddb63ff00c8f95046a7
   languageName: node
   linkType: hard
 
@@ -21694,6 +22258,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-regex-util@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-regex-util@npm:29.2.0"
+  checksum: 7c533e51c51230dac20c0d7395b19b8366cb022f7c6e08e6bcf2921626840ff90424af4c9b4689f02f0addfc9b071c4cd5f8f7a989298a4c8e0f9c94418ca1c3
+  languageName: node
+  linkType: hard
+
 "jest-resolve-dependencies@npm:^26.6.3":
   version: 26.6.3
   resolution: "jest-resolve-dependencies@npm:26.6.3"
@@ -21713,6 +22284,16 @@ __metadata:
     jest-regex-util: ^27.5.1
     jest-snapshot: ^27.5.1
   checksum: c67af97afad1da88f5530317c732bbd1262d1225f6cd7f4e4740a5db48f90ab0bd8564738ac70d1a43934894f9aef62205c1b8f8ee89e5c7a737e6a121ee4c25
+  languageName: node
+  linkType: hard
+
+"jest-resolve-dependencies@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-resolve-dependencies@npm:29.2.0"
+  dependencies:
+    jest-regex-util: ^29.2.0
+    jest-snapshot: ^29.2.0
+  checksum: 5b498bb244862d1eb02772ab5b53ed84ac025c6d4e6a96379c3c3eeb7785896f83ae2116c57418b96957fe3242ff5401087fa9a8481e94f6221f15ffe83900a1
   languageName: node
   linkType: hard
 
@@ -21758,6 +22339,23 @@ __metadata:
     resolve.exports: ^1.1.0
     slash: ^3.0.0
   checksum: 735830e7265b20a348029738680bb2f6e37f80ecea86cda869a4c318ba3a45d39c7a3a873a22f7f746d86258c50ead6e7f501de043e201c095d7ba628a1c440f
+  languageName: node
+  linkType: hard
+
+"jest-resolve@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-resolve@npm:29.2.0"
+  dependencies:
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.2.0
+    jest-pnp-resolver: ^1.2.2
+    jest-util: ^29.2.0
+    jest-validate: ^29.2.0
+    resolve: ^1.20.0
+    resolve.exports: ^1.1.0
+    slash: ^3.0.0
+  checksum: abbcb395d165cc17179f2237f33306dbb344c983136f112284418d5f5d8b26646e67b8981a2cc67cfe0578506f8c23cd2ef88f26f8d91d68eb48a48d71263e82
   languageName: node
   linkType: hard
 
@@ -21815,6 +22413,35 @@ __metadata:
     source-map-support: ^0.5.6
     throat: ^6.0.1
   checksum: 5bbe6cf847dd322b3332ec9d6977b54f91bd5f72ff620bc1a0192f0f129deda8aa7ca74c98922187a7aa87d8e0ce4f6c50e99a7ccb2a310bf4d94be2e0c3ce8e
+  languageName: node
+  linkType: hard
+
+"jest-runner@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-runner@npm:29.2.0"
+  dependencies:
+    "@jest/console": ^29.2.0
+    "@jest/environment": ^29.2.0
+    "@jest/test-result": ^29.2.0
+    "@jest/transform": ^29.2.0
+    "@jest/types": ^29.2.0
+    "@types/node": "*"
+    chalk: ^4.0.0
+    emittery: ^0.10.2
+    graceful-fs: ^4.2.9
+    jest-docblock: ^29.2.0
+    jest-environment-node: ^29.2.0
+    jest-haste-map: ^29.2.0
+    jest-leak-detector: ^29.2.0
+    jest-message-util: ^29.2.0
+    jest-resolve: ^29.2.0
+    jest-runtime: ^29.2.0
+    jest-util: ^29.2.0
+    jest-watcher: ^29.2.0
+    jest-worker: ^29.2.0
+    p-limit: ^3.1.0
+    source-map-support: 0.5.13
+  checksum: ebc49ab71e53301d5f1ae7f257e9ed0b38f6c4bd609b88a29b1d792db5b12a452dc8be3576d011d11f6d11ab1a29311173fc2c071c758db3b46cf4e2b123ab07
   languageName: node
   linkType: hard
 
@@ -21882,6 +22509,36 @@ __metadata:
     slash: ^3.0.0
     strip-bom: ^4.0.0
   checksum: 929e3df0c53dab43f831f2af4e2996b22aa8cb2d6d483919d6b0426cbc100098fd5b777b998c6568b77f8c4d860b2e83127514292ff61416064f5ef926492386
+  languageName: node
+  linkType: hard
+
+"jest-runtime@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-runtime@npm:29.2.0"
+  dependencies:
+    "@jest/environment": ^29.2.0
+    "@jest/fake-timers": ^29.2.0
+    "@jest/globals": ^29.2.0
+    "@jest/source-map": ^29.2.0
+    "@jest/test-result": ^29.2.0
+    "@jest/transform": ^29.2.0
+    "@jest/types": ^29.2.0
+    "@types/node": "*"
+    chalk: ^4.0.0
+    cjs-module-lexer: ^1.0.0
+    collect-v8-coverage: ^1.0.0
+    glob: ^7.1.3
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.2.0
+    jest-message-util: ^29.2.0
+    jest-mock: ^29.2.0
+    jest-regex-util: ^29.2.0
+    jest-resolve: ^29.2.0
+    jest-snapshot: ^29.2.0
+    jest-util: ^29.2.0
+    slash: ^3.0.0
+    strip-bom: ^4.0.0
+  checksum: a16c84ee3ce89280e4c660fcbcb2cd9556499b054f734e508cd2954236ac46733156c5cf828d6c5c4bffcc6ca544cfee1af5e9a2a8def140c38a5702e9ec73ac
   languageName: node
   linkType: hard
 
@@ -21977,6 +22634,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-snapshot@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-snapshot@npm:29.2.0"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@babel/generator": ^7.7.2
+    "@babel/plugin-syntax-jsx": ^7.7.2
+    "@babel/plugin-syntax-typescript": ^7.7.2
+    "@babel/traverse": ^7.7.2
+    "@babel/types": ^7.3.3
+    "@jest/expect-utils": ^29.2.0
+    "@jest/transform": ^29.2.0
+    "@jest/types": ^29.2.0
+    "@types/babel__traverse": ^7.0.6
+    "@types/prettier": ^2.1.5
+    babel-preset-current-node-syntax: ^1.0.0
+    chalk: ^4.0.0
+    expect: ^29.2.0
+    graceful-fs: ^4.2.9
+    jest-diff: ^29.2.0
+    jest-get-type: ^29.2.0
+    jest-haste-map: ^29.2.0
+    jest-matcher-utils: ^29.2.0
+    jest-message-util: ^29.2.0
+    jest-util: ^29.2.0
+    natural-compare: ^1.4.0
+    pretty-format: ^29.2.0
+    semver: ^7.3.5
+  checksum: 11fe8fd2e51882ae35c5d675e2bc25757f84b469c53b330194b30d03c98a033c32a6ef7c5ed5af0abf7350456e978cc5c4daa8ea87743c3038c4cbce41cc9804
+  languageName: node
+  linkType: hard
+
 "jest-util@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-util@npm:26.6.2"
@@ -22019,6 +22708,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-util@npm:^29.0.0, jest-util@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-util@npm:29.2.0"
+  dependencies:
+    "@jest/types": ^29.2.0
+    "@types/node": "*"
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    graceful-fs: ^4.2.9
+    picomatch: ^2.2.3
+  checksum: c1fc26008b3199387dbd28f145f692f48b7c8e911c6a71892e579544ee62819ecc2c693f7fc5e41284119a6f742130ef5c92f485caed89eea47c5e627003ad2d
+  languageName: node
+  linkType: hard
+
 "jest-validate@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-validate@npm:26.6.2"
@@ -22044,6 +22747,20 @@ __metadata:
     leven: ^3.1.0
     pretty-format: ^27.5.1
   checksum: 82e870f8ee7e4fb949652711b1567f05ae31c54be346b0899e8353e5c20fad7692b511905b37966945e90af8dc0383eb41a74f3ffefb16140ea4f9164d841412
+  languageName: node
+  linkType: hard
+
+"jest-validate@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-validate@npm:29.2.0"
+  dependencies:
+    "@jest/types": ^29.2.0
+    camelcase: ^6.2.0
+    chalk: ^4.0.0
+    jest-get-type: ^29.2.0
+    leven: ^3.1.0
+    pretty-format: ^29.2.0
+  checksum: 41680f078bf138af49a7ae297f4e5c09e84de693e716fa854313f6e61f4b3fe34be35a8736bf7d260c498631241ffe4622e544f6c0d0ece718e8441cd45ed327
   languageName: node
   linkType: hard
 
@@ -22110,6 +22827,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-watcher@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-watcher@npm:29.2.0"
+  dependencies:
+    "@jest/test-result": ^29.2.0
+    "@jest/types": ^29.2.0
+    "@types/node": "*"
+    ansi-escapes: ^4.2.1
+    chalk: ^4.0.0
+    emittery: ^0.10.2
+    jest-util: ^29.2.0
+    string-length: ^4.0.1
+  checksum: 86a0a79edcfab8ac96eddafad55327f8d8f0367d75506af8130fcd42c301189ecb3a0749e5739e8336e9478c2df5419ac73fca2bdb6c4180ed85896f01917697
+  languageName: node
+  linkType: hard
+
 "jest-worker@npm:^26.2.1, jest-worker@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-worker@npm:26.6.2"
@@ -22140,6 +22873,18 @@ __metadata:
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
   checksum: e921c9a1b8f0909da9ea07dbf3592f95b653aef3a8bb0cbcd20fc7f9a795a1304adecac31eecb308992c167e8d7e75c522061fec38a5928ace0f9571c90169ca
+  languageName: node
+  linkType: hard
+
+"jest-worker@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-worker@npm:29.2.0"
+  dependencies:
+    "@types/node": "*"
+    jest-util: ^29.2.0
+    merge-stream: ^2.0.0
+    supports-color: ^8.0.0
+  checksum: 680afa2b9efd0f6548a52210d055e1d8a5de2e8602cf5547d59075a55f7d9b6d4fd3c4a8bb34e03a3815975ae4c737b6dbc2c194e12088611a19941836960374
   languageName: node
   linkType: hard
 
@@ -22189,6 +22934,25 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: 96f1d69042b3c6dfc695f2a4e4b0db38af6fb78582ad1a02beaa57cfcd77cbd31567d7d865c1c85709b7c3e176eefa3b2035ffecd646005f15d8ef528eccf205
+  languageName: node
+  linkType: hard
+
+"jest@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest@npm:29.2.0"
+  dependencies:
+    "@jest/core": ^29.2.0
+    "@jest/types": ^29.2.0
+    import-local: ^3.0.2
+    jest-cli: ^29.2.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 580dae17d49d4c8b7487a2a828db8fe84ad7cf15a8bca56e8640170936101437cc5474b7599b2f37785704aa6c98f97ebfea7494fbb81865de9c65e500b11654
   languageName: node
   linkType: hard
 
@@ -23465,6 +24229,15 @@ __metadata:
     socks-proxy-agent: ^6.0.0
     ssri: ^8.0.0
   checksum: 0eb371c85fdd0b1584fcfdf3dc3c62395761b3c14658be02620c310305a9a7ecf1617a5e6fb30c1d081c5c8aaf177fa133ee225024313afabb7aa6a10f1e3d04
+  languageName: node
+  linkType: hard
+
+"makeerror@npm:1.0.12":
+  version: 1.0.12
+  resolution: "makeerror@npm:1.0.12"
+  dependencies:
+    tmpl: 1.0.5
+  checksum: b38a025a12c8146d6eeea5a7f2bf27d51d8ad6064da8ca9405fcf7bf9b54acd43e3b30ddd7abb9b1bfa4ddb266019133313482570ddb207de568f71ecfcf6060
   languageName: node
   linkType: hard
 
@@ -27242,6 +28015,17 @@ __metadata:
     ansi-styles: ^5.0.0
     react-is: ^18.0.0
   checksum: e69f857358a3e03d271252d7524bec758c35e44680287f36c1cb905187fbc82da9981a6eb07edfd8a03bc3cbeebfa6f5234c13a3d5b59f2bbdf9b4c4053e0a7f
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "pretty-format@npm:29.2.0"
+  dependencies:
+    "@jest/schemas": ^29.0.0
+    ansi-styles: ^5.0.0
+    react-is: ^18.0.0
+  checksum: f5ef6a848540f0881baafbcf6bf9908d2d8e2a47692bc095abbb06881ed3c780b41b08cb537b7d020fc79cec04c4a8bbd6a15cd44a3fe0693ddd235a2d0bda3a
   languageName: node
   linkType: hard
 
@@ -31307,6 +32091,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-support@npm:0.5.13":
+  version: 0.5.13
+  resolution: "source-map-support@npm:0.5.13"
+  dependencies:
+    buffer-from: ^1.0.0
+    source-map: ^0.6.0
+  checksum: 933550047b6c1a2328599a21d8b7666507427c0f5ef5eaadd56b5da0fd9505e239053c66fe181bf1df469a3b7af9d775778eee283cbb7ae16b902ddc09e93a97
+  languageName: node
+  linkType: hard
+
 "source-map-support@npm:^0.5.17":
   version: 0.5.19
   resolution: "source-map-support@npm:0.5.19"
@@ -33146,6 +33940,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-jest@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "ts-jest@npm:29.0.3"
+  dependencies:
+    bs-logger: 0.x
+    fast-json-stable-stringify: 2.x
+    jest-util: ^29.0.0
+    json5: ^2.2.1
+    lodash.memoize: 4.x
+    make-error: 1.x
+    semver: 7.x
+    yargs-parser: ^21.0.1
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/types": ^29.0.0
+    babel-jest: ^29.0.0
+    jest: ^29.0.0
+    typescript: ">=4.3"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: 541e51776d367fa2279af47f75af94b03e0538f1839ea9983de0f4ad7f188002f6eb1fc72440651d96daa62d25a7bc679a129c14e6ef291277eea9346751d56b
+  languageName: node
+  linkType: hard
+
 "ts-log@npm:^2.2.3":
   version: 2.2.3
   resolution: "ts-log@npm:2.2.3"
@@ -34263,6 +35090,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"v8-to-istanbul@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "v8-to-istanbul@npm:9.0.1"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.12
+    "@types/istanbul-lib-coverage": ^2.0.1
+    convert-source-map: ^1.6.0
+  checksum: a49c34bf0a3af0c11041a3952a2600913904a983bd1bc87148b5c033bc5c1d02d5a13620fcdbfa2c60bc582a2e2970185780f0c844b4c3a220abf405f8af6311
+  languageName: node
+  linkType: hard
+
 "valid-url@npm:1.0.9, valid-url@npm:^1.0.9":
   version: 1.0.9
   resolution: "valid-url@npm:1.0.9"
@@ -34504,6 +35342,15 @@ __metadata:
   dependencies:
     makeerror: 1.0.x
   checksum: 4038fcf92f6ab0288267ad05008aec9e089a759f1bd32e1ea45cc2eb498eb12095ec43cf8ca2bf23a465f4580a0d33b25b89f450ba521dd27083cbc695ee6bf5
+  languageName: node
+  linkType: hard
+
+"walker@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "walker@npm:1.0.8"
+  dependencies:
+    makeerror: 1.0.12
+  checksum: ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
   languageName: node
   linkType: hard
 
@@ -35458,6 +36305,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^21.0.1":
+  version: 21.1.1
+  resolution: "yargs-parser@npm:21.1.1"
+  checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c
+  languageName: node
+  linkType: hard
+
 "yargs@npm:17.5.1, yargs@npm:^17.0.0":
   version: 17.5.1
   resolution: "yargs@npm:17.5.1"
@@ -35504,6 +36358,21 @@ __metadata:
     y18n: ^5.0.5
     yargs-parser: ^20.2.2
   checksum: b14afbb51e3251a204d81937c86a7e9d4bdbf9a2bcee38226c900d00f522969ab675703bee2a6f99f8e20103f608382936034e64d921b74df82b63c07c5e8f59
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.3.1":
+  version: 17.6.0
+  resolution: "yargs@npm:17.6.0"
+  dependencies:
+    cliui: ^8.0.1
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.0.0
+  checksum: 604bdb4a6395a870540d2f3fea083c8e28441f12da8fd05b172b1e68480f00ed73d76be4a05fac19de9bf55ec7729b41e81cf555cccaed700aa192e4fff64872
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- sets up `jest` in the `highlight-next` package
  - is this ok? or should I be using `vitest` even though this package doesn't use `vite`?
- adds test coverage for 3 correct uses of rewrites and 2 others which should probably be handled too
- change code to handle cases where certain properties are not defined (even though this breaks the type definition)
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran unit tests
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- nope
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
