### PR TITLE
[issue_4707] Fix deleting an admin requires a refresh for the changes to be reflec…

### DIFF
--- a/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
+++ b/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
@@ -55,18 +55,9 @@ const WorkspaceTeam = () => {
 		update(cache, { data }) {
 			cache.modify({
 				fields: {
-					workspace_admins(existingAdmins, { readField }) {
-						if (data?.deleteAdminFromWorkspace !== undefined) {
-							message.success('Removed member')
-							return existingAdmins.filter(
-								(admin: any) =>
-									data.deleteAdminFromWorkspace !==
-									readField('id', admin),
-							)
-						}
-						message.success('Failed to remove member')
-						return existingAdmins
-					},
+					workspace_admins(_existingAdmins, { DELETE }) {
+						return DELETE
+					}
 				},
 			})
 		},


### PR DESCRIPTION
## Summary
Fix deleting an admin requires a refresh for the changes to be reflected in the UI.
Relate to https://github.com/highlight/highlight/issues/4707

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
Local UI is ok.
<img width="946" alt="image" src="https://user-images.githubusercontent.com/82889377/228159925-91b81dd5-0dda-43ec-a46a-ce18925be66c.png">
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/82889377/228159977-0fa6fd8a-47e0-4f12-acaf-94d37f90b80a.png">
<img width="981" alt="image" src="https://user-images.githubusercontent.com/82889377/228160028-30f45b07-0dfb-49e9-97b0-0c8155791abd.png">

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
No.
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
