### PR TITLE
Revert "[hotfix] Only query integration data on projects"

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -51,6 +51,7 @@ import analytics from '@util/analytics'
 import { auth } from '@util/auth'
 import { isProjectWithinTrial } from '@util/billing/billing'
 import { client } from '@util/graph'
+import { useClientIntegrated, useServerIntegrated } from '@util/integrated'
 import { isOnPrem } from '@util/onPrem/onPremUtils'
 import { useParams } from '@util/react-router/useParams'
 import { titleCaseString } from '@util/string'
@@ -65,12 +66,7 @@ import { useSessionStorage } from 'react-use'
 import { CommandBar as CommandBarV1 } from './CommandBar/CommandBar'
 import styles from './Header.module.scss'
 
-type Props = {
-	fullyIntegrated?: boolean
-	integrated?: boolean
-}
-
-export const Header: React.FC<Props> = ({ fullyIntegrated, integrated }) => {
+export const Header = () => {
 	const { project_id } = useParams<{
 		project_id: string
 	}>()
@@ -78,6 +74,12 @@ export const Header: React.FC<Props> = ({ fullyIntegrated, integrated }) => {
 	const { isLoggedIn } = useAuthContext()
 	const { currentProject, currentWorkspace } = useApplicationContext()
 	const workspaceId = currentWorkspace?.id
+	const { data: clientIntegration } = useClientIntegrated()
+	const { data: serverIntegration } = useServerIntegrated()
+	const fullyIntegrated =
+		!!clientIntegration?.integrated && !!serverIntegration?.integrated
+	const integrated =
+		!!clientIntegration?.integrated || !!serverIntegration?.integrated
 
 	const { pathname, state } = useLocation()
 	const goBackPath = state?.previousPath ?? `/${project_id}/sessions`
@@ -116,9 +118,7 @@ export const Header: React.FC<Props> = ({ fullyIntegrated, integrated }) => {
 			<CommandBar />
 			<CommandBarV1 />
 			<Box background="n2" borderBottom="secondary">
-				{!!project_id &&
-					!isSetup &&
-					getBanner(project_id, !!integrated)}
+				{!!project_id && !isSetup && getBanner(project_id, integrated)}
 				<Box
 					display="flex"
 					alignItems="center"
@@ -352,27 +352,23 @@ export const Header: React.FC<Props> = ({ fullyIntegrated, integrated }) => {
 							style={{ zIndex: 20000 }}
 							width="full"
 						>
-							{!!projectIdRemapped &&
-								!fullyIntegrated &&
-								!isSetup && (
-									<LinkButton
-										to={`/${project_id}/setup`}
-										state={{
-											previousPath: location.pathname,
-										}}
-										trackingId="header_setup-cta"
-										emphasis="low"
+							{!!fullyIntegrated && !isSetup && (
+								<LinkButton
+									to={`/${project_id}/setup`}
+									state={{ previousPath: location.pathname }}
+									trackingId="header_setup-cta"
+									emphasis="low"
+								>
+									<Stack
+										direction="row"
+										align="center"
+										gap="4"
 									>
-										<Stack
-											direction="row"
-											align="center"
-											gap="4"
-										>
-											<Text>Finish setup </Text>
-											<IconSolidArrowSmRight />
-										</Stack>
-									</LinkButton>
-								)}
+										<Text>Finish setup </Text>
+										<IconSolidArrowSmRight />
+									</Stack>
+								</LinkButton>
+							)}
 							{!!project_id && !isSetup && (
 								<Button
 									trackingId="quickSearchClicked"

--- a/frontend/src/pages/Setup/SetupRouter/SetupRouter.tsx
+++ b/frontend/src/pages/Setup/SetupRouter/SetupRouter.tsx
@@ -16,9 +16,13 @@ import {
 import { useProjectId } from '@hooks/useProjectId'
 import { SetupDocs } from '@pages/Setup/SetupDocs'
 import { SetupOptionsList } from '@pages/Setup/SetupOptionsList'
-import { IntegrationProps } from '@routers/ProjectRouter/ApplicationRouter'
 import { useGlobalContext } from '@routers/ProjectRouter/context/GlobalContext'
 import analytics from '@util/analytics'
+import {
+	useClientIntegrated,
+	useLogsIntegrated,
+	useServerIntegrated,
+} from '@util/integrated'
 import { message } from 'antd'
 import clsx from 'clsx'
 import React, { useEffect } from 'react'
@@ -34,12 +38,11 @@ import {
 
 import * as styles from './SetupRouter.css'
 
-export const SetupRouter: React.FC<IntegrationProps> = ({
-	clientIntegration,
-	serverIntegration,
-	logsIntegration,
-}) => {
+export const SetupRouter = () => {
 	const { toggleShowBanner } = useGlobalContext()
+	const { data: serverIntegration } = useServerIntegrated()
+	const { data: clientIntegration } = useClientIntegrated()
+	const { data: logsIntegration } = useLogsIntegrated()
 	const areaMatch = useMatch('/:project_id/setup/:area/*')
 	const area = areaMatch?.params.area || 'client'
 	const integrationData =

--- a/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
@@ -10,11 +10,6 @@ import PlayerPage from '@pages/Player/PlayerPage'
 import ProjectSettings from '@pages/ProjectSettings/ProjectSettings'
 import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext'
 import { SetupRouter } from '@pages/Setup/SetupRouter/SetupRouter'
-import {
-	useClientIntegrated,
-	useLogsIntegrated,
-	useServerIntegrated,
-} from '@util/integrated'
 import { usePreloadErrors, usePreloadSessions } from '@util/preload'
 import React, { Suspense } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
@@ -22,17 +17,11 @@ import { Navigate, Route, Routes } from 'react-router-dom'
 const Buttons = React.lazy(() => import('../../pages/Buttons/Buttons'))
 const HitTargets = React.lazy(() => import('../../pages/Buttons/HitTargets'))
 
-export type IntegrationProps = {
-	clientIntegration?: ReturnType<typeof useClientIntegrated>['data']
-	serverIntegration?: ReturnType<typeof useServerIntegrated>['data']
-	logsIntegration?: ReturnType<typeof useLogsIntegrated>['data']
+interface Props {
+	integrated: boolean
 }
 
-const ApplicationRouter: React.FC<IntegrationProps> = ({
-	clientIntegration,
-	serverIntegration,
-	logsIntegration,
-}) => {
+const ApplicationRouter = ({ integrated }: Props) => {
 	const { page, backendSearchQuery } = useSearchContext()
 	const { page: errorPage, backendSearchQuery: errorBackendSearchQuery } =
 		useErrorSearchContext()
@@ -42,10 +31,6 @@ const ApplicationRouter: React.FC<IntegrationProps> = ({
 		backendSearchQuery: errorBackendSearchQuery,
 	})
 	const { isLoggedIn } = useAuthContext()
-	const integrated =
-		!!clientIntegration?.integrated ||
-		!!serverIntegration?.integrated ||
-		!!logsIntegration?.integrated
 
 	return (
 		<Routes>
@@ -69,16 +54,7 @@ const ApplicationRouter: React.FC<IntegrationProps> = ({
 					<Route path="alerts/*" element={<AlertsRouter />} />
 					<Route path="alerts/logs/*" element={<LogAlertsRouter />} />
 
-					<Route
-						path="setup/*"
-						element={
-							<SetupRouter
-								clientIntegration={clientIntegration}
-								serverIntegration={serverIntegration}
-								logsIntegration={logsIntegration}
-							/>
-						}
-					/>
+					<Route path="setup/*" element={<SetupRouter />} />
 
 					<Route
 						path="integrations/*"

--- a/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
@@ -24,11 +24,7 @@ import { GlobalContextProvider } from '@routers/ProjectRouter/context/GlobalCont
 import WithErrorSearchContext from '@routers/ProjectRouter/WithErrorSearchContext'
 import WithSessionSearchContext from '@routers/ProjectRouter/WithSessionSearchContext'
 import { auth } from '@util/auth'
-import {
-	useClientIntegrated,
-	useLogsIntegrated,
-	useServerIntegrated,
-} from '@util/integrated'
+import { useIntegrated } from '@util/integrated'
 import { isOnPrem } from '@util/onPrem/onPremUtils'
 import { useDialogState } from 'ariakit/dialog'
 import clsx from 'clsx'
@@ -47,6 +43,7 @@ export const ProjectRouter = () => {
 	const [showBanner, toggleShowBanner] = useToggle(false)
 
 	const { projectId } = useNumericProjectId()
+
 	const { setLoadingState } = useAppLoadingContext()
 
 	const { data, loading, error } = useGetProjectDropdownOptionsQuery({
@@ -54,20 +51,7 @@ export const ProjectRouter = () => {
 		skip: !isLoggedIn || !projectId, // Higher level routers decide when guests are allowed to hit this router
 	})
 
-	const { data: clientIntegration, loading: clientLoading } =
-		useClientIntegrated()
-	const { data: serverIntegration, loading: serverLoading } =
-		useServerIntegrated()
-	const { data: logsIntegration, loading: logsLoading } = useLogsIntegrated()
-	const fullyIntegrated =
-		!!clientIntegration?.integrated &&
-		!!serverIntegration?.integrated &&
-		!!logsIntegration?.integrated
-	const integrated =
-		!!clientIntegration?.integrated ||
-		!!serverIntegration?.integrated ||
-		!!logsIntegration?.integrated
-	const integrationLoading = clientLoading || serverLoading || logsLoading
+	const { integrated, loading: integratedLoading } = useIntegrated()
 
 	useEffect(() => {
 		const uri =
@@ -125,7 +109,7 @@ export const ProjectRouter = () => {
 		if (!error) {
 			setLoadingState((previousLoadingState) => {
 				if (previousLoadingState !== AppLoadingState.EXTENDED_LOADING) {
-					return loading || integrationLoading
+					return loading || integratedLoading
 						? AppLoadingState.LOADING
 						: AppLoadingState.LOADED
 				}
@@ -135,7 +119,7 @@ export const ProjectRouter = () => {
 		} else {
 			setLoadingState(AppLoadingState.LOADED)
 		}
-	}, [error, integrationLoading, loading, setLoadingState])
+	}, [error, integratedLoading, loading, setLoadingState])
 
 	// if the user can join this workspace, give them that option via the ErrorState
 	const joinableWorkspace = data?.joinable_workspaces
@@ -183,7 +167,7 @@ export const ProjectRouter = () => {
 
 	const commandBarDialog = useDialogState()
 
-	if (loading || integrationLoading) {
+	if (loading || integratedLoading) {
 		return null
 	}
 
@@ -217,12 +201,7 @@ export const ProjectRouter = () => {
 									path=":project_id/*"
 									element={
 										<>
-											<Header
-												integrated={integrated}
-												fullyIntegrated={
-													fullyIntegrated
-												}
-											/>
+											<Header />
 											<KeyboardShortcutsEducation />
 											<div
 												className={clsx(
@@ -256,15 +235,7 @@ export const ProjectRouter = () => {
 													/>
 												) : (
 													<ApplicationRouter
-														clientIntegration={
-															clientIntegration
-														}
-														serverIntegration={
-															serverIntegration
-														}
-														logsIntegration={
-															logsIntegration
-														}
+														integrated={integrated}
 													/>
 												)}
 											</div>


### PR DESCRIPTION
Reverts highlight/highlight#4841

This is causing the page to randomly refresh every 2 seconds. We have an [intercom](https://highlightcorp.slack.com/archives/C01EQU6G18R/p1680788184803689) and I was able to reproduce this locally.

Not sure what the actual root issue is but we can figure that after the revert is out.