### PR TITLE
add vercel debug info and kafka log ingest sizes

### DIFF
--- a/backend/vercel/vercel.go
+++ b/backend/vercel/vercel.go
@@ -226,9 +226,9 @@ func CreateLogDrain(vercelProjectID string, projectVerboseID string, name string
 
 	headers := fmt.Sprintf(`{"%s":"%s"}`, VercelLogDrainProjectHeader, projectVerboseID)
 	projectIds := fmt.Sprintf(`["%s"]`, vercelProjectID)
-	body := fmt.Sprintf(`{"url":"https://pub.highlight.io/vercel/v1/logs","name":"%s","headers":%s,"projectIds":%s,"deliveryFormat":"ndjson"}`, name, headers, projectIds)
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/v2/integrations/log-drains?teamId=%s", VercelApiBaseUrl, vercelProjectID),
-		strings.NewReader(body))
+	u := fmt.Sprintf("%s/v2/integrations/log-drains?teamId=%s", VercelApiBaseUrl, vercelProjectID)
+	body := fmt.Sprintf(`{"url":"https://pub.highlight.run/vercel/v1/logs","name":"%s","headers":%s,"projectIds":%s,"deliveryFormat":"ndjson"}`, name, headers, projectIds)
+	req, err := http.NewRequest("POST", u, strings.NewReader(body))
 	if err != nil {
 		return errors.Wrap(err, "error creating api request to Vercel")
 	}
@@ -243,6 +243,11 @@ func CreateLogDrain(vercelProjectID string, projectVerboseID string, name string
 	b, err := io.ReadAll(res.Body)
 
 	if res.StatusCode != 200 {
+		log.WithField("Status", res.Status).
+			WithField("Body", string(b)).
+			WithField("Url", u).
+			WithField("Token", accessToken).
+			Errorf("Vercel Log Drain API responded with error")
 		return errors.New("Vercel Log Drain API responded with error; status_code=" + res.Status + "; body=" + string(b))
 	}
 

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -62,8 +62,8 @@ func (k *KafkaWorker) ProcessMessages() {
 	}
 }
 
-const BatchFlushSize = 512
-const BatchedFlushTimeout = 5 * time.Second
+const BatchFlushSize = 128
+const BatchedFlushTimeout = 1 * time.Second
 
 type KafkaWorker struct {
 	KafkaQueue   *kafkaqueue.Queue
@@ -98,6 +98,7 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 		}
 	}()
 
+	s.SetTag("NumLogRows", len(logRows))
 	err := k.Worker.PublicResolver.Clickhouse.BatchWriteLogRows(ctx, logRows)
 	if err != nil {
 		log.WithContext(ctx).WithError(err).Error("failed to batch write to clickhouse")


### PR DESCRIPTION
* add extra vercel log drain setup logging
* reduce batch processing size for log ingest to limit write size