### PR TITLE
disable reportConsoleErrors by default

### DIFF
--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -56,6 +56,7 @@ type InitializeSessionArgs struct {
 	IP                             string
 	ClientID                       string
 	NetworkRecordingDomains        []string
+	DisableSessionRecording        *bool
 }
 
 type IdentifySessionArgs struct {

--- a/backend/public-graph/graph/generated/generated.go
+++ b/backend/public-graph/graph/generated/generated.go
@@ -54,7 +54,7 @@ type ComplexityRoot struct {
 		AddSessionFeedback   func(childComplexity int, sessionSecureID string, userName *string, userEmail *string, verbatim string, timestamp time.Time) int
 		AddSessionProperties func(childComplexity int, sessionSecureID string, propertiesObject interface{}) int
 		IdentifySession      func(childComplexity int, sessionSecureID string, userIdentifier string, userObject interface{}) int
-		InitializeSession    func(childComplexity int, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, fingerprint string, clientID string, networkRecordingDomains []string) int
+		InitializeSession    func(childComplexity int, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, fingerprint string, clientID string, networkRecordingDomains []string, disableSessionRecording *bool) int
 		MarkBackendSetup     func(childComplexity int, projectID *string, sessionSecureID *string, typeArg *string) int
 		PushBackendPayload   func(childComplexity int, projectID *string, errors []*model.BackendErrorObjectInput) int
 		PushMetrics          func(childComplexity int, metrics []*model.MetricInput) int
@@ -74,7 +74,7 @@ type ComplexityRoot struct {
 }
 
 type MutationResolver interface {
-	InitializeSession(ctx context.Context, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, fingerprint string, clientID string, networkRecordingDomains []string) (*model.InitializeSessionResponse, error)
+	InitializeSession(ctx context.Context, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, fingerprint string, clientID string, networkRecordingDomains []string, disableSessionRecording *bool) (*model.InitializeSessionResponse, error)
 	IdentifySession(ctx context.Context, sessionSecureID string, userIdentifier string, userObject interface{}) (string, error)
 	AddSessionProperties(ctx context.Context, sessionSecureID string, propertiesObject interface{}) (string, error)
 	PushPayload(ctx context.Context, sessionSecureID string, events model.ReplayEventsInput, messages string, resources string, errors []*model.ErrorObjectInput, isBeacon *bool, hasSessionUnloaded *bool, highlightLogs *string, payloadID *int) (int, error)
@@ -162,7 +162,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.InitializeSession(childComplexity, args["session_secure_id"].(string), args["organization_verbose_id"].(string), args["enable_strict_privacy"].(bool), args["enable_recording_network_contents"].(bool), args["clientVersion"].(string), args["firstloadVersion"].(string), args["clientConfig"].(string), args["environment"].(string), args["appVersion"].(*string), args["fingerprint"].(string), args["client_id"].(string), args["network_recording_domains"].([]string)), true
+		return e.complexity.Mutation.InitializeSession(childComplexity, args["session_secure_id"].(string), args["organization_verbose_id"].(string), args["enable_strict_privacy"].(bool), args["enable_recording_network_contents"].(bool), args["clientVersion"].(string), args["firstloadVersion"].(string), args["clientConfig"].(string), args["environment"].(string), args["appVersion"].(*string), args["fingerprint"].(string), args["client_id"].(string), args["network_recording_domains"].([]string), args["disable_session_recording"].(*bool)), true
 
 	case "Mutation.markBackendSetup":
 		if e.complexity.Mutation.MarkBackendSetup == nil {
@@ -423,6 +423,7 @@ type Mutation {
 		fingerprint: String!
 		client_id: String!
 		network_recording_domains: [String!]
+		disable_session_recording: Boolean
 	): InitializeSessionResponse!
 	identifySession(
 		session_secure_id: String!
@@ -697,6 +698,15 @@ func (ec *executionContext) field_Mutation_initializeSession_args(ctx context.Co
 		}
 	}
 	args["network_recording_domains"] = arg11
+	var arg12 *bool
+	if tmp, ok := rawArgs["disable_session_recording"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disable_session_recording"))
+		arg12, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["disable_session_recording"] = arg12
 	return args, nil
 }
 
@@ -1029,7 +1039,7 @@ func (ec *executionContext) _Mutation_initializeSession(ctx context.Context, fie
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().InitializeSession(rctx, fc.Args["session_secure_id"].(string), fc.Args["organization_verbose_id"].(string), fc.Args["enable_strict_privacy"].(bool), fc.Args["enable_recording_network_contents"].(bool), fc.Args["clientVersion"].(string), fc.Args["firstloadVersion"].(string), fc.Args["clientConfig"].(string), fc.Args["environment"].(string), fc.Args["appVersion"].(*string), fc.Args["fingerprint"].(string), fc.Args["client_id"].(string), fc.Args["network_recording_domains"].([]string))
+		return ec.resolvers.Mutation().InitializeSession(rctx, fc.Args["session_secure_id"].(string), fc.Args["organization_verbose_id"].(string), fc.Args["enable_strict_privacy"].(bool), fc.Args["enable_recording_network_contents"].(bool), fc.Args["clientVersion"].(string), fc.Args["firstloadVersion"].(string), fc.Args["clientConfig"].(string), fc.Args["environment"].(string), fc.Args["appVersion"].(*string), fc.Args["fingerprint"].(string), fc.Args["client_id"].(string), fc.Args["network_recording_domains"].([]string), fc.Args["disable_session_recording"].(*bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1265,6 +1265,11 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 		AvoidPostgresStorage:           true,
 	}
 
+	// mark recording-less sessions as processed so they are considered excluded
+	if input.DisableSessionRecording != nil && *input.DisableSessionRecording {
+		session.Processed = &model.T
+	}
+
 	// determine if session is within billing quota
 	withinBillingQuota, quotaPercent := r.isWithinBillingQuota(ctx, project, workspace, *session.PayloadUpdatedAt)
 	setupSpan.Finish()

--- a/backend/public-graph/graph/schema.graphqls
+++ b/backend/public-graph/graph/schema.graphqls
@@ -94,6 +94,7 @@ type Mutation {
 		fingerprint: String!
 		client_id: String!
 		network_recording_domains: [String!]
+		disable_session_recording: Boolean
 	): InitializeSessionResponse!
 	identifySession(
 		session_secure_id: String!

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -23,7 +23,7 @@ import (
 )
 
 // InitializeSession is the resolver for the initializeSession field.
-func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, fingerprint string, clientID string, networkRecordingDomains []string) (*customModels.InitializeSessionResponse, error) {
+func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, fingerprint string, clientID string, networkRecordingDomains []string, disableSessionRecording *bool) (*customModels.InitializeSessionResponse, error) {
 	s, _ := tracer.StartSpanFromContext(ctx, "InitializeSession", tracer.ResourceName("gql.initializeSession"))
 	s.SetTag("secure_id", sessionSecureID)
 	s.SetTag("client_version", clientVersion)
@@ -56,6 +56,7 @@ func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureI
 				IP:                             ip,
 				ClientID:                       clientID,
 				NetworkRecordingDomains:        networkRecordingDomains,
+				DisableSessionRecording:        disableSessionRecording,
 			},
 		}, sessionSecureID)
 		if err == nil {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -73,7 +73,6 @@ const options: HighlightOptions = {
 			'session-contents-compressed',
 		],
 	},
-	reportConsoleErrors: false,
 	tracingOrigins: ['highlight.run', 'localhost', 'localhost:8082'],
 	integrations: {
 		amplitude: {

--- a/sdk/client/src/graph/generated/operations.ts
+++ b/sdk/client/src/graph/generated/operations.ts
@@ -108,6 +108,7 @@ export type MutationInitializeSessionArgs = {
 	clientConfig: Scalars['String']
 	clientVersion: Scalars['String']
 	client_id: Scalars['String']
+	disable_session_recording?: InputMaybe<Scalars['Boolean']>
 	enable_recording_network_contents: Scalars['Boolean']
 	enable_strict_privacy: Scalars['Boolean']
 	environment: Scalars['String']
@@ -263,6 +264,7 @@ export type InitializeSessionMutationVariables = Exact<{
 	network_recording_domains?: InputMaybe<
 		Array<Scalars['String']> | Scalars['String']
 	>
+	disable_session_recording?: InputMaybe<Scalars['Boolean']>
 }>
 
 export type InitializeSessionMutation = {
@@ -365,6 +367,7 @@ export const InitializeSessionDocument = gql`
 		$appVersion: String
 		$client_id: String!
 		$network_recording_domains: [String!]
+		$disable_session_recording: Boolean
 	) {
 		initializeSession(
 			session_secure_id: $session_secure_id
@@ -379,6 +382,7 @@ export const InitializeSessionDocument = gql`
 			fingerprint: $id
 			client_id: $client_id
 			network_recording_domains: $network_recording_domains
+			disable_session_recording: $disable_session_recording
 		) {
 			secure_id
 			project_id

--- a/sdk/client/src/graph/generated/schemas.ts
+++ b/sdk/client/src/graph/generated/schemas.ts
@@ -105,6 +105,7 @@ export type MutationInitializeSessionArgs = {
 	clientConfig: Scalars['String']
 	clientVersion: Scalars['String']
 	client_id: Scalars['String']
+	disable_session_recording?: InputMaybe<Scalars['Boolean']>
 	enable_recording_network_contents: Scalars['Boolean']
 	enable_strict_privacy: Scalars['Boolean']
 	environment: Scalars['String']

--- a/sdk/client/src/graph/operators/mutation.gql
+++ b/sdk/client/src/graph/operators/mutation.gql
@@ -77,6 +77,7 @@ mutation initializeSession(
 	$appVersion: String
 	$client_id: String!
 	$network_recording_domains: [String!]
+	$disable_session_recording: Boolean
 ) {
 	initializeSession(
 		session_secure_id: $session_secure_id
@@ -91,6 +92,7 @@ mutation initializeSession(
 		fingerprint: $id
 		client_id: $client_id
 		network_recording_domains: $network_recording_domains
+		disable_session_recording: $disable_session_recording
 	) {
 		secure_id
 		project_id

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -580,6 +580,8 @@ export class Highlight {
 					session_secure_id: this.sessionData.sessionSecureID,
 					client_id: clientID,
 					network_recording_domains: destinationDomains,
+					disable_session_recording:
+						this.options.disableSessionRecording,
 				})
 				if (
 					gr.initializeSession.secure_id !==
@@ -1149,10 +1151,6 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			await this._sendPayload({ isBeacon: false })
 			this.hasPushedData = true
 			this.sessionData.lastPushTime = Date.now()
-			// Listeners are cleared when the user calls stop() manually.
-			if (this.listeners.length === 0) {
-				return
-			}
 		} catch (e) {
 			if (this._isOnLocalHost) {
 				console.error(e)

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -94,6 +94,7 @@ export type HighlightClassOptions = {
 	networkRecording?: boolean | NetworkRecordingOptions
 	disableBackgroundRecording?: boolean
 	disableConsoleRecording?: boolean
+	disableSessionRecording?: boolean
 	reportConsoleErrors?: boolean
 	consoleMethodsToRecord?: ConsoleMethods[]
 	enableSegmentIntegration?: boolean
@@ -546,7 +547,9 @@ export class Highlight {
 			// Duplicate of logic inside FirstLoadListeners.setupNetworkListener,
 			// needed for initializeSession
 			let enableNetworkRecording
-			if (this.options.disableNetworkRecording !== undefined) {
+			if (this.options.disableSessionRecording) {
+				enableNetworkRecording = false
+			} else if (this.options.disableNetworkRecording !== undefined) {
 				enableNetworkRecording = false
 			} else if (typeof this.options.networkRecording === 'boolean') {
 				enableNetworkRecording = false
@@ -639,6 +642,29 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 					this.options,
 				)
 			}
+
+			if (this.pushPayloadTimerId) {
+				clearTimeout(this.pushPayloadTimerId)
+				this.pushPayloadTimerId = undefined
+			}
+			if (!this.options.isCrossOriginIframe) {
+				this.pushPayloadTimerId = setTimeout(() => {
+					this._save()
+				}, FIRST_SEND_FREQUENCY)
+			}
+
+			// if disabled, do not record session events / rrweb events.
+			// we still use firstload listeners to record frontend js console logs and errors.
+			if (this.options.disableSessionRecording) {
+				this.logger.log(
+					`Highlight is NOT RECORDING a session replay per H.init setting.`,
+				)
+				this.ready = true
+				this.state = 'Recording'
+				this.manualStopped = false
+				return
+			}
+
 			const { getDeviceDetails } = getPerformanceMethods()
 			if (getDeviceDetails) {
 				this.recordMetric([
@@ -651,15 +677,6 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 				])
 			}
 
-			if (this.pushPayloadTimerId) {
-				clearTimeout(this.pushPayloadTimerId)
-				this.pushPayloadTimerId = undefined
-			}
-			if (!this.options.isCrossOriginIframe) {
-				this.pushPayloadTimerId = setTimeout(() => {
-					this._save()
-				}, FIRST_SEND_FREQUENCY)
-			}
 			const emit = (event: eventWithTime) => {
 				this.events.push(event)
 			}

--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -41,7 +41,7 @@ export class FirstLoadListeners {
 	constructor(options: HighlightClassOptions) {
 		this.options = options
 		this.disableConsoleRecording = !!options.disableConsoleRecording
-		this.reportConsoleErrors = options.reportConsoleErrors ?? true
+		this.reportConsoleErrors = options.reportConsoleErrors ?? false
 		this.consoleMethodsToRecord = options.consoleMethodsToRecord || [
 			...ALL_CONSOLE_METHODS,
 		]

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -95,6 +95,12 @@ export declare type HighlightOptions = {
 	 */
 	disableConsoleRecording?: boolean
 	/**
+	 * Specifies whether Highlight will record user session replays.
+	 * Unless you are using Highlight only for error monitoring, you do not want to set this to true.
+	 * @default false
+	 */
+	disableSessionRecording?: boolean
+	/**
 	 * Specifies whether Highlight will report `console.error` invocations as Highlight Errors.
 	 * @default true
 	 */

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -146,3 +146,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 
 - Adds an opt-out `reportConsoleErrors` boolean setting to `H.init` that allows disabling reporting console logs as errors.
 - Ensures `console.error(...)` calls are reported as part of highlight frontend sessions in all cases.
+
+## 5.5.0
+
+### Minor Changes
+
+- Switches `reportConsoleErrors` to be disabled by default. With the setting disabled, `console.error(...)` calls will only be reported as error logs.

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -147,8 +147,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 - Adds an opt-out `reportConsoleErrors` boolean setting to `H.init` that allows disabling reporting console logs as errors.
 - Ensures `console.error(...)` calls are reported as part of highlight frontend sessions in all cases.
 
-## 5.5.0
+## 6.0.0
 
-### Minor Changes
+### Major Changes
 
 - Switches `reportConsoleErrors` to be disabled by default. With the setting disabled, `console.error(...)` calls will only be reported as error logs.
+- Updates rrweb dependency.

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -152,4 +152,5 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Major Changes
 
 - Switches `reportConsoleErrors` to be disabled by default. With the setting disabled, `console.error(...)` calls will only be reported as error logs.
+- Adds a `disableSessionRecording` setting that allows using the javascript sdk for error/logs recording without capturing session replays.
 - Updates rrweb dependency.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "5.5.0",
+	"version": "6.0.0",
 	"scripts": {
 		"build": "rollup -c",
 		"dev": "rollup -c -w",

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "5.4.2",
+	"version": "5.5.0",
 	"scripts": {
 		"build": "rollup -c",
 		"dev": "rollup -c -w",

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -100,6 +100,7 @@ export const H: HighlightPublicInterface = {
 				networkRecording: options?.networkRecording,
 				disableBackgroundRecording: options?.disableBackgroundRecording,
 				disableConsoleRecording: options?.disableConsoleRecording,
+				disableSessionRecording: options?.disableSessionRecording,
 				reportConsoleErrors: options?.reportConsoleErrors,
 				consoleMethodsToRecord: options?.consoleMethodsToRecord,
 				enableSegmentIntegration: options?.enableSegmentIntegration,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11395,6 +11395,7 @@ __metadata:
   resolution: "@highlight-run/rrweb-types@workspace:rrweb/packages/types"
   dependencies:
     "@highlight-run/rrweb-snapshot": "workspace:*"
+    typescript: ^4.7.3
     vite: ^3.2.0-beta.2
     vite-plugin-dts: ^1.6.6
   languageName: unknown
@@ -48008,6 +48009,7 @@ __metadata:
     "@types/minimist": ^1.2.1
     minimist: ^1.2.5
     puppeteer: ^19.7.2
+    typescript: ^4.7.3
   bin:
     rrvideo: build/cli.js
   languageName: unknown
@@ -52068,7 +52070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.9.5, typescript@npm:^4.9.0, typescript@npm:^4.9.4, typescript@npm:^4.9.5":
+"typescript@npm:4.9.5, typescript@npm:^4.7.3, typescript@npm:^4.9.0, typescript@npm:^4.9.4, typescript@npm:^4.9.5":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
   bin:
@@ -52118,7 +52120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.9.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.0#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.4#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
+"typescript@patch:typescript@4.9.5#~builtin<compat/typescript>, typescript@patch:typescript@^4.7.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.0#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.4#~builtin<compat/typescript>, typescript@patch:typescript@^4.9.5#~builtin<compat/typescript>":
   version: 4.9.5
   resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11312,7 +11312,6 @@ __metadata:
     rollup-plugin-typescript2: ^0.31.2
     rollup-plugin-web-worker-loader: ^1.6.1
     ts-jest: 27.1.5
-    typescript: ^4.7.3
   languageName: unknown
   linkType: soft
 
@@ -11335,7 +11334,6 @@ __metadata:
     rollup-plugin-typescript2: ^0.31.2
     rollup-plugin-web-worker-loader: ^1.6.1
     ts-jest: 27.1.5
-    typescript: ^4.7.3
   languageName: unknown
   linkType: soft
 
@@ -11365,7 +11363,6 @@ __metadata:
     svelte-check: ^1.4.0
     svelte-preprocess: ^4.0.0
     tslib: ^2.0.0
-    typescript: ^4.7.3
   languageName: unknown
   linkType: soft
 
@@ -11390,7 +11387,6 @@ __metadata:
     ts-jest: 27.1.5
     ts-node: ^7.0.1
     tslib: ^1.9.3
-    typescript: ^4.7.3
   languageName: unknown
   linkType: soft
 
@@ -11399,7 +11395,6 @@ __metadata:
   resolution: "@highlight-run/rrweb-types@workspace:rrweb/packages/types"
   dependencies:
     "@highlight-run/rrweb-snapshot": "workspace:*"
-    typescript: ^4.7.3
     vite: ^3.2.0-beta.2
     vite-plugin-dts: ^1.6.6
   languageName: unknown
@@ -11429,7 +11424,6 @@ __metadata:
     react-icons: ^4.4.0
     react-router-dom: ^6.4.1
     type-fest: ^2.19.0
-    typescript: ^4.7.3
     vite: ^3.1.8
     vite-plugin-web-extension: ^1.4.5
     vite-plugin-zip-pack: ^1.0.5
@@ -11480,7 +11474,6 @@ __metadata:
     ts-jest: 27.1.5
     ts-node: ^10.9.1
     tslib: ^2.3.1
-    typescript: ^4.7.3
   languageName: unknown
   linkType: soft
 
@@ -19884,6 +19877,13 @@ __metadata:
   version: 1.2.1
   resolution: "@types/minimist@npm:1.2.1"
   checksum: 02631cdd79d346ed6838f5443767b5218a0d915fd0529d4a8840c4eba942d7f6906f0056686dd5a119d42528bed0bee5767ebef7667fdca6fcb95411bb56084e
+  languageName: node
+  linkType: hard
+
+"@types/minimist@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "@types/minimist@npm:1.2.2"
+  checksum: b8da83c66eb4aac0440e64674b19564d9d86c80ae273144db9681e5eeff66f238ade9515f5006ffbfa955ceff8b89ad2bd8ec577d7caee74ba101431fb07045d
   languageName: node
   linkType: hard
 
@@ -47999,6 +47999,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rrvideo@workspace:rrweb/packages/rrvideo":
+  version: 0.0.0-use.local
+  resolution: "rrvideo@workspace:rrweb/packages/rrvideo"
+  dependencies:
+    "@highlight-run/rrweb-player": "workspace:*"
+    "@highlight-run/rrweb-types": "workspace:*"
+    "@types/minimist": ^1.2.1
+    minimist: ^1.2.5
+    puppeteer: ^19.7.2
+  bin:
+    rrvideo: build/cli.js
+  languageName: unknown
+  linkType: soft
+
 "rsvp@npm:^4.8.4":
   version: 4.8.5
   resolution: "rsvp@npm:4.8.5"
@@ -52044,7 +52058,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:*, typescript@npm:^4.6.3, typescript@npm:^4.7.3, typescript@npm:^4.8.4, typescript@npm:~4.8.4":
+"typescript@npm:*, typescript@npm:^4.6.3, typescript@npm:^4.8.4, typescript@npm:~4.8.4":
   version: 4.8.4
   resolution: "typescript@npm:4.8.4"
   bin:
@@ -52094,7 +52108,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@*#~builtin<compat/typescript>, typescript@patch:typescript@^4.6.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.7.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.8.4#~builtin<compat/typescript>, typescript@patch:typescript@~4.8.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@*#~builtin<compat/typescript>, typescript@patch:typescript@^4.6.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.8.4#~builtin<compat/typescript>, typescript@patch:typescript@~4.8.4#~builtin<compat/typescript>":
   version: 4.8.4
   resolution: "typescript@patch:typescript@npm%3A4.8.4#~builtin<compat/typescript>::version=4.8.4&hash=1a91c8"
   bin:


### PR DESCRIPTION
## Summary

Recently, we released a new flag to the frontend `H.init` to disable `console.error(...)` calls from being reported as Highlight Errors. This was done because frontend errors are still reported as error logs and are often noisy (not a real application-breaking error like a `window.onerror`, etc).
This PR switches `reportConsoleErrors` off by default to make this the default behavior for new SDK versions >= 5.5.0.
Adds a `disableSessionRecording` setting that allows using the javascript client without recording session data.

## How did you test this change?

Disabling the flag locally and ensuring that frontend `console.error` calls are not reported as Highlight errors.
![Screenshot 2023-03-31 at 4 21 42 PM](https://user-images.githubusercontent.com/1351531/229249081-249151c2-2c5d-49fa-a2b4-1c56a3d26f17.png)

Error reporting by the sessionless client.
<img width="606" alt="Screenshot 2023-04-11 at 12 06 31 AM" src="https://user-images.githubusercontent.com/1351531/231082628-9015b978-876e-419e-902f-336e8579171d.png">

## Are there any deployment considerations?

New `highlight.run` version 5.5.0