### PR TITLE
deprecate async updates to opensearch

### DIFF
--- a/backend/migrations/cmd/unexclude-sessions-opensearch/main.go
+++ b/backend/migrations/cmd/unexclude-sessions-opensearch/main.go
@@ -55,7 +55,7 @@ func main() {
 	log.WithContext(ctx).Infof("starting an opensearch update")
 
 	for _, sessionID := range sessionIDs {
-		if err := r.OpenSearch.Update(
+		if err := r.OpenSearch.UpdateSynchronous(
 			opensearch.IndexSessions,
 			sessionID,
 			map[string]interface{}{"Excluded": false},

--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -240,48 +240,6 @@ func NewOpensearchClient(db *gorm.DB) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) Update(index Index, id int, obj interface{}) error {
-	if c == nil || !c.isInitialized {
-		return nil
-	}
-
-	documentId := strconv.Itoa(id)
-
-	b, err := json.Marshal(obj)
-	if err != nil {
-		return e.Wrap(err, "OPENSEARCH_ERROR error marshalling map for update")
-	}
-	body := strings.NewReader(fmt.Sprintf("{ \"doc\" : %s }", string(b)))
-
-	indexStr := GetIndex(index)
-
-	item := opensearchutil.BulkIndexerItem{
-		Index:           indexStr,
-		Action:          "update",
-		DocumentID:      documentId,
-		Body:            body,
-		RetryOnConflict: pointy.Int(3),
-		OnSuccess: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem) {
-			// log.WithContext(ctx).Infof("OPENSEARCH_SUCCESS (%s : %s) [%d] %s", indexStr, item.DocumentID, res.Status, res.Result)
-		},
-		OnFailure: func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
-			if err != nil {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, item.Index, item.DocumentID, map[string]interface{}{"item.Action": item.Action, "res": res}, err)
-				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s", indexStr, item.DocumentID, err)
-			} else {
-				c.RetryableClient.ReportError(ctx, model.RetryableOpensearchError, item.Index, item.DocumentID, map[string]interface{}{"item.Action": item.Action, "res": res}, nil)
-				log.WithContext(ctx).Errorf("OPENSEARCH_ERROR (%s : %s) %s %s", indexStr, item.DocumentID, res.Error.Type, res.Error.Reason)
-			}
-		},
-	}
-
-	if err := c.BulkIndexer.Add(context.Background(), item); err != nil {
-		return e.Wrap(err, "OPENSEARCH_ERROR error adding bulk indexer item for update")
-	}
-
-	return nil
-}
-
 func (c *Client) UpdateSynchronous(index Index, id int, obj interface{}) error {
 	if c == nil || !c.isInitialized {
 		return nil


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Per #5457, async updates to opensearch are unreliable. Per #5511, we are migrating all async updates to be synchronous. Hence, this PR simply removes the async update functionality.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Confirmed opensearch updates that are processed via the worker (e.g. processing a session) still work as expected.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

Will monitor the [prod cluster](https://us-east-2.console.aws.amazon.com/aos/home?region=us-east-2#opensearch/domains/highlight-search-prod-v2?tabId=clusterHealth).
