### PR TITLE
[HIG-3511] arm64 for all services

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -196,14 +196,6 @@ jobs:
               run: |
                   docker buildx build --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64 -f deploy/Dockerfile.prod.arm64 .
                   docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64
-            - name: Build, tag, and push image to Amazon ECR
-              env:
-                  ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-                  ECR_REPOSITORY: highlight-production-ecr-repo
-                  IMAGE_TAG: ${{ github.sha }}
-              run: |
-                  docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f deploy/Dockerfile.prod .
-                  docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
             # Edit and deploy private-graph
             - name: Replace image label for private-graph task
               id: image-private-graph
@@ -211,7 +203,7 @@ jobs:
               with:
                   task-definition: deploy/private-graph-task.json
                   container-name: highlight-backend
-                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}
+                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
             - name: Deploy to Amazon ECS private-graph service
               uses: aws-actions/amazon-ecs-deploy-task-definition@v1
               with:
@@ -225,7 +217,7 @@ jobs:
               with:
                   task-definition: deploy/public-graph-task.json
                   container-name: highlight-backend
-                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}
+                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
             - name: Deploy to Amazon ECS public-graph service
               uses: aws-actions/amazon-ecs-deploy-task-definition@v1
               with:
@@ -253,7 +245,7 @@ jobs:
               with:
                   task-definition: deploy/metric-monitor-task.json
                   container-name: highlight-backend
-                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}
+                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
             - name: Deploy to Amazon ECS metric monitor service
               uses: aws-actions/amazon-ecs-deploy-task-definition@v1
               with:
@@ -267,7 +259,7 @@ jobs:
               with:
                   task-definition: deploy/public-worker-service.json
                   container-name: highlight-backend
-                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}
+                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
             - name: Deploy to Amazon ECS public worker service
               uses: aws-actions/amazon-ecs-deploy-task-definition@v1
               with:

--- a/deploy/metric-monitor-task.json
+++ b/deploy/metric-monitor-task.json
@@ -292,5 +292,6 @@
 	"status": "ACTIVE",
 	"inferenceAccelerators": null,
 	"proxyConfiguration": null,
-	"volumes": []
+	"volumes": [],
+	"runtimePlatform": { "cpuArchitecture": "ARM64" }
 }

--- a/deploy/private-graph-task.json
+++ b/deploy/private-graph-task.json
@@ -281,5 +281,6 @@
 	"status": "ACTIVE",
 	"inferenceAccelerators": null,
 	"proxyConfiguration": null,
-	"volumes": []
+	"volumes": [],
+	"runtimePlatform": { "cpuArchitecture": "ARM64" }
 }

--- a/deploy/public-graph-task.json
+++ b/deploy/public-graph-task.json
@@ -281,5 +281,6 @@
 	"status": "ACTIVE",
 	"inferenceAccelerators": null,
 	"proxyConfiguration": null,
-	"volumes": []
+	"volumes": [],
+	"runtimePlatform": { "cpuArchitecture": "ARM64" }
 }

--- a/deploy/public-worker-service.json
+++ b/deploy/public-worker-service.json
@@ -292,5 +292,6 @@
 	"status": "ACTIVE",
 	"inferenceAccelerators": null,
 	"proxyConfiguration": null,
-	"volumes": []
+	"volumes": [],
+	"runtimePlatform": { "cpuArchitecture": "ARM64" }
 }


### PR DESCRIPTION
## Summary
- looks like the worker service is working fine on arm64, do the switch for all other services
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- did a manual deployment of `public graph` in a separate service and validated it started up successfully, but no traffic was routed to it because it was not in the public graph load balancer target group
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- if something is failing after deployment, may take ~20 mins to revert code
- if public graph is down, will revert to previous task definition through ECS console to speed it up
- will wait until after hours PST to minimize impact
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
