### PR TITLE
trim command bar whitespace

### DIFF
--- a/frontend/src/components/CommandBar/CommandBar.tsx
+++ b/frontend/src/components/CommandBar/CommandBar.tsx
@@ -84,7 +84,7 @@ const CommandBarBox = () => {
 }
 const SearchOptions = () => {
 	const form = useCommandBarForm()
-	const query = form.getValue<string>(form.names.search)
+	const query = form.getValue(form.names.search).trim()
 	if (!query) return null
 	return (
 		<>
@@ -97,7 +97,7 @@ const SearchOptions = () => {
 
 const SearchBar = () => {
 	const form = useCommandBarForm()
-	const query = form.getValue<string>(form.names.search)
+	const query = form.getValue(form.names.search).trim()
 	const selectedDates = form.getValue<Date[]>(form.names.selectedDates)
 
 	const inputRef = useRef<HTMLInputElement>(null)
@@ -274,7 +274,7 @@ const SectionRow = ({
 				lines="1"
 				cssClass={styles.query}
 			>
-				{form.getValue(form.names.search)}
+				{form.getValue(form.names.search).trim()}
 			</Text>
 			{selected ? (
 				<Badge

--- a/frontend/src/components/CommandBar/context.tsx
+++ b/frontend/src/components/CommandBar/context.tsx
@@ -103,7 +103,7 @@ export const CommandBarContextProvider: React.FC<React.PropsWithChildren> = ({
 		},
 	})
 
-	const query = form.getValue<string>(form.names.search)
+	const query = form.getValue(form.names.search).trim()
 	const selectedDates = form.getValue<[Date, Date]>(form.names.selectedDates)
 	const searchAttribute = useAttributeSearch(form)
 

--- a/frontend/src/components/CommandBar/utils.ts
+++ b/frontend/src/components/CommandBar/utils.ts
@@ -74,7 +74,7 @@ export function nextAttribute(
 }
 
 export const useAttributeSearch = (form: FormState<CommandBarSearch>) => {
-	const query = form.getValue(form.names.search)
+	const query = form.getValue(form.names.search).trim()
 	const dates = form.getValue(form.names.selectedDates)
 
 	const navigate = useNavigate()


### PR DESCRIPTION
## Summary

Command bar inputs should trim leading/trailing whitespace 
in case someone copy-pastes an email or other search query with whitespace.

## How did you test this change?

https://www.loom.com/share/acffcc8bfa784402b5b0edc0b1bf1b5d

## Are there any deployment considerations?

No