### PR TITLE
add a date range when choosing log key values

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -745,7 +745,7 @@ type ComplexityRoot struct {
 		LiveUsersCount               func(childComplexity int, projectID int) int
 		Logs                         func(childComplexity int, projectID int, params model.LogsParamsInput, after *string) int
 		LogsHistogram                func(childComplexity int, projectID int, params model.LogsParamsInput) int
-		LogsKeyValues                func(childComplexity int, projectID int, keyName string) int
+		LogsKeyValues                func(childComplexity int, projectID int, keyName string, dateRange model.DateRangeRequiredInput) int
 		LogsKeys                     func(childComplexity int, projectID int) int
 		LogsTotalCount               func(childComplexity int, projectID int, params model.LogsParamsInput) int
 		Messages                     func(childComplexity int, sessionSecureID string) int
@@ -1363,7 +1363,7 @@ type QueryResolver interface {
 	LogsTotalCount(ctx context.Context, projectID int, params model.LogsParamsInput) (uint64, error)
 	LogsHistogram(ctx context.Context, projectID int, params model.LogsParamsInput) (*model.LogsHistogram, error)
 	LogsKeys(ctx context.Context, projectID int) ([]*model.LogKey, error)
-	LogsKeyValues(ctx context.Context, projectID int, keyName string) ([]string, error)
+	LogsKeyValues(ctx context.Context, projectID int, keyName string, dateRange model.DateRangeRequiredInput) ([]string, error)
 }
 type SegmentResolver interface {
 	Params(ctx context.Context, obj *model1.Segment) (*model1.SearchParams, error)
@@ -5404,7 +5404,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.LogsKeyValues(childComplexity, args["project_id"].(int), args["key_name"].(string)), true
+		return e.complexity.Query.LogsKeyValues(childComplexity, args["project_id"].(int), args["key_name"].(string), args["date_range"].(model.DateRangeRequiredInput)), true
 
 	case "Query.logs_keys":
 		if e.complexity.Query.LogsKeys == nil {
@@ -9191,7 +9191,11 @@ type Query {
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_histogram(project_id: ID!, params: LogsParamsInput!): LogsHistogram!
 	logs_keys(project_id: ID!): [LogKey!]!
-	logs_key_values(project_id: ID!, key_name: String!): [String!]!
+	logs_key_values(
+		project_id: ID!
+		key_name: String!
+		date_range: DateRangeRequiredInput!
+	): [String!]!
 }
 
 type Mutation {
@@ -13472,6 +13476,15 @@ func (ec *executionContext) field_Query_logs_key_values_args(ctx context.Context
 		}
 	}
 	args["key_name"] = arg1
+	var arg2 model.DateRangeRequiredInput
+	if tmp, ok := rawArgs["date_range"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("date_range"))
+		arg2, err = ec.unmarshalNDateRangeRequiredInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐDateRangeRequiredInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["date_range"] = arg2
 	return args, nil
 }
 
@@ -42578,7 +42591,7 @@ func (ec *executionContext) _Query_logs_key_values(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().LogsKeyValues(rctx, fc.Args["project_id"].(int), fc.Args["key_name"].(string))
+		return ec.resolvers.Query().LogsKeyValues(rctx, fc.Args["project_id"].(int), fc.Args["key_name"].(string), fc.Args["date_range"].(model.DateRangeRequiredInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -65841,6 +65854,11 @@ func (ec *executionContext) unmarshalNDateRangeInput2githubᚗcomᚋhighlightᚑ
 func (ec *executionContext) unmarshalNDateRangeInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐDateRangeInput(ctx context.Context, v interface{}) (*model.DateRangeInput, error) {
 	res, err := ec.unmarshalInputDateRangeInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNDateRangeRequiredInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐDateRangeRequiredInput(ctx context.Context, v interface{}) (model.DateRangeRequiredInput, error) {
+	res, err := ec.unmarshalInputDateRangeRequiredInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNDateRangeRequiredInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐDateRangeRequiredInput(ctx context.Context, v interface{}) (*model.DateRangeRequiredInput, error) {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1477,7 +1477,11 @@ type Query {
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_histogram(project_id: ID!, params: LogsParamsInput!): LogsHistogram!
 	logs_keys(project_id: ID!): [LogKey!]!
-	logs_key_values(project_id: ID!, key_name: String!): [String!]!
+	logs_key_values(
+		project_id: ID!
+		key_name: String!
+		date_range: DateRangeRequiredInput!
+	): [String!]!
 }
 
 type Mutation {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7033,13 +7033,13 @@ func (r *queryResolver) LogsKeys(ctx context.Context, projectID int) ([]*modelIn
 }
 
 // LogsKeyValues is the resolver for the logs_key_values field.
-func (r *queryResolver) LogsKeyValues(ctx context.Context, projectID int, keyName string) ([]string, error) {
+func (r *queryResolver) LogsKeyValues(ctx context.Context, projectID int, keyName string, dateRange modelInputs.DateRangeRequiredInput) ([]string, error) {
 	project, err := r.isAdminInProject(ctx, projectID)
 	if err != nil {
 		return nil, e.Wrap(err, "error querying project")
 	}
 
-	return r.ClickhouseClient.LogsKeyValues(ctx, project.ID, keyName)
+	return r.ClickhouseClient.LogsKeyValues(ctx, project.ID, keyName, dateRange.StartDate, dateRange.EndDate)
 }
 
 // Params is the resolver for the params field.

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -11677,8 +11677,16 @@ export type GetLogsKeysQueryResult = Apollo.QueryResult<
 	Types.GetLogsKeysQueryVariables
 >
 export const GetLogsKeyValuesDocument = gql`
-	query GetLogsKeyValues($project_id: ID!, $key_name: String!) {
-		logs_key_values(project_id: $project_id, key_name: $key_name)
+	query GetLogsKeyValues(
+		$project_id: ID!
+		$key_name: String!
+		$date_range: DateRangeRequiredInput!
+	) {
+		logs_key_values(
+			project_id: $project_id
+			key_name: $key_name
+			date_range: $date_range
+		)
 	}
 `
 
@@ -11696,6 +11704,7 @@ export const GetLogsKeyValuesDocument = gql`
  *   variables: {
  *      project_id: // value for 'project_id'
  *      key_name: // value for 'key_name'
+ *      date_range: // value for 'date_range'
  *   },
  * });
  */

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4002,6 +4002,7 @@ export type GetLogsKeysQuery = { __typename?: 'Query' } & {
 export type GetLogsKeyValuesQueryVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	key_name: Types.Scalars['String']
+	date_range: Types.DateRangeRequiredInput
 }>
 
 export type GetLogsKeyValuesQuery = { __typename?: 'Query' } & Pick<

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1802,6 +1802,7 @@ export type QueryLogs_HistogramArgs = {
 }
 
 export type QueryLogs_Key_ValuesArgs = {
+	date_range: DateRangeRequiredInput
 	key_name: Scalars['String']
 	project_id: Scalars['ID']
 }

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1894,6 +1894,14 @@ query GetLogsKeys($project_id: ID!) {
 	}
 }
 
-query GetLogsKeyValues($project_id: ID!, $key_name: String!) {
-	logs_key_values(project_id: $project_id, key_name: $key_name)
+query GetLogsKeyValues(
+	$project_id: ID!
+	$key_name: String!
+	$date_range: DateRangeRequiredInput!
+) {
+	logs_key_values(
+		project_id: $project_id
+		key_name: $key_name
+		date_range: $date_range
+	)
 }

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -14,7 +14,7 @@ import {
 	withDefault,
 } from 'use-query-params'
 
-const FORMAT = 'YYYY-MM-DDTHH:mm:00.000000000Z'
+export const FORMAT = 'YYYY-MM-DDTHH:mm:00.000000000Z'
 const now = moment()
 const fifteenMinutesAgo = now.clone().subtract(15, 'minutes').toDate()
 const thirtyDaysAgo = now.clone().subtract(30, 'days').toDate()

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -16,6 +16,7 @@ import {
 	useFormState,
 } from '@highlight-run/ui'
 import { useProjectId } from '@hooks/useProjectId'
+import { FORMAT } from '@pages/LogsPage/LogsPage'
 import {
 	BODY_KEY,
 	LogsSearchParam,
@@ -23,6 +24,7 @@ import {
 	stringifyLogsQuery,
 } from '@pages/LogsPage/SearchForm/utils'
 import { useParams } from '@util/react-router/useParams'
+import moment from 'moment'
 import React, { useEffect, useRef, useState } from 'react'
 
 import * as styles from './SearchForm.css'
@@ -81,7 +83,11 @@ const SearchForm = ({
 				width="full"
 				borderBottom="dividerWeak"
 			>
-				<Search keys={keysData?.logs_keys} />
+				<Search
+					keys={keysData?.logs_keys}
+					startDate={startDate}
+					endDate={endDate}
+				/>
 				<Box display="flex" pr="8" py="6">
 					<PreviousDateRangePicker
 						selectedDates={selectedDates}
@@ -99,7 +105,9 @@ export { SearchForm }
 
 const Search: React.FC<{
 	keys?: GetLogsKeysQuery['logs_keys']
-}> = ({ keys }) => {
+	startDate: Date
+	endDate: Date
+}> = ({ keys, startDate, endDate }) => {
 	const formState = useForm()
 	const [autoSelect, setAutoSelect] = useState(true)
 	const { query } = formState.values
@@ -138,9 +146,20 @@ const Search: React.FC<{
 			variables: {
 				project_id: project_id!,
 				key_name: activeTerm.key,
+				date_range: {
+					start_date: moment(startDate).format(FORMAT),
+					end_date: moment(endDate).format(FORMAT),
+				},
 			},
 		})
-	}, [activeTerm.key, getLogsKeyValues, project_id, showValues])
+	}, [
+		activeTerm.key,
+		endDate,
+		getLogsKeyValues,
+		project_id,
+		showValues,
+		startDate,
+	])
 
 	const handleItemSelect = (
 		key: GetLogsKeysQuery['logs_keys'][0] | string,


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Fetching values for keys takes too long. This is for two reasons:

* we are using an aggregation query `COUNT`
* we are not using a time range

This PR simplifies the query to fetch values to fix this issues. Per the linked issue, this dramatically speeds up the query.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Clicktested locally to confirm query still works.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

We should monitor in prod to confirm this results in the queries passing.
