### PR TITLE
add sales observability for error monitoring

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -618,6 +618,12 @@ type Session struct {
 	AvoidPostgresStorage bool
 }
 
+type SessionAdminsViews struct {
+	SessionID int       `gorm:"primaryKey"`
+	AdminID   int       `gorm:"primaryKey"`
+	ViewedAt  time.Time `gorm:"default:NOW()"`
+}
+
 type EventChunk struct {
 	Model
 	SessionID  int `gorm:"index"`
@@ -942,6 +948,12 @@ type ErrorGroup struct {
 	// Represents the admins that have viewed this session.
 	ViewedByAdmins []Admin `json:"viewed_by_admins" gorm:"many2many:error_group_admins_views;"`
 	Viewed         *bool   `json:"viewed"`
+}
+
+type ErrorGroupAdminsView struct {
+	ErrorGroupID int       `gorm:"primaryKey"`
+	AdminID      int       `gorm:"primaryKey"`
+	ViewedAt     time.Time `gorm:"default:NOW()"`
 }
 
 type ErrorInstance struct {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -479,23 +479,24 @@ func (u *Workspace) BeforeCreate(tx *gorm.DB) (err error) {
 
 type Admin struct {
 	Model
-	Name                   *string
-	FirstName              *string
-	LastName               *string
-	HubspotContactID       *int
-	Email                  *string
-	AboutYouDetailsFilled  *bool
-	Phone                  *string
-	NumberOfSessionsViewed *int
-	EmailVerified          *bool            `gorm:"default:false"`
-	PhotoURL               *string          `json:"photo_url"`
-	UID                    *string          `gorm:"uniqueIndex"`
-	Organizations          []Organization   `gorm:"many2many:organization_admins;"`
-	Projects               []Project        `gorm:"many2many:project_admins;"`
-	SessionComments        []SessionComment `gorm:"many2many:session_comment_admins;"`
-	ErrorComments          []ErrorComment   `gorm:"many2many:error_comment_admins;"`
-	Workspaces             []Workspace      `gorm:"many2many:workspace_admins;"`
-	SlackIMChannelID       *string
+	Name                      *string
+	FirstName                 *string
+	LastName                  *string
+	HubspotContactID          *int
+	Email                     *string
+	AboutYouDetailsFilled     *bool
+	Phone                     *string
+	NumberOfSessionsViewed    *int
+	NumberOfErrorGroupsViewed *int
+	EmailVerified             *bool            `gorm:"default:false"`
+	PhotoURL                  *string          `json:"photo_url"`
+	UID                       *string          `gorm:"uniqueIndex"`
+	Organizations             []Organization   `gorm:"many2many:organization_admins;"`
+	Projects                  []Project        `gorm:"many2many:project_admins;"`
+	SessionComments           []SessionComment `gorm:"many2many:session_comment_admins;"`
+	ErrorComments             []ErrorComment   `gorm:"many2many:error_comment_admins;"`
+	Workspaces                []Workspace      `gorm:"many2many:workspace_admins;"`
+	SlackIMChannelID          *string
 	// How/where this user was referred from to sign up to Highlight.
 	Referral *string `json:"referral"`
 	// This is the role the Admin has specified. This is their role in their organization, not within Highlight. This should not be used for authorization checks.
@@ -937,6 +938,10 @@ type ErrorGroup struct {
 	} `gorm:"-"`
 	FirstOccurrence *time.Time `gorm:"-"`
 	LastOccurrence  *time.Time `gorm:"-"`
+
+	// Represents the admins that have viewed this session.
+	ViewedByAdmins []Admin `json:"viewed_by_admins" gorm:"many2many:error_group_admins_views;"`
+	Viewed         *bool   `json:"viewed"`
 }
 
 type ErrorInstance struct {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -618,7 +618,7 @@ type Session struct {
 	AvoidPostgresStorage bool
 }
 
-type SessionAdminsViews struct {
+type SessionAdminsView struct {
 	SessionID int       `gorm:"primaryKey"`
 	AdminID   int       `gorm:"primaryKey"`
 	ViewedAt  time.Time `gorm:"default:NOW()"`

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -442,6 +442,7 @@ type ErrorGroup {
 	is_public: Boolean!
 	first_occurrence: Timestamp
 	last_occurrence: Timestamp
+	viewed: Boolean
 }
 
 type ErrorMetadata {
@@ -1420,6 +1421,10 @@ type Mutation {
 		backend_domains: StringArray
 	): Project
 	editWorkspace(id: ID!, name: String): Workspace
+	markErrorGroupAsViewed(
+		error_secure_id: String!
+		viewed: Boolean
+	): ErrorGroup
 	markSessionAsViewed(secure_id: String!, viewed: Boolean): Session
 	markSessionAsStarred(secure_id: String!, starred: Boolean): Session
 	updateErrorGroupState(

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -578,6 +578,101 @@ func (r *mutationResolver) EditWorkspace(ctx context.Context, id int, name *stri
 	return workspace, nil
 }
 
+// MarkErrorGroupAsViewed is the resolver for the markErrorGroupAsViewed field.
+func (r *mutationResolver) MarkErrorGroupAsViewed(ctx context.Context, errorSecureID string, viewed *bool) (*model.ErrorGroup, error) {
+	eg, err := r.canAdminModifyErrorGroup(ctx, errorSecureID)
+	if err != nil {
+		return nil, e.Wrap(err, "admin not error group owner")
+	}
+	admin, err := r.getCurrentAdmin(ctx)
+	if err != nil {
+		return nil, e.Wrap(err, "admin not logged in")
+	}
+
+	// Update the the number of error groups viewed for the current admin.
+	r.PrivateWorkerPool.SubmitRecover(func() {
+		// Check if this admin has already viewed
+		if _, err := r.isAdminInProject(ctx, eg.ProjectID); err != nil {
+			log.Infof("not adding error groups count to admin in hubspot; this is probably a demo project, with id [%v]", eg.ProjectID)
+			return
+		}
+		var currentErrorGroupCount int64
+		if err := r.DB.Raw(`
+			select count(*)
+			from error_group_admins_views
+			where error_group_id = ? and admin_id = ?
+	`, eg.ID, admin.ID).Scan(&currentErrorGroupCount).Error; err != nil {
+			log.Error(e.Wrap(err, "error querying count of error group views from admin"))
+			return
+		} else if currentErrorGroupCount > 0 {
+			log.Info("not updating hubspot error group count; admin has already viewed this error group")
+			return
+		}
+
+		var totalErrorGroupCount int64
+		if err := r.DB.Raw(`
+			select count(*)
+			from error_group_admins_views
+			where admin_id = ?
+	`, admin.ID).Scan(&totalErrorGroupCount).Error; err != nil {
+			log.Error(e.Wrap(err, "error querying total count of error group views from admin"))
+			return
+		}
+		totalErrorGroupCountAsInt := int(totalErrorGroupCount) + 1
+
+		if err := r.DB.Where(admin).Updates(&model.Admin{NumberOfErrorGroupsViewed: &totalErrorGroupCountAsInt}).Error; err != nil {
+			log.Error(e.Wrap(err, "error updating error group count for admin in postgres"))
+		}
+		if !util.IsDevEnv() {
+			if err := r.HubspotApi.UpdateContactProperty(admin.ID, []hubspot.Property{{
+				Name:     "number_of_highlight_error_groups_viewed",
+				Property: "number_of_highlight_error_groups_viewed",
+				Value:    totalErrorGroupCountAsInt,
+			}}); err != nil {
+				zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+				zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
+
+				zlog.Error().
+					Stack().
+					Err(err).
+					Int("admin_id", admin.ID).
+					Int("value", totalErrorGroupCountAsInt).
+					Msg("error updating error group count for admin in hubspot")
+			}
+			log.Infof("succesfully added to total error group count for admin [%v], who just viewed error group [%v]", admin.ID, eg.ID)
+		}
+	})
+
+	newErrorGroup := &model.ErrorGroup{}
+	updatedFields := &model.ErrorGroup{
+		Viewed: viewed,
+	}
+	if err := r.DB.Where(&model.ErrorGroup{Model: model.Model{ID: eg.ID}}).First(&newErrorGroup).Updates(updatedFields).Error; err != nil {
+		return nil, e.Wrap(err, "error writing error as viewed")
+	}
+
+	if err := r.OpenSearch.Update(opensearch.IndexErrorsCombined, eg.ID, map[string]interface{}{"viewed": viewed}); err != nil {
+		return nil, e.Wrap(err, "error updating error in opensearch")
+	}
+
+	newAdminView := struct {
+		ID int `json:"id"`
+	}{
+		ID: admin.ID,
+	}
+
+	if err := r.OpenSearch.AppendToField(opensearch.IndexErrorsCombined, newErrorGroup.ID, "viewed_by_admins", []interface{}{
+		newAdminView}); err != nil {
+		return nil, e.Wrap(err, "error updating error gorups's admin viewed by in opensearch")
+	}
+
+	if err := r.DB.Model(&eg).Association("ViewedByAdmins").Append(admin); err != nil {
+		return nil, e.Wrap(err, "error adding admin to ViewedByAdmins")
+	}
+
+	return newErrorGroup, nil
+}
+
 // MarkSessionAsViewed is the resolver for the markSessionAsViewed field.
 func (r *mutationResolver) MarkSessionAsViewed(ctx context.Context, secureID string, viewed *bool) (*model.Session, error) {
 	s, err := r.canAdminModifySession(ctx, secureID)

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1239,16 +1239,17 @@ func (w *Worker) RefreshMaterializedViews() {
 	}
 
 	type AggregateSessionCount struct {
-		WorkspaceID int   `json:"workspace_id"`
-		Count       int64 `json:"count"`
+		WorkspaceID  int   `json:"workspace_id"`
+		SessionCount int64 `json:"session_count"`
+		ErrorCount   int64 `json:"error_count"`
 	}
-	counts := []AggregateSessionCount{}
+	var counts []AggregateSessionCount
 
 	if err := w.Resolver.DB.Raw(`
-		SELECT p.workspace_id, sum(d.count) as count
-		FROM daily_session_counts_view d
-		INNER JOIN projects p
-		ON d.project_id = p.id
+		SELECT p.workspace_id, sum(dsc.count) as session_count, sum(dec.count) as error_count
+		FROM projects p
+				 INNER JOIN daily_session_counts_view dsc on p.id = dsc.project_id
+				 INNER JOIN daily_error_counts dec on p.id = dec.project_id
 		GROUP BY p.workspace_id`).Scan(&counts).Error; err != nil {
 		log.Fatal(e.Wrap(err, "Error retrieving session counts for Hubspot update"))
 	}
@@ -1264,11 +1265,16 @@ func (w *Worker) RefreshMaterializedViews() {
 			if err := w.Resolver.HubspotApi.UpdateCompanyProperty(c.WorkspaceID, []hubspot.Property{{
 				Name:     "highlight_session_count",
 				Property: "highlight_session_count",
-				Value:    c.Count,
+				Value:    c.SessionCount,
+			}, {
+				Name:     "highlight_error_count",
+				Property: "highlight_session_count",
+				Value:    c.ErrorCount,
 			}}); err != nil {
 				log.WithFields(log.Fields{
-					"workspace_id": c.WorkspaceID,
-					"value":        c.Count,
+					"workspace_id":  c.WorkspaceID,
+					"session_count": c.SessionCount,
+					"error_count":   c.ErrorCount,
 				}).Fatal(e.Wrap(err, "error updating highlight session count in hubspot"))
 			}
 			time.Sleep(150 * time.Millisecond)

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -91,6 +91,63 @@ export const SessionAlertFragmentFragmentDoc = gql`
 	}
 	${DiscordChannelFragmentFragmentDoc}
 `
+export const MarkErrorGroupAsViewedDocument = gql`
+	mutation MarkErrorGroupAsViewed(
+		$error_secure_id: String!
+		$viewed: Boolean!
+	) {
+		markErrorGroupAsViewed(
+			error_secure_id: $error_secure_id
+			viewed: $viewed
+		) {
+			secure_id
+			viewed
+		}
+	}
+`
+export type MarkErrorGroupAsViewedMutationFn = Apollo.MutationFunction<
+	Types.MarkErrorGroupAsViewedMutation,
+	Types.MarkErrorGroupAsViewedMutationVariables
+>
+
+/**
+ * __useMarkErrorGroupAsViewedMutation__
+ *
+ * To run a mutation, you first call `useMarkErrorGroupAsViewedMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useMarkErrorGroupAsViewedMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [markErrorGroupAsViewedMutation, { data, loading, error }] = useMarkErrorGroupAsViewedMutation({
+ *   variables: {
+ *      error_secure_id: // value for 'error_secure_id'
+ *      viewed: // value for 'viewed'
+ *   },
+ * });
+ */
+export function useMarkErrorGroupAsViewedMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.MarkErrorGroupAsViewedMutation,
+		Types.MarkErrorGroupAsViewedMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.MarkErrorGroupAsViewedMutation,
+		Types.MarkErrorGroupAsViewedMutationVariables
+	>(MarkErrorGroupAsViewedDocument, baseOptions)
+}
+export type MarkErrorGroupAsViewedMutationHookResult = ReturnType<
+	typeof useMarkErrorGroupAsViewedMutation
+>
+export type MarkErrorGroupAsViewedMutationResult =
+	Apollo.MutationResult<Types.MarkErrorGroupAsViewedMutation>
+export type MarkErrorGroupAsViewedMutationOptions = Apollo.BaseMutationOptions<
+	Types.MarkErrorGroupAsViewedMutation,
+	Types.MarkErrorGroupAsViewedMutationVariables
+>
 export const MarkSessionAsViewedDocument = gql`
 	mutation MarkSessionAsViewed($secure_id: String!, $viewed: Boolean!) {
 		markSessionAsViewed(secure_id: $secure_id, viewed: $viewed) {

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -1,5 +1,19 @@
 import * as Types from './schemas'
 
+export type MarkErrorGroupAsViewedMutationVariables = Types.Exact<{
+	error_secure_id: Types.Scalars['String']
+	viewed: Types.Scalars['Boolean']
+}>
+
+export type MarkErrorGroupAsViewedMutation = { __typename?: 'Mutation' } & {
+	markErrorGroupAsViewed?: Types.Maybe<
+		{ __typename?: 'ErrorGroup' } & Pick<
+			Types.ErrorGroup,
+			'secure_id' | 'viewed'
+		>
+	>
+}
+
 export type MarkSessionAsViewedMutationVariables = Types.Exact<{
 	secure_id: Types.Scalars['String']
 	viewed: Types.Scalars['Boolean']
@@ -4027,6 +4041,7 @@ export const namedOperations = {
 		GetLogs: 'GetLogs' as const,
 	},
 	Mutation: {
+		MarkErrorGroupAsViewed: 'MarkErrorGroupAsViewed' as const,
 		MarkSessionAsViewed: 'MarkSessionAsViewed' as const,
 		MarkSessionAsStarred: 'MarkSessionAsStarred' as const,
 		MuteSessionCommentThread: 'MuteSessionCommentThread' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -401,6 +401,7 @@ export type ErrorGroup = {
 	structured_stack_trace: Array<Maybe<ErrorTrace>>
 	type: Scalars['String']
 	updated_at: Scalars['Timestamp']
+	viewed?: Maybe<Scalars['Boolean']>
 }
 
 export type ErrorGroupFrequenciesParamsInput = {
@@ -773,6 +774,7 @@ export type Mutation = {
 	editWorkspace?: Maybe<Workspace>
 	emailSignup: Scalars['String']
 	joinWorkspace?: Maybe<Scalars['ID']>
+	markErrorGroupAsViewed?: Maybe<ErrorGroup>
 	markSessionAsStarred?: Maybe<Session>
 	markSessionAsViewed?: Maybe<Session>
 	modifyClearbitIntegration?: Maybe<Scalars['Boolean']>
@@ -1052,6 +1054,11 @@ export type MutationEmailSignupArgs = {
 
 export type MutationJoinWorkspaceArgs = {
 	workspace_id: Scalars['ID']
+}
+
+export type MutationMarkErrorGroupAsViewedArgs = {
+	error_secure_id: Scalars['String']
+	viewed?: InputMaybe<Scalars['Boolean']>
 }
 
 export type MutationMarkSessionAsStarredArgs = {

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -1,3 +1,10 @@
+mutation MarkErrorGroupAsViewed($error_secure_id: String!, $viewed: Boolean!) {
+	markErrorGroupAsViewed(error_secure_id: $error_secure_id, viewed: $viewed) {
+		secure_id
+		viewed
+	}
+}
+
 mutation MarkSessionAsViewed($secure_id: String!, $viewed: Boolean!) {
 	markSessionAsViewed(secure_id: $secure_id, viewed: $viewed) {
 		secure_id

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -4,6 +4,8 @@ import LoadingBox from '@components/LoadingBox'
 import { PreviousNextGroup } from '@components/PreviousNextGroup/PreviousNextGroup'
 import {
 	useGetErrorGroupQuery,
+	useMarkErrorGroupAsViewedMutation,
+	useMarkSessionAsViewedMutation,
 	useMuteErrorCommentThreadMutation,
 } from '@graph/hooks'
 import {
@@ -47,6 +49,7 @@ const ErrorsV2: React.FC<React.PropsWithChildren<{ integrated: boolean }>> = ({
 	const { isLoggedIn } = useAuthContext()
 	const { searchResultSecureIds } = useErrorSearchContext()
 	const { showLeftPanel, setShowLeftPanel } = useErrorPageConfiguration()
+	const [markErrorGroupAsViewed] = useMarkErrorGroupAsViewedMutation()
 
 	const currentSearchResultIndex = searchResultSecureIds.findIndex(
 		(secureId) => secureId === error_secure_id,
@@ -67,6 +70,14 @@ const ErrorsV2: React.FC<React.PropsWithChildren<{ integrated: boolean }>> = ({
 		variables: { secure_id: error_secure_id! },
 		skip: !error_secure_id,
 		onCompleted: () => {
+			if (error_secure_id) {
+				markErrorGroupAsViewed({
+					variables: {
+						error_secure_id,
+						viewed: true,
+					},
+				}).catch(console.error)
+			}
 			analytics.track('Viewed error', { is_guest: !isLoggedIn })
 		},
 	})


### PR DESCRIPTION
## Summary

Track error group views and add hubspot instrumentation for reporting error group view counts.

## How did you test this change?

Local deploy tracing whether a session view is reported.

## Are there any deployment considerations?

No.
