### PR TITLE
ensure logs only link valid errors

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -750,6 +750,7 @@ type ComplexityRoot struct {
 		LinearTeams                  func(childComplexity int, projectID int) int
 		LiveUsersCount               func(childComplexity int, projectID int) int
 		Logs                         func(childComplexity int, projectID int, params model.LogsParamsInput, after *string, before *string, at *string) int
+		LogsErrorObjects             func(childComplexity int, logCursors []string) int
 		LogsHistogram                func(childComplexity int, projectID int, params model.LogsParamsInput) int
 		LogsKeyValues                func(childComplexity int, projectID int, keyName string, dateRange model.DateRangeRequiredInput) int
 		LogsKeys                     func(childComplexity int, projectID int) int
@@ -1371,6 +1372,7 @@ type QueryResolver interface {
 	LogsHistogram(ctx context.Context, projectID int, params model.LogsParamsInput) (*model.LogsHistogram, error)
 	LogsKeys(ctx context.Context, projectID int) ([]*model.LogKey, error)
 	LogsKeyValues(ctx context.Context, projectID int, keyName string, dateRange model.DateRangeRequiredInput) ([]string, error)
+	LogsErrorObjects(ctx context.Context, logCursors []string) ([]*model1.ErrorObject, error)
 }
 type SegmentResolver interface {
 	Params(ctx context.Context, obj *model1.Segment) (*model1.SearchParams, error)
@@ -5436,6 +5438,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Logs(childComplexity, args["project_id"].(int), args["params"].(model.LogsParamsInput), args["after"].(*string), args["before"].(*string), args["at"].(*string)), true
 
+	case "Query.logs_error_objects":
+		if e.complexity.Query.LogsErrorObjects == nil {
+			break
+		}
+
+		args, err := ec.field_Query_logs_error_objects_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.LogsErrorObjects(childComplexity, args["log_cursors"].([]string)), true
+
 	case "Query.logs_histogram":
 		if e.complexity.Query.LogsHistogram == nil {
 			break
@@ -9262,6 +9276,7 @@ type Query {
 		key_name: String!
 		date_range: DateRangeRequiredInput!
 	): [String!]!
+	logs_error_objects(log_cursors: [String!]!): [ErrorObject!]!
 }
 
 type Mutation {
@@ -13527,6 +13542,21 @@ func (ec *executionContext) field_Query_logs_args(ctx context.Context, rawArgs m
 		}
 	}
 	args["at"] = arg4
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_logs_error_objects_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []string
+	if tmp, ok := rawArgs["log_cursors"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("log_cursors"))
+		arg0, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["log_cursors"] = arg0
 	return args, nil
 }
 
@@ -43064,6 +43094,110 @@ func (ec *executionContext) fieldContext_Query_logs_key_values(ctx context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_logs_error_objects(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_logs_error_objects(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().LogsErrorObjects(rctx, fc.Args["log_cursors"].([]string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model1.ErrorObject)
+	fc.Result = res
+	return ec.marshalNErrorObject2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐErrorObjectᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_logs_error_objects(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ErrorObject_id(ctx, field)
+			case "created_at":
+				return ec.fieldContext_ErrorObject_created_at(ctx, field)
+			case "project_id":
+				return ec.fieldContext_ErrorObject_project_id(ctx, field)
+			case "session_id":
+				return ec.fieldContext_ErrorObject_session_id(ctx, field)
+			case "trace_id":
+				return ec.fieldContext_ErrorObject_trace_id(ctx, field)
+			case "span_id":
+				return ec.fieldContext_ErrorObject_span_id(ctx, field)
+			case "log_cursor":
+				return ec.fieldContext_ErrorObject_log_cursor(ctx, field)
+			case "error_group_id":
+				return ec.fieldContext_ErrorObject_error_group_id(ctx, field)
+			case "error_group_secure_id":
+				return ec.fieldContext_ErrorObject_error_group_secure_id(ctx, field)
+			case "event":
+				return ec.fieldContext_ErrorObject_event(ctx, field)
+			case "type":
+				return ec.fieldContext_ErrorObject_type(ctx, field)
+			case "url":
+				return ec.fieldContext_ErrorObject_url(ctx, field)
+			case "source":
+				return ec.fieldContext_ErrorObject_source(ctx, field)
+			case "lineNumber":
+				return ec.fieldContext_ErrorObject_lineNumber(ctx, field)
+			case "columnNumber":
+				return ec.fieldContext_ErrorObject_columnNumber(ctx, field)
+			case "stack_trace":
+				return ec.fieldContext_ErrorObject_stack_trace(ctx, field)
+			case "structured_stack_trace":
+				return ec.fieldContext_ErrorObject_structured_stack_trace(ctx, field)
+			case "timestamp":
+				return ec.fieldContext_ErrorObject_timestamp(ctx, field)
+			case "payload":
+				return ec.fieldContext_ErrorObject_payload(ctx, field)
+			case "request_id":
+				return ec.fieldContext_ErrorObject_request_id(ctx, field)
+			case "os":
+				return ec.fieldContext_ErrorObject_os(ctx, field)
+			case "browser":
+				return ec.fieldContext_ErrorObject_browser(ctx, field)
+			case "environment":
+				return ec.fieldContext_ErrorObject_environment(ctx, field)
+			case "session":
+				return ec.fieldContext_ErrorObject_session(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ErrorObject", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_logs_error_objects_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query___type(ctx, field)
 	if err != nil {
@@ -62986,6 +63120,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
+		case "logs_error_objects":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_logs_error_objects(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
 		case "__type":
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
@@ -66905,6 +67059,60 @@ func (ec *executionContext) marshalNErrorObject2ᚕgithubᚗcomᚋhighlightᚑru
 	wg.Wait()
 
 	return ret
+}
+
+func (ec *executionContext) marshalNErrorObject2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐErrorObjectᚄ(ctx context.Context, sel ast.SelectionSet, v []*model1.ErrorObject) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNErrorObject2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐErrorObject(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNErrorObject2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐErrorObject(ctx context.Context, sel ast.SelectionSet, v *model1.ErrorObject) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ErrorObject(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNErrorResults2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐErrorResults(ctx context.Context, sel ast.SelectionSet, v model1.ErrorResults) graphql.Marshaler {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1494,6 +1494,7 @@ type Query {
 		key_name: String!
 		date_range: DateRangeRequiredInput!
 	): [String!]!
+	logs_error_objects(log_cursors: [String!]!): [ErrorObject!]!
 }
 
 type Mutation {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7056,6 +7056,15 @@ func (r *queryResolver) LogsKeyValues(ctx context.Context, projectID int, keyNam
 	return r.ClickhouseClient.LogsKeyValues(ctx, project.ID, keyName, dateRange.StartDate, dateRange.EndDate)
 }
 
+// LogsErrorObjects is the resolver for the logs_error_objects field.
+func (r *queryResolver) LogsErrorObjects(ctx context.Context, logCursors []string) ([]*model.ErrorObject, error) {
+	var errorObjects []*model.ErrorObject
+	if err := r.DB.Model(&model.ErrorObject{}).Where("log_cursor IN ?", logCursors).Scan(&errorObjects).Error; err != nil {
+		return nil, e.Wrap(err, "failed to find errors for log cursors")
+	}
+	return errorObjects, nil
+}
+
 // Params is the resolver for the params field.
 func (r *segmentResolver) Params(ctx context.Context, obj *model.Segment) (*model.SearchParams, error) {
 	params := &model.SearchParams{}

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -11881,3 +11881,61 @@ export type GetLogsKeyValuesQueryResult = Apollo.QueryResult<
 	Types.GetLogsKeyValuesQuery,
 	Types.GetLogsKeyValuesQueryVariables
 >
+export const GetLogsErrorObjectsDocument = gql`
+	query GetLogsErrorObjects($log_cursors: [String!]!) {
+		logs_error_objects(log_cursors: $log_cursors) {
+			log_cursor
+			error_group_secure_id
+			id
+		}
+	}
+`
+
+/**
+ * __useGetLogsErrorObjectsQuery__
+ *
+ * To run a query within a React component, call `useGetLogsErrorObjectsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetLogsErrorObjectsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetLogsErrorObjectsQuery({
+ *   variables: {
+ *      log_cursors: // value for 'log_cursors'
+ *   },
+ * });
+ */
+export function useGetLogsErrorObjectsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogsErrorObjectsQuery,
+		Types.GetLogsErrorObjectsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetLogsErrorObjectsQuery,
+		Types.GetLogsErrorObjectsQueryVariables
+	>(GetLogsErrorObjectsDocument, baseOptions)
+}
+export function useGetLogsErrorObjectsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogsErrorObjectsQuery,
+		Types.GetLogsErrorObjectsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetLogsErrorObjectsQuery,
+		Types.GetLogsErrorObjectsQueryVariables
+	>(GetLogsErrorObjectsDocument, baseOptions)
+}
+export type GetLogsErrorObjectsQueryHookResult = ReturnType<
+	typeof useGetLogsErrorObjectsQuery
+>
+export type GetLogsErrorObjectsLazyQueryHookResult = ReturnType<
+	typeof useGetLogsErrorObjectsLazyQuery
+>
+export type GetLogsErrorObjectsQueryResult = Apollo.QueryResult<
+	Types.GetLogsErrorObjectsQuery,
+	Types.GetLogsErrorObjectsQueryVariables
+>

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4054,6 +4054,19 @@ export type GetLogsKeyValuesQuery = { __typename?: 'Query' } & Pick<
 	'logs_key_values'
 >
 
+export type GetLogsErrorObjectsQueryVariables = Types.Exact<{
+	log_cursors: Array<Types.Scalars['String']> | Types.Scalars['String']
+}>
+
+export type GetLogsErrorObjectsQuery = { __typename?: 'Query' } & {
+	logs_error_objects: Array<
+		{ __typename?: 'ErrorObject' } & Pick<
+			Types.ErrorObject,
+			'log_cursor' | 'error_group_secure_id' | 'id'
+		>
+	>
+}
+
 export const namedOperations = {
 	Query: {
 		GetMetricsTimeline: 'GetMetricsTimeline' as const,
@@ -4174,6 +4187,7 @@ export const namedOperations = {
 		GetLogsHistogram: 'GetLogsHistogram' as const,
 		GetLogsKeys: 'GetLogsKeys' as const,
 		GetLogsKeyValues: 'GetLogsKeyValues' as const,
+		GetLogsErrorObjects: 'GetLogsErrorObjects' as const,
 	},
 	Mutation: {
 		MarkErrorGroupAsViewed: 'MarkErrorGroupAsViewed' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1476,6 +1476,7 @@ export type Query = {
 	linear_teams?: Maybe<Array<LinearTeam>>
 	liveUsersCount?: Maybe<Scalars['Int64']>
 	logs: LogsConnection
+	logs_error_objects: Array<ErrorObject>
 	logs_histogram: LogsHistogram
 	logs_key_values: Array<Scalars['String']>
 	logs_keys: Array<LogKey>
@@ -1815,6 +1816,10 @@ export type QueryLogsArgs = {
 	before?: InputMaybe<Scalars['String']>
 	params: LogsParamsInput
 	project_id: Scalars['ID']
+}
+
+export type QueryLogs_Error_ObjectsArgs = {
+	log_cursors: Array<Scalars['String']>
 }
 
 export type QueryLogs_HistogramArgs = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1943,3 +1943,11 @@ query GetLogsKeyValues(
 		date_range: $date_range
 	)
 }
+
+query GetLogsErrorObjects($log_cursors: [String!]!) {
+	logs_error_objects(log_cursors: $log_cursors) {
+		log_cursor
+		error_group_secure_id
+		id
+	}
+}

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -1,4 +1,4 @@
-import { LogEdge, LogLevel } from '@graph/schemas'
+import { LogEdge } from '@graph/schemas'
 import {
 	Box,
 	ButtonLink,
@@ -24,6 +24,7 @@ import {
 	LogsSearchParam,
 	stringifyLogsQuery,
 } from '@pages/LogsPage/SearchForm/utils'
+import { LogEdgeWithError } from '@pages/LogsPage/useGetLogs'
 import { Row } from '@tanstack/react-table'
 import { message as antdMessage } from 'antd'
 import React, { useEffect, useState } from 'react'
@@ -34,7 +35,7 @@ import { useQueryParam } from 'use-query-params'
 import * as styles from './LogDetails.css'
 
 type Props = {
-	row: Row<LogEdge>
+	row: Row<LogEdgeWithError>
 	queryTerms: LogsSearchParam[]
 }
 
@@ -222,14 +223,16 @@ export const LogDetails = ({ row, queryTerms }: Props) => {
 					flexDirection="row"
 					gap="16"
 				>
-					{row.original.node.level === LogLevel.Error && (
+					{row.original.error_object && (
 						<Tag
 							shape="basic"
 							kind="secondary"
 							emphasis="medium"
 							onClick={(e) => {
 								e.stopPropagation()
-								navigate(`/errors/logs/${row.original.cursor}`)
+								navigate(
+									`/errors/${row.original.error_object?.error_group_secure_id}/instances/${row.original.error_object?.id}`,
+								)
 							}}
 						>
 							<Box

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -14,6 +14,7 @@ import { LogMessage } from '@pages/LogsPage/LogsTable/LogMessage'
 import { LogTimestamp } from '@pages/LogsPage/LogsTable/LogTimestamp'
 import { NoLogsFound } from '@pages/LogsPage/LogsTable/NoLogsFound'
 import { parseLogsQuery } from '@pages/LogsPage/SearchForm/utils'
+import { LogEdgeWithError } from '@pages/LogsPage/useGetLogs'
 import {
 	ColumnDef,
 	ExpandedState,
@@ -31,7 +32,7 @@ import * as styles from './LogsTable.css'
 type Props = {
 	loading: boolean
 	loadingAfter: boolean
-	logEdges: LogEdge[]
+	logEdges: LogEdgeWithError[]
 	query: string
 	tableContainerRef: React.RefObject<HTMLDivElement>
 	selectedCursor: string | undefined


### PR DESCRIPTION
## Summary

Currently linking error log lines via the related error button does not always load an error. there are a few causes:
* the log line is stored but the error object is never created for that line because we have some static filtering rules to drop noisy errors
* the backlog in the logs and primary kafka queues may be different, so a log might be processed before an error is processed.

the crux of the problem is that logs and errors are processed independently after flowing thru different kafka queues, so their processing is entirely independent. meanwhile, on the logging frontend, we always show the related errors button for error logs because we don't have a way to know in advance whether the error log actually has a related error

This change ensures that the `Related Errors` button is only shown when the error log has recorded an error object.
This also simplifies the frontend to remove the need for a redirect step, allowing the logs to link directly to the error object.

Adds a new graphql operation `logs_error_objects` that searches for error objects for a given set of log cursors.

## How did you test this change?

https://www.loom.com/share/7c1bad1a2d4c461b8d640d2733c2f4aa

## Are there any deployment considerations?

No
