### PR TITLE
teardown old logs table

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -16,7 +16,7 @@ import (
 	e "github.com/pkg/errors"
 )
 
-const LogsTable = "logs_new"
+const LogsTable = "logs"
 
 func (client *Client) BatchWriteLogRows(ctx context.Context, logRows []*LogRow) error {
 	if len(logRows) == 0 {

--- a/backend/clickhouse/migrations/000007_drop_logs_old.down.sql
+++ b/backend/clickhouse/migrations/000007_drop_logs_old.down.sql
@@ -1,0 +1,25 @@
+CREATE TABLE logs
+(
+    Timestamp          DateTime64(9) CODEC (Delta, ZSTD(1)),
+    UUID               UUID CODEC (ZSTD(1)),
+    TraceId            String CODEC (ZSTD(1)),
+    SpanId             String CODEC (ZSTD(1)),
+    TraceFlags         UInt32 CODEC (ZSTD(1)),
+    SeverityText       LowCardinality(String) CODEC (ZSTD(1)),
+    SeverityNumber     Int32 CODEC (ZSTD(1)),
+    ServiceName        LowCardinality(String) CODEC (ZSTD(1)),
+    Body               String CODEC (ZSTD(1)),
+    LogAttributes      Map(LowCardinality(String), String) CODEC (ZSTD(1)),
+    ProjectId          UInt32 CODEC (ZSTD(1)),
+    SecureSessionId    String CODEC (ZSTD(1)),
+    INDEX idx_trace_id          TraceId TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_secure_session_id SecureSessionId TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_log_attr_key      mapKeys(LogAttributes) TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_log_attr_value    mapValues(LogAttributes) TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_body              Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
+)
+    ENGINE = MergeTree
+        PARTITION BY toDate(Timestamp)
+        ORDER BY (ProjectId, toUnixTimestamp(Timestamp), UUID)
+        TTL toDateTime(Timestamp) + toIntervalDay(30)
+        SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;

--- a/backend/clickhouse/migrations/000007_drop_logs_old.up.sql
+++ b/backend/clickhouse/migrations/000007_drop_logs_old.up.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS logs

--- a/backend/clickhouse/migrations/000008_rename_logs_table.down.sql
+++ b/backend/clickhouse/migrations/000008_rename_logs_table.down.sql
@@ -1,0 +1,1 @@
+RENAME TABLE logs TO logs_new;

--- a/backend/clickhouse/migrations/000008_rename_logs_table.up.sql
+++ b/backend/clickhouse/migrations/000008_rename_logs_table.up.sql
@@ -1,0 +1,1 @@
+RENAME TABLE logs_new TO logs;


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR tears down the old logs table now that our data has been fully migrated to the new schema (see #4667) and renames the `logs_new` table to `logs`

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Validated `show tables;` only shows a `logs` table
* Validated the data of `logs_new` still exists, just in a table called `logs` now.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

Per the query in #4667, this will free up 125 GB of data
