### PR TITLE
avoid duplicate errors from error boundary and show dialog by default

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -33,6 +33,12 @@ jobs:
                       npm-changed:
                         - 'sdk/client/**'
                         - 'sdk/firstload/**'
+                        - 'sdk/highlight-apollo/**'
+                        - 'sdk/highlight-cloudflare/**'
+                        - 'sdk/highlight-nest/**'
+                        - 'sdk/highlight-next/**'
+                        - 'sdk/highlight-node/**'
+                        - 'sdk/highlight-react/**'
 
             # automatically caches dependencies based on yarn.lock
             - name: Setup Node.js environment

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/react-error-boundary.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/react-error-boundary.md
@@ -15,7 +15,7 @@ Highlight provides an `ErrorBoundary` to help you provide a better experience fo
 import { ErrorBoundary } from '@highlight-run/react'
 
 const App = () => (
-  <ErrorBoundary showDialog>
+  <ErrorBoundary>
     <YourAwesomeApplication />
   </ErrorBoundary>
 )
@@ -31,7 +31,7 @@ const App = () => (
 import { ErrorBoundary } from '@highlight-run/react'
 
 const App = () => (
-  <ErrorBoundary showDialog>
+  <ErrorBoundary>
     <YourAwesomeApplication />
   </ErrorBoundary>
 )
@@ -46,7 +46,6 @@ import { ErrorBoundary } from '@highlight-run/react'
 
 const App = () => (
   <ErrorBoundary
-    showDialog
     customDialog={
       <div>
         <h2>Whoops! Looks like a crash happened.</h2>
@@ -76,7 +75,7 @@ A fallback component that gets rendered when the error boundary encounters an er
 
 ## `showDialog`
 
-Enables Highlight's crash report. When the `ErrorBoundary` is triggered, a form will be prompted to the user asking them for optional feedback.
+Enables Highlight's crash report. When the `ErrorBoundary` is triggered, a form will be prompted to the user asking them for optional feedback. Defaults to true.
 
 ### `dialogOptions`
 

--- a/e2e/nextjs/src/components/ErrorBoundaryButton.tsx
+++ b/e2e/nextjs/src/components/ErrorBoundaryButton.tsx
@@ -4,7 +4,7 @@ import { ErrorBoundary, SampleBuggyButton } from '@highlight-run/react'
 
 export default function ErrorBoundaryButton() {
 	return (
-		<ErrorBoundary showDialog>
+		<ErrorBoundary>
 			<SampleBuggyButton />
 		</ErrorBoundary>
 	)

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -138,7 +138,6 @@ const App = () => {
 
 	return (
 		<ErrorBoundary
-			showDialog
 			onAfterReportDialogCancelHandler={() => {
 				const { origin } = window.location
 				window.location.href = origin

--- a/highlight.io/components/Home/SnippetTab/SnippetTab.tsx
+++ b/highlight.io/components/Home/SnippetTab/SnippetTab.tsx
@@ -67,7 +67,7 @@ import { ErrorBoundary } from '@highlight-run/react';
 H.init('your-api-key');
 
 ReactDOM.render(
-  <ErrorBoundary showDialog>
+  <ErrorBoundary>
     <App />
   </ErrorBoundary>,
   document.getElementById('root')

--- a/highlight.io/components/QuickstartContent/frontend/next.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/next.tsx
@@ -65,7 +65,7 @@ yarn add highlight.run @highlight-run/react`,
 		initializeSnippet,
 		{
 			title: 'Add the ErrorBoundary component. (optional)',
-			content: `The ErrorBoundary component wraps your component tree and catches crashes/exceptions from your react app. When a crash happens, if \`showDialog\` is set, your users will be prompted with a modal to share details about what led up to the crash. Read more [here](${reactErrorBoundaryLink}).`,
+			content: `The ErrorBoundary component wraps your component tree and catches crashes/exceptions from your react app. When a crash happens, your users will be prompted with a modal to share details about what led up to the crash. Read more [here](${reactErrorBoundaryLink}).`,
 			code: {
 				text: ErrorBoundaryCodeSnippet,
 				language: 'js',

--- a/highlight.io/components/QuickstartContent/frontend/react.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/react.tsx
@@ -38,7 +38,7 @@ yarn add highlight.run @highlight-run/react`,
 		initializeSnippet,
 		{
 			title: 'Add the ErrorBoundary component. (optional)',
-			content: `The ErrorBoundary component wraps your component tree and catches crashes/exceptions from your react app. When a crash happens, if \`showDialog\` is set, your users will be prompted with a modal to share details about what led up to the crash. Read more [here](https://www.highlight.io/docs/getting-started/client-sdk/replay-configuration/react-error-boundary).`,
+			content: `The ErrorBoundary component wraps your component tree and catches crashes/exceptions from your react app. When a crash happens, your users will be prompted with a modal to share details about what led up to the crash. Read more [here](https://www.highlight.io/docs/getting-started/client-sdk/replay-configuration/react-error-boundary).`,
 			code: {
 				text: ErrorBoundaryCodeSnippet,
 				language: 'js',

--- a/packages/component-preview/src/ErrorBoundary.stories.tsx
+++ b/packages/component-preview/src/ErrorBoundary.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 export const Basic: React.FC = () => {
 	return (
-		<ErrorBoundary showDialog>
+		<ErrorBoundary>
 			<SampleBuggyButton />
 		</ErrorBoundary>
 	)

--- a/sdk/highlight-react/package.json
+++ b/sdk/highlight-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/react",
-	"version": "3.0.1",
+	"version": "3.1.0",
 	"description": "The official Highlight SDK for React",
 	"license": "MIT",
 	"peerDependencies": {

--- a/sdk/highlight-react/package.json
+++ b/sdk/highlight-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/react",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"description": "The official Highlight SDK for React",
 	"license": "MIT",
 	"peerDependencies": {

--- a/sdk/highlight-react/src/components/ErrorBoundary.tsx
+++ b/sdk/highlight-react/src/components/ErrorBoundary.tsx
@@ -9,15 +9,13 @@ export type FallbackRender = (errorData: {
 
 export type ErrorBoundaryProps = {
 	children?: React.ReactNode
-	/** Deprecated: no-op for compatibility. Dialog is enabled by default, unless {@link noShowDialog} is true. */
+	/** If a Highlight report dialog should be rendered on error. Defaults to true. */
 	showDialog?: boolean
-	/** Set true to disable the Highlight report dialog being rendered on error  */
-	noShowDialog?: boolean
 	/** A custom dialog that you can provide to be shown when the ErrorBoundary is shown. */
 	customDialog?: React.ReactNode
 	/**
 	 * Options to be passed into the Highlight report dialog.
-	 * No-op if {@link noShowDialog} is true.
+	 * No-op if {@link showDialog} is false.
 	 */
 	dialogOptions?: ReportDialogOptions
 	/**
@@ -64,7 +62,7 @@ export class ErrorBoundary extends React.Component<
 	public state: ErrorBoundaryState = INITIAL_STATE
 
 	componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-		const { beforeCapture, onError, noShowDialog } = this.props
+		const { beforeCapture, onError, showDialog } = this.props
 
 		if (beforeCapture) {
 			beforeCapture(error, errorInfo.componentStack)
@@ -73,7 +71,7 @@ export class ErrorBoundary extends React.Component<
 		if (onError) {
 			onError(error, errorInfo.componentStack)
 		}
-		if (!noShowDialog) {
+		if (showDialog !== false) {
 			this.setState({ ...this.state, showingDialog: true })
 		}
 

--- a/sdk/highlight-react/src/components/ErrorBoundary.tsx
+++ b/sdk/highlight-react/src/components/ErrorBoundary.tsx
@@ -9,13 +9,15 @@ export type FallbackRender = (errorData: {
 
 export type ErrorBoundaryProps = {
 	children?: React.ReactNode
-	/** If a Highlight report dialog should be rendered on error */
+	/** Deprecated: no-op for compatibility. Dialog is enabled by default, unless {@link noShowDialog} is true. */
 	showDialog?: boolean
+	/** Set true to disable the Highlight report dialog being rendered on error  */
+	noShowDialog?: boolean
 	/** A custom dialog that you can provide to be shown when the ErrorBoundary is shown. */
 	customDialog?: React.ReactNode
 	/**
 	 * Options to be passed into the Highlight report dialog.
-	 * No-op if {@link showDialog} is false.
+	 * No-op if {@link noShowDialog} is true.
 	 */
 	dialogOptions?: ReportDialogOptions
 	/**
@@ -62,7 +64,7 @@ export class ErrorBoundary extends React.Component<
 	public state: ErrorBoundaryState = INITIAL_STATE
 
 	componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-		const { beforeCapture, onError, showDialog } = this.props
+		const { beforeCapture, onError, noShowDialog } = this.props
 
 		if (beforeCapture) {
 			beforeCapture(error, errorInfo.componentStack)
@@ -71,7 +73,7 @@ export class ErrorBoundary extends React.Component<
 		if (onError) {
 			onError(error, errorInfo.componentStack)
 		}
-		if (showDialog) {
+		if (!noShowDialog) {
 			this.setState({ ...this.state, showingDialog: true })
 		}
 
@@ -196,10 +198,10 @@ function captureReactErrorBoundaryError(
 
 	const componentName = getComponentNameFromStack(componentStack)
 
+	// if highlight is active, then we'll catch the error via the `window.onerror` listener
+	// otherwise, we'll print it
 	if (!window.H) {
-		console.warn('You need to install highlight.run as a npm dependency.')
-	} else {
-		window.H.consumeError(
+		console.error(
 			errorBoundaryError,
 			`${
 				componentName


### PR DESCRIPTION
## Summary

* Disables error reporting to highlight by the error boundary when highlight is present because highlight will be catching the same error via the `window.onerror` listener, resulting in duplicate errors. ie. 
![image](https://user-images.githubusercontent.com/1351531/235011726-1cacd889-8e03-4130-8faf-3852e7943898.png)
* Changes the ErrorHandler props to default to `showDialog` and add an optional `noShowDialog` as we've heard from customers that the props are un-intuitive (the dialog is the whole point of the error boundary to begin with).


## How did you test this change?

buttons page
![image](https://user-images.githubusercontent.com/1351531/235014279-a08b6144-5dd2-44f8-a25d-f9c9c1563305.png)
only one error recorded
![image](https://user-images.githubusercontent.com/1351531/235014346-abbb9d24-a339-4645-8fc8-1c87b28a89db.png)


## Are there any deployment considerations?

The `showDialog` is kept to keep this change non-breaking. Since we just released the major version 3.x today, thinking we can still sneak this in as 3.0.1 though the behavior of the dialog has changed.

