### PR TITLE
Fix logic for creating error setup events

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -134,7 +134,7 @@ func getBackendError(ctx context.Context, ts time.Time, projectID, sessionID, re
 		LogCursor:       logCursor,
 		Event:           excMessage,
 		Type:            excType,
-		Source:          host,
+		Source:          source.String(),
 		StackTrace:      stackTrace,
 		Timestamp:       ts,
 		Payload:         pointy.String(string(payloadBytes)),
@@ -259,7 +259,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	for sessionID, errors := range traceErrors {
 		var backendError = false
 		for _, err := range errors {
-			if err.Type == modelInputs.LogSourceBackend.String() {
+			if err.Source == modelInputs.LogSourceBackend.String() {
 				backendError = true
 			}
 		}
@@ -294,7 +294,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	for projectID, errors := range projectErrors {
 		var backendError = false
 		for _, err := range errors {
-			if err.Type == modelInputs.LogSourceBackend.String() {
+			if err.Source == modelInputs.LogSourceBackend.String() {
 				backendError = true
 			}
 		}


### PR DESCRIPTION
## Summary

Noticed that setup events `where type = 'error'` haven't been created since April 5th, which led me to believe that https://github.com/highlight/highlight/pull/4839 might have changed some logic preventing these from being created. Turns out `err.Type` would never be equal to `modelInputs.LogSourceBackend.String()` (`"backend"`).

Thanks to @et for jumping on a call to help troubleshoot this one.

## How did you test this change?

Local click test.

## Are there any deployment considerations?

Will check prod DB to ensure setup events are being created as expected after this goes out.
