### PR TITLE
Nextjs Docs Change

### DIFF
--- a/docs-content/getting-started/1_overview.md
+++ b/docs-content/getting-started/1_overview.md
@@ -22,8 +22,8 @@ Installing highlight.io in javascript will automatically instrument frontend err
     <DocsCard title="Gatsby"  href="./client-sdk/gatsbyjs.md">
         {"Get started in your Gatsby app"}
     </DocsCard>
-    <DocsCard title="NextJS"  href="./client-sdk/nextjs.md">
-        {"Get started in your NextJS app"}
+    <DocsCard title="Next.js"  href="./client-sdk/nextjs.md">
+        {"Get started in your Next.js app"}
     </DocsCard>
     <DocsCard title="VueJS"  href="./client-sdk/vuejs.md">
         {"Get started in your VueJS app"}

--- a/docs-content/getting-started/4_backend-sdk/js/nextjs.md
+++ b/docs-content/getting-started/4_backend-sdk/js/nextjs.md
@@ -1,9 +1,0 @@
----
-title: Next.JS
-slug: nextjs
-createdAt: 2022-03-28T20:31:15.000Z
-updatedAt: 2022-04-06T20:22:54.000Z
-quickstart: true
----
-
-### [See the Next.JS Fullstack Integration Guide here.](../../fullstack-frameworks/next-js/1_overview.md)

--- a/docs-content/getting-started/fullstack-frameworks/next-js/1_overview.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/1_overview.md
@@ -14,6 +14,17 @@ The Highlight Next.js SDK adds additional features to Highlight, including:
 - automatic proxying for Highlight requests using Next.js rewrites
 
 ## Getting Started
+### Quick Start?
+
+Before getting started with NextJS specific features, we recommend installing a basic SDK setup. Read more below:
+
+<DocsCardGroup>
+    <DocsCard title="NextJS Quickstart" href="../../3_client-sdk/2_nextjs.md">
+        {"Get started with NextJS in just a few lines of code."}
+    </DocsCard>
+</DocsCardGroup>
+
+### The Next.js NPM Package
 
 The features in this SDK require the Highlight client SDK to be installed, so please follow the [Next.js](../../3_client-sdk/2_nextjs.md) frontend instructions if you have not yet done so.
 

--- a/docs-content/getting-started/fullstack-frameworks/next-js/1_overview.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/1_overview.md
@@ -14,13 +14,14 @@ The Highlight Next.js SDK adds additional features to Highlight, including:
 - automatic proxying for Highlight requests using Next.js rewrites
 
 ## Getting Started
+
 ### Quick Start?
 
-Before getting started with NextJS specific features, we recommend installing a basic SDK setup. Read more below:
+Before getting started with Next.js specific features, we recommend installing a basic SDK setup. Read more below:
 
 <DocsCardGroup>
-    <DocsCard title="NextJS Quickstart" href="../../3_client-sdk/2_nextjs.md">
-        {"Get started with NextJS in just a few lines of code."}
+    <DocsCard title="Next.js Quickstart" href="../../3_client-sdk/2_nextjs.md">
+        {"Get started with Next.js in just a few lines of code."}
     </DocsCard>
 </DocsCardGroup>
 

--- a/docs-content/getting-started/fullstack-frameworks/next-js/env-variables.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/env-variables.md
@@ -1,5 +1,5 @@
 ---
-title: Sourcemaps in NextJS
+title: Sourcemaps in Next.js
 slug: nextjs-sdk
 createdAt: 2022-04-01T20:28:06.000Z
 updatedAt: 2022-10-18T22:40:13.000Z

--- a/docs-content/sdk/client.md
+++ b/docs-content/sdk/client.md
@@ -13,7 +13,7 @@ slug: client
   </div>
   <div className="right">
     <h6>Just getting started?</h6>
-    <p>Check out our [getting started guide](https://google.com) to get up and running quickly.</p>
+    <p>Check out our [getting started guide](../getting-started/1_overview.md) to get up and running quickly.</p>
   </div>
 </section>
 

--- a/docs-content/sdk/go.md
+++ b/docs-content/sdk/go.md
@@ -12,7 +12,7 @@ slug: go
   </div>
   <div className="right">
     <h6>Just getting started?</h6>
-    <p>Check out our [getting started guide](https://google.com) to get up and running quickly.</p>
+    <p>Check out our [getting started guide](../getting-started/4_backend-sdk/go/1_overview.md) to get up and running quickly.</p>
   </div>
 </section>
 

--- a/docs-content/sdk/nextjs.md
+++ b/docs-content/sdk/nextjs.md
@@ -13,7 +13,7 @@ quickstart: true
   </div>
   <div className="right">
     <h6>Just getting started?</h6>
-    <p>Check out our [getting started guide](https://google.com) to get up and running quickly.</p>
+    <p>Check out our [getting started guide](../getting-started/1_overview.md) to get up and running quickly.</p>
   </div>
 </section>
 

--- a/docs-content/sdk/nodejs.md
+++ b/docs-content/sdk/nodejs.md
@@ -12,14 +12,14 @@ slug: nodejs
   </div>
   <div className="right">
     <h6>Just getting started?</h6>
-    <p>Check out our [getting started guide](https://google.com) to get up and running quickly.</p>
+    <p>Check out our [getting started guide](../getting-started/4_backend-sdk/js/1_overview.md) to get up and running quickly.</p>
   </div>
 </section>
 
 <section className="section">
   <div className="left">
     <h3>H.init</h3>
-    <p>H.init() initializes the Highlight backend SDK. If you are not using any of the provided handlers for [Express](https://google.com), it is required to call this method before recording backend errors or metrics.</p>
+    <p>H.init() initializes the Highlight backend SDK. If you are not using any of the provided handlers for [Express](../getting-started/4_backend-sdk/js/express.md), it is required to call this method before recording backend errors or metrics.</p>
     <h6>Method Parameters</h6>
     <aside className="parameter">
       <h5>options<code>NodeOptions</code> <code>required</code></h5>

--- a/docs-content/sdk/python.md
+++ b/docs-content/sdk/python.md
@@ -12,7 +12,7 @@ slug: python
   </div>
   <div className="right">
     <h6>Just getting started?</h6>
-    <p>Check out our [getting started guide](https://google.com) to get up and running quickly.</p>
+    <p>Check out our [getting started guide](../getting-started/4_backend-sdk/python/1_overview.md) to get up and running quickly.</p>
   </div>
 </section>
 

--- a/highlight.io/components/QuickstartContent/frontend/next.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/next.tsx
@@ -21,7 +21,7 @@ const next13DocsLink = siteUrl(
 
 export const nextBackendSnippet: QuickStartStep = {
 	title: 'More Next.js features?',
-	content: `With Next.js, we support automatic sourcemap uploading, network proxying, and log destinations. Read more in our Next.js [overview guide](${nextJSOverviewLink}).`,
+	content: `With Next.js, we have an additional package (\`@highlight-run/next\`) which supports automatic sourcemap uploading, network proxying, and log destinations. Read more in our Next.js [overview guide](${nextJSOverviewLink}).`,
 }
 
 export const next13Snippet: QuickStartStep = {

--- a/highlight.io/components/QuickstartContent/frontend/next.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/next.tsx
@@ -36,9 +36,9 @@ export default function App({ Component, pageProps }: AppProps) {
 	// other page level logic ...
   
 	return (
-	  <ErrorBoundary>
-		<Component {...pageProps} />
-	  </ErrorBoundary>
+		<ErrorBoundary>
+			<Component {...pageProps} />
+		</ErrorBoundary>
 	);
 }`
 

--- a/highlight.io/components/QuickstartContent/frontend/next.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/next.tsx
@@ -10,12 +10,16 @@ import {
 
 const ErrorBoundaryCodeSnippet = `import { ErrorBoundary } from '@highlight-run/react';
 
-ReactDOM.render(
-    <ErrorBoundary>
-        <App />
-    </ErrorBoundary>,
-    document.getElementById('root')
-);`
+export default function App({ Component, pageProps }: AppProps) {
+
+	// other page level logic ...
+  
+	return (
+	  <ErrorBoundary>
+		<Component {...pageProps} />
+	  </ErrorBoundary>
+	);
+}`
 
 export const NextContent: QuickStartContent = {
 	title: 'Next.js',

--- a/highlight.io/components/QuickstartContent/frontend/next.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/next.tsx
@@ -1,12 +1,33 @@
 import { siteUrl } from '../../../utils/urls'
-import { QuickStartContent } from '../QuickstartContent'
+import { QuickStartContent, QuickStartStep } from '../QuickstartContent'
 import {
 	configureSourcemapsCI,
 	identifySnippet,
 	initializeSnippet,
-	setupBackendSnippet,
 	verifySnippet,
 } from './shared-snippets'
+
+const reactErrorBoundaryLink = siteUrl(
+	'/docs/getting-started/client-sdk/replay-configuration',
+)
+
+const nextJSOverviewLink = siteUrl(
+	'/docs/getting-started/fullstack-frameworks/next-js/overview',
+)
+
+const next13DocsLink = siteUrl(
+	'/docs/getting-started/fullstack-frameworks/next-js/next-13-considerations',
+)
+
+export const nextBackendSnippet: QuickStartStep = {
+	title: 'More Next.js features?',
+	content: `With Next.js, we support automatic sourcemap uploading, network proxying, and log destinations. Read more in our Next.js [overview guide](${nextJSOverviewLink}).`,
+}
+
+export const next13Snippet: QuickStartStep = {
+	title: 'Using the `app` dir?',
+	content: `If you're using the \`app\` directory, you'll need to ensure that highlight.io gets intialized in a client-only context. See or docs on [Next.js 13 considerations](${next13DocsLink}).`,
+}
 
 const ErrorBoundaryCodeSnippet = `import { ErrorBoundary } from '@highlight-run/react';
 
@@ -40,10 +61,11 @@ yarn add highlight.run @highlight-run/react`,
 				language: 'bash',
 			},
 		},
+		next13Snippet,
 		initializeSnippet,
 		{
 			title: 'Add the ErrorBoundary component. (optional)',
-			content: `The ErrorBoundary component wraps your component tree and catches crashes/exceptions from your react app. When a crash happens, if \`showDialog\` is set, your users will be prompted with a modal to share details about what led up to the crash. Read more [here](/docs/getting-started/client-sdk/replay-configuration/react-error-boundary#__next)`,
+			content: `The ErrorBoundary component wraps your component tree and catches crashes/exceptions from your react app. When a crash happens, if \`showDialog\` is set, your users will be prompted with a modal to share details about what led up to the crash. Read more [here](${reactErrorBoundaryLink}).`,
 			code: {
 				text: ErrorBoundaryCodeSnippet,
 				language: 'js',
@@ -54,6 +76,6 @@ yarn add highlight.run @highlight-run/react`,
 		configureSourcemapsCI(
 			'/docs/getting-started/fullstack-frameworks/next-js/env-variables',
 		),
-		setupBackendSnippet,
+		nextBackendSnippet,
 	],
 }

--- a/highlight.io/components/QuickstartContent/frontend/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/shared-snippets.tsx
@@ -61,13 +61,13 @@ export const initializeSnippet: QuickStartStep = {
 import { H } from 'highlight.run';
 
 H.init('<YOUR_PROJECT_ID>', {
-    tracingOrigins: true,
+	tracingOrigins: true,
 	networkRecording: {
 		enabled: true,
 		recordHeadersAndBody: true,
-        urlBlocklist: [
-            // insert urls you don't want to record here
-        ],
+		urlBlocklist: [
+			// insert urls you don't want to record here
+		],
 	},
 });
 

--- a/highlight.io/components/QuickstartContent/frontend/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/shared-snippets.tsx
@@ -23,6 +23,9 @@ export const sessionReplayFeaturesLink = siteUrl(
 export const identifyingUsersLink = siteUrl(
 	'/docs/getting-started/client-sdk/replay-configuration/identifying-sessions',
 )
+export const sessionSearchLink = siteUrl(
+	'/docs/general/product-features/session-replay/session-search',
+)
 export const backendInstrumentationLink = siteUrl(
 	'/docs/getting-started/overview#For-your-backend',
 )
@@ -76,13 +79,21 @@ H.init('<YOUR_PROJECT_ID>', {
 
 export const identifySnippet: QuickStartStep = {
 	title: 'Identify users.',
-	content: `Identify users to tie their sessions/errors to their account. We suggest doing this after the authentication flow of your web app. \n\n\nThe first argument of \`identify\` will be searchable via the property \`identifier\`, and the second property is searchable by the key of each item in the object. Read more about this in our [identifying users](${identifyingUsersLink}) section.`,
+	content: `Identify users after the authentication flow of your web app. We reccommend doing this in a \`useEffect\` call or in any asynchronous, client-side context. \n\n\nThe first argument of \`identify\` will be searchable via the property \`identifier\`, and the second property is searchable by the key of each item in the object. \n\n\nFor more details, read about [session search](${sessionSearchLink}) or how to [identify users](${identifyingUsersLink}).`,
 	code: {
-		text: `H.identify('jay@highlight.io', {
-    id: 'very-secure-id',
-    phone: '867-5309',
-    bestFriend: 'jenny'
-});`,
+		text: `useEffect(() => {
+
+	// login logic...
+
+	H.identify('jay@highlight.io', {
+		id: 'very-secure-id',
+		phone: '867-5309',
+		bestFriend: 'jenny'
+	});
+
+
+}, [...])
+`,
 		language: 'js',
 	},
 }

--- a/highlight.io/components/QuickstartContent/frontend/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/shared-snippets.tsx
@@ -79,7 +79,7 @@ H.init('<YOUR_PROJECT_ID>', {
 
 export const identifySnippet: QuickStartStep = {
 	title: 'Identify users.',
-	content: `Identify users after the authentication flow of your web app. We reccommend doing this in a \`useEffect\` call or in any asynchronous, client-side context. \n\n\nThe first argument of \`identify\` will be searchable via the property \`identifier\`, and the second property is searchable by the key of each item in the object. \n\n\nFor more details, read about [session search](${sessionSearchLink}) or how to [identify users](${identifyingUsersLink}).`,
+	content: `Identify users after the authentication flow of your web app. We recommend doing this in a \`useEffect\` call or in any asynchronous, client-side context. \n\n\nThe first argument of \`identify\` will be searchable via the property \`identifier\`, and the second property is searchable by the key of each item in the object. \n\n\nFor more details, read about [session search](${sessionSearchLink}) or how to [identify users](${identifyingUsersLink}).`,
 	code: {
 		text: `useEffect(() => {
 


### PR DESCRIPTION
## Summary
- Adds `useEffect` to the identify example + clarification on why that's preferred (resolves #4927)
- Adds proper links to getting started guides in the sdk docs (resolves #4928)
- Updates the ErrorBoundary NextJS instructions to reflect `create-next-app`'s `_app` structure (resolves #4926)
- Use the `siteUrl` macro in the `next.tsx` file (resolves #4925) - cc @ccschmitz to take a look at.
- Consolidate Next.js Docs (resolves #4961)
    - Gets rid of `docs-content/getting-started/4_backend-sdk/js/nextjs.md`
    - Adds `next13Snippet` and `nextBackendSnippet` to `next.tsx`


<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
Clicktest. For those that review, would be nice if you spun it up locally (or looked at the preview) to confirm everything looks good.

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
no

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
