### PR TITLE
add total count to logs page

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -96,6 +96,22 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 	return logLines, rows.Err()
 }
 
+func (client *Client) ReadLogsTotalCount(ctx context.Context, projectID int, params modelInputs.LogsParamsInput) (uint64, error) {
+	whereClause := buildWhereClause(projectID, params)
+
+	query := fmt.Sprintf(`SELECT COUNT(*) FROM %s %s`, LogsTable, whereClause)
+
+	log.Info(query)
+
+	var count uint64
+	err := client.conn.QueryRow(
+		ctx,
+		query,
+	).Scan(&count)
+
+	return count, err
+}
+
 func makeSeverityText(severityText string) modelInputs.SeverityText {
 	switch strings.ToLower(severityText) {
 	case "trace":

--- a/backend/clickhouse/seeds/main.go
+++ b/backend/clickhouse/seeds/main.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/highlight-run/highlight/backend/clickhouse"
+	log "github.com/sirupsen/logrus"
+)
+
+func makeRandTime() time.Time {
+	now := time.Now()
+
+	randomTimes := [3]time.Time{
+		now.Add(-time.Hour * 72),
+		now.Add(-time.Hour * 144),
+		now,
+	}
+
+	return randomTimes[rand.Intn(len(randomTimes))]
+}
+
+func makeRandProjectId() uint32 {
+	projectIDs := make([]uint32, 0)
+	projectIDs = append(projectIDs, 1, 2, 3, 4, 5)
+	return projectIDs[rand.Intn(len(projectIDs))]
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func makeRandomBody() string {
+	b := make([]rune, 30)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+func makeRandLogAttributes() map[string]string {
+	randomKeys := [20]string{
+		"key1",
+		"key2",
+		"key3",
+		"key4",
+		"key5",
+		"key6",
+		"key7",
+		"key8",
+		"key9",
+		"key10",
+		"key11",
+		"key12",
+		"key13",
+		"key14",
+		"key15",
+		"key16",
+		"key17",
+		"key18",
+		"key19",
+		"key20",
+	}
+
+	randomVals := [20]string{
+		"val1",
+		"val2",
+		"val3",
+		"val4",
+		"val5",
+		"val6",
+		"val7",
+		"val8",
+		"val9",
+		"val10",
+		"val11",
+		"val12",
+		"val13",
+		"val14",
+		"val15",
+		"val16",
+		"val17",
+		"val18",
+		"val19",
+		"val20",
+	}
+
+	randomServices := [6]string{
+		"backend",
+		"frontend",
+		"middleware",
+		"logger",
+		"imageparser",
+		"flounder",
+	}
+
+	logAttributes := map[string]string{}
+
+	randomKey := randomKeys[rand.Intn(len(randomKeys))]
+	randomVal := randomVals[rand.Intn(len(randomVals))]
+	randomService := randomServices[rand.Intn(len(randomServices))]
+
+	logAttributes["workspace_id"] = strconv.Itoa(rand.Intn(100))
+	logAttributes["user_id"] = strconv.Itoa(rand.Intn(100))
+	logAttributes["service_name"] = randomService
+	logAttributes[randomKey] = randomVal
+
+	return logAttributes
+}
+
+// Run via
+// `doppler run -- go run backend/clickhouse/seeds/main.go“
+func main() {
+	client, err := clickhouse.NewClient(clickhouse.PrimaryDatabase)
+
+	if err != nil {
+		log.Fatal("could not connect to clickhouse db")
+	}
+
+	logRows := []*clickhouse.LogRow{}
+
+	for i := 1; i < 10000; i++ {
+		for j := 1; j < 10000; j++ {
+			logRows = append(logRows, &clickhouse.LogRow{
+				Timestamp:     makeRandTime(),
+				ProjectId:     makeRandProjectId(),
+				Body:          makeRandomBody(),
+				LogAttributes: makeRandLogAttributes(),
+			})
+		}
+
+		err = client.BatchWriteLogRows(context.Background(), logRows)
+
+		if err != nil {
+			log.Fatalf("failed to write log row data: %v", err)
+		}
+	}
+}

--- a/backend/private-graph/gqlgen.yml
+++ b/backend/private-graph/gqlgen.yml
@@ -55,6 +55,9 @@ models:
     Int64:
         model:
             - github.com/99designs/gqlgen/graphql.Int64
+    UInt64:
+        model:
+            - github.com/99designs/gqlgen/graphql.Uint64
     Float:
         model:
             - github.com/99designs/gqlgen/graphql.Float

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -702,6 +702,7 @@ type ComplexityRoot struct {
 		LinearTeams                  func(childComplexity int, projectID int) int
 		LiveUsersCount               func(childComplexity int, projectID int) int
 		Logs                         func(childComplexity int, projectID int, params model.LogsParamsInput) int
+		LogsTotalCount               func(childComplexity int, projectID int, params model.LogsParamsInput) int
 		Messages                     func(childComplexity int, sessionSecureID string) int
 		MetricMonitors               func(childComplexity int, projectID int, metricName *string) int
 		MetricTagValues              func(childComplexity int, projectID int, metricName string, tagName string) int
@@ -1301,6 +1302,7 @@ type QueryResolver interface {
 	OauthClientMetadata(ctx context.Context, clientID string) (*model.OAuthClient, error)
 	EmailOptOuts(ctx context.Context, token *string, adminID *int) ([]model.EmailOptOutCategory, error)
 	Logs(ctx context.Context, projectID int, params model.LogsParamsInput) ([]*model.LogLine, error)
+	LogsTotalCount(ctx context.Context, projectID int, params model.LogsParamsInput) (string, error)
 }
 type SegmentResolver interface {
 	Params(ctx context.Context, obj *model1.Segment) (*model1.SearchParams, error)
@@ -5172,6 +5174,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Logs(childComplexity, args["project_id"].(int), args["params"].(model.LogsParamsInput)), true
 
+	case "Query.logs_total_count":
+		if e.complexity.Query.LogsTotalCount == nil {
+			break
+		}
+
+		args, err := ec.field_Query_logs_total_count_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.LogsTotalCount(childComplexity, args["project_id"].(int), args["params"].(model.LogsParamsInput)), true
+
 	case "Query.messages":
 		if e.complexity.Query.Messages == nil {
 			break
@@ -7398,6 +7412,7 @@ var sources = []*ast.Source{
 scalar Any
 scalar Timestamp
 scalar Int64
+scalar UInt64
 scalar StringArray
 scalar Map
 
@@ -8794,6 +8809,7 @@ type Query {
 	oauth_client_metadata(client_id: String!): OAuthClient
 	email_opt_outs(token: String, admin_id: ID): [EmailOptOutCategory!]!
 	logs(project_id: ID!, params: LogsParamsInput!): [LogLine!]!
+	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 }
 
 type Mutation {
@@ -12996,6 +13012,30 @@ func (ec *executionContext) field_Query_liveUsersCount_args(ctx context.Context,
 }
 
 func (ec *executionContext) field_Query_logs_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 model.LogsParamsInput
+	if tmp, ok := rawArgs["params"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+		arg1, err = ec.unmarshalNLogsParamsInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogsParamsInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["params"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_logs_total_count_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 int
@@ -40765,6 +40805,60 @@ func (ec *executionContext) fieldContext_Query_logs(ctx context.Context, field g
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_logs_total_count(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_logs_total_count(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().LogsTotalCount(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.LogsParamsInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNUInt642string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_logs_total_count(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type UInt64 does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_logs_total_count_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query___type(ctx, field)
 	if err != nil {
@@ -59955,6 +60049,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
+		case "logs_total_count":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_logs_total_count(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
 		case "__type":
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
@@ -65999,6 +66113,21 @@ func (ec *executionContext) unmarshalNTrackPropertyInput2ᚕᚖgithubᚗcomᚋhi
 func (ec *executionContext) unmarshalNTrackPropertyInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTrackPropertyInput(ctx context.Context, v interface{}) (*model.TrackPropertyInput, error) {
 	res, err := ec.unmarshalInputTrackPropertyInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNUInt642string(ctx context.Context, v interface{}) (string, error) {
+	res, err := graphql.UnmarshalString(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUInt642string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
+	res := graphql.MarshalString(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
 }
 
 func (ec *executionContext) marshalNUserProperty2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐUserProperty(ctx context.Context, sel ast.SelectionSet, v []*model1.UserProperty) graphql.Marshaler {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1302,7 +1302,7 @@ type QueryResolver interface {
 	OauthClientMetadata(ctx context.Context, clientID string) (*model.OAuthClient, error)
 	EmailOptOuts(ctx context.Context, token *string, adminID *int) ([]model.EmailOptOutCategory, error)
 	Logs(ctx context.Context, projectID int, params model.LogsParamsInput) ([]*model.LogLine, error)
-	LogsTotalCount(ctx context.Context, projectID int, params model.LogsParamsInput) (string, error)
+	LogsTotalCount(ctx context.Context, projectID int, params model.LogsParamsInput) (uint64, error)
 }
 type SegmentResolver interface {
 	Params(ctx context.Context, obj *model1.Segment) (*model1.SearchParams, error)
@@ -40830,9 +40830,9 @@ func (ec *executionContext) _Query_logs_total_count(ctx context.Context, field g
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(uint64)
 	fc.Result = res
-	return ec.marshalNUInt642string(ctx, field.Selections, res)
+	return ec.marshalNUInt642uint64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_logs_total_count(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -66115,13 +66115,13 @@ func (ec *executionContext) unmarshalNTrackPropertyInput2ᚖgithubᚗcomᚋhighl
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNUInt642string(ctx context.Context, v interface{}) (string, error) {
-	res, err := graphql.UnmarshalString(v)
+func (ec *executionContext) unmarshalNUInt642uint64(ctx context.Context, v interface{}) (uint64, error) {
+	res, err := graphql.UnmarshalUint64(v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNUInt642string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
-	res := graphql.MarshalString(v)
+func (ec *executionContext) marshalNUInt642uint64(ctx context.Context, sel ast.SelectionSet, v uint64) graphql.Marshaler {
+	res := graphql.MarshalUint64(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -3,6 +3,7 @@
 scalar Any
 scalar Timestamp
 scalar Int64
+scalar UInt64
 scalar StringArray
 scalar Map
 
@@ -1399,6 +1400,7 @@ type Query {
 	oauth_client_metadata(client_id: String!): OAuthClient
 	email_opt_outs(token: String, admin_id: ID): [EmailOptOutCategory!]!
 	logs(project_id: ID!, params: LogsParamsInput!): [LogLine!]!
+	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 }
 
 type Mutation {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6850,15 +6850,13 @@ func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInp
 }
 
 // LogsTotalCount is the resolver for the logs_total_count field.
-func (r *queryResolver) LogsTotalCount(ctx context.Context, projectID int, params modelInputs.LogsParamsInput) (string, error) {
+func (r *queryResolver) LogsTotalCount(ctx context.Context, projectID int, params modelInputs.LogsParamsInput) (uint64, error) {
 	project, err := r.isAdminInProject(ctx, projectID)
 	if err != nil {
-		return "0", e.Wrap(err, "error querying project")
+		return 0, e.Wrap(err, "error querying project")
 	}
 
-	count, err := r.ClickhouseClient.ReadLogsTotalCount(ctx, project.ID, params)
-
-	return fmt.Sprint(count), err
+	return r.ClickhouseClient.ReadLogsTotalCount(ctx, project.ID, params)
 }
 
 // Params is the resolver for the params field.

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6849,6 +6849,18 @@ func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInp
 	return r.ClickhouseClient.ReadLogs(ctx, project.ID, params)
 }
 
+// LogsTotalCount is the resolver for the logs_total_count field.
+func (r *queryResolver) LogsTotalCount(ctx context.Context, projectID int, params modelInputs.LogsParamsInput) (string, error) {
+	project, err := r.isAdminInProject(ctx, projectID)
+	if err != nil {
+		return "0", e.Wrap(err, "error querying project")
+	}
+
+	count, err := r.ClickhouseClient.ReadLogsTotalCount(ctx, project.ID, params)
+
+	return fmt.Sprint(count), err
+}
+
 // Params is the resolver for the params field.
 func (r *segmentResolver) Params(ctx context.Context, obj *model.Segment) (*model.SearchParams, error) {
 	params := &model.SearchParams{}

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -11323,3 +11323,58 @@ export type GetLogsQueryResult = Apollo.QueryResult<
 	Types.GetLogsQuery,
 	Types.GetLogsQueryVariables
 >
+export const GetLogsTotalCountDocument = gql`
+	query GetLogsTotalCount($project_id: ID!, $params: LogsParamsInput!) {
+		logs_total_count(project_id: $project_id, params: $params)
+	}
+`
+
+/**
+ * __useGetLogsTotalCountQuery__
+ *
+ * To run a query within a React component, call `useGetLogsTotalCountQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetLogsTotalCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetLogsTotalCountQuery({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *      params: // value for 'params'
+ *   },
+ * });
+ */
+export function useGetLogsTotalCountQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogsTotalCountQuery,
+		Types.GetLogsTotalCountQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetLogsTotalCountQuery,
+		Types.GetLogsTotalCountQueryVariables
+	>(GetLogsTotalCountDocument, baseOptions)
+}
+export function useGetLogsTotalCountLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogsTotalCountQuery,
+		Types.GetLogsTotalCountQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetLogsTotalCountQuery,
+		Types.GetLogsTotalCountQueryVariables
+	>(GetLogsTotalCountDocument, baseOptions)
+}
+export type GetLogsTotalCountQueryHookResult = ReturnType<
+	typeof useGetLogsTotalCountQuery
+>
+export type GetLogsTotalCountLazyQueryHookResult = ReturnType<
+	typeof useGetLogsTotalCountLazyQuery
+>
+export type GetLogsTotalCountQueryResult = Apollo.QueryResult<
+	Types.GetLogsTotalCountQuery,
+	Types.GetLogsTotalCountQueryVariables
+>

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -3911,6 +3911,16 @@ export type GetLogsQuery = { __typename?: 'Query' } & {
 	>
 }
 
+export type GetLogsTotalCountQueryVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+	params: Types.LogsParamsInput
+}>
+
+export type GetLogsTotalCountQuery = { __typename?: 'Query' } & Pick<
+	Types.Query,
+	'logs_total_count'
+>
+
 export const namedOperations = {
 	Query: {
 		GetMetricsTimeline: 'GetMetricsTimeline' as const,
@@ -4025,6 +4035,7 @@ export const namedOperations = {
 		GetErrorGroupTags: 'GetErrorGroupTags' as const,
 		GetEmailOptOuts: 'GetEmailOptOuts' as const,
 		GetLogs: 'GetLogs' as const,
+		GetLogsTotalCount: 'GetLogsTotalCount' as const,
 	},
 	Mutation: {
 		MarkSessionAsViewed: 'MarkSessionAsViewed' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -21,6 +21,7 @@ export type Scalars = {
 	Map: any
 	StringArray: string[]
 	Timestamp: string
+	UInt64: any
 	Upload: any
 }
 
@@ -1406,6 +1407,7 @@ export type Query = {
 	linear_teams?: Maybe<Array<LinearTeam>>
 	liveUsersCount?: Maybe<Scalars['Int64']>
 	logs: Array<LogLine>
+	logs_total_count: Scalars['UInt64']
 	messages?: Maybe<Array<Maybe<Scalars['Any']>>>
 	metric_monitors: Array<Maybe<MetricMonitor>>
 	metric_tag_values: Array<Scalars['String']>
@@ -1731,6 +1733,11 @@ export type QueryLiveUsersCountArgs = {
 }
 
 export type QueryLogsArgs = {
+	params: LogsParamsInput
+	project_id: Scalars['ID']
+}
+
+export type QueryLogs_Total_CountArgs = {
 	params: LogsParamsInput
 	project_id: Scalars['ID']
 }

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1856,3 +1856,7 @@ query GetLogs($project_id: ID!, $params: LogsParamsInput!) {
 		logAttributes
 	}
 }
+
+query GetLogsTotalCount($project_id: ID!, $params: LogsParamsInput!) {
+	logs_total_count(project_id: $project_id, params: $params)
+}

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -1,5 +1,5 @@
-import { useGetLogsQuery } from '@graph/hooks'
-import { Box } from '@highlight-run/ui'
+import { useGetLogsQuery, useGetLogsTotalCountQuery } from '@graph/hooks'
+import { Box, Stack, Text } from '@highlight-run/ui'
 import { LogsTable } from '@pages/LogsPage/LogsTable/LogsTable'
 import { SearchForm } from '@pages/LogsPage/SearchForm/SearchForm'
 import { useParams } from '@util/react-router/useParams'
@@ -40,7 +40,20 @@ const QueryParam = withDefault(StringParam, '')
 const LogsPageInner = ({ project_id, start_date, end_date }: Props) => {
 	const [query, setQuery] = useQueryParam('query', QueryParam)
 
-	const { data, loading } = useGetLogsQuery({
+	const { data: logs, loading } = useGetLogsQuery({
+		variables: {
+			project_id,
+			params: {
+				query,
+				date_range: {
+					start_date,
+					end_date,
+				},
+			},
+		},
+	})
+
+	const { data: totalCount } = useGetLogsTotalCountQuery({
 		variables: {
 			project_id,
 			params: {
@@ -64,13 +77,27 @@ const LogsPageInner = ({ project_id, start_date, end_date }: Props) => {
 			</Helmet>
 			<Box background="n2" padding="8" flex="stretch">
 				<Box background="white" borderRadius="12">
-					<SearchForm
-						initialQuery={query}
-						onFormSubmit={handleFormSubmit}
-						startDate={start_date}
-						endDate={end_date}
-					/>
-					<LogsTable data={data} loading={loading} query={query} />
+					<Stack gap="4">
+						<SearchForm
+							initialQuery={query}
+							onFormSubmit={handleFormSubmit}
+							startDate={start_date}
+							endDate={end_date}
+						/>
+						<Stack direction="row" gap="2">
+							{totalCount && (
+								<Text color="weak">
+									{totalCount.logs_total_count}
+								</Text>
+							)}
+							<Text color="weak">logs</Text>
+						</Stack>
+						<LogsTable
+							data={logs}
+							loading={loading}
+							query={query}
+						/>
+					</Stack>
 				</Box>
 			</Box>
 		</>

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -2,6 +2,7 @@ import { useGetLogsQuery, useGetLogsTotalCountQuery } from '@graph/hooks'
 import { Box, Stack, Text } from '@highlight-run/ui'
 import { LogsTable } from '@pages/LogsPage/LogsTable/LogsTable'
 import { SearchForm } from '@pages/LogsPage/SearchForm/SearchForm'
+import { formatNumber } from '@util/numbers'
 import { useParams } from '@util/react-router/useParams'
 import moment from 'moment'
 import React from 'react'
@@ -87,7 +88,7 @@ const LogsPageInner = ({ project_id, start_date, end_date }: Props) => {
 						<Stack direction="row" gap="2">
 							{totalCount && (
 								<Text color="weak">
-									{totalCount.logs_total_count}
+									{formatNumber(totalCount.logs_total_count)}
 								</Text>
 							)}
 							<Text color="weak">logs</Text>


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Currently, we throw an arbitrary limit on our logs query: https://github.com/highlight/highlight/blob/7a6090f5f5d54768aaddafb46fce52b678a5bf08/backend/clickhouse/logs.go#L54-L58

At some point, we'll be adjusting to add infinite scroll (#4211) but we'll still need to show the total count that a query matches. 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

I pulled the script from #4173 to generate a lot of data. 

Confirmed the total count is present using the same formatting as the sessions view:
![Screenshot 2023-02-14 at 9 18 43 AM](https://user-images.githubusercontent.com/58678/218795653-15e2859c-f7a5-4a9c-8bf2-4991ab3c667f.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A