### PR TITLE
fix build failures due to incorrect turbo cache setting

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -28,7 +28,14 @@
 		"typegen": {
 			"dependsOn": ["^typegen"],
 			"inputs": ["src/**/*.tsx", "src/**/*.ts", "tsconfig.json"],
-			"outputs": ["dist/**/*.d.ts"]
+			"outputs": [
+				"lib/**",
+				"es/**",
+				"dist/**",
+				"typings/**",
+				"build/**",
+				"esm/**"
+			]
 		},
 		"build": {
 			"dependsOn": ["codegen", "typegen", "^build"],


### PR DESCRIPTION
## Summary

Because rrweb `typegen` commands also output js, we need to make sure they are cached from the step.
Otherwise, a build where the `typegen` output is retrieved from cache fails as follows:
![Screenshot 2023-04-12 at 2 23 18 PM](https://user-images.githubusercontent.com/1351531/231588202-f442ad8c-949d-4096-b7f8-ff2496e0d87e.png)

## How did you test this change?

Local build with cache.
![Screenshot 2023-04-12 at 2 26 06 PM](https://user-images.githubusercontent.com/1351531/231588776-7a374309-7467-4bee-8ebc-2cdf2caee7a3.png)


## Are there any deployment considerations?

No
