### PR TITLE
fix tracer panics on graphql parsing errors

### DIFF
--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -63,9 +63,6 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	}
 	span, ctx := tracer.StartSpanFromContext(ctx, "graphql.operation", tracer.ResourceName(opName))
 	span.SetTag("backend", t.serverType)
-	if oc != nil {
-		span.SetTag("size", len(oc.RawQuery))
-	}
 	defer span.Finish()
 	resp := next(ctx)
 	if resp.Errors != nil {

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -51,16 +51,21 @@ func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 }
 
 func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
-	rc := graphql.GetOperationContext(ctx)
+	var oc *graphql.OperationContext
+	if graphql.HasOperationContext(ctx) {
+		oc = graphql.GetOperationContext(ctx)
+	}
 	// NOTE: This gets called for the first time at the highest level. Creates the 'tracing' value, calls the next handler
 	// and returns the response.
 	opName := "undefined"
-	if rc != nil && rc.Operation != nil {
-		opName = rc.OperationName
+	if oc != nil {
+		opName = oc.OperationName
 	}
 	span, ctx := tracer.StartSpanFromContext(ctx, "graphql.operation", tracer.ResourceName(opName))
 	span.SetTag("backend", t.serverType)
-	span.SetTag("size", len(rc.RawQuery))
+	if oc != nil {
+		span.SetTag("size", len(oc.RawQuery))
+	}
 	defer span.Finish()
 	resp := next(ctx)
 	if resp.Errors != nil {

--- a/sdk/highlight-go/highlight_test.go
+++ b/sdk/highlight-go/highlight_test.go
@@ -113,7 +113,7 @@ func TestTracer(t *testing.T) {
 
 		a := flush()
 		// size, duration, errorsCount, fields duration
-		if len(a) != 4 {
+		if len(a) != 3 {
 			t.Errorf("flush returned the wrong number of metrics [%v != %v]", len(a), 4)
 			return
 		}

--- a/sdk/highlight-go/tracer.go
+++ b/sdk/highlight-go/tracer.go
@@ -83,11 +83,10 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 		oc = graphql.GetOperationContext(ctx)
 	}
 	opName := "undefined"
-	name := fmt.Sprintf("graphql.operation.%s", opName)
 	if oc != nil {
 		opName = oc.OperationName
-		RecordMetric(ctx, name+".size", float64(len(oc.RawQuery)))
 	}
+	name := fmt.Sprintf("graphql.operation.%s", opName)
 
 	span, ctx := StartTrace(ctx, name)
 	start := graphql.Now()


### PR DESCRIPTION
## Summary

`graphql.GetOperationContext` panics when there is no operation context.
When a graphql input validation error happens (eg. when someone sends us a request with
an invalid schema), the graphql input parsing layer throws an error leading to the operation context
being omitted. The result is a panic when we try and get the operation context.
Wrapping the operation with a check for the context fixes the panic and correctly responds
to the user with the error and expected 422 http code.

## How did you test this change?

Local postman sending invalid requests.

Before
<img width="1202" alt="Screenshot 2023-04-07 at 3 05 22 PM" src="https://user-images.githubusercontent.com/1351531/230684681-9f004faa-e06b-437e-b0f1-29b6e721d00f.png">

After
<img width="1363" alt="Screenshot 2023-04-07 at 3 04 53 PM" src="https://user-images.githubusercontent.com/1351531/230684634-0d092d11-807f-4104-9858-b81038a1d10c.png">

## Are there any deployment considerations?

Will publish new sdk version.
