### PR TITLE
add cloudflare response recording support

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -40,18 +40,18 @@ func castString(v interface{}, fallback string) string {
 
 func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestID *string) {
 	if p, ok := attrs[highlight.ProjectIDAttribute]; ok {
-		if p.(string) != "" {
-			*projectID = p.(string)
+		if v, _ := p.(string); v != "" {
+			*projectID = v
 		}
 	}
 	if s, ok := attrs[highlight.SessionIDAttribute]; ok {
-		if s.(string) != "" {
-			*sessionID = s.(string)
+		if v, _ := s.(string); v != "" {
+			*sessionID = v
 		}
 	}
 	if r, ok := attrs[highlight.RequestIDAttribute]; ok {
-		if r.(string) != "" {
-			*requestID = r.(string)
+		if v, _ := r.(string); v != "" {
+			*requestID = v
 		}
 	}
 }

--- a/examples/cloudflare-worker/package.json
+++ b/examples/cloudflare-worker/package.json
@@ -9,7 +9,7 @@
 	},
 	"private": true,
 	"scripts": {
-		"start": "wrangler dev",
+		"start": "wrangler dev -l",
 		"deploy": "wrangler publish",
 		"test": "vitest --run"
 	},

--- a/examples/cloudflare-worker/src/index.ts
+++ b/examples/cloudflare-worker/src/index.ts
@@ -43,10 +43,13 @@ async function doRequest() {
 
 export default {
 	async fetch(request: Request, env: {}, ctx: ExecutionContext) {
+		const hEnv = { HIGHLIGHT_PROJECT_ID: '1' }
 		try {
-			return await doRequest()
+			const response = await doRequest()
+			H.sendResponse(request, hEnv, ctx, response)
+			return response
 		} catch (e: any) {
-			H.consumeError(request, { HIGHLIGHT_PROJECT_ID: '1' }, ctx, e)
+			H.consumeError(request, hEnv, ctx, e)
 			throw e
 		}
 	},

--- a/sdk/highlight-cloudflare/package.json
+++ b/sdk/highlight-cloudflare/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@highlight-run/cloudflare",
+	"version": "1.0.1",
 	"packageManager": "yarn@3.2.3",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-cloudflare/src/sdk.ts
+++ b/sdk/highlight-cloudflare/src/sdk.ts
@@ -8,7 +8,7 @@ import { OTLPProtoLogExporter } from 'opentelemetry-sdk-workers/exporters/OTLPPr
 
 const HIGHLIGHT_PROJECT_ENV = 'HIGHLIGHT_PROJECT_ID'
 const HIGHLIGHT_REQUEST_HEADER = 'X-Highlight-Request'
-const HIGHLIGHT_OTLP_BASE = 'http://localhost:4318'
+const HIGHLIGHT_OTLP_BASE = 'https://otel.highlight.io'
 
 export interface HighlightEnv {
 	[HIGHLIGHT_PROJECT_ENV]: string

--- a/sdk/highlight-cloudflare/src/sdk.ts
+++ b/sdk/highlight-cloudflare/src/sdk.ts
@@ -8,35 +8,45 @@ import { OTLPProtoLogExporter } from 'opentelemetry-sdk-workers/exporters/OTLPPr
 
 const HIGHLIGHT_PROJECT_ENV = 'HIGHLIGHT_PROJECT_ID'
 const HIGHLIGHT_REQUEST_HEADER = 'X-Highlight-Request'
-const HIGHLIGHT_OTLP_BASE = 'https://otel.highlight.io'
+const HIGHLIGHT_OTLP_BASE = 'http://localhost:4318'
 
 export interface HighlightEnv {
 	[HIGHLIGHT_PROJECT_ENV]: string
 }
 
 export interface HighlightInterface {
+	_createSDK: (
+		request: Request,
+		env: HighlightEnv,
+		ctx: ExecutionContext,
+	) => WorkersSDK
 	consumeError: (
 		request: Request,
 		env: HighlightEnv,
 		ctx: ExecutionContext,
 		error: Error,
 	) => void
+	sendResponse: (
+		request: Request,
+		env: HighlightEnv,
+		ctx: ExecutionContext,
+		response: Response,
+	) => void
 }
 
 export const H: HighlightInterface = {
-	consumeError: (
+	_createSDK: (
 		request: Request,
 		{ [HIGHLIGHT_PROJECT_ENV]: projectID }: HighlightEnv,
 		ctx: ExecutionContext,
-		error: Error,
 		service?: string,
 	) => {
 		const [sessionID, requestID] = (
 			request.headers.get(HIGHLIGHT_REQUEST_HEADER) || ''
 		).split('/')
 		const endpoints = { default: HIGHLIGHT_OTLP_BASE }
-		const sdk = new WorkersSDK(request, ctx, {
-			service: service || 'worker',
+		return new WorkersSDK(request, ctx, {
+			service: service || 'cloudflare-worker',
 			consoleLogEnabled: true,
 			traceExporter: new OTLPProtoTraceExporter({
 				url: `${endpoints.default}/v1/traces`,
@@ -50,6 +60,25 @@ export const H: HighlightInterface = {
 				highlight_trace_id: requestID,
 			}),
 		})
+	},
+
+	consumeError: (
+		request: Request,
+		env: HighlightEnv,
+		ctx: ExecutionContext,
+		error: Error,
+	) => {
+		const sdk = H._createSDK(request, env, ctx)
 		sdk.captureException(error)
+	},
+
+	sendResponse: (
+		request: Request,
+		env: HighlightEnv,
+		ctx: ExecutionContext,
+		response: Response,
+	) => {
+		const sdk = H._createSDK(request, env, ctx)
+		sdk.sendResponse(response)
 	},
 }


### PR DESCRIPTION
## Summary

Improves the cloudflare SDK with response recording support.
Fixes the `@highlight-run/cloudflare` package to actually publish a version to npmjs.

## How did you test this change?

Local cloudflare testing using example.

## Are there any deployment considerations?

No.