### PR TITLE
reference the projectId, not the range index

### DIFF
--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -210,7 +210,7 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 	wSpan, wCtx := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.batched.process"))
 	wSpan.SetTag("BatchSize", len(k.BatchBuffer.messageQueue))
 	wSpan.SetTag("NumProjects", len(workspaceByProject))
-	for projectId := range markBackendSetupProjectIds {
+	for _, projectId := range markBackendSetupProjectIds {
 		err := k.Worker.PublicResolver.MarkBackendSetupImpl(wCtx, int(projectId), model.MarkBackendSetupTypeLogs)
 		if err != nil {
 			log.WithContext(wCtx).WithError(err).Error("failed to mark backend logs setup")


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Seeing a bunch of these errors locally:

![Screenshot 2023-05-30 at 10 24 53 AM](https://github.com/highlight/highlight/assets/58678/4c9b86ea-c3ba-415e-a8c9-601aabdfd510)


I thought this might have been a regression from #5465 but it looks like the behavior was always broken?


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

I debugged locally to confirm I was only marking setup events for projectId=1 locally.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
