### PR TITLE
Enforce billing quotas for errors / logs on ingest

### DIFF
--- a/backend/clickhouse/migrations/000010_log_count_daily_mv.down.sql
+++ b/backend/clickhouse/migrations/000010_log_count_daily_mv.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE log_count_daily_mv;

--- a/backend/clickhouse/migrations/000010_log_count_daily_mv.up.sql
+++ b/backend/clickhouse/migrations/000010_log_count_daily_mv.up.sql
@@ -1,0 +1,11 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS log_count_daily_mv
+ENGINE = SummingMergeTree
+PARTITION BY toDate(Day) ORDER BY (ProjectId, Day)
+POPULATE
+AS 
+SELECT
+    ProjectId,
+    toStartOfDay(Timestamp) AS Day,
+    count() as Count
+FROM logs
+GROUP BY ProjectId, Day;

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1460,27 +1460,6 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 		return false, e.Wrap(err, "Error creating error_fields_md5_idx")
 	}
 
-	if err := DB.Exec(`
-		CREATE TABLE IF NOT EXISTS default_billing_limits (planType, productType, quota)
-		AS SELECT 'Free', 'SESSIONS', 500
-		UNION SELECT 'Lite', 'SESSIONS', 2000
-		UNION SELECT 'Basic', 'SESSIONS', 10000
-		UNION SELECT 'Startup', 'SESSIONS', 80000
-		UNION SELECT 'Enterprise', 'SESSIONS', 300000
-		UNION SELECT 'Free', 'ERRORS', 1000
-		UNION SELECT 'Lite', 'ERRORS', 4000
-		UNION SELECT 'Basic', 'ERRORS', 20000
-		UNION SELECT 'Startup', 'ERRORS', 160000
-		UNION SELECT 'Enterprise', 'ERRORS', 600000
-		UNION SELECT 'Free', 'LOGS', 10000
-		UNION SELECT 'Lite', 'LOGS', 40000
-		UNION SELECT 'Basic', 'LOGS', 200000
-		UNION SELECT 'Startup', 'LOGS', 1600000
-		UNION SELECT 'Enterprise', 'LOGS', 6000000;
-	`).Error; err != nil {
-		return false, e.Wrap(err, "Error creating default_billing_limits")
-	}
-
 	// If sessions_id_seq is not greater than 30000000, set it
 	if err := DB.Exec(`
 		SELECT

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1460,6 +1460,27 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 		return false, e.Wrap(err, "Error creating error_fields_md5_idx")
 	}
 
+	if err := DB.Exec(`
+		CREATE TABLE IF NOT EXISTS default_billing_limits (planType, productType, quota)
+		AS SELECT 'Free', 'SESSIONS', 500
+		UNION SELECT 'Lite', 'SESSIONS', 2000
+		UNION SELECT 'Basic', 'SESSIONS', 10000
+		UNION SELECT 'Startup', 'SESSIONS', 80000
+		UNION SELECT 'Enterprise', 'SESSIONS', 300000
+		UNION SELECT 'Free', 'ERRORS', 1000
+		UNION SELECT 'Lite', 'ERRORS', 4000
+		UNION SELECT 'Basic', 'ERRORS', 20000
+		UNION SELECT 'Startup', 'ERRORS', 160000
+		UNION SELECT 'Enterprise', 'ERRORS', 600000
+		UNION SELECT 'Free', 'LOGS', 10000
+		UNION SELECT 'Lite', 'LOGS', 40000
+		UNION SELECT 'Basic', 'LOGS', 200000
+		UNION SELECT 'Startup', 'LOGS', 1600000
+		UNION SELECT 'Enterprise', 'LOGS', 6000000;
+	`).Error; err != nil {
+		return false, e.Wrap(err, "Error creating default_billing_limits")
+	}
+
 	// If sessions_id_seq is not greater than 30000000, set it
 	if err := DB.Exec(`
 		SELECT
@@ -1816,7 +1837,7 @@ func SendBillingNotifications(ctx context.Context, db *gorm.DB, mailClient *send
 
 	errors := []string{}
 	for _, toAddr := range toAddrs {
-		err := Email.SendBillingNotificationEmail(ctx, mailClient, emailType, workspace.ID, workspace.Name, toAddr.Email, toAddr.AdminID)
+		err := Email.SendBillingNotificationEmail(ctx, mailClient, workspace.ID, workspace.Name, workspace.RetentionPeriod, emailType, toAddr.Email, toAddr.AdminID)
 		if err != nil {
 			errors = append(errors, err.Error())
 		}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5459,7 +5459,7 @@ func (r *queryResolver) BillingDetails(ctx context.Context, workspaceID int) (*m
 	var logsMeter int64
 
 	g.Go(func() error {
-		sessionsMeter, err = pricing.GetWorkspaceSessionsMeter(r.DB, workspaceID)
+		sessionsMeter, err = pricing.GetWorkspaceSessionsMeter(ctx, r.DB, r.ClickhouseClient, workspace)
 		if err != nil {
 			return e.Wrap(err, "error from get quota")
 		}
@@ -5475,7 +5475,7 @@ func (r *queryResolver) BillingDetails(ctx context.Context, workspaceID int) (*m
 	})
 
 	g.Go(func() error {
-		errorsMeter, err = pricing.GetWorkspaceErrorsMeter(r.DB, workspaceID)
+		errorsMeter, err = pricing.GetWorkspaceErrorsMeter(ctx, r.DB, r.ClickhouseClient, workspace)
 		if err != nil {
 			return e.Wrap(err, "error querying errors meter")
 		}
@@ -5483,11 +5483,7 @@ func (r *queryResolver) BillingDetails(ctx context.Context, workspaceID int) (*m
 	})
 
 	g.Go(func() error {
-		workspace, err := r.Workspace(ctx, workspaceID)
-		if err != nil {
-			return err
-		}
-		logsMeter, err = pricing.GetWorkspaceLogsMeter(ctx, r.ClickhouseClient, *workspace)
+		logsMeter, err = pricing.GetWorkspaceLogsMeter(ctx, r.DB, r.ClickhouseClient, workspace)
 		if err != nil {
 			return e.Wrap(err, "error querying errors meter")
 		}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -840,11 +840,11 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 		defer util.Recover()
 		if workspace.PlanTier != privateModel.PlanTypeFree.String() && workspace.AllowMeterOverage {
 			if quotaPercent >= 1 {
-				if err := model.SendBillingNotifications(ctx, r.DB, r.MailClient, email.BillingSessionUsage100Percent, workspace); err != nil {
+				if err := model.SendBillingNotifications(ctx, r.DB, r.MailClient, email.BillingErrorsUsage100Percent, workspace); err != nil {
 					log.WithContext(ctx).Error(e.Wrap(err, "failed to send billing notifications"))
 				}
 			} else if quotaPercent >= .8 {
-				if err := model.SendBillingNotifications(ctx, r.DB, r.MailClient, email.BillingSessionUsage80Percent, workspace); err != nil {
+				if err := model.SendBillingNotifications(ctx, r.DB, r.MailClient, email.BillingErrorsUsage80Percent, workspace); err != nil {
 					log.WithContext(ctx).Error(e.Wrap(err, "failed to send billing notifications"))
 				}
 			}

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -3,13 +3,14 @@ package graph
 import (
 	"context"
 	"encoding/json"
-	"github.com/highlight-run/highlight/backend/timeseries"
-	"github.com/highlight-run/workerpool"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/timeseries"
+	"github.com/highlight-run/workerpool"
+	"github.com/stretchr/testify/assert"
 
 	e "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -205,7 +206,7 @@ func TestHandleErrorAndGroup(t *testing.T) {
 						t.Fatal(e.Wrap(err, "error unmarshalling error stack trace frames"))
 					}
 				}
-				errorGroup, err := r.HandleErrorAndGroup(context.TODO(), &errorObj, "", frames, nil, 1)
+				errorGroup, err := r.HandleErrorAndGroup(context.TODO(), &errorObj, "", frames, nil, 1, nil)
 				if err != nil {
 					t.Fatal(e.Wrap(err, "error handling error and group"))
 				}

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/highlight-run/highlight/backend/hlog"
 	kafkaqueue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/pricing"
 	generated1 "github.com/highlight-run/highlight/backend/public-graph/graph/generated"
 	customModels "github.com/highlight-run/highlight/backend/public-graph/graph/model"
 	"github.com/openlyinc/pointy"
@@ -63,9 +64,8 @@ func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureI
 			err = r.Redis.SetIsPendingSession(ctx, sessionSecureID, true)
 		}
 		if err == nil {
-			var exceeded bool
-			exceeded, err = r.Redis.IsBillingQuotaExceeded(ctx, projectID)
-			if err == nil && exceeded {
+			exceeded, err := r.Redis.IsBillingQuotaExceeded(ctx, projectID, pricing.ProductTypeSessions)
+			if err == nil && exceeded != nil && *exceeded {
 				err = e.New(string(customModels.PublicGraphErrorBillingQuotaExceeded))
 			}
 		}


### PR DESCRIPTION
## Summary
- use clickhouse materialized view to aggregate log counts per project per day 
- add billing notification emails when exceeding usage thresholds for errors + logs
- genericize a few methods to check quotas for sessions or errors or logs
- add quota check in `HandleErrorAndGroup` to skip if quota exceeded
- add quota check in logs ingest to skip if quota exceeded (uses redis for performance)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- testing is a WIP
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, can revert
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

Closes #4406 
