### PR TITLE
switch to single-broker ack

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -179,7 +179,7 @@ func New(ctx context.Context, topic string, mode Mode) *Queue {
 			Transport:    transport,
 			Topic:        pool.Topic,
 			Balancer:     &kafka.Hash{},
-			RequiredAcks: kafka.RequireAll,
+			RequiredAcks: kafka.RequireOne,
 			Compression:  kafka.Zstd,
 			// synchronous mode so that we can ensure messages are sent before we return
 			Async: false,

--- a/backend/main.go
+++ b/backend/main.go
@@ -112,10 +112,12 @@ func healthRouter(runtimeFlag util.Runtime, db *gorm.DB, tdb timeseries.DB, rCli
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		if err := queue.Submit(ctx, &kafkaqueue.Message{Type: kafkaqueue.HealthCheck}, "health"); err != nil {
+			log.WithContext(ctx).Error(fmt.Sprintf("failed kafka health check: %s", err))
 			http.Error(w, fmt.Sprintf("failed to write message to kafka %s", topic), 500)
 			return
 		}
 		if err := batchedQueue.Submit(ctx, &kafkaqueue.Message{Type: kafkaqueue.HealthCheck}, "health"); err != nil {
+			log.WithContext(ctx).Error(fmt.Sprintf("failed kafka batched health check: %s", err))
 			http.Error(w, fmt.Sprintf("failed to write message to kafka %s", batchedTopic), 500)
 			return
 		}


### PR DESCRIPTION
## Summary

Per [this guide](https://betterprogramming.pub/kafka-acks-explained-c0515b3b707e), switch to single-broker ack for writes
to make sure we are not blocked from writing messages when a broker is out-of-sync.
Since we have `min.insync.replicas=3` on our prod partition, this means that the previous `all` setting
would block until all 3 brokers have received messages. 

Adding a health check log to make sure it is obvious when health checks fail.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

Will monitor rollout.