### PR TITLE
readd delayed hubspot contact and company creation

### DIFF
--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -45,7 +45,9 @@ func retry[T *int](fn func() (T, error)) (ret T, err error) {
 
 func pollHubspot[T *int](fn func() (T, error)) (result T, err error) {
 	start := time.Now()
-	for t := range time.Tick(ClientSideCreationPollInterval) {
+	ticker := time.NewTicker(ClientSideCreationPollInterval)
+	defer ticker.Stop()
+	for t := range ticker.C {
 		result, err = fn()
 		if result != nil {
 			return

--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -29,7 +29,7 @@ import (
 const Retries = 5
 
 // ClientSideCreationTimeout is the time we will wait for the object to be created by the hubspot client-side snippet
-const ClientSideCreationTimeout = time.Minute
+const ClientSideCreationTimeout = 3 * time.Minute
 const ClientSideCreationPollInterval = 5 * time.Second
 
 func retry[T *int](fn func() (T, error)) (ret T, err error) {

--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	kafka_queue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/redis"
 	"github.com/openlyinc/pointy"
 	"github.com/samber/lo"
@@ -25,10 +26,14 @@ import (
 	"gorm.io/gorm"
 )
 
-const RETRIES = 5
+const Retries = 5
+
+// ClientSideCreationTimeout is the time we will wait for the object to be created by the hubspot client-side snippet
+const ClientSideCreationTimeout = time.Minute
+const ClientSideCreationPollInterval = 5 * time.Second
 
 func retry[T *int](fn func() (T, error)) (ret T, err error) {
-	for i := 0; i < RETRIES; i++ {
+	for i := 0; i < Retries; i++ {
 		ret, err = fn()
 		if err == nil {
 			return
@@ -38,16 +43,34 @@ func retry[T *int](fn func() (T, error)) (ret T, err error) {
 	return
 }
 
-type HubspotApi struct {
-	hubspotClient hubspot.Client
-	redisClient   *redis.Client
+func pollHubspot[T *int](fn func() (T, error)) (result T, err error) {
+	start := time.Now()
+	for t := range time.Tick(ClientSideCreationPollInterval) {
+		result, err = fn()
+		if result != nil {
+			return
+		}
+		if t.Sub(start) > ClientSideCreationTimeout {
+			break
+		}
+	}
+	return
 }
 
-func NewHubspotAPI(client hubspot.Client, redisClient *redis.Client) *HubspotApi {
-	h := &HubspotApi{}
-	h.hubspotClient = client
-	h.redisClient = redisClient
-	return h
+type HubspotApi struct {
+	db            *gorm.DB
+	hubspotClient hubspot.Client
+	redisClient   *redis.Client
+	kafkaProducer *kafka_queue.Queue
+}
+
+func NewHubspotAPI(client hubspot.Client, db *gorm.DB, redisClient *redis.Client, kafkaProducer *kafka_queue.Queue) *HubspotApi {
+	return &HubspotApi{
+		db:            db,
+		hubspotClient: client,
+		redisClient:   redisClient,
+		kafkaProducer: kafkaProducer,
+	}
 }
 
 // this is taken/edits from https://sourcegraph.com/github.com/leonelquinteros/hubspot/-/blob/contacts.go, but I got rid of 'AssociatedCompany' because of errors.
@@ -77,12 +100,6 @@ type CompaniesResponse struct {
 	HasMore bool               `json:"hasMore"`
 	Offset  int                `json:"offset"`
 	Total   int                `json:"total"`
-}
-
-func (h *HubspotApi) BackendCreationDisabled() bool {
-	// backend hubspot company and contact creation is disabled to see how the
-	// frontend javascript tracking snippet performs.
-	return true
 }
 
 func (h *HubspotApi) doRequest(url string, result interface{}, params map[string]string) error {
@@ -159,7 +176,7 @@ func (h *HubspotApi) getCompany(ctx context.Context, name string) (*int, error) 
 	if company, ok := lo.Find(companies, func(response *CompanyResponse) bool {
 		for prop, data := range response.Properties {
 			if prop == "name" {
-				return data.Value == name
+				return strings.EqualFold(data.Value, name)
 			}
 		}
 		return false
@@ -172,15 +189,14 @@ func (h *HubspotApi) getCompany(ctx context.Context, name string) (*int, error) 
 
 func (h *HubspotApi) getContactForAdmin(email string) (contactId *int, err error) {
 	r := CustomContactsResponse{}
-	if getErr := h.hubspotClient.Contacts().Client.Request("GET", "/contacts/v1/contact/email/"+email+"/profile", nil, &r); getErr != nil {
-		errr := e.Wrap(err, e.Wrap(getErr, "error getting hubspot contact data by email").Error())
-		return nil, errr
+	if err := h.hubspotClient.Contacts().Client.Request("GET", "/contacts/v1/contact/email/"+email+"/profile", nil, &r); err != nil {
+		return nil, err
 	} else {
 		return pointy.Int(r.Vid), nil
 	}
 }
 
-func (h *HubspotApi) createContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
+func (h *HubspotApi) createContactForAdmin(ctx context.Context, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
 	var hubspotContactId int
 	if resp, err := h.hubspotClient.Contacts().Create(hubspot.ContactsRequest{
 		Properties: []hubspot.Property{
@@ -233,27 +249,14 @@ func (h *HubspotApi) createContactForAdmin(ctx context.Context, adminID int, ema
 	return &hubspotContactId, nil
 }
 
-func (h *HubspotApi) CreateContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
-	if h.BackendCreationDisabled() {
-		return h.getContactForAdmin(email)
-	}
-
-	return retry(func() (*int, error) {
-		return h.createContactForAdmin(ctx, adminID, email, userDefinedRole, userDefinedPersona, first, last, phone, referral)
-	})
-}
-
-func (h *HubspotApi) CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int, db *gorm.DB) error {
-	if h.BackendCreationDisabled() {
-		return nil
-	}
+func (h *HubspotApi) CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int) error {
 	admin := &model.Admin{}
-	if err := db.Model(&model.Admin{}).Where("id = ?", adminID).First(&admin).Error; err != nil {
-		return e.Wrap(err, "error retrieving admin details")
+	if err := h.db.Model(&model.Admin{}).Where("id = ?", adminID).First(&admin).Error; err != nil {
+		return err
 	}
 	workspace := &model.Workspace{}
-	if err := db.Model(&model.Workspace{}).Where("id = ?", workspaceID).First(&workspace).Error; err != nil {
-		return e.Wrap(err, "error retrieving workspace details")
+	if err := h.db.Model(&model.Workspace{}).Where("id = ?", workspaceID).First(&workspace).Error; err != nil {
+		return err
 	}
 	if workspace.HubspotCompanyID == nil {
 		return e.New("hubspot company id is empty")
@@ -265,7 +268,7 @@ func (h *HubspotApi) CreateContactCompanyAssociation(ctx context.Context, adminI
 		FromObjectID: *workspace.HubspotCompanyID,
 		ToObjectID:   *admin.HubspotContactID,
 	}); err != nil {
-		return e.Wrap(err, "error creating company to contact association")
+		return err
 	} else {
 		log.WithContext(ctx).Info("success creating company to contact association")
 	}
@@ -274,23 +277,80 @@ func (h *HubspotApi) CreateContactCompanyAssociation(ctx context.Context, adminI
 		FromObjectID: *admin.HubspotContactID,
 		ToObjectID:   *workspace.HubspotCompanyID,
 	}); err != nil {
-		return e.Wrap(err, "error creating contact to copmany association")
+		return err
 	} else {
 		log.WithContext(ctx).Info("success creating contact to company association")
 	}
 	return nil
 }
 
-func (h *HubspotApi) CreateCompanyForWorkspace(ctx context.Context, workspaceID int, adminEmail string, name string, db *gorm.DB) (companyID *int, err error) {
+func (h *HubspotApi) CreateContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) error {
+	return h.kafkaProducer.Submit(ctx, &kafka_queue.Message{
+		Type: kafka_queue.HubSpotCreateContactForAdmin,
+		HubSpotCreateContactForAdmin: &kafka_queue.HubSpotCreateContactForAdminArgs{
+			AdminID:            adminID,
+			Email:              email,
+			UserDefinedRole:    userDefinedRole,
+			UserDefinedPersona: userDefinedPersona,
+			First:              first,
+			Last:               last,
+			Phone:              phone,
+			Referral:           referral,
+		},
+	}, "")
+}
+
+func (h *HubspotApi) CreateContactForAdminImpl(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
+	if contactId, err = pollHubspot(func() (*int, error) {
+		return h.getContactForAdmin(email)
+	}); contactId != nil {
+		return
+	}
+
+	log.WithContext(ctx).
+		WithField("email", email).
+		Warnf("failed to get client-side hubspot contact. creating")
+	contactId, err = retry(func() (*int, error) {
+		return h.createContactForAdmin(ctx, email, userDefinedRole, userDefinedPersona, first, last, phone, referral)
+	})
+
+	if err != nil || contactId == nil {
+		return nil, err
+	}
+	log.WithContext(ctx).Infof("succesfully created a hubspot contact with id: %v", contactId)
+	if err := h.db.Model(&model.Admin{Model: model.Model{ID: adminID}}).
+		Updates(&model.Admin{HubspotContactID: contactId}).Error; err != nil {
+		return nil, err
+	}
+	return
+}
+
+func (h *HubspotApi) CreateCompanyForWorkspace(ctx context.Context, workspaceID int, adminEmail string, name string) error {
+	return h.kafkaProducer.Submit(ctx, &kafka_queue.Message{
+		Type: kafka_queue.HubSpotCreateCompanyForWorkspace,
+		HubSpotCreateCompanyForWorkspace: &kafka_queue.HubSpotCreateCompanyForWorkspaceArgs{
+			WorkspaceID: workspaceID,
+			AdminEmail:  adminEmail,
+			Name:        name,
+		},
+	}, "")
+}
+
+func (h *HubspotApi) CreateCompanyForWorkspaceImpl(ctx context.Context, workspaceID int, adminEmail string, name string) (companyID *int, err error) {
 	// Don't create for Demo account
 	if workspaceID == 0 {
 		return
 	}
 
-	if h.BackendCreationDisabled() {
+	if companyID, err = pollHubspot(func() (*int, error) {
 		return h.getCompany(ctx, name)
+	}); companyID != nil {
+		return
 	}
 
+	log.WithContext(ctx).
+		WithField("name", name).
+		Warnf("failed to get client-side hubspot company. creating")
 	if emailproviders.Exists(adminEmail) {
 		adminEmail = ""
 	}
@@ -314,24 +374,34 @@ func (h *HubspotApi) CreateCompanyForWorkspace(ctx context.Context, workspaceID 
 		},
 	})
 	if err != nil {
-		return nil, e.Wrap(err, "error creating company in hubspot")
+		return nil, err
 	}
 	log.WithContext(ctx).Infof("succesfully created a hubspot company with id: %v", resp.CompanyID)
-	if err := db.Model(&model.Workspace{Model: model.Model{ID: workspaceID}}).
+	if err := h.db.Model(&model.Workspace{Model: model.Model{ID: workspaceID}}).
 		Updates(&model.Workspace{HubspotCompanyID: &resp.CompanyID}).Error; err != nil {
-		return &resp.CompanyID, e.Wrap(err, "error updating workspace HubspotCompanyID")
+		return &resp.CompanyID, err
 	}
 	return &resp.CompanyID, nil
 }
 
-func (h *HubspotApi) UpdateContactProperty(ctx context.Context, adminID int, properties []hubspot.Property, db *gorm.DB) error {
+func (h *HubspotApi) UpdateContactProperty(ctx context.Context, adminID int, properties []hubspot.Property) error {
+	return h.kafkaProducer.Submit(ctx, &kafka_queue.Message{
+		Type: kafka_queue.HubSpotUpdateContactProperty,
+		HubSpotUpdateContactProperty: &kafka_queue.HubSpotUpdateContactPropertyArgs{
+			AdminID:    adminID,
+			Properties: properties,
+		},
+	}, "")
+}
+
+func (h *HubspotApi) UpdateContactPropertyImpl(ctx context.Context, adminID int, properties []hubspot.Property) error {
 	admin := &model.Admin{}
-	if err := db.Model(&model.Admin{}).Where("id = ?", adminID).First(&admin).Error; err != nil {
-		return e.Wrap(err, "error retrieving admin details")
+	if err := h.db.Model(&model.Admin{}).Where("id = ?", adminID).First(&admin).Error; err != nil {
+		return err
 	}
 	hubspotContactID := admin.HubspotContactID
 	if hubspotContactID == nil {
-		id, err := h.CreateContactForAdmin(
+		id, err := h.CreateContactForAdminImpl(
 			ctx,
 			adminID,
 			ptr.ToString(admin.Email),
@@ -343,40 +413,49 @@ func (h *HubspotApi) UpdateContactProperty(ctx context.Context, adminID int, pro
 			ptr.ToString(admin.Referral),
 		)
 		if err != nil {
-			return e.Wrap(err, "error creating contact when trying to update contact property")
+			return err
 		}
 		hubspotContactID = id
 	}
 	if err := h.hubspotClient.Contacts().Update(ptr.ToInt(hubspotContactID), hubspot.ContactsRequest{
 		Properties: properties,
 	}); err != nil {
-		return e.Wrap(err, "error updating contact property")
+		return err
 	}
 	return nil
 }
 
-func (h *HubspotApi) UpdateCompanyProperty(ctx context.Context, workspaceID int, properties []hubspot.Property, db *gorm.DB) error {
+func (h *HubspotApi) UpdateCompanyProperty(ctx context.Context, workspaceID int, properties []hubspot.Property) error {
+	return h.kafkaProducer.Submit(ctx, &kafka_queue.Message{
+		Type: kafka_queue.HubSpotUpdateCompanyProperty,
+		HubSpotUpdateCompanyProperty: &kafka_queue.HubSpotUpdateCompanyPropertyArgs{
+			WorkspaceID: workspaceID,
+			Properties:  properties,
+		},
+	}, "")
+}
+
+func (h *HubspotApi) UpdateCompanyPropertyImpl(ctx context.Context, workspaceID int, properties []hubspot.Property) error {
 	workspace := &model.Workspace{}
-	if err := db.Model(&model.Workspace{}).Where("id = ?", workspaceID).First(&workspace).Error; err != nil {
-		return e.Wrap(err, "error retrieving workspace details")
+	if err := h.db.Model(&model.Workspace{}).Where("id = ?", workspaceID).First(&workspace).Error; err != nil {
+		return err
 	}
 	hubspotWorkspaceID := workspace.HubspotCompanyID
 	if hubspotWorkspaceID == nil && workspace.ID != 0 {
-		id, err := h.CreateCompanyForWorkspace(
+		id, err := h.CreateCompanyForWorkspaceImpl(
 			ctx,
 			workspaceID,
 			"", ptr.ToString(workspace.Name),
-			db,
 		)
 		if err != nil {
-			return e.Wrap(err, "error creating work when trying to update contact property")
+			return err
 		}
 		hubspotWorkspaceID = id
 	}
 	if _, err := h.hubspotClient.Companies().Update(ptr.ToInt(hubspotWorkspaceID), hubspot.CompaniesRequest{
 		Properties: properties,
 	}); err != nil {
-		return e.Wrap(err, "error updating company property")
+		return err
 	}
 	return nil
 }

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -240,6 +240,9 @@ func (p *Queue) Stop(ctx context.Context) {
 
 func (p *Queue) Submit(ctx context.Context, msg *Message, partitionKey string) error {
 	start := time.Now()
+	if partitionKey == "" {
+		partitionKey = util.GenerateRandomString(32)
+	}
 	msg.MaxRetries = taskRetries
 	msgBytes, err := p.serializeMessage(msg)
 	if err != nil {

--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -1,6 +1,7 @@
 package kafka_queue
 
 import (
+	"github.com/leonelquinteros/hubspot"
 	"math"
 	"time"
 
@@ -14,17 +15,21 @@ import (
 type PayloadType = int
 
 const (
-	PushPayload          PayloadType = iota
-	InitializeSession    PayloadType = iota
-	IdentifySession      PayloadType = iota
-	AddTrackProperties   PayloadType = iota // Deprecated: track events are now processed in pushPayload
-	AddSessionProperties PayloadType = iota
-	PushBackendPayload   PayloadType = iota
-	PushMetrics          PayloadType = iota
-	MarkBackendSetup     PayloadType = iota
-	AddSessionFeedback   PayloadType = iota
-	PushLogs             PayloadType = iota
-	HealthCheck          PayloadType = math.MaxInt
+	PushPayload                      PayloadType = iota
+	InitializeSession                PayloadType = iota
+	IdentifySession                  PayloadType = iota
+	AddTrackProperties               PayloadType = iota // Deprecated: track events are now processed in pushPayload
+	AddSessionProperties             PayloadType = iota
+	PushBackendPayload               PayloadType = iota
+	PushMetrics                      PayloadType = iota
+	MarkBackendSetup                 PayloadType = iota
+	AddSessionFeedback               PayloadType = iota
+	PushLogs                         PayloadType = iota
+	HubSpotCreateContactForAdmin     PayloadType = iota
+	HubSpotCreateCompanyForWorkspace PayloadType = iota
+	HubSpotUpdateContactProperty     PayloadType = iota
+	HubSpotUpdateCompanyProperty     PayloadType = iota
+	HealthCheck                      PayloadType = math.MaxInt
 )
 
 type PushPayloadArgs struct {
@@ -105,21 +110,52 @@ type PushLogsArgs struct {
 	LogRows []*clickhouse.LogRow
 }
 
+type HubSpotCreateContactForAdminArgs struct {
+	AdminID            int
+	Email              string
+	UserDefinedRole    string
+	UserDefinedPersona string
+	First              string
+	Last               string
+	Phone              string
+	Referral           string
+}
+
+type HubSpotCreateCompanyForWorkspaceArgs struct {
+	WorkspaceID int
+	AdminEmail  string
+	Name        string
+}
+
+type HubSpotUpdateContactPropertyArgs struct {
+	AdminID    int
+	Properties []hubspot.Property
+}
+
+type HubSpotUpdateCompanyPropertyArgs struct {
+	WorkspaceID int
+	Properties  []hubspot.Property
+}
+
 type Message struct {
-	Type                 PayloadType
-	Failures             int
-	MaxRetries           int
-	KafkaMessage         *kafka.Message
-	PushPayload          *PushPayloadArgs
-	InitializeSession    *InitializeSessionArgs
-	IdentifySession      *IdentifySessionArgs
-	AddTrackProperties   *AddTrackPropertiesArgs
-	AddSessionProperties *AddSessionPropertiesArgs
-	PushBackendPayload   *PushBackendPayloadArgs
-	PushMetrics          *PushMetricsArgs
-	MarkBackendSetup     *MarkBackendSetupArgs
-	AddSessionFeedback   *AddSessionFeedbackArgs
-	PushLogs             *PushLogsArgs
+	Type                             PayloadType
+	Failures                         int
+	MaxRetries                       int
+	KafkaMessage                     *kafka.Message
+	PushPayload                      *PushPayloadArgs
+	InitializeSession                *InitializeSessionArgs
+	IdentifySession                  *IdentifySessionArgs
+	AddTrackProperties               *AddTrackPropertiesArgs
+	AddSessionProperties             *AddSessionPropertiesArgs
+	PushBackendPayload               *PushBackendPayloadArgs
+	PushMetrics                      *PushMetricsArgs
+	MarkBackendSetup                 *MarkBackendSetupArgs
+	AddSessionFeedback               *AddSessionFeedbackArgs
+	PushLogs                         *PushLogsArgs
+	HubSpotCreateContactForAdmin     *HubSpotCreateContactForAdminArgs
+	HubSpotCreateCompanyForWorkspace *HubSpotCreateCompanyForWorkspaceArgs
+	HubSpotUpdateContactProperty     *HubSpotUpdateContactPropertyArgs
+	HubSpotUpdateCompanyProperty     *HubSpotUpdateCompanyPropertyArgs
 }
 
 type PartitionMessage struct {

--- a/backend/migrations/cmd/backfill-hubspot/main.go
+++ b/backend/migrations/cmd/backfill-hubspot/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	r := public.Resolver{
 		DB:         db,
-		HubspotApi: hubspotApi.NewHubspotAPI(hubspot.NewClient(hubspot.NewClientConfig()), nil),
+		HubspotApi: hubspotApi.NewHubspotAPI(hubspot.NewClient(hubspot.NewClientConfig()), db, nil, nil),
 	}
 
 	var admins []model.Admin
@@ -38,7 +38,7 @@ func main() {
 					log.WithContext(ctx).WithField("AdminID", admin.ID).Error("admin is not filled out")
 					continue
 				}
-				hubspotContactId, err := r.HubspotApi.CreateContactForAdmin(
+				hubspotContactId, err := r.HubspotApi.CreateContactForAdminImpl(
 					ctx,
 					admin.ID,
 					*admin.Email,
@@ -60,14 +60,14 @@ func main() {
 						log.WithContext(ctx).WithField("WorkspaceID", workspace.ID).Error("workspace is not filled out")
 						continue
 					}
-					hubspotCompanyId, err := r.HubspotApi.CreateCompanyForWorkspace(ctx, workspace.ID, *admin.Email, *workspace.Name, db)
+					hubspotCompanyId, err := r.HubspotApi.CreateCompanyForWorkspaceImpl(ctx, workspace.ID, *admin.Email, *workspace.Name)
 					if hubspotCompanyId != nil {
 						workspace.HubspotCompanyID = hubspotCompanyId
 					} else {
 						log.WithContext(ctx).WithError(err).WithField("WorkspaceID", workspace.ID).Error("error creating hubspot company")
 					}
 
-					if err := r.HubspotApi.CreateContactCompanyAssociation(ctx, admin.ID, workspace.ID, db); err != nil {
+					if err := r.HubspotApi.CreateContactCompanyAssociation(ctx, admin.ID, workspace.ID); err != nil {
 						log.WithContext(ctx).WithError(err).WithField("AdminID", admin.ID).WithField("WorkspaceID", workspace.ID).Error("error creating hubspot association")
 					}
 

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -229,11 +229,11 @@ func (r *Resolver) getCustomVerifiedAdminEmailDomain(admin *model.Admin) (string
 }
 
 type HubspotApiInterface interface {
-	CreateContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (*int, error)
-	CreateCompanyForWorkspace(ctx context.Context, workspaceID int, adminEmail string, name string, db *gorm.DB) (*int, error)
-	CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int, db *gorm.DB) error
-	UpdateContactProperty(ctx context.Context, adminID int, properties []hubspot.Property, db *gorm.DB) error
-	UpdateCompanyProperty(ctx context.Context, workspaceID int, properties []hubspot.Property, db *gorm.DB) error
+	CreateContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) error
+	CreateCompanyForWorkspace(ctx context.Context, workspaceID int, adminEmail string, name string) error
+	CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int) error
+	UpdateContactProperty(ctx context.Context, adminID int, properties []hubspot.Property) error
+	UpdateCompanyProperty(ctx context.Context, workspaceID int, properties []hubspot.Property) error
 }
 
 func (r *Resolver) getVerifiedAdminEmailDomain(admin *model.Admin) (string, error) {

--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -77,24 +77,24 @@ func TestResolver_GetSessionChunk(t *testing.T) {
 
 type HubspotMock struct{}
 
-func (h *HubspotMock) CreateContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (*int, error) {
-	return nil, nil
-}
-
-func (h *HubspotMock) CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int, db *gorm.DB) error {
+func (h *HubspotMock) CreateContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) error {
 	return nil
 }
 
-func (h *HubspotMock) CreateCompanyForWorkspace(ctx context.Context, workspaceID int, adminEmail string, name string, db *gorm.DB) (*int, error) {
-	return nil, nil
+func (h *HubspotMock) CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int) error {
+	return nil
 }
 
-func (h *HubspotMock) UpdateContactProperty(ctx context.Context, adminID int, properties []hubspot.Property, db *gorm.DB) error {
+func (h *HubspotMock) CreateCompanyForWorkspace(ctx context.Context, workspaceID int, adminEmail string, name string) error {
+	return nil
+}
+
+func (h *HubspotMock) UpdateContactProperty(ctx context.Context, adminID int, properties []hubspot.Property) error {
 	return nil
 
 }
 
-func (h *HubspotMock) UpdateCompanyProperty(ctx context.Context, workspaceID int, properties []hubspot.Property, db *gorm.DB) error {
+func (h *HubspotMock) UpdateCompanyProperty(ctx context.Context, workspaceID int, properties []hubspot.Property) error {
 	return nil
 
 }

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -912,6 +912,9 @@ func (r *mutationResolver) AddAdminToWorkspace(ctx context.Context, workspaceID 
 		return adminID, err
 	}
 	r.PrivateWorkerPool.SubmitRecover(func() {
+		if adminID == nil {
+			return
+		}
 		if err := r.HubspotApi.CreateContactCompanyAssociation(ctx, *adminID, workspaceID); err != nil {
 			log.WithContext(ctx).Error(e.Wrapf(
 				err,

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -46,14 +46,14 @@ import (
 	"github.com/highlight-run/highlight/backend/util"
 	"github.com/highlight-run/highlight/backend/vercel"
 	"github.com/highlight-run/highlight/backend/zapier"
-	highlight "github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/highlight/highlight/sdk/highlight-go"
 	"github.com/leonelquinteros/hubspot"
 	"github.com/lib/pq"
 	"github.com/openlyinc/pointy"
 	e "github.com/pkg/errors"
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
-	stripe "github.com/stripe/stripe-go/v72"
+	"github.com/stripe/stripe-go/v72"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -435,7 +435,7 @@ func (r *mutationResolver) UpdateAdminAboutYouDetails(ctx context.Context, admin
 	admin.AboutYouDetailsFilled = &model.T
 
 	if util.IsHubspotEnabled() {
-		hubspotContactId, err := r.HubspotApi.CreateContactForAdmin(
+		err := r.HubspotApi.CreateContactForAdmin(
 			ctx,
 			admin.ID,
 			*admin.Email,
@@ -448,9 +448,6 @@ func (r *mutationResolver) UpdateAdminAboutYouDetails(ctx context.Context, admin
 		)
 		if err != nil {
 			log.WithContext(ctx).Error(err, "error creating hubspot contact")
-		}
-		if hubspotContactId != nil {
-			admin.HubspotContactID = hubspotContactId
 		}
 	}
 
@@ -527,10 +524,8 @@ func (r *mutationResolver) CreateWorkspace(ctx context.Context, name string, pro
 
 	if util.IsHubspotEnabled() {
 		// For the first admin in a workspace, we explicitly create the association if the hubspot company creation succeeds.
-		if _, err := r.HubspotApi.CreateCompanyForWorkspace(ctx, workspace.ID, *admin.Email, name, r.DB); err != nil {
+		if err := r.HubspotApi.CreateCompanyForWorkspace(ctx, workspace.ID, *admin.Email, name); err != nil {
 			log.WithContext(ctx).Error(err, "error creating hubspot company")
-		} else if err := r.HubspotApi.CreateContactCompanyAssociation(ctx, admin.ID, workspace.ID, r.DB); err != nil {
-			log.WithContext(ctx).Error(err, "error creating association between hubspot records with admin ID [%v] and workspace ID [%v]", admin.ID, workspace.ID)
 		}
 	}
 
@@ -666,7 +661,7 @@ func (r *mutationResolver) MarkErrorGroupAsViewed(ctx context.Context, errorSecu
 				Name:     "number_of_highlight_error_groups_viewed",
 				Property: "number_of_highlight_error_groups_viewed",
 				Value:    totalErrorGroupCountAsInt,
-			}}, r.DB); err != nil {
+			}}); err != nil {
 				log.WithContext(ctx).
 					WithError(err).
 					WithField("admin_id", admin.ID).
@@ -760,7 +755,7 @@ func (r *mutationResolver) MarkSessionAsViewed(ctx context.Context, secureID str
 				Name:     "number_of_highlight_sessions_viewed",
 				Property: "number_of_highlight_sessions_viewed",
 				Value:    totalSessionCountAsInt,
-			}}, r.DB); err != nil {
+			}}); err != nil {
 				log.WithContext(ctx).
 					WithError(err).
 					WithField("admin_id", admin.ID).
@@ -917,7 +912,7 @@ func (r *mutationResolver) AddAdminToWorkspace(ctx context.Context, workspaceID 
 		return adminID, err
 	}
 	r.PrivateWorkerPool.SubmitRecover(func() {
-		if err := r.HubspotApi.CreateContactCompanyAssociation(ctx, *adminID, workspaceID, r.DB); err != nil {
+		if err := r.HubspotApi.CreateContactCompanyAssociation(ctx, *adminID, workspaceID); err != nil {
 			log.WithContext(ctx).Error(e.Wrapf(
 				err,
 				"error creating association between hubspot records with admin ID [%v] and workspace ID [%v]",
@@ -7270,7 +7265,7 @@ func (r *queryResolver) Logs(ctx context.Context, projectID int, params modelInp
 				Name:     "number_of_highlight_logs_viewed",
 				Property: "number_of_highlight_logs_viewed",
 				Value:    totalLogCountAsInt,
-			}}, r.DB); err != nil {
+			}}); err != nil {
 				log.WithContext(ctx).
 					WithError(err).
 					WithField("admin_id", admin.ID).

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1533,7 +1533,7 @@ func (r *Resolver) MarkBackendSetupImpl(ctx context.Context, projectVerboseID *s
 						Name:     "backend_setup",
 						Property: "backend_setup",
 						Value:    true,
-					}}, r.DB); err != nil {
+					}}); err != nil {
 						log.WithContext(ctx).Errorf("failed to update hubspot")
 					}
 				}

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -414,7 +414,7 @@ func (r *Client) SetHubspotCompanies(ctx context.Context, companies interface{})
 		Ctx:   ctx,
 		Key:   CacheKeyHubspotCompanies,
 		Value: companies,
-		TTL:   5 * time.Minute,
+		TTL:   time.Minute,
 	}); err != nil {
 		span.Finish(tracer.WithError(err))
 		return err

--- a/backend/util/random.go
+++ b/backend/util/random.go
@@ -2,14 +2,11 @@ package util
 
 import (
 	"math/rand"
-	"time"
 )
 
 const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 func GenerateRandomString(length int) string {
-	rand.Seed(time.Now().UnixNano())
-
 	b := make([]byte, length)
 	for i := range b {
 		b[i] = letters[rand.Intn(len(letters))]

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -334,7 +334,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 			task.PushPayload.HasSessionUnloaded != nil && *task.PushPayload.HasSessionUnloaded,
 			task.PushPayload.HighlightLogs,
 			task.PushPayload.PayloadID); err != nil {
-			log.WithContext(ctx).Error(errors.Wrap(err, "failed to process ProcessPayload task"))
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
 			return err
 		}
 	case kafkaqueue.InitializeSession:
@@ -348,7 +348,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 		}
 		hlog.Incr("worker.initializeSession.count", tags, 1)
 		if err != nil {
-			log.WithContext(ctx).Error(errors.Wrap(err, "failed to process InitializeSession task"))
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
 			return err
 		}
 	case kafkaqueue.IdentifySession:
@@ -356,7 +356,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 			break
 		}
 		if err := w.PublicResolver.IdentifySessionImpl(ctx, task.IdentifySession.SessionSecureID, task.IdentifySession.UserIdentifier, task.IdentifySession.UserObject, false); err != nil {
-			log.WithContext(ctx).Error(errors.Wrap(err, "failed to process IdentifySession task"))
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
 			return err
 		}
 	case kafkaqueue.AddTrackProperties:
@@ -368,7 +368,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 			return err
 		}
 		if err := w.PublicResolver.AddTrackPropertiesImpl(ctx, sessionID, task.AddTrackProperties.PropertiesObject); err != nil {
-			log.WithContext(ctx).Error(errors.Wrap(err, "failed to process AddTrackProperties task"))
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
 			return err
 		}
 	case kafkaqueue.AddSessionProperties:
@@ -380,7 +380,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 			return err
 		}
 		if err := w.PublicResolver.AddSessionPropertiesImpl(ctx, sessionID, task.AddSessionProperties.PropertiesObject); err != nil {
-			log.WithContext(ctx).Error(errors.Wrap(err, "failed to process AddSessionProperties task"))
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
 			return err
 		}
 	case kafkaqueue.PushBackendPayload:
@@ -393,7 +393,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 			break
 		}
 		if err := w.PublicResolver.PushMetricsImpl(ctx, task.PushMetrics.SessionSecureID, task.PushMetrics.Metrics); err != nil {
-			log.WithContext(ctx).Error(errors.Wrap(err, "failed to process PushMetricsImpl task"))
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
 			return err
 		}
 	case kafkaqueue.MarkBackendSetup:
@@ -401,7 +401,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 			break
 		}
 		if err := w.PublicResolver.MarkBackendSetupImpl(ctx, task.MarkBackendSetup.ProjectVerboseID, task.MarkBackendSetup.SessionSecureID, task.MarkBackendSetup.ProjectID, task.MarkBackendSetup.Type); err != nil {
-			log.WithContext(ctx).Error(errors.Wrap(err, "failed to process MarkBackendSetup task"))
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
 			return err
 		}
 	case kafkaqueue.AddSessionFeedback:
@@ -409,7 +409,58 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 			break
 		}
 		if err := w.PublicResolver.AddSessionFeedbackImpl(ctx, task.AddSessionFeedback); err != nil {
-			log.WithContext(ctx).Error(errors.Wrap(err, "failed to process AddSessionFeedback task"))
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
+			return err
+		}
+	case kafkaqueue.HubSpotCreateContactForAdmin:
+		if task.HubSpotCreateContactForAdmin == nil {
+			break
+		}
+		if _, err := w.PublicResolver.HubspotApi.CreateContactForAdminImpl(ctx,
+			task.HubSpotCreateContactForAdmin.AdminID,
+			task.HubSpotCreateContactForAdmin.Email,
+			task.HubSpotCreateContactForAdmin.UserDefinedRole,
+			task.HubSpotCreateContactForAdmin.UserDefinedPersona,
+			task.HubSpotCreateContactForAdmin.First,
+			task.HubSpotCreateContactForAdmin.Last,
+			task.HubSpotCreateContactForAdmin.Phone,
+			task.HubSpotCreateContactForAdmin.Referral,
+		); err != nil {
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
+			return err
+		}
+	case kafkaqueue.HubSpotCreateCompanyForWorkspace:
+		if task.HubSpotCreateCompanyForWorkspace == nil {
+			break
+		}
+		if _, err := w.PublicResolver.HubspotApi.CreateCompanyForWorkspaceImpl(ctx,
+			task.HubSpotCreateCompanyForWorkspace.WorkspaceID,
+			task.HubSpotCreateCompanyForWorkspace.AdminEmail,
+			task.HubSpotCreateCompanyForWorkspace.Name,
+		); err != nil {
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
+			return err
+		}
+	case kafkaqueue.HubSpotUpdateContactProperty:
+		if task.HubSpotUpdateContactProperty == nil {
+			break
+		}
+		if err := w.PublicResolver.HubspotApi.UpdateContactPropertyImpl(ctx,
+			task.HubSpotUpdateContactProperty.AdminID,
+			task.HubSpotUpdateContactProperty.Properties,
+		); err != nil {
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
+			return err
+		}
+	case kafkaqueue.HubSpotUpdateCompanyProperty:
+		if task.HubSpotUpdateCompanyProperty == nil {
+			break
+		}
+		if err := w.PublicResolver.HubspotApi.UpdateCompanyPropertyImpl(ctx,
+			task.HubSpotUpdateCompanyProperty.WorkspaceID,
+			task.HubSpotUpdateCompanyProperty.Properties,
+		); err != nil {
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
 			return err
 		}
 	case kafkaqueue.HealthCheck:
@@ -1270,7 +1321,7 @@ func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
 				Name:     "highlight_error_count",
 				Property: "highlight_error_count",
 				Value:    c.ErrorCount,
-			}}, w.Resolver.DB); err != nil {
+			}}); err != nil {
 				log.WithContext(ctx).WithFields(log.Fields{
 					"workspace_id":  c.WorkspaceID,
 					"session_count": c.SessionCount,


### PR DESCRIPTION
## Summary

Adds hubspot backend contact and company creation.
Uses kafka to queue contact and company creation messages to ensure they are not lost
if the private graph restarts while polling hubspot.
Polls hubspot every 5 seconds for up to a minute to wait for the contact or company to be created,
then creates the object as a fallback.

## How did you test this change?

Local deploy with hubspot api key, with a debugger in the codepath.

## Are there any deployment considerations?

Will monitor hubspot account creation.
