### PR TITLE
Set up WebSocketListener to intercept WebSocket events

### DIFF
--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -270,10 +270,6 @@ export class FirstLoadListeners {
 				// Prior to this, it may be best to refactor the existing logic
 				// above to be less tied to PerformanceResourceTiming, since we
 				// only care about a subset of fields.
-				console.log(
-					'Intercepted WebSocket events',
-					sThis.wsNetworkContents,
-				)
 			}
 		}
 		return resources

--- a/sdk/client/src/listeners/network-listener/network-listener.ts
+++ b/sdk/client/src/listeners/network-listener/network-listener.ts
@@ -1,16 +1,20 @@
 import { NetworkRecordingOptions } from '../../types/client'
 import { FetchListener } from './utils/fetch-listener'
-import { RequestResponsePair } from './utils/models'
+import { RequestResponsePair, WebSocketEvent } from './utils/models'
 import { sanitizeRequest, sanitizeResponse } from './utils/network-sanitizer'
+import { WebSocketListener } from './utils/ws-listener'
 import { XHRListener } from './utils/xhr-listener'
 
 export type NetworkListenerCallback = (
 	requestResponsePair: RequestResponsePair,
 ) => void
 
+export type WebSocketListenerCallback = (event: WebSocketEvent) => void
+
 type NetworkListenerArguments = {
 	xhrCallback: NetworkListenerCallback
 	fetchCallback: NetworkListenerCallback
+	wsCallback: WebSocketListenerCallback
 	headersToRedact: string[]
 	backendUrl: string
 	tracingOrigins: boolean | (string | RegExp)[]
@@ -21,6 +25,7 @@ type NetworkListenerArguments = {
 export const NetworkListener = ({
 	xhrCallback,
 	fetchCallback,
+	wsCallback,
 	headersToRedact,
 	backendUrl,
 	tracingOrigins,
@@ -61,10 +66,14 @@ export const NetworkListener = ({
 		sessionSecureID,
 		bodyKeysToRecord,
 	)
+	const removeWebSocketListener = WebSocketListener((event) => {
+		wsCallback(event)
+	})
 
 	return () => {
 		removeXHRListener()
 		removeFetchListener()
+		removeWebSocketListener()
 	}
 }
 

--- a/sdk/client/src/listeners/network-listener/utils/models.ts
+++ b/sdk/client/src/listeners/network-listener/utils/models.ts
@@ -24,3 +24,15 @@ export interface RequestResponsePair {
 	/** Whether this URL matched a `urlToBlock` so the contents should not be recorded. */
 	urlBlocked: boolean
 }
+
+export interface WebSocketEvent {
+	socketId: string
+	type: 'create' | 'error' | 'open' | 'close' | 'sent' | 'received'
+	size: number
+	/**
+	 * Only set if the data is a string (i.e. not Blob or ByteBuffer).
+	 *
+	 * In the case of an "create" event, this will be the URL.
+	 */
+	strData?: string
+}

--- a/sdk/client/src/listeners/network-listener/utils/ws-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/ws-listener.ts
@@ -1,0 +1,101 @@
+import { WebSocketListenerCallback } from '../network-listener'
+import { createNetworkRequestId } from './utils'
+
+export const WebSocketListener = (callback: WebSocketListenerCallback) => {
+	var originalWebSocket = window.WebSocket
+
+	function WebSocket(
+		this: WebSocket,
+		...args: [url: string, protocols?: string | string[]]
+	) {
+		const socketId = createNetworkRequestId()
+		if (!(this instanceof WebSocket)) {
+			// The browser will likely throw an error.
+			originalWebSocket.apply(this, args)
+			// If not, we do.
+			throw new Error('WebSocket must be called with new')
+		}
+		const ws = new originalWebSocket(...args)
+		callback({
+			socketId,
+			type: 'create',
+			size: 0,
+			strData: args[0],
+		})
+		ws.addEventListener('error', (event) => {
+			callback({
+				socketId,
+				type: 'error',
+				size: 0,
+			})
+		})
+		ws.addEventListener('open', (event) => {
+			callback({
+				socketId,
+				type: 'open',
+				size: 0,
+			})
+		})
+		ws.addEventListener('close', (event) => {
+			callback({
+				socketId,
+				type: 'close',
+				size: 0,
+			})
+		})
+		ws.addEventListener('message', (event) => {
+			let size: number
+			let strData =
+				typeof event.data === 'string' ? event.data : undefined
+			if (typeof event.data === 'string') {
+				// TODO: Consider passing the UTF-8 byte length instead.
+				size = event.data.length
+			} else {
+				size = event.data.byteLength || 0
+			}
+			callback({
+				socketId,
+				type: 'received',
+				size,
+				strData,
+			})
+		})
+		const originalSend = ws.send.bind(ws)
+		ws.send = (data) => {
+			let size: number
+			let strData = typeof data === 'string' ? data : undefined
+			if (typeof data === 'string') {
+				// TODO: Consider passing the UTF-8 byte length instead.
+				size = data.length
+			} else {
+				if (data instanceof Blob) {
+					size = data.size
+				} else {
+					size = data.byteLength
+				}
+			}
+			callback({
+				socketId,
+				type: 'sent',
+				size,
+				strData,
+			})
+			return originalSend(data)
+		}
+
+		return ws
+	}
+	WebSocket.CONNECTING = originalWebSocket.CONNECTING
+	WebSocket.OPEN = originalWebSocket.OPEN
+	WebSocket.CLOSING = originalWebSocket.CLOSING
+	WebSocket.CLOSED = originalWebSocket.CLOSED
+	WebSocket.prototype = originalWebSocket.prototype
+	WebSocket.prototype.constructor = WebSocket
+
+	// @ts-ignore
+	window.WebSocket = WebSocket
+
+	return () => {
+		window.WebSocket = originalWebSocket
+	}
+}


### PR DESCRIPTION
## Summary

This is a draft implementation of client-side recording of WebSocket events (#4403). It only implements the client-side interception and doesn't yet send events through.

Prior to this, it may be a good idea to improve type safety for the existing handling of `resources` so that we can integrate WebSocket events to that list in a safe manner. In particular, I suspect the current code may sometimes return objects that are missing `requestResponsePairs`, when a PerformanceResourceTiming isn't associated with a RequestResponsePair (e.g. for requests occurring before the Highlight client has finished loading). This would fail silently on the backend because [we just `return nil`](https://github.com/highlight/highlight/blob/fcb6dac185830b441f740733977395ccddf6fe5f/backend/public-graph/graph/resolver.go#L2810). Or perhaps Unmarshal defaults to an empty object when a field is missing?

Edit: re-reading the code, yes an empty object is expected. I wonder if a pointer would be good for RequestResponsePair so it would be null instead of empty when unmarshalled?

## How did you test this change?

I haven't had time to write tests yet, but I manually tested by establishing a WebSocket connection to a local server and checking that events were intercepted correctly (including a failed connection).

## Are there any deployment considerations?

No.