### PR TITLE
fix STRIPE_INTEGRATION_ERROR for grandfathered-in plans

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1220,7 +1220,7 @@ func (r *mutationResolver) CreateOrUpdateStripeSubscription(ctx context.Context,
 	}
 
 	// default to unlimited members pricing
-	prices, err := pricing.GetStripePrices(r.StripeClient, planType, pricingInterval, true, retentionPeriod)
+	prices, err := pricing.GetStripePrices(r.StripeClient, planType, pricingInterval, true, &retentionPeriod)
 	if err != nil {
 		return nil, e.Wrap(err, "STRIPE_INTEGRATION_ERROR cannot update stripe subscription - failed to get Stripe prices")
 	}


### PR DESCRIPTION
## Summary
- our stripe integration was failing to update details for older plans (e.g. ones without unlimited members) because `|SixMonths` was being appended to the lookup key
- default to the `3 month` prices instead (which doesn't add anything extra to the lookup key)
- don't update the workspace's retention period after the billing period ends to preserve the null  value
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran `make report-stripe-usage` locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- need to set `workspace.retention_period` to null for grandfathered 6 month retention customers 
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
