### PR TITLE
make sourcemap-uploader validate sourcemaps exist

### DIFF
--- a/sourcemap-uploader/package.json
+++ b/sourcemap-uploader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@highlight-run/sourcemap-uploader",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Command line tool to upload source maps to Highlight",
   "bin": "./dist/index.js",
   "author": "Highlight",

--- a/sourcemap-uploader/src/index.ts
+++ b/sourcemap-uploader/src/index.ts
@@ -8,14 +8,15 @@ program
 
 program
   .command("upload")
-  .option("-k, --apiKey <string>", "The Highlight api key")
-  .option("-av, --appVersion <string>", "The current version of your deploy")
+  .requiredOption("-k, --apiKey <string>", "The Highlight api key")
+  .option("-av, --appVersion [string]", "The current version of your deploy")
   .option(
-    "-p, --path <string>",
-    "Sets the directory of where the sourcemaps are"
+    "-p, --path [string]",
+    "Sets the directory of where the sourcemaps are",
+    "."
   )
   .option(
-    "-bp, --basePath",
+    "-bp, --basePath [string]",
     "An optional base path for the uploaded sourcemaps",
     ""
   )

--- a/sourcemap-uploader/src/lib.ts
+++ b/sourcemap-uploader/src/lib.ts
@@ -1,7 +1,7 @@
 import { basename, join } from "path";
 import { cwd } from "process";
 import { readFileSync, statSync } from "fs";
-import glob from "glob";
+import { globSync } from "glob";
 import fetch from "cross-fetch";
 
 const VERIFY_API_KEY_QUERY = `
@@ -141,20 +141,18 @@ async function getAllSourceMapFiles(paths: string[]) {
       }
 
       if (
-        !(
-          await glob("**/*.js.map", {
-            cwd: realPath,
-            nodir: true,
-            ignore: "**/node_modules/**/*",
-          })
-        ).length
+        !globSync("**/*.js.map", {
+          cwd: realPath,
+          nodir: true,
+          ignore: "**/node_modules/**/*",
+        }).length
       ) {
         throw new Error(
-          "no .js.map files found. please double check that you have generated sourcemaps for your app."
+          "No .js.map files found. Please double check that you have generated sourcemaps for your app."
         );
       }
 
-      for (const file of await glob("**/*.js?(.map)", {
+      for (const file of globSync("**/*.js?(.map)", {
         cwd: realPath,
         nodir: true,
         ignore: "**/node_modules/**/*",


### PR DESCRIPTION
## Summary

Check that `.js.map` files are present when running the sourcemap uploader
to make sure a customer is generating sourcemaps in the first place when using the script.

Fixes an issue where `--path` was a required argument.

## How did you test this change?

with `.js.map` files
![image](https://github.com/highlight/highlight/assets/1351531/3bee7c5a-c72b-4d45-acd2-0a8650b0c681)

without `.js.map` files but with other files there
![image](https://github.com/highlight/highlight/assets/1351531/815f75a3-7a4c-4917-a400-6ea9093b1ace)


## Are there any deployment considerations?

New sourcemap uploader version.
