### PR TITLE
stop autocreating monitors in UpsertDashboard

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3166,9 +3166,6 @@ func (r *mutationResolver) UpsertDashboard(ctx context.Context, id *int, project
 		if err := r.DB.Model(&dashboard).Association("Metrics").Append(&dashboardMetric); err != nil {
 			return -1, e.Wrap(err, "error updating fields")
 		}
-		if err := r.AutoCreateMetricMonitor(ctx, &dashboardMetric); err != nil {
-			log.WithContext(ctx).Errorf("failed to auto create metric monitor: %s", err)
-		}
 	}
 
 	// Update the existing record if it already exists


### PR DESCRIPTION
## Summary
- autocreated monitors are a bit overwhelming when visiting the alerts page for the first time
- charts function correctly with 0 related monitors
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally by creating new project + visiting dashboard
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
