### PR TITLE
Fix wrong hobby deployment link

### DIFF
--- a/highlight.io/pages/pricing/index.tsx
+++ b/highlight.io/pages/pricing/index.tsx
@@ -173,7 +173,7 @@ const Faqs: { question: string; answer: string; icon: string }[] = [
 	},
 	{
 		question: 'Can I deploy Highlight on-premise?',
-		answer: `Yes! To get a glimpse at how our hobby deployment process looks, take a look <a href="${docsUrl}/general/company/open-source/self-host-hobby">here</a>. To get a license key for a production deployment, contacts at <a href="mailto:sales@highlight.io">sales@highlight.io</a>.`,
+		answer: `Yes! To get a glimpse at how our hobby deployment process looks, take a look <a href="${docsUrl}/general/company/open-source/hosting/self-host-hobby">here</a>. To get a license key for a production deployment, contacts at <a href="mailto:sales@highlight.io">sales@highlight.io</a>.`,
 		icon: Globe,
 	},
 	{


### PR DESCRIPTION
## Summary

Change the "hobby deployment process" link to the correct one.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
