### PR TITLE
stub out page to load logs

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -237,6 +237,7 @@ func main() {
 		StepFunctions:          sfnClient,
 		OAuthServer:            oauthSrv,
 		IntegrationsClient:     integrationsClient,
+		ClickhouseClient:       clickhouseClient,
 	}
 	private.SetupAuthClient(oauthSrv, privateResolver.Query().APIKeyToOrgID)
 	r := chi.NewMux()

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -341,6 +341,12 @@ type LinearTeam struct {
 	Key    string `json:"key"`
 }
 
+type LogLine struct {
+	Timestamp    time.Time `json:"timestamp"`
+	SeverityText string    `json:"severityText"`
+	Body         string    `json:"body"`
+}
+
 type MetricPreview struct {
 	Date  time.Time `json:"date"`
 	Value float64   `json:"value"`

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/highlight-run/go-resthooks"
 	"github.com/highlight-run/highlight/backend/alerts/integrations/discord"
+	"github.com/highlight-run/highlight/backend/clickhouse"
 	"github.com/highlight-run/highlight/backend/clickup"
 	"github.com/highlight-run/highlight/backend/front"
 	"github.com/highlight-run/highlight/backend/integrations"
@@ -121,6 +122,7 @@ type Resolver struct {
 	StepFunctions          *stepfunctions.Client
 	OAuthServer            *oauth.Server
 	IntegrationsClient     *integrations.Client
+	ClickhouseClient       *clickhouse.Client
 }
 
 func (r *Resolver) getCurrentAdmin(ctx context.Context) (*model.Admin, error) {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -481,6 +481,11 @@ type SourceMappingError {
 type S3File {
 	key: String
 }
+type LogLine {
+	timestamp: Timestamp!
+	severityText: String!
+	body: String!
+}
 
 type ReferrerTablePayload {
 	host: String!
@@ -1363,6 +1368,7 @@ type Query {
 	sourcemap_versions(project_id: ID!): [String!]!
 	oauth_client_metadata(client_id: String!): OAuthClient
 	email_opt_outs(token: String, admin_id: ID): [EmailOptOutCategory!]!
+	logs(project_id: ID!): [LogLine!]!
 }
 
 type Mutation {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -53,7 +53,7 @@ import (
 	"github.com/rs/zerolog/pkgerrors"
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
-	"github.com/stripe/stripe-go/v72"
+	stripe "github.com/stripe/stripe-go/v72"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -6736,6 +6736,16 @@ func (r *queryResolver) EmailOptOuts(ctx context.Context, token *string, adminID
 	})
 
 	return results, nil
+}
+
+// Logs is the resolver for the logs field.
+func (r *queryResolver) Logs(ctx context.Context, projectID int) ([]*modelInputs.LogLine, error) {
+	project, err := r.isAdminInProject(ctx, projectID)
+	if err != nil {
+		return nil, e.Wrap(err, "error querying project")
+	}
+
+	return r.ClickhouseClient.ReadLogs(ctx, project.ID)
 }
 
 // Params is the resolver for the params field.

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -67,7 +67,7 @@ export const Header = () => {
 		project_id === DEMO_WORKSPACE_APPLICATION_ID
 			? DEMO_WORKSPACE_PROXY_APPLICATION_ID
 			: project_id
-	const { isLoggedIn } = useAuthContext()
+	const { isLoggedIn, isHighlightAdmin } = useAuthContext()
 	const { currentWorkspace } = useApplicationContext()
 	const workspaceId = currentWorkspace?.id
 
@@ -249,6 +249,33 @@ export const Header = () => {
 													</Box>
 												</Menu.Item>
 											</Link>
+											{isHighlightAdmin && (
+												<Link
+													to={`/${project_id}/logs`}
+													className={linkStyle}
+												>
+													<Menu.Item>
+														<Box
+															display="flex"
+															alignItems="center"
+															gap="4"
+														>
+															<IconSolidCog
+																size={14}
+																color={
+																	vars.theme
+																		.interactive
+																		.fill
+																		.secondary
+																		.content
+																		.text
+																}
+															/>
+															Logs
+														</Box>
+													</Menu.Item>
+												</Link>
+											)}
 										</Menu.List>
 									</Menu>
 								</Box>

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -11252,3 +11252,57 @@ export type GetEmailOptOutsQueryResult = Apollo.QueryResult<
 	Types.GetEmailOptOutsQuery,
 	Types.GetEmailOptOutsQueryVariables
 >
+export const GetLogsDocument = gql`
+	query GetLogs($project_id: ID!) {
+		logs(project_id: $project_id) {
+			timestamp
+			severityText
+			body
+		}
+	}
+`
+
+/**
+ * __useGetLogsQuery__
+ *
+ * To run a query within a React component, call `useGetLogsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetLogsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetLogsQuery({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *   },
+ * });
+ */
+export function useGetLogsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogsQuery,
+		Types.GetLogsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<Types.GetLogsQuery, Types.GetLogsQueryVariables>(
+		GetLogsDocument,
+		baseOptions,
+	)
+}
+export function useGetLogsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogsQuery,
+		Types.GetLogsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<Types.GetLogsQuery, Types.GetLogsQueryVariables>(
+		GetLogsDocument,
+		baseOptions,
+	)
+}
+export type GetLogsQueryHookResult = ReturnType<typeof useGetLogsQuery>
+export type GetLogsLazyQueryHookResult = ReturnType<typeof useGetLogsLazyQuery>
+export type GetLogsQueryResult = Apollo.QueryResult<
+	Types.GetLogsQuery,
+	Types.GetLogsQueryVariables
+>

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -3894,6 +3894,19 @@ export type GetEmailOptOutsQuery = { __typename?: 'Query' } & Pick<
 	'email_opt_outs'
 >
 
+export type GetLogsQueryVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+}>
+
+export type GetLogsQuery = { __typename?: 'Query' } & {
+	logs: Array<
+		{ __typename?: 'LogLine' } & Pick<
+			Types.LogLine,
+			'timestamp' | 'severityText' | 'body'
+		>
+	>
+}
+
 export const namedOperations = {
 	Query: {
 		GetMetricsTimeline: 'GetMetricsTimeline' as const,
@@ -4007,6 +4020,7 @@ export const namedOperations = {
 		GetErrorGroupFrequencies: 'GetErrorGroupFrequencies' as const,
 		GetErrorGroupTags: 'GetErrorGroupTags' as const,
 		GetEmailOptOuts: 'GetEmailOptOuts' as const,
+		GetLogs: 'GetLogs' as const,
 	},
 	Mutation: {
 		MarkSessionAsViewed: 'MarkSessionAsViewed' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -642,6 +642,13 @@ export type LinearTeam = {
 	team_id: Scalars['String']
 }
 
+export type LogLine = {
+	__typename?: 'LogLine'
+	body: Scalars['String']
+	severityText: Scalars['String']
+	timestamp: Scalars['Timestamp']
+}
+
 export type Metric = {
 	__typename?: 'Metric'
 	name: Scalars['String']
@@ -1374,6 +1381,7 @@ export type Query = {
 	joinable_workspaces?: Maybe<Array<Maybe<Workspace>>>
 	linear_teams?: Maybe<Array<LinearTeam>>
 	liveUsersCount?: Maybe<Scalars['Int64']>
+	logs: Array<LogLine>
 	messages?: Maybe<Array<Maybe<Scalars['Any']>>>
 	metric_monitors: Array<Maybe<MetricMonitor>>
 	metric_tag_values: Array<Scalars['String']>
@@ -1695,6 +1703,10 @@ export type QueryLinear_TeamsArgs = {
 }
 
 export type QueryLiveUsersCountArgs = {
+	project_id: Scalars['ID']
+}
+
+export type QueryLogsArgs = {
 	project_id: Scalars['ID']
 }
 

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1846,3 +1846,11 @@ query GetErrorGroupTags($error_group_secure_id: String!) {
 query GetEmailOptOuts($token: String, $admin_id: ID) {
 	email_opt_outs(token: $token, admin_id: $admin_id)
 }
+
+query GetLogs($project_id: ID!) {
+	logs(project_id: $project_id) {
+		timestamp
+		severityText
+		body
+	}
+}

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -1,0 +1,28 @@
+import JsonViewer from '@components/JsonViewer/JsonViewer'
+import { useGetLogsQuery } from '@graph/hooks'
+import { IconSolidLoading } from '@highlight-run/ui'
+import { useParams } from '@util/react-router/useParams'
+import React from 'react'
+import { Helmet } from 'react-helmet'
+
+const LogsPage = () => {
+	const { project_id } = useParams<{ project_id: string }>()
+	const { data, loading } = useGetLogsQuery({
+		variables: { project_id },
+	})
+
+	if (loading) {
+		return <IconSolidLoading />
+	}
+
+	return (
+		<>
+			<Helmet>
+				<title>Logs</title>
+			</Helmet>
+			<JsonViewer src={data as object} />
+		</>
+	)
+}
+
+export default LogsPage

--- a/frontend/src/routers/OrgRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/OrgRouter/ApplicationRouter.tsx
@@ -11,6 +11,7 @@ import { Redirect, Route, Switch } from 'react-router-dom'
 const Buttons = React.lazy(() => import('../../pages/Buttons/Buttons'))
 const HitTargets = React.lazy(() => import('../../pages/Buttons/HitTargets'))
 import { useErrorSearchContext } from '@pages/Errors/ErrorSearchContext/ErrorSearchContext'
+import LogsPage from '@pages/LogsPage/LogsPage'
 import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext'
 import { usePreloadErrors, usePreloadSessions } from '@util/preload'
 
@@ -27,7 +28,7 @@ const ApplicationRouter = ({ integrated }: Props) => {
 	usePreloadSessions({ page: page || 1 })
 	usePreloadErrors({ page: errorPage || 1 })
 	const { project_id } = useParams<{ project_id: string }>()
-	const { isLoggedIn } = useAuthContext()
+	const { isLoggedIn, isHighlightAdmin } = useAuthContext()
 
 	return (
 		<>
@@ -63,6 +64,11 @@ const ApplicationRouter = ({ integrated }: Props) => {
 				<Route path="/:project_id/setup">
 					<SetupRouter integrated={integrated} />
 				</Route>
+				{isHighlightAdmin && (
+					<Route path="/:project_id/logs">
+						<LogsPage />
+					</Route>
+				)}
 				<Route path="/:project_id/integrations/:integration_type?">
 					<IntegrationsPage />
 				</Route>


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

For the given data generated in #3606, this PR creates a stub page for showing the logs (`/${projectId}/logs`). This is only visible to Highlight admins.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Observe new log nav item:
![Screenshot 2023-01-26 at 12 02 06 PM](https://user-images.githubusercontent.com/58678/214926052-354c5390-f54c-4caa-8d73-c0c79ec34e88.png)

Observe log data shown in a simple json viewer:
![Screenshot 2023-01-26 at 12 02 15 PM](https://user-images.githubusercontent.com/58678/214926112-9f02f407-0b13-4659-8393-6fd25f01aaaf.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
