### PR TITLE
only autoset selected console message if the player is actually playing

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -3,6 +3,7 @@ import { useGetMessagesQuery } from '@graph/hooks'
 import { ConsoleMessage } from '@highlight-run/client'
 import { playerMetaData } from '@highlight-run/rrweb-types'
 import { Box, Text } from '@highlight-run/ui'
+import { ReplayerState } from '@pages/Player/ReplayerContext'
 import { EmptyDevToolsCallout } from '@pages/Player/Toolbar/DevToolsWindowV2/EmptyDevToolsCallout/EmptyDevToolsCallout'
 import { LogLevel, Tab } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import { indexedDBFetch } from '@util/db'
@@ -34,7 +35,7 @@ export const ConsolePage = ({
 	time: number
 }) => {
 	const [currentMessage, setCurrentMessage] = useState(-1)
-	const { session, setTime, sessionMetadata, isPlayerReady } =
+	const { session, setTime, sessionMetadata, isPlayerReady, state } =
 		useReplayerContext()
 	const [parsedMessages, setParsedMessages] = useState<
 		undefined | Array<ParsedMessage>
@@ -111,6 +112,9 @@ export const ConsolePage = ({
 
 	// Logic for scrolling to current entry.
 	useEffect(() => {
+		if (state !== ReplayerState.Playing) {
+			return
+		}
 		if (parsedMessages?.length) {
 			let msgIndex = 0
 			let msgDiff: number = Number.MAX_VALUE
@@ -125,7 +129,7 @@ export const ConsolePage = ({
 			}
 			setCurrentMessage(msgIndex)
 		}
-	}, [time, parsedMessages])
+	}, [state, time, parsedMessages])
 
 	const messagesToRender = useMemo(() => {
 		const currentMessages = parsedMessages?.filter((m) => {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

The logic to autoscroll console messages uses a "guess" based off the session's current time. This is fine for when the player is actually playing but it doesn't make sense to use this guessing when the player is paused as it can guess the wrong thing (see #4843).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Pause the player
* Click a console message
* Observe that the selection is what the user chose.

![Kapture 2023-04-05 at 12 54 08](https://user-images.githubusercontent.com/58678/230178619-8032ff0f-6bc4-4513-89a9-e5699473e0cc.gif)

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
