### PR TITLE
join on delete_sessions_tasks table in delete sessions / fields queries

### DIFF
--- a/backend/lambda-functions/deleteSessions/deleteSessionBatchFromOpenSearch/main.go
+++ b/backend/lambda-functions/deleteSessions/deleteSessionBatchFromOpenSearch/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
+	H "github.com/highlight/highlight/sdk/highlight-go"
+	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
 var h handlers.Handlers
@@ -12,5 +14,9 @@ func init() {
 }
 
 func main() {
+	H.SetProjectID("1jdkoe52")
+	H.Start()
+	defer H.Stop()
+	hlog.Init()
 	lambda.Start(h.DeleteSessionBatchFromOpenSearch)
 }

--- a/backend/lambda-functions/deleteSessions/deleteSessionBatchFromPostgres/main.go
+++ b/backend/lambda-functions/deleteSessions/deleteSessionBatchFromPostgres/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
+	H "github.com/highlight/highlight/sdk/highlight-go"
+	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
 var h handlers.Handlers
@@ -12,5 +14,9 @@ func init() {
 }
 
 func main() {
+	H.SetProjectID("1jdkoe52")
+	H.Start()
+	defer H.Stop()
+	hlog.Init()
 	lambda.Start(h.DeleteSessionBatchFromPostgres)
 }

--- a/backend/lambda-functions/deleteSessions/deleteSessionBatchFromS3/main.go
+++ b/backend/lambda-functions/deleteSessions/deleteSessionBatchFromS3/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
+	H "github.com/highlight/highlight/sdk/highlight-go"
+	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
 var h handlers.Handlers
@@ -12,5 +14,9 @@ func init() {
 }
 
 func main() {
+	H.SetProjectID("1jdkoe52")
+	H.Start()
+	defer H.Stop()
+	hlog.Init()
 	lambda.Start(h.DeleteSessionBatchFromS3)
 }

--- a/backend/lambda-functions/deleteSessions/getSessionIdsByQuery/main.go
+++ b/backend/lambda-functions/deleteSessions/getSessionIdsByQuery/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
+	H "github.com/highlight/highlight/sdk/highlight-go"
+	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
 var h handlers.Handlers
@@ -12,5 +14,9 @@ func init() {
 }
 
 func main() {
+	H.SetProjectID("1jdkoe52")
+	H.Start()
+	defer H.Stop()
+	hlog.Init()
 	lambda.Start(h.GetSessionIdsByQuery)
 }

--- a/backend/lambda-functions/deleteSessions/main.go
+++ b/backend/lambda-functions/deleteSessions/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/utils"
 	"github.com/highlight-run/highlight/backend/util"
+	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
 // Meant for local invocation for testing the lambda handler stack
@@ -15,6 +16,8 @@ func main() {
 	if !util.IsDevOrTestEnv() {
 		return
 	}
+
+	hlog.Init()
 
 	h := handlers.NewHandlers()
 	input := utils.QuerySessionsInput{

--- a/backend/lambda-functions/deleteSessions/main.go
+++ b/backend/lambda-functions/deleteSessions/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/utils"
 	"github.com/highlight-run/highlight/backend/util"
+	H "github.com/highlight/highlight/sdk/highlight-go"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
@@ -17,6 +18,9 @@ func main() {
 		return
 	}
 
+	H.SetProjectID("1jdkoe52")
+	H.Start()
+	defer H.Stop()
 	hlog.Init()
 
 	h := handlers.NewHandlers()

--- a/backend/lambda-functions/deleteSessions/sendEmail/main.go
+++ b/backend/lambda-functions/deleteSessions/sendEmail/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
+	H "github.com/highlight/highlight/sdk/highlight-go"
+	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
 var h handlers.Handlers
@@ -12,5 +14,9 @@ func init() {
 }
 
 func main() {
+	H.SetProjectID("1jdkoe52")
+	H.Start()
+	defer H.Stop()
+	hlog.Init()
 	lambda.Start(h.SendEmail)
 }


### PR DESCRIPTION
## Summary
- the delete from `session_fields` query is timing out even when there are no records left to delete
- this new form of the query selecting from the `delete_sessions_tasks` table completes in `.093s` right now (for 0 rows to delete)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran query against prod
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
