### PR TITLE
target arm64 in ECS task definition

### DIFF
--- a/deploy/worker-task.json
+++ b/deploy/worker-task.json
@@ -303,5 +303,6 @@
 		{
 			"name": "worker-volume"
 		}
-	]
+	],
+	"runtimePlatform": { "cpuArchitecture": "ARM64" }
 }


### PR DESCRIPTION
## Summary
- arm64 is a requirement for using Graviton instances on ECS (we want to use these for cost savings)
- hard to know what's going to happen without just deploying to prod and watching it
- starting with the session processing worker because if this breaks, the only effect is sessions remaining "live"
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- not tested yet
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will revert if this is breaking the worker
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
