### PR TITLE
Add "Thank you" page on demo confirmation

### DIFF
--- a/highlight.io/components/Home/CalendlyPopover.tsx
+++ b/highlight.io/components/Home/CalendlyPopover.tsx
@@ -1,10 +1,23 @@
 import { Popover } from '@headlessui/react'
 import { ArrowRightCircleIcon, XMarkIcon } from '@heroicons/react/20/solid'
 import classNames from 'classnames'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
 import { InlineWidget } from 'react-calendly'
 import { Typography } from '../common/Typography/Typography'
 
 export const CalendlyPopover = () => {
+	const router = useRouter()
+
+	useEffect(() => {
+		window.addEventListener('message', (message) => {
+			const { event } = message.data
+
+			if (event === 'calendly.event_scheduled')
+				router.push('/demo-confirmation')
+		})
+	}, [router])
+
 	return (
 		<Popover className="relative inline-flex flex-col items-center">
 			{({ open, close }) => (

--- a/highlight.io/components/Home/CalendlyPopover.tsx
+++ b/highlight.io/components/Home/CalendlyPopover.tsx
@@ -1,23 +1,10 @@
 import { Popover } from '@headlessui/react'
 import { ArrowRightCircleIcon, XMarkIcon } from '@heroicons/react/20/solid'
 import classNames from 'classnames'
-import { useRouter } from 'next/router'
-import { useEffect } from 'react'
 import { InlineWidget } from 'react-calendly'
 import { Typography } from '../common/Typography/Typography'
 
 export const CalendlyPopover = () => {
-	const router = useRouter()
-
-	useEffect(() => {
-		window.addEventListener('message', (message) => {
-			const { event } = message.data
-
-			if (event === 'calendly.event_scheduled')
-				router.push('/demo-confirmation')
-		})
-	}, [router])
-
 	return (
 		<Popover className="relative inline-flex flex-col items-center">
 			{({ open, close }) => (

--- a/highlight.io/pages/demo-confirmation.tsx
+++ b/highlight.io/pages/demo-confirmation.tsx
@@ -3,7 +3,7 @@ import Footer from '../components/common/Footer/Footer'
 import Navbar from '../components/common/Navbar/Navbar'
 import { Typography } from '../components/common/Typography/Typography'
 
-export default function Highlight404() {
+export default function DemoConfirmation() {
 	return (
 		<>
 			<Navbar />

--- a/highlight.io/pages/demo-confirmation.tsx
+++ b/highlight.io/pages/demo-confirmation.tsx
@@ -1,0 +1,23 @@
+import { FooterCallToAction } from '../components/common/CallToAction/FooterCallToAction'
+import Footer from '../components/common/Footer/Footer'
+import Navbar from '../components/common/Navbar/Navbar'
+import { Typography } from '../components/common/Typography/Typography'
+
+export default function Highlight404() {
+	return (
+		<>
+			<Navbar />
+			<main>
+				<div className="gap-4 mx-auto m-36 max-w-max">
+					<div className="flex flex-col items-center gap-4">
+						<Typography type="copy1">
+							Thank you for scheduling a demo. See you soon!
+						</Typography>
+					</div>
+				</div>
+				<FooterCallToAction />
+			</main>
+			<Footer />
+		</>
+	)
+}


### PR DESCRIPTION
## Summary

Add a `/demo-confirmation` page and redirect to it when scheduling a demo through Calendly. closes #5280

![image](https://github.com/highlight/highlight/assets/19144605/d3673e6e-9339-4233-a168-49503d376754)


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
