### PR TITLE
ensure we do not store invalid assets

### DIFF
--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -238,10 +238,12 @@ func TestSnapshot_ReplaceAssets(t *testing.T) {
 		t.Fatalf("failed to fetch assets %+v", err)
 	}
 
+	// broken asset "https://static.highlight.io/dev/test.mp4?AWSAccessKeyId=asdffdsa1234"
+	// should not be stored
 	assert.Equal(t, 2, len(assets))
 	for _, exp := range []string{
 		"https://static.highlight.io/dev/BigBuckBunny.mp4?AWSAccessKeyId=asdffdsa1234",
-		"https://static.highlight.io/dev/test.mp4?AWSAccessKeyId=asdffdsa1234",
+		"https://static.highlight.io/v6.2.0/index.js",
 	} {
 		matched := false
 		for _, asset := range assets {

--- a/backend/event-parse/sample-events/input.json
+++ b/backend/event-parse/sample-events/input.json
@@ -388,6 +388,18 @@
 							},
 							{
 								"attributes": {
+									"src": "https://static.highlight.io/v6.2.0/index.js",
+									"autoplay": true,
+									"crossorigin": "anonymous",
+									"preload=": "metadata"
+								},
+								"childNodes": [],
+								"id": 55558,
+								"tagName": "video",
+								"type": 2
+							},
+							{
+								"attributes": {
 									"src": "https://static.highlight.io/dev/BigBuckBunny.mp4?AWSAccessKeyId=asdffdsa1234&Signature=c%2F%2BCuVPNfRldO2qFGliECCC0R7A%3D&x-amz-security-token=IQoJb3JpZ2luX2VjEAEaCXVzLWVhc3QtMSJHMEUCIQDB%2FFE5eMBLpRgsOiCn%2Bud5S16cnzxm5b3hPmISSFsmLgIgS6YuPEatrTdf45C%2BNzxAKF1vt7vmmWSoRiegGU%2BCba0qgQUIGhACGgw0NzU3MjMyNDA4MzAiDGlc0ZNEJGWjspla3ireBDf2Cm3Zl2dxONxeR2H3fniBrwJHWGsCOxpc%2BQtyEHe2Q%2F7aES19r%2B%2BpBqI60FndLawE3Oi9BtsLop7ANGBd8S4SfgXddOXBAwhxgePdFT58nm2Ap70ztkO6sBGjs58zG5b%2B2fHeqE%2B6EHUlMeAipRALvXWrurEa7k811jHfrwlFifFz9AjK%2B9rqsnAG1tBaskDita3xGPGol45INyZhRGAQqAHhqDMFKWg8%2Bg1i7xbPPPTDsYJk1N5AIPsXF4YpwmlBHR%2B%2BxZwVflVLfsBL3pPn4gZOfHlq19RGjiT1zPfY8XUpbJvJeqcrfhpeagn%2FL7x70u9WacKSCGzfaWDxzNJxpSkKA%2FsHtfNmg1Sg%2FM1EzWafAs3%2FakVKDjEJiHC8ruaLK66NbsIcvH27K%2BtKlMSbFPHKLcz2Lzj9GSqd2HqL5bg4egLYUbUabkJkL%2FP4kFFSCOV04Yk2BVjQDi4ReYLr02EiXERDNG8nreDP47B5A1CjN85TvOe%2FsmeCJpzK3olBvnyczMAYiNKhEYhkgbP2hBTu75ZbvMWtNRD5tcKltIM8FxK560rHb9NCdZmpDoZbQkWQ%2Flym9DvW5pB5ENoSGqULWLyJOwaRWQDbWgTX7I7XXERqO9fsTmAzglaFssMIeew7nx4p9T8uzDGFxK1EfUghC7ibjTPMerxRoHGR7fPYxJCDG1W9lUz17b%2FplGCtw4myt1WVzAr4VjK00AdvNn1mQ0oh%2B2ocbvqtQIkCUd43%2FhMn1arpf0wDa11CoKTCFGLPU3irqd9dRWPWu%2BBK2M8QvDgZJAYSUUxa7TDm7NSiBjqaAdRiIWPgQpInj8bXcQCwVwg%2F9hFT0O0HYUGyBPGON5EX1CuW%2FuZoC%2FzIvHkFSbzCsTPkX3kU8jPHjmb%2FYlf4x2n8c8HSosZ1ikZfTAZo8SKpGHFxGBPbk3h3hdv4u13SrFTtgJrle5UIJ%2BvkVAo6sKnJsZGJQfRjc2dneExKCC2UHIn87auTo%2FEFZoQA%2BqIJMlfoawmYS5OqMhc%3D&Expires=1683313388",
 									"autoplay": true,
 									"crossorigin": "anonymous",
@@ -487,7 +499,7 @@
 							},
 							{
 								"attributes": {
-									"src": "http://localhost:8080/dist/index.js?909",
+									"src": "https://static.highlight.io/v6.2.0/index.js",
 									"type": "text/javascript"
 								},
 								"childNodes": [],

--- a/backend/event-parse/sample-events/output.json
+++ b/backend/event-parse/sample-events/output.json
@@ -386,6 +386,18 @@
 							},
 							{
 								"attributes": {
+									"src": "https://static.highlight.io/v6.2.0/index.js",
+									"autoplay": true,
+									"crossorigin": "anonymous",
+									"preload=": "metadata"
+								},
+								"childNodes": [],
+								"id": 55558,
+								"tagName": "video",
+								"type": 2
+							},
+							{
+								"attributes": {
 									"src": "https://static.highlight.io/dev/BigBuckBunny.mp4?AWSAccessKeyId=asdffdsa1234&Signature=c%2F%2BCuVPNfRldO2qFGliECCC0R7A%3D&x-amz-security-token=IQoJb3JpZ2luX2VjEAEaCXVzLWVhc3QtMSJHMEUCIQDB%2FFE5eMBLpRgsOiCn%2Bud5S16cnzxm5b3hPmISSFsmLgIgS6YuPEatrTdf45C%2BNzxAKF1vt7vmmWSoRiegGU%2BCba0qgQUIGhACGgw0NzU3MjMyNDA4MzAiDGlc0ZNEJGWjspla3ireBDf2Cm3Zl2dxONxeR2H3fniBrwJHWGsCOxpc%2BQtyEHe2Q%2F7aES19r%2B%2BpBqI60FndLawE3Oi9BtsLop7ANGBd8S4SfgXddOXBAwhxgePdFT58nm2Ap70ztkO6sBGjs58zG5b%2B2fHeqE%2B6EHUlMeAipRALvXWrurEa7k811jHfrwlFifFz9AjK%2B9rqsnAG1tBaskDita3xGPGol45INyZhRGAQqAHhqDMFKWg8%2Bg1i7xbPPPTDsYJk1N5AIPsXF4YpwmlBHR%2B%2BxZwVflVLfsBL3pPn4gZOfHlq19RGjiT1zPfY8XUpbJvJeqcrfhpeagn%2FL7x70u9WacKSCGzfaWDxzNJxpSkKA%2FsHtfNmg1Sg%2FM1EzWafAs3%2FakVKDjEJiHC8ruaLK66NbsIcvH27K%2BtKlMSbFPHKLcz2Lzj9GSqd2HqL5bg4egLYUbUabkJkL%2FP4kFFSCOV04Yk2BVjQDi4ReYLr02EiXERDNG8nreDP47B5A1CjN85TvOe%2FsmeCJpzK3olBvnyczMAYiNKhEYhkgbP2hBTu75ZbvMWtNRD5tcKltIM8FxK560rHb9NCdZmpDoZbQkWQ%2Flym9DvW5pB5ENoSGqULWLyJOwaRWQDbWgTX7I7XXERqO9fsTmAzglaFssMIeew7nx4p9T8uzDGFxK1EfUghC7ibjTPMerxRoHGR7fPYxJCDG1W9lUz17b%2FplGCtw4myt1WVzAr4VjK00AdvNn1mQ0oh%2B2ocbvqtQIkCUd43%2FhMn1arpf0wDa11CoKTCFGLPU3irqd9dRWPWu%2BBK2M8QvDgZJAYSUUxa7TDm7NSiBjqaAdRiIWPgQpInj8bXcQCwVwg%2F9hFT0O0HYUGyBPGON5EX1CuW%2FuZoC%2FzIvHkFSbzCsTPkX3kU8jPHjmb%2FYlf4x2n8c8HSosZ1ikZfTAZo8SKpGHFxGBPbk3h3hdv4u13SrFTtgJrle5UIJ%2BvkVAo6sKnJsZGJQfRjc2dneExKCC2UHIn87auTo%2FEFZoQA%2BqIJMlfoawmYS5OqMhc%3D&Expires=1683313388",
 									"autoplay": true,
 									"crossorigin": "anonymous",
@@ -485,7 +497,7 @@
 							},
 							{
 								"attributes": {
-									"src": "http://localhost:8080/dist/index.js?909",
+									"src": "https://static.highlight.io/v6.2.0/index.js",
 									"type": "text/javascript"
 								},
 								"childNodes": [],

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -7,7 +7,7 @@ import { linkStyle } from '@components/Header/styles.css'
 import { OpenCommandBarShortcut } from '@components/KeyboardShortcutsEducation/KeyboardShortcutsEducation'
 import { LinkButton } from '@components/LinkButton'
 import { useGetBillingDetailsForProjectQuery } from '@graph/hooks'
-import { Maybe, ProductType, Project } from '@graph/schemas'
+import { Maybe, PlanType, ProductType, Project } from '@graph/schemas'
 import {
 	Badge,
 	Box,
@@ -720,7 +720,10 @@ const BillingBanner: React.FC = () => {
 	if (productsOverQuota.length > 0) {
 		bannerMessage += `You've reached your monthly limit for ${productsToString(
 			productsOverQuota,
-		)}. New data won't be recorded.`
+		)}.`
+		if (data?.billingDetailsForProject?.plan.type === PlanType.Free) {
+			bannerMessage += ` New data won't be recorded.`
+		}
 	}
 	if (productsApproachingQuota.length > 0) {
 		bannerMessage += ` You're approaching your monthly limit for ${productsToString(


### PR DESCRIPTION
## Summary

Asset ingestion logic would store non-ok http responses.
Updates the header to only show the `data is not recorded` warning for non-paying (non-overage) customers.

## How did you test this change?

N/A

## Are there any deployment considerations?

No
