### PR TITLE
ensure go errors report stacktrace

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/goware/emailproviders v0.0.0-20200728124719-451ef785cf29
 	github.com/highlight-run/workerpool v1.3.0
-	github.com/highlight/highlight/sdk/highlight-go v0.8.3
+	github.com/highlight/highlight/sdk/highlight-go v0.8.4
 	github.com/influxdata/influxdb-client-go/v2 v2.9.1
 	github.com/jackc/pgconn v1.10.1
 	github.com/kylelemons/godebug v1.1.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -856,8 +856,8 @@ github.com/highlight-run/opensearch-go v1.0.1 h1:LNe4qAgQnw8YwXpAzK2Uu2RLtx61wka
 github.com/highlight-run/opensearch-go v1.0.1/go.mod h1:+6/XHCuTH+fwsMJikZEWsucZ4eZMma3zNSeLrTtVGbo=
 github.com/highlight-run/workerpool v1.3.0 h1:BuOWBJJeGG5ZRpq+IKXDTfASAdJoTkBS0sSH+lvCTgw=
 github.com/highlight-run/workerpool v1.3.0/go.mod h1:1iJmXJoC39MnWrqrLa+TaIqdveW4XaxPMoXAMH2wDYU=
-github.com/highlight/highlight/sdk/highlight-go v0.8.3 h1:33ARm7L4Hfe8aNJ0ZZFM5sxblpmlgwBYK1L9736t5i8=
-github.com/highlight/highlight/sdk/highlight-go v0.8.3/go.mod h1:QskPKvmBmUATlMVPFKdairQ2FnfG5EbHBm8vO18d2ws=
+github.com/highlight/highlight/sdk/highlight-go v0.8.4 h1:8GDEAl+NDIM15wL64cPILxWfA6oWQ20Zm79CguQ3Dhw=
+github.com/highlight/highlight/sdk/highlight-go v0.8.4/go.mod h1:QskPKvmBmUATlMVPFKdairQ2FnfG5EbHBm8vO18d2ws=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -33,10 +33,7 @@ type Handler struct {
 }
 
 func castString(v interface{}) string {
-	s, ok := v.(string)
-	if !ok {
-		log.WithField("v", v).Warnf("failed to cast interface to string %+v", v)
-	}
+	s, _ := v.(string)
 	return s
 }
 

--- a/docker/compose.dev.yml
+++ b/docker/compose.dev.yml
@@ -6,6 +6,9 @@ services:
 
         container_name: backend
         image: public.ecr.aws/k9o6n7l8/highlight
+        command:
+            - make
+            - start-no-doppler
         volumes:
             - ../backend:/build/backend
             - ../sdk/highlight-go:/build/sdk/highlight-go

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -89,6 +89,6 @@ func StartTrace(ctx context.Context, name string, tags ...attribute.KeyValue) (t
 func RecordError(ctx context.Context, err error, tags ...attribute.KeyValue) context.Context {
 	span, ctx := StartTrace(ctx, "highlight-ctx", tags...)
 	defer span.End()
-	span.RecordError(err)
+	span.RecordError(err, trace.WithStackTrace(true))
 	return ctx
 }


### PR DESCRIPTION
Updates the `highlight-go` sdk to report stacktrace, because otel does not report them by default.