### PR TITLE
#5195 add overage cards to sessions/errors/logs feeds

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -44,7 +44,7 @@ import { useProjectId } from '@hooks/useProjectId'
 import SvgHighlightLogoOnLight from '@icons/HighlightLogoOnLight'
 import SvgXIcon from '@icons/XIcon'
 import {
-	getQuotaPercents,
+	getMeterAmounts,
 	getTrialEndDateMessage,
 } from '@pages/Billing/utils/utils'
 import useLocalStorage from '@rehooks/local-storage'
@@ -754,7 +754,7 @@ const BillingBanner: React.FC = () => {
 	let bannerMessage: string | React.ReactNode = ''
 	const hasTrial = isProjectWithinTrial(data?.workspace_for_project)
 
-	const records = getQuotaPercents(data)
+	const records = getMeterAmounts(data)
 
 	const productsApproachingQuota = records
 		.filter((r) => r[1] > APPROACHING_QUOTA_THRESHOLD && r[1] <= 1)

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -44,7 +44,7 @@ import { useProjectId } from '@hooks/useProjectId'
 import SvgHighlightLogoOnLight from '@icons/HighlightLogoOnLight'
 import SvgXIcon from '@icons/XIcon'
 import {
-	getMeterAmounts,
+	getQuotaPercents,
 	getTrialEndDateMessage,
 } from '@pages/Billing/utils/utils'
 import useLocalStorage from '@rehooks/local-storage'
@@ -754,7 +754,7 @@ const BillingBanner: React.FC = () => {
 	let bannerMessage: string | React.ReactNode = ''
 	const hasTrial = isProjectWithinTrial(data?.workspace_for_project)
 
-	const records = getMeterAmounts(data)
+	const records = getQuotaPercents(data)
 
 	const productsApproachingQuota = records
 		.filter((r) => r[1] > APPROACHING_QUOTA_THRESHOLD && r[1] <= 1)

--- a/frontend/src/pages/Billing/utils/utils.ts
+++ b/frontend/src/pages/Billing/utils/utils.ts
@@ -2,12 +2,7 @@ import moment from 'moment'
 
 import { GetBillingDetailsForProjectQuery } from '@/graph/generated/operations'
 
-import {
-	Maybe,
-	PlanType,
-	ProductType,
-	RetentionPeriod,
-} from '../../../graph/generated/schemas'
+import { Maybe, PlanType, ProductType } from '../../../graph/generated/schemas'
 
 /**
  * Returns whether the change from the previousPlan to the newPlan was an upgrade.
@@ -49,9 +44,17 @@ export const getTrialEndDateMessage = (trialEndDate: any): string => {
 	)}. After this trial, you will be on the free tier.`
 }
 
-export const getQuotaPercents = (
+export const tryCastDate = (date: Maybe<string> | undefined) => {
+	if (date) {
+		return new Date(date)
+	} else {
+		return undefined
+	}
+}
+
+export const getMeterAmounts = (
 	data: GetBillingDetailsForProjectQuery,
-): [ProductType, number][] => {
+): [ProductType, number, number][] => {
 	const sessionsMeter = data.billingDetailsForProject?.meter ?? 0
 	const sessionsQuota =
 		data.billingDetailsForProject?.sessionsBillingLimit ?? 1
@@ -60,24 +63,14 @@ export const getQuotaPercents = (
 	const logsMeter = data.billingDetailsForProject?.logsMeter ?? 0
 	const logsQuota = data.billingDetailsForProject?.logsBillingLimit ?? 1
 	return [
-		[ProductType.Sessions, sessionsMeter / sessionsQuota],
-		[ProductType.Errors, errorsMeter / errorsQuota],
-		[ProductType.Logs, logsMeter / logsQuota],
+		[ProductType.Sessions, sessionsMeter, sessionsQuota],
+		[ProductType.Errors, errorsMeter, errorsQuota],
+		[ProductType.Logs, logsMeter, logsQuota],
 	]
 }
 
-export const RETENTION_PERIOD_LABELS = {
-	[RetentionPeriod.ThirtyDays]: '30 days',
-	[RetentionPeriod.ThreeMonths]: '3 months',
-	[RetentionPeriod.SixMonths]: '6 months',
-	[RetentionPeriod.TwelveMonths]: '12 months',
-	[RetentionPeriod.TwoYears]: '2 years',
-}
-
-export const tryCastDate = (date: Maybe<string> | undefined) => {
-	if (date) {
-		return new Date(date)
-	} else {
-		return undefined
-	}
+export const getQuotaPercents = (
+	data: GetBillingDetailsForProjectQuery,
+): [ProductType, number][] => {
+	return getMeterAmounts(data).map((r) => [r[0], r[1] / r[2]])
 }

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -8,7 +8,7 @@ import SearchPagination, {
 	START_PAGE,
 } from '@components/SearchPagination/SearchPagination'
 import { useGetErrorGroupsOpenSearchQuery } from '@graph/hooks'
-import { ErrorGroup, Maybe } from '@graph/schemas'
+import { ErrorGroup, Maybe, ProductType } from '@graph/schemas'
 import { Box } from '@highlight-run/ui'
 import { useErrorSearchContext } from '@pages/Errors/ErrorSearchContext/ErrorSearchContext'
 import { ErrorFeedCard } from '@pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard'
@@ -21,6 +21,7 @@ import { useParams } from '@util/react-router/useParams'
 import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 
+import { OverageCard } from '@/pages/Sessions/SessionsFeedV3/OverageCard/OverageCard'
 import { styledVerticalScrollbar } from '@/style/common.css'
 
 import * as style from './SearchPanel.css'
@@ -117,6 +118,7 @@ const SearchPanel = () => {
 					<LoadingBox />
 				) : (
 					<>
+						<OverageCard productType={ProductType.Errors} />
 						{searchResultsCount === 0 || !errorGroups ? (
 							<EmptySearchResults
 								kind={SearchResultsKind.Errors}

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -1,4 +1,4 @@
-import { LogLevel } from '@graph/schemas'
+import { LogLevel, ProductType } from '@graph/schemas'
 import { Box } from '@highlight-run/ui'
 import {
 	fifteenMinutesAgo,
@@ -23,6 +23,8 @@ import {
 	useQueryParam,
 	withDefault,
 } from 'use-query-params'
+
+import { OverageCard } from '@/pages/LogsPage/OverageCard/OverageCard'
 
 export const QueryParam = withDefault(StringParam, '')
 const FixedRangeStartDateParam = withDefault(DateTimeParam, fifteenMinutesAgo)
@@ -166,6 +168,9 @@ const LogsPageInner = ({ timeMode, logCursor, startDateDefault }: Props) => {
 						}
 						ref={tableContainerRef}
 					>
+						<Box my="4">
+							<OverageCard productType={ProductType.Logs} />
+						</Box>
 						<IntegrationCta />
 						<LogsTable
 							logEdges={logEdges}

--- a/frontend/src/pages/LogsPage/OverageCard/OverageCard.tsx
+++ b/frontend/src/pages/LogsPage/OverageCard/OverageCard.tsx
@@ -1,0 +1,99 @@
+import { Button } from '@components/Button'
+import { Box, Callout, Stack, Text } from '@highlight-run/ui'
+import { useNavigate } from 'react-router-dom'
+import { useSessionStorage } from 'react-use'
+
+import { useGetBillingDetailsForProjectQuery } from '@/graph/generated/hooks'
+import { ProductType } from '@/graph/generated/schemas'
+import { useProjectId } from '@/hooks/useProjectId'
+import { getMeterAmounts } from '@/pages/Billing/utils/utils'
+import { useApplicationContext } from '@/routers/ProjectRouter/context/ApplicationContext'
+import { formatNumberWithDelimiters } from '@/util/numbers'
+
+interface Props {
+	productType: ProductType
+}
+
+export const OverageCard = ({ productType }: Props) => {
+	const [hideOverageCard, setHideOverageCard] = useSessionStorage(
+		`highlightHideOverageCard-${productType}`,
+		false,
+	)
+
+	const navigate = useNavigate()
+	const { currentWorkspace } = useApplicationContext()
+	const { projectId } = useProjectId()
+	const { data, loading } = useGetBillingDetailsForProjectQuery({
+		variables: { project_id: projectId },
+	})
+
+	if (loading || !data || hideOverageCard) {
+		return null
+	}
+
+	const meters = getMeterAmounts(data)
+	const meter = meters[productType][0]
+	const quota = meters[productType][1]
+	if (quota === undefined || meter < quota) {
+		return null
+	}
+
+	const productTypeLower = productType.toLowerCase()
+
+	return (
+		<Box backgroundColor="n2" mb="4">
+			<Callout icon={false}>
+				<Stack
+					direction="row"
+					alignItems="center"
+					justifyContent="space-between"
+				>
+					<Stack direction="column" gap="12" my="6">
+						<Box alignItems="flex-start" display="flex">
+							<Box>
+								<Text
+									color="strong"
+									weight="bold"
+									size="medium"
+								>
+									{productType} overage!
+								</Text>
+							</Box>
+						</Box>
+						<Text color="moderate">
+							You've reached your limit of{' '}
+							<b>{formatNumberWithDelimiters(quota)}</b>{' '}
+							{productTypeLower} this month. To record more{' '}
+							{productTypeLower}, update your limit!
+						</Text>
+					</Stack>
+
+					<Stack direction="row" gap="8">
+						<Button
+							kind="primary"
+							onClick={() => {
+								navigate(
+									`/w/${currentWorkspace!.id}/current-plan`,
+								)
+							}}
+							trackingId="overageUpdateLimit"
+						>
+							Update limit
+						</Button>
+
+						<Button
+							kind="secondary"
+							emphasis="low"
+							onClick={() => {
+								setHideOverageCard(true)
+							}}
+							trackingId="hideOverageCard"
+						>
+							Hide
+						</Button>
+					</Stack>
+				</Stack>
+			</Callout>
+		</Box>
+	)
+}

--- a/frontend/src/pages/Sessions/SessionsFeedV3/OverageCard/OverageCard.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/OverageCard/OverageCard.tsx
@@ -1,0 +1,78 @@
+import { Button } from '@components/Button'
+import { Box, Callout, Stack, Text } from '@highlight-run/ui'
+import { useNavigate } from 'react-router-dom'
+import { useSessionStorage } from 'react-use'
+
+import { useGetBillingDetailsForProjectQuery } from '@/graph/generated/hooks'
+import { ProductType } from '@/graph/generated/schemas'
+import { useProjectId } from '@/hooks/useProjectId'
+import { getMeterAmounts } from '@/pages/Billing/utils/utils'
+import { useApplicationContext } from '@/routers/ProjectRouter/context/ApplicationContext'
+import { formatNumberWithDelimiters } from '@/util/numbers'
+
+interface Props {
+	productType: ProductType
+}
+
+export const OverageCard = ({ productType }: Props) => {
+	const [hideOverageCard, setHideOverageCard] = useSessionStorage(
+		`highlightHideOverageCard-${productType}`,
+		false,
+	)
+
+	const navigate = useNavigate()
+	const { currentWorkspace } = useApplicationContext()
+	const { projectId } = useProjectId()
+	const { data, loading } = useGetBillingDetailsForProjectQuery({
+		variables: { project_id: projectId },
+	})
+
+	if (loading || !data || hideOverageCard) {
+		return null
+	}
+
+	const meters = getMeterAmounts(data)
+	const meter = meters[productType][0]
+	const quota = meters[productType][1]
+	if (quota === undefined || meter < quota) {
+		return null
+	}
+
+	const productTypeLower = productType.toLowerCase()
+
+	return (
+		<Box backgroundColor="n2" mb="4">
+			<Callout title={`${productType} overage!`} icon={false}>
+				<Text color="moderate">
+					You've reached your limit of{' '}
+					<b>{formatNumberWithDelimiters(quota)}</b>{' '}
+					{productTypeLower} this month. To record more{' '}
+					{productTypeLower}, update your limit!
+				</Text>
+
+				<Stack direction="row" gap="8">
+					<Button
+						kind="primary"
+						onClick={() => {
+							navigate(`/w/${currentWorkspace!.id}/current-plan`)
+						}}
+						trackingId="overageUpdateLimit"
+					>
+						Update limit
+					</Button>
+
+					<Button
+						kind="secondary"
+						emphasis="low"
+						onClick={() => {
+							setHideOverageCard(true)
+						}}
+						trackingId="hideOverageCard"
+					>
+						Hide
+					</Button>
+				</Stack>
+			</Callout>
+		</Box>
+	)
+}

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -26,6 +26,7 @@ import {
 	DateHistogramBucketSize,
 	Maybe,
 	PlanType,
+	ProductType,
 	Session,
 } from '@graph/schemas'
 import { Box } from '@highlight-run/ui'
@@ -44,6 +45,7 @@ import { roundFeedDate, serializeAbsoluteTimeRange } from '@util/time'
 import clsx from 'clsx'
 import React, { useCallback, useEffect, useMemo, useRef } from 'react'
 
+import { OverageCard } from '@/pages/Sessions/SessionsFeedV3/OverageCard/OverageCard'
 import { styledVerticalScrollbar } from '@/style/common.css'
 
 import usePlayerConfiguration from '../../Player/PlayerHook/utils/usePlayerConfiguration'
@@ -316,6 +318,7 @@ export const SessionFeedV3 = React.memo(() => {
 						/>
 					</Box>
 				)}
+				{true && <OverageCard productType={ProductType.Sessions} />}
 				<Box
 					padding="8"
 					overflowX="hidden"

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -318,7 +318,6 @@ export const SessionFeedV3 = React.memo(() => {
 						/>
 					</Box>
 				)}
-				{true && <OverageCard productType={ProductType.Sessions} />}
 				<Box
 					padding="8"
 					overflowX="hidden"
@@ -330,6 +329,7 @@ export const SessionFeedV3 = React.memo(() => {
 						<LoadingBox />
 					) : (
 						<>
+							<OverageCard productType={ProductType.Sessions} />
 							{searchResultsCount === 0 ? (
 								showStarredSessions ? (
 									<SearchEmptyState


### PR DESCRIPTION
## Summary
- per https://github.com/highlight/highlight/issues/5195, adds overage cards to make it clearer to the user when they have sessions/logs/errors that are no longer being recorded due to exceeding their billing limits
<img width="977" alt="Screen Shot 2023-05-16 at 10 17 56 AM" src="https://github.com/highlight/highlight/assets/86132398/547b2c9e-dc44-4604-aab8-ff6762e0baf9">
<img width="410" alt="Screen Shot 2023-05-16 at 10 12 23 AM" src="https://github.com/highlight/highlight/assets/86132398/a20b11ff-4e67-4966-b15b-d14811c41c77">

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- local clicktest
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- dependent on `zane/billing_page_v2` branch, will merge into that branch or merge into main after that is deployed
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
