### PR TITLE
replace fingerprint with generated client id

### DIFF
--- a/sdk/client/package.json
+++ b/sdk/client/package.json
@@ -59,7 +59,6 @@
 		"vitest": "^0.24.1"
 	},
 	"dependencies": {
-		"@highlight-run/fingerprintjs": "^3.3.5",
 		"@highlight-run/rrweb": "workspace:*",
 		"error-stack-parser": "2.0.6",
 		"esbuild": "^0.14.47",

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -47,7 +47,6 @@ import SessionShortcutListener from './listeners/session-shortcut/session-shortc
 import { WebVitalsListener } from './listeners/web-vitals-listener/web-vitals-listener'
 import { initializeFeedbackWidget } from './ui/feedback-widget/feedback-widget'
 import { getPerformanceMethods } from './utils/performance/performance'
-import FingerprintJS, { Agent } from '@highlight-run/fingerprintjs'
 import {
 	PerformanceListener,
 	PerformancePayload,
@@ -169,7 +168,6 @@ export class Highlight {
 	manualStopped!: boolean
 	state!: 'NotRecording' | 'Recording'
 	logger!: Logger
-	fingerprintjs!: Promise<Agent>
 	enableSegmentIntegration!: boolean
 	enableStrictPrivacy!: boolean
 	enableCanvasRecording!: boolean
@@ -211,20 +209,6 @@ export class Highlight {
 		options: HighlightClassOptions,
 		firstLoadListeners?: FirstLoadListeners,
 	) {
-		// setup fingerprintjs as early as possible for it to run background tasks
-		// exclude sources that are slow and may block DOM rendering
-		this.fingerprintjs = FingerprintJS.load({
-			excludeSources: [
-				'fonts', // slow with lots of fonts
-				'domBlockers', // causes reflow, slow
-				'fontPreferences', // slow
-				'audio', //slow
-				'screenFrame', // causes reflow, slow
-				'timezone', // slow
-				'plugins', // very slow
-				'canvas', // slow
-			],
-		})
 		if (!options.sessionSecureID) {
 			// Firstload versions before 3.0.1 did not have this property
 			options.sessionSecureID = GenerateSecureID()
@@ -572,8 +556,6 @@ export class Highlight {
 					this.options.networkRecording?.recordHeadersAndBody || false
 			}
 
-			const client = await this.fingerprintjs
-			const fingerprint = await client.get()
 			let destinationDomains: string[] = []
 			if (
 				typeof this.options.networkRecording === 'object' &&
@@ -591,7 +573,7 @@ export class Highlight {
 					firstloadVersion: this.firstloadVersion,
 					clientConfig: JSON.stringify(this._optionsInternal),
 					environment: this.environment,
-					id: fingerprint.visitorId,
+					id: clientID,
 					appVersion: this.appVersion,
 					session_secure_id: this.sessionData.sessionSecureID,
 					client_id: clientID,

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "5.3.1",
+	"version": "5.3.2",
 	"scripts": {
 		"build": "yarn typegen && rollup -c",
 		"dev": "rollup -c -w",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10031,7 +10031,6 @@ __metadata:
     "@graphql-codegen/typescript": ^2.8.1
     "@graphql-codegen/typescript-graphql-request": ^4.5.2
     "@graphql-codegen/typescript-operations": ^2.5.2
-    "@highlight-run/fingerprintjs": ^3.3.5
     "@highlight-run/rrweb": "workspace:*"
     "@highlight-run/rrweb-types": "workspace:*"
     "@rollup/plugin-commonjs": ^22.0.1
@@ -10088,15 +10087,6 @@ __metadata:
     typescript: ^4.9.5
   languageName: unknown
   linkType: soft
-
-"@highlight-run/fingerprintjs@npm:^3.3.5":
-  version: 3.3.5
-  resolution: "@highlight-run/fingerprintjs@npm:3.3.5"
-  dependencies:
-    tslib: ^2.0.1
-  checksum: 130575d91be5ba9b767f3d0fb49584769f7ae04864f2c8487f57248497746b8002a5f46e22c60022f170b4005097aaed4186747473664c09e55ce2bb656b09c2
-  languageName: node
-  linkType: hard
 
 "@highlight-run/frontend@workspace:frontend":
   version: 0.0.0-use.local


### PR DESCRIPTION
## Summary

Customers have reported finding collisions in the `fingerprint` session value. Our usage of fingerprint.js limits what heuristics it uses so there are likely collisions in the ids.

Switch to using the generated clientID as the fingerprint for consistency in our session search and frontend UI. 

On our backend, we expect the fingerprint as a string now that is hashed, so the change should be entirely compatible.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

New client version.
