### PR TITLE
remove actual error message from logs error state

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -52,11 +52,12 @@ export const LogsTable = (props: Props) => {
 	if (props.error) {
 		return (
 			<FullScreenContainer>
-				<Box style={{ minWidth: 300 }}>
+				<Box m="auto" style={{ maxWidth: 300 }}>
 					<Callout title="Failed to load logs" kind="error">
 						<Box mb="6">
 							<Text color="moderate">
-								{props.error.message.toString()}
+								There was an error loading your logs. Reach out
+								to us if this might be a bug.
 							</Text>
 						</Box>
 						<Stack direction="row">


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

In #4738 we added an error state for logs. After looking at this with a real error, we decided that we shouldn't actually show the raw message of the error and should just show a generic message.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->


![Screenshot 2023-03-31 at 11 16 50 AM](https://user-images.githubusercontent.com/58678/229187069-9f4d99f1-5d07-4342-a036-9d1a02aef287.png)

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A