### PR TITLE
expand the permalinked log

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -135,7 +135,9 @@ export const LogsTable = ({
 				align: 'start',
 				behavior: 'smooth',
 			})
+			foundRow.toggleExpanded(true)
 		}
+
 		// Only run when the component mounts
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [])
@@ -170,14 +172,6 @@ export const LogsTable = ({
 									</Fragment>
 								)
 							})}
-
-							{/* TODO(et) - Wire this up with react-table's expanded state
-							    Currently, it seems non-trivial and we may have to possibly manage the state using `manualExpanding
-								https://tanstack.com/table/v8/docs/api/features/expanding?from=reactTableV7&original=https://react-table-v7.tanstack.com/docs/api/useExpanded#manualexpanding
-							*/}
-							{selectedCursor === row.original.cursor && (
-								<>Selected</>
-							)}
 						</Stack>
 
 						<LogDetails row={row} />


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Frontend polish from #4535

The permalinked log should expand open by default.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

![Kapture 2023-03-09 at 09 10 13](https://user-images.githubusercontent.com/58678/224084040-574f4b73-70e9-43d9-be4c-a7a8414739fd.gif)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
