### PR TITLE
Aaron i4556

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ErrorsPage/ErrorsPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ErrorsPage/ErrorsPage.tsx
@@ -36,7 +36,8 @@ const ErrorsPage = ({
 	const { errors, state, session, sessionMetadata, isPlayerReady, setTime } =
 		useReplayerContext()
 
-	const { setActiveError, setRightPanelView } = usePlayerUIContext()
+	const { activeError, setActiveError, setRightPanelView } =
+		usePlayerUIContext()
 	const { setShowRightPanel } = usePlayerConfiguration()
 
 	const loading = state === ReplayerState.Loading
@@ -99,11 +100,12 @@ const ErrorsPage = ({
 						<ErrorRow
 							key={error.error_group_secure_id}
 							error={error}
-							setSelectedError={() => {
-								setShowRightPanel(true)
+							onClickHandler={() => {
 								setActiveError(error)
+								setShowRightPanel(true)
 								setRightPanelView(RightPanelView.Error)
 							}}
+							setActiveError={setActiveError}
 							setTime={setTime}
 							startTime={sessionMetadata.startTime}
 							searchQuery={filter}
@@ -123,7 +125,10 @@ export enum ErrorCardState {
 }
 interface Props {
 	error: ErrorObject
-	setSelectedError: () => void
+	onClickHandler: () => void
+	setActiveError: React.Dispatch<
+		React.SetStateAction<ErrorObject | undefined>
+	>
 	setTime: (time: number) => void
 	startTime: number
 	searchQuery: string
@@ -133,7 +138,8 @@ interface Props {
 const ErrorRow = React.memo(
 	({
 		error,
-		setSelectedError,
+		onClickHandler,
+		setActiveError,
 		setTime,
 		startTime,
 		searchQuery,
@@ -158,7 +164,7 @@ const ErrorRow = React.memo(
 				className={styles.errorRowVariants({
 					current,
 				})}
-				onClick={setSelectedError}
+				onClick={onClickHandler}
 			>
 				<Box>
 					<TextHighlighter
@@ -202,8 +208,10 @@ const ErrorRow = React.memo(
 						emphasis="low"
 						kind="secondary"
 						size="medium"
-						onClick={() => {
+						onClick={(event) => {
 							setTime(timestamp)
+							event.stopPropagation() /* Prevents opening of right panel by parent row's onClick handler */
+							setActiveError(error)
 						}}
 					>
 						<IconSolidArrowCircleRight />

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -292,6 +292,7 @@ export const NetworkPage = ({
 								return (
 									<ResourceRow
 										key={index.toString()}
+										index={index}
 										resource={resource}
 										networkRange={networkRange}
 										isCurrentResource={
@@ -306,6 +307,12 @@ export const NetworkPage = ({
 												RightPanelView.NetworkResource,
 											)
 										}}
+										setCurrentActiveIndex={
+											setCurrentActiveIndex
+										}
+										setActiveNetworkResource={
+											setActiveNetworkResource
+										}
 										setTime={setTime}
 										playerStartTime={startTime}
 										hasError={!!error}
@@ -336,11 +343,18 @@ export const NetworkPage = ({
 }
 
 interface ResourceRowProps {
+	index: number
 	resource: NetworkResource
 	networkRange: number
 	isCurrentResource: boolean
 	searchTerm: string
 	onClickHandler: () => void
+	setCurrentActiveIndex: React.Dispatch<
+		React.SetStateAction<number | undefined>
+	>
+	setActiveNetworkResource: React.Dispatch<
+		React.SetStateAction<NetworkResource | undefined>
+	>
 	setTime: (time: number) => void
 	networkRequestAndResponseRecordingEnabled: boolean
 	playerStartTime: number
@@ -349,11 +363,14 @@ interface ResourceRowProps {
 }
 
 const ResourceRow = ({
+	index,
 	resource,
 	networkRange,
 	isCurrentResource,
 	searchTerm,
 	onClickHandler,
+	setCurrentActiveIndex,
+	setActiveNetworkResource,
 	networkRequestAndResponseRecordingEnabled,
 	setTime,
 	playerStartTime,
@@ -454,8 +471,11 @@ const ResourceRow = ({
 					emphasis="low"
 					kind="secondary"
 					size="medium"
-					onClick={() => {
+					onClick={(event) => {
 						setTime(resource.startTime)
+						event.stopPropagation() /* Prevents opening of right panel by parent row's onClick handler */
+						setCurrentActiveIndex(index)
+						setActiveNetworkResource(resource)
 					}}
 				>
 					<IconSolidArrowCircleRight />


### PR DESCRIPTION
## Summary

Issue #4556 
- For player console Network rows and Error rows:
- "Goto" button should only navigate to the correct timestamp, not open the right panel

## How did you test this change?
- Dev mode click test
- https://www.loom.com/share/e3d006d50fa04832bc6ff4fab8300e25

## Are there any deployment considerations?

- None
