### PR TITLE
#4310 disable session button and add callout when no session

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -482,7 +482,7 @@ const User: React.FC<{
 							aren't mapping errors to sessions.
 						</Text>
 					</Box>
-					<div style={{ height: 'fit-content' }}>
+					<Box display="flex">
 						<LinkButton
 							kind="secondary"
 							to="/setup/backend"
@@ -500,7 +500,7 @@ const User: React.FC<{
 						>
 							Learn more
 						</LinkButton>
-					</div>
+					</Box>
 				</Callout>
 			</Box>
 		)

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -4,6 +4,7 @@ import { Avatar } from '@components/Avatar/Avatar'
 import { Button } from '@components/Button'
 import JsonViewer from '@components/JsonViewer/JsonViewer'
 import { KeyboardShortcut } from '@components/KeyboardShortcut/KeyboardShortcut'
+import { LinkButton } from '@components/LinkButton'
 import LoadingBox from '@components/LoadingBox'
 import { Skeleton } from '@components/Skeleton/Skeleton'
 import {
@@ -18,6 +19,7 @@ import type {
 } from '@graph/schemas'
 import {
 	Box,
+	Callout,
 	Heading,
 	IconSolidExternalLink,
 	IconSolidPlay,
@@ -32,7 +34,6 @@ import {
 } from '@pages/Player/context/PlayerUIContext'
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import { Tab } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
-import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext'
 import {
 	getDisplayNameAndField,
 	getIdentifiedUserProfileImage,
@@ -294,7 +295,7 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 						<Button
 							kind="primary"
 							emphasis="high"
-							disabled={!isLoggedIn}
+							disabled={!isLoggedIn || !errorObject.session}
 							onClick={() => {
 								if (!isLoggedIn) {
 									return
@@ -463,11 +464,46 @@ const User: React.FC<{
 	const navigate = useNavigate()
 	const { projectId } = useProjectId()
 	const { isLoggedIn } = useAuthContext()
-	const { setSearchParams } = useSearchContext()
 	const [truncated, setTruncated] = useState(true)
 
 	if (!errorObject?.session) {
-		return null
+		return (
+			<Box width="full">
+				<Box pb="20" mt="12">
+					<Text weight="bold" size="large">
+						User details
+					</Text>
+				</Box>
+				<Callout title="We didn't find a session for this error">
+					<Box>
+						<Text size="small" weight="medium" color="moderate">
+							We weren't able to match this error to a session.
+							This error was either thrown in isolation or you
+							aren't mapping errors to sessions.
+						</Text>
+					</Box>
+					<div style={{ height: 'fit-content' }}>
+						<LinkButton
+							kind="secondary"
+							to="/setup/backend"
+							trackingId="error-mapping-setup"
+							target="_blank"
+						>
+							Backend SDK setup
+						</LinkButton>
+						<LinkButton
+							kind="secondary"
+							to="https://www.highlight.io/docs/getting-started/frontend-backend-mapping"
+							trackingId="error-mapping-docs"
+							emphasis="low"
+							target="_blank"
+						>
+							Learn more
+						</LinkButton>
+					</div>
+				</Callout>
+			</Box>
+		)
 	}
 
 	const { session } = errorObject


### PR DESCRIPTION
## Summary
<img width="499" alt="Screen Shot 2023-02-22 at 11 58 27 AM" src="https://user-images.githubusercontent.com/86132398/220749640-c60f3875-0ce2-4f63-aa86-0d5f3c825cb9.png">

- Julianified design for errors w/o a session
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally, made sure errors with sessions are displayed properly
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
