### PR TITLE
update pri.highlight.run -> pri.highlight.io

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -62,6 +62,8 @@ const options: HighlightOptions = {
 		destinationDomains: [
 			'pri.highlight.run',
 			'pub.highlight.run',
+			'pri.highlight.io',
+			'pub.highlight.io',
 			'localhost:8082',
 		],
 		urlBlocklist: [

--- a/frontend/src/pages/OAuthApproval/OAuthApprovalPage.tsx
+++ b/frontend/src/pages/OAuthApproval/OAuthApprovalPage.tsx
@@ -23,7 +23,7 @@ interface OAuthToken {
 
 const OAuthBackend =
 	window.location.port === ''
-		? `https://pri.highlight.run`
+		? `https://pri.highlight.io`
 		: `https://pri.highlight.localhost`
 const HighlightFrontend =
 	window.location.port === ''

--- a/sourcemap-uploader/package.json
+++ b/sourcemap-uploader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@highlight-run/sourcemap-uploader",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Command line tool to upload source maps to Highlight",
   "bin": "./dist/index.js",
   "author": "Highlight",

--- a/sourcemap-uploader/src/lib.ts
+++ b/sourcemap-uploader/src/lib.ts
@@ -39,7 +39,7 @@ export const uploadSourcemaps = async ({
     api_key: apiKey,
   };
 
-  const res = await fetch("https://pri.highlight.run", {
+  const res = await fetch("https://pri.highlight.io", {
     method: "post",
     headers: {
       "Content-Type": "application/json",
@@ -85,7 +85,7 @@ export const uploadSourcemaps = async ({
     getS3Key(organizationId, appVersion, basePath, name)
   );
 
-  const urlRes = await fetch("https://pri.highlight.run", {
+  const urlRes = await fetch("https://pri.highlight.io", {
     method: "post",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

Updates the frontend to use pri.highlight.io since the frontend is hosted on app.highlight.io.
While everything has been working so far on app.highlight.io using pri.highlight.run, today we
discovered that the `/assets` feature is broken as loading the authenticated resources
requires the project token cookie, set by a backend request on `.highlight.io`. This cookie
is not sent to requests to pri.highlight.run since the domain does not match.

I've already made the necessary AWS LB and DNS changes to set up pri.highlight.io.
This change cleans up other code references to pri.highlight.run to point to the new domain.

## How did you test this change?

Local depoy of the frontend with the `REACT_APP_PRIVATE_GRAPH_URI` set to pri.highlight.io runs into CORS issues but has valid SSL

![Screenshot from 2023-04-27 17-01-15](https://user-images.githubusercontent.com/1351531/235015082-f52c453b-c24e-454b-9eac-46df9125534d.png)

![Screenshot from 2023-04-27 17-00-54](https://user-images.githubusercontent.com/1351531/235015042-0e1c1c77-e9f7-4e99-bfb5-327b3205a9ef.png)


## Are there any deployment considerations?

Will update REACT_APP_PRIVATE_GRAPH_URI in production and monitor the release.