### PR TITLE
withHighlightConfig doc improvement

### DIFF
--- a/docs-content/getting-started/fullstack-frameworks/next-js/1_overview.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/1_overview.md
@@ -68,6 +68,11 @@ If you want to configure source map uploads during your production builds and en
 import { withHighlightConfig } from '@highlight-run/next'
 export default withHighlightConfig({
   // your next.config.js options here
+
+  // Note, withHighlightConfig works for Next version 
+  // >= v12.1.0. withHighlightConfig returns a promise, 
+  // which may be incompatible with other Next.js 
+  // config generators that have not been well maintained.
 })
 ```
 

--- a/docs-content/sdk/nextjs.md
+++ b/docs-content/sdk/nextjs.md
@@ -92,9 +92,15 @@ quickstart: true
   </div>
   <div className="right">
     <code>
+      
       import { withHighlightConfig } from "@highlight-run/next";
       export default withHighlightConfig({
         // your next.config.js options here
+
+        // Note, withHighlightConfig works for Next version 
+        // >= v12.1.0. withHighlightConfig returns a promise, 
+        // which may be incompatible with other Next.js 
+        // config generators that have not been well maintained.
       })
     </code>
   </div>


### PR DESCRIPTION
## Summary

Addresses #4057

We've added some comments to the `withHighlightConfig` docs. 

In short, `withHighlightConfig` returns a promise, which is supported for Next v12.1.0 and greater. This breaks old Next apps as well as Next config generator functions that haven't learned to accept a promise as their argument. `next-pwa` is the offender in this case.

![image](https://github.com/highlight/highlight/assets/878947/8e1f10f9-7170-4247-9842-0e7a44cc9e6b)

## How did you test this change?

Spun up the docs.

## Are there any deployment considerations?

Nope