### PR TITLE
use outer join on accounts page to show workspaces with 0 sessions

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -2971,7 +2971,7 @@ func (r *queryResolver) Accounts(ctx context.Context) ([]*modelInputs.Account, e
 		FROM workspaces w
 		INNER JOIN projects p
 		ON p.workspace_id = w.id
-		INNER JOIN daily_session_counts_view sc
+		LEFT OUTER JOIN daily_session_counts_view sc
 		ON sc.project_id = p.id
 		group by 1, 2
 	`).Scan(&accounts).Error; err != nil {


### PR DESCRIPTION
## Summary
- small update to `/accounts` page - show all workspaces even if they don't have sessions