### PR TITLE
update git submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "rrweb"]
 	path = rrweb
-	url = git@github.com:highlight-run/rrweb.git
+	url = https://github.com/highlight/rrweb.git


### PR DESCRIPTION
## Summary

`.gitmodules` pointed to old repository url (referencing old org name) which currently 301s but may break in the future.

## How did you test this change?

Local `git submodule init --update`; CI

## Are there any deployment considerations?

No