### PR TITLE
lower log limit

### DIFF
--- a/backend/clickhouse/cursor_test.go
+++ b/backend/clickhouse/cursor_test.go
@@ -59,7 +59,7 @@ func TestGetConnectionAfter(t *testing.T) {
 	})
 
 	assert.Equal(t, &modelInputs.LogsConnection{
-		Edges: manyEdges[:100],
+		Edges: manyEdges[:LogsLimit],
 		PageInfo: &modelInputs.PageInfo{
 			HasNextPage:     true,
 			HasPreviousPage: true,
@@ -117,7 +117,7 @@ func TestGetConnectionBefore(t *testing.T) {
 	})
 
 	assert.Equal(t, &modelInputs.LogsConnection{
-		Edges: manyEdges[1:100],
+		Edges: manyEdges[1:LogsLimit],
 		PageInfo: &modelInputs.PageInfo{
 			HasNextPage:     true,
 			HasPreviousPage: true,

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -40,7 +40,7 @@ func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) 
 	return batch.Send()
 }
 
-const LogsLimit int = 100
+const LogsLimit int = 50
 const KeyValuesLimit int = 50
 
 const OrderBackward = "Timestamp ASC, UUID ASC"

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -282,7 +282,7 @@ func TestReadLogsHasNextPage(t *testing.T) {
 	}, Pagination{})
 	assert.NoError(t, err)
 
-	assert.Len(t, payload.Edges, 100)
+	assert.Len(t, payload.Edges, 50)
 	assert.False(t, payload.PageInfo.HasNextPage)
 
 	// Add more more row to have 101 rows
@@ -444,9 +444,9 @@ func TestReadLogsAtCursor(t *testing.T) {
 
 	rows := []*LogRow{}
 
-	// LogsLimit+3 = 103
+	// LogsLimit+3 = 53
 	// 1 log not visible on the previous page
-	// 101 logs visible (50 before + 50 after + permalinked log)
+	// 51 logs visible (25 before + 25 after + permalinked log)
 	// 1 log not visible on the next page
 	for i := 1; i <= LogsLimit+3; i++ {
 		rows = append(rows, &LogRow{
@@ -465,10 +465,10 @@ func TestReadLogsAtCursor(t *testing.T) {
 	}, Pagination{})
 	assert.NoError(t, err)
 
-	assert.Len(t, originalConnection.Edges, 100)
+	assert.Len(t, originalConnection.Edges, 50)
 
 	// Permalink the log in the middle ensuring there is a previous and next page
-	permalink := originalConnection.Edges[51]
+	permalink := originalConnection.Edges[26]
 	connection, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 	}, Pagination{
@@ -476,14 +476,14 @@ func TestReadLogsAtCursor(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	assert.Len(t, connection.Edges, 101) // 50 before + 50 after + the permalinked log
-	assert.Equal(t, connection.Edges[50], permalink)
+	assert.Len(t, connection.Edges, 51) // 25 before + 25 after + the permalinked log
+	assert.Equal(t, connection.Edges[25], permalink)
 	assert.True(t, connection.PageInfo.HasPreviousPage)
 	assert.True(t, connection.PageInfo.HasNextPage)
 	assertCursorsOutput(t, connection.Edges, permalink.Cursor)
 
 	// Permalink the log before the middle ensuring there is not a previous page but has a next page
-	permalink = originalConnection.Edges[50]
+	permalink = originalConnection.Edges[25]
 	connection, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 	}, Pagination{
@@ -496,7 +496,7 @@ func TestReadLogsAtCursor(t *testing.T) {
 	assertCursorsOutput(t, connection.Edges, permalink.Cursor)
 
 	// Permalink the log after the middle ensuring there is a previous page but no next page
-	permalink = originalConnection.Edges[52]
+	permalink = originalConnection.Edges[27]
 	connection, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
 	}, Pagination{


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR lowers the number of logs loaded from 100 -> 50. There's a couple reasons for this:

* Loading large amounts of data (which we see with `LogAttributes`) can cause clickhouse to slow down significantly (see https://github.com/ClickHouse/ClickHouse/issues/7187)
* If there is very few matching results (e.g. find me logs with a log body of "STRIPE_INTEGRATION_ERROR"), we want to terminate as early as possible
* Loading less data results in a smaller payload size.
* Realistically, only about ~20-25 logs fix on the the screen (dependent on screen size) given our UX. This reason is less important as the previous points but mostly mentioning that this change shouldn't break our UX.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Verified that logs still load and pagination works as expected.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
