### PR TITLE
Load resources from Redis for unprocessed sessions

### DIFF
--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -292,38 +292,6 @@ func (r *Client) GetEvents(ctx context.Context, s *model.Session, cursor model.E
 	return allEvents, nil, newCursor
 }
 
-func (r *Client) GetResourceObjects(ctx context.Context, s *model.Session) ([]model.ResourcesObject, error) {
-	// TODO: Handle live mode + cursor
-
-	redisKey := NetworkResourcesKey(s.ID)
-	// redisData, err := r.redisClient.Get(ctx, redisKey).Result()
-	redisData, err := r.redisClient.ZRangeByScoreWithScores(ctx, redisKey, &redis.ZRangeBy{
-		Min: "-inf",
-		Max: "+inf",
-	}).Result()
-	if err != nil {
-		return nil, errors.Wrap(err, "error retrieving network resources from Redis")
-	}
-
-	resourceObjects := []model.ResourcesObject{}
-	for _, z := range redisData {
-		asBytes := []byte(z.Member.(string))
-
-		// Messages may be encoded with `snappy`.
-		// Try decoding them, but if decoding fails, use the original message.
-		decoded, err := snappy.Decode(nil, asBytes)
-		if err != nil {
-			decoded = asBytes
-		}
-
-		resourceObjects = append(resourceObjects, model.ResourcesObject{
-			Resources: string(decoded),
-		})
-	}
-
-	return resourceObjects, nil
-}
-
 func (r *Client) GetResources(ctx context.Context, s *model.Session) ([]interface{}, error) {
 	allResources := make([]interface{}, 0)
 


### PR DESCRIPTION
## Summary

Cleans up some outdated logic for fetching network request data from storage and Postgres and adds logic for reading from Redis. This is only hit when a session has not been processed (`resources_url == nil`).

https://www.loom.com/share/5557d98fa45c456ea306fc333e1173ef

Also started working on some notes about how data is fetched for session replay: https://www.notion.so/runhighlight/Live-Mode-Notes-53677c96bd9d4280a6e2164898da99df?pvs=4

## How did you test this change?

Local click test.

## Are there any deployment considerations?

Will monitor `Resources` resolver and click test once things are live in production.
