### PR TITLE
Use BuildJet Cache instead of GitHub Cache on BuildJet Runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,13 +20,13 @@ jobs:
                   submodules: true
 
             - name: Setup Node.js environment
-              uses: actions/setup-node@v3
+              uses: buildjet/setup-node@v3
               with:
                   node-version: 18
                   cache: 'yarn'
 
             - name: Setup Golang environment
-              uses: actions/setup-go@v4
+              uses: buildjet/setup-go@v4
               with:
                   go-version-file: 'backend/go.mod'
                   cache-dependency-path: '**/go.sum'
@@ -44,7 +44,7 @@ jobs:
                   ./start-infra.sh > /tmp/highlight.log 2>&1;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
                   ./run-frontend.sh  >> /tmp/highlight.log 2>&1 & ./run-backend.sh >> /tmp/highlight.log 2>&1 &
-                  yarn dlx wait-on -l -s 4 https://127.0.0.1:3000/index.html  https://127.0.0.1:3000/src/routers/AppRouter/AppRouter.tsx http://127.0.0.1:8080/dist/index.js https://127.0.0.1:8082/health;                
+                  yarn dlx wait-on -l -s 4 https://127.0.0.1:3000/index.html  https://127.0.0.1:3000/src/routers/AppRouter/AppRouter.tsx http://127.0.0.1:8080/dist/index.js https://127.0.0.1:8082/health;
                   popd;
 
                   yarn cy:run;


### PR DESCRIPTION
Use the BuildJet Cache when using the BuildJet runners

For more details on how to migrate → https://buildjet.com/for-github-actions/docs/guides/migrating-to-buildjet-cache