### PR TITLE
fix(#4143): error to session ux

### DIFF
--- a/frontend/src/pages/Error/components/ErrorComments/ErrorComments.tsx
+++ b/frontend/src/pages/Error/components/ErrorComments/ErrorComments.tsx
@@ -111,7 +111,6 @@ const ErrorCommentHeader = ({ comment, children, errorGroup }: any) => {
 	const { isIntegrated: isClickupIntegrated } = useIsProjectIntegratedWith(
 		IntegrationType.ClickUp,
 	)
-	debugger
 	const { isIntegrated: isHeightIntegrated } = useIsProjectIntegratedWith(
 		IntegrationType.Height,
 	)

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -39,7 +39,8 @@ const DevToolsWindowV2: React.FC<
 > = (props) => {
 	const { isPlayerFullscreen } = usePlayerUIContext()
 	const { time } = useReplayerContext()
-	const [tab, setTab] = React.useState<Tab>(Tab.Console)
+	const { selectedDevToolsTab, setSelectedDevToolsTab } =
+		usePlayerConfiguration()
 	const [requestType, setRequestType] = React.useState<RequestType>(
 		RequestType.All,
 	)
@@ -80,9 +81,9 @@ const DevToolsWindowV2: React.FC<
 				>
 					<Tabs<Tab>
 						handleRef={handleRef}
-						tab={tab}
+						tab={selectedDevToolsTab}
 						setTab={(t: Tab) => {
-							setTab(t)
+							setSelectedDevToolsTab(t)
 							form.reset()
 						}}
 						pages={{
@@ -175,7 +176,7 @@ const DevToolsWindowV2: React.FC<
 										</label>
 									</Form>
 
-									{tab === Tab.Console ? (
+									{selectedDevToolsTab === Tab.Console ? (
 										<MenuButton
 											divider
 											size="medium"
@@ -199,7 +200,7 @@ const DevToolsWindowV2: React.FC<
 												setLogLevel(ll as LogLevel)
 											}
 										/>
-									) : tab === Tab.Network ? (
+									) : selectedDevToolsTab === Tab.Network ? (
 										<MenuButton
 											size="medium"
 											options={Object.values(

--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineBar/TimelineBar.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineBar/TimelineBar.tsx
@@ -1,5 +1,8 @@
 import Popover from '@components/Popover/Popover'
-import { getFullScreenPopoverGetPopupContainer } from '@pages/Player/context/PlayerUIContext'
+import {
+	getFullScreenPopoverGetPopupContainer,
+	usePlayerUIContext,
+} from '@pages/Player/context/PlayerUIContext'
 import { EventsForTimeline } from '@pages/Player/PlayerHook/utils'
 import { EventBucket } from '@pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/TimelineIndicatorsBarGraph'
 import TimelinePopover from '@pages/Player/Toolbar/TimelineIndicators/TimelinePopover/TimelinePopover'
@@ -7,8 +10,8 @@ import { getAnnotationColor } from '@pages/Player/Toolbar/Toolbar'
 import { getTimelineEventDisplayName } from '@pages/Player/utils/utils'
 import { clamp } from '@util/numbers'
 import { TooltipPlacement } from 'antd/lib/tooltip'
-import classNames from 'classnames'
-import { useLayoutEffect, useMemo, useState } from 'react'
+import clsx from 'clsx'
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react'
 
 import styles from './TimelineBar.module.scss'
 
@@ -38,7 +41,6 @@ const TimelineIndicatorsBar = ({
 					name: getTimelineEventDisplayName(eventType || ''),
 					color,
 					count: bucket.identifier[eventType].length,
-					firstId: bucket.identifier[eventType][0],
 					percent:
 						(bucket.identifier[eventType].length /
 							bucket.totalCount) *
@@ -54,6 +56,24 @@ const TimelineIndicatorsBar = ({
 	const [isInsideBar, setIsInsideBar] = useState(false)
 	const [isInsidePopover, setIsInsidePopover] = useState(false)
 	const [isSelected, setIsSelected] = useState(false)
+	const { activeError } = usePlayerUIContext()
+
+	useEffect(() => {
+		if (
+			activeError?.error_group_secure_id &&
+			bucket.identifier.Errors.includes(
+				activeError?.error_group_secure_id as string,
+			) &&
+			bucket.instance[activeError?.error_group_secure_id].includes(
+				activeError.id,
+			)
+		) {
+			setIsSelected(true)
+		}
+		// run once
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [])
+
 	useLayoutEffect(() => {
 		const viewportDiv = viewportRef.current
 		if (!viewportDiv) {
@@ -144,7 +164,7 @@ const TimelineIndicatorsBar = ({
 			destroyTooltipOnHide
 		>
 			<div
-				className={classNames(styles.bar, {
+				className={clsx(styles.bar, {
 					[styles.isShaded]: isInsideBar || isSelected,
 				})}
 				style={{
@@ -174,7 +194,7 @@ const TimelineIndicatorsBar = ({
 										idx === data.length - 1 ? 0 : undefined,
 								}}
 								key={idx}
-							></div>
+							/>
 						)
 					})}
 				</div>

--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelinePopover/TimelinePopover.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelinePopover/TimelinePopover.tsx
@@ -21,7 +21,7 @@ import { getTimelineEventDisplayName } from '@pages/Player/utils/utils'
 import { formatTimeAsHMS, MillisToMinutesAndSeconds } from '@util/time'
 import { message } from 'antd'
 import classNames from 'classnames'
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
 
@@ -37,7 +37,8 @@ const POPOVER_CONTENT_ROW_HEIGHT = 28
 const TimelinePopover = ({ bucket }: Props) => {
 	const history = useHistory()
 	const { setActiveError, setRightPanelView } = usePlayerUIContext()
-	const { setCurrentEvent, pause, errors } = useReplayerContext()
+	const { setCurrentEvent, pause, errors, isPlayerReady } =
+		useReplayerContext()
 	const {
 		setShowRightPanel,
 		setShowDevTools,
@@ -45,7 +46,24 @@ const TimelinePopover = ({ bucket }: Props) => {
 		setSelectedRightPlayerPanelTab,
 	} = usePlayerConfiguration()
 
+	const { activeError } = usePlayerUIContext()
+
 	const [selectedType, setSelectedType] = useState<string | null>(null)
+
+	useEffect(() => {
+		if (
+			isPlayerReady &&
+			activeError?.error_group_secure_id &&
+			bucket.identifier.Errors.includes(
+				activeError?.error_group_secure_id as string,
+			)
+		) {
+			setSelectedType('Errors')
+		}
+		// run once
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [isPlayerReady])
+
 	const selectedTypeName = selectedType
 		? getTimelineEventDisplayName(selectedType)
 		: ''


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Resolves #4143:
open the popover over the corresponding bar
change the popover to show the error body rather than the secure id
open the errors tab in dev tools

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

local click test
## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no