### PR TITLE
fix python serverless signature

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,5 +1,6 @@
 import 'antd/dist/antd.css'
 import '@highlight-run/rrweb/dist/rrweb.min.css'
+import '@highlight-run/react/dist/index.css'
 import '@fontsource/poppins'
 import './index.scss'
 import './style/tailwind.css'

--- a/sdk/highlight-py/e2e/highlight_azure/HttpTrigger/function.json
+++ b/sdk/highlight-py/e2e/highlight_azure/HttpTrigger/function.json
@@ -6,7 +6,8 @@
 			"type": "httpTrigger",
 			"direction": "in",
 			"name": "req",
-			"methods": ["get", "post"]
+			"methods": ["get", "post"],
+			"route": "test/{session_id}"
 		},
 		{
 			"type": "http",

--- a/sdk/highlight-py/e2e/highlight_azure/HttpTrigger/function.json
+++ b/sdk/highlight-py/e2e/highlight_azure/HttpTrigger/function.json
@@ -6,8 +6,7 @@
 			"type": "httpTrigger",
 			"direction": "in",
 			"name": "req",
-			"methods": ["get", "post"],
-			"route": "test/{session_id}"
+			"methods": ["get", "post"]
 		},
 		{
 			"type": "http",

--- a/sdk/highlight-py/e2e/highlight_azure/requirements.txt
+++ b/sdk/highlight-py/e2e/highlight_azure/requirements.txt
@@ -3,4 +3,4 @@
 # Manually managing azure-functions-worker may cause unexpected issues
 
 azure-functions
-highlight-io>=0.4.3
+highlight-io>=0.4.4

--- a/sdk/highlight-py/highlight_io/integrations/aws.py
+++ b/sdk/highlight-py/highlight_io/integrations/aws.py
@@ -12,11 +12,10 @@ def observe_handler(fn):
     :return: a wrapped function that will record exceptions.
     """
 
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
+    def get_highlight_header(*args, **kwargs):
         highlight_header_value: str = ""
         if args and args[0] and callable(args[0].get):
             highlight_header_value = args[0].get(H.REQUEST_HEADER) or ""
-        return observe_serverless(highlight_header_value, fn)(*args, **kwargs)
+        return highlight_header_value
 
-    return wrapper
+    return observe_serverless(get_highlight_header, fn)

--- a/sdk/highlight-py/highlight_io/integrations/azure.py
+++ b/sdk/highlight-py/highlight_io/integrations/azure.py
@@ -1,5 +1,3 @@
-import functools
-
 from highlight_io import H
 from highlight_io.integrations.serverless import observe_serverless
 
@@ -12,11 +10,10 @@ def observe_handler(fn):
     :return: a wrapped function that will record exceptions.
     """
 
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
+    def get_highlight_header(*args, **kwargs):
         highlight_header_value: str = ""
         if args and args[0] and args[0].headers and callable(args[0].headers.get):
             highlight_header_value = args[0].headers.get(H.REQUEST_HEADER) or ""
-        return observe_serverless(highlight_header_value, fn)(*args, **kwargs)
+        return highlight_header_value
 
-    return wrapper
+    return observe_serverless(get_highlight_header, fn)

--- a/sdk/highlight-py/highlight_io/integrations/gcp.py
+++ b/sdk/highlight-py/highlight_io/integrations/gcp.py
@@ -1,5 +1,3 @@
-import functools
-
 from highlight_io import H
 from highlight_io.integrations.serverless import observe_serverless
 
@@ -12,11 +10,10 @@ def observe_handler(fn):
     :return: a wrapped function that will record exceptions.
     """
 
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
+    def get_highlight_header(*args, **kwargs):
         highlight_header_value: str = ""
         if args and args[0] and args[0].headers and callable(args[0].headers.get):
             highlight_header_value = args[0].headers.get(H.REQUEST_HEADER) or ""
-        return observe_serverless(highlight_header_value, fn)(*args, **kwargs)
+        return highlight_header_value
 
-    return wrapper
+    return observe_serverless(get_highlight_header, fn)

--- a/sdk/highlight-py/highlight_io/integrations/serverless.py
+++ b/sdk/highlight-py/highlight_io/integrations/serverless.py
@@ -14,7 +14,7 @@ def observe_serverless(get_highlight_header, fn):
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        session_id, request_id = get_highlight_header(*args, **kwargs)
+        session_id, request_id = get_highlight_header(*args, **kwargs).split('/')
         try:
             with H.get_instance().trace(session_id, request_id):
                 return fn(*args, **kwargs)

--- a/sdk/highlight-py/highlight_io/integrations/serverless.py
+++ b/sdk/highlight-py/highlight_io/integrations/serverless.py
@@ -14,7 +14,7 @@ def observe_serverless(get_highlight_header, fn):
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        session_id, request_id = get_highlight_header(*args, **kwargs).split('/')
+        session_id, request_id = get_highlight_header(*args, **kwargs).split("/")
         try:
             with H.get_instance().trace(session_id, request_id):
                 return fn(*args, **kwargs)

--- a/sdk/highlight-py/highlight_io/integrations/serverless.py
+++ b/sdk/highlight-py/highlight_io/integrations/serverless.py
@@ -14,7 +14,11 @@ def observe_serverless(get_highlight_header, fn):
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        session_id, request_id = get_highlight_header(*args, **kwargs).split("/")
+        session_id, request_id = "", ""
+        try:
+            session_id, request_id = get_highlight_header(*args, **kwargs).split("/")
+        except ValueError:
+            pass
         try:
             with H.get_instance().trace(session_id, request_id):
                 return fn(*args, **kwargs)

--- a/sdk/highlight-py/highlight_io/integrations/serverless.py
+++ b/sdk/highlight-py/highlight_io/integrations/serverless.py
@@ -3,7 +3,7 @@ import functools
 from highlight_io import H
 
 
-def observe_serverless(highlight_header_value: str, fn):
+def observe_serverless(get_highlight_header, fn):
     """
     Generic decorator for serverless request handlers. Extracts the request context
     to associate the request in azure functions, aws lambda, gcp, etc.
@@ -14,11 +14,7 @@ def observe_serverless(highlight_header_value: str, fn):
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        session_id, request_id = "", ""
-        try:
-            session_id, request_id = highlight_header_value.split("/")
-        except ValueError:
-            pass
+        session_id, request_id = get_highlight_header(*args, **kwargs)
         try:
             with H.get_instance().trace(session_id, request_id):
                 return fn(*args, **kwargs)

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.4.3"
+version = "0.4.4"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.4.4"
+version = "0.4.5"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary

Updates the highlight python sdk to ensure serverless wrapper signatures do not conflict with the serverless libraries.

## How did you test this change?
Pytest, currently testing on azure.
https://highlightaztest.azurewebsites.net/api/httptrigger

<img width="1014" alt="Screenshot 2023-03-14 at 2 58 41 PM" src="https://user-images.githubusercontent.com/1351531/225150126-616a9bfe-7353-4543-845a-81a9b96da609.png">

<img width="590" alt="image" src="https://user-images.githubusercontent.com/1351531/225150013-df10ce04-3db9-4157-b6a2-21a2f449a50a.png">

<img width="849" alt="Screenshot 2023-03-14 at 2 58 36 PM" src="https://user-images.githubusercontent.com/1351531/225150096-4d2ac37d-b025-4e76-ad82-155661a49dd5.png">


## Are there any deployment considerations?

Releasing new python sdk version 0.4.4
