### PR TITLE
add time boundaries to next/prev page requests

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -387,6 +387,7 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 
 		// See https://dba.stackexchange.com/a/206811
 		sb.Where(sb.LessEqualThan("toUInt64(toDateTime(Timestamp))", uint64(timestamp.Unix()))).
+			Where(sb.GreaterEqualThan("toUInt64(toDateTime(Timestamp))", uint64(params.DateRange.StartDate.Unix()))).
 			Where(
 				sb.Or(
 					sb.LessThan("toUInt64(toDateTime(Timestamp))", uint64(timestamp.Unix())),
@@ -407,6 +408,7 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 		}
 
 		sb.Where(sb.GreaterEqualThan("toUInt64(toDateTime(Timestamp))", uint64(timestamp.Unix()))).
+			Where(sb.LessEqualThan("toUInt64(toDateTime(Timestamp))", uint64(params.DateRange.EndDate.Unix()))).
 			Where(
 				sb.Or(
 					sb.GreaterThan("toUInt64(toDateTime(Timestamp))", uint64(timestamp.Unix())),


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

When the logs page first loads, we set a time frame of logs to load (now -> 15 minutes ago). However, when we load the next page of logs, there is no lower boundary (it's last log time stamp -> Infinity). 

### Without a time boundary

```sql
EXPLAIN indexes = 1
SELECT Timestamp
FROM logs
WHERE (ProjectId = 1) AND (Timestamp <= now())
ORDER BY Timestamp ASC
LIMIT 101

Query id: e64b6e14-3f3a-4df3-9d30-eafccb5796fa

┌─explain──────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expression (Projection)                                                                                  │
│   Limit (preliminary LIMIT (without OFFSET))                                                             │
│     Sorting (Sorting for ORDER BY)                                                                       │
│       Expression (Before ORDER BY)                                                                       │
│         Filter (WHERE)                                                                                   │
│           ReadFromMergeTree (default.logs)                                                               │
│           Indexes:                                                                                       │
│             MinMax                                                                                       │
│               Keys:                                                                                      │
│                 Timestamp                                                                                │
│               Condition: and((Timestamp in (-Inf, '1679364672']), (Timestamp in (-Inf, '1679364672']))   │
│               Parts: 202/217                                                                             │
│               Granules: 172506/172521                                                                    │
│             Partition                                                                                    │
│               Keys:                                                                                      │
│                 toDate(Timestamp)                                                                        │
│               Condition: and((toDate(Timestamp) in (-Inf, 19437]), (toDate(Timestamp) in (-Inf, 19437])) │
│               Parts: 202/202                                                                             │
│               Granules: 172506/172506                                                                    │
│             PrimaryKey                                                                                   │
│               Keys:                                                                                      │
│                 ProjectId                                                                                │
│                 toUnixTimestamp(Timestamp)                                                               │
│               Condition: and((ProjectId in [1, 1]), (toUnixTimestamp(Timestamp) in (-Inf, 1679364672]))  │
│               Parts: 156/202                                                                             │
│               Granules: 55646/172506                                                                     │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────
```

See `Granules: 55642/172501` 


### With a time boundary

```sql
EXPLAIN indexes = 1
SELECT
    Timestamp,
    UUID,
    SeverityText,
    Body,
    LogAttributes,
    TraceId,
    SpanId,
    SecureSessionId
FROM logs
WHERE (ProjectId = 1) AND (Timestamp <= now()) AND (Timestamp >= (now() - toIntervalMinute(15)))
ORDER BY
    Timestamp DESC,
    UUID DESC
LIMIT 101

Query id: ee8604ca-8e1e-40a5-a823-00688433cd71

┌─explain────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Expression (Projection)                                                                                                                                                                        │
│   Limit (preliminary LIMIT (without OFFSET))                                                                                                                                                   │
│     Sorting (Sorting for ORDER BY)                                                                                                                                                             │
│       Expression (Before ORDER BY)                                                                                                                                                             │
│         Filter (WHERE)                                                                                                                                                                         │
│           ReadFromMergeTree (default.logs)                                                                                                                                                     │
│           Indexes:                                                                                                                                                                             │
│             MinMax                                                                                                                                                                             │
│               Keys:                                                                                                                                                                            │
│                 Timestamp                                                                                                                                                                      │
│               Condition: and(and((Timestamp in ['1679363958', +Inf)), (Timestamp in (-Inf, '1679364858'])), and((Timestamp in ['1679363958', +Inf)), (Timestamp in (-Inf, '1679364858'])))     │
│               Parts: 12/212                                                                                                                                                                    │
│               Granules: 380/172526                                                                                                                                                             │
│             Partition                                                                                                                                                                          │
│               Keys:                                                                                                                                                                            │
│                 toDate(Timestamp)                                                                                                                                                              │
│               Condition: and(and((toDate(Timestamp) in [19437, +Inf)), (toDate(Timestamp) in (-Inf, 19437])), and((toDate(Timestamp) in [19437, +Inf)), (toDate(Timestamp) in (-Inf, 19437]))) │
│               Parts: 12/12                                                                                                                                                                     │
│               Granules: 380/380                                                                                                                                                                │
│             PrimaryKey                                                                                                                                                                         │
│               Keys:                                                                                                                                                                            │
│                 ProjectId                                                                                                                                                                      │
│                 toUnixTimestamp(Timestamp)                                                                                                                                                     │
│               Condition: and((ProjectId in [1, 1]), and((toUnixTimestamp(Timestamp) in [1679363958, +Inf)), (toUnixTimestamp(Timestamp) in (-Inf, 1679364858])))                               │
│               Parts: 12/12                                                                                                                                                                     │
│               Granules: 27/380                                                                                                                                                                 │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

See `Granules: 27/380`

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
