### PR TITLE
ensure logs query string is used when provided

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -350,7 +350,6 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 								if (logCursor) {
 									navigate(
 										`/${projectId}/logs/${logCursor}?${params}`,
-										{},
 									)
 								} else {
 									navigate(`/${projectId}/logs?${params}`)

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -344,18 +344,23 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 						>
 							<KeyboardShortcut label="Next" shortcut="]" />
 						</Tooltip>
-						<Button
+						<LinkButton
 							kind="primary"
 							emphasis="high"
+							to={getLogsLink(errorObject)}
 							disabled={!isLoggedIn || !errorObject.session}
-							onClick={() => {
-								navigate(getLogsLink(errorObject))
-							}}
-							iconLeft={<IconSolidViewList />}
-							trackingId="errorInstanceShowLogs"
+							trackingId="logs-related_session_link"
 						>
-							Show logs
-						</Button>
+							<Box
+								display="flex"
+								alignItems="center"
+								flexDirection="row"
+								gap="4"
+							>
+								<IconSolidViewList />
+								Show logs
+							</Box>
+						</LinkButton>
 						<Button
 							kind="primary"
 							emphasis="high"

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -67,6 +67,41 @@ const METADATA_LABELS: { [key: string]: string } = {
 	id: 'ID',
 } as const
 
+const getLogsLink = (errorObject: ErrorObject): string => {
+	const queryParams: LogsSearchParam[] = []
+	let offsetStart = 1
+	if (errorObject.session?.secure_id) {
+		queryParams.push({
+			key: ReservedLogKey.SecureSessionId,
+			operator: DEFAULT_LOGS_OPERATOR,
+			value: errorObject.session?.secure_id,
+			offsetStart: offsetStart++,
+		})
+	}
+	if (errorObject.trace_id) {
+		queryParams.push({
+			key: ReservedLogKey.TraceId,
+			operator: DEFAULT_LOGS_OPERATOR,
+			value: errorObject.trace_id,
+			offsetStart: offsetStart++,
+		})
+	}
+	const query = stringifyLogsQuery(queryParams)
+	const logCursor = errorObject.log_cursor
+	const params = createSearchParams({
+		query,
+		start_date: moment(errorObject.timestamp)
+			.add(-5, 'minutes')
+			.toISOString(),
+		end_date: moment(errorObject.timestamp).add(5, 'minutes').toISOString(),
+	})
+	if (logCursor) {
+		return `/${errorObject.project_id}/logs/${logCursor}?${params}`
+	} else {
+		return `/${errorObject.project_id}/logs?${params}`
+	}
+}
+
 const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 	const { error_object_id, error_secure_id } = useParams<{
 		error_secure_id: string
@@ -314,46 +349,7 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 							emphasis="high"
 							disabled={!isLoggedIn || !errorObject.session}
 							onClick={() => {
-								if (!isLoggedIn) {
-									return
-								}
-
-								const queryParams: LogsSearchParam[] = []
-								let offsetStart = 1
-								if (errorObject.session?.secure_id) {
-									queryParams.push({
-										key: ReservedLogKey.SecureSessionId,
-										operator: DEFAULT_LOGS_OPERATOR,
-										value: errorObject.session?.secure_id,
-										offsetStart: offsetStart++,
-									})
-								}
-								if (errorObject.trace_id) {
-									queryParams.push({
-										key: ReservedLogKey.TraceId,
-										operator: DEFAULT_LOGS_OPERATOR,
-										value: errorObject.trace_id,
-										offsetStart: offsetStart++,
-									})
-								}
-								const query = stringifyLogsQuery(queryParams)
-								const logCursor = errorObject.log_cursor
-								const params = createSearchParams({
-									query,
-									start_date: moment(errorObject.timestamp)
-										.add(-5, 'minutes')
-										.toISOString(),
-									end_date: moment(errorObject.timestamp)
-										.add(5, 'minutes')
-										.toISOString(),
-								})
-								if (logCursor) {
-									navigate(
-										`/${projectId}/logs/${logCursor}?${params}`,
-									)
-								} else {
-									navigate(`/${projectId}/logs?${params}`)
-								}
+								navigate(getLogsLink(errorObject))
 							}}
 							iconLeft={<IconSolidViewList />}
 							trackingId="errorInstanceShowLogs"

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -68,7 +68,11 @@ const SearchForm = ({
 		},
 	})
 
-	formState.useSubmit(() => onFormSubmit(formState.values.query))
+	formState.useSubmit(() => {
+		if (formState.submitting) {
+			onFormSubmit(formState.values.query)
+		}
+	})
 
 	const handleDatesChange = (dates: Date[]) => {
 		setSelectedDates(dates)

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -69,9 +69,7 @@ const SearchForm = ({
 	})
 
 	formState.useSubmit(() => {
-		if (formState.submitting) {
-			onFormSubmit(formState.values.query)
-		}
+		onFormSubmit(formState.values.query)
 	})
 
 	const handleDatesChange = (dates: Date[]) => {
@@ -195,14 +193,6 @@ const Search: React.FC<{
 		formState.setValue('query', state.value)
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [state.value])
-
-	useEffect(() => {
-		// removes the dirty state from URL when the query is empty
-		if (!query) {
-			submitQuery('')
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [query])
 
 	const handleItemSelect = (
 		key: GetLogsKeysQuery['logs_keys'][0] | string,


### PR DESCRIPTION
## Summary

Clicking `Show Logs` from errors would populate the query string that would be replaced with the default value of the form.
Ensure that the search form only updates the query when there is an actual input.

## How did you test this change?

https://www.loom.com/share/12625c23205348369aa2d745bf2a14e7

## Are there any deployment considerations?

No