### PR TITLE
public sessions fixup - remove auth check for retention period

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -3126,11 +3126,12 @@ func GetMetricTimeline(ctx context.Context, tdb timeseries.DB, projectID int, me
 	return
 }
 
-func (r *Resolver) GetProjectRetentionDate(ctx context.Context, projectId int) (time.Time, error) {
-	project, err := r.isAdminInProjectOrDemoProject(ctx, projectId)
-	if err != nil {
-		return time.Time{}, err
+func (r *Resolver) GetProjectRetentionDate(projectId int) (time.Time, error) {
+	var project *model.Project
+	if err := r.DB.Model(&model.Project{}).Where("id = ?", projectId).First(&project).Error; err != nil {
+		return time.Time{}, e.Wrap(err, "error querying project")
 	}
+
 	workspace, err := r.GetWorkspace(project.WorkspaceID)
 	if err != nil {
 		return time.Time{}, err

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3770,7 +3770,7 @@ func (r *queryResolver) Session(ctx context.Context, secureID string) (*model.Se
 		return nil, nil
 	}
 
-	retentionDate, err := r.GetProjectRetentionDate(ctx, s.ProjectID)
+	retentionDate, err := r.GetProjectRetentionDate(s.ProjectID)
 	if err != nil {
 		return nil, err
 	}
@@ -4001,7 +4001,7 @@ func (r *queryResolver) ErrorGroup(ctx context.Context, secureID string) (*model
 	if err != nil {
 		return nil, err
 	}
-	retentionDate, err := r.GetProjectRetentionDate(ctx, eg.ProjectID)
+	retentionDate, err := r.GetProjectRetentionDate(eg.ProjectID)
 	if err != nil {
 		return nil, err
 	}
@@ -4036,7 +4036,7 @@ func (r *queryResolver) ErrorInstance(ctx context.Context, errorGroupSecureID st
 		return nil, e.Wrap(err, "not authorized to view error group")
 	}
 
-	retentionDate, err := r.GetProjectRetentionDate(ctx, errorGroup.ProjectID)
+	retentionDate, err := r.GetProjectRetentionDate(errorGroup.ProjectID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- this method is only called from other resolvers that are already doing their own auth checks
- this broke making a session public
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- made a session public locally, validated I was able to view it incognito
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
