### PR TITLE
fix error to log url linking

### DIFF
--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -7743,6 +7743,7 @@ export const GetErrorObjectForLogDocument = gql`
 		error_object_for_log(log_cursor: $log_cursor) {
 			id
 			error_group_secure_id
+			project_id
 		}
 	}
 `

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2705,7 +2705,7 @@ export type GetErrorObjectForLogQuery = { __typename?: 'Query' } & {
 	error_object_for_log?: Types.Maybe<
 		{ __typename?: 'ErrorObject' } & Pick<
 			Types.ErrorObject,
-			'id' | 'error_group_secure_id'
+			'id' | 'error_group_secure_id' | 'project_id'
 		>
 	>
 }

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1048,6 +1048,7 @@ query GetErrorObjectForLog($log_cursor: String!) {
 	error_object_for_log(log_cursor: $log_cursor) {
 		id
 		error_group_secure_id
+		project_id
 	}
 }
 

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -337,13 +337,12 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 								}
 								const query = stringifyLogsQuery(queryParams)
 								const logCursor = errorObject.log_cursor
-								const errorTs = moment(errorObject.timestamp)
 								const params = createSearchParams({
 									query,
-									start_date: errorTs
+									start_date: moment(errorObject.timestamp)
 										.add(-5, 'minutes')
 										.toISOString(),
-									end_date: errorTs
+									end_date: moment(errorObject.timestamp)
 										.add(5, 'minutes')
 										.toISOString(),
 								})

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -53,7 +53,7 @@ import { buildQueryURLString } from '@util/url/params'
 import moment from 'moment'
 import React, { useEffect, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { useNavigate } from 'react-router-dom'
+import { createSearchParams, useNavigate } from 'react-router-dom'
 
 const MAX_USER_PROPERTIES = 4
 type Props = React.PropsWithChildren & {
@@ -319,14 +319,6 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 
 								const queryParams: LogsSearchParam[] = []
 								let offsetStart = 1
-								if (errorObject.source) {
-									queryParams.push({
-										key: 'host.name',
-										operator: DEFAULT_LOGS_OPERATOR,
-										value: errorObject.source,
-										offsetStart: offsetStart++,
-									})
-								}
 								if (errorObject.session?.secure_id) {
 									queryParams.push({
 										key: 'secure_session_id',
@@ -345,14 +337,23 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 								}
 								const query = stringifyLogsQuery(queryParams)
 								const logCursor = errorObject.log_cursor
+								const errorTs = moment(errorObject.timestamp)
+								const params = createSearchParams({
+									query,
+									start_date: errorTs
+										.add(-5, 'minutes')
+										.toISOString(),
+									end_date: errorTs
+										.add(5, 'minutes')
+										.toISOString(),
+								})
 								if (logCursor) {
 									navigate(
-										`/${projectId}/logs/${logCursor}?query=${query}`,
+										`/${projectId}/logs/${logCursor}?${params}`,
+										{},
 									)
 								} else {
-									navigate(
-										`/${projectId}/logs?query=${query}`,
-									)
+									navigate(`/${projectId}/logs?${params}`)
 								}
 							}}
 							iconLeft={<IconSolidViewList />}

--- a/frontend/src/pages/ErrorsV2/ErrorLogCursor/ErrorLogCursorRedirect.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorLogCursor/ErrorLogCursorRedirect.tsx
@@ -31,7 +31,7 @@ const ErrorLogCursorRedirect: React.FC = () => {
 		return (
 			<Navigate
 				replace
-				to={`/errors/${data.error_object_for_log.error_group_secure_id}/instances/${data.error_object_for_log.id}`}
+				to={`/${data.error_object_for_log.project_id}/errors/${data.error_object_for_log.error_group_secure_id}/instances/${data.error_object_for_log.id}`}
 			></Navigate>
 		)
 	}


### PR DESCRIPTION
## Summary

Adjusts how the logs query is built on the errors page for finding related logs.
Uses a +- 5 minutes time window for related logs.
Ensures the link has a project in it in case the user belongs to more than one project. 
This also fixes loading glitchiness on the logs -> errors link.

## How did you test this change?

https://www.loom.com/share/e97679360aaf4794967b6b03b6516fff

preview: https://frontend-pr-4665.onrender.com/sign_in

## Are there any deployment considerations?

No