### PR TITLE
ensure error logs create error objects

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -63,7 +63,7 @@ jobs:
             - name: Check for GORM Debug
               run: if [ "$(grep --exclude-dir migrations -rE 'DB.[\s\n]*Debug\(\)' ./backend | wc -l)" -gt 0 ]; then grep --exclude-dir migrations -rE 'DB.[\s\n]*Debug\(\)' ./backend && exit 1; fi
             - name: Check for logrus without context
-              run: if [ "$(grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | wc -l)" -gt 0 ]; then grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' && exit 1; fi
+              run: if [ "$(grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | grep -v 'Level' | wc -l)" -gt 0 ]; then grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | grep -v 'Level' && exit 1; fi
             - name: Run linter
               uses: golangci/golangci-lint-action@v3
               with:

--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -72,9 +72,9 @@ func (l *LogRow) Cursor() string {
 
 type LogRowOption func(*LogRow)
 
-func WithLogAttributes(resourceAttributes, eventAttributes map[string]any) LogRowOption {
+func WithLogAttributes(resourceAttributes, eventAttributes map[string]any, isFrontendLog bool) LogRowOption {
 	return func(h *LogRow) {
-		h.LogAttributes = getAttributesMap(resourceAttributes, eventAttributes)
+		h.LogAttributes = getAttributesMap(resourceAttributes, eventAttributes, isFrontendLog)
 	}
 }
 
@@ -115,7 +115,7 @@ func cast[T string | int64 | float64](v interface{}, fallback T) T {
 	return c
 }
 
-func getAttributesMap(resourceAttributes, eventAttributes map[string]any) map[string]string {
+func getAttributesMap(resourceAttributes, eventAttributes map[string]any, isFrontendLog bool) map[string]string {
 	attributesMap := make(map[string]string)
 	for _, m := range []map[string]any{resourceAttributes, eventAttributes} {
 		for k, v := range m {
@@ -125,6 +125,15 @@ func getAttributesMap(resourceAttributes, eventAttributes map[string]any) map[st
 				if k == attr {
 					shouldSkip = true
 					break
+				}
+			}
+
+			if isFrontendLog {
+				for _, attr := range highlight.BackendOnlyAttributePrefixes {
+					if strings.HasPrefix(k, attr) {
+						shouldSkip = true
+						break
+					}
 				}
 			}
 
@@ -173,34 +182,17 @@ func makeLogLevel(severityText string) modelInputs.LogLevel {
 func getSeverityNumber(logLevel modelInputs.LogLevel) int32 {
 	switch logLevel {
 	case modelInputs.LogLevelTrace:
-		{
-			return int32(log.TraceLevel)
-
-		}
+		return int32(log.TraceLevel)
 	case modelInputs.LogLevelDebug:
-		{
-			return int32(log.DebugLevel)
-
-		}
+		return int32(log.DebugLevel)
 	case modelInputs.LogLevelInfo:
-		{
-			return int32(log.InfoLevel)
-
-		}
+		return int32(log.InfoLevel)
 	case modelInputs.LogLevelWarn:
-		{
-			return int32(log.WarnLevel)
-		}
+		return int32(log.WarnLevel)
 	case modelInputs.LogLevelError:
-		{
-			return int32(log.ErrorLevel)
-		}
-
+		return int32(log.ErrorLevel)
 	case modelInputs.LogLevelFatal:
-		{
-			return int32(log.FatalLevel)
-		}
-
+		return int32(log.FatalLevel)
 	default:
 		return int32(log.InfoLevel)
 	}

--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -115,6 +115,12 @@ func getAttributesMap(resourceAttributes, eventAttributes map[string]any) map[st
 
 func makeLogLevel(severityText string) modelInputs.LogLevel {
 	switch strings.ToLower(severityText) {
+	case "log":
+		return modelInputs.LogLevelError
+	case "console.error":
+		return modelInputs.LogLevelError
+	case "window.onerror":
+		return modelInputs.LogLevelError
 	case "trace":
 		{
 			return modelInputs.LogLevelTrace

--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -10,9 +10,13 @@ func TestNewLogRowWithLogAttributes(t *testing.T) {
 	resourceAttributes := map[string]any{"os.description": "Debian GNU/Linux 11 (bullseye)"}
 	eventAttributes := map[string]any{"log.severity": "info"} // should be skipped since this is an internal attribute
 
-	logRow := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(resourceAttributes, eventAttributes))
+	logRow := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(resourceAttributes, eventAttributes, false))
 
 	assert.Equal(t, map[string]string{"os.description": "Debian GNU/Linux 11 (bullseye)"}, logRow.LogAttributes)
+
+	logRow = NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(resourceAttributes, eventAttributes, true))
+
+	assert.Equal(t, map[string]string{}, logRow.LogAttributes)
 }
 
 func TestNewLogRowWithSeverityText(t *testing.T) {

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -87,7 +87,7 @@ func getLogRow(ts time.Time, lvl, projectID, sessionID, traceID, spanID string, 
 
 func getBackendError(ctx context.Context, ts time.Time, projectID, sessionID, requestID, traceID, spanID string, logCursor *string, source, excMessage, tag string, resourceAttributes, eventAttributes map[string]any) (bool, *model.BackendErrorObjectInput) {
 	excType := cast(eventAttributes[string(semconv.ExceptionTypeKey)], source)
-	errorUrl := cast(eventAttributes[highlight.ErrorURLAttribute], "")
+	errorUrl := cast(eventAttributes[highlight.ErrorURLAttribute], source)
 	stackTrace := cast(eventAttributes[string(semconv.ExceptionStacktraceKey)], "")
 	if excType == "" && excMessage == "" {
 		log.WithContext(ctx).WithField("EventAttributes", eventAttributes).Error("otel received exception with no type and no message")
@@ -230,7 +230,6 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						// create a backend error for this error log
 						lvl, _ := log.ParseLevel(logSev)
 						if lvl <= log.ErrorLevel {
-							// TODO(vkorolik) stacktrace?
 							isProjectError, backendError := getBackendError(ctx, ts, projectID, sessionID, requestID, traceID, spanID, logCursor, source, logMessage, string(tagsBytes), resourceAttributes, eventAttributes)
 							if backendError == nil {
 								data, _ := req.MarshalJSON()

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -249,6 +249,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						// create a backend error for this error log
 						lvl, _ := log.ParseLevel(logSev)
 						if lvl <= log.ErrorLevel {
+							// TODO(vkorolik) stacktrace?
 							isProjectError, backendError := getBackendError(ctx, ts, projectID, sessionID, requestID, traceID, spanID, logCursor, source, logMessage, string(tagsBytes), resourceAttributes, eventAttributes)
 							if backendError == nil {
 								data, _ := req.MarshalJSON()

--- a/backend/otel/otel_test.go
+++ b/backend/otel/otel_test.go
@@ -1,0 +1,1 @@
+package otel

--- a/backend/otel/otel_test.go
+++ b/backend/otel/otel_test.go
@@ -16,9 +16,7 @@ func (m *MockResponseWriter) Write(bytes []byte) (int, error) {
 	return 0, nil
 }
 
-func (m *MockResponseWriter) WriteHeader(statusCode int) {
-	return
-}
+func (m *MockResponseWriter) WriteHeader(statusCode int) {}
 
 func TestHandler_HandleLog(t *testing.T) {
 	w := &MockResponseWriter{}

--- a/backend/otel/otel_test.go
+++ b/backend/otel/otel_test.go
@@ -1,1 +1,34 @@
 package otel
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type MockResponseWriter struct{}
+
+func (m *MockResponseWriter) Header() http.Header {
+	return http.Header{}
+}
+
+func (m *MockResponseWriter) Write(bytes []byte) (int, error) {
+	return 0, nil
+}
+
+func (m *MockResponseWriter) WriteHeader(statusCode int) {
+	return
+}
+
+func TestHandler_HandleLog(t *testing.T) {
+	w := &MockResponseWriter{}
+	r, _ := http.NewRequest("POST", "", strings.NewReader(""))
+	h := Handler{}
+	h.HandleLog(w, r)
+}
+func TestHandler_HandleTrace(t *testing.T) {
+	w := &MockResponseWriter{}
+	r, _ := http.NewRequest("POST", "", strings.NewReader(""))
+	h := Handler{}
+	h.HandleTrace(w, r)
+}

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -228,6 +228,7 @@ services:
             retries: 5
         ports:
             - 3000:3000
+            - 6006:6006
             - 8080:8080
         build:
             context: ..

--- a/frontend/src/pages/ErrorsV2/ErrorLogCursor/ErrorLogCursorRedirect.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorLogCursor/ErrorLogCursorRedirect.tsx
@@ -1,18 +1,29 @@
 import { ErrorState } from '@components/ErrorState/ErrorState'
+import {
+	AppLoadingState,
+	useAppLoadingContext,
+} from '@context/AppLoadingContext'
 import { useGetErrorObjectForLogQuery } from '@graph/hooks'
 import { useParams } from '@util/react-router/useParams'
 import React from 'react'
 import { Navigate } from 'react-router'
 
 const ErrorLogCursorRedirect: React.FC = () => {
+	const { setLoadingState } = useAppLoadingContext()
 	const { cursor_id: logCursor } = useParams<{
 		cursor_id: string
 	}>() as { cursor_id: string }
 
-	const { loading, data, error } = useGetErrorObjectForLogQuery({
+	const { called, loading, data, error } = useGetErrorObjectForLogQuery({
 		variables: { log_cursor: logCursor! },
 		skip: !logCursor,
 	})
+
+	setLoadingState(
+		!called || loading
+			? AppLoadingState.EXTENDED_LOADING
+			: AppLoadingState.LOADED,
+	)
 
 	if (loading) {
 		return null

--- a/sdk/highlight-go/highlight.go
+++ b/sdk/highlight-go/highlight.go
@@ -68,7 +68,7 @@ const backendSetupCooldown = 15
 
 // message channels should be large to avoid blocking request processing
 // in case of a surge of metrics or errors.
-const messageBufferSize = 1 << 16
+const messageBufferSize = 1 << 20
 const metricCategory = "BACKEND"
 
 var (
@@ -306,7 +306,6 @@ func MarkBackendSetup(ctx context.Context) {
 func RecordMetric(ctx context.Context, name string, value float64) {
 	sessionSecureID, requestID, err := validateRequest(ctx)
 	if err != nil {
-		logger.Errorf("[highlight-go] %v", err)
 		return
 	}
 	// track invocation of this function to ensure shutdown waits
@@ -326,7 +325,7 @@ func RecordMetric(ctx context.Context, name string, value float64) {
 	select {
 	case metricChan <- metric:
 	default:
-		logger.Errorf("[highlight-go] metric channel full. discarding value for %s", sessionSecureID)
+		// do nothing if the channel is full, as this is not a correctable error by the SDK user
 	}
 }
 

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -2,6 +2,7 @@ package hlog
 
 import (
 	"context"
+	"fmt"
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -57,15 +58,13 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 		return nil
 	}
 
-	span, _ := highlight.StartTrace(
-		ctx, "highlight-ctx",
-		attribute.String(highlight.SourceAttribute, highlight.SourceAttributeFrontend),
-		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
-		attribute.String(highlight.SessionIDAttribute, sessionSecureID),
-	)
-	defer highlight.EndTrace(span)
-
 	for _, row := range logRows {
+		span, _ := highlight.StartTrace(
+			ctx, "highlight-ctx",
+			attribute.String(highlight.SourceAttribute, highlight.SourceAttributeFrontend),
+			attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
+			attribute.String(highlight.SessionIDAttribute, sessionSecureID),
+		)
 		message := strings.Join(row.Value, " ")
 		attrs := []attribute.KeyValue{
 			LogSeverityKey.String(row.Type),
@@ -103,12 +102,21 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 			if cn != 0 {
 				attrs = append(attrs, semconv.CodeColumnKey.Int(cn))
 			}
+			stackTrace := message
+			for _, t := range row.Trace {
+				stackTrace += fmt.Sprintf(`\n\tat %s (%s:%d:%d)`, t.FunctionName, t.FileName, t.LineNumber, t.ColumnNumber)
+				if t.Source != "" {
+					stackTrace += fmt.Sprintf(` [as %s]`, t.Source)
+				}
+			}
+			attrs = append(attrs, semconv.ExceptionStacktraceKey.String(stackTrace))
 		}
 
 		span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(row.Time)))
 		if row.Type == "error" {
 			span.SetStatus(codes.Error, message)
 		}
+		highlight.EndTrace(span)
 	}
 
 	return nil

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -104,9 +104,10 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 			}
 			stackTrace := message
 			for _, t := range row.Trace {
-				stackTrace += fmt.Sprintf(`\n\tat %s (%s:%d:%d)`, t.FunctionName, t.FileName, t.LineNumber, t.ColumnNumber)
 				if t.Source != "" {
-					stackTrace += fmt.Sprintf(` [as %s]`, t.Source)
+					stackTrace += "\n" + t.Source
+				} else {
+					stackTrace += fmt.Sprintf("\n\tat %s (%s:%+v:%+v)", t.FunctionName, t.FileName, t.LineNumber, t.ColumnNumber)
 				}
 			}
 			attrs = append(attrs, semconv.ExceptionStacktraceKey.String(stackTrace))

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -53,6 +53,7 @@ var BackendOnlyAttributePrefixes = []string{
 	"host.",
 	"os.",
 	"process.",
+	"exception.",
 }
 
 type OTLP struct {

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -48,6 +48,13 @@ var InternalAttributes = []string{
 	LogSeverityAttribute,
 }
 
+var BackendOnlyAttributePrefixes = []string{
+	"container.",
+	"host.",
+	"os.",
+	"process.",
+}
+
 type OTLP struct {
 	tracerProvider *sdktrace.TracerProvider
 }


### PR DESCRIPTION
## Summary

OTEL error level logs should create error objects, so that our UI can successfully link logs to errors.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

No
