### PR TITLE
[HIG-3329] fix selected page highlight

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -66,7 +66,11 @@ export const Header = () => {
 	const { isLoggedIn } = useAuthContext()
 	const { currentWorkspace } = useApplicationContext()
 	const workspaceId = currentWorkspace?.id
-	const currentPage = location.pathname.split('/').pop()
+
+	const { pathname } = useLocation()
+	const parts = pathname.split('/')
+	const currentPage = parts.length >= 3 ? parts[2] : undefined
+
 	const { toggleShowKeyboardShortcutsGuide } = useGlobalContext()
 	const { admin } = useAuthContext()
 


### PR DESCRIPTION
## Summary
- highlighting the current selected page in the header was not working after clicking into a session/error
- fixes this by always grabbing element index `[2]` from the path instead of the last element
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click test locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- nope
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
