### PR TITLE
Prevent import with trailing slash

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -135,6 +135,10 @@
 				],
 				"patterns": [
 					{
+						"group": ["**/*/$"],
+						"message": "Import without the trailing / instead."
+					},
+					{
 						"group": ["**/packages/ui/src"],
 						"message": "Import from @highlight-run/ui instead."
 					}

--- a/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
+++ b/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@components/Button/'
+import { Button } from '@components/Button'
 import Tabs from '@components/Tabs/Tabs'
 import { useGetWorkspaceAdminsQuery } from '@graph/hooks'
 import { AdminRole, WorkspaceAdminRole } from '@graph/schemas'


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This broke Reflame builds because trailing slashes are treated as folder specifiers in import maps, so can't be mapped to the /index.ts module.

This PR fixes the 1 instance we have and adds a restricted import pattern to prevent this from happening again.

In the future we might be able to perform some lightweight import rewriting to normalize these automatically, or at least give more context in the error message and provide an autofix suggestion.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

[Reflame preview](https://preview.highlight.io/~r/start-preview/?variantId=01H1D65PJSW4EMHEJBRAHGNAE1&region=sjc&variantData=%7B%22type%22%3A%22branch%22%2C%22branch%22%3A%22prevent-import-with-trailing-slash%22%2C%22forkSpecifier%22%3A%22lewisl9029%2Fhighlight%22%2C%22githubOwnerName%22%3A%22highlight%22%2C%22githubRepositoryName%22%3A%22highlight%22%7D) works now.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
