### PR TITLE
make sure histogram bars are a consistent radius

### DIFF
--- a/frontend/src/components/Histogram/Histogram.tsx
+++ b/frontend/src/components/Histogram/Histogram.tsx
@@ -2,7 +2,7 @@ import tinycolor from '@ctrl/tinycolor'
 import { Box, Text } from '@highlight-run/ui'
 import { colors } from '@highlight-run/ui/src/css/colors'
 import moment from 'moment'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import { Bar, BarChart, Cell, ReferenceArea, Tooltip } from 'recharts'
 
@@ -16,9 +16,6 @@ export interface Series {
 
 const POPOVER_TIMEOUT_MS = 500
 const BAR_RADIUS_PX = 4
-// sets the visual minimum bar value
-// (to ensure bars are not so short that the border radius looks weird)
-const MIN_BAR_VALUE = 8
 
 interface Props {
 	bucketTimes: number[]
@@ -42,6 +39,15 @@ const Histogram = React.memo(
 		const [tooltipHidden, setTooltipHidden] = useState(true)
 		const [tooltipWantHidden, setTooltipWantHidden] = useState(true)
 
+		// sets the visual minimum bar value
+		// (to ensure bars are not so short that the border radius looks weird)
+		const maxBarValue = useMemo(() => {
+			return Math.max(
+				...seriesList.flatMap((value) => Math.max(...value.counts)),
+			)
+		}, [seriesList])
+		const minBarValue = Math.floor(maxBarValue * 0.2)
+
 		let dragLeft: number | undefined
 		let dragRight: number | undefined
 		if (dragStart !== undefined && dragEnd !== undefined) {
@@ -64,7 +70,7 @@ const Histogram = React.memo(
 				chartData[i][`${s.label}-raw`] = s.counts[i]
 				chartData[i][s.label] =
 					s.counts[i] > 0
-						? Math.max(MIN_BAR_VALUE, s.counts[i])
+						? Math.max(minBarValue, s.counts[i])
 						: s.counts[i]
 			}
 		}


### PR DESCRIPTION
## Summary

Ensures that feed histograms' bars are not too short when the value is small.
This prevents the border radius from making the bars look cut off.

## How did you test this change?

before
<img width="310" alt="Screenshot 2022-12-16 at 10 56 46 AM" src="https://user-images.githubusercontent.com/1351531/208169285-84637abf-cccc-4602-9295-e4cbe202b9fb.png">

after
<img width="452" alt="Screenshot 2022-12-16 at 10 55 47 AM" src="https://user-images.githubusercontent.com/1351531/208169115-fc624181-5de9-4064-87eb-62afb708c734.png">

works with errors where one day may have tons of errors by calculating min value dynamically
![Uploading Screenshot 2022-12-16 at 11.03.06 AM.png…]()


## Are there any deployment considerations?

No