### PR TITLE
standardize highlight context variable attribute names

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -40,24 +40,20 @@ func castString(v interface{}, fallback string) string {
 }
 
 func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestID, source *string) {
-	if p, ok := attrs[highlight.ProjectIDAttribute]; ok {
-		if v, _ := p.(string); v != "" {
-			*projectID = v
-		}
-	}
-	if s, ok := attrs[highlight.SessionIDAttribute]; ok {
-		if v, _ := s.(string); v != "" {
-			*sessionID = v
-		}
-	}
-	if r, ok := attrs[highlight.RequestIDAttribute]; ok {
-		if v, _ := r.(string); v != "" {
-			*requestID = v
-		}
-	}
-	if src, ok := attrs[highlight.SourceAttribute]; ok {
-		if v, _ := src.(string); v != "" {
-			*source = v
+	for k, ptr := range map[string]*string{
+		highlight.DeprecatedProjectIDAttribute: projectID,
+		highlight.DeprecatedSessionIDAttribute: sessionID,
+		highlight.DeprecatedRequestIDAttribute: requestID,
+		highlight.DeprecatedSourceAttribute:    source,
+		highlight.ProjectIDAttribute:           projectID,
+		highlight.SessionIDAttribute:           sessionID,
+		highlight.RequestIDAttribute:           requestID,
+		highlight.SourceAttribute:              source,
+	} {
+		if p, ok := attrs[k]; ok {
+			if v, _ := p.(string); v != "" {
+				*ptr = v
+			}
 		}
 	}
 }
@@ -77,6 +73,11 @@ func projectToInt(projectID string) (int, error) {
 func getAttributesMaps(resourceAttributes, eventAttributes map[string]any) (map[string]string, map[string]string) {
 	resourceAttributesMap := make(map[string]string)
 	for k, v := range resourceAttributes {
+		for _, attr := range highlight.InternalAttributes {
+			if k == attr {
+				continue
+			}
+		}
 		vStr := castString(v, "")
 		if vStr != "" {
 			resourceAttributesMap[k] = castString(v, "")
@@ -84,11 +85,15 @@ func getAttributesMaps(resourceAttributes, eventAttributes map[string]any) (map[
 	}
 	logAttributesMap := make(map[string]string)
 	for k, v := range eventAttributes {
-		vStr := castString(v, "")
-		if vStr == "" || k == string(hlog.LogMessageKey) || k == string(hlog.LogSeverityKey) {
-			continue
+		for _, attr := range highlight.InternalAttributes {
+			if k == attr {
+				continue
+			}
 		}
-		logAttributesMap[k] = castString(v, "")
+		vStr := castString(v, "")
+		if vStr != "" {
+			logAttributesMap[k] = castString(v, "")
+		}
 	}
 	return resourceAttributesMap, logAttributesMap
 }
@@ -194,7 +199,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 
 						func() {
 							excType := castString(eventAttributes[string(semconv.ExceptionTypeKey)], source)
-							errorUrl := castString(eventAttributes[highlight.ErrorURLKey], "")
+							errorUrl := castString(eventAttributes[highlight.ErrorURLAttribute], "")
 							stackTrace := castString(eventAttributes[string(semconv.ExceptionStacktraceKey)], "")
 							if excType == "" && excMessage == "" {
 								log.WithContext(ctx).WithField("Span", span).WithField("EventAttributes", eventAttributes).Error("otel received exception with no type and no message")

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -40,7 +40,7 @@ func castString(v interface{}, fallback string) string {
 }
 
 func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestID, source *string) {
-	for k, ptr := range map[string]*string{
+	ptrs := map[string]*string{
 		highlight.DeprecatedProjectIDAttribute: projectID,
 		highlight.DeprecatedSessionIDAttribute: sessionID,
 		highlight.DeprecatedRequestIDAttribute: requestID,
@@ -49,10 +49,20 @@ func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestI
 		highlight.SessionIDAttribute:           sessionID,
 		highlight.RequestIDAttribute:           requestID,
 		highlight.SourceAttribute:              source,
+	}
+	for _, k := range []string{
+		highlight.DeprecatedProjectIDAttribute,
+		highlight.DeprecatedSessionIDAttribute,
+		highlight.DeprecatedRequestIDAttribute,
+		highlight.DeprecatedSourceAttribute,
+		highlight.ProjectIDAttribute,
+		highlight.SessionIDAttribute,
+		highlight.RequestIDAttribute,
+		highlight.SourceAttribute,
 	} {
 		if p, ok := attrs[k]; ok {
 			if v, _ := p.(string); v != "" {
-				*ptr = v
+				*ptrs[k] = v
 			}
 		}
 	}

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -243,7 +243,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 						}()
-					} else if event.Name() == hlog.LogName {
+					} else if event.Name() == highlight.LogEvent {
 						logSev := castString(eventAttributes[string(hlog.LogSeverityKey)], "unknown")
 						logMessage := castString(eventAttributes[string(hlog.LogMessageKey)], "")
 						if logMessage == "" {

--- a/e2e/go/go.mod
+++ b/e2e/go/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/gofiber/fiber/v2 v2.42.0
 	github.com/highlight/highlight/sdk/highlight-go v0.9.1
+	github.com/pkg/errors v0.9.1
 )
 
 require (
@@ -22,7 +23,6 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/savsgio/dictpool v0.0.0-20221023140959-7bf2e61cea94 // indirect
 	github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d // indirect

--- a/sdk/highlight-cloudflare/package.json
+++ b/sdk/highlight-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/cloudflare",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"packageManager": "yarn@3.2.3",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-cloudflare/src/sdk.ts
+++ b/sdk/highlight-cloudflare/src/sdk.ts
@@ -55,9 +55,9 @@ export const H: HighlightInterface = {
 				url: `${endpoints.default}/v1/logs`,
 			}),
 			resource: new Resource({
-				highlight_project_id: projectID,
-				highlight_session_id: sessionID,
-				highlight_trace_id: requestID,
+				['highlight.project_id']: projectID,
+				['highlight.session_id']: sessionID,
+				['highlight.trace_id']: requestID,
 			}),
 		})
 	},

--- a/sdk/highlight-go/log/log.go
+++ b/sdk/highlight-go/log/log.go
@@ -13,9 +13,8 @@ import (
 )
 
 var (
-	LogName        = "log"
-	LogSeverityKey = attribute.Key("log.severity")
-	LogMessageKey  = attribute.Key("log.message")
+	LogSeverityKey = attribute.Key(highlight.LogSeverityAttribute)
+	LogMessageKey  = attribute.Key(highlight.LogMessageAttribute)
 )
 
 type VercelProxy struct {
@@ -111,7 +110,7 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 			}
 		}
 
-		span.AddEvent(LogName, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(row.Time)))
+		span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(row.Time)))
 		if row.Type == "error" {
 			span.SetStatus(codes.Error, message)
 		}
@@ -141,7 +140,7 @@ func submitVercelLog(ctx context.Context, projectID int, log VercelLog) {
 		semconv.HTTPMethodKey.Int64(log.StatusCode),
 	)
 
-	span.AddEvent(LogName, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(log.Timestamp)))
+	span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(log.Timestamp)))
 	if log.Type == "error" {
 		span.SetStatus(codes.Error, log.Message)
 	}

--- a/sdk/highlight-go/log/logrus.go
+++ b/sdk/highlight-go/log/logrus.go
@@ -88,7 +88,7 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 		}
 	}
 
-	span.AddEvent(LogName, trace.WithAttributes(attrs...))
+	span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...))
 
 	if entry.Level <= hook.errorStatusLevel {
 		span.SetStatus(codes.Error, entry.Message)

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -32,6 +32,10 @@ const SessionIDAttribute = "highlight.session_id"
 const RequestIDAttribute = "highlight.trace_id"
 const SourceAttribute = "highlight.source"
 
+const LogEvent = "log"
+const LogSeverityAttribute = "log.severity"
+const LogMessageAttribute = "log.message"
+
 var InternalAttributes = []string{
 	DeprecatedProjectIDAttribute,
 	DeprecatedSessionIDAttribute,

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -3,7 +3,6 @@ package highlight
 import (
 	"context"
 	"fmt"
-	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -45,8 +44,8 @@ var InternalAttributes = []string{
 	SessionIDAttribute,
 	RequestIDAttribute,
 	SourceAttribute,
-	string(hlog.LogMessageKey),
-	string(hlog.LogSeverityKey),
+	LogMessageAttribute,
+	LogSeverityAttribute,
 }
 
 type OTLP struct {

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "Client for interfacing with Highlight in next.js",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -114,9 +114,9 @@ export class Highlight {
 		}
 		span.recordException(error)
 		span.setAttributes({
-			highlight_project_id: this._projectID,
-			highlight_session_id: secureSessionId,
-			highlight_trace_id: requestId,
+			['highlight.project_id']: this._projectID,
+			['highlight.session_id']: secureSessionId,
+			['highlight.trace_id']: requestId,
 		})
 		if (spanCreated) {
 			span.end()

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -100,9 +100,9 @@ class H(object):
         :return: None
         """
         with self.tracer.start_as_current_span("highlight-ctx") as span:
-            span.set_attributes({"highlight_project_id": self._project_id})
-            span.set_attributes({"highlight_session_id": session_id})
-            span.set_attributes({"highlight_trace_id": request_id})
+            span.set_attributes({"highlight.project_id": self._project_id})
+            span.set_attributes({"highlight.session_id": session_id})
+            span.set_attributes({"highlight.trace_id": request_id})
             try:
                 yield
             except Exception as e:

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.3.0"
+version = "0.3.1"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary

Standardizes highlight otel attribute names to be more consistent with otel conventions.

## How did you test this change?

Local deploy running e2e examples of our sdks.

## Are there any deployment considerations?

New SDK versions.
Ingest will support deprecated attribute names, favoring the new ones.