### PR TITLE
update copy on billing page

### DIFF
--- a/frontend/src/pages/Billing/BillingPageV2.tsx
+++ b/frontend/src/pages/Billing/BillingPageV2.tsx
@@ -353,7 +353,7 @@ const BillingPageV2 = ({}: BillingPageProps) => {
 						<Text size="small" weight="medium">
 							Prices are usage based and flexible with your needs.
 							Need a custom quote or want to commit to a minimum
-							spend?{' '}
+							spend (at a discount)?{' '}
 							<a href="mailto:sales@highlight.run">
 								<Box display="inline-flex" alignItems="center">
 									Reach out to sales <IconSolidArrowSmRight />

--- a/frontend/src/pages/Billing/UpdatePlanPage.tsx
+++ b/frontend/src/pages/Billing/UpdatePlanPage.tsx
@@ -347,7 +347,21 @@ const ProductCard = ({
 					</Form.NamedSection>
 				</Box>
 				<Box cssClass={style.formSection}>
-					<Form.NamedSection label="Limit" name="Limit">
+					<Form.NamedSection
+						label="Limit"
+						name="Limit"
+						tag={
+							<Tooltip
+								trigger={
+									<IconSolidInformationCircle size={12} />
+								}
+							>
+								If a billing limit is added, extra{' '}
+								{productType.toLowerCase()} will not be recorded
+								once the limit is reached.
+							</Tooltip>
+						}
+					>
 						<Box display="flex">
 							<LimitButton
 								limitCents={limitCents}
@@ -802,7 +816,7 @@ const UpdatePlanPage = ({}: BillingPageProps) => {
 							<Text size="small" weight="medium">
 								Prices are usage based and flexible with your
 								needs. Need a custom quote or want to commit to
-								a minimum spend?{' '}
+								a minimum spend (at a discount)?{' '}
 								<a href="mailto:sales@highlight.run">
 									<Box
 										display="inline-flex"


### PR DESCRIPTION
## Summary
- adds tooltip to explain billing limit for #5455 
<img width="464" alt="Screen Shot 2023-05-31 at 2 18 12 PM" src="https://github.com/highlight/highlight/assets/86132398/a922581f-bb6c-499b-af60-4346e2c4c641">

- update minimum spend copy #5447 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
