### PR TITLE
change session process metrics to reduce cardinality

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -69,6 +69,7 @@ import (
 
 const ErrorGroupLookbackDays = 7
 const SessionActiveMetricName = "sessionActiveLength"
+const SessionProcessedMetricName = "sessionProcessed"
 
 var (
 	WhitelistedUID  = os.Getenv("WHITELISTED_FIREBASE_ACCOUNT")

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -884,13 +884,23 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 			Value:           float64(accumulator.ActiveDuration.Milliseconds()),
 			Category:        pointy.String(model.InternalMetricCategory),
 			Tags: []*publicModel.MetricTag{
-				{Name: "SessionID", Value: strconv.Itoa(s.ID)},
+				{Name: "Excluded", Value: "false"},
+				{Name: "Processed", Value: "true"},
+			},
+		},
+		{
+			SessionSecureID: s.SecureID,
+			Timestamp:       s.CreatedAt,
+			Name:            mgraph.SessionProcessedMetricName,
+			Value:           float64(s.ID),
+			Category:        pointy.String(model.InternalMetricCategory),
+			Tags: []*publicModel.MetricTag{
 				{Name: "Excluded", Value: "false"},
 				{Name: "Processed", Value: "true"},
 			},
 		},
 	}); err != nil {
-		log.Errorf("failed to count sessions metric for %s: %s", s.SecureID, err)
+		log.Errorf("failed to submit session processing metric for %s: %s", s.SecureID, err)
 	}
 
 	// Update session count on dailydb


### PR DESCRIPTION
## Summary

Cardinality too high by sending `SessionID` as a tag, which has too many unique values.

## How did you test this change?

Local deploy

## Are there any deployment considerations?

No. `sessionActiveLength` not actually being used yet.