### PR TITLE
Enable the new error page by default

### DIFF
--- a/frontend/src/routers/OrgRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/OrgRouter/ApplicationRouter.tsx
@@ -4,7 +4,6 @@ import DashboardsRouter from '@pages/Dashboards/DashboardsRouter'
 import ErrorsV2 from '@pages/ErrorsV2/ErrorsV2'
 import IntegrationsPage from '@pages/IntegrationsPage/IntegrationsPage'
 import SetupRouter from '@pages/Setup/SetupRouter/SetupRouter'
-import useLocalStorage from '@rehooks/local-storage'
 import { useParams } from '@util/react-router/useParams'
 import React, { Suspense } from 'react'
 import { Redirect, Route, Switch } from 'react-router-dom'
@@ -15,7 +14,6 @@ import { useErrorSearchContext } from '@pages/Errors/ErrorSearchContext/ErrorSea
 import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext'
 import { usePreloadErrors, usePreloadSessions } from '@util/preload'
 
-import ErrorPage from '../../pages/Error/ErrorPage'
 import PlayerPage from '../../pages/Player/PlayerPage'
 import ProjectSettings from '../../pages/ProjectSettings/ProjectSettings'
 
@@ -29,11 +27,7 @@ const ApplicationRouter = ({ integrated }: Props) => {
 	usePreloadSessions({ page: page || 1 })
 	usePreloadErrors({ page: errorPage || 1 })
 	const { project_id } = useParams<{ project_id: string }>()
-	const { isLoggedIn, isHighlightAdmin } = useAuthContext()
-	const [newErrorsPageEnabled] = useLocalStorage(
-		`highlight-new-errors-page-enabled`,
-		false,
-	)
+	const { isLoggedIn } = useAuthContext()
 
 	return (
 		<>
@@ -46,11 +40,7 @@ const ApplicationRouter = ({ integrated }: Props) => {
 					path="/:project_id/errors/:error_secure_id?/:error_tab_key?/:error_object_id?"
 					exact
 				>
-					{isHighlightAdmin && newErrorsPageEnabled ? (
-						<ErrorsV2 />
-					) : (
-						<ErrorPage integrated={integrated} />
-					)}
+					<ErrorsV2 />
 				</Route>
 				{/* If not logged in and project id is numeric and nonzero, redirect to login */}
 				{!isLoggedIn && (


### PR DESCRIPTION
## Summary

Enabled the new error page as the default. Will file a ticket for the cleanup of the old `ErrorPage` component and associated code.

## How did you test this change?

Locally and in the preview PR.

## Are there any deployment considerations?

Will need to keep an eye out for errors and any customer complaints about the new page.