### PR TITLE
Add a draggable handle to resize devtools

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -12,6 +12,7 @@ import {
 	Text,
 	useFormState,
 } from '@highlight-run/ui'
+import { themeVars } from '@highlight-run/ui/src/css/theme.css'
 import { useProjectId } from '@hooks/useProjectId'
 import { useWindowSize } from '@hooks/useWindowSize'
 import { getLogsURLForSession } from '@pages/LogsPage/SearchForm/utils'
@@ -204,8 +205,19 @@ const DevToolsWindowV2: React.FC<
 					ref={panelRef}
 					style={{ width: props.width }}
 				>
+					<Box
+						ref={handleRef}
+						my="4"
+						style={{
+							backgroundColor: themeVars.static.divider.weak,
+							borderRadius: 10,
+							cursor: 'grab',
+							height: 4,
+							width: 36,
+							zIndex: 1,
+						}}
+					/>
 					<Tabs<Tab>
-						handleRef={handleRef}
 						tab={selectedDevToolsTab}
 						setTab={(t: Tab) => {
 							setSelectedDevToolsTab(t)

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -207,16 +207,19 @@ const DevToolsWindowV2: React.FC<
 				>
 					<Box
 						ref={handleRef}
-						my="4"
-						style={{
-							backgroundColor: themeVars.static.divider.weak,
-							borderRadius: 10,
-							cursor: 'grab',
-							height: 4,
-							width: 36,
-							zIndex: 1,
-						}}
-					/>
+						p="4"
+						style={{ cursor: 'grab', width: 'auto' }}
+					>
+						<Box
+							style={{
+								backgroundColor: themeVars.static.divider.weak,
+								borderRadius: 10,
+								height: 4,
+								width: 36,
+								zIndex: 1,
+							}}
+						/>
+					</Box>
 					<Tabs<Tab>
 						tab={selectedDevToolsTab}
 						setTab={(t: Tab) => {

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -50,8 +50,7 @@ export const Tabs = function <T extends string>({
 							display="flex"
 							flexDirection="column"
 							justifyContent="center"
-							paddingTop="4"
-							gap="4"
+							gap="2"
 							key={t}
 							cssClass={styles.controlBarButton}
 							onMouseEnter={() => setHoveredTab(t)}


### PR DESCRIPTION
## Summary

Adds a "handle" to the draggable area of the dev tools. This has been a source of confusion for many as they didn't realize you could resize the dev tools.

https://www.loom.com/share/843eb726fff140b59b0d44783bdeb074

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A