### PR TITLE
warn instead of err for expected errors

### DIFF
--- a/backend/jobs/metric-monitor/metric-monitor.go
+++ b/backend/jobs/metric-monitor/metric-monitor.go
@@ -83,7 +83,7 @@ func processMetricMonitors(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, 
 			continue
 		}
 		if len(payload) < 1 {
-			log.WithContext(ctx).Errorf("invalid metrics payload %+v", payload)
+			log.WithContext(ctx).Warn("invalid empty metrics payload")
 			continue
 		}
 		value = payload[len(payload)-1].Value

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -786,7 +786,18 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 	}
 
 	if projectID == 1 {
-		if errorObj.Event == `input: initializeSession BillingQuotaExceeded` || errorObj.Event == `BillingQuotaExceeded` || errorObj.Event == `panic {error: missing operation context}` || errorObj.Event == `input: could not get json request body: unable to get Request Body unexpected EOF` || errorObj.Event == `no metrics provided` || errorObj.Event == `input: pushMetrics no metrics provided` {
+		if errorObj.Event == `input: initializeSession BillingQuotaExceeded` ||
+			errorObj.Event == `BillingQuotaExceeded` ||
+			errorObj.Event == `panic {error: missing operation context}` ||
+			errorObj.Event == `input: could not get json request body: unable to get Request Body unexpected EOF` ||
+			errorObj.Event == `no metrics provided` ||
+			errorObj.Event == `input: pushMetrics no metrics provided` ||
+			errorObj.Event == `Error updating error group: Filtering out noisy error` ||
+			errorObj.Event == `Error updating error group: Filtering out noisy Highlight error` ||
+			errorObj.Event == `error processing main session: error scanning session payload: error fetching events from Redis: error processing event chunk: The payload has an IncrementalSnapshot before the first FullSnapshot` ||
+			errorObj.Event == `session has reached the max retry count and will be excluded: error scanning session payload: error fetching events from Redis: error processing event chunk: The payload has an IncrementalSnapshot before the first FullSnapshot` ||
+			errorObj.Event == `invalid metrics payload []` ||
+			errorObj.Event == `public-graph graphql request failed` {
 			return nil, ErrNoisyError
 		}
 	}

--- a/backend/util/logging.go
+++ b/backend/util/logging.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -16,7 +17,7 @@ func GraphQLErrorPresenter(service string) func(ctx context.Context, e error) *g
 		log.WithContext(ctx).WithFields(log.Fields{
 			"error": e,
 			"path":  graphql.GetPath(ctx),
-		}).Errorf("%s graphql request failed", service)
+		}).Warnf("%s graphql request failed", service)
 
 		var gqlerr *gqlerror.Error
 		switch t := e.(type) {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1130,11 +1130,12 @@ func (w *Worker) Start(ctx context.Context) {
 						if err := w.Resolver.OpenSearch.Update(opensearch.IndexSessions, session.ID, map[string]interface{}{"Excluded": true}); err != nil {
 							log.WithContext(ctx).WithField("session_secure_id", session.SecureID).Error(e.Wrap(err, "error updating session in opensearch"))
 						}
+						span.Finish()
 					} else {
 						log.WithContext(ctx).WithField("session_secure_id", session.SecureID).Error(e.Wrap(err, "error processing main session"))
+						span.Finish(tracer.WithError(e.Wrapf(err, "error processing session: %v", session.ID)))
 					}
 
-					span.Finish(tracer.WithError(e.Wrapf(err, "error processing session: %v", session.ID)))
 					return
 				}
 				hlog.Incr("sessionsProcessed", nil, 1)

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1126,13 +1126,14 @@ func (w *Worker) Start(ctx context.Context) {
 					}
 
 					if excluded != nil && *excluded {
-						log.WithContext(ctx).WithField("session_secure_id", session.SecureID).Error(e.Wrap(err, "session has reached the max retry count and will be excluded"))
+						log.WithContext(ctx).WithField("session_secure_id", session.SecureID).Warn(e.Wrap(err, "session has reached the max retry count and will be excluded"))
 						if err := w.Resolver.OpenSearch.Update(opensearch.IndexSessions, session.ID, map[string]interface{}{"Excluded": true}); err != nil {
 							log.WithContext(ctx).WithField("session_secure_id", session.SecureID).Error(e.Wrap(err, "error updating session in opensearch"))
 						}
+					} else {
+						log.WithContext(ctx).WithField("session_secure_id", session.SecureID).Error(e.Wrap(err, "error processing main session"))
 					}
 
-					log.WithContext(ctx).WithField("session_secure_id", session.SecureID).Error(e.Wrap(err, "error processing main session"))
 					span.Finish(tracer.WithError(e.Wrapf(err, "error processing session: %v", session.ID)))
 					return
 				}


### PR DESCRIPTION
## Summary
- there are a bunch of "expected" errors - now that error logs are creating Highlight error groups, this is causing us to build up a Kafka backlog
- these should be treated as log level WARN
<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor in prod after deployment, expecting backlog to resolve
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
