### PR TITLE
fix(#4234): session feed settings

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/components/QueryBuilder/QueryBuilder.tsx
@@ -950,6 +950,7 @@ export const TimeRangeFilter = ({
 						weight="medium"
 						color="n9"
 						userSelect="none"
+						lines="1"
 					>
 						{value &&
 							value.options.length === 1 &&

--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/TimelineIndicatorsBarGraph.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/TimelineIndicatorsBarGraph.tsx
@@ -24,6 +24,7 @@ import {
 	useToolbarItemsContext,
 	ZoomAreaPercent,
 } from '@pages/Player/Toolbar/ToolbarItemsContext/ToolbarItemsContext'
+import { isInsideElement } from '@util/dom'
 import { serializeErrorIdentifier } from '@util/error'
 import { getErrorBody } from '@util/errors/errorUtils'
 import { clamp } from '@util/numbers'
@@ -533,13 +534,7 @@ const TimelineIndicatorsBarGraph = ({
 			if (!viewportBbox) {
 				return
 			}
-			const { clientX, clientY } = event
-
-			const isInsideViewport =
-				viewportBbox.left <= clientX &&
-				clientX <= viewportBbox.right &&
-				viewportBbox.bottom >= clientY &&
-				clientY >= viewportBbox.top
+			const isInsideViewport = isInsideElement(event, viewportRef.current)
 
 			const indicatorBbox =
 				timeIndicatorRef.current?.getBoundingClientRect()
@@ -554,11 +549,7 @@ const TimelineIndicatorsBarGraph = ({
 			}
 
 			setShowIndicatorText(
-				isDragging ||
-					(indicatorBbox.left <= clientX &&
-						clientX <= indicatorBbox.right &&
-						indicatorBbox.bottom >= clientY &&
-						clientY >= indicatorBbox.top),
+				isDragging || isInsideElement(event, timeIndicatorRef.current),
 			)
 		},
 		[isDragging, moveTime],

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedV3.css.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedV3.css.ts
@@ -14,21 +14,3 @@ export const searchPanelHidden = style({
 	position: 'fixed',
 	transform: `translateX(-${SESSION_FEED_LEFT_PANEL_WIDTH}px)`,
 })
-
-export const searchPanelToggleButton = style({
-	position: 'absolute',
-	right: 'calc((-1 * var(--size-xLarge) / 2))',
-	top: 16,
-	transform: 'translateY(calc(112px + var(--size-medium) + 30px))',
-	zIndex: 20,
-})
-
-export const SEARCH_PANEL_CONTROL_BAR_HEIGHT = 44
-
-export const controlBar = style({
-	height: SEARCH_PANEL_CONTROL_BAR_HEIGHT,
-	flexShrink: 0,
-	position: 'sticky',
-	top: 0,
-	zIndex: 10,
-})

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/components/QueryBuilder/QueryBuilder.tsx
@@ -952,6 +952,7 @@ export const TimeRangeFilter = ({
 						weight="medium"
 						color="n9"
 						userSelect="none"
+						lines="1"
 					>
 						{value &&
 							value.options.length === 1 &&

--- a/frontend/src/util/dom.ts
+++ b/frontend/src/util/dom.ts
@@ -1,0 +1,14 @@
+export function isInsideElement(
+	event: MouseEvent,
+	element: HTMLElement | null,
+) {
+	if (!element) return false
+	const { top, left, bottom, right } = element.getBoundingClientRect()
+	const { clientX, clientY } = event
+	return (
+		clientX >= left &&
+		clientX <= right &&
+		clientY >= top &&
+		clientY <= bottom
+	)
+}

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -13,7 +13,7 @@ import {
 	MenuHeadingProps,
 } from 'ariakit'
 import clsx, { ClassValue } from 'clsx'
-import React from 'react'
+import React, { forwardRef } from 'react'
 import {
 	Button as OriginalButton,
 	ButtonProps as ButtonProps,
@@ -41,68 +41,85 @@ export const Menu: MenuComponent = ({ children, ...props }: Props) => {
 	return <MenuContext.Provider value={menu}>{children}</MenuContext.Provider>
 }
 
-const Button: React.FC<
-	React.PropsWithChildren<{ cssClass?: ClassValue | ClassValue[] }> &
-		Omit<MenuButtonProps, 'state'> &
-		Pick<ButtonProps, 'iconLeft' | 'iconRight'> & {
-			emphasis?: ButtonProps['emphasis']
-			icon?: ButtonIconProps['icon']
-			kind?: ButtonProps['kind']
-			size?: ButtonProps['size'] | ButtonIconProps['size']
-		}
-> = ({ children, ...props }) => {
-	const menu = useMenu()
-	const Component = props.icon && !children ? ButtonIcon : OriginalButton
+type UIButtonProps = React.PropsWithChildren<{
+	cssClass?: ClassValue | ClassValue[]
+}> &
+	Omit<MenuButtonProps, 'state'> &
+	Pick<ButtonProps, 'iconLeft' | 'iconRight'> & {
+		emphasis?: ButtonProps['emphasis']
+		icon?: ButtonIconProps['icon']
+		kind?: ButtonProps['kind']
+		size?: ButtonProps['size'] | ButtonIconProps['size']
+	}
 
-	return (
-		<MenuButton as={Component} state={menu} {...props}>
-			{children}
-		</MenuButton>
-	)
-}
+const Button = forwardRef<HTMLButtonElement, UIButtonProps>(
+	({ children, ...props }, ref) => {
+		const menu = useMenu()
+		const Component = props.icon && !children ? ButtonIcon : OriginalButton
 
-const List: React.FC<
-	React.PropsWithChildren<{ cssClass?: ClassValue | ClassValue[] }> &
-		Partial<MenuProps>
-> = ({ children, cssClass }) => {
-	const menu = useMenu()
-
-	return (
-		<AriakitMenu state={menu} className={clsx(styles.menuList, cssClass)}>
-			{children}
-		</AriakitMenu>
-	)
-}
-
-const Item: React.FC<MenuItemProps> = ({ children, ...props }) => (
-	<MenuItem
-		className={styles.menuItemVariants({ selected: false })}
-		{...props}
-	>
-		{children}
-	</MenuItem>
+		return (
+			<MenuButton as={Component} state={menu} ref={ref} {...props}>
+				{children}
+			</MenuButton>
+		)
+	},
 )
 
-const Divider: React.FC<MenuSeparatorProps> = ({ children, ...props }) => (
-	<MenuSeparator className={styles.menuDivider} {...props}>
-		{children}
-	</MenuSeparator>
+type ListProps = React.PropsWithChildren<{
+	cssClass?: ClassValue | ClassValue[]
+}> &
+	Partial<MenuProps>
+
+const List = forwardRef<HTMLDivElement, ListProps>(
+	({ children, cssClass, ...props }, ref) => {
+		const menu = useMenu()
+
+		return (
+			<AriakitMenu
+				state={menu}
+				className={clsx(styles.menuList, cssClass)}
+				ref={ref}
+				{...props}
+			>
+				{children}
+			</AriakitMenu>
+		)
+	},
 )
 
-const Heading: React.FC<MenuHeadingProps> = ({
-	children,
-	className,
-	...props
-}) => (
-	<>
-		<AriakitMenuHeading
-			className={clsx(styles.menuHeading, className)}
+const Item = forwardRef<HTMLDivElement, MenuItemProps>(
+	({ children, ...props }, ref) => (
+		<MenuItem
+			className={styles.menuItemVariants({ selected: false })}
+			ref={ref}
 			{...props}
 		>
 			{children}
-		</AriakitMenuHeading>
-		<Divider />
-	</>
+		</MenuItem>
+	),
+)
+
+const Divider = forwardRef<HTMLHRElement, MenuSeparatorProps>(
+	({ children, ...props }, ref) => (
+		<MenuSeparator className={styles.menuDivider} ref={ref} {...props}>
+			{children}
+		</MenuSeparator>
+	),
+)
+
+const Heading = forwardRef<HTMLHeadingElement, MenuHeadingProps>(
+	({ children, className, ...props }, ref) => (
+		<>
+			<AriakitMenuHeading
+				className={clsx(styles.menuHeading, className)}
+				ref={ref}
+				{...props}
+			>
+				{children}
+			</AriakitMenuHeading>
+			<Divider />
+		</>
+	),
 )
 
 Menu.Button = Button


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Resolves #4234.

was:
![Screenshot 2023-02-15 at 1 48 18 PM](https://user-images.githubusercontent.com/17913919/219176050-5e1ef7d1-065e-48dd-bfa1-81418a11aea2.jpg)

now:
![Screenshot 2023-02-15 at 1 48 02 PM](https://user-images.githubusercontent.com/17913919/219176001-3a7f0277-aa9d-4406-831d-0cecf1032373.jpg)

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
local click test

go to the session feed settings in the top left


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no