### PR TITLE
fix(HIG-2843): remove duplicate filters

### DIFF
--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/SessionsQueryBuilder/SessionsQueryBuilder.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/SessionsQueryBuilder/SessionsQueryBuilder.tsx
@@ -16,7 +16,6 @@ import QueryBuilder, {
 	RuleProps,
 	SelectOption,
 	serializeRules,
-	SESSION_TYPE,
 	TIME_OPERATORS,
 	VIEWED_BY_OPERATORS,
 } from '@pages/Sessions/SessionsFeedV2/components/QueryBuilder/QueryBuilder'
@@ -52,27 +51,6 @@ const CUSTOM_FIELDS: CustomField[] = [
 		options: {
 			operators: RANGE_OPERATORS,
 			type: 'long',
-		},
-	},
-	{
-		type: SESSION_TYPE,
-		name: 'landing_page',
-		options: {
-			type: 'text',
-		},
-	},
-	{
-		type: SESSION_TYPE,
-		name: 'exit_page',
-		options: {
-			type: 'text',
-		},
-	},
-	{
-		type: SESSION_TYPE,
-		name: 'country',
-		options: {
-			type: 'text',
 		},
 	},
 	{


### PR DESCRIPTION
## Summary

Removes SESSION_TYPE filters from CUSTOM_FIELDS, since we pull them from OpenSearch.

## How did you test this change?

A click test on the local instance. Search for Country / Landing Page / Exit Page filters in the preview.

https://frontend-pr-3223.onrender.com/

Before:
<img width="178" alt="Screen Shot 2022-10-20 at 11 43 27 AM" src="https://user-images.githubusercontent.com/17913919/197031700-00d1765d-6980-4b46-8d0f-8ea8ed67d5fd.png">


After:

<img width="184" alt="Screen Shot 2022-10-20 at 11 45 35 AM" src="https://user-images.githubusercontent.com/17913919/197032046-7903776f-4c73-41a4-aee9-b24cb57f4267.png">


## Are there any deployment considerations?

N/a 
