### PR TITLE
add related logs to session devtools

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -12,10 +12,11 @@ import {
 	useGetErrorInstanceQuery,
 } from '@graph/hooks'
 import { GetErrorGroupQuery, GetErrorObjectQuery } from '@graph/operations'
-import type {
+import {
 	ErrorInstance as ErrorInstanceType,
 	ErrorObject,
 	Maybe,
+	ReservedLogKey,
 } from '@graph/schemas'
 import {
 	Box,
@@ -321,7 +322,7 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 								let offsetStart = 1
 								if (errorObject.session?.secure_id) {
 									queryParams.push({
-										key: 'secure_session_id',
+										key: ReservedLogKey.SecureSessionId,
 										operator: DEFAULT_LOGS_OPERATOR,
 										value: errorObject.session?.secure_id,
 										offsetStart: offsetStart++,
@@ -329,7 +330,7 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 								}
 								if (errorObject.trace_id) {
 									queryParams.push({
-										key: 'trace_id',
+										key: ReservedLogKey.TraceId,
 										operator: DEFAULT_LOGS_OPERATOR,
 										value: errorObject.trace_id,
 										offsetStart: offsetStart++,

--- a/frontend/src/pages/LogsPage/SearchForm/utils.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.ts
@@ -101,11 +101,8 @@ export const getLogsURLForSession = (projectId: string, session: Session) => {
 
 	const sessionStartDate = new Date(session.created_at)
 
-	// Instead of doing `new Date()` (equivalent to the time now), we set an arbitrary end date of one day after the session was created.
-	// We have found that Clickhouse doesn't perform well with long time ranges (see https://github.com/highlight/highlight/pull/4652)
-	// Rarely will a session last longer than a day. If users need to handle this case, we should figure out a way for the backend to optimize
-	// long time ranges.
-	const sessionEndDate = moment(sessionStartDate).add(1, 'day').toDate()
+	// Four hours is the max length of a session (see https://github.com/highlight/highlight/pull/4653#discussion_r1145569643)
+	const sessionEndDate = moment(sessionStartDate).add(4, 'hours').toDate()
 
 	const encodedQuery = encodeQueryParams(
 		{

--- a/frontend/src/pages/LogsPage/SearchForm/utils.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.ts
@@ -1,7 +1,7 @@
-import { Session } from "@graph/schemas"
-import moment from "moment";
-import { stringify } from 'query-string';
-import { DateTimeParam, encodeQueryParams, StringParam } from "use-query-params"
+import { Session } from '@graph/schemas'
+import moment from 'moment'
+import { stringify } from 'query-string'
+import { DateTimeParam, encodeQueryParams, StringParam } from 'use-query-params'
 
 export type LogsSearchParam = {
 	key: string
@@ -103,8 +103,16 @@ export const getLogsURLForSession = (projectId: string, session: Session) => {
 	const sessionEndDate = moment(sessionStartDate).add(1, 'day').toDate()
 
 	const encodedQuery = encodeQueryParams(
-		{ query: StringParam, start_date: DateTimeParam, end_date: DateTimeParam },
-		{ query: stringifyLogsQuery(queryParams), start_date: sessionStartDate, end_date: sessionEndDate}
-	);
+		{
+			query: StringParam,
+			start_date: DateTimeParam,
+			end_date: DateTimeParam,
+		},
+		{
+			query: stringifyLogsQuery(queryParams),
+			start_date: sessionStartDate,
+			end_date: sessionEndDate,
+		},
+	)
 	return `/${projectId}/logs?${stringify(encodedQuery)}`
 }

--- a/frontend/src/pages/LogsPage/SearchForm/utils.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.ts
@@ -1,4 +1,5 @@
 import { ReservedLogKey, Session } from '@graph/schemas'
+import moment from 'moment'
 import { stringify } from 'query-string'
 import { DateTimeParam, encodeQueryParams, StringParam } from 'use-query-params'
 
@@ -99,7 +100,12 @@ export const getLogsURLForSession = (projectId: string, session: Session) => {
 	})
 
 	const sessionStartDate = new Date(session.created_at)
-	const sessionEndDate = new Date()
+
+	// Instead of doing `new Date()` (equivalent to the time now), we set an arbitrary end date of one day after the session was created.
+	// We have found that Clickhouse doesn't perform well long time ranges (see https://github.com/highlight/highlight/pull/4652)
+	// Rarely will a session last longer than a day. If users need to handle this case, we should figure out a way for the backend to optimize
+	// long time ranges.
+	const sessionEndDate = moment(sessionStartDate).add(1, 'day').toDate()
 
 	const encodedQuery = encodeQueryParams(
 		{

--- a/frontend/src/pages/LogsPage/SearchForm/utils.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.ts
@@ -102,7 +102,7 @@ export const getLogsURLForSession = (projectId: string, session: Session) => {
 	const sessionStartDate = new Date(session.created_at)
 
 	// Instead of doing `new Date()` (equivalent to the time now), we set an arbitrary end date of one day after the session was created.
-	// We have found that Clickhouse doesn't perform well long time ranges (see https://github.com/highlight/highlight/pull/4652)
+	// We have found that Clickhouse doesn't perform well with long time ranges (see https://github.com/highlight/highlight/pull/4652)
 	// Rarely will a session last longer than a day. If users need to handle this case, we should figure out a way for the backend to optimize
 	// long time ranges.
 	const sessionEndDate = moment(sessionStartDate).add(1, 'day').toDate()

--- a/frontend/src/pages/LogsPage/SearchForm/utils.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.ts
@@ -1,4 +1,4 @@
-import { Session } from '@graph/schemas'
+import { ReservedLogKey, Session } from '@graph/schemas'
 import moment from 'moment'
 import { stringify } from 'query-string'
 import { DateTimeParam, encodeQueryParams, StringParam } from 'use-query-params'
@@ -93,7 +93,7 @@ export const validateLogsQuery = (params: LogsSearchParam[]): boolean => {
 export const getLogsURLForSession = (projectId: string, session: Session) => {
 	const queryParams: LogsSearchParam[] = []
 	queryParams.push({
-		key: 'secure_session_id',
+		key: ReservedLogKey.SecureSessionId,
 		operator: DEFAULT_LOGS_OPERATOR,
 		value: session.secure_id,
 		offsetStart: 0,

--- a/frontend/src/pages/LogsPage/SearchForm/utils.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.ts
@@ -1,5 +1,4 @@
 import { ReservedLogKey, Session } from '@graph/schemas'
-import moment from 'moment'
 import { stringify } from 'query-string'
 import { DateTimeParam, encodeQueryParams, StringParam } from 'use-query-params'
 
@@ -100,7 +99,7 @@ export const getLogsURLForSession = (projectId: string, session: Session) => {
 	})
 
 	const sessionStartDate = new Date(session.created_at)
-	const sessionEndDate = moment(sessionStartDate).add(1, 'day').toDate()
+	const sessionEndDate = new Date()
 
 	const encodedQuery = encodeQueryParams(
 		{

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -4,11 +4,14 @@ import {
 	Form,
 	IconSolidSearch,
 	IconSolidSwitchHorizontal,
+	IconSolidViewList,
 	MenuButton,
 	Tabs,
 	useFormState,
 } from '@highlight-run/ui'
+import { useProjectId } from '@hooks/useProjectId'
 import { useWindowSize } from '@hooks/useWindowSize'
+import { getLogsURLForSession } from '@pages/LogsPage/SearchForm/utils'
 import { usePlayerUIContext } from '@pages/Player/context/PlayerUIContext'
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import { useReplayerContext } from '@pages/Player/ReplayerContext'
@@ -28,6 +31,7 @@ import { ICountPerRequestType } from '@pages/Player/Toolbar/DevToolsWindowV2/uti
 import useLocalStorage from '@rehooks/local-storage'
 import clsx from 'clsx'
 import React, { useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import { styledVerticalScrollbar } from 'style/common.css'
 
 import { ConsolePage } from './ConsolePage/ConsolePage'
@@ -39,8 +43,9 @@ const DevToolsWindowV2: React.FC<
 		width: number
 	}
 > = (props) => {
+	const { projectId } = useProjectId()
 	const { isPlayerFullscreen } = usePlayerUIContext()
-	const { time } = useReplayerContext()
+	const { time, session } = useReplayerContext()
 	const { selectedDevToolsTab, setSelectedDevToolsTab } =
 		usePlayerConfiguration()
 	const [requestType, setRequestType] = React.useState<RequestType>(
@@ -90,7 +95,6 @@ const DevToolsWindowV2: React.FC<
 		})
 
 		return count
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [parsedResources])
 
 	if (!showDevTools || isPlayerFullscreen) {
@@ -258,6 +262,32 @@ const DevToolsWindowV2: React.FC<
 												)
 											}}
 										/>
+									) : null}
+
+									{selectedDevToolsTab === Tab.Console &&
+									session ? (
+										<Link
+											to={getLogsURLForSession(
+												projectId,
+												session,
+											)}
+											style={{ display: 'flex' }}
+										>
+											<Button
+												size="xSmall"
+												kind="secondary"
+												trackingId="relatedLogs"
+												cssClass={styles.autoScroll}
+												iconLeft={
+													<IconSolidViewList
+														width={12}
+														height={12}
+													/>
+												}
+											>
+												Related logs
+											</Button>
+										</Link>
 									) : null}
 
 									<Button


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

[Figma](https://www.figma.com/file/rdBPNzn7Klk6RG1LHUCE5B/Screen-Designs?node-id=40-3089&t=lrQbbI0AVltkH5CZ-0)

This adds a Related logs button to the session's devtools when the Console tab is selected.

<img width="859" alt="Screenshot 2023-03-20 at 9 47 24 PM" src="https://user-images.githubusercontent.com/58678/226513162-ce4e6c15-7777-4bb1-adcc-cbc61b095c9c.png">

Clicking on it loads the logs page when the secure session id filled in with a time range of (session.created_at + 1 day) to capture all the logs while also optimizing the clickhouse query. Setting a range is required so we don't use the default state of "Last 15 minutes". 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Verified that clicking Related logs loads the logs page correctly with the secure session id in the filter box.

![Kapture 2023-03-20 at 21 51 26](https://user-images.githubusercontent.com/58678/226513611-edb661bb-f9a5-4caf-968b-c42e584ae239.gif)



## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->


N/A