### PR TITLE
Resolve @highlight-run/client without relative paths

### DIFF
--- a/sdk/firstload/rollup.config.js
+++ b/sdk/firstload/rollup.config.js
@@ -22,7 +22,19 @@ const basePlugins = [
 	consts({
 		publicGraphURI: process.env.PUBLIC_GRAPH_URI,
 	}),
-	resolve({ browser: true }),
+	resolve({
+		browser: true,
+		// @highlight-run/client is a private package not published to npm, so
+		// listing it in package.json would break end users.
+		// Instead, we add root node_modules as a resolution path so it gets
+		// resolved as an internal module and included directly in the bundle.
+		// An alternative to the previous solution using relative paths that
+		// point outside package root described here:
+		// https://www.highlight.io/blog/publishing-private-pnpm-monorepo
+		modulePaths: ['../../node_modules'],
+		// Need to override this to add .ts and .tsx as valid resolution exts.
+		extensions: ['.mjs', '.js', '.json', '.node', '.ts', '.tsx'],
+	}),
 	webWorkerLoader({
 		targetPlatform: 'browser',
 		inline: true,

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -6,17 +6,20 @@ import {
 } from './integrations/amplitude'
 import { MixpanelAPI, setupMixpanelIntegration } from './integrations/mixpanel'
 import { initializeFetchListener } from './listeners/fetch'
-import { getPreviousSessionData } from '../../client/src/utils/sessionStorage/highlightSession'
-import { FirstLoadListeners } from '../../client/src/listeners/first-load-listeners'
-import { GenerateSecureID } from '../../client/src/utils/secure-id'
-import type { Highlight, HighlightClassOptions } from '../../client/src/index'
+import { getPreviousSessionData } from '@highlight-run/client/src/utils/sessionStorage/highlightSession'
+import { FirstLoadListeners } from '@highlight-run/client/src/listeners/first-load-listeners'
+import { GenerateSecureID } from '@highlight-run/client/src/utils/secure-id'
+import type {
+	Highlight,
+	HighlightClassOptions,
+} from '@highlight-run/client/src/index'
 import type {
 	HighlightOptions,
 	HighlightPublicInterface,
 	Metadata,
 	Metric,
 	SessionDetails,
-} from '../../client/src/types/types'
+} from '@highlight-run/client/src/types/types'
 import HighlightSegmentMiddleware from './integrations/segment'
 import configureElectronHighlight from './environments/electron'
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

_This is part of a [series](https://github.com/highlight/highlight/pull/4813) [of](https://github.com/highlight/highlight/pull/4848) [PRs](https://github.com/highlight/highlight/pull/4849) being spun off from [my WIP branch](https://github.com/lewisl9029/highlight/pull/2) to get the Highlight web app ready for [Reflame](https://reflame.app/). Hopefully this makes things a bit easier to review, test, and merge. 🙂_ 

The sdk/firstload package currently imports from `@highlight-run/client` using relative paths that point outside the package root. I read your [blog post on this](https://www.highlight.io/blog/publishing-private-pnpm-monorepo) and was able to get a good understanding of the motivations, but it was breaking the app in Reflame (where individual libraries are much more tightly isolated at the boundary, and relative imports outside the package root would basically just point into the aether) so I had to find a workaround. 😅 

I think I found a reasonable one here, where we use the [`modulePaths` option](https://github.com/rollup/plugins/tree/master/packages/node-resolve#modulepaths) in `@rollup/plugin-node-resolve` to make `@highlight-run/client` resolvable as an internal module, so it gets included in the bundle without the need to specify it as a dependency in package.json.

The resulting builds ended up having identical hashes as before the change, so this did manage to preserve the same output as before. Wdyt?

## How did you test this change?

I added `entryFileNames: '[name]-[hash].js'` to output options and ran the build in this branch and main. Both ended up with identical hashes, which means the build output was not affected at all by this change. 😄 


<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

Since the build output is identical I think we're good, but it could be a good idea to cut a new release just in case to confirm this doesn't cause any unforeseen issues in the wild.