### PR TITLE
fix white screen on log alert navigate, cancel goes back

### DIFF
--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -194,7 +194,7 @@ export const LogAlertPage = () => {
 					emphasis="low"
 					trackingId="closeLogMonitoringAlert"
 					onClick={() => {
-						navigate(`/${project_id}/alerts`)
+						navigate(-1)
 					}}
 				>
 					Cancel

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -132,7 +132,7 @@ const SearchForm = ({
 								},
 							)
 							navigate({
-								pathname: '/alerts/logs/new',
+								pathname: `/${projectId}/alerts/logs/new`,
 								search: stringify(encodedQuery),
 							})
 						}}


### PR DESCRIPTION
## Summary
- `navigate(-1)` from log alerts page to return to the previous page (since you can get there from alerts page or logs page)
- add `projectId` to path for creating alert to avoid the full page rerender
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
