### PR TITLE
use randomized key for project-level kafka messages, show timestamp for error instance

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -5,11 +5,12 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/samber/lo"
-	"github.com/segmentio/kafka-go/sasl"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/samber/lo"
+	"github.com/segmentio/kafka-go/sasl"
 
 	"github.com/DmitriyVTitov/size"
 	"github.com/highlight-run/highlight/backend/hlog"

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/DmitriyVTitov/size"
+	"github.com/google/uuid"
 	"github.com/highlight-run/highlight/backend/hlog"
 	kafkaqueue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/model"
@@ -136,7 +137,7 @@ func (r *mutationResolver) PushBackendPayload(ctx context.Context, projectID *st
 		if secureID != nil {
 			partitionKey = *secureID
 		} else if projectID != nil {
-			partitionKey = *projectID
+			partitionKey = uuid.New().String()
 		}
 		err := r.ProducerQueue.Submit(ctx, &kafkaqueue.Message{
 			Type: kafkaqueue.PushBackendPayload,
@@ -164,7 +165,7 @@ func (r *mutationResolver) MarkBackendSetup(ctx context.Context, projectID *stri
 	if sessionSecureID != nil {
 		partitionKey = *sessionSecureID
 	} else if projectID != nil {
-		partitionKey = *projectID
+		partitionKey = uuid.New().String()
 	}
 	err := r.ProducerQueue.Submit(ctx, &kafkaqueue.Message{
 		Type: kafkaqueue.MarkBackendSetup,

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -391,7 +391,7 @@ const Metadata: React.FC<{
 		{ key: 'browser', label: errorObject?.browser },
 		{ key: 'os', label: errorObject?.os },
 		{ key: 'url', label: errorObject?.url },
-		{ key: 'created_at', label: errorObject?.created_at },
+		{ key: 'timestamp', label: errorObject?.timestamp },
 		{
 			key: 'Custom Properties',
 			label: customProperties ? (
@@ -411,9 +411,9 @@ const Metadata: React.FC<{
 			<Box>
 				{metadata.map((meta) => {
 					const value =
-						meta.key === 'created_at'
+						meta.key === 'timestamp'
 							? moment(meta.label as string).format(
-									'M/D/YY h:mm:s.SSS A',
+									'M/D/YY h:mm:ss.SSS A',
 							  )
 							: meta.label
 					return (


### PR DESCRIPTION
## Summary
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->
- randomize partition key for project-level kafka messages to avoid unbalanced partitions
- show timestamp instead of created_at in error instance (time error was recorded rather than received)
- add leading 0 to seconds in timestamp
<img width="483" alt="Screen Shot 2023-03-13 at 3 37 18 PM" src="https://user-images.githubusercontent.com/86132398/224847976-0027d5f9-109a-45fe-b973-3859c4a216f6.png">

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
- no