### PR TITLE
hide about you for configurationId

### DIFF
--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -118,7 +118,8 @@ enum LoginFormState {
 export default function LoginForm() {
 	const [signUpParam] = useQueryParam('sign_up', BooleanParam)
 	const [nextParam] = useQueryParam('next', StringParam)
-	const isVercelIntegrationFlow = !!nextParam
+	const [configurationIdParam] = useQueryParam('configurationId', StringParam)
+	const isVercelIntegrationFlow = !!nextParam || !!configurationIdParam
 	const [formState, setFormState] = useState<LoginFormState>(
 		signUpParam ? LoginFormState.SignUp : LoginFormState.SignIn,
 	)


### PR DESCRIPTION
## Summary
- configure flow has `configurationId` and not `next`
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
