### PR TITLE
Supporting Next.js middleware

### DIFF
--- a/docs-content/getting-started/fullstack-frameworks/next-js.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js.md
@@ -140,6 +140,30 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
+You may have trouble with `__dirname`, which can happen with Next.js middleware, consider patching it. This example uses a `next.config.mjs` file instead of the CJS-style `next.config.js` pattern.
+
+```javascript
+// next.config.mjs
+import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import nextBuildId from 'next-build-id'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+	generateBuildId: () => nextBuildId({ dir: __dirname }),
+	experimental: {
+		appDir: true,
+		instrumentationHook: true,
+	},
+	productionBrowserSourceMaps: true,
+}
+
+export default nextConfig
+```
+
 3. Create `instrumentation.ts` at the root of your project as explained in the [instrumentation guide](https://nextjs.org/docs/advanced-features/instrumentation). Call `registerHighlight` from within the exported `register` function:
 
 ```javascript

--- a/docs-content/getting-started/fullstack-frameworks/next-js.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js.md
@@ -155,6 +155,31 @@ export async function register() {
 }
 ```
 
+> If you're using [Next Middleware](https://nextjs.org/docs/pages/building-your-application/routing/middleware), you'll need to do a conditional import. Otherwise you'll get an error like ` error - An error occurred while loading instrumentation hook: (0 , _highlight_run_next__WEBPACK_IMPORTED_MODULE_1__.registerHighlight) is not a function`
+
+```javascript
+// instrumentation.ts
+import CONSTANTS from '@/app/constants'
+
+export async function register() {
+	if (process.env.NEXT_RUNTIME === 'nodejs') {
+		/**
+		 * Conditional import required for use with Next middleware
+		 * 
+		 * Avoids the following error:
+		 * An error occurred while loading instrumentation hook: (0 , _highlight_run_next__WEBPACK_IMPORTED_MODULE_1__.registerHighlight) is not a function
+		 */
+		const { registerHighlight } = await import('@highlight-run/next')
+
+		registerHighlight({
+			projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
+			otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
+		})
+	}
+}
+
+```
+
 ## Instrument the client
 
 This implementation requires React 17 or greater. If you're behind on React versions, follow our [React.js docs](../3_client-sdk/1_reactjs.md)

--- a/docs-content/getting-started/fullstack-frameworks/next-js.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js.md
@@ -140,7 +140,7 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
-You may have trouble with `__dirname`, which can happen with Next.js middleware, consider patching it. This example uses a `next.config.mjs` file instead of the CJS-style `next.config.js` pattern.
+You may have trouble with a missing `__dirname` environment variable. This can happen with Next.js middleware. The following example uses a `next.config.mjs` file instead of the CJS-style `next.config.js` pattern. It calculates `__dirname` using native Node.js utility packages.
 
 ```javascript
 // next.config.mjs

--- a/docs-content/getting-started/fullstack-frameworks/next-js.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js.md
@@ -155,7 +155,7 @@ export async function register() {
 }
 ```
 
-> If you're using [Next Middleware](https://nextjs.org/docs/pages/building-your-application/routing/middleware), you'll need to do a conditional import. Otherwise you'll get an error like ` error - An error occurred while loading instrumentation hook: (0 , _highlight_run_next__WEBPACK_IMPORTED_MODULE_1__.registerHighlight) is not a function`
+> You'll need to do a conditional import if you're using [Next Middleware](https://nextjs.org/docs/pages/building-your-application/routing/middleware).
 
 ```javascript
 // instrumentation.ts

--- a/e2e/nextjs/instrumentation.ts
+++ b/e2e/nextjs/instrumentation.ts
@@ -1,10 +1,20 @@
 // instrumentation.ts
 import CONSTANTS from '@/app/constants'
-import { registerHighlight } from '@highlight-run/next'
+// import { registerHighlight } from '@highlight-run/next'
 
 export async function register() {
-	registerHighlight({
-		projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
-		otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
-	})
+	if (process.env.NEXT_RUNTIME === 'nodejs') {
+		/**
+		 * Conditional import required for use with Next middleware
+		 *
+		 * Avoids the following error:
+		 * An error occurred while loading instrumentation hook: (0 , _highlight_run_next__WEBPACK_IMPORTED_MODULE_1__.registerHighlight) is not a function
+		 */
+		const { registerHighlight } = await import('@highlight-run/next')
+
+		registerHighlight({
+			projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
+			otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
+		})
+	}
 }

--- a/e2e/nextjs/instrumentation.ts
+++ b/e2e/nextjs/instrumentation.ts
@@ -1,6 +1,5 @@
 // instrumentation.ts
 import CONSTANTS from '@/app/constants'
-// import { registerHighlight } from '@highlight-run/next'
 
 export async function register() {
 	if (process.env.NEXT_RUNTIME === 'nodejs') {

--- a/e2e/nextjs/middleware.ts
+++ b/e2e/nextjs/middleware.ts
@@ -1,0 +1,6 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+	return NextResponse.next()
+}

--- a/e2e/nextjs/next.config.mjs
+++ b/e2e/nextjs/next.config.mjs
@@ -1,5 +1,10 @@
 // next.config.js
+import { dirname } from 'path'
+import { fileURLToPath } from 'url'
 import nextBuildId from 'next-build-id'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/e2e/nextjs/next.config.mjs
+++ b/e2e/nextjs/next.config.mjs
@@ -1,5 +1,5 @@
 // next.config.js
-const nextBuildId = require('next-build-id')
+import nextBuildId from 'next-build-id'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -11,4 +11,4 @@ const nextConfig = {
 	productionBrowserSourceMaps: true,
 }
 
-module.exports = nextConfig
+export default nextConfig

--- a/e2e/nextjs/tsconfig.json
+++ b/e2e/nextjs/tsconfig.json
@@ -28,7 +28,7 @@
 		"**/*.ts",
 		"**/*.tsx",
 		".next/types/**/*.ts",
-		"next.config.js"
+		"next.config.mjs"
 	],
 	"exclude": ["node_modules"],
 	"references": [{


### PR DESCRIPTION
## Summary

DragonZSG discovered a problem with `middleware.ts` and `instrumentation.ts` on [this Discord thread](https://discord.com/channels/1026884757667188757/1109236631665385473/1109236631665385473)

I was able to reproduce and found this error:

```
An error occurred while loading instrumentation hook: (0 , _highlight_run_next__WEBPACK_IMPORTED_MODULE_1__.registerHighlight) is not a function
```

I was able to resolve the issue with a dynamic import in `instrumentation.ts`, because it appeared that `middleware.ts` was attempting to import Node.js-only code in a non-Node.js environment.

I've updated the docs.

![image](https://github.com/highlight/highlight/assets/878947/837d7b43-dd04-463a-896e-b6bc7bd47cf7)

## How did you test this change?

I created a `middleware.ts` file at the root of `e2e/nextjs` and reproduced the error.

Subsequent changes to `instrumentation.ts` resolved the issue

## Are there any deployment considerations?

Nope