### PR TITLE
fix prod sourcemaps

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -75,6 +75,7 @@ jobs:
               run: yarn && yarn sourcemaps:frontend
               env:
                   HIGHLIGHT_API_KEY: ${{ secrets.HIGHLIGHT_SOURCEMAP_API_KEY }}
+                  APP_VERSION: ${{ github.sha }}
 
             - name: Configure yarn npm registry credentials
               if: github.ref == 'refs/heads/main'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,7 @@
 		"codegen": "graphql-codegen --config codegen.yml",
 		"build": "yarn types:check && NODE_OPTIONS='--max-old-space-size=7168' vite build",
 		"lint": "eslint ./src",
-		"sourcemaps": "npx --yes @highlight-run/sourcemap-uploader upload --apiKey \"${HIGHLIGHT_API_KEY}\" --path ./build",
+		"sourcemaps": "npx --yes @highlight-run/sourcemap-uploader upload --apiKey \"${HIGHLIGHT_API_KEY}\" --appVersion \"${APP_VERSION}\" --path ./build",
 		"test": "TZ=UTC vitest --run",
 		"test:watch": "TZ=UTC vitest",
 		"types:check": "tsc -noEmit",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -86,6 +86,7 @@ const options: HighlightOptions = {
 	inlineStylesheet: true,
 	inlineImages: true,
 	sessionShortcut: 'alt+1,command+`,alt+esc',
+	version: import.meta.env.REACT_APP_COMMIT_SHA || undefined,
 }
 const favicon = document.querySelector("link[rel~='icon']") as any
 if (dev) {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -88,6 +88,13 @@ export default defineConfig(({ mode }) => {
 			// Vite sourcemaps are broken in development
 			// https://github.com/highlight-run/highlight/pull/3171
 			sourcemap: env.RENDER_PREVIEW !== 'true' && mode !== 'development',
+			rollupOptions: {
+				output: {
+					entryFileNames: `assets/[name].js`,
+					chunkFileNames: `assets/[name].js`,
+					assetFileNames: `assets/[name].[ext]`,
+				},
+			},
 		},
 		test: {
 			globals: true,


### PR DESCRIPTION
## Summary

Ensure vite build does not put hash strings into the js output.
Use versioned sourcemaps for app.highlight.io

## How did you test this change?

Preview

## Are there any deployment considerations?

No