### PR TITLE
speed up asset fetching

### DIFF
--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -452,6 +452,10 @@ func getOrCreateUrls(ctx context.Context, projectId int, originalUrls []string, 
 					}
 
 					file, err := os.Create(filepath.Join(dir, "asset"))
+					if err != nil {
+						return errors.Wrap(err, "failed to create asset file")
+					}
+
 					defer func(file *os.File) {
 						_ = file.Close()
 						_ = os.RemoveAll(dir)

--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -450,12 +450,11 @@ func getOrCreateUrls(ctx context.Context, projectId int, originalUrls []string, 
 					if err != nil {
 						return errors.Wrap(err, "failed to create temp directory")
 					}
-					assetTmpPath := filepath.Join(dir, "asset")
 
-					file, err := os.Create(assetTmpPath)
+					file, err := os.Create(filepath.Join(dir, "asset"))
 					defer func(file *os.File) {
 						_ = file.Close()
-						_ = os.Remove(assetTmpPath)
+						_ = os.RemoveAll(dir)
 					}(file)
 					_, err = io.Copy(file, response.Body)
 					if err != nil {

--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -249,6 +249,6 @@ func TestSnapshot_ReplaceAssets(t *testing.T) {
 				break
 			}
 		}
-		assert.True(t, matched, "no asset matched", exp)
+		assert.True(t, matched, "no asset matched %s", exp)
 	}
 }

--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -3,6 +3,13 @@ package parse
 import (
 	"context"
 	"encoding/json"
+	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/storage"
+	"github.com/highlight-run/highlight/backend/util"
+	e "github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
 	"os"
 	"strings"
 	"testing"
@@ -11,6 +18,21 @@ import (
 	"github.com/go-test/deep"
 	"github.com/kylelemons/godebug/pretty"
 )
+
+var DB *gorm.DB
+
+// Gets run once; M.run() calls the tests in this file.
+func TestMain(m *testing.M) {
+	dbName := "highlight_testing_db"
+	testLogger := log.WithContext(context.TODO()).WithFields(log.Fields{"DB_HOST": os.Getenv("PSQL_HOST"), "DB_NAME": dbName})
+	var err error
+	DB, err = util.CreateAndMigrateTestDB(dbName)
+	if err != nil {
+		testLogger.Error(e.Wrap(err, "error creating testdb"))
+	}
+	code := m.Run()
+	os.Exit(code)
+}
 
 func TestEventsFromString(t *testing.T) {
 	tables := []struct {
@@ -187,5 +209,46 @@ func TestEscapeJavascript(t *testing.T) {
 	str := string(processed)
 	if strings.Contains(str, "attack") {
 		t.Errorf("attack substring not escaped %+v", str)
+	}
+}
+
+func TestSnapshot_ReplaceAssets(t *testing.T) {
+	ctx := context.TODO()
+	inputBytes, err := os.ReadFile("./sample-events/input.json")
+	if err != nil {
+		t.Fatalf("error reading: %v", err)
+	}
+
+	snapshot, err := NewSnapshot(inputBytes)
+	if err != nil {
+		t.Fatalf("error parsing: %v", err)
+	}
+
+	var storageClient storage.Client
+	if storageClient, err = storage.NewFSClient(ctx, "https://test.highlight.io", "/tmp/test"); err != nil {
+		log.WithContext(ctx).Fatalf("error creating filesystem storage client: %v", err)
+	}
+	if err := snapshot.ReplaceAssets(ctx, 1, storageClient, DB); err != nil {
+		t.Fatalf("failed to replace assets %+v", err)
+	}
+
+	var assets []*model.SavedAsset
+	if err := DB.Model(&model.SavedAsset{}).Find(&assets).Error; err != nil {
+		t.Fatalf("failed to fetch assets %+v", err)
+	}
+
+	assert.Equal(t, 2, len(assets))
+	for _, exp := range []string{
+		"https://static.highlight.io/dev/BigBuckBunny.mp4?AWSAccessKeyId=asdffdsa1234",
+		"https://static.highlight.io/dev/test.mp4?AWSAccessKeyId=asdffdsa1234",
+	} {
+		matched := false
+		for _, asset := range assets {
+			if asset.OriginalUrl == exp {
+				matched = true
+				break
+			}
+		}
+		assert.True(t, matched, "no asset matched", exp)
 	}
 }

--- a/backend/event-parse/sample-events/input.json
+++ b/backend/event-parse/sample-events/input.json
@@ -363,6 +363,42 @@
 								"type": 2
 							},
 							{
+								"attributes": {
+									"src": "https://static.highlight.io/dev/BigBuckBunny.mp4?AWSAccessKeyId=asdffdsa1234",
+									"autoplay": true,
+									"crossorigin": "anonymous",
+									"preload=": "metadata"
+								},
+								"childNodes": [],
+								"id": 55555,
+								"tagName": "video",
+								"type": 2
+							},
+							{
+								"attributes": {
+									"src": "https://static.highlight.io/dev/test.mp4?AWSAccessKeyId=asdffdsa1234&Signature=c%2F%2BCuVPNfRldO2qFGliECCC0R7A%3D&x-amz-security-token=IQoJb3JpZ2luX2VjEAEaCXVzLWVhc3QtMSJHMEUCIQDB%2FFE5eMBLpRgsOiCn%2Bud5S16cnzxm5b3hPmISSFsmLgIgS6YuPEatrTdf45C%2BNzxAKF1vt7vmmWSoRiegGU%2BCba0qgQUIGhACGgw0NzU3MjMyNDA4MzAiDGlc0ZNEJGWjspla3ireBDf2Cm3Zl2dxONxeR2H3fniBrwJHWGsCOxpc%2BQtyEHe2Q%2F7aES19r%2B%2BpBqI60FndLawE3Oi9BtsLop7ANGBd8S4SfgXddOXBAwhxgePdFT58nm2Ap70ztkO6sBGjs58zG5b%2B2fHeqE%2B6EHUlMeAipRALvXWrurEa7k811jHfrwlFifFz9AjK%2B9rqsnAG1tBaskDita3xGPGol45INyZhRGAQqAHhqDMFKWg8%2Bg1i7xbPPPTDsYJk1N5AIPsXF4YpwmlBHR%2B%2BxZwVflVLfsBL3pPn4gZOfHlq19RGjiT1zPfY8XUpbJvJeqcrfhpeagn%2FL7x70u9WacKSCGzfaWDxzNJxpSkKA%2FsHtfNmg1Sg%2FM1EzWafAs3%2FakVKDjEJiHC8ruaLK66NbsIcvH27K%2BtKlMSbFPHKLcz2Lzj9GSqd2HqL5bg4egLYUbUabkJkL%2FP4kFFSCOV04Yk2BVjQDi4ReYLr02EiXERDNG8nreDP47B5A1CjN85TvOe%2FsmeCJpzK3olBvnyczMAYiNKhEYhkgbP2hBTu75ZbvMWtNRD5tcKltIM8FxK560rHb9NCdZmpDoZbQkWQ%2Flym9DvW5pB5ENoSGqULWLyJOwaRWQDbWgTX7I7XXERqO9fsTmAzglaFssMIeew7nx4p9T8uzDGFxK1EfUghC7ibjTPMerxRoHGR7fPYxJCDG1W9lUz17b%2FplGCtw4myt1WVzAr4VjK00AdvNn1mQ0oh%2B2ocbvqtQIkCUd43%2FhMn1arpf0wDa11CoKTCFGLPU3irqd9dRWPWu%2BBK2M8QvDgZJAYSUUxa7TDm7NSiBjqaAdRiIWPgQpInj8bXcQCwVwg%2F9hFT0O0HYUGyBPGON5EX1CuW%2FuZoC%2FzIvHkFSbzCsTPkX3kU8jPHjmb%2FYlf4x2n8c8HSosZ1ikZfTAZo8SKpGHFxGBPbk3h3hdv4u13SrFTtgJrle5UIJ%2BvkVAo6sKnJsZGJQfRjc2dneExKCC2UHIn87auTo%2FEFZoQA%2BqIJMlfoawmYS5OqMhc%3D&Expires=1683313388",
+									"autoplay": true,
+									"crossorigin": "anonymous",
+									"preload=": "metadata"
+								},
+								"childNodes": [],
+								"id": 55556,
+								"tagName": "video",
+								"type": 2
+							},
+							{
+								"attributes": {
+									"src": "https://static.highlight.io/dev/BigBuckBunny.mp4?AWSAccessKeyId=asdffdsa1234&Signature=c%2F%2BCuVPNfRldO2qFGliECCC0R7A%3D&x-amz-security-token=IQoJb3JpZ2luX2VjEAEaCXVzLWVhc3QtMSJHMEUCIQDB%2FFE5eMBLpRgsOiCn%2Bud5S16cnzxm5b3hPmISSFsmLgIgS6YuPEatrTdf45C%2BNzxAKF1vt7vmmWSoRiegGU%2BCba0qgQUIGhACGgw0NzU3MjMyNDA4MzAiDGlc0ZNEJGWjspla3ireBDf2Cm3Zl2dxONxeR2H3fniBrwJHWGsCOxpc%2BQtyEHe2Q%2F7aES19r%2B%2BpBqI60FndLawE3Oi9BtsLop7ANGBd8S4SfgXddOXBAwhxgePdFT58nm2Ap70ztkO6sBGjs58zG5b%2B2fHeqE%2B6EHUlMeAipRALvXWrurEa7k811jHfrwlFifFz9AjK%2B9rqsnAG1tBaskDita3xGPGol45INyZhRGAQqAHhqDMFKWg8%2Bg1i7xbPPPTDsYJk1N5AIPsXF4YpwmlBHR%2B%2BxZwVflVLfsBL3pPn4gZOfHlq19RGjiT1zPfY8XUpbJvJeqcrfhpeagn%2FL7x70u9WacKSCGzfaWDxzNJxpSkKA%2FsHtfNmg1Sg%2FM1EzWafAs3%2FakVKDjEJiHC8ruaLK66NbsIcvH27K%2BtKlMSbFPHKLcz2Lzj9GSqd2HqL5bg4egLYUbUabkJkL%2FP4kFFSCOV04Yk2BVjQDi4ReYLr02EiXERDNG8nreDP47B5A1CjN85TvOe%2FsmeCJpzK3olBvnyczMAYiNKhEYhkgbP2hBTu75ZbvMWtNRD5tcKltIM8FxK560rHb9NCdZmpDoZbQkWQ%2Flym9DvW5pB5ENoSGqULWLyJOwaRWQDbWgTX7I7XXERqO9fsTmAzglaFssMIeew7nx4p9T8uzDGFxK1EfUghC7ibjTPMerxRoHGR7fPYxJCDG1W9lUz17b%2FplGCtw4myt1WVzAr4VjK00AdvNn1mQ0oh%2B2ocbvqtQIkCUd43%2FhMn1arpf0wDa11CoKTCFGLPU3irqd9dRWPWu%2BBK2M8QvDgZJAYSUUxa7TDm7NSiBjqaAdRiIWPgQpInj8bXcQCwVwg%2F9hFT0O0HYUGyBPGON5EX1CuW%2FuZoC%2FzIvHkFSbzCsTPkX3kU8jPHjmb%2FYlf4x2n8c8HSosZ1ikZfTAZo8SKpGHFxGBPbk3h3hdv4u13SrFTtgJrle5UIJ%2BvkVAo6sKnJsZGJQfRjc2dneExKCC2UHIn87auTo%2FEFZoQA%2BqIJMlfoawmYS5OqMhc%3D&Expires=1683313388",
+									"autoplay": true,
+									"crossorigin": "anonymous",
+									"preload=": "metadata"
+								},
+								"childNodes": [],
+								"id": 55557,
+								"tagName": "video",
+								"type": 2
+							},
+							{
 								"id": 54,
 								"textContent": "\n        ",
 								"type": 3

--- a/backend/event-parse/sample-events/output.json
+++ b/backend/event-parse/sample-events/output.json
@@ -361,6 +361,42 @@
 								"type": 2
 							},
 							{
+								"attributes": {
+									"src": "https://static.highlight.io/dev/BigBuckBunny.mp4?AWSAccessKeyId=asdffdsa1234",
+									"autoplay": true,
+									"crossorigin": "anonymous",
+									"preload=": "metadata"
+								},
+								"childNodes": [],
+								"id": 55555,
+								"tagName": "video",
+								"type": 2
+							},
+							{
+								"attributes": {
+									"src": "https://static.highlight.io/dev/test.mp4?AWSAccessKeyId=asdffdsa1234&Signature=c%2F%2BCuVPNfRldO2qFGliECCC0R7A%3D&x-amz-security-token=IQoJb3JpZ2luX2VjEAEaCXVzLWVhc3QtMSJHMEUCIQDB%2FFE5eMBLpRgsOiCn%2Bud5S16cnzxm5b3hPmISSFsmLgIgS6YuPEatrTdf45C%2BNzxAKF1vt7vmmWSoRiegGU%2BCba0qgQUIGhACGgw0NzU3MjMyNDA4MzAiDGlc0ZNEJGWjspla3ireBDf2Cm3Zl2dxONxeR2H3fniBrwJHWGsCOxpc%2BQtyEHe2Q%2F7aES19r%2B%2BpBqI60FndLawE3Oi9BtsLop7ANGBd8S4SfgXddOXBAwhxgePdFT58nm2Ap70ztkO6sBGjs58zG5b%2B2fHeqE%2B6EHUlMeAipRALvXWrurEa7k811jHfrwlFifFz9AjK%2B9rqsnAG1tBaskDita3xGPGol45INyZhRGAQqAHhqDMFKWg8%2Bg1i7xbPPPTDsYJk1N5AIPsXF4YpwmlBHR%2B%2BxZwVflVLfsBL3pPn4gZOfHlq19RGjiT1zPfY8XUpbJvJeqcrfhpeagn%2FL7x70u9WacKSCGzfaWDxzNJxpSkKA%2FsHtfNmg1Sg%2FM1EzWafAs3%2FakVKDjEJiHC8ruaLK66NbsIcvH27K%2BtKlMSbFPHKLcz2Lzj9GSqd2HqL5bg4egLYUbUabkJkL%2FP4kFFSCOV04Yk2BVjQDi4ReYLr02EiXERDNG8nreDP47B5A1CjN85TvOe%2FsmeCJpzK3olBvnyczMAYiNKhEYhkgbP2hBTu75ZbvMWtNRD5tcKltIM8FxK560rHb9NCdZmpDoZbQkWQ%2Flym9DvW5pB5ENoSGqULWLyJOwaRWQDbWgTX7I7XXERqO9fsTmAzglaFssMIeew7nx4p9T8uzDGFxK1EfUghC7ibjTPMerxRoHGR7fPYxJCDG1W9lUz17b%2FplGCtw4myt1WVzAr4VjK00AdvNn1mQ0oh%2B2ocbvqtQIkCUd43%2FhMn1arpf0wDa11CoKTCFGLPU3irqd9dRWPWu%2BBK2M8QvDgZJAYSUUxa7TDm7NSiBjqaAdRiIWPgQpInj8bXcQCwVwg%2F9hFT0O0HYUGyBPGON5EX1CuW%2FuZoC%2FzIvHkFSbzCsTPkX3kU8jPHjmb%2FYlf4x2n8c8HSosZ1ikZfTAZo8SKpGHFxGBPbk3h3hdv4u13SrFTtgJrle5UIJ%2BvkVAo6sKnJsZGJQfRjc2dneExKCC2UHIn87auTo%2FEFZoQA%2BqIJMlfoawmYS5OqMhc%3D&Expires=1683313388",
+									"autoplay": true,
+									"crossorigin": "anonymous",
+									"preload=": "metadata"
+								},
+								"childNodes": [],
+								"id": 55556,
+								"tagName": "video",
+								"type": 2
+							},
+							{
+								"attributes": {
+									"src": "https://static.highlight.io/dev/BigBuckBunny.mp4?AWSAccessKeyId=asdffdsa1234&Signature=c%2F%2BCuVPNfRldO2qFGliECCC0R7A%3D&x-amz-security-token=IQoJb3JpZ2luX2VjEAEaCXVzLWVhc3QtMSJHMEUCIQDB%2FFE5eMBLpRgsOiCn%2Bud5S16cnzxm5b3hPmISSFsmLgIgS6YuPEatrTdf45C%2BNzxAKF1vt7vmmWSoRiegGU%2BCba0qgQUIGhACGgw0NzU3MjMyNDA4MzAiDGlc0ZNEJGWjspla3ireBDf2Cm3Zl2dxONxeR2H3fniBrwJHWGsCOxpc%2BQtyEHe2Q%2F7aES19r%2B%2BpBqI60FndLawE3Oi9BtsLop7ANGBd8S4SfgXddOXBAwhxgePdFT58nm2Ap70ztkO6sBGjs58zG5b%2B2fHeqE%2B6EHUlMeAipRALvXWrurEa7k811jHfrwlFifFz9AjK%2B9rqsnAG1tBaskDita3xGPGol45INyZhRGAQqAHhqDMFKWg8%2Bg1i7xbPPPTDsYJk1N5AIPsXF4YpwmlBHR%2B%2BxZwVflVLfsBL3pPn4gZOfHlq19RGjiT1zPfY8XUpbJvJeqcrfhpeagn%2FL7x70u9WacKSCGzfaWDxzNJxpSkKA%2FsHtfNmg1Sg%2FM1EzWafAs3%2FakVKDjEJiHC8ruaLK66NbsIcvH27K%2BtKlMSbFPHKLcz2Lzj9GSqd2HqL5bg4egLYUbUabkJkL%2FP4kFFSCOV04Yk2BVjQDi4ReYLr02EiXERDNG8nreDP47B5A1CjN85TvOe%2FsmeCJpzK3olBvnyczMAYiNKhEYhkgbP2hBTu75ZbvMWtNRD5tcKltIM8FxK560rHb9NCdZmpDoZbQkWQ%2Flym9DvW5pB5ENoSGqULWLyJOwaRWQDbWgTX7I7XXERqO9fsTmAzglaFssMIeew7nx4p9T8uzDGFxK1EfUghC7ibjTPMerxRoHGR7fPYxJCDG1W9lUz17b%2FplGCtw4myt1WVzAr4VjK00AdvNn1mQ0oh%2B2ocbvqtQIkCUd43%2FhMn1arpf0wDa11CoKTCFGLPU3irqd9dRWPWu%2BBK2M8QvDgZJAYSUUxa7TDm7NSiBjqaAdRiIWPgQpInj8bXcQCwVwg%2F9hFT0O0HYUGyBPGON5EX1CuW%2FuZoC%2FzIvHkFSbzCsTPkX3kU8jPHjmb%2FYlf4x2n8c8HSosZ1ikZfTAZo8SKpGHFxGBPbk3h3hdv4u13SrFTtgJrle5UIJ%2BvkVAo6sKnJsZGJQfRjc2dneExKCC2UHIn87auTo%2FEFZoQA%2BqIJMlfoawmYS5OqMhc%3D&Expires=1683313388",
+									"autoplay": true,
+									"crossorigin": "anonymous",
+									"preload=": "metadata"
+								},
+								"childNodes": [],
+								"id": 55557,
+								"tagName": "video",
+								"type": 2
+							},
+							{
 								"id": 54,
 								"textContent": "\n        ",
 								"type": 3

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -87,7 +87,7 @@ require (
 	go.opentelemetry.io/otel v1.13.0
 	go.opentelemetry.io/otel/trace v1.13.0
 	golang.org/x/oauth2 v0.6.0
-	golang.org/x/sync v0.1.0
+	golang.org/x/sync v0.2.0
 	golang.org/x/text v0.8.0
 	google.golang.org/api v0.110.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.43.1

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1722,8 +1722,9 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180224232135-f6cff0780e54/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2719,7 +2719,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 					// Replace any static resources with our own, hosted in S3
 					if projectID == 1 || projectID == 1344 || projectID == 5403 {
 						assetsSpan, _ := tracer.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
-							tracer.ResourceName("go.parseEvents.replaceAssets"), tracer.Tag("project_id", projectID))
+							tracer.ResourceName("go.parseEvents.replaceAssets"), tracer.Tag("project_id", projectID), tracer.Tag("session_secure_id", sessionSecureID))
 						err = snapshot.ReplaceAssets(ctx, projectID, r.StorageClient, r.DB)
 						assetsSpan.Finish()
 						if err != nil {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1121,7 +1121,7 @@ func (w *Worker) Start(ctx context.Context) {
 					vmStat, _ = mem.VirtualMemory()
 				}
 
-				span, ctx := tracer.StartSpanFromContext(ctx, "worker.operation", tracer.ResourceName("worker.processSession"))
+				span, ctx := tracer.StartSpanFromContext(ctx, "worker.operation", tracer.ResourceName("worker.processSession"), tracer.Tag("project_id", session.ProjectID), tracer.Tag("session_secure_id", session.SecureID))
 				if err := w.processSession(ctx, session); err != nil {
 					nextCount := session.RetryCount + 1
 					var excluded bool


### PR DESCRIPTION
## Summary

Deduplicate asset retrieval when certain query string parameters differ that do not affect the contents of the asset.
Parallelize fetching of assets to help with improving `PushPayload` performance.

## How did you test this change?

New functional test.

Assets correctly hashed and saved (1.mp4 and 2.mp4 were ones i renamed)
![image](https://user-images.githubusercontent.com/1351531/236558488-c0b166f1-d126-4d19-b558-8b3ba907569d.png)
![image](https://user-images.githubusercontent.com/1351531/236558562-7d9131d4-8355-492b-8097-696fbf4109f8.png)


## Are there any deployment considerations?

No