### PR TITLE
command to generate clickhouse databases

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -18,6 +18,10 @@ worker-test:
 		(cd ./worker; ENVIRONMENT=test LOG_LEVEL=debug PSQL_HOST=localhost PSQL_PORT=5432 PSQL_USER=postgres PSQL_PASSWORD=postgres go test ./... -v)
 test-and-coverage:
 		(ENVIRONMENT=test LOG_LEVEL=debug PSQL_HOST=localhost PSQL_PORT=5432 PSQL_USER=postgres PSQL_PASSWORD=postgres go test -p 1 -covermode=atomic -coverprofile=coverage.out ./... -v)
+init-clickhouse:
+		(go build; doppler run -- ./backend -runtime=worker -worker-handler=init-clickhouse)
+init-clickhouse-logs:
+		(go build; doppler run -- ./backend -runtime=worker -worker-handler=init-clickhouse-logs)
 init-opensearch:
 		(go build; doppler run -- ./backend -runtime=worker -worker-handler=init-opensearch)
 init-opensearch-sessions:

--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -67,7 +67,7 @@ func CreateDatabase() {
 	}
 
 	database := getDatabase()
-	err = conn.Exec(context.Background(), fmt.Sprintf("CREATE DATABASE `%s`", database))
+	err = conn.Exec(context.Background(), fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", database))
 	if err != nil {
 		log.Fatalf("CLICKHOUSE_ERROR failed to create `%s` database: %+v", database, err)
 	}

--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/highlight-run/highlight/backend/util"
@@ -47,7 +49,7 @@ func NewClient() (*Client, error) {
 	}, err
 }
 
-func CreateDatabase() error {
+func CreateDatabase() {
 	conn, err := clickhouse.Open(&clickhouse.Options{
 		Addr: []string{ServerAddr},
 		Auth: clickhouse.Auth{
@@ -61,8 +63,12 @@ func CreateDatabase() error {
 	})
 
 	if err != nil {
-		return err
+		log.Fatalf("CLICKHOUSE_ERROR failed to connect to `database` database: %+v", err)
 	}
 
-	return conn.Exec(context.Background(), fmt.Sprintf("CREATE DATABASE `%s`", getDatabase()))
+	database := getDatabase()
+	err = conn.Exec(context.Background(), fmt.Sprintf("CREATE DATABASE `%s`", database))
+	if err != nil {
+		log.Fatalf("CLICKHOUSE_ERROR failed to create `%s` database: %+v", database, err)
+	}
 }

--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/highlight-run/highlight/backend/util"
 )
 
 type Client struct {
@@ -16,7 +17,11 @@ type Client struct {
 }
 
 func getDatabase() string {
-	return os.Getenv("DOPPLER_CONFIG")
+	if util.IsDevEnv() {
+		return os.Getenv("DOPPLER_CONFIG")
+	} else {
+		return os.Getenv("CLICKHOUSE_DATABASE")
+	}
 }
 
 var (

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -18,11 +18,11 @@ type LogRow struct {
 	SecureSessionID string
 }
 
-func (client *Client) CreateLogsTable() error {
+func (client *Client) CreateLogsTable() {
 	ctx := context.Background()
 	client.conn.Exec(ctx, "DROP TABLE IF EXISTS logs") //nolint:errcheck
 
-	return client.conn.Exec(ctx, `
+	err := client.conn.Exec(ctx, `
 	CREATE TABLE IF NOT EXISTS logs (
 		Timestamp       DateTime64(9) CODEC (Delta, ZSTD(1)),
 		SeverityText    LowCardinality(String) CODEC (ZSTD(1)),
@@ -36,6 +36,10 @@ func (client *Client) CreateLogsTable() error {
 		TTL toDateTime(Timestamp) + toIntervalDay(30)
 		SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 	`)
+
+	if err != nil {
+		log.Fatalf("CLICKHOUSE_ERROR failed to create `logs` table: %+v", err)
+	}
 }
 
 type Message struct {

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -20,7 +20,6 @@ type LogRow struct {
 
 func (client *Client) CreateLogsTable() {
 	ctx := context.Background()
-	client.conn.Exec(ctx, "DROP TABLE IF EXISTS logs") //nolint:errcheck
 
 	err := client.conn.Exec(ctx, `
 	CREATE TABLE IF NOT EXISTS logs (

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -18,24 +18,25 @@ type LogRow struct {
 	SecureSessionID string
 }
 
-// func (client *Client) CreateLogsTable(ctx context.Context) error {
-// 	client.conn.Exec(ctx, "DROP TABLE IF EXISTS logs") //nolint:errcheck
+func (client *Client) CreateLogsTable() error {
+	ctx := context.Background()
+	client.conn.Exec(ctx, "DROP TABLE IF EXISTS logs") //nolint:errcheck
 
-// 	return client.conn.Exec(ctx, `
-// 	CREATE TABLE IF NOT EXISTS logs (
-// 		Timestamp       DateTime64(9) CODEC (Delta, ZSTD(1)),
-// 		SeverityText    LowCardinality(String) CODEC (ZSTD(1)),
-// 		Body            String CODEC (ZSTD(1)),
-// 		ProjectId 		UInt32 CODEC (ZSTD(1)),
-// 		SecureSessionID Nullable(String) CODEC (ZSTD(1))
-// 	)
-// 	ENGINE = MergeTree()
-// 		PARTITION BY toDate(Timestamp)
-// 		ORDER BY (ProjectId, toUnixTimestamp(Timestamp))
-// 		TTL toDateTime(Timestamp) + toIntervalDay(30)
-// 		SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
-// 	`)
-// }
+	return client.conn.Exec(ctx, `
+	CREATE TABLE IF NOT EXISTS logs (
+		Timestamp       DateTime64(9) CODEC (Delta, ZSTD(1)),
+		SeverityText    LowCardinality(String) CODEC (ZSTD(1)),
+		Body            String CODEC (ZSTD(1)),
+		ProjectId 		UInt32 CODEC (ZSTD(1)),
+		SecureSessionID Nullable(String) CODEC (ZSTD(1))
+	)
+	ENGINE = MergeTree()
+		PARTITION BY toDate(Timestamp)
+		ORDER BY (ProjectId, toUnixTimestamp(Timestamp))
+		TTL toDateTime(Timestamp) + toIntervalDay(30)
+		SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+	`)
+}
 
 type Message struct {
 	Type  string `json:"type"`

--- a/backend/main.go
+++ b/backend/main.go
@@ -237,6 +237,7 @@ func main() {
 		StepFunctions:          sfnClient,
 		OAuthServer:            oauthSrv,
 		IntegrationsClient:     integrationsClient,
+		ClickhouseClient:       clickhouseClient,
 	}
 	private.SetupAuthClient(oauthSrv, privateResolver.Query().APIKeyToOrgID)
 	r := chi.NewMux()

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/highlight-run/go-resthooks"
 	"github.com/highlight-run/highlight/backend/alerts/integrations/discord"
+	"github.com/highlight-run/highlight/backend/clickhouse"
 	"github.com/highlight-run/highlight/backend/clickup"
 	"github.com/highlight-run/highlight/backend/front"
 	"github.com/highlight-run/highlight/backend/integrations"
@@ -121,6 +122,7 @@ type Resolver struct {
 	StepFunctions          *stepfunctions.Client
 	OAuthServer            *oauth.Server
 	IntegrationsClient     *integrations.Client
+	ClickhouseClient       *clickhouse.Client
 }
 
 func (r *Resolver) getCurrentAdmin(ctx context.Context) (*model.Admin, error) {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -25,6 +25,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/highlight-run/highlight/backend/alerts"
+	"github.com/highlight-run/highlight/backend/clickhouse"
 	highlightErrors "github.com/highlight-run/highlight/backend/errors"
 	parse "github.com/highlight-run/highlight/backend/event-parse"
 	"github.com/highlight-run/highlight/backend/hlog"
@@ -1146,6 +1147,14 @@ func (w *Worker) InitializeOpenSearchSessions() {
 	}
 }
 
+func (w *Worker) InitializeClickhouse() {
+	clickhouse.CreateDatabase()
+}
+
+func (w *Worker) InitializeClickhouseLogs() {
+	w.Resolver.ClickhouseClient.CreateLogsTable()
+}
+
 func (w *Worker) InitializeOpenSearchIndex() {
 	w.InitIndexMappings()
 	w.IndexTable(opensearch.IndexFields, &model.Field{}, false)
@@ -1289,6 +1298,10 @@ func (w *Worker) GetHandler(handlerFlag string) func() {
 	switch handlerFlag {
 	case "report-stripe-usage":
 		return w.ReportStripeUsage
+	case "init-clickhouse":
+		return w.InitializeClickhouse
+	case "init-clickhouse-logs":
+		return w.InitializeClickhouseLogs
 	case "init-opensearch":
 		return w.InitializeOpenSearchIndex
 	case "init-opensearch-sessions":


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We need dedicated Clickhouse cloud databases for developer usage.

This PR operates similar to how we handle [initializing](https://www.notion.so/runhighlight/Running-the-App-8dd48f388f12443692340b5a0db1c717#3f6cd8e255474546a0a0b3187331c060) dedicated opensearch indexes.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Ran `cd backend && make init-clickhouse` and confirmed I have a database.

![Screenshot 2023-01-26 at 12 37 15 PM](https://user-images.githubusercontent.com/58678/214933192-b5994316-ddab-4d10-b97f-c3f3e1739bc4.png)

Ran `cd backend && make init-clickhouse-logs` and confirmed I have a `logs` table.
![Screenshot 2023-01-26 at 12 37 43 PM](https://user-images.githubusercontent.com/58678/214933255-fa56b292-17a0-4006-91e3-b43739439a69.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

* I will update the internal [docs](https://www.notion.so/runhighlight/Running-the-App-8dd48f388f12443692340b5a0db1c717) and ping the team that they need to run these `make` commands.
* Because this requires running a manual `make` command, I've opted to leave the prod environment to use the existing `CLICKHOUSE_DATABASE` (`default`) database to ensure there's no downtime.
* We should remove `CLICKHOUSE_DATABASE` from the `dev` config as it doesn't make sense anymore.