### PR TITLE
fix clickup integration

### DIFF
--- a/backend/integrations/integrations.go
+++ b/backend/integrations/integrations.go
@@ -116,6 +116,22 @@ func (c *Client) GetWorkspaceAccessToken(ctx context.Context, workspace *model.W
 }
 
 func (c *Client) IsProjectIntegrated(ctx context.Context, project *model.Project, integrationType modelInputs.IntegrationType) (bool, error) {
+	if integrationType == modelInputs.IntegrationTypeClickUp {
+		var projectMapping *model.IntegrationProjectMapping
+		if err := c.db.Where(&model.IntegrationProjectMapping{
+			ProjectID:       project.ID,
+			IntegrationType: integrationType,
+		}).First(&projectMapping).Error; err != nil {
+			return false, nil
+		}
+
+		if projectMapping == nil {
+			return false, nil
+		}
+
+		return true, nil
+	}
+
 	var workspace model.Workspace
 	if err := c.db.Where(&model.Workspace{Model: model.Model{ID: project.WorkspaceID}}).First(&workspace).Error; err != nil {
 		return false, nil

--- a/backend/integrations/integrations_test.go
+++ b/backend/integrations/integrations_test.go
@@ -1,0 +1,38 @@
+package integrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/highlight-run/highlight/backend/model"
+	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/highlight-run/highlight/backend/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsProjectIntegrated(t *testing.T) {
+	util.RunTestWithDBWipe(t, "UpdateProjectFilterSettings", client.db, func(t *testing.T) {
+		project := model.Project{}
+		err := client.db.Create(&project).Error
+		assert.NoError(t, err)
+
+		// Clickup
+		integrated, err := client.IsProjectIntegrated(context.Background(), &project, privateModel.IntegrationTypeClickUp)
+		assert.NoError(t, err)
+
+		assert.False(t, integrated)
+
+		mapping := model.IntegrationProjectMapping{
+			IntegrationType: privateModel.IntegrationTypeClickUp,
+			ProjectID:       project.ID,
+			ExternalID:      "clickup-space-id",
+		}
+		err = client.db.Create(&mapping).Error
+		assert.NoError(t, err)
+
+		integrated, err = client.IsProjectIntegrated(context.Background(), &project, privateModel.IntegrationTypeClickUp)
+		assert.NoError(t, err)
+		assert.True(t, integrated)
+
+	})
+}

--- a/backend/integrations/main_test.go
+++ b/backend/integrations/main_test.go
@@ -1,0 +1,28 @@
+package integrations
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/highlight-run/highlight/backend/util"
+	e "github.com/pkg/errors"
+)
+
+var client *Client
+
+func TestMain(m *testing.M) {
+	dbName := "highlight_testing_db"
+	testLogger := log.WithContext(context.TODO()).WithFields(log.Fields{"DB_HOST": os.Getenv("PSQL_HOST"), "DB_NAME": dbName})
+	var err error
+	db, err := util.CreateAndMigrateTestDB(dbName)
+	if err != nil {
+		testLogger.Error(e.Wrap(err, "error creating testdb"))
+	}
+
+	client = NewIntegrationsClient(db)
+	code := m.Run()
+	os.Exit(code)
+}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6027,21 +6027,6 @@ func (r *queryResolver) IsProjectIntegratedWith(ctx context.Context, integration
 		return false, e.Wrap(err, "error querying project")
 	}
 
-	if integrationType == modelInputs.IntegrationTypeClickUp {
-		var projectMapping *model.IntegrationProjectMapping
-		if err := r.DB.Where(&model.IntegrationProjectMapping{
-			ProjectID:       project.ID,
-			IntegrationType: integrationType,
-		}).First(&projectMapping).Error; err != nil {
-			return false, nil
-		}
-
-		if projectMapping == nil {
-			return false, nil
-		}
-
-	}
-
 	return r.IntegrationsClient.IsProjectIntegrated(ctx, project, integrationType)
 }
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

When checking if a project has clickup integrated, the `IsProjectIntegratedWith` endpoint was always returning `false`. This looks to be a regression that happened some time ago and we never realized the clickup integration was broken until a customer wrote in (clickup doesn't get a lot of usage). 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->


Added a regression unit test for verifying if a prorject is integrated with Clickup.

Verified manually that we can manually create an issue into a Clickup Task and can choose the Clickup List
![Screenshot 2023-05-31 at 10 20 12 AM](https://github.com/highlight/highlight/assets/58678/c7f8c256-bbb9-4dfe-b0c5-a20e22564520)
![Screenshot 2023-05-31 at 10 18 44 AM](https://github.com/highlight/highlight/assets/58678/f34f7858-1f24-4d38-a07f-efc763fa34be)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A