### PR TITLE
mark schema.resolvers.go as not generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+backend/private-graph/graph/schema.resolvers.go linguist-generated=false
+backend/public-graph/graph/schema.resolvers.go linguist-generated=false
 frontend/src/graph/generated/* linguist-generated=true
 client/src/graph/generated/* linguist-generated=true
 go.sum linguist-generated=true

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -263,7 +263,7 @@ func (r *errorSegmentResolver) Params(ctx context.Context, obj *model.ErrorSegme
 		return params, nil
 	}
 	if err := json.Unmarshal([]byte(*obj.Params), params); err != nil {
-		return nil, e.Wrapf(err, "error unmarshaling segment params")
+		return nil, e.Wrapf(err, "error unmarshalling segment params")
 	}
 	return params, nil
 }

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -149,7 +149,7 @@ func (r *mutationResolver) PushBackendPayload(ctx context.Context, projectID *st
 			}}, partitionKey)
 		if err != nil {
 			log.WithContext(ctx).WithFields(log.Fields{"project_id": projectID, "secure_id": secureID}).
-				Error(e.Wrap(err, "failed to send kafka message for push backend payload"))
+				Error(e.Wrap(err, "failed to send kafka message for push backend payload."))
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

GitHub hides our `schema.resolvers.go` file because gqlgen injects this comment:

https://github.com/highlight/highlight/blob/09b461b6c56809d4233ea651b9d5c8f29fb99aea/backend/public-graph/graph/schema.resolvers.go#L1-L6

But we have lots of non-generated code in these files. See this recent [PR](https://github.com/highlight/highlight/pull/5116/files) change and that `backend/private-graph/graph/schema.resolvers.go` is hidden yet there are actual non generated code changes in there.  

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

See the files changes for this PR output and observe that `schema.resolvers.go` changes are not hidden by default.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
