### PR TITLE
preload error group instances and sessions

### DIFF
--- a/frontend/src/util/db.ts
+++ b/frontend/src/util/db.ts
@@ -110,6 +110,7 @@ export class IndexedDBLink extends ApolloLink {
 		'GetEnhancedUserDetails',
 		'GetErrorDistribution',
 		'GetErrorGroup',
+		'GetErrorInstance',
 		'GetErrorGroupsOpenSearch',
 		'GetErrorsHistogram',
 		'GetEventChunks',

--- a/frontend/src/util/preload.ts
+++ b/frontend/src/util/preload.ts
@@ -4,6 +4,7 @@ import {
 	GetErrorDistributionDocument,
 	GetErrorGroupDocument,
 	GetErrorGroupsOpenSearchDocument,
+	GetErrorInstanceDocument,
 	GetErrorsHistogramDocument,
 	GetEventChunksDocument,
 	GetEventChunkUrlDocument,
@@ -16,7 +17,7 @@ import {
 	GetTimelineIndicatorEventsDocument,
 	GetWebVitalsDocument,
 } from '@graph/hooks'
-import { OpenSearchCalendarInterval } from '@graph/schemas'
+import { ErrorInstance, OpenSearchCalendarInterval } from '@graph/schemas'
 import { indexeddbEnabled, IndexedDBLink } from '@util/db'
 import { client } from '@util/graph'
 import log from '@util/log'
@@ -27,7 +28,8 @@ import { useEffect, useRef } from 'react'
 
 import { worker } from '../index'
 
-const CONCURRENT_PRELOADS = 1
+const CONCURRENT_PRELOADS = 2
+const PREVIOUS_ERROR_OBJECTS_TO_FETCH = 2
 
 export const usePreloadSessions = function ({ page }: { page: number }) {
 	const { project_id } = useParams<{
@@ -94,124 +96,7 @@ export const usePreloadSessions = function ({ page }: { page: number }) {
 
 			const promises: Promise<void>[] = []
 			for (const _s of sessions?.sessions_opensearch.sessions || []) {
-				const preloadPromise = (async (secureID: string) => {
-					if (
-						await IndexedDBLink.has('GetSession', {
-							secure_id: secureID,
-						})
-					) {
-						log('preload.ts', `skipping loaded session ${secureID}`)
-						return
-					}
-					const start = window.performance.now()
-					log('preload.ts', `preloading session ${secureID}`)
-					try {
-						const session = await client.query({
-							query: GetSessionDocument,
-							variables: {
-								secure_id: secureID,
-							},
-						})
-						const sess = session?.data?.session
-						if (!sess) return
-						if (sess.resources_url) {
-							worker.postMessage({
-								type: 'fetch',
-								url: sess.resources_url,
-							})
-						}
-						if (sess.messages_url) {
-							worker.postMessage({
-								type: 'fetch',
-								url: sess.messages_url,
-							})
-						}
-						if (sess.direct_download_url) {
-							worker.postMessage({
-								type: 'fetch',
-								url: sess.direct_download_url,
-							})
-						}
-						await client.query({
-							query: GetSessionIntervalsDocument,
-							variables: {
-								session_secure_id: secureID,
-							},
-						})
-						await client.query({
-							query: GetTimelineIndicatorEventsDocument,
-							variables: {
-								session_secure_id: secureID,
-							},
-						})
-						await client.query({
-							query: GetEventChunksDocument,
-							variables: {
-								secure_id: secureID,
-							},
-						})
-						await client.query({
-							query: GetSessionCommentsDocument,
-							variables: {
-								session_secure_id: secureID,
-							},
-						})
-						await client.query({
-							query: GetSessionPayloadDocument,
-							variables: {
-								session_secure_id: secureID,
-								skip_events: true,
-							},
-						})
-						await client.query({
-							query: GetEnhancedUserDetailsDocument,
-							variables: {
-								session_secure_id: secureID,
-							},
-						})
-						await client.query({
-							query: GetWebVitalsDocument,
-							variables: {
-								session_secure_id: secureID,
-							},
-						})
-						const response = await client.query({
-							query: GetEventChunkUrlDocument,
-							variables: {
-								secure_id: secureID,
-								index: 0,
-							},
-						})
-						worker.postMessage({
-							type: 'fetch',
-							url: response.data.event_chunk_url,
-						})
-						const preloadTime = window.performance.now() - start
-						log(
-							'preload.ts',
-							`preloaded session ${secureID} in ${
-								preloadTime / 1000
-							} s.`,
-						)
-						H.metrics([
-							{
-								name: 'preload-session-ms',
-								value: preloadTime,
-								tags: [
-									{
-										name: 'SecureID',
-										value: secureID,
-									},
-								],
-							},
-						])
-					} catch (e: any) {
-						const msg = `failed to preload session ${secureID}`
-						console.warn(msg)
-						H.consumeError(e, msg)
-					}
-				})(_s.secure_id)
-				promises.push(preloadPromise)
+				promises.push(loadSession(_s.secure_id))
 				if (promises.length === CONCURRENT_PRELOADS) {
 					await Promise.all(promises)
 					promises.length = 0
@@ -340,75 +225,7 @@ export const usePreloadErrors = function ({ page }: { page: number }) {
 			const promises: Promise<void>[] = []
 			for (const _eg of errors?.error_groups_opensearch.error_groups ||
 				[]) {
-				const preloadPromise = (async (secureID: string) => {
-					if (
-						await IndexedDBLink.has('GetErrorGroup', {
-							secure_id: secureID,
-						})
-					) {
-						log(
-							'preload.ts',
-							`skipping loaded error group ${secureID}`,
-						)
-						return
-					}
-					const start = window.performance.now()
-					log('preload.ts', `preloading error group ${secureID}`)
-					try {
-						await client.query({
-							query: GetErrorGroupDocument,
-							variables: {
-								secure_id: secureID,
-							},
-						})
-						await client.query({
-							query: GetRecentErrorsDocument,
-							variables: {
-								secure_id: secureID,
-							},
-						})
-						await client.query({
-							query: GetErrorDistributionDocument,
-							variables: {
-								error_group_secure_id: secureID,
-								project_id,
-								property: 'os',
-							},
-						})
-						await client.query({
-							query: GetErrorDistributionDocument,
-							variables: {
-								error_group_secure_id: secureID,
-								project_id,
-								property: 'browser',
-							},
-						})
-						const preloadTime = window.performance.now() - start
-						log(
-							'preload.ts',
-							`preloaded error group ${secureID} in ${
-								preloadTime / 1000
-							} s.`,
-						)
-						H.metrics([
-							{
-								name: 'preload-error-ms',
-								value: preloadTime,
-								tags: [
-									{
-										name: 'SecureID',
-										value: secureID,
-									},
-								],
-							},
-						])
-					} catch (e: any) {
-						const msg = `failed to preload error group ${secureID}`
-						console.warn(msg)
-						H.consumeError(e, msg)
-					}
-				})(_eg.secure_id)
-				promises.push(preloadPromise)
+				promises.push(loadErrorGroup(project_id, _eg.secure_id))
 				if (promises.length === CONCURRENT_PRELOADS) {
 					await Promise.all(promises)
 					promises.length = 0
@@ -417,4 +234,225 @@ export const usePreloadErrors = function ({ page }: { page: number }) {
 			await Promise.all(promises)
 		})()
 	}, [project_id, pageToLoad, query])
+}
+
+const loadSession = async function (secureID: string) {
+	if (
+		await IndexedDBLink.has('GetSession', {
+			secure_id: secureID,
+		})
+	) {
+		log('preload.ts', `skipping loaded session ${secureID}`)
+		return
+	}
+	const start = window.performance.now()
+	log('preload.ts', `preloading session ${secureID}`)
+	try {
+		const session = await client.query({
+			query: GetSessionDocument,
+			variables: {
+				secure_id: secureID,
+			},
+		})
+		const sess = session?.data?.session
+		if (!sess) return
+		if (sess.resources_url) {
+			worker.postMessage({
+				type: 'fetch',
+				url: sess.resources_url,
+			})
+		}
+		if (sess.messages_url) {
+			worker.postMessage({
+				type: 'fetch',
+				url: sess.messages_url,
+			})
+		}
+		if (sess.direct_download_url) {
+			worker.postMessage({
+				type: 'fetch',
+				url: sess.direct_download_url,
+			})
+		}
+		await client.query({
+			query: GetSessionIntervalsDocument,
+			variables: {
+				session_secure_id: secureID,
+			},
+		})
+		await client.query({
+			query: GetTimelineIndicatorEventsDocument,
+			variables: {
+				session_secure_id: secureID,
+			},
+		})
+		await client.query({
+			query: GetEventChunksDocument,
+			variables: {
+				secure_id: secureID,
+			},
+		})
+		await client.query({
+			query: GetSessionCommentsDocument,
+			variables: {
+				session_secure_id: secureID,
+			},
+		})
+		await client.query({
+			query: GetSessionPayloadDocument,
+			variables: {
+				session_secure_id: secureID,
+				skip_events: true,
+			},
+		})
+		await client.query({
+			query: GetEnhancedUserDetailsDocument,
+			variables: {
+				session_secure_id: secureID,
+			},
+		})
+		await client.query({
+			query: GetWebVitalsDocument,
+			variables: {
+				session_secure_id: secureID,
+			},
+		})
+		const response = await client.query({
+			query: GetEventChunkUrlDocument,
+			variables: {
+				secure_id: secureID,
+				index: 0,
+			},
+		})
+		worker.postMessage({
+			type: 'fetch',
+			url: response.data.event_chunk_url,
+		})
+		const preloadTime = window.performance.now() - start
+		log(
+			'preload.ts',
+			`preloaded session ${secureID} in ${preloadTime / 1000} s.`,
+		)
+		H.metrics([
+			{
+				name: 'preload-session-ms',
+				value: preloadTime,
+				tags: [
+					{
+						name: 'SecureID',
+						value: secureID,
+					},
+				],
+			},
+		])
+	} catch (e: any) {
+		const msg = `failed to preload session ${secureID}`
+		console.warn(msg)
+		H.consumeError(e, msg)
+	}
+}
+
+const loadErrorGroup = async function (projectID: string, secureID: string) {
+	if (
+		await IndexedDBLink.has('GetErrorGroup', {
+			secure_id: secureID,
+		})
+	) {
+		log('preload.ts', `skipping loaded error group ${secureID}`)
+		return
+	}
+	const start = window.performance.now()
+	log('preload.ts', `preloading error group ${secureID}`)
+	try {
+		await client.query({
+			query: GetErrorGroupDocument,
+			variables: {
+				secure_id: secureID,
+			},
+		})
+		// run this query with the `error_object_id` variable set to 0 as well, as the ui uses both
+		await client.query({
+			query: GetErrorInstanceDocument,
+			variables: {
+				error_group_secure_id: secureID,
+				error_object_id: '0',
+			},
+		})
+		let errorObjectID = '0'
+		for (let i = 0; i < PREVIOUS_ERROR_OBJECTS_TO_FETCH; i++) {
+			const errorInstance = (
+				await client.query({
+					query: GetErrorInstanceDocument,
+					variables:
+						errorObjectID === '0'
+							? { error_group_secure_id: secureID }
+							: {
+									error_group_secure_id: secureID,
+									error_object_id: errorObjectID,
+							  },
+				})
+			)?.data?.error_instance as ErrorInstance
+			const sessionSecureID =
+				errorInstance.error_object.session?.secure_id
+			if (sessionSecureID) {
+				log('preload.ts', 'loading session from error object', {
+					errorGroupSecureID: secureID,
+					errorInstance,
+					sessionSecureID,
+				})
+				await loadSession(sessionSecureID)
+			}
+			if (
+				errorInstance?.previous_id?.length &&
+				errorInstance.previous_id !== '0'
+			) {
+				errorObjectID = errorInstance?.previous_id
+			} else {
+				break
+			}
+		}
+		await client.query({
+			query: GetRecentErrorsDocument,
+			variables: {
+				secure_id: secureID,
+			},
+		})
+		await client.query({
+			query: GetErrorDistributionDocument,
+			variables: {
+				error_group_secure_id: secureID,
+				project_id: projectID,
+				property: 'os',
+			},
+		})
+		await client.query({
+			query: GetErrorDistributionDocument,
+			variables: {
+				error_group_secure_id: secureID,
+				project_id: projectID,
+				property: 'browser',
+			},
+		})
+		const preloadTime = window.performance.now() - start
+		log(
+			'preload.ts',
+			`preloaded error group ${secureID} in ${preloadTime / 1000} s.`,
+		)
+		H.metrics([
+			{
+				name: 'preload-error-ms',
+				value: preloadTime,
+				tags: [
+					{
+						name: 'SecureID',
+						value: secureID,
+					},
+				],
+			},
+		])
+	} catch (e: any) {
+		const msg = `failed to preload error group ${secureID}`
+		console.warn(msg)
+		H.consumeError(e, msg)
+	}
 }


### PR DESCRIPTION
## Summary

Ensures that `preload.ts` will fetch error instances (and the previous one before the top error instance).
Preloading error groups will also load the session that the top error instances are associated with.

## How did you test this change?

Local deploy.
https://www.loom.com/share/a93c1ce853a74c3b9074458a56d26839

## Are there any deployment considerations?

No.
