### PR TITLE
Revert "use the deployed sha for the version tag in datadog"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,7 +131,7 @@ jobs:
                   ECR_REPOSITORY: highlight-production-ecr-repo
                   IMAGE_TAG: ${{ github.sha }}
               run: |
-                  docker build --build-arg=REACT_APP_COMMIT_SHA=${{ github.sha }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f deploy/Dockerfile.prod .
+                  docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f deploy/Dockerfile.prod .
                   docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
             # Edit and deploy private-graph
             - name: Replace image label for private-graph task

--- a/backend/datadog/datadog.go
+++ b/backend/datadog/datadog.go
@@ -16,9 +16,8 @@ var (
 func Start(rt util.Runtime) error {
 	statsdHost := os.Getenv("DD_STATSD_HOST")
 	apmHost := os.Getenv("DD_APM_HOST")
-	version := os.Getenv("REACT_APP_COMMIT_SHA")
 	serviceTagKey, serviceTagValue := "service", string(rt)+"-service"
-	serviceVersionTagKey, serviceVersionTagValue := "version", version
+	serviceVersionTagKey, serviceVersionTagValue := "version", util.GenerateRandomString(8)
 
 	tracer.Start(
 		tracer.WithAgentAddr(apmHost),

--- a/backend/util/random.go
+++ b/backend/util/random.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"math/rand"
+	"time"
+)
+
+const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func GenerateRandomString(length int) string {
+	rand.Seed(time.Now().UnixNano())
+
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/deploy/Dockerfile.prod
+++ b/deploy/Dockerfile.prod
@@ -8,6 +8,4 @@ RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /bin/backend
 RUN wget -q -t3 'https://packages.doppler.com/public/cli/rsa.8004D9FF50437357.key' -O /etc/apk/keys/cli@doppler-8004D9FF50437357.rsa.pub && \
     echo 'https://packages.doppler.com/public/cli/alpine/any-version/main' | tee -a /etc/apk/repositories && \
     apk add doppler
-ARG REACT_APP_COMMIT_SHA
-ENV REACT_APP_COMMIT_SHA=${REACT_APP_COMMIT_SHA}
 CMD ["doppler", "run", "--", "/bin/backend", "-runtime=private-graph"]


### PR DESCRIPTION
Reverts highlight-run/highlight#3198
Possibly related to worker dashboard consumer/producer discrepancies