### PR TITLE
return empty list instead of throwing error if clickup not integrated

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5276,7 +5276,7 @@ func (r *queryResolver) ClickupTeams(ctx context.Context, workspaceID int) ([]*m
 	}
 
 	if workspace.ClickupAccessToken == nil {
-		return nil, e.New("Workspace is not integrated with ClickUp")
+		return []*modelInputs.ClickUpTeam{}, nil
 	}
 
 	teams, err := clickup.GetTeams(*workspace.ClickupAccessToken)


### PR DESCRIPTION
## Summary
- query checks `is_integrated` and `clickup_teams` in parallel:
```
query GetClickUpIntegrationSettings($workspace_id: ID!) {
  is_integrated: is_workspace_integrated_with(
    integration_type: ClickUp
    workspace_id: $workspace_id
  )
  clickup_teams(workspace_id: $workspace_id) {
  ...
  ```
- right now, the `ClickupTeams` resolver throws an error in this case, causing noise while not impacting the UI
- just return an empty list instead (`ClickupProjectMappings` is handled like this)
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested this case locally:
<img width="362" alt="Screen Shot 2022-12-23 at 4 25 03 PM" src="https://user-images.githubusercontent.com/86132398/209406758-d569f6d0-36ef-418b-be5f-c5dc0b0d4f74.png">

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
