### PR TITLE
add filtering for trace id, span id, and secure session id

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -73,6 +73,7 @@ func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) 
 }
 
 const Limit int = 100
+const KeyValuesLimit int = 50
 
 func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput, after *string) (*modelInputs.LogsPayload, error) {
 	sb, err := makeSelectBuilder("Timestamp, UUID, SeverityText, Body, LogAttributes, TraceId, SpanId, SecureSessionId", projectID, params, after)
@@ -202,7 +203,7 @@ func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName 
 			Where(sb.NotEqual("level", "")).
 			GroupBy("level").
 			OrderBy("cnt DESC").
-			Limit(50)
+			Limit(KeyValuesLimit)
 	case modelInputs.ReservedLogKeySecureSessionID.String():
 		sb.Select("SecureSessionId secure_session_id, count() as cnt").
 			From("logs").
@@ -210,7 +211,7 @@ func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName 
 			Where(sb.NotEqual("secure_session_id", "")).
 			GroupBy("secure_session_id").
 			OrderBy("cnt DESC").
-			Limit(50)
+			Limit(KeyValuesLimit)
 	case modelInputs.ReservedLogKeySpanID.String():
 		sb.Select("SpanId span_id, count() as cnt").
 			From("logs").
@@ -218,7 +219,7 @@ func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName 
 			Where(sb.NotEqual("span_id", "")).
 			GroupBy("span_id").
 			OrderBy("cnt DESC").
-			Limit(50)
+			Limit(KeyValuesLimit)
 	case modelInputs.ReservedLogKeyTraceID.String():
 		sb.Select("TraceId trace_id, count() as cnt").
 			From("logs").
@@ -226,7 +227,7 @@ func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName 
 			Where(sb.NotEqual("trace_id", "")).
 			GroupBy("trace_id").
 			OrderBy("cnt DESC").
-			Limit(50)
+			Limit(KeyValuesLimit)
 	default:
 		sb.Select("LogAttributes [" + sb.Var(keyName) + "] as value, count() as cnt").
 			From("logs").
@@ -234,7 +235,7 @@ func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName 
 			Where("mapContains(LogAttributes, " + sb.Var(keyName) + ")").
 			GroupBy("value").
 			OrderBy("cnt DESC").
-			Limit(50)
+			Limit(KeyValuesLimit)
 	}
 
 	sql, args := sb.Build()

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -3,9 +3,10 @@ package clickhouse
 import (
 	"context"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/google/uuid"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
@@ -74,7 +75,7 @@ func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) 
 const Limit int = 100
 
 func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput, after *string) (*modelInputs.LogsPayload, error) {
-	sb, err := makeSelectBuilder("Timestamp, UUID, SeverityText, Body, LogAttributes", projectID, params, after)
+	sb, err := makeSelectBuilder("Timestamp, UUID, SeverityText, Body, LogAttributes, TraceId, SpanId, SecureSessionId", projectID, params, after)
 	if err != nil {
 		return nil, err
 	}
@@ -95,24 +96,30 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 	logs := []*modelInputs.LogEdge{}
 
 	for rows.Next() {
-		var (
-			Timestamp     time.Time
-			UUID          string
-			SeverityText  string
-			Body          string
-			LogAttributes map[string]string
-		)
-		if err := rows.Scan(&Timestamp, &UUID, &SeverityText, &Body, &LogAttributes); err != nil {
+		var result struct {
+			Timestamp       time.Time
+			UUID            string
+			SeverityText    string
+			Body            string
+			LogAttributes   map[string]string
+			TraceId         string
+			SpanId          string
+			SecureSessionId string
+		}
+		if err := rows.ScanStruct(&result); err != nil {
 			return nil, err
 		}
 
 		logs = append(logs, &modelInputs.LogEdge{
-			Cursor: encodeCursor(Timestamp, UUID),
+			Cursor: encodeCursor(result.Timestamp, result.UUID),
 			Node: &modelInputs.Log{
-				Timestamp:     Timestamp,
-				SeverityText:  makeSeverityText(SeverityText),
-				Body:          Body,
-				LogAttributes: expandJSON(LogAttributes),
+				Timestamp:       result.Timestamp,
+				SeverityText:    makeSeverityText(result.SeverityText),
+				Body:            result.Body,
+				LogAttributes:   expandJSON(result.LogAttributes),
+				TraceID:         result.TraceId,
+				SpanID:          result.SpanId,
+				SecureSessionID: result.SecureSessionId,
 			},
 		})
 	}
@@ -172,10 +179,12 @@ func (client *Client) LogsKeys(ctx context.Context, projectID int) ([]*modelInpu
 		})
 	}
 
-	keys = append(keys, &modelInputs.LogKey{
-		Name: "level",
-		Type: modelInputs.LogKeyTypeString,
-	})
+	for _, key := range modelInputs.AllReservedLogKey {
+		keys = append(keys, &modelInputs.LogKey{
+			Name: key.String(),
+			Type: modelInputs.LogKeyTypeString,
+		})
+	}
 
 	rows.Close()
 	return keys, rows.Err()
@@ -185,8 +194,8 @@ func (client *Client) LogsKeys(ctx context.Context, projectID int) ([]*modelInpu
 func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName string) ([]string, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 
-	// TODO(et) - this is going to be a mess when we add other reserved keys like Trace. Clean this up when that happens.
-	if keyName == "level" {
+	switch keyName {
+	case modelInputs.ReservedLogKeyLevel.String():
 		sb.Select("SeverityText level, count() as cnt").
 			From("logs").
 			Where(sb.Equal("ProjectId", projectID)).
@@ -194,7 +203,31 @@ func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName 
 			GroupBy("level").
 			OrderBy("cnt DESC").
 			Limit(50)
-	} else {
+	case modelInputs.ReservedLogKeySecureSessionID.String():
+		sb.Select("SecureSessionId secure_session_id, count() as cnt").
+			From("logs").
+			Where(sb.Equal("ProjectId", projectID)).
+			Where(sb.NotEqual("secure_session_id", "")).
+			GroupBy("secure_session_id").
+			OrderBy("cnt DESC").
+			Limit(50)
+	case modelInputs.ReservedLogKeySpanID.String():
+		sb.Select("SpanId span_id, count() as cnt").
+			From("logs").
+			Where(sb.Equal("ProjectId", projectID)).
+			Where(sb.NotEqual("span_id", "")).
+			GroupBy("span_id").
+			OrderBy("cnt DESC").
+			Limit(50)
+	case modelInputs.ReservedLogKeyTraceID.String():
+		sb.Select("TraceId trace_id, count() as cnt").
+			From("logs").
+			Where(sb.Equal("ProjectId", projectID)).
+			Where(sb.NotEqual("trace_id", "")).
+			GroupBy("trace_id").
+			OrderBy("cnt DESC").
+			Limit(50)
+	default:
 		sb.Select("LogAttributes [" + sb.Var(keyName) + "] as value, count() as cnt").
 			From("logs").
 			Where(sb.Equal("ProjectId", projectID)).
@@ -298,11 +331,27 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 		sb.Where("Body ILIKE" + sb.Var(filters.body))
 	}
 
-	if len(filters.level) > 0 {
-		if strings.Contains(filters.level, "%") {
-			sb.Where(sb.Like("SeverityText", filters.level))
+	if len(filters.secure_session_id) > 0 {
+		if strings.Contains(filters.secure_session_id, "%") {
+			sb.Where(sb.Like("SecureSessionId", filters.secure_session_id))
 		} else {
-			sb.Where(sb.Equal("SeverityText", filters.level))
+			sb.Where(sb.Equal("SecureSessionId", filters.secure_session_id))
+		}
+	}
+
+	if len(filters.span_id) > 0 {
+		if strings.Contains(filters.span_id, "%") {
+			sb.Where(sb.Like("SpanId", filters.span_id))
+		} else {
+			sb.Where(sb.Equal("SpanId", filters.span_id))
+		}
+	}
+
+	if len(filters.trace_id) > 0 {
+		if strings.Contains(filters.trace_id, "%") {
+			sb.Where(sb.Like("TraceId", filters.trace_id))
+		} else {
+			sb.Where(sb.Equal("TraceId", filters.trace_id))
 		}
 	}
 
@@ -319,9 +368,12 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 }
 
 type filters struct {
-	body       string
-	level      string
-	attributes map[string]string
+	body              string
+	level             string
+	trace_id          string
+	span_id           string
+	secure_session_id string
+	attributes        map[string]string
 }
 
 func makeFilters(query string) filters {
@@ -346,9 +398,16 @@ func makeFilters(query string) filters {
 
 			wildcardValue := strings.ReplaceAll(value, "*", "%")
 
-			if key == "level" {
+			switch key {
+			case modelInputs.ReservedLogKeyLevel.String():
 				filters.level = wildcardValue
-			} else {
+			case modelInputs.ReservedLogKeySecureSessionID.String():
+				filters.secure_session_id = wildcardValue
+			case modelInputs.ReservedLogKeySpanID.String():
+				filters.span_id = wildcardValue
+			case modelInputs.ReservedLogKeyTraceID.String():
+				filters.trace_id = wildcardValue
+			default:
 				filters.attributes[key] = wildcardValue
 			}
 		}

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -331,6 +331,14 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 		sb.Where("Body ILIKE" + sb.Var(filters.body))
 	}
 
+	if len(filters.level) > 0 {
+		if strings.Contains(filters.level, "%") {
+			sb.Where(sb.Like("SeverityText", filters.level))
+		} else {
+			sb.Where(sb.Equal("SeverityText", filters.level))
+		}
+	}
+
 	if len(filters.secure_session_id) > 0 {
 		if strings.Contains(filters.secure_session_id, "%") {
 			sb.Where(sb.Like("SecureSessionId", filters.secure_session_id))

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -317,6 +317,159 @@ func TestReadLogsWithLevelFilter(t *testing.T) {
 	assert.Len(t, payload.Edges, 0)
 }
 
+func TestReadLogsWithSessionIdFilter(t *testing.T) {
+	ctx := context.Background()
+	client := setup(t)
+	defer teardown(client)
+
+	now := time.Now()
+	rows := []*LogRow{
+		{
+			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
+				Timestamp:       now,
+				ProjectId:       1,
+				SecureSessionId: "match",
+			},
+		},
+		{
+			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
+				Timestamp: now,
+				ProjectId: 1,
+			},
+			LogAttributes: map[string]string{
+				"secure_session_id": "no_match",
+			},
+		},
+	}
+
+	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
+
+	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "secure_session_id:match",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 1)
+	assert.Equal(t, "match", payload.Edges[0].Node.SecureSessionID)
+
+	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "secure_session_id:*atc*",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 1)
+	assert.Equal(t, "match", payload.Edges[0].Node.SecureSessionID)
+
+	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "secure_session_id:no_match",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 0)
+}
+
+func TestReadLogsWithSpanIdFilter(t *testing.T) {
+	ctx := context.Background()
+	client := setup(t)
+	defer teardown(client)
+
+	now := time.Now()
+	rows := []*LogRow{
+		{
+			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
+				Timestamp: now,
+				ProjectId: 1,
+				SpanId:    "match",
+			},
+		},
+		{
+			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
+				Timestamp: now,
+				ProjectId: 1,
+			},
+			LogAttributes: map[string]string{
+				"span_id": "no_match",
+			},
+		},
+	}
+
+	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
+
+	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "span_id:match",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 1)
+	assert.Equal(t, "match", payload.Edges[0].Node.SpanID)
+
+	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "span_id:*atc*",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 1)
+	assert.Equal(t, "match", payload.Edges[0].Node.SpanID)
+
+	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "span_id:no_match",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 0)
+}
+
+func TestReadLogsWithTraceIdFilter(t *testing.T) {
+	ctx := context.Background()
+	client := setup(t)
+	defer teardown(client)
+
+	now := time.Now()
+	rows := []*LogRow{
+		{
+			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
+				Timestamp: now,
+				ProjectId: 1,
+				TraceId:   "match",
+			},
+		},
+		{
+			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
+				Timestamp: now,
+				ProjectId: 1,
+			},
+			LogAttributes: map[string]string{
+				"trace_id": "no_match",
+			},
+		},
+	}
+
+	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
+
+	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "trace_id:match",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 1)
+	assert.Equal(t, "match", payload.Edges[0].Node.TraceID)
+
+	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "trace_id:*atc*",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 1)
+	assert.Equal(t, "match", payload.Edges[0].Node.TraceID)
+
+	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "trace_id:no_match",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 0)
+}
+
 func TestLogsKeys(t *testing.T) {
 	ctx := context.Background()
 	client := setup(t)
@@ -357,6 +510,18 @@ func TestLogsKeys(t *testing.T) {
 		// Non-custom keys ranked lower
 		{
 			Name: "level",
+			Type: modelInputs.LogKeyTypeString,
+		},
+		{
+			Name: "secure_session_id",
+			Type: modelInputs.LogKeyTypeString,
+		},
+		{
+			Name: "span_id",
+			Type: modelInputs.LogKeyTypeString,
+		},
+		{
+			Name: "trace_id",
 			Type: modelInputs.LogKeyTypeString,
 		},
 	}

--- a/backend/clickhouse/seeds/main.go
+++ b/backend/clickhouse/seeds/main.go
@@ -95,10 +95,22 @@ func makeRandomSeverityText() string {
 	return severities[rand.Intn(len(severities))]
 }
 
+func makeRandomTraceID() string {
+	spanIDs := [6]string{
+		"",
+		"trace_1",
+		"trace_2",
+		"trace_3",
+	}
+	return spanIDs[rand.Intn(len(spanIDs))]
+}
+
 func makeRandomSpanID() string {
 	spanIDs := [6]string{
 		"",
-		"span_id",
+		"span_1",
+		"span_2",
+		"span_3",
 	}
 	return spanIDs[rand.Intn(len(spanIDs))]
 }
@@ -106,7 +118,9 @@ func makeRandomSpanID() string {
 func makeRandomSecureSessionID() string {
 	secureSessionIDs := [6]string{
 		"",
-		"secure_session_id",
+		"secure_session_id_1",
+		"secure_session_id_2",
+		"secure_session_id_3",
 	}
 	return secureSessionIDs[rand.Intn(len(secureSessionIDs))]
 }
@@ -129,7 +143,7 @@ func main() {
 			LogRowPrimaryAttrs: clickhouse.LogRowPrimaryAttrs{
 				Timestamp:       now.Add(-time.Duration(i) * time.Second),
 				ProjectId:       1,
-				TraceId:         "trace_id",
+				TraceId:         makeRandomTraceID(),
 				SpanId:          makeRandomSpanID(),
 				SecureSessionId: makeRandomSecureSessionID(),
 			},

--- a/backend/clickhouse/seeds/main.go
+++ b/backend/clickhouse/seeds/main.go
@@ -109,7 +109,6 @@ func main() {
 
 	for i := 1; i < 10000; i++ {
 		logRows := []*clickhouse.LogRow{}
-
 		logRows = append(logRows, &clickhouse.LogRow{
 			LogRowPrimaryAttrs: clickhouse.LogRowPrimaryAttrs{
 				Timestamp: now.Add(-time.Duration(i) * time.Second),

--- a/backend/clickhouse/seeds/main.go
+++ b/backend/clickhouse/seeds/main.go
@@ -103,6 +103,14 @@ func makeRandomSpanID() string {
 	return spanIDs[rand.Intn(len(spanIDs))]
 }
 
+func makeRandomSecureSessionID() string {
+	secureSessionIDs := [6]string{
+		"",
+		"secure_session_id",
+	}
+	return secureSessionIDs[rand.Intn(len(secureSessionIDs))]
+}
+
 // Run via
 // `doppler run -- go run backend/clickhouse/seeds/main.go“
 func main() {
@@ -122,8 +130,8 @@ func main() {
 				Timestamp:       now.Add(-time.Duration(i) * time.Second),
 				ProjectId:       1,
 				TraceId:         "trace_id",
-				SpanId:          "span_id",
-				SecureSessionId: "span_id",
+				SpanId:          makeRandomSpanID(),
+				SecureSessionId: makeRandomSecureSessionID(),
 			},
 			Body:          fmt.Sprintf("Body %d", i),
 			LogAttributes: makeRandLogAttributes(),

--- a/backend/clickhouse/seeds/main.go
+++ b/backend/clickhouse/seeds/main.go
@@ -95,6 +95,14 @@ func makeRandomSeverityText() string {
 	return severities[rand.Intn(len(severities))]
 }
 
+func makeRandomSpanID() string {
+	spanIDs := [6]string{
+		"",
+		"span_id",
+	}
+	return spanIDs[rand.Intn(len(spanIDs))]
+}
+
 // Run via
 // `doppler run -- go run backend/clickhouse/seeds/main.go“
 func main() {
@@ -111,8 +119,11 @@ func main() {
 		logRows := []*clickhouse.LogRow{}
 		logRows = append(logRows, &clickhouse.LogRow{
 			LogRowPrimaryAttrs: clickhouse.LogRowPrimaryAttrs{
-				Timestamp: now.Add(-time.Duration(i) * time.Second),
-				ProjectId: 1,
+				Timestamp:       now.Add(-time.Duration(i) * time.Second),
+				ProjectId:       1,
+				TraceId:         "trace_id",
+				SpanId:          "span_id",
+				SecureSessionId: "span_id",
 			},
 			Body:          fmt.Sprintf("Body %d", i),
 			LogAttributes: makeRandLogAttributes(),

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -129,8 +129,6 @@ require (
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
-	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/marconi/go-resthooks v0.0.0-20190225103922-ad217f832acb // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -176,7 +174,6 @@ require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.5.1
 	github.com/DataDog/gostackparse v0.5.0 // indirect
 	github.com/DataDog/sketches-go v1.2.1 // indirect
-	github.com/Masterminds/squirrel v1.5.3
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/ReneKroon/ttlcache v1.7.0
 	github.com/agnivade/levenshtein v1.1.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -114,8 +114,6 @@ github.com/DmitriyVTitov/size v1.1.0 h1:9i2UsP0QpR3MmSv53M/WW7wVoWPZez8UMswDas3G
 github.com/DmitriyVTitov/size v1.1.0/go.mod h1:asVR2J1mZ/2yIobW+JomrhJb90qWzWMyuFJs1BX89+Y=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Masterminds/squirrel v1.5.3 h1:YPpoceAcxuzIljlr5iWpNKaql7hLeG1KLSrhvdHpkZc=
-github.com/Masterminds/squirrel v1.5.3/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
@@ -1034,10 +1032,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
-github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
-github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
-github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
-github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leonelquinteros/gorand v1.0.2 h1:YgHYktP/OwC0dA6xwrsV/cFjmKzN4Y1vTfnMsRDd8XQ=

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -492,10 +492,13 @@ type ComplexityRoot struct {
 	}
 
 	Log struct {
-		Body          func(childComplexity int) int
-		LogAttributes func(childComplexity int) int
-		SeverityText  func(childComplexity int) int
-		Timestamp     func(childComplexity int) int
+		Body            func(childComplexity int) int
+		LogAttributes   func(childComplexity int) int
+		SecureSessionID func(childComplexity int) int
+		SeverityText    func(childComplexity int) int
+		SpanID          func(childComplexity int) int
+		Timestamp       func(childComplexity int) int
+		TraceID         func(childComplexity int) int
 	}
 
 	LogEdge struct {
@@ -3339,6 +3342,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Log.LogAttributes(childComplexity), true
 
+	case "Log.secureSessionID":
+		if e.complexity.Log.SecureSessionID == nil {
+			break
+		}
+
+		return e.complexity.Log.SecureSessionID(childComplexity), true
+
 	case "Log.severityText":
 		if e.complexity.Log.SeverityText == nil {
 			break
@@ -3346,12 +3356,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Log.SeverityText(childComplexity), true
 
+	case "Log.spanID":
+		if e.complexity.Log.SpanID == nil {
+			break
+		}
+
+		return e.complexity.Log.SpanID(childComplexity), true
+
 	case "Log.timestamp":
 		if e.complexity.Log.Timestamp == nil {
 			break
 		}
 
 		return e.complexity.Log.Timestamp(childComplexity), true
+
+	case "Log.traceID":
+		if e.complexity.Log.TraceID == nil {
+			break
+		}
+
+		return e.complexity.Log.TraceID(childComplexity), true
 
 	case "LogEdge.cursor":
 		if e.complexity.LogEdge.Cursor == nil {
@@ -8069,6 +8093,9 @@ type Log {
 	severityText: SeverityText!
 	body: String!
 	logAttributes: Map!
+	traceID: String!
+	spanID: String!
+	secureSessionID: String!
 }
 
 type LogEdge {
@@ -8084,6 +8111,16 @@ type PageInfo {
 type LogsPayload {
 	edges: [LogEdge!]!
 	pageInfo: PageInfo!
+}
+
+enum ReservedLogKey {
+	"""
+	Keep this in alpha order
+	"""
+	level
+	secure_session_id
+	span_id
+	trace_id
 }
 
 enum LogKeyType {
@@ -26938,6 +26975,138 @@ func (ec *executionContext) fieldContext_Log_logAttributes(ctx context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Log_traceID(ctx context.Context, field graphql.CollectedField, obj *model.Log) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Log_traceID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TraceID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Log_traceID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Log",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Log_spanID(ctx context.Context, field graphql.CollectedField, obj *model.Log) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Log_spanID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SpanID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Log_spanID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Log",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Log_secureSessionID(ctx context.Context, field graphql.CollectedField, obj *model.Log) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Log_secureSessionID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SecureSessionID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Log_secureSessionID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Log",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _LogEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.LogEdge) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_LogEdge_cursor(ctx, field)
 	if err != nil {
@@ -27029,6 +27198,12 @@ func (ec *executionContext) fieldContext_LogEdge_node(ctx context.Context, field
 				return ec.fieldContext_Log_body(ctx, field)
 			case "logAttributes":
 				return ec.fieldContext_Log_logAttributes(ctx, field)
+			case "traceID":
+				return ec.fieldContext_Log_traceID(ctx, field)
+			case "spanID":
+				return ec.fieldContext_Log_spanID(ctx, field)
+			case "secureSessionID":
+				return ec.fieldContext_Log_secureSessionID(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Log", field.Name)
 		},
@@ -57794,6 +57969,27 @@ func (ec *executionContext) _Log(ctx context.Context, sel ast.SelectionSet, obj 
 		case "logAttributes":
 
 			out.Values[i] = ec._Log_logAttributes(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "traceID":
+
+			out.Values[i] = ec._Log_traceID(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "spanID":
+
+			out.Values[i] = ec._Log_spanID(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "secureSessionID":
+
+			out.Values[i] = ec._Log_secureSessionID(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -353,10 +353,13 @@ type LinearTeam struct {
 }
 
 type Log struct {
-	Timestamp     time.Time              `json:"timestamp"`
-	SeverityText  SeverityText           `json:"severityText"`
-	Body          string                 `json:"body"`
-	LogAttributes map[string]interface{} `json:"logAttributes"`
+	Timestamp       time.Time              `json:"timestamp"`
+	SeverityText    SeverityText           `json:"severityText"`
+	Body            string                 `json:"body"`
+	LogAttributes   map[string]interface{} `json:"logAttributes"`
+	TraceID         string                 `json:"traceID"`
+	SpanID          string                 `json:"spanID"`
+	SecureSessionID string                 `json:"secureSessionID"`
 }
 
 type LogEdge struct {
@@ -1113,6 +1116,52 @@ func (e *PlanType) UnmarshalGQL(v interface{}) error {
 }
 
 func (e PlanType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type ReservedLogKey string
+
+const (
+	// Keep this in alpha order
+	ReservedLogKeyLevel           ReservedLogKey = "level"
+	ReservedLogKeySecureSessionID ReservedLogKey = "secure_session_id"
+	ReservedLogKeySpanID          ReservedLogKey = "span_id"
+	ReservedLogKeyTraceID         ReservedLogKey = "trace_id"
+)
+
+var AllReservedLogKey = []ReservedLogKey{
+	ReservedLogKeyLevel,
+	ReservedLogKeySecureSessionID,
+	ReservedLogKeySpanID,
+	ReservedLogKeyTraceID,
+}
+
+func (e ReservedLogKey) IsValid() bool {
+	switch e {
+	case ReservedLogKeyLevel, ReservedLogKeySecureSessionID, ReservedLogKeySpanID, ReservedLogKeyTraceID:
+		return true
+	}
+	return false
+}
+
+func (e ReservedLogKey) String() string {
+	return string(e)
+}
+
+func (e *ReservedLogKey) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ReservedLogKey(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ReservedLogKey", str)
+	}
+	return nil
+}
+
+func (e ReservedLogKey) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -510,6 +510,9 @@ type Log {
 	severityText: SeverityText!
 	body: String!
 	logAttributes: Map!
+	traceID: String!
+	spanID: String!
+	secureSessionID: String!
 }
 
 type LogEdge {
@@ -525,6 +528,16 @@ type PageInfo {
 type LogsPayload {
 	edges: [LogEdge!]!
 	pageInfo: PageInfo!
+}
+
+enum ReservedLogKey {
+	"""
+	Keep this in alpha order
+	"""
+	level
+	secure_session_id
+	span_id
+	trace_id
 }
 
 enum LogKeyType {

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -11340,6 +11340,9 @@ export const GetLogsDocument = gql`
 					severityText
 					body
 					logAttributes
+					traceID
+					spanID
+					secureSessionID
 				}
 			}
 			pageInfo {

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -3925,7 +3925,13 @@ export type GetLogsQuery = { __typename?: 'Query' } & {
 			{ __typename?: 'LogEdge' } & Pick<Types.LogEdge, 'cursor'> & {
 					node: { __typename?: 'Log' } & Pick<
 						Types.Log,
-						'timestamp' | 'severityText' | 'body' | 'logAttributes'
+						| 'timestamp'
+						| 'severityText'
+						| 'body'
+						| 'logAttributes'
+						| 'traceID'
+						| 'spanID'
+						| 'secureSessionID'
 					>
 				}
 		>

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -660,8 +660,11 @@ export type Log = {
 	__typename?: 'Log'
 	body: Scalars['String']
 	logAttributes: Scalars['Map']
+	secureSessionID: Scalars['String']
 	severityText: SeverityText
+	spanID: Scalars['String']
 	timestamp: Scalars['Timestamp']
+	traceID: Scalars['String']
 }
 
 export type LogEdge = {
@@ -2042,6 +2045,14 @@ export type ReferrerTablePayload = {
 	count: Scalars['Int']
 	host: Scalars['String']
 	percent: Scalars['Float']
+}
+
+export enum ReservedLogKey {
+	/** Keep this in alpha order */
+	Level = 'level',
+	SecureSessionId = 'secure_session_id',
+	SpanId = 'span_id',
+	TraceId = 'trace_id',
 }
 
 export enum RetentionPeriod {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1860,6 +1860,9 @@ query GetLogs($project_id: ID!, $params: LogsParamsInput!, $after: String) {
 				severityText
 				body
 				logAttributes
+				traceID
+				spanID
+				secureSessionID
 			}
 		}
 		pageInfo {

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -24,7 +24,8 @@ type Props = {
 
 export const LogDetails = ({ row }: Props) => {
 	const [allExpanded, setAllExpanded] = useState(false)
-	const { logAttributes } = row.original.node
+	const { traceID, spanID, secureSessionID, logAttributes } =
+		row.original.node
 	const expanded = row.getIsExpanded()
 	const expandable = Object.values(logAttributes).some(
 		(v) => typeof v === 'object',
@@ -58,6 +59,25 @@ export const LogDetails = ({ row }: Props) => {
 					</Box>
 				)
 			})}
+
+			{traceID && (
+				<Box>
+					<LogValue label="trace_id" value={traceID} />
+				</Box>
+			)}
+			{spanID && (
+				<Box>
+					<LogValue label="span_id" value={spanID} />
+				</Box>
+			)}
+			{secureSessionID && (
+				<Box>
+					<LogValue
+						label="secure_session_id"
+						value={secureSessionID}
+					/>
+				</Box>
+			)}
 
 			<Box
 				display="flex"


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR adds support for filtering by `trace_id`, `span_id`, and `secure_session_id`. 

The naming of `"secure"_session_id` may be confusing (I could see an argument for calling this `session_id`). Jay and I chatted about this and we are opting to leave it as for now. People won't really be using this search directly (they'll only see it because they they were on a session page and clicked View logs which populated that filter). We can revisit this if it seems confusing.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Observe that values are only visible when a non-empty string:
![Screenshot 2023-03-02 at 3 44 15 PM](https://user-images.githubusercontent.com/58678/222576757-76e691ac-d781-4918-bb51-827110e418f2.png)

Trace id filtering works:
![Screenshot 2023-03-02 at 3 45 44 PM](https://user-images.githubusercontent.com/58678/222576988-2f90bcc4-8b90-41ad-919a-6967bcba7329.png)


Span id filtering works:
![Screenshot 2023-03-02 at 3 44 55 PM](https://user-images.githubusercontent.com/58678/222576825-5f55e233-69fc-48f7-851c-9189ef522347.png)


Secure session id filtering works:

![Screenshot 2023-03-02 at 3 46 13 PM](https://user-images.githubusercontent.com/58678/222577087-4697e382-7e2f-41d6-85cd-24d97d2f889d.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
