### PR TITLE
add discord community button

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,7 @@
 		"react-helmet": "^6.1.0",
 		"react-highlight-words": "^0.17.0",
 		"react-hotkeys-hook": "^3.3.1",
-		"react-icons": "^3.11.0",
+		"react-icons": "^4.7.1",
 		"react-infinite-scroll-hook": "^3.0.0",
 		"react-json-view": "^1.21.3",
 		"react-lines-ellipsis": "^0.14.1",

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -29,6 +29,7 @@ import {
 	IconSolidXCircle,
 	LinkButton,
 	Menu,
+	Text,
 } from '@highlight-run/ui'
 import { vars } from '@highlight-run/ui/src/css/vars'
 import SvgHighlightLogoOnLight from '@icons/HighlightLogoOnLight'
@@ -51,6 +52,7 @@ import { showIntercom } from '@util/window'
 import classNames from 'classnames/bind'
 import moment from 'moment'
 import React, { useEffect } from 'react'
+import { FaDiscord } from 'react-icons/fa'
 import { Link, useLocation } from 'react-router-dom'
 import { useSessionStorage } from 'react-use'
 
@@ -296,6 +298,34 @@ export const Header = () => {
 								</Box>
 							)}
 							<Box display="flex" alignItems="center" gap="4">
+								<Button
+									kind="secondary"
+									size="small"
+									emphasis="high"
+									onClick={() => {
+										window.open(
+											'https://discord.gg/yxaXEAqgwN',
+											'_blank',
+										)
+									}}
+									trackingId="DiscordSupportLinkClicked"
+								>
+									<Box
+										display="flex"
+										alignItems="center"
+										as="span"
+										gap="4"
+									>
+										<FaDiscord
+											style={{ height: 14, width: 14 }}
+											color={
+												vars.theme.interactive.fill
+													.secondary.content.text
+											}
+										/>
+										<Text lines="1">Community</Text>
+									</Box>
+								</Button>
 								{inProjectOrWorkspace && <Notifications />}
 								<Menu>
 									<Menu.Button

--- a/yarn.lock
+++ b/yarn.lock
@@ -8031,7 +8031,7 @@ __metadata:
     react-helmet: ^6.1.0
     react-highlight-words: ^0.17.0
     react-hotkeys-hook: ^3.3.1
-    react-icons: ^3.11.0
+    react-icons: ^4.7.1
     react-infinite-scroll-hook: ^3.0.0
     react-json-view: ^1.21.3
     react-lines-ellipsis: ^0.14.1
@@ -36260,23 +36260,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-icons@npm:^3.11.0":
-  version: 3.11.0
-  resolution: "react-icons@npm:3.11.0"
-  dependencies:
-    camelcase: ^5.0.0
-  peerDependencies:
-    react: "*"
-  checksum: 2d45d47387aa85692ee431abe814c3984bc303b0ff25146de86a3cecf7f144c75bc9755df296c626bf133a05622b812fbf95d99776d9a92c7edd90fa7fbbead1
-  languageName: node
-  linkType: hard
-
 "react-icons@npm:^4.2.0":
   version: 4.4.0
   resolution: "react-icons@npm:4.4.0"
   peerDependencies:
     react: "*"
   checksum: dd93a1dcc8ac8a3cf46a2b33e80b586fa967331fa5fcb90d061abf276155a8363a331643e203d67cb9bab4261d00a757da854bcce1fce2c6e4258bf3e33f711b
+  languageName: node
+  linkType: hard
+
+"react-icons@npm:^4.7.1":
+  version: 4.7.1
+  resolution: "react-icons@npm:4.7.1"
+  peerDependencies:
+    react: "*"
+  checksum: ed3cbdc5fc0c4d7d2debf78fdc8c4c80aeacf85a506a9a3c11b1d5922de393ac0a6542012b7fb81761e9280c54d0f26827d50a92b54ec8f0c8e52364d89970b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Add a discord community button per the [Figma](https://www.figma.com/file/pAHlb8IFmVSewPJcphbjIH/Component-Library?node-id=1405%3A12494&t=p2B4uQGVbJGEmu7b-1).
Updated react-icons to get the new discord logo.

## How did you test this change?

Local deploy 
![image](https://user-images.githubusercontent.com/1351531/210685541-e0b1292c-43ca-4b30-86c6-e3c150743cac.png)
Validated that other `react-icons` usage is not affected by the version bump.

## Are there any deployment considerations?

No