### PR TITLE
add more context to logs datetime picker when it is closed

### DIFF
--- a/packages/ui/src/components/DatePicker/PreviousDateRangePicker.test.tsx
+++ b/packages/ui/src/components/DatePicker/PreviousDateRangePicker.test.tsx
@@ -33,6 +33,6 @@ describe('getLabel', () => {
 	it('handles when the preset does not match', async () => {
 		const selectedDates = [subtractDays(now, 2), now]
 		const label = getLabel({ selectedDates, presets })
-		expect(label).toEqual('Sun Feb 12 2023 - Tue Feb 14 2023')
+		expect(label).toEqual('Feb 12, 2023, 09:30 PM - Feb 14, 2023, 09:30 PM')
 	})
 })

--- a/packages/ui/src/components/DatePicker/PreviousDateRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/PreviousDateRangePicker.tsx
@@ -42,6 +42,16 @@ const isCustomSelected = ({
 	return !foundPreset
 }
 
+function toDateTimeString(date: Date) {
+	return date.toLocaleDateString('en-us', {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+	})
+}
+
 export const getLabel = ({
 	selectedDates,
 	presets,
@@ -58,7 +68,9 @@ export const getLabel = ({
 	}
 
 	if (selectedDates.length == 2) {
-		return `${selectedDates[0].toDateString()} - ${selectedDates[1].toDateString()}`
+		return `${toDateTimeString(selectedDates[0])} - ${toDateTimeString(
+			selectedDates[1],
+		)}`
 	}
 
 	return ''


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

The relative date time picker doesn't include hours or minutes which can make it hard to understand what the time range is. For example, linking from the sessions, only [looks back the last 4 hours](https://github.com/highlight/highlight/pull/4653/files#diff-79ba7ec6cb62b65929c3c8a0aabc7b5857d3bd339dd50e40382ebf8f61f7194aR105).

This PR adjusts the label when the relative time picker is closed, namely:
* adds hours and minutes to when the relative date time picker is closed
* removes the day of week.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Before:
![Screenshot 2023-03-29 at 2 59 29 PM](https://user-images.githubusercontent.com/58678/228666130-121a2a49-6ba3-42ae-8e67-5a8282d794d2.png)



After:
![Screenshot 2023-03-29 at 2 55 19 PM](https://user-images.githubusercontent.com/58678/228665768-62106bd6-66de-4c09-8c13-9b33b1fa078c.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
