### PR TITLE
enable asset storage for another customer

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2685,7 +2685,9 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 					}
 
 					// Replace any static resources with our own, hosted in S3
-					if projectID == 1 || projectID == 1031 || projectID == 1344 || projectID == 5378 || projectID == 5403 {
+					if map[int]bool{
+						1: true, 1031: true, 1344: true, 5378: true, 5403: true, 6469: true,
+					}[projectID] {
 						assetsSpan, _ := tracer.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
 							tracer.ResourceName("go.parseEvents.replaceAssets"), tracer.Tag("project_id", projectID), tracer.Tag("session_secure_id", sessionSecureID))
 						err = snapshot.ReplaceAssets(ctx, projectID, r.StorageClient, r.DB, r.Redis)

--- a/frontend/src/pages/Buttons/Buttons.tsx
+++ b/frontend/src/pages/Buttons/Buttons.tsx
@@ -555,6 +555,22 @@ export const Buttons = () => {
 						))}
 					</Box>
 				</Box>
+
+				<Box width="full" style={{ height: 200 }}>
+					<div
+						style={{
+							backgroundImage:
+								'url("https://www.highlight.io/images/quickstart/react.svg")',
+							height: '24%',
+						}}
+					></div>
+					<div
+						style={{
+							backgroundImage:
+								'url("https://www.highlight.io/images/quickstart/react.svg")',
+						}}
+					></div>
+				</Box>
 			</div>
 		</div>
 	)


### PR DESCRIPTION
## Summary

Adds an example to the buttons page to ensure that we can correctly inline a style image asset.

## How did you test this change?

Customer has a div that uses a `style` attribute with a `backgroundImage("url(...)"` syntax.
Adding a sample div of that type to our hidden buttons page for internal testing.

<img width="685" alt="Screenshot 2023-05-22 at 6 37 59 PM" src="https://github.com/highlight/highlight/assets/1351531/8e14b59c-636b-4f50-8fd8-9849dd895958">


## Are there any deployment considerations?

No