### PR TITLE
Add border to docs and blog images

### DIFF
--- a/highlight.io/components/Blog/Blog.module.scss
+++ b/highlight.io/components/Blog/Blog.module.scss
@@ -386,11 +386,11 @@
 }
 
 .blogImageContainer {
-	padding: 12px 0;
-}
-
-.blogImage {
-	border-radius: 6px;
+	margin: 12px 0;
+	border-radius: 8px;
+	border: solid #30294e 1px;
+	overflow: hidden;
+	display: flex;
 }
 
 // Custom font styles for blog-specific text!!!

--- a/highlight.io/components/Blog/Blog.module.scss.d.ts
+++ b/highlight.io/components/Blog/Blog.module.scss.d.ts
@@ -3,7 +3,6 @@ export const authorDetails: string
 export const authorDiv: string
 export const avatar: string
 export const blogContainer: string
-export const blogImage: string
 export const blogImageContainer: string
 export const blogPost: string
 export const blogPostSmall: string

--- a/highlight.io/pages/blog/[slug].tsx
+++ b/highlight.io/pages/blog/[slug].tsx
@@ -290,7 +290,6 @@ const PostSection = ({ p }: { p: PostSection; idx: number }) => {
 					img: (props) => (
 						<div className={styles.blogImageContainer}>
 							<Image
-								className={styles.blogImage}
 								src={props.src || ''}
 								alt={props.altText}
 								width={props.width}

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -1140,6 +1140,17 @@ const DocPage = ({
 														</div>
 													)
 												},
+												img: (props) => {
+													return (
+														<picture>
+															<img
+																{...props}
+																alt={props.alt}
+																className="border-divider-on-dark border rounded-lg"
+															/>
+														</picture>
+													)
+												},
 											}}
 											{...markdownText}
 										/>


### PR DESCRIPTION
## Summary

Adds a border to all images in docs and blog pages. Closes #5108 

![image](https://user-images.githubusercontent.com/19144605/234349636-085e8de9-9c1a-44ad-8565-b6a5bc7a0581.png)
![image](https://user-images.githubusercontent.com/19144605/234349659-24c8f1e1-8711-4018-9717-f2d666963dca.png)

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
