### PR TITLE
use correct client for deletes

### DIFF
--- a/backend/lambda-functions/deleteSessions/handlers/handlers.go
+++ b/backend/lambda-functions/deleteSessions/handlers/handlers.go
@@ -171,7 +171,7 @@ func (h *handlers) DeleteSessionBatchFromS3(ctx context.Context, event utils.Bat
 				Key:    object.Key,
 			}
 			if !event.DryRun {
-				_, err := h.s3Client.DeleteObject(ctx, &options)
+				_, err := client.DeleteObject(ctx, &options)
 				if err != nil {
 					return nil, errors.Wrap(err, "error deleting objects from S3")
 				}


### PR DESCRIPTION
## Summary
- was using the old `us-west-2` client for this call
- `client` is a `us-west-2` or `us-east-2` client depending on the session id
- causing this error in prod: `operation error S3: DeleteObject, https response error StatusCode: 301`
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will watch for step function errors in future
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
