### PR TITLE
fix incorrect asset requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 backend/private-graph/graph/schema.resolvers.go linguist-generated=false
 backend/public-graph/graph/schema.resolvers.go linguist-generated=false
 frontend/src/graph/generated/* linguist-generated=true
+frontend/src/__generated/* linguist-generated=true
 client/src/graph/generated/* linguist-generated=true
 go.sum linguist-generated=true
 go.mod linguist-generated=true

--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/redis"
 	"io"
 	"net/http"
 	"net/url"
@@ -18,18 +17,18 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-	"gorm.io/gorm/clause"
-
 	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/redis"
 	"github.com/highlight-run/highlight/backend/storage"
 	"github.com/lukasbob/srcset"
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 	"github.com/tdewolff/parse/css"
+	"golang.org/x/sync/errgroup"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type EventType int

--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/redis"
 	"github.com/highlight-run/highlight/backend/storage"
 	"github.com/highlight-run/highlight/backend/util"
 	e "github.com/pkg/errors"
@@ -228,7 +229,7 @@ func TestSnapshot_ReplaceAssets(t *testing.T) {
 	if storageClient, err = storage.NewFSClient(ctx, "https://test.highlight.io", "/tmp/test"); err != nil {
 		log.WithContext(ctx).Fatalf("error creating filesystem storage client: %v", err)
 	}
-	if err := snapshot.ReplaceAssets(ctx, 1, storageClient, DB); err != nil {
+	if err := snapshot.ReplaceAssets(ctx, 1, storageClient, DB, redis.NewClient()); err != nil {
 		t.Fatalf("failed to replace assets %+v", err)
 	}
 

--- a/backend/migrations/cmd/unexclude-sessions-opensearch/main.go
+++ b/backend/migrations/cmd/unexclude-sessions-opensearch/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"os"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/opensearch"
+	public "github.com/highlight-run/highlight/backend/public-graph/graph"
+)
+
+func main() {
+	ctx := context.TODO()
+	log.WithContext(ctx).Info("setting up db")
+	db, err := model.SetupDB(ctx, os.Getenv("PSQL_DB"))
+	if err != nil {
+		log.WithContext(ctx).Fatalf("error setting up db: %+v", err)
+	}
+
+	sqlDB, err := db.DB()
+
+	if err != nil {
+		log.WithContext(ctx).Fatalf("error getting raw db: %+v", err)
+	}
+
+	if err := sqlDB.Ping(); err != nil {
+		log.WithContext(ctx).Fatalf("error pinging db: %+v", err)
+	}
+
+	opensearchClient, err := opensearch.NewOpensearchClient(nil)
+	if err != nil {
+		log.WithContext(ctx).Fatalf("error creating opensearch client: %v", err)
+	}
+
+	r := public.Resolver{
+		DB:         db,
+		OpenSearch: opensearchClient,
+	}
+	log.WithContext(ctx).Infof("starting query")
+
+	// find all distinct session ids from model.SessionComment
+	var sessionIDs []int
+	if err := r.DB.Debug().
+		Model(&model.Session{}).
+		Where("excluded is false and created_at > ?", time.Now().Add(-4*time.Hour).UTC()).
+		Pluck("id", &sessionIDs).
+		Error; err != nil {
+		log.WithContext(ctx).Fatalf("error getting sessions: %+v", err)
+	}
+
+	log.WithContext(ctx).Infof("found %d distinct session ids", len(sessionIDs))
+	log.WithContext(ctx).Infof("starting an opensearch update")
+
+	for _, sessionID := range sessionIDs {
+		if err := r.OpenSearch.Update(
+			opensearch.IndexSessions,
+			sessionID,
+			map[string]interface{}{"Excluded": false},
+		); err != nil {
+			log.WithContext(ctx).Fatalf("error updating session %d: %+v", sessionID, err)
+		}
+	}
+	if err := r.OpenSearch.Close(); err != nil {
+		log.WithContext(ctx).WithError(err).Fatal("failed to close opensearch")
+	}
+}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2681,7 +2681,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 					if projectID == 1 || projectID == 1344 || projectID == 5403 {
 						assetsSpan, _ := tracer.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
 							tracer.ResourceName("go.parseEvents.replaceAssets"), tracer.Tag("project_id", projectID), tracer.Tag("session_secure_id", sessionSecureID))
-						err = snapshot.ReplaceAssets(ctx, projectID, r.StorageClient, r.DB)
+						err = snapshot.ReplaceAssets(ctx, projectID, r.StorageClient, r.DB, r.Redis)
 						assetsSpan.Finish()
 						if err != nil {
 							log.WithContext(ctx).Error(e.Wrap(err, "error replacing assets"))

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -27,7 +27,7 @@ type Client struct {
 	Cache       *cache.Cache
 }
 
-const LockPollDuration = 100 * time.Millisecond
+const LockPollInterval = 100 * time.Millisecond
 
 var (
 	ServerAddr = os.Getenv("REDIS_EVENTS_STAGING_ENDPOINT")
@@ -442,7 +442,7 @@ func (r *Client) AcquireLock(ctx context.Context, key string, timeout time.Durat
 		if cmd.Err() != nil {
 			return nil
 		}
-		time.Sleep(LockPollDuration)
+		time.Sleep(LockPollInterval)
 	}
 	return errors.New("timed out acquiring lock")
 }

--- a/frontend/src/pages/Buttons/CanvasV2.tsx
+++ b/frontend/src/pages/Buttons/CanvasV2.tsx
@@ -119,7 +119,7 @@ export const CanvasPage = function () {
 						preload="metadata"
 						autoPlay={true}
 						crossOrigin="anonymous"
-						src="https://static.highlight.io/dev/BigBuckBunny.mp4"
+						src="https://static.highlight.io/dev/BigBuckBunny.mp4?expires=123&signature=a1b2c3&x-amz-security-token=foo&bar=baz"
 					></video>
 				</Box>
 				<Box border="dividerStrong">


### PR DESCRIPTION
## Summary

Fix logic that would incorrectly fail to inline media assets. 
For urls that were truncated ie. `https://foo.com/example?key=value&signature=bar -> https://foo.com/example?key=value`
the replacement would search for the truncated string, which would not exist.
The http request would also be made to the second string, which would return a 403.

## How did you test this change?

Recording a session locally from the customer whose assets were not inlined
![image](https://github.com/highlight/highlight/assets/1351531/c0dcc553-e1e1-434a-b622-c03b28c4e33d)

![image](https://github.com/highlight/highlight/assets/1351531/c34b24cb-dce1-4d9e-a12b-96d4c70f8cee)

## Are there any deployment considerations?

No
