### PR TITLE
Fix focus styles on buttons

### DIFF
--- a/frontend/src/components/LinkButton/styles.css.ts
+++ b/frontend/src/components/LinkButton/styles.css.ts
@@ -2,4 +2,10 @@ import { style } from '@vanilla-extract/css'
 
 export const base = style({
 	textDecoration: 'none',
+	selectors: {
+		// Restores default focus styles.
+		'&:focus-visible': {
+			outline: 'revert !important',
+		},
+	},
 })

--- a/packages/ui/src/components/Button/styles.css.ts
+++ b/packages/ui/src/components/Button/styles.css.ts
@@ -49,7 +49,7 @@ export const iconVariants = recipe({
 			},
 			danger: {
 				selectors: {
-					'&:focus, &:active': {
+					'&:active': {
 						color: vars.color.n3,
 					},
 				},
@@ -85,7 +85,6 @@ export const variants = recipe({
 			lineHeight: '1em',
 			width: 'auto',
 			backgroundColor: 'transparent',
-			outline: 'none',
 			selectors: {
 				'&:hover': {
 					cursor: 'pointer',
@@ -133,12 +132,12 @@ export const variants = recipe({
 						background: vars.color.r9,
 						color: vars.color.white,
 					},
-					'&:focus, &:active': {
+					'&:active': {
 						background: vars.color.r9,
 						color: vars.color.white,
 						boxShadow: 'none',
 					},
-					'&[disabled], &[disabled]:hover, &[disabled]:focus': {
+					'&[disabled], &[disabled]:hover': {
 						background: vars.color.r7,
 						color: vars.color.n1,
 						boxShadow: 'none',
@@ -185,7 +184,7 @@ export const variants = recipe({
 						color: vars.theme.interactive.fill.primary.content
 							.onEnabled,
 					},
-					'&[disabled], &[disabled]:hover, &[disabled]:focus': {
+					'&[disabled], &[disabled]:hover': {
 						backgroundColor:
 							vars.theme.interactive.fill.primary.disabled,
 						color: vars.theme.interactive.fill.primary.disabled,
@@ -216,7 +215,7 @@ export const variants = recipe({
 						border: vars.border.primaryPressed,
 						color: vars.theme.interactive.fill.primary.content.text,
 					},
-					'&[disabled], &[disabled]:hover, &[disabled]:focus': {
+					'&[disabled], &[disabled]:hover': {
 						border: vars.border.primaryDisabled,
 						color: vars.theme.interactive.fill.primary.content
 							.onDisabled,
@@ -244,7 +243,7 @@ export const variants = recipe({
 							vars.theme.interactive.overlay.primary.pressed,
 						color: vars.theme.interactive.fill.primary.content.text,
 					},
-					'&[disabled], &[disabled]:hover, &[disabled]:focus': {
+					'&[disabled], &[disabled]:hover': {
 						color: vars.theme.interactive.fill.primary.content
 							.onDisabled,
 					},
@@ -274,7 +273,7 @@ export const variants = recipe({
 						color: vars.theme.interactive.fill.secondary.content
 							.onEnabled,
 					},
-					'&[disabled], &[disabled]:hover, &[disabled]:focus': {
+					'&[disabled], &[disabled]:hover': {
 						backgroundColor:
 							vars.theme.interactive.fill.secondary.disabled,
 						color: vars.theme.interactive.fill.secondary.content
@@ -308,7 +307,7 @@ export const variants = recipe({
 						color: vars.theme.interactive.fill.secondary.content
 							.text,
 					},
-					'&[disabled], &[disabled]:hover, &[disabled]:focus': {
+					'&[disabled], &[disabled]:hover': {
 						backgroundColor:
 							vars.theme.interactive.overlay.secondary.disabled,
 						border: vars.border.secondaryDisabled,
@@ -336,7 +335,7 @@ export const variants = recipe({
 						color: vars.theme.interactive.fill.secondary.content
 							.text,
 					},
-					'&[disabled], &[disabled]:hover, &[disabled]:focus': {
+					'&[disabled], &[disabled]:hover': {
 						backgroundColor:
 							vars.theme.interactive.overlay.secondary.disabled,
 					},

--- a/packages/ui/src/components/ButtonIcon/styles.css.ts
+++ b/packages/ui/src/components/ButtonIcon/styles.css.ts
@@ -44,7 +44,7 @@ export const variants = recipe({
 						color: colors.n10,
 						boxShadow: shadows.grey,
 					},
-					'&:focus:enabled, &:active:enabled': {
+					'&:active:enabled': {
 						backgroundColor: vars.color.n5,
 						boxShadow: 'none',
 					},
@@ -260,7 +260,7 @@ export const variants = recipe({
 						backgroundColor:
 							vars.theme.interactive.overlay.secondary.hover,
 					},
-					'&:focus:enabled, &:active:enabled': {
+					'&:active:enabled': {
 						backgroundColor:
 							vars.theme.interactive.overlay.secondary.pressed,
 					},

--- a/packages/ui/src/components/SwitchButton/styles.css.ts
+++ b/packages/ui/src/components/SwitchButton/styles.css.ts
@@ -16,11 +16,6 @@ export const variants = recipe({
 		sprinkles({ borderRadius: '6' }),
 		{
 			selectors: {
-				'&:focus': {
-					border: 0,
-					boxShadow: 'none',
-					outline: 'none',
-				},
 				'&:hover': {
 					cursor: 'pointer',
 				},


### PR DESCRIPTION
## Summary

We've been adding styles with a `:focus` selector but these are having some undesirable side effects (see Linear issue linked below). It also results in losing the visual indicator of the active element in many of our interactive elements.

This PR restores the default styles for focusable elements which fixes the originally reported issue of confusing styles after closing a menu and restores the visual indicator to most of our interactive elements.

This video shows the changes in this PR first and then loads production and tabs through the page.

https://www.loom.com/share/fe0199d54754416fbbfbbf153974e22c

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A