### PR TITLE
show console.error data in the error view

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -121,11 +121,6 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 		})
 	}
 
-	let errorGroupEvent
-	if (errorGroup?.type === 'console.error' && errorGroup.event.length > 1) {
-		errorGroupEvent = errorGroup.event
-	}
-
 	if (!errorInstance || !errorInstance?.error_object) {
 		if (!loading) return null
 
@@ -304,17 +299,18 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 				</div>
 			</Box>
 
-			{errorGroupEvent && (
-				<>
-					<Text size="large" weight="bold">
-						Error event data
-					</Text>
+			{errorGroup?.type === 'console.error' &&
+				errorGroup.event.length > 1 && (
+					<>
+						<Text size="large" weight="bold">
+							Error event data
+						</Text>
 
-					<Box bt="secondary" my="12" py="16">
-						<JsonViewer src={errorGroupEvent} collapsed={1} />
-					</Box>
-				</>
-			)}
+						<Box bt="secondary" my="12" py="16">
+							<JsonViewer src={errorGroup.event} collapsed={1} />
+						</Box>
+					</>
+				)}
 
 			<Text size="large" weight="bold">
 				Stack trace


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

`console.error` errors are missing context when doing something like 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

We [disable console recording](https://github.com/highlight-run/highlight-javascript/blame/master/client/src/listeners/first-load-listeners.tsx#L42-L46) in development. So I commenting out this [check](https://github.com/highlight-run/highlight-javascript/blame/master/client/src/listeners/first-load-listeners.tsx#L45) and this [monkeypatch](https://github.com/highlight-run/highlight-javascript/blame/master/client/src/listeners/console-listener.tsx#L125).

Then I emitted `console.error("yo", new Error('error1'), new Error('error2'))` in the browser console to create this type of error.

* Visual test to see the new Error event data section if this is a `console.error` error:

![Screenshot 2023-01-09 at 1 52 16 PM](https://user-images.githubusercontent.com/58678/211405919-6d17f247-3620-4579-8ebd-e9d6f5ffda8b.png)


* Confirmed that this section is not present for other error types



## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
