### PR TITLE
hotfix: add email to commandbar filters

### DIFF
--- a/frontend/src/components/CommandBar/context.ts
+++ b/frontend/src/components/CommandBar/context.ts
@@ -14,6 +14,11 @@ export interface CommandBarSearch {
 export const ATTRIBUTES = [
 	{
 		type: 'user',
+		name: 'email',
+		displayName: 'Email',
+	},
+	{
+		type: 'user',
 		name: 'identifier',
 		displayName: 'Identifier',
 	},


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We've received customer feedback that they search for an email through commandbar using the 'identifier' filter, but not all identifiers are emails. 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
local click test

![Screenshot 2023-03-08 at 9 38 09 AM](https://user-images.githubusercontent.com/17913919/223742016-14f3d4d7-50df-4912-9f2a-c9edd3875fce.jpg)

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
no