### PR TITLE
retry hubspot admin creation

### DIFF
--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -2,7 +2,9 @@ package hubspot
 
 import (
 	"context"
+	"math"
 	"strings"
+	"time"
 
 	"github.com/aws/smithy-go/ptr"
 	"github.com/goware/emailproviders"
@@ -13,6 +15,19 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
+
+const RETRIES = 5
+
+func retry[T *int](fn func() (T, error)) (ret T, err error) {
+	for i := 0; i < RETRIES; i++ {
+		ret, err = fn()
+		if err == nil {
+			return
+		}
+		time.Sleep(16 * time.Millisecond * time.Duration(math.Pow(2, float64(i))))
+	}
+	return
+}
 
 type HubspotApi struct {
 	hubspotClient hubspot.Client
@@ -35,7 +50,7 @@ type CustomContactsResponse struct {
 	ProfileURL   string `json:"profile-url"`
 }
 
-func (h *HubspotApi) CreateContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
+func (h *HubspotApi) createContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
 	var hubspotContactId int
 	if emailproviders.Exists(email) {
 		email = ""
@@ -95,6 +110,12 @@ func (h *HubspotApi) CreateContactForAdmin(ctx context.Context, adminID int, ema
 	return &hubspotContactId, nil
 }
 
+func (h *HubspotApi) CreateContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
+	return retry(func() (*int, error) {
+		return h.createContactForAdmin(ctx, adminID, email, userDefinedRole, userDefinedPersona, first, last, phone, referral)
+	})
+}
+
 func (h *HubspotApi) CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int, db *gorm.DB) error {
 	admin := &model.Admin{}
 	if err := db.Model(&model.Admin{}).Where("id = ?", adminID).First(&admin).Error; err != nil {
@@ -105,9 +126,9 @@ func (h *HubspotApi) CreateContactCompanyAssociation(ctx context.Context, adminI
 		return e.Wrap(err, "error retrieving workspace details")
 	}
 	if workspace.HubspotCompanyID == nil {
-		return e.New("hubspot company id is empy")
+		return e.New("hubspot company id is empty")
 	} else if admin.HubspotContactID == nil {
-		return e.New("hubspot contact id is empy")
+		return e.New("hubspot contact id is empty")
 	}
 	if err := h.hubspotClient.CRMAssociations().Create(hubspot.CRMAssociationsRequest{
 		DefinitionID: hubspot.CRMAssociationCompanyToContact,


### PR DESCRIPTION
## Summary

Retry hubspot contact creation to avoid (hopefully) transient 500 errors.

<img width="1778" alt="Screenshot 2023-03-14 at 11 47 58 PM" src="https://user-images.githubusercontent.com/1351531/225228649-c3554079-01f3-4601-a9c2-275fe43ec461.png">


## How did you test this change?

<img width="1444" alt="image" src="https://user-images.githubusercontent.com/1351531/225228556-8258ba46-8a21-4e7a-954a-f47b2e4bc1f8.png">

<img width="1334" alt="Screenshot 2023-03-14 at 11 47 45 PM" src="https://user-images.githubusercontent.com/1351531/225228604-eb07a42f-5ff3-4972-a43a-6c303937c768.png">

## Are there any deployment considerations?

No