### PR TITLE
[HIG-3679] migration job for timeline indicator events to s3

### DIFF
--- a/backend/migrations/cmd/migrate-timeline-indicator-s3/main.go
+++ b/backend/migrations/cmd/migrate-timeline-indicator-s3/main.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/highlight-run/highlight/backend/payload"
+	"github.com/highlight-run/highlight/backend/storage"
+	"github.com/samber/lo"
+	"golang.org/x/sync/errgroup"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/highlight-run/highlight/backend/model"
+	"github.com/pkg/errors"
+)
+
+const BatchSize = 100
+
+func createFile(name string) (*os.File, error) {
+	file, err := os.Create(name)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating file")
+	}
+	return file, nil
+}
+
+func main() {
+	log.Info("ZANE_MIGRATION setting up db")
+	db, err := model.SetupDB(os.Getenv("PSQL_DB"))
+	if err != nil {
+		log.Fatalf("ZANE_MIGRATION error setting up db: %+v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		log.Fatalf("ZANE_MIGRATION error getting raw db: %+v", err)
+	}
+	if err := sqlDB.Ping(); err != nil {
+		log.Fatalf("ZANE_MIGRATION error pinging db: %+v", err)
+	}
+
+	storageClient, err := storage.NewStorageClient()
+	if err != nil {
+		log.Fatalf("ZANE_MIGRATION error creating storage client: %v", err)
+	}
+
+	max := 46656
+	maxAscii := "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+
+	chars := [36]byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'}
+
+	getAscii := func(i int) string {
+		i--
+		b0 := chars[i%36]
+		b1 := chars[(i/36)%36]
+		b2 := chars[(i/36/36)%36]
+		return string([]byte{b2, b1, b0})
+	}
+
+	for {
+		var start int
+		if err := db.Raw(`
+			with t as (
+				insert into zane_work (done) values (false)
+				returning start
+			) select * from t
+		`).Scan(&start).Error; err != nil {
+			log.Fatal(errors.Wrap(err, "ZANE_MIGRATION error querying next start"))
+		}
+
+		if start > max {
+			log.Info("ZANE_MIGRATION done all")
+			break
+		}
+
+		startAscii := getAscii(start)
+		endAscii := getAscii(start + 1)
+		if start == max {
+			endAscii = maxAscii
+		}
+
+		for {
+			var nextEvents []struct {
+				model.TimelineIndicatorEvent
+				SessionID int
+				ProjectID int
+			}
+
+			if err := db.Raw(`
+				select tie.*, s.id as session_id, s.project_id
+				from timeline_indicator_events tie
+				inner join sessions s
+				on tie.session_secure_id = s.secure_id
+				where tie.session_secure_id in (
+					select distinct session_secure_id from timeline_indicator_events
+					where deleted_at is null
+					and session_secure_id >= ? 
+					and session_secure_id < ?
+					limit ?
+				)
+				order by timestamp asc`, startAscii, endAscii, BatchSize).Scan(&nextEvents).Error; err != nil {
+				log.Fatalf("ZANE_MIGRATION error querying next sessions %v", err)
+			}
+
+			if len(nextEvents) == 0 {
+				if err := db.Exec(`
+					update zane_work
+					set done = true
+					where start = ?
+				`, start).Error; err != nil {
+					log.Fatal(errors.Wrap(err, "ZANE_MIGRATION error updating work block"))
+				}
+				log.Infof("ZANE_MIGRATION done block %d", start)
+				break
+			}
+
+			fileMap := map[int]*os.File{}
+			eventsMap := map[int][]model.TimelineIndicatorEvent{}
+			projectIdMap := map[int]int{}
+			secureIdMap := map[string]struct{}{}
+			for _, ne := range nextEvents {
+				secureIdMap[ne.SessionSecureID] = struct{}{}
+				_, ok := fileMap[ne.SessionID]
+				if !ok {
+					file, err := createFile(fmt.Sprintf("%d.json.br", ne.SessionID))
+					if err != nil {
+						log.Fatalf("error creating file")
+					}
+					fileMap[ne.SessionID] = file
+					eventsMap[ne.SessionID] = []model.TimelineIndicatorEvent{}
+					projectIdMap[ne.SessionID] = ne.ProjectID
+				}
+				eventsMap[ne.SessionID] = append(eventsMap[ne.SessionID], ne.TimelineIndicatorEvent)
+			}
+			secureIds := lo.Keys(secureIdMap)
+
+			log.Infof("ZANE_MIGRATION secure ids: %v", secureIds)
+
+			var g errgroup.Group
+			for sId, fi := range fileMap {
+				f := fi
+				sessionId := sId
+				g.Go(func() error {
+					projectId := projectIdMap[sessionId]
+					writer := payload.NewCompressedWriter(f)
+					eventBytes, err := json.Marshal(eventsMap[sessionId])
+					if err != nil {
+						return errors.Wrap(err, "error marshalling eventsForTimelineIndicator")
+					}
+					if err := writer.WriteString(string(eventBytes)); err != nil {
+						return errors.Wrap(err, "error writing to TimelineIndicatorEvents")
+					}
+					if err := writer.Close(); err != nil {
+						log.Error(errors.Wrap(err, "ZANE_MIGRATION error closing TimelineIndicatorEvents writer"))
+					}
+					if _, err := storageClient.PushCompressedFileToS3(context.Background(), sessionId, projectId, f, storage.TimelineIndicatorEvents); err != nil {
+						return errors.Wrap(err, "error pushing to s3")
+					}
+					if err := f.Close(); err != nil {
+						log.Error(errors.Wrap(err, "ZANE_MIGRATION failed to close file"))
+					}
+					if err := os.Remove(f.Name()); err != nil {
+						log.Error(errors.Wrap(err, "ZANE_MIGRATION failed to remove file"))
+					}
+					return nil
+				})
+			}
+
+			if err := g.Wait(); err != nil {
+				log.Fatal(errors.Wrap(err, "ZANE_MIGRATION error writing to s3"))
+			}
+
+			if err := db.Exec(`
+				update sessions
+				set avoid_postgres_storage = true
+				where secure_id in ?
+				`, secureIds).Error; err != nil {
+				log.Fatal(errors.Wrap(err, "ZANE_MIGRATION error updating sessions avoid_postgres_storage"))
+			}
+
+			if err := db.Exec(`
+				update timeline_indicator_events
+				set deleted_at = now()
+				where session_secure_id in ?
+				`, secureIds).Error; err != nil {
+				log.Fatal(errors.Wrap(err, "ZANE_MIGRATION error updating timeline_indicator_events deleted_at"))
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- migrates `timeline_indicator_events` to s3 in batches of 100 sessions
- locally took 9s to migrate 939 sessions
- at same rate, will take 7 days to migrate 62 million sessions
- expecting rate to be faster running in AWS due to parallelization and colocation
- work is allocated and tracked using a separate `zane_work` table
  - 46656 units of work (36^3) corresponding to secure_id ranges ('000' -> '001', '001' -> '002', ... , 'zzy' -> 'zzz', 'zzz' -> )
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- migrated my local `timeline_indicator_events`
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- waiting for index to be created before running this:
```
CREATE INDEX concurrently idx_zane_delet
 e ON public.timeline_indicator_events (session_secure_id) WHERE (dele
 ted_at is null)
 ```
- need to create `zane_work` table beforehand:
```
create table zane_work (
   start serial,
   done boolean
);
create unique index zane_work_pkey on zane_work (start);
```

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
