### PR TITLE
fix umd named object

### DIFF
--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "6.4.1",
+	"version": "6.4.2",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -35,7 +35,8 @@
 	},
 	"type": "module",
 	"main": "./dist/index.js",
-	"browser": "./dist/index.umd.cjs",
+	"unpkg": "./dist/index.umd.cjs",
+	"jsdelivr": "./dist/index.umd.cjs",
 	"types": "./dist/firstload/src/index.d.ts",
 	"exports": {
 		"types": "./dist/firstload/src/index.d.ts",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "6.4.1"
+export default "6.4.2"

--- a/sdk/firstload/vite.config.ts
+++ b/sdk/firstload/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
 		lib: {
 			formats: ['es', 'cjs', 'umd'],
 			entry: resolve(__dirname, 'src/index.tsx'),
-			name: 'highlight',
+			name: 'H',
 			fileName: 'index',
 		},
 		minify: 'terser',


### PR DESCRIPTION
## Summary

Main exported object is `H`, not `highlight`.

## How did you test this change?

![image](https://github.com/highlight/highlight/assets/1351531/2031a9c4-1072-47f9-9070-909ed01f6304)
![image](https://github.com/highlight/highlight/assets/1351531/a223efa8-9476-4423-a5f4-9dc9b68eb9d8)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
