### PR TITLE
Repairing doc parser's UL handling.

### DIFF
--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -1,45 +1,44 @@
-import { promises as fsp } from 'fs'
-import yaml from 'js-yaml'
-import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
-import { serialize } from 'next-mdx-remote/serialize'
-import { GetStaticPaths, GetStaticProps } from 'next/types'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { Collapse } from 'react-collapse'
-import remarkGfm from 'remark-gfm'
-import styles from '../../components/Docs/Docs.module.scss'
-import ChevronDown from '../../public/images/ChevronDownIcon'
-import Minus from '../../public/images/MinusIcon'
-
-import path from 'path'
-import { FaDiscord, FaGithub, FaTwitter } from 'react-icons/fa'
-
-import classNames from 'classnames'
-import matter from 'gray-matter'
-import Markdown from 'markdown-to-jsx'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
 import { BiChevronLeft, BiChevronRight } from 'react-icons/bi'
-import { Meta } from '../../components/common/Head/Meta'
-import Navbar from '../../components/common/Navbar/Navbar'
-import { Roadmap, RoadmapItem } from '../../components/common/Roadmap/Roadmap'
-import { roadmapFetcher } from '../../components/common/Roadmap/RoadmapUtils'
-import { Typography } from '../../components/common/Typography/Typography'
-import { Callout } from '../../components/Docs/Callout/Callout'
-import { DocSection } from '../../components/Docs/DocLayout/DocLayout'
-import DocSelect from '../../components/Docs/DocSelect/DocSelect'
-import { generateIdFromProps } from '../../components/Docs/DocsTypographyRenderer/DocsTypographyRenderer'
-import { HighlightCodeBlock } from '../../components/Docs/HighlightCodeBlock/HighlightCodeBlock'
-import { useMediaQuery } from '../../components/MediaQuery/MediaQuery'
-import {
-	quickStartContent,
-	QuickStartContent,
-	QuickStartStep,
-} from '../../components/QuickstartContent/QuickstartContent'
+import { FaDiscord, FaGithub, FaTwitter } from 'react-icons/fa'
+import { GetStaticPaths, GetStaticProps } from 'next/types'
 import {
 	IGNORED_DOCS_PATHS,
 	processDocPath,
 	removeOrderingPrefix,
 } from '../api/docs/github'
+import { MDXRemote, MDXRemoteSerializeResult } from 'next-mdx-remote'
+import {
+	QuickStartContent,
+	QuickStartStep,
+	quickStartContent,
+} from '../../components/QuickstartContent/QuickstartContent'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { Roadmap, RoadmapItem } from '../../components/common/Roadmap/Roadmap'
+
+import { Callout } from '../../components/Docs/Callout/Callout'
+import ChevronDown from '../../public/images/ChevronDownIcon'
+import { Collapse } from 'react-collapse'
+import { DocSection } from '../../components/Docs/DocLayout/DocLayout'
+import DocSelect from '../../components/Docs/DocSelect/DocSelect'
+import { HighlightCodeBlock } from '../../components/Docs/HighlightCodeBlock/HighlightCodeBlock'
+import Link from 'next/link'
+import Markdown from 'markdown-to-jsx'
+import { Meta } from '../../components/common/Head/Meta'
+import Minus from '../../public/images/MinusIcon'
+import Navbar from '../../components/common/Navbar/Navbar'
+import { Typography } from '../../components/common/Typography/Typography'
+import classNames from 'classnames'
+import { promises as fsp } from 'fs'
+import { generateIdFromProps } from '../../components/Docs/DocsTypographyRenderer/DocsTypographyRenderer'
+import matter from 'gray-matter'
+import path from 'path'
+import remarkGfm from 'remark-gfm'
+import { roadmapFetcher } from '../../components/common/Roadmap/RoadmapUtils'
+import { serialize } from 'next-mdx-remote/serialize'
+import styles from '../../components/Docs/Docs.module.scss'
+import { useMediaQuery } from '../../components/MediaQuery/MediaQuery'
+import { useRouter } from 'next/router'
+import yaml from 'js-yaml'
 
 const DOCS_CONTENT_PATH = path.join(process.cwd(), '../docs-content')
 const DOCS_GITUB_LINK = `https://github.com/highlight/highlight/blob/main/docs-content`
@@ -1098,11 +1097,7 @@ const DocPage = ({
 																			c.props &&
 																			c
 																				.props
-																				.children &&
-																			c
-																				.props
-																				.children
-																				.map && (
+																				.children && (
 																				<li
 																					className={
 																						styles.listItem
@@ -1111,12 +1106,19 @@ const DocPage = ({
 																						i
 																					}
 																				>
-																					{c?.props?.children?.map(
-																						(
-																							e: any,
-																						) =>
-																							e,
-																					)}
+																					{c
+																						.props
+																						.children
+																						.map
+																						? c?.props?.children?.map(
+																								(
+																									e: any,
+																								) =>
+																									e,
+																						  )
+																						: c
+																								?.props
+																								?.children}
 																				</li>
 																			)
 																		)


### PR DESCRIPTION
## Summary

The doc parser was only rendering complex unordered list items. Simple, text-only `<li>` elements under a `<ul>` were being skipped entirely.

I got it fixed 👇 
![image](https://github.com/highlight/highlight/assets/878947/1430aba3-cede-4f8f-a828-1122e1781ea6)

## How did you test this change?

I worked on the Changelog 18 page: https://www.highlight.io/docs/general/changelog/changelog-18

## Are there any deployment considerations?

Nope!