### PR TITLE
fix attaching error object to error group in opensearch

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -173,7 +173,11 @@ func enhancedHealthCheck(ctx context.Context, db *gorm.DB, tdb timeseries.DB, rC
 		defer wg.Done()
 		ctx, cancel := context.WithTimeout(ctx, Timeout)
 		defer cancel()
-		if err := osClient.IndexSynchronous(ctx, opensearch.IndexSessions, 0, struct{}{}); err != nil {
+		if err := osClient.IndexSynchronous(ctx, opensearch.IndexParams{
+			Index:  opensearch.IndexSessions,
+			ID:     0,
+			Object: struct{}{},
+		}); err != nil {
 			msg := fmt.Sprintf("failed to perform opensearch index: %s", err)
 			log.WithContext(ctx).Error(msg)
 			errors <- e.New(msg)

--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"gorm.io/gorm"
 	"io"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"gorm.io/gorm"
 
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/retryables"
@@ -359,61 +360,37 @@ func (c *Client) Delete(index Index, id int) error {
 	return nil
 }
 
-func (c *Client) Index(index Index, id int64, parentId *int, obj interface{}) error {
+func (c *Client) Index(ctx context.Context, params IndexParams) error {
 	if c == nil || !c.isInitialized {
 		return nil
 	}
 
-	documentId := ""
-	joinClause := ""
-	routing := ""
-	if parentId != nil {
-		if *parentId > 0 {
-			// Parent/child document ids could collide - prepend child document ids with 'child_'
-			documentId += "child_"
-			joinClause = fmt.Sprintf(`,"join_type":{"name":"child","parent":"%d"},"routing":"%d"`, *parentId, *parentId)
-			routing = strconv.Itoa(*parentId)
-		} else {
-			joinClause = `,"join_type": {"name": "parent"}`
-		}
-	}
-	documentId += strconv.FormatInt(id, 10)
-
-	b, err := json.Marshal(obj)
+	req, err := makeIndexRequest(params)
 	if err != nil {
-		return e.Wrap(err, "OPENSEARCH_ERROR error marshalling map for index")
+		return err
 	}
-	bodyStr := string(b)
-
-	// If there's a join clause, splice it into the end of the body
-	if joinClause != "" {
-		bodyStr = fmt.Sprintf("%s%s}", bodyStr[:len(bodyStr)-1], joinClause)
-	}
-	body := strings.NewReader(bodyStr)
-
-	indexStr := GetIndex(index)
 
 	item := opensearchutil.BulkIndexerItem{
-		Index:      indexStr,
+		Index:      req.Index,
 		Action:     "index",
-		DocumentID: documentId,
-		Body:       body,
-		Routing:    routing,
+		DocumentID: req.DocumentID,
+		Body:       req.Body,
+		Routing:    req.Routing,
 		OnSuccess: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem) {
 			// log.WithContext(ctx).Infof("OPENSEARCH_SUCCESS (%s : %s) [%d] %s", indexStr, item.DocumentID, res.Status, res.Result)
 		},
 		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 			if err != nil {
 				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, item.Index, item.DocumentID, map[string]interface{}{"item.Action": item.Action, "res": res}, err)
-				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
+				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", req.Index, item.DocumentID, err)
 			} else {
 				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, item.Index, item.DocumentID, map[string]interface{}{"item.Action": item.Action, "res": res}, nil)
-				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
+				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", req.Index, item.DocumentID, res.Error.Type, res.Error.Reason)
 			}
 		},
 	}
 
-	if err := c.BulkIndexer.Add(context.Background(), item); err != nil {
+	if err := c.BulkIndexer.Add(ctx, item); err != nil {
 		return e.Wrap(err, "OPENSEARCH_ERROR error adding bulk indexer item for index")
 	}
 
@@ -465,28 +442,23 @@ func (c *Client) AppendToField(index Index, sessionID int, fieldName string, fie
 	}
 
 	return nil
-
 }
 
-func (c *Client) IndexSynchronous(ctx context.Context, index Index, id int, obj interface{}) error {
+type IndexParams struct {
+	Index    Index
+	ID       int64
+	ParentID *int
+	Object   interface{}
+}
+
+func (c *Client) IndexSynchronous(ctx context.Context, params IndexParams) error {
 	if c == nil || !c.isInitialized {
 		return nil
 	}
 
-	documentId := strconv.Itoa(id)
-
-	b, err := json.Marshal(obj)
+	req, err := makeIndexRequest(params)
 	if err != nil {
-		return e.Wrap(err, "OPENSEARCH_ERROR error marshalling map for index")
-	}
-	body := strings.NewReader(string(b))
-
-	indexStr := GetIndex(index)
-
-	req := opensearchapi.IndexRequest{
-		Index:      indexStr,
-		DocumentID: documentId,
-		Body:       body,
+		return err
 	}
 
 	response, err := req.Do(ctx, c.Client)
@@ -498,9 +470,45 @@ func (c *Client) IndexSynchronous(ctx context.Context, index Index, id int, obj 
 		return e.New("OPENSEARCH_ERROR error indexing document: " + response.String())
 	}
 
-	// log.WithContext(ctx).Infof("OPENSEARCH_SUCCESS (%s : %s) [%d] created", indexStr, documentId, res.StatusCode)
-
 	return nil
+}
+
+func makeIndexRequest(params IndexParams) (opensearchapi.IndexRequest, error) {
+	documentId := ""
+	joinClause := ""
+	routing := ""
+	if params.ParentID != nil {
+		if *params.ParentID > 0 {
+			// Parent/child document ids could collide - prepend child document ids with 'child_'
+			documentId += "child_"
+			joinClause = fmt.Sprintf(`,"join_type":{"name":"child","parent":"%d"},"routing":"%d"`, *params.ParentID, *params.ParentID)
+			routing = strconv.Itoa(*params.ParentID)
+		} else {
+			joinClause = `,"join_type": {"name": "parent"}`
+		}
+	}
+	documentId += strconv.FormatInt(params.ID, 10)
+
+	b, err := json.Marshal(params.Object)
+	if err != nil {
+		return opensearchapi.IndexRequest{}, e.Wrap(err, "OPENSEARCH_ERROR error marshalling map for index")
+	}
+	bodyStr := string(b)
+
+	// If there's a join clause, splice it into the end of the body
+	if joinClause != "" {
+		bodyStr = fmt.Sprintf("%s%s}", bodyStr[:len(bodyStr)-1], joinClause)
+	}
+	body := strings.NewReader(bodyStr)
+
+	indexStr := GetIndex(params.Index)
+
+	return opensearchapi.IndexRequest{
+		Index:      indexStr,
+		DocumentID: documentId,
+		Body:       body,
+		Routing:    routing,
+	}, nil
 }
 
 func getAggregationResults(buckets []aggregateBucket) []AggregationResult {

--- a/backend/worker/opensearch.go
+++ b/backend/worker/opensearch.go
@@ -21,7 +21,11 @@ func (w *Worker) indexItem(ctx context.Context, index opensearch.Index, item int
 	id := val.FieldByName("ID").Int()
 
 	// Add an item to the indexer
-	if err := w.Resolver.OpenSearch.Index(index, id, nil, item); err != nil {
+	if err := w.Resolver.OpenSearch.Index(ctx, opensearch.IndexParams{
+		Index:  index,
+		ID:     id,
+		Object: item,
+	}); err != nil {
 		log.WithContext(ctx).Error(e.Wrap(err, "OPENSEARCH_ERROR error adding field to the indexer"))
 	}
 }
@@ -123,7 +127,12 @@ func (w *Worker) IndexErrorGroups(ctx context.Context, isUpdate bool) {
 			Fields:     nil,
 			Filename:   filename,
 		}
-		if err := w.Resolver.OpenSearch.Index(opensearch.IndexErrorsCombined, int64(eg.ID), pointy.Int(0), os); err != nil {
+		if err := w.Resolver.OpenSearch.Index(ctx, opensearch.IndexParams{
+			Index:    opensearch.IndexErrorsCombined,
+			ID:       int64(eg.ID),
+			ParentID: pointy.Int(0),
+			Object:   os,
+		}); err != nil {
 			log.WithContext(ctx).Error(e.Wrap(err, "OPENSEARCH_ERROR error adding error group to the indexer (combined)"))
 		}
 	}
@@ -177,7 +186,12 @@ func (w *Worker) IndexErrorObjects(ctx context.Context, isUpdate bool) {
 			Environment: eo.Environment,
 		}
 
-		if err := w.Resolver.OpenSearch.Index(opensearch.IndexErrorsCombined, int64(eo.ID), pointy.Int(eo.ErrorGroupID), os); err != nil {
+		if err := w.Resolver.OpenSearch.Index(ctx, opensearch.IndexParams{
+			Index:    opensearch.IndexErrorsCombined,
+			ID:       int64(eo.ID),
+			ParentID: pointy.Int(eo.ErrorGroupID),
+			Object:   os,
+		}); err != nil {
 			log.WithContext(ctx).Error(e.Wrap(err, "OPENSEARCH_ERROR error adding error object to the indexer (combined)"))
 		}
 	}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

#5301 had an unintended regression because `IndexSynchronous` does not handle parent/child relationships like `Index` does. 

As a result, error instances were not being attached to their error group in opensearch (postgres is fine) and therefore were not showing up in the error feed because they didn't have `join_type` defined on their document:

![Screenshot 2023-05-15 at 2 35 30 PM](https://github.com/highlight/highlight/assets/58678/8c8fdf2f-5c04-47ee-9470-04a0cddd00c1)


This PR adjusts the code so those two functions use the same logic for building up the openseach index request.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Validated that new error groups have `join_type` set 

![Screenshot 2023-05-15 at 2 37 24 PM](https://github.com/highlight/highlight/assets/58678/8a2e6624-f404-4ab2-97ad-79803ea95459)


and that they show up in the error feed

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
