### PR TITLE
improve copy on Discord disconnect modal

### DIFF
--- a/frontend/src/pages/IntegrationsPage/components/DiscordIntegration/DiscordIntegrationConfig.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/DiscordIntegration/DiscordIntegrationConfig.tsx
@@ -64,8 +64,8 @@ const DiscordIntegrationConfig: React.FC<IntegrationConfigProps> = ({
 		return (
 			<>
 				<p className={styles.modalSubTitle}>
-					Disconnecting Discord from Highlight will stop enhancing
-					your customer interactions.
+					Disconnecting Discord from Highlight will prevent alerts
+					from notifying Discord channels.
 				</p>
 				<footer>
 					<Button


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

The existing copy for disconnecting Discord was from the Front integration which doesn't really make sense here.

## How did you test this change?

Before:
<img width="573" alt="Screenshot 2022-12-14 at 9 39 58 PM" src="https://user-images.githubusercontent.com/58678/207774474-34d0ef65-2b2b-4148-b836-61b411446851.png">

After:
<img width="546" alt="Screenshot 2022-12-14 at 9 44 18 PM" src="https://user-images.githubusercontent.com/58678/207774514-ba075101-8a25-4ce0-ba9d-c2ee3a64c282.png">


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
