### PR TITLE
billing page - fixup cents calc

### DIFF
--- a/frontend/src/pages/Billing/BillingStatusCard/BillingStatusCard.tsx
+++ b/frontend/src/pages/Billing/BillingStatusCard/BillingStatusCard.tsx
@@ -112,10 +112,8 @@ export const BillingStatusCard = ({
 	})
 	const overageSubtotal = dinero({
 		amount:
-			Math.ceil(sessionsOverage / 1000) *
-				SESSIONS_CENTS_PER_THOUSAND *
-				100 +
-			Math.ceil(errorsOverage / 1000) * ERRORS_CENTS_PER_THOUSAND * 100,
+			Math.ceil(sessionsOverage / 1000) * SESSIONS_CENTS_PER_THOUSAND +
+			Math.ceil(errorsOverage / 1000) * ERRORS_CENTS_PER_THOUSAND,
 		currency: USD,
 	})
 


### PR DESCRIPTION
## Summary
- showing overage as 100x what it should be after the change to use cents - fix this
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click test locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
