### PR TITLE
add leading zero to time

### DIFF
--- a/frontend/src/pages/LogsPage/utils.ts
+++ b/frontend/src/pages/LogsPage/utils.ts
@@ -2,7 +2,7 @@ import { FORMAT } from '@pages/LogsPage/constants'
 import moment from 'moment'
 
 export const formatDate = (date: Date) => {
-	return moment(date).format('M/D/YY h:mm:s A')
+	return moment(date).format('M/D/YY h:mm:ss A')
 }
 
 export const isSignificantDateRange = (startDate: Date, endDate: Date) => {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

See this screenshot:
<img width="305" alt="Screenshot 2023-03-22 at 9 36 06 PM" src="https://user-images.githubusercontent.com/58678/227095720-9d5bdaa5-33fd-4093-8151-eb694d6e7b5f.png">

The `:8` for seconds is confusing without a leading zero. It should be `:08`


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Load with this URL: https://localhost:3000/1/logs?end_date=2023-03-23T03%3A32%3A08.738Z&start_date=2023-03-23T03%3A17%3A08.979Z

Confirmed the leading zero for seconds is present.

<img width="371" alt="Screenshot 2023-03-22 at 9 38 21 PM" src="https://user-images.githubusercontent.com/58678/227096003-6e3c8678-832d-41df-9fcb-47e794b8cb07.png">

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A