### PR TITLE
CGO_ENABLED=0 for all lambdas

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,15 +41,15 @@ jobs:
             - name: Build and zip
               run: |
                   cd backend/
-                  go build ./lambda-functions/deleteSessions/getSessionIdsByQuery
+                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/getSessionIdsByQuery
                   zip getSessionIdsByQuery.zip getSessionIdsByQuery
-                  go build ./lambda-functions/deleteSessions/deleteSessionBatchFromPostgres
+                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromPostgres
                   zip deleteSessionBatchFromPostgres.zip deleteSessionBatchFromPostgres
-                  go build ./lambda-functions/deleteSessions/deleteSessionBatchFromOpenSearch
+                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromOpenSearch
                   zip deleteSessionBatchFromOpenSearch.zip deleteSessionBatchFromOpenSearch
-                  go build ./lambda-functions/deleteSessions/deleteSessionBatchFromS3
+                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromS3
                   zip deleteSessionBatchFromS3.zip deleteSessionBatchFromS3
-                  go build ./lambda-functions/deleteSessions/sendEmail
+                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/sendEmail
                   zip sendEmail.zip sendEmail
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v2
@@ -127,11 +127,11 @@ jobs:
             - name: Build and zip
               run: |
                   cd backend/
-                  go build ./lambda-functions/digests/getProjectIds
+                  CGO_ENABLED=0 go build ./lambda-functions/digests/getProjectIds
                   zip getProjectIds.zip getProjectIds
-                  go build ./lambda-functions/digests/getDigestData
+                  CGO_ENABLED=0 go build ./lambda-functions/digests/getDigestData
                   zip getDigestData.zip getDigestData
-                  go build ./lambda-functions/digests/sendDigestEmails
+                  CGO_ENABLED=0 go build ./lambda-functions/digests/sendDigestEmails
                   zip sendDigestEmails.zip sendDigestEmails
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v2


### PR DESCRIPTION
## Summary
- lambdas are failing with glibc error (likely related to go 1.20)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- built + deployed lambda locally w/ `CGO_ENABLED=0`
- (this was working without `CGO_ENABLED=0` too when built + deployed locally, so not 100% clear if this will fix the issue)
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, can revert if this doesn't work
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
