### PR TITLE
[HIG-3749] add batched message processing for log ingestion

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -58,7 +58,7 @@ type Messages struct {
 	Messages []Message `json:"messages"`
 }
 
-func (client *Client) ParseConsoleMessages(projectID int, sessionSecureID string, messages string) ([]*LogRow, error) {
+func ParseConsoleMessages(projectID int, sessionSecureID string, messages string) ([]*LogRow, error) {
 	messagesParsed := Messages{}
 	if err := json.Unmarshal([]byte(messages), &messagesParsed); err != nil {
 		return nil, e.Wrap(err, "error decoding message data")
@@ -78,7 +78,7 @@ func (client *Client) ParseConsoleMessages(projectID int, sessionSecureID string
 }
 
 func (client *Client) BatchWriteMessagesForSession(ctx context.Context, projectID int, sessionSecureID string, messages string) error {
-	messagesParsed, err := client.ParseConsoleMessages(projectID, sessionSecureID, messages)
+	messagesParsed, err := ParseConsoleMessages(projectID, sessionSecureID, messages)
 	if err != nil {
 		return e.Wrap(err, "error decoding message data")
 	}

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -66,10 +66,14 @@ type MessageQueue interface {
 	LogStats()
 }
 
-func GetTopic(batched bool) string {
+type GetTopicOptions struct {
+	Batched bool
+}
+
+func GetTopic(options GetTopicOptions) string {
 	topic := os.Getenv("KAFKA_TOPIC")
 	topic = fmt.Sprintf("%s_%s", EnvironmentPrefix, topic)
-	if batched {
+	if options.Batched {
 		topic = fmt.Sprintf("%s_%s", topic, BatchedTopicSuffix)
 	}
 	return topic

--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -1,6 +1,7 @@
 package kafka_queue
 
 import (
+	"github.com/highlight-run/highlight/backend/clickhouse"
 	"time"
 
 	customModels "github.com/highlight-run/highlight/backend/public-graph/graph/model"
@@ -19,6 +20,7 @@ const (
 	PushMetrics          PayloadType = iota
 	MarkBackendSetup     PayloadType = iota
 	AddSessionFeedback   PayloadType = iota
+	PushLogs             PayloadType = iota
 )
 
 type PushPayloadArgs struct {
@@ -73,24 +75,29 @@ type PushBackendPayloadArgs struct {
 }
 
 type PushMetricsArgs struct {
-	SecureID  string
-	SessionID int
-	ProjectID int
-	Metrics   []*customModels.MetricInput
+	SessionSecureID string
+	SessionID       int
+	ProjectID       int
+	Metrics         []*customModels.MetricInput
 }
 
 type MarkBackendSetupArgs struct {
-	SecureID         *string
-	ProjectID        int
 	ProjectVerboseID *string
+	SessionSecureID  *string
+	ProjectID        int
 }
 
 type AddSessionFeedbackArgs struct {
-	SecureID  string
-	UserName  *string
-	UserEmail *string
-	Verbatim  string
-	Timestamp time.Time
+	SessionSecureID string
+	UserName        *string
+	UserEmail       *string
+	Verbatim        string
+	Timestamp       time.Time
+}
+
+type PushLogsArgs struct {
+	SessionSecureID string
+	LogRows         []*clickhouse.LogRow
 }
 
 type Message struct {
@@ -107,6 +114,7 @@ type Message struct {
 	PushMetrics          *PushMetricsArgs
 	MarkBackendSetup     *MarkBackendSetupArgs
 	AddSessionFeedback   *AddSessionFeedbackArgs
+	PushLogs             *PushLogsArgs
 }
 
 type PartitionMessage struct {

--- a/backend/main.go
+++ b/backend/main.go
@@ -350,6 +350,7 @@ func main() {
 			DB:              db,
 			TDB:             tdb,
 			ProducerQueue:   kafka_queue.New(os.Getenv("KAFKA_TOPIC"), kafka_queue.Producer),
+			BatchedQueue:    kafka_queue.New(os.Getenv("KAFKA_BATCH_TOPIC"), kafka_queue.Producer),
 			MailClient:      sendgrid.NewSendClient(sendgridKey),
 			StorageClient:   storage,
 			AlertWorkerPool: alertWorkerpool,
@@ -442,9 +443,11 @@ func main() {
 		alertWorkerpool := workerpool.New(40)
 		alertWorkerpool.SetPanicHandler(util.Recover)
 		publicResolver := &public.Resolver{
-			DB:              db,
-			TDB:             tdb,
-			ProducerQueue:   kafka_queue.New(os.Getenv("KAFKA_TOPIC"), kafka_queue.Producer),
+			DB:            db,
+			TDB:           tdb,
+			ProducerQueue: kafka_queue.New(os.Getenv("KAFKA_TOPIC"), kafka_queue.Producer),
+			// TODO(vkorolik) create topic env var
+			BatchedQueue:    kafka_queue.New(os.Getenv("KAFKA_BATCH_TOPIC"), kafka_queue.Producer),
 			MailClient:      sendgrid.NewSendClient(sendgridKey),
 			StorageClient:   storage,
 			AlertWorkerPool: alertWorkerpool,

--- a/backend/main.go
+++ b/backend/main.go
@@ -349,8 +349,8 @@ func main() {
 		publicResolver := &public.Resolver{
 			DB:              db,
 			TDB:             tdb,
-			ProducerQueue:   kafka_queue.New(os.Getenv("KAFKA_TOPIC"), kafka_queue.Producer),
-			BatchedQueue:    kafka_queue.New(os.Getenv("KAFKA_BATCH_TOPIC"), kafka_queue.Producer),
+			ProducerQueue:   kafka_queue.New(kafka_queue.GetTopic(false), kafka_queue.Producer),
+			BatchedQueue:    kafka_queue.New(kafka_queue.GetTopic(true), kafka_queue.Producer),
 			MailClient:      sendgrid.NewSendClient(sendgridKey),
 			StorageClient:   storage,
 			AlertWorkerPool: alertWorkerpool,
@@ -443,11 +443,10 @@ func main() {
 		alertWorkerpool := workerpool.New(40)
 		alertWorkerpool.SetPanicHandler(util.Recover)
 		publicResolver := &public.Resolver{
-			DB:            db,
-			TDB:           tdb,
-			ProducerQueue: kafka_queue.New(os.Getenv("KAFKA_TOPIC"), kafka_queue.Producer),
-			// TODO(vkorolik) create topic env var
-			BatchedQueue:    kafka_queue.New(os.Getenv("KAFKA_BATCH_TOPIC"), kafka_queue.Producer),
+			DB:              db,
+			TDB:             tdb,
+			ProducerQueue:   kafka_queue.New(kafka_queue.GetTopic(false), kafka_queue.Producer),
+			BatchedQueue:    kafka_queue.New(kafka_queue.GetTopic(true), kafka_queue.Producer),
 			MailClient:      sendgrid.NewSendClient(sendgridKey),
 			StorageClient:   storage,
 			AlertWorkerPool: alertWorkerpool,

--- a/backend/main.go
+++ b/backend/main.go
@@ -349,8 +349,8 @@ func main() {
 		publicResolver := &public.Resolver{
 			DB:              db,
 			TDB:             tdb,
-			ProducerQueue:   kafka_queue.New(kafka_queue.GetTopic(false), kafka_queue.Producer),
-			BatchedQueue:    kafka_queue.New(kafka_queue.GetTopic(true), kafka_queue.Producer),
+			ProducerQueue:   kafka_queue.New(kafka_queue.GetTopic(kafka_queue.GetTopicOptions{Batched: false}), kafka_queue.Producer),
+			BatchedQueue:    kafka_queue.New(kafka_queue.GetTopic(kafka_queue.GetTopicOptions{Batched: true}), kafka_queue.Producer),
 			MailClient:      sendgrid.NewSendClient(sendgridKey),
 			StorageClient:   storage,
 			AlertWorkerPool: alertWorkerpool,
@@ -445,8 +445,8 @@ func main() {
 		publicResolver := &public.Resolver{
 			DB:              db,
 			TDB:             tdb,
-			ProducerQueue:   kafka_queue.New(kafka_queue.GetTopic(false), kafka_queue.Producer),
-			BatchedQueue:    kafka_queue.New(kafka_queue.GetTopic(true), kafka_queue.Producer),
+			ProducerQueue:   kafka_queue.New(kafka_queue.GetTopic(kafka_queue.GetTopicOptions{Batched: false}), kafka_queue.Producer),
+			BatchedQueue:    kafka_queue.New(kafka_queue.GetTopic(kafka_queue.GetTopicOptions{Batched: true}), kafka_queue.Producer),
 			MailClient:      sendgrid.NewSendClient(sendgridKey),
 			StorageClient:   storage,
 			AlertWorkerPool: alertWorkerpool,

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2701,17 +2701,19 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			tracer.ResourceName("go.unmarshal.messages"), tracer.Tag("project_id", projectID))
 		defer unmarshalMessagesSpan.Finish()
 
-		logRows, err := clickhouse.ParseConsoleMessages(projectID, sessionSecureID, messages)
-		if err != nil {
-			log.WithError(err).Error("failed to parse console messages")
-		} else {
-			if err := r.BatchedQueue.Submit(&kafka_queue.Message{
-				Type: kafka_queue.PushLogs,
-				PushLogs: &kafka_queue.PushLogsArgs{
-					SessionSecureID: sessionSecureID,
-					LogRows:         logRows,
-				}}, sessionSecureID); err != nil {
-				log.WithError(err).Error("error writing console messages to clickhouse")
+		if projectID == 1 {
+			logRows, err := clickhouse.ParseConsoleMessages(projectID, sessionSecureID, messages)
+			if err != nil {
+				log.WithError(err).Error("failed to parse console messages")
+			} else {
+				if err := r.BatchedQueue.Submit(&kafka_queue.Message{
+					Type: kafka_queue.PushLogs,
+					PushLogs: &kafka_queue.PushLogsArgs{
+						SessionSecureID: sessionSecureID,
+						LogRows:         logRows,
+					}}, sessionSecureID); err != nil {
+					log.WithError(err).Error("error writing console messages to clickhouse")
+				}
 			}
 		}
 

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2701,7 +2701,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			tracer.ResourceName("go.unmarshal.messages"), tracer.Tag("project_id", projectID))
 		defer unmarshalMessagesSpan.Finish()
 
-		logRows, err := r.Clickhouse.ParseConsoleMessages(projectID, sessionSecureID, messages)
+		logRows, err := clickhouse.ParseConsoleMessages(projectID, sessionSecureID, messages)
 		if err != nil {
 			log.WithError(err).Error("failed to parse console messages")
 		} else {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1472,7 +1472,7 @@ func (r *Resolver) AddSessionFeedbackImpl(ctx context.Context, input *kafka_queu
 	metadata["timestamp"] = input.Timestamp
 
 	session := &model.Session{}
-	if err := r.DB.Select("project_id", "environment", "id", "secure_id").Where(&model.Session{SecureID: input.SecureID}).First(&session).Error; err != nil {
+	if err := r.DB.Select("project_id", "environment", "id", "secure_id").Where(&model.Session{SecureID: input.SessionSecureID}).First(&session).Error; err != nil {
 		return e.Wrap(err, "error querying session by sessionSecureID for adding session feedback")
 	}
 
@@ -2018,8 +2018,8 @@ func (r *Resolver) SubmitMetricsMessage(ctx context.Context, metrics []*publicMo
 		err := r.ProducerQueue.Submit(&kafka_queue.Message{
 			Type: kafka_queue.PushMetrics,
 			PushMetrics: &kafka_queue.PushMetricsArgs{
-				SecureID: secureID,
-				Metrics:  metrics,
+				SessionSecureID: secureID,
+				Metrics:         metrics,
 			}}, secureID)
 		if err != nil {
 			log.Error(err)
@@ -2701,26 +2701,22 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			tracer.ResourceName("go.unmarshal.messages"), tracer.Tag("project_id", projectID))
 		defer unmarshalMessagesSpan.Finish()
 
-		if sessionObj.AvoidPostgresStorage {
-			if err := r.SaveSessionData(ctx, projectID, sessionID, payloadIdDeref, false, isBeacon, model.PayloadTypeMessages, []byte(messages)); err != nil {
-				return e.Wrap(err, "error saving messages data")
-			}
+		logRows, err := r.Clickhouse.ParseConsoleMessages(projectID, sessionSecureID, messages)
+		if err != nil {
+			log.WithError(err).Error("failed to parse console messages")
 		} else {
-			// TODO - this code path is no longer hit.
-			if hasBeacon {
-				r.DB.Where(&model.MessagesObject{SessionID: sessionID, IsBeacon: true}).Delete(&model.MessagesObject{})
+			if err := r.BatchedQueue.Submit(&kafka_queue.Message{
+				Type: kafka_queue.PushLogs,
+				PushLogs: &kafka_queue.PushLogsArgs{
+					SessionSecureID: sessionSecureID,
+					LogRows:         logRows,
+				}}, sessionSecureID); err != nil {
+				log.WithError(err).Error("error writing console messages to clickhouse")
 			}
-			messagesParsed := make(map[string][]interface{})
-			if err := json.Unmarshal([]byte(messages), &messagesParsed); err != nil {
-				return e.Wrap(err, "error decoding message data")
-			}
-			if len(messagesParsed["messages"]) > 0 {
-				obj := &model.MessagesObject{SessionID: sessionID, Messages: messages, IsBeacon: isBeacon}
-				if err := r.DB.Create(obj).Error; err != nil {
-					return e.Wrap(err, "error creating messages object")
-				}
-			}
-			// End dead code path
+		}
+
+		if err := r.SaveSessionData(ctx, projectID, sessionID, payloadIdDeref, false, isBeacon, model.PayloadTypeMessages, []byte(messages)); err != nil {
+			return e.Wrap(err, "error saving messages data")
 		}
 		return nil
 	})

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -58,6 +58,7 @@ type Resolver struct {
 	DB              *gorm.DB
 	TDB             timeseries.DB
 	ProducerQueue   *kafka_queue.Queue
+	BatchedQueue    *kafka_queue.Queue
 	MailClient      *sendgrid.Client
 	StorageClient   *storage.StorageClient
 	OpenSearch      *opensearch.Client
@@ -2721,15 +2722,6 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			}
 			// End dead code path
 		}
-
-		// Only set for main Highlight project
-		if projectID == 1 {
-			if err := r.Clickhouse.BatchWriteMessagesForSession(ctx, projectID, sessionSecureID, messages); err != nil {
-				// If there's an issue with Clickhouse, we'll just log for investigation instead of building up a kafka backlog
-				log.WithError(err).Error("error writing console messages to clickhouse")
-			}
-		}
-
 		return nil
 	})
 

--- a/backend/scripts/reset-kafka-offset/main.go
+++ b/backend/scripts/reset-kafka-offset/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	k := kafkaqueue.New(kafkaqueue.GetTopic(false), kafkaqueue.Consumer)
+	k := kafkaqueue.New(kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Batched: false}), kafkaqueue.Consumer)
 	err := k.Rewind(24 * 7 * time.Hour)
 	if err != nil {
 		log.Error(err)

--- a/backend/scripts/reset-kafka-offset/main.go
+++ b/backend/scripts/reset-kafka-offset/main.go
@@ -3,12 +3,11 @@ package main
 import (
 	kafkaqueue "github.com/highlight-run/highlight/backend/kafka-queue"
 	log "github.com/sirupsen/logrus"
-	"os"
 	"time"
 )
 
 func main() {
-	k := kafkaqueue.New(os.Getenv("KAFKA_TOPIC"), kafkaqueue.Consumer)
+	k := kafkaqueue.New(kafkaqueue.GetTopic(false), kafkaqueue.Consumer)
 	err := k.Rewind(24 * 7 * time.Hour)
 	if err != nil {
 		log.Error(err)

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -100,9 +100,11 @@ func (k *KafkaBatchWorker) ProcessMessages() {
 			s.SetTag("worker.goroutine", k.WorkerThread)
 			defer s.Finish()
 
-			oldest := k.messageQueue[0]
-			if time.Since(oldest.KafkaMessage.Time) > BatchedFlushTimeout {
-				k.flush(ctx)
+			if len(k.messageQueue) > 0 {
+				oldest := k.messageQueue[0]
+				if time.Since(oldest.KafkaMessage.Time) > BatchedFlushTimeout {
+					k.flush(ctx)
+				}
 			}
 
 			s1, _ := tracer.StartSpanFromContext(ctx, "kafkaWorker", tracer.ResourceName("worker.kafka.batched.receive"))

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -83,9 +83,9 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 		}
 	}
 
-	err := k.Worker.PublicResolver.Clickhouse.BatchWriteLogRows(context.Background(), logRows)
+	err := k.Worker.PublicResolver.Clickhouse.BatchWriteLogRows(ctx, logRows)
 	if err != nil {
-		log.Error(err)
+		log.WithContext(ctx).WithError(err).Error("failed to batch write to clickhouse")
 	}
 
 	k.KafkaQueue.Commit(k.messageQueue[len(k.messageQueue)-1].KafkaMessage)

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -427,7 +427,7 @@ func (w *Worker) PublicWorker() {
 	for i := 0; i < parallelWorkers; i++ {
 		go func(workerId int) {
 			k := KafkaWorker{
-				KafkaQueue:   kafkaqueue.New(kafkaqueue.GetTopic(false), kafkaqueue.Consumer),
+				KafkaQueue:   kafkaqueue.New(kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Batched: false}), kafkaqueue.Consumer),
 				Worker:       w,
 				WorkerThread: workerId,
 			}
@@ -436,7 +436,7 @@ func (w *Worker) PublicWorker() {
 		}(i)
 		go func(workerId int) {
 			k := KafkaBatchWorker{
-				KafkaQueue:   kafkaqueue.New(kafkaqueue.GetTopic(true), kafkaqueue.Consumer),
+				KafkaQueue:   kafkaqueue.New(kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Batched: true}), kafkaqueue.Consumer),
 				Worker:       w,
 				WorkerThread: workerId,
 			}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -427,7 +427,7 @@ func (w *Worker) PublicWorker() {
 	for i := 0; i < parallelWorkers; i++ {
 		go func(workerId int) {
 			k := KafkaWorker{
-				KafkaQueue:   kafkaqueue.New(os.Getenv("KAFKA_TOPIC"), kafkaqueue.Consumer),
+				KafkaQueue:   kafkaqueue.New(kafkaqueue.GetTopic(false), kafkaqueue.Consumer),
 				Worker:       w,
 				WorkerThread: workerId,
 			}
@@ -436,7 +436,7 @@ func (w *Worker) PublicWorker() {
 		}(i)
 		go func(workerId int) {
 			k := KafkaBatchWorker{
-				KafkaQueue:   kafkaqueue.New(os.Getenv("KAFKA_BATCH_TOPIC"), kafkaqueue.Consumer),
+				KafkaQueue:   kafkaqueue.New(kafkaqueue.GetTopic(true), kafkaqueue.Consumer),
 				Worker:       w,
 				WorkerThread: workerId,
 			}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -390,7 +390,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 		if task.PushMetrics == nil {
 			break
 		}
-		if err := w.PublicResolver.PushMetricsImpl(ctx, task.PushMetrics.SecureID, task.PushMetrics.Metrics); err != nil {
+		if err := w.PublicResolver.PushMetricsImpl(ctx, task.PushMetrics.SessionSecureID, task.PushMetrics.Metrics); err != nil {
 			log.Error(errors.Wrap(err, "failed to process PushMetricsImpl task"))
 			return err
 		}
@@ -398,7 +398,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 		if task.MarkBackendSetup == nil {
 			break
 		}
-		if err := w.PublicResolver.MarkBackendSetupImpl(task.MarkBackendSetup.ProjectVerboseID, task.MarkBackendSetup.SecureID, task.MarkBackendSetup.ProjectID); err != nil {
+		if err := w.PublicResolver.MarkBackendSetupImpl(task.MarkBackendSetup.ProjectVerboseID, task.MarkBackendSetup.SessionSecureID, task.MarkBackendSetup.ProjectID); err != nil {
 			log.Error(errors.Wrap(err, "failed to process MarkBackendSetup task"))
 			return err
 		}


### PR DESCRIPTION
## Summary

Log data should be written to clickhouse in batches per their recommendations, especially when log writes can be frequent.
Adds a new separate kafka queue used for batched messages (only logs for now). Workers consume
these messages until the batch size or batch timeout is hit, at which point they are processed and written to clickhouse
with the entire batch.

## How did you test this change?

Local deploy observing creating and using the batched kafka queue.

## Are there any deployment considerations?

No

- [x] add tracing