### PR TITLE
add JSON validation for allowed_auto_join_email_origins

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -954,6 +954,10 @@ func (r *mutationResolver) UpdateAllowedEmailOrigins(ctx context.Context, worksp
 		return nil, e.Wrap(err, "error retrieving admin user")
 	}
 
+	if !json.Valid([]byte(allowedAutoJoinEmailOrigins)) {
+		return nil, e.Wrap(err, "allowedAutoJoinEmailOrigins is not valid JSON")
+	}
+
 	if err := r.DB.Model(&model.Workspace{Model: model.Model{ID: workspaceID}}).Updates(&model.Workspace{
 		AllowedAutoJoinEmailOrigins: &allowedAutoJoinEmailOrigins}).Error; err != nil {
 		return nil, e.Wrap(err, "error updating workspace")


### PR DESCRIPTION
## Summary
- had some invalid data break prod because some queries cast this column to jsonb when reading
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested different inputs to `json.Valid` in a Go sandbox, made sure this function worked locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
