### PR TITLE
improve performance of indexeddb caching

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -726,7 +726,7 @@ func (r *Resolver) canAdminModifyErrorGroup(ctx context.Context, errorGroupSecur
 
 func (r *Resolver) _doesAdminOwnSession(ctx context.Context, session_secure_id string) (session *model.Session, ownsSession bool, err error) {
 	session = &model.Session{}
-	if err = r.DB.Where(&model.Session{SecureID: session_secure_id}).First(&session).Error; err != nil {
+	if err := r.DB.Order("secure_id").Model(&session).Where(&model.Session{SecureID: session_secure_id}).Limit(1).Find(&session).Error; err != nil || session.ID == 0 {
 		return nil, false, e.Wrap(err, "error querying session by secure_id: "+session_secure_id)
 	}
 

--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -530,7 +530,7 @@ func (s *StorageClient) GetDirectDownloadURL(projectId int, sessionId int, paylo
 	} else {
 		unsignedURL = fmt.Sprintf("https://%s/%s", CloudfrontDomain, *key)
 	}
-	signedURL, err := s.URLSigner.Sign(unsignedURL, time.Now().Add(5*time.Minute))
+	signedURL, err := s.URLSigner.Sign(unsignedURL, time.Now().Add(15*time.Minute))
 	if err != nil {
 		return nil, errors.Wrap(err, "error signing URL")
 	}

--- a/frontend/src/util/db.ts
+++ b/frontend/src/util/db.ts
@@ -64,8 +64,8 @@ export const db = new DB()
 
 export class IndexedDBCache {
 	static expiryMS: { [op: string]: number } = {
-		GetEventChunkURL: moment.duration(5, 'minutes').asMilliseconds(),
-		GetSession: moment.duration(5, 'minutes').asMilliseconds(),
+		GetEventChunkURL: moment.duration(15, 'minutes').asMilliseconds(),
+		GetSession: moment.duration(15, 'minutes').asMilliseconds(),
 	}
 	getItem = async function (key: { operation: string; variables: any }) {
 		const result = await db.apollo
@@ -134,6 +134,13 @@ export class IndexedDBLink extends ApolloLink {
 			indexeddbEnabled &&
 			IndexedDBLink.cachedOperations.has(operation.operationName)
 		)
+	}
+
+	static async has(operationName: string, variables: any) {
+		return !!(await indexeddbCache.getItem({
+			operation: operationName,
+			variables: variables,
+		}))
 	}
 
 	request(


### PR DESCRIPTION
## Summary

Ensures indexeddb preloading does not make extra indexeddb requests when data is already loaded.
Adds indexeddb performance instrumentation.
Limits concurrent network / indexeddb requests from preload that may slow other loading.
Extends indexeddb cache retention for data with signed url responses by extending the expiration.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

No.
