### PR TITLE
[WIP] Spec out how multiple environments would look on error monitoring

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorDistribution/ErrorDistribution.module.scss
+++ b/frontend/src/pages/ErrorsV2/ErrorDistribution/ErrorDistribution.module.scss
@@ -1,0 +1,25 @@
+@import 'src/static/shared.scss';
+
+.label {
+	margin-top: var(--size-medium);
+	padding-bottom: var(--size-small);
+}
+
+.distributionContainer {
+	border-radius: 5px;
+	display: flex;
+	height: 8px;
+	width: 100%;
+}
+
+.percentageBar {
+	&:first-of-type {
+		border-top-left-radius: 5px;
+		border-bottom-left-radius: 5px;
+	}
+
+	&:last-of-type {
+		border-top-right-radius: 5px;
+		border-bottom-right-radius: 5px;
+	}
+}

--- a/frontend/src/pages/ErrorsV2/ErrorDistribution/ErrorDistribution.module.scss.d.ts
+++ b/frontend/src/pages/ErrorsV2/ErrorDistribution/ErrorDistribution.module.scss.d.ts
@@ -1,0 +1,3 @@
+export const distributionContainer: string
+export const label: string
+export const percentageBar: string

--- a/frontend/src/pages/ErrorsV2/ErrorDistribution/ErrorDistribution.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorDistribution/ErrorDistribution.tsx
@@ -1,0 +1,56 @@
+import { Text } from '@highlight-run/ui'
+import React from 'react'
+
+import styles from './ErrorDistribution.module.scss'
+
+type Props = {
+	totalCount: number
+	// TODO(spenny): add types
+	errorCategoryCounts: any
+	errorColors: any
+}
+
+const ErrorDistribution: React.FC<Props> = ({
+	totalCount,
+	errorCategoryCounts,
+	errorColors,
+}) => {
+	if (!totalCount || !Object.keys(errorCategoryCounts).length) {
+		return null
+	}
+
+	// TODO(spenny): use for tooltip
+	// const categoryBars = Object.keys(errorCategoryCounts).map((category) => ({
+	// 	label: category,
+	// 	percentage: Math.round(errorCategoryCounts[category] / totalCount),
+	// 	color: errorColors[category],
+	// }))
+
+	return (
+		<>
+			<Text weight="bold" cssClass={styles.label}>
+				Distribution
+			</Text>
+			<div className={styles.distributionContainer}>
+				{Object.keys(errorCategoryCounts).map((category) => {
+					const percentage = Math.round(
+						(errorCategoryCounts[category] * 100) / totalCount,
+					)
+					return (
+						<div
+							key={category}
+							className={styles.percentageBar}
+							style={{
+								backgroundColor: errorColors[category],
+								width: `${percentage}%`,
+								height: '100%',
+							}}
+						/>
+					)
+				})}
+			</div>
+		</>
+	)
+}
+
+export default ErrorDistribution

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorMetrics.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorMetrics.tsx
@@ -17,7 +17,7 @@ import moment from 'moment'
 import React, { useEffect, useState } from 'react'
 
 import styles from './ErrorMetrics.module.scss'
-import { testData } from './multiple_environment_test_data'
+import { TEST_DATA } from './multiple_environment_test_data'
 
 type Props = {
 	errorGroup: GetErrorGroupQuery['error_group']
@@ -81,7 +81,7 @@ const ErrorMetrics: React.FC<Props> = ({ errorGroup }) => {
 	}>({ start: '', end: '' })
 
 	// TODO(spenny): remove test data once graphql queries is updated
-	const { data: testFrequencies } = testData
+	const { data: testFrequencies } = TEST_DATA
 	const { data: frequencies } = useGetErrorGroupFrequenciesQuery({
 		variables: {
 			project_id: `${errorGroup?.project_id}`,

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorMetrics.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorMetrics.tsx
@@ -13,6 +13,7 @@ import {
 } from '@highlight-run/ui'
 import { vars } from '@highlight-run/ui/src/css/vars'
 import useDataTimeRange from '@hooks/useDataTimeRange'
+import ErrorDistribution from '@pages/ErrorsV2/ErrorDistribution/ErrorDistribution'
 import moment from 'moment'
 import React, { useEffect, useState } from 'react'
 
@@ -243,6 +244,12 @@ const ErrorMetrics: React.FC<Props> = ({ errorGroup }) => {
 							<Text>{errorCategoryTotals[label]}</Text>
 						</Box>
 					))}
+
+					<ErrorDistribution
+						totalCount={errorFrequencyTotal}
+						errorCategoryCounts={errorCategoryTotals}
+						errorColors={errorColors}
+					/>
 
 					<div className={styles.calloutContainer}>
 						<Callout

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/multiple_environment_test_data.ts
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/multiple_environment_test_data.ts
@@ -496,6 +496,254 @@ export const TEST_DATA = {
 				"label": "staging",
 				"value": 2,
 				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T17:36:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 13,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T18:24:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T19:12:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 7,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T20:00:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 12,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T20:48:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 4,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T21:36:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 8,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T22:24:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T23:12:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T00:00:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T00:48:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 2,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T01:36:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 1,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T02:24:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T03:12:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 1,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T04:00:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 2,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T04:48:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T05:36:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 1,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T06:24:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T07:12:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 3,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T08:00:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T08:48:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T09:36:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 1,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T10:24:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T11:12:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T12:00:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T12:48:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T13:36:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 12,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T14:24:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 1,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T15:12:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T16:00:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T16:48:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 1,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T17:24:00Z",
+				"name": "environmentCount",
+				"label": "demo",
+				"value": 1,
+				"__typename": "ErrorDistributionItem"
 			}
 		]
 	}

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/multiple_environment_test_data.ts
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/multiple_environment_test_data.ts
@@ -70,7 +70,7 @@ export const TEST_DATA = {
 				"date": "2022-12-02T00:00:00Z",
 				"name": "environmentCount",
 				"label": "production",
-				"value": 0,
+				"value": 7,
 				"__typename": "ErrorDistributionItem"
 			},
 			{
@@ -94,7 +94,7 @@ export const TEST_DATA = {
 				"date": "2022-12-02T02:24:00Z",
 				"name": "environmentCount",
 				"label": "production",
-				"value": 0,
+				"value": 24,
 				"__typename": "ErrorDistributionItem"
 			},
 			{
@@ -102,7 +102,7 @@ export const TEST_DATA = {
 				"date": "2022-12-02T03:12:00Z",
 				"name": "environmentCount",
 				"label": "production",
-				"value": 0,
+				"value": 9,
 				"__typename": "ErrorDistributionItem"
 			},
 			{

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/multiple_environment_test_data.ts
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/multiple_environment_test_data.ts
@@ -1,0 +1,502 @@
+export const testData = {
+	"data": {
+		"errorGroupFrequencies": [
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T17:36:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T18:24:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 28,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T19:12:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 6,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T20:00:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T20:48:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 10,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T21:36:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 14,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T22:24:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 8,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T23:12:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T00:00:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T00:48:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T01:36:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T02:24:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T03:12:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T04:00:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T04:48:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T05:36:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T06:24:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T07:12:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T08:00:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T08:48:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T09:36:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T10:24:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T11:12:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T12:00:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T12:48:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 8,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T13:36:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 22,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T14:24:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 8,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T15:12:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T16:00:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T16:48:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T17:24:00Z",
+				"name": "environmentCount",
+				"label": "production",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T17:36:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 3,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T18:24:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 2,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T19:12:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T20:00:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T20:48:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T21:36:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 4,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T22:24:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 8,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-01T23:12:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T00:00:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T00:48:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T01:36:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T02:24:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 44,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T03:12:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T04:00:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 12,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T04:48:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T05:36:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T06:24:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T07:12:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T08:00:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T08:48:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T09:36:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 1,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T10:24:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T11:12:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T12:00:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T12:48:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 5,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T13:36:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 2,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T14:24:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 8,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T15:12:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T16:00:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 0,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T16:48:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 1,
+				"__typename": "ErrorDistributionItem"
+			},
+			{
+				"error_group_id": "37",
+				"date": "2022-12-02T17:24:00Z",
+				"name": "environmentCount",
+				"label": "staging",
+				"value": 2,
+				"__typename": "ErrorDistributionItem"
+			}
+		]
+	}
+}

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/multiple_environment_test_data.ts
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/multiple_environment_test_data.ts
@@ -1,4 +1,4 @@
-export const testData = {
+export const TEST_DATA = {
 	"data": {
 		"errorGroupFrequencies": [
 			{


### PR DESCRIPTION
# Not to be merged
Spike of how the frontend would look when we want to support multiple environments. Assuming each data point is coming in something like:
```
{
    "error_group_id": "37",
    "date": "2022-12-02T01:36:00Z",
    "name": "environmentCount",
    "label": "staging",
    "value": 12,
    "__typename": "ErrorDistributionItem"
},
```

## Summary
We want to update the error monitor page to support multiple environments 

## How did you test this change?
Click test:
1) Load the error monitor page (`/1/errors/[:secure_id]`)
2) Click on the metrics tab
- [ ] Confirm the test data is displayed correctly
3) Edit the test data in `frontend/src/pages/ErrorsV2/ErrorMetrics/multiple_environment_test_data.ts`

<img width="1043" alt="Screen Shot 2022-12-02 at 4 37 13 PM" src="https://user-images.githubusercontent.com/17744174/205393852-6c371836-4e4c-4c2e-90ec-6be569cd4f4e.png">

## Are there any deployment considerations?
Do not merge - using fixed test data
