### PR TITLE
unpin golangci-lint version

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -39,9 +39,7 @@ jobs:
               with:
                   args: --config ./.golangci.yml --timeout 5m
                   working-directory: backend
-                  # version: latest
-                  # Pinning the version until https://github.com/golangci/golangci-lint/issues/3862 is solved
-                  version: v1.52.2
+                  version: latest
 
     make-check:
         needs: [code-setup]

--- a/.github/workflows/go-sdk.yml
+++ b/.github/workflows/go-sdk.yml
@@ -32,9 +32,7 @@ jobs:
               with:
                   args: --config ./.golangci.yaml --timeout 5m
                   working-directory: sdk/highlight-go
-                  # version: latest
-                  # Pinning the version until https://github.com/golangci/golangci-lint/issues/3862 is solved
-                  version: v1.52.2
+                  version: latest
 
     build:
         name: build binary


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

https://github.com/golangci/golangci-lint/issues/3862 is solved. We can unpin the golangci-lint version.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Build passes

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A