### PR TITLE
PoC authenticating via Hubspot's OAuth ENV

### DIFF
--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -1,6 +1,7 @@
 package hubspot
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/aws/smithy-go/ptr"
@@ -92,6 +93,17 @@ func (h *HubspotApi) CreateContactForAdmin(adminID int, email string, userDefine
 		return nil, e.Wrap(err, "error updating workspace HubspotContactID")
 	}
 	return &hubspotContactId, nil
+}
+
+func (h *HubspotApi) FetchContact(email string) error {
+	r := CustomContactsResponse{}
+	err := h.hubspotClient.Contacts().Client.Request("GET", "/contacts/v1/contact/email/"+email+"/profile", nil, &r)
+	if err != nil {
+		fmt.Printf("error: %+v", err)
+		return err
+	}
+	fmt.Printf("contact: %+v\n", r)
+	return nil
 }
 
 func (h *HubspotApi) CreateContactCompanyAssociation(adminID int, workspaceID int) error {

--- a/backend/migrations/cmd/example/main.go
+++ b/backend/migrations/cmd/example/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
+	hubspotApi "github.com/highlight-run/highlight/backend/hubspot"
+	"github.com/leonelquinteros/hubspot"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/highlight-run/highlight/backend/model"
@@ -10,15 +13,10 @@ import (
 
 func main() {
 	log.Info("setting up db")
-	db, err := model.SetupDB(os.Getenv("PSQL_DB"))
-	if err != nil {
-		log.Fatalf("error setting up db: %+v", err)
-	}
-	sqlDB, err := db.DB()
-	if err != nil {
-		log.Fatalf("error getting raw db: %+v", err)
-	}
-	if err := sqlDB.Ping(); err != nil {
-		log.Fatalf("error pinging db: %+v", err)
-	}
+	db, _ := model.SetupDB(os.Getenv("PSQL_DB"))
+
+	api := hubspotApi.NewHubspotAPI(hubspot.NewClient(hubspot.NewClientConfig()), db)
+	fmt.Printf("api: %+v\n", api)
+
+	api.FetchContact("chris@highlight.io")
 }


### PR DESCRIPTION
We need to migrate off our Hubspot API key to a private app key. Unfortunately, the Hubspot Go SDK we use does not have any functionality for authenticating private apps. The library does support OAuth and it happens to authenticate OAuth apps the same way private apps need to be authenticated, by [passing the key as part of the `Authorization` header](https://github.com/leonelquinteros/hubspot/blob/9178204b9a0d59938ecc2966e97150cbb57340c2/client.go#L122).

This PR is not meant to be merged. It's just showing the code I used locally to authenticate after setting `HUBSPOT_OAUTH_TOKEN` and renaming my `HUBSPOT_API_KEY` ENV vars in Doppler for local dev.

If you'd like to test locally:

1. Set your `HUBSPOT_OAUTH_TOKEN` token in Doppler. You can access this from our [private apps in Hubspot](https://app.hubspot.com/private-apps/20473940).
2. Rename/remove the `HUBSPOT_API_KEY` ENV var in Doppler.
3. Run the example command locally: `doppler run -- go run ./backend/migrations/cmd/example/main.go`
4. Verify the results look correct.
5. Modify ENV vars and run again. You can see the failed request if no valid token is present.

## Production Changes

In order to upgrade from our API key to the private app key, we will run steps 1 & 2 from above in production. It should not require any code changes to upgrade.