### PR TITLE
fix(hig-3172): change logic for slack channel fetcher

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2492,54 +2492,32 @@ func (r *Resolver) GetSlackChannelsFromSlack(workspaceId int) (*[]model.SlackCha
 		log.Error(e.Wrap(err, "failed to get users"))
 	}
 
-	newChannels := []model.SlackChannel{}
-	for _, channel := range allSlackChannelsFromAPI {
-		newChannel := model.SlackChannel{}
-
-		// Slack channels' `User` will be an empty string and the user's ID if it's a user.
-		if channel.User != "" {
-			var userToFind *slack.User
-			for _, user := range users {
-				if user.ID == channel.User {
-					userToFind = &user
-					break
-				}
-			}
-
-			if userToFind != nil {
-				// Filter out Slack Bots.
-				if userToFind.IsBot || userToFind.Name == "slackbot" {
-					continue
-				}
-				newChannel.WebhookChannel = fmt.Sprintf("@%s", userToFind.Name)
-			}
-		} else {
-			newChannel.WebhookChannel = fmt.Sprintf("#%s", channel.Name)
-		}
-
-		newChannel.WebhookChannelID = channel.ID
-		newChannels = append(newChannels, newChannel)
-	}
-
 	newChannelsCount := 0
-	// Filter out `newChannels` that already exist in `existingChannels` so we don't have duplicates.
-	for _, newChannel := range newChannels {
-		channelAlreadyExists := false
 
-		for _, existingChannel := range existingChannels {
-			if existingChannel.WebhookChannelID == newChannel.WebhookChannelID {
-				channelAlreadyExists = true
-				break
-			}
-		}
+	channelsAndUsers := map[string]model.SlackChannel{}
+	for _, channel := range existingChannels {
+		channelsAndUsers[channel.WebhookChannelID] = channel
+	}
 
-		if !channelAlreadyExists {
-			filteredNewChannels = append(filteredNewChannels, newChannel)
+	for _, channel := range allSlackChannelsFromAPI {
+		_, exists := channelsAndUsers[channel.ID]
+		if !exists && channel.IsChannel && channel.ID != "" {
 			newChannelsCount++
+			slackChannel := model.SlackChannel{WebhookChannelID: channel.ID, WebhookChannel: fmt.Sprintf("#%s", channel.Name)}
+			channelsAndUsers[channel.ID] = slackChannel
+			existingChannels = append(existingChannels, slackChannel)
 		}
 	}
 
-	existingChannels = append(existingChannels, filteredNewChannels...)
+	for _, user := range users {
+		_, exists := channelsAndUsers[user.ID]
+		if !exists && !user.IsBot && !user.Deleted && strings.ToLower(user.Name) != "slackbot" {
+			newChannelsCount++
+			slackChannel := model.SlackChannel{WebhookChannelID: user.ID, WebhookChannel: fmt.Sprintf("@%s", user.Name)}
+			channelsAndUsers[user.ID] = slackChannel
+			existingChannels = append(existingChannels, slackChannel)
+		}
+	}
 
 	return &existingChannels, newChannelsCount, nil
 }


### PR DESCRIPTION
## Summary

Before we relied on a heuristic to identify whether a fetched slack entity is a channel or user. This PR simplifies the logic and avoids making assumptions.

## How did you test this change?

Integrated with Slack locally and made sure that Julian and many others (like Akshay and me) now appear in suggestions:

<img width="499" alt="Screen Shot 2022-11-02 at 7 47 16 PM" src="https://user-images.githubusercontent.com/17913919/199638685-0751de71-6a81-4e41-8a19-a898e9398243.png">

## Are there any deployment considerations?

No