### PR TITLE
pin golangci-lint version in go sdk test

### DIFF
--- a/.github/workflows/go-sdk.yml
+++ b/.github/workflows/go-sdk.yml
@@ -32,7 +32,9 @@ jobs:
               with:
                   args: --config ./.golangci.yaml --timeout 5m
                   working-directory: sdk/highlight-go
-                  version: latest
+                  # version: latest
+                  # Pinning the version until https://github.com/golangci/golangci-lint/issues/3862 is solved
+                  version: v1.52.2
 
     build:
         name: build binary


### PR DESCRIPTION
## Summary

As with #5519, pin the golangci-lint version for the Go SDK test.

## How did you test this change?

CI

## Are there any deployment considerations?

No