### PR TITLE
ensure we use identical ordering as the schema when we query

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -78,8 +78,8 @@ func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) 
 const LogsLimit int = 100
 const KeyValuesLimit int = 50
 
-const OrderBackward = "Timestamp ASC, UUID ASC"
-const OrderForward = "Timestamp DESC, UUID DESC"
+const OrderBackward = "toUnixTimestamp(Timestamp) ASC, UUID ASC"
+const OrderForward = "toUnixTimestamp(Timestamp) DESC, UUID DESC"
 
 type Pagination struct {
 	After     *string


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

When we paginate forward, the query time becomes exceptionally slow. The reason for this is because clickhouse isn't optimizing ordering. Adjusting our `ORDER BY` to match our schema fixes the issue:

https://github.com/highlight/highlight/blob/95b5df43da50ebeb8f7f4236544950e65d8be1e1/backend/clickhouse/migrations/000004_create_new_logs_table.up.sql#L26

## How did you test this change?

Let's take a really simple query that trys to get the next set of logs before a given a timestamp.

```sql
SELECT *
FROM logs
WHERE (ProjectId = 1) AND (Timestamp >= '2023-03-10 20:39:09.801403533')
ORDER BY Timestamp DESC
LIMIT 10
```

This query takes an exceptionally long time to run:

`10 rows in set. Elapsed: 81.754 sec. Processed 170.75 million rows, 181.68 GB (2.09 million rows/s., 2.22 GB/s.)`

whereas if we run the exact same query, just flipping the order direction

```sql
SELECT *
FROM logs
WHERE (ProjectId = 1) AND (Timestamp >= '2023-03-10 20:39:09.801403533')
ORDER BY Timestamp ASC
LIMIT 10
```

=> `10 rows in set. Elapsed: 1.326 sec. Processed 1.71 million rows, 1.87 GB (1.29 million rows/s., 1.41 GB/s.)`

The `EXPLAIN` for both of these queries is identical:

```sql
┌─explain──────────────────────────────────────┐
│ Expression (Projection)                      │
│   Limit (preliminary LIMIT (without OFFSET)) │
│     Sorting (Sorting for ORDER BY)           │
│       Expression (Before ORDER BY)           │
│         Filter (WHERE)                       │
│           ReadFromMergeTree (default.logs)   │
└──────────────────────────────────────────────┘
```

After chatting with the the clickhouse community, I was advised to get some more debugging information. This can only be done through the [clickhouse-client](https://clickhouse.com/docs/en/interfaces/cli/).

```sh
./clickhouse client --host REDACTED --secure --password REDACTED
```

and to get additional debugging via `set send_logs_level = 'trace'`.

Running those exact same queries results in the following logs ([gist](https://gist.github.com/et/371b3f488b8e01a1f5cc8333050c06b5)). 

Look at the descending order logs, specifically this line:
`[c-claret-qb-28-server-1] 2023.03.10 22:09:08.586767 [ 6796 ] {8bdc25ea-74bf-4e82-bb7c-cb5abf4e666e} <Debug> MergingSortedTransform: Merge sorted 1 blocks, 10 rows in 81.720720691 sec., 0.12236798593360071 rows/sec., 376.60 B/sec`

`MergingSortedTransform` is for sorting in ascending order (yet we are sorting in descending order).


If we adjust our query to use the exact same `ORDER BY` as our schema:

```sql
SELECT *
FROM logs
WHERE (ProjectId = 1) AND (Timestamp <= '2023-03-01 20:39:09.801403533')
ORDER BY toUnixTimestamp(Timestamp) DESC
LIMIT 10
```

The query time goes down exceptionally ([logs](https://gist.github.com/et/403cba984913b5d795df70ffb2cd9249)):
`10 rows in set. Elapsed: 0.383 sec. Processed 79.47 thousand rows, 74.27 MB (207.56 thousand rows/s., 193.98 MB/s.)`


More importantly, we are using `MergeTreeReverseSelectProcessor` instead of `MergingSortedTransform`

We can actually validate this as well through `EXPLAIN` if we add the `actions=1` setting:

Before:
```sql
EXPLAIN actions=1 SELECT * FROM logs
WHERE ProjectId = 1
AND Timestamp <= '2023-03-10 20:39:09.801403533'
ORDER BY Timestamp DESC
LIMIT 10

Query id: 639be736-b5d8-40ae-924a-51a375219a32

...truncated...
│           ReadType: Default
...truncated...
```

After:

```sql
EXPLAIN actions=1 SELECT * FROM logs
WHERE ProjectId = 1
AND Timestamp <= '2023-03-10 20:39:09.801403533'
ORDER BY toUnixTimestamp(Timestamp) DESC
LIMIT 10

Query id: 639be736-b5d8-40ae-924a-51a375219a32

...truncated...
│           ReadType: InReverseOrder
...truncated...
```

`ReadType` is now `InReverseOrder` instead of `Default`.


### Actual queries

The above queries aren't including the UUID (and our subqueries). Using an actual query:

```sql
EXPLAIN actions=1 SELECT
                      Timestamp,
                      UUID,
                      SeverityText,
                      Body,
                      LogAttributes,
                      TraceId,
                      SpanId,
                      SecureSessionId
                    FROM
                      (
                        SELECT
                          Timestamp,
                          UUID,
                          SeverityText,
                          Body,
                          LogAttributes,
                          TraceId,
                          SpanId,
                          SecureSessionId
                        FROM
                          logs
                        WHERE
                          ProjectId = 1
                          AND toUInt64(
                            toDateTime(Timestamp)
                          ) <= 63814318088
                          AND (
                            toUInt64(
                              toDateTime(Timestamp)
                            ) < 63814318088
                            OR UUID < '4641e5e6-dd84-4c80-ba1c-dd482f8b4ddd'
                          )
                        ORDER BY
                          toUnixTimestamp(Timestamp) DESC,
                          UUID DESC
                        LIMIT
                          101
                      ) AS logs_window
                    ORDER BY
                      toUnixTimestamp(Timestamp) DESC,
                      UUID DESC
```

Does report the usage of `ReadType: InReverseOrder` but the query still feels it could be faster:

`Elapsed: 3.444s Read: 1,537,359 rows (1.77 GB)`. The less complex query took `0.383 sec`. It's still significantly faster than the `81.754 sec` we got with the unoptimized query. 

Open questions:
* does adjusting our schema's `ORDER BY` to be `DESC` have any improvements (does clickhouse optimize?
* is all the casting (the `toUInt64` and `toDateTime` stuff) slowing things down?
* should we remove the `toUnixTimestamp` from our schema? That was pulled from the OTEL [spec](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/18085/files#diff-96aeb1d861a7692a2b58cbc3de049b35877115e6f4b2f9ff7f13968a4583d98dL346) but we didn't really have much of a rationale here.
* can we still add an end timestamp to improve query time (e.g. a fixed range)?

I'm going to ask the above questions to our clickhouse support.

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
