### PR TITLE
unalias highlight package in Go code and docs

### DIFF
--- a/backend/lambda-functions/deleteSessions/deleteSessionBatchFromOpenSearch/main.go
+++ b/backend/lambda-functions/deleteSessions/deleteSessionBatchFromOpenSearch/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
-	H "github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/highlight/highlight/sdk/highlight-go"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
@@ -14,9 +14,9 @@ func init() {
 }
 
 func main() {
-	H.SetProjectID("1jdkoe52")
-	H.Start()
-	defer H.Stop()
+	highlight.SetProjectID("1jdkoe52")
+	highlight.Start()
+	defer highlight.Stop()
 	hlog.Init()
 	lambda.Start(h.DeleteSessionBatchFromOpenSearch)
 }

--- a/backend/lambda-functions/deleteSessions/deleteSessionBatchFromPostgres/main.go
+++ b/backend/lambda-functions/deleteSessions/deleteSessionBatchFromPostgres/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
-	H "github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/highlight/highlight/sdk/highlight-go"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
@@ -14,9 +14,9 @@ func init() {
 }
 
 func main() {
-	H.SetProjectID("1jdkoe52")
-	H.Start()
-	defer H.Stop()
+	highlight.SetProjectID("1jdkoe52")
+	highlight.Start()
+	defer highlight.Stop()
 	hlog.Init()
 	lambda.Start(h.DeleteSessionBatchFromPostgres)
 }

--- a/backend/lambda-functions/deleteSessions/deleteSessionBatchFromS3/main.go
+++ b/backend/lambda-functions/deleteSessions/deleteSessionBatchFromS3/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
-	H "github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/highlight/highlight/sdk/highlight-go"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
@@ -14,9 +14,9 @@ func init() {
 }
 
 func main() {
-	H.SetProjectID("1jdkoe52")
-	H.Start()
-	defer H.Stop()
+	highlight.SetProjectID("1jdkoe52")
+	highlight.Start()
+	defer highlight.Stop()
 	hlog.Init()
 	lambda.Start(h.DeleteSessionBatchFromS3)
 }

--- a/backend/lambda-functions/deleteSessions/getSessionIdsByQuery/main.go
+++ b/backend/lambda-functions/deleteSessions/getSessionIdsByQuery/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
-	H "github.com/highlight/highlight/sdk/highlight-go"
+	highlight "github.com/highlight/highlight/sdk/highlight-go"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
@@ -14,9 +14,9 @@ func init() {
 }
 
 func main() {
-	H.SetProjectID("1jdkoe52")
-	H.Start()
-	defer H.Stop()
+	highlight.SetProjectID("1jdkoe52")
+	highlight.Start()
+	defer highlight.Stop()
 	hlog.Init()
 	lambda.Start(h.GetSessionIdsByQuery)
 }

--- a/backend/lambda-functions/deleteSessions/main.go
+++ b/backend/lambda-functions/deleteSessions/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/utils"
 	"github.com/highlight-run/highlight/backend/util"
-	H "github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/highlight/highlight/sdk/highlight-go"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
@@ -18,9 +18,9 @@ func main() {
 		return
 	}
 
-	H.SetProjectID("1jdkoe52")
-	H.Start()
-	defer H.Stop()
+	highlight.SetProjectID("1jdkoe52")
+	highlight.Start()
+	defer highlight.Stop()
 	hlog.Init()
 
 	h := handlers.NewHandlers()

--- a/backend/lambda-functions/deleteSessions/sendEmail/main.go
+++ b/backend/lambda-functions/deleteSessions/sendEmail/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
-	H "github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/highlight/highlight/sdk/highlight-go"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 )
 
@@ -14,9 +14,9 @@ func init() {
 }
 
 func main() {
-	H.SetProjectID("1jdkoe52")
-	H.Start()
-	defer H.Stop()
+	highlight.SetProjectID("1jdkoe52")
+	highlight.Start()
+	defer highlight.Stop()
 	hlog.Init()
 	lambda.Start(h.SendEmail)
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -50,7 +50,7 @@ import (
 	"github.com/highlight-run/highlight/backend/worker"
 	"github.com/highlight-run/highlight/backend/zapier"
 	"github.com/highlight-run/workerpool"
-	H "github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/highlight/highlight/sdk/highlight-go"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 	"github.com/leonelquinteros/hubspot"
@@ -222,18 +222,18 @@ func main() {
 	ctx := context.TODO()
 
 	// setup highlight
-	H.SetProjectID("1jdkoe52")
+	highlight.SetProjectID("1jdkoe52")
 	if !util.IsOnPrem() && util.IsDevOrTestEnv() {
 		log.WithContext(ctx).Info("overwriting highlight-go graphql / otlp client address...")
-		H.SetGraphqlClientAddress("https://localhost:8082/public")
-		H.SetOTLPEndpoint("http://localhost:4318")
+		highlight.SetGraphqlClientAddress("https://localhost:8082/public")
+		highlight.SetOTLPEndpoint("http://localhost:4318")
 		if util.IsBackendInDocker() {
-			H.SetOTLPEndpoint("http://collector:4318")
+			highlight.SetOTLPEndpoint("http://collector:4318")
 		}
 	}
-	H.Start()
-	defer H.Stop()
-	H.SetDebugMode(log.StandardLogger())
+	highlight.Start()
+	defer highlight.Stop()
+	highlight.SetDebugMode(log.StandardLogger())
 
 	// setup highlight logrus hook
 	hlog.Init()
@@ -451,9 +451,9 @@ func main() {
 			})
 
 			privateServer.Use(util.NewTracer(util.PrivateGraph))
-			privateServer.Use(H.NewGraphqlTracer(string(util.PrivateGraph)).WithRequestFieldLogging())
-			privateServer.SetErrorPresenter(H.GraphQLErrorPresenter(string(util.PrivateGraph)))
-			privateServer.SetRecoverFunc(H.GraphQLRecoverFunc())
+			privateServer.Use(highlight.NewGraphqlTracer(string(util.PrivateGraph)).WithRequestFieldLogging())
+			privateServer.SetErrorPresenter(highlight.GraphQLErrorPresenter(string(util.PrivateGraph)))
+			privateServer.SetRecoverFunc(highlight.GraphQLRecoverFunc())
 			r.Handle("/",
 				privateServer,
 			)
@@ -495,9 +495,9 @@ func main() {
 					Resolvers: publicResolver,
 				}))
 			publicServer.Use(util.NewTracer(util.PublicGraph))
-			publicServer.Use(H.NewGraphqlTracer(string(util.PublicGraph)))
-			publicServer.SetErrorPresenter(H.GraphQLErrorPresenter(string(util.PublicGraph)))
-			publicServer.SetRecoverFunc(H.GraphQLRecoverFunc())
+			publicServer.Use(highlight.NewGraphqlTracer(string(util.PublicGraph)))
+			publicServer.SetErrorPresenter(highlight.GraphQLErrorPresenter(string(util.PublicGraph)))
+			publicServer.SetRecoverFunc(highlight.GraphQLRecoverFunc())
 			r.Handle("/",
 				publicServer,
 			)

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -64,7 +64,7 @@ import (
 	"github.com/highlight-run/highlight/backend/storage"
 	"github.com/highlight-run/highlight/backend/timeseries"
 	"github.com/highlight-run/highlight/backend/util"
-	H "github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/highlight/highlight/sdk/highlight-go"
 )
 
 // This file will not be regenerated automatically.
@@ -334,7 +334,7 @@ func (r *Resolver) isAdminInProjectOrDemoProject(ctx context.Context, project_id
 	defer authSpan.Finish()
 	start := time.Now()
 	defer func() {
-		H.RecordMetric(
+		highlight.RecordMetric(
 			ctx, "resolver.internal.auth.isAdminInProjectOrDemoProject", time.Since(start).Seconds(),
 		)
 	}()
@@ -358,7 +358,7 @@ func (r *Resolver) isAdminInWorkspaceOrDemoWorkspace(ctx context.Context, worksp
 	defer authSpan.Finish()
 	start := time.Now()
 	defer func() {
-		H.RecordMetric(
+		highlight.RecordMetric(
 			ctx, "resolver.internal.auth.isAdminInWorkspaceOrDemoWorkspace", time.Since(start).Seconds(),
 		)
 	}()

--- a/docs-content/sdk/go.md
+++ b/docs-content/sdk/go.md
@@ -18,19 +18,19 @@ slug: go
 
 <section className="section">
   <div className="left">
-    <h3>H.Start()</h3> 
+    <h3>highlight.Start()</h3>
     <p>Starts the background goroutine for transmitting metrics and errors.</p>
   </div>
   <div className="right">
     <code>
-        H.Start()
+        highlight.Start()
     </code>
   </div>
 </section>
 
 <section className="section">
   <div className="left">
-    <h3>H.StartWithContext()</h3> 
+    <h3>highlight.StartWithContext()</h3>
     <p>StartWithContext is used to start the Highlight client's collection service, 
 but allows the user to pass in their own context.Context. 
 This allows the user kill the highlight worker by canceling their context.CancelFunc.</p>
@@ -44,26 +44,26 @@ This allows the user kill the highlight worker by canceling their context.Cancel
     <code>
         ctx := context.Background()
         ...
-        H.startWithContext(ctx)
+        highlight.startWithContext(ctx)
     </code>
   </div>
 </section>
 
 <section className="section">
   <div className="left">
-    <h3>H.Stop()</h3> 
+    <h3>highlight.Stop()</h3>
     <p>Stop the Highlight client. Does not wait for all un-flushed data to be sent.</p>
   </div>
   <div className="right">
     <code>
-        H.Stop()
+        highlight.Stop()
     </code>
   </div>
 </section>
 
 <section className="section">
   <div className="left">
-    <h3>H.SetProjectID()</h3> 
+    <h3>highlight.SetProjectID()</h3>
     <p>Configure your Highlight project ID. See the [setup page for your project](https://app.highlight.io/setup).</p>
     <h6>Method Parameters</h6>
     <aside className="parameter">
@@ -73,19 +73,19 @@ This allows the user kill the highlight worker by canceling their context.Cancel
   </div>
   <div className="right">
     <code>
-        H.SetProjectID("<YOUR_PROJECT_ID>")
+        highlight.SetProjectID("<YOUR_PROJECT_ID>")
     </code>
   </div>
 </section>
 
 <section className="section">
   <div className="left">
-    <h3>H.RecordError()</h3> 
+    <h3>highlight.RecordError()</h3>
     <p>Record errors thrown in your backend.</p>
     <h6>Method Parameters</h6>
     <aside className="parameter">
       <h5>ctx <code>context.Context</code> <code>required</code></h5>
-      <p>The request context which should have highlight parameters set from H.InterceptRequest().</p>
+      <p>The request context which should have highlight parameters set from highlight.InterceptRequest().</p>
       <h5>err <code>error</code> <code>required</code></h5>
       <p>The error to report.</p>
      <h5>tags <code>...struct{Key: string, Value: string}</code> <code>optional</code></h5>
@@ -97,7 +97,7 @@ This allows the user kill the highlight worker by canceling their context.Cancel
         ctx := context.Background()
         result, err := myOperation(ctx)
         if err != nil {
-            H.RecordError(ctx, err)
+            highlight.RecordError(ctx, err)
         }
     </code>
   </div>
@@ -105,12 +105,12 @@ This allows the user kill the highlight worker by canceling their context.Cancel
 
 <section className="section">
   <div className="left">
-    <h3>H.RecordMetric()</h3> 
+    <h3>highlight.RecordMetric()</h3>
     <p>Record metrics from your backend to be visualized in Highlight charts.</p>
     <h6>Method Parameters</h6>
     <aside className="parameter">
       <h5>ctx <code>context.Context</code> <code>required</code></h5>
-      <p>The request context which should have highlight parameters set from H.InterceptRequest().</p>
+      <p>The request context which should have highlight parameters set from highlight.InterceptRequest().</p>
       <h5>name <code>string</code> <code>required</code></h5>
       <p>The metric name.</p>
       <h5>value <code>float64</code> <code>required</code></h5>
@@ -121,7 +121,7 @@ This allows the user kill the highlight worker by canceling their context.Cancel
     <code>
         start := time.Now()
         defer func() {
-            H.RecordMetric(
+            highlight.RecordMetric(
                 ctx, "my.operation.duration-s", time.Since(start).Seconds(),
             )
         }()
@@ -131,7 +131,7 @@ This allows the user kill the highlight worker by canceling their context.Cancel
 
 <section className="section">
   <div className="left">
-    <h3>H.InterceptRequest()</h3> 
+    <h3>highlight.InterceptRequest()</h3>
     <p>Called under the hood by our middleware web backend handlers to extract the request context.
 Use this if you are using the raw http server package and need to setup the Highlight context.</p>
     <h6>Method Parameters</h6>
@@ -159,11 +159,11 @@ Use this if you are using the raw http server package and need to setup the High
 
 <section className="section">
   <div className="left">
-    <h3>H.NewGraphqlTracer()</h3> 
+    <h3>highlight.NewGraphqlTracer()</h3>
     <p>An http middleware for tracing GraphQL servers.</p>
     <h6>Configuration</h6>
     <aside className="parameter">
-      <h5>H.NewGraphqlTracer().WithRequestFieldLogging()</h5>
+      <h5>highlight.NewGraphqlTracer().WithRequestFieldLogging()</h5>
       <p>Emits highlight logs with details of each graphql operation.</p>
     </aside>
   </div>
@@ -171,14 +171,14 @@ Use this if you are using the raw http server package and need to setup the High
     <code>
         import ghandler "github.com/99designs/gqlgen/graphql/handler"
         privateServer := ghandler.New(privategen.NewExecutableSchema(...)
-        server.Use(H.NewGraphqlTracer(string(util.PrivateGraph)).WithRequestFieldLogging())
+        server.Use(highlight.NewGraphqlTracer(string(util.PrivateGraph)).WithRequestFieldLogging())
     </code>
   </div>
 </section>
 
 <section className="section">
   <div className="left">
-    <h3>H.GraphQLRecoverFunc()</h3> 
+    <h3>highlight.GraphQLRecoverFunc()</h3>
     <p>A gqlgen recover function to capture panics.</p>
     <h6>Configuration</h6>
   </div>
@@ -186,14 +186,14 @@ Use this if you are using the raw http server package and need to setup the High
     <code>
         import ghandler "github.com/99designs/gqlgen/graphql/handler"
         privateServer := ghandler.New(privategen.NewExecutableSchema(...)
-        server.SetRecoverFunc(H.GraphQLRecoverFunc())
+        server.SetRecoverFunc(highlight.GraphQLRecoverFunc())
     </code>
   </div>
 </section>
 
 <section className="section">
   <div className="left">
-    <h3>H.GraphQLErrorPresenter()</h3> 
+    <h3>highlight.GraphQLErrorPresenter()</h3>
     <p>A gqlgen error presenter.</p>
     <h6>Configuration</h6>
     <aside className="parameter">
@@ -205,7 +205,7 @@ Use this if you are using the raw http server package and need to setup the High
     <code>
         import ghandler "github.com/99designs/gqlgen/graphql/handler"
         privateServer := ghandler.New(privategen.NewExecutableSchema(...)
-        privateServer.SetErrorPresenter(H.GraphQLErrorPresenter("private"))
+        privateServer.SetErrorPresenter(highlight.GraphQLErrorPresenter("private"))
     </code>
   </div>
 </section>

--- a/e2e/go/fiber.go
+++ b/e2e/go/fiber.go
@@ -1,22 +1,23 @@
 package main
 
 import (
+	"math/rand"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/logger"
-	H "github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/highlight/highlight/sdk/highlight-go"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 	highlightFiber "github.com/highlight/highlight/sdk/highlight-go/middleware/fiber"
 	e "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"math/rand"
 )
 
 func main() {
-	H.SetProjectID("1jdkoe52")
-	H.SetGraphqlClientAddress("https://localhost:8082/public")
-	H.SetOTLPEndpoint("http://localhost:4318")
-	H.Start()
-	defer H.Stop()
+	highlight.SetProjectID("1jdkoe52")
+	highlight.SetGraphqlClientAddress("https://localhost:8082/public")
+	highlight.SetOTLPEndpoint("http://localhost:4318")
+	highlight.Start()
+	defer highlight.Stop()
 	hlog.Init()
 
 	app := fiber.New()

--- a/highlight.io/components/QuickstartContent/backend/go/go-gqlgen.tsx
+++ b/highlight.io/components/QuickstartContent/backend/go/go-gqlgen.tsx
@@ -20,12 +20,12 @@ export const GoGqlgenContent: QuickStartContent = {
 		{
 			title: 'Add the Highlight gqlgen error handler.',
 			content:
-				'`H.NewGraphqlTracer` provides a middleware you can add to your [GraphQL](https://gqlgen.com/getting-started/) handler to automatically record and send GraphQL resolver errors to Highlight. ' +
+				'`highlight.NewGraphqlTracer` provides a middleware you can add to your [GraphQL](https://gqlgen.com/getting-started/) handler to automatically record and send GraphQL resolver errors to Highlight. ' +
 				'Calling `.WithRequestFieldLogging()` will also emit highlight logs for each graphql operation, giving you a way' +
 				'to search across all graphql requests to your backend.',
 			code: {
 				text: `import (
-  H "github.com/highlight/highlight/sdk/highlight-go"
+  "github.com/highlight/highlight/sdk/highlight-go"
 )
 
 func main() {
@@ -33,11 +33,11 @@ func main() {
   server := handler.New(...)
   // call with WithRequestFieldLogging() to emit highlight logs for each graphql operation
   // useful for tracing which graphql operations are called as part of which frontend sessions
-  server.Use(H.NewGraphqlTracer("your-backend-service-name").WithRequestFieldLogging())
+  server.Use(highlight.NewGraphqlTracer("your-backend-service-name").WithRequestFieldLogging())
   // capture panics emitted by graphql handlers in highlight
-  server.SetRecoverFunc(H.GraphQLRecoverFunc())
+  server.SetRecoverFunc(highlight.GraphQLRecoverFunc())
   // format logs on errors thrown by your graphql handlers
-  server.SetErrorPresenter(H.GraphQLErrorPresenter("my-gql-service"))
+  server.SetErrorPresenter(highlight.GraphQLErrorPresenter("my-gql-service"))
   // ...
 }`,
 				language: 'go',

--- a/highlight.io/components/QuickstartContent/backend/go/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/backend/go/shared-snippets.tsx
@@ -13,17 +13,17 @@ export const goGetSnippet: QuickStartStep = {
 export const initializeGoSdk: QuickStartStep = {
 	title: 'Initialize the Highlight Go SDK.',
 	content:
-		"`H.Start` starts a goroutine for recording and sending backend errors. Setting your project id lets Highlight record errors for background tasks and processes that aren't associated with a frontend session.",
+		"`highlight.Start` starts a goroutine for recording and sending backend errors. Setting your project id lets Highlight record errors for background tasks and processes that aren't associated with a frontend session.",
 	code: {
 		text: `import (
-  H "github.com/highlight/highlight/sdk/highlight-go"
+  "github.com/highlight/highlight/sdk/highlight-go"
 )
 
 func main() {
   // ...
-  H.SetProjectID("<YOUR_PROJECT_ID>")
-  H.Start()
-  defer H.Stop()
+  highlight.SetProjectID("<YOUR_PROJECT_ID>")
+  highlight.Start()
+  defer highlight.Stop()
   // ...
 }`,
 		language: 'go',
@@ -33,9 +33,9 @@ func main() {
 export const customGoError: QuickStartStep = {
 	title: 'Record custom errors. (optional)',
 	content:
-		'If you want to explicitly send an error to Highlight, you can use the `H.RecordError` method.',
+		'If you want to explicitly send an error to Highlight, you can use the `highlight.RecordError` method.',
 	code: {
-		text: `H.RecordError(ctx, err, attribute.String("key", "value"))`,
+		text: `highlight.RecordError(ctx, err, attribute.String("key", "value"))`,
 		language: 'go',
 	},
 }
@@ -49,10 +49,10 @@ export const verifyGoErrors: QuickStartStep = {
 export const verifyCustomError: QuickStartStep = {
 	title: 'Verify your errors are being recorded.',
 	content:
-		'Make a call to `H.RecordError` to see the resulting error in Highlight.',
+		'Make a call to `highlight.RecordError` to see the resulting error in Highlight.',
 	code: {
 		text: `func TestErrorHandler(w http.ResponseWriter, r *http.Request) {
-  H.RecordError(r.Context(), errors.New("a test error is being thrown!"))
+  highlight.RecordError(r.Context(), errors.New("a test error is being thrown!"))
 }`,
 		language: 'go',
 	},


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR removes all aliasing of the `highlight` Go SDK package in our docs and our code. The motivation for this is described in #5269

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Build passes
* Visual test on docs

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
