### PR TITLE
fix player unable to seek while playing

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -478,7 +478,7 @@ export const PlayerReducer = (
 				PlayerActionType.onChunksLoad,
 				s,
 				action.action,
-				s.time,
+				action.time,
 			)
 			s.isLoadingEvents = false
 			break


### PR DESCRIPTION
## Summary

Seeking while playing a large session would sometimes cause the seek to not occur.
This would show as an animation of the timeline to the desired point, only to jump back to the previous time.
Example session: https://app.highlight.io/629/sessions/9BHnjmqKkuAPolmgNrjdHg71GNM2

The issue was around concurrent loading of a chunk while a click was issued jumping to the prior time,
combined with the wrong time being used for the seek itself.

## How did you test this change?

[Preview](https://frontend-pr-3435.onrender.com/629/sessions/9BHnjmqKkuAPolmgNrjdHg71GNM2)

## Are there any deployment considerations?

No
