### PR TITLE
fix(HIG-3613): force a manual shard refresh on synchronous update in opensearch

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorStateSelect/ErrorStateSelect.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStateSelect/ErrorStateSelect.tsx
@@ -45,13 +45,13 @@ export const ErrorStateSelect: React.FC<{
 				namedOperations.Query.GetErrorGroup,
 				namedOperations.Query.GetErrorGroupsOpenSearch,
 			],
-			onQueryUpdated: async (obs) => {
-				await wait(500)
+			onQueryUpdated: async (observable) => {
 				await indexeddbCache.deleteItem({
-					operation: obs.queryName ?? '',
-					variables: obs.variables,
+					operation: observable.queryName ?? '',
+					variables: observable.variables,
 				})
-				await obs.refetch()
+				await wait(500)
+				await observable.refetch()
 			},
 			awaitRefetchQueries: true,
 		})


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

At the moment changes do not propagate in time to all replicas. This PR adds changes that forces shards to update. 

[Docs](https://opensearch.ossez.com/opensearch/rest-api/document-apis/update-document/):

<img width="683" alt="Screenshot 2023-01-13 at 8 49 28 AM" src="https://user-images.githubusercontent.com/17913919/212374453-9870e697-cd87-420a-b72e-816140caf620.png">


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

local instance

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no