### PR TITLE
Add root alias, use for style/common.css import

### DIFF
--- a/frontend/src/components/CollapsibleSection/index.tsx
+++ b/frontend/src/components/CollapsibleSection/index.tsx
@@ -2,7 +2,8 @@ import { collapsibleContent } from '@components/CollapsibleSection/style.css'
 import clsx from 'clsx'
 import { PropsWithChildren } from 'react'
 import ReactCollapsible from 'react-collapsible'
-import { styledVerticalScrollbar } from 'style/common.css'
+
+import { styledVerticalScrollbar } from '@/style/common.css'
 
 const CollapsibleSection = function ({
 	children,

--- a/frontend/src/components/FullCommentList/FullCommentList.tsx
+++ b/frontend/src/components/FullCommentList/FullCommentList.tsx
@@ -4,7 +4,8 @@ import LoadingBox from '@components/LoadingBox'
 import clsx from 'clsx'
 import React, { useRef } from 'react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
-import { styledVerticalScrollbar } from 'style/common.css'
+
+import { styledVerticalScrollbar } from '@/style/common.css'
 
 import styles from './FullCommentList.module.scss'
 

--- a/frontend/src/components/TextViewer/index.tsx
+++ b/frontend/src/components/TextViewer/index.tsx
@@ -11,7 +11,8 @@ import { copyToClipboard } from '@util/string'
 import React from 'react'
 // @ts-ignore
 import { specific } from 'react-files-hooks'
-import { styledHorizontalScrollbar } from 'style/common.css'
+
+import { styledHorizontalScrollbar } from '@/style/common.css'
 
 type Props = {
 	title: React.ReactElement

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -20,7 +20,8 @@ import { gqlSanitize } from '@util/gql'
 import { useParams } from '@util/react-router/useParams'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
-import { styledVerticalScrollbar } from 'style/common.css'
+
+import { styledVerticalScrollbar } from '@/style/common.css'
 
 import * as style from './SearchPanel.css'
 

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.css.ts
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.css.ts
@@ -1,7 +1,8 @@
 import { vars } from '@highlight-run/ui'
 import { sprinkles } from '@highlight-run/ui/src/css/sprinkles.css'
 import { globalStyle, style } from '@vanilla-extract/css'
-import { styledVerticalScrollbar } from 'style/common.css'
+
+import { styledVerticalScrollbar } from '@/style/common.css'
 
 export const searchIcon = style({
 	position: 'absolute',

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -13,7 +13,8 @@ import { H } from 'highlight.run'
 import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
-import { styledVerticalScrollbar } from 'style/common.css'
+
+import { styledVerticalScrollbar } from '@/style/common.css'
 
 import { useReplayerContext } from '../../../ReplayerContext'
 import * as styles from './style.css'

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -36,7 +36,8 @@ import useLocalStorage from '@rehooks/local-storage'
 import clsx from 'clsx'
 import React, { useMemo } from 'react'
 import { Link } from 'react-router-dom'
-import { styledVerticalScrollbar } from 'style/common.css'
+
+import { styledVerticalScrollbar } from '@/style/common.css'
 
 import { ConsolePage } from './ConsolePage/ConsolePage'
 import ErrorsPage from './ErrorsPage/ErrorsPage'

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ErrorsPage/ErrorsPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ErrorsPage/ErrorsPage.tsx
@@ -17,7 +17,8 @@ import { parseOptionalJSON } from '@util/string'
 import React, { useLayoutEffect, useMemo, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
-import { styledVerticalScrollbar } from 'style/common.css'
+
+import { styledVerticalScrollbar } from '@/style/common.css'
 
 import { ReplayerState, useReplayerContext } from '../../../ReplayerContext'
 import * as styles from './style.css'

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -26,7 +26,8 @@ import { message } from 'antd'
 import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
-import { styledVerticalScrollbar } from 'style/common.css'
+
+import { styledVerticalScrollbar } from '@/style/common.css'
 
 import TextHighlighter from '../../../../../components/TextHighlighter/TextHighlighter'
 import Tooltip from '../../../../../components/Tooltip/Tooltip'

--- a/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
@@ -22,7 +22,8 @@ import { useParams } from '@util/react-router/useParams'
 import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
-import { styledVerticalScrollbar } from 'style/common.css'
+
+import { styledVerticalScrollbar } from '@/style/common.css'
 
 import * as style from './EventStreamV2.css'
 

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -44,7 +44,8 @@ import { useParams } from '@util/react-router/useParams'
 import { roundFeedDate, serializeAbsoluteTimeRange } from '@util/time'
 import clsx from 'clsx'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
-import { styledVerticalScrollbar } from 'style/common.css'
+
+import { styledVerticalScrollbar } from '@/style/common.css'
 
 import usePlayerConfiguration from '../../Player/PlayerHook/utils/usePlayerConfiguration'
 import { useReplayerContext } from '../../Player/ReplayerContext'

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,6 +19,7 @@
 		"noFallthroughCasesInSwitch": true,
 		"baseUrl": "src",
 		"paths": {
+			"@/*": ["./*"],
 			"@components/*": ["./components/*"],
 			"@icons/*": ["./static/*"],
 			"@util/*": ["./util/*"],


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

_This is part of a [series](https://github.com/highlight/highlight/pull/4813) [of](https://github.com/highlight/highlight/pull/4848) [PRs](https://github.com/highlight/highlight/pull/4849) [being](https://github.com/highlight/highlight/pull/4851) [spun](https://github.com/highlight/highlight/pull/4852) off from [my WIP branch](https://github.com/lewisl9029/highlight/pull/2) to get the Highlight web app ready for [Reflame](https://reflame.app/). Hopefully this makes things a bit easier to review, test, and merge. 🙂_ 

Previously we had a bunch of places where we imported `/src/style/common.css` using the identifier `style/common.css`. `style/*` was not setup as an alias in tsconfig.json, but this seem to have worked anyways (I think it might be a quirk of the https://github.com/aleclarson/vite-tsconfig-paths plugin).

I don't think it's a good idea to rely on this behavior over the long term since there's nothing distinguishing it from npm package imports.

We could have worked around this by adding a `@styles` identifier like we have for most other top level folders, but in this PR I proposed what I believe is a more flexible option of simply exposing the src directory as a `@/*` alias.

This has several benefits over manually setting up aliases for top level folders separately:

- We can use it to import files on the top level as well (in my WIP PR I added a env.ts module that didn't make a lot of sense anywhere else)
- Imports from `@/*` matches the filesystem directory structure exactly, so there's never any ambiguity to where an imported file actually lives on disk (in our current setup, we have 2 aliases that don't map 1:1 to top level folders `@icons/*` and `@graph/*`)
- All else being equal, more path remapping rules will result in worse performance for module resolution compared to fewer (though I haven't ran the numbers to quantify this yet)

That said, this PR just introduces the new alias and uses it for `@/style/common.css`, and doesn't change any other existing imports, so none of these benefits are actually realized here. Though if the team is interested in moving forward with this, I'd be happy to open up a follow up PR to update imports throughout the rest of the codebase as well, and try running a few benchmarks to see if it actually moves the needle on performance.

Alternatively, let me know if y'all prefer to keep the current approach using manual top level path remappings instead. I'd be happy to switch over to a `@styles/*` import here as well.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

I ran the app using `yarn turbo run dev --filter frontend...`. 

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

None that I'm aware of.