### PR TITLE
#4616 ignore incremental snapshots before full snapshot

### DIFF
--- a/backend/worker/worker_test.go
+++ b/backend/worker/worker_test.go
@@ -118,7 +118,7 @@ func TestCalculateSessionLength(t *testing.T) {
 }
 
 func TestGetActiveDuration(t *testing.T) {
-	zeroTime := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+	zeroTime := time.Time{}
 	beginningOfTime := time.Unix(0, 1000000).UTC()
 	tables := map[string]struct {
 		events             []model.EventsObject
@@ -156,6 +156,7 @@ func TestGetActiveDuration(t *testing.T) {
 					"events": [{
 						"_sid": 1,
 						"data": {"source": 5},
+						"timestamp": 1,
 						"type": 2
 					}]
 				}
@@ -194,6 +195,7 @@ func TestGetActiveDuration(t *testing.T) {
 					"events": [{
 						"_sid": 1,
 						"data": {"source": 5},
+						"timestamp": 1,
 						"type": 2
 					}]
 				}
@@ -231,6 +233,7 @@ func TestGetActiveDuration(t *testing.T) {
 					"events": [{
 						"_sid": 1,
 						"data": {"source": 5},
+						"timestamp": 1,
 						"type": 2
 					}]
 				}
@@ -298,6 +301,7 @@ func TestGetActiveDuration(t *testing.T) {
 					"events": [{
 						"_sid": 1,
 						"data": {"source": 5},
+						"timestamp": 1,
 						"type": 2
 					}]
 				}
@@ -696,7 +700,7 @@ func TestGetActiveDuration(t *testing.T) {
 			if diff := deep.Equal(tt.wantActiveDuration, a.ActiveDuration); diff != nil {
 				t.Errorf("[active duration not equal to expected]: %v", diff)
 			}
-			if diff := deep.Equal(tt.expectedFirstTS, a.FirstEventTimestamp); diff != nil {
+			if diff := deep.Equal(tt.expectedFirstTS, a.FirstFullSnapshotTimestamp); diff != nil {
 				t.Errorf("[expected first timestamp not equal to actual]: %v", diff)
 			}
 			for _, iii := range a.RageClickSets {


### PR DESCRIPTION
## Summary
- remove `FirstEventTimestamp` from the accumulator and use `FirstFullSnapshotTimestamp` instead
- skip incremental events if no full snapshot has occurred
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested the happy path locally to make sure existing sessions weren't broken, will monitor prod for this error after deploying
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, can revert if this is causing issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
