### PR TITLE
use graphql enum for identifying log source

### DIFF
--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -74,10 +74,6 @@ func (l *LogRow) Cursor() string {
 	return encodeCursor(l.Timestamp, l.UUID)
 }
 
-func (l *LogRow) IsBackend() bool {
-	return l.Source == modelInputs.LogSourceBackend.String()
-}
-
 type LogRowOption func(*LogRow)
 
 func WithTimestamp(ts time.Time) LogRowOption {
@@ -102,13 +98,9 @@ func WithSeverityText(severityText string) LogRowOption {
 	}
 }
 
-func WithSource(sourceAttribute string) LogRowOption {
+func WithSource(source modelInputs.LogSource) LogRowOption {
 	return func(l *LogRow) {
-		if sourceAttribute == highlight.SourceAttributeFrontend {
-			l.Source = modelInputs.LogSourceFrontend.String()
-		} else {
-			l.Source = modelInputs.LogSourceBackend.String()
-		}
+		l.Source = source.String()
 	}
 }
 

--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -102,9 +102,9 @@ func WithSeverityText(severityText string) LogRowOption {
 	}
 }
 
-func WithSource(source string) LogRowOption {
+func WithSource(sourceAttribute string) LogRowOption {
 	return func(l *LogRow) {
-		if source == highlight.SourceAttributeFrontend {
+		if sourceAttribute == highlight.SourceAttributeFrontend {
 			l.Source = modelInputs.LogSourceFrontend.String()
 		} else {
 			l.Source = modelInputs.LogSourceBackend.String()

--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -44,7 +44,7 @@ type LogRow struct {
 	TraceFlags     uint32
 	SeverityText   string
 	SeverityNumber int32
-	Source         string
+	Source         modelInputs.LogSource
 	ServiceName    string
 	Body           string
 	LogAttributes  map[string]string
@@ -100,7 +100,7 @@ func WithSeverityText(severityText string) LogRowOption {
 
 func WithSource(source modelInputs.LogSource) LogRowOption {
 	return func(l *LogRow) {
-		l.Source = source.String()
+		l.Source = source
 	}
 }
 

--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -68,10 +68,10 @@ func TestNewLogRowWithLongBody(t *testing.T) {
 
 func TestNewLogRowWithSource(t *testing.T) {
 	lr := NewLogRow(LogRowPrimaryAttrs{}, WithSource(modelInputs.LogSourceFrontend))
-	assert.Equal(t, modelInputs.LogSourceFrontend.String(), lr.Source)
+	assert.Equal(t, modelInputs.LogSourceFrontend, lr.Source)
 
-	lr = NewLogRow(LogRowPrimaryAttrs{}, WithSource("InterceptField"))
-	assert.Equal(t, modelInputs.LogSourceBackend.String(), lr.Source)
+	lr = NewLogRow(LogRowPrimaryAttrs{}, WithSource(modelInputs.LogSourceBackend))
+	assert.Equal(t, modelInputs.LogSourceBackend, lr.Source)
 }
 
 func TestNewLogRowWithTimestamp(t *testing.T) {

--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
-	"github.com/highlight/highlight/sdk/highlight-go"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -68,19 +67,11 @@ func TestNewLogRowWithLongBody(t *testing.T) {
 }
 
 func TestNewLogRowWithSource(t *testing.T) {
-	lr := NewLogRow(LogRowPrimaryAttrs{}, WithSource(highlight.SourceAttributeFrontend))
+	lr := NewLogRow(LogRowPrimaryAttrs{}, WithSource(modelInputs.LogSourceFrontend))
 	assert.Equal(t, modelInputs.LogSourceFrontend.String(), lr.Source)
 
 	lr = NewLogRow(LogRowPrimaryAttrs{}, WithSource("InterceptField"))
 	assert.Equal(t, modelInputs.LogSourceBackend.String(), lr.Source)
-}
-
-func TestIsBackend(t *testing.T) {
-	lr := NewLogRow(LogRowPrimaryAttrs{}, WithSource(highlight.SourceAttributeFrontend))
-	assert.False(t, lr.IsBackend())
-
-	lr = NewLogRow(LogRowPrimaryAttrs{}, WithSource("InterceptField"))
-	assert.True(t, lr.IsBackend())
 }
 
 func TestNewLogRowWithTimestamp(t *testing.T) {

--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -2,9 +2,11 @@ package clickhouse
 
 import (
 	"context"
-	"github.com/highlight/highlight/sdk/highlight-go"
 	"testing"
 	"time"
+
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/highlight/highlight/sdk/highlight-go"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -67,11 +69,18 @@ func TestNewLogRowWithLongBody(t *testing.T) {
 
 func TestNewLogRowWithSource(t *testing.T) {
 	lr := NewLogRow(LogRowPrimaryAttrs{}, WithSource(highlight.SourceAttributeFrontend))
-	assert.Equal(t, LogRowSourceValueFrontend, lr.Source)
-	assert.Equal(t, "frontend", LogRowSourceValueFrontend)
+	assert.Equal(t, modelInputs.LogSourceFrontend.String(), lr.Source)
+
 	lr = NewLogRow(LogRowPrimaryAttrs{}, WithSource("InterceptField"))
-	assert.Equal(t, LogRowSourceValueBackend, lr.Source)
-	assert.Equal(t, "backend", LogRowSourceValueBackend)
+	assert.Equal(t, modelInputs.LogSourceBackend.String(), lr.Source)
+}
+
+func TestIsBackend(t *testing.T) {
+	lr := NewLogRow(LogRowPrimaryAttrs{}, WithSource(highlight.SourceAttributeFrontend))
+	assert.False(t, lr.IsBackend())
+
+	lr = NewLogRow(LogRowPrimaryAttrs{}, WithSource("InterceptField"))
+	assert.True(t, lr.IsBackend())
 }
 
 func TestNewLogRowWithTimestamp(t *testing.T) {

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -395,7 +395,7 @@ func (o *Handler) submitProjectLogs(ctx context.Context, projectLogs map[string]
 	for projectID, logRows := range projectLogs {
 		var hasBackendLogs bool
 		for _, logRow := range logRows {
-			if logRow.Source == modelInputs.LogSourceBackend.String() {
+			if logRow.Source == modelInputs.LogSourceBackend
 				hasBackendLogs = true
 				break
 			}

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -5,16 +5,18 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 	"io"
 	"net/http"
 	"time"
+
+	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 
 	"github.com/go-chi/chi"
 	"github.com/google/uuid"
 	"github.com/highlight-run/highlight/backend/clickhouse"
 	kafkaqueue "github.com/highlight-run/highlight/backend/kafka-queue"
 	model2 "github.com/highlight-run/highlight/backend/model"
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/public-graph/graph"
 	"github.com/highlight-run/highlight/backend/public-graph/graph/model"
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -39,26 +41,22 @@ func cast[T string | int64 | float64](v interface{}, fallback T) T {
 	return c
 }
 
-func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestID, source *string) {
+func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestID *string, source *modelInputs.LogSource) {
 	ptrs := map[string]*string{
 		highlight.DeprecatedProjectIDAttribute: projectID,
 		highlight.DeprecatedSessionIDAttribute: sessionID,
 		highlight.DeprecatedRequestIDAttribute: requestID,
-		highlight.DeprecatedSourceAttribute:    source,
 		highlight.ProjectIDAttribute:           projectID,
 		highlight.SessionIDAttribute:           sessionID,
 		highlight.RequestIDAttribute:           requestID,
-		highlight.SourceAttribute:              source,
 	}
 	for _, k := range []string{
 		highlight.DeprecatedProjectIDAttribute,
 		highlight.DeprecatedSessionIDAttribute,
 		highlight.DeprecatedRequestIDAttribute,
-		highlight.DeprecatedSourceAttribute,
 		highlight.ProjectIDAttribute,
 		highlight.SessionIDAttribute,
 		highlight.RequestIDAttribute,
-		highlight.SourceAttribute,
 	} {
 		if p, ok := attrs[k]; ok {
 			if v, _ := p.(string); v != "" {
@@ -66,9 +64,24 @@ func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestI
 			}
 		}
 	}
+
+	for _, k := range []string{
+		highlight.DeprecatedSourceAttribute,
+		highlight.SourceAttribute,
+	} {
+		if p, ok := attrs[k]; ok {
+			if v, _ := p.(string); v != "" {
+				if v == modelInputs.LogSourceFrontend.String() {
+					*source = modelInputs.LogSourceFrontend
+				} else {
+					*source = modelInputs.LogSourceBackend
+				}
+			}
+		}
+	}
 }
 
-func getLogRow(ctx context.Context, ts time.Time, lvl, projectID, sessionID, traceID, spanID string, excMessage string, resourceAttributes, spanAttributes, eventAttributes map[string]any, source string) *clickhouse.LogRow {
+func getLogRow(ctx context.Context, ts time.Time, lvl, projectID, sessionID, traceID, spanID string, excMessage string, resourceAttributes, spanAttributes, eventAttributes map[string]any, source modelInputs.LogSource) *clickhouse.LogRow {
 	return clickhouse.NewLogRow(
 		clickhouse.LogRowPrimaryAttrs{
 			TraceId:         traceID,
@@ -77,7 +90,7 @@ func getLogRow(ctx context.Context, ts time.Time, lvl, projectID, sessionID, tra
 		},
 		clickhouse.WithTimestamp(ts),
 		clickhouse.WithBody(ctx, excMessage),
-		clickhouse.WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, source == highlight.SourceAttributeFrontend),
+		clickhouse.WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, source == modelInputs.LogSourceFrontend),
 		clickhouse.WithProjectIDString(projectID),
 		clickhouse.WithServiceName(cast(resourceAttributes[string(semconv.ServiceNameKey)], "")),
 		clickhouse.WithSeverityText(lvl),
@@ -85,9 +98,9 @@ func getLogRow(ctx context.Context, ts time.Time, lvl, projectID, sessionID, tra
 	)
 }
 
-func getBackendError(ctx context.Context, ts time.Time, projectID, sessionID, requestID, traceID, spanID string, logCursor *string, source, excMessage string, resourceAttributes, spanAttributes, eventAttributes map[string]any) (bool, *model.BackendErrorObjectInput) {
-	excType := cast(eventAttributes[string(semconv.ExceptionTypeKey)], source)
-	errorUrl := cast(eventAttributes[highlight.ErrorURLAttribute], source)
+func getBackendError(ctx context.Context, ts time.Time, projectID, sessionID, requestID, traceID, spanID string, logCursor *string, excMessage string, source modelInputs.LogSource, resourceAttributes, spanAttributes, eventAttributes map[string]any) (bool, *model.BackendErrorObjectInput) {
+	excType := cast(eventAttributes[string(semconv.ExceptionTypeKey)], source.String())
+	errorUrl := cast(eventAttributes[highlight.ErrorURLAttribute], source.String())
 	stackTrace := cast(eventAttributes[string(semconv.ExceptionStacktraceKey)], "")
 	if excType == "" && excMessage == "" {
 		log.WithContext(ctx).WithField("EventAttributes", eventAttributes).Error("otel received exception with no type and no message")
@@ -159,7 +172,8 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 
 	spans := req.Traces().ResourceSpans()
 	for i := 0; i < spans.Len(); i++ {
-		var projectID, sessionID, requestID, source string
+		var projectID, sessionID, requestID string
+		var source modelInputs.LogSource
 		resource := spans.At(i).Resource()
 		resourceAttributes := resource.Attributes().AsRaw()
 		setHighlightAttributes(resourceAttributes, &projectID, &sessionID, &requestID, &source)
@@ -186,7 +200,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						projectLogs[projectID] = append(projectLogs[projectID], logRow)
 						logCursor = pointy.String(logRow.Cursor())
 
-						isProjectError, backendError := getBackendError(ctx, ts, projectID, sessionID, requestID, traceID, spanID, logCursor, source, excMessage, resourceAttributes, spanAttributes, eventAttributes)
+						isProjectError, backendError := getBackendError(ctx, ts, projectID, sessionID, requestID, traceID, spanID, logCursor, excMessage, source, resourceAttributes, spanAttributes, eventAttributes)
 						if backendError == nil {
 							log.WithContext(ctx).WithField("BackendErrorEvent", event).Errorf("otel span error got no session and no project")
 						} else {
@@ -221,7 +235,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	for sessionID, errors := range traceErrors {
 		var backendError = false
 		for _, err := range errors {
-			if err.Type != highlight.SourceAttributeFrontend {
+			if err.Type == modelInputs.LogSourceBackend.String() {
 				backendError = true
 			}
 		}
@@ -256,7 +270,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	for projectID, errors := range projectErrors {
 		var backendError = false
 		for _, err := range errors {
-			if err.Type != highlight.SourceAttributeFrontend {
+			if err.Type == modelInputs.LogSourceBackend.String() {
 				backendError = true
 			}
 		}
@@ -334,7 +348,8 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 
 	resourceLogs := req.Logs().ResourceLogs()
 	for i := 0; i < resourceLogs.Len(); i++ {
-		var projectID, sessionID, requestID, source string
+		var projectID, sessionID, requestID string
+		var source modelInputs.LogSource
 		resource := resourceLogs.At(i).Resource()
 		resourceAttributes := resource.Attributes().AsRaw()
 		setHighlightAttributes(resourceAttributes, &projectID, &sessionID, &requestID, &source)
@@ -380,7 +395,7 @@ func (o *Handler) submitProjectLogs(ctx context.Context, projectLogs map[string]
 	for projectID, logRows := range projectLogs {
 		var hasBackendLogs bool
 		for _, logRow := range logRows {
-			if logRow.IsBackend() {
+			if logRow.Source == modelInputs.LogSourceBackend.String() {
 				hasBackendLogs = true
 				break
 			}

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -395,7 +395,7 @@ func (o *Handler) submitProjectLogs(ctx context.Context, projectLogs map[string]
 	for projectID, logRows := range projectLogs {
 		var hasBackendLogs bool
 		for _, logRow := range logRows {
-			if logRow.Source == modelInputs.LogSourceBackend
+			if logRow.Source == modelInputs.LogSourceBackend {
 				hasBackendLogs = true
 				break
 			}

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -8447,6 +8447,11 @@ enum ReservedLogKey {
 	service_name
 }
 
+enum LogSource {
+	frontend
+	backend
+}
+
 enum LogKeyType {
 	String
 }

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -950,6 +950,47 @@ func (e LogLevel) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+type LogSource string
+
+const (
+	LogSourceFrontend LogSource = "frontend"
+	LogSourceBackend  LogSource = "backend"
+)
+
+var AllLogSource = []LogSource{
+	LogSourceFrontend,
+	LogSourceBackend,
+}
+
+func (e LogSource) IsValid() bool {
+	switch e {
+	case LogSourceFrontend, LogSourceBackend:
+		return true
+	}
+	return false
+}
+
+func (e LogSource) String() string {
+	return string(e)
+}
+
+func (e *LogSource) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = LogSource(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid LogSource", str)
+	}
+	return nil
+}
+
+func (e LogSource) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 type MetricAggregator string
 
 const (

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -550,6 +550,11 @@ enum ReservedLogKey {
 	service_name
 }
 
+enum LogSource {
+	frontend
+	backend
+}
+
 enum LogKeyType {
 	String
 }

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -711,6 +711,11 @@ export enum LogLevel {
 	Warn = 'warn',
 }
 
+export enum LogSource {
+	Backend = 'backend',
+	Frontend = 'frontend',
+}
+
 export type LogsConnection = {
 	__typename?: 'LogsConnection'
 	edges: Array<LogEdge>

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -3,14 +3,16 @@ package hlog
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
-	"strconv"
-	"strings"
-	"time"
 )
 
 type VercelProxy struct {
@@ -61,7 +63,7 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 	for _, row := range logRows {
 		span, _ := highlight.StartTrace(
 			ctx, "highlight-ctx",
-			attribute.String(highlight.SourceAttribute, highlight.SourceAttributeFrontend),
+			attribute.String(highlight.SourceAttribute, modelInputs.LogSourceFrontend.String()),
 			attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
 			attribute.String(highlight.SessionIDAttribute, sessionSecureID),
 		)

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -21,7 +21,6 @@ import (
 const OTLPDefaultEndpoint = "https://otel.highlight.io:4318"
 
 const ErrorURLAttribute = "URL"
-const SourceAttributeFrontend = "SubmitFrontendConsoleMessages"
 
 const DeprecatedProjectIDAttribute = "highlight_project_id"
 const DeprecatedSessionIDAttribute = "highlight_session_id"


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

In preparation for #4779, we need a GraphQL enum to identify the log source (because Go types aren't usable on the frontend without a of work).

Additionally, this PR fixes a bug with the `IsBackend` function that wasn't correctly identifying backend logs correctly.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Tests added
* Code should compile

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A