### PR TITLE
upgrade to go 1.20

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
             - name: Setup Golang environment
               uses: actions/setup-go@v4
               with:
-                  go-version: '^1.19'
+                  go-version-file: 'backend/go.mod'
                   cache-dependency-path: '**/go.sum'
 
             - name: Login to Docker Hub

--- a/.github/workflows/go-sdk.yml
+++ b/.github/workflows/go-sdk.yml
@@ -52,6 +52,6 @@ jobs:
                   fetch-depth: 2
             - uses: actions/setup-go@v4
               with:
-                  go-version: '1.19'
+                  go-version-file: 'backend/go.mod'
             - name: Run tests
               run: cd sdk/highlight-go && go test -race -covermode=atomic -coverprofile=coverage.out --v

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -26,18 +26,8 @@ linters:
 
 # all available settings of specific linters
 linters-settings:
-    gosimple:
-        go: '1.19'
-
     staticcheck:
-        go: '1.19'
         checks: ['all']
-
-    stylecheck:
-        go: '1.19'
-
-    unused:
-        go: '1.19'
 
     exhaustruct:
         include:

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -44,13 +44,12 @@ linters-settings:
             - 'backend/alerts'
 
     depguard:
-        list-type: blacklist
+        list-type: denylist
         include-go-root: true
         packages:
             - errors
             - log
 
         packages-with-error-message:
-            # specify an error message to output when a blacklisted package is used
-            - errors: 'error handling is allowed only by github.com/pkg/errors'
+            # specify an error message to output when a denylist package is used
             - log: 'logging is allowed only by github.com/sirupsen/logrus'

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -47,7 +47,6 @@ linters-settings:
         list-type: denylist
         include-go-root: true
         packages:
-            - errors
             - log
 
         packages-with-error-message:

--- a/backend/alerts/integrations/discord/discord.go
+++ b/backend/alerts/integrations/discord/discord.go
@@ -1,10 +1,10 @@
 package discord
 
 import (
+	"errors"
 	"os"
 
 	"github.com/bwmarrin/discordgo"
-	"github.com/pkg/errors"
 )
 
 type Bot struct {
@@ -24,7 +24,7 @@ func NewDiscordBot(guildId string) (*Bot, error) {
 	session, err := discordgo.New("Bot " + DiscordBotSecret)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "error creating Discord session")
+		return nil, errors.Join(err, errors.New("error creating Discord session"))
 	}
 
 	return &Bot{

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/highlight-run/highlight/backend
 
-go 1.19
+go 1.20
 
 replace github.com/opensearch-project/opensearch-go => github.com/highlight-run/opensearch-go v1.0.1
 

--- a/backend/kafka-queue/kafkaqueue_test.go
+++ b/backend/kafka-queue/kafkaqueue_test.go
@@ -2,6 +2,7 @@ package kafka_queue
 
 import (
 	"context"
+	cryptorand "crypto/rand"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -40,8 +41,12 @@ func BenchmarkQueue_Submit(b *testing.B) {
 		go func(w int) {
 			dataBytes := make([]byte, msgSizeBytes)
 			for j := 0; j < submitsPerWorker; j++ {
-				rand.Read(dataBytes)
-				err := writer.Submit(ctx, &Message{
+				_, err := cryptorand.Read(dataBytes)
+				if err != nil {
+					log.WithContext(ctx).Error(err)
+				}
+
+				err = writer.Submit(ctx, &Message{
 					Type: PushPayload,
 					PushPayload: &PushPayloadArgs{
 						Events: model.ReplayEventsInput{

--- a/backend/kafka-queue/kafkaqueue_test.go
+++ b/backend/kafka-queue/kafkaqueue_test.go
@@ -25,7 +25,7 @@ func BenchmarkQueue_Submit(b *testing.B) {
 	log.SetLevel(log.DebugLevel)
 	log.WithContext(ctx).Infof("Starting benchmark")
 
-	rand.Seed(time.Now().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	writer := New(ctx, "dev", Producer)
 	reader := New(ctx, "dev", Consumer)

--- a/backend/main.go
+++ b/backend/main.go
@@ -217,7 +217,7 @@ func validateOrigin(_ *http.Request, origin string) bool {
 var defaultPort = "8082"
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 	ctx := context.TODO()
 
 	// setup highlight

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4832,7 +4832,7 @@ func (r *queryResolver) DailyErrorFrequency(ctx context.Context, projectID int, 
 
 	if projectID == 0 {
 		// Make error distribution random for demo org so it looks pretty
-		rand.Seed(int64(errGroup.ID))
+		rand.New(rand.NewSource(int64(errGroup.ID)))
 		var dists []int64
 		for i := 0; i <= dateOffset; i++ {
 			t := int64(rand.Intn(10) + 1)
@@ -4856,7 +4856,7 @@ func (r *queryResolver) ErrorDistribution(ctx context.Context, projectID int, er
 
 	if projectID == 0 {
 		// Make error distribution random for demo org so it looks pretty
-		rand.Seed(int64(errGroup.ID))
+		rand.New(rand.NewSource(int64(errGroup.ID)))
 		dists := []*modelInputs.ErrorDistributionItem{}
 		for i := 0; i <= 3; i++ {
 			t := int64(rand.Intn(10) + 1)

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1083,7 +1083,7 @@ func (w *Worker) Start(ctx context.Context) {
 			sessionsSpan.Finish()
 			continue
 		}
-		rand.Seed(time.Now().UnixNano())
+		rand.New(rand.NewSource(time.Now().UnixNano()))
 		rand.Shuffle(len(sessions), func(i, j int) {
 			sessions[i], sessions[j] = sessions[j], sessions[i]
 		})

--- a/e2e/go/go.mod
+++ b/e2e/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/highlight/highlight/e2e/go
 
-go 1.19
+go 1.20
 
 require (
 	github.com/gofiber/fiber/v2 v2.42.0

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.19
+go 1.20
 
 use ./backend
 

--- a/highlight.io/components/QuickstartContent/self-host/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/self-host/shared-snippets.tsx
@@ -3,7 +3,7 @@ import { QuickStartStep } from '../QuickstartContent'
 export const dependencies: QuickStartStep = {
 	title: 'Prerequisites',
 	content:
-		'Before we get started, you should install [Go](https://go.dev/) (1.19) and [Node.js](https://nodejs.org/en) (18).' +
+		'Before we get started, you should install [Go](https://go.dev/) (1.20) and [Node.js](https://nodejs.org/en) (18).' +
 		'You should have the latest version of [Docker](https://docs.docker.com/engine/install/) (19.03.0+) ' +
 		'and [Git](https://git-scm.com/downloads) (2.13+) installed. ' +
 		'For a local deploy, we suggest [configuring docker](https://docs.docker.com/desktop/settings/mac/#resources) ' +
@@ -11,7 +11,7 @@ export const dependencies: QuickStartStep = {
 	code: {
 		language: 'bash',
 		text: `$ go version
-go version go1.19.3 darwin/arm64
+go version go1.20.3 darwin/arm64
 $ node --version
 v18.15.0`,
 	},

--- a/sdk/highlight-go/.golangci.yaml
+++ b/sdk/highlight-go/.golangci.yaml
@@ -22,15 +22,5 @@ linters:
 
 # all available settings of specific linters
 linters-settings:
-    gosimple:
-        go: '1.19'
-
     staticcheck:
-        go: '1.19'
         checks: ['all']
-
-    stylecheck:
-        go: '1.19'
-
-    unused:
-        go: '1.19'

--- a/sdk/highlight-go/go.mod
+++ b/sdk/highlight-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/highlight/highlight/sdk/highlight-go
 
-go 1.19
+go 1.20
 
 require (
 	github.com/99designs/gqlgen v0.17.24


### PR DESCRIPTION
# Need to upgrade?

If you're seeing this PR linked from somewhere else, you'll need to upgrade Go to [v1.20](https://go.dev/blog/go1.20).

### Homebrew

`brew install go@1.20`


### Other Go installations

https://go.dev/dl


## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR upgrades us to Go 1.20 ([release notes](https://go.dev/blog/go1.20)). The reasoning behind the upgrade is obviously to be on the latest and greatest but also to help prove we don't need the [deprecated github.com/pkg/errors](https://github.com/pkg/errors/issues/245) library. Specifically, Go 1.20 has a built-in [`errors.Join`](https://pkg.go.dev/errors#example-Join) function that does what the [`errors.Wrap`](https://github.com/pkg/errors#adding-context-to-an-error) function was doing.

As we have discussed over slack, Go error wrapping is unnecessary assuming there's an associated stack trace. Long term, I still plan on removing all of the error wrapping in our code base but wanted to make that distinct from the Go upgrade.  

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Updated our docs to reflect that Go 1.20 is now the minimum version. We don't [specify](https://www.highlight.io/docs/getting-started/self-host/dev-deployment-guide) how to install Go but for most of us, it's probably `brew install go@1.20` (other versions [here](https://go.dev/dl/)) and restart the backend.

I did a basic click test and didn't observe any issues. I didn't notice any breaking changes from the release notes either.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A