### PR TITLE
add www to site images to ensure we do not redirect

### DIFF
--- a/highlight.io/utils/urls.ts
+++ b/highlight.io/utils/urls.ts
@@ -1,7 +1,7 @@
 export const siteUrl = (url: string) => {
 	const base =
 		typeof process === 'undefined'
-			? 'https://highlight.io'
-			: process.env.WEBSITE_URL || 'https://highlight.io'
+			? 'https://www.highlight.io'
+			: process.env.WEBSITE_URL || 'https://www.highlight.io'
 	return `${base}${url}`
 }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Reusing images from highlight.io in app.highlight.io results in a 308 redirect error:
![Screenshot 2023-04-04 at 11 21 07 AM](https://user-images.githubusercontent.com/58678/229869394-21668bef-da4c-4052-b53f-20688425247e.png)

We observed that manually changing the URL to use www fixes that redirect error.


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

This is somewhat tricky to test. We're operating off of a hunch. If this does not work, we will just move the images over.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A