### PR TITLE
Fix infinite workspace redirect

### DIFF
--- a/frontend/src/pages/WorkspaceTabs/WorkspaceTabs.tsx
+++ b/frontend/src/pages/WorkspaceTabs/WorkspaceTabs.tsx
@@ -5,7 +5,7 @@ import WorkspaceTeam from '@pages/WorkspaceTeam/WorkspaceTeam'
 import analytics from '@util/analytics'
 import React, { Suspense, useEffect } from 'react'
 import { Helmet } from 'react-helmet'
-import { useLocation, useMatch, useNavigate } from 'react-router-dom'
+import { useLocation, useMatch, useNavigate, useParams } from 'react-router-dom'
 
 import styles from './WorkspaceTabs.module.scss'
 
@@ -36,8 +36,8 @@ export const WorkspaceTabs = () => {
 	const location = useLocation()
 	const navigate = useNavigate()
 
+	const { workspace_id: workspaceId } = useParams<{ workspace_id: string }>()
 	const workspaceMatch = useMatch('/w/:workspace_id/:page_id')
-	const workspaceId = workspaceMatch?.params.workspace_id
 	const pageId = workspaceMatch?.params.page_id as WorkspaceSettingsTab
 
 	useEffect(() => {

--- a/frontend/src/pages/WorkspaceTabs/WorkspaceTabs.tsx
+++ b/frontend/src/pages/WorkspaceTabs/WorkspaceTabs.tsx
@@ -3,9 +3,10 @@ import Tabs from '@components/Tabs/Tabs'
 import WorkspaceSettings from '@pages/WorkspaceSettings/WorkspaceSettings'
 import WorkspaceTeam from '@pages/WorkspaceTeam/WorkspaceTeam'
 import analytics from '@util/analytics'
+import { useParams } from '@util/react-router/useParams'
 import React, { Suspense, useEffect } from 'react'
 import { Helmet } from 'react-helmet'
-import { useLocation, useMatch, useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useMatch, useNavigate } from 'react-router-dom'
 
 import styles from './WorkspaceTabs.module.scss'
 
@@ -35,8 +36,10 @@ const getTitle = (tab: WorkspaceSettingsTab): string => {
 export const WorkspaceTabs = () => {
 	const location = useLocation()
 	const navigate = useNavigate()
-
 	const { workspace_id: workspaceId } = useParams<{ workspace_id: string }>()
+
+	// Using useMatch instead of pulling from useParams because :page_id isn't
+	// defined in a route anywhere, it's only used by the tabs.
 	const workspaceMatch = useMatch('/w/:workspace_id/:page_id')
 	const pageId = workspaceMatch?.params.page_id as WorkspaceSettingsTab
 


### PR DESCRIPTION
## Summary

Fixes an issue where users we stuck in a redirect loop when visiting the root path for their workspace (`/w/:workspace_id`).

## How did you test this change?

Local click test. Should be able to confirm in the PR preview as well.

## Are there any deployment considerations?

N/A