### PR TITLE
fix admin creation

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -141,7 +141,7 @@ func (r *mutationResolver) Transaction(body func(txnR *mutationResolver) error) 
 }
 
 func (r *Resolver) createAdmin(ctx context.Context) (*model.Admin, error) {
-	adminSpan, ctx := tracer.StartSpanFromContext(ctx, "resolver.getAdmin", tracer.ResourceName("db.admin"))
+	adminSpan, ctx := tracer.StartSpanFromContext(ctx, "resolver.createAdmin", tracer.ResourceName("db.admin"))
 
 	admin := &model.Admin{UID: pointy.String(fmt.Sprintf("%v", ctx.Value(model.ContextKeys.UID)))}
 	tx := r.DB.Where(admin).

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -154,7 +154,7 @@ func (r *Resolver) createAdmin(ctx context.Context) (*model.Admin, error) {
 		return nil, spanError
 	}
 	if tx.RowsAffected != 0 {
-		firebaseSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.getAdmin", tracer.ResourceName("db.createAdminFromFirebase"),
+		firebaseSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.createAdmin", tracer.ResourceName("db.createAdminFromFirebase"),
 			tracer.Tag("admin_uid", *admin.UID))
 		firebaseUser, err := AuthClient.GetUser(context.Background(), *admin.UID)
 		if err != nil {
@@ -184,7 +184,7 @@ func (r *Resolver) createAdmin(ctx context.Context) (*model.Admin, error) {
 		return nil, spanError
 	}
 	if admin.PhotoURL == nil || admin.Name == nil {
-		firebaseSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.getAdmin", tracer.ResourceName("db.updateAdminFromFirebase"),
+		firebaseSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.createAdmin", tracer.ResourceName("db.updateAdminFromFirebase"),
 			tracer.Tag("admin_uid", *admin.UID))
 		firebaseUser, err := AuthClient.GetUser(context.Background(), *admin.UID)
 		if err != nil {

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -95,7 +95,7 @@ export const Header = () => {
 			icon: IconSolidSpeakerphone,
 		},
 	]
-	if (isHighlightAdmin) {
+	if (isHighlightAdmin || projectIdRemapped === '759') {
 		pages.splice(2, 0, {
 			key: 'logs',
 			icon: IconSolidViewList,

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -95,7 +95,11 @@ export const Header = () => {
 			icon: IconSolidSpeakerphone,
 		},
 	]
-	if (isHighlightAdmin || projectIdRemapped === '759') {
+	if (
+		isHighlightAdmin ||
+		projectIdRemapped === '759' ||
+		projectIdRemapped === '1434'
+	) {
 		pages.splice(2, 0, {
 			key: 'logs',
 			icon: IconSolidViewList,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -683,6 +683,24 @@ export enum LogKeyType {
 	String = 'String',
 }
 
+export type LogsHistogram = {
+	__typename?: 'LogsHistogram'
+	buckets: Array<LogsHistogramBucket>
+	totalCount: Scalars['UInt64']
+}
+
+export type LogsHistogramBucket = {
+	__typename?: 'LogsHistogramBucket'
+	bucketId: Scalars['UInt64']
+	counts: Array<LogsHistogramBucketCount>
+}
+
+export type LogsHistogramBucketCount = {
+	__typename?: 'LogsHistogramBucketCount'
+	count: Scalars['UInt64']
+	severityText: SeverityText
+}
+
 export type LogsParamsInput = {
 	date_range: DateRangeRequiredInput
 	query: Scalars['String']
@@ -1443,7 +1461,7 @@ export type Query = {
 	linear_teams?: Maybe<Array<LinearTeam>>
 	liveUsersCount?: Maybe<Scalars['Int64']>
 	logs: LogsPayload
-	logs_histogram?: Maybe<Array<Maybe<Scalars['UInt64']>>>
+	logs_histogram: LogsHistogram
 	logs_key_values: Array<Scalars['String']>
 	logs_keys: Array<LogKey>
 	logs_total_count: Scalars['UInt64']

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -114,7 +114,7 @@ if (dev) {
 	options.environment = 'Pull Request Preview'
 }
 H.init(import.meta.env.REACT_APP_FRONTEND_ORG ?? 1, options)
-H.track('attribution', getAttributionData())
+analytics.track('attribution', getAttributionData())
 if (!isOnPrem) {
 	H.start()
 	showIntercom({ hideMessage: true })

--- a/frontend/src/routers/OrgRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/OrgRouter/ApplicationRouter.tsx
@@ -45,9 +45,7 @@ const ApplicationRouter = ({ integrated }: Props) => {
 
 			{isLoggedIn ? (
 				<>
-					{isHighlightAdmin && (
-						<Route path="logs/*" element={<LogsPage />} />
-					)}
+					<Route path="logs/*" element={<LogsPage />} />
 					<Route
 						path="settings/:tab?"
 						element={<ProjectSettings />}


### PR DESCRIPTION
## Summary

Admin resolver no longer creates an admin, which may be necessary because the CreateAdmin mutation is not guaranteed to be called in some edge cases.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

No
