### PR TITLE
Move excluded users up to ProcessPayload to avoid disappearing sessions

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -634,7 +634,7 @@ type Session struct {
 	VerboseID             string  `json:"verbose_id"`
 
 	// Excluded will be true when we would typically have deleted the session
-	Excluded *bool `gorm:"default:false"`
+	Excluded bool `gorm:"default:false"`
 
 	// Lock is the timestamp at which a session was locked
 	// - when selecting sessions, ignore Locks that are > 10 minutes old

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -8261,7 +8261,7 @@ type Session {
 	viewed: Boolean
 	starred: Boolean
 	processed: Boolean
-	excluded: Boolean
+	excluded: Boolean!
 	has_rage_clicks: Boolean
 	has_errors: Boolean
 	first_time: Boolean
@@ -49505,11 +49505,14 @@ func (ec *executionContext) _Session_excluded(ctx context.Context, field graphql
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*bool)
+	res := resTmp.(bool)
 	fc.Result = res
-	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Session_excluded(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -67544,6 +67547,9 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Values[i] = ec._Session_excluded(ctx, field, obj)
 
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "has_rage_clicks":
 
 			out.Values[i] = ec._Session_has_rage_clicks(ctx, field, obj)

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -45,7 +45,7 @@ type Session {
 	viewed: Boolean
 	starred: Boolean
 	processed: Boolean
-	excluded: Boolean
+	excluded: Boolean!
 	has_rage_clicks: Boolean
 	has_errors: Boolean
 	first_time: Boolean

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4156,7 +4156,7 @@ func (r *queryResolver) ErrorInstance(ctx context.Context, errorGroupSecureID st
 		if err := r.DB.Model(&session).Where("id = ?", *errorObject.SessionID).Find(&session).Error; err != nil {
 			return nil, e.Wrap(err, "error reading error group session")
 		}
-		if session.Excluded != nil && *session.Excluded {
+		if session.Excluded {
 			errorObject.SessionID = nil
 		}
 	}
@@ -4773,7 +4773,7 @@ func (r *queryResolver) ProjectHasViewedASession(ctx context.Context, projectID 
 	}
 
 	session := model.Session{}
-	if err := r.DB.Model(&session).Where("project_id = ?", projectID).Where(&model.Session{Viewed: &model.T, Excluded: &model.F}).First(&session).Error; err != nil {
+	if err := r.DB.Model(&session).Where("project_id = ?", projectID).Where(&model.Session{Viewed: &model.T, Excluded: false}).First(&session).Error; err != nil {
 		return &session, nil
 	}
 	return &session, nil

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/phonehome"
-	"go.opentelemetry.io/otel/attribute"
 	"hash/fnv"
 	"io"
 	"net/http"
@@ -16,6 +14,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/phonehome"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/PaesslerAG/jsonpath"
 	"github.com/highlight-run/go-resthooks"
@@ -1262,7 +1263,7 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 		LastUserInteractionTime:        time.Now(),
 		ViewedByAdmins:                 []model.Admin{},
 		ClientID:                       input.ClientID,
-		Excluded:                       &model.T, // A session is excluded by default until it receives events
+		Excluded:                       true, // A session is excluded by default until it receives events
 		ProcessWithRedis:               true,
 		AvoidPostgresStorage:           true,
 	}
@@ -2962,6 +2963,12 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 
 	updateSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.pushPayload", tracer.ResourceName("doSessionFieldsUpdate"))
 	defer updateSpan.Finish()
+
+	excluded := r.isSessionUserExcluded(ctx, sessionObj)
+	if excluded {
+		log.WithContext(ctx).WithFields(log.Fields{"session_id": sessionObj.ID, "project_id": sessionObj.ProjectID, "identifier": sessionObj.Identifier}).Infof("excluding session due to excluded identifier")
+	}
+
 	// Update only if any of these fields are changing
 	// Update the PayloadUpdatedAt field only if it's been >15s since the last one
 	doUpdate := sessionObj.PayloadUpdatedAt == nil ||
@@ -2971,12 +2978,12 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		(sessionObj.Processed != nil && *sessionObj.Processed) ||
 		(sessionObj.ObjectStorageEnabled != nil && *sessionObj.ObjectStorageEnabled) ||
 		(sessionObj.Chunked != nil && *sessionObj.Chunked) ||
-		(sessionObj.Excluded != nil && *sessionObj.Excluded) ||
+		(!excluded) ||
 		(sessionHasErrors && (sessionObj.HasErrors == nil || !*sessionObj.HasErrors))
 
 	if doUpdate {
 		fieldsToUpdate := model.Session{
-			PayloadUpdatedAt: &now, BeaconTime: beaconTime, HasUnloaded: hasSessionUnloaded, Processed: &model.F, ObjectStorageEnabled: &model.F, DirectDownloadEnabled: false, Chunked: &model.F, Excluded: &model.F,
+			PayloadUpdatedAt: &now, BeaconTime: beaconTime, HasUnloaded: hasSessionUnloaded, Processed: &model.F, ObjectStorageEnabled: &model.F, DirectDownloadEnabled: false, Chunked: &model.F, Excluded: false,
 		}
 
 		// We only want to update the `HasErrors` field if the session has errors.
@@ -3003,8 +3010,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	// in OpenSearch so that it's treated as a live session again.
 	// If the session was previously excluded (as we do with new sessions by default),
 	// clear it so it is shown as live in OpenSearch since we now have data for it.
-	if (sessionObj.Processed != nil && *sessionObj.Processed) ||
-		(sessionObj.Excluded != nil && *sessionObj.Excluded) {
+	if (sessionObj.Processed != nil && *sessionObj.Processed) || (!excluded) {
 		if err := r.OpenSearch.Update(opensearch.IndexSessions, sessionObj.ID, map[string]interface{}{
 			"processed":  false,
 			"Excluded":   false,
@@ -3024,6 +3030,43 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		}
 	}
 	return nil
+}
+
+func (r *Resolver) isSessionUserExcluded(ctx context.Context, s *model.Session) bool {
+	var project model.Project
+	if err := r.DB.Raw("SELECT * FROM projects WHERE id = ?;", s.ProjectID).Scan(&project).Error; err != nil {
+		log.WithContext(ctx).WithFields(log.Fields{"session_id": s.ID, "project_id": s.ProjectID, "identifier": s.Identifier}).Errorf("error fetching project for session: %v", err)
+		return false
+	}
+	if project.ExcludedUsers == nil {
+		return false
+	}
+	var email string
+	if s.UserProperties != "" {
+		encodedProperties := []byte(s.UserProperties)
+		decodedProperties := map[string]string{}
+		err := json.Unmarshal(encodedProperties, &decodedProperties)
+		if err != nil {
+			log.WithContext(ctx).WithFields(log.Fields{"session_id": s.ID, "project_id": s.ProjectID}).Errorf("Could not unmarshal user properties: %s, error: %v", s.UserProperties, err)
+			return false
+		}
+		email = decodedProperties["email"]
+	}
+	for _, value := range []string{s.Identifier, email} {
+		if value == "" {
+			continue
+		}
+		for _, excludedExpr := range project.ExcludedUsers {
+			matched, err := regexp.MatchString(excludedExpr, value)
+			if err != nil {
+				log.WithContext(ctx).WithFields(log.Fields{"session_id": s.ID, "project_id": s.ProjectID}).Errorf("error running regexp for excluded users: %s with value: %s, error: %v", excludedExpr, value, err.Error())
+				return false
+			} else if matched {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (r *Resolver) isExcludedError(ctx context.Context, errorFilters []string, errorEvent string, projectID int) bool {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2978,10 +2978,9 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		(sessionObj.Processed != nil && *sessionObj.Processed) ||
 		(sessionObj.ObjectStorageEnabled != nil && *sessionObj.ObjectStorageEnabled) ||
 		(sessionObj.Chunked != nil && *sessionObj.Chunked) ||
-		(!excluded) ||
 		(sessionHasErrors && (sessionObj.HasErrors == nil || !*sessionObj.HasErrors))
 
-	if doUpdate {
+	if doUpdate && !excluded {
 		fieldsToUpdate := model.Session{
 			PayloadUpdatedAt: &now, BeaconTime: beaconTime, HasUnloaded: hasSessionUnloaded, Processed: &model.F, ObjectStorageEnabled: &model.F, DirectDownloadEnabled: false, Chunked: &model.F, Excluded: false,
 		}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -496,7 +496,7 @@ func (w *Worker) DeleteCompletedSessions(ctx context.Context) {
 }
 
 func (w *Worker) excludeSession(ctx context.Context, s *model.Session) error {
-	s.Excluded = false
+	s.Excluded = true
 	s.Processed = &model.T
 	if err := w.Resolver.DB.Table(model.SESSIONS_TBL).Model(&model.Session{Model: model.Model{ID: s.ID}}).Updates(s).Error; err != nil {
 		log.WithContext(ctx).WithFields(log.Fields{"session_id": s.ID, "project_id": s.ProjectID, "identifier": s.Identifier,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2355,7 +2355,7 @@ export type Session = {
 	enable_strict_privacy?: Maybe<Scalars['Boolean']>
 	environment?: Maybe<Scalars['String']>
 	event_counts?: Maybe<Scalars['String']>
-	excluded?: Maybe<Scalars['Boolean']>
+	excluded: Scalars['Boolean']
 	field_group?: Maybe<Scalars['String']>
 	fields?: Maybe<Array<Maybe<Field>>>
 	fingerprint?: Maybe<Scalars['Int']>


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

_This is some initial set up work to make #4980 easier._

This PR moves the excluded users logic from the worker process session up to ProcessPayload. 

The previous logic worked like this:
* `InitializeSession` (excluded = true)
* `ProcessPayload` (excluded = false)
* Session is visible in the feed
* Session finishes
* Process session kicks off
* `isSessionUserExcluded = true` and the session is marked as `excluded = false` and removed from the feed


Now the logic works like this:
The previous logic worked like this:
* `InitializeSession` (excluded = true)
* `ProcessPayload` (excluded = false **unless `isSessionUserExcluded = true`**)
* Session is **not** visible in the feed
* Session finishes
* Process session kicks off

## How did you test this change?

* Confirmed that using the [excluded users setting](https://localhost:3000/1/settings) never shows the session in the feed (and that the db marked `excluded=true` on the session record).
* Confirmed that removing the [excluded users setting](https://localhost:3000/1/settings) does show in the feed (and that the db marked `excluded=false` on the session record).

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
