### PR TITLE
truncate messages / identifiers to 100 characters

### DIFF
--- a/backend/lambda-functions/digests/handlers/handlers.go
+++ b/backend/lambda-functions/digests/handlers/handlers.go
@@ -210,7 +210,7 @@ func (h *handlers) GetDigestData(ctx context.Context, input utils.ProjectIdRespo
 	activeSessions := []utils.ActiveSession{}
 	for _, item := range activeSessionsSql {
 		activeSessions = append(activeSessions, utils.ActiveSession{
-			Identifier:   getIdentifier(item.UserProperties, item.Identifier, item.Fingerprint),
+			Identifier:   truncate100(getIdentifier(item.UserProperties, item.Identifier, item.Fingerprint)),
 			Location:     getLocation(item.Country),
 			ActiveLength: formatDurationMinute(item.ActiveLength * time.Millisecond),
 			URL:          formatSessionURL(input.ProjectId, item.SecureId),
@@ -237,7 +237,7 @@ func (h *handlers) GetDigestData(ctx context.Context, input utils.ProjectIdRespo
 	errorSessions := []utils.ErrorSession{}
 	for _, item := range errorSessionsSql {
 		errorSessions = append(errorSessions, utils.ErrorSession{
-			Identifier:   getIdentifier(item.UserProperties, item.Identifier, item.Fingerprint),
+			Identifier:   truncate100(getIdentifier(item.UserProperties, item.Identifier, item.Fingerprint)),
 			ErrorCount:   formatNumber(item.ErrorCount),
 			ActiveLength: formatDurationMinute(item.ActiveLength * time.Millisecond),
 			URL:          formatSessionURL(input.ProjectId, item.SecureId),
@@ -266,7 +266,7 @@ func (h *handlers) GetDigestData(ctx context.Context, input utils.ProjectIdRespo
 	newErrors := []utils.NewError{}
 	for _, item := range newErrorsSql {
 		newErrors = append(newErrors, utils.NewError{
-			Message:           unwrapErrorMessage(item.Message),
+			Message:           truncate100(unwrapErrorMessage(item.Message)),
 			AffectedUserCount: formatNumber(item.AffectedUserCount),
 			URL:               formatErrorURL(input.ProjectId, item.SecureId),
 		})
@@ -292,7 +292,7 @@ func (h *handlers) GetDigestData(ctx context.Context, input utils.ProjectIdRespo
 	frequentErrors := []utils.FrequentError{}
 	for _, item := range frequentErrorsSql {
 		frequentErrors = append(frequentErrors, utils.FrequentError{
-			Message: unwrapErrorMessage(item.Message),
+			Message: truncate100(unwrapErrorMessage(item.Message)),
 			Count:   formatNumber(item.Count),
 			Delta:   formatDelta(item.Count - item.PriorCount),
 			URL:     formatErrorURL(input.ProjectId, item.SecureId),
@@ -394,6 +394,15 @@ func getIdentifier(userProperties string, identifier string, fingerprint string)
 		return "#" + fingerprint
 	}
 	return "unidentified"
+}
+
+// Truncate strings after 100 characters
+func truncate100(input string) string {
+	count := 100
+	if len(input) < count {
+		count = len(input)
+	}
+	return input[0:count]
 }
 
 // Error message may be a JSON string or array. Try to unwrap it.


### PR DESCRIPTION
- not sure if this is an issue but there could be a really long error message or identifier, truncating in case it spans a huge number of lines