### PR TITLE
increase asset storage limit

### DIFF
--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/highlight-run/highlight/backend/model"
-	storage "github.com/highlight-run/highlight/backend/storage"
+	"github.com/highlight-run/highlight/backend/storage"
 	"github.com/lukasbob/srcset"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
@@ -89,6 +89,7 @@ const (
 	ErrAssetTooLarge    = "ErrAssetTooLarge"
 	ErrAssetSizeUnknown = "ErrAssetSizeUnknown"
 	ErrFailedToFetch    = "ErrFailedToFetch"
+	MaxAssetSize        = 10 * 1024 * 1e6
 )
 
 type fetcher interface {
@@ -407,7 +408,7 @@ func getOrCreateUrls(ctx context.Context, projectId int, originalUrls []string, 
 			response, err := http.Get(url)
 			if err != nil {
 				hashVal = ErrFailedToFetch
-			} else if response.ContentLength > 30e6 {
+			} else if response.ContentLength > MaxAssetSize {
 				hashVal = ErrAssetTooLarge
 			} else {
 				res, err := io.ReadAll(response.Body)


### PR DESCRIPTION
## Summary

Increase the stored asset size to 10GB for the persistent-assets feature.
This feature is gated for a few projects so this would have no broad impact.
We can reduce this once we have a sense of the distribution of file sizes of assets saved.

## How did you test this change?

CI - feature is gated.

## Are there any deployment considerations?

No