### PR TITLE
Remove root from `root` from intersection observer calls

### DIFF
--- a/highlight.io/components/Home/CustomerReviewTrack.tsx
+++ b/highlight.io/components/Home/CustomerReviewTrack.tsx
@@ -38,7 +38,6 @@ export const CustomerReviewTrack = () => {
 				setScrollReviews(entry.isIntersecting)
 			},
 			{
-				root: document.body,
 				rootMargin: '250px 0px',
 				threshold: 0.00001,
 			},

--- a/highlight.io/pages/for/[slug].tsx
+++ b/highlight.io/pages/for/[slug].tsx
@@ -97,7 +97,6 @@ const Products = ({ product }: { product: iProduct }) => {
 				setScrollReviews(entry.isIntersecting)
 			},
 			{
-				root: document.body,
 				rootMargin: '250px 0px',
 				threshold: 0.0001,
 			},

--- a/highlight.io/pages/index.tsx
+++ b/highlight.io/pages/index.tsx
@@ -127,7 +127,6 @@ const Home: NextPage = () => {
 				setScrollReviews(entry.isIntersecting)
 			},
 			{
-				root: document.body,
 				rootMargin: '250px 0px',
 				threshold: 0.0001,
 			},


### PR DESCRIPTION
## Summary
Removes `root` from intersectionObserver calls because it is either:
- redundant
- problematic (causes issues)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
clicktest

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
n/a

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
