### PR TITLE
use db.Exec in lambda delete job

### DIFF
--- a/backend/lambda-functions/deleteSessions/handlers/handlers.go
+++ b/backend/lambda-functions/deleteSessions/handlers/handlers.go
@@ -120,14 +120,14 @@ func (h *handlers) DeleteSessionBatchFromPostgres(ctx context.Context, event uti
 	}
 
 	if !event.DryRun {
-		if err := h.db.Raw(`
+		if err := h.db.Exec(`
 			DELETE FROM session_fields
 			WHERE session_id in (?)
 		`, sessionIds).Error; err != nil {
 			return nil, errors.Wrap(err, "error deleting session fields")
 		}
 
-		if err := h.db.Raw(`
+		if err := h.db.Exec(`
 			DELETE FROM sessions
 			WHERE id in (?)
 		`, sessionIds).Error; err != nil {


### PR DESCRIPTION
## Summary
- need to use `db.Exec` instead of `db.Raw` to delete from postgres
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will validate post-release
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
