### PR TITLE
ensure ignored errors stay ignored

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -393,6 +393,8 @@ func (r *Resolver) GetOrCreateErrorGroup(ctx context.Context, errorObj *model.Er
 
 		updatedState := errorGroup.State
 
+		// Reopen resolved errors
+		// Note that ignored errors do change state
 		if updatedState == privateModel.ErrorStateResolved {
 			updatedState = privateModel.ErrorStateOpen
 		}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -391,31 +391,29 @@ func (r *Resolver) GetOrCreateErrorGroup(ctx context.Context, errorObj *model.Er
 
 		environmentsString := getIncrementedEnvironmentCount(ctx, errorGroup, errorObj)
 
+		updatedState := errorGroup.State
+
+		if updatedState == privateModel.ErrorStateResolved {
+			updatedState = privateModel.ErrorStateOpen
+		}
+
 		if err := r.DB.Model(errorGroup).Updates(&model.ErrorGroup{
 			StackTrace:       *errorObj.StackTrace,
 			MappedStackTrace: errorObj.MappedStackTrace,
 			Environments:     environmentsString,
 			Event:            errorObj.Event,
+			State:            updatedState,
 		}).Error; err != nil {
 			return nil, e.Wrap(err, "Error updating error group")
 		}
 	}
 
-	opensearchErrorGroup := &model.ErrorGroup{
-		Model:     errorGroup.Model,
-		SecureID:  errorGroup.SecureID,
-		ProjectID: errorObj.ProjectID,
-		Event:     errorObj.Event,
-		Type:      errorObj.Type,
-		State:     privateModel.ErrorStateOpen,
-		Fields:    []*model.ErrorField{},
-	}
 	if err := r.OpenSearch.IndexSynchronous(ctx,
 		opensearch.IndexParams{
 			Index:    opensearch.IndexErrorsCombined,
 			ID:       int64(errorGroup.ID),
 			ParentID: pointy.Int(0),
-			Object:   opensearchErrorGroup}); err != nil {
+			Object:   errorGroup}); err != nil {
 		return nil, e.Wrap(err, "error indexing error group (combined index) in opensearch")
 	}
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

If an ignored error reoccurs, it is reopening instead of staying ignored. This PR fixes that and ensures the opensearch data is the same as postgres.

Relates to #5511

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Tests added.

Manual test:
* Resolved errors reopen if they reoccur
* Ignored errors stay ignore if they reoccur

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A