### PR TITLE
skip invoking onboarding query if admin id is not present

### DIFF
--- a/frontend/src/components/OnboardingBubble/OnboardingBubble.tsx
+++ b/frontend/src/components/OnboardingBubble/OnboardingBubble.tsx
@@ -60,12 +60,13 @@ const OnboardingBubble = () => {
 		useGetOnboardingStepsQuery({
 			variables: {
 				project_id,
-				admin_id: (admin_data?.admin?.id as string) || '',
+				admin_id: admin_data?.admin?.id as string,
 			},
 			fetchPolicy: 'network-only',
 			skip:
 				temporarilyHideOnboardingBubble ||
-				permanentlyHideOnboardingBubble,
+				permanentlyHideOnboardingBubble ||
+				!admin_data?.admin?.id,
 		})
 
 	useEffect(() => {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

See [HIG-3569](https://linear.app/highlight/issue/HIG-3569/fix-input-adminhascreatedcommentadmin-id-strconvatoi-parsing) and the error on [prod](https://app.datadoghq.com/apm/services/private-graph-service/operations/graphql.operation/resources?env=none&resources=qson%3A%28data%3A%28visible%3A%21t%2Chits%3A%28selected%3Atotal%29%2Cerrors%3A%28selected%3Atotal%29%2Clatency%3A%28selected%3Ap99%29%2CtopN%3A%215%2Csearch%3AGetOnboarding%2CselectedResourceID%3A43a8964d48dfd0b5%29%2Cversion%3A%210%29&spanID=1152952465767367193&summary=qson%3A%28data%3A%28visible%3A%21t%2Cerrors%3A%28selected%3Acount%29%2Chits%3A%28selected%3Acount%29%2Clatency%3A%28selected%3Alatency%2Cslot%3A%28agg%3A75%29%2Cdistribution%3A%28isLogScale%3A%21f%29%29%2Csublayer%3A%28slot%3A%28layers%3Aservice%29%2Cselected%3Apercentage%29%29%2Cversion%3A%211%29&timeHint=1673282484029&topGraphs=latency%3Alatency%2Cerrors%3Aversion_count%2Chits%3Aversion_count&trace=AgAAAYWXaHc9W6xNHgAAAAAAAAAYAAAAAEFZV1hhSVh1QUFBMjlnc0ZtV0ViaUFBUQAAACQAAAAAMDE4NTk3NmMtZGY2Yy00NTliLWEwOWItZWVlOTk4ZmU1Mjgy&traceID=1152952465767367193&start=1673279178011&end=1673282778011&paused=true).

It looks like the first call to `GetOnboardingSteps` always fails because we have an async request to fetch the admin id that's not ready yet:

https://github.com/highlight-run/highlight/blob/7b4ff3254891ed18cc63e041e9de278ea4f67bfa/frontend/src/components/OnboardingBubble/OnboardingBubble.tsx#L58-L63



## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->


Confirmed that `GetOnboardingSteps` does not fail.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
