### PR TITLE
some polish work for error distributions

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
@@ -38,7 +38,7 @@ const ErrorDistributions = ({ errorGroup }: Props) => {
 		})
 
 		if (foundEnvironmentTag) {
-			setEnvironments(foundEnvironmentTag as ErrorGroupTagAggregation)
+			setEnvironments(foundEnvironmentTag)
 		}
 
 		const foundBrowserTag = data?.errorGroupTags.find((tag) => {
@@ -46,7 +46,7 @@ const ErrorDistributions = ({ errorGroup }: Props) => {
 		})
 
 		if (foundBrowserTag) {
-			setBrowsers(foundBrowserTag as ErrorGroupTagAggregation)
+			setBrowsers(foundBrowserTag)
 		}
 
 		const foundOperatingSytemTag = data?.errorGroupTags.find((tag) => {
@@ -54,9 +54,7 @@ const ErrorDistributions = ({ errorGroup }: Props) => {
 		})
 
 		if (foundOperatingSytemTag) {
-			setOperatingSystems(
-				foundOperatingSytemTag as ErrorGroupTagAggregation,
-			)
+			setOperatingSystems(foundOperatingSytemTag)
 		}
 	}, [data?.errorGroupTags])
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

The metrics distribution section doesn't look very good with production data. Specifically, each distribution will have a large bucket that will outweigh the other buckets. As an example, Chrome has most the market share so it'll almost always be the top Browser (similarly, production is the dominate environment and Mac OS X is the dominate operating system).

Out existing design chooses a 3 column layout:

`progress_bar | percentage | count`

but when `count` is exceedingly big compared to the other items (as is usually the case), a 3 column layout will never align nicely. 

To compensate for this, I've chosen the following
* Omit the count, and just use the percentage built-in from antd's [<Progress />](https://ant.design/components/progress) component. This ensures we get perfect alignment regardless of the dataset.
* Keep the metric distributions for all time (instead of figma's [last 30 days](https://www.figma.com/file/rdBPNzn7Klk6RG1LHUCE5B/Screen-Designs?t=ltoVrijMlq91RItt-0)). If we choose last 30 days, it's possible we will have empty data sets (e.g. the error last happened > 30 days ago). We don't have any mocks for empty data so I chose to keep the all time timeframe to prevent this edge case.

Additionally, I've fixed some vertical alignment issues and added a much needed loading state.

The only thing I think we should still address after this PR is the color contrast on the progress bars. I'm not sure why we decided to switch from purple -> grey for the bar color but there doesn't seem to be an easy way to match the figma's [design](https://www.figma.com/file/rdBPNzn7Klk6RG1LHUCE5B/Screen-Designs?node-id=4622%3A200060&t=ltoVrijMlq91RItt-0) for the antd `<Progress />` component (the stroke outline of the unfilled space is the challenge). If the contrast is too poor, I would suggest that we switch back to purple since it would take some time to roll our own horizontal bars in time for our launch date. 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Before:
![Screenshot 2023-01-06 at 9 04 39 AM](https://user-images.githubusercontent.com/58678/211050471-f7146d4c-a06a-4871-a3b1-48084be03d2a.png)


After:
![Screenshot 2023-01-06 at 9 04 19 AM](https://user-images.githubusercontent.com/58678/211050435-be296cf3-0d2b-43b9-a0d9-65d9a1408443.png)


Loading state:
![Screenshot 2023-01-06 at 9 05 08 AM](https://user-images.githubusercontent.com/58678/211050613-0794827f-c984-4b43-b6cc-e1e7d428961d.png)



## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A