### PR TITLE
Fix alignment on older/newer error instance links

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -304,7 +304,6 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 									}
 									kind="secondary"
 									emphasis="low"
-									display="inlineBlock"
 									trackingId="errorInstanceOlder"
 								>
 									Older
@@ -329,7 +328,6 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 									}
 									kind="secondary"
 									emphasis="low"
-									display="inlineBlock"
 									trackingId="errorInstanceNewer"
 								>
 									Newer

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -39,7 +39,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 			className,
 			cssClass,
 			disabled,
-			display,
 			...buttonProps
 		},
 		ref,
@@ -52,7 +51,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 						kind,
 						size,
 						emphasis,
-						display,
 					}),
 					className,
 					cssClass,

--- a/packages/ui/src/components/Button/styles.css.ts
+++ b/packages/ui/src/components/Button/styles.css.ts
@@ -102,14 +102,6 @@ export const variants = recipe({
 	],
 
 	variants: {
-		display: {
-			inlineBlock: {
-				display: 'inline-block',
-			},
-			inlineFlex: {
-				display: 'inline-flex',
-			},
-		},
 		emphasis: {
 			high: {},
 			medium: {},


### PR DESCRIPTION
## Summary

Fixes an issue with the older/newer error instance buttons not having their text vertically centered. Since no buttons were using the `display` prop anymore I decided to clean that up as well.

| --- | --- |
| Before | After |
| --- | --- |
| <img width="258" alt="Screenshot 2023-05-02 at 12 29 12 PM" src="https://user-images.githubusercontent.com/308182/235740366-40001ca3-3a33-4e96-907f-5d428c156cbf.png"> | <img width="394" alt="Screenshot 2023-05-02 at 12 27 48 PM" src="https://user-images.githubusercontent.com/308182/235740415-6ac87eff-6526-4f2a-99ec-4dda3aa24bdd.png"> |
| --- | --- |

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A
