### PR TITLE
ignore billing quota exceeded in session count

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1317,6 +1317,7 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 			SELECT project_id, DATE_TRUNC('day', created_at, 'UTC') as date, COUNT(*) as count
 			FROM sessions
 			WHERE excluded <> true
+			AND within_billing_quota
 			AND (active_length >= 1000 OR (active_length is null and length >= 1000))
 			AND processed = true
 			AND created_at > now() - interval '3 months'


### PR DESCRIPTION
## Summary
- fixes https://github.com/highlight/highlight/issues/4265
- don't count sessions not `within_billing_quota` in the meter
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally, altered mv in prod already
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, already deployed manually
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
