### PR TITLE
flush batched messages based on inner count

### DIFF
--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -94,6 +94,7 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 				switch lastMsg.Type {
 				case kafkaqueue.PushLogs:
 					logRows = append(logRows, lastMsg.PushLogs.LogRows...)
+					received += len(lastMsg.PushLogs.LogRows)
 				case kafkaqueue.MarkBackendSetup:
 					if lastMsg.MarkBackendSetup.ProjectID != 0 {
 						setupProjectIDs[lastMsg.MarkBackendSetup.ProjectID] = true
@@ -102,8 +103,8 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 					} else {
 						log.WithContext(ctx).Errorf("invalid MarkBackendSetup message %+v", lastMsg.MarkBackendSetup)
 					}
+					received += 1
 				}
-				received += 1
 				if received >= BatchFlushSize {
 					return
 				}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -420,7 +420,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 
 func (w *Worker) PublicWorker(ctx context.Context) {
 	const parallelWorkers = 64
-	const parallelBatchWorkers = 8
+	const parallelBatchWorkers = 16
 	// creates N parallel kafka message consumers that process messages.
 	// each consumer is considered part of the same consumer group and gets
 	// allocated a slice of all partitions. this ensures that a particular subset of partitions

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -420,7 +420,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 
 func (w *Worker) PublicWorker(ctx context.Context) {
 	const parallelWorkers = 64
-	const parallelBatchWorkers = 16
+	const parallelBatchWorkers = 8
 	// creates N parallel kafka message consumers that process messages.
 	// each consumer is considered part of the same consumer group and gets
 	// allocated a slice of all partitions. this ensures that a particular subset of partitions


### PR DESCRIPTION
## Summary

Ensure batches message flushing happens based on the inner count of messages to avoid OOM
due to a large batch of OTLP messages coming in.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

Monitoring kafka backlog.