### PR TITLE
use es6 build compatibility

### DIFF
--- a/sdk/client/vite.config.ts
+++ b/sdk/client/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
 		},
 	},
 	build: {
+		target: 'es6',
 		lib: {
 			formats: ['umd'],
 			entry: resolve(__dirname, 'src/index.tsx'),

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -216,3 +216,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 
 - Turn off client sourcemaps as they cause issues with next.js frontends.
 
+
+## 6.5.2
+
+### Patch Changes
+
+- Target ES6 for library build compatability.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "6.5.1",
+	"version": "6.5.2",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "6.5.1"
+export default "6.5.2"

--- a/sdk/firstload/vite.config.ts
+++ b/sdk/firstload/vite.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
 	envPrefix: ['REACT_APP_'],
 	build: {
+		target: 'es6',
 		lib: {
 			formats: ['es', 'cjs', 'umd'],
 			entry: resolve(__dirname, 'src/index.tsx'),


### PR DESCRIPTION
## Summary

Certain environments have a problem with the `modules` target that vite uses by default.
Bundle to `ES6` for best compatibility.

## How did you test this change?

Local client preview.

<img width="1613" alt="Screenshot 2023-05-19 at 10 30 14 AM" src="https://github.com/highlight/highlight/assets/1351531/c80c65d7-09e8-45a9-bcee-cc1ca750cc08">


## Are there any deployment considerations?

No