### PR TITLE
fix(#4135): dev tools jankiness

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -34,7 +34,8 @@ export const ConsolePage = ({
 	time: number
 }) => {
 	const [currentMessage, setCurrentMessage] = useState(-1)
-	const { session, setTime, sessionMetadata } = useReplayerContext()
+	const { session, setTime, sessionMetadata, isPlayerReady } =
+		useReplayerContext()
 	const [parsedMessages, setParsedMessages] = useState<
 		undefined | Array<ParsedMessage>
 	>([])
@@ -191,7 +192,7 @@ export const ConsolePage = ({
 
 	return (
 		<Box className={styles.consoleBox}>
-			{loading ? (
+			{loading || !isPlayerReady ? (
 				<LoadingBox />
 			) : messagesToRender?.length ? (
 				<Virtuoso

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ErrorsPage/ErrorsPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ErrorsPage/ErrorsPage.tsx
@@ -38,7 +38,8 @@ const ErrorsPage = ({
 }) => {
 	const virtuoso = useRef<VirtuosoHandle>(null)
 	const history = useHistory<ErrorsPageHistoryState>()
-	const { errors, state, session, sessionMetadata } = useReplayerContext()
+	const { errors, state, session, sessionMetadata, isPlayerReady } =
+		useReplayerContext()
 
 	const { setActiveError, setRightPanelView } = usePlayerUIContext()
 	const { setShowRightPanel } = usePlayerConfiguration()
@@ -95,7 +96,7 @@ const ErrorsPage = ({
 
 	return (
 		<Box className={styles.errorsContainer}>
-			{loading ? (
+			{loading || !isPlayerReady ? (
 				<LoadingBox />
 			) : !session || !errorsToRender.length ? (
 				<EmptyDevToolsCallout kind={Tab.Errors} filter={filter} />

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -18,6 +18,7 @@ import {
 	Tab,
 } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import analytics from '@util/analytics'
+import { useParams } from '@util/react-router/useParams'
 import { playerTimeToSessionAbsoluteTime } from '@util/session/utils'
 import { MillisToMinutesAndSeconds } from '@util/time'
 import { message } from 'antd'
@@ -66,6 +67,9 @@ export const NetworkPage = ({
 		rightPanelView,
 		setRightPanelView,
 	} = usePlayerUIContext()
+
+	const { session_secure_id } = useParams<{ session_secure_id: string }>()
+
 	const [currentActiveIndex, setCurrentActiveIndex] = useState<number>()
 
 	const virtuoso = useRef<VirtuosoHandle>(null)
@@ -81,7 +85,7 @@ export const NetworkPage = ({
 	useEffect(() => {
 		loadResources()
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [])
+	}, [session_secure_id])
 
 	const networkRange = useMemo(() => {
 		if (parsedResources.length > 0) {
@@ -252,7 +256,7 @@ export const NetworkPage = ({
 
 	return (
 		<Box className={styles.container}>
-			{loading || !session ? (
+			{!isPlayerReady || loading || !session ? (
 				<LoadingBox />
 			) : resourcesToRender.length > 0 ? (
 				<Box className={styles.container}>

--- a/frontend/src/pages/Player/Toolbar/ToolbarControlBar/ToolbarControlBar.tsx
+++ b/frontend/src/pages/Player/Toolbar/ToolbarControlBar/ToolbarControlBar.tsx
@@ -91,6 +91,7 @@ export const ToolbarControlBar = () => {
 		play,
 		pause,
 		canViewSession,
+		isPlayerReady,
 		isLiveMode,
 		setIsLiveMode,
 		session,
@@ -114,7 +115,8 @@ export const ToolbarControlBar = () => {
 	const sessionDuration = sessionMetadata.totalTime ?? 0
 	const isPlaybackComplete = time >= sessionDuration && !isLiveMode
 
-	const disableControls = state === ReplayerState.Loading || !canViewSession
+	const disableControls =
+		state === ReplayerState.Loading || !canViewSession || !isPlayerReady
 	const showLiveToggle = session?.processed === false && !disableControls
 
 	const [showSettings, setShowSettings] = useState(false)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Resolves #4135. Makes sure dev tools do not come out of the loading state before the replayer and reloads network requests on session nav.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
go to the sessions tab and check that the sessions are loading ok

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no