### PR TITLE
add log search specification link to logs empty state

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/NoLogsFound.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/NoLogsFound.tsx
@@ -1,3 +1,4 @@
+import { LinkButton } from '@components/LinkButton'
 import { Box, Callout, Text } from '@highlight-run/ui'
 import React from 'react'
 
@@ -16,18 +17,14 @@ const NoLogsFound = () => {
 						filters.
 					</Text>
 
-					{/*
-					TODO: Uncomment and ensure the link is accurate once
-					https://github.com/highlight/highlight/issues/4592 is resolved.
 					<LinkButton
 						trackingId="logs-empty-state_specification-docs"
 						kind="secondary"
-						to="https://www.highlight.io/docs/general/company/open-source/contributing/adding-an-sdk#Recording-a-Log"
+						to="https://highlight.io/docs/general/product-features/logging/log-search"
 						target="_blank"
 					>
 						Log search specification
 					</LinkButton>
-					*/}
 				</Box>
 			</Callout>
 		</Box>


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Log search [docs](https://www.highlight.io/docs/general/product-features/logging/log-search) are now live. We should update the empty state to reflect that.

Fixes #4723

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Visual test
![Screenshot 2023-03-28 at 9 23 43 AM](https://user-images.githubusercontent.com/58678/228287498-de27e384-4260-4825-ae4b-6f2fe25d6d69.png)



## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A