### PR TITLE
Replacing relative paths in stylesheets

### DIFF
--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -78,7 +78,7 @@ const (
 
 const (
 	ScriptPlaceholder = "SCRIPT_PLACEHOLDER"
-	PROXY_URL         = "https://replay-cors-proxy.highlightrun.workers.dev"
+	ProxyURL          = "https://replay-cors-proxy.highlightrun.workers.dev"
 )
 
 var DisallowedTagPrefixes = []string{
@@ -132,7 +132,7 @@ func replaceRelativePaths(body []byte, href string) []byte {
 	if err == nil {
 		base := u.Scheme + "://" + u.Host
 
-		return regexp.MustCompile(`url\(['"]\./`).ReplaceAll(body, []byte(fmt.Sprintf("url('%s?url=%s/", PROXY_URL, base)))
+		return regexp.MustCompile(`url\(['"]\./`).ReplaceAll(body, []byte(fmt.Sprintf("url('%s?url=%s/", ProxyURL, base)))
 	} else {
 		return body
 	}

--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -126,12 +126,14 @@ func (n networkFetcher) fetchStylesheetData(href string) ([]byte, error) {
 }
 
 func replaceRelativePaths(body []byte, href string) []byte {
+	const PROXY_URL string = "https://replay-cors-proxy.highlightrun.workers.dev"
+
 	u, err := url.Parse(href)
 
 	if err == nil {
 		base := u.Scheme + "://" + u.Host
 
-		return regexp.MustCompile(`url\(['"]\./`).ReplaceAll(body, []byte("url('"+base+"/"))
+		return regexp.MustCompile(`url\(['"]\./`).ReplaceAll(body, []byte("url('"+PROXY_URL+"?url="+base+"/"))
 	} else {
 		return body
 	}

--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -78,6 +78,7 @@ const (
 
 const (
 	ScriptPlaceholder = "SCRIPT_PLACEHOLDER"
+	PROXY_URL         = "https://replay-cors-proxy.highlightrun.workers.dev"
 )
 
 var DisallowedTagPrefixes = []string{
@@ -126,14 +127,12 @@ func (n networkFetcher) fetchStylesheetData(href string) ([]byte, error) {
 }
 
 func replaceRelativePaths(body []byte, href string) []byte {
-	const PROXY_URL string = "https://replay-cors-proxy.highlightrun.workers.dev"
-
 	u, err := url.Parse(href)
 
 	if err == nil {
 		base := u.Scheme + "://" + u.Host
 
-		return regexp.MustCompile(`url\(['"]\./`).ReplaceAll(body, []byte("url('"+PROXY_URL+"?url="+base+"/"))
+		return regexp.MustCompile(`url\(['"]\./`).ReplaceAll(body, []byte(fmt.Sprintf("url('%s?url=%s/", PROXY_URL, base)))
 	} else {
 		return body
 	}

--- a/e2e/nextjs/next.config.js
+++ b/e2e/nextjs/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
 	experimental: {
 		appDir: true,
 	},
-	transpilePackages: ['@highlight-run/react'],
+	// transpilePackages: ['@highlight-run/react'],
 }
 
 module.exports = withHighlightConfig(nextConfig, { uploadSourceMaps: true })

--- a/e2e/nextjs/next.config.js
+++ b/e2e/nextjs/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
 	experimental: {
 		appDir: true,
 	},
-	// transpilePackages: ['@highlight-run/react'],
+	transpilePackages: ['@highlight-run/react'],
 }
 
 module.exports = withHighlightConfig(nextConfig, { uploadSourceMaps: true })

--- a/e2e/nextjs/src/components/ErrorBoundaryButton.tsx
+++ b/e2e/nextjs/src/components/ErrorBoundaryButton.tsx
@@ -1,6 +1,9 @@
 'use client'
 
-import { ErrorBoundary, SampleBuggyButton } from '@highlight-run/react'
+import {
+	ErrorBoundary,
+	SampleBuggyButton,
+} from '@highlight-run/react/src/components'
 
 export default function ErrorBoundaryButton() {
 	return (


### PR DESCRIPTION
## Summary

closes #5182 

Relative stylesheet paths were persisting in the session viewer, leading to a lot of 404'ed requests to `app.highlight.io/some-font.ttf`

## How did you test this change?

I reproduced the issue locally.

## Are there any deployment considerations?

Nope.