### PR TITLE
Fix snoozing errors

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorStateSelect/ErrorStateSelect.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStateSelect/ErrorStateSelect.tsx
@@ -69,22 +69,23 @@ const ErrorStateSelectImpl: React.FC<Props> = ({
 	const snoozed = snoozedUntil && moment().isBefore(moment(snoozedUntil))
 
 	const handleChange = useCallback(
-		async (newState: ErrorState, snoozedUntil?: string) => {
-			if (initialErrorState === newState && !snoozed) return
+		async (newState: ErrorState, newSnoozedUntil?: string) => {
+			if (initialErrorState === newState && !newSnoozedUntil) return
+
 			await updateErrorGroupState({
 				variables: {
 					secure_id: error_secure_id,
 					state: newState,
-					snoozed_until: snoozedUntil,
+					snoozed_until: newSnoozedUntil,
 				},
 				onCompleted: async () => {
-					showStateUpdateMessage(newState, snoozedUntil)
+					showStateUpdateMessage(newState, newSnoozedUntil)
 					setMenuState(MenuState.Default)
 					setErrorState(newState)
 				},
 			})
 		},
-		[error_secure_id, initialErrorState, snoozed, updateErrorGroupState],
+		[error_secure_id, initialErrorState, updateErrorGroupState],
 	)
 
 	const history = useHistory()

--- a/frontend/src/pages/ErrorsV2/ErrorStateSelect/ErrorStateSelect.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStateSelect/ErrorStateSelect.tsx
@@ -70,7 +70,13 @@ const ErrorStateSelectImpl: React.FC<Props> = ({
 
 	const handleChange = useCallback(
 		async (newState: ErrorState, newSnoozedUntil?: string) => {
-			if (initialErrorState === newState && !newSnoozedUntil) return
+			if (
+				initialErrorState === newState &&
+				!snoozed &&
+				!newSnoozedUntil
+			) {
+				return
+			}
 
 			await updateErrorGroupState({
 				variables: {
@@ -85,7 +91,7 @@ const ErrorStateSelectImpl: React.FC<Props> = ({
 				},
 			})
 		},
-		[error_secure_id, initialErrorState, updateErrorGroupState],
+		[error_secure_id, initialErrorState, snoozed, updateErrorGroupState],
 	)
 
 	const history = useHistory()


### PR DESCRIPTION
## Summary

Snoozing an error doesn't currently work because of a regression introduced in https://github.com/highlight/highlight/pull/3521/files#diff-1118372a92bc179eb5799ac9af7dfea83da9368881356f012fbf52736af7305bR65 which is resolved in this PR.

<img width="927" alt="image" src="https://user-images.githubusercontent.com/308182/216622713-3beddc68-c58a-433f-a13a-5b7d2d27f830.png">

Resolves #4034 

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A
