### PR TITLE
fixup: bucket is in west 2, create separate presign client to handle it

### DIFF
--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -70,10 +70,11 @@ func GetChunkedPayloadType(offset int) PayloadType {
 }
 
 type StorageClient struct {
-	S3Client        *s3.Client
-	S3ClientEast2   *s3.Client
-	S3PresignClient *s3.PresignClient
-	URLSigner       *sign.URLSigner
+	S3Client             *s3.Client
+	S3ClientEast2        *s3.Client
+	S3PresignClient      *s3.PresignClient
+	S3PresignClientWest2 *s3.PresignClient
+	URLSigner            *sign.URLSigner
 }
 
 func NewStorageClient() (*StorageClient, error) {
@@ -98,10 +99,11 @@ func NewStorageClient() (*StorageClient, error) {
 	})
 
 	return &StorageClient{
-		S3Client:        client,
-		S3ClientEast2:   clientEast2,
-		S3PresignClient: s3.NewPresignClient(clientEast2),
-		URLSigner:       getURLSigner(),
+		S3Client:             client,
+		S3ClientEast2:        clientEast2,
+		S3PresignClient:      s3.NewPresignClient(clientEast2),
+		S3PresignClientWest2: s3.NewPresignClient(client),
+		URLSigner:            getURLSigner(),
 	}, nil
 }
 
@@ -542,7 +544,7 @@ func (s *StorageClient) GetSourceMapUploadUrl(key string) (string, error) {
 		Key:    pointy.String(key),
 	}
 
-	resp, err := s.S3PresignClient.PresignPutObject(context.TODO(), &input)
+	resp, err := s.S3PresignClientWest2.PresignPutObject(context.TODO(), &input)
 	if err != nil {
 		return "", errors.Wrap(err, "error signing s3 asset URL")
 	}


### PR DESCRIPTION
## Summary
- was getting 301 redirects when testing locally
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested request/response locally
```
fetch("https://localhost:8082/private", {
    method: "post",
    headers: {
      "Content-Type": "application/json",
    },
    body: JSON.stringify({
      query: `query GetSourceMapUploadUrls($api_key: String!, $paths: [String!]!) {
       get_source_map_upload_urls(api_key: $api_key, paths: $paths)
      }`,
      variables: {
        api_key: "ccr1olu49b3h2fbtn7m0",
        paths: "8/unversioned/zane/test.js",
      },
    }),
  })
  ```
  
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- nope
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
