### PR TITLE
fix billing details caching stripe url

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2614,7 +2614,7 @@ func (r *Resolver) GetGitHubRepos(
 	}
 
 	if accessToken == nil {
-		return nil, errors.New("No GitHub integration access token found.")
+		return nil, nil
 	}
 	var repos []*github2.Repository
 	if c, err := github.NewClient(ctx, *accessToken); err == nil {
@@ -2646,7 +2646,7 @@ func (r *Resolver) GetGitHubIssueLabels(
 	}
 
 	if accessToken == nil {
-		return nil, errors.New("No GitHub integration access token found.")
+		return nil, nil
 	}
 	var labels []*github2.Label
 	if c, err := github.NewClient(ctx, *accessToken); err == nil {

--- a/frontend/src/util/db.ts
+++ b/frontend/src/util/db.ts
@@ -139,7 +139,7 @@ export class IndexedDBLink extends ApolloLink {
 	static excluded = new Set<string>([
 		'GetAdmin',
 		'GetBillingDetails',
-		'GetCustomerPortalUrl',
+		'GetCustomerPortalURL',
 		'GetProject',
 		'GetSubscriptionDetails',
 	])
@@ -180,6 +180,9 @@ export class IndexedDBLink extends ApolloLink {
 		forward?: NextLink,
 	): Observable<FetchResult<Record<string, any>>> | null {
 		if (!IndexedDBLink.isCached({ operation })) {
+			log('db.ts', 'IndexedDBLink cache bypass', {
+				operation,
+			})
 			return this.httpLink.request(operation, forward)
 		}
 


### PR DESCRIPTION
## Summary

Operation name had the wrong case in the indexeddb cache exclusion policy.
Also stops emitting github integration errors as they are not actual errors.

## How did you test this change?

cache now bypassed for the payment settings page

<img width="989" alt="Screenshot 2023-05-23 at 1 02 01 PM" src="https://github.com/highlight/highlight/assets/1351531/8c8d1891-4108-4504-a8b3-0b098ce8c404">

different stripe urls loaded

<img width="433" alt="Screenshot 2023-05-23 at 1 02 47 PM" src="https://github.com/highlight/highlight/assets/1351531/2f01259c-44e5-40e3-8482-850ad33b7e2f">

## Are there any deployment considerations?

No