### PR TITLE
fix meta events missing from first chunk

### DIFF
--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -181,7 +181,7 @@ const PlayerPage = ({ integrated }: Props) => {
 			if (replayer && resizePlayer(replayer)) {
 				clearInterval(i)
 			}
-		}, 200)
+		}, 1000 / 60)
 		return () => {
 			i && clearInterval(i)
 		}


### PR DESCRIPTION
## Summary

#3338 Introduced an issue that would cause sessions with only a single chunk to miss the `Meta` event that includes the viewport. This causes sessions that never load as they do not have a size to render.

## How did you test this change?

Testing processing a local session with one chunk and many chunk loading correctly.
Testing that the sessions have all events as expected.

## Are there any deployment considerations?

No.
