### PR TITLE
Fix overflow on error bodies

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorBody/ErrorBody.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorBody/ErrorBody.tsx
@@ -262,6 +262,7 @@ const ErrorBody: React.FC<React.PropsWithChildren<Props>> = ({
 					family="monospace"
 					lines={truncated ? '3' : undefined}
 					ref={bodyRef}
+					break="word"
 				>
 					{body}
 				</Text>

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -228,7 +228,7 @@ const Metadata: React.FC<{
 									meta.label && copyToClipboard(meta.label)
 								}
 							>
-								<Text align="left" wrap="always" lines="1">
+								<Text align="left" break="all" lines="1">
 									{meta.label}
 								</Text>
 							</Box>

--- a/packages/ui/src/components/Text/styles.css.ts
+++ b/packages/ui/src/components/Text/styles.css.ts
@@ -103,9 +103,15 @@ export const variants = recipe({
 				textTransform: 'lowercase',
 			},
 		},
-		wrap: {
-			always: {
+		break: {
+			all: {
 				wordBreak: 'break-all',
+			},
+			word: {
+				wordBreak: 'break-word',
+			},
+			normal: {
+				wordBreak: 'normal',
 			},
 			none: {
 				whiteSpace: 'nowrap',


### PR DESCRIPTION
## Summary

Fixes error bodies overflowing on some errors.

### Before

<img width="1067" alt="Screen Shot 2022-12-15 at 11 07 17 AM" src="https://user-images.githubusercontent.com/308182/207923545-238f392f-7f8a-4497-8cfa-058d0a4154cb.png">

### After

<img width="1077" alt="Screen Shot 2022-12-15 at 11 07 47 AM" src="https://user-images.githubusercontent.com/308182/207923521-d439fda2-1d81-4070-9059-d4c694398c3a.png">

## How did you test this change?

Local and PR preview click test.

## Are there any deployment considerations?

N/A
