### PR TITLE
ensure go otel serializes stacktrace

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/goware/emailproviders v0.0.0-20200728124719-451ef785cf29
 	github.com/highlight-run/workerpool v1.3.0
-	github.com/highlight/highlight/sdk/highlight-go v0.8.5
+	github.com/highlight/highlight/sdk/highlight-go v0.8.6
 	github.com/influxdata/influxdb-client-go/v2 v2.9.1
 	github.com/jackc/pgconn v1.10.1
 	github.com/kylelemons/godebug v1.1.0

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/goware/emailproviders v0.0.0-20200728124719-451ef785cf29
 	github.com/highlight-run/workerpool v1.3.0
-	github.com/highlight/highlight/sdk/highlight-go v0.8.4
+	github.com/highlight/highlight/sdk/highlight-go v0.8.5
 	github.com/influxdata/influxdb-client-go/v2 v2.9.1
 	github.com/jackc/pgconn v1.10.1
 	github.com/kylelemons/godebug v1.1.0
@@ -113,9 +113,9 @@ require (
 	github.com/go-chi/chi/v5 v5.0.7 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.6.1 // indirect
-	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/goware/emailproviders v0.0.0-20200728124719-451ef785cf29
 	github.com/highlight-run/workerpool v1.3.0
-	github.com/highlight/highlight/sdk/highlight-go v0.8.6
+	github.com/highlight/highlight/sdk/highlight-go v0.8.8
 	github.com/influxdata/influxdb-client-go/v2 v2.9.1
 	github.com/jackc/pgconn v1.10.1
 	github.com/kylelemons/godebug v1.1.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -858,8 +858,8 @@ github.com/highlight-run/opensearch-go v1.0.1 h1:LNe4qAgQnw8YwXpAzK2Uu2RLtx61wka
 github.com/highlight-run/opensearch-go v1.0.1/go.mod h1:+6/XHCuTH+fwsMJikZEWsucZ4eZMma3zNSeLrTtVGbo=
 github.com/highlight-run/workerpool v1.3.0 h1:BuOWBJJeGG5ZRpq+IKXDTfASAdJoTkBS0sSH+lvCTgw=
 github.com/highlight-run/workerpool v1.3.0/go.mod h1:1iJmXJoC39MnWrqrLa+TaIqdveW4XaxPMoXAMH2wDYU=
-github.com/highlight/highlight/sdk/highlight-go v0.8.6 h1:ULuxLjCPjLfHAESYf37Fqjs8lZHc/0A/ATB82vBO5es=
-github.com/highlight/highlight/sdk/highlight-go v0.8.6/go.mod h1:QskPKvmBmUATlMVPFKdairQ2FnfG5EbHBm8vO18d2ws=
+github.com/highlight/highlight/sdk/highlight-go v0.8.8 h1:FltlXRNxcMEaFIVmV2JUJSfL2PMXaFT6xLXCnmumxq0=
+github.com/highlight/highlight/sdk/highlight-go v0.8.8/go.mod h1:QskPKvmBmUATlMVPFKdairQ2FnfG5EbHBm8vO18d2ws=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -858,8 +858,8 @@ github.com/highlight-run/opensearch-go v1.0.1 h1:LNe4qAgQnw8YwXpAzK2Uu2RLtx61wka
 github.com/highlight-run/opensearch-go v1.0.1/go.mod h1:+6/XHCuTH+fwsMJikZEWsucZ4eZMma3zNSeLrTtVGbo=
 github.com/highlight-run/workerpool v1.3.0 h1:BuOWBJJeGG5ZRpq+IKXDTfASAdJoTkBS0sSH+lvCTgw=
 github.com/highlight-run/workerpool v1.3.0/go.mod h1:1iJmXJoC39MnWrqrLa+TaIqdveW4XaxPMoXAMH2wDYU=
-github.com/highlight/highlight/sdk/highlight-go v0.8.5 h1:2LL1buUuM4Vjls12vs/A/yg0PU/U14cjYOwetFD06sg=
-github.com/highlight/highlight/sdk/highlight-go v0.8.5/go.mod h1:QskPKvmBmUATlMVPFKdairQ2FnfG5EbHBm8vO18d2ws=
+github.com/highlight/highlight/sdk/highlight-go v0.8.6 h1:ULuxLjCPjLfHAESYf37Fqjs8lZHc/0A/ATB82vBO5es=
+github.com/highlight/highlight/sdk/highlight-go v0.8.6/go.mod h1:QskPKvmBmUATlMVPFKdairQ2FnfG5EbHBm8vO18d2ws=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -858,8 +858,8 @@ github.com/highlight-run/opensearch-go v1.0.1 h1:LNe4qAgQnw8YwXpAzK2Uu2RLtx61wka
 github.com/highlight-run/opensearch-go v1.0.1/go.mod h1:+6/XHCuTH+fwsMJikZEWsucZ4eZMma3zNSeLrTtVGbo=
 github.com/highlight-run/workerpool v1.3.0 h1:BuOWBJJeGG5ZRpq+IKXDTfASAdJoTkBS0sSH+lvCTgw=
 github.com/highlight-run/workerpool v1.3.0/go.mod h1:1iJmXJoC39MnWrqrLa+TaIqdveW4XaxPMoXAMH2wDYU=
-github.com/highlight/highlight/sdk/highlight-go v0.8.4 h1:8GDEAl+NDIM15wL64cPILxWfA6oWQ20Zm79CguQ3Dhw=
-github.com/highlight/highlight/sdk/highlight-go v0.8.4/go.mod h1:QskPKvmBmUATlMVPFKdairQ2FnfG5EbHBm8vO18d2ws=
+github.com/highlight/highlight/sdk/highlight-go v0.8.5 h1:2LL1buUuM4Vjls12vs/A/yg0PU/U14cjYOwetFD06sg=
+github.com/highlight/highlight/sdk/highlight-go v0.8.5/go.mod h1:QskPKvmBmUATlMVPFKdairQ2FnfG5EbHBm8vO18d2ws=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -112,11 +112,14 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 					setHighlightAttributes(eventAttributes, &projectID, &sessionID, &requestID)
 					excType, hasType := eventAttributes["exception.type"]
 					excMessage, hasMessage := eventAttributes["exception.message"]
-					if hasType || hasMessage {
+					stackTrace := castString(eventAttributes["exception.stacktrace"])
+					if stackTrace == "" {
+						log.WithField("Span", span).WithField("EventAttributes", eventAttributes).Warn("otel received exception with no stacktrace")
+					} else if hasType || hasMessage {
 						exc := Exception{
 							Type:       castString(excType),
 							Message:    castString(excMessage),
-							Stacktrace: castString(eventAttributes["exception.stacktrace"]),
+							Stacktrace: stackTrace,
 							Escaped:    castString(eventAttributes["exception.escaped"]) == "true",
 						}
 						err := &model.BackendErrorObjectInput{

--- a/backend/util/logging.go
+++ b/backend/util/logging.go
@@ -3,8 +3,6 @@ package util
 import (
 	"context"
 
-	"github.com/highlight/highlight/sdk/highlight-go"
-
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -26,8 +24,6 @@ func GraphQLErrorPresenter(service string) func(ctx context.Context, e error) *g
 		default:
 			gqlerr = gqlerror.Errorf(e.Error())
 		}
-
-		highlight.RecordError(ctx, e)
 
 		return gqlerr
 	}

--- a/backend/util/logging.go
+++ b/backend/util/logging.go
@@ -20,7 +20,7 @@ func GraphQLErrorPresenter(service string) func(ctx context.Context, e error) *g
 		switch t := e.(type) {
 		case *gqlerror.Error:
 			gqlerr = t
-			e = gqlerr.Unwrap()
+			_ = gqlerr.Unwrap()
 		default:
 			gqlerr = gqlerror.Errorf(e.Error())
 		}

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -83,12 +83,21 @@ func StartTrace(ctx context.Context, name string, tags ...attribute.KeyValue) (t
 	return span, ctx
 }
 
+func EndTrace(span trace.Span) {
+	span.End(trace.WithStackTrace(true))
+}
+
+func RecordSpanError(span trace.Span, err error, tags ...attribute.KeyValue) {
+	span.SetAttributes(tags...)
+	span.RecordError(err, trace.WithStackTrace(true))
+}
+
 // RecordError processes `err` to be recorded as a part of the session or network request.
 // Highlight session and trace are inferred from the context.
 // If no sessionID is set, then the error is associated with the project without a session context.
 func RecordError(ctx context.Context, err error, tags ...attribute.KeyValue) context.Context {
 	span, ctx := StartTrace(ctx, "highlight-ctx", tags...)
-	defer span.End(trace.WithStackTrace(true))
-	span.RecordError(err, trace.WithStackTrace(true))
+	defer EndTrace(span)
+	RecordSpanError(span, err)
 	return ctx
 }

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -88,7 +88,7 @@ func StartTrace(ctx context.Context, name string, tags ...attribute.KeyValue) (t
 // If no sessionID is set, then the error is associated with the project without a session context.
 func RecordError(ctx context.Context, err error, tags ...attribute.KeyValue) context.Context {
 	span, ctx := StartTrace(ctx, "highlight-ctx", tags...)
-	defer span.End()
+	defer span.End(trace.WithStackTrace(true))
 	span.RecordError(err, trace.WithStackTrace(true))
 	return ctx
 }

--- a/sdk/highlight-go/tracer.go
+++ b/sdk/highlight-go/tracer.go
@@ -45,8 +45,8 @@ func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 	start := graphql.Now()
 	res, err := next(ctx)
 	end := graphql.Now()
-	span.RecordError(err)
-	span.End()
+	RecordSpanError(span, err)
+	EndTrace(span)
 
 	RecordMetric(ctx, name+".duration", end.Sub(start).Seconds())
 	return res, err
@@ -73,7 +73,7 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	start := graphql.Now()
 	resp := next(ctx)
 	end := graphql.Now()
-	span.End()
+	EndTrace(span)
 
 	RecordMetric(ctx, name+".duration", end.Sub(start).Seconds())
 	if resp.Errors != nil {


### PR DESCRIPTION
Adjust otel sdk settings to serialize go stacktraces.
Improve the otel ingest.
Improve golang graphql instrumentation to report stacktraces.