### PR TITLE
ensure tracer does not panic on graphql errors

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -463,7 +463,7 @@ func main() {
 			privateServer.Use(util.NewTracer(util.PrivateGraph))
 			privateServer.Use(H.NewGraphqlTracer(string(util.PrivateGraph)).WithRequestFieldLogging())
 			privateServer.SetErrorPresenter(util.GraphQLErrorPresenter(string(util.PrivateGraph)))
-			privateServer.SetRecoverFunc(util.GraphQLRecoverFunc())
+			privateServer.SetRecoverFunc(H.GraphQLRecoverFunc())
 			r.Handle("/",
 				privateServer,
 			)
@@ -507,7 +507,7 @@ func main() {
 			publicServer.Use(util.NewTracer(util.PublicGraph))
 			publicServer.Use(H.NewGraphqlTracer(string(util.PublicGraph)))
 			publicServer.SetErrorPresenter(util.GraphQLErrorPresenter(string(util.PublicGraph)))
-			publicServer.SetRecoverFunc(util.GraphQLRecoverFunc())
+			publicServer.SetRecoverFunc(H.GraphQLRecoverFunc())
 			r.Handle("/",
 				publicServer,
 			)

--- a/backend/util/logging.go
+++ b/backend/util/logging.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"context"
-
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -34,8 +33,12 @@ func GraphQLErrorPresenter(service string) func(ctx context.Context, e error) *g
 
 func GraphQLRecoverFunc() func(ctx context.Context, err interface{}) error {
 	return func(ctx context.Context, err interface{}) error {
-		err2 := errors.Errorf("panic {error: %+v}", err)
-		highlight.RecordError(ctx, err2, attribute.String(highlight.SourceAttribute, "GraphQLRecoverFunc"))
-		return err2
+		var ok bool
+		var e error
+		if e, ok = err.(error); !ok {
+			e = errors.Errorf("panic {error: %+v}", err)
+		}
+		highlight.RecordError(ctx, e, attribute.String(highlight.SourceAttribute, "GraphQLRecoverFunc"))
+		return e
 	}
 }

--- a/backend/util/logging.go
+++ b/backend/util/logging.go
@@ -2,11 +2,7 @@ package util
 
 import (
 	"context"
-	"github.com/highlight/highlight/sdk/highlight-go"
-	"go.opentelemetry.io/otel/attribute"
-
 	"github.com/99designs/gqlgen/graphql"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
@@ -28,17 +24,5 @@ func GraphQLErrorPresenter(service string) func(ctx context.Context, e error) *g
 		}
 
 		return gqlerr
-	}
-}
-
-func GraphQLRecoverFunc() func(ctx context.Context, err interface{}) error {
-	return func(ctx context.Context, err interface{}) error {
-		var ok bool
-		var e error
-		if e, ok = err.(error); !ok {
-			e = errors.Errorf("panic {error: %+v}", err)
-		}
-		highlight.RecordError(ctx, e, attribute.String(highlight.SourceAttribute, "GraphQLRecoverFunc"))
-		return e
 	}
 }

--- a/docs-content/sdk/go.md
+++ b/docs-content/sdk/go.md
@@ -169,10 +169,25 @@ Use this if you are using the raw http server package and need to setup the High
   </div>
   <div className="right">
     <code>
-        // InterceptField traces each graphql field response
-        func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (interface{}, error) { ... }
-        // InterceptResponse encapsulates the entire graphql request
-        func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response { ... }
+        import ghandler "github.com/99designs/gqlgen/graphql/handler"
+        privateServer := ghandler.New(privategen.NewExecutableSchema(...)
+        server.Use(H.NewGraphqlTracer(string(util.PrivateGraph)).WithRequestFieldLogging())
+    </code>
+  </div>
+</section>
+
+
+<section className="section">
+  <div className="left">
+    <h3>H.GraphQLRecoverFunc()</h3> 
+    <p>A gqlgen recover function to capture panics.</p>
+    <h6>Configuration</h6>
+  </div>
+  <div className="right">
+    <code>
+        import ghandler "github.com/99designs/gqlgen/graphql/handler"
+        privateServer := ghandler.New(privategen.NewExecutableSchema(...)
+        server.SetRecoverFunc(H.GraphQLRecoverFunc())
     </code>
   </div>
 </section>

--- a/highlight.io/components/QuickstartContent/backend/go/go-gqlgen.tsx
+++ b/highlight.io/components/QuickstartContent/backend/go/go-gqlgen.tsx
@@ -34,6 +34,8 @@ func main() {
   // call with WithRequestFieldLogging() to emit highlight logs for each graphql operation
   // useful for tracing which graphql operations are called as part of which frontend sessions
   server.Use(H.NewGraphqlTracer("your-backend-service-name").WithRequestFieldLogging())
+  // capture panics emitted by graphql handlers in highlight
+  server.SetRecoverFunc(H.GraphQLRecoverFunc())
   // ...
 }`,
 				language: 'go',

--- a/sdk/highlight-go/tracer.go
+++ b/sdk/highlight-go/tracer.go
@@ -110,12 +110,20 @@ func (t Tracer) log(ctx context.Context, span trace.Span, errs gqlerror.List) {
 		lvl = "error"
 	}
 	attrs := []attribute.KeyValue{
-		semconv.GraphqlOperationTypeKey.String(string(oc.Operation.Operation)),
-		semconv.GraphqlOperationNameKey.String(oc.OperationName),
-		semconv.GraphqlDocumentKey.String(oc.RawQuery),
 		attribute.String("graphql.graph", t.graphName),
-		attribute.String(LogMessageAttribute, fmt.Sprintf("graphql.operation.%s", oc.Operation.Name)),
 		attribute.String(LogSeverityAttribute, lvl),
+	}
+	if oc != nil {
+		attrs = append(attrs,
+			semconv.GraphqlOperationNameKey.String(oc.OperationName),
+			semconv.GraphqlDocumentKey.String(oc.RawQuery),
+		)
+		if oc.Operation != nil {
+			attrs = append(attrs,
+				attribute.String(LogMessageAttribute, fmt.Sprintf("graphql.operation.%s", oc.Operation.Name)),
+				semconv.GraphqlOperationTypeKey.String(string(oc.Operation.Operation)),
+			)
+		}
 	}
 	if err != "" {
 		attrs = append(attrs, attribute.String("graphql.error", err))


### PR DESCRIPTION
## Summary

Fixes an issue with the gqlgen graphql server middleware provided by the highlight go sdk that would
cause a panic on graphql server errors.

Improves the backend panic recovery utility to use the native gqlgen error object.

## How did you test this change?

Hitting the backend with an invalid graphql request no longer causes a panic:
![Screenshot 2023-04-04 at 12 33 49 PM](https://user-images.githubusercontent.com/1351531/229900617-1b351af1-b233-478f-99e4-1772debcf4d2.png)
![Screenshot 2023-04-04 at 12 37 04 PM](https://user-images.githubusercontent.com/1351531/229901226-faba0066-1492-4aa0-8f66-7f11722a7897.png)

Hitting the backend with a graphql request that actually panics shows a stacktrace:
![Screenshot 2023-04-04 at 12 37 44 PM](https://user-images.githubusercontent.com/1351531/229901337-3d2d2cb2-916b-4d84-a460-8170b8efe564.png)
![Screenshot 2023-04-04 at 12 38 03 PM](https://user-images.githubusercontent.com/1351531/229901404-e866e505-f25f-491c-b629-06407b0525b2.png)


Docs
![Screenshot 2023-04-04 at 12 33 07 PM](https://user-images.githubusercontent.com/1351531/229900493-f3a5fe46-ac16-4512-98d1-c76d21237f3f.png)

![Screenshot 2023-04-04 at 12 33 28 PM](https://user-images.githubusercontent.com/1351531/229900553-5643068b-0914-4780-857e-f244822b912c.png)

## Are there any deployment considerations?

Will tag a new go sdk version.
