### PR TITLE
do less time conversions at query time

### DIFF
--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -174,7 +174,7 @@ func TestReadLogsHistogram(t *testing.T) {
 	nBuckets := 48
 	payload, err := client.ReadLogsHistogram(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: &modelInputs.DateRangeRequiredInput{
-			StartDate: now.Add(-time.Hour * 2),
+			StartDate: now.Add(-time.Hour*2 - time.Second*1),
 			EndDate:   now.Add(-time.Hour * 1),
 		},
 	}, nBuckets)

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -1045,3 +1045,11 @@ func TestExpandJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestToClickhouseTimestamp(t *testing.T) {
+	now := time.Date(
+		2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
+
+	result := toClickhouseTimestamp(now)
+	assert.Equal(t, "2009-11-17 20:34:58.999000000", result)
+}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

While doing some testing of individual production queries, I noticed that running the time conversions using the built-in clickhouse functions can be slower than just comparing against the raw timestamp. 

So basically instead of this:

```sql
    WHERE 
      ProjectId = 3060 
      AND toUInt64(
        toDateTime(Timestamp)
      ) <= 1678970298 
```

we should do this:

```sql
    WHERE 
      ProjectId = 3060 
      AND Timestamp <= '2023-03-16 01:08:40.186000000' 
```


You can see this in this [analysis](https://gist.github.com/et/c048f850ca1632d84e309472604ad0b1).

Two things to look at:
* without clickhouse time functions, we actually using `toUnixTimestamp(Timestamp)` in the primary key
* without clickhouse time functions, the number of granules (and parts which I still don't get) is less which implies that the primary key filtered out more. The number of granules only goes down from 66 -> 64 so I don't think this would be hugely significant perf boost but it should help a little bit.



## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Existing tests should pass.
* Verified through the app that the ordering of logs is in the correct order.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
