### PR TITLE
harden otel test

### DIFF
--- a/backend/otel/otel_test.go
+++ b/backend/otel/otel_test.go
@@ -7,6 +7,7 @@ import (
 	kafkaqueue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	public "github.com/highlight-run/highlight/backend/public-graph/graph"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"net/http"
@@ -48,6 +49,7 @@ func TestHandler_HandleLog(t *testing.T) {
 	h := Handler{}
 	h.HandleLog(w, r)
 }
+
 func TestHandler_HandleTrace(t *testing.T) {
 	inputBytes, err := os.ReadFile("./samples/traces.json")
 	if err != nil {
@@ -84,19 +86,38 @@ func TestHandler_HandleTrace(t *testing.T) {
 	}
 	h.HandleTrace(w, r)
 
-	assert.Equal(t, 4, len(producer.messages))
-	assert.Equal(t, kafkaqueue.PushBackendPayload, producer.messages[0].Type)
-	assert.Equal(t, kafkaqueue.MarkBackendSetup, producer.messages[1].Type)
-	if assert.Equal(t, kafkaqueue.PushLogs, producer.messages[2].Type) {
-		assert.Equal(t, 14, len(producer.messages[2].PushLogs.LogRows))
-		for _, log := range producer.messages[2].PushLogs.LogRows {
-			assert.Equal(t, model.LogSourceBackend, log.Source)
-		}
-	}
-	if assert.Equal(t, kafkaqueue.PushLogs, producer.messages[3].Type) {
-		assert.Equal(t, 1, len(producer.messages[3].PushLogs.LogRows))
-		for _, log := range producer.messages[3].PushLogs.LogRows {
-			assert.Equal(t, model.LogSourceFrontend, log.Source)
+	assert.GreaterOrEqual(t, 4, len(producer.messages))
+
+	_, ok := lo.Find(producer.messages, func(message *kafkaqueue.Message) bool {
+		return message.Type == kafkaqueue.PushBackendPayload
+	})
+	assert.Truef(t, ok, "did not find a PushBackendPayload message")
+
+	_, ok = lo.Find(producer.messages, func(message *kafkaqueue.Message) bool {
+		return message.Type == kafkaqueue.MarkBackendSetup
+	})
+	assert.Truef(t, ok, "did not find a MarkBackendSetup message")
+
+	_, ok = lo.Find(producer.messages, func(message *kafkaqueue.Message) bool {
+		return message.Type == kafkaqueue.PushLogs
+	})
+	assert.Truef(t, ok, "did not find a PushLogs message")
+
+	allPushLogs := lo.Filter(producer.messages, func(message *kafkaqueue.Message, _ int) bool {
+		return message.Type == kafkaqueue.PushLogs
+	})
+
+	for _, pushLogs := range allPushLogs {
+		if len(pushLogs.PushLogs.LogRows) == 14 {
+			for _, log := range pushLogs.PushLogs.LogRows {
+				assert.Equal(t, model.LogSourceBackend, log.Source)
+			}
+		} else if len(pushLogs.PushLogs.LogRows) == 1 {
+			for _, log := range pushLogs.PushLogs.LogRows {
+				assert.Equal(t, model.LogSourceFrontend, log.Source)
+			}
+		} else {
+			assert.Fail(t, "found a push logs with no log rows")
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Improves stability of the `TestHandler_HandleTrace` test case which would
fail randomly because it assumed an order to opentelemetry messages.

## How did you test this change?

Running the test in a benchmark to ensure it consistently passes

<img width="718" alt="image" src="https://user-images.githubusercontent.com/1351531/233181901-453f2b68-23e0-4fe0-8896-feb1dd956c7b.png">


## Are there any deployment considerations?

No