### PR TITLE
use UpdateSynchronous when updating an error group state

### DIFF
--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -64,7 +64,7 @@ func (store *Store) updateErrorGroupState(ctx context.Context,
 		return errorGroup, err
 	}
 
-	if err := store.opensearch.Update(opensearch.IndexErrorsCombined, errorGroup.ID, errorGroup); err != nil {
+	if err := store.opensearch.UpdateSynchronous(opensearch.IndexErrorsCombined, errorGroup.ID, errorGroup); err != nil {
 		return errorGroup, errors.New("error updating error group state in OpenSearch")
 	}
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

When we autoresolve error groups, the status isn't getting updated in opensearch correctly. 

Per this [comment](https://github.com/highlight/highlight/pull/5354#discussion_r1201385154), we switched to updating async to limit writes to opensearch. However, the async flavor doesn't seem to propogate the update. My suspicion is that we don't explicitly refresh in this flow (#3550). I filed #5457 to look into this more.

Regardless, because `updateErrorGroupState` is called by non-worker code (e.g. updating the status in the app), we need this to be a sync operation so there isn't a delay.


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Ran the autoresolver locally with a "stale" error group (see #5354) and confirmed that both postgres and opensearch have updated "RESOLVED" states.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

We should monitor opensearch after running the autoresolver again and ensure that the write load on opensearch isn't dramatically overloaded.