### PR TITLE
add empty state for when no logs are found

### DIFF
--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -104,31 +104,32 @@ const LogsPage = () => {
 				<title>Logs</title>
 			</Helmet>
 			<Box background="n2" padding="8" flex="stretch">
-				<Box background="white" borderRadius="12">
-					<Stack gap="4">
-						<SearchForm
-							initialQuery={query}
-							onFormSubmit={handleFormSubmit}
-							startDate={startDate}
-							endDate={endDate}
-							onDatesChange={handleDatesChange}
-							presets={PRESETS}
-							minDate={thirtyDaysAgo}
-						/>
-						<Stack direction="row" gap="2">
-							{totalCount && (
-								<Text color="weak">
-									{formatNumber(totalCount.logs_total_count)}
-								</Text>
-							)}
-							<Text color="weak">logs</Text>
-						</Stack>
-						<LogsTable
-							data={logs}
-							loading={loading}
-							query={query}
-						/>
+				<Box
+					background="white"
+					borderRadius="12"
+					height="full"
+					gap="4"
+					flexDirection="column"
+					display="flex"
+				>
+					<SearchForm
+						initialQuery={query}
+						onFormSubmit={handleFormSubmit}
+						startDate={startDate}
+						endDate={endDate}
+						onDatesChange={handleDatesChange}
+						presets={PRESETS}
+						minDate={thirtyDaysAgo}
+					/>
+					<Stack direction="row" gap="2">
+						{totalCount && (
+							<Text color="weak">
+								{formatNumber(totalCount.logs_total_count)}
+							</Text>
+						)}
+						<Text color="weak">logs</Text>
 					</Stack>
+					<LogsTable data={logs} loading={loading} query={query} />
 				</Box>
 			</Box>
 		</>

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -7,6 +7,7 @@ import SvgChevronRightIcon from '@icons/ChevronRightIcon'
 import { LogBody } from '@pages/LogsPage/LogsTable/LogBody'
 import { LogSeverityText } from '@pages/LogsPage/LogsTable/LogSeverityText'
 import { LogTimestamp } from '@pages/LogsPage/LogsTable/LogTimestamp'
+import { NoLogsFound } from '@pages/LogsPage/LogsTable/NoLogsFound'
 import {
 	ColumnDef,
 	ExpandedState,
@@ -95,7 +96,29 @@ const LogsTable = ({ data, loading, query }: Props) => {
 	})
 
 	if (loading) {
-		return <LoadingBox />
+		return (
+			<Box
+				display="flex"
+				flexGrow={1}
+				alignItems="center"
+				justifyContent="center"
+			>
+				<LoadingBox />
+			</Box>
+		)
+	}
+
+	if (logs.length === 0) {
+		return (
+			<Box
+				display="flex"
+				flexGrow={1}
+				alignItems="center"
+				justifyContent="center"
+			>
+				<NoLogsFound />
+			</Box>
+		)
 	}
 
 	return (

--- a/frontend/src/pages/LogsPage/LogsTable/NoLogsFound.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/NoLogsFound.tsx
@@ -1,0 +1,25 @@
+import { Box, Callout, Text } from '@highlight-run/ui'
+import React from 'react'
+
+const NoLogsFound = () => {
+	return (
+		<Box style={{ maxWidth: '300px' }}>
+			<Callout title="No matching logs found">
+				<Box
+					display="flex"
+					flexDirection="column"
+					gap="16"
+					alignItems="flex-start"
+					mb="6"
+				>
+					<Text color="moderate">
+						Try using a more generic search query or removing
+						filters.
+					</Text>
+				</Box>
+			</Callout>
+		</Box>
+	)
+}
+
+export { NoLogsFound }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR creates an empty state when there are no logs found. Specifically when the query does not match anything. Note that this does not handle an onboarding situation whereby we have never received any logs (that'll be covered in #4213).

Fixes #4212

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

### Visual test

Observe empty state is horizontally and vertically centered:
![Screenshot 2023-02-15 at 12 37 42 PM](https://user-images.githubusercontent.com/58678/219134742-3a7872d5-7eaa-4f46-8602-eafe978d52ee.png)


I've also centered the loading spinner:
![Screenshot 2023-02-15 at 12 38 00 PM](https://user-images.githubusercontent.com/58678/219134800-ac27ed5c-9518-4c04-a354-94dd4047611f.png)





## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
