### PR TITLE
fix storybook story icons

### DIFF
--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta } from '@storybook/react'
 
 import { Button } from './Button'
 import { Box } from '../Box/Box'
-import { IconCaretDown, IconCreateFile } from '../icons'
+import { IconSolidCheveronDown, IconSolidDocumentAdd } from '../icons'
 import { Variants } from './styles.css'
 
 export default {
@@ -31,12 +31,12 @@ export const ButtonVariants = () => {
 								<Button
 									iconLeft={
 										jdx % emphasis.length !== 0 ? (
-											<IconCaretDown />
+											<IconSolidCheveronDown />
 										) : null
 									}
 									iconRight={
 										jdx % emphasis.length === 0 ? (
-											<IconCreateFile />
+											<IconSolidDocumentAdd />
 										) : null
 									}
 									size={$size}
@@ -54,7 +54,7 @@ export const ButtonVariants = () => {
 								size={size[size.length - 1]}
 								iconLeft={
 									jdx % emphasis.length !== 0 ? (
-										<IconCaretDown />
+										<IconSolidCheveronDown />
 									) : null
 								}
 								disabled

--- a/packages/ui/src/components/ButtonIcon/ButtonIcon.stories.tsx
+++ b/packages/ui/src/components/ButtonIcon/ButtonIcon.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta } from '@storybook/react'
 
 import { ButtonIcon } from './ButtonIcon'
 import { Box } from '../Box/Box'
-import { IconChevronDown } from '../icons'
+import { IconSolidCheveronDown } from '../icons'
 import { Variants } from './styles.css'
 
 export default {
@@ -32,7 +32,11 @@ export const AllVariants = () => {
 								<>
 									{shape.map(($shape, ldx) => (
 										<ButtonIcon
-											icon={<IconChevronDown size={12} />}
+											icon={
+												<IconSolidCheveronDown
+													size={12}
+												/>
+											}
 											size={$size}
 											kind={$kind}
 											emphasis={$emphasis}
@@ -43,7 +47,9 @@ export const AllVariants = () => {
 
 									<ButtonIcon
 										disabled
-										icon={<IconChevronDown size={12} />}
+										icon={
+											<IconSolidCheveronDown size={12} />
+										}
 										size={$size}
 										kind={$kind}
 										emphasis={$emphasis}

--- a/packages/ui/src/components/Tag/Tag.stories.tsx
+++ b/packages/ui/src/components/Tag/Tag.stories.tsx
@@ -4,9 +4,9 @@ import type { ComponentMeta } from '@storybook/react'
 import React from 'react'
 import {
 	IconArrowSmDown,
-	IconCaretDown,
+	IconSolidCheveronDown,
 	IconCog,
-	IconCreateFile,
+	IconSolidDocumentAdd,
 } from '../icons'
 import { Box } from '../Box/Box'
 
@@ -38,12 +38,12 @@ export const TagVariants = () => {
 										<Tag
 											icon={
 												jdx % emphasis.length !== 0 ? (
-													<IconCaretDown />
+													<IconSolidCheveronDown />
 												) : null
 											}
 											iconRight={
 												jdx % emphasis.length === 0 ? (
-													<IconCreateFile />
+													<IconSolidDocumentAdd />
 												) : null
 											}
 											size={$size}
@@ -63,7 +63,7 @@ export const TagVariants = () => {
 										size={$size}
 										iconLeft={
 											jdx % emphasis.length !== 0 ? (
-												<IconCaretDown />
+												<IconSolidCheveronDown />
 											) : null
 										}
 										disabled

--- a/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
@@ -6,7 +6,7 @@ import { Box } from '../Box/Box'
 import { Text } from '../Text/Text'
 import { Badge } from '../Badge/Badge'
 import { Tag } from '../Tag/Tag'
-import { IconTrendingUp } from '../icons'
+import { IconSolidTrendingUp } from '../icons'
 
 export default {
 	title: 'Components/Tooltip',
@@ -20,7 +20,7 @@ export const Basic = () => (
 				<Tag
 					kind="secondary"
 					shape="basic"
-					iconLeft={<IconTrendingUp size={12} />}
+					iconLeft={<IconSolidTrendingUp size={12} />}
 				>
 					200%
 				</Tag>


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

#3484 removed some icons we were using in storybook stories.

![Screenshot 2023-01-03 at 10 33 40 AM](https://user-images.githubusercontent.com/58678/210411635-b0cf3acb-291f-4899-82e7-aeb6e17a45d1.png)


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed that each story loads (with the exception of `LinkButton` that is breaking for a separate [issue](https://linear.app/highlight/issue/HIG-3528/fix-linkbutton-story)).

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
