### PR TITLE
clean up unused project filter settings endpoints

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -661,7 +661,6 @@ type ComplexityRoot struct {
 		DeleteSessions                   func(childComplexity int, projectID int, query string, sessionCount int) int
 		EditErrorSegment                 func(childComplexity int, id int, projectID int, params model.ErrorSearchParamsInput, name string) int
 		EditProject                      func(childComplexity int, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool) int
-		EditProjectFilterSettings        func(childComplexity int, projectID int, filterSessionsWithoutError bool) int
 		EditProjectSettings              func(childComplexity int, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool, filterSessionsWithoutError *bool) int
 		EditSegment                      func(childComplexity int, id int, projectID int, params model.SearchParamsInput, name string) int
 		EditWorkspace                    func(childComplexity int, id int, name *string) int
@@ -754,11 +753,6 @@ type ComplexityRoot struct {
 		WorkspaceID            func(childComplexity int) int
 	}
 
-	ProjectFilterSettings struct {
-		FilterSessionsWithoutError func(childComplexity int) int
-		ID                         func(childComplexity int) int
-	}
-
 	Query struct {
 		APIKeyToOrgID                func(childComplexity int, apiKey string) int
 		AccountDetails               func(childComplexity int, workspaceID int) int
@@ -846,7 +840,6 @@ type ComplexityRoot struct {
 		NewUsersCount                func(childComplexity int, projectID int, lookBackPeriod int) int
 		OauthClientMetadata          func(childComplexity int, clientID string) int
 		Project                      func(childComplexity int, id int) int
-		ProjectFilterSettings        func(childComplexity int, projectID int) int
 		ProjectHasViewedASession     func(childComplexity int, projectID int) int
 		ProjectSettings              func(childComplexity int, projectID int) int
 		ProjectSuggestion            func(childComplexity int, query string) int
@@ -1285,7 +1278,6 @@ type MutationResolver interface {
 	CreateProject(ctx context.Context, name string, workspaceID int) (*model1.Project, error)
 	CreateWorkspace(ctx context.Context, name string, promoCode *string) (*model1.Workspace, error)
 	EditProject(ctx context.Context, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool) (*model1.Project, error)
-	EditProjectFilterSettings(ctx context.Context, projectID int, filterSessionsWithoutError bool) (*model1.ProjectFilterSettings, error)
 	EditProjectSettings(ctx context.Context, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool, filterSessionsWithoutError *bool) (*model.AllProjectSettings, error)
 	EditWorkspace(ctx context.Context, id int, name *string) (*model1.Workspace, error)
 	MarkErrorGroupAsViewed(ctx context.Context, errorSecureID string, viewed *bool) (*model1.ErrorGroup, error)
@@ -1454,7 +1446,6 @@ type QueryResolver interface {
 	GithubRepos(ctx context.Context, workspaceID int) ([]*model.GitHubRepo, error)
 	GithubIssueLabels(ctx context.Context, workspaceID int, repository string) ([]string, error)
 	Project(ctx context.Context, id int) (*model1.Project, error)
-	ProjectFilterSettings(ctx context.Context, projectID int) (*model1.ProjectFilterSettings, error)
 	ProjectSettings(ctx context.Context, projectID int) (*model.AllProjectSettings, error)
 	Workspace(ctx context.Context, id int) (*model1.Workspace, error)
 	WorkspaceForInviteLink(ctx context.Context, secret string) (*model.WorkspaceForInviteLink, error)
@@ -4504,18 +4495,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.EditProject(childComplexity, args["id"].(int), args["name"].(*string), args["billing_email"].(*string), args["excluded_users"].(pq.StringArray), args["error_filters"].(pq.StringArray), args["error_json_paths"].(pq.StringArray), args["rage_click_window_seconds"].(*int), args["rage_click_radius_pixels"].(*int), args["rage_click_count"].(*int), args["backend_domains"].(pq.StringArray), args["filter_chrome_extension"].(*bool)), true
 
-	case "Mutation.editProjectFilterSettings":
-		if e.complexity.Mutation.EditProjectFilterSettings == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_editProjectFilterSettings_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.EditProjectFilterSettings(childComplexity, args["projectId"].(int), args["filterSessionsWithoutError"].(bool)), true
-
 	case "Mutation.editProjectSettings":
 		if e.complexity.Mutation.EditProjectSettings == nil {
 			break
@@ -5229,20 +5208,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Project.WorkspaceID(childComplexity), true
-
-	case "ProjectFilterSettings.filterSessionsWithoutError":
-		if e.complexity.ProjectFilterSettings.FilterSessionsWithoutError == nil {
-			break
-		}
-
-		return e.complexity.ProjectFilterSettings.FilterSessionsWithoutError(childComplexity), true
-
-	case "ProjectFilterSettings.id":
-		if e.complexity.ProjectFilterSettings.ID == nil {
-			break
-		}
-
-		return e.complexity.ProjectFilterSettings.ID(childComplexity), true
 
 	case "Query.api_key_to_org_id":
 		if e.complexity.Query.APIKeyToOrgID == nil {
@@ -6255,18 +6220,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Project(childComplexity, args["id"].(int)), true
-
-	case "Query.projectFilterSettings":
-		if e.complexity.Query.ProjectFilterSettings == nil {
-			break
-		}
-
-		args, err := ec.field_Query_projectFilterSettings_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.ProjectFilterSettings(childComplexity, args["projectId"].(int)), true
 
 	case "Query.projectHasViewedASession":
 		if e.complexity.Query.ProjectHasViewedASession == nil {
@@ -8869,11 +8822,6 @@ type Project {
 	filter_chrome_extension: Boolean
 }
 
-type ProjectFilterSettings {
-	id: ID!
-	filterSessionsWithoutError: Boolean!
-}
-
 type AllProjectSettings {
 	id: ID!
 	verbose_id: String!
@@ -10086,7 +10034,6 @@ type Query {
 	github_repos(workspace_id: ID!): [GitHubRepo!]
 	github_issue_labels(workspace_id: ID!, repository: String!): [String!]!
 	project(id: ID!): Project
-	projectFilterSettings(projectId: ID!): ProjectFilterSettings
 	projectSettings(projectId: ID!): AllProjectSettings
 	workspace(id: ID!): Workspace
 	workspace_for_invite_link(secret: String!): WorkspaceForInviteLink!
@@ -10172,10 +10119,6 @@ type Mutation {
 		backend_domains: StringArray
 		filter_chrome_extension: Boolean
 	): Project
-	editProjectFilterSettings(
-		projectId: ID!
-		filterSessionsWithoutError: Boolean!
-	): ProjectFilterSettings
 	editProjectSettings(
 		projectId: ID!
 		name: String
@@ -11830,30 +11773,6 @@ func (ec *executionContext) field_Mutation_editErrorSegment_args(ctx context.Con
 		}
 	}
 	args["name"] = arg3
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_editProjectFilterSettings_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 int
-	if tmp, ok := rawArgs["projectId"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectId"))
-		arg0, err = ec.unmarshalNID2int(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["projectId"] = arg0
-	var arg1 bool
-	if tmp, ok := rawArgs["filterSessionsWithoutError"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filterSessionsWithoutError"))
-		arg1, err = ec.unmarshalNBoolean2bool(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["filterSessionsWithoutError"] = arg1
 	return args, nil
 }
 
@@ -15232,21 +15151,6 @@ func (ec *executionContext) field_Query_oauth_client_metadata_args(ctx context.C
 		}
 	}
 	args["client_id"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_Query_projectFilterSettings_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 int
-	if tmp, ok := rawArgs["projectId"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectId"))
-		arg0, err = ec.unmarshalNID2int(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["projectId"] = arg0
 	return args, nil
 }
 
@@ -32959,63 +32863,6 @@ func (ec *executionContext) fieldContext_Mutation_editProject(ctx context.Contex
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_editProjectFilterSettings(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_editProjectFilterSettings(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().EditProjectFilterSettings(rctx, fc.Args["projectId"].(int), fc.Args["filterSessionsWithoutError"].(bool))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model1.ProjectFilterSettings)
-	fc.Result = res
-	return ec.marshalOProjectFilterSettings2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐProjectFilterSettings(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_editProjectFilterSettings(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_ProjectFilterSettings_id(ctx, field)
-			case "filterSessionsWithoutError":
-				return ec.fieldContext_ProjectFilterSettings_filterSessionsWithoutError(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type ProjectFilterSettings", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_editProjectFilterSettings_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Mutation_editProjectSettings(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_editProjectSettings(ctx, field)
 	if err != nil {
@@ -39104,94 +38951,6 @@ func (ec *executionContext) _Project_filter_chrome_extension(ctx context.Context
 func (ec *executionContext) fieldContext_Project_filter_chrome_extension(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Project",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _ProjectFilterSettings_id(ctx context.Context, field graphql.CollectedField, obj *model1.ProjectFilterSettings) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ProjectFilterSettings_id(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNID2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ProjectFilterSettings_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ProjectFilterSettings",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type ID does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _ProjectFilterSettings_filterSessionsWithoutError(ctx context.Context, field graphql.CollectedField, obj *model1.ProjectFilterSettings) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ProjectFilterSettings_filterSessionsWithoutError(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.FilterSessionsWithoutError, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ProjectFilterSettings_filterSessionsWithoutError(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ProjectFilterSettings",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -45835,63 +45594,6 @@ func (ec *executionContext) fieldContext_Query_project(ctx context.Context, fiel
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_project_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Query_projectFilterSettings(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_projectFilterSettings(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().ProjectFilterSettings(rctx, fc.Args["projectId"].(int))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model1.ProjectFilterSettings)
-	fc.Result = res
-	return ec.marshalOProjectFilterSettings2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐProjectFilterSettings(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_projectFilterSettings(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_ProjectFilterSettings_id(ctx, field)
-			case "filterSessionsWithoutError":
-				return ec.fieldContext_ProjectFilterSettings_filterSessionsWithoutError(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type ProjectFilterSettings", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_projectFilterSettings_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -65901,12 +65603,6 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 				return ec._Mutation_editProject(ctx, field)
 			})
 
-		case "editProjectFilterSettings":
-
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_editProjectFilterSettings(ctx, field)
-			})
-
 		case "editProjectSettings":
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
@@ -66621,41 +66317,6 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Values[i] = ec._Project_filter_chrome_extension(ctx, field, obj)
 
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var projectFilterSettingsImplementors = []string{"ProjectFilterSettings"}
-
-func (ec *executionContext) _ProjectFilterSettings(ctx context.Context, sel ast.SelectionSet, obj *model1.ProjectFilterSettings) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, projectFilterSettingsImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("ProjectFilterSettings")
-		case "id":
-
-			out.Values[i] = ec._ProjectFilterSettings_id(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "filterSessionsWithoutError":
-
-			out.Values[i] = ec._ProjectFilterSettings_filterSessionsWithoutError(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -68615,26 +68276,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_project(ctx, field)
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return rrm(innerCtx)
-			})
-		case "projectFilterSettings":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_projectFilterSettings(ctx, field)
 				return res
 			}
 
@@ -77670,13 +77311,6 @@ func (ec *executionContext) marshalOProject2ᚖgithubᚗcomᚋhighlightᚑrunᚋ
 		return graphql.Null
 	}
 	return ec._Project(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOProjectFilterSettings2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐProjectFilterSettings(ctx context.Context, sel ast.SelectionSet, v *model1.ProjectFilterSettings) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._ProjectFilterSettings(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOReferrerTablePayload2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐReferrerTablePayload(ctx context.Context, sel ast.SelectionSet, v *model.ReferrerTablePayload) graphql.Marshaler {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -355,11 +355,6 @@ type Project {
 	filter_chrome_extension: Boolean
 }
 
-type ProjectFilterSettings {
-	id: ID!
-	filterSessionsWithoutError: Boolean!
-}
-
 type AllProjectSettings {
 	id: ID!
 	verbose_id: String!
@@ -1572,7 +1567,6 @@ type Query {
 	github_repos(workspace_id: ID!): [GitHubRepo!]
 	github_issue_labels(workspace_id: ID!, repository: String!): [String!]!
 	project(id: ID!): Project
-	projectFilterSettings(projectId: ID!): ProjectFilterSettings
 	projectSettings(projectId: ID!): AllProjectSettings
 	workspace(id: ID!): Workspace
 	workspace_for_invite_link(secret: String!): WorkspaceForInviteLink!
@@ -1658,10 +1652,6 @@ type Mutation {
 		backend_domains: StringArray
 		filter_chrome_extension: Boolean
 	): Project
-	editProjectFilterSettings(
-		projectId: ID!
-		filterSessionsWithoutError: Boolean!
-	): ProjectFilterSettings
 	editProjectSettings(
 		projectId: ID!
 		name: String

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -584,20 +584,6 @@ func (r *mutationResolver) EditProject(ctx context.Context, id int, name *string
 	return project, nil
 }
 
-// EditProjectFilterSettings is the resolver for the editProjectFilterSettings field.
-func (r *mutationResolver) EditProjectFilterSettings(ctx context.Context, projectID int, filterSessionsWithoutError bool) (*model.ProjectFilterSettings, error) {
-	project, err := r.isAdminInProject(ctx, projectID)
-	if err != nil {
-		return nil, err
-	}
-
-	updatedProjectFilterSettings, err := r.Store.UpdateProjectFilterSettings(*project, model.ProjectFilterSettings{
-		FilterSessionsWithoutError: filterSessionsWithoutError,
-	})
-
-	return &updatedProjectFilterSettings, err
-}
-
 // EditProjectSettings is the resolver for the editProjectSettings field.
 func (r *mutationResolver) EditProjectSettings(ctx context.Context, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool, filterSessionsWithoutError *bool) (*modelInputs.AllProjectSettings, error) {
 	project, err := r.EditProject(ctx, projectID, name, billingEmail, excludedUsers, errorFilters, errorJSONPaths, rageClickWindowSeconds, rageClickRadiusPixels, rageClickCount, backendDomains, filterChromeExtension)
@@ -620,7 +606,9 @@ func (r *mutationResolver) EditProjectSettings(ctx context.Context, projectID in
 	}
 
 	if filterSessionsWithoutError != nil {
-		projectFilterSettings, err := r.EditProjectFilterSettings(ctx, projectID, *filterSessionsWithoutError)
+		projectFilterSettings, err := r.Store.UpdateProjectFilterSettings(*project, model.ProjectFilterSettings{
+			FilterSessionsWithoutError: *filterSessionsWithoutError,
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -6331,18 +6319,6 @@ func (r *queryResolver) Project(ctx context.Context, id int) (*model.Project, er
 	return project, nil
 }
 
-// ProjectFilterSettings is the resolver for the project_filter_settings field.
-func (r *queryResolver) ProjectFilterSettings(ctx context.Context, projectID int) (*model.ProjectFilterSettings, error) {
-	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
-	if err != nil {
-		return nil, err
-	}
-
-	projectFilterSettings, err := r.Store.GetProjectFilterSettings(*project)
-
-	return &projectFilterSettings, err
-}
-
 // ProjectSettings is the resolver for the projectSettings field.
 func (r *queryResolver) ProjectSettings(ctx context.Context, projectID int) (*modelInputs.AllProjectSettings, error) {
 	project, err := r.Project(ctx, projectID)
@@ -6350,7 +6326,7 @@ func (r *queryResolver) ProjectSettings(ctx context.Context, projectID int) (*mo
 		return nil, err
 	}
 
-	projectFilterSettings, err := r.ProjectFilterSettings(ctx, projectID)
+	projectFilterSettings, err := r.Store.GetProjectFilterSettings(*project)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -605,15 +605,13 @@ func (r *mutationResolver) EditProjectSettings(ctx context.Context, projectID in
 		RageClickCount:         &project.RageClickCount,
 	}
 
-	if filterSessionsWithoutError != nil {
-		projectFilterSettings, err := r.Store.UpdateProjectFilterSettings(*project, model.ProjectFilterSettings{
-			FilterSessionsWithoutError: *filterSessionsWithoutError,
-		})
-		if err != nil {
-			return nil, err
-		}
-		allProjectSettings.FilterSessionsWithoutError = projectFilterSettings.FilterSessionsWithoutError
+	projectFilterSettings, err := r.Store.UpdateProjectFilterSettings(*project, store.UpdateProjectFilterSettingsParams{
+		FilterSessionsWithoutError: filterSessionsWithoutError,
+	})
+	if err != nil {
+		return nil, err
 	}
+	allProjectSettings.FilterSessionsWithoutError = projectFilterSettings.FilterSessionsWithoutError
 
 	return &allProjectSettings, nil
 }

--- a/backend/store/project_filter_settings.go
+++ b/backend/store/project_filter_settings.go
@@ -18,8 +18,12 @@ type UpdateProjectFilterSettingsParams struct {
 }
 
 func (store *Store) UpdateProjectFilterSettings(project model.Project, updates UpdateProjectFilterSettingsParams) (model.ProjectFilterSettings, error) {
-	projectFilterSettings := model.ProjectFilterSettings{
-		ProjectID: project.ID,
+	var projectFilterSettings model.ProjectFilterSettings
+
+	projectFilterSettings, err := store.GetProjectFilterSettings(project)
+
+	if err != nil {
+		return projectFilterSettings, err
 	}
 
 	if updates.AutoResolveStaleErrorsDayInterval != nil {

--- a/backend/store/project_filter_settings.go
+++ b/backend/store/project_filter_settings.go
@@ -18,7 +18,9 @@ type UpdateProjectFilterSettingsParams struct {
 }
 
 func (store *Store) UpdateProjectFilterSettings(project model.Project, updates UpdateProjectFilterSettingsParams) (model.ProjectFilterSettings, error) {
-	projectFilterSettings := model.ProjectFilterSettings{}
+	projectFilterSettings := model.ProjectFilterSettings{
+		ProjectID: project.ID,
+	}
 
 	if updates.AutoResolveStaleErrorsDayInterval != nil {
 		projectFilterSettings.AutoResolveStaleErrorsDayInterval = *updates.AutoResolveStaleErrorsDayInterval
@@ -28,9 +30,7 @@ func (store *Store) UpdateProjectFilterSettings(project model.Project, updates U
 		projectFilterSettings.FilterSessionsWithoutError = *updates.FilterSessionsWithoutError
 	}
 
-	result := store.db.Where(model.ProjectFilterSettings{
-		ProjectID: project.ID,
-	}).Save(&projectFilterSettings)
+	result := store.db.Save(&projectFilterSettings)
 
 	return projectFilterSettings, result.Error
 }

--- a/backend/store/project_filter_settings.go
+++ b/backend/store/project_filter_settings.go
@@ -18,8 +18,6 @@ type UpdateProjectFilterSettingsParams struct {
 }
 
 func (store *Store) UpdateProjectFilterSettings(project model.Project, updates UpdateProjectFilterSettingsParams) (model.ProjectFilterSettings, error) {
-	var projectFilterSettings model.ProjectFilterSettings
-
 	projectFilterSettings, err := store.GetProjectFilterSettings(project)
 
 	if err != nil {

--- a/backend/store/project_filter_settings.go
+++ b/backend/store/project_filter_settings.go
@@ -12,12 +12,25 @@ func (store *Store) GetProjectFilterSettings(project model.Project) (model.Proje
 	return projectFilterSettings, result.Error
 }
 
-func (store *Store) UpdateProjectFilterSettings(project model.Project, updates model.ProjectFilterSettings) (model.ProjectFilterSettings, error) {
+type UpdateProjectFilterSettingsParams struct {
+	AutoResolveStaleErrorsDayInterval *int
+	FilterSessionsWithoutError        *bool
+}
+
+func (store *Store) UpdateProjectFilterSettings(project model.Project, updates UpdateProjectFilterSettingsParams) (model.ProjectFilterSettings, error) {
 	projectFilterSettings := model.ProjectFilterSettings{}
+
+	if updates.AutoResolveStaleErrorsDayInterval != nil {
+		projectFilterSettings.AutoResolveStaleErrorsDayInterval = *updates.AutoResolveStaleErrorsDayInterval
+	}
+
+	if updates.FilterSessionsWithoutError != nil {
+		projectFilterSettings.FilterSessionsWithoutError = *updates.FilterSessionsWithoutError
+	}
 
 	result := store.db.Where(model.ProjectFilterSettings{
 		ProjectID: project.ID,
-	}).Assign(updates).FirstOrCreate(&projectFilterSettings)
+	}).Save(&projectFilterSettings)
 
 	return projectFilterSettings, result.Error
 }

--- a/backend/store/project_filter_settings_test.go
+++ b/backend/store/project_filter_settings_test.go
@@ -11,24 +11,41 @@ import (
 	_ "gorm.io/driver/postgres"
 )
 
+func TestGetProjectFilterSettings(t *testing.T) {
+	util.RunTestWithDBWipe(t, "GetProjectFilterSettings", store.db, func(t *testing.T) {
+		project := model.Project{}
+		store.db.Create(&project)
+
+		originalSettings, err := store.GetProjectFilterSettings(project)
+		assert.NoError(t, err)
+		assert.NotNil(t, originalSettings.ID)
+
+		settings, err := store.GetProjectFilterSettings(project)
+		assert.NoError(t, err)
+		assert.Equal(t, settings.ID, originalSettings.ID)
+
+	})
+}
+
 func TestUpdateProjectFilterSettings(t *testing.T) {
 	util.RunTestWithDBWipe(t, "UpdateProjectFilterSettings", store.db, func(t *testing.T) {
 		project := model.Project{}
 		store.db.Create(&project)
 
-		updatedSettings, err := store.UpdateProjectFilterSettings(project, UpdateProjectFilterSettingsParams{
+		originalSettings, err := store.UpdateProjectFilterSettings(project, UpdateProjectFilterSettingsParams{
 			FilterSessionsWithoutError: ptr.Bool(true),
 		})
 		assert.NoError(t, err)
-		assert.True(t, updatedSettings.FilterSessionsWithoutError)
-		assert.Equal(t, updatedSettings.ProjectID, project.ID)
+		assert.True(t, originalSettings.FilterSessionsWithoutError)
+		assert.Equal(t, originalSettings.ProjectID, project.ID)
 
-		updatedSettings, err = store.UpdateProjectFilterSettings(project, UpdateProjectFilterSettingsParams{
+		updatedSettings, err := store.UpdateProjectFilterSettings(project, UpdateProjectFilterSettingsParams{
 			FilterSessionsWithoutError: ptr.Bool(false),
 		})
 		assert.NoError(t, err)
 		assert.False(t, updatedSettings.FilterSessionsWithoutError)
 		assert.Equal(t, updatedSettings.ProjectID, project.ID)
+		assert.Equal(t, originalSettings.ID, updatedSettings.ID)
 
 	})
 }

--- a/backend/store/project_filter_settings_test.go
+++ b/backend/store/project_filter_settings_test.go
@@ -21,12 +21,14 @@ func TestUpdateProjectFilterSettings(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.True(t, updatedSettings.FilterSessionsWithoutError)
+		assert.Equal(t, updatedSettings.ProjectID, project.ID)
 
 		updatedSettings, err = store.UpdateProjectFilterSettings(project, UpdateProjectFilterSettingsParams{
 			FilterSessionsWithoutError: ptr.Bool(false),
 		})
 		assert.NoError(t, err)
 		assert.False(t, updatedSettings.FilterSessionsWithoutError)
+		assert.Equal(t, updatedSettings.ProjectID, project.ID)
 
 	})
 }

--- a/backend/store/project_filter_settings_test.go
+++ b/backend/store/project_filter_settings_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/util"
 	"github.com/stretchr/testify/assert"
@@ -15,12 +16,18 @@ func TestUpdateProjectFilterSettings(t *testing.T) {
 		project := model.Project{}
 		store.db.Create(&project)
 
-		updatedSettings, err := store.UpdateProjectFilterSettings(project, model.ProjectFilterSettings{
-			FilterSessionsWithoutError: true,
+		updatedSettings, err := store.UpdateProjectFilterSettings(project, UpdateProjectFilterSettingsParams{
+			FilterSessionsWithoutError: ptr.Bool(true),
 		})
 		assert.NoError(t, err)
-
 		assert.True(t, updatedSettings.FilterSessionsWithoutError)
+
+		updatedSettings, err = store.UpdateProjectFilterSettings(project, UpdateProjectFilterSettingsParams{
+			FilterSessionsWithoutError: ptr.Bool(false),
+		})
+		assert.NoError(t, err)
+		assert.False(t, updatedSettings.FilterSessionsWithoutError)
+
 	})
 }
 
@@ -34,13 +41,13 @@ func TestFindProjectsWithAutoResolveSetting(t *testing.T) {
 
 		_, err := store.GetProjectFilterSettings(project1)
 		assert.NoError(t, err)
-		_, err = store.UpdateProjectFilterSettings(project1, model.ProjectFilterSettings{})
+		_, err = store.UpdateProjectFilterSettings(project1, UpdateProjectFilterSettingsParams{})
 		assert.NoError(t, err)
 
 		_, err = store.GetProjectFilterSettings(project2)
 		assert.NoError(t, err)
-		projectWithAutoResolveSetting, err := store.UpdateProjectFilterSettings(project1, model.ProjectFilterSettings{
-			AutoResolveStaleErrorsDayInterval: 1,
+		projectWithAutoResolveSetting, err := store.UpdateProjectFilterSettings(project1, UpdateProjectFilterSettingsParams{
+			AutoResolveStaleErrorsDayInterval: ptr.Int(1),
 		})
 		assert.NoError(t, err)
 

--- a/backend/worker/autoresolver_test.go
+++ b/backend/worker/autoresolver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/opensearch"
 	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
@@ -37,8 +38,8 @@ func TestAutoResolveStaleErrors(t *testing.T) {
 		project := model.Project{}
 		db.Create(&project)
 
-		_, err := autoResolver.store.UpdateProjectFilterSettings(project, model.ProjectFilterSettings{
-			AutoResolveStaleErrorsDayInterval: 1,
+		_, err := autoResolver.store.UpdateProjectFilterSettings(project, store.UpdateProjectFilterSettingsParams{
+			AutoResolveStaleErrorsDayInterval: ptr.Int(1),
 		})
 		assert.NoError(t, err)
 

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -1493,64 +1493,6 @@ export type EditProjectMutationOptions = Apollo.BaseMutationOptions<
 	Types.EditProjectMutation,
 	Types.EditProjectMutationVariables
 >
-export const EditProjectFilterSettingsDocument = gql`
-	mutation EditProjectFilterSettings(
-		$projectId: ID!
-		$filterSessionsWithoutError: Boolean!
-	) {
-		editProjectFilterSettings(
-			projectId: $projectId
-			filterSessionsWithoutError: $filterSessionsWithoutError
-		) {
-			id
-			filterSessionsWithoutError
-		}
-	}
-`
-export type EditProjectFilterSettingsMutationFn = Apollo.MutationFunction<
-	Types.EditProjectFilterSettingsMutation,
-	Types.EditProjectFilterSettingsMutationVariables
->
-
-/**
- * __useEditProjectFilterSettingsMutation__
- *
- * To run a mutation, you first call `useEditProjectFilterSettingsMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useEditProjectFilterSettingsMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [editProjectFilterSettingsMutation, { data, loading, error }] = useEditProjectFilterSettingsMutation({
- *   variables: {
- *      projectId: // value for 'projectId'
- *      filterSessionsWithoutError: // value for 'filterSessionsWithoutError'
- *   },
- * });
- */
-export function useEditProjectFilterSettingsMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.EditProjectFilterSettingsMutation,
-		Types.EditProjectFilterSettingsMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.EditProjectFilterSettingsMutation,
-		Types.EditProjectFilterSettingsMutationVariables
-	>(EditProjectFilterSettingsDocument, baseOptions)
-}
-export type EditProjectFilterSettingsMutationHookResult = ReturnType<
-	typeof useEditProjectFilterSettingsMutation
->
-export type EditProjectFilterSettingsMutationResult =
-	Apollo.MutationResult<Types.EditProjectFilterSettingsMutation>
-export type EditProjectFilterSettingsMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.EditProjectFilterSettingsMutation,
-		Types.EditProjectFilterSettingsMutationVariables
-	>
 export const EditProjectSettingsDocument = gql`
 	mutation EditProjectSettings(
 		$projectId: ID!
@@ -12755,63 +12697,6 @@ export type GetLogsErrorObjectsLazyQueryHookResult = ReturnType<
 export type GetLogsErrorObjectsQueryResult = Apollo.QueryResult<
 	Types.GetLogsErrorObjectsQuery,
 	Types.GetLogsErrorObjectsQueryVariables
->
-export const GetProjectFilterSettingsDocument = gql`
-	query GetProjectFilterSettings($projectId: ID!) {
-		projectFilterSettings(projectId: $projectId) {
-			id
-			filterSessionsWithoutError
-		}
-	}
-`
-
-/**
- * __useGetProjectFilterSettingsQuery__
- *
- * To run a query within a React component, call `useGetProjectFilterSettingsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetProjectFilterSettingsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetProjectFilterSettingsQuery({
- *   variables: {
- *      projectId: // value for 'projectId'
- *   },
- * });
- */
-export function useGetProjectFilterSettingsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetProjectFilterSettingsQuery,
-		Types.GetProjectFilterSettingsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetProjectFilterSettingsQuery,
-		Types.GetProjectFilterSettingsQueryVariables
-	>(GetProjectFilterSettingsDocument, baseOptions)
-}
-export function useGetProjectFilterSettingsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetProjectFilterSettingsQuery,
-		Types.GetProjectFilterSettingsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetProjectFilterSettingsQuery,
-		Types.GetProjectFilterSettingsQueryVariables
-	>(GetProjectFilterSettingsDocument, baseOptions)
-}
-export type GetProjectFilterSettingsQueryHookResult = ReturnType<
-	typeof useGetProjectFilterSettingsQuery
->
-export type GetProjectFilterSettingsLazyQueryHookResult = ReturnType<
-	typeof useGetProjectFilterSettingsLazyQuery
->
-export type GetProjectFilterSettingsQueryResult = Apollo.QueryResult<
-	Types.GetProjectFilterSettingsQuery,
-	Types.GetProjectFilterSettingsQueryVariables
 >
 export const GetProjectSettingsDocument = gql`
 	query GetProjectSettings($projectId: ID!) {

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -281,20 +281,6 @@ export type EditProjectMutation = { __typename?: 'Mutation' } & {
 	>
 }
 
-export type EditProjectFilterSettingsMutationVariables = Types.Exact<{
-	projectId: Types.Scalars['ID']
-	filterSessionsWithoutError: Types.Scalars['Boolean']
-}>
-
-export type EditProjectFilterSettingsMutation = { __typename?: 'Mutation' } & {
-	editProjectFilterSettings?: Types.Maybe<
-		{ __typename?: 'ProjectFilterSettings' } & Pick<
-			Types.ProjectFilterSettings,
-			'id' | 'filterSessionsWithoutError'
-		>
-	>
-}
-
 export type EditProjectSettingsMutationVariables = Types.Exact<{
 	projectId: Types.Scalars['ID']
 	name?: Types.Maybe<Types.Scalars['String']>
@@ -4325,19 +4311,6 @@ export type GetLogsErrorObjectsQuery = { __typename?: 'Query' } & {
 	>
 }
 
-export type GetProjectFilterSettingsQueryVariables = Types.Exact<{
-	projectId: Types.Scalars['ID']
-}>
-
-export type GetProjectFilterSettingsQuery = { __typename?: 'Query' } & {
-	projectFilterSettings?: Types.Maybe<
-		{ __typename?: 'ProjectFilterSettings' } & Pick<
-			Types.ProjectFilterSettings,
-			'id' | 'filterSessionsWithoutError'
-		>
-	>
-}
-
 export type GetProjectSettingsQueryVariables = Types.Exact<{
 	projectId: Types.Scalars['ID']
 }>
@@ -4505,7 +4478,6 @@ export const namedOperations = {
 		GetLogsKeys: 'GetLogsKeys' as const,
 		GetLogsKeyValues: 'GetLogsKeyValues' as const,
 		GetLogsErrorObjects: 'GetLogsErrorObjects' as const,
-		GetProjectFilterSettings: 'GetProjectFilterSettings' as const,
 		GetProjectSettings: 'GetProjectSettings' as const,
 		GetWorkspacePendingInvites: 'GetWorkspacePendingInvites' as const,
 	},
@@ -4536,7 +4508,6 @@ export const namedOperations = {
 		CreateAdmin: 'CreateAdmin' as const,
 		CreateWorkspace: 'CreateWorkspace' as const,
 		EditProject: 'EditProject' as const,
-		EditProjectFilterSettings: 'EditProjectFilterSettings' as const,
 		EditProjectSettings: 'EditProjectSettings' as const,
 		DeleteProject: 'DeleteProject' as const,
 		EditWorkspace: 'EditWorkspace' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -918,7 +918,6 @@ export type Mutation = {
 	deleteSessions: Scalars['Boolean']
 	editErrorSegment?: Maybe<Scalars['Boolean']>
 	editProject?: Maybe<Project>
-	editProjectFilterSettings?: Maybe<ProjectFilterSettings>
 	editProjectSettings?: Maybe<AllProjectSettings>
 	editSegment?: Maybe<Scalars['Boolean']>
 	editWorkspace?: Maybe<Workspace>
@@ -1193,11 +1192,6 @@ export type MutationEditProjectArgs = {
 	rage_click_count?: InputMaybe<Scalars['Int']>
 	rage_click_radius_pixels?: InputMaybe<Scalars['Int']>
 	rage_click_window_seconds?: InputMaybe<Scalars['Int']>
-}
-
-export type MutationEditProjectFilterSettingsArgs = {
-	filterSessionsWithoutError: Scalars['Boolean']
-	projectId: Scalars['ID']
 }
 
 export type MutationEditProjectSettingsArgs = {
@@ -1564,12 +1558,6 @@ export type Project = {
 	workspace_id: Scalars['ID']
 }
 
-export type ProjectFilterSettings = {
-	__typename?: 'ProjectFilterSettings'
-	filterSessionsWithoutError: Scalars['Boolean']
-	id: Scalars['ID']
-}
-
 export type Query = {
 	__typename?: 'Query'
 	account_details: AccountDetails
@@ -1658,7 +1646,6 @@ export type Query = {
 	new_user_alerts?: Maybe<Array<Maybe<SessionAlert>>>
 	oauth_client_metadata?: Maybe<OAuthClient>
 	project?: Maybe<Project>
-	projectFilterSettings?: Maybe<ProjectFilterSettings>
 	projectHasViewedASession?: Maybe<Session>
 	projectSettings?: Maybe<AllProjectSettings>
 	projectSuggestion: Array<Maybe<Project>>
@@ -2091,10 +2078,6 @@ export type QueryOauth_Client_MetadataArgs = {
 
 export type QueryProjectArgs = {
 	id: Scalars['ID']
-}
-
-export type QueryProjectFilterSettingsArgs = {
-	projectId: Scalars['ID']
 }
 
 export type QueryProjectHasViewedASessionArgs = {

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -245,19 +245,6 @@ mutation EditProject(
 	}
 }
 
-mutation EditProjectFilterSettings(
-	$projectId: ID!
-	$filterSessionsWithoutError: Boolean!
-) {
-	editProjectFilterSettings(
-		projectId: $projectId
-		filterSessionsWithoutError: $filterSessionsWithoutError
-	) {
-		id
-		filterSessionsWithoutError
-	}
-}
-
 mutation EditProjectSettings(
 	$projectId: ID!
 	$name: String

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2064,13 +2064,6 @@ query GetLogsErrorObjects($log_cursors: [String!]!) {
 	}
 }
 
-query GetProjectFilterSettings($projectId: ID!) {
-	projectFilterSettings(projectId: $projectId) {
-		id
-		filterSessionsWithoutError
-	}
-}
-
 query GetProjectSettings($projectId: ID!) {
 	projectSettings(projectId: $projectId) {
 		id


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR cleans up some unused endpoints that is no longer needed since we created a consolidated endpoint to save all project settings (#5387).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Confirmed that updating project settings (that exist on the project_filter_settings table) correctly update
* Added tests

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
