### PR TITLE
otel ingest should mark backend setup

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -186,14 +186,14 @@ func enhancedHealthCheck(ctx context.Context, db *gorm.DB, tdb timeseries.DB, rC
 	}()
 	wg.Wait()
 	select {
-	case e := <-errors:
-		return e
+	case err := <-errors:
+		return err
 	default:
 		return nil
 	}
 }
 
-func validateOrigin(request *http.Request, origin string) bool {
+func validateOrigin(_ *http.Request, origin string) bool {
 	if runtimeParsed == util.PrivateGraph {
 		// From the highlight frontend, only the url is whitelisted.
 		isRenderPreviewEnv := strings.HasPrefix(origin, "https://frontend-pr-") && strings.HasSuffix(origin, ".onrender.com")

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -254,7 +254,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 				},
 			}, sessionID)
 			if err != nil {
-				log.Error(err, "failed to submit otel mark backend setup")
+				log.WithContext(ctx).Error(err, "failed to submit otel mark backend setup")
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
@@ -289,7 +289,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 					},
 				}, projectID)
 				if err != nil {
-					log.Error(err, "failed to submit otel mark backend setup")
+					log.WithContext(ctx).Error(err, "failed to submit otel mark backend setup")
 					w.WriteHeader(http.StatusServiceUnavailable)
 					return
 				}
@@ -411,7 +411,7 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := o.submitProjectLogs(ctx, projectLogs); err != nil {
-		log.Error(err, "failed to submit otel project logs")
+		log.WithContext(ctx).Error(err, "failed to submit otel project logs")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
 	}

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -39,7 +39,7 @@ func castString(v interface{}, fallback string) string {
 	return s
 }
 
-func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestID *string) {
+func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestID, source *string) {
 	if p, ok := attrs[highlight.ProjectIDAttribute]; ok {
 		if v, _ := p.(string); v != "" {
 			*projectID = v
@@ -53,6 +53,11 @@ func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestI
 	if r, ok := attrs[highlight.RequestIDAttribute]; ok {
 		if v, _ := r.(string); v != "" {
 			*requestID = v
+		}
+	}
+	if src, ok := attrs[highlight.SourceAttribute]; ok {
+		if v, _ := src.(string); v != "" {
+			*source = v
 		}
 	}
 }
@@ -107,12 +112,12 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 
 	spans := req.Traces().ResourceSpans()
 	for i := 0; i < spans.Len(); i++ {
-		var projectID, sessionID, requestID string
+		var projectID, sessionID, requestID, source string
 		resource := spans.At(i).Resource()
 		resourceAttributes := resource.Attributes().AsRaw()
 		sdkLanguage := castString(resource.Attributes().AsRaw()[string(semconv.TelemetrySDKLanguageKey)], "")
 		serviceName := castString(resource.Attributes().AsRaw()[string(semconv.ServiceNameKey)], "")
-		setHighlightAttributes(resourceAttributes, &projectID, &sessionID, &requestID)
+		setHighlightAttributes(resourceAttributes, &projectID, &sessionID, &requestID, &source)
 		scopeScans := spans.At(i).ScopeSpans()
 		for j := 0; j < scopeScans.Len(); j++ {
 			scope := scopeScans.At(j).Scope()
@@ -125,14 +130,14 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 					log.WithContext(ctx).Errorf("failed to format error attributes %s", tagsBytes)
 					continue
 				}
-				setHighlightAttributes(spanAttributes, &projectID, &sessionID, &requestID)
+				setHighlightAttributes(spanAttributes, &projectID, &sessionID, &requestID, &source)
 				events := span.Events()
 				for l := 0; l < events.Len(); l++ {
 					event := events.At(l)
 					eventAttributes := event.Attributes().AsRaw()
-					setHighlightAttributes(eventAttributes, &projectID, &sessionID, &requestID)
+					setHighlightAttributes(eventAttributes, &projectID, &sessionID, &requestID, &source)
 					if event.Name() == semconv.ExceptionEventName {
-						excType := castString(eventAttributes[string(semconv.ExceptionTypeKey)], "")
+						excType := castString(eventAttributes[string(semconv.ExceptionTypeKey)], source)
 						excMessage := castString(eventAttributes[string(semconv.ExceptionMessageKey)], "")
 						stackTrace := castString(eventAttributes[string(semconv.ExceptionStacktraceKey)], "")
 						errorUrl := castString(eventAttributes[highlight.ErrorURLKey], "")
@@ -149,8 +154,8 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 							RequestID:       &requestID,
 							TraceID:         pointy.String(span.TraceID().String()),
 							SpanID:          pointy.String(span.SpanID().String()),
-							Event:           castString(excMessage, ""),
-							Type:            castString(excType, "BACKEND"),
+							Event:           excMessage,
+							Type:            excType,
 							Source: strings.Join(lo.Filter([]string{
 								sdkLanguage,
 								serviceName,
@@ -235,16 +240,24 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for sessionID, errors := range traceErrors {
-		err := o.resolver.BatchedQueue.Submit(ctx, &kafkaqueue.Message{
-			Type: kafkaqueue.MarkBackendSetup,
-			MarkBackendSetup: &kafkaqueue.MarkBackendSetupArgs{
-				SessionSecureID: pointy.String(sessionID),
-			},
-		}, sessionID)
-		if err != nil {
-			log.Error(err, "failed to submit otel mark backend setup")
-			w.WriteHeader(http.StatusServiceUnavailable)
-			return
+		var backendError = false
+		for _, err := range errors {
+			if err.Type != highlight.SourceAttributeFrontend {
+				backendError = true
+			}
+		}
+		if backendError {
+			err = o.resolver.BatchedQueue.Submit(ctx, &kafkaqueue.Message{
+				Type: kafkaqueue.MarkBackendSetup,
+				MarkBackendSetup: &kafkaqueue.MarkBackendSetupArgs{
+					SessionSecureID: pointy.String(sessionID),
+				},
+			}, sessionID)
+			if err != nil {
+				log.Error(err, "failed to submit otel mark backend setup")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
 		}
 
 		err = o.resolver.ProducerQueue.Submit(ctx, &kafkaqueue.Message{
@@ -261,17 +274,25 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for projectID, errors := range projectErrors {
-		if projectIDInt, err := projectToInt(projectID); err == nil {
-			err := o.resolver.BatchedQueue.Submit(ctx, &kafkaqueue.Message{
-				Type: kafkaqueue.MarkBackendSetup,
-				MarkBackendSetup: &kafkaqueue.MarkBackendSetupArgs{
-					ProjectID: projectIDInt,
-				},
-			}, projectID)
-			if err != nil {
-				log.Error(err, "failed to submit otel mark backend setup")
-				w.WriteHeader(http.StatusServiceUnavailable)
-				return
+		var backendError = false
+		for _, err := range errors {
+			if err.Type != highlight.SourceAttributeFrontend {
+				backendError = true
+			}
+		}
+		if backendError {
+			if projectIDInt, err := projectToInt(projectID); err == nil {
+				err := o.resolver.BatchedQueue.Submit(ctx, &kafkaqueue.Message{
+					Type: kafkaqueue.MarkBackendSetup,
+					MarkBackendSetup: &kafkaqueue.MarkBackendSetupArgs{
+						ProjectID: projectIDInt,
+					},
+				}, projectID)
+				if err != nil {
+					log.Error(err, "failed to submit otel mark backend setup")
+					w.WriteHeader(http.StatusServiceUnavailable)
+					return
+				}
 			}
 		}
 
@@ -332,18 +353,18 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 
 	resourceLogs := req.Logs().ResourceLogs()
 	for i := 0; i < resourceLogs.Len(); i++ {
-		var projectID, sessionID, requestID string
+		var projectID, sessionID, requestID, source string
 		resource := resourceLogs.At(i).Resource()
 		resourceAttributes := resource.Attributes().AsRaw()
 		serviceName := castString(resource.Attributes().AsRaw()[string(semconv.ServiceNameKey)], "")
-		setHighlightAttributes(resourceAttributes, &projectID, &sessionID, &requestID)
+		setHighlightAttributes(resourceAttributes, &projectID, &sessionID, &requestID, &source)
 		scopeLogs := resourceLogs.At(i).ScopeLogs()
 		for j := 0; j < scopeLogs.Len(); j++ {
 			logRecords := scopeLogs.At(j).LogRecords()
 			for k := 0; k < logRecords.Len(); k++ {
 				logRecord := logRecords.At(k)
 				logAttributes := logRecord.Attributes().AsRaw()
-				setHighlightAttributes(logAttributes, &projectID, &sessionID, &requestID)
+				setHighlightAttributes(logAttributes, &projectID, &sessionID, &requestID, &source)
 				projectIDInt, err := projectToInt(projectID)
 				if err != nil {
 					log.WithContext(ctx).WithField("ProjectID", projectID).WithField("LogMessage", logRecord.Body().AsRaw()).Errorf("otel log got invalid project id")
@@ -401,6 +422,7 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 func (o *Handler) submitProjectLogs(ctx context.Context, projectLogs map[string][]*clickhouse.LogRow) error {
 	for projectID, logRows := range projectLogs {
 		if projectIDInt, err := projectToInt(projectID); err == nil {
+			// otel logs only come from python sdk
 			err := o.resolver.BatchedQueue.Submit(ctx, &kafkaqueue.Message{
 				Type: kafkaqueue.MarkBackendSetup,
 				MarkBackendSetup: &kafkaqueue.MarkBackendSetupArgs{

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"github.com/openlyinc/pointy"
 	"sync"
 	"time"
 
@@ -80,6 +81,8 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 	defer s.Finish()
 
 	var logRows []*clickhouse.LogRow
+	setupProjectIDs := make(map[int]bool)
+	setupSessionIDs := make(map[string]bool)
 
 	var received int
 	var lastMsg *kafkaqueue.Message
@@ -90,6 +93,14 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 				switch lastMsg.Type {
 				case kafkaqueue.PushLogs:
 					logRows = append(logRows, lastMsg.PushLogs.LogRows...)
+				case kafkaqueue.MarkBackendSetup:
+					if lastMsg.MarkBackendSetup.ProjectID != 0 {
+						setupProjectIDs[lastMsg.MarkBackendSetup.ProjectID] = true
+					} else if lastMsg.MarkBackendSetup.SessionSecureID != nil {
+						setupSessionIDs[*lastMsg.MarkBackendSetup.SessionSecureID] = true
+					} else {
+						log.WithContext(ctx).Errorf("invalid MarkBackendSetup message %+v", lastMsg.MarkBackendSetup)
+					}
 				}
 				received += 1
 				if received >= BatchFlushSize {
@@ -103,9 +114,23 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 
 	s.SetTag("NumLogRows", len(logRows))
 	s.SetTag("PayloadSizeBytes", binary.Size(logRows))
-	err := k.Worker.PublicResolver.Clickhouse.BatchWriteLogRows(ctx, logRows)
-	if err != nil {
-		log.WithContext(ctx).WithError(err).Error("failed to batch write to clickhouse")
+	if len(logRows) > 0 {
+		err := k.Worker.PublicResolver.Clickhouse.BatchWriteLogRows(ctx, logRows)
+		if err != nil {
+			log.WithContext(ctx).WithError(err).Error("failed to batch write to clickhouse")
+		}
+	}
+	for projectID, _ := range setupProjectIDs {
+		err := k.Worker.PublicResolver.MarkBackendSetupImpl(nil, nil, projectID)
+		if err != nil {
+			log.WithContext(ctx).WithError(err).Error("failed to batch mark backend setup for project %d", projectID)
+		}
+	}
+	for sessionID, _ := range setupSessionIDs {
+		err := k.Worker.PublicResolver.MarkBackendSetupImpl(nil, pointy.String(sessionID), 0)
+		if err != nil {
+			log.WithContext(ctx).WithError(err).Error("failed to batch mark backend setup for session %s", sessionID)
+		}
 	}
 
 	k.KafkaQueue.Commit(ctx, lastMsg.KafkaMessage)

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -120,16 +120,16 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 			log.WithContext(ctx).WithError(err).Error("failed to batch write to clickhouse")
 		}
 	}
-	for projectID, _ := range setupProjectIDs {
+	for projectID := range setupProjectIDs {
 		err := k.Worker.PublicResolver.MarkBackendSetupImpl(ctx, nil, nil, projectID)
 		if err != nil {
-			log.WithContext(ctx).WithError(err).Error("failed to batch mark backend setup for project %d", projectID)
+			log.WithContext(ctx).WithError(err).Errorf("failed to batch mark backend setup for project %d", projectID)
 		}
 	}
-	for sessionID, _ := range setupSessionIDs {
+	for sessionID := range setupSessionIDs {
 		err := k.Worker.PublicResolver.MarkBackendSetupImpl(ctx, nil, pointy.String(sessionID), 0)
 		if err != nil {
-			log.WithContext(ctx).WithError(err).Error("failed to batch mark backend setup for session %s", sessionID)
+			log.WithContext(ctx).WithError(err).Errorf("failed to batch mark backend setup for session %s", sessionID)
 		}
 	}
 

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -121,13 +121,13 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 		}
 	}
 	for projectID, _ := range setupProjectIDs {
-		err := k.Worker.PublicResolver.MarkBackendSetupImpl(nil, nil, projectID)
+		err := k.Worker.PublicResolver.MarkBackendSetupImpl(ctx, nil, nil, projectID)
 		if err != nil {
 			log.WithContext(ctx).WithError(err).Error("failed to batch mark backend setup for project %d", projectID)
 		}
 	}
 	for sessionID, _ := range setupSessionIDs {
-		err := k.Worker.PublicResolver.MarkBackendSetupImpl(nil, pointy.String(sessionID), 0)
+		err := k.Worker.PublicResolver.MarkBackendSetupImpl(ctx, nil, pointy.String(sessionID), 0)
 		if err != nil {
 			log.WithContext(ctx).WithError(err).Error("failed to batch mark backend setup for session %s", sessionID)
 		}

--- a/sdk/highlight-go/log/log.go
+++ b/sdk/highlight-go/log/log.go
@@ -65,7 +65,7 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 
 	span, _ := highlight.StartTrace(
 		ctx, "highlight-ctx",
-		attribute.String("Source", "SubmitFrontendConsoleMessages"),
+		attribute.String(highlight.SourceAttribute, highlight.SourceAttributeFrontend),
 		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
 		attribute.String(highlight.SessionIDAttribute, sessionSecureID),
 	)

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -18,6 +18,8 @@ import (
 )
 
 const OTLPDefaultEndpoint = "https://otel.highlight.io:4318"
+const SourceAttribute = "Source"
+const SourceAttributeFrontend = "SubmitFrontendConsoleMessages"
 const ProjectIDAttribute = "highlight_project_id"
 const SessionIDAttribute = "highlight_session_id"
 const RequestIDAttribute = "highlight_trace_id"


### PR DESCRIPTION
## Summary

Makes the otel data ingest mark a project as having their backend integration setup.
For otel data coming from the frontend (frontend console logs), the flag should not be set.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

No.
