### PR TITLE
update next build clean script to be platform agnostic

### DIFF
--- a/sdk/highlight-next/bin/clean-highlight-init.sh
+++ b/sdk/highlight-next/bin/clean-highlight-init.sh
@@ -1,2 +1,2 @@
-sed -i '1s;^;"use client"\;;' dist/HighlightInit.js
-sed -i '1s;^;"use client"\;;' dist/HighlightInit.mjs
+printf '%s%s' '"use client";' "$(cat dist/HighlightInit.js)" > dist/HighlightInit.js
+printf '%s%s' '"use client";' "$(cat dist/HighlightInit.mjs)" > dist/HighlightInit.mjs


### PR DESCRIPTION
## Summary

Updates the next build pipeline to work on all platforms by switching the `sed` command to `printf`. 
`sed` on mac would error with `sed: 1: "dist/HighlightInit.js": extra characters at the end of d command` despite working on linux.
The build step is necessary because the bundle must be marked with `"use client"` to make sure next.js does not
try to use the highlight component in server-side rendered code.

## How did you test this change?

![image](https://github.com/highlight/highlight/assets/1351531/0bb247cd-7a9f-4980-bf82-2613b725bbdb)

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
