### PR TITLE
add the ability to search body via message:value

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -320,10 +320,12 @@ func (client *Client) LogsKeys(ctx context.Context, projectID int) ([]*modelInpu
 	}
 
 	for _, key := range modelInputs.AllReservedLogKey {
-		keys = append(keys, &modelInputs.LogKey{
-			Name: key.String(),
-			Type: modelInputs.LogKeyTypeString,
-		})
+		if key != modelInputs.ReservedLogKeyMessage { // skip `message` since it's just noise
+			keys = append(keys, &modelInputs.LogKey{
+				Name: key.String(),
+				Type: modelInputs.LogKeyTypeString,
+			})
+		}
 	}
 
 	rows.Close()

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -551,7 +551,9 @@ type filters struct {
 }
 
 func makeFilters(query string) filters {
-	filters := filters{}
+	filters := filters{
+		attributes: make(map[string]string),
+	}
 
 	queries := splitQuery(query)
 

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -560,21 +560,21 @@ func TestReadLogsWithMessageFilter(t *testing.T) {
 	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "message:foo",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "message:*o*",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     "message:bar",
-	}, nil)
+	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 0)
 }

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -539,6 +539,46 @@ func TestReadLogsWithKeyFilter(t *testing.T) {
 	assert.Len(t, payload.Edges, 1)
 }
 
+func TestReadLogsWithMessageFilter(t *testing.T) {
+	ctx := context.Background()
+	client, teardown := setupTest(t)
+	defer teardown(t)
+
+	now := time.Now()
+	rows := []*LogRow{
+		{
+			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
+				Timestamp: now,
+				ProjectId: 1,
+			},
+			Body: "foo",
+		},
+	}
+
+	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
+
+	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "message:foo",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 1)
+
+	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "message:*o*",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 1)
+
+	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "message:bar",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 0)
+}
+
 func TestReadLogsWithLevelFilter(t *testing.T) {
 	ctx := context.Background()
 	client, teardown := setupTest(t)

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -8267,6 +8267,7 @@ enum ReservedLogKey {
 	Keep this in alpha order
 	"""
 	level
+	message
 	secure_session_id
 	span_id
 	trace_id

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1199,6 +1199,7 @@ type ReservedLogKey string
 const (
 	// Keep this in alpha order
 	ReservedLogKeyLevel           ReservedLogKey = "level"
+	ReservedLogKeyMessage         ReservedLogKey = "message"
 	ReservedLogKeySecureSessionID ReservedLogKey = "secure_session_id"
 	ReservedLogKeySpanID          ReservedLogKey = "span_id"
 	ReservedLogKeyTraceID         ReservedLogKey = "trace_id"
@@ -1206,6 +1207,7 @@ const (
 
 var AllReservedLogKey = []ReservedLogKey{
 	ReservedLogKeyLevel,
+	ReservedLogKeyMessage,
 	ReservedLogKeySecureSessionID,
 	ReservedLogKeySpanID,
 	ReservedLogKeyTraceID,
@@ -1213,7 +1215,7 @@ var AllReservedLogKey = []ReservedLogKey{
 
 func (e ReservedLogKey) IsValid() bool {
 	switch e {
-	case ReservedLogKeyLevel, ReservedLogKeySecureSessionID, ReservedLogKeySpanID, ReservedLogKeyTraceID:
+	case ReservedLogKeyLevel, ReservedLogKeyMessage, ReservedLogKeySecureSessionID, ReservedLogKeySpanID, ReservedLogKeyTraceID:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -537,6 +537,7 @@ enum ReservedLogKey {
 	Keep this in alpha order
 	"""
 	level
+	message
 	secure_session_id
 	span_id
 	trace_id

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2087,6 +2087,7 @@ export type ReferrerTablePayload = {
 export enum ReservedLogKey {
 	/** Keep this in alpha order */
 	Level = 'level',
+	Message = 'message',
 	SecureSessionId = 'secure_session_id',
 	SpanId = 'span_id',
 	TraceId = 'trace_id',

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -18,8 +18,8 @@ import {
 import { useProjectId } from '@hooks/useProjectId'
 import { FORMAT } from '@pages/LogsPage/LogsPage'
 import {
-	BODY_KEY,
 	LogsSearchParam,
+	MESSAGE_KEY,
 	parseLogsQuery,
 	stringifyLogsQuery,
 } from '@pages/LogsPage/SearchForm/utils'
@@ -123,7 +123,7 @@ const Search: React.FC<{
 	const activeTermIndex = getActiveTermIndex(cursorIndex, queryTerms)
 	const activeTerm = queryTerms[activeTermIndex]
 	const showValues =
-		activeTerm.key !== BODY_KEY ||
+		activeTerm.key !== MESSAGE_KEY ||
 		!!keys?.find((k) => k.name === activeTerm.key)
 	const loading = keys?.length === 0 || (showValues && valuesLoading)
 	const showTermSelect = !!activeTerm.value.length
@@ -246,7 +246,7 @@ const Search: React.FC<{
 										<Stack direction="row" gap="8">
 											<Text>{activeTerm.value}:</Text>{' '}
 											<Text color="weak">
-												{activeTerm.key ?? 'Body'}
+												{activeTerm.key ?? 'Message'}
 											</Text>
 										</Stack>
 									</Combobox.Item>
@@ -379,8 +379,8 @@ const getVisibleKeys = (
 			(key) =>
 				// If it's a new term, don't filter results.
 				startingNewTerm ||
-				// Only filter for body queries
-				(activeQueryTerm.key === BODY_KEY &&
+				// Only filter for message queries
+				(activeQueryTerm.key === MESSAGE_KEY &&
 					// Don't filter if no query term
 					(!activeQueryTerm.value.length ||
 						startingNewTerm ||

--- a/frontend/src/pages/LogsPage/SearchForm/utils.test.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.test.ts
@@ -1,5 +1,5 @@
 import {
-	BODY_KEY,
+	MESSAGE_KEY,
 	parseLogsQuery,
 	stringifyLogsQuery,
 	validateLogsQuery,
@@ -26,7 +26,7 @@ const complexQueryParams = [
 		offsetStart: 46,
 	},
 	{
-		key: BODY_KEY,
+		key: MESSAGE_KEY,
 		operator: '=',
 		value: 'freetext query',
 		offsetStart: 59,
@@ -39,7 +39,7 @@ describe('parseLogsQuery', () => {
 
 		expect(parseLogsQuery(query)).toEqual([
 			{
-				key: BODY_KEY,
+				key: MESSAGE_KEY,
 				operator: '=',
 				value: query,
 				offsetStart: 0,
@@ -62,7 +62,7 @@ describe('parseLogsQuery', () => {
 				offsetStart: 0,
 			},
 			{
-				key: BODY_KEY,
+				key: MESSAGE_KEY,
 				operator: '=',
 				value: 'search query',
 				offsetStart: 14,
@@ -86,7 +86,7 @@ describe('parseLogsQuery', () => {
 				offsetStart: 0,
 			},
 			{
-				key: BODY_KEY,
+				key: MESSAGE_KEY,
 				operator: '=',
 				value: '',
 				offsetStart: 19,
@@ -100,7 +100,7 @@ describe('stringifyLogsQuery', () => {
 		expect(
 			stringifyLogsQuery([
 				{
-					key: BODY_KEY,
+					key: MESSAGE_KEY,
 					operator: '=',
 					value: 'a test query',
 					offsetStart: 0,

--- a/frontend/src/pages/LogsPage/SearchForm/utils.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.ts
@@ -7,7 +7,7 @@ export type LogsSearchParam = {
 
 const SEPARATOR = ':'
 const DEFAULT_OPERATOR = '='
-export const BODY_KEY = 'body'
+export const MESSAGE_KEY = 'message'
 
 // Inspired by search-query-parser:
 // https://github.com/nepsilon/search-query-parser/blob/8158d09c70b66168440e93ffabd720f4c8314c9b/lib/search-query-parser.js#L40
@@ -18,7 +18,7 @@ export const parseLogsQuery = (query = ''): LogsSearchParam[] => {
 	if (query.indexOf(SEPARATOR) === -1) {
 		return [
 			{
-				key: BODY_KEY,
+				key: MESSAGE_KEY,
 				operator: DEFAULT_OPERATOR,
 				value: query,
 				offsetStart: 0,
@@ -43,7 +43,7 @@ export const parseLogsQuery = (query = ''): LogsSearchParam[] => {
 			})
 		} else {
 			const textTermIndex = terms.findIndex(
-				(term) => term.key === BODY_KEY,
+				(term) => term.key === MESSAGE_KEY,
 			)
 
 			if (textTermIndex !== -1) {
@@ -53,7 +53,7 @@ export const parseLogsQuery = (query = ''): LogsSearchParam[] => {
 				const isEmptyString = term === ' '
 
 				terms.push({
-					key: BODY_KEY,
+					key: MESSAGE_KEY,
 					operator: DEFAULT_OPERATOR,
 					value: isEmptyString ? '' : term,
 					offsetStart: isEmptyString ? match.index + 1 : match.index,
@@ -69,7 +69,7 @@ export const stringifyLogsQuery = (params: LogsSearchParam[]) => {
 	const querySegments: string[] = []
 
 	params.forEach((param) => {
-		if (param.key === BODY_KEY) {
+		if (param.key === MESSAGE_KEY) {
 			querySegments.push(param.value)
 		} else {
 			const value =


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

To accompany #4509, this allows one to search for the log body via `message:value`. We'll use this once we wire up clicking on a log property to prefill the search (see https://github.com/highlight/highlight/issues/4471#issuecomment-1456516602) 

This _does not_ include `message` in the dropdown keys because it would just be noise at that point:
![Screenshot 2023-03-07 at 9 43 53 AM](https://user-images.githubusercontent.com/58678/223489993-a06e83b0-208e-4a46-a442-b47878878b19.png)


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed direct search works:
![Screenshot 2023-03-07 at 9 42 50 AM](https://user-images.githubusercontent.com/58678/223489776-b8fb813e-f444-408a-8eb4-83b4dd5e3ad9.png)

Confirmed wildcard works:
![Screenshot 2023-03-07 at 9 43 09 AM](https://user-images.githubusercontent.com/58678/223489809-b37f5b1f-d837-4d8a-a4fb-1853299d289e.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
