### PR TITLE
remove unnecessary session table indexes

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -561,14 +561,14 @@ type Session struct {
 	// The ID used publicly for the URL on the client; used for sharing
 	SecureID string `json:"secure_id" gorm:"uniqueIndex;not null;default:secure_id_generator()"`
 	// For associating unidentified sessions with a user after identification
-	ClientID string `json:"client_id" gorm:"index:idx_client_project,option:CONCURRENTLY;not null;default:''"`
+	ClientID string `json:"client_id" gorm:"not null;default:''"`
 	// Whether a session has been identified.
 	Identified  bool `json:"identified" gorm:"default:false;not null"`
 	Fingerprint int  `json:"fingerprint"`
 	// User provided identifier (see IdentifySession)
 	Identifier     string `json:"identifier"`
 	OrganizationID int    `json:"organization_id"`
-	ProjectID      int    `json:"project_id" gorm:"index:idx_client_project,option:CONCURRENTLY"`
+	ProjectID      int    `json:"project_id"`
 	// Location data based off user ip (see InitializeSession)
 	City      string  `json:"city"`
 	State     string  `json:"state"`
@@ -596,7 +596,7 @@ type Session struct {
 	ActiveLength   int64    `json:"active_length"`
 	Fields         []*Field `json:"fields" gorm:"many2many:session_fields;"`
 	Environment    string   `json:"environment"`
-	AppVersion     *string  `json:"app_version" gorm:"index"`
+	AppVersion     *string  `json:"app_version"`
 	UserObject     JSONB    `json:"user_object" sql:"type:jsonb"`
 	UserProperties string   `json:"user_properties"`
 	// Whether this is the first session created by this user.
@@ -612,13 +612,13 @@ type Session struct {
 	EnableStrictPrivacy            *bool   `json:"enable_strict_privacy"`
 	EnableRecordingNetworkContents *bool   `json:"enable_recording_network_contents"`
 	// The version of Highlight's Client.
-	ClientVersion string `json:"client_version" gorm:"index"`
+	ClientVersion string `json:"client_version"`
 	// The version of Highlight's Firstload.
-	FirstloadVersion string `json:"firstload_version" gorm:"index"`
+	FirstloadVersion string `json:"firstload_version"`
 	// The client configuration that the end-user sets up. This is used for debugging purposes.
 	ClientConfig *string `json:"client_config" sql:"type:jsonb"`
 	// Determines whether this session should be viewable. This enforces billing.
-	WithinBillingQuota *bool `json:"within_billing_quota" gorm:"index;default:true"` // index? probably.
+	WithinBillingQuota *bool `json:"within_billing_quota" gorm:"default:true"`
 	// Used for shareable links. No authentication is needed if IsPublic is true
 	IsPublic bool `json:"is_public" gorm:"default:false"`
 	// EventCounts is a len()=100 slice that contains the count of events for the session normalized over 100 points


### PR DESCRIPTION
## Summary

Removes unused session table indexes.

## How did you test this change?

Figuring out what indexes are unused via
```sql
select *
from pg_stat_all_indexes
where schemaname <> 'pg_catalog'
  and relname = 'sessions'
order by idx_scan desc;
```

## Are there any deployment considerations?

Should fix https://github.com/highlight/highlight/actions/runs/4885635564/jobs/8720972044 (caused by automigration trying to add manually-deleted indexes).
