### PR TITLE
fix about you forms getting stuck on completion

### DIFF
--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -112,13 +112,13 @@ func TestMutationResolver_AddAdminToWorkspace(t *testing.T) {
 			errorExpected: false,
 		},
 		"same email different case": {
-			adminEmail:    "foo@bar.com",
-			inviteEmail:   "fOO@Bar.com",
+			adminEmail:    "boo@bar.com",
+			inviteEmail:   "bOO@Bar.com",
 			errorExpected: false,
 		},
 		"different email": {
-			adminEmail:    "foo@bar.com",
-			inviteEmail:   "f00@bar.com",
+			adminEmail:    "zoo@bar.com",
+			inviteEmail:   "z00@bar.com",
 			errorExpected: true,
 		},
 	}
@@ -126,6 +126,7 @@ func TestMutationResolver_AddAdminToWorkspace(t *testing.T) {
 		util.RunTestWithDBWipe(t, "Test AddAdminToWorkspace", DB, func(t *testing.T) {
 			// inserting the data
 			admin := model.Admin{
+				Model:         model.Model{ID: 1},
 				UID:           ptr.String("a1b2c3"),
 				Name:          ptr.String("adm1"),
 				PhotoURL:      ptr.String("asdf"),
@@ -157,12 +158,12 @@ func TestMutationResolver_AddAdminToWorkspace(t *testing.T) {
 
 			t.Logf("workspace id: %v", workspace.ID)
 			t.Logf("invite link: %v", *inviteLink.Secret)
-			workspaceID, err := r.AddAdminToWorkspace(ctx, workspace.ID, *inviteLink.Secret)
+			adminID, err := r.AddAdminToWorkspace(ctx, workspace.ID, *inviteLink.Secret)
 			if v.errorExpected != (err != nil) {
 				t.Fatalf("error result invalid, expected? %t but saw %s", v.errorExpected, err)
 			}
-			if err == nil && *workspaceID != workspace.ID {
-				t.Fatalf("received invalid workspace ID %d", workspaceID)
+			if err == nil && *adminID != 1 {
+				t.Fatalf("received invalid admin ID %d", adminID)
 			}
 		})
 	}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6285,7 +6285,9 @@ func (r *queryResolver) Admin(ctx context.Context) (*model.Admin, error) {
 		Clauses(clause.Returning{Columns: []clause.Column{{Name: "uid"}}}, clause.OnConflict{
 			Columns:   []clause.Column{{Name: "uid"}},
 			DoNothing: true,
-		}).Create(&admin)
+		}).
+		Create(&admin).
+		Attrs(&admin)
 	if tx.Error != nil {
 		spanError := e.Wrap(tx.Error, "error retrieving user from db")
 		adminSpan.Finish(tracer.WithError(spanError))
@@ -6293,43 +6295,45 @@ func (r *queryResolver) Admin(ctx context.Context) (*model.Admin, error) {
 	}
 	if tx.RowsAffected != 0 {
 		firebaseSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.getAdmin", tracer.ResourceName("db.createAdminFromFirebase"),
-			tracer.Tag("admin_uid", uid))
-		firebaseUser, err := AuthClient.GetUser(context.Background(), uid)
+			tracer.Tag("admin_uid", *admin.UID))
+		firebaseUser, err := AuthClient.GetUser(context.Background(), *admin.UID)
 		if err != nil {
 			spanError := e.Wrap(err, "error retrieving user from firebase api")
 			firebaseSpan.Finish(tracer.WithError(spanError))
 			adminSpan.Finish(tracer.WithError(spanError))
 			return nil, spanError
 		}
-		newAdmin := &model.Admin{
-			UID:                   &uid,
+		if err := r.DB.Where(&model.Admin{UID: admin.UID}).Updates(&model.Admin{
+			UID:                   admin.UID,
 			Name:                  &firebaseUser.DisplayName,
 			Email:                 &firebaseUser.Email,
 			PhotoURL:              &firebaseUser.PhotoURL,
 			EmailVerified:         &firebaseUser.EmailVerified,
 			Phone:                 &firebaseUser.PhoneNumber,
 			AboutYouDetailsFilled: &model.F,
-		}
-		if err := r.DB.Where(&model.Admin{UID: &uid}).Updates(newAdmin).Error; err != nil {
+		}).Error; err != nil {
 			spanError := e.Wrap(err, "error creating new admin")
 			adminSpan.Finish(tracer.WithError(spanError))
 			return nil, spanError
 		}
 		firebaseSpan.Finish()
-
-		admin = newAdmin
+	}
+	if err := r.DB.Where(&model.Admin{UID: admin.UID}).First(&admin).Error; err != nil {
+		spanError := e.Wrap(err, "error fetching admin")
+		adminSpan.Finish(tracer.WithError(spanError))
+		return nil, spanError
 	}
 	if admin.PhotoURL == nil || admin.Name == nil {
 		firebaseSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.getAdmin", tracer.ResourceName("db.updateAdminFromFirebase"),
-			tracer.Tag("admin_uid", uid))
-		firebaseUser, err := AuthClient.GetUser(context.Background(), uid)
+			tracer.Tag("admin_uid", *admin.UID))
+		firebaseUser, err := AuthClient.GetUser(context.Background(), *admin.UID)
 		if err != nil {
 			spanError := e.Wrap(err, "error retrieving user from firebase api")
 			adminSpan.Finish(tracer.WithError(spanError))
 			firebaseSpan.Finish(tracer.WithError(spanError))
 			return nil, spanError
 		}
-		if err := r.DB.Where(&model.Admin{UID: &uid}).Updates(&model.Admin{
+		if err := r.DB.Where(&model.Admin{UID: admin.UID}).Updates(&model.Admin{
 			PhotoURL: &firebaseUser.PhotoURL,
 			Name:     &firebaseUser.DisplayName,
 			Phone:    &firebaseUser.PhoneNumber,
@@ -6348,15 +6352,15 @@ func (r *queryResolver) Admin(ctx context.Context) (*model.Admin, error) {
 	// Check email verification status
 	if admin.EmailVerified != nil && !*admin.EmailVerified {
 		firebaseSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.getAdmin", tracer.ResourceName("db.updateAdminFromFirebaseForEmailVerification"),
-			tracer.Tag("admin_uid", uid))
-		firebaseUser, err := AuthClient.GetUser(context.Background(), uid)
+			tracer.Tag("admin_uid", *admin.UID))
+		firebaseUser, err := AuthClient.GetUser(context.Background(), *admin.UID)
 		if err != nil {
 			spanError := e.Wrap(err, "error retrieving user from firebase api for email verification")
 			adminSpan.Finish(tracer.WithError(spanError))
 			firebaseSpan.Finish(tracer.WithError(spanError))
 			return nil, spanError
 		}
-		if err := r.DB.Where(&model.Admin{UID: &uid}).Updates(&model.Admin{
+		if err := r.DB.Where(&model.Admin{UID: admin.UID}).Updates(&model.Admin{
 			EmailVerified: &firebaseUser.EmailVerified,
 		}).Error; err != nil {
 			spanError := e.Wrap(err, "error updating admin fields")

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6282,10 +6282,7 @@ func (r *queryResolver) Admin(ctx context.Context) (*model.Admin, error) {
 		tracer.Tag("admin_uid", uid))
 	admin := &model.Admin{UID: &uid}
 	tx := r.DB.Where(admin).
-		Clauses(clause.Returning{Columns: []clause.Column{{Name: "uid"}}}, clause.OnConflict{
-			Columns:   []clause.Column{{Name: "uid"}},
-			DoNothing: true,
-		}).
+		Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "uid"}}, DoNothing: true}).
 		Create(&admin).
 		Attrs(&admin)
 	if tx.Error != nil {

--- a/frontend/src/pages/AboutYou/AboutYouCard.tsx
+++ b/frontend/src/pages/AboutYou/AboutYouCard.tsx
@@ -25,6 +25,7 @@ import { Helmet } from 'react-helmet'
 import { useToggle } from 'react-use'
 
 import styles from './AboutYouCard.module.scss'
+import { namedOperations } from '@graph/operations'
 
 interface Props {
 	onSubmitHandler: () => void
@@ -87,6 +88,10 @@ const AboutYouPage = ({ onSubmitHandler }: Props) => {
 						referral: attributionData.referral,
 					},
 				},
+				refetchQueries: [
+					namedOperations.Query.GetAdmin,
+					namedOperations.Query.GetAdminAboutYou,
+				],
 			})
 
 			if (window.Intercom) {
@@ -95,7 +100,7 @@ const AboutYouPage = ({ onSubmitHandler }: Props) => {
 					isEngineeringPersona: isEngineeringRole,
 				})
 			}
-			getAdminQuery()
+			await getAdminQuery()
 			message.success(`Nice to meet you ${firstName}, let's get started!`)
 		} catch {
 			analytics.track('About you submission error')

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -36,6 +36,7 @@ const NewProjectPage = () => {
 
 	const { data: currentWorkspaceData } = useGetWorkspaceQuery({
 		variables: { id: workspace_id! },
+		skip: !workspace_id,
 	})
 	const [
 		createProject,

--- a/frontend/src/util/db.ts
+++ b/frontend/src/util/db.ts
@@ -136,10 +136,15 @@ export class IndexedDBLink extends ApolloLink {
 
 	/* determines whether an operation should be stored in the cache.
 	 * */
-	static shouldCache({}: {
+	static shouldCache({
+		operation,
+	}: {
 		operation: Operation
 		result: FetchResult<Record<string, any>>
 	}): boolean {
+		if (operation.operationName === 'GetAdmin') {
+			return false
+		}
 		return true
 	}
 


### PR DESCRIPTION
## Summary

`AboutYou` page would get stuck on completion because the Admin query would be cached by indexeddb, and we were not awaiting the mutation to complete. Submitting the `AboutYou` page would not change the UI until the page was refreshed. This bug would only surface on production frontend builds.

Fixes a backend race condition with `Admin` row creation waiting for firebase data.

## How did you test this change?

Local production deploy of frontend: `doppler run -- yarn vite build; doppler run -- yarn vite preview --port 3000`
`make debug` backend gdb tracing
Testing with new account creation.

## Are there any deployment considerations?

No
