### PR TITLE
skip inactivity periods for live sessions

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -991,7 +991,6 @@ export const usePlayer = (): ReplayerContextInterface => {
 	useEffect(() => {
 		lastTimeRef.current = state.time
 		if (
-			!state.session?.processed ||
 			state.sessionMetadata.startTime === 0 ||
 			state.replayerState !== ReplayerState.Playing ||
 			session_secure_id !== state.session_secure_id
@@ -1040,7 +1039,6 @@ export const usePlayer = (): ReplayerContextInterface => {
 		state.time,
 		ensureChunksLoaded,
 		state.sessionMetadata.startTime,
-		state.session?.processed,
 		state.replayerState,
 		skipInactive,
 		getInactivityEnd,


### PR DESCRIPTION
## Summary

Sessions that are live but have been processed can have inactivity intervals.
We should skip them to make live sessions work more like non-live ones.

## How did you test this change?

[preview](https://frontend-pr-5359.onrender.com/1/sessions/jV2IeabUfdcacjr1XRnVdXMQy0D3?page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue%7C%7Ccustom_created_at%2Cbetween_date%2C2023-04-17T17%3A20%3A25.774Z_2023-05-17T17%3A20%3A25.774Z)
https://www.loom.com/share/5c94b3e044ca4be893dabd1cb13323b3

## Are there any deployment considerations?

No