### PR TITLE
Add `.next` to vscode ignore

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,6 +62,7 @@
 	"liveshare.allowGuestDebugControl": true,
 	"liveshare.allowGuestTaskControl": true,
 	"files.exclude": {
+		"**/.next/*": true,
 		"**/*.chunk.js": true,
 		"**/*.js.map": true,
 		"**/*.min.js": true,
@@ -71,7 +72,6 @@
 		"backend/go.sum": true,
 		"backend/event-parse/sample-events/*.json": true,
 		"**/*.scss.d.ts": true,
-		// "frontend/src/graph/generated/*": true,
 		"backend/payload/*": true,
 		"**/yarn-error.log": true
 	},


### PR DESCRIPTION
## Summary
Adds `.next` files to our ignored vscode settings.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
run a search in vscode.

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
n/a

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
