### PR TITLE
cleanup error loading

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -645,6 +645,17 @@ func (r *Resolver) SetErrorFrequenciesInflux(ctx context.Context, projectID int,
 			if err != nil {
 				log.WithContext(ctx).Error(err)
 			}
+			endDate := time.Now().UTC().AddDate(0, 0, -1)
+			startDate := endDate.AddDate(0, 0, -1*(lookbackPeriod-1))
+			for curDate := startDate; !curDate.After(endDate); curDate = curDate.AddDate(0, 0, 1) {
+				eg.ErrorFrequency = append(eg.ErrorFrequency, 0)
+				eg.ErrorMetrics = append(eg.ErrorMetrics, &struct {
+					ErrorGroupID int
+					Date         time.Time
+					Name         string
+					Value        int64
+				}{ErrorGroupID: eg.ID, Date: curDate.Truncate(24 * time.Hour), Name: "count", Value: 0})
+			}
 			for _, r := range results {
 				if r.Name == "count" {
 					eg.ErrorFrequency = append(eg.ErrorFrequency, r.Value)

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -627,7 +627,6 @@ func (r *Resolver) SetErrorFrequenciesInflux(ctx context.Context, projectID int,
 		ResolutionMinutes: 24 * 60,
 	}
 	var errorGroupMap = make(map[string]*model.ErrorGroup)
-	var errorGroupIDs []int
 	for _, errorGroup := range errorGroups {
 		errorGroup.ErrorMetrics = []*struct {
 			ErrorGroupID int
@@ -636,7 +635,6 @@ func (r *Resolver) SetErrorFrequenciesInflux(ctx context.Context, projectID int,
 			Value        int64
 		}{}
 		errorGroupMap[strconv.Itoa(errorGroup.ID)] = errorGroup
-		errorGroupIDs = append(errorGroupIDs, errorGroup.ID)
 	}
 	var oldErrorGroupIDs []int
 	var err error

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -766,7 +766,7 @@ export const AlertConfigurationCard = ({
 						)}
 
 						<section>
-							<h3>Channels to Notify</h3>
+							<h3>Slack Channels to Notify</h3>
 							<p>
 								Pick Slack channels or people to message when an
 								alert is created.

--- a/frontend/src/pages/Alerts/AlertSetupModal/AlertSetupModal.tsx
+++ b/frontend/src/pages/Alerts/AlertSetupModal/AlertSetupModal.tsx
@@ -269,7 +269,7 @@ const AlertSetupModal = () => {
 			title: 'Select Channels',
 			content: (
 				<>
-					<h3>Channels to Notify</h3>
+					<h3>Slack Channels to Notify</h3>
 					<p className={styles.stepDescription}>
 						Pick Slack channels or people to message when an alert
 						is created.

--- a/frontend/src/pages/Alerts/MonitorConfiguration/MonitorConfiguration.tsx
+++ b/frontend/src/pages/Alerts/MonitorConfiguration/MonitorConfiguration.tsx
@@ -429,7 +429,7 @@ const MonitorConfiguration = ({
 				</section>
 
 				<section>
-					<h3>Channels to Notify</h3>
+					<h3>Slack Channels to Notify</h3>
 					<p>
 						Pick Slack channels or people to message when an alert
 						is created.

--- a/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
@@ -5,7 +5,7 @@ import { DateHistogramBucketSize } from '@graph/schemas'
 import { useErrorSearchContext } from '@pages/Errors/ErrorSearchContext/ErrorSearchContext'
 import { updateQueriedTimeRange } from '@pages/Sessions/SessionsFeedV3/SessionQueryBuilder/components/QueryBuilder/QueryBuilder'
 import { useParams } from '@util/react-router/useParams'
-import { roundDateToMinute, serializeAbsoluteTimeRange } from '@util/time'
+import { roundFeedDate, serializeAbsoluteTimeRange } from '@util/time'
 import React, { useCallback } from 'react'
 
 import { TIME_RANGE_FIELD } from '../ErrorQueryBuilder/ErrorQueryBuilder'
@@ -24,10 +24,10 @@ const ErrorFeedHistogram = React.memo(() => {
 				time_zone:
 					Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'UTC',
 				bounds: {
-					start_date: roundDateToMinute(
+					start_date: roundFeedDate(
 						backendSearchQuery?.startDate.toISOString() ?? null,
 					).format(),
-					end_date: roundDateToMinute(
+					end_date: roundFeedDate(
 						backendSearchQuery?.endDate.toISOString() ?? null,
 					).format(),
 				},

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -39,6 +39,7 @@ import {
 	RightPanelView,
 	usePlayerUIContext,
 } from '@pages/Player/context/PlayerUIContext'
+import { PlayerSearchParameters } from '@pages/Player/PlayerHook/utils'
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import { Tab } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import {
@@ -372,7 +373,7 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 
 								navigate(
 									`/${projectId}/sessions/${errorObject.session?.secure_id}` +
-										`?tsAbs=${errorObject.timestamp}`,
+										`?${PlayerSearchParameters.tsAbs}=${errorObject.timestamp}`,
 								)
 								setShowLeftPanel(false)
 								setShowRightPanel(true)

--- a/frontend/src/pages/ErrorsV2/utils.ts
+++ b/frontend/src/pages/ErrorsV2/utils.ts
@@ -16,6 +16,13 @@ export const getErrorGroupStats = function (
 	if (counts.length < lookbackDays) {
 		counts = [...Array(lookbackDays - counts.length).fill(0), ...counts]
 	}
+
+	console.log('vadim', {
+		counts,
+		errorGroup,
+		secure: (errorGroup as ErrorGroup).secure_id,
+	})
+
 	const totalCount = counts?.reduce((a, b) => a + b, 0) || 1
 	const userCount =
 		errorGroup?.error_metrics

--- a/frontend/src/pages/ErrorsV2/utils.ts
+++ b/frontend/src/pages/ErrorsV2/utils.ts
@@ -17,12 +17,6 @@ export const getErrorGroupStats = function (
 		counts = [...Array(lookbackDays - counts.length).fill(0), ...counts]
 	}
 
-	console.log('vadim', {
-		counts,
-		errorGroup,
-		secure: (errorGroup as ErrorGroup).secure_id,
-	})
-
 	const totalCount = counts?.reduce((a, b) => a + b, 0) || 1
 	const userCount =
 		errorGroup?.error_metrics

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -887,6 +887,15 @@ export const usePlayer = (): ReplayerContextInterface => {
 			sessionIntervals,
 			timelineIndicatorEvents,
 		})
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [
+		sessionPayload,
+		sessionIntervals,
+		timelineIndicatorEvents,
+		chunkEventsSet,
+	])
+
+	useEffect(() => {
 		if (state.replayerState <= ReplayerState.Loading) {
 			pause(0).then()
 		}
@@ -896,12 +905,7 @@ export const usePlayer = (): ReplayerContextInterface => {
 			state.errors,
 		)
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [
-		sessionPayload,
-		sessionIntervals,
-		timelineIndicatorEvents,
-		chunkEventsSet,
-	])
+	}, [state.sessionMetadata])
 
 	useEffect(() => {
 		if (state.replayer) {

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -191,9 +191,8 @@ export const usePlayer = (): ReplayerContextInterface => {
 		fetchEventChunkURL,
 	})
 
-	const { setPlayerTimestamp } = useSetPlayerTimestampFromSearchParam(
-		(t) => seek(t),
-		state.replayer,
+	const { setPlayerTimestamp } = useSetPlayerTimestampFromSearchParam((t) =>
+		seek(t),
 	)
 
 	const resetPlayer = useCallback(() => {

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -887,6 +887,9 @@ export const usePlayer = (): ReplayerContextInterface => {
 			sessionIntervals,
 			timelineIndicatorEvents,
 		})
+		if (state.replayerState <= ReplayerState.Loading) {
+			pause(0).then()
+		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		sessionPayload,
@@ -896,9 +899,6 @@ export const usePlayer = (): ReplayerContextInterface => {
 	])
 
 	useEffect(() => {
-		if (state.replayerState <= ReplayerState.Loading) {
-			pause(0).then()
-		}
 		setPlayerTimestamp(
 			state.sessionMetadata.totalTime,
 			state.sessionMetadata.startTime,

--- a/frontend/src/pages/Player/PlayerHook/utils/index.tsx
+++ b/frontend/src/pages/Player/PlayerHook/utils/index.tsx
@@ -244,7 +244,6 @@ export const useSetPlayerTimestampFromSearchParam = (
 		},
 		[
 			location.search,
-			replayer,
 			selectedTimelineAnnotationTypes,
 			setSelectedTimelineAnnotationTypes,
 			setTime,

--- a/frontend/src/pages/Player/PlayerHook/utils/index.tsx
+++ b/frontend/src/pages/Player/PlayerHook/utils/index.tsx
@@ -151,7 +151,6 @@ export enum PlayerSearchParameters {
  */
 export const useSetPlayerTimestampFromSearchParam = (
 	setTime: (newTime: number) => void,
-	replayer?: Replayer,
 ) => {
 	const location = useLocation()
 	const searchParams = new URLSearchParams(location.search)

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/components/QueryBuilder/QueryBuilder.tsx
@@ -57,7 +57,7 @@ import {
 import { gqlSanitize } from '@util/gql'
 import { formatNumber } from '@util/numbers'
 import { useParams } from '@util/react-router/useParams'
-import { roundDateToMinute, serializeAbsoluteTimeRange } from '@util/time'
+import { roundFeedDate, serializeAbsoluteTimeRange } from '@util/time'
 import { QueryBuilderStateParam } from '@util/url/params'
 import { Checkbox, message } from 'antd'
 import clsx, { ClassValue } from 'clsx'
@@ -328,7 +328,7 @@ export const getAbsoluteStartTime = (value?: string): string | null => {
 		// value is a relative duration such as '7 days', subtract it from current time
 		const amount = parseInt(value.split(' ')[0])
 		const unit = value.split(' ')[1].toLowerCase()
-		return roundDateToMinute(
+		return roundFeedDate(
 			moment()
 				.subtract(amount, unit as unitOfTime.DurationConstructor)
 				.toISOString(),
@@ -340,7 +340,7 @@ export const getAbsoluteEndTime = (value?: string): string | null => {
 	if (!value) return null
 	if (!isAbsoluteTimeRange(value)) {
 		// value is a relative duration such as '7 days', use current time as end of range
-		return roundDateToMinute(moment().toISOString()).toISOString()
+		return roundFeedDate(moment().toISOString()).toISOString()
 	}
 	return value!.split('_')[1]
 }
@@ -1824,10 +1824,10 @@ function QueryBuilder(props: QueryBuilderProps) {
 
 	const updateSerializedQuery = useCallback(
 		(isAnd: boolean, rules: RuleProps[]) => {
-			const startDate = roundDateToMinute(
+			const startDate = roundFeedDate(
 				getAbsoluteStartTime(timeRangeRule.val?.options[0].value),
 			)
-			const endDate = roundDateToMinute(
+			const endDate = roundFeedDate(
 				getAbsoluteEndTime(timeRangeRule.val?.options[0].value),
 			)
 			const searchQuery = parseGroup(isAnd, rules)

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -41,7 +41,7 @@ import SessionQueryBuilder, {
 import { useGlobalContext } from '@routers/ProjectRouter/context/GlobalContext'
 import { useIntegrated } from '@util/integrated'
 import { useParams } from '@util/react-router/useParams'
-import { roundDateToMinute, serializeAbsoluteTimeRange } from '@util/time'
+import { roundFeedDate, serializeAbsoluteTimeRange } from '@util/time'
 import clsx from 'clsx'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 import { styledVerticalScrollbar } from 'style/common.css'
@@ -79,10 +79,10 @@ export const SessionsHistogram: React.FC<SessionsHistogramProps> = React.memo(
 						Intl.DateTimeFormat().resolvedOptions().timeZone ??
 						'UTC',
 					bounds: {
-						start_date: roundDateToMinute(
+						start_date: roundFeedDate(
 							backendSearchQuery?.startDate.toISOString() ?? null,
 						).format(),
-						end_date: roundDateToMinute(
+						end_date: roundFeedDate(
 							backendSearchQuery?.endDate.toISOString() ?? null,
 						).format(),
 					},

--- a/frontend/src/util/preload.ts
+++ b/frontend/src/util/preload.ts
@@ -23,7 +23,7 @@ import { indexeddbEnabled, indexedDBFetch, IndexedDBLink } from '@util/db'
 import { client } from '@util/graph'
 import log from '@util/log'
 import { useParams } from '@util/react-router/useParams'
-import { roundDateToMinute } from '@util/time'
+import { roundFeedDate } from '@util/time'
 import { H } from 'highlight.run'
 import moment from 'moment'
 import { useEffect, useRef } from 'react'
@@ -40,7 +40,7 @@ export const usePreloadSessions = function ({
 	const { project_id } = useParams<{
 		project_id: string
 	}>()
-	const endDate = useRef<moment.Moment>(roundDateToMinute(null))
+	const endDate = useRef<moment.Moment>(roundFeedDate(null))
 	const preloadedPages = useRef<Set<number>>(new Set<number>())
 
 	// only load the first page
@@ -116,7 +116,7 @@ export const usePreloadErrors = function ({
 	const { project_id } = useParams<{
 		project_id: string
 	}>()
-	const endDate = useRef<moment.Moment>(roundDateToMinute(null))
+	const endDate = useRef<moment.Moment>(roundFeedDate(null))
 	const preloadedPages = useRef<Set<number>>(new Set<number>())
 
 	// only load the first page

--- a/frontend/src/util/time.ts
+++ b/frontend/src/util/time.ts
@@ -80,8 +80,14 @@ export const serializeAbsoluteTimeRange = (
 	return `${startIso}_${endIso}`
 }
 
-export const roundDateToMinute = function (date: string | null) {
-	return moment(moment(date || undefined).format('MM/DD/YYYY HH:mm'))
+export const roundFeedDate = function (date: string | null) {
+	// nearest 15 seconds
+	const factor = 15
+	const m = moment(date || undefined)
+	return moment(m.format('MM/DD/YYYY HH:mm')).add(
+		Math.round(m.seconds() / factor) * factor,
+		'seconds',
+	)
 }
 
 export const wait = (ms: number) => new Promise((res) => setTimeout(res, ms))


### PR DESCRIPTION
## Summary

Tweaks local error group loading per some feedback.
* errors feed refresh icon does not refresh instances (only refreshes error group)
* error instance / user count not working correctly for new errors
* clicking show session from error opens session in weird state (does not move player to right time
* updates `channels to notify` -> `slack channels to notify` to be more specific

## How did you test this change?

Local deploy.

Correct instances for new error.

<img width="1005" alt="Screenshot 2023-03-27 at 12 45 13 AM" src="https://user-images.githubusercontent.com/1351531/227874686-62052d50-9701-46fe-9595-d7ef0b38c892.png">


## Are there any deployment considerations?

No.