### PR TITLE
add docs link to clearbit integration

### DIFF
--- a/frontend/src/pages/IntegrationsPage/Integrations.tsx
+++ b/frontend/src/pages/IntegrationsPage/Integrations.tsx
@@ -26,6 +26,7 @@ export interface Integration {
 	configurationPage: (opts: IntegrationConfigProps) => React.ReactNode
 	hasSettings: boolean
 	modalWidth?: number
+	docs?: string
 }
 
 export const SLACK_INTEGRATION: Integration = {
@@ -68,6 +69,7 @@ export const CLEARBIT_INTEGRATION: Integration = {
 	icon: '/images/integrations/clearbit.svg',
 	configurationPage: (opts) => <ClearbitIntegrationConfig {...opts} />,
 	hasSettings: false,
+	docs: 'https://www.highlight.io/docs/integrations/clearbit-integration',
 }
 
 export const FRONT_INTEGRATION: Integration = {

--- a/frontend/src/pages/IntegrationsPage/components/Integration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.tsx
@@ -37,6 +37,7 @@ const Integration = ({
 		defaultEnable,
 		hasSettings,
 		modalWidth,
+		docs,
 	},
 	showModalDefault,
 	showSettingsDefault,
@@ -107,6 +108,16 @@ const Integration = ({
 				<div>
 					<h2 className={styles.title}>{name}</h2>
 					<p className={styles.description}>{description}</p>
+					{docs && (
+						<a
+							className={styles.description}
+							href={docs}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Learn more about the integration.
+						</a>
+					)}
 				</div>
 			</Card>
 


### PR DESCRIPTION
## Summary

Per customer feedback, adds a link to the Clearbit docs in the integrations page.

## How did you test this change?

<img width="379" alt="Screenshot 2022-12-16 at 9 41 27 AM" src="https://user-images.githubusercontent.com/1351531/208157027-34a78916-a16b-46bf-b52e-b65146d78557.png">


## Are there any deployment considerations?

No