### PR TITLE
replace nestjs error filter with an interceptor

### DIFF
--- a/e2e/nestjs/src/main.ts
+++ b/e2e/nestjs/src/main.ts
@@ -1,6 +1,6 @@
-import { HttpAdapterHost, NestFactory } from '@nestjs/core'
+import { NestFactory } from '@nestjs/core'
 import { AppModule } from './app.module'
-import { HighlightLogger, HighlightErrorFilter } from '@highlight-run/nest'
+import { HighlightLogger, HighlightInterceptor } from '@highlight-run/nest'
 
 async function bootstrap() {
 	const app = await NestFactory.create(AppModule)
@@ -9,9 +9,7 @@ async function bootstrap() {
 		otlpEndpoint: 'http://localhost:4318',
 	}
 	app.useLogger(new HighlightLogger(highlightOpts))
-	app.useGlobalFilters(
-		new HighlightErrorFilter(app.get(HttpAdapterHost), highlightOpts),
-	)
+	app.useGlobalInterceptors(new HighlightInterceptor(highlightOpts))
 	await app.listen(3002)
 }
 bootstrap()

--- a/highlight.io/components/QuickstartContent/backend/js/nestjs.tsx
+++ b/highlight.io/components/QuickstartContent/backend/js/nestjs.tsx
@@ -17,14 +17,12 @@ export const JSNestContent: QuickStartContent = {
 			code: {
 				text: `import { HttpAdapterHost, NestFactory } from '@nestjs/core'
 import { AppModule } from './app.module'
-import { HighlightErrorFilter } from '@highlight-run/nest'
+import { HighlightInterceptor } from '@highlight-run/nest'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
   const highlightOpts = { projectID: 'YOUR_PROJECT_ID' }
-  app.useGlobalFilters(
-    new HighlightErrorFilter(app.get(HttpAdapterHost), highlightOpts),
-  )
+  app.useGlobalInterceptors(new HighlightInterceptor(highlightOpts))
   await app.listen(3000)
 }
 bootstrap()

--- a/sdk/highlight-nest/CHANGELOG.md
+++ b/sdk/highlight-nest/CHANGELOG.md
@@ -5,3 +5,9 @@
 ### Initial Release
 
 - Adds a new @highlight-run/nest sdk for error monitoring and log ingestion in nestjs
+
+## 0.4.0
+
+### Initial Release
+
+- Adds the `HighlightInterceptor` to be used for catching errors.

--- a/sdk/highlight-nest/package.json
+++ b/sdk/highlight-nest/package.json
@@ -19,7 +19,8 @@
 	"author": "",
 	"license": "MIT",
 	"peerDependencies": {
-		"@nestjs/core": ">=8"
+		"@nestjs/core": ">=8",
+		"rxjs": ">=7"
 	},
 	"dependencies": {
 		"@highlight-run/node": "workspace:*"
@@ -33,6 +34,7 @@
 		"class-validator": "^0.14.0",
 		"eslint": "^8.36.0",
 		"reflect-metadata": "^0.1.13",
+		"rxjs": "^7.8.0",
 		"tsup": "^6.6.3",
 		"typescript": "^4.9.5"
 	}

--- a/sdk/highlight-nest/package.json
+++ b/sdk/highlight-nest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/nest",
-	"version": "0.3.3",
+	"version": "0.4.0",
 	"description": "Client for interfacing with Highlight in nestjs",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-nest/src/index.ts
+++ b/sdk/highlight-nest/src/index.ts
@@ -85,14 +85,12 @@ export class HighlightInterceptor
 		@Inject(Symbol('HighlightModuleOptions'))
 		readonly opts: NodeOptions,
 	) {
-		console.log('vadim constructor')
 		if (!NodeH.isInitialized()) {
 			NodeH.init(opts)
 		}
 	}
 
 	async onApplicationShutdown(signal?: string) {
-		console.log('vadim shutdown')
 		await NodeH.flush()
 	}
 
@@ -101,7 +99,6 @@ export class HighlightInterceptor
 		const request = ctx.getRequest()
 		const highlightCtx = NodeH.parseHeaders(request.headers)
 
-		console.log('vadim intercept')
 		return next.handle().pipe(
 			catchError((err) => {
 				NodeH.consumeError(

--- a/sdk/highlight-nest/src/index.ts
+++ b/sdk/highlight-nest/src/index.ts
@@ -1,59 +1,16 @@
 import { H as NodeH, NodeOptions } from '@highlight-run/node'
+import type { OnApplicationShutdown } from '@nestjs/common'
 import {
+	BadGatewayException,
+	CallHandler,
 	ConsoleLogger,
-	Catch,
+	ExecutionContext,
 	Inject,
 	Injectable,
-	HttpException,
-	HttpStatus,
+	NestInterceptor,
 } from '@nestjs/common'
-import type {
-	ArgumentsHost,
-	ExceptionFilter,
-	HttpAdapterHost,
-	OnApplicationShutdown,
-} from '@nestjs/common'
-
-@Catch()
-export class HighlightErrorFilter
-	implements ExceptionFilter, OnApplicationShutdown
-{
-	constructor(
-		private readonly httpAdapterHost: HttpAdapterHost,
-		@Inject(Symbol('HighlightModuleOptions'))
-		readonly opts: NodeOptions,
-	) {
-		if (!NodeH.isInitialized()) {
-			NodeH.init(opts)
-		}
-	}
-
-	catch(exception: Error, host: ArgumentsHost): void {
-		const { httpAdapter } = this.httpAdapterHost
-
-		const ctx = host.switchToHttp()
-		const hCtx = NodeH.parseHeaders(ctx.getRequest().headers)
-
-		NodeH.consumeError(exception, hCtx?.secureSessionId, hCtx?.requestId)
-
-		const httpStatus =
-			exception instanceof HttpException
-				? exception.getStatus()
-				: HttpStatus.INTERNAL_SERVER_ERROR
-
-		const responseBody = {
-			statusCode: httpStatus,
-			timestamp: new Date().toISOString(),
-			path: httpAdapter.getRequestUrl(ctx.getRequest()),
-		}
-
-		httpAdapter.reply(ctx.getResponse(), responseBody, httpStatus)
-	}
-
-	async onApplicationShutdown(signal?: string) {
-		await NodeH.flush()
-	}
-}
+import { Observable, throwError } from 'rxjs'
+import { catchError } from 'rxjs/operators'
 
 @Injectable()
 export class HighlightLogger
@@ -120,15 +77,53 @@ export class HighlightLogger
 	}
 }
 
+@Injectable()
+export class HighlightInterceptor
+	implements NestInterceptor, OnApplicationShutdown
+{
+	constructor(
+		@Inject(Symbol('HighlightModuleOptions'))
+		readonly opts: NodeOptions,
+	) {
+		console.log('vadim constructor')
+		if (!NodeH.isInitialized()) {
+			NodeH.init(opts)
+		}
+	}
+
+	async onApplicationShutdown(signal?: string) {
+		console.log('vadim shutdown')
+		await NodeH.flush()
+	}
+
+	intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+		const ctx = context.switchToHttp()
+		const request = ctx.getRequest()
+		const highlightCtx = NodeH.parseHeaders(request.headers)
+
+		console.log('vadim intercept')
+		return next.handle().pipe(
+			catchError((err) => {
+				NodeH.consumeError(
+					err,
+					highlightCtx?.secureSessionId,
+					highlightCtx?.requestId,
+				)
+				return throwError(() => err)
+			}),
+		)
+	}
+}
+
 export class HighlightModule {
 	public static forRoot(options: NodeOptions) {
 		if (!NodeH.isInitialized()) {
 			NodeH.init(options)
 		}
 		return {
-			exports: [HighlightLogger, HighlightErrorFilter],
+			exports: [HighlightLogger, HighlightInterceptor],
 			module: HighlightModule,
-			providers: [HighlightLogger, HighlightErrorFilter],
+			providers: [HighlightLogger, HighlightInterceptor],
 		}
 	}
 	public static async forRootAsync(options: NodeOptions) {
@@ -136,9 +131,9 @@ export class HighlightModule {
 			NodeH.init(options)
 		}
 		return {
-			exports: [HighlightLogger, HighlightErrorFilter],
+			exports: [HighlightLogger, HighlightInterceptor],
 			module: HighlightModule,
-			providers: [HighlightLogger, HighlightErrorFilter],
+			providers: [HighlightLogger, HighlightInterceptor],
 		}
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11082,10 +11082,12 @@ __metadata:
     class-validator: ^0.14.0
     eslint: ^8.36.0
     reflect-metadata: ^0.1.13
+    rxjs: ^7.8.0
     tsup: ^6.6.3
     typescript: ^4.9.5
   peerDependencies:
     "@nestjs/core": ">=8"
+    rxjs: ">=7"
   languageName: unknown
   linkType: soft
 
@@ -49195,7 +49197,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.2.0":
+"rxjs@npm:^7.2.0, rxjs@npm:^7.8.0":
   version: 7.8.0
   resolution: "rxjs@npm:7.8.0"
   dependencies:


### PR DESCRIPTION
## Summary

The nestjs `HighlightErrorFilter` would alter exceptions raised by applications.
This meant that exceptions that should return a body with a 400 exception would
be replaced by a 500 response coming from highlight.
The `NestInterceptor` interface allows us to observe exceptions raised by api handlers
without altering the response. This is a better fit for the highlight nestjs sdk to record errors. 

## How did you test this change?

![Screenshot 2023-04-05 at 12 59 52 PM](https://user-images.githubusercontent.com/1351531/230194458-f7055a30-b000-4d1c-9626-c6dcc8b88e26.png)

![Screenshot 2023-04-05 at 1 01 23 PM](https://user-images.githubusercontent.com/1351531/230195032-c3dfd4f3-3326-4c79-9984-1c3df3c52ccb.png)

example usage
![image](https://user-images.githubusercontent.com/1351531/230196775-fe1d6a98-3137-434b-801e-5529486fcabf.png)


## Are there any deployment considerations?

New nestjs sdk version published.
