### PR TITLE
[HIG-3749] add batched message processing for log ingestion

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -58,25 +58,13 @@ type Messages struct {
 	Messages []Message `json:"messages"`
 }
 
-func (client *Client) BatchWriteMessagesForSession(ctx context.Context, projectID int, sessionSecureID string, messages string) error {
+func ParseConsoleMessages(projectID int, sessionSecureID string, messages string) ([]*LogRow, error) {
 	messagesParsed := Messages{}
 	if err := json.Unmarshal([]byte(messages), &messagesParsed); err != nil {
-		return e.Wrap(err, "error decoding message data")
-	}
-	if len(messagesParsed.Messages) == 0 {
-		return nil
+		return nil, e.Wrap(err, "error decoding message data")
 	}
 
-	query := fmt.Sprintf(`
-		INSERT INTO %s
-	`, LogsTable)
-
-	batch, err := client.conn.PrepareBatch(ctx, query)
-
-	if err != nil {
-		return e.Wrap(err, "failed to create logs batch")
-	}
-
+	var logRows []*LogRow
 	for _, message := range messagesParsed.Messages {
 		logRow, err := makeLogRow(projectID, sessionSecureID, message)
 		if err != nil {
@@ -84,7 +72,27 @@ func (client *Client) BatchWriteMessagesForSession(ctx context.Context, projectI
 			log.WithError(err).Error("failed to parse log message")
 			continue
 		}
+		logRows = append(logRows, logRow)
+	}
+	return logRows, nil
+}
 
+func (client *Client) BatchWriteMessagesForSession(ctx context.Context, projectID int, sessionSecureID string, messages string) error {
+	messagesParsed, err := ParseConsoleMessages(projectID, sessionSecureID, messages)
+	if err != nil {
+		return e.Wrap(err, "error decoding message data")
+	}
+	return client.BatchWriteLogRows(ctx, messagesParsed)
+}
+
+func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) error {
+	batch, err := client.conn.PrepareBatch(ctx, "INSERT INTO logs")
+
+	if err != nil {
+		return e.Wrap(err, "failed to create logs batch")
+	}
+
+	for _, logRow := range logRows {
 		err = batch.AppendStruct(logRow)
 		if err != nil {
 			return err

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -24,6 +24,7 @@ import (
 const KafkaOperationTimeout = 25 * time.Second
 
 const ConsumerGroupName = "group-default"
+const BatchedTopicSuffix = "batched"
 
 const (
 	taskRetries           = 5
@@ -63,6 +64,19 @@ type MessageQueue interface {
 	Receive() *Message
 	Submit(*Message, int)
 	LogStats()
+}
+
+type GetTopicOptions struct {
+	Batched bool
+}
+
+func GetTopic(options GetTopicOptions) string {
+	topic := os.Getenv("KAFKA_TOPIC")
+	topic = fmt.Sprintf("%s_%s", EnvironmentPrefix, topic)
+	if options.Batched {
+		topic = fmt.Sprintf("%s_%s", topic, BatchedTopicSuffix)
+	}
+	return topic
 }
 
 func New(topic string, mode Mode) *Queue {
@@ -115,7 +129,6 @@ func New(topic string, mode Mode) *Queue {
 	if util.IsDevOrTestEnv() {
 		// create per-profile consumer and topic to avoid collisions between dev envs
 		groupID = fmt.Sprintf("%s_%s", EnvironmentPrefix, groupID)
-		topic = fmt.Sprintf("%s_%s", EnvironmentPrefix, topic)
 		_, err := client.CreateTopics(context.Background(), &kafka.CreateTopicsRequest{
 			Topics: []kafka.TopicConfig{{
 				Topic:             topic,
@@ -170,7 +183,7 @@ func New(topic string, mode Mode) *Queue {
 			// override batch limit to be our message max size
 			BatchBytes:   messageSizeBytes,
 			BatchSize:    1,
-			ReadTimeout:  KafkaOperationTimeout,
+			ReadTimeout:  5 * time.Second,
 			WriteTimeout: KafkaOperationTimeout,
 			// low timeout because we don't want to block WriteMessage calls since we are sync mode
 			BatchTimeout: 1 * time.Millisecond,

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -72,7 +72,9 @@ type GetTopicOptions struct {
 
 func GetTopic(options GetTopicOptions) string {
 	topic := os.Getenv("KAFKA_TOPIC")
-	topic = fmt.Sprintf("%s_%s", EnvironmentPrefix, topic)
+	if len(EnvironmentPrefix) > 0 {
+		topic = fmt.Sprintf("%s_%s", EnvironmentPrefix, topic)
+	}
 	if options.Batched {
 		topic = fmt.Sprintf("%s_%s", topic, BatchedTopicSuffix)
 	}

--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -1,6 +1,7 @@
 package kafka_queue
 
 import (
+	"github.com/highlight-run/highlight/backend/clickhouse"
 	"time"
 
 	customModels "github.com/highlight-run/highlight/backend/public-graph/graph/model"
@@ -19,6 +20,7 @@ const (
 	PushMetrics          PayloadType = iota
 	MarkBackendSetup     PayloadType = iota
 	AddSessionFeedback   PayloadType = iota
+	PushLogs             PayloadType = iota
 )
 
 type PushPayloadArgs struct {
@@ -73,24 +75,29 @@ type PushBackendPayloadArgs struct {
 }
 
 type PushMetricsArgs struct {
-	SecureID  string
-	SessionID int
-	ProjectID int
-	Metrics   []*customModels.MetricInput
+	SessionSecureID string
+	SessionID       int
+	ProjectID       int
+	Metrics         []*customModels.MetricInput
 }
 
 type MarkBackendSetupArgs struct {
-	SecureID         *string
-	ProjectID        int
 	ProjectVerboseID *string
+	SessionSecureID  *string
+	ProjectID        int
 }
 
 type AddSessionFeedbackArgs struct {
-	SecureID  string
-	UserName  *string
-	UserEmail *string
-	Verbatim  string
-	Timestamp time.Time
+	SessionSecureID string
+	UserName        *string
+	UserEmail       *string
+	Verbatim        string
+	Timestamp       time.Time
+}
+
+type PushLogsArgs struct {
+	SessionSecureID string
+	LogRows         []*clickhouse.LogRow
 }
 
 type Message struct {
@@ -107,6 +114,7 @@ type Message struct {
 	PushMetrics          *PushMetricsArgs
 	MarkBackendSetup     *MarkBackendSetupArgs
 	AddSessionFeedback   *AddSessionFeedbackArgs
+	PushLogs             *PushLogsArgs
 }
 
 type PartitionMessage struct {

--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -2,6 +2,7 @@ package kafka_queue
 
 import (
 	"github.com/highlight-run/highlight/backend/clickhouse"
+	"math"
 	"time"
 
 	customModels "github.com/highlight-run/highlight/backend/public-graph/graph/model"
@@ -21,6 +22,7 @@ const (
 	MarkBackendSetup     PayloadType = iota
 	AddSessionFeedback   PayloadType = iota
 	PushLogs             PayloadType = iota
+	HealthCheck          PayloadType = math.MaxInt
 )
 
 type PushPayloadArgs struct {

--- a/backend/main.go
+++ b/backend/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"gorm.io/gorm"
 	"html/template"
 	"io"
 	"net/http"
@@ -99,20 +98,20 @@ func init() {
 	runtimeParsed = util.Runtime(*runtimeFlag)
 }
 
-func healthRouter(runtimeFlag util.Runtime, db *gorm.DB) http.HandlerFunc {
+func healthRouter(runtimeFlag util.Runtime) http.HandlerFunc {
+	// only checks kafka because kafka is the only critical infrastructure needed for public graph to be healthy.
+	topic := kafka_queue.GetTopic(kafka_queue.GetTopicOptions{Batched: false})
+	queue := kafka_queue.New(topic, kafka_queue.Producer)
+	batchedTopic := kafka_queue.GetTopic(kafka_queue.GetTopicOptions{Batched: true})
+	batchedQueue := kafka_queue.New(batchedTopic, kafka_queue.Producer)
 	return func(w http.ResponseWriter, r *http.Request) {
-		var value int
-		if err := db.Raw(`SELECT 1`).First(&value).Error; err != nil || value != 1 {
-			http.Error(w, "failed to query postgres", 500)
+		if err := queue.Submit(&kafka_queue.Message{Type: kafka_queue.HealthCheck}, "health"); err != nil {
+			http.Error(w, fmt.Sprintf("failed to write message to kafka %s", topic), 500)
 			return
 		}
-		for _, batched := range []bool{false, true} {
-			topic := kafka_queue.GetTopic(kafka_queue.GetTopicOptions{Batched: batched})
-			queue := kafka_queue.New(topic, kafka_queue.Producer)
-			if err := queue.Submit(&kafka_queue.Message{Type: kafka_queue.HealthCheck}, "health"); err != nil || value != 1 {
-				http.Error(w, fmt.Sprintf("failed to write message to kafka %s", topic), 500)
-				return
-			}
+		if err := batchedQueue.Submit(&kafka_queue.Message{Type: kafka_queue.HealthCheck}, "health"); err != nil {
+			http.Error(w, fmt.Sprintf("failed to write message to kafka %s", batchedTopic), 500)
+			return
 		}
 		_, err := w.Write([]byte(fmt.Sprintf("%v is healthy", runtimeFlag)))
 		if err != nil {
@@ -272,7 +271,7 @@ func main() {
 		AllowCredentials:       true,
 		AllowedHeaders:         []string{"*"},
 	}).Handler)
-	r.HandleFunc("/health", healthRouter(runtimeParsed, db))
+	r.HandleFunc("/health", healthRouter(runtimeParsed))
 
 	zapierStore := zapier.ZapierResthookStore{
 		DB: db,

--- a/backend/main.go
+++ b/backend/main.go
@@ -349,7 +349,8 @@ func main() {
 		publicResolver := &public.Resolver{
 			DB:              db,
 			TDB:             tdb,
-			ProducerQueue:   kafka_queue.New(os.Getenv("KAFKA_TOPIC"), kafka_queue.Producer),
+			ProducerQueue:   kafka_queue.New(kafka_queue.GetTopic(kafka_queue.GetTopicOptions{Batched: false}), kafka_queue.Producer),
+			BatchedQueue:    kafka_queue.New(kafka_queue.GetTopic(kafka_queue.GetTopicOptions{Batched: true}), kafka_queue.Producer),
 			MailClient:      sendgrid.NewSendClient(sendgridKey),
 			StorageClient:   storage,
 			AlertWorkerPool: alertWorkerpool,
@@ -444,7 +445,8 @@ func main() {
 		publicResolver := &public.Resolver{
 			DB:              db,
 			TDB:             tdb,
-			ProducerQueue:   kafka_queue.New(os.Getenv("KAFKA_TOPIC"), kafka_queue.Producer),
+			ProducerQueue:   kafka_queue.New(kafka_queue.GetTopic(kafka_queue.GetTopicOptions{Batched: false}), kafka_queue.Producer),
+			BatchedQueue:    kafka_queue.New(kafka_queue.GetTopic(kafka_queue.GetTopicOptions{Batched: true}), kafka_queue.Producer),
 			MailClient:      sendgrid.NewSendClient(sendgridKey),
 			StorageClient:   storage,
 			AlertWorkerPool: alertWorkerpool,

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -169,7 +169,7 @@ func (r *mutationResolver) MarkBackendSetup(ctx context.Context, projectID *stri
 		Type: kafkaqueue.MarkBackendSetup,
 		MarkBackendSetup: &kafkaqueue.MarkBackendSetupArgs{
 			ProjectVerboseID: projectID,
-			SecureID:         sessionSecureID,
+			SessionSecureID:  sessionSecureID,
 		}}, partitionKey)
 	return nil, err
 }
@@ -179,11 +179,11 @@ func (r *mutationResolver) AddSessionFeedback(ctx context.Context, sessionSecure
 	err := r.ProducerQueue.Submit(&kafkaqueue.Message{
 		Type: kafkaqueue.AddSessionFeedback,
 		AddSessionFeedback: &kafkaqueue.AddSessionFeedbackArgs{
-			SecureID:  sessionSecureID,
-			UserName:  userName,
-			UserEmail: userEmail,
-			Verbatim:  verbatim,
-			Timestamp: timestamp,
+			SessionSecureID: sessionSecureID,
+			UserName:        userName,
+			UserEmail:       userEmail,
+			Verbatim:        verbatim,
+			Timestamp:       timestamp,
 		}}, sessionSecureID)
 
 	return sessionSecureID, err

--- a/backend/scripts/reset-kafka-offset/main.go
+++ b/backend/scripts/reset-kafka-offset/main.go
@@ -3,12 +3,11 @@ package main
 import (
 	kafkaqueue "github.com/highlight-run/highlight/backend/kafka-queue"
 	log "github.com/sirupsen/logrus"
-	"os"
 	"time"
 )
 
 func main() {
-	k := kafkaqueue.New(os.Getenv("KAFKA_TOPIC"), kafkaqueue.Consumer)
+	k := kafkaqueue.New(kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Batched: false}), kafkaqueue.Consumer)
 	err := k.Rewind(24 * 7 * time.Hour)
 	if err != nil {
 		log.Error(err)

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -410,6 +410,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 			log.Error(errors.Wrap(err, "failed to process AddSessionFeedback task"))
 			return err
 		}
+	case kafkaqueue.HealthCheck:
 	default:
 		log.Errorf("Unknown task type %+v", task.Type)
 	}


### PR DESCRIPTION
## Summary

Unreverts #3614 with a fix to the topic name.

Log data should be written to clickhouse in batches per their recommendations, especially when log writes can be frequent.
Adds a new separate kafka queue used for batched messages (only logs for now). Workers consume
these messages until the batch size or batch timeout is hit, at which point they are processed and written to clickhouse
with the entire batch.

## How did you test this change?

Local deploy observing creating and using the batched kafka queue.

## Are there any deployment considerations?

Because of the risk of breaking session ingest again, I'll be adding kafka to our health check before shipping this.