### PR TITLE
revert error boundary error reporting change

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
                   cache-dependency-path: '**/go.sum'
 
             - name: Login to Docker Hub
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight'
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/master'
               uses: docker/login-action@v2
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,7 +31,7 @@ jobs:
             - name: Test
               run: poetry run pytest --cov=highlight_io --cov-branch --cov-report xml
             - name: Get Cover
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.event_name == 'pull_request'
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight'
               uses: orgoro/coverage@v3
               with:
                   coverageFile: ./sdk/highlight-py/coverage.xml
@@ -39,7 +39,7 @@ jobs:
             - name: Build
               run: poetry build
             - name: Publish
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref == 'refs/heads/main'
+              if: github.ref == 'refs/heads/main'
               run: poetry publish -u $PYPI_USERNAME -p $PYPI_PASSWORD --skip-existing
               env:
                   PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -60,7 +60,7 @@ jobs:
                   GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
 
             - name: Configure AWS credentials
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' && steps.filter.outputs.npm-changed == 'true'
+              if: steps.filter.outputs.npm-changed == 'true' && (github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/master')
               uses: aws-actions/configure-aws-credentials@v2
               with:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -68,7 +68,7 @@ jobs:
                   aws-region: us-east-2
 
             - name: Validate project is ready to be published
-              if: github.repository == 'highlight/highlight' && steps.filter.outputs.npm-changed == 'true'
+              if: steps.filter.outputs.npm-changed == 'true' && (github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/master')
               run: yarn validate
 
             # always publish client, even in PRs
@@ -76,18 +76,18 @@ jobs:
             # any previous builds, while doing this in PR will allow the PR frontend preview
             # to reference the PR's latest version of client
             - name: Publish client bundle
-              if: github.repository == 'highlight/highlight' && steps.filter.outputs.npm-changed == 'true'
+              if: steps.filter.outputs.npm-changed == 'true' && (github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/master')
               run: yarn publish:client
 
             - name: Upload frontend sourcemaps
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref == 'refs/heads/main'
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/master'
               run: yarn && yarn sourcemaps:frontend
               env:
                   HIGHLIGHT_API_KEY: ${{ secrets.HIGHLIGHT_SOURCEMAP_API_KEY }}
                   APP_VERSION: ${{ github.sha }}
 
             - name: Configure yarn npm registry credentials
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref == 'refs/heads/main'
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/master'
               run: |
                   yarn config set npmRegistryServer "https://registry.npmjs.org"
                   yarn config set npmAuthToken "${NPM_TOKEN}"
@@ -95,7 +95,7 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Publish npm packages
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref == 'refs/heads/main'
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/master'
               run: yarn publish:turbo
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -80,14 +80,14 @@ jobs:
               run: yarn publish:client
 
             - name: Upload frontend sourcemaps
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/master'
+              if: github.ref == 'refs/heads/master'
               run: yarn && yarn sourcemaps:frontend
               env:
                   HIGHLIGHT_API_KEY: ${{ secrets.HIGHLIGHT_SOURCEMAP_API_KEY }}
                   APP_VERSION: ${{ github.sha }}
 
             - name: Configure yarn npm registry credentials
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/master'
+              if: github.ref == 'refs/heads/master'
               run: |
                   yarn config set npmRegistryServer "https://registry.npmjs.org"
                   yarn config set npmAuthToken "${NPM_TOKEN}"
@@ -95,7 +95,7 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Publish npm packages
-              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/master'
+              if: github.ref == 'refs/heads/master'
               run: yarn publish:turbo
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -139,12 +139,7 @@ const App = () => {
 	)
 
 	return (
-		<ErrorBoundary
-			onAfterReportDialogCancelHandler={() => {
-				const { origin } = window.location
-				window.location.href = origin
-			}}
-		>
+		<ErrorBoundary>
 			<ApolloProvider client={client}>
 				<SkeletonTheme
 					baseColor="var(--color-gray-200)"

--- a/sdk/highlight-react/package.json
+++ b/sdk/highlight-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/react",
-	"version": "3.1.1",
+	"version": "3.2.0",
 	"description": "The official Highlight SDK for React",
 	"license": "MIT",
 	"peerDependencies": {

--- a/sdk/highlight-react/package.json
+++ b/sdk/highlight-react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/react",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"description": "The official Highlight SDK for React",
 	"license": "MIT",
 	"peerDependencies": {

--- a/sdk/highlight-react/src/components/ErrorBoundary.tsx
+++ b/sdk/highlight-react/src/components/ErrorBoundary.tsx
@@ -196,10 +196,10 @@ function captureReactErrorBoundaryError(
 
 	const componentName = getComponentNameFromStack(componentStack)
 
-	// if highlight is active, then we'll catch the error via the `window.onerror` listener
-	// otherwise, we'll print it
 	if (!window.H) {
-		console.error(
+		console.warn('You need to install highlight.run as a npm dependency.')
+	} else {
+		window.H.consumeError(
 			errorBoundaryError,
 			`${
 				componentName

--- a/sdk/highlight-react/src/components/ErrorBoundary.tsx
+++ b/sdk/highlight-react/src/components/ErrorBoundary.tsx
@@ -195,7 +195,11 @@ function captureReactErrorBoundaryError(
 	if (!window.H) {
 		console.warn('You need to install highlight.run.')
 	} else {
-		window.H.consumeError(error, undefined, { component })
+		window.H.consumeError(
+			error,
+			undefined,
+			component ? { component } : undefined,
+		)
 	}
 }
 

--- a/sdk/highlight-react/src/components/ErrorBoundary.tsx
+++ b/sdk/highlight-react/src/components/ErrorBoundary.tsx
@@ -67,7 +67,7 @@ export class ErrorBoundary extends React.Component<
 		if (beforeCapture) {
 			beforeCapture(error, errorInfo.componentStack)
 		}
-		captureReactErrorBoundaryError(error, errorInfo.componentStack)
+		captureReactErrorBoundaryError(error, errorInfo)
 		if (onError) {
 			onError(error, errorInfo.componentStack)
 		}
@@ -183,30 +183,17 @@ export class ErrorBoundary extends React.Component<
  * Logs react error boundary errors to Highlight.
  *
  * @param error An error captured by React Error Boundary
- * @param componentStack The component stacktrace
+ * @param errorInfo The error details
  */
 function captureReactErrorBoundaryError(
 	error: Error,
-	componentStack: string,
+	errorInfo: ErrorInfo,
 ): void {
-	const errorBoundaryError = new Error(` ${error.message}`)
-	errorBoundaryError.name = `React ErrorBoundary ${error.name}`
-	//   errorBoundaryError.stack = `${componentStack}`;
-	errorBoundaryError.stack = error.stack
-
-	const componentName = getComponentNameFromStack(componentStack)
-
+	const component = getComponentNameFromStack(errorInfo.componentStack)
 	if (!window.H) {
-		console.warn('You need to install highlight.run as a npm dependency.')
+		console.warn('You need to install highlight.run.')
 	} else {
-		window.H.consumeError(
-			errorBoundaryError,
-			`${
-				componentName
-					? `ErrorBoundary ${componentName}`
-					: 'HighlightErrorBoundary'
-			}`,
-		)
+		window.H.consumeError(error, undefined, { component })
 	}
 }
 

--- a/sdk/highlight-react/src/components/ErrorBoundary.tsx
+++ b/sdk/highlight-react/src/components/ErrorBoundary.tsx
@@ -106,10 +106,12 @@ export class ErrorBoundary extends React.Component<
 
 	hideDialog: () => void = () => {
 		this.setState({ ...this.state, showingDialog: false })
-
-		if (this.props.onAfterReportDialogCancelHandler) {
-			this.props.onAfterReportDialogCancelHandler()
-		}
+		;(
+			this.props.onAfterReportDialogCancelHandler ||
+			(() => {
+				window.location.href = window.location.origin
+			})
+		)()
 	}
 
 	onReportDialogSubmitHandler: () => void = () => {


### PR DESCRIPTION
## Summary

Revert the error boundary change to keep reporting caught errors.
Duplicate errors were previously encountered because the legacy SDK was used that reported `console.error` exceptions.
Cleans up the reported exception name to remove extraneous text in the title.
Defaults to refreshing the page when `cancel` or `submit` is pressed as per customer suggestion.

## How did you test this change?

Turns out when I thought that React was causing the `window.onerror` events, it was actually a chrome extension.
![image](https://user-images.githubusercontent.com/1351531/235278806-8548744c-5904-45bb-b5ca-03d9b9807277.png)

As seen from that `PushPayload` contents, now there is only one real error sent in a production environment.

![image](https://user-images.githubusercontent.com/1351531/235279229-a89a3289-d010-4d9d-9742-209492bd5608.png)

## Are there any deployment considerations?

New react sdk version.
Instructions to customers with duplicate issues: upgrade to `highlight.run@>=6.0.0` and `@highlight-run/react@>=3.1.1`
