### PR TITLE
[HIG-3518] use integration in path to open clickup settings after integrating

### DIFF
--- a/frontend/src/pages/IntegrationAuthCallback/IntegrationAuthCallbackPage.tsx
+++ b/frontend/src/pages/IntegrationAuthCallback/IntegrationAuthCallbackPage.tsx
@@ -248,9 +248,11 @@ const WorkspaceIntegrationCallback = ({
 	code,
 	projectId,
 	name,
+	type,
 	addIntegration,
 }: Props & {
 	name: string
+	type: string
 	addIntegration: (code: string) => Promise<unknown>
 }) => {
 	const history = useHistory()
@@ -258,7 +260,7 @@ const WorkspaceIntegrationCallback = ({
 
 	useEffect(() => {
 		if (!addIntegration || !code) return
-		const next = `/${projectId}/integrations`
+		const next = `/${projectId}/integrations/${type}`
 		;(async () => {
 			try {
 				await addIntegration(code)
@@ -285,6 +287,7 @@ const ClickUpIntegrationCallback = ({ code, projectId }: Props) => {
 		<WorkspaceIntegrationCallback
 			code={code}
 			name="ClickUp"
+			type="clickup"
 			addIntegration={addIntegration}
 			projectId={projectId}
 		/>


### PR DESCRIPTION
## Summary
- https://www.loom.com/share/22afa89879aa47fe93302425dba2d6c8
- `integration_type` in path was added for vercel integration, reuse for clickup
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click test locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- nope
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
