### PR TITLE
fix(#3909): switch to horizontal scrollbars for long json

### DIFF
--- a/frontend/src/components/CollapsibleSection/index.tsx
+++ b/frontend/src/components/CollapsibleSection/index.tsx
@@ -2,7 +2,7 @@ import { collapsibleContent } from '@components/CollapsibleSection/style.css'
 import clsx from 'clsx'
 import { PropsWithChildren } from 'react'
 import ReactCollapsible from 'react-collapsible'
-import { styledScrollbar } from 'style/common.css'
+import { styledVerticalScrollbar } from 'style/common.css'
 
 const CollapsibleSection = function ({
 	children,
@@ -20,7 +20,10 @@ const CollapsibleSection = function ({
 			open={expanded}
 			handleTriggerClick={() => setExpanded(!expanded)}
 			transitionTime={150}
-			contentInnerClassName={clsx(collapsibleContent, styledScrollbar)}
+			contentInnerClassName={clsx(
+				collapsibleContent,
+				styledVerticalScrollbar,
+			)}
 		>
 			{children}
 		</ReactCollapsible>

--- a/frontend/src/components/FullCommentList/FullCommentList.tsx
+++ b/frontend/src/components/FullCommentList/FullCommentList.tsx
@@ -4,7 +4,7 @@ import LoadingBox from '@components/LoadingBox'
 import classNames from 'classnames'
 import React, { useRef } from 'react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
-import { styledScrollbar } from 'style/common.css'
+import { styledVerticalScrollbar } from 'style/common.css'
 
 import styles from './FullCommentList.module.scss'
 
@@ -42,7 +42,7 @@ const FullCommentList = ({
 						ref={virtuoso}
 						overscan={500}
 						data={comments}
-						className={styledScrollbar}
+						className={styledVerticalScrollbar}
 						itemContent={(index, comment: any) => (
 							<div
 								key={comment.id || index}

--- a/frontend/src/components/TextViewer/TextViewer.css.ts
+++ b/frontend/src/components/TextViewer/TextViewer.css.ts
@@ -9,6 +9,5 @@ export const jsonContainer = style({
 })
 
 export const consoleText = style({
-	whiteSpace: 'pre-wrap',
-	overflowWrap: 'break-word',
+	whiteSpace: 'pre',
 })

--- a/frontend/src/components/TextViewer/index.tsx
+++ b/frontend/src/components/TextViewer/index.tsx
@@ -11,6 +11,7 @@ import { copyToClipboard } from '@util/string'
 import React from 'react'
 // @ts-ignore
 import { specific } from 'react-files-hooks'
+import { styledHorizontalScrollbar } from 'style/common.css'
 
 type Props = {
 	title: React.ReactElement
@@ -97,6 +98,9 @@ const TextViewer = React.memo(
 					borderRadius="5"
 					border="dividerWeak"
 					background="nested"
+					overflowX="auto"
+					overflowY="hidden"
+					cssClass={styledHorizontalScrollbar}
 				>
 					{!!repr ? (
 						repr

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -20,7 +20,7 @@ import { gqlSanitize } from '@util/gql'
 import { useParams } from '@util/react-router/useParams'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
-import { styledScrollbar } from 'style/common.css'
+import { styledVerticalScrollbar } from 'style/common.css'
 
 import * as style from './SearchPanel.css'
 
@@ -110,7 +110,7 @@ const SearchPanel = () => {
 				padding="8"
 				overflowX="hidden"
 				overflowY="auto"
-				cssClass={[style.content, styledScrollbar]}
+				cssClass={[style.content, styledVerticalScrollbar]}
 			>
 				{loading ? (
 					<LoadingBox />

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -12,7 +12,7 @@ import { H } from 'highlight.run'
 import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
-import { styledScrollbar } from 'style/common.css'
+import { styledVerticalScrollbar } from 'style/common.css'
 
 import { useReplayerContext } from '../../../ReplayerContext'
 import * as styles from './style.css'
@@ -199,7 +199,7 @@ export const ConsolePage = ({
 					overscan={1024}
 					increaseViewportBy={1024}
 					data={messagesToRender}
-					className={styledScrollbar}
+					className={styledVerticalScrollbar}
 					itemContent={(_index, message: ParsedMessage) => (
 						<MessageRow
 							key={message.id.toString()}

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -26,7 +26,7 @@ import {
 import useLocalStorage from '@rehooks/local-storage'
 import clsx from 'clsx'
 import React from 'react'
-import { styledScrollbar } from 'style/common.css'
+import { styledVerticalScrollbar } from 'style/common.css'
 
 import { ConsolePage } from './ConsolePage/ConsolePage'
 import ErrorsPage from './ErrorsPage/ErrorsPage'
@@ -74,7 +74,10 @@ const DevToolsWindowV2: React.FC<
 			{({ panelRef, handleRef }) => (
 				<Box
 					bt={showHistogram ? undefined : 'dividerWeak'}
-					cssClass={clsx(styles.devToolsWindowV2, styledScrollbar)}
+					cssClass={clsx(
+						styles.devToolsWindowV2,
+						styledVerticalScrollbar,
+					)}
 					ref={panelRef}
 					style={{ width: props.width }}
 				>

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ErrorsPage/ErrorsPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ErrorsPage/ErrorsPage.tsx
@@ -18,7 +18,7 @@ import { parseOptionalJSON } from '@util/string'
 import React, { useLayoutEffect, useMemo, useRef } from 'react'
 import { useHistory } from 'react-router-dom'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
-import { styledScrollbar } from 'style/common.css'
+import { styledVerticalScrollbar } from 'style/common.css'
 
 import { ReplayerState, useReplayerContext } from '../../../ReplayerContext'
 import * as styles from './style.css'
@@ -104,7 +104,7 @@ const ErrorsPage = ({
 					ref={virtuoso}
 					overscan={500}
 					data={errorsToRender}
-					className={styledScrollbar}
+					className={styledVerticalScrollbar}
 					itemContent={(index, error) => (
 						<ErrorRow
 							key={error.error_group_secure_id}

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -24,7 +24,7 @@ import { message } from 'antd'
 import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
-import { styledScrollbar } from 'style/common.css'
+import { styledVerticalScrollbar } from 'style/common.css'
 
 import TextHighlighter from '../../../../../components/TextHighlighter/TextHighlighter'
 import Tooltip from '../../../../../components/Tooltip/Tooltip'
@@ -264,7 +264,7 @@ export const NetworkPage = ({
 							ref={virtuoso}
 							overscan={1024}
 							increaseViewportBy={1024}
-							className={styledScrollbar}
+							className={styledVerticalScrollbar}
 							components={{
 								ScrollSeekPlaceholder: () => (
 									<div

--- a/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
@@ -22,7 +22,7 @@ import { useParams } from '@util/react-router/useParams'
 import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
-import { styledScrollbar } from 'style/common.css'
+import { styledVerticalScrollbar } from 'style/common.css'
 
 import * as style from './EventStreamV2.css'
 
@@ -155,7 +155,7 @@ const EventStreamV2 = function () {
 							ref={virtuoso}
 							data={filteredEvents}
 							totalCount={filteredEvents.length}
-							className={styledScrollbar}
+							className={styledVerticalScrollbar}
 							itemContent={(index, event) => (
 								<StreamEventV2
 									e={event}

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -47,7 +47,7 @@ import { useParams } from '@util/react-router/useParams'
 import { roundDateToMinute, serializeAbsoluteTimeRange } from '@util/time'
 import clsx from 'clsx'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
-import { styledScrollbar } from 'style/common.css'
+import { styledVerticalScrollbar } from 'style/common.css'
 
 import usePlayerConfiguration from '../../Player/PlayerHook/utils/usePlayerConfiguration'
 import { useReplayerContext } from '../../Player/ReplayerContext'
@@ -322,7 +322,7 @@ export const SessionFeedV3 = React.memo(() => {
 					overflowX="hidden"
 					overflowY="auto"
 					height="full"
-					cssClass={styledScrollbar}
+					cssClass={styledVerticalScrollbar}
 				>
 					{searchResultsLoading ? (
 						<LoadingBox />

--- a/frontend/src/pages/Setup/CodeBlock/CodeBlock.tsx
+++ b/frontend/src/pages/Setup/CodeBlock/CodeBlock.tsx
@@ -1,7 +1,7 @@
 import SvgCopyIcon from '@icons/CopyIcon'
 import useLocalStorage from '@rehooks/local-storage'
 import { message } from 'antd'
-import classNames from 'classnames'
+import clsx from 'clsx'
 import React, { useEffect } from 'react'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import {
@@ -77,7 +77,7 @@ export const CodeBlock = ({
 				</span>
 			)}
 			<span
-				className={classNames({
+				className={clsx({
 					[styles.codeBlockInner]: showLineNumbers,
 				})}
 			>
@@ -97,7 +97,7 @@ export const CodeBlock = ({
 								(i) => (
 									<div
 										key={i}
-										className={classNames(
+										className={clsx(
 											styles.lineNumberSticky,
 											{
 												[styles.highlightedLine]:

--- a/frontend/src/style/common.css.ts
+++ b/frontend/src/style/common.css.ts
@@ -4,24 +4,45 @@ import { style } from '@vanilla-extract/css'
 
 export const SCROLLBAR_SIZE = 9
 
-export const styledScrollbar = style({
+const scrollbarThumbCoreStyles = {
+	backgroundClip: 'padding-box',
+	backgroundColor: themeVars.interactive.outline.secondary.enabled,
+	border: '1px solid transparent',
+	borderRadius: 30,
+} as const
+
+const scrollbarCommonStyles = {
+	'&::-webkit-scrollbar': {
+		width: SCROLLBAR_SIZE,
+		height: SCROLLBAR_SIZE,
+	},
+	':hover&::-webkit-scrollbar-thumb': {
+		backgroundColor: themeVars.interactive.outline.secondary.hover,
+	},
+} as const
+
+export const styledHorizontalScrollbar = style({
 	selectors: {
-		'&::-webkit-scrollbar': {
-			width: SCROLLBAR_SIZE,
-			height: SCROLLBAR_SIZE,
+		...scrollbarCommonStyles,
+		':hover&::-webkit-scrollbar': {
+			borderTop: borders.dividerWeak,
 		},
+		'&::-webkit-scrollbar-thumb': {
+			...scrollbarThumbCoreStyles,
+			borderTopWidth: 2,
+		},
+	},
+})
+
+export const styledVerticalScrollbar = style({
+	selectors: {
+		...scrollbarCommonStyles,
 		':hover&::-webkit-scrollbar': {
 			borderLeft: borders.dividerWeak,
 		},
 		'&::-webkit-scrollbar-thumb': {
-			backgroundClip: 'padding-box',
-			backgroundColor: themeVars.interactive.outline.secondary.enabled,
-			border: '1px solid transparent',
+			...scrollbarThumbCoreStyles,
 			borderLeftWidth: 2,
-			borderRadius: 30,
-		},
-		':hover&::-webkit-scrollbar-thumb': {
-			backgroundColor: themeVars.interactive.outline.secondary.hover,
 		},
 	},
 })


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->
<img width="288" alt="Screenshot 2023-02-06 at 1 07 37 PM" src="https://user-images.githubusercontent.com/17913919/217087781-59c3569e-8a1f-4036-bb8b-173cc3ce7959.png">
Instead of wrapping long lines in json previews, show a horizontal scrollbar. 

Closes https://github.com/highlight/highlight/issues/3909
## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
local clicktest

go to any session with long metadata to see it in action

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no