### PR TITLE
fix any usage in form input props

### DIFF
--- a/frontend/src/components/NewIssueModal/NewIssueModal.tsx
+++ b/frontend/src/components/NewIssueModal/NewIssueModal.tsx
@@ -242,6 +242,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 							name={form.names.issueDescription}
 							label="Issue Description"
 							placeholder="Hey, check this out!"
+							/* @ts-ignore */
 							as="textarea"
 							outline
 							aria-multiline

--- a/packages/ui/src/components/Form/Form.tsx
+++ b/packages/ui/src/components/Form/Form.tsx
@@ -50,8 +50,7 @@ export const NamedSection = ({
 	)
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Props = React.PropsWithChildren<{ state: AriaKitFormState<any> }>
+type Props = React.PropsWithChildren<{ state: AriaKitFormState }>
 export const Form: FormComponent = ({ children, state }: Props) => {
 	return <AriaKitForm state={state}>{children}</AriaKitForm>
 }
@@ -64,8 +63,7 @@ export const Submit = ({ ...props }: ButtonProps) => {
 	return <Button type="submit" {...props} />
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type InputProps = Omit<AriaKitFormInputProps<any>, 'size'> &
+type InputProps = Omit<AriaKitFormInputProps, 'size'> &
 	Variants &
 	HasLabel & {
 		cssClass?: ClassValue | ClassValue[]
@@ -110,8 +108,7 @@ export const Input = ({
 	)
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type FormFieldProps = AriaKitFormFieldProps<any> &
+type FormFieldProps = AriaKitFormFieldProps &
 	React.PropsWithChildren &
 	Variants &
 	HasLabel & {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Cleans up some `any` in the `<Form.* />` components. 
Without this change, we weren't getting the underlying [ARIA kit form](https://ariakit.org/components/form) props. 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Before:
![Screenshot 2023-02-02 at 10 11 57 AM](https://user-images.githubusercontent.com/58678/216394470-931c665a-95cf-4d44-b9d7-ba08f59247cb.png)

After:
![Screenshot 2023-02-02 at 10 12 21 AM](https://user-images.githubusercontent.com/58678/216394534-5b37ff5d-8018-43e7-bec4-02a9da141519.png)



## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
