### PR TITLE
hotfix: time indicator text when histogram view is off

### DIFF
--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/TimelineIndicatorsBarGraph.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/TimelineIndicatorsBarGraph.tsx
@@ -1138,6 +1138,13 @@ const TimelineIndicatorsBarGraph = ({
 				style={{
 					transform: `translateX(${textStart}px)`,
 					visibility: showIndicatorText ? 'visible' : 'hidden',
+					top:
+						style.PROGRESS_BAR_HEIGHT +
+						(showHistogram ? style.SESSION_MONITOR_HEIGHT : 0) +
+						style.TIME_AXIS_HEIGHT -
+						style.TIME_INDICATOR_TOP_HEIGHT -
+						style.TIME_INDICATOR_TEXT_HEIGHT -
+						4,
 				}}
 			>
 				<Text

--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/style.css.ts
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/style.css.ts
@@ -8,9 +8,9 @@ export const SESSION_MONITOR_HEIGHT = 20
 export const TIME_AXIS_HEIGHT = 24
 export const TIME_INDICATOR_ACTIVATION_RADIUS = 15
 export const TIME_INDICATOR_TOP_WIDTH = 10
+export const TIME_INDICATOR_TOP_HEIGHT = 12
 export const TIME_INDICATOR_TEXT_HEIGHT = 20
 export const TIMELINE_MARGIN = 8
-export const TOP_HEIGHT = 12
 
 export const timelineContainer = style({
 	alignItems: 'center',
@@ -232,16 +232,14 @@ export const hairHidden = style({
 	visibility: 'hidden',
 })
 
-const timeIndicatorTopOffset = TIME_AXIS_HEIGHT - TOP_HEIGHT + 1
-
 export const timeIndicatorTop = style({
 	backgroundColor: 'var(--color-neutral-900)',
 	border: '1px solid var(--color-white)',
 	borderRadius: '1px 1px 12px 12px',
 	cursor: 'grab',
-	height: TOP_HEIGHT,
+	height: TIME_INDICATOR_TOP_HEIGHT,
 	position: 'sticky',
-	top: timeIndicatorTopOffset,
+	top: TIME_AXIS_HEIGHT - TIME_INDICATOR_TOP_HEIGHT + 1,
 	width: '8px',
 })
 
@@ -249,11 +247,5 @@ export const timeIndicatorText = style({
 	zIndex: 2,
 	height: TIME_INDICATOR_TEXT_HEIGHT,
 	left: 0,
-	top:
-		PROGRESS_BAR_HEIGHT +
-		SESSION_MONITOR_HEIGHT +
-		timeIndicatorTopOffset -
-		TIME_INDICATOR_TEXT_HEIGHT -
-		4,
 	transformOrigin: 'left',
 })


### PR DESCRIPTION
## Summary

this fixes the top offset for time indicator text

before:

<img width="866" alt="Screen Shot 2022-11-07 at 2 48 59 PM" src="https://user-images.githubusercontent.com/17913919/200431897-08a3cf98-82b7-4c41-8526-422277c11648.png">

after:

<img width="967" alt="Screen Shot 2022-11-07 at 2 49 17 PM" src="https://user-images.githubusercontent.com/17913919/200431944-e1d4fcb6-b2c6-4b73-9408-c5eb4d0ee837.png">

## How did you test this change?

[preview](https://frontend-pr-3295.onrender.com/)
## Are there any deployment considerations?

no