### PR TITLE
optimize autoresolver query

### DIFF
--- a/backend/worker/autoresolver.go
+++ b/backend/worker/autoresolver.go
@@ -65,7 +65,7 @@ func (autoResolver *AutoResolver) resolveStaleErrorsForProject(ctx context.Conte
 			State:     privateModel.ErrorStateOpen,
 			ProjectID: project.ID,
 		}).
-		Where("id NOT IN (?)", subQuery).
+		Where("NOT EXISTS (?)", subQuery).
 		Find(&errorGroups).Error
 
 	if err != nil {

--- a/backend/worker/autoresolver.go
+++ b/backend/worker/autoresolver.go
@@ -57,7 +57,11 @@ func (autoResolver *AutoResolver) resolveStaleErrorsForProject(ctx context.Conte
 	subQuery := db.
 		Model(model.ErrorObject{}).
 		Select("error_group_id").
-		Where("created_at >= ?", time.Now().AddDate(0, 0, -interval))
+		Where("error_objects.error_group_id = error_groups.id").
+		Where("created_at >= ?", time.Now().AddDate(0, 0, -interval)).
+		Where(model.ErrorObject{
+			ProjectID: project.ID,
+		})
 
 	err := db.Debug().
 		Select("DISTINCT(error_groups.id), error_groups.project_id").

--- a/backend/worker/autoresolver_test.go
+++ b/backend/worker/autoresolver_test.go
@@ -55,6 +55,7 @@ func TestAutoResolveStaleErrors(t *testing.T) {
 		db.Create(&recentErrorGroup)
 		recentErrorObject := model.ErrorObject{
 			ErrorGroupID: recentErrorGroup.ID,
+			ProjectID:    project.ID,
 			Model: model.Model{
 				CreatedAt: twentyThreeHoursAgo,
 			},
@@ -69,6 +70,7 @@ func TestAutoResolveStaleErrors(t *testing.T) {
 		db.Create(&oldErrorGroup)
 		oldErrorObject := model.ErrorObject{
 			ErrorGroupID: oldErrorGroup.ID,
+			ProjectID:    project.ID,
 			Model: model.Model{
 				CreatedAt: twentyFiveHoursAgo,
 			},
@@ -83,6 +85,7 @@ func TestAutoResolveStaleErrors(t *testing.T) {
 		db.Create(&hasManyErrorObjectsErrorGroup)
 		errorObject1 := model.ErrorObject{
 			ErrorGroupID: hasManyErrorObjectsErrorGroup.ID,
+			ProjectID:    project.ID,
 			Model: model.Model{
 				CreatedAt: twentyFiveHoursAgo,
 			},
@@ -90,6 +93,7 @@ func TestAutoResolveStaleErrors(t *testing.T) {
 		db.Create(&errorObject1)
 		errorObject2 := model.ErrorObject{
 			ErrorGroupID: hasManyErrorObjectsErrorGroup.ID,
+			ProjectID:    project.ID,
 			Model: model.Model{
 				CreatedAt: twentyThreeHoursAgo,
 			},


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

The autoresolver query to find stale errors is taking too long
![image](https://github.com/highlight/highlight/assets/58678/1756512e-0677-4a27-bc8f-44bacb6e2099)

This PR optimizes the autoresolve query to use `NOT EXISTS` instead of `NOT IN` and includes the project_id in the subquery

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Tests pass

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A