### PR TITLE
omit empty error instance stacktrace

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -141,12 +141,12 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						excMessage := castString(eventAttributes[string(semconv.ExceptionMessageKey)], "")
 						stackTrace := castString(eventAttributes[string(semconv.ExceptionStacktraceKey)], "")
 						errorUrl := castString(eventAttributes[highlight.ErrorURLKey], "")
-						if stackTrace == "" {
+						if excType == "" && excMessage == "" {
+							log.WithContext(ctx).WithField("Span", span).WithField("EventAttributes", eventAttributes).Error("otel received exception with no type and no message")
+							continue
+						} else if stackTrace == "" || stackTrace == "null" {
 							log.WithContext(ctx).WithField("Span", span).WithField("EventAttributes", eventAttributes).Warn("otel received exception with no stacktrace")
-							continue
-						} else if excType == "" && excMessage == "" {
-							log.WithContext(ctx).WithField("Span", span).WithField("EventAttributes", eventAttributes).Warn("otel received exception with no type and no message")
-							continue
+							stackTrace = ""
 						}
 						stackTrace = formatStructureStackTrace(ctx, stackTrace)
 						err := &model.BackendErrorObjectInput{

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -232,7 +232,8 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 		)
 	}
 
-	const errorObject = errorInstance?.error_object
+	const errorObject =
+		errorInstance.error_object as ErrorInstanceType['error_object']
 
 	return (
 		<Box id="error-instance-container">
@@ -350,16 +351,22 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 					</>
 				)}
 
-			<Text size="large" weight="bold">
-				Stack trace
-			</Text>
-			<Box bt="secondary" mt="12" pt="16">
-				<ErrorStackTrace
-					errorObject={
-						errorObject as ErrorInstanceType['error_object']
-					}
-				/>
-			</Box>
+			{(errorObject.stack_trace !== '' &&
+				errorObject.stack_trace !== 'null') ||
+			errorObject.structured_stack_trace?.length ? (
+				<>
+					<Text size="large" weight="bold">
+						Stack trace
+					</Text>
+					<Box bt="secondary" mt="12" pt="16">
+						<ErrorStackTrace
+							errorObject={
+								errorObject as ErrorInstanceType['error_object']
+							}
+						/>
+					</Box>
+				</>
+			) : null}
 		</Box>
 	)
 }


### PR DESCRIPTION
## Summary

If a stacktrace is empty on an error instance, omit it in the frontend.

## How did you test this change?

Local deploy manipulating stacktrace to be `"null"` or `""`

## Are there any deployment considerations?

No
