### PR TITLE
Typo linking to alerts

### DIFF
--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/tracking-events.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/tracking-events.md
@@ -5,7 +5,7 @@ createdAt: 2021-09-13T23:23:28.000Z
 updatedAt: 2022-03-21T18:25:39.000Z
 ---
 
-A track event is a named event that you've defined. Adding a track event is useful if you want to be able to be alerted (see [Recording Network Requests and Responses](../../../general/6_product-features/3_general-features/alerts.md)) or search for sessions where the user has done an action.
+A track event is a named event that you've defined. Adding a track event is useful if you want to be able to be alerted (see [alerts](../../../general/6_product-features/3_general-features/alerts.md)) or search for sessions where the user has done an action.
 
 ## Example Scenario: A Shopping Cart
 


### PR DESCRIPTION
## Summary

Typo linking to alerts in the tracking docs.

## How did you test this change?

CI building the highlight.io preview.

## Are there any deployment considerations?

No
