### PR TITLE
use consistent js extension for highlight.run

### DIFF
--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -197,3 +197,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Patch Changes
 
 - Switch to umd default output.
+
+## 6.4.3
+
+### Patch Changes
+
+- Fixes to umd format

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -61,7 +61,7 @@
 	"size-limit": [
 		{
 			"path": "dist/**.js",
-			"limit": "32 kB",
+			"limit": "64 kB",
 			"brotli": true
 		}
 	]

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "6.4.2",
+	"version": "6.4.3",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",
@@ -34,16 +34,16 @@
 		"typegen": "tsc && node scripts/replace-client-imports.mjs"
 	},
 	"type": "module",
-	"main": "./dist/index.js",
-	"unpkg": "./dist/index.umd.cjs",
-	"jsdelivr": "./dist/index.umd.cjs",
+	"main": "./dist/index.es.js",
+	"unpkg": "./dist/index.umd.js",
+	"jsdelivr": "./dist/index.umd.js",
 	"types": "./dist/firstload/src/index.d.ts",
 	"exports": {
 		"types": "./dist/firstload/src/index.d.ts",
-		"import": "./dist/index.js",
-		"require": "./dist/index.cjs",
-		"node": "./dist/index.cjs",
-		"default": "./dist/index.js"
+		"import": "./dist/index.es.js",
+		"require": "./dist/index.cjs.js",
+		"node": "./dist/index.cjs.js",
+		"default": "./dist/index.es.js"
 	},
 	"files": [
 		"dist"

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "6.4.2"
+export default "6.4.3"

--- a/sdk/firstload/vite.config.ts
+++ b/sdk/firstload/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
 		rollupOptions: {
 			output: {
 				exports: 'named',
+				entryFileNames: '[name].[format].js',
 			},
 		},
 	},


### PR DESCRIPTION
## Summary

unpkg will use `application/node` when the file extension is `.umd.cjs`

## How did you test this change?

![image](https://github.com/highlight/highlight/assets/1351531/b003b160-2433-41d0-a2ab-0b31d2e2232e)


## Are there any deployment considerations?

new highlight.run patch