### PR TITLE
skip updating session count for demo project

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1260,7 +1260,7 @@ func (w *Worker) RefreshMaterializedViews() {
 	if !util.IsDevOrTestEnv() {
 		for _, c := range counts {
 			// See HIG-2743
-			// Skip updating session count for demo project because we exclude it from Hubspot
+			// Skip updating session count for demo workspace because we exclude it from Hubspot
 			if c.WorkspaceID == 0 {
 				continue
 			}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We are getting log errors when trying to update the session count in Hubspot for the demo project ([logs](https://app.datadoghq.com/logs?query=error%20updating%20highlight%20session%20count%20in%20hubspot&agg_q=%40workspace_id&analyticsOptions=%22bars%22&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=timeseries&from_ts=1668442312797&to_ts=1671034312797&live=true)). This is because the demo project doesn't exist in Hubspot (see #3081).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

N/A

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A