### PR TITLE
catch upcoming invoice not exists error

### DIFF
--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -347,6 +347,11 @@ func reportUsage(DB *gorm.DB, stripeClient *client.API, workspaceID int, product
 	invoiceParams.AddExpand("lines.data.price.product")
 
 	invoice, err := stripeClient.Invoices.GetNext(invoiceParams)
+	// Cancelled subscriptions have no upcoming invoice - we can skip these since we won't
+	// be charging any overage for their next billing period.
+	if err.Error() == string(stripe.ErrorCodeInvoiceUpcomingNone) {
+		return nil
+	}
 	if err != nil {
 		return e.Wrap(err, "STRIPE_INTEGRATION_ERROR cannot report usage - failed to retrieve upcoming invoice")
 	}


### PR DESCRIPTION
## Summary
- catch `ErrorCodeInvoiceUpcomingNone` - this happens when a customer has cancelled their subscription, there is no invoice to update
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- did not test, will see if this resolves errors during next stripe update job
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
