### PR TITLE
skip writing postgres metrics if there are none to write

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2099,8 +2099,10 @@ func (r *Resolver) PushMetricsImpl(ctx context.Context, sessionSecureID string, 
 			// downsampled bucket.
 			downsampledMetric = downsampledMetric || m.Name == graph.SessionActiveMetricName
 		}
-		if err := r.DB.Create(&newMetrics).Error; err != nil {
-			return err
+		if len(newMetrics) > 0 {
+			if err := r.DB.Create(&newMetrics).Error; err != nil {
+				return err
+			}
 		}
 		if downsampledMetric {
 			aggregatePoints = append(aggregatePoints, timeseries.Point{


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

I get a load of log lines based where the core error message is `empty slice found`. Because of the kakfa retries, my logs are unreadable:

![Screenshot 2022-12-27 at 2 25 58 PM](https://user-images.githubusercontent.com/58678/209723916-bd17ad9b-842e-4fd7-9d1c-5ad1faade807.png)

The error message looks to stem from gorm (see https://github.com/go-gorm/gorm/issues/4076) whereby creating an empty slice fails.

I see the same issue on prod ([datadog](https://app.datadoghq.com/logs?query=empty%20slice%20found&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1669584185604&to_ts=1672176185604&live=true)) starting on Dec 21:

![Screenshot 2022-12-28 at 11 17 11 AM](https://user-images.githubusercontent.com/58678/209855350-72d4ebda-3e43-42b2-99a2-2e96821a24c3.png)

Which aligns _roughly_ (I say "roughly" because I think our log retention is seven days so it may have started prior to Dec 21) to when #3442 was merged, specifically this conditional:

https://github.com/highlight-run/highlight/blob/c9867de45dd4452bda4db332a112d4c67c934dcf/backend/public-graph/graph/resolver.go#L2078-L2086

since now `newMetrics` could be an empty slice.

My interpretation of the impact is that any metrics that only need influx (per #3442 seem to be anything that's not web vitals nor device metrics) are failing to be updated. I couldn't find a dashboard that specifically pinpoints this issue but I did notice that our [kafka fail rate](https://app.datadoghq.com/dashboard/ziy-zwg-zph/worker-dashboard?fullscreen_end_ts=1672252637067&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1669660637067&fullscreen_widget=5300335495265734&from_ts=1669660640904&to_ts=1672252640904&live=true) was previously near 0 at the beginning of the month and has has a wild uptick that hasn't stablized:

![Screenshot 2022-12-28 at 11 37 58 AM](https://user-images.githubusercontent.com/58678/209857860-8dfc0f9d-7d27-494d-9b7c-4877dc3c3733.png)

**Reviewer: if you know of any dashboards that might be helpful, please share!**

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* I made this change and observed the session doesn't fail to process because there is no new metrics.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

* We should check to see if this log message disappears from the logs on prod
* We should see if this improves the kafka fail rate
