### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+    # Maintain dependencies for Golang
+    - package-ecosystem: gomod
+      directory: /backend
+      schedule:
+          interval: daily
+
+    # Maintain dependencies for GitHub Actions
+    - package-ecosystem: 'github-actions'
+      directory: /
+      schedule:
+          interval: weekly
+
+    # Maintain dependencies for npm
+    - package-ecosystem: 'npm'
+      directory: /
+      schedule:
+          interval: daily
+
+    # Maintain git submodules
+    - package-ecosystem: 'gitsubmodule'
+      directory: /
+      schedule:
+          interval: daily


### PR DESCRIPTION
Add dependabot for golang and git submodules.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file