### PR TITLE
fix filtering by log level

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -69,6 +69,8 @@ func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) 
 		if len(logRow.UUID) == 0 {
 			logRow.UUID = uuid.New().String()
 		}
+		// TODO (et) - move this logic to a builder function (#4464)
+		logRow.SeverityText = strings.ToLower(logRow.SeverityText)
 		err = batch.AppendStruct(logRow)
 		if err != nil {
 			return err

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -975,28 +975,28 @@ func TestLogKeyValuesLevel(t *testing.T) {
 				Timestamp: now,
 				ProjectId: 1,
 			},
-			SeverityText: "INFO",
+			SeverityText: modelInputs.LogLevelInfo.String(),
 		},
 		{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
 				Timestamp: now,
 				ProjectId: 1,
 			},
-			SeverityText: "WARN",
+			SeverityText: modelInputs.LogLevelWarn.String(),
 		},
 		{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
 				Timestamp: now,
 				ProjectId: 1,
 			},
-			SeverityText: "INFO",
+			SeverityText: modelInputs.LogLevelInfo.String(),
 		},
 		{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
 				Timestamp: now,
 				ProjectId: 1,
 			},
-			LogAttributes: map[string]string{"level": "FATAL"}, // should be skipped in the output
+			LogAttributes: map[string]string{"level": modelInputs.LogLevelFatal.String()}, // should be skipped in the output
 		},
 	}
 
@@ -1005,7 +1005,7 @@ func TestLogKeyValuesLevel(t *testing.T) {
 	values, err := client.LogsKeyValues(ctx, 1, "level", now, now)
 	assert.NoError(t, err)
 
-	expected := []string{"INFO", "WARN"}
+	expected := []string{"info", "warn"}
 
 	sort.Strings(values)
 	sort.Strings(expected)

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -632,7 +632,7 @@ func TestReadLogsWithLevelFilter(t *testing.T) {
 				Timestamp: now,
 				ProjectId: 1,
 			},
-			SeverityText: "INFO",
+			SeverityText: modelInputs.LogLevelInfo.String(),
 		},
 		{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
@@ -640,7 +640,7 @@ func TestReadLogsWithLevelFilter(t *testing.T) {
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{
-				"level": "WARN",
+				"level": modelInputs.LogLevelWarn.String(),
 			},
 		},
 	}
@@ -649,23 +649,23 @@ func TestReadLogsWithLevelFilter(t *testing.T) {
 
 	payload, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
-		Query:     "level:INFO",
+		Query:     "level:info",
 	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
-	assert.Equal(t, modelInputs.LogLevel("INFO"), payload.Edges[0].Node.Level)
+	assert.Equal(t, modelInputs.LogLevelInfo, payload.Edges[0].Node.Level)
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
-		Query:     "level:*NF*",
+		Query:     "level:*nf*",
 	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
-	assert.Equal(t, modelInputs.LogLevel("INFO"), payload.Edges[0].Node.Level)
+	assert.Equal(t, modelInputs.LogLevelInfo, payload.Edges[0].Node.Level)
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
-		Query:     "level:WARN",
+		Query:     "level:warn",
 	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 0)

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -130,42 +130,42 @@ func TestReadLogsHistogram(t *testing.T) {
 				Timestamp: now,
 				ProjectId: 1,
 			},
-			SeverityText: "INFO",
+			SeverityText: modelInputs.LogLevelInfo.String(),
 		},
 		{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
 				Timestamp: now.Add(-time.Hour - time.Minute*29),
 				ProjectId: 1,
 			},
-			SeverityText: "DEBUG",
+			SeverityText: modelInputs.LogLevelDebug.String(),
 		},
 		{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
 				Timestamp: now.Add(-time.Hour - time.Minute*30),
 				ProjectId: 1,
 			},
-			SeverityText: "INFO",
+			SeverityText: modelInputs.LogLevelInfo.String(),
 		},
 		{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
 				Timestamp: now.Add(-time.Hour * 2),
 				ProjectId: 1,
 			},
-			SeverityText: "ERROR",
+			SeverityText: modelInputs.LogLevelError.String(),
 		},
 		{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
 				Timestamp: now.Add(-time.Hour*2 - time.Minute*30),
 				ProjectId: 1,
 			},
-			SeverityText: "ERROR",
+			SeverityText: modelInputs.LogLevelError.String(),
 		},
 		{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
 				Timestamp: now.Add(-time.Hour * 3),
 				ProjectId: 1,
 			},
-			SeverityText: "ERROR",
+			SeverityText: modelInputs.LogLevelError.String(),
 		},
 	}
 
@@ -220,7 +220,7 @@ func TestReadLogsHistogram(t *testing.T) {
 
 	assert.Equal(
 		t,
-		modelInputs.LogLevel("ERROR"),
+		modelInputs.LogLevelError,
 		payload.Buckets[0].Counts[4].Level,
 		"The first bucket should have the count 4 with severity of ERROR",
 	)
@@ -233,7 +233,7 @@ func TestReadLogsHistogram(t *testing.T) {
 
 	assert.Equal(
 		t,
-		modelInputs.LogLevel("DEBUG"),
+		modelInputs.LogLevelDebug,
 		payload.Buckets[1].Counts[1].Level,
 		"The second bucket should have the count 1 with severity of DEBUG",
 	)
@@ -245,7 +245,7 @@ func TestReadLogsHistogram(t *testing.T) {
 	)
 	assert.Equal(
 		t,
-		modelInputs.LogLevel("INFO"),
+		modelInputs.LogLevelInfo,
 		payload.Buckets[1].Counts[2].Level,
 		"The second bucket should have the second count with severity of INFO",
 	)

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -8043,12 +8043,12 @@ enum SessionAlertType {
 }
 
 enum LogLevel {
-	TRACE
-	DEBUG
-	INFO
-	WARN
-	ERROR
-	FATAL
+	trace
+	debug
+	info
+	warn
+	error
+	fatal
 }
 
 type Project {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -848,12 +848,12 @@ func (e LogKeyType) MarshalGQL(w io.Writer) {
 type LogLevel string
 
 const (
-	LogLevelTrace LogLevel = "TRACE"
-	LogLevelDebug LogLevel = "DEBUG"
-	LogLevelInfo  LogLevel = "INFO"
-	LogLevelWarn  LogLevel = "WARN"
-	LogLevelError LogLevel = "ERROR"
-	LogLevelFatal LogLevel = "FATAL"
+	LogLevelTrace LogLevel = "trace"
+	LogLevelDebug LogLevel = "debug"
+	LogLevelInfo  LogLevel = "info"
+	LogLevelWarn  LogLevel = "warn"
+	LogLevelError LogLevel = "error"
+	LogLevelFatal LogLevel = "fatal"
 )
 
 var AllLogLevel = []LogLevel{

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -299,12 +299,12 @@ enum SessionAlertType {
 }
 
 enum LogLevel {
-	TRACE
-	DEBUG
-	INFO
-	WARN
-	ERROR
-	FATAL
+	trace
+	debug
+	info
+	warn
+	error
+	fatal
 }
 
 type Project {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -684,12 +684,12 @@ export enum LogKeyType {
 }
 
 export enum LogLevel {
-	Debug = 'DEBUG',
-	Error = 'ERROR',
-	Fatal = 'FATAL',
-	Info = 'INFO',
-	Trace = 'TRACE',
-	Warn = 'WARN',
+	Debug = 'debug',
+	Error = 'error',
+	Fatal = 'fatal',
+	Info = 'info',
+	Trace = 'trace',
+	Warn = 'warn',
 }
 
 export type LogsConnection = {

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -370,17 +370,12 @@ const LogValue: React.FC<{
 										const index = queryTerms.findIndex(
 											(term) => term.key === queryKey,
 										)
-										const newValue =
-											label === 'level'
-												? value.toLowerCase()
-												: value
 
 										index !== -1
-											? (queryTerms[index].value =
-													newValue)
+											? (queryTerms[index].value = value)
 											: queryTerms.push({
 													key: queryKey,
-													value: newValue,
+													value,
 													operator: DEFAULT_OPERATOR,
 													offsetStart: 0, // not actually used
 											  })

--- a/frontend/src/pages/LogsPage/LogsTable/LogLevel.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogLevel.tsx
@@ -14,7 +14,7 @@ const LogLevel = ({ level }: Props) => {
 	return (
 		<Box flexShrink={0} style={{ width: 46 }}>
 			<Text color={color} weight="bold" family="monospace">
-				{level}
+				{level.toUpperCase()}
 			</Text>
 		</Box>
 	)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Filtering by log level is sometimes broken because we haven't normalized it before writing to the db (something that will have a more robust fix in #4464).

To compensate for the discrepancy, in [#4555,](https://github.com/highlight/highlight/pull/4555/files#diff-44251d85d1baf341cd7313aaa7aa61bd8d4832267460557e8cbb6b215ba3b52fR373-R378) the frontend is lowercasing the level but this is something the backend should just be figuring out.

This PR ensures that the backend always sends the frontend lowercase log levels and that we always write it to lowercase before hitting the clickhouse db.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Confirmed the backend is sending lowercase log levels to the frontend
* Confirmed we can filter by log level via the frontend

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
