### PR TITLE
Added mavenrepository links for java docs

### DIFF
--- a/docs-content/sdk/java.md
+++ b/docs-content/sdk/java.md
@@ -13,7 +13,7 @@ slug: java
   <div className="right">
     <h6>Just getting started?</h6>
     <p>Check out our [getting started guide](https://www.highlight.io/docs/getting-started/overview) to get up and running quickly.</p>
-	<p>Import our maven dependency from [mvnrepository](https://mvnrepository.com/artifact/io.highlight/highlight-sdk/latest)</p>
+    <p>Import our maven dependency from [mvnrepository](https://mvnrepository.com/artifact/io.highlight/highlight-sdk/latest)</p>
   </div>
 </section>
 

--- a/docs-content/sdk/java.md
+++ b/docs-content/sdk/java.md
@@ -7,12 +7,13 @@ slug: java
   <div className="left">
     <h3>Java SDK</h3>
     <p>
-      Highlight's Java SDK makes it easy to monitor errors and metrics on your Java backend.
+      Highlight's [Java SDK](https://mvnrepository.com/artifact/io.highlight/highlight-sdk/latest) makes it easy to monitor errors and metrics on your Java backend.
     </p>
   </div>
   <div className="right">
     <h6>Just getting started?</h6>
     <p>Check out our [getting started guide](https://www.highlight.io/docs/getting-started/overview) to get up and running quickly.</p>
+	<p>Import our maven dependency from [mvnrepository](https://mvnrepository.com/artifact/io.highlight/highlight-sdk/latest)</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
I've made some changes to the Java docs that should make it easier to locate the required dependencies.

## How did you test this change?
Locally

## Are there any deployment considerations?
No