### PR TITLE
add sleep to avoid Hubspot rate limit

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1199,25 +1199,17 @@ func (w *Worker) RefreshMaterializedViews() {
 		log.Fatal(e.Wrap(err, "Error retrieving session counts for Hubspot update"))
 	}
 
-	var g errgroup.Group
-	for _, c := range counts {
-		c := c
-		g.Go(func() error {
-			if !util.IsDevOrTestEnv() {
-				if err := w.Resolver.HubspotApi.UpdateCompanyProperty(c.WorkspaceID, []hubspot.Property{{
-					Name:     "highlight_session_count",
-					Property: "highlight_session_count",
-					Value:    c.Count,
-				}}); err != nil {
-					return e.Wrap(err, "error updating highlight session count in hubspot")
-				}
+	if !util.IsDevOrTestEnv() {
+		for _, c := range counts {
+			if err := w.Resolver.HubspotApi.UpdateCompanyProperty(c.WorkspaceID, []hubspot.Property{{
+				Name:     "highlight_session_count",
+				Property: "highlight_session_count",
+				Value:    c.Count,
+			}}); err != nil {
+				log.Fatal(e.Wrap(err, "error updating highlight session count in hubspot"))
 			}
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		log.Fatal(err)
+			time.Sleep(150 * time.Millisecond)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Hubspot has rate limit of 100 requests per 10 seconds
- add a 150ms sleep and make request synchronous
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- only runs in prod, will monitor after deployment
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- nope
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
