### PR TITLE
fix(HIG-3481): look for completed sessions first

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3764,24 +3764,68 @@ func (r *queryResolver) ErrorInstance(ctx context.Context, errorGroupSecureID st
 	}
 
 	errorObject := model.ErrorObject{}
-	errorObjectQuery := r.DB.Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID})
+	errorObjectQuery := r.DB.Model(&model.ErrorObject{}).Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID})
+
 	if errorObjectID == nil {
-		if err := errorObjectQuery.Last(&errorObject).Error; err != nil {
-			return nil, e.Wrap(err, "error reading error object for instance")
+		sessionIds := []int{}
+		if err := r.DB.Model(&errorObject).
+			Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).
+			Pluck("session_id", &sessionIds).
+			Error; err != nil {
+			return nil, e.Wrap(err, "error reading session ids")
+		}
+
+		processedSessions := []int{}
+		// find all processed sessions
+		if err := r.DB.Model(&model.Session{}).
+			Where("id IN (?) AND processed = ?", sessionIds, true).
+			Pluck("id", &processedSessions).
+			Error; err != nil {
+			return nil, e.Wrap(err, "error querying processed sessions")
+		}
+
+		if len(processedSessions) == 0 {
+			if err := errorObjectQuery.Last(&errorObject).Error; err != nil {
+				return nil, e.Wrap(err, "error reading error object for instance")
+			}
+		} else {
+			// find the most recent object from the processed session
+			if err := errorObjectQuery.
+				Where("session_id IN ?", processedSessions).
+				Order("id desc").
+				First(&errorObject).
+				Error; err != nil {
+				return nil, e.Wrap(err, "error reading error object for instance")
+			}
 		}
 	} else {
-		if err := errorObjectQuery.Where(&model.ErrorObject{Model: model.Model{ID: *errorObjectID}}).First(&errorObject).Error; err != nil {
+		if err := errorObjectQuery.
+			Where(&model.ErrorObject{Model: model.Model{ID: *errorObjectID}}).
+			First(&errorObject).
+			Error; err != nil {
 			return nil, e.Wrap(err, "error reading error object for instance")
 		}
 	}
 
 	nextErrorObject := model.ErrorObject{}
-	if err := r.DB.Model(&errorObject).Select("id").Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).Where("id > ?", errorObject.ID).Order("id asc").Limit(1).Find(&nextErrorObject).Error; err != nil {
+	if err := r.DB.Model(&model.ErrorObject{}).
+		Select("id").
+		Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).
+		Where("id > ?", errorObject.ID).
+		Order("id asc").
+		Limit(1).
+		Find(&nextErrorObject).Error; err != nil {
 		return nil, e.Wrap(err, "error reading next error object in group")
 	}
 
 	previousErrorObject := model.ErrorObject{}
-	if err := r.DB.Model(&errorObject).Select("id").Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).Where("id < ?", errorObject.ID).Order("id desc").Limit(1).Find(&previousErrorObject).Error; err != nil {
+	if err := r.DB.Model(&model.ErrorObject{}).
+		Select("id").
+		Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).
+		Where("id < ?", errorObject.ID).
+		Order("id desc").
+		Limit(1).
+		Find(&previousErrorObject).Error; err != nil {
 		return nil, e.Wrap(err, "error reading previous error object in group")
 	}
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Makes sure that the _latest_ session we show is not the one active but not yet processed (if it exists).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

local click test with /buttons

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no
