### PR TITLE
Treat Reflame generated files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,9 @@
 backend/private-graph/graph/schema.resolvers.go linguist-generated=false
 backend/public-graph/graph/schema.resolvers.go linguist-generated=false
 frontend/src/graph/generated/* linguist-generated=true
-frontend/src/__generated/* linguist-generated=true
+frontend/src/__generated/* binary linguist-generated=true
 client/src/graph/generated/* linguist-generated=true
-packages/ui/src/__generated/* linguist-generated=true
+packages/ui/src/__generated/* binary linguist-generated=true
 go.sum linguist-generated=true
 go.mod linguist-generated=true
 /.yarn/releases/** binary


### PR DESCRIPTION
## Summary

So users won't get a useless diff, instead would be prompted to accept either version wholesale, and then regenerate using `yarn reflame-build`.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
