### PR TITLE
add related sessions button

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.css.ts
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.css.ts
@@ -1,3 +1,4 @@
+import { vars } from '@highlight-run/ui/src'
 import { style } from '@vanilla-extract/css'
 
 export const line = style({
@@ -31,6 +32,22 @@ export const attributeAction = style({
 	selectors: {
 		'&:hover': {
 			opacity: 1,
+		},
+	},
+})
+
+export const buttonLink = style({
+	background: 'transparent',
+	border: 0,
+	cursor: 'pointer',
+	padding: 0,
+	color: vars.theme.interactive.fill.secondary.content.text,
+	selectors: {
+		'&:hover': {
+			color: vars.theme.interactive.fill.secondary.content.onEnabled,
+		},
+		'&:active': {
+			color: vars.theme.interactive.fill.secondary.content.onEnabled,
 		},
 	},
 })

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -30,7 +30,7 @@ import { Row } from '@tanstack/react-table'
 import { message as antdMessage } from 'antd'
 import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
-import { generatePath } from 'react-router-dom'
+import { generatePath, Link } from 'react-router-dom'
 import { useQueryParam } from 'use-query-params'
 
 import * as styles from './LogDetails.css'
@@ -219,7 +219,7 @@ export const LogDetails = ({ row, queryTerms }: Props) => {
 						</Box>
 					</ButtonLink>
 
-					{row.original.node.secureSessionID?.length ||
+					{row.original.node.secureSessionID ||
 					row.original.error_object ? (
 						<Box
 							border="divider"
@@ -227,15 +227,10 @@ export const LogDetails = ({ row, queryTerms }: Props) => {
 						/>
 					) : null}
 
-					{row.original.node.secureSessionID?.length ? (
-						<ButtonLink
-							kind="secondary"
-							onClick={(e) => {
-								e.stopPropagation()
-								navigate(
-									`/${projectId}/sessions/${row.original.node.secureSessionID}`,
-								)
-							}}
+					{row.original.node.secureSessionID ? (
+						<Link
+							className={styles.buttonLink}
+							to={`/${projectId}/sessions/${row.original.node.secureSessionID}`}
 						>
 							<Box
 								display="flex"
@@ -246,17 +241,12 @@ export const LogDetails = ({ row, queryTerms }: Props) => {
 								<IconSolidPlayCircle />
 								Related Session
 							</Box>
-						</ButtonLink>
+						</Link>
 					) : null}
 					{row.original.error_object && (
-						<ButtonLink
-							kind="secondary"
-							onClick={(e) => {
-								e.stopPropagation()
-								navigate(
-									`/${projectId}/errors/${row.original.error_object?.error_group_secure_id}/instances/${row.original.error_object?.id}`,
-								)
-							}}
+						<Link
+							className={styles.buttonLink}
+							to={`/${projectId}/errors/${row.original.error_object?.error_group_secure_id}/instances/${row.original.error_object?.id}`}
 						>
 							<Box
 								display="flex"
@@ -267,7 +257,7 @@ export const LogDetails = ({ row, queryTerms }: Props) => {
 								<IconSolidLightningBolt />
 								Related Error
 							</Box>
-						</ButtonLink>
+						</Link>
 					)}
 				</Box>
 			</Box>

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -9,11 +9,12 @@ import {
 	IconSolidFilter,
 	IconSolidLightningBolt,
 	IconSolidLink,
+	IconSolidPlayCircle,
 	Stack,
-	Tag,
 	Text,
 	Tooltip,
 } from '@highlight-run/ui'
+import { useProjectId } from '@hooks/useProjectId'
 import { QueryParam } from '@pages/LogsPage/LogsPage'
 import {
 	IconCollapsed,
@@ -48,6 +49,7 @@ export const getLogURL = (row: Row<LogEdge>) => {
 }
 
 export const LogDetails = ({ row, queryTerms }: Props) => {
+	const { projectId } = useProjectId()
 	const navigate = useNavigate()
 	const [allExpanded, setAllExpanded] = useState(false)
 	const { traceID, spanID, secureSessionID, logAttributes, message, level } =
@@ -139,6 +141,7 @@ export const LogDetails = ({ row, queryTerms }: Props) => {
 				flexDirection="row"
 				gap="16"
 				mt="8"
+				mb="4"
 			>
 				<Box
 					display="flex"
@@ -215,23 +218,43 @@ export const LogDetails = ({ row, queryTerms }: Props) => {
 							Copy link
 						</Box>
 					</ButtonLink>
-				</Box>
 
-				<Box
-					display="flex"
-					alignItems="center"
-					flexDirection="row"
-					gap="16"
-				>
-					{row.original.error_object && (
-						<Tag
-							shape="basic"
+					{row.original.node.secureSessionID?.length ||
+					row.original.error_object ? (
+						<Box
+							border="divider"
+							style={{ width: 1, height: 14 }}
+						/>
+					) : null}
+
+					{row.original.node.secureSessionID?.length ? (
+						<ButtonLink
 							kind="secondary"
-							emphasis="medium"
 							onClick={(e) => {
 								e.stopPropagation()
 								navigate(
-									`/errors/${row.original.error_object?.error_group_secure_id}/instances/${row.original.error_object?.id}`,
+									`/${projectId}/sessions/${row.original.node.secureSessionID}`,
+								)
+							}}
+						>
+							<Box
+								display="flex"
+								alignItems="center"
+								flexDirection="row"
+								gap="4"
+							>
+								<IconSolidPlayCircle />
+								Related Session
+							</Box>
+						</ButtonLink>
+					) : null}
+					{row.original.error_object && (
+						<ButtonLink
+							kind="secondary"
+							onClick={(e) => {
+								e.stopPropagation()
+								navigate(
+									`/${projectId}/errors/${row.original.error_object?.error_group_secure_id}/instances/${row.original.error_object?.id}`,
 								)
 							}}
 						>
@@ -244,7 +267,7 @@ export const LogDetails = ({ row, queryTerms }: Props) => {
 								<IconSolidLightningBolt />
 								Related Error
 							</Box>
-						</Tag>
+						</ButtonLink>
 					)}
 				</Box>
 			</Box>


### PR DESCRIPTION
## Summary

Adds a `Related Session` button for logs that have a session id.
Updates the `Related Error` button design per figma.

## How did you test this change?

<img width="630" alt="Screenshot 2023-03-22 at 6 38 32 PM" src="https://user-images.githubusercontent.com/1351531/227076780-f68da4ba-11ca-404d-aa8e-f4192914a8aa.png">

https://www.loom.com/share/51ef1bcf3b8f412ea3a90fc09f138880

## Are there any deployment considerations?

No
