### PR TITLE
filter out empty strings when fetching values for a key

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -148,6 +148,7 @@ func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName 
 	query := sq.Select("LogAttributes[?] as value, count() as cnt").
 		From("logs").
 		Where(sq.Eq{"ProjectId": projectID}).
+		Where("mapContains(LogAttributes, ?)", keyName).
 		GroupBy("value").
 		OrderBy("cnt DESC").
 		Limit(50)

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -232,6 +232,11 @@ func TestLogKeyValues(t *testing.T) {
 			ProjectId:     1,
 			LogAttributes: map[string]string{"workspace_id": "4"},
 		},
+		{
+			Timestamp:     time.Now(),
+			ProjectId:     1,
+			LogAttributes: map[string]string{"unrelated_key": "value"},
+		},
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We can get an empty string when fetching key values. 

Example:

```sql
CREATE TABLE table_map (a Map(String, String)) ENGINE=Memory;
INSERT INTO table_map VALUES ({'foo':'bar'})
INSERT INTO table_map VALUES ({'baz':'buzz'})
```

```sql
SELECT a['foo'] as value, count() as cnt FROM table_map
GROUP BY value
ORDER BY cnt DESC
```

| value | count |
|-------|-------|
|       | 1     |
| bar   | 1     |

This is seems to be because of some weird clickhouse quirk whereby the `baz` row is saying I have nothing that matches the `a['foo']` column. We can filter it out with a `mapContains`

```
SELECT a['foo'] as value, count() as cnt FROM table_map
where mapContains(a, 'foo')
GROUP BY value
ORDER BY cnt DESC
```

| value | count |
|-------|-------|
| bar   | 1     |


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Unit tests FTW

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A