### PR TITLE
Adds 'product philsophy' docs

### DIFF
--- a/docs-content/general/4_company/product-philosphy.md
+++ b/docs-content/general/4_company/product-philosphy.md
@@ -9,6 +9,6 @@ Our product philsophy at highlight.io is centered around the concept of "cohesio
 
 Prior to working on highlight.io, we all worked at several tech companies of varying sizes, and had first-hand experience trying to stich together numerous tools to reproduce bugs. It wasn't uncommon that we had to, for e.g., login to Sentry to see a stacktrace, log into Splunk to query logs, and after loads more tools, finally succumb to having to login "as the user" to try and reproduce the issue.
 
-With highlight.io, we're trying to change that. By building monitoring software that "wraps" your infrastructure and application. Our long-term goal is that you can see the full picture of what's happening in your app, whether it be logs, errors, session replay and more, and we do the work to associate all of these resources so that you can ship w/ confidence.
+With highlight.io, we're trying to change that by building monitoring software that "wraps" your infrastructure and application, and ideally, we do ALL the work to stitch together everything. Our long-term goal is that you can trace everything from a button click to a server-side regression with little to no effort.
 
 Now, you may ask, "but that's a lot to build, no?". And we'd reply with "Yep, you're right.". It's definitely ambitious. But that's why its exciting. 

--- a/docs-content/general/4_company/product-philosphy.md
+++ b/docs-content/general/4_company/product-philosphy.md
@@ -9,7 +9,7 @@ This doc acts as a reference for our product philosophy at highlight.io, or to b
 
 ## Cohesion
 
-Our product philsophy at highlight.io is centered around the concept of "cohesion", or the idea that we're focused on building  a tightly coupled suite of tools that helps developers ship software with confidence.
+Our product philsophy at highlight.io is centered around the concept of "cohesion", or the idea that we're focused on building a tightly coupled suite of tools that helps developers ship software with confidence.
 
 Prior to working on highlight.io, we all worked at several tech companies of varying sizes, and had first-hand experience trying to stich together numerous tools to reproduce bugs. It wasn't uncommon that we had to, for e.g., login to Sentry to see a stacktrace, log into Splunk to query logs, and after investigating with even more tools, give up and log in "as the user" to try and reproduce the issue.
 
@@ -17,4 +17,4 @@ Prior to working on highlight.io, we all worked at several tech companies of var
 
 With highlight.io, we're trying to change that by building monitoring software that "wraps" your infrastructure and application, and ideally, we do ALL the work to stitch together everything. Our long-term goal is that you can trace everything from a button click to a server-side regression with little to no effort.
 
-Now, if you were to ask, "but that's a lot to build, no?" we would reply with "Yes, feel free to give us a hand": [careers.highlight.run](https://careers.highlight.run).
+Now, if you were to ask, "but that's a lot to build, no?" we would reply with "Yes, give us a hand?": [careers.highlight.run](https://careers.highlight.run).

--- a/docs-content/general/4_company/product-philosphy.md
+++ b/docs-content/general/4_company/product-philosphy.md
@@ -5,16 +5,16 @@ slug: product-philosphy
 
 ## Overview 
 
-This doc acts as a reference for our product philosophy at highlight.io, or to be more exact, how we think about what we build (not necessarily how we build it). It acts a way for our team to prioritize work, but also educate the public on where we're headed. Sharing this type of content aligns with our values to [build in public](./1_values.md#we-build-in-public) and we hope to continue sharing more in this space.
+This doc acts as a reference for our product philosophy at highlight.io, or to be more exact, how we think about what we build (not necessarily how we build it). It acts as a way for our team to prioritize work, but also educate the public on where we're headed. Sharing this type of content aligns with our values to [build in public](./1_values.md#we-build-in-public) and we hope to continue sharing more in this space.
 
 ## Cohesion
 
 Our product philsophy at highlight.io is centered around the concept of "cohesion", or the idea that we're focused on building  a tightly coupled suite of tools that helps developers ship software with confidence.
 
-Prior to working on highlight.io, we all worked at several tech companies of varying sizes, and had first-hand experience trying to stich together numerous tools to reproduce bugs. It wasn't uncommon that we had to, for e.g., login to Sentry to see a stacktrace, log into Splunk to query logs, and after loads more tools, finally succumb to having to login "as the user" to try and reproduce the issue.
+Prior to working on highlight.io, we all worked at several tech companies of varying sizes, and had first-hand experience trying to stich together numerous tools to reproduce bugs. It wasn't uncommon that we had to, for e.g., login to Sentry to see a stacktrace, log into Splunk to query logs, and after investigating with even more tools, give up and log in "as the user" to try and reproduce the issue.
 
 ## The Vision
 
 With highlight.io, we're trying to change that by building monitoring software that "wraps" your infrastructure and application, and ideally, we do ALL the work to stitch together everything. Our long-term goal is that you can trace everything from a button click to a server-side regression with little to no effort.
 
-Now, you may ask, "but that's a lot to build, no?". And we'd reply with "Yep, you're right.". It's definitely ambitious. But that's why its exciting. 
+Now, if you were to ask, "but that's a lot to build, no?" we would reply with "Yes, feel free to give us a hand": [careers.highlight.run](https://careers.highlight.run).

--- a/docs-content/general/4_company/product-philosphy.md
+++ b/docs-content/general/4_company/product-philosphy.md
@@ -1,8 +1,6 @@
 ---
 title: Our Product Philsophy
 slug: product-philosphy
-createdAt: 2022-04-01T20:28:14.000Z
-updatedAt: 2022-04-15T02:07:22.000Z
 ---
 
 This doc acts as a reference for our product philosophy at highlight.io, or to be more exact, how we think about what we build (not necessarily how we build it). It acts a way for our team to prioritize work, but also educate the public on where we're headed. Sharing this type of content aligns with our values to [build in public](./1_values.md#we-build-in-public) and we hope to continue sharing more in this space.

--- a/docs-content/general/4_company/product-philosphy.md
+++ b/docs-content/general/4_company/product-philosphy.md
@@ -1,0 +1,16 @@
+---
+title: Our Product Philsophy
+slug: product-philosphy
+createdAt: 2022-04-01T20:28:14.000Z
+updatedAt: 2022-04-15T02:07:22.000Z
+---
+
+This doc acts as a reference for our product philosophy at highlight.io, or to be more exact, how we think about what we build (not necessarily how we build it). It acts a way for our team to prioritize work, but also educate the public on where we're headed. Sharing this type of content aligns with our values to [build in public](./1_values.md#we-build-in-public) and we hope to continue sharing more in this space.
+
+Our product philsophy at highlight.io is centered around the concept of "cohesion", or the idea that we're focused on building  a tightly coupled suite of tools that helps developers ship software with confidence.
+
+Prior to working on highlight.io, we all worked at several tech companies of varying sizes, and had first-hand experience trying to stich together numerous tools to reproduce bugs. It wasn't uncommon that we had to, for e.g., login to Sentry to see a stacktrace, log into Splunk to query logs, and after loads more tools, finally succumb to having to login "as the user" to try and reproduce the issue.
+
+With highlight.io, we're trying to change that. By building monitoring software that "wraps" your infrastructure and application. Our long-term goal is that you can see the full picture of what's happening in your app, whether it be logs, errors, session replay and more, and we do the work to associate all of these resources so that you can ship w/ confidence.
+
+Now, you may ask, "but that's a lot to build, no?". And we'd reply with "Yep, you're right.". It's definitely ambitious. But that's why its exciting. 

--- a/docs-content/general/4_company/product-philosphy.md
+++ b/docs-content/general/4_company/product-philosphy.md
@@ -3,11 +3,17 @@ title: Our Product Philsophy
 slug: product-philosphy
 ---
 
+## Overview 
+
 This doc acts as a reference for our product philosophy at highlight.io, or to be more exact, how we think about what we build (not necessarily how we build it). It acts a way for our team to prioritize work, but also educate the public on where we're headed. Sharing this type of content aligns with our values to [build in public](./1_values.md#we-build-in-public) and we hope to continue sharing more in this space.
+
+## Cohesion
 
 Our product philsophy at highlight.io is centered around the concept of "cohesion", or the idea that we're focused on building  a tightly coupled suite of tools that helps developers ship software with confidence.
 
 Prior to working on highlight.io, we all worked at several tech companies of varying sizes, and had first-hand experience trying to stich together numerous tools to reproduce bugs. It wasn't uncommon that we had to, for e.g., login to Sentry to see a stacktrace, log into Splunk to query logs, and after loads more tools, finally succumb to having to login "as the user" to try and reproduce the issue.
+
+## The Vision
 
 With highlight.io, we're trying to change that by building monitoring software that "wraps" your infrastructure and application, and ideally, we do ALL the work to stitch together everything. Our long-term goal is that you can trace everything from a button click to a server-side regression with little to no effort.
 

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -989,6 +989,7 @@ const DocPage = ({
 										<MDXRemote
 											components={{
 												MissingFrameworkCopy,
+												Callout,
 												Roadmap,
 												RoadmapItem,
 												QuickStart,

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -989,7 +989,6 @@ const DocPage = ({
 										<MDXRemote
 											components={{
 												MissingFrameworkCopy,
-												Callout,
 												Roadmap,
 												RoadmapItem,
 												QuickStart,


### PR DESCRIPTION
## Summary
Adds a section to our `company` docs about our product philsophy. 

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
I read it.

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
no.

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
