### PR TITLE
Revert "Resolve @highlight-run/client without relative paths"

### DIFF
--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -157,6 +157,12 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 
 ## 6.0.1
 
-### Minor Changes
+### Patch Changes
 
 - Fixes `H.track` reporting to ensure events are recorded as part of the session timeline indicators.
+
+## 6.0.2
+
+### Patch Changes
+
+- Fixes typescript definitions for `highlight.run` which referenced an internal unpublished package.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "6.0.1",
+	"version": "6.0.2",
 	"scripts": {
 		"build": "rollup -c",
 		"dev": "rollup -c -w",

--- a/sdk/firstload/rollup.config.js
+++ b/sdk/firstload/rollup.config.js
@@ -22,19 +22,7 @@ const basePlugins = [
 	consts({
 		publicGraphURI: process.env.PUBLIC_GRAPH_URI,
 	}),
-	resolve({
-		browser: true,
-		// @highlight-run/client is a private package not published to npm, so
-		// listing it in package.json would break end users.
-		// Instead, we add root node_modules as a resolution path so it gets
-		// resolved as an internal module and included directly in the bundle.
-		// An alternative to the previous solution using relative paths that
-		// point outside package root described here:
-		// https://www.highlight.io/blog/publishing-private-pnpm-monorepo
-		modulePaths: ['../../node_modules'],
-		// Need to override this to add .ts and .tsx as valid resolution exts.
-		extensions: ['.mjs', '.js', '.json', '.node', '.ts', '.tsx'],
-	}),
+	resolve({ browser: true }),
 	webWorkerLoader({
 		targetPlatform: 'browser',
 		inline: true,

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -6,20 +6,17 @@ import {
 } from './integrations/amplitude'
 import { MixpanelAPI, setupMixpanelIntegration } from './integrations/mixpanel'
 import { initializeFetchListener } from './listeners/fetch'
-import { getPreviousSessionData } from '@highlight-run/client/src/utils/sessionStorage/highlightSession'
-import { FirstLoadListeners } from '@highlight-run/client/src/listeners/first-load-listeners'
-import { GenerateSecureID } from '@highlight-run/client/src/utils/secure-id'
-import type {
-	Highlight,
-	HighlightClassOptions,
-} from '@highlight-run/client/src/index'
+import { getPreviousSessionData } from '../../client/src/utils/sessionStorage/highlightSession'
+import { FirstLoadListeners } from '../../client/src/listeners/first-load-listeners'
+import { GenerateSecureID } from '../../client/src/utils/secure-id'
+import type { Highlight, HighlightClassOptions } from '../../client/src/index'
 import type {
 	HighlightOptions,
 	HighlightPublicInterface,
 	Metadata,
 	Metric,
 	SessionDetails,
-} from '@highlight-run/client/src/types/types'
+} from '../../client/src/types/types'
 import HighlightSegmentMiddleware from './integrations/segment'
 import configureElectronHighlight from './environments/electron'
 


### PR DESCRIPTION
Reverts highlight/highlight#4851

The changes to firstload -> client imports break types checking in packages using highlight.run after #4851
```
[1] 11:03:22 AM - Found 1 error. Watching for file changes.
[2] node_modules/highlight.run/dist/firstload/src/index.d.ts(1,65): error TS2307: Cannot find module '@highlight-run/client/src/types/types' or its corresponding type declarations.
[2] wait-on http://127.0.0.1:3000 && tsc -p electron && electron . exited with code 1
```
Looks like that's because our npm.js package packages the typescript definitions with their imports from the client package, which is not a public package.
```
 ~/w/react-typescript-electron-sample-with-create-react-app-and-electron-builder   master ±  cat node_modules/highlight.run/dist/firstload/src/index.d.ts
import type { HighlightOptions, HighlightPublicInterface } from '@highlight-run/client/src/types/types';
import HighlightSegmentMiddleware from './integrations/segment';
import configureElectronHighlight from './environments/electron';
export declare enum MetricCategory {
    Device = "Device",
    WebVital = "WebVital",
    Frontend = "Frontend",
    Backend = "Backend"
}
export declare const H: HighlightPublicInterface;
export { HighlightSegmentMiddleware, configureElectronHighlight };
export type { HighlightOptions };
```

To fix this, we need some way to tell firstload typescript to bundle the client types in firstload and reference the local imports.

cc @lewisl9029 