### PR TITLE
update sql queries for backend integration checks

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4596,7 +4596,7 @@ func (r *queryResolver) ClientIntegration(ctx context.Context, projectID int) (*
 	}
 
 	firstSession := model.Session{}
-	err := r.DB.Model(&model.Session{}).Where("project_id = ?", projectID).First(&firstSession).Error
+	err := r.DB.Model(&model.Session{}).Where("project_id = ?", projectID).Limit(1).Find(&firstSession).Error
 	if e.Is(err, gorm.ErrRecordNotFound) {
 		return integration, nil
 	}
@@ -4622,7 +4622,7 @@ func (r *queryResolver) ServerIntegration(ctx context.Context, projectID int) (*
 	}
 
 	firstErrorGroup := model.ErrorGroup{}
-	err := r.DB.Model(&model.ErrorGroup{}).Where("project_id = ?", projectID).First(&firstErrorGroup).Error
+	err := r.DB.Model(&model.ErrorGroup{}).Where("project_id = ?", projectID).Limit(1).Find(&firstErrorGroup).Error
 	if e.Is(err, gorm.ErrRecordNotFound) {
 		return integration, nil
 	}
@@ -4649,7 +4649,7 @@ func (r *queryResolver) LogsIntegration(ctx context.Context, projectID int) (*mo
 	}
 
 	setupEvent := model.SetupEvent{}
-	err = r.DB.Model(&model.SetupEvent{}).Where("project_id = ? AND type = ?", projectID, model.MarkBackendSetupTypeLogs).First(&setupEvent).Error
+	err = r.DB.Model(&model.SetupEvent{}).Where("project_id = ? AND type = ?", projectID, model.MarkBackendSetupTypeLogs).Limit(1).Find(&setupEvent).Error
 	if err != nil {
 		if e.Is(err, gorm.ErrRecordNotFound) {
 			integration.Integrated = false


### PR DESCRIPTION
## Summary

Change backend integration checks from querying `.First` to `.Limit(1).Find` so that SQL queries are faster.

## How did you test this change?

```
-- old query
SELECT * FROM "error_groups" WHERE project_id = 1 ORDER BY "error_groups"."id" LIMIT 1

Limit  (cost=0.56..508.62 rows=1 width=1580) (actual time=33636.120..33636.120 rows=1 loops=1)
  ->  Index Scan using error_groups_pkey on error_groups  (cost=0.56..6014852.53 rows=11839 width=1580) (actual time=33636.119..33636.119 rows=1 loops=1)
        Filter: (project_id = 1344)
        Rows Removed by Filter: 34845309
Planning Time: 0.087 ms
Execution Time: 33636.140 ms

-- new query
SELECT * FROM "error_groups" WHERE project_id = 1 LIMIT 1

Limit  (cost=0.44..1.35 rows=1 width=1580) (actual time=0.049..0.049 rows=1 loops=1)
  ->  Index Scan using idx_error_groups_project_id on error_groups  (cost=0.44..10770.28 rows=11839 width=1580) (actual time=0.048..0.048 rows=1 loops=1)
        Index Cond: (project_id = 1344)
Planning Time: 0.088 ms
Execution Time: 0.071 ms
```

## Are there any deployment considerations?

No
