### PR TITLE
add a spinner when fetching the total log count

### DIFF
--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -1,3 +1,4 @@
+import { CircularSpinner } from '@components/Loading/Loading'
 import { useGetLogsQuery, useGetLogsTotalCountQuery } from '@graph/hooks'
 import { Box, Preset, Stack, Text } from '@highlight-run/ui'
 import { LogsTable } from '@pages/LogsPage/LogsTable/LogsTable'
@@ -75,19 +76,20 @@ const LogsPage = () => {
 		skip: !project_id,
 	})
 
-	const { data: totalCount } = useGetLogsTotalCountQuery({
-		variables: {
-			project_id: project_id!,
-			params: {
-				query,
-				date_range: {
-					start_date: moment(startDate).format(FORMAT),
-					end_date: moment(endDate).format(FORMAT),
+	const { data: totalCount, loading: logCountLoading } =
+		useGetLogsTotalCountQuery({
+			variables: {
+				project_id: project_id!,
+				params: {
+					query,
+					date_range: {
+						start_date: moment(startDate).format(FORMAT),
+						end_date: moment(endDate).format(FORMAT),
+					},
 				},
 			},
-		},
-		skip: !project_id,
-	})
+			skip: !project_id,
+		})
 
 	const handleFormSubmit = (value: string) => {
 		setQuery(value)
@@ -122,12 +124,20 @@ const LogsPage = () => {
 						minDate={thirtyDaysAgo}
 					/>
 					<Stack direction="row" gap="2">
-						{totalCount && (
-							<Text color="weak">
-								{formatNumber(totalCount.logs_total_count)}
-							</Text>
+						{logCountLoading ? (
+							<CircularSpinner />
+						) : (
+							totalCount && (
+								<>
+									<Text color="weak">
+										{formatNumber(
+											totalCount.logs_total_count,
+										)}
+									</Text>
+									<Text color="weak">logs</Text>
+								</>
+							)
 						)}
-						<Text color="weak">logs</Text>
 					</Stack>
 					<LogsTable data={logs} loading={loading} query={query} />
 				</Box>


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We need to add a spinner for the total log count added in #4253

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Observe spinner while we are fetching the log count
![Kapture 2023-02-16 at 11 00 27](https://user-images.githubusercontent.com/58678/219449528-9e0efcaf-b238-4eb6-9ec7-72d063077229.gif)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A