### PR TITLE
add config files for log-alerts service deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -256,6 +256,20 @@ jobs:
                   task-definition: ${{ steps.image-metric-monitor.outputs.task-definition }}
                   service: metric-monitor
                   cluster: highlight-production-cluster
+            # Edit and deploy log alerts
+            - name: Replace image label for log alerts task
+              id: image-log-alerts
+              uses: aws-actions/amazon-ecs-render-task-definition@v1
+              with:
+                  task-definition: deploy/log-alerts-task.json
+                  container-name: highlight-backend
+                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+            - name: Deploy to Amazon ECS log alerts service
+              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+              with:
+                  task-definition: ${{ steps.image-log-alerts.outputs.task-definition }}
+                  service: log-alerts-service
+                  cluster: highlight-production-cluster
             # Edit and deploy public worker
             - name: Replace image label for public worker service
               id: image-public-worker

--- a/backend/jobs/log-alerts/log-alerts.go
+++ b/backend/jobs/log-alerts/log-alerts.go
@@ -79,8 +79,9 @@ func WatchLogAlerts(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, MailCli
 			})
 	}
 
-	if g.Wait() != nil {
-		log.WithContext(ctx).Error(g.Wait())
+	err := g.Wait()
+	if err != nil {
+		log.WithContext(ctx).Error(err)
 	}
 }
 

--- a/deploy/log-alerts-task.json
+++ b/deploy/log-alerts-task.json
@@ -1,0 +1,283 @@
+{
+	"ipcMode": null,
+	"executionRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"containerDefinitions": [
+		{
+			"dnsSearchDomains": null,
+			"environmentFiles": null,
+			"logConfiguration": {
+				"logDriver": "awslogs",
+				"secretOptions": null,
+				"options": {
+					"awslogs-group": "/ecs/log-alerts-task",
+					"awslogs-region": "us-east-2",
+					"awslogs-stream-prefix": "ecs"
+				}
+			},
+			"entryPoint": null,
+			"portMappings": [],
+			"command": null,
+			"linuxParameters": null,
+			"cpu": 0,
+			"environment": [
+				{
+					"name": "DD_APM_ENABLED",
+					"value": "true"
+				},
+				{
+					"name": "ECS_FARGATE",
+					"value": "true"
+				}
+			],
+			"resourceRequirements": null,
+			"ulimits": null,
+			"dnsServers": null,
+			"mountPoints": [],
+			"workingDirectory": null,
+			"secrets": [
+				{
+					"valueFrom": "DD_API_KEY",
+					"name": "DD_API_KEY"
+				}
+			],
+			"dockerSecurityOptions": null,
+			"memory": null,
+			"memoryReservation": null,
+			"volumesFrom": [],
+			"stopTimeout": null,
+			"image": "datadog/agent:latest",
+			"startTimeout": null,
+			"firelensConfiguration": null,
+			"dependsOn": null,
+			"disableNetworking": null,
+			"interactive": null,
+			"healthCheck": null,
+			"essential": true,
+			"links": null,
+			"hostname": null,
+			"extraHosts": null,
+			"pseudoTerminal": null,
+			"user": null,
+			"readonlyRootFilesystem": null,
+			"dockerLabels": null,
+			"systemControls": null,
+			"privileged": null,
+			"name": "datadog-agent"
+		},
+		{
+			"dnsSearchDomains": null,
+			"environmentFiles": null,
+			"entryPoint": null,
+			"logConfiguration": {
+				"logDriver": "awslogs",
+				"options": {
+					"awslogs-group": "/ecs/log-alerts-task",
+					"awslogs-region": "us-east-2",
+					"awslogs-stream-prefix": "ecs"
+				}
+			},
+			"portMappings": [
+				{
+					"hostPort": 8082,
+					"protocol": "tcp",
+					"containerPort": 8082
+				}
+			],
+			"command": [
+				"doppler",
+				"run",
+				"--",
+				"/bin/backend",
+				"-runtime=worker",
+				"-worker-handler=log-alerts"
+			],
+			"linuxParameters": null,
+			"cpu": 0,
+			"environment": [],
+			"resourceRequirements": null,
+			"ulimits": null,
+			"dnsServers": null,
+			"mountPoints": [],
+			"workingDirectory": null,
+			"secrets": [
+				{
+					"valueFrom": "DOPPLER_TOKEN",
+					"name": "DOPPLER_TOKEN"
+				}
+			],
+			"dockerSecurityOptions": null,
+			"memory": null,
+			"memoryReservation": null,
+			"volumesFrom": [],
+			"stopTimeout": null,
+			"image": "173971919437.dkr.ecr.us-east-2.amazonaws.com/highlight-production-ecr-repo:12cbccd09345f7eb72224b9f809bc80edea821e6",
+			"startTimeout": null,
+			"firelensConfiguration": null,
+			"dependsOn": null,
+			"disableNetworking": null,
+			"interactive": null,
+			"healthCheck": null,
+			"essential": true,
+			"links": null,
+			"hostname": null,
+			"extraHosts": null,
+			"pseudoTerminal": null,
+			"user": null,
+			"readonlyRootFilesystem": null,
+			"dockerLabels": null,
+			"systemControls": null,
+			"privileged": null,
+			"name": "highlight-backend"
+		},
+		{
+			"dnsSearchDomains": null,
+			"environmentFiles": null,
+			"logConfiguration": {
+				"logDriver": "awslogs",
+				"secretOptions": null,
+				"options": {
+					"awslogs-group": "/ecs/log-alerts-task",
+					"awslogs-region": "us-east-2",
+					"awslogs-stream-prefix": "ecs"
+				}
+			},
+			"entryPoint": null,
+			"portMappings": [],
+			"command": null,
+			"linuxParameters": null,
+			"cpu": 0,
+			"environment": [],
+			"resourceRequirements": null,
+			"ulimits": null,
+			"dnsServers": null,
+			"mountPoints": [],
+			"workingDirectory": null,
+			"secrets": null,
+			"dockerSecurityOptions": null,
+			"memory": null,
+			"memoryReservation": null,
+			"volumesFrom": [],
+			"stopTimeout": null,
+			"image": "906394416424.dkr.ecr.us-east-2.amazonaws.com/aws-for-fluent-bit:stable",
+			"startTimeout": null,
+			"firelensConfiguration": null,
+			"dependsOn": null,
+			"disableNetworking": null,
+			"interactive": null,
+			"healthCheck": null,
+			"essential": true,
+			"links": null,
+			"hostname": null,
+			"extraHosts": null,
+			"pseudoTerminal": null,
+			"user": "0",
+			"readonlyRootFilesystem": null,
+			"dockerLabels": null,
+			"systemControls": null,
+			"privileged": null,
+			"name": "log_router"
+		}
+	],
+	"placementConstraints": [],
+	"memory": "4096",
+	"taskRoleArn": "arn:aws:iam::173971919437:role/ecsTaskExecutionRole",
+	"compatibilities": ["EC2", "FARGATE"],
+	"taskDefinitionArn": "arn:aws:ecs:us-east-2:173971919437:task-definition/worker-task:40",
+	"family": "log-alerts-task",
+	"requiresAttributes": [
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "ecs.capability.execution-role-awslogs"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "com.amazonaws.ecs.capability.ecr-auth"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "com.amazonaws.ecs.capability.logging-driver.awsfirelens"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "com.amazonaws.ecs.capability.task-iam-role"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "ecs.capability.execution-role-ecr-pull"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "ecs.capability.secrets.ssm.environment-variables"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "ecs.capability.task-eni"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "ecs.capability.efsAuth"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "ecs.capability.firelens.fluentbit"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "ecs.capability.efs"
+		},
+		{
+			"targetId": null,
+			"targetType": null,
+			"value": null,
+			"name": "com.amazonaws.ecs.capability.docker-remote-api.1.25"
+		}
+	],
+	"pidMode": null,
+	"requiresCompatibilities": ["FARGATE"],
+	"networkMode": "awsvpc",
+	"cpu": "1024",
+	"revision": 40,
+	"status": "ACTIVE",
+	"inferenceAccelerators": null,
+	"proxyConfiguration": null,
+	"volumes": [],
+	"runtimePlatform": { "cpuArchitecture": "ARM64" }
+}


### PR DESCRIPTION
## Summary
- task definitions / service were manually set up in ECS console, make it part of the deployment
- use `errgroup` to prevent log alert watcher from exiting
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested `make start-log-alerts-watch` locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- nope
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
