### PR TITLE
Add vercel log drain docs

### DIFF
--- a/docs-content/general/7_integrations/vercel-integration.md
+++ b/docs-content/general/7_integrations/vercel-integration.md
@@ -5,6 +5,12 @@ createdAt: 2022-10-13T18:03:19.000Z
 updatedAt: 2022-10-13T18:09:17.000Z
 ---
 
+## Vercel SDK Integrations
+
 If you use Vercel to deploy your app, you can install the Vercel Highlight integration here: [https://vercel.com/integrations/highlight/](https://vercel.com/integrations/highlight/)
 
 After linking your Vercel projects to your Highlight projects, Highlight will automatically set the `HIGHLIGHT_SOURCEMAP_API_KEY` environment variable. If you're using `@higlight-run/sourcemap-uploader` or `withHighlightConfig` to upload your sourcemaps, those tools will check for this API key.
+
+## Vercel Log Drain Integrations
+
+If you use Vercel to deploy your server-side applications, the Vercel integration will also send your server-side logs to Highlight. You can view these logs in the Highlight UI by clicking on the "Logs" tab in your dashboard. To configure whether to collect logs in highlight.io, you can do this by limiting logs in your billing settings.

--- a/docs-content/general/7_integrations/vercel-integration.md
+++ b/docs-content/general/7_integrations/vercel-integration.md
@@ -15,6 +15,6 @@ More details on calling these methods [here](../../getting-started/fullstack-fra
 
 ## Vercel Log Drain Integrations
 
-If you use Vercel to deploy your server-side applications, the Vercel integration will also send your server-side logs to Highlight. You can view these logs in the Highlight UI by clicking on the "Logs" tab in your dashboard. To configure whether to collect logs in highlight.io, you can do this by limiting logs in your billing settings.
+If you use Vercel to deploy your server-side applications, the Vercel integration will also send your logs to Highlight. Vercel will forward build logs, lambda and edge function (server-side) logs, and static access logs. You can view these logs in the Highlight UI by clicking on the "Logs" tab in your dashboard. To configure whether to collect logs in highlight.io, you can do this by limiting logs in your billing settings.
 
 More details on turning on this integration [here](../../getting-started/backend-logging/6_hosting/vercel.md).

--- a/docs-content/general/7_integrations/vercel-integration.md
+++ b/docs-content/general/7_integrations/vercel-integration.md
@@ -5,12 +5,16 @@ createdAt: 2022-10-13T18:03:19.000Z
 updatedAt: 2022-10-13T18:09:17.000Z
 ---
 
+If you use Vercel to deploy your app, you can install the Vercel Highlight integration here: [https://vercel.com/integrations/highlight/](https://vercel.com/integrations/highlight/). Below are the details of what this integration provides.
+
 ## Vercel SDK Integrations
 
-If you use Vercel to deploy your app, you can install the Vercel Highlight integration here: [https://vercel.com/integrations/highlight/](https://vercel.com/integrations/highlight/)
-
 After linking your Vercel projects to your Highlight projects, Highlight will automatically set the `HIGHLIGHT_SOURCEMAP_API_KEY` environment variable. If you're using `@higlight-run/sourcemap-uploader` or `withHighlightConfig` to upload your sourcemaps, those tools will check for this API key.
+
+More details on calling these methods [here](../../getting-started/fullstack-frameworks/next-js/1_overview.md).
 
 ## Vercel Log Drain Integrations
 
 If you use Vercel to deploy your server-side applications, the Vercel integration will also send your server-side logs to Highlight. You can view these logs in the Highlight UI by clicking on the "Logs" tab in your dashboard. To configure whether to collect logs in highlight.io, you can do this by limiting logs in your billing settings.
+
+More details on turning on this integration [here](../../getting-started/backend-logging/6_hosting/vercel.md).

--- a/highlight.io/components/QuickstartContent/logging/hosting/vercel.tsx
+++ b/highlight.io/components/QuickstartContent/logging/hosting/vercel.tsx
@@ -3,14 +3,14 @@ import { QuickStartContent } from '../../QuickstartContent'
 import { verifyLogs } from '../shared-snippets'
 
 export const HostingVercelLogContent: QuickStartContent = {
-	title: 'Vercel',
+	title: 'Vercel Log Drain',
 	subtitle: 'Learn how to setup Highlight log ingestion on Vercel.',
 	logoUrl: siteUrl('/images/quickstart/vercel.svg'),
 	entries: [
 		{
 			title: 'Setup the Highlight Vercel integration.',
 			content:
-				'Visit the [Vercel Highlight Integration page](https://vercel.com/integrations/highlight) to install it in your account.' +
+				'Visit the [Vercel Highlight Integration page](https://vercel.com/integrations/highlight) to install it in your account. ' +
 				'A log drain will automatically be created for all projects you grant access to.',
 		},
 		verifyLogs,


### PR DESCRIPTION
## Summary

Adds vercel log drain docs to the integrations page. 

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
clicktest

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
n/a

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
