### PR TITLE
[HIG-3034] skip about you page when integrating with Vercel

### DIFF
--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -24,7 +24,7 @@ import React, {
 	useState,
 } from 'react'
 import { useHistory } from 'react-router'
-import { BooleanParam, useQueryParam } from 'use-query-params'
+import { BooleanParam, StringParam, useQueryParam } from 'use-query-params'
 
 import commonStyles from '../../Common.module.scss'
 import Button from '../../components/Button/Button/Button'
@@ -117,6 +117,8 @@ enum LoginFormState {
 
 export default function LoginForm() {
 	const [signUpParam] = useQueryParam('sign_up', BooleanParam)
+	const [nextParam] = useQueryParam('next', StringParam)
+	const isVercelIntegrationFlow = !!nextParam
 	const [formState, setFormState] = useState<LoginFormState>(
 		signUpParam ? LoginFormState.SignUp : LoginFormState.SignIn,
 	)
@@ -232,6 +234,12 @@ export default function LoginForm() {
 				}}
 			/>
 		)
+	} else if (
+		isLoggedIn &&
+		(formState === LoginFormState.FinishedOnboarding ||
+			isVercelIntegrationFlow) // Do not show the about you page if this is during the Vercel integration flow
+	) {
+		return <AuthAdminRouter />
 	} else if (isLoggedIn && formState === LoginFormState.MissingUserDetails) {
 		return (
 			<AboutYouPage
@@ -240,8 +248,6 @@ export default function LoginForm() {
 				}}
 			/>
 		)
-	} else if (isLoggedIn && formState === LoginFormState.FinishedOnboarding) {
-		return <AuthAdminRouter />
 	}
 
 	function getLoginTitleText() {


### PR DESCRIPTION
## Summary
- a little hacky, but the Vercel integration uses a `next` query param to store a callback URL - if this is present, assume we're in the Vercel integration flow and skip the about you page
- this was feedback from our Vercel contact
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- nope
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
