### PR TITLE
fix invalid timestamp

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogTimestamp.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogTimestamp.tsx
@@ -1,18 +1,10 @@
 import { Text } from '@highlight-run/ui'
+import moment from 'moment'
 import React from 'react'
 
 const toYearMonthDay = (timestamp: string) => {
 	const date = new Date(timestamp)
-	const dateString = date.toLocaleDateString('en-US', {
-		year: 'numeric',
-		month: '2-digit',
-		day: '2-digit',
-	})
-	const timeString = date.toLocaleTimeString('en-US', {
-		hour12: false,
-	})
-
-	return `${dateString} ${timeString}`
+	return moment(date).format('YYYY-MM-DD HH:mm:ss')
 }
 
 type Props = {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Uses moment to format timestamps. Using the built-in javascript datetime formatting handles the hour at the start of the day weirdly (see #4605)

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed this moment format starts at the zero hour.

<img width="598" alt="Screenshot 2023-03-15 at 12 04 05 PM" src="https://user-images.githubusercontent.com/58678/225402491-0d52611a-5a00-4061-9a91-8c54bc968188.png">

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
