### PR TITLE
Request Headers

### DIFF
--- a/e2e/nextjs/package.json
+++ b/e2e/nextjs/package.json
@@ -25,6 +25,7 @@
 		"eslint": "8.39.0",
 		"eslint-config-next": "13.3.4",
 		"highlight.run": "workspace:*",
+		"ky": "^0.33.3",
 		"next": "13.3.4",
 		"next-build-id": "^3.0.0",
 		"react": "18.2.0",

--- a/e2e/nextjs/src/app/api/app-directory-test/route.ts
+++ b/e2e/nextjs/src/app/api/app-directory-test/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
 export const GET = async function GET(request: Request) {
@@ -11,6 +12,14 @@ export const GET = async function GET(request: Request) {
 	} else {
 		throw new Error('Error: /api/app-directory-test')
 	}
+}
+
+export const POST = async function POST(request: Request) {
+	const headers = Object.fromEntries(request.headers.entries())
+
+	return NextResponse.json({
+		body: { headers },
+	})
 }
 
 export const runtime = 'nodejs'

--- a/e2e/nextjs/src/app/components/fetch-tests.tsx
+++ b/e2e/nextjs/src/app/components/fetch-tests.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Button } from '@/app/components/button'
+import ky from 'ky'
+
+export function FetchTests() {
+	return <Button onClick={fireKy}>Test KY</Button>
+}
+
+function fireKy() {
+	ky.post('/api/app-directory-test?success=true', {
+		headers: {
+			Accept: 'application/json',
+			'Content-type': 'application/json',
+		},
+	})
+		.then((res) => res.json())
+		.then((data) => console.info(data))
+}

--- a/e2e/nextjs/src/app/page.tsx
+++ b/e2e/nextjs/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { ErrorButtons } from '@/app/components/error-buttons'
+import { FetchTests } from '@/app/components/fetch-tests'
 import Image from 'next/image'
 import { PathButtons } from '@/app/components/path-buttons'
 import { TrpcQueries } from '@/app/components/trpc-queries'
@@ -23,6 +24,9 @@ export default function Home() {
 
 			<h3>tRPC</h3>
 			<TrpcQueries />
+
+			<h3>Fetch</h3>
+			<FetchTests />
 		</main>
 	)
 }

--- a/sdk/client/src/listeners/network-listener/utils/fetch-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/fetch-listener.ts
@@ -1,17 +1,18 @@
-import { getBodyThatShouldBeRecorded } from './xhr-listener'
-import { NetworkListenerCallback } from '../network-listener'
 import {
-	RequestResponsePair,
-	Request as HighlightRequest,
-	Response as HighlightResponse,
-} from './models'
-import {
+	HIGHLIGHT_REQUEST_HEADER,
 	createNetworkRequestId,
 	getHighlightRequestHeader,
-	HIGHLIGHT_REQUEST_HEADER,
 	shouldNetworkRequestBeRecorded,
 	shouldNetworkRequestBeTraced,
 } from './utils'
+import {
+	Request as HighlightRequest,
+	Response as HighlightResponse,
+	RequestResponsePair,
+} from './models'
+
+import { NetworkListenerCallback } from '../network-listener'
+import { getBodyThatShouldBeRecorded } from './xhr-listener'
 
 export interface HighlightFetchWindow extends WindowOrWorkerGlobalScope {
 	_originalFetch: WindowOrWorkerGlobalScope['fetch']
@@ -43,10 +44,18 @@ export const FetchListener = (
 			init = init || {}
 			// Pre-existing headers could be one of three different formats; this reads all of them.
 			let headers = new Headers(init.headers)
+
+			if (input instanceof Request) {
+				;[...input.headers].forEach(([key, value]) =>
+					headers.set(key, value),
+				)
+			}
+
 			headers.set(
 				HIGHLIGHT_REQUEST_HEADER,
 				getHighlightRequestHeader(sessionSecureID, requestId),
 			)
+
 			init.headers = Object.fromEntries(headers.entries())
 		}
 

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -26,7 +26,7 @@
 	},
 	"scripts": {
 		"typegen": "tsup --dts-only",
-		"dev": "yarn build --watch",
+		"dev": "tsup --watch && sh ./bin/clean-highlight-init.sh",
 		"build": "tsup && sh ./bin/clean-highlight-init.sh",
 		"test": "jest"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -37776,6 +37776,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ky@npm:^0.33.3":
+  version: 0.33.3
+  resolution: "ky@npm:0.33.3"
+  checksum: d1869e1f33c0165355f621b6726fcc1a9de20a31f4a826ca0cfd5753d83b9cba8723402d554a00194e0ee3959e0dda0638f4b99d54a3a7de928b55ff870b0bcc
+  languageName: node
+  linkType: hard
+
 "lambdafs@npm:^2.0.3":
   version: 2.1.1
   resolution: "lambdafs@npm:2.1.1"
@@ -40722,6 +40729,7 @@ __metadata:
     eslint: 8.39.0
     eslint-config-next: 13.3.4
     highlight.run: "workspace:*"
+    ky: ^0.33.3
     next: 13.3.4
     next-build-id: ^3.0.0
     react: 18.2.0


### PR DESCRIPTION
## Summary

We've had consistent bug reports of missing headers.

Here's an example:
https://discord.com/channels/1026884757667188757/1109049760909885480

This likely closes a bunch of other issues in the repo.

## How did you test this change?

I used [sindresorhus/ky](https://github.com/sindresorhus/ky) to reproduce. This library uses the native `Request` object in a way that we weren't supporting.

## Are there any deployment considerations?

Nope! Just a patch version bump.