### PR TITLE
add additional debugging information on when there are no timeline indicator events

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -8499,6 +8499,7 @@ enum SessionExcludedReason {
 	Initializing
 	NoActivity
 	NoUserInteractionEvents
+	NoTimelineIndicatorEvents
 	NoError
 	IgnoredUser
 }

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1579,24 +1579,26 @@ func (e SessionCommentType) MarshalGQL(w io.Writer) {
 type SessionExcludedReason string
 
 const (
-	SessionExcludedReasonInitializing            SessionExcludedReason = "Initializing"
-	SessionExcludedReasonNoActivity              SessionExcludedReason = "NoActivity"
-	SessionExcludedReasonNoUserInteractionEvents SessionExcludedReason = "NoUserInteractionEvents"
-	SessionExcludedReasonNoError                 SessionExcludedReason = "NoError"
-	SessionExcludedReasonIgnoredUser             SessionExcludedReason = "IgnoredUser"
+	SessionExcludedReasonInitializing              SessionExcludedReason = "Initializing"
+	SessionExcludedReasonNoActivity                SessionExcludedReason = "NoActivity"
+	SessionExcludedReasonNoUserInteractionEvents   SessionExcludedReason = "NoUserInteractionEvents"
+	SessionExcludedReasonNoTimelineIndicatorEvents SessionExcludedReason = "NoTimelineIndicatorEvents"
+	SessionExcludedReasonNoError                   SessionExcludedReason = "NoError"
+	SessionExcludedReasonIgnoredUser               SessionExcludedReason = "IgnoredUser"
 )
 
 var AllSessionExcludedReason = []SessionExcludedReason{
 	SessionExcludedReasonInitializing,
 	SessionExcludedReasonNoActivity,
 	SessionExcludedReasonNoUserInteractionEvents,
+	SessionExcludedReasonNoTimelineIndicatorEvents,
 	SessionExcludedReasonNoError,
 	SessionExcludedReasonIgnoredUser,
 }
 
 func (e SessionExcludedReason) IsValid() bool {
 	switch e {
-	case SessionExcludedReasonInitializing, SessionExcludedReasonNoActivity, SessionExcludedReasonNoUserInteractionEvents, SessionExcludedReasonNoError, SessionExcludedReasonIgnoredUser:
+	case SessionExcludedReasonInitializing, SessionExcludedReasonNoActivity, SessionExcludedReasonNoUserInteractionEvents, SessionExcludedReasonNoTimelineIndicatorEvents, SessionExcludedReasonNoError, SessionExcludedReasonIgnoredUser:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -18,6 +18,7 @@ enum SessionExcludedReason {
 	Initializing
 	NoActivity
 	NoUserInteractionEvents
+	NoTimelineIndicatorEvents
 	NoError
 	IgnoredUser
 }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Noticed this [comment](https://github.com/highlight/highlight/issues/5471#issuecomment-1568563563) and while looking at all the places where we exclude a session, I noticed this piece of code that excludes sessions when there are no timeline indicator events. I've added tracking to determine if this is a reason we exclude a session (see #5252).

I don't think this PR solves this comment linked but it may help with understanding why this query returns non-zero results:

```sql
SELECT
	created_at,
	excluded,
	excluded_reason
FROM
	sessions
WHERE
	excluded = TRUE
	AND excluded_reason IS NULL
ORDER BY
	created_at DESC
LIMIT 100
```

<img width="572" alt="Screenshot 2023-06-01 at 8 03 27 PM" src="https://github.com/highlight/highlight/assets/58678/23b20c92-8912-45f3-87d1-b0284a5106e8">
 


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
