### PR TITLE
Fetch session logs via clickhouse

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,6 +72,7 @@
 		"backend/public-graph/graph/generated/*": true,
 		"backend/go.sum": true,
 		"backend/event-parse/sample-events/*.json": true,
+		"frontend/build/assets/*": true,
 		"**/*.scss.d.ts": true,
 		"backend/payload/*": true,
 		"**/yarn-error.log": true

--- a/frontend/src/pages/LogsPage/SearchForm/utils.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.ts
@@ -1,9 +1,8 @@
-import { LogLevel, LogSource, LogsParamsInput, ReservedLogKey, Session } from '@graph/schemas'
+import { LogLevel, LogSource, ReservedLogKey, Session } from '@graph/schemas'
 import moment from 'moment'
 import { stringify } from 'query-string'
 import { DateTimeParam, encodeQueryParams, StringParam } from 'use-query-params'
 
-import { LOG_TIME_FORMAT } from '@/pages/LogsPage/constants'
 
 export type LogsSearchParam = {
 	key: string
@@ -114,7 +113,7 @@ export const validateLogsQuery = (params: LogsSearchParam[]): boolean => {
 	return !params.some((param) => !param.value)
 }
 
-export const buildSessionParams = ({session, levels, sources}: {session: Session | undefined, levels: LogLevel[], sources: LogSource[]}): LogsParamsInput => {
+export const buildSessionParams = ({session, levels, sources}: {session: Session | undefined, levels: LogLevel[], sources: LogSource[]}) => {
 	const queryParams: LogsSearchParam[] = []
 	let offsetStart = 1
 
@@ -148,12 +147,9 @@ export const buildSessionParams = ({session, levels, sources}: {session: Session
 	return {
 		query: stringifyLogsQuery(queryParams),
 		date_range: {
-			start_date: moment(session?.created_at).format(
-				LOG_TIME_FORMAT,
-			),
+			start_date: moment(session?.created_at),
 			end_date: moment(session?.created_at)
 						.add(4, 'hours')
-						.format(LOG_TIME_FORMAT),
 		}
 	}
 }
@@ -168,7 +164,9 @@ export const getLogsURLForSession = ({projectId, session, levels, sources} : {pr
 			end_date: DateTimeParam,
 		},
 		{
-			...params,
+			query: params.query,
+			start_date: params.date_range.start_date.toDate(),
+			end_date: params.date_range.end_date.toDate(),
 		},
 	)
 	return `/${projectId}/logs?${stringify(encodedQuery)}`

--- a/frontend/src/pages/LogsPage/SearchForm/utils.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.ts
@@ -1,7 +1,9 @@
-import { ReservedLogKey, Session } from '@graph/schemas'
+import { LogLevel, LogSource, LogsParamsInput, ReservedLogKey, Session } from '@graph/schemas'
 import moment from 'moment'
 import { stringify } from 'query-string'
 import { DateTimeParam, encodeQueryParams, StringParam } from 'use-query-params'
+
+import { LOG_TIME_FORMAT } from '@/pages/LogsPage/constants'
 
 export type LogsSearchParam = {
 	key: string
@@ -112,20 +114,53 @@ export const validateLogsQuery = (params: LogsSearchParam[]): boolean => {
 	return !params.some((param) => !param.value)
 }
 
-export const getLogsURLForSession = (projectId: string, session: Session) => {
+export const buildSessionParams = ({session, levels, sources}: {session: Session | undefined, levels: LogLevel[], sources: LogSource[]}): LogsParamsInput => {
 	const queryParams: LogsSearchParam[] = []
-	queryParams.push({
-		key: ReservedLogKey.SecureSessionId,
-		operator: DEFAULT_LOGS_OPERATOR,
-		value: session.secure_id,
-		offsetStart: 0,
+	let offsetStart = 1
+
+	if (session?.secure_id) {
+		queryParams.push({
+			key: ReservedLogKey.SecureSessionId,
+			operator: DEFAULT_LOGS_OPERATOR,
+			value: session.secure_id,
+			offsetStart: offsetStart++,
+		})
+	}
+
+	levels.forEach((level) => {
+		queryParams.push({
+			key: ReservedLogKey.Level,
+			operator: DEFAULT_LOGS_OPERATOR,
+			value: level,
+			offsetStart: offsetStart++,
+		})
 	})
 
-	const sessionStartDate = new Date(session.created_at)
+	sources.forEach((source) => {
+		queryParams.push({
+			key: ReservedLogKey.Source,
+			operator: DEFAULT_LOGS_OPERATOR,
+			value: source,
+			offsetStart: offsetStart++,
+		})
+	})
 
-	// Four hours is the max length of a session (see https://github.com/highlight/highlight/pull/4653#discussion_r1145569643)
-	const sessionEndDate = moment(sessionStartDate).add(4, 'hours').toDate()
+	return {
+		query: stringifyLogsQuery(queryParams),
+		date_range: {
+			start_date: moment(session?.created_at).format(
+				LOG_TIME_FORMAT,
+			),
+			end_date: moment(session?.created_at)
+						.add(4, 'hours')
+						.format(LOG_TIME_FORMAT),
+		}
+	}
+}
 
+export const getLogsURLForSession = ({projectId, session, levels, sources} : {projectId: string, session: Session, levels: LogLevel[], sources: LogSource[]}) => {
+	const params = buildSessionParams({session, levels, sources})
+	
 	const encodedQuery = encodeQueryParams(
 		{
 			query: StringParam,
@@ -133,9 +168,7 @@ export const getLogsURLForSession = (projectId: string, session: Session) => {
 			end_date: DateTimeParam,
 		},
 		{
-			query: stringifyLogsQuery(queryParams),
-			start_date: sessionStartDate,
-			end_date: sessionEndDate,
+			...params,
 		},
 	)
 	return `/${projectId}/logs?${stringify(encodedQuery)}`

--- a/frontend/src/pages/LogsPage/SearchForm/utils.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/utils.ts
@@ -3,7 +3,6 @@ import moment from 'moment'
 import { stringify } from 'query-string'
 import { DateTimeParam, encodeQueryParams, StringParam } from 'use-query-params'
 
-
 export type LogsSearchParam = {
 	key: string
 	operator: string
@@ -113,7 +112,15 @@ export const validateLogsQuery = (params: LogsSearchParam[]): boolean => {
 	return !params.some((param) => !param.value)
 }
 
-export const buildSessionParams = ({session, levels, sources}: {session: Session | undefined, levels: LogLevel[], sources: LogSource[]}) => {
+export const buildSessionParams = ({
+	session,
+	levels,
+	sources,
+}: {
+	session: Session | undefined
+	levels: LogLevel[]
+	sources: LogSource[]
+}) => {
 	const queryParams: LogsSearchParam[] = []
 	let offsetStart = 1
 
@@ -148,15 +155,24 @@ export const buildSessionParams = ({session, levels, sources}: {session: Session
 		query: stringifyLogsQuery(queryParams),
 		date_range: {
 			start_date: moment(session?.created_at),
-			end_date: moment(session?.created_at)
-						.add(4, 'hours')
-		}
+			end_date: moment(session?.created_at).add(4, 'hours'),
+		},
 	}
 }
 
-export const getLogsURLForSession = ({projectId, session, levels, sources} : {projectId: string, session: Session, levels: LogLevel[], sources: LogSource[]}) => {
-	const params = buildSessionParams({session, levels, sources})
-	
+export const getLogsURLForSession = ({
+	projectId,
+	session,
+	levels,
+	sources,
+}: {
+	projectId: string
+	session: Session
+	levels: LogLevel[]
+	sources: LogSource[]
+}) => {
+	const params = buildSessionParams({ session, levels, sources })
+
 	const encodedQuery = encodeQueryParams(
 		{
 			query: StringParam,

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -59,7 +59,7 @@ export const ConsolePage = ({
 			},
 			project_id: projectId,
 		},
-		skip: !session?.created_at,
+		skip: !session,
 	})
 
 	const messagesToRender = useMemo(() => {

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -190,9 +190,10 @@ const MessageRow = React.memo(function ({
 				}),
 			)}
 			borderBottom="dividerWeak"
-			py="8"
+			pt="2"
+			pb="2"
 		>
-			<Stack direction="row">
+			<Stack direction="row" align="center">
 				<Box flexGrow={1}>
 					<Text
 						family="monospace"

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -190,10 +190,9 @@ const MessageRow = React.memo(function ({
 				}),
 			)}
 			borderBottom="dividerWeak"
-			pt="2"
-			pb="2"
+			py="8"
 		>
-			<Stack direction="row" align="center">
+			<Stack direction="row">
 				<Box flexGrow={1}>
 					<Text
 						family="monospace"

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -89,8 +89,8 @@ export const ConsolePage = ({
 			for (let i = 0; i < messagesToRender.length; i++) {
 				const currentDiff: number =
 					time -
-					(new Date(messagesToRender[i].node.timestamp).getDate() -
-						new Date(messagesToRender[0].node.timestamp).getDate())
+					(new Date(messagesToRender[i].node.timestamp).getTime() -
+						new Date(messagesToRender[0].node.timestamp).getTime())
 				if (currentDiff < 0) break
 				if (currentDiff < msgDiff) {
 					cursor = messagesToRender[i].cursor
@@ -120,18 +120,27 @@ export const ConsolePage = ({
 					// See: https://virtuoso.dev/scroll-to-index/
 					// behavior: 'smooth'
 				})
-				const timestamp =
-					new Date(messagesToRender[index].node.timestamp).getTime() -
-					sessionMetadata.startTime
-				setTime(timestamp)
+
+				if (state !== ReplayerState.Playing || !autoScroll) {
+					// We really only want this run when the component is mounted
+					// and we are trying to set the player time based on what the log cursor
+					// query param is.
+					const timestamp =
+						new Date(
+							messagesToRender[index].node.timestamp,
+						).getTime() - sessionMetadata.startTime
+					setTime(timestamp)
+				}
 			}
 		}
 	}, [
+		autoScroll,
 		isPlayerReady,
 		messagesToRender,
 		selectedCursor,
 		sessionMetadata.startTime,
 		setTime,
+		state,
 	])
 
 	return (
@@ -181,9 +190,9 @@ const MessageRow = React.memo(function ({
 				}),
 			)}
 			borderBottom="dividerWeak"
-			py="4"
+			py="8"
 		>
-			<Stack direction="row" align="center">
+			<Stack direction="row">
 				<Box flexGrow={1}>
 					<Text
 						family="monospace"
@@ -208,6 +217,7 @@ const MessageRow = React.memo(function ({
 						shape="basic"
 						emphasis="low"
 						kind="secondary"
+						size="small"
 						iconRight={<IconSolidArrowCircleRight />}
 						onClick={onSelect}
 					>

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -112,6 +112,7 @@ export const ConsolePage = ({
 			(logEdge) => logEdge.cursor === selectedCursor,
 		)
 	}, [messagesToRender, selectedCursor])
+
 	useEffect(() => {
 		if (
 			isPlayerReady && // ensure Virtuoso component is actually rendered
@@ -127,7 +128,7 @@ export const ConsolePage = ({
 					// behavior: 'smooth'
 				})
 
-				if (state !== ReplayerState.Playing || !autoScroll) {
+				if (state === ReplayerState.Paused) {
 					// We really only want this run when the component is mounted
 					// and we are trying to set the player time based on what the log cursor
 					// query param is.

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/style.css.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/style.css.ts
@@ -1,35 +1,13 @@
 import { colors } from '@highlight-run/ui/src/css/colors'
 import { style } from '@vanilla-extract/css'
-import { recipe, RecipeVariants } from '@vanilla-extract/recipes'
+import { recipe } from '@vanilla-extract/recipes'
 
 export const consoleBox = style({
-	width: '100%',
-	height: '100%',
-	display: 'flex',
-	flexDirection: 'column',
 	paddingLeft: 8,
-	overflowX: 'hidden',
-	overflowY: 'auto',
-	wordWrap: 'break-word',
-})
-
-export const consoleBar = style({
-	width: 2,
-	borderRadius: 4,
-	marginRight: 4,
-})
-
-export const consoleText = style({
-	lineHeight: '20px',
-	color: 'rgba(26, 21, 35, 0.72)',
+	height: '100%',
 })
 
 export const consoleRow = style({
-	display: 'flex',
-	flexDirection: 'row',
-	justifyContent: 'flex-start',
-	padding: '2px 4px',
-	margin: '8px 0',
 	selectors: {
 		'&:focus, &:active, &:hover': {
 			backgroundColor: colors.n5,
@@ -37,29 +15,7 @@ export const consoleRow = style({
 	},
 })
 
-export const variants = recipe({
-	variants: {
-		type: {
-			trace: { backgroundColor: colors.lb700 },
-			info: { backgroundColor: 'rgba(26, 21, 35, 0.72)' },
-			log: { backgroundColor: colors.n11 },
-			warn: { backgroundColor: colors.orange500 },
-			error: { backgroundColor: colors.red500 },
-			assert: { backgroundColor: colors.r9 },
-		},
-	},
-
-	defaultVariants: {
-		type: 'log',
-	},
-})
-
-export type Variants = RecipeVariants<typeof variants>
-
 export const messageRowVariants = recipe({
-	base: {
-		borderRadius: 4,
-	},
 	variants: {
 		current: {
 			true: {

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -218,7 +218,6 @@ const DevToolsWindowV2: React.FC<
 										levels={levels}
 										sources={sources}
 										filter={filter}
-										time={time}
 									/>
 								),
 							},

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -77,7 +77,9 @@ const DevToolsWindowV2: React.FC<
 
 	const [searchShown, setSearchShown] = React.useState<boolean>(false)
 	const [levels, setLevels] = React.useState<LogLevel[]>([])
-	const [sources, setSources] = React.useState<LogSource[]>([])
+	const [sources, setSources] = React.useState<LogSource[]>([
+		LogSource.Frontend,
+	])
 	const form = useFormState({
 		defaultValues: {
 			search: '',
@@ -325,6 +327,7 @@ const DevToolsWindowV2: React.FC<
 											<MenuButton
 												divider
 												size="medium"
+												selectedKey={LogSource.Frontend}
 												options={LogSourceValues.map(
 													(source) => ({
 														key: source,

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -38,6 +38,7 @@ import clsx from 'clsx'
 import React, { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 
+import { useLinkLogCursor } from '@/pages/Player/PlayerHook/utils'
 import { styledVerticalScrollbar } from '@/style/common.css'
 
 import { ConsolePage } from './ConsolePage/ConsolePage'
@@ -62,6 +63,7 @@ const DevToolsWindowV2: React.FC<
 	}
 > = (props) => {
 	const { projectId } = useProjectId()
+	const { logCursor } = useLinkLogCursor()
 	const { isPlayerFullscreen } = usePlayerUIContext()
 	const { time, session } = useReplayerContext()
 	const { selectedDevToolsTab, setSelectedDevToolsTab } =
@@ -212,6 +214,7 @@ const DevToolsWindowV2: React.FC<
 								page: (
 									<ConsolePage
 										autoScroll={autoScroll}
+										logCursor={logCursor}
 										levels={levels}
 										sources={sources}
 										filter={filter}
@@ -402,6 +405,7 @@ const DevToolsWindowV2: React.FC<
 												levels,
 												sources,
 											})}
+											target="_blank"
 											style={{ display: 'flex' }}
 										>
 											<Button

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -508,7 +508,7 @@ const ResourceRow = ({
 					shape="basic"
 					emphasis="low"
 					kind="secondary"
-					size="medium"
+					iconRight={<IconSolidArrowCircleRight />}
 					onClick={(event) => {
 						setTime(resource.startTime)
 						event.stopPropagation() /* Prevents opening of right panel by parent row's onClick handler */
@@ -516,7 +516,7 @@ const ResourceRow = ({
 						setActiveNetworkResource(resource)
 					}}
 				>
-					<IconSolidArrowCircleRight />
+					Go to
 				</Tag>
 			</Box>
 		</Box>

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -508,7 +508,7 @@ const ResourceRow = ({
 					shape="basic"
 					emphasis="low"
 					kind="secondary"
-					iconRight={<IconSolidArrowCircleRight />}
+					size="medium"
 					onClick={(event) => {
 						setTime(resource.startTime)
 						event.stopPropagation() /* Prevents opening of right panel by parent row's onClick handler */
@@ -516,7 +516,7 @@ const ResourceRow = ({
 						setActiveNetworkResource(resource)
 					}}
 				>
-					Go to
+					<IconSolidArrowCircleRight />
 				</Tag>
 			</Box>
 		</Box>

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -102,7 +102,7 @@ export const getHighlightRequestId = (resource?: NetworkResource) => {
 
 export enum Tab {
 	Errors = 'Errors',
-	Console = 'Console',
+	Console = 'Console Logs',
 	Network = 'Network',
 	Events = 'Events',
 }
@@ -110,7 +110,6 @@ export enum Tab {
 export enum LogLevel {
 	All = 'All',
 	Info = 'Info',
-	Log = 'Log',
 	Warn = 'Warn',
 	Error = 'Error',
 }
@@ -118,7 +117,6 @@ export enum LogLevel {
 export const LogLevelVariants = {
 	[LogLevel.All]: 'white',
 	[LogLevel.Info]: 'white',
-	[LogLevel.Log]: 'blue',
 	[LogLevel.Warn]: 'yellow',
 	[LogLevel.Error]: 'red',
 } as const

--- a/frontend/src/util/preload.ts
+++ b/frontend/src/util/preload.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { DEFAULT_PAGE_SIZE } from '@components/Pagination/Pagination'
 import { BackendSearchQuery } from '@context/BaseSearchContext'
 import {
@@ -213,10 +212,6 @@ export const loadSession = async function (secureID: string) {
 		if (!sess) return
 		if (sess.resources_url) {
 			for await (const _ of indexedDBFetch(sess.resources_url)) {
-			}
-		}
-		if (sess.messages_url) {
-			for await (const _ of indexedDBFetch(sess.messages_url)) {
 			}
 		}
 		if (sess.direct_download_url) {

--- a/packages/ui/src/components/MenuButton/MenuButton.tsx
+++ b/packages/ui/src/components/MenuButton/MenuButton.tsx
@@ -14,12 +14,15 @@ type Props = styles.Variants & {
 		render: React.ReactNode
 		variants?: Variants
 	}[]
+	selectedKey?: string
 	onChange: (value: string) => void
 	divider?: boolean
 }
 
 export const MenuButton: React.FC<Props> = ({ ...props }) => {
-	const [selected, setSelected] = React.useState<string>(props.options[0].key)
+	const [selected, setSelected] = React.useState<string>(
+		props.selectedKey ?? props.options[0].key,
+	)
 	return (
 		<Menu>
 			<Menu.Button

--- a/packages/ui/src/css/theme.css.ts
+++ b/packages/ui/src/css/theme.css.ts
@@ -28,7 +28,7 @@ export const themeVars = createGlobalTheme('.highlight-light-theme', {
 				informative: '#6346af',
 			},
 		},
-		divider: { strong: '#c8c7cb', default: '#dcdbdd', weak: '#e4e2e4' },
+		divider: { strong: '#c8c7cb', default: '#dcdbdd', weak: '#ebe9eb' },
 	},
 	interactive: {
 		fill: {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR's main purpose is to change the session logs source from S3 to Clickhouse (dedicated backend endpoint added in #4883). Additionally, we now have the ability to see Backend logs in the session logs viewer.

We are also making several UX change. See [figma](https://www.figma.com/file/rdBPNzn7Klk6RG1LHUCE5B/Screen-Designs?node-id=4451-205639&t=dnCWY9epGQJQ8INj-11) but also below for a detailed before/after.

Fixes #4779

**Note: we don't have a component for multi-select (#4816) so the filters use the existing menu button component which only permits single select**

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

### Adjust log level filter

Adjust the level filter to remove all colors and use the normalized log levels from clickhouse:
https://github.com/highlight/highlight/blob/83da5535aa0bca9239bd316a91c2f402e4f3f824/backend/private-graph/graph/schema.graphqls#L296-L303

Before

![Screenshot 2023-04-10 at 2 58 50 PM](https://user-images.githubusercontent.com/58678/230997689-d05acfa7-98fb-498d-a4fc-68215347b653.png)

After:

![Screenshot 2023-04-10 at 2 59 02 PM](https://user-images.githubusercontent.com/58678/230997714-dd7ba8b1-8027-4f86-a588-6e54fe6500af.png)

### Add explicit level to the log line

Instead of a vertical bar to indiciate the log level, we have the explicit name of the level on the line. This uses the same colors as the log viewer.

Before:

![Screenshot 2023-04-10 at 3 04 11 PM](https://user-images.githubusercontent.com/58678/230998536-8b7d0f7a-6bd8-416b-8e8c-ed0ef079959a.png)


After:
![Screenshot 2023-04-10 at 3 02 04 PM](https://user-images.githubusercontent.com/58678/230998383-e3c0999e-ca4b-4264-9b33-b66cf613b1a7.png)





### Add source filter

Adds a source filter to distiguish between Frontend and Backend logs. This should default to Frontend

![Screenshot 2023-04-10 at 3 00 01 PM](https://user-images.githubusercontent.com/58678/230997975-433dbb7c-128e-4a33-93a3-530e9045bbfa.png)

### Add Go to button

Instead of clicking the whole log to select the log (and move the session player), we now have an explicit button:


![Screenshot 2023-04-10 at 3 00 51 PM](https://user-images.githubusercontent.com/58678/230998115-26b237b7-055a-41d6-ae08-60df63303b40.png)

Fixes #4871


### Other things

* Rename the "Console" tab to "Console Logs"
* Rename "Related logs" button to "Show in Log Viewer"
  * Clicking this button should persist the `level`, `source`, and `secure_session_id` filters.
* Clicking "Related Session" in the main logs view will select the log line in the session logs and set the player to that time.
* Disabling preloading. This seems to load decently fast and we don't need to prefetch this data.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
