### PR TITLE
Fix empty state query slashes causing parse error

### DIFF
--- a/frontend/src/pages/Sessions/EmptySessionsSearchParams.tsx
+++ b/frontend/src/pages/Sessions/EmptySessionsSearchParams.tsx
@@ -20,5 +20,5 @@ export const EmptySessionsSearchParams: Complete<SearchParamsInput> = {
 	environments: [],
 	app_versions: [],
 	show_live_sessions: false,
-	query: `{\"isAnd\":true,\"rules\":[[\"custom_processed\",\"is\",\"true\"]]}`,
+	query: `{"isAnd":true,"rules":[["custom_processed","is","true"]]}`,
 }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

In [EmptySessionsSearchParams.tsx](https://github.com/highlight/highlight/blob/eadc0963613dd70110121d728331ae86a93cd6c3/frontend/src/pages/Sessions/EmptySessionsSearchParams.tsx#L23), we have this set as the default query: ``{\"isAnd\":true,\"rules\":[[\"custom_processed\",\"is\",\"true\"]]}``

The backslashes end up causing this exception in my Reflame deploy because they end up as literal slashes due to the template string already escaping double quotes:

![Screenshot 2023-04-10 at 3 43 11 PM](https://user-images.githubusercontent.com/6934200/231013521-0e304589-30cc-4397-8859-b5600b10e4d4.png)

Removing the backslashes seems to fix this.

## How did you test this change?

Tested in a Reflame deploy.

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

None I can think of.