### PR TITLE
report retryable opensearch errors to postgres for reprocessing

### DIFF
--- a/backend/lambda-functions/deleteSessions/handlers/handlers.go
+++ b/backend/lambda-functions/deleteSessions/handlers/handlers.go
@@ -57,7 +57,7 @@ func NewHandlers() *handlers {
 		log.WithContext(ctx).Fatal(errors.Wrap(err, "error setting up DB"))
 	}
 
-	opensearchClient, err := opensearch.NewOpensearchClient()
+	opensearchClient, err := opensearch.NewOpensearchClient(nil)
 	if err != nil {
 		log.WithContext(ctx).Fatal(errors.Wrap(err, "error creating opensearch client"))
 	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -324,7 +324,7 @@ func main() {
 		}
 	}
 
-	opensearchClient, err := opensearch.NewOpensearchClient()
+	opensearchClient, err := opensearch.NewOpensearchClient(db)
 	if err != nil {
 		log.WithContext(ctx).Fatalf("error creating opensearch client: %v", err)
 	}

--- a/backend/migrations/cmd/add-has-comments-opensearch-field/main.go
+++ b/backend/migrations/cmd/add-has-comments-opensearch-field/main.go
@@ -30,7 +30,7 @@ func main() {
 		log.WithContext(ctx).Fatalf("error pinging db: %+v", err)
 	}
 
-	opensearchClient, err := opensearch.NewOpensearchClient()
+	opensearchClient, err := opensearch.NewOpensearchClient(nil)
 	if err != nil {
 		log.WithContext(ctx).Fatalf("error creating opensearch client: %v", err)
 	}

--- a/backend/migrations/cmd/backfill-session-missing-user-properties/main.go
+++ b/backend/migrations/cmd/backfill-session-missing-user-properties/main.go
@@ -63,7 +63,7 @@ func main() {
 		log.WithContext(ctx).Fatalf("error setting up db: %+v", err)
 	}
 
-	opensearchClient, err := opensearch.NewOpensearchClient()
+	opensearchClient, err := opensearch.NewOpensearchClient(nil)
 	if err != nil {
 		log.WithContext(ctx).Fatalf("error creating opensearch client: %v", err)
 	}

--- a/backend/migrations/cmd/influxdb-backfill-error-groups/main.go
+++ b/backend/migrations/cmd/influxdb-backfill-error-groups/main.go
@@ -24,7 +24,7 @@ func main() {
 	if err != nil {
 		log.WithContext(ctx).Fatalf("error creating db: %v", err)
 	}
-	opensearchClient, err := opensearch.NewOpensearchClient()
+	opensearchClient, err := opensearch.NewOpensearchClient(nil)
 	if err != nil {
 		log.WithContext(ctx).Fatalf("error creating opensearch client: %v", err)
 	}

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1198,11 +1198,11 @@ const (
 
 type Retryable struct {
 	Model
-	Type     RetryableType
-	Path     string
-	Function string
-	Payload  JSONB `sql:"type:jsonb"`
-	Error    string
+	Type        RetryableType
+	PayloadType string
+	PayloadID   string
+	Payload     JSONB `sql:"type:jsonb"`
+	Error       string
 }
 
 func SetupDB(ctx context.Context, dbName string) (*gorm.DB, error) {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -183,6 +183,7 @@ var Models = []interface{}{
 	&IntegrationWorkspaceMapping{},
 	&EmailOptOut{},
 	&BillingEmailHistory{},
+	&Retryable{},
 }
 
 func init() {
@@ -1187,6 +1188,21 @@ type BillingEmailHistory struct {
 	Active      bool
 	WorkspaceID int
 	Type        Email.EmailType
+}
+
+type RetryableType string
+
+const (
+	RetryableOpensearchError RetryableType = "OPENSEARCH_ERROR"
+)
+
+type Retryable struct {
+	Model
+	Type     RetryableType
+	Path     string
+	Function string
+	Payload  JSONB `json:"user_object" sql:"type:jsonb"`
+	Error    string
 }
 
 func SetupDB(ctx context.Context, dbName string) (*gorm.DB, error) {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1201,7 +1201,7 @@ type Retryable struct {
 	Type     RetryableType
 	Path     string
 	Function string
-	Payload  JSONB `json:"user_object" sql:"type:jsonb"`
+	Payload  JSONB `sql:"type:jsonb"`
 	Error    string
 }
 

--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -265,10 +265,10 @@ func (c *Client) Update(index Index, id int, obj map[string]interface{}) error {
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
@@ -310,7 +310,7 @@ func (c *Client) UpdateSynchronous(index Index, id int, obj map[string]interface
 	}
 
 	if res.IsError() {
-		c.RetryableClient.ReportError(context.Background(), model.RetryableOpensearchError, "opensearch/opensearch.go", "UpdateSynchronous:res.IsError", map[string]interface{}{"indexStr": indexStr, "id": id, "obj": obj, "documentId": documentId, "res": &res}, nil)
+		c.RetryableClient.ReportError(context.Background(), model.RetryableOpensearchError, "opensearch/opensearch.go", "UpdateSynchronous:res.IsError", map[string]interface{}{"indexStr": indexStr, "id": id, "obj": obj, "documentId": documentId, "res": res}, nil)
 		return e.New(
 			fmt.Sprintf(
 				"OPENSEARCH_ERROR (%s : %s) [%d] %s",
@@ -343,10 +343,10 @@ func (c *Client) Delete(index Index, id int) error {
 		RetryOnConflict: pointy.Int(3),
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
@@ -404,10 +404,10 @@ func (c *Client) Index(index Index, id int64, parentId *int, obj interface{}) er
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
@@ -451,10 +451,10 @@ func (c *Client) AppendToField(index Index, sessionID int, fieldName string, fie
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},

--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -265,10 +265,10 @@ func (c *Client) Update(index Index, id int, obj map[string]interface{}) error {
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, item.Index, item.DocumentID, map[string]interface{}{"item.Action": item.Action, "res": res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, item.Index, item.DocumentID, map[string]interface{}{"item.Action": item.Action, "res": res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
@@ -310,7 +310,7 @@ func (c *Client) UpdateSynchronous(index Index, id int, obj map[string]interface
 	}
 
 	if res.IsError() {
-		c.RetryableClient.ReportError(context.Background(), model.RetryableOpensearchError, "opensearch/opensearch.go", "UpdateSynchronous:res.IsError", map[string]interface{}{"indexStr": indexStr, "id": id, "obj": obj, "documentId": documentId, "res": res}, nil)
+		c.RetryableClient.ReportError(context.Background(), model.RetryableOpensearchError, indexStr, documentId, map[string]interface{}{"id": id, "obj": obj, "res": res}, nil)
 		return e.New(
 			fmt.Sprintf(
 				"OPENSEARCH_ERROR (%s : %s) [%d] %s",
@@ -343,10 +343,10 @@ func (c *Client) Delete(index Index, id int) error {
 		RetryOnConflict: pointy.Int(3),
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, item.Index, item.DocumentID, map[string]interface{}{"item.Action": item.Action, "res": res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, item.Index, item.DocumentID, map[string]interface{}{"item.Action": item.Action, "res": res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
@@ -404,10 +404,10 @@ func (c *Client) Index(index Index, id int64, parentId *int, obj interface{}) er
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, item.Index, item.DocumentID, map[string]interface{}{"item.Action": item.Action, "res": res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, item.Index, item.DocumentID, map[string]interface{}{"item.Action": item.Action, "res": res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
@@ -451,10 +451,10 @@ func (c *Client) AppendToField(index Index, sessionID int, fieldName string, fie
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, item.Index, item.DocumentID, map[string]interface{}{"item.Action": item.Action, "res": res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"item.Index": item.Index, "item.DocumentID": item.DocumentID, "item.Action": item.Action, "item.Routing": item.Routing, "res": res}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, item.Index, item.DocumentID, map[string]interface{}{"item.Action": item.Action, "res": res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},

--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -265,10 +265,10 @@ func (c *Client) Update(index Index, id int, obj map[string]interface{}) error {
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"indexStr": indexStr, "item.DocumentID": item.DocumentID}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"indexStr": indexStr, "item.DocumentID": item.DocumentID, "res.Error.Type": res.Error.Type, "res.Error.Reason": res.Error.Reason}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
@@ -343,10 +343,10 @@ func (c *Client) Delete(index Index, id int) error {
 		RetryOnConflict: pointy.Int(3),
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"indexStr": indexStr, "item.DocumentID": item.DocumentID}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"indexStr": indexStr, "item.DocumentID": item.DocumentID, "res.Error.Type": res.Error.Type, "res.Error.Reason": res.Error.Reason}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
@@ -404,10 +404,10 @@ func (c *Client) Index(index Index, id int64, parentId *int, obj interface{}) er
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"indexStr": indexStr, "item.DocumentID": item.DocumentID}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"indexStr": indexStr, "item.DocumentID": item.DocumentID, "res.Error.Type": res.Error.Type, "res.Error.Reason": res.Error.Reason}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
@@ -451,10 +451,10 @@ func (c *Client) AppendToField(index Index, sessionID int, fieldName string, fie
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"indexStr": indexStr, "item.DocumentID": item.DocumentID}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"indexStr": indexStr, "item.DocumentID": item.DocumentID, "res.Error.Type": res.Error.Type, "res.Error.Reason": res.Error.Reason}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},

--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -265,10 +265,10 @@ func (c *Client) Update(index Index, id int, obj map[string]interface{}) error {
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Update:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
@@ -310,7 +310,7 @@ func (c *Client) UpdateSynchronous(index Index, id int, obj map[string]interface
 	}
 
 	if res.IsError() {
-		c.RetryableClient.ReportError(context.Background(), model.RetryableOpensearchError, "opensearch/opensearch.go", "UpdateSynchronous:res.IsError", map[string]interface{}{"index": index, "id": id, "obj": obj, "indexStr": indexStr, "documentId": documentId, "res.StatusCode": res.StatusCode, "res.String": res.String()}, nil)
+		c.RetryableClient.ReportError(context.Background(), model.RetryableOpensearchError, "opensearch/opensearch.go", "UpdateSynchronous:res.IsError", map[string]interface{}{"indexStr": indexStr, "id": id, "obj": obj, "documentId": documentId, "res": &res}, nil)
 		return e.New(
 			fmt.Sprintf(
 				"OPENSEARCH_ERROR (%s : %s) [%d] %s",
@@ -343,10 +343,10 @@ func (c *Client) Delete(index Index, id int) error {
 		RetryOnConflict: pointy.Int(3),
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Delete:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
@@ -404,10 +404,10 @@ func (c *Client) Index(index Index, id int64, parentId *int, obj interface{}) er
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "Index:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
@@ -451,10 +451,10 @@ func (c *Client) AppendToField(index Index, sessionID int, fieldName string, fie
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, err)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, err)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
 			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": item, "res": res}, nil)
+				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, "opensearch/opensearch.go", "AppendToField:OnFailure", map[string]interface{}{"indexStr": indexStr, "item": &item, "res": &res}, nil)
 				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -252,8 +252,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 						}()
-					}
-					if event.Name() == highlight.LogEvent {
+					} else if event.Name() == highlight.LogEvent {
 						logSev := cast(eventAttributes[string(hlog.LogSeverityKey)], "unknown")
 						logMessage := cast(eventAttributes[string(hlog.LogMessageKey)], "")
 						if logMessage == "" {

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -252,7 +252,8 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 								return
 							}
 						}()
-					} else if event.Name() == highlight.LogEvent {
+					}
+					if event.Name() == highlight.LogEvent {
 						logSev := cast(eventAttributes[string(hlog.LogSeverityKey)], "unknown")
 						logMessage := cast(eventAttributes[string(hlog.LogMessageKey)], "")
 						if logMessage == "" {

--- a/backend/retryables/retryables.go
+++ b/backend/retryables/retryables.go
@@ -1,0 +1,32 @@
+package retryables
+
+import (
+	"context"
+	"github.com/highlight-run/highlight/backend/model"
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+type RetryableClient struct {
+	DB *gorm.DB
+}
+
+func (c *RetryableClient) ReportError(ctx context.Context, t model.RetryableType, path, function string, payload map[string]interface{}, e error) {
+	log.WithContext(ctx).
+		WithField("Type", t).
+		WithField("Path", path).
+		WithField("Function", function).
+		WithField("Payload", payload).
+		WithError(e).
+		Errorf("RetryableError %s [%s::%s] - %+v, %+v", t, path, function, payload, e)
+	r := model.Retryable{
+		Type:     t,
+		Path:     path,
+		Function: function,
+		Payload:  payload,
+		Error:    e.Error(),
+	}
+	if err := c.DB.Create(r).Error; err != nil {
+		log.WithContext(ctx).WithError(err).Error("error writing retryable error")
+	}
+}

--- a/backend/retryables/retryables.go
+++ b/backend/retryables/retryables.go
@@ -23,7 +23,7 @@ func (c *RetryableClient) ReportError(ctx context.Context, t model.RetryableType
 		WithField("Payload", payload).
 		WithError(e).
 		Errorf("RetryableError %s [%s::%s] - %+v, %+v", t, path, function, payload, e)
-	r := model.Retryable{
+	r := &model.Retryable{
 		Type:     t,
 		Path:     path,
 		Function: function,

--- a/backend/retryables/retryables.go
+++ b/backend/retryables/retryables.go
@@ -28,7 +28,9 @@ func (c *RetryableClient) ReportError(ctx context.Context, t model.RetryableType
 		Path:     path,
 		Function: function,
 		Payload:  payload,
-		Error:    e.Error(),
+	}
+	if e != nil {
+		r.Error = e.Error()
 	}
 	if err := c.DB.Create(r).Error; err != nil {
 		log.WithContext(ctx).WithError(err).Error("error writing retryable error")

--- a/backend/retryables/retryables.go
+++ b/backend/retryables/retryables.go
@@ -7,6 +7,10 @@ import (
 	"gorm.io/gorm"
 )
 
+type Client interface {
+	ReportError(ctx context.Context, t model.RetryableType, path, function string, payload map[string]interface{}, e error)
+}
+
 type RetryableClient struct {
 	DB *gorm.DB
 }
@@ -29,4 +33,18 @@ func (c *RetryableClient) ReportError(ctx context.Context, t model.RetryableType
 	if err := c.DB.Create(r).Error; err != nil {
 		log.WithContext(ctx).WithError(err).Error("error writing retryable error")
 	}
+}
+
+type DummyClient struct {
+	DB *gorm.DB
+}
+
+func (c *DummyClient) ReportError(ctx context.Context, t model.RetryableType, path, function string, payload map[string]interface{}, e error) {
+	log.WithContext(ctx).
+		WithField("Type", t).
+		WithField("Path", path).
+		WithField("Function", function).
+		WithField("Payload", payload).
+		WithError(e).
+		Errorf("RetryableError %s [%s::%s] - %+v, %+v", t, path, function, payload, e)
 }

--- a/backend/retryables/retryables.go
+++ b/backend/retryables/retryables.go
@@ -8,26 +8,26 @@ import (
 )
 
 type Client interface {
-	ReportError(ctx context.Context, t model.RetryableType, path, function string, payload map[string]interface{}, e error)
+	ReportError(ctx context.Context, t model.RetryableType, payloadType, payloadID string, payload map[string]interface{}, e error)
 }
 
 type RetryableClient struct {
 	DB *gorm.DB
 }
 
-func (c *RetryableClient) ReportError(ctx context.Context, t model.RetryableType, path, function string, payload map[string]interface{}, e error) {
+func (c *RetryableClient) ReportError(ctx context.Context, t model.RetryableType, payloadType, payloadID string, payload map[string]interface{}, e error) {
 	log.WithContext(ctx).
 		WithField("Type", t).
-		WithField("Path", path).
-		WithField("Function", function).
+		WithField("PayloadType", payloadType).
+		WithField("PayloadID", payloadID).
 		WithField("Payload", payload).
 		WithError(e).
-		Errorf("RetryableError %s [%s::%s] - %+v, %+v", t, path, function, payload, e)
+		Errorf("RetryableError %s [%s::%s] - %+v, %+v", t, payloadType, payloadID, payload, e)
 	r := &model.Retryable{
-		Type:     t,
-		Path:     path,
-		Function: function,
-		Payload:  payload,
+		Type:        t,
+		PayloadType: payloadType,
+		PayloadID:   payloadID,
+		Payload:     payload,
 	}
 	if e != nil {
 		r.Error = e.Error()
@@ -41,12 +41,12 @@ type DummyClient struct {
 	DB *gorm.DB
 }
 
-func (c *DummyClient) ReportError(ctx context.Context, t model.RetryableType, path, function string, payload map[string]interface{}, e error) {
+func (c *DummyClient) ReportError(ctx context.Context, t model.RetryableType, payloadType, payloadID string, payload map[string]interface{}, e error) {
 	log.WithContext(ctx).
 		WithField("Type", t).
-		WithField("Path", path).
-		WithField("Function", function).
+		WithField("PayloadType", payloadType).
+		WithField("PayloadID", payloadID).
 		WithField("Payload", payload).
 		WithError(e).
-		Errorf("RetryableError %s [%s::%s] - %+v, %+v", t, path, function, payload, e)
+		Errorf("RetryableError %s [%s::%s] - %+v, %+v", t, payloadType, payloadID, payload, e)
 }


### PR DESCRIPTION
## Summary

Report opensearch indexing errors as postgres rows.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

No