### PR TITLE
fix(HIG-3725): abstract ops crash

### DIFF
--- a/frontend/src/components/KeyValueTable/KeyValueTable.tsx
+++ b/frontend/src/components/KeyValueTable/KeyValueTable.tsx
@@ -39,11 +39,11 @@ const KeyValueTable = ({
 								key={`${keyDisplayValue}-${valueDisplayValue}-${valueInfoTooltipMessage}`}
 							>
 								<p className={styles.key}>{keyDisplayValue}</p>
-								<p className={styles.value}>
+								<div className={styles.value}>
 									{renderType === 'string' ? (
 										<>
 											{valueDisplayValue}{' '}
-											{valueInfoTooltipMessage && (
+											{!!valueInfoTooltipMessage && (
 												<InfoTooltip
 													title={
 														valueInfoTooltipMessage
@@ -57,7 +57,7 @@ const KeyValueTable = ({
 									) : renderType === 'react-node' ? (
 										<>
 											{valueDisplayValue}
-											{valueInfoTooltipMessage && (
+											{!!valueInfoTooltipMessage && (
 												<InfoTooltip
 													title={
 														valueInfoTooltipMessage
@@ -78,7 +78,7 @@ const KeyValueTable = ({
 									) : (
 										'undefined'
 									)}
-								</p>
+								</div>
 							</React.Fragment>
 						),
 				  )}

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -28,7 +28,7 @@ export const useResources = (
 	const [sessionSecureId, setSessionSecureId] = useState<string>()
 	const [downloadResources] = useQueryParam('downloadresources', BooleanParam)
 
-	const [resourcesLoading, setResourcesLoading] = useState(true)
+	const [resourcesLoading, setResourcesLoading] = useState(false)
 	const skipQuery =
 		sessionSecureId === undefined ||
 		session === undefined ||

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ErrorsPage/components/ErrorModal/ErrorModal.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ErrorsPage/components/ErrorModal/ErrorModal.tsx
@@ -35,71 +35,68 @@ const ErrorModal = ({ error, showRequestAlert }: Props) => {
 	return (
 		<div className={styles.container}>
 			<div>
-				<>
-					{showRequestAlert && (
-						<Alert
-							type="warning"
-							trackingId="UnmatchedBackendError"
-							message="Request data not found"
-							className={styles.alertContainer}
-							description={
-								<>
-									The network resource associated with this
-									error could not be found. This could happen
-									if the tracingOrigins parameter of H.init()
-									was not configured correctly, or if the
-									user's browser failed to push the network
-									resource data while the session was being
-									recorded.
-								</>
-							}
-						/>
-					)}
+				{showRequestAlert && (
+					<Alert
+						type="warning"
+						trackingId="UnmatchedBackendError"
+						message="Request data not found"
+						className={styles.alertContainer}
+						description={
+							<>
+								The network resource associated with this error
+								could not be found. This could happen if the
+								tracingOrigins parameter of H.init() was not
+								configured correctly, or if the user's browser
+								failed to push the network resource data while
+								the session was being recorded.
+							</>
+						}
+					/>
+				)}
 
-					<div className={styles.titleContainer}>
-						{data ? (
-							<ErrorTitle
-								errorGroup={data.error_group}
-								showShareButton={false}
-								errorObject={error}
-							/>
-						) : (
-							<Skeleton height="57px" />
-						)}
-					</div>
-
-					<div className={styles.errorBodyContainer}>
-						{data ? (
-							<ErrorBody
-								errorGroup={data.error_group}
-								errorObject={error}
-							/>
-						) : (
-							<Skeleton height="217px" />
-						)}
-					</div>
-
-					<h3>Stack Trace</h3>
+				<div className={styles.titleContainer}>
 					{data ? (
-						<StackTraceSection
+						<ErrorTitle
 							errorGroup={data.error_group}
-							loading={loading}
-							compact={true}
+							showShareButton={false}
+							errorObject={error}
 						/>
 					) : (
-						<Skeleton
-							height="212px"
-							count={5}
-							containerClassName={styles.stackTraceLoadingWrapper}
-						/>
+						<Skeleton height="57px" />
 					)}
+				</div>
 
+				<div className={styles.errorBodyContainer}>
 					{data ? (
-						<ErrorFrequencyGraph errorGroup={data.error_group} />
+						<ErrorBody
+							errorGroup={data.error_group}
+							errorObject={error}
+						/>
 					) : (
-						<Skeleton height="353px" />
+						<Skeleton height="217px" />
 					)}
-				</>
+				</div>
+
+				<h3>Stack Trace</h3>
+				{data ? (
+					<StackTraceSection
+						errorGroup={data.error_group}
+						loading={loading}
+						compact={true}
+					/>
+				) : (
+					<Skeleton
+						height="212px"
+						count={5}
+						containerClassName={styles.stackTraceLoadingWrapper}
+					/>
+				)}
+
+				{data ? (
+					<ErrorFrequencyGraph errorGroup={data.error_group} />
+				) : (
+					<Skeleton height="353px" />
+				)}
 				<div className={styles.actionsContainer}>
 					<Button
 						trackingId="GoToErrorPageFromSessionErrorModal"

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/components/ResourceDetailsModal/ResourceDetailsModal.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/components/ResourceDetailsModal/ResourceDetailsModal.tsx
@@ -1,17 +1,20 @@
+import DataCard from '@components/DataCard/DataCard'
+import KeyValueTable, {
+	KeyValueTableRow,
+} from '@components/KeyValueTable/KeyValueTable'
+import Space from '@components/Space/Space'
 import { ErrorObject } from '@graph/schemas'
 import { formatTime } from '@pages/Home/components/KeyPerformanceIndicators/utils/utils'
+import { getNetworkResourcesDisplayName } from '@pages/Player/Toolbar/DevToolsWindow/Option/Option'
 import RequestMetrics from '@pages/Player/Toolbar/DevToolsWindow/ResourcePage/components/RequestMetrics/RequestMetrics'
 import { UnknownRequestStatusCode } from '@pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage'
+import {
+	formatSize,
+	NetworkResource,
+} from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import { CodeBlock } from '@pages/Setup/CodeBlock/CodeBlock'
 import React from 'react'
 
-import DataCard from '../../../../../../../components/DataCard/DataCard'
-import KeyValueTable, {
-	KeyValueTableRow,
-} from '../../../../../../../components/KeyValueTable/KeyValueTable'
-import Space from '../../../../../../../components/Space/Space'
-import { formatSize, NetworkResource } from '../../../../DevToolsWindowV2/utils'
-import { getNetworkResourcesDisplayName } from '../../../Option/Option'
 import styles from './ResourceDetailsModal.module.scss'
 
 interface Props {
@@ -187,7 +190,7 @@ const ResourceDetailsModal = ({
 			} catch {
 				requestPayloadData.push({
 					keyDisplayValue: 'body',
-					valueDisplayValue: request.body,
+					valueDisplayValue: JSON.stringify(request.body),
 					renderType: 'string',
 				})
 			}

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -96,8 +96,8 @@ export const findResourceWithMatchingHighlightHeader = (
 	)
 }
 
-export const getHighlightRequestId = (resource: NetworkResource) => {
-	return resource.requestResponsePairs?.request?.id
+export const getHighlightRequestId = (resource?: NetworkResource) => {
+	return resource?.requestResponsePairs?.request?.id
 }
 
 export enum LogLevel {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->
This fixes the following issue:

<img width="917" alt="Screenshot 2023-01-24 at 11 53 57 AM" src="https://user-images.githubusercontent.com/17913919/214394988-e0265d50-d522-458b-85a4-e7e05c84eaa0.png">

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
local click test on a copy of the session;

go to https://frontend-pr-3579.onrender.com/1/sessions/ezXja9PhDAU9ig8A3TYWP8vC08X6 and check that clicking on the error in the second bar does not crash the app
 
<img width="262" alt="Screenshot 2023-01-24 at 11 55 57 AM" src="https://user-images.githubusercontent.com/17913919/214395374-4c382cfb-76e4-497a-89fd-71c897634d8d.png">

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no
