### PR TITLE
make initializeSession opensearch indexing idempotent

### DIFF
--- a/backend/migrations/cmd/backfill-session-missing-user-properties/main.go
+++ b/backend/migrations/cmd/backfill-session-missing-user-properties/main.go
@@ -2,15 +2,58 @@ package main
 
 import (
 	"context"
+	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/opensearch"
 	public "github.com/highlight-run/highlight/backend/public-graph/graph"
+	"github.com/highlight-run/workerpool"
 	e "github.com/pkg/errors"
-	"os"
-
 	log "github.com/sirupsen/logrus"
-
-	"github.com/highlight-run/highlight/backend/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"net/mail"
+	"os"
+	"reflect"
+	"sync"
 )
+
+const BatchSize = 64
+
+func FindInBatches(db *gorm.DB, dest interface{}, batchSize int, fc func(tx *gorm.DB, batch int) error) *gorm.DB {
+	var (
+		tx = db.Order(clause.OrderByColumn{
+			Column: clause.Column{Table: clause.CurrentTable, Name: "created_at"},
+		}).Session(&gorm.Session{})
+		queryDB      = tx
+		rowsAffected int64
+		batch        int
+	)
+
+	for {
+		result := queryDB.Limit(batchSize).Find(dest)
+		rowsAffected += result.RowsAffected
+		batch++
+
+		if result.Error == nil && result.RowsAffected != 0 {
+			tx.AddError(fc(result, batch))
+		} else if result.Error != nil {
+			tx.AddError(result.Error)
+		}
+
+		if tx.Error != nil || int(result.RowsAffected) < batchSize {
+			break
+		} else {
+			resultsValue := reflect.Indirect(reflect.ValueOf(dest))
+			if result.Statement.Schema.PrioritizedPrimaryField == nil {
+				tx.AddError(gorm.ErrPrimaryKeyRequired)
+				break
+			} else {
+				primaryValue, _ := result.Statement.Schema.PrioritizedPrimaryField.ValueOf(resultsValue.Index(resultsValue.Len() - 1))
+				queryDB = tx.Clauses(clause.Gt{Column: clause.Column{Table: clause.CurrentTable, Name: clause.PrimaryKey}, Value: primaryValue})
+			}
+		}
+	}
+	return tx
+}
 
 func main() {
 	log.Info("setting up db")
@@ -25,27 +68,61 @@ func main() {
 	}
 
 	r := public.Resolver{
-		DB:         db,
-		OpenSearch: opensearchClient,
+		AlertWorkerPool: workerpool.New(16),
+		DB:              db,
+		OpenSearch:      opensearchClient,
 	}
 	log.Infof("starting query")
 
 	var sessions []model.Session
-	if err := db.Debug().Model(&model.Session{}).Where("project_id = ?", 762).Where("created_at > ?", "2022-08-10").Where("created_at < ?", "2022-08-24 17:46:00").Where("COALESCE(user_properties, '') != ''").Scan(&sessions).Error; err != nil {
+
+	wg := sync.WaitGroup{}
+	inner := func(tx *gorm.DB, batch int) error {
+		wg.Add(1)
+		go func() {
+			for _, session := range sessions {
+				if err := r.IndexSessionOpensearch(context.Background(), &session); err != nil {
+					log.Error(e.Wrap(err, "error indexing new session in opensearch"))
+					continue
+				}
+
+				userObj := make(map[string]string)
+				// get existing session user properties in case of multiple identify calls
+				if existingUserProps, err := session.GetUserProperties(); err == nil {
+					for k, v := range existingUserProps {
+						userObj[k] = v
+					}
+				}
+				if session.Identifier != "" {
+					userObj["identifier"] = session.Identifier
+				}
+				_, err = mail.ParseAddress(session.Identifier)
+				if err == nil {
+					userObj["email"] = session.Identifier
+				}
+
+				if err := r.AppendProperties(context.Background(), session.ID, userObj, public.PropertyType.USER); err != nil {
+					log.Error(e.Wrapf(err, "error backfilling: session: %d", session.ID))
+				}
+
+				log.Infof("updated %d", session.ID)
+			}
+			wg.Done()
+		}()
+		return nil
+	}
+
+	//if err := db.Debug().Clauses().Model(&model.Session{}).Where("created_at > ?", "2023-02-09 14:00:00 PST").Where("created_at <= ?", "2023-02-10 09:13:00 PST").FindInBatches(&sessions, BatchSize, inner).Error; err != nil {
+	//	log.Fatalf("error getting sessions: %v", err)
+	//}
+
+	if err := FindInBatches(db.Debug().Clauses().Model(&model.Session{}).Where("created_at > ?", "2023-02-09 14:00:00 PST").Where("created_at <= ?", "2023-02-10 09:13:00 PST"), &sessions, BatchSize, inner).Error; err != nil {
 		log.Fatalf("error getting sessions: %v", err)
 	}
 
-	for _, session := range sessions {
-		userProperties, err := session.GetUserProperties()
-		if err != nil {
-			log.Error(e.Wrapf(err, "error getting user properties: %d", session.ID))
-			continue
-		}
-		if err := r.AppendProperties(context.Background(), session.ID, userProperties, public.PropertyType.USER); err != nil {
-			log.Error(e.Wrapf(err, "error backfilling: session: %d", session.ID))
-		}
-		log.Infof("updated %d user props %+v", session.ID, userProperties)
-	}
+	wg.Wait()
 
-	_ = opensearchClient.Close()
+	if err := r.OpenSearch.Close(); err != nil {
+		log.Fatalf("error closing OS: %v", err)
+	}
 }

--- a/backend/migrations/cmd/backfill-session-missing-user-properties/main.go
+++ b/backend/migrations/cmd/backfill-session-missing-user-properties/main.go
@@ -34,9 +34,9 @@ func FindInBatches(db *gorm.DB, dest interface{}, batchSize int, fc func(tx *gor
 		batch++
 
 		if result.Error == nil && result.RowsAffected != 0 {
-			tx.AddError(fc(result, batch))
+			_ = tx.AddError(fc(result, batch))
 		} else if result.Error != nil {
-			tx.AddError(result.Error)
+			_ = tx.AddError(result.Error)
 		}
 
 		if tx.Error != nil || int(result.RowsAffected) < batchSize {
@@ -44,7 +44,7 @@ func FindInBatches(db *gorm.DB, dest interface{}, batchSize int, fc func(tx *gor
 		} else {
 			resultsValue := reflect.Indirect(reflect.ValueOf(dest))
 			if result.Statement.Schema.PrioritizedPrimaryField == nil {
-				tx.AddError(gorm.ErrPrimaryKeyRequired)
+				_ = tx.AddError(gorm.ErrPrimaryKeyRequired)
 				break
 			} else {
 				primaryValue, _ := result.Statement.Schema.PrioritizedPrimaryField.ValueOf(resultsValue.Index(resultsValue.Len() - 1))

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1124,6 +1124,29 @@ func (r *Resolver) getExistingSession(projectID int, secureID string) (*model.Se
 	return nil, nil
 }
 
+func (r *Resolver) IndexSessionOpensearch(ctx context.Context, session *model.Session) error {
+	osSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.InitializeSessionImpl", tracer.ResourceName("go.sessions.OSIndex"))
+	if err := r.OpenSearch.IndexSynchronous(opensearch.IndexSessions, session.ID, session); err != nil {
+		return e.Wrap(err, "error indexing new session in opensearch")
+	}
+
+	sessionProperties := map[string]string{
+		"os_name":         session.OSName,
+		"os_version":      session.OSVersion,
+		"browser_name":    session.BrowserName,
+		"browser_version": session.BrowserVersion,
+		"environment":     session.Environment,
+		"device_id":       strconv.Itoa(session.Fingerprint),
+		"city":            session.City,
+		"country":         session.Country,
+	}
+	if err := r.AppendProperties(ctx, session.ID, sessionProperties, PropertyType.SESSION); err != nil {
+		log.Error(e.Wrap(err, "error adding set of properties to db"))
+	}
+	osSpan.Finish()
+	return nil
+}
+
 func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue.InitializeSessionArgs) (*model.Session, error) {
 	initSpan, initCtx := tracer.StartSpanFromContext(ctx, "public-graph.InitializeSessionImpl",
 		tracer.ResourceName("go.sessions.InitializeSessionImpl"),
@@ -1151,6 +1174,9 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 		return nil, err
 	}
 	if existingSession != nil {
+		if err := r.IndexSessionOpensearch(initCtx, existingSession); err != nil {
+			return nil, err
+		}
 		return existingSession, nil
 	}
 	initSpan.SetTag("duplicate", false)
@@ -1286,25 +1312,9 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 		log.Errorf("failed to count sessions metric for %s: %s", session.SecureID, err)
 	}
 
-	osSpan, _ := tracer.StartSpanFromContext(initCtx, "public-graph.InitializeSessionImpl", tracer.ResourceName("go.sessions.OSIndex"))
-	if err := r.OpenSearch.IndexSynchronous(opensearch.IndexSessions, session.ID, session); err != nil {
-		return nil, e.Wrap(err, "error indexing new session in opensearch")
+	if err := r.IndexSessionOpensearch(initCtx, existingSession); err != nil {
+		return nil, err
 	}
-
-	sessionProperties := map[string]string{
-		"os_name":         session.OSName,
-		"os_version":      session.OSVersion,
-		"browser_name":    session.BrowserName,
-		"browser_version": session.BrowserVersion,
-		"environment":     session.Environment,
-		"device_id":       strconv.Itoa(session.Fingerprint),
-		"city":            session.City,
-		"country":         session.Country,
-	}
-	if err := r.AppendProperties(initCtx, session.ID, sessionProperties, PropertyType.SESSION); err != nil {
-		log.Error(e.Wrap(err, "error adding set of properties to db"))
-	}
-	osSpan.Finish()
 
 	if len(input.NetworkRecordingDomains) > 0 {
 		project.BackendDomains = input.NetworkRecordingDomains

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1126,6 +1126,7 @@ func (r *Resolver) getExistingSession(projectID int, secureID string) (*model.Se
 
 func (r *Resolver) IndexSessionOpensearch(ctx context.Context, session *model.Session) error {
 	osSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.InitializeSessionImpl", tracer.ResourceName("go.sessions.OSIndex"))
+	defer osSpan.Finish()
 	if err := r.OpenSearch.IndexSynchronous(opensearch.IndexSessions, session.ID, session); err != nil {
 		return e.Wrap(err, "error indexing new session in opensearch")
 	}
@@ -1143,7 +1144,6 @@ func (r *Resolver) IndexSessionOpensearch(ctx context.Context, session *model.Se
 	if err := r.AppendProperties(ctx, session.ID, sessionProperties, PropertyType.SESSION); err != nil {
 		log.Error(e.Wrap(err, "error adding set of properties to db"))
 	}
-	osSpan.Finish()
 	return nil
 }
 


### PR DESCRIPTION
## Summary

As discovered during our topic rewind due to opensearch running out of space, our
indexing of sessions in opensearch is not idempotent because it only happens if a session
does not exist in postgres.

Makes the opensearch session addition from `InitializeSession` always occur, even if the session exists in postgres.

Improves the backfill-session migration script for bulk processing and full reindexing of sessions in opensearch.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

No
