### PR TITLE
enable logs recording by default

### DIFF
--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -32,7 +32,7 @@ class H(object):
         self,
         project_id: str,
         integrations: typing.List[Integration] = None,
-        record_logs: bool = False,
+        record_logs: bool = True,
         otlp_endpoint: str = "",
     ):
         """
@@ -45,7 +45,7 @@ class H(object):
 
         :param project_id: a string that corresponds to the verbose id of your project from app.highlight.io/setup
         :param integrations: a list of Integrations that allow connecting with your framework, like Flask or Django.
-        :param record_logs: set True if you would like python logging to be recorded as part of the session.
+        :param record_logs: defaults to True. set False if you want to disable python logging recording.
         :param otlp_endpoint: set to a custom otlp destination
         :return: a configured H instance
         """

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.4.5"
+version = "0.4.6"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary

To keep SDKs consistent, enable log recording by default in the Python SDK.

## How did you test this change?

Pytests.

## Are there any deployment considerations?

New version released.
