### PR TITLE
fix quoting logic for filters

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -294,16 +294,16 @@ func splitQuery(query string) []string {
 	inquote := false
 	i := 0
 	for j, c := range query {
-		if c == '\'' {
+		if c == '"' {
 			inquote = !inquote
 		} else if c == ' ' && !inquote {
 			result = append(result, unquoteAndTrim(query[i:j]))
-			i = j + i
+			i = j + 1
 		}
 	}
 	return append(result, unquoteAndTrim(query[i:]))
 }
 
 func unquoteAndTrim(s string) string {
-	return strings.ReplaceAll(strings.Trim(s, " "), "'", "")
+	return strings.ReplaceAll(strings.Trim(s, " "), `"`, "")
 }

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -117,9 +117,13 @@ func TestReadLogsWithKeyFilter(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		{
-			Timestamp:     now,
-			ProjectId:     1,
-			LogAttributes: map[string]string{"service": "image processor"},
+			Timestamp: now,
+			ProjectId: 1,
+			LogAttributes: map[string]string{
+				"service":      "image processor",
+				"workspace_id": "1",
+				"user_id":      "1",
+			},
 		},
 	}
 
@@ -134,7 +138,7 @@ func TestReadLogsWithKeyFilter(t *testing.T) {
 
 	logs, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
-		Query:     "service:'image processor'",
+		Query:     `service:"image processor"`,
 	})
 	assert.NoError(t, err)
 	assert.Len(t, logs, 1)
@@ -142,6 +146,13 @@ func TestReadLogsWithKeyFilter(t *testing.T) {
 	logs, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "service:*mage*",
+	})
+	assert.NoError(t, err)
+	assert.Len(t, logs, 1)
+
+	logs, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "service:image* workspace_id:1 user_id:1",
 	})
 	assert.NoError(t, err)
 	assert.Len(t, logs, 1)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR solves two things:
* Fix our quoting logic that results in a panic with multiple filters (#4359)
* Changes the quote delimiter from single quote (`'`) to double quote (`"`). Per a conversation with @ccschmitz, the latter seems more logical to support (and matches the way datadog works).

Fixes #4359

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

I red/greened this with a unit test.

I also click tested the query from #4359 to validate there is no panic error anymore:
![Screenshot 2023-02-22 at 3 32 27 PM](https://user-images.githubusercontent.com/58678/220775193-55e22451-9b6f-41fb-a5f8-e235027b7bf8.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
