### PR TITLE
exclude live sessions

### DIFF
--- a/frontend/src/pages/Sessions/EmptySessionsSearchParams.tsx
+++ b/frontend/src/pages/Sessions/EmptySessionsSearchParams.tsx
@@ -1,6 +1,7 @@
 import { SearchParamsInput } from '@graph/schemas'
 import { Complete } from '@util/types'
 
+// TODO: only keep query (remove all other attributes) after deprecating static filters
 export const EmptySessionsSearchParams: Complete<SearchParamsInput> = {
 	user_properties: [],
 	identified: false,

--- a/frontend/src/pages/Sessions/EmptySessionsSearchParams.tsx
+++ b/frontend/src/pages/Sessions/EmptySessionsSearchParams.tsx
@@ -1,7 +1,6 @@
 import { SearchParamsInput } from '@graph/schemas'
 import { Complete } from '@util/types'
 
-// TODO: only keep query (remove all other attributes) after deprecating static filters
 export const EmptySessionsSearchParams: Complete<SearchParamsInput> = {
 	user_properties: [],
 	identified: false,
@@ -20,5 +19,5 @@ export const EmptySessionsSearchParams: Complete<SearchParamsInput> = {
 	environments: [],
 	app_versions: [],
 	show_live_sessions: false,
-	query: ``,
+	query: `{\"isAnd\":true,\"rules\":[[\"custom_processed\",\"is\",\"true\"]]}`,
 }


### PR DESCRIPTION
## Summary

Live sessions should not be shown by default because they have a tendency to confuse highlight users.

## How did you test this change?

Local frontend deploy.

## Are there any deployment considerations?

No