### PR TITLE
add a performance testing script

### DIFF
--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -18,7 +18,7 @@ import (
 )
 
 type Client struct {
-	conn driver.Conn
+	Conn driver.Conn
 }
 
 var (
@@ -30,10 +30,12 @@ var (
 )
 
 func NewClient(dbName string) (*Client, error) {
+	options := getClickhouseOptions(dbName)
+	log.Print(options)
 	conn, err := clickhouse.Open(getClickhouseOptions(dbName))
 
 	return &Client{
-		conn: conn,
+		Conn: conn,
 	}, err
 }
 

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -31,7 +31,7 @@ func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) 
 		INSERT INTO %s
 	`, LogsTable)
 
-	batch, err := client.conn.PrepareBatch(ctx, query)
+	batch, err := client.Conn.PrepareBatch(ctx, query)
 
 	if err != nil {
 		return e.Wrap(err, "failed to create logs batch")
@@ -53,7 +53,7 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int) ([]*modelInpu
 		LIMIT 100
 	`, LogsTable, projectID)
 
-	rows, err := client.conn.Query(
+	rows, err := client.Conn.Query(
 		ctx,
 		query,
 	)

--- a/backend/clickhouse/performance/main.go
+++ b/backend/clickhouse/performance/main.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"context"
+	"math/rand"
+	"strconv"
+	"time"
+
+	goClickhouse "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/highlight-run/highlight/backend/clickhouse"
+	log "github.com/sirupsen/logrus"
+)
+
+// CREATE database performance
+// CREATE TABLE IF NOT EXISTS performance.logs
+// (
+//     Timestamp          DateTime64(9) CODEC (Delta, ZSTD(1)),
+//     TraceId            String CODEC (ZSTD(1)),
+//     SpanId             String CODEC (ZSTD(1)),
+//     TraceFlags         UInt32 CODEC (ZSTD(1)),
+//     SeverityText       LowCardinality(String) CODEC (ZSTD(1)),
+//     SeverityNumber     Int32 CODEC (ZSTD(1)),
+//     ServiceName        LowCardinality(String) CODEC (ZSTD(1)),
+//     Body               String CODEC (ZSTD(1)),
+//     ResourceAttributes Map(LowCardinality(String), String) CODEC (ZSTD(1)),
+//     LogAttributes      Map(LowCardinality(String), String) CODEC (ZSTD(1)),
+//     ProjectId          UInt32 CODEC (ZSTD(1)),
+//     SecureSessionId    String CODEC (ZSTD(1)),
+//     INDEX idx_trace_id          TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+//     INDEX idx_secure_session_id SecureSessionId TYPE bloom_filter(0.001) GRANULARITY 1,
+//     INDEX idx_res_attr_key      mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+//     INDEX idx_res_attr_value    mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+//     INDEX idx_log_attr_key      mapKeys(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+//     INDEX idx_log_attr_value    mapValues(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+//     INDEX idx_body              Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
+// )
+//     ENGINE = MergeTree
+//         PARTITION BY toDate(Timestamp)
+//         ORDER BY (ProjectId, toUnixTimestamp(Timestamp), TraceId)
+//         TTL toDateTime(Timestamp) + toIntervalDay(30)
+//         SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+
+func makeRandTime() time.Time {
+	now := time.Now()
+
+	randomTimes := [3]time.Time{
+		now.Add(-time.Hour * 72),
+		now.Add(-time.Hour * 144),
+		now,
+	}
+
+	return randomTimes[rand.Intn(len(randomTimes))]
+}
+
+func makeRandProjectId() uint32 {
+	projectIDs := make([]uint32, 0)
+	projectIDs = append(projectIDs, 1, 2, 3, 4, 5)
+	return projectIDs[rand.Intn(len(projectIDs))]
+}
+
+func makeRandLogAttributes() map[string]string {
+	randomKeys := [20]string{
+		"key1",
+		"key2",
+		"key3",
+		"key4",
+		"key5",
+		"key6",
+		"key7",
+		"key8",
+		"key9",
+		"key10",
+		"key11",
+		"key12",
+		"key13",
+		"key14",
+		"key15",
+		"key16",
+		"key17",
+		"key18",
+		"key19",
+		"key20",
+	}
+
+	randomVals := [20]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+		"val5",
+		"val6",
+		"val7",
+		"val8",
+		"val9",
+		"val10",
+		"val11",
+		"val12",
+		"val13",
+		"val14",
+		"val15",
+		"val16",
+		"val17",
+		"val18",
+		"val19",
+		"val20",
+	}
+
+	randomServices := [6]string{
+		"backend",
+		"frontend",
+		"middleware",
+		"logger",
+		"imageparser",
+		"flounder",
+	}
+
+	logAttributes := map[string]string{}
+
+	randomKey := randomKeys[rand.Intn(len(randomKeys))]
+	randomVal := randomVals[rand.Intn(len(randomVals))]
+	randomService := randomServices[rand.Intn(len(randomServices))]
+
+	logAttributes["workspace_id"] = strconv.Itoa(rand.Intn(100))
+	logAttributes["user_id"] = strconv.Itoa(rand.Intn(100))
+	logAttributes["service_name"] = randomService
+	logAttributes[randomKey] = randomVal
+
+	return logAttributes
+}
+
+func main() {
+	options := &goClickhouse.Options{
+		Addr: []string{"localhost:9000"},
+		Auth: goClickhouse.Auth{
+			Database: "performance",
+			Username: "default",
+			Password: "",
+		},
+		DialTimeout: time.Duration(10) * time.Second,
+	}
+
+	conn, err := goClickhouse.Open(options)
+
+	client := &clickhouse.Client{
+		Conn: conn,
+	}
+
+	if err != nil {
+		log.Fatal("could not connect to performance db")
+	}
+
+	logRows := []*clickhouse.LogRow{}
+
+	for i := 1; i < 1000; i++ {
+		for j := 1; j < 1000; j++ {
+			logRows = append(logRows, &clickhouse.LogRow{
+				Timestamp:     makeRandTime(),
+				ProjectId:     makeRandProjectId(),
+				LogAttributes: makeRandLogAttributes(),
+			})
+		}
+
+		err = client.BatchWriteLogRows(context.Background(), logRows)
+
+		if err != nil {
+			log.Fatalf("failed to write log row data: %v", err)
+		}
+	}
+}
+
+// Get all logs for a given project
+// SELECT * from performance.logs where ProjectId = 1 order by Timestamp DESC
+// Elapsed: 18.587 sec, read 94.60 million rows, 10.90 GB.
+
+// Add a limit to the above query
+// SELECT * from performance.logs where ProjectId = 1 order by Timestamp DESC LIMIT 100
+// Elapsed: 1.775 sec, read 94.60 million rows, 10.90 GB.
+
+// Get all facets for a given project
+// SELECT arrayJoin(LogAttributes.keys) as keys, count() as cnt FROM performance.logs WHERE ProjectId = 1 GROUP BY keys ORDER BY cnt DESC;
+// Elapsed: 1.178 sec, read 94.60 million rows, 1.44 GB.
+
+// Query by one attribute
+// SELECT * from performance.logs where ProjectId = 1 AND LogAttributes['key7'] = 'val4' order by Timestamp DESC
+// Elapsed: 3.053 sec, read 93.92 million rows, 7.45 GB.
+
+// Query by two attributes whereby one is fixed across all projects
+// SELECT * from performance.logs where ProjectId = 1 AND LogAttributes['key7'] = 'val4' AND LogAttributes['user_id'] = '98' order by Timestamp DESC
+// Elapsed: 3.177 sec, read 89.30 million rows, 4.44 GB
+
+// Query by many attributes
+// SELECT * from performance.logs where ProjectId = 1 AND LogAttributes['workspace_id'] = '60' AND LogAttributes['user_id'] = '28' AND LogAttributes['key8'] = 'val19'
+// Elapsed: 1.897 sec, read 85.52 million rows, 4.33 GB
+
+// Casting
+// SELECT * from performance.logs where ProjectId = 1 AND LogAttributes['service_name'] = 'middleware' AND LogAttributes['workspace_id'] = '46' AND toInt8(LogAttributes['user_id']) > 1 order by Timestamp DESC LIMIT 100
+
+// Wildcard search
+// SELECT * from performance.logs where ProjectId = 1 AND LogAttributes['service_name'] LIKE '%middleware%' AND toInt8(LogAttributes['workspace_id']) < 99 AND toInt8(LogAttributes['user_id']) > 1 order by Timestamp DESC
+// Elapsed: 3.051 sec, read 94.60 million rows, 6.09 GB
+
+// Give me all the facets for this query
+// SELECT arrayJoin(LogAttributes.keys) as keys, count() as cnt from performance.logs where ProjectId = 1 AND LogAttributes['service_name'] LIKE '%middleware%' AND toInt8(LogAttributes['workspace_id']) < 99 AND toInt8(LogAttributes['user_id']) > 1 GROUP BY keys ORDER BY cnt DESC
+// Elapsed: 1.568 sec, read 94.60 million rows, 5.01 GB.

--- a/backend/clickhouse/test_utils.go
+++ b/backend/clickhouse/test_utils.go
@@ -11,7 +11,7 @@ func setupClickhouseTestDB() (*Client, error) {
 		return nil, err
 	}
 
-	err = client.conn.Exec(context.Background(), fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", TestDatabase))
+	err = client.Conn.Exec(context.Background(), fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", TestDatabase))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR is a quick script to seed a clickhouse database for the purposes of benchmarking. The reason for this is that our production database is around ~80mb and doesn't give us a lot of confidence of how our queries will perform when we release this out to the wild.

Usage:

```bash
CLICKHOUSE_ADDRESS=GET_FROM_DOPPLER CLICKHOUSE_PASSWORD=GET_FROM_DOPPLER go run backend/clickhouse/performance/main.go
```

This script will insert millions of rows into a the `benchmarks.logs` table (`benchmarks` is the name of the db).

## How did you test this

```sql
select concat(database, '.', table)                         as table,
       formatReadableSize(sum(bytes))                       as size,
       sum(rows)                                            as rows,
       max(modification_time)                               as latest_modification,
       sum(bytes)                                           as bytes_size,
       any(engine)                                          as engine,
       formatReadableSize(sum(primary_key_bytes_in_memory)) as primary_keys_size
from system.parts
where active
and table == 'benchmarks.logs'
group by database, table
order by bytes_size desc;
```

table | size | rows | latest_modification | bytes_size | engine | primary_keys_size
-- | -- | -- | -- | -- | -- | --
benchmarks.logs | 1.52 GiB | 233286669 | 2023-02-07 01:45:34 | 1083089516 | ReplicatedMergeTree | 380.76 KiB

Per the above, **`benchmarks.logs` is 1.52 GB** which is a more realistic data set.

### Get last 100 logs for a given project 🟡 

```sql
SELECT * from benchmarks.logs
WHERE ProjectId = 1
ORDER BY Timestamp DESC
LIMIT 100

// Elapsed: 7.401s Read: 37,634,048 rows (4.92 GB)
```

### Get last 100 logs with a time interval 🟢 

```sql
SELECT * from benchmarks.logs
WHERE ProjectId = 1
AND Timestamp < now()
AND Timestamp >= (now() - toIntervalDay(1))
ORDER BY Timestamp DESC
LIMIT 100

// Elapsed: 1.580s Read: 12,500,992 rows (1.63 GB)
```

### Get all facets for a project 🟢 

```sql
SELECT arrayJoin(LogAttributes.keys) as keys, count() as cnt FROM benchmarks.logs
WHERE ProjectId = 1
GROUP BY keys
ORDER BY cnt DESC;

// Elapsed: 1.825s Read: 37,634,048 rows (602.37 MB)
```

### Get all facets for a project with a time interval 🟢 

```sql
SELECT arrayJoin(LogAttributes.keys) as keys, count() as cnt FROM benchmarks.logs
WHERE ProjectId = 1
AND Timestamp < now()
AND Timestamp >= (now() - toIntervalDay(1))
GROUP BY keys
ORDER BY cnt DESC;

// Elapsed: 0.817s Read: 12,500,992 rows (300.10 MB)
```

### Find all logs given a log attribute 🟡 

```sql
SELECT * from benchmarks.logs
WHERE ProjectId = 1 AND LogAttributes['key7'] = 'val4'
order by Timestamp DESC
LIMIT 1000

// Elapsed: 4.539s Read: 37,634,048 rows (4.68 GB)
```

### Casting 🟡 

```sql
SELECT * from benchmarks.logs
WHERE ProjectId = 1 AND LogAttributes['key7'] = 'val4' AND toInt8(LogAttributes['workspace_id']) > 0
order by Timestamp DESC
LIMIT 1000

// Elapsed: 5.322s Read: 37,634,048 rows (4.67 GB)
```

### Casting with a wildcard 🟡 

```sql
SELECT * from benchmarks.logs
WHERE ProjectId = 1
AND LogAttributes['service_name'] LIKE '%middleware%'
AND toInt8(LogAttributes['workspace_id']) < 99
AND toInt8(LogAttributes['user_id']) > 1
ORDER BY Timestamp DESC
LIMIT 1000

// Elapsed: 7.540s Read: 37,634,048 rows (4.92 GB)
```

### Casting with a wildcard and a time interval 🟡 

```sql
SELECT * from benchmarks.logs
WHERE ProjectId = 1
AND Timestamp < now()
AND Timestamp >= (now() - toIntervalDay(1))
AND LogAttributes['service_name'] LIKE '%middleware%'
AND toInt8(LogAttributes['workspace_id']) < 99
AND toInt8(LogAttributes['user_id']) > 1
ORDER BY Timestamp DESC
LIMIT 1000

// Elapsed: 10.732s Read: 15,562,011 rows (2.13 GB)
```

### Casting with a wildcard, find all facets with a time interval 🔴 

```sql
SELECT arrayJoin(LogAttributes.keys) as keys, count() as cnt FROM benchmarks.logs
WHERE ProjectId = 1
AND Timestamp < now()
AND Timestamp >= (now() - toIntervalDay(1))
AND LogAttributes['service_name'] LIKE '%middleware%'
AND toInt8(LogAttributes['workspace_id']) < 99
AND toInt8(LogAttributes['user_id']) > 1
GROUP BY keys
ORDER BY cnt DESC;

"Code: 33. DB::Exception: Cannot read all data. Bytes read: 0. Bytes expected: 8.: (while reading column LogAttributes.keys): (while reading from part /var/lib/clickhouse/disks/s3disk/store/204/2040e058-ea6e-4fe8-b2b7-2a71cdd01cb0/20230207_0_194_6/ from mark 0 with max_rows_to_read = 16384): While executing MergeTreeThread. (CANNOT_READ_ALL_DATA) (version 22.12.1.21301 (official build))\n"
```

The query times out even if the count is removed.

### Same as previous query but searching on a top level column (`Body`) 🟢 

```sql
SELECT arrayJoin(LogAttributes.keys) as keys, count() as cnt FROM benchmarks.logs
WHERE ProjectId = 1
AND Timestamp < now()
AND Timestamp >= (now() - toIntervalDay(1))
AND Body LIKE '%uvDdArNtsokfhzfqYnzyLZj%'
GROUP BY keys
ORDER BY cnt DESC;

// Elapsed: 0.544s Read: 14,677,275 rows (199.18 MB)
```

The `EXPLAIN` for this query and the previous one are the same. But because we have an index on `Body`, we can filter down the number of rows more easily.

### Adding a materialized column 🟢 

Let's see if we can improve the `Casting with a wildcard and a time interval and `Casting with a wildcard, find all facets with a time inverval` queries by adding a materialized column similar to how [posthog describes](https://posthog.com/blog/clickhouse-materialized-columns). 

```sql
ALTER TABLE logs
ADD COLUMN mat_$service_name
VARCHAR MATERIALIZED LogAttributes['service_name']
```

```sql
/* Backfill data */
OPTIMIZE TABLE logs FINAL 
```

```sql
SELECT * from benchmarks.logs
WHERE ProjectId = 1
AND Timestamp < now()
AND Timestamp >= (now() - toIntervalDay(1))
AND mat_$service_name LIKE '%middleware%'
AND toInt8(LogAttributes['workspace_id']) < 99
AND toInt8(LogAttributes['user_id']) > 1
ORDER BY Timestamp DESC
LIMIT 1000

// Elapsed: 3.621s Read: 15,523,840 rows (2.39 GB)
```
**Previous: 10.7s
Now: ~3.6s**


```sql
SELECT arrayJoin(LogAttributes.keys) as keys, count() as cnt FROM benchmarks.logs
WHERE ProjectId = 1
AND Timestamp < now()
AND Timestamp >= (now() - toIntervalDay(1))
AND mat_$service_name LIKE '%middleware%'
AND toInt8(LogAttributes['workspace_id']) < 99
AND toInt8(LogAttributes['user_id']) > 1
GROUP BY keys
ORDER BY cnt DESC;
// Elapsed: 2.825s Read: 15,562,011 rows (1.65 GB)
```
**Previous: Timedout
Now: ~2.8s**

## TLDR; adding a materialized column speeds up when querying on arbitrary log data (in a clickhouse map)