### PR TITLE
log hubspot errors with additional metadata

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -568,7 +568,10 @@ func (r *mutationResolver) MarkSessionAsViewed(ctx context.Context, secureID str
 				Property: "number_of_highlight_sessions_viewed",
 				Value:    totalSessionCountAsInt,
 			}}); err != nil {
-				log.Error(e.Wrap(err, "error updating session count for admin in hubspot"))
+				log.WithFields(log.Fields{
+					"admin_id": admin.ID,
+					"value":    totalSessionCountAsInt,
+				}).Error(e.Wrap(err, "error updating session count for admin in hubspot"))
 			}
 			log.Infof("succesfully added to total session count for admin [%v], who just viewed session [%v]", admin.ID, s.ID)
 		}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1264,7 +1264,10 @@ func (w *Worker) RefreshMaterializedViews() {
 				Property: "highlight_session_count",
 				Value:    c.Count,
 			}}); err != nil {
-				log.Fatal(e.Wrap(err, "error updating highlight session count in hubspot"))
+				log.WithFields(log.Fields{
+					"workspace_id": c.WorkspaceID,
+					"value":        c.Count,
+				}).Fatal(e.Wrap(err, "error updating highlight session count in hubspot"))
 			}
 			time.Sleep(150 * time.Millisecond)
 		}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We are getting errors when updating the workspace's session count and admin's viewed session count in Hubspot ([logs](https://app.datadoghq.com/logs?query=error%20updating%20highlight%20session%20count%20in%20hubspot&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1668442312797&to_ts=1671034312797&live=true) and [logs](https://app.datadoghq.com/logs?query=error%20updating%20session%20count%20for%20admin%20in%20hubspot&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1668442312797&to_ts=1671034312797&live=true)). 



We don't have enough information to deduce why so this PR adds additional metadata to our logs so we can cross reference what Hubspot entry we are trying to update.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Code compiles

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
