### PR TITLE
remove logrow and requestjson from logging

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -186,7 +186,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						isProjectError, backendError := getBackendError(ctx, ts, projectID, sessionID, requestID, traceID, spanID, logCursor, source, excMessage, resourceAttributes, spanAttributes, eventAttributes)
 						if backendError == nil {
 							data, _ := req.MarshalJSON()
-							log.WithContext(ctx).WithField("BackendErrorEvent", event).WithField("LogRow", *logRow).WithField("RequestJSON", string(data)).Errorf("otel span error got no session and no project")
+							log.WithContext(ctx).WithField("BackendErrorEvent", event).WithField("RequestJSON", string(data)).Errorf("otel span error got no session and no project")
 						} else {
 							if isProjectError {
 								projectErrors[projectID] = append(projectErrors[projectID], backendError)

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -185,8 +185,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 
 						isProjectError, backendError := getBackendError(ctx, ts, projectID, sessionID, requestID, traceID, spanID, logCursor, source, excMessage, resourceAttributes, spanAttributes, eventAttributes)
 						if backendError == nil {
-							data, _ := req.MarshalJSON()
-							log.WithContext(ctx).WithField("BackendErrorEvent", event).WithField("RequestJSON", string(data)).Errorf("otel span error got no session and no project")
+							log.WithContext(ctx).WithField("BackendErrorEvent", event).Errorf("otel span error got no session and no project")
 						} else {
 							if isProjectError {
 								projectErrors[projectID] = append(projectErrors[projectID], backendError)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

There are logs with very large `LogAttributes` columns:

```sql
select * from logs where Body = 'otel span error got no session and no project' and Timestamp >= (now() - toIntervalDay(1))
```

This is causing issues when trying to return that data to the frontend (see [slack](https://highlightcorp.slack.com/archives/C04NUD29BT3/p1679955470606809?thread_ts=1679944459.103359&cid=C04NUD29BT3)).



## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
