### PR TITLE
speed up body searches by utilizing bloom filter index

### DIFF
--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -508,6 +508,20 @@ func TestReadLogsWithBodyFilter(t *testing.T) {
 			},
 			Body: "body with space",
 		},
+		{
+			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
+				Timestamp: now,
+				ProjectId: 1,
+			},
+			Body: "STRIPE_INTEGRATION_ERROR cannot report usage - customer has no subscriptions",
+		},
+		{
+			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
+				Timestamp: now,
+				ProjectId: 1,
+			},
+			Body: "STRIPE-INTEGRATION-ERROR cannot report usage - customer has no subscriptions",
+		},
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -528,7 +542,7 @@ func TestReadLogsWithBodyFilter(t *testing.T) {
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
-		Query:     "od", // wildcard match
+		Query:     "*od*", // wildcard match
 	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
@@ -539,6 +553,20 @@ func TestReadLogsWithBodyFilter(t *testing.T) {
 	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
+
+	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "STRIPE_INTEGRATION_ERROR", // uses reserved separator character
+	}, Pagination{})
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 2)
+
+	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "STRIPE-INTEGRATION-ERROR", // uses reserved separator character
+	}, Pagination{})
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 2)
 }
 
 func TestReadLogsWithKeyFilter(t *testing.T) {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

When we search on the log body, we aren't utilizing the `tokenbf_v1` index (see #4575). This particular index basically takes a log body such as `log.Info("some message that we emit")` and splits it into tokens `["some", "message", "that", "we", "emit"])`.

In order to leverage it properly, we need to switch to actually use the `hasToken` function to see if one of those tokens contains our string. This does require us to split up the body string even further:

For example: searching for "some message that we emit" would construct this query:

```sql
SELECT Timestamp, Body
FROM 
  logs 
WHERE 
  ProjectId = 1 
  AND Timestamp >= (now() - toIntervalDay(15))  
  AND (hasToken(Body, 'some'))
  AND (hasToken(Body, 'message'))
  AND (hasToken(Body, 'that'))
  AND (hasToken(Body, 'we'))
  AND (hasToken(Body, 'emit'))
ORDER BY 
  toUnixTimestamp(Timestamp) DESC
LIMIT 
  100 
```

This does mean that we aren't searching for a direct match of `AND Body = 'some message that we emit'` but the performance gain is worth it.



## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

When we first noticed this, we observed that searching for "STRIPE_INTEGRATION_ERROR" is slow ([something we log a lot of](https://github.com/highlight/highlight/search?q=STRIPE_INTEGRATION_ERROR)). A caveat with using `tokenbf_v1` is that tokens are split by non-alphanumeric characters ([docs](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree/#token-bloom-filter)). Hence, the `_` is split similar to whitespace.

With all that being said, searching for `STRIPE_INTEGRATION_ERROR` for the last 15 days:

Previous:
```sql
SELECT Timestamp, Body
FROM 
  logs 
WHERE 
  ProjectId = 1 
  AND Timestamp >= (now() - toIntervalDay(15))  
  AND Body ILIKE '%STRIPE_INTEGRATION_ERROR%' 
ORDER BY 
  toUnixTimestamp(Timestamp) DESC
LIMIT 
  100 

Elapsed: 18.954s
Read: 44,413,741 rows (4.05 GB)
```

```sql
SELECT Timestamp, Body
FROM 
  logs 
WHERE 
  ProjectId = 1 
  AND Timestamp >= (now() - toIntervalDay(15))  
  AND (hasTokenCaseInsensitive(Body, 'STRIPE'))
  AND (hasTokenCaseInsensitive(Body, 'INTEGRATION'))
  AND (hasTokenCaseInsensitive(Body, 'ERROR'))
ORDER BY 
  toUnixTimestamp(Timestamp) DESC
LIMIT 
  100 
Elapsed: 4.730s
Read: 22,468,784 rows (2.18 GB)
```

So a fairly significant speed up. More importantly is that we are using our `tokenbf_v1` index

```sql
EXPLAIN indexes = 1
SELECT Timestamp, Body
FROM 
  logs 
WHERE 
  ProjectId = 1 
  AND Timestamp >= (now() - toIntervalDay(15))  
  AND (hasToken(Body, 'STRIPE'))
  AND (hasTokenCaseInsensitive(Body, 'INTEGRATION'))
  AND (hasTokenCaseInsensitive(Body, 'ERROR'))
ORDER BY 
  toUnixTimestamp(Timestamp) DESC
LIMIT 
  100 

...truncated

│             Skip                                                                                         │
│               Name: idx_body                                                                             │
│               Description: tokenbf_v1 GRANULARITY 1                                                      │
│               Parts: 47/116                                                                              │
│               Granules: 165/35779
```

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A