### PR TITLE
Fix query param rendering via use-query-params

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -83,7 +83,7 @@
 		"stacktrace-js": "^2.0.2",
 		"subscriptions-transport-ws": "^0.11.0",
 		"use-http": "^1.0.26",
-		"use-query-params": "^1.2.0",
+		"use-query-params": "^2.2.0",
 		"validator": "13.7.0",
 		"xss": "^1.0.14"
 	},

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -159,24 +159,24 @@ const App = () => {
 			}}
 		>
 			<ApolloProvider client={client}>
-				<QueryParamProvider>
-					<SkeletonTheme
-						baseColor="var(--color-gray-200)"
-						highlightColor="var(--color-primary-background)"
+				<SkeletonTheme
+					baseColor="var(--color-gray-200)"
+					highlightColor="var(--color-primary-background)"
+				>
+					<AppLoadingContext
+						value={{
+							loadingState,
+							setLoadingState,
+						}}
 					>
-						<AppLoadingContext
-							value={{
-								loadingState,
-								setLoadingState,
-							}}
-						>
-							<LoadingPage />
-							<BrowserRouter>
+						<LoadingPage />
+						<BrowserRouter>
+							<QueryParamProvider>
 								<AuthenticationRoleRouter />
-							</BrowserRouter>
-						</AppLoadingContext>
-					</SkeletonTheme>
-				</QueryParamProvider>
+							</QueryParamProvider>
+						</BrowserRouter>
+					</AppLoadingContext>
+				</SkeletonTheme>
 			</ApolloProvider>
 		</ErrorBoundary>
 	)

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -41,12 +41,14 @@ import { client } from '@util/graph'
 import { isOnPrem } from '@util/onPrem/onPremUtils'
 import { showIntercom } from '@util/window'
 import { H, HighlightOptions } from 'highlight.run'
+import { parse, stringify } from 'query-string'
 import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom'
 import { Helmet } from 'react-helmet'
 import { SkeletonTheme } from 'react-loading-skeleton'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { QueryParamProvider } from 'use-query-params'
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6'
 
 analytics.initialize()
 const dev = import.meta.env.DEV
@@ -171,7 +173,13 @@ const App = () => {
 					>
 						<LoadingPage />
 						<BrowserRouter>
-							<QueryParamProvider>
+							<QueryParamProvider
+								adapter={ReactRouter6Adapter}
+								options={{
+									searchStringToObject: parse,
+									objectToSearchString: stringify,
+								}}
+							>
 								<AuthenticationRoleRouter />
 							</QueryParamProvider>
 						</BrowserRouter>

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -4,17 +4,11 @@ import { LogsTable } from '@pages/LogsPage/LogsTable/LogsTable'
 import { SearchForm } from '@pages/LogsPage/SearchForm/SearchForm'
 import { useParams } from '@util/react-router/useParams'
 import moment from 'moment'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { Helmet } from 'react-helmet'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { StringParam, useQueryParam, withDefault } from 'use-query-params'
 
 const FORMAT = 'YYYY-MM-DDTHH:mm:00.000000000Z'
-
-function useQuery() {
-	const { search } = useLocation()
-
-	return React.useMemo(() => new URLSearchParams(search), [search])
-}
 
 const defaultEndDate = moment().format(FORMAT)
 const defaultStartDate = moment(defaultEndDate)
@@ -25,12 +19,10 @@ const LogsPage = () => {
 	const { project_id } = useParams<{
 		project_id: string
 	}>()
-	const queryParams = useQuery()
 
 	return (
 		<LogsPageInner
 			project_id={project_id!}
-			queryParam={queryParams.get('query') ?? ''}
 			start_date={defaultStartDate}
 			end_date={defaultEndDate}
 		/>
@@ -39,29 +31,14 @@ const LogsPage = () => {
 
 type Props = {
 	project_id: string
-	queryParam: string
 	start_date: string
 	end_date: string
 }
 
-const LogsPageInner = ({
-	project_id,
-	queryParam,
-	start_date,
-	end_date,
-}: Props) => {
-	const [query, setQuery] = useState(queryParam)
-	const navigate = useNavigate()
+const QueryParam = withDefault(StringParam, '')
 
-	useEffect(() => {
-		const params = new URLSearchParams()
-		if (query) {
-			params.append('query', query)
-		} else {
-			params.delete('query')
-		}
-		navigate({ search: params.toString() }, { replace: true })
-	}, [query, navigate])
+const LogsPageInner = ({ project_id, start_date, end_date }: Props) => {
+	const [query, setQuery] = useQueryParam('query', QueryParam)
 
 	const { data, loading } = useGetLogsQuery({
 		variables: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8073,7 +8073,7 @@ __metadata:
     typed-scss-modules: ^3.4.0
     typescript: ^4.8.2
     use-http: ^1.0.26
-    use-query-params: ^1.2.0
+    use-query-params: ^2.2.0
     validator: 13.7.0
     vite: ^4.0.4
     vite-plugin-imp: ^2.3.1
@@ -37955,12 +37955,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-query-params@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "serialize-query-params@npm:1.3.1"
-  peerDependencies:
-    query-string: ^5.1.1 || ^6
-  checksum: efb1fbc00153cda1e9527b0f118310cc4f7f1080911f1850198ba206b91ad059ce1fd4f02fe1c13e45907a07347f46ebd5ad70649f160d4f3f39b2b073369d5d
+"serialize-query-params@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "serialize-query-params@npm:2.0.2"
+  checksum: 6dccdbd68cbec44c99599c4f77968e8685a74cc597f473ed93b15a8d03c3a67f50c958af9af3d186e64aabd7f98b59d674a05aa4e69d997ed86a5478cf133b27
   languageName: node
   linkType: hard
 
@@ -41682,15 +41680,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-query-params@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "use-query-params@npm:1.2.0"
+"use-query-params@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "use-query-params@npm:2.2.0"
   dependencies:
-    serialize-query-params: ^1.3.1
+    serialize-query-params: ^2.0.2
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: 6bf94910be38f2ed484369ae3de4b2516ec44b5464f9b7ae569d376445603bc90459e2caba5c6ee69ef9b850e6d1f5b085f4e648f04e0dd0bf88f9539d6942e3
+  checksum: b0b6a6b0e72f95d03a0a7256713837cf2b4f39df5b98a880dcfddfe28677e774f3085e0f8e15b6cc9d0a67bfa4d90e39ae9fb6634c3ccab8a09df0284110eddd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

See the revert of #4257. 

Basically, when we call `set*` with use-query-params, the updated value wasn't triggering a re-render. 

I discovered that the fix for this was two things:
* upgrading [use-query-params](https://github.com/pbeshai/use-query-params/tree/master/packages/use-query-params) to the next major version (see [migration plan](https://github.com/pbeshai/use-query-params/blob/master/packages/use-query-params/CHANGELOG.md#migrating-from-v1))
* correctly nesting `QueryParamProvider` under `BrowserRouter`

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

I undid the revert of #4257 and confirmed that updating the logs query correctly re-renders (triggers a new request to load logs). 

It seems like my bug occurs only when we are using a `set*` but most times we just pluck off the query value and then pipe it into something else. For example, the `sign_up` param on the login form is simply piped into some form state: https://github.com/highlight/highlight/blob/07d3e88369aa29ee538291216508362197e024b6/frontend/src/pages/Login/Login.tsx#L106-L112

I did find some examples of the `set*` in our pagination: 
https://github.com/highlight/highlight/blame/07d3e88369aa29ee538291216508362197e024b6/frontend/src/components/SearchPagination/SearchPagination.tsx#L100-L113

and in the query builder:
https://github.com/highlight/highlight/blob/07d3e88369aa29ee538291216508362197e024b6/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/components/QueryBuilder/QueryBuilder.tsx#L1371-L1380

Doing some click testing around there (back/forward buttons, deep linking, etc) looks to be working as expected.



## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A