### PR TITLE
clean up the layout on the error distributions section

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
@@ -1,11 +1,12 @@
 import { CircularSpinner } from '@components/Loading/Loading'
+import { getPercentageDisplayValue } from '@components/ProgressBarTable/utils/utils'
 import { useGetErrorGroupTagsQuery } from '@graph/hooks'
 import { GetErrorGroupQuery } from '@graph/operations'
 import {
 	ErrorGroupTagAggregation,
 	ErrorGroupTagAggregationBucket,
 } from '@graph/schemas'
-import { Box, Stack, Text } from '@highlight-run/ui'
+import { Badge, Box, Stack, Text } from '@highlight-run/ui'
 import { colors } from '@highlight-run/ui/src/css/colors'
 import { Progress } from 'antd'
 import React, { useEffect, useState } from 'react'
@@ -127,14 +128,35 @@ const Buckets: React.FC<
 	}>
 > = ({ buckets }) => {
 	return (
-		<Box display="flex" flexDirection="column" gap="12">
+		<Box display="flex" flexDirection="column" gap="8">
 			{buckets.map((bucket) => {
 				return (
 					<Box key={bucket.key}>
-						<Text>{bucket.key}</Text>
+						<Box
+							display="flex"
+							justifyContent="space-between"
+							alignItems="center"
+						>
+							<Text>{bucket.key}</Text>
+							<Box display="flex" gap="4" alignItems="center">
+								<Badge
+									variant="grey"
+									size="tiny"
+									label={getPercentageDisplayValue(
+										bucket.percent,
+									)}
+								/>
+								<Text weight="bold" as="span">
+									{bucket.doc_count}
+								</Text>
+							</Box>
+						</Box>
 						<Progress
 							percent={Math.floor(bucket.percent * 100)}
+							showInfo={false}
 							strokeColor={colors.n8}
+							trailColor={colors.n4}
+							strokeWidth={4}
 							status="normal"
 						/>
 					</Box>


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR tightens up the layout on the error distributions section per Julian's feedback.


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Visual test

| before | after |
| ------ | ----- |
| ![Screenshot 2023-01-11 at 11 41 23 AM](https://user-images.githubusercontent.com/58678/211890979-2f899ed5-3ba7-4298-937f-0db31ba07531.png) |![Screenshot 2023-01-11 at 11 41 08 AM](https://user-images.githubusercontent.com/58678/211891064-61509dcb-4cd9-4337-911d-1c43565937ba.png) |




## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A