### PR TITLE
[hotfix] highlight.io build error

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,9 @@ name: Docker
 on:
     push:
         branches: ['main']
+    # TODO: Remove
+    pull_request:
+        types: [opened, synchronize]
     workflow_dispatch:
     merge_group:
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,9 +3,6 @@ name: Docker
 on:
     push:
         branches: ['main']
-    # TODO: Remove
-    pull_request:
-        types: [opened, synchronize]
     workflow_dispatch:
     merge_group:
 

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -29,6 +29,7 @@ COPY ../sdk/highlight-nest/package.json ./sdk/highlight-nest/package.json
 COPY ../sdk/highlight-next/package.json ./sdk/highlight-next/package.json
 COPY ../sdk/highlight-node/package.json ./sdk/highlight-node/package.json
 COPY ../sdk/highlight-react/package.json ./sdk/highlight-react/package.json
+COPY ../highlight.io/package.json ./highlight.io/package.json
 COPY ../frontend/package.json ./frontend/package.json
 RUN yarn
 
@@ -43,6 +44,7 @@ COPY ../packages ./packages
 COPY ../render ./render
 COPY ../sourcemap-uploader ./sourcemap-uploader
 COPY ../sdk ./sdk
+COPY ../highlight.io ./highlight.io
 COPY ../frontend ./frontend
 COPY ../backend/public-graph ./backend/public-graph
 COPY ../backend/private-graph ./backend/private-graph


### PR DESCRIPTION
## Summary

We are hitting the following error in our docker builds on main:

```sh
#50 [public.ecr.aws/k9o6n7l8/highlight-frontend frontend-base 28/42] RUN yarn
#50 0.787 ➤ YN0000: ┌ Project validation
#50 0.787 ➤ YN0057: │ @highlight-run/frontend: Resolutions field will be ignored
#50 0.788 ➤ YN0057: │ @highlight-run/client: Resolutions field will be ignored
#50 0.788 ➤ YN0000: └ Completed
#50 0.788 ➤ YN0000: ┌ Resolution step
#50 1.439 ➤ YN0001: │ Error: highlight.io@workspace:*: Workspace not found (highlight.io@workspace:*)
```

The problem is that we don't copy over our `highlight.io` directory in our `frontend.Dockerfile`.

## How did you test this change?

Set the workflow step to run and took it from [red](https://github.com/highlight/highlight/actions/runs/4598192564/jobs/8121903507?pr=4815) to [green (still failing because an ENV var wasn't set, but you can see we got past the failure)](https://github.com/highlight/highlight/actions/runs/4598207841/jobs/8121940258?pr=4815).

## Are there any deployment considerations?

N/A
