### PR TITLE
fix turbo build

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"patch-package": "^6.4.7",
 		"prettier": "^2.7.1",
 		"pretty-quick": "^3.1.3",
-		"turbo": "^1.5.4"
+		"turbo": "^1.6.3"
 	},
 	"packageManager": "yarn@3.2.3",
 	"resolutions": {

--- a/turbo.json
+++ b/turbo.json
@@ -61,5 +61,6 @@
 			"env": ["HIGHLIGHT_API_KEY"]
 		}
 	},
-	"globalEnv": ["DOPPLER_TOKEN"]
+	"globalEnv": ["DOPPLER_TOKEN"],
+	"globalDependencies": ["package.json", "yarn.lock"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25102,7 +25102,7 @@ __metadata:
     patch-package: ^6.4.7
     prettier: ^2.7.1
     pretty-quick: ^3.1.3
-    turbo: ^1.5.4
+    turbo: ^1.6.3
   languageName: unknown
   linkType: soft
 
@@ -41140,58 +41140,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"turbo-darwin-64@npm:1.5.4":
-  version: 1.5.4
-  resolution: "turbo-darwin-64@npm:1.5.4"
+"turbo-darwin-64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-darwin-64@npm:1.6.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-darwin-arm64@npm:1.5.4":
-  version: 1.5.4
-  resolution: "turbo-darwin-arm64@npm:1.5.4"
+"turbo-darwin-arm64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-darwin-arm64@npm:1.6.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo-linux-64@npm:1.5.4":
-  version: 1.5.4
-  resolution: "turbo-linux-64@npm:1.5.4"
+"turbo-linux-64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-linux-64@npm:1.6.3"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-linux-arm64@npm:1.5.4":
-  version: 1.5.4
-  resolution: "turbo-linux-arm64@npm:1.5.4"
+"turbo-linux-arm64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-linux-arm64@npm:1.6.3"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo-windows-64@npm:1.5.4":
-  version: 1.5.4
-  resolution: "turbo-windows-64@npm:1.5.4"
+"turbo-windows-64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-windows-64@npm:1.6.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"turbo-windows-arm64@npm:1.5.4":
-  version: 1.5.4
-  resolution: "turbo-windows-arm64@npm:1.5.4"
+"turbo-windows-arm64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-windows-arm64@npm:1.6.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"turbo@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "turbo@npm:1.5.4"
+"turbo@npm:^1.6.3":
+  version: 1.6.3
+  resolution: "turbo@npm:1.6.3"
   dependencies:
-    turbo-darwin-64: 1.5.4
-    turbo-darwin-arm64: 1.5.4
-    turbo-linux-64: 1.5.4
-    turbo-linux-arm64: 1.5.4
-    turbo-windows-64: 1.5.4
-    turbo-windows-arm64: 1.5.4
+    turbo-darwin-64: 1.6.3
+    turbo-darwin-arm64: 1.6.3
+    turbo-linux-64: 1.6.3
+    turbo-linux-arm64: 1.6.3
+    turbo-windows-64: 1.6.3
+    turbo-windows-arm64: 1.6.3
   dependenciesMeta:
     turbo-darwin-64:
       optional: true
@@ -41207,7 +41207,7 @@ __metadata:
       optional: true
   bin:
     turbo: bin/turbo
-  checksum: 37f16e8a3e30c032d3fe250fff4a3c781702b3cd9e634855196a97aca2b4c7d3efeffbbd305affc0a4f677e1dfe3007a7d1953781f31f767f1a2a3ff71cf134d
+  checksum: 35195f4b7623014c25ba152c11a8cb23e51cbd75dc9266d0656692665f85b28faf3496dea8cecacf52795a917410668124186ffbdcf276325ccc3e11df9e9623
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

[Master build was failing](https://github.com/highlight-run/highlight/actions/runs/3623138155/jobs/6108661540) because frontend typechecking would happen before firstload+client were built. #3377 added type checking to frontend that introduced this failure (when a subsequent firstload/client change was made in #3381)

## How did you test this change?

`yarn test:all`

## Are there any deployment considerations?

No
