### PR TITLE
Add config to test current file in debug mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,7 @@
 {
 	// Use IntelliSense to learn about possible attributes.
 	// Hover to view descriptions of existing attributes.
-	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid": " 830387
 	"version": "0.2.0",
 	"configurations": [
 		{
@@ -11,6 +11,23 @@
 			"debugAdapter": "dlv-dap",
 			"mode": "remote",
 			"port": 2345
-		}
+		},
+        {
+            "name": "Test Current File",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${relativeFileDirname}",
+            "env": {
+				"ENVIRONMENT": "test",
+				"LOG_LEVEL": "debug",
+				"PSQL_HOST": "localhost",
+				"PSQL_PORT": "5432",
+				"PSQL_USER": "postgres",
+				"PSQL_PASSWORD": "postgres"
+			},
+            "args": [],
+            "showLog": true
+        }   
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,7 @@
 {
 	// Use IntelliSense to learn about possible attributes.
 	// Hover to view descriptions of existing attributes.
-	// For more information, visit: https://go.microsoft.com/fwlink/?linkid": " 830387
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 	"version": "0.2.0",
 	"configurations": [
 		{


### PR DESCRIPTION
## Summary
Its tough to run go tests in debug mode. Add a debug config to run a go test file in debug mode.

## How did you test this change?
1. Open a go test file
2. Place a break point in the file
3. Open the "Run and Debug" tab in VSCode
4. Run "Test Current File"
- [ ] Only tests in the current directory are ran
- [ ] Catches the breakpoint

![Screenshot 2023-06-01 at 4 10 13 PM](https://github.com/highlight/highlight/assets/17744174/5f2e8ca5-3529-412a-b89f-5d1f09326a4f)

## Are there any deployment considerations?
N/A
