### PR TITLE
filter out draft invoices for billing warning

### DIFF
--- a/frontend/src/pages/Billing/Billing.tsx
+++ b/frontend/src/pages/Billing/Billing.tsx
@@ -87,9 +87,9 @@ export const useBillingHook = ({
 			!subscriptionLoading &&
 			subscriptionData?.subscription_details.lastInvoice?.status
 				?.length &&
-			subscriptionData.subscription_details.lastInvoice.status !==
-				'paid' &&
-			subscriptionData.subscription_details.lastInvoice.status !== 'void',
+			!['paid', 'void', 'draft'].includes(
+				subscriptionData.subscription_details.lastInvoice.status,
+			),
 	}
 }
 


### PR DESCRIPTION
- this is getting triggered for the Highlight workspace rn
- will probably go away in an hour on its own once the invoice is no longer in draft state, but this would happen for all subscriptions when a new invoice is created