### PR TITLE
billing page fixes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
 		"color-hash": "^2.0.1",
 		"dexie": "^3.2.2",
 		"dexie-react-hooks": "^1.1.1",
-		"dinero.js": "^2.0.0-alpha.8",
+		"dinero.js": "alpha",
 		"eslint-plugin-simple-import-sort": "^7.0.0",
 		"firebase": "^8.10.1",
 		"framer-motion": "^6.3.15",

--- a/frontend/src/pages/Accounts/Accounts.tsx
+++ b/frontend/src/pages/Accounts/Accounts.tsx
@@ -11,7 +11,7 @@ import {
 import useLocalStorage from '@rehooks/local-storage'
 import { useParams } from '@util/react-router/useParams'
 import { Table } from 'antd'
-import { dinero, down, toUnit } from 'dinero.js'
+import { dinero, toDecimal } from 'dinero.js'
 import moment from 'moment'
 import React, { useEffect } from 'react'
 // @ts-expect-error
@@ -146,13 +146,7 @@ const COLUMNS = [
 				amount: value,
 				currency: USD,
 			})
-			return (
-				'$' +
-				toUnit(baseAmount, {
-					digits: 2,
-					round: down,
-				})
-			)
+			return '$' + toDecimal(baseAmount)
 		},
 		sorter: (a: { paid_prev: any }, b: { paid_prev: any }) =>
 			(a.paid_prev ?? 0) - (b.paid_prev ?? 0),
@@ -174,13 +168,7 @@ const COLUMNS = [
 				amount: value,
 				currency: USD,
 			})
-			return (
-				'$' +
-				toUnit(baseAmount, {
-					digits: 2,
-					round: down,
-				})
-			)
+			return '$' + toDecimal(baseAmount)
 		},
 		sorter: (a: { paid_prev_prev: any }, b: { paid_prev_prev: any }) =>
 			(a.paid_prev_prev ?? 0) - (b.paid_prev_prev ?? 0),

--- a/frontend/src/pages/Billing/Billing.tsx
+++ b/frontend/src/pages/Billing/Billing.tsx
@@ -32,7 +32,7 @@ import {
 } from '@util/authorization/authorization'
 import { POLICY_NAMES } from '@util/authorization/authorizationPolicies'
 import { message } from 'antd'
-import { dinero, down, toUnit } from 'dinero.js'
+import { dinero, toDecimal } from 'dinero.js'
 import moment from 'moment'
 import { useEffect, useState } from 'react'
 import Confetti from 'react-confetti'
@@ -545,14 +545,8 @@ const BillingPage = () => {
 								Your last invoice failed to process!
 							</span>
 							<br />
-							<span>
-								$
-								{toUnit(outstandingAmount, {
-									digits: 2,
-									round: down,
-								})}
-							</span>{' '}
-							is past due as of{' '}
+							<span>${toDecimal(outstandingAmount)}</span> is past
+							due as of{' '}
 							{moment(
 								subscriptionData?.subscription_details
 									?.lastInvoice?.date,

--- a/frontend/src/pages/Billing/BillingPlanCard/BillingConfig.ts
+++ b/frontend/src/pages/Billing/BillingPlanCard/BillingConfig.ts
@@ -1,8 +1,10 @@
-import { PlanType } from '@graph/schemas'
+import { USD } from '@dinero.js/currencies'
+import { PlanType, RetentionPeriod } from '@graph/schemas'
+import { dinero, toDecimal } from 'dinero.js'
 
 type FeatureWithTooltip = {
 	text: string
-	tooltip?: string
+	tooltip?: (rp: RetentionPeriod) => string
 }
 
 export type BillingPlan = {
@@ -14,11 +16,30 @@ export type BillingPlan = {
 	membersIncluded?: number
 }
 
-const SESSIONS_AFTER_LIMIT_TOOLTIP =
-	'After this monthly limit is reached, extra sessions will be charged $5.00 per 1,000 sessions.'
+const sessionsPrices = {
+	[RetentionPeriod.ThreeMonths]: 500,
+	[RetentionPeriod.SixMonths]: 750,
+	[RetentionPeriod.TwelveMonths]: 1000,
+	[RetentionPeriod.TwoYears]: 1250,
+}
 
-const ERRORS_AFTER_LIMIT_TOOLTIP =
-	'After this monthly limit is reached, extra errors will be charged $0.20 per 1,000 errors.'
+const getSessionsAfterLimitTooltip = (rp: RetentionPeriod) => {
+	const amt = dinero({ amount: sessionsPrices[rp], currency: USD })
+	const formatted = toDecimal(amt)
+	return `After this monthly limit is reached, extra sessions will be charged $${formatted} per 1,000 sessions.`
+}
+
+const errorsPrices = {
+	[RetentionPeriod.ThreeMonths]: 20,
+	[RetentionPeriod.SixMonths]: 30,
+	[RetentionPeriod.TwelveMonths]: 40,
+	[RetentionPeriod.TwoYears]: 50,
+}
+const getErrorsAfterLimitTooltip = (rp: RetentionPeriod) => {
+	const amt = dinero({ amount: errorsPrices[rp], currency: USD })
+	const formatted = toDecimal(amt)
+	return `After this monthly limit is reached, extra errors will be charged $${formatted} per 1,000 errors.`
+}
 
 const freePlan: BillingPlan = {
 	name: 'Free',
@@ -28,12 +49,12 @@ const freePlan: BillingPlan = {
 	advertisedFeatures: [
 		{
 			text: '500 sessions / month',
-			tooltip:
+			tooltip: () =>
 				'After this monthly limit is reached, sessions will be recorded but will not be visible until your plan is upgraded.',
 		},
 		{
 			text: '1,000 errors / month',
-			tooltip:
+			tooltip: () =>
 				'After this monthly limit is reached, errors will be recorded but will not be visible until your plan is upgraded.',
 		},
 		'3 month retention',
@@ -49,11 +70,11 @@ const litePlan: BillingPlan = {
 	advertisedFeatures: [
 		{
 			text: '2,000 free sessions / mo',
-			tooltip: SESSIONS_AFTER_LIMIT_TOOLTIP,
+			tooltip: getSessionsAfterLimitTooltip,
 		},
 		{
 			text: '4,000 free errors / mo',
-			tooltip: ERRORS_AFTER_LIMIT_TOOLTIP,
+			tooltip: getErrorsAfterLimitTooltip,
 		},
 		'Unlimited members included',
 		'Unlimited dev tools access',
@@ -68,11 +89,11 @@ const basicPlan: BillingPlan = {
 	advertisedFeatures: [
 		{
 			text: '10,000 free sessions / mo',
-			tooltip: SESSIONS_AFTER_LIMIT_TOOLTIP,
+			tooltip: getSessionsAfterLimitTooltip,
 		},
 		{
 			text: '20,000 free errors / mo',
-			tooltip: ERRORS_AFTER_LIMIT_TOOLTIP,
+			tooltip: getErrorsAfterLimitTooltip,
 		},
 		'Everything in Basic',
 	],
@@ -86,11 +107,11 @@ const startupPlan: BillingPlan = {
 	advertisedFeatures: [
 		{
 			text: '80,000 free sessions / mo',
-			tooltip: SESSIONS_AFTER_LIMIT_TOOLTIP,
+			tooltip: getSessionsAfterLimitTooltip,
 		},
 		{
 			text: '160,000 free errors / mo',
-			tooltip: ERRORS_AFTER_LIMIT_TOOLTIP,
+			tooltip: getErrorsAfterLimitTooltip,
 		},
 		'Everything in Essentials',
 		'Enhanced user metadata',

--- a/frontend/src/pages/Billing/BillingPlanCard/BillingPlanCard.tsx
+++ b/frontend/src/pages/Billing/BillingPlanCard/BillingPlanCard.tsx
@@ -123,7 +123,10 @@ export const BillingPlanCard = ({
 							<span>
 								{feature.text}
 								<InfoTooltip
-									title={feature.tooltip}
+									title={
+										feature.tooltip &&
+										feature.tooltip(retentionPeriod)
+									}
 									size="medium"
 								/>
 							</span>

--- a/frontend/src/pages/Billing/BillingStatusCard/BillingStatusCard.tsx
+++ b/frontend/src/pages/Billing/BillingStatusCard/BillingStatusCard.tsx
@@ -15,20 +15,19 @@ import { Divider } from 'antd'
 import {
 	add,
 	dinero,
-	down,
 	isZero,
 	lessThan,
 	multiply,
 	subtract,
-	toUnit,
+	toDecimal,
 } from 'dinero.js'
 import moment from 'moment'
 import React from 'react'
 
 import styles from './BillingStatusCard.module.scss'
 
-const SESSIONS_PRICE_PER_THOUSAND = 5
-const ERRORS_PRICE_PER_THOUSAND = 0.2
+const SESSIONS_CENTS_PER_THOUSAND = 500
+const ERRORS_CENTS_PER_THOUSAND = 20
 export const MEMBERS_PRICE = 20
 
 export const BillingStatusCard = ({
@@ -114,9 +113,9 @@ export const BillingStatusCard = ({
 	const overageSubtotal = dinero({
 		amount:
 			Math.ceil(sessionsOverage / 1000) *
-				SESSIONS_PRICE_PER_THOUSAND *
+				SESSIONS_CENTS_PER_THOUSAND *
 				100 +
-			Math.ceil(errorsOverage / 1000) * ERRORS_PRICE_PER_THOUSAND * 100,
+			Math.ceil(errorsOverage / 1000) * ERRORS_CENTS_PER_THOUSAND * 100,
 		currency: USD,
 	})
 
@@ -204,7 +203,7 @@ export const BillingStatusCard = ({
 					<Skeleton width="45px" />
 				) : (
 					<span className={styles.subtotal}>
-						${toUnit(baseSubtotal, { digits: 2, round: down })}
+						${toDecimal(baseSubtotal)}
 					</span>
 				)}
 			</div>
@@ -278,11 +277,7 @@ export const BillingStatusCard = ({
 							<Skeleton width="45px" />
 						) : (
 							<span className={styles.subtotal}>
-								$
-								{toUnit(membersSubtotal, {
-									digits: 2,
-									round: down,
-								})}
+								${toDecimal(membersSubtotal)}
 							</span>
 						)}
 					</div>
@@ -314,11 +309,7 @@ export const BillingStatusCard = ({
 							<Skeleton width="45px" />
 						) : (
 							<span className={styles.subtotal}>
-								$
-								{toUnit(overageSubtotal, {
-									digits: 2,
-									round: down,
-								})}
+								${toDecimal(overageSubtotal)}
 							</span>
 						)}
 					</div>
@@ -382,12 +373,7 @@ export const BillingStatusCard = ({
 								<span>Discount: {discountPercent}% off</span>
 							) : (
 								<span>
-									Discount: $
-									{toUnit(discountAmount, {
-										digits: 2,
-										round: down,
-									})}{' '}
-									off
+									Discount: ${toDecimal(discountAmount)} off
 								</span>
 							)
 						) : null}
@@ -409,11 +395,7 @@ export const BillingStatusCard = ({
 										</span>
 									)}
 									<span className={styles.subtotal}>
-										$
-										{toUnit(total, {
-											digits: 2,
-											round: down,
-										})}{' '}
+										${toDecimal(total)}
 									</span>
 								</>
 							)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7074,28 +7074,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dinero.js/calculator-number@npm:2.0.0-alpha.8":
-  version: 2.0.0-alpha.8
-  resolution: "@dinero.js/calculator-number@npm:2.0.0-alpha.8"
+"@dinero.js/calculator-number@npm:2.0.0-alpha.14":
+  version: 2.0.0-alpha.14
+  resolution: "@dinero.js/calculator-number@npm:2.0.0-alpha.14"
   dependencies:
-    "@dinero.js/core": 2.0.0-alpha.8
-  checksum: 843f05ba3f30e08f78469f1ad0c83bcbbc789455a60061a5a956867c950b2e627ad17708d86e088ff2bc39458d847ba242f6e5c6cdedca1db9d61965f60195b4
+    "@dinero.js/core": 2.0.0-alpha.14
+  checksum: 8d3a726daa7e7448aa83159132ba5751a295d5bdbb81f7a220781a0d8924843e491c998357ce63697e373d104e6a8c9aacd13355f6389e00463c9b22ab1f19ca
   languageName: node
   linkType: hard
 
-"@dinero.js/core@npm:2.0.0-alpha.8":
-  version: 2.0.0-alpha.8
-  resolution: "@dinero.js/core@npm:2.0.0-alpha.8"
+"@dinero.js/core@npm:2.0.0-alpha.14":
+  version: 2.0.0-alpha.14
+  resolution: "@dinero.js/core@npm:2.0.0-alpha.14"
   dependencies:
-    "@dinero.js/currencies": 2.0.0-alpha.8
-  checksum: a747cec35e6709e23d8e41666fcce467faffa58248dbbd3440785dbecc8fc55379f608e16ecb7fe9c0007e29b1872f05666ce10891138fe0f856d0e825ecfe2d
+    "@dinero.js/currencies": 2.0.0-alpha.14
+  checksum: cb13efd3de18de1d7805ddad382d176d74428235efeb19be6cc3b06c5ad38c297300c14043c33b20e4567be851a66ff68115c87eec97bdcaf31568b3ed785243
   languageName: node
   linkType: hard
 
-"@dinero.js/currencies@npm:2.0.0-alpha.8":
-  version: 2.0.0-alpha.8
-  resolution: "@dinero.js/currencies@npm:2.0.0-alpha.8"
-  checksum: db1e2e775df9c2c211f245bd966c9f66d7e3fb7b6989ce6f2246b2c5685337c72eb9b1ae9c38adcb5aa745f5a7e6f8c8e3207dac47f87ab31698b5e9b00c3206
+"@dinero.js/currencies@npm:2.0.0-alpha.14":
+  version: 2.0.0-alpha.14
+  resolution: "@dinero.js/currencies@npm:2.0.0-alpha.14"
+  checksum: d764b60e993e90d1385c01ee372cab74ca19a33c1354b22f529ef8961a496e4bbc84e41a20229548258e00e6cb349f41aa88a80d9d3d52b3deb7378da7b76dd6
   languageName: node
   linkType: hard
 
@@ -10159,7 +10159,7 @@ __metadata:
     color-hash: ^2.0.1
     dexie: ^3.2.2
     dexie-react-hooks: ^1.1.1
-    dinero.js: ^2.0.0-alpha.8
+    dinero.js: alpha
     eslint: ^7.0.0
     eslint-config-prettier: ^7.2.0
     eslint-plugin-react: ^7.31.11
@@ -24698,14 +24698,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dinero.js@npm:^2.0.0-alpha.8":
-  version: 2.0.0-alpha.8
-  resolution: "dinero.js@npm:2.0.0-alpha.8"
+"dinero.js@npm:alpha":
+  version: 2.0.0-alpha.14
+  resolution: "dinero.js@npm:2.0.0-alpha.14"
   dependencies:
-    "@dinero.js/calculator-number": 2.0.0-alpha.8
-    "@dinero.js/core": 2.0.0-alpha.8
-    "@dinero.js/currencies": 2.0.0-alpha.8
-  checksum: ca57fc25fa296d3b188ff4b6c47b21461d8d709c8b55c41cb5ce848b7f4986e882ed06ed6348a2c088406a6a57ef683c112b472c7af88c84903d95483ebd0a69
+    "@dinero.js/calculator-number": 2.0.0-alpha.14
+    "@dinero.js/core": 2.0.0-alpha.14
+    "@dinero.js/currencies": 2.0.0-alpha.14
+  checksum: c48163bf32bb9ba260de6a8018bde4e2294c87c2f4f85c6a5b796d4b96bef42cac79a2bfb00d2da7fd841067a228ebf4c0302c6c300ca60c1eaee5154112c75a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- upgrade to latest version of `dinero` for `toDecimal`
- adjust tooltip text based on retention period
- represent session + error overage prices as cents to avoid floating point math (crashes page for certain inputs because of an `assert` in the `dinero` constructor)
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
