### PR TITLE
stop session feed query carryover on error feed

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/components/QueryBuilder/QueryBuilder.tsx
@@ -1946,20 +1946,17 @@ function QueryBuilder(props: QueryBuilderProps) {
 	const [qbState, setQbState] = useState<string | undefined>(undefined)
 
 	useEffect(() => {
-		if (!segmentsLoading) {
-			if (activeSegmentUrlParam) {
-				selectSegment(activeSegmentUrlParam)
-			}
-			if (searchParamsToUrlParams.query !== undefined) {
-				setSearchParams(searchParamsToUrlParams as SearchParamsInput)
-			}
+		if (searchParamsToUrlParams.query !== undefined) {
+			setSearchParams(searchParamsToUrlParams as SearchParamsInput)
+		} else {
+			setSearchParams(EmptyErrorsSearchParams)
 		}
 
 		// We only want to run this on mount (i.e. when the page first loads)
 		// after fetching segments.
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [segmentsLoading])
+	}, [])
 
 	const [forceReload, setForceReload] = useQueryParam('reload', BooleanParam)
 	useEffect(() => {
@@ -1968,6 +1965,19 @@ function QueryBuilder(props: QueryBuilderProps) {
 			setForceReload(false)
 		}
 	}, [forceReload, searchParamsToUrlParams, setForceReload, setSearchParams])
+
+	useEffect(() => {
+		if (!segmentsLoading) {
+			if (activeSegmentUrlParam) {
+				selectSegment(activeSegmentUrlParam)
+			}
+			if (searchParamsToUrlParams.query !== undefined) {
+				setSearchParams(searchParamsToUrlParams as SearchParamsInput)
+			}
+		}
+		// We only want to run this once after loading segments.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [segmentsLoading])
 
 	// Errors Segment Deep Linking
 	useEffect(() => {


### PR DESCRIPTION
## Summary

When reloading the sessions page and the URL is populated with a session query, 
the query params carry over to the error feed, breaking the query for errors.

This was caused by the differing error feed logic of triggering the `setSearchParams` update
on `segmentsLoading` change.

By making this consistent with the error feed, we get the right behavior on the errors feed.

## How did you test this change?

Before: https://www.loom.com/share/af6cc98433214fdc9b73988da19f19c7

After: https://www.loom.com/share/5e9973ba3841426a97fe4a426216c686

## Are there any deployment considerations?

No