### PR TITLE
add backend endpoint to fetch log attributes keys

### DIFF
--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -84,3 +84,35 @@ func (suite *ReadLogsTestSuite) TestReadLogsWithTimeQuery(t *testing.T) {
 
 	assert.Len(t, logLines, 1)
 }
+
+func (suite *ReadLogsTestSuite) TestLogsKeys(t *testing.T) {
+	rows := []*LogRow{
+		{
+			Timestamp:     time.Now(),
+			ProjectId:     1,
+			LogAttributes: map[string]string{"user_id": "1", "workspace_id": "2"},
+		},
+		{
+			Timestamp:     time.Now(),
+			ProjectId:     1,
+			LogAttributes: map[string]string{"workspace_id": "3"},
+		},
+	}
+
+	assert.NoError(t, suite.client.BatchWriteLogRows(suite.ctx, rows))
+
+	keys, err := suite.client.LogsKeys(suite.ctx, 1)
+	assert.NoError(t, err)
+
+	expected := []*modelInputs.LogKey{
+		{
+			Name: "workspace_id", // workspace_id has more hits so it should be ranked higher
+			Type: modelInputs.LogKeyTypeString,
+		},
+		{
+			Name: "user_id",
+			Type: modelInputs.LogKeyTypeString,
+		},
+	}
+	assert.Equal(t, expected, keys)
+}

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -490,6 +490,11 @@ type ComplexityRoot struct {
 		TeamID func(childComplexity int) int
 	}
 
+	LogKey struct {
+		Name func(childComplexity int) int
+		Type func(childComplexity int) int
+	}
+
 	LogLine struct {
 		Body          func(childComplexity int) int
 		LogAttributes func(childComplexity int) int
@@ -704,6 +709,7 @@ type ComplexityRoot struct {
 		LinearTeams                  func(childComplexity int, projectID int) int
 		LiveUsersCount               func(childComplexity int, projectID int) int
 		Logs                         func(childComplexity int, projectID int, params model.LogsParamsInput) int
+		LogsKeys                     func(childComplexity int, projectID int) int
 		LogsTotalCount               func(childComplexity int, projectID int, params model.LogsParamsInput) int
 		Messages                     func(childComplexity int, sessionSecureID string) int
 		MetricMonitors               func(childComplexity int, projectID int, metricName *string) int
@@ -1306,6 +1312,7 @@ type QueryResolver interface {
 	EmailOptOuts(ctx context.Context, token *string, adminID *int) ([]model.EmailOptOutCategory, error)
 	Logs(ctx context.Context, projectID int, params model.LogsParamsInput) ([]*model.LogLine, error)
 	LogsTotalCount(ctx context.Context, projectID int, params model.LogsParamsInput) (uint64, error)
+	LogsKeys(ctx context.Context, projectID int) ([]*model.LogKey, error)
 }
 type SegmentResolver interface {
 	Params(ctx context.Context, obj *model1.Segment) (*model1.SearchParams, error)
@@ -3291,6 +3298,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.LinearTeam.TeamID(childComplexity), true
 
+	case "LogKey.name":
+		if e.complexity.LogKey.Name == nil {
+			break
+		}
+
+		return e.complexity.LogKey.Name(childComplexity), true
+
+	case "LogKey.type":
+		if e.complexity.LogKey.Type == nil {
+			break
+		}
+
+		return e.complexity.LogKey.Type(childComplexity), true
+
 	case "LogLine.body":
 		if e.complexity.LogLine.Body == nil {
 			break
@@ -5195,6 +5216,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Logs(childComplexity, args["project_id"].(int), args["params"].(model.LogsParamsInput)), true
+
+	case "Query.logs_keys":
+		if e.complexity.Query.LogsKeys == nil {
+			break
+		}
+
+		args, err := ec.field_Query_logs_keys_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.LogsKeys(childComplexity, args["project_id"].(int)), true
 
 	case "Query.logs_total_count":
 		if e.complexity.Query.LogsTotalCount == nil {
@@ -7932,6 +7965,15 @@ type LogLine {
 	logAttributes: Map!
 }
 
+enum LogKeyType {
+	String
+}
+
+type LogKey {
+	name: String!
+	type: LogKeyType!
+}
+
 type ReferrerTablePayload {
 	host: String!
 	count: Int!
@@ -8833,6 +8875,7 @@ type Query {
 	email_opt_outs(token: String, admin_id: ID): [EmailOptOutCategory!]!
 	logs(project_id: ID!, params: LogsParamsInput!): [LogLine!]!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
+	logs_keys(project_id: ID!): [LogKey!]!
 }
 
 type Mutation {
@@ -13083,6 +13126,21 @@ func (ec *executionContext) field_Query_logs_args(ctx context.Context, rawArgs m
 		}
 	}
 	args["params"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_logs_keys_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
 	return args, nil
 }
 
@@ -26488,6 +26546,94 @@ func (ec *executionContext) fieldContext_LinearTeam_key(ctx context.Context, fie
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LogKey_name(ctx context.Context, field graphql.CollectedField, obj *model.LogKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LogKey_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LogKey_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LogKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LogKey_type(ctx context.Context, field graphql.CollectedField, obj *model.LogKey) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LogKey_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Type, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.LogKeyType)
+	fc.Result = res
+	return ec.marshalNLogKeyType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogKeyType(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LogKey_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LogKey",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type LogKeyType does not have child fields")
 		},
 	}
 	return fc, nil
@@ -41048,6 +41194,66 @@ func (ec *executionContext) fieldContext_Query_logs_total_count(ctx context.Cont
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_logs_total_count_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_logs_keys(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_logs_keys(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().LogsKeys(rctx, fc.Args["project_id"].(int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.LogKey)
+	fc.Result = res
+	return ec.marshalNLogKey2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogKeyᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_logs_keys(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "name":
+				return ec.fieldContext_LogKey_name(ctx, field)
+			case "type":
+				return ec.fieldContext_LogKey_type(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type LogKey", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_logs_keys_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -56895,6 +57101,41 @@ func (ec *executionContext) _LinearTeam(ctx context.Context, sel ast.SelectionSe
 	return out
 }
 
+var logKeyImplementors = []string{"LogKey"}
+
+func (ec *executionContext) _LogKey(ctx context.Context, sel ast.SelectionSet, obj *model.LogKey) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, logKeyImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("LogKey")
+		case "name":
+
+			out.Values[i] = ec._LogKey_name(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "type":
+
+			out.Values[i] = ec._LogKey_type(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var logLineImplementors = []string{"LogLine"}
 
 func (ec *executionContext) _LogLine(ctx context.Context, sel ast.SelectionSet, obj *model.LogLine) graphql.Marshaler {
@@ -60264,6 +60505,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_logs_total_count(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "logs_keys":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_logs_keys(ctx, field)
 				return res
 			}
 
@@ -64859,6 +65120,70 @@ func (ec *executionContext) marshalNLinearTeam2ᚖgithubᚗcomᚋhighlightᚑrun
 		return graphql.Null
 	}
 	return ec._LinearTeam(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNLogKey2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogKeyᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.LogKey) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNLogKey2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogKey(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNLogKey2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogKey(ctx context.Context, sel ast.SelectionSet, v *model.LogKey) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._LogKey(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNLogKeyType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogKeyType(ctx context.Context, v interface{}) (model.LogKeyType, error) {
+	var res model.LogKeyType
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNLogKeyType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogKeyType(ctx context.Context, sel ast.SelectionSet, v model.LogKeyType) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) marshalNLogLine2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogLineᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.LogLine) graphql.Marshaler {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -351,6 +351,11 @@ type LinearTeam struct {
 	Key    string `json:"key"`
 }
 
+type LogKey struct {
+	Name string     `json:"name"`
+	Type LogKeyType `json:"type"`
+}
+
 type LogLine struct {
 	Timestamp     time.Time              `json:"timestamp"`
 	SeverityText  SeverityText           `json:"severityText"`
@@ -752,6 +757,45 @@ func (e *IntegrationType) UnmarshalGQL(v interface{}) error {
 }
 
 func (e IntegrationType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type LogKeyType string
+
+const (
+	LogKeyTypeString LogKeyType = "String"
+)
+
+var AllLogKeyType = []LogKeyType{
+	LogKeyTypeString,
+}
+
+func (e LogKeyType) IsValid() bool {
+	switch e {
+	case LogKeyTypeString:
+		return true
+	}
+	return false
+}
+
+func (e LogKeyType) String() string {
+	return string(e)
+}
+
+func (e *LogKeyType) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = LogKeyType(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid LogKeyType", str)
+	}
+	return nil
+}
+
+func (e LogKeyType) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -501,6 +501,15 @@ type LogLine {
 	logAttributes: Map!
 }
 
+enum LogKeyType {
+	String
+}
+
+type LogKey {
+	name: String!
+	type: LogKeyType!
+}
+
 type ReferrerTablePayload {
 	host: String!
 	count: Int!
@@ -1402,6 +1411,7 @@ type Query {
 	email_opt_outs(token: String, admin_id: ID): [EmailOptOutCategory!]!
 	logs(project_id: ID!, params: LogsParamsInput!): [LogLine!]!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
+	logs_keys(project_id: ID!): [LogKey!]!
 }
 
 type Mutation {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6955,6 +6955,16 @@ func (r *queryResolver) LogsTotalCount(ctx context.Context, projectID int, param
 	return r.ClickhouseClient.ReadLogsTotalCount(ctx, project.ID, params)
 }
 
+// LogsKeys is the resolver for the logs_keys field.
+func (r *queryResolver) LogsKeys(ctx context.Context, projectID int) ([]*modelInputs.LogKey, error) {
+	project, err := r.isAdminInProject(ctx, projectID)
+	if err != nil {
+		return nil, e.Wrap(err, "error querying project")
+	}
+
+	return r.ClickhouseClient.LogsKeys(ctx, project.ID)
+}
+
 // Params is the resolver for the params field.
 func (r *segmentResolver) Params(ctx context.Context, obj *model.Segment) (*model.SearchParams, error) {
 	params := &model.SearchParams{}

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -11435,3 +11435,58 @@ export type GetLogsTotalCountQueryResult = Apollo.QueryResult<
 	Types.GetLogsTotalCountQuery,
 	Types.GetLogsTotalCountQueryVariables
 >
+export const GetLogsKeysDocument = gql`
+	query GetLogsKeys($project_id: ID!) {
+		logs_keys(project_id: $project_id) {
+			name
+			type
+		}
+	}
+`
+
+/**
+ * __useGetLogsKeysQuery__
+ *
+ * To run a query within a React component, call `useGetLogsKeysQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetLogsKeysQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetLogsKeysQuery({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *   },
+ * });
+ */
+export function useGetLogsKeysQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogsKeysQuery,
+		Types.GetLogsKeysQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetLogsKeysQuery,
+		Types.GetLogsKeysQueryVariables
+	>(GetLogsKeysDocument, baseOptions)
+}
+export function useGetLogsKeysLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogsKeysQuery,
+		Types.GetLogsKeysQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetLogsKeysQuery,
+		Types.GetLogsKeysQueryVariables
+	>(GetLogsKeysDocument, baseOptions)
+}
+export type GetLogsKeysQueryHookResult = ReturnType<typeof useGetLogsKeysQuery>
+export type GetLogsKeysLazyQueryHookResult = ReturnType<
+	typeof useGetLogsKeysLazyQuery
+>
+export type GetLogsKeysQueryResult = Apollo.QueryResult<
+	Types.GetLogsKeysQuery,
+	Types.GetLogsKeysQueryVariables
+>

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -3935,6 +3935,16 @@ export type GetLogsTotalCountQuery = { __typename?: 'Query' } & Pick<
 	'logs_total_count'
 >
 
+export type GetLogsKeysQueryVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+}>
+
+export type GetLogsKeysQuery = { __typename?: 'Query' } & {
+	logs_keys: Array<
+		{ __typename?: 'LogKey' } & Pick<Types.LogKey, 'name' | 'type'>
+	>
+}
+
 export const namedOperations = {
 	Query: {
 		GetMetricsTimeline: 'GetMetricsTimeline' as const,
@@ -4050,6 +4060,7 @@ export const namedOperations = {
 		GetEmailOptOuts: 'GetEmailOptOuts' as const,
 		GetLogs: 'GetLogs' as const,
 		GetLogsTotalCount: 'GetLogsTotalCount' as const,
+		GetLogsKeys: 'GetLogsKeys' as const,
 	},
 	Mutation: {
 		MarkErrorGroupAsViewed: 'MarkErrorGroupAsViewed' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -655,6 +655,16 @@ export type LinearTeam = {
 	team_id: Scalars['String']
 }
 
+export type LogKey = {
+	__typename?: 'LogKey'
+	name: Scalars['String']
+	type: LogKeyType
+}
+
+export enum LogKeyType {
+	String = 'String',
+}
+
 export type LogLine = {
 	__typename?: 'LogLine'
 	body: Scalars['String']
@@ -1414,6 +1424,7 @@ export type Query = {
 	linear_teams?: Maybe<Array<LinearTeam>>
 	liveUsersCount?: Maybe<Scalars['Int64']>
 	logs: Array<LogLine>
+	logs_keys: Array<LogKey>
 	logs_total_count: Scalars['UInt64']
 	messages?: Maybe<Array<Maybe<Scalars['Any']>>>
 	metric_monitors: Array<Maybe<MetricMonitor>>
@@ -1741,6 +1752,10 @@ export type QueryLiveUsersCountArgs = {
 
 export type QueryLogsArgs = {
 	params: LogsParamsInput
+	project_id: Scalars['ID']
+}
+
+export type QueryLogs_KeysArgs = {
 	project_id: Scalars['ID']
 }
 

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1860,3 +1860,10 @@ query GetLogs($project_id: ID!, $params: LogsParamsInput!) {
 query GetLogsTotalCount($project_id: ID!, $params: LogsParamsInput!) {
 	logs_total_count(project_id: $project_id, params: $params)
 }
+
+query GetLogsKeys($project_id: ID!) {
+	logs_keys(project_id: $project_id) {
+		name
+		type
+	}
+}

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -1,5 +1,9 @@
 import { CircularSpinner } from '@components/Loading/Loading'
-import { useGetLogsQuery, useGetLogsTotalCountQuery } from '@graph/hooks'
+import {
+	useGetLogsKeysQuery,
+	useGetLogsQuery,
+	useGetLogsTotalCountQuery,
+} from '@graph/hooks'
 import { Box, Preset, Stack, Text } from '@highlight-run/ui'
 import { LogsTable } from '@pages/LogsPage/LogsTable/LogsTable'
 import { SearchForm } from '@pages/LogsPage/SearchForm/SearchForm'
@@ -90,6 +94,17 @@ const LogsPage = () => {
 			},
 			skip: !project_id,
 		})
+
+	const { data: keys } = useGetLogsKeysQuery({
+		variables: {
+			project_id: project_id!,
+		},
+		skip: !project_id,
+	})
+
+	if (keys) {
+		console.log(keys)
+	}
 
 	const handleFormSubmit = (value: string) => {
 		setQuery(value)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We need to fetch all the possible facets (the keys of [LogAttributes](https://github.com/highlight/highlight/blob/bea44cc29d858c1d5267376fb601eda9bd48ae22/backend/clickhouse/migrations/000001_create_logs_table.up.sql#L12)) such that we can use this to build a really great UX to filter on.

Effectively, we need to get all keys over the last 30 days (the TTL of a log) with this query:

```sql
SELECT arrayJoin(LogAttributes.keys) as key, count() as cnt FROM logs
WHERE ProjectId = ${ProjectID}
AND Timestamp < now()
AND Timestamp >= (now() - toIntervalDay(30))
GROUP BY key
ORDER BY cnt DESC;
```

This orders the keys by popularity of how often they occur (see the unit test for an example).

The frontend receives this sorted array of `[{name, type}]` where `name` is the key name and `type` indicates what kind of key this is.

For example `{workspace_id: 1, service: "image-compressor"}`  should return:
`[{ name: "workspace_id", type: 'integer' }, { name: 'image-compressor', type: 'string' }]`

For now, i've hardcoded every `type` to be a string since that's our MVP goal. 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

My local clickhouse db is populated with the test script from #4253.

I `console.log` the query from the frontend and you'll see that it shows all the keys, ordered by popularity (in this case, `user_id` is the most popular key). 

<img width="564" alt="Screenshot 2023-02-15 at 9 45 48 PM" src="https://user-images.githubusercontent.com/58678/219271032-ee0fa801-89c9-4678-b1cd-cc940e537f73.png">


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
