### PR TITLE
fixup: fix source map api key check

### DIFF
--- a/highlight-next/package.json
+++ b/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"description": "Client for interfacing with Highlight in next.js",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/highlight-next/src/util/withHighlightConfig.ts
+++ b/highlight-next/src/util/withHighlightConfig.ts
@@ -60,8 +60,7 @@ const getDefaultOpts = (
 		uploadSourceMaps:
 			isProdBuild &&
 			(highlightOpts?.uploadSourceMaps ??
-				!config.productionBrowserSourceMaps ??
-				hasSourcemapApiKey),
+				(!config.productionBrowserSourceMaps && hasSourcemapApiKey)),
 		configureHighlightProxy: highlightOpts?.configureHighlightProxy ?? true,
 		apiKey: highlightOpts?.apiKey ?? '',
 		appVersion: highlightOpts?.appVersion ?? '',


### PR DESCRIPTION
## Summary
- `!config.productionBrowserSourceMaps` is true if `productionBrowserSourceMaps` is undefined, skipping the check for `hasSourcemapApiKey`
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- nope
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
