### PR TITLE
fix inconsistent error frequencies due to differing queries

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -587,7 +587,7 @@ type ComplexityRoot struct {
 		ErrorFieldsOpensearch        func(childComplexity int, projectID int, count int, fieldType string, fieldName string, query string) int
 		ErrorGroup                   func(childComplexity int, secureID string) int
 		ErrorGroupFrequencies        func(childComplexity int, projectID int, errorGroupSecureIds []string, params model.ErrorGroupFrequenciesParamsInput, metric *string) int
-		ErrorGroupsOpensearch        func(childComplexity int, projectID int, count int, query string, page *int, influx bool) int
+		ErrorGroupsOpensearch        func(childComplexity int, projectID int, count int, query string, page *int) int
 		ErrorInstance                func(childComplexity int, errorGroupSecureID string, errorObjectID *int) int
 		ErrorObject                  func(childComplexity int, id int) int
 		ErrorSegments                func(childComplexity int, projectID int) int
@@ -1093,7 +1093,7 @@ type QueryResolver interface {
 	TimelineIndicatorEvents(ctx context.Context, sessionSecureID string) ([]*model1.TimelineIndicatorEvent, error)
 	RageClicks(ctx context.Context, sessionSecureID string) ([]*model1.RageClickEvent, error)
 	RageClicksForProject(ctx context.Context, projectID int, lookBackPeriod int) ([]*model.RageClickEventForProject, error)
-	ErrorGroupsOpensearch(ctx context.Context, projectID int, count int, query string, page *int, influx bool) (*model1.ErrorResults, error)
+	ErrorGroupsOpensearch(ctx context.Context, projectID int, count int, query string, page *int) (*model1.ErrorResults, error)
 	ErrorsHistogram(ctx context.Context, projectID int, query string, histogramOptions model.DateHistogramOptions) (*model1.ErrorsHistogram, error)
 	ErrorGroup(ctx context.Context, secureID string) (*model1.ErrorGroup, error)
 	ErrorObject(ctx context.Context, id int) (*model1.ErrorObject, error)
@@ -4339,7 +4339,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ErrorGroupsOpensearch(childComplexity, args["project_id"].(int), args["count"].(int), args["query"].(string), args["page"].(*int), args["influx"].(bool)), true
+		return e.complexity.Query.ErrorGroupsOpensearch(childComplexity, args["project_id"].(int), args["count"].(int), args["query"].(string), args["page"].(*int)), true
 
 	case "Query.error_instance":
 		if e.complexity.Query.ErrorInstance == nil {
@@ -7891,7 +7891,6 @@ type Query {
 		count: Int!
 		query: String!
 		page: Int
-		influx: Boolean!
 	): ErrorResults!
 	errors_histogram(
 		project_id: ID!
@@ -11421,15 +11420,6 @@ func (ec *executionContext) field_Query_error_groups_opensearch_args(ctx context
 		}
 	}
 	args["page"] = arg3
-	var arg4 bool
-	if tmp, ok := rawArgs["influx"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("influx"))
-		arg4, err = ec.unmarshalNBoolean2bool(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["influx"] = arg4
 	return args, nil
 }
 
@@ -30701,7 +30691,7 @@ func (ec *executionContext) _Query_error_groups_opensearch(ctx context.Context, 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().ErrorGroupsOpensearch(rctx, fc.Args["project_id"].(int), fc.Args["count"].(int), fc.Args["query"].(string), fc.Args["page"].(*int), fc.Args["influx"].(bool))
+		return ec.resolvers.Query().ErrorGroupsOpensearch(rctx, fc.Args["project_id"].(int), fc.Args["count"].(int), fc.Args["query"].(string), fc.Args["page"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1079,7 +1079,6 @@ type Query {
 		count: Int!
 		query: String!
 		page: Int
-		influx: Boolean!
 	): ErrorResults!
 	errors_histogram(
 		project_id: ID!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3314,7 +3314,7 @@ func (r *queryResolver) RageClicksForProject(ctx context.Context, projectID int,
 }
 
 // ErrorGroupsOpensearch is the resolver for the error_groups_opensearch field.
-func (r *queryResolver) ErrorGroupsOpensearch(ctx context.Context, projectID int, count int, query string, page *int, influx bool) (*model.ErrorResults, error) {
+func (r *queryResolver) ErrorGroupsOpensearch(ctx context.Context, projectID int, count int, query string, page *int) (*model.ErrorResults, error) {
 	_, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
 		return nil, nil
@@ -3346,19 +3346,11 @@ func (r *queryResolver) ErrorGroupsOpensearch(ctx context.Context, projectID int
 		asErrorGroups = append(asErrorGroups, result.ToErrorGroup())
 	}
 
-	if influx {
-		errorFrequencyInfluxSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal",
-			tracer.ResourceName("resolver.errorFrequencyInflux"), tracer.Tag("project_id", projectID))
+	errorFrequencyInfluxSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal",
+		tracer.ResourceName("resolver.errorFrequencyInflux"), tracer.Tag("project_id", projectID))
 
-		err = r.SetErrorFrequenciesInflux(ctx, projectID, asErrorGroups, ErrorGroupLookbackDays)
-		errorFrequencyInfluxSpan.Finish()
-	} else {
-		errorFrequencyOpensearchSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal",
-			tracer.ResourceName("resolver.errorFrequencyOpensearch"), tracer.Tag("project_id", projectID))
-
-		err = r.SetErrorFrequencies(asErrorGroups, ErrorGroupLookbackDays)
-		errorFrequencyOpensearchSpan.Finish()
-	}
+	err = r.SetErrorFrequenciesInflux(ctx, projectID, asErrorGroups, ErrorGroupLookbackDays)
+	errorFrequencyInfluxSpan.Finish()
 
 	if err != nil {
 		return nil, err
@@ -3404,10 +3396,6 @@ func (r *queryResolver) ErrorsHistogram(ctx context.Context, projectID int, quer
 func (r *queryResolver) ErrorGroup(ctx context.Context, secureID string) (*model.ErrorGroup, error) {
 	eg, err := r.canAdminViewErrorGroup(ctx, secureID, true)
 	if err != nil {
-		return nil, err
-	}
-	eg.FirstOccurrence, eg.LastOccurrence, err = r.GetErrorGroupOccurrences(ctx, eg.ProjectID, eg.ID)
-	if err := r.SetErrorFrequenciesInflux(ctx, eg.ProjectID, []*model.ErrorGroup{eg}, ErrorGroupLookbackDays); err != nil {
 		return nil, err
 	}
 	return eg, err

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -5850,14 +5850,12 @@ export const GetErrorGroupsOpenSearchDocument = gql`
 		$count: Int!
 		$query: String!
 		$page: Int
-		$influx: Boolean!
 	) {
 		error_groups_opensearch(
 			project_id: $project_id
 			count: $count
 			query: $query
 			page: $page
-			influx: $influx
 		) {
 			error_groups {
 				created_at
@@ -5907,7 +5905,6 @@ export const GetErrorGroupsOpenSearchDocument = gql`
  *      count: // value for 'count'
  *      query: // value for 'query'
  *      page: // value for 'page'
- *      influx: // value for 'influx'
  *   },
  * });
  */

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2024,7 +2024,6 @@ export type GetErrorGroupsOpenSearchQueryVariables = Types.Exact<{
 	count: Types.Scalars['Int']
 	query: Types.Scalars['String']
 	page?: Types.Maybe<Types.Scalars['Int']>
-	influx: Types.Scalars['Boolean']
 }>
 
 export type GetErrorGroupsOpenSearchQuery = { __typename?: 'Query' } & {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1407,7 +1407,6 @@ export type QueryError_GroupArgs = {
 
 export type QueryError_Groups_OpensearchArgs = {
 	count: Scalars['Int']
-	influx: Scalars['Boolean']
 	page?: InputMaybe<Scalars['Int']>
 	project_id: Scalars['ID']
 	query: Scalars['String']

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -666,14 +666,12 @@ query GetErrorGroupsOpenSearch(
 	$count: Int!
 	$query: String!
 	$page: Int
-	$influx: Boolean!
 ) {
 	error_groups_opensearch(
 		project_id: $project_id
 		count: $count
 		query: $query
 		page: $page
-		influx: $influx
 	) {
 		error_groups {
 			created_at

--- a/frontend/src/pages/Errors/ErrorFeedV2/ErrorFeedV2.tsx
+++ b/frontend/src/pages/Errors/ErrorFeedV2/ErrorFeedV2.tsx
@@ -150,7 +150,6 @@ export const ErrorFeedV2 = () => {
 
 	const { loading } = useGetErrorGroupsOpenSearchQuery({
 		variables: {
-			influx: false,
 			query: backendSearchQuery?.searchQuery || '',
 			count: PAGE_SIZE,
 			page: page && page > 0 ? page : 1,

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -51,7 +51,6 @@ const SearchPanel = () => {
 			count: PAGE_SIZE,
 			page: page && page > 0 ? page : 1,
 			project_id: projectId,
-			influx: true,
 		},
 		onError: () => {
 			setSearchResultsLoading(false)

--- a/frontend/src/util/preload.ts
+++ b/frontend/src/util/preload.ts
@@ -182,7 +182,6 @@ export const usePreloadErrors = function ({ page }: { page: number }) {
 					query,
 					count: DEFAULT_PAGE_SIZE,
 					page: pageToLoad,
-					influx: false,
 					project_id,
 				},
 			})
@@ -191,16 +190,6 @@ export const usePreloadErrors = function ({ page }: { page: number }) {
 				return false
 			preloadedPages.current.add(pageToLoad)
 
-			client.query({
-				query: GetErrorGroupsOpenSearchDocument,
-				variables: {
-					query,
-					count: DEFAULT_PAGE_SIZE,
-					page: pageToLoad,
-					influx: true,
-					project_id,
-				},
-			})
 			client.query({
 				query: GetErrorsHistogramDocument,
 				variables: {


### PR DESCRIPTION
## Summary

Because we had `ErrorGroup` objects returned with a mix of influx and opensearch frequency data, the `error_frequency` field's data was inconsistent. The new error page would call `GetErrorGroupsOpenSearch` which returned `ErrorGroup` objects populated with the `error_frequency` array from influxdb, but the `GetErrorGroup` query would return the same `ErrorGroup` with `error_frequency` populated from opensearch.

This PR removes the `influxdb` setting since data is now populated in influx. This ensures that the results are consistent.

## How did you test this change?

Local deploy with the new error page off and on shows no changes to the error frequency charts.

## Are there any deployment considerations?

No.