### PR TITLE
add auth checks to error object endpoints

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -886,9 +886,9 @@ type ErrorObject struct {
 	SessionID        *int
 	TraceID          *string
 	SpanID           *string
-	LogCursor        *string    `gorm:"index:idx_error_object_log_cursor,option:CONCURRENTLY"`
-	ErrorGroupID     int        `gorm:"index:idx_error_group_id_id,priority:1,option:CONCURRENTLY"`
-	ErrorGroup       ErrorGroup `gorm:"foreignkey:ErrorGroupID"`
+	LogCursor        *string `gorm:"index:idx_error_object_log_cursor,option:CONCURRENTLY"`
+	ErrorGroupID     int     `gorm:"index:idx_error_group_id_id,priority:1,option:CONCURRENTLY"`
+	ErrorGroup       ErrorGroup
 	Event            string
 	Type             string
 	URL              string
@@ -929,7 +929,7 @@ type ErrorGroup struct {
 	ErrorMetrics     []*modelInputs.ErrorDistributionItem `gorm:"-"`
 	FirstOccurrence  *time.Time                           `gorm:"-"`
 	LastOccurrence   *time.Time                           `gorm:"-"`
-	ErrorObjects     []ErrorObject                        `gorm:"foreignkey:ErrorGroupID"`
+	ErrorObjects     []ErrorObject
 
 	// Represents the admins that have viewed this session.
 	ViewedByAdmins []Admin `json:"viewed_by_admins" gorm:"many2many:error_group_admins_views;"`

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -886,8 +886,9 @@ type ErrorObject struct {
 	SessionID        *int
 	TraceID          *string
 	SpanID           *string
-	LogCursor        *string `gorm:"index:idx_error_object_log_cursor,option:CONCURRENTLY"`
-	ErrorGroupID     int     `gorm:"index:idx_error_group_id_id,priority:1,option:CONCURRENTLY"`
+	LogCursor        *string    `gorm:"index:idx_error_object_log_cursor,option:CONCURRENTLY"`
+	ErrorGroupID     int        `gorm:"index:idx_error_group_id_id,priority:1,option:CONCURRENTLY"`
+	ErrorGroup       ErrorGroup `gorm:"foreignkey:ErrorGroupID"`
 	Event            string
 	Type             string
 	URL              string
@@ -928,6 +929,7 @@ type ErrorGroup struct {
 	ErrorMetrics     []*modelInputs.ErrorDistributionItem `gorm:"-"`
 	FirstOccurrence  *time.Time                           `gorm:"-"`
 	LastOccurrence   *time.Time                           `gorm:"-"`
+	ErrorObjects     []ErrorObject                        `gorm:"foreignkey:ErrorGroupID"`
 
 	// Represents the admins that have viewed this session.
 	ViewedByAdmins []Admin `json:"viewed_by_admins" gorm:"many2many:error_group_admins_views;"`

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -920,10 +920,6 @@ func (r *Resolver) canAdminViewErrorObject(ctx context.Context, errorObjectID in
 	defer authSpan.Finish()
 
 	errorObject := model.ErrorObject{}
-	if err := r.DB.Where(&model.ErrorObject{ID: errorObjectID}).First(&errorObject).Error; err != nil {
-		return nil, err
-	}
-
 	if err := r.DB.Where(&model.ErrorObject{ID: errorObjectID}).
 		Preload("ErrorGroup").
 		First(&errorObject).Error; err != nil {

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -915,6 +915,28 @@ func (r *Resolver) doesAdminOwnErrorGroup(ctx context.Context, errorGroupSecureI
 	return eg, true, nil
 }
 
+func (r *Resolver) canAdminViewErrorObject(ctx context.Context, errorObjectID int) (*model.ErrorObject, error) {
+	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("canAdminViewErrorObject"))
+	defer authSpan.Finish()
+
+	errorObject := model.ErrorObject{}
+	if err := r.DB.Where(&model.ErrorObject{ID: errorObjectID}).First(&errorObject).Error; err != nil {
+		return nil, err
+	}
+
+	if err := r.DB.Where(&model.ErrorObject{ID: errorObjectID}).
+		Preload("ErrorGroup").
+		First(&errorObject).Error; err != nil {
+		return nil, err
+	}
+
+	if _, err := r.canAdminViewErrorGroup(ctx, errorObject.ErrorGroup.SecureID); err != nil {
+		return nil, err
+	}
+
+	return &errorObject, nil
+}
+
 func (r *Resolver) canAdminViewErrorGroup(ctx context.Context, errorGroupSecureID string) (*model.ErrorGroup, error) {
 	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("canAdminViewErrorGroup"))
 	defer authSpan.Finish()


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR adds some auth checks to error object endpoints

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

On the main branch:

Copy one of the queries as curl and paste it into Postman
<img width="718" alt="Screenshot 2023-06-05 at 8 10 48 PM" src="https://github.com/highlight/highlight/assets/58678/d702962b-71a8-4590-aa1d-6441a5b4afa6">

In Postman, uncheck the `token` param and observe that the request goes through:
<img width="1116" alt="Screenshot 2023-06-05 at 8 11 28 PM" src="https://github.com/highlight/highlight/assets/58678/e900e999-9308-4485-a812-2f04d8c59caa">


On this branch:
Perform the same request and observe the request is rejected
<img width="1088" alt="Screenshot 2023-06-05 at 8 12 33 PM" src="https://github.com/highlight/highlight/assets/58678/8377e625-6ce9-4130-beba-e8a466e47915">


If you check the `token` param, the request should go through:

<img width="1112" alt="Screenshot 2023-06-05 at 8 13 04 PM" src="https://github.com/highlight/highlight/assets/58678/2fb9e209-6e44-49ee-b30d-12cf968cd500">


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
