### PR TITLE
update mui injection logic for synder

### DIFF
--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -21,32 +21,23 @@
 	"themeColor": "#5629c6",
 	"filesIgnored": ["**/**.css.ts", "**/**.scss"],
 	"environment": {
-		"REACT_APP_FIREBASE_CONFIG_OBJECT": {
-			"type": "expression",
-			"value": "JSON.stringify({apiKey: 'AIzaSyD7g86A3EzEKmoE7aZ04Re3HZ0B4bWlL68',authDomain: 'auth.highlight.run',databaseURL: 'https://highlight-f5c5b.firebaseio.com',projectId: 'highlight-f5c5b',storageBucket: 'highlight-f5c5b.appspot.com',messagingSenderId: '263184175068',appId: '1:263184175068:web:f8190c20320087d1c6c919',})"
-		},
-		"REACT_APP_COMMIT_SHA": {
-			"type": "expression",
-			"value": "Reflame.gitCommitSha"
-		},
-		"REACT_APP_PRIVATE_GRAPH_URI": "https://pri.highlight.run",
-		"REACT_APP_ONPREM": false,
-		"REACT_APP_FRONTEND_URI": {
-			"type": "expression",
-			"value": "window.location.origin"
-		},
-		"REACT_APP_FRONTEND_ORG": 1,
-		"REACT_APP_PUBLIC_GRAPH_URI": "https://pub.highlight.run",
+		"REACT_APP_FIREBASE_CONFIG_OBJECT": "{\n    apiKey: 'AIzaSyD7g86A3EzEKmoE7aZ04Re3HZ0B4bWlL68',\n    authDomain: 'auth.highlight.run',\n    databaseURL: 'https://highlight-f5c5b.firebaseio.com',\n    projectId: 'highlight-f5c5b',\n    storageBucket: 'highlight-f5c5b.appspot.com',\n    messagingSenderId: '263184175068',\n    appId: '1:263184175068:web:f8190c20320087d1c6c919',\n}",
+		"REACT_APP_COMMIT_SHA": "asdf",
+		"REACT_APP_PRIVATE_GRAPH_URI": "https://localhost:8082/private",
+		"REACT_APP_ONPREM": "false",
+		"REACT_APP_FRONTEND_URI": "https://localhost:3000",
+		"REACT_APP_FRONTEND_ORG": "1",
+		"REACT_APP_PUBLIC_GRAPH_URI": "https://localhost:8082/public",
 		"REACT_APP_AUTH_MODE": null,
-		"SLACK_CLIENT_ID": null,
-		"REACT_APP_STRIPE_API_PK": null,
-		"DEMO_ERROR_URL": null,
-		"CLICKUP_CLIENT_ID": null,
-		"DISCORD_CLIENT_ID": null,
-		"REACT_APP_FRONT_INTEGRATION_CLIENT_ID": null,
-		"HEIGHT_CLIENT_ID": null,
-		"DEMO_SESSION_URL": null,
-		"LINEAR_CLIENT_ID": null
+		"SLACK_CLIENT_ID": "1354469824468.1868913469441",
+		"REACT_APP_STRIPE_API_PK": "pk_test_51Hlqh1Gz4ry65q42v4lYEnAGIB4Tq5rzWwE7PgpdCpQjqJjg1iVuosCzEGFbaJNTxDpo77F3YwOfrSlUp8g4wZYB00ojMQX0DP",
+		"DEMO_ERROR_URL": "/1/errors/RxxaYWFKZPsIa1lF1phmFqTQ04BO",
+		"CLICKUP_CLIENT_ID": "7DAKQO04LB9AT9J9I7ZA37T9HKJO2PPD",
+		"DISCORD_CLIENT_ID": "1024079182013149185",
+		"REACT_APP_FRONT_INTEGRATION_CLIENT_ID": "e77eb8f15b02423c9525",
+		"HEIGHT_CLIENT_ID": "N58AdgpuOi2AmSeG2wKc8Osayo8WIU0UoQGwACiYqyI",
+		"DEMO_SESSION_URL": "/1/sessions/SGKFqG4mE8au2UmHjT0BhjO5Q15f",
+		"LINEAR_CLIENT_ID": "f60ff43c7376d0aceaa1e111db39e60d"
 	},
 	"scripts": [
 		"/intercom.js",

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2678,7 +2678,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 					}
 
 					// Replace any static resources with our own, hosted in S3
-					if projectID == 1 || projectID == 1344 || projectID == 5403 {
+					if projectID == 1 || projectID == 1031 || projectID == 1344 || projectID == 5378 || projectID == 5403 {
 						assetsSpan, _ := tracer.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
 							tracer.ResourceName("go.parseEvents.replaceAssets"), tracer.Tag("project_id", projectID), tracer.Tag("session_secure_id", sessionSecureID))
 						err = snapshot.ReplaceAssets(ctx, projectID, r.StorageClient, r.DB, r.Redis)

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2490,6 +2490,7 @@ export enum SessionCommentType {
 
 export enum SessionExcludedReason {
 	IgnoredUser = 'IgnoredUser',
+	Initializing = 'Initializing',
 	NoActivity = 'NoActivity',
 	NoError = 'NoError',
 	NoUserInteractionEvents = 'NoUserInteractionEvents',

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -44,7 +44,6 @@ import { HighlightEvent } from '../HighlightEvent'
 import { ReplayerContextInterface, ReplayerState } from '../ReplayerContext'
 import {
 	findNextSessionInList,
-	loadiFrameResources,
 	PlayerSearchParameters,
 	toHighlightEvents,
 	useSetPlayerTimestampFromSearchParam,
@@ -581,10 +580,6 @@ export const usePlayer = (): ReplayerContextInterface => {
 				return Promise.resolve()
 			}
 
-			if (state.replayer) {
-				loadiFrameResources(state.replayer, state.project_id)
-			}
-
 			timerStart('timelineChangeTime')
 			dispatch({ type: PlayerActionType.setTime, time: newTime })
 			return new Promise<void>((r) =>
@@ -604,23 +599,13 @@ export const usePlayer = (): ReplayerContextInterface => {
 				}),
 			)
 		},
-		[
-			ensureChunksLoaded,
-			state.project_id,
-			state.replayer,
-			state.sessionEndTime,
-			state.session_secure_id,
-		],
+		[ensureChunksLoaded, state.sessionEndTime, state.session_secure_id],
 	)
 
 	const pause = useCallback(
 		(time?: number) => {
 			return new Promise<void>((r) => {
 				if (time !== undefined) {
-					if (state.replayer) {
-						loadiFrameResources(state.replayer, state.project_id)
-					}
-
 					timerStart('timelineChangeTime')
 					dispatch({ type: PlayerActionType.setTime, time })
 					ensureChunksLoaded(
@@ -644,12 +629,7 @@ export const usePlayer = (): ReplayerContextInterface => {
 				}
 			})
 		},
-		[
-			ensureChunksLoaded,
-			state.project_id,
-			state.replayer,
-			state.session_secure_id,
-		],
+		[ensureChunksLoaded, state.session_secure_id],
 	)
 
 	const seek = useCallback(
@@ -737,7 +717,6 @@ export const usePlayer = (): ReplayerContextInterface => {
 					getTimeFromReplayer(state.replayer, state.sessionMetadata) +
 					state.sessionMetadata.startTime,
 			})
-			loadiFrameResources(state.replayer, state.project_id)
 		}, FRAME_MS * 60),
 		[],
 	)

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -31,6 +31,7 @@ import {
 	getCommentsInSessionIntervalsRelative,
 	getEventsForTimelineIndicator,
 	getSessionIntervals,
+	loadiFrameResources,
 	toHighlightEvents,
 } from '@pages/Player/PlayerHook/utils'
 import {
@@ -688,6 +689,9 @@ const replayerAction = (
 					s.replayer.play(desiredTime)
 				} else {
 					return s
+				}
+				if (s.replayer) {
+					loadiFrameResources(s.replayer, s.project_id)
 				}
 			} catch (e: any) {
 				console.error(


### PR DESCRIPTION
## Summary

For some projects, we need to inject styles when we are replaying to ensure the replay looks correct.
Ensure we do this after applying rrweb mutations to make sure the styles are rendered correctly.
Enables media asset inlining for this project.

## How did you test this change?

before
<img width="1110" alt="Screenshot 2023-05-10 at 11 03 39 PM" src="https://github.com/highlight/highlight/assets/1351531/2ab5b445-bdbd-4e3c-aa4f-53a93971400c">


after
<img width="1269" alt="Screenshot 2023-05-10 at 11 03 19 PM" src="https://github.com/highlight/highlight/assets/1351531/37271302-2b15-48fc-854d-f29414783ee3">

https://frontend-pr-5292.onrender.com/1031/sessions/6MvXaWNjUZ9RW6wuANX4QCKYZ79h

https://frontend-pr-5292.onrender.com/1031/sessions/7S4SqSsK5nNRmrqNf7ObE8rMJGFD

## Are there any deployment considerations?

No
