### PR TITLE
fix(#3997): container corners in session replay

### DIFF
--- a/frontend/src/pages/Player/styles.css.ts
+++ b/frontend/src/pages/Player/styles.css.ts
@@ -1,5 +1,6 @@
 import { vars } from '@highlight-run/ui'
 import { colors } from '@highlight-run/ui/src/css/colors'
+import { sprinkles } from '@highlight-run/ui/src/css/sprinkles.css'
 import { RIGHT_PANEL_WIDTH } from '@pages/Player/RightPlayerPanel/style.css'
 import { SESSION_FEED_LEFT_PANEL_WIDTH } from '@pages/Sessions/SessionsFeedV3/SessionFeedV3.css'
 import { style } from '@vanilla-extract/css'
@@ -53,11 +54,12 @@ export const rrwebPlayerWrapper = style({
 	width: '100%',
 })
 
-export const rrwebInnerWrapper = style({
-	border: `1px solid ${vars.theme.static.divider.weak}`,
-	borderRadius: 8,
-	boxShadow: vars.shadows.medium,
-})
+export const rrwebInnerWrapper = style([
+	sprinkles({
+		border: 'dividerWeak',
+		boxShadow: 'medium',
+	}),
+])
 
 export const playerCenterColumn = style({
 	alignItems: 'center',

--- a/frontend/src/pages/Player/styles.css.ts
+++ b/frontend/src/pages/Player/styles.css.ts
@@ -1,9 +1,9 @@
 import { vars } from '@highlight-run/ui'
+import { borders } from '@highlight-run/ui/src/css/borders'
 import { colors } from '@highlight-run/ui/src/css/colors'
-import { sprinkles } from '@highlight-run/ui/src/css/sprinkles.css'
 import { RIGHT_PANEL_WIDTH } from '@pages/Player/RightPlayerPanel/style.css'
 import { SESSION_FEED_LEFT_PANEL_WIDTH } from '@pages/Sessions/SessionsFeedV3/SessionFeedV3.css'
-import { style } from '@vanilla-extract/css'
+import { globalStyle, style } from '@vanilla-extract/css'
 
 export const PLAYER_PADDING = 8
 export const MIN_CENTER_COLUMN_WIDTH = 428
@@ -54,12 +54,12 @@ export const rrwebPlayerWrapper = style({
 	width: '100%',
 })
 
-export const rrwebInnerWrapper = style([
-	sprinkles({
-		border: 'dividerWeak',
-		boxShadow: 'medium',
-	}),
-])
+export const rrwebInnerWrapper = style({})
+globalStyle(`${rrwebInnerWrapper} iframe`, {
+	borderRadius: 4,
+	border: borders.dividerWeak,
+	boxShadow: vars.shadows.medium,
+})
 
 export const playerCenterColumn = style({
 	alignItems: 'center',


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Resolves #3997.

was

![Screenshot 2023-02-24 at 4 58 58 PM](https://user-images.githubusercontent.com/17913919/221301236-4dda9a78-1586-4805-b467-6e895df0821c.jpg)

going to be
![Screenshot 2023-02-24 at 5 18 29 PM](https://user-images.githubusercontent.com/17913919/221304124-a991853d-f507-464a-82d0-e01c7f2e37ba.jpg)





## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

local click test
## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no