### PR TITLE
Support sorting logs in ascending order

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -198,6 +198,8 @@ func (client *Client) ReadLogsHistogram(ctx context.Context, projectID int, para
 		projectID,
 		params,
 		Pagination{},
+		OrderBackwardNatural,
+		OrderForwardNatural,
 	)
 
 	if err != nil {

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -53,6 +53,7 @@ type Pagination struct {
 	After     *string
 	Before    *string
 	At        *string
+	Direction modelInputs.LogDirection
 	CountOnly bool
 }
 
@@ -64,7 +65,7 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 
 	orderForward := OrderForwardNatural
 	orderBackward := OrderBackwardNatural
-	if params.Direction == modelInputs.LogDirectionAsc {
+	if pagination.Direction == modelInputs.LogDirectionAsc {
 		orderForward = OrderForwardInverted
 		orderBackward = OrderBackwardInverted
 	}

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -56,7 +56,7 @@ type Pagination struct {
 	CountOnly bool
 }
 
-func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput, pagination Pagination, direction *modelInputs.LogDirection) (*modelInputs.LogsConnection, error) {
+func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput, pagination Pagination) (*modelInputs.LogsConnection, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	var err error
 	var args []interface{}
@@ -64,7 +64,7 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 
 	orderForward := OrderForwardNatural
 	orderBackward := OrderBackwardNatural
-	if *direction == modelInputs.LogDirectionAsc {
+	if params.Direction == modelInputs.LogDirectionAsc {
 		orderForward = OrderForwardInverted
 		orderBackward = OrderBackwardInverted
 	}

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -759,7 +759,7 @@ type ComplexityRoot struct {
 		JoinableWorkspaces           func(childComplexity int) int
 		LinearTeams                  func(childComplexity int, projectID int) int
 		LiveUsersCount               func(childComplexity int, projectID int) int
-		Logs                         func(childComplexity int, projectID int, params model.LogsParamsInput, after *string, before *string, at *string) int
+		Logs                         func(childComplexity int, projectID int, params model.LogsParamsInput, after *string, before *string, at *string, direction *model.LogDirection) int
 		LogsErrorObjects             func(childComplexity int, logCursors []string) int
 		LogsHistogram                func(childComplexity int, projectID int, params model.LogsParamsInput) int
 		LogsIntegration              func(childComplexity int, projectID int) int
@@ -1386,7 +1386,7 @@ type QueryResolver interface {
 	SourcemapVersions(ctx context.Context, projectID int) ([]string, error)
 	OauthClientMetadata(ctx context.Context, clientID string) (*model.OAuthClient, error)
 	EmailOptOuts(ctx context.Context, token *string, adminID *int) ([]model.EmailOptOutCategory, error)
-	Logs(ctx context.Context, projectID int, params model.LogsParamsInput, after *string, before *string, at *string) (*model.LogsConnection, error)
+	Logs(ctx context.Context, projectID int, params model.LogsParamsInput, after *string, before *string, at *string, direction *model.LogDirection) (*model.LogsConnection, error)
 	LogsTotalCount(ctx context.Context, projectID int, params model.LogsParamsInput) (uint64, error)
 	LogsHistogram(ctx context.Context, projectID int, params model.LogsParamsInput) (*model.LogsHistogram, error)
 	LogsKeys(ctx context.Context, projectID int, dateRange model.DateRangeRequiredInput) ([]*model.LogKey, error)
@@ -5504,7 +5504,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Logs(childComplexity, args["project_id"].(int), args["params"].(model.LogsParamsInput), args["after"].(*string), args["before"].(*string), args["at"].(*string)), true
+		return e.complexity.Query.Logs(childComplexity, args["project_id"].(int), args["params"].(model.LogsParamsInput), args["after"].(*string), args["before"].(*string), args["at"].(*string), args["direction"].(*model.LogDirection)), true
 
 	case "Query.logs_error_objects":
 		if e.complexity.Query.LogsErrorObjects == nil {
@@ -8191,6 +8191,11 @@ enum LogLevel {
 	fatal
 }
 
+enum LogDirection {
+	ASC
+	DESC
+}
+
 type Project {
 	id: ID!
 	verbose_id: String!
@@ -9401,6 +9406,7 @@ type Query {
 		after: String
 		before: String
 		at: String
+		direction: LogDirection
 	): LogsConnection!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_histogram(project_id: ID!, params: LogsParamsInput!): LogsHistogram!
@@ -13698,6 +13704,15 @@ func (ec *executionContext) field_Query_logs_args(ctx context.Context, rawArgs m
 		}
 	}
 	args["at"] = arg4
+	var arg5 *model.LogDirection
+	if tmp, ok := rawArgs["direction"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("direction"))
+		arg5, err = ec.unmarshalOLogDirection2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogDirection(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["direction"] = arg5
 	return args, nil
 }
 
@@ -43465,7 +43480,7 @@ func (ec *executionContext) _Query_logs(ctx context.Context, field graphql.Colle
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Logs(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.LogsParamsInput), fc.Args["after"].(*string), fc.Args["before"].(*string), fc.Args["at"].(*string))
+		return ec.resolvers.Query().Logs(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.LogsParamsInput), fc.Args["after"].(*string), fc.Args["before"].(*string), fc.Args["at"].(*string), fc.Args["direction"].(*model.LogDirection))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -71881,6 +71896,22 @@ func (ec *executionContext) marshalOLinearTeam2ᚕᚖgithubᚗcomᚋhighlightᚑ
 	}
 
 	return ret
+}
+
+func (ec *executionContext) unmarshalOLogDirection2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogDirection(ctx context.Context, v interface{}) (*model.LogDirection, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(model.LogDirection)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOLogDirection2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogDirection(ctx context.Context, sel ast.SelectionSet, v *model.LogDirection) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) marshalOLogsConnection2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogsConnection(ctx context.Context, sel ast.SelectionSet, v *model.LogsConnection) graphql.Marshaler {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -403,6 +403,7 @@ type LogsHistogramBucketCount struct {
 type LogsParamsInput struct {
 	Query     string                  `json:"query"`
 	DateRange *DateRangeRequiredInput `json:"date_range"`
+	Direction LogDirection            `json:"direction"`
 }
 
 type MetricPreview struct {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -820,6 +820,47 @@ func (e IntegrationType) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+type LogDirection string
+
+const (
+	LogDirectionAsc  LogDirection = "ASC"
+	LogDirectionDesc LogDirection = "DESC"
+)
+
+var AllLogDirection = []LogDirection{
+	LogDirectionAsc,
+	LogDirectionDesc,
+}
+
+func (e LogDirection) IsValid() bool {
+	switch e {
+	case LogDirectionAsc, LogDirectionDesc:
+		return true
+	}
+	return false
+}
+
+func (e LogDirection) String() string {
+	return string(e)
+}
+
+func (e *LogDirection) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = LogDirection(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid LogDirection", str)
+	}
+	return nil
+}
+
+func (e LogDirection) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 type LogKeyType string
 
 const (

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -403,7 +403,6 @@ type LogsHistogramBucketCount struct {
 type LogsParamsInput struct {
 	Query     string                  `json:"query"`
 	DateRange *DateRangeRequiredInput `json:"date_range"`
-	Direction LogDirection            `json:"direction"`
 }
 
 type MetricPreview struct {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -652,6 +652,7 @@ input ErrorGroupFrequenciesParamsInput {
 input LogsParamsInput {
 	query: String!
 	date_range: DateRangeRequiredInput!
+	direction: LogDirection!
 }
 
 enum MetricTagFilterOp {
@@ -1517,7 +1518,6 @@ type Query {
 		after: String
 		before: String
 		at: String
-		direction: LogDirection
 	): LogsConnection!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_histogram(project_id: ID!, params: LogsParamsInput!): LogsHistogram!

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -652,7 +652,6 @@ input ErrorGroupFrequenciesParamsInput {
 input LogsParamsInput {
 	query: String!
 	date_range: DateRangeRequiredInput!
-	direction: LogDirection!
 }
 
 enum MetricTagFilterOp {
@@ -1518,6 +1517,7 @@ type Query {
 		after: String
 		before: String
 		at: String
+		direction: LogDirection!
 	): LogsConnection!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_histogram(project_id: ID!, params: LogsParamsInput!): LogsHistogram!

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -302,6 +302,11 @@ enum LogLevel {
 	fatal
 }
 
+enum LogDirection {
+	ASC
+	DESC
+}
+
 type Project {
 	id: ID!
 	verbose_id: String!
@@ -1512,6 +1517,7 @@ type Query {
 		after: String
 		before: String
 		at: String
+		direction: LogDirection
 	): LogsConnection!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_histogram(project_id: ID!, params: LogsParamsInput!): LogsHistogram!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7006,7 +7006,7 @@ func (r *queryResolver) EmailOptOuts(ctx context.Context, token *string, adminID
 }
 
 // Logs is the resolver for the logs field.
-func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput, after *string, before *string, at *string, direction *modelInputs.LogDirection) (*modelInputs.LogsConnection, error) {
+func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput, after *string, before *string, at *string) (*modelInputs.LogsConnection, error) {
 	project, err := r.isAdminInProject(ctx, projectID)
 	if err != nil {
 		return nil, e.Wrap(err, "error querying project")
@@ -7016,7 +7016,7 @@ func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInp
 		After:  after,
 		Before: before,
 		At:     at,
-	}, direction)
+	})
 }
 
 // LogsTotalCount is the resolver for the logs_total_count field.

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7006,7 +7006,7 @@ func (r *queryResolver) EmailOptOuts(ctx context.Context, token *string, adminID
 }
 
 // Logs is the resolver for the logs field.
-func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput, after *string, before *string, at *string) (*modelInputs.LogsConnection, error) {
+func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput, after *string, before *string, at *string, direction *modelInputs.LogDirection) (*modelInputs.LogsConnection, error) {
 	project, err := r.isAdminInProject(ctx, projectID)
 	if err != nil {
 		return nil, e.Wrap(err, "error querying project")
@@ -7016,7 +7016,7 @@ func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInp
 		After:  after,
 		Before: before,
 		At:     at,
-	})
+	}, direction)
 }
 
 // LogsTotalCount is the resolver for the logs_total_count field.

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7006,16 +7006,17 @@ func (r *queryResolver) EmailOptOuts(ctx context.Context, token *string, adminID
 }
 
 // Logs is the resolver for the logs field.
-func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput, after *string, before *string, at *string) (*modelInputs.LogsConnection, error) {
+func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput, after *string, before *string, at *string, direction modelInputs.LogDirection) (*modelInputs.LogsConnection, error) {
 	project, err := r.isAdminInProject(ctx, projectID)
 	if err != nil {
 		return nil, e.Wrap(err, "error querying project")
 	}
 
 	return r.ClickhouseClient.ReadLogs(ctx, project.ID, params, clickhouse.Pagination{
-		After:  after,
-		Before: before,
-		At:     at,
+		After:     after,
+		Before:    before,
+		At:        at,
+		Direction: direction,
 	})
 }
 

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -11641,6 +11641,7 @@ export const GetLogsDocument = gql`
 		$after: String
 		$before: String
 		$at: String
+		$direction: LogDirection
 	) {
 		logs(
 			project_id: $project_id
@@ -11648,6 +11649,7 @@ export const GetLogsDocument = gql`
 			after: $after
 			before: $before
 			at: $at
+			direction: $direction
 		) {
 			edges {
 				cursor
@@ -11690,6 +11692,7 @@ export const GetLogsDocument = gql`
  *      after: // value for 'after'
  *      before: // value for 'before'
  *      at: // value for 'at'
+ *      direction: // value for 'direction'
  *   },
  * });
  */

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -11641,7 +11641,7 @@ export const GetLogsDocument = gql`
 		$after: String
 		$before: String
 		$at: String
-		$direction: LogDirection
+		$direction: LogDirection!
 	) {
 		logs(
 			project_id: $project_id

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4004,7 +4004,7 @@ export type GetLogsQueryVariables = Types.Exact<{
 	after?: Types.Maybe<Types.Scalars['String']>
 	before?: Types.Maybe<Types.Scalars['String']>
 	at?: Types.Maybe<Types.Scalars['String']>
-	direction?: Types.Maybe<Types.LogDirection>
+	direction: Types.LogDirection
 }>
 
 export type GetLogsQuery = { __typename?: 'Query' } & {

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4004,6 +4004,7 @@ export type GetLogsQueryVariables = Types.Exact<{
 	after?: Types.Maybe<Types.Scalars['String']>
 	before?: Types.Maybe<Types.Scalars['String']>
 	at?: Types.Maybe<Types.Scalars['String']>
+	direction?: Types.Maybe<Types.LogDirection>
 }>
 
 export type GetLogsQuery = { __typename?: 'Query' } & {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -736,6 +736,7 @@ export type LogsHistogramBucketCount = {
 
 export type LogsParamsInput = {
 	date_range: DateRangeRequiredInput
+	direction: LogDirection
 	query: Scalars['String']
 }
 
@@ -1833,7 +1834,6 @@ export type QueryLogsArgs = {
 	after?: InputMaybe<Scalars['String']>
 	at?: InputMaybe<Scalars['String']>
 	before?: InputMaybe<Scalars['String']>
-	direction?: InputMaybe<LogDirection>
 	params: LogsParamsInput
 	project_id: Scalars['ID']
 }

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -736,7 +736,6 @@ export type LogsHistogramBucketCount = {
 
 export type LogsParamsInput = {
 	date_range: DateRangeRequiredInput
-	direction: LogDirection
 	query: Scalars['String']
 }
 
@@ -1834,6 +1833,7 @@ export type QueryLogsArgs = {
 	after?: InputMaybe<Scalars['String']>
 	at?: InputMaybe<Scalars['String']>
 	before?: InputMaybe<Scalars['String']>
+	direction: LogDirection
 	params: LogsParamsInput
 	project_id: Scalars['ID']
 }

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -680,6 +680,11 @@ export type Log = {
 	traceID?: Maybe<Scalars['String']>
 }
 
+export enum LogDirection {
+	Asc = 'ASC',
+	Desc = 'DESC',
+}
+
 export type LogEdge = {
 	__typename?: 'LogEdge'
 	cursor: Scalars['String']
@@ -1828,6 +1833,7 @@ export type QueryLogsArgs = {
 	after?: InputMaybe<Scalars['String']>
 	at?: InputMaybe<Scalars['String']>
 	before?: InputMaybe<Scalars['String']>
+	direction?: InputMaybe<LogDirection>
 	params: LogsParamsInput
 	project_id: Scalars['ID']
 }

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1903,7 +1903,6 @@ query GetLogs(
 	$after: String
 	$before: String
 	$at: String
-	$direction: LogDirection
 ) {
 	logs(
 		project_id: $project_id
@@ -1911,7 +1910,6 @@ query GetLogs(
 		after: $after
 		before: $before
 		at: $at
-		direction: $direction
 	) {
 		edges {
 			cursor

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1903,6 +1903,7 @@ query GetLogs(
 	$after: String
 	$before: String
 	$at: String
+	$direction: LogDirection
 ) {
 	logs(
 		project_id: $project_id
@@ -1910,6 +1911,7 @@ query GetLogs(
 		after: $after
 		before: $before
 		at: $at
+		direction: $direction
 	) {
 		edges {
 			cursor

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1903,6 +1903,7 @@ query GetLogs(
 	$after: String
 	$before: String
 	$at: String
+	$direction: LogDirection!
 ) {
 	logs(
 		project_id: $project_id
@@ -1910,6 +1911,7 @@ query GetLogs(
 		after: $after
 		before: $before
 		at: $at
+		direction: $direction
 	) {
 		edges {
 			cursor

--- a/frontend/src/pages/LogsPage/LogsHistogram/LogsHistogram.tsx
+++ b/frontend/src/pages/LogsPage/LogsHistogram/LogsHistogram.tsx
@@ -1,5 +1,6 @@
 import { useGetLogsHistogramQuery } from '@graph/hooks'
 import { LogLevel as Level } from '@graph/schemas'
+import * as Types from '@graph/schemas'
 import { Box, Popover, Text } from '@highlight-run/ui'
 import { COLOR_MAPPING, FORMAT } from '@pages/LogsPage/constants'
 import { isSignificantDateRange } from '@pages/LogsPage/utils'
@@ -46,6 +47,7 @@ const LogsHistogram = ({
 					start_date: moment(startDate).format(FORMAT),
 					end_date: moment(endDate).format(FORMAT),
 				},
+				direction: Types.LogDirection.Desc,
 			},
 		},
 		skip: !project_id,

--- a/frontend/src/pages/LogsPage/LogsHistogram/LogsHistogram.tsx
+++ b/frontend/src/pages/LogsPage/LogsHistogram/LogsHistogram.tsx
@@ -1,6 +1,5 @@
 import { useGetLogsHistogramQuery } from '@graph/hooks'
 import { LogLevel as Level } from '@graph/schemas'
-import * as Types from '@graph/schemas'
 import { Box, Popover, Text } from '@highlight-run/ui'
 import { COLOR_MAPPING, FORMAT } from '@pages/LogsPage/constants'
 import { isSignificantDateRange } from '@pages/LogsPage/utils'
@@ -47,7 +46,6 @@ const LogsHistogram = ({
 					start_date: moment(startDate).format(FORMAT),
 					end_date: moment(endDate).format(FORMAT),
 				},
-				direction: Types.LogDirection.Desc,
 			},
 		},
 		skip: !project_id,

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -60,6 +60,7 @@ export const useGetLogs = ({
 						end_date: moment(endDate).format(FORMAT),
 					},
 				},
+				direction: Types.LogDirection.Asc,
 			},
 			fetchPolicy: 'cache-and-network',
 		})

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -59,8 +59,8 @@ export const useGetLogs = ({
 						start_date: moment(startDate).format(FORMAT),
 						end_date: moment(endDate).format(FORMAT),
 					},
+					direction: Types.LogDirection.Asc,
 				},
-				direction: Types.LogDirection.Asc,
 			},
 			fetchPolicy: 'cache-and-network',
 		})

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -53,13 +53,13 @@ export const useGetLogs = ({
 			variables: {
 				project_id: project_id!,
 				at: logCursor,
+				direction: Types.LogDirection.Asc,
 				params: {
 					query: serverQuery,
 					date_range: {
 						start_date: moment(startDate).format(FORMAT),
 						end_date: moment(endDate).format(FORMAT),
 					},
-					direction: Types.LogDirection.Asc,
 				},
 			},
 			fetchPolicy: 'cache-and-network',

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -53,7 +53,7 @@ export const useGetLogs = ({
 			variables: {
 				project_id: project_id!,
 				at: logCursor,
-				direction: Types.LogDirection.Asc,
+				direction: Types.LogDirection.Desc,
 				params: {
 					query: serverQuery,
 					date_range: {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Currently, our logs endpoint defaults to sorting logs in descending order. This PR adds backend support to sort logs in ascending order. A follow up PR will actually leverage this such that we can replace the session viewer logs (which expects ascending order).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

I manually modified the logs query to use ascending order

```diff
diff --git a/frontend/src/pages/LogsPage/useGetLogs.ts b/frontend/src/pages/LogsPage/useGetLogs.ts
index 5bb453596..1c3e84745 100644
--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -53,7 +53,7 @@ export const useGetLogs = ({
 			variables: {
 				project_id: project_id!,
 				at: logCursor,
-				direction: Types.LogDirection.Desc,
+				direction: Types.LogDirection.Asc,
 				params: {
 					query: serverQuery,
 					date_range: {

```

and confirmed the backend returns the logs in ascending order:
![Screenshot 2023-04-03 at 1 24 35 PM](https://user-images.githubusercontent.com/58678/229607288-40527a08-c887-496d-aeb1-e7045b13a5db.png)



## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
