### PR TITLE
pin lambda-action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,5 @@
 name: Deploy to AWS
 on:
-    pull_request:
-        types: [opened, synchronize]
     push:
         branches:
             - 'main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
                   aws lambda update-function-configuration --function-name sendEmail \
                     --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
             - name: Deploy getSessionIdsByQuery
-              uses: appleboy/lambda-action@master
+              uses: appleboy/lambda-action@v0.1.9
               with:
                   aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -80,7 +80,7 @@ jobs:
                   function_name: getSessionIdsByQuery
                   zip_file: backend/getSessionIdsByQuery.zip
             - name: Deploy deleteSessionBatchFromPostgres
-              uses: appleboy/lambda-action@master
+              uses: appleboy/lambda-action@v0.1.9
               with:
                   aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -88,7 +88,7 @@ jobs:
                   function_name: deleteSessionBatchFromPostgres
                   zip_file: backend/deleteSessionBatchFromPostgres.zip
             - name: Deploy deleteSessionBatchFromOpenSearch
-              uses: appleboy/lambda-action@master
+              uses: appleboy/lambda-action@v0.1.9
               with:
                   aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -96,7 +96,7 @@ jobs:
                   function_name: deleteSessionBatchFromOpenSearch
                   zip_file: backend/deleteSessionBatchFromOpenSearch.zip
             - name: Deploy deleteSessionBatchFromS3
-              uses: appleboy/lambda-action@master
+              uses: appleboy/lambda-action@v0.1.9
               with:
                   aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -104,7 +104,7 @@ jobs:
                   function_name: deleteSessionBatchFromS3
                   zip_file: backend/deleteSessionBatchFromS3.zip
             - name: Deploy sendEmail
-              uses: appleboy/lambda-action@master
+              uses: appleboy/lambda-action@v0.1.9
               with:
                   aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -150,7 +150,7 @@ jobs:
                   aws lambda update-function-configuration --function-name sendDigestEmails \
                     --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
             - name: Deploy getProjectIds
-              uses: appleboy/lambda-action@master
+              uses: appleboy/lambda-action@v0.1.9
               with:
                   aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -158,7 +158,7 @@ jobs:
                   function_name: getProjectIds
                   zip_file: backend/getProjectIds.zip
             - name: Deploy getDigestData
-              uses: appleboy/lambda-action@master
+              uses: appleboy/lambda-action@v0.1.9
               with:
                   aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -166,7 +166,7 @@ jobs:
                   function_name: getDigestData
                   zip_file: backend/getDigestData.zip
             - name: Deploy sendDigestEmails
-              uses: appleboy/lambda-action@master
+              uses: appleboy/lambda-action@v0.1.9
               with:
                   aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,7 @@
 name: Deploy to AWS
 on:
+    pull_request:
+        types: [opened, synchronize]
     push:
         branches:
             - 'main'


### PR DESCRIPTION
## Summary

Pin the github action version to make sure we do not pick up breaking changes, such as the AWS policy requirements.

## How did you test this change?

CI, running this in non-main deploy: https://github.com/highlight/highlight/actions/runs/4615047524/jobs/8158572791

## Are there any deployment considerations?

No
