### PR TITLE
Fix autoresolve query

### DIFF
--- a/backend/worker/autoresolver.go
+++ b/backend/worker/autoresolver.go
@@ -54,15 +54,18 @@ func (autoResolver *AutoResolver) resolveStaleErrorsForProject(ctx context.Conte
 
 	db := autoResolver.db
 
+	subQuery := db.
+		Model(model.ErrorObject{}).
+		Select("error_group_id").
+		Where("created_at >= ?", time.Now().AddDate(0, 0, -interval))
+
 	err := db.Debug().
-		Table("error_groups").
-		Select("DISTINCT(error_groups.id), error_groups.project_id").
-		Joins("INNER JOIN error_objects ON error_groups.id = error_objects.error_group_id").
-		Where("error_groups.state = ?", privateModel.ErrorStateOpen).
-		Where("error_groups.project_id = ?", project.ID).
-		Where("error_objects.created_at < ?", time.Now().AddDate(0, 0, -interval)).
-		Find(&errorGroups).
-		Error
+		Where(model.ErrorGroup{
+			State:     privateModel.ErrorStateOpen,
+			ProjectID: project.ID,
+		}).
+		Where("id NOT IN (?)", subQuery).
+		Find(&errorGroups).Error
 
 	if err != nil {
 		return err

--- a/backend/worker/autoresolver.go
+++ b/backend/worker/autoresolver.go
@@ -60,6 +60,7 @@ func (autoResolver *AutoResolver) resolveStaleErrorsForProject(ctx context.Conte
 		Where("created_at >= ?", time.Now().AddDate(0, 0, -interval))
 
 	err := db.Debug().
+		Select("DISTINCT(error_groups.id), error_groups.project_id").
 		Where(model.ErrorGroup{
 			State:     privateModel.ErrorStateOpen,
 			ProjectID: project.ID,

--- a/backend/worker/autoresolver_test.go
+++ b/backend/worker/autoresolver_test.go
@@ -74,6 +74,27 @@ func TestAutoResolveStaleErrors(t *testing.T) {
 		}
 		db.Create(&oldErrorObject)
 
+		// Should not be autoresolved
+		hasManyErrorObjectsErrorGroup := model.ErrorGroup{
+			State:     privateModel.ErrorStateOpen,
+			ProjectID: project.ID,
+		}
+		db.Create(&hasManyErrorObjectsErrorGroup)
+		errorObject1 := model.ErrorObject{
+			ErrorGroupID: hasManyErrorObjectsErrorGroup.ID,
+			Model: model.Model{
+				CreatedAt: twentyFiveHoursAgo,
+			},
+		}
+		db.Create(&errorObject1)
+		errorObject2 := model.ErrorObject{
+			ErrorGroupID: hasManyErrorObjectsErrorGroup.ID,
+			Model: model.Model{
+				CreatedAt: twentyThreeHoursAgo,
+			},
+		}
+		db.Create(&errorObject2)
+
 		// Should not be autoresolved since it belongs to a different project
 		projectWithNoSettings := model.Project{}
 		db.Create(&projectWithNoSettings)
@@ -111,9 +132,17 @@ func TestAutoResolveStaleErrors(t *testing.T) {
 		errorGroup3 := model.ErrorGroup{}
 		db.Where(model.ErrorGroup{
 			Model: model.Model{
-				ID: oldErrorGroupForUnrelatedProject.ID,
+				ID: hasManyErrorObjectsErrorGroup.ID,
 			},
 		}).Find(&errorGroup3)
 		assert.Equal(t, errorGroup3.State, privateModel.ErrorStateOpen) // was not autoresolved
+
+		errorGroup4 := model.ErrorGroup{}
+		db.Where(model.ErrorGroup{
+			Model: model.Model{
+				ID: oldErrorGroupForUnrelatedProject.ID,
+			},
+		}).Find(&errorGroup4)
+		assert.Equal(t, errorGroup4.State, privateModel.ErrorStateOpen) // was not autoresolved
 	})
 }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

The previous query would overmatch since it was not considering whether there were error objects that were recently created.

Before:

```sql
SELECT DISTINCT (error_groups.id), error_groups.project_id
FROM
	"error_groups"
	INNER JOIN error_objects ON error_groups.id = error_objects.error_group_id
WHERE error_groups.state = 'OPEN'
	AND error_groups.project_id = 1
	AND error_objects.created_at < '2023-04-30 11:54:57.589'
```

After:

```sql
SELECT DISTINCT (error_groups.id), error_groups.project_id
FROM
	"error_groups"
WHERE
	"error_groups"."project_id" = 1
	AND "error_groups"."state" = 'OPEN'
	AND id NOT IN(
		SELECT
			"error_group_id" FROM "error_objects"
		WHERE
			created_at >= '2023-04-30 11:54:57.589')
```

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Added a regression test.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A