### PR TITLE
use link for related session error link

### DIFF
--- a/backend/clickhouse/cursor.go
+++ b/backend/clickhouse/cursor.go
@@ -80,7 +80,7 @@ func getCursorIdx(edges []*modelInputs.LogEdge, cursor string) int {
 }
 
 func encodeCursor(t time.Time, uuid string) string {
-	key := fmt.Sprintf("%s,%s", t.Format(time.RFC3339Nano), uuid)
+	key := fmt.Sprintf("%s,%s", t.Format(time.RFC3339), uuid)
 	return base64.StdEncoding.EncodeToString([]byte(key))
 }
 func decodeCursor(encodedCursor string) (timestamp time.Time, uuid string, err error) {
@@ -95,7 +95,7 @@ func decodeCursor(encodedCursor string) (timestamp time.Time, uuid string, err e
 		return
 	}
 
-	timestamp, err = time.Parse(time.RFC3339Nano, arrStr[0])
+	timestamp, err = time.Parse(time.RFC3339, arrStr[0])
 	if err != nil {
 		return
 	}

--- a/backend/clickhouse/cursor_test.go
+++ b/backend/clickhouse/cursor_test.go
@@ -186,8 +186,8 @@ func TestClickhouseDecode(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 		},

--- a/backend/clickhouse/cursor_test.go
+++ b/backend/clickhouse/cursor_test.go
@@ -168,7 +168,8 @@ func TestEncodeDecode(t *testing.T) {
 	timestamp, uuid, err := decodeCursor(cursor)
 	assert.NoError(t, err)
 
-	assert.Equal(t, timestamp.UnixNano(), now.UnixNano())
+	// decoded timestamp should have second precision
+	assert.Equal(t, timestamp.UnixNano(), now.Unix()*10e8)
 	assert.Equal(t, "uuid", uuid)
 }
 

--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -84,6 +84,8 @@ type LogRowOption func(*LogRow)
 
 func WithTimestamp(ts time.Time) LogRowOption {
 	return func(h *LogRow) {
+		// ensure timestamp is written at second precision,
+		// since clickhouse schema will truncate to second precision anyways.
 		h.Timestamp = ts.Truncate(time.Second)
 	}
 }

--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -33,7 +33,6 @@ func ProjectToInt(projectID string) (int, error) {
 }
 
 type LogRowPrimaryAttrs struct {
-	Timestamp       time.Time
 	ProjectId       uint32
 	TraceId         string
 	SpanId          string
@@ -42,6 +41,7 @@ type LogRowPrimaryAttrs struct {
 
 type LogRow struct {
 	LogRowPrimaryAttrs
+	Timestamp      time.Time
 	UUID           string
 	TraceFlags     uint32
 	SeverityText   string
@@ -55,7 +55,6 @@ type LogRow struct {
 func NewLogRow(attrs LogRowPrimaryAttrs, opts ...LogRowOption) *LogRow {
 	logRow := &LogRow{
 		LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-			Timestamp:       attrs.Timestamp,
 			TraceId:         attrs.TraceId,
 			SpanId:          attrs.SpanId,
 			ProjectId:       attrs.ProjectId,
@@ -82,6 +81,12 @@ func (l *LogRow) IsBackend() bool {
 }
 
 type LogRowOption func(*LogRow)
+
+func WithTimestamp(ts time.Time) LogRowOption {
+	return func(h *LogRow) {
+		h.Timestamp = ts.Truncate(time.Second)
+	}
+}
 
 func WithLogAttributes(ctx context.Context, resourceAttributes, spanAttributes, eventAttributes map[string]any, isFrontendLog bool) LogRowOption {
 	return func(h *LogRow) {

--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -71,4 +72,11 @@ func TestNewLogRowWithSource(t *testing.T) {
 	lr = NewLogRow(LogRowPrimaryAttrs{}, WithSource("InterceptField"))
 	assert.Equal(t, LogRowSourceValueBackend, lr.Source)
 	assert.Equal(t, "backend", LogRowSourceValueBackend)
+}
+
+func TestNewLogRowWithTimestamp(t *testing.T) {
+	ts := time.Now()
+	lr := NewLogRow(LogRowPrimaryAttrs{}, WithTimestamp(ts))
+	// log row should be created with second precision, per clickhouse precision
+	assert.Equal(t, ts.Truncate(time.Second), lr.Timestamp)
 }

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -105,15 +105,15 @@ func TestReadLogsAscending(t *testing.T) {
 	oneSecondAgo := now.Add(-time.Second * 1)
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			Body: "Body 1",
 		},
 		{
+			Timestamp: oneSecondAgo,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: oneSecondAgo,
 				ProjectId: 1,
 			},
 			Body: "Body 2",

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -93,6 +93,7 @@ func TestReadLogsWithTimeQuery(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Len(t, payload.Edges, 1)
+	assert.Equal(t, now.Truncate(time.Second).UTC(), payload.Edges[0].Node.Timestamp.UTC())
 }
 
 func TestReadLogsAscending(t *testing.T) {

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -65,8 +65,8 @@ func TestReadLogsWithTimeQuery(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 		},
@@ -141,8 +141,8 @@ func TestReadLogsTotalCount(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 		},
@@ -165,43 +165,43 @@ func TestReadLogsHistogram(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			SeverityText: modelInputs.LogLevelInfo.String(),
 		},
 		{
+			Timestamp: now.Add(-time.Hour - time.Minute*29),
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now.Add(-time.Hour - time.Minute*29),
 				ProjectId: 1,
 			},
 			SeverityText: modelInputs.LogLevelDebug.String(),
 		},
 		{
+			Timestamp: now.Add(-time.Hour - time.Minute*30),
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now.Add(-time.Hour - time.Minute*30),
 				ProjectId: 1,
 			},
 			SeverityText: modelInputs.LogLevelInfo.String(),
 		},
 		{
+			Timestamp: now.Add(-time.Hour * 2),
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now.Add(-time.Hour * 2),
 				ProjectId: 1,
 			},
 			SeverityText: modelInputs.LogLevelError.String(),
 		},
 		{
+			Timestamp: now.Add(-time.Hour*2 - time.Minute*30),
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now.Add(-time.Hour*2 - time.Minute*30),
 				ProjectId: 1,
 			},
 			SeverityText: modelInputs.LogLevelError.String(),
 		},
 		{
+			Timestamp: now.Add(-time.Hour * 3),
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now.Add(-time.Hour * 3),
 				ProjectId: 1,
 			},
 			SeverityText: modelInputs.LogLevelError.String(),
@@ -307,8 +307,8 @@ func TestReadLogsHasNextPage(t *testing.T) {
 
 	for i := 1; i <= LogsLimit; i++ { // 100 is a hardcoded limit
 		rows = append(rows, &LogRow{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 		})
@@ -326,8 +326,8 @@ func TestReadLogsHasNextPage(t *testing.T) {
 	// Add more more row to have 101 rows
 	assert.NoError(t, client.BatchWriteLogRows(ctx, []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 		},
@@ -352,32 +352,32 @@ func TestReadLogsAfterCursor(t *testing.T) {
 
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			Body: "Body 1",
 			UUID: "c051edc8-3749-4e44-8f48-0ea90f3fc3d9",
 		},
 		{
+			Timestamp: oneSecondAgo,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: oneSecondAgo,
 				ProjectId: 1,
 			},
 			Body: "Body 2",
 			UUID: "a0d9abd6-7cbf-47de-b211-d16bb0935e04",
 		},
 		{
+			Timestamp: oneSecondAgo,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: oneSecondAgo,
 				ProjectId: 1,
 			},
 			Body: "Body 3",
 			UUID: "b6e255ee-049e-4563-bbfe-c33503cde94c",
 		},
 		{
+			Timestamp: oneDayAgo,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: oneDayAgo,
 				ProjectId: 1,
 			},
 			Body: "Body 4",
@@ -418,31 +418,31 @@ func TestReadLogsBeforeCursor(t *testing.T) {
 
 	rows := []*LogRow{
 		{
+			Timestamp: oneDayFromNow,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: oneDayFromNow,
 				ProjectId: 1,
 			},
 			Body: "Body 0",
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			Body: "Body 1",
 			UUID: "c051edc8-3749-4e44-8f48-0ea90f3fc3d9",
 		},
 		{
+			Timestamp: oneSecondAgo,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: oneSecondAgo,
 				ProjectId: 1,
 			},
 			Body: "Body 2",
 			UUID: "a0d9abd6-7cbf-47de-b211-d16bb0935e04",
 		},
 		{
+			Timestamp: oneSecondAgo,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: oneSecondAgo,
 				ProjectId: 1,
 			},
 			Body: "Body 3",
@@ -488,8 +488,8 @@ func TestReadLogsAtCursor(t *testing.T) {
 	// 1 log not visible on the next page
 	for i := 1; i <= LogsLimit+3; i++ {
 		rows = append(rows, &LogRow{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 		})
@@ -555,22 +555,22 @@ func TestReadLogsWithBodyFilter(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			Body: "body with space",
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			Body: "STRIPE_INTEGRATION_ERROR cannot report usage - customer has no subscriptions",
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			Body: "STRIPE-INTEGRATION-ERROR cannot report usage - customer has no subscriptions",
@@ -630,8 +630,8 @@ func TestReadLogsWithKeyFilter(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{
@@ -681,15 +681,15 @@ func TestReadLogsWithLevelFilter(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			SeverityText: modelInputs.LogLevelInfo.String(),
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{
@@ -732,15 +732,15 @@ func TestReadLogsWithSessionIdFilter(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp:       now,
 				ProjectId:       1,
 				SecureSessionId: "match",
 			},
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{
@@ -783,15 +783,15 @@ func TestReadLogsWithSpanIdFilter(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 				SpanId:    "match",
 			},
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{
@@ -834,15 +834,15 @@ func TestReadLogsWithTraceIdFilter(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 				TraceId:   "match",
 			},
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{
@@ -885,22 +885,22 @@ func TestReadLogsWithSourceFilter(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			Source:      "backend",
 			ServiceName: "bar",
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{
@@ -946,30 +946,30 @@ func TestLogsKeys(t *testing.T) {
 
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"user_id": "1", "workspace_id": "2"},
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"workspace_id": "3"},
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			Source:      "frontend",
 			ServiceName: "foo-service",
 		},
 		{
+			Timestamp: now.Add(-time.Second * 1), // out of range, should not be included
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now.Add(-time.Second * 1), // out of range, should not be included
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"workspace_id": "5"},
@@ -1033,57 +1033,57 @@ func TestLogKeyValues(t *testing.T) {
 
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"workspace_id": "2"},
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"workspace_id": "2"},
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"workspace_id": "3"},
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"workspace_id": "3"},
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"workspace_id": "3"},
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"workspace_id": "4"},
 		},
 		{
+			Timestamp: now.Add(-time.Second * 1), // out of range, should not be included
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now.Add(-time.Second * 1), // out of range, should not be included
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"workspace_id": "5"},
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"unrelated_key": "value"},
@@ -1113,29 +1113,29 @@ func TestLogKeyValuesLevel(t *testing.T) {
 
 	rows := []*LogRow{
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			SeverityText: modelInputs.LogLevelInfo.String(),
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			SeverityText: modelInputs.LogLevelWarn.String(),
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			SeverityText: modelInputs.LogLevelInfo.String(),
 		},
 		{
+			Timestamp: now,
 			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				Timestamp: now,
 				ProjectId: 1,
 			},
 			LogAttributes: map[string]string{"level": modelInputs.LogLevelFatal.String()}, // should be skipped in the output

--- a/backend/clickhouse/seeds/main.go
+++ b/backend/clickhouse/seeds/main.go
@@ -11,7 +11,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func makeRandLogAttributes() map[string]string {
+func makeRandLogAttributes() map[string]any {
 	randomKeys := [21]string{
 		"key1",
 		"key2",
@@ -68,7 +68,7 @@ func makeRandLogAttributes() map[string]string {
 		"flounder",
 	}
 
-	logAttributes := map[string]string{}
+	logAttributes := map[string]any{}
 
 	randomKey := randomKeys[rand.Intn(len(randomKeys))]
 	randomVal := randomVals[rand.Intn(len(randomVals))]
@@ -138,19 +138,17 @@ func main() {
 	now := time.Now()
 
 	for i := 1; i < 10000; i++ {
-		logRows := []*clickhouse.LogRow{}
-		logRows = append(logRows, &clickhouse.LogRow{
-			Timestamp: now.Add(-time.Duration(i) * time.Second),
-			LogRowPrimaryAttrs: clickhouse.LogRowPrimaryAttrs{
-				ProjectId:       1,
-				TraceId:         makeRandomTraceID(),
-				SpanId:          makeRandomSpanID(),
-				SecureSessionId: makeRandomSecureSessionID(),
-			},
-			Body:          fmt.Sprintf("Body %d", i),
-			LogAttributes: makeRandLogAttributes(),
-			SeverityText:  makeRandomSeverityText(),
-		})
+		var logRows []*clickhouse.LogRow
+		logRows = append(logRows, clickhouse.NewLogRow(clickhouse.LogRowPrimaryAttrs{
+			ProjectId:       1,
+			TraceId:         makeRandomTraceID(),
+			SpanId:          makeRandomSpanID(),
+			SecureSessionId: makeRandomSecureSessionID(),
+		}, clickhouse.WithTimestamp(now.Add(-time.Duration(i)*time.Second)),
+			clickhouse.WithBody(ctx, fmt.Sprintf("Body %d", i)),
+			clickhouse.WithLogAttributes(ctx, makeRandLogAttributes(), makeRandLogAttributes(), makeRandLogAttributes(), false),
+			clickhouse.WithSeverityText(makeRandomSeverityText()),
+		))
 		err = client.BatchWriteLogRows(context.Background(), logRows)
 
 		if err != nil {

--- a/backend/clickhouse/seeds/main.go
+++ b/backend/clickhouse/seeds/main.go
@@ -140,8 +140,8 @@ func main() {
 	for i := 1; i < 10000; i++ {
 		logRows := []*clickhouse.LogRow{}
 		logRows = append(logRows, &clickhouse.LogRow{
+			Timestamp: now.Add(-time.Duration(i) * time.Second),
 			LogRowPrimaryAttrs: clickhouse.LogRowPrimaryAttrs{
-				Timestamp:       now.Add(-time.Duration(i) * time.Second),
 				ProjectId:       1,
 				TraceId:         makeRandomTraceID(),
 				SpanId:          makeRandomSpanID(),

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -71,11 +71,11 @@ func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestI
 func getLogRow(ctx context.Context, ts time.Time, lvl, projectID, sessionID, traceID, spanID string, excMessage string, resourceAttributes, spanAttributes, eventAttributes map[string]any, source string) *clickhouse.LogRow {
 	return clickhouse.NewLogRow(
 		clickhouse.LogRowPrimaryAttrs{
-			Timestamp:       ts,
 			TraceId:         traceID,
 			SpanId:          spanID,
 			SecureSessionId: sessionID,
 		},
+		clickhouse.WithTimestamp(ts),
 		clickhouse.WithBody(ctx, excMessage),
 		clickhouse.WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, source == highlight.SourceAttributeFrontend),
 		clickhouse.WithProjectIDString(projectID),
@@ -337,7 +337,6 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 		var projectID, sessionID, requestID, source string
 		resource := resourceLogs.At(i).Resource()
 		resourceAttributes := resource.Attributes().AsRaw()
-		serviceName := cast(resource.Attributes().AsRaw()[string(semconv.ServiceNameKey)], "")
 		setHighlightAttributes(resourceAttributes, &projectID, &sessionID, &requestID, &source)
 		scopeLogs := resourceLogs.At(i).ScopeLogs()
 		for j := 0; j < scopeLogs.Len(); j++ {
@@ -348,24 +347,13 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 				logRecord := logRecords.At(k)
 				logAttributes := logRecord.Attributes().AsRaw()
 				setHighlightAttributes(logAttributes, &projectID, &sessionID, &requestID, &source)
-				projectIDInt, err := clickhouse.ProjectToInt(projectID)
-				if err != nil {
-					log.WithContext(ctx).WithField("ProjectID", projectID).WithField("LogMessage", logRecord.Body().AsRaw()).Errorf("otel log got invalid project id")
+
+				logRow := getLogRow(ctx, logRecord.Timestamp().AsTime(), logRecord.SeverityText(), projectID, sessionID, logRecord.TraceID().String(), logRecord.SpanID().String(), logRecord.Body().Str(), resourceAttributes, scopeAttributes, logAttributes, source)
+				if logRow == nil {
+					log.WithContext(ctx).WithField("ProjectID", projectID).WithField("LogMessage", logRecord.Body().AsRaw()).Errorf("otel log got invalid log record")
 					continue
 				}
-				logRow := clickhouse.NewLogRow(clickhouse.LogRowPrimaryAttrs{
-					Timestamp:       logRecord.Timestamp().AsTime(),
-					TraceId:         logRecord.TraceID().String(),
-					SpanId:          logRecord.SpanID().String(),
-					ProjectId:       uint32(projectIDInt),
-					SecureSessionId: sessionID,
-				},
-					clickhouse.WithLogAttributes(ctx, resourceAttributes, scopeAttributes, logAttributes, false),
-					clickhouse.WithSeverityText(logRecord.SeverityText()),
-				)
 
-				logRow.ServiceName = serviceName
-				logRow.Body = logRecord.Body().Str()
 				if projectID != "" {
 					if _, ok := projectLogs[projectID]; !ok {
 						projectLogs[projectID] = []*clickhouse.LogRow{}

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -35,13 +35,7 @@ import {
 	LogsSearchParam,
 	stringifyLogsQuery,
 } from '@pages/LogsPage/SearchForm/utils'
-import {
-	RightPanelView,
-	usePlayerUIContext,
-} from '@pages/Player/context/PlayerUIContext'
 import { PlayerSearchParameters } from '@pages/Player/PlayerHook/utils'
-import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
-import { Tab } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import {
 	getDisplayNameAndField,
 	getIdentifiedUserProfileImage,
@@ -101,6 +95,14 @@ const getLogsLink = (errorObject: ErrorObject): string => {
 	} else {
 		return `/${errorObject.project_id}/logs?${params}`
 	}
+}
+
+const getSessionLink = (errorObject: ErrorObject): string => {
+	const params = createSearchParams({
+		tsAbs: errorObject.timestamp,
+		[PlayerSearchParameters.errorId]: errorObject.id,
+	})
+	return `/${errorObject.project_id}/sessions/${errorObject.session?.secure_id}?${params}`
 }
 
 const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
@@ -164,15 +166,6 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 		() => goToErrorInstance(errorInstance?.previous_id, 'previous'),
 		[errorInstance?.previous_id],
 	)
-
-	const {
-		setShowLeftPanel,
-		setShowRightPanel,
-		setShowDevTools,
-		setSelectedDevToolsTab,
-	} = usePlayerConfiguration()
-
-	const { setActiveError, setRightPanelView } = usePlayerUIContext()
 
 	const goToErrorInstance = (
 		errorInstanceId: Maybe<string> | undefined,
@@ -350,7 +343,7 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 							emphasis="high"
 							to={getLogsLink(errorObject)}
 							disabled={!isLoggedIn || !errorObject.session}
-							trackingId="logs-related_session_link"
+							trackingId="error-related_logs_link"
 						>
 							<Box
 								display="flex"
@@ -362,33 +355,23 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 								Show logs
 							</Box>
 						</LinkButton>
-						<Button
+						<LinkButton
 							kind="primary"
 							emphasis="high"
+							to={getSessionLink(errorObject)}
 							disabled={!isLoggedIn || !errorObject.session}
-							onClick={() => {
-								if (!isLoggedIn) {
-									return
-								}
-
-								navigate(
-									`/${projectId}/sessions/${errorObject.session?.secure_id}` +
-										`?${PlayerSearchParameters.tsAbs}=${errorObject.timestamp}`,
-								)
-								setShowLeftPanel(false)
-								setShowRightPanel(true)
-								setShowDevTools(true)
-								setSelectedDevToolsTab(Tab.Errors)
-								setActiveError(
-									errorInstance?.error_object as ErrorObject,
-								)
-								setRightPanelView(RightPanelView.Error)
-							}}
-							iconLeft={<IconSolidPlay />}
-							trackingId="errorInstanceShowSession"
+							trackingId="error-related_session_link"
 						>
-							Show session
-						</Button>
+							<Box
+								display="flex"
+								alignItems="center"
+								flexDirection="row"
+								gap="4"
+							>
+								<IconSolidPlay />
+								Show session
+							</Box>
+						</LinkButton>
 					</Box>
 				</Box>
 			</Box>

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -26,7 +26,10 @@ import NoActiveErrorCard from '@pages/ErrorsV2/NoActiveErrorCard/NoActiveErrorCa
 import SearchPanel from '@pages/ErrorsV2/SearchPanel/SearchPanel'
 import { getHeaderFromError } from '@pages/ErrorsV2/utils'
 import useErrorPageConfiguration from '@pages/ErrorsV2/utils/ErrorPageUIConfiguration'
-import { PlayerSearchParameters } from '@pages/Player/PlayerHook/utils'
+import {
+	PlayerSearchParameters,
+	useLinkLogCursor,
+} from '@pages/Player/PlayerHook/utils'
 import analytics from '@util/analytics'
 import { useParams } from '@util/react-router/useParams'
 import { message } from 'antd'
@@ -84,6 +87,13 @@ const ErrorsV2: React.FC<React.PropsWithChildren<{ integrated: boolean }>> = ({
 
 	const navigate = useNavigate()
 	const location = useLocation()
+
+	const { logCursor } = useLinkLogCursor()
+	useEffect(() => {
+		if (logCursor) {
+			setShowLeftPanel(false)
+		}
+	}, [logCursor, setShowLeftPanel])
 
 	useEffect(() => {
 		if (!isLoggedIn && !data?.error_group?.is_public && !loading) {

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -28,10 +28,11 @@ import {
 	stringifyLogsQuery,
 } from '@pages/LogsPage/SearchForm/utils'
 import { LogEdgeWithError } from '@pages/LogsPage/useGetLogs'
+import { PlayerSearchParameters } from '@pages/Player/PlayerHook/utils'
 import { Row } from '@tanstack/react-table'
 import { message as antdMessage } from 'antd'
 import React, { useEffect, useState } from 'react'
-import { generatePath } from 'react-router-dom'
+import { createSearchParams, generatePath } from 'react-router-dom'
 import { useQueryParam } from 'use-query-params'
 
 import * as styles from './LogDetails.css'
@@ -47,6 +48,20 @@ export const getLogURL = (row: Row<LogEdge>) => {
 		log_cursor: row.original.cursor,
 	})
 	return currentUrl.origin + path
+}
+
+const getSessionLink = (projectId: string, log: LogEdgeWithError): string => {
+	const params = createSearchParams({
+		[PlayerSearchParameters.log]: log.cursor,
+	})
+	return `/${projectId}/sessions/${log.node.secureSessionID}?${params}`
+}
+
+const getErrorLink = (projectId: string, log: LogEdgeWithError): string => {
+	const params = createSearchParams({
+		[PlayerSearchParameters.log]: log.cursor,
+	})
+	return `/errors/${log.error_object?.error_group_secure_id}/instances/${log.error_object?.id}?${params}`
 }
 
 export const LogDetails = ({ row, queryTerms }: Props) => {
@@ -234,7 +249,7 @@ export const LogDetails = ({ row, queryTerms }: Props) => {
 						<LinkButton
 							kind="secondary"
 							emphasis="low"
-							to={`/errors/logs/${row.original.cursor}`}
+							to={getErrorLink(projectId, row.original)}
 							trackingId="logs-related_error_link"
 						>
 							<Box
@@ -253,7 +268,7 @@ export const LogDetails = ({ row, queryTerms }: Props) => {
 						<LinkButton
 							kind="secondary"
 							emphasis="low"
-							to={`/${projectId}/sessions/${secureSessionID}`}
+							to={getSessionLink(projectId, row.original)}
 							trackingId="logs-related_session_link"
 						>
 							<Box

--- a/frontend/src/pages/Player/PlayerHook/utils/index.tsx
+++ b/frontend/src/pages/Player/PlayerHook/utils/index.tsx
@@ -1,3 +1,4 @@
+import { useGetErrorObjectQuery } from '@graph/hooks'
 import { ErrorObject, Session, SessionComment } from '@graph/schemas'
 import { EventType, Replayer } from '@highlight-run/rrweb'
 import { playerMetaData, SessionInterval } from '@highlight-run/rrweb-types'
@@ -143,6 +144,23 @@ export enum PlayerSearchParameters {
 	commentId = 'commentId',
 	/** Whether to mark the comment thread as muted.*/
 	muted = 'muted',
+}
+
+export const usePlayerLinkErrorInstance = () => {
+	const location = useLocation()
+	const searchParams = new URLSearchParams(location.search)
+	const errorInstanceID = searchParams.get(PlayerSearchParameters.errorId)
+
+	const { data: errorObject } = useGetErrorObjectQuery({
+		variables: {
+			id: errorInstanceID!,
+		},
+		skip: !errorInstanceID,
+	})
+
+	return {
+		errorObject: errorObject?.error_object,
+	}
 }
 
 /**

--- a/frontend/src/pages/Player/PlayerHook/utils/index.tsx
+++ b/frontend/src/pages/Player/PlayerHook/utils/index.tsx
@@ -140,13 +140,15 @@ export enum PlayerSearchParameters {
 	tsAbs = 'tsAbs',
 	/** The error ID for an error in the current session. The player's time will be set to the lookback period before the error's timestamp. */
 	errorId = 'errorId',
+	/** The Log Cursor where a link was coming from. **/
+	log = 'log',
 	/** The comment ID for a comment in the current session. The player's time will be set to the comments's timestamp. */
 	commentId = 'commentId',
 	/** Whether to mark the comment thread as muted.*/
 	muted = 'muted',
 }
 
-export const usePlayerLinkErrorInstance = () => {
+export const useLinkErrorInstance = () => {
 	const location = useLocation()
 	const searchParams = new URLSearchParams(location.search)
 	const errorInstanceID = searchParams.get(PlayerSearchParameters.errorId)
@@ -160,6 +162,15 @@ export const usePlayerLinkErrorInstance = () => {
 
 	return {
 		errorObject: errorObject?.error_object,
+	}
+}
+
+export const useLinkLogCursor = () => {
+	const location = useLocation()
+	const searchParams = new URLSearchParams(location.search)
+	const logCursor = searchParams.get(PlayerSearchParameters.log)
+	return {
+		logCursor,
 	}
 }
 

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -13,12 +13,16 @@ import { useWindowSize } from '@hooks/useWindowSize'
 import { CompleteSetup } from '@pages/Player/components/CompleteSetup/CompleteSetup'
 import NoActiveSessionCard from '@pages/Player/components/NoActiveSessionCard/NoActiveSessionCard'
 import UnauthorizedViewingForm from '@pages/Player/components/UnauthorizedViewingForm/UnauthorizedViewingForm'
-import { usePlayerUIContext } from '@pages/Player/context/PlayerUIContext'
+import {
+	RightPanelView,
+	usePlayerUIContext,
+} from '@pages/Player/context/PlayerUIContext'
 import PlayerCommentCanvas, {
 	Coordinates2D,
 } from '@pages/Player/PlayerCommentCanvas/PlayerCommentCanvas'
 import { usePlayer } from '@pages/Player/PlayerHook/PlayerHook'
 import { SessionViewability } from '@pages/Player/PlayerHook/PlayerState'
+import { usePlayerLinkErrorInstance } from '@pages/Player/PlayerHook/utils'
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import PlayerPageProductTour from '@pages/Player/PlayerPageProductTour/PlayerPageProductTour'
 import {
@@ -32,6 +36,7 @@ import {
 import RightPlayerPanel from '@pages/Player/RightPlayerPanel/RightPlayerPanel'
 import SessionLevelBarV2 from '@pages/Player/SessionLevelBar/SessionLevelBarV2'
 import { DevTools } from '@pages/Player/Toolbar/DevTools'
+import { Tab } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import { NewCommentModal } from '@pages/Player/Toolbar/NewCommentModal/NewCommentModal'
 import { Toolbar } from '@pages/Player/Toolbar/Toolbar'
 import useToolbarItems from '@pages/Player/Toolbar/ToolbarItems/useToolbarItems'
@@ -111,9 +116,34 @@ const PlayerPage = ({ integrated }: Props) => {
 
 	const {
 		setShowLeftPanel,
+		setShowRightPanel,
+		setSelectedDevToolsTab,
+		setShowDevTools,
 		showLeftPanel: showLeftPanelPreference,
 		showRightPanel,
 	} = usePlayerConfiguration()
+	const { setRightPanelView, setActiveError } = usePlayerUIContext()
+
+	const { errorObject } = usePlayerLinkErrorInstance()
+	useEffect(() => {
+		if (errorObject) {
+			setShowLeftPanel(false)
+			setShowRightPanel(true)
+			setShowDevTools(true)
+			setSelectedDevToolsTab(Tab.Errors)
+			setActiveError({ ...errorObject, session })
+			setRightPanelView(RightPanelView.Error)
+		}
+	}, [
+		errorObject,
+		session,
+		setActiveError,
+		setRightPanelView,
+		setSelectedDevToolsTab,
+		setShowDevTools,
+		setShowLeftPanel,
+		setShowRightPanel,
+	])
 
 	const toolbarContext = useToolbarItems()
 

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -22,7 +22,10 @@ import PlayerCommentCanvas, {
 } from '@pages/Player/PlayerCommentCanvas/PlayerCommentCanvas'
 import { usePlayer } from '@pages/Player/PlayerHook/PlayerHook'
 import { SessionViewability } from '@pages/Player/PlayerHook/PlayerState'
-import { usePlayerLinkErrorInstance } from '@pages/Player/PlayerHook/utils'
+import {
+	useLinkErrorInstance,
+	useLinkLogCursor,
+} from '@pages/Player/PlayerHook/utils'
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import PlayerPageProductTour from '@pages/Player/PlayerPageProductTour/PlayerPageProductTour'
 import {
@@ -124,7 +127,7 @@ const PlayerPage = ({ integrated }: Props) => {
 	} = usePlayerConfiguration()
 	const { setRightPanelView, setActiveError } = usePlayerUIContext()
 
-	const { errorObject } = usePlayerLinkErrorInstance()
+	const { errorObject } = useLinkErrorInstance()
 	useEffect(() => {
 		if (errorObject) {
 			setShowLeftPanel(false)
@@ -144,6 +147,13 @@ const PlayerPage = ({ integrated }: Props) => {
 		setShowLeftPanel,
 		setShowRightPanel,
 	])
+
+	const { logCursor } = useLinkLogCursor()
+	useEffect(() => {
+		if (logCursor) {
+			setShowLeftPanel(false)
+		}
+	}, [logCursor, setShowLeftPanel])
 
 	const toolbarContext = useToolbarItems()
 


### PR DESCRIPTION
## Summary

Addresses linking logic between errors and logs.
* makes error -> `related session` button use a copyable link that closes left panel while populating error details
* makes logs -> `related session` button use a copyable link that closes left panel
* makes logs -> `related error` button use a copyable link that closes left panel

Fixes issue in clickhouse timestamp rounding after #4667 that broke logs -> errors linking

```
returned by clickhouse
2023-04-03 23:15:46 +0000
MjAyMy0wNC0wM1QyMzoxNTo0NlosODVmM2EwYTAtYjFhMS00ZWJiLWIxMjctODRmZTAxNjdmYTBk

in otel
2023-04-03 23:32:12.547854882 +0000
MjAyMy0wNC0wM1QyMzozMjoxMi41NDc4NTQ4ODJaLDc5MDFmMGM2LTYwMmYtNDk1NS05ZTZmLTYwYTQyODQ3NmI0NQ==

after fix in otel
2023-04-03 23:37:51 +0000
MjAyMy0wNC0wM1QyMzozNzo1MVosY2M3ODlkOTMtN2Q4ZS00MTJkLTliMTgtZjM2ZDZiNzdkOWMz
```

## How did you test this change?

https://www.loom.com/share/d478a195d89546edb1d3d7d3f3c13422

## Are there any deployment considerations?

No