### PR TITLE
Create dedicated endpoint for loading session logs

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -825,6 +825,7 @@ type ComplexityRoot struct {
 		SessionCommentsForProject    func(childComplexity int, projectID int) int
 		SessionFeedbackAlerts        func(childComplexity int, projectID int) int
 		SessionIntervals             func(childComplexity int, sessionSecureID string) int
+		SessionLogs                  func(childComplexity int, projectID int, params model.LogsParamsInput) int
 		SessionsHistogram            func(childComplexity int, projectID int, query string, histogramOptions model.DateHistogramOptions) int
 		SessionsOpensearch           func(childComplexity int, projectID int, count int, query string, sortDesc bool, page *int) int
 		SlackChannelSuggestion       func(childComplexity int, projectID int) int
@@ -1430,6 +1431,7 @@ type QueryResolver interface {
 	OauthClientMetadata(ctx context.Context, clientID string) (*model.OAuthClient, error)
 	EmailOptOuts(ctx context.Context, token *string, adminID *int) ([]model.EmailOptOutCategory, error)
 	Logs(ctx context.Context, projectID int, params model.LogsParamsInput, after *string, before *string, at *string, direction model.LogDirection) (*model.LogsConnection, error)
+	SessionLogs(ctx context.Context, projectID int, params model.LogsParamsInput) ([]*model.LogEdge, error)
 	LogsTotalCount(ctx context.Context, projectID int, params model.LogsParamsInput) (uint64, error)
 	LogsHistogram(ctx context.Context, projectID int, params model.LogsParamsInput) (*model.LogsHistogram, error)
 	LogsKeys(ctx context.Context, projectID int, dateRange model.DateRangeRequiredInput) ([]*model.LogKey, error)
@@ -6181,6 +6183,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.SessionIntervals(childComplexity, args["session_secure_id"].(string)), true
 
+	case "Query.sessionLogs":
+		if e.complexity.Query.SessionLogs == nil {
+			break
+		}
+
+		args, err := ec.field_Query_sessionLogs_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.SessionLogs(childComplexity, args["project_id"].(int), args["params"].(model.LogsParamsInput)), true
+
 	case "Query.sessions_histogram":
 		if e.complexity.Query.SessionsHistogram == nil {
 			break
@@ -9693,6 +9707,7 @@ type Query {
 		at: String
 		direction: LogDirection!
 	): LogsConnection!
+	sessionLogs(project_id: ID!, params: LogsParamsInput!): [LogEdge!]!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_histogram(project_id: ID!, params: LogsParamsInput!): LogsHistogram!
 	logs_keys(project_id: ID!, date_range: DateRangeRequiredInput!): [LogKey!]!
@@ -14751,6 +14766,30 @@ func (ec *executionContext) field_Query_serverIntegration_args(ctx context.Conte
 		}
 	}
 	args["project_id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_sessionLogs_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 model.LogsParamsInput
+	if tmp, ok := rawArgs["params"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+		arg1, err = ec.unmarshalNLogsParamsInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogsParamsInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["params"] = arg1
 	return args, nil
 }
 
@@ -45295,6 +45334,66 @@ func (ec *executionContext) fieldContext_Query_logs(ctx context.Context, field g
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_sessionLogs(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_sessionLogs(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().SessionLogs(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.LogsParamsInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.LogEdge)
+	fc.Result = res
+	return ec.marshalNLogEdge2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐLogEdgeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_sessionLogs(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_LogEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_LogEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type LogEdge", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_sessionLogs_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_logs_total_count(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_logs_total_count(ctx, field)
 	if err != nil {
@@ -66114,6 +66213,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_logs(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "sessionLogs":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_sessionLogs(ctx, field)
 				return res
 			}
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1562,6 +1562,7 @@ type Query {
 		at: String
 		direction: LogDirection!
 	): LogsConnection!
+	sessionLogs(project_id: ID!, params: LogsParamsInput!): [LogEdge!]!
 	logs_total_count(project_id: ID!, params: LogsParamsInput!): UInt64!
 	logs_histogram(project_id: ID!, params: LogsParamsInput!): LogsHistogram!
 	logs_keys(project_id: ID!, date_range: DateRangeRequiredInput!): [LogKey!]!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7186,6 +7186,16 @@ func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInp
 	})
 }
 
+// SessionLogs is the resolver for the sessionLogs field.
+func (r *queryResolver) SessionLogs(ctx context.Context, projectID int, params modelInputs.LogsParamsInput) ([]*modelInputs.LogEdge, error) {
+	project, err := r.isAdminInProject(ctx, projectID)
+	if err != nil {
+		return nil, e.Wrap(err, "error querying project")
+	}
+
+	return r.ClickhouseClient.ReadSessionLogs(ctx, project.ID, params)
+}
+
 // LogsTotalCount is the resolver for the logs_total_count field.
 func (r *queryResolver) LogsTotalCount(ctx context.Context, projectID int, params modelInputs.LogsParamsInput) (uint64, error) {
 	project, err := r.isAdminInProject(ctx, projectID)

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -12179,6 +12179,68 @@ export type GetLogsQueryResult = Apollo.QueryResult<
 	Types.GetLogsQuery,
 	Types.GetLogsQueryVariables
 >
+export const GetSessionLogsDocument = gql`
+	query GetSessionLogs($project_id: ID!, $params: LogsParamsInput!) {
+		sessionLogs(project_id: $project_id, params: $params) {
+			cursor
+			node {
+				timestamp
+				level
+				message
+			}
+		}
+	}
+`
+
+/**
+ * __useGetSessionLogsQuery__
+ *
+ * To run a query within a React component, call `useGetSessionLogsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetSessionLogsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetSessionLogsQuery({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *      params: // value for 'params'
+ *   },
+ * });
+ */
+export function useGetSessionLogsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSessionLogsQuery,
+		Types.GetSessionLogsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSessionLogsQuery,
+		Types.GetSessionLogsQueryVariables
+	>(GetSessionLogsDocument, baseOptions)
+}
+export function useGetSessionLogsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSessionLogsQuery,
+		Types.GetSessionLogsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSessionLogsQuery,
+		Types.GetSessionLogsQueryVariables
+	>(GetSessionLogsDocument, baseOptions)
+}
+export type GetSessionLogsQueryHookResult = ReturnType<
+	typeof useGetSessionLogsQuery
+>
+export type GetSessionLogsLazyQueryHookResult = ReturnType<
+	typeof useGetSessionLogsLazyQuery
+>
+export type GetSessionLogsQueryResult = Apollo.QueryResult<
+	Types.GetSessionLogsQuery,
+	Types.GetSessionLogsQueryVariables
+>
 export const GetLogsTotalCountDocument = gql`
 	query GetLogsTotalCount($project_id: ID!, $params: LogsParamsInput!) {
 		logs_total_count(project_id: $project_id, params: $params)

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4196,6 +4196,22 @@ export type GetLogsQuery = { __typename?: 'Query' } & {
 	}
 }
 
+export type GetSessionLogsQueryVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+	params: Types.LogsParamsInput
+}>
+
+export type GetSessionLogsQuery = { __typename?: 'Query' } & {
+	sessionLogs: Array<
+		{ __typename?: 'LogEdge' } & Pick<Types.LogEdge, 'cursor'> & {
+				node: { __typename?: 'Log' } & Pick<
+					Types.Log,
+					'timestamp' | 'level' | 'message'
+				>
+			}
+	>
+}
+
 export type GetLogsTotalCountQueryVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	params: Types.LogsParamsInput
@@ -4388,6 +4404,7 @@ export const namedOperations = {
 		GetErrorGroupTags: 'GetErrorGroupTags' as const,
 		GetEmailOptOuts: 'GetEmailOptOuts' as const,
 		GetLogs: 'GetLogs' as const,
+		GetSessionLogs: 'GetSessionLogs' as const,
 		GetLogsTotalCount: 'GetLogsTotalCount' as const,
 		GetLogsHistogram: 'GetLogsHistogram' as const,
 		GetLogsKeys: 'GetLogsKeys' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1589,6 +1589,7 @@ export type Query = {
 	segments?: Maybe<Array<Maybe<Segment>>>
 	serverIntegration: IntegrationStatus
 	session?: Maybe<Session>
+	sessionLogs: Array<LogEdge>
 	session_comment_tags_for_project: Array<SessionCommentTag>
 	session_comments: Array<Maybe<SessionComment>>
 	session_comments_for_admin: Array<Maybe<SessionComment>>
@@ -2054,6 +2055,11 @@ export type QueryServerIntegrationArgs = {
 
 export type QuerySessionArgs = {
 	secure_id: Scalars['String']
+}
+
+export type QuerySessionLogsArgs = {
+	params: LogsParamsInput
+	project_id: Scalars['ID']
 }
 
 export type QuerySession_Comment_Tags_For_ProjectArgs = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2028,6 +2028,17 @@ query GetLogs(
 	}
 }
 
+query GetSessionLogs($project_id: ID!, $params: LogsParamsInput!) {
+	sessionLogs(project_id: $project_id, params: $params) {
+		cursor
+		node {
+			timestamp
+			level
+			message
+		}
+	}
+}
+
 query GetLogsTotalCount($project_id: ID!, $params: LogsParamsInput!) {
 	logs_total_count(project_id: $project_id, params: $params)
 }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR creates a dedicated endpoint for session logs. Unlike the log viewer that has to handle pagination, session logs are more well scoped. Specifically they:

* have a `secure_session_id` to filter on
* are [confined to a 4 hour window ](https://github.com/highlight/highlight/blob/et/session-logs-endpoint/frontend/src/pages/LogsPage/SearchForm/utils.ts#L126-L127)

Because it's more well scoped, it can avoid limitations of dealing with pagination (very unpredictable with virtualized lists).

Additionally, session logs do not need `LogAttributes` which is a very heavy column. A previous [observation](https://gist.github.com/et/bd25c44fd04b64bd76a0e35853e8cb3b) has noticed that omitting this column speeds up queries.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

### Performance tests

Using a [30 minute session](https://app.highlight.io/1/sessions/6T5zO03EWSN4OBoblLfLBtTkxAQq), I generated this query on prod:

```sql
select Timestamp, SeverityText, Body from logs where SecureSessionId = '6T5zO03EWSN4OBoblLfLBtTkxAQq' and ProjectId = 1 and Timestamp >= '2023-04-06 20:28:57'  
```

where `2023-04-06 20:28:57` is the session start time (in UTC).

The above query returns 5,279 rows and takes 0.325s which is an acceptable duration to load all of this session's logs.

### Unit tests

I did add tests to confirm:

* we aren't respecting `LogLimit`
* we aren't loading `LogAttributes`


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

This is only the backend piece. A frontend PR will follow that will leverage this but we want this to be deployed first so we can test this endpoint with a render preview.
