### PR TITLE
track why a session was excluded

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -641,7 +641,8 @@ type Session struct {
 	VerboseID             string  `json:"verbose_id"`
 
 	// Excluded will be true when we would typically have deleted the session
-	Excluded bool `gorm:"default:false"`
+	Excluded       bool `gorm:"default:false"`
+	ExcludedReason modelInputs.SessionExcludedReason
 
 	// Lock is the timestamp at which a session was locked
 	// - when selecting sessions, ignore Locks that are > 10 minutes old

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -642,7 +642,7 @@ type Session struct {
 
 	// Excluded will be true when we would typically have deleted the session
 	Excluded       bool `gorm:"default:false"`
-	ExcludedReason modelInputs.SessionExcludedReason
+	ExcludedReason *modelInputs.SessionExcludedReason
 
 	// Lock is the timestamp at which a session was locked
 	// - when selecting sessions, ignore Locks that are > 10 minutes old

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -8277,6 +8277,13 @@ type Field {
 	type: String
 }
 
+enum SessionExcludedReason {
+	NoActivity
+	NoUserInteractionEvents
+	NoError
+	IgnoredUser
+}
+
 type Session {
 	id: ID!
 	secure_id: String!

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1547,6 +1547,51 @@ func (e SessionCommentType) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+type SessionExcludedReason string
+
+const (
+	SessionExcludedReasonNoActivity              SessionExcludedReason = "NoActivity"
+	SessionExcludedReasonNoUserInteractionEvents SessionExcludedReason = "NoUserInteractionEvents"
+	SessionExcludedReasonNoError                 SessionExcludedReason = "NoError"
+	SessionExcludedReasonIgnoredUser             SessionExcludedReason = "IgnoredUser"
+)
+
+var AllSessionExcludedReason = []SessionExcludedReason{
+	SessionExcludedReasonNoActivity,
+	SessionExcludedReasonNoUserInteractionEvents,
+	SessionExcludedReasonNoError,
+	SessionExcludedReasonIgnoredUser,
+}
+
+func (e SessionExcludedReason) IsValid() bool {
+	switch e {
+	case SessionExcludedReasonNoActivity, SessionExcludedReasonNoUserInteractionEvents, SessionExcludedReasonNoError, SessionExcludedReasonIgnoredUser:
+		return true
+	}
+	return false
+}
+
+func (e SessionExcludedReason) String() string {
+	return string(e)
+}
+
+func (e *SessionExcludedReason) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SessionExcludedReason(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SessionExcludedReason", str)
+	}
+	return nil
+}
+
+func (e SessionExcludedReason) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 type SessionLifecycle string
 
 const (

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -14,6 +14,13 @@ type Field {
 	type: String
 }
 
+enum SessionExcludedReason {
+	NoActivity
+	NoUserInteractionEvents
+	NoError
+	IgnoredUser
+}
+
 type Session {
 	id: ID!
 	secure_id: String!

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2963,7 +2963,6 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			if err := r.DB.Model(&model.Session{Model: model.Model{ID: sessionID}}).
 				Select("ExcludedReason").
 				Updates(updates).Error; err != nil {
-				log.WithContext(ctx).Error(e.Wrap(err, "error updating session excluded reason"))
 				return err
 			}
 		}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2954,13 +2954,9 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			return err
 		}
 	} else if excluded {
+		// Only update the excluded reason if it has changed
 		if sessionObj.ExcludedReason != reason {
-			updates := model.Session{
-				ExcludedReason: reason,
-			}
-			if err := r.DB.Model(&model.Session{Model: model.Model{ID: sessionID}}).
-				Select("ExcludedReason").
-				Updates(updates).Error; err != nil {
+			if err := r.DB.Model(&model.Session{Model: model.Model{ID: sessionID}}).Update("ExcludedReason", reason).Error; err != nil {
 				return err
 			}
 		}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2933,27 +2933,23 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		(sessionHasErrors && (sessionObj.HasErrors == nil || !*sessionObj.HasErrors))
 
 	if doUpdate && !excluded {
-		fieldsToUpdate := model.Session{
-			PayloadUpdatedAt:      &now,
-			BeaconTime:            beaconTime,
-			HasUnloaded:           hasSessionUnloaded,
-			Processed:             &model.F,
-			ObjectStorageEnabled:  &model.F,
-			DirectDownloadEnabled: false,
-			Chunked:               &model.F,
-			Excluded:              false,
-			ExcludedReason:        "",
-			HasErrors:             &sessionHasErrors,
-		}
-
 		// By default, GORM will not update non-zero fields. This is undesirable for boolean columns.
 		// By explicitly specifying the columns to update, we can override the behavior.
 		// See https://gorm.io/docs/update.html#Updates-multiple-columns
-		columnsToUpdate := []string{"PayloadUpdatedAt", "BeaconTime", "HasUnloaded", "Processed", "ObjectStorageEnabled", "Chunked", "DirectDownloadEnabled", "Excluded", "ExcludedReason", "HasErrors"}
-
 		if err := r.DB.Model(&model.Session{Model: model.Model{ID: sessionID}}).
-			Select(columnsToUpdate).
-			Updates(&fieldsToUpdate).Error; err != nil {
+			Select("PayloadUpdatedAt", "BeaconTime", "HasUnloaded", "Processed", "ObjectStorageEnabled", "Chunked", "DirectDownloadEnabled", "Excluded", "ExcludedReason", "HasErrors").
+			Updates(&model.Session{
+				PayloadUpdatedAt:      &now,
+				BeaconTime:            beaconTime,
+				HasUnloaded:           hasSessionUnloaded,
+				Processed:             &model.F,
+				ObjectStorageEnabled:  &model.F,
+				DirectDownloadEnabled: false,
+				Chunked:               &model.F,
+				Excluded:              false,
+				ExcludedReason:        "",
+				HasErrors:             &sessionHasErrors,
+			}).Error; err != nil {
 			log.WithContext(ctx).Error(e.Wrap(err, "error updating session"))
 			return err
 		}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -548,7 +548,7 @@ func (w *Worker) DeleteCompletedSessions(ctx context.Context) {
 
 func (w *Worker) excludeSession(ctx context.Context, s *model.Session, reason backend.SessionExcludedReason) error {
 	s.Excluded = true
-	s.ExcludedReason = reason
+	s.ExcludedReason = &reason
 	s.Processed = &model.T
 	if err := w.Resolver.DB.Table(model.SESSIONS_TBL).Model(&model.Session{Model: model.Model{ID: s.ID}}).Updates(s).Error; err != nil {
 		log.WithContext(ctx).WithFields(log.Fields{"session_id": s.ID, "project_id": s.ProjectID, "identifier": s.Identifier,

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -546,8 +546,9 @@ func (w *Worker) DeleteCompletedSessions(ctx context.Context) {
 	}
 }
 
-func (w *Worker) excludeSession(ctx context.Context, s *model.Session) error {
+func (w *Worker) excludeSession(ctx context.Context, s *model.Session, reason backend.SessionExcludedReason) error {
 	s.Excluded = true
+	s.ExcludedReason = reason
 	s.Processed = &model.T
 	if err := w.Resolver.DB.Table(model.SESSIONS_TBL).Model(&model.Session{Model: model.Model{ID: s.ID}}).Updates(s).Error; err != nil {
 		log.WithContext(ctx).WithFields(log.Fields{"session_id": s.ID, "project_id": s.ProjectID, "identifier": s.Identifier,
@@ -692,8 +693,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 
 	userInteractionEvents := accumulator.UserInteractionEvents
 	if len(userInteractionEvents) == 0 {
-		log.WithContext(ctx).WithFields(log.Fields{"session_id": s.ID, "project_id": s.ProjectID}).Infof("excluding session due to no user interaction events")
-		return w.excludeSession(ctx, s)
+		return w.excludeSession(ctx, s, backend.SessionExcludedReasonNoUserInteractionEvents)
 	}
 
 	userInteractionEvents = append(userInteractionEvents, []*parse.ReplayEvent{{
@@ -818,9 +818,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 	// 1. Nothing happened in the session
 	// 2. A web crawler visited the page and produced no events
 	if accumulator.ActiveDuration == 0 {
-		log.WithContext(ctx).WithFields(log.Fields{"session_id": s.ID, "project_id": s.ProjectID, "identifier": s.Identifier,
-			"session_obj": s}).Warnf("excluding session with 0ms length active duration (session_id=%d, identifier=%s)", s.ID, s.Identifier)
-		return w.excludeSession(ctx, s)
+		return w.excludeSession(ctx, s, backend.SessionExcludedReasonNoActivity)
 	}
 
 	visitFields := []model.Field{}

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2488,6 +2488,13 @@ export enum SessionCommentType {
 	Feedback = 'FEEDBACK',
 }
 
+export enum SessionExcludedReason {
+	IgnoredUser = 'IgnoredUser',
+	NoActivity = 'NoActivity',
+	NoError = 'NoError',
+	NoUserInteractionEvents = 'NoUserInteractionEvents',
+}
+
 export type SessionInterval = {
 	__typename?: 'SessionInterval'
 	active: Scalars['Boolean']


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR tracks why a session was excluded (see #5231 for reasons why a session could be excluded). We log this information but we don't persist it to the db. Hence, it's not possible for us to tell the end user why I session was excluded. With this change, we'll have the information available and can present it as such. 

Note: this is just the backend changes to record the excluded reason. A follow up PR will tidy up the [frontend code](https://github.com/highlight/highlight/pull/5223/files#diff-c740ecb3d6dc5071064893b4a639d723ff746a049d50e3dde47fe24b59ccd49aR531-R545). 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Tested [various exclusion reasons](https://github.com/highlight/highlight/issues/5231). Ensured that `excluded_reason` is set when `excluded=true`

<img width="662" alt="Screenshot 2023-05-09 at 11 40 47 AM" src="https://github.com/highlight/highlight/assets/58678/7a126b09-35cf-42db-b988-768800eb20b9">



## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A