### PR TITLE
ensure sdk types built first before frontend

### DIFF
--- a/sdk/highlight-cloudflare/package.json
+++ b/sdk/highlight-cloudflare/package.json
@@ -6,7 +6,8 @@
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",
 	"scripts": {
-		"build": "tsup src/index.ts --format cjs,esm --dts --clean"
+		"typegen": "tsup src/index.ts --dts-only",
+		"build": "tsup src/index.ts --format cjs,esm --dts"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -13,7 +13,8 @@
 		}
 	},
 	"scripts": {
-		"build": "tsup src/index.ts --format cjs,esm --dts --clean",
+		"typegen": "tsup src/index.ts --dts-only",
+		"build": "tsup src/index.ts --format cjs,esm --dts",
 		"test": "jest"
 	},
 	"author": "",

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -14,7 +14,8 @@
 	},
 	"scripts": {
 		"codegen": "graphql-codegen --config codegen.yml",
-		"build": "tsup src/index.ts --format cjs,esm --dts --clean",
+		"typegen": "tsup src/index.ts --dts-only",
+		"build": "tsup src/index.ts --format cjs,esm --dts",
 		"test": "jest"
 	},
 	"publishConfig": {

--- a/sdk/highlight-react/package.json
+++ b/sdk/highlight-react/package.json
@@ -11,7 +11,8 @@
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",
 	"scripts": {
-		"build": "tsup src/index.tsx --format cjs,esm --dts --clean",
+		"typegen": "tsup src/index.tsx --dts-only",
+		"build": "tsup src/index.tsx --format cjs,esm --dts",
 		"dev": "yarn build --watch"
 	},
 	"devDependencies": {

--- a/sourcemap-uploader/package.json
+++ b/sourcemap-uploader/package.json
@@ -21,7 +21,8 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts src/lib.ts --format cjs,esm --dts --clean"
+    "typegen": "tsup src/index.ts src/lib.ts --dts-only",
+    "build": "tsup src/index.ts src/lib.ts --format cjs,esm --dts"
   },
   "devDependencies": {
     "@types/commander": "^2.12.2",


### PR DESCRIPTION
## Summary

Makes our packages using tsup consistently implement a `typegen` script that will be used by turborepo in the right order.

## How did you test this change?

Local `yarn test:all`

## Are there any deployment considerations?

No. Could bump versions, but this change does not actually affect the npmjs packaged files (just affects our CI build ordering)
