### PR TITLE
[HIG-3007] separate withHighlightConfig from backend instructions

### DIFF
--- a/frontend/src/pages/Setup/SetupPage.tsx
+++ b/frontend/src/pages/Setup/SetupPage.tsx
@@ -960,6 +960,24 @@ const NextBackendInstructions = () => {
 					language="shell"
 				/>
 			</Section>
+			<Section title="Wrapping your Next Config" defaultOpen>
+				<p>
+					In <code>next.config.js</code>, use{' '}
+					<code>withHighlightConfig</code> to wrap your config. This
+					will automatically configure source map uploading and
+					proxying for Highlight requests.
+				</p>
+				<p>
+					<CodeBlock
+						language="javascript"
+						text={`import { withHighlightConfig } from "@highlight-run/next";
+
+export default withHighlightConfig({
+	// your next.config.js options here
+})`}
+					/>
+				</p>
+			</Section>
 			<Section title="Initializing Highlight on the Backend" defaultOpen>
 				<p>Initialize the SDK by importing Highlight like so: </p>
 				<CodeBlock
@@ -999,20 +1017,6 @@ const handler = async (req, res) => {
 };
 
 export default withHighlight(handler);`}
-					/>
-				</p>
-				<p>
-					In <code>next.config.js</code>, use{' '}
-					<code>withHighlightConfig</code> to wrap your config.
-				</p>
-				<p>
-					<CodeBlock
-						language="javascript"
-						text={`import { withHighlightConfig } from "@highlight-run/next";
-
-export default withHighlightConfig({
-	// your next.config.js options here
-})`}
 					/>
 				</p>
 			</Section>


### PR DESCRIPTION
## Summary
- `withHighlightConfig` instructions are separate from backend and are useful for others who may want to use Highlight only on frontend
- separating from the backend section to reduce confusion
<img width="667" alt="Screen Shot 2022-10-17 at 9 42 51 AM" src="https://user-images.githubusercontent.com/86132398/196235255-40bfca6b-73c4-4c43-a20e-41d2387f4bf6.png">
