### PR TITLE
support private channel slack integration

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2755,8 +2755,10 @@ func (r *Resolver) GetSlackChannelsFromSlack(workspaceId int) (*[]model.SlackCha
 	getConversationsParam := slack.GetConversationsParameters{
 		Limit: 1000,
 		// public_channel is for public channels in the Slack workspace
+		// private is for private channels in the Slack workspace that the Bot is included in
 		// im is for all individuals in the Slack workspace
-		Types: []string{"public_channel", "im"},
+		// mpim is for multi-person conversations in the Slack workspace that the Bot is included in
+		Types: []string{"public_channel", "private_channel", "mpim", "im"},
 	}
 	allSlackChannelsFromAPI := []slack.Channel{}
 


### PR DESCRIPTION
## Summary

Allow Alerts / Comments to message private / DM conversations that the Highlight bot is added to in Slack.

## How did you test this change?

Local deploy shows private channel that bot was added to.
![image](https://user-images.githubusercontent.com/1351531/210433412-772dc408-0b4e-41ff-993b-c2252c6a6368.png)
![image](https://user-images.githubusercontent.com/1351531/210433242-219ddae9-8107-42c2-9050-1de79912a0f0.png)

## Are there any deployment considerations?

No.
