### PR TITLE
fix incorrect usage of lazy query

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -44,9 +44,10 @@ type Props = {
 	matchedAttributes: ReturnType<typeof findMatchingLogAttributes>
 }
 
-export const getLogURL = (row: Row<LogEdge>) => {
+export const getLogURL = (projectId: string, row: Row<LogEdge>) => {
 	const currentUrl = new URL(window.location.href)
-	const path = generatePath('/logs/:log_cursor', {
+	const path = generatePath('/:project_id/logs/:log_cursor', {
+		project_id: projectId,
 		log_cursor: row.original.cursor,
 	})
 	return currentUrl.origin + path
@@ -226,7 +227,7 @@ export const LogDetails: React.FC<Props> = ({
 						kind="secondary"
 						emphasis="low"
 						onClick={(e) => {
-							const url = getLogURL(row)
+							const url = getLogURL(projectId, row)
 							e.stopPropagation()
 							navigator.clipboard.writeText(url)
 							antdMessage.success('Copied link!')

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -52,7 +52,7 @@ export const useGetLogs = ({
 
 	useEffect(() => {
 		setWindowInfo(initialWindowInfo)
-	}, [query])
+	}, [query, startDate, endDate])
 
 	const { data, loading, error, refetch, fetchMore } = useGetLogsQuery({
 		variables: {

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -7,7 +7,7 @@ import {
 	parseLogsQuery,
 } from '@pages/LogsPage/SearchForm/utils'
 import moment from 'moment'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 export type LogEdgeWithError = LogEdge & {
 	error_object?: Pick<
@@ -38,8 +38,8 @@ export const useGetLogs = ({
 	// If the user scrolls forward to get the next 100 logs, the server will say that hasPreviousPage is `true` since we're on page 2.
 	// Hence, we track the initial information (where "window" is effectively multiple pages) to ensure we aren't making requests unnecessarily.
 	const [windowInfo, setWindowInfo] = useState<PageInfo>({
-		hasNextPage: false,
-		hasPreviousPage: false,
+		hasNextPage: true,
+		hasPreviousPage: true,
 		startCursor: '', // unused but needed for typedef
 		endCursor: '', // unused but needed for typedef
 	})
@@ -63,12 +63,6 @@ export const useGetLogs = ({
 		},
 		fetchPolicy: 'cache-and-network',
 	})
-
-	useEffect(() => {
-		if (data) {
-			setWindowInfo(data.logs.pageInfo)
-		}
-	}, [data])
 
 	const { data: logErrorObjects } = useGetLogsErrorObjectsQuery({
 		variables: { log_cursors: data?.logs.edges.map((e) => e.cursor) || [] },

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -7,13 +7,20 @@ import {
 	parseLogsQuery,
 } from '@pages/LogsPage/SearchForm/utils'
 import moment from 'moment'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 export type LogEdgeWithError = LogEdge & {
 	error_object?: Pick<
 		Types.ErrorObject,
 		'log_cursor' | 'error_group_secure_id' | 'id'
 	>
+}
+
+const initialWindowInfo: PageInfo = {
+	hasNextPage: true,
+	hasPreviousPage: true,
+	startCursor: '', // unused but needed for typedef
+	endCursor: '', // unused but needed for typedef
 }
 
 export const useGetLogs = ({
@@ -37,16 +44,15 @@ export const useGetLogs = ({
 	//
 	// If the user scrolls forward to get the next 100 logs, the server will say that hasPreviousPage is `true` since we're on page 2.
 	// Hence, we track the initial information (where "window" is effectively multiple pages) to ensure we aren't making requests unnecessarily.
-	const [windowInfo, setWindowInfo] = useState<PageInfo>({
-		hasNextPage: true,
-		hasPreviousPage: true,
-		startCursor: '', // unused but needed for typedef
-		endCursor: '', // unused but needed for typedef
-	})
+	const [windowInfo, setWindowInfo] = useState<PageInfo>(initialWindowInfo)
 	const [loadingAfter, setLoadingAfter] = useState(false)
 	const [loadingBefore, setLoadingBefore] = useState(false)
 	const queryTerms = parseLogsQuery(query)
 	const serverQuery = buildLogsQueryForServer(queryTerms)
+
+	useEffect(() => {
+		setWindowInfo(initialWindowInfo)
+	}, [query])
 
 	const { data, loading, error, refetch, fetchMore } = useGetLogsQuery({
 		variables: {

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -7,7 +7,7 @@ import {
 	parseLogsQuery,
 } from '@pages/LogsPage/SearchForm/utils'
 import moment from 'moment'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 export type LogEdgeWithError = LogEdge & {
 	error_object?: Pick<
@@ -29,7 +29,7 @@ export const useGetLogs = ({
 	startDate: Date
 	endDate: Date
 }) => {
-	const [hasNextPage, setHasNextPage] = useState(true)
+	const [hasNextPage, setHasNextPage] = useState(false)
 	const [hasPreviousPage, setHasPreviousPage] = useState(false)
 	const [loadingAfter, setLoadingAfter] = useState(false)
 	const [loadingBefore, setLoadingBefore] = useState(false)
@@ -51,6 +51,13 @@ export const useGetLogs = ({
 		},
 		fetchPolicy: 'cache-and-network',
 	})
+
+	useEffect(() => {
+		if (data) {
+			setHasNextPage(data.logs.pageInfo.hasNextPage)
+			setHasPreviousPage(data.logs.pageInfo.hasPreviousPage)
+		}
+	}, [data])
 
 	const { data: logErrorObjects } = useGetLogsErrorObjectsQuery({
 		variables: { log_cursors: data?.logs.edges.map((e) => e.cursor) || [] },

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -49,6 +49,7 @@ export const useGetLogs = ({
 				},
 			},
 		},
+		fetchPolicy: 'cache-and-network',
 	})
 
 	const { data: logErrorObjects } = useGetLogsErrorObjectsQuery({

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -50,6 +50,16 @@ export const useGetLogs = ({
 
 	const [getLogs, { data, loading, error, refetch, fetchMore }] =
 		useGetLogsLazyQuery({
+			fetchPolicy: 'cache-and-network',
+		})
+
+	const { data: logErrorObjects } = useGetLogsErrorObjectsQuery({
+		variables: { log_cursors: data?.logs.edges.map((e) => e.cursor) || [] },
+		skip: !data?.logs.edges.length,
+	})
+
+	useEffect(() => {
+		getLogs({
 			variables: {
 				project_id: project_id!,
 				at: logCursor,
@@ -62,21 +72,12 @@ export const useGetLogs = ({
 					},
 				},
 			},
-			fetchPolicy: 'cache-and-network',
-		})
-
-	const { data: logErrorObjects } = useGetLogsErrorObjectsQuery({
-		variables: { log_cursors: data?.logs.edges.map((e) => e.cursor) || [] },
-		skip: !data?.logs.edges.length,
-	})
-
-	useEffect(() => {
-		getLogs().then((result) => {
+		}).then((result) => {
 			if (result.data?.logs) {
 				setWindowInfo(result.data.logs.pageInfo)
 			}
 		})
-	}, [getLogs])
+	}, [endDate, getLogs, logCursor, project_id, serverQuery, startDate])
 
 	const fetchMoreForward = useCallback(() => {
 		if (!windowInfo.hasNextPage) {

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -1,5 +1,5 @@
-import { useGetLogsErrorObjectsQuery, useGetLogsLazyQuery } from '@graph/hooks'
-import { LogEdge, PageInfo } from '@graph/schemas'
+import { useGetLogsErrorObjectsQuery, useGetLogsQuery } from '@graph/hooks'
+import { LogEdge } from '@graph/schemas'
 import * as Types from '@graph/schemas'
 import { LOG_TIME_FORMAT } from '@pages/LogsPage/constants'
 import {
@@ -7,7 +7,7 @@ import {
 	parseLogsQuery,
 } from '@pages/LogsPage/SearchForm/utils'
 import moment from 'moment'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 export type LogEdgeWithError = LogEdge & {
 	error_object?: Pick<
@@ -29,112 +29,96 @@ export const useGetLogs = ({
 	startDate: Date
 	endDate: Date
 }) => {
-	// The backend can only tell us page info about a single page.
-	// It has no idea what pages have already been loaded.
-	//
-	// For example: say we make the initial request for 100 logs and hasNextPage=true and hasPreviousPage=false
-	// That means that we should not make any requests when going backwards.
-	//
-	// If the user scrolls forward to get the next 100 logs, the server will say that hasPreviousPage is `true` since we're on page 2.
-	// Hence, we track the initial information (where "window" is effectively multiple pages) to ensure we aren't making requests unnecessarily.
-	const [windowInfo, setWindowInfo] = useState<PageInfo>({
-		hasNextPage: false,
-		hasPreviousPage: false,
-		startCursor: '',
-		endCursor: '',
-	})
+	const [hasNextPage, setHasNextPage] = useState(true)
+	const [hasPreviousPage, setHasPreviousPage] = useState(false)
 	const [loadingAfter, setLoadingAfter] = useState(false)
 	const [loadingBefore, setLoadingBefore] = useState(false)
 	const queryTerms = parseLogsQuery(query)
 	const serverQuery = buildLogsQueryForServer(queryTerms)
 
-	const [getLogs, { data, loading, error, refetch, fetchMore }] =
-		useGetLogsLazyQuery({
-			fetchPolicy: 'cache-and-network',
-		})
+	const { data, loading, error, refetch, fetchMore } = useGetLogsQuery({
+		variables: {
+			project_id: project_id!,
+			at: logCursor,
+			direction: Types.LogDirection.Desc,
+			params: {
+				query: serverQuery,
+				date_range: {
+					start_date: moment(startDate).format(LOG_TIME_FORMAT),
+					end_date: moment(endDate).format(LOG_TIME_FORMAT),
+				},
+			},
+		},
+	})
 
 	const { data: logErrorObjects } = useGetLogsErrorObjectsQuery({
 		variables: { log_cursors: data?.logs.edges.map((e) => e.cursor) || [] },
 		skip: !data?.logs.edges.length,
 	})
 
-	useEffect(() => {
-		getLogs({
-			variables: {
-				project_id: project_id!,
-				at: logCursor,
-				direction: Types.LogDirection.Desc,
-				params: {
-					query: serverQuery,
-					date_range: {
-						start_date: moment(startDate).format(LOG_TIME_FORMAT),
-						end_date: moment(endDate).format(LOG_TIME_FORMAT),
-					},
-				},
-			},
-		}).then((result) => {
-			if (result.data?.logs) {
-				setWindowInfo(result.data.logs.pageInfo)
-			}
-		})
-	}, [endDate, getLogs, logCursor, project_id, serverQuery, startDate])
+	const fetchMoreForward = useCallback(async () => {
+		if (!hasNextPage || loadingAfter) {
+			return
+		}
 
-	const fetchMoreForward = useCallback(() => {
-		if (!windowInfo.hasNextPage) {
+		const lastItem = data && data.logs.edges[data.logs.edges.length - 1]
+		const lastCursor = lastItem?.cursor
+
+		if (!lastCursor) {
 			return
 		}
 
 		setLoadingAfter(true)
 
-		fetchMore({
-			variables: {
-				after: windowInfo.endCursor,
-				before: undefined,
-				at: undefined,
+		await fetchMore({
+			variables: { after: lastCursor },
+			updateQuery: (prevResult, { fetchMoreResult }) => {
+				const newData = fetchMoreResult.logs.edges
+				setHasNextPage(fetchMoreResult.logs.pageInfo.hasNextPage)
+				setLoadingAfter(false)
+				return {
+					logs: {
+						...prevResult.logs,
+						edges: [...prevResult.logs.edges, ...newData],
+						pageInfo: fetchMoreResult.logs.pageInfo,
+					},
+				}
 			},
 		})
-			.then((result) => {
-				if (result.data?.logs) {
-					const { pageInfo } = result.data?.logs
-					setWindowInfo({
-						...windowInfo,
-						hasNextPage: pageInfo.hasNextPage,
-						endCursor: pageInfo.endCursor,
-					})
-				}
-			})
-			.finally(() => {
-				setLoadingAfter(false)
-			})
-	}, [fetchMore, windowInfo])
+	}, [data, fetchMore, hasNextPage, loadingAfter])
 
-	const fetchMoreBackward = useCallback(() => {
-		if (!windowInfo.hasPreviousPage) {
+	const fetchMoreBackward = useCallback(async () => {
+		if (!hasPreviousPage || loadingBefore) {
 			return
 		}
 
-		setLoadingBefore(false)
-		fetchMore({
-			variables: {
-				after: undefined,
-				before: windowInfo.startCursor,
-				at: undefined,
+		const firstItem = data && data.logs.edges[0]
+		const firstCursor = firstItem?.cursor
+
+		if (!firstCursor) {
+			return
+		}
+
+		setLoadingBefore(true)
+
+		await fetchMore({
+			variables: { before: firstCursor },
+			updateQuery: (prevResult, { fetchMoreResult }) => {
+				const newData = fetchMoreResult.logs.edges
+				setHasPreviousPage(
+					fetchMoreResult.logs.pageInfo.hasPreviousPage,
+				)
+				setLoadingBefore(false)
+				return {
+					logs: {
+						...prevResult.logs,
+						edges: [...prevResult.logs.edges, ...newData],
+						pageInfo: fetchMoreResult.logs.pageInfo,
+					},
+				}
 			},
 		})
-			.then((result) => {
-				if (result.data?.logs) {
-					const { pageInfo } = result.data?.logs
-					setWindowInfo({
-						...windowInfo,
-						hasPreviousPage: pageInfo.hasPreviousPage,
-						startCursor: pageInfo.startCursor,
-					})
-				}
-			})
-			.finally(() => {
-				setLoadingBefore(false)
-			})
-	}, [fetchMore, windowInfo])
+	}, [data, fetchMore, hasPreviousPage, loadingBefore])
 
 	const logEdgesWithError: LogEdgeWithError[] = (data?.logs.edges || []).map(
 		(e) => ({


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

There's an interesting bug whereby we can't scroll when changing the `query`. To reproduce:

* Visit the logs page and set the time frame to something small (Last 15 minutes is sufficient for local, you may need something smaller for prod)
* You should have more than one page of logs
* Set the query to: `level:trace`
* Keep scrolling until you hit the end of all trace logs
* Clear the query
* Observe that you cannot scroll past the first page of logs

The reason this was happening was because I initially configured the lazy query in #4535 to apply the variables at the instantiation of the lazy query, not when I actually call the query (`getLogs()`). This is a gotcha with apollo (see [#5912](https://github.com/apollographql/apollo-client/issues/5912)). 

The reason why we even use a lazy query in the first place is because changing the window info is dependent on what we're doing:
* first time the page loads, set window info from the results of invoking the lazy query
* variable (such as `query`, start time, end time) changes, set window info from the results of invoking the lazy query
* scrolling to the next page (or previous page), set window info based on the [`fetchMore`](https://www.apollographql.com/docs/react/pagination/core-api/#the-fetchmore-function) function

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Per the test above, we should be able to scroll past that first page of logs after clearing the query.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A