### PR TITLE
add frontend logic to retrieving and setting webhook configurations

### DIFF
--- a/backend/alerts/integrations/webhook/serializer.go
+++ b/backend/alerts/integrations/webhook/serializer.go
@@ -1,0 +1,18 @@
+package webhook
+
+import (
+	"github.com/highlight-run/highlight/backend/model"
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+)
+
+func GQLInputToGo(webhooks []*modelInputs.WebhookDestinationInput) []*model.WebhookDestination {
+	var ret []*model.WebhookDestination
+	for _, wh := range webhooks {
+		ret = append(ret, &model.WebhookDestination{
+			URL:           wh.URL,
+			Authorization: wh.Authorization,
+		})
+	}
+
+	return ret
+}

--- a/backend/alerts/integrations/webhook/webhook.go
+++ b/backend/alerts/integrations/webhook/webhook.go
@@ -25,7 +25,7 @@ func sendWebhookData(destination *model.WebhookDestination, body []byte) error {
 		return nil
 	}
 
-	return e.New(fmt.Sprintf("webhook %s received unexpected response code %d", destination, resp.StatusCode))
+	return e.New(fmt.Sprintf("webhook %+v received unexpected response code %d", destination, resp.StatusCode))
 }
 
 func SendErrorAlert(destination *model.WebhookDestination, payload *integrations.ErrorAlertPayload) error {

--- a/backend/alerts/sessionalerts.go
+++ b/backend/alerts/sessionalerts.go
@@ -100,6 +100,7 @@ func BuildSessionAlert(project *model.Project, workspace *model.Workspace, admin
 		ExcludeRules:    excludeRulesString,
 		AlertIntegrations: model.AlertIntegrations{
 			DiscordChannelsToNotify: discord.GQLInputToGo(input.DiscordChannels),
+			WebhookDestinations:     input.WebhookDestinations,
 		},
 	}, nil
 }

--- a/backend/alerts/sessionalerts.go
+++ b/backend/alerts/sessionalerts.go
@@ -68,7 +68,7 @@ func BuildSessionAlert(project *model.Project, workspace *model.Workspace, admin
 		return nil, errors.Wrap(err, "error parsing user properties for user properties alert")
 	}
 	userPropertiesString := string(userPropertiesBytes)
- 
+
 	excludeRulesString, err := marshalEnvironments(input.ExcludeRules)
 	if err != nil {
 		return nil, err

--- a/backend/alerts/sessionalerts.go
+++ b/backend/alerts/sessionalerts.go
@@ -2,6 +2,7 @@ package alerts
 
 import (
 	"encoding/json"
+	"github.com/highlight-run/highlight/backend/alerts/integrations/webhook"
 
 	"github.com/pkg/errors"
 
@@ -67,7 +68,7 @@ func BuildSessionAlert(project *model.Project, workspace *model.Workspace, admin
 		return nil, errors.Wrap(err, "error parsing user properties for user properties alert")
 	}
 	userPropertiesString := string(userPropertiesBytes)
-
+ 
 	excludeRulesString, err := marshalEnvironments(input.ExcludeRules)
 	if err != nil {
 		return nil, err
@@ -100,7 +101,7 @@ func BuildSessionAlert(project *model.Project, workspace *model.Workspace, admin
 		ExcludeRules:    excludeRulesString,
 		AlertIntegrations: model.AlertIntegrations{
 			DiscordChannelsToNotify: discord.GQLInputToGo(input.DiscordChannels),
-			WebhookDestinations:     input.WebhookDestinations,
+			WebhookDestinations:     webhook.GQLInputToGo(input.WebhookDestinations),
 		},
 	}, nil
 }

--- a/backend/model/sessionalerts.go
+++ b/backend/model/sessionalerts.go
@@ -31,7 +31,7 @@ func (dc DiscordChannels) Value() (driver.Value, error) {
 
 type WebhookDestination struct {
 	URL           string
-	Authorization string
+	Authorization *string
 }
 
 type WebhookDestinations []*WebhookDestination

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -8811,7 +8811,6 @@ input SanitizedSlackChannelInput {
 	webhook_channel_id: String
 }
 
-
 type DiscordChannel {
 	id: String!
 	name: String!
@@ -8821,7 +8820,6 @@ input DiscordChannelInput {
 	name: String!
 	id: String!
 }
-
 
 type WebhookDestination {
 	url: String!

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -265,6 +265,7 @@ type ComplexityRoot struct {
 		ThresholdWindow         func(childComplexity int) int
 		Type                    func(childComplexity int) int
 		UpdatedAt               func(childComplexity int) int
+		WebhookDestinations     func(childComplexity int) int
 	}
 
 	ErrorComment struct {
@@ -554,6 +555,7 @@ type ComplexityRoot struct {
 		Threshold               func(childComplexity int) int
 		Units                   func(childComplexity int) int
 		UpdatedAt               func(childComplexity int) int
+		WebhookDestinations     func(childComplexity int) int
 	}
 
 	MetricPreview struct {
@@ -574,12 +576,12 @@ type ComplexityRoot struct {
 		ChangeAdminRole                  func(childComplexity int, workspaceID int, adminID int, newRole string) int
 		CreateAdmin                      func(childComplexity int) int
 		CreateDefaultAlerts              func(childComplexity int, projectID int, alertTypes []string, slackChannels []*model.SanitizedSlackChannelInput, emails []*string) int
-		CreateErrorAlert                 func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, emails []*string, environments []*string, regexGroups []*string, frequency int) int
+		CreateErrorAlert                 func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, environments []*string, regexGroups []*string, frequency int) int
 		CreateErrorComment               func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, integrations []*model.IntegrationType) int
 		CreateErrorSegment               func(childComplexity int, projectID int, name string, params model.ErrorSearchParamsInput) int
 		CreateIssueForErrorComment       func(childComplexity int, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueTeamID *string, integrations []*model.IntegrationType) int
 		CreateIssueForSessionComment     func(childComplexity int, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueDescription *string, issueTeamID *string, integrations []*model.IntegrationType) int
-		CreateMetricMonitor              func(childComplexity int, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, emails []*string, filters []*model.MetricTagFilterInput) int
+		CreateMetricMonitor              func(childComplexity int, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, filters []*model.MetricTagFilterInput) int
 		CreateOrUpdateStripeSubscription func(childComplexity int, workspaceID int, planType model.PlanType, interval model.SubscriptionInterval, retentionPeriod model.RetentionPeriod) int
 		CreateProject                    func(childComplexity int, name string, workspaceID int) int
 		CreateSegment                    func(childComplexity int, projectID int, name string, params model.SearchParamsInput) int
@@ -626,12 +628,12 @@ type ComplexityRoot struct {
 		UpdateBillingDetails             func(childComplexity int, workspaceID int) int
 		UpdateClickUpProjectMappings     func(childComplexity int, workspaceID int, projectMappings []*model.ClickUpProjectMappingInput) int
 		UpdateEmailOptOut                func(childComplexity int, token *string, adminID *int, category model.EmailOptOutCategory, isOptOut bool) int
-		UpdateErrorAlert                 func(childComplexity int, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) int
+		UpdateErrorAlert                 func(childComplexity int, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) int
 		UpdateErrorAlertIsDisabled       func(childComplexity int, id int, projectID int, disabled bool) int
 		UpdateErrorGroupIsPublic         func(childComplexity int, errorGroupSecureID string, isPublic bool) int
 		UpdateErrorGroupState            func(childComplexity int, secureID string, state string, snoozedUntil *time.Time) int
 		UpdateIntegrationProjectMappings func(childComplexity int, workspaceID int, integrationType model.IntegrationType, projectMappings []*model.IntegrationProjectMappingInput) int
-		UpdateMetricMonitor              func(childComplexity int, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) int
+		UpdateMetricMonitor              func(childComplexity int, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) int
 		UpdateMetricMonitorIsDisabled    func(childComplexity int, id int, projectID int, disabled bool) int
 		UpdateSessionAlert               func(childComplexity int, id int, input model.SessionAlertInput) int
 		UpdateSessionAlertIsDisabled     func(childComplexity int, id int, projectID int, disabled bool) int
@@ -1139,6 +1141,7 @@ type CommentReplyResolver interface {
 type ErrorAlertResolver interface {
 	ChannelsToNotify(ctx context.Context, obj *model1.ErrorAlert) ([]*model.SanitizedSlackChannel, error)
 	DiscordChannelsToNotify(ctx context.Context, obj *model1.ErrorAlert) ([]*model1.DiscordChannel, error)
+	WebhookDestinations(ctx context.Context, obj *model1.ErrorAlert) ([]string, error)
 	EmailsToNotify(ctx context.Context, obj *model1.ErrorAlert) ([]*string, error)
 	ExcludedEnvironments(ctx context.Context, obj *model1.ErrorAlert) ([]*string, error)
 
@@ -1172,6 +1175,7 @@ type ErrorSegmentResolver interface {
 type MetricMonitorResolver interface {
 	ChannelsToNotify(ctx context.Context, obj *model1.MetricMonitor) ([]*model.SanitizedSlackChannel, error)
 	DiscordChannelsToNotify(ctx context.Context, obj *model1.MetricMonitor) ([]*model1.DiscordChannel, error)
+	WebhookDestinations(ctx context.Context, obj *model1.MetricMonitor) ([]string, error)
 	EmailsToNotify(ctx context.Context, obj *model1.MetricMonitor) ([]*string, error)
 
 	Filters(ctx context.Context, obj *model1.MetricMonitor) ([]*model.MetricTagFilter, error)
@@ -1222,10 +1226,10 @@ type MutationResolver interface {
 	RemoveIntegrationFromWorkspace(ctx context.Context, integrationType model.IntegrationType, workspaceID int) (bool, error)
 	SyncSlackIntegration(ctx context.Context, projectID int) (*model.SlackSyncResponse, error)
 	CreateDefaultAlerts(ctx context.Context, projectID int, alertTypes []string, slackChannels []*model.SanitizedSlackChannelInput, emails []*string) (*bool, error)
-	CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, emails []*string, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
-	UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
-	CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, emails []*string, environments []*string, regexGroups []*string, frequency int) (*model1.ErrorAlert, error)
-	UpdateErrorAlert(ctx context.Context, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) (*model1.ErrorAlert, error)
+	CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
+	UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
+	CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, environments []*string, regexGroups []*string, frequency int) (*model1.ErrorAlert, error)
+	UpdateErrorAlert(ctx context.Context, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) (*model1.ErrorAlert, error)
 	DeleteErrorAlert(ctx context.Context, projectID int, errorAlertID int) (*model1.ErrorAlert, error)
 	DeleteMetricMonitor(ctx context.Context, projectID int, metricMonitorID int) (*model1.MetricMonitor, error)
 	UpdateSessionAlertIsDisabled(ctx context.Context, id int, projectID int, disabled bool) (*model1.SessionAlert, error)
@@ -2342,6 +2346,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ErrorAlert.UpdatedAt(childComplexity), true
+
+	case "ErrorAlert.WebhookDestinations":
+		if e.complexity.ErrorAlert.WebhookDestinations == nil {
+			break
+		}
+
+		return e.complexity.ErrorAlert.WebhookDestinations(childComplexity), true
 
 	case "ErrorComment.attachments":
 		if e.complexity.ErrorComment.Attachments == nil {
@@ -3631,6 +3642,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.MetricMonitor.UpdatedAt(childComplexity), true
 
+	case "MetricMonitor.webhook_destinations":
+		if e.complexity.MetricMonitor.WebhookDestinations == nil {
+			break
+		}
+
+		return e.complexity.MetricMonitor.WebhookDestinations(childComplexity), true
+
 	case "MetricPreview.date":
 		if e.complexity.MetricPreview.Date == nil {
 			break
@@ -3743,7 +3761,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateErrorAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["count_threshold"].(int), args["threshold_window"].(int), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["emails"].([]*string), args["environments"].([]*string), args["regex_groups"].([]*string), args["frequency"].(int)), true
+		return e.complexity.Mutation.CreateErrorAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["count_threshold"].(int), args["threshold_window"].(int), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["webhook_destinations"].([]string), args["emails"].([]*string), args["environments"].([]*string), args["regex_groups"].([]*string), args["frequency"].(int)), true
 
 	case "Mutation.createErrorComment":
 		if e.complexity.Mutation.CreateErrorComment == nil {
@@ -3803,7 +3821,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateMetricMonitor(childComplexity, args["project_id"].(int), args["name"].(string), args["aggregator"].(model.MetricAggregator), args["periodMinutes"].(*int), args["threshold"].(float64), args["units"].(*string), args["metric_to_monitor"].(string), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["emails"].([]*string), args["filters"].([]*model.MetricTagFilterInput)), true
+		return e.complexity.Mutation.CreateMetricMonitor(childComplexity, args["project_id"].(int), args["name"].(string), args["aggregator"].(model.MetricAggregator), args["periodMinutes"].(*int), args["threshold"].(float64), args["units"].(*string), args["metric_to_monitor"].(string), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["webhook_destinations"].([]string), args["emails"].([]*string), args["filters"].([]*model.MetricTagFilterInput)), true
 
 	case "Mutation.createOrUpdateStripeSubscription":
 		if e.complexity.Mutation.CreateOrUpdateStripeSubscription == nil {
@@ -4367,7 +4385,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateErrorAlert(childComplexity, args["project_id"].(int), args["name"].(*string), args["error_alert_id"].(int), args["count_threshold"].(*int), args["threshold_window"].(*int), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["emails"].([]*string), args["environments"].([]*string), args["regex_groups"].([]*string), args["frequency"].(*int), args["disabled"].(*bool)), true
+		return e.complexity.Mutation.UpdateErrorAlert(childComplexity, args["project_id"].(int), args["name"].(*string), args["error_alert_id"].(int), args["count_threshold"].(*int), args["threshold_window"].(*int), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["webhook_destinations"].([]string), args["emails"].([]*string), args["environments"].([]*string), args["regex_groups"].([]*string), args["frequency"].(*int), args["disabled"].(*bool)), true
 
 	case "Mutation.updateErrorAlertIsDisabled":
 		if e.complexity.Mutation.UpdateErrorAlertIsDisabled == nil {
@@ -4427,7 +4445,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateMetricMonitor(childComplexity, args["metric_monitor_id"].(int), args["project_id"].(int), args["name"].(*string), args["aggregator"].(*model.MetricAggregator), args["periodMinutes"].(*int), args["threshold"].(*float64), args["units"].(*string), args["metric_to_monitor"].(*string), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["emails"].([]*string), args["disabled"].(*bool), args["filters"].([]*model.MetricTagFilterInput)), true
+		return e.complexity.Mutation.UpdateMetricMonitor(childComplexity, args["metric_monitor_id"].(int), args["project_id"].(int), args["name"].(*string), args["aggregator"].(*model.MetricAggregator), args["periodMinutes"].(*int), args["threshold"].(*float64), args["units"].(*string), args["metric_to_monitor"].(*string), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["webhook_destinations"].([]string), args["emails"].([]*string), args["disabled"].(*bool), args["filters"].([]*model.MetricTagFilterInput)), true
 
 	case "Mutation.updateMetricMonitorIsDisabled":
 		if e.complexity.Mutation.UpdateMetricMonitorIsDisabled == nil {
@@ -8537,6 +8555,7 @@ input SessionAlertInput {
 	threshold_window: Int!
 	slack_channels: [SanitizedSlackChannelInput!]!
 	discord_channels: [DiscordChannelInput!]!
+	webhook_destinations: [String!]!
 	emails: [String!]!
 	environments: [String!]!
 	disabled: Boolean!
@@ -8788,6 +8807,7 @@ type ErrorAlert {
 	Name: String
 	ChannelsToNotify: [SanitizedSlackChannel]!
 	DiscordChannelsToNotify: [DiscordChannel!]!
+	WebhookDestinations: [String!]!
 	EmailsToNotify: [String]!
 	ExcludedEnvironments: [String]!
 	CountThreshold: Int!
@@ -8978,6 +8998,7 @@ type MetricMonitor {
 	name: String!
 	channels_to_notify: [SanitizedSlackChannel]!
 	discord_channels_to_notify: [DiscordChannel!]!
+	webhook_destinations: [String!]!
 	emails_to_notify: [String]!
 	aggregator: MetricAggregator!
 	period_minutes: Int
@@ -9478,6 +9499,7 @@ type Mutation {
 		metric_to_monitor: String!
 		slack_channels: [SanitizedSlackChannelInput]!
 		discord_channels: [DiscordChannelInput!]!
+		webhook_destinations: [String!]!
 		emails: [String]!
 		filters: [MetricTagFilterInput!]
 	): MetricMonitor
@@ -9492,6 +9514,7 @@ type Mutation {
 		metric_to_monitor: String
 		slack_channels: [SanitizedSlackChannelInput]
 		discord_channels: [DiscordChannelInput!]!
+		webhook_destinations: [String!]!
 		emails: [String]
 		disabled: Boolean
 		filters: [MetricTagFilterInput!]
@@ -9503,6 +9526,7 @@ type Mutation {
 		threshold_window: Int!
 		slack_channels: [SanitizedSlackChannelInput]!
 		discord_channels: [DiscordChannelInput!]!
+		webhook_destinations: [String!]!
 		emails: [String]!
 		environments: [String]!
 		regex_groups: [String]!
@@ -9516,6 +9540,7 @@ type Mutation {
 		threshold_window: Int
 		slack_channels: [SanitizedSlackChannelInput]
 		discord_channels: [DiscordChannelInput!]!
+		webhook_destinations: [String!]!
 		emails: [String]
 		environments: [String]
 		regex_groups: [String]
@@ -9837,42 +9862,51 @@ func (ec *executionContext) field_Mutation_createErrorAlert_args(ctx context.Con
 		}
 	}
 	args["discord_channels"] = arg5
-	var arg6 []*string
-	if tmp, ok := rawArgs["emails"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("emails"))
-		arg6, err = ec.unmarshalNString2ᚕᚖstring(ctx, tmp)
+	var arg6 []string
+	if tmp, ok := rawArgs["webhook_destinations"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhook_destinations"))
+		arg6, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["emails"] = arg6
+	args["webhook_destinations"] = arg6
 	var arg7 []*string
-	if tmp, ok := rawArgs["environments"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environments"))
+	if tmp, ok := rawArgs["emails"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("emails"))
 		arg7, err = ec.unmarshalNString2ᚕᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["environments"] = arg7
+	args["emails"] = arg7
 	var arg8 []*string
-	if tmp, ok := rawArgs["regex_groups"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("regex_groups"))
+	if tmp, ok := rawArgs["environments"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environments"))
 		arg8, err = ec.unmarshalNString2ᚕᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["regex_groups"] = arg8
-	var arg9 int
-	if tmp, ok := rawArgs["frequency"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("frequency"))
-		arg9, err = ec.unmarshalNInt2int(ctx, tmp)
+	args["environments"] = arg8
+	var arg9 []*string
+	if tmp, ok := rawArgs["regex_groups"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("regex_groups"))
+		arg9, err = ec.unmarshalNString2ᚕᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["frequency"] = arg9
+	args["regex_groups"] = arg9
+	var arg10 int
+	if tmp, ok := rawArgs["frequency"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("frequency"))
+		arg10, err = ec.unmarshalNInt2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["frequency"] = arg10
 	return args, nil
 }
 
@@ -10290,24 +10324,33 @@ func (ec *executionContext) field_Mutation_createMetricMonitor_args(ctx context.
 		}
 	}
 	args["discord_channels"] = arg8
-	var arg9 []*string
+	var arg9 []string
+	if tmp, ok := rawArgs["webhook_destinations"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhook_destinations"))
+		arg9, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["webhook_destinations"] = arg9
+	var arg10 []*string
 	if tmp, ok := rawArgs["emails"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("emails"))
-		arg9, err = ec.unmarshalNString2ᚕᚖstring(ctx, tmp)
+		arg10, err = ec.unmarshalNString2ᚕᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["emails"] = arg9
-	var arg10 []*model.MetricTagFilterInput
+	args["emails"] = arg10
+	var arg11 []*model.MetricTagFilterInput
 	if tmp, ok := rawArgs["filters"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filters"))
-		arg10, err = ec.unmarshalOMetricTagFilterInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐMetricTagFilterInputᚄ(ctx, tmp)
+		arg11, err = ec.unmarshalOMetricTagFilterInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐMetricTagFilterInputᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["filters"] = arg10
+	args["filters"] = arg11
 	return args, nil
 }
 
@@ -11811,51 +11854,60 @@ func (ec *executionContext) field_Mutation_updateErrorAlert_args(ctx context.Con
 		}
 	}
 	args["discord_channels"] = arg6
-	var arg7 []*string
-	if tmp, ok := rawArgs["emails"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("emails"))
-		arg7, err = ec.unmarshalOString2ᚕᚖstring(ctx, tmp)
+	var arg7 []string
+	if tmp, ok := rawArgs["webhook_destinations"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhook_destinations"))
+		arg7, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["emails"] = arg7
+	args["webhook_destinations"] = arg7
 	var arg8 []*string
-	if tmp, ok := rawArgs["environments"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environments"))
+	if tmp, ok := rawArgs["emails"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("emails"))
 		arg8, err = ec.unmarshalOString2ᚕᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["environments"] = arg8
+	args["emails"] = arg8
 	var arg9 []*string
-	if tmp, ok := rawArgs["regex_groups"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("regex_groups"))
+	if tmp, ok := rawArgs["environments"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environments"))
 		arg9, err = ec.unmarshalOString2ᚕᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["regex_groups"] = arg9
-	var arg10 *int
+	args["environments"] = arg9
+	var arg10 []*string
+	if tmp, ok := rawArgs["regex_groups"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("regex_groups"))
+		arg10, err = ec.unmarshalOString2ᚕᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["regex_groups"] = arg10
+	var arg11 *int
 	if tmp, ok := rawArgs["frequency"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("frequency"))
-		arg10, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		arg11, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["frequency"] = arg10
-	var arg11 *bool
+	args["frequency"] = arg11
+	var arg12 *bool
 	if tmp, ok := rawArgs["disabled"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
-		arg11, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		arg12, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["disabled"] = arg11
+	args["disabled"] = arg12
 	return args, nil
 }
 
@@ -12075,33 +12127,42 @@ func (ec *executionContext) field_Mutation_updateMetricMonitor_args(ctx context.
 		}
 	}
 	args["discord_channels"] = arg9
-	var arg10 []*string
+	var arg10 []string
+	if tmp, ok := rawArgs["webhook_destinations"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhook_destinations"))
+		arg10, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["webhook_destinations"] = arg10
+	var arg11 []*string
 	if tmp, ok := rawArgs["emails"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("emails"))
-		arg10, err = ec.unmarshalOString2ᚕᚖstring(ctx, tmp)
+		arg11, err = ec.unmarshalOString2ᚕᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["emails"] = arg10
-	var arg11 *bool
+	args["emails"] = arg11
+	var arg12 *bool
 	if tmp, ok := rawArgs["disabled"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disabled"))
-		arg11, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		arg12, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["disabled"] = arg11
-	var arg12 []*model.MetricTagFilterInput
+	args["disabled"] = arg12
+	var arg13 []*model.MetricTagFilterInput
 	if tmp, ok := rawArgs["filters"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filters"))
-		arg12, err = ec.unmarshalOMetricTagFilterInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐMetricTagFilterInputᚄ(ctx, tmp)
+		arg13, err = ec.unmarshalOMetricTagFilterInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐMetricTagFilterInputᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["filters"] = arg12
+	args["filters"] = arg13
 	return args, nil
 }
 
@@ -20044,6 +20105,50 @@ func (ec *executionContext) fieldContext_ErrorAlert_DiscordChannelsToNotify(ctx 
 				return ec.fieldContext_DiscordChannel_name(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type DiscordChannel", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ErrorAlert_WebhookDestinations(ctx context.Context, field graphql.CollectedField, obj *model1.ErrorAlert) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ErrorAlert_WebhookDestinations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.ErrorAlert().WebhookDestinations(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ErrorAlert_WebhookDestinations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ErrorAlert",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -28429,6 +28534,50 @@ func (ec *executionContext) fieldContext_MetricMonitor_discord_channels_to_notif
 	return fc, nil
 }
 
+func (ec *executionContext) _MetricMonitor_webhook_destinations(ctx context.Context, field graphql.CollectedField, obj *model1.MetricMonitor) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_MetricMonitor_webhook_destinations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.MetricMonitor().WebhookDestinations(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_MetricMonitor_webhook_destinations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "MetricMonitor",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _MetricMonitor_emails_to_notify(ctx context.Context, field graphql.CollectedField, obj *model1.MetricMonitor) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_MetricMonitor_emails_to_notify(ctx, field)
 	if err != nil {
@@ -31991,7 +32140,7 @@ func (ec *executionContext) _Mutation_createMetricMonitor(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateMetricMonitor(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["aggregator"].(model.MetricAggregator), fc.Args["periodMinutes"].(*int), fc.Args["threshold"].(float64), fc.Args["units"].(*string), fc.Args["metric_to_monitor"].(string), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["emails"].([]*string), fc.Args["filters"].([]*model.MetricTagFilterInput))
+		return ec.resolvers.Mutation().CreateMetricMonitor(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["aggregator"].(model.MetricAggregator), fc.Args["periodMinutes"].(*int), fc.Args["threshold"].(float64), fc.Args["units"].(*string), fc.Args["metric_to_monitor"].(string), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["webhook_destinations"].([]string), fc.Args["emails"].([]*string), fc.Args["filters"].([]*model.MetricTagFilterInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -32022,6 +32171,8 @@ func (ec *executionContext) fieldContext_Mutation_createMetricMonitor(ctx contex
 				return ec.fieldContext_MetricMonitor_channels_to_notify(ctx, field)
 			case "discord_channels_to_notify":
 				return ec.fieldContext_MetricMonitor_discord_channels_to_notify(ctx, field)
+			case "webhook_destinations":
+				return ec.fieldContext_MetricMonitor_webhook_destinations(ctx, field)
 			case "emails_to_notify":
 				return ec.fieldContext_MetricMonitor_emails_to_notify(ctx, field)
 			case "aggregator":
@@ -32072,7 +32223,7 @@ func (ec *executionContext) _Mutation_updateMetricMonitor(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateMetricMonitor(rctx, fc.Args["metric_monitor_id"].(int), fc.Args["project_id"].(int), fc.Args["name"].(*string), fc.Args["aggregator"].(*model.MetricAggregator), fc.Args["periodMinutes"].(*int), fc.Args["threshold"].(*float64), fc.Args["units"].(*string), fc.Args["metric_to_monitor"].(*string), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["emails"].([]*string), fc.Args["disabled"].(*bool), fc.Args["filters"].([]*model.MetricTagFilterInput))
+		return ec.resolvers.Mutation().UpdateMetricMonitor(rctx, fc.Args["metric_monitor_id"].(int), fc.Args["project_id"].(int), fc.Args["name"].(*string), fc.Args["aggregator"].(*model.MetricAggregator), fc.Args["periodMinutes"].(*int), fc.Args["threshold"].(*float64), fc.Args["units"].(*string), fc.Args["metric_to_monitor"].(*string), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["webhook_destinations"].([]string), fc.Args["emails"].([]*string), fc.Args["disabled"].(*bool), fc.Args["filters"].([]*model.MetricTagFilterInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -32103,6 +32254,8 @@ func (ec *executionContext) fieldContext_Mutation_updateMetricMonitor(ctx contex
 				return ec.fieldContext_MetricMonitor_channels_to_notify(ctx, field)
 			case "discord_channels_to_notify":
 				return ec.fieldContext_MetricMonitor_discord_channels_to_notify(ctx, field)
+			case "webhook_destinations":
+				return ec.fieldContext_MetricMonitor_webhook_destinations(ctx, field)
 			case "emails_to_notify":
 				return ec.fieldContext_MetricMonitor_emails_to_notify(ctx, field)
 			case "aggregator":
@@ -32153,7 +32306,7 @@ func (ec *executionContext) _Mutation_createErrorAlert(ctx context.Context, fiel
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateErrorAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["count_threshold"].(int), fc.Args["threshold_window"].(int), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["emails"].([]*string), fc.Args["environments"].([]*string), fc.Args["regex_groups"].([]*string), fc.Args["frequency"].(int))
+		return ec.resolvers.Mutation().CreateErrorAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["count_threshold"].(int), fc.Args["threshold_window"].(int), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["webhook_destinations"].([]string), fc.Args["emails"].([]*string), fc.Args["environments"].([]*string), fc.Args["regex_groups"].([]*string), fc.Args["frequency"].(int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -32184,6 +32337,8 @@ func (ec *executionContext) fieldContext_Mutation_createErrorAlert(ctx context.C
 				return ec.fieldContext_ErrorAlert_ChannelsToNotify(ctx, field)
 			case "DiscordChannelsToNotify":
 				return ec.fieldContext_ErrorAlert_DiscordChannelsToNotify(ctx, field)
+			case "WebhookDestinations":
+				return ec.fieldContext_ErrorAlert_WebhookDestinations(ctx, field)
 			case "EmailsToNotify":
 				return ec.fieldContext_ErrorAlert_EmailsToNotify(ctx, field)
 			case "ExcludedEnvironments":
@@ -32236,7 +32391,7 @@ func (ec *executionContext) _Mutation_updateErrorAlert(ctx context.Context, fiel
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateErrorAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(*string), fc.Args["error_alert_id"].(int), fc.Args["count_threshold"].(*int), fc.Args["threshold_window"].(*int), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["emails"].([]*string), fc.Args["environments"].([]*string), fc.Args["regex_groups"].([]*string), fc.Args["frequency"].(*int), fc.Args["disabled"].(*bool))
+		return ec.resolvers.Mutation().UpdateErrorAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(*string), fc.Args["error_alert_id"].(int), fc.Args["count_threshold"].(*int), fc.Args["threshold_window"].(*int), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["webhook_destinations"].([]string), fc.Args["emails"].([]*string), fc.Args["environments"].([]*string), fc.Args["regex_groups"].([]*string), fc.Args["frequency"].(*int), fc.Args["disabled"].(*bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -32267,6 +32422,8 @@ func (ec *executionContext) fieldContext_Mutation_updateErrorAlert(ctx context.C
 				return ec.fieldContext_ErrorAlert_ChannelsToNotify(ctx, field)
 			case "DiscordChannelsToNotify":
 				return ec.fieldContext_ErrorAlert_DiscordChannelsToNotify(ctx, field)
+			case "WebhookDestinations":
+				return ec.fieldContext_ErrorAlert_WebhookDestinations(ctx, field)
 			case "EmailsToNotify":
 				return ec.fieldContext_ErrorAlert_EmailsToNotify(ctx, field)
 			case "ExcludedEnvironments":
@@ -32350,6 +32507,8 @@ func (ec *executionContext) fieldContext_Mutation_deleteErrorAlert(ctx context.C
 				return ec.fieldContext_ErrorAlert_ChannelsToNotify(ctx, field)
 			case "DiscordChannelsToNotify":
 				return ec.fieldContext_ErrorAlert_DiscordChannelsToNotify(ctx, field)
+			case "WebhookDestinations":
+				return ec.fieldContext_ErrorAlert_WebhookDestinations(ctx, field)
 			case "EmailsToNotify":
 				return ec.fieldContext_ErrorAlert_EmailsToNotify(ctx, field)
 			case "ExcludedEnvironments":
@@ -32433,6 +32592,8 @@ func (ec *executionContext) fieldContext_Mutation_deleteMetricMonitor(ctx contex
 				return ec.fieldContext_MetricMonitor_channels_to_notify(ctx, field)
 			case "discord_channels_to_notify":
 				return ec.fieldContext_MetricMonitor_discord_channels_to_notify(ctx, field)
+			case "webhook_destinations":
+				return ec.fieldContext_MetricMonitor_webhook_destinations(ctx, field)
 			case "emails_to_notify":
 				return ec.fieldContext_MetricMonitor_emails_to_notify(ctx, field)
 			case "aggregator":
@@ -32599,6 +32760,8 @@ func (ec *executionContext) fieldContext_Mutation_updateErrorAlertIsDisabled(ctx
 				return ec.fieldContext_ErrorAlert_ChannelsToNotify(ctx, field)
 			case "DiscordChannelsToNotify":
 				return ec.fieldContext_ErrorAlert_DiscordChannelsToNotify(ctx, field)
+			case "WebhookDestinations":
+				return ec.fieldContext_ErrorAlert_WebhookDestinations(ctx, field)
 			case "EmailsToNotify":
 				return ec.fieldContext_ErrorAlert_EmailsToNotify(ctx, field)
 			case "ExcludedEnvironments":
@@ -32682,6 +32845,8 @@ func (ec *executionContext) fieldContext_Mutation_updateMetricMonitorIsDisabled(
 				return ec.fieldContext_MetricMonitor_channels_to_notify(ctx, field)
 			case "discord_channels_to_notify":
 				return ec.fieldContext_MetricMonitor_discord_channels_to_notify(ctx, field)
+			case "webhook_destinations":
+				return ec.fieldContext_MetricMonitor_webhook_destinations(ctx, field)
 			case "emails_to_notify":
 				return ec.fieldContext_MetricMonitor_emails_to_notify(ctx, field)
 			case "aggregator":
@@ -39219,6 +39384,8 @@ func (ec *executionContext) fieldContext_Query_error_alerts(ctx context.Context,
 				return ec.fieldContext_ErrorAlert_ChannelsToNotify(ctx, field)
 			case "DiscordChannelsToNotify":
 				return ec.fieldContext_ErrorAlert_DiscordChannelsToNotify(ctx, field)
+			case "WebhookDestinations":
+				return ec.fieldContext_ErrorAlert_WebhookDestinations(ctx, field)
 			case "EmailsToNotify":
 				return ec.fieldContext_ErrorAlert_EmailsToNotify(ctx, field)
 			case "ExcludedEnvironments":
@@ -42438,6 +42605,8 @@ func (ec *executionContext) fieldContext_Query_metric_monitors(ctx context.Conte
 				return ec.fieldContext_MetricMonitor_channels_to_notify(ctx, field)
 			case "discord_channels_to_notify":
 				return ec.fieldContext_MetricMonitor_discord_channels_to_notify(ctx, field)
+			case "webhook_destinations":
+				return ec.fieldContext_MetricMonitor_webhook_destinations(ctx, field)
 			case "emails_to_notify":
 				return ec.fieldContext_MetricMonitor_emails_to_notify(ctx, field)
 			case "aggregator":
@@ -56126,7 +56295,7 @@ func (ec *executionContext) unmarshalInputSessionAlertInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"project_id", "name", "count_threshold", "threshold_window", "slack_channels", "discord_channels", "emails", "environments", "disabled", "type", "user_properties", "exclude_rules", "track_properties"}
+	fieldsInOrder := [...]string{"project_id", "name", "count_threshold", "threshold_window", "slack_channels", "discord_channels", "webhook_destinations", "emails", "environments", "disabled", "type", "user_properties", "exclude_rules", "track_properties"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -56178,6 +56347,14 @@ func (ec *executionContext) unmarshalInputSessionAlertInput(ctx context.Context,
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("discord_channels"))
 			it.DiscordChannels, err = ec.unmarshalNDiscordChannelInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐDiscordChannelInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "webhook_destinations":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhook_destinations"))
+			it.WebhookDestinations, err = ec.unmarshalNString2ᚕstringᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -57686,6 +57863,26 @@ func (ec *executionContext) _ErrorAlert(ctx context.Context, sel ast.SelectionSe
 					}
 				}()
 				res = ec._ErrorAlert_DiscordChannelsToNotify(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		case "WebhookDestinations":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ErrorAlert_WebhookDestinations(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}
@@ -59739,6 +59936,26 @@ func (ec *executionContext) _MetricMonitor(ctx context.Context, sel ast.Selectio
 					}
 				}()
 				res = ec._MetricMonitor_discord_channels_to_notify(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		case "webhook_destinations":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._MetricMonitor_webhook_destinations(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -576,12 +576,12 @@ type ComplexityRoot struct {
 		ChangeAdminRole                  func(childComplexity int, workspaceID int, adminID int, newRole string) int
 		CreateAdmin                      func(childComplexity int) int
 		CreateDefaultAlerts              func(childComplexity int, projectID int, alertTypes []string, slackChannels []*model.SanitizedSlackChannelInput, emails []*string) int
-		CreateErrorAlert                 func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, environments []*string, regexGroups []*string, frequency int) int
+		CreateErrorAlert                 func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency int) int
 		CreateErrorComment               func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, integrations []*model.IntegrationType) int
 		CreateErrorSegment               func(childComplexity int, projectID int, name string, params model.ErrorSearchParamsInput) int
 		CreateIssueForErrorComment       func(childComplexity int, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueTeamID *string, integrations []*model.IntegrationType) int
 		CreateIssueForSessionComment     func(childComplexity int, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueDescription *string, issueTeamID *string, integrations []*model.IntegrationType) int
-		CreateMetricMonitor              func(childComplexity int, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, filters []*model.MetricTagFilterInput) int
+		CreateMetricMonitor              func(childComplexity int, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) int
 		CreateOrUpdateStripeSubscription func(childComplexity int, workspaceID int, planType model.PlanType, interval model.SubscriptionInterval, retentionPeriod model.RetentionPeriod) int
 		CreateProject                    func(childComplexity int, name string, workspaceID int) int
 		CreateSegment                    func(childComplexity int, projectID int, name string, params model.SearchParamsInput) int
@@ -628,12 +628,12 @@ type ComplexityRoot struct {
 		UpdateBillingDetails             func(childComplexity int, workspaceID int) int
 		UpdateClickUpProjectMappings     func(childComplexity int, workspaceID int, projectMappings []*model.ClickUpProjectMappingInput) int
 		UpdateEmailOptOut                func(childComplexity int, token *string, adminID *int, category model.EmailOptOutCategory, isOptOut bool) int
-		UpdateErrorAlert                 func(childComplexity int, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) int
+		UpdateErrorAlert                 func(childComplexity int, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) int
 		UpdateErrorAlertIsDisabled       func(childComplexity int, id int, projectID int, disabled bool) int
 		UpdateErrorGroupIsPublic         func(childComplexity int, errorGroupSecureID string, isPublic bool) int
 		UpdateErrorGroupState            func(childComplexity int, secureID string, state string, snoozedUntil *time.Time) int
 		UpdateIntegrationProjectMappings func(childComplexity int, workspaceID int, integrationType model.IntegrationType, projectMappings []*model.IntegrationProjectMappingInput) int
-		UpdateMetricMonitor              func(childComplexity int, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) int
+		UpdateMetricMonitor              func(childComplexity int, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) int
 		UpdateMetricMonitorIsDisabled    func(childComplexity int, id int, projectID int, disabled bool) int
 		UpdateSessionAlert               func(childComplexity int, id int, input model.SessionAlertInput) int
 		UpdateSessionAlertIsDisabled     func(childComplexity int, id int, projectID int, disabled bool) int
@@ -1092,6 +1092,11 @@ type ComplexityRoot struct {
 		VercelProjectID func(childComplexity int) int
 	}
 
+	WebhookDestination struct {
+		Authorization func(childComplexity int) int
+		URL           func(childComplexity int) int
+	}
+
 	Workspace struct {
 		AllowMeterOverage           func(childComplexity int) int
 		AllowedAutoJoinEmailOrigins func(childComplexity int) int
@@ -1141,7 +1146,7 @@ type CommentReplyResolver interface {
 type ErrorAlertResolver interface {
 	ChannelsToNotify(ctx context.Context, obj *model1.ErrorAlert) ([]*model.SanitizedSlackChannel, error)
 	DiscordChannelsToNotify(ctx context.Context, obj *model1.ErrorAlert) ([]*model1.DiscordChannel, error)
-	WebhookDestinations(ctx context.Context, obj *model1.ErrorAlert) ([]string, error)
+	WebhookDestinations(ctx context.Context, obj *model1.ErrorAlert) ([]*model1.WebhookDestination, error)
 	EmailsToNotify(ctx context.Context, obj *model1.ErrorAlert) ([]*string, error)
 	ExcludedEnvironments(ctx context.Context, obj *model1.ErrorAlert) ([]*string, error)
 
@@ -1175,7 +1180,7 @@ type ErrorSegmentResolver interface {
 type MetricMonitorResolver interface {
 	ChannelsToNotify(ctx context.Context, obj *model1.MetricMonitor) ([]*model.SanitizedSlackChannel, error)
 	DiscordChannelsToNotify(ctx context.Context, obj *model1.MetricMonitor) ([]*model1.DiscordChannel, error)
-	WebhookDestinations(ctx context.Context, obj *model1.MetricMonitor) ([]string, error)
+	WebhookDestinations(ctx context.Context, obj *model1.MetricMonitor) ([]*model1.WebhookDestination, error)
 	EmailsToNotify(ctx context.Context, obj *model1.MetricMonitor) ([]*string, error)
 
 	Filters(ctx context.Context, obj *model1.MetricMonitor) ([]*model.MetricTagFilter, error)
@@ -1226,10 +1231,10 @@ type MutationResolver interface {
 	RemoveIntegrationFromWorkspace(ctx context.Context, integrationType model.IntegrationType, workspaceID int) (bool, error)
 	SyncSlackIntegration(ctx context.Context, projectID int) (*model.SlackSyncResponse, error)
 	CreateDefaultAlerts(ctx context.Context, projectID int, alertTypes []string, slackChannels []*model.SanitizedSlackChannelInput, emails []*string) (*bool, error)
-	CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
-	UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
-	CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, environments []*string, regexGroups []*string, frequency int) (*model1.ErrorAlert, error)
-	UpdateErrorAlert(ctx context.Context, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []string, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) (*model1.ErrorAlert, error)
+	CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
+	UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) (*model1.MetricMonitor, error)
+	CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency int) (*model1.ErrorAlert, error)
+	UpdateErrorAlert(ctx context.Context, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) (*model1.ErrorAlert, error)
 	DeleteErrorAlert(ctx context.Context, projectID int, errorAlertID int) (*model1.ErrorAlert, error)
 	DeleteMetricMonitor(ctx context.Context, projectID int, metricMonitorID int) (*model1.MetricMonitor, error)
 	UpdateSessionAlertIsDisabled(ctx context.Context, id int, projectID int, disabled bool) (*model1.SessionAlert, error)
@@ -3761,7 +3766,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateErrorAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["count_threshold"].(int), args["threshold_window"].(int), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["webhook_destinations"].([]string), args["emails"].([]*string), args["environments"].([]*string), args["regex_groups"].([]*string), args["frequency"].(int)), true
+		return e.complexity.Mutation.CreateErrorAlert(childComplexity, args["project_id"].(int), args["name"].(string), args["count_threshold"].(int), args["threshold_window"].(int), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["webhook_destinations"].([]*model.WebhookDestinationInput), args["emails"].([]*string), args["environments"].([]*string), args["regex_groups"].([]*string), args["frequency"].(int)), true
 
 	case "Mutation.createErrorComment":
 		if e.complexity.Mutation.CreateErrorComment == nil {
@@ -3821,7 +3826,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateMetricMonitor(childComplexity, args["project_id"].(int), args["name"].(string), args["aggregator"].(model.MetricAggregator), args["periodMinutes"].(*int), args["threshold"].(float64), args["units"].(*string), args["metric_to_monitor"].(string), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["webhook_destinations"].([]string), args["emails"].([]*string), args["filters"].([]*model.MetricTagFilterInput)), true
+		return e.complexity.Mutation.CreateMetricMonitor(childComplexity, args["project_id"].(int), args["name"].(string), args["aggregator"].(model.MetricAggregator), args["periodMinutes"].(*int), args["threshold"].(float64), args["units"].(*string), args["metric_to_monitor"].(string), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["webhook_destinations"].([]*model.WebhookDestinationInput), args["emails"].([]*string), args["filters"].([]*model.MetricTagFilterInput)), true
 
 	case "Mutation.createOrUpdateStripeSubscription":
 		if e.complexity.Mutation.CreateOrUpdateStripeSubscription == nil {
@@ -4385,7 +4390,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateErrorAlert(childComplexity, args["project_id"].(int), args["name"].(*string), args["error_alert_id"].(int), args["count_threshold"].(*int), args["threshold_window"].(*int), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["webhook_destinations"].([]string), args["emails"].([]*string), args["environments"].([]*string), args["regex_groups"].([]*string), args["frequency"].(*int), args["disabled"].(*bool)), true
+		return e.complexity.Mutation.UpdateErrorAlert(childComplexity, args["project_id"].(int), args["name"].(*string), args["error_alert_id"].(int), args["count_threshold"].(*int), args["threshold_window"].(*int), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["webhook_destinations"].([]*model.WebhookDestinationInput), args["emails"].([]*string), args["environments"].([]*string), args["regex_groups"].([]*string), args["frequency"].(*int), args["disabled"].(*bool)), true
 
 	case "Mutation.updateErrorAlertIsDisabled":
 		if e.complexity.Mutation.UpdateErrorAlertIsDisabled == nil {
@@ -4445,7 +4450,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateMetricMonitor(childComplexity, args["metric_monitor_id"].(int), args["project_id"].(int), args["name"].(*string), args["aggregator"].(*model.MetricAggregator), args["periodMinutes"].(*int), args["threshold"].(*float64), args["units"].(*string), args["metric_to_monitor"].(*string), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["webhook_destinations"].([]string), args["emails"].([]*string), args["disabled"].(*bool), args["filters"].([]*model.MetricTagFilterInput)), true
+		return e.complexity.Mutation.UpdateMetricMonitor(childComplexity, args["metric_monitor_id"].(int), args["project_id"].(int), args["name"].(*string), args["aggregator"].(*model.MetricAggregator), args["periodMinutes"].(*int), args["threshold"].(*float64), args["units"].(*string), args["metric_to_monitor"].(*string), args["slack_channels"].([]*model.SanitizedSlackChannelInput), args["discord_channels"].([]*model.DiscordChannelInput), args["webhook_destinations"].([]*model.WebhookDestinationInput), args["emails"].([]*string), args["disabled"].(*bool), args["filters"].([]*model.MetricTagFilterInput)), true
 
 	case "Mutation.updateMetricMonitorIsDisabled":
 		if e.complexity.Mutation.UpdateMetricMonitorIsDisabled == nil {
@@ -7477,6 +7482,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.VercelProjectMapping.VercelProjectID(childComplexity), true
 
+	case "WebhookDestination.authorization":
+		if e.complexity.WebhookDestination.Authorization == nil {
+			break
+		}
+
+		return e.complexity.WebhookDestination.Authorization(childComplexity), true
+
+	case "WebhookDestination.url":
+		if e.complexity.WebhookDestination.URL == nil {
+			break
+		}
+
+		return e.complexity.WebhookDestination.URL(childComplexity), true
+
 	case "Workspace.allow_meter_overage":
 		if e.complexity.Workspace.AllowMeterOverage == nil {
 			break
@@ -7721,6 +7740,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputTrackPropertyInput,
 		ec.unmarshalInputUserPropertyInput,
 		ec.unmarshalInputVercelProjectMappingInput,
+		ec.unmarshalInputWebhookDestinationInput,
 	)
 	first := true
 
@@ -7927,11 +7947,6 @@ type Plan {
 	quota: Int!
 	membersLimit: Int
 	errorsLimit: Int!
-}
-
-type DiscordChannel {
-	id: String!
-	name: String!
 }
 
 enum PlanType {
@@ -8555,7 +8570,7 @@ input SessionAlertInput {
 	threshold_window: Int!
 	slack_channels: [SanitizedSlackChannelInput!]!
 	discord_channels: [DiscordChannelInput!]!
-	webhook_destinations: [String!]!
+	webhook_destinations: [WebhookDestinationInput!]!
 	emails: [String!]!
 	environments: [String!]!
 	disabled: Boolean!
@@ -8796,9 +8811,26 @@ input SanitizedSlackChannelInput {
 	webhook_channel_id: String
 }
 
+
+type DiscordChannel {
+	id: String!
+	name: String!
+}
+
 input DiscordChannelInput {
 	name: String!
 	id: String!
+}
+
+
+type WebhookDestination {
+	url: String!
+	authorization: String
+}
+
+input WebhookDestinationInput {
+	url: String!
+	authorization: String
 }
 
 type ErrorAlert {
@@ -8807,7 +8839,7 @@ type ErrorAlert {
 	Name: String
 	ChannelsToNotify: [SanitizedSlackChannel]!
 	DiscordChannelsToNotify: [DiscordChannel!]!
-	WebhookDestinations: [String!]!
+	WebhookDestinations: [WebhookDestination!]!
 	EmailsToNotify: [String]!
 	ExcludedEnvironments: [String]!
 	CountThreshold: Int!
@@ -8998,7 +9030,7 @@ type MetricMonitor {
 	name: String!
 	channels_to_notify: [SanitizedSlackChannel]!
 	discord_channels_to_notify: [DiscordChannel!]!
-	webhook_destinations: [String!]!
+	webhook_destinations: [WebhookDestination!]!
 	emails_to_notify: [String]!
 	aggregator: MetricAggregator!
 	period_minutes: Int
@@ -9499,7 +9531,7 @@ type Mutation {
 		metric_to_monitor: String!
 		slack_channels: [SanitizedSlackChannelInput]!
 		discord_channels: [DiscordChannelInput!]!
-		webhook_destinations: [String!]!
+		webhook_destinations: [WebhookDestinationInput!]!
 		emails: [String]!
 		filters: [MetricTagFilterInput!]
 	): MetricMonitor
@@ -9514,7 +9546,7 @@ type Mutation {
 		metric_to_monitor: String
 		slack_channels: [SanitizedSlackChannelInput]
 		discord_channels: [DiscordChannelInput!]!
-		webhook_destinations: [String!]!
+		webhook_destinations: [WebhookDestinationInput!]!
 		emails: [String]
 		disabled: Boolean
 		filters: [MetricTagFilterInput!]
@@ -9526,7 +9558,7 @@ type Mutation {
 		threshold_window: Int!
 		slack_channels: [SanitizedSlackChannelInput]!
 		discord_channels: [DiscordChannelInput!]!
-		webhook_destinations: [String!]!
+		webhook_destinations: [WebhookDestinationInput!]!
 		emails: [String]!
 		environments: [String]!
 		regex_groups: [String]!
@@ -9540,7 +9572,7 @@ type Mutation {
 		threshold_window: Int
 		slack_channels: [SanitizedSlackChannelInput]
 		discord_channels: [DiscordChannelInput!]!
-		webhook_destinations: [String!]!
+		webhook_destinations: [WebhookDestinationInput!]!
 		emails: [String]
 		environments: [String]
 		regex_groups: [String]
@@ -9862,10 +9894,10 @@ func (ec *executionContext) field_Mutation_createErrorAlert_args(ctx context.Con
 		}
 	}
 	args["discord_channels"] = arg5
-	var arg6 []string
+	var arg6 []*model.WebhookDestinationInput
 	if tmp, ok := rawArgs["webhook_destinations"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhook_destinations"))
-		arg6, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		arg6, err = ec.unmarshalNWebhookDestinationInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐWebhookDestinationInputᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -10324,10 +10356,10 @@ func (ec *executionContext) field_Mutation_createMetricMonitor_args(ctx context.
 		}
 	}
 	args["discord_channels"] = arg8
-	var arg9 []string
+	var arg9 []*model.WebhookDestinationInput
 	if tmp, ok := rawArgs["webhook_destinations"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhook_destinations"))
-		arg9, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		arg9, err = ec.unmarshalNWebhookDestinationInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐWebhookDestinationInputᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -11854,10 +11886,10 @@ func (ec *executionContext) field_Mutation_updateErrorAlert_args(ctx context.Con
 		}
 	}
 	args["discord_channels"] = arg6
-	var arg7 []string
+	var arg7 []*model.WebhookDestinationInput
 	if tmp, ok := rawArgs["webhook_destinations"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhook_destinations"))
-		arg7, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		arg7, err = ec.unmarshalNWebhookDestinationInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐWebhookDestinationInputᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -12127,10 +12159,10 @@ func (ec *executionContext) field_Mutation_updateMetricMonitor_args(ctx context.
 		}
 	}
 	args["discord_channels"] = arg9
-	var arg10 []string
+	var arg10 []*model.WebhookDestinationInput
 	if tmp, ok := rawArgs["webhook_destinations"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhook_destinations"))
-		arg10, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		arg10, err = ec.unmarshalNWebhookDestinationInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐWebhookDestinationInputᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -20136,9 +20168,9 @@ func (ec *executionContext) _ErrorAlert_WebhookDestinations(ctx context.Context,
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]string)
+	res := resTmp.([]*model1.WebhookDestination)
 	fc.Result = res
-	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+	return ec.marshalNWebhookDestination2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐWebhookDestinationᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ErrorAlert_WebhookDestinations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -20148,7 +20180,13 @@ func (ec *executionContext) fieldContext_ErrorAlert_WebhookDestinations(ctx cont
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			switch field.Name {
+			case "url":
+				return ec.fieldContext_WebhookDestination_url(ctx, field)
+			case "authorization":
+				return ec.fieldContext_WebhookDestination_authorization(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type WebhookDestination", field.Name)
 		},
 	}
 	return fc, nil
@@ -28560,9 +28598,9 @@ func (ec *executionContext) _MetricMonitor_webhook_destinations(ctx context.Cont
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]string)
+	res := resTmp.([]*model1.WebhookDestination)
 	fc.Result = res
-	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+	return ec.marshalNWebhookDestination2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐWebhookDestinationᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_MetricMonitor_webhook_destinations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -28572,7 +28610,13 @@ func (ec *executionContext) fieldContext_MetricMonitor_webhook_destinations(ctx 
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			switch field.Name {
+			case "url":
+				return ec.fieldContext_WebhookDestination_url(ctx, field)
+			case "authorization":
+				return ec.fieldContext_WebhookDestination_authorization(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type WebhookDestination", field.Name)
 		},
 	}
 	return fc, nil
@@ -32140,7 +32184,7 @@ func (ec *executionContext) _Mutation_createMetricMonitor(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateMetricMonitor(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["aggregator"].(model.MetricAggregator), fc.Args["periodMinutes"].(*int), fc.Args["threshold"].(float64), fc.Args["units"].(*string), fc.Args["metric_to_monitor"].(string), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["webhook_destinations"].([]string), fc.Args["emails"].([]*string), fc.Args["filters"].([]*model.MetricTagFilterInput))
+		return ec.resolvers.Mutation().CreateMetricMonitor(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["aggregator"].(model.MetricAggregator), fc.Args["periodMinutes"].(*int), fc.Args["threshold"].(float64), fc.Args["units"].(*string), fc.Args["metric_to_monitor"].(string), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["webhook_destinations"].([]*model.WebhookDestinationInput), fc.Args["emails"].([]*string), fc.Args["filters"].([]*model.MetricTagFilterInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -32223,7 +32267,7 @@ func (ec *executionContext) _Mutation_updateMetricMonitor(ctx context.Context, f
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateMetricMonitor(rctx, fc.Args["metric_monitor_id"].(int), fc.Args["project_id"].(int), fc.Args["name"].(*string), fc.Args["aggregator"].(*model.MetricAggregator), fc.Args["periodMinutes"].(*int), fc.Args["threshold"].(*float64), fc.Args["units"].(*string), fc.Args["metric_to_monitor"].(*string), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["webhook_destinations"].([]string), fc.Args["emails"].([]*string), fc.Args["disabled"].(*bool), fc.Args["filters"].([]*model.MetricTagFilterInput))
+		return ec.resolvers.Mutation().UpdateMetricMonitor(rctx, fc.Args["metric_monitor_id"].(int), fc.Args["project_id"].(int), fc.Args["name"].(*string), fc.Args["aggregator"].(*model.MetricAggregator), fc.Args["periodMinutes"].(*int), fc.Args["threshold"].(*float64), fc.Args["units"].(*string), fc.Args["metric_to_monitor"].(*string), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["webhook_destinations"].([]*model.WebhookDestinationInput), fc.Args["emails"].([]*string), fc.Args["disabled"].(*bool), fc.Args["filters"].([]*model.MetricTagFilterInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -32306,7 +32350,7 @@ func (ec *executionContext) _Mutation_createErrorAlert(ctx context.Context, fiel
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateErrorAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["count_threshold"].(int), fc.Args["threshold_window"].(int), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["webhook_destinations"].([]string), fc.Args["emails"].([]*string), fc.Args["environments"].([]*string), fc.Args["regex_groups"].([]*string), fc.Args["frequency"].(int))
+		return ec.resolvers.Mutation().CreateErrorAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(string), fc.Args["count_threshold"].(int), fc.Args["threshold_window"].(int), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["webhook_destinations"].([]*model.WebhookDestinationInput), fc.Args["emails"].([]*string), fc.Args["environments"].([]*string), fc.Args["regex_groups"].([]*string), fc.Args["frequency"].(int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -32391,7 +32435,7 @@ func (ec *executionContext) _Mutation_updateErrorAlert(ctx context.Context, fiel
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().UpdateErrorAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(*string), fc.Args["error_alert_id"].(int), fc.Args["count_threshold"].(*int), fc.Args["threshold_window"].(*int), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["webhook_destinations"].([]string), fc.Args["emails"].([]*string), fc.Args["environments"].([]*string), fc.Args["regex_groups"].([]*string), fc.Args["frequency"].(*int), fc.Args["disabled"].(*bool))
+		return ec.resolvers.Mutation().UpdateErrorAlert(rctx, fc.Args["project_id"].(int), fc.Args["name"].(*string), fc.Args["error_alert_id"].(int), fc.Args["count_threshold"].(*int), fc.Args["threshold_window"].(*int), fc.Args["slack_channels"].([]*model.SanitizedSlackChannelInput), fc.Args["discord_channels"].([]*model.DiscordChannelInput), fc.Args["webhook_destinations"].([]*model.WebhookDestinationInput), fc.Args["emails"].([]*string), fc.Args["environments"].([]*string), fc.Args["regex_groups"].([]*string), fc.Args["frequency"].(*int), fc.Args["disabled"].(*bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -51948,6 +51992,91 @@ func (ec *executionContext) fieldContext_VercelProjectMapping_project_id(ctx con
 	return fc, nil
 }
 
+func (ec *executionContext) _WebhookDestination_url(ctx context.Context, field graphql.CollectedField, obj *model1.WebhookDestination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WebhookDestination_url(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.URL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WebhookDestination_url(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WebhookDestination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WebhookDestination_authorization(ctx context.Context, field graphql.CollectedField, obj *model1.WebhookDestination) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WebhookDestination_authorization(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Authorization, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WebhookDestination_authorization(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WebhookDestination",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Workspace_id(ctx context.Context, field graphql.CollectedField, obj *model1.Workspace) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Workspace_id(ctx, field)
 	if err != nil {
@@ -56354,7 +56483,7 @@ func (ec *executionContext) unmarshalInputSessionAlertInput(ctx context.Context,
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("webhook_destinations"))
-			it.WebhookDestinations, err = ec.unmarshalNString2ᚕstringᚄ(ctx, v)
+			it.WebhookDestinations, err = ec.unmarshalNWebhookDestinationInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐWebhookDestinationInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -56579,6 +56708,42 @@ func (ec *executionContext) unmarshalInputVercelProjectMappingInput(ctx context.
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
 			it.ProjectID, err = ec.unmarshalOID2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputWebhookDestinationInput(ctx context.Context, obj interface{}) (model.WebhookDestinationInput, error) {
+	var it model.WebhookDestinationInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"url", "authorization"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "url":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("url"))
+			it.URL, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "authorization":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("authorization"))
+			it.Authorization, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -65337,6 +65502,38 @@ func (ec *executionContext) _VercelProjectMapping(ctx context.Context, sel ast.S
 	return out
 }
 
+var webhookDestinationImplementors = []string{"WebhookDestination"}
+
+func (ec *executionContext) _WebhookDestination(ctx context.Context, sel ast.SelectionSet, obj *model1.WebhookDestination) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, webhookDestinationImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("WebhookDestination")
+		case "url":
+
+			out.Values[i] = ec._WebhookDestination_url(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "authorization":
+
+			out.Values[i] = ec._WebhookDestination_authorization(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var workspaceImplementors = []string{"Workspace"}
 
 func (ec *executionContext) _Workspace(ctx context.Context, sel ast.SelectionSet, obj *model1.Workspace) graphql.Marshaler {
@@ -70022,6 +70219,82 @@ func (ec *executionContext) unmarshalNVercelProjectMappingInput2ᚕᚖgithubᚗc
 
 func (ec *executionContext) unmarshalNVercelProjectMappingInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐVercelProjectMappingInput(ctx context.Context, v interface{}) (*model.VercelProjectMappingInput, error) {
 	res, err := ec.unmarshalInputVercelProjectMappingInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNWebhookDestination2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐWebhookDestinationᚄ(ctx context.Context, sel ast.SelectionSet, v []*model1.WebhookDestination) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNWebhookDestination2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐWebhookDestination(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNWebhookDestination2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐWebhookDestination(ctx context.Context, sel ast.SelectionSet, v *model1.WebhookDestination) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._WebhookDestination(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNWebhookDestinationInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐWebhookDestinationInputᚄ(ctx context.Context, v interface{}) ([]*model.WebhookDestinationInput, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.WebhookDestinationInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNWebhookDestinationInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐWebhookDestinationInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNWebhookDestinationInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐWebhookDestinationInput(ctx context.Context, v interface{}) (*model.WebhookDestinationInput, error) {
+	res, err := ec.unmarshalInputWebhookDestinationInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -517,7 +517,7 @@ type SessionAlertInput struct {
 	ThresholdWindow     int                           `json:"threshold_window"`
 	SlackChannels       []*SanitizedSlackChannelInput `json:"slack_channels"`
 	DiscordChannels     []*DiscordChannelInput        `json:"discord_channels"`
-	WebhookDestinations []string                      `json:"webhook_destinations"`
+	WebhookDestinations []*WebhookDestinationInput    `json:"webhook_destinations"`
 	Emails              []string                      `json:"emails"`
 	Environments        []string                      `json:"environments"`
 	Disabled            bool                          `json:"disabled"`
@@ -614,6 +614,11 @@ type VercelProjectMappingInput struct {
 	VercelProjectID string  `json:"vercel_project_id"`
 	NewProjectName  *string `json:"new_project_name"`
 	ProjectID       *int    `json:"project_id"`
+}
+
+type WebhookDestinationInput struct {
+	URL           string  `json:"url"`
+	Authorization *string `json:"authorization"`
 }
 
 type WorkspaceForInviteLink struct {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -511,19 +511,20 @@ type SearchParamsInput struct {
 }
 
 type SessionAlertInput struct {
-	ProjectID       int                           `json:"project_id"`
-	Name            string                        `json:"name"`
-	CountThreshold  int                           `json:"count_threshold"`
-	ThresholdWindow int                           `json:"threshold_window"`
-	SlackChannels   []*SanitizedSlackChannelInput `json:"slack_channels"`
-	DiscordChannels []*DiscordChannelInput        `json:"discord_channels"`
-	Emails          []string                      `json:"emails"`
-	Environments    []string                      `json:"environments"`
-	Disabled        bool                          `json:"disabled"`
-	Type            SessionAlertType              `json:"type"`
-	UserProperties  []*UserPropertyInput          `json:"user_properties"`
-	ExcludeRules    []string                      `json:"exclude_rules"`
-	TrackProperties []*TrackPropertyInput         `json:"track_properties"`
+	ProjectID           int                           `json:"project_id"`
+	Name                string                        `json:"name"`
+	CountThreshold      int                           `json:"count_threshold"`
+	ThresholdWindow     int                           `json:"threshold_window"`
+	SlackChannels       []*SanitizedSlackChannelInput `json:"slack_channels"`
+	DiscordChannels     []*DiscordChannelInput        `json:"discord_channels"`
+	WebhookDestinations []string                      `json:"webhook_destinations"`
+	Emails              []string                      `json:"emails"`
+	Environments        []string                      `json:"environments"`
+	Disabled            bool                          `json:"disabled"`
+	Type                SessionAlertType              `json:"type"`
+	UserProperties      []*UserPropertyInput          `json:"user_properties"`
+	ExcludeRules        []string                      `json:"exclude_rules"`
+	TrackProperties     []*TrackPropertyInput         `json:"track_properties"`
 }
 
 type SessionCommentTagInput struct {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -755,6 +755,7 @@ input SessionAlertInput {
 	threshold_window: Int!
 	slack_channels: [SanitizedSlackChannelInput!]!
 	discord_channels: [DiscordChannelInput!]!
+	webhook_destinations: [String!]!
 	emails: [String!]!
 	environments: [String!]!
 	disabled: Boolean!
@@ -1006,6 +1007,7 @@ type ErrorAlert {
 	Name: String
 	ChannelsToNotify: [SanitizedSlackChannel]!
 	DiscordChannelsToNotify: [DiscordChannel!]!
+	WebhookDestinations: [String!]!
 	EmailsToNotify: [String]!
 	ExcludedEnvironments: [String]!
 	CountThreshold: Int!
@@ -1196,6 +1198,7 @@ type MetricMonitor {
 	name: String!
 	channels_to_notify: [SanitizedSlackChannel]!
 	discord_channels_to_notify: [DiscordChannel!]!
+	webhook_destinations: [String!]!
 	emails_to_notify: [String]!
 	aggregator: MetricAggregator!
 	period_minutes: Int
@@ -1696,6 +1699,7 @@ type Mutation {
 		metric_to_monitor: String!
 		slack_channels: [SanitizedSlackChannelInput]!
 		discord_channels: [DiscordChannelInput!]!
+		webhook_destinations: [String!]!
 		emails: [String]!
 		filters: [MetricTagFilterInput!]
 	): MetricMonitor
@@ -1710,6 +1714,7 @@ type Mutation {
 		metric_to_monitor: String
 		slack_channels: [SanitizedSlackChannelInput]
 		discord_channels: [DiscordChannelInput!]!
+		webhook_destinations: [String!]!
 		emails: [String]
 		disabled: Boolean
 		filters: [MetricTagFilterInput!]
@@ -1721,6 +1726,7 @@ type Mutation {
 		threshold_window: Int!
 		slack_channels: [SanitizedSlackChannelInput]!
 		discord_channels: [DiscordChannelInput!]!
+		webhook_destinations: [String!]!
 		emails: [String]!
 		environments: [String]!
 		regex_groups: [String]!
@@ -1734,6 +1740,7 @@ type Mutation {
 		threshold_window: Int
 		slack_channels: [SanitizedSlackChannelInput]
 		discord_channels: [DiscordChannelInput!]!
+		webhook_destinations: [String!]!
 		emails: [String]
 		environments: [String]
 		regex_groups: [String]

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -129,11 +129,6 @@ type Plan {
 	errorsLimit: Int!
 }
 
-type DiscordChannel {
-	id: String!
-	name: String!
-}
-
 enum PlanType {
 	Free
 	Lite
@@ -755,7 +750,7 @@ input SessionAlertInput {
 	threshold_window: Int!
 	slack_channels: [SanitizedSlackChannelInput!]!
 	discord_channels: [DiscordChannelInput!]!
-	webhook_destinations: [String!]!
+	webhook_destinations: [WebhookDestinationInput!]!
 	emails: [String!]!
 	environments: [String!]!
 	disabled: Boolean!
@@ -996,9 +991,24 @@ input SanitizedSlackChannelInput {
 	webhook_channel_id: String
 }
 
+type DiscordChannel {
+	id: String!
+	name: String!
+}
+
 input DiscordChannelInput {
 	name: String!
 	id: String!
+}
+
+type WebhookDestination {
+	url: String!
+	authorization: String
+}
+
+input WebhookDestinationInput {
+	url: String!
+	authorization: String
 }
 
 type ErrorAlert {
@@ -1007,7 +1017,7 @@ type ErrorAlert {
 	Name: String
 	ChannelsToNotify: [SanitizedSlackChannel]!
 	DiscordChannelsToNotify: [DiscordChannel!]!
-	WebhookDestinations: [String!]!
+	WebhookDestinations: [WebhookDestination!]!
 	EmailsToNotify: [String]!
 	ExcludedEnvironments: [String]!
 	CountThreshold: Int!
@@ -1198,7 +1208,7 @@ type MetricMonitor {
 	name: String!
 	channels_to_notify: [SanitizedSlackChannel]!
 	discord_channels_to_notify: [DiscordChannel!]!
-	webhook_destinations: [String!]!
+	webhook_destinations: [WebhookDestination!]!
 	emails_to_notify: [String]!
 	aggregator: MetricAggregator!
 	period_minutes: Int
@@ -1699,7 +1709,7 @@ type Mutation {
 		metric_to_monitor: String!
 		slack_channels: [SanitizedSlackChannelInput]!
 		discord_channels: [DiscordChannelInput!]!
-		webhook_destinations: [String!]!
+		webhook_destinations: [WebhookDestinationInput!]!
 		emails: [String]!
 		filters: [MetricTagFilterInput!]
 	): MetricMonitor
@@ -1714,7 +1724,7 @@ type Mutation {
 		metric_to_monitor: String
 		slack_channels: [SanitizedSlackChannelInput]
 		discord_channels: [DiscordChannelInput!]!
-		webhook_destinations: [String!]!
+		webhook_destinations: [WebhookDestinationInput!]!
 		emails: [String]
 		disabled: Boolean
 		filters: [MetricTagFilterInput!]
@@ -1726,7 +1736,7 @@ type Mutation {
 		threshold_window: Int!
 		slack_channels: [SanitizedSlackChannelInput]!
 		discord_channels: [DiscordChannelInput!]!
-		webhook_destinations: [String!]!
+		webhook_destinations: [WebhookDestinationInput!]!
 		emails: [String]!
 		environments: [String]!
 		regex_groups: [String]!
@@ -1740,7 +1750,7 @@ type Mutation {
 		threshold_window: Int
 		slack_channels: [SanitizedSlackChannelInput]
 		discord_channels: [DiscordChannelInput!]!
-		webhook_destinations: [String!]!
+		webhook_destinations: [WebhookDestinationInput!]!
 		emails: [String]
 		environments: [String]
 		regex_groups: [String]

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -85,6 +85,11 @@ func (r *errorAlertResolver) DiscordChannelsToNotify(ctx context.Context, obj *m
 	return obj.DiscordChannelsToNotify, nil
 }
 
+// WebhookDestinations is the resolver for the WebhookDestinations field.
+func (r *errorAlertResolver) WebhookDestinations(ctx context.Context, obj *model.ErrorAlert) ([]string, error) {
+	return obj.WebhookDestinations, nil
+}
+
 // EmailsToNotify is the resolver for the EmailsToNotify field.
 func (r *errorAlertResolver) EmailsToNotify(ctx context.Context, obj *model.ErrorAlert) ([]*string, error) {
 	return obj.GetEmailsToNotify()
@@ -307,6 +312,11 @@ func (r *metricMonitorResolver) ChannelsToNotify(ctx context.Context, obj *model
 // DiscordChannelsToNotify is the resolver for the discord_channels_to_notify field.
 func (r *metricMonitorResolver) DiscordChannelsToNotify(ctx context.Context, obj *model.MetricMonitor) ([]*model.DiscordChannel, error) {
 	return obj.DiscordChannelsToNotify, nil
+}
+
+// WebhookDestinations is the resolver for the webhook_destinations field.
+func (r *metricMonitorResolver) WebhookDestinations(ctx context.Context, obj *model.MetricMonitor) ([]string, error) {
+	return obj.WebhookDestinations, nil
 }
 
 // EmailsToNotify is the resolver for the emails_to_notify field.
@@ -2433,7 +2443,7 @@ func (r *mutationResolver) CreateDefaultAlerts(ctx context.Context, projectID in
 }
 
 // CreateMetricMonitor is the resolver for the createMetricMonitor field.
-func (r *mutationResolver) CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator modelInputs.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, emails []*string, filters []*modelInputs.MetricTagFilterInput) (*model.MetricMonitor, error) {
+func (r *mutationResolver) CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator modelInputs.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, webhookDestinations []string, emails []*string, filters []*modelInputs.MetricTagFilterInput) (*model.MetricMonitor, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	workspace, _ := r.GetWorkspace(project.WorkspaceID)
@@ -2474,6 +2484,7 @@ func (r *mutationResolver) CreateMetricMonitor(ctx context.Context, projectID in
 		Filters:           mmFilters,
 		AlertIntegrations: model.AlertIntegrations{
 			DiscordChannelsToNotify: discord.GQLInputToGo(discordChannels),
+			WebhookDestinations:     webhookDestinations,
 		},
 	}
 
@@ -2488,7 +2499,7 @@ func (r *mutationResolver) CreateMetricMonitor(ctx context.Context, projectID in
 }
 
 // UpdateMetricMonitor is the resolver for the updateMetricMonitor field.
-func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *modelInputs.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, emails []*string, disabled *bool, filters []*modelInputs.MetricTagFilterInput) (*model.MetricMonitor, error) {
+func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *modelInputs.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, webhookDestinations []string, emails []*string, disabled *bool, filters []*modelInputs.MetricTagFilterInput) (*model.MetricMonitor, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	workspace, _ := r.GetWorkspace(project.WorkspaceID)
@@ -2532,6 +2543,7 @@ func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonito
 
 	metricMonitor.AlertIntegrations = model.AlertIntegrations{
 		DiscordChannelsToNotify: discord.GQLInputToGo(discordChannels),
+		WebhookDestinations:     webhookDestinations,
 	}
 
 	if emails != nil {
@@ -2574,7 +2586,7 @@ func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonito
 }
 
 // CreateErrorAlert is the resolver for the createErrorAlert field.
-func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, emails []*string, environments []*string, regexGroups []*string, frequency int) (*model.ErrorAlert, error) {
+func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, webhookDestinations []string, emails []*string, environments []*string, regexGroups []*string, frequency int) (*model.ErrorAlert, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	workspace, _ := r.GetWorkspace(project.WorkspaceID)
@@ -2620,6 +2632,7 @@ func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, 
 		RegexGroups: &regexGroupsString,
 		AlertIntegrations: model.AlertIntegrations{
 			DiscordChannelsToNotify: discord.GQLInputToGo(discordChannels),
+			WebhookDestinations:     webhookDestinations,
 		},
 	}
 
@@ -2634,7 +2647,7 @@ func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, 
 }
 
 // UpdateErrorAlert is the resolver for the updateErrorAlert field.
-func (r *mutationResolver) UpdateErrorAlert(ctx context.Context, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) (*model.ErrorAlert, error) {
+func (r *mutationResolver) UpdateErrorAlert(ctx context.Context, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, webhookDestinations []string, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) (*model.ErrorAlert, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	workspace, _ := r.GetWorkspace(project.WorkspaceID)
@@ -2702,6 +2715,7 @@ func (r *mutationResolver) UpdateErrorAlert(ctx context.Context, projectID int, 
 
 	projectAlert.AlertIntegrations = model.AlertIntegrations{
 		DiscordChannelsToNotify: discord.GQLInputToGo(discordChannels),
+		WebhookDestinations:     webhookDestinations,
 	}
 
 	if err := r.DB.Model(&model.ErrorAlert{

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/clearbit/clearbit-go/clearbit"
 	"github.com/highlight-run/highlight/backend/alerts"
 	"github.com/highlight-run/highlight/backend/alerts/integrations/discord"
+	"github.com/highlight-run/highlight/backend/alerts/integrations/webhook"
 	"github.com/highlight-run/highlight/backend/apolloio"
 	"github.com/highlight-run/highlight/backend/clickhouse"
 	"github.com/highlight-run/highlight/backend/clickup"
@@ -86,7 +87,7 @@ func (r *errorAlertResolver) DiscordChannelsToNotify(ctx context.Context, obj *m
 }
 
 // WebhookDestinations is the resolver for the WebhookDestinations field.
-func (r *errorAlertResolver) WebhookDestinations(ctx context.Context, obj *model.ErrorAlert) ([]string, error) {
+func (r *errorAlertResolver) WebhookDestinations(ctx context.Context, obj *model.ErrorAlert) ([]*model.WebhookDestination, error) {
 	return obj.WebhookDestinations, nil
 }
 
@@ -315,7 +316,7 @@ func (r *metricMonitorResolver) DiscordChannelsToNotify(ctx context.Context, obj
 }
 
 // WebhookDestinations is the resolver for the webhook_destinations field.
-func (r *metricMonitorResolver) WebhookDestinations(ctx context.Context, obj *model.MetricMonitor) ([]string, error) {
+func (r *metricMonitorResolver) WebhookDestinations(ctx context.Context, obj *model.MetricMonitor) ([]*model.WebhookDestination, error) {
 	return obj.WebhookDestinations, nil
 }
 
@@ -2443,7 +2444,7 @@ func (r *mutationResolver) CreateDefaultAlerts(ctx context.Context, projectID in
 }
 
 // CreateMetricMonitor is the resolver for the createMetricMonitor field.
-func (r *mutationResolver) CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator modelInputs.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, webhookDestinations []string, emails []*string, filters []*modelInputs.MetricTagFilterInput) (*model.MetricMonitor, error) {
+func (r *mutationResolver) CreateMetricMonitor(ctx context.Context, projectID int, name string, aggregator modelInputs.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, webhookDestinations []*modelInputs.WebhookDestinationInput, emails []*string, filters []*modelInputs.MetricTagFilterInput) (*model.MetricMonitor, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	workspace, _ := r.GetWorkspace(project.WorkspaceID)
@@ -2484,7 +2485,7 @@ func (r *mutationResolver) CreateMetricMonitor(ctx context.Context, projectID in
 		Filters:           mmFilters,
 		AlertIntegrations: model.AlertIntegrations{
 			DiscordChannelsToNotify: discord.GQLInputToGo(discordChannels),
-			WebhookDestinations:     webhookDestinations,
+			WebhookDestinations:     webhook.GQLInputToGo(webhookDestinations),
 		},
 	}
 
@@ -2499,7 +2500,7 @@ func (r *mutationResolver) CreateMetricMonitor(ctx context.Context, projectID in
 }
 
 // UpdateMetricMonitor is the resolver for the updateMetricMonitor field.
-func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *modelInputs.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, webhookDestinations []string, emails []*string, disabled *bool, filters []*modelInputs.MetricTagFilterInput) (*model.MetricMonitor, error) {
+func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonitorID int, projectID int, name *string, aggregator *modelInputs.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, webhookDestinations []*modelInputs.WebhookDestinationInput, emails []*string, disabled *bool, filters []*modelInputs.MetricTagFilterInput) (*model.MetricMonitor, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	workspace, _ := r.GetWorkspace(project.WorkspaceID)
@@ -2543,7 +2544,7 @@ func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonito
 
 	metricMonitor.AlertIntegrations = model.AlertIntegrations{
 		DiscordChannelsToNotify: discord.GQLInputToGo(discordChannels),
-		WebhookDestinations:     webhookDestinations,
+		WebhookDestinations:     webhook.GQLInputToGo(webhookDestinations),
 	}
 
 	if emails != nil {
@@ -2586,7 +2587,7 @@ func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonito
 }
 
 // CreateErrorAlert is the resolver for the createErrorAlert field.
-func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, webhookDestinations []string, emails []*string, environments []*string, regexGroups []*string, frequency int) (*model.ErrorAlert, error) {
+func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, webhookDestinations []*modelInputs.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency int) (*model.ErrorAlert, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	workspace, _ := r.GetWorkspace(project.WorkspaceID)
@@ -2632,7 +2633,7 @@ func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, 
 		RegexGroups: &regexGroupsString,
 		AlertIntegrations: model.AlertIntegrations{
 			DiscordChannelsToNotify: discord.GQLInputToGo(discordChannels),
-			WebhookDestinations:     webhookDestinations,
+			WebhookDestinations:     webhook.GQLInputToGo(webhookDestinations),
 		},
 	}
 
@@ -2647,7 +2648,7 @@ func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, 
 }
 
 // UpdateErrorAlert is the resolver for the updateErrorAlert field.
-func (r *mutationResolver) UpdateErrorAlert(ctx context.Context, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, webhookDestinations []string, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) (*model.ErrorAlert, error) {
+func (r *mutationResolver) UpdateErrorAlert(ctx context.Context, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*modelInputs.SanitizedSlackChannelInput, discordChannels []*modelInputs.DiscordChannelInput, webhookDestinations []*modelInputs.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) (*model.ErrorAlert, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	admin, _ := r.getCurrentAdmin(ctx)
 	workspace, _ := r.GetWorkspace(project.WorkspaceID)
@@ -2715,7 +2716,7 @@ func (r *mutationResolver) UpdateErrorAlert(ctx context.Context, projectID int, 
 
 	projectAlert.AlertIntegrations = model.AlertIntegrations{
 		DiscordChannelsToNotify: discord.GQLInputToGo(discordChannels),
-		WebhookDestinations:     webhookDestinations,
+		WebhookDestinations:     webhook.GQLInputToGo(webhookDestinations),
 	}
 
 	if err := r.DB.Model(&model.ErrorAlert{

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -2574,7 +2574,7 @@ export const CreateErrorAlertDocument = gql`
 		$threshold_window: Int!
 		$slack_channels: [SanitizedSlackChannelInput]!
 		$discord_channels: [DiscordChannelInput!]!
-		$webhook_destinations: [String!]!
+		$webhook_destinations: [WebhookDestinationInput!]!
 		$emails: [String]!
 		$environments: [String]!
 		$regex_groups: [String]!
@@ -2674,7 +2674,7 @@ export const CreateMetricMonitorDocument = gql`
 		$metric_to_monitor: String!
 		$slack_channels: [SanitizedSlackChannelInput]!
 		$discord_channels: [DiscordChannelInput!]!
-		$webhook_destinations: [String!]!
+		$webhook_destinations: [WebhookDestinationInput!]!
 		$emails: [String]!
 	) {
 		createMetricMonitor(
@@ -2774,7 +2774,7 @@ export const UpdateMetricMonitorDocument = gql`
 		$metric_to_monitor: String
 		$slack_channels: [SanitizedSlackChannelInput]
 		$discord_channels: [DiscordChannelInput!]!
-		$webhook_destinations: [String!]!
+		$webhook_destinations: [WebhookDestinationInput!]!
 		$emails: [String]
 		$disabled: Boolean
 	) {
@@ -3041,7 +3041,7 @@ export const UpdateErrorAlertDocument = gql`
 		$threshold_window: Int
 		$slack_channels: [SanitizedSlackChannelInput]
 		$discord_channels: [DiscordChannelInput!]!
-		$webhook_destinations: [String!]!
+		$webhook_destinations: [WebhookDestinationInput!]!
 		$emails: [String]
 		$environments: [String]
 		$regex_groups: [String]
@@ -10560,7 +10560,10 @@ export const GetAlertsPagePayloadDocument = gql`
 			DiscordChannelsToNotify {
 				...DiscordChannelFragment
 			}
-			WebhookDestinations
+			WebhookDestinations {
+				url
+				authorization
+			}
 			EmailsToNotify
 			ExcludedEnvironments
 			updated_at
@@ -10605,7 +10608,10 @@ export const GetAlertsPagePayloadDocument = gql`
 				id
 				name
 			}
-			webhook_destinations
+			webhook_destinations {
+				url
+				authorization
+			}
 			emails_to_notify
 			aggregator
 			period_minutes

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -2574,6 +2574,7 @@ export const CreateErrorAlertDocument = gql`
 		$threshold_window: Int!
 		$slack_channels: [SanitizedSlackChannelInput]!
 		$discord_channels: [DiscordChannelInput!]!
+		$webhook_destinations: [String!]!
 		$emails: [String]!
 		$environments: [String]!
 		$regex_groups: [String]!
@@ -2585,6 +2586,7 @@ export const CreateErrorAlertDocument = gql`
 			name: $name
 			slack_channels: $slack_channels
 			discord_channels: $discord_channels
+			webhook_destinations: $webhook_destinations
 			emails: $emails
 			environments: $environments
 			threshold_window: $threshold_window
@@ -2632,6 +2634,7 @@ export type CreateErrorAlertMutationFn = Apollo.MutationFunction<
  *      threshold_window: // value for 'threshold_window'
  *      slack_channels: // value for 'slack_channels'
  *      discord_channels: // value for 'discord_channels'
+ *      webhook_destinations: // value for 'webhook_destinations'
  *      emails: // value for 'emails'
  *      environments: // value for 'environments'
  *      regex_groups: // value for 'regex_groups'
@@ -2671,6 +2674,7 @@ export const CreateMetricMonitorDocument = gql`
 		$metric_to_monitor: String!
 		$slack_channels: [SanitizedSlackChannelInput]!
 		$discord_channels: [DiscordChannelInput!]!
+		$webhook_destinations: [String!]!
 		$emails: [String]!
 	) {
 		createMetricMonitor(
@@ -2684,6 +2688,7 @@ export const CreateMetricMonitorDocument = gql`
 			metric_to_monitor: $metric_to_monitor
 			slack_channels: $slack_channels
 			discord_channels: $discord_channels
+			webhook_destinations: $webhook_destinations
 			emails: $emails
 		) {
 			id
@@ -2731,6 +2736,7 @@ export type CreateMetricMonitorMutationFn = Apollo.MutationFunction<
  *      metric_to_monitor: // value for 'metric_to_monitor'
  *      slack_channels: // value for 'slack_channels'
  *      discord_channels: // value for 'discord_channels'
+ *      webhook_destinations: // value for 'webhook_destinations'
  *      emails: // value for 'emails'
  *   },
  * });
@@ -2768,6 +2774,7 @@ export const UpdateMetricMonitorDocument = gql`
 		$metric_to_monitor: String
 		$slack_channels: [SanitizedSlackChannelInput]
 		$discord_channels: [DiscordChannelInput!]!
+		$webhook_destinations: [String!]!
 		$emails: [String]
 		$disabled: Boolean
 	) {
@@ -2783,6 +2790,7 @@ export const UpdateMetricMonitorDocument = gql`
 			metric_to_monitor: $metric_to_monitor
 			slack_channels: $slack_channels
 			discord_channels: $discord_channels
+			webhook_destinations: $webhook_destinations
 			emails: $emails
 			disabled: $disabled
 		) {
@@ -2832,6 +2840,7 @@ export type UpdateMetricMonitorMutationFn = Apollo.MutationFunction<
  *      metric_to_monitor: // value for 'metric_to_monitor'
  *      slack_channels: // value for 'slack_channels'
  *      discord_channels: // value for 'discord_channels'
+ *      webhook_destinations: // value for 'webhook_destinations'
  *      emails: // value for 'emails'
  *      disabled: // value for 'disabled'
  *   },
@@ -3032,6 +3041,7 @@ export const UpdateErrorAlertDocument = gql`
 		$threshold_window: Int
 		$slack_channels: [SanitizedSlackChannelInput]
 		$discord_channels: [DiscordChannelInput!]!
+		$webhook_destinations: [String!]!
 		$emails: [String]
 		$environments: [String]
 		$regex_groups: [String]
@@ -3045,6 +3055,7 @@ export const UpdateErrorAlertDocument = gql`
 			count_threshold: $count_threshold
 			slack_channels: $slack_channels
 			discord_channels: $discord_channels
+			webhook_destinations: $webhook_destinations
 			emails: $emails
 			environments: $environments
 			threshold_window: $threshold_window
@@ -3097,6 +3108,7 @@ export type UpdateErrorAlertMutationFn = Apollo.MutationFunction<
  *      threshold_window: // value for 'threshold_window'
  *      slack_channels: // value for 'slack_channels'
  *      discord_channels: // value for 'discord_channels'
+ *      webhook_destinations: // value for 'webhook_destinations'
  *      emails: // value for 'emails'
  *      environments: // value for 'environments'
  *      regex_groups: // value for 'regex_groups'
@@ -10548,6 +10560,7 @@ export const GetAlertsPagePayloadDocument = gql`
 			DiscordChannelsToNotify {
 				...DiscordChannelFragment
 			}
+			WebhookDestinations
 			EmailsToNotify
 			ExcludedEnvironments
 			updated_at
@@ -10592,6 +10605,7 @@ export const GetAlertsPagePayloadDocument = gql`
 				id
 				name
 			}
+			webhook_destinations
 			emails_to_notify
 			aggregator
 			period_minutes

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -685,8 +685,8 @@ export type CreateErrorAlertMutationVariables = Types.Exact<{
 		| Array<Types.DiscordChannelInput>
 		| Types.DiscordChannelInput
 	webhook_destinations:
-		| Array<Types.Scalars['String']>
-		| Types.Scalars['String']
+		| Array<Types.WebhookDestinationInput>
+		| Types.WebhookDestinationInput
 	emails:
 		| Array<Types.Maybe<Types.Scalars['String']>>
 		| Types.Maybe<Types.Scalars['String']>
@@ -744,8 +744,8 @@ export type CreateMetricMonitorMutationVariables = Types.Exact<{
 		| Array<Types.DiscordChannelInput>
 		| Types.DiscordChannelInput
 	webhook_destinations:
-		| Array<Types.Scalars['String']>
-		| Types.Scalars['String']
+		| Array<Types.WebhookDestinationInput>
+		| Types.WebhookDestinationInput
 	emails:
 		| Array<Types.Maybe<Types.Scalars['String']>>
 		| Types.Maybe<Types.Scalars['String']>
@@ -798,8 +798,8 @@ export type UpdateMetricMonitorMutationVariables = Types.Exact<{
 		| Array<Types.DiscordChannelInput>
 		| Types.DiscordChannelInput
 	webhook_destinations:
-		| Array<Types.Scalars['String']>
-		| Types.Scalars['String']
+		| Array<Types.WebhookDestinationInput>
+		| Types.WebhookDestinationInput
 	emails?: Types.Maybe<
 		| Array<Types.Maybe<Types.Scalars['String']>>
 		| Types.Maybe<Types.Scalars['String']>
@@ -898,8 +898,8 @@ export type UpdateErrorAlertMutationVariables = Types.Exact<{
 		| Array<Types.DiscordChannelInput>
 		| Types.DiscordChannelInput
 	webhook_destinations:
-		| Array<Types.Scalars['String']>
-		| Types.Scalars['String']
+		| Array<Types.WebhookDestinationInput>
+		| Types.WebhookDestinationInput
 	emails?: Types.Maybe<
 		| Array<Types.Maybe<Types.Scalars['String']>>
 		| Types.Maybe<Types.Scalars['String']>
@@ -3637,7 +3637,6 @@ export type GetAlertsPagePayloadQuery = { __typename?: 'Query' } & {
 		Types.Maybe<
 			{ __typename?: 'ErrorAlert' } & Pick<
 				Types.ErrorAlert,
-				| 'WebhookDestinations'
 				| 'EmailsToNotify'
 				| 'ExcludedEnvironments'
 				| 'updated_at'
@@ -3664,6 +3663,12 @@ export type GetAlertsPagePayloadQuery = { __typename?: 'Query' } & {
 						{
 							__typename?: 'DiscordChannel'
 						} & DiscordChannelFragmentFragment
+					>
+					WebhookDestinations: Array<
+						{ __typename?: 'WebhookDestination' } & Pick<
+							Types.WebhookDestination,
+							'url' | 'authorization'
+						>
 					>
 				}
 		>
@@ -3707,7 +3712,6 @@ export type GetAlertsPagePayloadQuery = { __typename?: 'Query' } & {
 				| 'id'
 				| 'updated_at'
 				| 'name'
-				| 'webhook_destinations'
 				| 'emails_to_notify'
 				| 'aggregator'
 				| 'period_minutes'
@@ -3729,6 +3733,12 @@ export type GetAlertsPagePayloadQuery = { __typename?: 'Query' } & {
 						{ __typename?: 'DiscordChannel' } & Pick<
 							Types.DiscordChannel,
 							'id' | 'name'
+						>
+					>
+					webhook_destinations: Array<
+						{ __typename?: 'WebhookDestination' } & Pick<
+							Types.WebhookDestination,
+							'url' | 'authorization'
 						>
 					>
 					filters?: Types.Maybe<

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -684,6 +684,9 @@ export type CreateErrorAlertMutationVariables = Types.Exact<{
 	discord_channels:
 		| Array<Types.DiscordChannelInput>
 		| Types.DiscordChannelInput
+	webhook_destinations:
+		| Array<Types.Scalars['String']>
+		| Types.Scalars['String']
 	emails:
 		| Array<Types.Maybe<Types.Scalars['String']>>
 		| Types.Maybe<Types.Scalars['String']>
@@ -740,6 +743,9 @@ export type CreateMetricMonitorMutationVariables = Types.Exact<{
 	discord_channels:
 		| Array<Types.DiscordChannelInput>
 		| Types.DiscordChannelInput
+	webhook_destinations:
+		| Array<Types.Scalars['String']>
+		| Types.Scalars['String']
 	emails:
 		| Array<Types.Maybe<Types.Scalars['String']>>
 		| Types.Maybe<Types.Scalars['String']>
@@ -791,6 +797,9 @@ export type UpdateMetricMonitorMutationVariables = Types.Exact<{
 	discord_channels:
 		| Array<Types.DiscordChannelInput>
 		| Types.DiscordChannelInput
+	webhook_destinations:
+		| Array<Types.Scalars['String']>
+		| Types.Scalars['String']
 	emails?: Types.Maybe<
 		| Array<Types.Maybe<Types.Scalars['String']>>
 		| Types.Maybe<Types.Scalars['String']>
@@ -888,6 +897,9 @@ export type UpdateErrorAlertMutationVariables = Types.Exact<{
 	discord_channels:
 		| Array<Types.DiscordChannelInput>
 		| Types.DiscordChannelInput
+	webhook_destinations:
+		| Array<Types.Scalars['String']>
+		| Types.Scalars['String']
 	emails?: Types.Maybe<
 		| Array<Types.Maybe<Types.Scalars['String']>>
 		| Types.Maybe<Types.Scalars['String']>
@@ -3625,6 +3637,7 @@ export type GetAlertsPagePayloadQuery = { __typename?: 'Query' } & {
 		Types.Maybe<
 			{ __typename?: 'ErrorAlert' } & Pick<
 				Types.ErrorAlert,
+				| 'WebhookDestinations'
 				| 'EmailsToNotify'
 				| 'ExcludedEnvironments'
 				| 'updated_at'
@@ -3694,6 +3707,7 @@ export type GetAlertsPagePayloadQuery = { __typename?: 'Query' } & {
 				| 'id'
 				| 'updated_at'
 				| 'name'
+				| 'webhook_destinations'
 				| 'emails_to_notify'
 				| 'aggregator'
 				| 'period_minutes'

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -347,6 +347,7 @@ export type ErrorAlert = {
 	RegexGroups: Array<Maybe<Scalars['String']>>
 	ThresholdWindow?: Maybe<Scalars['Int']>
 	Type: Scalars['String']
+	WebhookDestinations: Array<Scalars['String']>
 	disabled: Scalars['Boolean']
 	id: Scalars['ID']
 	updated_at: Scalars['Timestamp']
@@ -758,6 +759,7 @@ export type MetricMonitor = {
 	threshold: Scalars['Float']
 	units?: Maybe<Scalars['String']>
 	updated_at: Scalars['Timestamp']
+	webhook_destinations: Array<Scalars['String']>
 }
 
 export type MetricPreview = {
@@ -909,6 +911,7 @@ export type MutationCreateErrorAlertArgs = {
 	regex_groups: Array<InputMaybe<Scalars['String']>>
 	slack_channels: Array<InputMaybe<SanitizedSlackChannelInput>>
 	threshold_window: Scalars['Int']
+	webhook_destinations: Array<Scalars['String']>
 }
 
 export type MutationCreateErrorCommentArgs = {
@@ -969,6 +972,7 @@ export type MutationCreateMetricMonitorArgs = {
 	slack_channels: Array<InputMaybe<SanitizedSlackChannelInput>>
 	threshold: Scalars['Float']
 	units?: InputMaybe<Scalars['String']>
+	webhook_destinations: Array<Scalars['String']>
 }
 
 export type MutationCreateOrUpdateStripeSubscriptionArgs = {
@@ -1247,6 +1251,7 @@ export type MutationUpdateErrorAlertArgs = {
 	regex_groups?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
 	slack_channels?: InputMaybe<Array<InputMaybe<SanitizedSlackChannelInput>>>
 	threshold_window?: InputMaybe<Scalars['Int']>
+	webhook_destinations: Array<Scalars['String']>
 }
 
 export type MutationUpdateErrorAlertIsDisabledArgs = {
@@ -1286,6 +1291,7 @@ export type MutationUpdateMetricMonitorArgs = {
 	slack_channels?: InputMaybe<Array<InputMaybe<SanitizedSlackChannelInput>>>
 	threshold?: InputMaybe<Scalars['Float']>
 	units?: InputMaybe<Scalars['String']>
+	webhook_destinations: Array<Scalars['String']>
 }
 
 export type MutationUpdateMetricMonitorIsDisabledArgs = {
@@ -2280,6 +2286,7 @@ export type SessionAlertInput = {
 	track_properties: Array<TrackPropertyInput>
 	type: SessionAlertType
 	user_properties: Array<UserPropertyInput>
+	webhook_destinations: Array<Scalars['String']>
 }
 
 export enum SessionAlertType {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -347,7 +347,7 @@ export type ErrorAlert = {
 	RegexGroups: Array<Maybe<Scalars['String']>>
 	ThresholdWindow?: Maybe<Scalars['Int']>
 	Type: Scalars['String']
-	WebhookDestinations: Array<Scalars['String']>
+	WebhookDestinations: Array<WebhookDestination>
 	disabled: Scalars['Boolean']
 	id: Scalars['ID']
 	updated_at: Scalars['Timestamp']
@@ -759,7 +759,7 @@ export type MetricMonitor = {
 	threshold: Scalars['Float']
 	units?: Maybe<Scalars['String']>
 	updated_at: Scalars['Timestamp']
-	webhook_destinations: Array<Scalars['String']>
+	webhook_destinations: Array<WebhookDestination>
 }
 
 export type MetricPreview = {
@@ -911,7 +911,7 @@ export type MutationCreateErrorAlertArgs = {
 	regex_groups: Array<InputMaybe<Scalars['String']>>
 	slack_channels: Array<InputMaybe<SanitizedSlackChannelInput>>
 	threshold_window: Scalars['Int']
-	webhook_destinations: Array<Scalars['String']>
+	webhook_destinations: Array<WebhookDestinationInput>
 }
 
 export type MutationCreateErrorCommentArgs = {
@@ -972,7 +972,7 @@ export type MutationCreateMetricMonitorArgs = {
 	slack_channels: Array<InputMaybe<SanitizedSlackChannelInput>>
 	threshold: Scalars['Float']
 	units?: InputMaybe<Scalars['String']>
-	webhook_destinations: Array<Scalars['String']>
+	webhook_destinations: Array<WebhookDestinationInput>
 }
 
 export type MutationCreateOrUpdateStripeSubscriptionArgs = {
@@ -1251,7 +1251,7 @@ export type MutationUpdateErrorAlertArgs = {
 	regex_groups?: InputMaybe<Array<InputMaybe<Scalars['String']>>>
 	slack_channels?: InputMaybe<Array<InputMaybe<SanitizedSlackChannelInput>>>
 	threshold_window?: InputMaybe<Scalars['Int']>
-	webhook_destinations: Array<Scalars['String']>
+	webhook_destinations: Array<WebhookDestinationInput>
 }
 
 export type MutationUpdateErrorAlertIsDisabledArgs = {
@@ -1291,7 +1291,7 @@ export type MutationUpdateMetricMonitorArgs = {
 	slack_channels?: InputMaybe<Array<InputMaybe<SanitizedSlackChannelInput>>>
 	threshold?: InputMaybe<Scalars['Float']>
 	units?: InputMaybe<Scalars['String']>
-	webhook_destinations: Array<Scalars['String']>
+	webhook_destinations: Array<WebhookDestinationInput>
 }
 
 export type MutationUpdateMetricMonitorIsDisabledArgs = {
@@ -2286,7 +2286,7 @@ export type SessionAlertInput = {
 	track_properties: Array<TrackPropertyInput>
 	type: SessionAlertType
 	user_properties: Array<UserPropertyInput>
-	webhook_destinations: Array<Scalars['String']>
+	webhook_destinations: Array<WebhookDestinationInput>
 }
 
 export enum SessionAlertType {
@@ -2524,6 +2524,17 @@ export type VercelProjectMappingInput = {
 	new_project_name?: InputMaybe<Scalars['String']>
 	project_id?: InputMaybe<Scalars['ID']>
 	vercel_project_id: Scalars['String']
+}
+
+export type WebhookDestination = {
+	__typename?: 'WebhookDestination'
+	authorization?: Maybe<Scalars['String']>
+	url: Scalars['String']
+}
+
+export type WebhookDestinationInput = {
+	authorization?: InputMaybe<Scalars['String']>
+	url: Scalars['String']
 }
 
 export type Workspace = {

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -585,7 +585,7 @@ mutation CreateErrorAlert(
 	$threshold_window: Int!
 	$slack_channels: [SanitizedSlackChannelInput]!
 	$discord_channels: [DiscordChannelInput!]!
-	$webhook_destinations: [String!]!
+	$webhook_destinations: [WebhookDestinationInput!]!
 	$emails: [String]!
 	$environments: [String]!
 	$regex_groups: [String]!
@@ -632,7 +632,7 @@ mutation CreateMetricMonitor(
 	$metric_to_monitor: String!
 	$slack_channels: [SanitizedSlackChannelInput]!
 	$discord_channels: [DiscordChannelInput!]!
-	$webhook_destinations: [String!]!
+	$webhook_destinations: [WebhookDestinationInput!]!
 	$emails: [String]!
 ) {
 	createMetricMonitor(
@@ -678,7 +678,7 @@ mutation UpdateMetricMonitor(
 	$metric_to_monitor: String
 	$slack_channels: [SanitizedSlackChannelInput]
 	$discord_channels: [DiscordChannelInput!]!
-	$webhook_destinations: [String!]!
+	$webhook_destinations: [WebhookDestinationInput!]!
 	$emails: [String]
 	$disabled: Boolean
 ) {
@@ -757,7 +757,7 @@ mutation UpdateErrorAlert(
 	$threshold_window: Int
 	$slack_channels: [SanitizedSlackChannelInput]
 	$discord_channels: [DiscordChannelInput!]!
-	$webhook_destinations: [String!]!
+	$webhook_destinations: [WebhookDestinationInput!]!
 	$emails: [String]
 	$environments: [String]
 	$regex_groups: [String]

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -585,6 +585,7 @@ mutation CreateErrorAlert(
 	$threshold_window: Int!
 	$slack_channels: [SanitizedSlackChannelInput]!
 	$discord_channels: [DiscordChannelInput!]!
+	$webhook_destinations: [String!]!
 	$emails: [String]!
 	$environments: [String]!
 	$regex_groups: [String]!
@@ -596,6 +597,7 @@ mutation CreateErrorAlert(
 		name: $name
 		slack_channels: $slack_channels
 		discord_channels: $discord_channels
+		webhook_destinations: $webhook_destinations
 		emails: $emails
 		environments: $environments
 		threshold_window: $threshold_window
@@ -630,6 +632,7 @@ mutation CreateMetricMonitor(
 	$metric_to_monitor: String!
 	$slack_channels: [SanitizedSlackChannelInput]!
 	$discord_channels: [DiscordChannelInput!]!
+	$webhook_destinations: [String!]!
 	$emails: [String]!
 ) {
 	createMetricMonitor(
@@ -643,6 +646,7 @@ mutation CreateMetricMonitor(
 		metric_to_monitor: $metric_to_monitor
 		slack_channels: $slack_channels
 		discord_channels: $discord_channels
+		webhook_destinations: $webhook_destinations
 		emails: $emails
 	) {
 		id
@@ -674,6 +678,7 @@ mutation UpdateMetricMonitor(
 	$metric_to_monitor: String
 	$slack_channels: [SanitizedSlackChannelInput]
 	$discord_channels: [DiscordChannelInput!]!
+	$webhook_destinations: [String!]!
 	$emails: [String]
 	$disabled: Boolean
 ) {
@@ -689,6 +694,7 @@ mutation UpdateMetricMonitor(
 		metric_to_monitor: $metric_to_monitor
 		slack_channels: $slack_channels
 		discord_channels: $discord_channels
+		webhook_destinations: $webhook_destinations
 		emails: $emails
 		disabled: $disabled
 	) {
@@ -751,6 +757,7 @@ mutation UpdateErrorAlert(
 	$threshold_window: Int
 	$slack_channels: [SanitizedSlackChannelInput]
 	$discord_channels: [DiscordChannelInput!]!
+	$webhook_destinations: [String!]!
 	$emails: [String]
 	$environments: [String]
 	$regex_groups: [String]
@@ -764,6 +771,7 @@ mutation UpdateErrorAlert(
 		count_threshold: $count_threshold
 		slack_channels: $slack_channels
 		discord_channels: $discord_channels
+		webhook_destinations: $webhook_destinations
 		emails: $emails
 		environments: $environments
 		threshold_window: $threshold_window

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1660,7 +1660,10 @@ query GetAlertsPagePayload($project_id: ID!) {
 		DiscordChannelsToNotify {
 			...DiscordChannelFragment
 		}
-		WebhookDestinations
+		WebhookDestinations {
+			url
+			authorization
+		}
 		EmailsToNotify
 		ExcludedEnvironments
 		updated_at
@@ -1705,7 +1708,10 @@ query GetAlertsPagePayload($project_id: ID!) {
 			id
 			name
 		}
-		webhook_destinations
+		webhook_destinations {
+			url
+			authorization
+		}
 		emails_to_notify
 		aggregator
 		period_minutes

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1660,6 +1660,7 @@ query GetAlertsPagePayload($project_id: ID!) {
 		DiscordChannelsToNotify {
 			...DiscordChannelFragment
 		}
+		WebhookDestinations
 		EmailsToNotify
 		ExcludedEnvironments
 		updated_at
@@ -1704,6 +1705,7 @@ query GetAlertsPagePayload($project_id: ID!) {
 			id
 			name
 		}
+		webhook_destinations
 		emails_to_notify
 		aggregator
 		period_minutes

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -14,7 +14,11 @@ import {
 	useUpdateSessionAlertMutation,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
-import { DiscordChannel, SessionAlertType } from '@graph/schemas'
+import {
+	DiscordChannel,
+	SessionAlertType,
+	WebhookDestination,
+} from '@graph/schemas'
 import alertConfigurationCardStyles from '@pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.module.scss'
 import { DiscordChannnelsSection } from '@pages/Alerts/AlertConfigurationCard/DiscordChannelsSection'
 import SyncWithSlackButton from '@pages/Alerts/AlertConfigurationCard/SyncWithSlackButton'
@@ -87,7 +91,7 @@ export const AlertConfigurationCard = ({
 	const [emailsToNotify, setEmailsToNotify] = useState<string[]>(
 		alert?.EmailsToNotify || [],
 	)
-	const [webhooks, setWebhooks] = useState<string[]>(
+	const [webhooks, setWebhooks] = useState<WebhookDestination[]>(
 		alert?.WebhookDestinations || [],
 	)
 	const [selectedDiscordChannels, setSelectedDiscordChannels] = useState<
@@ -596,7 +600,7 @@ export const AlertConfigurationCard = ({
 		setFormTouched(true)
 	}
 
-	const onWebhooksChange = (webhooks: string[]) => {
+	const onWebhooksChange = (webhooks: WebhookDestination[]) => {
 		form.setFieldsValue({ webhooks })
 		setWebhooks(webhooks)
 		setFormTouched(true)
@@ -923,10 +927,14 @@ export const AlertConfigurationCard = ({
 								className={
 									alertConfigurationCardStyles.channelSelect
 								}
-								value={webhooks}
+								value={webhooks.map((wh) => wh.url)}
 								mode="tags"
 								placeholder="Select webhook web addresses to send the alert to."
-								onChange={onWebhooksChange}
+								onChange={(whs: string[]) =>
+									onWebhooksChange(
+										whs.map((wh) => ({ url: wh })),
+									)
+								}
 							/>
 						</section>
 

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -15,6 +15,7 @@ import {
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
 import { DiscordChannel, SessionAlertType } from '@graph/schemas'
+import alertConfigurationCardStyles from '@pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.module.scss'
 import { DiscordChannnelsSection } from '@pages/Alerts/AlertConfigurationCard/DiscordChannelsSection'
 import SyncWithSlackButton from '@pages/Alerts/AlertConfigurationCard/SyncWithSlackButton'
 import { useApplicationContext } from '@routers/ProjectRouter/context/ApplicationContext'
@@ -86,6 +87,9 @@ export const AlertConfigurationCard = ({
 	const [emailsToNotify, setEmailsToNotify] = useState<string[]>(
 		alert?.EmailsToNotify || [],
 	)
+	const [webhooks, setWebhooks] = useState<string[]>(
+		alert?.WebhookDestinations || [],
+	)
 	const [selectedDiscordChannels, setSelectedDiscordChannels] = useState<
 		DiscordChannel[]
 	>(alert?.DiscordChannelsToNotify || [])
@@ -108,6 +112,7 @@ export const AlertConfigurationCard = ({
 			environments: [],
 			slack_channels: [],
 			discord_channels: [],
+			webhook_destinations: [],
 			threshold_window: 30,
 			name: 'Error',
 			regex_groups: [],
@@ -157,7 +162,8 @@ export const AlertConfigurationCard = ({
 				})),
 			name: form.getFieldValue('name'),
 			discord_channels: selectedDiscordChannels,
-		}
+			webhook_destinations: webhooks,
+		} as const
 		const requestBody = {
 			refetchQueries: [namedOperations.Query.GetAlertsPagePayload],
 		}
@@ -590,6 +596,12 @@ export const AlertConfigurationCard = ({
 		setFormTouched(true)
 	}
 
+	const onWebhooksChange = (webhooks: string[]) => {
+		form.setFieldsValue({ webhooks })
+		setWebhooks(webhooks)
+		setFormTouched(true)
+	}
+
 	const onUserPropertiesChange = (_value: any, options: any) => {
 		const userProperties = options.map(
 			({ value: valueAndName }: { key: string; value: string }) => {
@@ -895,6 +907,27 @@ export const AlertConfigurationCard = ({
 									/>
 								)}
 							</Form.Item>
+						</section>
+
+						<section>
+							<h3>Webhooks to Notify</h3>
+							<p>
+								Add webhook destinations for this alert, sent as
+								JSON over HTTP. See the{' '}
+								<Link to="https://www.highlight.io/docs/general/product-features/general-features/alerts/webhooks">
+									docs
+								</Link>{' '}
+								for more info.
+							</p>
+							<Select
+								className={
+									alertConfigurationCardStyles.channelSelect
+								}
+								value={webhooks}
+								mode="tags"
+								placeholder="Select webhook web addresses to send the alert to."
+								onChange={onWebhooksChange}
+							/>
 						</section>
 
 						<section>

--- a/frontend/src/pages/Alerts/EditMonitorPage.tsx
+++ b/frontend/src/pages/Alerts/EditMonitorPage.tsx
@@ -8,6 +8,7 @@ import {
 	DiscordChannel,
 	MetricAggregator,
 	MetricTagFilter,
+	WebhookDestination,
 } from '@graph/schemas'
 import { useAlertsContext } from '@pages/Alerts/AlertsContext/AlertsContext'
 import MonitorConfiguration from '@pages/Alerts/MonitorConfiguration/MonitorConfiguration'
@@ -52,7 +53,7 @@ const EditMonitorPage = ({
 	const [units, setUnits] = useState<string>()
 	const [slackChannels, setSlackChannels] = useState<string[]>([])
 	const [discordChannels, setDiscordChannels] = useState<DiscordChannel[]>([])
-	const [webhooks, setWebhooks] = useState<string[]>([])
+	const [webhooks, setWebhooks] = useState<WebhookDestination[]>([])
 	const [isDisabled, setIsDisabled] = useState<boolean>(false)
 	const [emails, setEmails] = useState<string[]>([])
 	const [updateMonitor] = useUpdateMetricMonitorMutation({

--- a/frontend/src/pages/Alerts/EditMonitorPage.tsx
+++ b/frontend/src/pages/Alerts/EditMonitorPage.tsx
@@ -52,6 +52,7 @@ const EditMonitorPage = ({
 	const [units, setUnits] = useState<string>()
 	const [slackChannels, setSlackChannels] = useState<string[]>([])
 	const [discordChannels, setDiscordChannels] = useState<DiscordChannel[]>([])
+	const [webhooks, setWebhooks] = useState<string[]>([])
 	const [isDisabled, setIsDisabled] = useState<boolean>(false)
 	const [emails, setEmails] = useState<string[]>([])
 	const [updateMonitor] = useUpdateMetricMonitorMutation({
@@ -70,6 +71,7 @@ const EditMonitorPage = ({
 				webhook_channel_id,
 			})),
 			discord_channels: discordChannels,
+			webhook_destinations: webhooks,
 			threshold,
 			filters,
 			units,
@@ -106,6 +108,7 @@ const EditMonitorPage = ({
 				emails_to_notify,
 				disabled,
 				discord_channels_to_notify,
+				webhook_destinations,
 			} = existingMonitor
 
 			setMetricToMonitorName(metric_to_monitor)
@@ -123,6 +126,7 @@ const EditMonitorPage = ({
 			setPeriodMinutes(period || 1)
 			setIsDisabled(disabled)
 			setDiscordChannels(discord_channels_to_notify)
+			setWebhooks(webhook_destinations)
 		}
 
 		if (
@@ -160,6 +164,8 @@ const EditMonitorPage = ({
 						onSlackChannelsChange={setSlackChannels}
 						discordChannels={discordChannels}
 						onDiscordChannelsChange={setDiscordChannels}
+						webhooks={webhooks}
+						onWebhooksChange={setWebhooks}
 						slackChannels={slackChannels}
 						onThresholdChange={setThreshold}
 						onFiltersChange={setFilters}

--- a/frontend/src/pages/Alerts/MonitorConfiguration/MonitorConfiguration.tsx
+++ b/frontend/src/pages/Alerts/MonitorConfiguration/MonitorConfiguration.tsx
@@ -11,6 +11,7 @@ import {
 	DiscordChannel,
 	MetricAggregator,
 	MetricTagFilter,
+	WebhookDestination,
 } from '@graph/schemas'
 import { DiscordChannnelsSection } from '@pages/Alerts/AlertConfigurationCard/DiscordChannelsSection'
 import SyncWithSlackButton from '@pages/Alerts/AlertConfigurationCard/SyncWithSlackButton'
@@ -52,8 +53,8 @@ interface Props {
 	onSlackChannelsChange: (newChannels: string[]) => void
 	discordChannels: DiscordChannel[]
 	onDiscordChannelsChange: (discordChannels: DiscordChannel[]) => void
-	webhooks: string[]
-	onWebhooksChange: (webhooks: string[]) => void
+	webhooks: WebhookDestination[]
+	onWebhooksChange: (webhooks: WebhookDestination[]) => void
 	emails: string[]
 	onEmailsChange: (newEmails: string[]) => void
 	onFormSubmit: (values: any) => void
@@ -553,10 +554,12 @@ const MonitorConfiguration = ({
 					</p>
 					<Select
 						className={alertConfigurationCardStyles.channelSelect}
-						value={webhooks}
+						value={webhooks.map((wh) => wh.url)}
 						mode="tags"
 						placeholder="Select webhook web addresses to send the alert to."
-						onChange={onWebhooksChange}
+						onChange={(whs: string[]) =>
+							onWebhooksChange(whs.map((wh) => ({ url: wh })))
+						}
 					/>
 				</section>
 

--- a/frontend/src/pages/Alerts/MonitorConfiguration/MonitorConfiguration.tsx
+++ b/frontend/src/pages/Alerts/MonitorConfiguration/MonitorConfiguration.tsx
@@ -49,9 +49,11 @@ interface Props {
 	units?: string
 	onUnitsChange: (newUnits: string) => void
 	slackChannels: string[]
-	discordChannels: DiscordChannel[]
 	onSlackChannelsChange: (newChannels: string[]) => void
+	discordChannels: DiscordChannel[]
 	onDiscordChannelsChange: (discordChannels: DiscordChannel[]) => void
+	webhooks: string[]
+	onWebhooksChange: (webhooks: string[]) => void
 	emails: string[]
 	onEmailsChange: (newEmails: string[]) => void
 	onFormSubmit: (values: any) => void
@@ -78,6 +80,8 @@ const MonitorConfiguration = ({
 	monitorName,
 	emails,
 	onEmailsChange,
+	webhooks,
+	onWebhooksChange,
 	threshold,
 	filters,
 	onFormSubmit,
@@ -534,6 +538,25 @@ const MonitorConfiguration = ({
 								</Link>
 							</div>
 						}
+					/>
+				</section>
+
+				<section>
+					<h3>Webhooks to Notify</h3>
+					<p>
+						Add webhook destinations for this alert, sent as JSON
+						over HTTP. See the{' '}
+						<Link to="https://www.highlight.io/docs/general/product-features/general-features/alerts/webhooks">
+							docs
+						</Link>{' '}
+						for more info.
+					</p>
+					<Select
+						className={alertConfigurationCardStyles.channelSelect}
+						value={webhooks}
+						mode="tags"
+						placeholder="Select webhook web addresses to send the alert to."
+						onChange={onWebhooksChange}
 					/>
 				</section>
 

--- a/frontend/src/pages/Alerts/NewAlertPage.tsx
+++ b/frontend/src/pages/Alerts/NewAlertPage.tsx
@@ -173,7 +173,7 @@ const getNewAlert = (type: ALERT_NAMES) => {
 					ThresholdWindow: 30,
 				},
 				configuration: ALERT_CONFIGURATIONS['ERROR_ALERT'],
-			}
+			} as const
 		case snakeCaseString(ALERT_NAMES.TRACK_PROPERTIES_ALERT):
 			return {
 				alert: {
@@ -183,7 +183,7 @@ const getNewAlert = (type: ALERT_NAMES) => {
 					Type: ALERT_TYPE.TrackProperties,
 				},
 				configuration: ALERT_CONFIGURATIONS['TRACK_PROPERTIES_ALERT'],
-			}
+			} as const
 		case snakeCaseString(ALERT_NAMES.SESSION_FEEDBACK_ALERT):
 			return {
 				alert: {
@@ -194,7 +194,7 @@ const getNewAlert = (type: ALERT_NAMES) => {
 					Type: ALERT_TYPE.SessionFeedback,
 				},
 				configuration: ALERT_CONFIGURATIONS['SESSION_FEEDBACK_ALERT'],
-			}
+			} as const
 		case snakeCaseString(ALERT_NAMES.NEW_SESSION_ALERT):
 			return {
 				alert: {
@@ -205,7 +205,7 @@ const getNewAlert = (type: ALERT_NAMES) => {
 					Type: ALERT_TYPE.NewSession,
 				},
 				configuration: ALERT_CONFIGURATIONS['NEW_SESSION_ALERT'],
-			}
+			} as const
 		case snakeCaseString(ALERT_NAMES.NEW_USER_ALERT):
 			return {
 				alert: {
@@ -216,7 +216,7 @@ const getNewAlert = (type: ALERT_NAMES) => {
 					Type: ALERT_TYPE.FirstTimeUser,
 				},
 				configuration: ALERT_CONFIGURATIONS['NEW_USER_ALERT'],
-			}
+			} as const
 		case snakeCaseString(ALERT_NAMES.USER_PROPERTIES_ALERT):
 			return {
 				alert: {
@@ -228,7 +228,7 @@ const getNewAlert = (type: ALERT_NAMES) => {
 					UserProperties: [],
 				},
 				configuration: ALERT_CONFIGURATIONS['USER_PROPERTIES_ALERT'],
-			}
+			} as const
 		case snakeCaseString(ALERT_NAMES.RAGE_CLICK_ALERT):
 			return {
 				alert: {
@@ -239,6 +239,6 @@ const getNewAlert = (type: ALERT_NAMES) => {
 					ThresholdWindow: 30,
 				},
 				configuration: ALERT_CONFIGURATIONS['RAGE_CLICK_ALERT'],
-			}
+			} as const
 	}
 }

--- a/frontend/src/pages/Alerts/NewMonitorPage.tsx
+++ b/frontend/src/pages/Alerts/NewMonitorPage.tsx
@@ -5,6 +5,7 @@ import {
 	DiscordChannel,
 	MetricAggregator,
 	MetricTagFilter,
+	WebhookDestination,
 } from '@graph/schemas'
 import { useAlertsContext } from '@pages/Alerts/AlertsContext/AlertsContext'
 import MonitorConfiguration from '@pages/Alerts/MonitorConfiguration/MonitorConfiguration'
@@ -52,7 +53,7 @@ const NewMonitorPage = ({
 	)
 	const [slackChannels, setSlackChannels] = useState<string[]>([])
 	const [discordChannels, setDiscordChannels] = useState<DiscordChannel[]>([])
-	const [webhooks, setWebhooks] = useState<string[]>([])
+	const [webhooks, setWebhooks] = useState<WebhookDestination[]>([])
 	const [emails, setEmails] = useState<string[]>([])
 	const [units, setUnits] = useState<string>(metricConfig?.units || '')
 	const [createMonitor] = useCreateMetricMonitorMutation({

--- a/frontend/src/pages/Alerts/NewMonitorPage.tsx
+++ b/frontend/src/pages/Alerts/NewMonitorPage.tsx
@@ -52,6 +52,7 @@ const NewMonitorPage = ({
 	)
 	const [slackChannels, setSlackChannels] = useState<string[]>([])
 	const [discordChannels, setDiscordChannels] = useState<DiscordChannel[]>([])
+	const [webhooks, setWebhooks] = useState<string[]>([])
 	const [emails, setEmails] = useState<string[]>([])
 	const [units, setUnits] = useState<string>(metricConfig?.units || '')
 	const [createMonitor] = useCreateMetricMonitorMutation({
@@ -69,6 +70,7 @@ const NewMonitorPage = ({
 				webhook_channel_id,
 			})),
 			discord_channels: discordChannels,
+			webhook_destinations: webhooks,
 			threshold,
 			filters,
 			units,
@@ -114,6 +116,8 @@ const NewMonitorPage = ({
 						slackChannels={slackChannels}
 						discordChannels={discordChannels}
 						onDiscordChannelsChange={setDiscordChannels}
+						webhooks={webhooks}
+						onWebhooksChange={setWebhooks}
 						onThresholdChange={setThreshold}
 						onFiltersChange={setFilters}
 						aggregator={aggregator}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"dev": "run-p --print-label --race 'dev:*'",
 		"dev:backend": "cd backend && make start",
 		"dev:components": "yarn turbo run dev --filter @highlight-run/component-preview...",
-		"dev:frontend": "doppler run -- yarn turbo run dev --filter frontend...",
+		"dev:frontend": "doppler run -- yarn turbo run dev --filter frontend... --filter=!@highlight-run/rrweb...",
 		"dev:ui": "yarn turbo run dev --filter @highlight-run/ui...",
 		"dev:redis": "redis-server",
 		"docker:frontend": "yarn turbo run dev --filter frontend...",


### PR DESCRIPTION
## Summary

Adds a frontend for viewing and editing webhook alerts.
Depends on merging #4678 

## How did you test this change?

Local deploy.

https://www.loom.com/share/e2053fab48c74af58d73cd9fc0f41a22

## Are there any deployment considerations?

No.
