### PR TITLE
indexeddb should always make requests that update data

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -30,7 +30,7 @@ import {
 	SessionViewability,
 } from '@pages/Player/PlayerHook/PlayerState'
 import analytics from '@util/analytics'
-import { indexedDBFetch } from '@util/db'
+import { indexedDBFetch, indexedDBString } from '@util/db'
 import log from '@util/log'
 import { useParams } from '@util/react-router/useParams'
 import { timerEnd, timerStart } from '@util/timer/timer'
@@ -71,10 +71,34 @@ export const usePlayer = (): ReplayerContextInterface => {
 	} = usePlayerConfiguration()
 
 	const [markSessionAsViewed] = useMarkSessionAsViewedMutation()
-	const { refetch: fetchEventChunkURL } = useGetEventChunkUrlQuery({
+	const { refetch: rawFetchEventChunkURL } = useGetEventChunkUrlQuery({
 		fetchPolicy: 'no-cache',
 		skip: true,
 	})
+	const fetchEventChunkURL = useCallback(
+		async function ({
+			secure_id,
+			index,
+		}: {
+			secure_id: string
+			index: number
+		}) {
+			const args = {
+				secure_id,
+				index,
+			}
+			let result = ''
+			for await (const url of indexedDBString({
+				key: JSON.stringify(args),
+				fn: async () =>
+					(await rawFetchEventChunkURL(args)).data.event_chunk_url,
+			})) {
+				result = url
+			}
+			return result
+		},
+		[rawFetchEventChunkURL],
+	)
 	const { data: sessionIntervals } = useGetSessionIntervalsQuery({
 		variables: {
 			session_secure_id: session_secure_id,
@@ -337,13 +361,19 @@ export const usePlayer = (): ReplayerContextInterface => {
 					promises.push(
 						(async (_i: number) => {
 							try {
-								const response = await fetchEventChunkURL({
+								const url = await fetchEventChunkURL({
 									secure_id: session_secure_id,
 									index: _i,
 								})
-								for await (const chunkResponse of await indexedDBFetch(
-									response.data.event_chunk_url,
+								log('PlayerHook.tsx', 'loading chunk', {
+									url,
+								})
+								for await (const chunkResponse of indexedDBFetch(
+									url,
 								)) {
+									log('PlayerHook.tsx', 'chunk data', {
+										chunkResponse,
+									})
 									chunkEventsSet(
 										_i,
 										toHighlightEvents(

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -341,20 +341,21 @@ export const usePlayer = (): ReplayerContextInterface => {
 									secure_id: session_secure_id,
 									index: _i,
 								})
-								const chunkResponse = await indexedDBFetch(
+								for await (const chunkResponse of await indexedDBFetch(
 									response.data.event_chunk_url,
-								)
-								chunkEventsSet(
-									_i,
-									toHighlightEvents(
-										await chunkResponse.json(),
-									),
-								)
-								log(
-									'PlayerHook.tsx:ensureChunksLoaded',
-									'set data for chunk',
-									_i,
-								)
+								)) {
+									chunkEventsSet(
+										_i,
+										toHighlightEvents(
+											await chunkResponse.json(),
+										),
+									)
+									log(
+										'PlayerHook.tsx:ensureChunksLoaded',
+										'set data for chunk',
+										_i,
+									)
+								}
 							} catch (e: any) {
 								H.consumeError(
 									e,

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -1,7 +1,5 @@
-import { ApolloQueryResult } from '@apollo/client'
 import { MarkSessionAsViewedMutationFn } from '@graph/hooks'
 import {
-	GetEventChunkUrlQuery,
 	GetSessionIntervalsQuery,
 	GetSessionPayloadQuery,
 	GetSessionQuery,
@@ -9,7 +7,6 @@ import {
 } from '@graph/operations'
 import {
 	ErrorObject,
-	Exact,
 	Session,
 	SessionComment,
 	SessionResults,
@@ -77,11 +74,10 @@ export enum SessionViewability {
 	ERROR,
 }
 
-type FetchEventChunkURLFn = (
-	variables?:
-		| Partial<Exact<{ secure_id: string; index: number }>>
-		| undefined,
-) => Promise<ApolloQueryResult<GetEventChunkUrlQuery>>
+type FetchEventChunkURLFn = ({}: {
+	secure_id: string
+	index: number
+}) => Promise<string>
 
 interface PlayerState {
 	browserExtensionScriptURLs: string[]

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -94,35 +94,38 @@ export const useResources = (
 			!!session?.resources_url
 		) {
 			setResourcesLoading(true)
-			indexedDBFetch(session.resources_url)
-				.then((response) => response.json())
-				.then((data) => {
-					setResources(
-						(
-							(data as any[] | undefined)?.map((r, i) => {
-								return { ...r, id: i }
-							}) ?? []
-						)
-							.sort((a, b) => a.startTime - b.startTime)
-							.map((resource) => {
-								const resolverName =
-									getGraphQLResolverName(resource)
+			const processUpdate = (p: Promise<IteratorResult<Response>>) =>
+				p
+					.then((response) => response.value.json())
+					.then((data) => {
+						setResources(
+							(
+								(data as any[] | undefined)?.map((r, i) => {
+									return { ...r, id: i }
+								}) ?? []
+							)
+								.sort((a, b) => a.startTime - b.startTime)
+								.map((resource) => {
+									const resolverName =
+										getGraphQLResolverName(resource)
 
-								if (resolverName) {
-									return {
-										...resource,
-										displayName: `${resolverName} (${resource.name})`,
+									if (resolverName) {
+										return {
+											...resource,
+											displayName: `${resolverName} (${resource.name})`,
+										}
 									}
-								}
-								return resource
-							}),
-					)
-				})
-				.catch((e) => {
-					setResources([])
-					H.consumeError(e, 'Error direct downloading resources')
-				})
-				.finally(() => setResourcesLoading(false))
+									return resource
+								}),
+						)
+					})
+					.catch((e) => {
+						setResources([])
+						H.consumeError(e, 'Error direct downloading resources')
+					})
+					.finally(() => setResourcesLoading(false))
+			const req = indexedDBFetch(session.resources_url)
+			processUpdate(req.next()).then(() => processUpdate(req.next()))
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [sessionSecureId, session?.secure_id])

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -22,199 +22,194 @@ interface ParsedMessage extends ConsoleMessage {
 	id: number
 }
 
-export const ConsolePage = React.memo(
-	({
-		autoScroll,
-		filter,
-		logLevel,
-		time,
-	}: {
-		autoScroll: boolean
-		filter: string
-		logLevel: LogLevel
-		time: number
-	}) => {
-		const [currentMessage, setCurrentMessage] = useState(-1)
-		const { session, setTime, sessionMetadata } = useReplayerContext()
-		const [parsedMessages, setParsedMessages] = useState<
-			undefined | Array<ParsedMessage>
-		>([])
-		const { session_secure_id } = useParams<{ session_secure_id: string }>()
-		const [loading, setLoading] = useState(true)
-		const skipQuery = session === undefined || !!session?.messages_url
-		const { data, loading: queryLoading } = useGetMessagesQuery({
-			variables: {
-				session_secure_id,
-			},
-			fetchPolicy: 'no-cache',
-			skip: skipQuery, // Skip if there is a URL to fetch messages
+export const ConsolePage = ({
+	autoScroll,
+	filter,
+	logLevel,
+	time,
+}: {
+	autoScroll: boolean
+	filter: string
+	logLevel: LogLevel
+	time: number
+}) => {
+	const [currentMessage, setCurrentMessage] = useState(-1)
+	const { session, setTime, sessionMetadata } = useReplayerContext()
+	const [parsedMessages, setParsedMessages] = useState<
+		undefined | Array<ParsedMessage>
+	>([])
+	const { session_secure_id } = useParams<{ session_secure_id: string }>()
+	const [loading, setLoading] = useState(true)
+	const skipQuery = session === undefined || !!session?.messages_url
+	const { data, loading: queryLoading } = useGetMessagesQuery({
+		variables: {
+			session_secure_id,
+		},
+		fetchPolicy: 'no-cache',
+		skip: skipQuery, // Skip if there is a URL to fetch messages
+	})
+
+	useEffect(() => {
+		if (!skipQuery) {
+			setLoading(queryLoading)
+		}
+	}, [queryLoading, skipQuery])
+
+	// If sessionSecureId is set and equals the current session's (ensures effect is run once)
+	// and resources url is defined, fetch using resources url
+	useEffect(() => {
+		if (
+			session_secure_id === session?.secure_id &&
+			!!session?.messages_url
+		) {
+			setLoading(true)
+			const processUpdate = (p: Promise<IteratorResult<Response>>) =>
+				p
+					.then((result) => result.value.json())
+					.then((data) => {
+						setParsedMessages(
+							(data as any[] | undefined)?.map(
+								(m: ConsoleMessage, i) => {
+									return {
+										...m,
+										id: i,
+									}
+								},
+							) ?? [],
+						)
+					})
+					.catch((e) => {
+						setParsedMessages([])
+						H.consumeError(e, 'Error direct downloading resources')
+					})
+					.finally(() => setLoading(false))
+			const req = indexedDBFetch(session.messages_url)
+			processUpdate(req.next()).then(() => processUpdate(req.next()))
+		}
+	}, [session?.messages_url, session?.secure_id, session_secure_id])
+
+	useEffect(() => {
+		setParsedMessages(
+			data?.messages?.map((m: ConsoleMessage, i) => {
+				return {
+					...m,
+					id: i,
+				}
+			}) ?? [],
+		)
+	}, [data?.messages])
+
+	// Logic for scrolling to current entry.
+	useEffect(() => {
+		if (parsedMessages?.length) {
+			let msgIndex = 0
+			let msgDiff: number = Number.MAX_VALUE
+			for (let i = 0; i < parsedMessages.length; i++) {
+				const currentDiff: number =
+					time - (parsedMessages[i].time - parsedMessages[0].time)
+				if (currentDiff < 0) break
+				if (currentDiff < msgDiff) {
+					msgIndex = i
+					msgDiff = currentDiff
+				}
+			}
+			setCurrentMessage(msgIndex)
+		}
+	}, [time, parsedMessages])
+
+	const messagesToRender = useMemo(() => {
+		const currentMessages = parsedMessages?.filter((m) => {
+			// if the console type is 'all', let all messages through. otherwise, filter.
+			if (logLevel === LogLevel.All) {
+				return true
+			} else if (m.type === logLevel.toLowerCase()) {
+				return true
+			}
+			return false
 		})
 
-		useEffect(() => {
-			if (!skipQuery) {
-				setLoading(queryLoading)
-			}
-		}, [queryLoading, skipQuery])
+		if (!currentMessages) {
+			return []
+		}
 
-		// If sessionSecureId is set and equals the current session's (ensures effect is run once)
-		// and resources url is defined, fetch using resources url
-		useEffect(() => {
-			if (
-				session_secure_id === session?.secure_id &&
-				!!session?.messages_url
-			) {
-				setLoading(true)
-				const processUpdate = (p: Promise<IteratorResult<Response>>) =>
-					p
-						.then((result) => result.value.json())
-						.then((data) => {
-							setParsedMessages(
-								(data as any[] | undefined)?.map(
-									(m: ConsoleMessage, i) => {
-										return {
-											...m,
-											id: i,
-										}
-									},
-								) ?? [],
-							)
-						})
-						.catch((e) => {
-							setParsedMessages([])
-							H.consumeError(
-								e,
-								'Error direct downloading resources',
-							)
-						})
-						.finally(() => setLoading(false))
-				const req = indexedDBFetch(session.messages_url)
-				processUpdate(req.next()).then(() => processUpdate(req.next()))
-			}
-		}, [session?.messages_url, session?.secure_id, session_secure_id])
-
-		useEffect(() => {
-			setParsedMessages(
-				data?.messages?.map((m: ConsoleMessage, i) => {
-					return {
-						...m,
-						id: i,
-					}
-				}) ?? [],
-			)
-		}, [data?.messages])
-
-		// Logic for scrolling to current entry.
-		useEffect(() => {
-			if (parsedMessages?.length) {
-				let msgIndex = 0
-				let msgDiff: number = Number.MAX_VALUE
-				for (let i = 0; i < parsedMessages.length; i++) {
-					const currentDiff: number =
-						time - (parsedMessages[i].time - parsedMessages[0].time)
-					if (currentDiff < 0) break
-					if (currentDiff < msgDiff) {
-						msgIndex = i
-						msgDiff = currentDiff
-					}
+		if (filter !== '') {
+			return currentMessages.filter((message) => {
+				if (!message.value) {
+					return false
 				}
-				setCurrentMessage(msgIndex)
-			}
-		}, [time, parsedMessages])
 
-		const messagesToRender = useMemo(() => {
-			const currentMessages = parsedMessages?.filter((m) => {
-				// if the console type is 'all', let all messages through. otherwise, filter.
-				if (logLevel === LogLevel.All) {
-					return true
-				} else if (m.type === logLevel.toLowerCase()) {
-					return true
-				}
-				return false
-			})
-
-			if (!currentMessages) {
-				return []
-			}
-
-			if (filter !== '') {
-				return currentMessages.filter((message) => {
-					if (!message.value) {
-						return false
-					}
-
-					switch (typeof message.value) {
-						case 'string':
-							return message.value
+				switch (typeof message.value) {
+					case 'string':
+						return message.value
+							.toLocaleLowerCase()
+							.includes(filter.toLocaleLowerCase())
+					case 'object':
+						return message.value.some((line: string | null) => {
+							return line
+								?.toString()
 								.toLocaleLowerCase()
 								.includes(filter.toLocaleLowerCase())
-						case 'object':
-							return message.value.some((line: string | null) => {
-								return line
-									?.toString()
-									.toLocaleLowerCase()
-									.includes(filter.toLocaleLowerCase())
-							})
-						default:
-							return false
-					}
+						})
+					default:
+						return false
+				}
+			})
+		}
+
+		return currentMessages.filter((message) => message?.value?.length)
+	}, [logLevel, filter, parsedMessages])
+
+	const virtuoso = useRef<VirtuosoHandle>(null)
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	const scrollFunction = useCallback(
+		_.debounce((index: number) => {
+			if (virtuoso.current) {
+				virtuoso.current.scrollToIndex({
+					index,
+					align: 'center',
+					behavior: 'smooth',
 				})
 			}
+		}, 1000 / 60),
+		[],
+	)
 
-			return currentMessages.filter((message) => message?.value?.length)
-		}, [logLevel, filter, parsedMessages])
+	useEffect(() => {
+		if (autoScroll) {
+			scrollFunction(currentMessage)
+		}
+	}, [autoScroll, scrollFunction, currentMessage])
 
-		const virtuoso = useRef<VirtuosoHandle>(null)
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		const scrollFunction = useCallback(
-			_.debounce((index: number) => {
-				if (virtuoso.current) {
-					virtuoso.current.scrollToIndex({
-						index,
-						align: 'center',
-						behavior: 'smooth',
-					})
-				}
-			}, 1000 / 60),
-			[],
-		)
-
-		useEffect(() => {
-			if (autoScroll) {
-				scrollFunction(currentMessage)
-			}
-		}, [autoScroll, scrollFunction, currentMessage])
-
-		return (
-			<Box className={styles.consoleBox}>
-				{loading ? (
-					<LoadingBox />
-				) : messagesToRender?.length ? (
-					<Virtuoso
-						ref={virtuoso}
-						overscan={1024}
-						increaseViewportBy={1024}
-						data={messagesToRender}
-						className={styledScrollbar}
-						itemContent={(_index, message: ParsedMessage) => (
-							<MessageRow
-								key={message.id.toString()}
-								message={message}
-								current={message.id === currentMessage}
-								setTime={(time: number) => {
-									setTime(time)
-									setCurrentMessage(_index)
-								}}
-								sessionMetadata={sessionMetadata}
-							/>
-						)}
-					/>
-				) : (
-					<EmptyDevToolsCallout kind={Tab.Console} filter={filter} />
-				)}
-			</Box>
-		)
-	},
-)
+	return (
+		<Box className={styles.consoleBox}>
+			{loading ? (
+				<LoadingBox />
+			) : messagesToRender?.length ? (
+				<Virtuoso
+					ref={virtuoso}
+					overscan={1024}
+					increaseViewportBy={1024}
+					data={messagesToRender}
+					className={styledScrollbar}
+					itemContent={(_index, message: ParsedMessage) => (
+						<MessageRow
+							key={message.id.toString()}
+							message={message}
+							current={message.id === currentMessage}
+							setTime={(time: number) => {
+								setTime(time)
+								setCurrentMessage(_index)
+							}}
+							sessionMetadata={sessionMetadata}
+						/>
+					)}
+				/>
+			) : (
+				<EmptyDevToolsCallout kind={Tab.Console} filter={filter} />
+			)}
+		</Box>
+	)
+}
 
 const MessageRow = React.memo(function ({
 	message,

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -29,316 +29,302 @@ import Tooltip from '../../../../../components/Tooltip/Tooltip'
 import { ReplayerState, useReplayerContext } from '../../../ReplayerContext'
 import * as styles from './style.css'
 
-export const NetworkPage = React.memo(
-	({
-		time,
-		autoScroll,
-		filter,
-		requestType,
-		method,
-	}: {
-		time: number
-		autoScroll: boolean
-		filter: string
-		requestType: RequestType
-		method?: string
-	}) => {
-		const {
-			state,
-			session,
-			isPlayerReady,
-			errors,
-			replayer,
-			setTime,
-			sessionMetadata,
-		} = useReplayerContext()
-		const startTime = sessionMetadata.startTime
-		const {
-			setShowDevTools,
-			setSelectedDevToolsTab,
-			showPlayerAbsoluteTime,
-		} = usePlayerConfiguration()
-		const [currentActiveIndex, setCurrentActiveIndex] = useState<number>()
+export const NetworkPage = ({
+	time,
+	autoScroll,
+	filter,
+	requestType,
+	method,
+}: {
+	time: number
+	autoScroll: boolean
+	filter: string
+	requestType: RequestType
+	method?: string
+}) => {
+	const {
+		state,
+		session,
+		isPlayerReady,
+		errors,
+		replayer,
+		setTime,
+		sessionMetadata,
+	} = useReplayerContext()
+	const startTime = sessionMetadata.startTime
+	const { setShowDevTools, setSelectedDevToolsTab, showPlayerAbsoluteTime } =
+		usePlayerConfiguration()
+	const [currentActiveIndex, setCurrentActiveIndex] = useState<number>()
 
-		const virtuoso = useRef<VirtuosoHandle>(null)
-		const errorId = new URLSearchParams(location.search).get(
-			PlayerSearchParameters.errorId,
-		)
-		const { setResourcePanel, setErrorPanel, panelIsOpen } =
-			useResourceOrErrorDetailPanel()
+	const virtuoso = useRef<VirtuosoHandle>(null)
+	const errorId = new URLSearchParams(location.search).get(
+		PlayerSearchParameters.errorId,
+	)
+	const { setResourcePanel, setErrorPanel, panelIsOpen } =
+		useResourceOrErrorDetailPanel()
 
-		const {
-			resources: parsedResources,
-			loadResources,
-			resourcesLoading: loading,
-		} = useResourcesContext()
-		useEffect(() => {
-			loadResources()
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [])
-
-		const networkRange = useMemo(() => {
-			if (parsedResources.length > 0) {
-				const start = parsedResources[0].startTime
-				const end =
-					parsedResources[parsedResources.length - 1].responseEnd
-				return end - start
-			}
-			return 0
-		}, [parsedResources])
-
-		const resourcesToRender = useMemo(() => {
-			const current =
-				(parsedResources
-					?.filter(
-						(r) =>
-							(method === undefined ||
-								method ===
-									r.requestResponsePairs?.request.verb) &&
-							(requestType === RequestType.All ||
-								requestType === r.initiatorType),
-					)
-					.map((event) => ({
-						...event,
-						timestamp: event.startTime + startTime,
-					})) as NetworkResource[]) ?? []
-
-			if (filter !== '') {
-				return current.filter((resource) => {
-					if (!resource.name) {
-						return false
-					}
-
-					return (resource.displayName || resource.name)
-						.toLocaleLowerCase()
-						.includes(filter.toLocaleLowerCase())
-				})
-			}
-
-			return current
-		}, [parsedResources, filter, method, requestType, startTime])
-
-		const currentResourceIdx = useMemo(() => {
-			return findLastActiveEventIndex(
-				Math.round(time),
-				startTime,
-				resourcesToRender,
-			)
-		}, [resourcesToRender, startTime, time])
-
+	const {
+		resources: parsedResources,
+		loadResources,
+		resourcesLoading: loading,
+	} = useResourcesContext()
+	useEffect(() => {
+		loadResources()
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		const scrollFunction = useCallback(
-			_.debounce((index: number) => {
-				requestAnimationFrame(() => {
-					if (virtuoso.current) {
-						virtuoso.current.scrollToIndex({
-							index,
-							align: 'center',
-							behavior: 'smooth',
-						})
-					}
-				})
-			}, 1000 / 60),
-			[],
-		)
+	}, [])
 
-		useEffect(() => {
-			if (
-				errorId &&
-				!loading &&
-				!!session &&
-				!!resourcesToRender &&
-				resourcesToRender.length > 0 &&
-				!!errors &&
-				errors.length > 0 &&
-				isPlayerReady
-			) {
-				const matchingError = errors.find((e) => e.id === errorId)
-				if (matchingError && matchingError.request_id) {
-					const resource = findResourceWithMatchingHighlightHeader(
-						matchingError.request_id,
-						resourcesToRender,
+	const networkRange = useMemo(() => {
+		if (parsedResources.length > 0) {
+			const start = parsedResources[0].startTime
+			const end = parsedResources[parsedResources.length - 1].responseEnd
+			return end - start
+		}
+		return 0
+	}, [parsedResources])
+
+	const resourcesToRender = useMemo(() => {
+		const current =
+			(parsedResources
+				?.filter(
+					(r) =>
+						(method === undefined ||
+							method === r.requestResponsePairs?.request.verb) &&
+						(requestType === RequestType.All ||
+							requestType === r.initiatorType),
+				)
+				.map((event) => ({
+					...event,
+					timestamp: event.startTime + startTime,
+				})) as NetworkResource[]) ?? []
+
+		if (filter !== '') {
+			return current.filter((resource) => {
+				if (!resource.name) {
+					return false
+				}
+
+				return (resource.displayName || resource.name)
+					.toLocaleLowerCase()
+					.includes(filter.toLocaleLowerCase())
+			})
+		}
+
+		return current
+	}, [parsedResources, filter, method, requestType, startTime])
+
+	const currentResourceIdx = useMemo(() => {
+		return findLastActiveEventIndex(
+			Math.round(time),
+			startTime,
+			resourcesToRender,
+		)
+	}, [resourcesToRender, startTime, time])
+
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	const scrollFunction = useCallback(
+		_.debounce((index: number) => {
+			requestAnimationFrame(() => {
+				if (virtuoso.current) {
+					virtuoso.current.scrollToIndex({
+						index,
+						align: 'center',
+						behavior: 'smooth',
+					})
+				}
+			})
+		}, 1000 / 60),
+		[],
+	)
+
+	useEffect(() => {
+		if (
+			errorId &&
+			!loading &&
+			!!session &&
+			!!resourcesToRender &&
+			resourcesToRender.length > 0 &&
+			!!errors &&
+			errors.length > 0 &&
+			isPlayerReady
+		) {
+			const matchingError = errors.find((e) => e.id === errorId)
+			if (matchingError && matchingError.request_id) {
+				const resource = findResourceWithMatchingHighlightHeader(
+					matchingError.request_id,
+					resourcesToRender,
+				)
+				if (resource) {
+					setResourcePanel(resource)
+					setTime(resource.startTime)
+					scrollFunction(resourcesToRender.indexOf(resource))
+					message.success(
+						`Changed player time to when error was thrown at ${MillisToMinutesAndSeconds(
+							resource.startTime,
+						)}.`,
 					)
-					if (resource) {
-						setResourcePanel(resource)
-						setTime(resource.startTime)
-						scrollFunction(resourcesToRender.indexOf(resource))
+				} else {
+					setSelectedDevToolsTab(Tab.Errors)
+					setErrorPanel(matchingError)
+					const startTime = sessionMetadata.startTime
+					if (startTime && matchingError.timestamp) {
+						const errorDateTime = new Date(matchingError.timestamp)
+						const deltaMilliseconds =
+							errorDateTime.getTime() - startTime
+						setTime(deltaMilliseconds)
 						message.success(
 							`Changed player time to when error was thrown at ${MillisToMinutesAndSeconds(
-								resource.startTime,
+								deltaMilliseconds,
 							)}.`,
 						)
-					} else {
-						setSelectedDevToolsTab(Tab.Errors)
-						setErrorPanel(matchingError)
-						const startTime = sessionMetadata.startTime
-						if (startTime && matchingError.timestamp) {
-							const errorDateTime = new Date(
-								matchingError.timestamp,
-							)
-							const deltaMilliseconds =
-								errorDateTime.getTime() - startTime
-							setTime(deltaMilliseconds)
-							message.success(
-								`Changed player time to when error was thrown at ${MillisToMinutesAndSeconds(
-									deltaMilliseconds,
-								)}.`,
-							)
-						}
-						analytics.track(
-							'FailedToMatchHighlightResourceHeaderWithResource',
-						)
 					}
-				}
-			}
-			// eslint-disable-next-line react-hooks/exhaustive-deps
-		}, [
-			resourcesToRender,
-			errors,
-			isPlayerReady,
-			loading,
-			replayer,
-			scrollFunction,
-			session,
-			setErrorPanel,
-			setResourcePanel,
-			setSelectedDevToolsTab,
-			setShowDevTools,
-		])
-
-		useEffect(() => {
-			if (autoScroll && state === ReplayerState.Playing) {
-				scrollFunction(currentResourceIdx)
-			}
-		}, [currentResourceIdx, scrollFunction, autoScroll, state])
-
-		useEffect(() => {
-			// scroll network events on player timeline click
-			if (autoScroll && state === ReplayerState.Paused) {
-				scrollFunction(currentResourceIdx)
-			}
-		}, [autoScroll, currentResourceIdx, scrollFunction, state, time])
-
-		// Sets up a keydown listener to allow the user to quickly view network requests details in the resource panel by using the up/down arrow key.
-		useEffect(() => {
-			const listener = (e: KeyboardEvent) => {
-				let direction: undefined | number = undefined
-				if (e.key === 'ArrowUp') {
-					direction = -1
-				} else if (e.key === 'ArrowDown') {
-					direction = 1
-				}
-
-				if (direction !== undefined) {
-					e.preventDefault()
-					let nextIndex = (currentActiveIndex || 0) + direction
-					if (nextIndex < 0) {
-						nextIndex = 0
-					} else if (nextIndex >= resourcesToRender.length) {
-						nextIndex = resourcesToRender.length - 1
-					}
-
-					setCurrentActiveIndex(nextIndex)
-					if (panelIsOpen) {
-						requestAnimationFrame(() => {
-							setResourcePanel(resourcesToRender[nextIndex])
-							virtuoso.current?.scrollToIndex(nextIndex - 1)
-						})
-					}
-				}
-			}
-			document.addEventListener('keydown', listener, { passive: false })
-
-			return () => {
-				document.removeEventListener('keydown', listener)
-			}
-		}, [
-			currentActiveIndex,
-			panelIsOpen,
-			resourcesToRender,
-			setResourcePanel,
-		])
-
-		return (
-			<Box className={styles.container}>
-				{loading || !session ? (
-					<LoadingBox />
-				) : resourcesToRender.length > 0 ? (
-					<Box className={styles.container}>
-						<Box className={styles.networkHeader}>
-							<Text color="n11">Status</Text>
-							<Text color="n11">Type</Text>
-							<Text color="n11">Name</Text>
-							<Text color="n11">Time</Text>
-							<Text color="n11">Waterfall</Text>
-						</Box>
-						<Box className={styles.networkBox}>
-							<Virtuoso
-								ref={virtuoso}
-								overscan={1024}
-								increaseViewportBy={1024}
-								className={styledScrollbar}
-								components={{
-									ScrollSeekPlaceholder: () => (
-										<div
-											style={{
-												height: 36,
-											}}
-										/>
-									),
-								}}
-								scrollSeekConfiguration={{
-									enter: (v) => v > 512,
-									exit: (v) => v < 128,
-								}}
-								data={resourcesToRender}
-								itemContent={(index, resource) => {
-									const requestId =
-										getHighlightRequestId(resource)
-									const error = errors.find(
-										(e) => e.request_id === requestId,
-									)
-									return (
-										<ResourceRow
-											key={index.toString()}
-											resource={resource}
-											networkRange={networkRange}
-											isCurrentResource={
-												currentResourceIdx === index
-											}
-											searchTerm={filter}
-											onClickHandler={() => {
-												setCurrentActiveIndex(index)
-												setResourcePanel(resource)
-											}}
-											playerStartTime={startTime}
-											hasError={!!error}
-											networkRequestAndResponseRecordingEnabled={
-												session.enable_recording_network_contents ||
-												false
-											}
-											showPlayerAbsoluteTime={
-												showPlayerAbsoluteTime
-											}
-										/>
-									)
-								}}
-							/>
-						</Box>
-					</Box>
-				) : (
-					resourcesToRender.length === 0 && (
-						<EmptyDevToolsCallout
-							kind={Tab.Network}
-							filter={filter}
-							requestType={requestType}
-						/>
+					analytics.track(
+						'FailedToMatchHighlightResourceHeaderWithResource',
 					)
-				)}
-			</Box>
-		)
-	},
-)
+				}
+			}
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [
+		resourcesToRender,
+		errors,
+		isPlayerReady,
+		loading,
+		replayer,
+		scrollFunction,
+		session,
+		setErrorPanel,
+		setResourcePanel,
+		setSelectedDevToolsTab,
+		setShowDevTools,
+	])
+
+	useEffect(() => {
+		if (autoScroll && state === ReplayerState.Playing) {
+			scrollFunction(currentResourceIdx)
+		}
+	}, [currentResourceIdx, scrollFunction, autoScroll, state])
+
+	useEffect(() => {
+		// scroll network events on player timeline click
+		if (autoScroll && state === ReplayerState.Paused) {
+			scrollFunction(currentResourceIdx)
+		}
+	}, [autoScroll, currentResourceIdx, scrollFunction, state, time])
+
+	// Sets up a keydown listener to allow the user to quickly view network requests details in the resource panel by using the up/down arrow key.
+	useEffect(() => {
+		const listener = (e: KeyboardEvent) => {
+			let direction: undefined | number = undefined
+			if (e.key === 'ArrowUp') {
+				direction = -1
+			} else if (e.key === 'ArrowDown') {
+				direction = 1
+			}
+
+			if (direction !== undefined) {
+				e.preventDefault()
+				let nextIndex = (currentActiveIndex || 0) + direction
+				if (nextIndex < 0) {
+					nextIndex = 0
+				} else if (nextIndex >= resourcesToRender.length) {
+					nextIndex = resourcesToRender.length - 1
+				}
+
+				setCurrentActiveIndex(nextIndex)
+				if (panelIsOpen) {
+					requestAnimationFrame(() => {
+						setResourcePanel(resourcesToRender[nextIndex])
+						virtuoso.current?.scrollToIndex(nextIndex - 1)
+					})
+				}
+			}
+		}
+		document.addEventListener('keydown', listener, { passive: false })
+
+		return () => {
+			document.removeEventListener('keydown', listener)
+		}
+	}, [currentActiveIndex, panelIsOpen, resourcesToRender, setResourcePanel])
+
+	return (
+		<Box className={styles.container}>
+			{loading || !session ? (
+				<LoadingBox />
+			) : resourcesToRender.length > 0 ? (
+				<Box className={styles.container}>
+					<Box className={styles.networkHeader}>
+						<Text color="n11">Status</Text>
+						<Text color="n11">Type</Text>
+						<Text color="n11">Name</Text>
+						<Text color="n11">Time</Text>
+						<Text color="n11">Waterfall</Text>
+					</Box>
+					<Box className={styles.networkBox}>
+						<Virtuoso
+							ref={virtuoso}
+							overscan={1024}
+							increaseViewportBy={1024}
+							className={styledScrollbar}
+							components={{
+								ScrollSeekPlaceholder: () => (
+									<div
+										style={{
+											height: 36,
+										}}
+									/>
+								),
+							}}
+							scrollSeekConfiguration={{
+								enter: (v) => v > 512,
+								exit: (v) => v < 128,
+							}}
+							data={resourcesToRender}
+							itemContent={(index, resource) => {
+								const requestId =
+									getHighlightRequestId(resource)
+								const error = errors.find(
+									(e) => e.request_id === requestId,
+								)
+								return (
+									<ResourceRow
+										key={index.toString()}
+										resource={resource}
+										networkRange={networkRange}
+										isCurrentResource={
+											currentResourceIdx === index
+										}
+										searchTerm={filter}
+										onClickHandler={() => {
+											setCurrentActiveIndex(index)
+											setResourcePanel(resource)
+										}}
+										playerStartTime={startTime}
+										hasError={!!error}
+										networkRequestAndResponseRecordingEnabled={
+											session.enable_recording_network_contents ||
+											false
+										}
+										showPlayerAbsoluteTime={
+											showPlayerAbsoluteTime
+										}
+									/>
+								)
+							}}
+						/>
+					</Box>
+				</Box>
+			) : (
+				resourcesToRender.length === 0 && (
+					<EmptyDevToolsCallout
+						kind={Tab.Network}
+						filter={filter}
+						requestType={requestType}
+					/>
+				)
+			)}
+		</Box>
+	)
+}
 
 interface ResourceRowProps {
 	resource: NetworkResource

--- a/frontend/src/util/preload.ts
+++ b/frontend/src/util/preload.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { DEFAULT_PAGE_SIZE } from '@components/Pagination/Pagination'
 import {
 	GetEnhancedUserDetailsDocument,
@@ -265,13 +266,16 @@ export const loadSession = async function (secureID: string) {
 		const sess = session?.data?.session
 		if (!sess) return
 		if (sess.resources_url) {
-			await indexedDBFetch(sess.resources_url)
+			for await (const _ of indexedDBFetch(sess.resources_url)) {
+			}
 		}
 		if (sess.messages_url) {
-			await indexedDBFetch(sess.messages_url)
+			for await (const _ of indexedDBFetch(sess.messages_url)) {
+			}
 		}
 		if (sess.direct_download_url) {
-			await indexedDBFetch(sess.direct_download_url)
+			for await (const _ of indexedDBFetch(sess.direct_download_url)) {
+			}
 		}
 		await client.query({
 			query: GetSessionIntervalsDocument,


### PR DESCRIPTION
## Summary

IndexedDB caching has caused issues with stale data.
To allow caching all data and ensure that we never show incorrect data, return cached data first but always update with network data.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

No. IndexedDB version update not needed since data model has not changed.

Closes #3605