### PR TITLE
improve cloudflare sdk interface for logging

### DIFF
--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -152,26 +152,42 @@ func GetAttributesMap(ctx context.Context, resourceAttributes, spanAttributes, e
 				continue
 			}
 
-			if vStr, ok := v.(string); ok {
-				if len(vStr) > LogAttributeValueLengthLimit {
-					log.WithContext(ctx).
-						WithField("AttributeMapIdx", mIdx).
-						WithField("Key", k).
-						WithField("ValueLength", len(vStr)).
-						Warnf("attribute value for %s is too long %d", k, len(vStr))
-					vStr = vStr[:LogAttributeValueLengthLimit] + "..."
-				}
-				attributesMap[k] = vStr
-			}
-			if vInt, ok := v.(int64); ok {
-				attributesMap[k] = strconv.FormatInt(vInt, 10)
-			}
-			if vFlt, ok := v.(float64); ok {
-				attributesMap[k] = strconv.FormatFloat(vFlt, 'f', -1, 64)
+			for key, value := range format(ctx, mIdx, k, v) {
+				attributesMap[key] = value
 			}
 		}
 	}
 	return attributesMap
+}
+
+func format(ctx context.Context, attrMapIdx int, k string, v interface{}) map[string]string {
+	if vStr, ok := v.(string); ok {
+		if len(vStr) > LogAttributeValueLengthLimit {
+			log.WithContext(ctx).
+				WithField("AttributeMapIdx", attrMapIdx).
+				WithField("Key", k).
+				WithField("ValueLength", len(vStr)).
+				Warnf("attribute value for %s is too long %d", k, len(vStr))
+			vStr = vStr[:LogAttributeValueLengthLimit] + "..."
+		}
+		return map[string]string{k: vStr}
+	}
+	if vInt, ok := v.(int64); ok {
+		return map[string]string{k: strconv.FormatInt(vInt, 10)}
+	}
+	if vFlt, ok := v.(float64); ok {
+		return map[string]string{k: strconv.FormatFloat(vFlt, 'f', -1, 64)}
+	}
+	if vMap, ok := v.(map[string]interface{}); ok {
+		m := make(map[string]string)
+		for mapKey, mapV := range vMap {
+			for k2, v2 := range format(ctx, attrMapIdx, mapKey, mapV) {
+				m[fmt.Sprintf("%s.%s", k, k2)] = v2
+			}
+		}
+		return m
+	}
+	return nil
 }
 
 func makeLogLevel(severityText string) modelInputs.LogLevel {

--- a/docs-content/getting-started/backend-logging/2_js/1_overview.md
+++ b/docs-content/getting-started/backend-logging/2_js/1_overview.md
@@ -17,4 +17,10 @@ If you don't see one of your languages / frameworks below, reach out to us in ou
     <DocsCard title="NodeJS" href="./nodejs.md">
         {"Integrate logging in NodeJS."}
     </DocsCard>
+    <DocsCard title="Winston" href="./winston.md">
+        {"Integrate logging in Winston.js."}
+    </DocsCard>
+    <DocsCard title="Cloudflare" href="./cloudflare.md">
+        {"Integrate logging in Cloudflare Workers."}
+    </DocsCard>
 </DocsCardGroup>

--- a/docs-content/getting-started/backend-logging/2_js/cloudflare.md
+++ b/docs-content/getting-started/backend-logging/2_js/cloudflare.md
@@ -1,0 +1,8 @@
+---
+title: Cloudflare Workers
+heading: Logging in Cloudflare Workers
+slug: cloudflare
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["backend-logging"]["js"]["cloudflare"]}/>

--- a/e2e/cloudflare-worker/package.json
+++ b/e2e/cloudflare-worker/package.json
@@ -9,7 +9,8 @@
 	"private": true,
 	"scripts": {
 		"start": "wrangler dev",
-		"deploy": "wrangler deploy"
+		"deploy": "wrangler deploy",
+		"typegen": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@highlight-run/cloudflare": "workspace:*"

--- a/e2e/cloudflare-worker/package.json
+++ b/e2e/cloudflare-worker/package.json
@@ -4,12 +4,12 @@
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230115.0",
 		"typescript": "^4.9.5",
-		"wrangler": "2.9.1"
+		"wrangler": "^3.0.1"
 	},
 	"private": true,
 	"scripts": {
-		"start": "wrangler dev -l",
-		"deploy": "wrangler publish"
+		"start": "wrangler dev",
+		"deploy": "wrangler deploy"
 	},
 	"dependencies": {
 		"@highlight-run/cloudflare": "workspace:*"

--- a/e2e/cloudflare-worker/src/index.ts
+++ b/e2e/cloudflare-worker/src/index.ts
@@ -14,14 +14,16 @@ async function doRequest() {
 	 * @param {Response} response
 	 */
 	async function gatherResponse(response: any) {
+		H.setAttributes({ foo: 'bar', random: Math.random() })
 		console.log('yo! gathering a cloudflare worker response', {
-			random: Math.random(),
+			another: Math.random(),
+			bar: 'bar',
 		})
 		console.warn('warning! gathering a cloudflare worker response', {
-			random: Math.random(),
+			bar: 'warning',
 		})
 		console.warn('error! gathering a cloudflare worker response', {
-			random: Math.random(),
+			another: Math.random(),
 		})
 		if (Math.random() < 0.2) {
 			throw new Error('random error from cloudflare worker!')

--- a/e2e/cloudflare-worker/src/index.ts
+++ b/e2e/cloudflare-worker/src/index.ts
@@ -14,6 +14,15 @@ async function doRequest() {
 	 * @param {Response} response
 	 */
 	async function gatherResponse(response: any) {
+		console.log('yo! gathering a cloudflare worker response', {
+			random: Math.random(),
+		})
+		console.warn('warning! gathering a cloudflare worker response', {
+			random: Math.random(),
+		})
+		console.warn('error! gathering a cloudflare worker response', {
+			random: Math.random(),
+		})
 		if (Math.random() < 0.2) {
 			throw new Error('random error from cloudflare worker!')
 		}
@@ -43,13 +52,13 @@ async function doRequest() {
 
 export default {
 	async fetch(request: Request, env: {}, ctx: ExecutionContext) {
-		const hEnv = { HIGHLIGHT_PROJECT_ID: '1' }
+		H.init(request, { HIGHLIGHT_PROJECT_ID: '1' }, ctx)
 		try {
 			const response = await doRequest()
-			H.sendResponse(request, hEnv, ctx, response)
+			H.sendResponse(response)
 			return response
 		} catch (e: any) {
-			H.consumeError(request, hEnv, ctx, e)
+			H.consumeError(e)
 			throw e
 		}
 	},

--- a/e2e/cloudflare-worker/tsconfig.json
+++ b/e2e/cloudflare-worker/tsconfig.json
@@ -8,10 +8,9 @@
 		"noEmit": true,
 		"resolveJsonModule": true,
 		"sourceMap": true,
-		/* required due to our sdk's dependence on opentelemetry-sdk-workers
-		   which hacks around the dependence on @opentelemetry by dynamically replacing
-		   javascript, but does not replace the '@types/node' dependency
-		*/
+		/* required due to our sdk's usage of 'opentelemetry-sdk-workers'
+		   which works around node syntax in its dependencies by dynamically replacing
+		   the imported javascript bundle, but does not replace the '@types/node' dependency */
 		"skipLibCheck": true,
 		"strict": true,
 		"target": "es2022",

--- a/e2e/cloudflare-worker/tsconfig.json
+++ b/e2e/cloudflare-worker/tsconfig.json
@@ -8,9 +8,14 @@
 		"noEmit": true,
 		"resolveJsonModule": true,
 		"sourceMap": true,
+		/* required due to our sdk's dependence on opentelemetry-sdk-workers
+		   which hacks around the dependence on @opentelemetry by dynamically replacing
+		   javascript, but does not replace the '@types/node' dependency
+		*/
+		"skipLibCheck": true,
 		"strict": true,
 		"target": "es2022",
-		"types": ["@cloudflare/workers-types", "@highlight-run/cloudflare"],
+		"types": ["@cloudflare/workers-types", "@highlight-run/cloudflare"]
 	},
 	"include": ["src", "../common"]
 }

--- a/e2e/cloudflare-worker/tsconfig.json
+++ b/e2e/cloudflare-worker/tsconfig.json
@@ -1,29 +1,16 @@
 {
 	"compilerOptions": {
-		"target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-		"lib": [
-			"es2021"
-		] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-		"jsx": "react" /* Specify what JSX code is generated. */,
-		"module": "es2022" /* Specify what module code is generated. */,
-		"moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
-		"types": [
-			"@cloudflare/workers-types",
-			"@highlight-run/cloudflare"
-		] /* Specify type package names to be included without being referenced in a source file. */,
-		"resolveJsonModule": true /* Enable importing .json files */,
-		"allowJs": true /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */,
-		"checkJs": false /* Enable error reporting in type-checked JavaScript files. */,
-		"noEmit": true /* Disable emitting files from a compilation. */,
-		"isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
-		"allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
-		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-		"strict": true /* Enable all strict type-checking options. */,
-		"skipLibCheck": true /* Skip type checking all .d.ts files. */
+		"allowSyntheticDefaultImports": true,
+		"baseUrl": ".",
+		"lib": ["es2022"],
+		"module": "ESNext",
+		"moduleResolution": "Node",
+		"noEmit": true,
+		"resolveJsonModule": true,
+		"sourceMap": true,
+		"strict": true,
+		"target": "es2022",
+		"types": ["@cloudflare/workers-types", "@highlight-run/cloudflare"],
 	},
-	"references": [
-		{
-			"path": "../../sdk/highlight-cloudflare"
-		}
-	]
+	"include": ["src", "../common"]
 }

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -40,6 +40,7 @@ import { RubyOtherLogContent } from './logging/ruby/other'
 import { RubyRailsLogContent } from './logging/ruby/rails'
 import { DevDeploymentContent } from './self-host/dev-deploy'
 import { SelfHostContent } from './self-host/self-host'
+import { JSCloudflareLoggingContent } from './logging/js/cloudflare'
 
 export type QuickStartOptions = {
 	title: string
@@ -201,6 +202,7 @@ export const quickStartContent = {
 			[QuickStartType.JSNodejs]: JSOtherLogContent,
 			[QuickStartType.JSNestjs]: JSNestLogContent,
 			[QuickStartType.JSWinston]: JSWinstonHTTPJSONLogContent,
+			[QuickStartType.JSCloudflare]: JSCloudflareLoggingContent,
 		},
 		http: {
 			title: 'curl',

--- a/highlight.io/components/QuickstartContent/backend/js/cloudflare.tsx
+++ b/highlight.io/components/QuickstartContent/backend/js/cloudflare.tsx
@@ -7,6 +7,7 @@ import {
 	setupLogging,
 	verifyError,
 } from './shared-snippets'
+import { tsconfig } from '../../shared-snippets'
 
 export const JSCloudflareContent: QuickStartContent = {
 	title: 'Cloudflare Workers',
@@ -55,6 +56,7 @@ export default {
   },
 }`,
 		),
+		tsconfig,
 		setupLogging('cloudflare'),
 	],
 }

--- a/highlight.io/components/QuickstartContent/backend/js/cloudflare.tsx
+++ b/highlight.io/components/QuickstartContent/backend/js/cloudflare.tsx
@@ -31,13 +31,14 @@ async function doRequest() {
 
 export default {
   async fetch(request: Request, env: {}, ctx: ExecutionContext) {
-    const hEnv = { HIGHLIGHT_PROJECT_ID: '<YOUR_PROJECT_ID>' }
+    H.init(request, { HIGHLIGHT_PROJECT_ID: '<YOUR_PROJECT_ID>' }, ctx)
+    console.log('starting some work...')
     try {
       const response = await doRequest()
-      H.sendResponse(request, hEnv, ctx, response)
+      H.sendResponse(response)
       return response
     } catch (e: any) {
-      H.consumeError(request, hEnv, ctx, e)
+      H.consumeError(e)
       throw e
     }
   },
@@ -49,7 +50,8 @@ export default {
 			'cloudflare',
 			`export default {
   async fetch(request: Request, env: {}, ctx: ExecutionContext) {
-    H.consumeError(request, { HIGHLIGHT_PROJECT_ID: '<YOUR_PROJECT_ID>' }, ctx, new Error('example error!'))
+    H.init(request, { HIGHLIGHT_PROJECT_ID: '<YOUR_PROJECT_ID>' }, ctx)
+    H.consumeError(new Error('example error!'))
   },
 }`,
 		),

--- a/highlight.io/components/QuickstartContent/logging/js/cloudflare.tsx
+++ b/highlight.io/components/QuickstartContent/logging/js/cloudflare.tsx
@@ -1,0 +1,32 @@
+import { siteUrl } from '../../../../utils/urls'
+import { QuickStartContent } from '../../QuickstartContent'
+import { previousInstallSnippet, verifyLogs } from '../shared-snippets'
+
+export const JSCloudflareLoggingContent: QuickStartContent = {
+	title: 'Cloudflare Workers',
+	subtitle:
+		'Learn how to set up highlight.io log ingestion in Cloudflare Workers.',
+	logoUrl: siteUrl('/images/quickstart/cloudflare.svg'),
+	entries: [
+		previousInstallSnippet('cloudflare'),
+		{
+			title: `Add the Cloudflare Worker Highlight integration.`,
+			content:
+				'All you need to start recording your console methods is call `H.init`. ' +
+				'All Highlight data submission uses [waitUntil](https://developers.cloudflare.com/workers/runtime-apis/fetch-event/#waituntil) to make sure that we have no impact on request handling performance.',
+			code: {
+				text: `import { H } from '@highlight-run/cloudflare'
+
+export default {
+  async fetch(request: Request, env: {}, ctx: ExecutionContext) {
+    H.init(request, { HIGHLIGHT_PROJECT_ID: '<YOUR_PROJECT_ID>' }, ctx)
+    console.log('starting some work...')
+    // ...
+  },
+}`,
+				language: `js`,
+			},
+		},
+		verifyLogs,
+	],
+}

--- a/highlight.io/components/QuickstartContent/logging/js/cloudflare.tsx
+++ b/highlight.io/components/QuickstartContent/logging/js/cloudflare.tsx
@@ -1,6 +1,7 @@
 import { siteUrl } from '../../../../utils/urls'
 import { QuickStartContent } from '../../QuickstartContent'
 import { previousInstallSnippet, verifyLogs } from '../shared-snippets'
+import { tsconfig } from '../../shared-snippets'
 
 export const JSCloudflareLoggingContent: QuickStartContent = {
 	title: 'Cloudflare Workers',
@@ -27,6 +28,7 @@ export default {
 				language: `js`,
 			},
 		},
+		tsconfig,
 		verifyLogs,
 	],
 }

--- a/highlight.io/components/QuickstartContent/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/shared-snippets.tsx
@@ -1,0 +1,20 @@
+export const tsconfig = {
+	title: 'Having TypeScript issues?',
+	content:
+		'Using our library requires setting skipLibCheck because of one of our dependencies that references node types. ' +
+		'At runtime, this does not cause issues because of dynamic imports and other polyfilling done to ensure the sdk works in the cloud flare worker runtime, but the types are still referenced.\n',
+	code: {
+		text: `{
+  /* ... your other options ... */
+  "compilerOptions": {
+    /* required due to our sdk's usage of 'opentelemetry-sdk-workers'
+       which works around node syntax in its dependencies by dynamically replacing
+       the imported javascript bundle, but does not replace the '@types/node' dependency */
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+}
+`,
+		language: `json`,
+	},
+}

--- a/sdk/highlight-cloudflare/package.json
+++ b/sdk/highlight-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/cloudflare",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"packageManager": "yarn@3.2.3",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -13,6 +13,7 @@
 		"access": "public"
 	},
 	"dependencies": {
+		"diary": "^0.4.4",
 		"opentelemetry-sdk-workers": "^0.6.2"
 	},
 	"devDependencies": {

--- a/sdk/highlight-cloudflare/package.json
+++ b/sdk/highlight-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/cloudflare",
-	"version": "2.0.0",
+	"version": "2.0.2",
 	"packageManager": "yarn@3.2.3",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -16,8 +16,6 @@
 		"opentelemetry-sdk-workers": "^0.6.2"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20230518.0",
-		"@opentelemetry/core": "^1.13.0",
 		"tsup": "^6.7.0"
 	}
 }

--- a/sdk/highlight-cloudflare/package.json
+++ b/sdk/highlight-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/cloudflare",
-	"version": "1.0.2",
+	"version": "2.0.0",
 	"packageManager": "yarn@3.2.3",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -16,8 +16,8 @@
 		"opentelemetry-sdk-workers": "^0.6.2"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20230115.0",
-		"@opentelemetry/core": "^1.12.0",
-		"tsup": "^6.6.2"
+		"@cloudflare/workers-types": "^4.20230518.0",
+		"@opentelemetry/core": "^1.13.0",
+		"tsup": "^6.7.0"
 	}
 }

--- a/sdk/highlight-cloudflare/package.json
+++ b/sdk/highlight-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/cloudflare",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"packageManager": "yarn@3.2.3",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -16,6 +16,7 @@
 		"opentelemetry-sdk-workers": "^0.6.2"
 	},
 	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20230518.0",
 		"tsup": "^6.7.0"
 	}
 }

--- a/sdk/highlight-cloudflare/package.json
+++ b/sdk/highlight-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/cloudflare",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"packageManager": "yarn@3.2.3",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-cloudflare/src/sdk.ts
+++ b/sdk/highlight-cloudflare/src/sdk.ts
@@ -92,6 +92,8 @@ export const H: HighlightInterface = {
 	// Setting a key previously set will update the value.
 	setAttributes: (attributes: ResourceAttributes) => {
 		// @ts-ignore
-		sdk.traceProvider.resource.merge(new Resource(attributes))
+		sdk.traceProvider.resource = sdk.traceProvider.resource.merge(
+			new Resource(attributes),
+		)
 	},
 }

--- a/sdk/highlight-cloudflare/src/sdk.ts
+++ b/sdk/highlight-cloudflare/src/sdk.ts
@@ -37,6 +37,7 @@ export interface HighlightInterface {
 let sdk: WorkersSDK
 
 export const H: HighlightInterface = {
+	// Initialize the highlight SDK. This monkeypatches the console methods to start sending console logs to highlight.
 	init: (
 		request: Request,
 		{ [HIGHLIGHT_PROJECT_ENV]: projectID }: HighlightEnv,
@@ -68,6 +69,7 @@ export const H: HighlightInterface = {
 		return sdk
 	},
 
+	// Capture a javascript exception as an error in highlight.
 	consumeError: (error: Error) => {
 		if (!sdk) {
 			console.error(
@@ -78,6 +80,7 @@ export const H: HighlightInterface = {
 		sdk.captureException(error)
 	},
 
+	// Capture a cloudflare response as a trace in highlight.
 	sendResponse: (response: Response) => {
 		if (!sdk) {
 			console.error(
@@ -91,6 +94,12 @@ export const H: HighlightInterface = {
 	// Set custom attributes on the errors and logs reported to highlight.
 	// Setting a key previously set will update the value.
 	setAttributes: (attributes: ResourceAttributes) => {
+		if (!sdk) {
+			console.error(
+				'please call H.init(...) before calling H.setAttributes(...)',
+			)
+			return
+		}
 		// @ts-ignore
 		sdk.traceProvider.resource = sdk.traceProvider.resource.merge(
 			new Resource(attributes),

--- a/sdk/highlight-cloudflare/src/sdk.ts
+++ b/sdk/highlight-cloudflare/src/sdk.ts
@@ -5,6 +5,7 @@ import { WorkersSDK } from 'opentelemetry-sdk-workers'
 import { Resource } from '@opentelemetry/resources'
 import { OTLPProtoTraceExporter } from 'opentelemetry-sdk-workers/exporters/OTLPProtoTraceExporter'
 import { OTLPProtoLogExporter } from 'opentelemetry-sdk-workers/exporters/OTLPProtoLogExporter'
+import type { ResourceAttributes } from '@opentelemetry/resources/build/src/types'
 
 const HIGHLIGHT_PROJECT_ENV = 'HIGHLIGHT_PROJECT_ID'
 const HIGHLIGHT_REQUEST_HEADER = 'X-Highlight-Request'
@@ -15,7 +16,6 @@ export const RECORDED_CONSOLE_METHODS = [
 	'error',
 	'info',
 	'log',
-	'trace',
 	'warn',
 ] as const
 
@@ -31,6 +31,7 @@ export interface HighlightInterface {
 	) => WorkersSDK
 	consumeError: (error: Error) => void
 	sendResponse: (response: Response) => void
+	setAttributes: (attributes: ResourceAttributes) => void
 }
 
 let sdk: WorkersSDK
@@ -85,5 +86,12 @@ export const H: HighlightInterface = {
 			return
 		}
 		sdk.sendResponse(response)
+	},
+
+	// Set custom attributes on the errors and logs reported to highlight.
+	// Setting a key previously set will update the value.
+	setAttributes: (attributes: ResourceAttributes) => {
+		// @ts-ignore
+		sdk.traceProvider.resource.merge(new Resource(attributes))
 	},
 }

--- a/sdk/highlight-cloudflare/tsconfig.json
+++ b/sdk/highlight-cloudflare/tsconfig.json
@@ -1,19 +1,16 @@
 {
 	"compilerOptions": {
-		"types": ["@cloudflare/workers-types"],
-		"target": "ES6",
-		"skipLibCheck": true,
 		"allowSyntheticDefaultImports": true,
-		"strict": true,
-		"forceConsistentCasingInFileNames": true,
-		"module": "ES6",
-		"outDir": "dist",
-		"removeComments": true,
-		"declaration": true,
-		"declarationDir": "dist",
-		"moduleResolution": "node",
+		"baseUrl": ".",
+		"lib": ["es2022"],
+		"module": "ESNext",
+		"moduleResolution": "Node",
+		"noEmit": true,
 		"resolveJsonModule": true,
-		"jsx": "react"
+		"sourceMap": true,
+		"strict": true,
+		"target": "es2022",
+		"types": ["@cloudflare/workers-types"]
 	},
 	"include": ["src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11002,6 +11002,7 @@ __metadata:
   resolution: "@highlight-run/cloudflare@workspace:sdk/highlight-cloudflare"
   dependencies:
     "@cloudflare/workers-types": ^4.20230518.0
+    diary: ^0.4.4
     opentelemetry-sdk-workers: ^0.6.2
     tsup: ^6.7.0
   languageName: unknown
@@ -27744,6 +27745,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diary@npm:^0.4.4":
+  version: 0.4.4
+  resolution: "diary@npm:0.4.4"
+  checksum: 906a276d05fae33e7d8330b26846448d09ce5d8d7457e8a559e938d8267788bb667718bbcd74b184b4203602d0acebf1259c229fbfb639b7f4226285deca824a
+  languageName: node
+  linkType: hard
+
 "didyoumean@npm:^1.2.2":
   version: 1.2.2
   resolution: "didyoumean@npm:1.2.2"
@@ -40256,7 +40264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.1, nanoid@npm:^3.3.3, nanoid@npm:^3.3.4":
+"nanoid@npm:^3.3.1, nanoid@npm:^3.3.4":
   version: 3.3.4
   resolution: "nanoid@npm:3.3.4"
   bin:
@@ -40265,7 +40273,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.6":
+"nanoid@npm:^3.3.3, nanoid@npm:^3.3.6":
   version: 3.3.6
   resolution: "nanoid@npm:3.3.6"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7627,6 +7627,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/workers-types@npm:^4.20230518.0":
+  version: 4.20230518.0
+  resolution: "@cloudflare/workers-types@npm:4.20230518.0"
+  checksum: 69c861437f1064b860b2a52129ed973f670090a8d2de9f4b205f86f8a2f40caec48b8c7614533c6531875d1fa254fc7d9da3ab52d7a6fff46be0f64079b394dc
+  languageName: node
+  linkType: hard
+
 "@cnakazawa/watch@npm:^1.0.3":
   version: 1.0.4
   resolution: "@cnakazawa/watch@npm:1.0.4"
@@ -10994,6 +11001,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@highlight-run/cloudflare@workspace:sdk/highlight-cloudflare"
   dependencies:
+    "@cloudflare/workers-types": ^4.20230518.0
     opentelemetry-sdk-workers: ^0.6.2
     tsup: ^6.7.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -7592,6 +7592,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/workers-types@npm:^4.20230518.0":
+  version: 4.20230518.0
+  resolution: "@cloudflare/workers-types@npm:4.20230518.0"
+  checksum: 69c861437f1064b860b2a52129ed973f670090a8d2de9f4b205f86f8a2f40caec48b8c7614533c6531875d1fa254fc7d9da3ab52d7a6fff46be0f64079b394dc
+  languageName: node
+  linkType: hard
+
 "@cnakazawa/watch@npm:^1.0.3":
   version: 1.0.4
   resolution: "@cnakazawa/watch@npm:1.0.4"
@@ -10959,10 +10966,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@highlight-run/cloudflare@workspace:sdk/highlight-cloudflare"
   dependencies:
-    "@cloudflare/workers-types": ^4.20230115.0
-    "@opentelemetry/core": ^1.12.0
+    "@cloudflare/workers-types": ^4.20230518.0
+    "@opentelemetry/core": ^1.13.0
     opentelemetry-sdk-workers: ^0.6.2
-    tsup: ^6.6.2
+    tsup: ^6.7.0
   languageName: unknown
   linkType: soft
 
@@ -13527,7 +13534,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/core@npm:1.12.0, @opentelemetry/core@npm:^1.12.0, @opentelemetry/core@npm:^1.8.0":
+"@opentelemetry/core@npm:1.12.0, @opentelemetry/core@npm:^1.8.0":
   version: 1.12.0
   resolution: "@opentelemetry/core@npm:1.12.0"
   dependencies:
@@ -13538,7 +13545,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/core@npm:1.13.0":
+"@opentelemetry/core@npm:1.13.0, @opentelemetry/core@npm:^1.13.0":
   version: 1.13.0
   resolution: "@opentelemetry/core@npm:1.13.0"
   dependencies:
@@ -51458,7 +51465,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsup@npm:^6.6.2, tsup@npm:^6.6.3":
+"tsup@npm:^6.6.3":
   version: 6.6.3
   resolution: "tsup@npm:6.6.3"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7585,17 +7585,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/workerd-darwin-64@npm:1.20230518.0":
+  version: 1.20230518.0
+  resolution: "@cloudflare/workerd-darwin-64@npm:1.20230518.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-darwin-arm64@npm:1.20230518.0":
+  version: 1.20230518.0
+  resolution: "@cloudflare/workerd-darwin-arm64@npm:1.20230518.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-linux-64@npm:1.20230518.0":
+  version: 1.20230518.0
+  resolution: "@cloudflare/workerd-linux-64@npm:1.20230518.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-linux-arm64@npm:1.20230518.0":
+  version: 1.20230518.0
+  resolution: "@cloudflare/workerd-linux-arm64@npm:1.20230518.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@cloudflare/workerd-windows-64@npm:1.20230518.0":
+  version: 1.20230518.0
+  resolution: "@cloudflare/workerd-windows-64@npm:1.20230518.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@cloudflare/workers-types@npm:^4.20230115.0":
   version: 4.20230214.0
   resolution: "@cloudflare/workers-types@npm:4.20230214.0"
   checksum: f0889b56cc0a28903b1e494f3f12ca578e3634acbb31a8192fd618ae545c91f420f7271424e220c6d94281ebb3ee6a4dcf221e921fa1536890c527c90d76bfbd
-  languageName: node
-  linkType: hard
-
-"@cloudflare/workers-types@npm:^4.20230518.0":
-  version: 4.20230518.0
-  resolution: "@cloudflare/workers-types@npm:4.20230518.0"
-  checksum: 69c861437f1064b860b2a52129ed973f670090a8d2de9f4b205f86f8a2f40caec48b8c7614533c6531875d1fa254fc7d9da3ab52d7a6fff46be0f64079b394dc
   languageName: node
   linkType: hard
 
@@ -10966,8 +10994,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@highlight-run/cloudflare@workspace:sdk/highlight-cloudflare"
   dependencies:
-    "@cloudflare/workers-types": ^4.20230518.0
-    "@opentelemetry/core": ^1.13.0
     opentelemetry-sdk-workers: ^0.6.2
     tsup: ^6.7.0
   languageName: unknown
@@ -12600,207 +12626,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@miniflare/cache@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/cache@npm:2.11.0"
-  dependencies:
-    "@miniflare/core": 2.11.0
-    "@miniflare/shared": 2.11.0
-    http-cache-semantics: ^4.1.0
-    undici: 5.9.1
-  checksum: 9c7562193798bee4e52f2530e592b7e1636d61489bc558c2ac0b0a0f415a3eee982aeb2c15bf87dc3ccfa4b74fbcc4d4eff9147c7c32c3d63a8f51acb39fc9f7
-  languageName: node
-  linkType: hard
-
-"@miniflare/cli-parser@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/cli-parser@npm:2.11.0"
-  dependencies:
-    "@miniflare/shared": 2.11.0
-    kleur: ^4.1.4
-  checksum: e6c27c51bc25eebc3dc28115d46a052c7b36088883ea5dbbac4cef9af6ebf2b60554dee01b4192923468b169a822fb3308fb42145ca574c89c16bd65e6ebe9ff
-  languageName: node
-  linkType: hard
-
-"@miniflare/core@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/core@npm:2.11.0"
-  dependencies:
-    "@iarna/toml": ^2.2.5
-    "@miniflare/queues": 2.11.0
-    "@miniflare/shared": 2.11.0
-    "@miniflare/watcher": 2.11.0
-    busboy: ^1.6.0
-    dotenv: ^10.0.0
-    kleur: ^4.1.4
-    set-cookie-parser: ^2.4.8
-    undici: 5.9.1
-    urlpattern-polyfill: ^4.0.3
-  checksum: 9d20dca2b34b8147c802009eaa03e8129f0c7c936777f281dae55c7fe1009297650daec22109aa9f7ed95dc75d2e85f5f8ff37239f8522e32d4bd17ebcd03bd2
-  languageName: node
-  linkType: hard
-
-"@miniflare/d1@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/d1@npm:2.11.0"
-  dependencies:
-    "@miniflare/core": 2.11.0
-    "@miniflare/shared": 2.11.0
-  checksum: d5d06150cb01374dd7edfcfea21c53862aff2a6b712574cc1e8fbc9809b55eeffc2e83565e556f96ba802505488471cd88ed89a8f0e6a358b25b9c5fd128e608
-  languageName: node
-  linkType: hard
-
-"@miniflare/durable-objects@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/durable-objects@npm:2.11.0"
-  dependencies:
-    "@miniflare/core": 2.11.0
-    "@miniflare/shared": 2.11.0
-    "@miniflare/storage-memory": 2.11.0
-    undici: 5.9.1
-  checksum: 1ba8c659f25bf1443aeada6a86bf8779818381e682a8d13565751b7d1a864043f2a7f0ee13b2993752606d7a18b2c123a8fc49db7c581b2fd4669e180a1e29bf
-  languageName: node
-  linkType: hard
-
-"@miniflare/html-rewriter@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/html-rewriter@npm:2.11.0"
-  dependencies:
-    "@miniflare/core": 2.11.0
-    "@miniflare/shared": 2.11.0
-    html-rewriter-wasm: ^0.4.1
-    undici: 5.9.1
-  checksum: fa4b85745fa5b20609d402bab506c0d57cd654da5b325a8e4011dc88f4f3b4c44563a951ce7c23348c9aca5efc9421cf9eaa6ba6aeedd59bf9ccfc575bc6e757
-  languageName: node
-  linkType: hard
-
-"@miniflare/http-server@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/http-server@npm:2.11.0"
-  dependencies:
-    "@miniflare/core": 2.11.0
-    "@miniflare/shared": 2.11.0
-    "@miniflare/web-sockets": 2.11.0
-    kleur: ^4.1.4
-    selfsigned: ^2.0.0
-    undici: 5.9.1
-    ws: ^8.2.2
-    youch: ^2.2.2
-  checksum: 997d7376c539a34535946478acf940f8b8712a0f02a4ae941e45930119773921dcb35527a134030e9271b389fb03bd9a4263dc19c5ba01993194e3689816724d
-  languageName: node
-  linkType: hard
-
-"@miniflare/kv@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/kv@npm:2.11.0"
-  dependencies:
-    "@miniflare/shared": 2.11.0
-  checksum: eefb5bde1f3af9c9d234ab8f5975822f1a98547aac9d29691726eaa070e56e8c76216d1af85a8985934d2759890db1dd5df70e595ddaf2b739cc06ac28e732c8
-  languageName: node
-  linkType: hard
-
-"@miniflare/queues@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/queues@npm:2.11.0"
-  dependencies:
-    "@miniflare/shared": 2.11.0
-  checksum: 204c9e5046560f33b5516d53c76b8d8c2d0268b7e5978a4dd4518a585b1a3613dc2ab2cc6765c6dc2656cd7c9c4ffefcd49a367dc8a83492bfcee311d0ead96e
-  languageName: node
-  linkType: hard
-
-"@miniflare/r2@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/r2@npm:2.11.0"
-  dependencies:
-    "@miniflare/shared": 2.11.0
-    undici: 5.9.1
-  checksum: ef09a28e967aac844c56c33eb7d1183da45809f39cbfe93b0d185f2831d75ee63c9c317398e723e092d76a97ee684ed104cbb3d4c0f484cb2e616005d8ed3c20
-  languageName: node
-  linkType: hard
-
-"@miniflare/runner-vm@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/runner-vm@npm:2.11.0"
-  dependencies:
-    "@miniflare/shared": 2.11.0
-  checksum: a532d75a85e0bda840043f35f43f78a3b100c81bb1a50583cf26e772fe4b17ecac8801fc99bda897b2d5b171f1d7eb4b620248a261438b3e5d5930a7fac624cb
-  languageName: node
-  linkType: hard
-
-"@miniflare/scheduler@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/scheduler@npm:2.11.0"
-  dependencies:
-    "@miniflare/core": 2.11.0
-    "@miniflare/shared": 2.11.0
-    cron-schedule: ^3.0.4
-  checksum: 099b8387f4c8984f91451292c5c52250d6ca8f3371a17f6c8ebaeda5f898336483fe1e9c11152ac1cc09e76ed801df33432676438a3c8bd93e35052583a888de
-  languageName: node
-  linkType: hard
-
-"@miniflare/shared@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/shared@npm:2.11.0"
-  dependencies:
-    "@types/better-sqlite3": ^7.6.0
-    kleur: ^4.1.4
-    npx-import: ^1.1.3
-    picomatch: ^2.3.1
-  checksum: f0df1b7817e388c7171b7fc12911bfb5c0fb2e608be11bce906db67fe0463de7a6681845cd9a17051fc005a531fb357ff4cd9198da2a9391d027b453bb82fe6a
-  languageName: node
-  linkType: hard
-
-"@miniflare/sites@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/sites@npm:2.11.0"
-  dependencies:
-    "@miniflare/kv": 2.11.0
-    "@miniflare/shared": 2.11.0
-    "@miniflare/storage-file": 2.11.0
-  checksum: 1074cedfa21df727c744eb022b325f02a61c0e8d89b40c10619f6be27c9b49091db0298d54b16e728a40569a82e4bac160c77a0de47bdba7202b7d1e36fa1fb3
-  languageName: node
-  linkType: hard
-
-"@miniflare/storage-file@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/storage-file@npm:2.11.0"
-  dependencies:
-    "@miniflare/shared": 2.11.0
-    "@miniflare/storage-memory": 2.11.0
-  checksum: 8c55458216c6fe28e41171d85fe28b97ca1753a4bf12a2b4d45a2b14d125a506c7c603fe3c00f31eaa7377357f30333c336ffca1af8bedc30061a65f1ca7cd94
-  languageName: node
-  linkType: hard
-
-"@miniflare/storage-memory@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/storage-memory@npm:2.11.0"
-  dependencies:
-    "@miniflare/shared": 2.11.0
-  checksum: c685fc0c504278e70e2acb4dd7778ce454fb6d228a8ed323baf54eedbe3b70d87bb71189b6b230860777d857bf0cc57a998d7c194914509fccb0a5d08fd5ef6e
-  languageName: node
-  linkType: hard
-
-"@miniflare/watcher@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/watcher@npm:2.11.0"
-  dependencies:
-    "@miniflare/shared": 2.11.0
-  checksum: 977b256f791a9abbaca427170aeeb9e1bc4f2ff1e5ae71d8227dfac6b3b00aa6964fda7bd78e9c3e751a8ba9b5ab424f9927163c5b3fb58c0d79ae05454272c2
-  languageName: node
-  linkType: hard
-
-"@miniflare/web-sockets@npm:2.11.0":
-  version: 2.11.0
-  resolution: "@miniflare/web-sockets@npm:2.11.0"
-  dependencies:
-    "@miniflare/core": 2.11.0
-    "@miniflare/shared": 2.11.0
-    undici: 5.9.1
-    ws: ^8.2.2
-  checksum: 3bca225d4afea726b182ff35b78a7ca43c0c0f11157cb62e274615c033796fe4f9eca21a145e54df4a3471079d33e5c195e7b3f8a2c723df73b55b202bd67cbb
-  languageName: node
-  linkType: hard
-
 "@motionone/animation@npm:^10.12.0":
   version: 10.14.0
   resolution: "@motionone/animation@npm:10.14.0"
@@ -13545,7 +13370,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/core@npm:1.13.0, @opentelemetry/core@npm:^1.13.0":
+"@opentelemetry/core@npm:1.13.0":
   version: 1.13.0
   resolution: "@opentelemetry/core@npm:1.13.0"
   dependencies:
@@ -19499,15 +19324,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/better-sqlite3@npm:^7.6.0":
-  version: 7.6.3
-  resolution: "@types/better-sqlite3@npm:7.6.3"
-  dependencies:
-    "@types/node": "*"
-  checksum: 37ffd2507beb55f284261fc72b2f0b5585aecd65ffaffbc1f48a4d59958c3bcc16e54b83d9fd6af5f6a0edab830e384aef7ed79dbbfc3d443f850cb1eab091f5
-  languageName: node
-  linkType: hard
-
 "@types/body-parser@npm:*":
   version: 1.19.2
   resolution: "@types/body-parser@npm:1.19.2"
@@ -21005,13 +20821,6 @@ __metadata:
   version: 0.1.2
   resolution: "@types/source-list-map@npm:0.1.2"
   checksum: fda8f37537aca9d3ed860d559289ab1dddb6897e642e6f53e909bbd18a7ac3129a8faa2a7d093847c91346cf09c86ef36e350c715406fba1f2271759b449adf6
-  languageName: node
-  linkType: hard
-
-"@types/stack-trace@npm:0.0.29":
-  version: 0.0.29
-  resolution: "@types/stack-trace@npm:0.0.29"
-  checksum: 2dcfdf8f10e250a76e43efe6d3e05a463b4e22ca290dbb423ec14fa21f57f94ef0cc8ba19ed3394c448218d9ddd9f7cd9adea131fb6572aa2d484b1cf7f043aa
   languageName: node
   linkType: hard
 
@@ -23435,6 +23244,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"as-table@npm:^1.0.36":
+  version: 1.0.55
+  resolution: "as-table@npm:1.0.55"
+  dependencies:
+    printable-characters: ^1.0.42
+  checksum: 341c99d9e99a702c315b3f0744d49b4764b26ef7ddd32bafb9e1706626560c0e599100521fc1b17f640e804bd0503ce70b2ba519c023da6edf06bdd9086dccd9
+  languageName: node
+  linkType: hard
+
 "asap@npm:~2.0.3, asap@npm:~2.0.6":
   version: 2.0.6
   resolution: "asap@npm:2.0.6"
@@ -24208,6 +24026,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"better-sqlite3@npm:^8.1.0":
+  version: 8.4.0
+  resolution: "better-sqlite3@npm:8.4.0"
+  dependencies:
+    bindings: ^1.5.0
+    node-gyp: latest
+    prebuild-install: ^7.1.0
+  checksum: f8b180c26428a2d381482e83b4519d0d81a918e00f92cafd255f42eb9583f49b2fed1015121ad49ebe1f3f790cc8c6f4697d1e805193d65e70dacf2e8abbd6af
+  languageName: node
+  linkType: hard
+
 "big-integer@npm:^1.6.44, big-integer@npm:^1.6.7":
   version: 1.6.51
   resolution: "big-integer@npm:1.6.51"
@@ -24240,6 +24069,15 @@ __metadata:
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
   checksum: ccd267956c58d2315f5d3ea6757cf09863c5fc703e50fbeb13a7dc849b812ef76e3cf9ca8f35a0c48498776a7478d7b4a0418e1e2b8cb9cb9731f2922aaad7f8
+  languageName: node
+  linkType: hard
+
+"bindings@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "bindings@npm:1.5.0"
+  dependencies:
+    file-uri-to-path: 1.0.0
+  checksum: 65b6b48095717c2e6105a021a7da4ea435aa8d3d3cd085cb9e85bcb6e5773cf318c4745c3f7c504412855940b585bdf9b918236612a1c7a7942491de176f1ae7
   languageName: node
   linkType: hard
 
@@ -24653,15 +24491,6 @@ __metadata:
   version: 3.3.0
   resolution: "builtin-modules@npm:3.3.0"
   checksum: db021755d7ed8be048f25668fe2117620861ef6703ea2c65ed2779c9e3636d5c3b82325bd912244293959ff3ae303afa3471f6a15bf5060c103e4cc3a839749d
-  languageName: node
-  linkType: hard
-
-"builtins@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "builtins@npm:5.0.1"
-  dependencies:
-    semver: ^7.0.0
-  checksum: 66d204657fe36522822a95b288943ad11b58f5eaede235b11d8c4edaa28ce4800087d44a2681524c340494aadb120a0068011acabe99d30e8f11a7d826d83515
   languageName: node
   linkType: hard
 
@@ -25093,6 +24922,16 @@ __metadata:
     tslib: ^2.0.3
     upper-case-first: ^2.0.2
   checksum: 41fa8fa87f6d24d0835a2b4a9341a3eaecb64ac29cd7c5391f35d6175a0fa98ab044e7f2602e1ec3afc886231462ed71b5b80c590b8b41af903ec2c15e5c5931
+  languageName: node
+  linkType: hard
+
+"capnp-ts@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "capnp-ts@npm:0.7.0"
+  dependencies:
+    debug: ^4.3.1
+    tslib: ^2.2.0
+  checksum: 9ab495a887c5d5fd56afa3cc930733cd8c6c0743c52c2e79c46675eb5c7753e5578f71348628a4b3d9f03e5269bc71f811e58af18d0b0557607c4ee56189cfbb
   languageName: node
   linkType: hard
 
@@ -25808,7 +25647,7 @@ __metadata:
     "@cloudflare/workers-types": ^4.20230115.0
     "@highlight-run/cloudflare": "workspace:*"
     typescript: ^4.9.5
-    wrangler: 2.9.1
+    wrangler: ^3.0.1
   languageName: unknown
   linkType: soft
 
@@ -26342,17 +26181,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.5.0":
+"cookie@npm:0.5.0, cookie@npm:^0.5.0":
   version: 0.5.0
   resolution: "cookie@npm:0.5.0"
   checksum: 1f4bd2ca5765f8c9689a7e8954183f5332139eb72b6ff783d8947032ec1fdf43109852c178e21a953a30c0dd42257828185be01b49d1eb1a67fd054ca588a180
-  languageName: node
-  linkType: hard
-
-"cookie@npm:^0.4.1":
-  version: 0.4.2
-  resolution: "cookie@npm:0.4.2"
-  checksum: a00833c998bedf8e787b4c342defe5fa419abd96b32f4464f718b91022586b8f1bafbddd499288e75c037642493c83083da426c6a9080d309e3bd90fd11baa9b
   languageName: node
   linkType: hard
 
@@ -26587,13 +26419,6 @@ __metadata:
   version: 1.1.1
   resolution: "create-require@npm:1.1.1"
   checksum: a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
-  languageName: node
-  linkType: hard
-
-"cron-schedule@npm:^3.0.4":
-  version: 3.0.6
-  resolution: "cron-schedule@npm:3.0.6"
-  checksum: 5f6bee86397f5098602588d7acda799c474452145bf1e767319a54e8827e02224585dd231c9e39fd66ffb308def775bf5581ebb1065b12a8e2c2fe91884d44d8
   languageName: node
   linkType: hard
 
@@ -27311,6 +27136,13 @@ __metadata:
   version: 2.0.0
   resolution: "dashify@npm:2.0.0"
   checksum: f13233f38fc39ea8dabe3a5bef51421906aa8a52e4403fcb56e3e6464428f5c0bdd75562706929a245c698bceccf68a82e30e9e327a0c582469868522a163f8c
+  languageName: node
+  linkType: hard
+
+"data-uri-to-buffer@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "data-uri-to-buffer@npm:2.0.2"
+  checksum: 152bec5e77513ee253a7c686700a1723246f582dad8b614e8eaaaba7fa45a15c8671ae4b8f4843f4f3a002dae1d3e7a20f852f7d7bdc8b4c15cfe7adfdfb07f8
   languageName: node
   linkType: hard
 
@@ -28229,13 +28061,6 @@ __metadata:
   version: 16.0.3
   resolution: "dotenv@npm:16.0.3"
   checksum: afcf03f373d7a6d62c7e9afea6328e62851d627a4e73f2e12d0a8deae1cd375892004f3021883f8aec85932cd2834b091f568ced92b4774625b321db83b827f8
-  languageName: node
-  linkType: hard
-
-"dotenv@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "dotenv@npm:10.0.0"
-  checksum: f412c5fe8c24fbe313d302d2500e247ba8a1946492db405a4de4d30dd0eb186a88a43f13c958c5a7de303938949c4231c56994f97d05c4bc1f22478d631b4005
   languageName: node
   linkType: hard
 
@@ -30550,23 +30375,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "execa@npm:6.1.0"
-  dependencies:
-    cross-spawn: ^7.0.3
-    get-stream: ^6.0.1
-    human-signals: ^3.0.1
-    is-stream: ^3.0.0
-    merge-stream: ^2.0.0
-    npm-run-path: ^5.1.0
-    onetime: ^6.0.0
-    signal-exit: ^3.0.7
-    strip-final-newline: ^3.0.0
-  checksum: 1a4af799839134f5c72eb63d525b87304c1114a63aa71676c91d57ccef2e26f2f53e14c11384ab11c4ec479be1efa83d11c8190e00040355c2c5c3364327fa8e
-  languageName: node
-  linkType: hard
-
 "execall@npm:^2.0.0":
   version: 2.0.0
   resolution: "execall@npm:2.0.0"
@@ -30589,6 +30397,13 @@ __metadata:
   version: 1.2.2
   resolution: "exenv@npm:1.2.2"
   checksum: a894f3b60ab8419e0b6eec99c690a009c8276b4c90655ccaf7d28faba2de3a6b93b3d92210f9dc5efd36058d44f04098f6bbccef99859151104bfd49939904dc
+  languageName: node
+  linkType: hard
+
+"exit-hook@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "exit-hook@npm:2.2.1"
+  checksum: 1aa8359b6c5590a012d6cadf9cd337d227291bfcaa8970dc585d73dffef0582af34ed8ac56f6164f8979979fb417cff1eb49f03cdfd782f9332a30c773f0ada0
   languageName: node
   linkType: hard
 
@@ -31193,6 +31008,13 @@ __metadata:
     fs-extra: ^10.1.0
     ramda: ^0.28.0
   checksum: d60d7aadf2e9d1629c20dd423f9e1fc3a9719f80dc4e08017a1aa06a8f8d8f66cf140a63ab68a72f07edd9684786ce7409ef4177b43ed0209cd6bcdbb39dab00
+  languageName: node
+  linkType: hard
+
+"file-uri-to-path@npm:1.0.0":
+  version: 1.0.0
+  resolution: "file-uri-to-path@npm:1.0.0"
+  checksum: b648580bdd893a008c92c7ecc96c3ee57a5e7b6c4c18a9a09b44fb5d36d79146f8e442578bc0e173dc027adf3987e254ba1dfd6e3ec998b7c282873010502144
   languageName: node
   linkType: hard
 
@@ -32195,6 +32017,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-source@npm:^2.0.12":
+  version: 2.0.12
+  resolution: "get-source@npm:2.0.12"
+  dependencies:
+    data-uri-to-buffer: ^2.0.0
+    source-map: ^0.6.1
+  checksum: c73368fee709594ba38682ec1a96872aac6f7d766396019611d3d2358b68186a7847765a773ea0db088c42781126cc6bc09e4b87f263951c74dae5dcea50ad42
+  languageName: node
+  linkType: hard
+
 "get-stdin@npm:^4.0.1":
   version: 4.0.1
   resolution: "get-stdin@npm:4.0.1"
@@ -32234,7 +32066,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^6.0.0, get-stream@npm:^6.0.1":
+"get-stream@npm:^6.0.0":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: e04ecece32c92eebf5b8c940f51468cd53554dcbb0ea725b2748be583c9523d00128137966afce410b9b051eb2ef16d657cd2b120ca8edafcf5a65e81af63cad
@@ -33611,13 +33443,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-rewriter-wasm@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "html-rewriter-wasm@npm:0.4.1"
-  checksum: e97f76e0f9e2bfb187ffae1c93da4da20a82469e270f96d8d5d8b7f410cdfcce5b3ecb917558cc865fd50b6a2d71a4e8504a66b4ae1b9c6a5e9182a1c6f01ce4
-  languageName: node
-  linkType: hard
-
 "html-tags@npm:^3.1.0, html-tags@npm:^3.2.0":
   version: 3.2.0
   resolution: "html-tags@npm:3.2.0"
@@ -33850,13 +33675,6 @@ __metadata:
   version: 2.1.0
   resolution: "human-signals@npm:2.1.0"
   checksum: b87fd89fce72391625271454e70f67fe405277415b48bcc0117ca73d31fa23a4241787afdc8d67f5a116cf37258c052f59ea82daffa72364d61351423848e3b8
-  languageName: node
-  linkType: hard
-
-"human-signals@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "human-signals@npm:3.0.1"
-  checksum: f252a7769c8094a5c9dc6772816bdb417b188820b04c8b42d0fc468e03a0ba905b1dd07afabe9385cc83504af1ccc2b985cd1e4aeeeb8e0029896c5af2e6f354
   languageName: node
   linkType: hard
 
@@ -35265,13 +35083,6 @@ __metadata:
   version: 2.0.0
   resolution: "is-stream@npm:2.0.0"
   checksum: 4dc47738e26bc4f1b3be9070b6b9e39631144f204fc6f87db56961220add87c10a999ba26cf81699f9ef9610426f69cb08a4713feff8deb7d8cadac907826935
-  languageName: node
-  linkType: hard
-
-"is-stream@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "is-stream@npm:3.0.0"
-  checksum: 172093fe99119ffd07611ab6d1bcccfe8bc4aa80d864b15f43e63e54b7abc71e779acd69afdb854c4e2a67fdc16ae710e370eda40088d1cfc956a50ed82d8f16
   languageName: node
   linkType: hard
 
@@ -37693,7 +37504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kleur@npm:^4.0.3, kleur@npm:^4.1.4":
+"kleur@npm:^4.0.3, kleur@npm:^4.1.5":
   version: 4.1.5
   resolution: "kleur@npm:4.1.5"
   checksum: 1dc476e32741acf0b1b5b0627ffd0d722e342c1b0da14de3e8ae97821327ca08f9fb944542fb3c126d90ac5f27f9d804edbe7c585bf7d12ef495d115e0f22c12
@@ -40007,13 +39818,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-fn@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "mimic-fn@npm:4.0.0"
-  checksum: 995dcece15ee29aa16e188de6633d43a3db4611bcf93620e7e62109ec41c79c0f34277165b8ce5e361205049766e371851264c21ac64ca35499acb5421c2ba56
-  languageName: node
-  linkType: hard
-
 "mimic-response@npm:^1.0.0":
   version: 1.0.1
   resolution: "mimic-response@npm:1.0.1"
@@ -40044,45 +39848,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"miniflare@npm:2.11.0":
-  version: 2.11.0
-  resolution: "miniflare@npm:2.11.0"
+"miniflare@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "miniflare@npm:3.0.0"
   dependencies:
-    "@miniflare/cache": 2.11.0
-    "@miniflare/cli-parser": 2.11.0
-    "@miniflare/core": 2.11.0
-    "@miniflare/d1": 2.11.0
-    "@miniflare/durable-objects": 2.11.0
-    "@miniflare/html-rewriter": 2.11.0
-    "@miniflare/http-server": 2.11.0
-    "@miniflare/kv": 2.11.0
-    "@miniflare/queues": 2.11.0
-    "@miniflare/r2": 2.11.0
-    "@miniflare/runner-vm": 2.11.0
-    "@miniflare/scheduler": 2.11.0
-    "@miniflare/shared": 2.11.0
-    "@miniflare/sites": 2.11.0
-    "@miniflare/storage-file": 2.11.0
-    "@miniflare/storage-memory": 2.11.0
-    "@miniflare/web-sockets": 2.11.0
-    kleur: ^4.1.4
-    semiver: ^1.1.0
-    source-map-support: ^0.5.20
-    undici: 5.9.1
-  peerDependencies:
-    "@miniflare/storage-redis": 2.11.0
-    cron-schedule: ^3.0.4
-    ioredis: ^4.27.9
-  peerDependenciesMeta:
-    "@miniflare/storage-redis":
-      optional: true
-    cron-schedule:
-      optional: true
-    ioredis:
-      optional: true
-  bin:
-    miniflare: bootstrap.js
-  checksum: 73a7e253d93b9016d63d5b55028c689252a3d6c527951ef908634ed8202e3dafa7b11d71a27043805938381cb5ac8cbd978621a152b2d5027dee358d414888f9
+    acorn: ^8.8.0
+    acorn-walk: ^8.2.0
+    better-sqlite3: ^8.1.0
+    capnp-ts: ^0.7.0
+    exit-hook: ^2.2.1
+    glob-to-regexp: ^0.4.1
+    http-cache-semantics: ^4.1.0
+    kleur: ^4.1.5
+    source-map-support: 0.5.21
+    stoppable: ^1.1.0
+    undici: ^5.13.0
+    workerd: ^1.20230512.0
+    ws: ^8.11.0
+    youch: ^3.2.2
+    zod: ^3.20.6
+  checksum: 30a1bf4d6f1a7cb39ed57cebaf6d863c00af7b673b6bdfc14974986f0f4ab5c08a264d2b09c8bfb14f389f79af4c72ad4da58a51a66515f58826fc51b7a66065
   languageName: node
   linkType: hard
 
@@ -41068,15 +40853,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-path@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "npm-run-path@npm:5.1.0"
-  dependencies:
-    path-key: ^4.0.0
-  checksum: dc184eb5ec239d6a2b990b43236845332ef12f4e0beaa9701de724aa797fe40b6bbd0157fb7639d24d3ab13f5d5cf22d223a19c6300846b8126f335f788bee66
-  languageName: node
-  linkType: hard
-
 "npmlog@npm:^4.1.2":
   version: 4.1.2
   resolution: "npmlog@npm:4.1.2"
@@ -41117,18 +40893,6 @@ __metadata:
   version: 0.2.0
   resolution: "nprogress@npm:0.2.0"
   checksum: 66b7bec5d563ecf2d1c3d2815e6d5eb74ed815eee8563e0afa63d3f185ab1b9cf2ddd97e1ded263b9995c5019d26d600320e849e50f3747984daa033744619dc
-  languageName: node
-  linkType: hard
-
-"npx-import@npm:^1.1.3":
-  version: 1.1.4
-  resolution: "npx-import@npm:1.1.4"
-  dependencies:
-    execa: ^6.1.0
-    parse-package-name: ^1.0.0
-    semver: ^7.3.7
-    validate-npm-package-name: ^4.0.0
-  checksum: 7557d0c7d23bc0084e8da489c8e7b5cafcd1ee720826ca96f2b8388d64955b28cea36f2fefc8cb4835cb34795bf3ee26c20b2e8bcfbec626db50e3954240937c
   languageName: node
   linkType: hard
 
@@ -41443,15 +41207,6 @@ __metadata:
   dependencies:
     mimic-fn: ^2.1.0
   checksum: 2478859ef817fc5d4e9c2f9e5728512ddd1dbc9fb7829ad263765bb6d3b91ce699d6e2332eef6b7dff183c2f490bd3349f1666427eaba4469fba0ac38dfd0d34
-  languageName: node
-  linkType: hard
-
-"onetime@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "onetime@npm:6.0.0"
-  dependencies:
-    mimic-fn: ^4.0.0
-  checksum: 0846ce78e440841335d4e9182ef69d5762e9f38aa7499b19f42ea1c4cd40f0b4446094c455c713f9adac3f4ae86f613bb5e30c99e52652764d06a89f709b3788
   languageName: node
   linkType: hard
 
@@ -41970,13 +41725,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-package-name@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "parse-package-name@npm:1.0.0"
-  checksum: dfbfa8ce7a1f84340a59b2b5dd7d64f2de49a8cbd22621714d5042b7cce436e726b081e400e66341a1d27f1dd50c5c55c48be308e03415b567dc6a1d71314168
-  languageName: node
-  linkType: hard
-
 "parse5-htmlparser2-tree-adapter@npm:^6.0.1":
   version: 6.0.1
   resolution: "parse5-htmlparser2-tree-adapter@npm:6.0.1"
@@ -42162,13 +41910,6 @@ __metadata:
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
   checksum: 55cd7a9dd4b343412a8386a743f9c746ef196e57c823d90ca3ab917f90ab9f13dd0ded27252ba49dbdfcab2b091d998bc446f6220cd3cea65db407502a740020
-  languageName: node
-  linkType: hard
-
-"path-key@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "path-key@npm:4.0.0"
-  checksum: 8e6c314ae6d16b83e93032c61020129f6f4484590a777eed709c4a01b50e498822b00f76ceaf94bc64dbd90b327df56ceadce27da3d83393790f1219e07721d7
   languageName: node
   linkType: hard
 
@@ -43473,7 +43214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prebuild-install@npm:^7.1.1":
+"prebuild-install@npm:^7.1.0, prebuild-install@npm:^7.1.1":
   version: 7.1.1
   resolution: "prebuild-install@npm:7.1.1"
   dependencies:
@@ -43643,6 +43384,13 @@ __metadata:
   bin:
     pretty-quick: bin/pretty-quick.js
   checksum: 28bdc32571e6308e049497f58a9245f272275973782b6ed7fbcf98937101cc605a81b3ab48629dba4687b7e86c87a3733febacdc0746ca4da5d1c80a0b88cf45
+  languageName: node
+  linkType: hard
+
+"printable-characters@npm:^1.0.42":
+  version: 1.0.42
+  resolution: "printable-characters@npm:1.0.42"
+  checksum: 2724aa02919d7085933af0f8f904bd0de67a6b53834f2e5b98fc7aa3650e20755c805e8c85bcf96c09f678cb16a58b55640dd3a2da843195fce06b1ccb0c8ce4
   languageName: node
   linkType: hard
 
@@ -48098,19 +47846,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"selfsigned@npm:^2.0.0, selfsigned@npm:^2.0.1":
+"selfsigned@npm:^2.0.1":
   version: 2.1.1
   resolution: "selfsigned@npm:2.1.1"
   dependencies:
     node-forge: ^1
   checksum: aa9ce2150a54838978d5c0aee54d7ebe77649a32e4e690eb91775f71fdff773874a4fbafd0ac73d8ec3b702ff8a395c604df4f8e8868528f36fd6c15076fb43a
-  languageName: node
-  linkType: hard
-
-"semiver@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "semiver@npm:1.1.0"
-  checksum: 87e78c4fca6e082fed8905266341524b952a6d917397ca7e4feba469459e4165015fb25c0cd5b214f30ac4588e227e7c5b56ce91fd053893738d8a44a761ddb3
   languageName: node
   linkType: hard
 
@@ -48143,7 +47884,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.3.8, semver@npm:^7.0.0, semver@npm:^7.1.2, semver@npm:^7.3.8, semver@npm:~7.3.0":
+"semver@npm:7.3.8, semver@npm:^7.1.2, semver@npm:^7.3.8, semver@npm:~7.3.0":
   version: 7.3.8
   resolution: "semver@npm:7.3.8"
   dependencies:
@@ -48299,13 +48040,6 @@ __metadata:
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
   checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
-  languageName: node
-  linkType: hard
-
-"set-cookie-parser@npm:^2.4.8":
-  version: 2.5.1
-  resolution: "set-cookie-parser@npm:2.5.1"
-  checksum: b99c37f976e68ae6eb7c758bf2bbce1e60bb54e3eccedaa25f2da45b77b9cab58d90674cf9edd7aead6fbeac6308f2eb48713320a47ca120d0e838d0194513b6
   languageName: node
   linkType: hard
 
@@ -48855,7 +48589,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:0.5.21, source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.20, source-map-support@npm:^0.5.21, source-map-support@npm:^0.5.6, source-map-support@npm:~0.5.12, source-map-support@npm:~0.5.20":
+"source-map-support@npm:0.5.21, source-map-support@npm:^0.5.16, source-map-support@npm:^0.5.21, source-map-support@npm:^0.5.6, source-map-support@npm:~0.5.12, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:
@@ -49122,7 +48856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stack-trace@npm:0.0.10, stack-trace@npm:0.0.x":
+"stack-trace@npm:0.0.x":
   version: 0.0.10
   resolution: "stack-trace@npm:0.0.10"
   checksum: 473036ad32f8c00e889613153d6454f9be0536d430eb2358ca51cad6b95cea08a3cc33cc0e34de66b0dad221582b08ed2e61ef8e13f4087ab690f388362d6610
@@ -49182,6 +48916,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stacktracey@npm:^2.1.8":
+  version: 2.1.8
+  resolution: "stacktracey@npm:2.1.8"
+  dependencies:
+    as-table: ^1.0.36
+    get-source: ^2.0.12
+  checksum: abd8316b4e120884108f5a47b2f61abdcaeaa118afd95f3c48317cb057fff43d697450ba00de3f9fe7fee61ee72644ccda4db990a8e4553706644f7c17522eab
+  languageName: node
+  linkType: hard
+
 "state-toggle@npm:^1.0.0":
   version: 1.0.3
   resolution: "state-toggle@npm:1.0.3"
@@ -49233,6 +48977,13 @@ __metadata:
   dependencies:
     internal-slot: ^1.0.4
   checksum: d04173690b2efa40e24ab70e5e51a3ff31d56d699550cfad084104ab3381390daccb36652b25755e420245f3b0737de66c1879eaa2a8d4fc0a78f9bf892fcb42
+  languageName: node
+  linkType: hard
+
+"stoppable@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "stoppable@npm:1.1.0"
+  checksum: 63104fcbdece130bc4906fd982061e763d2ef48065ed1ab29895e5ad00552c625f8a4c50c9cd2e3bfa805c8a2c3bfdda0f07c5ae39694bd2d5cb0bee1618d1e9
   languageName: node
   linkType: hard
 
@@ -49611,13 +49362,6 @@ __metadata:
   version: 2.0.0
   resolution: "strip-final-newline@npm:2.0.0"
   checksum: 69412b5e25731e1938184b5d489c32e340605bb611d6140344abc3421b7f3c6f9984b21dff296dfcf056681b82caa3bb4cc996a965ce37bcfad663e92eae9c64
-  languageName: node
-  linkType: hard
-
-"strip-final-newline@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "strip-final-newline@npm:3.0.0"
-  checksum: 23ee263adfa2070cd0f23d1ac14e2ed2f000c9b44229aec9c799f1367ec001478469560abefd00c5c99ee6f0b31c137d53ec6029c53e9f32a93804e18c201050
   languageName: node
   linkType: hard
 
@@ -52585,13 +52329,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"urlpattern-polyfill@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "urlpattern-polyfill@npm:4.0.3"
-  checksum: 96ac2aea49a7b17a9ff41b2ccccdaf5e58a18c33c494cf663bea853c1ac2e70fd26a147b33b83ff7c6b77f9e34ee48409d21dbc1f2a2ad5cd9509cf3d5cb148e
-  languageName: node
-  linkType: hard
-
 "use-callback-ref@npm:^1.3.0":
   version: 1.3.0
   resolution: "use-callback-ref@npm:1.3.0"
@@ -52871,15 +52608,6 @@ __metadata:
     spdx-correct: ^3.0.0
     spdx-expression-parse: ^3.0.0
   checksum: 35703ac889d419cf2aceef63daeadbe4e77227c39ab6287eeb6c1b36a746b364f50ba22e88591f5d017bc54685d8137bc2d328d0a896e4d3fd22093c0f32a9ad
-  languageName: node
-  linkType: hard
-
-"validate-npm-package-name@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "validate-npm-package-name@npm:4.0.0"
-  dependencies:
-    builtins: ^5.0.0
-  checksum: a32fd537bad17fcb59cfd58ae95a414d443866020d448ec3b22e8d40550cb585026582a57efbe1f132b882eea4da8ac38ee35f7be0dd72988a3cb55d305a20c1
   languageName: node
   linkType: hard
 
@@ -54141,21 +53869,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrangler@npm:2.9.1":
-  version: 2.9.1
-  resolution: "wrangler@npm:2.9.1"
+"workerd@npm:^1.20230512.0":
+  version: 1.20230518.0
+  resolution: "workerd@npm:1.20230518.0"
+  dependencies:
+    "@cloudflare/workerd-darwin-64": 1.20230518.0
+    "@cloudflare/workerd-darwin-arm64": 1.20230518.0
+    "@cloudflare/workerd-linux-64": 1.20230518.0
+    "@cloudflare/workerd-linux-arm64": 1.20230518.0
+    "@cloudflare/workerd-windows-64": 1.20230518.0
+  dependenciesMeta:
+    "@cloudflare/workerd-darwin-64":
+      optional: true
+    "@cloudflare/workerd-darwin-arm64":
+      optional: true
+    "@cloudflare/workerd-linux-64":
+      optional: true
+    "@cloudflare/workerd-linux-arm64":
+      optional: true
+    "@cloudflare/workerd-windows-64":
+      optional: true
+  bin:
+    workerd: bin/workerd
+  checksum: 1d1b45d478695e5d4ecab98d6b200a9bc23e66cd72f2707cef843a44bcfd0817ff9cb50413bd7929de8b1f13147828e3c21157351d61ec7f9c1b55dceee1e046
+  languageName: node
+  linkType: hard
+
+"wrangler@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "wrangler@npm:3.0.1"
   dependencies:
     "@cloudflare/kv-asset-handler": ^0.2.0
     "@esbuild-plugins/node-globals-polyfill": ^0.1.1
     "@esbuild-plugins/node-modules-polyfill": ^0.1.4
-    "@miniflare/core": 2.11.0
-    "@miniflare/d1": 2.11.0
-    "@miniflare/durable-objects": 2.11.0
     blake3-wasm: ^2.1.5
     chokidar: ^3.5.3
     esbuild: 0.16.3
     fsevents: ~2.3.2
-    miniflare: 2.11.0
+    miniflare: ^3.0.0
     nanoid: ^3.3.3
     path-to-regexp: ^6.2.0
     selfsigned: ^2.0.1
@@ -54167,7 +53918,7 @@ __metadata:
   bin:
     wrangler: bin/wrangler.js
     wrangler2: bin/wrangler.js
-  checksum: e9cbb17cb19d34a5aa7caaa95366e52e67d8200e5ef17de6a12bec38d538b18e2901a57758d47ba14ff043dfef7a09ba81198034a669ad9d7197df7b88c8ffb0
+  checksum: 7970d31b5fe8c9266f1fb2351eaec34cd714338613cd360959ed4559f73ec3037069a0ce821119579d707e920050465dd039780776322f9b853ba4c64b97d6cb
   languageName: node
   linkType: hard
 
@@ -54604,15 +54355,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"youch@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "youch@npm:2.2.2"
+"youch@npm:^3.2.2":
+  version: 3.2.3
+  resolution: "youch@npm:3.2.3"
   dependencies:
-    "@types/stack-trace": 0.0.29
-    cookie: ^0.4.1
+    cookie: ^0.5.0
     mustache: ^4.2.0
-    stack-trace: 0.0.10
-  checksum: e81644ad9469a26949a85cb2e1a3f9c9faf11daa67a265e9ad0361942b2c06cf02ee1dc8c85d74fe7ad25d35bbc2fee34717a54c5a0b8eeb82dc9276d139906b
+    stacktracey: ^2.1.8
+  checksum: c0faced3813c1f81a1f98befbfe7f260d4933b99cd8ca16b0da48e6f69bacaf6f2b1172e83a666413dee7613c31705c4fcfbf4779e953ee3e7003eb1efc4a6c9
   languageName: node
   linkType: hard
 
@@ -54670,7 +54420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.21.4":
+"zod@npm:^3.20.6, zod@npm:^3.21.4":
   version: 3.21.4
   resolution: "zod@npm:3.21.4"
   checksum: f185ba87342ff16f7a06686767c2b2a7af41110c7edf7c1974095d8db7a73792696bcb4a00853de0d2edeb34a5b2ea6a55871bc864227dace682a0a28de33e1f


### PR DESCRIPTION
## Summary

Updates the interface for `H` in cloudflare workers to add a separate `H.init` to allow starting logging.
Adds a `setAttributes()` method to the cloudflare SDK to set global attributes.
Allows sending cloudflare logs with attributes per console method.
Fixes ingesting opentelemetry logs with nested attribute maps.
https://discord.com/channels/1026884757667188757/1111459644053921822

## How did you test this change?

v1
![image](https://github.com/highlight/highlight/assets/1351531/7df8c9ac-0f3d-4d0c-b4d7-35d661d1f789)
![image](https://github.com/highlight/highlight/assets/1351531/7cdb09f0-cfeb-4b7d-afdf-5c2feef1bffa)

v2
![image](https://github.com/highlight/highlight/assets/1351531/95e492de-78f6-4351-82e6-9e7f265c30b5)

https://www.loom.com/share/ed41b7c6b5924dec920c9397d849987e

New docs:
1. [cloudflare error monitoring](https://highlight-landing-git-vadim-cloudflare-sdk-321afb-highlight-run.vercel.app/docs/getting-started/backend-sdk/js/cloudflare)
2. [cloudflare logging](https://highlight-landing-git-vadim-cloudflare-sdk-321afb-highlight-run.vercel.app/docs/getting-started/backend-logging/js/cloudflare)

## Are there any deployment considerations?

New major version of cloudflare sdk released. Docs updated.