### PR TITLE
Add a video to canvas recording docs.

### DIFF
--- a/docs-content/general/6_product-features/1_session-replay/canvas-iframe.md
+++ b/docs-content/general/6_product-features/1_session-replay/canvas-iframe.md
@@ -3,12 +3,16 @@ title: Canvas & Iframe
 slug: canvas-iframe
 ---
 
-Highlight.io supports recording canvas elements (and therefore anything related to WebGL) as well as recording cross-origin iframes. Below is a video recording of what this looks like in action:
-
-
 ## Recording `canvas` elements
 
-[highlight.io](https://highlight.io) supports recording canvas (and therefore WebGL) elements, although due to the nature of `canvas`, there are caveats regarding the quality/fidelity of the recording. Read more about how to get started with this in our [getting started docs](../../../getting-started/3_client-sdk/7_replay-configuration/canvas.md).
+[highlight.io](https://highlight.io) supports recording canvas (and therefore WebGL) elements, although due to the nature of `canvas`, there are caveats regarding the quality/fidelity of the recording. Read more about how to get started with this in our [getting started docs](../../../getting-started/3_client-sdk/7_replay-configuration/canvas.md). Below is a video demo of what the video recording looks like:
+
+<br/>
+
+<div style={{position: "relative", paddingBottom: "64.90384615384616%", height: 0 }}>
+    <iframe src="https://www.loom.com/embed/87dd1ea89efc46f294b64363ea58cc02" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
+</div>
+
 
 ## Installing highlight.io in an `iframe`
 

--- a/docs-content/general/6_product-features/1_session-replay/canvas-iframe.md
+++ b/docs-content/general/6_product-features/1_session-replay/canvas-iframe.md
@@ -10,7 +10,7 @@ slug: canvas-iframe
 <br/>
 
 <div style={{position: "relative", paddingBottom: "64.90384615384616%", height: 0 }}>
-    <iframe src="https://www.loom.com/embed/87dd1ea89efc46f294b64363ea58cc02" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
+    <iframe src="https://www.loom.com/share/ebb971bf5fdd4aaf9ae1924e7e536fb7" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
 </div>
 
 

--- a/docs-content/general/6_product-features/1_session-replay/canvas-iframe.md
+++ b/docs-content/general/6_product-features/1_session-replay/canvas-iframe.md
@@ -10,7 +10,7 @@ slug: canvas-iframe
 <br/>
 
 <div style={{position: "relative", paddingBottom: "64.90384615384616%", height: 0 }}>
-    <iframe src="https://www.loom.com/share/ebb971bf5fdd4aaf9ae1924e7e536fb7" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
+    <iframe src="https://www.loom.com/embed/ebb971bf5fdd4aaf9ae1924e7e536fb7" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
 </div>
 
 

--- a/docs-content/general/6_product-features/1_session-replay/canvas-iframe.md
+++ b/docs-content/general/6_product-features/1_session-replay/canvas-iframe.md
@@ -3,6 +3,9 @@ title: Canvas & Iframe
 slug: canvas-iframe
 ---
 
+Highlight.io supports recording canvas elements (and therefore anything related to WebGL) as well as recording cross-origin iframes. Below is a video recording of what this looks like in action:
+
+
 ## Recording `canvas` elements
 
 [highlight.io](https://highlight.io) supports recording canvas (and therefore WebGL) elements, although due to the nature of `canvas`, there are caveats regarding the quality/fidelity of the recording. Read more about how to get started with this in our [getting started docs](../../../getting-started/3_client-sdk/7_replay-configuration/canvas.md).

--- a/docs-content/general/6_product-features/1_session-replay/canvas-iframe.md
+++ b/docs-content/general/6_product-features/1_session-replay/canvas-iframe.md
@@ -5,7 +5,7 @@ slug: canvas-iframe
 
 ## Recording `canvas` elements
 
-[highlight.io](https://highlight.io) supports recording canvas (and therefore WebGL) elements, although due to the nature of `canvas`, there are caveats regarding the quality/fidelity of the recording. Read more about how to get started with this in our [getting started docs](../../../getting-started/3_client-sdk/7_replay-configuration/canvas.md). Below is a video demo of what the video recording looks like:
+[highlight.io](https://highlight.io) supports recording canvas (and therefore WebGL) elements, although due to the nature of `canvas`, there are caveats regarding the quality/fidelity of the recording. Read more about how to get started with this in our [canvas configuration docs](../../../getting-started/3_client-sdk/7_replay-configuration/canvas.md). Below is a video demo of what the video recording looks like:
 
 <br/>
 

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
@@ -37,7 +37,13 @@ Enabling canvas recording should not have any impact on the performance your app
 
 ## WebGL Recording
 
-Highlight is able to record websites that use WebGL in the `<canvas>` element. To enable WebGL recording, enable canvas recording by following the steps above.
+Highlight is able to record websites that use WebGL in the `<canvas>` element. Below is a short demo of what a canvas experience in Highlight.io looks like:
+
+<div style={{position: "relative", paddingBottom: "64.90384615384616%", height: 0 }}>
+    <iframe src="https://www.loom.com/embed/87dd1ea89efc46f294b64363ea58cc02" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
+</div>
+
+To enable WebGL recording, enable canvas recording by following the steps above.
 
 ## Webcam Recording and Inlining Video Resources
 

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
@@ -4,19 +4,17 @@ slug: canvas
 createdAt: 2021-10-13T22:55:19.000Z
 updatedAt: 2022-09-29T18:01:58.000Z
 ---
-
-## Canvas Recording
-
-
-Highlight can now not record the contents of `<canvas>` elements. This feature is disabled by default, but can be enabled and configured via the `H.init` options. You'll want to configure the recording settings depending on the type of HTML5 Canvas application you are building. For example, a video game WebGL application may require a higher snapshotting framerate to ensure the replay has enough frames to understand what was happening.
-
-Below is a quick demo of what this looks like on the threejs.org homepage:
-
 <br/>
 
 <div style={{position: "relative", paddingBottom: "64.90384615384616%", height: 0 }}>
     <iframe src="https://www.loom.com/embed/ebb971bf5fdd4aaf9ae1924e7e536fb7" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
 </div>
+## Canvas Recording
+
+Highlight can now not record the contents of `<canvas>` elements. This feature is disabled by default, but can be enabled and configured via the `H.init` options. You'll want to configure the recording settings depending on the type of HTML5 Canvas application you are building. For example, a video game WebGL application may require a higher snapshotting framerate to ensure the replay has enough frames to understand what was happening.
+
+Below is a quick demo of what this looks like on the threejs.org homepage:
+
 
 Enable canvas recording by configuring [H.init()](../../../sdk/client.md#Hinit) in the following way:
 

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
@@ -40,7 +40,7 @@ Enabling canvas recording should not have any impact on the performance your app
 Highlight is able to record websites that use WebGL in the `<canvas>` element. Below is a short demo of what a canvas experience in Highlight.io looks like:
 
 <div style={{position: "relative", paddingBottom: "64.90384615384616%", height: 0 }}>
-    <iframe src="https://www.loom.com/embed/87dd1ea89efc46f294b64363ea58cc02" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
+    <iframe src="https://www.loom.com/share/ebb971bf5fdd4aaf9ae1924e7e536fb7" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
 </div>
 
 To enable WebGL recording, enable canvas recording by following the steps above.

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
@@ -39,8 +39,10 @@ Enabling canvas recording should not have any impact on the performance your app
 
 Highlight is able to record websites that use WebGL in the `<canvas>` element. Below is a short demo of what a canvas experience in Highlight.io looks like:
 
+<br/>
+
 <div style={{position: "relative", paddingBottom: "64.90384615384616%", height: 0 }}>
-    <iframe src="https://www.loom.com/share/ebb971bf5fdd4aaf9ae1924e7e536fb7" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
+    <iframe src="https://www.loom.com/embed/ebb971bf5fdd4aaf9ae1924e7e536fb7" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
 </div>
 
 To enable WebGL recording, enable canvas recording by following the steps above.

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
@@ -7,7 +7,16 @@ updatedAt: 2022-09-29T18:01:58.000Z
 
 ## Canvas Recording
 
+
 Highlight can now not record the contents of `<canvas>` elements. This feature is disabled by default, but can be enabled and configured via the `H.init` options. You'll want to configure the recording settings depending on the type of HTML5 Canvas application you are building. For example, a video game WebGL application may require a higher snapshotting framerate to ensure the replay has enough frames to understand what was happening.
+
+Below is a quick demo of what this looks like on the threejs.org homepage:
+
+<br/>
+
+<div style={{position: "relative", paddingBottom: "64.90384615384616%", height: 0 }}>
+    <iframe src="https://www.loom.com/embed/ebb971bf5fdd4aaf9ae1924e7e536fb7" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
+</div>
 
 Enable canvas recording by configuring [H.init()](../../../sdk/client.md#Hinit) in the following way:
 
@@ -39,11 +48,6 @@ Enabling canvas recording should not have any impact on the performance your app
 
 Highlight is able to record websites that use WebGL in the `<canvas>` element. Below is a short demo of what a canvas experience in Highlight.io looks like:
 
-<br/>
-
-<div style={{position: "relative", paddingBottom: "64.90384615384616%", height: 0 }}>
-    <iframe src="https://www.loom.com/embed/ebb971bf5fdd4aaf9ae1924e7e536fb7" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe>
-</div>
 
 To enable WebGL recording, enable canvas recording by following the steps above.
 

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
@@ -13,9 +13,6 @@ updatedAt: 2022-09-29T18:01:58.000Z
 
 Highlight can now not record the contents of `<canvas>` elements. This feature is disabled by default, but can be enabled and configured via the `H.init` options. You'll want to configure the recording settings depending on the type of HTML5 Canvas application you are building. For example, a video game WebGL application may require a higher snapshotting framerate to ensure the replay has enough frames to understand what was happening.
 
-Below is a quick demo of what this looks like on the threejs.org homepage:
-
-
 Enable canvas recording by configuring [H.init()](../../../sdk/client.md#Hinit) in the following way:
 
 ```javascript
@@ -44,8 +41,7 @@ Enabling canvas recording should not have any impact on the performance your app
 
 ## WebGL Recording
 
-Highlight is able to record websites that use WebGL in the `<canvas>` element. Below is a short demo of what a canvas experience in Highlight.io looks like:
-
+Highlight is able to record websites that use WebGL in the `<canvas>` element. 
 
 To enable WebGL recording, enable canvas recording by following the steps above.
 


### PR DESCRIPTION
## Summary
This adds a short loom video to our canvas recording docs. 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
Click test + watched the video.

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
n/a

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
