### PR TITLE
add debugging information for determining if we can remove a legacy slack codepath

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2502,11 +2502,18 @@ func (r *Resolver) sendCommentPrimaryNotification(
 		if len(admins) < 1 {
 			return
 		}
+
 		var taggedAdminSlacks []*modelInputs.SanitizedSlackChannelInput
 		for _, a := range admins {
 			taggedAdminSlacks = append(taggedAdminSlacks, &modelInputs.SanitizedSlackChannelInput{
 				WebhookChannelID: a.SlackIMChannelID,
 			})
+
+			// See HIG-3438
+			// We need additional debugging information to see if we can remove this code path.
+			log.WithFields(log.Fields{
+				"admin_id": a.ID,
+			}).Info("Sending slack notification for a Highlight user using a legacy slack configuration")
 		}
 
 		err := r.SendSlackAlertToUser(workspace, admin, taggedAdminSlacks, viewLink, textForEmail, action, subjectScope, nil, sessionCommentID, errorCommentID, additionalContext)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

I'd like to remove this legacy codepath for slack entirely but we need more debugging information to ensure this is entirely unused.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Code compiles

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
