### PR TITLE
fix(hig-3235): goto should keep panel open and pause replay

### DIFF
--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelinePopover/TimelinePopover.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelinePopover/TimelinePopover.tsx
@@ -32,10 +32,9 @@ const POPOVER_CONTENT_ROW_HEIGHT = 28
 
 const TimelinePopover = ({ bucket }: Props) => {
 	const history = useHistory()
-	const { setTime, setCurrentEvent } = useReplayerContext()
+	const { setCurrentEvent, pause } = useReplayerContext()
 	const {
 		setShowRightPanel,
-		setShowLeftPanel,
 		setShowDevTools,
 		setSelectedDevToolsTab,
 		setSelectedRightPlayerPanelTab,
@@ -64,21 +63,19 @@ const TimelinePopover = ({ bucket }: Props) => {
 	const onEventInstanceClick = (type: string, identifier: string) => {
 		const timestamp = bucket.timestamp[identifier]
 
-		setTime(timestamp)
+		pause(timestamp)
 		if (type === 'Comments') {
 			const urlSearchParams = new URLSearchParams()
 			urlSearchParams.append(PlayerSearchParameters.commentId, identifier)
 			history.replace(
 				`${history.location.pathname}?${urlSearchParams.toString()}`,
 			)
-			setShowLeftPanel(false)
 			setShowRightPanel(true)
 			setSelectedRightPlayerPanelTab(RightPlayerPanelTabType.Comments)
 		} else if (type === 'Errors') {
 			setShowDevTools(true)
 			setSelectedDevToolsTab(DevToolTabType.Errors)
 		} else {
-			setShowLeftPanel(false)
 			setShowRightPanel(true)
 			setSelectedRightPlayerPanelTab(RightPlayerPanelTabType.Events)
 			setCurrentEvent(identifier)
@@ -101,7 +98,7 @@ const TimelinePopover = ({ bucket }: Props) => {
 					if (selectedType) {
 						setSelectedType(null)
 					} else {
-						setTime(bucket.startTime)
+						pause(bucket.startTime)
 					}
 				}}
 			>


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->
- do not close the left panel on event instance click
- pause rather than setTime 

## How did you test this change?
[preview](https://frontend-pr-3310.onrender.com/)

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
n/a
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
