### PR TITLE
ensure backend logs are autoselected when linked from logs -> session

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -77,9 +77,9 @@ const DevToolsWindowV2: React.FC<
 
 	const [searchShown, setSearchShown] = React.useState<boolean>(false)
 	const [levels, setLevels] = React.useState<LogLevel[]>([])
-	const [sources, setSources] = React.useState<LogSource[]>([
-		LogSource.Frontend,
-	])
+	const [sources, setSources] = React.useState<LogSource[]>(
+		logCursor ? [] : [LogSource.Frontend],
+	)
 	const form = useFormState({
 		defaultValues: {
 			search: '',
@@ -327,7 +327,13 @@ const DevToolsWindowV2: React.FC<
 											<MenuButton
 												divider
 												size="medium"
-												selectedKey={LogSource.Frontend}
+												selectedKey={
+													sources.includes(
+														LogSource.Frontend,
+													)
+														? LogSource.Frontend
+														: 'All'
+												}
 												options={LogSourceValues.map(
 													(source) => ({
 														key: source,


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

By default, when we load the session console logs, we autoselect Frontend only (see #4833). However, when we are linked from the log viewer, we should select "All" such that if a `source:backend` log was linked, it can be autoselected.

Fixes #4833

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Click tested to confirm that a `source:backend` log with a linked session correctly is autoselected when clicking "Related Session" on the log line.

![Kapture 2023-04-13 at 11 49 35](https://user-images.githubusercontent.com/58678/231842823-2f8ad7e2-13fb-484f-9403-88596a904057.gif)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
