### PR TITLE
Ignore error groups by regex

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -323,6 +323,7 @@ type Project struct {
 	WorkspaceID         int
 	FreeTier            bool           `gorm:"default:false"`
 	ExcludedUsers       pq.StringArray `json:"excluded_users" gorm:"type:text[]"`
+	ErrorFilters        pq.StringArray `gorm:"type:text[]"`
 	ErrorJsonPaths      pq.StringArray `gorm:"type:text[]"`
 
 	// During metrics querying for network requests, only keep these relevant URLs

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -8468,7 +8468,7 @@ type Project {
 	secret: String
 	workspace_id: ID!
 	excluded_users: StringArray
-	error_filters: StringArray!
+	error_filters: StringArray
 	error_json_paths: StringArray
 	rage_click_window_seconds: Int
 	rage_click_radius_pixels: Int
@@ -36877,14 +36877,11 @@ func (ec *executionContext) _Project_error_filters(ctx context.Context, field gr
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(pq.StringArray)
 	fc.Result = res
-	return ec.marshalNStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, field.Selections, res)
+	return ec.marshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Project_error_filters(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -63771,9 +63768,6 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Values[i] = ec._Project_error_filters(ctx, field, obj)
 
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "error_json_paths":
 
 			out.Values[i] = ec._Project_error_json_paths(ctx, field, obj)
@@ -72709,27 +72703,6 @@ func (ec *executionContext) marshalNString2ᚖstring(ctx context.Context, sel as
 		return graphql.Null
 	}
 	res := graphql.MarshalString(*v)
-	if res == graphql.Null {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-	}
-	return res
-}
-
-func (ec *executionContext) unmarshalNStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx context.Context, v interface{}) (pq.StringArray, error) {
-	res, err := model1.UnmarshalStringArray(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx context.Context, sel ast.SelectionSet, v pq.StringArray) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	res := model1.MarshalStringArray(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -8468,7 +8468,7 @@ type Project {
 	secret: String
 	workspace_id: ID!
 	excluded_users: StringArray
-	error_filters: StringArray
+	error_filters: StringArray!
 	error_json_paths: StringArray
 	rage_click_window_seconds: Int
 	rage_click_radius_pixels: Int
@@ -11476,7 +11476,6 @@ func (ec *executionContext) field_Mutation_editProject_args(ctx context.Context,
 		}
 	}
 	args["backend_domains"] = arg9
-
 	var arg10 *bool
 	if tmp, ok := rawArgs["filter_chrome_extension"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filter_chrome_extension"))
@@ -36878,11 +36877,14 @@ func (ec *executionContext) _Project_error_filters(ctx context.Context, field gr
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(pq.StringArray)
 	fc.Result = res
-	return ec.marshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, field.Selections, res)
+	return ec.marshalNStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Project_error_filters(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -63769,6 +63771,9 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Values[i] = ec._Project_error_filters(ctx, field, obj)
 
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "error_json_paths":
 
 			out.Values[i] = ec._Project_error_json_paths(ctx, field, obj)
@@ -72704,6 +72709,27 @@ func (ec *executionContext) marshalNString2ᚖstring(ctx context.Context, sel as
 		return graphql.Null
 	}
 	res := graphql.MarshalString(*v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx context.Context, v interface{}) (pq.StringArray, error) {
+	res, err := model1.UnmarshalStringArray(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx context.Context, sel ast.SelectionSet, v pq.StringArray) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	res := model1.MarshalStringArray(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -631,7 +631,7 @@ type ComplexityRoot struct {
 		DeleteSessionComment             func(childComplexity int, id int) int
 		DeleteSessions                   func(childComplexity int, projectID int, query string, sessionCount int) int
 		EditErrorSegment                 func(childComplexity int, id int, projectID int, params model.ErrorSearchParamsInput, name string) int
-		EditProject                      func(childComplexity int, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool) int
+		EditProject                      func(childComplexity int, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool) int
 		EditSegment                      func(childComplexity int, id int, projectID int, params model.SearchParamsInput, name string) int
 		EditWorkspace                    func(childComplexity int, id int, name *string) int
 		EmailSignup                      func(childComplexity int, email string) int
@@ -707,6 +707,7 @@ type ComplexityRoot struct {
 	Project struct {
 		BackendDomains         func(childComplexity int) int
 		BillingEmail           func(childComplexity int) int
+		ErrorFilters           func(childComplexity int) int
 		ErrorJsonPaths         func(childComplexity int) int
 		ExcludedUsers          func(childComplexity int) int
 		FilterChromeExtension  func(childComplexity int) int
@@ -1237,7 +1238,7 @@ type MutationResolver interface {
 	CreateAdmin(ctx context.Context) (*model1.Admin, error)
 	CreateProject(ctx context.Context, name string, workspaceID int) (*model1.Project, error)
 	CreateWorkspace(ctx context.Context, name string, promoCode *string) (*model1.Workspace, error)
-	EditProject(ctx context.Context, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool) (*model1.Project, error)
+	EditProject(ctx context.Context, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool) (*model1.Project, error)
 	EditWorkspace(ctx context.Context, id int, name *string) (*model1.Workspace, error)
 	MarkErrorGroupAsViewed(ctx context.Context, errorSecureID string, viewed *bool) (*model1.ErrorGroup, error)
 	MarkSessionAsViewed(ctx context.Context, secureID string, viewed *bool) (*model1.Session, error)
@@ -4287,7 +4288,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.EditProject(childComplexity, args["id"].(int), args["name"].(*string), args["billing_email"].(*string), args["excluded_users"].(pq.StringArray), args["error_json_paths"].(pq.StringArray), args["rage_click_window_seconds"].(*int), args["rage_click_radius_pixels"].(*int), args["rage_click_count"].(*int), args["backend_domains"].(pq.StringArray), args["filter_chrome_extension"].(*bool)), true
+		return e.complexity.Mutation.EditProject(childComplexity, args["id"].(int), args["name"].(*string), args["billing_email"].(*string), args["excluded_users"].(pq.StringArray), args["error_filters"].(pq.StringArray), args["error_json_paths"].(pq.StringArray), args["rage_click_window_seconds"].(*int), args["rage_click_radius_pixels"].(*int), args["rage_click_count"].(*int), args["backend_domains"].(pq.StringArray), args["filter_chrome_extension"].(*bool)), true
 
 	case "Mutation.editSegment":
 		if e.complexity.Mutation.EditSegment == nil {
@@ -4887,6 +4888,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Project.BillingEmail(childComplexity), true
+
+	case "Project.error_filters":
+		if e.complexity.Project.ErrorFilters == nil {
+			break
+		}
+
+		return e.complexity.Project.ErrorFilters(childComplexity), true
 
 	case "Project.error_json_paths":
 		if e.complexity.Project.ErrorJsonPaths == nil {
@@ -8460,6 +8468,7 @@ type Project {
 	secret: String
 	workspace_id: ID!
 	excluded_users: StringArray
+	error_filters: StringArray
 	error_json_paths: StringArray
 	rage_click_window_seconds: Int
 	rage_click_radius_pixels: Int
@@ -9732,6 +9741,7 @@ type Mutation {
 		name: String
 		billing_email: String
 		excluded_users: StringArray
+		error_filters: StringArray
 		error_json_paths: StringArray
 		rage_click_window_seconds: Int
 		rage_click_radius_pixels: Int
@@ -11413,59 +11423,69 @@ func (ec *executionContext) field_Mutation_editProject_args(ctx context.Context,
 	}
 	args["excluded_users"] = arg3
 	var arg4 pq.StringArray
-	if tmp, ok := rawArgs["error_json_paths"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_json_paths"))
+	if tmp, ok := rawArgs["error_filters"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_filters"))
 		arg4, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["error_json_paths"] = arg4
-	var arg5 *int
-	if tmp, ok := rawArgs["rage_click_window_seconds"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_window_seconds"))
-		arg5, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+	args["error_filters"] = arg4
+	var arg5 pq.StringArray
+	if tmp, ok := rawArgs["error_json_paths"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_json_paths"))
+		arg5, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["rage_click_window_seconds"] = arg5
+	args["error_json_paths"] = arg5
 	var arg6 *int
-	if tmp, ok := rawArgs["rage_click_radius_pixels"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_radius_pixels"))
+	if tmp, ok := rawArgs["rage_click_window_seconds"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_window_seconds"))
 		arg6, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["rage_click_radius_pixels"] = arg6
+	args["rage_click_window_seconds"] = arg6
 	var arg7 *int
-	if tmp, ok := rawArgs["rage_click_count"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_count"))
+	if tmp, ok := rawArgs["rage_click_radius_pixels"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_radius_pixels"))
 		arg7, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["rage_click_count"] = arg7
-	var arg8 pq.StringArray
+	args["rage_click_radius_pixels"] = arg7
+	var arg8 *int
+	if tmp, ok := rawArgs["rage_click_count"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_count"))
+		arg8, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["rage_click_count"] = arg8
+	var arg9 pq.StringArray
 	if tmp, ok := rawArgs["backend_domains"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("backend_domains"))
-		arg8, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
+		arg9, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["backend_domains"] = arg8
-	var arg9 *bool
+	args["backend_domains"] = arg9
+
+	var arg10 *bool
 	if tmp, ok := rawArgs["filter_chrome_extension"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filter_chrome_extension"))
-		arg9, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		arg10, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["filter_chrome_extension"] = arg9
+	args["filter_chrome_extension"] = arg10
 	return args, nil
 }
 
@@ -30822,6 +30842,8 @@ func (ec *executionContext) fieldContext_Mutation_updateAdminAndCreateWorkspace(
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -31024,6 +31046,8 @@ func (ec *executionContext) fieldContext_Mutation_createProject(ctx context.Cont
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -31155,7 +31179,7 @@ func (ec *executionContext) _Mutation_editProject(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().EditProject(rctx, fc.Args["id"].(int), fc.Args["name"].(*string), fc.Args["billing_email"].(*string), fc.Args["excluded_users"].(pq.StringArray), fc.Args["error_json_paths"].(pq.StringArray), fc.Args["rage_click_window_seconds"].(*int), fc.Args["rage_click_radius_pixels"].(*int), fc.Args["rage_click_count"].(*int), fc.Args["backend_domains"].(pq.StringArray), fc.Args["filter_chrome_extension"].(*bool))
+		return ec.resolvers.Mutation().EditProject(rctx, fc.Args["id"].(int), fc.Args["name"].(*string), fc.Args["billing_email"].(*string), fc.Args["excluded_users"].(pq.StringArray), fc.Args["error_filters"].(pq.StringArray), fc.Args["error_json_paths"].(pq.StringArray), fc.Args["rage_click_window_seconds"].(*int), fc.Args["rage_click_radius_pixels"].(*int), fc.Args["rage_click_count"].(*int), fc.Args["backend_domains"].(pq.StringArray), fc.Args["filter_chrome_extension"].(*bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -31190,6 +31214,8 @@ func (ec *executionContext) fieldContext_Mutation_editProject(ctx context.Contex
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -36831,6 +36857,47 @@ func (ec *executionContext) fieldContext_Project_excluded_users(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _Project_error_filters(ctx context.Context, field graphql.CollectedField, obj *model1.Project) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Project_error_filters(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ErrorFilters, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(pq.StringArray)
+	fc.Result = res
+	return ec.marshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Project_error_filters(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Project",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type StringArray does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Project_error_json_paths(ctx context.Context, field graphql.CollectedField, obj *model1.Project) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Project_error_json_paths(ctx, field)
 	if err != nil {
@@ -41232,6 +41299,8 @@ func (ec *executionContext) fieldContext_Query_projects(ctx context.Context, fie
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -42287,6 +42356,8 @@ func (ec *executionContext) fieldContext_Query_projectSuggestion(ctx context.Con
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -43572,6 +43643,8 @@ func (ec *executionContext) fieldContext_Query_project(ctx context.Context, fiel
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -54647,6 +54720,8 @@ func (ec *executionContext) fieldContext_Workspace_projects(ctx context.Context,
 				return ec.fieldContext_Project_workspace_id(ctx, field)
 			case "excluded_users":
 				return ec.fieldContext_Project_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_Project_error_filters(ctx, field)
 			case "error_json_paths":
 				return ec.fieldContext_Project_error_json_paths(ctx, field)
 			case "rage_click_window_seconds":
@@ -63689,6 +63764,10 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 		case "excluded_users":
 
 			out.Values[i] = ec._Project_excluded_users(ctx, field, obj)
+
+		case "error_filters":
+
+			out.Values[i] = ec._Project_error_filters(ctx, field, obj)
 
 		case "error_json_paths":
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -315,7 +315,7 @@ type Project {
 	secret: String
 	workspace_id: ID!
 	excluded_users: StringArray
-	error_filters: StringArray
+	error_filters: StringArray!
 	error_json_paths: StringArray
 	rage_click_window_seconds: Int
 	rage_click_radius_pixels: Int

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -315,6 +315,7 @@ type Project {
 	secret: String
 	workspace_id: ID!
 	excluded_users: StringArray
+	error_filters: StringArray
 	error_json_paths: StringArray
 	rage_click_window_seconds: Int
 	rage_click_radius_pixels: Int
@@ -1587,6 +1588,7 @@ type Mutation {
 		name: String
 		billing_email: String
 		excluded_users: StringArray
+		error_filters: StringArray
 		error_json_paths: StringArray
 		rage_click_window_seconds: Int
 		rage_click_radius_pixels: Int

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -315,7 +315,7 @@ type Project {
 	secret: String
 	workspace_id: ID!
 	excluded_users: StringArray
-	error_filters: StringArray!
+	error_filters: StringArray
 	error_json_paths: StringArray
 	rage_click_window_seconds: Int
 	rage_click_radius_pixels: Int

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -556,7 +556,7 @@ func (r *mutationResolver) CreateWorkspace(ctx context.Context, name string, pro
 }
 
 // EditProject is the resolver for the editProject field.
-func (r *mutationResolver) EditProject(ctx context.Context, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool) (*model.Project, error) {
+func (r *mutationResolver) EditProject(ctx context.Context, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool) (*model.Project, error) {
 	project, err := r.isAdminInProject(ctx, id)
 	if err != nil {
 		return nil, e.Wrap(err, "error querying project")
@@ -579,6 +579,7 @@ func (r *mutationResolver) EditProject(ctx context.Context, id int, name *string
 		Name:                  name,
 		BillingEmail:          billingEmail,
 		ExcludedUsers:         excludedUsers,
+		ErrorFilters:  	 	   errorFilters,
 		ErrorJsonPaths:        errorJSONPaths,
 		BackendDomains:        backendDomains,
 		FilterChromeExtension: filterChromeExtension,

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -579,7 +579,7 @@ func (r *mutationResolver) EditProject(ctx context.Context, id int, name *string
 		Name:                  name,
 		BillingEmail:          billingEmail,
 		ExcludedUsers:         excludedUsers,
-		ErrorFilters:  	 	   errorFilters,
+		ErrorFilters:          errorFilters,
 		ErrorJsonPaths:        errorJSONPaths,
 		BackendDomains:        backendDomains,
 		FilterChromeExtension: filterChromeExtension,

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2346,9 +2346,14 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 	for _, errorObject := range errorObjects {
 
 		// Filter out by project.ErrorFilters, aka regexp filters
+		var err error
 		matchedRegexp := false
 		for _, errorFilter := range project.ErrorFilters {
-			matchedRegexp, _ = regexp.MatchString(errorFilter, errorObject.Event)
+			matchedRegexp, err = regexp.MatchString(errorFilter, errorObject.Event)
+			if err != nil {
+				log.WithContext(ctx).WithField("regex", errorFilter).WithError(err).Error("invalid regex: failed to parse backend error filter")
+				continue
+			}
 
 			if matchedRegexp {
 				break
@@ -2908,6 +2913,10 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			matchedRegexp := false
 			for _, errorFilter := range project.ErrorFilters {
 				matchedRegexp, err = regexp.MatchString(errorFilter, v.Event)
+				if err != nil {
+					log.WithContext(ctx).WithField("regex", errorFilter).WithError(err).Error("invalid regex: failed to parse error filter")
+					continue
+				}
 
 				if matchedRegexp {
 					return nil

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2875,12 +2875,28 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			VisitedURL string
 			SessionObj *model.Session
 		})
+
+		var project model.Project
+		if err := r.DB.Where(&model.Project{Model: model.Model{ID: projectID}}).First(&project).Error; err != nil {
+			return e.Wrap(err, "error querying project")
+		}
+
 		for _, v := range errors {
 			traceBytes, err := json.Marshal(v.StackTrace)
 			if err != nil {
 				log.WithContext(ctx).Errorf("Error marshaling trace: %v", v.StackTrace)
 				continue
 			}
+
+			matched := false
+			for _, errorFilter := range project.ErrorFilters {
+				matched, err = regexp.MatchString(errorFilter, v.Event)
+
+				if matched {
+					return nil
+				}
+			}
+
 			traceString := string(traceBytes)
 
 			errorToInsert := &model.ErrorObject{

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2338,7 +2338,7 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 
 	var project model.Project
 	if err := r.DB.Where(&model.Project{Model: model.Model{ID: projectID}}).First(&project).Error; err != nil {
-		return
+		log.WithContext(ctx).WithError(err).WithField("project", project).WithField("projectVerboseID", projectVerboseID).Error("failed to find project")
 	}
 
 	// Filter out empty errors

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"github.com/highlight-run/highlight/backend/timeseries"
 	"github.com/highlight-run/workerpool"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"strconv"
 	"testing"
@@ -226,4 +227,12 @@ func TestHandleErrorAndGroup(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolver_isExcludedError(t *testing.T) {
+	r := &Resolver{}
+	assert.False(t, r.isExcludedError(context.Background(), []string{}, ""))
+	assert.True(t, r.isExcludedError(context.Background(), []string{}, "[{}]"))
+	assert.True(t, r.isExcludedError(context.Background(), []string{".*a+.*"}, "foo bar baz"))
+	assert.False(t, r.isExcludedError(context.Background(), []string{"("}, "foo bar baz"))
 }

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -231,8 +231,8 @@ func TestHandleErrorAndGroup(t *testing.T) {
 
 func TestResolver_isExcludedError(t *testing.T) {
 	r := &Resolver{}
-	assert.False(t, r.isExcludedError(context.Background(), []string{}, ""))
-	assert.True(t, r.isExcludedError(context.Background(), []string{}, "[{}]"))
-	assert.True(t, r.isExcludedError(context.Background(), []string{".*a+.*"}, "foo bar baz"))
-	assert.False(t, r.isExcludedError(context.Background(), []string{"("}, "foo bar baz"))
+	assert.False(t, r.isExcludedError(context.Background(), []string{}, "", 1))
+	assert.True(t, r.isExcludedError(context.Background(), []string{}, "[{}]", 2))
+	assert.True(t, r.isExcludedError(context.Background(), []string{".*a+.*"}, "foo bar baz", 3))
+	assert.False(t, r.isExcludedError(context.Background(), []string{"("}, "foo bar baz", 4))
 }

--- a/docs-content/general/6_product-features/2_error-monitoring/ignoring-errors.md
+++ b/docs-content/general/6_product-features/2_error-monitoring/ignoring-errors.md
@@ -17,7 +17,7 @@ If your users are using chrome extensions, you may see errors that are not relev
 If you have alerts set up for your project, you can ignore specific error groups from triggering alerts. You can do this by clicking the "Ignore" button on the error group page.
 
 ## Ignore errors by regex on the error body
-If you'd like to ignore specific errors by regex pattern match against the error body, you can do so by adding error filters in your [project settings](https://app.highlight.io/settings/errors#filters).
+If you'd like to ignore specific errors by a regex pattern match against the error body, you can do so by adding error filters in your [project settings](https://app.highlight.io/settings/errors#filters) as well.
 
 ## Want to ignore something else?
 If you'd like an easier way to ignore specific types of errors, we're open to feedback. Please reach out to us in our [discord community](https://highlight.io/community).

--- a/docs-content/general/6_product-features/2_error-monitoring/ignoring-errors.md
+++ b/docs-content/general/6_product-features/2_error-monitoring/ignoring-errors.md
@@ -17,7 +17,7 @@ If your users are using chrome extensions, you may see errors that are not relev
 If you have alerts set up for your project, you can ignore specific error groups from triggering alerts. You can do this by clicking the "Ignore" button on the error group page.
 
 ## Ignore errors by regex on the error body
-Coming soon.
+If you'd like to ignore specific errors by regex pattern match against the error body, you can do so by adding error filters in your [project settings](https://app.highlight.io/settings/errors#filters).
 
 ## Want to ignore something else?
 If you'd like an easier way to ignore specific types of errors, we're open to feedback. Please reach out to us in our [discord community](https://highlight.io/community).

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -7137,6 +7137,7 @@ export const GetProjectDropdownOptionsDocument = gql`
 			billing_email
 			secret
 			workspace_id
+			error_filters
 		}
 		workspace: workspace_for_project(project_id: $project_id) {
 			id

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -1274,6 +1274,7 @@ export const EditProjectDocument = gql`
 		$name: String
 		$billing_email: String
 		$excluded_users: StringArray
+		$error_filters: StringArray
 		$error_json_paths: StringArray
 		$filter_chrome_extension: Boolean
 		$rage_click_window_seconds: Int
@@ -1286,6 +1287,7 @@ export const EditProjectDocument = gql`
 			name: $name
 			billing_email: $billing_email
 			excluded_users: $excluded_users
+			error_filters: $error_filters
 			error_json_paths: $error_json_paths
 			filter_chrome_extension: $filter_chrome_extension
 			rage_click_window_seconds: $rage_click_window_seconds
@@ -1297,6 +1299,7 @@ export const EditProjectDocument = gql`
 			name
 			billing_email
 			excluded_users
+			error_filters
 			error_json_paths
 			filter_chrome_extension
 			rage_click_window_seconds
@@ -1328,6 +1331,7 @@ export type EditProjectMutationFn = Apollo.MutationFunction<
  *      name: // value for 'name'
  *      billing_email: // value for 'billing_email'
  *      excluded_users: // value for 'excluded_users'
+ *      error_filters: // value for 'error_filters'
  *      error_json_paths: // value for 'error_json_paths'
  *      filter_chrome_extension: // value for 'filter_chrome_extension'
  *      rage_click_window_seconds: // value for 'rage_click_window_seconds'
@@ -7540,6 +7544,7 @@ export const GetProjectDocument = gql`
 			verbose_id
 			billing_email
 			excluded_users
+			error_filters
 			error_json_paths
 			filter_chrome_extension
 			rage_click_window_seconds

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -238,6 +238,7 @@ export type EditProjectMutationVariables = Types.Exact<{
 	name?: Types.Maybe<Types.Scalars['String']>
 	billing_email?: Types.Maybe<Types.Scalars['String']>
 	excluded_users?: Types.Maybe<Types.Scalars['StringArray']>
+	error_filters?: Types.Maybe<Types.Scalars['StringArray']>
 	error_json_paths?: Types.Maybe<Types.Scalars['StringArray']>
 	filter_chrome_extension?: Types.Maybe<Types.Scalars['Boolean']>
 	rage_click_window_seconds?: Types.Maybe<Types.Scalars['Int']>
@@ -254,6 +255,7 @@ export type EditProjectMutation = { __typename?: 'Mutation' } & {
 			| 'name'
 			| 'billing_email'
 			| 'excluded_users'
+			| 'error_filters'
 			| 'error_json_paths'
 			| 'filter_chrome_extension'
 			| 'rage_click_window_seconds'
@@ -2585,6 +2587,7 @@ export type GetProjectQuery = { __typename?: 'Query' } & {
 			| 'verbose_id'
 			| 'billing_email'
 			| 'excluded_users'
+			| 'error_filters'
 			| 'error_json_paths'
 			| 'filter_chrome_extension'
 			| 'rage_click_window_seconds'

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2394,6 +2394,7 @@ export type GetProjectDropdownOptionsQuery = { __typename?: 'Query' } & {
 			| 'billing_email'
 			| 'secret'
 			| 'workspace_id'
+			| 'error_filters'
 		>
 	>
 	workspace?: Types.Maybe<

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1477,7 +1477,7 @@ export type Project = {
 	__typename?: 'Project'
 	backend_domains?: Maybe<Scalars['StringArray']>
 	billing_email?: Maybe<Scalars['String']>
-	error_filters: Scalars['StringArray']
+	error_filters?: Maybe<Scalars['StringArray']>
 	error_json_paths?: Maybe<Scalars['StringArray']>
 	excluded_users?: Maybe<Scalars['StringArray']>
 	filter_chrome_extension?: Maybe<Scalars['Boolean']>

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1149,6 +1149,7 @@ export type MutationEditErrorSegmentArgs = {
 export type MutationEditProjectArgs = {
 	backend_domains?: InputMaybe<Scalars['StringArray']>
 	billing_email?: InputMaybe<Scalars['String']>
+	error_filters?: InputMaybe<Scalars['StringArray']>
 	error_json_paths?: InputMaybe<Scalars['StringArray']>
 	excluded_users?: InputMaybe<Scalars['StringArray']>
 	filter_chrome_extension?: InputMaybe<Scalars['Boolean']>
@@ -1476,6 +1477,7 @@ export type Project = {
 	__typename?: 'Project'
 	backend_domains?: Maybe<Scalars['StringArray']>
 	billing_email?: Maybe<Scalars['String']>
+	error_filters?: Maybe<Scalars['StringArray']>
 	error_json_paths?: Maybe<Scalars['StringArray']>
 	excluded_users?: Maybe<Scalars['StringArray']>
 	filter_chrome_extension?: Maybe<Scalars['Boolean']>

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1477,7 +1477,7 @@ export type Project = {
 	__typename?: 'Project'
 	backend_domains?: Maybe<Scalars['StringArray']>
 	billing_email?: Maybe<Scalars['String']>
-	error_filters?: Maybe<Scalars['StringArray']>
+	error_filters: Scalars['StringArray']
 	error_json_paths?: Maybe<Scalars['StringArray']>
 	excluded_users?: Maybe<Scalars['StringArray']>
 	filter_chrome_extension?: Maybe<Scalars['Boolean']>

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -190,6 +190,7 @@ mutation EditProject(
 	$name: String
 	$billing_email: String
 	$excluded_users: StringArray
+	$error_filters: StringArray
 	$error_json_paths: StringArray
 	$filter_chrome_extension: Boolean
 	$rage_click_window_seconds: Int
@@ -202,6 +203,7 @@ mutation EditProject(
 		name: $name
 		billing_email: $billing_email
 		excluded_users: $excluded_users
+		error_filters: $error_filters
 		error_json_paths: $error_json_paths
 		filter_chrome_extension: $filter_chrome_extension
 		rage_click_window_seconds: $rage_click_window_seconds
@@ -213,6 +215,7 @@ mutation EditProject(
 		name
 		billing_email
 		excluded_users
+		error_filters
 		error_json_paths
 		filter_chrome_extension
 		rage_click_window_seconds

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -928,6 +928,7 @@ query GetProject($id: ID!) {
 		verbose_id
 		billing_email
 		excluded_users
+		error_filters
 		error_json_paths
 		filter_chrome_extension
 		rage_click_window_seconds

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -817,6 +817,7 @@ query GetProjectDropdownOptions($project_id: ID!) {
 		billing_email
 		secret
 		workspace_id
+		error_filters
 	}
 	workspace: workspace_for_project(project_id: $project_id) {
 		id

--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.module.scss
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.module.scss
@@ -1,0 +1,11 @@
+.inputAndButtonRow {
+	align-items: center;
+	display: grid;
+	grid-template-columns: 1fr 80px;
+	margin-top: 5px;
+}
+
+.saveButton {
+	margin-left: 15px;
+	width: max-content;
+}

--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.module.scss
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.module.scss
@@ -1,8 +1,12 @@
 .inputAndButtonRow {
 	align-items: center;
-	display: grid;
-	grid-template-columns: 1fr 80px;
+	display: flex;
+	justify-content: space-between;
 	margin-top: 5px;
+}
+
+.input {
+	width: 100%;
 }
 
 .saveButton {

--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.module.scss.d.ts
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.module.scss.d.ts
@@ -1,2 +1,3 @@
+export const input: string
 export const inputAndButtonRow: string
 export const saveButton: string

--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.module.scss.d.ts
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.module.scss.d.ts
@@ -1,0 +1,2 @@
+export const inputAndButtonRow: string
+export const saveButton: string

--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
@@ -1,0 +1,99 @@
+import { FieldsBox } from '@components/FieldsBox/FieldsBox'
+import { CircularSpinner, LoadingBar } from '@components/Loading/Loading'
+import Select from '@components/Select/Select'
+import { useEditProjectMutation, useGetProjectQuery } from '@graph/hooks'
+import { namedOperations } from '@graph/operations'
+import { useParams } from '@util/react-router/useParams'
+import { message } from 'antd'
+import clsx from 'clsx'
+import React, { useEffect, useState } from 'react'
+
+import commonStyles from '../../../Common.module.scss'
+import Button from '../../../components/Button/Button/Button'
+import styles from './ErrorFiltersForm.module.scss'
+
+export const ErrorFiltersForm = () => {
+	const { project_id } = useParams<{
+		project_id: string
+	}>()
+	const [errorFilters, setErrorFilters] = useState<string[]>([])
+	const { data, loading } = useGetProjectQuery({
+		variables: {
+			id: project_id!,
+		},
+		skip: !project_id,
+	})
+
+	const [editProject, { loading: editProjectLoading }] =
+		useEditProjectMutation({
+			refetchQueries: [
+				namedOperations.Query.GetProjects,
+				namedOperations.Query.GetProject,
+			],
+		})
+
+	const onSubmit = (e: { preventDefault: () => void }) => {
+		e.preventDefault()
+		if (!project_id) {
+			return
+		}
+		editProject({
+			variables: {
+				id: project_id!,
+				error_filters: errorFilters,
+			},
+		}).then(() => {
+			message.success('Updated error filters!', 5)
+		})
+	}
+
+	useEffect(() => {
+		if (!loading) {
+			setErrorFilters(data?.project?.error_filters || [])
+		}
+	}, [data?.project?.error_filters, loading])
+
+	if (loading) {
+		return <LoadingBar />
+	}
+
+	return (
+		<FieldsBox id="errors">
+			<h3>Error Filters</h3>
+
+			<form onSubmit={onSubmit} key={project_id}>
+				<p>Enter REGEXP patterns to filter out errors.</p>
+				<div className={styles.inputAndButtonRow}>
+					<Select
+						mode="tags"
+						placeholder="TypeError: Failed to fetch"
+						defaultValue={data?.project?.error_filters || undefined}
+						onChange={(paths: string[]) => {
+							setErrorFilters(paths)
+						}}
+					/>
+					<Button
+						trackingId="UpdateErrorFilters"
+						htmlType="submit"
+						type="primary"
+						className={clsx(
+							commonStyles.submitButton,
+							styles.saveButton,
+						)}
+					>
+						{editProjectLoading ? (
+							<CircularSpinner
+								style={{
+									fontSize: 18,
+									color: 'var(--text-primary-inverted)',
+								}}
+							/>
+						) : (
+							'Save'
+						)}
+					</Button>
+				</div>
+			</form>
+		</FieldsBox>
+	)
+}

--- a/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm.tsx
@@ -58,7 +58,7 @@ export const ErrorSettingsForm = () => {
 	}
 
 	return (
-		<FieldsBox id="errors">
+		<FieldsBox id="grouping">
 			<h3>Error Grouping</h3>
 
 			<form onSubmit={onSubmit} key={project_id}>

--- a/frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx
+++ b/frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx
@@ -79,7 +79,7 @@ export const FilterExtensionForm = () => {
 	]
 
 	return (
-		<FieldsBox id="errors">
+		<FieldsBox id="extension">
 			<h3>Filter Browser Extension</h3>
 
 			<p>

--- a/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
@@ -1,6 +1,7 @@
 import LeadAlignLayout from '@components/layout/LeadAlignLayout'
 import Tabs from '@components/Tabs/Tabs'
 import { DangerForm } from '@pages/ProjectSettings/DangerForm/DangerForm'
+import { ErrorFiltersForm } from '@pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm'
 import { ErrorSettingsForm } from '@pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm'
 import { ExcludedUsersForm } from '@pages/ProjectSettings/ExcludedUsersForm/ExcludedUsersForm'
 import { FilterExtensionForm } from '@pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm'
@@ -54,6 +55,7 @@ const ProjectSettings = () => {
 									<>
 										<ErrorSettingsForm />
 										<FilterExtensionForm />
+										<ErrorFiltersForm />
 										<SourcemapSettings />
 									</>
 								),


### PR DESCRIPTION
Based on https://github.com/highlight/highlight/pull/4631

## To Do

- [x] Add a postgres project table `error_filter` regex column, which can be nil.
- [x] Add a private-graph operations to get and set the `error_filter` value.
- [x] Update `PublicResolver.ProcessBackendPayloadImpl` to use the `error_filter` to decide if errors should be ignored. Frontend errors go thru a different codepath in `PublicResolver.ProcessPayload`.
- [x] Build the frontend /<project>/settings/errors UI to edit / update the error pattern

## Summary

Addresses issue #4457 

Added `error_filters` to `projects` table and cloned front-end for `error_json_paths`.

Confirmed successful save.


## How did you test this change?

https://user-images.githubusercontent.com/878947/225923680-8fa075d7-b41f-4bcf-a3eb-943d7f3f4870.mp4

The back-end error filtering is harder to test. I added a `panic("test message")` into the front-end error handling code and got it to register against an `error_filter` in the back-end handling code.

## Are there any deployment considerations?

No need to backfill data. Migration should be automatic.