### PR TITLE
remove javascript from session events

### DIFF
--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -272,8 +272,6 @@ func escapeNodeScriptTags(ctx context.Context, node map[string]interface{}) {
 			}
 		}
 	}
-
-	return
 }
 
 func escapeNodeWithJSAttrs(ctx context.Context, node map[string]interface{}) {
@@ -300,8 +298,6 @@ func escapeNodeWithJSAttrs(ctx context.Context, node map[string]interface{}) {
 			}
 		}
 	}
-
-	return
 }
 
 // InjectStylesheets injects custom stylesheets into a given snapshot event.

--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -237,13 +237,11 @@ func escapeNodeScriptTags(ctx context.Context, node map[string]interface{}) {
 		return
 	}
 
-	var childNodes []interface{}
 	for _, c := range node["childNodes"].([]interface{}) {
 		if child, ok := c.(map[string]interface{}); ok {
 			if txt, txtOk := child["textContent"]; txtOk {
-				if txt == ScriptPlaceholder {
-					childNodes = append(childNodes, c)
-				} else {
+				if txt != ScriptPlaceholder {
+					child["textContent"] = ScriptPlaceholder
 					log.WithContext(ctx).
 						WithField("node", node).
 						WithField("TextContent", txt).
@@ -252,7 +250,6 @@ func escapeNodeScriptTags(ctx context.Context, node map[string]interface{}) {
 			}
 		}
 	}
-	node["childNodes"] = childNodes
 }
 
 func escapeNodeWithJSAttrs(ctx context.Context, node map[string]interface{}) {
@@ -274,7 +271,8 @@ func escapeNodeWithJSAttrs(ctx context.Context, node map[string]interface{}) {
 						WithField("disallowedTagAttribute", key).
 						WithField("value", value).
 						Warnf("potential js attack, dropping disallowed attribute on session events tag")
-					delete(a, key)
+					a[key] = ScriptPlaceholder
+					break
 				}
 			}
 		}

--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -74,17 +74,12 @@ const (
 	ScriptPlaceholder = "SCRIPT_PLACEHOLDER"
 )
 
-var DisallowedScriptAttributes = []string{
-	"src",
-	"srcset",
-}
-
 var DisallowedTagPrefixes = []string{
-	"onload",
+	"onchange",
 	"onclick",
-	"onmouse",
 	"onkey",
-	"src",
+	"onload",
+	"onmouse",
 }
 
 var ResourcesBasePath = os.Getenv("RESOURCES_BASE_PATH")
@@ -258,20 +253,6 @@ func escapeNodeScriptTags(ctx context.Context, node map[string]interface{}) {
 		}
 	}
 	node["childNodes"] = childNodes
-
-	if a, attributesOk := node["attributes"].(map[string]interface{}); attributesOk {
-		for _, badAttr := range DisallowedScriptAttributes {
-			if src, srcOk := a[badAttr]; srcOk {
-				log.WithContext(ctx).
-					WithField("node", node).
-					WithField("src", src).
-					WithField("tagName", tagName).
-					WithField("disallowedScriptAttribute", badAttr).
-					Warnf("potential js attack, dropping disallowed attribute on session events script tag")
-				delete(a, badAttr)
-			}
-		}
-	}
 }
 
 func escapeNodeWithJSAttrs(ctx context.Context, node map[string]interface{}) {

--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -188,7 +188,4 @@ func TestEscapeJavascript(t *testing.T) {
 	if strings.Contains(str, "attack") {
 		t.Errorf("attack substring not escaped %+v", str)
 	}
-	if strings.Contains(str, "vadweb.us") {
-		t.Errorf("src substring not escaped %+v", str)
-	}
 }

--- a/backend/event-parse/sample-events/dom-with-scripts.json
+++ b/backend/event-parse/sample-events/dom-with-scripts.json
@@ -1,0 +1,173 @@
+{
+	"session_secure_id": "a1b2c3d400000001",
+	"messages": "{\"messages\": []}",
+	"resources": "{\"resources\": []}",
+	"errors": [],
+	"events": {
+		"events": [
+			{
+				"_sid": 1,
+				"data": {
+					"height": 1336,
+					"href": "https://app.highlight.io/",
+					"width": 2560
+				},
+				"timestamp": 1680823363609,
+				"type": 4
+			},
+			{
+				"_sid": 2,
+				"data": {
+					"initialOffset": {
+						"left": 0,
+						"top": 0
+					},
+					"node": {
+						"childNodes": [
+							{
+								"id": 2,
+								"name": "html",
+								"publicId": "",
+								"systemId": "",
+								"type": 1
+							},
+							{
+								"attributes": {
+									"lang": "en"
+								},
+								"childNodes": [
+									{
+										"attributes": {},
+										"childNodes": [
+											{
+												"id": 5,
+												"textContent": "\n\t\t",
+												"type": 3
+											},
+											{
+												"attributes": {
+													"href": "https://app.highlight.io/"
+												},
+												"childNodes": [
+													{
+														"attributes": {
+															"src": "https://vadweb.us/"
+														},
+														"childNodes": [],
+														"id": 7,
+														"tagName": "script",
+														"type": 2
+													},
+													{
+														"attributes": {
+															"async": ""
+														},
+														"childNodes": [
+															{
+																"id": 10,
+																"textContent": "console.log('script tag attack');",
+																"type": 3
+															}
+														],
+														"id": 7,
+														"tagName": "script",
+														"type": 2
+													}
+												],
+												"id": 6,
+												"tagName": "base",
+												"type": 2
+											}
+										],
+										"id": 4,
+										"tagName": "head",
+										"type": 2
+									},
+									{
+										"attributes": {},
+										"childNodes": [
+											{
+												"attributes": {
+													"onclick": "console.log('button attack')"
+												},
+												"childNodes": [
+													{
+														"id": 13,
+														"textContent": "hello;",
+														"type": 3
+													}
+												],
+												"id": 12,
+												"tagName": "button",
+												"type": 2
+											},
+											{
+												"attributes": {
+													"onkeydown": "console.log('keydown attack')"
+												},
+												"childNodes": [
+													{
+														"id": 15,
+														"textContent": "hello;",
+														"type": 3
+													}
+												],
+												"id": 14,
+												"tagName": "input",
+												"type": 2
+											}
+										],
+										"id": 11,
+										"tagName": "body",
+										"type": 2
+									}
+								],
+								"id": 3,
+								"tagName": "html",
+								"type": 2
+							}
+						],
+						"id": 1,
+						"type": 0
+					}
+				},
+				"timestamp": 1680823363650,
+				"type": 2
+			},
+			{
+				"_sid": 3,
+				"data": {
+					"adds": [
+						{
+							"nextId": null,
+							"node": {
+								"attributes": {
+									"src": "https://vadweb.us"
+								},
+								"childNodes": [],
+								"id": 9,
+								"tagName": "script",
+								"type": 2
+							},
+							"parentId": 7
+						}
+					],
+					"attributes": [
+						{
+							"attributes": {
+								"onclick": "console.log('button update attack')",
+								"src": "https://vadweb.us"
+							},
+							"id": 12
+						}
+					],
+					"removes": [],
+					"source": 0,
+					"texts": []
+				},
+				"timestamp": 1680823374771,
+				"type": 3
+			}
+		]
+	}
+}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2744,7 +2744,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 						if err != nil {
 							log.WithContext(ctx).Error(e.Wrap(err, "Error unmarshalling incremental event"))
 						}
-						if userEvent, _ := map[parse.EventSource]bool{
+						if userEvent := map[parse.EventSource]bool{
 							parse.MouseMove: true, parse.MouseInteraction: true, parse.Scroll: true,
 							parse.Input: true, parse.TouchMove: true, parse.Drag: true,
 						}[*mouseInteractionEventData.Source]; userEvent {


### PR DESCRIPTION
## Summary

Adds an additional guard rail to our events ingest to ensure javascript injection is not possible.
For more details, see [slack](https://highlightcorp.slack.com/archives/C0524MRA4NA/p1680904810669179).

## How did you test this change?

Adds a new unit test for parsing events.

Validated that sessions are recorded correctly locally.
<img width="1397" alt="Screenshot 2023-04-07 at 2 57 05 PM" src="https://user-images.githubusercontent.com/1351531/230683960-99c3b397-1a6c-4ff1-bd2f-223817ba04d2.png">

Validated that the existing issue is fixed (javascript is removed server-side).
<img width="1260" alt="Screenshot 2023-04-07 at 2 56 11 PM" src="https://user-images.githubusercontent.com/1351531/230683864-03270ef0-fd35-4644-92bd-c222461a22ba.png">

## Are there any deployment considerations?

Will monitor rollout to ensure sessions recorded correctly.
