### PR TITLE
add enhanced health check for non-public-graph runtimes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,10 +46,14 @@ jobs:
                   docker compose up -d --build --remove-orphans;
                   echo 'Docker compose started; waiting for services to come online'
 
-                  npx -y wait-on https://localhost:3000/index.html http://localhost:8080/dist/index.js https://localhost:8082/health;
+                  npx -y wait-on -l -s 3 https://localhost:3000/index.html http://localhost:8080/dist/index.js https://localhost:8082/health;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql';
 
                   yarn cy:run;
+
+            - name: Dump docker logs on failure
+              if: failure()
+              run: docker compose logs
 
             - name: Save videos
               uses: actions/upload-artifact@v2

--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -451,7 +451,7 @@ func (c *Client) AppendToField(index Index, sessionID int, fieldName string, fie
 
 }
 
-func (c *Client) IndexSynchronous(index Index, id int, obj interface{}) error {
+func (c *Client) IndexSynchronous(ctx context.Context, index Index, id int, obj interface{}) error {
 	if c == nil || !c.isInitialized {
 		return nil
 	}
@@ -472,7 +472,7 @@ func (c *Client) IndexSynchronous(index Index, id int, obj interface{}) error {
 		Body:       body,
 	}
 
-	response, err := req.Do(context.Background(), c.Client)
+	response, err := req.Do(ctx, c.Client)
 	if err != nil {
 		return e.Wrap(err, "OPENSEARCH_ERROR error indexing document")
 	}

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -172,8 +172,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 							}
 							projectErrors[projectID] = append(projectErrors[projectID], err)
 						} else {
-							data, _ := req.MarshalJSON()
-							log.WithField("BackendErrorObjectInput", *err).WithField("RequestJSON", string(data)).Errorf("otel error got no session and no project")
+							log.WithField("BackendErrorObjectInput", *err).Errorf("otel error got no session and no project")
 							continue
 						}
 					} else if event.Name() == hlog.LogName {
@@ -361,8 +360,7 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 					}
 					projectLogs[projectID] = append(projectLogs[projectID], logRow)
 				} else {
-					data, _ := req.MarshalJSON()
-					log.WithField("LogRecord", logRecords).WithField("LogRow", *logRow).WithField("RequestJSON", string(data)).Errorf("otel log got no project")
+					log.WithField("LogRecord", logRecords).WithField("LogRow", *logRow).Errorf("otel log got no project")
 					continue
 				}
 			}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1127,7 +1127,7 @@ func (r *Resolver) getExistingSession(projectID int, secureID string) (*model.Se
 func (r *Resolver) IndexSessionOpensearch(ctx context.Context, session *model.Session) error {
 	osSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.InitializeSessionImpl", tracer.ResourceName("go.sessions.OSIndex"))
 	defer osSpan.Finish()
-	if err := r.OpenSearch.IndexSynchronous(opensearch.IndexSessions, session.ID, session); err != nil {
+	if err := r.OpenSearch.IndexSynchronous(ctx, opensearch.IndexSessions, session.ID, session); err != nil {
 		return e.Wrap(err, "error indexing new session in opensearch")
 	}
 


### PR DESCRIPTION
## Summary

Adds an enhanced health check for postgres, influx, redis, opensearch, and clickhouse.
Enhanced health check does not run for public graph since public graph only depends on kafka, and
we want to make sure public graph remains up even if other infra is down (ECS LB would not route traffic
to nodes that are not passing the health check).
Public graph health check validates kafka communication.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

Will monitor rollout. If health checks fail during rollout, ECS will not switch traffic over to the new containers.