### PR TITLE
filter noisy highlight errors

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -783,6 +783,11 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 		return nil, e.New("error object event was nil or empty")
 	}
 
+	if projectID == 1 {
+		if errorObj.Event == `input: initializeSession BillingQuotaExceeded` || errorObj.Event == `BillingQuotaExceeded` || errorObj.Event == `panic {error: missing operation context}` {
+			return nil, e.New("Filtering out noisy Highlight error")
+		}
+	}
 	if projectID == 356 {
 		if errorObj.Event == `["\"ReferenceError: Can't find variable: widgetContainerAttribute\""]` ||
 			errorObj.Event == `"ReferenceError: Can't find variable: widgetContainerAttribute"` ||


### PR DESCRIPTION
## Summary

Some new projects are sending lots of sessions causing our own `BillingQuotaExceeded` error to cause high json match load on postgres.

<img width="945" alt="image" src="https://user-images.githubusercontent.com/1351531/225148255-d91153fd-39d2-4e4b-b4f2-6e4954e54fc6.png">

## How did you test this change?

Local backend build.

## Are there any deployment considerations?

No