### PR TITLE
fix(#4229): clean up tabs

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/style.css.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/style.css.ts
@@ -1,7 +1,5 @@
 import { colors } from '@highlight-run/ui/src/css/colors'
-import { themeVars } from '@highlight-run/ui/src/css/theme.css'
 import { style } from '@vanilla-extract/css'
-import { recipe } from '@vanilla-extract/recipes'
 
 export const devToolsWindowV2 = style({
 	alignItems: 'center',
@@ -12,85 +10,10 @@ export const devToolsWindowV2 = style({
 	position: 'relative',
 })
 
-export const controlBarButton = style({
-	backgroundColor: 'white',
-	boxShadow: 'none',
-	color: colors.n11,
-})
-
 export const switchInverted = style({
 	transform: 'rotate(90deg)',
 })
 
 export const autoScroll = style({
 	height: 20,
-})
-
-export const pageWrapper = style({
-	backgroundColor: colors.n1,
-	borderTop: `1px solid ${colors.n6}`,
-	width: '100%',
-	height: '100%',
-	paddingBottom: 8,
-})
-
-export const controlBarVariants = recipe({
-	base: {
-		background: 'none',
-		borderRadius: 0,
-		borderBottom: `none`,
-		boxShadow: 'none',
-		selectors: {
-			'&:focus:enabled, &:active:enabled, &:hover:enabled': {
-				background: 'none',
-				boxShadow: 'none',
-				borderRadius: 0,
-				color: colors.n11,
-			},
-		},
-	},
-	variants: {
-		selected: {
-			true: {
-				color: colors.p9,
-			},
-			false: {
-				color: colors.n11,
-			},
-		},
-	},
-
-	defaultVariants: {
-		selected: false,
-	},
-})
-
-export const controlBarBottomVariants = recipe({
-	base: {
-		backgroundColor: colors.n11,
-		borderRadius: '2px 2px 0px 0px',
-		height: 2,
-		transition: 'background-color 1s ease',
-	},
-	variants: {
-		selected: {
-			true: {
-				backgroundColor: colors.p9,
-			},
-		},
-		hovered: {
-			true: {
-				backgroundColor:
-					themeVars.interactive.outline.secondary.enabled,
-			},
-		},
-	},
-	compoundVariants: [
-		{
-			variants: { hovered: true, selected: true },
-			style: {
-				backgroundColor: colors.p9,
-			},
-		},
-	],
 })

--- a/packages/ui/src/components/Tabs/styles.css.ts
+++ b/packages/ui/src/components/Tabs/styles.css.ts
@@ -13,7 +13,6 @@ export const pageWrapper = style({
 })
 
 export const controlBarButton = style({
-	backgroundColor: 'white',
 	boxShadow: 'none',
 })
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->
Removes the background color from tabs and cleans up unused styles.

Closes #4229.
## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
go to the right panel and dev tools in the session view and make sure tabs look ok
![Screenshot 2023-02-14 at 11 13 07 AM](https://user-images.githubusercontent.com/17913919/218834646-92de7edc-7f3b-48df-b267-d854b3d1098c.jpg)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no
