### PR TITLE
Fix missed relative font url in public.css

### DIFF
--- a/frontend/src/public.css
+++ b/frontend/src/public.css
@@ -35,7 +35,7 @@ body {
 	font-style: normal;
 	font-weight: 800;
 	src: local('Steradian Black'), local('SteradianBlack'),
-		url('/font/SteradianBlack.woff2') format('woff2');
+		url('./font/SteradianBlack.woff2') format('woff2');
 }
 
 @font-face {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

A quick fix to #5088, where I missed one of font urls in public.css.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
