### PR TITLE
Consistent docs link

### DIFF
--- a/highlight.io/pages/for/[slug].tsx
+++ b/highlight.io/pages/for/[slug].tsx
@@ -182,7 +182,7 @@ const Products = ({ product }: { product: iProduct }) => {
 									</PrimaryButton>
 
 									<PrimaryButton
-										href={'/docs'}
+										href={product.docsLink}
 										className={classNames(
 											styles.hollowButton,
 										)}


### PR DESCRIPTION
## Summary
The first "Docs" CTA on the framework page linked to the generic docs site, instead of the purpose-built guide for the selected framework. This change simply uses the link provided for all the other docs CTAs.

<img width="832" alt="Screenshot 2023-04-21 at 7 06 21 AM" src="https://user-images.githubusercontent.com/1341253/233631907-20d04c87-6d88-4950-8ac4-55030f141bc1.png">


## How did you test this change?
Click the first CTA, see it take you to the `product.docsLink`

## Are there any deployment considerations?

nope
