### PR TITLE
skip retryable flow for updating opensearch synchronously

### DIFF
--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -311,16 +311,7 @@ func (c *Client) UpdateSynchronous(index Index, id int, obj interface{}) error {
 	}
 
 	if res.IsError() {
-		c.RetryableClient.ReportError(context.Background(), model.RetryableOpensearchError, indexStr, documentId, map[string]interface{}{"id": id, "obj": obj, "res": res}, nil)
-		return e.New(
-			fmt.Sprintf(
-				"OPENSEARCH_ERROR (%s : %s) [%d] %s",
-				indexStr,
-				documentId,
-				res.StatusCode,
-				res.String(),
-			),
-		)
+		return e.New("OPENSEARCH_ERROR error updating document: " + res.String())
 	}
 
 	// log.WithContext(ctx).Infof("OPENSEARCH_SUCCESS (%s : %s) [%d] created", indexStr, documentId, res.StatusCode)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Synchronous updates to opensearch should be an all or nothing operation in terms of their success/failure. If they fail through our kafka flow, we should rely on kakfa to retry instead of the Retryable workflow (which is only for async updates to opensearch). This keeps the logic consistent with how we do synchronous index operations (see [slack](https://highlightcorp.slack.com/archives/C02CJANPHQS/p1685733121119179?thread_ts=1685660764.377189&cid=C02CJANPHQS)).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A