### PR TITLE
expand nested json in logs

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -8,6 +8,7 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	flat "github.com/nqd/flat"
 	e "github.com/pkg/errors"
 )
 
@@ -74,16 +75,11 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 			return nil, err
 		}
 
-		gqlLogAttributes := make(map[string]interface{}, len(LogAttributes))
-		for i, v := range LogAttributes {
-			gqlLogAttributes[i] = v
-		}
-
 		logLines = append(logLines, &modelInputs.LogLine{
 			Timestamp:     Timestamp,
 			SeverityText:  makeSeverityText(SeverityText),
 			Body:          Body,
-			LogAttributes: gqlLogAttributes,
+			LogAttributes: expandJSON(LogAttributes),
 		})
 	}
 	rows.Close()
@@ -306,4 +302,18 @@ func splitQuery(query string) []string {
 
 func unquoteAndTrim(s string) string {
 	return strings.ReplaceAll(strings.Trim(s, " "), "'", "")
+}
+
+func expandJSON(logAttributes map[string]string) map[string]interface{} {
+	gqlLogAttributes := make(map[string]interface{}, len(logAttributes))
+	for i, v := range logAttributes {
+		gqlLogAttributes[i] = v
+	}
+
+	out, err := flat.Unflatten(gqlLogAttributes, nil)
+	if err != nil {
+		return gqlLogAttributes
+	}
+
+	return out
 }

--- a/backend/clickhouse/seeds/main.go
+++ b/backend/clickhouse/seeds/main.go
@@ -39,7 +39,7 @@ func makeRandomBody() string {
 }
 
 func makeRandLogAttributes() map[string]string {
-	randomKeys := [20]string{
+	randomKeys := [21]string{
 		"key1",
 		"key2",
 		"key3",
@@ -60,6 +60,7 @@ func makeRandLogAttributes() map[string]string {
 		"key18",
 		"key19",
 		"key20",
+		"nested.log",
 	}
 
 	randomVals := [20]string{

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -124,6 +124,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hasura/go-graphql-client v0.9.0 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -216,6 +217,7 @@ require (
 	github.com/jinzhu/now v1.1.3 // indirect
 	github.com/klauspost/compress v1.15.15 // indirect
 	github.com/leonelquinteros/hubspot v0.1.0
+	github.com/nqd/flat v0.2.0
 	github.com/philhofer/fwd v1.1.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -871,6 +871,7 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imkira/go-interpol v1.1.0 h1:KIiKr0VSG2CUW1hl1jpiyuzuJeKUUpC8iM1AIE7N1Vk=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
@@ -1154,6 +1155,8 @@ github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86w
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:ncO5VaFWh0Nrt+4KT4mOZboaczBZcLuHrG+/sUeP8gI=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nqd/flat v0.2.0 h1:g6lXtMxsxrz6PZOO+rNnAJUn/GGRrK4FgVEhy/v+cHI=
+github.com/nqd/flat v0.2.0/go.mod h1:FOuslZmNY082wVfVUUb7qAGWKl8z8Nor9FMg+Xj2Nss=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We need to expand flatted json when fetching logs.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Test setup
While I added nested json to the seeds script, it's probably easier to test via:

```sql
TRUNCATE logs;
```

make the following diff locally:
```diff
diff --git a/backend/clickhouse/seeds/main.go b/backend/clickhouse/seeds/main.go
index 9d552cea1..1525e618f 100644
--- a/backend/clickhouse/seeds/main.go
+++ b/backend/clickhouse/seeds/main.go
@@ -39,27 +39,7 @@ func makeRandomBody() string {
 }
 
 func makeRandLogAttributes() map[string]string {
-       randomKeys := [21]string{
-               "key1",
-               "key2",
-               "key3",
-               "key4",
-               "key5",
-               "key6",
-               "key7",
-               "key8",
-               "key9",
-               "key10",
-               "key11",
-               "key12",
-               "key13",
-               "key14",
-               "key15",
-               "key16",
-               "key17",
-               "key18",
-               "key19",
-               "key20",
+       randomKeys := [1]string{
                "nested.log.key",
        }
```

Re-run seeds with `doppler run -- go run backend/clickhouse/seeds/main.go`


Confirmed that nested json is correctly expanded in the output:
![Screenshot 2023-02-22 at 1 52 13 PM](https://user-images.githubusercontent.com/58678/220756305-99904f8d-f41a-48fd-93e8-d65e36a120d8.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
