### PR TITLE
remove useless opensearch update

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2864,24 +2864,3 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 	}
 	return nil
 }
-
-// Returns the first filename from a stack trace, or nil if
-// the stack trace cannot be unmarshalled or doesn't have a filename.
-func GetFirstFilename(stackTraceString string) *string {
-	var unmarshalled []*modelInputs.ErrorTrace
-	if err := json.Unmarshal([]byte(stackTraceString), &unmarshalled); err != nil {
-		// Stack trace may not be able to be unmarshalled as the format may differ,
-		// should not be treated as an error
-		return nil
-	}
-
-	// Return the first non empty frame's filename
-	empty := modelInputs.ErrorTrace{}
-	for _, frame := range unmarshalled {
-		if frame != nil && *frame != empty {
-			return frame.FileName
-		}
-	}
-
-	return nil
-}

--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"gorm.io/gorm"
 	"io"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"gorm.io/gorm"
 
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/retryables"
@@ -778,8 +779,7 @@ type OpenSearchField struct {
 
 type OpenSearchError struct {
 	*model.ErrorGroup
-	Fields   []*OpenSearchErrorField `json:"fields"`
-	Filename *string                 `json:"filename"`
+	Fields []*OpenSearchErrorField `json:"fields"`
 }
 
 type OpenSearchErrorObject struct {
@@ -788,14 +788,6 @@ type OpenSearchErrorObject struct {
 	Browser     string    `json:"browser"`
 	Timestamp   time.Time `json:"timestamp"`
 	Environment string    `json:"environment"`
-}
-
-func (oe *OpenSearchError) ToErrorGroup() *model.ErrorGroup {
-	inner := oe.ErrorGroup
-	if oe.Filename != nil {
-		inner.StackTrace = fmt.Sprintf(`[{"fileName":"%s"}]`, *oe.Filename)
-	}
-	return inner
 }
 
 type OpenSearchErrorField struct {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3989,7 +3989,7 @@ func (r *queryResolver) ErrorGroupsOpensearch(ctx context.Context, projectID int
 
 	asErrorGroups := []*model.ErrorGroup{}
 	for _, result := range results {
-		asErrorGroups = append(asErrorGroups, result.ToErrorGroup())
+		asErrorGroups = append(asErrorGroups, result.ErrorGroup)
 	}
 
 	errorFrequencyInfluxSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal",

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -970,21 +970,6 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 		}
 	}
 
-	var filename *string
-	if newMappedStackTraceString != nil {
-		filename = model.GetFirstFilename(*newMappedStackTraceString)
-	} else {
-		filename = model.GetFirstFilename(newFrameString)
-	}
-
-	if err := r.OpenSearch.Update(opensearch.IndexErrorsCombined, errorGroup.ID, map[string]interface{}{
-		"filename":   filename,
-		"updated_at": time.Now(),
-		"Event":      errorObj.Event,
-	}); err != nil {
-		return nil, e.Wrap(err, "error updating error group in opensearch")
-	}
-
 	return errorGroup, nil
 }
 

--- a/backend/worker/opensearch.go
+++ b/backend/worker/opensearch.go
@@ -107,12 +107,6 @@ func (w *Worker) IndexErrorGroups(ctx context.Context, isUpdate bool) {
 		if err := w.Resolver.DB.ScanRows(rows, &eg); err != nil {
 			log.WithContext(ctx).Errorf("OPENSEARCH_ERROR error scanning rows: %+v", err)
 		}
-		var filename *string
-		if eg.MappedStackTrace != nil {
-			filename = model.GetFirstFilename(*eg.MappedStackTrace)
-		} else {
-			filename = model.GetFirstFilename(eg.StackTrace)
-		}
 		eg.FieldGroup = nil
 		eg.Fields = nil
 		eg.Environments = ""
@@ -121,7 +115,6 @@ func (w *Worker) IndexErrorGroups(ctx context.Context, isUpdate bool) {
 		os := opensearch.OpenSearchError{
 			ErrorGroup: &eg,
 			Fields:     nil,
-			Filename:   filename,
 		}
 		if err := w.Resolver.OpenSearch.Index(opensearch.IndexErrorsCombined, int64(eg.ID), pointy.Int(0), os); err != nil {
 			log.WithContext(ctx).Error(e.Wrap(err, "OPENSEARCH_ERROR error adding error group to the indexer (combined)"))


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

In the flow to create or update an error group, we have some logic that attaches the stacktrace's top frame's filename to the opensearch document (see #2091 for when this was added). Per a chat with @mayberryzane, this is from a time when we showed the filename in the error feed. We no longer do this and therefore:

* have no need to include the filename
* can reduce an unnecessary update

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed error feed indexing still works as expected.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
