### PR TITLE
Selfhost page is missing the `link` property

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,6 +62,7 @@
 	"liveshare.allowGuestDebugControl": true,
 	"liveshare.allowGuestTaskControl": true,
 	"files.exclude": {
+		"**/.turbo/*": true,
 		"**/.next/*": true,
 		"**/*.chunk.js": true,
 		"**/*.js.map": true,

--- a/highlight.io/components/Home/FeatureCarousel/CarouselCard.tsx
+++ b/highlight.io/components/Home/FeatureCarousel/CarouselCard.tsx
@@ -1,14 +1,13 @@
-import React from 'react'
-import { Feature } from './FeatureCarousel'
-import styles from '../Home.module.scss'
 import Image from 'next/image'
-import { Typography } from '../../common/Typography/Typography'
-import highlightCodeTheme from '../../common/CodeBlock/highlight-code-theme'
-import { Code } from 'react-code-blocks'
 import Link from 'next/link'
 import { useState } from 'react'
+import { Code } from 'react-code-blocks'
 import { HiArrowRight } from 'react-icons/hi'
 import { AnimateCarouselImage } from '../../Animate'
+import highlightCodeTheme from '../../common/CodeBlock/highlight-code-theme'
+import { Typography } from '../../common/Typography/Typography'
+import styles from '../Home.module.scss'
+import { Feature } from './FeatureCarousel'
 
 const codeTheme = {
 	...highlightCodeTheme,
@@ -57,23 +56,37 @@ const CarouselFeatures = ({ feature }: { feature: Feature }) => {
 					</Typography>
 				</div>
 				{feature.code ? (
-					<div className="border-[1px] rounded-lg border-divider-on-dark mt-3">
-						{feature.code.map((line, index) => (
-							<div key={index} className="flex flex-col">
-								<div className="m-3 whitespace-pre-wrap break-words sm:break-normal">
-									<Code
-										language={'bash'}
-										text={line}
-										theme={codeTheme}
-										wrapLines
-									/>
-								</div>
-								{index != feature.code!.length - 1 && (
-									<div className="w-full h-[1px] bg-divider-on-dark" />
-								)}
+					<>
+						{feature.link && (
+							<div className="flex justify-center sm:justify-start mb-4">
+								<Link href={`${feature.link}`}>
+									<Typography type="copy3" emphasis={true}>
+										<div className="flex items-center justify-center gap-2">
+											Learn More{' '}
+											<HiArrowRight className="h-5" />
+										</div>
+									</Typography>
+								</Link>
 							</div>
-						))}
-					</div>
+						)}
+						<div className="border-[1px] rounded-lg border-divider-on-dark mt-3">
+							{feature.code.map((line, index) => (
+								<div key={index} className="flex flex-col">
+									<div className="m-3 whitespace-pre-wrap break-words sm:break-normal">
+										<Code
+											language={'bash'}
+											text={line}
+											theme={codeTheme}
+											wrapLines
+										/>
+									</div>
+									{index != feature.code!.length - 1 && (
+										<div className="w-full h-[1px] bg-divider-on-dark" />
+									)}
+								</div>
+							))}
+						</div>
+					</>
 				) : (
 					<div className="flex flex-col gap-3 rounded-lg">
 						{feature.link && (

--- a/highlight.io/components/Home/FeatureCarousel/FeatureCarousel.tsx
+++ b/highlight.io/components/Home/FeatureCarousel/FeatureCarousel.tsx
@@ -1,40 +1,40 @@
-import styles from '../Home.module.scss'
+import { ExclamationCircleFilled } from '@ant-design/icons'
 import classNames from 'classnames'
-import { Typography } from '../../common/Typography/Typography'
-import { useEffect, useState } from 'react'
-import { StaticImageData } from 'next/image'
-import sessionReplay from '../../../public/images/session-replay.png'
-import errorMonitoring from '../../../public/images/error-monitoring.png'
-import fullstackLogging from '../../../public/images/fullstack-logging.png'
-import selfHosting from '../../../public/images/docker.png'
-import openSource from '../../../public/images/open-source.png'
-import githubscreenshot from '../../../public/images/githubscreenshot.png'
-import dockerscreenshot from '../../../public/images/dockerscreenshot.png'
-import loggingscreenshot from '../../../public/images/loggingscreenshot.png'
-import monitoringscreenshot from '../../../public/images/monitoringscreenshot.png'
-import sessionscreenshot from '../../../public/images/sessionscreenshot.png'
 import useEmblaCarousel from 'embla-carousel-react'
+import { StaticImageData } from 'next/image'
+import { useEffect, useState } from 'react'
+import { isMobile } from 'react-device-detect'
+import { AiFillGithub } from 'react-icons/ai'
 import {
-	HiTerminal,
+	HiBell,
+	HiChevronDown,
+	HiCloudDownload,
+	HiCode,
+	HiDatabase,
+	HiDesktopComputer,
+	HiDocumentSearch,
 	HiFilm,
 	HiLightningBolt,
-	HiCloudDownload,
+	HiPhoneOutgoing,
+	HiPresentationChartLine,
+	HiTerminal,
 	HiUserGroup,
 	HiViewBoards,
-	HiDocumentSearch,
-	HiPhoneOutgoing,
-	HiDatabase,
-	HiBell,
-	HiCode,
-	HiDesktopComputer,
-	HiPresentationChartLine,
 } from 'react-icons/hi'
-import { CarouselCard } from './CarouselCard'
-import { HiChevronDown } from 'react-icons/hi'
+import selfHosting from '../../../public/images/docker.png'
+import dockerscreenshot from '../../../public/images/dockerscreenshot.png'
+import errorMonitoring from '../../../public/images/error-monitoring.png'
+import fullstackLogging from '../../../public/images/fullstack-logging.png'
+import githubscreenshot from '../../../public/images/githubscreenshot.png'
+import loggingscreenshot from '../../../public/images/loggingscreenshot.png'
+import monitoringscreenshot from '../../../public/images/monitoringscreenshot.png'
+import openSource from '../../../public/images/open-source.png'
+import sessionReplay from '../../../public/images/session-replay.png'
+import sessionscreenshot from '../../../public/images/sessionscreenshot.png'
 import { PrimaryButton } from '../../common/Buttons/PrimaryButton'
-import { AiFillGithub } from 'react-icons/ai'
-import { ExclamationCircleFilled } from '@ant-design/icons'
-import { isMobile } from 'react-device-detect'
+import { Typography } from '../../common/Typography/Typography'
+import styles from '../Home.module.scss'
+import { CarouselCard } from './CarouselCard'
 
 export type Feature = {
 	name: string


### PR DESCRIPTION
## Summary
Adds rendering of the `link` property for the self-host section of the carousel.
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
CI / Clicktest

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
n/a

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
