### PR TITLE
fix datadogRum warning

### DIFF
--- a/frontend/src/util/perf/instrument.ts
+++ b/frontend/src/util/perf/instrument.ts
@@ -18,7 +18,7 @@ export const timedCall = (
 				tags: tags || [],
 			},
 		])
-		datadogRum.addTiming(name, dur)
+		datadogRum.addTiming(ddSanitize(name), dur)
 	}
 }
 
@@ -43,7 +43,12 @@ export const timedCallback = <T extends Function>(
 					tags: tags || [],
 				},
 			])
-			datadogRum.addTiming(name, dur)
+			datadogRum.addTiming(ddSanitize(name), dur)
 		}
 	}
+}
+
+// Datadog RUM does not allow timing names with `/`
+function ddSanitize(name: string): string {
+	return name.replaceAll('/', '_')
 }


### PR DESCRIPTION
## Summary

Fix datadog rum `addTiming` calls which do not like `/` characters in the timing key.

## How did you test this change?

Before - ![image](https://user-images.githubusercontent.com/1351531/197075065-8bcf3c26-4d6c-4434-bf63-652a48d894d4.png)

After - no more warnings

## Are there any deployment considerations?

No
