### PR TITLE
fix go graphql sdk recording duplicate errrors

### DIFF
--- a/sdk/highlight-go/log/logrus.go
+++ b/sdk/highlight-go/log/logrus.go
@@ -3,7 +3,6 @@ package hlog
 import (
 	"context"
 	"fmt"
-	"runtime/debug"
 	"strings"
 
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -78,22 +77,8 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 		}
 	}
 
-	hasError := false
 	for k, v := range entry.Data {
-		if k == "error" {
-			hasError = true
-			if err, ok := v.(highlight.ErrorWithStack); ok {
-				highlight.RecordSpanErrorWithStack(span, err)
-			} else if err, ok := v.(error); ok {
-				span.RecordError(err, trace.WithStackTrace(true))
-			}
-		} else {
-			attrs = append(attrs, attribute.String(k, fmt.Sprintf("%+v", v)))
-		}
-	}
-
-	if !hasError {
-		attrs = append(attrs, semconv.ExceptionStacktraceKey.String(string(debug.Stack())))
+		attrs = append(attrs, attribute.String(k, fmt.Sprintf("%+v", v)))
 	}
 
 	span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...))


### PR DESCRIPTION
## Summary

Fixes duplicate errors recorded by the go graphql SDK.
* Errors were recorded any time a `logrus.WithError(err)...` print statement was made. This is incorrect behavior - we should report the error as an attribute of the log, but never create error objects from the log statement.
* The graphql tracer would record two errors for the same request - once from `InterceptField` (the right place that has access to the stacktrace of the error) and once from `InterceptResponse` (an aggregate of the errors that do not have the source stacktraces).

## How did you test this change?

* Checking the types of stacktraces present in go errors reported to highlight.
*Only two errors now reported in a clean local deploy
![image](https://user-images.githubusercontent.com/1351531/235265135-c75c372f-216d-4c47-b793-15b387ed8b49.png)
![image](https://user-images.githubusercontent.com/1351531/235265151-3c42498c-dabe-4c51-a7a0-a9f80c550bce.png)
![image](https://user-images.githubusercontent.com/1351531/235265191-95f0c4c7-ea02-431d-bccd-92962f03067a.png)

## Are there any deployment considerations?

Will tag a new version of the Go SDK.