### PR TITLE
hotfix: session date in feed

### DIFF
--- a/frontend/src/pages/Sessions/SessionsFeedV2/components/SessionFeedConfiguration/SessionFeedConfiguration.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV2/components/SessionFeedConfiguration/SessionFeedConfiguration.tsx
@@ -148,7 +148,7 @@ export const formatDatetime = (
 				return dt.format('M/D/YY')
 			} else if (moment().month() !== dt.month()) {
 				return dt.format('M/D HH:mm')
-			} else if (moment().day() !== dt.day()) {
+			} else if (moment().date() !== dt.date()) {
 				return dt.format('MMM D h:mm A')
 			} else {
 				return dt.format('h:mm A')


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

moment.day returns the day of the week (1 - 7), not the day of the month

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
local click test

old:

https://app.highlight.io/898/sessions/Mn8PwKIp8t3idNJ11QEjRXmVQ6y6?query=and%7C%7Ccustom_processed%2Cis%2Ctrue%7C%7Ccustom_created_at%2Cbetween_date%2C30%20days%7C%7Cuser_email%2Cis%2Crachel.bahl%40netlify.com%7C%7Ctrack_window%2Cis%2Csidekick

new

https://frontend-pr-4294.onrender.com/898/sessions/Mn8PwKIp8t3idNJ11QEjRXmVQ6y6?query=and%7C%7Ccustom_processed%2Cis%2Ctrue%7C%7Ccustom_created_at%2Cbetween_date%2C30%20days%7C%7Cuser_email%2Cis%2Crachel.bahl%40netlify.com%7C%7Ctrack_window%2Cis%2Csidekick


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

no
