### PR TITLE
Add idx_error_group_id_id index

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -858,10 +858,11 @@ type ErrorSegment struct {
 
 type ErrorObject struct {
 	Model
+	ID               int `gorm:"primary_key;type:serial;index:idx_error_group_id_id,priority:2,option:CONCURRENTLY" json:"id" deep:"-"`
 	OrganizationID   int
 	ProjectID        int `json:"project_id"`
 	SessionID        int
-	ErrorGroupID     int
+	ErrorGroupID     int `gorm:"index:idx_error_group_id_id,priority:1,option:CONCURRENTLY"`
 	Event            string
 	Type             string
 	URL              string


### PR DESCRIPTION
## Summary

Adds the `idx_error_group_id_id` index on `error_objects.error_group_id` and `error_objects.id` to optimize the previous/next ID fetching for navigating error instances.

## How did you test this change?

This was already run in a production console, just adding to GORM so our local DBs stay in sync. I confirmed the index exists in the prod DB:

```sh
postgres@database-1:postgres> select * from pg_indexes where tablename = 'error_objects' and indexname = 'idx_error_objects_session_id'
+------------+---------------+------------------------------+------------+-------------------------------------------------------------------------------------------+
| schemaname | tablename     | indexname                    | tablespace | indexdef                                                                                  |
|------------+---------------+------------------------------+------------+-------------------------------------------------------------------------------------------|
| public     | error_objects | idx_error_objects_session_id | <null>     | CREATE INDEX idx_error_objects_session_id ON public.error_objects USING hash (session_id) |
+------------+---------------+------------------------------+------------+-------------------------------------------------------------------------------------------+
```

## Are there any deployment considerations?

Should monitor as this is deployed, but should be a noop.