### PR TITLE
Set hex dashboard link on Hubspot companies

### DIFF
--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	kafka_queue "github.com/highlight-run/highlight/backend/kafka-queue"
-	"github.com/highlight-run/highlight/backend/redis"
-	"github.com/openlyinc/pointy"
-	"github.com/samber/lo"
 	"io"
 	"math"
 	"net/http"
@@ -15,6 +11,11 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	kafka_queue "github.com/highlight-run/highlight/backend/kafka-queue"
+	"github.com/highlight-run/highlight/backend/redis"
+	"github.com/openlyinc/pointy"
+	"github.com/samber/lo"
 
 	"github.com/aws/smithy-go/ptr"
 	"github.com/goware/emailproviders"
@@ -361,6 +362,7 @@ func (h *HubspotApi) CreateCompanyForWorkspaceImpl(ctx context.Context, workspac
 	if len(components) > 1 {
 		domain = components[1]
 	}
+	hexLink := fmt.Sprintf("https://workspace-details.highlight.io?_workspace_id=%v", workspaceID)
 	resp, err := h.hubspotClient.Companies().Create(hubspot.CompaniesRequest{
 		Properties: []hubspot.Property{
 			{
@@ -372,6 +374,11 @@ func (h *HubspotApi) CreateCompanyForWorkspaceImpl(ctx context.Context, workspac
 				Property: "domain",
 				Name:     "domain",
 				Value:    domain,
+			},
+			{
+				Property: "hex_link",
+				Name:     "hex_link",
+				Value:    hexLink,
 			},
 		},
 	})

--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -375,24 +375,17 @@ func (h *HubspotApi) CreateCompanyForWorkspaceImpl(ctx context.Context, workspac
 	}
 
 	if companyID, err = pollHubspot(func() (*int, error) {
-		id, err := h.getCompany(ctx, name)
-		if err != nil {
-			return nil, err
-		}
-
+		return h.getCompany(ctx, name)
+	}); companyID != nil {
 		log.WithContext(ctx).
 			WithField("name", name).
-			Warnf("company already exists in Hubspot. updating")
+			Infof("company already exists in Hubspot. updating")
 
-		if id != nil {
-			_, err := h.hubspotClient.Companies().Update(*id, companyProperties)
-			if err != nil {
-				return nil, err
-			}
+		_, er := h.hubspotClient.Companies().Update(*companyID, companyProperties)
+		if er != nil {
+			return nil, er
 		}
 
-		return id, nil
-	}); companyID != nil {
 		return
 	}
 


### PR DESCRIPTION
## Summary

We are adding links to hex dashboards manually to Hubspot companies, but the link is in a consistent format and can be assigned automatically.

## How did you test this change?

Will click test after this change goes outl.

## Are there any deployment considerations?

Confirm property gets set as expected.