### PR TITLE
fix exclusion logic

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -8278,6 +8278,7 @@ type Field {
 }
 
 enum SessionExcludedReason {
+	Initializing
 	NoActivity
 	NoUserInteractionEvents
 	NoError

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1550,6 +1550,7 @@ func (e SessionCommentType) MarshalGQL(w io.Writer) {
 type SessionExcludedReason string
 
 const (
+	SessionExcludedReasonInitializing            SessionExcludedReason = "Initializing"
 	SessionExcludedReasonNoActivity              SessionExcludedReason = "NoActivity"
 	SessionExcludedReasonNoUserInteractionEvents SessionExcludedReason = "NoUserInteractionEvents"
 	SessionExcludedReasonNoError                 SessionExcludedReason = "NoError"
@@ -1557,6 +1558,7 @@ const (
 )
 
 var AllSessionExcludedReason = []SessionExcludedReason{
+	SessionExcludedReasonInitializing,
 	SessionExcludedReasonNoActivity,
 	SessionExcludedReasonNoUserInteractionEvents,
 	SessionExcludedReasonNoError,
@@ -1565,7 +1567,7 @@ var AllSessionExcludedReason = []SessionExcludedReason{
 
 func (e SessionExcludedReason) IsValid() bool {
 	switch e {
-	case SessionExcludedReasonNoActivity, SessionExcludedReasonNoUserInteractionEvents, SessionExcludedReasonNoError, SessionExcludedReasonIgnoredUser:
+	case SessionExcludedReasonInitializing, SessionExcludedReasonNoActivity, SessionExcludedReasonNoUserInteractionEvents, SessionExcludedReasonNoError, SessionExcludedReasonIgnoredUser:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -15,6 +15,7 @@ type Field {
 }
 
 enum SessionExcludedReason {
+	Initializing
 	NoActivity
 	NoUserInteractionEvents
 	NoError


### PR DESCRIPTION
## Summary

As reported in [Intercom](https://app.intercom.com/a/inbox/gm6369ty/inbox/admin/5462337/conversation/41260?view=List), our all sessions were excluded after #5252.

This corrects the exclusion logic and adds a better reason for the default exclusion from `InitializeSession`

## How did you test this change?

Local deploy recording sessions
![image](https://github.com/highlight/highlight/assets/1351531/f4292870-1a76-4ded-8689-1d14ed7797a4)

## Are there any deployment considerations?

Monitoring session processing rates. To reprocess existing sessions, will manually reset `processed` flag.
