### PR TITLE
migrate session count materialized view to influxdb

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -3077,7 +3077,7 @@ func CalculateMetricUnitConversion(originalUnits *string, desiredUnits *string) 
 func MetricOriginalUnits(metricName string) (originalUnits *string) {
 	if strings.HasSuffix(metricName, "-ms") {
 		originalUnits = pointy.String("ms")
-	} else if map[string]bool{"fcp": true, "fid": true, "lcp": true, "ttfb": true, "jank": true, SessionActiveMetricName: true}[strings.ToLower(metricName)] {
+	} else if map[string]bool{"fcp": true, "fid": true, "lcp": true, "ttfb": true, "jank": true, strings.ToLower(SessionActiveMetricName): true}[strings.ToLower(metricName)] {
 		originalUnits = pointy.String("ms")
 	} else if map[string]bool{"latency": true}[strings.ToLower(metricName)] {
 		originalUnits = pointy.String("ns")

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -897,7 +897,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 			},
 		},
 	}); err != nil {
-		log.Errorf("failed to count sessions metric for %s: %s", s.SecureID, err)
+		log.WithContext(ctx).Errorf("failed to count sessions metric for %s: %s", s.SecureID, err)
 	}
 
 	// Update session count on dailydb


### PR DESCRIPTION
## Summary

The `daily_session_counts_view` materialized view requires a lot of DB iops to calculate.
Daily, we have a worker that would update this view calculating the number of active sessions for each project.
Using influxdb for this metric means that we do not need to have as large of a DB (and no need for provisioned iops).

## How did you test this change?

Local view of the accounts page using the queries.
Manual querying of influx for larger projects to ensure influx performance.
![image](https://user-images.githubusercontent.com/1351531/208211223-29674810-ad43-45b8-8683-446fb263ac52.png)
![image](https://user-images.githubusercontent.com/1351531/208211259-e512c144-fcbe-4707-ad5b-90a39b9dd308.png)


## Are there any deployment considerations?

Can revert if there are any issues.