### PR TITLE
Fix view all sessions for users link on error page

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -32,7 +32,6 @@ import {
 } from '@pages/Player/context/PlayerUIContext'
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import { Tab } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
-import { EmptySessionsSearchParams } from '@pages/Sessions/EmptySessionsSearchParams'
 import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext'
 import {
 	getDisplayNameAndField,
@@ -43,6 +42,7 @@ import analytics from '@util/analytics'
 import { loadSession } from '@util/preload'
 import { useParams } from '@util/react-router/useParams'
 import { copyToClipboard } from '@util/string'
+import { buildQueryURLString } from '@util/url/params'
 import moment from 'moment'
 import React, { useEffect, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -526,27 +526,19 @@ const User: React.FC<{
 									return
 								}
 
-								// Logic taken from Metadata box. There may be a cleaner way.
-								const searchParams = {
-									...EmptySessionsSearchParams,
-								}
-
+								const searchParams: any = {}
 								if (session.identifier && field !== null) {
-									searchParams.user_properties = [
-										{
-											id: '0',
-											name: field,
-											value: displayName,
-										},
-									]
+									searchParams[`user_${field}`] = displayName
 								} else if (session?.fingerprint) {
 									searchParams.device_id = String(
 										session.fingerprint,
 									)
 								}
 
-								navigate(`/${projectId}/sessions`)
-								setSearchParams(searchParams)
+								navigate({
+									pathname: `/${projectId}/sessions`,
+									search: buildQueryURLString(searchParams),
+								})
 							}}
 							trackingId="errorInstanceAllSessionsForuser"
 						>


### PR DESCRIPTION
## Summary

Fixes the "View all sessions for user" link on the errors page.

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A