### PR TITLE
Import from specific entry points in react-syntax-highlighter

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorSourcePreview/ErrorSourcePreview.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorSourcePreview/ErrorSourcePreview.tsx
@@ -1,7 +1,7 @@
 import { Maybe } from '@graph/schemas'
 import { StackSectionProps } from '@pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace'
 import React from 'react'
-import SyntaxHighlighter from 'react-syntax-highlighter'
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/light'
 
 type ErrorSourcePreviewProps = {
 	lineContent: StackSectionProps['lineContent']

--- a/frontend/src/pages/Setup/CodeBlock/CodeBlock.tsx
+++ b/frontend/src/pages/Setup/CodeBlock/CodeBlock.tsx
@@ -4,10 +4,8 @@ import { message } from 'antd'
 import clsx from 'clsx'
 import React, { useEffect } from 'react'
 import CopyToClipboard from 'react-copy-to-clipboard'
-import {
-	Prism as SyntaxHighlighter,
-	SyntaxHighlighterProps,
-} from 'react-syntax-highlighter'
+import { type SyntaxHighlighterProps } from 'react-syntax-highlighter'
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism'
 import {
 	atomDark as darkTheme,
 	coy as lightTheme,


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

_This is part of a [series](https://github.com/highlight/highlight/pull/4813) [of](https://github.com/highlight/highlight/pull/4848) PRs being spun off from [my WIP branch](https://github.com/lewisl9029/highlight/pull/2) to get the Highlight web app ready for [Reflame](https://reflame.app/). Hopefully this makes things a bit easier to review, test, and merge. 🙂_ 

I ran into this specific [esbuild issue](https://github.com/evanw/esbuild/issues/1836) when preping the dependencies bundle for the [Highlight app](https://highlight-test-lewisl.reflame.dev/~r/start-preview/?mode=production&userId=01FQZZ7XJFDA799Z1Z9DRCFXWA&variantId=01GSY56NZ2GP8KAA4Y26A1RT6E&variantName=git%7Enew-reflame-app-1&resourceIdHtml=YvIo8Nr9gSIBHlECxeibDghiBAU) in [Reflame](https://reflame.app/). And my workaround was to point to specific entry points that we were actually using instead of from the root entry point.

Turns out, this also had a _dramatic_ impact on bundle size for the production Vite build:

Before:
```
build/assets/index2.js                            1,463.51 kB │ gzip:   364.69 kB │ map:  4,645.33 kB
build/assets/index.js                             7,624.60 kB │ gzip: 2,187.98 kB │ map: 25,251.61 kB 
```

After:
```
build/assets/index2.js                            1,463.51 kB │ gzip:   364.78 kB │ map:  4,644.97 kB
build/assets/index.js                             6,753.71 kB │ gzip: 1,903.80 kB │ map: 23,556.41 kB
```

Saves almost 300kb gzipped! 

It looks like the default entry point of `react-syntax-highlighter` contains import statements for basically all variantions (sync vs async), all languages and all themes that apparently weren't being tree shaken out properly.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

I ran the app using `yarn turbo run dev --filter frontend...` but still haven't figured out how to get past the signin screen there.

However, I did apply the same change in Reflame and was able to verify syntax highlighting still looked fine on the setup pages: 

![highlight-test-lewisl reflame dev_773_setup_client_js_react](https://user-images.githubusercontent.com/6934200/230259280-8a206b76-300c-49a1-8c19-1d6c4988e2dd.png)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

Probably worth poking around in a Render preview as well just to be safe.
