### PR TITLE
use log row constructor everywhere

### DIFF
--- a/backend/clickhouse/cursor_test.go
+++ b/backend/clickhouse/cursor_test.go
@@ -186,12 +186,7 @@ func TestClickhouseDecode(t *testing.T) {
 
 	now := time.Now()
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-		},
+		NewLogRow(now, 1),
 	}
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
 

--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -15,22 +15,26 @@ func TestNewLogRowWithLogAttributes(t *testing.T) {
 	spanAttributes := map[string]any{"highlight.source": "frontend", "foo": "bar"}
 	eventAttributes := map[string]any{"log.severity": "info"} // should be skipped since this is an internal attribute
 
-	logRow := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(context.TODO(), resourceAttributes, spanAttributes, eventAttributes, false))
+	now := time.Now()
+
+	logRow := NewLogRow(now, 1, WithLogAttributes(context.TODO(), resourceAttributes, spanAttributes, eventAttributes, false))
 
 	assert.Equal(t, map[string]string{"foo": "bar", "os.description": "Debian GNU/Linux 11 (bullseye)"}, logRow.LogAttributes)
 
-	logRow = NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(context.TODO(), resourceAttributes, spanAttributes, eventAttributes, true))
+	logRow = NewLogRow(now, 1, WithLogAttributes(context.TODO(), resourceAttributes, spanAttributes, eventAttributes, true))
 
 	assert.Equal(t, map[string]string{"foo": "bar"}, logRow.LogAttributes)
 }
 
 func TestNewLogRowWithSeverityText(t *testing.T) {
-	assert.Equal(t, "warn", NewLogRow(LogRowPrimaryAttrs{}, WithSeverityText("WARN")).SeverityText, "it downcases")
-	assert.Equal(t, "info", NewLogRow(LogRowPrimaryAttrs{}, WithSeverityText("dir")).SeverityText, "it defaults to info when unknown")
-	assert.Equal(t, int32(4), NewLogRow(LogRowPrimaryAttrs{}, WithSeverityText("dir")).SeverityNumber, "it handles figuring out the severity number")
+	now := time.Now()
+	assert.Equal(t, "warn", NewLogRow(now, 1, WithSeverityText("WARN")).SeverityText, "it downcases")
+	assert.Equal(t, "info", NewLogRow(now, 1, WithSeverityText("dir")).SeverityText, "it defaults to info when unknown")
+	assert.Equal(t, int32(4), NewLogRow(now, 1, WithSeverityText("dir")).SeverityNumber, "it handles figuring out the severity number")
 }
 
 func TestNewLogRowWithException(t *testing.T) {
+	now := time.Now()
 	ctx := context.TODO()
 	var resourceAttributes, spanAttributes, eventAttributes map[string]any
 	resourceAttributes = map[string]any{
@@ -38,13 +42,14 @@ func TestNewLogRowWithException(t *testing.T) {
 		"exception.stacktrace": "bar",
 		"exception.type":       "baz",
 	}
-	lr := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, false))
+	lr := NewLogRow(now, 1, WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, false))
 	assert.Equal(t, "", lr.LogAttributes["exception.message"])
 	assert.Equal(t, "", lr.LogAttributes["exception.stacktrace"])
 	assert.Equal(t, "baz", lr.LogAttributes["exception.type"])
 }
 
 func TestNewLogRowWithLongField(t *testing.T) {
+	now := time.Now()
 	ctx := context.TODO()
 	var resourceAttributes, spanAttributes, eventAttributes map[string]any
 	var value string
@@ -52,31 +57,33 @@ func TestNewLogRowWithLongField(t *testing.T) {
 		value += "a"
 	}
 	spanAttributes = map[string]any{"foo": value}
-	lr := NewLogRow(LogRowPrimaryAttrs{}, WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, false))
+	lr := NewLogRow(now, 1, WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, false))
 	assert.Equal(t, 2048+3, len(lr.LogAttributes["foo"]))
 }
 
 func TestNewLogRowWithLongBody(t *testing.T) {
+	now := time.Now()
 	ctx := context.TODO()
 	var body string
 	for i := 0; i < 2<<16; i++ {
 		body += "a"
 	}
-	lr := NewLogRow(LogRowPrimaryAttrs{}, WithBody(ctx, body))
+	lr := NewLogRow(now, 1, WithBody(ctx, body))
 	assert.Equal(t, 2048+3, len(lr.Body))
 }
 
 func TestNewLogRowWithSource(t *testing.T) {
-	lr := NewLogRow(LogRowPrimaryAttrs{}, WithSource(modelInputs.LogSourceFrontend))
+	now := time.Now()
+	lr := NewLogRow(now, 1, WithSource(modelInputs.LogSourceFrontend))
 	assert.Equal(t, modelInputs.LogSourceFrontend, lr.Source)
 
-	lr = NewLogRow(LogRowPrimaryAttrs{}, WithSource(modelInputs.LogSourceBackend))
+	lr = NewLogRow(now, 1, WithSource(modelInputs.LogSourceBackend))
 	assert.Equal(t, modelInputs.LogSourceBackend, lr.Source)
 }
 
 func TestNewLogRowWithTimestamp(t *testing.T) {
 	ts := time.Now()
-	lr := NewLogRow(LogRowPrimaryAttrs{}, WithTimestamp(ts))
+	lr := NewLogRow(ts, 1)
 	// log row should be created with second precision, per clickhouse precision
 	assert.Equal(t, ts.Truncate(time.Second), lr.Timestamp)
 }

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -64,14 +64,8 @@ func TestBatchWriteLogRows(t *testing.T) {
 
 	now := time.Now()
 
-	logRow := NewLogRow(
-		LogRowPrimaryAttrs{},
-		WithSource(modelInputs.LogSourceFrontend),
-		WithProjectIDString("1"),
-		WithTimestamp(now),
-	)
 	rows := []*LogRow{
-		logRow,
+		NewLogRow(now, 1, WithSource(modelInputs.LogSourceFrontend)),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -91,12 +85,7 @@ func TestReadLogsWithTimeQuery(t *testing.T) {
 
 	now := time.Now()
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-		},
+		NewLogRow(now, 1),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -131,20 +120,8 @@ func TestReadLogsAscending(t *testing.T) {
 	now := time.Now()
 	oneSecondAgo := now.Add(-time.Second * 1)
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "Body 1",
-		},
-		{
-			Timestamp: oneSecondAgo,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "Body 2",
-		},
+		NewLogRow(now, 1, WithBody(ctx, "Body 1")),
+		NewLogRow(oneSecondAgo, 1, WithBody(ctx, "Body 2")),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -167,13 +144,9 @@ func TestReadLogsTotalCount(t *testing.T) {
 	defer teardown(t)
 
 	now := time.Now()
+
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-		},
+		NewLogRow(now, 1),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -192,48 +165,12 @@ func TestReadLogsHistogram(t *testing.T) {
 
 	now := time.Now()
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			SeverityText: modelInputs.LogLevelInfo.String(),
-		},
-		{
-			Timestamp: now.Add(-time.Hour - time.Minute*29),
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			SeverityText: modelInputs.LogLevelDebug.String(),
-		},
-		{
-			Timestamp: now.Add(-time.Hour - time.Minute*30),
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			SeverityText: modelInputs.LogLevelInfo.String(),
-		},
-		{
-			Timestamp: now.Add(-time.Hour * 2),
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			SeverityText: modelInputs.LogLevelError.String(),
-		},
-		{
-			Timestamp: now.Add(-time.Hour*2 - time.Minute*30),
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			SeverityText: modelInputs.LogLevelError.String(),
-		},
-		{
-			Timestamp: now.Add(-time.Hour * 3),
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			SeverityText: modelInputs.LogLevelError.String(),
-		},
+		NewLogRow(now, 1, WithSeverityText(modelInputs.LogLevelInfo.String())),
+		NewLogRow(now.Add(-time.Hour-time.Minute*29), 1, WithSeverityText(modelInputs.LogLevelDebug.String())),
+		NewLogRow(now.Add(-time.Hour-time.Minute*30), 1, WithSeverityText(modelInputs.LogLevelInfo.String())),
+		NewLogRow(now.Add(-time.Hour*2), 1, WithSeverityText(modelInputs.LogLevelError.String())),
+		NewLogRow(now.Add(-time.Hour*2-time.Minute*30), 1, WithSeverityText(modelInputs.LogLevelError.String())),
+		NewLogRow(now.Add(-time.Hour*3), 1, WithSeverityText(modelInputs.LogLevelError.String())),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -334,12 +271,7 @@ func TestReadLogsHasNextPage(t *testing.T) {
 	var rows []*LogRow
 
 	for i := 1; i <= LogsLimit; i++ { // 100 is a hardcoded limit
-		rows = append(rows, &LogRow{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-		})
+		rows = append(rows, NewLogRow(now, 1))
 	}
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
 
@@ -353,12 +285,7 @@ func TestReadLogsHasNextPage(t *testing.T) {
 
 	// Add more more row to have 101 rows
 	assert.NoError(t, client.BatchWriteLogRows(ctx, []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-		},
+		NewLogRow(now, 1),
 	}))
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
@@ -381,34 +308,26 @@ func TestReadLogsAfterCursor(t *testing.T) {
 	rows := []*LogRow{
 		{
 			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "Body 1",
-			UUID: "c051edc8-3749-4e44-8f48-0ea90f3fc3d9",
+			ProjectId: 1,
+			Body:      "Body 1",
+			UUID:      "c051edc8-3749-4e44-8f48-0ea90f3fc3d9",
 		},
 		{
 			Timestamp: oneSecondAgo,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "Body 2",
-			UUID: "a0d9abd6-7cbf-47de-b211-d16bb0935e04",
+			ProjectId: 1,
+			Body:      "Body 2",
+			UUID:      "a0d9abd6-7cbf-47de-b211-d16bb0935e04",
 		},
 		{
 			Timestamp: oneSecondAgo,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "Body 3",
-			UUID: "b6e255ee-049e-4563-bbfe-c33503cde94c",
+			ProjectId: 1,
+			Body:      "Body 3",
+			UUID:      "b6e255ee-049e-4563-bbfe-c33503cde94c",
 		},
 		{
 			Timestamp: oneDayAgo,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "Body 4",
+			ProjectId: 1,
+			Body:      "Body 4",
 		},
 	}
 
@@ -447,34 +366,26 @@ func TestReadLogsBeforeCursor(t *testing.T) {
 	rows := []*LogRow{
 		{
 			Timestamp: oneDayFromNow,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "Body 0",
+			ProjectId: 1,
+			Body:      "Body 0",
 		},
 		{
 			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "Body 1",
-			UUID: "c051edc8-3749-4e44-8f48-0ea90f3fc3d9",
+			ProjectId: 1,
+			Body:      "Body 1",
+			UUID:      "c051edc8-3749-4e44-8f48-0ea90f3fc3d9",
 		},
 		{
 			Timestamp: oneSecondAgo,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "Body 2",
-			UUID: "a0d9abd6-7cbf-47de-b211-d16bb0935e04",
+			ProjectId: 1,
+			Body:      "Body 2",
+			UUID:      "a0d9abd6-7cbf-47de-b211-d16bb0935e04",
 		},
 		{
 			Timestamp: oneSecondAgo,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "Body 3",
-			UUID: "b6e255ee-049e-4563-bbfe-c33503cde94c",
+			ProjectId: 1,
+			Body:      "Body 3",
+			UUID:      "b6e255ee-049e-4563-bbfe-c33503cde94c",
 		},
 	}
 
@@ -515,12 +426,7 @@ func TestReadLogsAtCursor(t *testing.T) {
 	// 51 logs visible (25 before + 25 after + permalinked log)
 	// 1 log not visible on the next page
 	for i := 1; i <= LogsLimit+3; i++ {
-		rows = append(rows, &LogRow{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-		})
+		rows = append(rows, NewLogRow(now, 1))
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -582,27 +488,9 @@ func TestReadLogsWithBodyFilter(t *testing.T) {
 
 	now := time.Now()
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "body with space",
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "STRIPE_INTEGRATION_ERROR cannot report usage - customer has no subscriptions",
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Body: "STRIPE-INTEGRATION-ERROR cannot report usage - customer has no subscriptions",
-		},
+		NewLogRow(now, 1, WithBody(ctx, "body with space")),
+		NewLogRow(now, 1, WithBody(ctx, "STRIPE_INTEGRATION_ERROR cannot report usage - customer has no subscriptions")),
+		NewLogRow(now, 1, WithBody(ctx, "STRIPE-INTEGRATION-ERROR cannot report usage - customer has no subscriptions")),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -656,18 +544,17 @@ func TestReadLogsWithKeyFilter(t *testing.T) {
 	defer teardown(t)
 
 	now := time.Now()
+
+	var resourceAttributes, spanAttributes, eventAttributes map[string]any
+	resourceAttributes = map[string]any{
+		"service":      "image processor",
+		"workspace_id": "1",
+		"user_id":      "1",
+	}
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{
-				"service":      "image processor",
-				"workspace_id": "1",
-				"user_id":      "1",
-			},
-		},
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, false),
+		),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -708,22 +595,12 @@ func TestReadLogsWithLevelFilter(t *testing.T) {
 
 	now := time.Now()
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			SeverityText: modelInputs.LogLevelInfo.String(),
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{
+		NewLogRow(now, 1, WithSeverityText(modelInputs.LogLevelInfo.String())),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
 				"level": modelInputs.LogLevelWarn.String(),
-			},
-		},
+			}, map[string]any{}, map[string]any{}, false),
+		),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -759,22 +636,12 @@ func TestReadLogsWithSessionIdFilter(t *testing.T) {
 
 	now := time.Now()
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId:       1,
-				SecureSessionId: "match",
-			},
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{
+		NewLogRow(now, 1, WithSecureSessionID("match")),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
 				"secure_session_id": "no_match",
-			},
-		},
+			}, map[string]any{}, map[string]any{}, false),
+		),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -810,22 +677,12 @@ func TestReadLogsWithSpanIdFilter(t *testing.T) {
 
 	now := time.Now()
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-				SpanId:    "match",
-			},
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{
+		NewLogRow(now, 1, WithSpanID("match")),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
 				"span_id": "no_match",
-			},
-		},
+			}, map[string]any{}, map[string]any{}, false),
+		),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -861,22 +718,12 @@ func TestReadLogsWithTraceIdFilter(t *testing.T) {
 
 	now := time.Now()
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-				TraceId:   "match",
-			},
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{
+		NewLogRow(now, 1, WithTraceID("match")),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
 				"trace_id": "no_match",
-			},
-		},
+			}, map[string]any{}, map[string]any{}, false),
+		),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -912,29 +759,13 @@ func TestReadLogsWithSourceFilter(t *testing.T) {
 
 	now := time.Now()
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Source:      "backend",
-			ServiceName: "bar",
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{
+		NewLogRow(now, 1),
+		NewLogRow(now, 1, WithSource(modelInputs.LogSourceBackend), WithServiceName("bar")),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
 				"source": "frontend",
-			},
-		},
+			}, map[string]any{}, map[string]any{}, false),
+		),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -973,35 +804,23 @@ func TestLogsKeys(t *testing.T) {
 	now := time.Now()
 
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{"user_id": "1", "workspace_id": "2"},
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{"workspace_id": "3"},
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			Source:      "frontend",
-			ServiceName: "foo-service",
-		},
-		{
-			Timestamp: now.Add(-time.Second * 1), // out of range, should not be included
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{"workspace_id": "5"},
-		},
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
+				"user_id":      "1",
+				"workspace_id": "2",
+			}, map[string]any{}, map[string]any{}, false),
+		),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
+				"workspace_id": "3",
+			}, map[string]any{}, map[string]any{}, false),
+		),
+		NewLogRow(now, 1, WithSource(modelInputs.LogSourceFrontend), WithServiceName("foo-service")),
+		NewLogRow(now.Add(-time.Second*1), 1, // out of range, should not be included
+			WithLogAttributes(ctx, map[string]any{
+				"workspace_id": "5",
+			}, map[string]any{}, map[string]any{}, false),
+		),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -1060,62 +879,46 @@ func TestLogKeyValues(t *testing.T) {
 	now := time.Now()
 
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{"workspace_id": "2"},
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{"workspace_id": "2"},
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{"workspace_id": "3"},
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{"workspace_id": "3"},
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{"workspace_id": "3"},
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{"workspace_id": "4"},
-		},
-		{
-			Timestamp: now.Add(-time.Second * 1), // out of range, should not be included
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{"workspace_id": "5"},
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{"unrelated_key": "value"},
-		},
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
+				"workspace_id": "2",
+			}, map[string]any{}, map[string]any{}, false),
+		),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
+				"workspace_id": "2",
+			}, map[string]any{}, map[string]any{}, false),
+		),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
+				"workspace_id": "3",
+			}, map[string]any{}, map[string]any{}, false),
+		),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
+				"workspace_id": "3",
+			}, map[string]any{}, map[string]any{}, false),
+		),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
+				"workspace_id": "3",
+			}, map[string]any{}, map[string]any{}, false),
+		),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
+				"workspace_id": "4",
+			}, map[string]any{}, map[string]any{}, false),
+		),
+		NewLogRow(now.Add(-time.Second*1), 1, // out of range, should not be included
+			WithLogAttributes(ctx, map[string]any{
+				"workspace_id": "5",
+			}, map[string]any{}, map[string]any{}, false),
+		),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
+				"unrelated_key": "value",
+			}, map[string]any{}, map[string]any{}, false),
+		),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
@@ -1140,34 +943,14 @@ func TestLogKeyValuesLevel(t *testing.T) {
 	now := time.Now()
 
 	rows := []*LogRow{
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			SeverityText: modelInputs.LogLevelInfo.String(),
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			SeverityText: modelInputs.LogLevelWarn.String(),
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			SeverityText: modelInputs.LogLevelInfo.String(),
-		},
-		{
-			Timestamp: now,
-			LogRowPrimaryAttrs: LogRowPrimaryAttrs{
-				ProjectId: 1,
-			},
-			LogAttributes: map[string]string{"level": modelInputs.LogLevelFatal.String()}, // should be skipped in the output
-		},
+		NewLogRow(now, 1, WithSeverityText(modelInputs.LogLevelInfo.String())),
+		NewLogRow(now, 1, WithSeverityText(modelInputs.LogLevelWarn.String())),
+		NewLogRow(now, 1, WithSeverityText(modelInputs.LogLevelInfo.String())),
+		NewLogRow(now, 1,
+			WithLogAttributes(ctx, map[string]any{
+				"level": modelInputs.LogLevelFatal.String(), // should be skipped in the output
+			}, map[string]any{}, map[string]any{}, false),
+		),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -596,11 +596,6 @@ func TestReadLogsWithLevelFilter(t *testing.T) {
 	now := time.Now()
 	rows := []*LogRow{
 		NewLogRow(now, 1, WithSeverityText(modelInputs.LogLevelInfo.String())),
-		NewLogRow(now, 1,
-			WithLogAttributes(ctx, map[string]any{
-				"level": modelInputs.LogLevelWarn.String(),
-			}, map[string]any{}, map[string]any{}, false),
-		),
 	}
 
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))

--- a/backend/clickhouse/seeds/main.go
+++ b/backend/clickhouse/seeds/main.go
@@ -139,12 +139,12 @@ func main() {
 
 	for i := 1; i < 10000; i++ {
 		var logRows []*clickhouse.LogRow
-		logRows = append(logRows, clickhouse.NewLogRow(clickhouse.LogRowPrimaryAttrs{
-			ProjectId:       1,
-			TraceId:         makeRandomTraceID(),
-			SpanId:          makeRandomSpanID(),
-			SecureSessionId: makeRandomSecureSessionID(),
-		}, clickhouse.WithTimestamp(now.Add(-time.Duration(i)*time.Second)),
+		ts := now.Add(-time.Duration(i) * time.Second)
+
+		logRows = append(logRows, clickhouse.NewLogRow(ts, 1,
+			clickhouse.WithTraceID(makeRandomTraceID()),
+			clickhouse.WithSpanID(makeRandomSpanID()),
+			clickhouse.WithSecureSessionID(makeRandomSecureSessionID()),
 			clickhouse.WithBody(ctx, fmt.Sprintf("Body %d", i)),
 			clickhouse.WithLogAttributes(ctx, makeRandLogAttributes(), makeRandLogAttributes(), makeRandLogAttributes(), false),
 			clickhouse.WithSeverityText(makeRandomSeverityText()),

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -82,13 +82,13 @@ func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestI
 }
 
 func getLogRow(ctx context.Context, ts time.Time, lvl, projectID, sessionID, traceID, spanID string, excMessage string, resourceAttributes, spanAttributes, eventAttributes map[string]any, source modelInputs.LogSource) *clickhouse.LogRow {
+	projectIDInt, _ := clickhouse.ProjectToInt(projectID)
+
 	return clickhouse.NewLogRow(
-		clickhouse.LogRowPrimaryAttrs{
-			TraceId:         traceID,
-			SpanId:          spanID,
-			SecureSessionId: sessionID,
-		},
-		clickhouse.WithTimestamp(ts),
+		ts, uint32(projectIDInt),
+		clickhouse.WithTraceID(traceID),
+		clickhouse.WithSpanID(spanID),
+		clickhouse.WithSecureSessionID(sessionID),
 		clickhouse.WithBody(ctx, excMessage),
 		clickhouse.WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, source == modelInputs.LogSourceFrontend),
 		clickhouse.WithProjectIDString(projectID),

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -81,8 +81,12 @@ func setHighlightAttributes(attrs map[string]any, projectID, sessionID, requestI
 	}
 }
 
-func getLogRow(ctx context.Context, ts time.Time, lvl, projectID, sessionID, traceID, spanID string, excMessage string, resourceAttributes, spanAttributes, eventAttributes map[string]any, source modelInputs.LogSource) *clickhouse.LogRow {
-	projectIDInt, _ := clickhouse.ProjectToInt(projectID)
+func getLogRow(ctx context.Context, ts time.Time, lvl, projectID, sessionID, traceID, spanID string, excMessage string, resourceAttributes, spanAttributes, eventAttributes map[string]any, source modelInputs.LogSource) (*clickhouse.LogRow, error) {
+	projectIDInt, err := clickhouse.ProjectToInt(projectID)
+
+	if err != nil {
+		return nil, err
+	}
 
 	return clickhouse.NewLogRow(
 		ts, uint32(projectIDInt),
@@ -94,7 +98,7 @@ func getLogRow(ctx context.Context, ts time.Time, lvl, projectID, sessionID, tra
 		clickhouse.WithServiceName(cast(resourceAttributes[string(semconv.ServiceNameKey)], "")),
 		clickhouse.WithSeverityText(lvl),
 		clickhouse.WithSource(source),
-	)
+	), nil
 }
 
 func getBackendError(ctx context.Context, ts time.Time, projectID, sessionID, requestID, traceID, spanID string, logCursor *string, excMessage string, source modelInputs.LogSource, resourceAttributes, spanAttributes, eventAttributes map[string]any) (bool, *model.BackendErrorObjectInput) {
@@ -195,7 +199,13 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						ts := event.Timestamp().AsTime()
 
 						var logCursor *string
-						logRow := getLogRow(ctx, ts, "ERROR", projectID, sessionID, traceID, spanID, excMessage, resourceAttributes, spanAttributes, eventAttributes, source)
+						logRow, err := getLogRow(ctx, ts, "ERROR", projectID, sessionID, traceID, spanID, excMessage, resourceAttributes, spanAttributes, eventAttributes, source)
+
+						if err != nil {
+							log.WithContext(ctx).Error("failed to create log row", err)
+							continue
+						}
+
 						projectLogs[projectID] = append(projectLogs[projectID], logRow)
 						logCursor = pointy.String(logRow.Cursor())
 
@@ -220,10 +230,16 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 							continue
 						}
 
-						logRow := getLogRow(
+						logRow, err := getLogRow(
 							ctx, ts, logSev, projectID, sessionID, traceID, spanID,
 							logMessage, resourceAttributes, spanAttributes, eventAttributes, source,
 						)
+
+						if err != nil {
+							log.WithContext(ctx).Error("failed to create log row", err)
+							continue
+						}
+
 						projectLogs[projectID] = append(projectLogs[projectID], logRow)
 					}
 				}
@@ -362,8 +378,9 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 				logAttributes := logRecord.Attributes().AsRaw()
 				setHighlightAttributes(logAttributes, &projectID, &sessionID, &requestID, &source)
 
-				logRow := getLogRow(ctx, logRecord.Timestamp().AsTime(), logRecord.SeverityText(), projectID, sessionID, logRecord.TraceID().String(), logRecord.SpanID().String(), logRecord.Body().Str(), resourceAttributes, scopeAttributes, logAttributes, source)
-				if logRow == nil {
+				logRow, err := getLogRow(ctx, logRecord.Timestamp().AsTime(), logRecord.SeverityText(), projectID, sessionID, logRecord.TraceID().String(), logRecord.SpanID().String(), logRecord.Body().Str(), resourceAttributes, scopeAttributes, logAttributes, source)
+
+				if err != nil {
 					log.WithContext(ctx).WithField("ProjectID", projectID).WithField("LogMessage", logRecord.Body().AsRaw()).Errorf("otel log got invalid log record")
 					continue
 				}

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -91,7 +91,6 @@ func getLogRow(ctx context.Context, ts time.Time, lvl, projectID, sessionID, tra
 		clickhouse.WithSecureSessionID(sessionID),
 		clickhouse.WithBody(ctx, excMessage),
 		clickhouse.WithLogAttributes(ctx, resourceAttributes, spanAttributes, eventAttributes, source == modelInputs.LogSourceFrontend),
-		clickhouse.WithProjectIDString(projectID),
 		clickhouse.WithServiceName(cast(resourceAttributes[string(semconv.ServiceNameKey)], "")),
 		clickhouse.WithSeverityText(lvl),
 		clickhouse.WithSource(source),


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We have a lot of data normalization when using the log row constructor (`NewLogRow`) and it's options (e.g. `WithSeverityText`). But some code calls the struct (`LogRow`) directly (specifically the tests) and that makes our code more brittle. 

Hence, this PR is doing a couple things:

* ensuring that all log rows are created with `NewLogRow`
* adjusted the constructor to require a timestamp and a project id (these are the bare minimum requirements for a log, everything else is optional and should use the `With*` functions)
* Got rid of `LogRowPrimaryAttrs` in favor of more `With*` functions (e.g. `WithTraceID`)
* Since timestamp is required, I got rid of `WithTimestamp` (the logic of truncating to the second is still present)
* Since project id is required, I got rid of `WithProjectIDString`. It wasn't doing error handling (see inline comment below).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Existing tests should pass and code should compile

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
