### PR TITLE
Handle backward pagination and permalinking logs (backend)

### DIFF
--- a/backend/clickhouse/cursor.go
+++ b/backend/clickhouse/cursor.go
@@ -25,22 +25,23 @@ func getLogsConnection(edges []*modelInputs.LogEdge, pagination Pagination) *mod
 			hasNextPage = true
 			hasPreviousPage = true
 
-			edges = edges[1:]            // remove first
-			edges = edges[:len(edges)-1] // remove last
+			edges = edges[1 : len(edges)-1] // remove first and last
 		} else if len(edges) == LogsLimit+2 { // has forward pagination (not backwards)
 			hasNextPage = true
 			edges = edges[:len(edges)-1] // remove last
 		}
 
 	} else if pagination.After != nil && len(*pagination.After) > 1 {
+		hasPreviousPage = true // implicitly true because the passed in cursor should match
 		if len(edges) == LogsLimit+1 {
 			hasNextPage = len(edges) == LogsLimit+1
-			edges = edges[:LogsLimit]
+			edges = edges[:len(edges)-1]
 		}
 	} else if pagination.Before != nil && len(*pagination.Before) > 1 {
+		hasNextPage = true // implicitly true because the passed in cursor should match
 		if len(edges) == LogsLimit+1 {
 			hasPreviousPage = len(edges) == LogsLimit+1
-			edges = edges[1 : LogsLimit-1]
+			edges = edges[1 : len(edges)-1]
 		}
 	} else {
 		if len(edges) == LogsLimit+1 { // has forward page

--- a/backend/clickhouse/cursor_test.go
+++ b/backend/clickhouse/cursor_test.go
@@ -5,9 +5,230 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/smithy-go/ptr"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestGetConnectionAfter(t *testing.T) {
+	zeroEdges := []*modelInputs.LogEdge{}
+	oneEdge := []*modelInputs.LogEdge{
+		{
+			Cursor: "cursor",
+		},
+	}
+
+	manyEdges := []*modelInputs.LogEdge{}
+	for i := 1; i <= LogsLimit+1; i++ {
+		manyEdges = append(manyEdges, &modelInputs.LogEdge{
+			Cursor: "cursor",
+		})
+	}
+
+	connection := getLogsConnection(zeroEdges, Pagination{
+		After: ptr.String("cursor"),
+	})
+
+	assert.Equal(t, &modelInputs.LogsConnection{
+		Edges: zeroEdges,
+		PageInfo: &modelInputs.PageInfo{
+			HasNextPage:     false,
+			HasPreviousPage: true,
+			StartCursor:     "",
+			EndCursor:       "",
+		},
+	}, connection)
+
+	connection = getLogsConnection(oneEdge, Pagination{
+		After: ptr.String("cursor"),
+	})
+
+	assert.Equal(t, &modelInputs.LogsConnection{
+		Edges: oneEdge,
+		PageInfo: &modelInputs.PageInfo{
+			HasNextPage:     false,
+			HasPreviousPage: true,
+			StartCursor:     "cursor",
+			EndCursor:       "cursor",
+		},
+	}, connection)
+
+	connection = getLogsConnection(manyEdges, Pagination{
+		After: ptr.String("cursor"),
+	})
+
+	assert.Equal(t, &modelInputs.LogsConnection{
+		Edges: manyEdges[:100],
+		PageInfo: &modelInputs.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: true,
+			StartCursor:     "cursor",
+			EndCursor:       "cursor",
+		},
+	}, connection)
+}
+
+func TestGetConnectionBefore(t *testing.T) {
+	zeroEdges := []*modelInputs.LogEdge{}
+	oneEdge := []*modelInputs.LogEdge{
+		{
+			Cursor: "cursor",
+		},
+	}
+
+	manyEdges := []*modelInputs.LogEdge{}
+	for i := 1; i <= LogsLimit+1; i++ {
+		manyEdges = append(manyEdges, &modelInputs.LogEdge{
+			Cursor: "cursor",
+		})
+	}
+
+	connection := getLogsConnection(zeroEdges, Pagination{
+		Before: ptr.String("cursor"),
+	})
+
+	assert.Equal(t, &modelInputs.LogsConnection{
+		Edges: zeroEdges,
+		PageInfo: &modelInputs.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: false,
+			StartCursor:     "",
+			EndCursor:       "",
+		},
+	}, connection)
+
+	connection = getLogsConnection(oneEdge, Pagination{
+		Before: ptr.String("cursor"),
+	})
+
+	assert.Equal(t, &modelInputs.LogsConnection{
+		Edges: oneEdge,
+		PageInfo: &modelInputs.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: false,
+			StartCursor:     "cursor",
+			EndCursor:       "cursor",
+		},
+	}, connection)
+
+	connection = getLogsConnection(manyEdges, Pagination{
+		Before: ptr.String("cursor"),
+	})
+
+	assert.Equal(t, &modelInputs.LogsConnection{
+		Edges: manyEdges[1:100],
+		PageInfo: &modelInputs.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: true,
+			StartCursor:     "cursor",
+			EndCursor:       "cursor",
+		},
+	}, connection)
+}
+
+func TestGetConnectionAt(t *testing.T) {
+	zeroEdges := []*modelInputs.LogEdge{}
+	forwardAndBackwardsEdges := []*modelInputs.LogEdge{
+		{
+			Cursor: "cursor",
+		},
+	}
+
+	for i := 1; i <= LogsLimit+2; i++ {
+		forwardAndBackwardsEdges = append(forwardAndBackwardsEdges, &modelInputs.LogEdge{
+			Cursor: "cursor",
+		})
+	}
+
+	forwardEdgesOnly := []*modelInputs.LogEdge{
+		{
+			Cursor: "cursor",
+		},
+	}
+
+	for i := 1; i <= LogsLimit+1; i++ {
+		forwardEdgesOnly = append(forwardEdgesOnly, &modelInputs.LogEdge{
+			Cursor: "cursor",
+		})
+	}
+
+	connection := getLogsConnection(zeroEdges, Pagination{
+		At: ptr.String("cursor"),
+	})
+
+	assert.Equal(t, &modelInputs.LogsConnection{
+		Edges: zeroEdges,
+		PageInfo: &modelInputs.PageInfo{
+			HasNextPage:     false,
+			HasPreviousPage: false,
+			StartCursor:     "",
+			EndCursor:       "",
+		},
+	}, connection)
+
+	connection = getLogsConnection(forwardAndBackwardsEdges, Pagination{
+		At: ptr.String("cursor"),
+	})
+
+	assert.Equal(t, &modelInputs.LogsConnection{
+		Edges: forwardAndBackwardsEdges[1:102],
+		PageInfo: &modelInputs.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: true,
+			StartCursor:     "cursor",
+			EndCursor:       "cursor",
+		},
+	}, connection)
+
+	connection = getLogsConnection(forwardEdgesOnly, Pagination{
+		At: ptr.String("cursor"),
+	})
+
+	assert.Equal(t, &modelInputs.LogsConnection{
+		Edges: forwardEdgesOnly[0:101],
+		PageInfo: &modelInputs.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: false,
+			StartCursor:     "cursor",
+			EndCursor:       "cursor",
+		},
+	}, connection)
+
+}
+
+func TestGetConnectionNoPagination(t *testing.T) {
+	zeroEdges := []*modelInputs.LogEdge{}
+	manyEdges := []*modelInputs.LogEdge{}
+	for i := 1; i <= LogsLimit+1; i++ {
+		manyEdges = append(manyEdges, &modelInputs.LogEdge{
+			Cursor: "cursor",
+		})
+	}
+
+	connection := getLogsConnection(zeroEdges, Pagination{})
+
+	assert.Equal(t, &modelInputs.LogsConnection{
+		Edges: zeroEdges,
+		PageInfo: &modelInputs.PageInfo{
+			HasNextPage:     false,
+			HasPreviousPage: false,
+			StartCursor:     "",
+			EndCursor:       "",
+		},
+	}, connection)
+
+	connection = getLogsConnection(manyEdges, Pagination{})
+
+	assert.Equal(t, &modelInputs.LogsConnection{
+		Edges: manyEdges[:LogsLimit],
+		PageInfo: &modelInputs.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: false,
+			StartCursor:     "cursor",
+			EndCursor:       "cursor",
+		},
+	}, connection)
+}
 
 func TestEncodeDecode(t *testing.T) {
 	now := time.Now()

--- a/backend/clickhouse/cursor_test.go
+++ b/backend/clickhouse/cursor_test.go
@@ -43,7 +43,7 @@ func TestClickhouseDecode(t *testing.T) {
 
 	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 
 	cursor := payload.Edges[0].Cursor

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -89,7 +89,7 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 	sb := sqlbuilder.NewSelectBuilder()
 	var err error
 	var args []interface{}
-	selectStr := "Timestamp, UUID, SeverityText, Body, LogAttributes"
+	selectStr := "Timestamp, UUID, SeverityText, Body, LogAttributes, TraceId, SpanId, SecureSessionId"
 
 	if pagination.At != nil && len(*pagination.At) > 1 {
 		// Create a "window" around the cursor
@@ -123,8 +123,6 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 	}
 
 	sql, args := sb.Build()
-	test := sb.String()
-	fmt.Print(test)
 
 	rows, err := client.conn.Query(ctx, sql, args...)
 

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -61,7 +61,7 @@ func TestReadLogsWithTimeQuery(t *testing.T) {
 			StartDate: now.Add(-time.Hour * 2),
 			EndDate:   now.Add(-time.Hour * 1),
 		},
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 
 	assert.Len(t, payload.Edges, 0)
@@ -71,7 +71,7 @@ func TestReadLogsWithTimeQuery(t *testing.T) {
 			StartDate: now.Add(-time.Hour * 1),
 			EndDate:   now.Add(time.Hour * 1),
 		},
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 
 	assert.Len(t, payload.Edges, 1)
@@ -225,7 +225,7 @@ func TestReadLogsHasNextPage(t *testing.T) {
 	now := time.Now()
 	var rows []*LogRow
 
-	for i := 1; i <= Limit; i++ { // 100 is a hardcoded limit
+	for i := 1; i <= LogsLimit; i++ { // 100 is a hardcoded limit
 		rows = append(rows, &LogRow{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
 				Timestamp: now,
@@ -237,7 +237,7 @@ func TestReadLogsHasNextPage(t *testing.T) {
 
 	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 
 	assert.Len(t, payload.Edges, 100)
@@ -255,7 +255,7 @@ func TestReadLogsHasNextPage(t *testing.T) {
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 
 	assert.True(t, payload.PageInfo.HasNextPage)
@@ -297,7 +297,7 @@ func TestReadLogsAfterCursor(t *testing.T) {
 
 	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 3)
 
@@ -311,7 +311,9 @@ func TestReadLogsAfterCursor(t *testing.T) {
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
-	}, &secondCursor)
+	}, Pagination{
+		After: &secondCursor,
+	})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 
@@ -339,28 +341,28 @@ func TestReadLogsWithBodyFilter(t *testing.T) {
 	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "no match",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 0)
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "body", // direct match
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "od", // wildcard match
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "BODY", // case insensitive match
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 }
@@ -390,28 +392,28 @@ func TestReadLogsWithKeyFilter(t *testing.T) {
 	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "service:foo",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 0)
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     `service:"image processor"`,
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "service:*mage*",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "service:image* workspace_id:1 user_id:1",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 }
@@ -446,7 +448,7 @@ func TestReadLogsWithLevelFilter(t *testing.T) {
 	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "level:INFO",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 	assert.Equal(t, modelInputs.LogLevel("INFO"), payload.Edges[0].Node.Level)
@@ -454,7 +456,7 @@ func TestReadLogsWithLevelFilter(t *testing.T) {
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "level:*NF*",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 	assert.Equal(t, modelInputs.LogLevel("INFO"), payload.Edges[0].Node.Level)
@@ -462,7 +464,7 @@ func TestReadLogsWithLevelFilter(t *testing.T) {
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "level:WARN",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 0)
 }
@@ -497,7 +499,7 @@ func TestReadLogsWithSessionIdFilter(t *testing.T) {
 	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "secure_session_id:match",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 	assert.Equal(t, ptr.String("match"), payload.Edges[0].Node.SecureSessionID)
@@ -505,7 +507,7 @@ func TestReadLogsWithSessionIdFilter(t *testing.T) {
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "secure_session_id:*atc*",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 	assert.Equal(t, ptr.String("match"), payload.Edges[0].Node.SecureSessionID)
@@ -513,7 +515,7 @@ func TestReadLogsWithSessionIdFilter(t *testing.T) {
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "secure_session_id:no_match",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 0)
 }
@@ -548,7 +550,7 @@ func TestReadLogsWithSpanIdFilter(t *testing.T) {
 	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "span_id:match",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 	assert.Equal(t, ptr.String("match"), payload.Edges[0].Node.SpanID)
@@ -556,7 +558,7 @@ func TestReadLogsWithSpanIdFilter(t *testing.T) {
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "span_id:*atc*",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 	assert.Equal(t, ptr.String("match"), payload.Edges[0].Node.SpanID)
@@ -564,7 +566,7 @@ func TestReadLogsWithSpanIdFilter(t *testing.T) {
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "span_id:no_match",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 0)
 }
@@ -599,7 +601,7 @@ func TestReadLogsWithTraceIdFilter(t *testing.T) {
 	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "trace_id:match",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 	assert.Equal(t, ptr.String("match"), payload.Edges[0].Node.TraceID)
@@ -607,7 +609,7 @@ func TestReadLogsWithTraceIdFilter(t *testing.T) {
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "trace_id:*atc*",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 	assert.Equal(t, ptr.String("match"), payload.Edges[0].Node.TraceID)
@@ -615,7 +617,7 @@ func TestReadLogsWithTraceIdFilter(t *testing.T) {
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "trace_id:no_match",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 0)
 }

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -388,7 +388,11 @@ func TestReadLogsAtCursor(t *testing.T) {
 
 	rows := []*LogRow{}
 
-	for i := 1; i <= 500; i++ {
+	// LogsLimit+3 = 103
+	// 1 log not visible on the previous page
+	// 101 logs visible (50 before + 50 after + permalinked log)
+	// 1 log not visible on the next page
+	for i := 1; i <= LogsLimit+3; i++ {
 		rows = append(rows, &LogRow{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
 				Timestamp: now,

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -511,6 +511,11 @@ type ComplexityRoot struct {
 		Type func(childComplexity int) int
 	}
 
+	LogsConnection struct {
+		Edges    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
+	}
+
 	LogsHistogram struct {
 		Buckets    func(childComplexity int) int
 		TotalCount func(childComplexity int) int
@@ -524,11 +529,6 @@ type ComplexityRoot struct {
 	LogsHistogramBucketCount struct {
 		Count func(childComplexity int) int
 		Level func(childComplexity int) int
-	}
-
-	LogsPayload struct {
-		Edges    func(childComplexity int) int
-		PageInfo func(childComplexity int) int
 	}
 
 	Metric struct {
@@ -653,8 +653,10 @@ type ComplexityRoot struct {
 	}
 
 	PageInfo struct {
-		EndCursor   func(childComplexity int) int
-		HasNextPage func(childComplexity int) int
+		EndCursor       func(childComplexity int) int
+		HasNextPage     func(childComplexity int) int
+		HasPreviousPage func(childComplexity int) int
+		StartCursor     func(childComplexity int) int
 	}
 
 	Plan struct {
@@ -743,7 +745,7 @@ type ComplexityRoot struct {
 		JoinableWorkspaces           func(childComplexity int) int
 		LinearTeams                  func(childComplexity int, projectID int) int
 		LiveUsersCount               func(childComplexity int, projectID int) int
-		Logs                         func(childComplexity int, projectID int, params model.LogsParamsInput, after *string) int
+		Logs                         func(childComplexity int, projectID int, params model.LogsParamsInput, after *string, before *string, at *string) int
 		LogsHistogram                func(childComplexity int, projectID int, params model.LogsParamsInput) int
 		LogsKeyValues                func(childComplexity int, projectID int, keyName string, dateRange model.DateRangeRequiredInput) int
 		LogsKeys                     func(childComplexity int, projectID int) int
@@ -1359,7 +1361,7 @@ type QueryResolver interface {
 	SourcemapVersions(ctx context.Context, projectID int) ([]string, error)
 	OauthClientMetadata(ctx context.Context, clientID string) (*model.OAuthClient, error)
 	EmailOptOuts(ctx context.Context, token *string, adminID *int) ([]model.EmailOptOutCategory, error)
-	Logs(ctx context.Context, projectID int, params model.LogsParamsInput, after *string) (*model.LogsPayload, error)
+	Logs(ctx context.Context, projectID int, params model.LogsParamsInput, after *string, before *string, at *string) (*model.LogsConnection, error)
 	LogsTotalCount(ctx context.Context, projectID int, params model.LogsParamsInput) (uint64, error)
 	LogsHistogram(ctx context.Context, projectID int, params model.LogsParamsInput) (*model.LogsHistogram, error)
 	LogsKeys(ctx context.Context, projectID int) ([]*model.LogKey, error)
@@ -3433,6 +3435,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.LogKey.Type(childComplexity), true
 
+	case "LogsConnection.edges":
+		if e.complexity.LogsConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.LogsConnection.Edges(childComplexity), true
+
+	case "LogsConnection.pageInfo":
+		if e.complexity.LogsConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.LogsConnection.PageInfo(childComplexity), true
+
 	case "LogsHistogram.buckets":
 		if e.complexity.LogsHistogram.Buckets == nil {
 			break
@@ -3474,20 +3490,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.LogsHistogramBucketCount.Level(childComplexity), true
-
-	case "LogsPayload.edges":
-		if e.complexity.LogsPayload.Edges == nil {
-			break
-		}
-
-		return e.complexity.LogsPayload.Edges(childComplexity), true
-
-	case "LogsPayload.pageInfo":
-		if e.complexity.LogsPayload.PageInfo == nil {
-			break
-		}
-
-		return e.complexity.LogsPayload.PageInfo(childComplexity), true
 
 	case "Metric.name":
 		if e.complexity.Metric.Name == nil {
@@ -4527,6 +4529,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PageInfo.HasNextPage(childComplexity), true
 
+	case "PageInfo.hasPreviousPage":
+		if e.complexity.PageInfo.HasPreviousPage == nil {
+			break
+		}
+
+		return e.complexity.PageInfo.HasPreviousPage(childComplexity), true
+
+	case "PageInfo.startCursor":
+		if e.complexity.PageInfo.StartCursor == nil {
+			break
+		}
+
+		return e.complexity.PageInfo.StartCursor(childComplexity), true
+
 	case "Plan.errorsLimit":
 		if e.complexity.Plan.ErrorsLimit == nil {
 			break
@@ -5380,7 +5396,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Logs(childComplexity, args["project_id"].(int), args["params"].(model.LogsParamsInput), args["after"].(*string)), true
+		return e.complexity.Query.Logs(childComplexity, args["project_id"].(int), args["params"].(model.LogsParamsInput), args["after"].(*string), args["before"].(*string), args["at"].(*string)), true
 
 	case "Query.logs_histogram":
 		if e.complexity.Query.LogsHistogram == nil {
@@ -8236,10 +8252,12 @@ type LogEdge {
 
 type PageInfo {
 	hasNextPage: Boolean!
+	hasPreviousPage: Boolean!
+	startCursor: String!
 	endCursor: String!
 }
 
-type LogsPayload {
+type LogsConnection {
 	edges: [LogEdge!]!
 	pageInfo: PageInfo!
 }
@@ -9187,7 +9205,13 @@ type Query {
 	sourcemap_versions(project_id: ID!): [String!]!
 	oauth_client_metadata(client_id: String!): OAuthClient
 	email_opt_outs(token: String, admin_id: ID): [EmailOptOutCategory!]!
-	logs(project_id: ID!, params: LogsParamsInput!, after: String): LogsPayload!
+	logs(
+		project_id: ID!
+		params: LogsParamsInput!
+		after: String
+		before: String
+		at: String
+	): LogsConnection!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_histogram(project_id: ID!, params: LogsParamsInput!): LogsHistogram!
 	logs_keys(project_id: ID!): [LogKey!]!
@@ -13428,6 +13452,24 @@ func (ec *executionContext) field_Query_logs_args(ctx context.Context, rawArgs m
 		}
 	}
 	args["after"] = arg2
+	var arg3 *string
+	if tmp, ok := rawArgs["before"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+		arg3, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["before"] = arg3
+	var arg4 *string
+	if tmp, ok := rawArgs["at"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("at"))
+		arg4, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["at"] = arg4
 	return args, nil
 }
 
@@ -27462,6 +27504,110 @@ func (ec *executionContext) fieldContext_LogKey_type(ctx context.Context, field 
 	return fc, nil
 }
 
+func (ec *executionContext) _LogsConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.LogsConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LogsConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.LogEdge)
+	fc.Result = res
+	return ec.marshalNLogEdge2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LogsConnection_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LogsConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_LogEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_LogEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type LogEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LogsConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.LogsConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LogsConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LogsConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LogsConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _LogsHistogram_buckets(ctx context.Context, field graphql.CollectedField, obj *model.LogsHistogram) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_LogsHistogram_buckets(ctx, field)
 	if err != nil {
@@ -27733,106 +27879,6 @@ func (ec *executionContext) fieldContext_LogsHistogramBucketCount_level(ctx cont
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type LogLevel does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _LogsPayload_edges(ctx context.Context, field graphql.CollectedField, obj *model.LogsPayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_LogsPayload_edges(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Edges, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]*model.LogEdge)
-	fc.Result = res
-	return ec.marshalNLogEdge2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogEdgeᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_LogsPayload_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "LogsPayload",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "cursor":
-				return ec.fieldContext_LogEdge_cursor(ctx, field)
-			case "node":
-				return ec.fieldContext_LogEdge_node(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type LogEdge", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _LogsPayload_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.LogsPayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_LogsPayload_pageInfo(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.PageInfo, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.PageInfo)
-	fc.Result = res
-	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐPageInfo(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_LogsPayload_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "LogsPayload",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "hasNextPage":
-				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
-			case "endCursor":
-				return ec.fieldContext_PageInfo_endCursor(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
 		},
 	}
 	return fc, nil
@@ -33867,6 +33913,94 @@ func (ec *executionContext) fieldContext_PageInfo_hasNextPage(ctx context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PageInfo_hasPreviousPage(ctx context.Context, field graphql.CollectedField, obj *model.PageInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.HasPreviousPage, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PageInfo_hasPreviousPage(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PageInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PageInfo_startCursor(ctx context.Context, field graphql.CollectedField, obj *model.PageInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PageInfo_startCursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.StartCursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PageInfo_startCursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PageInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -42357,7 +42491,7 @@ func (ec *executionContext) _Query_logs(ctx context.Context, field graphql.Colle
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Logs(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.LogsParamsInput), fc.Args["after"].(*string))
+		return ec.resolvers.Query().Logs(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.LogsParamsInput), fc.Args["after"].(*string), fc.Args["before"].(*string), fc.Args["at"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -42368,9 +42502,9 @@ func (ec *executionContext) _Query_logs(ctx context.Context, field graphql.Colle
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.LogsPayload)
+	res := resTmp.(*model.LogsConnection)
 	fc.Result = res
-	return ec.marshalNLogsPayload2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogsPayload(ctx, field.Selections, res)
+	return ec.marshalNLogsConnection2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogsConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_logs(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -42382,11 +42516,11 @@ func (ec *executionContext) fieldContext_Query_logs(ctx context.Context, field g
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "edges":
-				return ec.fieldContext_LogsPayload_edges(ctx, field)
+				return ec.fieldContext_LogsConnection_edges(ctx, field)
 			case "pageInfo":
-				return ec.fieldContext_LogsPayload_pageInfo(ctx, field)
+				return ec.fieldContext_LogsConnection_pageInfo(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type LogsPayload", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type LogsConnection", field.Name)
 		},
 	}
 	defer func() {
@@ -58909,6 +59043,41 @@ func (ec *executionContext) _LogKey(ctx context.Context, sel ast.SelectionSet, o
 	return out
 }
 
+var logsConnectionImplementors = []string{"LogsConnection"}
+
+func (ec *executionContext) _LogsConnection(ctx context.Context, sel ast.SelectionSet, obj *model.LogsConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, logsConnectionImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("LogsConnection")
+		case "edges":
+
+			out.Values[i] = ec._LogsConnection_edges(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "pageInfo":
+
+			out.Values[i] = ec._LogsConnection_pageInfo(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var logsHistogramImplementors = []string{"LogsHistogram"}
 
 func (ec *executionContext) _LogsHistogram(ctx context.Context, sel ast.SelectionSet, obj *model.LogsHistogram) graphql.Marshaler {
@@ -58999,41 +59168,6 @@ func (ec *executionContext) _LogsHistogramBucketCount(ctx context.Context, sel a
 		case "level":
 
 			out.Values[i] = ec._LogsHistogramBucketCount_level(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var logsPayloadImplementors = []string{"LogsPayload"}
-
-func (ec *executionContext) _LogsPayload(ctx context.Context, sel ast.SelectionSet, obj *model.LogsPayload) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, logsPayloadImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("LogsPayload")
-		case "edges":
-
-			out.Values[i] = ec._LogsPayload_edges(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "pageInfo":
-
-			out.Values[i] = ec._LogsPayload_pageInfo(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -59887,6 +60021,20 @@ func (ec *executionContext) _PageInfo(ctx context.Context, sel ast.SelectionSet,
 		case "hasNextPage":
 
 			out.Values[i] = ec._PageInfo_hasNextPage(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "hasPreviousPage":
+
+			out.Values[i] = ec._PageInfo_hasPreviousPage(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "startCursor":
+
+			out.Values[i] = ec._PageInfo_startCursor(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -67296,6 +67444,20 @@ func (ec *executionContext) marshalNLogLevel2githubᚗcomᚋhighlightᚑrunᚋhi
 	return v
 }
 
+func (ec *executionContext) marshalNLogsConnection2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogsConnection(ctx context.Context, sel ast.SelectionSet, v model.LogsConnection) graphql.Marshaler {
+	return ec._LogsConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNLogsConnection2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogsConnection(ctx context.Context, sel ast.SelectionSet, v *model.LogsConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._LogsConnection(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNLogsHistogram2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogsHistogram(ctx context.Context, sel ast.SelectionSet, v model.LogsHistogram) graphql.Marshaler {
 	return ec._LogsHistogram(ctx, sel, &v)
 }
@@ -67421,20 +67583,6 @@ func (ec *executionContext) marshalNLogsHistogramBucketCount2ᚖgithubᚗcomᚋh
 func (ec *executionContext) unmarshalNLogsParamsInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogsParamsInput(ctx context.Context, v interface{}) (model.LogsParamsInput, error) {
 	res, err := ec.unmarshalInputLogsParamsInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNLogsPayload2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogsPayload(ctx context.Context, sel ast.SelectionSet, v model.LogsPayload) graphql.Marshaler {
-	return ec._LogsPayload(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNLogsPayload2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogsPayload(ctx context.Context, sel ast.SelectionSet, v *model.LogsPayload) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._LogsPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNMap2map(ctx context.Context, v interface{}) (map[string]interface{}, error) {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -372,6 +372,11 @@ type LogKey struct {
 	Type LogKeyType `json:"type"`
 }
 
+type LogsConnection struct {
+	Edges    []*LogEdge `json:"edges"`
+	PageInfo *PageInfo  `json:"pageInfo"`
+}
+
 type LogsHistogram struct {
 	Buckets    []*LogsHistogramBucket `json:"buckets"`
 	TotalCount uint64                 `json:"totalCount"`
@@ -390,11 +395,6 @@ type LogsHistogramBucketCount struct {
 type LogsParamsInput struct {
 	Query     string                  `json:"query"`
 	DateRange *DateRangeRequiredInput `json:"date_range"`
-}
-
-type LogsPayload struct {
-	Edges    []*LogEdge `json:"edges"`
-	PageInfo *PageInfo  `json:"pageInfo"`
 }
 
 type MetricPreview struct {
@@ -435,8 +435,10 @@ type OAuthClient struct {
 }
 
 type PageInfo struct {
-	HasNextPage bool   `json:"hasNextPage"`
-	EndCursor   string `json:"endCursor"`
+	HasNextPage     bool   `json:"hasNextPage"`
+	HasPreviousPage bool   `json:"hasPreviousPage"`
+	StartCursor     string `json:"startCursor"`
+	EndCursor       string `json:"endCursor"`
 }
 
 type Plan struct {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -522,10 +522,12 @@ type LogEdge {
 
 type PageInfo {
 	hasNextPage: Boolean!
+	hasPreviousPage: Boolean!
+	startCursor: String!
 	endCursor: String!
 }
 
-type LogsPayload {
+type LogsConnection {
 	edges: [LogEdge!]!
 	pageInfo: PageInfo!
 }
@@ -1473,7 +1475,13 @@ type Query {
 	sourcemap_versions(project_id: ID!): [String!]!
 	oauth_client_metadata(client_id: String!): OAuthClient
 	email_opt_outs(token: String, admin_id: ID): [EmailOptOutCategory!]!
-	logs(project_id: ID!, params: LogsParamsInput!, after: String): LogsPayload!
+	logs(
+		project_id: ID!
+		params: LogsParamsInput!
+		after: String
+		before: String
+		at: String
+	): LogsConnection!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_histogram(project_id: ID!, params: LogsParamsInput!): LogsHistogram!
 	logs_keys(project_id: ID!): [LogKey!]!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/highlight-run/highlight/backend/alerts"
 	"github.com/highlight-run/highlight/backend/alerts/integrations/discord"
 	"github.com/highlight-run/highlight/backend/apolloio"
+	"github.com/highlight-run/highlight/backend/clickhouse"
 	"github.com/highlight-run/highlight/backend/clickup"
 	Email "github.com/highlight-run/highlight/backend/email"
 	highlightErrors "github.com/highlight-run/highlight/backend/errors"
@@ -6993,13 +6994,17 @@ func (r *queryResolver) EmailOptOuts(ctx context.Context, token *string, adminID
 }
 
 // Logs is the resolver for the logs field.
-func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput, after *string) (*modelInputs.LogsPayload, error) {
+func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput, after *string, before *string, at *string) (*modelInputs.LogsConnection, error) {
 	project, err := r.isAdminInProject(ctx, projectID)
 	if err != nil {
 		return nil, e.Wrap(err, "error querying project")
 	}
 
-	return r.ClickhouseClient.ReadLogs(ctx, project.ID, params, after)
+	return r.ClickhouseClient.ReadLogs(ctx, project.ID, params, clickhouse.Pagination{
+		After:  after,
+		Before: before,
+		At:     at,
+	})
 }
 
 // LogsTotalCount is the resolver for the logs_total_count field.

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -3957,7 +3957,7 @@ export type GetLogsQueryVariables = Types.Exact<{
 }>
 
 export type GetLogsQuery = { __typename?: 'Query' } & {
-	logs: { __typename?: 'LogsPayload' } & {
+	logs: { __typename?: 'LogsConnection' } & {
 		edges: Array<
 			{ __typename?: 'LogEdge' } & Pick<Types.LogEdge, 'cursor'> & {
 					node: { __typename?: 'Log' } & Pick<

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -692,6 +692,12 @@ export enum LogLevel {
 	Warn = 'WARN',
 }
 
+export type LogsConnection = {
+	__typename?: 'LogsConnection'
+	edges: Array<LogEdge>
+	pageInfo: PageInfo
+}
+
 export type LogsHistogram = {
 	__typename?: 'LogsHistogram'
 	buckets: Array<LogsHistogramBucket>
@@ -713,12 +719,6 @@ export type LogsHistogramBucketCount = {
 export type LogsParamsInput = {
 	date_range: DateRangeRequiredInput
 	query: Scalars['String']
-}
-
-export type LogsPayload = {
-	__typename?: 'LogsPayload'
-	edges: Array<LogEdge>
-	pageInfo: PageInfo
 }
 
 export type Metric = {
@@ -1370,6 +1370,8 @@ export type PageInfo = {
 	__typename?: 'PageInfo'
 	endCursor: Scalars['String']
 	hasNextPage: Scalars['Boolean']
+	hasPreviousPage: Scalars['Boolean']
+	startCursor: Scalars['String']
 }
 
 export type Plan = {
@@ -1469,7 +1471,7 @@ export type Query = {
 	joinable_workspaces?: Maybe<Array<Maybe<Workspace>>>
 	linear_teams?: Maybe<Array<LinearTeam>>
 	liveUsersCount?: Maybe<Scalars['Int64']>
-	logs: LogsPayload
+	logs: LogsConnection
 	logs_histogram: LogsHistogram
 	logs_key_values: Array<Scalars['String']>
 	logs_keys: Array<LogKey>
@@ -1801,6 +1803,8 @@ export type QueryLiveUsersCountArgs = {
 
 export type QueryLogsArgs = {
 	after?: InputMaybe<Scalars['String']>
+	at?: InputMaybe<Scalars['String']>
+	before?: InputMaybe<Scalars['String']>
 	params: LogsParamsInput
 	project_id: Scalars['ID']
 }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR extends #4319 to add backward pagination and support to permalink to log. A frontend PR will follow that wires up these changes.

### Backward pagination

This continues with the [Relay spec](https://relay.dev/graphql/connections.htm#sec-Backward-pagination-arguments) adding a `before` argument.

Similar to handling the `after` cursor logic:

```sql
WHERE Timestamp <= x
  AND ( Timestamp < x OR UUID < y )
ORDER BY Timestamp DESC, UUID DESC
```

we need to invert the logic to handle going "backwards" ("backward" in flying quotes because it's going forward in time to get the newer logs)


```sql
WHERE Timestamp >= x
  AND ( Timestamp > x OR UUID > y )
ORDER BY Timestamp ASC, UUID ASC # Note the flipped order here
```

If we simply returned this directly though, the result would not match the existing descending order, hence, we wrap this in a sub-select to return the order correctly.

```sql
SELECT * FROM logs_window (
  SELECT * FROM logs
    WHERE Timestamp >= x
      AND ( Timestamp > x OR UUID > y )
    ORDER BY Timestamp ASC, UUID ASC
 AS logs_window
) ORDER BY Timestamp DESC, UUID DESC
```


### Permalinking

The relay spec has no concept of permalinking so we leverage that.

A naive approach would be:
* given a cursor, return the log that matches this cursor
* frontend can make two more requests to get the logs before/after this cursor

This is obviously unperformant and is pretty annoying for the frontend to have to make all these requests.

Hence, I chose to get a "window" of logs (see [stackoverflow](https://stackoverflow.com/questions/71699810/it-is-possible-in-cursor-based-pagination-to-get-the-prev-and-next-cursor-in-the/71738696#71738696)) around this cursor. Specifically loading `Limit / 2` logs before and after this cursor (`Limit` is 100 so with the log matching, the result is 101 logs).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Unit tests were added (specifically around ensuring [PageInfo](https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo) is correct as the frontend needs this to be accurate to determine if it should load additional requests).

I also verified this behavior with a simple frontend (https://github.com/highlight/highlight/pull/4486/files#diff-96c1192170afa8f77ed262c7c42ab64f29d1f31091d907d211563db845369e54R103) that will be more complete in a follow up PR.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
