### PR TITLE
set NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID in integration - for use in demo app

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -2896,14 +2896,24 @@ func (r *mutationResolver) UpdateVercelProjectMappings(ctx context.Context, proj
 			return false, e.New("cannot access Vercel project")
 		}
 
-		var matchingEnvId *string
+		var sourceMapEnvId *string
+		var projectEnvId *string
 		for _, e := range vercelProject.Env {
 			if e.Key == vercel.SourcemapEnvKey {
-				matchingEnvId = &e.ID
+				sourceMapEnvId = &e.ID
+			}
+			if e.Key == vercel.ProjectIdEnvVar {
+				projectEnvId = &e.ID
 			}
 		}
 
-		if err := vercel.SetEnvVariable(m.VercelProjectID, *project.Secret, *workspace.VercelAccessToken, workspace.VercelTeamID, matchingEnvId); err != nil {
+		if err := vercel.SetEnvVariable(m.VercelProjectID, *project.Secret, *workspace.VercelAccessToken,
+			workspace.VercelTeamID, sourceMapEnvId, vercel.SourcemapEnvKey); err != nil {
+			return false, err
+		}
+
+		if err := vercel.SetEnvVariable(m.VercelProjectID, project.VerboseID(), *workspace.VercelAccessToken,
+			workspace.VercelTeamID, projectEnvId, vercel.ProjectIdEnvVar); err != nil {
 			return false, err
 		}
 		configs = append(configs, &model.VercelIntegrationConfig{

--- a/backend/vercel/vercel.go
+++ b/backend/vercel/vercel.go
@@ -18,6 +18,7 @@ var (
 	VercelClientId     = os.Getenv("VERCEL_CLIENT_ID")
 	VercelClientSecret = os.Getenv("VERCEL_CLIENT_SECRET")
 	SourcemapEnvKey    = "HIGHLIGHT_SOURCEMAP_UPLOAD_API_KEY"
+	ProjectIdEnvVar    = "NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID"
 	VercelApiBaseUrl   = "https://api.vercel.com"
 )
 
@@ -68,7 +69,7 @@ func GetAccessToken(code string) (VercelAccessTokenResponse, error) {
 	return accessTokenResponse, nil
 }
 
-func SetEnvVariable(projectId string, apiKey string, accessToken string, teamId *string, envId *string) error {
+func SetEnvVariable(projectId string, apiKey string, accessToken string, teamId *string, envId *string, key string) error {
 	client := &http.Client{}
 
 	teamIdParam := ""
@@ -76,7 +77,12 @@ func SetEnvVariable(projectId string, apiKey string, accessToken string, teamId 
 		teamIdParam = "?teamId=" + *teamId
 	}
 
-	body := fmt.Sprintf(`{"type":"encrypted","value":"%s","target":["production"],"key":"%s"}`, apiKey, SourcemapEnvKey)
+	supportedEnvs := `["production"]`
+	if key == ProjectIdEnvVar {
+		supportedEnvs = `["production", "preview", "development"]`
+	}
+
+	body := fmt.Sprintf(`{"type":"encrypted","value":"%s","target":%s,"key":"%s"}`, apiKey, supportedEnvs, key)
 
 	method := "POST"
 	envIdStr := ""


### PR DESCRIPTION
## Summary
- set `NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID` during integration flow
- this can be used in `H.init`
- adding this to our demo app so users can deploy straight to Vercel and test without modifying code
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- nope
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
