### PR TITLE
limit batch size for opensearch update job

### DIFF
--- a/backend/worker/opensearch.go
+++ b/backend/worker/opensearch.go
@@ -14,7 +14,7 @@ import (
 	"gorm.io/gorm"
 )
 
-const BATCH_SIZE = 200
+const BATCH_SIZE = 2
 
 func (w *Worker) indexItem(ctx context.Context, index opensearch.Index, item interface{}) {
 	val := reflect.ValueOf(item).Elem()


### PR DESCRIPTION
## Summary
<img width="178" alt="Screen Shot 2023-03-20 at 10 12 09 AM" src="https://user-images.githubusercontent.com/86132398/226416402-b2cd2e58-cceb-44b3-8797-5449e50c284f.png">
- some sessions have many associated fields, if more than 2 of these are loaded at the same time, we'll hit the postgres 65535 parameter limit
- longer term, we could have a custom script for this instead, performance won't be great since it's making separate calls for each pair of sessions, but there won't usually be more than a few dozen per 30 minute run of the update-opensearch job
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- made sure `update-opensearch` job still worked locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- nope, will monitor for errors post-deployment
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
