### PR TITLE
use materialized view for errors count

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -744,8 +744,6 @@ type DailySessionCount struct {
 
 const (
 	SESSIONS_TBL                    = "sessions"
-	DAILY_ERROR_COUNTS_TBL          = "daily_error_counts"
-	DAILY_ERROR_COUNTS_UNIQ         = "date_project_id_error_type_uniq"
 	METRIC_GROUPS_NAME_SESSION_UNIQ = "metric_groups_name_session_uniq"
 	DASHBOARD_METRIC_FILTERS_UNIQ   = "dashboard_metric_filters_uniq"
 )
@@ -1296,23 +1294,6 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 		return false, e.Wrap(err, "Error migrating db")
 	}
 
-	// Add unique constraint to daily_error_counts
-	if err := DB.Exec(`
-		DO $$
-			BEGIN
-				BEGIN
-					ALTER TABLE daily_error_counts
-					ADD CONSTRAINT date_project_id_error_type_uniq
-						UNIQUE (date, project_id, error_type);
-				EXCEPTION
-					WHEN duplicate_table
-					THEN RAISE NOTICE 'daily_error_counts.date_project_id_error_type_uniq already exists';
-				END;
-			END $$;
-	`).Error; err != nil {
-		return false, e.Wrap(err, "Error adding unique constraint on daily_error_counts")
-	}
-
 	// Drop the null constraint on error_fingerprints.error_group_id
 	// This is necessary for replacing the error_groups.fingerprints association through GORM
 	// (not sure if this is a GORM bug or due to our GORM / Postgres version)
@@ -1353,6 +1334,28 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 		END $$;
 	`).Error; err != nil {
 		return false, e.Wrap(err, "Error creating idx_daily_session_counts_view_project_id_date")
+	}
+
+	if err := DB.Exec(`
+		CREATE MATERIALIZED VIEW IF NOT EXISTS daily_error_counts_view AS
+			SELECT project_id, DATE_TRUNC('day', created_at, 'UTC') as date, COUNT(*) as count
+			FROM error_objects
+			GROUP BY 1, 2;
+	`).Error; err != nil {
+		return false, e.Wrap(err, "Error creating daily_error_counts_view")
+	}
+
+	if err := DB.Exec(`
+		DO $$
+		BEGIN
+			IF NOT EXISTS
+				(select * from pg_indexes where indexname = 'idx_daily_error_counts_view_project_id_date')
+			THEN
+				CREATE UNIQUE INDEX IF NOT EXISTS idx_daily_error_counts_view_project_id_date ON daily_error_counts_view (project_id, date);
+			END IF;
+		END $$;
+	`).Error; err != nil {
+		return false, e.Wrap(err, "Error creating idx_daily_error_counts_view_project_id_date")
 	}
 
 	// Create unique conditional index for billing email history

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1318,6 +1318,7 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 			WHERE excluded <> true
 			AND (active_length >= 1000 OR (active_length is null and length >= 1000))
 			AND processed = true
+			AND created_at > now() - interval '3 months'
 			GROUP BY 1, 2;
 	`).Error; err != nil {
 		return false, e.Wrap(err, "Error creating daily_session_counts_view")
@@ -1340,6 +1341,7 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 		CREATE MATERIALIZED VIEW IF NOT EXISTS daily_error_counts_view AS
 			SELECT project_id, DATE_TRUNC('day', created_at, 'UTC') as date, COUNT(*) as count
 			FROM error_objects
+			WHERE created_at > now() - interval '3 months'
 			GROUP BY 1, 2;
 	`).Error; err != nil {
 		return false, e.Wrap(err, "Error creating daily_error_counts_view")

--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -71,7 +71,7 @@ func GetWorkspaceErrorsMeter(DB *gorm.DB, workspaceID int) (int64, error) {
 	var meter int64
 	if err := DB.Raw(`
 			SELECT COALESCE(SUM(count), 0) as currentPeriodErrorsCount
-			FROM daily_error_counts
+			FROM daily_error_counts_view
 			WHERE project_id in (SELECT id FROM projects WHERE workspace_id=? AND free_tier = false)
 			AND date >= (
 				SELECT COALESCE(next_invoice_date - interval '1 month', billing_period_start, date_trunc('month', now(), 'UTC'))

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4652,8 +4652,8 @@ func (r *queryResolver) DailyErrorsCount(ctx context.Context, projectID int, dat
 	startDateUTC := time.Date(dateRange.StartDate.UTC().Year(), dateRange.StartDate.UTC().Month(), dateRange.StartDate.UTC().Day(), 0, 0, 0, 0, time.UTC)
 	endDateUTC := time.Date(dateRange.EndDate.UTC().Year(), dateRange.EndDate.UTC().Month(), dateRange.EndDate.UTC().Day(), 0, 0, 0, 0, time.UTC)
 
-	if err := r.DB.Where("project_id = ?", projectID).Where("date BETWEEN ? AND ?", startDateUTC, endDateUTC).Find(&dailyErrors).Error; err != nil {
-		return nil, e.Wrap(err, "error reading from daily errors")
+	if err := r.DB.Raw("SELECT * FROM daily_error_counts_view WHERE date BETWEEN ? AND ? AND project_id = ?", startDateUTC, endDateUTC, projectID).Find(&dailyErrors).Error; err != nil {
+		return nil, e.Wrap(err, "error reading from daily sessions")
 	}
 
 	return dailyErrors, nil

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2252,38 +2252,11 @@ func extractErrorFields(sessionObj *model.Session, errorToProcess *model.ErrorOb
 	return errorFields
 }
 
-func (r *Resolver) updateErrorsCount(ctx context.Context, errorsByProject map[int]int64, errorsBySession map[string]int64, errors int, errorType string) {
+func (r *Resolver) updateErrorsCount(ctx context.Context, errorsBySession map[string]int64, errors int, errorType string) {
 	dailyErrorCountSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.processBackendPayload", tracer.ResourceName("db.updateDailyErrorCounts"))
 	dailyErrorCountSpan.SetTag("numberOfErrors", errors)
-	dailyErrorCountSpan.SetTag("numberOfProjects", len(errorsByProject))
 	dailyErrorCountSpan.SetTag("numberOfSessions", len(errorsBySession))
 	defer dailyErrorCountSpan.Finish()
-
-	// For each project, increment daily error count by the current error count
-	n := time.Now()
-	currentDate := time.Date(n.UTC().Year(), n.UTC().Month(), n.UTC().Day(), 0, 0, 0, 0, time.UTC)
-
-	dailyErrorCounts := make([]*model.DailyErrorCount, 0)
-	for projectId, count := range errorsByProject {
-		errorCount := model.DailyErrorCount{
-			ProjectID: projectId,
-			Date:      &currentDate,
-			Count:     count,
-			ErrorType: errorType,
-		}
-		dailyErrorCounts = append(dailyErrorCounts, &errorCount)
-	}
-
-	// Upsert error counts into daily_error_counts
-	if err := r.DB.Table(model.DAILY_ERROR_COUNTS_TBL).Clauses(clause.OnConflict{
-		OnConstraint: model.DAILY_ERROR_COUNTS_UNIQ,
-		DoUpdates:    clause.Assignments(map[string]interface{}{"count": gorm.Expr("daily_error_counts.count + excluded.count")}),
-	}).Create(&dailyErrorCounts).Error; err != nil {
-		wrapped := e.Wrap(err, "error updating daily error count")
-		dailyErrorCountSpan.Finish(tracer.WithError(wrapped))
-		log.WithContext(ctx).Error(wrapped)
-		return
-	}
 
 	for sessionSecureId, count := range errorsBySession {
 		if err := r.PushMetricsImpl(context.Background(), sessionSecureId, []*publicModel.MetricInput{
@@ -2357,16 +2330,14 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 	}
 
 	// Count the number of errors for each project
-	errorsByProject := make(map[int]int64)
 	errorsBySession := make(map[string]int64)
 	for _, err := range errorObjects {
 		if err.SessionSecureID != nil {
 			errorsBySession[*err.SessionSecureID] += 1
 		}
-		errorsByProject[projectID] += 1
 	}
 
-	r.updateErrorsCount(ctx, errorsByProject, errorsBySession, len(errorObjects), model.ErrorType.BACKEND)
+	r.updateErrorsCount(ctx, errorsBySession, len(errorObjects), model.ErrorType.BACKEND)
 
 	// put errors in db
 	putErrorsToDBSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.processBackendPayload",
@@ -2853,7 +2824,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		// increment daily error table
 		numErrors := int64(len(errors))
 		if numErrors > 0 {
-			r.updateErrorsCount(ctx, map[int]int64{projectID: numErrors}, map[string]int64{sessionSecureID: numErrors}, len(errors), model.ErrorType.FRONTEND)
+			r.updateErrorsCount(ctx, map[string]int64{sessionSecureID: numErrors}, len(errors), model.ErrorType.FRONTEND)
 		}
 
 		// put errors in db

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -56,8 +56,8 @@ const MAX_RETRIES = 5
 // cancel events_objects reads after 5 minutes
 const EVENTS_READ_TIMEOUT = 300000
 
-// cancel refreshing materialized views after 15 minutes
-const REFRESH_MATERIALIZED_VIEW_TIMEOUT = 15 * 60 * 1000
+// cancel refreshing materialized views after 30 minutes
+const REFRESH_MATERIALIZED_VIEW_TIMEOUT = 30 * 60 * 1000
 
 type Worker struct {
 	Resolver       *mgraph.Resolver
@@ -1238,6 +1238,20 @@ func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
 		log.WithContext(ctx).Fatal(e.Wrap(err, "Error refreshing daily_session_counts_view"))
 	}
 
+	if err := w.Resolver.DB.Transaction(func(tx *gorm.DB) error {
+		err := tx.Exec(fmt.Sprintf("SET LOCAL statement_timeout TO %d", REFRESH_MATERIALIZED_VIEW_TIMEOUT)).Error
+		if err != nil {
+			return err
+		}
+
+		return tx.Exec(`
+			REFRESH MATERIALIZED VIEW CONCURRENTLY daily_error_counts_view;
+		`).Error
+
+	}); err != nil {
+		log.WithContext(ctx).Fatal(e.Wrap(err, "Error refreshing daily_error_counts_view"))
+	}
+
 	type AggregateSessionCount struct {
 		WorkspaceID  int   `json:"workspace_id"`
 		SessionCount int64 `json:"session_count"`
@@ -1249,7 +1263,7 @@ func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
 		SELECT p.workspace_id, sum(dsc.count) as session_count, sum(dec.count) as error_count
 		FROM projects p
 				 INNER JOIN daily_session_counts_view dsc on p.id = dsc.project_id
-				 INNER JOIN daily_error_counts dec on p.id = dec.project_id
+				 INNER JOIN daily_error_counts_view dec on p.id = dec.project_id
 		GROUP BY p.workspace_id`).Scan(&counts).Error; err != nil {
 		log.WithContext(ctx).Fatal(e.Wrap(err, "Error retrieving session counts for Hubspot update"))
 	}


### PR DESCRIPTION
## Summary
- `daily_error_counts` was overcounting - switch this to use a materialized view similar to the sessions count instead
- cleanup some now-unused code
- increase timeout to 30 mins per refresh
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested errors count in billing query locally
- tested `make refresh-materialized-views`
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
