### PR TITLE
handle race condition when updating asset metadata

### DIFF
--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -21,6 +21,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/tdewolff/parse/css"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type EventType int
@@ -332,7 +333,7 @@ func getOrCreateUrls(projectId int, originalUrls []string, s *storage.StorageCli
 		}
 
 		if len(newResults) != 0 {
-			if err := db.Create(&newResults).Error; err != nil {
+			if err := db.Clauses(clause.OnConflict{DoNothing: true}).Create(&newResults).Error; err != nil {
 				return nil, errors.Wrap(err, "error saving asset metadata")
 			}
 		}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We are getting race conditions when updating saved assets ([logs](https://app.datadoghq.com/logs?query=error%20replacing%20assets&cols=host%2Cservice&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1673045216197&to_ts=1673304416197&live=true)).

Per Zane, this happens when:
![Screenshot 2023-01-17 at 11 16 12 AM](https://user-images.githubusercontent.com/58678/212979133-c9b0acf3-7779-48b6-ba67-a3585b1e9469.png)


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

This is pretty tricky to replicate. We should monitor datadog to see the error logs stop.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A