### PR TITLE
switch timestamp precision on logs table

### DIFF
--- a/backend/clickhouse/cursor_test.go
+++ b/backend/clickhouse/cursor_test.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -178,7 +179,8 @@ func TestClickhouseDecode(t *testing.T) {
 	assert.NoError(t, err)
 
 	defer func() {
-		client.conn.Exec(ctx, "TRUNCATE TABLE logs") //nolint:errcheck
+		err := client.conn.Exec(ctx, fmt.Sprintf("TRUNCATE TABLE %s", LogsTable))
+		assert.NoError(t, err)
 	}()
 
 	now := time.Now()

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -16,11 +16,13 @@ import (
 	e "github.com/pkg/errors"
 )
 
+const LogsTable = "logs_new"
+
 func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) error {
 	if len(logRows) == 0 {
 		return nil
 	}
-	batch, err := client.conn.PrepareBatch(ctx, "INSERT INTO logs")
+	batch, err := client.conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", LogsTable))
 
 	if err != nil {
 		return e.Wrap(err, "failed to create logs batch")
@@ -192,7 +194,7 @@ func (client *Client) ReadLogsHistogram(ctx context.Context, projectID int, para
 
 	sb.
 		Select("bucketId, level, count()").
-		From(sb.BuilderAs(fromSb, "logs")).
+		From(sb.BuilderAs(fromSb, LogsTable)).
 		GroupBy("bucketId, level").
 		OrderBy("bucketId, level")
 
@@ -267,7 +269,7 @@ func (client *Client) ReadLogsHistogram(ctx context.Context, projectID int, para
 func (client *Client) LogsKeys(ctx context.Context, projectID int) ([]*modelInputs.LogKey, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select("arrayJoin(LogAttributes.keys) as key, count() as cnt").
-		From("logs").
+		From(LogsTable).
 		Where(sb.Equal("ProjectId", projectID)).
 		GroupBy("key").
 		OrderBy("cnt DESC").
@@ -315,31 +317,31 @@ func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName 
 	switch keyName {
 	case modelInputs.ReservedLogKeyLevel.String():
 		sb.Select("DISTINCT SeverityText level").
-			From("logs").
+			From(LogsTable).
 			Where(sb.Equal("ProjectId", projectID)).
 			Where(sb.NotEqual("level", "")).
 			Limit(KeyValuesLimit)
 	case modelInputs.ReservedLogKeySecureSessionID.String():
 		sb.Select("DISTINCT SecureSessionId secure_session_id").
-			From("logs").
+			From(LogsTable).
 			Where(sb.Equal("ProjectId", projectID)).
 			Where(sb.NotEqual("secure_session_id", "")).
 			Limit(KeyValuesLimit)
 	case modelInputs.ReservedLogKeySpanID.String():
 		sb.Select("DISTINCT SpanId span_id").
-			From("logs").
+			From(LogsTable).
 			Where(sb.Equal("ProjectId", projectID)).
 			Where(sb.NotEqual("span_id", "")).
 			Limit(KeyValuesLimit)
 	case modelInputs.ReservedLogKeyTraceID.String():
 		sb.Select("DISTINCT TraceId trace_id").
-			From("logs").
+			From(LogsTable).
 			Where(sb.Equal("ProjectId", projectID)).
 			Where(sb.NotEqual("trace_id", "")).
 			Limit(KeyValuesLimit)
 	default:
 		sb.Select("DISTINCT LogAttributes [" + sb.Var(keyName) + "] as value").
-			From("logs").
+			From(LogsTable).
 			Where(sb.Equal("ProjectId", projectID)).
 			Where("mapContains(LogAttributes, " + sb.Var(keyName) + ")").
 			Limit(KeyValuesLimit)
@@ -376,7 +378,7 @@ func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName 
 func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsParamsInput, pagination Pagination) (*sqlbuilder.SelectBuilder, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select(selectStr).
-		From("logs").
+		From(LogsTable).
 		Where(sb.Equal("ProjectId", projectID))
 
 	if pagination.After != nil && len(*pagination.After) > 1 {

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -43,8 +43,8 @@ func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) 
 const LogsLimit int = 100
 const KeyValuesLimit int = 50
 
-const OrderBackward = "toUnixTimestamp(Timestamp) ASC, UUID ASC"
-const OrderForward = "toUnixTimestamp(Timestamp) DESC, UUID DESC"
+const OrderBackward = "Timestamp ASC, UUID ASC"
+const OrderForward = "Timestamp DESC, UUID DESC"
 
 type Pagination struct {
 	After     *string

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -28,7 +28,8 @@ func setupTest(tb testing.TB) (*Client, func(tb testing.TB)) {
 	client, _ := NewClient(TestDatabase)
 
 	return client, func(tb testing.TB) {
-		client.conn.Exec(context.Background(), "TRUNCATE TABLE logs") //nolint:errcheck
+		err := client.conn.Exec(context.Background(), fmt.Sprintf("TRUNCATE TABLE %s", LogsTable))
+		assert.NoError(tb, err)
 	}
 }
 

--- a/backend/clickhouse/migrations/000006_create_logs_new.down.sql
+++ b/backend/clickhouse/migrations/000006_create_logs_new.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS logs_new

--- a/backend/clickhouse/migrations/000006_create_logs_new.up.sql
+++ b/backend/clickhouse/migrations/000006_create_logs_new.up.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS logs_new
+(
+    Timestamp          DateTime,
+    UUID               UUID,
+    TraceId            String,
+    SpanId             String,
+    TraceFlags         UInt32,
+    SeverityText       LowCardinality(String),
+    SeverityNumber     Int32,
+    ServiceName        LowCardinality(String),
+    Body               String,
+    LogAttributes      Map(LowCardinality(String), String),
+    ProjectId          UInt32,
+    SecureSessionId    String,
+    INDEX idx_trace_id          TraceId TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_secure_session_id SecureSessionId TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_log_attr_key      mapKeys(LogAttributes) TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_log_attr_value    mapValues(LogAttributes) TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_body              Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
+)
+    ENGINE = MergeTree
+        PARTITION BY toDate(Timestamp)
+        ORDER BY (ProjectId, Timestamp, UUID)
+        TTL Timestamp + toIntervalDay(30)
+        SETTINGS ttl_only_drop_parts = 1;


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Our existing schema is hitting memory errors. From doing some analysis, it appears that using an `ORDER BY` (which we always do to sort logs in time descending order) isn't working very well with a DateTime64.

The original reasoning for using this precision was borrowed from the OTEL schema. But in reality, this nanosecond precision is overkill and using a `DateTime` (second precision) is adequate.

This PR creates a new table (`logs_new` but we can rename this later to `logs`) that has a simpler schema, namely:

* Timestamp changed from DateTime64 -> DateTime
* Removed all the codec stuff
* Removed `toUnixTimestamp` in the order by
* Removed `index_granularity` setting (we were using 8092 which is the default, if we remove it, clickhouse can adjust it with adaptive granularity if it makes sense).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

The `logs_new` table already exists on prod and I ~backfilled~ am currently backfilling it per the [docs](https://clickhouse.com/docs/en/optimize/sparse-primary-indexes#option-1-secondary-tables):

```sql
INSERT INTO logs_new
SELECT * from logs;
OPTIMIZE TABLE logs_new FINAL;
```

So all this PR is doing is adjusting the application code to read/write to this new table.

To validate this actually is an improvement, I validated that the new table does not hit memory errors:

### Old table
```sql
select * from logs where ProjectId = 1 and Timestamp >= (now() - toIntervalDay(30)) order by Timestamp DESC LIMIT 50
```

```
"Code: 241. DB::Exception: Memory limit (for user) exceeded: would use 8.00 GiB (attempt to allocate chunk of 4434098 bytes), maximum: 8.00 GiB. OvercommitTracker decision: Query was selected to stop by OvercommitTracker.: Cache info: Buffer path: ch-s3-faf28823-b036-4ef3-b703-750dad5ee0b9/mergetree/yga/qhwalotmlwzbleeyyrlienvykaxpy, hash key: a4c87d31cb1ecdb47bc88ff5cd84fd12, file_offset_of_buffer_end: 430543, internal buffer remaining read range: [430587:430586], read_type: REMOTE_FS_READ_AND_PUT_IN_CACHE, last caller: ef1cdf5e-fba0-470c-a27b-e2b3fa435d20:471, file segment info: None: (while reading column TraceFlags): (while reading from part /var/lib/clickhouse/disks/s3disk/store/48e/48e1599a-61fc-4783-91d0-cea46ab2400f/20230306_94087_95989_1467/ from mark 0 with max_rows_to_read = 3512): While executing MergeTreeReverse. (MEMORY_LIMIT_EXCEEDED) (version 22.13.1.24479 (official build))\n"
````

### New table
```sql
select * from logs_new where ProjectId = 1 and Timestamp >= (now() - toIntervalDay(30)) order by Timestamp DESC LIMIT 50
```
=> Elapsed: 2.987s
Read: 295,314 rows (520.34 MB)

## Backfill status

The backfill is still running and we should wait to merge this PR until it's finished but I feel pretty confident that we have a large enough dataset to confirm this is a good improvement over our existing schema:

```
SELECT table,
    formatReadableSize(sum(bytes)) as size,
    sum(rows) AS rows
    FROM system.parts
    WHERE active
GROUP BY table
ORDER BY sum(bytes) DESC;

┌─table───────────────────┬─size───────┬───────rows─┐
│ logs                    │ 118.96 GiB │  817517218 │
│ logs_new                │ 88.38 GiB  │  727621060 │
│ text_log                │ 9.06 GiB   │  431185840 │
│ asynchronous_metric_log │ 2.25 GiB   │ 1863160108 │
│ query_log               │ 1.87 GiB   │   31081263 │
│ trace_log               │ 806.83 MiB │   60932792 │
│ metric_log              │ 457.13 MiB │    2612428 │
│ part_log                │ 185.13 MiB │   10039748 │
│ session_log             │ 2.77 MiB   │     146872 │
│ schema_migrations       │ 422.00 B   │         16 │
└─────────────────────────┴────────────┴────────────┘
```

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

* The migration intentionally uses `IF NOT EXISTS` because the table exists on prod already.
* After this is merged, we should run the backfill one more time (it's idempotent) to get the latest records since the previous backfill was run. 
* If we're happy with the new schema, we should
  * truncate the old logs table (right now, we have 2x storage)
  * create a new PR that drops the old table and renames `logs_new` -> `logs`