### PR TITLE
add ability to flush nodejs sdk

### DIFF
--- a/sdk/highlight-apollo/package.json
+++ b/sdk/highlight-apollo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/apollo",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-nest/package.json
+++ b/sdk/highlight-nest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/nest",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "Client for interfacing with Highlight in nestjs",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "2.2.2",
+	"version": "2.2.3",
 	"description": "Client for interfacing with Highlight in next.js",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-node/CHANGELOG.md
+++ b/sdk/highlight-node/CHANGELOG.md
@@ -35,3 +35,9 @@
 ### Minor Changes
 
 -   Exposes internal `log` function for writing logs to highlight.
+
+## 2.5.2
+
+### Minor Changes
+
+-   Ensures `flush` method will send opentelemetry spans to highlight.

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -22,11 +22,11 @@
 		"access": "public"
 	},
 	"dependencies": {
-		"@opentelemetry/api": "1.3.0",
-		"@opentelemetry/auto-instrumentations-node": "^0.32.1",
-		"@opentelemetry/exporter-trace-otlp-http": "^0.32.0",
-		"@opentelemetry/sdk-node": "^0.32.0",
-		"@opentelemetry/sdk-trace-base": "^1.9.1",
+		"@opentelemetry/api": ">=1.0.0 <1.3.0",
+		"@opentelemetry/auto-instrumentations-node": "0.32.1",
+		"@opentelemetry/exporter-trace-otlp-http": "0.32.0",
+		"@opentelemetry/sdk-node": "0.32.0",
+		"@opentelemetry/sdk-trace-base": "1.6.0",
 		"error-stack-parser": "2.0.7",
 		"graphql": "^16.6.0",
 		"graphql-request": "3.7.0",

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -8,7 +8,6 @@ import {
 import { GraphQLClient } from 'graphql-request'
 import { NodeOptions } from './types.js'
 import log from './log'
-import * as opentelemetry from '@opentelemetry/sdk-node'
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http'
 import { trace, Tracer } from '@opentelemetry/api'
@@ -17,6 +16,7 @@ import {
 	BatchSpanProcessor,
 	SpanProcessor,
 } from '@opentelemetry/sdk-trace-base'
+import { NodeSDK } from '@opentelemetry/sdk-node'
 
 const OTLP_HTTP = 'https://otel.highlight.io:4318'
 
@@ -30,7 +30,7 @@ export class Highlight {
 	lastBackendSetupEvent: number = 0
 	_projectID: string
 	_debug: boolean
-	private otel: opentelemetry.NodeSDK
+	private otel: NodeSDK
 	private tracer: Tracer
 	private processor: SpanProcessor
 
@@ -55,7 +55,7 @@ export class Highlight {
 		})
 
 		this.processor = new BatchSpanProcessor(exporter, {})
-		this.otel = new opentelemetry.NodeSDK({
+		this.otel = new NodeSDK({
 			autoDetectResources: true,
 			defaultAttributes: { 'highlight.project_id': this._projectID },
 			spanProcessor: this.processor,

--- a/sdk/highlight-node/src/handlers.ts
+++ b/sdk/highlight-node/src/handlers.ts
@@ -52,7 +52,7 @@ export function errorHandler(
 	next: (error: MiddlewareError) => void,
 ) => void {
 	H._debug('setting up error handler')
-	return async (
+	return (
 		error: MiddlewareError,
 		req: http.IncomingMessage,
 		res: http.ServerResponse,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10421,11 +10421,11 @@ __metadata:
     "@graphql-codegen/typescript": 2.8.1
     "@graphql-codegen/typescript-graphql-request": 4.5.2
     "@graphql-codegen/typescript-operations": 2.5.2
-    "@opentelemetry/api": 1.3.0
-    "@opentelemetry/auto-instrumentations-node": ^0.32.1
-    "@opentelemetry/exporter-trace-otlp-http": ^0.32.0
-    "@opentelemetry/sdk-node": ^0.32.0
-    "@opentelemetry/sdk-trace-base": ^1.9.1
+    "@opentelemetry/api": ">=1.0.0 <1.3.0"
+    "@opentelemetry/auto-instrumentations-node": 0.32.1
+    "@opentelemetry/exporter-trace-otlp-http": 0.32.0
+    "@opentelemetry/sdk-node": 0.32.0
+    "@opentelemetry/sdk-trace-base": 1.6.0
     "@types/jest": ^29.2.0
     "@types/lru-cache": ^7.10.10
     "@types/node": 17.0.13
@@ -12804,10 +12804,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@opentelemetry/api@npm:1.3.0"
-  checksum: 33d284b67b6fab20ff72961d289c6487d3cb27caf7489f0231d7030551f82871e081e744b0390751d8aef3bf1614bd79f854788901a354e15274f552581fb374
+"@opentelemetry/api@npm:>=1.0.0 <1.3.0":
+  version: 1.2.0
+  resolution: "@opentelemetry/api@npm:1.2.0"
+  checksum: 764efa81bf939200a8e80520a4735b23038abafc60c80420b007ae2bbb7ad843d806894414e95d974c2ef1b81d4ae8a3106804e1af7b5090240cfeb2467db099
   languageName: node
   linkType: hard
 
@@ -12818,7 +12818,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/auto-instrumentations-node@npm:^0.32.1":
+"@opentelemetry/auto-instrumentations-node@npm:0.32.1":
   version: 0.32.1
   resolution: "@opentelemetry/auto-instrumentations-node@npm:0.32.1"
   dependencies:
@@ -12901,7 +12901,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/exporter-trace-otlp-http@npm:^0.32.0":
+"@opentelemetry/exporter-trace-otlp-http@npm:0.32.0":
   version: 0.32.0
   resolution: "@opentelemetry/exporter-trace-otlp-http@npm:0.32.0"
   dependencies:
@@ -13473,7 +13473,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-node@npm:^0.32.0":
+"@opentelemetry/sdk-node@npm:0.32.0":
   version: 0.32.0
   resolution: "@opentelemetry/sdk-node@npm:0.32.0"
   dependencies:


### PR DESCRIPTION
## Summary

* Make the expressjs error middleware synchronous to ensure other middleware runs serially.
* Adds a way to force flushing opentelemetry trace data from the nodejs sdk.

## How did you test this change?

Usage of local SDK - https://github.com/Learn-Build-Teach/learn-build-teach-discord-bot/tree/add-highlight

## Are there any deployment considerations?

New versions of SDK released.
