### PR TITLE
Ignore error groups by regex

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -319,6 +319,7 @@ type Project struct {
 	WorkspaceID         int
 	FreeTier            bool           `gorm:"default:false"`
 	ExcludedUsers       pq.StringArray `json:"excluded_users" gorm:"type:text[]"`
+	ErrorFilters        pq.StringArray `gorm:"type:text[]"`
 	ErrorJsonPaths      pq.StringArray `gorm:"type:text[]"`
 
 	// During metrics querying for network requests, only keep these relevant URLs

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -599,7 +599,7 @@ type ComplexityRoot struct {
 		DeleteSessionComment             func(childComplexity int, id int) int
 		DeleteSessions                   func(childComplexity int, projectID int, query string, sessionCount int) int
 		EditErrorSegment                 func(childComplexity int, id int, projectID int, params model.ErrorSearchParamsInput, name string) int
-		EditProject                      func(childComplexity int, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray) int
+		EditProject                      func(childComplexity int, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray) int
 		EditSegment                      func(childComplexity int, id int, projectID int, params model.SearchParamsInput, name string) int
 		EditWorkspace                    func(childComplexity int, id int, name *string) int
 		EmailSignup                      func(childComplexity int, email string) int
@@ -673,6 +673,7 @@ type ComplexityRoot struct {
 	Project struct {
 		BackendDomains         func(childComplexity int) int
 		BillingEmail           func(childComplexity int) int
+		ErrorFilters           func(childComplexity int) int
 		ErrorJsonPaths         func(childComplexity int) int
 		ExcludedUsers          func(childComplexity int) int
 		ID                     func(childComplexity int) int
@@ -1181,7 +1182,7 @@ type MutationResolver interface {
 	CreateAdmin(ctx context.Context) (*model1.Admin, error)
 	CreateProject(ctx context.Context, name string, workspaceID int) (*model1.Project, error)
 	CreateWorkspace(ctx context.Context, name string, promoCode *string) (*model1.Workspace, error)
-	EditProject(ctx context.Context, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray) (*model1.Project, error)
+	EditProject(ctx context.Context, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray) (*model1.Project, error)
 	EditWorkspace(ctx context.Context, id int, name *string) (*model1.Workspace, error)
 	MarkErrorGroupAsViewed(ctx context.Context, errorSecureID string, viewed *bool) (*model1.ErrorGroup, error)
 	MarkSessionAsViewed(ctx context.Context, secureID string, viewed *bool) (*model1.Session, error)
@@ -4041,7 +4042,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.EditProject(childComplexity, args["id"].(int), args["name"].(*string), args["billing_email"].(*string), args["excluded_users"].(pq.StringArray), args["error_json_paths"].(pq.StringArray), args["rage_click_window_seconds"].(*int), args["rage_click_radius_pixels"].(*int), args["rage_click_count"].(*int), args["backend_domains"].(pq.StringArray)), true
+		return e.complexity.Mutation.EditProject(childComplexity, args["id"].(int), args["name"].(*string), args["billing_email"].(*string), args["excluded_users"].(pq.StringArray), args["error_filters"].(pq.StringArray), args["error_json_paths"].(pq.StringArray), args["rage_click_window_seconds"].(*int), args["rage_click_radius_pixels"].(*int), args["rage_click_count"].(*int), args["backend_domains"].(pq.StringArray)), true
 
 	case "Mutation.editSegment":
 		if e.complexity.Mutation.EditSegment == nil {
@@ -4617,6 +4618,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Project.BillingEmail(childComplexity), true
+
+	case "Project.error_filters":
+		if e.complexity.Project.ErrorFilters == nil {
+			break
+		}
+
+		return e.complexity.Project.ErrorFilters(childComplexity), true
 
 	case "Project.error_json_paths":
 		if e.complexity.Project.ErrorJsonPaths == nil {
@@ -8083,6 +8091,7 @@ type Project {
 	secret: String
 	workspace_id: ID!
 	excluded_users: StringArray
+	error_filters: StringArray
 	error_json_paths: StringArray
 	rage_click_window_seconds: Int
 	rage_click_radius_pixels: Int
@@ -9277,6 +9286,7 @@ type Mutation {
 		name: String
 		billing_email: String
 		excluded_users: StringArray
+		error_filters: StringArray
 		error_json_paths: StringArray
 		rage_click_window_seconds: Int
 		rage_click_radius_pixels: Int
@@ -10936,50 +10946,59 @@ func (ec *executionContext) field_Mutation_editProject_args(ctx context.Context,
 	}
 	args["excluded_users"] = arg3
 	var arg4 pq.StringArray
-	if tmp, ok := rawArgs["error_json_paths"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_json_paths"))
+	if tmp, ok := rawArgs["error_filters"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_filters"))
 		arg4, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["error_json_paths"] = arg4
-	var arg5 *int
-	if tmp, ok := rawArgs["rage_click_window_seconds"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_window_seconds"))
-		arg5, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+	args["error_filters"] = arg4
+	var arg5 pq.StringArray
+	if tmp, ok := rawArgs["error_json_paths"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_json_paths"))
+		arg5, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["rage_click_window_seconds"] = arg5
+	args["error_json_paths"] = arg5
 	var arg6 *int
-	if tmp, ok := rawArgs["rage_click_radius_pixels"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_radius_pixels"))
+	if tmp, ok := rawArgs["rage_click_window_seconds"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_window_seconds"))
 		arg6, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["rage_click_radius_pixels"] = arg6
+	args["rage_click_window_seconds"] = arg6
 	var arg7 *int
-	if tmp, ok := rawArgs["rage_click_count"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_count"))
+	if tmp, ok := rawArgs["rage_click_radius_pixels"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_radius_pixels"))
 		arg7, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["rage_click_count"] = arg7
-	var arg8 pq.StringArray
-	if tmp, ok := rawArgs["backend_domains"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("backend_domains"))
-		arg8, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
+	args["rage_click_radius_pixels"] = arg7
+	var arg8 *int
+	if tmp, ok := rawArgs["rage_click_count"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_count"))
+		arg8, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["backend_domains"] = arg8
+	args["rage_click_count"] = arg8
+	var arg9 pq.StringArray
+	if tmp, ok := rawArgs["backend_domains"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("backend_domains"))
+		arg9, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["backend_domains"] = arg9
 	return args, nil
 }
 
@@ -29054,6 +29073,8 @@ func (ec *executionContext) fieldContext_Mutation_updateAdminAndCreateWorkspace(
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -29254,6 +29275,8 @@ func (ec *executionContext) fieldContext_Mutation_createProject(ctx context.Cont
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -29383,7 +29406,7 @@ func (ec *executionContext) _Mutation_editProject(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().EditProject(rctx, fc.Args["id"].(int), fc.Args["name"].(*string), fc.Args["billing_email"].(*string), fc.Args["excluded_users"].(pq.StringArray), fc.Args["error_json_paths"].(pq.StringArray), fc.Args["rage_click_window_seconds"].(*int), fc.Args["rage_click_radius_pixels"].(*int), fc.Args["rage_click_count"].(*int), fc.Args["backend_domains"].(pq.StringArray))
+		return ec.resolvers.Mutation().EditProject(rctx, fc.Args["id"].(int), fc.Args["name"].(*string), fc.Args["billing_email"].(*string), fc.Args["excluded_users"].(pq.StringArray), fc.Args["error_filters"].(pq.StringArray), fc.Args["error_json_paths"].(pq.StringArray), fc.Args["rage_click_window_seconds"].(*int), fc.Args["rage_click_radius_pixels"].(*int), fc.Args["rage_click_count"].(*int), fc.Args["backend_domains"].(pq.StringArray))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -29418,6 +29441,8 @@ func (ec *executionContext) fieldContext_Mutation_editProject(ctx context.Contex
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -34752,6 +34777,47 @@ func (ec *executionContext) fieldContext_Project_excluded_users(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _Project_error_filters(ctx context.Context, field graphql.CollectedField, obj *model1.Project) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Project_error_filters(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ErrorFilters, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(pq.StringArray)
+	fc.Result = res
+	return ec.marshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Project_error_filters(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Project",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type StringArray does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Project_error_json_paths(ctx context.Context, field graphql.CollectedField, obj *model1.Project) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Project_error_json_paths(ctx, field)
 	if err != nil {
@@ -38920,6 +38986,8 @@ func (ec *executionContext) fieldContext_Query_projects(ctx context.Context, fie
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -39795,6 +39863,8 @@ func (ec *executionContext) fieldContext_Query_projectSuggestion(ctx context.Con
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -41078,6 +41148,8 @@ func (ec *executionContext) fieldContext_Query_project(ctx context.Context, fiel
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -51900,6 +51972,8 @@ func (ec *executionContext) fieldContext_Workspace_projects(ctx context.Context,
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -60476,6 +60550,10 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 		case "excluded_users":
 
 			out.Values[i] = ec._Project_excluded_users(ctx, field, obj)
+
+		case "error_filters":
+
+			out.Values[i] = ec._Project_error_filters(ctx, field, obj)
 
 		case "error_json_paths":
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -315,6 +315,7 @@ type Project {
 	secret: String
 	workspace_id: ID!
 	excluded_users: StringArray
+	error_filters: StringArray
 	error_json_paths: StringArray
 	rage_click_window_seconds: Int
 	rage_click_radius_pixels: Int
@@ -1509,6 +1510,7 @@ type Mutation {
 		name: String
 		billing_email: String
 		excluded_users: StringArray
+		error_filters: StringArray
 		error_json_paths: StringArray
 		rage_click_window_seconds: Int
 		rage_click_radius_pixels: Int

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -525,7 +525,7 @@ func (r *mutationResolver) CreateWorkspace(ctx context.Context, name string, pro
 }
 
 // EditProject is the resolver for the editProject field.
-func (r *mutationResolver) EditProject(ctx context.Context, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray) (*model.Project, error) {
+func (r *mutationResolver) EditProject(ctx context.Context, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray) (*model.Project, error) {
 	project, err := r.isAdminInProject(ctx, id)
 	if err != nil {
 		return nil, e.Wrap(err, "error querying project")
@@ -548,6 +548,7 @@ func (r *mutationResolver) EditProject(ctx context.Context, id int, name *string
 		Name:           name,
 		BillingEmail:   billingEmail,
 		ExcludedUsers:  excludedUsers,
+		ErrorFilters:   errorFilters,
 		ErrorJsonPaths: errorJSONPaths,
 		BackendDomains: backendDomains,
 	}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2316,9 +2316,25 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 
 	querySessionSpan.Finish()
 
+	var project model.Project
+	if err := r.DB.Where(&model.Project{Model: model.Model{ID: projectID}}).First(&project).Error; err != nil {
+		return
+	}
+
 	// Filter out empty errors
 	var filteredErrors []*publicModel.BackendErrorObjectInput
 	for _, errorObject := range errorObjects {
+
+		// Filter out by project.ErrorFilters, aka regexp filters
+		matchedRegexp := false
+		for _, errorFilter := range project.ErrorFilters {
+			matchedRegexp, _ = regexp.MatchString(errorFilter, errorObject.Event)
+
+			if matchedRegexp {
+				break
+			}
+		}
+
 		if errorObject.Event == "[{}]" {
 			var objString string
 			objBytes, err := json.Marshal(errorObject)
@@ -2333,7 +2349,7 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 				"session_secure_id": errorObject.SessionSecureID,
 				"error_object":      objString,
 			}).Warn("caught empty error, continuing...")
-		} else {
+		} else if !matchedRegexp {
 			filteredErrors = append(filteredErrors, errorObject)
 		}
 	}
@@ -2861,11 +2877,12 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 				continue
 			}
 
-			matched := false
+			// Filter out by project.ErrorFilters, aka regexp filters
+			matchedRegexp := false
 			for _, errorFilter := range project.ErrorFilters {
-				matched, err = regexp.MatchString(errorFilter, v.Event)
+				matchedRegexp, err = regexp.MatchString(errorFilter, v.Event)
 
-				if matched {
+				if matchedRegexp {
 					return nil
 				}
 			}

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -1274,6 +1274,7 @@ export const EditProjectDocument = gql`
 		$name: String
 		$billing_email: String
 		$excluded_users: StringArray
+		$error_filters: StringArray
 		$error_json_paths: StringArray
 		$rage_click_window_seconds: Int
 		$rage_click_radius_pixels: Int
@@ -1285,6 +1286,7 @@ export const EditProjectDocument = gql`
 			name: $name
 			billing_email: $billing_email
 			excluded_users: $excluded_users
+			error_filters: $error_filters
 			error_json_paths: $error_json_paths
 			rage_click_window_seconds: $rage_click_window_seconds
 			rage_click_radius_pixels: $rage_click_radius_pixels
@@ -1295,6 +1297,7 @@ export const EditProjectDocument = gql`
 			name
 			billing_email
 			excluded_users
+			error_filters
 			error_json_paths
 			rage_click_window_seconds
 			rage_click_radius_pixels
@@ -1325,6 +1328,7 @@ export type EditProjectMutationFn = Apollo.MutationFunction<
  *      name: // value for 'name'
  *      billing_email: // value for 'billing_email'
  *      excluded_users: // value for 'excluded_users'
+ *      error_filters: // value for 'error_filters'
  *      error_json_paths: // value for 'error_json_paths'
  *      rage_click_window_seconds: // value for 'rage_click_window_seconds'
  *      rage_click_radius_pixels: // value for 'rage_click_radius_pixels'
@@ -7375,6 +7379,7 @@ export const GetProjectDocument = gql`
 			verbose_id
 			billing_email
 			excluded_users
+			error_filters
 			error_json_paths
 			rage_click_window_seconds
 			rage_click_radius_pixels

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -238,6 +238,7 @@ export type EditProjectMutationVariables = Types.Exact<{
 	name?: Types.Maybe<Types.Scalars['String']>
 	billing_email?: Types.Maybe<Types.Scalars['String']>
 	excluded_users?: Types.Maybe<Types.Scalars['StringArray']>
+	error_filters?: Types.Maybe<Types.Scalars['StringArray']>
 	error_json_paths?: Types.Maybe<Types.Scalars['StringArray']>
 	rage_click_window_seconds?: Types.Maybe<Types.Scalars['Int']>
 	rage_click_radius_pixels?: Types.Maybe<Types.Scalars['Int']>
@@ -253,6 +254,7 @@ export type EditProjectMutation = { __typename?: 'Mutation' } & {
 			| 'name'
 			| 'billing_email'
 			| 'excluded_users'
+			| 'error_filters'
 			| 'error_json_paths'
 			| 'rage_click_window_seconds'
 			| 'rage_click_radius_pixels'
@@ -2541,6 +2543,7 @@ export type GetProjectQuery = { __typename?: 'Query' } & {
 			| 'verbose_id'
 			| 'billing_email'
 			| 'excluded_users'
+			| 'error_filters'
 			| 'error_json_paths'
 			| 'rage_click_window_seconds'
 			| 'rage_click_radius_pixels'

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1085,6 +1085,7 @@ export type MutationEditErrorSegmentArgs = {
 export type MutationEditProjectArgs = {
 	backend_domains?: InputMaybe<Scalars['StringArray']>
 	billing_email?: InputMaybe<Scalars['String']>
+	error_filters?: InputMaybe<Scalars['StringArray']>
 	error_json_paths?: InputMaybe<Scalars['StringArray']>
 	excluded_users?: InputMaybe<Scalars['StringArray']>
 	id: Scalars['ID']
@@ -1398,6 +1399,7 @@ export type Project = {
 	__typename?: 'Project'
 	backend_domains?: Maybe<Scalars['StringArray']>
 	billing_email?: Maybe<Scalars['String']>
+	error_filters?: Maybe<Scalars['StringArray']>
 	error_json_paths?: Maybe<Scalars['StringArray']>
 	excluded_users?: Maybe<Scalars['StringArray']>
 	id: Scalars['ID']

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -190,6 +190,7 @@ mutation EditProject(
 	$name: String
 	$billing_email: String
 	$excluded_users: StringArray
+	$error_filters: StringArray
 	$error_json_paths: StringArray
 	$rage_click_window_seconds: Int
 	$rage_click_radius_pixels: Int
@@ -201,6 +202,7 @@ mutation EditProject(
 		name: $name
 		billing_email: $billing_email
 		excluded_users: $excluded_users
+		error_filters: $error_filters
 		error_json_paths: $error_json_paths
 		rage_click_window_seconds: $rage_click_window_seconds
 		rage_click_radius_pixels: $rage_click_radius_pixels
@@ -211,6 +213,7 @@ mutation EditProject(
 		name
 		billing_email
 		excluded_users
+		error_filters
 		error_json_paths
 		rage_click_window_seconds
 		rage_click_radius_pixels

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -928,6 +928,7 @@ query GetProject($id: ID!) {
 		verbose_id
 		billing_email
 		excluded_users
+		error_filters
 		error_json_paths
 		rage_click_window_seconds
 		rage_click_radius_pixels

--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.module.scss
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.module.scss
@@ -1,0 +1,11 @@
+.inputAndButtonRow {
+	align-items: center;
+	display: grid;
+	grid-template-columns: 1fr 80px;
+	margin-top: 5px;
+}
+
+.saveButton {
+	margin-left: 15px;
+	width: max-content;
+}

--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
@@ -1,0 +1,99 @@
+import { FieldsBox } from '@components/FieldsBox/FieldsBox'
+import { CircularSpinner, LoadingBar } from '@components/Loading/Loading'
+import Select from '@components/Select/Select'
+import { useEditProjectMutation, useGetProjectQuery } from '@graph/hooks'
+import { namedOperations } from '@graph/operations'
+import { useParams } from '@util/react-router/useParams'
+import { message } from 'antd'
+import clsx from 'clsx'
+import React, { useEffect, useState } from 'react'
+
+import commonStyles from '../../../Common.module.scss'
+import Button from '../../../components/Button/Button/Button'
+import styles from './ErrorFiltersForm.module.scss'
+
+export const ErrorFiltersForm = () => {
+	const { project_id } = useParams<{
+		project_id: string
+	}>()
+	const [errorFilters, setErrorFilters] = useState<string[]>([])
+	const { data, loading } = useGetProjectQuery({
+		variables: {
+			id: project_id!,
+		},
+		skip: !project_id,
+	})
+
+	const [editProject, { loading: editProjectLoading }] =
+		useEditProjectMutation({
+			refetchQueries: [
+				namedOperations.Query.GetProjects,
+				namedOperations.Query.GetProject,
+			],
+		})
+
+	const onSubmit = (e: { preventDefault: () => void }) => {
+		e.preventDefault()
+		if (!project_id) {
+			return
+		}
+		editProject({
+			variables: {
+				id: project_id!,
+				error_filters: errorFilters,
+			},
+		}).then(() => {
+			message.success('Updated error filters!', 5)
+		})
+	}
+
+	useEffect(() => {
+		if (!loading) {
+			setErrorFilters(data?.project?.error_filters || [])
+		}
+	}, [data?.project?.error_filters, loading])
+
+	if (loading) {
+		return <LoadingBar />
+	}
+
+	return (
+		<FieldsBox id="errors">
+			<h3>Error Filters</h3>
+
+			<form onSubmit={onSubmit} key={project_id}>
+				<p>Enter REGEXP patterns to filter out errors.</p>
+				<div className={styles.inputAndButtonRow}>
+					<Select
+						mode="tags"
+						placeholder="TypeError: Failed to fetch"
+						defaultValue={data?.project?.error_filters || undefined}
+						onChange={(paths: string[]) => {
+							setErrorFilters(paths)
+						}}
+					/>
+					<Button
+						trackingId="UpdateErrorFilters"
+						htmlType="submit"
+						type="primary"
+						className={clsx(
+							commonStyles.submitButton,
+							styles.saveButton,
+						)}
+					>
+						{editProjectLoading ? (
+							<CircularSpinner
+								style={{
+									fontSize: 18,
+									color: 'var(--text-primary-inverted)',
+								}}
+							/>
+						) : (
+							'Save'
+						)}
+					</Button>
+				</div>
+			</form>
+		</FieldsBox>
+	)
+}

--- a/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
@@ -1,6 +1,7 @@
 import LeadAlignLayout from '@components/layout/LeadAlignLayout'
 import Tabs from '@components/Tabs/Tabs'
 import { DangerForm } from '@pages/ProjectSettings/DangerForm/DangerForm'
+import { ErrorFiltersForm } from '@pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm'
 import { ErrorSettingsForm } from '@pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm'
 import { ExcludedUsersForm } from '@pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm'
 import { NetworkRecordingForm } from '@pages/ProjectSettings/NetworkRecordingForm/NetworkRecordingForm'
@@ -52,6 +53,7 @@ const ProjectSettings = () => {
 								panelContent: (
 									<>
 										<ErrorSettingsForm />
+										<ErrorFiltersForm />
 										<SourcemapSettings />
 									</>
 								),


### PR DESCRIPTION
## To Do

- [x] Add a postgres project table `error_filter` regex column, which can be nil.
- [x] Add a private-graph operations to get and set the `error_filter` value.
- [x] Update `PublicResolver.ProcessBackendPayloadImpl` to use the `error_filter` to decide if errors should be ignored. Frontend errors go thru a different codepath in `PublicResolver.ProcessPayload`.
- [x] Build the frontend /<project>/settings/errors UI to edit / update the error pattern

## Summary

Addresses issue #4457 

Added `error_filters` to `projects` table and cloned front-end for `error_json_paths`.

Confirmed successful save.


## How did you test this change?

https://user-images.githubusercontent.com/878947/225923680-8fa075d7-b41f-4bcf-a3eb-943d7f3f4870.mp4

The back-end error filtering is harder to test. I added a `panic("test message")` into the front-end error handling code and got it to register against an `error_filter` in the back-end handling code.

## Are there any deployment considerations?

No need to backfill data. Migration should be automatic.