### PR TITLE
Show custom properties on error instances

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -296,7 +296,7 @@ const Metadata: React.FC<{
 		{
 			key: 'Custom Properties',
 			label: customProperties ? (
-				<JsonViewer src={customProperties} />
+				<JsonViewer src={customProperties} name="Custom Properties" />
 			) : undefined,
 		},
 	].filter((t) => Boolean(t.label))
@@ -331,15 +331,21 @@ const Metadata: React.FC<{
 						<Box
 							cursor="pointer"
 							py="10"
-							onClick={() =>
-								meta.label && copyToClipboard(meta.label)
-							}
+							onClick={() => {
+								if (typeof meta.label === 'string') {
+									meta.label && copyToClipboard(meta.label)
+								}
+							}}
 							style={{ width: '67%' }}
 						>
 							<Text
 								align="left"
 								break="word"
-								lines="4"
+								lines={
+									typeof meta.label === 'string'
+										? '4'
+										: undefined
+								}
 								title={String(meta.label)}
 							>
 								{meta.label}


### PR DESCRIPTION
## Summary

Adds custom properties on errors to the error instance details. Since it's an unknown shape, we render it in `JsonViewer`.

https://www.loom.com/share/4f1eaf63a88d4dbf8dbc8a3113760511

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A - UI only