### PR TITLE
Add option to redact specific request/response body keys

### DIFF
--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/recording-network-requests-and-responses.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/recording-network-requests-and-responses.md
@@ -56,7 +56,7 @@ Out of the box, Highlight will not record these URLs:
 
 If you are dealing with sensitive data or want to go the allowlist approach then you can configure `networkRecording.headerKeysToRecord` and `networkRecording.bodyKeysToRecord`. Using these 2 configs, you'll be able to explicitly define which header/body keys to record.
 
-You can also redact specific headers by using `networkRecording.networkHeadersToRedact` and `networkRecoding.networkBodyKeysToRedact`.
+You can also redact specific headers by using `networkRecording.networkHeadersToRedact` and redact specific keys in the request/response body with `networkRecoding.networkBodyKeysToRedact`.
 
 This configuration is only available for `highlight.run` versions newer than `4.1.0`.
 

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/recording-network-requests-and-responses.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/recording-network-requests-and-responses.md
@@ -56,6 +56,8 @@ Out of the box, Highlight will not record these URLs:
 
 If you are dealing with sensitive data or want to go the allowlist approach then you can configure `networkRecording.headerKeysToRecord` and `networkRecording.bodyKeysToRecord`. Using these 2 configs, you'll be able to explicitly define which header/body keys to record.
 
+You can also redact specific headers by using `networkRecording.networkHeadersToRedact` and `networkRecoding.networkBodyKeysToRedact`.
+
 This configuration is only available for `highlight.run` versions newer than `4.1.0`.
 
 ## API

--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -188,7 +188,7 @@ export class FirstLoadListeners {
 
 			sThis.networkBodyKeysToRecord =
 				options.networkRecording?.bodyKeysToRecord
-			// `headerKeysToRecord` override `networkHeadersToRedact`.
+			// `bodyKeysToRecord` override `networkBodyKeysToRedact`.
 			if (sThis.networkBodyKeysToRecord) {
         sThis.networkBodyKeysToRedact = []
 				sThis.networkBodyKeysToRecord =

--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -162,7 +162,7 @@ export class FirstLoadListeners {
 				options.networkRecording?.networkHeadersToRedact?.map(
 					(header) => header.toLowerCase(),
 				) || []
-				sThis.networkBodyKeysToRedact =
+			sThis.networkBodyKeysToRedact =
 				options.networkRecording?.networkBodyKeysToRedact?.map(
 					(bodyKey) => bodyKey.toLowerCase(),
 				) || []
@@ -190,7 +190,7 @@ export class FirstLoadListeners {
 				options.networkRecording?.bodyKeysToRecord
 			// `bodyKeysToRecord` override `networkBodyKeysToRedact`.
 			if (sThis.networkBodyKeysToRecord) {
-        sThis.networkBodyKeysToRedact = []
+				sThis.networkBodyKeysToRedact = []
 				sThis.networkBodyKeysToRecord =
 					sThis.networkBodyKeysToRecord.map((key) =>
 						key.toLocaleLowerCase(),

--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -34,6 +34,7 @@ export class FirstLoadListeners {
 	fetchNetworkContents!: RequestResponsePair[]
 	tracingOrigins!: boolean | (string | RegExp)[]
 	networkHeadersToRedact!: string[]
+	networkBodyKeysToRedact: string[] | undefined
 	networkBodyKeysToRecord: string[] | undefined
 	networkHeaderKeysToRecord: string[] | undefined
 	urlBlocklist!: string[]
@@ -138,6 +139,7 @@ export class FirstLoadListeners {
 			sThis.disableNetworkRecording = options?.disableNetworkRecording
 			sThis.enableRecordingNetworkContents = false
 			sThis.networkHeadersToRedact = []
+			sThis.networkBodyKeysToRedact = []
 			sThis.urlBlocklist = []
 			sThis.networkBodyKeysToRecord = []
 			sThis.networkBodyKeysToRecord = []
@@ -145,6 +147,7 @@ export class FirstLoadListeners {
 			sThis.disableNetworkRecording = !options.networkRecording
 			sThis.enableRecordingNetworkContents = false
 			sThis.networkHeadersToRedact = []
+			sThis.networkBodyKeysToRedact = []
 			sThis.urlBlocklist = []
 		} else {
 			if (options.networkRecording?.enabled !== undefined) {
@@ -158,6 +161,10 @@ export class FirstLoadListeners {
 			sThis.networkHeadersToRedact =
 				options.networkRecording?.networkHeadersToRedact?.map(
 					(header) => header.toLowerCase(),
+				) || []
+				sThis.networkBodyKeysToRedact =
+				options.networkRecording?.networkBodyKeysToRedact?.map(
+					(bodyKey) => bodyKey.toLowerCase(),
 				) || []
 			sThis.urlBlocklist =
 				options.networkRecording?.urlBlocklist?.map((url) =>
@@ -181,8 +188,9 @@ export class FirstLoadListeners {
 
 			sThis.networkBodyKeysToRecord =
 				options.networkRecording?.bodyKeysToRecord
-
+			// `headerKeysToRecord` override `networkHeadersToRedact`.
 			if (sThis.networkBodyKeysToRecord) {
+        sThis.networkBodyKeysToRedact = []
 				sThis.networkBodyKeysToRecord =
 					sThis.networkBodyKeysToRecord.map((key) =>
 						key.toLocaleLowerCase(),
@@ -203,6 +211,7 @@ export class FirstLoadListeners {
 						sThis.fetchNetworkContents.push(requestResponsePair)
 					},
 					headersToRedact: sThis.networkHeadersToRedact,
+					bodyKeysToRedact: sThis.networkBodyKeysToRedact,
 					backendUrl: sThis._backendUrl,
 					tracingOrigins: sThis.tracingOrigins,
 					urlBlocklist: sThis.urlBlocklist,

--- a/sdk/client/src/listeners/network-listener/network-listener.ts
+++ b/sdk/client/src/listeners/network-listener/network-listener.ts
@@ -12,7 +12,7 @@ type NetworkListenerArguments = {
 	xhrCallback: NetworkListenerCallback
 	fetchCallback: NetworkListenerCallback
 	headersToRedact: string[]
-  bodyKeysToRedact: string[]
+	bodyKeysToRedact: string[]
 	backendUrl: string
 	tracingOrigins: boolean | (string | RegExp)[]
 	urlBlocklist: string[]
@@ -23,7 +23,7 @@ export const NetworkListener = ({
 	xhrCallback,
 	fetchCallback,
 	headersToRedact,
-  bodyKeysToRedact,
+	bodyKeysToRedact,
 	backendUrl,
 	tracingOrigins,
 	urlBlocklist,
@@ -45,7 +45,7 @@ export const NetworkListener = ({
 		tracingOrigins,
 		urlBlocklist,
 		sessionSecureID,
-    bodyKeysToRedact,
+		bodyKeysToRedact,
 		bodyKeysToRecord,
 	)
 	const removeFetchListener = FetchListener(
@@ -62,7 +62,7 @@ export const NetworkListener = ({
 		tracingOrigins,
 		urlBlocklist,
 		sessionSecureID,
-    bodyKeysToRedact,
+		bodyKeysToRedact,
 		bodyKeysToRecord,
 	)
 

--- a/sdk/client/src/listeners/network-listener/network-listener.ts
+++ b/sdk/client/src/listeners/network-listener/network-listener.ts
@@ -12,6 +12,7 @@ type NetworkListenerArguments = {
 	xhrCallback: NetworkListenerCallback
 	fetchCallback: NetworkListenerCallback
 	headersToRedact: string[]
+  bodyKeysToRedact: string[]
 	backendUrl: string
 	tracingOrigins: boolean | (string | RegExp)[]
 	urlBlocklist: string[]
@@ -22,6 +23,7 @@ export const NetworkListener = ({
 	xhrCallback,
 	fetchCallback,
 	headersToRedact,
+  bodyKeysToRedact,
 	backendUrl,
 	tracingOrigins,
 	urlBlocklist,
@@ -43,6 +45,7 @@ export const NetworkListener = ({
 		tracingOrigins,
 		urlBlocklist,
 		sessionSecureID,
+    bodyKeysToRedact,
 		bodyKeysToRecord,
 	)
 	const removeFetchListener = FetchListener(
@@ -59,6 +62,7 @@ export const NetworkListener = ({
 		tracingOrigins,
 		urlBlocklist,
 		sessionSecureID,
+    bodyKeysToRedact,
 		bodyKeysToRecord,
 	)
 

--- a/sdk/client/src/listeners/network-listener/utils/fetch-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/fetch-listener.ts
@@ -27,6 +27,7 @@ export const FetchListener = (
 	tracingOrigins: boolean | (string | RegExp)[],
 	urlBlocklist: string[],
 	sessionSecureID: string,
+  bodyKeysToRedact?: string[],
 	bodyKeysToRecord?: string[],
 ) => {
 	const originalFetch = window._fetchProxy
@@ -65,6 +66,7 @@ export const FetchListener = (
 			)
 			request.body = getBodyThatShouldBeRecorded(
 				init?.body,
+        bodyKeysToRedact,
 				bodyKeysToRecord,
 				init?.headers,
 			)
@@ -76,6 +78,7 @@ export const FetchListener = (
 			request,
 			callback,
 			shouldRecordHeaderAndBody,
+      bodyKeysToRedact,
 			bodyKeysToRecord,
 		)
 		return responsePromise
@@ -117,6 +120,7 @@ const logRequest = (
 	requestPayload: HighlightRequest,
 	callback: NetworkListenerCallback,
 	shouldRecordHeaderAndBody: boolean,
+  bodyKeysToRedact?: string[],
 	bodyKeysToRecord?: string[],
 ) => {
 	const onPromiseResolveHandler = async (response: Response | Error) => {
@@ -167,6 +171,7 @@ const logRequest = (
 						text = result
 						text = getBodyThatShouldBeRecorded(
 							text,
+              bodyKeysToRedact,
 							bodyKeysToRecord,
 							response.headers,
 						)

--- a/sdk/client/src/listeners/network-listener/utils/fetch-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/fetch-listener.ts
@@ -27,7 +27,7 @@ export const FetchListener = (
 	tracingOrigins: boolean | (string | RegExp)[],
 	urlBlocklist: string[],
 	sessionSecureID: string,
-  bodyKeysToRedact?: string[],
+	bodyKeysToRedact?: string[],
 	bodyKeysToRecord?: string[],
 ) => {
 	const originalFetch = window._fetchProxy
@@ -66,7 +66,7 @@ export const FetchListener = (
 			)
 			request.body = getBodyThatShouldBeRecorded(
 				init?.body,
-        bodyKeysToRedact,
+				bodyKeysToRedact,
 				bodyKeysToRecord,
 				init?.headers,
 			)
@@ -78,7 +78,7 @@ export const FetchListener = (
 			request,
 			callback,
 			shouldRecordHeaderAndBody,
-      bodyKeysToRedact,
+			bodyKeysToRedact,
 			bodyKeysToRecord,
 		)
 		return responsePromise
@@ -120,7 +120,7 @@ const logRequest = (
 	requestPayload: HighlightRequest,
 	callback: NetworkListenerCallback,
 	shouldRecordHeaderAndBody: boolean,
-  bodyKeysToRedact?: string[],
+	bodyKeysToRedact?: string[],
 	bodyKeysToRecord?: string[],
 ) => {
 	const onPromiseResolveHandler = async (response: Response | Error) => {
@@ -171,7 +171,7 @@ const logRequest = (
 						text = result
 						text = getBodyThatShouldBeRecorded(
 							text,
-              bodyKeysToRedact,
+							bodyKeysToRedact,
 							bodyKeysToRecord,
 							response.headers,
 						)

--- a/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
@@ -281,7 +281,7 @@ export const getBodyThatShouldBeRecorded = (
 				bodyData = JSON.stringify(json)
 			} catch {}
 		}
-		
+
 		if (bodyKeysToRecord) {
 			try {
 				const json = JSON.parse(bodyData)

--- a/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
@@ -25,7 +25,7 @@ export const XHRListener = (
 	tracingOrigins: boolean | (string | RegExp)[],
 	urlBlocklist: string[],
 	sessionSecureID: string,
-  bodyKeysToRedact?: string[],
+	bodyKeysToRedact?: string[],
 	bodyKeysToRecord?: string[],
 ) => {
 	const XHR = XMLHttpRequest.prototype
@@ -95,7 +95,7 @@ export const XHRListener = (
 				if (bodyData) {
 					requestModel['body'] = getBodyThatShouldBeRecorded(
 						bodyData,
-            bodyKeysToRedact,
+						bodyKeysToRedact,
 						bodyKeysToRecord,
 						requestModel.headers,
 					)
@@ -133,7 +133,7 @@ export const XHRListener = (
 					if (bodyData) {
 						requestModel['body'] = getBodyThatShouldBeRecorded(
 							bodyData,
-              bodyKeysToRedact,
+							bodyKeysToRedact,
 							bodyKeysToRecord,
 							responseModel.headers,
 						)
@@ -143,7 +143,7 @@ export const XHRListener = (
 				if (this.responseType === '' || this.responseType === 'text') {
 					responseModel['body'] = getBodyThatShouldBeRecorded(
 						this.responseText,
-            bodyKeysToRedact,
+						bodyKeysToRedact,
 						bodyKeysToRecord,
 						responseModel.headers,
 					)
@@ -154,7 +154,7 @@ export const XHRListener = (
 					const response = await blob.text()
 					responseModel['body'] = getBodyThatShouldBeRecorded(
 						response,
-            bodyKeysToRedact,
+						bodyKeysToRedact,
 						bodyKeysToRecord,
 						responseModel.headers,
 					)
@@ -163,7 +163,7 @@ export const XHRListener = (
 					try {
 						responseModel['body'] = getBodyThatShouldBeRecorded(
 							this.response,
-              bodyKeysToRedact,
+							bodyKeysToRedact,
 							bodyKeysToRecord,
 							responseModel.headers,
 						)
@@ -247,7 +247,7 @@ const BODY_SIZE_LIMITS = {
 
 export const getBodyThatShouldBeRecorded = (
 	bodyData: any,
-  bodyKeysToRedact?: string[],
+	bodyKeysToRedact?: string[],
 	bodyKeysToRecord?: string[],
 	headers?: Headers | { [key: string]: string },
 ) => {
@@ -267,35 +267,35 @@ export const getBodyThatShouldBeRecorded = (
 			DEFAULT_BODY_LIMIT
 	}
 
-  if (bodyData) {
-    if (bodyKeysToRedact) {
-      try {
-        const json = JSON.parse(bodyData)
+	if (bodyData) {
+		if (bodyKeysToRedact) {
+			try {
+				const json = JSON.parse(bodyData)
 
-        Object.keys(json).forEach((key) => {
-          if (bodyKeysToRedact.includes(key.toLocaleLowerCase())) {
-            json[key] = '[REDACTED]'
-          }
-        })
+				Object.keys(json).forEach((key) => {
+					if (bodyKeysToRedact.includes(key.toLocaleLowerCase())) {
+						json[key] = '[REDACTED]'
+					}
+				})
 
-        bodyData = JSON.stringify(json)
-      } catch {}
-    }
-    
-    if (bodyKeysToRecord) {
-      try {
-        const json = JSON.parse(bodyData)
+				bodyData = JSON.stringify(json)
+			} catch {}
+		}
+		
+		if (bodyKeysToRecord) {
+			try {
+				const json = JSON.parse(bodyData)
 
-        Object.keys(json).forEach((key) => {
-          if (!bodyKeysToRecord.includes(key.toLocaleLowerCase())) {
-            json[key] = '[REDACTED]'
-          }
-        })
+				Object.keys(json).forEach((key) => {
+					if (!bodyKeysToRecord.includes(key.toLocaleLowerCase())) {
+						json[key] = '[REDACTED]'
+					}
+				})
 
-        bodyData = JSON.stringify(json)
-      } catch {}
-    }
-  }
+				bodyData = JSON.stringify(json)
+			} catch {}
+		}
+	}
 
 	try {
 		bodyData = bodyData.slice(0, bodyLimit)

--- a/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
@@ -25,6 +25,7 @@ export const XHRListener = (
 	tracingOrigins: boolean | (string | RegExp)[],
 	urlBlocklist: string[],
 	sessionSecureID: string,
+  bodyKeysToRedact?: string[],
 	bodyKeysToRecord?: string[],
 ) => {
 	const XHR = XMLHttpRequest.prototype
@@ -94,6 +95,7 @@ export const XHRListener = (
 				if (bodyData) {
 					requestModel['body'] = getBodyThatShouldBeRecorded(
 						bodyData,
+            bodyKeysToRedact,
 						bodyKeysToRecord,
 						requestModel.headers,
 					)
@@ -131,6 +133,7 @@ export const XHRListener = (
 					if (bodyData) {
 						requestModel['body'] = getBodyThatShouldBeRecorded(
 							bodyData,
+              bodyKeysToRedact,
 							bodyKeysToRecord,
 							responseModel.headers,
 						)
@@ -140,6 +143,7 @@ export const XHRListener = (
 				if (this.responseType === '' || this.responseType === 'text') {
 					responseModel['body'] = getBodyThatShouldBeRecorded(
 						this.responseText,
+            bodyKeysToRedact,
 						bodyKeysToRecord,
 						responseModel.headers,
 					)
@@ -150,6 +154,7 @@ export const XHRListener = (
 					const response = await blob.text()
 					responseModel['body'] = getBodyThatShouldBeRecorded(
 						response,
+            bodyKeysToRedact,
 						bodyKeysToRecord,
 						responseModel.headers,
 					)
@@ -158,6 +163,7 @@ export const XHRListener = (
 					try {
 						responseModel['body'] = getBodyThatShouldBeRecorded(
 							this.response,
+              bodyKeysToRedact,
 							bodyKeysToRecord,
 							responseModel.headers,
 						)
@@ -241,6 +247,7 @@ const BODY_SIZE_LIMITS = {
 
 export const getBodyThatShouldBeRecorded = (
 	bodyData: any,
+  bodyKeysToRedact?: string[],
 	bodyKeysToRecord?: string[],
 	headers?: Headers | { [key: string]: string },
 ) => {
@@ -260,19 +267,35 @@ export const getBodyThatShouldBeRecorded = (
 			DEFAULT_BODY_LIMIT
 	}
 
-	if (bodyKeysToRecord && bodyData) {
-		try {
-			const json = JSON.parse(bodyData)
+  if (bodyData) {
+    if (bodyKeysToRedact) {
+      try {
+        const json = JSON.parse(bodyData)
 
-			Object.keys(json).forEach((header) => {
-				if (!bodyKeysToRecord.includes(header.toLocaleLowerCase())) {
-					json[header] = '[REDACTED]'
-				}
-			})
+        Object.keys(json).forEach((key) => {
+          if (bodyKeysToRedact.includes(key.toLocaleLowerCase())) {
+            json[key] = '[REDACTED]'
+          }
+        })
 
-			bodyData = JSON.stringify(json)
-		} catch {}
-	}
+        bodyData = JSON.stringify(json)
+      } catch {}
+    }
+    
+    if (bodyKeysToRecord) {
+      try {
+        const json = JSON.parse(bodyData)
+
+        Object.keys(json).forEach((key) => {
+          if (!bodyKeysToRecord.includes(key.toLocaleLowerCase())) {
+            json[key] = '[REDACTED]'
+          }
+        })
+
+        bodyData = JSON.stringify(json)
+      } catch {}
+    }
+  }
 
 	try {
 		bodyData = bodyData.slice(0, bodyLimit)

--- a/sdk/client/src/types/client.ts
+++ b/sdk/client/src/types/client.ts
@@ -50,8 +50,8 @@ export declare type NetworkRecordingOptions = {
 	networkHeadersToRedact?: string[]
 	/**
 	 * Specifies the keys for request/response JSON body that should not be recorded.
-   * The body value is replaced with '[REDACTED]'.
-   * These keys are case-insensitive.
+	 * The body value is replaced with '[REDACTED]'.
+	 * These keys are case-insensitive.
 	 * `enabled` and `recordHeadersAndBody` need to be `true`. Otherwise this option will be ignored.
 	 * @example bodyKeysToRedact: ['secret-token', 'plain-text-password']
 	 * // Only `body.id` and `body.pageNumber` will be recorded.
@@ -62,7 +62,7 @@ export declare type NetworkRecordingOptions = {
 	 * 'plain-text-password': 'password123',
 	 * }
 	 */
-  networkBodyKeysToRedact?: string[]
+	networkBodyKeysToRedact?: string[]
 	/**
 	 * URLs to not record headers and bodies for.
 	 * To disable recording headers and bodies for all URLs, set `recordHeadersAndBody` to `false`.
@@ -85,7 +85,7 @@ export declare type NetworkRecordingOptions = {
 	headerKeysToRecord?: string[]
 	/**
 	 * Specifies the keys for request/response JSON body to record.
-   * This option will override `networkBodyKeysToRedact` if specified.
+	 * This option will override `networkBodyKeysToRedact` if specified.
 	 * `enabled` and `recordHeadersAndBody` need to be `true`. Otherwise this option will be ignored.
 	 * @example bodyKeysToRecord: ['id', 'pageNumber']
 	 * // Only `body.id` and `body.pageNumber` will be recorded.

--- a/sdk/client/src/types/client.ts
+++ b/sdk/client/src/types/client.ts
@@ -49,6 +49,21 @@ export declare type NetworkRecordingOptions = {
 	 */
 	networkHeadersToRedact?: string[]
 	/**
+	 * Specifies the keys for request/response JSON body that should not be recorded.
+   * The body value is replaced with '[REDACTED]'.
+   * These keys are case-insensitive.
+	 * `enabled` and `recordHeadersAndBody` need to be `true`. Otherwise this option will be ignored.
+	 * @example bodyKeysToRedact: ['secret-token', 'plain-text-password']
+	 * // Only `body.id` and `body.pageNumber` will be recorded.
+	 * body = {
+	 * 'id': '123',
+	 * 'pageNumber': '1',
+	 * 'secret-token': 'super-sensitive-value',
+	 * 'plain-text-password': 'password123',
+	 * }
+	 */
+  networkBodyKeysToRedact?: string[]
+	/**
 	 * URLs to not record headers and bodies for.
 	 * To disable recording headers and bodies for all URLs, set `recordHeadersAndBody` to `false`.
 	 * @default ['https://www.googleapis.com/identitytoolkit', 'https://securetoken.googleapis.com']
@@ -69,7 +84,8 @@ export declare type NetworkRecordingOptions = {
 	 */
 	headerKeysToRecord?: string[]
 	/**
-	 * Specifies the keys for request/response headers to record.
+	 * Specifies the keys for request/response JSON body to record.
+   * This option will override `networkBodyKeysToRedact` if specified.
 	 * `enabled` and `recordHeadersAndBody` need to be `true`. Otherwise this option will be ignored.
 	 * @example bodyKeysToRecord: ['id', 'pageNumber']
 	 * // Only `body.id` and `body.pageNumber` will be recorded.

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -179,3 +179,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 
 - Supports recording inlined `<video>` elements such as webcams or `src="blob://...`.
 - Limits the size of network request bodies recorded to prevent replay-time crashes.
+
+## 6.3.0
+
+### Minor Changes
+
+- Support the option to redact specific request/response body keys while recording all others.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "6.2.0",
+	"version": "6.3.0",
 	"scripts": {
 		"build": "node scripts/version.mjs && rollup -c",
 		"dev": "node scripts/version.mjs && rollup -c -w",


### PR DESCRIPTION
## Summary
Add option to specify specific keys in the request/response body to redact and to record all others by default.

## How did you test this change?
Not tested