### PR TITLE
remove logic to fetch error instance that is not live

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4071,55 +4071,14 @@ func (r *queryResolver) ErrorInstance(ctx context.Context, errorGroupSecureID st
 	}
 
 	errorObject := model.ErrorObject{}
-	errorObjectQuery := r.DB.
-		Model(&model.ErrorObject{}).
-		Where("error_group_id = ?", errorGroup.ID).
-		Where("created_at > ?", retentionDate).
-		Order("id desc")
+	errorObjectQuery := r.DB.Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID})
 
 	if errorObjectID == nil {
-		var sessionIds []int
-		if err := r.DB.Model(&errorObject).
-			Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).
-			Where("session_id is not null").
-			Where("created_at > ?", retentionDate).
-			Limit(100).
-			Pluck("session_id", &sessionIds).
-			Error; err != nil {
-			return nil, e.Wrap(err, "error reading session ids")
-		}
-
-		var processedSessions []int
-		// find all processed sessions
-		if err := r.DB.Model(&model.Session{}).
-			Where("id IN (?) AND processed = ? AND excluded = ?", sessionIds, true, false).
-			Where("created_at > ?", retentionDate).
-			Pluck("id", &processedSessions).
-			Error; err != nil {
-			return nil, e.Wrap(err, "error querying processed sessions")
-		}
-
-		if len(processedSessions) == 0 {
-			if err := errorObjectQuery.Limit(1).Find(&errorObject).Error; err != nil {
-				return nil, e.Wrap(err, "error reading error object for instance")
-			}
-		} else {
-			// find the most recent object from the processed session
-			if err := errorObjectQuery.
-				Where("session_id IN ?", processedSessions).
-				Limit(1).
-				Find(&errorObject).
-				Error; err != nil {
-				return nil, e.Wrap(err, "error reading error object for instance")
-			}
+		if err := errorObjectQuery.Last(&errorObject).Error; err != nil {
+			return nil, e.Wrap(err, "error reading error object for instance")
 		}
 	} else {
-		if err := errorObjectQuery.
-			Where(&model.ErrorObject{Model: model.Model{ID: *errorObjectID}}).
-			Where("created_at > ?", retentionDate).
-			Limit(1).
-			Find(&errorObject).
-			Error; err != nil {
+		if err := errorObjectQuery.Where(&model.ErrorObject{Model: model.Model{ID: *errorObjectID}}).First(&errorObject).Error; err != nil {
 			return nil, e.Wrap(err, "error reading error object for instance")
 		}
 	}
@@ -4147,16 +4106,6 @@ func (r *queryResolver) ErrorInstance(ctx context.Context, errorGroupSecureID st
 		Limit(1).
 		Pluck("id", &previousID).Error; err != nil {
 		return nil, e.Wrap(err, "error reading previous error object in group")
-	}
-
-	if errorObject.SessionID != nil {
-		var session model.Session
-		if err := r.DB.Model(&session).Where("id = ?", *errorObject.SessionID).Find(&session).Error; err != nil {
-			return nil, e.Wrap(err, "error reading error group session")
-		}
-		if session.Excluded {
-			errorObject.SessionID = nil
-		}
 	}
 
 	errorInstance := model.ErrorInstance{

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -91,6 +91,67 @@ export const SessionAlertFragmentFragmentDoc = gql`
 	}
 	${DiscordChannelFragmentFragmentDoc}
 `
+export const ErrorObjectFragmentDoc = gql`
+	fragment ErrorObject on ErrorObject {
+		id
+		created_at
+		project_id
+		session_id
+		trace_id
+		span_id
+		log_cursor
+		session {
+			identifier
+			fingerprint
+			secure_id
+			city
+			state
+			country
+			user_properties
+			processed
+		}
+		error_group_id
+		error_group_secure_id
+		event
+		type
+		url
+		source
+		lineNumber
+		columnNumber
+		stack_trace
+		structured_stack_trace {
+			fileName
+			lineNumber
+			functionName
+			columnNumber
+			lineContent
+			linesBefore
+			linesAfter
+			error
+			sourceMappingErrorMetadata {
+				errorCode
+				stackTraceFileURL
+				sourcemapFetchStrategy
+				sourceMapURL
+				minifiedFetchStrategy
+				actualMinifiedFetchedPath
+				minifiedLineNumber
+				minifiedColumnNumber
+				actualSourcemapFetchedPath
+				sourcemapFileSize
+				minifiedFileSize
+				mappedLineNumber
+				mappedColumnNumber
+			}
+		}
+		timestamp
+		payload
+		request_id
+		os
+		browser
+		environment
+	}
+`
 export const MarkErrorGroupAsViewedDocument = gql`
 	mutation MarkErrorGroupAsViewed(
 		$error_secure_id: String!
@@ -7979,45 +8040,10 @@ export type GetErrorObjectForLogQueryResult = Apollo.QueryResult<
 export const GetErrorObjectDocument = gql`
 	query GetErrorObject($id: ID!) {
 		error_object(id: $id) {
-			id
-			created_at
-			project_id
-			session {
-				identifier
-				fingerprint
-				secure_id
-				city
-				state
-				country
-				user_properties
-			}
-			error_group_id
-			error_group_secure_id
-			event
-			type
-			url
-			source
-			lineNumber
-			columnNumber
-			stack_trace
-			structured_stack_trace {
-				fileName
-				lineNumber
-				functionName
-				columnNumber
-				lineContent
-				linesBefore
-				linesAfter
-				error
-			}
-			timestamp
-			payload
-			request_id
-			os
-			browser
-			environment
+			...ErrorObject
 		}
 	}
+	${ErrorObjectFragmentDoc}
 `
 
 /**
@@ -8078,67 +8104,13 @@ export const GetErrorInstanceDocument = gql`
 			error_object_id: $error_object_id
 		) {
 			error_object {
-				id
-				created_at
-				project_id
-				session_id
-				trace_id
-				span_id
-				log_cursor
-				session {
-					identifier
-					fingerprint
-					secure_id
-					city
-					state
-					country
-					user_properties
-				}
-				error_group_id
-				error_group_secure_id
-				event
-				type
-				url
-				source
-				lineNumber
-				columnNumber
-				stack_trace
-				structured_stack_trace {
-					fileName
-					lineNumber
-					functionName
-					columnNumber
-					lineContent
-					linesBefore
-					linesAfter
-					error
-					sourceMappingErrorMetadata {
-						errorCode
-						stackTraceFileURL
-						sourcemapFetchStrategy
-						sourceMapURL
-						minifiedFetchStrategy
-						actualMinifiedFetchedPath
-						minifiedLineNumber
-						minifiedColumnNumber
-						actualSourcemapFetchedPath
-						sourcemapFileSize
-						minifiedFileSize
-						mappedLineNumber
-						mappedColumnNumber
-					}
-				}
-				timestamp
-				payload
-				request_id
-				os
-				browser
-				environment
+				...ErrorObject
 			}
 			next_id
 			previous_id
 		}
 	}
+	${ErrorObjectFragmentDoc}
 `
 
 /**

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -109,6 +109,7 @@ export const ErrorObjectFragmentDoc = gql`
 			country
 			user_properties
 			processed
+			excluded
 		}
 		error_group_id
 		error_group_secure_id

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2811,6 +2811,7 @@ export type ErrorObjectFragment = { __typename?: 'ErrorObject' } & Pick<
 				| 'country'
 				| 'user_properties'
 				| 'processed'
+				| 'excluded'
 			>
 		>
 		structured_stack_trace: Array<

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2775,61 +2775,87 @@ export type GetErrorObjectForLogQuery = { __typename?: 'Query' } & {
 	>
 }
 
+export type ErrorObjectFragment = { __typename?: 'ErrorObject' } & Pick<
+	Types.ErrorObject,
+	| 'id'
+	| 'created_at'
+	| 'project_id'
+	| 'session_id'
+	| 'trace_id'
+	| 'span_id'
+	| 'log_cursor'
+	| 'error_group_id'
+	| 'error_group_secure_id'
+	| 'event'
+	| 'type'
+	| 'url'
+	| 'source'
+	| 'lineNumber'
+	| 'columnNumber'
+	| 'stack_trace'
+	| 'timestamp'
+	| 'payload'
+	| 'request_id'
+	| 'os'
+	| 'browser'
+	| 'environment'
+> & {
+		session?: Types.Maybe<
+			{ __typename?: 'Session' } & Pick<
+				Types.Session,
+				| 'identifier'
+				| 'fingerprint'
+				| 'secure_id'
+				| 'city'
+				| 'state'
+				| 'country'
+				| 'user_properties'
+				| 'processed'
+			>
+		>
+		structured_stack_trace: Array<
+			Types.Maybe<
+				{ __typename?: 'ErrorTrace' } & Pick<
+					Types.ErrorTrace,
+					| 'fileName'
+					| 'lineNumber'
+					| 'functionName'
+					| 'columnNumber'
+					| 'lineContent'
+					| 'linesBefore'
+					| 'linesAfter'
+					| 'error'
+				> & {
+						sourceMappingErrorMetadata?: Types.Maybe<
+							{ __typename?: 'SourceMappingError' } & Pick<
+								Types.SourceMappingError,
+								| 'errorCode'
+								| 'stackTraceFileURL'
+								| 'sourcemapFetchStrategy'
+								| 'sourceMapURL'
+								| 'minifiedFetchStrategy'
+								| 'actualMinifiedFetchedPath'
+								| 'minifiedLineNumber'
+								| 'minifiedColumnNumber'
+								| 'actualSourcemapFetchedPath'
+								| 'sourcemapFileSize'
+								| 'minifiedFileSize'
+								| 'mappedLineNumber'
+								| 'mappedColumnNumber'
+							>
+						>
+					}
+			>
+		>
+	}
+
 export type GetErrorObjectQueryVariables = Types.Exact<{
 	id: Types.Scalars['ID']
 }>
 
 export type GetErrorObjectQuery = { __typename?: 'Query' } & {
 	error_object?: Types.Maybe<
-		{ __typename?: 'ErrorObject' } & Pick<
-			Types.ErrorObject,
-			| 'id'
-			| 'created_at'
-			| 'project_id'
-			| 'error_group_id'
-			| 'error_group_secure_id'
-			| 'event'
-			| 'type'
-			| 'url'
-			| 'source'
-			| 'lineNumber'
-			| 'columnNumber'
-			| 'stack_trace'
-			| 'timestamp'
-			| 'payload'
-			| 'request_id'
-			| 'os'
-			| 'browser'
-			| 'environment'
-		> & {
-				session?: Types.Maybe<
-					{ __typename?: 'Session' } & Pick<
-						Types.Session,
-						| 'identifier'
-						| 'fingerprint'
-						| 'secure_id'
-						| 'city'
-						| 'state'
-						| 'country'
-						| 'user_properties'
-					>
-				>
-				structured_stack_trace: Array<
-					Types.Maybe<
-						{ __typename?: 'ErrorTrace' } & Pick<
-							Types.ErrorTrace,
-							| 'fileName'
-							| 'lineNumber'
-							| 'functionName'
-							| 'columnNumber'
-							| 'lineContent'
-							| 'linesBefore'
-							| 'linesAfter'
-							| 'error'
-						>
-					>
-				>
-			}
+		{ __typename?: 'ErrorObject' } & ErrorObjectFragment
 	>
 }
 
@@ -2844,80 +2870,9 @@ export type GetErrorInstanceQuery = { __typename?: 'Query' } & {
 			Types.ErrorInstance,
 			'next_id' | 'previous_id'
 		> & {
-				error_object: { __typename?: 'ErrorObject' } & Pick<
-					Types.ErrorObject,
-					| 'id'
-					| 'created_at'
-					| 'project_id'
-					| 'session_id'
-					| 'trace_id'
-					| 'span_id'
-					| 'log_cursor'
-					| 'error_group_id'
-					| 'error_group_secure_id'
-					| 'event'
-					| 'type'
-					| 'url'
-					| 'source'
-					| 'lineNumber'
-					| 'columnNumber'
-					| 'stack_trace'
-					| 'timestamp'
-					| 'payload'
-					| 'request_id'
-					| 'os'
-					| 'browser'
-					| 'environment'
-				> & {
-						session?: Types.Maybe<
-							{ __typename?: 'Session' } & Pick<
-								Types.Session,
-								| 'identifier'
-								| 'fingerprint'
-								| 'secure_id'
-								| 'city'
-								| 'state'
-								| 'country'
-								| 'user_properties'
-							>
-						>
-						structured_stack_trace: Array<
-							Types.Maybe<
-								{ __typename?: 'ErrorTrace' } & Pick<
-									Types.ErrorTrace,
-									| 'fileName'
-									| 'lineNumber'
-									| 'functionName'
-									| 'columnNumber'
-									| 'lineContent'
-									| 'linesBefore'
-									| 'linesAfter'
-									| 'error'
-								> & {
-										sourceMappingErrorMetadata?: Types.Maybe<
-											{
-												__typename?: 'SourceMappingError'
-											} & Pick<
-												Types.SourceMappingError,
-												| 'errorCode'
-												| 'stackTraceFileURL'
-												| 'sourcemapFetchStrategy'
-												| 'sourceMapURL'
-												| 'minifiedFetchStrategy'
-												| 'actualMinifiedFetchedPath'
-												| 'minifiedLineNumber'
-												| 'minifiedColumnNumber'
-												| 'actualSourcemapFetchedPath'
-												| 'sourcemapFileSize'
-												| 'minifiedFileSize'
-												| 'mappedLineNumber'
-												| 'mappedColumnNumber'
-											>
-										>
-									}
-							>
-						>
-					}
+				error_object: {
+					__typename?: 'ErrorObject'
+				} & ErrorObjectFragment
 			}
 	>
 }
@@ -4545,5 +4500,6 @@ export const namedOperations = {
 		SessionPayloadFragment: 'SessionPayloadFragment' as const,
 		SessionAlertFragment: 'SessionAlertFragment' as const,
 		DiscordChannelFragment: 'DiscordChannelFragment' as const,
+		ErrorObject: 'ErrorObject' as const,
 	},
 }

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1080,6 +1080,7 @@ fragment ErrorObject on ErrorObject {
 		country
 		user_properties
 		processed
+		excluded
 	}
 	error_group_id
 	error_group_secure_id

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1063,45 +1063,69 @@ query GetErrorObjectForLog($log_cursor: String!) {
 	}
 }
 
+fragment ErrorObject on ErrorObject {
+	id
+	created_at
+	project_id
+	session_id
+	trace_id
+	span_id
+	log_cursor
+	session {
+		identifier
+		fingerprint
+		secure_id
+		city
+		state
+		country
+		user_properties
+		processed
+	}
+	error_group_id
+	error_group_secure_id
+	event
+	type
+	url
+	source
+	lineNumber
+	columnNumber
+	stack_trace
+	structured_stack_trace {
+		fileName
+		lineNumber
+		functionName
+		columnNumber
+		lineContent
+		linesBefore
+		linesAfter
+		error
+		sourceMappingErrorMetadata {
+			errorCode
+			stackTraceFileURL
+			sourcemapFetchStrategy
+			sourceMapURL
+			minifiedFetchStrategy
+			actualMinifiedFetchedPath
+			minifiedLineNumber
+			minifiedColumnNumber
+			actualSourcemapFetchedPath
+			sourcemapFileSize
+			minifiedFileSize
+			mappedLineNumber
+			mappedColumnNumber
+		}
+	}
+	timestamp
+	payload
+	request_id
+	os
+	browser
+	environment
+}
+
 query GetErrorObject($id: ID!) {
 	error_object(id: $id) {
-		id
-		created_at
-		project_id
-		session {
-			identifier
-			fingerprint
-			secure_id
-			city
-			state
-			country
-			user_properties
-		}
-		error_group_id
-		error_group_secure_id
-		event
-		type
-		url
-		source
-		lineNumber
-		columnNumber
-		stack_trace
-		structured_stack_trace {
-			fileName
-			lineNumber
-			functionName
-			columnNumber
-			lineContent
-			linesBefore
-			linesAfter
-			error
-		}
-		timestamp
-		payload
-		request_id
-		os
-		browser
-		environment
+		...ErrorObject
 	}
 }
 
@@ -1111,62 +1135,7 @@ query GetErrorInstance($error_group_secure_id: String!, $error_object_id: ID) {
 		error_object_id: $error_object_id
 	) {
 		error_object {
-			id
-			created_at
-			project_id
-			session_id
-			trace_id
-			span_id
-			log_cursor
-			session {
-				identifier
-				fingerprint
-				secure_id
-				city
-				state
-				country
-				user_properties
-			}
-			error_group_id
-			error_group_secure_id
-			event
-			type
-			url
-			source
-			lineNumber
-			columnNumber
-			stack_trace
-			structured_stack_trace {
-				fileName
-				lineNumber
-				functionName
-				columnNumber
-				lineContent
-				linesBefore
-				linesAfter
-				error
-				sourceMappingErrorMetadata {
-					errorCode
-					stackTraceFileURL
-					sourcemapFetchStrategy
-					sourceMapURL
-					minifiedFetchStrategy
-					actualMinifiedFetchedPath
-					minifiedLineNumber
-					minifiedColumnNumber
-					actualSourcemapFetchedPath
-					sourcemapFileSize
-					minifiedFileSize
-					mappedLineNumber
-					mappedColumnNumber
-				}
-			}
-			timestamp
-			payload
-			request_id
-			os
-			browser
-			environment
+			...ErrorObject
 		}
 		next_id
 		previous_id

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -528,6 +528,36 @@ const User: React.FC<{
 				</Callout>
 			</Box>
 		)
+	} else if (errorObject.session.excluded) {
+		return (
+			<Box width="full">
+				<Box pb="20" mt="12">
+					<Text weight="bold" size="large">
+						User details
+					</Text>
+				</Box>
+				<Callout title="We didn't find a session for this error">
+					<Box>
+						<Text size="small" weight="medium" color="moderate">
+							We weren't able to match this error to a session.
+							This can happen when a session has no activity or it
+							has been ignored.
+						</Text>
+					</Box>
+					<Box display="flex">
+						<LinkButton
+							kind="secondary"
+							to="https://www.highlight.io/docs/general/product-features/session-replay/ignoring-sessions"
+							trackingId="session-ignoring-docs"
+							emphasis="low"
+							target="_blank"
+						>
+							Learn more
+						</LinkButton>
+					</Box>
+				</Callout>
+			</Box>
+		)
 	}
 
 	const { session } = errorObject

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ShowSessionButton.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ShowSessionButton.tsx
@@ -15,10 +15,10 @@ const getSessionLink = (errorObject: ErrorObjectFragment): string => {
 	return `/${errorObject.project_id}/sessions/${errorObject.session?.secure_id}?${params}`
 }
 
-const WithTooltip = ({ children }: React.PropsWithChildren) => {
+const WithDevToolsTooltip = ({ children }: React.PropsWithChildren) => {
 	return (
 		<Tooltip trigger={children}>
-			This session is still live and some Dev tools may not work as
+			This session is still live -- some Dev tools may not work as
 			expected.
 		</Tooltip>
 	)
@@ -51,8 +51,8 @@ export const ShowSessionButton = ({ errorObject }: Props) => {
 			</LinkButton>
 		)
 
-		if (errorObject.session?.processed === false) {
-			return <WithTooltip>{linkButton}</WithTooltip>
+		if (errorObject.session && errorObject.session.processed === false) {
+			return <WithDevToolsTooltip>{linkButton}</WithDevToolsTooltip>
 		} else {
 			return linkButton
 		}

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ShowSessionButton.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ShowSessionButton.tsx
@@ -1,0 +1,72 @@
+import { Box, IconSolidPlay, Tooltip } from '@highlight-run/ui'
+import { createSearchParams } from 'react-router-dom'
+
+import { isLoggedIn } from '@/authentication/AuthContext'
+import { Button } from '@/components/Button'
+import { LinkButton } from '@/components/LinkButton'
+import { ErrorObjectFragment } from '@/graph/generated/operations'
+import { PlayerSearchParameters } from '@/pages/Player/PlayerHook/utils'
+
+const getSessionLink = (errorObject: ErrorObjectFragment): string => {
+	const params = createSearchParams({
+		tsAbs: errorObject.timestamp,
+		[PlayerSearchParameters.errorId]: errorObject.id,
+	})
+	return `/${errorObject.project_id}/sessions/${errorObject.session?.secure_id}?${params}`
+}
+
+const WithTooltip = ({ children }: React.PropsWithChildren) => {
+	return (
+		<Tooltip trigger={children}>
+			Heads up! This session is still live and some Dev tools may not work
+			as expected.
+		</Tooltip>
+	)
+}
+
+type Props = {
+	errorObject?: ErrorObjectFragment
+}
+
+export const ShowSessionButton = ({ errorObject }: Props) => {
+	const trackingId = 'errorInstanceShowSession'
+	if (errorObject) {
+		const linkButton = (
+			<LinkButton
+				kind="primary"
+				emphasis="high"
+				to={getSessionLink(errorObject)}
+				disabled={!isLoggedIn || !errorObject.session}
+				trackingId={trackingId}
+			>
+				<Box
+					display="flex"
+					alignItems="center"
+					flexDirection="row"
+					gap="4"
+				>
+					<IconSolidPlay />
+					Show session
+				</Box>
+			</LinkButton>
+		)
+
+		if (errorObject.session?.processed === false) {
+			return <WithTooltip>{linkButton}</WithTooltip>
+		} else {
+			return linkButton
+		}
+	} else {
+		return (
+			<Button
+				kind="primary"
+				emphasis="high"
+				disabled={true}
+				iconLeft={<IconSolidPlay />}
+				trackingId={trackingId}
+			>
+				Show session
+			</Button>
+		)
+	}
+}

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ShowSessionButton.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ShowSessionButton.tsx
@@ -30,7 +30,9 @@ type Props = {
 
 export const ShowSessionButton = ({ errorObject }: Props) => {
 	const trackingId = 'errorInstanceShowSession'
-	if (errorObject) {
+	const sessionAvailable =
+		errorObject && errorObject.session?.excluded === false
+	if (sessionAvailable) {
 		const linkButton = (
 			<LinkButton
 				kind="primary"

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ShowSessionButton.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ShowSessionButton.tsx
@@ -18,8 +18,8 @@ const getSessionLink = (errorObject: ErrorObjectFragment): string => {
 const WithTooltip = ({ children }: React.PropsWithChildren) => {
 	return (
 		<Tooltip trigger={children}>
-			Heads up! This session is still live and some Dev tools may not work
-			as expected.
+			This session is still live and some Dev tools may not work as
+			expected.
 		</Tooltip>
 	)
 }

--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -2,7 +2,7 @@ import { Button } from '@components/Button'
 import InfoTooltip from '@components/InfoTooltip/InfoTooltip'
 import { LinkButton } from '@components/LinkButton'
 import Tooltip from '@components/Tooltip/Tooltip'
-import { ErrorInstance, Maybe, SourceMappingError } from '@graph/schemas'
+import { Maybe, SourceMappingError } from '@graph/schemas'
 import {
 	Box,
 	ButtonIcon,
@@ -22,10 +22,12 @@ import clsx from 'clsx'
 import React from 'react'
 import ReactCollapsible from 'react-collapsible'
 
+import { ErrorObjectFragment } from '@/graph/generated/operations'
+
 import * as styles from './ErrorStackTrace.css'
 
 interface Props {
-	errorObject?: ErrorInstance['error_object']
+	errorObject?: ErrorObjectFragment
 }
 
 const ErrorStackTrace = ({ errorObject }: Props) => {

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -9,7 +9,7 @@ import { Box } from '../Box/Box'
 
 export type TooltipProps = Partial<TooltipState> &
 	React.PropsWithChildren<{
-		trigger: React.ReactElement
+		trigger: React.ReactNode
 		disabled?: boolean
 		style?: React.CSSProperties
 	}>


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

#3576 attempted to fetch the first error instance with a non-live session (`processed=true`). The reasoning behind this was the devtools in for livemode aren't great (#4965). Additionally, #4269 tried to avoid error instances tied to excluded sessions.

The problem with these approaches is that the error group's last instance timestamp doesn't match one these selected. Here's a visual:
![236049033-4e4d768f-a4ad-441b-b453-f815aba8b9a7](https://user-images.githubusercontent.com/58678/236330902-0e860977-0622-4fbc-a355-7b2d94d928f8.png)

This PR removes the backend logic and relies more on frontend UX to inform the user if there is an issue. 




## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

If the session is excluded, we disable the "Show session" button and use a callout:
![Screenshot 2023-05-04 at 3 04 10 PM](https://user-images.githubusercontent.com/58678/236331027-13673129-a778-42d1-8c51-f8ebd5ec32cd.png)

If the session is live, we provide a tooltip to warn them about dev tools:
![Kapture 2023-05-04 at 10 11 41](https://user-images.githubusercontent.com/58678/236331238-7b4a16b1-02d3-46b0-8304-46a5ea455c12.gif)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

Will confirm with the customer that reported this that this fixes their issue.
