### PR TITLE
Always use ID for identifying users

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -297,7 +297,7 @@ const AuthenticationRoleRouter = () => {
 					return
 				}
 
-				analytics.identify(adminData.email, {
+				analytics.identify(adminData.id, {
 					'Project ID': data.project?.id,
 					'Workspace ID': data.workspace?.id,
 				})


### PR DESCRIPTION
## Summary

Fast follow to #3337 where I accidentally used `email` and `id` as the main identifier for users. This ensures we always use `id`.

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A