### PR TITLE
fix(HIG-2957): fix height & unblock scrolling in the network tab

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.module.scss
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.module.scss
@@ -65,6 +65,8 @@ $right-padding: 12px;
 }
 
 .networkTableWrapper {
+	display: flex;
+	flex-direction: column;
 	height: calc(100% - var(--player-toolbar-height));
 	margin-left: 1px;
 	overflow-y: hidden;

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/ResourcePage.tsx
@@ -340,7 +340,6 @@ export const ResourcePage = React.memo(
 						</div>
 					) : (
 						<>
-							<TimingCanvas />
 							<div className={styles.networkTopBar}>
 								<div className={styles.networkColumn}>
 									Status
@@ -470,17 +469,6 @@ export const ResourcePage = React.memo(
 		)
 	},
 )
-
-const TimingCanvas = () => {
-	const canvasRef = useRef<HTMLCanvasElement>(null)
-
-	return (
-		<canvas
-			ref={canvasRef}
-			className={styles.canvasNetworkWrapper}
-		></canvas>
-	)
-}
 
 export type NetworkResource = NetworkResourceWithID & {
 	requestResponsePairs?: RequestResponsePair


### PR DESCRIPTION
## Summary

- Fixes the overflow of rows in the network tab of dev tools.
- Removes canvas that does nothing but blocking scroll events.

## How did you test this change?

The scrollbar now does not overflow into the control bar.

<img width="766" alt="Screen Shot 2022-10-19 at 4 50 59 PM" src="https://user-images.githubusercontent.com/17913919/196825462-f08e9563-06fa-4534-89c3-d58bf9e60ab9.png">

## Are there any deployment considerations?

N/a.