### PR TITLE
fix billing details not loading when coming from non-workspace page

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -316,10 +316,9 @@ const AuthenticationRoleRouter = () => {
 			unsubscribeFirebase()
 		}
 
-		// We need to make sure this doesn't run more than once or it will create
-		// multiple auth state change listeners.
+		// Don't rerun this more than necessary. Rerun if the project / workspace context changes.
 		// eslint-disable-next-line
-	}, [])
+	}, [getAdminQuery])
 
 	useEffect(() => {
 		// Check user exists here as well because adminData isn't cleared correctly


### PR DESCRIPTION
## Summary

Make sure that the `getAdmin` query reruns when switching between project and workspace context.
Rerunning the firebase subscription if the context changes should be ok since the useEffect returns a cleanup callback.

## How did you test this change?

Visiting `/w/1/upgrade-plan` locally after logging in/out would exhibit the `access denied` modal which is fixed with this change.

## Are there any deployment considerations?

No.