### PR TITLE
add an endpoint to fetch values for a given key

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -119,7 +119,8 @@ func (client *Client) LogsKeys(ctx context.Context, projectID int) ([]*modelInpu
 		FROM logs
 		WHERE ProjectId = ?
 		GROUP BY key
-		ORDER BY cnt DESC;`,
+		ORDER BY cnt DESC
+		LIMIT 50;`,
 		projectID,
 	)
 
@@ -154,7 +155,8 @@ func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName 
 		SELECT LogAttributes[?] as value, count() as cnt FROM logs
 		WHERE ProjectId = ?
 		GROUP BY value
-		ORDER BY cnt DESC;`,
+		ORDER BY cnt DESC
+		LIMIT 50;`,
 		keyName,
 		projectID,
 	)

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -116,3 +116,36 @@ func (suite *ReadLogsTestSuite) TestLogsKeys(t *testing.T) {
 	}
 	assert.Equal(t, expected, keys)
 }
+
+func (suite *ReadLogsTestSuite) TestLogKeys(t *testing.T) {
+	rows := []*LogRow{
+		{
+			Timestamp:     time.Now(),
+			ProjectId:     1,
+			LogAttributes: map[string]string{"workspace_id": "2"},
+		},
+		{
+			Timestamp:     time.Now(),
+			ProjectId:     1,
+			LogAttributes: map[string]string{"workspace_id": "3"},
+		},
+		{
+			Timestamp:     time.Now(),
+			ProjectId:     1,
+			LogAttributes: map[string]string{"workspace_id": "3"},
+		},
+		{
+			Timestamp:     time.Now(),
+			ProjectId:     1,
+			LogAttributes: map[string]string{"workspace_id": "4"},
+		},
+	}
+
+	assert.NoError(t, suite.client.BatchWriteLogRows(suite.ctx, rows))
+
+	values, err := suite.client.LogsKeyValues(suite.ctx, 1, "workspace_id")
+	assert.NoError(t, err)
+
+	expected := []string{"3", "2", "4"}
+	assert.Equal(t, expected, values)
+}

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -709,6 +709,7 @@ type ComplexityRoot struct {
 		LinearTeams                  func(childComplexity int, projectID int) int
 		LiveUsersCount               func(childComplexity int, projectID int) int
 		Logs                         func(childComplexity int, projectID int, params model.LogsParamsInput) int
+		LogsKeyValues                func(childComplexity int, projectID int, keyName string) int
 		LogsKeys                     func(childComplexity int, projectID int) int
 		LogsTotalCount               func(childComplexity int, projectID int, params model.LogsParamsInput) int
 		Messages                     func(childComplexity int, sessionSecureID string) int
@@ -1313,6 +1314,7 @@ type QueryResolver interface {
 	Logs(ctx context.Context, projectID int, params model.LogsParamsInput) ([]*model.LogLine, error)
 	LogsTotalCount(ctx context.Context, projectID int, params model.LogsParamsInput) (uint64, error)
 	LogsKeys(ctx context.Context, projectID int) ([]*model.LogKey, error)
+	LogsKeyValues(ctx context.Context, projectID int, keyName string) ([]string, error)
 }
 type SegmentResolver interface {
 	Params(ctx context.Context, obj *model1.Segment) (*model1.SearchParams, error)
@@ -5217,6 +5219,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Logs(childComplexity, args["project_id"].(int), args["params"].(model.LogsParamsInput)), true
 
+	case "Query.logs_key_values":
+		if e.complexity.Query.LogsKeyValues == nil {
+			break
+		}
+
+		args, err := ec.field_Query_logs_key_values_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.LogsKeyValues(childComplexity, args["project_id"].(int), args["key_name"].(string)), true
+
 	case "Query.logs_keys":
 		if e.complexity.Query.LogsKeys == nil {
 			break
@@ -8876,6 +8890,7 @@ type Query {
 	logs(project_id: ID!, params: LogsParamsInput!): [LogLine!]!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_keys(project_id: ID!): [LogKey!]!
+	logs_key_values(project_id: ID!, key_name: String!): [String!]!
 }
 
 type Mutation {
@@ -13126,6 +13141,30 @@ func (ec *executionContext) field_Query_logs_args(ctx context.Context, rawArgs m
 		}
 	}
 	args["params"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_logs_key_values_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["key_name"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("key_name"))
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["key_name"] = arg1
 	return args, nil
 }
 
@@ -41260,6 +41299,60 @@ func (ec *executionContext) fieldContext_Query_logs_keys(ctx context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_logs_key_values(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_logs_key_values(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().LogsKeyValues(rctx, fc.Args["project_id"].(int), fc.Args["key_name"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_logs_key_values(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_logs_key_values_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query___type(ctx, field)
 	if err != nil {
@@ -60525,6 +60618,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_logs_keys(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "logs_key_values":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_logs_key_values(ctx, field)
 				return res
 			}
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1412,6 +1412,7 @@ type Query {
 	logs(project_id: ID!, params: LogsParamsInput!): [LogLine!]!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_keys(project_id: ID!): [LogKey!]!
+	logs_key_values(project_id: ID!, key_name: String!): [String!]!
 }
 
 type Mutation {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6965,6 +6965,16 @@ func (r *queryResolver) LogsKeys(ctx context.Context, projectID int) ([]*modelIn
 	return r.ClickhouseClient.LogsKeys(ctx, project.ID)
 }
 
+// LogsKeyValues is the resolver for the logs_key_values field.
+func (r *queryResolver) LogsKeyValues(ctx context.Context, projectID int, keyName string) ([]string, error) {
+	project, err := r.isAdminInProject(ctx, projectID)
+	if err != nil {
+		return nil, e.Wrap(err, "error querying project")
+	}
+
+	return r.ClickhouseClient.LogsKeyValues(ctx, project.ID, keyName)
+}
+
 // Params is the resolver for the params field.
 func (r *segmentResolver) Params(ctx context.Context, obj *model.Segment) (*model.SearchParams, error) {
 	params := &model.SearchParams{}

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1424,6 +1424,7 @@ export type Query = {
 	linear_teams?: Maybe<Array<LinearTeam>>
 	liveUsersCount?: Maybe<Scalars['Int64']>
 	logs: Array<LogLine>
+	logs_key_values: Array<Scalars['String']>
 	logs_keys: Array<LogKey>
 	logs_total_count: Scalars['UInt64']
 	messages?: Maybe<Array<Maybe<Scalars['Any']>>>
@@ -1752,6 +1753,11 @@ export type QueryLiveUsersCountArgs = {
 
 export type QueryLogsArgs = {
 	params: LogsParamsInput
+	project_id: Scalars['ID']
+}
+
+export type QueryLogs_Key_ValuesArgs = {
+	key_name: Scalars['String']
 	project_id: Scalars['ID']
 }
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

When the user types into the log input and has a filter selected, we should provide possible values that might facilliate their search. This will work similar to datadog's search:

![Screenshot 2023-02-16 at 4 17 49 PM](https://user-images.githubusercontent.com/58678/219509944-3939b12e-8755-413a-9da2-64023930b6d5.png)

This is the backend endpoint. A follow up PR will handle wiring this up to the frontend.


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Unit test added

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A