### PR TITLE
fix ci check for opensearch migration

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,10 +60,13 @@ jobs:
 
                   yarn cy:run;
 
-            - name: Dump docker logs on failure
+            - name: Dump setup logs on failure
+              if: failure()
+              run: cat /tmp/highlight.log
+
+            - name: Dump docker container logs on failure
               if: failure()
               run: |
-                  cat /tmp/highlight.log;
                   cd docker;
                   docker compose logs;
 

--- a/docker/start-infra.sh
+++ b/docker/start-infra.sh
@@ -14,9 +14,9 @@ pushd ../backend
 go run ./migrations/main.go > /tmp/highlightSetup.log 2>&1
 # setup opensearch indices
 go run main.go -runtime=worker -worker-handler=init-opensearch >> /tmp/highlightSetup.log 2>&1
-if grep -i 'error ' /tmp/highlightSetup.log | grep -v lambda; then
+if grep -e 'OPENSEARCH_ERROR' /tmp/highlightSetup.log; then
   echo 'Failed to migrate highlight infrastructure.'
-  grep -i 'error ' /tmp/highlightSetup.log | grep -v lambda
+  grep -e 'OPENSEARCH_ERROR' /tmp/highlightSetup.log
   echo 'Full output.'
   cat /tmp/highlightSetup.log
   exit 1


### PR DESCRIPTION
## Summary

Make the check for migration success more strict so that it does not match irrelevant lines.
```bash
2023-04-06T04:19:40.4627731Z + grep -i 'error ' /tmp/highlightSetup.log
2023-04-06T04:19:40.4627833Z + grep -v lambda
2023-04-06T04:19:40.4628053Z go: downloading github.com/hashicorp/go-multierror v1.1.1
```
Improving the GitHub Action output as well to make it easier to triage the test.

## How did you test this change?

Running in CI.
Testing the bad-path locally:
<img width="1800" alt="Screenshot 2023-04-05 at 9 50 08 PM" src="https://user-images.githubusercontent.com/1351531/230274737-66483735-4512-4dcf-ac3a-4f8ce681ee8d.png">

## Are there any deployment considerations?

No
