### PR TITLE
ensure that backend spans set source correctly

### DIFF
--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -16,6 +16,8 @@ import (
 )
 
 const LogAttributeValueLengthLimit = 2 << 10
+const LogRowSourceValueFrontend = "frontend"
+const LogRowSourceValueBackend = "backend"
 
 func ProjectToInt(projectID string) (int, error) {
 	i, err := strconv.ParseInt(projectID, 10, 32)
@@ -93,9 +95,10 @@ func WithSeverityText(severityText string) LogRowOption {
 func WithSource(source string) LogRowOption {
 	return func(h *LogRow) {
 		if source == highlight.SourceAttributeFrontend {
-			source = "frontend"
+			h.Source = LogRowSourceValueFrontend
+		} else {
+			h.Source = LogRowSourceValueBackend
 		}
-		h.Source = source
 	}
 }
 

--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"context"
+	"github.com/highlight/highlight/sdk/highlight-go"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,4 +62,13 @@ func TestNewLogRowWithLongBody(t *testing.T) {
 	}
 	lr := NewLogRow(LogRowPrimaryAttrs{}, WithBody(ctx, body))
 	assert.Equal(t, 2048+3, len(lr.Body))
+}
+
+func TestNewLogRowWithSource(t *testing.T) {
+	lr := NewLogRow(LogRowPrimaryAttrs{}, WithSource(highlight.SourceAttributeFrontend))
+	assert.Equal(t, LogRowSourceValueFrontend, lr.Source)
+	assert.Equal(t, "frontend", LogRowSourceValueFrontend)
+	lr = NewLogRow(LogRowPrimaryAttrs{}, WithSource("InterceptField"))
+	assert.Equal(t, LogRowSourceValueBackend, lr.Source)
+	assert.Equal(t, "backend", LogRowSourceValueBackend)
 }

--- a/backend/util/logging.go
+++ b/backend/util/logging.go
@@ -35,7 +35,7 @@ func GraphQLErrorPresenter(service string) func(ctx context.Context, e error) *g
 func GraphQLRecoverFunc() func(ctx context.Context, err interface{}) error {
 	return func(ctx context.Context, err interface{}) error {
 		err2 := errors.Errorf("panic {error: %+v}", err)
-		highlight.RecordError(ctx, err2, attribute.String("Source", "GraphQLRecoverFunc"))
+		highlight.RecordError(ctx, err2, attribute.String(highlight.SourceAttribute, "GraphQLRecoverFunc"))
 		return err2
 	}
 }

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -126,7 +126,7 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 func submitVercelLog(ctx context.Context, projectID int, log VercelLog) {
 	span, _ := highlight.StartTrace(
 		ctx, "highlight-ctx",
-		attribute.String("Source", "SubmitVercelLogs"),
+		attribute.String(highlight.SourceAttribute, "SubmitVercelLogs"),
 		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
 	)
 	defer highlight.EndTrace(span)

--- a/sdk/highlight-go/middleware/fiber/middleware.go
+++ b/sdk/highlight-go/middleware/fiber/middleware.go
@@ -37,7 +37,7 @@ func Middleware() fiber.Handler {
 		highlight.MarkBackendSetup(hCtx)
 		highlight.RecordSpanError(
 			span, err,
-			attribute.String("Source", "GoFiberMiddleware"),
+			attribute.String(highlight.SourceAttribute, "GoFiberMiddleware"),
 			attribute.String(string(semconv.HTTPURLKey), c.BaseURL()),
 			attribute.String(string(semconv.HTTPRouteKey), c.Path()),
 			attribute.String(string(semconv.HTTPMethodKey), c.Method()),

--- a/sdk/highlight-go/tracer.go
+++ b/sdk/highlight-go/tracer.go
@@ -49,7 +49,7 @@ func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 	end := graphql.Now()
 	RecordSpanError(
 		span, err,
-		attribute.String("Source", "InterceptField"),
+		attribute.String(SourceAttribute, "InterceptField"),
 		semconv.GraphqlOperationNameKey.String(name),
 	)
 	EndTrace(span)


### PR DESCRIPTION
## Summary

Our graphql entrypoint `InterceptResponse` creates a span that passes a context to children with that span set.
Nested operations may set the span attributes affecting the parent span, as happens in the following log:  
![Screenshot 2023-03-29 at 10 24 34 AM](https://user-images.githubusercontent.com/1351531/228618982-bad77d7d-1616-4521-91b0-986c046a4543.png)

In general, this standardizes the format of the source to be `frontend` or `backend`.

## How did you test this change?

![Screenshot 2023-03-29 at 10 28 29 AM](https://user-images.githubusercontent.com/1351531/228619832-7c6612fc-12d0-4466-8e1f-ebc39e2513c0.png)

## Are there any deployment considerations?

No.
