### PR TITLE
Don't allow integration setup when disabled

### DIFF
--- a/sdk/client/src/types/client.ts
+++ b/sdk/client/src/types/client.ts
@@ -114,12 +114,12 @@ type DefaultIntegrationOptions = {
 
 export declare interface MixpanelIntegrationOptions
 	extends DefaultIntegrationOptions {
-	projectToken: string
+	projectToken?: string
 }
 
 export declare interface AmplitudeIntegrationOptions
 	extends DefaultIntegrationOptions {
-	apiKey: string
+	apiKey?: string
 }
 
 export declare interface IntercomIntegrationOptions

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -133,3 +133,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Minor Changes
 
 - Adds `recordCrossOriginIframe` setting to opt-in enable cross-origin iframe recording.
+
+## 5.4.1
+
+### Patch Changes
+
+- Ensure integrations are not initialized when `disabled: true`.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "5.4.0",
+	"version": "5.4.1",
 	"scripts": {
 		"build": "yarn typegen && rollup -c",
 		"dev": "rollup -c -w",

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -146,11 +146,17 @@ export const H: HighlightPublicInterface = {
 				}
 			})
 
-			if (options?.integrations?.mixpanel?.projectToken) {
+			if (
+				!options?.integrations?.mixpanel?.disabled &&
+				options?.integrations?.mixpanel?.projectToken
+			) {
 				setupMixpanelIntegration(options.integrations.mixpanel)
 			}
 
-			if (options?.integrations?.amplitude?.apiKey) {
+			if (
+				!options?.integrations?.amplitude?.disabled &&
+				options?.integrations?.amplitude?.apiKey
+			) {
 				setupAmplitudeIntegration(options.integrations.amplitude)
 			}
 		} catch (e) {
@@ -224,10 +230,6 @@ export const H: HighlightPublicInterface = {
 						...metadata,
 						highlightSessionURL: highlightUrl,
 					})
-				} else {
-					console.warn(
-						"Mixpanel not loaded, but Highlight is configured to use it. This is usually caused by Mixpanel being blocked by the user's browser.",
-					)
 				}
 			}
 


### PR DESCRIPTION
## Summary

Ensures we don't initialize Mixpanel or Amplitude integrations when they are explicitly disabled. Also removes a Mixpanel warning which wasn't accurate and makes the tokens/keys optional in the integration objects optional so you don't need to specify them when trying to set `disabled: true`.

## How did you test this change?

Local click test.

## Are there any deployment considerations?

Could possibly change tracking behavior if projects were not configured correctly in the past (were passing the token/API key + `disabled`).