### PR TITLE
Added cursor:pointer to docs link icon

### DIFF
--- a/highlight.io/components/Docs/Docs.module.scss
+++ b/highlight.io/components/Docs/Docs.module.scss
@@ -307,6 +307,7 @@
 h4:hover .headingCopyIcon,
 h5:hover .headingCopyIcon {
 	display: inline-flex;
+	cursor: pointer;
 }
 
 .headingCopyIcon {


### PR DESCRIPTION
## Summary

Added `cursor: pointer` to the docs link icon
