### PR TITLE
fix(HIG-3353): persist query and segment in error page url

### DIFF
--- a/frontend/src/context/BaseSearchContext.tsx
+++ b/frontend/src/context/BaseSearchContext.tsx
@@ -20,6 +20,16 @@ export type BaseSearchContext<T> = {
 	setExistingParams: React.Dispatch<React.SetStateAction<T>>
 	segmentName: string | null
 	setSegmentName: React.Dispatch<React.SetStateAction<string | null>>
+	selectedSegment: { value: string; id: string } | undefined
+	setSelectedSegment: (
+		newValue:
+			| {
+					value: string
+					id: string
+			  }
+			| undefined,
+	) => void
+	removeSelectedSegment: () => void
 	/** The query sent to the backend */
 	backendSearchQuery: BackendSearchQuery
 	setBackendSearchQuery: React.Dispatch<

--- a/frontend/src/pages/Error/components/SegmentPickerForErrors/SegmentPickerForErrors.tsx
+++ b/frontend/src/pages/Error/components/SegmentPickerForErrors/SegmentPickerForErrors.tsx
@@ -1,6 +1,5 @@
 import { namedOperations } from '@graph/operations'
 import SvgXIcon from '@icons/XIcon'
-import useLocalStorage from '@rehooks/local-storage'
 import { message, Select as AntDesignSelect } from 'antd'
 import classNames from 'classnames'
 const { Option } = AntDesignSelect
@@ -37,16 +36,12 @@ const SegmentPickerForErrors = () => {
 		segmentName,
 		searchParams,
 		existingParams,
+		selectedSegment,
+		setSelectedSegment,
 	} = useErrorSearchContext()
 	const { loading, data } = useGetErrorSegmentsQuery({
 		variables: { project_id },
 	})
-	const [selectedSegment, setSelectedSegment] = useLocalStorage<
-		{ value: string; id: string } | undefined
-	>(
-		`highlightSegmentPickerForErrorsSelectedSegmentId-${project_id}`,
-		undefined,
-	)
 	const [paramsIsDifferent, setParamsIsDifferent] = useState(false)
 	const [showCreateSegmentModal, setShowCreateSegmentModal] = useState(false)
 	const [segmentToDelete, setSegmentToDelete] = useState<{

--- a/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/components/QueryBuilder/QueryBuilder.tsx
@@ -58,7 +58,7 @@ import AsyncSelect from 'react-select/async'
 import Creatable from 'react-select/creatable'
 import { Styles } from 'react-select/src/styles'
 import { OptionTypeBase } from 'react-select/src/types'
-import { useLocalStorage, useToggle } from 'react-use'
+import { useToggle } from 'react-use'
 
 import * as newStyle from './QueryBuilder.css'
 import styles from './QueryBuilder.module.scss'
@@ -1312,6 +1312,9 @@ function QueryBuilder(props: QueryBuilderProps) {
 		segmentName,
 		setSegmentName,
 		searchResultsCount,
+		selectedSegment,
+		setSelectedSegment,
+		removeSelectedSegment,
 	} = searchContext
 
 	const { project_id: projectId } = useParams<{
@@ -1346,11 +1349,6 @@ function QueryBuilder(props: QueryBuilderProps) {
 		useGetErrorSegmentsQuery({
 			variables: { project_id: projectId },
 		})
-
-	const [selectedSegment, setSelectedSegment, removeSelectedSegment] =
-		useLocalStorage<{ value: string; id: string }>(
-			`highlightSegmentPickerForErrorsSelectedSegmentId-${projectId}`,
-		)
 
 	useEffect(() => {
 		setSegmentName(selectedSegment?.value || null)

--- a/frontend/src/pages/Sessions/SearchContext/SearchContext.tsx
+++ b/frontend/src/pages/Sessions/SearchContext/SearchContext.tsx
@@ -12,15 +12,6 @@ export type QueryBuilderInput =
 type SearchContext = BaseSearchContext<SearchParamsInput> & {
 	showStarredSessions: boolean
 	setShowStarredSessions: React.Dispatch<React.SetStateAction<boolean>>
-	selectedSegment: { value: string; id: string } | undefined
-	setSelectedSegment: (
-		newValue:
-			| {
-					value: string
-					id: string
-			  }
-			| undefined,
-	) => void
 	queryBuilderInput: QueryBuilderInput
 	setQueryBuilderInput: React.Dispatch<
 		React.SetStateAction<QueryBuilderInput>

--- a/packages/ui/src/components/Column/styles.css.ts
+++ b/packages/ui/src/components/Column/styles.css.ts
@@ -1,7 +1,7 @@
 import { style, styleVariants } from '@vanilla-extract/css'
 import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles'
 import { mediaQueries } from '../../css/breakpoints'
-import { Space, spaces } from '../../css/spaces'
+import { Space } from '../../css/spaces'
 
 export const columns = style({
 	display: 'flex',


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Adds persistence for dynamic queries (including date ranges) and segment choice for the error page.
## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

[preview](https://linear.app/highlight/issue/HIG-3353/persist-date-range-in-url)

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

no