### PR TITLE
Fix overmatching for attribute and body filters

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -357,18 +357,18 @@ export const findMatchingLogAttributes = (
 		}
 
 		let matchingAttribute: string | undefined = undefined
-		if (bodyQueryValue && value.indexOf(bodyQueryValue) !== -1) {
+		if (
+			bodyQueryValue &&
+			key === 'message' &&
+			value.indexOf(bodyQueryValue) !== -1
+		) {
 			matchingAttribute = bodyQueryValue
 		} else {
 			queryTerms.some((term) => {
 				const queryKey = term.key
 				const queryValue = term.value
 
-				if (
-					queryKey === key ||
-					queryValue === value ||
-					value.indexOf(queryValue) !== -1
-				) {
+				if (queryKey === key && value.indexOf(queryValue) !== -1) {
 					matchingAttribute = queryValue
 				}
 			})

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -2,7 +2,7 @@ import { ApolloError } from '@apollo/client'
 import { Button } from '@components/Button'
 import { Link } from '@components/Link'
 import LoadingBox from '@components/LoadingBox'
-import { LogLevel as LogLevelType } from '@graph/schemas'
+import { LogLevel as LogLevelType, ReservedLogKey } from '@graph/schemas'
 import { LogEdge } from '@graph/schemas'
 import {
 	Box,
@@ -333,6 +333,8 @@ export const IconCollapsed: React.FC = () => (
 	<IconSolidCheveronRight color="#6F6E77" size="16" />
 )
 
+const bodyKey = ReservedLogKey['Message']
+
 export const findMatchingLogAttributes = (
 	queryTerms: LogsSearchParam[],
 	logAttributes: object | string,
@@ -359,7 +361,7 @@ export const findMatchingLogAttributes = (
 		let matchingAttribute: string | undefined = undefined
 		if (
 			bodyQueryValue &&
-			key === 'message' &&
+			key === bodyKey &&
 			value.indexOf(bodyQueryValue) !== -1
 		) {
 			matchingAttribute = bodyQueryValue


### PR DESCRIPTION
## Summary

Fixes issues with overmatching and highlighting attributes that aren't actually relevant to the logic for the logs being shown.

### Before

<img width="1512" alt="Screenshot 2023-04-21 at 9 25 21 AM" src="https://user-images.githubusercontent.com/308182/233661257-6333b333-df76-4557-9694-e57a07dc90dd.png">
<img width="1512" alt="Screenshot 2023-04-21 at 9 25 36 AM" src="https://user-images.githubusercontent.com/308182/233661261-cf27fab2-abc6-4e6a-a073-40c37ae5aa2c.png">

### After

<img width="1512" alt="Screenshot 2023-04-21 at 9 25 11 AM" src="https://user-images.githubusercontent.com/308182/233661320-1c48af01-ab63-454c-95f4-134c36352a33.png">
<img width="1512" alt="Screenshot 2023-04-21 at 9 25 43 AM" src="https://user-images.githubusercontent.com/308182/233661324-9cb5cf42-4c44-4041-a9ab-c6251f692431.png">

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A