### PR TITLE
#4880 log alerts polish

### DIFF
--- a/backend/alerts/alerts.go
+++ b/backend/alerts/alerts.go
@@ -3,13 +3,14 @@ package alerts
 import (
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/highlight-run/highlight/backend/alerts/integrations/webhook"
+	"github.com/highlight-run/highlight/backend/model"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/highlight-run/highlight/backend/alerts/integrations"
 	"github.com/highlight-run/highlight/backend/alerts/integrations/discord"
-	"github.com/highlight-run/highlight/backend/model"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -509,6 +510,8 @@ type LogAlertEvent struct {
 	LogAlert  *model.LogAlert
 	Workspace *model.Workspace
 	Count     int
+	StartDate time.Time
+	EndDate   time.Time
 }
 
 func SendLogAlert(event LogAlertEvent) error {
@@ -516,9 +519,11 @@ func SendLogAlert(event LogAlertEvent) error {
 		Name:           *event.LogAlert.Name,
 		Query:          event.LogAlert.Query,
 		Count:          event.Count,
+		StartDate:      event.StartDate,
+		EndDate:        event.EndDate,
 		Threshold:      event.LogAlert.CountThreshold,
 		BelowThreshold: event.LogAlert.BelowThreshold,
-		AlertURL:       getLogAlertURL(event.LogAlert),
+		AlertURL:       model.GetLogAlertURL(event.LogAlert.ProjectID, event.LogAlert.Query, event.StartDate, event.EndDate),
 	}
 
 	for _, wh := range event.LogAlert.WebhookDestinations {

--- a/backend/alerts/integrations/discord/messages.go
+++ b/backend/alerts/integrations/discord/messages.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/highlight-run/highlight/backend/alerts/integrations"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 func newMessageEmbed() *discordgo.MessageEmbed {
@@ -449,7 +447,6 @@ func (bot *Bot) SendLogAlert(channelId string, payload integrations.LogAlertPayl
 	}
 
 	_, err := bot.Session.ChannelMessageSendComplex(channelId, &messageSend)
-	logrus.Error(errors.Wrap(err, "zane test"))
 
 	return err
 }

--- a/backend/alerts/integrations/discord/messages.go
+++ b/backend/alerts/integrations/discord/messages.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/highlight-run/highlight/backend/alerts/integrations"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func newMessageEmbed() *discordgo.MessageEmbed {
@@ -398,11 +400,13 @@ func (bot *Bot) SendMetricMonitorAlert(channelId string, payload integrations.Me
 func (bot *Bot) SendLogAlert(channelId string, payload integrations.LogAlertPayload) error {
 	fields := []*discordgo.MessageEmbedField{}
 
-	fields = append(fields, &discordgo.MessageEmbedField{
-		Name:   "Query",
-		Value:  payload.Query,
-		Inline: true,
-	})
+	if payload.Query != "" {
+		fields = append(fields, &discordgo.MessageEmbedField{
+			Name:   "Query",
+			Value:  payload.Query,
+			Inline: true,
+		})
+	}
 
 	fields = append(fields, &discordgo.MessageEmbedField{
 		Name:   "Count",
@@ -434,7 +438,7 @@ func (bot *Bot) SendLogAlert(channelId string, payload integrations.LogAlertPayl
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{
 					discordgo.Button{
-						Label:    "View Alert",
+						Label:    "View Logs",
 						Style:    discordgo.LinkButton,
 						Disabled: false,
 						URL:      payload.AlertURL,
@@ -445,6 +449,7 @@ func (bot *Bot) SendLogAlert(channelId string, payload integrations.LogAlertPayl
 	}
 
 	_, err := bot.Session.ChannelMessageSendComplex(channelId, &messageSend)
+	logrus.Error(errors.Wrap(err, "zane test"))
 
 	return err
 }

--- a/backend/alerts/integrations/integrations.go
+++ b/backend/alerts/integrations/integrations.go
@@ -1,6 +1,10 @@
 package integrations
 
-import "github.com/bwmarrin/discordgo"
+import (
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
 
 type ErrorAlertPayload struct {
 	ErrorCount      int64
@@ -71,6 +75,8 @@ type LogAlertPayload struct {
 	Name           string
 	Query          string
 	Count          int
+	StartDate      time.Time
+	EndDate        time.Time
 	Threshold      int
 	BelowThreshold bool
 	AlertURL       string

--- a/backend/alerts/routing.go
+++ b/backend/alerts/routing.go
@@ -50,8 +50,3 @@ func getMonitorURL(metricMonitor *model.MetricMonitor) string {
 	frontendURL := os.Getenv("FRONTEND_URI")
 	return fmt.Sprintf("%s/%d/alerts/monitors/%d", frontendURL, metricMonitor.ProjectID, metricMonitor.ID)
 }
-
-func getLogAlertURL(alert *model.LogAlert) string {
-	frontendURL := os.Getenv("FRONTEND_URI")
-	return fmt.Sprintf("%s/%d/alerts/logs/%d", frontendURL, alert.ProjectID, alert.ID)
-}

--- a/backend/jobs/log-alerts/log-alerts.go
+++ b/backend/jobs/log-alerts/log-alerts.go
@@ -3,7 +3,6 @@ package log_alerts
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/highlight-run/highlight/backend/alerts"
@@ -68,10 +67,12 @@ func WatchLogAlerts(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, MailCli
 					for _, alert := range alerts {
 						alertWorkerpool.SubmitRecover(
 							func() {
+								log.WithContext(ctx).Info("processing log alert!")
 								err := processLogAlert(ctx, DB, TDB, MailClient, alert, rh, redis, ccClient)
 								if err != nil {
 									log.WithContext(ctx).Error(err)
 								}
+								log.WithContext(ctx).Info("processed log alert!")
 							})
 					}
 				}
@@ -106,7 +107,7 @@ func processLogAlert(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, MailCl
 		lastTs = time.Now()
 	}
 	end := lastTs.Add(-time.Minute)
-	start := end.Add(-time.Minute)
+	start := end.Add(time.Duration(alert.Frequency) * time.Second)
 
 	count64, err := ccClient.ReadLogsTotalCount(ctx, alert.ProjectID, modelInputs.LogsParamsInput{Query: alert.Query, DateRange: &modelInputs.DateRangeRequiredInput{
 		StartDate: start,
@@ -150,7 +151,7 @@ func processLogAlert(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, MailCl
 			queryStr = fmt.Sprintf(`for query *%s* `, alert.Query)
 		}
 		message := fmt.Sprintf(
-			"🚨 *%s* fired!\nLog count %sis currently %s the threshold.\n"+
+			"🚨 *%s* fired!\nLog count %swas %s the threshold.\n"+
 				"_Count_: %d | _Threshold_: %d",
 			*alert.Name,
 			queryStr,
@@ -161,7 +162,7 @@ func processLogAlert(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, MailCl
 
 		log.WithContext(ctx).Info(message)
 
-		if err := alert.SendSlackAlert(ctx, &model.SendLogAlertForMetricMonitorInput{Message: message, Workspace: &workspace}); err != nil {
+		if err := alert.SendSlackAlert(ctx, &model.SendSlackAlertForLogAlertInput{Message: message, Workspace: &workspace, StartDate: start, EndDate: end}); err != nil {
 			log.WithContext(ctx).Error("error sending slack alert for metric monitor", err)
 		}
 
@@ -169,6 +170,8 @@ func processLogAlert(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, MailCl
 			LogAlert:  alert,
 			Workspace: &workspace,
 			Count:     count,
+			StartDate: start,
+			EndDate:   end,
 		}); err != nil {
 			log.WithContext(ctx).Error(err)
 		}
@@ -178,8 +181,7 @@ func processLogAlert(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, MailCl
 			log.WithContext(ctx).Error(err)
 		}
 
-		frontendURL := os.Getenv("FRONTEND_URI")
-		alertUrl := fmt.Sprintf("%s/%d/alerts/logs/%d", frontendURL, alert.ProjectID, alert.ID)
+		alertUrl := model.GetLogAlertURL(alert.ProjectID, alert.Query, start, end)
 
 		for _, email := range emailsToNotify {
 			queryStr := ""
@@ -188,9 +190,9 @@ func processLogAlert(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, MailCl
 			}
 			message = fmt.Sprintf(
 				"<b>%s</b> fired! Log count %sis currently %s the threshold.<br>"+
-					"<em>Count</em>: %d | <em>Threshold: %d"+
+					"<em>Count</em>: %d | <em>Threshold</em>: %d"+
 					"<br><br>"+
-					"<a href=\"%s\">View Alert</a>",
+					"<a href=\"%s\">View Logs</a>",
 				*alert.Name,
 				queryStr,
 				aboveStr,

--- a/backend/jobs/log-alerts/log-alerts.go
+++ b/backend/jobs/log-alerts/log-alerts.go
@@ -67,12 +67,10 @@ func WatchLogAlerts(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, MailCli
 					for _, alert := range alerts {
 						alertWorkerpool.SubmitRecover(
 							func() {
-								log.WithContext(ctx).Info("processing log alert!")
 								err := processLogAlert(ctx, DB, TDB, MailClient, alert, rh, redis, ccClient)
 								if err != nil {
 									log.WithContext(ctx).Error(err)
 								}
-								log.WithContext(ctx).Info("processed log alert!")
 							})
 					}
 				}

--- a/frontend/src/components/Select/Select.tsx
+++ b/frontend/src/components/Select/Select.tsx
@@ -5,6 +5,7 @@ import {
 	Select as AntDesignSelect,
 	SelectProps as AntDesignSelectProps,
 } from 'antd'
+import { BaseOptionType, DefaultOptionType } from 'antd/lib/select'
 import clsx from 'clsx'
 import React from 'react'
 
@@ -14,49 +15,31 @@ const { Option } = AntDesignSelect
 
 export interface OptionType {
 	value: string
-	displayValue: string | React.ReactNode
+	displayValue: React.ReactNode
 	disabled?: boolean
 	id: string
 	dropDownIcon?: React.ReactNode
 }
 
-type Props = Pick<
-	AntDesignSelectProps<any>,
-	| 'onChange'
-	| 'placeholder'
-	| 'loading'
-	| 'value'
-	| 'className'
-	| 'allowClear'
-	| 'notFoundContent'
-	| 'mode'
-	| 'dropdownRender'
-	| 'defaultValue'
-	| 'onSearch'
-	| 'children'
-	| 'optionLabelProp'
-	| 'filterOption'
-	| 'bordered'
-	| 'disabled'
-	| 'defaultActiveFirstOption'
-	| 'aria-label'
-	| 'tagRender'
-	| 'open'
-	| 'dropdownMatchSelectWidth'
-	| 'optionFilterProp'
-> & {
-	options?: OptionType[]
+type Props<
+	ValueType,
+	OptType extends BaseOptionType | DefaultOptionType,
+> = AntDesignSelectProps<ValueType, OptType> & {
+	options?: OptType[]
 	dropdownClassName?: string
 }
 
-const Select = ({
+const Select = <
+	ValueType = any,
+	OptType extends BaseOptionType | DefaultOptionType = OptionType,
+>({
 	options,
 	className,
 	dropdownClassName,
 	children,
 	defaultActiveFirstOption = false,
 	...props
-}: Props) => {
+}: Props<ValueType, OptType>) => {
 	return (
 		<AntDesignSelect
 			// @ts-ignore

--- a/frontend/src/components/Select/Select.tsx
+++ b/frontend/src/components/Select/Select.tsx
@@ -5,7 +5,6 @@ import {
 	Select as AntDesignSelect,
 	SelectProps as AntDesignSelectProps,
 } from 'antd'
-import { BaseOptionType, DefaultOptionType } from 'antd/lib/select'
 import clsx from 'clsx'
 import React from 'react'
 
@@ -21,25 +20,19 @@ export interface OptionType {
 	dropDownIcon?: React.ReactNode
 }
 
-type Props<
-	ValueType,
-	OptType extends BaseOptionType | DefaultOptionType,
-> = AntDesignSelectProps<ValueType, OptType> & {
-	options?: OptType[]
+type Props = Omit<AntDesignSelectProps, 'options'> & {
+	options?: OptionType[]
 	dropdownClassName?: string
 }
 
-const Select = <
-	ValueType = any,
-	OptType extends BaseOptionType | DefaultOptionType = OptionType,
->({
+const Select = ({
 	options,
 	className,
 	dropdownClassName,
 	children,
 	defaultActiveFirstOption = false,
 	...props
-}: Props<ValueType, OptType>) => {
+}: Props) => {
 	return (
 		<AntDesignSelect
 			// @ts-ignore

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -56,7 +56,7 @@ const dev =
 	import.meta.env.DEV ||
 	import.meta.env.REACT_APP_FRONTEND_URI?.indexOf('localhost') !== -1
 const options: HighlightOptions = {
-	debug: { clientInteractions: true, domRecording: true },
+	debug: { domRecording: true },
 	manualStart: true,
 	enableStrictPrivacy: Math.floor(Math.random() * 8) === 0,
 	networkRecording: {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -56,7 +56,7 @@ const dev =
 	import.meta.env.DEV ||
 	import.meta.env.REACT_APP_FRONTEND_URI?.indexOf('localhost') !== -1
 const options: HighlightOptions = {
-	debug: { domRecording: true },
+	debug: { clientInteractions: true, domRecording: true },
 	manualStart: true,
 	enableStrictPrivacy: Math.floor(Math.random() * 8) === 0,
 	networkRecording: {

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -7,7 +7,6 @@ import {
 	useGetLogsKeysQuery,
 	useUpdateLogAlertMutation,
 } from '@graph/hooks'
-import { DiscordChannel, SanitizedSlackChannel } from '@graph/schemas'
 import {
 	Badge,
 	Box,
@@ -47,18 +46,33 @@ import { message } from 'antd'
 import { capitalize } from 'lodash'
 import moment from 'moment'
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
+import { DateTimeParam, StringParam, useQueryParam } from 'use-query-params'
+
+import LoadingBox from '@/components/LoadingBox'
+import { namedOperations } from '@/graph/generated/operations'
+import {
+	DiscordChannelInput,
+	SanitizedSlackChannelInput,
+} from '@/graph/generated/schemas'
 
 import * as styles from './styles.css'
 
 export const LogAlertPage = () => {
-	const [selectedDates, setSelectedDates] = useState([
-		LOG_TIME_PRESETS[0].startDate,
-		now.toDate(),
+	const [startDateParam] = useQueryParam('start_date', DateTimeParam)
+	const [endDateParam] = useQueryParam('end_date', DateTimeParam)
+
+	const [startDate, setStartDate] = useState(
+		startDateParam ?? LOG_TIME_PRESETS[0].startDate,
+	)
+
+	const [endDate, setEndDate] = useState(endDateParam ?? now.toDate())
+	const [selectedDates, setSelectedDates] = useState<Date[]>([
+		startDate,
+		endDate,
 	])
 
-	const [startDate, setStartDate] = useState(LOG_TIME_PRESETS[0].startDate)
-	const [endDate, setEndDate] = useState(now.toDate())
+	const [queryParam] = useQueryParam('query', StringParam)
 
 	const { alert_id } = useParams<{
 		alert_id: string
@@ -83,7 +97,7 @@ export const LogAlertPage = () => {
 
 	const form = useFormState<LogMonitorForm>({
 		defaultValues: {
-			query: '',
+			query: queryParam ?? '',
 			name: '',
 			belowThreshold: false,
 			excludedEnvironments: [],
@@ -98,13 +112,35 @@ export const LogAlertPage = () => {
 
 	useEffect(() => {
 		if (!loading && data) {
+			console.log(
+				'test',
+				data?.log_alert.ChannelsToNotify.map((c) => ({
+					...c,
+					displayValue: c.webhook_channel,
+					value: c.webhook_channel_id,
+					id: c.webhook_channel_id,
+				})),
+			)
 			form.setValues({
 				query: data?.log_alert.query,
 				name: data?.log_alert.Name,
 				belowThreshold: data?.log_alert.BelowThreshold,
 				excludedEnvironments: data?.log_alert.ExcludedEnvironments,
-				slackChannels: data?.log_alert.ChannelsToNotify,
-				discordChannels: data?.log_alert.DiscordChannelsToNotify,
+				slackChannels: data?.log_alert.ChannelsToNotify.map((c) => ({
+					...c,
+					webhook_channel_name: c.webhook_channel,
+					displayValue: c.webhook_channel,
+					value: c.webhook_channel_id,
+					id: c.webhook_channel_id,
+				})),
+				discordChannels: data?.log_alert.DiscordChannelsToNotify.map(
+					(c) => ({
+						...c,
+						displayValue: c.name,
+						value: c.id,
+						id: c.id,
+					}),
+				),
 				webhookDestinations: data?.log_alert.WebhookDestinations.map(
 					(d) => d.url,
 				),
@@ -112,13 +148,29 @@ export const LogAlertPage = () => {
 				threshold: data?.log_alert.CountThreshold,
 				frequency: data?.log_alert.ThresholdWindow,
 			})
+			console.log('form.values.slackChannels', form.values.slackChannels)
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data, loading])
 
-	const [createLogAlertMutation] = useCreateLogAlertMutation()
-	const [updateLogAlertMutation] = useUpdateLogAlertMutation()
-	const [deleteLogAlertMutation] = useDeleteLogAlertMutation()
+	const [createLogAlertMutation] = useCreateLogAlertMutation({
+		refetchQueries: [
+			namedOperations.Query.GetLogAlert,
+			namedOperations.Query.GetAlertsPagePayload,
+		],
+	})
+	const [updateLogAlertMutation] = useUpdateLogAlertMutation({
+		refetchQueries: [
+			namedOperations.Query.GetLogAlert,
+			namedOperations.Query.GetAlertsPagePayload,
+		],
+	})
+	const [deleteLogAlertMutation] = useDeleteLogAlertMutation({
+		refetchQueries: [
+			namedOperations.Query.GetLogAlert,
+			namedOperations.Query.GetAlertsPagePayload,
+		],
+	})
 
 	const { project_id } = useParams<{
 		project_id: string
@@ -134,16 +186,13 @@ export const LogAlertPage = () => {
 	const header = (
 		<Box
 			display="flex"
-			justifyContent="space-between"
+			justifyContent="flex-end"
 			alignItems="center"
 			borderBottom="dividerWeak"
 			px="8"
 			py="6"
 			cssClass={styles.header}
 		>
-			<Text userSelect="none">
-				{capitalize(createStr)} log monitoring alert
-			</Text>
 			<Box display="flex" alignItems="center" gap="4">
 				<Button
 					kind="secondary"
@@ -195,8 +244,11 @@ export const LogAlertPage = () => {
 								form.names.belowThreshold,
 							),
 							disabled: false,
-							discord_channels: form.getValue(
-								form.names.discordChannels,
+							discord_channels: form.values.discordChannels.map(
+								(c) => ({
+									name: c.name,
+									id: c.id,
+								}),
 							),
 							emails: form.getValue(form.names.emails),
 							environments: form.getValue(
@@ -204,8 +256,12 @@ export const LogAlertPage = () => {
 							),
 							name: form.getValue(form.names.name),
 							project_id: project_id || '0',
-							slack_channels: form.getValue(
-								form.names.slackChannels,
+							slack_channels: form.values.slackChannels.map(
+								(c) => ({
+									webhook_channel_id: c.webhook_channel_id,
+									webhook_channel_name:
+										c.webhook_channel_name,
+								}),
 							),
 							webhook_destinations: form
 								.getValue(form.names.webhookDestinations)
@@ -217,7 +273,7 @@ export const LogAlertPage = () => {
 						}
 
 						if (!input.name) {
-							message.error(`Missing name!`)
+							message.error(`Missing alert name!`)
 							return
 						}
 
@@ -277,82 +333,89 @@ export const LogAlertPage = () => {
 				flexDirection="column"
 				height="full"
 			>
-				{header}
-				<Container
-					display="flex"
-					flexDirection="column"
-					py="24"
-					gap="40"
-				>
-					<Box
-						display="flex"
-						flexDirection="column"
-						width="full"
-						height="full"
-						gap="12"
-					>
-						<Box
+				{loading && <LoadingBox />}
+				{!loading && (
+					<>
+						{header}
+						<Container
 							display="flex"
-							alignItems="center"
-							width="full"
-							justifyContent="space-between"
+							flexDirection="column"
+							py="24"
+							gap="40"
 						>
 							<Box
 								display="flex"
-								alignItems="center"
-								gap="4"
-								color="weak"
+								flexDirection="column"
+								width="full"
+								height="full"
+								gap="12"
 							>
-								<Tag
-									kind="secondary"
-									size="medium"
-									shape="basic"
-									emphasis="high"
-									iconLeft={<IconSolidSpeakerphone />}
-									onClick={() => {
-										navigate(`/${project_id}/alerts`)
+								<Box
+									display="flex"
+									alignItems="center"
+									width="full"
+									justifyContent="space-between"
+								>
+									<Box
+										display="flex"
+										alignItems="center"
+										gap="4"
+										color="weak"
+									>
+										<Tag
+											kind="secondary"
+											size="medium"
+											shape="basic"
+											emphasis="high"
+											iconLeft={<IconSolidSpeakerphone />}
+											onClick={() => {
+												navigate(
+													`/${project_id}/alerts`,
+												)
+											}}
+										>
+											Alerts
+										</Tag>
+										<IconSolidCheveronRight />
+										<Text
+											color="moderate"
+											size="small"
+											weight="medium"
+											userSelect="none"
+										>
+											Log monitor
+										</Text>
+									</Box>
+									<PreviousDateRangePicker
+										selectedDates={selectedDates}
+										onDatesChange={setSelectedDates}
+										presets={LOG_TIME_PRESETS}
+										minDate={thirtyDaysAgo}
+										kind="secondary"
+										size="medium"
+										emphasis="low"
+									/>
+								</Box>
+								<LogsHistogram
+									query={query}
+									startDate={startDate}
+									endDate={endDate}
+									onDatesChange={(startDate, endDate) => {
+										setSelectedDates([startDate, endDate])
 									}}
-								>
-									Alerts
-								</Tag>
-								<IconSolidCheveronRight />
-								<Text
-									color="moderate"
-									size="small"
-									weight="medium"
-									userSelect="none"
-								>
-									Log monitor
-								</Text>
+									onLevelChange={() => {}}
+									outline
+									threshold={threshold}
+									belowThreshold={belowThreshold}
+									frequencySeconds={frequency}
+								/>
 							</Box>
-							<PreviousDateRangePicker
-								selectedDates={selectedDates}
-								onDatesChange={setSelectedDates}
-								presets={LOG_TIME_PRESETS}
-								minDate={thirtyDaysAgo}
-								kind="secondary"
-								size="medium"
-								emphasis="low"
-							/>
-						</Box>
-						<LogsHistogram
-							query={query}
-							startDate={startDate}
-							endDate={endDate}
-							onDatesChange={(startDate, endDate) => {
-								setSelectedDates([startDate, endDate])
-							}}
-							onLevelChange={() => {}}
-							outline
-							threshold={threshold}
-							belowThreshold={belowThreshold}
-							frequencySeconds={frequency}
-						/>
-					</Box>
-					<Form state={form} resetOnSubmit={false}>
-						<LogAlertForm {...{ startDate, endDate }} />
-					</Form>
-				</Container>
+							<Form state={form} resetOnSubmit={false}>
+								<LogAlertForm {...{ startDate, endDate }} />
+							</Form>
+						</Container>
+					</>
+				)}
 			</Box>
 		</Box>
 	)
@@ -412,6 +475,9 @@ const LogAlertForm = ({
 			value: email,
 			id: email,
 		}))
+
+	console.log('form.values.discordChannels', form.values.discordChannels)
+	console.log('form.values.slackChannels', form.values.slackChannels)
 
 	return (
 		<Box cssClass={styles.grid}>
@@ -507,7 +573,7 @@ const LogAlertForm = ({
 				<Form.Input
 					name={form.names.name}
 					type="text"
-					placeholder="Type alert name"
+					placeholder="Alert name"
 					label="Name"
 				/>
 
@@ -540,7 +606,6 @@ const LogAlertForm = ({
 				</Box>
 
 				<Box borderTop="dividerWeak" width="full" />
-
 				<Form.NamedSection
 					label="Slack channels to notify"
 					name={form.names.slackChannels}
@@ -549,13 +614,25 @@ const LogAlertForm = ({
 						aria-label="Slack channels to notify"
 						placeholder="Select Slack channels"
 						options={slackChannels}
-						onChange={(values: any): any =>
-							form.setValue(form.names.slackChannels, values)
-						}
+						onChange={(values) => {
+							form.setValue(
+								form.names.slackChannels,
+								values.map((v: any) => ({
+									webhook_channel_name: v.label,
+									webhook_channel_id: v.value,
+									...v,
+								})),
+							)
+						}}
 						value={form.values.slackChannels}
-						notFoundContent={<p>No channel suggestions</p>}
+						notFoundContent={
+							<Link to="/integrations">
+								Connect Highlight with Slack
+							</Link>
+						}
 						className={styles.selectContainer}
 						mode="multiple"
+						labelInValue
 					/>
 				</Form.NamedSection>
 
@@ -567,13 +644,25 @@ const LogAlertForm = ({
 						aria-label="Discord channels to notify"
 						placeholder="Select Discord channels"
 						options={discordChannels}
-						onChange={(values: any): any =>
-							form.setValue(form.names.discordChannels, values)
-						}
+						onChange={(values) => {
+							form.setValue(
+								form.names.discordChannels,
+								values.map((v: any) => ({
+									name: v.label,
+									id: v.value,
+									...v,
+								})),
+							)
+						}}
 						value={form.values.discordChannels}
-						notFoundContent={<p>No channel suggestions</p>}
+						notFoundContent={
+							<Link to="/integrations">
+								Connect Highlight with Discord
+							</Link>
+						}
 						className={styles.selectContainer}
 						mode="multiple"
+						labelInValue
 					/>
 				</Form.NamedSection>
 
@@ -667,8 +756,8 @@ interface LogMonitorForm {
 	threshold: number | undefined
 	frequency: number
 	excludedEnvironments: string[]
-	slackChannels: SanitizedSlackChannel[]
-	discordChannels: DiscordChannel[]
+	slackChannels: SanitizedSlackChannelInput[]
+	discordChannels: DiscordChannelInput[]
 	emails: string[]
 	webhookDestinations: string[]
 }

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -112,15 +112,6 @@ export const LogAlertPage = () => {
 
 	useEffect(() => {
 		if (!loading && data) {
-			console.log(
-				'test',
-				data?.log_alert.ChannelsToNotify.map((c) => ({
-					...c,
-					displayValue: c.webhook_channel,
-					value: c.webhook_channel_id,
-					id: c.webhook_channel_id,
-				})),
-			)
 			form.setValues({
 				query: data?.log_alert.query,
 				name: data?.log_alert.Name,
@@ -148,7 +139,6 @@ export const LogAlertPage = () => {
 				threshold: data?.log_alert.CountThreshold,
 				frequency: data?.log_alert.ThresholdWindow,
 			})
-			console.log('form.values.slackChannels', form.values.slackChannels)
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data, loading])
@@ -475,9 +465,6 @@ const LogAlertForm = ({
 			value: email,
 			id: email,
 		}))
-
-	console.log('form.values.discordChannels', form.values.discordChannels)
-	console.log('form.values.slackChannels', form.values.slackChannels)
 
 	return (
 		<Box cssClass={styles.grid}>

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -107,6 +107,7 @@ export const LogAlertPage = () => {
 			emails: [],
 			threshold: undefined,
 			frequency: 15,
+			loaded: false,
 		},
 	})
 
@@ -138,6 +139,7 @@ export const LogAlertPage = () => {
 				emails: data?.log_alert.EmailsToNotify,
 				threshold: data?.log_alert.CountThreshold,
 				frequency: data?.log_alert.ThresholdWindow,
+				loaded: true,
 			})
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -311,6 +313,8 @@ export const LogAlertPage = () => {
 		</Box>
 	)
 
+	const isLoading = !isCreate && !form.values.loaded
+
 	return (
 		<Box width="full" background="raised" p="8">
 			<Box
@@ -323,8 +327,8 @@ export const LogAlertPage = () => {
 				flexDirection="column"
 				height="full"
 			>
-				{loading && <LoadingBox />}
-				{!loading && (
+				{isLoading && <LoadingBox />}
+				{!isLoading && (
 					<>
 						{header}
 						<Container
@@ -747,6 +751,7 @@ interface LogMonitorForm {
 	discordChannels: DiscordChannelInput[]
 	emails: string[]
 	webhookDestinations: string[]
+	loaded: boolean
 }
 
 export default LogAlertPage

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -5,6 +5,7 @@ import {
 	Box,
 	Combobox,
 	Form,
+	IconSolidPlus,
 	IconSolidSearch,
 	IconSolidSwitchVertical,
 	IconSolidXCircle,
@@ -27,7 +28,12 @@ import {
 } from '@pages/LogsPage/SearchForm/utils'
 import { useParams } from '@util/react-router/useParams'
 import moment from 'moment'
+import { stringify } from 'query-string'
 import React, { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { DateTimeParam, encodeQueryParams, StringParam } from 'use-query-params'
+
+import { Button } from '@/components/Button'
 
 import * as styles from './SearchForm.css'
 
@@ -54,6 +60,7 @@ const SearchForm = ({
 	minDate,
 	timeMode,
 }: Props) => {
+	const navigate = useNavigate()
 	const [selectedDates, setSelectedDates] = useState([startDate, endDate])
 	const formState = useFormState({ defaultValues: { query: initialQuery } })
 	const { projectId } = useProjectId()
@@ -99,7 +106,7 @@ const SearchForm = ({
 					keys={keysData?.logs_keys}
 					keysLoading={keysLoading}
 				/>
-				<Box display="flex" pr="8" py="6">
+				<Box display="flex" pr="8" py="6" gap="6">
 					<PreviousDateRangePicker
 						emphasis="low"
 						selectedDates={selectedDates}
@@ -108,6 +115,32 @@ const SearchForm = ({
 						minDate={minDate}
 						disabled={timeMode === 'permalink'}
 					/>
+					<Button
+						kind="secondary"
+						trackingId="create-alert"
+						onClick={() => {
+							const encodedQuery = encodeQueryParams(
+								{
+									query: StringParam,
+									start_date: DateTimeParam,
+									end_date: DateTimeParam,
+								},
+								{
+									query: formState.values.query,
+									start_date: startDate,
+									end_date: endDate,
+								},
+							)
+							navigate({
+								pathname: '/alerts/logs/new',
+								search: stringify(encodedQuery),
+							})
+						}}
+						emphasis="medium"
+						iconLeft={<IconSolidPlus />}
+					>
+						Create alert
+					</Button>{' '}
 				</Box>
 			</Box>
 		</Form>


### PR DESCRIPTION
## Summary
- url in the email/slack/discord alerts links to the logs page
- add `create alert` button to logs page
- log alert page uses the same query params as the logs page
- fix bug where selecting slack / discord channels was broken
- use spinner loading state for logs histogram
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click test locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
