### PR TITLE
temporarily disable migration during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,30 +8,30 @@ on:
             - 'deploy/**'
             - '.github/workflows/deploy.yml'
 jobs:
-    migrate-database:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-            - name: Setup Go
-              uses: actions/setup-go@v3
-              with:
-                  go-version-file: 'backend/go.mod'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v1
-            - name: Migrate database
-              run: |
-                  cd backend/
-                  make migrate
-              env:
-                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+    # migrate-database:
+    #     runs-on: ubuntu-latest
+    #     steps:
+    #         - name: Checkout
+    #           uses: actions/checkout@v3
+    #         - name: Setup Go
+    #           uses: actions/setup-go@v3
+    #           with:
+    #               go-version-file: 'backend/go.mod'
+    #         - name: Install Doppler CLI
+    #           uses: dopplerhq/cli-action@v1
+    #         - name: Migrate database
+    #           run: |
+    #               cd backend/
+    #               make migrate
+    #           env:
+    #               DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
 
-            - name: Run Stoat Action
-              uses: stoat-dev/stoat-action@v0
-              if: always()
+    #         - name: Run Stoat Action
+    #           uses: stoat-dev/stoat-action@v0
+    #           if: always()
 
     deploy-session-delete-lambdas:
-        needs: migrate-database
+        # needs: migrate-database
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -121,7 +121,7 @@ jobs:
               if: always()
 
     deploy-digest-lambdas:
-        needs: migrate-database
+        # needs: migrate-database
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -187,7 +187,7 @@ jobs:
               if: always()
 
     deploy_backend:
-        needs: migrate-database
+        # needs: migrate-database
         runs-on: buildjet-2vcpu-ubuntu-2204-arm
         steps:
             - name: Check out the repo


### PR DESCRIPTION
## Summary
- disabling this migration step to avoid DB blocking while we migrate our DB to another instance
- GORM automigrate would run a few `ALTER TABLE ALTER COLUMN` commands - this is fixed in newer versions of GORM, but there are some other issues happening in our code base with the newest GORM v1 release
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will keep monitoring prod
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, will revert this once DB instance migration is complete 
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
