### PR TITLE
Fix handling of quotes in logs queries

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,6 +99,7 @@
 		"lint:fix": "eslint ./src --fix",
 		"sourcemaps": "npx --yes @highlight-run/sourcemap-uploader upload --apiKey \"${HIGHLIGHT_API_KEY}\" --appVersion \"${APP_VERSION}\" --path ./build",
 		"test": "TZ=UTC vitest --run",
+		"test:watch": "TZ=UTC vitest",
 		"types:check": "tsc -noEmit",
 		"analyze": "source-map-explorer 'build/static/js/*.js'",
 		"svg": "svgr --typescript ./src/static --out-dir ./src/static --icon && yarn lint:es",

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -24,6 +24,7 @@ import {
 import {
 	DEFAULT_LOGS_OPERATOR,
 	LogsSearchParam,
+	quoteQueryValue,
 	stringifyLogsQuery,
 } from '@pages/LogsPage/SearchForm/utils'
 import { LogEdgeWithError } from '@pages/LogsPage/useGetLogs'
@@ -395,7 +396,9 @@ const LogValue: React.FC<{
 											? (queryTerms[index].value = value)
 											: queryTerms.push({
 													key: queryKey,
-													value,
+													value: quoteQueryValue(
+														value,
+													),
 													operator:
 														DEFAULT_LOGS_OPERATOR,
 													offsetStart: 0, // not actually used

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -22,6 +22,7 @@ import {
 	BODY_KEY,
 	LogsSearchParam,
 	parseLogsQuery,
+	quoteQueryValue,
 	stringifyLogsQuery,
 } from '@pages/LogsPage/SearchForm/utils'
 import { useParams } from '@util/react-router/useParams'
@@ -211,8 +212,7 @@ const Search: React.FC<{
 
 		// If string, it's a value not a key
 		if (isValueSelect) {
-			queryTerms[activeTermIndex].value =
-				key.indexOf(' ') > -1 ? `"${key}"` : key
+			queryTerms[activeTermIndex].value = quoteQueryValue(key)
 		} else {
 			queryTerms[activeTermIndex].key = key.name
 			queryTerms[activeTermIndex].value = ''

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -125,7 +125,11 @@ const Search: React.FC<{
 	const { project_id } = useParams()
 	const containerRef = useRef<HTMLDivElement | null>(null)
 	const inputRef = useRef<HTMLInputElement | null>(null)
-	const state = useComboboxState({ gutter: 10, sameWidth: true })
+	const state = useComboboxState({
+		gutter: 10,
+		sameWidth: true,
+		defaultValue: initialQuery ?? '',
+	})
 	const [getLogsKeyValues, { data, loading: valuesLoading }] =
 		useGetLogsKeyValuesLazyQuery()
 
@@ -207,7 +211,8 @@ const Search: React.FC<{
 
 		// If string, it's a value not a key
 		if (isValueSelect) {
-			queryTerms[activeTermIndex].value = key
+			queryTerms[activeTermIndex].value =
+				key.indexOf(' ') > -1 ? `"${key}"` : key
 		} else {
 			queryTerms[activeTermIndex].key = key.name
 			queryTerms[activeTermIndex].value = ''

--- a/frontend/src/pages/LogsPage/SearchForm/utils.test.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.test.ts
@@ -114,8 +114,8 @@ describe('parseLogsQuery', () => {
 		])
 	})
 
-	it('handles messy quotes', () => {
-		const query = `"test: \"ing" user:"Chilly \"McWilly\""`
+	it('handles nested quotes', () => {
+		const query = `'test: "ing' user:'Chilly "McWilly"'`
 		expect(parseLogsQuery(query)).toEqual([
 			{
 				key: BODY_KEY,

--- a/frontend/src/pages/LogsPage/SearchForm/utils.test.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.test.ts
@@ -201,7 +201,6 @@ describe('validateLogsQuery', () => {
 	})
 })
 
-// write somes tests for quoteQueryValue
 describe('quoteQueryValue', () => {
 	it('quotes strings with spaces', () => {
 		expect(quoteQueryValue('a test query')).toEqual('"a test query"')

--- a/frontend/src/pages/LogsPage/SearchForm/utils.test.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.test.ts
@@ -2,6 +2,7 @@ import {
 	BODY_KEY,
 	buildLogsQueryForServer,
 	parseLogsQuery,
+	quoteQueryValue,
 	stringifyLogsQuery,
 	validateLogsQuery,
 } from './utils'
@@ -197,5 +198,20 @@ describe('validateLogsQuery', () => {
 		const params = [...complexQueryParams]
 		params[0].value = ''
 		expect(validateLogsQuery(params)).toBeFalsy()
+	})
+})
+
+// write somes tests for quoteQueryValue
+describe('quoteQueryValue', () => {
+	it('quotes strings with spaces', () => {
+		expect(quoteQueryValue('a test query')).toEqual('"a test query"')
+	})
+
+	it('handles double quoted strings', () => {
+		expect(quoteQueryValue('"a test query"')).toEqual('"a test query"')
+	})
+
+	it('handles single quoted strings', () => {
+		expect(quoteQueryValue("'a test query'")).toEqual("'a test query'")
 	})
 })

--- a/frontend/src/pages/LogsPage/SearchForm/utils.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.ts
@@ -140,3 +140,11 @@ export const getLogsURLForSession = (projectId: string, session: Session) => {
 	)
 	return `/${projectId}/logs?${stringify(encodedQuery)}`
 }
+
+export const quoteQueryValue = (value: string) => {
+	if (value.startsWith('"') || value.startsWith("'")) {
+		return value
+	}
+
+	return `"${value}"`
+}

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -2,6 +2,10 @@ import { useGetLogsErrorObjectsQuery, useGetLogsLazyQuery } from '@graph/hooks'
 import { LogEdge, PageInfo } from '@graph/schemas'
 import * as Types from '@graph/schemas'
 import { FORMAT } from '@pages/LogsPage/constants'
+import {
+	buildLogsQueryForServer,
+	parseLogsQuery,
+} from '@pages/LogsPage/SearchForm/utils'
 import moment from 'moment'
 import { useCallback, useEffect, useState } from 'react'
 
@@ -41,13 +45,15 @@ export const useGetLogs = ({
 	})
 	const [loadingAfter, setLoadingAfter] = useState(false)
 	const [loadingBefore, setLoadingBefore] = useState(false)
+	const queryTerms = parseLogsQuery(query)
+	const serverQuery = buildLogsQueryForServer(queryTerms)
 
 	const [getLogs, { data, loading, error, fetchMore }] = useGetLogsLazyQuery({
 		variables: {
 			project_id: project_id!,
 			at: logCursor,
 			params: {
-				query,
+				query: serverQuery,
 				date_range: {
 					start_date: moment(startDate).format(FORMAT),
 					end_date: moment(endDate).format(FORMAT),


### PR DESCRIPTION
## Summary

Updates the behavior for handling strings in logs queries.

* Does not strip/transform quotes on user input anymore. Instead, we perform a transformation before sending the query string to the server to convert everything to double quotes.
* Adds quotes around values that need it when being applied outside the search input (e.g. "Apply as filter" button or selecting an item in the dropdown list).

## How did you test this change?

Local and PR preview click testing.

## Are there any deployment considerations?

N/A