### PR TITLE
fix(HIG-3363): show single events in a nested menu

### DIFF
--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelinePopover/TimelinePopover.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelinePopover/TimelinePopover.tsx
@@ -150,10 +150,6 @@ const TimelinePopover = ({ bucket }: Props) => {
 						const count = bucket.identifier[eventType].length
 						const name = getTimelineEventDisplayName(eventType)
 						const color = `var(${getAnnotationColor(eventType)})`
-						const first = bucket.identifier[eventType][0]
-						const firstHMS = formatTimeAsHMS(
-							bucket.timestamp[first],
-						)
 						return (
 							<div
 								className={style.eventTypeRow}
@@ -162,11 +158,7 @@ const TimelinePopover = ({ bucket }: Props) => {
 								onClick={(ev) => {
 									ev.preventDefault()
 									ev.stopPropagation()
-									if (count === 1) {
-										onEventInstanceClick(eventType, first)
-									} else {
-										setSelectedType(eventType)
-									}
+									setSelectedType(eventType)
 								}}
 							>
 								<button className={style.actionButton}>
@@ -180,32 +172,16 @@ const TimelinePopover = ({ bucket }: Props) => {
 											style.eventIdentifier,
 										)}
 									>
-										{count > 1
-											? name
-											: bucket.details[first]}
+										{name}
 									</span>
 									<div className={style.rightCounter}>
-										{count > 1 ? (
-											<>
-												<span>{count}</span>
-												<ChevronRightIcon
-													className={classNames(
-														style.transitionIcon,
-														style.rightActionIcon,
-													)}
-												/>
-											</>
-										) : (
-											<>
-												<span>{firstHMS}</span>
-												<CircleRightArrow
-													className={classNames(
-														style.transitionIcon,
-														style.rightActionIcon,
-													)}
-												/>
-											</>
-										)}
+										<span>{count}</span>
+										<ChevronRightIcon
+											className={classNames(
+												style.transitionIcon,
+												style.rightActionIcon,
+											)}
+										/>
 									</div>
 								</button>
 							</div>


### PR DESCRIPTION
## Summary

Removes the logic that showed single events without nesting in the timeline.
Before:
<img width="261" alt="Screenshot 2022-12-02 at 9 05 34 AM" src="https://user-images.githubusercontent.com/17913919/205346386-484f8d65-249a-415b-8ad5-8969f506131a.png">

After:
<img width="253" alt="Screenshot 2022-12-02 at 9 03 45 AM" src="https://user-images.githubusercontent.com/17913919/205346044-68f5defc-927f-4212-840c-8be0f5655a29.png">


## How did you test this change?

[preview](https://frontend-pr-3379.onrender.com/)

## Are there any deployment considerations?

no
