### PR TITLE
bundle web vitals listener into client

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -63,7 +63,7 @@ jobs:
 
             - name: Validate project is ready to be published
               if: github.repository == 'highlight/highlight' && steps.filter.outputs.npm-changed == 'true'
-              run: yarn prepublish
+              run: yarn validate
 
             # always publish client, even in PRs
             # this is ok because the final push to main of the version will replace

--- a/sdk/client/package.json
+++ b/sdk/client/package.json
@@ -66,7 +66,8 @@
 		"graphql-request": "^4.3.0",
 		"graphql-tag": "^2.12.6",
 		"json-stringify-safe": "^5.0.1",
-		"stacktrace-js": "2.0.2"
+		"stacktrace-js": "2.0.2",
+		"web-vitals": "^3.3.1"
 	},
 	"resolutions": {
 		"ansi-regex": "5.0.1",

--- a/sdk/client/src/listeners/web-vitals-listener/web-vitals-listener.tsx
+++ b/sdk/client/src/listeners/web-vitals-listener/web-vitals-listener.tsx
@@ -1,28 +1,17 @@
+import { onCLS, onFCP, onFID, onLCP, onTTFB, onINP } from 'web-vitals'
+
 interface Metric {
 	name: string
 	value: number
 }
 
 export const WebVitalsListener = (callback: (metric: Metric) => void) => {
-	const script = document.createElement('script')
-	script.src = 'https://static.highlight.io/web-vitals.iife.js'
-	script.onload = function () {
-		window?.webVitals?.getCLS(callback)
-		window?.webVitals?.getFCP(callback)
-		window?.webVitals?.getFID(callback)
-		window?.webVitals?.getLCP(callback)
-		window?.webVitals?.getTTFB(callback)
-	}
-	document.head.appendChild(script)
+	onCLS(callback)
+	onFCP(callback)
+	onFID(callback)
+	onLCP(callback)
+	onTTFB(callback)
+	onINP(callback)
 
-	return () => {
-		document.head.removeChild(script)
-	}
+	return () => {}
 }
-
-// eslint-disable-next-line no-unused-vars
-interface Window {
-	webVitals?: any
-}
-
-declare var window: Window

--- a/sdk/client/src/listeners/web-vitals-listener/web-vitals-listener.tsx
+++ b/sdk/client/src/listeners/web-vitals-listener/web-vitals-listener.tsx
@@ -1,9 +1,4 @@
-import { onCLS, onFCP, onFID, onLCP, onTTFB, onINP } from 'web-vitals'
-
-interface Metric {
-	name: string
-	value: number
-}
+import { onCLS, onFCP, onFID, onLCP, onTTFB, onINP, Metric } from 'web-vitals'
 
 export const WebVitalsListener = (callback: (metric: Metric) => void) => {
 	onCLS(callback)

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -166,3 +166,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Patch Changes
 
 - Fixes typescript definitions for `highlight.run` which referenced an internal unpublished package.
+
+## 6.0.3
+
+### Patch Changes
+
+- Packages the web-vitals library as part of the highlight.io client bundle.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "6.0.2",
+	"version": "6.0.3",
 	"scripts": {
 		"build": "rollup -c",
 		"dev": "rollup -c -w",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10989,6 +10989,7 @@ __metadata:
     stacktrace-js: 2.0.2
     typescript: ^4.1.3
     vitest: ^0.24.1
+    web-vitals: ^3.3.1
   languageName: unknown
   linkType: soft
 
@@ -53903,6 +53904,13 @@ __metadata:
   version: 3.2.1
   resolution: "web-streams-polyfill@npm:3.2.1"
   checksum: b119c78574b6d65935e35098c2afdcd752b84268e18746606af149e3c424e15621b6f1ff0b42b2676dc012fc4f0d313f964b41a4b5031e525faa03997457da02
+  languageName: node
+  linkType: hard
+
+"web-vitals@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "web-vitals@npm:3.3.1"
+  checksum: ff417dec2d77f57bc5130767f47aad6f93173e5d0e24a179082c7dca423850106ba1d66c737f91400a6bed6585a7295531d9e54354d1cb31d1a3e68596bb2000
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Switch to using an npm package for web vitals measurement. This bundles the web vitals logic into client
which is loaded asynchronously, and prevents Highlight from needing to fetch another file that would otherwise
often be blocked by ad-blockers.

## How did you test this change?

new session

![Screenshot 2023-04-13 at 5 05 33 PM](https://user-images.githubusercontent.com/1351531/231908824-ec0ce2be-e5a0-4bb0-b754-324b8178f71d.png)

no web vitals download but client has the npmjs library

![Screenshot 2023-04-13 at 5 09 55 PM](https://user-images.githubusercontent.com/1351531/231909299-a3011a25-5149-4244-8d93-96bd92531e37.png)


## Are there any deployment considerations?

Will publish new highlight.run package.
