### PR TITLE
some datepicker additions

### DIFF
--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -17,6 +17,7 @@ import {
 const FORMAT = 'YYYY-MM-DDTHH:mm:00.000000000Z'
 const now = moment()
 const fifteenMinutesAgo = now.clone().subtract(15, 'minutes').toDate()
+const thirtyDaysAgo = now.clone().subtract(30, 'days').toDate()
 const PRESETS: Preset[] = [
 	{
 		startDate: fifteenMinutesAgo,
@@ -39,7 +40,7 @@ const PRESETS: Preset[] = [
 		label: 'Last 7 days',
 	},
 	{
-		startDate: now.clone().subtract(30, 'days').toDate(),
+		startDate: thirtyDaysAgo,
 		label: 'Last 30 days',
 	},
 ]
@@ -112,6 +113,7 @@ const LogsPage = () => {
 							endDate={endDate}
 							onDatesChange={handleDatesChange}
 							presets={PRESETS}
+							minDate={thirtyDaysAgo}
 						/>
 						<Stack direction="row" gap="2">
 							{totalCount && (

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -8,6 +8,7 @@ type Props = {
 	endDate: Date
 	onDatesChange: (startDate: Date, endDate: Date) => void
 	presets: Preset[]
+	minDate: Date
 }
 
 const SearchForm = ({
@@ -17,6 +18,7 @@ const SearchForm = ({
 	onDatesChange,
 	onFormSubmit,
 	presets,
+	minDate,
 }: Props) => {
 	const [query, setQuery] = useState(initialQuery)
 	const [selectedDates, setSelectedDates] = useState([startDate, endDate])
@@ -53,6 +55,7 @@ const SearchForm = ({
 						selectedDates={selectedDates}
 						onDatesChange={handleDatesChange}
 						presets={presets}
+						minDate={minDate}
 					/>
 				</Box>
 			</Box>

--- a/packages/ui/src/components/DatePicker/PreviousDateRangePicker.stories.tsx
+++ b/packages/ui/src/components/DatePicker/PreviousDateRangePicker.stories.tsx
@@ -60,6 +60,7 @@ export const Basic = () => {
 				selectedDates={selectedDates}
 				onDatesChange={onDatesChange}
 				presets={presets}
+				minDate={subtractDays(now, 90)}
 			/>
 		</div>
 	)

--- a/packages/ui/src/components/DatePicker/PreviousDateRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/PreviousDateRangePicker.tsx
@@ -3,7 +3,9 @@ import React from 'react'
 import { DatePicker } from './Calendar/DatePicker'
 import { DatePickerStateProvider } from '@rehookify/datepicker'
 import { Menu, useMenu } from '../Menu/Menu'
-import { IconSolidCheveronDown } from '../icons'
+import { Text } from '../Text/Text'
+import { IconSolidCheck, IconSolidCheveronDown } from '../icons'
+import { Stack } from '../Stack/Stack'
 
 export type Preset = {
 	label: string
@@ -15,6 +17,30 @@ enum MenuState {
 	Custom,
 }
 
+const isPresetSelected = ({
+	preset,
+	selectedDates,
+}: {
+	preset: Preset
+	selectedDates: Date[]
+}) => {
+	return preset.startDate.getTime() === selectedDates[0].getTime()
+}
+
+const isCustomSelected = ({
+	presets,
+	selectedDates,
+}: {
+	presets: Preset[]
+	selectedDates: Date[]
+}) => {
+	const foundPreset = presets.find((preset) => {
+		return isPresetSelected({ preset, selectedDates })
+	})
+
+	return !foundPreset
+}
+
 export const getLabel = ({
 	selectedDates,
 	presets,
@@ -23,7 +49,7 @@ export const getLabel = ({
 	presets: Preset[]
 }) => {
 	const foundPreset = presets.find((preset) => {
-		return preset.startDate.getTime() === selectedDates[0].getTime()
+		return isPresetSelected({ preset, selectedDates })
 	})
 
 	if (foundPreset) {
@@ -43,6 +69,7 @@ type Props = {
 	selectedDates: Date[]
 	onDatesChange: (selectedDates: Date[]) => void
 	presets: Preset[]
+	minDate: Date
 }
 
 export const PreviousDateRangePicker: React.FC<Props> = (props) => (
@@ -52,10 +79,19 @@ export const PreviousDateRangePicker: React.FC<Props> = (props) => (
 	</Menu>
 )
 
+const CheckboxIconIfSelected = ({ isSelected }: { isSelected: boolean }) => {
+	return (
+		<div style={{ height: 16, width: 16 }}>
+			{isSelected && <IconSolidCheck size={16} />}
+		</div>
+	)
+}
+
 const PreviousDateRangePickerImpl = ({
 	selectedDates,
 	onDatesChange,
 	presets,
+	minDate,
 }: Props) => {
 	const [menuState, setMenuState] = React.useState<MenuState>(
 		MenuState.Default,
@@ -81,7 +117,7 @@ const PreviousDateRangePickerImpl = ({
 			config={{
 				selectedDates,
 				onDatesChange: handleDatesChange,
-				dates: { mode: 'range', maxDate: new Date() },
+				dates: { mode: 'range', minDate, maxDate: new Date() },
 			}}
 		>
 			<Menu.Button kind="secondary" iconRight={<IconSolidCheveronDown />}>
@@ -101,7 +137,19 @@ const PreviousDateRangePickerImpl = ({
 										])
 									}
 								>
-									{preset.label}
+									<Stack
+										direction="row"
+										align="center"
+										gap={'4'}
+									>
+										<CheckboxIconIfSelected
+											isSelected={isPresetSelected({
+												preset,
+												selectedDates,
+											})}
+										/>
+										<Text>{preset.label}</Text>
+									</Stack>
 								</Menu.Item>
 							)
 						})}
@@ -111,7 +159,15 @@ const PreviousDateRangePickerImpl = ({
 								setMenuState(MenuState.Custom)
 							}}
 						>
-							Custom
+							<Stack direction="row" align="center" gap={'4'}>
+								<CheckboxIconIfSelected
+									isSelected={isCustomSelected({
+										presets,
+										selectedDates,
+									})}
+								/>
+								<Text>Custom</Text>
+							</Stack>
 						</Menu.Item>
 					</>
 				) : (


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

* Add a checkbox if range (or custom) is selected
* Add support for a min date

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

### Visual test

**Preset selected**
![Screenshot 2023-02-15 at 10 27 30 AM](https://user-images.githubusercontent.com/58678/219106615-1e5f381f-37ef-45c8-b4b1-35f72fb04134.png)


**Custom selected**
![Screenshot 2023-02-15 at 10 27 25 AM](https://user-images.githubusercontent.com/58678/219106598-2094a807-e98b-4bd8-883d-b3378d54805f.png)

**Min date**
Observe that dates prior to `minDate` are greyed out and not selectable (the storybook example uses 90 days ago)
![Screenshot 2023-02-15 at 10 28 20 AM](https://user-images.githubusercontent.com/58678/219106719-4b0b01b2-7a3b-42b9-9513-948857bd8d60.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A