### PR TITLE
escape log attribute searches

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -522,11 +522,14 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 	}
 
 	for key, value := range filters.attributes {
-		column := fmt.Sprintf("LogAttributes['%s']", key)
 		if strings.Contains(value, "%") {
-			sb.Where(sb.Like(column, value))
+			sb.Where(
+				sb.Var(sqlbuilder.Buildf("LogAttributes[%s] LIKE %s", key, value)),
+			)
 		} else {
-			sb.Where(sb.Equal(column, value))
+			sb.Where(
+				sb.Var(sqlbuilder.Buildf("LogAttributes[%s] = %s", key, value)),
+			)
 		}
 	}
 

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -1149,3 +1149,37 @@ func TestExpandJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestBadInput(t *testing.T) {
+	ctx := context.Background()
+	client, teardown := setupTest(t)
+	defer teardown(t)
+
+	now := time.Now()
+
+	testcases := []string{"\"asdf': asdf\""}
+
+	for _, userInput := range testcases {
+		_, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+			DateRange: makeDateWithinRange(now),
+			Query:     userInput,
+		}, Pagination{})
+		assert.NoError(t, err)
+	}
+}
+
+func FuzzReadLogs(f *testing.F) {
+	ctx := context.Background()
+	client, teardown := setupTest(f)
+	defer teardown(f)
+
+	now := time.Now()
+
+	f.Fuzz(func(t *testing.T, userInput string) {
+		_, err := client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+			DateRange: makeDateWithinRange(now),
+			Query:     userInput,
+		}, Pagination{})
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Log attribute searches are not escaped.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Added a unit test to confirm we don't error.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
