### PR TITLE
include double quotes in error event

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -802,7 +802,7 @@ func (r *Resolver) HandleErrorAndGroup(errorObj *model.ErrorObject, stackTraceSt
 	}
 	if projectID == 1703 {
 		if errorObj.Event == `["\"Uncaught TypeError: Cannot read properties of null (reading 'play')\""]` ||
-			errorObj.Event == `Uncaught TypeError: Cannot read properties of null (reading 'play')` {
+			errorObj.Event == `"Uncaught TypeError: Cannot read properties of null (reading 'play')"` {
 			return nil, e.New("Filtering out noisy error")
 		}
 	}


### PR DESCRIPTION
## Summary
- followup to https://github.com/highlight/highlight/pull/4282
- this event was not being filtered - error message includes double quotes
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- built locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
