### PR TITLE
HIG-3358 Fix categorical bar chart ticks

### DIFF
--- a/frontend/src/components/CategoricalBarChart/CategoricalBarChar.tsx
+++ b/frontend/src/components/CategoricalBarChart/CategoricalBarChar.tsx
@@ -61,7 +61,7 @@ const CategoricalBarChart = ({
 	for (const x of data) {
 		dateGroups[x.date] = { ...dateGroups[x.date], ...x }
 	}
-	let groupedData: any[] = Object.values(dateGroups)
+	const groupedData: any[] = Object.values(dateGroups)
 	const allYAxisKeys =
 		data.length > 0
 			? Object.keys(groupedData[0]).filter(
@@ -71,15 +71,6 @@ const CategoricalBarChart = ({
 			  )
 			: []
 	const yAxisKeys = allYAxisKeys.slice(0, MAX_LEGEND_ITEMS)
-	groupedData = groupedData.map((x) => {
-		const o: { [k: string]: any } = {}
-		for (const [k, v] of Object.entries(x)) {
-			if (yAxisKeys.indexOf(k) !== -1) {
-				o[k] = v
-			}
-		}
-		return o
-	})
 	const gridColor = 'none'
 	const labelColor = 'var(--color-gray-500)'
 


### PR DESCRIPTION
## Summary
After massaging the data, we were losing the x-axis data point in the grouped data. As a result, the categorical bar charts were being rendered without a date.

## How did you test this change?
1) Load the dashboard =
- [ ] Confirm the categorical bar charts have dates rendered on the x-axis
- [ ] able to drag the chart to update the times

<img width="697" alt="Screen Shot 2022-12-01 at 3 18 26 PM" src="https://user-images.githubusercontent.com/17744174/205151316-07b7800f-36f0-4215-8cb4-bbaae3bb7753.png">

## Are there any deployment considerations?
None
