### PR TITLE
Supress @highlight-run/client sourcemaps

### DIFF
--- a/sdk/client/vite.config.ts
+++ b/sdk/client/vite.config.ts
@@ -1,6 +1,7 @@
 // vite.config.ts
-import { resolve } from 'path'
+
 import { defineConfig } from 'vite'
+import { resolve } from 'path'
 
 export default defineConfig({
 	envPrefix: ['REACT_APP_'],
@@ -26,7 +27,7 @@ export default defineConfig({
 		},
 		minify: 'terser',
 		emptyOutDir: false,
-		sourcemap: true,
+		sourcemap: false,
 	},
 	define: {
 		// used by dependencies of highlight-client-worker

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -209,3 +209,10 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Minor Changes
 
 - Adds an `H.start({forceNew: true})` option that allows forcing the start of a new session recording.
+
+## 6.5.1
+
+### Patch Changes
+
+- Turn off client sourcemaps as they cause issues with next.js frontends.
+

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "6.5.0",
+	"version": "6.5.1",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "6.5.0"
+export default "6.5.1"

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "2.5.4",
+	"version": "2.5.5",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",


### PR DESCRIPTION
It looks like our `highlight-run/client` sourcemaps references are causing some weird, 404ed queries in client applications.

https://discord.com/channels/1026884757667188757/1026884757667188763/1108885210277347389