### PR TITLE
make python logging opt-in

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -133,6 +133,15 @@
 			gtag('config', 'AW-10833687189');
 			window.gtag = gtag"
 		></script>
+		<!-- Start of HubSpot Embed Code -->
+		<script
+			type="text/javascript"
+			id="hs-script-loader"
+			async
+			defer
+			src="//js.hs-scripts.com/20473940.js"
+		></script>
+		<!-- End of HubSpot Embed Code -->
 
 		<script type="module" src="./src/index.tsx"></script>
 	</head>

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -32,7 +32,7 @@ class H(object):
         self,
         project_id: str,
         integrations: typing.List[Integration] = None,
-        record_logs: bool = False,
+        record_logs: bool = True,
         otlp_endpoint: str = "",
     ):
         """

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.4.3"
+version = "0.4.4"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary

Switches the python sdk to not record logs by default for consistency across SDKs.

## How did you test this change?

Python unit tests.

## Are there any deployment considerations?

New python version released. We don't have any customers actively using python for logging, so this should not have impact on existing users.