### PR TITLE
[hotfix] Make sure we always fetch integration status on setup

### DIFF
--- a/frontend/src/util/integrated.tsx
+++ b/frontend/src/util/integrated.tsx
@@ -165,6 +165,7 @@ export const useClientIntegrated = () => {
 	useEffect(() => {
 		if (!isLoggedIn) return
 		if (localStorageIntegrated) {
+			query()
 			setIntegrated(localStorageIntegrated)
 		} else {
 			query()
@@ -220,6 +221,7 @@ export const useServerIntegrated = () => {
 	useEffect(() => {
 		if (!isLoggedIn) return
 		if (localStorageIntegrated) {
+			query()
 			setIntegrated(localStorageIntegrated)
 		} else {
 			query()


### PR DESCRIPTION
## Summary

The integration status gets stuck in pending/loading because we don't fetch it when we've already cached the status in localStorage.

## How did you test this change?

Local click test.

## Are there any deployment considerations?

We are making more requests now to the integration endpoint. We should circle back on this to eliminate the extra requests if we already know they are integrated.