### PR TITLE
add manual log methods to highlight go sdk

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -48,7 +48,7 @@ import (
 	"github.com/highlight-run/highlight/backend/zapier"
 	"github.com/highlight-run/workerpool"
 	H "github.com/highlight/highlight/sdk/highlight-go"
-	"github.com/highlight/highlight/sdk/highlight-go/log"
+	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 	e "github.com/pkg/errors"
 	"github.com/rs/cors"

--- a/backend/main.go
+++ b/backend/main.go
@@ -236,6 +236,7 @@ func main() {
 	H.Start()
 	defer H.Stop()
 	H.SetDebugMode(log.StandardLogger())
+	hlog.Info("welcome to highlight.io")
 	// setup highlight logrus hook
 	log.AddHook(hlog.NewHook(hlog.WithLevels(
 		log.PanicLevel,

--- a/backend/main.go
+++ b/backend/main.go
@@ -228,10 +228,12 @@ func main() {
 	log.SetReportCaller(true)
 	// setup highlight
 	H.SetProjectID("1jdkoe52")
-	if util.IsDevOrTestEnv() && !util.IsInDocker() {
+	if util.IsDevOrTestEnv() {
 		log.WithContext(ctx).Info("overwriting highlight-go graphql client address...")
 		H.SetGraphqlClientAddress("https://localhost:8082/public")
-		H.SetOTLPEndpoint("http://collector:4318")
+		if util.IsInDocker() {
+			H.SetOTLPEndpoint("http://collector:4318")
+		}
 	}
 	H.Start()
 	defer H.Stop()

--- a/backend/main.go
+++ b/backend/main.go
@@ -238,7 +238,9 @@ func main() {
 	H.Start()
 	defer H.Stop()
 	H.SetDebugMode(log.StandardLogger())
-	hlog.Info("welcome to highlight.io")
+	hlog.SetOutput(true)
+	hlog.SetOutputLevel(hlog.DebugLevel)
+	hlog.WithContext(ctx).Info("welcome to highlight.io")
 	// setup highlight logrus hook
 	log.AddHook(hlog.NewHook(hlog.WithLevels(
 		log.PanicLevel,

--- a/backend/main.go
+++ b/backend/main.go
@@ -48,7 +48,7 @@ import (
 	"github.com/highlight-run/highlight/backend/zapier"
 	"github.com/highlight-run/workerpool"
 	H "github.com/highlight/highlight/sdk/highlight-go"
-	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
+	"github.com/highlight/highlight/sdk/highlight-go/log"
 	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 	e "github.com/pkg/errors"
 	"github.com/rs/cors"

--- a/sdk/highlight-go/highlight.go
+++ b/sdk/highlight-go/highlight.go
@@ -25,6 +25,8 @@ var (
 	wg                   sync.WaitGroup
 	graphqlClientAddress string
 	otlpEndpoint         string
+	projectID            string
+	logOut               = true
 )
 
 // contextKey represents the keys that highlight may store in the users' context
@@ -83,8 +85,6 @@ type Logger interface {
 	Error(v ...interface{})
 	Errorf(format string, v ...interface{})
 }
-
-var projectID string
 
 // log is this packages logger
 var logger struct {
@@ -253,6 +253,16 @@ func SetDebugMode(l Logger) {
 
 func SetProjectID(id string) {
 	projectID = id
+}
+
+func SetLogOut(print bool) {
+	logOut = print
+}
+
+func Print(message string) {
+	if logOut {
+		fmt.Print(message)
+	}
 }
 
 func GetProjectID() string {

--- a/sdk/highlight-go/highlight.go
+++ b/sdk/highlight-go/highlight.go
@@ -26,7 +26,6 @@ var (
 	graphqlClientAddress string
 	otlpEndpoint         string
 	projectID            string
-	logOut               = true
 )
 
 // contextKey represents the keys that highlight may store in the users' context
@@ -253,16 +252,6 @@ func SetDebugMode(l Logger) {
 
 func SetProjectID(id string) {
 	projectID = id
-}
-
-func SetLogOut(print bool) {
-	logOut = print
-}
-
-func Print(message string) {
-	if logOut {
-		fmt.Print(message)
-	}
 }
 
 func GetProjectID() string {

--- a/sdk/highlight-go/highlight.go
+++ b/sdk/highlight-go/highlight.go
@@ -255,6 +255,10 @@ func SetProjectID(id string) {
 	projectID = id
 }
 
+func GetProjectID() string {
+	return projectID
+}
+
 // InterceptRequest calls InterceptRequestWithContext using the request object's context
 func InterceptRequest(r *http.Request) context.Context {
 	return InterceptRequestWithContext(r.Context(), r)

--- a/sdk/highlight-go/log/console_messages_parser.go
+++ b/sdk/highlight-go/log/console_messages_parser.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-type Trace struct {
+type MessageTrace struct {
 	ColumnNumber any    `json:"columnNumber"`
 	LineNumber   any    `json:"lineNumber"`
 	FileName     string `json:"fileName"`
@@ -15,10 +15,10 @@ type Trace struct {
 }
 
 type Message struct {
-	Type  string   `json:"type"`
-	Trace []Trace  `json:"trace"`
-	Value []string `json:"value"`
-	Time  int64    `json:"time"`
+	Type  string         `json:"type"`
+	Trace []MessageTrace `json:"trace"`
+	Value []string       `json:"value"`
+	Time  int64          `json:"time"`
 }
 
 type Messages struct {

--- a/sdk/highlight-go/log/console_messages_parser_test.go
+++ b/sdk/highlight-go/log/console_messages_parser_test.go
@@ -33,7 +33,7 @@ func TestParseConsoleMessages(t *testing.T) {
 	assert.Equal(t, message, msg)
 
 	tr := rows[0].Trace[0]
-	trace := Trace{
+	trace := MessageTrace{
 		ColumnNumber: "23",
 		LineNumber:   "18070",
 		FileName:     "http://localhost:8080/dist/index.js",

--- a/sdk/highlight-go/log/log.go
+++ b/sdk/highlight-go/log/log.go
@@ -132,6 +132,10 @@ func (p *Printer) WithRequest(requestID string) *Printer {
 	return p
 }
 
+func (p *Printer) Trace(message string) {
+	p.log(TraceLevel, message)
+}
+
 func (p *Printer) Debug(message string) {
 	p.log(DebugLevel, message)
 }
@@ -146,6 +150,11 @@ func (p *Printer) Warn(message string) {
 
 func (p *Printer) Error(message string) {
 	p.log(ErrorLevel, message)
+}
+
+func (p *Printer) Fatal(message string) {
+	p.log(FatalLevel, message)
+	panic(message)
 }
 
 func WithContext(ctx context.Context) *Printer {
@@ -163,6 +172,10 @@ func WithRequest(requestID string) *Printer {
 	return p.WithRequest(requestID)
 }
 
+func Trace(message string) {
+	WithContext(context.TODO()).Trace(message)
+}
+
 func Debug(message string) {
 	WithContext(context.TODO()).Debug(message)
 }
@@ -177,4 +190,8 @@ func Warn(message string) {
 
 func Error(message string) {
 	WithContext(context.TODO()).Error(message)
+}
+
+func Fatal(message string) {
+	WithContext(context.TODO()).Fatal(message)
 }

--- a/sdk/highlight-go/log/log.go
+++ b/sdk/highlight-go/log/log.go
@@ -2,6 +2,8 @@ package hlog
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -66,10 +68,6 @@ func HighlightTags(projectID, sessionID, requestID string) []attribute.KeyValue 
 	return tags
 }
 
-func Log(level, message string, tags ...attribute.KeyValue) {
-	LogWithContext(context.TODO(), level, message, tags...)
-}
-
 func LogWithContext(ctx context.Context, level, message string, tags ...attribute.KeyValue) {
 	span, _ := highlight.StartTrace(ctx, "highlight-go/log")
 	defer highlight.EndTrace(span)
@@ -89,6 +87,16 @@ func LogWithContext(ctx context.Context, level, message string, tags ...attribut
 	if strings.Contains(strings.ToLower(level), "error") {
 		span.SetStatus(codes.Error, message)
 	}
+}
+
+func Log(level, message string, tags ...attribute.KeyValue) {
+	var tagsStr string
+	if len(tags) > 0 {
+		s, _ := json.Marshal(tags)
+		tagsStr = fmt.Sprintf(" %s", s)
+	}
+	highlight.Print(fmt.Sprintf("[%s] %s%s\n", level, message, tagsStr))
+	LogWithContext(context.TODO(), level, message, tags...)
 }
 
 func Trace(message string, tags ...attribute.KeyValue) {

--- a/sdk/highlight-go/log/log.go
+++ b/sdk/highlight-go/log/log.go
@@ -63,7 +63,7 @@ func HighlightTags(projectID, sessionID, requestID string) []attribute.KeyValue 
 		tags = append(tags, attribute.String(highlight.SessionIDAttribute, sessionID))
 	}
 	if requestID != "" {
-		tags = append(tags, attribute.String(highlight.ProjectIDAttribute, sessionID))
+		tags = append(tags, attribute.String(highlight.RequestIDAttribute, requestID))
 	}
 	return tags
 }

--- a/sdk/highlight-go/log/logrus.go
+++ b/sdk/highlight-go/log/logrus.go
@@ -8,9 +8,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // Option applies a configuration to the given config.
@@ -59,13 +57,7 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 		ctx = context.TODO()
 	}
 
-	span, _ := highlight.StartTrace(ctx, "highlight-go/logrus")
-	defer highlight.EndTrace(span)
-
-	attrs := []attribute.KeyValue{
-		LogSeverityKey.String(levelString(entry.Level)),
-		LogMessageKey.String(entry.Message),
-	}
+	var attrs []attribute.KeyValue
 	if entry.Caller != nil {
 		if entry.Caller.Function != "" {
 			attrs = append(attrs, semconv.CodeFunctionKey.String(entry.Caller.Function))
@@ -78,22 +70,15 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 
 	for k, v := range entry.Data {
 		if k == "error" {
-			if err, ok := v.(highlight.ErrorWithStack); ok {
-				highlight.RecordSpanErrorWithStack(span, err)
-			} else if err, ok := v.(error); ok {
-				span.RecordError(err)
+			if err, ok := v.(error); ok {
+				highlight.RecordError(ctx, err)
 			}
 		} else {
 			attrs = append(attrs, attribute.String(k, fmt.Sprintf("%+v", v)))
 		}
 	}
 
-	span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...))
-
-	if entry.Level <= hook.errorStatusLevel {
-		span.SetStatus(codes.Error, entry.Message)
-	}
-
+	LogWithContext(ctx, levelString(entry.Level), entry.Message, attrs...)
 	return nil
 }
 

--- a/sdk/highlight-go/log/logrus.go
+++ b/sdk/highlight-go/log/logrus.go
@@ -78,7 +78,8 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 		}
 	}
 
-	LogWithContext(ctx, levelString(entry.Level), entry.Message, attrs...)
+	lvl, _ := parseLevel(levelString(entry.Level))
+	WithContext(ctx).log(lvl, entry.Message, attrs...)
 	return nil
 }
 

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -1,0 +1,152 @@
+package hlog
+
+import (
+	"context"
+	"github.com/highlight/highlight/sdk/highlight-go"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/trace"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type VercelProxy struct {
+	Timestamp   int64    `json:"timestamp"`
+	Method      string   `json:"method"`
+	Scheme      string   `json:"scheme"`
+	Host        string   `json:"host"`
+	Path        string   `json:"path"`
+	UserAgent   []string `json:"userAgent"`
+	Referer     string   `json:"referer"`
+	StatusCode  int64    `json:"statusCode"`
+	ClientIp    string   `json:"clientIp"`
+	Region      string   `json:"region"`
+	CacheId     string   `json:"cacheId"`
+	VercelCache string   `json:"vercelCache"`
+}
+
+type VercelLog struct {
+	Id           string `json:"id"`
+	Message      string `json:"message"`
+	Timestamp    int64  `json:"timestamp"`
+	Source       string `json:"source"`
+	ProjectId    string `json:"projectId"`
+	DeploymentId string `json:"deploymentId"`
+	BuildId      string `json:"buildId"`
+	Host         string `json:"host"`
+
+	Type       string `json:"type"`
+	Entrypoint string `json:"entrypoint"`
+
+	RequestId   string      `json:"requestId"`
+	StatusCode  int64       `json:"statusCode"`
+	Destination string      `json:"destination"`
+	Path        string      `json:"path"`
+	Proxy       VercelProxy `json:"proxy"`
+}
+
+func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSecureID string, messages string) error {
+	logRows, err := ParseConsoleMessages(messages)
+	if err != nil {
+		return err
+	}
+
+	if len(logRows) == 0 {
+		return nil
+	}
+
+	span, _ := highlight.StartTrace(
+		ctx, "highlight-ctx",
+		attribute.String(highlight.SourceAttribute, highlight.SourceAttributeFrontend),
+		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
+		attribute.String(highlight.SessionIDAttribute, sessionSecureID),
+	)
+	defer highlight.EndTrace(span)
+
+	for _, row := range logRows {
+		message := strings.Join(row.Value, " ")
+		attrs := []attribute.KeyValue{
+			LogSeverityKey.String(row.Type),
+			LogMessageKey.String(message),
+		}
+		if len(row.Trace) > 0 {
+			traceEnd := &row.Trace[len(row.Trace)-1]
+			attrs = append(
+				attrs,
+				semconv.CodeFunctionKey.String(traceEnd.FunctionName),
+				semconv.CodeNamespaceKey.String(traceEnd.Source),
+				semconv.CodeFilepathKey.String(traceEnd.FileName),
+			)
+
+			var ln int
+			if x, ok := traceEnd.LineNumber.(int); ok {
+				ln = x
+			} else if x, ok := traceEnd.LineNumber.(string); ok {
+				if i, err := strconv.ParseInt(x, 10, 32); err == nil {
+					ln = int(i)
+				}
+			}
+			if ln != 0 {
+				attrs = append(attrs, semconv.CodeLineNumberKey.Int(ln))
+			}
+
+			var cn int
+			if x, ok := traceEnd.ColumnNumber.(int); ok {
+				cn = x
+			} else if x, ok := traceEnd.ColumnNumber.(string); ok {
+				if i, err := strconv.ParseInt(x, 10, 32); err == nil {
+					cn = int(i)
+				}
+			}
+			if cn != 0 {
+				attrs = append(attrs, semconv.CodeColumnKey.Int(cn))
+			}
+		}
+
+		span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(row.Time)))
+		if row.Type == "error" {
+			span.SetStatus(codes.Error, message)
+		}
+	}
+
+	return nil
+}
+
+func submitVercelLog(ctx context.Context, projectID int, log VercelLog) {
+	span, _ := highlight.StartTrace(
+		ctx, "highlight-ctx",
+		attribute.String("Source", "SubmitVercelLogs"),
+		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
+	)
+	defer highlight.EndTrace(span)
+
+	attrs := []attribute.KeyValue{
+		LogSeverityKey.String(log.Type),
+		LogMessageKey.String(log.Message),
+	}
+	attrs = append(
+		attrs,
+		semconv.CodeNamespaceKey.String(log.Source),
+		semconv.CodeFilepathKey.String(log.Path),
+		semconv.CodeFunctionKey.String(log.Entrypoint),
+		semconv.HostNameKey.String(log.Host),
+		semconv.HTTPMethodKey.Int64(log.StatusCode),
+	)
+
+	span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(log.Timestamp)))
+	if log.Type == "error" {
+		span.SetStatus(codes.Error, log.Message)
+	}
+}
+
+func SubmitVercelLogs(ctx context.Context, projectID int, logs []VercelLog) {
+	if len(logs) == 0 {
+		return
+	}
+
+	for _, log := range logs {
+		submitVercelLog(ctx, projectID, log)
+	}
+}

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -124,6 +124,16 @@ func EndTrace(span trace.Span) {
 	span.End(trace.WithStackTrace(true))
 }
 
+// RecordError processes `err` to be recorded as a part of the session or network request.
+// Highlight session and trace are inferred from the context.
+// If no sessionID is set, then the error is associated with the project without a session context.
+func RecordError(ctx context.Context, err error, tags ...attribute.KeyValue) context.Context {
+	span, ctx := StartTrace(ctx, "highlight-ctx", tags...)
+	defer EndTrace(span)
+	RecordSpanError(span, err)
+	return ctx
+}
+
 func RecordSpanError(span trace.Span, err error, tags ...attribute.KeyValue) {
 	if urlErr, ok := err.(*url.Error); ok {
 		span.SetAttributes(attribute.String("Op", urlErr.Op))
@@ -136,16 +146,6 @@ func RecordSpanError(span trace.Span, err error, tags ...attribute.KeyValue) {
 	} else {
 		span.RecordError(err, trace.WithStackTrace(true))
 	}
-}
-
-// RecordError processes `err` to be recorded as a part of the session or network request.
-// Highlight session and trace are inferred from the context.
-// If no sessionID is set, then the error is associated with the project without a session context.
-func RecordError(ctx context.Context, err error, tags ...attribute.KeyValue) context.Context {
-	span, ctx := StartTrace(ctx, "highlight-ctx", tags...)
-	defer EndTrace(span)
-	RecordSpanError(span, err)
-	return ctx
 }
 
 func RecordSpanErrorWithStack(span trace.Span, err ErrorWithStack) {


### PR DESCRIPTION
## Summary

Enhances the go sdk with manual log functions that can be used without a logging library.

## How did you test this change?

Local deploy.
![Screenshot 2023-03-08 at 2 16 06 PM](https://user-images.githubusercontent.com/1351531/223863613-285b7693-91db-42bc-9d46-a8021a9880cb.png)

## Are there any deployment considerations?

Will release new highlight-go tag.
