### PR TITLE
add support for implicit OR on duplicate attribute keys

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -485,64 +485,25 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 		}
 	}
 
-	if filters.level != "" {
-		if strings.Contains(filters.level, "%") {
-			sb.Where(sb.Like("SeverityText", filters.level))
-		} else {
-			sb.Where(sb.Equal("SeverityText", filters.level))
+	makeFilterConditions(sb, filters.level, "SeverityText")
+	makeFilterConditions(sb, filters.secure_session_id, "SecureSessionId")
+	makeFilterConditions(sb, filters.span_id, "SpanId")
+	makeFilterConditions(sb, filters.trace_id, "TraceId")
+	makeFilterConditions(sb, filters.source, "Source")
+	makeFilterConditions(sb, filters.service_name, "ServiceName")
+
+	conditions := []string{}
+	for key, values := range filters.attributes {
+		for _, value := range values {
+			if strings.Contains(value, "%") {
+				conditions = append(conditions, sb.Var(sqlbuilder.Buildf("LogAttributes[%s] LIKE %s", key, value)))
+			} else {
+				conditions = append(conditions, sb.Var(sqlbuilder.Buildf("LogAttributes[%s] = %s", key, value)))
+			}
 		}
 	}
-
-	if filters.secure_session_id != "" {
-		if strings.Contains(filters.secure_session_id, "%") {
-			sb.Where(sb.Like("SecureSessionId", filters.secure_session_id))
-		} else {
-			sb.Where(sb.Equal("SecureSessionId", filters.secure_session_id))
-		}
-	}
-
-	if filters.span_id != "" {
-		if strings.Contains(filters.span_id, "%") {
-			sb.Where(sb.Like("SpanId", filters.span_id))
-		} else {
-			sb.Where(sb.Equal("SpanId", filters.span_id))
-		}
-	}
-
-	if filters.trace_id != "" {
-		if strings.Contains(filters.trace_id, "%") {
-			sb.Where(sb.Like("TraceId", filters.trace_id))
-		} else {
-			sb.Where(sb.Equal("TraceId", filters.trace_id))
-		}
-	}
-
-	if filters.source != "" {
-		if strings.Contains(filters.source, "%") {
-			sb.Where(sb.Like("Source", filters.source))
-		} else {
-			sb.Where(sb.Equal("Source", filters.source))
-		}
-	}
-
-	if filters.service_name != "" {
-		if strings.Contains(filters.service_name, "%") {
-			sb.Where(sb.Like("ServiceName", filters.service_name))
-		} else {
-			sb.Where(sb.Equal("ServiceName", filters.service_name))
-		}
-	}
-
-	for key, value := range filters.attributes {
-		if strings.Contains(value, "%") {
-			sb.Where(
-				sb.Var(sqlbuilder.Buildf("LogAttributes[%s] LIKE %s", key, value)),
-			)
-		} else {
-			sb.Where(
-				sb.Var(sqlbuilder.Buildf("LogAttributes[%s] = %s", key, value)),
-			)
-		}
+	if len(conditions) > 0 {
+		sb.Where(sb.Or(conditions...))
 	}
 
 	return sb, nil
@@ -550,18 +511,18 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 
 type filters struct {
 	body              []string
-	level             string
-	trace_id          string
-	span_id           string
-	secure_session_id string
-	source            string
-	service_name      string
-	attributes        map[string]string
+	level             []string
+	trace_id          []string
+	span_id           []string
+	secure_session_id []string
+	source            []string
+	service_name      []string
+	attributes        map[string][]string
 }
 
 func makeFilters(query string) filters {
 	filters := filters{
-		attributes: make(map[string]string),
+		attributes: make(map[string][]string),
 	}
 
 	queries := splitQuery(query)
@@ -586,19 +547,19 @@ func makeFilters(query string) filters {
 
 			switch key {
 			case modelInputs.ReservedLogKeyLevel.String():
-				filters.level = wildcardValue
+				filters.level = append(filters.level, wildcardValue)
 			case modelInputs.ReservedLogKeySecureSessionID.String():
-				filters.secure_session_id = wildcardValue
+				filters.secure_session_id = append(filters.secure_session_id, wildcardValue)
 			case modelInputs.ReservedLogKeySpanID.String():
-				filters.span_id = wildcardValue
+				filters.span_id = append(filters.span_id, wildcardValue)
 			case modelInputs.ReservedLogKeyTraceID.String():
-				filters.trace_id = wildcardValue
+				filters.trace_id = append(filters.trace_id, wildcardValue)
 			case modelInputs.ReservedLogKeySource.String():
-				filters.source = wildcardValue
+				filters.source = append(filters.source, wildcardValue)
 			case modelInputs.ReservedLogKeyServiceName.String():
-				filters.service_name = wildcardValue
+				filters.service_name = append(filters.service_name, wildcardValue)
 			default:
-				filters.attributes[key] = wildcardValue
+				filters.attributes[key] = append(filters.attributes[key], wildcardValue)
 			}
 		}
 	}
@@ -608,6 +569,21 @@ func makeFilters(query string) filters {
 
 func isSeparator(r rune) bool {
 	return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+}
+
+func makeFilterConditions(sb *sqlbuilder.SelectBuilder, filters []string, column string) {
+	conditions := []string{}
+	for _, filter := range filters {
+		if strings.Contains(filter, "%") {
+			conditions = append(conditions, sb.Like(column, filter))
+		} else {
+			conditions = append(conditions, sb.Equal(column, filter))
+		}
+	}
+
+	if len(conditions) > 0 {
+		sb.Where(sb.Or(conditions...))
+	}
 }
 
 // Splits the query by spaces _unless_ it is quoted

--- a/docs-content/general/6_product-features/4_logging/log-search.md
+++ b/docs-content/general/6_product-features/4_logging/log-search.md
@@ -44,7 +44,17 @@ log.info({
 We can search for it via:
 
 - `user_id:42` matches every log where `user_id` is `42`
-- `level:info` matches every log with level `info`
+- `level:info` matches every log where `level` is `info`
+
+#### AND vs OR
+
+When multiple attributes are included, they work as an `AND` operator:
+
+- `user_id:42 level:info` - matches every log where `user_id` is `42` _and_ `level` is `info`
+
+When the same attribute is included twice in a search, it works as an `OR` operator:
+
+- `user_id:42 level:info level:warn` - matches every log where `user_id` is `42` _and_ (`level` is `info` _or_ `level` is `warn`)
 
 ### Wildcard search
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR adds support for doing an implicit OR on attribute when the attribute is included more than once (e.g. `level:info level:warn`)

Docs have been added for this behavior:

![Screenshot 2023-04-07 at 8 52 52 AM](https://user-images.githubusercontent.com/58678/230629426-cf8244cf-d698-4c2d-afcd-c2851e4465ca.png)



## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Verified it works `level` (uses the `SeverityText` column)

<img width="846" alt="Screenshot 2023-04-06 at 9 20 07 PM" src="https://user-images.githubusercontent.com/58678/230534593-64c97d12-5bf7-4c23-83af-5a39ce84269e.png">


Verified it works on `span_id` (uses the `SpanId` column)

<img width="1014" alt="Screenshot 2023-04-06 at 9 22 27 PM" src="https://user-images.githubusercontent.com/58678/230534583-8648d41f-d4ce-451f-91fc-f44b57db68ab.png">


Verified it works on an arbitrary key (which uses the `LogAttributes` map column)

<img width="1340" alt="Screenshot 2023-04-06 at 9 39 16 PM" src="https://user-images.githubusercontent.com/58678/230536212-cff1f282-5566-41ff-a100-b29a058c9dce.png">

This should also work for `secure_session_id`, `trace_id`, `source`, and `service_name` (confirmed via tests).

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
