### PR TITLE
cleanup unused gorm indexes

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -796,18 +796,18 @@ type MessagesObject struct {
 }
 
 type Metric struct {
-	CreatedAt     time.Time `json:"created_at" deep:"-" gorm:"index"`
+	CreatedAt     time.Time `json:"created_at" deep:"-"`
 	MetricGroupID int       `gorm:"index"`
-	Name          string    `gorm:"index;not null;"`
-	Value         float64   `gorm:"index"`
-	Category      string    `gorm:"index"`
+	Name          string
+	Value         float64
+	Category      string
 }
 
 type MetricGroup struct {
-	ID        int       `gorm:"primary_key;type:bigserial" json:"id" deep:"-"`
-	GroupName string    // index with session_id
-	SessionID int       // index with Name
-	ProjectID int       `gorm:"index;not null;"`
+	ID        int `gorm:"primary_key;type:bigserial" json:"id" deep:"-"`
+	GroupName string
+	SessionID int
+	ProjectID int
 	Metrics   []*Metric `gorm:"foreignKey:MetricGroupID;"`
 }
 


### PR DESCRIPTION
## Summary

Remove some indexes set in `model.go` that are not used, as per
```sql
select pg_size_pretty(pg_relation_size(i.indexrelid)) AS index_size, *
from pg_stat_all_indexes psai
         LEFT JOIN pg_index i ON i.indexrelid = psai.indexrelid
where schemaname = 'public'
and idx_scan < 1
order by pg_relation_size(i.indexrelid) desc, idx_scan desc, relname;
```

## How did you test this change?

Checking that these indexes have 0 bytes scanned.

## Are there any deployment considerations?

Will monitor the migration step in the aws deploy.