### PR TITLE
DX test - getting started docs fixes

### DIFF
--- a/docs-content/getting-started/backend-logging/3_python/1_overview.md
+++ b/docs-content/getting-started/backend-logging/3_python/1_overview.md
@@ -12,7 +12,7 @@ If you don't see one of your languages / frameworks below, reach out to us in ou
 
 
 <DocsCardGroup>
-    <DocsCard title="Python" href="./python.md">
+    <DocsCard title="Python" href="./python-install.md">
         {"Integrate logging in Python."}
     </DocsCard>
 </DocsCardGroup>

--- a/frontend/src/pages/Setup/SetupDocs.tsx
+++ b/frontend/src/pages/Setup/SetupDocs.tsx
@@ -64,7 +64,7 @@ export const SetupDocs: React.FC<Props> = ({ projectVerboseId }) => {
 												},
 											)
 										}}
-										text={entry.code.text.replace(
+										text={entry.code.text.replaceAll(
 											'<YOUR_PROJECT_ID>',
 											projectVerboseId,
 										)}

--- a/highlight.io/components/QuickstartContent/backend/js/apollo.tsx
+++ b/highlight.io/components/QuickstartContent/backend/js/apollo.tsx
@@ -32,7 +32,7 @@ import { ApolloServerHighlightPlugin } from '@highlight-run/apollo'
 const server = new ApolloServer({
   typeDefs,
   resolvers,
-  plugins: [ApolloServerHighlightPlugin({ projectID: 'YOUR_PROJECT_ID' })],
+  plugins: [ApolloServerHighlightPlugin({ projectID: '<YOUR_PROJECT_ID>' })],
 })`,
 				language: `js`,
 			},

--- a/highlight.io/components/QuickstartContent/backend/js/cloudflare.tsx
+++ b/highlight.io/components/QuickstartContent/backend/js/cloudflare.tsx
@@ -31,7 +31,7 @@ async function doRequest() {
 
 export default {
   async fetch(request: Request, env: {}, ctx: ExecutionContext) {
-    const hEnv = { HIGHLIGHT_PROJECT_ID: 'YOUR_PROJECT_ID' }
+    const hEnv = { HIGHLIGHT_PROJECT_ID: '<YOUR_PROJECT_ID>' }
     try {
       const response = await doRequest()
       H.sendResponse(request, hEnv, ctx, response)
@@ -49,7 +49,7 @@ export default {
 			'cloudflare',
 			`export default {
   async fetch(request: Request, env: {}, ctx: ExecutionContext) {
-    H.consumeError(request, { HIGHLIGHT_PROJECT_ID: 'YOUR_PROJECT_ID' }, ctx, new Error('example error!'))
+    H.consumeError(request, { HIGHLIGHT_PROJECT_ID: '<YOUR_PROJECT_ID>' }, ctx, new Error('example error!'))
   },
 }`,
 		),

--- a/highlight.io/components/QuickstartContent/backend/js/express.tsx
+++ b/highlight.io/components/QuickstartContent/backend/js/express.tsx
@@ -32,7 +32,7 @@ app.get('/', (req, res) => {
 })
 
 // This should be before any other error middleware and after all controllers (route definitions)
-app.use(Handlers.errorHandler({ projectID: 'YOUR_PROJECT_ID' }))
+app.use(Handlers.errorHandler({ projectID: '<YOUR_PROJECT_ID>' }))
 app.listen(8080, () => {
   console.log(\`Example app listening on port 8080\`)
 })`,

--- a/highlight.io/components/QuickstartContent/backend/js/firebase.tsx
+++ b/highlight.io/components/QuickstartContent/backend/js/firebase.tsx
@@ -30,7 +30,7 @@ exports.exampleCallable = functions.https.onCall(
       // ... your handler code here
       return { result: 'useful result!' }
     },
-    { projectID: 'YOUR_PROJECT_ID' },
+    { projectID: '<YOUR_PROJECT_ID>' },
   ),
 )
 
@@ -41,7 +41,7 @@ exports.exampleHttp = functions.https.onRequest(
       // ... your handler code here
       res.json({ result: 'useful result!' })
     },
-    { projectID: 'YOUR_PROJECT_ID' },
+    { projectID: '<YOUR_PROJECT_ID>' },
   ),
 )`,
 				language: `js`,
@@ -55,7 +55,7 @@ exports.exampleHttp = functions.https.onRequest(
       throw new Error('example error!')
       return { result: 'useful result!' }
     },
-    { projectID: 'YOUR_PROJECT_ID' },
+    { projectID: '<YOUR_PROJECT_ID>' },
   ),
 )`,
 		),

--- a/highlight.io/components/QuickstartContent/backend/js/nestjs.tsx
+++ b/highlight.io/components/QuickstartContent/backend/js/nestjs.tsx
@@ -21,7 +21,7 @@ import { HighlightInterceptor } from '@highlight-run/nest'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
-  const highlightOpts = { projectID: 'YOUR_PROJECT_ID' }
+  const highlightOpts = { projectID: '<YOUR_PROJECT_ID>' }
   app.useGlobalInterceptors(new HighlightInterceptor(highlightOpts))
   await app.listen(3000)
 }

--- a/highlight.io/components/QuickstartContent/backend/js/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/backend/js/shared-snippets.tsx
@@ -34,7 +34,7 @@ export const initializeNodeSDK: (slug: string) => QuickStartStep = (slug) => ({
 	code: {
 		text: `import { H } from '@highlight-run/${slug}'
 
-H.init({projectID: 'YOUR_PROJECT_ID'})`,
+H.init({projectID: '<YOUR_PROJECT_ID>'})`,
 		language: 'js',
 	},
 })

--- a/highlight.io/components/QuickstartContent/backend/js/trpc.tsx
+++ b/highlight.io/components/QuickstartContent/backend/js/trpc.tsx
@@ -28,7 +28,7 @@ export default createNextApiHandler({
   // ... your config
   onError: ({ error, req }) => {
     // ... your own error handling logic here
-    Handlers.trpcOnError({ error, req }, { projectID: 'YOUR_PROJECT_ID' })
+    Handlers.trpcOnError({ error, req }, { projectID: '<YOUR_PROJECT_ID>' })
   },
 })
 `,

--- a/highlight.io/components/QuickstartContent/backend/python/aws.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/aws.tsx
@@ -21,7 +21,7 @@ export const PythonAWSContext: QuickStartContent = {
 				text: `import highlight_io
 from highlight_io.integrations.aws import observe_handler
 
-H = highlight_io.H("1", record_logs=True)
+H = highlight_io.H("<YOUR_PROJECT_ID>", record_logs=True)
 
 
 @observe_handler
@@ -46,7 +46,7 @@ def lambda_handler(event, context):
 				text: `import highlight_io
 from highlight_io.integrations.aws import observe_handler
 
-H = highlight_io.H("1", record_logs=True)
+H = highlight_io.H("<YOUR_PROJECT_ID>", record_logs=True)
 
 
 @observe_handler

--- a/highlight.io/components/QuickstartContent/backend/python/azure.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/azure.tsx
@@ -23,7 +23,7 @@ export const PythonAzureContext: QuickStartContent = {
 import highlight_io
 from highlight_io.integrations.azure import observe_handler
 
-H = highlight_io.H("1", record_logs=True)
+H = highlight_io.H("<YOUR_PROJECT_ID>", record_logs=True)
 
 
 @observe_handler
@@ -50,7 +50,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
 import highlight_io
 from highlight_io.integrations.azure import observe_handler
 
-H = highlight_io.H("1", record_logs=True)
+H = highlight_io.H("<YOUR_PROJECT_ID>", record_logs=True)
 
 
 @observe_handler

--- a/highlight.io/components/QuickstartContent/backend/python/django.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/django.tsx
@@ -22,7 +22,7 @@ export const PythonDjangoContext: QuickStartContent = {
 				text: `import highlight_io
 from highlight_io.integrations.django import DjangoIntegration
 
-H = highlight_io.H("YOUR_PROJECT_ID", integrations=[DjangoIntegration()], record_logs=True)`,
+H = highlight_io.H("<YOUR_PROJECT_ID>", integrations=[DjangoIntegration()], record_logs=True)`,
 				language: 'python',
 			},
 		},

--- a/highlight.io/components/QuickstartContent/backend/python/fastapi.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/fastapi.tsx
@@ -23,7 +23,7 @@ export const PythonFastAPIContext: QuickStartContent = {
 import highlight_io
 from highlight_io.integrations.fastapi import FastAPIMiddleware
 
-H = highlight_io.H("YOUR_PROJECT_ID", record_logs=True)
+H = highlight_io.H("<YOUR_PROJECT_ID>", record_logs=True)
 
 app = FastAPI()
 app.add_middleware(FastAPIMiddleware)`,
@@ -44,7 +44,7 @@ app.add_middleware(FastAPIMiddleware)`,
 import highlight_io
 from highlight_io.integrations.fastapi import FastAPIMiddleware
 
-H = highlight_io.H("YOUR_PROJECT_ID", record_logs=True)
+H = highlight_io.H("<YOUR_PROJECT_ID>", record_logs=True)
 
 app = FastAPI()
 app.add_middleware(FastAPIMiddleware)

--- a/highlight.io/components/QuickstartContent/backend/python/flask.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/flask.tsx
@@ -24,7 +24,7 @@ import highlight_io
 from highlight_io.integrations.flask import FlaskIntegration
 
 app = Flask(__name__)
-H = highlight_io.H("YOUR_PROJECT_ID", integrations=[FlaskIntegration()], record_logs=True)`,
+H = highlight_io.H("<YOUR_PROJECT_ID>", integrations=[FlaskIntegration()], record_logs=True)`,
 				language: 'python',
 			},
 		},
@@ -47,7 +47,7 @@ import highlight_io
 from highlight_io.integrations.flask import FlaskIntegration
 
 app = Flask(__name__)
-H = highlight_io.H("YOUR_PROJECT_ID", integrations=[FlaskIntegration()], record_logs=True)
+H = highlight_io.H("<YOUR_PROJECT_ID>", integrations=[FlaskIntegration()], record_logs=True)
 
 
 @app.route("/hello")

--- a/highlight.io/components/QuickstartContent/backend/python/gcp.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/gcp.tsx
@@ -27,7 +27,7 @@ import functions_framework
 import highlight_io
 from highlight_io.integrations.gcp import observe_handler
 
-H = highlight_io.H("1", record_logs=True)
+H = highlight_io.H("<YOUR_PROJECT_ID>", record_logs=True)
 
 
 @observe_handler
@@ -56,7 +56,7 @@ import functions_framework
 import highlight_io
 from highlight_io.integrations.gcp import observe_handler
 
-H = highlight_io.H("1", record_logs=True)
+H = highlight_io.H("<YOUR_PROJECT_ID>", record_logs=True)
 
 
 @observe_handler

--- a/highlight.io/components/QuickstartContent/backend/python/other.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/other.tsx
@@ -19,7 +19,7 @@ export const PythonOtherContext: QuickStartContent = {
 			code: {
 				text: `import highlight_io
 
-H = highlight_io.H("YOUR_PROJECT_ID", record_logs=True)`,
+H = highlight_io.H("<YOUR_PROJECT_ID>", record_logs=True)`,
 				language: 'python',
 			},
 		},
@@ -37,7 +37,7 @@ import time
 
 import highlight_io
 
-H = highlight_io.H("YOUR_PROJECT_ID", record_logs=True)
+H = highlight_io.H("<YOUR_PROJECT_ID>", record_logs=True)
 
 
 def main():

--- a/highlight.io/components/QuickstartContent/logging/go/fiber.tsx
+++ b/highlight.io/components/QuickstartContent/logging/go/fiber.tsx
@@ -22,7 +22,7 @@ import (
 
 func main() {
   // setup the highlight SDK
-  highlight.SetProjectID("YOUR_PROJECT_ID")
+  highlight.SetProjectID("<YOUR_PROJECT_ID>")
   highlight.Start()
   defer highlight.Stop()
 

--- a/highlight.io/components/QuickstartContent/logging/go/other.tsx
+++ b/highlight.io/components/QuickstartContent/logging/go/other.tsx
@@ -22,7 +22,7 @@ import (
 
 func main() {
   // setup the highlight SDK
-  highlight.SetProjectID("YOUR_PROJECT_ID")
+  highlight.SetProjectID("<YOUR_PROJECT_ID>")
   highlight.Start()
   defer highlight.Stop()
 

--- a/highlight.io/components/QuickstartContent/logging/js/nestjs.tsx
+++ b/highlight.io/components/QuickstartContent/logging/js/nestjs.tsx
@@ -19,7 +19,7 @@ import { HighlightLogger } from '@highlight-run/nest'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
-  const highlightOpts = { projectID: 'YOUR_PROJECT_ID' }
+  const highlightOpts = { projectID: '<YOUR_PROJECT_ID>' }
   app.useLogger(new HighlightLogger(highlightOpts))
   await app.listen(3000)
 }

--- a/highlight.io/components/QuickstartContent/logging/python/other.tsx
+++ b/highlight.io/components/QuickstartContent/logging/python/other.tsx
@@ -17,7 +17,7 @@ export const PythonOtherLogContent: QuickStartContent = {
 			code: {
 				text: `import highlight_io
 
-H = highlight_io.H("YOUR_PROJECT_ID", record_logs=True)`,
+H = highlight_io.H("<YOUR_PROJECT_ID>", record_logs=True)`,
 				language: 'python',
 			},
 		},

--- a/highlight.io/components/QuickstartContent/logging/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/logging/shared-snippets.tsx
@@ -45,7 +45,7 @@ export const curlExample: QuickStartStep = {
                     {
                       "key": "highlight.project_id",
                       "value": {
-                        "stringValue": "YOUR_PROJECT_ID"
+                        "stringValue": "<YOUR_PROJECT_ID>"
                       }
                     },
                     {


### PR DESCRIPTION
## Summary
- link to the python logging getting started docs was broken from the overview page
- backend `highlight_io.H` initialization had hardcoded `"1"` as the project id
- use bracketed `<YOUR_PROJECT_ID>` everywhere
- `replaceAll` for code snippets w/ project id listed more than once
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
