### PR TITLE
Convert errorBody display to details and summary

### DIFF
--- a/frontend/src/components/ErrorState/ErrorState.module.scss
+++ b/frontend/src/components/ErrorState/ErrorState.module.scss
@@ -13,6 +13,7 @@
 }
 
 .errorBody {
+	color: var(--color-black);
 	max-width: 800px;
 	word-wrap: break-word;
 }
@@ -20,11 +21,6 @@
 .buttonGroup {
 	display: flex;
 	margin-top: 25px;
-}
-
-.expandButton {
-	color: var(--color-primary-500);
-	cursor: pointer;
 }
 
 .loggedInButtonGroup {

--- a/frontend/src/components/ErrorState/ErrorState.module.scss.d.ts
+++ b/frontend/src/components/ErrorState/ErrorState.module.scss.d.ts
@@ -1,6 +1,5 @@
 export const buttonGroup: string
 export const errorBody: string
 export const errorWrapper: string
-export const expandButton: string
 export const loggedInButtonGroup: string
 export const shownWithHeader: string

--- a/frontend/src/components/ErrorState/ErrorState.tsx
+++ b/frontend/src/components/ErrorState/ErrorState.tsx
@@ -48,7 +48,7 @@ export const ErrorState = ({
 				</p>
 				{errorString !== undefined && (
 					<details onToggle={() => setShowError((t) => !t)}>
-						<summary className="cursor-pointer">
+						<summary className="cursor-pointer text-gray-500">
 							{showError ? 'show less' : 'show more'}
 						</summary>
 						{showError && (

--- a/frontend/src/components/ErrorState/ErrorState.tsx
+++ b/frontend/src/components/ErrorState/ErrorState.tsx
@@ -45,18 +45,20 @@ export const ErrorState = ({
 							'already able to join this workspace! ' +
 							'Join it to be able to view the session.'}
 					{message}
-					{errorString !== undefined && (
-						<span
-							className={styles.expandButton}
-							onClick={() => setShowError((t) => !t)}
-						>
-							{showError ? 'show less' : 'show more'}
-						</span>
-					)}
 				</p>
-				{showError && (
-					<code className={styles.errorBody}>{errorString}</code>
+				{errorString !== undefined && (
+					<details onToggle={() => setShowError((t) => !t)}>
+						<summary className="cursor-pointer">
+							{showError ? 'show less' : 'show more'}
+						</summary>
+						{showError && (
+							<code className={styles.errorBody}>
+								{errorString}
+							</code>
+						)}
+					</details>
 				)}
+
 				<div className={styles.buttonGroup}>
 					{isLoggedIn ? (
 						<div className={styles.loggedInButtonGroup}>


### PR DESCRIPTION
## Summary

Converts the ErrorState component from a clickable span to `<details><summary/></details>` [elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details), which handles showing and hiding detailed information natively.

## How did you test this change?
Tested with auth error. Validated in Chrome, Firefox, Safari.

### Before
<img width="547" alt="Screenshot 2023-04-10 at 9 12 04 PM" src="https://user-images.githubusercontent.com/1341253/231039779-5adbda4d-3af7-4bfd-bd46-b54b638963f6.png">

<img width="540" alt="Screenshot 2023-04-10 at 9 12 10 PM" src="https://user-images.githubusercontent.com/1341253/231039838-bf2cb95e-73da-43b9-9b53-6bf623abd0dd.png">

### After
<img width="577" alt="Screenshot 2023-04-10 at 9 12 50 PM" src="https://user-images.githubusercontent.com/1341253/231039865-7ddff6c7-e68b-4c76-b8b1-e14db307015e.png">

<img width="524" alt="Screenshot 2023-04-10 at 9 12 58 PM" src="https://user-images.githubusercontent.com/1341253/231039898-4a64723a-fbb5-4c2e-af0b-e1808fb249e5.png">



## Are there any deployment considerations?
nope.
