### PR TITLE
tweak frontend stacktrace display

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorSourcePreview/ErrorSourcePreview.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorSourcePreview/ErrorSourcePreview.tsx
@@ -83,7 +83,6 @@ const ErrorSourcePreview: React.FC<
 			style="light"
 			showLineNumbers={showLineNumbers}
 			wrapLines
-			wrapLongLines
 			startingLineNumber={(lineNumber ?? 1) - before.length}
 			customStyle={{
 				backgroundColor: 'transparent',

--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.css.ts
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.css.ts
@@ -40,3 +40,15 @@ export const iconCaret = recipe({
 		},
 	},
 })
+
+export const name = style({
+	overflow: 'hidden',
+	textOverflow: 'ellipsis',
+	whiteSpace: 'nowrap',
+	paddingTop: 2,
+	height: 16,
+	maxWidth: 120,
+})
+export const file = style({
+	maxWidth: 560,
+})

--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -22,6 +22,7 @@ import React from 'react'
 import ReactCollapsible from 'react-collapsible'
 
 import * as styles from './ErrorStackTrace.css'
+import clsx from 'clsx'
 
 interface Props {
 	errorObject?: ErrorInstance['error_object']
@@ -246,16 +247,22 @@ const StackSection: React.FC<React.PropsWithChildren<StackSectionProps>> = ({
 			justifyContent="space-between"
 			alignItems="center"
 		>
-			<Box display="flex" gap="4">
-				<Text>{truncateFileName(fileName || '')}</Text>
-				<Text color="n11" as="span">
+			<Box display="flex" gap="4" alignItems="center">
+				<Text cssClass={clsx(styles.name, styles.file)} as="span">
+					{truncateFileName(fileName || '')}
+				</Text>
+				<Text cssClass={styles.name} color="n11" as="span">
 					{functionName ? ' in ' : ''}
 				</Text>
-				<Text>{functionName}</Text>
-				<Text color="n11" as="span">
+				<Text cssClass={styles.name} as="span">
+					{functionName}
+				</Text>
+				<Text cssClass={styles.name} color="n11" as="span">
 					{lineNumber ? ' at line ' : ''}
 				</Text>
-				<Text>{lineNumber}</Text>
+				<Text cssClass={styles.name} as="span">
+					{lineNumber}
+				</Text>
 			</Box>
 
 			<Box display="flex" gap="4" alignItems="center">

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -56,6 +56,9 @@ func StartOTLP() (*OTLP, error) {
 	}
 	resources, err := resource.New(context.Background(),
 		resource.WithFromEnv(),
+		resource.WithHost(),
+		resource.WithContainer(),
+		resource.WithOS(),
 		resource.WithProcess(),
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

Tweaks display of error stack trace titles.

## How did you test this change?

stops wrapping of long lines because 
![image](https://user-images.githubusercontent.com/1351531/219523441-234225f3-fd8e-43e0-9e9b-25f07ec9ee1c.png)

limits on the length of file names
![image](https://user-images.githubusercontent.com/1351531/219523343-41c0b9ed-8b4d-4087-b888-f5737ff60180.png)

## Are there any deployment considerations?

No