### PR TITLE
use retryables table in opensearch-update job to reduce DB I/O

### DIFF
--- a/backend/worker/opensearch.go
+++ b/backend/worker/opensearch.go
@@ -59,7 +59,8 @@ func (w *Worker) IndexSessions(ctx context.Context, isUpdate bool) {
 				where r.deleted_at is null
 				and r.type = 'OPENSEARCH_ERROR'
 				and r.payload_type = '%s'
-				and r.payload_id = cast(sessions.id as text)
+				and r.payload_id ~ '^[0-9]+$'
+				and cast(r.payload_id as bigint) = sessions.id
 				and r.created_at <= ?)`, opensearch.GetIndex(opensearch.IndexSessions)), start)
 	}
 
@@ -90,7 +91,8 @@ func (w *Worker) IndexErrorGroups(ctx context.Context, isUpdate bool) {
 				where r.deleted_at is null
 				and r.type = 'OPENSEARCH_ERROR'
 				and r.payload_type = '%s'
-				and r.payload_id = cast(error_groups.id as text)
+				and r.payload_id ~ '^[0-9]+$'
+				and cast(r.payload_id as bigint) = error_groups.id
 				and r.created_at <= ?)`, opensearch.GetIndex(opensearch.IndexErrorsCombined)), start)
 	}
 
@@ -149,7 +151,8 @@ func (w *Worker) IndexErrorObjects(ctx context.Context, isUpdate bool) {
 				where r.deleted_at is null
 				and r.type = 'OPENSEARCH_ERROR'
 				and r.payload_type = '%s'
-				and r.payload_id = concat('child_', cast(error_objects.id as text))
+				and r.payload_id ~ '^child_[0-9]+$'
+				and cast(ltrim(r.payload_id, 'child_') as bigint) = error_objects.id
 				and r.created_at <= ?)`, opensearch.GetIndex(opensearch.IndexErrorsCombined)), start)
 	}
 
@@ -208,7 +211,8 @@ func (w *Worker) IndexTable(ctx context.Context, index opensearch.Index, modelPr
 				where r.deleted_at is null
 				and r.type = 'OPENSEARCH_ERROR'
 				and r.payload_type = '%s'
-				and r.payload_id = cast(%s.id as text)
+				and r.payload_id ~ '^[0-9]+$'
+				and cast(r.payload_id as bigint) = %s.id
 				and r.created_at <= ?)`, opensearch.GetIndex(index), table), start)
 	}
 


### PR DESCRIPTION
## Summary
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->
- instead of querying all updated records for the past 30 mins, use the `retryables` table to get only the records needed to update

## How did you test this change?
- mocked some `retryables` records locally to make sure documents were pushed to opensearch for all data types and the records were marked with `deleted_at` after updating
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, this modifies the existing `update-opensearch` job, and I already created this index 
```CREATE INDEX idx_to_retry ON public.retryables USING btree (type, payload_type, payload_id, created_at) WHERE (deleted_at IS NULL)```
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
