### PR TITLE
fix clickhouse tracing calls to correctly match the query time

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -110,9 +110,8 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 
 	rows, err := client.conn.Query(ctx, sql, args...)
 
-	span.Finish(tracer.WithError(err))
-
 	if err != nil {
+		span.Finish(tracer.WithError(err))
 		return nil, err
 	}
 
@@ -148,6 +147,7 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 	}
 	rows.Close()
 
+	span.Finish(tracer.WithError(rows.Err()))
 	return getLogsConnection(edges, pagination), rows.Err()
 }
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

The span to measure a clickhouse read query is incorrectly returning early. I noticed this when the app is taking a couple seconds to load, yet datadog says the query took a couple milliseconds:

![Screenshot 2023-03-16 at 1 47 18 PM](https://user-images.githubusercontent.com/58678/225736300-20163a8f-1d68-46fe-98e1-4caae29067d4.png)

What's happening is that we're using `rows.Next()` ([source](https://github.com/ClickHouse/clickhouse-go/blob/b3e5d32dcbc36d6abea48a5383cb3f9a6f08adc0/clickhouse_rows.go#L38-L69)) which is a stream. So the original span was measuring a call to clickhouse with the query, but not actually waiting for all the results to load.

This PR waits until after the loop in `rows.Next()` is complete before finishing the span. 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A