### PR TITLE
feat(HIG-3371): update the  empty state for error search

### DIFF
--- a/frontend/src/components/EmptySearchResults/EmptySearchResults.tsx
+++ b/frontend/src/components/EmptySearchResults/EmptySearchResults.tsx
@@ -1,0 +1,46 @@
+import { useAuthContext } from '@authentication/AuthContext'
+import { Button, Callout, Stack, Text } from '@highlight-run/ui'
+import { showIntercom } from '@util/window'
+
+export enum SearchResultsKind {
+	Errors = 'errors',
+	Sessions = 'sessions',
+}
+
+interface Props {
+	kind: SearchResultsKind
+}
+
+export const EmptySearchResults = ({ kind }: Props) => {
+	const { admin } = useAuthContext()
+
+	return (
+		<Callout title={`Couldn't find any relevant ${kind}`}>
+			<Text>
+				If you think something's wrong, feel free to reach out to us!
+			</Text>
+			<Stack direction="row" gap="8">
+				<Button
+					kind="secondary"
+					onClick={() => showIntercom({ admin })}
+				>
+					Contact
+				</Button>
+				<Button
+					kind="secondary"
+					emphasis="low"
+					onClick={() => {
+						const url =
+							kind === SearchResultsKind.Errors
+								? 'https://www.highlight.io/docs/error-monitoring/grouping-errors'
+								: 'https://www.highlight.io/docs/product-features/session-search'
+
+						window.open(url, '_blank')
+					}}
+				>
+					Learn more
+				</Button>
+			</Stack>
+		</Callout>
+	)
+}

--- a/frontend/src/components/EmptySearchResults/SearchEmptyState.module.scss.d.ts
+++ b/frontend/src/components/EmptySearchResults/SearchEmptyState.module.scss.d.ts
@@ -1,0 +1,6 @@
+export const emptyStateSection: string
+export const emptyStateWrapper: string
+export const emptySubTitle: string
+export const emptyTitle: string
+export const intercomButton: string
+export const newFeedStyles: string

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -44,8 +44,8 @@ import { useIntegrated } from '@util/integrated'
 import { isOnPrem } from '@util/onPrem/onPremUtils'
 import { useParams } from '@util/react-router/useParams'
 import { titleCaseString } from '@util/string'
+import { showIntercom } from '@util/window'
 import classNames from 'classnames/bind'
-import { H } from 'highlight.run'
 import moment from 'moment'
 import React, { useEffect } from 'react'
 import { Link, useLocation } from 'react-router-dom'
@@ -335,21 +335,9 @@ export const Header = () => {
 											</Menu.Item>
 										</Link>
 										<Menu.Item
-											onClick={async () => {
-												const sessionId =
-													await H.getSessionURL()
-
-												window.Intercom('boot', {
-													app_id: 'gm6369ty',
-													alignment: 'right',
-													hide_default_launcher: true,
-													email: admin?.email,
-													sessionId,
-												})
-												window.Intercom(
-													'showNewMessage',
-												)
-											}}
+											onClick={() =>
+												showIntercom({ admin })
+											}
 										>
 											<Box
 												display="flex"

--- a/frontend/src/components/Header/HelpMenu/HelpMenu.tsx
+++ b/frontend/src/components/Header/HelpMenu/HelpMenu.tsx
@@ -1,9 +1,9 @@
+import { useAuthContext } from '@authentication/AuthContext'
 import { isOnPrem } from '@util/onPrem/onPremUtils'
-import { H } from 'highlight.run'
+import { showIntercom } from '@util/window'
 import React from 'react'
 import { FiTwitter } from 'react-icons/fi'
 
-import { useGetAdminQuery } from '../../../graph/generated/hooks'
 import SvgBookIcon from '../../../static/BookIcon'
 import SvgEditIcon from '../../../static/EditIcon'
 import SvgHelpCircleIcon from '../../../static/HelpCircleIcon'
@@ -14,7 +14,7 @@ import popoverMenuStyles from '../../PopoverMenu/PopoverMenu.module.scss'
 import styles from './HelpMenu.module.scss'
 
 const HelpMenu = () => {
-	const { data } = useGetAdminQuery()
+	const { admin } = useAuthContext()
 
 	const leadMenuItems: PopoverMenuItem[] = [
 		...(!isOnPrem
@@ -22,18 +22,7 @@ const HelpMenu = () => {
 					{
 						icon: <SvgMessageIcon />,
 						displayName: 'Send us a message',
-						action: async () => {
-							const sessionId = await H.getSessionURL()
-
-							window.Intercom('boot', {
-								app_id: 'gm6369ty',
-								alignment: 'right',
-								hide_default_launcher: true,
-								email: data?.admin?.email,
-								sessionId,
-							})
-							window.Intercom('showNewMessage')
-						},
+						action: () => showIntercom({ admin }),
 					},
 			  ]
 			: []),

--- a/frontend/src/components/Header/components/FeedbackButton/FeedbackButton.tsx
+++ b/frontend/src/components/Header/components/FeedbackButton/FeedbackButton.tsx
@@ -1,6 +1,6 @@
 import SvgMailIcon from '@icons/MailIcon'
 import { isOnPrem } from '@util/onPrem/onPremUtils'
-import { H } from 'highlight.run'
+import { showIntercom } from '@util/window'
 import React from 'react'
 
 import { useAuthContext } from '../../../../authentication/AuthContext'
@@ -22,18 +22,7 @@ const FeedbackButton = () => {
 							{
 								displayName: 'Bug Report',
 								icon: <SvgBugIcon />,
-								action: async () => {
-									const sessionId = await H.getSessionURL()
-
-									window.Intercom('boot', {
-										app_id: 'gm6369ty',
-										alignment: 'right',
-										hide_default_launcher: true,
-										email: admin?.email,
-										sessionId,
-									})
-									window.Intercom('showNewMessage')
-								},
+								action: () => showIntercom({ admin }),
 							},
 					  ]
 					: []),

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -37,6 +37,7 @@ import { HIGHLIGHT_ADMIN_EMAIL_DOMAINS } from '@util/authorization/authorization
 import { showHiringMessage } from '@util/console/hiringMessage'
 import { client } from '@util/graph'
 import { isOnPrem } from '@util/onPrem/onPremUtils'
+import { showIntercom } from '@util/window'
 import { H, HighlightOptions } from 'highlight.run'
 import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom'
@@ -116,12 +117,7 @@ H.init(import.meta.env.REACT_APP_FRONTEND_ORG ?? 1, options)
 if (!isOnPrem) {
 	H.start()
 
-	window.Intercom('boot', {
-		app_id: 'gm6369ty',
-		alignment: 'right',
-		hide_default_launcher: true,
-	})
-
+	showIntercom({ hideMessage: true })
 	if (!dev) {
 		datadogLogs.init({
 			clientToken: import.meta.env.DD_CLIENT_TOKEN,

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -1,4 +1,7 @@
-import { SearchEmptyState } from '@components/SearchEmptyState/SearchEmptyState'
+import {
+	EmptySearchResults,
+	SearchResultsKind,
+} from '@components/EmptySearchResults/EmptySearchResults'
 import SearchPagination, {
 	DEFAULT_PAGE_SIZE,
 	START_PAGE,
@@ -133,7 +136,9 @@ const SearchPanel = () => {
 				) : (
 					<>
 						{searchResultsCount === 0 ? (
-							<SearchEmptyState item="errors" />
+							<EmptySearchResults
+								kind={SearchResultsKind.Errors}
+							/>
 						) : (
 							fetchedData.error_groups?.map(
 								(eg: Maybe<ErrorGroup>, ind: number) => (

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -12,6 +12,7 @@ import useLocalStorage from '@rehooks/local-storage'
 import { AppRouter } from '@routers/AppRouter/AppRouter'
 import analytics from '@util/analytics'
 import { auth, googleProvider } from '@util/auth'
+import { showIntercom } from '@util/window'
 import { message } from 'antd'
 import classNames from 'classnames'
 import firebase from 'firebase'
@@ -65,27 +66,7 @@ export const AuthAdminRouter = () => {
 			// static property for the user ID rather than something that could change
 			// over time, like an email address.
 			analytics.identify(admin.id, omit(identifyMetadata, ['id']))
-
-			H.getSessionURL()
-				.then((sessionUrl) => {
-					window.Intercom('boot', {
-						app_id: 'gm6369ty',
-						alignment: 'right',
-						hide_default_launcher: true,
-						email: admin?.email,
-						user_id: admin?.uid,
-						sessionUrl,
-					})
-				})
-				.catch(() => {
-					window.Intercom('boot', {
-						app_id: 'gm6369ty',
-						alignment: 'right',
-						hide_default_launcher: true,
-						email: admin?.email,
-						user_id: admin?.uid,
-					})
-				})
+			showIntercom({ admin, hideMessage: true })
 		}
 	}, [admin])
 

--- a/frontend/src/util/constants/constants.ts
+++ b/frontend/src/util/constants/constants.ts
@@ -1,2 +1,4 @@
 export const DEMO_WORKSPACE_NAME = 'Pied Piper Inc.'
 export const DEMO_PROJECT_NAME = 'Frontend'
+
+export const INTERCOM_APP_ID = 'gm6369ty'

--- a/frontend/src/util/window.ts
+++ b/frontend/src/util/window.ts
@@ -1,6 +1,40 @@
+import { Admin } from '@graph/schemas'
+import { INTERCOM_APP_ID } from '@util/constants/constants'
+import { H } from 'highlight.run'
+
 export function GetBaseURL(): string {
 	return (
 		import.meta.env.REACT_APP_FRONTEND_URI ||
 		window.location.protocol + '//' + window.location.host
 	)
+}
+
+interface IntercomInit {
+	admin?: Admin
+	hideMessage?: boolean
+}
+
+export function showIntercom({ admin, hideMessage }: IntercomInit = {}) {
+	const config = {
+		app_id: INTERCOM_APP_ID,
+		alignment: 'right',
+		hide_default_launcher: true,
+		email: admin?.email,
+		user_id: admin?.uid,
+	}
+
+	H.getSessionURL()
+		.then((sessionUrl) => {
+			window.Intercom('boot', {
+				...config,
+				sessionUrl,
+			})
+		})
+		.catch(() => {
+			window.Intercom('boot', config)
+		})
+
+	if (!hideMessage) {
+		window.Intercom('showNewMessage')
+	}
 }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

- updates the empty state to align with [figma](https://www.figma.com/file/pAHlb8IFmVSewPJcphbjIH/Component-Library?node-id=876%3A15068&viewport=996%2C-537%2C0.98&t=ONVRtDx0rXPDmgpr-0)
- delegates all the intercom calls to a common util function
<img width="347" alt="Screenshot 2022-12-07 at 12 35 25 PM" src="https://user-images.githubusercontent.com/17913919/206289874-1bf93537-044d-43b4-88c5-d6c77beb796e.png">

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

link to a segment with no results (changes are only visible in the new error ui):

https://frontend-pr-3404.onrender.com/1/errors?query=and%7C%7Cerror_state%2Cis%2COPEN%7C%7Cerror-field_timestamp%2Cbetween_date%2C30%20days%7C%7Cerror_state%2Cis%2CRESOLVED&segment=%7B%22id%22%3A%22126%22%2C%22name%22%3A%22non-segment%22%7D
## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no