### PR TITLE
rename logs table

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -24,7 +24,7 @@ type LogRow struct {
 	SecureSessionId    string
 }
 
-const LogsTable = "logs_new"
+const LogsTable = "logs"
 
 func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) error {
 	query := fmt.Sprintf(`

--- a/backend/clickhouse/migrations/000002_rename_logs_table.down.sql
+++ b/backend/clickhouse/migrations/000002_rename_logs_table.down.sql
@@ -1,0 +1,1 @@
+RENAME TABLE logs TO logs_new;

--- a/backend/clickhouse/migrations/000002_rename_logs_table.up.sql
+++ b/backend/clickhouse/migrations/000002_rename_logs_table.up.sql
@@ -1,0 +1,1 @@
+RENAME TABLE logs_new TO logs;


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

See rollout plan of #4109.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed `logs_new` does not exist and `logs` does exist:

```
show tables;
=> 
name
--
logs
schema_migrations


```

Confirmed `logs` has data:

```sql
select count(*) from logs
=> 
count()
--
777
```

I also confirmed that we are reading/writing logs to the renamed table correctly. 

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

Per the rollout of #4109, I manually dropped `logs` on prod (`drop table logs;`). So when this rolls, out, this migration should run cleanly.