### PR TITLE
hotfix: remove useEffect watching the panels

### DIFF
--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -29,7 +29,9 @@ import {
 	ResourcesContextProvider,
 	useResources,
 } from '@pages/Player/ResourcesContext/ResourcesContext'
-import RightPlayerPanel from '@pages/Player/RightPlayerPanel/RightPlayerPanel'
+import RightPlayerPanel, {
+	DUAL_PANEL_VIEWPORT_THRESHOLD,
+} from '@pages/Player/RightPlayerPanel/RightPlayerPanel'
 import SearchPanel from '@pages/Player/SearchPanel/SearchPanel'
 import SessionLevelBar from '@pages/Player/SessionLevelBar/SessionLevelBar'
 import DetailPanel from '@pages/Player/Toolbar/DevToolsWindow/DetailPanel/DetailPanel'
@@ -55,6 +57,7 @@ import React, {
 import { Helmet } from 'react-helmet'
 import Skeleton, { SkeletonTheme } from 'react-loading-skeleton'
 import useResizeAware from 'react-resize-aware'
+import { useWindowSize } from 'react-use'
 
 import WaitingAnimation from '../../lottie/waiting.json'
 import styles from './PlayerPage.module.scss'
@@ -100,8 +103,11 @@ const Player = ({ integrated }: Props) => {
 	})
 
 	const resources = useResources(session)
-	const { setShowLeftPanel, showLeftPanel: showLeftPanelPreference } =
-		usePlayerConfiguration()
+	const {
+		setShowRightPanel,
+		setShowLeftPanel,
+		showLeftPanel: showLeftPanelPreference,
+	} = usePlayerConfiguration()
 	const playerWrapperRef = useRef<HTMLDivElement>(null)
 	const { isPlayerFullscreen, setIsPlayerFullscreen, playerCenterPanelRef } =
 		usePlayerFullscreen()
@@ -220,6 +226,8 @@ const Player = ({ integrated }: Props) => {
 		)
 	}, [controllerWidth])
 
+	const { width: windowWidth } = useWindowSize()
+
 	return (
 		<PlayerUIContextProvider
 			value={{
@@ -274,6 +282,14 @@ const Player = ({ integrated }: Props) => {
 								direction="left"
 								isOpen={showLeftPanelPreference}
 								onClick={() => {
+									if (
+										!showLeftPanelPreference &&
+										windowWidth <=
+											DUAL_PANEL_VIEWPORT_THRESHOLD
+									) {
+										setShowRightPanel(false)
+									}
+
 									setShowLeftPanel(!showLeftPanelPreference)
 								}}
 							/>

--- a/frontend/src/pages/Player/RightPlayerPanel/RightPlayerPanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/RightPlayerPanel.tsx
@@ -18,12 +18,11 @@ import { useReplayerContext } from '../ReplayerContext'
 import SessionFullCommentList from '../SessionFullCommentList/SessionFullCommentList'
 import styles from './RightPlayerPanel.module.scss'
 
-const RIGHT_PANEL_VIEWPORT_THRESHOLD = 1400
+export const DUAL_PANEL_VIEWPORT_THRESHOLD = 1400
 
 const RightPlayerPanel = React.memo(() => {
 	const {
 		showRightPanel: showRightPanelPreference,
-		showLeftPanel,
 		setShowRightPanel,
 		setShowLeftPanel,
 	} = usePlayerConfiguration()
@@ -34,16 +33,6 @@ const RightPlayerPanel = React.memo(() => {
 	const showRightPanel = showRightPanelPreference && canViewSession
 
 	const { width } = useWindowSize()
-
-	useEffect(() => {
-		if (
-			showRightPanel &&
-			showLeftPanel &&
-			width <= RIGHT_PANEL_VIEWPORT_THRESHOLD
-		) {
-			setShowRightPanel(false)
-		}
-	}, [setShowRightPanel, showLeftPanel, showRightPanel, width])
 
 	useEffect(() => {
 		const commentId = new URLSearchParams(location.search).get(
@@ -75,11 +64,13 @@ const RightPlayerPanel = React.memo(() => {
 					direction="right"
 					isOpen={showRightPanel}
 					onClick={() => {
-						const isOpen = !showRightPanel
-						if (isOpen && width <= RIGHT_PANEL_VIEWPORT_THRESHOLD) {
+						if (
+							!showRightPanel &&
+							width <= DUAL_PANEL_VIEWPORT_THRESHOLD
+						) {
 							setShowLeftPanel(false)
 						}
-						setShowRightPanel(isOpen)
+						setShowRightPanel(!showRightPanel)
 					}}
 				/>
 				{showRightPanel && (


### PR DESCRIPTION
## Summary

Context: Vera from enterneverland.com cannot open the right panel on a pretty large screen (1247 x 1810).

https://app.intercom.com/a/inbox/gm6369ty/inbox/shared/all/conversation/41135?view=List

I cannot reproduce this behavior, but believe this is due to a useEffect that should be closing the right panel if they are both open on a small enough screen. Moving the logic that does that to event handlers on buttons.

Session on highlight showcasing the behavior:

https://app.highlight.run/1/sessions/LO7wtMT9JSxMmJmAS3XmDLlOISDw?page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue%7C%7Ccustom_created_at%2Cbetween_date%2C30%20days%7C%7Cuser_identifier%2Cis%2Cvera%40enterneverland.com

## How did you test this change?

Chrome dev tools. 

## Are there any deployment considerations?

No
