### PR TITLE
fix: removed groupbytrace otel processor

### DIFF
--- a/docker/otel-collector.yaml
+++ b/docker/otel-collector.yaml
@@ -17,10 +17,6 @@ exporters:
             Authorization: 969e17fe-77aa-4f5a-8602-e50ebfccf816
 processors:
     batch:
-    groupbytrace:
-        wait_duration: 10s
-        num_traces: 100
-        num_workers: 1
 service:
     extensions: [health_check]
     pipelines:
@@ -38,7 +34,7 @@ service:
             exporters: [otlphttp]
         traces/traceloop:
             receivers: [otlp]
-            processors: [groupbytrace, batch]
+            processors: [batch]
             exporters: [otlphttp/traceloop]
 extensions:
     health_check:


### PR DESCRIPTION
## Summary
Since we're not using the `otel-contrib` image, the `groupby` processor is missing, so we remove it.
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
