### PR TITLE
remove writing session console messages to redis

### DIFF
--- a/backend/migrations/cmd/delete-behave-health-sessions/main.go
+++ b/backend/migrations/cmd/delete-behave-health-sessions/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	var s3Keys []types.ObjectIdentifier
 	for _, id := range ids {
-		for _, suffix := range []string{"console-messages", "network-resources", "session-contents"} {
+		for _, suffix := range []string{"network-resources", "session-contents"} {
 			key := fmt.Sprintf("1/%d/%s", id, suffix)
 			s3Keys = append(s3Keys, types.ObjectIdentifier{Key: &key})
 		}

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1162,7 +1162,6 @@ type RawPayloadType string
 const (
 	PayloadTypeEvents    RawPayloadType = "raw-events"
 	PayloadTypeResources RawPayloadType = "raw-resources"
-	PayloadTypeMessages  RawPayloadType = "raw-messages"
 )
 
 type BillingEmailHistory struct {

--- a/backend/payload/payload.go
+++ b/backend/payload/payload.go
@@ -139,7 +139,6 @@ type FileType string
 const (
 	EventsCompressed        FileType = "EventsCompressed"
 	ResourcesCompressed     FileType = "ResourcesCompressed"
-	MessagesCompressed      FileType = "MessagesCompressed"
 	EventsChunked           FileType = "EventsChunked"
 	TimelineIndicatorEvents FileType = "TimelineIndicatorEvents"
 )
@@ -180,10 +179,6 @@ func NewPayloadManager(ctx context.Context, filenamePrefix string) (*PayloadMana
 			suffix: ".resources.json.br",
 			ddTag:  "resourcesCompressedPayloadSize",
 		},
-		MessagesCompressed: {
-			suffix: ".messages.json.br",
-			ddTag:  "messagesCompressedPayloadSize",
-		},
 		TimelineIndicatorEvents: {
 			suffix: ".timelineindicatorevents.json.br",
 			ddTag:  "timelineIndicatorEventsPayloadSize",
@@ -208,8 +203,6 @@ func NewPayloadManager(ctx context.Context, filenamePrefix string) (*PayloadMana
 			manager.EventsCompressed = NewCompressedWriter(fileInfo.file)
 		case ResourcesCompressed:
 			manager.ResourcesCompressed = NewCompressedWriter(fileInfo.file)
-		case MessagesCompressed:
-			manager.MessagesCompressed = NewCompressedWriter(fileInfo.file)
 		case TimelineIndicatorEvents:
 			manager.TimelineIndicatorEvents = NewCompressedWriter(fileInfo.file)
 		}

--- a/backend/payload/payload.go
+++ b/backend/payload/payload.go
@@ -128,7 +128,6 @@ func (w *CompressedWriter) Close() error {
 type PayloadManager struct {
 	EventsCompressed        *CompressedWriter
 	ResourcesCompressed     *CompressedWriter
-	MessagesCompressed      *CompressedWriter
 	EventsChunked           *CompressedWriter
 	TimelineIndicatorEvents *CompressedWriter
 	ChunkIndex              int

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -835,7 +835,6 @@ type ComplexityRoot struct {
 		LogsKeyValues                func(childComplexity int, projectID int, keyName string, dateRange model.DateRangeRequiredInput) int
 		LogsKeys                     func(childComplexity int, projectID int, dateRange model.DateRangeRequiredInput) int
 		LogsTotalCount               func(childComplexity int, projectID int, params model.LogsParamsInput) int
-		Messages                     func(childComplexity int, sessionSecureID string) int
 		MetricMonitors               func(childComplexity int, projectID int, metricName *string) int
 		MetricTagValues              func(childComplexity int, projectID int, metricName string, tagName string) int
 		MetricTags                   func(childComplexity int, projectID int, metricName string) int
@@ -1370,7 +1369,6 @@ type QueryResolver interface {
 	ErrorObject(ctx context.Context, id int) (*model1.ErrorObject, error)
 	ErrorObjectForLog(ctx context.Context, logCursor string) (*model1.ErrorObject, error)
 	ErrorInstance(ctx context.Context, errorGroupSecureID string, errorObjectID *int) (*model1.ErrorInstance, error)
-	Messages(ctx context.Context, sessionSecureID string) ([]interface{}, error)
 	EnhancedUserDetails(ctx context.Context, sessionSecureID string) (*model.EnhancedUserDetailsResult, error)
 	Errors(ctx context.Context, sessionSecureID string) ([]*model1.ErrorObject, error)
 	Resources(ctx context.Context, sessionSecureID string) ([]interface{}, error)
@@ -6123,18 +6121,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.LogsTotalCount(childComplexity, args["project_id"].(int), args["params"].(model.LogsParamsInput)), true
 
-	case "Query.messages":
-		if e.complexity.Query.Messages == nil {
-			break
-		}
-
-		args, err := ec.field_Query_messages_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.Messages(childComplexity, args["session_secure_id"].(string)), true
-
 	case "Query.metric_monitors":
 		if e.complexity.Query.MetricMonitors == nil {
 			break
@@ -9925,7 +9911,6 @@ type Query {
 		error_group_secure_id: String!
 		error_object_id: ID
 	): ErrorInstance
-	messages(session_secure_id: String!): [Any]
 	enhanced_user_details(session_secure_id: String!): EnhancedUserDetailsResult
 	errors(session_secure_id: String!): [ErrorObject]
 	resources(session_secure_id: String!): [Any]
@@ -14983,21 +14968,6 @@ func (ec *executionContext) field_Query_logs_total_count_args(ctx context.Contex
 		}
 	}
 	args["params"] = arg1
-	return args, nil
-}
-
-func (ec *executionContext) field_Query_messages_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 string
-	if tmp, ok := rawArgs["session_secure_id"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_secure_id"))
-		arg0, err = ec.unmarshalNString2string(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["session_secure_id"] = arg0
 	return args, nil
 }
 
@@ -40273,57 +40243,6 @@ func (ec *executionContext) fieldContext_Query_error_instance(ctx context.Contex
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_error_instance_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Query_messages(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_messages(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Messages(rctx, fc.Args["session_secure_id"].(string))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]interface{})
-	fc.Result = res
-	return ec.marshalOAny2ᚕinterface(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_messages(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Any does not have child fields")
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_messages_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -66883,26 +66802,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_error_instance(ctx, field)
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return rrm(innerCtx)
-			})
-		case "messages":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_messages(ctx, field)
 				return res
 			}
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1419,7 +1419,6 @@ type Query {
 		error_group_secure_id: String!
 		error_object_id: ID
 	): ErrorInstance
-	messages(session_secure_id: String!): [Any]
 	enhanced_user_details(session_secure_id: String!): EnhancedUserDetailsResult
 	errors(session_secure_id: String!): [ErrorObject]
 	resources(session_secure_id: String!): [Any]

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2762,9 +2762,6 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			log.WithContext(ctx).WithError(err).Error("failed to parse console messages")
 		}
 
-		if err := r.SaveSessionData(ctx, projectID, sessionID, payloadIdDeref, false, isBeacon, model.PayloadTypeMessages, []byte(messages)); err != nil {
-			return e.Wrap(err, "error saving messages data")
-		}
 		return nil
 	})
 

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"os"
 	"sort"
 	"strconv"
 	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/go-redis/cache/v8"
 	"github.com/go-redis/redis/v8"
@@ -40,10 +41,6 @@ func EventsKey(sessionId int) string {
 
 func NetworkResourcesKey(sessionId int) string {
 	return fmt.Sprintf("network-resources-%d", sessionId)
-}
-
-func ConsoleMessagesKey(sessionId int) string {
-	return fmt.Sprintf("console-messages-%d", sessionId)
 }
 
 func SessionInitializedKey(sessionSecureId string) string {
@@ -148,8 +145,6 @@ func GetKey(sessionId int, payloadType model.RawPayloadType) string {
 		return EventsKey(sessionId)
 	case model.PayloadTypeResources:
 		return NetworkResourcesKey(sessionId)
-	case model.PayloadTypeMessages:
-		return ConsoleMessagesKey(sessionId)
 	default:
 		return ""
 	}

--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -86,7 +86,6 @@ type Client interface {
 	PushFiles(ctx context.Context, sessionId, projectId int, payloadManager *payload.PayloadManager) (int64, error)
 	PushRawEvents(ctx context.Context, sessionId, projectId int, payloadType model.RawPayloadType, events []redis.Z) error
 	PushSourceMapFile(ctx context.Context, projectId int, version *string, fileName string, fileBytes []byte) (*int64, error)
-	ReadMessages(ctx context.Context, sessionId int, projectId int) ([]interface{}, error)
 	ReadResources(ctx context.Context, sessionId int, projectId int) ([]interface{}, error)
 	ReadSourceMapFile(ctx context.Context, projectId int, version *string, fileName string) ([]byte, error)
 	ReadTimelineIndicatorEvents(ctx context.Context, sessionId int, projectId int) ([]*model.TimelineIndicatorEvent, error)

--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -58,7 +58,6 @@ type PayloadType string
 
 const (
 	NetworkResources           PayloadType = "network-resources"
-	ConsoleMessages            PayloadType = "console-messages"
 	SessionContentsCompressed  PayloadType = "session-contents-compressed"
 	NetworkResourcesCompressed PayloadType = "network-resources-compressed"
 	TimelineIndicatorEvents    PayloadType = "timeline-indicator-events"

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -8399,58 +8399,6 @@ export type GetRecentErrorsQueryResult = Apollo.QueryResult<
 	Types.GetRecentErrorsQuery,
 	Types.GetRecentErrorsQueryVariables
 >
-export const GetMessagesDocument = gql`
-	query GetMessages($session_secure_id: String!) {
-		messages(session_secure_id: $session_secure_id)
-	}
-`
-
-/**
- * __useGetMessagesQuery__
- *
- * To run a query within a React component, call `useGetMessagesQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetMessagesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetMessagesQuery({
- *   variables: {
- *      session_secure_id: // value for 'session_secure_id'
- *   },
- * });
- */
-export function useGetMessagesQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetMessagesQuery,
-		Types.GetMessagesQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetMessagesQuery,
-		Types.GetMessagesQueryVariables
-	>(GetMessagesDocument, baseOptions)
-}
-export function useGetMessagesLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetMessagesQuery,
-		Types.GetMessagesQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetMessagesQuery,
-		Types.GetMessagesQueryVariables
-	>(GetMessagesDocument, baseOptions)
-}
-export type GetMessagesQueryHookResult = ReturnType<typeof useGetMessagesQuery>
-export type GetMessagesLazyQueryHookResult = ReturnType<
-	typeof useGetMessagesLazyQuery
->
-export type GetMessagesQueryResult = Apollo.QueryResult<
-	Types.GetMessagesQuery,
-	Types.GetMessagesQueryVariables
->
 export const GetResourcesDocument = gql`
 	query GetResources($session_secure_id: String!) {
 		resources(session_secure_id: $session_secure_id)

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2956,15 +2956,6 @@ export type GetRecentErrorsQuery = { __typename?: 'Query' } & {
 	>
 }
 
-export type GetMessagesQueryVariables = Types.Exact<{
-	session_secure_id: Types.Scalars['String']
-}>
-
-export type GetMessagesQuery = { __typename?: 'Query' } & Pick<
-	Types.Query,
-	'messages'
->
-
 export type GetResourcesQueryVariables = Types.Exact<{
 	session_secure_id: Types.Scalars['String']
 }>
@@ -4425,7 +4416,6 @@ export const namedOperations = {
 		GetErrorObject: 'GetErrorObject' as const,
 		GetErrorInstance: 'GetErrorInstance' as const,
 		GetRecentErrors: 'GetRecentErrors' as const,
-		GetMessages: 'GetMessages' as const,
 		GetResources: 'GetResources' as const,
 		GetFieldSuggestion: 'GetFieldSuggestion' as const,
 		GetEnvironments: 'GetEnvironments' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1647,7 +1647,6 @@ export type Query = {
 	logs_key_values: Array<Scalars['String']>
 	logs_keys: Array<LogKey>
 	logs_total_count: Scalars['UInt64']
-	messages?: Maybe<Array<Maybe<Scalars['Any']>>>
 	metric_monitors: Array<Maybe<MetricMonitor>>
 	metric_tag_values: Array<Scalars['String']>
 	metric_tags: Array<Scalars['String']>
@@ -2037,10 +2036,6 @@ export type QueryLogs_KeysArgs = {
 export type QueryLogs_Total_CountArgs = {
 	params: LogsParamsInput
 	project_id: Scalars['ID']
-}
-
-export type QueryMessagesArgs = {
-	session_secure_id: Scalars['String']
 }
 
 export type QueryMetric_MonitorsArgs = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1155,10 +1155,6 @@ query GetRecentErrors($secure_id: String!) {
 	}
 }
 
-query GetMessages($session_secure_id: String!) {
-	messages(session_secure_id: $session_secure_id)
-}
-
 query GetResources($session_secure_id: String!) {
 	resources(session_secure_id: $session_secure_id)
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -69,7 +69,6 @@ const options: HighlightOptions = {
 			'localhost:8082',
 		],
 		urlBlocklist: [
-			'console-messages-compressed',
 			'network-resources-compressed',
 			'session-contents-compressed',
 		],

--- a/scripts/remove_uncompressed.py
+++ b/scripts/remove_uncompressed.py
@@ -17,7 +17,7 @@ WORKER_PREFETCH = 4
 WORKERS = cpu_count() * 4
 MAX_TASKS_WAITING = WORKERS * WORKER_PREFETCH
 
-HIGHLIGHT_FILES = {'session-contents', 'console-messages', 'network-resources'}
+HIGHLIGHT_FILES = {'session-contents', 'network-resources'}
 
 
 class PatchedQueue:

--- a/scripts/test_remove_uncompressed.py
+++ b/scripts/test_remove_uncompressed.py
@@ -19,16 +19,13 @@ def expect_calls(m, files):
 
 
 @pytest.mark.parametrize('session_compressed', [False, True])
-@pytest.mark.parametrize('console_compressed', [False, True])
 @pytest.mark.parametrize('network_compressed', [False, True])
 @pytest.mark.parametrize('do_archive', [False, True])
 @pytest.mark.parametrize('do_compress', [False, True])
-def test(mocker, session_compressed, console_compressed, network_compressed, do_archive, do_compress):
+def test(mocker, session_compressed, network_compressed, do_archive, do_compress):
     files = set(HIGHLIGHT_FILES)
     if session_compressed:
         files.add('session-contents-compressed')
-    if console_compressed:
-        files.add('console-messages-compressed')
     if network_compressed:
         files.add('network-resources-compressed')
 
@@ -42,7 +39,7 @@ def test(mocker, session_compressed, console_compressed, network_compressed, do_
         for p in range(1, 10) for s in range(1, 10) for k in sorted(files)
     ]
     process('mock-bucket', '1/', debug=True, do_archive=do_archive, do_compress=do_compress)
-    if session_compressed and console_compressed and network_compressed:
+    if session_compressed and network_compressed:
         mock_compress.assert_not_called()
         expect_calls(mock_archive, files)
     else:


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR cleans up writing (and reading) console messages from redis. We now write/read this data from clickhouse (#4833)

Note: `messages_url` endpoint already cleaned up in #5336

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed no errors with a new session and that the console messages still read/write from clickhouse.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A