### PR TITLE
Tweak doc tables style

### DIFF
--- a/highlight.io/components/Docs/Docs.module.scss
+++ b/highlight.io/components/Docs/Docs.module.scss
@@ -975,7 +975,7 @@ h5:hover .headingCopyIcon {
 .docsTable {
 	width: 100%;
 	border: solid #30294e 1px;
-	border-radius: 4px;
+	border-radius: 8px;
 	overflow: hidden;
 
 	table {

--- a/highlight.io/components/Docs/Docs.module.scss
+++ b/highlight.io/components/Docs/Docs.module.scss
@@ -974,11 +974,9 @@ h5:hover .headingCopyIcon {
 
 .docsTable {
 	width: 100%;
-	border: solid #fff2 1px;
+	border: solid #30294e 1px;
 	border-radius: 4px;
 	overflow: hidden;
-	padding: 16px 0 0 0;
-	background-color: #30294e;
 
 	table {
 		width: 100%;
@@ -991,8 +989,19 @@ h5:hover .headingCopyIcon {
 
 		th,
 		td {
-			padding: 8px 16px;
-			border-bottom: solid 1px #fff2;
+			padding: 4px 12px;
+			border-bottom: solid 1px #30294e;
+			border-left: solid 1px #30294e;
+
+			&:first-child {
+				border-left: none;
+			}
+		}
+
+		th {
+			padding: 8px 12px;
+			font-size: 16px;
+			line-height: 26px;
 		}
 
 		tbody {

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -1132,7 +1132,11 @@ const DocPage = ({
 																styles.docsTable
 															}
 														>
-															<table {...props} />
+															<Typography type="copy2">
+																<table
+																	{...props}
+																/>
+															</Typography>
 														</div>
 													)
 												},

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -6,7 +6,7 @@ import { GetStaticPaths, GetStaticProps } from 'next/types'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Collapse } from 'react-collapse'
 import remarkGfm from 'remark-gfm'
-import styles, { docsTable } from '../../components/Docs/Docs.module.scss'
+import styles from '../../components/Docs/Docs.module.scss'
 import ChevronDown from '../../public/images/ChevronDownIcon'
 import Minus from '../../public/images/MinusIcon'
 
@@ -1129,7 +1129,7 @@ const DocPage = ({
 													return (
 														<div
 															className={
-																docsTable
+																styles.docsTable
 															}
 														>
 															<table {...props} />


### PR DESCRIPTION
## Summary

Adjust the table styles based on the design document.

![image](https://user-images.githubusercontent.com/19144605/234143855-d8b12409-3775-46a5-a893-2eb720039100.png)

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
