### PR TITLE
fix(HIG-3699): loading state for errors

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
@@ -11,12 +11,8 @@ import React, { useCallback } from 'react'
 
 const ErrorFeedHistogram = React.memo(() => {
 	const { project_id } = useParams<{ project_id: string }>()
-	const {
-		backendSearchQuery,
-		searchParams,
-		setSearchParams,
-		searchResultsLoading,
-	} = useErrorSearchContext()
+	const { backendSearchQuery, searchParams, setSearchParams } =
+		useErrorSearchContext()
 	const { loading, data } = useGetErrorsHistogramQuery({
 		variables: {
 			query: backendSearchQuery?.childSearchQuery as string,
@@ -80,7 +76,7 @@ const ErrorFeedHistogram = React.memo(() => {
 			seriesList={histogram.seriesList}
 			bucketTimes={histogram.bucketTimes}
 			bucketSize={backendSearchQuery?.histogramBucketSize}
-			loading={loading || searchResultsLoading}
+			loading={loading}
 			updateTimeRange={updateTimeRange}
 			barGap={2.4}
 		/>

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -30,7 +30,6 @@ const SearchPanel = () => {
 		backendSearchQuery,
 		page,
 		setPage,
-		searchResultsLoading,
 		setSearchResultsLoading,
 		searchResultsCount,
 		setSearchResultsCount,
@@ -69,12 +68,12 @@ const SearchPanel = () => {
 		setSearchResultsLoading(loading)
 	}, [loading, setSearchResultsLoading])
 
-	const showHistogram = searchResultsLoading || searchResultsCount > 0
+	const showHistogram = loading || searchResultsCount > 0
 
 	const [, setSyncButtonDisabled] = useState<boolean>(false)
 
 	useEffect(() => {
-		if (!searchResultsLoading) {
+		if (!loading) {
 			const timer = setTimeout(() => {
 				setSyncButtonDisabled(false)
 			}, 3000)
@@ -84,7 +83,7 @@ const SearchPanel = () => {
 		} else {
 			setSyncButtonDisabled(true)
 		}
-	}, [searchResultsLoading])
+	}, [loading])
 
 	const errorGroups = fetchedData?.error_groups_opensearch
 	return (
@@ -112,7 +111,7 @@ const SearchPanel = () => {
 				overflowY="auto"
 				cssClass={style.content}
 			>
-				{searchResultsLoading ? (
+				{loading ? (
 					<LoadingBox />
 				) : (
 					<>


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Makes sure that the loading state comes directly from the request rather than the app state to avoid flicker.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
local click test: go to the error page, switch to sessions and back to errors
## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no