### PR TITLE
fix onFrame raf loop not stopping

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -772,17 +772,6 @@ export const usePlayer = (): ReplayerContextInterface => {
 	])
 
 	useEffect(() => {
-		if (
-			state.replayerState !== ReplayerState.Playing &&
-			!state.isLiveMode &&
-			animationFrameID.current
-		) {
-			cancelAnimationFrame(animationFrameID.current)
-			animationFrameID.current = 0
-		}
-	}, [state.replayerState, state.isLiveMode])
-
-	useEffect(() => {
 		setPlayerTimeToPersistance(state.time)
 	}, [setPlayerTimeToPersistance, state.time])
 


### PR DESCRIPTION
## Summary

ensure onFrame `requestAnimationFrame` loop stops when the player is not playing.

## How did you test this change?

local deploy

## Are there any deployment considerations?

no
