### PR TITLE
Wrapping text in the Errors header

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorOccurenceDate/index.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorOccurenceDate/index.tsx
@@ -13,17 +13,17 @@ const ErrorOccurenceDate = ({ errorGroup }: Props) => {
 			gap="4"
 			alignItems="center"
 			flexShrink={0}
-			flexWrap="nowrap"
+			flexWrap="wrap"
+			maxWidth="full"
 		>
-			<Text color="black" size="large" weight="bold">
+			<Text color="black" size="large" weight="bold" whiteSpace="nowrap">
 				{errorGroup?.last_occurrence
 					? moment(errorGroup.last_occurrence).fromNow(true)
-					: 'just now'}
+					: 'just now'}{' '}
+				/
 			</Text>
-			<Text color="n11" size="large" weight="bold">
-				{' / '}
-			</Text>
-			<Text color="n11" size="large" weight="bold">
+
+			<Text color="n11" size="large" weight="bold" whiteSpace="nowrap">
 				{errorGroup?.first_occurrence
 					? moment(errorGroup.first_occurrence).fromNow(true)
 					: 'just now'}

--- a/frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorOccurenceDate/index.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorOccurenceDate/index.tsx
@@ -15,6 +15,7 @@ const ErrorOccurenceDate = ({ errorGroup }: Props) => {
 			flexShrink={0}
 			flexWrap="wrap"
 			maxWidth="full"
+			style={{ rowGap: 8 }}
 		>
 			<Text color="black" size="large" weight="bold" whiteSpace="nowrap">
 				{errorGroup?.last_occurrence

--- a/packages/ui/src/components/Text/Text.tsx
+++ b/packages/ui/src/components/Text/Text.tsx
@@ -15,6 +15,7 @@ export type Props = React.PropsWithChildren &
 		userSelect?: BoxProps['userSelect']
 		cssClass?: BoxProps['cssClass']
 		title?: string
+		whiteSpace?: BoxProps['whiteSpace']
 		wrap?: BoxProps['overflowWrap']
 	}
 
@@ -30,6 +31,7 @@ export const Text = React.forwardRef<unknown, Props>(
 			userSelect,
 			cssClass,
 			title,
+			whiteSpace,
 			wrap,
 			...props
 		},
@@ -54,6 +56,7 @@ export const Text = React.forwardRef<unknown, Props>(
 				cssClass={clsx(styles.variants({ ...props }), cssClass)}
 				title={title}
 				overflowWrap={wrap}
+				whiteSpace={whiteSpace}
 			>
 				{content}
 			</Box>


### PR DESCRIPTION
This text could overflow in ugly ways. It's not common, but it shouldn't be breaking out of its containing box.

![image](https://user-images.githubusercontent.com/878947/232562672-cd97f0d6-3d84-4c52-99d3-e114379f1553.png)