### PR TITLE
[HIG-3208] show period start / end in billing card

### DIFF
--- a/frontend/src/pages/Billing/BillingStatusCard/BillingStatusCard.tsx
+++ b/frontend/src/pages/Billing/BillingStatusCard/BillingStatusCard.tsx
@@ -134,11 +134,21 @@ export const BillingStatusCard = ({
 			nextInvoiceDate < billingPeriodEnd
 				? nextInvoiceDate
 				: billingPeriodEnd
+	} else if (billingPeriodEnd) {
+		nextBillingDate = billingPeriodEnd
 	}
 
 	return (
 		<div className={styles.fieldsBox}>
-			<h3 className={styles.cardTitle}>Current Billing Status</h3>
+			<h3 className={styles.cardTitle}>
+				Current Billing Status
+				{nextBillingDate &&
+					` - ${moment(nextBillingDate)
+						.subtract(1, 'months')
+						.format('MMM D')} to ${moment(nextBillingDate).format(
+						'MMM D',
+					)}`}
+			</h3>
 			<div className={styles.cardSubtitleContainer}>
 				<span>Current Base Plan</span>
 				{loading ? (


### PR DESCRIPTION
## Summary
- fix issue where due date wasn't shown for monthly subscriptions
- show billing period start and end date in heading
<img width="726" alt="Screen Shot 2022-12-14 at 11 54 20 AM" src="https://user-images.githubusercontent.com/86132398/207701449-93ad67d9-531a-45c3-ae66-40389a211bb0.png">

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
