### PR TITLE
Update email domain sender

### DIFF
--- a/backend/email/email.go
+++ b/backend/email/email.go
@@ -25,7 +25,7 @@ var (
 	SessionsDeletedEmailTemplateID       = "d-d9e10ce22c774fc9850dd0b36ccde339"
 	DigestEmailTemplateID                = "d-5bb29dabe298425ab9422b74636516bd"
 	BillingNotificationTemplateID        = "d-9fa375187c114dc1a5b561e81fbee794"
-	SendGridOutboundEmail                = "gm@runhighlight.com"
+	SendGridOutboundEmail                = "notifications@notify.highlight.io"
 	SessionCommentMentionsAsmId          = 20950
 	ErrorCommentMentionsAsmId            = 20994
 	frontendUri                          = os.Getenv("FRONTEND_URI")


### PR DESCRIPTION
## Summary
Issue: https://github.com/highlight/highlight/issues/5481
Update our emails to send from the `notifications@notify.highlight.io` address. Added the appropriate CNAME files to Google Domains to verify domain in [Sendgrid](https://app.sendgrid.com/settings/sender_auth).

## How did you test this change?
1. Go to the team settings page (`/w/1/team`)
2. Invite yourself
- [ ] Email received
- [ ] Sender address is "notifications@notify.highlight.io"

<img width="892" alt="Screenshot 2023-05-31 at 12 27 16 PM" src="https://github.com/highlight/highlight/assets/17744174/30ad392e-c1a8-4ec7-a1a2-d64e432ca49d">

## Are there any deployment considerations?
N/A
