### PR TITLE
create vercel log drain from the integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ The fastest and most reliable way to get started with highlight.io is signing up
 Deploy a hobby instance in one line on Linux with Docker (recommended 16 CPU cores, 32GB RAM, 256GB disk):
 
 ```bash
-git clone https://github.com/highlight/highlight
+git clone --recurse-submodules https://github.com/highlight/highlight
+# or `git submodule update --init --recursive` on git < 2.13
 cd docker && docker compose up -d --build
 ```
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/highlight-run/highlight/backend/vercel"
 	"html/template"
 	"io"
 	"net/http"
@@ -400,6 +401,7 @@ func main() {
 		})
 		otelHandler := otel.New(publicResolver)
 		otelHandler.Listen(r)
+		vercel.Listen(r)
 	}
 
 	if util.IsDevOrTestEnv() {

--- a/backend/otel/parse_test.go
+++ b/backend/otel/parse_test.go
@@ -9,7 +9,10 @@ import (
 
 func FuzzFormatStructureStackTrace(f *testing.F) {
 	f.Fuzz(func(t *testing.T, stackTrace string) {
-		formatStructureStackTrace(stackTrace)
+		output := formatStructureStackTrace(stackTrace)
+		if stackTrace != "" && output == "" {
+			t.Fatalf("expected to get an output")
+		}
 	})
 }
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3216,6 +3216,11 @@ func (r *mutationResolver) UpdateVercelProjectMappings(ctx context.Context, proj
 			workspace.VercelTeamID, projectEnvId, vercel.ProjectIdEnvVar); err != nil {
 			return false, err
 		}
+
+		if err := vercel.CreateLogDrain(m.VercelProjectID, project.VerboseID(), "highlight-log-drain", *workspace.VercelAccessToken); err != nil {
+			return false, err
+		}
+
 		configs = append(configs, &model.VercelIntegrationConfig{
 			WorkspaceID:     workspaceId,
 			VercelProjectID: m.VercelProjectID,

--- a/frontend/src/pages/Setup/SetupPage.tsx
+++ b/frontend/src/pages/Setup/SetupPage.tsx
@@ -997,8 +997,7 @@ export default withHighlightConfig({
 				<p>
 					<CodeBlock
 						language="javascript"
-						text={`const highlightOptions = {};
-export const withHighlight = Highlight(highlightOptions);`}
+						text={`export const withHighlight = Highlight({projectID: 'YOUR_PROJECT_ID'});`}
 					/>
 				</p>
 				<p>


### PR DESCRIPTION
## Summary

* Sets up new log drain handler on pub/vercel/v1/logs
* Adds [log drain creation](https://vercel.com/docs/concepts/observability/log-drains-overview/log-drains-reference) to the vercel integration setup workflow.

## How did you test this change?

Local deploy testing the vercel log creation.

## Are there any deployment considerations?

Tricky to test the log drain locally.