### PR TITLE
set AvoidPostgresStorage = true

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1193,7 +1193,7 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 		ClientID:                       input.ClientID,
 		Excluded:                       &model.T, // A session is excluded by default until it receives events
 		ProcessWithRedis:               true,
-		AvoidPostgresStorage:           false,
+		AvoidPostgresStorage:           true,
 	}
 
 	// determine if session is within billing quota


### PR DESCRIPTION
## Summary
- code is deployed now, set this flag to start processing resources / messages with Redis
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- already tested new code path previously
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- nope, can revert
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
