### PR TITLE
Repairing wordwrap settings for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -104,8 +104,6 @@
 	"[markdown]": {
 		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	},
-	"editor.wordWrapColumn": 120,
-	"editor.wordWrap": "wordWrapColumn",
 	"[css]": {
 		"editor.defaultFormatter": "vscode.css-language-features"
 	},


### PR DESCRIPTION
I didn't mean to commit this.