### PR TITLE
Fix vertical scroll on errors page

### DIFF
--- a/packages/ui/src/components/Container/styles.css.ts
+++ b/packages/ui/src/components/Container/styles.css.ts
@@ -9,6 +9,7 @@ const containerName = createContainer()
 export const container = style({
 	containerName,
 	containerType: 'inline-size',
+	overflowY: 'scroll',
 	width: '100%',
 })
 


### PR DESCRIPTION
## Summary

The fix for #4064 introduced a regression which prevents vertical scrolling on the errors page. This PR resolves that.

Resolves #4150

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A