### PR TITLE
avoid caching billing data in indexeddb

### DIFF
--- a/frontend/src/util/db.ts
+++ b/frontend/src/util/db.ts
@@ -136,6 +136,13 @@ export class IndexedDBCache {
 export const indexeddbCache = new IndexedDBCache()
 
 export class IndexedDBLink extends ApolloLink {
+	static excluded = new Set<string>([
+		'GetAdmin',
+		'GetBillingDetails',
+		'GetCustomerPortalUrl',
+		'GetProject',
+		'GetSubscriptionDetails',
+	])
 	httpLink: ApolloLink
 
 	constructor(httpLink: ApolloLink) {
@@ -154,7 +161,7 @@ export class IndexedDBLink extends ApolloLink {
 			return false
 		}
 
-		if (operation.operationName === 'GetAdmin') {
+		if (IndexedDBLink.excluded.has(operation.operationName)) {
 			return false
 		}
 


### PR DESCRIPTION
## Summary

Our indexeddb caching strategy always updates the cache, but certain code that uses `window.open` or
`navigate` will switch the page before the cache gets to update. As a result, the cache is never updated
and can result in invalid behavior (ie. invalid stripe urls opened).
Adds a consistent way to exclude graphql queries from the apollo indexeddb cache.

## How did you test this change?

Issue was originally reported by a customer.
<img width="1461" alt="image" src="https://user-images.githubusercontent.com/1351531/233183526-fc8f9cbf-ccf6-4d89-a311-808380f5b121.png">

Before:
<img width="1574" alt="Screenshot 2023-04-19 at 12 52 50 PM" src="https://user-images.githubusercontent.com/1351531/233184871-1d071971-e63d-4b1b-ab4d-760ed25d4ace.png">

After:
<img width="1561" alt="Screenshot 2023-04-19 at 12 53 46 PM" src="https://user-images.githubusercontent.com/1351531/233185052-243b9b0d-2073-4a10-9139-6433b5154a35.png">

## Are there any deployment considerations?

No.