### PR TITLE
attach a time frame when fetching log keys

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -264,16 +264,25 @@ func (client *Client) ReadLogsHistogram(ctx context.Context, projectID int, para
 	return histogram, err
 }
 
-func (client *Client) LogsKeys(ctx context.Context, projectID int) ([]*modelInputs.LogKey, error) {
+func (client *Client) LogsKeys(ctx context.Context, projectID int, startDate time.Time, endDate time.Time) ([]*modelInputs.LogKey, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select("arrayJoin(LogAttributes.keys) as key, count() as cnt").
 		From("logs").
 		Where(sb.Equal("ProjectId", projectID)).
 		GroupBy("key").
 		OrderBy("cnt DESC").
-		Limit(50)
+		Where(sb.LessEqualThan("toUInt64(toDateTime(Timestamp))", uint64(endDate.Unix()))).
+		Where(sb.GreaterEqualThan("toUInt64(toDateTime(Timestamp))", uint64(startDate.Unix())))
 
 	sql, args := sb.Build()
+
+	span, _ := tracer.StartSpanFromContext(ctx, "logs", tracer.ResourceName("LogsKeys"))
+	query, err := sqlbuilder.ClickHouse.Interpolate(sql, args)
+	if err != nil {
+		span.Finish(tracer.WithError(err))
+		return nil, err
+	}
+	span.SetTag("Query", query)
 
 	rows, err := client.conn.Query(ctx, sql, args...)
 
@@ -305,6 +314,8 @@ func (client *Client) LogsKeys(ctx context.Context, projectID int) ([]*modelInpu
 	}
 
 	rows.Close()
+
+	span.Finish(tracer.WithError(rows.Err()))
 	return keys, rows.Err()
 
 }

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -843,26 +843,35 @@ func TestLogsKeys(t *testing.T) {
 	client, teardown := setupTest(t)
 	defer teardown(t)
 
+	now := time.Now()
+
 	rows := []*LogRow{
 		{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: time.Now(),
+				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"user_id": "1", "workspace_id": "2"},
 		},
 		{
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: time.Now(),
+				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"workspace_id": "3"},
+		},
+		{
+			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
+				Timestamp: now.Add(-time.Second * 1), // out of range, should not be included
+				ProjectId: 1,
+			},
+			LogAttributes: map[string]string{"workspace_id": "5"},
 		},
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
 
-	keys, err := client.LogsKeys(ctx, 1)
+	keys, err := client.LogsKeys(ctx, 1, now, now)
 	assert.NoError(t, err)
 
 	expected := []*modelInputs.LogKey{

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -752,7 +752,7 @@ type ComplexityRoot struct {
 		Logs                         func(childComplexity int, projectID int, params model.LogsParamsInput, after *string, before *string, at *string) int
 		LogsHistogram                func(childComplexity int, projectID int, params model.LogsParamsInput) int
 		LogsKeyValues                func(childComplexity int, projectID int, keyName string, dateRange model.DateRangeRequiredInput) int
-		LogsKeys                     func(childComplexity int, projectID int) int
+		LogsKeys                     func(childComplexity int, projectID int, dateRange model.DateRangeRequiredInput) int
 		LogsTotalCount               func(childComplexity int, projectID int, params model.LogsParamsInput) int
 		Messages                     func(childComplexity int, sessionSecureID string) int
 		MetricMonitors               func(childComplexity int, projectID int, metricName *string) int
@@ -1369,7 +1369,7 @@ type QueryResolver interface {
 	Logs(ctx context.Context, projectID int, params model.LogsParamsInput, after *string, before *string, at *string) (*model.LogsConnection, error)
 	LogsTotalCount(ctx context.Context, projectID int, params model.LogsParamsInput) (uint64, error)
 	LogsHistogram(ctx context.Context, projectID int, params model.LogsParamsInput) (*model.LogsHistogram, error)
-	LogsKeys(ctx context.Context, projectID int) ([]*model.LogKey, error)
+	LogsKeys(ctx context.Context, projectID int, dateRange model.DateRangeRequiredInput) ([]*model.LogKey, error)
 	LogsKeyValues(ctx context.Context, projectID int, keyName string, dateRange model.DateRangeRequiredInput) ([]string, error)
 }
 type SegmentResolver interface {
@@ -5470,7 +5470,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.LogsKeys(childComplexity, args["project_id"].(int)), true
+		return e.complexity.Query.LogsKeys(childComplexity, args["project_id"].(int), args["date_range"].(model.DateRangeRequiredInput)), true
 
 	case "Query.logs_total_count":
 		if e.complexity.Query.LogsTotalCount == nil {
@@ -9256,7 +9256,7 @@ type Query {
 	): LogsConnection!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_histogram(project_id: ID!, params: LogsParamsInput!): LogsHistogram!
-	logs_keys(project_id: ID!): [LogKey!]!
+	logs_keys(project_id: ID!, date_range: DateRangeRequiredInput!): [LogKey!]!
 	logs_key_values(
 		project_id: ID!
 		key_name: String!
@@ -13599,6 +13599,15 @@ func (ec *executionContext) field_Query_logs_keys_args(ctx context.Context, rawA
 		}
 	}
 	args["project_id"] = arg0
+	var arg1 model.DateRangeRequiredInput
+	if tmp, ok := rawArgs["date_range"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("date_range"))
+		arg1, err = ec.unmarshalNDateRangeRequiredInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐDateRangeRequiredInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["date_range"] = arg1
 	return args, nil
 }
 
@@ -42964,7 +42973,7 @@ func (ec *executionContext) _Query_logs_keys(ctx context.Context, field graphql.
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().LogsKeys(rctx, fc.Args["project_id"].(int))
+		return ec.resolvers.Query().LogsKeys(rctx, fc.Args["project_id"].(int), fc.Args["date_range"].(model.DateRangeRequiredInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1488,7 +1488,7 @@ type Query {
 	): LogsConnection!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_histogram(project_id: ID!, params: LogsParamsInput!): LogsHistogram!
-	logs_keys(project_id: ID!): [LogKey!]!
+	logs_keys(project_id: ID!, date_range: DateRangeRequiredInput!): [LogKey!]!
 	logs_key_values(
 		project_id: ID!
 		key_name: String!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7037,13 +7037,13 @@ func (r *queryResolver) LogsHistogram(ctx context.Context, projectID int, params
 }
 
 // LogsKeys is the resolver for the logs_keys field.
-func (r *queryResolver) LogsKeys(ctx context.Context, projectID int) ([]*modelInputs.LogKey, error) {
+func (r *queryResolver) LogsKeys(ctx context.Context, projectID int, dateRange modelInputs.DateRangeRequiredInput) ([]*modelInputs.LogKey, error) {
 	project, err := r.isAdminInProject(ctx, projectID)
 	if err != nil {
 		return nil, e.Wrap(err, "error querying project")
 	}
 
-	return r.ClickhouseClient.LogsKeys(ctx, project.ID)
+	return r.ClickhouseClient.LogsKeys(ctx, project.ID, dateRange.StartDate, dateRange.EndDate)
 }
 
 // LogsKeyValues is the resolver for the logs_key_values field.

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -11762,8 +11762,8 @@ export type GetLogsHistogramQueryResult = Apollo.QueryResult<
 	Types.GetLogsHistogramQueryVariables
 >
 export const GetLogsKeysDocument = gql`
-	query GetLogsKeys($project_id: ID!) {
-		logs_keys(project_id: $project_id) {
+	query GetLogsKeys($project_id: ID!, $date_range: DateRangeRequiredInput!) {
+		logs_keys(project_id: $project_id, date_range: $date_range) {
 			name
 			type
 		}
@@ -11783,6 +11783,7 @@ export const GetLogsKeysDocument = gql`
  * const { data, loading, error } = useGetLogsKeysQuery({
  *   variables: {
  *      project_id: // value for 'project_id'
+ *      date_range: // value for 'date_range'
  *   },
  * });
  */

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4035,6 +4035,7 @@ export type GetLogsHistogramQuery = { __typename?: 'Query' } & {
 
 export type GetLogsKeysQueryVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
+	date_range: Types.DateRangeRequiredInput
 }>
 
 export type GetLogsKeysQuery = { __typename?: 'Query' } & {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1829,6 +1829,7 @@ export type QueryLogs_Key_ValuesArgs = {
 }
 
 export type QueryLogs_KeysArgs = {
+	date_range: DateRangeRequiredInput
 	project_id: Scalars['ID']
 }
 

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1924,8 +1924,8 @@ query GetLogsHistogram($project_id: ID!, $params: LogsParamsInput!) {
 	}
 }
 
-query GetLogsKeys($project_id: ID!) {
-	logs_keys(project_id: $project_id) {
+query GetLogsKeys($project_id: ID!, $date_range: DateRangeRequiredInput!) {
+	logs_keys(project_id: $project_id, date_range: $date_range) {
 		name
 		type
 	}

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -61,6 +61,10 @@ const SearchForm = ({
 	const { data: keysData } = useGetLogsKeysQuery({
 		variables: {
 			project_id: projectId,
+			date_range: {
+				start_date: moment(startDate).format(FORMAT),
+				end_date: moment(endDate).format(FORMAT),
+			},
 		},
 	})
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Fetching log key queries is slow because we don't specify a time range (see #4652 and #4507). 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Added unit test
* Verified log keys still loads via the frontend

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

A more robust solution would be #4662 but we'll look into that after our launch.