### PR TITLE
load timeline indicator events on frontend from s3

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -970,7 +970,6 @@ type ComplexityRoot struct {
 		Language                       func(childComplexity int) int
 		LastUserInteractionTime        func(childComplexity int) int
 		Length                         func(childComplexity int) int
-		MessagesURL                    func(childComplexity int) int
 		OSName                         func(childComplexity int) int
 		OSVersion                      func(childComplexity int) int
 		ObjectStorageEnabled           func(childComplexity int) int
@@ -982,6 +981,7 @@ type ComplexityRoot struct {
 		SecureID                       func(childComplexity int) int
 		Starred                        func(childComplexity int) int
 		State                          func(childComplexity int) int
+		TimelineIndicatorsURL          func(childComplexity int) int
 		UserObject                     func(childComplexity int) int
 		UserProperties                 func(childComplexity int) int
 		Viewed                         func(childComplexity int) int
@@ -1468,7 +1468,7 @@ type SessionResolver interface {
 
 	DirectDownloadURL(ctx context.Context, obj *model1.Session) (*string, error)
 	ResourcesURL(ctx context.Context, obj *model1.Session) (*string, error)
-	MessagesURL(ctx context.Context, obj *model1.Session) (*string, error)
+	TimelineIndicatorsURL(ctx context.Context, obj *model1.Session) (*string, error)
 	DeviceMemory(ctx context.Context, obj *model1.Session) (*int, error)
 }
 type SessionAlertResolver interface {
@@ -7129,13 +7129,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Session.Length(childComplexity), true
 
-	case "Session.messages_url":
-		if e.complexity.Session.MessagesURL == nil {
-			break
-		}
-
-		return e.complexity.Session.MessagesURL(childComplexity), true
-
 	case "Session.os_name":
 		if e.complexity.Session.OSName == nil {
 			break
@@ -7212,6 +7205,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Session.State(childComplexity), true
+
+	case "Session.timeline_indicators_url":
+		if e.complexity.Session.TimelineIndicatorsURL == nil {
+			break
+		}
+
+		return e.complexity.Session.TimelineIndicatorsURL(childComplexity), true
 
 	case "Session.user_object":
 		if e.complexity.Session.UserObject == nil {
@@ -8339,7 +8339,7 @@ type Session {
 	event_counts: String
 	direct_download_url: String
 	resources_url: String
-	messages_url: String
+	timeline_indicators_url: String
 	deviceMemory: Int
 	last_user_interaction_time: Timestamp!
 	chunked: Boolean
@@ -25301,8 +25301,8 @@ func (ec *executionContext) fieldContext_ErrorObject_session(ctx context.Context
 				return ec.fieldContext_Session_direct_download_url(ctx, field)
 			case "resources_url":
 				return ec.fieldContext_Session_resources_url(ctx, field)
-			case "messages_url":
-				return ec.fieldContext_Session_messages_url(ctx, field)
+			case "timeline_indicators_url":
+				return ec.fieldContext_Session_timeline_indicators_url(ctx, field)
 			case "deviceMemory":
 				return ec.fieldContext_Session_deviceMemory(ctx, field)
 			case "last_user_interaction_time":
@@ -31979,8 +31979,8 @@ func (ec *executionContext) fieldContext_Mutation_markSessionAsViewed(ctx contex
 				return ec.fieldContext_Session_direct_download_url(ctx, field)
 			case "resources_url":
 				return ec.fieldContext_Session_resources_url(ctx, field)
-			case "messages_url":
-				return ec.fieldContext_Session_messages_url(ctx, field)
+			case "timeline_indicators_url":
+				return ec.fieldContext_Session_timeline_indicators_url(ctx, field)
 			case "deviceMemory":
 				return ec.fieldContext_Session_deviceMemory(ctx, field)
 			case "last_user_interaction_time":
@@ -32130,8 +32130,8 @@ func (ec *executionContext) fieldContext_Mutation_markSessionAsStarred(ctx conte
 				return ec.fieldContext_Session_direct_download_url(ctx, field)
 			case "resources_url":
 				return ec.fieldContext_Session_resources_url(ctx, field)
-			case "messages_url":
-				return ec.fieldContext_Session_messages_url(ctx, field)
+			case "timeline_indicators_url":
+				return ec.fieldContext_Session_timeline_indicators_url(ctx, field)
 			case "deviceMemory":
 				return ec.fieldContext_Session_deviceMemory(ctx, field)
 			case "last_user_interaction_time":
@@ -35594,8 +35594,8 @@ func (ec *executionContext) fieldContext_Mutation_updateSessionIsPublic(ctx cont
 				return ec.fieldContext_Session_direct_download_url(ctx, field)
 			case "resources_url":
 				return ec.fieldContext_Session_resources_url(ctx, field)
-			case "messages_url":
-				return ec.fieldContext_Session_messages_url(ctx, field)
+			case "timeline_indicators_url":
+				return ec.fieldContext_Session_timeline_indicators_url(ctx, field)
 			case "deviceMemory":
 				return ec.fieldContext_Session_deviceMemory(ctx, field)
 			case "last_user_interaction_time":
@@ -37977,8 +37977,8 @@ func (ec *executionContext) fieldContext_Query_session(ctx context.Context, fiel
 				return ec.fieldContext_Session_direct_download_url(ctx, field)
 			case "resources_url":
 				return ec.fieldContext_Session_resources_url(ctx, field)
-			case "messages_url":
-				return ec.fieldContext_Session_messages_url(ctx, field)
+			case "timeline_indicators_url":
+				return ec.fieldContext_Session_timeline_indicators_url(ctx, field)
 			case "deviceMemory":
 				return ec.fieldContext_Session_deviceMemory(ctx, field)
 			case "last_user_interaction_time":
@@ -40457,8 +40457,8 @@ func (ec *executionContext) fieldContext_Query_projectHasViewedASession(ctx cont
 				return ec.fieldContext_Session_direct_download_url(ctx, field)
 			case "resources_url":
 				return ec.fieldContext_Session_resources_url(ctx, field)
-			case "messages_url":
-				return ec.fieldContext_Session_messages_url(ctx, field)
+			case "timeline_indicators_url":
+				return ec.fieldContext_Session_timeline_indicators_url(ctx, field)
 			case "deviceMemory":
 				return ec.fieldContext_Session_deviceMemory(ctx, field)
 			case "last_user_interaction_time":
@@ -50432,8 +50432,8 @@ func (ec *executionContext) fieldContext_Session_resources_url(ctx context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _Session_messages_url(ctx context.Context, field graphql.CollectedField, obj *model1.Session) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Session_messages_url(ctx, field)
+func (ec *executionContext) _Session_timeline_indicators_url(ctx context.Context, field graphql.CollectedField, obj *model1.Session) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Session_timeline_indicators_url(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -50446,7 +50446,7 @@ func (ec *executionContext) _Session_messages_url(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Session().MessagesURL(rctx, obj)
+		return ec.resolvers.Session().TimelineIndicatorsURL(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -50460,7 +50460,7 @@ func (ec *executionContext) _Session_messages_url(ctx context.Context, field gra
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Session_messages_url(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Session_timeline_indicators_url(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Session",
 		Field:      field,
@@ -52802,8 +52802,8 @@ func (ec *executionContext) fieldContext_SessionResults_sessions(ctx context.Con
 				return ec.fieldContext_Session_direct_download_url(ctx, field)
 			case "resources_url":
 				return ec.fieldContext_Session_resources_url(ctx, field)
-			case "messages_url":
-				return ec.fieldContext_Session_messages_url(ctx, field)
+			case "timeline_indicators_url":
+				return ec.fieldContext_Session_timeline_indicators_url(ctx, field)
 			case "deviceMemory":
 				return ec.fieldContext_Session_deviceMemory(ctx, field)
 			case "last_user_interaction_time":
@@ -68069,7 +68069,7 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 				return innerFunc(ctx)
 
 			})
-		case "messages_url":
+		case "timeline_indicators_url":
 			field := field
 
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
@@ -68078,7 +68078,7 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Session_messages_url(ctx, field, obj)
+				res = ec._Session_timeline_indicators_url(ctx, field, obj)
 				return res
 			}
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -68,7 +68,7 @@ type Session {
 	event_counts: String
 	direct_download_url: String
 	resources_url: String
-	messages_url: String
+	timeline_indicators_url: String
 	deviceMemory: Int
 	last_user_interaction_time: Timestamp!
 	chunked: Boolean

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7399,16 +7399,16 @@ func (r *sessionResolver) ResourcesURL(ctx context.Context, obj *model.Session) 
 	return str, err
 }
 
-// MessagesURL is the resolver for the messages_url field.
-func (r *sessionResolver) MessagesURL(ctx context.Context, obj *model.Session) (*string, error) {
+// TimelineIndicatorsURL is the resolver for the timeline_indicators_url field.
+func (r *sessionResolver) TimelineIndicatorsURL(ctx context.Context, obj *model.Session) (*string, error) {
 	// Direct download only supported for clients that accept Brotli content encoding
 	if !obj.AllObjectsCompressed || !r.isBrotliAccepted(ctx) {
 		return nil, nil
 	}
 
-	str, err := r.StorageClient.GetDirectDownloadURL(ctx, obj.ProjectID, obj.ID, storage.ConsoleMessagesCompressed, nil)
+	str, err := r.StorageClient.GetDirectDownloadURL(ctx, obj.ProjectID, obj.ID, storage.TimelineIndicatorEvents, nil)
 	if err != nil {
-		return nil, e.Wrap(err, "error getting messages URL")
+		return nil, e.Wrap(err, "error getting timeline indicators URL")
 	}
 
 	return str, err

--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -109,7 +109,7 @@ func (f *FilesystemClient) GetDirectDownloadURL(_ context.Context, projectId int
 }
 
 func (f *FilesystemClient) GetRawData(ctx context.Context, sessionId, projectId int, payloadType model.RawPayloadType) (map[int]string, error) {
-	prefix := fmt.Sprintf("%s/raw-events/%d/%d", f.fsRoot, sessionId, projectId)
+	prefix := fmt.Sprintf("%s/raw-events/%d/%d", f.fsRoot, projectId, sessionId)
 	dir, err := os.ReadDir(prefix)
 	if err != nil {
 		log.WithContext(ctx).Warnf("error listing objects in fs: %s", err)
@@ -240,7 +240,7 @@ func (f *FilesystemClient) PushRawEvents(ctx context.Context, sessionId, project
 		return errors.Wrap(err, "error encoding gob")
 	}
 
-	key := fmt.Sprintf("%s/raw-events/%d/%d/%v-%s", f.fsRoot, sessionId, projectId, payloadType, uuid.New().String())
+	key := fmt.Sprintf("%s/raw-events/%d/%d/%v-%s", f.fsRoot, projectId, sessionId, payloadType, uuid.New().String())
 	_, err := f.writeFSBytes(ctx, key, buf)
 	return err
 }
@@ -307,7 +307,7 @@ func (f *FilesystemClient) UploadAsset(ctx context.Context, uuid, _ string, read
 }
 
 func (f *FilesystemClient) readCompressed(ctx context.Context, sessionId int, projectId int, t PayloadType, results interface{}) error {
-	key := fmt.Sprintf("%s/%v/%v/%v", f.fsRoot, sessionId, projectId, t)
+	key := fmt.Sprintf("%s/%v/%v/%v", f.fsRoot, projectId, sessionId, t)
 	if _, err := os.Stat(key); err != nil {
 		log.WithContext(ctx).Warnf("file %s does not exist", key)
 		return nil

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -5133,7 +5133,7 @@ export const GetSessionDocument = gql`
 			event_counts
 			direct_download_url
 			resources_url
-			messages_url
+			timeline_indicators_url
 			deviceMemory
 			last_user_interaction_time
 			length

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -1632,7 +1632,7 @@ export type GetSessionQuery = { __typename?: 'Query' } & {
 			| 'event_counts'
 			| 'direct_download_url'
 			| 'resources_url'
-			| 'messages_url'
+			| 'timeline_indicators_url'
 			| 'deviceMemory'
 			| 'last_user_interaction_time'
 			| 'length'

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2388,7 +2388,6 @@ export type Session = {
 	language: Scalars['String']
 	last_user_interaction_time: Scalars['Timestamp']
 	length?: Maybe<Scalars['Int']>
-	messages_url?: Maybe<Scalars['String']>
 	object_storage_enabled?: Maybe<Scalars['Boolean']>
 	os_name: Scalars['String']
 	os_version: Scalars['String']
@@ -2400,6 +2399,7 @@ export type Session = {
 	secure_id: Scalars['String']
 	starred?: Maybe<Scalars['Boolean']>
 	state: Scalars['String']
+	timeline_indicators_url?: Maybe<Scalars['String']>
 	user_object?: Maybe<Scalars['Any']>
 	user_properties?: Maybe<Scalars['String']>
 	viewed?: Maybe<Scalars['Boolean']>

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -251,7 +251,7 @@ query GetSession($secure_id: String!) {
 		event_counts
 		direct_download_url
 		resources_url
-		messages_url
+		timeline_indicators_url
 		deviceMemory
 		last_user_interaction_time
 		length

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -6,7 +6,6 @@ import {
 	useGetSessionIntervalsQuery,
 	useGetSessionPayloadQuery,
 	useGetSessionQuery,
-	useGetTimelineIndicatorEventsQuery,
 	useMarkSessionAsViewedMutation,
 } from '@graph/hooks'
 import { GetSessionQuery } from '@graph/operations'
@@ -28,6 +27,7 @@ import {
 	PlayerReducer,
 	SessionViewability,
 } from '@pages/Player/PlayerHook/PlayerState'
+import { useTimelineIndicators } from '@pages/Player/TimelineIndicatorsContext/TimelineIndicatorsContext'
 import analytics from '@util/analytics'
 import { indexedDBFetch, indexedDBString } from '@util/db'
 import log from '@util/log'
@@ -114,13 +114,6 @@ export const usePlayer = (): ReplayerContextInterface => {
 			!project_id ||
 			CHUNKING_DISABLED_PROJECTS.includes(project_id),
 	})
-	const { data: timelineIndicatorEvents } =
-		useGetTimelineIndicatorEventsQuery({
-			variables: {
-				session_secure_id: session_secure_id!,
-			},
-			skip: !session_secure_id,
-		})
 	const { data: sessionData } = useGetSessionQuery({
 		variables: {
 			secure_id: session_secure_id!,
@@ -145,6 +138,9 @@ export const usePlayer = (): ReplayerContextInterface => {
 		skip: !session_secure_id,
 		fetchPolicy: 'network-only',
 	})
+	const { timelineIndicatorEvents } = useTimelineIndicators(
+		sessionData?.session || undefined,
+	)
 	const { data: sessionPayload, subscribeToMore: subscribeToSessionPayload } =
 		useGetSessionPayloadQuery({
 			fetchPolicy: 'no-cache',

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -3,13 +3,13 @@ import {
 	GetSessionIntervalsQuery,
 	GetSessionPayloadQuery,
 	GetSessionQuery,
-	GetTimelineIndicatorEventsQuery,
 } from '@graph/operations'
 import {
 	ErrorObject,
 	Session,
 	SessionComment,
 	SessionResults,
+	TimelineIndicatorEvent,
 } from '@graph/schemas'
 import { EventType, Replayer } from '@highlight-run/rrweb'
 import {
@@ -105,7 +105,12 @@ interface PlayerState {
 	onSessionPayloadLoadedPayload?: {
 		sessionIntervals: GetSessionIntervalsQuery | undefined
 		sessionPayload: GetSessionPayloadQuery | undefined
-		timelineIndicatorEvents: GetTimelineIndicatorEventsQuery | undefined
+		timelineIndicatorEvents:
+			| Pick<
+					TimelineIndicatorEvent,
+					'timestamp' | 'data' | 'type' | 'sid'
+			  >[]
+			| undefined
 	}
 	performancePayloads: Array<HighlightPerformancePayload>
 	project_id: string
@@ -249,7 +254,10 @@ interface onSessionPayloadLoaded {
 	type: PlayerActionType.onSessionPayloadLoaded
 	sessionPayload?: GetSessionPayloadQuery
 	sessionIntervals?: GetSessionIntervalsQuery
-	timelineIndicatorEvents?: GetTimelineIndicatorEventsQuery
+	timelineIndicatorEvents?: Pick<
+		TimelineIndicatorEvent,
+		'timestamp' | 'data' | 'type' | 'sid'
+	>[]
 }
 
 interface setLastActiveString {
@@ -791,11 +799,9 @@ const processSessionMetadata = (
 
 	const parsedTimelineIndicatorEvents =
 		s.onSessionPayloadLoadedPayload.timelineIndicatorEvents &&
-		s.onSessionPayloadLoadedPayload.timelineIndicatorEvents
-			.timeline_indicator_events.length > 0
+		s.onSessionPayloadLoadedPayload.timelineIndicatorEvents.length > 0
 			? toHighlightEvents(
-					s.onSessionPayloadLoadedPayload.timelineIndicatorEvents
-						.timeline_indicator_events,
+					s.onSessionPayloadLoadedPayload.timelineIndicatorEvents,
 			  )
 			: events
 	s.sessionIntervals = getCommentsInSessionIntervalsRelative(

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -10,7 +10,7 @@ import { H } from 'highlight.run'
 import { useCallback, useEffect, useState } from 'react'
 import { BooleanParam, useQueryParam } from 'use-query-params'
 
-export enum ResourceLoadingError {
+export enum LoadingError {
 	NetworkResourcesTooLarge = 'payload too large.',
 	NetworkResourcesFetchFailed = 'failed to fetch.',
 }
@@ -19,7 +19,7 @@ interface ResourcesContext {
 	resourcesLoading: boolean
 	loadResources: () => void
 	resources: NetworkResourceWithID[]
-	error?: ResourceLoadingError
+	error?: LoadingError
 }
 
 export type NetworkResourceWithID = PerformanceResourceTiming & {
@@ -33,7 +33,7 @@ export const useResources = (
 ): ResourcesContext => {
 	const { session_secure_id } = useParams<{ session_secure_id: string }>()
 	const [sessionSecureId, setSessionSecureId] = useState<string>()
-	const [error, setError] = useState<ResourceLoadingError>()
+	const [error, setError] = useState<LoadingError>()
 	const [downloadResources] = useQueryParam('downloadresources', BooleanParam)
 
 	const [resourcesLoading, setResourcesLoading] = useState(false)
@@ -107,7 +107,7 @@ export const useResources = (
 				if (!session.resources_url) return
 				const limit = await checkResourceLimit(session.resources_url)
 				if (limit) {
-					setError(ResourceLoadingError.NetworkResourcesTooLarge)
+					setError(LoadingError.NetworkResourcesTooLarge)
 					H.consumeError(new Error(limit.error), undefined, {
 						fileSize: limit.fileSize.toString(),
 						limit: limit.sizeLimit.toString(),
@@ -146,9 +146,7 @@ export const useResources = (
 							)
 						})
 						.catch((e) => {
-							setError(
-								ResourceLoadingError.NetworkResourcesFetchFailed,
-							)
+							setError(LoadingError.NetworkResourcesFetchFailed)
 							setResources([])
 							H.consumeError(
 								e,

--- a/frontend/src/pages/Player/TimelineIndicatorsContext/TimelineIndicatorsContext.tsx
+++ b/frontend/src/pages/Player/TimelineIndicatorsContext/TimelineIndicatorsContext.tsx
@@ -1,0 +1,121 @@
+import { useGetTimelineIndicatorEventsQuery } from '@graph/hooks'
+import { Session, TimelineIndicatorEvent } from '@graph/schemas'
+import { LoadingError } from '@pages/Player/ResourcesContext/ResourcesContext'
+import { indexedDBFetch } from '@util/db'
+import { checkResourceLimit } from '@util/preload'
+import { H } from 'highlight.run'
+import { useEffect, useState } from 'react'
+
+interface TimelineIndicatorsContext {
+	timelineIndicatorsLoading: boolean
+	timelineIndicatorEvents: Pick<
+		TimelineIndicatorEvent,
+		'timestamp' | 'data' | 'type' | 'sid'
+	>[]
+	error?: LoadingError
+}
+
+export const useTimelineIndicators = (
+	session: Pick<Session, 'timeline_indicators_url' | 'secure_id'> | undefined,
+): TimelineIndicatorsContext => {
+	const [error, setError] = useState<LoadingError>()
+
+	const [loading, setLoading] = useState(false)
+	const skipQuery = !session?.secure_id || !!session?.timeline_indicators_url
+
+	const { data, loading: queryLoading } = useGetTimelineIndicatorEventsQuery({
+		variables: {
+			session_secure_id: session?.secure_id ?? '',
+		},
+		fetchPolicy: 'no-cache',
+		skip: skipQuery,
+	})
+
+	useEffect(() => {
+		if (!skipQuery) {
+			setLoading(queryLoading)
+		}
+	}, [queryLoading, skipQuery])
+
+	const [timelineIndicatorEvents, setTimelineIndicatorEvents] = useState<
+		Pick<TimelineIndicatorEvent, 'timestamp' | 'data' | 'type' | 'sid'>[]
+	>([])
+	useEffect(() => {
+		if (!session?.secure_id || !data?.timeline_indicator_events) return
+		setError(undefined)
+		setTimelineIndicatorEvents(
+			data.timeline_indicator_events.map((e) => ({
+				...e,
+				session_secure_id: session.secure_id,
+			})) ?? [],
+		)
+	}, [data?.timeline_indicator_events, session?.secure_id])
+
+	useEffect(() => {
+		if (!!session?.timeline_indicators_url) {
+			setLoading(true)
+			;(async () => {
+				if (!session.timeline_indicators_url) return
+				const limit = await checkResourceLimit(
+					session.timeline_indicators_url,
+				)
+				if (limit) {
+					setError(LoadingError.NetworkResourcesTooLarge)
+					H.consumeError(new Error(limit.error), undefined, {
+						fileSize: limit.fileSize.toString(),
+						limit: limit.sizeLimit.toString(),
+						sessionSecureID: session?.secure_id,
+					})
+					return
+				}
+				let response
+				for await (const r of indexedDBFetch(
+					session.timeline_indicators_url,
+				)) {
+					response = r
+				}
+				if (response) {
+					response
+						.json()
+						.then((data) => {
+							setError(undefined)
+							setTimelineIndicatorEvents(
+								(data as any[] | undefined)?.map(
+									// convert the s3 file schema to what frontend expects
+									(r) =>
+										({
+											timestamp: r.Timestamp,
+											type: r.Type,
+											sid: r.SID,
+											data: r.data,
+										} as Pick<
+											TimelineIndicatorEvent,
+											| 'timestamp'
+											| 'data'
+											| 'type'
+											| 'sid'
+										>),
+								) ?? [],
+							)
+						})
+						.catch((e) => {
+							setError(LoadingError.NetworkResourcesFetchFailed)
+							setTimelineIndicatorEvents([])
+							H.consumeError(
+								e,
+								'Error direct downloading resources',
+							)
+						})
+						.finally(() => setLoading(false))
+				}
+			})()
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [session?.secure_id])
+
+	return {
+		timelineIndicatorEvents,
+		timelineIndicatorsLoading: loading,
+		error,
+	}
+}

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -16,7 +16,7 @@ import {
 import { PlayerSearchParameters } from '@pages/Player/PlayerHook/utils'
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import {
-	ResourceLoadingError,
+	LoadingError,
 	useResourcesContext,
 } from '@pages/Player/ResourcesContext/ResourcesContext'
 import { EmptyDevToolsCallout } from '@pages/Player/Toolbar/DevToolsWindowV2/EmptyDevToolsCallout/EmptyDevToolsCallout'
@@ -573,7 +573,7 @@ export const UnknownRequestStatusCode = ({
 const ResourceLoadingErrorCallout = function ({
 	error,
 }: {
-	error: ResourceLoadingError
+	error: LoadingError
 }) {
 	return (
 		<Box

--- a/frontend/src/util/preload.ts
+++ b/frontend/src/util/preload.ts
@@ -18,7 +18,7 @@ import {
 	GetWebVitalsDocument,
 } from '@graph/hooks'
 import { ErrorInstance, OpenSearchCalendarInterval } from '@graph/schemas'
-import { ResourceLoadingError } from '@pages/Player/ResourcesContext/ResourcesContext'
+import { LoadingError } from '@pages/Player/ResourcesContext/ResourcesContext'
 import { indexedDBFetch, IndexedDBLink, isIndexedDBEnabled } from '@util/db'
 import { client } from '@util/graph'
 import log from '@util/log'
@@ -207,7 +207,7 @@ export const checkResourceLimit = async function (resources_url: string) {
 	const fileSize = Number(r.headers.get('Content-Length'))
 	if (fileSize > RESOURCE_FILE_SIZE_LIMIT_BYTES) {
 		return {
-			error: ResourceLoadingError.NetworkResourcesTooLarge,
+			error: LoadingError.NetworkResourcesTooLarge,
 			fileSize: fileSize,
 			sizeLimit: RESOURCE_FILE_SIZE_LIMIT_BYTES,
 		}
@@ -239,6 +239,15 @@ export const loadSession = async function (secureID: string) {
 			const limit = await checkResourceLimit(sess.resources_url)
 			if (!limit) {
 				for await (const _ of indexedDBFetch(sess.resources_url)) {
+				}
+			}
+		}
+		if (sess.timeline_indicators_url) {
+			const limit = await checkResourceLimit(sess.timeline_indicators_url)
+			if (!limit) {
+				for await (const _ of indexedDBFetch(
+					sess.timeline_indicators_url,
+				)) {
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Timeline indicator events were loaded from the backend where the backend would download the file from S3.
Instead, pass the S3 signed url to the frontend as we do for resources and the events data
so that the frontend could asynchronously load the timeline without blocking the rest of the loading, and
to make sure the cloudfront download could happen faster and be cached by the browser.

## How did you test this change?

Local fetch and render of large session VbEEeAuUMnOqTefUNruC7Dhd3Yb0
![image](https://github.com/highlight/highlight/assets/1351531/27b3f2e6-822c-403a-bb17-35af1ff21c4d)


## Are there any deployment considerations?

No