### PR TITLE
Endpoint that saves all settings

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -113,6 +113,24 @@ type ComplexityRoot struct {
 		UserDefinedRole       func(childComplexity int) int
 	}
 
+	AllProjectSettings struct {
+		BackendDomains             func(childComplexity int) int
+		BillingEmail               func(childComplexity int) int
+		ErrorFilters               func(childComplexity int) int
+		ErrorJSONPaths             func(childComplexity int) int
+		ExcludedUsers              func(childComplexity int) int
+		FilterChromeExtension      func(childComplexity int) int
+		FilterSessionsWithoutError func(childComplexity int) int
+		ID                         func(childComplexity int) int
+		Name                       func(childComplexity int) int
+		RageClickCount             func(childComplexity int) int
+		RageClickRadiusPixels      func(childComplexity int) int
+		RageClickWindowSeconds     func(childComplexity int) int
+		Secret                     func(childComplexity int) int
+		VerboseID                  func(childComplexity int) int
+		WorkspaceID                func(childComplexity int) int
+	}
+
 	AverageSessionLength struct {
 		Length func(childComplexity int) int
 	}
@@ -639,6 +657,7 @@ type ComplexityRoot struct {
 		EditErrorSegment                 func(childComplexity int, id int, projectID int, params model.ErrorSearchParamsInput, name string) int
 		EditProject                      func(childComplexity int, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool) int
 		EditProjectFilterSettings        func(childComplexity int, projectID int, filterSessionsWithoutError bool) int
+		EditProjectSettings              func(childComplexity int, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool, filterSessionsWithoutError *bool) int
 		EditSegment                      func(childComplexity int, id int, projectID int, params model.SearchParamsInput, name string) int
 		EditWorkspace                    func(childComplexity int, id int, name *string) int
 		EmailSignup                      func(childComplexity int, email string) int
@@ -824,6 +843,7 @@ type ComplexityRoot struct {
 		Project                      func(childComplexity int, id int) int
 		ProjectFilterSettings        func(childComplexity int, projectID int) int
 		ProjectHasViewedASession     func(childComplexity int, projectID int) int
+		ProjectSettings              func(childComplexity int, projectID int) int
 		ProjectSuggestion            func(childComplexity int, query string) int
 		Projects                     func(childComplexity int) int
 		PropertySuggestion           func(childComplexity int, projectID int, query string, typeArg string) int
@@ -1257,6 +1277,7 @@ type MutationResolver interface {
 	CreateWorkspace(ctx context.Context, name string, promoCode *string) (*model1.Workspace, error)
 	EditProject(ctx context.Context, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool) (*model1.Project, error)
 	EditProjectFilterSettings(ctx context.Context, projectID int, filterSessionsWithoutError bool) (*model1.ProjectFilterSettings, error)
+	EditProjectSettings(ctx context.Context, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool, filterSessionsWithoutError *bool) (*model.AllProjectSettings, error)
 	EditWorkspace(ctx context.Context, id int, name *string) (*model1.Workspace, error)
 	MarkErrorGroupAsViewed(ctx context.Context, errorSecureID string, viewed *bool) (*model1.ErrorGroup, error)
 	MarkSessionAsViewed(ctx context.Context, secureID string, viewed *bool) (*model1.Session, error)
@@ -1425,6 +1446,7 @@ type QueryResolver interface {
 	GithubIssueLabels(ctx context.Context, workspaceID int, repository string) ([]string, error)
 	Project(ctx context.Context, id int) (*model1.Project, error)
 	ProjectFilterSettings(ctx context.Context, projectID int) (*model1.ProjectFilterSettings, error)
+	ProjectSettings(ctx context.Context, projectID int) (*model.AllProjectSettings, error)
 	Workspace(ctx context.Context, id int) (*model1.Workspace, error)
 	WorkspaceForInviteLink(ctx context.Context, secret string) (*model.WorkspaceForInviteLink, error)
 	WorkspaceInviteLinks(ctx context.Context, workspaceID int) (*model1.WorkspaceInviteLink, error)
@@ -1784,6 +1806,111 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Admin.UserDefinedRole(childComplexity), true
+
+	case "AllProjectSettings.backend_domains":
+		if e.complexity.AllProjectSettings.BackendDomains == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.BackendDomains(childComplexity), true
+
+	case "AllProjectSettings.billing_email":
+		if e.complexity.AllProjectSettings.BillingEmail == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.BillingEmail(childComplexity), true
+
+	case "AllProjectSettings.error_filters":
+		if e.complexity.AllProjectSettings.ErrorFilters == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.ErrorFilters(childComplexity), true
+
+	case "AllProjectSettings.error_json_paths":
+		if e.complexity.AllProjectSettings.ErrorJSONPaths == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.ErrorJSONPaths(childComplexity), true
+
+	case "AllProjectSettings.excluded_users":
+		if e.complexity.AllProjectSettings.ExcludedUsers == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.ExcludedUsers(childComplexity), true
+
+	case "AllProjectSettings.filter_chrome_extension":
+		if e.complexity.AllProjectSettings.FilterChromeExtension == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.FilterChromeExtension(childComplexity), true
+
+	case "AllProjectSettings.filterSessionsWithoutError":
+		if e.complexity.AllProjectSettings.FilterSessionsWithoutError == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.FilterSessionsWithoutError(childComplexity), true
+
+	case "AllProjectSettings.id":
+		if e.complexity.AllProjectSettings.ID == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.ID(childComplexity), true
+
+	case "AllProjectSettings.name":
+		if e.complexity.AllProjectSettings.Name == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.Name(childComplexity), true
+
+	case "AllProjectSettings.rage_click_count":
+		if e.complexity.AllProjectSettings.RageClickCount == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.RageClickCount(childComplexity), true
+
+	case "AllProjectSettings.rage_click_radius_pixels":
+		if e.complexity.AllProjectSettings.RageClickRadiusPixels == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.RageClickRadiusPixels(childComplexity), true
+
+	case "AllProjectSettings.rage_click_window_seconds":
+		if e.complexity.AllProjectSettings.RageClickWindowSeconds == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.RageClickWindowSeconds(childComplexity), true
+
+	case "AllProjectSettings.secret":
+		if e.complexity.AllProjectSettings.Secret == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.Secret(childComplexity), true
+
+	case "AllProjectSettings.verbose_id":
+		if e.complexity.AllProjectSettings.VerboseID == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.VerboseID(childComplexity), true
+
+	case "AllProjectSettings.workspace_id":
+		if e.complexity.AllProjectSettings.WorkspaceID == nil {
+			break
+		}
+
+		return e.complexity.AllProjectSettings.WorkspaceID(childComplexity), true
 
 	case "AverageSessionLength.length":
 		if e.complexity.AverageSessionLength.Length == nil {
@@ -4344,6 +4471,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.EditProjectFilterSettings(childComplexity, args["projectId"].(int), args["filterSessionsWithoutError"].(bool)), true
 
+	case "Mutation.editProjectSettings":
+		if e.complexity.Mutation.EditProjectSettings == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_editProjectSettings_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.EditProjectSettings(childComplexity, args["projectId"].(int), args["name"].(*string), args["billing_email"].(*string), args["excluded_users"].(pq.StringArray), args["error_filters"].(pq.StringArray), args["error_json_paths"].(pq.StringArray), args["rage_click_window_seconds"].(*int), args["rage_click_radius_pixels"].(*int), args["rage_click_count"].(*int), args["backend_domains"].(pq.StringArray), args["filter_chrome_extension"].(*bool), args["filterSessionsWithoutError"].(*bool)), true
+
 	case "Mutation.editSegment":
 		if e.complexity.Mutation.EditSegment == nil {
 			break
@@ -6095,6 +6234,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.ProjectHasViewedASession(childComplexity, args["project_id"].(int)), true
+
+	case "Query.projectSettings":
+		if e.complexity.Query.ProjectSettings == nil {
+			break
+		}
+
+		args, err := ec.field_Query_projectSettings_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.ProjectSettings(childComplexity, args["projectId"].(int)), true
 
 	case "Query.projectSuggestion":
 		if e.complexity.Query.ProjectSuggestion == nil {
@@ -8624,6 +8775,24 @@ type ProjectFilterSettings {
 	filterSessionsWithoutError: Boolean!
 }
 
+type AllProjectSettings {
+	id: ID!
+	verbose_id: String!
+	name: String!
+	billing_email: String
+	secret: String
+	workspace_id: ID!
+	excluded_users: StringArray
+	error_filters: StringArray
+	error_json_paths: StringArray
+	rage_click_window_seconds: Int
+	rage_click_radius_pixels: Int
+	rage_click_count: Int
+	backend_domains: StringArray
+	filter_chrome_extension: Boolean
+	filterSessionsWithoutError: Boolean!
+}
+
 type Account {
 	id: ID!
 	name: String!
@@ -9815,6 +9984,7 @@ type Query {
 	github_issue_labels(workspace_id: ID!, repository: String!): [String!]!
 	project(id: ID!): Project
 	projectFilterSettings(projectId: ID!): ProjectFilterSettings
+	projectSettings(projectId: ID!): AllProjectSettings
 	workspace(id: ID!): Workspace
 	workspace_for_invite_link(secret: String!): WorkspaceForInviteLink!
 	workspace_invite_links(workspace_id: ID!): WorkspaceInviteLink!
@@ -9902,6 +10072,20 @@ type Mutation {
 		projectId: ID!
 		filterSessionsWithoutError: Boolean!
 	): ProjectFilterSettings
+	editProjectSettings(
+		projectId: ID!
+		name: String
+		billing_email: String
+		excluded_users: StringArray
+		error_filters: StringArray
+		error_json_paths: StringArray
+		rage_click_window_seconds: Int
+		rage_click_radius_pixels: Int
+		rage_click_count: Int
+		backend_domains: StringArray
+		filter_chrome_extension: Boolean
+		filterSessionsWithoutError: Boolean
+	): AllProjectSettings
 	editWorkspace(id: ID!, name: String): Workspace
 	markErrorGroupAsViewed(
 		error_secure_id: String!
@@ -11557,6 +11741,120 @@ func (ec *executionContext) field_Mutation_editProjectFilterSettings_args(ctx co
 		}
 	}
 	args["filterSessionsWithoutError"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_editProjectSettings_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["projectId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectId"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["projectId"] = arg0
+	var arg1 *string
+	if tmp, ok := rawArgs["name"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+		arg1, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["name"] = arg1
+	var arg2 *string
+	if tmp, ok := rawArgs["billing_email"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("billing_email"))
+		arg2, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["billing_email"] = arg2
+	var arg3 pq.StringArray
+	if tmp, ok := rawArgs["excluded_users"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("excluded_users"))
+		arg3, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["excluded_users"] = arg3
+	var arg4 pq.StringArray
+	if tmp, ok := rawArgs["error_filters"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_filters"))
+		arg4, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["error_filters"] = arg4
+	var arg5 pq.StringArray
+	if tmp, ok := rawArgs["error_json_paths"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_json_paths"))
+		arg5, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["error_json_paths"] = arg5
+	var arg6 *int
+	if tmp, ok := rawArgs["rage_click_window_seconds"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_window_seconds"))
+		arg6, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["rage_click_window_seconds"] = arg6
+	var arg7 *int
+	if tmp, ok := rawArgs["rage_click_radius_pixels"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_radius_pixels"))
+		arg7, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["rage_click_radius_pixels"] = arg7
+	var arg8 *int
+	if tmp, ok := rawArgs["rage_click_count"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("rage_click_count"))
+		arg8, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["rage_click_count"] = arg8
+	var arg9 pq.StringArray
+	if tmp, ok := rawArgs["backend_domains"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("backend_domains"))
+		arg9, err = ec.unmarshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["backend_domains"] = arg9
+	var arg10 *bool
+	if tmp, ok := rawArgs["filter_chrome_extension"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filter_chrome_extension"))
+		arg10, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["filter_chrome_extension"] = arg10
+	var arg11 *bool
+	if tmp, ok := rawArgs["filterSessionsWithoutError"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filterSessionsWithoutError"))
+		arg11, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["filterSessionsWithoutError"] = arg11
 	return args, nil
 }
 
@@ -14800,6 +15098,21 @@ func (ec *executionContext) field_Query_projectHasViewedASession_args(ctx contex
 	return args, nil
 }
 
+func (ec *executionContext) field_Query_projectSettings_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["projectId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectId"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["projectId"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Query_projectSuggestion_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -17324,6 +17637,636 @@ func (ec *executionContext) fieldContext_Admin_user_defined_persona(ctx context.
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_id(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNID2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_verbose_id(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_verbose_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.VerboseID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_verbose_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_name(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_billing_email(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_billing_email(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BillingEmail, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_billing_email(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_secret(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_secret(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Secret, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_secret(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_workspace_id(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_workspace_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.WorkspaceID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNID2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_workspace_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_excluded_users(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_excluded_users(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ExcludedUsers, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(pq.StringArray)
+	fc.Result = res
+	return ec.marshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_excluded_users(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type StringArray does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_error_filters(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_error_filters(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ErrorFilters, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(pq.StringArray)
+	fc.Result = res
+	return ec.marshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_error_filters(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type StringArray does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_error_json_paths(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_error_json_paths(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ErrorJSONPaths, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(pq.StringArray)
+	fc.Result = res
+	return ec.marshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_error_json_paths(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type StringArray does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_rage_click_window_seconds(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_rage_click_window_seconds(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RageClickWindowSeconds, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_rage_click_window_seconds(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_rage_click_radius_pixels(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_rage_click_radius_pixels(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RageClickRadiusPixels, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_rage_click_radius_pixels(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_rage_click_count(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_rage_click_count(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RageClickCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_rage_click_count(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_backend_domains(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_backend_domains(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BackendDomains, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(pq.StringArray)
+	fc.Result = res
+	return ec.marshalOStringArray2githubᚗcomᚋlibᚋpqᚐStringArray(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_backend_domains(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type StringArray does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_filter_chrome_extension(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_filter_chrome_extension(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FilterChromeExtension, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_filter_chrome_extension(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AllProjectSettings_filterSessionsWithoutError(ctx context.Context, field graphql.CollectedField, obj *model.AllProjectSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AllProjectSettings_filterSessionsWithoutError(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FilterSessionsWithoutError, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AllProjectSettings_filterSessionsWithoutError(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AllProjectSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -31672,6 +32615,89 @@ func (ec *executionContext) fieldContext_Mutation_editProjectFilterSettings(ctx 
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_editProjectSettings(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_editProjectSettings(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().EditProjectSettings(rctx, fc.Args["projectId"].(int), fc.Args["name"].(*string), fc.Args["billing_email"].(*string), fc.Args["excluded_users"].(pq.StringArray), fc.Args["error_filters"].(pq.StringArray), fc.Args["error_json_paths"].(pq.StringArray), fc.Args["rage_click_window_seconds"].(*int), fc.Args["rage_click_radius_pixels"].(*int), fc.Args["rage_click_count"].(*int), fc.Args["backend_domains"].(pq.StringArray), fc.Args["filter_chrome_extension"].(*bool), fc.Args["filterSessionsWithoutError"].(*bool))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.AllProjectSettings)
+	fc.Result = res
+	return ec.marshalOAllProjectSettings2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAllProjectSettings(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_editProjectSettings(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AllProjectSettings_id(ctx, field)
+			case "verbose_id":
+				return ec.fieldContext_AllProjectSettings_verbose_id(ctx, field)
+			case "name":
+				return ec.fieldContext_AllProjectSettings_name(ctx, field)
+			case "billing_email":
+				return ec.fieldContext_AllProjectSettings_billing_email(ctx, field)
+			case "secret":
+				return ec.fieldContext_AllProjectSettings_secret(ctx, field)
+			case "workspace_id":
+				return ec.fieldContext_AllProjectSettings_workspace_id(ctx, field)
+			case "excluded_users":
+				return ec.fieldContext_AllProjectSettings_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_AllProjectSettings_error_filters(ctx, field)
+			case "error_json_paths":
+				return ec.fieldContext_AllProjectSettings_error_json_paths(ctx, field)
+			case "rage_click_window_seconds":
+				return ec.fieldContext_AllProjectSettings_rage_click_window_seconds(ctx, field)
+			case "rage_click_radius_pixels":
+				return ec.fieldContext_AllProjectSettings_rage_click_radius_pixels(ctx, field)
+			case "rage_click_count":
+				return ec.fieldContext_AllProjectSettings_rage_click_count(ctx, field)
+			case "backend_domains":
+				return ec.fieldContext_AllProjectSettings_backend_domains(ctx, field)
+			case "filter_chrome_extension":
+				return ec.fieldContext_AllProjectSettings_filter_chrome_extension(ctx, field)
+			case "filterSessionsWithoutError":
+				return ec.fieldContext_AllProjectSettings_filterSessionsWithoutError(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AllProjectSettings", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_editProjectSettings_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_editWorkspace(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_editWorkspace(ctx, field)
 	if err != nil {
@@ -44405,6 +45431,89 @@ func (ec *executionContext) fieldContext_Query_projectFilterSettings(ctx context
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_projectFilterSettings_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_projectSettings(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_projectSettings(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ProjectSettings(rctx, fc.Args["projectId"].(int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.AllProjectSettings)
+	fc.Result = res
+	return ec.marshalOAllProjectSettings2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAllProjectSettings(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_projectSettings(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AllProjectSettings_id(ctx, field)
+			case "verbose_id":
+				return ec.fieldContext_AllProjectSettings_verbose_id(ctx, field)
+			case "name":
+				return ec.fieldContext_AllProjectSettings_name(ctx, field)
+			case "billing_email":
+				return ec.fieldContext_AllProjectSettings_billing_email(ctx, field)
+			case "secret":
+				return ec.fieldContext_AllProjectSettings_secret(ctx, field)
+			case "workspace_id":
+				return ec.fieldContext_AllProjectSettings_workspace_id(ctx, field)
+			case "excluded_users":
+				return ec.fieldContext_AllProjectSettings_excluded_users(ctx, field)
+			case "error_filters":
+				return ec.fieldContext_AllProjectSettings_error_filters(ctx, field)
+			case "error_json_paths":
+				return ec.fieldContext_AllProjectSettings_error_json_paths(ctx, field)
+			case "rage_click_window_seconds":
+				return ec.fieldContext_AllProjectSettings_rage_click_window_seconds(ctx, field)
+			case "rage_click_radius_pixels":
+				return ec.fieldContext_AllProjectSettings_rage_click_radius_pixels(ctx, field)
+			case "rage_click_count":
+				return ec.fieldContext_AllProjectSettings_rage_click_count(ctx, field)
+			case "backend_domains":
+				return ec.fieldContext_AllProjectSettings_backend_domains(ctx, field)
+			case "filter_chrome_extension":
+				return ec.fieldContext_AllProjectSettings_filter_chrome_extension(ctx, field)
+			case "filterSessionsWithoutError":
+				return ec.fieldContext_AllProjectSettings_filterSessionsWithoutError(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AllProjectSettings", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_projectSettings_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -60363,6 +61472,102 @@ func (ec *executionContext) _Admin(ctx context.Context, sel ast.SelectionSet, ob
 	return out
 }
 
+var allProjectSettingsImplementors = []string{"AllProjectSettings"}
+
+func (ec *executionContext) _AllProjectSettings(ctx context.Context, sel ast.SelectionSet, obj *model.AllProjectSettings) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, allProjectSettingsImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AllProjectSettings")
+		case "id":
+
+			out.Values[i] = ec._AllProjectSettings_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "verbose_id":
+
+			out.Values[i] = ec._AllProjectSettings_verbose_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "name":
+
+			out.Values[i] = ec._AllProjectSettings_name(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "billing_email":
+
+			out.Values[i] = ec._AllProjectSettings_billing_email(ctx, field, obj)
+
+		case "secret":
+
+			out.Values[i] = ec._AllProjectSettings_secret(ctx, field, obj)
+
+		case "workspace_id":
+
+			out.Values[i] = ec._AllProjectSettings_workspace_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "excluded_users":
+
+			out.Values[i] = ec._AllProjectSettings_excluded_users(ctx, field, obj)
+
+		case "error_filters":
+
+			out.Values[i] = ec._AllProjectSettings_error_filters(ctx, field, obj)
+
+		case "error_json_paths":
+
+			out.Values[i] = ec._AllProjectSettings_error_json_paths(ctx, field, obj)
+
+		case "rage_click_window_seconds":
+
+			out.Values[i] = ec._AllProjectSettings_rage_click_window_seconds(ctx, field, obj)
+
+		case "rage_click_radius_pixels":
+
+			out.Values[i] = ec._AllProjectSettings_rage_click_radius_pixels(ctx, field, obj)
+
+		case "rage_click_count":
+
+			out.Values[i] = ec._AllProjectSettings_rage_click_count(ctx, field, obj)
+
+		case "backend_domains":
+
+			out.Values[i] = ec._AllProjectSettings_backend_domains(ctx, field, obj)
+
+		case "filter_chrome_extension":
+
+			out.Values[i] = ec._AllProjectSettings_filter_chrome_extension(ctx, field, obj)
+
+		case "filterSessionsWithoutError":
+
+			out.Values[i] = ec._AllProjectSettings_filterSessionsWithoutError(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var averageSessionLengthImplementors = []string{"AverageSessionLength"}
 
 func (ec *executionContext) _AverageSessionLength(ctx context.Context, sel ast.SelectionSet, obj *model.AverageSessionLength) graphql.Marshaler {
@@ -63934,6 +65139,12 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 				return ec._Mutation_editProjectFilterSettings(ctx, field)
 			})
 
+		case "editProjectSettings":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_editProjectSettings(ctx, field)
+			})
+
 		case "editWorkspace":
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
@@ -66670,6 +67881,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_projectFilterSettings(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "projectSettings":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_projectSettings(ctx, field)
 				return res
 			}
 
@@ -74675,6 +75906,13 @@ func (ec *executionContext) marshalOAdmin2ᚖgithubᚗcomᚋhighlightᚑrunᚋhi
 		return graphql.Null
 	}
 	return ec._Admin(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOAllProjectSettings2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐAllProjectSettings(ctx context.Context, sel ast.SelectionSet, v *model.AllProjectSettings) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._AllProjectSettings(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOAny2interface(ctx context.Context, v interface{}) (interface{}, error) {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"strconv"
 	"time"
+
+	"github.com/lib/pq"
 )
 
 type Account struct {
@@ -62,6 +64,24 @@ type AdminAndWorkspaceDetails struct {
 	WorkspaceName               string  `json:"workspace_name"`
 	AllowedAutoJoinEmailOrigins *string `json:"allowed_auto_join_email_origins"`
 	PromoCode                   *string `json:"promo_code"`
+}
+
+type AllProjectSettings struct {
+	ID                         int            `json:"id"`
+	VerboseID                  string         `json:"verbose_id"`
+	Name                       string         `json:"name"`
+	BillingEmail               *string        `json:"billing_email"`
+	Secret                     *string        `json:"secret"`
+	WorkspaceID                int            `json:"workspace_id"`
+	ExcludedUsers              pq.StringArray `json:"excluded_users"`
+	ErrorFilters               pq.StringArray `json:"error_filters"`
+	ErrorJSONPaths             pq.StringArray `json:"error_json_paths"`
+	RageClickWindowSeconds     *int           `json:"rage_click_window_seconds"`
+	RageClickRadiusPixels      *int           `json:"rage_click_radius_pixels"`
+	RageClickCount             *int           `json:"rage_click_count"`
+	BackendDomains             pq.StringArray `json:"backend_domains"`
+	FilterChromeExtension      *bool          `json:"filter_chrome_extension"`
+	FilterSessionsWithoutError bool           `json:"filterSessionsWithoutError"`
 }
 
 type AverageSessionLength struct {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -353,6 +353,24 @@ type ProjectFilterSettings {
 	filterSessionsWithoutError: Boolean!
 }
 
+type AllProjectSettings {
+	id: ID!
+	verbose_id: String!
+	name: String!
+	billing_email: String
+	secret: String
+	workspace_id: ID!
+	excluded_users: StringArray
+	error_filters: StringArray
+	error_json_paths: StringArray
+	rage_click_window_seconds: Int
+	rage_click_radius_pixels: Int
+	rage_click_count: Int
+	backend_domains: StringArray
+	filter_chrome_extension: Boolean
+	filterSessionsWithoutError: Boolean!
+}
+
 type Account {
 	id: ID!
 	name: String!
@@ -1544,6 +1562,7 @@ type Query {
 	github_issue_labels(workspace_id: ID!, repository: String!): [String!]!
 	project(id: ID!): Project
 	projectFilterSettings(projectId: ID!): ProjectFilterSettings
+	projectSettings(projectId: ID!): AllProjectSettings
 	workspace(id: ID!): Workspace
 	workspace_for_invite_link(secret: String!): WorkspaceForInviteLink!
 	workspace_invite_links(workspace_id: ID!): WorkspaceInviteLink!
@@ -1631,6 +1650,20 @@ type Mutation {
 		projectId: ID!
 		filterSessionsWithoutError: Boolean!
 	): ProjectFilterSettings
+	editProjectSettings(
+		projectId: ID!
+		name: String
+		billing_email: String
+		excluded_users: StringArray
+		error_filters: StringArray
+		error_json_paths: StringArray
+		rage_click_window_seconds: Int
+		rage_click_radius_pixels: Int
+		rage_click_count: Int
+		backend_domains: StringArray
+		filter_chrome_extension: Boolean
+		filterSessionsWithoutError: Boolean
+	): AllProjectSettings
 	editWorkspace(id: ID!, name: String): Workspace
 	markErrorGroupAsViewed(
 		error_secure_id: String!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -617,6 +617,38 @@ func (r *mutationResolver) EditProjectFilterSettings(ctx context.Context, projec
 	return &projectFilterSettings, err
 }
 
+// EditProjectSettings is the resolver for the editProjectSettings field.
+func (r *mutationResolver) EditProjectSettings(ctx context.Context, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool, filterSessionsWithoutError *bool) (*modelInputs.AllProjectSettings, error) {
+	project, err := r.EditProject(ctx, projectID, name, billingEmail, excludedUsers, errorFilters, errorJSONPaths, rageClickWindowSeconds, rageClickRadiusPixels, rageClickCount, backendDomains, filterChromeExtension)
+	if err != nil {
+		return nil, err
+	}
+
+	allProjectSettings := modelInputs.AllProjectSettings{
+		ID:                     project.ID,
+		Name:                   *project.Name,
+		BillingEmail:           project.BillingEmail,
+		ExcludedUsers:          project.ExcludedUsers,
+		ErrorFilters:           project.ErrorFilters,
+		ErrorJSONPaths:         project.ErrorJsonPaths,
+		BackendDomains:         project.BackendDomains,
+		FilterChromeExtension:  project.FilterChromeExtension,
+		RageClickWindowSeconds: &project.RageClickWindowSeconds,
+		RageClickRadiusPixels:  &project.RageClickRadiusPixels,
+		RageClickCount:         &project.RageClickCount,
+	}
+
+	if filterSessionsWithoutError != nil {
+		projectFilterSettings, err := r.EditProjectFilterSettings(ctx, projectID, *filterSessionsWithoutError)
+		if err != nil {
+			return nil, err
+		}
+		allProjectSettings.FilterSessionsWithoutError = projectFilterSettings.FilterSessionsWithoutError
+	}
+
+	return &allProjectSettings, nil
+}
+
 // EditWorkspace is the resolver for the editWorkspace field.
 func (r *mutationResolver) EditWorkspace(ctx context.Context, id int, name *string) (*model.Workspace, error) {
 	workspace, err := r.isAdminInWorkspace(ctx, id)
@@ -6393,6 +6425,36 @@ func (r *queryResolver) ProjectFilterSettings(ctx context.Context, projectID int
 	r.DB.Where(model.ProjectFilterSettings{ProjectID: project.ID}).FirstOrCreate(&projectFilterSettings)
 
 	return &projectFilterSettings, err
+}
+
+// ProjectSettings is the resolver for the projectSettings field.
+func (r *queryResolver) ProjectSettings(ctx context.Context, projectID int) (*modelInputs.AllProjectSettings, error) {
+	project, err := r.Project(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	projectFilterSettings, err := r.ProjectFilterSettings(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	allProjectSettings := modelInputs.AllProjectSettings{
+		ID:                         project.ID,
+		Name:                       *project.Name,
+		BillingEmail:               project.BillingEmail,
+		ExcludedUsers:              project.ExcludedUsers,
+		ErrorFilters:               project.ErrorFilters,
+		ErrorJSONPaths:             project.ErrorJsonPaths,
+		BackendDomains:             project.BackendDomains,
+		FilterChromeExtension:      project.FilterChromeExtension,
+		RageClickWindowSeconds:     &project.RageClickWindowSeconds,
+		RageClickRadiusPixels:      &project.RageClickRadiusPixels,
+		RageClickCount:             &project.RageClickCount,
+		FilterSessionsWithoutError: projectFilterSettings.FilterSessionsWithoutError,
+	}
+
+	return &allProjectSettings, nil
 }
 
 // Workspace is the resolver for the workspace field.

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -1482,6 +1482,103 @@ export type EditProjectFilterSettingsMutationOptions =
 		Types.EditProjectFilterSettingsMutation,
 		Types.EditProjectFilterSettingsMutationVariables
 	>
+export const EditProjectSettingsDocument = gql`
+	mutation EditProjectSettings(
+		$projectId: ID!
+		$name: String
+		$billing_email: String
+		$excluded_users: StringArray
+		$error_filters: StringArray
+		$error_json_paths: StringArray
+		$filter_chrome_extension: Boolean
+		$rage_click_window_seconds: Int
+		$rage_click_radius_pixels: Int
+		$rage_click_count: Int
+		$backend_domains: StringArray
+		$filterSessionsWithoutError: Boolean
+	) {
+		editProjectSettings(
+			projectId: $projectId
+			name: $name
+			billing_email: $billing_email
+			excluded_users: $excluded_users
+			error_filters: $error_filters
+			error_json_paths: $error_json_paths
+			filter_chrome_extension: $filter_chrome_extension
+			rage_click_window_seconds: $rage_click_window_seconds
+			rage_click_radius_pixels: $rage_click_radius_pixels
+			rage_click_count: $rage_click_count
+			backend_domains: $backend_domains
+			filterSessionsWithoutError: $filterSessionsWithoutError
+		) {
+			id
+			name
+			billing_email
+			excluded_users
+			error_filters
+			error_json_paths
+			filter_chrome_extension
+			rage_click_window_seconds
+			rage_click_radius_pixels
+			rage_click_count
+			backend_domains
+			filterSessionsWithoutError
+		}
+	}
+`
+export type EditProjectSettingsMutationFn = Apollo.MutationFunction<
+	Types.EditProjectSettingsMutation,
+	Types.EditProjectSettingsMutationVariables
+>
+
+/**
+ * __useEditProjectSettingsMutation__
+ *
+ * To run a mutation, you first call `useEditProjectSettingsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useEditProjectSettingsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [editProjectSettingsMutation, { data, loading, error }] = useEditProjectSettingsMutation({
+ *   variables: {
+ *      projectId: // value for 'projectId'
+ *      name: // value for 'name'
+ *      billing_email: // value for 'billing_email'
+ *      excluded_users: // value for 'excluded_users'
+ *      error_filters: // value for 'error_filters'
+ *      error_json_paths: // value for 'error_json_paths'
+ *      filter_chrome_extension: // value for 'filter_chrome_extension'
+ *      rage_click_window_seconds: // value for 'rage_click_window_seconds'
+ *      rage_click_radius_pixels: // value for 'rage_click_radius_pixels'
+ *      rage_click_count: // value for 'rage_click_count'
+ *      backend_domains: // value for 'backend_domains'
+ *      filterSessionsWithoutError: // value for 'filterSessionsWithoutError'
+ *   },
+ * });
+ */
+export function useEditProjectSettingsMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.EditProjectSettingsMutation,
+		Types.EditProjectSettingsMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.EditProjectSettingsMutation,
+		Types.EditProjectSettingsMutationVariables
+	>(EditProjectSettingsDocument, baseOptions)
+}
+export type EditProjectSettingsMutationHookResult = ReturnType<
+	typeof useEditProjectSettingsMutation
+>
+export type EditProjectSettingsMutationResult =
+	Apollo.MutationResult<Types.EditProjectSettingsMutation>
+export type EditProjectSettingsMutationOptions = Apollo.BaseMutationOptions<
+	Types.EditProjectSettingsMutation,
+	Types.EditProjectSettingsMutationVariables
+>
 export const DeleteProjectDocument = gql`
 	mutation DeleteProject($id: ID!) {
 		deleteProject(id: $id)
@@ -12673,4 +12770,72 @@ export type GetProjectFilterSettingsLazyQueryHookResult = ReturnType<
 export type GetProjectFilterSettingsQueryResult = Apollo.QueryResult<
 	Types.GetProjectFilterSettingsQuery,
 	Types.GetProjectFilterSettingsQueryVariables
+>
+export const GetProjectSettingsDocument = gql`
+	query GetProjectSettings($projectId: ID!) {
+		projectSettings(projectId: $projectId) {
+			id
+			name
+			verbose_id
+			billing_email
+			excluded_users
+			error_filters
+			error_json_paths
+			filter_chrome_extension
+			rage_click_window_seconds
+			rage_click_radius_pixels
+			rage_click_count
+			backend_domains
+			filterSessionsWithoutError
+		}
+	}
+`
+
+/**
+ * __useGetProjectSettingsQuery__
+ *
+ * To run a query within a React component, call `useGetProjectSettingsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetProjectSettingsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetProjectSettingsQuery({
+ *   variables: {
+ *      projectId: // value for 'projectId'
+ *   },
+ * });
+ */
+export function useGetProjectSettingsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetProjectSettingsQuery,
+		Types.GetProjectSettingsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetProjectSettingsQuery,
+		Types.GetProjectSettingsQueryVariables
+	>(GetProjectSettingsDocument, baseOptions)
+}
+export function useGetProjectSettingsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetProjectSettingsQuery,
+		Types.GetProjectSettingsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetProjectSettingsQuery,
+		Types.GetProjectSettingsQueryVariables
+	>(GetProjectSettingsDocument, baseOptions)
+}
+export type GetProjectSettingsQueryHookResult = ReturnType<
+	typeof useGetProjectSettingsQuery
+>
+export type GetProjectSettingsLazyQueryHookResult = ReturnType<
+	typeof useGetProjectSettingsLazyQuery
+>
+export type GetProjectSettingsQueryResult = Apollo.QueryResult<
+	Types.GetProjectSettingsQuery,
+	Types.GetProjectSettingsQueryVariables
 >

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -280,6 +280,41 @@ export type EditProjectFilterSettingsMutation = { __typename?: 'Mutation' } & {
 	>
 }
 
+export type EditProjectSettingsMutationVariables = Types.Exact<{
+	projectId: Types.Scalars['ID']
+	name?: Types.Maybe<Types.Scalars['String']>
+	billing_email?: Types.Maybe<Types.Scalars['String']>
+	excluded_users?: Types.Maybe<Types.Scalars['StringArray']>
+	error_filters?: Types.Maybe<Types.Scalars['StringArray']>
+	error_json_paths?: Types.Maybe<Types.Scalars['StringArray']>
+	filter_chrome_extension?: Types.Maybe<Types.Scalars['Boolean']>
+	rage_click_window_seconds?: Types.Maybe<Types.Scalars['Int']>
+	rage_click_radius_pixels?: Types.Maybe<Types.Scalars['Int']>
+	rage_click_count?: Types.Maybe<Types.Scalars['Int']>
+	backend_domains?: Types.Maybe<Types.Scalars['StringArray']>
+	filterSessionsWithoutError?: Types.Maybe<Types.Scalars['Boolean']>
+}>
+
+export type EditProjectSettingsMutation = { __typename?: 'Mutation' } & {
+	editProjectSettings?: Types.Maybe<
+		{ __typename?: 'AllProjectSettings' } & Pick<
+			Types.AllProjectSettings,
+			| 'id'
+			| 'name'
+			| 'billing_email'
+			| 'excluded_users'
+			| 'error_filters'
+			| 'error_json_paths'
+			| 'filter_chrome_extension'
+			| 'rage_click_window_seconds'
+			| 'rage_click_radius_pixels'
+			| 'rage_click_count'
+			| 'backend_domains'
+			| 'filterSessionsWithoutError'
+		>
+	>
+}
+
 export type DeleteProjectMutationVariables = Types.Exact<{
 	id: Types.Scalars['ID']
 }>
@@ -4266,6 +4301,31 @@ export type GetProjectFilterSettingsQuery = { __typename?: 'Query' } & {
 	>
 }
 
+export type GetProjectSettingsQueryVariables = Types.Exact<{
+	projectId: Types.Scalars['ID']
+}>
+
+export type GetProjectSettingsQuery = { __typename?: 'Query' } & {
+	projectSettings?: Types.Maybe<
+		{ __typename?: 'AllProjectSettings' } & Pick<
+			Types.AllProjectSettings,
+			| 'id'
+			| 'name'
+			| 'verbose_id'
+			| 'billing_email'
+			| 'excluded_users'
+			| 'error_filters'
+			| 'error_json_paths'
+			| 'filter_chrome_extension'
+			| 'rage_click_window_seconds'
+			| 'rage_click_radius_pixels'
+			| 'rage_click_count'
+			| 'backend_domains'
+			| 'filterSessionsWithoutError'
+		>
+	>
+}
+
 export const namedOperations = {
 	Query: {
 		GetMetricsTimeline: 'GetMetricsTimeline' as const,
@@ -4395,6 +4455,7 @@ export const namedOperations = {
 		GetLogsKeyValues: 'GetLogsKeyValues' as const,
 		GetLogsErrorObjects: 'GetLogsErrorObjects' as const,
 		GetProjectFilterSettings: 'GetProjectFilterSettings' as const,
+		GetProjectSettings: 'GetProjectSettings' as const,
 	},
 	Mutation: {
 		MarkErrorGroupAsViewed: 'MarkErrorGroupAsViewed' as const,
@@ -4423,6 +4484,7 @@ export const namedOperations = {
 		CreateWorkspace: 'CreateWorkspace' as const,
 		EditProject: 'EditProject' as const,
 		EditProjectFilterSettings: 'EditProjectFilterSettings' as const,
+		EditProjectSettings: 'EditProjectSettings' as const,
 		DeleteProject: 'DeleteProject' as const,
 		EditWorkspace: 'EditWorkspace' as const,
 		DeleteSegment: 'DeleteSegment' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -104,6 +104,25 @@ export enum AdminRole {
 	Member = 'MEMBER',
 }
 
+export type AllProjectSettings = {
+	__typename?: 'AllProjectSettings'
+	backend_domains?: Maybe<Scalars['StringArray']>
+	billing_email?: Maybe<Scalars['String']>
+	error_filters?: Maybe<Scalars['StringArray']>
+	error_json_paths?: Maybe<Scalars['StringArray']>
+	excluded_users?: Maybe<Scalars['StringArray']>
+	filterSessionsWithoutError: Scalars['Boolean']
+	filter_chrome_extension?: Maybe<Scalars['Boolean']>
+	id: Scalars['ID']
+	name: Scalars['String']
+	rage_click_count?: Maybe<Scalars['Int']>
+	rage_click_radius_pixels?: Maybe<Scalars['Int']>
+	rage_click_window_seconds?: Maybe<Scalars['Int']>
+	secret?: Maybe<Scalars['String']>
+	verbose_id: Scalars['String']
+	workspace_id: Scalars['ID']
+}
+
 export type AverageSessionLength = {
 	__typename?: 'AverageSessionLength'
 	length: Scalars['Float']
@@ -895,6 +914,7 @@ export type Mutation = {
 	editErrorSegment?: Maybe<Scalars['Boolean']>
 	editProject?: Maybe<Project>
 	editProjectFilterSettings?: Maybe<ProjectFilterSettings>
+	editProjectSettings?: Maybe<AllProjectSettings>
 	editSegment?: Maybe<Scalars['Boolean']>
 	editWorkspace?: Maybe<Workspace>
 	emailSignup: Scalars['String']
@@ -1172,6 +1192,21 @@ export type MutationEditProjectArgs = {
 export type MutationEditProjectFilterSettingsArgs = {
 	filterSessionsWithoutError: Scalars['Boolean']
 	projectId: Scalars['ID']
+}
+
+export type MutationEditProjectSettingsArgs = {
+	backend_domains?: InputMaybe<Scalars['StringArray']>
+	billing_email?: InputMaybe<Scalars['String']>
+	error_filters?: InputMaybe<Scalars['StringArray']>
+	error_json_paths?: InputMaybe<Scalars['StringArray']>
+	excluded_users?: InputMaybe<Scalars['StringArray']>
+	filterSessionsWithoutError?: InputMaybe<Scalars['Boolean']>
+	filter_chrome_extension?: InputMaybe<Scalars['Boolean']>
+	name?: InputMaybe<Scalars['String']>
+	projectId: Scalars['ID']
+	rage_click_count?: InputMaybe<Scalars['Int']>
+	rage_click_radius_pixels?: InputMaybe<Scalars['Int']>
+	rage_click_window_seconds?: InputMaybe<Scalars['Int']>
 }
 
 export type MutationEditSegmentArgs = {
@@ -1609,6 +1644,7 @@ export type Query = {
 	project?: Maybe<Project>
 	projectFilterSettings?: Maybe<ProjectFilterSettings>
 	projectHasViewedASession?: Maybe<Session>
+	projectSettings?: Maybe<AllProjectSettings>
 	projectSuggestion: Array<Maybe<Project>>
 	projects?: Maybe<Array<Maybe<Project>>>
 	property_suggestion?: Maybe<Array<Maybe<Field>>>
@@ -2050,6 +2086,10 @@ export type QueryProjectFilterSettingsArgs = {
 
 export type QueryProjectHasViewedASessionArgs = {
 	project_id: Scalars['ID']
+}
+
+export type QueryProjectSettingsArgs = {
+	projectId: Scalars['ID']
 }
 
 export type QueryProjectSuggestionArgs = {

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -238,6 +238,49 @@ mutation EditProjectFilterSettings(
 	}
 }
 
+mutation EditProjectSettings(
+	$projectId: ID!
+	$name: String
+	$billing_email: String
+	$excluded_users: StringArray
+	$error_filters: StringArray
+	$error_json_paths: StringArray
+	$filter_chrome_extension: Boolean
+	$rage_click_window_seconds: Int
+	$rage_click_radius_pixels: Int
+	$rage_click_count: Int
+	$backend_domains: StringArray
+	$filterSessionsWithoutError: Boolean
+) {
+	editProjectSettings(
+		projectId: $projectId
+		name: $name
+		billing_email: $billing_email
+		excluded_users: $excluded_users
+		error_filters: $error_filters
+		error_json_paths: $error_json_paths
+		filter_chrome_extension: $filter_chrome_extension
+		rage_click_window_seconds: $rage_click_window_seconds
+		rage_click_radius_pixels: $rage_click_radius_pixels
+		rage_click_count: $rage_click_count
+		backend_domains: $backend_domains
+		filterSessionsWithoutError: $filterSessionsWithoutError
+	) {
+		id
+		name
+		billing_email
+		excluded_users
+		error_filters
+		error_json_paths
+		filter_chrome_extension
+		rage_click_window_seconds
+		rage_click_radius_pixels
+		rage_click_count
+		backend_domains
+		filterSessionsWithoutError
+	}
+}
+
 mutation DeleteProject($id: ID!) {
 	deleteProject(id: $id)
 }

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2049,3 +2049,21 @@ query GetProjectFilterSettings($projectId: ID!) {
 		filterSessionsWithoutError
 	}
 }
+
+query GetProjectSettings($projectId: ID!) {
+	projectSettings(projectId: $projectId) {
+		id
+		name
+		verbose_id
+		billing_email
+		excluded_users
+		error_filters
+		error_json_paths
+		filter_chrome_extension
+		rage_click_window_seconds
+		rage_click_radius_pixels
+		rage_click_count
+		backend_domains
+		filterSessionsWithoutError
+	}
+}

--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
@@ -1,16 +1,11 @@
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
 import { LoadingBar } from '@components/Loading/Loading'
 import Select from '@components/Select/Select'
-import { useEditProjectMutation, useGetProjectQuery } from '@graph/hooks'
-import { namedOperations } from '@graph/operations'
-import { useProjectId } from '@hooks/useProjectId'
 import { message } from 'antd'
-import clsx from 'clsx'
-import React, { useEffect, useState } from 'react'
 import { Text } from 'recharts'
 
-import commonStyles from '../../../Common.module.scss'
-import Button from '../../../components/Button/Button/Button'
+import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
+
 import styles from './ErrorFiltersForm.module.scss'
 
 const isValidRegex = function (p: string) {
@@ -24,48 +19,11 @@ const isValidRegex = function (p: string) {
 }
 
 export const ErrorFiltersForm = () => {
-	const { projectId } = useProjectId()
-	const [errorFilters, setErrorFilters] = useState<string[]>([])
-	const { data, loading } = useGetProjectQuery({
-		variables: {
-			id: projectId!,
-		},
-		skip: !projectId,
-	})
-
-	const [editProject, { loading: editProjectLoading }] =
-		useEditProjectMutation({
-			refetchQueries: [
-				namedOperations.Query.GetProjects,
-				namedOperations.Query.GetProject,
-			],
-		})
-
-	const onSubmit = (e: { preventDefault: () => void }) => {
-		e.preventDefault()
-		if (!projectId) {
-			return
-		}
-		if (errorFilters.filter(isValidRegex).length < errorFilters.length) {
-			message.error(
-				`Please correct invalid regex patterns before saving.`,
-			)
-			return
-		}
-
-		editProject({
-			variables: {
-				id: projectId!,
-				error_filters: errorFilters,
-			},
-		}).then(() => {
-			message.success('Updated error filters!', 5)
-		})
-	}
-
-	useEffect(() => {
-		setErrorFilters(data?.project?.error_filters ?? [])
-	}, [data?.project?.error_filters])
+	const {
+		allProjectSettings: data,
+		loading,
+		setAllProjectSettings,
+	} = useProjectSettingsContext()
 
 	if (loading) {
 		return <LoadingBar />
@@ -75,14 +33,14 @@ export const ErrorFiltersForm = () => {
 		<FieldsBox id="filters">
 			<h3>Error Filters</h3>
 
-			<form onSubmit={onSubmit}>
+			<form>
 				<p>Enter regular expression patterns to filter out errors.</p>
 				<div className={styles.inputAndButtonRow}>
 					<Select
 						className={styles.input}
 						mode="tags"
 						placeholder="TypeError: Failed to fetch"
-						defaultValue={data?.project?.error_filters}
+						value={data?.projectSettings?.error_filters}
 						notFoundContent={
 							<Text>
 								Provide a regex pattern to filter out errors.
@@ -90,21 +48,18 @@ export const ErrorFiltersForm = () => {
 						}
 						onChange={(patterns: string[]) => {
 							patterns.filter(isValidRegex)
-							setErrorFilters(patterns)
+							setAllProjectSettings((currentProjectSettings) =>
+								currentProjectSettings?.projectSettings
+									? {
+											projectSettings: {
+												...currentProjectSettings.projectSettings,
+												error_filters: patterns,
+											},
+									  }
+									: currentProjectSettings,
+							)
 						}}
 					/>
-					<Button
-						loading={editProjectLoading}
-						trackingId="UpdateErrorFilters"
-						htmlType="submit"
-						type="primary"
-						className={clsx(
-							commonStyles.submitButton,
-							styles.saveButton,
-						)}
-					>
-						Save
-					</Button>
 				</div>
 			</form>
 		</FieldsBox>

--- a/frontend/src/pages/ProjectSettings/NetworkRecordingForm/NetworkRecordingForm.tsx
+++ b/frontend/src/pages/ProjectSettings/NetworkRecordingForm/NetworkRecordingForm.tsx
@@ -1,57 +1,20 @@
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
 import InfoTooltip from '@components/InfoTooltip/InfoTooltip'
-import { CircularSpinner, LoadingBar } from '@components/Loading/Loading'
+import { LoadingBar } from '@components/Loading/Loading'
 import Select from '@components/Select/Select'
-import { useEditProjectMutation, useGetProjectQuery } from '@graph/hooks'
-import { namedOperations } from '@graph/operations'
 import { useParams } from '@util/react-router/useParams'
-import { message } from 'antd'
-import clsx from 'clsx'
-import React, { useEffect, useState } from 'react'
 
-import commonStyles from '../../../Common.module.scss'
-import Button from '../../../components/Button/Button/Button'
+import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
+
 import styles from './NetworkRecordingForm.module.scss'
 
 export const NetworkRecordingForm = () => {
 	const { project_id } = useParams<{ project_id: string }>()
-	const [backendDomains, setBackendDomains] = useState<string[]>([])
-	const { data, loading } = useGetProjectQuery({
-		variables: {
-			id: project_id!,
-		},
-		skip: !project_id,
-	})
-
-	const [editProject, { loading: editProjectLoading }] =
-		useEditProjectMutation({
-			refetchQueries: [
-				namedOperations.Query.GetProjects,
-				namedOperations.Query.GetProject,
-			],
-			onCompleted: () => {
-				message.success('Updated network recording settings!', 5)
-			},
-		})
-
-	const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-		e.preventDefault()
-		if (!project_id) {
-			return
-		}
-		editProject({
-			variables: {
-				id: project_id!,
-				backend_domains: backendDomains,
-			},
-		}).catch(console.error)
-	}
-
-	useEffect(() => {
-		if (!loading) {
-			setBackendDomains(data?.project?.backend_domains ?? [])
-		}
-	}, [data?.project?.backend_domains, loading])
+	const {
+		allProjectSettings: data,
+		loading,
+		setAllProjectSettings,
+	} = useProjectSettingsContext()
 
 	if (loading) {
 		return <LoadingBar />
@@ -60,7 +23,7 @@ export const NetworkRecordingForm = () => {
 	return (
 		<FieldsBox id="network">
 			<h3>Network Recording Settings</h3>
-			<form onSubmit={onSubmit} key={project_id}>
+			<form key={project_id}>
 				<p>
 					Adjust how we process your network requests at the project
 					level.
@@ -78,36 +41,20 @@ export const NetworkRecordingForm = () => {
 						mode="tags"
 						placeholder="api.highlight.run"
 						notFoundContent={null}
-						defaultValue={data?.project?.backend_domains || []}
+						value={data?.projectSettings?.backend_domains ?? []}
 						onChange={(domains: string[]) => {
-							setBackendDomains(domains)
+							setAllProjectSettings((currentProjectSettings) =>
+								currentProjectSettings?.projectSettings
+									? {
+											projectSettings: {
+												...currentProjectSettings.projectSettings,
+												backend_domains: domains,
+											},
+									  }
+									: currentProjectSettings,
+							)
 						}}
 					/>
-				</div>
-				<div className={styles.fieldRow}>
-					<div className={styles.fieldKey}></div>
-					<div className={styles.saveButton}>
-						<Button
-							trackingId="NetworkRecordingSettingsUpdate"
-							htmlType="submit"
-							type="primary"
-							className={clsx(
-								commonStyles.submitButton,
-								styles.saveButton,
-							)}
-						>
-							{editProjectLoading ? (
-								<CircularSpinner
-									style={{
-										fontSize: 18,
-										color: 'var(--text-primary-inverted)',
-									}}
-								/>
-							) : (
-								'Save'
-							)}
-						</Button>
-					</div>
 				</div>
 			</form>
 		</FieldsBox>

--- a/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
@@ -1,4 +1,6 @@
 import Tabs from '@components/Tabs/Tabs'
+import { Heading } from '@highlight-run/ui'
+import { Box, Text } from '@highlight-run/ui'
 import { DangerForm } from '@pages/ProjectSettings/DangerForm/DangerForm'
 import { ErrorFiltersForm } from '@pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm'
 import { ErrorSettingsForm } from '@pages/ProjectSettings/ErrorSettingsForm/ErrorSettingsForm'
@@ -8,68 +10,188 @@ import { NetworkRecordingForm } from '@pages/ProjectSettings/NetworkRecordingFor
 import { RageClicksForm } from '@pages/ProjectSettings/RageClicksForm/RageClicksForm'
 import SourcemapSettings from '@pages/WorkspaceSettings/SourcemapSettings/SourcemapSettings'
 import { useParams } from '@util/react-router/useParams'
-import React from 'react'
+import { message } from 'antd'
+import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
 
+import { Button } from '@/components/Button'
 import LeadAlignLayout from '@/components/layout/LeadAlignLayout'
+import { CircularSpinner } from '@/components/Loading/Loading'
+import {
+	useEditProjectSettingsMutation,
+	useGetProjectQuery,
+	useGetProjectSettingsQuery,
+} from '@/graph/generated/hooks'
+import {
+	GetProjectSettingsQuery,
+	namedOperations,
+} from '@/graph/generated/operations'
 import { FilterSessionsWithoutErrorForm } from '@/pages/ProjectSettings/FilterSessionsWithoutErrorForm/FilterSessionsWithoutErrorForm'
+import { ProjectSettingsContextProvider } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
 
 import styles from './ProjectSettings.module.scss'
 
 const ProjectSettings = () => {
 	const navigate = useNavigate()
-	const params = useParams()
+	const { project_id, ...params } = useParams()
+	const [allProjectSettings, setAllProjectSettings] =
+		useState<GetProjectSettingsQuery>()
+
+	const { data: projectData } = useGetProjectQuery({
+		variables: {
+			id: project_id!,
+		},
+		skip: !project_id,
+	})
+	const { data, loading } = useGetProjectSettingsQuery({
+		variables: {
+			projectId: project_id!,
+		},
+		skip: !project_id,
+	})
+
+	const [editProjectSettings, { loading: editProjectSettingsLoading }] =
+		useEditProjectSettingsMutation({
+			refetchQueries: [namedOperations.Query.GetProjectSettings],
+		})
+
+	const onSubmit = (e: { preventDefault: () => void }) => {
+		e.preventDefault()
+		if (!project_id) {
+			return
+		}
+		editProjectSettings({
+			variables: {
+				projectId: project_id!,
+				...allProjectSettings?.projectSettings,
+			},
+		}).then(() => {
+			message.success('Updated session replay settings!', 5)
+		})
+	}
+
+	useEffect(() => {
+		if (!loading) {
+			setAllProjectSettings(data)
+			console.log('pepe', data, projectData)
+		}
+	}, [data, projectData, loading])
 
 	return (
 		<>
 			<Helmet>
 				<title>Project Settings</title>
 			</Helmet>
-
 			<LeadAlignLayout>
-				<h2>Project Settings</h2>
+				<Heading mt="16" level="h4">
+					Project Settings
+				</Heading>
 				<div className={styles.tabsContainer}>
-					<Tabs
-						activeKeyOverride={params.tab ?? 'sessions'}
-						onChange={(key) => {
-							navigate(`/${params.project_id}/settings/${key}`)
+					<ProjectSettingsContextProvider
+						value={{
+							allProjectSettings,
+							setAllProjectSettings,
+							loading,
 						}}
-						noHeaderPadding
-						noPadding
-						id="settingsTabs"
-						tabs={[
-							{
-								key: 'sessions',
-								title: 'Session Replay',
-								panelContent: (
-									<>
-										<ExcludedUsersForm />
-										<FilterSessionsWithoutErrorForm />
-										<RageClicksForm />
-										<NetworkRecordingForm />
-									</>
-								),
-							},
-							{
-								key: 'errors',
-								title: 'Error Monitoring',
-								panelContent: (
-									<>
-										<ErrorSettingsForm />
-										<FilterExtensionForm />
-										<ErrorFiltersForm />
-										<SourcemapSettings />
-									</>
-								),
-							},
-							{
-								key: 'general',
-								title: 'General',
-								panelContent: <DangerForm />,
-							},
-						]}
-					/>
+					>
+						<Tabs
+							activeKeyOverride={params.tab ?? 'sessions'}
+							onChange={(key) => {
+								navigate(`/${project_id}/settings/${key}`)
+							}}
+							noHeaderPadding
+							noPadding
+							id="settingsTabs"
+							tabs={[
+								{
+									key: 'sessions',
+									title: 'Session replay',
+									panelContent: (
+										<>
+											<Box
+												display="flex"
+												gap="8"
+												justifyContent="space-between"
+												alignItems="center"
+											>
+												<Text
+													size="large"
+													weight="bold"
+												>
+													Session replay
+												</Text>
+												<Button
+													onClick={onSubmit}
+													trackingId="ProjectSettingsUpdate"
+												>
+													{editProjectSettingsLoading ? (
+														<CircularSpinner
+															style={{
+																fontSize: 18,
+																color: 'var(--text-primary-inverted)',
+															}}
+														/>
+													) : (
+														'Save changes'
+													)}
+												</Button>
+											</Box>
+											<ExcludedUsersForm />
+											<FilterSessionsWithoutErrorForm />
+											<RageClicksForm />
+											<NetworkRecordingForm />
+										</>
+									),
+								},
+								{
+									key: 'errors',
+									title: 'Error monitoring',
+									panelContent: (
+										<>
+											<Box
+												display="flex"
+												gap="8"
+												justifyContent="space-between"
+												alignItems="center"
+											>
+												<Text
+													size="large"
+													weight="bold"
+												>
+													Error monitoring
+												</Text>
+												<Button
+													onClick={onSubmit}
+													trackingId="ProjectSettingsUpdate"
+												>
+													{editProjectSettingsLoading ? (
+														<CircularSpinner
+															style={{
+																fontSize: 18,
+																color: 'var(--text-primary-inverted)',
+															}}
+														/>
+													) : (
+														'Save changes'
+													)}
+												</Button>
+											</Box>
+											<ErrorSettingsForm />
+											<FilterExtensionForm />
+											<ErrorFiltersForm />
+											<SourcemapSettings />
+										</>
+									),
+								},
+								{
+									key: 'general',
+									title: 'General',
+									panelContent: <DangerForm />,
+								},
+							]}
+						/>
+					</ProjectSettingsContextProvider>
 				</div>
 			</LeadAlignLayout>
 		</>

--- a/frontend/src/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext.tsx
+++ b/frontend/src/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext.tsx
@@ -1,0 +1,11 @@
+import { GetProjectSettingsQuery } from '@/graph/generated/operations'
+import { createContext } from '@/util/context/context'
+
+export const [useProjectSettingsContext, ProjectSettingsContextProvider] =
+	createContext<{
+		allProjectSettings: GetProjectSettingsQuery | undefined
+		setAllProjectSettings: React.Dispatch<
+			React.SetStateAction<GetProjectSettingsQuery | undefined>
+		>
+		loading: boolean
+	}>('ProjectSettingsContext')

--- a/frontend/src/pages/ProjectSettings/RageClicksForm/RageClicksForm.tsx
+++ b/frontend/src/pages/ProjectSettings/RageClicksForm/RageClicksForm.tsx
@@ -1,16 +1,12 @@
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
 import InfoTooltip from '@components/InfoTooltip/InfoTooltip'
 import InputNumber from '@components/InputNumber/InputNumber'
-import { CircularSpinner, LoadingBar } from '@components/Loading/Loading'
-import { useEditProjectMutation, useGetProjectQuery } from '@graph/hooks'
-import { namedOperations } from '@graph/operations'
+import { LoadingBar } from '@components/Loading/Loading'
 import { useParams } from '@util/react-router/useParams'
-import { message } from 'antd'
-import clsx from 'clsx'
 import React, { useEffect, useState } from 'react'
 
-import commonStyles from '../../../Common.module.scss'
-import Button from '../../../components/Button/Button/Button'
+import { useProjectSettingsContext } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
+
 import styles from './RageClicksForm.module.scss'
 
 export const RageClicksForm = () => {
@@ -22,53 +18,26 @@ export const RageClicksForm = () => {
 	const [rageClickRadiusPixels, setRageClickRadiusPixels] =
 		useState<number>(0)
 	const [rageClickCount, setRageClickCount] = useState<number>(0)
-	const { data, loading } = useGetProjectQuery({
-		variables: {
-			id: project_id!,
-		},
-		skip: !project_id,
-	})
-
-	const [editProject, { loading: editProjectLoading }] =
-		useEditProjectMutation({
-			refetchQueries: [
-				namedOperations.Query.GetProjects,
-				namedOperations.Query.GetProject,
-			],
-			onCompleted: () => {
-				message.success('Updated rage clicks settings!', 5)
-			},
-		})
-
-	const onSubmit = (e: { preventDefault: () => void }) => {
-		e.preventDefault()
-		if (!project_id) {
-			return
-		}
-		editProject({
-			variables: {
-				id: project_id!,
-				rage_click_window_seconds: rageClickWindowSeconds,
-				rage_click_radius_pixels: rageClickRadiusPixels,
-				rage_click_count: rageClickCount,
-			},
-		})
-	}
+	const {
+		allProjectSettings: data,
+		loading,
+		setAllProjectSettings,
+	} = useProjectSettingsContext()
 
 	useEffect(() => {
 		if (!loading) {
 			setRageClickWindowSeconds(
-				data?.project?.rage_click_window_seconds ?? 0,
+				data?.projectSettings?.rage_click_window_seconds ?? 0,
 			)
 			setRageClickRadiusPixels(
-				data?.project?.rage_click_radius_pixels ?? 0,
+				data?.projectSettings?.rage_click_radius_pixels ?? 0,
 			)
-			setRageClickCount(data?.project?.rage_click_count ?? 0)
+			setRageClickCount(data?.projectSettings?.rage_click_count ?? 0)
 		}
 	}, [
-		data?.project?.rage_click_count,
-		data?.project?.rage_click_radius_pixels,
-		data?.project?.rage_click_window_seconds,
+		data?.projectSettings?.rage_click_count,
+		data?.projectSettings?.rage_click_radius_pixels,
+		data?.projectSettings?.rage_click_window_seconds,
 		loading,
 	])
 
@@ -79,7 +48,7 @@ export const RageClicksForm = () => {
 	return (
 		<FieldsBox id="rage">
 			<h3>Rage Clicks</h3>
-			<form onSubmit={onSubmit} key={project_id}>
+			<form key={project_id}>
 				<p>
 					Use these settings to adjust the sensitivity for detecting
 					rage clicks.
@@ -97,6 +66,17 @@ export const RageClicksForm = () => {
 						value={rageClickWindowSeconds}
 						onChange={(val) => {
 							setRageClickWindowSeconds(val as number)
+							setAllProjectSettings((currentProjectSettings) =>
+								currentProjectSettings?.projectSettings
+									? {
+											projectSettings: {
+												...currentProjectSettings.projectSettings,
+												rage_click_window_seconds:
+													val as number,
+											},
+									  }
+									: currentProjectSettings,
+							)
 						}}
 						min={1}
 					/>
@@ -114,6 +94,17 @@ export const RageClicksForm = () => {
 						value={rageClickRadiusPixels}
 						onChange={(val) => {
 							setRageClickRadiusPixels(val as number)
+							setAllProjectSettings((currentProjectSettings) =>
+								currentProjectSettings?.projectSettings
+									? {
+											projectSettings: {
+												...currentProjectSettings.projectSettings,
+												rage_click_radius_pixels:
+													val as number,
+											},
+									  }
+									: currentProjectSettings,
+							)
 						}}
 						min={1}
 					/>
@@ -131,34 +122,19 @@ export const RageClicksForm = () => {
 						value={rageClickCount}
 						onChange={(val) => {
 							setRageClickCount(val as number)
+							setAllProjectSettings((currentProjectSettings) =>
+								currentProjectSettings?.projectSettings
+									? {
+											projectSettings: {
+												...currentProjectSettings.projectSettings,
+												rage_click_count: val as number,
+											},
+									  }
+									: currentProjectSettings,
+							)
 						}}
 						min={1}
 					/>
-				</div>
-				<div className={styles.fieldRow}>
-					<div className={styles.fieldKey}></div>
-					<div className={styles.saveButton}>
-						<Button
-							trackingId="RageClickSettingsUpdate"
-							htmlType="submit"
-							type="primary"
-							className={clsx(
-								commonStyles.submitButton,
-								styles.saveButton,
-							)}
-						>
-							{editProjectLoading ? (
-								<CircularSpinner
-									style={{
-										fontSize: 18,
-										color: 'var(--text-primary-inverted)',
-									}}
-								/>
-							) : (
-								'Save'
-							)}
-						</Button>
-					</div>
 				</div>
 			</form>
 		</FieldsBox>


### PR DESCRIPTION
## Summary

Figma for the new settings show that project settings are saved using a single button. This PR adds that endpoint, and changed much of the logic in the project settings to use the new context that manages settings. 

Discussion in Slack about it: https://highlightcorp.slack.com/archives/C01FJL7V630/p1683905993153839

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
