### PR TITLE
fix issue where identify after payload isn't excluded

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2969,9 +2969,13 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			return err
 		}
 	} else if excluded {
-		// Only update the excluded reason if it has changed
-		if sessionObj.ExcludedReason != reason {
-			if err := r.DB.Model(&model.Session{Model: model.Model{ID: sessionID}}).Update("ExcludedReason", reason).Error; err != nil {
+		// Only update the excluded flag and reason if either have changed
+		if sessionObj.Excluded != excluded || sessionObj.ExcludedReason != reason {
+			if err := r.DB.Model(&model.Session{Model: model.Model{ID: sessionID}}).
+				Select("Excluded", "ExcludedReason").Updates(&model.Session{
+				Excluded:       excluded,
+				ExcludedReason: reason,
+			}).Error; err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary
- there are sessions for ignored users not getting flagged as excluded: 
`select * from sessions where excluded_reason = 'IgnoredUser' and not excluded limit 1`
- it seems like this is affecting sessions where a payload is ingested before the session is identified
- was able to repro by logging out, starting a new session, and logging in as an ignored user
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- followed steps above before and after change
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, but we can probably backfill the excluded flag for these sessions. looking into how many are affected
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
