### PR TITLE
skip writing log attributes if these are internal attributes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
 			"port": 2345,
 			"substitutePath": [
 				{ "from": "${workspaceFolder}", "to": "/build" },
-			],
+			]
 		}
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,9 +11,7 @@
 			"debugAdapter": "dlv-dap",
 			"mode": "remote",
 			"port": 2345,
-			"substitutePath": [
-				{ "from": "${workspaceFolder}", "to": "/build" },
-			]
+			"substitutePath": [{ "from": "${workspaceFolder}", "to": "/build" }]
 		}
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,8 +8,12 @@
 			"name": "Attach to Process",
 			"type": "go",
 			"request": "attach",
-			"mode": "local",
-			"processId": "main"
+			"debugAdapter": "dlv-dap",
+			"mode": "remote",
+			"port": 2345,
+			"substitutePath": [
+				{ "from": "${workspaceFolder}", "to": "/build" },
+			],
 		}
 	]
 }

--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/highlight/highlight/sdk/highlight-go"
-	"github.com/influxdata/influxdb-client-go/v2/log"
+	log "github.com/sirupsen/logrus"
 )
 
 type LogRowPrimaryAttrs struct {

--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -78,7 +78,7 @@ func getAttributesMap(resourceAttributes, eventAttributes map[string]any) map[st
 			for _, attr := range highlight.InternalAttributes {
 				if k == attr {
 					shouldSkip = true
-					continue
+					break
 				}
 			}
 

--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -1,0 +1,104 @@
+package clickhouse
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/influxdata/influxdb-client-go/v2/log"
+)
+
+type LogRowPrimaryAttrs struct {
+	Timestamp       time.Time
+	ProjectId       uint32
+	TraceId         string
+	SpanId          string
+	SecureSessionId string
+}
+
+type LogRow struct {
+	LogRowPrimaryAttrs
+	UUID           string
+	TraceFlags     uint32
+	SeverityText   string
+	SeverityNumber int32
+	ServiceName    string
+	Body           string
+	LogAttributes  map[string]string
+}
+
+func NewLogRow(attrs LogRowPrimaryAttrs, opts ...LogRowOption) *LogRow {
+	logRow := &LogRow{
+		LogRowPrimaryAttrs: LogRowPrimaryAttrs{
+			Timestamp:       attrs.Timestamp,
+			TraceId:         attrs.TraceId,
+			SpanId:          attrs.SpanId,
+			ProjectId:       attrs.ProjectId,
+			SecureSessionId: attrs.SecureSessionId,
+		},
+		UUID:           uuid.New().String(),
+		SeverityText:   "INFO",
+		SeverityNumber: int32(log.InfoLevel),
+	}
+
+	for _, opt := range opts {
+		opt(logRow)
+	}
+
+	return logRow
+}
+
+func (l *LogRow) Cursor() string {
+	return encodeCursor(l.Timestamp, l.UUID)
+}
+
+type LogRowOption func(*LogRow)
+
+func WithLogAttributes(resourceAttributes, eventAttributes map[string]any) LogRowOption {
+	return func(h *LogRow) {
+		h.LogAttributes = getAttributesMap(resourceAttributes, eventAttributes)
+	}
+}
+
+func cast[T string | int64 | float64](v interface{}, fallback T) T {
+	c, ok := v.(T)
+	if !ok {
+		return fallback
+	}
+	return c
+}
+
+func getAttributesMap(resourceAttributes, eventAttributes map[string]any) map[string]string {
+	attributesMap := make(map[string]string)
+	for _, m := range []map[string]any{resourceAttributes, eventAttributes} {
+		for k, v := range m {
+			shouldSkip := false
+
+			for _, attr := range highlight.InternalAttributes {
+				if k == attr {
+					shouldSkip = true
+					continue
+				}
+			}
+
+			if shouldSkip {
+				continue
+			}
+
+			vStr := cast(v, "")
+			if vStr != "" {
+				attributesMap[k] = vStr
+			}
+			vInt := cast[int64](v, 0)
+			if vInt != 0 {
+				attributesMap[k] = strconv.FormatInt(vInt, 10)
+			}
+			vFlt := cast(v, 0.)
+			if vFlt > 0. {
+				attributesMap[k] = strconv.FormatFloat(vFlt, 'f', -1, 64)
+			}
+		}
+	}
+	return attributesMap
+}

--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -1,0 +1,16 @@
+package clickhouse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLogRowWithLogAttributes(t *testing.T) {
+	resourceAttributes := map[string]any{"os.description": "Debian GNU/Linux 11 (bullseye)"}
+	eventAttributes := map[string]any{"log.severity": "info"} // should be skipped since this is an internal attribute
+
+	logRow := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(resourceAttributes, eventAttributes))
+
+	assert.Equal(t, map[string]string{"os.description": "Debian GNU/Linux 11 (bullseye)"}, logRow.LogAttributes)
+}

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -7,7 +7,6 @@ import (
 	"time"
 	"unicode"
 
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/google/uuid"
@@ -16,44 +15,6 @@ import (
 	flat "github.com/nqd/flat"
 	e "github.com/pkg/errors"
 )
-
-type LogRowPrimaryAttrs struct {
-	Timestamp       time.Time
-	ProjectId       uint32
-	TraceId         string
-	SpanId          string
-	SecureSessionId string
-}
-
-type LogRow struct {
-	LogRowPrimaryAttrs
-	UUID           string
-	TraceFlags     uint32
-	SeverityText   string
-	SeverityNumber int32
-	ServiceName    string
-	Body           string
-	LogAttributes  map[string]string
-}
-
-func NewLogRow(attrs LogRowPrimaryAttrs) *LogRow {
-	return &LogRow{
-		LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-			Timestamp:       attrs.Timestamp,
-			TraceId:         attrs.TraceId,
-			SpanId:          attrs.SpanId,
-			ProjectId:       attrs.ProjectId,
-			SecureSessionId: attrs.SecureSessionId,
-		},
-		UUID:           uuid.New().String(),
-		SeverityText:   "INFO",
-		SeverityNumber: int32(log.InfoLevel),
-	}
-}
-
-func (l *LogRow) Cursor() string {
-	return encodeCursor(l.Timestamp, l.UUID)
-}
 
 func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) error {
 	if len(logRows) == 0 {

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -91,6 +91,7 @@ func getAttributesMap(resourceAttributes, eventAttributes map[string]any) map[st
 			for _, attr := range highlight.InternalAttributes {
 				if k == attr {
 					shouldSkip = true
+					continue
 				}
 			}
 

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -86,11 +86,18 @@ func getAttributesMap(resourceAttributes, eventAttributes map[string]any) map[st
 	attributesMap := make(map[string]string)
 	for _, m := range []map[string]any{resourceAttributes, eventAttributes} {
 		for k, v := range m {
+			shouldSkip := false
+
 			for _, attr := range highlight.InternalAttributes {
 				if k == attr {
-					continue
+					shouldSkip = true
 				}
 			}
+
+			if shouldSkip {
+				continue
+			}
+
 			vStr := cast(v, "")
 			if vStr != "" {
 				attributesMap[k] = vStr


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

`log.severity` and `log.message` aren't being excluded from `LogAttributes`.

This PR fixes that. It also moves some data parsing logic down out of the OTEL code and into the logs code. This makes it easier to unit test and it sets up a better interface for building a log row.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed `log.severity` and `log.message`  aren't present in log attributes anymore.

<img width="1488" alt="Screenshot 2023-03-14 at 10 42 54 PM" src="https://user-images.githubusercontent.com/58678/225208807-f7f3c030-50dc-4a8b-8ab9-762f697f7325.png">


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
