### PR TITLE
retry sync updates to opensearch in case of conflict

### DIFF
--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -299,10 +299,11 @@ func (c *Client) UpdateSynchronous(index Index, id int, obj interface{}) error {
 	indexStr := GetIndex(index)
 
 	req := opensearchapi.UpdateRequest{
-		Index:      indexStr,
-		DocumentID: documentId,
-		Body:       body,
-		Refresh:    "true",
+		Index:           indexStr,
+		DocumentID:      documentId,
+		Body:            body,
+		RetryOnConflict: pointy.Int(3),
+		Refresh:         "true",
 	}
 
 	res, err := req.Do(context.Background(), c.Client)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Since switching to sync updates to opensearch (#5524), we are getting some conflict updates:
![Screenshot 2023-06-02 at 1 41 40 PM](https://github.com/highlight/highlight/assets/58678/7cf5b179-702f-44e0-8573-148602a16274)

See this stackoverflow: https://stackoverflow.com/questions/36188917/how-to-fix-elasticsearch-conflicts-on-the-same-key-when-two-process-writing-at-t

These are fine since kafka will retry, however it's a lot of noise.

Per looking at the source, it looks like the async update had RetryOnConflict set. This PR ports that behavior to the sync update.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

We should monitor to confirm this cools off these logs:
https://app.highlight.io/1/logs?query=error%20updating%20session%20in%20opensearch%20level%3Aerror%20code.filepath%3A%2Fbuild%2Fbackend%2Fpublic-graph%2Fgraph%2Fresolver.go
