### PR TITLE
Don't expand custom properties on single error view

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -447,7 +447,11 @@ const Metadata: React.FC<{
 		{
 			key: 'Custom Properties',
 			label: customProperties ? (
-				<JsonViewer src={customProperties} name="Custom Properties" />
+				<JsonViewer
+					collapsed={false}
+					src={customProperties}
+					name="Custom Properties"
+				/>
 			) : undefined,
 		},
 	].filter((t) => Boolean(t.label))

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -448,7 +448,7 @@ const Metadata: React.FC<{
 			key: 'Custom Properties',
 			label: customProperties ? (
 				<JsonViewer
-					collapsed={false}
+					collapsed={true}
 					src={customProperties}
 					name="Custom Properties"
 				/>


### PR DESCRIPTION
## Summary
Don't expand custom properties on single error view. Prevents this issue (very long custom properties):

<img width="973" alt="image" src="https://user-images.githubusercontent.com/20292680/234729363-a1263ce7-d166-4bef-88a1-fa8ff7888e10.png">


<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
Visual test.

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
n/a

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
