### PR TITLE
Adds utm params to calendly widget

### DIFF
--- a/frontend/src/components/CreateAlertButton/CreateAlertButton.tsx
+++ b/frontend/src/components/CreateAlertButton/CreateAlertButton.tsx
@@ -29,5 +29,5 @@ export const CreateAlertButton = function ({
 	)
 }
 export const Divider: React.FC = () => {
-	return <Box className={styles.divider}></Box>
+	return <Box cssClass={styles.divider}></Box>
 }

--- a/highlight.io/components/Home/CalendlyPopover.tsx
+++ b/highlight.io/components/Home/CalendlyPopover.tsx
@@ -5,6 +5,8 @@ import { InlineWidget } from 'react-calendly'
 import { Typography } from '../common/Typography/Typography'
 
 export const CalendlyPopover = () => {
+	const query = new URLSearchParams(window.location.search)
+
 	return (
 		<Popover className="relative inline-flex flex-col items-center">
 			{({ open, close }) => (
@@ -36,6 +38,13 @@ export const CalendlyPopover = () => {
 							<InlineWidget
 								url="https://calendly.com/d/2gt-rw5-qg5/highlight-demo-call"
 								styles={{ width: '100%', height: '100%' }}
+								utm={{
+									utmCampaign: query.get('utm_campaign'),
+									utmSource: query.get('utm_source'),
+									utmMedium: query.get('utm_medium'),
+									utmContent: query.get('utm_content'),
+									utmTerm: query.get('utm_term'),
+								}}
 							/>
 						</div>
 						<button

--- a/highlight.io/components/Home/CalendlyPopover.tsx
+++ b/highlight.io/components/Home/CalendlyPopover.tsx
@@ -39,11 +39,12 @@ export const CalendlyPopover = () => {
 								url="https://calendly.com/d/2gt-rw5-qg5/highlight-demo-call"
 								styles={{ width: '100%', height: '100%' }}
 								utm={{
-									utmCampaign: query.get('utm_campaign'),
-									utmSource: query.get('utm_source'),
-									utmMedium: query.get('utm_medium'),
-									utmContent: query.get('utm_content'),
-									utmTerm: query.get('utm_term'),
+									utmCampaign:
+										query.get('utm_campaign') ?? '',
+									utmSource: query.get('utm_source') ?? '',
+									utmMedium: query.get('utm_medium') ?? '',
+									utmContent: query.get('utm_content') ?? '',
+									utmTerm: query.get('utm_term') ?? '',
 								}}
 							/>
 						</div>

--- a/highlight.io/components/Home/CalendlyPopover.tsx
+++ b/highlight.io/components/Home/CalendlyPopover.tsx
@@ -1,11 +1,14 @@
+'use client'
+
 import { Popover } from '@headlessui/react'
 import { ArrowRightCircleIcon, XMarkIcon } from '@heroicons/react/20/solid'
 import classNames from 'classnames'
 import { InlineWidget } from 'react-calendly'
 import { Typography } from '../common/Typography/Typography'
+import { useSearchParams } from 'next/navigation'
 
 export const CalendlyPopover = () => {
-	const query = new URLSearchParams(window.location.search)
+	const query = useSearchParams()
 
 	return (
 		<Popover className="relative inline-flex flex-col items-center">


### PR DESCRIPTION
## Summary
Carries over utm params from our site to the calendly widget.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
clicking

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
no

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
