### PR TITLE
[hotfix] Fix images not loading in setup docs from app

### DIFF
--- a/highlight.io/next.config.js
+++ b/highlight.io/next.config.js
@@ -61,6 +61,14 @@ const nextConfig = {
 			},
 		]
 	},
+	async headers() {
+		return [
+			{
+				source: '/images/:path*',
+				headers: [{ key: 'Access-Control-Allow-Origin', value: '*' }],
+			},
+		]
+	},
 	async rewrites() {
 		return [
 			{


### PR DESCRIPTION
## Summary

We are seeing some issues loading images on our setup pages. The error is CORS related.

<img width="446" alt="Screenshot 2023-04-03 at 10 03 43 PM" src="https://user-images.githubusercontent.com/308182/229667664-8096d78b-8b6a-4d95-ab11-9186bd2a9a7d.png">

This PR sets a header to allow cross origin requests for our images in `public/images`.

## How did you test this change?

Confirmed the header was set when inspecting an image loaded locally.

<img width="927" alt="Screenshot 2023-04-03 at 12 55 40 PM" src="https://user-images.githubusercontent.com/308182/229667777-2a73d95c-f54f-4a28-a283-b09d86ad06b8.png">

## Are there any deployment considerations?

Should just monitor to ensure images are being loaded as expected once this goes out to prod.