### PR TITLE
fix serialiazation issue for frontend log lines

### DIFF
--- a/sdk/highlight-go/log/console_messages_parser.go
+++ b/sdk/highlight-go/log/console_messages_parser.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Trace struct {
-	ColumnNumber string `json:"columnNumber"`
-	LineNumber   string `json:"lineNumber"`
+	ColumnNumber any    `json:"columnNumber"`
+	LineNumber   any    `json:"lineNumber"`
 	FileName     string `json:"fileName"`
 	FunctionName string `json:"functionName,omitempty"`
 	Source       string `json:"source"`

--- a/sdk/highlight-go/log/log.go
+++ b/sdk/highlight-go/log/log.go
@@ -84,9 +84,31 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 				semconv.CodeFunctionKey.String(traceEnd.FunctionName),
 				semconv.CodeNamespaceKey.String(traceEnd.Source),
 				semconv.CodeFilepathKey.String(traceEnd.FileName),
-				semconv.CodeLineNumberKey.String(traceEnd.LineNumber),
-				semconv.CodeColumnKey.String(traceEnd.ColumnNumber),
 			)
+
+			var ln int
+			if x, ok := traceEnd.LineNumber.(int); ok {
+				ln = x
+			} else if x, ok := traceEnd.LineNumber.(string); ok {
+				if i, err := strconv.ParseInt(x, 10, 32); err == nil {
+					ln = int(i)
+				}
+			}
+			if ln != 0 {
+				attrs = append(attrs, semconv.CodeLineNumberKey.Int(ln))
+			}
+
+			var cn int
+			if x, ok := traceEnd.ColumnNumber.(int); ok {
+				cn = x
+			} else if x, ok := traceEnd.ColumnNumber.(string); ok {
+				if i, err := strconv.ParseInt(x, 10, 32); err == nil {
+					cn = int(i)
+				}
+			}
+			if cn != 0 {
+				attrs = append(attrs, semconv.CodeColumnKey.Int(cn))
+			}
 		}
 
 		span.AddEvent(LogName, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(row.Time)))


### PR DESCRIPTION
## Summary

Column / Line number can come as int or string. Ensure they are parsed as an int.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

No
