### PR TITLE
skip loading message values

### DIFF
--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -1,5 +1,6 @@
 import { useGetLogsKeysQuery, useGetLogsKeyValuesLazyQuery } from '@graph/hooks'
 import { GetLogsKeysQuery } from '@graph/operations'
+import { ReservedLogKey } from '@graph/schemas'
 import {
 	Badge,
 	Box,
@@ -142,16 +143,18 @@ const Search: React.FC<{
 			return
 		}
 
-		getLogsKeyValues({
-			variables: {
-				project_id: project_id!,
-				key_name: activeTerm.key,
-				date_range: {
-					start_date: moment(startDate).format(FORMAT),
-					end_date: moment(endDate).format(FORMAT),
+		if (activeTerm.key !== ReservedLogKey.Message) {
+			getLogsKeyValues({
+				variables: {
+					project_id: project_id!,
+					key_name: activeTerm.key,
+					date_range: {
+						start_date: moment(startDate).format(FORMAT),
+						end_date: moment(endDate).format(FORMAT),
+					},
 				},
-			},
-		})
+			})
+		}
 	}, [
 		activeTerm.key,
 		endDate,

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -1,6 +1,5 @@
 import { useGetLogsKeysQuery, useGetLogsKeyValuesLazyQuery } from '@graph/hooks'
 import { GetLogsKeysQuery } from '@graph/operations'
-import { ReservedLogKey } from '@graph/schemas'
 import {
 	Badge,
 	Box,
@@ -143,7 +142,7 @@ const Search: React.FC<{
 			return
 		}
 
-		if (activeTerm.key !== ReservedLogKey.Message) {
+		if (activeTerm.key !== 'message') {
 			getLogsKeyValues({
 				variables: {
 					project_id: project_id!,


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

The frontend is sending a request for fetching the values for the `message` key. This results in the backend actually searching for `LogAttributes['message']` which doesn't make sense:

<img width="614" alt="Screenshot 2023-03-07 at 4 12 33 PM" src="https://user-images.githubusercontent.com/58678/223575425-f741b56f-fc03-433b-bbe1-55ec9c1d7102.png">


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Try on the render preview as that takes longer to fetch keys which is how I got into this state.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
