### PR TITLE
fix comments goto button at 0:00 timestamp

### DIFF
--- a/frontend/src/components/Comment/SessionComment/SessionCommentHeader.tsx
+++ b/frontend/src/components/Comment/SessionComment/SessionCommentHeader.tsx
@@ -45,7 +45,7 @@ const SessionCommentHeader = ({
 	onClose,
 	footer,
 }: PropsWithChildren<Props>) => {
-	const { pause, session, sessionMetadata, replayer } = useReplayerContext()
+	const { pause, session, sessionMetadata } = useReplayerContext()
 	const [deleteSessionComment] = useDeleteSessionCommentMutation({
 		refetchQueries: [namedOperations.Query.GetSessionComments],
 	})


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Clicking the goto button on comments set at 0:00 is not functional (it does work correctly through the more menu).

![Screenshot_2022-12-12_at_1_13_27_PM](https://user-images.githubusercontent.com/58678/207145420-8e73882b-fd98-443e-b8ba-b3c53644ba0a.png)

https://www.loom.com/share/9cf41f12b3ee434796ce6bcbb4ef9f05

To fix this, I reused the logic from the goto button inside the more menu.

**Note:** previously, the non-more menu goto button would just jump the replayer time. By consolidating to the logic, this also pops open the comment window over the session player and updates the URL. I don't know if the previous behavior was intentional but the tradeoff of de-duplicating code seems worth it along with having a consistent UX. Let me know if there's any objections to this.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

I validated that clicking the goto button does indeed move the time correctly for a comment set at 0:00.

https://www.loom.com/share/c4c47422b99041b18c882aad4e2f0532

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
