### PR TITLE
ensure errors page does not load large session resources

### DIFF
--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2490,6 +2490,7 @@ export enum SessionCommentType {
 
 export enum SessionExcludedReason {
 	IgnoredUser = 'IgnoredUser',
+	Initializing = 'Initializing',
 	NoActivity = 'NoActivity',
 	NoError = 'NoError',
 	NoUserInteractionEvents = 'NoUserInteractionEvents',

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -113,6 +113,7 @@ export const useResources = (
 						limit: limit.sizeLimit.toString(),
 						sessionSecureID: session?.secure_id,
 					})
+					return
 				}
 				let response
 				for await (const r of indexedDBFetch(session.resources_url)) {

--- a/frontend/src/util/preload.ts
+++ b/frontend/src/util/preload.ts
@@ -18,6 +18,7 @@ import {
 	GetWebVitalsDocument,
 } from '@graph/hooks'
 import { ErrorInstance, OpenSearchCalendarInterval } from '@graph/schemas'
+import { ResourceLoadingError } from '@pages/Player/ResourcesContext/ResourcesContext'
 import { indexedDBFetch, IndexedDBLink, isIndexedDBEnabled } from '@util/db'
 import { client } from '@util/graph'
 import log from '@util/log'
@@ -29,6 +30,9 @@ import { useEffect, useRef } from 'react'
 
 const CONCURRENT_PRELOADS = 1
 const PREVIOUS_ERROR_OBJECTS_TO_FETCH = 2
+// Max brotlied resource file allowed. Note that a brotli file with some binary data
+// has a compression ratio of >5x, so unbrotlied this file will take up much more memory.
+const RESOURCE_FILE_SIZE_LIMIT_BYTES = 16 * 1024 * 1024
 
 export const usePreloadSessions = function ({
 	backendSearchQuery,
@@ -196,6 +200,21 @@ export const usePreloadErrors = function ({
 	}, [project_id, pageToLoad, backendSearchQuery?.searchQuery])
 }
 
+export const checkResourceLimit = async function (resources_url: string) {
+	const r = await fetch(resources_url, {
+		method: 'HEAD',
+	})
+	const fileSize = Number(r.headers.get('Content-Length'))
+	if (fileSize > RESOURCE_FILE_SIZE_LIMIT_BYTES) {
+		return {
+			error: ResourceLoadingError.NetworkResourcesTooLarge,
+			fileSize: fileSize,
+			sizeLimit: RESOURCE_FILE_SIZE_LIMIT_BYTES,
+		}
+	}
+	return undefined
+}
+
 export const loadSession = async function (secureID: string) {
 	if (
 		await IndexedDBLink.has('GetSession', {
@@ -217,7 +236,10 @@ export const loadSession = async function (secureID: string) {
 		const sess = session?.data?.session
 		if (!sess) return
 		if (sess.resources_url) {
-			for await (const _ of indexedDBFetch(sess.resources_url)) {
+			const limit = await checkResourceLimit(sess.resources_url)
+			if (!limit) {
+				for await (const _ of indexedDBFetch(sess.resources_url)) {
+				}
 			}
 		}
 		if (sess.direct_download_url) {


### PR DESCRIPTION
## Summary

Consolidate network resource size logic from #5264 between all places that we fetch network resources.
This ensures that viewing an error instance that will preload the session does not fetch a large network resource file.

## How did you test this change?

[preview](https://preview.highlight.io/5403/errors/j5pxbefr4utB8uHe5y8RANfHf3BA) of error with large session j5pxbefr4utB8uHe5y8RANfHf3BA that would crash on loading network resources.
![image](https://github.com/highlight/highlight/assets/1351531/49b6b106-6c97-4430-bd82-4a9c3181bcbd)
![Screenshot from 2023-05-11 15-44-43](https://github.com/highlight/highlight/assets/1351531/6db27c2a-90ff-44bc-a61c-2030567e3923)


## Are there any deployment considerations?

No
