### PR TITLE
Revert "ban imports from @icons (#5389)"

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -131,10 +131,6 @@
 					{
 						"group": ["**/packages/ui/src"],
 						"message": "Import from @highlight-run/ui instead."
-					},
-					{
-						"group": ["@icons/**"],
-						"message": "Import from @highlight-run/ui instead."
 					}
 				]
 			}


### PR DESCRIPTION
This reverts commit bc887cbadf4143734cf93f7fdfc5cf551490896a.

This broke the build since `yarn lint` didn't run on that PR. 

See broken build on a different PR:
https://github.com/highlight/highlight/actions/runs/5047812453/jobs/9055181704?pr=5127