### PR TITLE
add support for next.js generateBuildId

### DIFF
--- a/e2e/nextjs/next.config.js
+++ b/e2e/nextjs/next.config.js
@@ -2,6 +2,7 @@ const { withHighlightConfig } = require('@highlight-run/next')
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+	generateBuildId: () => nextBuildId({ dir: __dirname }),
 	experimental: {
 		appDir: true,
 	},

--- a/e2e/nextjs/next.config.js
+++ b/e2e/nextjs/next.config.js
@@ -1,3 +1,4 @@
+const nextBuildId = require('next-build-id')
 const { withHighlightConfig } = require('@highlight-run/next')
 
 /** @type {import('next').NextConfig} */
@@ -8,4 +9,4 @@ const nextConfig = {
 	},
 }
 
-module.exports = withHighlightConfig(nextConfig)
+module.exports = withHighlightConfig(nextConfig, { uploadSourceMaps: true })

--- a/e2e/nextjs/package.json
+++ b/e2e/nextjs/package.json
@@ -18,6 +18,7 @@
 		"eslint-config-next": "13.1.6",
 		"highlight.run": "workspace:*",
 		"next": "13.1.6",
+		"next-build-id": "^3.0.0",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"typescript": "4.9.5"

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -17,3 +17,9 @@
 
 -   require project id for H.init
 -   support for errors without associated sessions/requests
+
+## 2.1.2
+
+### Patch Changes
+
+-   Adds support for Next.js `generateBuildId` config parameter, which will set Highlight `appVersion` if none is provided.

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "2.1.1",
+	"version": "2.1.2",
 	"description": "Client for interfacing with Highlight in next.js",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-next/src/util/withHighlightConfig.test.ts
+++ b/sdk/highlight-next/src/util/withHighlightConfig.test.ts
@@ -19,8 +19,9 @@ describe('withHighlightConfig', () => {
 
 	it('creates new rewrites if none exist', async () => {
 		expect(
-			await withHighlightConfig({}, { uploadSourceMaps: true })
-				.rewrites!(),
+			await (
+				await withHighlightConfig({}, { uploadSourceMaps: true })
+			).rewrites!(),
 		).toMatchObject(defaultRewrite)
 	})
 
@@ -35,7 +36,9 @@ describe('withHighlightConfig', () => {
 		const expected = { ...defaultRewrite }
 		expected.afterFiles = [testEntry, ...expected.afterFiles]
 		expect(
-			await withHighlightConfig({ rewrites }).rewrites!(),
+			await (
+				await withHighlightConfig({ rewrites })
+			).rewrites!(),
 		).toMatchObject(expected)
 	})
 
@@ -59,7 +62,9 @@ describe('withHighlightConfig', () => {
 		expected.beforeFiles = [testEntry]
 		expected.fallback = [testEntry]
 		expect(
-			await withHighlightConfig({ rewrites }).rewrites!(),
+			await (
+				await withHighlightConfig({ rewrites })
+			).rewrites!(),
 		).toMatchObject(expected)
 	})
 
@@ -81,7 +86,9 @@ describe('withHighlightConfig', () => {
 		expected.beforeFiles = undefined
 		expected.fallback = [testEntry]
 		expect(
-			await withHighlightConfig({ rewrites }).rewrites!(),
+			await (
+				await withHighlightConfig({ rewrites })
+			).rewrites!(),
 		).toMatchObject(expected)
 	})
 
@@ -99,7 +106,9 @@ describe('withHighlightConfig', () => {
 			() => Promise.resolve(undefined)
 
 		expect(
-			await withHighlightConfig({ rewrites }).rewrites!(),
+			await (
+				await withHighlightConfig({ rewrites })
+			).rewrites!(),
 		).toMatchObject(defaultRewrite)
 	})
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -37698,6 +37698,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"next-build-id@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "next-build-id@npm:3.0.0"
+  checksum: e36e15979420c343e32a5e7a55efc1300a4b12aea1637df8300f0085ca862bf78e4fd3ac969ce7c7757cfad40c3c77e02ae4859be77692c9bdcb4243cbabb810
+  languageName: node
+  linkType: hard
+
 "next@npm:13.1.6, next@npm:^13.1.6":
   version: 13.1.6
   resolution: "next@npm:13.1.6"
@@ -37779,6 +37786,7 @@ __metadata:
     eslint-config-next: 13.1.6
     highlight.run: "workspace:*"
     next: 13.1.6
+    next-build-id: ^3.0.0
     react: 18.2.0
     react-dom: 18.2.0
     typescript: 4.9.5


### PR DESCRIPTION
## Summary

Adds support for [generateBuildId](https://nextjs.org/docs/api-reference/next.config.js/configuring-the-build-id) which is how folks typically provide their app version to a next.js app. 

## How did you test this change?

Local deploy of e2e next.js app with `generateBuildId` set in config.
<img width="545" alt="Screenshot 2023-02-27 at 3 15 32 PM" src="https://user-images.githubusercontent.com/1351531/221710855-6da3501e-6611-4c54-a1c6-3d7740eb532f.png">

## Are there any deployment considerations?

`@highlight-run/next` version bump.

Closes #4418