### PR TITLE
add front plugin configuration button

### DIFF
--- a/frontend/src/pages/IntegrationsPage/Integrations.tsx
+++ b/frontend/src/pages/IntegrationsPage/Integrations.tsx
@@ -8,6 +8,7 @@ import SlackIntegrationConfig from '@pages/IntegrationsPage/components/SlackInte
 import VercelIntegrationConfig from '@pages/IntegrationsPage/components/VercelIntegration/VercelIntegrationConfig'
 import ZapierIntegrationConfig from '@pages/IntegrationsPage/components/ZapierIntegration/ZapierIntegrationConfig'
 import React from 'react'
+import FrontPluginConfig from '@pages/IntegrationsPage/components/FrontPlugin/FrontPluginConfig'
 
 export interface Integration {
 	key: string
@@ -80,6 +81,16 @@ export const FRONT_INTEGRATION: Integration = {
 	hasSettings: false,
 }
 
+export const FRONT_PLUGIN: Integration = {
+	key: 'front',
+	name: 'Front',
+	configurationPath: 'front',
+	description: 'Enhance your customer interaction experience.',
+	icon: '/images/integrations/front.png',
+	configurationPage: (opts) => <FrontPluginConfig {...opts} />,
+	hasSettings: false,
+}
+
 export const VERCEL_INTEGRATION: Integration = {
 	key: 'vercel',
 	name: 'Vercel',
@@ -108,7 +119,7 @@ const INTEGRATIONS: Integration[] = [
 	LINEAR_INTEGRATION,
 	ZAPIER_INTEGRATION,
 	CLEARBIT_INTEGRATION,
-	FRONT_INTEGRATION,
+	FRONT_PLUGIN,
 	VERCEL_INTEGRATION,
 	DISCORD_INTEGRATION,
 ]

--- a/frontend/src/pages/IntegrationsPage/components/FrontPlugin/FrontPluginConfig.module.scss
+++ b/frontend/src/pages/IntegrationsPage/components/FrontPlugin/FrontPluginConfig.module.scss
@@ -1,0 +1,23 @@
+.modalBtn {
+	background: var(--color-purple);
+	border-radius: 8px;
+	padding: 8px 12px !important;
+}
+
+.modalBtnIcon {
+	margin-right: 0.5rem;
+}
+
+.modalSubTitle {
+	color: var(--color-gray-500) !important;
+	font-size: 16px;
+	margin-bottom: 20px;
+	margin-top: 0 !important;
+}
+
+.modalBtnText {
+	align-items: center;
+	color: var(--color-white) !important;
+	display: inline-flex !important;
+	height: 100%;
+}

--- a/frontend/src/pages/IntegrationsPage/components/FrontPlugin/FrontPluginConfig.module.scss.d.ts
+++ b/frontend/src/pages/IntegrationsPage/components/FrontPlugin/FrontPluginConfig.module.scss.d.ts
@@ -1,0 +1,4 @@
+export const modalBtn: string
+export const modalBtnIcon: string
+export const modalBtnText: string
+export const modalSubTitle: string

--- a/frontend/src/pages/IntegrationsPage/components/FrontPlugin/FrontPluginConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/FrontPlugin/FrontPluginConfig.tsx
@@ -1,0 +1,31 @@
+import Sparkles2Icon from '@icons/Sparkles2Icon'
+import { IntegrationConfigProps } from '@pages/IntegrationsPage/components/Integration'
+import React from 'react'
+
+import styles from './FrontPluginConfig.module.scss'
+
+const FrontPluginConfig: React.FC<IntegrationConfigProps> = ({}) => {
+	return (
+		<>
+			<p className={styles.modalSubTitle}>
+				Connect Highlight with Front to enhance your customer
+				conversations with their recorded sessions from your app.
+			</p>
+			<footer>
+				<a
+					className={styles.modalBtn}
+					target="_blank"
+					rel="noreferrer"
+					href={`https://front.com/integrations/highlight`}
+				>
+					<span className={styles.modalBtnText}>
+						<Sparkles2Icon className={styles.modalBtnIcon} />
+						<span>Connect Highlight with Front</span>
+					</span>
+				</a>
+			</footer>
+		</>
+	)
+}
+
+export default FrontPluginConfig


### PR DESCRIPTION
## Summary

Since our plugin is now published in the Front marketplace, link that as the Front -> Highlight integration.
Hides the existing front integration since that is for integrating with the front api and is unused.

<img width="1030" alt="Screenshot 2022-10-26 at 10 11 29 AM" src="https://user-images.githubusercontent.com/1351531/198092059-1d74fe22-ca34-40f0-a1db-7a801b1a27e9.png">


## How did you test this change?

Local UI deploy.

## Are there any deployment considerations?

No.