### PR TITLE
forward electron close events to highlight client

### DIFF
--- a/sdk/firstload/src/environments/electron.ts
+++ b/sdk/firstload/src/environments/electron.ts
@@ -10,5 +10,9 @@ export default function configureElectronHighlight(window: any) {
 		window.on('blur', () => {
 			window.webContents.send('highlight.run', { visible: false })
 		})
+
+		window.on('close', () => {
+			window.webContents.send('highlight.run', { visible: false })
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Ensure that electron app closing forwards an event to the renderer thread so that
the highlight client can issue a `navigator.sendBeacon` payload.

## How did you test this change?

Local deploy of an electron sample app.
The local backend received a beacon event with remaining rrweb events as soon as the electron window was closed.
<img width="292" alt="Screenshot 2023-04-12 at 11 28 52 AM" src="https://user-images.githubusercontent.com/1351531/231551356-910f1a77-6ae8-4130-a0a6-61a3a017f544.png">

Will follow up on improving docs in #4947 
Will add an e2e test for electron and event listeners in #4588

## Are there any deployment considerations?

Will publish a new version of the highlight.run client in another PR.
