### PR TITLE
fix(HIG-3407): janky query builder

### DIFF
--- a/frontend/src/pages/Errors/ErrorsPage.tsx
+++ b/frontend/src/pages/Errors/ErrorsPage.tsx
@@ -13,4 +13,4 @@ export const EmptyErrorsSearchParams: Complete<ErrorSearchParamsInput> = {
 	type: undefined,
 	// TODO: remove the other attributes after deprecating static filters
 	query: `{\"isAnd\":true,\"rules\":[[\"error_state\",\"is\",\"${ErrorState.Open}\"]]}`,
-}
+} as const

--- a/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/components/QueryBuilder/QueryBuilder.tsx
@@ -1213,6 +1213,9 @@ export const deserializeGroup = (
 }
 
 const deserializeRules = (ruleGroups: any): RuleProps[] => {
+	if (!ruleGroups) {
+		return []
+	}
 	return ruleGroups.map((group: any[]) => {
 		const [field, op, ...vals] = group
 		return deserializeGroup(field, op, vals)
@@ -1723,7 +1726,7 @@ function QueryBuilder(props: QueryBuilderProps) {
 		},
 		[defaultTimeRangeRule, parseRule, timeRangeField.value],
 	)
-
+	const [isAnd, toggleIsAnd] = useToggle(true)
 	const [rules, setRulesImpl] = useState<RuleProps[]>([defaultTimeRangeRule])
 	const serializedQuery = useRef<BackendSearchQuery | undefined>()
 	const [syncButtonDisabled, setSyncButtonDisabled] = useState<boolean>(false)
@@ -1779,8 +1782,6 @@ function QueryBuilder(props: QueryBuilderProps) {
 
 		return timeRange
 	}, [addRule, defaultTimeRangeRule, rules, timeRangeField.value])
-
-	const [isAnd, toggleIsAnd] = useToggle(true)
 
 	const getKeyOptions = useCallback(
 		async (input: string) => {
@@ -2470,7 +2471,7 @@ function QueryBuilder(props: QueryBuilderProps) {
 				m="8"
 				shadow="small"
 			>
-				{mode !== QueryBuilderMode.EMPTY && !segmentsLoading && (
+				{mode !== QueryBuilderMode.EMPTY && (
 					<Box
 						p="4"
 						paddingBottom="8"

--- a/frontend/src/routers/OrgRouter/WithErrorSearchContext.tsx
+++ b/frontend/src/routers/OrgRouter/WithErrorSearchContext.tsx
@@ -1,6 +1,7 @@
 import { BackendSearchQuery } from '@context/BaseSearchContext'
 import { ErrorSearchParamsInput } from '@graph/schemas'
 import { ErrorSearchContextProvider } from '@pages/Errors/ErrorSearchContext/ErrorSearchContext'
+import { EmptyErrorsSearchParams } from '@pages/Errors/ErrorsPage'
 import { useParams } from '@util/react-router/useParams'
 import { useState } from 'react'
 import { useLocalStorage } from 'react-use'
@@ -15,9 +16,11 @@ const WithErrorSearchContext: React.FC<React.PropsWithChildren<unknown>> = ({
 	// TODO: remove this in favor of selectedSegment after updating the session search query builder
 	const [segmentName, setSegmentName] = useState<string | null>(null)
 
-	const [searchParams, setSearchParams] = useState<ErrorSearchParamsInput>({})
+	const [searchParams, setSearchParams] = useState<ErrorSearchParamsInput>(
+		EmptyErrorsSearchParams,
+	)
 	const [searchResultsLoading, setSearchResultsLoading] =
-		useState<boolean>(false)
+		useState<boolean>(true)
 
 	const [searchResultsCount, setSearchResultsCount] = useState<number>(0)
 	const [searchResultSecureIds, setSearchResultSecureIds] = useState<
@@ -25,7 +28,7 @@ const WithErrorSearchContext: React.FC<React.PropsWithChildren<unknown>> = ({
 	>([])
 
 	const [existingParams, setExistingParams] =
-		useState<ErrorSearchParamsInput>({})
+		useState<ErrorSearchParamsInput>(EmptyErrorsSearchParams)
 
 	const [backendSearchQuery, setBackendSearchQuery] =
 		useState<BackendSearchQuery>(undefined)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Makes sure the initial state of the query builder for errors does not depend on whether segments are loaded or not. Sets more sensible defaults.
## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

click test
https://frontend-pr-3415.onrender.com/
## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no