### PR TITLE
fix searching log body with a space

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -552,7 +552,11 @@ func makeFilters(query string) filters {
 			if strings.Contains(body, "*") {
 				body = strings.ReplaceAll(body, "*", "%")
 			}
-			filters.body = filters.body + body
+			if len(filters.body) == 0 {
+				filters.body = body
+			} else {
+				filters.body = filters.body + " " + body
+			}
 		} else if len(parts) == 2 {
 			key, value := parts[0], parts[1]
 

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -453,7 +453,7 @@ func TestReadLogsWithBodyFilter(t *testing.T) {
 				Timestamp: now,
 				ProjectId: 1,
 			},
-			Body: "body",
+			Body: "body with space",
 		},
 	}
 
@@ -468,7 +468,7 @@ func TestReadLogsWithBodyFilter(t *testing.T) {
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
-		Query:     "body", // direct match
+		Query:     "body with space", // direct match
 	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR ensures we persist a space when searching a log body.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed that searching with a space works.

Before:
![Screenshot 2023-03-07 at 1 40 06 PM](https://user-images.githubusercontent.com/58678/223547250-46a62dd9-6b31-435e-8723-7e13cbd576fc.png)


After:
![Screenshot 2023-03-07 at 1 39 24 PM](https://user-images.githubusercontent.com/58678/223547126-29b48be6-f843-4853-96fa-27bad37cf84e.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
