### PR TITLE
switch readmessage to fetchmessage

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -251,7 +251,7 @@ func (p *Queue) Receive() (msg *Message) {
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(context.Background(), KafkaOperationTimeout)
 	defer cancel()
-	m, err := p.kafkaC.ReadMessage(ctx)
+	m, err := p.kafkaC.FetchMessage(ctx)
 	if err != nil {
 		if err.Error() != "context deadline exceeded" {
 			log.Error(errors.Wrap(err, "failed to receive message"))


### PR DESCRIPTION
## Summary

Turns out our explicit commit logic wasn't doing anything because `ReceiveMessage` was doing an implicit commit.
Switch to [FetchMessage](https://pkg.go.dev/github.com/segmentio/kafka-go#Reader.FetchMessage) to allow manual committing.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

No.