### PR TITLE
ban imports from @icons

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -131,6 +131,10 @@
 					{
 						"group": ["**/packages/ui/src"],
 						"message": "Import from @highlight-run/ui instead."
+					},
+					{
+						"group": ["@icons/**"],
+						"message": "Import from @highlight-run/ui instead."
 					}
 				]
 			}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR bans imports from `@icons` via an eslint rule.

Closes #4385

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
Confirmed we cannot import from `@icons`

![Screenshot 2023-05-22 at 8 41 31 AM](https://github.com/highlight/highlight/assets/58678/f8d359b8-5adf-4225-bd36-024d9bd82235)

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
