### PR TITLE
fallback to using opensearch for error group frequency queries

### DIFF
--- a/backend/migrations/cmd/influxdb-backfill-error-groups/main.go
+++ b/backend/migrations/cmd/influxdb-backfill-error-groups/main.go
@@ -47,7 +47,7 @@ func main() {
 		go func(projectID int) {
 			errorGroups := &[]*model.ErrorGroup{}
 			inner := func(tx *gorm.DB, batch int) error {
-				err = pri.SetErrorFrequencies(*errorGroups, LookbackDays)
+				err = pri.SetErrorFrequencies(ctx, projectID, *errorGroups, LookbackDays)
 				if err != nil {
 					return err
 				}

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -938,16 +938,11 @@ type ErrorGroup struct {
 	Fingerprints     []*ErrorFingerprint
 	FieldGroup       *string
 	Environments     string
-	IsPublic         bool    `gorm:"default:false"`
-	ErrorFrequency   []int64 `gorm:"-"`
-	ErrorMetrics     []*struct {
-		ErrorGroupID int
-		Date         time.Time
-		Name         string
-		Value        int64
-	} `gorm:"-"`
-	FirstOccurrence *time.Time `gorm:"-"`
-	LastOccurrence  *time.Time `gorm:"-"`
+	IsPublic         bool                                 `gorm:"default:false"`
+	ErrorFrequency   []int64                              `gorm:"-"`
+	ErrorMetrics     []*modelInputs.ErrorDistributionItem `gorm:"-"`
+	FirstOccurrence  *time.Time                           `gorm:"-"`
+	LastOccurrence   *time.Time                           `gorm:"-"`
 
 	// Represents the admins that have viewed this session.
 	ViewedByAdmins []Admin `json:"viewed_by_admins" gorm:"many2many:error_group_admins_views;"`

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1165,8 +1165,6 @@ type ErrorGroupResolver interface {
 	MetadataLog(ctx context.Context, obj *model1.ErrorGroup) ([]*model.ErrorMetadata, error)
 
 	State(ctx context.Context, obj *model1.ErrorGroup) (model.ErrorState, error)
-
-	ErrorMetrics(ctx context.Context, obj *model1.ErrorGroup) ([]*model.ErrorDistributionItem, error)
 }
 type ErrorObjectResolver interface {
 	ErrorGroupSecureID(ctx context.Context, obj *model1.ErrorObject) (string, error)
@@ -8796,7 +8794,7 @@ type DailyErrorCount {
 }
 
 type ErrorDistributionItem {
-	error_group_id: String!
+	error_group_id: ID!
 	date: Timestamp!
 	name: String!
 	value: Int64!
@@ -21146,9 +21144,9 @@ func (ec *executionContext) _ErrorDistributionItem_error_group_id(ctx context.Co
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(int)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNID2int(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ErrorDistributionItem_error_group_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -21158,7 +21156,7 @@ func (ec *executionContext) fieldContext_ErrorDistributionItem_error_group_id(ct
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	return fc, nil
@@ -22184,7 +22182,7 @@ func (ec *executionContext) _ErrorGroup_error_metrics(ctx context.Context, field
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.ErrorGroup().ErrorMetrics(rctx, obj)
+		return obj.ErrorMetrics, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -22205,8 +22203,8 @@ func (ec *executionContext) fieldContext_ErrorGroup_error_metrics(ctx context.Co
 	fc = &graphql.FieldContext{
 		Object:     "ErrorGroup",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "error_group_id":
@@ -58641,25 +58639,12 @@ func (ec *executionContext) _ErrorGroup(ctx context.Context, sel ast.SelectionSe
 				atomic.AddUint32(&invalids, 1)
 			}
 		case "error_metrics":
-			field := field
 
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._ErrorGroup_error_metrics(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
+			out.Values[i] = ec._ErrorGroup_error_metrics(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
 			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
 		case "is_public":
 
 			out.Values[i] = ec._ErrorGroup_is_public(ctx, field, obj)

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -224,7 +224,7 @@ type EnhancedUserDetailsResult struct {
 }
 
 type ErrorDistributionItem struct {
-	ErrorGroupID string    `json:"error_group_id"`
+	ErrorGroupID int       `json:"error_group_id"`
 	Date         time.Time `json:"date"`
 	Name         string    `json:"name"`
 	Value        int64     `json:"value"`

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -510,8 +510,8 @@ func (r *Resolver) isAdminInProject(ctx context.Context, project_id int) (*model
 	return nil, e.New("admin doesn't exist in project")
 }
 
-func (r *Resolver) GetErrorGroupOccurrences(ctx context.Context, projectID int, errorGroupID int, errorGroupCreated time.Time) (*time.Time, *time.Time, error) {
-	bucket, measurement := r.TDB.GetSampledMeasurement(r.TDB.GetBucket(strconv.Itoa(projectID), timeseries.Errors), timeseries.Errors, time.Since(errorGroupCreated))
+func (r *Resolver) GetErrorGroupOccurrences(ctx context.Context, eg *model.ErrorGroup) (*time.Time, *time.Time, error) {
+	bucket, measurement := r.TDB.GetSampledMeasurement(r.TDB.GetBucket(strconv.Itoa(eg.ProjectID), timeseries.Errors), timeseries.Errors, time.Since(eg.CreatedAt))
 	var filter string
 	if measurement == timeseries.Error.AggName {
 		filter = `|> filter(fn: (r) => r._value > 0)`
@@ -526,18 +526,90 @@ func (r *Resolver) GetErrorGroupOccurrences(ctx context.Context, projectID int, 
 
       union(tables:[query() |> first(), query() |> last()])
         |> sort(columns: ["ErrorGroupID", "_field", "_time"])
-	`, bucket, measurement, errorGroupID, filter)
+	`, bucket, measurement, eg.ID, filter)
 	span, _ := tracer.StartSpanFromContext(ctx, "tdb.errorGroupOccurrences")
-	span.SetTag("projectID", projectID)
-	span.SetTag("errorGroupID", errorGroupID)
+	span.SetTag("projectID", eg.ProjectID)
+	span.SetTag("errorGroupID", eg.ID)
 	results, err := r.TDB.Query(ctx, query)
 	if err != nil {
-		return nil, nil, e.Wrap(err, "failed to perform tdb query for error group occurrences")
+		log.WithContext(ctx).WithError(err).Error("failed to perform tdb query for error group occurrences")
 	}
 	if len(results) < 2 {
-		return nil, nil, nil
+		return &eg.CreatedAt, &eg.UpdatedAt, nil
 	}
 	return &results[0].Time, &results[1].Time, nil
+}
+
+func (r *Resolver) GetErrorFrequenciesOpensearch(errorGroups []*model.ErrorGroup, lookbackPeriod int) (map[int][]int64, map[int][]*modelInputs.ErrorDistributionItem, error) {
+	endDate := time.Now().UTC()
+	startDate := endDate.AddDate(0, 0, -1*lookbackPeriod)
+	startDateFormatted := startDate.Format("2006-01-02")
+
+	aggQuery :=
+		fmt.Sprintf(`{"bool": {
+			"must": [
+				{
+					"terms": {
+					"routing.keyword" : [%s]
+				}},
+				{
+					"range": {
+					"timestamp": {
+						"gte": "%s"
+					}
+				}}
+			]
+		}}`,
+			strings.Join(lo.Map(errorGroups, func(e *model.ErrorGroup, i int) string { return strconv.Itoa(e.ID) }), ","),
+			startDateFormatted)
+	aggOptions := opensearch.SearchOptions{
+		MaxResults: pointy.Int(0),
+		Aggregation: &opensearch.TermsAggregation{
+			Field: "routing.keyword",
+			SubAggregation: &opensearch.DateHistogramAggregation{
+				Field:            "timestamp",
+				CalendarInterval: "day",
+				SortOrder:        "desc",
+				Format:           "yyyy-MM-dd",
+				TimeZone:         "UTC",
+			},
+		},
+	}
+
+	var ignored []struct{}
+	_, aggResults, err := r.OpenSearch.Search([]opensearch.Index{opensearch.IndexErrorsCombined}, -1, aggQuery, aggOptions, &ignored)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	errFreqs := map[int][]int64{}
+	errMetrics := map[int][]*modelInputs.ErrorDistributionItem{}
+	for _, ar1 := range aggResults {
+		errorGroupId, err := strconv.Atoi(ar1.Key)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		freqMap := map[string]int64{}
+		for _, ar2 := range ar1.SubAggregationResults {
+			freqMap[ar2.Key] = ar2.DocCount
+		}
+
+		var freqs []int64
+		for curDate := startDate; !curDate.After(endDate); curDate = curDate.AddDate(0, 0, 1) {
+			curDateFormatted := curDate.Format("2006-01-02")
+			freq, ok := freqMap[curDateFormatted]
+			if !ok {
+				freq = 0
+			}
+			freqs = append(freqs, freq)
+			errMetrics[errorGroupId] = append(errMetrics[errorGroupId], &modelInputs.ErrorDistributionItem{ErrorGroupID: errorGroupId, Date: curDate.Truncate(24 * time.Hour), Name: "count", Value: freq})
+		}
+
+		errFreqs[errorGroupId] = freqs
+	}
+
+	return errFreqs, errMetrics, nil
 }
 
 func (r *Resolver) GetErrorGroupFrequenciesUnsampled(ctx context.Context, projectID int, errorGroupID int) ([]*modelInputs.ErrorDistributionItem, error) {
@@ -557,7 +629,7 @@ func (r *Resolver) GetErrorGroupFrequenciesUnsampled(ctx context.Context, projec
 				"count", "environmentCount", "identifierCount", "sessionCount",
 			} {
 				response = append(response, &modelInputs.ErrorDistributionItem{
-					ErrorGroupID: strconv.Itoa(errorGroupID),
+					ErrorGroupID: errorGroupID,
 					Date:         r.Time,
 					Name:         k,
 					Value:        r.Values[k].(int64),
@@ -607,8 +679,9 @@ func (r *Resolver) GetErrorGroupFrequencies(ctx context.Context, projectID int, 
 			if r.Values["ErrorGroupID"] != nil {
 				id = r.Values["ErrorGroupID"].(string)
 			}
+			idInt, _ := strconv.Atoi(id)
 			response = append(response, &modelInputs.ErrorDistributionItem{
-				ErrorGroupID: id,
+				ErrorGroupID: idInt,
 				Date:         r.Time,
 				Name:         field.(string),
 				Value:        value,
@@ -618,7 +691,7 @@ func (r *Resolver) GetErrorGroupFrequencies(ctx context.Context, projectID int, 
 	return response, nil
 }
 
-func (r *Resolver) SetErrorFrequenciesInflux(ctx context.Context, projectID int, errorGroups []*model.ErrorGroup, lookbackPeriod int) error {
+func (r *Resolver) SetErrorFrequencies(ctx context.Context, projectID int, errorGroups []*model.ErrorGroup, lookbackPeriod int) error {
 	params := modelInputs.ErrorGroupFrequenciesParamsInput{
 		DateRange: &modelInputs.DateRangeRequiredInput{
 			StartDate: time.Now().Add(time.Duration(-24*lookbackPeriod) * time.Hour),
@@ -626,17 +699,12 @@ func (r *Resolver) SetErrorFrequenciesInflux(ctx context.Context, projectID int,
 		},
 		ResolutionMinutes: 24 * 60,
 	}
-	var errorGroupMap = make(map[string]*model.ErrorGroup)
+	var errorGroupMap = make(map[int]*model.ErrorGroup)
 	for _, errorGroup := range errorGroups {
-		errorGroup.ErrorMetrics = []*struct {
-			ErrorGroupID int
-			Date         time.Time
-			Name         string
-			Value        int64
-		}{}
-		errorGroupMap[strconv.Itoa(errorGroup.ID)] = errorGroup
+		errorGroup.ErrorMetrics = []*modelInputs.ErrorDistributionItem{}
+		errorGroupMap[errorGroup.ID] = errorGroup
 	}
-	var oldErrorGroupIDs []int
+	oldErrorGroups := make(map[int]*model.ErrorGroup)
 	var err error
 	var results []*modelInputs.ErrorDistributionItem
 	for _, eg := range errorGroups {
@@ -649,30 +717,32 @@ func (r *Resolver) SetErrorFrequenciesInflux(ctx context.Context, projectID int,
 			startDate := endDate.AddDate(0, 0, -1*(lookbackPeriod-1))
 			for curDate := startDate; !curDate.After(endDate); curDate = curDate.AddDate(0, 0, 1) {
 				eg.ErrorFrequency = append(eg.ErrorFrequency, 0)
-				eg.ErrorMetrics = append(eg.ErrorMetrics, &struct {
-					ErrorGroupID int
-					Date         time.Time
-					Name         string
-					Value        int64
-				}{ErrorGroupID: eg.ID, Date: curDate.Truncate(24 * time.Hour), Name: "count", Value: 0})
+				eg.ErrorMetrics = append(eg.ErrorMetrics, &modelInputs.ErrorDistributionItem{ErrorGroupID: eg.ID, Date: curDate.Truncate(24 * time.Hour), Name: "count", Value: 0})
 			}
 			for _, r := range results {
 				if r.Name == "count" {
 					eg.ErrorFrequency = append(eg.ErrorFrequency, r.Value)
 				}
-				eg.ErrorMetrics = append(eg.ErrorMetrics, &struct {
-					ErrorGroupID int
-					Date         time.Time
-					Name         string
-					Value        int64
-				}{ErrorGroupID: eg.ID, Date: r.Date, Name: r.Name, Value: r.Value})
+				eg.ErrorMetrics = append(eg.ErrorMetrics, &modelInputs.ErrorDistributionItem{ErrorGroupID: eg.ID, Date: r.Date, Name: r.Name, Value: r.Value})
+			}
+			// fallback to using opensearch for the frequency query
+			if len(results) == 0 {
+				errFreqs, errMetrics, err := r.GetErrorFrequenciesOpensearch([]*model.ErrorGroup{eg}, lookbackPeriod)
+				if err != nil {
+					log.WithContext(ctx).Error(err)
+				} else {
+					eg.ErrorFrequency = errFreqs[eg.ID]
+					eg.ErrorMetrics = errMetrics[eg.ID]
+				}
 			}
 		} else {
-			oldErrorGroupIDs = append(oldErrorGroupIDs, eg.ID)
+			oldErrorGroups[eg.ID] = eg
 		}
 	}
 
-	results, err = r.GetErrorGroupFrequencies(ctx, projectID, oldErrorGroupIDs, params, "")
+	results, err = r.GetErrorGroupFrequencies(ctx, projectID, lo.Map(lo.Values(oldErrorGroups), func(eg *model.ErrorGroup, i int) int {
+		return eg.ID
+	}), params, "")
 	if err != nil {
 		return err
 	}
@@ -681,101 +751,21 @@ func (r *Resolver) SetErrorFrequenciesInflux(ctx context.Context, projectID int,
 		if r.Name == "count" {
 			eg.ErrorFrequency = append(eg.ErrorFrequency, r.Value)
 		}
-		eg.ErrorMetrics = append(eg.ErrorMetrics, &struct {
-			ErrorGroupID int
-			Date         time.Time
-			Name         string
-			Value        int64
-		}{ErrorGroupID: eg.ID, Date: r.Date, Name: r.Name, Value: r.Value})
+		eg.ErrorMetrics = append(eg.ErrorMetrics, &modelInputs.ErrorDistributionItem{ErrorGroupID: eg.ID, Date: r.Date, Name: r.Name, Value: r.Value})
 	}
-	return nil
-}
-
-func (r *Resolver) SetErrorFrequencies(errorGroups []*model.ErrorGroup, lookbackPeriod int) error {
-	endDate := time.Now().UTC()
-	startDate := endDate.AddDate(0, 0, -1*lookbackPeriod)
-	startDateFormatted := startDate.Format("2006-01-02")
-
-	aggQuery :=
-		fmt.Sprintf(`{"bool": {
-			"must": [
-				{
-					"terms": {
-					"routing.keyword" : [%s]
-				}},
-				{
-					"range": {
-					"timestamp": {
-						"gte": "%s"
-					}
-				}}
-			]
-		}}`,
-			strings.Join(lo.Map(errorGroups, func(e *model.ErrorGroup, i int) string { return strconv.Itoa(e.ID) }), ","),
-			startDateFormatted)
-	aggOptions := opensearch.SearchOptions{
-		MaxResults: pointy.Int(0),
-		Aggregation: &opensearch.TermsAggregation{
-			Field: "routing.keyword",
-			SubAggregation: &opensearch.DateHistogramAggregation{
-				Field:            "timestamp",
-				CalendarInterval: "day",
-				SortOrder:        "desc",
-				Format:           "yyyy-MM-dd",
-				TimeZone:         "UTC",
-			},
-		},
-	}
-
-	ignored := []struct{}{}
-	_, aggResults, err := r.OpenSearch.Search([]opensearch.Index{opensearch.IndexErrorsCombined}, -1, aggQuery, aggOptions, &ignored)
-	if err != nil {
-		return err
-	}
-
-	errFreqs := map[int][]int64{}
-	errMetrics := map[int][]*struct {
-		ErrorGroupID int
-		Date         time.Time
-		Name         string
-		Value        int64
-	}{}
-	for _, ar1 := range aggResults {
-		errorGroupId, err := strconv.Atoi(ar1.Key)
+	// fallback to using opensearch for the frequency query
+	if len(results) == 0 {
+		errFreqs, errMetrics, err := r.GetErrorFrequenciesOpensearch(lo.Values(oldErrorGroups), lookbackPeriod)
 		if err != nil {
-			return err
-		}
-
-		freqMap := map[string]int64{}
-		for _, ar2 := range ar1.SubAggregationResults {
-			freqMap[ar2.Key] = ar2.DocCount
-		}
-
-		freqs := []int64{}
-		for curDate := startDate; !curDate.After(endDate); curDate = curDate.AddDate(0, 0, 1) {
-			curDateFormatted := curDate.Format("2006-01-02")
-			freq, ok := freqMap[curDateFormatted]
-			if !ok {
-				freq = 0
+			log.WithContext(ctx).Error(err)
+		} else {
+			for egID, freqs := range errFreqs {
+				eg := oldErrorGroups[egID]
+				eg.ErrorFrequency = freqs
+				eg.ErrorMetrics = errMetrics[egID]
 			}
-			freqs = append(freqs, freq)
-
-			errMetrics[errorGroupId] = append(errMetrics[errorGroupId], &struct {
-				ErrorGroupID int
-				Date         time.Time
-				Name         string
-				Value        int64
-			}{ErrorGroupID: errorGroupId, Date: curDate.Truncate(24 * time.Hour), Name: "count", Value: freq})
 		}
-
-		errFreqs[errorGroupId] = freqs
 	}
-
-	for _, eg := range errorGroups {
-		eg.ErrorFrequency = errFreqs[eg.ID]
-		eg.ErrorMetrics = errMetrics[eg.ID]
-	}
-
 	return nil
 }
 
@@ -890,10 +880,10 @@ func (r *Resolver) doesAdminOwnErrorGroup(ctx context.Context, errorGroupSecureI
 		return eg, false, e.Wrap(err, "error validating admin in project")
 	}
 
-	if eg.FirstOccurrence, eg.LastOccurrence, err = r.GetErrorGroupOccurrences(ctx, eg.ProjectID, eg.ID, eg.CreatedAt); err != nil {
+	if eg.FirstOccurrence, eg.LastOccurrence, err = r.GetErrorGroupOccurrences(ctx, eg); err != nil {
 		return nil, false, e.Wrap(err, "error querying error group occurrences")
 	}
-	if err := r.SetErrorFrequenciesInflux(ctx, eg.ProjectID, []*model.ErrorGroup{eg}, ErrorGroupLookbackDays); err != nil {
+	if err := r.SetErrorFrequencies(ctx, eg.ProjectID, []*model.ErrorGroup{eg}, ErrorGroupLookbackDays); err != nil {
 		return nil, false, e.Wrap(err, "error querying error group frequencies")
 	}
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -960,7 +960,7 @@ type DailyErrorCount {
 }
 
 type ErrorDistributionItem {
-	error_group_id: String!
+	error_group_id: ID!
 	date: Timestamp!
 	name: String!
 	value: Int64!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7433,22 +7433,3 @@ type sessionAlertResolver struct{ *Resolver }
 type sessionCommentResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }
 type timelineIndicatorEventResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
-func (r *errorGroupResolver) ErrorMetrics(ctx context.Context, obj *model.ErrorGroup) ([]*modelInputs.ErrorDistributionItem, error) {
-	if time.Since(obj.CreatedAt) <= time.Hour {
-		return r.GetErrorGroupFrequenciesUnsampled(ctx, obj.ProjectID, obj.ID)
-	}
-	return r.GetErrorGroupFrequencies(ctx, obj.ProjectID, []int{obj.ID}, modelInputs.ErrorGroupFrequenciesParamsInput{
-		DateRange: &modelInputs.DateRangeRequiredInput{
-			StartDate: time.Now().Add(-24 * 30 * time.Hour),
-			EndDate:   time.Now(),
-		},
-		ResolutionMinutes: 24 * 60,
-	}, "")
-}

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -370,7 +370,7 @@ export type ErrorComment = {
 export type ErrorDistributionItem = {
 	__typename?: 'ErrorDistributionItem'
 	date: Scalars['Timestamp']
-	error_group_id: Scalars['String']
+	error_group_id: Scalars['ID']
 	name: Scalars['String']
 	value: Scalars['Int64']
 }


### PR DESCRIPTION
## Summary

Ensure error instance counts are correct by falling back on opensearch queries / postgres data
when an error group metric is missing from influxdb.
Consolidates some types by using the `modelInputs.ErrorDistributionItem` consisntly.

## How did you test this change?

Before
![Screenshot 2023-03-27 at 10 47 33 PM](https://user-images.githubusercontent.com/1351531/228140231-7cc4d923-9bcb-4f83-a297-ffcf70a2af05.png)

After
![Screenshot 2023-03-27 at 10 50 51 PM](https://user-images.githubusercontent.com/1351531/228140813-792c9028-12fb-4b31-a6cc-ef095256af31.png)

## Are there any deployment considerations?

No