### PR TITLE
correctly process file-scheme js files with uploaded sourcemaps

### DIFF
--- a/backend/errors/errors.go
+++ b/backend/errors/errors.go
@@ -250,7 +250,7 @@ func processStackFrame(projectId int, version *string, stackTrace publicModel.St
 		sourceMapURL, sourceMapFileBytes, err = getURLSourcemap(projectId, version, stackTraceFileURL, stackTraceFilePath, stackFileNameIndex, storageClient)
 	}
 	if err != nil {
-		return nil, e.Wrapf(err, "error getting source map for %v", stackTraceFilePath)
+		return nil, err
 	}
 
 	if len(sourceMapFileBytes) > SOURCE_MAP_MAX_FILE_SIZE {


### PR DESCRIPTION
## Summary

As seen with errors in Electron [sessions](https://app.highlight.run/729/sessions/RneeegTiUrye9sMxv5em2aT0qXdQ), sourcemaps are not processed because we cannot resolve the `file:///...` schemes of Electron js files.

This change updates the sourcemap processing to suppoort the scheme if the `.map` files are uploaded via the sourcemap uploader.

For `file:///` scheme stack traces, we try a best-effort match of the path to the customer's sourcemap bucket. We cannot
do an exact match because we are not sure what the prefix is for a particular electron app. For example, for Aerotime, the
stacktrace file is `file:///Applications/Aerotime.app/Contents/Resources/app.asar/build/static/js/main.400b100f.chunk.js` but the sourcemap lives in sourcemap bucket path `static/js/main.400b100f.chunk.js`. Since the path may be OS / env specific and depend on where the customer uploaded the sourcemaps from, we should attempt a best-effort match.

## How did you test this change?

Local deploy using `1/sessions/RneeegTiUrye9sMxv5em2aT0qXdQ`

Now mapping the source code.

![image](https://user-images.githubusercontent.com/1351531/196525040-8b088e28-c7b4-494f-9f97-1c45ae6b407a.png)


## Are there any deployment considerations?

No
