### PR TITLE
update slack alerts to link to error instance

### DIFF
--- a/backend/alerts/alerts.go
+++ b/backend/alerts/alerts.go
@@ -12,12 +12,13 @@ import (
 )
 
 type SendErrorAlertEvent struct {
-	Session    *model.Session
-	ErrorAlert *model.ErrorAlert
-	ErrorGroup *model.ErrorGroup
-	Workspace  *model.Workspace
-	ErrorCount int64
-	VisitedURL string
+	Session     *model.Session
+	ErrorAlert  *model.ErrorAlert
+	ErrorGroup  *model.ErrorGroup
+	ErrorObject *model.ErrorObject
+	Workspace   *model.Workspace
+	ErrorCount  int64
+	VisitedURL  string
 }
 
 func SendErrorAlert(event SendErrorAlertEvent) error {
@@ -30,10 +31,10 @@ func SendErrorAlert(event SendErrorAlertEvent) error {
 		ErrorCount:      event.ErrorCount,
 		ErrorTitle:      errorTitle,
 		UserIdentifier:  event.Session.Identifier,
-		ErrorURL:        getErrorURL(event.ErrorAlert, event.ErrorGroup),
-		ErrorResolveURL: getErrorResolveURL(event.ErrorAlert, event.ErrorGroup),
-		ErrorIgnoreURL:  getErrorIgnoreURL(event.ErrorAlert, event.ErrorGroup),
-		ErrorSnoozeURL:  getErrorSnoozeURL(event.ErrorAlert, event.ErrorGroup),
+		ErrorURL:        getErrorURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
+		ErrorResolveURL: getErrorResolveURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
+		ErrorIgnoreURL:  getErrorIgnoreURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
+		ErrorSnoozeURL:  getErrorSnoozeURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
 		SessionURL:      getSessionURL(event.ErrorAlert.ProjectID, event.Session),
 		VisitedURL:      event.VisitedURL,
 	}

--- a/backend/alerts/routing.go
+++ b/backend/alerts/routing.go
@@ -7,32 +7,32 @@ import (
 	"github.com/highlight-run/highlight/backend/model"
 )
 
-func getErrorURL(errorAlert *model.ErrorAlert, errorGroup *model.ErrorGroup) string {
+func getErrorURL(errorAlert *model.ErrorAlert, errorGroup *model.ErrorGroup, errorObject *model.ErrorObject) string {
 	projectId := errorAlert.ProjectID
 	frontendURL := os.Getenv("FRONTEND_URI")
 
-	return fmt.Sprintf("%s/%d/errors/%s", frontendURL, projectId, errorGroup.SecureID)
+	return fmt.Sprintf("%s/%d/errors/%s/instances/%d", frontendURL, projectId, errorGroup.SecureID, errorObject.ID)
 }
 
-func getErrorResolveURL(errorAlert *model.ErrorAlert, errorGroup *model.ErrorGroup) string {
+func getErrorResolveURL(errorAlert *model.ErrorAlert, errorGroup *model.ErrorGroup, errorObject *model.ErrorObject) string {
 	projectId := errorAlert.ProjectID
 	frontendURL := os.Getenv("FRONTEND_URI")
 
-	return fmt.Sprintf("%s/%d/errors/%s?action=resolved", frontendURL, projectId, errorGroup.SecureID)
+	return fmt.Sprintf("%s/%d/errors/%s/instances/%d?action=resolved", frontendURL, projectId, errorGroup.SecureID, errorObject.ID)
 }
 
-func getErrorIgnoreURL(errorAlert *model.ErrorAlert, errorGroup *model.ErrorGroup) string {
+func getErrorIgnoreURL(errorAlert *model.ErrorAlert, errorGroup *model.ErrorGroup, errorObject *model.ErrorObject) string {
 	projectId := errorAlert.ProjectID
 	frontendURL := os.Getenv("FRONTEND_URI")
 
-	return fmt.Sprintf("%s/%d/errors/%s?action=ignored", frontendURL, projectId, errorGroup.SecureID)
+	return fmt.Sprintf("%s/%d/errors/%s/instances/%d?action=ignored", frontendURL, projectId, errorGroup.SecureID, errorObject.ID)
 }
 
-func getErrorSnoozeURL(errorAlert *model.ErrorAlert, errorGroup *model.ErrorGroup) string {
+func getErrorSnoozeURL(errorAlert *model.ErrorAlert, errorGroup *model.ErrorGroup, errorObject *model.ErrorObject) string {
 	projectId := errorAlert.ProjectID
 	frontendURL := os.Getenv("FRONTEND_URI")
 
-	return fmt.Sprintf("%s/%d/errors/%s?action=snooze", frontendURL, projectId, errorGroup.SecureID)
+	return fmt.Sprintf("%s/%d/errors/%s/instances/%d?action=snooze", frontendURL, projectId, errorGroup.SecureID, errorObject.ID)
 }
 
 func getSessionURL(projectID int, session *model.Session) string {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1715,7 +1715,7 @@ func (obj *ErrorAlert) SendAlerts(ctx context.Context, db *gorm.DB, mailClient *
 	}
 
 	frontendURL := os.Getenv("FRONTEND_URI")
-	errorURL := fmt.Sprintf("%s/%d/errors/%s", frontendURL, obj.ProjectID, input.Group.SecureID)
+	errorURL := fmt.Sprintf("%s/%d/errors/%s/instances/%d", frontendURL, obj.ProjectID, input.Group.SecureID, input.ErrorObject.ID)
 	sessionURL := fmt.Sprintf("%s/%d/sessions/%s", frontendURL, obj.ProjectID, input.SessionSecureID)
 
 	for _, email := range emailsToNotify {
@@ -2317,6 +2317,8 @@ type SendSlackAlertInput struct {
 	UserObject JSONB
 	// Group is a required parameter for Error alerts
 	Group *ErrorGroup
+	// ErrorObject is a required parameter for Error alerts
+	ErrorObject *ErrorObject
 	// URL is an optional parameter for Error alerts
 	URL *string
 	// ErrorsCount is a required parameter for Error alerts

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2447,7 +2447,7 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 		if len(input.Group.Event) > 50 {
 			shortEvent = input.Group.Event[:50] + "..."
 		}
-		errorLink := fmt.Sprintf("%s/%d/errors/%s", frontendURL, obj.ProjectID, input.Group.SecureID)
+		errorLink := fmt.Sprintf("%s/%d/errors/%s/instances/%d", frontendURL, obj.ProjectID, input.Group.SecureID, input.ErrorObject.ID)
 		// construct Slack message
 		previewText = fmt.Sprintf("Highlight: Error Alert: %s", shortEvent)
 		textBlock = slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Highlight Error Alert: %d Recent Occurrences*\n\n%s\n<%s/|View Thread>", *input.ErrorsCount, shortEvent, errorLink), false, false)


### PR DESCRIPTION
## Summary

Slack alerts should link to an error instance so that the session from which an alert triggers
is included as part of the URL and shows the relevant stacktrace. Otherwise, customers have
complained about the slack alert URLs leading them to error instances from old sessions or situations
where the stack trace is out of date.

## How did you test this change?

Local deploy with alerts integrated.
<img width="769" alt="image" src="https://user-images.githubusercontent.com/1351531/224125030-0610212a-0791-470b-951b-7bee97612926.png">
![Screenshot 2023-03-09 at 10 49 27 AM](https://user-images.githubusercontent.com/1351531/224125511-6f60264e-1d3d-40f8-aff9-dbe48855fb98.png)


## Are there any deployment considerations?

No