### PR TITLE
Import from react-router-dom instead of react-router

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -38,7 +38,10 @@
 		"@typescript-eslint/no-explicit-any": "off",
 		"@typescript-eslint/no-unused-vars": [
 			"error",
-			{ "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
+			{
+				"argsIgnorePattern": "^_",
+				"varsIgnorePattern": "^_"
+			}
 		],
 		"unused-imports/no-unused-imports-ts": "error",
 		"@typescript-eslint/no-non-null-assertion": "off",
@@ -103,6 +106,10 @@
 						"name": "antd",
 						"importNames": ["InputNumber"],
 						"message": "Please use InputNumber from /src/components/InputNumber instead."
+					},
+					{
+						"name": "react-router",
+						"message": "Please use `react-router-dom` instead."
 					},
 					{
 						"name": "react-router-dom",

--- a/frontend/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb/Breadcrumb.tsx
@@ -2,7 +2,7 @@ import SvgChevronRightIcon from '@icons/ChevronRightIcon'
 import { Breadcrumb as AntDesignBreadcrumb } from 'antd'
 import clsx from 'clsx'
 import React from 'react'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom'
 import { Link } from 'react-router-dom'
 
 import styles from './Breadcrumb.module.scss'

--- a/frontend/src/components/FieldsBox/FieldsBox.tsx
+++ b/frontend/src/components/FieldsBox/FieldsBox.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import React from 'react'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom'
 
 import styles from './FieldsBox.module.scss'
 

--- a/frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.tsx
+++ b/frontend/src/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation.tsx
@@ -12,7 +12,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import React from 'react'
 import { useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom'
 
 import styles from './KeyboardShortcutsEducation.module.scss'
 

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -28,7 +28,7 @@ import { Divider, Form, message } from 'antd'
 import clsx from 'clsx'
 import React, { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
-import { useNavigate } from 'react-router'
+import { useNavigate } from 'react-router-dom'
 import { Link, useLocation } from 'react-router-dom'
 import TextTransition from 'react-text-transition'
 

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -42,11 +42,12 @@ import {
 } from '@pages/LogsPage/constants'
 import LogsHistogram from '@pages/LogsPage/LogsHistogram/LogsHistogram'
 import { Search } from '@pages/LogsPage/SearchForm/SearchForm'
+import { useParams } from '@util/react-router/useParams'
 import { message } from 'antd'
 import { capitalize } from 'lodash'
 import moment from 'moment'
 import { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router'
+import { useNavigate } from 'react-router-dom'
 
 import * as styles from './styles.css'
 

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -38,7 +38,7 @@ import clsx from 'clsx'
 import React, { useEffect } from 'react'
 import { Helmet } from 'react-helmet'
 import { useHotkeys } from 'react-hotkeys-hook'
-import { useNavigate } from 'react-router'
+import { useNavigate } from 'react-router-dom'
 import { useLocation } from 'react-router-dom'
 
 import * as styles from './styles.css'

--- a/frontend/src/pages/Player/PlayerHook/utils/index.tsx
+++ b/frontend/src/pages/Player/PlayerHook/utils/index.tsx
@@ -7,7 +7,7 @@ import { MillisToMinutesAndSeconds } from '@util/time'
 import { message } from 'antd'
 import moment from 'moment'
 import { useCallback, useState } from 'react'
-import { useLocation } from 'react-router'
+import { useLocation } from 'react-router-dom'
 import { NavigateFunction } from 'react-router-dom'
 
 import { HighlightEvent } from '../../HighlightEvent'

--- a/frontend/src/pages/Setup/SetupPage.tsx
+++ b/frontend/src/pages/Setup/SetupPage.tsx
@@ -16,7 +16,7 @@ import React, { FunctionComponent, useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import Skeleton from 'react-loading-skeleton'
 import ReactMarkdown from 'react-markdown'
-import { useNavigate } from 'react-router'
+import { useNavigate } from 'react-router-dom'
 
 import ButtonLink from '../../components/Button/ButtonLink/ButtonLink'
 import Collapsible from '../../components/Collapsible/Collapsible'

--- a/frontend/src/util/react-router/useParams.tsx
+++ b/frontend/src/util/react-router/useParams.tsx
@@ -1,5 +1,7 @@
 import { DEMO_WORKSPACE_PROXY_APPLICATION_ID } from '@components/DemoWorkspaceButton/DemoWorkspaceButton'
-import { useParams as ReactRouterUseParams } from 'react-router'
+// This is the implementation for our custom useParams, exempting from rule
+// eslint-disable-next-line no-restricted-imports
+import { useParams as ReactRouterUseParams } from 'react-router-dom'
 import validator from 'validator'
 
 /**


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

_This is part of a [series](https://github.com/highlight/highlight/pull/4813) of PRs being spun off from [my WIP branch](https://github.com/lewisl9029/highlight/pull/2) to get the Highlight web app ready for [Reflame](https://reflame.app/). Hopefully this makes things a bit easier to review, test, and merge. 🙂_ 

There were several places in the frontend codebase where we were importing from `react-router`, a transitive dependency, instead of `react-router-dom`, a direct dependency.

This is often referred to as a phantom dependency, and can cause a number of issues, both in theory and practice:

- We have a rule against importing `useParams` from `react-router-dom`, but that does nothing to protect against importing `useParams` from `react-router`. In fact, this was something I [had to fix](https://github.com/highlight/highlight/commit/38a02f4ebcab29c1b8df368b864488b7bf736daf#diff-5fd6e69a538cbc878adc5b71eb5d9a6d68cd53d6588689284f4ecd9506343681L49) as part of this PR.

- Since the versions of transitive deps are not specified explicitly, they can easily change under our feet without us noticing and potentially cause us to import a different version than we were expecting, or can even inexplicably disappear altogether when seemingly unrelated deps change. The potential for spooky actions at a distance is greatly exacerbated in a large monorepo like we have here. The Rush.js folks did a great [writeup](https://rushjs.io/pages/advanced/phantom_deps/) on the perils of phathom dependencies, so I won't rehash all the details. 

- It's incompatible with stricter package management schemes like pnpm (and the one used by [Reflame](https://reflame.app/) itself, which was admittedly my primary motivation for this PR 😅) that don't expose non-direct dependencies to the resolution algorithm to begin with, specifically to combat the phantom dependency problem.

All I did to fix this was to search & replace all references of `'react-router'` to `'react-router-dom'`. And to prevent this specific issue from happening again, I added `react-router` to our existing list of restricted imports in eslint. For a more thorough defense against phantom deps, we'll need to switch to something like pnpm, npm's new [`linked` install strategy](https://github.com/npm/cli/pull/6078), or possibly yarn's [pnpm nodeLinker option](https://github.com/yarnpkg/berry/pull/3338) for a less disruptive migration (though I have no idea if it does what I think it does).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

I ran `yarn turbo run dev --filter frontend...` locally and poked around the app.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

None that I can think of.
