### PR TITLE
remove extra padding on calendar select

### DIFF
--- a/packages/ui/src/components/DatePicker/PreviousDateRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/PreviousDateRangePicker.tsx
@@ -171,7 +171,10 @@ const PreviousDateRangePickerImpl = ({
 						</Menu.Item>
 					</>
 				) : (
-					<Menu.Item onClick={(e) => e.preventDefault()}>
+					<Menu.Item
+						style={{ padding: 0 }}
+						onClick={(e) => e.preventDefault()}
+					>
 						<DatePicker />
 					</Menu.Item>
 				)}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

There's some extra padding when opening the calendar view of the datepicker. This is due to the padding of nesting inside a menu item:

https://github.com/highlight/highlight/blob/f2e0522c30be9fb644c06cb04fa5e43c8eec86e9/packages/ui/src/components/Menu/styles.css.ts#L20-L24

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Before:
![Screenshot 2023-02-15 at 12 47 29 PM](https://user-images.githubusercontent.com/58678/219137052-b6857b6f-9a5e-4af1-8c35-8a28c143720e.png)


After:
![Screenshot 2023-02-15 at 12 47 59 PM](https://user-images.githubusercontent.com/58678/219137047-0940926e-71db-498b-8be2-d4069aca4d13.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A