### PR TITLE
Issue #4416 - show count per network request type

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -71,7 +71,6 @@ const DevToolsWindowV2: React.FC<
 	const countPerRequestType = useMemo(() => {
 		const count: ICountPerRequestType = {
 			All: 0,
-			beacon: 0,
 			link: 0,
 			script: 0,
 			other: 0,
@@ -83,9 +82,14 @@ const DevToolsWindowV2: React.FC<
 		}
 
 		parsedResources.forEach((request) => {
-			const type = request.initiatorType as keyof ICountPerRequestType
-			count[type] += 1
-			count['All'] += 1
+			const requestType =
+				request.initiatorType as keyof ICountPerRequestType
+
+			//-- Only count request types defined in ICountPerRequestType, e.g. skip 'beacon' --//
+			if (count.hasOwnProperty(request.initiatorType)) {
+				count['All'] += 1
+				count[requestType] += 1
+			}
 		})
 
 		return count
@@ -240,7 +244,9 @@ const DevToolsWindowV2: React.FC<
 											options={Object.values(
 												RequestType,
 											).map((requestType: string) => ({
-												key: requestType,
+												key: NETWORK_REQUEST_DISPLAY_NAMES[
+													requestType
+												],
 												render: `${
 													NETWORK_REQUEST_DISPLAY_NAMES[
 														requestType

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -24,10 +24,7 @@ import {
 	RequestType,
 	Tab,
 } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
-import {
-	ICountPerRequestType,
-	NETWORK_REQUEST_DISPLAY_NAMES,
-} from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
+import { ICountPerRequestType } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import useLocalStorage from '@rehooks/local-storage'
 import clsx from 'clsx'
 import React, { useMemo } from 'react'
@@ -241,25 +238,23 @@ const DevToolsWindowV2: React.FC<
 									) : selectedDevToolsTab === Tab.Network ? (
 										<MenuButton
 											size="medium"
-											options={Object.values(
+											options={Object.entries(
 												RequestType,
-											).map((requestType: string) => ({
-												key: NETWORK_REQUEST_DISPLAY_NAMES[
-													requestType
-												],
-												render: `${
-													NETWORK_REQUEST_DISPLAY_NAMES[
-														requestType
-													]
-												} (${
-													countPerRequestType[
-														requestType as keyof ICountPerRequestType
-													]
-												})`,
-											}))}
-											onChange={(rt: string) => {
+											).map(
+												([
+													displayName,
+													requestName,
+												]) => ({
+													key: displayName,
+													render: `${displayName} (${countPerRequestType[requestName]})`,
+												}),
+											)}
+											onChange={(displayName) => {
 												setRequestType(
-													rt as RequestType,
+													//-- Set type to be the requestName value --//
+													RequestType[
+														displayName as keyof typeof RequestType
+													],
 												)
 											}}
 										/>

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -125,6 +125,7 @@ export const LogLevelVariants = {
 
 export enum RequestType {
 	All = 'All',
+	Beacon = 'beacon',
 	Link = 'link',
 	Script = 'script',
 	Other = 'other',
@@ -135,8 +136,22 @@ export enum RequestType {
 	Img = 'img',
 }
 
+export interface ICountPerRequestType {
+	All: number
+	beacon: number
+	link: number
+	script: number
+	other: number
+	xmlhttprequest: number
+	css: number
+	iframe: number
+	fetch: number
+	img: number
+}
+
 export const NETWORK_REQUEST_DISPLAY_NAMES: { [key: string]: string } = {
 	All: 'All',
+	beacon: 'Beacon',
 	link: 'Link',
 	script: 'Script',
 	other: 'Other',

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -124,6 +124,7 @@ export const LogLevelVariants = {
 } as const
 
 export enum RequestType {
+	//-- [displayName]: requestName --//
 	All = 'All',
 	CSS = 'css',
 	Fetch = 'fetch',
@@ -147,24 +148,11 @@ export interface ICountPerRequestType {
 	xmlhttprequest: number
 }
 
-export const NETWORK_REQUEST_DISPLAY_NAMES: { [key: string]: string } = {
-	All: 'All',
-	css: 'CSS',
-	fetch: 'Fetch',
-	iframe: 'iFrame',
-	img: 'Img',
-	link: 'Link',
-	other: 'Other',
-	script: 'Script',
-	xmlhttprequest: 'XHR',
-} as const
-
 export const getNetworkResourcesDisplayName = (value: string): string => {
-	switch (true) {
-		case value in NETWORK_REQUEST_DISPLAY_NAMES: {
-			return NETWORK_REQUEST_DISPLAY_NAMES[value]
+	for (const [displayName, requestName] of Object.entries(RequestType)) {
+		if (value === requestName) {
+			return displayName
 		}
-		default:
-			return value?.charAt(0).toUpperCase() + value?.slice(1)
 	}
+	return value?.charAt(0).toUpperCase() + value?.slice(1)
 }

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -125,41 +125,38 @@ export const LogLevelVariants = {
 
 export enum RequestType {
 	All = 'All',
-	Beacon = 'beacon',
-	Link = 'link',
-	Script = 'script',
-	Other = 'other',
-	XHR = 'xmlhttprequest',
 	CSS = 'css',
-	iFrame = 'iframe', // didn't find a request to verify that 'iframe' is what is actually received
 	Fetch = 'fetch',
+	iFrame = 'iframe', // didn't find a request to verify that 'iframe' is what is actually received
 	Img = 'img',
+	Link = 'link',
+	Other = 'other',
+	Script = 'script',
+	XHR = 'xmlhttprequest',
 }
 
 export interface ICountPerRequestType {
 	All: number
-	beacon: number
-	link: number
-	script: number
-	other: number
-	xmlhttprequest: number
 	css: number
-	iframe: number
 	fetch: number
+	iframe: number
 	img: number
+	link: number
+	other: number
+	script: number
+	xmlhttprequest: number
 }
 
 export const NETWORK_REQUEST_DISPLAY_NAMES: { [key: string]: string } = {
 	All: 'All',
-	beacon: 'Beacon',
-	link: 'Link',
-	script: 'Script',
-	other: 'Other',
-	xmlhttprequest: 'XHR',
 	css: 'CSS',
-	iframe: 'iFrame',
 	fetch: 'Fetch',
+	iframe: 'iFrame',
 	img: 'Img',
+	link: 'Link',
+	other: 'Other',
+	script: 'Script',
+	xmlhttprequest: 'XHR',
 } as const
 
 export const getNetworkResourcesDisplayName = (value: string): string => {


### PR DESCRIPTION
## Summary

Issue #4416 
-Improves network request filtering
-Shows count per request type
-Displays proper name in MenuButton for selected network request filter type

-**Note - doesn't implement multi-select, perhaps that can be split into a separate issue**

## How did you test this change?

-Dev mode click test

![Screenshot 2023-03-06 at 3 11 22 PM](https://user-images.githubusercontent.com/59704103/223231712-aa8d26a0-1dfb-414e-9f96-2f5cf5a71a50.png)

![Screenshot 2023-03-06 at 3 11 44 PM](https://user-images.githubusercontent.com/59704103/223231782-d688371e-e5c6-4c26-b17c-eea064970d3d.png)

![Screenshot 2023-03-06 at 3 11 59 PM](https://user-images.githubusercontent.com/59704103/223231831-8b8f38cc-e6f6-4141-a917-957265c69f50.png)


## Are there any deployment considerations?

-None