### PR TITLE
improve middleware to trace http request handling

### DIFF
--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -15,7 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const LogAttributeValueLengthLimit = 2 << 10
+const LogAttributeValueLengthLimit = 2 << 12
 const LogRowSourceValueFrontend = "frontend"
 const LogRowSourceValueBackend = "backend"
 

--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -15,7 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const LogAttributeValueLengthLimit = 2 << 12
+const LogAttributeValueLengthLimit = 2 << 10
 const LogRowSourceValueFrontend = "frontend"
 const LogRowSourceValueBackend = "backend"
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -461,7 +461,7 @@ func main() {
 			})
 
 			privateServer.Use(util.NewTracer(util.PrivateGraph))
-			privateServer.Use(H.NewGraphqlTracer(string(util.PrivateGraph)).WithRequestFieldLogging(true))
+			privateServer.Use(H.NewGraphqlTracer(string(util.PrivateGraph)).WithRequestFieldLogging())
 			privateServer.SetErrorPresenter(util.GraphQLErrorPresenter(string(util.PrivateGraph)))
 			privateServer.SetRecoverFunc(util.GraphQLRecoverFunc())
 			r.Handle("/",

--- a/backend/main.go
+++ b/backend/main.go
@@ -461,7 +461,7 @@ func main() {
 			})
 
 			privateServer.Use(util.NewTracer(util.PrivateGraph))
-			privateServer.Use(H.NewGraphqlTracer(string(util.PrivateGraph)))
+			privateServer.Use(H.NewGraphqlTracer(string(util.PrivateGraph)).WithRequestFieldLogging(true))
 			privateServer.SetErrorPresenter(util.GraphQLErrorPresenter(string(util.PrivateGraph)))
 			privateServer.SetRecoverFunc(util.GraphQLRecoverFunc())
 			r.Handle("/",

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 	"io"
 	"net/http"
 	"time"
@@ -413,6 +414,7 @@ func (o *Handler) submitProjectLogs(ctx context.Context, projectLogs map[string]
 
 func (o *Handler) Listen(r *chi.Mux) {
 	r.Route("/otel/v1", func(r chi.Router) {
+		r.Use(highlightChi.Middleware)
 		r.HandleFunc("/traces", o.HandleTrace)
 		r.HandleFunc("/logs", o.HandleLog)
 	})

--- a/backend/vercel/vercel.go
+++ b/backend/vercel/vercel.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-chi/chi"
 	model2 "github.com/highlight-run/highlight/backend/model"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
+	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
@@ -298,6 +299,7 @@ func HandleLog(w http.ResponseWriter, r *http.Request) {
 
 func Listen(r *chi.Mux) {
 	r.Route("/vercel/v1", func(r chi.Router) {
+		r.Use(highlightChi.Middleware)
 		r.HandleFunc("/logs", HandleLog)
 	})
 }

--- a/docs-content/sdk/go.md
+++ b/docs-content/sdk/go.md
@@ -156,3 +156,23 @@ Use this if you are using the raw http server package and need to setup the High
     </code>
   </div>
 </section>
+
+<section className="section">
+  <div className="left">
+    <h3>H.NewGraphqlTracer()</h3> 
+    <p>An http middleware for tracing graphql servers.</p>
+    <h6>Configuration</h6>
+    <aside className="parameter">
+      <h5>H.NewGraphqlTracer().WithRequestFieldLogging()</h5>
+      <p>Emits highlight logs with details of each graphql operation.</p>
+    </aside>
+  </div>
+  <div className="right">
+    <code>
+        // InterceptField traces each graphql field response
+        func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (interface{}, error) { ... }
+        // InterceptResponse encapsulates the entire graphql request
+        func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response { ... }
+    </code>
+  </div>
+</section>

--- a/e2e/go/fiber.go
+++ b/e2e/go/fiber.go
@@ -24,7 +24,7 @@ func main() {
 	app.Use(highlightFiber.Middleware())
 
 	app.Get("/", func(c *fiber.Ctx) error {
-		logrus.WithContext(c.UserContext()).Infof("hello from highlight.io")
+		logrus.WithContext(c.Context()).Infof("hello from highlight.io")
 		if rand.Float64() < 0.2 {
 			return e.New("random error from go fiber!")
 		}

--- a/e2e/go/go.mod
+++ b/e2e/go/go.mod
@@ -4,8 +4,9 @@ go 1.19
 
 require (
 	github.com/gofiber/fiber/v2 v2.42.0
-	github.com/highlight/highlight/sdk/highlight-go v0.9.2
+	github.com/highlight/highlight/sdk/highlight-go v0.9.6
 	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.9.0
 )
 
 require (

--- a/e2e/go/go.sum
+++ b/e2e/go/go.sum
@@ -176,8 +176,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hasura/go-graphql-client v0.9.0 h1:IPL+8CjLrTw4lAJno6qP6e9Nz64+fHSwJTbx4feXI80=
 github.com/hasura/go-graphql-client v0.9.0/go.mod h1:jlTUQWgTJOI4opQssMlCkzVjpRVSyL+PQsTjkAwcr3w=
-github.com/highlight/highlight/sdk/highlight-go v0.9.2 h1:U/axnk3cik7ljQhfvCetIgQctMUtwbmvd+6eQiWuqKc=
-github.com/highlight/highlight/sdk/highlight-go v0.9.2/go.mod h1:VhowtuXaYBYDugF6LAAftX31TraMIHenvA0BFxPdn3c=
+github.com/highlight/highlight/sdk/highlight-go v0.9.6 h1:2Yrhu3IYKVtGHyCd62utFstrdwUhB7W8y3sMGMtwGOU=
+github.com/highlight/highlight/sdk/highlight-go v0.9.6/go.mod h1:HYmYb5OQ59dH0VBySJWnc9Q8vTW8Q0Rx7byUOlMmgB8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -228,6 +228,8 @@ github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d h1:Q+gqLBOPkFGHyCJx
 github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d/go.mod h1:Gy+0tqhJvgGlqnTF8CVGP0AaGRjwBtXs/a5PA0Y3+A4=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -406,6 +408,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/highlight.io/components/QuickstartContent/backend/go/go-gqlgen.tsx
+++ b/highlight.io/components/QuickstartContent/backend/go/go-gqlgen.tsx
@@ -20,7 +20,9 @@ export const GoGqlgenContent: QuickStartContent = {
 		{
 			title: 'Add the Highlight gqlgen error handler.',
 			content:
-				'`H.NewGraphqlTracer` provides a middleware you can add to your [GraphQL](https://gqlgen.com/getting-started/) handler to automatically record and send GraphQL resolver errors to Highlight.',
+				'`H.NewGraphqlTracer` provides a middleware you can add to your [GraphQL](https://gqlgen.com/getting-started/) handler to automatically record and send GraphQL resolver errors to Highlight. ' +
+				'Calling `.WithRequestFieldLogging()` will also emit highlight logs for each graphql operation, giving you a way' +
+				'to search across all graphql requests to your backend.',
 			code: {
 				text: `import (
   H "github.com/highlight/highlight/sdk/highlight-go"
@@ -29,7 +31,9 @@ export const GoGqlgenContent: QuickStartContent = {
 func main() {
   // ...
   server := handler.New(...)
-  server.Use(H.NewGraphqlTracer("your-backend-service-name")
+  // call with WithRequestFieldLogging() to emit highlight logs for each graphql operation
+  // useful for tracing which graphql operations are called as part of which frontend sessions
+  server.Use(H.NewGraphqlTracer("your-backend-service-name").WithRequestFieldLogging())
   // ...
 }`,
 				language: 'go',

--- a/highlight.io/components/QuickstartContent/logging/go/fiber.tsx
+++ b/highlight.io/components/QuickstartContent/logging/go/fiber.tsx
@@ -10,7 +10,7 @@ export const GoFiberLogContent: QuickStartContent = {
 	entries: [
 		previousInstallSnippet('go'),
 		...logrusExample(
-			'c.UserContext()',
+			'c.Context()',
 			`package main
 
 import (
@@ -38,7 +38,7 @@ func main() {
 
   app.Get("/", func(c *fiber.Ctx) error {
   	// in handlers, use logrus with the UserContext to associate logs with the frontend session.
-	logrus.WithContext(c.UserContext()).Infof("hello from highlight.io")
+	logrus.WithContext(c.Context()).Infof("hello from highlight.io")
 	return c.SendString("Hello, World!")
   })
 

--- a/sdk/highlight-go/middleware/chi/middleware.go
+++ b/sdk/highlight-go/middleware/chi/middleware.go
@@ -1,10 +1,11 @@
 package chi
 
 import (
-	"github.com/highlight/highlight/sdk/highlight-go/middleware"
-	"net/http"
-
 	"github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/highlight/highlight/sdk/highlight-go/middleware"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"net/http"
 )
 
 // Middleware is a chi compatible middleware
@@ -18,8 +19,21 @@ func Middleware(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := highlight.InterceptRequest(r)
 		r = r.WithContext(ctx)
-		highlight.MarkBackendSetup(r.Context())
+
+		span, hCtx := highlight.StartTrace(ctx, "highlight/chi")
+		defer highlight.EndTrace(span)
+
 		next.ServeHTTP(w, r)
+
+		highlight.MarkBackendSetup(hCtx)
+		span.SetAttributes(
+			attribute.String(highlight.SourceAttribute, "GoChiMiddleware"),
+			attribute.String(string(semconv.HTTPURLKey), r.URL.String()),
+			attribute.String(string(semconv.HTTPRouteKey), r.URL.RequestURI()),
+			attribute.String(string(semconv.HTTPMethodKey), r.Method),
+			attribute.String(string(semconv.HTTPClientIPKey), middleware.GetIPAddress(r)),
+			attribute.Int(string(semconv.HTTPStatusCodeKey), r.Response.StatusCode),
+		)
 	}
 	return http.HandlerFunc(fn)
 }

--- a/sdk/highlight-go/middleware/chi/middleware.go
+++ b/sdk/highlight-go/middleware/chi/middleware.go
@@ -4,7 +4,6 @@ import (
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"github.com/highlight/highlight/sdk/highlight-go/middleware"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"net/http"
 )
 
@@ -26,14 +25,8 @@ func Middleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 
 		highlight.MarkBackendSetup(hCtx)
-		span.SetAttributes(
-			attribute.String(highlight.SourceAttribute, "GoChiMiddleware"),
-			attribute.String(string(semconv.HTTPURLKey), r.URL.String()),
-			attribute.String(string(semconv.HTTPRouteKey), r.URL.RequestURI()),
-			attribute.String(string(semconv.HTTPMethodKey), r.Method),
-			attribute.String(string(semconv.HTTPClientIPKey), middleware.GetIPAddress(r)),
-			attribute.Int(string(semconv.HTTPStatusCodeKey), r.Response.StatusCode),
-		)
+		span.SetAttributes(attribute.String(highlight.SourceAttribute, "GoChiMiddleware"))
+		span.SetAttributes(middleware.GetRequestAttributes(r)...)
 	}
 	return http.HandlerFunc(fn)
 }

--- a/sdk/highlight-go/middleware/fiber/middleware.go
+++ b/sdk/highlight-go/middleware/fiber/middleware.go
@@ -28,7 +28,7 @@ func Middleware() fiber.Handler {
 			ctx = context.WithValue(ctx, highlight.ContextKeys.RequestID, ids[1])
 		}
 
-		span, hCtx := highlight.StartTrace(ctx, c.OriginalURL())
+		span, hCtx := highlight.StartTrace(ctx, "highlight/fiber")
 		defer highlight.EndTrace(span)
 
 		c.SetUserContext(hCtx)
@@ -38,7 +38,7 @@ func Middleware() fiber.Handler {
 		highlight.RecordSpanError(
 			span, err,
 			attribute.String(highlight.SourceAttribute, "GoFiberMiddleware"),
-			attribute.String(string(semconv.HTTPURLKey), c.BaseURL()),
+			attribute.String(string(semconv.HTTPURLKey), c.OriginalURL()),
 			attribute.String(string(semconv.HTTPRouteKey), c.Path()),
 			attribute.String(string(semconv.HTTPMethodKey), c.Method()),
 			attribute.String(string(semconv.HTTPClientIPKey), c.IP()),

--- a/sdk/highlight-go/middleware/fiber/middleware.go
+++ b/sdk/highlight-go/middleware/fiber/middleware.go
@@ -1,7 +1,6 @@
 package fiber
 
 import (
-	"context"
 	"github.com/gofiber/fiber/v2"
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"github.com/highlight/highlight/sdk/highlight-go/middleware"
@@ -20,12 +19,12 @@ import (
 func Middleware() fiber.Handler {
 	middleware.CheckStatus()
 	return func(c *fiber.Ctx) error {
-		ctx := c.UserContext()
+		ctx := c.Context()
 		highlightReqDetails := c.Request().Header.Peek("X-Highlight-Request")
 		ids := strings.Split(string(highlightReqDetails), "/")
 		if len(ids) >= 2 {
-			ctx = context.WithValue(ctx, highlight.ContextKeys.SessionSecureID, ids[0])
-			ctx = context.WithValue(ctx, highlight.ContextKeys.RequestID, ids[1])
+			ctx.SetUserValue(highlight.ContextKeys.SessionSecureID, ids[0])
+			ctx.SetUserValue(highlight.ContextKeys.RequestID, ids[1])
 		}
 
 		span, hCtx := highlight.StartTrace(ctx, "highlight/fiber")

--- a/sdk/highlight-go/middleware/gin/middleware.go
+++ b/sdk/highlight-go/middleware/gin/middleware.go
@@ -3,7 +3,6 @@ package gin
 import (
 	"github.com/highlight/highlight/sdk/highlight-go/middleware"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -34,14 +33,8 @@ func Middleware() gin.HandlerFunc {
 		c.Next()
 
 		highlight.MarkBackendSetup(hCtx)
-		span.SetAttributes(
-			attribute.String(highlight.SourceAttribute, "GoChiMiddleware"),
-			attribute.String(string(semconv.HTTPURLKey), r.URL.String()),
-			attribute.String(string(semconv.HTTPRouteKey), r.URL.RequestURI()),
-			attribute.String(string(semconv.HTTPMethodKey), r.Method),
-			attribute.String(string(semconv.HTTPClientIPKey), middleware.GetIPAddress(r)),
-			attribute.Int(string(semconv.HTTPStatusCodeKey), r.Response.StatusCode),
-		)
+		span.SetAttributes(attribute.String(highlight.SourceAttribute, "GoChiMiddleware"))
+		span.SetAttributes(middleware.GetRequestAttributes(c.Request)...)
 		if len(c.Errors) > 0 {
 			highlight.RecordSpanError(span, c.Errors[0])
 		}

--- a/sdk/highlight-go/middleware/gin/middleware.go
+++ b/sdk/highlight-go/middleware/gin/middleware.go
@@ -33,7 +33,7 @@ func Middleware() gin.HandlerFunc {
 		c.Next()
 
 		highlight.MarkBackendSetup(hCtx)
-		span.SetAttributes(attribute.String(highlight.SourceAttribute, "GoChiMiddleware"))
+		span.SetAttributes(attribute.String(highlight.SourceAttribute, "GoGinMiddleware"))
 		span.SetAttributes(middleware.GetRequestAttributes(c.Request)...)
 		if len(c.Errors) > 0 {
 			highlight.RecordSpanError(span, c.Errors[0])

--- a/sdk/highlight-go/middleware/gorillamux/middleware.go
+++ b/sdk/highlight-go/middleware/gorillamux/middleware.go
@@ -2,6 +2,8 @@ package gorillamux
 
 import (
 	"github.com/highlight/highlight/sdk/highlight-go/middleware"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"net/http"
 
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -18,8 +20,21 @@ func Middleware(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := highlight.InterceptRequest(r)
 		r = r.WithContext(ctx)
-		highlight.MarkBackendSetup(r.Context())
+
+		span, hCtx := highlight.StartTrace(ctx, "highlight/gorillamux")
+		defer highlight.EndTrace(span)
+
 		next.ServeHTTP(w, r)
+
+		highlight.MarkBackendSetup(hCtx)
+		span.SetAttributes(
+			attribute.String(highlight.SourceAttribute, "GoChiMiddleware"),
+			attribute.String(string(semconv.HTTPURLKey), r.URL.String()),
+			attribute.String(string(semconv.HTTPRouteKey), r.URL.RequestURI()),
+			attribute.String(string(semconv.HTTPMethodKey), r.Method),
+			attribute.String(string(semconv.HTTPClientIPKey), middleware.GetIPAddress(r)),
+			attribute.Int(string(semconv.HTTPStatusCodeKey), r.Response.StatusCode),
+		)
 	}
 	return http.HandlerFunc(fn)
 }

--- a/sdk/highlight-go/middleware/gorillamux/middleware.go
+++ b/sdk/highlight-go/middleware/gorillamux/middleware.go
@@ -3,7 +3,6 @@ package gorillamux
 import (
 	"github.com/highlight/highlight/sdk/highlight-go/middleware"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"net/http"
 
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -27,14 +26,8 @@ func Middleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 
 		highlight.MarkBackendSetup(hCtx)
-		span.SetAttributes(
-			attribute.String(highlight.SourceAttribute, "GoChiMiddleware"),
-			attribute.String(string(semconv.HTTPURLKey), r.URL.String()),
-			attribute.String(string(semconv.HTTPRouteKey), r.URL.RequestURI()),
-			attribute.String(string(semconv.HTTPMethodKey), r.Method),
-			attribute.String(string(semconv.HTTPClientIPKey), middleware.GetIPAddress(r)),
-			attribute.Int(string(semconv.HTTPStatusCodeKey), r.Response.StatusCode),
-		)
+		span.SetAttributes(attribute.String(highlight.SourceAttribute, "GoChiMiddleware"))
+		span.SetAttributes(middleware.GetRequestAttributes(r)...)
 	}
 	return http.HandlerFunc(fn)
 }

--- a/sdk/highlight-go/middleware/gorillamux/middleware.go
+++ b/sdk/highlight-go/middleware/gorillamux/middleware.go
@@ -26,7 +26,7 @@ func Middleware(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 
 		highlight.MarkBackendSetup(hCtx)
-		span.SetAttributes(attribute.String(highlight.SourceAttribute, "GoChiMiddleware"))
+		span.SetAttributes(attribute.String(highlight.SourceAttribute, "GoGorillaMuxMiddleware"))
 		span.SetAttributes(middleware.GetRequestAttributes(r)...)
 	}
 	return http.HandlerFunc(fn)

--- a/sdk/highlight-go/middleware/util.go
+++ b/sdk/highlight-go/middleware/util.go
@@ -3,10 +3,32 @@ package middleware
 import (
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"github.com/sirupsen/logrus"
+	"net/http"
+	"strings"
 )
 
 func CheckStatus() {
 	if !highlight.IsRunning() {
 		logrus.Errorf("[highlight-go] middleware added but highlight is not running. did you forget to run `H.Start(); defer H.Stop()`?")
 	}
+}
+
+func GetIPAddress(r *http.Request) string {
+	// get users ip for geolocation data
+	IPAddress := r.Header.Get("X-Real-Ip")
+	if IPAddress == "" {
+		IPAddress = r.Header.Get("X-Client-IP")
+	}
+	if IPAddress == "" {
+		IPAddress = r.Header.Get("X-Forwarded-For")
+		if IPAddress != "" && strings.Contains(IPAddress, ",") {
+			if ipList := strings.Split(IPAddress, ","); len(ipList) > 0 {
+				IPAddress = ipList[0]
+			}
+		}
+	}
+	if IPAddress == "" {
+		IPAddress = r.RemoteAddr
+	}
+	return IPAddress
 }

--- a/sdk/highlight-go/tracer.go
+++ b/sdk/highlight-go/tracer.go
@@ -99,6 +99,9 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 }
 
 func (t Tracer) logTrace(ctx context.Context, fc *graphql.FieldContext, res interface{}, err error) {
+	if !t.requestFieldLogging {
+		return
+	}
 	lg := logrus.WithContext(ctx).
 		WithField(string(semconv.GraphqlOperationTypeKey), fc.Field.Definition.Type.String()).
 		WithField(string(semconv.GraphqlOperationNameKey), fmt.Sprintf("operation.field.%s", fc.Field.Name)).

--- a/sdk/highlight-go/tracer.go
+++ b/sdk/highlight-go/tracer.go
@@ -112,8 +112,8 @@ func (t Tracer) logTrace(ctx context.Context, res interface{}, err error) {
 		WithField("graphql.graph", t.graphName)
 
 	if err != nil {
-		lg.WithError(err).Errorf("graphql field error %+v: %+v", res, err)
+		lg.WithError(err).Errorf("graphql field error")
 	} else {
-		lg.Debug("graphql field ok")
+		lg.Info("graphql field ok")
 	}
 }

--- a/sdk/highlight-go/tracer.go
+++ b/sdk/highlight-go/tracer.go
@@ -61,7 +61,7 @@ func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 		attribute.String(SourceAttribute, "InterceptField"),
 		semconv.GraphqlOperationNameKey.String(name),
 	)
-	t.logTrace(ctx, res, err)
+	t.log(ctx, res, err)
 	EndTrace(span)
 
 	RecordMetric(ctx, name+".duration", end.Sub(start).Seconds())
@@ -98,7 +98,7 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	return resp
 }
 
-func (t Tracer) logTrace(ctx context.Context, res interface{}, err error) {
+func (t Tracer) log(ctx context.Context, res interface{}, err error) {
 	if !t.requestFieldLogging {
 		return
 	}


### PR DESCRIPTION
## Summary

Improve our highlight graphql `tracer` to allow logging all graphql operations. 
This is particularly handy until we have a better tracing product to allow folks to find
highlight frontend sessions where a particular network request (GraphQL operation) was
called by searching for it in the logs and then finding its session.

Fixes the go/fiber middleware to use the `c.Context()` which is more commonly 
available in customers' codebases rather than the `UserContext()`

## How did you test this change?

<img width="1773" alt="Screenshot 2023-03-30 at 11 49 57 PM" src="https://user-images.githubusercontent.com/1351531/229044825-b69d7d40-dfff-41c7-a898-83b9b8ce29fb.png">

<img width="1740" alt="Screenshot 2023-03-30 at 11 51 09 PM" src="https://user-images.githubusercontent.com/1351531/229045085-cab5097c-8529-4e0d-a393-235948c47569.png">

<img width="1437" alt="Screenshot 2023-03-30 at 11 16 20 PM" src="https://user-images.githubusercontent.com/1351531/229038616-c0916a71-61e0-4bba-bce9-169fe6bf23e5.png">

<img width="1388" alt="Screenshot 2023-03-30 at 11 15 12 PM" src="https://user-images.githubusercontent.com/1351531/229038462-590daa0c-3dea-4db5-be4c-130f5fe92531.png">


## Are there any deployment considerations?

Will deploy new version of the go package.
