### PR TITLE
ensure go sdk does not panic if middleware added without start

### DIFF
--- a/sdk/highlight-go/middleware/chi/middleware.go
+++ b/sdk/highlight-go/middleware/chi/middleware.go
@@ -1,6 +1,7 @@
 package chi
 
 import (
+	"github.com/highlight/highlight/sdk/highlight-go/middleware"
 	"net/http"
 
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -13,6 +14,7 @@ import (
 // ...
 // r.Use(highlightchi.Middleware)
 func Middleware(next http.Handler) http.Handler {
+	middleware.CheckStatus()
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := highlight.InterceptRequest(r)
 		r = r.WithContext(ctx)

--- a/sdk/highlight-go/middleware/fiber/middleware.go
+++ b/sdk/highlight-go/middleware/fiber/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/gofiber/fiber/v2"
 	"github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/highlight/highlight/sdk/highlight-go/middleware"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"strings"
@@ -17,6 +18,7 @@ import (
 // r.Use(highlightfiber.Middleware())
 
 func Middleware() fiber.Handler {
+	middleware.CheckStatus()
 	return func(c *fiber.Ctx) error {
 		ctx := c.UserContext()
 		highlightReqDetails := c.Request().Header.Peek("X-Highlight-Request")

--- a/sdk/highlight-go/middleware/gin/middleware.go
+++ b/sdk/highlight-go/middleware/gin/middleware.go
@@ -1,6 +1,7 @@
 package gin
 
 import (
+	"github.com/highlight/highlight/sdk/highlight-go/middleware"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -15,6 +16,7 @@ import (
 // ...
 // r.Use(highlightgin.Middleware())
 func Middleware() gin.HandlerFunc {
+	middleware.CheckStatus()
 	return func(c *gin.Context) {
 		highlightReqDetails := c.GetHeader("X-Highlight-Request")
 		ids := strings.Split(highlightReqDetails, "/")

--- a/sdk/highlight-go/middleware/gorillamux/middleware.go
+++ b/sdk/highlight-go/middleware/gorillamux/middleware.go
@@ -1,6 +1,7 @@
 package gorillamux
 
 import (
+	"github.com/highlight/highlight/sdk/highlight-go/middleware"
 	"net/http"
 
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -13,6 +14,7 @@ import (
 // ...
 // r.Use(highlightgorilla.Middleware)
 func Middleware(next http.Handler) http.Handler {
+	middleware.CheckStatus()
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := highlight.InterceptRequest(r)
 		r = r.WithContext(ctx)

--- a/sdk/highlight-go/middleware/util.go
+++ b/sdk/highlight-go/middleware/util.go
@@ -1,0 +1,12 @@
+package middleware
+
+import (
+	"github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/sirupsen/logrus"
+)
+
+func CheckStatus() {
+	if !highlight.IsRunning() {
+		logrus.Errorf("[highlight-go] middleware added but highlight is not running. did you forget to run `H.Start(); defer H.Stop()`?")
+	}
+}


### PR DESCRIPTION
## Summary

As reported by courtyard, the go SDK will panic if a middleware is added without an `H.Start()` call.
Ensures we do not panic in this case and adds an error log to ensure the SDK is set up correctly.

## How did you test this change?

Local invocation of the fiber e2e app without `H.start()`
<img width="1224" alt="Screenshot 2023-03-24 at 10 25 35 AM" src="https://user-images.githubusercontent.com/1351531/227597400-c1d8e93e-c8ac-4a86-9121-3ca4a71718ee.png">

## Are there any deployment considerations?

Will publish new go sdk version.
