### PR TITLE
update phonehome telemetry metrics

### DIFF
--- a/backend/phonehome/phonehome.go
+++ b/backend/phonehome/phonehome.go
@@ -29,16 +29,18 @@ const ErrorViewCount = "highlight-error-view-count"
 const LogViewCount = "highlight-log-view-count"
 
 const AboutYouSpanName = "highlight-about-you"
-const AboutYouSpanRole = "highlight-about-you-role"
 const AboutYouSpanReferral = "highlight-about-you-referral"
+const AboutYouSpanRole = "highlight-about-you-role"
 const HeartbeatInterval = 5 * time.Second
-const HeartbeatSpanHighlightVersion = "highlight-version"
 const HeartbeatSpanName = "highlight-heartbeat"
 const HighlightProjectID = "1"
 const MetricMemTotal = "highlight-mem-total"
 const MetricMemUsedPercent = "highlight-mem-used-percent"
 const MetricNumCPU = "highlight-num-cpu"
 const SpanDeployment = "highlight-phone-home-deployment-id"
+const SpanDopplerConfig = "highlight-doppler-config"
+const SpanHighlightVersion = "highlight-version"
+const SpanOnPrem = "highlight-is-onprem"
 
 func IsOptedOut(_ context.Context) bool {
 	return false
@@ -59,6 +61,9 @@ func GetDefaultAttributes() ([]attribute.KeyValue, error) {
 	return []attribute.KeyValue{
 		attribute.String(highlight.ProjectIDAttribute, HighlightProjectID),
 		attribute.String(SpanDeployment, cfg.PhoneHomeDeploymentID),
+		attribute.String(SpanDopplerConfig, util.DopplerConfig),
+		attribute.String(SpanHighlightVersion, util.Version),
+		attribute.String(SpanOnPrem, util.OnPrem),
 	}, nil
 }
 
@@ -76,7 +81,6 @@ func Start(ctx context.Context) error {
 			highlight.RecordMetric(ctx, MetricMemTotal, float64(vmStat.Total))
 			tags, _ := GetDefaultAttributes()
 			tags = append(tags,
-				attribute.String(HeartbeatSpanHighlightVersion, util.Version),
 				attribute.Int(MetricNumCPU, runtime.NumCPU()),
 				attribute.Float64(MetricMemUsedPercent, vmStat.UsedPercent),
 				attribute.Int64(MetricMemTotal, int64(vmStat.Total)),

--- a/docs-content/general/4_company/open-source/hosting/telemetry.md
+++ b/docs-content/general/4_company/open-source/hosting/telemetry.md
@@ -18,7 +18,6 @@ When you start highlight for development or a hobby deploy, our scripts will sha
 | num-cpu          | CPU Count             | int    |
 | mem-used-percent | Percent memory used   | float  |
 | mem-total        | Bytes of memory total | int    |
-| version          | Highlight version sha | string |
 
 ## Self-reported User Attributes
 
@@ -38,3 +37,12 @@ When you start highlight for development or a hobby deploy, our scripts will sha
 | session-view-count | Number of sessions viewed   | int  |
 | error-view-count   | Number of errors viewed     | int  |
 | log-view-count     | Number of logs viewed       | int  |
+
+## General Telemetry
+
+| Name                     | Description                                        | Type   |
+|--------------------------|----------------------------------------------------|--------|
+| version                  | Highlight version sha                              | string |
+| is-onprem                | Value of env var ON_PREM                           | string |
+| doppler-config           | When doppler is used, the name of the environment. | string |
+| phone-home-deployment-id | A randomly-generated deployment identifier.        | string |


### PR DESCRIPTION
## Summary

Update the telemetry metrics to include `doppler-config` so that we can differentiate
our cloud hosted deployments from on-prem ones.

## How did you test this change?

<img width="1524" alt="Screenshot 2023-04-20 at 3 21 59 PM" src="https://user-images.githubusercontent.com/1351531/233499553-eff4f517-8edb-43f0-bef3-fb1f08768575.png">

## Are there any deployment considerations?

Will release new docker images.