### PR TITLE
Fix deep links for workspace-level pages

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -44,7 +44,7 @@ import React, { useEffect, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { Helmet } from 'react-helmet'
 import { SkeletonTheme } from 'react-loading-skeleton'
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom'
 import { QueryParamProvider } from 'use-query-params'
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6'
 
@@ -167,8 +167,9 @@ const App = () => {
 }
 
 const AuthenticationRoleRouter = () => {
-	const workspaceId = /^\/w\/(\d+)\/.*$/.exec(window.location.pathname)?.pop()
-	const projectId = /^\/(\d+)\/.*$/.exec(window.location.pathname)?.pop()
+	const location = useLocation()
+	const workspaceId = /^\/w\/(\d+)\/.*$/.exec(location.pathname)?.pop()
+	const projectId = /^\/(\d+)\/.*$/.exec(location.pathname)?.pop()
 
 	const [
 		getAdminWorkspaceRoleQuery,

--- a/frontend/src/routers/OrgRouter/DefaultWorkspaceRouter.tsx
+++ b/frontend/src/routers/OrgRouter/DefaultWorkspaceRouter.tsx
@@ -9,9 +9,10 @@ import React, { useEffect } from 'react'
 import { Navigate, useMatch } from 'react-router-dom'
 
 export const DefaultWorkspaceRouter = () => {
-	const { isLoggedIn } = useAuthContext()
+	const { isLoggedIn, workspaceRole } = useAuthContext()
+	console.log('workspaceRole', workspaceRole)
 
-	const workspaceMatch = useMatch('/w/:workspace_id/:page_id')
+	const workspaceMatch = useMatch('/w/:page_id')
 	const pageId = workspaceMatch?.params.page_id ?? ''
 	const { setLoadingState } = useAppLoadingContext()
 

--- a/frontend/src/routers/OrgRouter/DefaultWorkspaceRouter.tsx
+++ b/frontend/src/routers/OrgRouter/DefaultWorkspaceRouter.tsx
@@ -9,8 +9,7 @@ import React, { useEffect } from 'react'
 import { Navigate, useMatch } from 'react-router-dom'
 
 export const DefaultWorkspaceRouter = () => {
-	const { isLoggedIn, workspaceRole } = useAuthContext()
-	console.log('workspaceRole', workspaceRole)
+	const { isLoggedIn } = useAuthContext()
 
 	const workspaceMatch = useMatch('/w/:page_id')
 	const pageId = workspaceMatch?.params.page_id ?? ''


### PR DESCRIPTION
## Summary
- use `useLocation` hook to rerender `AuthenticationRoleRouter` on page change
- remove `workspace_id` from the `DefaultWorkspaceRouter` match because the component is only used when there is no numeric workspace_id provided
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click test locally, went to a bunch of pages to make sure the top level `useLocation` wasn't causing any major issues
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
