### PR TITLE
manually set PREWHERE when using log body searches

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -473,8 +473,6 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 
 	}
 
-	filters := makeFilters(params.Query)
-
 	for _, body := range filters.body {
 		if strings.Contains(body, "%") {
 			sb.Where("Body ILIKE" + sb.Var(body))

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -473,14 +473,6 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 
 	}
 
-	for _, body := range filters.body {
-		if strings.Contains(body, "%") {
-			sb.Where("Body ILIKE" + sb.Var(body))
-		} else {
-			sb.Where("hasTokenCaseInsensitive(Body, " + sb.Var(body) + ")")
-		}
-	}
-
 	if filters.level != "" {
 		if strings.Contains(filters.level, "%") {
 			sb.Where(sb.Like("SeverityText", filters.level))


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached Linear ticket that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Clickhouse has a feature called [PREWHERE](https://clickhouse.com/docs/en/sql-reference/statements/select/prewhere) which allows it to filter data efficiently.

Under the hood, Clickhouse does this automatically. 

See how it's doing it when we search for `SecureSessionId`:

```sql
EXPLAIN SYNTAX
SELECT
    Timestamp,
    UUID,
    SeverityText,
    Body,
    LogAttributes,
    TraceId,
    SpanId,
    SecureSessionId
FROM logs
WHERE (ProjectId = 1) AND (Timestamp <= now()) AND (Timestamp >= (now() - toIntervalHour(1))) AND (SecureSessionId = 'test')
ORDER BY Timestamp ASC
LIMIT 50

┌─explain────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ SELECT                                                                                                                         │
│     Timestamp,                                                                                                                 │
│     UUID,                                                                                                                      │
│     SeverityText,                                                                                                              │
│     Body,                                                                                                                      │
│     LogAttributes,                                                                                                             │
│     TraceId,                                                                                                                   │
│     SpanId,                                                                                                                    │
│     SecureSessionId                                                                                                            │
│ FROM logs                                                                                                                      │
│ PREWHERE (Timestamp <= now()) AND (Timestamp >= (now() - toIntervalHour(1))) AND (SecureSessionId = 'test')                    │
│ WHERE ((Timestamp <= now()) AND (Timestamp >= (now() - toIntervalHour(1))) AND (SecureSessionId = 'test')) AND (ProjectId = 1) │
│ ORDER BY Timestamp ASC                                                                                                         │
│ LIMIT 50                                                                                                                       │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

But in the case of searching a log body, it decides to not include `Body` as part of the `PREWHERE` clause (see [here](https://gist.github.com/et/905f16ab0774db154db656da84e842c2#examining-the-explain-syntax)).

I believe this is because `Body` has a lot of data in it and Clickhouse believes that it doesn't make sense to use this as part of its pre-filtering.

However, per the [docs](https://clickhouse.com/docs/en/sql-reference/statements/select/prewhere), one can manually specify `PREWHERE` if we think it's the right thing to do. 
In this case, searching the log`Body` is very important and we'd rather take the hit of it using more memory if returns the results faster. Additionally, log body has an index (#4578) that should be utilized.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

We have existing tests that search on the log body and I inspected the generated query to see that the `PREWHERE` was added to the generated sql:

<img width="1081" alt="Screenshot 2023-03-27 at 10 22 08 PM" src="https://user-images.githubusercontent.com/58678/228127585-061f3688-ddf6-4ec5-80d5-9a1d1f298cde.png">


You'll notice that above only includes `Body` in the `PREWHERE`, not the timestamps. It would actually be quite challenging to change the position the timestamps without affecting non log body queries i.e. `PREWHERE` is an escape hatch and we don't want to use it unless we really have to.

From a quick test, the performance is very adequate with only `Body` in the `PREWHERE`.

### Searching last day

```sql
   SELECT 
      Timestamp, 
      UUID, 
      SeverityText, 
      Body, 
      LogAttributes, 
      TraceId, 
      SpanId, 
      SecureSessionId 
    FROM 
      logs 
    PREWHERE
      hasTokenCaseInsensitive(Body, 'test')
    WHERE 
      ProjectId = 1 
      AND Timestamp <= now() 
      AND Timestamp >= (now() - toIntervalDay(1))
    ORDER BY 
      Timestamp
    LIMIT 
      50


Elapsed: 0.270s
Read: 1,374,071 rows (367.89 MB)
```

### Searching last 30 days

```sql
   SELECT 
      Timestamp, 
      UUID, 
      SeverityText, 
      Body, 
      LogAttributes, 
      TraceId, 
      SpanId, 
      SecureSessionId 
    FROM 
      logs 
    PREWHERE
      hasTokenCaseInsensitive(Body, 'test')
    WHERE 
      ProjectId = 1 
      AND Timestamp <= now() 
      AND Timestamp >= (now() - toIntervalDay(30))
    ORDER BY 
      Timestamp
    LIMIT 
      50

Elapsed: 3.586s
Read: 7,904,651 rows (1.71 GB)
```

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
