### PR TITLE
improve experience of recording cross-origin iframes

### DIFF
--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/iframes.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/iframes.md
@@ -21,16 +21,16 @@ updatedAt: 2022-04-19T18:48:07.000Z
 
 [Cross-origin iframes](https://learn.microsoft.com/en-us/skype-sdk/ucwa/cross_domainiframe) are `<iframe>` elements in your app that reference a domain considered to be of a [different origin](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy). When your iframe uses a `src` tag pointing to a different origin, the iframe is not accessible from the parent page. However, the iframe can still emit messages that the parent page can hear.
 
-To support cross-origin iframes, we added functionality into our recording client that allows the iframe to forward its events to the parent session. All you need to do is add the Highlight snippet to both the parent window and the iframe.
+To support cross-origin iframes, we added functionality into our recording client that allows the iframe to forward its events to the parent session. All you need to do is add the Highlight snippet to **both** the parent window and the iframe.
 
-Ensure you are using [highlight.run](https://www.npmjs.com/package/highlight.run) 5.2.0 or newer. Then, add the following option to the `H.init` call **inside of your iframe**.
+Ensure you are using [highlight.run](https://www.npmjs.com/package/highlight.run) 7.1.0 or newer. Then, set the following option on both of the `H.init` calls: in the parent window and in the iframe.
 
 ```typescript
 import { H } from 'highlight.run'
 
 H.init('<YOUR_PROJECT_ID>', {
-  isCrossOriginIframe: true,
+  recordCrossOriginIframe: true,
 })
 ```
 
-Ensure that you add the `H.init` call to both the parent page and the iframe page, but that you only set `isCrossOriginIframe` **in the H.init call of your iframe**. Otherwise your sessions will not be recorded.
+Ensure that you add the `H.init` call to both the parent page and the iframe page, and that you've set `recordCrossOriginIframe` **in both H.init calls**.

--- a/docs-content/sdk/client.md
+++ b/docs-content/sdk/client.md
@@ -84,8 +84,8 @@ slug: client
           <p>Specifies where the backend of the app lives. If specified, Highlight will attach the X-Highlight-Request header to outgoing requests whose destination URLs match a substring or regexp from this list, so that backend errors can be linked back to the session. If true is specified, all requests to the current domain will be matched. Example tracingOrigins: ['localhost', /^\//, 'backend.myapp.com']</p>
         </aside>
         <aside className="parameter">
-          <h5>isCrossOriginIframe <code>boolean</code> <code>optional</code></h5>
-          <p>Specifies that the current app is a cross origin iframe in an app where Highlight is also enabled. This flag should only be set in the iframe, not in the parent application hosting the iframe. This allows the iframe to forward its recording to the parent to be included as part of the session. See [cross-origin iframe recording](../getting-started/3_client-sdk/7_replay-configuration/iframes.md) for more details.</p>
+          <h5>recordCrossOriginIframe <code>boolean</code> <code>optional</code></h5>
+          <p>Specifies that cross-origin iframe elements should be recorded. Should be set in both the parent window and in the iframe. See [cross-origin iframe recording](../getting-started/3_client-sdk/7_replay-configuration/iframes.md) for more details.</p>
         </aside>
         <aside className="parameter">
           <h5>urlBlocklist <code>string[]</code> <code>optional</code></h5>

--- a/sdk/client/src/types/iframe.ts
+++ b/sdk/client/src/types/iframe.ts
@@ -1,0 +1,13 @@
+export const IFRAME_PARENT_READY = 'iframe parent ready'
+
+export interface HighlightIframeMessage {
+	highlight: typeof IFRAME_PARENT_READY
+	projectID: number
+	sessionSecureID: string
+}
+
+export const IFRAME_PARENT_RESPONSE = 'iframe ok'
+
+export interface HighlightIframeReponse {
+	highlight: typeof IFRAME_PARENT_RESPONSE
+}

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -169,13 +169,6 @@ export declare type HighlightOptions = {
 	 * @default false
 	 */
 	recordCrossOriginIframe?: boolean
-	/**
-	 * Specifies that the current app is a cross origin iframe in an app where Highlight is also enabled.
-	 * This flag should only be set in the iframe, not in the parent application hosting the iframe.
-	 * This allows the iframe to forward its recording to the parent to be included as part of the session.
-	 * @default false
-	 */
-	isCrossOriginIframe?: boolean
 	integrations?: IntegrationOptions
 	/**
 	 * Specifies the keyboard shortcut to open the current session in Highlight.

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -169,6 +169,11 @@ export declare type HighlightOptions = {
 	 * @default false
 	 */
 	recordCrossOriginIframe?: boolean
+	/**
+	 * Deprecated: this setting is now inferred automatically. Passing this option does nothing.
+	 * @deprecated
+	 */
+	isCrossOriginIframe?: boolean
 	integrations?: IntegrationOptions
 	/**
 	 * Specifies the keyboard shortcut to open the current session in Highlight.

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -235,3 +235,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Breaking Changes
 
 - Removed the `feedbackWidget` option.
+
+## 7.1.0
+
+### Minor Changes
+
+- Improves the experience of configuring cross-origin `<iframe>` recording.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.0.0",
+	"version": "7.1.0",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.0.0"
+export default "7.1.0"

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -114,7 +114,6 @@ const H: HighlightPublicInterface = {
 				inlineImages: options?.inlineImages,
 				inlineStylesheet: options?.inlineStylesheet,
 				recordCrossOriginIframe: options?.recordCrossOriginIframe,
-				isCrossOriginIframe: options?.isCrossOriginIframe,
 				firstloadVersion,
 				environment: options?.environment || 'production',
 				appVersion: options?.version,


### PR DESCRIPTION
## Summary

Improves the experience of using highlight with a cross-origin iframe setup by removing the
`isCrossOriginIframe` option (now automatically inferred) and by making the `H.init` setup more robust to the order in which it is called.

Before this change, `H.init` had to be called first in the parent window and then in the cross-origin iframe
to make sure the iframe would be recorded. This change adds window message listeners to the parent
and iframe to allow them to communicate about the rrweb initialization state to allow the iframe to wait
for the parent window to set up rrweb.

## How did you test this change?

https://www.loom.com/share/7727bf44b7e2418db9d8f9dc8238d220

## Are there any deployment considerations?

New minor version 7.1.0
https://highlightcorp.slack.com/archives/C01JFQ77WTX/p1685063049376099
