### PR TITLE
enable frontend log streaming through otel for all projects

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2703,10 +2703,8 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			tracer.ResourceName("go.unmarshal.messages"), tracer.Tag("project_id", projectID))
 		defer unmarshalMessagesSpan.Finish()
 
-		if projectID == 1 {
-			if err := hlog.SubmitFrontendConsoleMessages(ctx, projectID, sessionSecureID, messages); err != nil {
-				log.WithError(err).Error("failed to parse console messages")
-			}
+		if err := hlog.SubmitFrontendConsoleMessages(ctx, projectID, sessionSecureID, messages); err != nil {
+			log.WithError(err).Error("failed to parse console messages")
 		}
 
 		if err := r.SaveSessionData(ctx, projectID, sessionID, payloadIdDeref, false, isBeacon, model.PayloadTypeMessages, []byte(messages)); err != nil {

--- a/sdk/highlight-go/highlight.go
+++ b/sdk/highlight-go/highlight.go
@@ -170,11 +170,6 @@ func init() {
 // Start is used to start the Highlight client's collection service.
 func Start() {
 	StartWithContext(context.Background())
-	var err error
-	otlp, err = StartOTLP()
-	if err != nil {
-		logger.Errorf("failed to start opentelemetry exporter: %s", err)
-	}
 }
 
 // StartWithContext is used to start the Highlight client's collection
@@ -185,6 +180,11 @@ func StartWithContext(ctx context.Context) {
 	defer stateMutex.Unlock()
 	if state == started {
 		return
+	}
+	var err error
+	otlp, err = StartOTLP()
+	if err != nil {
+		logger.Errorf("failed to start opentelemetry exporter: %s", err)
 	}
 	var httpClient *http.Client = nil
 	if graphqlClientAddress == "https://localhost:8082/public" {


### PR DESCRIPTION
## Summary

Ungate the backend console message processing so that all projects' frontend client logs are streamed through otel.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

Will monitor kafka queue backlogs / otel collector metrics.