### PR TITLE
handle when clickup is not attached to a project

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5513,6 +5513,21 @@ func (r *queryResolver) IsProjectIntegratedWith(ctx context.Context, integration
 		return false, e.Wrap(err, "error querying project")
 	}
 
+	if integrationType == modelInputs.IntegrationTypeClickUp {
+		var projectMapping *model.IntegrationProjectMapping
+		if err := r.DB.Where(&model.IntegrationProjectMapping{
+			ProjectID:       project.ID,
+			IntegrationType: integrationType,
+		}).First(&projectMapping).Error; err != nil {
+			return false, nil
+		}
+
+		if projectMapping == nil {
+			return false, nil
+		}
+
+	}
+
 	return r.IntegrationsClient.IsProjectIntegrated(ctx, project, integrationType)
 }
 

--- a/frontend/src/components/Comment/SessionComment/SessionCommentHeader.tsx
+++ b/frontend/src/components/Comment/SessionComment/SessionCommentHeader.tsx
@@ -11,7 +11,6 @@ import SvgCopyIcon from '@icons/CopyIcon'
 import SvgFileText2Icon from '@icons/FileText2Icon'
 import SvgReferrer from '@icons/Referrer'
 import SvgTrashIcon from '@icons/TrashIcon'
-import { useClickUpIntegration } from '@pages/IntegrationsPage/components/ClickUpIntegration/utils'
 import { useIsProjectIntegratedWith } from '@pages/IntegrationsPage/components/common/useIsProjectIntegratedWith'
 import { useLinearIntegration } from '@pages/IntegrationsPage/components/LinearIntegration/utils'
 import {
@@ -60,12 +59,9 @@ const SessionCommentHeader = ({
 
 	const { isLinearIntegratedWithProject, loading: isLoadingLinear } =
 		useLinearIntegration()
-	const {
-		settings: {
-			isIntegrated: isClickupIntegrated,
-			loading: isLoadingClickUp,
-		},
-	} = useClickUpIntegration()
+
+	const { isIntegrated: isClickupIntegrated, loading: isLoadingClickUp } =
+		useIsProjectIntegratedWith(IntegrationType.ClickUp)
 
 	const { isIntegrated: isHeightIntegrated, loading: isLoadingHeight } =
 		useIsProjectIntegratedWith(IntegrationType.Height)

--- a/frontend/src/pages/Error/components/ErrorComments/ErrorComments.tsx
+++ b/frontend/src/pages/Error/components/ErrorComments/ErrorComments.tsx
@@ -12,7 +12,6 @@ import { ErrorComment, IntegrationType, Maybe } from '@graph/schemas'
 import SvgFileText2Icon from '@icons/FileText2Icon'
 import SvgTrashIcon from '@icons/TrashIcon'
 import { ErrorCommentButton } from '@pages/Error/components/ErrorComments/ErrorCommentButton/ErrorCommentButton'
-import { useClickUpIntegration } from '@pages/IntegrationsPage/components/ClickUpIntegration/utils'
 import { useIsProjectIntegratedWith } from '@pages/IntegrationsPage/components/common/useIsProjectIntegratedWith'
 import { useLinearIntegration } from '@pages/IntegrationsPage/components/LinearIntegration/utils'
 import {
@@ -109,9 +108,10 @@ const ErrorCommentHeader = ({ comment, children, errorGroup }: any) => {
 	}, [errorGroup])
 
 	const { isLinearIntegratedWithProject } = useLinearIntegration()
-	const {
-		settings: { isIntegrated: isClickupIntegrated },
-	} = useClickUpIntegration()
+	const { isIntegrated: isClickupIntegrated } = useIsProjectIntegratedWith(
+		IntegrationType.ClickUp,
+	)
+	debugger
 	const { isIntegrated: isHeightIntegrated } = useIsProjectIntegratedWith(
 		IntegrationType.Height,
 	)

--- a/frontend/src/pages/ErrorsV2/ErrorIssueButton/ErrorIssueButton.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorIssueButton/ErrorIssueButton.tsx
@@ -18,7 +18,6 @@ import {
 } from '@highlight-run/ui'
 import { Box, Menu, Text } from '@highlight-run/ui'
 import { useProjectId } from '@hooks/useProjectId'
-import { useClickUpIntegration } from '@pages/IntegrationsPage/components/ClickUpIntegration/utils'
 import { useIsProjectIntegratedWith } from '@pages/IntegrationsPage/components/common/useIsProjectIntegratedWith'
 import { useLinearIntegration } from '@pages/IntegrationsPage/components/LinearIntegration/utils'
 import {
@@ -43,12 +42,9 @@ const ErrorIssueButton = ({ errorGroup }: Props) => {
 
 	const { isLinearIntegratedWithProject, loading: isLoadingLinear } =
 		useLinearIntegration()
-	const {
-		settings: {
-			isIntegrated: isClickupIntegrated,
-			loading: isLoadingClickUp,
-		},
-	} = useClickUpIntegration()
+
+	const { isIntegrated: isClickupIntegrated, loading: isLoadingClickUp } =
+		useIsProjectIntegratedWith(IntegrationType.ClickUp)
 
 	const { isIntegrated: isHeightIntegrated, loading: isLoadingHeight } =
 		useIsProjectIntegratedWith(IntegrationType.Height)

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
@@ -26,7 +26,6 @@ import {
 } from '@graph/schemas'
 import ArrowLeftIcon from '@icons/ArrowLeftIcon'
 import ArrowRightIcon from '@icons/ArrowRightIcon'
-import { useClickUpIntegration } from '@pages/IntegrationsPage/components/ClickUpIntegration/utils'
 import { useIsProjectIntegratedWith } from '@pages/IntegrationsPage/components/common/useIsProjectIntegratedWith'
 import { useLinearIntegration } from '@pages/IntegrationsPage/components/LinearIntegration/utils'
 import ISSUE_TRACKER_INTEGRATIONS, {
@@ -392,9 +391,9 @@ export const NewCommentForm = ({
 
 	const { isLinearIntegratedWithProject } = useLinearIntegration()
 
-	const {
-		settings: { isIntegrated: isClickupIntegrated },
-	} = useClickUpIntegration()
+	const { isIntegrated: isClickupIntegrated } = useIsProjectIntegratedWith(
+		IntegrationType.ClickUp,
+	)
 
 	const { isIntegrated: isHeightIntegrated } = useIsProjectIntegratedWith(
 		IntegrationType.Height,


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Similar to #3511, we are currently checking to see if clickup is integrated at the workspace level when we should be checking at the project level.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Integrate with Clickup
* Do not link a Clickup workspace with a Highlight project
* Confirm that Clickup is not a selectable option when creating a session comment or an error issue.


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
