### PR TITLE
docs: fix an invalid link in the Slack Integration document

### DIFF
--- a/docs-content/general/7_integrations/slack-integration.md
+++ b/docs-content/general/7_integrations/slack-integration.md
@@ -13,4 +13,4 @@ To get started, go to [https://app.highlight.io/alerts](https://app.highlight.io
 
 1.  [Comments](../6_product-features/3_general-features/comments.md) will send a Slack message to whoever is tagged in a comment
 
-2.  [Alerts](../6_product-features/3_general-features/comments.md) will send a Slack message to channels or users who want to receive alerts
+2.  [Alerts](../6_product-features/3_general-features/alerts.md) will send a Slack message to channels or users who want to receive alerts


### PR DESCRIPTION
## Summary

Fix an invalid link in the Slack Integration document.

## How did you test this change?

I launched the documentation site locally and checked that the link is working correctly

## Are there any deployment considerations?

No