### PR TITLE
add a datadog metric to record error grouping sql

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -38,6 +38,7 @@ import (
 	"github.com/highlight-run/highlight/backend/email"
 	"github.com/highlight-run/highlight/backend/errors"
 	parse "github.com/highlight-run/highlight/backend/event-parse"
+	stats "github.com/highlight-run/highlight/backend/hlog"
 	highlightHubspot "github.com/highlight-run/highlight/backend/hubspot"
 	kafka_queue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/model"
@@ -665,6 +666,7 @@ func (r *Resolver) GetTopErrorGroupMatch(event string, projectID int, fingerprin
 	if projectID == 356 {
 		return nil, nil
 	}
+	start := time.Now()
 	if err := r.DB.Raw(`
 		WITH json_results AS (
 			SELECT CAST(value as VARCHAR), (2 ^ ordinality) * 1000 as score
@@ -724,6 +726,7 @@ func (r *Resolver) GetTopErrorGroupMatch(event string, projectID int, fingerprin
 		Scan(&result).Error; err != nil {
 		return nil, e.Wrap(err, "error querying top error group match")
 	}
+	stats.Histogram("GetTopErrorGroupMatch.groupSQL.durationMs", float64(time.Since(start).Milliseconds()), nil, 1)
 
 	minScore := 10 + len(restMeta) - 1
 	if len(restCode) > len(restMeta) {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We want to optimize the error grouping SQL. Before we do this, we want to capture more information as to how long it takes (e.g. give us the p99 in addition to the [AWS average](https://us-east-2.console.aws.amazon.com/rds/home?region=us-east-2#performance-insights-v20206:/resourceId/db-5ESFOLISXAYURFEQRLL3CX3SSY/resourceName/database-2-aurora/startTime/1683656528137/endTime/1683660128137/presetKey/1h/presetAmount/1/presetUnit/hour)):

![Screenshot 2023-05-09 at 1 22 41 PM](https://github.com/highlight/highlight/assets/58678/7cbcac01-8527-4d27-9dd4-00c79e38e78d)


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

This uses Datadog under the hood to measure. I wanted to use our own metrics but discovered a bug with how we record backend only metrics (see #5258).

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
