### PR TITLE
hotfix: commandbar polish

### DIFF
--- a/frontend/src/components/CommandBar/CommandBar.tsx
+++ b/frontend/src/components/CommandBar/CommandBar.tsx
@@ -107,6 +107,7 @@ const CommandBar = () => {
 		'cmd+k, ctrl+k, /',
 		(e) => {
 			e.preventDefault()
+			form.reset()
 			setCurrentAttribute(ATTRIBUTES[0])
 			commandBarDialog.toggle()
 		},

--- a/frontend/src/components/CommandBar/CommandBar.tsx
+++ b/frontend/src/components/CommandBar/CommandBar.tsx
@@ -85,18 +85,17 @@ const CommandBar = () => {
 	const containerRef = useRef<HTMLDivElement>(null)
 	const query = form.getValue<string>(form.names.search)
 	const selectedDates = form.getValue<[Date, Date]>(form.names.selectedDates)
-	const [currentAttribute, setCurrentAttributeImpl] = useState<
-		Attribute | undefined
-	>(undefined)
+	const [currentAttribute, setCurrentAttributeImpl] = useState<Attribute>(
+		ATTRIBUTES[0],
+	)
 
-	const setCurrentAttribute = (row: Attribute | undefined) =>
-		setCurrentAttributeImpl(row)
+	const setCurrentAttribute = (row: Attribute) => setCurrentAttributeImpl(row)
 
 	const searchAttribute = useAttributeSearch(form)
 
 	form.useSubmit(() => {
 		if (query) {
-			searchAttribute(currentAttribute ?? ATTRIBUTES[0], {
+			searchAttribute(currentAttribute, {
 				withDate:
 					selectedDates[0].getTime() !==
 					last30Days.startDate.getTime(),
@@ -108,7 +107,7 @@ const CommandBar = () => {
 		'cmd+k, ctrl+k, /',
 		(e) => {
 			e.preventDefault()
-			setCurrentAttribute(undefined)
+			setCurrentAttribute(ATTRIBUTES[0])
 			commandBarDialog.toggle()
 		},
 		[],
@@ -145,11 +144,6 @@ const CommandBar = () => {
 				onClick={(e) => {
 					if (!isInsideElement(e.nativeEvent, containerRef.current)) {
 						commandBarDialog.hide()
-					}
-				}}
-				onMouseMove={(e) => {
-					if (!isInsideElement(e.nativeEvent, containerRef.current)) {
-						setCurrentAttribute(undefined)
 					}
 				}}
 			>
@@ -231,15 +225,12 @@ const SearchBar = ({ form }: { form: FormState<CommandBarSearch> }) => {
 								if (e.code === 'Enter') {
 									e.preventDefault()
 									if (e.metaKey || e.ctrlKey) {
-										searchAttribute(
-											currentAttribute ?? ATTRIBUTES[0],
-											{
-												newTab: true,
-												withDate:
-													selectedDates[0].getTime() !==
-													last30Days.startDate.getTime(),
-											},
-										)
+										searchAttribute(currentAttribute, {
+											newTab: true,
+											withDate:
+												selectedDates[0].getTime() !==
+												last30Days.startDate.getTime(),
+										})
 									} else {
 										form.submit()
 									}
@@ -353,6 +344,15 @@ const SectionRow = ({
 			>
 				{form.getValue(form.names.search)}
 			</Text>
+			{selected ? (
+				<Badge
+					shape="basic"
+					size="small"
+					variant="outlineGray"
+					label="Enter"
+					ml="auto"
+				/>
+			) : null}
 		</Box>
 	)
 }

--- a/frontend/src/components/CommandBar/context.ts
+++ b/frontend/src/components/CommandBar/context.ts
@@ -57,8 +57,8 @@ export const ATTRIBUTES = [
 export type Attribute = typeof ATTRIBUTES[number]
 
 interface CommandBarContext {
-	currentAttribute: Attribute | undefined
-	setCurrentAttribute: (row: Attribute | undefined) => void
+	currentAttribute: Attribute
+	setCurrentAttribute: (row: Attribute) => void
 	form: FormState<CommandBarSearch>
 }
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->
Jay's suggestions:

1. At least one option is always selected, which avoids the confusion about the behavior on `enter` press with no explicit selection.
2. Adds `enter` hint for the selected option.

![Screenshot 2023-02-24 at 3 45 42 PM](https://user-images.githubusercontent.com/17913919/221288061-f95f9f2f-4894-40f0-8a1c-79ece2d654e3.jpg)


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
cmd-k or /
## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no