### PR TITLE
ensure errors created from a log pass structured metadata

### DIFF
--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -72,9 +72,9 @@ func (l *LogRow) Cursor() string {
 
 type LogRowOption func(*LogRow)
 
-func WithLogAttributes(resourceAttributes, eventAttributes map[string]any, isFrontendLog bool) LogRowOption {
+func WithLogAttributes(resourceAttributes, spanAttributes, eventAttributes map[string]any, isFrontendLog bool) LogRowOption {
 	return func(h *LogRow) {
-		h.LogAttributes = getAttributesMap(resourceAttributes, eventAttributes, isFrontendLog)
+		h.LogAttributes = GetAttributesMap(resourceAttributes, spanAttributes, eventAttributes, isFrontendLog)
 	}
 }
 
@@ -115,9 +115,9 @@ func cast[T string | int64 | float64](v interface{}, fallback T) T {
 	return c
 }
 
-func getAttributesMap(resourceAttributes, eventAttributes map[string]any, isFrontendLog bool) map[string]string {
+func GetAttributesMap(resourceAttributes, spanAttributes, eventAttributes map[string]any, isFrontendLog bool) map[string]string {
 	attributesMap := make(map[string]string)
-	for _, m := range []map[string]any{resourceAttributes, eventAttributes} {
+	for _, m := range []map[string]any{resourceAttributes, spanAttributes, eventAttributes} {
 		for k, v := range m {
 			shouldSkip := false
 

--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -8,15 +8,16 @@ import (
 
 func TestNewLogRowWithLogAttributes(t *testing.T) {
 	resourceAttributes := map[string]any{"os.description": "Debian GNU/Linux 11 (bullseye)"}
+	spanAttributes := map[string]any{"highlight.source": "frontend", "foo": "bar"}
 	eventAttributes := map[string]any{"log.severity": "info"} // should be skipped since this is an internal attribute
 
-	logRow := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(resourceAttributes, eventAttributes, false))
+	logRow := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(resourceAttributes, spanAttributes, eventAttributes, false))
 
-	assert.Equal(t, map[string]string{"os.description": "Debian GNU/Linux 11 (bullseye)"}, logRow.LogAttributes)
+	assert.Equal(t, map[string]string{"foo": "bar", "os.description": "Debian GNU/Linux 11 (bullseye)"}, logRow.LogAttributes)
 
-	logRow = NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(resourceAttributes, eventAttributes, true))
+	logRow = NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(resourceAttributes, spanAttributes, eventAttributes, true))
 
-	assert.Equal(t, map[string]string{}, logRow.LogAttributes)
+	assert.Equal(t, map[string]string{"foo": "bar"}, logRow.LogAttributes)
 }
 
 func TestNewLogRowWithSeverityText(t *testing.T) {

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -66,7 +66,7 @@ func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestI
 	}
 }
 
-func getLogRow(ts time.Time, lvl, projectID, sessionID, traceID, spanID string, excMessage string, resourceAttributes, eventAttributes map[string]any, source string) *clickhouse.LogRow {
+func getLogRow(ts time.Time, lvl, projectID, sessionID, traceID, spanID string, excMessage string, resourceAttributes, spanAttributes, eventAttributes map[string]any, source string) *clickhouse.LogRow {
 	return clickhouse.NewLogRow(
 		clickhouse.LogRowPrimaryAttrs{
 			Timestamp:       ts,
@@ -77,12 +77,12 @@ func getLogRow(ts time.Time, lvl, projectID, sessionID, traceID, spanID string, 
 		clickhouse.WithBody(excMessage),
 		clickhouse.WithProjectIDString(projectID),
 		clickhouse.WithServiceName(cast(resourceAttributes[string(semconv.ServiceNameKey)], "")),
-		clickhouse.WithLogAttributes(resourceAttributes, eventAttributes, source == highlight.SourceAttributeFrontend),
+		clickhouse.WithLogAttributes(resourceAttributes, spanAttributes, eventAttributes, source == highlight.SourceAttributeFrontend),
 		clickhouse.WithSeverityText(lvl),
 	)
 }
 
-func getBackendError(ctx context.Context, ts time.Time, projectID, sessionID, requestID, traceID, spanID string, logCursor *string, source, excMessage, tag string, resourceAttributes, eventAttributes map[string]any) (bool, *model.BackendErrorObjectInput) {
+func getBackendError(ctx context.Context, ts time.Time, projectID, sessionID, requestID, traceID, spanID string, logCursor *string, source, excMessage string, resourceAttributes, spanAttributes, eventAttributes map[string]any) (bool, *model.BackendErrorObjectInput) {
 	excType := cast(eventAttributes[string(semconv.ExceptionTypeKey)], source)
 	errorUrl := cast(eventAttributes[highlight.ErrorURLAttribute], source)
 	stackTrace := cast(eventAttributes[string(semconv.ExceptionStacktraceKey)], "")
@@ -94,6 +94,7 @@ func getBackendError(ctx context.Context, ts time.Time, projectID, sessionID, re
 		stackTrace = ""
 	}
 	stackTrace = formatStructureStackTrace(ctx, stackTrace)
+	payloadBytes, _ := json.Marshal(clickhouse.GetAttributesMap(resourceAttributes, spanAttributes, eventAttributes, false))
 	err := &model.BackendErrorObjectInput{
 		SessionSecureID: &sessionID,
 		RequestID:       &requestID,
@@ -105,7 +106,7 @@ func getBackendError(ctx context.Context, ts time.Time, projectID, sessionID, re
 		Source:          cast(resourceAttributes[string(semconv.HostNameKey)], ""),
 		StackTrace:      stackTrace,
 		Timestamp:       ts,
-		Payload:         pointy.String(tag),
+		Payload:         pointy.String(string(payloadBytes)),
 		URL:             errorUrl,
 	}
 	if sessionID != "" {
@@ -165,11 +166,6 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 			for k := 0; k < spans.Len(); k++ {
 				span := spans.At(k)
 				spanAttributes := span.Attributes().AsRaw()
-				tagsBytes, err := json.Marshal(spanAttributes)
-				if err != nil {
-					log.WithContext(ctx).Errorf("failed to format error attributes %s", tagsBytes)
-					continue
-				}
 				setHighlightAttributes(spanAttributes, &projectID, &sessionID, &requestID, &source)
 				events := span.Events()
 				for l := 0; l < events.Len(); l++ {
@@ -183,11 +179,11 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						ts := event.Timestamp().AsTime()
 
 						var logCursor *string
-						logRow := getLogRow(ts, "ERROR", projectID, sessionID, traceID, spanID, excMessage, resourceAttributes, eventAttributes, source)
+						logRow := getLogRow(ts, "ERROR", projectID, sessionID, traceID, spanID, excMessage, resourceAttributes, spanAttributes, eventAttributes, source)
 						projectLogs[projectID] = append(projectLogs[projectID], logRow)
 						logCursor = pointy.String(logRow.Cursor())
 
-						isProjectError, backendError := getBackendError(ctx, ts, projectID, sessionID, requestID, traceID, spanID, logCursor, source, excMessage, string(tagsBytes), resourceAttributes, eventAttributes)
+						isProjectError, backendError := getBackendError(ctx, ts, projectID, sessionID, requestID, traceID, spanID, logCursor, source, excMessage, resourceAttributes, spanAttributes, eventAttributes)
 						if backendError == nil {
 							data, _ := req.MarshalJSON()
 							log.WithContext(ctx).WithField("BackendErrorEvent", event).WithField("LogRow", *logRow).WithField("RequestJSON", string(data)).Errorf("otel span error got no session and no project")
@@ -210,13 +206,13 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						}
 
 						var logCursor *string
-						logRow := getLogRow(ts, logSev, projectID, sessionID, traceID, spanID, logMessage, resourceAttributes, eventAttributes, source)
+						logRow := getLogRow(ts, logSev, projectID, sessionID, traceID, spanID, logMessage, resourceAttributes, spanAttributes, eventAttributes, source)
 						projectLogs[projectID] = append(projectLogs[projectID], logRow)
 						logCursor = pointy.String(logRow.Cursor())
 
 						// create a backend error for this error log, if this is a backend log
 						if logRow.SeverityNumber <= int32(log.ErrorLevel) && source != highlight.SourceAttributeFrontend {
-							isProjectError, backendError := getBackendError(ctx, ts, projectID, sessionID, requestID, traceID, spanID, logCursor, source, logMessage, string(tagsBytes), resourceAttributes, eventAttributes)
+							isProjectError, backendError := getBackendError(ctx, ts, projectID, sessionID, requestID, traceID, spanID, logCursor, source, logMessage, resourceAttributes, spanAttributes, eventAttributes)
 							if backendError == nil {
 								data, _ := req.MarshalJSON()
 								log.WithContext(ctx).WithField("BackendErrorEvent", event).WithField("LogRow", *logRow).WithField("RequestJSON", string(data)).Errorf("otel span error got no session and no project")
@@ -355,7 +351,9 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 		setHighlightAttributes(resourceAttributes, &projectID, &sessionID, &requestID, &source)
 		scopeLogs := resourceLogs.At(i).ScopeLogs()
 		for j := 0; j < scopeLogs.Len(); j++ {
-			logRecords := scopeLogs.At(j).LogRecords()
+			scopeLogs := scopeLogs.At(j)
+			scopeAttributes := scopeLogs.Scope().Attributes().AsRaw()
+			logRecords := scopeLogs.LogRecords()
 			for k := 0; k < logRecords.Len(); k++ {
 				logRecord := logRecords.At(k)
 				logAttributes := logRecord.Attributes().AsRaw()
@@ -372,7 +370,7 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 					ProjectId:       uint32(projectIDInt),
 					SecureSessionId: sessionID,
 				},
-					clickhouse.WithLogAttributes(resourceAttributes, logAttributes, false),
+					clickhouse.WithLogAttributes(resourceAttributes, scopeAttributes, logAttributes, false),
 					clickhouse.WithSeverityText(logRecord.SeverityText()),
 				)
 


### PR DESCRIPTION
## Summary

Error created from error logs should have the logattributes as the payload. 
For example, the following [error](https://app.highlight.io/1/errors/pkQAv9oKfgBVYBO99aZ0ocJ3qk1w/instances/162208765?page=1) has an associated [log](https://app.highlight.io/logs/MjAyMy0wMy0yM1QxNToxOTowMVosMjc5OTYzYzgtOGMzNS00NjBjLWJhYTctYjhhMmI1NmQ3MDlm) that has structured attributes that are not passed to the created error.

The PR also captures span attributes that were not being processed on logs and errors (for example, the go sdk can report attributes on a span with the `span.SetAttribute` method exposed via the opentelemetry span interface.

![image](https://user-images.githubusercontent.com/1351531/227275350-2cc808cc-024d-4589-82e1-5141b0f280be.png)

<img width="542" alt="Screenshot 2023-03-23 at 10 17 00 PM" src="https://user-images.githubusercontent.com/1351531/227430885-62f221a5-6633-4712-aca6-cf638072b997.png">

## How did you test this change?

After the change, errors show useful tags that can help with debugging an error. In the above example, the `path` attribute is a custom tag on the log line that shows the graphql operation field.

<img width="1003" alt="Screenshot 2023-03-23 at 10 22 33 PM" src="https://user-images.githubusercontent.com/1351531/227431617-081fb30d-cb16-4a6b-82e8-3a921482cd0b.png">


## Are there any deployment considerations?

No