### PR TITLE
add tracing for querying clickhouse

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -138,6 +138,7 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 	span, _ := tracer.StartSpanFromContext(ctx, "logs", tracer.ResourceName("ReadLogs"))
 	query, err := sqlbuilder.ClickHouse.Interpolate(sql, args)
 	if err != nil {
+		span.Finish(tracer.WithError(err))
 		return nil, err
 	}
 	span.SetTag("Query", query)
@@ -145,7 +146,7 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 
 	rows, err := client.conn.Query(ctx, sql, args...)
 
-	span.Finish()
+	span.Finish(tracer.WithError(err))
 
 	if err != nil {
 		return nil, err

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -141,6 +141,7 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 		return nil, err
 	}
 	span.SetTag("Query", query)
+	span.SetTag("Params", params)
 
 	rows, err := client.conn.Query(ctx, sql, args...)
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We are currently optimizing slow queries for things we know about it but It would be great to have insight on other slow queries we don't know about.

This PR adds tracing data for our read logs queries.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Will observe in datadog.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A