### PR TITLE
Clean up display of instance metadata

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -295,6 +295,7 @@ const User: React.FC<{
 					alignItems="center"
 					display="flex"
 					justifyContent="space-between"
+					gap="4"
 				>
 					<Box alignItems="center" display="flex" gap="8">
 						<Avatar


### PR DESCRIPTION
## Summary

Fixes some display issues for metadata values on error instances.

* Allows values to be multiline, up to 4 lines
* Changed markup structure to avoid issue where column height don't match
* Added space between the email and all sessions link
* Cleaned up labels for `OS`, `URL`, and `ID`

<img width="968" alt="Screen Shot 2022-12-16 at 8 36 18 AM" src="https://user-images.githubusercontent.com/308182/208121589-2a461cf3-e03a-4001-88b7-eb305b5a1e59.png">

## How did you test this change?

Local click test

## Are there any deployment considerations?

N/A
