### PR TITLE
ensure error instances are shown in the right order

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3792,7 +3792,7 @@ func (r *queryResolver) ErrorInstance(ctx context.Context, errorGroupSecureID st
 		}
 
 		if len(processedSessions) == 0 {
-			if err := errorObjectQuery.Last(&errorObject).Error; err != nil {
+			if err := errorObjectQuery.First(&errorObject).Error; err != nil {
 				return nil, e.Wrap(err, "error reading error object for instance")
 			}
 		} else {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3770,7 +3770,7 @@ func (r *queryResolver) ErrorInstance(ctx context.Context, errorGroupSecureID st
 	}
 
 	errorObject := model.ErrorObject{}
-	errorObjectQuery := r.DB.Model(&model.ErrorObject{}).Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID})
+	errorObjectQuery := r.DB.Model(&model.ErrorObject{}).Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).Order("id desc")
 
 	if errorObjectID == nil {
 		sessionIds := []int{}
@@ -3799,7 +3799,6 @@ func (r *queryResolver) ErrorInstance(ctx context.Context, errorGroupSecureID st
 			// find the most recent object from the processed session
 			if err := errorObjectQuery.
 				Where("session_id IN ?", processedSessions).
-				Order("id desc").
 				First(&errorObject).
 				Error; err != nil {
 				return nil, e.Wrap(err, "error reading error object for instance")

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -72,6 +72,7 @@ type KafkaWorker struct {
 
 func (k *KafkaBatchWorker) flush(ctx context.Context) {
 	s, _ := tracer.StartSpanFromContext(ctx, "kafkaWorker", tracer.ResourceName("worker.kafka.batched.flush"))
+	s.SetTag("BatchSize", k.messageQueue)
 	defer s.Finish()
 
 	var logRows []*clickhouse.LogRow

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -72,7 +72,7 @@ type KafkaWorker struct {
 
 func (k *KafkaBatchWorker) flush(ctx context.Context) {
 	s, _ := tracer.StartSpanFromContext(ctx, "kafkaWorker", tracer.ResourceName("worker.kafka.batched.flush"))
-	s.SetTag("BatchSize", k.messageQueue)
+	s.SetTag("BatchSize", len(k.messageQueue))
 	defer s.Finish()
 
 	var logRows []*clickhouse.LogRow


### PR DESCRIPTION
## Summary

Error instances were not reported in the right order because the order clause was sometimes omitted.

## How did you test this change?

Local deploy with debug query output.

## Are there any deployment considerations?

No