### PR TITLE
fix(hig-3697): design of search bars

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -8,7 +8,6 @@ import {
 	Tabs,
 	useFormState,
 } from '@highlight-run/ui'
-import { colors } from '@highlight-run/ui/src/css/colors'
 import { useWindowSize } from '@hooks/useWindowSize'
 import { usePlayerUIContext } from '@pages/Player/context/PlayerUIContext'
 import { useReplayerContext } from '@pages/Player/ReplayerContext'
@@ -155,9 +154,9 @@ const DevToolsWindowV2: React.FC<
 																(s) => !s,
 															)
 														}}
+														color="weak"
 													>
 														<IconSolidSearch
-															color={colors.n8}
 															size={16}
 														/>
 													</Box>
@@ -165,6 +164,7 @@ const DevToolsWindowV2: React.FC<
 														name={form.names.search}
 														placeholder="Search"
 														size="xSmall"
+														outline={false}
 														collapsed={!searchShown}
 														onKeyDown={(e: any) => {
 															if (

--- a/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
@@ -123,22 +123,22 @@ const EventStreamV2 = function () {
 				>
 					<Box px="12" py="8">
 						<Form state={form}>
-							<label>
-								<Box
-									display="flex"
-									justifyContent="space-between"
-									align="center"
-								>
-									<Box display="flex" align="center">
-										<IconSolidSearch color="n8" size={16} />
-									</Box>
-									<Form.Input
-										name={form.names.search}
-										placeholder="Search"
-										size="xSmall"
-									/>
-								</Box>
-							</label>
+							<Box
+								display="flex"
+								justifyContent="space-between"
+								align="center"
+								as="label"
+								gap="6"
+								color="weak"
+							>
+								<IconSolidSearch size={16} />
+								<Form.Input
+									name={form.names.search}
+									placeholder="Search"
+									size="xSmall"
+									outline={false}
+								/>
+							</Box>
 						</Form>
 					</Box>
 					{replayer && filteredEvents.length > 0 ? (

--- a/packages/ui/src/components/Form/styles.css.ts
+++ b/packages/ui/src/components/Form/styles.css.ts
@@ -13,13 +13,6 @@ export const inputVariants = recipe({
 		outline: 0,
 		width: '100%',
 		selectors: {
-			'&:focus, &:active': {
-				border: vars.border.secondaryPressed,
-			},
-			'&:placeholder-shown:hover': {
-				background: vars.theme.interactive.overlay.secondary.hover,
-				border: vars.border.secondaryHover,
-			},
 			'&::placeholder': {
 				color: vars.theme.interactive.fill.secondary.content.onDisabled,
 			},
@@ -50,14 +43,29 @@ export const inputVariants = recipe({
 				width: 0,
 				padding: 0,
 				border: 'none',
+				'&:focus, &:active, &:placeholder-shown:hover': {
+					border: 'none',
+				},
 			},
 			false: {},
 		},
 		outline: {
 			true: {
 				border: vars.border.secondary,
+				selectors: {
+					'&:focus, &:active': {
+						border: vars.border.secondaryPressed,
+					},
+					'&:placeholder-shown:hover': {
+						background:
+							vars.theme.interactive.overlay.secondary.hover,
+						border: vars.border.secondaryHover,
+					},
+				},
 			},
-			false: {},
+			false: {
+				border: 'none',
+			},
 		},
 	},
 	defaultVariants: {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

now:
<img width="303" alt="Screenshot 2023-01-25 at 9 46 12 AM" src="https://user-images.githubusercontent.com/17913919/214641833-8246091f-52af-4011-ad62-51b0497e7435.png">
<img width="207" alt="Screenshot 2023-01-25 at 9 46 23 AM" src="https://user-images.githubusercontent.com/17913919/214641893-78f3ef09-97c8-4fa1-a709-94a3f0ba0882.png">

going to be:
<img width="300" alt="Screenshot 2023-01-25 at 9 46 38 AM" src="https://user-images.githubusercontent.com/17913919/214641936-dfb3988f-a803-410e-82d2-2ad4ee47093c.png">
<img width="191" alt="Screenshot 2023-01-25 at 9 46 46 AM" src="https://user-images.githubusercontent.com/17913919/214641956-f0a1f86e-2038-4ac6-a7d7-8140a1560eac.png">



## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
go to the session view and make sure search bar in the dev tools and right panel are ok

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no