### PR TITLE
fix(HIG-3356): loading state

### DIFF
--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -42,7 +42,7 @@ const SearchPanel = () => {
 		totalCount: 0,
 	})
 
-	useGetErrorGroupsOpenSearchQuery({
+	const { loading } = useGetErrorGroupsOpenSearchQuery({
 		variables: {
 			query: backendSearchQuery?.searchQuery || '',
 			count: PAGE_SIZE,
@@ -65,10 +65,8 @@ const SearchPanel = () => {
 	})
 
 	useEffect(() => {
-		if (!!backendSearchQuery) {
-			setSearchResultsLoading(true)
-		}
-	}, [backendSearchQuery, setSearchResultsLoading])
+		setSearchResultsLoading(loading)
+	}, [loading, setSearchResultsLoading])
 
 	const showHistogram = searchResultsLoading || searchResultsCount > 0
 


### PR DESCRIPTION
## Summary

This PR syncs `searchResultsLoading` with the `loading` state from the `useGetErrorGroupsOpenSearchQuery` hook, to avoid relying on the logic based on whether backendSearchQuery is not trivial. Also fixes the issue when going to a new page in error search did not trigger a loading state. 

## How did you test this change?

[preview](https://frontend-pr-3372.onrender.com/)

## Are there any deployment considerations?

no
