### PR TITLE
Polish for logs view

### DIFF
--- a/backend/clickhouse/seeds/main.go
+++ b/backend/clickhouse/seeds/main.go
@@ -60,7 +60,7 @@ func makeRandLogAttributes() map[string]string {
 		"key18",
 		"key19",
 		"key20",
-		"nested.log",
+		"deeply.nested.log.value",
 	}
 
 	randomVals := [20]string{

--- a/frontend/src/pages/LogsPage/LogsTable/LogBody.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogBody.tsx
@@ -16,6 +16,7 @@ const LogBody = ({ body, expanded, query }: Props) => {
 			weight="bold"
 			family="monospace"
 			lines={expanded ? undefined : '1'}
+			break="word"
 		>
 			<TextHighlighter searchWords={searchWords} textToHighlight={body} />
 		</Text>

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.css.ts
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.css.ts
@@ -1,0 +1,9 @@
+import { style } from '@vanilla-extract/css'
+
+export const line = style({
+	selectors: {
+		'& &': {
+			paddingLeft: 22,
+		},
+	},
+})

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -129,8 +129,8 @@ const LogDetailsObject: React.FC<{
 	let stringIsJson = false
 	if (typeof attribute === 'string') {
 		try {
-			JSON.parse(attribute)
-			stringIsJson = true
+			const parsedJson = JSON.parse(attribute)
+			stringIsJson = typeof parsedJson === 'object'
 		} catch {}
 	}
 

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -135,11 +135,7 @@ const LogDetailsObject: React.FC<{
 	const isObject = typeof attribute === 'object' || stringIsJson
 
 	useEffect(() => {
-		if (open && !allExpanded) {
-			setOpen(false)
-		}
-		// Only want to fire when allExpanded changes
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+		setOpen(allExpanded)
 	}, [allExpanded])
 
 	return isObject ? (
@@ -159,7 +155,7 @@ const LogDetailsObject: React.FC<{
 				</Box>
 			</LogAttributeLine>
 
-			{(open || allExpanded) &&
+			{open &&
 				Object.keys(attribute).map((key, index) => (
 					<LogDetailsObject
 						key={index}
@@ -181,10 +177,12 @@ const LogValue: React.FC<{ label: string; value: string }> = ({
 	value,
 }) => (
 	<LogAttributeLine>
-		<Text family="monospace" weight="bold">
-			"{label}":
-		</Text>
-		<Text family="monospace" weight="bold" color="caution">
+		<Box flexShrink={0}>
+			<Text family="monospace" weight="bold">
+				"{label}":
+			</Text>
+		</Box>
+		<Text family="monospace" weight="bold" color="caution" break="word">
 			{value}
 		</Text>
 	</LogAttributeLine>
@@ -194,7 +192,7 @@ const LogAttributeLine: React.FC<React.PropsWithChildren> = ({ children }) => {
 	return (
 		<Box
 			display="flex"
-			alignItems="center"
+			alignItems="flex-start"
 			flexDirection="row"
 			gap="10"
 			py="8"

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -22,7 +22,11 @@ type Props = {
 
 export const LogDetails = ({ row }: Props) => {
 	const [allExpanded, setAllExpanded] = useState(false)
+	const { logAttributes } = row.original
 	const expanded = row.getIsExpanded()
+	const expandable = Object.values(logAttributes).some(
+		(v) => typeof v === 'object',
+	)
 
 	if (!expanded) {
 		return null
@@ -30,11 +34,8 @@ export const LogDetails = ({ row }: Props) => {
 
 	return (
 		<Stack p="6" paddingBottom="0" gap="1" paddingLeft="16">
-			{Object.keys(row.original.logAttributes).map((key, index) => {
-				const value =
-					row.original.logAttributes[
-						key as keyof typeof row.original.logAttributes
-					]
+			{Object.keys(logAttributes).map((key, index) => {
+				const value = logAttributes[key as keyof typeof logAttributes]
 				const isObject = typeof value === 'object'
 
 				return (
@@ -59,31 +60,33 @@ export const LogDetails = ({ row }: Props) => {
 				gap="16"
 				my="10"
 			>
-				<ButtonLink
-					kind="secondary"
-					onClick={(e) => {
-						e.stopPropagation()
-						setAllExpanded(!allExpanded)
-					}}
-				>
-					<Box
-						alignItems="center"
-						display="flex"
-						flexDirection="row"
-						gap="4"
+				{expandable && (
+					<ButtonLink
+						kind="secondary"
+						onClick={(e) => {
+							e.stopPropagation()
+							setAllExpanded(!allExpanded)
+						}}
 					>
-						{allExpanded ? (
-							<>
-								<IconSolidChevronDoubleUp /> Collapse all
-							</>
-						) : (
-							<>
-								<IconSolidChevronDoubleDown />
-								Expand all
-							</>
-						)}
-					</Box>
-				</ButtonLink>
+						<Box
+							alignItems="center"
+							display="flex"
+							flexDirection="row"
+							gap="4"
+						>
+							{allExpanded ? (
+								<>
+									<IconSolidChevronDoubleUp /> Collapse all
+								</>
+							) : (
+								<>
+									<IconSolidChevronDoubleDown />
+									Expand all
+								</>
+							)}
+						</Box>
+					</ButtonLink>
+				)}
 
 				<ButtonLink
 					kind="secondary"

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -1,0 +1,200 @@
+import { LogLine } from '@graph/schemas'
+import {
+	Box,
+	ButtonLink,
+	IconSolidCheveronDown,
+	IconSolidCheveronRight,
+	IconSolidChevronDoubleDown,
+	IconSolidChevronDoubleUp,
+	IconSolidClipboard,
+	Stack,
+	Text,
+} from '@highlight-run/ui'
+import { Row } from '@tanstack/react-table'
+import { message } from 'antd'
+import React, { useEffect, useState } from 'react'
+
+import * as styles from './LogDetails.css'
+
+type Props = {
+	row: Row<LogLine>
+}
+
+export const LogDetails = ({ row }: Props) => {
+	const [allExpanded, setAllExpanded] = useState(false)
+	const expanded = row.getIsExpanded()
+
+	if (!expanded) {
+		return null
+	}
+
+	return (
+		<Stack p="6" paddingBottom="0" gap="1" paddingLeft="16">
+			{Object.keys(row.original.logAttributes).map((key, index) => {
+				const value =
+					row.original.logAttributes[
+						key as keyof typeof row.original.logAttributes
+					]
+				const isObject = typeof value === 'object'
+
+				return (
+					<Box key={index}>
+						{isObject ? (
+							<LogDetailsObject
+								allExpanded={allExpanded}
+								attribute={value}
+								label={key}
+							/>
+						) : (
+							<LogValue label={key} value={value} />
+						)}
+					</Box>
+				)
+			})}
+
+			<Box
+				display="flex"
+				alignItems="center"
+				flexDirection="row"
+				gap="16"
+				my="10"
+			>
+				<ButtonLink
+					kind="secondary"
+					onClick={(e) => {
+						e.stopPropagation()
+						setAllExpanded(!allExpanded)
+					}}
+				>
+					<Box
+						alignItems="center"
+						display="flex"
+						flexDirection="row"
+						gap="4"
+					>
+						{allExpanded ? (
+							<>
+								<IconSolidChevronDoubleUp />{' '}
+								<Text color="weak">Collapse all</Text>
+							</>
+						) : (
+							<>
+								<IconSolidChevronDoubleDown />
+								<Text color="weak">Expand all</Text>
+							</>
+						)}
+					</Box>
+				</ButtonLink>
+
+				<ButtonLink
+					kind="secondary"
+					onClick={(e) => {
+						e.stopPropagation()
+						navigator.clipboard.writeText(
+							JSON.stringify(row.original),
+						)
+						message.success('Copied logs!')
+					}}
+				>
+					<Box
+						display="flex"
+						alignItems="center"
+						flexDirection="row"
+						gap="4"
+					>
+						<IconSolidClipboard />
+						Copy
+					</Box>
+				</ButtonLink>
+			</Box>
+		</Stack>
+	)
+}
+
+const LogDetailsObject: React.FC<{
+	allExpanded: boolean
+	attribute: string | object
+	label: string
+}> = ({ allExpanded, attribute, label }) => {
+	const [open, setOpen] = useState(false)
+
+	let stringIsJson = false
+	if (typeof attribute === 'string') {
+		try {
+			JSON.parse(attribute)
+			stringIsJson = true
+		} catch {}
+	}
+
+	const isObject = typeof attribute === 'object' || stringIsJson
+
+	useEffect(() => {
+		if (open && !allExpanded) {
+			setOpen(false)
+		}
+		// Only want to fire when allExpanded changes
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [allExpanded])
+
+	return isObject ? (
+		<Box
+			cssClass={styles.line}
+			onClick={(e) => {
+				e.stopPropagation()
+				setOpen(!open)
+			}}
+		>
+			<LogAttributeLine>
+				{open ? <IconSolidCheveronDown /> : <IconSolidCheveronRight />}
+				<Box>
+					<Text color="weak" family="monospace" weight="bold">
+						{label}
+					</Text>
+				</Box>
+			</LogAttributeLine>
+
+			{(open || allExpanded) &&
+				Object.keys(attribute).map((key, index) => (
+					<LogDetailsObject
+						key={index}
+						allExpanded={allExpanded}
+						attribute={attribute[key as keyof typeof attribute]}
+						label={key}
+					/>
+				))}
+		</Box>
+	) : (
+		<Box cssClass={styles.line}>
+			<LogValue label={label} value={attribute} />
+		</Box>
+	)
+}
+
+const LogValue: React.FC<{ label: string; value: string }> = ({
+	label,
+	value,
+}) => (
+	<LogAttributeLine>
+		<Text family="monospace" weight="bold">
+			"{label}":
+		</Text>
+		<Text family="monospace" weight="bold" color="caution">
+			{value}
+		</Text>
+	</LogAttributeLine>
+)
+
+const LogAttributeLine: React.FC<React.PropsWithChildren> = ({ children }) => {
+	return (
+		<Box
+			display="flex"
+			alignItems="center"
+			flexDirection="row"
+			gap="10"
+			py="8"
+			flexShrink={0}
+		>
+			{children}
+		</Box>
+	)
+}

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -74,13 +74,12 @@ export const LogDetails = ({ row }: Props) => {
 					>
 						{allExpanded ? (
 							<>
-								<IconSolidChevronDoubleUp />{' '}
-								<Text color="weak">Collapse all</Text>
+								<IconSolidChevronDoubleUp /> Collapse all
 							</>
 						) : (
 							<>
 								<IconSolidChevronDoubleDown />
-								<Text color="weak">Expand all</Text>
+								Expand all
 							</>
 						)}
 					</Box>

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -192,7 +192,7 @@ const LogAttributeLine: React.FC<React.PropsWithChildren> = ({ children }) => {
 	return (
 		<Box
 			display="flex"
-			alignItems="flex-start"
+			alignItems="center"
 			flexDirection="row"
 			gap="10"
 			py="8"

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -2,14 +2,16 @@ import { LogLine } from '@graph/schemas'
 import {
 	Box,
 	ButtonLink,
-	IconSolidCheveronDown,
-	IconSolidCheveronRight,
 	IconSolidChevronDoubleDown,
 	IconSolidChevronDoubleUp,
 	IconSolidClipboard,
 	Stack,
 	Text,
 } from '@highlight-run/ui'
+import {
+	IconCollapsed,
+	IconExpanded,
+} from '@pages/LogsPage/LogsTable/LogsTable'
 import { Row } from '@tanstack/react-table'
 import { message } from 'antd'
 import React, { useEffect, useState } from 'react'
@@ -37,7 +39,7 @@ export const LogDetails = ({ row }: Props) => {
 	}
 
 	return (
-		<Stack p="6" paddingBottom="0" gap="1" paddingLeft="16">
+		<Stack py="6" paddingBottom="0" gap="1">
 			{Object.keys(logAttributes).map((key, index) => {
 				const value = logAttributes[key as keyof typeof logAttributes]
 				const isObject = typeof value === 'object'
@@ -147,7 +149,7 @@ const LogDetailsObject: React.FC<{
 			}}
 		>
 			<LogAttributeLine>
-				{open ? <IconSolidCheveronDown /> : <IconSolidCheveronRight />}
+				{open ? <IconExpanded /> : <IconCollapsed />}
 				<Box>
 					<Text color="weak" family="monospace" weight="bold">
 						{label}
@@ -195,7 +197,7 @@ const LogAttributeLine: React.FC<React.PropsWithChildren> = ({ children }) => {
 			alignItems="center"
 			flexDirection="row"
 			gap="10"
-			py="8"
+			py="6"
 			flexShrink={0}
 		>
 			{children}

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -29,6 +29,10 @@ export const LogDetails = ({ row }: Props) => {
 	)
 
 	if (!expanded) {
+		if (allExpanded) {
+			setAllExpanded(false)
+		}
+
 		return null
 	}
 

--- a/frontend/src/pages/LogsPage/LogsTable/LogTimestamp.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogTimestamp.tsx
@@ -3,13 +3,11 @@ import React from 'react'
 
 const toYearMonthDay = (timestamp: string) => {
 	const date = new Date(timestamp)
-	const dateString = date
-		.toLocaleDateString('en-US', {
-			year: 'numeric',
-			month: '2-digit',
-			day: '2-digit',
-		})
-		.replaceAll('/', '-')
+	const dateString = date.toLocaleDateString('en-US', {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	})
 	const timeString = date.toLocaleTimeString('en-US', {
 		hour12: false,
 	})

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.css.ts
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.css.ts
@@ -3,7 +3,8 @@ import { style } from '@vanilla-extract/css'
 
 export const row = style({
 	borderRadius: 6,
-	padding: '6px 8px',
+	padding: '8px 8px 8px 28px',
+	position: 'relative',
 	selectors: {
 		'&:hover': {
 			backgroundColor: vars.theme.interactive.overlay.secondary.hover,
@@ -19,7 +20,10 @@ export const rowExpanded = style({
 })
 
 export const expandIcon = style({
+	left: 8,
 	opacity: 0,
+	position: 'absolute',
+	top: 5,
 	selectors: {
 		[`${row}:hover &`]: {
 			opacity: 1,

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.css.ts
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.css.ts
@@ -17,3 +17,15 @@ export const row = style({
 export const rowExpanded = style({
 	background: vars.theme.interactive.overlay.secondary.pressed,
 })
+
+export const expandIcon = style({
+	opacity: 0,
+	selectors: {
+		[`${row}:hover &`]: {
+			opacity: 1,
+		},
+		[`${rowExpanded} &`]: {
+			opacity: 1,
+		},
+	},
+})

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -146,8 +146,9 @@ const LogsTable = ({ data, loading, query }: Props) => {
 						key={row.id}
 						cursor="pointer"
 						onClick={row.getToggleExpandedHandler()}
+						mb="1"
 					>
-						<Stack direction="row" align="center">
+						<Stack direction="row" align="flex-start">
 							{row.getVisibleCells().map((cell) => {
 								return (
 									<Fragment key={cell.id}>

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -21,7 +21,7 @@ import {
 	useReactTable,
 } from '@tanstack/react-table'
 import clsx from 'clsx'
-import React, { Fragment, useState } from 'react'
+import React, { Fragment, useEffect, useState } from 'react'
 
 import * as styles from './LogsTable.css'
 
@@ -103,6 +103,11 @@ const LogsTable = ({ data, loading, query }: Props) => {
 		getExpandedRowModel: getExpandedRowModel(),
 		debugTable: true,
 	})
+
+	useEffect(() => {
+		// Collapse all rows when search changes
+		table.toggleAllRowsExpanded(false)
+	}, [logs])
 
 	if (loading) {
 		return (

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -47,7 +47,11 @@ const LogsTable = ({ data, loading, query }: Props) => {
 						gap="6"
 					>
 						{row.getCanExpand() && (
-							<Box display="flex" alignItems="center">
+							<Box
+								display="flex"
+								alignItems="center"
+								cssClass={styles.expandIcon}
+							>
 								{row.getIsExpanded() ? (
 									<IconSolidCheveronDown />
 								) : (

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -6,9 +6,9 @@ import {
 	IconSolidCheveronDown,
 	IconSolidCheveronRight,
 	Stack,
-	Text,
 } from '@highlight-run/ui'
 import { LogBody } from '@pages/LogsPage/LogsTable/LogBody'
+import { LogDetails } from '@pages/LogsPage/LogsTable/LogDetails'
 import { LogSeverityText } from '@pages/LogsPage/LogsTable/LogSeverityText'
 import { LogTimestamp } from '@pages/LogsPage/LogsTable/LogTimestamp'
 import { NoLogsFound } from '@pages/LogsPage/LogsTable/NoLogsFound'
@@ -18,7 +18,6 @@ import {
 	flexRender,
 	getCoreRowModel,
 	getExpandedRowModel,
-	Row,
 	useReactTable,
 } from '@tanstack/react-table'
 import clsx from 'clsx'
@@ -30,41 +29,6 @@ type Props = {
 	loading: boolean
 	data: GetLogsQuery | undefined
 	query: string
-}
-
-const renderSubComponent = ({ row }: { row: Row<LogLine> }) => {
-	return (
-		<Stack p="6" paddingBottom="0" gap="1">
-			{Object.keys(row.original.logAttributes).map((key, index) => {
-				const value =
-					row.original.logAttributes[
-						key as keyof typeof row.original.logAttributes
-					]
-				const isString = typeof value === 'string'
-				const color = isString ? 'caution' : 'informative'
-
-				return (
-					<Box
-						key={index}
-						display="flex"
-						alignItems="center"
-						flexDirection="row"
-						gap="10"
-						py="8"
-						flexShrink={0}
-					>
-						<Text family="monospace" weight="bold">
-							"{key}":
-						</Text>
-
-						<Text family="monospace" weight="bold" color={color}>
-							{JSON.stringify(value)}
-						</Text>
-					</Box>
-				)
-			})}
-		</Stack>
-	)
 }
 
 const LogsTable = ({ data, loading, query }: Props) => {
@@ -187,9 +151,7 @@ const LogsTable = ({ data, loading, query }: Props) => {
 							})}
 						</Stack>
 
-						{row.getIsExpanded() && (
-							<Box>{renderSubComponent({ row })}</Box>
-						)}
+						<LogDetails row={row} />
 					</Box>
 				)
 			})}

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -31,7 +31,7 @@ type Props = {
 	query: string
 }
 
-const LogsTable = ({ data, loading, query }: Props) => {
+export const LogsTable = ({ data, loading, query }: Props) => {
 	const [expanded, setExpanded] = useState<ExpandedState>({})
 
 	const columns = React.useMemo<ColumnDef<LogLine>[]>(
@@ -43,19 +43,19 @@ const LogsTable = ({ data, loading, query }: Props) => {
 						flexShrink={0}
 						flexDirection="row"
 						display="flex"
-						alignItems="center"
+						alignItems="flex-start"
 						gap="6"
 					>
 						{row.getCanExpand() && (
 							<Box
 								display="flex"
-								alignItems="center"
+								alignItems="flex-start"
 								cssClass={styles.expandIcon}
 							>
 								{row.getIsExpanded() ? (
-									<IconSolidCheveronDown />
+									<IconExpanded />
 								) : (
-									<IconSolidCheveronRight />
+									<IconCollapsed />
 								)}
 							</Box>
 						)}
@@ -169,4 +169,10 @@ const LogsTable = ({ data, loading, query }: Props) => {
 	)
 }
 
-export { LogsTable }
+export const IconExpanded: React.FC = () => (
+	<IconSolidCheveronDown color="#6F6E77" size="16" />
+)
+
+export const IconCollapsed: React.FC = () => (
+	<IconSolidCheveronRight color="#6F6E77" size="16" />
+)

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.css.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.css.ts
@@ -40,6 +40,7 @@ export const comboboxPopover = style({
 })
 
 export const comboboxItem = style({
+	cursor: 'pointer',
 	padding: '12px 10px',
 	selectors: {
 		'&:hover': {

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -17,6 +17,7 @@ import {
 } from '@highlight-run/ui'
 import { useProjectId } from '@hooks/useProjectId'
 import {
+	BODY_KEY,
 	LogsSearchParam,
 	parseLogsQuery,
 	stringifyLogsQuery,
@@ -112,21 +113,20 @@ const Search: React.FC<{
 	const cursorIndex = inputRef.current?.selectionStart || 0
 	const activeTermIndex = getActiveTermIndex(cursorIndex, queryTerms)
 	const activeTerm = queryTerms[activeTermIndex]
-
 	const showValues =
-		activeTerm.key !== 'text' ||
+		activeTerm.key !== BODY_KEY ||
 		!!keys?.find((k) => k.name === activeTerm.key)
 	const loading = keys?.length === 0 || (showValues && valuesLoading)
-
-	const activeTermKeys = queryTerms.map((term) => term.key)
-	keys = keys?.filter((key) => activeTermKeys.indexOf(key.name) === -1)
+	const showTermSelect = showValues && activeTerm.value.length
 
 	const visibleItems = showValues
 		? getVisibleValues(activeTerm, data?.logs_key_values)
-		: getVisibleKeys(query, activeTerm, keys)
+		: getVisibleKeys(query, queryTerms, activeTerm, keys)
 
 	// Limit number of items shown
 	visibleItems.length = Math.min(MAX_ITEMS, visibleItems.length)
+
+	const showResults = loading || visibleItems.length > 0 || showTermSelect
 
 	useEffect(() => {
 		if (!showValues) {
@@ -195,7 +195,7 @@ const Search: React.FC<{
 				onBlur={formState.submit}
 			/>
 
-			{(loading || visibleItems.length > 0) && (
+			{showResults && (
 				<Combobox.Popover
 					className={styles.comboboxPopover}
 					state={state}
@@ -206,6 +206,17 @@ const Search: React.FC<{
 							state={state}
 						>
 							<Combobox.GroupLabel state={state}>
+								{showValues && activeTerm.value && (
+									<Combobox.Item
+										className={styles.comboboxItem}
+										onClick={() =>
+											handleItemSelect(activeTerm.value)
+										}
+										state={state}
+									>
+										<Text>{activeTerm.value}</Text>
+									</Combobox.Item>
+								)}
 								<Box px="10" py="6">
 									<Text size="xSmall" color="weak">
 										Filters
@@ -321,32 +332,45 @@ const getActiveTermIndex = (
 
 const getVisibleKeys = (
 	queryText: string,
-	activeTerm: LogsSearchParam,
+	queryTerms: LogsSearchParam[],
+	activeQueryTerm: LogsSearchParam,
 	keys?: GetLogsKeysQuery['logs_keys'],
 ) => {
 	const startingNewTerm = queryText.endsWith(' ')
+	const activeTermKeys = queryTerms.map((term) => term.key)
+	keys = keys?.filter((key) => activeTermKeys.indexOf(key.name) === -1)
 
 	return (
 		keys?.filter(
 			(key) =>
+				// If it's a new term, don't filter results.
 				startingNewTerm ||
-				(activeTerm.key === 'text' &&
-					(!activeTerm.value.length ||
+				// Only filter for body queries
+				(activeQueryTerm.key === BODY_KEY &&
+					// Don't filter if no query term
+					(!activeQueryTerm.value.length ||
 						startingNewTerm ||
-						key.name.indexOf(activeTerm.value) > -1)),
+						// Filter empty results
+						(key.name.length > 0 &&
+							// Only show results that contain the term
+							key.name.indexOf(activeQueryTerm.value) > -1))),
 		) || []
 	)
 }
 
-const getVisibleValues = (activeTerm: LogsSearchParam, values?: string[]) => {
-	const filteredValues =
+const getVisibleValues = (
+	activeQueryTerm: LogsSearchParam,
+	values?: string[],
+) => {
+	return (
 		values?.filter(
-			(v) => !activeTerm.value.length || v.indexOf(activeTerm.value) > -1,
+			(v) =>
+				// Don't filter if no value has been typed
+				!activeQueryTerm.value.length ||
+				// Exclude the current term since that is given special treatment
+				(v !== activeQueryTerm.value &&
+					// Return values that match the query term
+					v.indexOf(activeQueryTerm.value) > -1),
 		) || []
-
-	if (values?.indexOf(activeTerm.value) === -1) {
-		filteredValues.unshift(activeTerm.value)
-	}
-
-	return filteredValues
+	)
 }

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -117,7 +117,7 @@ const Search: React.FC<{
 		activeTerm.key !== BODY_KEY ||
 		!!keys?.find((k) => k.name === activeTerm.key)
 	const loading = keys?.length === 0 || (showValues && valuesLoading)
-	const showTermSelect = showValues && activeTerm.value.length
+	const showTermSelect = activeTerm.value.length
 
 	const visibleItems = showValues
 		? getVisibleValues(activeTerm, data?.logs_key_values)
@@ -206,7 +206,7 @@ const Search: React.FC<{
 							state={state}
 						>
 							<Combobox.GroupLabel state={state}>
-								{showValues && activeTerm.value && (
+								{activeTerm.value && (
 									<Combobox.Item
 										className={styles.comboboxItem}
 										onClick={() =>
@@ -214,7 +214,12 @@ const Search: React.FC<{
 										}
 										state={state}
 									>
-										<Text>{activeTerm.value}</Text>
+										<Stack direction="row" gap="8">
+											<Text>{activeTerm.value}:</Text>{' '}
+											<Text color="weak">
+												{activeTerm.key ?? 'Body'}
+											</Text>
+										</Stack>
 									</Combobox.Item>
 								)}
 								<Box px="10" py="6">

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -5,8 +5,8 @@ import {
 	Box,
 	Combobox,
 	Form,
-	IconSolidArrowsExpand,
 	IconSolidSearch,
+	IconSolidSwitchVertical,
 	Preset,
 	PreviousDateRangePicker,
 	Stack,
@@ -101,6 +101,7 @@ const Search: React.FC<{
 	keys?: GetLogsKeysQuery['logs_keys']
 }> = ({ keys }) => {
 	const formState = useForm()
+	const [autoSelect, setAutoSelect] = useState(true)
 	const { query } = formState.values
 	const { project_id } = useParams()
 	const containerRef = useRef<HTMLDivElement | null>(null)
@@ -176,23 +177,32 @@ const Search: React.FC<{
 			<IconSolidSearch className={styles.searchIcon} />
 
 			<Combobox
-				autoSelect
+				autoSelect={autoSelect}
 				ref={inputRef}
 				state={state}
 				name="search"
 				placeholder="Search your logs..."
 				value={query}
 				onChange={(e) => {
-					formState.setValue('query', e.target.value)
-					state.setOpen(true)
+					const value = e.target.value
+					formState.setValue('query', value)
 
-					if (state.items.length) {
-						state.setActiveId(state.items[0].id)
+					if (!state.open) {
+						state.setOpen(true)
+					}
+
+					if (value === '' && autoSelect) {
+						setAutoSelect(false)
+					} else if (value !== '' && !autoSelect) {
+						setAutoSelect(true)
 					}
 				}}
 				className={styles.combobox}
 				setValueOnChange={false}
-				onBlur={formState.submit}
+				onBlur={() => {
+					formState.submit()
+					setAutoSelect(true)
+				}}
 			/>
 
 			{showResults && (
@@ -277,7 +287,7 @@ const Search: React.FC<{
 								<Badge
 									variant="gray"
 									size="small"
-									iconStart={<IconSolidArrowsExpand />}
+									iconStart={<IconSolidSwitchVertical />}
 								/>{' '}
 								<Text color="weak" size="xSmall">
 									Select
@@ -295,7 +305,7 @@ const Search: React.FC<{
 									label="Enter"
 								/>
 								<Text color="weak" size="xSmall">
-									Open
+									Select
 								</Text>
 							</Box>
 						</Box>

--- a/packages/ui/src/components/ButtonLink/ButtonLink.tsx
+++ b/packages/ui/src/components/ButtonLink/ButtonLink.tsx
@@ -3,12 +3,21 @@ import { Button as AriakitButton, ButtonProps } from 'ariakit/button'
 import { Text } from '../Text/Text'
 
 import * as styles from './styles.css'
+import clsx from 'clsx'
 
-type Props = React.PropsWithChildren & ButtonProps
+type Props = React.PropsWithChildren & ButtonProps & styles.Variants
 
-export const ButtonLink: React.FC<Props> = ({ children, ...buttonProps }) => {
+export const ButtonLink: React.FC<Props> = ({
+	children,
+	kind,
+	...buttonProps
+}) => {
 	return (
-		<AriakitButton as="button" className={styles.button} {...buttonProps}>
+		<AriakitButton
+			as="button"
+			className={clsx(styles.button, styles.variants({ kind }))}
+			{...buttonProps}
+		>
 			<Text>{children}</Text>
 		</AriakitButton>
 	)

--- a/packages/ui/src/components/ButtonLink/styles.css.ts
+++ b/packages/ui/src/components/ButtonLink/styles.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css'
+import { recipe, RecipeVariants } from '@vanilla-extract/recipes'
 import { vars } from '../../css/vars'
 
 export const button = style({
@@ -6,13 +7,40 @@ export const button = style({
 	border: 0,
 	cursor: 'pointer',
 	padding: 0,
-	color: vars.theme.interactive.fill.primary.enabled,
-	selectors: {
-		'&:hover': {
-			color: vars.theme.interactive.fill.primary.hover,
-		},
-		'&:active': {
-			color: vars.theme.interactive.fill.primary.pressed,
+})
+
+export const variants = recipe({
+	variants: {
+		kind: {
+			primary: {
+				color: vars.theme.interactive.fill.primary.enabled,
+				selectors: {
+					'&:hover': {
+						color: vars.theme.interactive.fill.primary.hover,
+					},
+					'&:active': {
+						color: vars.theme.interactive.fill.primary.pressed,
+					},
+				},
+			},
+
+			secondary: {
+				color: vars.theme.interactive.fill.secondary.enabled,
+				selectors: {
+					'&:hover': {
+						color: vars.theme.interactive.fill.secondary.hover,
+					},
+					'&:active': {
+						color: vars.theme.interactive.fill.secondary.pressed,
+					},
+				},
+			},
 		},
 	},
+
+	defaultVariants: {
+		kind: 'primary',
+	},
 })
+
+export type Variants = RecipeVariants<typeof variants>

--- a/packages/ui/src/components/ButtonLink/styles.css.ts
+++ b/packages/ui/src/components/ButtonLink/styles.css.ts
@@ -25,13 +25,15 @@ export const variants = recipe({
 			},
 
 			secondary: {
-				color: vars.theme.interactive.fill.secondary.enabled,
+				color: vars.theme.interactive.fill.secondary.content.text,
 				selectors: {
 					'&:hover': {
-						color: vars.theme.interactive.fill.secondary.hover,
+						color: vars.theme.interactive.fill.secondary.content
+							.onEnabled,
 					},
 					'&:active': {
-						color: vars.theme.interactive.fill.secondary.pressed,
+						color: vars.theme.interactive.fill.secondary.content
+							.onEnabled,
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

* Some UI updates to better match what we have in Figma
* Adds a copy button to copy the raw log to your clipboard
* Adds a button to toggle all nested fields
* Adds some logic to collapse all rows when the search query changes
* Adds a `kind` prop to `ButtonLink` that allows creating button links that are gray instead of purple
* Fixes a display issue when logs have very long string values with no spaces

https://www.loom.com/share/a744874144484127845f78a4eab3d649

## How did you test this change?

Local and PR preview click test

## Are there any deployment considerations?

N/A