### PR TITLE
initialize alert emails to what was already saved to prevent them from being cleared on save

### DIFF
--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -83,7 +83,9 @@ export const AlertConfigurationCard = ({
 		getFrequencyOption(alert?.Frequency).value,
 	)
 	const [isDisabled, setIsDisabled] = useState(alert?.disabled || false)
-	const [emailsToNotify, setEmailsToNotify] = useState<string[]>([])
+	const [emailsToNotify, setEmailsToNotify] = useState<string[]>(
+		alert?.EmailsToNotify || [],
+	)
 	const [selectedDiscordChannels, setSelectedDiscordChannels] = useState<
 		DiscordChannel[]
 	>(alert?.DiscordChannelsToNotify || [])


### PR DESCRIPTION
## Summary
- if a user edited any of the other alert fields without editing the "emails to notify", the emails would be cleared
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click test locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
