### PR TITLE
Allow attribute passing into H#record_log

### DIFF
--- a/sdk/highlight-ruby/highlight/lib/highlight.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight.rb
@@ -64,7 +64,7 @@ module Highlight
             span.record_exception(e)
         end
 
-        def record_log(session_id, request_id, level, message)
+        def record_log(session_id, request_id, level, message, attrs = {})
             caller_info = caller[0].split(":", 3)
             function = caller_info[2]
             if function
@@ -86,7 +86,7 @@ module Highlight
                     CODE_FILEPATH => caller_info[0],
                     CODE_LINENO => caller_info[1],
                     CODE_FUNCTION => function,
-                })
+                }.merge(attrs))
             end
         end
 


### PR DESCRIPTION
## Summary

Presently, the ruby SDK does not support specifying custom attributes on log messages.

This PR adds basic support for passing these custom attributes through to highlight.

## Are there any deployment considerations?

This change should be backwards compatible with the existing SDK version

## Notes

Right now, it's possible to configure this with some ruby magic and an initializer in a rails app, but this is far some ideal and brittle to breaking whenever the SDK makes minor changes:

```
Rails.application.reloader.to_prepare do
  Highlight::H.class_eval do
    def record_log(session_id, request_id, level, message, attrs = {})
      caller_info = caller[0].split(":", 3)
      function = caller_info[2]
      if function
          # format: "in `<function_name>""
          function.delete_prefix!("in `")
          function.delete_suffix!("\"")
      end
      @tracer.in_span("highlight-ctx", attributes: { 
          self.class.const_get(:HIGHLIGHT_PROJECT_ATTRIBUTE) => @project_id, 
          self.class.const_get(:HIGHLIGHT_SESSION_ATTRIBUTE) => session_id,
          self.class.const_get(:HIGHLIGHT_TRACE_ATTRIBUTE) => request_id,
      }.compact) do |span|
          if level == Logger::ERROR || level == Logger::FATAL
              span.status = OpenTelemetry::Trace::Status.error(message)
          end
          span.add_event(self.class.const_get(:LOG_EVENT), attributes: {
              self.class.const_get(:LOG_SEVERITY_ATTRIBUTE) => Highlight::H.log_level_string(level),
              self.class.const_get(:LOG_MESSAGE_ATTRIBUTE) => message,
              self.class.const_get(:CODE_FILEPATH) => caller_info[0],
              self.class.const_get(:CODE_LINENO) => caller_info[1],
              self.class.const_get(:CODE_FUNCTION) => function,
          }.merge(attrs))
      end
    end
  end
end
```

We're using highlight over at [embolt.app](https://embolt.app) and love the value prop so far -- I'd like to introduce a tagged logger that forwards attributes to highlight and a change like this would allow me to write a custom logger without needing to perform class evaluation at runtime.