### PR TITLE
improve kafka log batching and highlight-py sdk

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -197,7 +197,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						eventAttributesMap := make(map[string]string)
 						for k, v := range eventAttributes {
 							vStr := castString(v, "")
-							if vStr != "" {
+							if vStr != "" && k != string(hlog.LogMessageKey) {
 								eventAttributesMap[k] = castString(v, "")
 							}
 						}

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -194,12 +194,13 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 								resourceAttributesMap[k] = castString(v, "")
 							}
 						}
-						eventAttributesMap := make(map[string]string)
+						logAttributesMap := make(map[string]string)
 						for k, v := range eventAttributes {
 							vStr := castString(v, "")
-							if vStr != "" && k != string(hlog.LogMessageKey) {
-								eventAttributesMap[k] = castString(v, "")
+							if vStr == "" || k == string(hlog.LogMessageKey) || k == string(hlog.LogSeverityKey) {
+								continue
 							}
+							logAttributesMap[k] = castString(v, "")
 						}
 						lvl, _ := log.ParseLevel(logSev)
 						logRow := &clickhouse.LogRow{
@@ -211,7 +212,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 							ServiceName:        serviceName,
 							Body:               logMessage,
 							ResourceAttributes: resourceAttributesMap,
-							LogAttributes:      eventAttributesMap,
+							LogAttributes:      logAttributesMap,
 							ProjectId:          uint32(projectIDInt),
 							SecureSessionId:    sessionID,
 						}

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -62,8 +62,8 @@ func (k *KafkaWorker) ProcessMessages() {
 	}
 }
 
-const BatchFlushSize = 64
-const BatchedFlushTimeout = 60 * time.Second
+const BatchFlushSize = 512
+const BatchedFlushTimeout = 5 * time.Second
 
 type KafkaWorker struct {
 	KafkaQueue   *kafkaqueue.Queue

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -8,6 +8,7 @@ import (
 	"github.com/highlight-run/highlight/backend/util"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"sync"
 	"time"
 )
 
@@ -61,8 +62,8 @@ func (k *KafkaWorker) ProcessMessages() {
 	}
 }
 
-const BatchFlushSize = 100
-const BatchedFlushTimeout = 5 * time.Second
+const BatchFlushSize = 64
+const BatchedFlushTimeout = 60 * time.Second
 
 type KafkaWorker struct {
 	KafkaQueue   *kafkaqueue.Queue
@@ -72,25 +73,38 @@ type KafkaWorker struct {
 
 func (k *KafkaBatchWorker) flush(ctx context.Context) {
 	s, _ := tracer.StartSpanFromContext(ctx, "kafkaWorker", tracer.ResourceName("worker.kafka.batched.flush"))
-	s.SetTag("BatchSize", len(k.messageQueue))
+	s.SetTag("BatchSize", len(k.BatchBuffer.messageQueue))
 	defer s.Finish()
 
 	var logRows []*clickhouse.LogRow
 
-	for _, msg := range k.messageQueue {
-		switch msg.Type {
-		case kafkaqueue.PushLogs:
-			logRows = append(logRows, msg.PushLogs.LogRows...)
+	var received int
+	var lastMsg *kafkaqueue.Message
+	func() {
+		for {
+			select {
+			case lastMsg = <-k.BatchBuffer.messageQueue:
+				switch lastMsg.Type {
+				case kafkaqueue.PushLogs:
+					logRows = append(logRows, lastMsg.PushLogs.LogRows...)
+				}
+				received += 1
+				if received >= BatchFlushSize {
+					return
+				}
+			default:
+				return
+			}
 		}
-	}
+	}()
 
 	err := k.Worker.PublicResolver.Clickhouse.BatchWriteLogRows(ctx, logRows)
 	if err != nil {
 		log.WithContext(ctx).WithError(err).Error("failed to batch write to clickhouse")
 	}
 
-	k.KafkaQueue.Commit(k.messageQueue[len(k.messageQueue)-1].KafkaMessage)
-	k.messageQueue = []*kafkaqueue.Message{}
+	k.KafkaQueue.Commit(lastMsg.KafkaMessage)
+	k.BatchBuffer.lastMessage = nil
 }
 
 func (k *KafkaBatchWorker) ProcessMessages() {
@@ -99,16 +113,15 @@ func (k *KafkaBatchWorker) ProcessMessages() {
 			defer util.Recover()
 			s, ctx := tracer.StartSpanFromContext(context.Background(), "kafkaWorker", tracer.ResourceName("worker.kafka.batched.process"))
 			s.SetTag("worker.goroutine", k.WorkerThread)
-			s.SetTag("BatchSize", len(k.messageQueue))
+			s.SetTag("BatchSize", len(k.BatchBuffer.messageQueue))
 			defer s.Finish()
 
-			if len(k.messageQueue) > 0 {
-				oldest := k.messageQueue[0]
-				s.SetTag("OldestMessage", time.Since(oldest.KafkaMessage.Time))
-				if time.Since(oldest.KafkaMessage.Time) > BatchedFlushTimeout {
-					k.flush(ctx)
-				}
+			k.BatchBuffer.flushLock.Lock()
+			if k.BatchBuffer.lastMessage != nil && time.Since(*k.BatchBuffer.lastMessage) > BatchedFlushTimeout {
+				s.SetTag("OldestMessage", time.Since(*k.BatchBuffer.lastMessage))
+				k.flush(ctx)
 			}
+			k.BatchBuffer.flushLock.Unlock()
 
 			s1, _ := tracer.StartSpanFromContext(ctx, "kafkaWorker", tracer.ResourceName("worker.kafka.batched.receive"))
 			task := k.KafkaQueue.Receive()
@@ -117,10 +130,17 @@ func (k *KafkaBatchWorker) ProcessMessages() {
 				return
 			}
 
-			k.messageQueue = append(k.messageQueue, task)
-			if len(k.messageQueue) >= BatchFlushSize {
+			k.BatchBuffer.messageQueue <- task
+
+			k.BatchBuffer.flushLock.Lock()
+			if k.BatchBuffer.lastMessage == nil {
+				t := time.Now()
+				k.BatchBuffer.lastMessage = &t
+			}
+			if len(k.BatchBuffer.messageQueue) >= BatchFlushSize {
 				k.flush(ctx)
 			}
+			k.BatchBuffer.flushLock.Unlock()
 		}()
 	}
 }
@@ -129,7 +149,11 @@ type KafkaBatchWorker struct {
 	KafkaQueue   *kafkaqueue.Queue
 	Worker       *Worker
 	WorkerThread int
+	BatchBuffer  *KafkaBatchBuffer
+}
 
-	// does not need to be atomic as each goroutine is a KafkaBatchWorker and this buffer is not shared
-	messageQueue []*kafkaqueue.Message
+type KafkaBatchBuffer struct {
+	lastMessage  *time.Time
+	messageQueue chan *kafkaqueue.Message
+	flushLock    sync.Mutex
 }

--- a/sdk/highlight-py/examples/app.py
+++ b/sdk/highlight-py/examples/app.py
@@ -9,7 +9,10 @@ from highlight_io.integrations.flask import FlaskIntegration
 
 app = Flask(__name__)
 H = highlight_io.H(
-    "YOUR_PROJECT_ID", integrations=[FlaskIntegration()], record_logs=True
+    "1",
+    integrations=[FlaskIntegration()],
+    record_logs=True,
+    otlp_endpoint="http://localhost:4318",
 )
 
 

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -33,6 +33,7 @@ class H(object):
         project_id: str,
         integrations: typing.List[Integration] = None,
         record_logs: bool = False,
+        otlp_endpoint: str = "",
     ):
         """
         Setup Highlight backend instrumentation.
@@ -45,25 +46,27 @@ class H(object):
         :param project_id: a string that corresponds to the verbose id of your project from app.highlight.io/setup
         :param integrations: a list of Integrations that allow connecting with your framework, like Flask or Django.
         :param record_logs: set True if you would like python logging to be recorded as part of the session.
+        :param otlp_endpoint: set to a custom otlp destination
         :return: a configured H instance
         """
         H._instance = self
         self._project_id = project_id
         self._integrations = integrations or []
         self._record_logs = record_logs
+        self._otlp_endpoint = otlp_endpoint or H.OTLP_HTTP
         if self._record_logs:
             self._instrument_logs()
 
         self._trace_provider = TracerProvider()
         self._trace_provider.add_span_processor(
-            BatchSpanProcessor(OTLPSpanExporter(f"{H.OTLP_HTTP}/v1/traces"))
+            BatchSpanProcessor(OTLPSpanExporter(f"{self._otlp_endpoint}/v1/traces"))
         )
         trace.set_tracer_provider(self._trace_provider)
         self.tracer = trace.get_tracer(__name__)
 
         self._log_provider = LoggerProvider()
         self._log_provider.add_log_record_processor(
-            BatchLogRecordProcessor(OTLPLogExporter(f"{H.OTLP_HTTP}/v1/logs"))
+            BatchLogRecordProcessor(OTLPLogExporter(f"{self._otlp_endpoint}/v1/logs"))
         )
         _logs.set_logger_provider(self._log_provider)
         self.log = self._log_provider.get_logger(__name__)

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import time
 import typing
 
 from opentelemetry import trace, _logs
@@ -138,8 +139,10 @@ class H(object):
     def _log_hook(self, span: _Span, record: logging.LogRecord):
         if span and span.is_recording():
             ctx = span.get_span_context()
+            # record.created is sec but timestamp should be ns
+            ts = int(record.created * 1000. * 1000. * 1000.)
             r = LogRecord(
-                timestamp=int(record.created),
+                timestamp=ts,
                 trace_id=ctx.trace_id,
                 span_id=ctx.span_id,
                 trace_flags=ctx.trace_flags,

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -140,7 +140,7 @@ class H(object):
         if span and span.is_recording():
             ctx = span.get_span_context()
             # record.created is sec but timestamp should be ns
-            ts = int(record.created * 1000. * 1000. * 1000.)
+            ts = int(record.created * 1000.0 * 1000.0 * 1000.0)
             r = LogRecord(
                 timestamp=ts,
                 trace_id=ctx.trace_id,

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.1.4"
+version = "0.1.5"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary

* Allow highlight python sdk to override OTLP endpoint.
* Batch messages from multiple partitions into a shared in-memory buffer.
    * currently, each public-worker container runs 8 goroutines for the batched topic. each goroutine gets a set of subset of partitions assigned to it. as messages are consumed by the goroutines, we should aggregate the LogRows together across these partitions so that the batching can be more substantial. without this change, each goroutine had its own in-memory buffer which would not get many messages (and actually could lead to dropping messages because a goroutine would flush its partition's messages as the front of the topic, while in reality there may be other unflushed messages)
* Don't write log messages as an attribute.

## How did you test this change?

Local deploy with debugger.

## Are there any deployment considerations?

New highlight python sdk version.
