### PR TITLE
hotfix: update loaders for pages with integrations and alerts

### DIFF
--- a/frontend/src/pages/Alerts/Alerts.tsx
+++ b/frontend/src/pages/Alerts/Alerts.tsx
@@ -1,7 +1,7 @@
 import BarChart from '@components/BarChart/BarChart'
 import ButtonLink from '@components/Button/ButtonLink/ButtonLink'
 import Card from '@components/Card/Card'
-import { CircularSpinner } from '@components/Loading/Loading'
+import LoadingBox from '@components/LoadingBox'
 import { SearchEmptyState } from '@components/SearchEmptyState/SearchEmptyState'
 import Table from '@components/Table/Table'
 import Tag from '@components/Tag/Tag'
@@ -258,14 +258,14 @@ export default function AlertsPage() {
 
 	if (loading) {
 		return (
-			<div>
+			<>
 				<div className={styles.subTitleContainer}>
 					<p>Manage the alerts for your project.</p>
 				</div>
-				<div className="flex justify-center p-8">
-					<CircularSpinner />
-				</div>
-			</div>
+				<Card noPadding>
+					<LoadingBox height={640} />
+				</Card>
+			</>
 		)
 	}
 

--- a/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/IntegrationsPage/IntegrationsPage.tsx
@@ -1,7 +1,6 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import { useSlackBot } from '@components/Header/components/ConnectHighlightWithSlackButton/utils/utils'
 import LeadAlignLayout from '@components/layout/LeadAlignLayout'
-import { Skeleton } from '@components/Skeleton/Skeleton'
 import { useClearbitIntegration } from '@pages/IntegrationsPage/components/ClearbitIntegration/utils'
 import { useClickUpIntegration } from '@pages/IntegrationsPage/components/ClickUpIntegration/utils'
 import { useDiscordIntegration } from '@pages/IntegrationsPage/components/DiscordIntegration/utils'
@@ -142,22 +141,17 @@ const IntegrationsPage = () => {
 					tools you use everyday.
 				</p>
 				<div className={styles.integrationsContainer}>
-					{integrations.map((integration) =>
-						loading ? (
-							<Skeleton height={187} key={integration.key} />
-						) : (
-							<Integration
-								integration={integration}
-								key={integration.key}
-								showModalDefault={
-									popUpModal === integration.key
-								}
-								showSettingsDefault={
-									configureIntegration === integration.key
-								}
-							/>
-						),
-					)}
+					{integrations.map((integration) => (
+						<Integration
+							integration={integration}
+							key={integration.key}
+							showModalDefault={popUpModal === integration.key}
+							showSettingsDefault={
+								configureIntegration === integration.key
+							}
+							loading={loading}
+						/>
+					))}
 				</div>
 			</LeadAlignLayout>
 		</>

--- a/frontend/src/pages/IntegrationsPage/components/Integration.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/Integration.tsx
@@ -1,5 +1,6 @@
 import Button from '@components/Button/Button/Button'
 import Card from '@components/Card/Card'
+import LoadingBox from '@components/LoadingBox'
 import Modal from '@components/Modal/Modal'
 import Switch from '@components/Switch/Switch'
 import SettingsIcon from '@icons/SettingsIcon'
@@ -25,6 +26,7 @@ interface Props {
 	integration: IntegrationType
 	showModalDefault?: boolean
 	showSettingsDefault?: boolean
+	loading?: boolean
 }
 
 const Integration = ({
@@ -41,6 +43,7 @@ const Integration = ({
 	},
 	showModalDefault,
 	showSettingsDefault,
+	loading,
 }: Props) => {
 	const [showConfiguration, setShowConfiguration] = useState(
 		showModalDefault && !defaultEnable,
@@ -54,6 +57,13 @@ const Integration = ({
 	useEffect(() => {
 		setIntegrationEnabled(defaultEnable)
 	}, [defaultEnable, setIntegrationEnabled])
+	if (loading) {
+		return (
+			<Card>
+				<LoadingBox height={156} />
+			</Card>
+		)
+	}
 
 	return (
 		<>


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->
<img width="970" alt="Screenshot 2023-01-19 at 8 48 54 AM" src="https://user-images.githubusercontent.com/17913919/213505204-4327afe5-7fa3-4ef4-8523-367c726cea92.png">


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
Go to /1/integrations and /1/alerts.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no