### PR TITLE
make otel process stacktraces into structured format

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -141,6 +141,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 							log.WithField("Span", span).WithField("EventAttributes", eventAttributes).Warn("otel received exception with no type and no message")
 							continue
 						}
+						stackTrace = formatStructureStackTrace(stackTrace)
 						err := &model.BackendErrorObjectInput{
 							SessionSecureID: &sessionID,
 							RequestID:       &requestID,

--- a/backend/otel/parse.go
+++ b/backend/otel/parse.go
@@ -1,0 +1,99 @@
+package otel
+
+import (
+	"encoding/json"
+	model3 "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/openlyinc/pointy"
+	log "github.com/sirupsen/logrus"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+func structureStackTrace(stackTrace string) ([]*model3.ErrorTrace, error) {
+	var language string
+	var errMsg string
+	var frames []*model3.ErrorTrace
+	var frame *model3.ErrorTrace
+	lines := strings.Split(stackTrace, "\n")
+	for idx, line := range lines {
+		if idx == 0 {
+			if line == "" {
+				language = "golang"
+				continue
+			} else if line == "Traceback (most recent call last):" {
+				language = "python"
+				continue
+			}
+			errMsg = line
+			continue
+		}
+		if line == "" {
+			continue
+		}
+		if language == "python" && idx == len(lines)-2 {
+			errMsg = line
+			continue
+		}
+		if frame == nil {
+			frame = &model3.ErrorTrace{
+				Error: &errMsg,
+			}
+		}
+		jsPattern := regexp.MustCompile(` {4}at ((.+) )?\(?(.+):(\d+):(\d+)\)?`)
+		jsAnonPattern := regexp.MustCompile(` {4}at (.+) \((.+)\)`)
+		pyPattern := regexp.MustCompile(` {2}File "(.+)", line (\d+), in (\w+)`)
+		goLinePattern := regexp.MustCompile(`\t(.+):(\d+)`)
+		generalPattern := regexp.MustCompile(`^(.+)`)
+		if matches := jsPattern.FindSubmatch([]byte(line)); matches != nil {
+			language = "js"
+			if matches[2] != nil {
+				frame.FunctionName = pointy.String(string(matches[2]))
+			}
+			frame.FileName = pointy.String(string(matches[3]))
+			l, _ := strconv.ParseInt(string(matches[4]), 10, 32)
+			col, _ := strconv.ParseInt(string(matches[5]), 10, 32)
+			frame.LineNumber = pointy.Int(int(l))
+			frame.ColumnNumber = pointy.Int(int(col))
+		} else if matches := jsAnonPattern.FindSubmatch([]byte(line)); matches != nil {
+			language = "js"
+			frame.FunctionName = pointy.String(string(matches[1]))
+			frame.FileName = pointy.String(string(matches[2]))
+			frame.LineContent = pointy.String(string(matches[2]))
+		} else if matches := pyPattern.FindSubmatch([]byte(line)); matches != nil {
+			language = "python"
+			frame.FunctionName = pointy.String(string(matches[3]))
+			frame.FileName = pointy.String(string(matches[1]))
+			line, _ := strconv.ParseInt(string(matches[2]), 10, 32)
+			frame.LineNumber = pointy.Int(int(line))
+			continue
+		} else if matches := goLinePattern.FindSubmatch([]byte(line)); matches != nil {
+			language = "golang"
+			frame.FileName = pointy.String(string(matches[1]))
+			line, _ := strconv.ParseInt(string(matches[2]), 10, 32)
+			frame.LineNumber = pointy.Int(int(line))
+		} else if matches := generalPattern.FindSubmatch([]byte(line)); matches != nil {
+			frame.FunctionName = pointy.String(string(matches[1]))
+			if language == "golang" {
+				continue
+			}
+		}
+		frames = append(frames, frame)
+		frame = nil
+	}
+	return frames, nil
+}
+
+func formatStructureStackTrace(stackTrace string) string {
+	frames, err := structureStackTrace(stackTrace)
+	if err != nil {
+		log.WithField("StackTrace", stackTrace).WithError(err).Warnf("otel failed to structure stacktrace")
+		return stackTrace
+	}
+	output, err := json.Marshal(frames)
+	if err != nil {
+		log.WithField("Frames", frames).WithField("StackTrace", stackTrace).WithError(err).Warnf("otel failed to json stringify frames")
+		return stackTrace
+	}
+	return string(output)
+}

--- a/backend/otel/parse.go
+++ b/backend/otel/parse.go
@@ -73,9 +73,11 @@ func structureStackTrace(stackTrace string) ([]*model3.ErrorTrace, error) {
 			line, _ := strconv.ParseInt(string(matches[2]), 10, 32)
 			frame.LineNumber = pointy.Int(int(line))
 		} else if matches := generalPattern.FindSubmatch([]byte(line)); matches != nil {
-			frame.FunctionName = pointy.String(string(matches[1]))
 			if language == "golang" {
+				frame.FunctionName = pointy.String(string(matches[1]))
 				continue
+			} else {
+				frame.LineContent = pointy.String(string(matches[1]))
 			}
 		}
 		frames = append(frames, frame)

--- a/backend/otel/parse_test.go
+++ b/backend/otel/parse_test.go
@@ -30,6 +30,7 @@ func TestFormatStructureStackTrace(t *testing.T) {
 				assert.NotNil(t, frame)
 				assert.NotNil(t, frame.FileName)
 				assert.GreaterOrEqual(t, len(*frame.FileName), 1)
+				assert.Equal(t, input.expectedFrameError, *frame.Error)
 			}
 		})
 	}

--- a/backend/otel/parse_test.go
+++ b/backend/otel/parse_test.go
@@ -1,0 +1,36 @@
+package otel
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func FuzzFormatStructureStackTrace(f *testing.F) {
+	f.Fuzz(func(t *testing.T, stackTrace string) {
+		formatStructureStackTrace(stackTrace)
+	})
+}
+
+func TestFormatStructureStackTrace(t *testing.T) {
+	var inputs = []struct {
+		language           string
+		stacktrace         string
+		expectedFrameError string
+	}{
+		{language: "trpc", stacktrace: "Error: oh no!\n    at Procedure.resolve [as resolver] (webpack-internal:///(api)/./src/server/routers/name.ts:18:19)\n    at Array.<anonymous> (/Users/vkorolik/work/web-test/trpc-nextjs-demo-internal/node_modules/@trpc/server/dist/router-ee876044.cjs.dev.js:101:36)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at async callRecursive (/Users/vkorolik/work/web-test/trpc-nextjs-demo-internal/node_modules/@trpc/server/dist/router-ee876044.cjs.dev.js:119:24)\n    at async Procedure.call (/Users/vkorolik/work/web-test/trpc-nextjs-demo-internal/node_modules/@trpc/server/dist/router-ee876044.cjs.dev.js:144:20)\n    at async eval (webpack-internal:///(api)/./node_modules/@trpc/server/dist/resolveHTTPResponse-ab01e4b9.cjs.dev.js:205:24)\n    at async Promise.all (index 0)\n    at async Object.resolveHTTPResponse (webpack-internal:///(api)/./node_modules/@trpc/server/dist/resolveHTTPResponse-ab01e4b9.cjs.dev.js:201:24)\n    at async Object.nodeHTTPRequestHandler (webpack-internal:///(api)/./node_modules/@trpc/server/dist/nodeHTTPRequestHandler-9a93c255.cjs.dev.js:68:18)\n    at async eval (webpack-internal:///(api)/./node_modules/@trpc/server/adapters/next/dist/trpc-server-adapters-next.cjs.dev.js:48:5)", expectedFrameError: "Error: oh no!"},
+		{language: "python", stacktrace: "Traceback (most recent call last):\n  File \"/Users/vkorolik/Library/Caches/pypoetry/virtualenvs/highlight-io-T_znYNk9-py3.10/lib/python3.10/site-packages/flask/app.py\", line 2525, in wsgi_app\n    response = self.full_dispatch_request()\n  File \"/Users/vkorolik/Library/Caches/pypoetry/virtualenvs/highlight-io-T_znYNk9-py3.10/lib/python3.10/site-packages/flask/app.py\", line 1822, in full_dispatch_request\n    rv = self.handle_user_exception(e)\n  File \"/Users/vkorolik/Library/Caches/pypoetry/virtualenvs/highlight-io-T_znYNk9-py3.10/lib/python3.10/site-packages/flask/app.py\", line 1820, in full_dispatch_request\n    rv = self.dispatch_request()\n  File \"/Users/vkorolik/Library/Caches/pypoetry/virtualenvs/highlight-io-T_znYNk9-py3.10/lib/python3.10/site-packages/flask/app.py\", line 1796, in dispatch_request\n    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)\n  File \"/Users/vkorolik/work/highlight/sdk/highlight-py/examples/app.py\", line 25, in hello\n    raise Exception(f\"random error! {idx}\")\nException: random error! 106\n", expectedFrameError: "Exception: random error! 106"},
+		{language: "golang", stacktrace: "\ngithub.com/highlight-run/highlight/backend/private-graph/graph.(*queryResolver).Admin\n\t/build/backend/private-graph/graph/schema.resolvers.go:6081\ngithub.com/highlight-run/highlight/backend/private-graph/graph/generated.(*executionContext)._Query_admin.func2\n\t/build/backend/private-graph/graph/generated/generated.go:39227\ngithub.com/99designs/gqlgen/graphql/executor.processExtensions.func4\n\t/go/pkg/mod/github.com/99designs/gqlgen@v0.17.24/graphql/executor/extensions.go:72\ngithub.com/99designs/gqlgen/graphql/executor.processExtensions.func8.1\n\t/go/pkg/mod/github.com/99designs/gqlgen@v0.17.24/graphql/executor/extensions.go:110\ngithub.com/highlight/highlight/sdk/highlight-go.Tracer.InterceptField\n\t/build/sdk/highlight-go/tracer.go:47\ngithub.com/99designs/gqlgen/graphql/executor.processExtensions.func8\n\t/go/pkg/mod/github.com/99designs/gqlgen@v0.17.24/graphql/executor/extensions.go:109\ngithub.com/99designs/gqlgen/graphql/executor.processExtensions.func8.1\n\t/go/pkg/mod/github.com/99designs/gqlgen@v0.17.24/graphql/executor/extensions.go:110\ngithub.com/highlight-run/highlight/backend/util.Tracer.InterceptField\n\t/build/backend/util/tracer.go:45\ngithub.com/99designs/gqlgen/graphql/executor.processExtensions.func8\n\t/go/pkg/mod/github.com/99designs/gqlgen@v0.17.24/graphql/executor/extensions.go:109\ngithub.com/highlight-run/highlight/backend/private-graph/graph/generated.(*executionContext)._Query_admin\n\t/build/backend/private-graph/graph/generated/generated.go:39225\ngithub.com/highlight-run/highlight/backend/private-graph/graph/generated.(*executionContext)._Query.func280\n\t/build/backend/private-graph/graph/generated/generated.go:59279\ngithub.com/99designs/gqlgen/graphql/executor.processExtensions.func3\n\t/go/pkg/mod/github.com/99designs/gqlgen@v0.17.24/graphql/executor/extensions.go:69\ngithub.com/highlight-run/highlight/backend/private-graph/graph/generated.(*executionContext)._Query.func281\n\t/build/backend/private-graph/graph/generated/generated.go:59284\ngithub.com/highlight-run/highlight/backend/private-graph/graph/generated.(*executionContext)._Query.func282\n\t/build/backend/private-graph/graph/generated/generated.go:59288\ngithub.com/99designs/gqlgen/graphql.(*FieldSet).Dispatch.func1\n\t/go/pkg/mod/github.com/99designs/gqlgen@v0.17.24/graphql/fieldset.go:42\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1172"},
+		{language: "next.js-backend", stacktrace: "Error: GraphQL Error (Code: 401): {\"response\":{\"error\":\"{\\\"errors\\\":[{\\\"message\\\":\\\"token verification failed: token contains an invalid number of segments\\\"}],\\\"data\\\":null}\",\"status\":401,\"headers\":{}},\"request\":{\"query\":\"\\n      query GetPosts() {\\n        posts(orderBy: publishedAt_DESC) {\\n          slug\\n        }\\n      }\\n    \"}}\n    at /Users/jaykhatri/projects/highlight.io/node_modules/graphql-request/dist/index.js:416:31\n    at step (/Users/jaykhatri/projects/highlight.io/node_modules/graphql-request/dist/index.js:67:23)\n    at Object.next (/Users/jaykhatri/projects/highlight.io/node_modules/graphql-request/dist/index.js:48:53)\n    at fulfilled (/Users/jaykhatri/projects/highlight.io/node_modules/graphql-request/dist/index.js:39:58)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)", expectedFrameError: "Error: GraphQL Error (Code: 401): {\"response\":{\"error\":\"{\\\"errors\\\":[{\\\"message\\\":\\\"token verification failed: token contains an invalid number of segments\\\"}],\\\"data\\\":null}\",\"status\":401,\"headers\":{}},\"request\":{\"query\":\"\\n      query GetPosts() {\\n        posts(orderBy: publishedAt_DESC) {\\n          slug\\n        }\\n      }\\n    \"}}"},
+	}
+	for _, input := range inputs {
+		t.Run(input.language, func(t *testing.T) {
+			frames, err := structureStackTrace(input.stacktrace)
+			assert.NoErrorf(t, err, "unexpected error")
+			for _, frame := range frames {
+				assert.NotNil(t, frame)
+				assert.NotNil(t, frame.FileName)
+				assert.GreaterOrEqual(t, len(*frame.FileName), 1)
+			}
+		})
+	}
+}

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -7760,7 +7760,7 @@ type ErrorObject {
 	id: ID!
 	created_at: Timestamp!
 	project_id: Int!
-	session_id: Int!
+	session_id: Int
 	error_group_id: Int!
 	error_group_secure_id: String!
 	event: [String]!
@@ -22523,14 +22523,11 @@ func (ec *executionContext) _ErrorObject_session_id(ctx context.Context, field g
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*int)
 	fc.Result = res
-	return ec.marshalNInt2ᚖint(ctx, field.Selections, res)
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ErrorObject_session_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -55494,9 +55491,6 @@ func (ec *executionContext) _ErrorObject(ctx context.Context, sel ast.SelectionS
 
 			out.Values[i] = ec._ErrorObject_session_id(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "error_group_id":
 
 			out.Values[i] = ec._ErrorObject_error_group_id(ctx, field, obj)
@@ -64097,27 +64091,6 @@ func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}
 
 func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
 	res := graphql.MarshalInt(v)
-	if res == graphql.Null {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-	}
-	return res
-}
-
-func (ec *executionContext) unmarshalNInt2ᚖint(ctx context.Context, v interface{}) (*int, error) {
-	res, err := graphql.UnmarshalInt(v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNInt2ᚖint(ctx context.Context, sel ast.SelectionSet, v *int) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	res := graphql.MarshalInt(*v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -380,7 +380,7 @@ type ErrorObject {
 	id: ID!
 	created_at: Timestamp!
 	project_id: Int!
-	session_id: Int!
+	session_id: Int
 	error_group_id: Int!
 	error_group_secure_id: String!
 	event: [String]!

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2047,10 +2047,12 @@ func (r *Resolver) AddLegacyMetric(ctx context.Context, sessionID int, name stri
 
 func (r *Resolver) PushMetricsImpl(ctx context.Context, sessionSecureID string, metrics []*publicModel.MetricInput) error {
 	span, _ := tracer.StartSpanFromContext(ctx, "public-graph.PushMetricsImpl", tracer.ResourceName("go.push-metrics"))
+	span.SetTag("SessionSecureID", sessionSecureID)
+	span.SetTag("NumMetrics", len(metrics))
 	defer span.Finish()
 
 	if sessionSecureID == "" {
-		return e.New("PushMetricsImpl called without secureID")
+		return nil
 	}
 	session := &model.Session{}
 	if err := r.DB.Order("secure_id").Model(&session).Where(&model.Session{SecureID: sessionSecureID}).Limit(1).Find(&session).Error; err != nil || session.ID == 0 {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -451,7 +451,7 @@ export type ErrorObject = {
 	project_id: Scalars['Int']
 	request_id?: Maybe<Scalars['String']>
 	session?: Maybe<Session>
-	session_id: Scalars['Int']
+	session_id?: Maybe<Scalars['Int']>
 	source?: Maybe<Scalars['String']>
 	stack_trace: Scalars['String']
 	structured_stack_trace: Array<Maybe<ErrorTrace>>


### PR DESCRIPTION
## Summary

* Makes our otel errors ingest parse stack traces into a structured format that the frontend can render.
* Resolves a noisy log `PushMetricsImpl called without secureID` from session-less metrics (not yet supported).

## How did you test this change?

New unit test, full stack deploy.

## Are there any deployment considerations?

No.