### PR TITLE
stop creating errors for error logs

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -73,6 +73,7 @@ const options: HighlightOptions = {
 			'session-contents-compressed',
 		],
 	},
+	reportConsoleErrors: false,
 	tracingOrigins: ['highlight.run', 'localhost'],
 	integrations: {
 		amplitude: {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -74,7 +74,7 @@ const options: HighlightOptions = {
 		],
 	},
 	reportConsoleErrors: false,
-	tracingOrigins: ['highlight.run', 'localhost'],
+	tracingOrigins: ['highlight.run', 'localhost', 'localhost:8082'],
 	integrations: {
 		amplitude: {
 			apiKey: 'fb83ae15d6122ef1b3f0ecdaa3393fea',

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -91,10 +91,10 @@ export type HighlightClassOptions = {
 	backendUrl?: string
 	tracingOrigins?: boolean | (string | RegExp)[]
 	disableNetworkRecording?: boolean
-	reportConsoleErrors?: boolean
 	networkRecording?: boolean | NetworkRecordingOptions
 	disableBackgroundRecording?: boolean
 	disableConsoleRecording?: boolean
+	reportConsoleErrors?: boolean
 	consoleMethodsToRecord?: ConsoleMethods[]
 	enableSegmentIntegration?: boolean
 	enableStrictPrivacy?: boolean

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -91,6 +91,7 @@ export type HighlightClassOptions = {
 	backendUrl?: string
 	tracingOrigins?: boolean | (string | RegExp)[]
 	disableNetworkRecording?: boolean
+	reportConsoleErrors?: boolean
 	networkRecording?: boolean | NetworkRecordingOptions
 	disableBackgroundRecording?: boolean
 	disableConsoleRecording?: boolean

--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -19,6 +19,7 @@ import publicGraphURI from 'consts:publicGraphURI'
 // codebase. When constructed in firstload, it will match the codebase at the time the npm package was published.
 export class FirstLoadListeners {
 	disableConsoleRecording: boolean
+	reportConsoleErrors: boolean
 	consoleMethodsToRecord: ConsoleMethods[]
 	listeners: (() => void)[]
 	errors: ErrorMessage[]
@@ -40,6 +41,7 @@ export class FirstLoadListeners {
 	constructor(options: HighlightClassOptions) {
 		this.options = options
 		this.disableConsoleRecording = !!options.disableConsoleRecording
+		this.reportConsoleErrors = options.reportConsoleErrors ?? true
 		this.consoleMethodsToRecord = options.consoleMethodsToRecord || [
 			...ALL_CONSOLE_METHODS,
 		]
@@ -60,6 +62,7 @@ export class FirstLoadListeners {
 				ConsoleListener(
 					(c: ConsoleMessage) => {
 						if (
+							this.reportConsoleErrors &&
 							(c.type === 'Error' || c.type === 'error') &&
 							c.value &&
 							c.trace
@@ -89,9 +92,8 @@ export class FirstLoadListeners {
 								stackTrace: c.trace,
 								timestamp: new Date().toISOString(),
 							})
-						} else {
-							highlightThis.messages.push(c)
 						}
+						highlightThis.messages.push(c)
 					},
 					{
 						level: this.consoleMethodsToRecord,

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -95,6 +95,11 @@ export declare type HighlightOptions = {
 	 */
 	disableConsoleRecording?: boolean
 	/**
+	 * Specifies whether Highlight will report `console.error` invocations as Highlight Errors.
+	 * @default true
+	 */
+	reportConsoleErrors?: boolean
+	/**
 	 * Specifies which console methods to record.
 	 * The value here will be ignored if `disabledConsoleRecording` is `true`.
 	 * @default All console methods.

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -139,3 +139,10 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Patch Changes
 
 - Ensure integrations are not initialized when `disabled: true`.
+
+## 5.4.2
+
+### Patch Changes
+
+- Adds an opt-out `reportConsoleErrors` boolean setting to `H.init` that allows disabling reporting console logs as errors.
+- Ensures `console.error(...)` calls are reported as part of highlight frontend sessions in all cases.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "5.4.1",
+	"version": "5.4.2",
 	"scripts": {
 		"build": "yarn typegen && rollup -c",
 		"dev": "rollup -c -w",

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -100,6 +100,7 @@ export const H: HighlightPublicInterface = {
 				networkRecording: options?.networkRecording,
 				disableBackgroundRecording: options?.disableBackgroundRecording,
 				disableConsoleRecording: options?.disableConsoleRecording,
+				reportConsoleErrors: options?.reportConsoleErrors,
 				consoleMethodsToRecord: options?.consoleMethodsToRecord,
 				enableSegmentIntegration: options?.enableSegmentIntegration,
 				enableStrictPrivacy: options?.enableStrictPrivacy,


### PR DESCRIPTION
## Summary

* stop creating error instances from error logs
* adds an opt-in way to disable reporting console logs as errors

## How did you test this change?

Testing with new `reportConsoleErrors: false` setting.
![Screenshot 2023-03-28 at 1 45 30 PM](https://user-images.githubusercontent.com/1351531/228362637-b4a3448d-85bb-4a46-b3f1-477ed76520ca.png)
![Screenshot 2023-03-28 at 1 45 53 PM](https://user-images.githubusercontent.com/1351531/228362721-66cb9db4-42b6-4e53-bc87-cf8623471453.png)
![Screenshot 2023-03-28 at 1 46 17 PM](https://user-images.githubusercontent.com/1351531/228362805-b6ab19ed-626c-4b39-9942-f8e9ec6f96dc.png)

Testing without the `reportConsoleErrors` (should default to true) continues to report errors.
![Screenshot 2023-03-28 at 1 48 01 PM](https://user-images.githubusercontent.com/1351531/228363174-1d28681d-7218-44f7-a6c6-304e4f16ec48.png)


## Are there any deployment considerations?

New version of the `highlight.run` npm package. `reportConsoleErrors` will default to `true` for now.
