### PR TITLE
some more error logging for stripe webhook

### DIFF
--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -353,7 +353,8 @@ func reportUsage(DB *gorm.DB, stripeClient *client.API, workspaceID int, product
 		return nil
 	}
 	if err != nil {
-		return e.Wrap(err, "STRIPE_INTEGRATION_ERROR cannot report usage - failed to retrieve upcoming invoice")
+		log.Error(err)
+		return e.Wrap(err, "STRIPE_INTEGRATION_ERROR cannot report usage - failed to retrieve upcoming invoice for customer "+c.ID)
 	}
 
 	invoiceLines := map[ProductType]*stripe.InvoiceLine{}


### PR DESCRIPTION
- inner error is blank after `e.wrap` for some reason, trying to log it by itself and log the customer id.
- previous change worked to fix the error from the daily update job, but did not fix the same error happening in the webhook