### PR TITLE
use port 4000 for docs to avoid a conflict with the main app

### DIFF
--- a/docs-content/general/4_company/open-source/contributing/4_landing-site.md
+++ b/docs-content/general/4_company/open-source/contributing/4_landing-site.md
@@ -15,6 +15,7 @@ To run the app locally, install dependencies and call `yarn dev` as follows:
 yarn install;
 cd highlight.io;
 yarn dev;
+open http://localhost:4000/
 ```
 
 Changes to `docs-content` may require refreshing the browser.

--- a/highlight.io/package.json
+++ b/highlight.io/package.json
@@ -7,10 +7,10 @@
 	"scripts": {
 		"build": "next build",
 		"dev": "run-p next-dev styles",
-		"next-dev": "next dev",
+		"next-dev": "next dev -p 4000",
 		"lint": "next lint",
 		"prepare": "husky install",
-		"start": "next start",
+		"start": "next start -p 4000",
 		"styles": "yarn typed-scss-modules ./ --watch --ignore '**/node_modules'"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR runs the docs on port 4000 (it currently defaults to 3000). This avoid conflicts with the main app.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

`yarn dev:frontend` successfully runs

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A