### PR TITLE
Adds `tracingOrigins` to Sveltekit docs

### DIFF
--- a/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
@@ -17,6 +17,7 @@ import { H } from 'highlight.run';
 H.init('<YOUR_PROJECT_ID>', {
     environment: 'production',
     version: 'commit:abcdefg12345',
+    tracingOrigins: true,
 	networkRecording: {
 		enabled: true,
 		recordHeadersAndBody: true,


### PR DESCRIPTION
## Summary

Adds tracingOrigins to Sveltekit docs. Called out by our dear friend James Q Quick.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
clicktest

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
n/a

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
