### PR TITLE
fix log alert y axis ticks when max bucket size < 5

### DIFF
--- a/frontend/src/pages/LogsPage/LogsHistogram/LogsHistogram.tsx
+++ b/frontend/src/pages/LogsPage/LogsHistogram/LogsHistogram.tsx
@@ -146,8 +146,8 @@ const LogsHistogram = ({
 	}, [data?.logs_histogram, endDate, maxBucketCount, startDate])
 
 	const tickValues = useMemo(() => {
-		// return the axis with 5 ticks based on maxBucketCount
-		const count = 5
+		// return the axis with up to 5 ticks based on maxBucketCount
+		const count = Math.min(5, maxBucketCount)
 		return [
 			...new Set(
 				[...Array(count + 1)].map((_, idx) => {


### PR DESCRIPTION
## Summary
- if the max bucket had less than 5 items, the histogram appeared as if it had 5
- this will show N+1 ticks (including a 0 tick) if N < 5
<img width="990" alt="Screen Shot 2023-04-18 at 11 28 07 AM" src="https://user-images.githubusercontent.com/86132398/232870493-39745c78-bc0d-4b89-863b-be92a2173b48.png">

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
