### PR TITLE
add highlight.run browser key for cdn distribution

### DIFF
--- a/sdk/firstload/.npmignore
+++ b/sdk/firstload/.npmignore
@@ -1,3 +1,2 @@
 .turbo
-*.js.map
-
+*.map

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -191,3 +191,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Minor Changes
 
 - Moves bundling from rollup to vite.
+
+## 6.4.1
+
+### Patch Changes
+
+- Switch to umd default output.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,29 @@
 {
 	"name": "highlight.run",
-	"version": "6.4.0",
+	"version": "6.4.1",
+	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
+	"keywords": [
+		"highlight",
+		"session replay",
+		"error monitoring",
+		"logging",
+		"debugging",
+		"observability",
+		"browser",
+		"library"
+	],
+	"homepage": "https://github.com/highlight/highlight#readme",
+	"bugs": {
+		"url": "https://github.com/highlight/highlight/issues",
+		"email": "support@highlight.io"
+	},
+	"license": "Apache-2.0",
+	"repository": {
+		"repository": {
+			"type": "git",
+			"url": "https://github.com/highlight/highlight.git"
+		}
+	},
 	"scripts": {
 		"build": "node scripts/version.mjs && yarn typegen && vite build",
 		"dev": "node scripts/version.mjs && vite dev",
@@ -12,6 +35,7 @@
 	},
 	"type": "module",
 	"main": "./dist/index.js",
+	"browser": "./dist/index.umd.cjs",
 	"types": "./dist/firstload/src/index.d.ts",
 	"exports": {
 		"types": "./dist/firstload/src/index.d.ts",
@@ -23,7 +47,6 @@
 	"files": [
 		"dist"
 	],
-	"license": "MIT",
 	"devDependencies": {
 		"@size-limit/file": "^8.1.0",
 		"@types/chrome": "^0.0.144",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "6.4.0"
+export default "6.4.1"

--- a/sdk/firstload/vite.config.ts
+++ b/sdk/firstload/vite.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
 		},
 		minify: 'terser',
 		emptyOutDir: false,
-		sourcemap: true,
+		// sourcemaps are not published to reduce package size
+		sourcemap: false,
 		rollupOptions: {
 			output: {
 				exports: 'named',


### PR DESCRIPTION
## Summary

As mentioned in https://github.com/highlight/highlight/pull/5282#issuecomment-1549450686, our highlight.run release
was not setting a `browser` key resulting in `unpkg` and `cdn.jsdelivr.net` using the `main` file, which is now an ESM build.

Adds the `browser` key to ship the `<script>` tag umd file.
https://www.jsdelivr.com/documentation#id-configuring-a-default-file-in-packagejson

Updates some other highlight.run package metadata.

## How did you test this change?

Local deploy using `<script src="http://localhost:5173/dist/index.umd.cjs></script>`

https://www.loom.com/share/98a9863ada1143b197f3201bf6ad4400

## Are there any deployment considerations?

New patch version of highlight.run released.
