### PR TITLE
Bump limit of events returned for filtering in sessions

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -184,12 +184,12 @@ func (r *errorGroupResolver) MetadataLog(ctx context.Context, obj *model.ErrorGr
 				20
 			) AS e ON s.id = e.session_id
 		WHERE
-			s.excluded <> true 
+			s.excluded <> true
 			AND s.project_id = ?
 		ORDER BY
 			s.updated_at DESC
 		LIMIT
-			20;	
+			20;
 	`,
 		obj.ID,
 		obj.ProjectID,
@@ -4249,7 +4249,7 @@ func (r *queryResolver) FieldTypes(ctx context.Context, projectID int) ([]*model
 		Aggregation: &opensearch.TermsAggregation{
 			Field:   "fields.Key.raw",
 			Include: pointy.String("(session|track|user)_.*"),
-			Size:    pointy.Int(100),
+			Size:    pointy.Int(500),
 		},
 	}
 


### PR DESCRIPTION
## Summary

Some users aren't seeing the events they expect in search results filters because they use more event names than we return as filter values. This PR bumps up the number of filters we return to temporarily resolve this issue.

## How did you test this change?

Click tested locally, but was not able to run against prod data because backend changes aren't deployed for Render previews. I will check to see if properties like `location` and `diffLength` appear for Superpowered in prod after the deploy.

## Are there any deployment considerations?

Should continue to monitor performance of `GetFieldsType`. Want to make sure this doesn't degrade performance to the point where it's unusable.