### PR TITLE
hotfix: replace useParams with useMatch for useIntegrated

### DIFF
--- a/frontend/src/util/integrated.tsx
+++ b/frontend/src/util/integrated.tsx
@@ -3,6 +3,7 @@ import {
 	useIsBackendIntegratedLazyQuery,
 	useIsIntegratedLazyQuery,
 } from '@graph/hooks'
+import { useNumericProjectId } from '@hooks/useProjectId'
 import useLocalStorage from '@rehooks/local-storage'
 import analytics from '@util/analytics'
 import { useParams } from '@util/react-router/useParams'
@@ -10,13 +11,13 @@ import { useEffect, useState } from 'react'
 
 export const useIntegrated = (): { integrated: boolean; loading: boolean } => {
 	const { isLoggedIn, isAuthLoading } = useAuthContext()
-	const { project_id } = useParams<{ project_id: string }>()
+	const { projectId } = useNumericProjectId()
 	const [query, { data, loading }] = useIsIntegratedLazyQuery({
-		variables: { project_id: project_id! },
+		variables: { project_id: projectId! },
 		fetchPolicy: 'cache-and-network',
 	})
 	const [localStorageIntegrated, setLocalStorageIntegrated] = useLocalStorage(
-		`highlight-${project_id}-integrated`,
+		`highlight-${projectId}-integrated`,
 		false,
 	)
 	const [integrated, setIntegrated] = useState<boolean | undefined>(undefined)
@@ -51,13 +52,13 @@ export const useIntegrated = (): { integrated: boolean; loading: boolean } => {
 				localStorageIntegrated === false &&
 				integratedRaw?.valueOf() === true
 			) {
-				analytics.track('IntegratedProject', { id: project_id })
+				analytics.track('IntegratedProject', { id: projectId })
 			}
 		}
 	}, [
 		integratedRaw,
 		localStorageIntegrated,
-		project_id,
+		projectId,
 		setLocalStorageIntegrated,
 	])
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

After the rewrite of routes, `project_id` [is undefined](https://github.com/highlight/highlight/blob/3921bc3ec1aff3500a1ef01281037fcef6e6cca6/frontend/src/routers/AppRouter/AppRouter.tsx#L123) at the point where we are calling useIntegrated. This PR fixes the useIntegrated hook by replacing useParams with useMatch which does not depend on the param defined inside `<Route .../>`.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Go to /sessions or /errors for any integrated project and check that the empty session card is correct.

e.g. https://frontend-pr-4244.onrender.com/1/sessions

should be (this PR):
![Screenshot 2023-02-13 at 1 48 27 PM](https://user-images.githubusercontent.com/17913919/218582198-ab90ef57-3e09-4906-8a26-51d095cc96a7.jpg)

now:
![Screenshot 2023-02-13 at 1 48 45 PM](https://user-images.githubusercontent.com/17913919/218582235-f33defc0-2b33-4986-94f7-095cbed4927f.jpg)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no