### PR TITLE
exclude exception tags and limit log attributes

### DIFF
--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -1,6 +1,7 @@
 package clickhouse
 
 import (
+	"context"
 	"fmt"
 	model2 "github.com/highlight-run/highlight/backend/model"
 	e "github.com/pkg/errors"
@@ -13,6 +14,8 @@ import (
 	"github.com/highlight/highlight/sdk/highlight-go"
 	log "github.com/sirupsen/logrus"
 )
+
+const LogAttributeValueLengthLimit = 2 << 15
 
 func ProjectToInt(projectID string) (int, error) {
 	i, err := strconv.ParseInt(projectID, 10, 32)
@@ -73,9 +76,9 @@ func (l *LogRow) Cursor() string {
 
 type LogRowOption func(*LogRow)
 
-func WithLogAttributes(resourceAttributes, spanAttributes, eventAttributes map[string]any, isFrontendLog bool) LogRowOption {
+func WithLogAttributes(ctx context.Context, resourceAttributes, spanAttributes, eventAttributes map[string]any, isFrontendLog bool) LogRowOption {
 	return func(h *LogRow) {
-		h.LogAttributes = GetAttributesMap(resourceAttributes, spanAttributes, eventAttributes, isFrontendLog)
+		h.LogAttributes = GetAttributesMap(ctx, resourceAttributes, spanAttributes, eventAttributes, isFrontendLog)
 	}
 }
 
@@ -125,42 +128,37 @@ func cast[T string | int64 | float64](v interface{}, fallback T) T {
 	return c
 }
 
-func GetAttributesMap(resourceAttributes, spanAttributes, eventAttributes map[string]any, isFrontendLog bool) map[string]string {
+func GetAttributesMap(ctx context.Context, resourceAttributes, spanAttributes, eventAttributes map[string]any, isFrontendLog bool) map[string]string {
 	attributesMap := make(map[string]string)
 	for _, m := range []map[string]any{resourceAttributes, spanAttributes, eventAttributes} {
 		for k, v := range m {
-			shouldSkip := false
+			prefixes := highlight.InternalAttributePrefixes
+			if isFrontendLog {
+				prefixes = append(prefixes, highlight.BackendOnlyAttributePrefixes...)
+			}
 
-			for _, attr := range highlight.InternalAttributes {
-				if k == attr {
+			shouldSkip := false
+			for _, prefix := range prefixes {
+				if strings.HasPrefix(k, prefix) {
 					shouldSkip = true
 					break
 				}
 			}
-
-			if isFrontendLog {
-				for _, attr := range highlight.BackendOnlyAttributePrefixes {
-					if strings.HasPrefix(k, attr) {
-						shouldSkip = true
-						break
-					}
-				}
-			}
-
 			if shouldSkip {
 				continue
 			}
 
-			vStr := cast(v, "")
-			if vStr != "" {
+			if vStr, ok := v.(string); ok {
+				if len(vStr) > LogAttributeValueLengthLimit {
+					log.WithContext(ctx).Warnf("attribute value for %s is too long %d", k, len(vStr))
+					continue
+				}
 				attributesMap[k] = vStr
 			}
-			vInt := cast[int64](v, 0)
-			if vInt != 0 {
+			if vInt, ok := v.(int64); ok {
 				attributesMap[k] = strconv.FormatInt(vInt, 10)
 			}
-			vFlt := cast(v, 0.)
-			if vFlt > 0. {
+			if vFlt, ok := v.(float64); ok {
 				attributesMap[k] = strconv.FormatFloat(vFlt, 'f', -1, 64)
 			}
 		}

--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -99,8 +99,14 @@ func WithSource(source string) LogRowOption {
 	}
 }
 
-func WithBody(body string) LogRowOption {
+func WithBody(ctx context.Context, body string) LogRowOption {
 	return func(h *LogRow) {
+		if len(body) > LogAttributeValueLengthLimit {
+			log.WithContext(ctx).
+				WithField("ValueLength", len(body)).
+				Warnf("log body value is too long %d", len(body))
+			body = body[:LogAttributeValueLengthLimit] + "..."
+		}
 		h.Body = body
 	}
 }

--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -120,14 +120,6 @@ func WithProjectIDString(projectID string) LogRowOption {
 	}
 }
 
-func cast[T string | int64 | float64](v interface{}, fallback T) T {
-	c, ok := v.(T)
-	if !ok {
-		return fallback
-	}
-	return c
-}
-
 func GetAttributesMap(ctx context.Context, resourceAttributes, spanAttributes, eventAttributes map[string]any, isFrontendLog bool) map[string]string {
 	attributesMap := make(map[string]string)
 	for _, m := range []map[string]any{resourceAttributes, spanAttributes, eventAttributes} {

--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -26,3 +26,29 @@ func TestNewLogRowWithSeverityText(t *testing.T) {
 	assert.Equal(t, "info", NewLogRow(LogRowPrimaryAttrs{}, WithSeverityText("dir")).SeverityText, "it defaults to info when unknown")
 	assert.Equal(t, int32(4), NewLogRow(LogRowPrimaryAttrs{}, WithSeverityText("dir")).SeverityNumber, "it handles figuring out the severity number")
 }
+
+func TestNewLogRowWithException(t *testing.T) {
+	ctx := context.TODO()
+	var resourceAttributes, spanAttributes, eventAttributes map[string]any
+	resourceAttributes = map[string]any{
+		"exception.message":    "foo",
+		"exception.stacktrace": "bar",
+		"exception.type":       "baz",
+	}
+	lr := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, false))
+	assert.Equal(t, "", lr.LogAttributes["exception.message"])
+	assert.Equal(t, "", lr.LogAttributes["exception.stacktrace"])
+	assert.Equal(t, "baz", lr.LogAttributes["exception.type"])
+}
+
+func TestNewLogRowWithLongField(t *testing.T) {
+	ctx := context.TODO()
+	var resourceAttributes, spanAttributes, eventAttributes map[string]any
+	var value string
+	for i := 0; i < 2<<16; i++ {
+		value += "a"
+	}
+	spanAttributes = map[string]any{"foo": value}
+	lr := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, false))
+	assert.Equal(t, 2048+3, len(lr.LogAttributes["foo"]))
+}

--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -1,6 +1,7 @@
 package clickhouse
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,11 +12,11 @@ func TestNewLogRowWithLogAttributes(t *testing.T) {
 	spanAttributes := map[string]any{"highlight.source": "frontend", "foo": "bar"}
 	eventAttributes := map[string]any{"log.severity": "info"} // should be skipped since this is an internal attribute
 
-	logRow := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(resourceAttributes, spanAttributes, eventAttributes, false))
+	logRow := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(context.TODO(), resourceAttributes, spanAttributes, eventAttributes, false))
 
 	assert.Equal(t, map[string]string{"foo": "bar", "os.description": "Debian GNU/Linux 11 (bullseye)"}, logRow.LogAttributes)
 
-	logRow = NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(resourceAttributes, spanAttributes, eventAttributes, true))
+	logRow = NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(context.TODO(), resourceAttributes, spanAttributes, eventAttributes, true))
 
 	assert.Equal(t, map[string]string{"foo": "bar"}, logRow.LogAttributes)
 }

--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -52,3 +52,13 @@ func TestNewLogRowWithLongField(t *testing.T) {
 	lr := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, false))
 	assert.Equal(t, 2048+3, len(lr.LogAttributes["foo"]))
 }
+
+func TestNewLogRowWithLongBody(t *testing.T) {
+	ctx := context.TODO()
+	var body string
+	for i := 0; i < 2<<16; i++ {
+		body += "a"
+	}
+	lr := NewLogRow(LogRowPrimaryAttrs{}, WithBody(ctx, body))
+	assert.Equal(t, 2048+3, len(lr.Body))
+}

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -74,7 +74,7 @@ func getLogRow(ctx context.Context, ts time.Time, lvl, projectID, sessionID, tra
 			SpanId:          spanID,
 			SecureSessionId: sessionID,
 		},
-		clickhouse.WithBody(excMessage),
+		clickhouse.WithBody(ctx, excMessage),
 		clickhouse.WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, source == highlight.SourceAttributeFrontend),
 		clickhouse.WithProjectIDString(projectID),
 		clickhouse.WithServiceName(cast(resourceAttributes[string(semconv.ServiceNameKey)], "")),

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -66,7 +66,7 @@ func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestI
 	}
 }
 
-func getLogRow(ts time.Time, lvl, projectID, sessionID, traceID, spanID string, excMessage string, resourceAttributes, spanAttributes, eventAttributes map[string]any, source string) *clickhouse.LogRow {
+func getLogRow(ctx context.Context, ts time.Time, lvl, projectID, sessionID, traceID, spanID string, excMessage string, resourceAttributes, spanAttributes, eventAttributes map[string]any, source string) *clickhouse.LogRow {
 	return clickhouse.NewLogRow(
 		clickhouse.LogRowPrimaryAttrs{
 			Timestamp:       ts,
@@ -75,7 +75,7 @@ func getLogRow(ts time.Time, lvl, projectID, sessionID, traceID, spanID string, 
 			SecureSessionId: sessionID,
 		},
 		clickhouse.WithBody(excMessage),
-		clickhouse.WithLogAttributes(resourceAttributes, spanAttributes, eventAttributes, source == highlight.SourceAttributeFrontend),
+		clickhouse.WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, source == highlight.SourceAttributeFrontend),
 		clickhouse.WithProjectIDString(projectID),
 		clickhouse.WithServiceName(cast(resourceAttributes[string(semconv.ServiceNameKey)], "")),
 		clickhouse.WithSeverityText(lvl),
@@ -95,7 +95,7 @@ func getBackendError(ctx context.Context, ts time.Time, projectID, sessionID, re
 		stackTrace = ""
 	}
 	stackTrace = formatStructureStackTrace(ctx, stackTrace)
-	payloadBytes, _ := json.Marshal(clickhouse.GetAttributesMap(resourceAttributes, spanAttributes, eventAttributes, false))
+	payloadBytes, _ := json.Marshal(clickhouse.GetAttributesMap(ctx, resourceAttributes, spanAttributes, eventAttributes, false))
 	err := &model.BackendErrorObjectInput{
 		SessionSecureID: &sessionID,
 		RequestID:       &requestID,
@@ -180,7 +180,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						ts := event.Timestamp().AsTime()
 
 						var logCursor *string
-						logRow := getLogRow(ts, "ERROR", projectID, sessionID, traceID, spanID, excMessage, resourceAttributes, spanAttributes, eventAttributes, source)
+						logRow := getLogRow(ctx, ts, "ERROR", projectID, sessionID, traceID, spanID, excMessage, resourceAttributes, spanAttributes, eventAttributes, source)
 						projectLogs[projectID] = append(projectLogs[projectID], logRow)
 						logCursor = pointy.String(logRow.Cursor())
 
@@ -207,7 +207,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						}
 
 						var logCursor *string
-						logRow := getLogRow(ts, logSev, projectID, sessionID, traceID, spanID, logMessage, resourceAttributes, spanAttributes, eventAttributes, source)
+						logRow := getLogRow(ctx, ts, logSev, projectID, sessionID, traceID, spanID, logMessage, resourceAttributes, spanAttributes, eventAttributes, source)
 						projectLogs[projectID] = append(projectLogs[projectID], logRow)
 						logCursor = pointy.String(logRow.Cursor())
 
@@ -371,7 +371,7 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 					ProjectId:       uint32(projectIDInt),
 					SecureSessionId: sessionID,
 				},
-					clickhouse.WithLogAttributes(resourceAttributes, scopeAttributes, logAttributes, false),
+					clickhouse.WithLogAttributes(ctx, resourceAttributes, scopeAttributes, logAttributes, false),
 					clickhouse.WithSeverityText(logRecord.SeverityText()),
 				)
 

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -35,7 +35,7 @@ const LogEvent = "log"
 const LogSeverityAttribute = "log.severity"
 const LogMessageAttribute = "log.message"
 
-var InternalAttributes = []string{
+var InternalAttributePrefixes = []string{
 	DeprecatedProjectIDAttribute,
 	DeprecatedSessionIDAttribute,
 	DeprecatedRequestIDAttribute,
@@ -46,6 +46,8 @@ var InternalAttributes = []string{
 	SourceAttribute,
 	LogMessageAttribute,
 	LogSeverityAttribute,
+	// exception should be parsed as structured and not included as part of log attributes
+	"exception.",
 }
 
 var BackendOnlyAttributePrefixes = []string{

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -47,7 +47,8 @@ var InternalAttributePrefixes = []string{
 	LogMessageAttribute,
 	LogSeverityAttribute,
 	// exception should be parsed as structured and not included as part of log attributes
-	"exception.",
+	"exception.message",
+	"exception.stacktrace",
 }
 
 var BackendOnlyAttributePrefixes = []string{


### PR DESCRIPTION
## Summary

Removes `exception.` attributes from logs since they are bloating `LogAttributes` and are not useful. 
For error stacktraces, we parse and structure them anyway.
Adds a limit to tag values at 64K characters. 
This is a pretty high limit but prevents arbitrarily-large values from being sent.

## How did you test this change?

<img width="1338" alt="Screenshot 2023-03-26 at 10 10 33 PM" src="https://user-images.githubusercontent.com/1351531/227846352-61874be8-6d27-4ce5-b969-659fc2e564af.png">

## Are there any deployment considerations?

No