### PR TITLE
fix vercel log drain integration

### DIFF
--- a/backend/vercel/vercel.go
+++ b/backend/vercel/vercel.go
@@ -8,6 +8,7 @@ import (
 	model2 "github.com/highlight-run/highlight/backend/model"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
+	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
@@ -224,12 +225,14 @@ func GetProjects(accessToken string, teamId *string) ([]*model.VercelProject, er
 	return projects, nil
 }
 
-func CreateLogDrain(vercelTeamID *string, vercelProjectID string, projectVerboseID string, name string, accessToken string) error {
+func CreateLogDrain(vercelTeamID *string, vercelProjectIDs []string, projectVerboseID string, name string, accessToken string) error {
 	client := &http.Client{}
 
 	headers := fmt.Sprintf(`{"%s":"%s"}`, VercelLogDrainProjectHeader, projectVerboseID)
-	projectIds := fmt.Sprintf(`["%s"]`, vercelProjectID)
-	body := fmt.Sprintf(`{"url":"https://pub.highlight.run/vercel/v1/logs","name":"%s","headers":%s,"projectIds":%s,"deliveryFormat":"ndjson"}`, name, headers, projectIds)
+	projectIds := fmt.Sprintf(`[%s]`, strings.Join(lo.Map(vercelProjectIDs, func(t string, i int) string {
+		return fmt.Sprintf("\"%s\"", t)
+	}), ","))
+	body := fmt.Sprintf(`{"url":"https://pub.highlight.run/vercel/v1/logs", "name":"%s", "headers":%s, "projectIds":%s, "deliveryFormat":"ndjson", "secret": "%s", "sources": ["static", "lambda", "edge", "build", "external"]}`, name, headers, projectIds, projectVerboseID)
 	u := fmt.Sprintf("%s/v2/integrations/log-drains", VercelApiBaseUrl)
 	if vercelTeamID != nil {
 		u = fmt.Sprintf("%s?teamId=%s", u, *vercelTeamID)

--- a/backend/vercel/vercel_test.go
+++ b/backend/vercel/vercel_test.go
@@ -1,0 +1,55 @@
+package vercel
+
+import (
+	"encoding/json"
+	"github.com/openlyinc/pointy"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type MockHTTP struct {
+}
+
+func (c *MockHTTP) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{}, nil
+}
+
+func TestCreateLogDrain(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/integrations/log-drains" {
+			t.Errorf("Expected to request '/fixedvalue', got: %s", r.URL.Path)
+		}
+		var resp struct {
+			Url            string
+			Name           string
+			Headers        map[string]string
+			ProjectIds     []string
+			DeliveryFormat string
+			Secret         string
+			Sources        []string
+		}
+		data, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(data, &resp); err != nil {
+			t.Error(err)
+		}
+
+		assert.Equal(t, "https://pub.highlight.run/vercel/v1/logs", resp.Url)
+		assert.Equal(t, "Highlight Log Drain", resp.Name)
+		assert.Equal(t, "1", resp.Headers[VercelLogDrainProjectHeader])
+		assert.Equal(t, []string{"prj_UYboDfJ3kTGcKmmqu4Ydryzy2KQC"}, resp.ProjectIds)
+		assert.Equal(t, "ndjson", resp.DeliveryFormat)
+		assert.Equal(t, "1", resp.Secret)
+		assert.Equal(t, []string{"static", "lambda", "edge", "build", "external"}, resp.Sources)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	VercelApiBaseUrl = server.URL
+	if err := CreateLogDrain(pointy.String("team_FRV1rjc2RxkhqoTsz8t76fGs"), []string{"prj_UYboDfJ3kTGcKmmqu4Ydryzy2KQC"}, "1", "Highlight Log Drain", "b81LedZpnZtAVrPy5kIdEgWi"); err != nil {
+		t.Errorf("failed to create log drain")
+	}
+}

--- a/backend/vercel/vercel_test.go
+++ b/backend/vercel/vercel_test.go
@@ -10,13 +10,6 @@ import (
 	"testing"
 )
 
-type MockHTTP struct {
-}
-
-func (c *MockHTTP) Do(req *http.Request) (*http.Response, error) {
-	return &http.Response{}, nil
-}
-
 func TestCreateLogDrain(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v2/integrations/log-drains" {

--- a/docs-content/getting-started/backend-logging/6_hosting/index.md
+++ b/docs-content/getting-started/backend-logging/6_hosting/index.md
@@ -1,0 +1,4 @@
+---
+title: Hosting Providers
+slug: hosting
+---

--- a/docs-content/getting-started/backend-logging/6_hosting/vercel.md
+++ b/docs-content/getting-started/backend-logging/6_hosting/vercel.md
@@ -1,0 +1,9 @@
+---
+title: Vercel
+slug: vercel
+createdAt: 2022-03-28T20:31:15.000Z
+updatedAt: 2022-04-06T20:22:54.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["backend-logging"]["hosting"]["vercel"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -37,6 +37,7 @@ import { RubyOtherLogContent } from './logging/ruby/other'
 import { RubyRailsLogContent } from './logging/ruby/rails'
 import { DevDeploymentContent } from './self-host/dev-deploy'
 import { SelfHostContent } from './self-host/self-host'
+import { HostingVercelLogContent } from './logging/hosting/vercel'
 
 export type QuickStartOptions = {
 	title: string
@@ -97,6 +98,7 @@ export enum QuickStartType {
 	HTTPOTLP = 'http-otlp',
 	RubyOther = 'other',
 	RubyRails = 'rails',
+	HostingVercel = 'vercel',
 }
 
 export const quickStartContent = {
@@ -209,6 +211,12 @@ export const quickStartContent = {
 			logoUrl: siteUrl('/images/quickstart/ruby.svg'),
 			[QuickStartType.RubyRails]: RubyRailsLogContent,
 			[QuickStartType.RubyOther]: RubyOtherLogContent,
+		},
+		hosting: {
+			title: 'Hosting Provider',
+			subtitle:
+				'Select your Hosting provider to setup the Highlight integration and stream logs.',
+			[QuickStartType.HostingVercel]: HostingVercelLogContent,
 		},
 	},
 	other: {

--- a/highlight.io/components/QuickstartContent/logging/hosting/vercel.tsx
+++ b/highlight.io/components/QuickstartContent/logging/hosting/vercel.tsx
@@ -4,7 +4,7 @@ import { verifyLogs } from '../shared-snippets'
 
 export const HostingVercelLogContent: QuickStartContent = {
 	title: 'Vercel',
-	subtitle: 'Learn how to setup highlight log ingestion on Vercel.',
+	subtitle: 'Learn how to setup Highlight log ingestion on Vercel.',
 	logoUrl: siteUrl('/images/quickstart/vercel.svg'),
 	entries: [
 		{

--- a/highlight.io/components/QuickstartContent/logging/hosting/vercel.tsx
+++ b/highlight.io/components/QuickstartContent/logging/hosting/vercel.tsx
@@ -1,0 +1,18 @@
+import { siteUrl } from '../../../../utils/urls'
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyLogs } from '../shared-snippets'
+
+export const HostingVercelLogContent: QuickStartContent = {
+	title: 'Vercel',
+	subtitle: 'Learn how to setup highlight log ingestion on Vercel.',
+	logoUrl: siteUrl('/images/quickstart/vercel.svg'),
+	entries: [
+		{
+			title: 'Setup the Highlight Vercel integration.',
+			content:
+				'Visit the [Vercel Highlight Integration page](https://vercel.com/integrations/highlight) to install it in your account.' +
+				'A log drain will automatically be created for all projects you grant access to.',
+		},
+		verifyLogs,
+	],
+}


### PR DESCRIPTION
## Summary

Ensure the log drain is correctly created with sources to ensure vercel will use it.
Ensure that only one log drain is created for all desired projects.

## How did you test this change?

Firing request from the test.

<img width="941" alt="Screenshot 2023-04-09 at 12 58 02 AM" src="https://user-images.githubusercontent.com/1351531/230761260-2816a595-9042-463a-825b-acda219e913b.png">

After accessing highlight.io

<img width="885" alt="Screenshot 2023-04-09 at 12 58 17 AM" src="https://user-images.githubusercontent.com/1351531/230761269-9aa8be81-1da5-4868-925d-6381294750a2.png">

New unit test.

## Are there any deployment considerations?

Adding  documentation.
