### PR TITLE
Add tracking for navigating error instances

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -104,6 +104,10 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 									pathname: `/${projectId}/errors/${error_secure_id}/instances/${errorInstance.previous_id}`,
 									search: window.location.search,
 								})
+
+								analytics.track('Viewed error instance', {
+									direction: 'previous',
+								})
 							}}
 							disabled={Number(errorInstance.previous_id) === 0}
 							kind="secondary"
@@ -117,6 +121,10 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 								history.push({
 									pathname: `/${projectId}/errors/${error_secure_id}/instances/${errorInstance.next_id}`,
 									search: window.location.search,
+								})
+
+								analytics.track('Viewed error instance', {
+									direction: 'next',
 								})
 							}}
 							disabled={Number(errorInstance.next_id) === 0}


### PR DESCRIPTION
## Summary

Adds tracking when someone navigates between error instances in an error group.

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A - only a tracking change.