### PR TITLE
fix moment deprecation warning

### DIFF
--- a/frontend/src/util/time.ts
+++ b/frontend/src/util/time.ts
@@ -84,7 +84,7 @@ export const roundFeedDate = function (date: string | null) {
 	// nearest 15 seconds
 	const factor = 15
 	const m = moment(date || undefined)
-	return moment(m.format('MM/DD/YYYY HH:mm')).add(
+	return moment(m.startOf('minute')).add(
 		Math.round(m.seconds() / factor) * factor,
 		'seconds',
 	)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We are getting this moment deprecation warning on the session page:

![Screenshot 2023-04-05 at 4 40 17 PM](https://user-images.githubusercontent.com/58678/230228600-e87c2254-20de-43a8-bb5b-6f565acb8820.png)

This is pretty noisy especially when it shows up in the session console viewer ([example](https://app.highlight.io/1/sessions/1vlsA5jzUoyLvuBU1mEn5O2RdJzn)).

This has been happening for some time now and it appears to be because we are feeding moment a non standard time format. Hence it falls back to using `new Date` (see [here](https://stackoverflow.com/a/23376374) for more context).

The code in question is simply trying to get the floor time of the nearest minute and moment has a built-in function to do that while still maintaining proper formatting.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Observed no deprecation warning.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
