### PR TITLE
fix recording in iframes without highlight in the parent window

### DIFF
--- a/frontend/src/pages/Setup/SetupPage.tsx
+++ b/frontend/src/pages/Setup/SetupPage.tsx
@@ -430,7 +430,7 @@ const App = () => {
 								<div className={styles.integrationContainer}>
 									<ButtonLink
 										anchor
-										href="https://docs.highlight.run/reactjs-integration"
+										href="https://www.highlight.io/docs/getting-started/client-sdk/replay-configuration/react-error-boundary"
 										trackingId="SetupPageDocsReact"
 									>
 										Learn More about the React Package
@@ -454,7 +454,7 @@ const App = () => {
 						<ul>
 							<li>
 								<a
-									href="https://docs.highlight.run/comments"
+									href="https://www.highlight.io/docs/general/product-features/general-features/comments"
 									target="_blank"
 									rel="noreferrer"
 								>
@@ -463,7 +463,7 @@ const App = () => {
 							</li>
 							<li>
 								<a
-									href="https://docs.highlight.run/user-feedback"
+									href="https://www.highlight.io/docs/sdk/client#feedbackWidget"
 									target="_blank"
 									rel="noreferrer"
 								>
@@ -473,7 +473,7 @@ const App = () => {
 							</li>
 							<li>
 								<a
-									href="https://docs.highlight.run/network-devtools"
+									href="https://www.highlight.io/docs/getting-started/client-sdk/replay-configuration/recording-network-requests-and-responses"
 									target="_blank"
 									rel="noreferrer"
 								>
@@ -482,7 +482,7 @@ const App = () => {
 							</li>
 							<li>
 								<a
-									href="https://docs.highlight.run/deployment-overview"
+									href="https://www.highlight.io/docs/general/company/open-source/self-host-hobby"
 									target="_blank"
 									rel="noreferrer"
 								>
@@ -491,7 +491,7 @@ const App = () => {
 							</li>
 							<li>
 								<a
-									href="https://docs.highlight.run/sourcemaps"
+									href="https://www.highlight.io/docs/general/product-features/error-monitoring/sourcemaps"
 									target="_blank"
 									rel="noreferrer"
 								>
@@ -504,7 +504,7 @@ const App = () => {
 						<div className={styles.integrationContainer}>
 							<ButtonLink
 								anchor
-								href="https://docs.highlight.run/"
+								href="https://www.highlight.io/docs/general/welcome"
 								trackingId="SetupPageDocs"
 							>
 								Read the Docs
@@ -531,6 +531,8 @@ const BackendSetup = ({
 	projectLoading: boolean
 	integrated: boolean
 }) => {
+	const projectVerboseId =
+		projectData?.project?.verbose_id || 'YOUR_PROJECT_ID'
 	return (
 		<>
 			<div className={styles.headingWrapper}>
@@ -560,11 +562,17 @@ const BackendSetup = ({
 			) : (
 				<div className={styles.stepsContainer}>
 					{backendPlatform === BackendPlatformType.NextJs ? (
-						<NextBackendInstructions />
+						<NextBackendInstructions
+							projectVerboseId={projectVerboseId}
+						/>
 					) : backendPlatform === BackendPlatformType.Express ? (
-						<ExpressBackendInstructions />
+						<ExpressBackendInstructions
+							projectVerboseId={projectVerboseId}
+						/>
 					) : (
-						<GoBackendInstructions />
+						<GoBackendInstructions
+							projectVerboseId={projectVerboseId}
+						/>
 					)}
 					<Section title="Frontend Configuration" defaultOpen>
 						<p>
@@ -572,7 +580,7 @@ const BackendSetup = ({
 							initialized with the below settings included.{' '}
 						</p>
 						<CodeBlock
-							text={`H.init("<YOUR_PROJECT_ID>", {
+							text={`H.init("${projectVerboseId}", {
     ...
     tracingOrigins: true,
     networkRecording: {
@@ -627,7 +635,7 @@ const BackendSetup = ({
 						<ul>
 							<li>
 								<a
-									href="https://docs.highlight.run/comments"
+									href="https://www.highlight.io/docs/general/product-features/general-features/comments"
 									target="_blank"
 									rel="noreferrer"
 								>
@@ -636,7 +644,7 @@ const BackendSetup = ({
 							</li>
 							<li>
 								<a
-									href="https://docs.highlight.run/user-feedback"
+									href="https://www.highlight.io/docs/sdk/client#feedbackWidget"
 									target="_blank"
 									rel="noreferrer"
 								>
@@ -646,7 +654,7 @@ const BackendSetup = ({
 							</li>
 							<li>
 								<a
-									href="https://docs.highlight.run/network-devtools"
+									href="https://www.highlight.io/docs/getting-started/client-sdk/replay-configuration/recording-network-requests-and-responses"
 									target="_blank"
 									rel="noreferrer"
 								>
@@ -655,7 +663,7 @@ const BackendSetup = ({
 							</li>
 							<li>
 								<a
-									href="https://docs.highlight.run/deployment-overview"
+									href="https://www.highlight.io/docs/general/company/open-source/self-host-hobby"
 									target="_blank"
 									rel="noreferrer"
 								>
@@ -664,7 +672,7 @@ const BackendSetup = ({
 							</li>
 							<li>
 								<a
-									href="https://docs.highlight.run/sourcemaps"
+									href="https://www.highlight.io/docs/general/product-features/error-monitoring/sourcemaps"
 									target="_blank"
 									rel="noreferrer"
 								>
@@ -677,7 +685,7 @@ const BackendSetup = ({
 						<div className={styles.integrationContainer}>
 							<ButtonLink
 								anchor
-								href="https://docs.highlight.run/"
+								href="https://www.highlight.io/docs/general/welcome"
 								trackingId="SetupPageDocs"
 							>
 								Read the Docs
@@ -804,7 +812,7 @@ const MoreSetup = ({
 						</p>
 						<div className={styles.integrationContainer}>
 							<ButtonLink
-								href="https://docs.highlight.run/proxying-highlight"
+								href="https://www.highlight.io/docs/getting-started/client-sdk/replay-configuration/proxying-highlight"
 								trackingId="ProxyDocsFromSetupPage"
 								anchor
 							>
@@ -913,7 +921,11 @@ const HtmlInstructions = ({
 	)
 }
 
-const NextBackendInstructions = () => {
+const NextBackendInstructions = ({
+	projectVerboseId,
+}: {
+	projectVerboseId: string
+}) => {
 	return (
 		<>
 			<Section title="Vercel Integration" defaultOpen>
@@ -969,7 +981,7 @@ export default withHighlightConfig({
 					and then defining it in a common file. You can configure how
 					Highlight records with the{' '}
 					<a
-						href="https://docs.highlight.run/api#w0-highlightoptions"
+						href="https://www.highlight.io/docs/sdk/client#Hinit"
 						target="_blank"
 						rel="noreferrer"
 					>
@@ -980,7 +992,7 @@ export default withHighlightConfig({
 				<p>
 					<CodeBlock
 						language="javascript"
-						text={`export const withHighlight = Highlight({projectID: 'YOUR_PROJECT_ID'});`}
+						text={`export const withHighlight = Highlight({projectID: '${projectVerboseId}'});`}
 					/>
 				</p>
 				<p>
@@ -1004,7 +1016,11 @@ export default withHighlight(handler);`}
 	)
 }
 
-const ExpressBackendInstructions = () => {
+const ExpressBackendInstructions = ({
+	projectVerboseId,
+}: {
+	projectVerboseId: string
+}) => {
 	return (
 		<>
 			<Section title="Installing the SDK" defaultOpen>
@@ -1032,7 +1048,7 @@ const ExpressBackendInstructions = () => {
 					and then calling as soon as you can in your site's startup
 					process. You can configure how Highlight records with the{' '}
 					<a
-						href="https://docs.highlight.run/api#w0-highlightoptions"
+						href="https://www.highlight.io/docs/sdk/client#Hinit"
 						target="_blank"
 						rel="noreferrer"
 					>
@@ -1043,9 +1059,7 @@ const ExpressBackendInstructions = () => {
 				<p>
 					<CodeBlock
 						language="javascript"
-						text={`const highlightOptions = {};
-const highlightHandler = Handlers.errorHandler(highlightOptions);
-`}
+						text={`const highlightHandler = Handlers.errorHandler({projectID: '${projectVerboseId}'});`}
 					/>
 				</p>
 				<p>
@@ -1067,7 +1081,11 @@ app.use(highlightHandler);`}
 	)
 }
 
-const GoBackendInstructions = () => {
+const GoBackendInstructions = ({
+	projectVerboseId,
+}: {
+	projectVerboseId: string
+}) => {
 	return (
 		<>
 			<Section title="Installing the SDK" defaultOpen>
@@ -1092,6 +1110,7 @@ const GoBackendInstructions = () => {
 
 func main() {
     //...application logic...
+    highlight.SetProjectID("${projectVerboseId}")
     highlight.Start()
     defer highlight.Stop()
     //...application logic...
@@ -1144,7 +1163,7 @@ func main() {
 					<div className={styles.integrationContainer}>
 						<ButtonLink
 							anchor
-							href="https://docs.highlight.run/go-backend"
+							href="https://www.highlight.io/docs/getting-started/backend-sdk/go/overview"
 							trackingId="SetupPageBackend"
 						>
 							See an Example
@@ -1212,7 +1231,7 @@ const JsAppInstructions = ({
 					you can in your site's startup process. You can configure
 					how Highlight records with the{' '}
 					<a
-						href="https://docs.highlight.run/api#w0-highlightoptions"
+						href="https://www.highlight.io/docs/sdk/client#Hinit"
 						target="_blank"
 						rel="noreferrer"
 					>

--- a/frontend/src/pages/Setup/SetupPage.tsx
+++ b/frontend/src/pages/Setup/SetupPage.tsx
@@ -1025,7 +1025,7 @@ const ExpressBackendInstructions = () => {
 			<Section title="Initializing Highlight on the Backend" defaultOpen>
 				<p>Initialize the SDK by importing Highlight like so: </p>
 				<CodeBlock
-					text={`import { Highlight } from '@highlight-run/node';`}
+					text={`import { Handlers } from '@highlight-run/node';`}
 					language="javascript"
 				/>
 				<p>
@@ -1044,19 +1044,19 @@ const ExpressBackendInstructions = () => {
 					<CodeBlock
 						language="javascript"
 						text={`const highlightOptions = {};
-const highlightHandler = Highlight.Handlers.errorHandler(highlightOptions);
+const highlightHandler = Handlers.errorHandler(highlightOptions);
 `}
 					/>
 				</p>
 				<p>
 					<CodeBlock
 						language="javascript"
-						text={`import { Highlight } from "@highlight-run/node";
+						text={`import { Handlers } from "@highlight-run/node";
 
 const app = express();
 
 const highlightOptions = {};
-const highlightHandler = Highlight.Handlers.errorHandler(highlightOptions);
+const highlightHandler = Handlers.errorHandler(highlightOptions);
 
 // This should be before any other error middleware and after all controllers
 app.use(highlightHandler);`}

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -103,6 +103,7 @@ export type HighlightClassOptions = {
 	inlineImages?: boolean
 	inlineStylesheet?: boolean
 	isCrossOriginIframe?: boolean
+	recordCrossOriginIframe?: boolean
 	firstloadVersion?: string
 	environment?: 'development' | 'production' | 'staging' | string
 	appVersion?: string
@@ -668,7 +669,8 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 					ignoreClass: 'highlight-ignore',
 					blockClass: 'highlight-block',
 					emit,
-					recordCrossOriginIframes: true,
+					recordCrossOriginIframes:
+						this.options.recordCrossOriginIframe,
 					enableStrictPrivacy: this.enableStrictPrivacy,
 					maskAllInputs: this.enableStrictPrivacy,
 					recordCanvas: this.enableCanvasRecording,
@@ -683,7 +685,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 						},
 					},
 					keepIframeSrcFn: (_src) => {
-						return !this.options.isCrossOriginIframe
+						return !this.options.recordCrossOriginIframe
 					},
 					inlineImages: this.inlineImages,
 					inlineStylesheet: this.inlineStylesheet,

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -153,6 +153,12 @@ export declare type HighlightOptions = {
 	 */
 	inlineStylesheet?: boolean
 	/**
+	 * Enables recording of cross-origin iframes. Should be set in both the parent window and
+	 * in the cross-origin iframe.
+	 * @default false
+	 */
+	recordCrossOriginIframe?: boolean
+	/**
 	 * Specifies that the current app is a cross origin iframe in an app where Highlight is also enabled.
 	 * This flag should only be set in the iframe, not in the parent application hosting the iframe.
 	 * This allows the iframe to forward its recording to the parent to be included as part of the session.

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -127,3 +127,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 - Defaults to inlining stylesheets.
 - Replaces fingerprint with generated client id.
 - Enables console and error recording on localhost.
+
+## 5.4.0
+
+### Minor Changes
+
+- Adds `recordCrossOriginIframe` setting to opt-in enable cross-origin iframe recording.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "5.3.3",
+	"version": "5.4.0",
 	"scripts": {
 		"build": "yarn typegen && rollup -c",
 		"dev": "rollup -c -w",

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -108,6 +108,7 @@ export const H: HighlightPublicInterface = {
 				samplingStrategy: options?.samplingStrategy,
 				inlineImages: options?.inlineImages,
 				inlineStylesheet: options?.inlineStylesheet,
+				recordCrossOriginIframe: options?.recordCrossOriginIframe,
 				isCrossOriginIframe: options?.isCrossOriginIframe,
 				firstloadVersion: packageJson['version'],
 				environment: options?.environment || 'production',


### PR DESCRIPTION
## Summary

Highlight does not record correctly in an iframe because of the cross-origin setting. Before this change,
when Highlight is added to an iframe with the intention to record just the iframe, we would assume that
the iframe was emitting events to the parent while there was no Highlight instance in the parent.

Since previously we would pass `recordCrossOriginIframes: true` to rrweb, the following logic in rrweb would never emit events in an iframe.

```ts
  const inEmittingFrame = recordCrossOriginIframes
    ? window.parent === window
    : true;
```

## How did you test this change?

Buttons page iframe recording.
![Screenshot 2023-03-06 at 12 55 09 PM](https://user-images.githubusercontent.com/1351531/223228559-53f22177-a6c0-47e8-aa34-d59505bb8fef.png)


## Are there any deployment considerations?

New highlight.run minor version bump.