### PR TITLE
fix(#4255): routing for project settings

### DIFF
--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelinePopover/TimelinePopover.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelinePopover/TimelinePopover.tsx
@@ -50,7 +50,6 @@ const TimelinePopover = ({ bucket }: Props) => {
 	} = useReplayerContext()
 	const {
 		setShowRightPanel,
-		setShowDevTools,
 		setSelectedDevToolsTab,
 		setSelectedRightPlayerPanelTab,
 	} = usePlayerConfiguration()

--- a/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
@@ -9,7 +9,7 @@ import SourcemapSettings from '@pages/WorkspaceSettings/SourcemapSettings/Source
 import { useParams } from '@util/react-router/useParams'
 import React from 'react'
 import { Helmet } from 'react-helmet'
-import { Route, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 
 import styles from './ProjectSettings.module.scss'
 
@@ -25,52 +25,45 @@ const ProjectSettings = () => {
 
 			<LeadAlignLayout>
 				<h2>Project Settings</h2>
-				<Route
-					path="/:tab?"
-					element={
-						<div className={styles.tabsContainer}>
-							<Tabs
-								activeKeyOverride={params.tab || 'recording'}
-								onChange={(key) => {
-									navigate(
-										`${params.project_id}/settings/${key}`,
-									)
-								}}
-								noHeaderPadding
-								noPadding
-								id="settingsTabs"
-								tabs={[
-									{
-										key: 'recording',
-										title: 'Recording',
-										panelContent: (
-											<>
-												<ExcludedUsersForm />
-												<RageClicksForm />
-												<NetworkRecordingForm />
-											</>
-										),
-									},
-									{
-										key: 'errors',
-										title: 'Errors',
-										panelContent: (
-											<>
-												<ErrorSettingsForm />
-												<SourcemapSettings />
-											</>
-										),
-									},
-									{
-										key: 'general',
-										title: 'General',
-										panelContent: <DangerForm />,
-									},
-								]}
-							/>
-						</div>
-					}
-				/>
+				<div className={styles.tabsContainer}>
+					<Tabs
+						activeKeyOverride={params.tab ?? 'recording'}
+						onChange={(key) => {
+							navigate(`/${params.project_id}/settings/${key}`)
+						}}
+						noHeaderPadding
+						noPadding
+						id="settingsTabs"
+						tabs={[
+							{
+								key: 'recording',
+								title: 'Recording',
+								panelContent: (
+									<>
+										<ExcludedUsersForm />
+										<RageClicksForm />
+										<NetworkRecordingForm />
+									</>
+								),
+							},
+							{
+								key: 'errors',
+								title: 'Errors',
+								panelContent: (
+									<>
+										<ErrorSettingsForm />
+										<SourcemapSettings />
+									</>
+								),
+							},
+							{
+								key: 'general',
+								title: 'General',
+								panelContent: <DangerForm />,
+							},
+						]}
+					/>
+				</div>
 			</LeadAlignLayout>
 		</>
 	)

--- a/frontend/src/routers/OrgRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/OrgRouter/ApplicationRouter.tsx
@@ -44,7 +44,10 @@ const ApplicationRouter = ({ integrated }: Props) => {
 					{isHighlightAdmin && (
 						<Route path="logs/*" element={<LogsPage />} />
 					)}
-					<Route path="settings/*" element={<ProjectSettings />} />
+					<Route
+						path="settings/:tab?"
+						element={<ProjectSettings />}
+					/>
 					<Route path="alerts/*" element={<AlertsRouter />} />
 
 					<Route


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->
Resolves #4255.


At the moment going to project settings crashes the app:
https://app.highlight.io/1/settings/errors

Check out the preview: https://frontend-pr-4260.onrender.com/1/settings/errors

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Go to project settings from the menu in the top left.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no