### PR TITLE
add tracer data to audit the auth flow

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -411,6 +411,7 @@ func (r *Resolver) isAdminInProject(ctx context.Context, project_id int) (*model
 	}
 	for _, p := range projects {
 		if p.ID == project_id {
+			span.SetTag("WorkspaceID", p.WorkspaceID)
 			return p, nil
 		}
 	}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Currently, we have sessions failing to process because the associated project was deleted at some point (see #3451). Unfortunately, because the project is deleted, we have no way to correlate what workspace the project belonged to. Hence, we can't reach out to a user to inform them about the issue. 

Each GQL operation is traced in datadog:
https://github.com/highlight-run/highlight/blob/208b6cb00574333fd1083c38ef28eb0379a02184/backend/util/tracer.go#L53-L63

Along with the variables passed:
https://github.com/highlight-run/highlight/blob/59c5f522f63a203819398ac52f58fd6df9e40ef1/backend/util/tracer.go#L34-L51

We can see this in action by looking at the trace for [DeleteProject](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20-service%3A%28worker-service%20OR%20public-graph-service%29%20resource_name%3ADeleteProject&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=true&messageDisplay=inline&sort=desc&spanID=4991201897294882109&spanType=service-entry&timeHint=1671063269874&trace=AgAAAYUTIfHyBbfACAAAAAAAAAAYAAAAAEFZVVRJZmNsQUFCb0JpTGhkZlJLdmtSRgAAACQAAAAAMDE4NTEzZGUtZTE4NC00YWY5LTllOTUtMzZhNTEwMmM3YzBl&traceID=4991201897294882109&start=1670000965701&end=1671210565701&paused=false). 

![Screenshot_2022-12-16_at_10_24_21_AM](https://user-images.githubusercontent.com/58678/208154225-0dcd2759-054b-4b20-bc85-700a94274f5b.png)


However, we are still missing information about who performed the GQL operation. Looking through the auth code, I managed to find a custom trace for `isAdminInProjectOrDemoProject`: 

https://github.com/highlight-run/highlight/blob/59c5f522f63a203819398ac52f58fd6df9e40ef1/backend/private-graph/graph/resolver.go#L220-L221

I can see this for GQL operations that call that codepath ([example](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20-service%3A%28worker-service%20OR%20public-graph-service%29&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=true&messageDisplay=inline&sort=desc&spanID=4827669404797628407&spanType=service-entry&timeHint=1671210719411&trace=AgAAAYUb69izPyV9TAAAAAAAAAAYAAAAAEFZVWI2OXFTQUFDM0l6X2pmVlNhdXY5QwAAACQAAAAAMDE4NTFiZWItZDhiMy00Y2IzLTg0ODgtNzY1NDhjMGI3YjFm&traceID=4827669404797628407&start=1670001205648&end=1671210805648&paused=false)). 
![Screenshot 2022-12-16 at 10 13 05 AM](https://user-images.githubusercontent.com/58678/208152306-3c6935ba-e751-4709-b38b-94997dfc9e56.png)


However, the `DeleteProject` operation does not call this flow. Nor does it include any information that would be useful for auditing purposes.

This PR adds additional trace data to `isAdminInWorkspace` and `isAdminInProject` for gathering auditing information of what is available without requiring additional db lookups.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Testing in Datadog

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A