### PR TITLE
[HIG-3574] fix quota check for free tier

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1817,11 +1817,10 @@ func (r *Resolver) isWithinBillingQuota(project *model.Project, workspace *model
 	}
 
 	var quota int
-	var stripePlan privateModel.PlanType
+	stripePlan := privateModel.PlanType(workspace.PlanTier)
 	if workspace.MonthlySessionLimit != nil && *workspace.MonthlySessionLimit > 0 {
 		quota = *workspace.MonthlySessionLimit
 	} else {
-		stripePlan := privateModel.PlanType(workspace.PlanTier)
 		quota = pricing.TypeToQuota(stripePlan)
 	}
 


### PR DESCRIPTION
## Summary
- `stripePlan` was shadowed inside the else block
- remove `UpdateSessionsVisibility` logic since we won't have data for those sessions anymore
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested free tier locally, validated that new sessions over the quota were marked as `within_billing_quota = false`
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
