### PR TITLE
add analytics calls to session playback

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -49,6 +49,7 @@ import {
 	getAllUrlEvents,
 	getBrowserExtensionScriptURLs,
 } from '@pages/Player/SessionLevelBar/utils/utils'
+import analytics from '@util/analytics'
 import log from '@util/log'
 import { timedCall } from '@util/perf/instrument'
 import { H } from 'highlight.run'
@@ -400,6 +401,12 @@ export const PlayerReducer = (
 							viewed: true,
 						},
 					}).catch(console.error)
+					analytics.track('Viewed session', {
+						project_id: s.project_id,
+						is_guest: !s.isLoggedIn,
+						is_live: s.isLiveMode,
+						secure_id: s.session_secure_id,
+					})
 				}
 				s.sessionViewability = SessionViewability.VIEWABLE
 			} else {


### PR DESCRIPTION
## Summary

Report additional track / mixpanel events from the player to allow tracking when sessions are viewed and played.

## How did you test this change?

Local deploy and preview.

## Are there any deployment considerations?

No.
