### PR TITLE
separate web worker from client bundle

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -13,6 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         # configures turborepo Remote Caching
         env:
+            ENVIRONMENT: prod
             TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
             TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 

--- a/.yarn/patches/rollup-plugin-web-worker-loader-npm-1.6.1-ee2e4494aa.patch
+++ b/.yarn/patches/rollup-plugin-web-worker-loader-npm-1.6.1-ee2e4494aa.patch
@@ -1,0 +1,17 @@
+diff --git a/src/plugin/load.js b/src/plugin/load.js
+index 5a2bb6970dcfb491c5ffd2bfa1e9da63b55fc5ea..7d937107ccfc34d2a6b865be8a5de3728c7ca5ef 100644
+--- a/src/plugin/load.js
++++ b/src/plugin/load.js
+@@ -50,7 +50,11 @@ function handleBundleGenerated(state, config, addWatchFile, id, workerID, result
+             }
+         } else {
+             const workerPath = path.posix.join(config.outputFolder, workerID);
+-            source = path.posix.join(config.loadPath, workerPath);
++            if (config.loadPath.indexOf('https://') !== -1) {
++                source = config.loadPath;
++            } else {
++                source = path.posix.join(config.loadPath, workerPath);
++            }
+             chunk.fileName = workerPath;
+             state.idMap.get(id).chunk = chunk;
+         }

--- a/client/rollup.config.js
+++ b/client/rollup.config.js
@@ -10,6 +10,7 @@ import webWorkerLoader from 'rollup-plugin-web-worker-loader'
 import pkg from './package.json'
 import consts from 'rollup-plugin-consts'
 import replace from '@rollup/plugin-replace'
+import packageJson from '../firstload/package.json'
 
 const development = process.env.ENVIRONMENT === 'dev'
 const sourceMap = true
@@ -39,7 +40,10 @@ const basePlugins = [
 	}),
 	webWorkerLoader({
 		targetPlatform: 'browser',
-		inline: true,
+		inline: development,
+		loadPath: development
+			? ''
+			: `https://static.highlight.io/v${packageJson.version}/`,
 		sourceMap,
 	}),
 	commonjs({}),

--- a/client/rollup.config.js
+++ b/client/rollup.config.js
@@ -43,8 +43,10 @@ const basePlugins = [
 		inline: development,
 		loadPath: development
 			? ''
-			: `https://static.highlight.io/v${packageJson.version}/`,
-		sourceMap,
+			: `https://static.highlight.io/v${packageJson.version}/highlight-client-worker.js`,
+		preserveSource: true,
+		preserveFileNames: true,
+		sourcemap: sourceMap,
 	}),
 	commonjs({}),
 	esbuild({

--- a/firstload/package.json
+++ b/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "5.1.2",
+	"version": "5.1.3",
 	"scripts": {
 		"build": "yarn typegen && rollup -c",
 		"dev": "doppler run -- rollup -c -w",

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -444,6 +444,7 @@ export type ErrorTrace = {
 	lineNumber?: Maybe<Scalars['Int']>
 	linesAfter?: Maybe<Scalars['String']>
 	linesBefore?: Maybe<Scalars['String']>
+	sourceMappingErrorMetadata?: Maybe<SourceMappingError>
 }
 
 export type ErrorsHistogram = {
@@ -2026,6 +2027,36 @@ export enum SocialType {
 	LinkedIn = 'LinkedIn',
 	Site = 'Site',
 	Twitter = 'Twitter',
+}
+
+export type SourceMappingError = {
+	__typename?: 'SourceMappingError'
+	actualMinifiedFetchedPath?: Maybe<Scalars['String']>
+	actualSourcemapFetchedPath?: Maybe<Scalars['String']>
+	errorCode?: Maybe<SourceMappingErrorCode>
+	mappedColumnNumber?: Maybe<Scalars['Int']>
+	mappedLineNumber?: Maybe<Scalars['Int']>
+	minifiedColumnNumber?: Maybe<Scalars['Int']>
+	minifiedFetchStrategy?: Maybe<Scalars['String']>
+	minifiedFileSize?: Maybe<Scalars['String']>
+	minifiedLineNumber?: Maybe<Scalars['Int']>
+	sourceMapURL?: Maybe<Scalars['String']>
+	sourcemapFetchStrategy?: Maybe<Scalars['String']>
+	sourcemapFileSize?: Maybe<Scalars['String']>
+	stackTraceFileURL?: Maybe<Scalars['String']>
+}
+
+export enum SourceMappingErrorCode {
+	ErrorParsingStackTraceFileUrl = 'Error_Parsing_Stack_Trace_File_Url',
+	FileNameMissingFromSourcePath = 'File_Name_Missing_From_Source_Path',
+	InvalidSourceMapUrl = 'Invalid_SourceMapURL',
+	MinifiedFileLarger = 'Minified_File_Larger',
+	MinifiedFileMissingInS3AndUrl = 'Minified_File_Missing_In_S3_And_URL',
+	MissingSourceMapFileInS3 = 'Missing_Source_Map_File_In_S3',
+	SourceMapFileLarger = 'Source_Map_File_Larger',
+	SourcemapFileMissingInS3AndUrl = 'Sourcemap_File_Missing_In_S3_And_URL',
+	SourcemapLibraryCouldntParse = 'Sourcemap_Library_Couldnt_Parse',
+	SourcemapLibraryCouldntRetrieveSource = 'Sourcemap_Library_Couldnt_Retrieve_Source',
 }
 
 export type Subscription = {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"tmpl": "1.0.5",
 		"trim-newlines": "3.0.1",
 		"trim": "0.0.3",
-		"minimatch": "3.0.5"
+		"minimatch": "3.0.5",
+		"rollup-plugin-web-worker-loader@^1.6.1": "patch:rollup-plugin-web-worker-loader@npm%3A1.6.1#./.yarn/patches/rollup-plugin-web-worker-loader-npm-1.6.1-ee2e4494aa.patch"
 	}
 }

--- a/turbo.json
+++ b/turbo.json
@@ -64,5 +64,5 @@
 			"env": ["HIGHLIGHT_API_KEY"]
 		}
 	},
-	"globalEnv": ["DOPPLER_TOKEN"]
+	"globalEnv": ["ENVIRONMENT", "DOPPLER_TOKEN"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -37610,12 +37610,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-web-worker-loader@npm:^1.6.1":
+"rollup-plugin-web-worker-loader@npm:1.6.1":
   version: 1.6.1
   resolution: "rollup-plugin-web-worker-loader@npm:1.6.1"
   peerDependencies:
     rollup: ^1.9.2 || ^2.0.0
   checksum: 1239c2657bfaea5d3c7a0df901cfc8016cc306dc0a9eb3945b0750e48aec45b0fa0f9e587164e94187e0a84a3fe842bf71697c76a475c66d5e36fbff97fd8730
+  languageName: node
+  linkType: hard
+
+"rollup-plugin-web-worker-loader@patch:rollup-plugin-web-worker-loader@npm%3A1.6.1#./.yarn/patches/rollup-plugin-web-worker-loader-npm-1.6.1-ee2e4494aa.patch::locator=highlight%40workspace%3A.":
+  version: 1.6.1
+  resolution: "rollup-plugin-web-worker-loader@patch:rollup-plugin-web-worker-loader@npm%3A1.6.1#./.yarn/patches/rollup-plugin-web-worker-loader-npm-1.6.1-ee2e4494aa.patch::version=1.6.1&hash=cd6a70&locator=highlight%40workspace%3A."
+  peerDependencies:
+    rollup: ^1.9.2 || ^2.0.0
+  checksum: 0f96d696cf9102c12815b1ecae51c47910c0dc1a03f263b197c08174c7a5288ec4961cfc080067f0e3214f1d00c9a2df91f786255dd703486e2776c7946a39ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

A customer requested that our CSP was more strict than `blob:` for the `worker-src` which would
allow any of their js code to create web workers.
Have the client bundle the web worker as another file hosted on static.highlight.io.

## How did you test this change?

Local deploy continues to inline the web worker because of CORS.
Preview environment should use 5.1.3 highlight.run and use the separated `web-worker-0.js` file.

## Are there any deployment considerations?

Bumped version and updated docs.
