### PR TITLE
omit unneeded env var

### DIFF
--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -2,7 +2,6 @@
 
 interface ImportMetaEnv {
 	readonly REACT_APP_COMMIT_SHA: string
-	readonly REACT_APP_ENVIRONMENT: string
 	readonly REACT_APP_FIREBASE_CONFIG_OBJECT: string
 	readonly REACT_APP_FRONT_INTEGRATION_CLIENT_ID: string
 	readonly REACT_APP_FRONTEND_ORG: string

--- a/frontend/src/util/graph.tsx
+++ b/frontend/src/util/graph.tsx
@@ -131,5 +131,5 @@ export const client = new ApolloClient({
 	),
 	cache,
 	assumeImmutableResults: true,
-	connectToDevTools: import.meta.env.REACT_APP_ENVIRONMENT === 'dev',
+	connectToDevTools: import.meta.env.DEV,
 })

--- a/turbo.json
+++ b/turbo.json
@@ -34,7 +34,6 @@
 			"outputs": ["build/**", "dist/**", "esm/**"],
 			"env": [
 				"REACT_APP_COMMIT_SHA",
-				"REACT_APP_ENVIRONMENT",
 				"REACT_APP_FIREBASE_CONFIG_OBJECT",
 				"REACT_APP_FRONT_INTEGRATION_CLIENT_ID",
 				"REACT_APP_FRONTEND_ORG",


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We can infer the environment from vite (see [docs](https://vitejs.dev/guide/env-and-mode.html#env-variables)). 



## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

I confirmed that `import.meta.env.DEV` evaluates to `true` in development and that the Apollo devtools still work in development (what `connectToDevTools` [determines](https://www.apollographql.com/docs/react/development-testing/developer-tooling/#configuration)) but not on production (verified through render PR URL).

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

We should remove `REACT_APP_ENVIRONMENT` from the doppler configs.
