### PR TITLE
Stop minifying generated css again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,9 @@
 backend/private-graph/graph/schema.resolvers.go linguist-generated=false
 backend/public-graph/graph/schema.resolvers.go linguist-generated=false
 frontend/src/graph/generated/* linguist-generated=true
-frontend/src/__generated/* binary linguist-generated=true
+frontend/src/__generated/* linguist-generated=true
 client/src/graph/generated/* linguist-generated=true
-packages/ui/src/__generated/* binary linguist-generated=true
+packages/ui/src/__generated/* linguist-generated=true
 go.sum linguist-generated=true
 go.mod linguist-generated=true
 /.yarn/releases/** binary

--- a/frontend/scripts/build-css-bundle.mjs
+++ b/frontend/scripts/build-css-bundle.mjs
@@ -38,7 +38,12 @@ export const run = async ({ rootDirectory }) => {
 
 				await fs.promises.writeFile(
 					path_.join(outputDirectory, 'index.css'),
-					cssOutput.contents,
+					// vanilla extract outputs comments that seem to depend on absolute path
+					// need to strip them for consistent output between local and ci
+					cssOutput.text.replaceAll(
+						/\n\/\* vanilla-extract-css-ns\:.*\n/g,
+						'',
+					),
 				)
 				console.log(new Date(), 'built css bundle', cssOutput.path)
 			})
@@ -57,9 +62,7 @@ export const run = async ({ rootDirectory }) => {
 		platform: 'browser',
 		outdir: outputDirectory,
 		outbase: workingDirectory,
-		// vanilla extract outputs comments that seem to depend on absolute path
-		// need to minify for consistent output between local and ci
-		minify: true,
+		minify: false,
 		splitting: false,
 		target: 'esnext',
 		plugins: [

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -1,1 +1,13411 @@
-:root{--color-purple-100: #ede9fe;--color-purple-200: #ddd6fe;--color-purple-300: #c4b5fd;--color-purple-400: #a78bfa;--color-purple-500: #8b5cf6;--color-purple-600: #7c3aed;--color-purple-700: #6d28d9;--color-purple-800: #5b21b6;--color-purple-900: #4c1d95;--color-purple: #5629c6;--color-purple-rgb: 86, 41, 198;--color-blue-100: #dbeafe;--color-blue-200: #bfdbfe;--color-blue-300: #93c5fd;--color-blue-400: #60a5fa;--color-blue-500: #3b82f6;--color-blue-600: #2563eb;--color-blue-700: #1d4ed8;--color-blue-800: #1e40af;--color-blue-900: #1e3a8a;--color-green-100: #d1fae5;--color-green-200: #a7f3d0;--color-green-300: #6ee7b7;--color-green-400: #34d399;--color-green-500: #10b981;--color-green-600: #059669;--color-green-700: #047857;--color-green-800: #065f46;--color-green-900: #064e3b;--color-yellow-100: #fef3c7;--color-yellow-200: #fde68a;--color-yellow-300: #fcd34d;--color-yellow-400: #fbbf24;--color-yellow-500: #f59e0b;--color-yellow-600: #d97706;--color-yellow-700: #b45309;--color-yellow-800: #92400e;--color-yellow-900: #78350f;--color-orange-300: rgba(242, 106, 76, .37);--color-orange-400: #ffb038;--color-orange-500: #c67e29;--color-brown: #835e00;--color-red: #ff0000;--color-red-100: #fee2e2;--color-red-200: #fecaca;--color-red-300: #fca5a5;--color-red-400: #f87171;--color-red-500: #ef4444;--color-red-600: #dc2626;--color-red-700: #b91c1c;--color-red-800: #991b1b;--color-red-900: #7f1d1d;--color-gray-100: #efefef7d;--color-gray-200: #f2f2f2;--color-gray-300: #eaeaea;--color-gray-400: #bdbdbd;--color-gray-500: #828282;--color-gray-600: #7e7e7e;--color-gray-700: #8a8f98;--color-gray-800: #2d2f36;--color-black: #111;--color-white: #fff;--color-neutral-50: #f5f5f5;--color-neutral-100: #e9e9e9;--color-neutral-200: #dddddd;--color-neutral-300: #a4a4a4;--color-neutral-500: #777777;--color-neutral-700: #444444;--color-neutral-800: #2c2c2c;--color-neutral-900: #1a1a1a;--color-neutral-N1: #fdfcfd;--color-new-purple-100: #b19cff;--color-new-purple-500: #6c37f4;--color-new-purple-700: #5420d1;--color-new-purple-900: #0d0225;--color-editor-background: #fafafa;--color-editor-foreground-text: #383a42;--color-editor-secondary-text: #4078f2;--color-primary-background: #fff;--color-primary-inverted-background: #111;--color-secondary-background: #f9f9f9;--color-background-overlay: rgba(0, 0, 0, .8);--text-primary-inverted: #fff;--text-primary: var(--color-black);--color-link: var(--color-purple);--logo-background-color: #6c37f4;--logo-border-color: #0b0222;--color-brand-pastel-dark: #bcb3d3;--size-xxxLarge: 56px;--size-xxLarge: 48px;--size-xLarge: 32px;--size-large: 24px;--size-medium: 16px;--size-small: 12px;--size-xSmall: 8px;--size-xxSmall: 4px;--size-icon: 18px;--box-shadow: 0px .9px 1.4px rgba(0, 0, 0, .012), 0px 2.2px 3.6px rgba(0, 0, 0, .018), 0px 4.4px 7.4px rgba(0, 0, 0, .022), 0px 9.1px 15.3px rgba(0, 0, 0, .028), 0px 25px 42px rgba(0, 0, 0, .04);--box-shadow-2: 0 3px 6px -4px rgb(0 0 0 / 12%), 0 6px 16px 0 rgb(0 0 0 / 8%), 0 9px 28px 8px rgb(0 0 0 / 5%);--box-shadow-3: 0 2.8px 2.2px rgba(0, 0, 0, .02), 0 6.7px 5.3px rgba(0, 0, 0, .028), 0 12.5px 10px rgba(0, 0, 0, .035), 0 22.3px 17.9px rgba(0, 0, 0, .042), 0 41.8px 33.4px rgba(0, 0, 0, .05), 0 100px 80px rgba(0, 0, 0, .07);--header-font-family: "Steradian", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;--body-font-family: "Steradian", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";--monospace-font-family: "Roboto Mono", monospace;--button-border-radius: var(--size-xSmall);--border-radius: var(--size-xSmall);--header-height: 45px;--banner-height: 32px;--color-error-resolved: var(--color-green-400);--color-error-ignored: var(--color-gray-500);--color-error-open: var(--color-red-400);--color-scrubber-zoom-region-border: #565656;--color-scrubber-zoom-region: #56565622;--color-scrubber-zoom-handle: #757575;--color-scrubber-scrub-handle: #ca0000;--color-scrubber-inactive-region: #f0f0f0a6}[data-theme=dark]{--color-purple-100: #bea8f1;--color-purple-200: #301e79;--color-purple-300: #eee7ff;--color-purple-400: #a17ce4;--color-purple: #7856ff;--color-purple-800: #302c3a;--color-blue-100: #deebff;--color-blue-200: #b2d4ff;--color-blue-300: #56ccf2;--color-blue-400: #2d9cdb;--color-blue-500: #2f80ed;--color-green-100: #beff6c5e;--color-green-300: #6fcf97;--color-green-400: #27ae60;--color-green-500: #219653;--color-green-600: #006400;--color-yellow-200: #ffd82c;--color-yellow: #f2c94c;--color-orange-300: rgba(242, 106, 76, .37);--color-orange-400: #ffb038;--color-orange-500: #c67e29;--color-brown: #835e00;--color-red-100: #fee2e2;--color-red-200: #fecaca;--color-red-300: #fca5a5;--color-red-400: #f87171;--color-red-500: #ef4444;--color-red-600: #dc2626;--color-red-700: #b91c1c;--color-red-800: #991b1b;--color-red-900: #7f1d1d;--color-gray-100: #1a1a1a;--color-gray-200: #333333;--color-gray-300: #333333;--color-gray-400: #595959;--color-gray-500: #8c8c8c;--color-gray-600: #a6a6a6;--color-gray-700: #cccccc;--color-gray-800: #f2f2f2;--color-black: #111;--color-white: #fff;--color-editor-background: #111;--color-editor-foreground-text: var(--color-gray-700);--color-editor-secondary-text: #4078f2;--color-primary-background: #1f2023;--color-primary-inverted-background: #000;--color-secondary-background: var(--color-gray-200);--color-background-overlay: rgba(0, 0, 0, .8);--text-primary-inverted: #1f2023;--text-primary: #f6f6f6;--color-link: var(--color-purple)}body{background-color:var(--color-primary-background)!important;color:var(--text-primary);font-family:var(--body-font-family)!important;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-weight:400!important;margin:0;text-rendering:geometricPrecision}h1,h2,h3,h4,h5,h6{font-family:var(--header-font-family);margin:0;color:var(--text-primary)}h2{font-size:28px}h3{font-size:20px}h4{font-weight:400!important}p{line-height:initial!important;margin:var(--size-small) 0!important}li,p,label{color:var(--text-primary)}h3{margin-bottom:var(--size-xSmall)!important}h4{margin-bottom:var(--size-xxSmall)!important}h4:last-of-type{margin-bottom:0!important}button{font-family:var(--header-font-family)!important;font-weight:400!important}input{font-weight:400!important}.atom-overlay{color:#00f;z-index:1000000}a{color:var(--color-link)}.blob{height:15px;margin:10px;width:15px}.css-foqpf7{width:100%!important}.ant-slider-rail{background-color:#d3d3d3}.ant-slider-track,.ant-slider-track:hover,.ant-slider:hover .ant-slider-track{background-color:var(--color-purple)}.ant-slider:hover .ant-slider-handle:not(.ant-tooltip-open){border-color:var(--color-purple)}.ant-slider-dot,.ant-slider-handle{border-color:var(--color-purple)}.ant-slider-handle:focus{border-color:var(--color-purple);box-shadow:0 0 0 5px #5629c61f}.ant-slider-handle:hover{border-color:var(--color-purple)}.ant-slider-handle-dragging.ant-slider-handle-dragging.ant-slider-handle-dragging{border-color:var(--color-purple);box-shadow:0 0 0 5px #5629c61f}.ant-switch-checked{background-color:var(--color-purple)}.ant-message{z-index:99999999999!important}.ant-message-notice-content{background:#1f1f1f;border-radius:8px;color:var(--color-primary-background)}.ant-tooltip{z-index:99999!important}.ant-tooltip-inner{border-radius:6px}.ant-skeleton-content .ant-skeleton-title{border-radius:5px}.ant-skeleton-content .ant-skeleton-paragraph>li{border-radius:5px}.ant-select-item-option-active:not(.ant-select-item-option-disabled){background-color:var(--color-gray-200)!important}.ant-select-item-option-selected:not(.ant-select-item-option-disabled){background-color:var(--color-purple)!important;color:var(--text-primary-inverted)!important;font-weight:400!important}.ant-select-item{padding-top:var(--size-xSmall)!important;padding-bottom:var(--size-xSmall)!important;padding-left:var(--size-small)!important;padding-right:var(--size-small)!important}code{border-radius:4px;line-height:2;margin:0;font-family:var(--monospace-font-family)}code:not([class]){background-color:var(--color-secondary-background);border:1px solid var(--color-gray-300);font-size:87.5%;padding:1px 3px}.ant-dropdown-menu{padding:0!important;border:1px solid var(--color-gray-300)!important;border-radius:var(--border-radius)!important;box-shadow:var(--box-shadow)!important}.ant-dropdown-menu-item{border-radius:0!important;padding-top:var(--size-small)!important;padding-left:var(--size-xSmall)!important;padding-right:var(--size-xSmall)!important;padding-bottom:var(--size-small)!important}.ant-dropdown-menu-item:hover,.ant-dropdown-menu-submenu-title:hover{background-color:var(--color-gray-200)!important}strong{font-weight:500!important}.pulse{animation:pulse 2s infinite}@keyframes pulse{0%{box-shadow:0 0 0 0 rgba(var(--pulse-color),.7);transform:scale(.95)}70%{box-shadow:0 0 0 10px rgba(var(--pulse-color),0);transform:scale(1)}to{box-shadow:0 0 0 0 rgba(var(--pulse-color),0);transform:scale(.95)}}.ant-modal-mask{z-index:99999999!important}.container{width:100%}@media (min-width: 640px){.container{max-width:640px}}@media (min-width: 768px){.container{max-width:768px}}@media (min-width: 1024px){.container{max-width:1024px}}@media (min-width: 1280px){.container{max-width:1280px}}@media (min-width: 1536px){.container{max-width:1536px}}.visible,.\!visible{visibility:visible!important}.invisible{visibility:hidden!important}.static{position:static!important}.fixed{position:fixed!important}.absolute{position:absolute!important}.relative{position:relative!important}.sticky{position:sticky!important}.inset-x-0{left:0!important;right:0!important}.right-5{right:1.25rem!important}.top-5{top:1.25rem!important}.top-0{top:0!important}.left-0{left:0!important}.bottom-0{bottom:0!important}.float-right{float:right!important}.m-0{margin:0!important}.m-4{margin:1rem!important}.mx-0{margin-left:0!important;margin-right:0!important}.my-6{margin-top:1.5rem!important;margin-bottom:1.5rem!important}.mt-4{margin-top:1rem!important}.mb-0{margin-bottom:0!important}.mb-4{margin-bottom:1rem!important}.mt-1{margin-top:.25rem!important}.mr-8{margin-right:2rem!important}.mb-3{margin-bottom:.75rem!important}.mb-6{margin-bottom:1.5rem!important}.mb-8{margin-bottom:2rem!important}.ml-auto{margin-left:auto!important}.mt-6{margin-top:1.5rem!important}.block{display:block!important}.inline-block{display:inline-block!important}.inline{display:inline!important}.flex{display:flex!important}.inline-flex{display:inline-flex!important}.table{display:table!important}.grid{display:grid!important}.contents{display:contents!important}.hidden{display:none!important}.h-full{height:100%!important}.h-\[18px\]{height:18px!important}.h-\[20px\]{height:20px!important}.h-8{height:2rem!important}.max-h-48{max-height:12rem!important}.w-full{width:100%!important}.w-11\/12{width:91.666667%!important}.w-\[672px\]{width:672px!important}.w-\[20px\]{width:20px!important}.w-8{width:2rem!important}.max-w-lg{max-width:32rem!important}.max-w-\[150px\]{max-width:150px!important}.flex-shrink{flex-shrink:1!important}.flex-grow,.grow{flex-grow:1!important}.transform{transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skew(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))!important}.cursor-pointer{cursor:pointer!important}.resize{resize:both!important}.auto-cols-fr{grid-auto-columns:minmax(0,1fr)!important}.grid-flow-col{grid-auto-flow:column!important}.grid-cols-4{grid-template-columns:repeat(4,minmax(0,1fr))!important}.flex-row{flex-direction:row!important}.flex-col{flex-direction:column!important}.flex-wrap{flex-wrap:wrap!important}.items-center{align-items:center!important}.justify-end{justify-content:flex-end!important}.justify-center{justify-content:center!important}.justify-between{justify-content:space-between!important}.justify-around{justify-content:space-around!important}.gap-1{gap:.25rem!important}.gap-6{gap:1.5rem!important}.gap-5{gap:1.25rem!important}.gap-2{gap:.5rem!important}.gap-8{gap:2rem!important}.gap-3{gap:.75rem!important}.gap-x-4{column-gap:1rem!important}.gap-x-2{column-gap:.5rem!important}.gap-x-1{column-gap:.25rem!important}.overflow-hidden{overflow:hidden!important}.overflow-x-auto{overflow-x:auto!important}.overflow-y-scroll{overflow-y:scroll!important}.truncate{overflow:hidden!important;text-overflow:ellipsis!important;white-space:nowrap!important}.text-ellipsis{text-overflow:ellipsis!important}.whitespace-nowrap{white-space:nowrap!important}.break-normal{overflow-wrap:normal!important;word-break:normal!important}.rounded{border-radius:.25rem!important}.rounded-md{border-radius:.375rem!important}.rounded-none{border-radius:0!important}.rounded-lg{border-radius:.5rem!important}.border,.\!border{border-width:1px!important}.border-0{border-width:0px!important}.border-t{border-top-width:1px!important}.border-solid{border-style:solid!important}.border-gray-300{--tw-border-opacity: 1 !important;border-color:rgb(209 213 219 / var(--tw-border-opacity))!important}.border-transparent{border-color:transparent!important}.border-\[\#eaeaea\]{--tw-border-opacity: 1 !important;border-color:rgb(234 234 234 / var(--tw-border-opacity))!important}.bg-white{--tw-bg-opacity: 1 !important;background-color:rgb(255 255 255 / var(--tw-bg-opacity))!important}.p-0{padding:0!important}.p-8{padding:2rem!important}.p-2{padding:.5rem!important}.p-6{padding:1.5rem!important}.px-8{padding-left:2rem!important;padding-right:2rem!important}.py-6{padding-top:1.5rem!important;padding-bottom:1.5rem!important}.px-4{padding-left:1rem!important;padding-right:1rem!important}.py-0{padding-top:0!important;padding-bottom:0!important}.pb-5{padding-bottom:1.25rem!important}.pt-6{padding-top:1.5rem!important}.pb-20{padding-bottom:5rem!important}.pl-3{padding-left:.75rem!important}.pr-5{padding-right:1.25rem!important}.pt-0{padding-top:0!important}.text-center{text-align:center!important}.align-middle{vertical-align:middle!important}.text-xs{font-size:.75rem!important;line-height:1rem!important}.text-2xl{font-size:1.5rem!important;line-height:2rem!important}.text-base{font-size:1rem!important;line-height:1.5rem!important}.font-medium{font-weight:500!important}.uppercase{text-transform:uppercase!important}.lowercase{text-transform:lowercase!important}.capitalize{text-transform:capitalize!important}.italic{font-style:italic!important}.leading-normal{line-height:1.5!important}.text-primary-3{--tw-text-opacity: 1 !important;color:rgb(84 32 209 / var(--tw-text-opacity))!important}.text-gray-500{--tw-text-opacity: 1 !important;color:rgb(107 114 128 / var(--tw-text-opacity))!important}.text-red-600{--tw-text-opacity: 1 !important;color:rgb(220 38 38 / var(--tw-text-opacity))!important}.underline{text-decoration-line:underline!important}.shadow{--tw-shadow: 0 1px 3px 0 rgb(0 0 0 / .1), 0 1px 2px -1px rgb(0 0 0 / .1) !important;--tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color) !important;box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000),var(--tw-ring-shadow, 0 0 #0000),var(--tw-shadow)!important}.outline,.\!outline{outline-style:solid!important}.blur{--tw-blur: blur(8px) !important;filter:var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)!important}.blur-xs{--tw-blur: blur(2px) !important;filter:var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)!important}.invert{--tw-invert: invert(100%) !important;filter:var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)!important}.filter,.\!filter{filter:var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)!important}.backdrop-filter{backdrop-filter:var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia)!important}.transition{transition-property:color,background-color,border-color,text-decoration-color,fill,stroke,opacity,box-shadow,transform,filter,backdrop-filter!important;transition-timing-function:cubic-bezier(.4,0,.2,1)!important;transition-duration:.15s!important}.ease-in-out{transition-timing-function:cubic-bezier(.4,0,.2,1)!important}.hover\:bg-neutral-100:hover{--tw-bg-opacity: 1 !important;background-color:rgb(245 245 245 / var(--tw-bg-opacity))!important}.focus\:outline-none:focus{outline:2px solid transparent!important;outline-offset:2px!important}.focus-visible\:bg-neutral-100:focus-visible{--tw-bg-opacity: 1 !important;background-color:rgb(245 245 245 / var(--tw-bg-opacity))!important}._buttonBase_14ocv_1{align-items:center;color:var(--text-primary)!important;display:flex;height:auto;padding-bottom:8px;padding-top:8px}._buttonBase_14ocv_1.ant-btn-primary{color:var(--color-white)!important}._buttonBase_14ocv_1[disabled]{color:var(--text-primary-inverted)!important}._buttonBase_14ocv_1.ant-btn-block{justify-content:center}._buttonBase_14ocv_1._iconButton_14ocv_18{align-items:center;border-radius:50%;color:var(--text-primary);display:flex;height:var(--size-xLarge);justify-content:center;padding:0;width:var(--size-xLarge)}._buttonBase_14ocv_1._iconButton_14ocv_18.ant-btn-sm{height:var(--size-small);width:var(--size-small)}._buttonBase_14ocv_1._iconButton_14ocv_18.ant-btn[disabled]{background:var(--color-gray-300)!important;border-color:var(--color-gray-400)!important;fill:var(--color-gray-500)!important}._buttonBase_14ocv_1._iconButton_14ocv_18:hover{background-color:var(--color-gray-200)}._buttonBase_14ocv_1._iconButton_14ocv_18 svg{height:var(--size-icon);width:var(--size-icon)}._buttonBase_14ocv_1._small_14ocv_44 svg{height:var(--size-small);width:var(--size-small)}._buttonBase_14ocv_1.ant-btn-ghost{border-color:var(--color-gray-300)!important}._buttonBase_14ocv_1.ant-btn-text:hover{background:var(--color-gray-200)!important}._buttonBase_14ocv_1.ant-btn-default.ant-btn-dangerous{color:var(--color-red-400)!important}._small_14ocv_44{padding-bottom:var(--size-xxSmall);padding-left:var(--size-small);padding-right:var(--size-small);padding-top:var(--size-xxSmall)}._link_14ocv_65{border:0;display:inline;font-size:inherit;line-height:inherit;margin:0;padding:0}._pulse_14ocv_74{animation:_pulse_14ocv_74 2s infinite}@keyframes _pulse_14ocv_74{0%{box-shadow:0 0 0 0 rgba(var(--pulse-color),.7)}70%{box-shadow:0 0 0 10px rgba(var(--pulse-color),0)}to{box-shadow:0 0 0 0 rgba(var(--pulse-color),0)}}._link_z3guv_1{background:var(--color-purple);border:1px solid transparent!important;border-radius:var(--button-border-radius);color:var(--color-white)!important;display:block;font-family:var(--header-font-family);padding-bottom:var(--size-xSmall);padding-left:var(--size-medium);padding-right:var(--size-medium);padding-top:var(--size-xSmall);text-align:center;width:max-content}._link_z3guv_1:hover{color:var(--text-primary-inverted)}._link_z3guv_1._withIcon_z3guv_18{align-items:center;column-gap:var(--size-medium);display:flex}._link_z3guv_1._fullWidth_z3guv_23{justify-content:center;width:100%}._link_z3guv_1._to_z3guv_27:hover,._link_z3guv_1._to_z3guv_27:active,._link_z3guv_1._to_z3guv_27:focus{background:var(--color-purple-600);border-color:var(--color-purple-600)}._link_z3guv_1._defaultButtonStyles_z3guv_31{background:var(--color-primary-background)!important;border:1px solid var(--color-gray-400)!important;box-sizing:border-box;color:var(--text-primary)!important}._link_z3guv_1:disabled{background:var(--color-purple);color:var(--color-purple-200)}._link_z3guv_1:disabled:hover{background:var(--color-purple)}._space_1oubz_1{display:flex;flex-direction:row}._alignStart_1oubz_6{align-items:flex-start}._alignEnd_1oubz_10{align-items:flex-end}._alignCenter_1oubz_14{align-items:center}._verticalDirection_1oubz_18{flex-direction:column}._wrap_1oubz_22{flex-wrap:wrap}._xxSmall_1oubz_26{gap:var(--size-xxSmall)}._xSmall_1oubz_30{gap:var(--size-xSmall)}._small_1oubz_34{gap:var(--size-small)}._medium_1oubz_38{gap:var(--size-medium)}._large_1oubz_42{gap:var(--size-large)}._xLarge_1oubz_46{gap:var(--size-xLarge)}._xxLarge_1oubz_50{gap:var(--size-xxLarge)}@keyframes _1wdh3sj0{0%{transform:rotate(0)}to{transform:rotate(360deg)}}._1wdh3sj1{animation-name:_1wdh3sj0;animation-duration:1s;animation-iteration-count:infinite;animation-timing-function:linear}._demoWorkspaceButton_am6u9_1{background-color:var(--color-primary-inverted-background);border:0;border-radius:var(--border-radius);column-gap:var(--size-xSmall)}._demoWorkspaceButton_am6u9_1:hover,._demoWorkspaceButton_am6u9_1:active,._demoWorkspaceButton_am6u9_1:focus{background-color:var(--color-gray-800);border:0}._userAvatarWrapper_12k1r_1{border-radius:50%;height:max-content}._userAvatarBorder_12k1r_6{border:4px solid var(--color-black);box-shadow:var(--box-shadow)}._userAvatar_12k1r_1{border-radius:50%}._userAvatarText_12k1r_15{align-items:center;border-radius:50%;display:flex;font-family:var(--header-font-family);font-weight:500;justify-content:center;line-height:initial}._dropdownName_1f2xb_1{font-size:16px;margin-bottom:2px}._dropdownEmail_1f2xb_6{color:var(--color-gray-500);margin:0!important;margin-top:var(--size-xSmall)!important}._logoutIcon_1f2xb_12{height:16px;margin-left:auto;width:16px}._avatarWrapper_1f2xb_18{align-items:center;display:flex;justify-content:center;padding:10px}._userInfoWrapper_1f2xb_25{align-items:center;border-bottom:1px solid var(--color-gray-300);display:flex;flex-direction:row;justify-self:center}._dropdownInner_1f2xb_33{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:8px;box-shadow:var(--box-shadow);color:var(--text-primary);margin-top:-10px;overflow:hidden}._dropdownMyAccount_1f2xb_43{align-items:center;display:flex;padding:var(--size-xSmall) var(--size-medium);transition:.2s;width:100%}._dropdownMyAccount_1f2xb_43:hover{background-color:var(--color-purple-200)}._dropdownLogout_1f2xb_54{align-items:center;color:var(--color-red-400);cursor:pointer;display:flex;padding:var(--size-xSmall) var(--size-medium);transition:.2s;width:100%}._dropdownLogout_1f2xb_54:hover{background-color:var(--color-red-200)}._dropdownLogoutText_1f2xb_67{font-size:16px}._dropdownMenu_1f2xb_71{box-shadow:none;min-width:200px}._accountIconWrapper_1f2xb_76{align-items:center;cursor:pointer;display:flex;height:100%;justify-content:center}._accountIcon_1f2xb_76{cursor:pointer;fill:var(--color-purple);height:25px;margin-right:30px;width:25px}._userCopy_1f2xb_92{padding:14px 25px 14px 6px}._1ta0zd10{width:280px}._errorWrapper_yb6kl_1{align-items:center;background:var(--color-primary-500);display:flex;height:100vh;justify-content:center;width:100vw}._errorWrapper_yb6kl_1._shownWithHeader_yb6kl_9{background:var(--color-primary-background);height:calc(100vh - var(--header-height))}._errorWrapper_yb6kl_1>div{max-width:360px}._errorBody_yb6kl_17{color:var(--color-black);max-width:800px;word-wrap:break-word;margin:0!important}._buttonGroup_yb6kl_24{display:flex}._loggedInButtonGroup_yb6kl_28{display:flex;justify-content:space-between;width:100%}._spinnerStyle_xtyfi_1{align-items:center;display:flex;justify-content:center;width:100px;z-index:10}._spinnerWrapper_xtyfi_9{align-items:center;display:flex;height:100%;justify-content:center;width:100%}._loadingWrapper_xtyfi_17{align-items:center;background:var(--color-primary-background);display:flex;height:100vh;justify-content:center;position:absolute;width:100vw;z-index:9999999999}._loadingFlexWrapper_xtyfi_28{height:100%;width:100%}._background_xtyfi_33{--background-color: var(--color-primary-background);--dot-color: var(--color-gray-200);--dot-size: 2px;--square-size: 50px;background-image:radial-gradient(var(--dot-color) var(--dot-size),var(--background-color) var(--dot-size));background-position:0 0;background-size:var(--square-size) var(--square-size);height:100vh;position:absolute;width:100vw;z-index:-1}._logoContainer_xtyfi_47{--logo-size: 60px;display:grid;height:var(--logo-size);width:var(--logo-size)}._logoContainer_xtyfi_47 ._logo_xtyfi_47{grid-column-start:1;grid-row-start:1;height:var(--logo-size);width:var(--logo-size);z-index:2}._logoContainer_xtyfi_47 ._logo_xtyfi_47 svg{height:100%;width:100%}._logoContainer_xtyfi_47 ._logoBackground_xtyfi_64{background:var(--logo-background-color);border:2px solid var(--logo-border-color);border-radius:50%;grid-column-start:1;grid-row-start:1;height:var(--logo-size);transform-origin:center;width:var(--logo-size)}.App{text-align:center}.Collapsible__contentInner{margin:1px}.ant-picker-input input::placeholder{color:var(--color-gray-500);font-size:14px;font-weight:300}.ant-picker-suffix{color:var(--color-gray-500)}.ant-picker-input>input{font-weight:300}.ant-picker-dropdown{z-index:9999999999!important}.ant-dropdown{z-index:999999!important}.ant-dropdown-menu-item{font-family:var(--header-font-family)}.ant-tabs{height:100%}.ant-tabs-nav-wrap{padding-bottom:0;padding-left:var(--size-large);padding-right:var(--size-large);padding-top:0}.ant-tabs-content{display:flex;height:100%;width:100%}.ant-tabs-tab-btn{color:var(--color-gray-500);font-size:14px;outline:none;outline-color:initial;outline-style:none;outline-width:initial;transition:all .3s}.ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn{color:var(--text-primary)!important}.ant-tabs-tab{margin:0 16px!important}.ant-tabs-tab:after{background:var(--color-gray-400);border-radius:5px;bottom:0;content:"";height:3px;opacity:0;position:absolute;transition:opacity .2s ease-in-out;width:100%}.ant-tabs-tab:hover.ant-tabs-tab:after{opacity:1}.ant-tabs-ink-bar{background:var(--text-primary)!important;border-radius:5px;height:3px!important}.ant-tabs-nav{margin-bottom:0!important}.ant-tabs-top>.ant-tabs-nav:before,.ant-tabs-bottom>.ant-tabs-nav:before,.ant-tabs-top>div>.ant-tabs-nav:before,.ant-tabs-bottom>div>.ant-tabs-nav:before{border-bottom:1px solid var(--color-gray-300)!important}.ant-popover-inner-content{padding-bottom:0!important}input[name=option-input]{background-color:transparent!important;border:0!important;font-weight:300;outline:none!important}.Collapsible{width:100%}.replayer-wrapper{position:absolute}.rc-slider{cursor:pointer;padding:0!important}iframe{background-color:var(--color-primary-background);border:0;z-index:-10}.ant-table-cell{border-bottom:0!important;cursor:pointer;padding:0!important}.ant-table-cell>*{align-items:center;display:flex;height:100%}.ant-table-body{overflow-y:auto!important}._label_oj421_1{align-items:center;color:var(--color-gray-500);column-gap:var(--size-xSmall);display:flex;line-height:normal;transition:color .2s ease-in}._label_oj421_1._checked_oj421_9{color:var(--text-primary)}._label_oj421_1._checked_oj421_9._red_oj421_12{color:var(--color-red)}._label_oj421_1._spaceBetween_oj421_15{display:flex;justify-content:space-between}._label_oj421_1._noMarginAroundSwitch_oj421_19{margin:0}._label_oj421_1._setMarginForAnimation_oj421_22{margin:6px}._switchStyles_oj421_26{background:var(--color-gray-400)}._switchStyles_oj421_26.ant-switch-checked{background:var(--color-purple)}._switchStyles_oj421_26.ant-switch-checked._red_oj421_12{background:var(--color-red)}._2hsj210{margin-bottom:6px}._2hsj211{width:100%}.highlight-light-theme{--_1pyqka90: #fdfcfd;--_1pyqka91: #ffffff;--_1pyqka92: #f9f8f9;--_1pyqka93: #f4f2f4;--_1pyqka94: rgba(26, 21, 35, .72);--_1pyqka95: #ddf3e4;--_1pyqka96: #ffecbc;--_1pyqka97: #ffe5e5;--_1pyqka98: #ede7fe;--_1pyqka99: #eeedef;--_1pyqka9a: #1a1523;--_1pyqka9b: rgba(26, 21, 35, .72);--_1pyqka9c: #6f6e77;--_1pyqka9d: rgba(111, 110, 119, .8);--_1pyqka9e: #18794e;--_1pyqka9f: #ad5700;--_1pyqka9g: #cd2b31;--_1pyqka9h: #6346af;--_1pyqka9i: #c8c7cb;--_1pyqka9j: #dcdbdd;--_1pyqka9k: #ebe9eb;--_1pyqka9l: #744ed4;--_1pyqka9m: #6b48c7;--_1pyqka9n: #6346af;--_1pyqka9o: rgba(116, 78, 212, .24);--_1pyqka9p: #ffffff;--_1pyqka9q: rgba(32, 16, 77, .36);--_1pyqka9r: #6346af;--_1pyqka9s: #eeedef;--_1pyqka9t: #e9e8ea;--_1pyqka9u: #e4e2e4;--_1pyqka9v: #f4f2f4;--_1pyqka9w: rgba(26, 21, 35, .72);--_1pyqka9x: #c8c7cb;--_1pyqka9y: #6f6e77;--_1pyqka9z: #e5484d;--_1pyqka910: #dc3d43;--_1pyqka911: #cd2b31;--_1pyqka912: rgba(229, 72, 77, .24);--_1pyqka913: #ffffff;--_1pyqka914: rgba(56, 19, 22, .36);--_1pyqka915: #cd2b31;--_1pyqka916: #ffb224;--_1pyqka917: #ffa01c;--_1pyqka918: #ee9d2b;--_1pyqka919: rgba(255, 178, 36, .24);--_1pyqka91a: #4e2009;--_1pyqka91b: rgba(78, 32, 9, .36);--_1pyqka91c: #ad5700;--_1pyqka91d: #30a46c;--_1pyqka91e: #299764;--_1pyqka91f: #18794e;--_1pyqka91g: rgba(48, 164, 108, .24);--_1pyqka91h: #ffffff;--_1pyqka91i: rgba(21, 50, 38, .36);--_1pyqka91j: #18794e;--_1pyqka91k: #d9cdf9;--_1pyqka91l: #c9b9f3;--_1pyqka91m: #af98ec;--_1pyqka91n: #f4f0ff;--_1pyqka91o: #dcdbdd;--_1pyqka91p: #c8c7cb;--_1pyqka91q: #c8c7cb;--_1pyqka91r: #f4f2f4;--_1pyqka91s: rgba(237, 231, 254, 0);--_1pyqka91t: #ede7fe;--_1pyqka91u: #e7defc;--_1pyqka91v: rgba(237, 231, 254, 0);--_1pyqka91w: rgba(238, 237, 239, 0);--_1pyqka91x: #eeedef;--_1pyqka91y: #e9e8ea;--_1pyqka91z: rgba(238, 237, 239, 0);--_1pyqka920: rgba(238, 237, 239, .64);--_1pyqka921: rgba(238, 237, 239, .84)}.mt0ih20{align-items:stretch}.mt0ih21{align-items:flex-start}.mt0ih22{align-items:center}.mt0ih23{align-items:flex-end}.mt0ih24{border-radius:2px}.mt0ih25{border-radius:3px}.mt0ih26{border-radius:4px}.mt0ih27{border-radius:5px}.mt0ih28{border-radius:6px}.mt0ih29{border-radius:8px}.mt0ih2a{border-radius:10px}.mt0ih2b{border-radius:12px}.mt0ih2c{border-radius:16px}.mt0ih2d{border-radius:23px}.mt0ih2e{border-radius:999px}.mt0ih2f{border-radius:inherit}.mt0ih2g{border-top-left-radius:2px}.mt0ih2h{border-top-left-radius:3px}.mt0ih2i{border-top-left-radius:4px}.mt0ih2j{border-top-left-radius:5px}.mt0ih2k{border-top-left-radius:6px}.mt0ih2l{border-top-left-radius:8px}.mt0ih2m{border-top-left-radius:10px}.mt0ih2n{border-top-left-radius:12px}.mt0ih2o{border-top-left-radius:16px}.mt0ih2p{border-top-left-radius:23px}.mt0ih2q{border-top-left-radius:999px}.mt0ih2r{border-top-left-radius:inherit}.mt0ih2s{border-top-right-radius:2px}.mt0ih2t{border-top-right-radius:3px}.mt0ih2u{border-top-right-radius:4px}.mt0ih2v{border-top-right-radius:5px}.mt0ih2w{border-top-right-radius:6px}.mt0ih2x{border-top-right-radius:8px}.mt0ih2y{border-top-right-radius:10px}.mt0ih2z{border-top-right-radius:12px}.mt0ih210{border-top-right-radius:16px}.mt0ih211{border-top-right-radius:23px}.mt0ih212{border-top-right-radius:999px}.mt0ih213{border-top-right-radius:inherit}.mt0ih214{border-bottom-left-radius:2px}.mt0ih215{border-bottom-left-radius:3px}.mt0ih216{border-bottom-left-radius:4px}.mt0ih217{border-bottom-left-radius:5px}.mt0ih218{border-bottom-left-radius:6px}.mt0ih219{border-bottom-left-radius:8px}.mt0ih21a{border-bottom-left-radius:10px}.mt0ih21b{border-bottom-left-radius:12px}.mt0ih21c{border-bottom-left-radius:16px}.mt0ih21d{border-bottom-left-radius:23px}.mt0ih21e{border-bottom-left-radius:999px}.mt0ih21f{border-bottom-left-radius:inherit}.mt0ih21g{border-bottom-right-radius:2px}.mt0ih21h{border-bottom-right-radius:3px}.mt0ih21i{border-bottom-right-radius:4px}.mt0ih21j{border-bottom-right-radius:5px}.mt0ih21k{border-bottom-right-radius:6px}.mt0ih21l{border-bottom-right-radius:8px}.mt0ih21m{border-bottom-right-radius:10px}.mt0ih21n{border-bottom-right-radius:12px}.mt0ih21o{border-bottom-right-radius:16px}.mt0ih21p{border-bottom-right-radius:23px}.mt0ih21q{border-bottom-right-radius:999px}.mt0ih21r{border-bottom-right-radius:inherit}.mt0ih21s{cursor:default}.mt0ih21t{cursor:pointer}.mt0ih21u{display:none}.mt0ih21v{display:flex}.mt0ih21w{display:block}.mt0ih21x{display:inline}.mt0ih21y{display:inline-block}.mt0ih21z{display:inline-flex}.mt0ih220{position:absolute}.mt0ih221{position:fixed}.mt0ih222{position:relative}.mt0ih223{position:static}.mt0ih224{position:sticky}.mt0ih225{text-align:left}.mt0ih226{text-align:center}.mt0ih227{text-align:right}.mt0ih228{gap:0}.mt0ih229{gap:1px}.mt0ih22a{gap:2px}.mt0ih22b{gap:3px}.mt0ih22c{gap:4px}.mt0ih22d{gap:6px}.mt0ih22e{gap:7px}.mt0ih22f{gap:8px}.mt0ih22g{gap:9px}.mt0ih22h{gap:10px}.mt0ih22i{gap:12px}.mt0ih22j{gap:16px}.mt0ih22k{gap:20px}.mt0ih22l{gap:24px}.mt0ih22m{gap:28px}.mt0ih22n{gap:32px}.mt0ih22o{gap:40px}.mt0ih22p{flex:1 1 0}.mt0ih22q{flex:0 0 auto}.mt0ih22r{flex-basis:0}.mt0ih22s{flex-basis:1px}.mt0ih22t{flex-direction:row}.mt0ih22u{flex-direction:column}.mt0ih22v{flex-direction:column-reverse}.mt0ih22w{flex-grow:0}.mt0ih22x{flex-grow:1}.mt0ih22y{flex-shrink:0}.mt0ih22z{flex-wrap:wrap}.mt0ih230{flex-wrap:nowrap}.mt0ih231{justify-content:stretch}.mt0ih232{justify-content:flex-start}.mt0ih233{justify-content:center}.mt0ih234{justify-content:flex-end}.mt0ih235{justify-content:space-around}.mt0ih236{justify-content:space-between}.mt0ih237{justify-self:stretch}.mt0ih238{justify-self:flex-start}.mt0ih239{justify-self:center}.mt0ih23a{justify-self:flex-end}.mt0ih23b{justify-self:space-around}.mt0ih23c{justify-self:space-between}.mt0ih23d{padding:0}.mt0ih23e{padding:1px}.mt0ih23f{padding:2px}.mt0ih23g{padding:3px}.mt0ih23h{padding:4px}.mt0ih23i{padding:6px}.mt0ih23j{padding:7px}.mt0ih23k{padding:8px}.mt0ih23l{padding:9px}.mt0ih23m{padding:10px}.mt0ih23n{padding:12px}.mt0ih23o{padding:16px}.mt0ih23p{padding:20px}.mt0ih23q{padding:24px}.mt0ih23r{padding:28px}.mt0ih23s{padding:32px}.mt0ih23t{padding:40px}.mt0ih23u{padding-top:0}.mt0ih23v{padding-top:1px}.mt0ih23w{padding-top:2px}.mt0ih23x{padding-top:3px}.mt0ih23y{padding-top:4px}.mt0ih23z{padding-top:6px}.mt0ih240{padding-top:7px}.mt0ih241{padding-top:8px}.mt0ih242{padding-top:9px}.mt0ih243{padding-top:10px}.mt0ih244{padding-top:12px}.mt0ih245{padding-top:16px}.mt0ih246{padding-top:20px}.mt0ih247{padding-top:24px}.mt0ih248{padding-top:28px}.mt0ih249{padding-top:32px}.mt0ih24a{padding-top:40px}.mt0ih24b{padding-bottom:0}.mt0ih24c{padding-bottom:1px}.mt0ih24d{padding-bottom:2px}.mt0ih24e{padding-bottom:3px}.mt0ih24f{padding-bottom:4px}.mt0ih24g{padding-bottom:6px}.mt0ih24h{padding-bottom:7px}.mt0ih24i{padding-bottom:8px}.mt0ih24j{padding-bottom:9px}.mt0ih24k{padding-bottom:10px}.mt0ih24l{padding-bottom:12px}.mt0ih24m{padding-bottom:16px}.mt0ih24n{padding-bottom:20px}.mt0ih24o{padding-bottom:24px}.mt0ih24p{padding-bottom:28px}.mt0ih24q{padding-bottom:32px}.mt0ih24r{padding-bottom:40px}.mt0ih24s{padding-left:0}.mt0ih24t{padding-left:1px}.mt0ih24u{padding-left:2px}.mt0ih24v{padding-left:3px}.mt0ih24w{padding-left:4px}.mt0ih24x{padding-left:6px}.mt0ih24y{padding-left:7px}.mt0ih24z{padding-left:8px}.mt0ih250{padding-left:9px}.mt0ih251{padding-left:10px}.mt0ih252{padding-left:12px}.mt0ih253{padding-left:16px}.mt0ih254{padding-left:20px}.mt0ih255{padding-left:24px}.mt0ih256{padding-left:28px}.mt0ih257{padding-left:32px}.mt0ih258{padding-left:40px}.mt0ih259{padding-right:0}.mt0ih25a{padding-right:1px}.mt0ih25b{padding-right:2px}.mt0ih25c{padding-right:3px}.mt0ih25d{padding-right:4px}.mt0ih25e{padding-right:6px}.mt0ih25f{padding-right:7px}.mt0ih25g{padding-right:8px}.mt0ih25h{padding-right:9px}.mt0ih25i{padding-right:10px}.mt0ih25j{padding-right:12px}.mt0ih25k{padding-right:16px}.mt0ih25l{padding-right:20px}.mt0ih25m{padding-right:24px}.mt0ih25n{padding-right:28px}.mt0ih25o{padding-right:32px}.mt0ih25p{padding-right:40px}.mt0ih25q{margin:0}.mt0ih25r{margin:1px}.mt0ih25s{margin:2px}.mt0ih25t{margin:3px}.mt0ih25u{margin:4px}.mt0ih25v{margin:6px}.mt0ih25w{margin:7px}.mt0ih25x{margin:8px}.mt0ih25y{margin:9px}.mt0ih25z{margin:10px}.mt0ih260{margin:12px}.mt0ih261{margin:16px}.mt0ih262{margin:20px}.mt0ih263{margin:24px}.mt0ih264{margin:28px}.mt0ih265{margin:32px}.mt0ih266{margin:40px}.mt0ih267{margin:auto}.mt0ih268{margin-top:0}.mt0ih269{margin-top:1px}.mt0ih26a{margin-top:2px}.mt0ih26b{margin-top:3px}.mt0ih26c{margin-top:4px}.mt0ih26d{margin-top:6px}.mt0ih26e{margin-top:7px}.mt0ih26f{margin-top:8px}.mt0ih26g{margin-top:9px}.mt0ih26h{margin-top:10px}.mt0ih26i{margin-top:12px}.mt0ih26j{margin-top:16px}.mt0ih26k{margin-top:20px}.mt0ih26l{margin-top:24px}.mt0ih26m{margin-top:28px}.mt0ih26n{margin-top:32px}.mt0ih26o{margin-top:40px}.mt0ih26p{margin-top:auto}.mt0ih26q{margin-bottom:0}.mt0ih26r{margin-bottom:1px}.mt0ih26s{margin-bottom:2px}.mt0ih26t{margin-bottom:3px}.mt0ih26u{margin-bottom:4px}.mt0ih26v{margin-bottom:6px}.mt0ih26w{margin-bottom:7px}.mt0ih26x{margin-bottom:8px}.mt0ih26y{margin-bottom:9px}.mt0ih26z{margin-bottom:10px}.mt0ih270{margin-bottom:12px}.mt0ih271{margin-bottom:16px}.mt0ih272{margin-bottom:20px}.mt0ih273{margin-bottom:24px}.mt0ih274{margin-bottom:28px}.mt0ih275{margin-bottom:32px}.mt0ih276{margin-bottom:40px}.mt0ih277{margin-bottom:auto}.mt0ih278{margin-left:0}.mt0ih279{margin-left:1px}.mt0ih27a{margin-left:2px}.mt0ih27b{margin-left:3px}.mt0ih27c{margin-left:4px}.mt0ih27d{margin-left:6px}.mt0ih27e{margin-left:7px}.mt0ih27f{margin-left:8px}.mt0ih27g{margin-left:9px}.mt0ih27h{margin-left:10px}.mt0ih27i{margin-left:12px}.mt0ih27j{margin-left:16px}.mt0ih27k{margin-left:20px}.mt0ih27l{margin-left:24px}.mt0ih27m{margin-left:28px}.mt0ih27n{margin-left:32px}.mt0ih27o{margin-left:40px}.mt0ih27p{margin-left:auto}.mt0ih27q{margin-right:0}.mt0ih27r{margin-right:1px}.mt0ih27s{margin-right:2px}.mt0ih27t{margin-right:3px}.mt0ih27u{margin-right:4px}.mt0ih27v{margin-right:6px}.mt0ih27w{margin-right:7px}.mt0ih27x{margin-right:8px}.mt0ih27y{margin-right:9px}.mt0ih27z{margin-right:10px}.mt0ih280{margin-right:12px}.mt0ih281{margin-right:16px}.mt0ih282{margin-right:20px}.mt0ih283{margin-right:24px}.mt0ih284{margin-right:28px}.mt0ih285{margin-right:32px}.mt0ih286{margin-right:40px}.mt0ih287{margin-right:auto}.mt0ih288{height:100%}.mt0ih289{height:100vh}.mt0ih28a{width:100%}.mt0ih28b{width:100vw}.mt0ih28c{max-height:100%}.mt0ih28d{max-height:100vh}.mt0ih28e{max-width:100%}.mt0ih28f{max-width:100vw}.mt0ih28g{min-height:100%}.mt0ih28h{min-height:100vh}.mt0ih28i{min-width:100%}.mt0ih28j{min-width:100vw}.mt0ih28k{overflow:auto}.mt0ih28l{overflow:hidden}.mt0ih28m{overflow:visible}.mt0ih28n{overflow:scroll}.mt0ih28o{overflow-x:auto}.mt0ih28p{overflow-x:hidden}.mt0ih28q{overflow-x:visible}.mt0ih28r{overflow-x:scroll}.mt0ih28s{overflow-y:auto}.mt0ih28t{overflow-y:hidden}.mt0ih28u{overflow-y:visible}.mt0ih28v{overflow-y:scroll}.mt0ih28w{overflow-wrap:normal}.mt0ih28x{overflow-wrap:break-word}.mt0ih28y{text-transform:none}.mt0ih28z{text-transform:capitalize}.mt0ih290{text-transform:uppercase}.mt0ih291{text-transform:lowercase}.mt0ih292{text-transform:full-width}.mt0ih293{text-transform:full-size-kana}.mt0ih294{user-select:all}.mt0ih295{user-select:auto}.mt0ih296{user-select:none}.mt0ih297{visibility:hidden}.mt0ih298{visibility:visible}.mt0ih299{white-space:normal}.mt0ih29a{white-space:nowrap}.mt0ih29b,.mt0ih29c:hover{background-color:inherit}.mt0ih29d,.mt0ih29e:hover{background-color:#fff}.mt0ih29f,.mt0ih29g:hover{background-color:#000}.mt0ih29h,.mt0ih29i:hover{background-color:#fdfcfd}.mt0ih29j,.mt0ih29k:hover{background-color:#f9f8f9}.mt0ih29l,.mt0ih29m:hover{background-color:#f4f2f4}.mt0ih29n,.mt0ih29o:hover{background-color:#eeedef}.mt0ih29p,.mt0ih29q:hover{background-color:#e9e8ea}.mt0ih29r,.mt0ih29s:hover{background-color:#e4e2e4}.mt0ih29t,.mt0ih29u:hover{background-color:#dcdbdd}.mt0ih29v,.mt0ih29w:hover{background-color:#c8c7cb}.mt0ih29x,.mt0ih29y:hover{background-color:#908e96}.mt0ih29z,.mt0ih2a0:hover{background-color:#86848d}.mt0ih2a1,.mt0ih2a2:hover{background-color:#6f6e77}.mt0ih2a3,.mt0ih2a4:hover{background-color:#1a1523}.mt0ih2a5,.mt0ih2a6:hover{background-color:#fcfbfe}.mt0ih2a7,.mt0ih2a8:hover{background-color:#f8f5ff}.mt0ih2a9,.mt0ih2aa:hover{background-color:#f4f0ff}.mt0ih2ab,.mt0ih2ac:hover{background-color:#ede7fe}.mt0ih2ad,.mt0ih2ae:hover{background-color:#e7defc}.mt0ih2af,.mt0ih2ag:hover{background-color:#d9cdf9}.mt0ih2ah,.mt0ih2ai:hover{background-color:#c9b9f3}.mt0ih2aj,.mt0ih2ak:hover{background-color:#af98ec}.mt0ih2al,.mt0ih2am:hover{background-color:#744ed4}.mt0ih2an,.mt0ih2ao:hover{background-color:#6b48c7}.mt0ih2ap,.mt0ih2aq:hover{background-color:#6346af}.mt0ih2ar,.mt0ih2as:hover{background-color:#20104d}.mt0ih2at,.mt0ih2au:hover{background-color:#fffcfc}.mt0ih2av,.mt0ih2aw:hover{background-color:#fff8f8}.mt0ih2ax,.mt0ih2ay:hover{background-color:#ffefef}.mt0ih2az,.mt0ih2b0:hover{background-color:#ffe5e5}.mt0ih2b1,.mt0ih2b2:hover{background-color:#fdd8d8}.mt0ih2b3,.mt0ih2b4:hover{background-color:#f9c6c6}.mt0ih2b5,.mt0ih2b6:hover{background-color:#f3aeaf}.mt0ih2b7,.mt0ih2b8:hover{background-color:#eb9091}.mt0ih2b9,.mt0ih2ba:hover{background-color:#e5484d}.mt0ih2bb,.mt0ih2bc:hover{background-color:#dc3d43}.mt0ih2bd,.mt0ih2be:hover{background-color:#cd2b31}.mt0ih2bf,.mt0ih2bg:hover{background-color:#381316}.mt0ih2bh,.mt0ih2bi:hover{background-color:#fbfefc}.mt0ih2bj,.mt0ih2bk:hover{background-color:#f2fcf5}.mt0ih2bl,.mt0ih2bm:hover{background-color:#e9f9ee}.mt0ih2bn,.mt0ih2bo:hover{background-color:#ddf3e4}.mt0ih2bp,.mt0ih2bq:hover{background-color:#ccebd7}.mt0ih2br,.mt0ih2bs:hover{background-color:#b4dfc4}.mt0ih2bt,.mt0ih2bu:hover{background-color:#92ceac}.mt0ih2bv,.mt0ih2bw:hover{background-color:#5bb98c}.mt0ih2bx,.mt0ih2by:hover{background-color:#30a46c}.mt0ih2bz,.mt0ih2c0:hover{background-color:#299764}.mt0ih2c1,.mt0ih2c2:hover{background-color:#18794e}.mt0ih2c3,.mt0ih2c4:hover{background-color:#153226}.mt0ih2c5,.mt0ih2c6:hover{background-color:#fefdfb}.mt0ih2c7,.mt0ih2c8:hover{background-color:#fff9ed}.mt0ih2c9,.mt0ih2ca:hover{background-color:#fff4d5}.mt0ih2cb,.mt0ih2cc:hover{background-color:#ffecbc}.mt0ih2cd,.mt0ih2ce:hover{background-color:#ffe3a2}.mt0ih2cf,.mt0ih2cg:hover{background-color:#ffd386}.mt0ih2ch,.mt0ih2ci:hover{background-color:#f3ba63}.mt0ih2cj,.mt0ih2ck:hover{background-color:#ee9d2b}.mt0ih2cl,.mt0ih2cm:hover{background-color:#ffb224}.mt0ih2cn,.mt0ih2co:hover{background-color:#ffa01c}.mt0ih2cp,.mt0ih2cq:hover{background-color:#ad5700}.mt0ih2cr,.mt0ih2cs:hover{background-color:#4e2009}.mt0ih2ct,.mt0ih2cu:hover{background-color:#d6f0ff}.mt0ih2cv,.mt0ih2cw:hover{background-color:#96d5f8}.mt0ih2cx,.mt0ih2cy:hover{background-color:#4fb5ee}.mt0ih2cz,.mt0ih2d0:hover{background-color:#0b75aa}.mt0ih2d1,.mt0ih2d2:hover{background-color:#ebff5e}.mt0ih2d3,.mt0ih2d4:hover{background-color:#8dc31a}.mt0ih2d5,.mt0ih2d6:hover{background-color:#ff5377}.mt0ih2d7,.mt0ih2d8:hover{background-color:#ff9457}.mt0ih2d9,.mt0ih2da:hover{background-color:#36e79b}.mt0ih2db,.mt0ih2dc:hover{background-color:var(--_1pyqka90)}.mt0ih2dd,.mt0ih2de:hover{background-color:var(--_1pyqka91)}.mt0ih2df,.mt0ih2dg:hover{background-color:var(--_1pyqka92)}.mt0ih2dh,.mt0ih2di:hover{background-color:var(--_1pyqka93)}.mt0ih2dj,.mt0ih2dk:hover{background-color:var(--_1pyqka94)}.mt0ih2dl,.mt0ih2dm:hover{background-color:var(--_1pyqka95)}.mt0ih2dn,.mt0ih2do:hover{background-color:var(--_1pyqka98)}.mt0ih2dp,.mt0ih2dq:hover{background-color:var(--_1pyqka96)}.mt0ih2dr,.mt0ih2ds:hover{background-color:var(--_1pyqka9c)}.mt0ih2dt,.mt0ih2du:hover{background-color:var(--_1pyqka9a)}.mt0ih2dv,.mt0ih2dw:hover{background-color:var(--_1pyqka9g)}.mt0ih2dx,.mt0ih2dy:hover{background-color:var(--_1pyqka9e)}.mt0ih2dz,.mt0ih2e0:hover{background-color:var(--_1pyqka9f)}.mt0ih2e1,.mt0ih2e2:hover{background-color:var(--_1pyqka9h)}.mt0ih2e3,.mt0ih2e4:hover{background-color:var(--_1pyqka9d)}.mt0ih2e5,.mt0ih2e6:hover{background-color:var(--_1pyqka91z)}.mt0ih2e7,.mt0ih2e8:hover{background-color:var(--_1pyqka91w)}.mt0ih2e9,.mt0ih2ea:hover{background-color:var(--_1pyqka91x)}.mt0ih2eb,.mt0ih2ec:hover{background-color:var(--_1pyqka91y)}.mt0ih2ed,.mt0ih2ee:hover{background-color:var(--_1pyqka920)}.mt0ih2ef,.mt0ih2eg:hover{background-color:var(--_1pyqka921)}.mt0ih2eh,.mt0ih2ei:hover{background-color:var(--_1pyqka91v)}.mt0ih2ej,.mt0ih2ek:hover{background-color:var(--_1pyqka91s)}.mt0ih2el,.mt0ih2em:hover{background-color:var(--_1pyqka91t)}.mt0ih2en,.mt0ih2eo:hover{background-color:var(--_1pyqka91u)}.mt0ih2ep,.mt0ih2eq:hover{border:0}.mt0ih2er,.mt0ih2es:hover{border:var(--_1pyqka91k) solid 1px}.mt0ih2et,.mt0ih2eu:hover{border:var(--_1pyqka91l) solid 1px}.mt0ih2ev,.mt0ih2ew:hover{border:var(--_1pyqka91m) solid 1px}.mt0ih2ex,.mt0ih2ey:hover{border:var(--_1pyqka91n) solid 1px}.mt0ih2ez,.mt0ih2f0:hover{border:var(--_1pyqka91o) solid 1px}.mt0ih2f1,.mt0ih2f2:hover{border:var(--_1pyqka9z) solid 1px}.mt0ih2f3,.mt0ih2f4:hover{border:var(--_1pyqka91p) solid 1px}.mt0ih2f5,.mt0ih2f6:hover{border:var(--_1pyqka91q) solid 1px}.mt0ih2f7,.mt0ih2f8:hover{border:var(--_1pyqka91r) solid 1px}.mt0ih2f9,.mt0ih2fa:hover{border:var(--_1pyqka9j) solid 1px}.mt0ih2fb,.mt0ih2fc:hover{border:var(--_1pyqka9k) solid 1px}.mt0ih2fd,.mt0ih2fe:hover{border:var(--_1pyqka9i) solid 1px}.mt0ih2ff,.mt0ih2fg:hover{border-top:0}.mt0ih2fh,.mt0ih2fi:hover{border-top:var(--_1pyqka91k) solid 1px}.mt0ih2fj,.mt0ih2fk:hover{border-top:var(--_1pyqka91l) solid 1px}.mt0ih2fl,.mt0ih2fm:hover{border-top:var(--_1pyqka91m) solid 1px}.mt0ih2fn,.mt0ih2fo:hover{border-top:var(--_1pyqka91n) solid 1px}.mt0ih2fp,.mt0ih2fq:hover{border-top:var(--_1pyqka91o) solid 1px}.mt0ih2fr,.mt0ih2fs:hover{border-top:var(--_1pyqka9z) solid 1px}.mt0ih2ft,.mt0ih2fu:hover{border-top:var(--_1pyqka91p) solid 1px}.mt0ih2fv,.mt0ih2fw:hover{border-top:var(--_1pyqka91q) solid 1px}.mt0ih2fx,.mt0ih2fy:hover{border-top:var(--_1pyqka91r) solid 1px}.mt0ih2fz,.mt0ih2g0:hover{border-top:var(--_1pyqka9j) solid 1px}.mt0ih2g1,.mt0ih2g2:hover{border-top:var(--_1pyqka9k) solid 1px}.mt0ih2g3,.mt0ih2g4:hover{border-top:var(--_1pyqka9i) solid 1px}.mt0ih2g5,.mt0ih2g6:hover{border-right:0}.mt0ih2g7,.mt0ih2g8:hover{border-right:var(--_1pyqka91k) solid 1px}.mt0ih2g9,.mt0ih2ga:hover{border-right:var(--_1pyqka91l) solid 1px}.mt0ih2gb,.mt0ih2gc:hover{border-right:var(--_1pyqka91m) solid 1px}.mt0ih2gd,.mt0ih2ge:hover{border-right:var(--_1pyqka91n) solid 1px}.mt0ih2gf,.mt0ih2gg:hover{border-right:var(--_1pyqka91o) solid 1px}.mt0ih2gh,.mt0ih2gi:hover{border-right:var(--_1pyqka9z) solid 1px}.mt0ih2gj,.mt0ih2gk:hover{border-right:var(--_1pyqka91p) solid 1px}.mt0ih2gl,.mt0ih2gm:hover{border-right:var(--_1pyqka91q) solid 1px}.mt0ih2gn,.mt0ih2go:hover{border-right:var(--_1pyqka91r) solid 1px}.mt0ih2gp,.mt0ih2gq:hover{border-right:var(--_1pyqka9j) solid 1px}.mt0ih2gr,.mt0ih2gs:hover{border-right:var(--_1pyqka9k) solid 1px}.mt0ih2gt,.mt0ih2gu:hover{border-right:var(--_1pyqka9i) solid 1px}.mt0ih2gv,.mt0ih2gw:hover{border-bottom:0}.mt0ih2gx,.mt0ih2gy:hover{border-bottom:var(--_1pyqka91k) solid 1px}.mt0ih2gz,.mt0ih2h0:hover{border-bottom:var(--_1pyqka91l) solid 1px}.mt0ih2h1,.mt0ih2h2:hover{border-bottom:var(--_1pyqka91m) solid 1px}.mt0ih2h3,.mt0ih2h4:hover{border-bottom:var(--_1pyqka91n) solid 1px}.mt0ih2h5,.mt0ih2h6:hover{border-bottom:var(--_1pyqka91o) solid 1px}.mt0ih2h7,.mt0ih2h8:hover{border-bottom:var(--_1pyqka9z) solid 1px}.mt0ih2h9,.mt0ih2ha:hover{border-bottom:var(--_1pyqka91p) solid 1px}.mt0ih2hb,.mt0ih2hc:hover{border-bottom:var(--_1pyqka91q) solid 1px}.mt0ih2hd,.mt0ih2he:hover{border-bottom:var(--_1pyqka91r) solid 1px}.mt0ih2hf,.mt0ih2hg:hover{border-bottom:var(--_1pyqka9j) solid 1px}.mt0ih2hh,.mt0ih2hi:hover{border-bottom:var(--_1pyqka9k) solid 1px}.mt0ih2hj,.mt0ih2hk:hover{border-bottom:var(--_1pyqka9i) solid 1px}.mt0ih2hl,.mt0ih2hm:hover{border-left:0}.mt0ih2hn,.mt0ih2ho:hover{border-left:var(--_1pyqka91k) solid 1px}.mt0ih2hp,.mt0ih2hq:hover{border-left:var(--_1pyqka91l) solid 1px}.mt0ih2hr,.mt0ih2hs:hover{border-left:var(--_1pyqka91m) solid 1px}.mt0ih2ht,.mt0ih2hu:hover{border-left:var(--_1pyqka91n) solid 1px}.mt0ih2hv,.mt0ih2hw:hover{border-left:var(--_1pyqka91o) solid 1px}.mt0ih2hx,.mt0ih2hy:hover{border-left:var(--_1pyqka9z) solid 1px}.mt0ih2hz,.mt0ih2i0:hover{border-left:var(--_1pyqka91p) solid 1px}.mt0ih2i1,.mt0ih2i2:hover{border-left:var(--_1pyqka91q) solid 1px}.mt0ih2i3,.mt0ih2i4:hover{border-left:var(--_1pyqka91r) solid 1px}.mt0ih2i5,.mt0ih2i6:hover{border-left:var(--_1pyqka9j) solid 1px}.mt0ih2i7,.mt0ih2i8:hover{border-left:var(--_1pyqka9k) solid 1px}.mt0ih2i9,.mt0ih2ia:hover{border-left:var(--_1pyqka9i) solid 1px}.mt0ih2ib,.mt0ih2ic:hover{border-color:inherit}.mt0ih2id,.mt0ih2ie:hover{border-color:#fff}.mt0ih2if,.mt0ih2ig:hover{border-color:#000}.mt0ih2ih,.mt0ih2ii:hover{border-color:#fdfcfd}.mt0ih2ij,.mt0ih2ik:hover{border-color:#f9f8f9}.mt0ih2il,.mt0ih2im:hover{border-color:#f4f2f4}.mt0ih2in,.mt0ih2io:hover{border-color:#eeedef}.mt0ih2ip,.mt0ih2iq:hover{border-color:#e9e8ea}.mt0ih2ir,.mt0ih2is:hover{border-color:#e4e2e4}.mt0ih2it,.mt0ih2iu:hover{border-color:#dcdbdd}.mt0ih2iv,.mt0ih2iw:hover{border-color:#c8c7cb}.mt0ih2ix,.mt0ih2iy:hover{border-color:#908e96}.mt0ih2iz,.mt0ih2j0:hover{border-color:#86848d}.mt0ih2j1,.mt0ih2j2:hover{border-color:#6f6e77}.mt0ih2j3,.mt0ih2j4:hover{border-color:#1a1523}.mt0ih2j5,.mt0ih2j6:hover{border-color:#fcfbfe}.mt0ih2j7,.mt0ih2j8:hover{border-color:#f8f5ff}.mt0ih2j9,.mt0ih2ja:hover{border-color:#f4f0ff}.mt0ih2jb,.mt0ih2jc:hover{border-color:#ede7fe}.mt0ih2jd,.mt0ih2je:hover{border-color:#e7defc}.mt0ih2jf,.mt0ih2jg:hover{border-color:#d9cdf9}.mt0ih2jh,.mt0ih2ji:hover{border-color:#c9b9f3}.mt0ih2jj,.mt0ih2jk:hover{border-color:#af98ec}.mt0ih2jl,.mt0ih2jm:hover{border-color:#744ed4}.mt0ih2jn,.mt0ih2jo:hover{border-color:#6b48c7}.mt0ih2jp,.mt0ih2jq:hover{border-color:#6346af}.mt0ih2jr,.mt0ih2js:hover{border-color:#20104d}.mt0ih2jt,.mt0ih2ju:hover{border-color:#fffcfc}.mt0ih2jv,.mt0ih2jw:hover{border-color:#fff8f8}.mt0ih2jx,.mt0ih2jy:hover{border-color:#ffefef}.mt0ih2jz,.mt0ih2k0:hover{border-color:#ffe5e5}.mt0ih2k1,.mt0ih2k2:hover{border-color:#fdd8d8}.mt0ih2k3,.mt0ih2k4:hover{border-color:#f9c6c6}.mt0ih2k5,.mt0ih2k6:hover{border-color:#f3aeaf}.mt0ih2k7,.mt0ih2k8:hover{border-color:#eb9091}.mt0ih2k9,.mt0ih2ka:hover{border-color:#e5484d}.mt0ih2kb,.mt0ih2kc:hover{border-color:#dc3d43}.mt0ih2kd,.mt0ih2ke:hover{border-color:#cd2b31}.mt0ih2kf,.mt0ih2kg:hover{border-color:#381316}.mt0ih2kh,.mt0ih2ki:hover{border-color:#fbfefc}.mt0ih2kj,.mt0ih2kk:hover{border-color:#f2fcf5}.mt0ih2kl,.mt0ih2km:hover{border-color:#e9f9ee}.mt0ih2kn,.mt0ih2ko:hover{border-color:#ddf3e4}.mt0ih2kp,.mt0ih2kq:hover{border-color:#ccebd7}.mt0ih2kr,.mt0ih2ks:hover{border-color:#b4dfc4}.mt0ih2kt,.mt0ih2ku:hover{border-color:#92ceac}.mt0ih2kv,.mt0ih2kw:hover{border-color:#5bb98c}.mt0ih2kx,.mt0ih2ky:hover{border-color:#30a46c}.mt0ih2kz,.mt0ih2l0:hover{border-color:#299764}.mt0ih2l1,.mt0ih2l2:hover{border-color:#18794e}.mt0ih2l3,.mt0ih2l4:hover{border-color:#153226}.mt0ih2l5,.mt0ih2l6:hover{border-color:#fefdfb}.mt0ih2l7,.mt0ih2l8:hover{border-color:#fff9ed}.mt0ih2l9,.mt0ih2la:hover{border-color:#fff4d5}.mt0ih2lb,.mt0ih2lc:hover{border-color:#ffecbc}.mt0ih2ld,.mt0ih2le:hover{border-color:#ffe3a2}.mt0ih2lf,.mt0ih2lg:hover{border-color:#ffd386}.mt0ih2lh,.mt0ih2li:hover{border-color:#f3ba63}.mt0ih2lj,.mt0ih2lk:hover{border-color:#ee9d2b}.mt0ih2ll,.mt0ih2lm:hover{border-color:#ffb224}.mt0ih2ln,.mt0ih2lo:hover{border-color:#ffa01c}.mt0ih2lp,.mt0ih2lq:hover{border-color:#ad5700}.mt0ih2lr,.mt0ih2ls:hover{border-color:#4e2009}.mt0ih2lt,.mt0ih2lu:hover{border-color:#d6f0ff}.mt0ih2lv,.mt0ih2lw:hover{border-color:#96d5f8}.mt0ih2lx,.mt0ih2ly:hover{border-color:#4fb5ee}.mt0ih2lz,.mt0ih2m0:hover{border-color:#0b75aa}.mt0ih2m1,.mt0ih2m2:hover{border-color:#ebff5e}.mt0ih2m3,.mt0ih2m4:hover{border-color:#8dc31a}.mt0ih2m5,.mt0ih2m6:hover{border-color:#ff5377}.mt0ih2m7,.mt0ih2m8:hover{border-color:#ff9457}.mt0ih2m9,.mt0ih2ma:hover{border-color:#36e79b}.mt0ih2mb,.mt0ih2mc:hover{border-style:hidden}.mt0ih2md,.mt0ih2me:hover{border-style:solid}.mt0ih2mf,.mt0ih2mg:hover{border-width:1px}.mt0ih2mh,.mt0ih2mi:hover{border-width:2px}.mt0ih2mj,.mt0ih2mk:hover{border-width:4px}.mt0ih2ml,.mt0ih2mm:hover{box-shadow:0 2px 8px -2px #3b3b3b14}.mt0ih2mn,.mt0ih2mo:hover{box-shadow:0 6px 12px -2px #3b3b3b1f}.mt0ih2mp,.mt0ih2mq:hover{box-shadow:0 -1px #00000052 inset}.mt0ih2mr,.mt0ih2ms:hover{box-shadow:0 -1px #0000001a inset}.mt0ih2mt,.mt0ih2mu:hover{color:inherit}.mt0ih2mv,.mt0ih2mw:hover{color:#fff}.mt0ih2mx,.mt0ih2my:hover{color:#000}.mt0ih2mz,.mt0ih2n0:hover{color:#fdfcfd}.mt0ih2n1,.mt0ih2n2:hover{color:#f9f8f9}.mt0ih2n3,.mt0ih2n4:hover{color:#f4f2f4}.mt0ih2n5,.mt0ih2n6:hover{color:#eeedef}.mt0ih2n7,.mt0ih2n8:hover{color:#e9e8ea}.mt0ih2n9,.mt0ih2na:hover{color:#e4e2e4}.mt0ih2nb,.mt0ih2nc:hover{color:#dcdbdd}.mt0ih2nd,.mt0ih2ne:hover{color:#c8c7cb}.mt0ih2nf,.mt0ih2ng:hover{color:#908e96}.mt0ih2nh,.mt0ih2ni:hover{color:#86848d}.mt0ih2nj,.mt0ih2nk:hover{color:#6f6e77}.mt0ih2nl,.mt0ih2nm:hover{color:#1a1523}.mt0ih2nn,.mt0ih2no:hover{color:#fcfbfe}.mt0ih2np,.mt0ih2nq:hover{color:#f8f5ff}.mt0ih2nr,.mt0ih2ns:hover{color:#f4f0ff}.mt0ih2nt,.mt0ih2nu:hover{color:#ede7fe}.mt0ih2nv,.mt0ih2nw:hover{color:#e7defc}.mt0ih2nx,.mt0ih2ny:hover{color:#d9cdf9}.mt0ih2nz,.mt0ih2o0:hover{color:#c9b9f3}.mt0ih2o1,.mt0ih2o2:hover{color:#af98ec}.mt0ih2o3,.mt0ih2o4:hover{color:#744ed4}.mt0ih2o5,.mt0ih2o6:hover{color:#6b48c7}.mt0ih2o7,.mt0ih2o8:hover{color:#6346af}.mt0ih2o9,.mt0ih2oa:hover{color:#20104d}.mt0ih2ob,.mt0ih2oc:hover{color:#fffcfc}.mt0ih2od,.mt0ih2oe:hover{color:#fff8f8}.mt0ih2of,.mt0ih2og:hover{color:#ffefef}.mt0ih2oh,.mt0ih2oi:hover{color:#ffe5e5}.mt0ih2oj,.mt0ih2ok:hover{color:#fdd8d8}.mt0ih2ol,.mt0ih2om:hover{color:#f9c6c6}.mt0ih2on,.mt0ih2oo:hover{color:#f3aeaf}.mt0ih2op,.mt0ih2oq:hover{color:#eb9091}.mt0ih2or,.mt0ih2os:hover{color:#e5484d}.mt0ih2ot,.mt0ih2ou:hover{color:#dc3d43}.mt0ih2ov,.mt0ih2ow:hover{color:#cd2b31}.mt0ih2ox,.mt0ih2oy:hover{color:#381316}.mt0ih2oz,.mt0ih2p0:hover{color:#fbfefc}.mt0ih2p1,.mt0ih2p2:hover{color:#f2fcf5}.mt0ih2p3,.mt0ih2p4:hover{color:#e9f9ee}.mt0ih2p5,.mt0ih2p6:hover{color:#ddf3e4}.mt0ih2p7,.mt0ih2p8:hover{color:#ccebd7}.mt0ih2p9,.mt0ih2pa:hover{color:#b4dfc4}.mt0ih2pb,.mt0ih2pc:hover{color:#92ceac}.mt0ih2pd,.mt0ih2pe:hover{color:#5bb98c}.mt0ih2pf,.mt0ih2pg:hover{color:#30a46c}.mt0ih2ph,.mt0ih2pi:hover{color:#299764}.mt0ih2pj,.mt0ih2pk:hover{color:#18794e}.mt0ih2pl,.mt0ih2pm:hover{color:#153226}.mt0ih2pn,.mt0ih2po:hover{color:#fefdfb}.mt0ih2pp,.mt0ih2pq:hover{color:#fff9ed}.mt0ih2pr,.mt0ih2ps:hover{color:#fff4d5}.mt0ih2pt,.mt0ih2pu:hover{color:#ffecbc}.mt0ih2pv,.mt0ih2pw:hover{color:#ffe3a2}.mt0ih2px,.mt0ih2py:hover{color:#ffd386}.mt0ih2pz,.mt0ih2q0:hover{color:#f3ba63}.mt0ih2q1,.mt0ih2q2:hover{color:#ee9d2b}.mt0ih2q3,.mt0ih2q4:hover{color:#ffb224}.mt0ih2q5,.mt0ih2q6:hover{color:#ffa01c}.mt0ih2q7,.mt0ih2q8:hover{color:#ad5700}.mt0ih2q9,.mt0ih2qa:hover{color:#4e2009}.mt0ih2qb,.mt0ih2qc:hover{color:#d6f0ff}.mt0ih2qd,.mt0ih2qe:hover{color:#96d5f8}.mt0ih2qf,.mt0ih2qg:hover{color:#4fb5ee}.mt0ih2qh,.mt0ih2qi:hover{color:#0b75aa}.mt0ih2qj,.mt0ih2qk:hover{color:#ebff5e}.mt0ih2ql,.mt0ih2qm:hover{color:#8dc31a}.mt0ih2qn,.mt0ih2qo:hover{color:#ff5377}.mt0ih2qp,.mt0ih2qq:hover{color:#ff9457}.mt0ih2qr,.mt0ih2qs:hover{color:#36e79b}.mt0ih2qt,.mt0ih2qu:hover{color:var(--_1pyqka9b)}.mt0ih2qv,.mt0ih2qw:hover{color:var(--_1pyqka9c)}.mt0ih2qx,.mt0ih2qy:hover{color:var(--_1pyqka9a)}.mt0ih2qz,.mt0ih2r0:hover{color:var(--_1pyqka9g)}.mt0ih2r1,.mt0ih2r2:hover{color:var(--_1pyqka9e)}.mt0ih2r3,.mt0ih2r4:hover{color:var(--_1pyqka9f)}.mt0ih2r5,.mt0ih2r6:hover{color:var(--_1pyqka9h)}.mt0ih2r7,.mt0ih2r8:hover{color:var(--_1pyqka9d)}.mt0ih2r9,.mt0ih2ra:hover{color:var(--_1pyqka9l)}.mt0ih2rb,.mt0ih2rc:hover{color:var(--_1pyqka9m)}.mt0ih2rd,.mt0ih2re:hover{color:var(--_1pyqka9n)}.mt0ih2rf,.mt0ih2rg:hover{color:var(--_1pyqka9o)}.mt0ih2rh,.mt0ih2ri:hover{color:var(--_1pyqka9p)}.mt0ih2rj,.mt0ih2rk:hover{color:var(--_1pyqka9q)}.mt0ih2rl,.mt0ih2rm:hover{color:var(--_1pyqka9r)}.mt0ih2rn,.mt0ih2ro:hover{color:var(--_1pyqka9s)}.mt0ih2rp,.mt0ih2rq:hover{color:var(--_1pyqka9t)}.mt0ih2rr,.mt0ih2rs:hover{color:var(--_1pyqka9u)}.mt0ih2rt,.mt0ih2ru:hover{color:var(--_1pyqka9v)}.mt0ih2rv,.mt0ih2rw:hover{color:var(--_1pyqka9w)}.mt0ih2rx,.mt0ih2ry:hover{color:var(--_1pyqka9x)}.mt0ih2rz,.mt0ih2s0:hover{color:var(--_1pyqka9y)}.mt0ih2s1,.mt0ih2s2:hover{text-transform:none}.mt0ih2s3,.mt0ih2s4:hover{text-transform:capitalize}.mt0ih2s5,.mt0ih2s6:hover{text-transform:uppercase}.mt0ih2s7,.mt0ih2s8:hover{text-transform:lowercase}._19y1zt60{-ms-overflow-style:none;scrollbar-width:none}._19y1zt60::-webkit-scrollbar{display:none}._15exe0r0{display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden;word-break:break-all;-webkit-line-clamp:1;line-clamp:1}._15exe0r1{display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden;word-break:break-all;-webkit-line-clamp:2;line-clamp:2}._15exe0r2{display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden;word-break:break-all;-webkit-line-clamp:3;line-clamp:3}._15exe0r3{display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden;word-break:break-all;-webkit-line-clamp:4;line-clamp:4}._145lkmv0{text-align:center}._145lkmv1{text-align:left}._145lkmv2{text-align:right}._145lkmv3{font-family:Steradian,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol}._145lkmv4{font-family:Steradian,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif}._145lkmv5{font-family:IBM Plex Mono,Menlo,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier,monospace}._145lkmv6{font-size:11px;line-height:12px}._145lkmv6:before{content:"";margin-bottom:-.1875em;display:table}._145lkmv6:after{content:"";margin-top:-.2005em;display:table}._145lkmv7{font-size:12px;line-height:16px}._145lkmv7:before{content:"";margin-bottom:-.3087em;display:table}._145lkmv7:after{content:"";margin-top:-.3217em;display:table}._145lkmv8{font-size:13px;line-height:20px}._145lkmv8:before{content:"";margin-bottom:-.4112em;display:table}._145lkmv8:after{content:"";margin-top:-.4242em;display:table}._145lkmv9{font-size:14px;line-height:20px}._145lkmv9:before{content:"";margin-bottom:-.3563em;display:table}._145lkmv9:after{content:"";margin-top:-.3693em;display:table}._145lkmva{font-size:16px;line-height:24px}._145lkmva:before{content:"";margin-bottom:-.392em;display:table}._145lkmva:after{content:"";margin-top:-.405em;display:table}._145lkmvb{font-weight:300}._145lkmvc{font-weight:400}._145lkmvd{font-weight:500}._145lkmve{text-transform:capitalize}._145lkmvf{text-transform:uppercase}._145lkmvg{text-transform:lowercase}._145lkmvh{word-break:break-all}._145lkmvi{word-break:break-word}._145lkmvj{word-break:normal}._145lkmvk{white-space:nowrap}._145lkmvl,._145lkmvm{font-weight:400}._145lkmvn{font-weight:500}._145lkmvo{font-weight:700}._145lkmvp{font-size:14px;line-height:20px}._145lkmvp:before{content:"";margin-bottom:-.3913em;display:table}._145lkmvp:after{content:"";margin-top:-.3393em;display:table}._145lkmvq{font-size:11px;line-height:23px}._145lkmvq:before{content:"";margin-bottom:-.7225em;display:table}._145lkmvq:after{content:"";margin-top:-.6705em;display:table}._145lkmvr{font-size:10px;line-height:14px}._145lkmvr:before{content:"";margin-bottom:-.377em;display:table}._145lkmvr:after{content:"";margin-top:-.325em;display:table}body{color:var(--_1pyqka9b);font-family:Steradian,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol}.dxo6qt4{align-items:center;display:inline-flex;user-select:none;width:max-content}.dxo6qt5{min-height:16px}.dxo6qt6{min-height:20px}.dxo6qt7{min-height:24px}.dxo6qta{background:var(--_1pyqka91);border:var(--_1pyqka91o) solid 1px;color:var(--_1pyqka9c)}.dxo6qtb{background:var(--_1pyqka99);color:var(--_1pyqka9c)}.dxo6qtc{border:var(--_1pyqka91o) solid 1px;color:var(--_1pyqka9c)}.dxo6qtd{background:var(--_1pyqka95);color:var(--_1pyqka9e)}.dxo6qtf{background:var(--_1pyqka97);color:var(--_1pyqka9g)}.dxo6qtg{background:var(--_1pyqka96);color:var(--_1pyqka9f)}.dxo6qth{background:var(--_1pyqka98);color:var(--_1pyqka9h)}.dxo6qti{border-radius:3px}.dxo6qtj{border-radius:5px}.dxo6qtk{border-radius:6px}.dxo6qtl{border-radius:23px}.dxo6qtm{border-radius:10px}.dxo6qtn{border-radius:16px}._1oerpj90{align-items:center;cursor:pointer;display:inline-flex;justify-content:center;flex-shrink:0}._1oerpj90[disabled]{color:var(--_1pyqka9o);pointer-events:none;user-select:none}._1oerpj91{height:12px;width:12px;font-size:12px;line-height:16px}._1oerpj91:before{content:"";margin-bottom:-.3087em;display:table}._1oerpj91:after{content:"";margin-top:-.3217em;display:table}._1oerpj92{height:12px;width:12px;font-size:13px;line-height:20px}._1oerpj92:before{content:"";margin-bottom:-.4112em;display:table}._1oerpj92:after{content:"";margin-top:-.4242em;display:table}._1oerpj93{height:14px;width:14px;font-size:13px;line-height:20px}._1oerpj93:before{content:"";margin-bottom:-.4112em;display:table}._1oerpj93:after{content:"";margin-top:-.4242em;display:table}._1oerpj94{height:16px;width:16px;font-size:13px;line-height:20px}._1oerpj94:before{content:"";margin-bottom:-.4112em;display:table}._1oerpj94:after{content:"";margin-top:-.4242em;display:table}._1oerpj95{height:16px;width:16px;font-size:16px;line-height:24px}._1oerpj95:before{content:"";margin-bottom:-.392em;display:table}._1oerpj95:after{content:"";margin-top:-.405em;display:table}._1oerpj99{color:var(--_1pyqka9p)}._1oerpj9a{color:var(--_1pyqka9w)}._1oerpj9b:active{color:#f4f2f4}._1oerpj9c{color:var(--_1pyqka9p)}._1oerpj9h{background-color:transparent;cursor:pointer;line-height:1em}._1oerpj9h:hover{cursor:pointer}._1oerpj9h[disabled],._1oerpj9h[disabled]:hover,._1oerpj9h[disabled]:focus{color:var(--_1pyqka9x);pointer-events:none;user-select:none}._1oerpj9l,._1oerpj9m{color:var(--_1pyqka9r)}._1oerpj9n{background:#eb9091;color:#fff;box-shadow:inset 0 -1px #00000052}._1oerpj9n:hover{background:#e5484d;color:#fff}._1oerpj9n:active{background:#e5484d;color:#fff;box-shadow:none}._1oerpj9n[disabled],._1oerpj9n[disabled]:hover{background:#f3aeaf;color:#fdfcfd;box-shadow:none}._1oerpj9o{height:24px}._1oerpj9p{height:28px}._1oerpj9q{height:32px}._1oerpj9r{background-color:var(--_1pyqka9l);box-shadow:inset 0 -1px #00000052;color:var(--_1pyqka9p)}._1oerpj9r:hover{background-color:var(--_1pyqka9m);color:var(--_1pyqka9p)}._1oerpj9r:active{background-color:var(--_1pyqka9n);box-shadow:none;color:var(--_1pyqka9p)}._1oerpj9r[disabled],._1oerpj9r[disabled]:hover{background-color:var(--_1pyqka9o);color:var(--_1pyqka9o);box-shadow:none}._1oerpj9s{border:var(--_1pyqka91k) solid 1px;box-shadow:none;color:var(--_1pyqka9r)}._1oerpj9s:hover{background-color:var(--_1pyqka91t);border:var(--_1pyqka91l) solid 1px;color:var(--_1pyqka9r)}._1oerpj9s:active{background-color:var(--_1pyqka91u);border:var(--_1pyqka91m) solid 1px;color:var(--_1pyqka9r)}._1oerpj9s[disabled],._1oerpj9s[disabled]:hover{border:var(--_1pyqka91n) solid 1px;color:var(--_1pyqka9q)}._1oerpj9t{border:0;box-shadow:none;color:var(--_1pyqka9r)}._1oerpj9t:hover{background-color:var(--_1pyqka91t);color:var(--_1pyqka9r)}._1oerpj9t:active{background-color:var(--_1pyqka91u);color:var(--_1pyqka9r)}._1oerpj9t[disabled],._1oerpj9t[disabled]:hover{color:var(--_1pyqka9q)}._1oerpj9u{background-color:var(--_1pyqka9s);box-shadow:inset 0 -1px #0000001a;color:var(--_1pyqka9w)}._1oerpj9u:hover{background-color:var(--_1pyqka9t);color:var(--_1pyqka9w)}._1oerpj9u:active{background-color:var(--_1pyqka9u);box-shadow:none;color:var(--_1pyqka9w)}._1oerpj9u[disabled],._1oerpj9u[disabled]:hover{background-color:var(--_1pyqka9v);color:var(--_1pyqka9x);box-shadow:none}._1oerpj9v{border:var(--_1pyqka91o) solid 1px;box-shadow:none;color:var(--_1pyqka9y)}._1oerpj9v:hover{background-color:var(--_1pyqka91x);border:var(--_1pyqka91p) solid 1px;color:var(--_1pyqka9y)}._1oerpj9v:active{border:var(--_1pyqka91q) solid 1px;background-color:var(--_1pyqka91y);color:var(--_1pyqka9y)}._1oerpj9v[disabled],._1oerpj9v[disabled]:hover{background-color:var(--_1pyqka91z);border:var(--_1pyqka91r) solid 1px}._1oerpj9w{color:var(--_1pyqka9y)}._1oerpj9w:hover{background-color:var(--_1pyqka91x);color:var(--_1pyqka9y)}._1oerpj9w:active{background-color:var(--_1pyqka91y);color:var(--_1pyqka9y)}._1oerpj9w[disabled],._1oerpj9w[disabled]:hover{background-color:var(--_1pyqka91z)}._1ku4sk20{align-items:center;display:inline-flex;justify-content:center;border:none;border-radius:6px;color:var(--_1pyqka9l);cursor:pointer;padding:0;outline:none}._1ku4sk20[disabled],._1ku4sk20[disabled]:hover,._1ku4sk20[disabled]:focus{box-shadow:none;color:var(--_1pyqka9q);cursor:not-allowed;outline:none}._1ku4sk26{color:#6f6e77;background-color:inherit}._1ku4sk26:hover:enabled{background-color:#eeedef;color:#86848d;box-shadow:inset 0 -1px #0000001a}._1ku4sk26:active:enabled{background-color:#e9e8ea;box-shadow:none}._1ku4sk27{height:24px;width:24px}._1ku4sk28{height:28px;width:28px}._1ku4sk29{height:32px;width:32px}._1ku4sk2a{height:20px;width:20px;border-radius:4px}._1ku4sk2d{width:16px}._1ku4sk2e{width:18px}._1ku4sk2f{width:20px}._1ku4sk2g{background-color:var(--_1pyqka9l);box-shadow:inset 0 -1px #00000052;color:#fff}._1ku4sk2g:hover:enabled{background-color:var(--_1pyqka9m)}._1ku4sk2g:active:enabled{background-color:var(--_1pyqka9n);box-shadow:none}._1ku4sk2g[disabled]{background-color:var(--_1pyqka9o)}._1ku4sk2h{background-color:var(--_1pyqka91s);border:var(--_1pyqka91k) solid 1px;box-shadow:none;color:var(--_1pyqka9l)}._1ku4sk2h[disabled]{border:var(--_1pyqka91n) solid 1px}._1ku4sk2h:hover:enabled{background-color:var(--_1pyqka91t);border:var(--_1pyqka91l) solid 1px}._1ku4sk2h:active:enabled{background-color:var(--_1pyqka91u);border:var(--_1pyqka91m) solid 1px}._1ku4sk2i{background-color:var(--_1pyqka91s);box-shadow:none;color:var(--_1pyqka9l)}._1ku4sk2i:hover:enabled{background-color:var(--_1pyqka91t)}._1ku4sk2i:active:enabled{background-color:var(--_1pyqka91u)}._1ku4sk2j{background-color:var(--_1pyqka9s);color:var(--_1pyqka9y);box-shadow:inset 0 -1px #0000001a}._1ku4sk2j:hover:enabled{background-color:var(--_1pyqka9t)}._1ku4sk2j:active:enabled{background-color:var(--_1pyqka9u);box-shadow:none}._1ku4sk2j[disabled]{background-color:var(--_1pyqka9v);color:var(--_1pyqka9x)}._1ku4sk2k{background-color:transparent;border:var(--_1pyqka91o) solid 1px;box-shadow:none;color:var(--_1pyqka9y)}._1ku4sk2k[disabled]{border:var(--_1pyqka91r) solid 1px;color:var(--_1pyqka9x)}._1ku4sk2k:hover:enabled{background-color:var(--_1pyqka91x);border:var(--_1pyqka91p) solid 1px}._1ku4sk2k:active:enabled{background-color:var(--_1pyqka91y);border:var(--_1pyqka91q) solid 1px}._1ku4sk2l{background-color:var(--_1pyqka91w);box-shadow:none;color:var(--_1pyqka9y)}._1ku4sk2l[disabled]{color:var(--_1pyqka9x)}._1ku4sk2l:hover:enabled{background-color:var(--_1pyqka91x)}._1ku4sk2l:active:enabled{background-color:var(--_1pyqka91y)}.mquqy90{background:transparent;border:0;cursor:pointer;padding:0}.mquqy91{color:var(--_1pyqka9l)}.mquqy91:hover{color:var(--_1pyqka9m)}.mquqy91:active{color:var(--_1pyqka9n)}.mquqy92{color:var(--_1pyqka9y)}.mquqy92:hover,.mquqy92:active{color:var(--_1pyqka9w)}._118xo1h2{background:transparent}._118xo1h3,._118xo1h4{background-color:var(--_1pyqka92)}._1o4id6s0{display:flex;flex-wrap:wrap;min-width:100%}._1o4id6s1{box-sizing:border-box;min-width:0}._1o4id6s2{flex:0 0 calc(100% / 12)}._1o4id6s6{flex:0 0 calc(100% * 2 / 12)}._1o4id6sa{flex:0 0 25%}._1o4id6se{flex:0 0 calc(100% * 4 / 12)}._1o4id6si{flex:0 0 calc(100% * 5 / 12)}._1o4id6sm{flex:0 0 50%}._1o4id6sq{flex:0 0 calc(100% * 7 / 12)}._1o4id6su{flex:0 0 calc(100% * 8 / 12)}._1o4id6sy{flex:0 0 75%}._1o4id6s12{flex:0 0 calc(100% * 10 / 12)}._1o4id6s16{flex:0 0 calc(100% * 11 / 12)}._1o4id6s1a{flex:0 0 100%}._1o4id6s1e{flex:1 0 auto}._1o4id6s1i{margin-left:0;margin-top:0}._1o4id6s1j{margin-left:-1px;margin-top:-1px}._1o4id6s1k{margin-left:-2px;margin-top:-2px}._1o4id6s1l{margin-left:-3px;margin-top:-3px}._1o4id6s1m{margin-left:-4px;margin-top:-4px}._1o4id6s1n{margin-left:-6px;margin-top:-6px}._1o4id6s1o{margin-left:-7px;margin-top:-7px}._1o4id6s1p{margin-left:-8px;margin-top:-8px}._1o4id6s1q{margin-left:-9px;margin-top:-9px}._1o4id6s1r{margin-left:-10px;margin-top:-10px}._1o4id6s1s{margin-left:-12px;margin-top:-12px}._1o4id6s1t{margin-left:-16px;margin-top:-16px}._1o4id6s1u{margin-left:-20px;margin-top:-20px}._1o4id6s1v{margin-left:-24px;margin-top:-24px}._1o4id6s1w{margin-left:-28px;margin-top:-28px}._1o4id6s1x{margin-left:-32px;margin-top:-32px}._1o4id6s1y{margin-left:-40px;margin-top:-40px}@media screen and (min-width: 740px){._1o4id6s3{flex:0 0 calc(100% / 12)}._1o4id6s7{flex:0 0 calc(100% * 2 / 12)}._1o4id6sb{flex:0 0 25%}._1o4id6sf{flex:0 0 calc(100% * 4 / 12)}._1o4id6sj{flex:0 0 calc(100% * 5 / 12)}._1o4id6sn{flex:0 0 50%}._1o4id6sr{flex:0 0 calc(100% * 7 / 12)}._1o4id6sv{flex:0 0 calc(100% * 8 / 12)}._1o4id6sz{flex:0 0 75%}._1o4id6s13{flex:0 0 calc(100% * 10 / 12)}._1o4id6s17{flex:0 0 calc(100% * 11 / 12)}._1o4id6s1b{flex:0 0 100%}._1o4id6s1f{flex:1 0 auto}._1o4id6s1z{margin-left:0;margin-top:0}._1o4id6s20{margin-left:-1px;margin-top:-1px}._1o4id6s21{margin-left:-2px;margin-top:-2px}._1o4id6s22{margin-left:-3px;margin-top:-3px}._1o4id6s23{margin-left:-4px;margin-top:-4px}._1o4id6s24{margin-left:-6px;margin-top:-6px}._1o4id6s25{margin-left:-7px;margin-top:-7px}._1o4id6s26{margin-left:-8px;margin-top:-8px}._1o4id6s27{margin-left:-9px;margin-top:-9px}._1o4id6s28{margin-left:-10px;margin-top:-10px}._1o4id6s29{margin-left:-12px;margin-top:-12px}._1o4id6s2a{margin-left:-16px;margin-top:-16px}._1o4id6s2b{margin-left:-20px;margin-top:-20px}._1o4id6s2c{margin-left:-24px;margin-top:-24px}._1o4id6s2d{margin-left:-28px;margin-top:-28px}._1o4id6s2e{margin-left:-32px;margin-top:-32px}._1o4id6s2f{margin-left:-40px;margin-top:-40px}}@media screen and (min-width: 992px){._1o4id6s4{flex:0 0 calc(100% / 12)}._1o4id6s8{flex:0 0 calc(100% * 2 / 12)}._1o4id6sc{flex:0 0 25%}._1o4id6sg{flex:0 0 calc(100% * 4 / 12)}._1o4id6sk{flex:0 0 calc(100% * 5 / 12)}._1o4id6so{flex:0 0 50%}._1o4id6ss{flex:0 0 calc(100% * 7 / 12)}._1o4id6sw{flex:0 0 calc(100% * 8 / 12)}._1o4id6s10{flex:0 0 75%}._1o4id6s14{flex:0 0 calc(100% * 10 / 12)}._1o4id6s18{flex:0 0 calc(100% * 11 / 12)}._1o4id6s1c{flex:0 0 100%}._1o4id6s1g{flex:1 0 auto}._1o4id6s2g{margin-left:0;margin-top:0}._1o4id6s2h{margin-left:-1px;margin-top:-1px}._1o4id6s2i{margin-left:-2px;margin-top:-2px}._1o4id6s2j{margin-left:-3px;margin-top:-3px}._1o4id6s2k{margin-left:-4px;margin-top:-4px}._1o4id6s2l{margin-left:-6px;margin-top:-6px}._1o4id6s2m{margin-left:-7px;margin-top:-7px}._1o4id6s2n{margin-left:-8px;margin-top:-8px}._1o4id6s2o{margin-left:-9px;margin-top:-9px}._1o4id6s2p{margin-left:-10px;margin-top:-10px}._1o4id6s2q{margin-left:-12px;margin-top:-12px}._1o4id6s2r{margin-left:-16px;margin-top:-16px}._1o4id6s2s{margin-left:-20px;margin-top:-20px}._1o4id6s2t{margin-left:-24px;margin-top:-24px}._1o4id6s2u{margin-left:-28px;margin-top:-28px}._1o4id6s2v{margin-left:-32px;margin-top:-32px}._1o4id6s2w{margin-left:-40px;margin-top:-40px}}@media screen and (min-width: 1200px){._1o4id6s5{flex:0 0 calc(100% / 12)}._1o4id6s9{flex:0 0 calc(100% * 2 / 12)}._1o4id6sd{flex:0 0 25%}._1o4id6sh{flex:0 0 calc(100% * 4 / 12)}._1o4id6sl{flex:0 0 calc(100% * 5 / 12)}._1o4id6sp{flex:0 0 50%}._1o4id6st{flex:0 0 calc(100% * 7 / 12)}._1o4id6sx{flex:0 0 calc(100% * 8 / 12)}._1o4id6s11{flex:0 0 75%}._1o4id6s15{flex:0 0 calc(100% * 10 / 12)}._1o4id6s19{flex:0 0 calc(100% * 11 / 12)}._1o4id6s1d{flex:0 0 100%}._1o4id6s1h{flex:1 0 auto}._1o4id6s2x{margin-left:0;margin-top:0}._1o4id6s2y{margin-left:-1px;margin-top:-1px}._1o4id6s2z{margin-left:-2px;margin-top:-2px}._1o4id6s30{margin-left:-3px;margin-top:-3px}._1o4id6s31{margin-left:-4px;margin-top:-4px}._1o4id6s32{margin-left:-6px;margin-top:-6px}._1o4id6s33{margin-left:-7px;margin-top:-7px}._1o4id6s34{margin-left:-8px;margin-top:-8px}._1o4id6s35{margin-left:-9px;margin-top:-9px}._1o4id6s36{margin-left:-10px;margin-top:-10px}._1o4id6s37{margin-left:-12px;margin-top:-12px}._1o4id6s38{margin-left:-16px;margin-top:-16px}._1o4id6s39{margin-left:-20px;margin-top:-20px}._1o4id6s3a{margin-left:-24px;margin-top:-24px}._1o4id6s3b{margin-left:-28px;margin-top:-28px}._1o4id6s3c{margin-left:-32px;margin-top:-32px}._1o4id6s3d{margin-left:-40px;margin-top:-40px}}._1ec5cce1{container-name:_1ec5cce0;container-type:inline-size;overflow-y:scroll;width:100%;height:100%}@media (min-width: 1200px){._1ec5cce2{width:980px}}@container (min-width: 980px){._1ec5cce2{width:980px}}@container (max-width: 979px){._1ec5cce2{width:auto}}.ybwwtm0{align-items:center;display:grid;grid-template-columns:repeat(7,minmax(0,1fr));height:2rem;row-gap:.5rem}.ybwwtm1{align-items:center;display:grid;grid-template-columns:repeat(7,minmax(0,1fr));row-gap:.5rem}._14bi7ra0{background-color:#fff;border:var(--_1pyqka91o) solid 1px;border-radius:4px;padding-bottom:4px;padding-top:4px;width:fit-content;max-width:320px;min-width:200px;box-shadow:0 6px 12px -2px #3b3b3b1f;z-index:6}._14bi7ra2{min-height:20px;color:var(--_1pyqka9y);cursor:pointer;font-size:13px;line-height:20px}._14bi7ra2:before{content:"";margin-bottom:-.4112em;display:table}._14bi7ra2:after{content:"";margin-top:-.4242em;display:table}._14bi7ra2[aria-disabled]{cursor:default;opacity:.5}._14bi7ra2[data-active-item],._14bi7ra2:hover{background-color:var(--_1pyqka91x)}._14bi7ra3{background-color:var(--_1pyqka91w)}._14bi7ra5{background-color:var(--_1pyqka9j);border:0;height:1px;margin-bottom:4px;margin-top:4px}._14bi7ra6{align-items:center;display:flex;height:16px;justify-content:space-between;margin:0;padding-right:8px;padding-left:8px;width:100%}.in1xv90{border:none;font-size:13px;color:var(--_1pyqka9b);caret-color:var(--_1pyqka9l);outline:0;width:100%}.in1xv90::placeholder{color:var(--_1pyqka9x);font-family:Steradian,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol}.in1xv90:disabled{background:#e9e8ea}.in1xv91{text-overflow:ellipsis;overflow:hidden;white-space:nowrap}.in1xv93{height:20px}.in1xv94{height:28px}.in1xv95{width:0;padding:0;border:none}.in1xv95:focus,.in1xv95:active,.in1xv95:placeholder-shown:hover{border:none}.in1xv97{border-radius:6px;padding:4px 6px;border:var(--_1pyqka91o) solid 1px}.in1xv97:focus,.in1xv97:active{border:var(--_1pyqka91q) solid 1px}.in1xv97:placeholder-shown:hover{background:var(--_1pyqka91x);border:var(--_1pyqka91p) solid 1px}.in1xv98{padding:0;border:none}.in1xv99{border-radius:6px;border:var(--_1pyqka91o) solid 1px;cursor:pointer;display:block;padding:4px 16px;font-size:13px;color:var(--_1pyqka9c);outline:0;appearance:none;background-image:url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="1.1em" height="1.1em" fill="none" viewBox="0 0 20 20" focusable="false" > <path fill="grey" fillRule="evenodd" d="M5.293 7.293a1 1 0 0 1 1.414 0L10 10.586l3.293-3.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 0-1.414Z" clipRule="evenodd" /> </svg>');background-repeat:no-repeat;background-position:right 4px center}.in1xv99::placeholder{color:var(--_1pyqka9x)}.in1xv99:disabled{background:#e9e8ea}.in1xv99:focus{border:var(--_1pyqka91q) solid 1px}._1e9eref2{text-align:center}._1e9eref3{font-size:36px;line-height:50px;font-family:Steradian,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif;font-weight:700}._1e9eref3:before{content:"";margin-bottom:-.3364em;display:table}._1e9eref3:after{content:"";margin-top:-.3494em;display:table}._1e9eref4{font-size:30px;line-height:32px;font-family:Steradian,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif;font-weight:700}._1e9eref4:before{content:"";margin-bottom:-.1753em;display:table}._1e9eref4:after{content:"";margin-top:-.1883em;display:table}._1e9eref5{font-size:24px;line-height:34px;font-family:Steradian,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif;font-weight:700}._1e9eref5:before{content:"";margin-bottom:-.3503em;display:table}._1e9eref5:after{content:"";margin-top:-.3633em;display:table}._1e9eref6{font-size:20px;line-height:28px;font-family:Steradian,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif;font-weight:500!important}._1e9eref6:before{content:"";margin-bottom:-.342em;display:table}._1e9eref6:after{content:"";margin-top:-.355em;display:table}._12rav3x0{display:flex;align-items:center;justify-content:center;background-color:#fff;border:1px solid #e4e2e4;border-radius:6px;box-shadow:none;padding:2px 4px}._12rav3x1{height:22px;font-size:13px;line-height:20px}._12rav3x1:before{content:"";margin-bottom:-.4112em;display:table}._12rav3x1:after{content:"";margin-top:-.4242em;display:table}._1oemo0l0{display:none}._1oemo0l1{align-items:center;background-color:#fff;border:var(--_1pyqka91o) solid 1px;border-radius:6px;color:var(--_1pyqka9c);display:flex;font-size:13px;gap:4px;padding:0 8px}._1oemo0l2{background-color:#fff;border:var(--_1pyqka91o) solid 1px;border-radius:6px;min-width:150px;z-index:10}._1oemo0l3{align-items:center;display:flex;font-size:13px;gap:4px;padding:4px 8px}._1oemo0l3[data-active-item]{background-color:#e9e8ea;color:var(--_1pyqka9b);cursor:pointer}._1oemo0l4{border:var(--_1pyqka91o) solid 1px;border-radius:6px;display:flex;padding:1px}._1oemo0l3[aria-selected=true] ._1oemo0l4{background-color:var(--_1pyqka9l)}._1oemo0l3[aria-selected=false] ._1oemo0l4{background-color:#fff}._1nph9oi0{align-items:center;border:none;display:inline-flex;justify-content:center;flex-shrink:0}._1nph9oi1,._1nph9oi2{height:12px;width:12px}._1nph9oi3{height:16px;width:16px}._1nph9oib{line-height:1em;width:auto;word-break:break-word;text-align:left}._1nph9oib[disabled],._1nph9oib[disabled]:hover,._1nph9oib[disabled]:focus{background-color:var(--_1pyqka91z);border:0;box-shadow:none;color:var(--_1pyqka9x)}._1nph9oib:active{box-shadow:none;outline:none;border:0}._1nph9oib:hover{cursor:pointer}._1nph9oij{min-height:16px}._1nph9oik{min-height:20px}._1nph9oil{min-height:24px}._1nph9oim{background-color:var(--_1pyqka9l);box-shadow:inset 0 -1px #00000052;color:var(--_1pyqka9p)}._1nph9oim:hover{background-color:var(--_1pyqka9m)}._1nph9oim:active{background-color:var(--_1pyqka9n);box-shadow:none}._1nph9oim[disabled],._1nph9oim[disabled]:hover,._1nph9oim[disabled]:focus{background-color:var(--_1pyqka9o);color:var(--_1pyqka9o);box-shadow:none}._1nph9oin{background-color:var(--_1pyqka91s);border:var(--_1pyqka91k) solid 1px;box-shadow:none;color:var(--_1pyqka9r)}._1nph9oin:hover{background-color:var(--_1pyqka91t);border:var(--_1pyqka91l) solid 1px}._1nph9oin:active{background-color:var(--_1pyqka91u);border:var(--_1pyqka91m) solid 1px}._1nph9oin[disabled],._1nph9oin[disabled]:hover,._1nph9oin[disabled]:focus{border:var(--_1pyqka91n) solid 1px;color:var(--_1pyqka9q)}._1nph9oio{background-color:var(--_1pyqka91s);border:0;box-shadow:none;color:var(--_1pyqka9r)}._1nph9oio:hover{background-color:var(--_1pyqka91t)}._1nph9oio:active{background-color:var(--_1pyqka91u)}._1nph9oio[disabled],._1nph9oio[disabled]:hover,._1nph9oio[disabled]:focus{color:var(--_1pyqka9q)}._1nph9oip{background-color:var(--_1pyqka9s);box-shadow:inset 0 -1px #0000001a;color:var(--_1pyqka9w)}._1nph9oip:hover{background-color:var(--_1pyqka9t)}._1nph9oip:active{background-color:var(--_1pyqka9u);box-shadow:none}._1nph9oip[disabled],._1nph9oip[disabled]:hover,._1nph9oip[disabled]:focus{background-color:var(--_1pyqka9v);color:var(--_1pyqka9x);box-shadow:none}._1nph9oiq{background-color:var(--_1pyqka91y);border:var(--_1pyqka91o) solid 1px;box-shadow:none;color:var(--_1pyqka9y)}._1nph9oiq:hover{background-color:var(--_1pyqka91x);border:var(--_1pyqka91p) solid 1px}._1nph9oiq:active{border:var(--_1pyqka91q) solid 1px;background-color:var(--_1pyqka91y)}._1nph9oiq[disabled],._1nph9oiq[disabled]:hover,._1nph9oiq[disabled]:focus{background-color:var(--_1pyqka91z);border:var(--_1pyqka91r) solid 1px}._1nph9oir{background-color:var(--_1pyqka91w);color:var(--_1pyqka9y)}._1nph9oir:hover{background-color:var(--_1pyqka91x)}._1nph9oir:active{background-color:var(--_1pyqka91y)}._1nph9oir[disabled],._1nph9oir[disabled]:hover,._1nph9oir[disabled]:focus{background-color:var(--_1pyqka91z)}._8wggow1{align-items:center;box-shadow:none;display:inline-flex;justify-content:center;padding:4px}._8wggow1:hover{cursor:pointer}._8wggow2{height:24px;width:24px}._8wggow3{height:28px;width:28px}._8wggow4{height:32px;width:32px}._8wggow5{background:var(--_1pyqka9l);border:0;color:#fff;box-shadow:inset 0 -1px #00000052}._8wggow5:hover{background:var(--_1pyqka9m)}._8wggow5:active{background:var(--_1pyqka9n)}._8wggow5:disabled{background:var(--_1pyqka9o);color:var(--_1pyqka9q)}._8wggow6{background:var(--_1pyqka91w);border:var(--_1pyqka91o) solid 1px;color:var(--_1pyqka9y)}._8wggow6:hover{background:var(--_1pyqka91x);border:var(--_1pyqka91p) solid 1px;color:var(--_1pyqka9y)}._8wggow6:active{background:var(--_1pyqka91y);border:var(--_1pyqka91q) solid 1px;color:var(--_1pyqka9y)}._8wggow6:disabled{background:var(--_1pyqka91z);border:var(--_1pyqka91r) solid 1px;color:var(--_1pyqka9x)}._189mxz60{width:100%;height:100%;position:relative}._189mxz61{box-shadow:none}._189mxz62{display:flex}._189mxz63{height:20px;width:100%;position:absolute;top:-10px}._189mxz64{cursor:grab}._189mxz64:active{cursor:grabbing}._189mxz65{background-color:#e4e2e4;height:1px;width:100%;position:relative;top:10px}._189mxz66{background:none;border-radius:0;border-bottom:none;box-shadow:none}._189mxz66:focus:enabled,._189mxz66:active:enabled,._189mxz66:hover:enabled{background:none;box-shadow:none;border-radius:0;color:#6f6e77}._189mxz67{color:#744ed4}._189mxz68{color:#6f6e77}._189mxz69{border-radius:2px 2px 0 0;height:2px}._189mxz6a{background-color:#744ed4}._189mxz6b{background-color:var(--_1pyqka91o)}._189mxz6c{background-color:#744ed4}.hqr510{color:var(--_1pyqka9l)}.hqr510:hover{color:var(--_1pyqka9m)}.hqr510:active{color:var(--_1pyqka9n)}.hqr511{text-decoration:none}.hqr512{text-decoration:underline}.hqr513,.hqr513:hover{color:#6f6e77}.hqr513:focus{color:#6f6e77}.hqr513:active{color:#6f6e77}._17v45he0{border-radius:6px;border:var(--_1pyqka91o) solid 1px;cursor:pointer;display:block;padding:4px 6px;font-size:13px;color:var(--_1pyqka9c);outline:0;width:100%;appearance:none;background-image:url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="1.1em" height="1.1em" fill="none" viewBox="0 0 20 20" focusable="false" > <path fill="grey" fillRule="evenodd" d="M5.293 7.293a1 1 0 0 1 1.414 0L10 10.586l3.293-3.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 0-1.414Z" clipRule="evenodd" /> </svg>');background-repeat:no-repeat;background-position:right 6px center}._17v45he0::placeholder{color:var(--_1pyqka9x)}._17v45he0:disabled{background:#e9e8ea}._17v45he0:focus{border:var(--_1pyqka91q) solid 1px}._tooltip_1y9lk_1{flex-shrink:0;z-index:9999999999999!important}._tooltip_1y9lk_1 a{color:var(--text-primary-inverted)!important;text-decoration:underline}._tooltip_1y9lk_1 .ant-tooltip-inner{background:var(--color-primary-inverted-background)!important;border-radius:var(--border-radius)!important}._tooltip_1y9lk_1._hideArrow_1y9lk_13 .ant-tooltip-arrow-content{display:none}._icon_1y9lk_17{--size: var(--size-small);flex-shrink:0;height:var(--size);width:var(--size)}._icon_1y9lk_17._medium_1y9lk_23{--size: var(--size-medium)}._icon_1y9lk_17._large_1y9lk_26{--size: var(--size-large)}._content_i3h6f_1{font-size:14px}._popover_i3h6f_5{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:var(--border-radius);box-shadow:var(--box-shadow);padding-bottom:0!important;padding-left:0;padding-top:0;z-index:10000000000000000!important}._popover_i3h6f_5 .ant-popover-inner{background-color:transparent;border-radius:0;box-shadow:none}._contentContainer_i3h6f_21{padding-bottom:var(--size-xxSmall)}._contentContainer_i3h6f_21._large_i3h6f_24{padding:var(--size-small);padding-bottom:var(--size-xSmall)}._container_lgd2g_1{display:flex;margin:0 auto;position:relative;width:100%;z-index:2}._container_lgd2g_1>div{height:44px;width:100%}._tooltipPopover_lgd2g_13{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:var(--border-radius);color:var(--text-primary)!important;padding:var(--size-small) 0!important;transition:scale .2s ease-in-out}._tooltipPopover_lgd2g_13>*{padding-left:var(--size-medium)!important;padding-right:var(--size-medium)!important}._tooltipPopover_lgd2g_13>h4{border-bottom:1px solid var(--color-gray-300);font-family:var(--header-font-family);font-size:13px!important;margin-bottom:var(--size-small)!important;padding-bottom:var(--size-xSmall)}._tooltipPopover_lgd2g_13>p{color:var(--color-gray-500)!important;font-size:14px!important;margin:0!important}._popoverContent_lgd2g_38{max-height:300px;overflow:hidden;overflow-wrap:anywhere;overflow-y:auto;text-overflow:ellipsis}._title_lgd2g_46{column-gap:var(--size-xSmall);display:flex;font-weight:700}._skeleton_clrr7_1{border-radius:var(--border-radius)}._highlighterStyles_1qb5d_1{background-color:transparent;font-weight:600!important;padding:0}._tooltipOverlay_1cgd2_1{z-index:10000000000000000!important}._tooltipOverlay_1cgd2_1 a{color:var(--text-primary-inverted)!important;text-decoration:underline}._tooltipOverlay_1cgd2_1 table{border-collapse:collapse;border-spacing:0;width:100%}._tooltipOverlay_1cgd2_1 table td:first-of-type{padding-right:var(--size-small)}._tooltipOverlay_1cgd2_1 .ant-tooltip-inner{background:var(--color-primary-inverted-background)!important;border-radius:var(--border-radius)!important}._input_eommn_1{background:var(--color-gray-200)!important;border:1px solid transparent!important;border-radius:var(--border-radius)!important;color:var(--text-primary)!important;font-size:16px!important;line-height:initial!important;padding:var(--size-xSmall) var(--size-small)!important}._input_eommn_1.ant-input-lg{padding:var(--size-xSmall) var(--size-small)!important}._input_eommn_1 .ant-input-sm{padding:var(--size-xxSmall) var(--size-xxSmall)!important}._input_eommn_1 .ant-input-sm~.ant-input-suffix svg{height:var(--size-small)!important;width:var(--size-small)!important}._input_eommn_1.ant-input-group-wrapper{align-items:center;display:flex;overflow:hidden!important;padding:0!important;transition:all .3s}._input_eommn_1.ant-input-group-wrapper .ant-input:hover,._input_eommn_1.ant-input-group-wrapper .ant-input:focus,._input_eommn_1.ant-input-group-wrapper .ant-input{border-color:transparent!important;box-shadow:none!important;color:var(--text-primary)!important;font-size:16px!important;height:100%;line-height:initial!important;padding:10px!important}._input_eommn_1.ant-input-group-wrapper .ant-input-group-addon{background:transparent!important;border-color:transparent!important}._input_eommn_1.ant-input-group-wrapper .ant-input-wrapper.ant-input-group{height:100%;overflow:hidden}._input_eommn_1.ant-input-group-wrapper:focus,._input_eommn_1.ant-input-group-wrapper:active,._input_eommn_1.ant-input-group-wrapper:focus-within{background:var(--color-primary-background)!important;border-color:var(--color-purple)!important;box-shadow:0 0 0 4px rgba(var(--color-purple-rgb),.2)!important}._input_eommn_1.ant-input-group-wrapper:focus .ant-input,._input_eommn_1.ant-input-group-wrapper:active .ant-input,._input_eommn_1.ant-input-group-wrapper:focus-within .ant-input{background:var(--color-primary-background)!important}._input_eommn_1.ant-input-affix-wrapper,._input_eommn_1 .ant-input{background:var(--color-gray-200)!important;color:var(--text-primary)!important}._input_eommn_1 .ant-input-clear-icon{color:var(--color-gray-500)!important}._input_eommn_1.ant-input-affix-wrapper-sm{padding:0 var(--size-xSmall)!important}._input_eommn_1:not(.ant-input-affix-wrapper-disabled) .ant-input{background:var(--color-gray-200)!important}._input_eommn_1:not(.ant-input-affix-wrapper-disabled) .ant-input::placeholder{color:var(--color-gray-500)!important}._input_eommn_1:not(.ant-input-affix-wrapper-disabled):focus,._input_eommn_1:not(.ant-input-affix-wrapper-disabled).ant-input-affix-wrapper-focused{background:var(--color-primary-background)!important;border-color:var(--color-purple)!important;box-shadow:0 0 0 4px rgba(var(--color-purple-rgb),.2)!important}._input_eommn_1:not(.ant-input-affix-wrapper-disabled):focus .ant-input,._input_eommn_1:not(.ant-input-affix-wrapper-disabled).ant-input-affix-wrapper-focused .ant-input{background:var(--color-primary-background)!important}._input_eommn_1:not(.ant-input-affix-wrapper-disabled):hover{border-color:var(--color-purple)!important}._input_eommn_1.ant-input-affix-wrapper-disabled{background:var(--color-gray-200)!important}._modal_u71tu_1{max-width:60vw;pointer-events:unset}._modal_u71tu_1 .ant-modal-content{border-radius:var(--border-radius)!important}._modalContent_u71tu_9{overflow:visible}._title_u71tu_13{margin-bottom:var(--size-medium)!important}._modalWrap_u71tu_17{z-index:999999999}._modalBody_nihhy_1{padding:0}._modalWrapper_1x9k5_1{width:60vh}._modalSubTitle_1x9k5_5{color:var(--color-gray-500)!important;font-size:16px;line-height:1.5!important;margin-top:0!important}._queryBuilderContainer_1x9k5_12{margin-bottom:var(--size-large)!important}._segmentPickerMenu_10cqr_1{box-shadow:none;font-family:var(--header-font-family);margin-bottom:12px;min-width:200px;width:100%}._segmentPickerInner_10cqr_9{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:8px;color:var(--text-primary);min-width:220px}._segmentPickerInner_10cqr_9 ._segmentItemWrapper_10cqr_16:last-child ._segmentItem_10cqr_16{border-bottom:0}._downIcon_10cqr_20{color:var(--color-purple);height:14px;margin-left:auto;margin-right:5px;transition:.4s;width:14px}._checkIcon_10cqr_29{color:var(--color-purple);fill:var(--color-purple);height:15px;margin-bottom:2px;margin-left:auto;margin-right:5px;width:15px}._trashIcon_10cqr_39{color:var(--color-gray-500);fill:var(--color-gray-500);margin-bottom:2px}._segmentAction_10cqr_45{align-items:center;background-color:var(--color-gray-200);border:0;border-radius:5px;bottom:0;display:none;height:30px;margin:auto;padding:0 6px;position:absolute;right:5px;top:0;width:30px}._segmentAction_10cqr_45:hover{background-color:var(--color-gray-300);cursor:pointer}._segmentAction_10cqr_45:hover ._trashIcon_10cqr_39{color:var(--text-primary);fill:var(--text-primary)}._dropdownHandler_10cqr_69{align-items:center;border:1px solid var(--color-gray-300);border-radius:8px;color:var(--text-primary);cursor:pointer;display:flex;font-size:16px;height:40px;justify-content:center;margin-top:13px;padding:10px 10px 10px 14px;width:100%}._plusIcon_10cqr_85{color:var(--color-purple);fill:var(--color-purple);height:15px;margin-bottom:2px;margin-left:auto;margin-right:5px;width:15px}._newSearchDiv_10cqr_95{align-items:center;color:var(--color-purple);cursor:pointer;display:flex;font-size:14px;padding:10px 10px 10px 15px;width:100%}._newSearchDiv_10cqr_95:hover{background-color:var(--color-gray-200)}._noSegmentsText_10cqr_110{color:var(--color-gray-500);margin-top:10px}._segmentItemWrapper_10cqr_16{position:relative}._segmentItemWrapper_10cqr_16:hover{background-color:var(--color-gray-200)}._segmentItemWrapper_10cqr_16:hover ._segmentAction_10cqr_45{display:flex}._segmentItem_10cqr_16{align-items:center;border-bottom:1px solid var(--color-gray-300);cursor:pointer;display:flex;font-size:16px;padding:10px 10px 10px 15px;width:100%}._segmentText_10cqr_136{color:var(--text-primary);font-size:14px;margin-right:20px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;width:100%}._segmentUnselected_10cqr_146{color:var(--color-gray-500)}._segmentNameText_10cqr_150{display:block;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;width:100%}._modalWrapper_10cqr_159{width:60vh}._modalSubTitle_10cqr_163{color:var(--color-gray-500)!important;font-size:14px;margin-bottom:20px;margin-top:0!important}._actionsContainer_10cqr_170{column-gap:var(--size-medium);display:flex;padding-top:var(--size-medium)}._actionsContainer_10cqr_170>button{flex-grow:1;justify-content:center}._commonInputWrapper_z8rd3_1{padding:10px 0}._searchInput_z8rd3_5{padding-top:0}._switchSpan_z8rd3_9{display:inline-block;line-height:normal;vertical-align:middle}._datePicker_z8rd3_15{border:1px solid var(--color-gray-300);border-radius:var(--size-xSmall);font-family:var(--header-font-family);font-size:14px;font-weight:300!important;height:45px;width:100%}._iconWrapper_z8rd3_25{display:flex;margin:0 10px 0 0}._iconWrapper_z8rd3_25>svg{color:var(--color-gray-400)!important;height:var(--size-medium);width:var(--size-medium)}._iconWrapper_z8rd3_25>svg._fill_z8rd3_34{color:var(--color-gray-400)!important;fill:none!important}._subTitle_z8rd3_39{color:var(--text-primary);font-size:11px;margin-bottom:8px;margin-top:10px}._checkboxUnselected_z8rd3_46{color:var(--color-gray-500)}._select_z8rd3_50{width:100%}._selectWithIconContainer_z8rd3_54{position:relative;width:100%}._icon_z8rd3_25{color:var(--color-gray-400);height:var(--size-medium);position:absolute;right:10px;top:15px;width:var(--size-medium)}._sessionLengthInput_igdy7_1{height:100%;padding:12px;width:300px}._sessionLengthInputLabel_igdy7_7{color:var(--text-primary);font-size:12px}._slider_igdy7_12 .ant-slider-mark-text{font-size:12px!important}._headerContainer_igdy7_16{align-items:center;display:flex;justify-content:space-between;margin-top:var(--size-xxSmall)}._headerContainer_igdy7_16 button{color:var(--color-purple);font-size:12px;height:13px!important;padding:0}._advancedLengthInput_igdy7_29{display:flex;justify-content:space-between;margin-top:var(--size-xSmall)}._advancedLengthInput_igdy7_29 ._group_igdy7_34{display:flex;height:43px}._advancedLengthInput_igdy7_29 ._group_igdy7_34 input{border:1px solid var(--color-gray-300);width:100px}._buttonContainer_igdy7_43{display:flex;justify-content:flex-end}._setLengthButton_igdy7_48{font-size:12px;height:fit-content;width:fit-content}._3x527v0{border-top-right-radius:0;border-bottom-right-radius:0}._3x527v1{border-top-left-radius:0;border-bottom-left-radius:0}._3x527v2{display:inline-flex;height:20px}._3x527v3{height:20px;width:20px}._3x527v4{flex:1;word-break:normal;white-space:nowrap}._3x527v5{flex:1}._3x527v6{flex-shrink:0}._3x527v7{max-width:50%}._optionLabelContainer_1yzqu_1{align-items:center;display:flex;overflow:hidden;position:relative;text-overflow:ellipsis;width:100%}._optionCheckbox_1yzqu_10{margin-right:12px}._optionLabelType_1yzqu_14{background:var(--color-gray-300);border-radius:3px;color:var(--text-primary)!important;margin-right:6px;padding-left:4px;padding-right:4px;width:fit-content}._labelTypeContainer_1yzqu_24{width:60px}._highlighterStyles_1yzqu_28{background-color:transparent;font-weight:600!important;padding:0}._shadowParent_1yzqu_34{height:100%;overflow:hidden;position:relative;width:100%}._shadowContainer_1yzqu_41{height:100%;left:0;pointer-events:none;position:absolute;top:0;width:100%;z-index:100000000000000020!important}._shadowRight_1yzqu_51{background-attachment:scroll;background-image:linear-gradient(to left,rgba(255,255,255,.6),rgba(255,255,255,0));background-position:right center;background-repeat:no-repeat;background-size:20px 100%;transition:background-image .2s ease-in-out}._shadowLeft_1yzqu_60{background-attachment:scroll;background-image:linear-gradient(to right,rgba(255,255,255,.6),rgba(255,255,255,0));background-position:left center;background-repeat:no-repeat;background-size:20px 100%;transition:background-image .2s ease-in-out}._shadowBoth_1yzqu_69{background-attachment:scroll,scroll;background-image:linear-gradient(to right,rgba(255,255,255,.6),rgba(255,255,255,0)),linear-gradient(to left,rgba(255,255,255,.6),rgba(255,255,255,0));background-position:left center,right center;background-repeat:no-repeat;background-size:20px 100%,20px 100%;transition:background-image .2s ease-in-out}._optionLabelName_1yzqu_78{color:var(--text-primary)!important;overflow-x:scroll;padding-bottom:8px;padding-top:8px;scrollbar-width:none}._optionLabelName_1yzqu_78::-webkit-scrollbar{display:none}._nameLabel_1yzqu_89{color:var(--text-primary)!important;flex-grow:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._optionTooltip_1yzqu_97{color:var(--text-primary)!important;margin-left:4px}._builderContainer_1yzqu_102{border:1px solid var(--color-gray-300);border-radius:var(--border-radius);display:flex;flex-direction:column;width:100%}._builderContainer_1yzqu_102>div{border-bottom:1px solid var(--color-gray-300);gap:var(--size-xSmall);line-height:0;padding:var(--size-xSmall)}._builderContainer_1yzqu_102>div:last-child{border-bottom:0}._rulesContainer_1yzqu_121{align-items:center;column-gap:var(--size-xxSmall);display:inline-flex;flex-wrap:wrap;justify-content:flex-start;row-gap:var(--size-xSmall)}._separator_1yzqu_130{border:0;font-size:12px;justify-content:center;padding:3px;width:32px}._separator_1yzqu_130[disabled]{background:none;color:var(--color-gray-800)!important}._separator_1yzqu_130:hover{background:none!important}._separator_1yzqu_130:hover:not([disabled]){background-color:var(--color-purple-100)!important}span:first-child ._ruleItem_1yzqu_148{border-bottom-left-radius:3px;border-top-left-radius:3px}span:last-child ._ruleItem_1yzqu_148{border-bottom-right-radius:3px;border-top-right-radius:3px}._invalid_1yzqu_158{background-color:var(--color-red-400)!important}._invalid_1yzqu_158:hover{background-color:var(--color-red-600)!important}._timeRangeContainer_1yzqu_165 ._ruleItem_1yzqu_148 span{max-width:100%}._removeRule_1yzqu_169{border-bottom-right-radius:3px;border-top-right-radius:3px}._syncButton_1yzqu_174,._syncButton_1yzqu_174[disabled],._syncButton_1yzqu_174:active,._syncButton_1yzqu_174:focus,._syncButton_1yzqu_174:hover{background-color:var(--color-green-600)!important;border-radius:3px;color:var(--color-white)!important;padding:6px}._syncButton_1yzqu_174:hover{opacity:.6}._syncButton_1yzqu_174[disabled]{opacity:.2}._addFilter_1yzqu_193{border:1px dashed var(--color-purple-500);border-radius:3px;color:var(--color-purple-500)!important;font-size:12px;height:100%;margin-top:var(--size-xSmall);padding:0 4px}._menuListContainer_1yzqu_203{overflow-y:auto;scrollbar-width:none}._menuListContainer_1yzqu_203::-webkit-scrollbar{display:none}._popoverContainer_1yzqu_211{width:fit-content}._popoverContainer_1yzqu_211 .ant-popover-inner-content{padding:0}._contentContainer_1yzqu_218{display:flex;flex-direction:column;max-width:50vw;min-width:150px;padding-bottom:0;row-gap:var(--size-medium)}._contentContainer_1yzqu_218 ._label_1yzqu_24{display:flex;flex-direction:column;font-size:10px;row-gap:var(--size-xxSmall)}._controlBar_1yzqu_233{flex-shrink:0;height:44px}._menuList_1yzqu_203{overflow:hidden;padding-top:0;z-index:5}._1ukfp2a0{border-radius:0;border:0!important}._1ukfp2a0:focus,._1ukfp2a0:active{background:inherit}._1ukfp2a1{border-right:var(--_1pyqka91o) solid 1px!important}._1ukfp2a2{background:var(--_1pyqka9t)}._1ukfp2a2:focus,._1ukfp2a2:active{background:var(--_1pyqka9u)}._modalSubTitle_6e4mp_1{color:var(--color-gray-500)!important;font-size:16px;line-height:1.5!important;margin-top:0!important}._queryBuilderContainer_6e4mp_8{margin-bottom:var(--size-large)!important}._segmentPickerMenu_16b00_1{box-shadow:none;margin-bottom:12px;min-width:200px;width:100%}._segmentPickerInner_16b00_8{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:5px;color:var(--text-primary);min-width:220px}._segmentPickerInner_16b00_8 ._segmentItemWrapper_16b00_15:last-child ._segmentItem_16b00_15{border-bottom:0}._downIcon_16b00_19{color:var(--color-purple);height:14px;margin-left:auto;margin-right:5px;transition:.4s;width:14px}._checkIcon_16b00_28{color:var(--color-purple);fill:var(--color-purple);height:15px;margin-bottom:2px;margin-left:auto;margin-right:5px;width:15px}._trashIcon_16b00_38{color:var(--color-gray-500);fill:var(--color-gray-500);margin-bottom:2px}._starIcon_16b00_44{color:var(--text-primary);fill:var(--text-primary);height:1rem;margin-bottom:2px;margin-left:6px;padding:1px}._segmentAction_16b00_53{align-items:center;background-color:var(--color-gray-200);border:0;border-radius:5px;bottom:0;display:none;height:30px;margin:auto;padding:0 6px;position:absolute;right:5px;top:0;width:30px}._segmentAction_16b00_53:hover{background-color:var(--color-gray-300);cursor:pointer}._segmentAction_16b00_53:hover ._trashIcon_16b00_38{color:var(--text-primary);fill:var(--text-primary)}._dropdownHandler_16b00_77{align-items:center;border:1px solid var(--color-gray-300);border-radius:8px;color:var(--text-primary);cursor:pointer;display:flex;font-size:16px;height:40px;justify-content:center;margin-top:13px;padding:10px 10px 10px 14px;width:100%}._plusIcon_16b00_93{color:var(--color-purple);fill:var(--color-purple);height:15px;margin-bottom:2px;margin-left:auto;margin-right:5px;width:15px}._newSearchDiv_16b00_103{align-items:center;color:var(--color-purple);cursor:pointer;display:flex;font-size:14px;padding:10px 10px 10px 15px;width:100%}._newSearchDiv_16b00_103:hover{background-color:var(--color-gray-200)}._noSegmentsText_16b00_118{color:var(--color-gray-500);margin-top:10px}._segmentItemWrapper_16b00_15{position:relative}._segmentItemWrapper_16b00_15:hover{background-color:var(--color-gray-200)}._segmentItemWrapper_16b00_15:hover ._segmentAction_16b00_53{display:flex}._segmentItem_16b00_15{align-items:center;border-bottom:1px solid var(--color-gray-300);cursor:pointer;display:flex;font-size:16px;padding:10px 10px 10px 15px;width:100%}._segmentText_16b00_144{color:var(--text-primary);font-size:14px;margin-right:20px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;width:100%}._segmentUnselected_16b00_154{color:var(--color-gray-500)}._segmentUnselected_16b00_154 ._starIcon_16b00_44{color:var(--color-gray-500);fill:var(--color-gray-500)}._segmentNameText_16b00_162{display:block;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;width:100%}._liveSessionsSegment_16b00_171{align-items:center;display:flex}._liveSessionsCount_16b00_176{align-items:center;background:var(--color-purple);border-radius:13px;color:var(--color-primary-background);display:flex;font-size:10px;gap:var(--size-xSmall);height:20px;justify-content:center;line-height:normal;margin-left:var(--size-xSmall);min-width:20px;padding:0 7px}._liveSessionsCountInactive_16b00_192{opacity:.5}._modalSubTitle_16b00_196{color:var(--color-gray-500)!important;margin-bottom:20px;margin-top:0!important}._actionsContainer_16b00_202{column-gap:var(--size-medium);display:flex;padding-top:var(--size-medium)}._actionsContainer_16b00_202>button{flex-grow:1;justify-content:center}._select_1kghn_1{border-radius:var(--border-radius);color:var(--text-primary)!important;transition:all .2s ease-in-out}._select_1kghn_1 .ant-select-selector{background-color:var(--color-primary-background)!important;border:1px solid var(--color-gray-300)!important;border-radius:var(--border-radius)!important;font-family:var(--body-font-family);height:fit-content!important;padding:var(--size-xSmall) var(--size-small)!important;transition:all .2s ease-in-out}._select_1kghn_1 .ant-select-selection-placeholder{color:var(--color-gray-500)!important;left:var(--size-small)}._select_1kghn_1 .ant-select-selection-search{margin-left:0!important}._select_1kghn_1 .ant-select-arrow{align-items:center;display:flex;flex-direction:column;height:18px;width:18px}._select_1kghn_1 .ant-select-arrow>svg{height:100%;position:relative;right:-2px;top:-4px;width:100%}._select_1kghn_1 .ant-select-clear{background:var(--color-primary-background);color:var(--color-gray-400)}._select_1kghn_1.ant-select-disabled .ant-select-selector{background:var(--color-gray-300)!important}._select_1kghn_1.ant-select-multiple .ant-select-selection-item{background-color:var(--color-gray-200)!important;border-color:var(--color-gray-200)!important}._select_1kghn_1 .ant-select-selection-item-remove{color:var(--color-gray-700)!important}._select_1kghn_1.ant-select-borderless .ant-select-selector{background:transparent!important;border-color:transparent!important;color:var(--text-primary)!important}._select_1kghn_1.ant-select-borderless .ant-select-selector:active,._select_1kghn_1.ant-select-borderless .ant-select-selector:focus,._select_1kghn_1.ant-select-borderless .ant-select-selector:focus-within,._select_1kghn_1.ant-select-borderless .ant-select-selector:focus-visible{box-shadow:none!important;outline-color:transparent!important}._select_1kghn_1.ant-select-borderless.ant-select-focused:not(.ant-select-disabled).ant-select:not(.ant-select-customize-input) .ant-select-selector{border-color:transparent!important;box-shadow:none!important}._dropdownIcon_1kghn_65{display:inline}._dropdownIcon_1kghn_65 ._icon_1kghn_68{display:none}.ant-select-dropdown{z-index:100000000000000020!important}._dropdown_1kghn_65{background-color:var(--color-primary-background)!important;border:1px solid var(--color-gray-300);border-radius:var(--border-radius);box-shadow:var(--box-shadow);padding-bottom:0!important;padding-top:0!important;z-index:100000000000000020!important}._dropdown_1kghn_65 .ant-select-item-option-selected{color:var(--color-white)!important}._dropdown_1kghn_65 .ant-select-item-option-content,._dropdown_1kghn_65 ._dropdownIcon_1kghn_65{align-items:center;display:flex}._dropdown_1kghn_65 ._dropdownIcon_1kghn_65 ._icon_1kghn_68{display:contents;width:100%}._popover_6rlz1_1{display:flex;flex-direction:column;padding-bottom:var(--size-medium);row-gap:var(--size-medium);width:250px}._popover_6rlz1_1 ._label_6rlz1_8{display:flex;flex-direction:column;font-size:10px;row-gap:var(--size-xxSmall)}.niznha0{border-top-right-radius:0;border-bottom-right-radius:0}.niznha1{border-top-left-radius:0;border-bottom-left-radius:0}.niznha2{display:inline-flex;height:20px}.niznha3{height:20px;width:20px}.niznha4{flex:1;word-break:normal;white-space:nowrap}.niznha5{flex:1}.niznha6{flex-shrink:0}.niznha7{max-width:50%}._card_lh268_1{background:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:var(--border-radius);box-shadow:var(--box-shadow-2);color:var(--text-primary);max-width:500px;padding-bottom:var(--size-xLarge);padding-left:var(--size-xLarge);padding-right:var(--size-xLarge);padding-top:var(--size-xLarge)}._card_lh268_1._center_lh268_13{text-align:center}._card_lh268_1 h2{color:var(--text-primary);font-size:24px;margin:0;margin-bottom:var(--size-medium)}._card_lh268_1 p{color:var(--color-gray-500);margin-bottom:0!important}._card_lh268_1 ._content_lh268_26{font-size:16px;max-width:400px;word-wrap:break-word}._card_lh268_1 ._animation_lh268_31{margin:0 auto;margin-bottom:var(--size-large);width:250px}._card_lh268_1 ._actions_lh268_36{margin-top:var(--size-xLarge)}._elevatedCard_t9uz9_1{--width: 400px;height:calc(100% - 2 * var(--size-medium));overflow-y:auto;padding-bottom:var(--size-small);padding-left:var(--size-large);padding-right:var(--size-large);padding-top:var(--size-small);width:var(--width)}._backdrop_t9uz9_12{background:rgba(0,0,0,.25);inset:0;opacity:1;position:fixed;z-index:999999999}._elevatedCardMotion_t9uz9_20{height:calc(100% - (var(--size-medium)));position:fixed;right:var(--size-medium);top:var(--size-medium);z-index:9999999999}._searchIcon_t9uz9_28{color:var(--color-gray-500)}._container_t9uz9_32{padding-top:var(--size-large)}._container_t9uz9_32 section{padding-top:var(--size-large)}._container_t9uz9_32 table,._container_t9uz9_32 tr{width:100%}._container_t9uz9_32 tr:not(:last-of-type) td{padding-bottom:var(--size-small)}._container_t9uz9_32 p{font-size:13px!important}._container_t9uz9_32 h3{font-size:16px!important;margin-bottom:var(--size-small)!important}._kbdContainer_t9uz9_55{column-gap:var(--size-xxSmall);display:flex}._kbd_t9uz9_55{align-items:center;background:var(--color-gray-200);border-radius:var(--size-xxSmall);display:flex;font-family:var(--monospace-font-family);font-size:11px;justify-content:center;min-width:20px;padding-bottom:var(--size-xxSmall);padding-left:var(--size-xxSmall);padding-right:var(--size-xxSmall);padding-top:var(--size-xxSmall);text-transform:capitalize}._kbd_t9uz9_55._symbol_t9uz9_75{font-size:16px;line-height:0px}._description_t9uz9_80{color:var(--color-gray-800);font-size:13px;padding-right:var(--size-medium)}._shortcutContainer_t9uz9_86{display:flex;justify-content:flex-end}._emptyTitle_t9uz9_91{text-transform:capitalize}._emptyDescription_t9uz9_95{margin-top:0!important;text-align:center}._disabled_t9uz9_100{cursor:not-allowed;filter:opacity(.3)}._titleContainer_t9uz9_105{align-items:center;display:flex}._suggestionButton_t9uz9_110{align-items:center;background:var(--color-gray-300)!important;color:var(--text-primary)!important;column-gap:var(--size-small);display:flex;font-size:12px;margin-left:auto;padding-bottom:var(--size-xSmall);padding-left:var(--size-small);padding-right:var(--size-small);padding-top:var(--size-xSmall)}._suggestionButton_t9uz9_110:hover{color:var(--text-primary)}._suggestionButton_t9uz9_110._cta_t9uz9_126{background:var(--color-purple);color:var(--text-primary-inverted);font-weight:500;margin:0 auto;margin-top:var(--size-large)}._1ek953u0{z-index:99999;background-color:#6f6e777a;height:100vh;width:100vw;display:flex;justify-content:center}._1ek953u1{width:580px;top:25vh}._1ek953u2{width:100%}._1ek953u3,._1ek953u4{flex-shrink:0}._1ek953u5{border-top-right-radius:0;border-bottom-right-radius:0}._1ek953u6{border-top-left-radius:0;border-bottom-left-radius:0}._1ek953u7{flex:1}._1ek953u8:hover{cursor:pointer}.bsyaa20{text-decoration:none;color:var(--_1pyqka9y)}.bsyaa20:hover{color:var(--_1pyqka9y)}._1kpm5g60{text-decoration:none}._1kpm5g60:focus-visible{outline:revert!important}._container_djd1q_1{font-family:var(--header-font-family)}._input_djd1q_5{background:var(--color-primary-background);border:0;box-sizing:border-box;caret-color:var(--color-purple);color:var(--text-primary);font-size:14px;margin:var(--size-small);outline:none;padding:6px;width:stretch}._input-focused_djd1q_18{background-color:var(--text-primary);border-color:var(--color-red-400)}._suggestion_djd1q_23{background:var(--color-primary-background);border-left:5px solid transparent;color:var(--color-gray-700);cursor:pointer;padding:14px 12px;transition:color .2s ease-in-out}._suggestion_djd1q_23 b{color:var(--color-purple-600)}._suggestionsContainerOpen_djd1q_35{border-bottom:1px solid var(--color-gray-300);border-top:1px solid var(--color-gray-300);max-height:400px;overflow-y:auto}._suggestionsContainerOpen_djd1q_35::-webkit-scrollbar{display:none}._suggestionHighlighted_djd1q_45{background:var(--color-gray-300);border-left:5px solid var(--color-purple);color:var(--text-primary)}._modal_djd1q_51{background:var(--color-primary-background);border:0;border-radius:var(--border-radius);box-shadow:var(--box-shadow-2);inset:25% auto auto 50%;outline:none;overflow:hidden;position:absolute;transform:translate(-50%);width:605px}._suggestion_yf8tj_1{align-items:center;background:var(--header-font-family);column-gap:var(--size-small);display:flex;font-size:14px}._category_yf8tj_9{align-items:center;display:flex}._category_yf8tj_9>svg{height:12px;width:12px}._trialLink_x1tvd_1{color:var(--text-primary-inverted)!important;text-decoration:underline}._trialWrapper_x1tvd_6{align-items:center;background-color:#744ed4;color:var(--text-primary-inverted);display:flex;height:var(--banner-height);justify-content:center;width:100%;z-index:1000}._trialWrapper_x1tvd_6._productHunt_x1tvd_16{background-color:var(--color-green-600)}._trialWrapper_x1tvd_6._youtube_x1tvd_19{background-color:var(--color-red-600)}._trialWrapper_x1tvd_6._maintenance_x1tvd_22{background-color:var(--color-purple-600)}._trialWrapper_x1tvd_6._error_x1tvd_25{background-color:var(--color-red-400)}._trialWrapper_x1tvd_6._error_x1tvd_25 button{background:transparent}._trialWrapper_x1tvd_6 button{--button-size: var(--size-medium);--icon-size: var(--size-xSmall);align-items:center;background:transparent;border:0;border-radius:50%;cursor:pointer;display:flex;height:var(--button-size);justify-content:center;margin-right:var(--size-small);position:absolute;right:0;transform:scale(1.5);transform-origin:center;transition:all .2s ease-in-out;width:var(--button-size)}._trialWrapper_x1tvd_6 button svg{flex-shrink:0;height:var(--icon-size);transform-origin:center;transition:all .2s ease-in-out;width:var(--icon-size)}._trialWrapper_x1tvd_6 button:hover{transform:scale(2)}._trialTimeText_x1tvd_61{font-size:12px;padding-bottom:4px;padding-top:4px;z-index:100}._trialTimeText_x1tvd_61 a{color:#fff;text-decoration:underline}._homeLink_x1tvd_72{align-items:center;color:var(--text-primary)!important;cursor:pointer;display:flex;justify-content:center;text-decoration:none}._homeLink_x1tvd_72:hover{color:inherit;text-decoration:none}._demoLink_x1tvd_86{color:var(--color-text-primary-inverted)!important;text-decoration:underline}._demoLink_x1tvd_86:hover{color:var(--color-gray-400)!important}._button_x1tvd_95:first-of-type{border-top-right-radius:0;border-bottom-right-radius:0}._button_x1tvd_95:not(:first-of-type){border-top-left-radius:0;border-bottom-left-radius:0;border-left:1px solid #dcdbdd}._leadAlignLayout_1i40a_1{height:min-content;margin:40px 80px 20px;max-width:650px;padding-bottom:var(--size-xxLarge);width:100%}._leadAlignLayout_1i40a_1._fullWidth_1i40a_8{max-width:100%}._leadAlignLayout_1i40a_1 ._subTitle_1i40a_11{color:var(--color-gray-500);font-size:18px;margin-bottom:var(--size-xLarge)!important}._card_iv1eg_1{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:var(--border-radius);overflow:hidden;padding:var(--size-large);transition:border-color .1s ease-in-out,box-shadow .2s ease-in-out;width:100%}._card_iv1eg_1._noPadding_iv1eg_10{padding:0}._card_iv1eg_1._full_iv1eg_13{height:100%}._card_iv1eg_1 h2,._card_iv1eg_1 ._cardHeader_iv1eg_17{font-size:22px!important;margin-bottom:var(--size-medium)!important}._card_iv1eg_1 h3{font-size:16px!important;margin-bottom:var(--size-xSmall)!important}._card_iv1eg_1 p{color:var(--color-gray-500);margin-top:0!important}._card_iv1eg_1 section{padding-bottom:var(--size-medium)}._card_iv1eg_1 section:last-of-type{padding-bottom:var(--size-large)}._card_iv1eg_1 ._titleContainer_iv1eg_35{border-bottom:1px solid var(--color-gray-300);font-size:14px!important;margin:0 calc(-1 * var(--size-large));margin-bottom:var(--size-small);margin-top:calc(-1 * var(--size-xSmall));padding-bottom:0;padding-left:var(--size-large);padding-right:var(--size-large);padding-top:0}._card_iv1eg_1 ._titleContainer_iv1eg_35._noTitleBottomMargin_iv1eg_46{margin-bottom:0}._card_iv1eg_1 ._titleContainer_iv1eg_35 h3{margin-bottom:var(--size-medium)!important}._card_iv1eg_1:hover._interactable_iv1eg_52{border-color:var(--color-purple);box-shadow:0 5px 8px #5629c633}._cardForm_iv1eg_57{display:flex;flex-direction:column;row-gap:var(--size-large)}._cardSubHeader_iv1eg_63{color:var(--color-gray-500)!important;font-size:16px;line-height:1.5!important;margin-bottom:var(--size-large)!important}._cardFormActionsContainer_iv1eg_70{display:flex;flex-direction:column;row-gap:var(--size-medium)}._integration_14mrc_1 ._logo_14mrc_1{border-radius:50%;height:var(--size-xxLarge);width:var(--size-xxLarge)}._integration_14mrc_1 ._header_14mrc_6{align-items:flex-start;display:flex;justify-content:space-between;padding-bottom:var(--size-small)}._integration_14mrc_1 ._connectButton_14mrc_12{text-transform:uppercase}._integration_14mrc_1 ._title_14mrc_15{margin-bottom:var(--size-small)!important}._integration_14mrc_1 ._description_14mrc_18{margin-bottom:0!important}._modal_14mrc_22 footer{column-gap:var(--size-medium);display:flex;justify-content:flex-end;padding-top:var(--size-large)}._normalTableSizing_1oyoa_1{--padding-x: var(--size-large);--padding-y: var(--size-medium)}._smallTableSizing_1oyoa_6{--padding-x: var(--size-medium);--padding-y: var(--size-small)}._table_1oyoa_11 .ant-table-thead>tr>th{background:transparent!important;border-bottom:1px solid var(--color-gray-300)!important;border-top:1px solid var(--color-gray-300)!important;color:var(--color-gray-800)!important;font-weight:400!important;padding-bottom:var(--size-xSmall)!important;padding-top:var(--size-xSmall)!important}._table_1oyoa_11 tr>.ant-table-cell{border-bottom:1px solid var(--color-gray-300)!important;padding-bottom:var(--padding-y)!important;padding-top:var(--padding-y)!important}._table_1oyoa_11 .ant-table-row:last-of-type>.ant-table-cell{border-bottom:0!important}._table_1oyoa_11 .ant-table-tbody>tr.ant-table-row:hover>td{background:none!important;cursor:auto}._table_1oyoa_11 .ant-table{background:var(--color-primary-background);color:var(--text-primary)!important}._table_1oyoa_11._interactable_1oyoa_36 .ant-table-tbody>tr.ant-table-row:hover>td{background:var(--color-gray-100)!important;cursor:pointer}._table_1oyoa_11 .ant-table-placeholder .ant-table-cell{border-bottom:0!important}._table_1oyoa_11._rowHasPadding_1oyoa_43 tr>.ant-table-cell:first-of-type{padding-left:var(--padding-x)!important}._table_1oyoa_11._rowHasPadding_1oyoa_43 tr>.ant-table-cell:last-of-type{padding-right:var(--padding-x)!important}._modalBtn_i09bj_1{padding-bottom:4px!important;padding-top:4px!important}._modalBtnIcon_i09bj_6{margin-right:.5rem}._modalSubTitle_i09bj_10{color:var(--color-gray-500)!important;font-size:16px;margin-bottom:20px;margin-top:0!important}._modalBtnText_i09bj_17{align-items:center;display:inline-flex!important;height:100%}._select_i09bj_23 .ant-select-selection-item-content{max-width:150px}._projectInput_i09bj_27{font-size:14px!important}._dot_gor0a_1{--pulse-color: 86, 41, 198;background-color:var(--color-purple);border-radius:10px;height:var(--size-xSmall);width:var(--size-xSmall)}._dotRed_gor0a_9{--pulse-color: 255, 0, 0;background-color:var(--color-red)}._pulse_gor0a_14{animation:_pulse_gor0a_14 2s infinite}@keyframes _pulse_gor0a_14{0%{box-shadow:0 0 0 0 rgba(var(--pulse-color),.7)}70%{box-shadow:0 0 0 10px rgba(var(--pulse-color),0)}to{box-shadow:0 0 0 0 rgba(var(--pulse-color),0)}}._container_1h4bj_1{align-items:flex-start;row-gap:var(--size-xxSmall);display:flex;flex-direction:column;justify-content:space-between;max-height:fit-content;min-height:var(--size-xxLarge)}._switchClass_1h4bj_11{flex-shrink:0}._select_1h4bj_15{width:100%}._select_1h4bj_15.ant-select-disabled .ant-select-selector{background-color:var(--color-primary-background)!important}._box_14vj7_1{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:8px;max-width:500px;padding:30px}._title_14vj7_9{font-size:24px;margin-bottom:10px}._subTitle_14vj7_14{color:var(--color-gray-500)!important;font-size:16px;line-height:1.5!important;margin-bottom:var(--size-large)!important}._switchWorkspace_14vj7_21{color:var(--color-purple);cursor:pointer}._button_14vj7_26{display:flex;margin-bottom:0;margin-top:0}._button_14vj7_26 ._workspaceCount_14vj7_31{color:var(--color-white);font-size:var(--size-xSmall);height:var(--size-small);margin-left:var(--size-xxSmall);width:var(--size-small)}._cardForm_14vj7_39{grid-row-gap:20px}._inputLabel_14vj7_43{display:flex;flex-direction:column;gap:4px;justify-content:space-between;margin-top:-6px}._promoCodeToggle_14vj7_51{color:var(--color-purple);cursor:pointer;margin-top:-6px;width:fit-content}._bodyWrapper_16hbb_1{display:flex;height:calc(100% - var(--header-height));overflow-x:hidden;position:relative;width:100%}._bodyWrapper_16hbb_1._bannerShown_16hbb_8{animation:.5s forwards;height:calc(100% - var(--header-height) - var(--banner-height))}._submitButton_16hbb_13{align-items:center;display:flex;justify-content:center;margin:8px 0;min-height:40px;outline:none;width:100%}._errorMessage_16hbb_23{color:var(--color-red-400);margin-left:5px}._secondaryButton_16hbb_28{align-items:center;display:flex;justify-content:center;margin:8px 0;width:100%}._title_16hbb_36{font-size:28px;font-weight:400}._box_1js2t_1{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:8px;max-width:500px;padding:30px}._title_1js2t_9{font-size:22px;margin-bottom:10px}._subTitle_1js2t_14{color:var(--color-gray-500)!important;font-size:14px;line-height:1.5!important;margin-bottom:var(--size-large)!important}._inputLabel_1js2t_21{display:flex;flex-direction:column;font-size:12px;gap:10px;justify-content:space-between;margin-bottom:var(--size-large)}._formInput_1js2t_30{font-size:14px!important}._button_1js2t_34{margin-bottom:0;margin-top:var(--size-large)}._inline_1eto1_1{color:var(--color-link)!important;display:inline;padding:0!important}._inline_1eto1_1>*{text-decoration:underline!important}._box_1jyd5_1{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:8px;max-width:500px;padding:30px}._title_1jyd5_9{font-size:24px;margin-bottom:10px}._subTitle_1jyd5_14{color:var(--color-gray-500)!important;font-size:16px!important;line-height:1.5!important;margin-bottom:var(--size-large)!important}._fullWidth_1jyd5_21{width:100%}._intercomButton_1jyd5_25{color:var(--color-purple);cursor:pointer;display:inline-block;line-height:1}._button_1jyd5_32{display:flex;margin-bottom:0;margin-top:var(--size-large)}._tag_12yz4_1{align-items:center;border-radius:var(--size-large);color:var(--text-primary);column-gap:var(--size-xxSmall);display:flex;font-size:12px;height:var(--size-large);padding:var(--size-xxSmall) var(--size-small);width:fit-content}._box_z0dv5_1{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:8px;max-width:500px;padding:30px}._title_z0dv5_9{font-size:24px;margin-bottom:10px}._subTitle_z0dv5_14{color:var(--color-gray-500)!important;font-size:16px!important;line-height:1.5!important;margin-bottom:var(--size-large)!important}._fullWidth_z0dv5_21{width:100%}._newWorkspace_z0dv5_25{color:var(--color-purple);cursor:pointer}._joinButton_z0dv5_30{margin-left:auto}._intercomButton_z0dv5_34{color:var(--color-purple);cursor:pointer;display:inline-block;line-height:1}._button_z0dv5_41{display:flex;margin-bottom:0;margin-top:var(--size-large)}._container_y1zv8_1{position:relative;font-size:13px}._downloadButton_y1zv8_6{position:absolute;right:0;z-index:5}._emptyCardPlaceholder_1j6pu_1{cursor:auto;display:flex;flex-direction:column;justify-content:center}._graphicContainer_1j6pu_8{margin-bottom:var(--size-xLarge);margin-top:var(--size-xLarge)}._graphicContainer_1j6pu_8._compact_1j6pu_12{margin-bottom:var(--size-small);margin-top:var(--size-medium)}._10haslo0{display:flex;flex-direction:column;flex-grow:1;justify-content:flex-end}._10haslo1{background-color:#908e96;border-radius:4px;height:0;width:100%}._10haslo2{background-color:#744ed4}._10haslo3{align-items:flex-end;display:flex;justify-content:flex-end}._emptyStateSection_14p25_1{align-items:center;border:1px solid var(--color-gray-300);border-radius:8px;display:flex;justify-content:center;margin:10px;padding:20px;width:max-content}._emptyStateWrapper_14p25_12{align-items:center;display:flex;flex-direction:column;height:100%;width:100%}._emptyStateWrapper_14p25_12 svg{height:30px;width:220px}._emptySubTitle_14p25_24{color:var(--color-gray-500);font-size:var(--size-small)!important;margin:0 auto!important;max-width:350px;text-align:center}._emptyTitle_14p25_32{font-size:14px;font-weight:400!important;margin-top:30px!important;text-align:center}._intercomButton_14p25_39{color:var(--color-purple);cursor:pointer;display:inline-block;line-height:1}._newFeedStyles_14p25_46 ._emptyStateWrapper_14p25_12 svg{height:20px;width:120px}._newFeedStyles_14p25_46 ._emptyStateSection_14p25_1{padding:10px}._newFeedStyles_14p25_46 ._emptySubTitle_14p25_24{font-size:var(--size-small)!important;margin-top:var(--size-small)!important}._newFeedStyles_14p25_46 ._emptyTitle_14p25_32{font-size:14px!important;font-weight:400!important;margin-bottom:0!important;margin-top:var(--size-small)!important}._statusCell_140f1_1{align-items:center;display:flex;gap:.1rem;justify-content:center;padding:1.5rem .5rem}._statusCell_140f1_1>label>span{width:3.75rem}._container_mz1af_1{align-items:center;column-gap:var(--size-xSmall);display:flex;margin-top:var(--size-xSmall)}._container_mz1af_1 ._adminContainer_mz1af_7{color:var(--color-gray-500)}._container_mz1af_1 ._adminContainer_mz1af_7 ._value_mz1af_10{color:var(--color-gray-600);font-weight:500}._configurationContainer_pn353_1{display:flex;flex-direction:column;row-gap:var(--size-large)}._configurationContainer_pn353_1 .ant-form-item{margin-bottom:0}._integrationAlert_pn353_10{margin-bottom:var(--size-xxLarge)}._cellWithTooltip_pn353_14{column-gap:var(--size-xxSmall);display:flex;padding:0 .5rem}._nameCell_pn353_20{align-items:flex-start;display:flex;flex-direction:column;height:auto}._nameCell_pn353_20 ._primary_pn353_26{font-size:16px;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;width:500px}._subTitleContainer_pn353_35{align-items:center;display:flex;height:40px;margin-bottom:var(--size-medium);margin-top:var(--size-small)}._subTitleContainer_pn353_35 p{align-self:flex-start;color:var(--color-gray-500);font-size:18px;margin-bottom:0!important;margin-top:0!important}._subTitleContainer_pn353_35 ._callToAction_pn353_49{margin-left:auto;transform:translateY(-49px)}._configureButton_pn353_54{align-items:center;color:var(--color-gray-500)!important;display:flex;font-weight:300;justify-content:flex-end}._configureButton_pn353_54:hover{color:var(--color-gray-500)!important}._configureButton_pn353_54 svg{color:var(--color-gray-400);height:var(--size-large);width:var(--size-large)}._emptyContainer_pn353_70{cursor:auto;display:flex;flex-direction:column;margin:0 auto;max-width:400px;padding-bottom:var(--size-xLarge);padding-top:var(--size-xLarge)}._intercomButton_pn353_80{color:var(--color-purple);cursor:pointer;display:inline-block;line-height:1}._chart_pn353_87{display:flex;justify-content:center}._chart_pn353_87 ._innerChart_pn353_91{align-items:center;background-color:var(--color-gray-100);border-radius:5px;display:flex;height:54px;justify-content:center;padding:var(--size-small);width:124px}._frequencyGraphEmptyMessage_pn353_102{font-size:12px;margin-bottom:0!important}._avatarWrapper_1av3u_1{align-items:center;display:flex;height:100%;justify-content:center;position:relative}._readMarkerContainer_1av3u_9{align-items:center;display:flex;margin-left:6px;position:relative;width:8px}._topText_1av3u_17{color:var(--color-gray-500);font-size:12px;margin:0!important;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._middleText_1av3u_26{color:var(--text-primary);font-size:14px;margin:0!important;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._bottomText_1av3u_35{color:var(--text-primary);font-size:12px;margin:0!important;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._sessionTextSection_1av3u_44{max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._sessionTextSection_1av3u_44._detailed_1av3u_50{max-width:250px}._sessionTextSection_1av3u_44._errorVersion_1av3u_53{max-width:185px}._detailedSection_1av3u_57{display:grid;gap:var(--size-xxSmall);grid-template-columns:1fr 1fr;max-width:unset;padding-top:var(--size-xSmall)}._detailedSection_1av3u_57._withLongDatetimeFormat_1av3u_64{grid-template-columns:1.7fr 1fr}._identifier_1av3u_68{align-items:center;display:flex}._backfilledIcon_1av3u_73{align-items:center;background-color:var(--color-gray-600);border-radius:2.5px;color:var(--color-white);display:flex;font-size:18px;height:var(--size-medium);justify-content:center;margin-left:var(--size-xSmall);width:var(--size-medium)}._backfilledIcon_1av3u_73 svg{height:var(--size-small);width:var(--size-small)}._tagWrapper_1av3u_90{display:flex;flex-flow:row wrap;height:28px;overflow:hidden}._sessionCardWrapper_1av3u_97{position:relative}._sessionCardWrapper_1av3u_97:hover ._sessionCardAction_1av3u_100{display:flex}._sessionCardAction_1av3u_100{align-items:center;background-color:var(--color-primary-background);border:0;border-radius:var(--border-radius);bottom:0;display:none;height:30px;margin:auto;padding:0 6px;position:absolute;right:8px;top:0;width:30px}._sessionCardAction_1av3u_100:hover{background-color:var(--color-gray-300);cursor:pointer}._sessionCardAction_1av3u_100:hover ._actionIcon_1av3u_123{color:var(--text-primary);fill:var(--text-primary);stroke:var(--text-primary)}._actionIcon_1av3u_123{color:var(--color-gray-500);fill:var(--color-gray-500);stroke:var(--color-gray-500)}._starredIconWrapper_1av3u_135{bottom:0;display:flex;height:30px;left:8px;margin:auto;padding:6px;position:absolute;top:0;width:30px;z-index:5}._starredIconWrapper_1av3u_135:hover{cursor:pointer}._starredIconWrapper_1av3u_135:hover ._actionIcon_1av3u_123{color:var(--text-primary);fill:var(--text-primary);stroke:var(--text-primary)}._starredIcon_1av3u_135{color:var(--color-yellow-200);fill:var(--color-yellow-200);stroke:var(--color-yellow-200)}._sessionCard_1av3u_97{border:1px solid var(--color-gray-300);border-radius:var(--size-xSmall);cursor:pointer;font-weight:400;margin-bottom:var(--size-small);position:relative;transition:box-shadow .1s ease-in}._sessionCard_1av3u_97:not(:first-of-type){margin-top:14px}._sessionCard_1av3u_97:before{background-color:var(--color-purple);border-bottom-left-radius:var(--size-xSmall);border-top-left-radius:var(--size-xSmall);content:"";height:100%;left:0;opacity:0;position:absolute;top:0;transition:opacity .1s ease-in;width:8px;z-index:99}._sessionCard_1av3u_97._selected_1av3u_188{border:1px solid var(--color-purple);box-shadow:0 0 9px #5629c640}._sessionCard_1av3u_97._selected_1av3u_188:before{opacity:1}._sessionCard_1av3u_97:hover:not(._linkDisabled_1av3u_195){border:1px solid var(--color-purple);box-shadow:0 0 9px #5629c640}._sessionCard_1av3u_97._linkDisabled_1av3u_195{cursor:not-allowed}._sessionCard_1av3u_97 ._activityGraphContainer_1av3u_202{border-top:1px solid var(--color-gray-300);width:100%}._sessionCardContentWrapper_1av3u_207{align-items:center;column-gap:var(--size-medium);display:grid;grid-template-columns:26px 1fr .5fr;padding:var(--size-medium);width:100%}._sessionCardContentWrapper_1av3u_207._detailed_1av3u_50{grid-template-columns:26px 1fr .25fr}._sessionCardContentWrapper_1av3u_207._compact_1av3u_218{grid-template-columns:1fr .33fr}._sessionCardContentWrapper_1av3u_207._errorVersion_1av3u_53{grid-template-columns:26px 1fr}._sessionTextSectionWrapper_1av3u_225{display:flex;flex-direction:column;justify-content:space-between}._cardAnnotationContainer_1av3u_231{column-gap:var(--size-medium);display:flex;justify-content:flex-end}._cardAnnotationContainer_1av3u_231._detailed_1av3u_50{flex-wrap:wrap;justify-content:flex-start;row-gap:var(--size-medium)}._cardAnnotationContainer_1av3u_231>div{height:16px;width:16px}._cardAnnotation_1av3u_231{align-items:center;background:var(--primary-color);border-radius:2.5px;color:var(--color-white);display:flex;height:var(--size-medium);justify-content:center;width:var(--size-medium)}._cardAnnotation_1av3u_231 svg{height:var(--size-xSmall);width:var(--size-xSmall)}._separator_1av3u_261{margin-left:1ch;margin-right:1ch}._h2_1wwat_1{display:inline}._icon_1wwat_5{height:var(--size-large);padding-top:var(--size-xxSmall);width:var(--size-large)}._breadcrumb_1wwat_11{align-items:center;display:flex}._breadcrumb_1wwat_11 .ant-breadcrumb-separator{color:var(--color-gray-400);margin-left:var(--size-xxSmall)!important;margin-right:var(--size-xxSmall)!important}._breadcrumb_1wwat_11>span{align-items:center;display:flex}._disabled_1wwat_25{pointer-events:none}._channelSelect_ejzcm_1{margin-bottom:var(--size-medium);width:100%}._channelSelect_ejzcm_1:last-of-type{margin-bottom:0}._saveButton_ejzcm_9{justify-content:center;width:125px}._alertConfigurationCard_ejzcm_14 ._subTitle_ejzcm_14{margin-top:var(--size-small)!important}._alertConfigurationCard_ejzcm_14 h2{font-size:22px!important;margin-bottom:0!important}._alertConfigurationCard_ejzcm_14 h3{font-size:16px!important;margin-bottom:var(--size-xSmall)!important}._alertConfigurationCard_ejzcm_14 p,._alertConfigurationCard_ejzcm_14 section>span{color:var(--color-gray-500);display:block;margin-bottom:var(--size-medium)!important;margin-top:0!important}._alertConfigurationCard_ejzcm_14 section{padding-bottom:var(--size-xxLarge)}._alertConfigurationCard_ejzcm_14 section:last-of-type{padding-bottom:var(--size-xLarge)}._alertConfigurationCard_ejzcm_14 .ant-form-item:last-of-type{margin-bottom:0}._addContainer_ejzcm_42{color:var(--color-gray-500);padding:0 var(--size-small)}._notFoundMessage_ejzcm_47{padding:var(--size-small) 0}._frequencyContainer_ejzcm_51{column-gap:var(--size-large);display:flex}._lookbackPeriodSelect_ejzcm_56{width:150px!important}._actionsContainer_ejzcm_60{column-gap:var(--size-large);display:flex;margin-left:auto}._footer_ejzcm_66{display:flex}._notFoundContentEmail_ejzcm_70{color:var(--color-gray-500);padding:var(--size-medium) 0}._selectMessage_1dqb2_1{color:var(--color-gray-500)}._notFoundMessage_1dqb2_5{padding-left:var(--size-xSmall) 0;padding-right:var(--size-xSmall) 0}._syncButton_1dqb2_10{color:var(--color-link)!important;display:inline-flex;font-weight:400;padding:0}._small_1dqb2_17{display:flex;padding:0}._inputNumber_1arvo_1{background:var(--color-primary-background)!important;border:1px solid var(--color-gray-300)!important;border-radius:var(--border-radius);color:var(--text-primary)!important;padding-bottom:var(--size-xSmall)!important;padding-left:var(--size-xSmall)!important;padding-right:var(--size-xSmall)!important;padding-top:var(--size-xSmall)!important}._inputNumber_1arvo_1 .ant-input-number-input{padding:0}._inputNumber_1arvo_1.ant-input-number-focused{border-color:#2f80ed80!important;border-right-width:1px!important;box-shadow:0 0 0 2px #2f80ed80!important;outline:0}._inputNumber_1arvo_1.ant-input-number:hover{border-color:#2f80ed80!important;border-right-width:1px!important}._inputNumber_1arvo_1 .ant-input-number-handler-wrap{background-color:var(--color-primary-background)!important;border-color:var(--color-gray-300)!important;border-radius:0 var(--border-radius) var(--border-radius) 0}._inputNumber_1arvo_1 .ant-input-number-handler-wrap svg{color:var(--text-primary)!important}._inputNumber_1arvo_1 .ant-input-number-handler-down{border-color:var(--color-gray-300)!important}._labelItem_wjar6_1{align-items:center;border-bottom:1px solid var(--color-gray-300);cursor:pointer;display:flex;font-size:14px;padding:10px 10px 10px 6px;width:100%}._labelItem_wjar6_1:hover{background-color:var(--color-gray-200)}._labelText_wjar6_15{color:var(--text-primary);margin-left:6px;margin-right:12px}._dropdownInner_wjar6_21{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:5px;box-shadow:var(--box-shadow);color:var(--text-primary);margin-top:9px}._dropdownMenu_wjar6_30{box-shadow:none}._icon_wjar6_34{color:var(--color-purple);height:16px;margin-left:4px;transition:.4s;width:16px}._labelNameText_wjar6_42{align-items:center;display:flex;margin-left:6px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;width:100%}._dropdownHandler_wjar6_52{align-items:center;background:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:8px;color:var(--text-primary);cursor:pointer;display:flex;font-size:14px;height:40px;justify-content:center;padding:10px 10px 10px 6px}._dropdownHandler_wjar6_52._dropdownGray_wjar6_65{background:var(--color-gray-200)!important;border:1px solid transparent!important}._overlay_wjar6_70{z-index:9999999999!important}._placeholder_wjar6_74{color:var(--color-gray-400)!important}._tooltip_qqyxl_1{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:var(--border-radius);box-shadow:var(--box-shadow);color:var(--text-primary)!important;padding:var(--size-small) 0!important}._tooltip_qqyxl_1>*{padding-left:var(--size-medium)!important;padding-right:var(--size-medium)!important}._tooltip_qqyxl_1>h4{border-bottom:1px solid var(--color-gray-300);font-family:var(--header-font-family);font-size:13px!important;margin-bottom:var(--size-small)!important;padding-bottom:var(--size-xSmall)}._tooltip_qqyxl_1>p{color:var(--color-gray-500)!important;font-size:14px!important;margin:0!important}.recharts-tooltip-wrapper:focus-visible{outline:none}._verticalSlider_1098s_1{height:166px;margin-top:50px;position:absolute}._horizontalSlider_1098s_7{height:16px;left:31px;margin-right:45px;position:absolute;top:38px}._sliderThumb_1098s_15{background-color:var(--color-primary-background);border:3px solid var(--color-gray-300);border-radius:var(--border-radius);color:var(--color-purple-500);font-size:8px;left:50px;padding:2px;position:absolute}._sliderTrack_1098s_26{width:500px}._metric_jsssh_1{--good-color: var(--color-green-500) !important;--needs-improvement-color: var(--color-yellow-500) !important;--poor-color: var(--color-red-500) !important}._metric_jsssh_1 ._name_jsssh_6,._metric_jsssh_1 ._value_jsssh_7{display:flex;font-size:12px!important;font-weight:500!important;margin-bottom:0!important}._metric_jsssh_1 ._value_jsssh_7{column-gap:.25ch}._metric_jsssh_1 ._units_jsssh_16{color:var(--color-gray-500)!important;font-weight:400!important}._metric_jsssh_1._goodScore_jsssh_20{color:var(--good-color)}._metric_jsssh_1._needsImprovementScore_jsssh_23{color:var(--needs-improvement-color)}._metric_jsssh_1._poorScore_jsssh_26{color:var(--poor-color)}._simpleMetric_jsssh_30{align-items:center;column-gap:var(--size-xSmall);display:grid;grid-template-columns:3fr auto}._detailedMetric_jsssh_37{align-items:center;column-gap:var(--size-xSmall);display:flex}._detailedMetric_jsssh_37 ._name_jsssh_6{width:6ch}._detailedMetric_jsssh_37 ._value_jsssh_7{margin-left:auto;transform:translateY(-100%)}._detailedMetric_jsssh_37 ._value_jsssh_7._mirror_jsssh_49{position:absolute;right:0}._infoTooltip_jsssh_54{color:var(--color-gray-500)!important}._scoreVisualization_jsssh_58{--color: transparent;column-gap:2px;display:flex;height:1ch;position:relative;width:100%}._scoreVisualization_jsssh_58>div{background-color:var(--color-gray-300);border-radius:var(--size-xxSmall);flex-grow:1;height:100%}._scoreVisualization_jsssh_58 ._poor_jsssh_26{--color: var(--poor-color)}._scoreVisualization_jsssh_58 ._needsImprovement_jsssh_23{--color: var(--needs-improvement-color)}._scoreVisualization_jsssh_58 ._good_jsssh_20{--color: var(--good-color)}._scoreVisualization_jsssh_58 ._active_jsssh_81{background-color:var(--color)}._scoreVisualization_jsssh_58 ._scoreIndicator_jsssh_84{--size: var(--size-medium);background:var(--color-white);border:2px solid var(--color-gray-400);border-radius:50%;box-shadow:var(--box-shadow);flex-grow:0;flex-shrink:0;height:var(--size);left:0;position:absolute;top:calc(var(--size) / -4);transition:left .2s ease-in;width:var(--size);z-index:2}._legendValue_a1rwg_1{color:var(--color-gray-500)!important;overflow:hidden;text-overflow:ellipsis}._legendValue_a1rwg_1._notShowing_a1rwg_6{text-decoration:line-through}._legendIcon_a1rwg_10{border-radius:2px;flex-shrink:0;height:var(--size-small);margin-bottom:auto;margin-top:auto;width:var(--size-small)}._legendIcon_a1rwg_10._notShowing_a1rwg_6{filter:grayscale(.5)}._referenceLineValue_a1rwg_22{color:var(--color-gray-500)}._tooltipGrid_a1rwg_26{display:grid;grid-column-gap:var(--size-xSmall);grid-template-columns:1fr 10px 64px 10px;width:100%}._scoreIcon_a1rwg_33{--size: var(--size-small);align-items:center;color:var(--color-gray-500);display:flex;flex-shrink:0;height:var(--size);width:var(--size)}._tooltipValue_a1rwg_43{color:var(--text-primary);font-size:12px;line-height:initial}._text_a1rwg_49{-ms-overflow-style:none;scrollbar-width:none}._text_a1rwg_49::-webkit-scrollbar{width:0!important}._legendContainer_h2jc0_1{align-items:center;display:flex;justify-content:center;margin-top:var(--size-xSmall)}._legendItem_h2jc0_8{align-items:center;color:var(--color-gray-500)!important;column-gap:var(--size-xxSmall);display:flex;font-size:12px;padding-bottom:0!important;padding-top:0!important}._legendValue_h2jc0_18{color:var(--color-gray-500)!important}._legendValue_h2jc0_18._notShowing_h2jc0_21{text-decoration:line-through}._legendIcon_h2jc0_25{border-radius:2px;flex-shrink:0;height:var(--size-small);width:var(--size-small)}._legendIcon_h2jc0_25._notShowing_h2jc0_21{filter:grayscale(.5)}._tooltipEntry_h2jc0_35{align-items:center;column-gap:var(--size-xxSmall);display:flex;margin-bottom:0!important}._referenceLineValue_h2jc0_42{color:var(--color-gray-500)}._tooltipRow_h2jc0_46{align-items:center;column-gap:var(--size-xSmall);display:flex;justify-content:space-between;width:100%}._scoreIcon_h2jc0_54{--size: var(--size-small);align-items:center;color:var(--color-gray-500);display:flex;flex-shrink:0;height:var(--size);width:var(--size)}._tooltipValue_h2jc0_64{color:var(--text-primary);font-size:12px;line-height:initial}._button_1tsha_1{background:none;border:1px solid var(--color-gray-400);border-radius:var(--border-radius);cursor:pointer;padding:var(--size-small);position:relative;text-align:left;transition:border-color .1s ease-in-out,box-shadow .2s ease-in-out}._button_1tsha_1:hover{border-color:var(--color-purple);box-shadow:0 5px 8px #5629c633}._button_1tsha_1 p{font-size:12px!important;margin:0!important;margin-top:var(--size-xSmall)!important}._button_1tsha_1 h4{font-weight:500!important}._button_1tsha_1 ._icon_1tsha_23{--size: var(--size-medium);align-items:center;background:var(--color-purple);border-radius:50%;color:var(--color-white);display:flex;height:var(--size);justify-content:center;position:absolute;right:var(--size-small);top:var(--size-small);width:var(--size)}._button_1tsha_1 ._icon_1tsha_23 svg{--size: var(--size-small);height:var(--size);width:var(--size)}._select_3y5oy_1{border-radius:var(--border-radius)!important;height:40px;width:100%}._select_3y5oy_1 .ant-select-selection-search{align-items:center;display:flex}._select_3y5oy_1 .ant-select-selector{border:1px solid var(--color-gray-300)!important;border-radius:var(--border-radius)!important;font-family:var(--body-font-family);font-size:16px;height:40px!important;padding:var(--size-xSmall) var(--size-medium)!important}._select_3y5oy_1 .ant-select-selection-placeholder{left:14px}._select_3y5oy_1 .ant-select-selector{border:0!important;border-color:transparent!important;box-shadow:none!important}._select_3y5oy_1 .ant-select-selection-item{display:none}._select_3y5oy_1 .ant-select-selector{background-color:var(--color-gray-200)!important}._select_3y5oy_1 .ant-select-arrow{align-items:center;display:flex;flex-direction:column;height:18px;width:100%}._select_3y5oy_1 .ant-select-arrow>svg{color:var(--text-primary);height:100%;position:relative;right:-10px;top:-3px;width:100%}._select_3y5oy_1 .ant-select-selector:hover .ant-select-open{background:var(--color-gray-300)!important}._select_3y5oy_1 .ant-select-selector:hover .ant-select-open ._ant-select-selector_3y5oy_10{background-color:var(--color-gray-300)!important;border-radius:var(--border-radius)!important}._minMaxRow_3qnus_1{display:grid;grid-gap:var(--size-medium);grid-template-columns:80px 1fr 150px 80px 1fr 150px}._formLabel_3qnus_7{margin-bottom:0;margin-top:4px}._submitRow_3qnus_12{column-gap:var(--size-medium);display:flex;justify-content:flex-end;margin-top:var(--size-large);width:100%}._section_3qnus_20{display:flex;flex-direction:column;padding-bottom:0!important;padding-top:var(--size-medium);row-gap:var(--size-medium)}._section_3qnus_20:first-of-type{padding-top:0}._section_3qnus_20 h3{font-size:16px;margin-bottom:0!important;margin-top:0!important}._typesContainer_3qnus_36{display:grid;grid-gap:var(--size-medium);grid-template-columns:1fr 1fr 1fr}._metricViewDetails_3qnus_42{display:grid;grid-gap:var(--size-medium);grid-template-columns:1fr 1fr}._metricViewDetail_3qnus_42{display:flex;flex-direction:column;row-gap:var(--size-medium)}._typeSubheader_3qnus_54{color:var(--color-gray-500)}._tagFilterGroup_3qnus_58{display:flex;flex-direction:column;row-gap:var(--size-xxSmall)}._filtersRow_3qnus_64{display:grid;grid-gap:var(--size-medium);grid-template-columns:11fr 5fr 14fr 50px;width:100%}._groupsRow_3qnus_71{display:grid;grid-gap:var(--size-medium);grid-template-columns:1fr 50px;width:100%}._removeTagFilterButton_3qnus_78{background-color:var(--color-red-700);border:var(--color-red-900);color:var(--color-white)!important;height:40px;padding:0 16px}._removeTagFilterButton_3qnus_78[disabled]{background-color:var(--color-red-300)!important;border:var(--color-red-400)}._removeTagFilterButton_3qnus_78[disabled]:hover{background-color:var(--color-red-300)!important}._removeTagFilterButton_3qnus_78:hover{background-color:var(--color-red-600)!important}._card_1adi5_1{height:100%}._card_1adi5_1 .recharts-cartesian-axis-tick{user-select:none}._componentCard_1adi5_8{height:100%;width:100%}._noDataContainer_1adi5_13{align-items:center;display:flex;flex-direction:column;justify-content:center;margin:0 auto;max-width:300px;padding-top:var(--size-medium);text-align:center}._draggable_1adi5_24{align-items:center;color:var(--color-gray-500);cursor:move;display:flex;justify-content:center}._overlayButton_1adi5_32{position:absolute;right:var(--size-xLarge);top:var(--size-medium)}._button_1adi5_38{justify-content:center}._infoTooltip_1adi5_42{margin-left:var(--size-xxSmall)}._actionsContainer_1adi5_46{column-gap:var(--size-large);display:flex;margin-top:var(--size-xLarge)}._actionsContainer_1adi5_46>*{width:50%}._actionsContainer_1adi5_46 ._button_1adi5_38{justify-content:center}._description_1adi5_58{color:var(--color-gray-500)!important;margin-top:0!important}._monitorItem_1adi5_63{align-items:center;border:1px solid var(--color-gray-400);border-radius:var(--border-radius);column-gap:var(--size-xxSmall)!important;display:flex;height:var(--size-xLarge);margin:0!important;padding:10px 8px 10px 14px!important}._monitorName_1adi5_74{display:inline-block;line-height:20px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;width:70px}._submitRow_1adi5_83{display:flex;justify-content:flex-end;padding-top:var(--size-small);width:100%}._minMaxRow_1adi5_90{display:grid;grid-gap:var(--size-medium);grid-template-columns:80px 1fr 150px 80px 1fr 150px}._formLabel_1adi5_96{margin-bottom:0;margin-top:4px}._removeTagFilterButton_1adi5_101{height:48px;padding:0 16px}._chartInner_1adi5_106{padding:0 10px 16px 16px}._createNewAlertRow_1adi5_110{align-items:center;display:flex;justify-content:center}._mainHeaderContent_1adi5_116{align-items:flex-start;display:flex;justify-content:space-between;min-height:52px;padding:10px 10px 10px 20px;width:100%}._cardHeader_1adi5_125{align-items:center;display:flex;flex-direction:column;justify-content:space-between}._cardHeader_1adi5_125>button{margin-bottom:var(--size-medium)}._headerContainer_1adi5_135{overflow:hidden}._header_1adi5_135{color:var(--color-text-primary);display:block;font-size:16px;font-weight:500;overflow:hidden;padding-top:2px;text-overflow:ellipsis;white-space:nowrap}._subheader_1adi5_150{color:var(--color-gray-700);display:block;font-size:12px;font-weight:400}._blurChart_1adi5_157{filter:blur(2px)}._card_1r3ct_1{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:var(--border-radius);overflow:hidden;transition:border-color .1s ease-in-out,box-shadow .2s ease-in-out;width:100%}._card_1r3ct_1._noPadding_1r3ct_9{padding:0}._card_1r3ct_1 h2,._card_1r3ct_1 ._cardHeader_1r3ct_13{font-size:22px!important;margin-bottom:var(--size-medium)!important}._card_1r3ct_1 h3{font-size:16px!important;margin-bottom:var(--size-xSmall)!important}._card_1r3ct_1 p{color:var(--color-gray-500);margin-top:0!important}._card_1r3ct_1 section{padding-bottom:var(--size-medium)}._card_1r3ct_1 section:last-of-type{padding-bottom:var(--size-large)}._card_1r3ct_1 ._titleContainer_1r3ct_31{border-bottom:1px solid var(--color-gray-300);font-size:14px!important;padding-bottom:0;padding-top:0}._card_1r3ct_1 ._titleContainer_1r3ct_31._noTitleBottomMargin_1r3ct_37{margin-bottom:0}._card_1r3ct_1 ._titleContainer_1r3ct_31 h3{margin-bottom:var(--size-medium)!important}._card_1r3ct_1:hover._interactable_1r3ct_43{border-color:var(--color-purple);box-shadow:0 5px 8px #5629c633}._cardForm_1r3ct_48{display:flex;flex-direction:column;row-gap:var(--size-large)}._cardSubHeader_1r3ct_54{color:var(--color-gray-500)!important;font-size:16px;line-height:1.5!important;margin-bottom:var(--size-large)!important}._cardFormActionsContainer_1r3ct_61{display:flex;flex-direction:column;row-gap:var(--size-medium)}.ant-slider:hover .ant-slider-track{background-color:var(--color-blue-400)!important}.ant-slider:hover .ant-slider-handle:not(.ant-tooltip-open){border-color:var(--color-blue-400)!important}.ant-slider-dot,.ant-slider-handle{border-color:var(--color-blue-400)!important}.ant-slider-handle:focus{border-color:var(--color-blue-400)!important;box-shadow:0 0 0 5px var(--color-blue-400)!important}.ant-slider-handle:hover{border-color:var(--color-blue-400)!important}.ant-slider-handle-dragging.ant-slider-handle-dragging.ant-slider-handle-dragging{border-color:var(--color-blue-400)!important;box-shadow:0 0 0 5px var(--color-blue-400)!important}._chartContainer_px3ht_25{height:230px;margin-bottom:var(--size-large)}._formFooter_px3ht_30{display:flex;justify-content:space-between;margin-top:var(--size-large)}._actionsContainer_px3ht_36{column-gap:var(--size-large);display:flex;margin-left:auto}._select_px3ht_42{width:100%}._slider_px3ht_46{left:27px;top:36px;z-index:99999}._thresholdRow_px3ht_52{display:flex}._threshold_px3ht_52{flex-grow:1}._thresholdUnits_px3ht_60{margin-left:var(--size-xxSmall);width:160px}._select_2ddse_1{width:100%}._cardGrid_2ddse_5{display:grid;gap:var(--size-xLarge);grid-template-columns:1fr 1fr;grid-template-rows:1fr}._cardContainer_2ddse_12{height:100%}._cardContent_2ddse_16{display:block}._cardContent_2ddse_16 ._icon_2ddse_19{align-items:center;border-radius:50%;color:var(--color-white)!important;display:flex;flex-shrink:0;height:1.5em;justify-content:center;width:1.5em}._cardContent_2ddse_16 ._icon_2ddse_19 svg{height:.8em;width:.8em}#_title_2ddse_1{align-items:center;column-gap:var(--size-small);display:flex;margin-bottom:var(--size-xxSmall)!important}._description_2ddse_41{margin-bottom:0!important;margin-left:calc(1.5em + 2 * var(--size-small))!important}._155k3sw0{height:4.16rem}._155k3sw1{height:120px}._155k3sw2{cursor:pointer}._155k3sw2:hover{background-color:var(--_1pyqka91x)}._155k3sw3{background-color:var(--_1pyqka91);z-index:10!important;border:var(--_1pyqka9j) solid 1px;box-shadow:0 6px 12px -2px #3b3b3b1f;border-radius:6px;width:224px}._155k3sw4{height:28px}._155k3sw5{background-color:#dcdbdd;opacity:.5}._155k3sw6{opacity:.2;left:0;z-index:1;width:calc(100% - 4px);pointer-events:none}._14ud0dc0::-webkit-scrollbar{width:9px;height:9px}:hover._14ud0dc0::-webkit-scrollbar-thumb{background-color:var(--_1pyqka91p)}:hover._14ud0dc0::-webkit-scrollbar{border-top:var(--_1pyqka9k) solid 1px}._14ud0dc0::-webkit-scrollbar-thumb{background-clip:padding-box;background-color:var(--_1pyqka91o);border:1px solid transparent;border-radius:30px;border-top-width:2px}._14ud0dc1::-webkit-scrollbar{width:9px;height:9px}:hover._14ud0dc1::-webkit-scrollbar-thumb{background-color:var(--_1pyqka91p)}:hover._14ud0dc1::-webkit-scrollbar{border-left:var(--_1pyqka9k) solid 1px}._14ud0dc1::-webkit-scrollbar-thumb{background-clip:padding-box;background-color:var(--_1pyqka91o);border:1px solid transparent;border-radius:30px;border-left-width:2px}._1sd10050{position:absolute;top:13px;left:14px}._1sd10052{background:transparent;border:0;color:var(--_1pyqka9b);display:flex;font-size:13px;width:100%}._1sd10052:focus{outline:0}._1sd10052::placeholder{color:var(--_1pyqka9x)}._1sd10053{background:var(--_1pyqka91);border:var(--_1pyqka9k) solid 1px;border-radius:8px;box-shadow:0 2px 8px -2px #3b3b3b14;display:flex;flex-direction:column;flex-grow:1;max-width:600px;max-height:min(var(--popover-available-height,300px),300px);z-index:1}._1sd10054{cursor:pointer;padding:12px 10px}._1sd10054:hover{background-color:var(--_1pyqka9t)}._1sd10054[data-active-item]{background-color:var(--_1pyqka9u)}._1sd10056+._1sd10056{border-top:var(--_1pyqka91o) solid 1px}._1tecd1u0{height:40px}._1tecd1u1{display:grid;grid-template-columns:1fr 1fr;grid-template-rows:auto auto;grid-column-gap:40px;grid-row-gap:40px}._1tecd1u5{border:0;background:transparent;color:var(--_1pyqka9b);display:flex;font-size:13px;width:100%}._1tecd1u5:focus{outline:0}._1tecd1u5::placeholder{color:var(--_1pyqka9x)}._1tecd1u7,._1tecd1u9{height:20px}._1tecd1ua{color:var(--_1pyqka9b)!important}._1tecd1ua:hover{background:var(--_1pyqka91x)}._1tecd1ua .ant-select-selector{padding:0 6px!important;border-radius:6px!important;border:var(--_1pyqka91o) solid 1px!important;box-shadow:none!important}._1tecd1ua .ant-select-selector:hover{background:var(--_1pyqka91x)!important}._1tecd1ua .ant-select-selection-item{display:flex;align-items:center}._percentContainer_e32yg_1{align-items:center;border:1px solid var(--color-gray-300);border-radius:var(--border-radius);column-gap:var(--size-xSmall);display:flex;justify-content:space-between;padding:var(--size-xxSmall) var(--size-xSmall);width:fit-content}._barGraph_e32yg_12{background:var(--color-gray-300);border-radius:var(--size-xxSmall);flex-shrink:0;height:1rem;overflow:hidden;position:relative;width:var(--size-large)}._barGraph_e32yg_12:after{background:var(--text-primary);border-bottom-right-radius:var(--size-xxSmall);border-top-right-radius:var(--size-xxSmall);content:"";height:100%;position:absolute;width:var(--percentage)}._pill_e32yg_31{align-items:center;border:1px solid var(--color-gray-300);border-radius:var(--border-radius);column-gap:var(--size-xxSmall);display:flex;flex-wrap:nowrap;justify-content:space-between;min-width:68px;padding:var(--size-xxSmall) var(--size-xSmall);white-space:nowrap;width:fit-content}._rowGroup_e32yg_45{column-gap:var(--size-small);display:flex;width:100%}._rowGroup_e32yg_45._endingAlignment_e32yg_50{justify-content:flex-end}._table_rv890_1{margin-bottom:-24px;margin-left:-24px;margin-right:-24px;max-width:initial!important}._table_rv890_1 .ant-table{background:var(--color-primary-background)!important;color:var(--text-primary)!important}._table_rv890_1 .ant-table-cell{border-bottom:1px solid var(--color-gray-300)!important;padding:12px 0!important}._table_rv890_1 .ant-table-cell:first-of-type{padding-left:var(--size-large)!important}._table_rv890_1 .ant-table-cell:last-of-type{padding-right:var(--size-large)!important}._table_rv890_1 .ant-table-row:last-of-type .ant-table-cell{border-bottom:0!important}._table_rv890_1 .ant-table-tbody>tr.ant-table-row:hover>td{background:var(--color-gray-300)!important}._table_rv890_1 .ant-table-tbody>tr.ant-table-placeholder:hover>td{background:transparent!important}._table_rv890_1 .ant-table-empty{margin-top:var(--size-xxLarge)}._table_rv890_1 .ant-table-empty .ant-table-cell{border-bottom:0!important}._card_13l8s_1{padding:0 var(--size-large)}._hostContainer_ieeaf_1{align-items:center;column-gap:var(--size-xxSmall);display:flex;padding-right:2rem}._hostContainer_ieeaf_1 span{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._timeRow_ieeaf_13{column-gap:var(--size-xxSmall);display:flex;justify-content:center;width:fit-content}._loading_ieeaf_20{filter:blur(2px)}._keyPerformanceIndicator_mpv8j_1 ._value_mpv8j_1{font-size:36px!important}._keyPerformanceIndicator_mpv8j_1 ._label_mpv8j_4{margin:0!important}._keyPerformanceIndicator_mpv8j_1 ._tooltip_mpv8j_7{color:var(--text-primary);position:absolute;right:calc(var(--size-small) * -1);top:calc(var(--size-xxSmall) * -1)}._keyPerformanceIndicator_mpv8j_1 ._labelContainer_mpv8j_13{display:flex;position:relative;width:fit-content}._hostContainer_qgrox_1{align-items:center;column-gap:var(--size-xxSmall);display:flex}._hostContainer_qgrox_1 span{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._loading_qgrox_12{filter:blur(2px)}._hostContainer_10q3z_1{padding-right:2rem}._hostContainer_10q3z_1 span{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._loading_10q3z_10{filter:blur(2px)}._loading_140gu_1{filter:blur(2px)}._gridContainer_rp08v_1{padding:30px 80px}._gridContainer_rp08v_1._isEditing_rp08v_4 .react-resizable-handle{opacity:1}._gridContainer_rp08v_1 .react-grid-item.react-grid-placeholder{background-color:var(--color-gray-400);border-radius:var(--border-radius)}._gridContainer_rp08v_1 .react-resizable-handle{background:var(--color-gray-400);background-image:none;border-radius:var(--size-small);bottom:var(--size-small)!important;height:var(--size-small);opacity:0;right:var(--size-small)!important;transform:unset!important;transition:opacity .2s ease-in-out;width:var(--size-small)}._gridContainer_rp08v_1 .react-resizable-handle:after{content:none}._customLeadAlignLayout_rp08v_27{margin:0}._headerPanel_rp08v_31{display:flex;justify-content:space-between;width:100%}._dashboardPageFixedHeader_rp08v_37{background-color:var(--color-white);border-bottom:var(--color-gray-300) 1px solid;display:flex;flex-direction:column;padding:40px 80px 30px;position:sticky;z-index:1000}._dateRangePicker_rp08v_47{margin-left:auto;width:fit-content}._rightControllerSection_rp08v_52{display:flex;flex-direction:column}._rightControllerText_rp08v_57{align-self:flex-end}._absoluteColored_rp08v_61{color:var(--color-blue-900);font-weight:500}._liveColored_rp08v_66{color:var(--color-green-900);font-weight:500}._liveIndicator_rp08v_71{align-items:center;background-color:var(--color-green-300);border:var(--color-green-900) 1.5px solid;border-radius:8px;color:var(--color-green-900);display:flex;justify-content:center;padding:2px 12px;text-align:right}._dateRangePickerContainer_rp08v_83{display:flex;gap:10px;height:40px;right:80px;top:118px}._metric_rp08v_91{display:grid;grid-gap:var(--size-medium);grid-template-columns:1fr 1fr 1fr 3fr}._newMetric_rp08v_97{display:flex;justify-content:space-between;margin-top:var(--size-large)}._container_rp08v_103{flex-grow:1;position:relative;width:100%}._dropdownPlaceholder_rp08v_109{height:20px;width:20px}._section_rp08v_114{display:flex;flex-direction:row;padding-bottom:0!important;padding-top:var(--size-small);row-gap:var(--size-medium);width:100%}._section_rp08v_114:first-of-type{padding-top:0}._section_rp08v_114 h3{font-size:var(--size-medium);margin-bottom:0!important;margin-top:0!important}._pillButton_rp08v_131{align-items:center;background:0;border:0;border-radius:var(--size-xSmall);column-gap:var(--size-xxSmall);display:flex;font-size:14px;height:40px;justify-content:center;min-width:86px;padding:var(--size-xxSmall) var(--size-small);transition:background .1s ease-in-out}._pillButton_rp08v_131._pillButtonSmall_rp08v_145{height:30px}._pillLoading_rp08v_149{background:var(--color-brand-pastel-dark);border:1px solid var(--color-text-primary);color:var(--color-text-primary)}._pillLive_rp08v_155{background:var(--color-green-100);border:1px solid var(--color-green-600);color:var(--color-green-900)}._pillStatic_rp08v_161{background:var(--color-blue-100);border:1px solid var(--color-blue-600);color:var(--color-blue-900)}._pillButtonText_rp08v_167{align-items:center;column-gap:var(--size-xxSmall);display:flex;justify-content:center;opacity:0;position:absolute;transition:opacity .1s ease-in-out}._pillButtonTextVisible_rp08v_177{opacity:1}._settingsDropdownMenu_rp08v_181 .ant-dropdown-menu-item{padding:0!important}._resize_rp08v_185{border-bottom:10px solid var(--color-gray-300);border-left:10px solid transparent;border-radius:8px;border-right:10px solid transparent;bottom:6px;position:absolute;right:0;transform:rotate(135deg);transition:border-bottom ease-in-out .2s}._resize_rp08v_185:hover{border-bottom:10px solid var(--color-purple-400)}._actionsContainer_1w0mw_1{column-gap:var(--size-large);display:flex;margin-top:var(--size-xLarge)}._actionsContainer_1w0mw_1>*{width:50%}._actionsContainer_1w0mw_1 ._button_1w0mw_9{justify-content:center}._description_1w0mw_13{color:var(--color-gray-500)!important;margin-top:0!important}._name_1w0mw_18{flex-grow:1;margin-left:var(--size-medium)}._submitRow_1w0mw_23{column-gap:var(--size-medium);display:flex;justify-content:flex-end;margin-top:var(--size-large);width:100%}._section_1w0mw_31{display:flex;flex-direction:column;padding-bottom:0!important;padding-top:var(--size-medium);row-gap:var(--size-medium)}._section_1w0mw_31:first-of-type{padding-top:0}._section_1w0mw_31 h3{font-size:16px;margin-bottom:0!important;margin-top:0!important}._dashboardWrapper_4u0hf_1{width:100%}._dashboard_4u0hf_1{padding:0}._subTitle_4u0hf_9{font-size:18px}._chartHeaderWrapper_4u0hf_13{align-items:center;display:flex;height:15px;justify-content:space-between;margin-bottom:var(--size-medium)}._chartHeaderWrapper_4u0hf_13 #_h3_4u0hf_1{margin-bottom:0!important}._chartHeaderWrapper_4u0hf_13 .ant-input-affix-wrapper{width:150px}._chartHeaderWrapper_4u0hf_13._smallMargin_4u0hf_26{margin-bottom:var(--size-medium)}._dashboardBody_4u0hf_30{display:grid;gap:var(--size-xxLarge);grid-template-columns:repeat(auto-fit,minmax(400px,1fr));position:relative;width:100%}._filtersContainer_4u0hf_38{display:flex;justify-content:flex-end;padding-bottom:var(--size-medium)}._headerContainer_4u0hf_44{display:flex;justify-content:space-between;margin-bottom:var(--size-xLarge)}._noDataContainer_4u0hf_50{align-items:center;backdrop-filter:blur(2px);border-radius:var(--border-radius);display:flex;height:100%;justify-content:center;left:0;position:fixed;top:0;transition:backdrop-filter .2s ease-in-out;width:100%}._composedChart_4u0hf_64{cursor:pointer!important}._demoWorkspaceButton_4u0hf_68{display:flex;justify-content:center;margin-top:var(--size-medium)}.t0fsad0{border-top-right-radius:0;border-bottom-right-radius:0}.t0fsad1{border-top-left-radius:0;border-bottom-left-radius:0}._33eaux0{max-height:16em}._tabPane_19cqh_1{height:100%;overflow-y:auto}._tabPane_19cqh_1._withPadding_19cqh_5{padding:var(--size-small) var(--size-medium)}._tabPane_19cqh_1._unsetOverflowY_19cqh_8{overflow-y:unset}._extraContentContainer_19cqh_12{align-items:center;column-gap:var(--size-medium);display:flex}._extraContentContainer_19cqh_12._withHeaderPadding_19cqh_17{padding-right:var(--size-large)}._tabs_19cqh_21{font-family:var(--header-font-family)!important}._tabs_19cqh_21._noHeaderPadding_19cqh_24 .ant-tabs-nav-wrap{padding:0}.ah2zbm0{background-color:var(--_1pyqka90);border:1px solid var(--_1pyqka9k);border-radius:5px;padding:6px 4px}.ah2zbm1{border:1px solid var(--_1pyqka9k);border-radius:6px;width:100%}.ofc9fn0{border-right:var(--_1pyqka91o) solid 1px;border-bottom:var(--_1pyqka91o) solid 1px;border-left:var(--_1pyqka91o) solid 1px;margin:0}.ofc9fn1{border-bottom-left-radius:6px;border-bottom-right-radius:6px}.ofc9fn3{display:inline-block;text-align:center;width:46px}.ofc9fn4{height:14px;transition:transform .25s}.ofc9fn5{transform:rotate(-180deg)}.ofc9fn7{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-top:2px;height:16px;max-width:120px}.ofc9fn8{max-width:560px}._pageButtonsRow_3uoyz_1{display:flex;flex-shrink:0;justify-content:flex-end;left:0;margin:var(--size-large) 0;width:100%}._pageButtonsContainer_3uoyz_10{display:grid;gap:var(--size-xSmall);grid-template-columns:1fr 1fr;width:auto}._container_3uoyz_17{align-self:center;display:flex;justify-content:center;width:100%}._btn_3uoyz_24{align-content:center;align-self:center;display:flex;justify-content:center;width:100%}._metricsDistributionContainer_1bgqt_1{min-height:240px}._iconContainer_1bgqt_5{margin-right:var(--size-xSmall);padding-top:4px}._titleContainer_1bgqt_10{align-items:center;display:flex}._timePickerContainer_1bgqt_15{z-index:10}._calloutContainer_1bgqt_19{background-color:#f9f8f9;margin-top:var(--size-medium)}._calloutContainer_1bgqt_19 ._bodyText_1bgqt_23{line-height:20px;margin-bottom:var(--size-small)}._tabs_ywpbe_1{margin-top:var(--size-xxLarge)}._tabs_ywpbe_1 .ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn{color:var(--color-purple)!important}._tabs_ywpbe_1 .ant-tabs-ink-bar{background:var(--color-purple)!important}._tabs_ywpbe_1 .ant-tabs-tab{margin-left:0!important}._modalBtn_1h3ip_1{padding-bottom:4px!important;padding-top:4px!important}._modalBtnIcon_1h3ip_6{margin-right:.5rem}._modalSubTitle_1h3ip_10{color:var(--color-gray-500)!important;font-size:16px;margin-bottom:20px;margin-top:0!important}._1g045pm0{color:var(--_1pyqka9b)!important}._1g045pm0:hover{background:var(--_1pyqka91x)}._1g045pm0 .ant-select-selector{padding:0 6px!important;border-radius:6px!important;border:var(--_1pyqka91o) solid 1px!important;box-shadow:none!important}._1g045pm0 .ant-select-selector:hover{background:var(--_1pyqka91x)!important}._1g045pm0 .ant-select-selection-item{display:flex;align-items:center}._modalBtn_1es5w_1{padding-bottom:4px!important;padding-top:4px!important}._modalBtnIcon_1es5w_6{margin-right:.5rem}._modalSubTitle_1es5w_10{color:var(--color-gray-500)!important;font-size:16px;margin-bottom:20px;margin-top:0!important}._modalBtnText_1es5w_17{align-items:center;display:inline-flex!important;height:100%}._modalBtn_1kqcu_1{background:var(--color-purple);border-radius:8px;padding:8px 12px!important}._modalBtnIcon_1kqcu_7{margin-right:.5rem}._modalSubTitle_1kqcu_11{color:var(--color-gray-500)!important;font-size:16px;margin-bottom:20px;margin-top:0!important}._modalBtnText_1kqcu_18{align-items:center;color:var(--color-white)!important;display:inline-flex!important;height:100%}._copyButton_11h6r_1{background:var(--color-gray-300);border-radius:var(--size-xSmall);cursor:pointer;opacity:0;padding:var(--size-xxSmall);position:absolute;right:5px;top:5px;transition:opacity .2s ease-in-out;z-index:10}._copyDiv_11h6r_14{align-items:center;display:flex;font-size:8px;justify-content:center;padding:10px}._codeBlock_11h6r_22{position:relative}._codeBlock_11h6r_22 pre{margin:0!important}._codeBlock_11h6r_22:hover ._copyButton_11h6r_1{opacity:1}._codeBlockInner_11h6r_32{display:flex}._highlightedLine_11h6r_36{background-color:var(--color-gray-300)}._lineNumberSticky_11h6r_40{color:#7d8b99;display:block;min-width:2.25em;padding-left:16px;padding-right:16px;text-align:right;user-select:none}._1tn5c580{color:var(--_1pyqka9y)}._1tn5c581{max-width:108px}._1w5sij40{padding:0}.gadbsf0{border:var(--_1pyqka91o) solid 1px;padding:4px 6px;font-size:13px;width:100%}.gadbsf0:hover{border:var(--_1pyqka91p) solid 1px}.gadbsf0 .ant-picker-input input{font-size:13px}.gadbsf0.ant-picker-focused{border:var(--_1pyqka91q) solid 1px;box-shadow:none}.gadbsf1{z-index:1}._card_10wj8_1{align-self:center;margin-bottom:auto;margin-top:auto;max-width:300px}._3dlaof0{height:20px}._3dlaof1{max-width:100%}._3dlaof2:hover{background:var(--_1pyqka91x)}._3dlaof3{background:var(--_1pyqka91y);box-shadow:0 -1px #0000001a inset}._3dlaof3:hover{background-color:var(--_1pyqka91y)}._1f2v8en0{transition:transform .2s ease-in-out;width:340px;position:fixed;height:calc(100vh - var(--header-height))}._1f2v8en1{height:calc(100vh - var(--header-height) - var(--banner-height))}._1f2v8en2{position:fixed;transform:translate(-340px)}._1f2v8en3{position:absolute;right:calc((-1 * var(--size-xLarge) / 2));top:16px;transform:translateY(calc(112px + var(--size-medium) + 30px));z-index:20}._1f2v8en4{right:calc(-1 * (var(--sidebar-width) - var(--size-xLarge)))}._1f2v8en5{height:100%}._1f2v8en6{height:44px;flex-shrink:0;position:sticky;top:0;z-index:10}._75g8nf0{display:flex;width:100%}._75g8nf1{background-color:#f9f8f9;display:flex;flex-direction:column;flex-grow:1;height:100%;padding:8px}._75g8nf2{background:white;border-radius:4px;display:flex;height:100%;margin-left:0;overflow-y:scroll;width:100%}._75g8nf3{display:flex;gap:var(--size-medium);margin-top:var(--size-medium)}._75g8nf4{margin-left:340px}._75g8nf5{border:0!important;border-radius:0}._integrationsContainer_ixqmc_1{display:grid;grid-gap:var(--size-large);grid-template-columns:repeat(auto-fit,minmax(240px,1fr))}._modalBtn_ixqmc_7{padding-bottom:4px!important;padding-top:4px!important}._1f99hkr0{height:2.305rem}._1vb6x0p0{text-decoration:none;color:var(--_1pyqka9y)}._1vb6x0p0:hover{color:var(--_1pyqka9y)}.szxd8q0 .szxd8q0{padding-left:22px}.szxd8q2{align-items:center;display:none;flex-direction:row;gap:4px;opacity:.5}.szxd8q2:hover{opacity:1}.szxd8q1:hover .szxd8q2{display:flex}.szxd8q3{opacity:.6}.szxd8q3:hover{opacity:1}.szxd8q4{background:transparent;border:0;cursor:pointer;padding:0;color:var(--_1pyqka9y)}.szxd8q4:hover,.szxd8q4:active{color:var(--_1pyqka9w)}.g2tqod0{border-radius:6px;padding:8px 8px 8px 28px;position:relative}.g2tqod0:hover{background-color:var(--_1pyqka91x)}.g2tqod1{background:var(--_1pyqka91y)}.g2tqod2{left:8px;opacity:0;position:absolute;top:5px}.g2tqod0:hover .g2tqod2,.g2tqod1 .g2tqod2{opacity:1}.g2tqod3{background-color:var(--_1pyqka96);border-radius:4px;color:inherit!important;display:inline-block;padding:0 4px}._fullBleedCard_h1fdv_1{align-items:center;backdrop-filter:blur(2px);border-radius:var(--border-radius);display:flex;height:100%;justify-content:center;left:0;position:absolute;top:0;transition:backdrop-filter .2s ease-in-out;width:100%;z-index:99}._actionButtons_1w4el_1{display:flex;gap:var(--size-xSmall);justify-content:flex-end}._actionButtons_1w4el_1 button{align-items:center;display:flex;flex-direction:row;gap:var(--size-small)}._textBoxStyles_1w4el_13{font-size:inherit!important}._integrationIcon_1w4el_17{border-radius:var(--size-xxSmall);margin-bottom:2px;margin-right:var(--size-xSmall);width:calc(var(--size-medium) + 2px)}._integrationIcon_1w4el_17._largeSize_1w4el_24{margin-bottom:4px;width:calc(var(--size-large) + 2px)}._formItemSpacer_1w4el_29{display:flex;flex-direction:column;gap:var(--size-xSmall);justify-content:space-between;row-gap:var(--size-medium)}._actionButtonsContainer_1w4el_37{margin-bottom:0}._commentInputContainer_1w4el_41{background:var(--color-gray-200);border:1px solid transparent;border-radius:var(--border-radius);box-shadow:none!important;height:100px;padding-bottom:var(--size-xSmall)!important;padding-left:var(--size-small)!important;padding-right:var(--size-small)!important;padding-top:var(--size-xSmall)!important;transition:all .2s ease-in-out}._commentInputContainer_1w4el_41 div{height:100%}._commentInputContainer_1w4el_41 textarea{color:var(--text-primary)!important;height:100%}._commentInputContainer_1w4el_41:hover,._commentInputContainer_1w4el_41:active,._commentInputContainer_1w4el_41:focus-within{background:var(--color-primary-background);border-color:var(--color-purple);box-shadow:0 0 0 4px rgba(var(--color-purple-rgb),.2)!important}._intercomLink_1w4el_66{cursor:pointer;text-decoration:underline}._form_1w4el_29 .ant-form-item{margin-bottom:0!important}._hide_1w4el_75{animation-fill-mode:forwards;opacity:0;visibility:hidden!important}._slides_1w4el_81{align-items:flex-start;display:flex;flex-direction:row;flex-wrap:nowrap;row-gap:var(--size-medium);transition:transform .25s ease;width:calc(200% + var(--size-medium) / 2)}._slides_1w4el_81>div{transition:opacity .25s,visibility .15s linear;visibility:visible;width:100%}._showSecondSlide_1w4el_96{transform:translate(calc(-50% - var(--size-xxSmall)))}._slidesContainer_1w4el_100{margin-left:calc(-1 * var(--size-large));margin-right:calc(-1 * var(--size-large));overflow-x:hidden;padding-bottom:var(--size-xSmall);padding-left:var(--size-large);padding-right:var(--size-large);padding-top:var(--size-xSmall)}._submitButton_1w4el_110{transition:background-color .3s ease}._loading_1w4el_114{background-color:var(--color-gray-400);border:solid 1px var(--color-gray-400)}._loading_1w4el_114:hover,._loading_1w4el_114:active,._loading_1w4el_114:focus-within{background-color:var(--color-gray-400);border:solid 1px var(--color-gray-400)}._suggestionContainer_ixcq8_1{align-items:center;column-gap:var(--size-xSmall);display:flex}._suggestionContainer_ixcq8_1 ._adminText_ixcq8_6{display:flex;flex-direction:column}._suggestionContainer_ixcq8_1 ._adminText_ixcq8_6 ._email_ixcq8_10{color:var(--color-gray-500)}._suggestionContainer_ixcq8_1 ._adminText_ixcq8_6 ._longValue_ixcq8_13{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;width:225px}._suggestionContainer_ixcq8_1 ._slackLogo_ixcq8_19{height:var(--size-medium);width:var(--size-medium)}._suggestionContainer_ixcq8_1 ._slackLogoContainer_ixcq8_23{align-items:center;background:var(--color-primary-background);border-radius:50%;box-shadow:var(--box-shadow-3);display:flex;height:calc(var(--size-medium) + var(--size-xxSmall));justify-content:center;left:calc(-1 * var(--size-xSmall));position:absolute;top:calc(-1 * var(--size-xSmall));width:calc(var(--size-medium) + var(--size-xxSmall))}._suggestionContainer_ixcq8_1 ._avatarContainer_ixcq8_36{position:relative}._suggestionHeader_ixcq8_40{background:var(--color-primary-background);border:1px solid var(--color-gray-300);border-bottom:0;border-top-left-radius:var(--border-radius);border-top-right-radius:var(--border-radius);display:flex;height:50px;justify-content:space-between;padding:var(--size-medium) var(--size-small)}._suggestionHeader_ixcq8_40 p{font-size:13px;font-weight:400;margin:0!important}._noResultsMessage_ixcq8_57{background:var(--color-primary-background);border:1px solid var(--color-gray-300);border-bottom-left-radius:var(--border-radius);border-bottom-right-radius:var(--border-radius);margin:0!important;max-width:300px;padding:var(--size-medium) var(--size-small)}._commentLink_ixcq8_67{color:var(--color-purple)}._mentions_vzopr_1{font-size:14px!important;line-height:initial}._mentions--singleLine_vzopr_6 ._mentions__control_vzopr_6{display:inline-block;width:130px}._mentions--singleLine_vzopr_6 ._mentions__highlighter_vzopr_11{border:2px inset transparent;padding:1px}._mentions--singleLine_vzopr_6 ._mentions__input_vzopr_16{border:2px inset;padding:1px}._mentions--multiLine_vzopr_21 ._mentions__control_vzopr_6{font-size:14px!important}._mentions--multiLine_vzopr_21 ._mentions__highlighter_vzopr_11{border:1px solid transparent;font-weight:400;padding:0}._mentions--multiLine_vzopr_21 ._mentions__highlighter_vzopr_11 span{overflow-wrap:anywhere}._mentions--multiLine_vzopr_21 ._mentions__input_vzopr_16{border:1px solid transparent;color:var(--color-gray-500);cursor:inherit;font-weight:400;outline:0;padding:0}._mentions--multiLine_vzopr_21 ._mentions__input_vzopr_16[aria-readonly=true]{caret-color:transparent}._mentions__input_vzopr_16::placeholder{color:#c8c7cb!important}._mentions__suggestions__list_vzopr_53{background:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:var(--border-radius)!important;border-top-left-radius:0!important;border-top-right-radius:0!important;box-shadow:var(--box-shadow-3);max-height:400px;max-width:300px;overflow-y:auto;padding:var(--size-xSmall) var(--size-small)}._mentions__suggestions__item_vzopr_66{padding:var(--size-xSmall) 12px}._mentions__suggestions__item_vzopr_66:not(:last-of-type){border-bottom:1px solid var(--color-gray-300)}._mentions__suggestions__item--focused_vzopr_74{background:var(--color-gray-300)}._mentions__mention_vzopr_78{color:var(--color-link);font-weight:400!important;pointer-events:none;position:relative;text-shadow:1px 1px 1px var(--color-white),1px -1px 1px var(--color-white),-1px 1px 1px var(--color-white),-1px -1px 1px var(--color-white);z-index:1}._container_1m9ig_1{background:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:var(--size-xSmall);overflow:hidden;padding-bottom:var(--size-small);padding-left:calc(var(--size-xSmall) + 11px);padding-right:calc(var(--size-xSmall) + 11px);padding-top:var(--size-small);position:relative;text-align:left;transition:box-shadow .1s ease-in;width:100%}._container_1m9ig_1>p{font-size:14px;font-weight:200}._container_1m9ig_1._hasShadow_1m9ig_19{box-shadow:var(--box-shadow)}._container_1m9ig_1:before{background-color:var(--color-purple);content:"";height:100%;left:0;opacity:0;position:absolute;top:0;transition:opacity .2s ease-in-out;width:6px}._container_1m9ig_1:hover{border:1px solid var(--color-purple);box-shadow:0 0 9px #5629c640}._deepLinkedComment_1m9ig_38:before{opacity:1}._footer_1m9ig_42{display:flex;justify-content:space-between;padding-top:var(--size-medium)}._footer_1m9ig_42 ._actions_1m9ig_47{column-gap:var(--size-xxSmall);display:flex}._iconLabel_1m9ig_52{align-items:center;column-gap:var(--size-small);display:flex!important}._actionButton_1m9ig_58{padding-bottom:var(--size-xxSmall);padding-left:var(--size-medium);padding-right:var(--size-medium);padding-top:var(--size-xxSmall)}._tagsContainer_1m9ig_65{display:flex;flex-wrap:wrap;gap:var(--size-xSmall);padding-top:var(--size-small)}._popover_1fpwu_1{border:0}._popover_1fpwu_1 .ant-popover-inner{background-clip:initial;background-color:transparent;border-radius:initial;box-shadow:none}._popover_1fpwu_1 .ant-popover-inner-content{padding:0}._popover_1fpwu_1 .ant-popover-arrow{display:none!important}._commentButton_r3jun_1{--comment-indicator-height: 32px;--comment-indicator-width: 32px;background:transparent;border:0;cursor:crosshair;outline:none;padding:0;position:absolute;user-select:text;z-index:1}._commentIndicator_r3jun_14{animation:_grow_r3jun_1 .2s forwards;height:var(--comment-indicator-height);position:absolute;transform:scale(0);width:var(--comment-indicator-width)}@keyframes _grow_r3jun_1{0%{transform:scale(0)}to{transform:scale(1)}}._blurBackground_r3jun_30{backdrop-filter:blur(2px)}._comment_mrsyj_1{cursor:auto;display:flex;position:absolute;z-index:9999}._comment_mrsyj_1 ._commentPinButton_mrsyj_7{background:none;border:0;cursor:pointer;outline:none}._comment_mrsyj_1>._commentPinButton_mrsyj_7{position:relative;z-index:99}._comment_mrsyj_1:hover{z-index:10000}._sessionCommentCardContainer_mrsyj_21{background:white;padding:4px;width:350px}._1hjkzyj0{padding:4px;gap:2px;border:1px solid var(--_1pyqka9k);border-radius:5px}._1hjkzyj1{white-space:pre}._explanatoryPopoverOverlay_jdhfs_1 .ant-popover-inner-content{align-items:center;display:flex;gap:4px;justify-content:center;padding:4px!important}._explanatoryPopoverOverlay_jdhfs_1.ant-popover-placement-top{pointer-events:none}._explanatoryPopoverOverlay_jdhfs_1.ant-popover-inner{border:1px solid var(--color-neutral-200);overflow:hidden}._1ubqgtn0{display:grid;grid-template-columns:82px 1fr;grid-gap:8px;cursor:pointer;align-items:center}._1ubqgtn2{display:block}._1ecj17q0{height:28px;width:28px}._1ecj17q1{color:var(--_1pyqka9b)}._1ecj17q2{color:var(--_1pyqka9y)}._1ecj17q3{align-items:center;column-gap:14px;display:grid;grid-template-columns:fit-content(20px) auto;padding:8px;position:relative}._1ecj17q4{align-items:center;color:var(--color-gray-500)!important;column-gap:6px;display:flex}._wrapper_ekn0a_1{display:flex}._detailedView_ekn0a_5{display:flex;flex-direction:column;row-gap:var(--size-large)}._goToButton_16iej_1{align-items:center;align-self:flex-start;background:none;border:0;border-radius:var(--button-border-radius);cursor:pointer;display:flex;font-size:12px;outline:none;padding:5px 6px;width:fit-content}._goToButton_16iej_1:hover{background:var(--color-purple-200)}._icon_16iej_18{color:var(--color-gray-500);fill:var(--color-gray-500);height:10px;margin-left:var(--size-xSmall);width:auto}._small_16iej_26{filter:brightness(0) saturate(100%);height:1em;margin-left:0;transform:scale(1.2);width:1em}._smallIconContainer_16iej_34{align-items:center;height:var(--size-large);justify-content:center}._smallIconContainer_16iej_34:hover{background:var(--color-gray-300)}._card_dtk0v_1{--primary-color: var(--color-purple);border:1px solid var(--color-gray-300);border-radius:var(--border-radius);margin:0 var(--size-large);overflow:hidden;padding:var(--size-xSmall) var(--size-medium);position:relative;transition:box-shadow .1s ease-in}._card_dtk0v_1:hover{border:1px solid var(--color-purple);box-shadow:0 0 9px #5629c640}._card_dtk0v_1:before{background:var(--primary-color);content:"";height:100%;left:0;opacity:0;position:absolute;top:0;transition:opacity .1s ease-in;width:6px;z-index:5}._card_dtk0v_1._selected_dtk0v_27:before{opacity:1}._timelinePopoverContent_156p4_1{align-items:center;display:flex;flex-direction:column;justify-content:center;width:224px}._timelinePopoverContent_156p4_1 span:not(._selectedTypeName_156p4_8){font-size:13px;font-weight:400;letter-spacing:-.01em;line-height:20px}._timelinePopoverContent_156p4_1 span._selectedTypeName_156p4_8{color:var(--color-neutral-800);font-size:11px;font-weight:500;line-height:12px}._infoPanel_156p4_21{align-items:center;border-bottom:1px solid var(--color-neutral-200);display:flex;height:36px;justify-content:flex-start;padding:4px 8px;user-select:none;width:100%}._timelinePopoverHeader_156p4_32:hover,._eventTypeRow_156p4_33:hover{background-color:var(--color-neutral-50);cursor:pointer}._timelinePopoverHeader_156p4_32:hover ._transitionIcon_156p4_37 path,._eventTypeRow_156p4_33:hover ._transitionIcon_156p4_37 path{fill:var(--color-neutral-500)}._actionButton_156p4_42{align-items:center;background:inherit;border:0;cursor:pointer;display:flex;justify-content:flex-start;padding:0;user-select:none;width:100%}._leftActionIcon_156p4_54{margin-right:4px}._rightActionIcon_156p4_58{margin-left:4px}._eventTypeRow_156p4_33{align-items:center;display:flex;justify-content:flex-start;padding:4px 8px;width:100%}._transitionIcon_156p4_37{height:16px;width:16px}._transitionIcon_156p4_37 path{fill:var(--color-neutral-300)}._rightCounter_156p4_78{align-items:center;color:var(--color-neutral-300);display:flex;margin-left:auto}._infoPanelCounter_156p4_85{border:1px solid var(--color-neutral-200);border-radius:3px;color:var(--color-neutral-700);height:16px;padding:0 4px}._isHidden_156p4_93{visibility:hidden}._timelinePopoverDetails_156p4_97{display:flex;flex-direction:column;padding-top:4px;width:100%}._eventTypeIcon_156p4_104{border-radius:9999px;height:8px;margin:4px;width:8px}._eventIdentifier_156p4_111{max-width:128px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._bar_1azqj_1{align-items:center;display:flex;flex-direction:column;height:100%;justify-content:flex-end;overflow:hidden;position:absolute}._isShaded_1azqj_11{background-color:var(--color-neutral-100)}._rectangleContainer_1azqj_15{border-radius:.2em;display:flex;flex-direction:column;margin:8px 2px 2px;overflow:hidden;width:calc(100% - 4px)}._barRectangle_1azqj_25{border-radius:2px;cursor:pointer;margin-bottom:2px}._eventAggregateTitle_1azqj_31{margin:0;width:100%}._timelineBarPopoverContainer_1azqj_36 .ant-popover-inner-content{padding:0!important}._timelineBarPopoverContainer_1azqj_36 .ant-popover-inner{border:1px solid var(--color-neutral-200);overflow:hidden}._2maxeq0{align-items:center;background-color:#fff;display:flex;flex-direction:column;z-index:5;position:relative}._2maxeq1{border-bottom:1px var(--color-neutral-100) solid;height:7px;overflow:hidden;position:relative;width:100%;z-index:2}._2maxeq2{border:0!important;height:0!important;overflow-x:hidden;visibility:hidden}._2maxeq3{overflow:hidden!important}._2maxeq4{background-color:var(--color-neutral-300);border-bottom:1px solid var(--color-neutral-100);border-radius:1px 1px 0 0;height:3px;overflow:hidden;position:relative;width:100%;z-index:1}._2maxeq5{will-change:transform;background-color:var(--color-neutral-700);height:3px;left:0;position:absolute;top:0;width:100%;transform-origin:left}._2maxeq6{animation-duration:2s;animation-fill-mode:forwards;animation-iteration-count:infinite;animation-name:liveShimmer;animation-timing-function:linear;background:linear-gradient(to right,var(--color-red-300) 8%,var(--color-red) 38%,var(--color-red-300) 68%);background-size:800px 5px;display:flex;height:3px;position:absolute;transition:all .2s ease-in-out;width:100%}._2maxeq7{background-color:var(--color-white);height:3px;position:absolute;top:0;z-index:2;display:flex}._2maxeq8{will-change:transform;background-color:var(--color-neutral-500);z-index:4;width:100%;transform-origin:left}._2maxeq9{height:min-content;overflow-x:clip;overflow-y:hidden;overscroll-behavior:none;position:relative;width:100%!important}._2maxeqa{display:flex;flex-direction:column;height:58px;margin-left:8px;margin-right:8px;position:relative;justify-content:flex-end}._2maxeqb{position:relative;width:100%;height:58px}._2maxeqc{height:24px;margin-left:8px;margin-right:8px;pointer-events:none;position:relative}._2maxeqd{border-bottom:1px var(--color-neutral-100) solid}._2maxeqe{border-left:1px var(--color-neutral-200) solid;bottom:0;position:absolute}._2maxeqf{bottom:10px;color:var(--color-neutral-300);font-family:var(--header-font-family);font-size:10px;letter-spacing:-.1em;line-height:12px;position:absolute;text-align:center;user-select:none}._2maxeqg{border-left:1px solid var(--color-neutral-200);bottom:0;position:absolute}._2maxeqh{height:8px}._2maxeqi{height:4px}._2maxeqj{height:2px}._2maxeqk{background-color:var(--color-neutral-50);bottom:0;height:100%;position:absolute;z-index:-1}._2maxeql{transition:transform .3s linear}._2maxeqm{position:absolute;left:8px;height:100%;bottom:0}._2maxeqn{will-change:transform;position:relative;height:100%;width:10px;overflow:hidden;z-index:1}._2maxeqo{align-items:center;bottom:0;display:flex;flex-direction:column;height:100%;width:10px;position:relative;z-index:2}._2maxeqp{transition:transform .17s linear}._2maxeqq{width:4px;background-color:var(--_1pyqka9b);border:1px solid #ffffff;border-top:none;cursor:ew-resize;height:59px;position:absolute;top:24px}._2maxeqr{height:0;visibility:hidden}._2maxeqs{background-color:var(--_1pyqka9b);border:1px solid #ffffff;border-radius:1px 1px 12px 12px;cursor:grab;height:10px;position:sticky;top:15px;width:8px}._2maxeqt{z-index:2;height:20px;left:0;transform-origin:left}._4zq3u0{position:absolute;right:4px;top:39px;z-index:6;display:flex;flex-direction:row;border-radius:5px;overflow:hidden;justify-content:center;align-items:center;background:#ffffff}._4zq3u1{height:20px!important}._13m092k0{align-items:center;background-color:var(--_1pyqka91o);border-radius:40px;bottom:0;cursor:grab;display:flex;height:100%;justify-content:space-between;opacity:.8;position:absolute;z-index:2}._13m092k1{background-color:var(--_1pyqka9i);border-radius:40px;cursor:ew-resize;display:flex;flex-direction:column;height:100%;justify-content:center;padding:0 2px;user-select:none}._13m092k2{background-color:#fff;border-radius:3px;height:50%;user-select:none;width:3px}._13m092k3{height:100%;width:100%}._13m092k4{transition:width .17s linear}._sessionToken_ci7y5_1{align-items:center;color:var(--color-gray-500);display:flex;flex-shrink:0;font-size:12px;gap:var(--size-xSmall);max-width:378px;min-width:0}._sessionToken_ci7y5_1>span{color:var(--color-gray-500);line-height:normal;margin:0;white-space:nowrap}._sessionToken_ci7y5_1 a{color:var(--text-primary)}._sessionToken_ci7y5_1 svg{color:var(--color-gray-500);flex-shrink:0;height:16px;width:16px}._iconContainer_ci7y5_27{display:flex}._button_1d1w0_1{align-items:center;border:1px solid var(--color-neutral-100);border-radius:6px;display:flex;height:30px;justify-content:center;padding:6px;width:30px}._button_1d1w0_1>svg{height:16px;width:16px}._button_1d1w0_1>svg path{fill:var(--color-neutral-800)}._button_1d1w0_1:disabled{background:var(--color-white)!important;border:0;cursor:not-allowed}._button_1d1w0_1:disabled>svg path{fill:var(--color-neutral-300)}._button_1d1w0_1:after{display:none!important}._button_1d1w0_1:hover,._button_1d1w0_1:focus{background-color:var(--color-neutral-50);border:1px solid var(--color-neutral-100)}._button_1d1w0_1:focus{border:1px solid var(--color-neutral-300)}._popoverCmdShortcut_1d1w0_40{background-color:var(--color-neutral-100);border-radius:3px;color:var(--color-neutral-500);font-size:11px;padding:1px 4px}._moveRight_1d1w0_48{margin-left:auto}._smallButton_1d1w0_52{background:var(--color-neutral-50);border:0;border-radius:10px;height:20px;padding:2px 10px;width:fit-content}._smallButton_1d1w0_52>span{color:var(--color-neutral-700);font-size:12px;line-height:16px}._smallButton_1d1w0_52:hover,._smallButton_1d1w0_52:focus{background:var(--color-neutral-50);border:0}._minorButton_1d1w0_72{background:var(--color-neutral-100);border:0;box-shadow:inset 0 -1px #0000001a}._minorButton_1d1w0_72:hover,._minorButton_1d1w0_72:focus{background:var(--color-neutral-200);border:0;box-shadow:none}._minorButton_1d1w0_72:focus{border:1px solid var(--color-neutral-300)}._activeButton_1d1w0_89,._activeButton_1d1w0_89:hover,._activeButton_1d1w0_89:focus{background:var(--color-new-purple-500)}._activeButton_1d1w0_89>svg path,._activeButton_1d1w0_89:hover>svg path,._activeButton_1d1w0_89:focus>svg path{fill:var(--color-white)}._activeButton_1d1w0_89>span,._activeButton_1d1w0_89:hover>span,._activeButton_1d1w0_89:focus>span{color:var(--color-white)}._currentTime_1d1w0_105{color:var(--color-neutral-500);font-size:13px}._settingsPopoverOverlay_1d1w0_110 .ant-popover-inner-content{padding:0!important}._settingsPopoverOverlay_1d1w0_110 .ant-popover-inner-content>div{padding:0!important}._settingsPopoverOverlay_1d1w0_110 .ant-popover-inner{border:1px solid var(--color-neutral-200);overflow:hidden}._settingsContainer_1d1w0_121{align-items:center;display:flex;flex-direction:column;justify-content:center;width:224px}._settingsContainer_1d1w0_121>._section_1d1w0_128:first-child{border-bottom:1px solid var(--color-neutral-200)}._section_1d1w0_128{align-items:center;display:flex;flex-direction:column;justify-content:center;padding:4px 0;width:100%}._settingsButton_1d1w0_141{align-items:center;background-color:inherit;border:0;display:flex;font-size:13px;gap:4px;height:28px;padding:4px 8px;user-select:none;width:100%}._settingsButton_1d1w0_141:hover{background:var(--color-neutral-50);cursor:pointer}._settingsButton_1d1w0_141>svg{height:16px;width:16px}._settingsButton_1d1w0_141>svg path{fill:var(--color-neutral-300)}._settingsOptionShortcut_1d1w0_165{align-items:center;border:1px solid var(--color-neutral-200);border-radius:3px;display:flex;font-size:12px;font-weight:400;height:16px;line-height:16px;padding:0 4px}._leftSelection_1d1w0_177{align-items:center;display:flex;flex-direction:row;width:100%}._leftSelection_1d1w0_177:hover>._leftClickActionName_1d1w0_183{visibility:visible}._leftClickActionName_1d1w0_183{color:var(--color-neutral-500);font-size:11px;visibility:hidden}._liveUserStatus_1d1w0_193{user-select:none}._eventWrapper_livaz_1{align-items:center;display:flex;font-size:12px;height:max-content}._streamElement_livaz_8{align-items:center;background-color:inherit;border-radius:6px;color:var(--color-gray-500);column-gap:var(--size-small);display:grid;fill:var(--color-gray-500);font-family:var(--body-font-family);font-size:12px!important;grid-template-columns:22px 1fr min-content;height:100%;position:relative;width:100%}._streamElement_livaz_8._noTimestamp_livaz_23{grid-template-columns:22px 1fr}._card_livaz_27{cursor:pointer}._cardContainer_livaz_31{padding-bottom:var(--size-medium)}._cardContainer_livaz_31._firstCard_livaz_34{padding-top:var(--size-medium)}._eventTime_livaz_38{align-items:center;display:flex;font-size:10px;height:100%;justify-content:flex-end;margin-left:10px;padding:5px 0 5px 5px;width:max-content}._iconWrapper_livaz_50{background:var(--primary-color);border-radius:50%;cursor:pointer;display:flex;flex-direction:column;height:100%;padding:5px}._playIcon_livaz_60{height:20px;width:20px}._directionIcon_livaz_65{color:var(--text-primary-inverted);fill:var(--text-primary-inverted);height:var(--size-small);transition:transform .3s;width:var(--size-small)}._defaultIcon_livaz_73{color:var(--text-primary-inverted);height:var(--size-small);width:var(--size-small)}._tiltedIcon_livaz_79{color:var(--text-primary-inverted);fill:var(--text-primary-inverted);height:var(--size-small);transform:rotate(-20deg);width:var(--size-small)}._eventText_livaz_87{color:var(--color-gray-500)!important;margin:0!important;overflow:hidden;text-overflow:ellipsis;transition:color .2s ease-in-out;white-space:nowrap}._eventText_livaz_87._eventTextSelected_livaz_95{color:var(--text-primary)!important}._eventContent_livaz_99{align-items:center;display:flex;height:100%;min-width:100%}._eventContentVerbose_livaz_106{display:flex;flex-direction:column;justify-content:center;min-width:100%}._timestamp_livaz_113{grid-column-end:3;grid-column-start:1}._goToButton_livaz_118{color:var(--color-gray-500);grid-column-start:3;grid-row-start:3;position:absolute;right:-8px;top:-6px}._goToButton_livaz_118:hover{color:var(--text-primary);fill:var(--text-primary)}._goToButton_livaz_118:hover svg{fill:var(--text-primary)}._payloadContainer_livaz_134{border-top:1px solid var(--color-gray-300);grid-column-end:-1;grid-column-start:1;margin:0 -18px;margin-top:var(--size-xSmall);padding:var(--size-small) 18px}._selectedIcon_livaz_143{fill:var(--text-primary);transform:rotate(180deg)}._headerRow_livaz_148{align-items:center;display:flex}._payloadTitle_livaz_153{font-size:12px!important;margin-bottom:var(--size-xSmall)!important}._payloadTitle_livaz_153>div{overflow-wrap:anywhere}._objectKey_1bobg_1{color:var(--color-gray-500);display:block;font-size:12px!important;font-style:normal;line-height:initial;margin-bottom:var(--size-xxSmall);text-transform:capitalize}._objectList_1bobg_11{column-gap:var(--size-small);display:grid;font-family:var(--header-font-family);grid-template-columns:auto 1fr;padding:0;row-gap:var(--size-xSmall)}._objectValue_1bobg_20{color:var(--text-primary);font-size:12px!important;font-style:normal;line-height:initial;width:154px}._objectValue_1bobg_20>*{display:block;overflow-wrap:break-word;width:154px}._payload_1bobg_33{margin:0!important;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._anchor_1bobg_40{vertical-align:middle;word-wrap:break-word}.v8kz6z0{border-radius:6px;display:flex;flex-direction:column;gap:4px;padding:8px;width:100%}.v8kz6z0:hover{background-color:var(--_1pyqka91x)}.v8kz6z2{background-color:var(--_1pyqka91y);box-shadow:inset 0 -1px #0000001a}._1eia00s0{display:flex;flex-direction:column;height:100%;width:100%}._1eia00s1{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;line-height:20px}._1mjemv0{margin:0;max-height:calc(100vh - 540px);overflow-y:auto;overflow-x:hidden}._card_1sxl2_1{border:1px solid var(--color-gray-300);border-radius:var(--border-radius);transition:box-shadow .1s ease-in}._card_1sxl2_1 p,._card_1sxl2_1 a{font-size:12px;margin-top:0!important}._card_1sxl2_1 p{color:var(--color-gray-500)}._card_1sxl2_1 h2{color:var(--text-primary);font-size:12px!important;margin:0}._card_1sxl2_1:hover{border:1px solid var(--color-purple);box-shadow:0 0 9px #5629c640}._card_1sxl2_1 ._titleContainer_1sxl2_23{align-items:center;border-bottom:1px solid var(--color-gray-300);display:flex;height:48px;justify-content:space-between;margin-bottom:var(--size-xxSmall);padding:0 var(--size-small);width:100%}._card_1sxl2_1 ._content_1sxl2_33{padding-bottom:var(--size-small);padding-left:var(--size-small);padding-right:var(--size-small);padding-top:var(--size-small)}._fullWidth_1sxl2_40{width:100%}._requestMetrics_1a9is_1{width:100%}._chartContainer_1a9is_5{height:200px;margin-top:var(--size-medium)}.riaubm0{background:#fdfcfd;width:100%;height:100%}.riaubm1{width:100%;height:calc(100% - 32px);display:flex;flex-direction:column;padding-left:8px;overflow-x:hidden;overflow-y:auto;word-wrap:break-word}.riaubm2{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding-right:24px}.riaubm3{align-items:center;display:flex;justify-content:center;height:100%}.riaubm4{background-color:#e4e2e4}.riaubm5{background-color:#6b48c7;border-radius:4px;height:60%}.riaubm6{display:grid;grid-template-columns:80px 80px 1fr 100px 80px 80px 20px;grid-gap:6px;border-bottom:1px solid #e4e2e4;padding:12px 14px 10px}.riaubm7{display:grid;grid-template-columns:80px 80px 1fr 100px 80px 80px 20px;grid-gap:6px;padding:6px;color:var(--_1pyqka9w);width:100%;height:36px;align-items:center}.riaubm7:hover{background-color:var(--_1pyqka91x)}.riaubma{color:var(--_1pyqka915)}.riaubmc{font-weight:500}._9ttgrc0{height:100%;width:100%}._1gzpu1z0{display:flex;flex-direction:column;row-gap:4px}._noCommentsContainer_1vmpu_1{align-items:center;display:flex;flex-direction:column;height:inherit;justify-content:center;margin:var(--size-xxLarge)}._noCommentsTextContainer_1vmpu_10{text-align:center;top:35%;width:200px}._noCommentsTextContainer_1vmpu_10 h2{color:var(--text-primary);font-size:14px!important;font-weight:400!important;margin:0;margin-bottom:var(--size-xSmall)}._noCommentsTextContainer_1vmpu_10 p{color:var(--color-gray-500);font-size:12px!important;margin:0}._timestamp_1vmpu_28{color:var(--color-gray-500);margin:0!important}._skeleton_1vmpu_33{border-radius:var(--size-xSmall)!important;display:block!important;height:90px;margin:var(--size-xxSmall) var(--size-large);margin-bottom:var(--size-medium);margin-top:var(--size-xSmall);width:auto!important}.ltrwrc0{height:calc(100vh - 108px - var(--banner-height))}.ltrwrc1{position:fixed;left:100%;transform:translate(300px)}.ltrwrc2{height:100%;padding:0}.ltrwrc3{border-radius:8px}._1l6nlco0{padding:0}._1m26oyu0{align-items:center;background-color:#fff;display:flex}._1m26oyu1{transform:rotate(180deg);height:14px;color:#6f6e77}._1m26oyu2{height:14px;padding-right:8px;color:#6f6e77}._1m26oyu3{border-left:1px solid #e4e2e4;height:16px}._1m26oyu4{text-overflow:ellipsis;white-space:nowrap;overflow-x:hidden;display:inline-block}._1m26oyu5{display:flex;align-items:center;overflow-x:hidden;gap:8px}._1m26oyu6{display:flex;align-items:center;justify-content:flex-end;gap:6px;min-width:400px}._1m26oyu7{flex-shrink:0}._1m26oyu8:focus:enabled,._1m26oyu8:active:enabled{background:#e9e8ea;box-shadow:inset 0 -1px #0000001a}._1m26oyu9:focus:enabled,._1m26oyu9:active:enabled{background:transparent;color:#6f6e77}.izessr0{padding-left:8px;height:100%}.izessr1:focus,.izessr1:active,.izessr1:hover{background-color:#e9e8ea}.izessr2{background-color:#eeedef}._1p577ua0{font-size:13px;height:100%;overflow-x:hidden;overflow-y:auto}._1p577ua1{border-radius:6px;color:#6f6e77;display:grid;grid-template-columns:3fr 1fr auto 100px 20px;gap:8px;margin-bottom:1px;padding:8px}._1p577ua1:hover,._1p577ua2{background-color:#eeedef;border-bottom:1px solid #e4e2e4;box-shadow:inset 0 -1px #0000001a;margin-bottom:0}._1p577ua4{align-items:center;display:flex;word-wrap:break-word}._1p577ua5{display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden;word-break:break-all;-webkit-line-clamp:1;line-clamp:1}._1eq64x70{align-items:center;background-color:#fff;display:flex;flex-direction:column;z-index:5;position:relative}._1eq64x71{transform:rotate(90deg)}._1eq64x72{height:20px}.hgp31e0 .ant-modal-content{background-color:var(--_1pyqka92);border-radius:8px!important;border:var(--_1pyqka9j) solid 1px;box-shadow:0 6px 12px -2px #3b3b3b1f}.hgp31e0 .ant-modal-body{padding:0}.tzvxpp0{width:340px;position:fixed;height:calc(100vh - var(--header-height))}.tzvxpp1{height:calc(100vh - var(--header-height) - var(--banner-height))}.tzvxpp2{position:fixed;transform:translate(-340px)}._1gfijho0{align-items:center;display:flex;height:20px;justify-content:space-between}._1gfijho1{max-width:100%}._1gfijho2{color:#6f6e77}._1gfijho3{cursor:pointer;padding-top:2px;width:80px}._1gfijho4:hover{background:#eeedef}._1gfijho5{background:#e9e8ea}._1gfijho5:hover{background-color:#e9e8ea}._1gpgayi0{border-top:solid 1px #e4e2e4;display:flex;flex-direction:column;flex-grow:1}._1gpgayi1{display:flex;flex-direction:column;position:relative}._1gpgayi2{background-color:#f9f8f9;display:flex;flex-direction:column;flex-grow:1;height:100%;padding:8px}._1gpgayi3{background:#fdfcfd;border:1px solid #e4e2e4;border-radius:6px;box-shadow:0 2px 8px -2px #3b3b3b14;overflow:clip;display:flex;flex:2;height:100%;width:100%}._1gpgayi4{align-items:center;box-sizing:border-box;display:flex;flex-grow:1;justify-content:center;position:relative;width:100%}._1gpgayi5 iframe{border-radius:4px;border:var(--_1pyqka9k) solid 1px;box-shadow:0 6px 12px -2px #3b3b3b1f}._1gpgayi6{align-items:center;display:flex;flex-direction:column;flex-grow:1;position:relative;min-width:428px}._1gpgayi7{position:relative;z-index:98}._1gpgayi8{position:fixed;transform:translate(-340px)}._1gpgayi9{align-items:center;color:#000;cursor:move;display:flex;justify-content:flex-end;position:relative;left:32px;top:-700px;z-index:200}._1gpgayia{align-self:center!important;height:fit-content;justify-self:center!important}._1gpgayib{cursor:pointer;text-decoration:underline}._1gpgayic{display:grid;grid-template-columns:1fr}._1gpgayid{grid-template-columns:340px 1fr}._1gpgayie{grid-template-columns:1fr 300px}._1t72qig0{position:absolute;right:0;top:-6px}._1t72qig1{background-color:var(--_1pyqka92);border:var(--_1pyqka9k) solid 1px;border-radius:6px;display:block;padding:0;position:relative}._1t72qig1 code{padding-bottom:8px!important;padding-top:8px!important}@keyframes bva4e60{0%{transform:rotate(0)}to{transform:rotate(360deg)}}.bva4e61{animation:1s bva4e60 linear infinite}.bva4e62{border-top-right-radius:0;border-bottom-right-radius:0}.bva4e63{border-top-left-radius:0;border-bottom-left-radius:0}.u1xyjd0{border-radius:4px;color:var(--_1pyqka9y);cursor:pointer;padding:12px 8px;width:325px}.u1xyjd0:hover{background-color:var(--_1pyqka91x);color:var(--_1pyqka9w)}.u1xyjd1{background-color:var(--_1pyqka91y);color:var(--_1pyqka9w)}.u1xyjd2{background-color:var(--_1pyqka91z);color:var(--_1pyqka9x);cursor:not-allowed}.u1xyjd2:hover{background-color:var(--_1pyqka91z);color:var(--_1pyqka9x)}.u1xyjd3{align-items:center;display:flex;flex-direction:row;gap:4px;padding:8px}.u1xyjd4{align-items:center;border:var(--_1pyqka9k) solid 1px;border-radius:6px;display:flex;height:36px;margin-bottom:6px;justify-content:space-between;padding:0 8px;width:325px}._alert_1c69p_1.ant-alert-info{background-color:var(--color-blue-100)!important;border:0!important;border-radius:var(--border-radius)!important;color:var(--color-blue-800)!important}._alert_1c69p_1.ant-alert-info .ant-alert-message,._alert_1c69p_1.ant-alert-info .ant-alert-close-text{color:var(--color-blue-800)!important}._alert_1c69p_1.ant-alert-info .ant-alert-icon{color:var(--color-blue-600)!important}._alert_1c69p_1.ant-alert-success{background-color:var(--color-green-100)!important;border:0!important;border-radius:var(--border-radius)!important;color:var(--color-green-800)!important}._alert_1c69p_1.ant-alert-success .ant-alert-message,._alert_1c69p_1.ant-alert-success .ant-alert-close-text{color:var(--color-green-800)!important}._alert_1c69p_1.ant-alert-success .ant-alert-icon{color:var(--color-green-600)!important}._alert_1c69p_1.ant-alert-warning{background-color:var(--color-yellow-100)!important;border:0!important;border-radius:var(--border-radius)!important;color:var(--color-yellow-800)!important}._alert_1c69p_1.ant-alert-warning .ant-alert-message,._alert_1c69p_1.ant-alert-warning .ant-alert-close-text{color:var(--color-yellow-800)!important}._alert_1c69p_1.ant-alert-warning .ant-alert-icon{color:var(--color-yellow-600)!important}._alert_1c69p_1 .ant-alert-description{font-size:12px!important;line-height:1.6em!important}._alert_1c69p_1.ant-alert-error{background-color:var(--color-orange-300)!important;border:0!important;border-radius:var(--border-radius)!important;color:var(--text-primary)!important}._alert_1c69p_1.ant-alert-error .ant-alert-message,._alert_1c69p_1.ant-alert-error .ant-alert-close-text{color:var(--text-primary)!important}._alert_1c69p_1.ant-alert-error .ant-alert-icon{color:var(--color-red-600)!important}._alert_1c69p_1 .ant-alert-icon{margin-right:var(--size-small)!important}._alert_1c69p_1.ant-alert{padding-bottom:var(--size-medium)!important;padding-left:var(--size-medium)!important;padding-right:var(--size-medium)!important;padding-top:var(--size-medium)!important}._alert_1c69p_1 .ant-alert-message{font-weight:500;margin-bottom:var(--size-small)!important}._fieldsBox_1vi9t_1{border:1px solid var(--color-gray-300);border-radius:8px;margin-top:var(--size-large);padding:30px;width:100%}._fieldsBox_1vi9t_1 h3{font-size:18px;margin-bottom:var(--size-large)!important}._focus_1vi9t_13{border-color:var(--color-purple-400)}._fieldRow_lusyh_1{display:grid;grid-template-columns:120px 1fr;margin-bottom:var(--size-large)}._fieldRow_lusyh_1:last-of-type{margin-bottom:0}._fieldKey_lusyh_10{align-items:center;display:flex;height:100%}._saveButton_lusyh_16{width:max-content}._container_4rhi2_1{max-width:700px}._subTitle_4rhi2_5{font-size:18px}._titleContainer_4rhi2_9{margin-bottom:var(--size-xxLarge);margin-top:var(--size-xxLarge)}._popConfirmContainer_m61jp_1{z-index:999999999}._popConfirmContainer_m61jp_1 .ant-popover-message-title{max-width:300px;padding-left:0!important}._popConfirmContainer_m61jp_1 .ant-popover-inner-content{padding-bottom:var(--size-medium)!important}._popConfirmContainer_m61jp_1 .ant-btn{height:unset!important;padding-bottom:8px!important;padding-top:8px!important}._popConfirmContainer_m61jp_1 .ant-popover-inner{background-color:var(--color-primary-background);border:1px solid var(--color-gray-300);border-radius:var(--border-radius);box-shadow:var(--box-shadow)}._popConfirmContainer_m61jp_1 ._description_m61jp_22{color:var(--color-gray-500)!important;line-height:1.5!important;margin-bottom:0!important;margin-top:var(--size-xSmall)!important}._popConfirmContainer_m61jp_1 .ant-popover-buttons button{margin-left:var(--size-medium)!important}._popConfirmContainer_m61jp_1 .ant-btn{border-radius:var(--button-border-radius)!important;padding:var(--size-xSmall) var(--size-medium)!important}._memberCard_1ebot_1{align-items:center;column-gap:var(--size-small);display:flex;flex-direction:row}._memberCardWrapper_1ebot_8{margin-right:var(--size-xxLarge)!important;max-width:700px;width:100%}._email_1ebot_14{color:var(--color-gray-500);font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._role_1ebot_22{color:var(--color-gray-500);font-size:13px;justify-content:flex-end}._removeTeamMemberButton_1ebot_28{border:none;flex-shrink:0;height:fit-content;margin-left:auto}._container_17qsm_1{align-items:center;background-color:var(--color-gray-100);border:1px solid rgb(223,223,223);border-radius:var(--button-border-radius);display:flex;height:36px}._container_17qsm_1 ._copyButton_17qsm_9{border-radius:var(--button-border-radius);border-bottom-left-radius:0;border-top-left-radius:0;height:36px;margin-left:auto}._container_17qsm_1 ._link_17qsm_16{margin-left:var(--size-small);margin-right:var(--size-small);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._inlineContainer_17qsm_24{align-items:center;column-gap:var(--size-xxSmall);display:flex}._inlineContainer_17qsm_24 ._copyButton_17qsm_9{color:inherit!important;height:1.2em;width:1.2em}._inlineContainer_17qsm_24 ._copyButton_17qsm_9 svg{color:inherit;height:1em}._boxSubTitle_1g9q5_1{color:var(--color-gray-500)!important;margin-top:0!important}._buttonRow_1g9q5_6{align-items:center;column-gap:var(--size-medium);display:grid;grid-template-columns:1fr 120px}._emailInput_1g9q5_13{height:40px}._inviteButton_1g9q5_17{width:100%}._hr_1g9q5_21{border:0;border-top:1px solid var(--color-gray-300);margin:var(--size-large) 0}._inviteCard_b35ac_1{align-items:center;column-gap:var(--size-small);display:flex;flex-direction:row}._inviteCardWrapper_b35ac_8{margin-right:var(--size-xxLarge)!important;max-width:700px;width:100%}._inviteTime_b35ac_14{color:var(--color-gray-500);font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}._role_b35ac_22{color:var(--color-gray-500);font-size:13px;justify-content:flex-end}._removeTeamMemberButton_b35ac_28{border:none;flex-shrink:0;height:fit-content;margin-left:auto}._titleContainer_ov5oy_1{margin-bottom:var(--size-medium)!important;margin-top:var(--size-xxLarge)!important;max-width:700px}._titleContainer_ov5oy_1 #_subTitle_ov5oy_1{margin-bottom:0!important;margin-top:var(--size-xSmall)!important}._tabTitle_ov5oy_11{font-weight:500!important}._teamTabs_ov5oy_15 .ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn{color:var(--color-purple)!important}._teamTabs_ov5oy_15 .ant-tabs-ink-bar{background:var(--color-purple)!important}._teamTabs_ov5oy_15 .ant-tabs-tab{margin-left:0!important}._dangerRow_lvmhv_1{align-items:center;display:grid;grid-template-columns:1fr 120px;margin-top:5px}._deleteButton_lvmhv_8{background-color:var(--color-red-400);margin-left:15px;padding-left:30px;padding-right:30px;width:max-content}._dangerSubTitle_lvmhv_16{margin-bottom:10px;margin-top:10px}._inputAndButtonRow_ib336_1{align-items:center;display:flex;justify-content:space-between;margin-top:5px}._input_ib336_1{width:100%}._saveButton_ib336_12{margin-left:15px;width:max-content}._sourcemapInfo_16mzb_1{border-bottom:1px solid var(--color-gray-300);margin-bottom:var(--size-xLarge);padding-bottom:var(--size-xLarge)}._list_16mzb_7{margin-top:var(--size-xxSmall)}._list_16mzb_7 .ant-table-cell{cursor:default}._listHeader_16mzb_14{margin-bottom:var(--size-medium)}._listHeader_16mzb_14 h3{margin-bottom:0!important}._listHeader_16mzb_14 .ant-input-affix-wrapper{width:150px}._listHeader_16mzb_14 ._versionSelect_16mzb_23{margin-bottom:var(--size-medium);width:100%}._listRow_16mzb_28{display:block;width:100%}._select_16mzb_33{margin-bottom:var(--size-medium);width:100%}._tabsContainer_lizta_1{margin-top:var(--size-large)}._tabsContainer_lizta_1 .ant-tabs-nav:before{border-bottom:0!important}._tabsContainer_lizta_1 .ant-tabs-tab{margin:0 var(--size-large) 0 0!important}._tabsContainer_lizta_1 .ant-tabs-content-holder{margin-top:var(--size-large)}._error_fqrcl_1,._signInAlert_fqrcl_5{margin:var(--size-medium) 0}._4qdycv0{height:12px}._4qdycv1{border-radius:4px;color:var(--_1pyqka9y);cursor:pointer;padding:8px;width:325px;height:28px;display:flex}._4qdycv1:hover{background-color:var(--_1pyqka91x);color:var(--_1pyqka9w)}._4qdycv2{background-color:var(--_1pyqka91y);color:var(--_1pyqka9w)}._4qdycv3{background-color:var(--_1pyqka91z);color:var(--_1pyqka9x);cursor:not-allowed}._4qdycv3:hover{background-color:var(--_1pyqka91z);color:var(--_1pyqka9x)}._4qdycv5+._4qdycv5{border-top:var(--_1pyqka91o) solid 1px}._1xxy0on0{width:560px;margin-top:64px;margin-bottom:12px}._1xxy0on1{height:40px;top:0;background-color:#fff}._1xxy0on2{height:4px;border-radius:2px;background-color:#e9e8ea;overflow:hidden}._1xxy0on3{background-color:#6f6e77}._1xxy0on4{background-color:#ad5700}._1xxy0on5{width:344px}._1xxy0on6{width:216px}._1xxy0on7{background-color:#f9f8f9}._1xxy0on8{height:16px}._1xxy0on9{padding-top:8px}._1xxy0ona{height:28px}._1q3ayoh0{width:560px;margin-top:36px;margin-bottom:12px}._1q3ayoh1{height:4px;border-radius:2px;background-color:#e9e8ea;overflow:hidden}._1q3ayoh2{background-color:#6f6e77}._1q3ayoh3{background-color:#ad5700}._1q3ayoh4{height:14px}._1q3ayoh5,._1q3ayoh6{height:20px}._buttonBody_18sne_1{column-gap:30px;display:grid;gap:0 0;grid-template-areas:". Left-Panel Center-Panel Right-Panel .";grid-template-columns:auto 300px minmax(200px,700px) 300px auto;padding-left:100px;padding-top:100px;width:100%}._hitTargets_18sne_12{column-gap:30px;height:100%;padding-left:100px;padding-top:200px;width:100%}._hitTargets_18sne_12 section{margin-bottom:var(--size-xxLarge)}._container_18sne_23{display:flex;flex-direction:column;width:100%}._sourcemapErrors_18sne_29{margin:20px auto;max-width:980px;padding:0 20px}
+/* temp_stylePlugin:ni:sha-256;hMrgZB-3mPb_0Q08y0Q63h6uXV5zAJXj4ckTBvCRjWY */
+:root {
+  --color-purple-100: #ede9fe;
+  --color-purple-200: #ddd6fe;
+  --color-purple-300: #c4b5fd;
+  --color-purple-400: #a78bfa;
+  --color-purple-500: #8b5cf6;
+  --color-purple-600: #7c3aed;
+  --color-purple-700: #6d28d9;
+  --color-purple-800: #5b21b6;
+  --color-purple-900: #4c1d95;
+  --color-purple: #5629c6;
+  --color-purple-rgb:
+    86,
+    41,
+    198;
+  --color-blue-100: #dbeafe;
+  --color-blue-200: #bfdbfe;
+  --color-blue-300: #93c5fd;
+  --color-blue-400: #60a5fa;
+  --color-blue-500: #3b82f6;
+  --color-blue-600: #2563eb;
+  --color-blue-700: #1d4ed8;
+  --color-blue-800: #1e40af;
+  --color-blue-900: #1e3a8a;
+  --color-green-100: #d1fae5;
+  --color-green-200: #a7f3d0;
+  --color-green-300: #6ee7b7;
+  --color-green-400: #34d399;
+  --color-green-500: #10b981;
+  --color-green-600: #059669;
+  --color-green-700: #047857;
+  --color-green-800: #065f46;
+  --color-green-900: #064e3b;
+  --color-yellow-100: #fef3c7;
+  --color-yellow-200: #fde68a;
+  --color-yellow-300: #fcd34d;
+  --color-yellow-400: #fbbf24;
+  --color-yellow-500: #f59e0b;
+  --color-yellow-600: #d97706;
+  --color-yellow-700: #b45309;
+  --color-yellow-800: #92400e;
+  --color-yellow-900: #78350f;
+  --color-orange-300: rgba(242, 106, 76, 0.37);
+  --color-orange-400: #ffb038;
+  --color-orange-500: #c67e29;
+  --color-brown: #835e00;
+  --color-red: #ff0000;
+  --color-red-100: #fee2e2;
+  --color-red-200: #fecaca;
+  --color-red-300: #fca5a5;
+  --color-red-400: #f87171;
+  --color-red-500: #ef4444;
+  --color-red-600: #dc2626;
+  --color-red-700: #b91c1c;
+  --color-red-800: #991b1b;
+  --color-red-900: #7f1d1d;
+  --color-gray-100: #efefef7d;
+  --color-gray-200: #f2f2f2;
+  --color-gray-300: #eaeaea;
+  --color-gray-400: #bdbdbd;
+  --color-gray-500: #828282;
+  --color-gray-600: #7e7e7e;
+  --color-gray-700: #8a8f98;
+  --color-gray-800: #2d2f36;
+  --color-black: #111;
+  --color-white: #fff;
+  --color-neutral-50: #f5f5f5;
+  --color-neutral-100: #e9e9e9;
+  --color-neutral-200: #dddddd;
+  --color-neutral-300: #a4a4a4;
+  --color-neutral-500: #777777;
+  --color-neutral-700: #444444;
+  --color-neutral-800: #2c2c2c;
+  --color-neutral-900: #1a1a1a;
+  --color-neutral-N1: #fdfcfd;
+  --color-new-purple-100: #b19cff;
+  --color-new-purple-500: #6c37f4;
+  --color-new-purple-700: #5420d1;
+  --color-new-purple-900: #0d0225;
+  --color-editor-background: #fafafa;
+  --color-editor-foreground-text: #383a42;
+  --color-editor-secondary-text: #4078f2;
+  --color-primary-background: #fff;
+  --color-primary-inverted-background: #111;
+  --color-secondary-background: #f9f9f9;
+  --color-background-overlay: rgba(0, 0, 0, 0.8);
+  --text-primary-inverted: #fff;
+  --text-primary: var(--color-black);
+  --color-link: var(--color-purple);
+  --logo-background-color: #6c37f4;
+  --logo-border-color: #0b0222;
+  --color-brand-pastel-dark: #bcb3d3;
+  --size-xxxLarge: 56px;
+  --size-xxLarge: 48px;
+  --size-xLarge: 32px;
+  --size-large: 24px;
+  --size-medium: 16px;
+  --size-small: 12px;
+  --size-xSmall: 8px;
+  --size-xxSmall: 4px;
+  --size-icon: 18px;
+  --box-shadow:
+    0px 0.9px 1.4px rgba(0, 0, 0, 0.012),
+    0px 2.2px 3.6px rgba(0, 0, 0, 0.018),
+    0px 4.4px 7.4px rgba(0, 0, 0, 0.022),
+    0px 9.1px 15.3px rgba(0, 0, 0, 0.028),
+    0px 25px 42px rgba(0, 0, 0, 0.04);
+  --box-shadow-2:
+    0 3px 6px -4px rgb(0 0 0 / 12%),
+    0 6px 16px 0 rgb(0 0 0 / 8%),
+    0 9px 28px 8px rgb(0 0 0 / 5%);
+  --box-shadow-3:
+    0 2.8px 2.2px rgba(0, 0, 0, 0.02),
+    0 6.7px 5.3px rgba(0, 0, 0, 0.028),
+    0 12.5px 10px rgba(0, 0, 0, 0.035),
+    0 22.3px 17.9px rgba(0, 0, 0, 0.042),
+    0 41.8px 33.4px rgba(0, 0, 0, 0.05),
+    0 100px 80px rgba(0, 0, 0, 0.07);
+  --header-font-family:
+    "Steradian",
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    Arial,
+    "Noto Sans",
+    sans-serif;
+  --body-font-family:
+    "Steradian",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif,
+    "Apple Color Emoji",
+    "Segoe UI Emoji",
+    "Segoe UI Symbol";
+  --monospace-font-family: "Roboto Mono", monospace;
+  --button-border-radius: var(--size-xSmall);
+  --border-radius: var(--size-xSmall);
+  --header-height: 45px;
+  --banner-height: 32px;
+  --color-error-resolved: var(--color-green-400);
+  --color-error-ignored: var(--color-gray-500);
+  --color-error-open: var(--color-red-400);
+  --color-scrubber-zoom-region-border: #565656;
+  --color-scrubber-zoom-region: #56565622;
+  --color-scrubber-zoom-handle: #757575;
+  --color-scrubber-scrub-handle: #ca0000;
+  --color-scrubber-inactive-region: #f0f0f0a6;
+}
+[data-theme=dark] {
+  --color-purple-100: #bea8f1;
+  --color-purple-200: #301e79;
+  --color-purple-300: #eee7ff;
+  --color-purple-400: #a17ce4;
+  --color-purple: #7856ff;
+  --color-purple-800: #302c3a;
+  --color-blue-100: #deebff;
+  --color-blue-200: #b2d4ff;
+  --color-blue-300: #56ccf2;
+  --color-blue-400: #2d9cdb;
+  --color-blue-500: #2f80ed;
+  --color-green-100: #beff6c5e;
+  --color-green-300: #6fcf97;
+  --color-green-400: #27ae60;
+  --color-green-500: #219653;
+  --color-green-600: #006400;
+  --color-yellow-200: #ffd82c;
+  --color-yellow: #f2c94c;
+  --color-orange-300: rgba(242, 106, 76, 0.37);
+  --color-orange-400: #ffb038;
+  --color-orange-500: #c67e29;
+  --color-brown: #835e00;
+  --color-red-100: #fee2e2;
+  --color-red-200: #fecaca;
+  --color-red-300: #fca5a5;
+  --color-red-400: #f87171;
+  --color-red-500: #ef4444;
+  --color-red-600: #dc2626;
+  --color-red-700: #b91c1c;
+  --color-red-800: #991b1b;
+  --color-red-900: #7f1d1d;
+  --color-gray-100: #1a1a1a;
+  --color-gray-200: #333333;
+  --color-gray-300: #333333;
+  --color-gray-400: #595959;
+  --color-gray-500: #8c8c8c;
+  --color-gray-600: #a6a6a6;
+  --color-gray-700: #cccccc;
+  --color-gray-800: #f2f2f2;
+  --color-black: #111;
+  --color-white: #fff;
+  --color-editor-background: #111;
+  --color-editor-foreground-text: var(--color-gray-700);
+  --color-editor-secondary-text: #4078f2;
+  --color-primary-background: #1f2023;
+  --color-primary-inverted-background: #000;
+  --color-secondary-background: var(--color-gray-200);
+  --color-background-overlay: rgba(0, 0, 0, 0.8);
+  --text-primary-inverted: #1f2023;
+  --text-primary: #f6f6f6;
+  --color-link: var(--color-purple);
+}
+body {
+  background-color: var(--color-primary-background) !important;
+  color: var(--text-primary);
+  font-family: var(--body-font-family) !important;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400 !important;
+  margin: 0;
+  text-rendering: geometricPrecision;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--header-font-family);
+  margin: 0;
+  color: var(--text-primary);
+}
+h2 {
+  font-size: 28px;
+}
+h3 {
+  font-size: 20px;
+}
+h4 {
+  font-weight: 400 !important;
+}
+p {
+  line-height: initial !important;
+  margin: var(--size-small) 0 !important;
+}
+li,
+p,
+label {
+  color: var(--text-primary);
+}
+h3 {
+  margin-bottom: var(--size-xSmall) !important;
+}
+h4 {
+  margin-bottom: var(--size-xxSmall) !important;
+}
+h4:last-of-type {
+  margin-bottom: 0 !important;
+}
+button {
+  font-family: var(--header-font-family) !important;
+  font-weight: 400 !important;
+}
+input {
+  font-weight: 400 !important;
+}
+.atom-overlay {
+  color: blue;
+  z-index: 1000000;
+}
+a {
+  color: var(--color-link);
+}
+.blob {
+  height: 15px;
+  margin: 10px;
+  width: 15px;
+}
+.css-foqpf7 {
+  width: 100% !important;
+}
+.ant-slider-rail {
+  background-color: lightgrey;
+}
+.ant-slider-track {
+  background-color: var(--color-purple);
+}
+.ant-slider-track:hover {
+  background-color: var(--color-purple);
+}
+.ant-slider:hover .ant-slider-track {
+  background-color: var(--color-purple);
+}
+.ant-slider:hover .ant-slider-handle:not(.ant-tooltip-open) {
+  border-color: var(--color-purple);
+}
+.ant-slider-dot {
+  border-color: var(--color-purple);
+}
+.ant-slider-handle {
+  border-color: var(--color-purple);
+}
+.ant-slider-handle:focus {
+  border-color: var(--color-purple);
+  box-shadow: 0 0 0 5px rgba(86, 41, 198, 0.12);
+}
+.ant-slider-handle:hover {
+  border-color: var(--color-purple);
+}
+.ant-slider-handle-dragging.ant-slider-handle-dragging.ant-slider-handle-dragging {
+  border-color: var(--color-purple);
+  box-shadow: 0 0 0 5px rgba(86, 41, 198, 0.12);
+}
+.ant-switch-checked {
+  background-color: var(--color-purple);
+}
+.ant-message {
+  z-index: 99999999999 !important;
+}
+.ant-message-notice-content {
+  background: #1f1f1f;
+  border-radius: 8px;
+  color: var(--color-primary-background);
+}
+.ant-tooltip {
+  z-index: 99999 !important;
+}
+.ant-tooltip-inner {
+  border-radius: 6px;
+}
+.ant-skeleton-content .ant-skeleton-title {
+  border-radius: 5px;
+}
+.ant-skeleton-content .ant-skeleton-paragraph > li {
+  border-radius: 5px;
+}
+.ant-select-item-option-active:not(.ant-select-item-option-disabled) {
+  background-color: var(--color-gray-200) !important;
+}
+.ant-select-item-option-selected:not(.ant-select-item-option-disabled) {
+  background-color: var(--color-purple) !important;
+  color: var(--text-primary-inverted) !important;
+  font-weight: normal !important;
+}
+.ant-select-item {
+  padding-top: var(--size-xSmall) !important;
+  padding-bottom: var(--size-xSmall) !important;
+  padding-left: var(--size-small) !important;
+  padding-right: var(--size-small) !important;
+}
+code {
+  border-radius: 4px;
+  line-height: 2;
+  margin: 0;
+  font-family: var(--monospace-font-family);
+}
+code:not([class]) {
+  background-color: var(--color-secondary-background);
+  border: 1px solid var(--color-gray-300);
+  font-size: 87.5%;
+  padding: 1px 3px;
+}
+.ant-dropdown-menu {
+  padding: 0 !important;
+  border: 1px solid var(--color-gray-300) !important;
+  border-radius: var(--border-radius) !important;
+  box-shadow: var(--box-shadow) !important;
+}
+.ant-dropdown-menu-item {
+  border-radius: 0 !important;
+  padding-top: var(--size-small) !important;
+  padding-left: var(--size-xSmall) !important;
+  padding-right: var(--size-xSmall) !important;
+  padding-bottom: var(--size-small) !important;
+}
+.ant-dropdown-menu-item:hover,
+.ant-dropdown-menu-submenu-title:hover {
+  background-color: var(--color-gray-200) !important;
+}
+strong {
+  font-weight: 500 !important;
+}
+.pulse {
+  animation: pulse 2s infinite;
+}
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(var(--pulse-color), 0.7);
+    transform: scale(0.95);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(var(--pulse-color), 0);
+    transform: scale(1);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(var(--pulse-color), 0);
+    transform: scale(0.95);
+  }
+}
+.ant-modal-mask {
+  z-index: 99999999 !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;ssVf0YXHMRBlOQdkNQCpM4PG3-IUXtUolw8eZs4QsY4 */
+.container {
+  width: 100%;
+}
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+@media (min-width: 1536px) {
+  .container {
+    max-width: 1536px;
+  }
+}
+.visible {
+  visibility: visible !important;
+}
+.\!visible {
+  visibility: visible !important;
+}
+.invisible {
+  visibility: hidden !important;
+}
+.static {
+  position: static !important;
+}
+.fixed {
+  position: fixed !important;
+}
+.absolute {
+  position: absolute !important;
+}
+.relative {
+  position: relative !important;
+}
+.sticky {
+  position: sticky !important;
+}
+.inset-x-0 {
+  left: 0px !important;
+  right: 0px !important;
+}
+.right-5 {
+  right: 1.25rem !important;
+}
+.top-5 {
+  top: 1.25rem !important;
+}
+.top-0 {
+  top: 0px !important;
+}
+.left-0 {
+  left: 0px !important;
+}
+.bottom-0 {
+  bottom: 0px !important;
+}
+.float-right {
+  float: right !important;
+}
+.m-0 {
+  margin: 0px !important;
+}
+.m-4 {
+  margin: 1rem !important;
+}
+.mx-0 {
+  margin-left: 0px !important;
+  margin-right: 0px !important;
+}
+.my-6 {
+  margin-top: 1.5rem !important;
+  margin-bottom: 1.5rem !important;
+}
+.mt-4 {
+  margin-top: 1rem !important;
+}
+.mb-0 {
+  margin-bottom: 0px !important;
+}
+.mb-4 {
+  margin-bottom: 1rem !important;
+}
+.mt-1 {
+  margin-top: 0.25rem !important;
+}
+.mr-8 {
+  margin-right: 2rem !important;
+}
+.mb-3 {
+  margin-bottom: 0.75rem !important;
+}
+.mb-6 {
+  margin-bottom: 1.5rem !important;
+}
+.mb-8 {
+  margin-bottom: 2rem !important;
+}
+.ml-auto {
+  margin-left: auto !important;
+}
+.mt-6 {
+  margin-top: 1.5rem !important;
+}
+.block {
+  display: block !important;
+}
+.inline-block {
+  display: inline-block !important;
+}
+.inline {
+  display: inline !important;
+}
+.flex {
+  display: flex !important;
+}
+.inline-flex {
+  display: inline-flex !important;
+}
+.table {
+  display: table !important;
+}
+.grid {
+  display: grid !important;
+}
+.contents {
+  display: contents !important;
+}
+.hidden {
+  display: none !important;
+}
+.h-full {
+  height: 100% !important;
+}
+.h-\[18px\] {
+  height: 18px !important;
+}
+.h-\[20px\] {
+  height: 20px !important;
+}
+.h-8 {
+  height: 2rem !important;
+}
+.max-h-48 {
+  max-height: 12rem !important;
+}
+.w-full {
+  width: 100% !important;
+}
+.w-11\/12 {
+  width: 91.666667% !important;
+}
+.w-\[672px\] {
+  width: 672px !important;
+}
+.w-\[20px\] {
+  width: 20px !important;
+}
+.w-8 {
+  width: 2rem !important;
+}
+.max-w-lg {
+  max-width: 32rem !important;
+}
+.max-w-\[150px\] {
+  max-width: 150px !important;
+}
+.flex-shrink {
+  flex-shrink: 1 !important;
+}
+.flex-grow {
+  flex-grow: 1 !important;
+}
+.grow {
+  flex-grow: 1 !important;
+}
+.transform {
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y)) !important;
+}
+.cursor-pointer {
+  cursor: pointer !important;
+}
+.resize {
+  resize: both !important;
+}
+.auto-cols-fr {
+  grid-auto-columns: minmax(0, 1fr) !important;
+}
+.grid-flow-col {
+  grid-auto-flow: column !important;
+}
+.grid-cols-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+}
+.flex-row {
+  flex-direction: row !important;
+}
+.flex-col {
+  flex-direction: column !important;
+}
+.flex-wrap {
+  flex-wrap: wrap !important;
+}
+.items-center {
+  align-items: center !important;
+}
+.justify-end {
+  justify-content: flex-end !important;
+}
+.justify-center {
+  justify-content: center !important;
+}
+.justify-between {
+  justify-content: space-between !important;
+}
+.justify-around {
+  justify-content: space-around !important;
+}
+.gap-1 {
+  gap: 0.25rem !important;
+}
+.gap-6 {
+  gap: 1.5rem !important;
+}
+.gap-5 {
+  gap: 1.25rem !important;
+}
+.gap-2 {
+  gap: 0.5rem !important;
+}
+.gap-8 {
+  gap: 2rem !important;
+}
+.gap-3 {
+  gap: 0.75rem !important;
+}
+.gap-x-4 {
+  column-gap: 1rem !important;
+}
+.gap-x-2 {
+  column-gap: 0.5rem !important;
+}
+.gap-x-1 {
+  column-gap: 0.25rem !important;
+}
+.overflow-hidden {
+  overflow: hidden !important;
+}
+.overflow-x-auto {
+  overflow-x: auto !important;
+}
+.overflow-y-scroll {
+  overflow-y: scroll !important;
+}
+.truncate {
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+}
+.text-ellipsis {
+  text-overflow: ellipsis !important;
+}
+.whitespace-nowrap {
+  white-space: nowrap !important;
+}
+.break-normal {
+  overflow-wrap: normal !important;
+  word-break: normal !important;
+}
+.rounded {
+  border-radius: 0.25rem !important;
+}
+.rounded-md {
+  border-radius: 0.375rem !important;
+}
+.rounded-none {
+  border-radius: 0px !important;
+}
+.rounded-lg {
+  border-radius: 0.5rem !important;
+}
+.border {
+  border-width: 1px !important;
+}
+.\!border {
+  border-width: 1px !important;
+}
+.border-0 {
+  border-width: 0px !important;
+}
+.border-t {
+  border-top-width: 1px !important;
+}
+.border-solid {
+  border-style: solid !important;
+}
+.border-gray-300 {
+  --tw-border-opacity: 1 !important;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity)) !important;
+}
+.border-transparent {
+  border-color: transparent !important;
+}
+.border-\[\#eaeaea\] {
+  --tw-border-opacity: 1 !important;
+  border-color: rgb(234 234 234 / var(--tw-border-opacity)) !important;
+}
+.bg-white {
+  --tw-bg-opacity: 1 !important;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity)) !important;
+}
+.p-0 {
+  padding: 0px !important;
+}
+.p-8 {
+  padding: 2rem !important;
+}
+.p-2 {
+  padding: 0.5rem !important;
+}
+.p-6 {
+  padding: 1.5rem !important;
+}
+.px-8 {
+  padding-left: 2rem !important;
+  padding-right: 2rem !important;
+}
+.py-6 {
+  padding-top: 1.5rem !important;
+  padding-bottom: 1.5rem !important;
+}
+.px-4 {
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+}
+.py-0 {
+  padding-top: 0px !important;
+  padding-bottom: 0px !important;
+}
+.pb-5 {
+  padding-bottom: 1.25rem !important;
+}
+.pt-6 {
+  padding-top: 1.5rem !important;
+}
+.pb-20 {
+  padding-bottom: 5rem !important;
+}
+.pl-3 {
+  padding-left: 0.75rem !important;
+}
+.pr-5 {
+  padding-right: 1.25rem !important;
+}
+.pt-0 {
+  padding-top: 0px !important;
+}
+.text-center {
+  text-align: center !important;
+}
+.align-middle {
+  vertical-align: middle !important;
+}
+.text-xs {
+  font-size: 0.75rem !important;
+  line-height: 1rem !important;
+}
+.text-2xl {
+  font-size: 1.5rem !important;
+  line-height: 2rem !important;
+}
+.text-base {
+  font-size: 1rem !important;
+  line-height: 1.5rem !important;
+}
+.font-medium {
+  font-weight: 500 !important;
+}
+.uppercase {
+  text-transform: uppercase !important;
+}
+.lowercase {
+  text-transform: lowercase !important;
+}
+.capitalize {
+  text-transform: capitalize !important;
+}
+.italic {
+  font-style: italic !important;
+}
+.leading-normal {
+  line-height: 1.5 !important;
+}
+.text-primary-3 {
+  --tw-text-opacity: 1 !important;
+  color: rgb(84 32 209 / var(--tw-text-opacity)) !important;
+}
+.text-gray-500 {
+  --tw-text-opacity: 1 !important;
+  color: rgb(107 114 128 / var(--tw-text-opacity)) !important;
+}
+.text-red-600 {
+  --tw-text-opacity: 1 !important;
+  color: rgb(220 38 38 / var(--tw-text-opacity)) !important;
+}
+.underline {
+  text-decoration-line: underline !important;
+}
+.shadow {
+  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1) !important;
+  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color) !important;
+  box-shadow:
+    var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000),
+    var(--tw-shadow) !important;
+}
+.outline {
+  outline-style: solid !important;
+}
+.\!outline {
+  outline-style: solid !important;
+}
+.blur {
+  --tw-blur: blur(8px) !important;
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow) !important;
+}
+.blur-xs {
+  --tw-blur: blur(2px) !important;
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow) !important;
+}
+.invert {
+  --tw-invert: invert(100%) !important;
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow) !important;
+}
+.filter {
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow) !important;
+}
+.\!filter {
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow) !important;
+}
+.backdrop-filter {
+  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia) !important;
+}
+.transition {
+  transition-property:
+    color,
+    background-color,
+    border-color,
+    text-decoration-color,
+    fill,
+    stroke,
+    opacity,
+    box-shadow,
+    transform,
+    filter,
+    backdrop-filter !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+  transition-duration: 150ms !important;
+}
+.ease-in-out {
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.hover\:bg-neutral-100:hover {
+  --tw-bg-opacity: 1 !important;
+  background-color: rgb(245 245 245 / var(--tw-bg-opacity)) !important;
+}
+.focus\:outline-none:focus {
+  outline: 2px solid transparent !important;
+  outline-offset: 2px !important;
+}
+.focus-visible\:bg-neutral-100:focus-visible {
+  --tw-bg-opacity: 1 !important;
+  background-color: rgb(245 245 245 / var(--tw-bg-opacity)) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;TifPc2JAA6_JCHbW5cMKmekopC62GkrDxB4trcwK2KU */
+._buttonBase_14ocv_1 {
+  align-items: center;
+  color: var(--text-primary) !important;
+  display: flex;
+  height: auto;
+  padding-bottom: 8px;
+  padding-top: 8px;
+}
+._buttonBase_14ocv_1.ant-btn-primary {
+  color: var(--color-white) !important;
+}
+._buttonBase_14ocv_1[disabled] {
+  color: var(--text-primary-inverted) !important;
+}
+._buttonBase_14ocv_1.ant-btn-block {
+  justify-content: center;
+}
+._buttonBase_14ocv_1._iconButton_14ocv_18 {
+  align-items: center;
+  border-radius: 50%;
+  color: var(--text-primary);
+  display: flex;
+  height: var(--size-xLarge);
+  justify-content: center;
+  padding: 0;
+  width: var(--size-xLarge);
+}
+._buttonBase_14ocv_1._iconButton_14ocv_18.ant-btn-sm {
+  height: var(--size-small);
+  width: var(--size-small);
+}
+._buttonBase_14ocv_1._iconButton_14ocv_18.ant-btn[disabled] {
+  background: var(--color-gray-300) !important;
+  border-color: var(--color-gray-400) !important;
+  fill: var(--color-gray-500) !important;
+}
+._buttonBase_14ocv_1._iconButton_14ocv_18:hover {
+  background-color: var(--color-gray-200);
+}
+._buttonBase_14ocv_1._iconButton_14ocv_18 svg {
+  height: var(--size-icon);
+  width: var(--size-icon);
+}
+._buttonBase_14ocv_1._small_14ocv_44 svg {
+  height: var(--size-small);
+  width: var(--size-small);
+}
+._buttonBase_14ocv_1.ant-btn-ghost {
+  border-color: var(--color-gray-300) !important;
+}
+._buttonBase_14ocv_1.ant-btn-text:hover {
+  background: var(--color-gray-200) !important;
+}
+._buttonBase_14ocv_1.ant-btn-default.ant-btn-dangerous {
+  color: var(--color-red-400) !important;
+}
+._small_14ocv_44 {
+  padding-bottom: var(--size-xxSmall);
+  padding-left: var(--size-small);
+  padding-right: var(--size-small);
+  padding-top: var(--size-xxSmall);
+}
+._link_14ocv_65 {
+  border: 0;
+  display: inline;
+  font-size: inherit;
+  line-height: inherit;
+  margin: 0;
+  padding: 0;
+}
+._pulse_14ocv_74 {
+  animation: _pulse_14ocv_74 2s infinite;
+}
+@keyframes _pulse_14ocv_74 {
+  0% {
+    box-shadow: 0 0 0 0 rgba(var(--pulse-color), 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(var(--pulse-color), 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(var(--pulse-color), 0);
+  }
+}
+
+/* temp_stylePlugin:ni:sha-256;Sz-RWBbjd3g_mAc7r0u6O25Qkhl20h_kxcrY94p6HuI */
+._link_z3guv_1 {
+  background: var(--color-purple);
+  border: 1px solid transparent !important;
+  border-radius: var(--button-border-radius);
+  color: var(--color-white) !important;
+  display: block;
+  font-family: var(--header-font-family);
+  padding-bottom: var(--size-xSmall);
+  padding-left: var(--size-medium);
+  padding-right: var(--size-medium);
+  padding-top: var(--size-xSmall);
+  text-align: center;
+  width: max-content;
+}
+._link_z3guv_1:hover {
+  color: var(--text-primary-inverted);
+}
+._link_z3guv_1._withIcon_z3guv_18 {
+  align-items: center;
+  column-gap: var(--size-medium);
+  display: flex;
+}
+._link_z3guv_1._fullWidth_z3guv_23 {
+  justify-content: center;
+  width: 100%;
+}
+._link_z3guv_1._to_z3guv_27:hover,
+._link_z3guv_1._to_z3guv_27:active,
+._link_z3guv_1._to_z3guv_27:focus {
+  background: var(--color-purple-600);
+  border-color: var(--color-purple-600);
+}
+._link_z3guv_1._defaultButtonStyles_z3guv_31 {
+  background: var(--color-primary-background) !important;
+  border: 1px solid var(--color-gray-400) !important;
+  box-sizing: border-box;
+  color: var(--text-primary) !important;
+}
+._link_z3guv_1:disabled {
+  background: var(--color-purple);
+  color: var(--color-purple-200);
+}
+._link_z3guv_1:disabled:hover {
+  background: var(--color-purple);
+}
+
+/* temp_stylePlugin:ni:sha-256;wUwID7vad1vWbjJDD9-3SRyk8tsmyhRTlzpNJIO00HA */
+._space_1oubz_1 {
+  display: flex;
+  flex-direction: row;
+}
+._alignStart_1oubz_6 {
+  align-items: flex-start;
+}
+._alignEnd_1oubz_10 {
+  align-items: flex-end;
+}
+._alignCenter_1oubz_14 {
+  align-items: center;
+}
+._verticalDirection_1oubz_18 {
+  flex-direction: column;
+}
+._wrap_1oubz_22 {
+  flex-wrap: wrap;
+}
+._xxSmall_1oubz_26 {
+  gap: var(--size-xxSmall);
+}
+._xSmall_1oubz_30 {
+  gap: var(--size-xSmall);
+}
+._small_1oubz_34 {
+  gap: var(--size-small);
+}
+._medium_1oubz_38 {
+  gap: var(--size-medium);
+}
+._large_1oubz_42 {
+  gap: var(--size-large);
+}
+._xLarge_1oubz_46 {
+  gap: var(--size-xLarge);
+}
+._xxLarge_1oubz_50 {
+  gap: var(--size-xxLarge);
+}
+@keyframes _1wdh3sj0 {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+._1wdh3sj1 {
+  animation-name: _1wdh3sj0;
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+
+/* temp_stylePlugin:ni:sha-256;uUGPDy1jkcyd_T0Ruxn0axXZSLy88hzA0ScbKZx7aCk */
+._demoWorkspaceButton_am6u9_1 {
+  background-color: var(--color-primary-inverted-background);
+  border: 0;
+  border-radius: var(--border-radius);
+  column-gap: var(--size-xSmall);
+}
+._demoWorkspaceButton_am6u9_1:hover,
+._demoWorkspaceButton_am6u9_1:active,
+._demoWorkspaceButton_am6u9_1:focus {
+  background-color: var(--color-gray-800);
+  border: 0;
+}
+
+/* temp_stylePlugin:ni:sha-256;tFfWUXfmLy9JYsQBlF-aufmCS8GIoAjcHm2jXgOoYww */
+._userAvatarWrapper_12k1r_1 {
+  border-radius: 50%;
+  height: max-content;
+}
+._userAvatarBorder_12k1r_6 {
+  border: 4px solid var(--color-black);
+  box-shadow: var(--box-shadow);
+}
+._userAvatar_12k1r_1 {
+  border-radius: 50%;
+}
+._userAvatarText_12k1r_15 {
+  align-items: center;
+  border-radius: 50%;
+  display: flex;
+  font-family: var(--header-font-family);
+  font-weight: 500;
+  justify-content: center;
+  line-height: initial;
+}
+
+/* temp_stylePlugin:ni:sha-256;IT87lkkQb9cC8s6Id58a1jre2_Bu0s6UkaSFxFP9beY */
+._dropdownName_1f2xb_1 {
+  font-size: 16px;
+  margin-bottom: 2px;
+}
+._dropdownEmail_1f2xb_6 {
+  color: var(--color-gray-500);
+  margin: 0 !important;
+  margin-top: var(--size-xSmall) !important;
+}
+._logoutIcon_1f2xb_12 {
+  height: 16px;
+  margin-left: auto;
+  width: 16px;
+}
+._avatarWrapper_1f2xb_18 {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  padding: 10px;
+}
+._userInfoWrapper_1f2xb_25 {
+  align-items: center;
+  border-bottom: 1px solid var(--color-gray-300);
+  display: flex;
+  flex-direction: row;
+  justify-self: center;
+}
+._dropdownInner_1f2xb_33 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: 8px;
+  box-shadow: var(--box-shadow);
+  color: var(--text-primary);
+  margin-top: -10px;
+  overflow: hidden;
+}
+._dropdownMyAccount_1f2xb_43 {
+  align-items: center;
+  display: flex;
+  padding: var(--size-xSmall) var(--size-medium);
+  transition: 0.2s;
+  width: 100%;
+}
+._dropdownMyAccount_1f2xb_43:hover {
+  background-color: var(--color-purple-200);
+}
+._dropdownLogout_1f2xb_54 {
+  align-items: center;
+  color: var(--color-red-400);
+  cursor: pointer;
+  display: flex;
+  padding: var(--size-xSmall) var(--size-medium);
+  transition: 0.2s;
+  width: 100%;
+}
+._dropdownLogout_1f2xb_54:hover {
+  background-color: var(--color-red-200);
+}
+._dropdownLogoutText_1f2xb_67 {
+  font-size: 16px;
+}
+._dropdownMenu_1f2xb_71 {
+  box-shadow: none;
+  min-width: 200px;
+}
+._accountIconWrapper_1f2xb_76 {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+}
+._accountIcon_1f2xb_76 {
+  cursor: pointer;
+  fill: var(--color-purple);
+  height: 25px;
+  margin-right: 30px;
+  width: 25px;
+}
+._userCopy_1f2xb_92 {
+  padding: 14px;
+  padding-left: 6px;
+  padding-right: 25px;
+}
+._1ta0zd10 {
+  width: 280px;
+}
+
+/* temp_stylePlugin:ni:sha-256;HNl1EbL_tv0j7H5V19e-0thGI1HRKfytPxMFishAP8U */
+._errorWrapper_yb6kl_1 {
+  align-items: center;
+  background: var(--color-primary-500);
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  width: 100vw;
+}
+._errorWrapper_yb6kl_1._shownWithHeader_yb6kl_9 {
+  background: var(--color-primary-background);
+  height: calc(100vh - var(--header-height));
+}
+._errorWrapper_yb6kl_1 > div {
+  max-width: 360px;
+}
+._errorBody_yb6kl_17 {
+  color: var(--color-black);
+  max-width: 800px;
+  word-wrap: break-word;
+  margin: 0 !important;
+}
+._buttonGroup_yb6kl_24 {
+  display: flex;
+}
+._loggedInButtonGroup_yb6kl_28 {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
+/* temp_stylePlugin:ni:sha-256;S3Ony6LmftmKw_kNjDGRNKRx1RyyMF1aPj3SeKi_XzE */
+._spinnerStyle_xtyfi_1 {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  width: 100px;
+  z-index: 10;
+}
+._spinnerWrapper_xtyfi_9 {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  width: 100%;
+}
+._loadingWrapper_xtyfi_17 {
+  align-items: center;
+  background: var(--color-primary-background);
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  position: absolute;
+  width: 100vw;
+  z-index: 9999999999;
+}
+._loadingFlexWrapper_xtyfi_28 {
+  height: 100%;
+  width: 100%;
+}
+._background_xtyfi_33 {
+  --background-color: var(--color-primary-background);
+  --dot-color: var(--color-gray-200);
+  --dot-size: 2px;
+  --square-size: 50px;
+  background-image: radial-gradient(var(--dot-color) var(--dot-size), var(--background-color) var(--dot-size));
+  background-position: 0 0;
+  background-size: var(--square-size) var(--square-size);
+  height: 100vh;
+  position: absolute;
+  width: 100vw;
+  z-index: -1;
+}
+._logoContainer_xtyfi_47 {
+  --logo-size: 60px;
+  display: grid;
+  height: var(--logo-size);
+  width: var(--logo-size);
+}
+._logoContainer_xtyfi_47 ._logo_xtyfi_47 {
+  grid-column-start: 1;
+  grid-row-start: 1;
+  height: var(--logo-size);
+  width: var(--logo-size);
+  z-index: 2;
+}
+._logoContainer_xtyfi_47 ._logo_xtyfi_47 svg {
+  height: 100%;
+  width: 100%;
+}
+._logoContainer_xtyfi_47 ._logoBackground_xtyfi_64 {
+  background: var(--logo-background-color);
+  border: 2px solid var(--logo-border-color);
+  border-radius: 50%;
+  grid-column-start: 1;
+  grid-row-start: 1;
+  height: var(--logo-size);
+  transform-origin: center;
+  width: var(--logo-size);
+}
+
+/* temp_stylePlugin:ni:sha-256;KwX-TVKSd6oFGnHzG35QHBOweO5ro7iyDaipjeQrPSE */
+.App {
+  text-align: center;
+}
+.Collapsible__contentInner {
+  margin: 1px;
+}
+.ant-picker-input input::placeholder {
+  color: var(--color-gray-500);
+  font-size: 14px;
+  font-weight: 300;
+}
+.ant-picker-suffix {
+  color: var(--color-gray-500);
+}
+.ant-picker-input > input {
+  font-weight: 300;
+}
+.ant-picker-dropdown {
+  z-index: 9999999999 !important;
+}
+.ant-dropdown {
+  z-index: 999999 !important;
+}
+.ant-dropdown-menu-item {
+  font-family: var(--header-font-family);
+}
+.ant-tabs {
+  height: 100%;
+}
+.ant-tabs-nav-wrap {
+  padding-bottom: 0;
+  padding-left: var(--size-large);
+  padding-right: var(--size-large);
+  padding-top: 0;
+}
+.ant-tabs-content {
+  display: flex;
+  height: 100%;
+  width: 100%;
+}
+.ant-tabs-tab-btn {
+  color: var(--color-gray-500);
+  font-size: 14px;
+  outline: none;
+  outline-color: initial;
+  outline-style: none;
+  outline-width: initial;
+  transition: all 0.3s;
+}
+.ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn {
+  color: var(--text-primary) !important;
+}
+.ant-tabs-tab {
+  margin: 0 16px !important;
+}
+.ant-tabs-tab::after {
+  background: var(--color-gray-400);
+  border-radius: 5px;
+  bottom: 0;
+  content: "";
+  height: 3px;
+  opacity: 0;
+  position: absolute;
+  transition: opacity 0.2s ease-in-out;
+  width: 100%;
+}
+.ant-tabs-tab:hover.ant-tabs-tab::after {
+  opacity: 1;
+}
+.ant-tabs-ink-bar {
+  background: var(--text-primary) !important;
+  border-radius: 5px;
+  height: 3px !important;
+}
+.ant-tabs-nav {
+  margin-bottom: 0 !important;
+}
+.ant-tabs-top > .ant-tabs-nav::before,
+.ant-tabs-bottom > .ant-tabs-nav::before,
+.ant-tabs-top > div > .ant-tabs-nav::before,
+.ant-tabs-bottom > div > .ant-tabs-nav::before {
+  border-bottom: 1px solid var(--color-gray-300) !important;
+}
+.ant-popover-inner-content {
+  padding-bottom: 0 !important;
+}
+input[name=option-input] {
+  background-color: transparent !important;
+  border: 0 !important;
+  font-weight: 300;
+  outline: none !important;
+}
+.Collapsible {
+  width: 100%;
+}
+.replayer-wrapper {
+  position: absolute;
+}
+.rc-slider {
+  cursor: pointer;
+  padding: 0 !important;
+}
+iframe {
+  background-color: var(--color-primary-background);
+  border: 0;
+  z-index: -10;
+}
+.ant-table-cell {
+  border-bottom: 0 !important;
+  cursor: pointer;
+  padding: 0 !important;
+}
+.ant-table-cell > * {
+  align-items: center;
+  display: flex;
+  height: 100%;
+}
+.ant-table-body {
+  overflow-y: auto !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;_-1sMzv3vQbC-XgFwd6KLRJgN9EpwkdwNuRQ8ocraE0 */
+._label_oj421_1 {
+  align-items: center;
+  color: var(--color-gray-500);
+  column-gap: var(--size-xSmall);
+  display: flex;
+  line-height: normal;
+  transition: color 0.2s ease-in;
+}
+._label_oj421_1._checked_oj421_9 {
+  color: var(--text-primary);
+}
+._label_oj421_1._checked_oj421_9._red_oj421_12 {
+  color: var(--color-red);
+}
+._label_oj421_1._spaceBetween_oj421_15 {
+  display: flex;
+  justify-content: space-between;
+}
+._label_oj421_1._noMarginAroundSwitch_oj421_19 {
+  margin: 0;
+}
+._label_oj421_1._setMarginForAnimation_oj421_22 {
+  margin: 6px;
+}
+._switchStyles_oj421_26 {
+  background: var(--color-gray-400);
+}
+._switchStyles_oj421_26.ant-switch-checked {
+  background: var(--color-purple);
+}
+._switchStyles_oj421_26.ant-switch-checked._red_oj421_12 {
+  background: var(--color-red);
+}
+._2hsj210 {
+  margin-bottom: 6px;
+}
+._2hsj211 {
+  width: 100%;
+}
+.highlight-light-theme {
+  --_1pyqka90: #fdfcfd;
+  --_1pyqka91: #ffffff;
+  --_1pyqka92: #f9f8f9;
+  --_1pyqka93: #f4f2f4;
+  --_1pyqka94: rgba(26, 21, 35, 0.72);
+  --_1pyqka95: #ddf3e4;
+  --_1pyqka96: #ffecbc;
+  --_1pyqka97: #ffe5e5;
+  --_1pyqka98: #ede7fe;
+  --_1pyqka99: #eeedef;
+  --_1pyqka9a: #1a1523;
+  --_1pyqka9b: rgba(26, 21, 35, 0.72);
+  --_1pyqka9c: #6f6e77;
+  --_1pyqka9d: rgba(111, 110, 119, 0.8);
+  --_1pyqka9e: #18794e;
+  --_1pyqka9f: #ad5700;
+  --_1pyqka9g: #cd2b31;
+  --_1pyqka9h: #6346af;
+  --_1pyqka9i: #c8c7cb;
+  --_1pyqka9j: #dcdbdd;
+  --_1pyqka9k: #ebe9eb;
+  --_1pyqka9l: #744ed4;
+  --_1pyqka9m: #6b48c7;
+  --_1pyqka9n: #6346af;
+  --_1pyqka9o: rgba(116, 78, 212, 0.24);
+  --_1pyqka9p: #ffffff;
+  --_1pyqka9q: rgba(32, 16, 77, 0.36);
+  --_1pyqka9r: #6346af;
+  --_1pyqka9s: #eeedef;
+  --_1pyqka9t: #e9e8ea;
+  --_1pyqka9u: #e4e2e4;
+  --_1pyqka9v: #f4f2f4;
+  --_1pyqka9w: rgba(26, 21, 35, 0.72);
+  --_1pyqka9x: #c8c7cb;
+  --_1pyqka9y: #6f6e77;
+  --_1pyqka9z: #e5484d;
+  --_1pyqka910: #dc3d43;
+  --_1pyqka911: #cd2b31;
+  --_1pyqka912: rgba(229, 72, 77, 0.24);
+  --_1pyqka913: #ffffff;
+  --_1pyqka914: rgba(56, 19, 22, 0.36);
+  --_1pyqka915: #cd2b31;
+  --_1pyqka916: #ffb224;
+  --_1pyqka917: #ffa01c;
+  --_1pyqka918: #ee9d2b;
+  --_1pyqka919: rgba(255, 178, 36, 0.24);
+  --_1pyqka91a: #4e2009;
+  --_1pyqka91b: rgba(78, 32, 9, 0.36);
+  --_1pyqka91c: #ad5700;
+  --_1pyqka91d: #30a46c;
+  --_1pyqka91e: #299764;
+  --_1pyqka91f: #18794e;
+  --_1pyqka91g: rgba(48, 164, 108, 0.24);
+  --_1pyqka91h: #ffffff;
+  --_1pyqka91i: rgba(21, 50, 38, 0.36);
+  --_1pyqka91j: #18794e;
+  --_1pyqka91k: #d9cdf9;
+  --_1pyqka91l: #c9b9f3;
+  --_1pyqka91m: #af98ec;
+  --_1pyqka91n: #f4f0ff;
+  --_1pyqka91o: #dcdbdd;
+  --_1pyqka91p: #c8c7cb;
+  --_1pyqka91q: #c8c7cb;
+  --_1pyqka91r: #f4f2f4;
+  --_1pyqka91s: rgba(237, 231, 254, 0.0);
+  --_1pyqka91t: #ede7fe;
+  --_1pyqka91u: #e7defc;
+  --_1pyqka91v: rgba(237, 231, 254, 0.0);
+  --_1pyqka91w: rgba(238, 237, 239, 0.0);
+  --_1pyqka91x: #eeedef;
+  --_1pyqka91y: #e9e8ea;
+  --_1pyqka91z: rgba(238, 237, 239, 0.0);
+  --_1pyqka920: rgba(238, 237, 239, 0.64);
+  --_1pyqka921: rgba(238, 237, 239, 0.84);
+}
+.mt0ih20 {
+  align-items: stretch;
+}
+.mt0ih21 {
+  align-items: flex-start;
+}
+.mt0ih22 {
+  align-items: center;
+}
+.mt0ih23 {
+  align-items: flex-end;
+}
+.mt0ih24 {
+  border-radius: 2px;
+}
+.mt0ih25 {
+  border-radius: 3px;
+}
+.mt0ih26 {
+  border-radius: 4px;
+}
+.mt0ih27 {
+  border-radius: 5px;
+}
+.mt0ih28 {
+  border-radius: 6px;
+}
+.mt0ih29 {
+  border-radius: 8px;
+}
+.mt0ih2a {
+  border-radius: 10px;
+}
+.mt0ih2b {
+  border-radius: 12px;
+}
+.mt0ih2c {
+  border-radius: 16px;
+}
+.mt0ih2d {
+  border-radius: 23px;
+}
+.mt0ih2e {
+  border-radius: 999px;
+}
+.mt0ih2f {
+  border-radius: inherit;
+}
+.mt0ih2g {
+  border-top-left-radius: 2px;
+}
+.mt0ih2h {
+  border-top-left-radius: 3px;
+}
+.mt0ih2i {
+  border-top-left-radius: 4px;
+}
+.mt0ih2j {
+  border-top-left-radius: 5px;
+}
+.mt0ih2k {
+  border-top-left-radius: 6px;
+}
+.mt0ih2l {
+  border-top-left-radius: 8px;
+}
+.mt0ih2m {
+  border-top-left-radius: 10px;
+}
+.mt0ih2n {
+  border-top-left-radius: 12px;
+}
+.mt0ih2o {
+  border-top-left-radius: 16px;
+}
+.mt0ih2p {
+  border-top-left-radius: 23px;
+}
+.mt0ih2q {
+  border-top-left-radius: 999px;
+}
+.mt0ih2r {
+  border-top-left-radius: inherit;
+}
+.mt0ih2s {
+  border-top-right-radius: 2px;
+}
+.mt0ih2t {
+  border-top-right-radius: 3px;
+}
+.mt0ih2u {
+  border-top-right-radius: 4px;
+}
+.mt0ih2v {
+  border-top-right-radius: 5px;
+}
+.mt0ih2w {
+  border-top-right-radius: 6px;
+}
+.mt0ih2x {
+  border-top-right-radius: 8px;
+}
+.mt0ih2y {
+  border-top-right-radius: 10px;
+}
+.mt0ih2z {
+  border-top-right-radius: 12px;
+}
+.mt0ih210 {
+  border-top-right-radius: 16px;
+}
+.mt0ih211 {
+  border-top-right-radius: 23px;
+}
+.mt0ih212 {
+  border-top-right-radius: 999px;
+}
+.mt0ih213 {
+  border-top-right-radius: inherit;
+}
+.mt0ih214 {
+  border-bottom-left-radius: 2px;
+}
+.mt0ih215 {
+  border-bottom-left-radius: 3px;
+}
+.mt0ih216 {
+  border-bottom-left-radius: 4px;
+}
+.mt0ih217 {
+  border-bottom-left-radius: 5px;
+}
+.mt0ih218 {
+  border-bottom-left-radius: 6px;
+}
+.mt0ih219 {
+  border-bottom-left-radius: 8px;
+}
+.mt0ih21a {
+  border-bottom-left-radius: 10px;
+}
+.mt0ih21b {
+  border-bottom-left-radius: 12px;
+}
+.mt0ih21c {
+  border-bottom-left-radius: 16px;
+}
+.mt0ih21d {
+  border-bottom-left-radius: 23px;
+}
+.mt0ih21e {
+  border-bottom-left-radius: 999px;
+}
+.mt0ih21f {
+  border-bottom-left-radius: inherit;
+}
+.mt0ih21g {
+  border-bottom-right-radius: 2px;
+}
+.mt0ih21h {
+  border-bottom-right-radius: 3px;
+}
+.mt0ih21i {
+  border-bottom-right-radius: 4px;
+}
+.mt0ih21j {
+  border-bottom-right-radius: 5px;
+}
+.mt0ih21k {
+  border-bottom-right-radius: 6px;
+}
+.mt0ih21l {
+  border-bottom-right-radius: 8px;
+}
+.mt0ih21m {
+  border-bottom-right-radius: 10px;
+}
+.mt0ih21n {
+  border-bottom-right-radius: 12px;
+}
+.mt0ih21o {
+  border-bottom-right-radius: 16px;
+}
+.mt0ih21p {
+  border-bottom-right-radius: 23px;
+}
+.mt0ih21q {
+  border-bottom-right-radius: 999px;
+}
+.mt0ih21r {
+  border-bottom-right-radius: inherit;
+}
+.mt0ih21s {
+  cursor: default;
+}
+.mt0ih21t {
+  cursor: pointer;
+}
+.mt0ih21u {
+  display: none;
+}
+.mt0ih21v {
+  display: flex;
+}
+.mt0ih21w {
+  display: block;
+}
+.mt0ih21x {
+  display: inline;
+}
+.mt0ih21y {
+  display: inline-block;
+}
+.mt0ih21z {
+  display: inline-flex;
+}
+.mt0ih220 {
+  position: absolute;
+}
+.mt0ih221 {
+  position: fixed;
+}
+.mt0ih222 {
+  position: relative;
+}
+.mt0ih223 {
+  position: static;
+}
+.mt0ih224 {
+  position: sticky;
+}
+.mt0ih225 {
+  text-align: left;
+}
+.mt0ih226 {
+  text-align: center;
+}
+.mt0ih227 {
+  text-align: right;
+}
+.mt0ih228 {
+  gap: 0;
+}
+.mt0ih229 {
+  gap: 1px;
+}
+.mt0ih22a {
+  gap: 2px;
+}
+.mt0ih22b {
+  gap: 3px;
+}
+.mt0ih22c {
+  gap: 4px;
+}
+.mt0ih22d {
+  gap: 6px;
+}
+.mt0ih22e {
+  gap: 7px;
+}
+.mt0ih22f {
+  gap: 8px;
+}
+.mt0ih22g {
+  gap: 9px;
+}
+.mt0ih22h {
+  gap: 10px;
+}
+.mt0ih22i {
+  gap: 12px;
+}
+.mt0ih22j {
+  gap: 16px;
+}
+.mt0ih22k {
+  gap: 20px;
+}
+.mt0ih22l {
+  gap: 24px;
+}
+.mt0ih22m {
+  gap: 28px;
+}
+.mt0ih22n {
+  gap: 32px;
+}
+.mt0ih22o {
+  gap: 40px;
+}
+.mt0ih22p {
+  flex: 1 1 0;
+}
+.mt0ih22q {
+  flex: 0 0 auto;
+}
+.mt0ih22r {
+  flex-basis: 0;
+}
+.mt0ih22s {
+  flex-basis: 1px;
+}
+.mt0ih22t {
+  flex-direction: row;
+}
+.mt0ih22u {
+  flex-direction: column;
+}
+.mt0ih22v {
+  flex-direction: column-reverse;
+}
+.mt0ih22w {
+  flex-grow: 0;
+}
+.mt0ih22x {
+  flex-grow: 1;
+}
+.mt0ih22y {
+  flex-shrink: 0;
+}
+.mt0ih22z {
+  flex-wrap: wrap;
+}
+.mt0ih230 {
+  flex-wrap: nowrap;
+}
+.mt0ih231 {
+  justify-content: stretch;
+}
+.mt0ih232 {
+  justify-content: flex-start;
+}
+.mt0ih233 {
+  justify-content: center;
+}
+.mt0ih234 {
+  justify-content: flex-end;
+}
+.mt0ih235 {
+  justify-content: space-around;
+}
+.mt0ih236 {
+  justify-content: space-between;
+}
+.mt0ih237 {
+  justify-self: stretch;
+}
+.mt0ih238 {
+  justify-self: flex-start;
+}
+.mt0ih239 {
+  justify-self: center;
+}
+.mt0ih23a {
+  justify-self: flex-end;
+}
+.mt0ih23b {
+  justify-self: space-around;
+}
+.mt0ih23c {
+  justify-self: space-between;
+}
+.mt0ih23d {
+  padding: 0;
+}
+.mt0ih23e {
+  padding: 1px;
+}
+.mt0ih23f {
+  padding: 2px;
+}
+.mt0ih23g {
+  padding: 3px;
+}
+.mt0ih23h {
+  padding: 4px;
+}
+.mt0ih23i {
+  padding: 6px;
+}
+.mt0ih23j {
+  padding: 7px;
+}
+.mt0ih23k {
+  padding: 8px;
+}
+.mt0ih23l {
+  padding: 9px;
+}
+.mt0ih23m {
+  padding: 10px;
+}
+.mt0ih23n {
+  padding: 12px;
+}
+.mt0ih23o {
+  padding: 16px;
+}
+.mt0ih23p {
+  padding: 20px;
+}
+.mt0ih23q {
+  padding: 24px;
+}
+.mt0ih23r {
+  padding: 28px;
+}
+.mt0ih23s {
+  padding: 32px;
+}
+.mt0ih23t {
+  padding: 40px;
+}
+.mt0ih23u {
+  padding-top: 0;
+}
+.mt0ih23v {
+  padding-top: 1px;
+}
+.mt0ih23w {
+  padding-top: 2px;
+}
+.mt0ih23x {
+  padding-top: 3px;
+}
+.mt0ih23y {
+  padding-top: 4px;
+}
+.mt0ih23z {
+  padding-top: 6px;
+}
+.mt0ih240 {
+  padding-top: 7px;
+}
+.mt0ih241 {
+  padding-top: 8px;
+}
+.mt0ih242 {
+  padding-top: 9px;
+}
+.mt0ih243 {
+  padding-top: 10px;
+}
+.mt0ih244 {
+  padding-top: 12px;
+}
+.mt0ih245 {
+  padding-top: 16px;
+}
+.mt0ih246 {
+  padding-top: 20px;
+}
+.mt0ih247 {
+  padding-top: 24px;
+}
+.mt0ih248 {
+  padding-top: 28px;
+}
+.mt0ih249 {
+  padding-top: 32px;
+}
+.mt0ih24a {
+  padding-top: 40px;
+}
+.mt0ih24b {
+  padding-bottom: 0;
+}
+.mt0ih24c {
+  padding-bottom: 1px;
+}
+.mt0ih24d {
+  padding-bottom: 2px;
+}
+.mt0ih24e {
+  padding-bottom: 3px;
+}
+.mt0ih24f {
+  padding-bottom: 4px;
+}
+.mt0ih24g {
+  padding-bottom: 6px;
+}
+.mt0ih24h {
+  padding-bottom: 7px;
+}
+.mt0ih24i {
+  padding-bottom: 8px;
+}
+.mt0ih24j {
+  padding-bottom: 9px;
+}
+.mt0ih24k {
+  padding-bottom: 10px;
+}
+.mt0ih24l {
+  padding-bottom: 12px;
+}
+.mt0ih24m {
+  padding-bottom: 16px;
+}
+.mt0ih24n {
+  padding-bottom: 20px;
+}
+.mt0ih24o {
+  padding-bottom: 24px;
+}
+.mt0ih24p {
+  padding-bottom: 28px;
+}
+.mt0ih24q {
+  padding-bottom: 32px;
+}
+.mt0ih24r {
+  padding-bottom: 40px;
+}
+.mt0ih24s {
+  padding-left: 0;
+}
+.mt0ih24t {
+  padding-left: 1px;
+}
+.mt0ih24u {
+  padding-left: 2px;
+}
+.mt0ih24v {
+  padding-left: 3px;
+}
+.mt0ih24w {
+  padding-left: 4px;
+}
+.mt0ih24x {
+  padding-left: 6px;
+}
+.mt0ih24y {
+  padding-left: 7px;
+}
+.mt0ih24z {
+  padding-left: 8px;
+}
+.mt0ih250 {
+  padding-left: 9px;
+}
+.mt0ih251 {
+  padding-left: 10px;
+}
+.mt0ih252 {
+  padding-left: 12px;
+}
+.mt0ih253 {
+  padding-left: 16px;
+}
+.mt0ih254 {
+  padding-left: 20px;
+}
+.mt0ih255 {
+  padding-left: 24px;
+}
+.mt0ih256 {
+  padding-left: 28px;
+}
+.mt0ih257 {
+  padding-left: 32px;
+}
+.mt0ih258 {
+  padding-left: 40px;
+}
+.mt0ih259 {
+  padding-right: 0;
+}
+.mt0ih25a {
+  padding-right: 1px;
+}
+.mt0ih25b {
+  padding-right: 2px;
+}
+.mt0ih25c {
+  padding-right: 3px;
+}
+.mt0ih25d {
+  padding-right: 4px;
+}
+.mt0ih25e {
+  padding-right: 6px;
+}
+.mt0ih25f {
+  padding-right: 7px;
+}
+.mt0ih25g {
+  padding-right: 8px;
+}
+.mt0ih25h {
+  padding-right: 9px;
+}
+.mt0ih25i {
+  padding-right: 10px;
+}
+.mt0ih25j {
+  padding-right: 12px;
+}
+.mt0ih25k {
+  padding-right: 16px;
+}
+.mt0ih25l {
+  padding-right: 20px;
+}
+.mt0ih25m {
+  padding-right: 24px;
+}
+.mt0ih25n {
+  padding-right: 28px;
+}
+.mt0ih25o {
+  padding-right: 32px;
+}
+.mt0ih25p {
+  padding-right: 40px;
+}
+.mt0ih25q {
+  margin: 0;
+}
+.mt0ih25r {
+  margin: 1px;
+}
+.mt0ih25s {
+  margin: 2px;
+}
+.mt0ih25t {
+  margin: 3px;
+}
+.mt0ih25u {
+  margin: 4px;
+}
+.mt0ih25v {
+  margin: 6px;
+}
+.mt0ih25w {
+  margin: 7px;
+}
+.mt0ih25x {
+  margin: 8px;
+}
+.mt0ih25y {
+  margin: 9px;
+}
+.mt0ih25z {
+  margin: 10px;
+}
+.mt0ih260 {
+  margin: 12px;
+}
+.mt0ih261 {
+  margin: 16px;
+}
+.mt0ih262 {
+  margin: 20px;
+}
+.mt0ih263 {
+  margin: 24px;
+}
+.mt0ih264 {
+  margin: 28px;
+}
+.mt0ih265 {
+  margin: 32px;
+}
+.mt0ih266 {
+  margin: 40px;
+}
+.mt0ih267 {
+  margin: auto;
+}
+.mt0ih268 {
+  margin-top: 0;
+}
+.mt0ih269 {
+  margin-top: 1px;
+}
+.mt0ih26a {
+  margin-top: 2px;
+}
+.mt0ih26b {
+  margin-top: 3px;
+}
+.mt0ih26c {
+  margin-top: 4px;
+}
+.mt0ih26d {
+  margin-top: 6px;
+}
+.mt0ih26e {
+  margin-top: 7px;
+}
+.mt0ih26f {
+  margin-top: 8px;
+}
+.mt0ih26g {
+  margin-top: 9px;
+}
+.mt0ih26h {
+  margin-top: 10px;
+}
+.mt0ih26i {
+  margin-top: 12px;
+}
+.mt0ih26j {
+  margin-top: 16px;
+}
+.mt0ih26k {
+  margin-top: 20px;
+}
+.mt0ih26l {
+  margin-top: 24px;
+}
+.mt0ih26m {
+  margin-top: 28px;
+}
+.mt0ih26n {
+  margin-top: 32px;
+}
+.mt0ih26o {
+  margin-top: 40px;
+}
+.mt0ih26p {
+  margin-top: auto;
+}
+.mt0ih26q {
+  margin-bottom: 0;
+}
+.mt0ih26r {
+  margin-bottom: 1px;
+}
+.mt0ih26s {
+  margin-bottom: 2px;
+}
+.mt0ih26t {
+  margin-bottom: 3px;
+}
+.mt0ih26u {
+  margin-bottom: 4px;
+}
+.mt0ih26v {
+  margin-bottom: 6px;
+}
+.mt0ih26w {
+  margin-bottom: 7px;
+}
+.mt0ih26x {
+  margin-bottom: 8px;
+}
+.mt0ih26y {
+  margin-bottom: 9px;
+}
+.mt0ih26z {
+  margin-bottom: 10px;
+}
+.mt0ih270 {
+  margin-bottom: 12px;
+}
+.mt0ih271 {
+  margin-bottom: 16px;
+}
+.mt0ih272 {
+  margin-bottom: 20px;
+}
+.mt0ih273 {
+  margin-bottom: 24px;
+}
+.mt0ih274 {
+  margin-bottom: 28px;
+}
+.mt0ih275 {
+  margin-bottom: 32px;
+}
+.mt0ih276 {
+  margin-bottom: 40px;
+}
+.mt0ih277 {
+  margin-bottom: auto;
+}
+.mt0ih278 {
+  margin-left: 0;
+}
+.mt0ih279 {
+  margin-left: 1px;
+}
+.mt0ih27a {
+  margin-left: 2px;
+}
+.mt0ih27b {
+  margin-left: 3px;
+}
+.mt0ih27c {
+  margin-left: 4px;
+}
+.mt0ih27d {
+  margin-left: 6px;
+}
+.mt0ih27e {
+  margin-left: 7px;
+}
+.mt0ih27f {
+  margin-left: 8px;
+}
+.mt0ih27g {
+  margin-left: 9px;
+}
+.mt0ih27h {
+  margin-left: 10px;
+}
+.mt0ih27i {
+  margin-left: 12px;
+}
+.mt0ih27j {
+  margin-left: 16px;
+}
+.mt0ih27k {
+  margin-left: 20px;
+}
+.mt0ih27l {
+  margin-left: 24px;
+}
+.mt0ih27m {
+  margin-left: 28px;
+}
+.mt0ih27n {
+  margin-left: 32px;
+}
+.mt0ih27o {
+  margin-left: 40px;
+}
+.mt0ih27p {
+  margin-left: auto;
+}
+.mt0ih27q {
+  margin-right: 0;
+}
+.mt0ih27r {
+  margin-right: 1px;
+}
+.mt0ih27s {
+  margin-right: 2px;
+}
+.mt0ih27t {
+  margin-right: 3px;
+}
+.mt0ih27u {
+  margin-right: 4px;
+}
+.mt0ih27v {
+  margin-right: 6px;
+}
+.mt0ih27w {
+  margin-right: 7px;
+}
+.mt0ih27x {
+  margin-right: 8px;
+}
+.mt0ih27y {
+  margin-right: 9px;
+}
+.mt0ih27z {
+  margin-right: 10px;
+}
+.mt0ih280 {
+  margin-right: 12px;
+}
+.mt0ih281 {
+  margin-right: 16px;
+}
+.mt0ih282 {
+  margin-right: 20px;
+}
+.mt0ih283 {
+  margin-right: 24px;
+}
+.mt0ih284 {
+  margin-right: 28px;
+}
+.mt0ih285 {
+  margin-right: 32px;
+}
+.mt0ih286 {
+  margin-right: 40px;
+}
+.mt0ih287 {
+  margin-right: auto;
+}
+.mt0ih288 {
+  height: 100%;
+}
+.mt0ih289 {
+  height: 100vh;
+}
+.mt0ih28a {
+  width: 100%;
+}
+.mt0ih28b {
+  width: 100vw;
+}
+.mt0ih28c {
+  max-height: 100%;
+}
+.mt0ih28d {
+  max-height: 100vh;
+}
+.mt0ih28e {
+  max-width: 100%;
+}
+.mt0ih28f {
+  max-width: 100vw;
+}
+.mt0ih28g {
+  min-height: 100%;
+}
+.mt0ih28h {
+  min-height: 100vh;
+}
+.mt0ih28i {
+  min-width: 100%;
+}
+.mt0ih28j {
+  min-width: 100vw;
+}
+.mt0ih28k {
+  overflow: auto;
+}
+.mt0ih28l {
+  overflow: hidden;
+}
+.mt0ih28m {
+  overflow: visible;
+}
+.mt0ih28n {
+  overflow: scroll;
+}
+.mt0ih28o {
+  overflow-x: auto;
+}
+.mt0ih28p {
+  overflow-x: hidden;
+}
+.mt0ih28q {
+  overflow-x: visible;
+}
+.mt0ih28r {
+  overflow-x: scroll;
+}
+.mt0ih28s {
+  overflow-y: auto;
+}
+.mt0ih28t {
+  overflow-y: hidden;
+}
+.mt0ih28u {
+  overflow-y: visible;
+}
+.mt0ih28v {
+  overflow-y: scroll;
+}
+.mt0ih28w {
+  overflow-wrap: normal;
+}
+.mt0ih28x {
+  overflow-wrap: break-word;
+}
+.mt0ih28y {
+  text-transform: none;
+}
+.mt0ih28z {
+  text-transform: capitalize;
+}
+.mt0ih290 {
+  text-transform: uppercase;
+}
+.mt0ih291 {
+  text-transform: lowercase;
+}
+.mt0ih292 {
+  text-transform: full-width;
+}
+.mt0ih293 {
+  text-transform: full-size-kana;
+}
+.mt0ih294 {
+  user-select: all;
+}
+.mt0ih295 {
+  user-select: auto;
+}
+.mt0ih296 {
+  user-select: none;
+}
+.mt0ih297 {
+  visibility: hidden;
+}
+.mt0ih298 {
+  visibility: visible;
+}
+.mt0ih299 {
+  white-space: normal;
+}
+.mt0ih29a {
+  white-space: nowrap;
+}
+.mt0ih29b {
+  background-color: inherit;
+}
+.mt0ih29c:hover {
+  background-color: inherit;
+}
+.mt0ih29d {
+  background-color: #ffffff;
+}
+.mt0ih29e:hover {
+  background-color: #ffffff;
+}
+.mt0ih29f {
+  background-color: #000000;
+}
+.mt0ih29g:hover {
+  background-color: #000000;
+}
+.mt0ih29h {
+  background-color: #fdfcfd;
+}
+.mt0ih29i:hover {
+  background-color: #fdfcfd;
+}
+.mt0ih29j {
+  background-color: #f9f8f9;
+}
+.mt0ih29k:hover {
+  background-color: #f9f8f9;
+}
+.mt0ih29l {
+  background-color: #f4f2f4;
+}
+.mt0ih29m:hover {
+  background-color: #f4f2f4;
+}
+.mt0ih29n {
+  background-color: #eeedef;
+}
+.mt0ih29o:hover {
+  background-color: #eeedef;
+}
+.mt0ih29p {
+  background-color: #e9e8ea;
+}
+.mt0ih29q:hover {
+  background-color: #e9e8ea;
+}
+.mt0ih29r {
+  background-color: #e4e2e4;
+}
+.mt0ih29s:hover {
+  background-color: #e4e2e4;
+}
+.mt0ih29t {
+  background-color: #dcdbdd;
+}
+.mt0ih29u:hover {
+  background-color: #dcdbdd;
+}
+.mt0ih29v {
+  background-color: #c8c7cb;
+}
+.mt0ih29w:hover {
+  background-color: #c8c7cb;
+}
+.mt0ih29x {
+  background-color: #908e96;
+}
+.mt0ih29y:hover {
+  background-color: #908e96;
+}
+.mt0ih29z {
+  background-color: #86848d;
+}
+.mt0ih2a0:hover {
+  background-color: #86848d;
+}
+.mt0ih2a1 {
+  background-color: #6f6e77;
+}
+.mt0ih2a2:hover {
+  background-color: #6f6e77;
+}
+.mt0ih2a3 {
+  background-color: #1a1523;
+}
+.mt0ih2a4:hover {
+  background-color: #1a1523;
+}
+.mt0ih2a5 {
+  background-color: #fcfbfe;
+}
+.mt0ih2a6:hover {
+  background-color: #fcfbfe;
+}
+.mt0ih2a7 {
+  background-color: #f8f5ff;
+}
+.mt0ih2a8:hover {
+  background-color: #f8f5ff;
+}
+.mt0ih2a9 {
+  background-color: #f4f0ff;
+}
+.mt0ih2aa:hover {
+  background-color: #f4f0ff;
+}
+.mt0ih2ab {
+  background-color: #ede7fe;
+}
+.mt0ih2ac:hover {
+  background-color: #ede7fe;
+}
+.mt0ih2ad {
+  background-color: #e7defc;
+}
+.mt0ih2ae:hover {
+  background-color: #e7defc;
+}
+.mt0ih2af {
+  background-color: #d9cdf9;
+}
+.mt0ih2ag:hover {
+  background-color: #d9cdf9;
+}
+.mt0ih2ah {
+  background-color: #c9b9f3;
+}
+.mt0ih2ai:hover {
+  background-color: #c9b9f3;
+}
+.mt0ih2aj {
+  background-color: #af98ec;
+}
+.mt0ih2ak:hover {
+  background-color: #af98ec;
+}
+.mt0ih2al {
+  background-color: #744ed4;
+}
+.mt0ih2am:hover {
+  background-color: #744ed4;
+}
+.mt0ih2an {
+  background-color: #6b48c7;
+}
+.mt0ih2ao:hover {
+  background-color: #6b48c7;
+}
+.mt0ih2ap {
+  background-color: #6346af;
+}
+.mt0ih2aq:hover {
+  background-color: #6346af;
+}
+.mt0ih2ar {
+  background-color: #20104d;
+}
+.mt0ih2as:hover {
+  background-color: #20104d;
+}
+.mt0ih2at {
+  background-color: #fffcfc;
+}
+.mt0ih2au:hover {
+  background-color: #fffcfc;
+}
+.mt0ih2av {
+  background-color: #fff8f8;
+}
+.mt0ih2aw:hover {
+  background-color: #fff8f8;
+}
+.mt0ih2ax {
+  background-color: #ffefef;
+}
+.mt0ih2ay:hover {
+  background-color: #ffefef;
+}
+.mt0ih2az {
+  background-color: #ffe5e5;
+}
+.mt0ih2b0:hover {
+  background-color: #ffe5e5;
+}
+.mt0ih2b1 {
+  background-color: #fdd8d8;
+}
+.mt0ih2b2:hover {
+  background-color: #fdd8d8;
+}
+.mt0ih2b3 {
+  background-color: #f9c6c6;
+}
+.mt0ih2b4:hover {
+  background-color: #f9c6c6;
+}
+.mt0ih2b5 {
+  background-color: #f3aeaf;
+}
+.mt0ih2b6:hover {
+  background-color: #f3aeaf;
+}
+.mt0ih2b7 {
+  background-color: #eb9091;
+}
+.mt0ih2b8:hover {
+  background-color: #eb9091;
+}
+.mt0ih2b9 {
+  background-color: #e5484d;
+}
+.mt0ih2ba:hover {
+  background-color: #e5484d;
+}
+.mt0ih2bb {
+  background-color: #dc3d43;
+}
+.mt0ih2bc:hover {
+  background-color: #dc3d43;
+}
+.mt0ih2bd {
+  background-color: #cd2b31;
+}
+.mt0ih2be:hover {
+  background-color: #cd2b31;
+}
+.mt0ih2bf {
+  background-color: #381316;
+}
+.mt0ih2bg:hover {
+  background-color: #381316;
+}
+.mt0ih2bh {
+  background-color: #fbfefc;
+}
+.mt0ih2bi:hover {
+  background-color: #fbfefc;
+}
+.mt0ih2bj {
+  background-color: #f2fcf5;
+}
+.mt0ih2bk:hover {
+  background-color: #f2fcf5;
+}
+.mt0ih2bl {
+  background-color: #e9f9ee;
+}
+.mt0ih2bm:hover {
+  background-color: #e9f9ee;
+}
+.mt0ih2bn {
+  background-color: #ddf3e4;
+}
+.mt0ih2bo:hover {
+  background-color: #ddf3e4;
+}
+.mt0ih2bp {
+  background-color: #ccebd7;
+}
+.mt0ih2bq:hover {
+  background-color: #ccebd7;
+}
+.mt0ih2br {
+  background-color: #b4dfc4;
+}
+.mt0ih2bs:hover {
+  background-color: #b4dfc4;
+}
+.mt0ih2bt {
+  background-color: #92ceac;
+}
+.mt0ih2bu:hover {
+  background-color: #92ceac;
+}
+.mt0ih2bv {
+  background-color: #5bb98c;
+}
+.mt0ih2bw:hover {
+  background-color: #5bb98c;
+}
+.mt0ih2bx {
+  background-color: #30a46c;
+}
+.mt0ih2by:hover {
+  background-color: #30a46c;
+}
+.mt0ih2bz {
+  background-color: #299764;
+}
+.mt0ih2c0:hover {
+  background-color: #299764;
+}
+.mt0ih2c1 {
+  background-color: #18794e;
+}
+.mt0ih2c2:hover {
+  background-color: #18794e;
+}
+.mt0ih2c3 {
+  background-color: #153226;
+}
+.mt0ih2c4:hover {
+  background-color: #153226;
+}
+.mt0ih2c5 {
+  background-color: #fefdfb;
+}
+.mt0ih2c6:hover {
+  background-color: #fefdfb;
+}
+.mt0ih2c7 {
+  background-color: #fff9ed;
+}
+.mt0ih2c8:hover {
+  background-color: #fff9ed;
+}
+.mt0ih2c9 {
+  background-color: #fff4d5;
+}
+.mt0ih2ca:hover {
+  background-color: #fff4d5;
+}
+.mt0ih2cb {
+  background-color: #ffecbc;
+}
+.mt0ih2cc:hover {
+  background-color: #ffecbc;
+}
+.mt0ih2cd {
+  background-color: #ffe3a2;
+}
+.mt0ih2ce:hover {
+  background-color: #ffe3a2;
+}
+.mt0ih2cf {
+  background-color: #ffd386;
+}
+.mt0ih2cg:hover {
+  background-color: #ffd386;
+}
+.mt0ih2ch {
+  background-color: #f3ba63;
+}
+.mt0ih2ci:hover {
+  background-color: #f3ba63;
+}
+.mt0ih2cj {
+  background-color: #ee9d2b;
+}
+.mt0ih2ck:hover {
+  background-color: #ee9d2b;
+}
+.mt0ih2cl {
+  background-color: #ffb224;
+}
+.mt0ih2cm:hover {
+  background-color: #ffb224;
+}
+.mt0ih2cn {
+  background-color: #ffa01c;
+}
+.mt0ih2co:hover {
+  background-color: #ffa01c;
+}
+.mt0ih2cp {
+  background-color: #ad5700;
+}
+.mt0ih2cq:hover {
+  background-color: #ad5700;
+}
+.mt0ih2cr {
+  background-color: #4e2009;
+}
+.mt0ih2cs:hover {
+  background-color: #4e2009;
+}
+.mt0ih2ct {
+  background-color: #d6f0ff;
+}
+.mt0ih2cu:hover {
+  background-color: #d6f0ff;
+}
+.mt0ih2cv {
+  background-color: #96d5f8;
+}
+.mt0ih2cw:hover {
+  background-color: #96d5f8;
+}
+.mt0ih2cx {
+  background-color: #4fb5ee;
+}
+.mt0ih2cy:hover {
+  background-color: #4fb5ee;
+}
+.mt0ih2cz {
+  background-color: #0b75aa;
+}
+.mt0ih2d0:hover {
+  background-color: #0b75aa;
+}
+.mt0ih2d1 {
+  background-color: #ebff5e;
+}
+.mt0ih2d2:hover {
+  background-color: #ebff5e;
+}
+.mt0ih2d3 {
+  background-color: #8dc31a;
+}
+.mt0ih2d4:hover {
+  background-color: #8dc31a;
+}
+.mt0ih2d5 {
+  background-color: #ff5377;
+}
+.mt0ih2d6:hover {
+  background-color: #ff5377;
+}
+.mt0ih2d7 {
+  background-color: #ff9457;
+}
+.mt0ih2d8:hover {
+  background-color: #ff9457;
+}
+.mt0ih2d9 {
+  background-color: #36e79b;
+}
+.mt0ih2da:hover {
+  background-color: #36e79b;
+}
+.mt0ih2db {
+  background-color: var(--_1pyqka90);
+}
+.mt0ih2dc:hover {
+  background-color: var(--_1pyqka90);
+}
+.mt0ih2dd {
+  background-color: var(--_1pyqka91);
+}
+.mt0ih2de:hover {
+  background-color: var(--_1pyqka91);
+}
+.mt0ih2df {
+  background-color: var(--_1pyqka92);
+}
+.mt0ih2dg:hover {
+  background-color: var(--_1pyqka92);
+}
+.mt0ih2dh {
+  background-color: var(--_1pyqka93);
+}
+.mt0ih2di:hover {
+  background-color: var(--_1pyqka93);
+}
+.mt0ih2dj {
+  background-color: var(--_1pyqka94);
+}
+.mt0ih2dk:hover {
+  background-color: var(--_1pyqka94);
+}
+.mt0ih2dl {
+  background-color: var(--_1pyqka95);
+}
+.mt0ih2dm:hover {
+  background-color: var(--_1pyqka95);
+}
+.mt0ih2dn {
+  background-color: var(--_1pyqka98);
+}
+.mt0ih2do:hover {
+  background-color: var(--_1pyqka98);
+}
+.mt0ih2dp {
+  background-color: var(--_1pyqka96);
+}
+.mt0ih2dq:hover {
+  background-color: var(--_1pyqka96);
+}
+.mt0ih2dr {
+  background-color: var(--_1pyqka9c);
+}
+.mt0ih2ds:hover {
+  background-color: var(--_1pyqka9c);
+}
+.mt0ih2dt {
+  background-color: var(--_1pyqka9a);
+}
+.mt0ih2du:hover {
+  background-color: var(--_1pyqka9a);
+}
+.mt0ih2dv {
+  background-color: var(--_1pyqka9g);
+}
+.mt0ih2dw:hover {
+  background-color: var(--_1pyqka9g);
+}
+.mt0ih2dx {
+  background-color: var(--_1pyqka9e);
+}
+.mt0ih2dy:hover {
+  background-color: var(--_1pyqka9e);
+}
+.mt0ih2dz {
+  background-color: var(--_1pyqka9f);
+}
+.mt0ih2e0:hover {
+  background-color: var(--_1pyqka9f);
+}
+.mt0ih2e1 {
+  background-color: var(--_1pyqka9h);
+}
+.mt0ih2e2:hover {
+  background-color: var(--_1pyqka9h);
+}
+.mt0ih2e3 {
+  background-color: var(--_1pyqka9d);
+}
+.mt0ih2e4:hover {
+  background-color: var(--_1pyqka9d);
+}
+.mt0ih2e5 {
+  background-color: var(--_1pyqka91z);
+}
+.mt0ih2e6:hover {
+  background-color: var(--_1pyqka91z);
+}
+.mt0ih2e7 {
+  background-color: var(--_1pyqka91w);
+}
+.mt0ih2e8:hover {
+  background-color: var(--_1pyqka91w);
+}
+.mt0ih2e9 {
+  background-color: var(--_1pyqka91x);
+}
+.mt0ih2ea:hover {
+  background-color: var(--_1pyqka91x);
+}
+.mt0ih2eb {
+  background-color: var(--_1pyqka91y);
+}
+.mt0ih2ec:hover {
+  background-color: var(--_1pyqka91y);
+}
+.mt0ih2ed {
+  background-color: var(--_1pyqka920);
+}
+.mt0ih2ee:hover {
+  background-color: var(--_1pyqka920);
+}
+.mt0ih2ef {
+  background-color: var(--_1pyqka921);
+}
+.mt0ih2eg:hover {
+  background-color: var(--_1pyqka921);
+}
+.mt0ih2eh {
+  background-color: var(--_1pyqka91v);
+}
+.mt0ih2ei:hover {
+  background-color: var(--_1pyqka91v);
+}
+.mt0ih2ej {
+  background-color: var(--_1pyqka91s);
+}
+.mt0ih2ek:hover {
+  background-color: var(--_1pyqka91s);
+}
+.mt0ih2el {
+  background-color: var(--_1pyqka91t);
+}
+.mt0ih2em:hover {
+  background-color: var(--_1pyqka91t);
+}
+.mt0ih2en {
+  background-color: var(--_1pyqka91u);
+}
+.mt0ih2eo:hover {
+  background-color: var(--_1pyqka91u);
+}
+.mt0ih2ep {
+  border: 0;
+}
+.mt0ih2eq:hover {
+  border: 0;
+}
+.mt0ih2er {
+  border: var(--_1pyqka91k) solid 1px;
+}
+.mt0ih2es:hover {
+  border: var(--_1pyqka91k) solid 1px;
+}
+.mt0ih2et {
+  border: var(--_1pyqka91l) solid 1px;
+}
+.mt0ih2eu:hover {
+  border: var(--_1pyqka91l) solid 1px;
+}
+.mt0ih2ev {
+  border: var(--_1pyqka91m) solid 1px;
+}
+.mt0ih2ew:hover {
+  border: var(--_1pyqka91m) solid 1px;
+}
+.mt0ih2ex {
+  border: var(--_1pyqka91n) solid 1px;
+}
+.mt0ih2ey:hover {
+  border: var(--_1pyqka91n) solid 1px;
+}
+.mt0ih2ez {
+  border: var(--_1pyqka91o) solid 1px;
+}
+.mt0ih2f0:hover {
+  border: var(--_1pyqka91o) solid 1px;
+}
+.mt0ih2f1 {
+  border: var(--_1pyqka9z) solid 1px;
+}
+.mt0ih2f2:hover {
+  border: var(--_1pyqka9z) solid 1px;
+}
+.mt0ih2f3 {
+  border: var(--_1pyqka91p) solid 1px;
+}
+.mt0ih2f4:hover {
+  border: var(--_1pyqka91p) solid 1px;
+}
+.mt0ih2f5 {
+  border: var(--_1pyqka91q) solid 1px;
+}
+.mt0ih2f6:hover {
+  border: var(--_1pyqka91q) solid 1px;
+}
+.mt0ih2f7 {
+  border: var(--_1pyqka91r) solid 1px;
+}
+.mt0ih2f8:hover {
+  border: var(--_1pyqka91r) solid 1px;
+}
+.mt0ih2f9 {
+  border: var(--_1pyqka9j) solid 1px;
+}
+.mt0ih2fa:hover {
+  border: var(--_1pyqka9j) solid 1px;
+}
+.mt0ih2fb {
+  border: var(--_1pyqka9k) solid 1px;
+}
+.mt0ih2fc:hover {
+  border: var(--_1pyqka9k) solid 1px;
+}
+.mt0ih2fd {
+  border: var(--_1pyqka9i) solid 1px;
+}
+.mt0ih2fe:hover {
+  border: var(--_1pyqka9i) solid 1px;
+}
+.mt0ih2ff {
+  border-top: 0;
+}
+.mt0ih2fg:hover {
+  border-top: 0;
+}
+.mt0ih2fh {
+  border-top: var(--_1pyqka91k) solid 1px;
+}
+.mt0ih2fi:hover {
+  border-top: var(--_1pyqka91k) solid 1px;
+}
+.mt0ih2fj {
+  border-top: var(--_1pyqka91l) solid 1px;
+}
+.mt0ih2fk:hover {
+  border-top: var(--_1pyqka91l) solid 1px;
+}
+.mt0ih2fl {
+  border-top: var(--_1pyqka91m) solid 1px;
+}
+.mt0ih2fm:hover {
+  border-top: var(--_1pyqka91m) solid 1px;
+}
+.mt0ih2fn {
+  border-top: var(--_1pyqka91n) solid 1px;
+}
+.mt0ih2fo:hover {
+  border-top: var(--_1pyqka91n) solid 1px;
+}
+.mt0ih2fp {
+  border-top: var(--_1pyqka91o) solid 1px;
+}
+.mt0ih2fq:hover {
+  border-top: var(--_1pyqka91o) solid 1px;
+}
+.mt0ih2fr {
+  border-top: var(--_1pyqka9z) solid 1px;
+}
+.mt0ih2fs:hover {
+  border-top: var(--_1pyqka9z) solid 1px;
+}
+.mt0ih2ft {
+  border-top: var(--_1pyqka91p) solid 1px;
+}
+.mt0ih2fu:hover {
+  border-top: var(--_1pyqka91p) solid 1px;
+}
+.mt0ih2fv {
+  border-top: var(--_1pyqka91q) solid 1px;
+}
+.mt0ih2fw:hover {
+  border-top: var(--_1pyqka91q) solid 1px;
+}
+.mt0ih2fx {
+  border-top: var(--_1pyqka91r) solid 1px;
+}
+.mt0ih2fy:hover {
+  border-top: var(--_1pyqka91r) solid 1px;
+}
+.mt0ih2fz {
+  border-top: var(--_1pyqka9j) solid 1px;
+}
+.mt0ih2g0:hover {
+  border-top: var(--_1pyqka9j) solid 1px;
+}
+.mt0ih2g1 {
+  border-top: var(--_1pyqka9k) solid 1px;
+}
+.mt0ih2g2:hover {
+  border-top: var(--_1pyqka9k) solid 1px;
+}
+.mt0ih2g3 {
+  border-top: var(--_1pyqka9i) solid 1px;
+}
+.mt0ih2g4:hover {
+  border-top: var(--_1pyqka9i) solid 1px;
+}
+.mt0ih2g5 {
+  border-right: 0;
+}
+.mt0ih2g6:hover {
+  border-right: 0;
+}
+.mt0ih2g7 {
+  border-right: var(--_1pyqka91k) solid 1px;
+}
+.mt0ih2g8:hover {
+  border-right: var(--_1pyqka91k) solid 1px;
+}
+.mt0ih2g9 {
+  border-right: var(--_1pyqka91l) solid 1px;
+}
+.mt0ih2ga:hover {
+  border-right: var(--_1pyqka91l) solid 1px;
+}
+.mt0ih2gb {
+  border-right: var(--_1pyqka91m) solid 1px;
+}
+.mt0ih2gc:hover {
+  border-right: var(--_1pyqka91m) solid 1px;
+}
+.mt0ih2gd {
+  border-right: var(--_1pyqka91n) solid 1px;
+}
+.mt0ih2ge:hover {
+  border-right: var(--_1pyqka91n) solid 1px;
+}
+.mt0ih2gf {
+  border-right: var(--_1pyqka91o) solid 1px;
+}
+.mt0ih2gg:hover {
+  border-right: var(--_1pyqka91o) solid 1px;
+}
+.mt0ih2gh {
+  border-right: var(--_1pyqka9z) solid 1px;
+}
+.mt0ih2gi:hover {
+  border-right: var(--_1pyqka9z) solid 1px;
+}
+.mt0ih2gj {
+  border-right: var(--_1pyqka91p) solid 1px;
+}
+.mt0ih2gk:hover {
+  border-right: var(--_1pyqka91p) solid 1px;
+}
+.mt0ih2gl {
+  border-right: var(--_1pyqka91q) solid 1px;
+}
+.mt0ih2gm:hover {
+  border-right: var(--_1pyqka91q) solid 1px;
+}
+.mt0ih2gn {
+  border-right: var(--_1pyqka91r) solid 1px;
+}
+.mt0ih2go:hover {
+  border-right: var(--_1pyqka91r) solid 1px;
+}
+.mt0ih2gp {
+  border-right: var(--_1pyqka9j) solid 1px;
+}
+.mt0ih2gq:hover {
+  border-right: var(--_1pyqka9j) solid 1px;
+}
+.mt0ih2gr {
+  border-right: var(--_1pyqka9k) solid 1px;
+}
+.mt0ih2gs:hover {
+  border-right: var(--_1pyqka9k) solid 1px;
+}
+.mt0ih2gt {
+  border-right: var(--_1pyqka9i) solid 1px;
+}
+.mt0ih2gu:hover {
+  border-right: var(--_1pyqka9i) solid 1px;
+}
+.mt0ih2gv {
+  border-bottom: 0;
+}
+.mt0ih2gw:hover {
+  border-bottom: 0;
+}
+.mt0ih2gx {
+  border-bottom: var(--_1pyqka91k) solid 1px;
+}
+.mt0ih2gy:hover {
+  border-bottom: var(--_1pyqka91k) solid 1px;
+}
+.mt0ih2gz {
+  border-bottom: var(--_1pyqka91l) solid 1px;
+}
+.mt0ih2h0:hover {
+  border-bottom: var(--_1pyqka91l) solid 1px;
+}
+.mt0ih2h1 {
+  border-bottom: var(--_1pyqka91m) solid 1px;
+}
+.mt0ih2h2:hover {
+  border-bottom: var(--_1pyqka91m) solid 1px;
+}
+.mt0ih2h3 {
+  border-bottom: var(--_1pyqka91n) solid 1px;
+}
+.mt0ih2h4:hover {
+  border-bottom: var(--_1pyqka91n) solid 1px;
+}
+.mt0ih2h5 {
+  border-bottom: var(--_1pyqka91o) solid 1px;
+}
+.mt0ih2h6:hover {
+  border-bottom: var(--_1pyqka91o) solid 1px;
+}
+.mt0ih2h7 {
+  border-bottom: var(--_1pyqka9z) solid 1px;
+}
+.mt0ih2h8:hover {
+  border-bottom: var(--_1pyqka9z) solid 1px;
+}
+.mt0ih2h9 {
+  border-bottom: var(--_1pyqka91p) solid 1px;
+}
+.mt0ih2ha:hover {
+  border-bottom: var(--_1pyqka91p) solid 1px;
+}
+.mt0ih2hb {
+  border-bottom: var(--_1pyqka91q) solid 1px;
+}
+.mt0ih2hc:hover {
+  border-bottom: var(--_1pyqka91q) solid 1px;
+}
+.mt0ih2hd {
+  border-bottom: var(--_1pyqka91r) solid 1px;
+}
+.mt0ih2he:hover {
+  border-bottom: var(--_1pyqka91r) solid 1px;
+}
+.mt0ih2hf {
+  border-bottom: var(--_1pyqka9j) solid 1px;
+}
+.mt0ih2hg:hover {
+  border-bottom: var(--_1pyqka9j) solid 1px;
+}
+.mt0ih2hh {
+  border-bottom: var(--_1pyqka9k) solid 1px;
+}
+.mt0ih2hi:hover {
+  border-bottom: var(--_1pyqka9k) solid 1px;
+}
+.mt0ih2hj {
+  border-bottom: var(--_1pyqka9i) solid 1px;
+}
+.mt0ih2hk:hover {
+  border-bottom: var(--_1pyqka9i) solid 1px;
+}
+.mt0ih2hl {
+  border-left: 0;
+}
+.mt0ih2hm:hover {
+  border-left: 0;
+}
+.mt0ih2hn {
+  border-left: var(--_1pyqka91k) solid 1px;
+}
+.mt0ih2ho:hover {
+  border-left: var(--_1pyqka91k) solid 1px;
+}
+.mt0ih2hp {
+  border-left: var(--_1pyqka91l) solid 1px;
+}
+.mt0ih2hq:hover {
+  border-left: var(--_1pyqka91l) solid 1px;
+}
+.mt0ih2hr {
+  border-left: var(--_1pyqka91m) solid 1px;
+}
+.mt0ih2hs:hover {
+  border-left: var(--_1pyqka91m) solid 1px;
+}
+.mt0ih2ht {
+  border-left: var(--_1pyqka91n) solid 1px;
+}
+.mt0ih2hu:hover {
+  border-left: var(--_1pyqka91n) solid 1px;
+}
+.mt0ih2hv {
+  border-left: var(--_1pyqka91o) solid 1px;
+}
+.mt0ih2hw:hover {
+  border-left: var(--_1pyqka91o) solid 1px;
+}
+.mt0ih2hx {
+  border-left: var(--_1pyqka9z) solid 1px;
+}
+.mt0ih2hy:hover {
+  border-left: var(--_1pyqka9z) solid 1px;
+}
+.mt0ih2hz {
+  border-left: var(--_1pyqka91p) solid 1px;
+}
+.mt0ih2i0:hover {
+  border-left: var(--_1pyqka91p) solid 1px;
+}
+.mt0ih2i1 {
+  border-left: var(--_1pyqka91q) solid 1px;
+}
+.mt0ih2i2:hover {
+  border-left: var(--_1pyqka91q) solid 1px;
+}
+.mt0ih2i3 {
+  border-left: var(--_1pyqka91r) solid 1px;
+}
+.mt0ih2i4:hover {
+  border-left: var(--_1pyqka91r) solid 1px;
+}
+.mt0ih2i5 {
+  border-left: var(--_1pyqka9j) solid 1px;
+}
+.mt0ih2i6:hover {
+  border-left: var(--_1pyqka9j) solid 1px;
+}
+.mt0ih2i7 {
+  border-left: var(--_1pyqka9k) solid 1px;
+}
+.mt0ih2i8:hover {
+  border-left: var(--_1pyqka9k) solid 1px;
+}
+.mt0ih2i9 {
+  border-left: var(--_1pyqka9i) solid 1px;
+}
+.mt0ih2ia:hover {
+  border-left: var(--_1pyqka9i) solid 1px;
+}
+.mt0ih2ib {
+  border-color: inherit;
+}
+.mt0ih2ic:hover {
+  border-color: inherit;
+}
+.mt0ih2id {
+  border-color: #ffffff;
+}
+.mt0ih2ie:hover {
+  border-color: #ffffff;
+}
+.mt0ih2if {
+  border-color: #000000;
+}
+.mt0ih2ig:hover {
+  border-color: #000000;
+}
+.mt0ih2ih {
+  border-color: #fdfcfd;
+}
+.mt0ih2ii:hover {
+  border-color: #fdfcfd;
+}
+.mt0ih2ij {
+  border-color: #f9f8f9;
+}
+.mt0ih2ik:hover {
+  border-color: #f9f8f9;
+}
+.mt0ih2il {
+  border-color: #f4f2f4;
+}
+.mt0ih2im:hover {
+  border-color: #f4f2f4;
+}
+.mt0ih2in {
+  border-color: #eeedef;
+}
+.mt0ih2io:hover {
+  border-color: #eeedef;
+}
+.mt0ih2ip {
+  border-color: #e9e8ea;
+}
+.mt0ih2iq:hover {
+  border-color: #e9e8ea;
+}
+.mt0ih2ir {
+  border-color: #e4e2e4;
+}
+.mt0ih2is:hover {
+  border-color: #e4e2e4;
+}
+.mt0ih2it {
+  border-color: #dcdbdd;
+}
+.mt0ih2iu:hover {
+  border-color: #dcdbdd;
+}
+.mt0ih2iv {
+  border-color: #c8c7cb;
+}
+.mt0ih2iw:hover {
+  border-color: #c8c7cb;
+}
+.mt0ih2ix {
+  border-color: #908e96;
+}
+.mt0ih2iy:hover {
+  border-color: #908e96;
+}
+.mt0ih2iz {
+  border-color: #86848d;
+}
+.mt0ih2j0:hover {
+  border-color: #86848d;
+}
+.mt0ih2j1 {
+  border-color: #6f6e77;
+}
+.mt0ih2j2:hover {
+  border-color: #6f6e77;
+}
+.mt0ih2j3 {
+  border-color: #1a1523;
+}
+.mt0ih2j4:hover {
+  border-color: #1a1523;
+}
+.mt0ih2j5 {
+  border-color: #fcfbfe;
+}
+.mt0ih2j6:hover {
+  border-color: #fcfbfe;
+}
+.mt0ih2j7 {
+  border-color: #f8f5ff;
+}
+.mt0ih2j8:hover {
+  border-color: #f8f5ff;
+}
+.mt0ih2j9 {
+  border-color: #f4f0ff;
+}
+.mt0ih2ja:hover {
+  border-color: #f4f0ff;
+}
+.mt0ih2jb {
+  border-color: #ede7fe;
+}
+.mt0ih2jc:hover {
+  border-color: #ede7fe;
+}
+.mt0ih2jd {
+  border-color: #e7defc;
+}
+.mt0ih2je:hover {
+  border-color: #e7defc;
+}
+.mt0ih2jf {
+  border-color: #d9cdf9;
+}
+.mt0ih2jg:hover {
+  border-color: #d9cdf9;
+}
+.mt0ih2jh {
+  border-color: #c9b9f3;
+}
+.mt0ih2ji:hover {
+  border-color: #c9b9f3;
+}
+.mt0ih2jj {
+  border-color: #af98ec;
+}
+.mt0ih2jk:hover {
+  border-color: #af98ec;
+}
+.mt0ih2jl {
+  border-color: #744ed4;
+}
+.mt0ih2jm:hover {
+  border-color: #744ed4;
+}
+.mt0ih2jn {
+  border-color: #6b48c7;
+}
+.mt0ih2jo:hover {
+  border-color: #6b48c7;
+}
+.mt0ih2jp {
+  border-color: #6346af;
+}
+.mt0ih2jq:hover {
+  border-color: #6346af;
+}
+.mt0ih2jr {
+  border-color: #20104d;
+}
+.mt0ih2js:hover {
+  border-color: #20104d;
+}
+.mt0ih2jt {
+  border-color: #fffcfc;
+}
+.mt0ih2ju:hover {
+  border-color: #fffcfc;
+}
+.mt0ih2jv {
+  border-color: #fff8f8;
+}
+.mt0ih2jw:hover {
+  border-color: #fff8f8;
+}
+.mt0ih2jx {
+  border-color: #ffefef;
+}
+.mt0ih2jy:hover {
+  border-color: #ffefef;
+}
+.mt0ih2jz {
+  border-color: #ffe5e5;
+}
+.mt0ih2k0:hover {
+  border-color: #ffe5e5;
+}
+.mt0ih2k1 {
+  border-color: #fdd8d8;
+}
+.mt0ih2k2:hover {
+  border-color: #fdd8d8;
+}
+.mt0ih2k3 {
+  border-color: #f9c6c6;
+}
+.mt0ih2k4:hover {
+  border-color: #f9c6c6;
+}
+.mt0ih2k5 {
+  border-color: #f3aeaf;
+}
+.mt0ih2k6:hover {
+  border-color: #f3aeaf;
+}
+.mt0ih2k7 {
+  border-color: #eb9091;
+}
+.mt0ih2k8:hover {
+  border-color: #eb9091;
+}
+.mt0ih2k9 {
+  border-color: #e5484d;
+}
+.mt0ih2ka:hover {
+  border-color: #e5484d;
+}
+.mt0ih2kb {
+  border-color: #dc3d43;
+}
+.mt0ih2kc:hover {
+  border-color: #dc3d43;
+}
+.mt0ih2kd {
+  border-color: #cd2b31;
+}
+.mt0ih2ke:hover {
+  border-color: #cd2b31;
+}
+.mt0ih2kf {
+  border-color: #381316;
+}
+.mt0ih2kg:hover {
+  border-color: #381316;
+}
+.mt0ih2kh {
+  border-color: #fbfefc;
+}
+.mt0ih2ki:hover {
+  border-color: #fbfefc;
+}
+.mt0ih2kj {
+  border-color: #f2fcf5;
+}
+.mt0ih2kk:hover {
+  border-color: #f2fcf5;
+}
+.mt0ih2kl {
+  border-color: #e9f9ee;
+}
+.mt0ih2km:hover {
+  border-color: #e9f9ee;
+}
+.mt0ih2kn {
+  border-color: #ddf3e4;
+}
+.mt0ih2ko:hover {
+  border-color: #ddf3e4;
+}
+.mt0ih2kp {
+  border-color: #ccebd7;
+}
+.mt0ih2kq:hover {
+  border-color: #ccebd7;
+}
+.mt0ih2kr {
+  border-color: #b4dfc4;
+}
+.mt0ih2ks:hover {
+  border-color: #b4dfc4;
+}
+.mt0ih2kt {
+  border-color: #92ceac;
+}
+.mt0ih2ku:hover {
+  border-color: #92ceac;
+}
+.mt0ih2kv {
+  border-color: #5bb98c;
+}
+.mt0ih2kw:hover {
+  border-color: #5bb98c;
+}
+.mt0ih2kx {
+  border-color: #30a46c;
+}
+.mt0ih2ky:hover {
+  border-color: #30a46c;
+}
+.mt0ih2kz {
+  border-color: #299764;
+}
+.mt0ih2l0:hover {
+  border-color: #299764;
+}
+.mt0ih2l1 {
+  border-color: #18794e;
+}
+.mt0ih2l2:hover {
+  border-color: #18794e;
+}
+.mt0ih2l3 {
+  border-color: #153226;
+}
+.mt0ih2l4:hover {
+  border-color: #153226;
+}
+.mt0ih2l5 {
+  border-color: #fefdfb;
+}
+.mt0ih2l6:hover {
+  border-color: #fefdfb;
+}
+.mt0ih2l7 {
+  border-color: #fff9ed;
+}
+.mt0ih2l8:hover {
+  border-color: #fff9ed;
+}
+.mt0ih2l9 {
+  border-color: #fff4d5;
+}
+.mt0ih2la:hover {
+  border-color: #fff4d5;
+}
+.mt0ih2lb {
+  border-color: #ffecbc;
+}
+.mt0ih2lc:hover {
+  border-color: #ffecbc;
+}
+.mt0ih2ld {
+  border-color: #ffe3a2;
+}
+.mt0ih2le:hover {
+  border-color: #ffe3a2;
+}
+.mt0ih2lf {
+  border-color: #ffd386;
+}
+.mt0ih2lg:hover {
+  border-color: #ffd386;
+}
+.mt0ih2lh {
+  border-color: #f3ba63;
+}
+.mt0ih2li:hover {
+  border-color: #f3ba63;
+}
+.mt0ih2lj {
+  border-color: #ee9d2b;
+}
+.mt0ih2lk:hover {
+  border-color: #ee9d2b;
+}
+.mt0ih2ll {
+  border-color: #ffb224;
+}
+.mt0ih2lm:hover {
+  border-color: #ffb224;
+}
+.mt0ih2ln {
+  border-color: #ffa01c;
+}
+.mt0ih2lo:hover {
+  border-color: #ffa01c;
+}
+.mt0ih2lp {
+  border-color: #ad5700;
+}
+.mt0ih2lq:hover {
+  border-color: #ad5700;
+}
+.mt0ih2lr {
+  border-color: #4e2009;
+}
+.mt0ih2ls:hover {
+  border-color: #4e2009;
+}
+.mt0ih2lt {
+  border-color: #d6f0ff;
+}
+.mt0ih2lu:hover {
+  border-color: #d6f0ff;
+}
+.mt0ih2lv {
+  border-color: #96d5f8;
+}
+.mt0ih2lw:hover {
+  border-color: #96d5f8;
+}
+.mt0ih2lx {
+  border-color: #4fb5ee;
+}
+.mt0ih2ly:hover {
+  border-color: #4fb5ee;
+}
+.mt0ih2lz {
+  border-color: #0b75aa;
+}
+.mt0ih2m0:hover {
+  border-color: #0b75aa;
+}
+.mt0ih2m1 {
+  border-color: #ebff5e;
+}
+.mt0ih2m2:hover {
+  border-color: #ebff5e;
+}
+.mt0ih2m3 {
+  border-color: #8dc31a;
+}
+.mt0ih2m4:hover {
+  border-color: #8dc31a;
+}
+.mt0ih2m5 {
+  border-color: #ff5377;
+}
+.mt0ih2m6:hover {
+  border-color: #ff5377;
+}
+.mt0ih2m7 {
+  border-color: #ff9457;
+}
+.mt0ih2m8:hover {
+  border-color: #ff9457;
+}
+.mt0ih2m9 {
+  border-color: #36e79b;
+}
+.mt0ih2ma:hover {
+  border-color: #36e79b;
+}
+.mt0ih2mb {
+  border-style: hidden;
+}
+.mt0ih2mc:hover {
+  border-style: hidden;
+}
+.mt0ih2md {
+  border-style: solid;
+}
+.mt0ih2me:hover {
+  border-style: solid;
+}
+.mt0ih2mf {
+  border-width: 1px;
+}
+.mt0ih2mg:hover {
+  border-width: 1px;
+}
+.mt0ih2mh {
+  border-width: 2px;
+}
+.mt0ih2mi:hover {
+  border-width: 2px;
+}
+.mt0ih2mj {
+  border-width: 4px;
+}
+.mt0ih2mk:hover {
+  border-width: 4px;
+}
+.mt0ih2ml {
+  box-shadow: 0 2px 8px -2px rgba(59, 59, 59, 0.08);
+}
+.mt0ih2mm:hover {
+  box-shadow: 0 2px 8px -2px rgba(59, 59, 59, 0.08);
+}
+.mt0ih2mn {
+  box-shadow: 0 6px 12px -2px rgba(59, 59, 59, 0.12);
+}
+.mt0ih2mo:hover {
+  box-shadow: 0 6px 12px -2px rgba(59, 59, 59, 0.12);
+}
+.mt0ih2mp {
+  box-shadow: 0 -1px 0 0 rgba(0, 0, 0, 0.32) inset;
+}
+.mt0ih2mq:hover {
+  box-shadow: 0 -1px 0 0 rgba(0, 0, 0, 0.32) inset;
+}
+.mt0ih2mr {
+  box-shadow: 0 -1px 0 0 rgba(0, 0, 0, 0.1) inset;
+}
+.mt0ih2ms:hover {
+  box-shadow: 0 -1px 0 0 rgba(0, 0, 0, 0.1) inset;
+}
+.mt0ih2mt {
+  color: inherit;
+}
+.mt0ih2mu:hover {
+  color: inherit;
+}
+.mt0ih2mv {
+  color: #ffffff;
+}
+.mt0ih2mw:hover {
+  color: #ffffff;
+}
+.mt0ih2mx {
+  color: #000000;
+}
+.mt0ih2my:hover {
+  color: #000000;
+}
+.mt0ih2mz {
+  color: #fdfcfd;
+}
+.mt0ih2n0:hover {
+  color: #fdfcfd;
+}
+.mt0ih2n1 {
+  color: #f9f8f9;
+}
+.mt0ih2n2:hover {
+  color: #f9f8f9;
+}
+.mt0ih2n3 {
+  color: #f4f2f4;
+}
+.mt0ih2n4:hover {
+  color: #f4f2f4;
+}
+.mt0ih2n5 {
+  color: #eeedef;
+}
+.mt0ih2n6:hover {
+  color: #eeedef;
+}
+.mt0ih2n7 {
+  color: #e9e8ea;
+}
+.mt0ih2n8:hover {
+  color: #e9e8ea;
+}
+.mt0ih2n9 {
+  color: #e4e2e4;
+}
+.mt0ih2na:hover {
+  color: #e4e2e4;
+}
+.mt0ih2nb {
+  color: #dcdbdd;
+}
+.mt0ih2nc:hover {
+  color: #dcdbdd;
+}
+.mt0ih2nd {
+  color: #c8c7cb;
+}
+.mt0ih2ne:hover {
+  color: #c8c7cb;
+}
+.mt0ih2nf {
+  color: #908e96;
+}
+.mt0ih2ng:hover {
+  color: #908e96;
+}
+.mt0ih2nh {
+  color: #86848d;
+}
+.mt0ih2ni:hover {
+  color: #86848d;
+}
+.mt0ih2nj {
+  color: #6f6e77;
+}
+.mt0ih2nk:hover {
+  color: #6f6e77;
+}
+.mt0ih2nl {
+  color: #1a1523;
+}
+.mt0ih2nm:hover {
+  color: #1a1523;
+}
+.mt0ih2nn {
+  color: #fcfbfe;
+}
+.mt0ih2no:hover {
+  color: #fcfbfe;
+}
+.mt0ih2np {
+  color: #f8f5ff;
+}
+.mt0ih2nq:hover {
+  color: #f8f5ff;
+}
+.mt0ih2nr {
+  color: #f4f0ff;
+}
+.mt0ih2ns:hover {
+  color: #f4f0ff;
+}
+.mt0ih2nt {
+  color: #ede7fe;
+}
+.mt0ih2nu:hover {
+  color: #ede7fe;
+}
+.mt0ih2nv {
+  color: #e7defc;
+}
+.mt0ih2nw:hover {
+  color: #e7defc;
+}
+.mt0ih2nx {
+  color: #d9cdf9;
+}
+.mt0ih2ny:hover {
+  color: #d9cdf9;
+}
+.mt0ih2nz {
+  color: #c9b9f3;
+}
+.mt0ih2o0:hover {
+  color: #c9b9f3;
+}
+.mt0ih2o1 {
+  color: #af98ec;
+}
+.mt0ih2o2:hover {
+  color: #af98ec;
+}
+.mt0ih2o3 {
+  color: #744ed4;
+}
+.mt0ih2o4:hover {
+  color: #744ed4;
+}
+.mt0ih2o5 {
+  color: #6b48c7;
+}
+.mt0ih2o6:hover {
+  color: #6b48c7;
+}
+.mt0ih2o7 {
+  color: #6346af;
+}
+.mt0ih2o8:hover {
+  color: #6346af;
+}
+.mt0ih2o9 {
+  color: #20104d;
+}
+.mt0ih2oa:hover {
+  color: #20104d;
+}
+.mt0ih2ob {
+  color: #fffcfc;
+}
+.mt0ih2oc:hover {
+  color: #fffcfc;
+}
+.mt0ih2od {
+  color: #fff8f8;
+}
+.mt0ih2oe:hover {
+  color: #fff8f8;
+}
+.mt0ih2of {
+  color: #ffefef;
+}
+.mt0ih2og:hover {
+  color: #ffefef;
+}
+.mt0ih2oh {
+  color: #ffe5e5;
+}
+.mt0ih2oi:hover {
+  color: #ffe5e5;
+}
+.mt0ih2oj {
+  color: #fdd8d8;
+}
+.mt0ih2ok:hover {
+  color: #fdd8d8;
+}
+.mt0ih2ol {
+  color: #f9c6c6;
+}
+.mt0ih2om:hover {
+  color: #f9c6c6;
+}
+.mt0ih2on {
+  color: #f3aeaf;
+}
+.mt0ih2oo:hover {
+  color: #f3aeaf;
+}
+.mt0ih2op {
+  color: #eb9091;
+}
+.mt0ih2oq:hover {
+  color: #eb9091;
+}
+.mt0ih2or {
+  color: #e5484d;
+}
+.mt0ih2os:hover {
+  color: #e5484d;
+}
+.mt0ih2ot {
+  color: #dc3d43;
+}
+.mt0ih2ou:hover {
+  color: #dc3d43;
+}
+.mt0ih2ov {
+  color: #cd2b31;
+}
+.mt0ih2ow:hover {
+  color: #cd2b31;
+}
+.mt0ih2ox {
+  color: #381316;
+}
+.mt0ih2oy:hover {
+  color: #381316;
+}
+.mt0ih2oz {
+  color: #fbfefc;
+}
+.mt0ih2p0:hover {
+  color: #fbfefc;
+}
+.mt0ih2p1 {
+  color: #f2fcf5;
+}
+.mt0ih2p2:hover {
+  color: #f2fcf5;
+}
+.mt0ih2p3 {
+  color: #e9f9ee;
+}
+.mt0ih2p4:hover {
+  color: #e9f9ee;
+}
+.mt0ih2p5 {
+  color: #ddf3e4;
+}
+.mt0ih2p6:hover {
+  color: #ddf3e4;
+}
+.mt0ih2p7 {
+  color: #ccebd7;
+}
+.mt0ih2p8:hover {
+  color: #ccebd7;
+}
+.mt0ih2p9 {
+  color: #b4dfc4;
+}
+.mt0ih2pa:hover {
+  color: #b4dfc4;
+}
+.mt0ih2pb {
+  color: #92ceac;
+}
+.mt0ih2pc:hover {
+  color: #92ceac;
+}
+.mt0ih2pd {
+  color: #5bb98c;
+}
+.mt0ih2pe:hover {
+  color: #5bb98c;
+}
+.mt0ih2pf {
+  color: #30a46c;
+}
+.mt0ih2pg:hover {
+  color: #30a46c;
+}
+.mt0ih2ph {
+  color: #299764;
+}
+.mt0ih2pi:hover {
+  color: #299764;
+}
+.mt0ih2pj {
+  color: #18794e;
+}
+.mt0ih2pk:hover {
+  color: #18794e;
+}
+.mt0ih2pl {
+  color: #153226;
+}
+.mt0ih2pm:hover {
+  color: #153226;
+}
+.mt0ih2pn {
+  color: #fefdfb;
+}
+.mt0ih2po:hover {
+  color: #fefdfb;
+}
+.mt0ih2pp {
+  color: #fff9ed;
+}
+.mt0ih2pq:hover {
+  color: #fff9ed;
+}
+.mt0ih2pr {
+  color: #fff4d5;
+}
+.mt0ih2ps:hover {
+  color: #fff4d5;
+}
+.mt0ih2pt {
+  color: #ffecbc;
+}
+.mt0ih2pu:hover {
+  color: #ffecbc;
+}
+.mt0ih2pv {
+  color: #ffe3a2;
+}
+.mt0ih2pw:hover {
+  color: #ffe3a2;
+}
+.mt0ih2px {
+  color: #ffd386;
+}
+.mt0ih2py:hover {
+  color: #ffd386;
+}
+.mt0ih2pz {
+  color: #f3ba63;
+}
+.mt0ih2q0:hover {
+  color: #f3ba63;
+}
+.mt0ih2q1 {
+  color: #ee9d2b;
+}
+.mt0ih2q2:hover {
+  color: #ee9d2b;
+}
+.mt0ih2q3 {
+  color: #ffb224;
+}
+.mt0ih2q4:hover {
+  color: #ffb224;
+}
+.mt0ih2q5 {
+  color: #ffa01c;
+}
+.mt0ih2q6:hover {
+  color: #ffa01c;
+}
+.mt0ih2q7 {
+  color: #ad5700;
+}
+.mt0ih2q8:hover {
+  color: #ad5700;
+}
+.mt0ih2q9 {
+  color: #4e2009;
+}
+.mt0ih2qa:hover {
+  color: #4e2009;
+}
+.mt0ih2qb {
+  color: #d6f0ff;
+}
+.mt0ih2qc:hover {
+  color: #d6f0ff;
+}
+.mt0ih2qd {
+  color: #96d5f8;
+}
+.mt0ih2qe:hover {
+  color: #96d5f8;
+}
+.mt0ih2qf {
+  color: #4fb5ee;
+}
+.mt0ih2qg:hover {
+  color: #4fb5ee;
+}
+.mt0ih2qh {
+  color: #0b75aa;
+}
+.mt0ih2qi:hover {
+  color: #0b75aa;
+}
+.mt0ih2qj {
+  color: #ebff5e;
+}
+.mt0ih2qk:hover {
+  color: #ebff5e;
+}
+.mt0ih2ql {
+  color: #8dc31a;
+}
+.mt0ih2qm:hover {
+  color: #8dc31a;
+}
+.mt0ih2qn {
+  color: #ff5377;
+}
+.mt0ih2qo:hover {
+  color: #ff5377;
+}
+.mt0ih2qp {
+  color: #ff9457;
+}
+.mt0ih2qq:hover {
+  color: #ff9457;
+}
+.mt0ih2qr {
+  color: #36e79b;
+}
+.mt0ih2qs:hover {
+  color: #36e79b;
+}
+.mt0ih2qt {
+  color: var(--_1pyqka9b);
+}
+.mt0ih2qu:hover {
+  color: var(--_1pyqka9b);
+}
+.mt0ih2qv {
+  color: var(--_1pyqka9c);
+}
+.mt0ih2qw:hover {
+  color: var(--_1pyqka9c);
+}
+.mt0ih2qx {
+  color: var(--_1pyqka9a);
+}
+.mt0ih2qy:hover {
+  color: var(--_1pyqka9a);
+}
+.mt0ih2qz {
+  color: var(--_1pyqka9g);
+}
+.mt0ih2r0:hover {
+  color: var(--_1pyqka9g);
+}
+.mt0ih2r1 {
+  color: var(--_1pyqka9e);
+}
+.mt0ih2r2:hover {
+  color: var(--_1pyqka9e);
+}
+.mt0ih2r3 {
+  color: var(--_1pyqka9f);
+}
+.mt0ih2r4:hover {
+  color: var(--_1pyqka9f);
+}
+.mt0ih2r5 {
+  color: var(--_1pyqka9h);
+}
+.mt0ih2r6:hover {
+  color: var(--_1pyqka9h);
+}
+.mt0ih2r7 {
+  color: var(--_1pyqka9d);
+}
+.mt0ih2r8:hover {
+  color: var(--_1pyqka9d);
+}
+.mt0ih2r9 {
+  color: var(--_1pyqka9l);
+}
+.mt0ih2ra:hover {
+  color: var(--_1pyqka9l);
+}
+.mt0ih2rb {
+  color: var(--_1pyqka9m);
+}
+.mt0ih2rc:hover {
+  color: var(--_1pyqka9m);
+}
+.mt0ih2rd {
+  color: var(--_1pyqka9n);
+}
+.mt0ih2re:hover {
+  color: var(--_1pyqka9n);
+}
+.mt0ih2rf {
+  color: var(--_1pyqka9o);
+}
+.mt0ih2rg:hover {
+  color: var(--_1pyqka9o);
+}
+.mt0ih2rh {
+  color: var(--_1pyqka9p);
+}
+.mt0ih2ri:hover {
+  color: var(--_1pyqka9p);
+}
+.mt0ih2rj {
+  color: var(--_1pyqka9q);
+}
+.mt0ih2rk:hover {
+  color: var(--_1pyqka9q);
+}
+.mt0ih2rl {
+  color: var(--_1pyqka9r);
+}
+.mt0ih2rm:hover {
+  color: var(--_1pyqka9r);
+}
+.mt0ih2rn {
+  color: var(--_1pyqka9s);
+}
+.mt0ih2ro:hover {
+  color: var(--_1pyqka9s);
+}
+.mt0ih2rp {
+  color: var(--_1pyqka9t);
+}
+.mt0ih2rq:hover {
+  color: var(--_1pyqka9t);
+}
+.mt0ih2rr {
+  color: var(--_1pyqka9u);
+}
+.mt0ih2rs:hover {
+  color: var(--_1pyqka9u);
+}
+.mt0ih2rt {
+  color: var(--_1pyqka9v);
+}
+.mt0ih2ru:hover {
+  color: var(--_1pyqka9v);
+}
+.mt0ih2rv {
+  color: var(--_1pyqka9w);
+}
+.mt0ih2rw:hover {
+  color: var(--_1pyqka9w);
+}
+.mt0ih2rx {
+  color: var(--_1pyqka9x);
+}
+.mt0ih2ry:hover {
+  color: var(--_1pyqka9x);
+}
+.mt0ih2rz {
+  color: var(--_1pyqka9y);
+}
+.mt0ih2s0:hover {
+  color: var(--_1pyqka9y);
+}
+.mt0ih2s1 {
+  text-transform: none;
+}
+.mt0ih2s2:hover {
+  text-transform: none;
+}
+.mt0ih2s3 {
+  text-transform: capitalize;
+}
+.mt0ih2s4:hover {
+  text-transform: capitalize;
+}
+.mt0ih2s5 {
+  text-transform: uppercase;
+}
+.mt0ih2s6:hover {
+  text-transform: uppercase;
+}
+.mt0ih2s7 {
+  text-transform: lowercase;
+}
+.mt0ih2s8:hover {
+  text-transform: lowercase;
+}
+._19y1zt60 {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+._19y1zt60::-webkit-scrollbar {
+  display: none;
+}
+._15exe0r0 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-all;
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+}
+._15exe0r1 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-all;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+}
+._15exe0r2 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-all;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+}
+._15exe0r3 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-all;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+}
+._145lkmv0 {
+  text-align: center;
+}
+._145lkmv1 {
+  text-align: left;
+}
+._145lkmv2 {
+  text-align: right;
+}
+._145lkmv3 {
+  font-family:
+    Steradian,
+    -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif,
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol;
+}
+._145lkmv4 {
+  font-family:
+    Steradian,
+    Segoe UI,
+    Roboto,
+    Helvetica Neue,
+    Arial,
+    Noto Sans,
+    sans-serif;
+}
+._145lkmv5 {
+  font-family:
+    IBM Plex Mono,
+    Menlo,
+    DejaVu Sans Mono,
+    Bitstream Vera Sans Mono,
+    Courier,
+    monospace;
+}
+._145lkmv6 {
+  font-size: 11px;
+  line-height: 12px;
+}
+._145lkmv6::before {
+  content: "";
+  margin-bottom: -0.1875em;
+  display: table;
+}
+._145lkmv6::after {
+  content: "";
+  margin-top: -0.2005em;
+  display: table;
+}
+._145lkmv7 {
+  font-size: 12px;
+  line-height: 16px;
+}
+._145lkmv7::before {
+  content: "";
+  margin-bottom: -0.3087em;
+  display: table;
+}
+._145lkmv7::after {
+  content: "";
+  margin-top: -0.3217em;
+  display: table;
+}
+._145lkmv8 {
+  font-size: 13px;
+  line-height: 20px;
+}
+._145lkmv8::before {
+  content: "";
+  margin-bottom: -0.4112em;
+  display: table;
+}
+._145lkmv8::after {
+  content: "";
+  margin-top: -0.4242em;
+  display: table;
+}
+._145lkmv9 {
+  font-size: 14px;
+  line-height: 20px;
+}
+._145lkmv9::before {
+  content: "";
+  margin-bottom: -0.3563em;
+  display: table;
+}
+._145lkmv9::after {
+  content: "";
+  margin-top: -0.3693em;
+  display: table;
+}
+._145lkmva {
+  font-size: 16px;
+  line-height: 24px;
+}
+._145lkmva::before {
+  content: "";
+  margin-bottom: -0.392em;
+  display: table;
+}
+._145lkmva::after {
+  content: "";
+  margin-top: -0.405em;
+  display: table;
+}
+._145lkmvb {
+  font-weight: 300;
+}
+._145lkmvc {
+  font-weight: 400;
+}
+._145lkmvd {
+  font-weight: 500;
+}
+._145lkmve {
+  text-transform: capitalize;
+}
+._145lkmvf {
+  text-transform: uppercase;
+}
+._145lkmvg {
+  text-transform: lowercase;
+}
+._145lkmvh {
+  word-break: break-all;
+}
+._145lkmvi {
+  word-break: break-word;
+}
+._145lkmvj {
+  word-break: normal;
+}
+._145lkmvk {
+  white-space: nowrap;
+}
+._145lkmvl {
+  font-weight: 400;
+}
+._145lkmvm {
+  font-weight: 400;
+}
+._145lkmvn {
+  font-weight: 500;
+}
+._145lkmvo {
+  font-weight: 700;
+}
+._145lkmvp {
+  font-size: 14px;
+  line-height: 20px;
+}
+._145lkmvp::before {
+  content: "";
+  margin-bottom: -0.3913em;
+  display: table;
+}
+._145lkmvp::after {
+  content: "";
+  margin-top: -0.3393em;
+  display: table;
+}
+._145lkmvq {
+  font-size: 11px;
+  line-height: 23px;
+}
+._145lkmvq::before {
+  content: "";
+  margin-bottom: -0.7225em;
+  display: table;
+}
+._145lkmvq::after {
+  content: "";
+  margin-top: -0.6705em;
+  display: table;
+}
+._145lkmvr {
+  font-size: 10px;
+  line-height: 14px;
+}
+._145lkmvr::before {
+  content: "";
+  margin-bottom: -0.377em;
+  display: table;
+}
+._145lkmvr::after {
+  content: "";
+  margin-top: -0.325em;
+  display: table;
+}
+body {
+  color: var(--_1pyqka9b);
+  font-family:
+    Steradian,
+    -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif,
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol;
+}
+.dxo6qt4 {
+  align-items: center;
+  display: inline-flex;
+  user-select: none;
+  width: max-content;
+}
+.dxo6qt5 {
+  min-height: 16px;
+}
+.dxo6qt6 {
+  min-height: 20px;
+}
+.dxo6qt7 {
+  min-height: 24px;
+}
+.dxo6qta {
+  background: var(--_1pyqka91);
+  border: var(--_1pyqka91o) solid 1px;
+  color: var(--_1pyqka9c);
+}
+.dxo6qtb {
+  background: var(--_1pyqka99);
+  color: var(--_1pyqka9c);
+}
+.dxo6qtc {
+  border: var(--_1pyqka91o) solid 1px;
+  color: var(--_1pyqka9c);
+}
+.dxo6qtd {
+  background: var(--_1pyqka95);
+  color: var(--_1pyqka9e);
+}
+.dxo6qtf {
+  background: var(--_1pyqka97);
+  color: var(--_1pyqka9g);
+}
+.dxo6qtg {
+  background: var(--_1pyqka96);
+  color: var(--_1pyqka9f);
+}
+.dxo6qth {
+  background: var(--_1pyqka98);
+  color: var(--_1pyqka9h);
+}
+.dxo6qti {
+  border-radius: 3px;
+}
+.dxo6qtj {
+  border-radius: 5px;
+}
+.dxo6qtk {
+  border-radius: 6px;
+}
+.dxo6qtl {
+  border-radius: 23px;
+}
+.dxo6qtm {
+  border-radius: 10px;
+}
+.dxo6qtn {
+  border-radius: 16px;
+}
+._1oerpj90 {
+  align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: center;
+  flex-shrink: 0;
+}
+._1oerpj90[disabled] {
+  color: var(--_1pyqka9o);
+  pointer-events: none;
+  user-select: none;
+}
+._1oerpj91 {
+  height: 12px;
+  width: 12px;
+  font-size: 12px;
+  line-height: 16px;
+}
+._1oerpj91::before {
+  content: "";
+  margin-bottom: -0.3087em;
+  display: table;
+}
+._1oerpj91::after {
+  content: "";
+  margin-top: -0.3217em;
+  display: table;
+}
+._1oerpj92 {
+  height: 12px;
+  width: 12px;
+  font-size: 13px;
+  line-height: 20px;
+}
+._1oerpj92::before {
+  content: "";
+  margin-bottom: -0.4112em;
+  display: table;
+}
+._1oerpj92::after {
+  content: "";
+  margin-top: -0.4242em;
+  display: table;
+}
+._1oerpj93 {
+  height: 14px;
+  width: 14px;
+  font-size: 13px;
+  line-height: 20px;
+}
+._1oerpj93::before {
+  content: "";
+  margin-bottom: -0.4112em;
+  display: table;
+}
+._1oerpj93::after {
+  content: "";
+  margin-top: -0.4242em;
+  display: table;
+}
+._1oerpj94 {
+  height: 16px;
+  width: 16px;
+  font-size: 13px;
+  line-height: 20px;
+}
+._1oerpj94::before {
+  content: "";
+  margin-bottom: -0.4112em;
+  display: table;
+}
+._1oerpj94::after {
+  content: "";
+  margin-top: -0.4242em;
+  display: table;
+}
+._1oerpj95 {
+  height: 16px;
+  width: 16px;
+  font-size: 16px;
+  line-height: 24px;
+}
+._1oerpj95::before {
+  content: "";
+  margin-bottom: -0.392em;
+  display: table;
+}
+._1oerpj95::after {
+  content: "";
+  margin-top: -0.405em;
+  display: table;
+}
+._1oerpj99 {
+  color: var(--_1pyqka9p);
+}
+._1oerpj9a {
+  color: var(--_1pyqka9w);
+}
+._1oerpj9b:active {
+  color: #f4f2f4;
+}
+._1oerpj9c {
+  color: var(--_1pyqka9p);
+}
+._1oerpj9h {
+  background-color: transparent;
+  cursor: pointer;
+  line-height: 1em;
+}
+._1oerpj9h:hover {
+  cursor: pointer;
+}
+._1oerpj9h[disabled],
+._1oerpj9h[disabled]:hover,
+._1oerpj9h[disabled]:focus {
+  color: var(--_1pyqka9x);
+  pointer-events: none;
+  user-select: none;
+}
+._1oerpj9l {
+  color: var(--_1pyqka9r);
+}
+._1oerpj9m {
+  color: var(--_1pyqka9r);
+}
+._1oerpj9n {
+  background: #eb9091;
+  color: #ffffff;
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.32);
+}
+._1oerpj9n:hover {
+  background: #e5484d;
+  color: #ffffff;
+}
+._1oerpj9n:active {
+  background: #e5484d;
+  color: #ffffff;
+  box-shadow: none;
+}
+._1oerpj9n[disabled],
+._1oerpj9n[disabled]:hover {
+  background: #f3aeaf;
+  color: #fdfcfd;
+  box-shadow: none;
+}
+._1oerpj9o {
+  height: 24px;
+}
+._1oerpj9p {
+  height: 28px;
+}
+._1oerpj9q {
+  height: 32px;
+}
+._1oerpj9r {
+  background-color: var(--_1pyqka9l);
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.32);
+  color: var(--_1pyqka9p);
+}
+._1oerpj9r:hover {
+  background-color: var(--_1pyqka9m);
+  color: var(--_1pyqka9p);
+}
+._1oerpj9r:active {
+  background-color: var(--_1pyqka9n);
+  box-shadow: none;
+  color: var(--_1pyqka9p);
+}
+._1oerpj9r[disabled],
+._1oerpj9r[disabled]:hover {
+  background-color: var(--_1pyqka9o);
+  color: var(--_1pyqka9o);
+  box-shadow: none;
+}
+._1oerpj9s {
+  border: var(--_1pyqka91k) solid 1px;
+  box-shadow: none;
+  color: var(--_1pyqka9r);
+}
+._1oerpj9s:hover {
+  background-color: var(--_1pyqka91t);
+  border: var(--_1pyqka91l) solid 1px;
+  color: var(--_1pyqka9r);
+}
+._1oerpj9s:active {
+  background-color: var(--_1pyqka91u);
+  border: var(--_1pyqka91m) solid 1px;
+  color: var(--_1pyqka9r);
+}
+._1oerpj9s[disabled],
+._1oerpj9s[disabled]:hover {
+  border: var(--_1pyqka91n) solid 1px;
+  color: var(--_1pyqka9q);
+}
+._1oerpj9t {
+  border: 0;
+  box-shadow: none;
+  color: var(--_1pyqka9r);
+}
+._1oerpj9t:hover {
+  background-color: var(--_1pyqka91t);
+  color: var(--_1pyqka9r);
+}
+._1oerpj9t:active {
+  background-color: var(--_1pyqka91u);
+  color: var(--_1pyqka9r);
+}
+._1oerpj9t[disabled],
+._1oerpj9t[disabled]:hover {
+  color: var(--_1pyqka9q);
+}
+._1oerpj9u {
+  background-color: var(--_1pyqka9s);
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.1);
+  color: var(--_1pyqka9w);
+}
+._1oerpj9u:hover {
+  background-color: var(--_1pyqka9t);
+  color: var(--_1pyqka9w);
+}
+._1oerpj9u:active {
+  background-color: var(--_1pyqka9u);
+  box-shadow: none;
+  color: var(--_1pyqka9w);
+}
+._1oerpj9u[disabled],
+._1oerpj9u[disabled]:hover {
+  background-color: var(--_1pyqka9v);
+  color: var(--_1pyqka9x);
+  box-shadow: none;
+}
+._1oerpj9v {
+  border: var(--_1pyqka91o) solid 1px;
+  box-shadow: none;
+  color: var(--_1pyqka9y);
+}
+._1oerpj9v:hover {
+  background-color: var(--_1pyqka91x);
+  border: var(--_1pyqka91p) solid 1px;
+  color: var(--_1pyqka9y);
+}
+._1oerpj9v:active {
+  border: var(--_1pyqka91q) solid 1px;
+  background-color: var(--_1pyqka91y);
+  color: var(--_1pyqka9y);
+}
+._1oerpj9v[disabled],
+._1oerpj9v[disabled]:hover {
+  background-color: var(--_1pyqka91z);
+  border: var(--_1pyqka91r) solid 1px;
+}
+._1oerpj9w {
+  color: var(--_1pyqka9y);
+}
+._1oerpj9w:hover {
+  background-color: var(--_1pyqka91x);
+  color: var(--_1pyqka9y);
+}
+._1oerpj9w:active {
+  background-color: var(--_1pyqka91y);
+  color: var(--_1pyqka9y);
+}
+._1oerpj9w[disabled],
+._1oerpj9w[disabled]:hover {
+  background-color: var(--_1pyqka91z);
+}
+._1ku4sk20 {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  border: none;
+  border-radius: 6px;
+  color: var(--_1pyqka9l);
+  cursor: pointer;
+  padding: 0;
+  outline: none;
+}
+._1ku4sk20[disabled],
+._1ku4sk20[disabled]:hover,
+._1ku4sk20[disabled]:focus {
+  box-shadow: none;
+  color: var(--_1pyqka9q);
+  cursor: not-allowed;
+  outline: none;
+}
+._1ku4sk26 {
+  color: #6f6e77;
+  background-color: inherit;
+}
+._1ku4sk26:hover:enabled {
+  background-color: #eeedef;
+  color: #86848d;
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.1);
+}
+._1ku4sk26:active:enabled {
+  background-color: #e9e8ea;
+  box-shadow: none;
+}
+._1ku4sk27 {
+  height: 24px;
+  width: 24px;
+}
+._1ku4sk28 {
+  height: 28px;
+  width: 28px;
+}
+._1ku4sk29 {
+  height: 32px;
+  width: 32px;
+}
+._1ku4sk2a {
+  height: 20px;
+  width: 20px;
+  border-radius: 4px;
+}
+._1ku4sk2d {
+  width: 16px;
+}
+._1ku4sk2e {
+  width: 18px;
+}
+._1ku4sk2f {
+  width: 20px;
+}
+._1ku4sk2g {
+  background-color: var(--_1pyqka9l);
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.32);
+  color: #ffffff;
+}
+._1ku4sk2g:hover:enabled {
+  background-color: var(--_1pyqka9m);
+}
+._1ku4sk2g:active:enabled {
+  background-color: var(--_1pyqka9n);
+  box-shadow: none;
+}
+._1ku4sk2g[disabled] {
+  background-color: var(--_1pyqka9o);
+}
+._1ku4sk2h {
+  background-color: var(--_1pyqka91s);
+  border: var(--_1pyqka91k) solid 1px;
+  box-shadow: none;
+  color: var(--_1pyqka9l);
+}
+._1ku4sk2h[disabled] {
+  border: var(--_1pyqka91n) solid 1px;
+}
+._1ku4sk2h:hover:enabled {
+  background-color: var(--_1pyqka91t);
+  border: var(--_1pyqka91l) solid 1px;
+}
+._1ku4sk2h:active:enabled {
+  background-color: var(--_1pyqka91u);
+  border: var(--_1pyqka91m) solid 1px;
+}
+._1ku4sk2i {
+  background-color: var(--_1pyqka91s);
+  box-shadow: none;
+  color: var(--_1pyqka9l);
+}
+._1ku4sk2i:hover:enabled {
+  background-color: var(--_1pyqka91t);
+}
+._1ku4sk2i:active:enabled {
+  background-color: var(--_1pyqka91u);
+}
+._1ku4sk2j {
+  background-color: var(--_1pyqka9s);
+  color: var(--_1pyqka9y);
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.1);
+}
+._1ku4sk2j:hover:enabled {
+  background-color: var(--_1pyqka9t);
+}
+._1ku4sk2j:active:enabled {
+  background-color: var(--_1pyqka9u);
+  box-shadow: none;
+}
+._1ku4sk2j[disabled] {
+  background-color: var(--_1pyqka9v);
+  color: var(--_1pyqka9x);
+}
+._1ku4sk2k {
+  background-color: transparent;
+  border: var(--_1pyqka91o) solid 1px;
+  box-shadow: none;
+  color: var(--_1pyqka9y);
+}
+._1ku4sk2k[disabled] {
+  border: var(--_1pyqka91r) solid 1px;
+  color: var(--_1pyqka9x);
+}
+._1ku4sk2k:hover:enabled {
+  background-color: var(--_1pyqka91x);
+  border: var(--_1pyqka91p) solid 1px;
+}
+._1ku4sk2k:active:enabled {
+  background-color: var(--_1pyqka91y);
+  border: var(--_1pyqka91q) solid 1px;
+}
+._1ku4sk2l {
+  background-color: var(--_1pyqka91w);
+  box-shadow: none;
+  color: var(--_1pyqka9y);
+}
+._1ku4sk2l[disabled] {
+  color: var(--_1pyqka9x);
+}
+._1ku4sk2l:hover:enabled {
+  background-color: var(--_1pyqka91x);
+}
+._1ku4sk2l:active:enabled {
+  background-color: var(--_1pyqka91y);
+}
+.mquqy90 {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+}
+.mquqy91 {
+  color: var(--_1pyqka9l);
+}
+.mquqy91:hover {
+  color: var(--_1pyqka9m);
+}
+.mquqy91:active {
+  color: var(--_1pyqka9n);
+}
+.mquqy92 {
+  color: var(--_1pyqka9y);
+}
+.mquqy92:hover {
+  color: var(--_1pyqka9w);
+}
+.mquqy92:active {
+  color: var(--_1pyqka9w);
+}
+._118xo1h2 {
+  background: transparent;
+}
+._118xo1h3 {
+  background-color: var(--_1pyqka92);
+}
+._118xo1h4 {
+  background-color: var(--_1pyqka92);
+}
+._1o4id6s0 {
+  display: flex;
+  flex-wrap: wrap;
+  min-width: 100%;
+}
+._1o4id6s1 {
+  box-sizing: border-box;
+  min-width: 0;
+}
+._1o4id6s2 {
+  flex: 0 0 calc(100% / 12);
+}
+._1o4id6s6 {
+  flex: 0 0 calc(100% * 2 / 12);
+}
+._1o4id6sa {
+  flex: 0 0 calc(100% * 3 / 12);
+}
+._1o4id6se {
+  flex: 0 0 calc(100% * 4 / 12);
+}
+._1o4id6si {
+  flex: 0 0 calc(100% * 5 / 12);
+}
+._1o4id6sm {
+  flex: 0 0 calc(100% * 6 / 12);
+}
+._1o4id6sq {
+  flex: 0 0 calc(100% * 7 / 12);
+}
+._1o4id6su {
+  flex: 0 0 calc(100% * 8 / 12);
+}
+._1o4id6sy {
+  flex: 0 0 calc(100% * 9 / 12);
+}
+._1o4id6s12 {
+  flex: 0 0 calc(100% * 10 / 12);
+}
+._1o4id6s16 {
+  flex: 0 0 calc(100% * 11 / 12);
+}
+._1o4id6s1a {
+  flex: 0 0 100%;
+}
+._1o4id6s1e {
+  flex: 1 0 auto;
+}
+._1o4id6s1i {
+  margin-left: 0;
+  margin-top: 0;
+}
+._1o4id6s1j {
+  margin-left: -1px;
+  margin-top: -1px;
+}
+._1o4id6s1k {
+  margin-left: -2px;
+  margin-top: -2px;
+}
+._1o4id6s1l {
+  margin-left: -3px;
+  margin-top: -3px;
+}
+._1o4id6s1m {
+  margin-left: -4px;
+  margin-top: -4px;
+}
+._1o4id6s1n {
+  margin-left: -6px;
+  margin-top: -6px;
+}
+._1o4id6s1o {
+  margin-left: -7px;
+  margin-top: -7px;
+}
+._1o4id6s1p {
+  margin-left: -8px;
+  margin-top: -8px;
+}
+._1o4id6s1q {
+  margin-left: -9px;
+  margin-top: -9px;
+}
+._1o4id6s1r {
+  margin-left: -10px;
+  margin-top: -10px;
+}
+._1o4id6s1s {
+  margin-left: -12px;
+  margin-top: -12px;
+}
+._1o4id6s1t {
+  margin-left: -16px;
+  margin-top: -16px;
+}
+._1o4id6s1u {
+  margin-left: -20px;
+  margin-top: -20px;
+}
+._1o4id6s1v {
+  margin-left: -24px;
+  margin-top: -24px;
+}
+._1o4id6s1w {
+  margin-left: -28px;
+  margin-top: -28px;
+}
+._1o4id6s1x {
+  margin-left: -32px;
+  margin-top: -32px;
+}
+._1o4id6s1y {
+  margin-left: -40px;
+  margin-top: -40px;
+}
+@media screen and (min-width: 740px) {
+  ._1o4id6s3 {
+    flex: 0 0 calc(100% / 12);
+  }
+  ._1o4id6s7 {
+    flex: 0 0 calc(100% * 2 / 12);
+  }
+  ._1o4id6sb {
+    flex: 0 0 calc(100% * 3 / 12);
+  }
+  ._1o4id6sf {
+    flex: 0 0 calc(100% * 4 / 12);
+  }
+  ._1o4id6sj {
+    flex: 0 0 calc(100% * 5 / 12);
+  }
+  ._1o4id6sn {
+    flex: 0 0 calc(100% * 6 / 12);
+  }
+  ._1o4id6sr {
+    flex: 0 0 calc(100% * 7 / 12);
+  }
+  ._1o4id6sv {
+    flex: 0 0 calc(100% * 8 / 12);
+  }
+  ._1o4id6sz {
+    flex: 0 0 calc(100% * 9 / 12);
+  }
+  ._1o4id6s13 {
+    flex: 0 0 calc(100% * 10 / 12);
+  }
+  ._1o4id6s17 {
+    flex: 0 0 calc(100% * 11 / 12);
+  }
+  ._1o4id6s1b {
+    flex: 0 0 100%;
+  }
+  ._1o4id6s1f {
+    flex: 1 0 auto;
+  }
+  ._1o4id6s1z {
+    margin-left: 0;
+    margin-top: 0;
+  }
+  ._1o4id6s20 {
+    margin-left: -1px;
+    margin-top: -1px;
+  }
+  ._1o4id6s21 {
+    margin-left: -2px;
+    margin-top: -2px;
+  }
+  ._1o4id6s22 {
+    margin-left: -3px;
+    margin-top: -3px;
+  }
+  ._1o4id6s23 {
+    margin-left: -4px;
+    margin-top: -4px;
+  }
+  ._1o4id6s24 {
+    margin-left: -6px;
+    margin-top: -6px;
+  }
+  ._1o4id6s25 {
+    margin-left: -7px;
+    margin-top: -7px;
+  }
+  ._1o4id6s26 {
+    margin-left: -8px;
+    margin-top: -8px;
+  }
+  ._1o4id6s27 {
+    margin-left: -9px;
+    margin-top: -9px;
+  }
+  ._1o4id6s28 {
+    margin-left: -10px;
+    margin-top: -10px;
+  }
+  ._1o4id6s29 {
+    margin-left: -12px;
+    margin-top: -12px;
+  }
+  ._1o4id6s2a {
+    margin-left: -16px;
+    margin-top: -16px;
+  }
+  ._1o4id6s2b {
+    margin-left: -20px;
+    margin-top: -20px;
+  }
+  ._1o4id6s2c {
+    margin-left: -24px;
+    margin-top: -24px;
+  }
+  ._1o4id6s2d {
+    margin-left: -28px;
+    margin-top: -28px;
+  }
+  ._1o4id6s2e {
+    margin-left: -32px;
+    margin-top: -32px;
+  }
+  ._1o4id6s2f {
+    margin-left: -40px;
+    margin-top: -40px;
+  }
+}
+@media screen and (min-width: 992px) {
+  ._1o4id6s4 {
+    flex: 0 0 calc(100% / 12);
+  }
+  ._1o4id6s8 {
+    flex: 0 0 calc(100% * 2 / 12);
+  }
+  ._1o4id6sc {
+    flex: 0 0 calc(100% * 3 / 12);
+  }
+  ._1o4id6sg {
+    flex: 0 0 calc(100% * 4 / 12);
+  }
+  ._1o4id6sk {
+    flex: 0 0 calc(100% * 5 / 12);
+  }
+  ._1o4id6so {
+    flex: 0 0 calc(100% * 6 / 12);
+  }
+  ._1o4id6ss {
+    flex: 0 0 calc(100% * 7 / 12);
+  }
+  ._1o4id6sw {
+    flex: 0 0 calc(100% * 8 / 12);
+  }
+  ._1o4id6s10 {
+    flex: 0 0 calc(100% * 9 / 12);
+  }
+  ._1o4id6s14 {
+    flex: 0 0 calc(100% * 10 / 12);
+  }
+  ._1o4id6s18 {
+    flex: 0 0 calc(100% * 11 / 12);
+  }
+  ._1o4id6s1c {
+    flex: 0 0 100%;
+  }
+  ._1o4id6s1g {
+    flex: 1 0 auto;
+  }
+  ._1o4id6s2g {
+    margin-left: 0;
+    margin-top: 0;
+  }
+  ._1o4id6s2h {
+    margin-left: -1px;
+    margin-top: -1px;
+  }
+  ._1o4id6s2i {
+    margin-left: -2px;
+    margin-top: -2px;
+  }
+  ._1o4id6s2j {
+    margin-left: -3px;
+    margin-top: -3px;
+  }
+  ._1o4id6s2k {
+    margin-left: -4px;
+    margin-top: -4px;
+  }
+  ._1o4id6s2l {
+    margin-left: -6px;
+    margin-top: -6px;
+  }
+  ._1o4id6s2m {
+    margin-left: -7px;
+    margin-top: -7px;
+  }
+  ._1o4id6s2n {
+    margin-left: -8px;
+    margin-top: -8px;
+  }
+  ._1o4id6s2o {
+    margin-left: -9px;
+    margin-top: -9px;
+  }
+  ._1o4id6s2p {
+    margin-left: -10px;
+    margin-top: -10px;
+  }
+  ._1o4id6s2q {
+    margin-left: -12px;
+    margin-top: -12px;
+  }
+  ._1o4id6s2r {
+    margin-left: -16px;
+    margin-top: -16px;
+  }
+  ._1o4id6s2s {
+    margin-left: -20px;
+    margin-top: -20px;
+  }
+  ._1o4id6s2t {
+    margin-left: -24px;
+    margin-top: -24px;
+  }
+  ._1o4id6s2u {
+    margin-left: -28px;
+    margin-top: -28px;
+  }
+  ._1o4id6s2v {
+    margin-left: -32px;
+    margin-top: -32px;
+  }
+  ._1o4id6s2w {
+    margin-left: -40px;
+    margin-top: -40px;
+  }
+}
+@media screen and (min-width: 1200px) {
+  ._1o4id6s5 {
+    flex: 0 0 calc(100% / 12);
+  }
+  ._1o4id6s9 {
+    flex: 0 0 calc(100% * 2 / 12);
+  }
+  ._1o4id6sd {
+    flex: 0 0 calc(100% * 3 / 12);
+  }
+  ._1o4id6sh {
+    flex: 0 0 calc(100% * 4 / 12);
+  }
+  ._1o4id6sl {
+    flex: 0 0 calc(100% * 5 / 12);
+  }
+  ._1o4id6sp {
+    flex: 0 0 calc(100% * 6 / 12);
+  }
+  ._1o4id6st {
+    flex: 0 0 calc(100% * 7 / 12);
+  }
+  ._1o4id6sx {
+    flex: 0 0 calc(100% * 8 / 12);
+  }
+  ._1o4id6s11 {
+    flex: 0 0 calc(100% * 9 / 12);
+  }
+  ._1o4id6s15 {
+    flex: 0 0 calc(100% * 10 / 12);
+  }
+  ._1o4id6s19 {
+    flex: 0 0 calc(100% * 11 / 12);
+  }
+  ._1o4id6s1d {
+    flex: 0 0 100%;
+  }
+  ._1o4id6s1h {
+    flex: 1 0 auto;
+  }
+  ._1o4id6s2x {
+    margin-left: 0;
+    margin-top: 0;
+  }
+  ._1o4id6s2y {
+    margin-left: -1px;
+    margin-top: -1px;
+  }
+  ._1o4id6s2z {
+    margin-left: -2px;
+    margin-top: -2px;
+  }
+  ._1o4id6s30 {
+    margin-left: -3px;
+    margin-top: -3px;
+  }
+  ._1o4id6s31 {
+    margin-left: -4px;
+    margin-top: -4px;
+  }
+  ._1o4id6s32 {
+    margin-left: -6px;
+    margin-top: -6px;
+  }
+  ._1o4id6s33 {
+    margin-left: -7px;
+    margin-top: -7px;
+  }
+  ._1o4id6s34 {
+    margin-left: -8px;
+    margin-top: -8px;
+  }
+  ._1o4id6s35 {
+    margin-left: -9px;
+    margin-top: -9px;
+  }
+  ._1o4id6s36 {
+    margin-left: -10px;
+    margin-top: -10px;
+  }
+  ._1o4id6s37 {
+    margin-left: -12px;
+    margin-top: -12px;
+  }
+  ._1o4id6s38 {
+    margin-left: -16px;
+    margin-top: -16px;
+  }
+  ._1o4id6s39 {
+    margin-left: -20px;
+    margin-top: -20px;
+  }
+  ._1o4id6s3a {
+    margin-left: -24px;
+    margin-top: -24px;
+  }
+  ._1o4id6s3b {
+    margin-left: -28px;
+    margin-top: -28px;
+  }
+  ._1o4id6s3c {
+    margin-left: -32px;
+    margin-top: -32px;
+  }
+  ._1o4id6s3d {
+    margin-left: -40px;
+    margin-top: -40px;
+  }
+}
+._1ec5cce1 {
+  container-name: _1ec5cce0;
+  container-type: inline-size;
+  overflow-y: scroll;
+  width: 100%;
+  height: 100%;
+}
+@media (min-width: 1200px) {
+  ._1ec5cce2 {
+    width: 980px;
+  }
+}
+@container (min-width: 980px) {
+  ._1ec5cce2 {
+    width: 980px;
+  }
+}
+@container (max-width: 979px) {
+  ._1ec5cce2 {
+    width: auto;
+  }
+}
+.ybwwtm0 {
+  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  height: 2rem;
+  row-gap: 0.5rem;
+}
+.ybwwtm1 {
+  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  row-gap: 0.5rem;
+}
+._14bi7ra0 {
+  background-color: white;
+  border: var(--_1pyqka91o) solid 1px;
+  border-radius: 4px;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  width: fit-content;
+  max-width: 320px;
+  min-width: 200px;
+  box-shadow: 0 6px 12px -2px rgba(59, 59, 59, .12);
+  z-index: 6;
+}
+._14bi7ra2 {
+  min-height: 20px;
+  color: var(--_1pyqka9y);
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 20px;
+}
+._14bi7ra2::before {
+  content: "";
+  margin-bottom: -0.4112em;
+  display: table;
+}
+._14bi7ra2::after {
+  content: "";
+  margin-top: -0.4242em;
+  display: table;
+}
+._14bi7ra2[aria-disabled] {
+  cursor: default;
+  opacity: 0.5;
+}
+._14bi7ra2[data-active-item],
+._14bi7ra2:hover {
+  background-color: var(--_1pyqka91x);
+}
+._14bi7ra3 {
+  background-color: var(--_1pyqka91w);
+}
+._14bi7ra5 {
+  background-color: var(--_1pyqka9j);
+  border: 0;
+  height: 1px;
+  margin-bottom: 4px;
+  margin-top: 4px;
+}
+._14bi7ra6 {
+  align-items: center;
+  display: flex;
+  height: 16px;
+  justify-content: space-between;
+  margin: 0;
+  padding-right: 8px;
+  padding-left: 8px;
+  width: 100%;
+}
+.in1xv90 {
+  border: none;
+  font-size: 13px;
+  color: var(--_1pyqka9b);
+  caret-color: var(--_1pyqka9l);
+  outline: 0;
+  width: 100%;
+}
+.in1xv90::placeholder {
+  color: var(--_1pyqka9x);
+  font-family:
+    Steradian,
+    -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif,
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol;
+}
+.in1xv90:disabled {
+  background: #e9e8ea;
+}
+.in1xv91 {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.in1xv93 {
+  height: 20px;
+}
+.in1xv94 {
+  height: 28px;
+}
+.in1xv95 {
+  width: 0;
+  padding: 0;
+  border: none;
+}
+.in1xv95:focus,
+.in1xv95:active,
+.in1xv95:placeholder-shown:hover {
+  border: none;
+}
+.in1xv97 {
+  border-radius: 6px;
+  padding: 4px 6px;
+  border: var(--_1pyqka91o) solid 1px;
+}
+.in1xv97:focus,
+.in1xv97:active {
+  border: var(--_1pyqka91q) solid 1px;
+}
+.in1xv97:placeholder-shown:hover {
+  background: var(--_1pyqka91x);
+  border: var(--_1pyqka91p) solid 1px;
+}
+.in1xv98 {
+  padding: 0;
+  border: none;
+}
+.in1xv99 {
+  border-radius: 6px;
+  border: var(--_1pyqka91o) solid 1px;
+  cursor: pointer;
+  display: block;
+  padding: 4px 16px;
+  font-size: 13px;
+  color: var(--_1pyqka9c);
+  outline: 0;
+  appearance: none;
+  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="1.1em" height="1.1em" fill="none" viewBox="0 0 20 20" focusable="false" > <path fill="grey" fillRule="evenodd" d="M5.293 7.293a1 1 0 0 1 1.414 0L10 10.586l3.293-3.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 0-1.414Z" clipRule="evenodd" /> </svg>');
+  background-repeat: no-repeat;
+  background-position: right 4px center;
+}
+.in1xv99::placeholder {
+  color: var(--_1pyqka9x);
+}
+.in1xv99:disabled {
+  background: #e9e8ea;
+}
+.in1xv99:focus {
+  border: var(--_1pyqka91q) solid 1px;
+}
+._1e9eref2 {
+  text-align: center;
+}
+._1e9eref3 {
+  font-size: 36px;
+  line-height: 50px;
+  font-family:
+    Steradian,
+    Segoe UI,
+    Roboto,
+    Helvetica Neue,
+    Arial,
+    Noto Sans,
+    sans-serif;
+  font-weight: 700;
+}
+._1e9eref3::before {
+  content: "";
+  margin-bottom: -0.3364em;
+  display: table;
+}
+._1e9eref3::after {
+  content: "";
+  margin-top: -0.3494em;
+  display: table;
+}
+._1e9eref4 {
+  font-size: 30px;
+  line-height: 32px;
+  font-family:
+    Steradian,
+    Segoe UI,
+    Roboto,
+    Helvetica Neue,
+    Arial,
+    Noto Sans,
+    sans-serif;
+  font-weight: 700;
+}
+._1e9eref4::before {
+  content: "";
+  margin-bottom: -0.1753em;
+  display: table;
+}
+._1e9eref4::after {
+  content: "";
+  margin-top: -0.1883em;
+  display: table;
+}
+._1e9eref5 {
+  font-size: 24px;
+  line-height: 34px;
+  font-family:
+    Steradian,
+    Segoe UI,
+    Roboto,
+    Helvetica Neue,
+    Arial,
+    Noto Sans,
+    sans-serif;
+  font-weight: 700;
+}
+._1e9eref5::before {
+  content: "";
+  margin-bottom: -0.3503em;
+  display: table;
+}
+._1e9eref5::after {
+  content: "";
+  margin-top: -0.3633em;
+  display: table;
+}
+._1e9eref6 {
+  font-size: 20px;
+  line-height: 28px;
+  font-family:
+    Steradian,
+    Segoe UI,
+    Roboto,
+    Helvetica Neue,
+    Arial,
+    Noto Sans,
+    sans-serif;
+  font-weight: 500 !important;
+}
+._1e9eref6::before {
+  content: "";
+  margin-bottom: -0.342em;
+  display: table;
+}
+._1e9eref6::after {
+  content: "";
+  margin-top: -0.355em;
+  display: table;
+}
+._12rav3x0 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #ffffff;
+  border: 1px solid #e4e2e4;
+  border-radius: 6px;
+  box-shadow: none;
+  padding: 2px 4px;
+}
+._12rav3x1 {
+  height: 22px;
+  font-size: 13px;
+  line-height: 20px;
+}
+._12rav3x1::before {
+  content: "";
+  margin-bottom: -0.4112em;
+  display: table;
+}
+._12rav3x1::after {
+  content: "";
+  margin-top: -0.4242em;
+  display: table;
+}
+._1oemo0l0 {
+  display: none;
+}
+._1oemo0l1 {
+  align-items: center;
+  background-color: #ffffff;
+  border: var(--_1pyqka91o) solid 1px;
+  border-radius: 6px;
+  color: var(--_1pyqka9c);
+  display: flex;
+  font-size: 13px;
+  gap: 4px;
+  padding: 0 8px;
+}
+._1oemo0l2 {
+  background-color: #ffffff;
+  border: var(--_1pyqka91o) solid 1px;
+  border-radius: 6px;
+  min-width: 150px;
+  z-index: 10;
+}
+._1oemo0l3 {
+  align-items: center;
+  display: flex;
+  font-size: 13px;
+  gap: 4px;
+  padding: 4px 8px;
+}
+._1oemo0l3[data-active-item] {
+  background-color: #e9e8ea;
+  color: var(--_1pyqka9b);
+  cursor: pointer;
+}
+._1oemo0l4 {
+  border: var(--_1pyqka91o) solid 1px;
+  border-radius: 6px;
+  display: flex;
+  padding: 1px;
+}
+._1oemo0l3[aria-selected=true] ._1oemo0l4 {
+  background-color: var(--_1pyqka9l);
+}
+._1oemo0l3[aria-selected=false] ._1oemo0l4 {
+  background-color: white;
+}
+._1nph9oi0 {
+  align-items: center;
+  border: none;
+  display: inline-flex;
+  justify-content: center;
+  flex-shrink: 0;
+}
+._1nph9oi1 {
+  height: 12px;
+  width: 12px;
+}
+._1nph9oi2 {
+  height: 12px;
+  width: 12px;
+}
+._1nph9oi3 {
+  height: 16px;
+  width: 16px;
+}
+._1nph9oib {
+  line-height: 1em;
+  width: auto;
+  word-break: break-word;
+  text-align: left;
+}
+._1nph9oib[disabled],
+._1nph9oib[disabled]:hover,
+._1nph9oib[disabled]:focus {
+  background-color: var(--_1pyqka91z);
+  border: 0;
+  box-shadow: none;
+  color: var(--_1pyqka9x);
+}
+._1nph9oib:active {
+  box-shadow: none;
+  outline: none;
+  border: 0;
+}
+._1nph9oib:hover {
+  cursor: pointer;
+}
+._1nph9oij {
+  min-height: 16px;
+}
+._1nph9oik {
+  min-height: 20px;
+}
+._1nph9oil {
+  min-height: 24px;
+}
+._1nph9oim {
+  background-color: var(--_1pyqka9l);
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.32);
+  color: var(--_1pyqka9p);
+}
+._1nph9oim:hover {
+  background-color: var(--_1pyqka9m);
+}
+._1nph9oim:active {
+  background-color: var(--_1pyqka9n);
+  box-shadow: none;
+}
+._1nph9oim[disabled],
+._1nph9oim[disabled]:hover,
+._1nph9oim[disabled]:focus {
+  background-color: var(--_1pyqka9o);
+  color: var(--_1pyqka9o);
+  box-shadow: none;
+}
+._1nph9oin {
+  background-color: var(--_1pyqka91s);
+  border: var(--_1pyqka91k) solid 1px;
+  box-shadow: none;
+  color: var(--_1pyqka9r);
+}
+._1nph9oin:hover {
+  background-color: var(--_1pyqka91t);
+  border: var(--_1pyqka91l) solid 1px;
+}
+._1nph9oin:active {
+  background-color: var(--_1pyqka91u);
+  border: var(--_1pyqka91m) solid 1px;
+}
+._1nph9oin[disabled],
+._1nph9oin[disabled]:hover,
+._1nph9oin[disabled]:focus {
+  border: var(--_1pyqka91n) solid 1px;
+  color: var(--_1pyqka9q);
+}
+._1nph9oio {
+  background-color: var(--_1pyqka91s);
+  border: 0;
+  box-shadow: none;
+  color: var(--_1pyqka9r);
+}
+._1nph9oio:hover {
+  background-color: var(--_1pyqka91t);
+}
+._1nph9oio:active {
+  background-color: var(--_1pyqka91u);
+}
+._1nph9oio[disabled],
+._1nph9oio[disabled]:hover,
+._1nph9oio[disabled]:focus {
+  color: var(--_1pyqka9q);
+}
+._1nph9oip {
+  background-color: var(--_1pyqka9s);
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.1);
+  color: var(--_1pyqka9w);
+}
+._1nph9oip:hover {
+  background-color: var(--_1pyqka9t);
+}
+._1nph9oip:active {
+  background-color: var(--_1pyqka9u);
+  box-shadow: none;
+}
+._1nph9oip[disabled],
+._1nph9oip[disabled]:hover,
+._1nph9oip[disabled]:focus {
+  background-color: var(--_1pyqka9v);
+  color: var(--_1pyqka9x);
+  box-shadow: none;
+}
+._1nph9oiq {
+  background-color: var(--_1pyqka91y);
+  border: var(--_1pyqka91o) solid 1px;
+  box-shadow: none;
+  color: var(--_1pyqka9y);
+}
+._1nph9oiq:hover {
+  background-color: var(--_1pyqka91x);
+  border: var(--_1pyqka91p) solid 1px;
+}
+._1nph9oiq:active {
+  border: var(--_1pyqka91q) solid 1px;
+  background-color: var(--_1pyqka91y);
+}
+._1nph9oiq[disabled],
+._1nph9oiq[disabled]:hover,
+._1nph9oiq[disabled]:focus {
+  background-color: var(--_1pyqka91z);
+  border: var(--_1pyqka91r) solid 1px;
+}
+._1nph9oir {
+  background-color: var(--_1pyqka91w);
+  color: var(--_1pyqka9y);
+}
+._1nph9oir:hover {
+  background-color: var(--_1pyqka91x);
+}
+._1nph9oir:active {
+  background-color: var(--_1pyqka91y);
+}
+._1nph9oir[disabled],
+._1nph9oir[disabled]:hover,
+._1nph9oir[disabled]:focus {
+  background-color: var(--_1pyqka91z);
+}
+._8wggow1 {
+  align-items: center;
+  box-shadow: none;
+  display: inline-flex;
+  justify-content: center;
+  padding: 4px;
+}
+._8wggow1:hover {
+  cursor: pointer;
+}
+._8wggow2 {
+  height: 24px;
+  width: 24px;
+}
+._8wggow3 {
+  height: 28px;
+  width: 28px;
+}
+._8wggow4 {
+  height: 32px;
+  width: 32px;
+}
+._8wggow5 {
+  background: var(--_1pyqka9l);
+  border: 0;
+  color: #ffffff;
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.32);
+}
+._8wggow5:hover {
+  background: var(--_1pyqka9m);
+}
+._8wggow5:active {
+  background: var(--_1pyqka9n);
+}
+._8wggow5:disabled {
+  background: var(--_1pyqka9o);
+  color: var(--_1pyqka9q);
+}
+._8wggow6 {
+  background: var(--_1pyqka91w);
+  border: var(--_1pyqka91o) solid 1px;
+  color: var(--_1pyqka9y);
+}
+._8wggow6:hover {
+  background: var(--_1pyqka91x);
+  border: var(--_1pyqka91p) solid 1px;
+  color: var(--_1pyqka9y);
+}
+._8wggow6:active {
+  background: var(--_1pyqka91y);
+  border: var(--_1pyqka91q) solid 1px;
+  color: var(--_1pyqka9y);
+}
+._8wggow6:disabled {
+  background: var(--_1pyqka91z);
+  border: var(--_1pyqka91r) solid 1px;
+  color: var(--_1pyqka9x);
+}
+._189mxz60 {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+._189mxz61 {
+  box-shadow: none;
+}
+._189mxz62 {
+  display: flex;
+}
+._189mxz63 {
+  height: 20px;
+  width: 100%;
+  position: absolute;
+  top: -10px;
+}
+._189mxz64 {
+  cursor: grab;
+}
+._189mxz64:active {
+  cursor: grabbing;
+}
+._189mxz65 {
+  background-color: #e4e2e4;
+  height: 1px;
+  width: 100%;
+  position: relative;
+  top: 10px;
+}
+._189mxz66 {
+  background: none;
+  border-radius: 0;
+  border-bottom: none;
+  box-shadow: none;
+}
+._189mxz66:focus:enabled,
+._189mxz66:active:enabled,
+._189mxz66:hover:enabled {
+  background: none;
+  box-shadow: none;
+  border-radius: 0;
+  color: #6f6e77;
+}
+._189mxz67 {
+  color: #744ed4;
+}
+._189mxz68 {
+  color: #6f6e77;
+}
+._189mxz69 {
+  border-radius: 2px 2px 0px 0px;
+  height: 2px;
+}
+._189mxz6a {
+  background-color: #744ed4;
+}
+._189mxz6b {
+  background-color: var(--_1pyqka91o);
+}
+._189mxz6c {
+  background-color: #744ed4;
+}
+.hqr510 {
+  color: var(--_1pyqka9l);
+}
+.hqr510:hover {
+  color: var(--_1pyqka9m);
+}
+.hqr510:active {
+  color: var(--_1pyqka9n);
+}
+.hqr511 {
+  text-decoration: none;
+}
+.hqr512 {
+  text-decoration: underline;
+}
+.hqr513 {
+  color: #6f6e77;
+}
+.hqr513:hover {
+  color: #6f6e77;
+}
+.hqr513:focus {
+  color: #6f6e77;
+}
+.hqr513:active {
+  color: #6f6e77;
+}
+._17v45he0 {
+  border-radius: 6px;
+  border: var(--_1pyqka91o) solid 1px;
+  cursor: pointer;
+  display: block;
+  padding: 4px 6px;
+  font-size: 13px;
+  color: var(--_1pyqka9c);
+  outline: 0;
+  width: 100%;
+  appearance: none;
+  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="1.1em" height="1.1em" fill="none" viewBox="0 0 20 20" focusable="false" > <path fill="grey" fillRule="evenodd" d="M5.293 7.293a1 1 0 0 1 1.414 0L10 10.586l3.293-3.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 0-1.414Z" clipRule="evenodd" /> </svg>');
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+}
+._17v45he0::placeholder {
+  color: var(--_1pyqka9x);
+}
+._17v45he0:disabled {
+  background: #e9e8ea;
+}
+._17v45he0:focus {
+  border: var(--_1pyqka91q) solid 1px;
+}
+
+/* temp_stylePlugin:ni:sha-256;BimKasTQsEf0bY9MY1wxsng0FAqgT79IpnGdA68_FII */
+._tooltip_1y9lk_1 {
+  flex-shrink: 0;
+  z-index: 9999999999999 !important;
+}
+._tooltip_1y9lk_1 a {
+  color: var(--text-primary-inverted) !important;
+  text-decoration: underline;
+}
+._tooltip_1y9lk_1 .ant-tooltip-inner {
+  background: var(--color-primary-inverted-background) !important;
+  border-radius: var(--border-radius) !important;
+}
+._tooltip_1y9lk_1._hideArrow_1y9lk_13 .ant-tooltip-arrow-content {
+  display: none;
+}
+._icon_1y9lk_17 {
+  --size: var(--size-small);
+  flex-shrink: 0;
+  height: var(--size);
+  width: var(--size);
+}
+._icon_1y9lk_17._medium_1y9lk_23 {
+  --size: var(--size-medium);
+}
+._icon_1y9lk_17._large_1y9lk_26 {
+  --size: var(--size-large);
+}
+
+/* temp_stylePlugin:ni:sha-256;Zb17zRk9KVH1-R37Fs_H-jZN-cF06TgDBbjwyGxTfhg */
+._content_i3h6f_1 {
+  font-size: 14px;
+}
+._popover_i3h6f_5 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow);
+  padding-bottom: 0 !important;
+  padding-left: 0;
+  padding-top: 0;
+  z-index: 10000000000000000 !important;
+}
+._popover_i3h6f_5 .ant-popover-inner {
+  background-color: transparent;
+  border-radius: 0;
+  box-shadow: none;
+}
+._contentContainer_i3h6f_21 {
+  padding-bottom: var(--size-xxSmall);
+}
+._contentContainer_i3h6f_21._large_i3h6f_24 {
+  padding: var(--size-small);
+  padding-bottom: var(--size-xSmall);
+}
+
+/* temp_stylePlugin:ni:sha-256;41iKM81iCmJo5l_FFUs-MxnCihIyl4eEn7GpiAh6zi8 */
+._container_lgd2g_1 {
+  display: flex;
+  margin: 0 auto;
+  position: relative;
+  width: 100%;
+  z-index: 2;
+}
+._container_lgd2g_1 > div {
+  height: 44px;
+  width: 100%;
+}
+._tooltipPopover_lgd2g_13 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  color: var(--text-primary) !important;
+  padding: var(--size-small) 0 !important;
+  transition: scale 0.2s ease-in-out;
+}
+._tooltipPopover_lgd2g_13 > * {
+  padding-left: var(--size-medium) !important;
+  padding-right: var(--size-medium) !important;
+}
+._tooltipPopover_lgd2g_13 > h4 {
+  border-bottom: 1px solid var(--color-gray-300);
+  font-family: var(--header-font-family);
+  font-size: 13px !important;
+  margin-bottom: var(--size-small) !important;
+  padding-bottom: var(--size-xSmall);
+}
+._tooltipPopover_lgd2g_13 > p {
+  color: var(--color-gray-500) !important;
+  font-size: 14px !important;
+  margin: 0 !important;
+}
+._popoverContent_lgd2g_38 {
+  max-height: 300px;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  overflow-y: auto;
+  text-overflow: ellipsis;
+}
+._title_lgd2g_46 {
+  column-gap: var(--size-xSmall);
+  display: flex;
+  font-weight: 700;
+}
+
+/* temp_stylePlugin:ni:sha-256;SIvwWoXX5S9aMHYEHTRPFYV6CYA4cbnkc7AaNO4iVE0 */
+._skeleton_clrr7_1 {
+  border-radius: var(--border-radius);
+}
+
+/* temp_stylePlugin:ni:sha-256;pUOh6dlxWNM5YiB7uv9B-7CadczSgDpVBPrr29hl1pg */
+._highlighterStyles_1qb5d_1 {
+  background-color: transparent;
+  font-weight: 600 !important;
+  padding: 0;
+}
+
+/* temp_stylePlugin:ni:sha-256;puCT_asvt5wqVbnwJ5BCIgFzqJl3WEEYuLv5WBMdCu0 */
+._tooltipOverlay_1cgd2_1 {
+  z-index: 10000000000000000 !important;
+}
+._tooltipOverlay_1cgd2_1 a {
+  color: var(--text-primary-inverted) !important;
+  text-decoration: underline;
+}
+._tooltipOverlay_1cgd2_1 table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  width: 100%;
+}
+._tooltipOverlay_1cgd2_1 table td:first-of-type {
+  padding-right: var(--size-small);
+}
+._tooltipOverlay_1cgd2_1 .ant-tooltip-inner {
+  background: var(--color-primary-inverted-background) !important;
+  border-radius: var(--border-radius) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;VqHqkHRLUODM7V0uUkE7To1d_RwRNdmwWea5XX27zLk */
+._input_eommn_1 {
+  background: var(--color-gray-200) !important;
+  border: 1px solid transparent !important;
+  border-radius: var(--border-radius) !important;
+  color: var(--text-primary) !important;
+  font-size: 16px !important;
+  line-height: initial !important;
+  padding: var(--size-xSmall) var(--size-small) !important;
+}
+._input_eommn_1.ant-input-lg {
+  padding: var(--size-xSmall) var(--size-small) !important;
+}
+._input_eommn_1 .ant-input-sm {
+  padding: var(--size-xxSmall) var(--size-xxSmall) !important;
+}
+._input_eommn_1 .ant-input-sm ~ .ant-input-suffix svg {
+  height: var(--size-small) !important;
+  width: var(--size-small) !important;
+}
+._input_eommn_1.ant-input-group-wrapper {
+  align-items: center;
+  display: flex;
+  overflow: hidden !important;
+  padding: 0 !important;
+  transition: all 0.3s;
+}
+._input_eommn_1.ant-input-group-wrapper .ant-input:hover,
+._input_eommn_1.ant-input-group-wrapper .ant-input:focus,
+._input_eommn_1.ant-input-group-wrapper .ant-input {
+  border-color: transparent !important;
+  box-shadow: none !important;
+  color: var(--text-primary) !important;
+  font-size: 16px !important;
+  height: 100%;
+  line-height: initial !important;
+  padding: 10px !important;
+}
+._input_eommn_1.ant-input-group-wrapper .ant-input-group-addon {
+  background: transparent !important;
+  border-color: transparent !important;
+}
+._input_eommn_1.ant-input-group-wrapper .ant-input-wrapper.ant-input-group {
+  height: 100%;
+  overflow: hidden;
+}
+._input_eommn_1.ant-input-group-wrapper:focus,
+._input_eommn_1.ant-input-group-wrapper:active,
+._input_eommn_1.ant-input-group-wrapper:focus-within {
+  background: var(--color-primary-background) !important;
+  border-color: var(--color-purple) !important;
+  box-shadow: 0 0 0 4px rgba(var(--color-purple-rgb), 0.2) !important;
+}
+._input_eommn_1.ant-input-group-wrapper:focus .ant-input,
+._input_eommn_1.ant-input-group-wrapper:active .ant-input,
+._input_eommn_1.ant-input-group-wrapper:focus-within .ant-input {
+  background: var(--color-primary-background) !important;
+}
+._input_eommn_1.ant-input-affix-wrapper,
+._input_eommn_1 .ant-input {
+  background: var(--color-gray-200) !important;
+  color: var(--text-primary) !important;
+}
+._input_eommn_1 .ant-input-clear-icon {
+  color: var(--color-gray-500) !important;
+}
+._input_eommn_1.ant-input-affix-wrapper-sm {
+  padding: 0 var(--size-xSmall) !important;
+}
+._input_eommn_1:not(.ant-input-affix-wrapper-disabled) .ant-input {
+  background: var(--color-gray-200) !important;
+}
+._input_eommn_1:not(.ant-input-affix-wrapper-disabled) .ant-input::placeholder {
+  color: var(--color-gray-500) !important;
+}
+._input_eommn_1:not(.ant-input-affix-wrapper-disabled):focus,
+._input_eommn_1:not(.ant-input-affix-wrapper-disabled).ant-input-affix-wrapper-focused {
+  background: var(--color-primary-background) !important;
+  border-color: var(--color-purple) !important;
+  box-shadow: 0 0 0 4px rgba(var(--color-purple-rgb), 0.2) !important;
+}
+._input_eommn_1:not(.ant-input-affix-wrapper-disabled):focus .ant-input,
+._input_eommn_1:not(.ant-input-affix-wrapper-disabled).ant-input-affix-wrapper-focused .ant-input {
+  background: var(--color-primary-background) !important;
+}
+._input_eommn_1:not(.ant-input-affix-wrapper-disabled):hover {
+  border-color: var(--color-purple) !important;
+}
+._input_eommn_1.ant-input-affix-wrapper-disabled {
+  background: var(--color-gray-200) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;5weElp2go83xEHG9NXNousawCrqJcscuzyyhAUCwPZc */
+._modal_u71tu_1 {
+  max-width: 60vw;
+  pointer-events: unset;
+}
+._modal_u71tu_1 .ant-modal-content {
+  border-radius: var(--border-radius) !important;
+}
+._modalContent_u71tu_9 {
+  overflow: visible;
+}
+._title_u71tu_13 {
+  margin-bottom: var(--size-medium) !important;
+}
+._modalWrap_u71tu_17 {
+  z-index: 999999999;
+}
+
+/* temp_stylePlugin:ni:sha-256;11R5fzJLBjsCCsE6XWnkB1NRfXi21lhbe4yvgPvzEow */
+._modalBody_nihhy_1 {
+  padding: 0;
+}
+
+/* temp_stylePlugin:ni:sha-256;Fb-QI6Zf-ufy2t_PaZLEKU1lFSZ4IpST6uiqkY-Sb18 */
+._modalWrapper_1x9k5_1 {
+  width: 60vh;
+}
+._modalSubTitle_1x9k5_5 {
+  color: var(--color-gray-500) !important;
+  font-size: 16px;
+  line-height: 1.5 !important;
+  margin-top: 0 !important;
+}
+._queryBuilderContainer_1x9k5_12 {
+  margin-bottom: var(--size-large) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;JgnfpYQwLH-fpbf6uebt1w9_twcRh4QOore5Oma50oU */
+._segmentPickerMenu_10cqr_1 {
+  box-shadow: none;
+  font-family: var(--header-font-family);
+  margin-bottom: 12px;
+  min-width: 200px;
+  width: 100%;
+}
+._segmentPickerInner_10cqr_9 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: 8px;
+  color: var(--text-primary);
+  min-width: 220px;
+}
+._segmentPickerInner_10cqr_9 ._segmentItemWrapper_10cqr_16:last-child ._segmentItem_10cqr_16 {
+  border-bottom: 0;
+}
+._downIcon_10cqr_20 {
+  color: var(--color-purple);
+  height: 14px;
+  margin-left: auto;
+  margin-right: 5px;
+  transition: 0.4s;
+  width: 14px;
+}
+._checkIcon_10cqr_29 {
+  color: var(--color-purple);
+  fill: var(--color-purple);
+  height: 15px;
+  margin-bottom: 2px;
+  margin-left: auto;
+  margin-right: 5px;
+  width: 15px;
+}
+._trashIcon_10cqr_39 {
+  color: var(--color-gray-500);
+  fill: var(--color-gray-500);
+  margin-bottom: 2px;
+}
+._segmentAction_10cqr_45 {
+  align-items: center;
+  background-color: var(--color-gray-200);
+  border: 0;
+  border-radius: 5px;
+  bottom: 0;
+  display: none;
+  height: 30px;
+  margin: auto;
+  padding: 0 6px;
+  position: absolute;
+  right: 5px;
+  top: 0;
+  width: 30px;
+}
+._segmentAction_10cqr_45:hover {
+  background-color: var(--color-gray-300);
+  cursor: pointer;
+}
+._segmentAction_10cqr_45:hover ._trashIcon_10cqr_39 {
+  color: var(--text-primary);
+  fill: var(--text-primary);
+}
+._dropdownHandler_10cqr_69 {
+  align-items: center;
+  border: 1px solid var(--color-gray-300);
+  border-radius: 8px;
+  color: var(--text-primary);
+  cursor: pointer;
+  display: flex;
+  font-size: 16px;
+  height: 40px;
+  justify-content: center;
+  margin-top: 13px;
+  padding: 10px;
+  padding-left: 14px;
+  width: 100%;
+}
+._plusIcon_10cqr_85 {
+  color: var(--color-purple);
+  fill: var(--color-purple);
+  height: 15px;
+  margin-bottom: 2px;
+  margin-left: auto;
+  margin-right: 5px;
+  width: 15px;
+}
+._newSearchDiv_10cqr_95 {
+  align-items: center;
+  color: var(--color-purple);
+  cursor: pointer;
+  display: flex;
+  font-size: 14px;
+  padding: 10px;
+  padding-left: 15px;
+  width: 100%;
+}
+._newSearchDiv_10cqr_95:hover {
+  background-color: var(--color-gray-200);
+}
+._noSegmentsText_10cqr_110 {
+  color: var(--color-gray-500);
+  margin-top: 10px;
+}
+._segmentItemWrapper_10cqr_16 {
+  position: relative;
+}
+._segmentItemWrapper_10cqr_16:hover {
+  background-color: var(--color-gray-200);
+}
+._segmentItemWrapper_10cqr_16:hover ._segmentAction_10cqr_45 {
+  display: flex;
+}
+._segmentItem_10cqr_16 {
+  align-items: center;
+  border-bottom: 1px solid var(--color-gray-300);
+  cursor: pointer;
+  display: flex;
+  font-size: 16px;
+  padding: 10px;
+  padding-left: 15px;
+  width: 100%;
+}
+._segmentText_10cqr_136 {
+  color: var(--text-primary);
+  font-size: 14px;
+  margin-right: 20px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+._segmentUnselected_10cqr_146 {
+  color: var(--color-gray-500);
+}
+._segmentNameText_10cqr_150 {
+  display: block;
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+._modalWrapper_10cqr_159 {
+  width: 60vh;
+}
+._modalSubTitle_10cqr_163 {
+  color: var(--color-gray-500) !important;
+  font-size: 14px;
+  margin-bottom: 20px;
+  margin-top: 0 !important;
+}
+._actionsContainer_10cqr_170 {
+  column-gap: var(--size-medium);
+  display: flex;
+  padding-top: var(--size-medium);
+}
+._actionsContainer_10cqr_170 > button {
+  flex-grow: 1;
+  justify-content: center;
+}
+
+/* temp_stylePlugin:ni:sha-256;tCo5ZLTdL-0yjXdwFbndLgIJS4FhZ21YMHY8PnjI0nY */
+._commonInputWrapper_z8rd3_1 {
+  padding: 10px 0;
+}
+._searchInput_z8rd3_5 {
+  padding-top: 0;
+}
+._switchSpan_z8rd3_9 {
+  display: inline-block;
+  line-height: normal;
+  vertical-align: middle;
+}
+._datePicker_z8rd3_15 {
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--size-xSmall);
+  font-family: var(--header-font-family);
+  font-size: 14px;
+  font-weight: 300 !important;
+  height: 45px;
+  width: 100%;
+}
+._iconWrapper_z8rd3_25 {
+  display: flex;
+  margin: 0 10px 0 0;
+}
+._iconWrapper_z8rd3_25 > svg {
+  color: var(--color-gray-400) !important;
+  height: var(--size-medium);
+  width: var(--size-medium);
+}
+._iconWrapper_z8rd3_25 > svg._fill_z8rd3_34 {
+  color: var(--color-gray-400) !important;
+  fill: none !important;
+}
+._subTitle_z8rd3_39 {
+  color: var(--text-primary);
+  font-size: 11px;
+  margin-bottom: 8px;
+  margin-top: 10px;
+}
+._checkboxUnselected_z8rd3_46 {
+  color: var(--color-gray-500);
+}
+._select_z8rd3_50 {
+  width: 100%;
+}
+._selectWithIconContainer_z8rd3_54 {
+  position: relative;
+  width: 100%;
+}
+._icon_z8rd3_25 {
+  color: var(--color-gray-400);
+  height: var(--size-medium);
+  position: absolute;
+  right: 10px;
+  top: 15px;
+  width: var(--size-medium);
+}
+
+/* temp_stylePlugin:ni:sha-256;x1xT-MuTUeZpYnlTbsdDjia7zKlBrBDleub1Bv0HwtQ */
+._sessionLengthInput_igdy7_1 {
+  height: 100%;
+  padding: 12px;
+  width: 300px;
+}
+._sessionLengthInputLabel_igdy7_7 {
+  color: var(--text-primary);
+  font-size: 12px;
+}
+._slider_igdy7_12 .ant-slider-mark-text {
+  font-size: 12px !important;
+}
+._headerContainer_igdy7_16 {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--size-xxSmall);
+}
+._headerContainer_igdy7_16 button {
+  color: var(--color-purple);
+  font-size: 12px;
+  height: 13px !important;
+  padding: 0;
+}
+._advancedLengthInput_igdy7_29 {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--size-xSmall);
+}
+._advancedLengthInput_igdy7_29 ._group_igdy7_34 {
+  display: flex;
+  height: 43px;
+}
+._advancedLengthInput_igdy7_29 ._group_igdy7_34 input {
+  border: 1px solid var(--color-gray-300);
+  width: 100px;
+}
+._buttonContainer_igdy7_43 {
+  display: flex;
+  justify-content: flex-end;
+}
+._setLengthButton_igdy7_48 {
+  font-size: 12px;
+  height: fit-content;
+  width: fit-content;
+}
+._3x527v0 {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+._3x527v1 {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+._3x527v2 {
+  display: inline-flex;
+  height: 20px;
+}
+._3x527v3 {
+  height: 20px;
+  width: 20px;
+}
+._3x527v4 {
+  flex: 1;
+  word-break: normal;
+  white-space: nowrap;
+}
+._3x527v5 {
+  flex: 1;
+}
+._3x527v6 {
+  flex-shrink: 0;
+}
+._3x527v7 {
+  max-width: 50%;
+}
+
+/* temp_stylePlugin:ni:sha-256;LtXQFuh7m9cBiR5lOVI7iVSOjVdsX-AxpS1I8xwak1s */
+._optionLabelContainer_1yzqu_1 {
+  align-items: center;
+  display: flex;
+  overflow: hidden;
+  position: relative;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+._optionCheckbox_1yzqu_10 {
+  margin-right: 12px;
+}
+._optionLabelType_1yzqu_14 {
+  background: var(--color-gray-300);
+  border-radius: 3px;
+  color: var(--text-primary) !important;
+  margin-right: 6px;
+  padding-left: 4px;
+  padding-right: 4px;
+  width: fit-content;
+}
+._labelTypeContainer_1yzqu_24 {
+  width: 60px;
+}
+._highlighterStyles_1yzqu_28 {
+  background-color: transparent;
+  font-weight: 600 !important;
+  padding: 0;
+}
+._shadowParent_1yzqu_34 {
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+}
+._shadowContainer_1yzqu_41 {
+  height: 100%;
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 100000000000000020 !important;
+}
+._shadowRight_1yzqu_51 {
+  background-attachment: scroll;
+  background-image: linear-gradient(to left, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
+  background-position: right center;
+  background-repeat: no-repeat;
+  background-size: 20px 100%;
+  transition: background-image 0.2s ease-in-out;
+}
+._shadowLeft_1yzqu_60 {
+  background-attachment: scroll;
+  background-image: linear-gradient(to right, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
+  background-position: left center;
+  background-repeat: no-repeat;
+  background-size: 20px 100%;
+  transition: background-image 0.2s ease-in-out;
+}
+._shadowBoth_1yzqu_69 {
+  background-attachment: scroll, scroll;
+  background-image: linear-gradient(to right, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0)), linear-gradient(to left, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
+  background-position: left center, right center;
+  background-repeat: no-repeat;
+  background-size: 20px 100%, 20px 100%;
+  transition: background-image 0.2s ease-in-out;
+}
+._optionLabelName_1yzqu_78 {
+  color: var(--text-primary) !important;
+  overflow-x: scroll;
+  padding-bottom: 8px;
+  padding-top: 8px;
+  scrollbar-width: none;
+}
+._optionLabelName_1yzqu_78::-webkit-scrollbar {
+  display: none;
+}
+._nameLabel_1yzqu_89 {
+  color: var(--text-primary) !important;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._optionTooltip_1yzqu_97 {
+  color: var(--text-primary) !important;
+  margin-left: 4px;
+}
+._builderContainer_1yzqu_102 {
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+._builderContainer_1yzqu_102 > div {
+  border-bottom: 1px solid var(--color-gray-300);
+  gap: var(--size-xSmall);
+  line-height: 0;
+  padding: var(--size-xSmall);
+}
+._builderContainer_1yzqu_102 > div:last-child {
+  border-bottom: 0;
+}
+._rulesContainer_1yzqu_121 {
+  align-items: center;
+  column-gap: var(--size-xxSmall);
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  row-gap: var(--size-xSmall);
+}
+._separator_1yzqu_130 {
+  border: 0;
+  font-size: 12px;
+  justify-content: center;
+  padding: 3px;
+  width: 32px;
+}
+._separator_1yzqu_130[disabled] {
+  background: none;
+  color: var(--color-gray-800) !important;
+}
+._separator_1yzqu_130:hover {
+  background: none !important;
+}
+._separator_1yzqu_130:hover:not([disabled]) {
+  background-color: var(--color-purple-100) !important;
+}
+span:first-child ._ruleItem_1yzqu_148 {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+}
+span:last-child ._ruleItem_1yzqu_148 {
+  border-bottom-right-radius: 3px;
+  border-top-right-radius: 3px;
+}
+._invalid_1yzqu_158 {
+  background-color: var(--color-red-400) !important;
+}
+._invalid_1yzqu_158:hover {
+  background-color: var(--color-red-600) !important;
+}
+._timeRangeContainer_1yzqu_165 ._ruleItem_1yzqu_148 span {
+  max-width: 100%;
+}
+._removeRule_1yzqu_169 {
+  border-bottom-right-radius: 3px;
+  border-top-right-radius: 3px;
+}
+._syncButton_1yzqu_174,
+._syncButton_1yzqu_174[disabled],
+._syncButton_1yzqu_174:active,
+._syncButton_1yzqu_174:focus,
+._syncButton_1yzqu_174:hover {
+  background-color: var(--color-green-600) !important;
+  border-radius: 3px;
+  color: var(--color-white) !important;
+  padding: 6px;
+}
+._syncButton_1yzqu_174:hover {
+  opacity: 0.6;
+}
+._syncButton_1yzqu_174[disabled] {
+  opacity: 0.2;
+}
+._addFilter_1yzqu_193 {
+  border: 1px dashed var(--color-purple-500);
+  border-radius: 3px;
+  color: var(--color-purple-500) !important;
+  font-size: 12px;
+  height: 100%;
+  margin-top: var(--size-xSmall);
+  padding: 0 4px;
+}
+._menuListContainer_1yzqu_203 {
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+._menuListContainer_1yzqu_203::-webkit-scrollbar {
+  display: none;
+}
+._popoverContainer_1yzqu_211 {
+  width: fit-content;
+}
+._popoverContainer_1yzqu_211 .ant-popover-inner-content {
+  padding: 0;
+}
+._contentContainer_1yzqu_218 {
+  display: flex;
+  flex-direction: column;
+  max-width: 50vw;
+  min-width: 150px;
+  padding-bottom: 0;
+  row-gap: var(--size-medium);
+}
+._contentContainer_1yzqu_218 ._label_1yzqu_24 {
+  display: flex;
+  flex-direction: column;
+  font-size: 10px;
+  row-gap: var(--size-xxSmall);
+}
+._controlBar_1yzqu_233 {
+  flex-shrink: 0;
+  height: 44px;
+}
+._menuList_1yzqu_203 {
+  overflow: hidden;
+  padding-top: 0;
+  z-index: 5;
+}
+._1ukfp2a0 {
+  border-radius: 0;
+  border: 0 !important;
+}
+._1ukfp2a0:focus,
+._1ukfp2a0:active {
+  background: inherit;
+}
+._1ukfp2a1 {
+  border-right: var(--_1pyqka91o) solid 1px !important;
+}
+._1ukfp2a2 {
+  background: var(--_1pyqka9t);
+}
+._1ukfp2a2:focus,
+._1ukfp2a2:active {
+  background: var(--_1pyqka9u);
+}
+
+/* temp_stylePlugin:ni:sha-256;cjUQ68xQ3D0AfNnYjZhH0ZnDUhPluWo4BzWLROzSB-0 */
+._modalSubTitle_6e4mp_1 {
+  color: var(--color-gray-500) !important;
+  font-size: 16px;
+  line-height: 1.5 !important;
+  margin-top: 0 !important;
+}
+._queryBuilderContainer_6e4mp_8 {
+  margin-bottom: var(--size-large) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;VxNfg_v_Z0qUGtlkSUmcNbhGPcC-3BQsSUwACK0QBCI */
+._segmentPickerMenu_16b00_1 {
+  box-shadow: none;
+  margin-bottom: 12px;
+  min-width: 200px;
+  width: 100%;
+}
+._segmentPickerInner_16b00_8 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: 5px;
+  color: var(--text-primary);
+  min-width: 220px;
+}
+._segmentPickerInner_16b00_8 ._segmentItemWrapper_16b00_15:last-child ._segmentItem_16b00_15 {
+  border-bottom: 0;
+}
+._downIcon_16b00_19 {
+  color: var(--color-purple);
+  height: 14px;
+  margin-left: auto;
+  margin-right: 5px;
+  transition: 0.4s;
+  width: 14px;
+}
+._checkIcon_16b00_28 {
+  color: var(--color-purple);
+  fill: var(--color-purple);
+  height: 15px;
+  margin-bottom: 2px;
+  margin-left: auto;
+  margin-right: 5px;
+  width: 15px;
+}
+._trashIcon_16b00_38 {
+  color: var(--color-gray-500);
+  fill: var(--color-gray-500);
+  margin-bottom: 2px;
+}
+._starIcon_16b00_44 {
+  color: var(--text-primary);
+  fill: var(--text-primary);
+  height: 1rem;
+  margin-bottom: 2px;
+  margin-left: 6px;
+  padding: 1px;
+}
+._segmentAction_16b00_53 {
+  align-items: center;
+  background-color: var(--color-gray-200);
+  border: 0;
+  border-radius: 5px;
+  bottom: 0;
+  display: none;
+  height: 30px;
+  margin: auto;
+  padding: 0 6px;
+  position: absolute;
+  right: 5px;
+  top: 0;
+  width: 30px;
+}
+._segmentAction_16b00_53:hover {
+  background-color: var(--color-gray-300);
+  cursor: pointer;
+}
+._segmentAction_16b00_53:hover ._trashIcon_16b00_38 {
+  color: var(--text-primary);
+  fill: var(--text-primary);
+}
+._dropdownHandler_16b00_77 {
+  align-items: center;
+  border: 1px solid var(--color-gray-300);
+  border-radius: 8px;
+  color: var(--text-primary);
+  cursor: pointer;
+  display: flex;
+  font-size: 16px;
+  height: 40px;
+  justify-content: center;
+  margin-top: 13px;
+  padding: 10px;
+  padding-left: 14px;
+  width: 100%;
+}
+._plusIcon_16b00_93 {
+  color: var(--color-purple);
+  fill: var(--color-purple);
+  height: 15px;
+  margin-bottom: 2px;
+  margin-left: auto;
+  margin-right: 5px;
+  width: 15px;
+}
+._newSearchDiv_16b00_103 {
+  align-items: center;
+  color: var(--color-purple);
+  cursor: pointer;
+  display: flex;
+  font-size: 14px;
+  padding: 10px;
+  padding-left: 15px;
+  width: 100%;
+}
+._newSearchDiv_16b00_103:hover {
+  background-color: var(--color-gray-200);
+}
+._noSegmentsText_16b00_118 {
+  color: var(--color-gray-500);
+  margin-top: 10px;
+}
+._segmentItemWrapper_16b00_15 {
+  position: relative;
+}
+._segmentItemWrapper_16b00_15:hover {
+  background-color: var(--color-gray-200);
+}
+._segmentItemWrapper_16b00_15:hover ._segmentAction_16b00_53 {
+  display: flex;
+}
+._segmentItem_16b00_15 {
+  align-items: center;
+  border-bottom: 1px solid var(--color-gray-300);
+  cursor: pointer;
+  display: flex;
+  font-size: 16px;
+  padding: 10px;
+  padding-left: 15px;
+  width: 100%;
+}
+._segmentText_16b00_144 {
+  color: var(--text-primary);
+  font-size: 14px;
+  margin-right: 20px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+._segmentUnselected_16b00_154 {
+  color: var(--color-gray-500);
+}
+._segmentUnselected_16b00_154 ._starIcon_16b00_44 {
+  color: var(--color-gray-500);
+  fill: var(--color-gray-500);
+}
+._segmentNameText_16b00_162 {
+  display: block;
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+._liveSessionsSegment_16b00_171 {
+  align-items: center;
+  display: flex;
+}
+._liveSessionsCount_16b00_176 {
+  align-items: center;
+  background: var(--color-purple);
+  border-radius: 13px;
+  color: var(--color-primary-background);
+  display: flex;
+  font-size: 10px;
+  gap: var(--size-xSmall);
+  height: 20px;
+  justify-content: center;
+  line-height: normal;
+  margin-left: var(--size-xSmall);
+  min-width: 20px;
+  padding: 0 7px;
+}
+._liveSessionsCountInactive_16b00_192 {
+  opacity: 0.5;
+}
+._modalSubTitle_16b00_196 {
+  color: var(--color-gray-500) !important;
+  margin-bottom: 20px;
+  margin-top: 0 !important;
+}
+._actionsContainer_16b00_202 {
+  column-gap: var(--size-medium);
+  display: flex;
+  padding-top: var(--size-medium);
+}
+._actionsContainer_16b00_202 > button {
+  flex-grow: 1;
+  justify-content: center;
+}
+
+/* temp_stylePlugin:ni:sha-256;tffipz9fm2ubrBw4Ewg55SQsVOwLi1QdTWz92dhHZDM */
+._select_1kghn_1 {
+  border-radius: var(--border-radius);
+  color: var(--text-primary) !important;
+  transition: all 0.2s ease-in-out;
+}
+._select_1kghn_1 .ant-select-selector {
+  background-color: var(--color-primary-background) !important;
+  border: 1px solid var(--color-gray-300) !important;
+  border-radius: var(--border-radius) !important;
+  font-family: var(--body-font-family);
+  height: fit-content !important;
+  padding: var(--size-xSmall) var(--size-small) !important;
+  transition: all 0.2s ease-in-out;
+}
+._select_1kghn_1 .ant-select-selection-placeholder {
+  color: var(--color-gray-500) !important;
+  left: var(--size-small);
+}
+._select_1kghn_1 .ant-select-selection-search {
+  margin-left: 0 !important;
+}
+._select_1kghn_1 .ant-select-arrow {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 18px;
+  width: 18px;
+}
+._select_1kghn_1 .ant-select-arrow > svg {
+  height: 100%;
+  position: relative;
+  right: -2px;
+  top: -4px;
+  width: 100%;
+}
+._select_1kghn_1 .ant-select-clear {
+  background: var(--color-primary-background);
+  color: var(--color-gray-400);
+}
+._select_1kghn_1.ant-select-disabled .ant-select-selector {
+  background: var(--color-gray-300) !important;
+}
+._select_1kghn_1.ant-select-multiple .ant-select-selection-item {
+  background-color: var(--color-gray-200) !important;
+  border-color: var(--color-gray-200) !important;
+}
+._select_1kghn_1 .ant-select-selection-item-remove {
+  color: var(--color-gray-700) !important;
+}
+._select_1kghn_1.ant-select-borderless .ant-select-selector {
+  background: transparent !important;
+  border-color: transparent !important;
+  color: var(--text-primary) !important;
+}
+._select_1kghn_1.ant-select-borderless .ant-select-selector:active,
+._select_1kghn_1.ant-select-borderless .ant-select-selector:focus,
+._select_1kghn_1.ant-select-borderless .ant-select-selector:focus-within,
+._select_1kghn_1.ant-select-borderless .ant-select-selector:focus-visible {
+  box-shadow: none !important;
+  outline-color: transparent !important;
+}
+._select_1kghn_1.ant-select-borderless.ant-select-focused:not(.ant-select-disabled).ant-select:not(.ant-select-customize-input) .ant-select-selector {
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+._dropdownIcon_1kghn_65 {
+  display: inline;
+}
+._dropdownIcon_1kghn_65 ._icon_1kghn_68 {
+  display: none;
+}
+.ant-select-dropdown {
+  z-index: 100000000000000020 !important;
+}
+._dropdown_1kghn_65 {
+  background-color: var(--color-primary-background) !important;
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow);
+  padding-bottom: 0 !important;
+  padding-top: 0 !important;
+  z-index: 100000000000000020 !important;
+}
+._dropdown_1kghn_65 .ant-select-item-option-selected {
+  color: var(--color-white) !important;
+}
+._dropdown_1kghn_65 .ant-select-item-option-content {
+  align-items: center;
+  display: flex;
+}
+._dropdown_1kghn_65 ._dropdownIcon_1kghn_65 {
+  align-items: center;
+  display: flex;
+}
+._dropdown_1kghn_65 ._dropdownIcon_1kghn_65 ._icon_1kghn_68 {
+  display: contents;
+  width: 100%;
+}
+
+/* temp_stylePlugin:ni:sha-256;kuAvMOOt9YmubiHQswsa4nJR1GR2dKQIKgsfe8wHDtg */
+._popover_6rlz1_1 {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: var(--size-medium);
+  row-gap: var(--size-medium);
+  width: 250px;
+}
+._popover_6rlz1_1 ._label_6rlz1_8 {
+  display: flex;
+  flex-direction: column;
+  font-size: 10px;
+  row-gap: var(--size-xxSmall);
+}
+.niznha0 {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.niznha1 {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.niznha2 {
+  display: inline-flex;
+  height: 20px;
+}
+.niznha3 {
+  height: 20px;
+  width: 20px;
+}
+.niznha4 {
+  flex: 1;
+  word-break: normal;
+  white-space: nowrap;
+}
+.niznha5 {
+  flex: 1;
+}
+.niznha6 {
+  flex-shrink: 0;
+}
+.niznha7 {
+  max-width: 50%;
+}
+
+/* temp_stylePlugin:ni:sha-256;KPmzgWQPzijpGyC1S4AlK46qFjF9gx3Sn71GP_oa8mg */
+._card_lh268_1 {
+  background: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow-2);
+  color: var(--text-primary);
+  max-width: 500px;
+  padding-bottom: var(--size-xLarge);
+  padding-left: var(--size-xLarge);
+  padding-right: var(--size-xLarge);
+  padding-top: var(--size-xLarge);
+}
+._card_lh268_1._center_lh268_13 {
+  text-align: center;
+}
+._card_lh268_1 h2 {
+  color: var(--text-primary);
+  font-size: 24px;
+  margin: 0;
+  margin-bottom: var(--size-medium);
+}
+._card_lh268_1 p {
+  color: var(--color-gray-500);
+  margin-bottom: 0 !important;
+}
+._card_lh268_1 ._content_lh268_26 {
+  font-size: 16px;
+  max-width: 400px;
+  word-wrap: break-word;
+}
+._card_lh268_1 ._animation_lh268_31 {
+  margin: 0 auto;
+  margin-bottom: var(--size-large);
+  width: 250px;
+}
+._card_lh268_1 ._actions_lh268_36 {
+  margin-top: var(--size-xLarge);
+}
+
+/* temp_stylePlugin:ni:sha-256;rgKsUI61Mjbx0SfCZS9Sl6VV8xr6u2hGA56RzaZNNp0 */
+._elevatedCard_t9uz9_1 {
+  --width: 400px;
+  height: calc(100% - 2 * var(--size-medium));
+  overflow-y: auto;
+  padding-bottom: var(--size-small);
+  padding-left: var(--size-large);
+  padding-right: var(--size-large);
+  padding-top: var(--size-small);
+  width: var(--width);
+}
+._backdrop_t9uz9_12 {
+  background: rgba(0, 0, 0, 0.25);
+  inset: 0;
+  opacity: 1;
+  position: fixed;
+  z-index: 999999999;
+}
+._elevatedCardMotion_t9uz9_20 {
+  height: calc(100% - (var(--size-medium)));
+  position: fixed;
+  right: var(--size-medium);
+  top: var(--size-medium);
+  z-index: 9999999999;
+}
+._searchIcon_t9uz9_28 {
+  color: var(--color-gray-500);
+}
+._container_t9uz9_32 {
+  padding-top: var(--size-large);
+}
+._container_t9uz9_32 section {
+  padding-top: var(--size-large);
+}
+._container_t9uz9_32 table {
+  width: 100%;
+}
+._container_t9uz9_32 tr {
+  width: 100%;
+}
+._container_t9uz9_32 tr:not(:last-of-type) td {
+  padding-bottom: var(--size-small);
+}
+._container_t9uz9_32 p {
+  font-size: 13px !important;
+}
+._container_t9uz9_32 h3 {
+  font-size: 16px !important;
+  margin-bottom: var(--size-small) !important;
+}
+._kbdContainer_t9uz9_55 {
+  column-gap: var(--size-xxSmall);
+  display: flex;
+}
+._kbd_t9uz9_55 {
+  align-items: center;
+  background: var(--color-gray-200);
+  border-radius: var(--size-xxSmall);
+  display: flex;
+  font-family: var(--monospace-font-family);
+  font-size: 11px;
+  justify-content: center;
+  min-width: 20px;
+  padding-bottom: var(--size-xxSmall);
+  padding-left: var(--size-xxSmall);
+  padding-right: var(--size-xxSmall);
+  padding-top: var(--size-xxSmall);
+  text-transform: capitalize;
+}
+._kbd_t9uz9_55._symbol_t9uz9_75 {
+  font-size: 16px;
+  line-height: 0px;
+}
+._description_t9uz9_80 {
+  color: var(--color-gray-800);
+  font-size: 13px;
+  padding-right: var(--size-medium);
+}
+._shortcutContainer_t9uz9_86 {
+  display: flex;
+  justify-content: flex-end;
+}
+._emptyTitle_t9uz9_91 {
+  text-transform: capitalize;
+}
+._emptyDescription_t9uz9_95 {
+  margin-top: 0 !important;
+  text-align: center;
+}
+._disabled_t9uz9_100 {
+  cursor: not-allowed;
+  filter: opacity(0.3);
+}
+._titleContainer_t9uz9_105 {
+  align-items: center;
+  display: flex;
+}
+._suggestionButton_t9uz9_110 {
+  align-items: center;
+  background: var(--color-gray-300) !important;
+  color: var(--text-primary) !important;
+  column-gap: var(--size-small);
+  display: flex;
+  font-size: 12px;
+  margin-left: auto;
+  padding-bottom: var(--size-xSmall);
+  padding-left: var(--size-small);
+  padding-right: var(--size-small);
+  padding-top: var(--size-xSmall);
+}
+._suggestionButton_t9uz9_110:hover {
+  color: var(--text-primary);
+}
+._suggestionButton_t9uz9_110._cta_t9uz9_126 {
+  background: var(--color-purple);
+  color: var(--text-primary-inverted);
+  font-weight: 500;
+  margin: 0 auto;
+  margin-top: var(--size-large);
+}
+._1ek953u0 {
+  z-index: 99999;
+  background-color: rgba(111, 110, 119, 0.48);
+  height: 100vh;
+  width: 100vw;
+  display: flex;
+  justify-content: center;
+}
+._1ek953u1 {
+  width: 580px;
+  top: 25vh;
+}
+._1ek953u2 {
+  width: 100%;
+}
+._1ek953u3 {
+  flex-shrink: 0;
+}
+._1ek953u4 {
+  flex-shrink: 0;
+}
+._1ek953u5 {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+._1ek953u6 {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+._1ek953u7 {
+  flex: 1;
+}
+._1ek953u8:hover {
+  cursor: pointer;
+}
+.bsyaa20 {
+  text-decoration: none;
+  color: var(--_1pyqka9y);
+}
+.bsyaa20:hover {
+  color: var(--_1pyqka9y);
+}
+._1kpm5g60 {
+  text-decoration: none;
+}
+._1kpm5g60:focus-visible {
+  outline: revert !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;0ADqhuP96pZ7r4UPHUQNYwt9i101HKDJNZFYz2EsM94 */
+._container_djd1q_1 {
+  font-family: var(--header-font-family);
+}
+._input_djd1q_5 {
+  background: var(--color-primary-background);
+  border: 0;
+  box-sizing: border-box;
+  caret-color: var(--color-purple);
+  color: var(--text-primary);
+  font-size: 14px;
+  margin: var(--size-small);
+  outline: none;
+  padding: 6px;
+  width: stretch;
+}
+._input-focused_djd1q_18 {
+  background-color: var(--text-primary);
+  border-color: var(--color-red-400);
+}
+._suggestion_djd1q_23 {
+  background: var(--color-primary-background);
+  border-left: 5px solid transparent;
+  color: var(--color-gray-700);
+  cursor: pointer;
+  padding: 14px 12px;
+  transition: color 0.2s ease-in-out;
+}
+._suggestion_djd1q_23 b {
+  color: var(--color-purple-600);
+}
+._suggestionsContainerOpen_djd1q_35 {
+  border-bottom: 1px solid var(--color-gray-300);
+  border-top: 1px solid var(--color-gray-300);
+  max-height: 400px;
+  overflow-y: auto;
+}
+._suggestionsContainerOpen_djd1q_35::-webkit-scrollbar {
+  display: none;
+}
+._suggestionHighlighted_djd1q_45 {
+  background: var(--color-gray-300);
+  border-left: 5px solid var(--color-purple);
+  color: var(--text-primary);
+}
+._modal_djd1q_51 {
+  background: var(--color-primary-background);
+  border: 0;
+  border-radius: var(--border-radius);
+  bottom: auto;
+  box-shadow: var(--box-shadow-2);
+  left: 50%;
+  outline: none;
+  overflow: hidden;
+  position: absolute;
+  right: auto;
+  top: 25%;
+  transform: translate(-50%, 0);
+  width: 605px;
+}
+
+/* temp_stylePlugin:ni:sha-256;Oxb-gJeaLALPhMvdTRYom8v_mIFUMtmm1A0ro0M2j0w */
+._suggestion_yf8tj_1 {
+  align-items: center;
+  background: var(--header-font-family);
+  column-gap: var(--size-small);
+  display: flex;
+  font-size: 14px;
+}
+._category_yf8tj_9 {
+  align-items: center;
+  display: flex;
+}
+._category_yf8tj_9 > svg {
+  height: 12px;
+  width: 12px;
+}
+
+/* temp_stylePlugin:ni:sha-256;cSJ37MlNoiPLveG5uiDTeqb1yikgScFuLe-22nURUWQ */
+._trialLink_x1tvd_1 {
+  color: var(--text-primary-inverted) !important;
+  text-decoration: underline;
+}
+._trialWrapper_x1tvd_6 {
+  align-items: center;
+  background-color: #744ed4;
+  color: var(--text-primary-inverted);
+  display: flex;
+  height: var(--banner-height);
+  justify-content: center;
+  width: 100%;
+  z-index: 1000;
+}
+._trialWrapper_x1tvd_6._productHunt_x1tvd_16 {
+  background-color: var(--color-green-600);
+}
+._trialWrapper_x1tvd_6._youtube_x1tvd_19 {
+  background-color: var(--color-red-600);
+}
+._trialWrapper_x1tvd_6._maintenance_x1tvd_22 {
+  background-color: var(--color-purple-600);
+}
+._trialWrapper_x1tvd_6._error_x1tvd_25 {
+  background-color: var(--color-red-400);
+}
+._trialWrapper_x1tvd_6._error_x1tvd_25 button {
+  background: transparent;
+}
+._trialWrapper_x1tvd_6 button {
+  --button-size: var(--size-medium);
+  --icon-size: var(--size-xSmall);
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  height: var(--button-size);
+  justify-content: center;
+  margin-right: var(--size-small);
+  position: absolute;
+  right: 0;
+  transform: scale(1.5);
+  transform-origin: center;
+  transition: all 0.2s ease-in-out;
+  width: var(--button-size);
+}
+._trialWrapper_x1tvd_6 button svg {
+  flex-shrink: 0;
+  height: var(--icon-size);
+  transform-origin: center;
+  transition: all 0.2s ease-in-out;
+  width: var(--icon-size);
+}
+._trialWrapper_x1tvd_6 button:hover {
+  transform: scale(2);
+}
+._trialTimeText_x1tvd_61 {
+  font-size: 12px;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  z-index: 100;
+}
+._trialTimeText_x1tvd_61 a {
+  color: white;
+  text-decoration: underline;
+}
+._homeLink_x1tvd_72 {
+  align-items: center;
+  color: var(--text-primary) !important;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  text-decoration: none;
+}
+._homeLink_x1tvd_72:hover {
+  color: inherit;
+  text-decoration: none;
+}
+._demoLink_x1tvd_86 {
+  color: var(--color-text-primary-inverted) !important;
+  text-decoration: underline;
+}
+._demoLink_x1tvd_86:hover {
+  color: var(--color-gray-400) !important;
+}
+._button_x1tvd_95:first-of-type {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+._button_x1tvd_95:not(:first-of-type) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: 1px solid #dcdbdd;
+}
+
+/* temp_stylePlugin:ni:sha-256;q1X9OSmT1A5N6EmV_Abj7J6r_nhkTjhuzGd8bTjRjug */
+._leadAlignLayout_1i40a_1 {
+  height: min-content;
+  margin: 40px 80px 20px;
+  max-width: 650px;
+  padding-bottom: var(--size-xxLarge);
+  width: 100%;
+}
+._leadAlignLayout_1i40a_1._fullWidth_1i40a_8 {
+  max-width: 100%;
+}
+._leadAlignLayout_1i40a_1 ._subTitle_1i40a_11 {
+  color: var(--color-gray-500);
+  font-size: 18px;
+  margin-bottom: var(--size-xLarge) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;14IPliw4FWr50FC_0ye0ySmsBllOXW4fH4Xfl7ZkJZk */
+._card_iv1eg_1 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  padding: var(--size-large);
+  transition: border-color 0.1s ease-in-out, box-shadow 0.2s ease-in-out;
+  width: 100%;
+}
+._card_iv1eg_1._noPadding_iv1eg_10 {
+  padding: 0;
+}
+._card_iv1eg_1._full_iv1eg_13 {
+  height: 100%;
+}
+._card_iv1eg_1 h2,
+._card_iv1eg_1 ._cardHeader_iv1eg_17 {
+  font-size: 22px !important;
+  margin-bottom: var(--size-medium) !important;
+}
+._card_iv1eg_1 h3 {
+  font-size: 16px !important;
+  margin-bottom: var(--size-xSmall) !important;
+}
+._card_iv1eg_1 p {
+  color: var(--color-gray-500);
+  margin-top: 0 !important;
+}
+._card_iv1eg_1 section {
+  padding-bottom: var(--size-medium);
+}
+._card_iv1eg_1 section:last-of-type {
+  padding-bottom: var(--size-large);
+}
+._card_iv1eg_1 ._titleContainer_iv1eg_35 {
+  border-bottom: 1px solid var(--color-gray-300);
+  font-size: 14px !important;
+  margin: 0 calc(-1 * var(--size-large));
+  margin-bottom: var(--size-small);
+  margin-top: calc(-1 * var(--size-xSmall));
+  padding-bottom: 0;
+  padding-left: var(--size-large);
+  padding-right: var(--size-large);
+  padding-top: 0;
+}
+._card_iv1eg_1 ._titleContainer_iv1eg_35._noTitleBottomMargin_iv1eg_46 {
+  margin-bottom: 0;
+}
+._card_iv1eg_1 ._titleContainer_iv1eg_35 h3 {
+  margin-bottom: var(--size-medium) !important;
+}
+._card_iv1eg_1:hover._interactable_iv1eg_52 {
+  border-color: var(--color-purple);
+  box-shadow: 0 5px 8px rgba(86, 41, 198, 0.2);
+}
+._cardForm_iv1eg_57 {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--size-large);
+}
+._cardSubHeader_iv1eg_63 {
+  color: var(--color-gray-500) !important;
+  font-size: 16px;
+  line-height: 1.5 !important;
+  margin-bottom: var(--size-large) !important;
+}
+._cardFormActionsContainer_iv1eg_70 {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--size-medium);
+}
+
+/* temp_stylePlugin:ni:sha-256;7zFMhkbsV49BpGuKB2yynYFNUGYMWAynACqyfXCmR7Q */
+._integration_14mrc_1 ._logo_14mrc_1 {
+  border-radius: 50%;
+  height: var(--size-xxLarge);
+  width: var(--size-xxLarge);
+}
+._integration_14mrc_1 ._header_14mrc_6 {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: var(--size-small);
+}
+._integration_14mrc_1 ._connectButton_14mrc_12 {
+  text-transform: uppercase;
+}
+._integration_14mrc_1 ._title_14mrc_15 {
+  margin-bottom: var(--size-small) !important;
+}
+._integration_14mrc_1 ._description_14mrc_18 {
+  margin-bottom: 0 !important;
+}
+._modal_14mrc_22 footer {
+  column-gap: var(--size-medium);
+  display: flex;
+  justify-content: flex-end;
+  padding-top: var(--size-large);
+}
+
+/* temp_stylePlugin:ni:sha-256;R2b97LzwyQyFNyOhbbJ-y6dPYUxwYXjkLltS6BNtr1s */
+._normalTableSizing_1oyoa_1 {
+  --padding-x: var(--size-large);
+  --padding-y: var(--size-medium);
+}
+._smallTableSizing_1oyoa_6 {
+  --padding-x: var(--size-medium);
+  --padding-y: var(--size-small);
+}
+._table_1oyoa_11 .ant-table-thead > tr > th {
+  background: transparent !important;
+  border-bottom: 1px solid var(--color-gray-300) !important;
+  border-top: 1px solid var(--color-gray-300) !important;
+  color: var(--color-gray-800) !important;
+  font-weight: normal !important;
+  padding-bottom: var(--size-xSmall) !important;
+  padding-top: var(--size-xSmall) !important;
+}
+._table_1oyoa_11 tr > .ant-table-cell {
+  border-bottom: 1px solid var(--color-gray-300) !important;
+  padding-bottom: var(--padding-y) !important;
+  padding-top: var(--padding-y) !important;
+}
+._table_1oyoa_11 .ant-table-row:last-of-type > .ant-table-cell {
+  border-bottom: 0 !important;
+}
+._table_1oyoa_11 .ant-table-tbody > tr.ant-table-row:hover > td {
+  background: none !important;
+  cursor: auto;
+}
+._table_1oyoa_11 .ant-table {
+  background: var(--color-primary-background);
+  color: var(--text-primary) !important;
+}
+._table_1oyoa_11._interactable_1oyoa_36 .ant-table-tbody > tr.ant-table-row:hover > td {
+  background: var(--color-gray-100) !important;
+  cursor: pointer;
+}
+._table_1oyoa_11 .ant-table-placeholder .ant-table-cell {
+  border-bottom: 0 !important;
+}
+._table_1oyoa_11._rowHasPadding_1oyoa_43 tr > .ant-table-cell:first-of-type {
+  padding-left: var(--padding-x) !important;
+}
+._table_1oyoa_11._rowHasPadding_1oyoa_43 tr > .ant-table-cell:last-of-type {
+  padding-right: var(--padding-x) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;ey01dz_DqMJfkJcv711db1DcJWWT4lJy-KSMInMyP3k */
+._modalBtn_i09bj_1 {
+  padding-bottom: 4px !important;
+  padding-top: 4px !important;
+}
+._modalBtnIcon_i09bj_6 {
+  margin-right: 0.5rem;
+}
+._modalSubTitle_i09bj_10 {
+  color: var(--color-gray-500) !important;
+  font-size: 16px;
+  margin-bottom: 20px;
+  margin-top: 0 !important;
+}
+._modalBtnText_i09bj_17 {
+  align-items: center;
+  display: inline-flex !important;
+  height: 100%;
+}
+._select_i09bj_23 .ant-select-selection-item-content {
+  max-width: 150px;
+}
+._projectInput_i09bj_27 {
+  font-size: 14px !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;unznzyoYNPxlEu0QNcliUPqNrTJuUaDmhosbq-agbQ4 */
+._dot_gor0a_1 {
+  --pulse-color:
+    86,
+    41,
+    198;
+  background-color: var(--color-purple);
+  border-radius: 10px;
+  height: var(--size-xSmall);
+  width: var(--size-xSmall);
+}
+._dotRed_gor0a_9 {
+  --pulse-color:
+    255,
+    0,
+    0;
+  background-color: var(--color-red);
+}
+._pulse_gor0a_14 {
+  animation: _pulse_gor0a_14 2s infinite;
+}
+@keyframes _pulse_gor0a_14 {
+  0% {
+    box-shadow: 0 0 0 0 rgba(var(--pulse-color), 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(var(--pulse-color), 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(var(--pulse-color), 0);
+  }
+}
+
+/* temp_stylePlugin:ni:sha-256;6Or_OCY68IFdqUhoTosz5WpJeh21n67cIVmRu8grNWw */
+._container_1h4bj_1 {
+  align-items: flex-start;
+  row-gap: var(--size-xxSmall);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  max-height: fit-content;
+  min-height: var(--size-xxLarge);
+}
+._switchClass_1h4bj_11 {
+  flex-shrink: 0;
+}
+._select_1h4bj_15 {
+  width: 100%;
+}
+._select_1h4bj_15.ant-select-disabled .ant-select-selector {
+  background-color: var(--color-primary-background) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;G-Jh9Y9VEvnbWcGWVzC_TFcIgQ3uShvpPkg7-sz4tkM */
+._box_14vj7_1 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: 8px;
+  max-width: 500px;
+  padding: 30px;
+}
+._title_14vj7_9 {
+  font-size: 24px;
+  margin-bottom: 10px;
+}
+._subTitle_14vj7_14 {
+  color: var(--color-gray-500) !important;
+  font-size: 16px;
+  line-height: 1.5 !important;
+  margin-bottom: var(--size-large) !important;
+}
+._switchWorkspace_14vj7_21 {
+  color: var(--color-purple);
+  cursor: pointer;
+}
+._button_14vj7_26 {
+  display: flex;
+  margin-bottom: 0;
+  margin-top: 0;
+}
+._button_14vj7_26 ._workspaceCount_14vj7_31 {
+  color: var(--color-white);
+  font-size: var(--size-xSmall);
+  height: var(--size-small);
+  margin-left: var(--size-xxSmall);
+  width: var(--size-small);
+}
+._cardForm_14vj7_39 {
+  grid-row-gap: 20px;
+}
+._inputLabel_14vj7_43 {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  justify-content: space-between;
+  margin-top: -6px;
+}
+._promoCodeToggle_14vj7_51 {
+  color: var(--color-purple);
+  cursor: pointer;
+  margin-top: -6px;
+  width: fit-content;
+}
+
+/* temp_stylePlugin:ni:sha-256;6iEa366Mf1E-y2rt4gJdabTKrcMBGmCKLi13RX8Md-g */
+._bodyWrapper_16hbb_1 {
+  display: flex;
+  height: calc(100% - var(--header-height));
+  overflow-x: hidden;
+  position: relative;
+  width: 100%;
+}
+._bodyWrapper_16hbb_1._bannerShown_16hbb_8 {
+  animation: 0.5s forwards;
+  height: calc(100% - var(--header-height) - var(--banner-height));
+}
+._submitButton_16hbb_13 {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin: 8px 0;
+  min-height: 40px;
+  outline: none;
+  width: 100%;
+}
+._errorMessage_16hbb_23 {
+  color: var(--color-red-400);
+  margin-left: 5px;
+}
+._secondaryButton_16hbb_28 {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin: 8px 0;
+  width: 100%;
+}
+._title_16hbb_36 {
+  font-size: 28px;
+  font-weight: 400;
+}
+
+/* temp_stylePlugin:ni:sha-256;450OuAXKxAc4neRVLhBMCviS4bSjTSXUgGvrWVeHyrw */
+._box_1js2t_1 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: 8px;
+  max-width: 500px;
+  padding: 30px;
+}
+._title_1js2t_9 {
+  font-size: 22px;
+  margin-bottom: 10px;
+}
+._subTitle_1js2t_14 {
+  color: var(--color-gray-500) !important;
+  font-size: 14px;
+  line-height: 1.5 !important;
+  margin-bottom: var(--size-large) !important;
+}
+._inputLabel_1js2t_21 {
+  display: flex;
+  flex-direction: column;
+  font-size: 12px;
+  gap: 10px;
+  justify-content: space-between;
+  margin-bottom: var(--size-large);
+}
+._formInput_1js2t_30 {
+  font-size: 14px !important;
+}
+._button_1js2t_34 {
+  margin-bottom: 0;
+  margin-top: var(--size-large);
+}
+
+/* temp_stylePlugin:ni:sha-256;yZeOKeOiUnj4ifm8UQSb4gdfeZw2IOVCysMkxUP6dXM */
+._inline_1eto1_1 {
+  color: var(--color-link) !important;
+  display: inline;
+  padding: 0 !important;
+}
+._inline_1eto1_1 > * {
+  text-decoration: underline !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;1WrikljbCkvT97oB7Y5UDW4vdTMuL6NpGmtdxFSeRF8 */
+._box_1jyd5_1 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: 8px;
+  max-width: 500px;
+  padding: 30px;
+}
+._title_1jyd5_9 {
+  font-size: 24px;
+  margin-bottom: 10px;
+}
+._subTitle_1jyd5_14 {
+  color: var(--color-gray-500) !important;
+  font-size: 16px !important;
+  line-height: 1.5 !important;
+  margin-bottom: var(--size-large) !important;
+}
+._fullWidth_1jyd5_21 {
+  width: 100%;
+}
+._intercomButton_1jyd5_25 {
+  color: var(--color-purple);
+  cursor: pointer;
+  display: inline-block;
+  line-height: 1;
+}
+._button_1jyd5_32 {
+  display: flex;
+  margin-bottom: 0;
+  margin-top: var(--size-large);
+}
+
+/* temp_stylePlugin:ni:sha-256;IZHeL7lNPqfxdX9yFnRjSvOgCkMBv_J_lVKMNSOLUL4 */
+._tag_12yz4_1 {
+  align-items: center;
+  border-radius: var(--size-large);
+  color: var(--text-primary);
+  column-gap: var(--size-xxSmall);
+  display: flex;
+  font-size: 12px;
+  height: var(--size-large);
+  padding: var(--size-xxSmall) var(--size-small);
+  width: fit-content;
+}
+
+/* temp_stylePlugin:ni:sha-256;aCjmkGQFVFIP-gzpnRVSqo6FD2-CyYUJeZk6pElqFj0 */
+._box_z0dv5_1 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: 8px;
+  max-width: 500px;
+  padding: 30px;
+}
+._title_z0dv5_9 {
+  font-size: 24px;
+  margin-bottom: 10px;
+}
+._subTitle_z0dv5_14 {
+  color: var(--color-gray-500) !important;
+  font-size: 16px !important;
+  line-height: 1.5 !important;
+  margin-bottom: var(--size-large) !important;
+}
+._fullWidth_z0dv5_21 {
+  width: 100%;
+}
+._newWorkspace_z0dv5_25 {
+  color: var(--color-purple);
+  cursor: pointer;
+}
+._joinButton_z0dv5_30 {
+  margin-left: auto;
+}
+._intercomButton_z0dv5_34 {
+  color: var(--color-purple);
+  cursor: pointer;
+  display: inline-block;
+  line-height: 1;
+}
+._button_z0dv5_41 {
+  display: flex;
+  margin-bottom: 0;
+  margin-top: var(--size-large);
+}
+
+/* temp_stylePlugin:ni:sha-256;5MaD-7hGxwVI7rG0FCZkkYfAyDodQfsPvLQj1bf4CnI */
+._container_y1zv8_1 {
+  position: relative;
+  font-size: 13px;
+}
+._downloadButton_y1zv8_6 {
+  position: absolute;
+  right: 0;
+  z-index: 5;
+}
+
+/* temp_stylePlugin:ni:sha-256;yYl6iGYVsi-J2_mZAhXEuDcMIFrhRDKxZFcbtotOceo */
+._emptyCardPlaceholder_1j6pu_1 {
+  cursor: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+._graphicContainer_1j6pu_8 {
+  margin-bottom: var(--size-xLarge);
+  margin-top: var(--size-xLarge);
+}
+._graphicContainer_1j6pu_8._compact_1j6pu_12 {
+  margin-bottom: var(--size-small);
+  margin-top: var(--size-medium);
+}
+._10haslo0 {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: flex-end;
+}
+._10haslo1 {
+  background-color: #908e96;
+  border-radius: 4px;
+  height: 0;
+  width: 100%;
+}
+._10haslo2 {
+  background-color: #744ed4;
+}
+._10haslo3 {
+  align-items: flex-end;
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* temp_stylePlugin:ni:sha-256;Go39T7yoRdt6QxieAFFXX2PZE1xBuMinttXzEHaHsFY */
+._emptyStateSection_14p25_1 {
+  align-items: center;
+  border: 1px solid var(--color-gray-300);
+  border-radius: 8px;
+  display: flex;
+  justify-content: center;
+  margin: 10px;
+  padding: 20px;
+  width: max-content;
+}
+._emptyStateWrapper_14p25_12 {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+._emptyStateWrapper_14p25_12 svg {
+  height: 30px;
+  width: 220px;
+}
+._emptySubTitle_14p25_24 {
+  color: var(--color-gray-500);
+  font-size: var(--size-small) !important;
+  margin: 0 auto !important;
+  max-width: 350px;
+  text-align: center;
+}
+._emptyTitle_14p25_32 {
+  font-size: 14px;
+  font-weight: 400 !important;
+  margin-top: 30px !important;
+  text-align: center;
+}
+._intercomButton_14p25_39 {
+  color: var(--color-purple);
+  cursor: pointer;
+  display: inline-block;
+  line-height: 1;
+}
+._newFeedStyles_14p25_46 ._emptyStateWrapper_14p25_12 svg {
+  height: 20px;
+  width: 120px;
+}
+._newFeedStyles_14p25_46 ._emptyStateSection_14p25_1 {
+  padding: 10px;
+}
+._newFeedStyles_14p25_46 ._emptySubTitle_14p25_24 {
+  font-size: var(--size-small) !important;
+  margin-top: var(--size-small) !important;
+}
+._newFeedStyles_14p25_46 ._emptyTitle_14p25_32 {
+  font-size: 14px !important;
+  font-weight: 400 !important;
+  margin-bottom: 0 !important;
+  margin-top: var(--size-small) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;559fqb-MkFxltqffdmIUJ0EnGh8ipswQaLRARo6dx0U */
+._statusCell_140f1_1 {
+  align-items: center;
+  display: flex;
+  gap: 0.1rem;
+  justify-content: center;
+  padding: 1.5rem 0.5rem;
+}
+._statusCell_140f1_1 > label > span {
+  width: 3.75rem;
+}
+
+/* temp_stylePlugin:ni:sha-256;9h2LbyaL8wunIVgrC3NN-AmOZ8Y5tAVMSrWMPfgF2eg */
+._container_mz1af_1 {
+  align-items: center;
+  column-gap: var(--size-xSmall);
+  display: flex;
+  margin-top: var(--size-xSmall);
+}
+._container_mz1af_1 ._adminContainer_mz1af_7 {
+  color: var(--color-gray-500);
+}
+._container_mz1af_1 ._adminContainer_mz1af_7 ._value_mz1af_10 {
+  color: var(--color-gray-600);
+  font-weight: 500;
+}
+
+/* temp_stylePlugin:ni:sha-256;0IQYSge-tbxvfDgK0MCJhtoPgfxWKw5tHSnih4juKmM */
+._configurationContainer_pn353_1 {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--size-large);
+}
+._configurationContainer_pn353_1 .ant-form-item {
+  margin-bottom: 0;
+}
+._integrationAlert_pn353_10 {
+  margin-bottom: var(--size-xxLarge);
+}
+._cellWithTooltip_pn353_14 {
+  column-gap: var(--size-xxSmall);
+  display: flex;
+  padding: 0 0.5rem;
+}
+._nameCell_pn353_20 {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  height: auto;
+}
+._nameCell_pn353_20 ._primary_pn353_26 {
+  font-size: 16px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 500px;
+}
+._subTitleContainer_pn353_35 {
+  align-items: center;
+  display: flex;
+  height: 40px;
+  margin-bottom: var(--size-medium);
+  margin-top: var(--size-small);
+}
+._subTitleContainer_pn353_35 p {
+  align-self: flex-start;
+  color: var(--color-gray-500);
+  font-size: 18px;
+  margin-bottom: 0 !important;
+  margin-top: 0 !important;
+}
+._subTitleContainer_pn353_35 ._callToAction_pn353_49 {
+  margin-left: auto;
+  transform: translateY(-49px);
+}
+._configureButton_pn353_54 {
+  align-items: center;
+  color: var(--color-gray-500) !important;
+  display: flex;
+  font-weight: 300;
+  justify-content: flex-end;
+}
+._configureButton_pn353_54:hover {
+  color: var(--color-gray-500) !important;
+}
+._configureButton_pn353_54 svg {
+  color: var(--color-gray-400);
+  height: var(--size-large);
+  width: var(--size-large);
+}
+._emptyContainer_pn353_70 {
+  cursor: auto;
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  max-width: 400px;
+  padding-bottom: var(--size-xLarge);
+  padding-top: var(--size-xLarge);
+}
+._intercomButton_pn353_80 {
+  color: var(--color-purple);
+  cursor: pointer;
+  display: inline-block;
+  line-height: 1;
+}
+._chart_pn353_87 {
+  display: flex;
+  justify-content: center;
+}
+._chart_pn353_87 ._innerChart_pn353_91 {
+  align-items: center;
+  background-color: var(--color-gray-100);
+  border-radius: 5px;
+  display: flex;
+  height: 54px;
+  justify-content: center;
+  padding: var(--size-small);
+  width: 124px;
+}
+._frequencyGraphEmptyMessage_pn353_102 {
+  font-size: 12px;
+  margin-bottom: 0 !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;YPFLDDxizrqvPHzBlbJfuVhNvQWMIoIM4GobMktNqzA */
+._avatarWrapper_1av3u_1 {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  position: relative;
+}
+._readMarkerContainer_1av3u_9 {
+  align-items: center;
+  display: flex;
+  margin-left: 6px;
+  position: relative;
+  width: 8px;
+}
+._topText_1av3u_17 {
+  color: var(--color-gray-500);
+  font-size: 12px;
+  margin: 0 !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._middleText_1av3u_26 {
+  color: var(--text-primary);
+  font-size: 14px;
+  margin: 0 !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._bottomText_1av3u_35 {
+  color: var(--text-primary);
+  font-size: 12px;
+  margin: 0 !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._sessionTextSection_1av3u_44 {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._sessionTextSection_1av3u_44._detailed_1av3u_50 {
+  max-width: 250px;
+}
+._sessionTextSection_1av3u_44._errorVersion_1av3u_53 {
+  max-width: 185px;
+}
+._detailedSection_1av3u_57 {
+  display: grid;
+  gap: var(--size-xxSmall);
+  grid-template-columns: 1fr 1fr;
+  max-width: unset;
+  padding-top: var(--size-xSmall);
+}
+._detailedSection_1av3u_57._withLongDatetimeFormat_1av3u_64 {
+  grid-template-columns: 1.7fr 1fr;
+}
+._identifier_1av3u_68 {
+  align-items: center;
+  display: flex;
+}
+._backfilledIcon_1av3u_73 {
+  align-items: center;
+  background-color: var(--color-gray-600);
+  border-radius: 2.5px;
+  color: var(--color-white);
+  display: flex;
+  font-size: 18px;
+  height: var(--size-medium);
+  justify-content: center;
+  margin-left: var(--size-xSmall);
+  width: var(--size-medium);
+}
+._backfilledIcon_1av3u_73 svg {
+  height: var(--size-small);
+  width: var(--size-small);
+}
+._tagWrapper_1av3u_90 {
+  display: flex;
+  flex-flow: row wrap;
+  height: 28px;
+  overflow: hidden;
+}
+._sessionCardWrapper_1av3u_97 {
+  position: relative;
+}
+._sessionCardWrapper_1av3u_97:hover ._sessionCardAction_1av3u_100 {
+  display: flex;
+}
+._sessionCardAction_1av3u_100 {
+  align-items: center;
+  background-color: var(--color-primary-background);
+  border: 0;
+  border-radius: var(--border-radius);
+  bottom: 0;
+  display: none;
+  height: 30px;
+  margin: auto;
+  padding: 0 6px;
+  position: absolute;
+  right: 8px;
+  top: 0;
+  width: 30px;
+}
+._sessionCardAction_1av3u_100:hover {
+  background-color: var(--color-gray-300);
+  cursor: pointer;
+}
+._sessionCardAction_1av3u_100:hover ._actionIcon_1av3u_123 {
+  color: var(--text-primary);
+  fill: var(--text-primary);
+  stroke: var(--text-primary);
+}
+._actionIcon_1av3u_123 {
+  color: var(--color-gray-500);
+  fill: var(--color-gray-500);
+  stroke: var(--color-gray-500);
+}
+._starredIconWrapper_1av3u_135 {
+  bottom: 0;
+  display: flex;
+  height: 30px;
+  left: 8px;
+  margin: auto;
+  padding: 6px;
+  position: absolute;
+  top: 0;
+  width: 30px;
+  z-index: 5;
+}
+._starredIconWrapper_1av3u_135:hover {
+  cursor: pointer;
+}
+._starredIconWrapper_1av3u_135:hover ._actionIcon_1av3u_123 {
+  color: var(--text-primary);
+  fill: var(--text-primary);
+  stroke: var(--text-primary);
+}
+._starredIcon_1av3u_135 {
+  color: var(--color-yellow-200);
+  fill: var(--color-yellow-200);
+  stroke: var(--color-yellow-200);
+}
+._sessionCard_1av3u_97 {
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--size-xSmall);
+  cursor: pointer;
+  font-weight: 400;
+  margin-bottom: var(--size-small);
+  position: relative;
+  transition: box-shadow 0.1s ease-in;
+}
+._sessionCard_1av3u_97:not(:first-of-type) {
+  margin-top: 14px;
+}
+._sessionCard_1av3u_97::before {
+  background-color: var(--color-purple);
+  border-bottom-left-radius: var(--size-xSmall);
+  border-top-left-radius: var(--size-xSmall);
+  content: "";
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  transition: opacity 0.1s ease-in;
+  width: 8px;
+  z-index: 99;
+}
+._sessionCard_1av3u_97._selected_1av3u_188 {
+  border: 1px solid var(--color-purple);
+  box-shadow: 0 0 9px rgba(86, 41, 198, 0.25);
+}
+._sessionCard_1av3u_97._selected_1av3u_188::before {
+  opacity: 1;
+}
+._sessionCard_1av3u_97:hover:not(._linkDisabled_1av3u_195) {
+  border: 1px solid var(--color-purple);
+  box-shadow: 0 0 9px rgba(86, 41, 198, 0.25);
+}
+._sessionCard_1av3u_97._linkDisabled_1av3u_195 {
+  cursor: not-allowed;
+}
+._sessionCard_1av3u_97 ._activityGraphContainer_1av3u_202 {
+  border-top: 1px solid var(--color-gray-300);
+  width: 100%;
+}
+._sessionCardContentWrapper_1av3u_207 {
+  align-items: center;
+  column-gap: var(--size-medium);
+  display: grid;
+  grid-template-columns: 26px 1fr 0.5fr;
+  padding: var(--size-medium);
+  width: 100%;
+}
+._sessionCardContentWrapper_1av3u_207._detailed_1av3u_50 {
+  grid-template-columns: 26px 1fr 0.25fr;
+}
+._sessionCardContentWrapper_1av3u_207._compact_1av3u_218 {
+  grid-template-columns: 1fr 0.33fr;
+}
+._sessionCardContentWrapper_1av3u_207._errorVersion_1av3u_53 {
+  grid-template-columns: 26px 1fr;
+}
+._sessionTextSectionWrapper_1av3u_225 {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+._cardAnnotationContainer_1av3u_231 {
+  column-gap: var(--size-medium);
+  display: flex;
+  justify-content: flex-end;
+}
+._cardAnnotationContainer_1av3u_231._detailed_1av3u_50 {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  row-gap: var(--size-medium);
+}
+._cardAnnotationContainer_1av3u_231 > div {
+  height: 16px;
+  width: 16px;
+}
+._cardAnnotation_1av3u_231 {
+  align-items: center;
+  background: var(--primary-color);
+  border-radius: 2.5px;
+  color: var(--color-white);
+  display: flex;
+  height: var(--size-medium);
+  justify-content: center;
+  width: var(--size-medium);
+}
+._cardAnnotation_1av3u_231 svg {
+  height: var(--size-xSmall);
+  width: var(--size-xSmall);
+}
+._separator_1av3u_261 {
+  margin-left: 1ch;
+  margin-right: 1ch;
+}
+
+/* temp_stylePlugin:ni:sha-256;m8DxXi5iSfmLrbZYB1bEazI_TA2XuIBc3jRmcy4QMMQ */
+._h2_1wwat_1 {
+  display: inline;
+}
+._icon_1wwat_5 {
+  height: var(--size-large);
+  padding-top: var(--size-xxSmall);
+  width: var(--size-large);
+}
+._breadcrumb_1wwat_11 {
+  align-items: center;
+  display: flex;
+}
+._breadcrumb_1wwat_11 .ant-breadcrumb-separator {
+  color: var(--color-gray-400);
+  margin-left: var(--size-xxSmall) !important;
+  margin-right: var(--size-xxSmall) !important;
+}
+._breadcrumb_1wwat_11 > span {
+  align-items: center;
+  display: flex;
+}
+._disabled_1wwat_25 {
+  pointer-events: none;
+}
+
+/* temp_stylePlugin:ni:sha-256;DWGkn8RJXsdfPtIDGCZe-CsLtRphLcJu7yzY1a-Kqhg */
+._channelSelect_ejzcm_1 {
+  margin-bottom: var(--size-medium);
+  width: 100%;
+}
+._channelSelect_ejzcm_1:last-of-type {
+  margin-bottom: 0;
+}
+._saveButton_ejzcm_9 {
+  justify-content: center;
+  width: 125px;
+}
+._alertConfigurationCard_ejzcm_14 ._subTitle_ejzcm_14 {
+  margin-top: var(--size-small) !important;
+}
+._alertConfigurationCard_ejzcm_14 h2 {
+  font-size: 22px !important;
+  margin-bottom: 0 !important;
+}
+._alertConfigurationCard_ejzcm_14 h3 {
+  font-size: 16px !important;
+  margin-bottom: var(--size-xSmall) !important;
+}
+._alertConfigurationCard_ejzcm_14 p,
+._alertConfigurationCard_ejzcm_14 section > span {
+  color: var(--color-gray-500);
+  display: block;
+  margin-bottom: var(--size-medium) !important;
+  margin-top: 0 !important;
+}
+._alertConfigurationCard_ejzcm_14 section {
+  padding-bottom: var(--size-xxLarge);
+}
+._alertConfigurationCard_ejzcm_14 section:last-of-type {
+  padding-bottom: var(--size-xLarge);
+}
+._alertConfigurationCard_ejzcm_14 .ant-form-item:last-of-type {
+  margin-bottom: 0;
+}
+._addContainer_ejzcm_42 {
+  color: var(--color-gray-500);
+  padding: 0 var(--size-small);
+}
+._notFoundMessage_ejzcm_47 {
+  padding: var(--size-small) 0;
+}
+._frequencyContainer_ejzcm_51 {
+  column-gap: var(--size-large);
+  display: flex;
+}
+._lookbackPeriodSelect_ejzcm_56 {
+  width: 150px !important;
+}
+._actionsContainer_ejzcm_60 {
+  column-gap: var(--size-large);
+  display: flex;
+  margin-left: auto;
+}
+._footer_ejzcm_66 {
+  display: flex;
+}
+._notFoundContentEmail_ejzcm_70 {
+  color: var(--color-gray-500);
+  padding: var(--size-medium) 0;
+}
+
+/* temp_stylePlugin:ni:sha-256;x7xtVoySCH1AmwG0xzmEObgX9s8ZtybI9N9x904oPdU */
+._selectMessage_1dqb2_1 {
+  color: var(--color-gray-500);
+}
+._notFoundMessage_1dqb2_5 {
+  padding-left: var(--size-xSmall) 0;
+  padding-right: var(--size-xSmall) 0;
+}
+._syncButton_1dqb2_10 {
+  color: var(--color-link) !important;
+  display: inline-flex;
+  font-weight: 400;
+  padding: 0;
+}
+._small_1dqb2_17 {
+  display: flex;
+  padding: 0;
+}
+
+/* temp_stylePlugin:ni:sha-256;-7bIkg0OsPtxTPN6hFl7x9S1NUhe7u8FACoXlnm7BR4 */
+._inputNumber_1arvo_1 {
+  background: var(--color-primary-background) !important;
+  border: 1px solid var(--color-gray-300) !important;
+  border-radius: var(--border-radius);
+  color: var(--text-primary) !important;
+  padding-bottom: var(--size-xSmall) !important;
+  padding-left: var(--size-xSmall) !important;
+  padding-right: var(--size-xSmall) !important;
+  padding-top: var(--size-xSmall) !important;
+}
+._inputNumber_1arvo_1 .ant-input-number-input {
+  padding: 0;
+}
+._inputNumber_1arvo_1.ant-input-number-focused {
+  border-color: rgba(47, 128, 237, 0.5) !important;
+  border-right-width: 1px !important;
+  box-shadow: 0 0 0 2px rgba(47, 128, 237, 0.5) !important;
+  outline: 0;
+}
+._inputNumber_1arvo_1.ant-input-number:hover {
+  border-color: rgba(47, 128, 237, 0.5) !important;
+  border-right-width: 1px !important;
+}
+._inputNumber_1arvo_1 .ant-input-number-handler-wrap {
+  background-color: var(--color-primary-background) !important;
+  border-color: var(--color-gray-300) !important;
+  border-radius: 0 var(--border-radius) var(--border-radius) 0;
+}
+._inputNumber_1arvo_1 .ant-input-number-handler-wrap svg {
+  color: var(--text-primary) !important;
+}
+._inputNumber_1arvo_1 .ant-input-number-handler-down {
+  border-color: var(--color-gray-300) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;jSxnbnZeZuaw01ic9cxoyS0CYq9nDPPat2ykNJQ9gcE */
+._labelItem_wjar6_1 {
+  align-items: center;
+  border-bottom: 1px solid var(--color-gray-300);
+  cursor: pointer;
+  display: flex;
+  font-size: 14px;
+  padding: 10px 10px 10px 6px;
+  width: 100%;
+}
+._labelItem_wjar6_1:hover {
+  background-color: var(--color-gray-200);
+}
+._labelText_wjar6_15 {
+  color: var(--text-primary);
+  margin-left: 6px;
+  margin-right: 12px;
+}
+._dropdownInner_wjar6_21 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: 5px;
+  box-shadow: var(--box-shadow);
+  color: var(--text-primary);
+  margin-top: 9px;
+}
+._dropdownMenu_wjar6_30 {
+  box-shadow: none;
+}
+._icon_wjar6_34 {
+  color: var(--color-purple);
+  height: 16px;
+  margin-left: 4px;
+  transition: 0.4s;
+  width: 16px;
+}
+._labelNameText_wjar6_42 {
+  align-items: center;
+  display: flex;
+  margin-left: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+._dropdownHandler_wjar6_52 {
+  align-items: center;
+  background: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: 8px;
+  color: var(--text-primary);
+  cursor: pointer;
+  display: flex;
+  font-size: 14px;
+  height: 40px;
+  justify-content: center;
+  padding: 10px 10px 10px 6px;
+}
+._dropdownHandler_wjar6_52._dropdownGray_wjar6_65 {
+  background: var(--color-gray-200) !important;
+  border: 1px solid transparent !important;
+}
+._overlay_wjar6_70 {
+  z-index: 9999999999 !important;
+}
+._placeholder_wjar6_74 {
+  color: var(--color-gray-400) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;-BA1D9lITPkBNRmYgmyr-Gb2NtKYF6QGf5yDEyhrzmk */
+._tooltip_qqyxl_1 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow);
+  color: var(--text-primary) !important;
+  padding: var(--size-small) 0 !important;
+}
+._tooltip_qqyxl_1 > * {
+  padding-left: var(--size-medium) !important;
+  padding-right: var(--size-medium) !important;
+}
+._tooltip_qqyxl_1 > h4 {
+  border-bottom: 1px solid var(--color-gray-300);
+  font-family: var(--header-font-family);
+  font-size: 13px !important;
+  margin-bottom: var(--size-small) !important;
+  padding-bottom: var(--size-xSmall);
+}
+._tooltip_qqyxl_1 > p {
+  color: var(--color-gray-500) !important;
+  font-size: 14px !important;
+  margin: 0 !important;
+}
+.recharts-tooltip-wrapper:focus-visible {
+  outline: none;
+}
+
+/* temp_stylePlugin:ni:sha-256;QzNXba2z9Kf1--JULe3QyEQ6RJ_RnFsg9fl2a00sDo0 */
+._verticalSlider_1098s_1 {
+  height: 166px;
+  margin-top: 50px;
+  position: absolute;
+}
+._horizontalSlider_1098s_7 {
+  height: 16px;
+  left: 31px;
+  margin-right: 45px;
+  position: absolute;
+  top: 38px;
+}
+._sliderThumb_1098s_15 {
+  background-color: var(--color-primary-background);
+  border: 3px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  color: var(--color-purple-500);
+  font-size: 8px;
+  left: 50px;
+  padding: 2px;
+  position: absolute;
+}
+._sliderTrack_1098s_26 {
+  width: 500px;
+}
+
+/* temp_stylePlugin:ni:sha-256;9O-Dq9ekfSvBPb8tgvuRlgk7BM9rgBnlsv_4JIBxY_M */
+._metric_jsssh_1 {
+  --good-color: var(--color-green-500) !important;
+  --needs-improvement-color: var(--color-yellow-500) !important;
+  --poor-color: var(--color-red-500) !important;
+}
+._metric_jsssh_1 ._name_jsssh_6,
+._metric_jsssh_1 ._value_jsssh_7 {
+  display: flex;
+  font-size: 12px !important;
+  font-weight: 500 !important;
+  margin-bottom: 0 !important;
+}
+._metric_jsssh_1 ._value_jsssh_7 {
+  column-gap: 0.25ch;
+}
+._metric_jsssh_1 ._units_jsssh_16 {
+  color: var(--color-gray-500) !important;
+  font-weight: 400 !important;
+}
+._metric_jsssh_1._goodScore_jsssh_20 {
+  color: var(--good-color);
+}
+._metric_jsssh_1._needsImprovementScore_jsssh_23 {
+  color: var(--needs-improvement-color);
+}
+._metric_jsssh_1._poorScore_jsssh_26 {
+  color: var(--poor-color);
+}
+._simpleMetric_jsssh_30 {
+  align-items: center;
+  column-gap: var(--size-xSmall);
+  display: grid;
+  grid-template-columns: 3fr auto;
+}
+._detailedMetric_jsssh_37 {
+  align-items: center;
+  column-gap: var(--size-xSmall);
+  display: flex;
+}
+._detailedMetric_jsssh_37 ._name_jsssh_6 {
+  width: 6ch;
+}
+._detailedMetric_jsssh_37 ._value_jsssh_7 {
+  margin-left: auto;
+  transform: translateY(-100%);
+}
+._detailedMetric_jsssh_37 ._value_jsssh_7._mirror_jsssh_49 {
+  position: absolute;
+  right: 0;
+}
+._infoTooltip_jsssh_54 {
+  color: var(--color-gray-500) !important;
+}
+._scoreVisualization_jsssh_58 {
+  --color: transparent;
+  column-gap: 2px;
+  display: flex;
+  height: 1ch;
+  position: relative;
+  width: 100%;
+}
+._scoreVisualization_jsssh_58 > div {
+  background-color: var(--color-gray-300);
+  border-radius: var(--size-xxSmall);
+  flex-grow: 1;
+  height: 100%;
+}
+._scoreVisualization_jsssh_58 ._poor_jsssh_26 {
+  --color: var(--poor-color);
+}
+._scoreVisualization_jsssh_58 ._needsImprovement_jsssh_23 {
+  --color: var(--needs-improvement-color);
+}
+._scoreVisualization_jsssh_58 ._good_jsssh_20 {
+  --color: var(--good-color);
+}
+._scoreVisualization_jsssh_58 ._active_jsssh_81 {
+  background-color: var(--color);
+}
+._scoreVisualization_jsssh_58 ._scoreIndicator_jsssh_84 {
+  --size: var(--size-medium);
+  background: var(--color-white);
+  border: 2px solid var(--color-gray-400);
+  border-radius: 50%;
+  box-shadow: var(--box-shadow);
+  flex-grow: 0;
+  flex-shrink: 0;
+  height: var(--size);
+  left: 0;
+  position: absolute;
+  top: calc(var(--size) / -4);
+  transition: left 0.2s ease-in;
+  width: var(--size);
+  z-index: 2;
+}
+
+/* temp_stylePlugin:ni:sha-256;orTQZ4C5gTau0ZRK4y-lR8GOLUq-OCpxlBPEMwO-gbQ */
+._legendValue_a1rwg_1 {
+  color: var(--color-gray-500) !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+._legendValue_a1rwg_1._notShowing_a1rwg_6 {
+  text-decoration: line-through;
+}
+._legendIcon_a1rwg_10 {
+  border-radius: 2px;
+  flex-shrink: 0;
+  height: var(--size-small);
+  margin-bottom: auto;
+  margin-top: auto;
+  width: var(--size-small);
+}
+._legendIcon_a1rwg_10._notShowing_a1rwg_6 {
+  filter: grayscale(0.5);
+}
+._referenceLineValue_a1rwg_22 {
+  color: var(--color-gray-500);
+}
+._tooltipGrid_a1rwg_26 {
+  display: grid;
+  grid-column-gap: var(--size-xSmall);
+  grid-template-columns: 1fr 10px 64px 10px;
+  width: 100%;
+}
+._scoreIcon_a1rwg_33 {
+  --size: var(--size-small);
+  align-items: center;
+  color: var(--color-gray-500);
+  display: flex;
+  flex-shrink: 0;
+  height: var(--size);
+  width: var(--size);
+}
+._tooltipValue_a1rwg_43 {
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: initial;
+}
+._text_a1rwg_49 {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+._text_a1rwg_49::-webkit-scrollbar {
+  width: 0 !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;Szb1Dek6J0ELW1PYddLUO1Ir9xXWwtY75rA1HINQjIg */
+._legendContainer_h2jc0_1 {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin-top: var(--size-xSmall);
+}
+._legendItem_h2jc0_8 {
+  align-items: center;
+  color: var(--color-gray-500) !important;
+  column-gap: var(--size-xxSmall);
+  display: flex;
+  font-size: 12px;
+  padding-bottom: 0 !important;
+  padding-top: 0 !important;
+}
+._legendValue_h2jc0_18 {
+  color: var(--color-gray-500) !important;
+}
+._legendValue_h2jc0_18._notShowing_h2jc0_21 {
+  text-decoration: line-through;
+}
+._legendIcon_h2jc0_25 {
+  border-radius: 2px;
+  flex-shrink: 0;
+  height: var(--size-small);
+  width: var(--size-small);
+}
+._legendIcon_h2jc0_25._notShowing_h2jc0_21 {
+  filter: grayscale(0.5);
+}
+._tooltipEntry_h2jc0_35 {
+  align-items: center;
+  column-gap: var(--size-xxSmall);
+  display: flex;
+  margin-bottom: 0 !important;
+}
+._referenceLineValue_h2jc0_42 {
+  color: var(--color-gray-500);
+}
+._tooltipRow_h2jc0_46 {
+  align-items: center;
+  column-gap: var(--size-xSmall);
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+._scoreIcon_h2jc0_54 {
+  --size: var(--size-small);
+  align-items: center;
+  color: var(--color-gray-500);
+  display: flex;
+  flex-shrink: 0;
+  height: var(--size);
+  width: var(--size);
+}
+._tooltipValue_h2jc0_64 {
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: initial;
+}
+
+/* temp_stylePlugin:ni:sha-256;AOOW4Krl9szsR0YplhoodBrX16-31uiqZ_KsH4CjRDM */
+._button_1tsha_1 {
+  background: none;
+  border: 1px solid var(--color-gray-400);
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  padding: var(--size-small);
+  position: relative;
+  text-align: left;
+  transition: border-color 0.1s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+._button_1tsha_1:hover {
+  border-color: var(--color-purple);
+  box-shadow: 0 5px 8px rgba(86, 41, 198, 0.2);
+}
+._button_1tsha_1 p {
+  font-size: 12px !important;
+  margin: 0 !important;
+  margin-top: var(--size-xSmall) !important;
+}
+._button_1tsha_1 h4 {
+  font-weight: 500 !important;
+}
+._button_1tsha_1 ._icon_1tsha_23 {
+  --size: var(--size-medium);
+  align-items: center;
+  background: var(--color-purple);
+  border-radius: 50%;
+  color: var(--color-white);
+  display: flex;
+  height: var(--size);
+  justify-content: center;
+  position: absolute;
+  right: var(--size-small);
+  top: var(--size-small);
+  width: var(--size);
+}
+._button_1tsha_1 ._icon_1tsha_23 svg {
+  --size: var(--size-small);
+  height: var(--size);
+  width: var(--size);
+}
+
+/* temp_stylePlugin:ni:sha-256;uG-GoN6vxp_q66WgfCkjYWCl9TJaDvWhnqyp90h20nE */
+._select_3y5oy_1 {
+  border-radius: var(--border-radius) !important;
+  height: 40px;
+  width: 100%;
+}
+._select_3y5oy_1 .ant-select-selection-search {
+  align-items: center;
+  display: flex;
+}
+._select_3y5oy_1 .ant-select-selector {
+  border: 1px solid var(--color-gray-300) !important;
+  border-radius: var(--border-radius) !important;
+  font-family: var(--body-font-family);
+  font-size: 16px;
+  height: 40px !important;
+  padding: var(--size-xSmall) var(--size-medium) !important;
+}
+._select_3y5oy_1 .ant-select-selection-placeholder {
+  left: 14px;
+}
+._select_3y5oy_1 .ant-select-selector {
+  border: 0 !important;
+  border-color: transparent !important;
+  box-shadow: none !important;
+}
+._select_3y5oy_1 .ant-select-selection-item {
+  display: none;
+}
+._select_3y5oy_1 .ant-select-selector {
+  background-color: var(--color-gray-200) !important;
+}
+._select_3y5oy_1 .ant-select-arrow {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 18px;
+  width: 100%;
+}
+._select_3y5oy_1 .ant-select-arrow > svg {
+  color: var(--text-primary);
+  height: 100%;
+  position: relative;
+  right: -10px;
+  top: -3px;
+  width: 100%;
+}
+._select_3y5oy_1 .ant-select-selector:hover .ant-select-open {
+  background: var(--color-gray-300) !important;
+}
+._select_3y5oy_1 .ant-select-selector:hover .ant-select-open ._ant-select-selector_3y5oy_10 {
+  background-color: var(--color-gray-300) !important;
+  border-radius: var(--border-radius) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;oKqIlVx2jQw5pICgU8Rqt9-AVSf8p8VgdvIEWREqrKM */
+._minMaxRow_3qnus_1 {
+  display: grid;
+  grid-gap: var(--size-medium);
+  grid-template-columns: 80px 1fr 150px 80px 1fr 150px;
+}
+._formLabel_3qnus_7 {
+  margin-bottom: 0;
+  margin-top: 4px;
+}
+._submitRow_3qnus_12 {
+  column-gap: var(--size-medium);
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--size-large);
+  width: 100%;
+}
+._section_3qnus_20 {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 0 !important;
+  padding-top: var(--size-medium);
+  row-gap: var(--size-medium);
+}
+._section_3qnus_20:first-of-type {
+  padding-top: 0;
+}
+._section_3qnus_20 h3 {
+  font-size: 16px;
+  margin-bottom: 0 !important;
+  margin-top: 0 !important;
+}
+._typesContainer_3qnus_36 {
+  display: grid;
+  grid-gap: var(--size-medium);
+  grid-template-columns: 1fr 1fr 1fr;
+}
+._metricViewDetails_3qnus_42 {
+  display: grid;
+  grid-gap: var(--size-medium);
+  grid-template-columns: 1fr 1fr;
+}
+._metricViewDetail_3qnus_42 {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--size-medium);
+}
+._typeSubheader_3qnus_54 {
+  color: var(--color-gray-500);
+}
+._tagFilterGroup_3qnus_58 {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--size-xxSmall);
+}
+._filtersRow_3qnus_64 {
+  display: grid;
+  grid-gap: var(--size-medium);
+  grid-template-columns: 11fr 5fr 14fr 50px;
+  width: 100%;
+}
+._groupsRow_3qnus_71 {
+  display: grid;
+  grid-gap: var(--size-medium);
+  grid-template-columns: 1fr 50px;
+  width: 100%;
+}
+._removeTagFilterButton_3qnus_78 {
+  background-color: var(--color-red-700);
+  border: var(--color-red-900);
+  color: var(--color-white) !important;
+  height: 40px;
+  padding: 0 16px;
+}
+._removeTagFilterButton_3qnus_78[disabled] {
+  background-color: var(--color-red-300) !important;
+  border: var(--color-red-400);
+}
+._removeTagFilterButton_3qnus_78[disabled]:hover {
+  background-color: var(--color-red-300) !important;
+}
+._removeTagFilterButton_3qnus_78:hover {
+  background-color: var(--color-red-600) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;NxO_kux9f6jVglOjCXpIYhsUE5zfZG8qJfPn6bYN2EM */
+._card_1adi5_1 {
+  height: 100%;
+}
+._card_1adi5_1 .recharts-cartesian-axis-tick {
+  user-select: none;
+}
+._componentCard_1adi5_8 {
+  height: 100%;
+  width: 100%;
+}
+._noDataContainer_1adi5_13 {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0 auto;
+  max-width: 300px;
+  padding-top: var(--size-medium);
+  text-align: center;
+}
+._draggable_1adi5_24 {
+  align-items: center;
+  color: var(--color-gray-500);
+  cursor: move;
+  display: flex;
+  justify-content: center;
+}
+._overlayButton_1adi5_32 {
+  position: absolute;
+  right: var(--size-xLarge);
+  top: var(--size-medium);
+}
+._button_1adi5_38 {
+  justify-content: center;
+}
+._infoTooltip_1adi5_42 {
+  margin-left: var(--size-xxSmall);
+}
+._actionsContainer_1adi5_46 {
+  column-gap: var(--size-large);
+  display: flex;
+  margin-top: var(--size-xLarge);
+}
+._actionsContainer_1adi5_46 > * {
+  width: 50%;
+}
+._actionsContainer_1adi5_46 ._button_1adi5_38 {
+  justify-content: center;
+}
+._description_1adi5_58 {
+  color: var(--color-gray-500) !important;
+  margin-top: 0 !important;
+}
+._monitorItem_1adi5_63 {
+  align-items: center;
+  border: 1px solid var(--color-gray-400);
+  border-radius: var(--border-radius);
+  column-gap: var(--size-xxSmall) !important;
+  display: flex;
+  height: var(--size-xLarge);
+  margin: 0 !important;
+  padding: 10px 8px 10px 14px !important;
+}
+._monitorName_1adi5_74 {
+  display: inline-block;
+  line-height: 20px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 70px;
+}
+._submitRow_1adi5_83 {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: var(--size-small);
+  width: 100%;
+}
+._minMaxRow_1adi5_90 {
+  display: grid;
+  grid-gap: var(--size-medium);
+  grid-template-columns: 80px 1fr 150px 80px 1fr 150px;
+}
+._formLabel_1adi5_96 {
+  margin-bottom: 0;
+  margin-top: 4px;
+}
+._removeTagFilterButton_1adi5_101 {
+  height: 48px;
+  padding: 0 16px;
+}
+._chartInner_1adi5_106 {
+  padding: 0 10px 16px 16px;
+}
+._createNewAlertRow_1adi5_110 {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+._mainHeaderContent_1adi5_116 {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+  min-height: 52px;
+  padding: 10px 10px 10px 20px;
+  width: 100%;
+}
+._cardHeader_1adi5_125 {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+._cardHeader_1adi5_125 > button {
+  margin-bottom: var(--size-medium);
+}
+._headerContainer_1adi5_135 {
+  overflow: hidden;
+}
+._header_1adi5_135 {
+  color: var(--color-text-primary);
+  display: block;
+  font-size: 16px;
+  font-weight: 500;
+  overflow: hidden;
+  padding-top: 2px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._subheader_1adi5_150 {
+  color: var(--color-gray-700);
+  display: block;
+  font-size: 12px;
+  font-weight: 400;
+}
+._blurChart_1adi5_157 {
+  filter: blur(2px);
+}
+
+/* temp_stylePlugin:ni:sha-256;0Ym1J8TqOkpSo0dX04w1fh6CyrcBIX7sF_DBJju-Aa4 */
+._card_1r3ct_1 {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  transition: border-color 0.1s ease-in-out, box-shadow 0.2s ease-in-out;
+  width: 100%;
+}
+._card_1r3ct_1._noPadding_1r3ct_9 {
+  padding: 0;
+}
+._card_1r3ct_1 h2,
+._card_1r3ct_1 ._cardHeader_1r3ct_13 {
+  font-size: 22px !important;
+  margin-bottom: var(--size-medium) !important;
+}
+._card_1r3ct_1 h3 {
+  font-size: 16px !important;
+  margin-bottom: var(--size-xSmall) !important;
+}
+._card_1r3ct_1 p {
+  color: var(--color-gray-500);
+  margin-top: 0 !important;
+}
+._card_1r3ct_1 section {
+  padding-bottom: var(--size-medium);
+}
+._card_1r3ct_1 section:last-of-type {
+  padding-bottom: var(--size-large);
+}
+._card_1r3ct_1 ._titleContainer_1r3ct_31 {
+  border-bottom: 1px solid var(--color-gray-300);
+  font-size: 14px !important;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+._card_1r3ct_1 ._titleContainer_1r3ct_31._noTitleBottomMargin_1r3ct_37 {
+  margin-bottom: 0;
+}
+._card_1r3ct_1 ._titleContainer_1r3ct_31 h3 {
+  margin-bottom: var(--size-medium) !important;
+}
+._card_1r3ct_1:hover._interactable_1r3ct_43 {
+  border-color: var(--color-purple);
+  box-shadow: 0 5px 8px rgba(86, 41, 198, 0.2);
+}
+._cardForm_1r3ct_48 {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--size-large);
+}
+._cardSubHeader_1r3ct_54 {
+  color: var(--color-gray-500) !important;
+  font-size: 16px;
+  line-height: 1.5 !important;
+  margin-bottom: var(--size-large) !important;
+}
+._cardFormActionsContainer_1r3ct_61 {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--size-medium);
+}
+
+/* temp_stylePlugin:ni:sha-256;VqQZhOP_Qs1kh7csOA57zBoi34toB9oWJrxEJjTRFBI */
+.ant-slider:hover .ant-slider-track {
+  background-color: var(--color-blue-400) !important;
+}
+.ant-slider:hover .ant-slider-handle:not(.ant-tooltip-open) {
+  border-color: var(--color-blue-400) !important;
+}
+.ant-slider-dot {
+  border-color: var(--color-blue-400) !important;
+}
+.ant-slider-handle {
+  border-color: var(--color-blue-400) !important;
+}
+.ant-slider-handle:focus {
+  border-color: var(--color-blue-400) !important;
+  box-shadow: 0 0 0 5px var(--color-blue-400) !important;
+}
+.ant-slider-handle:hover {
+  border-color: var(--color-blue-400) !important;
+}
+.ant-slider-handle-dragging.ant-slider-handle-dragging.ant-slider-handle-dragging {
+  border-color: var(--color-blue-400) !important;
+  box-shadow: 0 0 0 5px var(--color-blue-400) !important;
+}
+._chartContainer_px3ht_25 {
+  height: 230px;
+  margin-bottom: var(--size-large);
+}
+._formFooter_px3ht_30 {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--size-large);
+}
+._actionsContainer_px3ht_36 {
+  column-gap: var(--size-large);
+  display: flex;
+  margin-left: auto;
+}
+._select_px3ht_42 {
+  width: 100%;
+}
+._slider_px3ht_46 {
+  left: 27px;
+  top: 36px;
+  z-index: 99999;
+}
+._thresholdRow_px3ht_52 {
+  display: flex;
+}
+._threshold_px3ht_52 {
+  flex-grow: 1;
+}
+._thresholdUnits_px3ht_60 {
+  margin-left: var(--size-xxSmall);
+  width: 160px;
+}
+
+/* temp_stylePlugin:ni:sha-256;sPMWPEfD_xQTin9hxZVVD8ldDACnHEGfwak8GexrlOQ */
+._select_2ddse_1 {
+  width: 100%;
+}
+._cardGrid_2ddse_5 {
+  display: grid;
+  gap: var(--size-xLarge);
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr;
+}
+._cardContainer_2ddse_12 {
+  height: 100%;
+}
+._cardContent_2ddse_16 {
+  display: block;
+}
+._cardContent_2ddse_16 ._icon_2ddse_19 {
+  align-items: center;
+  border-radius: 50%;
+  color: var(--color-white) !important;
+  display: flex;
+  flex-shrink: 0;
+  height: 1.5em;
+  justify-content: center;
+  width: 1.5em;
+}
+._cardContent_2ddse_16 ._icon_2ddse_19 svg {
+  height: 0.8em;
+  width: 0.8em;
+}
+#_title_2ddse_1 {
+  align-items: center;
+  column-gap: var(--size-small);
+  display: flex;
+  margin-bottom: var(--size-xxSmall) !important;
+}
+._description_2ddse_41 {
+  margin-bottom: 0 !important;
+  margin-left: calc(1.5em + 2 * var(--size-small)) !important;
+}
+._155k3sw0 {
+  height: 4.16rem;
+}
+._155k3sw1 {
+  height: 120px;
+}
+._155k3sw2 {
+  cursor: pointer;
+}
+._155k3sw2:hover {
+  background-color: var(--_1pyqka91x);
+}
+._155k3sw3 {
+  background-color: var(--_1pyqka91);
+  z-index: 10 !important;
+  border: var(--_1pyqka9j) solid 1px;
+  box-shadow: 0 6px 12px -2px rgba(59, 59, 59, 0.12);
+  border-radius: 6px;
+  width: 224px;
+}
+._155k3sw4 {
+  height: 28px;
+}
+._155k3sw5 {
+  background-color: #dcdbdd;
+  opacity: 0.5;
+}
+._155k3sw6 {
+  opacity: 0.2;
+  left: 0;
+  z-index: 1;
+  width: calc(100% - 4px);
+  pointer-events: none;
+}
+._14ud0dc0::-webkit-scrollbar {
+  width: 9px;
+  height: 9px;
+}
+:hover._14ud0dc0::-webkit-scrollbar-thumb {
+  background-color: var(--_1pyqka91p);
+}
+:hover._14ud0dc0::-webkit-scrollbar {
+  border-top: var(--_1pyqka9k) solid 1px;
+}
+._14ud0dc0::-webkit-scrollbar-thumb {
+  background-clip: padding-box;
+  background-color: var(--_1pyqka91o);
+  border: 1px solid transparent;
+  border-radius: 30px;
+  border-top-width: 2px;
+}
+._14ud0dc1::-webkit-scrollbar {
+  width: 9px;
+  height: 9px;
+}
+:hover._14ud0dc1::-webkit-scrollbar-thumb {
+  background-color: var(--_1pyqka91p);
+}
+:hover._14ud0dc1::-webkit-scrollbar {
+  border-left: var(--_1pyqka9k) solid 1px;
+}
+._14ud0dc1::-webkit-scrollbar-thumb {
+  background-clip: padding-box;
+  background-color: var(--_1pyqka91o);
+  border: 1px solid transparent;
+  border-radius: 30px;
+  border-left-width: 2px;
+}
+._1sd10050 {
+  position: absolute;
+  top: 13px;
+  left: 14px;
+}
+._1sd10052 {
+  background: transparent;
+  border: 0;
+  color: var(--_1pyqka9b);
+  display: flex;
+  font-size: 13px;
+  width: 100%;
+}
+._1sd10052:focus {
+  outline: 0;
+}
+._1sd10052::placeholder {
+  color: var(--_1pyqka9x);
+}
+._1sd10053 {
+  background: var(--_1pyqka91);
+  border: var(--_1pyqka9k) solid 1px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px -2px rgba(59, 59, 59, 0.08);
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  max-width: 600px;
+  max-height: min(var(--popover-available-height,300px), 300px);
+  z-index: 1;
+}
+._1sd10054 {
+  cursor: pointer;
+  padding: 12px 10px;
+}
+._1sd10054:hover {
+  background-color: var(--_1pyqka9t);
+}
+._1sd10054[data-active-item] {
+  background-color: var(--_1pyqka9u);
+}
+._1sd10056 + ._1sd10056 {
+  border-top: var(--_1pyqka91o) solid 1px;
+}
+._1tecd1u0 {
+  height: 40px;
+}
+._1tecd1u1 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto;
+  grid-column-gap: 40px;
+  grid-row-gap: 40px;
+}
+._1tecd1u5 {
+  border: 0;
+  background: transparent;
+  color: var(--_1pyqka9b);
+  display: flex;
+  font-size: 13px;
+  width: 100%;
+}
+._1tecd1u5:focus {
+  outline: 0;
+}
+._1tecd1u5::placeholder {
+  color: var(--_1pyqka9x);
+}
+._1tecd1u7 {
+  height: 20px;
+}
+._1tecd1u9 {
+  height: 20px;
+}
+._1tecd1ua {
+  color: var(--_1pyqka9b) !important;
+}
+._1tecd1ua:hover {
+  background: var(--_1pyqka91x);
+}
+._1tecd1ua .ant-select-selector {
+  padding: 0 6px !important;
+  border-radius: 6px !important;
+  border: var(--_1pyqka91o) solid 1px !important;
+  box-shadow: none !important;
+}
+._1tecd1ua .ant-select-selector:hover {
+  background: var(--_1pyqka91x) !important;
+}
+._1tecd1ua .ant-select-selection-item {
+  display: flex;
+  align-items: center;
+}
+
+/* temp_stylePlugin:ni:sha-256;6datuXjsS3zX7N7KNWxJJkdgx3B9QuSAh0Ue9SjtsoM */
+._percentContainer_e32yg_1 {
+  align-items: center;
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  column-gap: var(--size-xSmall);
+  display: flex;
+  justify-content: space-between;
+  padding: var(--size-xxSmall) var(--size-xSmall);
+  width: fit-content;
+}
+._barGraph_e32yg_12 {
+  background: var(--color-gray-300);
+  border-radius: var(--size-xxSmall);
+  flex-shrink: 0;
+  height: 1rem;
+  overflow: hidden;
+  position: relative;
+  width: var(--size-large);
+}
+._barGraph_e32yg_12::after {
+  background: var(--text-primary);
+  border-bottom-right-radius: var(--size-xxSmall);
+  border-top-right-radius: var(--size-xxSmall);
+  content: "";
+  height: 100%;
+  position: absolute;
+  width: var(--percentage);
+}
+._pill_e32yg_31 {
+  align-items: center;
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  column-gap: var(--size-xxSmall);
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  min-width: 68px;
+  padding: var(--size-xxSmall) var(--size-xSmall);
+  white-space: nowrap;
+  width: fit-content;
+}
+._rowGroup_e32yg_45 {
+  column-gap: var(--size-small);
+  display: flex;
+  width: 100%;
+}
+._rowGroup_e32yg_45._endingAlignment_e32yg_50 {
+  justify-content: flex-end;
+}
+
+/* temp_stylePlugin:ni:sha-256;ZFoUMMhiqVF46EynLmpBg-KbVNCKslhonyvDXd_4mxA */
+._table_rv890_1 {
+  margin-bottom: -24px;
+  margin-left: -24px;
+  margin-right: -24px;
+  max-width: initial !important;
+}
+._table_rv890_1 .ant-table {
+  background: var(--color-primary-background) !important;
+  color: var(--text-primary) !important;
+}
+._table_rv890_1 .ant-table-cell {
+  border-bottom: 1px solid var(--color-gray-300) !important;
+  padding: 12px 0 !important;
+}
+._table_rv890_1 .ant-table-cell:first-of-type {
+  padding-left: var(--size-large) !important;
+}
+._table_rv890_1 .ant-table-cell:last-of-type {
+  padding-right: var(--size-large) !important;
+}
+._table_rv890_1 .ant-table-row:last-of-type .ant-table-cell {
+  border-bottom: 0 !important;
+}
+._table_rv890_1 .ant-table-tbody > tr.ant-table-row:hover > td {
+  background: var(--color-gray-300) !important;
+}
+._table_rv890_1 .ant-table-tbody > tr.ant-table-placeholder:hover > td {
+  background: transparent !important;
+}
+._table_rv890_1 .ant-table-empty {
+  margin-top: var(--size-xxLarge);
+}
+._table_rv890_1 .ant-table-empty .ant-table-cell {
+  border-bottom: 0 !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;ggSycYJjMEPPFhmSXzEZ9SAMBe9U73qGZWv0Pb8lWIA */
+._card_13l8s_1 {
+  padding: 0 var(--size-large);
+}
+
+/* temp_stylePlugin:ni:sha-256;Kn4bqgfsVKX7THnEvBE4bTKEWM61ocnOQ0fToJlHAmU */
+._hostContainer_ieeaf_1 {
+  align-items: center;
+  column-gap: var(--size-xxSmall);
+  display: flex;
+  padding-right: 2rem;
+}
+._hostContainer_ieeaf_1 span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._timeRow_ieeaf_13 {
+  column-gap: var(--size-xxSmall);
+  display: flex;
+  justify-content: center;
+  width: fit-content;
+}
+._loading_ieeaf_20 {
+  filter: blur(2px);
+}
+
+/* temp_stylePlugin:ni:sha-256;uF4zsogCP55Ya8YrNfVQoVTg7GOMXZPlESB-bS4u5I0 */
+._keyPerformanceIndicator_mpv8j_1 ._value_mpv8j_1 {
+  font-size: 36px !important;
+}
+._keyPerformanceIndicator_mpv8j_1 ._label_mpv8j_4 {
+  margin: 0 !important;
+}
+._keyPerformanceIndicator_mpv8j_1 ._tooltip_mpv8j_7 {
+  color: var(--text-primary);
+  position: absolute;
+  right: calc(var(--size-small) * -1);
+  top: calc(var(--size-xxSmall) * -1);
+}
+._keyPerformanceIndicator_mpv8j_1 ._labelContainer_mpv8j_13 {
+  display: flex;
+  position: relative;
+  width: fit-content;
+}
+
+/* temp_stylePlugin:ni:sha-256;7lHoFERtTXwKuDf8k70D3TFG3TW8Ub_VK9tXoVZo2-U */
+._hostContainer_qgrox_1 {
+  align-items: center;
+  column-gap: var(--size-xxSmall);
+  display: flex;
+}
+._hostContainer_qgrox_1 span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._loading_qgrox_12 {
+  filter: blur(2px);
+}
+
+/* temp_stylePlugin:ni:sha-256;YVQn90rnZDI6PMfmdGZEuMI2hvNLj5nuW-yNgAyZKAU */
+._hostContainer_10q3z_1 {
+  padding-right: 2rem;
+}
+._hostContainer_10q3z_1 span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._loading_10q3z_10 {
+  filter: blur(2px);
+}
+
+/* temp_stylePlugin:ni:sha-256;ieJBzPfKDSmJmxrtQVPR2Ze2T0M78T5Q8ngMcdnXB0U */
+._loading_140gu_1 {
+  filter: blur(2px);
+}
+
+/* temp_stylePlugin:ni:sha-256;65Bhjj4_4jpO8gULX5Un0OpKqGosQs9i0ZeS4PSvYtk */
+._gridContainer_rp08v_1 {
+  padding: 30px 80px;
+}
+._gridContainer_rp08v_1._isEditing_rp08v_4 .react-resizable-handle {
+  opacity: 1;
+}
+._gridContainer_rp08v_1 .react-grid-item.react-grid-placeholder {
+  background-color: var(--color-gray-400);
+  border-radius: var(--border-radius);
+}
+._gridContainer_rp08v_1 .react-resizable-handle {
+  background: var(--color-gray-400);
+  background-image: none;
+  border-radius: var(--size-small);
+  bottom: var(--size-small) !important;
+  height: var(--size-small);
+  opacity: 0;
+  right: var(--size-small) !important;
+  transform: unset !important;
+  transition: opacity 0.2s ease-in-out;
+  width: var(--size-small);
+}
+._gridContainer_rp08v_1 .react-resizable-handle::after {
+  content: none;
+}
+._customLeadAlignLayout_rp08v_27 {
+  margin: 0;
+}
+._headerPanel_rp08v_31 {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+._dashboardPageFixedHeader_rp08v_37 {
+  background-color: var(--color-white);
+  border-bottom: var(--color-gray-300) 1px solid;
+  display: flex;
+  flex-direction: column;
+  padding: 40px 80px 30px;
+  position: sticky;
+  z-index: 1000;
+}
+._dateRangePicker_rp08v_47 {
+  margin-left: auto;
+  width: fit-content;
+}
+._rightControllerSection_rp08v_52 {
+  display: flex;
+  flex-direction: column;
+}
+._rightControllerText_rp08v_57 {
+  align-self: flex-end;
+}
+._absoluteColored_rp08v_61 {
+  color: var(--color-blue-900);
+  font-weight: 500;
+}
+._liveColored_rp08v_66 {
+  color: var(--color-green-900);
+  font-weight: 500;
+}
+._liveIndicator_rp08v_71 {
+  align-items: center;
+  background-color: var(--color-green-300);
+  border: var(--color-green-900) 1.5px solid;
+  border-radius: 8px;
+  color: var(--color-green-900);
+  display: flex;
+  justify-content: center;
+  padding: 2px 12px;
+  text-align: right;
+}
+._dateRangePickerContainer_rp08v_83 {
+  display: flex;
+  gap: 10px;
+  height: 40px;
+  right: 80px;
+  top: 118px;
+}
+._metric_rp08v_91 {
+  display: grid;
+  grid-gap: var(--size-medium);
+  grid-template-columns: 1fr 1fr 1fr 3fr;
+}
+._newMetric_rp08v_97 {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--size-large);
+}
+._container_rp08v_103 {
+  flex-grow: 1;
+  position: relative;
+  width: 100%;
+}
+._dropdownPlaceholder_rp08v_109 {
+  height: 20px;
+  width: 20px;
+}
+._section_rp08v_114 {
+  display: flex;
+  flex-direction: row;
+  padding-bottom: 0 !important;
+  padding-top: var(--size-small);
+  row-gap: var(--size-medium);
+  width: 100%;
+}
+._section_rp08v_114:first-of-type {
+  padding-top: 0;
+}
+._section_rp08v_114 h3 {
+  font-size: var(--size-medium);
+  margin-bottom: 0 !important;
+  margin-top: 0 !important;
+}
+._pillButton_rp08v_131 {
+  align-items: center;
+  background: 0;
+  border: 0;
+  border-radius: var(--size-xSmall);
+  column-gap: var(--size-xxSmall);
+  display: flex;
+  font-size: 14px;
+  height: 40px;
+  justify-content: center;
+  min-width: 86px;
+  padding: var(--size-xxSmall) var(--size-small);
+  transition: background 0.1s ease-in-out;
+}
+._pillButton_rp08v_131._pillButtonSmall_rp08v_145 {
+  height: 30px;
+}
+._pillLoading_rp08v_149 {
+  background: var(--color-brand-pastel-dark);
+  border: 1px solid var(--color-text-primary);
+  color: var(--color-text-primary);
+}
+._pillLive_rp08v_155 {
+  background: var(--color-green-100);
+  border: 1px solid var(--color-green-600);
+  color: var(--color-green-900);
+}
+._pillStatic_rp08v_161 {
+  background: var(--color-blue-100);
+  border: 1px solid var(--color-blue-600);
+  color: var(--color-blue-900);
+}
+._pillButtonText_rp08v_167 {
+  align-items: center;
+  column-gap: var(--size-xxSmall);
+  display: flex;
+  justify-content: center;
+  opacity: 0;
+  position: absolute;
+  transition: opacity 0.1s ease-in-out;
+}
+._pillButtonTextVisible_rp08v_177 {
+  opacity: 1;
+}
+._settingsDropdownMenu_rp08v_181 .ant-dropdown-menu-item {
+  padding: 0 !important;
+}
+._resize_rp08v_185 {
+  border-bottom: 10px solid var(--color-gray-300);
+  border-left: 10px solid transparent;
+  border-radius: 8px;
+  border-right: 10px solid transparent;
+  bottom: 6px;
+  position: absolute;
+  right: 0;
+  transform: rotate(135deg);
+  transition: border-bottom ease-in-out 0.2s;
+}
+._resize_rp08v_185:hover {
+  border-bottom: 10px solid var(--color-purple-400);
+}
+
+/* temp_stylePlugin:ni:sha-256;ml3pUupnjjXBT_6FTAsyS6s2p7umBnHfXULdyh17WM0 */
+._actionsContainer_1w0mw_1 {
+  column-gap: var(--size-large);
+  display: flex;
+  margin-top: var(--size-xLarge);
+}
+._actionsContainer_1w0mw_1 > * {
+  width: 50%;
+}
+._actionsContainer_1w0mw_1 ._button_1w0mw_9 {
+  justify-content: center;
+}
+._description_1w0mw_13 {
+  color: var(--color-gray-500) !important;
+  margin-top: 0 !important;
+}
+._name_1w0mw_18 {
+  flex-grow: 1;
+  margin-left: var(--size-medium);
+}
+._submitRow_1w0mw_23 {
+  column-gap: var(--size-medium);
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--size-large);
+  width: 100%;
+}
+._section_1w0mw_31 {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 0 !important;
+  padding-top: var(--size-medium);
+  row-gap: var(--size-medium);
+}
+._section_1w0mw_31:first-of-type {
+  padding-top: 0;
+}
+._section_1w0mw_31 h3 {
+  font-size: 16px;
+  margin-bottom: 0 !important;
+  margin-top: 0 !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;wMROBNnNkjYC53knhWwOdIHCBjloSInSCKTXrz4BDv4 */
+._dashboardWrapper_4u0hf_1 {
+  width: 100%;
+}
+._dashboard_4u0hf_1 {
+  padding: 0;
+}
+._subTitle_4u0hf_9 {
+  font-size: 18px;
+}
+._chartHeaderWrapper_4u0hf_13 {
+  align-items: center;
+  display: flex;
+  height: 15px;
+  justify-content: space-between;
+  margin-bottom: var(--size-medium);
+}
+._chartHeaderWrapper_4u0hf_13 #_h3_4u0hf_1 {
+  margin-bottom: 0 !important;
+}
+._chartHeaderWrapper_4u0hf_13 .ant-input-affix-wrapper {
+  width: 150px;
+}
+._chartHeaderWrapper_4u0hf_13._smallMargin_4u0hf_26 {
+  margin-bottom: var(--size-medium);
+}
+._dashboardBody_4u0hf_30 {
+  display: grid;
+  gap: var(--size-xxLarge);
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  position: relative;
+  width: 100%;
+}
+._filtersContainer_4u0hf_38 {
+  display: flex;
+  justify-content: flex-end;
+  padding-bottom: var(--size-medium);
+}
+._headerContainer_4u0hf_44 {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: var(--size-xLarge);
+}
+._noDataContainer_4u0hf_50 {
+  align-items: center;
+  backdrop-filter: blur(2px);
+  border-radius: var(--border-radius);
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  top: 0;
+  transition: backdrop-filter 0.2s ease-in-out;
+  width: 100%;
+}
+._composedChart_4u0hf_64 {
+  cursor: pointer !important;
+}
+._demoWorkspaceButton_4u0hf_68 {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--size-medium);
+}
+.t0fsad0 {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.t0fsad1 {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+._33eaux0 {
+  max-height: 16em;
+}
+
+/* temp_stylePlugin:ni:sha-256;rMrQRyZrKw_rd6RipEc2Ve-7bXKt5YqAsAeoQ0Mt554 */
+._tabPane_19cqh_1 {
+  height: 100%;
+  overflow-y: auto;
+}
+._tabPane_19cqh_1._withPadding_19cqh_5 {
+  padding: var(--size-small) var(--size-medium);
+}
+._tabPane_19cqh_1._unsetOverflowY_19cqh_8 {
+  overflow-y: unset;
+}
+._extraContentContainer_19cqh_12 {
+  align-items: center;
+  column-gap: var(--size-medium);
+  display: flex;
+}
+._extraContentContainer_19cqh_12._withHeaderPadding_19cqh_17 {
+  padding-right: var(--size-large);
+}
+._tabs_19cqh_21 {
+  font-family: var(--header-font-family) !important;
+}
+._tabs_19cqh_21._noHeaderPadding_19cqh_24 .ant-tabs-nav-wrap {
+  padding: 0;
+}
+.ah2zbm0 {
+  background-color: var(--_1pyqka90);
+  border: 1px solid var(--_1pyqka9k);
+  border-radius: 5px;
+  padding: 6px 4px;
+}
+.ah2zbm1 {
+  border: 1px solid var(--_1pyqka9k);
+  border-radius: 6px;
+  width: 100%;
+}
+.ofc9fn0 {
+  border-right: var(--_1pyqka91o) solid 1px;
+  border-bottom: var(--_1pyqka91o) solid 1px;
+  border-left: var(--_1pyqka91o) solid 1px;
+  margin: 0;
+}
+.ofc9fn1 {
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+.ofc9fn3 {
+  display: inline-block;
+  text-align: center;
+  width: 46px;
+}
+.ofc9fn4 {
+  height: 14px;
+  transition: transform 0.25s;
+}
+.ofc9fn5 {
+  transform: rotate(-180deg);
+}
+.ofc9fn7 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-top: 2px;
+  height: 16px;
+  max-width: 120px;
+}
+.ofc9fn8 {
+  max-width: 560px;
+}
+
+/* temp_stylePlugin:ni:sha-256;a4S8h3K4hzJZqGw6bvgIobVWcltc8CnnuyHj7puJyyk */
+._pageButtonsRow_3uoyz_1 {
+  display: flex;
+  flex-shrink: 0;
+  justify-content: flex-end;
+  left: 0;
+  margin: var(--size-large) 0;
+  width: 100%;
+}
+._pageButtonsContainer_3uoyz_10 {
+  display: grid;
+  gap: var(--size-xSmall);
+  grid-template-columns: 1fr 1fr;
+  width: auto;
+}
+._container_3uoyz_17 {
+  align-self: center;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+._btn_3uoyz_24 {
+  align-content: center;
+  align-self: center;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+/* temp_stylePlugin:ni:sha-256;BtqyzEEtG8ThljpH4yzPm1T9yuUz6xMGDnI9IWq9o3c */
+._metricsDistributionContainer_1bgqt_1 {
+  min-height: 240px;
+}
+._iconContainer_1bgqt_5 {
+  margin-right: var(--size-xSmall);
+  padding-top: 4px;
+}
+._titleContainer_1bgqt_10 {
+  align-items: center;
+  display: flex;
+}
+._timePickerContainer_1bgqt_15 {
+  z-index: 10;
+}
+._calloutContainer_1bgqt_19 {
+  background-color: #f9f8f9;
+  margin-top: var(--size-medium);
+}
+._calloutContainer_1bgqt_19 ._bodyText_1bgqt_23 {
+  line-height: 20px;
+  margin-bottom: var(--size-small);
+}
+
+/* temp_stylePlugin:ni:sha-256;DMx_yhueaNtyoiolxqddtH2hqPvsQLI-nunleTtuIsA */
+._tabs_ywpbe_1 {
+  margin-top: var(--size-xxLarge);
+}
+._tabs_ywpbe_1 .ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn {
+  color: var(--color-purple) !important;
+}
+._tabs_ywpbe_1 .ant-tabs-ink-bar {
+  background: var(--color-purple) !important;
+}
+._tabs_ywpbe_1 .ant-tabs-tab {
+  margin-left: 0 !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;-cJt9rEk1bDY6EYOV7ZPlvnqfLMZiWCuhNEQYzfMn44 */
+._modalBtn_1h3ip_1 {
+  padding-bottom: 4px !important;
+  padding-top: 4px !important;
+}
+._modalBtnIcon_1h3ip_6 {
+  margin-right: 0.5rem;
+}
+._modalSubTitle_1h3ip_10 {
+  color: var(--color-gray-500) !important;
+  font-size: 16px;
+  margin-bottom: 20px;
+  margin-top: 0 !important;
+}
+._1g045pm0 {
+  color: var(--_1pyqka9b) !important;
+}
+._1g045pm0:hover {
+  background: var(--_1pyqka91x);
+}
+._1g045pm0 .ant-select-selector {
+  padding: 0 6px !important;
+  border-radius: 6px !important;
+  border: var(--_1pyqka91o) solid 1px !important;
+  box-shadow: none !important;
+}
+._1g045pm0 .ant-select-selector:hover {
+  background: var(--_1pyqka91x) !important;
+}
+._1g045pm0 .ant-select-selection-item {
+  display: flex;
+  align-items: center;
+}
+
+/* temp_stylePlugin:ni:sha-256;hoPFPmv3uapgLFhSxRtcdGtNSmv5y6EpTj94PTXVaYU */
+._modalBtn_1es5w_1 {
+  padding-bottom: 4px !important;
+  padding-top: 4px !important;
+}
+._modalBtnIcon_1es5w_6 {
+  margin-right: 0.5rem;
+}
+._modalSubTitle_1es5w_10 {
+  color: var(--color-gray-500) !important;
+  font-size: 16px;
+  margin-bottom: 20px;
+  margin-top: 0 !important;
+}
+._modalBtnText_1es5w_17 {
+  align-items: center;
+  display: inline-flex !important;
+  height: 100%;
+}
+
+/* temp_stylePlugin:ni:sha-256;kmL8yqsmxOmtnYBePm7Yp18HOxZ85_n8PmjnZolYLoI */
+._modalBtn_1kqcu_1 {
+  background: var(--color-purple);
+  border-radius: 8px;
+  padding: 8px 12px !important;
+}
+._modalBtnIcon_1kqcu_7 {
+  margin-right: 0.5rem;
+}
+._modalSubTitle_1kqcu_11 {
+  color: var(--color-gray-500) !important;
+  font-size: 16px;
+  margin-bottom: 20px;
+  margin-top: 0 !important;
+}
+._modalBtnText_1kqcu_18 {
+  align-items: center;
+  color: var(--color-white) !important;
+  display: inline-flex !important;
+  height: 100%;
+}
+
+/* temp_stylePlugin:ni:sha-256;o-TLetARGwKzz1GCzHjAGgANWglqTmBhk2Kej3_QMDM */
+._copyButton_11h6r_1 {
+  background: var(--color-gray-300);
+  border-radius: var(--size-xSmall);
+  cursor: pointer;
+  opacity: 0;
+  padding: var(--size-xxSmall);
+  position: absolute;
+  right: 5px;
+  top: 5px;
+  transition: opacity 0.2s ease-in-out;
+  z-index: 10;
+}
+._copyDiv_11h6r_14 {
+  align-items: center;
+  display: flex;
+  font-size: 8px;
+  justify-content: center;
+  padding: 10px;
+}
+._codeBlock_11h6r_22 {
+  position: relative;
+}
+._codeBlock_11h6r_22 pre {
+  margin: 0 !important;
+}
+._codeBlock_11h6r_22:hover ._copyButton_11h6r_1 {
+  opacity: 1;
+}
+._codeBlockInner_11h6r_32 {
+  display: flex;
+}
+._highlightedLine_11h6r_36 {
+  background-color: var(--color-gray-300);
+}
+._lineNumberSticky_11h6r_40 {
+  color: rgb(125, 139, 153);
+  display: block;
+  min-width: 2.25em;
+  padding-left: 16px;
+  padding-right: 16px;
+  text-align: right;
+  user-select: none;
+}
+._1tn5c580 {
+  color: var(--_1pyqka9y);
+}
+._1tn5c581 {
+  max-width: 108px;
+}
+._1w5sij40 {
+  padding: 0;
+}
+.gadbsf0 {
+  border: var(--_1pyqka91o) solid 1px;
+  padding: 4px 6px;
+  font-size: 13px;
+  width: 100%;
+}
+.gadbsf0:hover {
+  border: var(--_1pyqka91p) solid 1px;
+}
+.gadbsf0 .ant-picker-input input {
+  font-size: 13px;
+}
+.gadbsf0.ant-picker-focused {
+  border: var(--_1pyqka91q) solid 1px;
+  box-shadow: none;
+}
+.gadbsf1 {
+  z-index: 1;
+}
+
+/* temp_stylePlugin:ni:sha-256;VZylchIV3JHUU-3Ecd67nVNE_E_dTdFnC1xiRFbtZLY */
+._card_10wj8_1 {
+  align-self: center;
+  margin-bottom: auto;
+  margin-top: auto;
+  max-width: 300px;
+}
+._3dlaof0 {
+  height: 20px;
+}
+._3dlaof1 {
+  max-width: 100%;
+}
+._3dlaof2:hover {
+  background: var(--_1pyqka91x);
+}
+._3dlaof3 {
+  background: var(--_1pyqka91y);
+  box-shadow: 0 -1px 0 0 rgba(0, 0, 0, 0.1) inset;
+}
+._3dlaof3:hover {
+  background-color: var(--_1pyqka91y);
+}
+._1f2v8en0 {
+  transition: transform 0.2s ease-in-out;
+  width: 340px;
+  position: fixed;
+  height: calc(100vh - var(--header-height));
+}
+._1f2v8en1 {
+  height: calc(100vh - var(--header-height) - var(--banner-height));
+}
+._1f2v8en2 {
+  position: fixed;
+  transform: translateX(-340px);
+}
+._1f2v8en3 {
+  position: absolute;
+  right: calc((-1 * var(--size-xLarge) / 2));
+  top: 16px;
+  transform: translateY(calc(112px + var(--size-medium) + 30px));
+  z-index: 20;
+}
+._1f2v8en4 {
+  right: calc(-1 * (var(--sidebar-width) - var(--size-xLarge)));
+}
+._1f2v8en5 {
+  height: 100%;
+}
+._1f2v8en6 {
+  height: 44px;
+  flex-shrink: 0;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+._75g8nf0 {
+  display: flex;
+  width: 100%;
+}
+._75g8nf1 {
+  background-color: #f9f8f9;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  height: 100%;
+  padding: 8px;
+}
+._75g8nf2 {
+  background: white;
+  border-radius: 4px;
+  display: flex;
+  height: 100%;
+  margin-left: 0;
+  overflow-y: scroll;
+  width: 100%;
+}
+._75g8nf3 {
+  display: flex;
+  gap: var(--size-medium);
+  margin-top: var(--size-medium);
+}
+._75g8nf4 {
+  margin-left: 340px;
+}
+._75g8nf5 {
+  border: 0 !important;
+  border-radius: 0;
+}
+
+/* temp_stylePlugin:ni:sha-256;Ey6_QcTV8I1lBOhqZ2JZ4lEeJYyj4SCpSrUW4GlbAzw */
+._integrationsContainer_ixqmc_1 {
+  display: grid;
+  grid-gap: var(--size-large);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+._modalBtn_ixqmc_7 {
+  padding-bottom: 4px !important;
+  padding-top: 4px !important;
+}
+._1f99hkr0 {
+  height: 2.305rem;
+}
+._1vb6x0p0 {
+  text-decoration: none;
+  color: var(--_1pyqka9y);
+}
+._1vb6x0p0:hover {
+  color: var(--_1pyqka9y);
+}
+.szxd8q0 .szxd8q0 {
+  padding-left: 22px;
+}
+.szxd8q2 {
+  align-items: center;
+  display: none;
+  flex-direction: row;
+  gap: 4px;
+  opacity: 0.5;
+}
+.szxd8q2:hover {
+  opacity: 1;
+}
+.szxd8q1:hover .szxd8q2 {
+  display: flex;
+}
+.szxd8q3 {
+  opacity: 0.6;
+}
+.szxd8q3:hover {
+  opacity: 1;
+}
+.szxd8q4 {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  color: var(--_1pyqka9y);
+}
+.szxd8q4:hover {
+  color: var(--_1pyqka9w);
+}
+.szxd8q4:active {
+  color: var(--_1pyqka9w);
+}
+.g2tqod0 {
+  border-radius: 6px;
+  padding: 8px 8px 8px 28px;
+  position: relative;
+}
+.g2tqod0:hover {
+  background-color: var(--_1pyqka91x);
+}
+.g2tqod1 {
+  background: var(--_1pyqka91y);
+}
+.g2tqod2 {
+  left: 8px;
+  opacity: 0;
+  position: absolute;
+  top: 5px;
+}
+.g2tqod0:hover .g2tqod2 {
+  opacity: 1;
+}
+.g2tqod1 .g2tqod2 {
+  opacity: 1;
+}
+.g2tqod3 {
+  background-color: var(--_1pyqka96);
+  border-radius: 4px;
+  color: inherit !important;
+  display: inline-block;
+  padding: 0 4px;
+}
+
+/* temp_stylePlugin:ni:sha-256;NxHN4GrE6NlglKUItkw0sC187iIkyHBH8-E4pMw-_Vc */
+._fullBleedCard_h1fdv_1 {
+  align-items: center;
+  backdrop-filter: blur(2px);
+  border-radius: var(--border-radius);
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  top: 0;
+  transition: backdrop-filter 0.2s ease-in-out;
+  width: 100%;
+  z-index: 99;
+}
+
+/* temp_stylePlugin:ni:sha-256;bcFf3nCQPA6_UveoFl8it03evdU08PYcKoMTTMssX_0 */
+._actionButtons_1w4el_1 {
+  display: flex;
+  gap: var(--size-xSmall);
+  justify-content: flex-end;
+}
+._actionButtons_1w4el_1 button {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: var(--size-small);
+}
+._textBoxStyles_1w4el_13 {
+  font-size: inherit !important;
+}
+._integrationIcon_1w4el_17 {
+  border-radius: var(--size-xxSmall);
+  margin-bottom: 2px;
+  margin-right: var(--size-xSmall);
+  width: calc(var(--size-medium) + 2px);
+}
+._integrationIcon_1w4el_17._largeSize_1w4el_24 {
+  margin-bottom: 4px;
+  width: calc(var(--size-large) + 2px);
+}
+._formItemSpacer_1w4el_29 {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-xSmall);
+  justify-content: space-between;
+  row-gap: var(--size-medium);
+}
+._actionButtonsContainer_1w4el_37 {
+  margin-bottom: 0;
+}
+._commentInputContainer_1w4el_41 {
+  background: var(--color-gray-200);
+  border: 1px solid transparent;
+  border-radius: var(--border-radius);
+  box-shadow: none !important;
+  height: 100px;
+  padding-bottom: var(--size-xSmall) !important;
+  padding-left: var(--size-small) !important;
+  padding-right: var(--size-small) !important;
+  padding-top: var(--size-xSmall) !important;
+  transition: all 0.2s ease-in-out;
+}
+._commentInputContainer_1w4el_41 div {
+  height: 100%;
+}
+._commentInputContainer_1w4el_41 textarea {
+  color: var(--text-primary) !important;
+  height: 100%;
+}
+._commentInputContainer_1w4el_41:hover,
+._commentInputContainer_1w4el_41:active,
+._commentInputContainer_1w4el_41:focus-within {
+  background: var(--color-primary-background);
+  border-color: var(--color-purple);
+  box-shadow: 0 0 0 4px rgba(var(--color-purple-rgb), 0.2) !important;
+}
+._intercomLink_1w4el_66 {
+  cursor: pointer;
+  text-decoration: underline;
+}
+._form_1w4el_29 .ant-form-item {
+  margin-bottom: 0 !important;
+}
+._hide_1w4el_75 {
+  animation-fill-mode: forwards;
+  opacity: 0;
+  visibility: hidden !important;
+}
+._slides_1w4el_81 {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  row-gap: var(--size-medium);
+  transition: transform 0.25s ease;
+  width: calc(200% + var(--size-medium) / 2);
+}
+._slides_1w4el_81 > div {
+  transition: opacity 0.25s, visibility 0.15s linear;
+  visibility: visible;
+  width: 100%;
+}
+._showSecondSlide_1w4el_96 {
+  transform: translateX(calc(-50% - var(--size-xxSmall)));
+}
+._slidesContainer_1w4el_100 {
+  margin-left: calc(-1 * var(--size-large));
+  margin-right: calc(-1 * var(--size-large));
+  overflow-x: hidden;
+  padding-bottom: var(--size-xSmall);
+  padding-left: var(--size-large);
+  padding-right: var(--size-large);
+  padding-top: var(--size-xSmall);
+}
+._submitButton_1w4el_110 {
+  transition: background-color 0.3s ease;
+}
+._loading_1w4el_114 {
+  background-color: var(--color-gray-400);
+  border: solid 1px var(--color-gray-400);
+}
+._loading_1w4el_114:hover,
+._loading_1w4el_114:active,
+._loading_1w4el_114:focus-within {
+  background-color: var(--color-gray-400);
+  border: solid 1px var(--color-gray-400);
+}
+
+/* temp_stylePlugin:ni:sha-256;VPmqGM6ttZGxzXKsT8T8VQbaUm69qi6Yi1jAbnxgiqg */
+._suggestionContainer_ixcq8_1 {
+  align-items: center;
+  column-gap: var(--size-xSmall);
+  display: flex;
+}
+._suggestionContainer_ixcq8_1 ._adminText_ixcq8_6 {
+  display: flex;
+  flex-direction: column;
+}
+._suggestionContainer_ixcq8_1 ._adminText_ixcq8_6 ._email_ixcq8_10 {
+  color: var(--color-gray-500);
+}
+._suggestionContainer_ixcq8_1 ._adminText_ixcq8_6 ._longValue_ixcq8_13 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 225px;
+}
+._suggestionContainer_ixcq8_1 ._slackLogo_ixcq8_19 {
+  height: var(--size-medium);
+  width: var(--size-medium);
+}
+._suggestionContainer_ixcq8_1 ._slackLogoContainer_ixcq8_23 {
+  align-items: center;
+  background: var(--color-primary-background);
+  border-radius: 50%;
+  box-shadow: var(--box-shadow-3);
+  display: flex;
+  height: calc(var(--size-medium) + var(--size-xxSmall));
+  justify-content: center;
+  left: calc(-1 * var(--size-xSmall));
+  position: absolute;
+  top: calc(-1 * var(--size-xSmall));
+  width: calc(var(--size-medium) + var(--size-xxSmall));
+}
+._suggestionContainer_ixcq8_1 ._avatarContainer_ixcq8_36 {
+  position: relative;
+}
+._suggestionHeader_ixcq8_40 {
+  background: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-bottom: 0;
+  border-top-left-radius: var(--border-radius);
+  border-top-right-radius: var(--border-radius);
+  display: flex;
+  height: 50px;
+  justify-content: space-between;
+  padding: var(--size-medium) var(--size-small);
+}
+._suggestionHeader_ixcq8_40 p {
+  font-size: 13px;
+  font-weight: 400;
+  margin: 0 !important;
+}
+._noResultsMessage_ixcq8_57 {
+  background: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+  margin: 0 !important;
+  max-width: 300px;
+  padding: var(--size-medium) var(--size-small);
+}
+._commentLink_ixcq8_67 {
+  color: var(--color-purple);
+}
+
+/* temp_stylePlugin:ni:sha-256;gXgfkcFmngR0gwULkNSEzwJ-ThK6tz2_KzgHlNkenaY */
+._mentions_vzopr_1 {
+  font-size: 14px !important;
+  line-height: initial;
+}
+._mentions--singleLine_vzopr_6 ._mentions__control_vzopr_6 {
+  display: inline-block;
+  width: 130px;
+}
+._mentions--singleLine_vzopr_6 ._mentions__highlighter_vzopr_11 {
+  border: 2px inset transparent;
+  padding: 1px;
+}
+._mentions--singleLine_vzopr_6 ._mentions__input_vzopr_16 {
+  border: 2px inset;
+  padding: 1px;
+}
+._mentions--multiLine_vzopr_21 ._mentions__control_vzopr_6 {
+  font-size: 14px !important;
+}
+._mentions--multiLine_vzopr_21 ._mentions__highlighter_vzopr_11 {
+  border: 1px solid transparent;
+  font-weight: 400;
+  padding: 0;
+}
+._mentions--multiLine_vzopr_21 ._mentions__highlighter_vzopr_11 span {
+  overflow-wrap: anywhere;
+}
+._mentions--multiLine_vzopr_21 ._mentions__input_vzopr_16 {
+  border: 1px solid transparent;
+  color: var(--color-gray-500);
+  cursor: inherit;
+  font-weight: 400;
+  outline: 0;
+  padding: 0;
+}
+._mentions--multiLine_vzopr_21 ._mentions__input_vzopr_16[aria-readonly=true] {
+  caret-color: transparent;
+}
+._mentions__input_vzopr_16::placeholder {
+  color: #c8c7cb !important;
+}
+._mentions__suggestions__list_vzopr_53 {
+  background: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius) !important;
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+  box-shadow: var(--box-shadow-3);
+  max-height: 400px;
+  max-width: 300px;
+  overflow-y: auto;
+  padding: var(--size-xSmall) var(--size-small);
+}
+._mentions__suggestions__item_vzopr_66 {
+  padding: var(--size-xSmall) 12px;
+}
+._mentions__suggestions__item_vzopr_66:not(:last-of-type) {
+  border-bottom: 1px solid var(--color-gray-300);
+}
+._mentions__suggestions__item--focused_vzopr_74 {
+  background: var(--color-gray-300);
+}
+._mentions__mention_vzopr_78 {
+  color: var(--color-link);
+  font-weight: 400 !important;
+  pointer-events: none;
+  position: relative;
+  text-shadow:
+    1px 1px 1px var(--color-white),
+    1px -1px 1px var(--color-white),
+    -1px 1px 1px var(--color-white),
+    -1px -1px 1px var(--color-white);
+  z-index: 1;
+}
+
+/* temp_stylePlugin:ni:sha-256;u_Z46p2z1qqq3-AJMq3YnHGQ00NZKWhfflV0llLDtEs */
+._container_1m9ig_1 {
+  background: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--size-xSmall);
+  overflow: hidden;
+  padding-bottom: var(--size-small);
+  padding-left: calc(var(--size-xSmall) + 11px);
+  padding-right: calc(var(--size-xSmall) + 11px);
+  padding-top: var(--size-small);
+  position: relative;
+  text-align: left;
+  transition: box-shadow 0.1s ease-in;
+  width: 100%;
+}
+._container_1m9ig_1 > p {
+  font-size: 14px;
+  font-weight: 200;
+}
+._container_1m9ig_1._hasShadow_1m9ig_19 {
+  box-shadow: var(--box-shadow);
+}
+._container_1m9ig_1::before {
+  background-color: var(--color-purple);
+  content: "";
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  transition: opacity 0.2s ease-in-out;
+  width: 6px;
+}
+._container_1m9ig_1:hover {
+  border: 1px solid var(--color-purple);
+  box-shadow: 0 0 9px rgba(86, 41, 198, 0.25);
+}
+._deepLinkedComment_1m9ig_38::before {
+  opacity: 1;
+}
+._footer_1m9ig_42 {
+  display: flex;
+  justify-content: space-between;
+  padding-top: var(--size-medium);
+}
+._footer_1m9ig_42 ._actions_1m9ig_47 {
+  column-gap: var(--size-xxSmall);
+  display: flex;
+}
+._iconLabel_1m9ig_52 {
+  align-items: center;
+  column-gap: var(--size-small);
+  display: flex !important;
+}
+._actionButton_1m9ig_58 {
+  padding-bottom: var(--size-xxSmall);
+  padding-left: var(--size-medium);
+  padding-right: var(--size-medium);
+  padding-top: var(--size-xxSmall);
+}
+._tagsContainer_1m9ig_65 {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--size-xSmall);
+  padding-top: var(--size-small);
+}
+
+/* temp_stylePlugin:ni:sha-256;UoSOcmegM3oFFGLGqHlroMMFa0x44tLCdGETDMYSquE */
+._popover_1fpwu_1 {
+  border: 0;
+}
+._popover_1fpwu_1 .ant-popover-inner {
+  background-clip: initial;
+  background-color: transparent;
+  border-radius: initial;
+  box-shadow: none;
+}
+._popover_1fpwu_1 .ant-popover-inner-content {
+  padding: 0;
+}
+._popover_1fpwu_1 .ant-popover-arrow {
+  display: none !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;iuMzoGe35dpQI5HTjtdOwJPRPiVaKTKeWA7vxo0J7s8 */
+._commentButton_r3jun_1 {
+  --comment-indicator-height: 32px;
+  --comment-indicator-width: 32px;
+  background: transparent;
+  border: 0;
+  cursor: crosshair;
+  outline: none;
+  padding: 0;
+  position: absolute;
+  user-select: text;
+  z-index: 1;
+}
+._commentIndicator_r3jun_14 {
+  animation: _grow_r3jun_1 0.2s forwards;
+  height: var(--comment-indicator-height);
+  position: absolute;
+  transform: scale(0);
+  width: var(--comment-indicator-width);
+}
+@keyframes _grow_r3jun_1 {
+  0% {
+    transform: scale(0);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+._blurBackground_r3jun_30 {
+  backdrop-filter: blur(2px);
+}
+
+/* temp_stylePlugin:ni:sha-256;KNLtybHOodlDwe5ALpgQtMziCaPT_ehTA1sSK-nkdDs */
+._comment_mrsyj_1 {
+  cursor: auto;
+  display: flex;
+  position: absolute;
+  z-index: 9999;
+}
+._comment_mrsyj_1 ._commentPinButton_mrsyj_7 {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  outline: none;
+}
+._comment_mrsyj_1 > ._commentPinButton_mrsyj_7 {
+  position: relative;
+  z-index: 99;
+}
+._comment_mrsyj_1:hover {
+  z-index: 10000;
+}
+._sessionCommentCardContainer_mrsyj_21 {
+  background: white;
+  padding: 4px;
+  width: 350px;
+}
+._1hjkzyj0 {
+  padding: 4px;
+  gap: 2px;
+  border: 1px solid var(--_1pyqka9k);
+  border-radius: 5px;
+}
+._1hjkzyj1 {
+  white-space: pre;
+}
+
+/* temp_stylePlugin:ni:sha-256;oDUKD9GxDsgeQivffCYJSAujfaHEtPdjRZBdu4Gz04U */
+._explanatoryPopoverOverlay_jdhfs_1 .ant-popover-inner-content {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+  padding: 4px !important;
+}
+._explanatoryPopoverOverlay_jdhfs_1.ant-popover-placement-top {
+  pointer-events: none;
+}
+._explanatoryPopoverOverlay_jdhfs_1.ant-popover-inner {
+  border: 1px solid var(--color-neutral-200);
+  overflow: hidden;
+}
+._1ubqgtn0 {
+  display: grid;
+  grid-template-columns: 82px 1fr;
+  grid-gap: 8px;
+  cursor: pointer;
+  align-items: center;
+}
+._1ubqgtn2 {
+  display: block;
+}
+._1ecj17q0 {
+  height: 28px;
+  width: 28px;
+}
+._1ecj17q1 {
+  color: var(--_1pyqka9b);
+}
+._1ecj17q2 {
+  color: var(--_1pyqka9y);
+}
+._1ecj17q3 {
+  align-items: center;
+  column-gap: 14px;
+  display: grid;
+  grid-template-columns: fit-content(20px) auto;
+  padding: 8px;
+  position: relative;
+}
+._1ecj17q4 {
+  align-items: center;
+  color: var(--color-gray-500) !important;
+  column-gap: 6px;
+  display: flex;
+}
+
+/* temp_stylePlugin:ni:sha-256;ArcsoNAz4p7FUYC2F1Yv3aNfODFEVZ1Ni1vkIHgwwDk */
+._wrapper_ekn0a_1 {
+  display: flex;
+}
+._detailedView_ekn0a_5 {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--size-large);
+}
+
+/* temp_stylePlugin:ni:sha-256;lfHcsdobC94rw4ojrYCpBkaQGGiSldRgO4pDhlp774w */
+._goToButton_16iej_1 {
+  align-items: center;
+  align-self: flex-start;
+  background: none;
+  border: 0;
+  border-radius: var(--button-border-radius);
+  cursor: pointer;
+  display: flex;
+  font-size: 12px;
+  outline: none;
+  padding: 5px 6px;
+  width: fit-content;
+}
+._goToButton_16iej_1:hover {
+  background: var(--color-purple-200);
+}
+._icon_16iej_18 {
+  color: var(--color-gray-500);
+  fill: var(--color-gray-500);
+  height: 10px;
+  margin-left: var(--size-xSmall);
+  width: auto;
+}
+._small_16iej_26 {
+  filter: brightness(0) saturate(100%);
+  height: 1em;
+  margin-left: 0;
+  transform: scale(1.2);
+  width: 1em;
+}
+._smallIconContainer_16iej_34 {
+  align-items: center;
+  height: var(--size-large);
+  justify-content: center;
+}
+._smallIconContainer_16iej_34:hover {
+  background: var(--color-gray-300);
+}
+
+/* temp_stylePlugin:ni:sha-256;RO6LLK70601pbDvyoyUJbxxe0CqEchiHf7vcLoMCYKg */
+._card_dtk0v_1 {
+  --primary-color: var(--color-purple);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  margin: 0 var(--size-large);
+  overflow: hidden;
+  padding: var(--size-xSmall) var(--size-medium);
+  position: relative;
+  transition: box-shadow 0.1s ease-in;
+}
+._card_dtk0v_1:hover {
+  border: 1px solid var(--color-purple);
+  box-shadow: 0 0 9px rgba(86, 41, 198, 0.25);
+}
+._card_dtk0v_1::before {
+  background: var(--primary-color);
+  content: "";
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  transition: opacity 0.1s ease-in;
+  width: 6px;
+  z-index: 5;
+}
+._card_dtk0v_1._selected_dtk0v_27::before {
+  opacity: 1;
+}
+
+/* temp_stylePlugin:ni:sha-256;U1R1Ei936Ren6QF-gkmm6pjiUZur8PDqJ3Lyu7enRbw */
+._timelinePopoverContent_156p4_1 {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 224px;
+}
+._timelinePopoverContent_156p4_1 span:not(._selectedTypeName_156p4_8) {
+  font-size: 13px;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 20px;
+}
+._timelinePopoverContent_156p4_1 span._selectedTypeName_156p4_8 {
+  color: var(--color-neutral-800);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 12px;
+}
+._infoPanel_156p4_21 {
+  align-items: center;
+  border-bottom: 1px solid var(--color-neutral-200);
+  display: flex;
+  height: 36px;
+  justify-content: flex-start;
+  padding: 4px 8px;
+  user-select: none;
+  width: 100%;
+}
+._timelinePopoverHeader_156p4_32:hover,
+._eventTypeRow_156p4_33:hover {
+  background-color: var(--color-neutral-50);
+  cursor: pointer;
+}
+._timelinePopoverHeader_156p4_32:hover ._transitionIcon_156p4_37 path,
+._eventTypeRow_156p4_33:hover ._transitionIcon_156p4_37 path {
+  fill: var(--color-neutral-500);
+}
+._actionButton_156p4_42 {
+  align-items: center;
+  background: inherit;
+  border: 0;
+  cursor: pointer;
+  display: flex;
+  justify-content: flex-start;
+  padding: 0;
+  user-select: none;
+  width: 100%;
+}
+._leftActionIcon_156p4_54 {
+  margin-right: 4px;
+}
+._rightActionIcon_156p4_58 {
+  margin-left: 4px;
+}
+._eventTypeRow_156p4_33 {
+  align-items: center;
+  display: flex;
+  justify-content: flex-start;
+  padding: 4px 8px;
+  width: 100%;
+}
+._transitionIcon_156p4_37 {
+  height: 16px;
+  width: 16px;
+}
+._transitionIcon_156p4_37 path {
+  fill: var(--color-neutral-300);
+}
+._rightCounter_156p4_78 {
+  align-items: center;
+  color: var(--color-neutral-300);
+  display: flex;
+  margin-left: auto;
+}
+._infoPanelCounter_156p4_85 {
+  border: 1px solid var(--color-neutral-200);
+  border-radius: 3px;
+  color: var(--color-neutral-700);
+  height: 16px;
+  padding: 0 4px;
+}
+._isHidden_156p4_93 {
+  visibility: hidden;
+}
+._timelinePopoverDetails_156p4_97 {
+  display: flex;
+  flex-direction: column;
+  padding-top: 4px;
+  width: 100%;
+}
+._eventTypeIcon_156p4_104 {
+  border-radius: 9999px;
+  height: 8px;
+  margin: 4px;
+  width: 8px;
+}
+._eventIdentifier_156p4_111 {
+  max-width: 128px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* temp_stylePlugin:ni:sha-256;D-TCUv2QRf-i6-eBuTRhlKsp28wW55SF7i63SeOqkXs */
+._bar_1azqj_1 {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: flex-end;
+  overflow: hidden;
+  position: absolute;
+}
+._isShaded_1azqj_11 {
+  background-color: var(--color-neutral-100);
+}
+._rectangleContainer_1azqj_15 {
+  border-radius: 0.2em;
+  display: flex;
+  flex-direction: column;
+  margin: 2px;
+  margin-top: 8px;
+  overflow: hidden;
+  width: calc(100% - 4px);
+}
+._barRectangle_1azqj_25 {
+  border-radius: 2px;
+  cursor: pointer;
+  margin-bottom: 2px;
+}
+._eventAggregateTitle_1azqj_31 {
+  margin: 0;
+  width: 100%;
+}
+._timelineBarPopoverContainer_1azqj_36 .ant-popover-inner-content {
+  padding: 0 !important;
+}
+._timelineBarPopoverContainer_1azqj_36 .ant-popover-inner {
+  border: 1px solid var(--color-neutral-200);
+  overflow: hidden;
+}
+._2maxeq0 {
+  align-items: center;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  z-index: 5;
+  position: relative;
+}
+._2maxeq1 {
+  border-bottom: 1px var(--color-neutral-100) solid;
+  height: 7px;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+  z-index: 2;
+}
+._2maxeq2 {
+  border: 0 !important;
+  height: 0 !important;
+  overflow-x: hidden;
+  visibility: hidden;
+}
+._2maxeq3 {
+  overflow: hidden !important;
+}
+._2maxeq4 {
+  background-color: var(--color-neutral-300);
+  border-bottom: 1px solid var(--color-neutral-100);
+  border-radius: 1px 1px 0 0;
+  height: 3px;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+  z-index: 1;
+}
+._2maxeq5 {
+  will-change: transform;
+  background-color: var(--color-neutral-700);
+  height: 3px;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  transform-origin: left;
+}
+._2maxeq6 {
+  animation-duration: 2s;
+  animation-fill-mode: forwards;
+  animation-iteration-count: infinite;
+  animation-name: liveShimmer;
+  animation-timing-function: linear;
+  background: linear-gradient(to right, var(--color-red-300) 8%, var(--color-red) 38%, var(--color-red-300) 68%);
+  background-size: 800px 5px;
+  display: flex;
+  height: 3px;
+  position: absolute;
+  transition: all 0.2s ease-in-out;
+  width: 100%;
+}
+._2maxeq7 {
+  background-color: var(--color-white);
+  height: 3px;
+  position: absolute;
+  top: 0;
+  z-index: 2;
+  display: flex;
+}
+._2maxeq8 {
+  will-change: transform;
+  background-color: var(--color-neutral-500);
+  z-index: 4;
+  width: 100%;
+  transform-origin: left;
+}
+._2maxeq9 {
+  height: min-content;
+  overflow-x: clip;
+  overflow-y: hidden;
+  overscroll-behavior: none;
+  position: relative;
+  width: 100% !important;
+}
+._2maxeqa {
+  display: flex;
+  flex-direction: column;
+  height: 58px;
+  margin-left: 8px;
+  margin-right: 8px;
+  position: relative;
+  justify-content: flex-end;
+}
+._2maxeqb {
+  position: relative;
+  width: 100%;
+  height: 58px;
+}
+._2maxeqc {
+  height: 24px;
+  margin-left: 8px;
+  margin-right: 8px;
+  pointer-events: none;
+  position: relative;
+}
+._2maxeqd {
+  border-bottom: 1px var(--color-neutral-100) solid;
+}
+._2maxeqe {
+  border-left: 1px var(--color-neutral-200) solid;
+  bottom: 0;
+  position: absolute;
+}
+._2maxeqf {
+  bottom: 10px;
+  color: var(--color-neutral-300);
+  font-family: var(--header-font-family);
+  font-size: 10px;
+  letter-spacing: -0.1em;
+  line-height: 12px;
+  position: absolute;
+  text-align: center;
+  user-select: none;
+}
+._2maxeqg {
+  border-left: 1px solid var(--color-neutral-200);
+  bottom: 0;
+  position: absolute;
+}
+._2maxeqh {
+  height: 8px;
+}
+._2maxeqi {
+  height: 4px;
+}
+._2maxeqj {
+  height: 2px;
+}
+._2maxeqk {
+  background-color: var(--color-neutral-50);
+  bottom: 0;
+  height: 100%;
+  position: absolute;
+  z-index: -1;
+}
+._2maxeql {
+  transition: transform 0.3s linear;
+}
+._2maxeqm {
+  position: absolute;
+  left: 8px;
+  height: 100%;
+  bottom: 0;
+}
+._2maxeqn {
+  will-change: transform;
+  position: relative;
+  height: 100%;
+  width: 10px;
+  overflow: hidden;
+  z-index: 1;
+}
+._2maxeqo {
+  align-items: center;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 10px;
+  position: relative;
+  z-index: 2;
+}
+._2maxeqp {
+  transition: transform 0.17s linear;
+}
+._2maxeqq {
+  width: 4px;
+  background-color: var(--_1pyqka9b);
+  border: 1px solid #ffffff;
+  border-top: none;
+  cursor: ew-resize;
+  height: 59px;
+  position: absolute;
+  top: 24px;
+}
+._2maxeqr {
+  height: 0;
+  visibility: hidden;
+}
+._2maxeqs {
+  background-color: var(--_1pyqka9b);
+  border: 1px solid #ffffff;
+  border-radius: 1px 1px 12px 12px;
+  cursor: grab;
+  height: 10px;
+  position: sticky;
+  top: 15px;
+  width: 8px;
+}
+._2maxeqt {
+  z-index: 2;
+  height: 20px;
+  left: 0;
+  transform-origin: left;
+}
+._4zq3u0 {
+  position: absolute;
+  right: 4px;
+  top: 39px;
+  z-index: 6;
+  display: flex;
+  flex-direction: row;
+  border-radius: 5px;
+  overflow: hidden;
+  justify-content: center;
+  align-items: center;
+  background: #ffffff;
+}
+._4zq3u1 {
+  height: 20px !important;
+}
+._13m092k0 {
+  align-items: center;
+  background-color: var(--_1pyqka91o);
+  border-radius: 40px;
+  bottom: 0;
+  cursor: grab;
+  display: flex;
+  height: 100%;
+  justify-content: space-between;
+  opacity: 0.8;
+  position: absolute;
+  z-index: 2;
+}
+._13m092k1 {
+  background-color: var(--_1pyqka9i);
+  border-radius: 40px;
+  cursor: ew-resize;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  padding: 0 2px;
+  user-select: none;
+}
+._13m092k2 {
+  background-color: #ffffff;
+  border-radius: 3px;
+  height: 50%;
+  user-select: none;
+  width: 3px;
+}
+._13m092k3 {
+  height: 100%;
+  width: 100%;
+}
+._13m092k4 {
+  transition: width 0.17s linear;
+}
+
+/* temp_stylePlugin:ni:sha-256;o3NjbMjlK-G0_Mov2-LHBqEp_X-_GYBGeP3nsXHQRNc */
+._sessionToken_ci7y5_1 {
+  align-items: center;
+  color: var(--color-gray-500);
+  display: flex;
+  flex-shrink: 0;
+  font-size: 12px;
+  gap: var(--size-xSmall);
+  max-width: 378px;
+  min-width: 0;
+}
+._sessionToken_ci7y5_1 > span {
+  color: var(--color-gray-500);
+  line-height: normal;
+  margin: 0;
+  white-space: nowrap;
+}
+._sessionToken_ci7y5_1 a {
+  color: var(--text-primary);
+}
+._sessionToken_ci7y5_1 svg {
+  color: var(--color-gray-500);
+  flex-shrink: 0;
+  height: 16px;
+  width: 16px;
+}
+._iconContainer_ci7y5_27 {
+  display: flex;
+}
+
+/* temp_stylePlugin:ni:sha-256;q4KT-az-mVtYfjCc2zkmD8tLbc6VYVZOpzuEihLTzeU */
+._button_1d1w0_1 {
+  align-items: center;
+  border: 1px solid var(--color-neutral-100);
+  border-radius: 6px;
+  display: flex;
+  height: 30px;
+  justify-content: center;
+  padding: 6px;
+  width: 30px;
+}
+._button_1d1w0_1 > svg {
+  height: 16px;
+  width: 16px;
+}
+._button_1d1w0_1 > svg path {
+  fill: var(--color-neutral-800);
+}
+._button_1d1w0_1:disabled {
+  background: var(--color-white) !important;
+  border: 0;
+  cursor: not-allowed;
+}
+._button_1d1w0_1:disabled > svg path {
+  fill: var(--color-neutral-300);
+}
+._button_1d1w0_1::after {
+  display: none !important;
+}
+._button_1d1w0_1:hover,
+._button_1d1w0_1:focus {
+  background-color: var(--color-neutral-50);
+  border: 1px solid var(--color-neutral-100);
+}
+._button_1d1w0_1:focus {
+  border: 1px solid var(--color-neutral-300);
+}
+._popoverCmdShortcut_1d1w0_40 {
+  background-color: var(--color-neutral-100);
+  border-radius: 3px;
+  color: var(--color-neutral-500);
+  font-size: 11px;
+  padding: 1px 4px;
+}
+._moveRight_1d1w0_48 {
+  margin-left: auto;
+}
+._smallButton_1d1w0_52 {
+  background: var(--color-neutral-50);
+  border: 0;
+  border-radius: 10px;
+  height: 20px;
+  padding: 2px 10px;
+  width: fit-content;
+}
+._smallButton_1d1w0_52 > span {
+  color: var(--color-neutral-700);
+  font-size: 12px;
+  line-height: 16px;
+}
+._smallButton_1d1w0_52:hover,
+._smallButton_1d1w0_52:focus {
+  background: var(--color-neutral-50);
+  border: 0;
+}
+._minorButton_1d1w0_72 {
+  background: var(--color-neutral-100);
+  border: 0;
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+}
+._minorButton_1d1w0_72:hover,
+._minorButton_1d1w0_72:focus {
+  background: var(--color-neutral-200);
+  border: 0;
+  box-shadow: none;
+}
+._minorButton_1d1w0_72:focus {
+  border: 1px solid var(--color-neutral-300);
+}
+._activeButton_1d1w0_89,
+._activeButton_1d1w0_89:hover,
+._activeButton_1d1w0_89:focus {
+  background: var(--color-new-purple-500);
+}
+._activeButton_1d1w0_89 > svg path,
+._activeButton_1d1w0_89:hover > svg path,
+._activeButton_1d1w0_89:focus > svg path {
+  fill: var(--color-white);
+}
+._activeButton_1d1w0_89 > span,
+._activeButton_1d1w0_89:hover > span,
+._activeButton_1d1w0_89:focus > span {
+  color: var(--color-white);
+}
+._currentTime_1d1w0_105 {
+  color: var(--color-neutral-500);
+  font-size: 13px;
+}
+._settingsPopoverOverlay_1d1w0_110 .ant-popover-inner-content {
+  padding: 0 !important;
+}
+._settingsPopoverOverlay_1d1w0_110 .ant-popover-inner-content > div {
+  padding: 0 !important;
+}
+._settingsPopoverOverlay_1d1w0_110 .ant-popover-inner {
+  border: 1px solid var(--color-neutral-200);
+  overflow: hidden;
+}
+._settingsContainer_1d1w0_121 {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 224px;
+}
+._settingsContainer_1d1w0_121 > ._section_1d1w0_128:first-child {
+  border-bottom: 1px solid var(--color-neutral-200);
+}
+._section_1d1w0_128 {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 4px 0;
+  width: 100%;
+}
+._settingsButton_1d1w0_141 {
+  align-items: center;
+  background-color: inherit;
+  border: 0;
+  display: flex;
+  font-size: 13px;
+  gap: 4px;
+  height: 28px;
+  padding: 4px 8px;
+  user-select: none;
+  width: 100%;
+}
+._settingsButton_1d1w0_141:hover {
+  background: var(--color-neutral-50);
+  cursor: pointer;
+}
+._settingsButton_1d1w0_141 > svg {
+  height: 16px;
+  width: 16px;
+}
+._settingsButton_1d1w0_141 > svg path {
+  fill: var(--color-neutral-300);
+}
+._settingsOptionShortcut_1d1w0_165 {
+  align-items: center;
+  border: 1px solid var(--color-neutral-200);
+  border-radius: 3px;
+  display: flex;
+  font-size: 12px;
+  font-weight: 400;
+  height: 16px;
+  line-height: 16px;
+  padding: 0 4px;
+}
+._leftSelection_1d1w0_177 {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+}
+._leftSelection_1d1w0_177:hover > ._leftClickActionName_1d1w0_183 {
+  visibility: visible;
+}
+._leftClickActionName_1d1w0_183 {
+  color: var(--color-neutral-500);
+  font-size: 11px;
+  visibility: hidden;
+}
+._liveUserStatus_1d1w0_193 {
+  user-select: none;
+}
+
+/* temp_stylePlugin:ni:sha-256;qZTeLDHs_ZRYGV0yYlAnkKl81dOnCQrTe81L_PKtwgg */
+._eventWrapper_livaz_1 {
+  align-items: center;
+  display: flex;
+  font-size: 12px;
+  height: max-content;
+}
+._streamElement_livaz_8 {
+  align-items: center;
+  background-color: inherit;
+  border-radius: 6px;
+  color: var(--color-gray-500);
+  column-gap: var(--size-small);
+  display: grid;
+  fill: var(--color-gray-500);
+  font-family: var(--body-font-family);
+  font-size: 12px !important;
+  grid-template-columns: 22px 1fr min-content;
+  height: 100%;
+  position: relative;
+  width: 100%;
+}
+._streamElement_livaz_8._noTimestamp_livaz_23 {
+  grid-template-columns: 22px 1fr;
+}
+._card_livaz_27 {
+  cursor: pointer;
+}
+._cardContainer_livaz_31 {
+  padding-bottom: var(--size-medium);
+}
+._cardContainer_livaz_31._firstCard_livaz_34 {
+  padding-top: var(--size-medium);
+}
+._eventTime_livaz_38 {
+  align-items: center;
+  display: flex;
+  font-size: 10px;
+  height: 100%;
+  justify-content: flex-end;
+  margin-left: 10px;
+  padding: 5px;
+  padding-right: 0;
+  width: max-content;
+}
+._iconWrapper_livaz_50 {
+  background: var(--primary-color);
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 5px;
+}
+._playIcon_livaz_60 {
+  height: 20px;
+  width: 20px;
+}
+._directionIcon_livaz_65 {
+  color: var(--text-primary-inverted);
+  fill: var(--text-primary-inverted);
+  height: var(--size-small);
+  transition: transform 0.3s;
+  width: var(--size-small);
+}
+._defaultIcon_livaz_73 {
+  color: var(--text-primary-inverted);
+  height: var(--size-small);
+  width: var(--size-small);
+}
+._tiltedIcon_livaz_79 {
+  color: var(--text-primary-inverted);
+  fill: var(--text-primary-inverted);
+  height: var(--size-small);
+  transform: rotate(-20deg);
+  width: var(--size-small);
+}
+._eventText_livaz_87 {
+  color: var(--color-gray-500) !important;
+  margin: 0 !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color 0.2s ease-in-out;
+  white-space: nowrap;
+}
+._eventText_livaz_87._eventTextSelected_livaz_95 {
+  color: var(--text-primary) !important;
+}
+._eventContent_livaz_99 {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  min-width: 100%;
+}
+._eventContentVerbose_livaz_106 {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 100%;
+}
+._timestamp_livaz_113 {
+  grid-column-end: 3;
+  grid-column-start: 1;
+}
+._goToButton_livaz_118 {
+  color: var(--color-gray-500);
+  grid-column-start: 3;
+  grid-row-start: 3;
+  position: absolute;
+  right: -8px;
+  top: -6px;
+}
+._goToButton_livaz_118:hover {
+  color: var(--text-primary);
+  fill: var(--text-primary);
+}
+._goToButton_livaz_118:hover svg {
+  fill: var(--text-primary);
+}
+._payloadContainer_livaz_134 {
+  border-top: 1px solid var(--color-gray-300);
+  grid-column-end: -1;
+  grid-column-start: 1;
+  margin: 0 -18px;
+  margin-top: var(--size-xSmall);
+  padding: var(--size-small) 18px;
+}
+._selectedIcon_livaz_143 {
+  fill: var(--text-primary);
+  transform: rotate(180deg);
+}
+._headerRow_livaz_148 {
+  align-items: center;
+  display: flex;
+}
+._payloadTitle_livaz_153 {
+  font-size: 12px !important;
+  margin-bottom: var(--size-xSmall) !important;
+}
+._payloadTitle_livaz_153 > div {
+  overflow-wrap: anywhere;
+}
+
+/* temp_stylePlugin:ni:sha-256;_HaBycMH4QV4R2J4csVwhyiuj75ICdXj4v98WCoRdHw */
+._objectKey_1bobg_1 {
+  color: var(--color-gray-500);
+  display: block;
+  font-size: 12px !important;
+  font-style: normal;
+  line-height: initial;
+  margin-bottom: var(--size-xxSmall);
+  text-transform: capitalize;
+}
+._objectList_1bobg_11 {
+  column-gap: var(--size-small);
+  display: grid;
+  font-family: var(--header-font-family);
+  grid-template-columns: auto 1fr;
+  padding: 0;
+  row-gap: var(--size-xSmall);
+}
+._objectValue_1bobg_20 {
+  color: var(--text-primary);
+  font-size: 12px !important;
+  font-style: normal;
+  line-height: initial;
+  width: 154px;
+}
+._objectValue_1bobg_20 > * {
+  display: block;
+  overflow-wrap: break-word;
+  width: 154px;
+}
+._payload_1bobg_33 {
+  margin: 0 !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._anchor_1bobg_40 {
+  vertical-align: middle;
+  word-wrap: break-word;
+}
+.v8kz6z0 {
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  width: 100%;
+}
+.v8kz6z0:hover {
+  background-color: var(--_1pyqka91x);
+}
+.v8kz6z2 {
+  background-color: var(--_1pyqka91y);
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.1);
+}
+._1eia00s0 {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+._1eia00s1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 20px;
+}
+._1mjemv0 {
+  margin: 0;
+  max-height: calc(100vh - 540px);
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/* temp_stylePlugin:ni:sha-256;OIrsnmx3ccW_yCvbGjyoF5h50DXkhQnrvLlOqyBqs34 */
+._card_1sxl2_1 {
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  transition: box-shadow 0.1s ease-in;
+}
+._card_1sxl2_1 p,
+._card_1sxl2_1 a {
+  font-size: 12px;
+  margin-top: 0 !important;
+}
+._card_1sxl2_1 p {
+  color: var(--color-gray-500);
+}
+._card_1sxl2_1 h2 {
+  color: var(--text-primary);
+  font-size: 12px !important;
+  margin: 0;
+}
+._card_1sxl2_1:hover {
+  border: 1px solid var(--color-purple);
+  box-shadow: 0 0 9px rgba(86, 41, 198, 0.25);
+}
+._card_1sxl2_1 ._titleContainer_1sxl2_23 {
+  align-items: center;
+  border-bottom: 1px solid var(--color-gray-300);
+  display: flex;
+  height: 48px;
+  justify-content: space-between;
+  margin-bottom: var(--size-xxSmall);
+  padding: 0 var(--size-small);
+  width: 100%;
+}
+._card_1sxl2_1 ._content_1sxl2_33 {
+  padding-bottom: var(--size-small);
+  padding-left: var(--size-small);
+  padding-right: var(--size-small);
+  padding-top: var(--size-small);
+}
+._fullWidth_1sxl2_40 {
+  width: 100%;
+}
+
+/* temp_stylePlugin:ni:sha-256;UVyX9Lg_AskWpQZHWLQtFR92pfvLw4hswGxdqdqg7_w */
+._requestMetrics_1a9is_1 {
+  width: 100%;
+}
+._chartContainer_1a9is_5 {
+  height: 200px;
+  margin-top: var(--size-medium);
+}
+.riaubm0 {
+  background: #fdfcfd;
+  width: 100%;
+  height: 100%;
+}
+.riaubm1 {
+  width: 100%;
+  height: calc(100% - 32px);
+  display: flex;
+  flex-direction: column;
+  padding-left: 8px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  word-wrap: break-word;
+}
+.riaubm2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding-right: 24px;
+}
+.riaubm3 {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  height: 100%;
+}
+.riaubm4 {
+  background-color: #e4e2e4;
+}
+.riaubm5 {
+  background-color: #6b48c7;
+  border-radius: 4px;
+  height: 60%;
+}
+.riaubm6 {
+  display: grid;
+  grid-template-columns: 80px 80px 1fr 100px 80px 80px 20px;
+  grid-gap: 6px;
+  border-bottom: 1px solid #e4e2e4;
+  padding: 12px 14px 10px;
+}
+.riaubm7 {
+  display: grid;
+  grid-template-columns: 80px 80px 1fr 100px 80px 80px 20px;
+  grid-gap: 6px;
+  padding: 6px;
+  color: var(--_1pyqka9w);
+  width: 100%;
+  height: 36px;
+  align-items: center;
+}
+.riaubm7:hover {
+  background-color: var(--_1pyqka91x);
+}
+.riaubma {
+  color: var(--_1pyqka915);
+}
+.riaubmc {
+  font-weight: 500;
+}
+._9ttgrc0 {
+  height: 100%;
+  width: 100%;
+}
+._1gzpu1z0 {
+  display: flex;
+  flex-direction: column;
+  row-gap: 4px;
+}
+
+/* temp_stylePlugin:ni:sha-256;kLThyQVADRduAdI4tXILtXF01bMXoF0zvQyu0IW5E94 */
+._noCommentsContainer_1vmpu_1 {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: inherit;
+  justify-content: center;
+  margin: var(--size-xxLarge);
+}
+._noCommentsTextContainer_1vmpu_10 {
+  text-align: center;
+  top: 35%;
+  width: 200px;
+}
+._noCommentsTextContainer_1vmpu_10 h2 {
+  color: var(--text-primary);
+  font-size: 14px !important;
+  font-weight: 400 !important;
+  margin: 0;
+  margin-bottom: var(--size-xSmall);
+}
+._noCommentsTextContainer_1vmpu_10 p {
+  color: var(--color-gray-500);
+  font-size: 12px !important;
+  margin: 0;
+}
+._timestamp_1vmpu_28 {
+  color: var(--color-gray-500);
+  margin: 0 !important;
+}
+._skeleton_1vmpu_33 {
+  border-radius: var(--size-xSmall) !important;
+  display: block !important;
+  height: 90px;
+  margin: var(--size-xxSmall) var(--size-large);
+  margin-bottom: var(--size-medium);
+  margin-top: var(--size-xSmall);
+  width: auto !important;
+}
+.ltrwrc0 {
+  height: calc(100vh - 108px - var(--banner-height));
+}
+.ltrwrc1 {
+  position: fixed;
+  left: 100%;
+  transform: translateX(300px);
+}
+.ltrwrc2 {
+  height: 100%;
+  padding: 0;
+}
+.ltrwrc3 {
+  border-radius: 8px;
+}
+._1l6nlco0 {
+  padding: 0;
+}
+._1m26oyu0 {
+  align-items: center;
+  background-color: #ffffff;
+  display: flex;
+}
+._1m26oyu1 {
+  transform: rotate(180deg);
+  height: 14px;
+  color: #6f6e77;
+}
+._1m26oyu2 {
+  height: 14px;
+  padding-right: 8px;
+  color: #6f6e77;
+}
+._1m26oyu3 {
+  border-left: 1px solid #e4e2e4;
+  height: 16px;
+}
+._1m26oyu4 {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-x: hidden;
+  display: inline-block;
+}
+._1m26oyu5 {
+  display: flex;
+  align-items: center;
+  overflow-x: hidden;
+  gap: 8px;
+}
+._1m26oyu6 {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  min-width: 400px;
+}
+._1m26oyu7 {
+  flex-shrink: 0;
+}
+._1m26oyu8:focus:enabled,
+._1m26oyu8:active:enabled {
+  background: #e9e8ea;
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.1);
+}
+._1m26oyu9:focus:enabled,
+._1m26oyu9:active:enabled {
+  background: transparent;
+  color: #6f6e77;
+}
+.izessr0 {
+  padding-left: 8px;
+  height: 100%;
+}
+.izessr1:focus,
+.izessr1:active,
+.izessr1:hover {
+  background-color: #e9e8ea;
+}
+.izessr2 {
+  background-color: #eeedef;
+}
+._1p577ua0 {
+  font-size: 13px;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+._1p577ua1 {
+  border-radius: 6px;
+  color: #6f6e77;
+  display: grid;
+  grid-template-columns: 3fr 1fr auto 100px 20px;
+  gap: 8px;
+  margin-bottom: 1px;
+  padding: 8px;
+}
+._1p577ua1:hover {
+  background-color: #eeedef;
+  border-bottom: 1px solid #e4e2e4;
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.1);
+  margin-bottom: 0;
+}
+._1p577ua2 {
+  background-color: #eeedef;
+  border-bottom: 1px solid #e4e2e4;
+  box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.1);
+  margin-bottom: 0;
+}
+._1p577ua4 {
+  align-items: center;
+  display: flex;
+  word-wrap: break-word;
+}
+._1p577ua5 {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-all;
+  -webkit-line-clamp: 1;
+  line-clamp: 1;
+}
+._1eq64x70 {
+  align-items: center;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  z-index: 5;
+  position: relative;
+}
+._1eq64x71 {
+  transform: rotate(90deg);
+}
+._1eq64x72 {
+  height: 20px;
+}
+.hgp31e0 .ant-modal-content {
+  background-color: var(--_1pyqka92);
+  border-radius: 8px !important;
+  border: var(--_1pyqka9j) solid 1px;
+  box-shadow: 0 6px 12px -2px rgba(59, 59, 59, 0.12);
+}
+.hgp31e0 .ant-modal-body {
+  padding: 0;
+}
+.tzvxpp0 {
+  width: 340px;
+  position: fixed;
+  height: calc(100vh - var(--header-height));
+}
+.tzvxpp1 {
+  height: calc(100vh - var(--header-height) - var(--banner-height));
+}
+.tzvxpp2 {
+  position: fixed;
+  transform: translateX(-340px);
+}
+._1gfijho0 {
+  align-items: center;
+  display: flex;
+  height: 20px;
+  justify-content: space-between;
+}
+._1gfijho1 {
+  max-width: 100%;
+}
+._1gfijho2 {
+  color: #6f6e77;
+}
+._1gfijho3 {
+  cursor: pointer;
+  padding-top: 2px;
+  width: 80px;
+}
+._1gfijho4:hover {
+  background: #eeedef;
+}
+._1gfijho5 {
+  background: #e9e8ea;
+}
+._1gfijho5:hover {
+  background-color: #e9e8ea;
+}
+._1gpgayi0 {
+  border-top: solid 1px #e4e2e4;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+._1gpgayi1 {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+._1gpgayi2 {
+  background-color: #f9f8f9;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  height: 100%;
+  padding: 8px;
+}
+._1gpgayi3 {
+  background: #fdfcfd;
+  border: 1px solid #e4e2e4;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px -2px rgba(59, 59, 59, 0.08);
+  overflow: clip;
+  display: flex;
+  flex: 2;
+  height: 100%;
+  width: 100%;
+}
+._1gpgayi4 {
+  align-items: center;
+  box-sizing: border-box;
+  display: flex;
+  flex-grow: 1;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+}
+._1gpgayi5 iframe {
+  border-radius: 4px;
+  border: var(--_1pyqka9k) solid 1px;
+  box-shadow: 0 6px 12px -2px rgba(59, 59, 59, 0.12);
+}
+._1gpgayi6 {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  position: relative;
+  min-width: 428px;
+}
+._1gpgayi7 {
+  position: relative;
+  z-index: 98;
+}
+._1gpgayi8 {
+  position: fixed;
+  transform: translateX(-340px);
+}
+._1gpgayi9 {
+  align-items: center;
+  color: #000000;
+  cursor: move;
+  display: flex;
+  justify-content: flex-end;
+  position: relative;
+  left: 32px;
+  top: -700px;
+  z-index: 200;
+}
+._1gpgayia {
+  align-self: center !important;
+  height: fit-content;
+  justify-self: center !important;
+}
+._1gpgayib {
+  cursor: pointer;
+  text-decoration: underline;
+}
+._1gpgayic {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+._1gpgayid {
+  grid-template-columns: 340px 1fr;
+}
+._1gpgayie {
+  grid-template-columns: 1fr 300px;
+}
+._1t72qig0 {
+  position: absolute;
+  right: 0;
+  top: -6px;
+}
+._1t72qig1 {
+  background-color: var(--_1pyqka92);
+  border: var(--_1pyqka9k) solid 1px;
+  border-radius: 6px;
+  display: block;
+  padding: 0;
+  position: relative;
+}
+._1t72qig1 code {
+  padding-bottom: 8px !important;
+  padding-top: 8px !important;
+}
+@keyframes bva4e60 {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+.bva4e61 {
+  animation: 1s bva4e60 linear infinite;
+}
+.bva4e62 {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.bva4e63 {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.u1xyjd0 {
+  border-radius: 4px;
+  color: var(--_1pyqka9y);
+  cursor: pointer;
+  padding: 12px 8px;
+  width: 325px;
+}
+.u1xyjd0:hover {
+  background-color: var(--_1pyqka91x);
+  color: var(--_1pyqka9w);
+}
+.u1xyjd1 {
+  background-color: var(--_1pyqka91y);
+  color: var(--_1pyqka9w);
+}
+.u1xyjd2 {
+  background-color: var(--_1pyqka91z);
+  color: var(--_1pyqka9x);
+  cursor: not-allowed;
+}
+.u1xyjd2:hover {
+  background-color: var(--_1pyqka91z);
+  color: var(--_1pyqka9x);
+}
+.u1xyjd3 {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+  padding: 8px;
+}
+.u1xyjd4 {
+  align-items: center;
+  border: var(--_1pyqka9k) solid 1px;
+  border-radius: 6px;
+  display: flex;
+  height: 36px;
+  margin-bottom: 6px;
+  justify-content: space-between;
+  padding: 0 8px;
+  width: 325px;
+}
+
+/* temp_stylePlugin:ni:sha-256;xzxoGgxTfoh-imsoN727UnT5YWTJkn2XSqtpBc6dwoU */
+._alert_1c69p_1.ant-alert-info {
+  background-color: var(--color-blue-100) !important;
+  border: 0 !important;
+  border-radius: var(--border-radius) !important;
+  color: var(--color-blue-800) !important;
+}
+._alert_1c69p_1.ant-alert-info .ant-alert-message {
+  color: var(--color-blue-800) !important;
+}
+._alert_1c69p_1.ant-alert-info .ant-alert-close-text {
+  color: var(--color-blue-800) !important;
+}
+._alert_1c69p_1.ant-alert-info .ant-alert-icon {
+  color: var(--color-blue-600) !important;
+}
+._alert_1c69p_1.ant-alert-success {
+  background-color: var(--color-green-100) !important;
+  border: 0 !important;
+  border-radius: var(--border-radius) !important;
+  color: var(--color-green-800) !important;
+}
+._alert_1c69p_1.ant-alert-success .ant-alert-message {
+  color: var(--color-green-800) !important;
+}
+._alert_1c69p_1.ant-alert-success .ant-alert-close-text {
+  color: var(--color-green-800) !important;
+}
+._alert_1c69p_1.ant-alert-success .ant-alert-icon {
+  color: var(--color-green-600) !important;
+}
+._alert_1c69p_1.ant-alert-warning {
+  background-color: var(--color-yellow-100) !important;
+  border: 0 !important;
+  border-radius: var(--border-radius) !important;
+  color: var(--color-yellow-800) !important;
+}
+._alert_1c69p_1.ant-alert-warning .ant-alert-message {
+  color: var(--color-yellow-800) !important;
+}
+._alert_1c69p_1.ant-alert-warning .ant-alert-close-text {
+  color: var(--color-yellow-800) !important;
+}
+._alert_1c69p_1.ant-alert-warning .ant-alert-icon {
+  color: var(--color-yellow-600) !important;
+}
+._alert_1c69p_1 .ant-alert-description {
+  font-size: 12px !important;
+  line-height: 1.6em !important;
+}
+._alert_1c69p_1.ant-alert-error {
+  background-color: var(--color-orange-300) !important;
+  border: 0 !important;
+  border-radius: var(--border-radius) !important;
+  color: var(--text-primary) !important;
+}
+._alert_1c69p_1.ant-alert-error .ant-alert-message {
+  color: var(--text-primary) !important;
+}
+._alert_1c69p_1.ant-alert-error .ant-alert-close-text {
+  color: var(--text-primary) !important;
+}
+._alert_1c69p_1.ant-alert-error .ant-alert-icon {
+  color: var(--color-red-600) !important;
+}
+._alert_1c69p_1 .ant-alert-icon {
+  margin-right: var(--size-small) !important;
+}
+._alert_1c69p_1.ant-alert {
+  padding-bottom: var(--size-medium) !important;
+  padding-left: var(--size-medium) !important;
+  padding-right: var(--size-medium) !important;
+  padding-top: var(--size-medium) !important;
+}
+._alert_1c69p_1 .ant-alert-message {
+  font-weight: 500;
+  margin-bottom: var(--size-small) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;9Bp9lbLvuqqJsCiaFjLSmTa76gHvcv-y1nXmbKR8teA */
+._fieldsBox_1vi9t_1 {
+  border: 1px solid var(--color-gray-300);
+  border-radius: 8px;
+  margin-top: var(--size-large);
+  padding: 30px;
+  width: 100%;
+}
+._fieldsBox_1vi9t_1 h3 {
+  font-size: 18px;
+  margin-bottom: var(--size-large) !important;
+}
+._focus_1vi9t_13 {
+  border-color: var(--color-purple-400);
+}
+
+/* temp_stylePlugin:ni:sha-256;srCfFoKae8fKdlD_DuLZp6hqbN88QrIprqPTLFPjM_w */
+._fieldRow_lusyh_1 {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  margin-bottom: var(--size-large);
+}
+._fieldRow_lusyh_1:last-of-type {
+  margin-bottom: 0;
+}
+._fieldKey_lusyh_10 {
+  align-items: center;
+  display: flex;
+  height: 100%;
+}
+._saveButton_lusyh_16 {
+  width: max-content;
+}
+
+/* temp_stylePlugin:ni:sha-256;2BqSHb7JhJqB7pN5j3AH2eB-mYmtzm11QLpg4wZpkhk */
+._container_4rhi2_1 {
+  max-width: 700px;
+}
+._subTitle_4rhi2_5 {
+  font-size: 18px;
+}
+._titleContainer_4rhi2_9 {
+  margin-bottom: var(--size-xxLarge);
+  margin-top: var(--size-xxLarge);
+}
+
+/* temp_stylePlugin:ni:sha-256;nTbiwVbahkscGSGQHrhzO0foF4qYpunjdY6K8JO9iMY */
+._popConfirmContainer_m61jp_1 {
+  z-index: 999999999;
+}
+._popConfirmContainer_m61jp_1 .ant-popover-message-title {
+  max-width: 300px;
+  padding-left: 0 !important;
+}
+._popConfirmContainer_m61jp_1 .ant-popover-inner-content {
+  padding-bottom: var(--size-medium) !important;
+}
+._popConfirmContainer_m61jp_1 .ant-btn {
+  height: unset !important;
+  padding-bottom: 8px !important;
+  padding-top: 8px !important;
+}
+._popConfirmContainer_m61jp_1 .ant-popover-inner {
+  background-color: var(--color-primary-background);
+  border: 1px solid var(--color-gray-300);
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow);
+}
+._popConfirmContainer_m61jp_1 ._description_m61jp_22 {
+  color: var(--color-gray-500) !important;
+  line-height: 1.5 !important;
+  margin-bottom: 0 !important;
+  margin-top: var(--size-xSmall) !important;
+}
+._popConfirmContainer_m61jp_1 .ant-popover-buttons button {
+  margin-left: var(--size-medium) !important;
+}
+._popConfirmContainer_m61jp_1 .ant-btn {
+  border-radius: var(--button-border-radius) !important;
+  padding: var(--size-xSmall) var(--size-medium) !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;lkiIVfj2hgwEVrPzESe6RjW3aasNdGYzoJDGWcnRDgg */
+._memberCard_1ebot_1 {
+  align-items: center;
+  column-gap: var(--size-small);
+  display: flex;
+  flex-direction: row;
+}
+._memberCardWrapper_1ebot_8 {
+  margin-right: var(--size-xxLarge) !important;
+  max-width: 700px;
+  width: 100%;
+}
+._email_1ebot_14 {
+  color: var(--color-gray-500);
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._role_1ebot_22 {
+  color: var(--color-gray-500);
+  font-size: 13px;
+  justify-content: flex-end;
+}
+._removeTeamMemberButton_1ebot_28 {
+  border: none;
+  flex-shrink: 0;
+  height: fit-content;
+  margin-left: auto;
+}
+
+/* temp_stylePlugin:ni:sha-256;c1OKVW9cr_3q9e5EDPveLl2Gvpz9U2jPDBwkoUgTo_I */
+._container_17qsm_1 {
+  align-items: center;
+  background-color: var(--color-gray-100);
+  border: 1px solid rgb(223, 223, 223);
+  border-radius: var(--button-border-radius);
+  display: flex;
+  height: 36px;
+}
+._container_17qsm_1 ._copyButton_17qsm_9 {
+  border-radius: var(--button-border-radius);
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+  height: 36px;
+  margin-left: auto;
+}
+._container_17qsm_1 ._link_17qsm_16 {
+  margin-left: var(--size-small);
+  margin-right: var(--size-small);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._inlineContainer_17qsm_24 {
+  align-items: center;
+  column-gap: var(--size-xxSmall);
+  display: flex;
+}
+._inlineContainer_17qsm_24 ._copyButton_17qsm_9 {
+  color: inherit !important;
+  height: 1.2em;
+  width: 1.2em;
+}
+._inlineContainer_17qsm_24 ._copyButton_17qsm_9 svg {
+  color: inherit;
+  height: 1em;
+}
+
+/* temp_stylePlugin:ni:sha-256;QyjayrCu-j-AM2Y_jekCzF3uO1cAmdBIVQpsRbb7Srg */
+._boxSubTitle_1g9q5_1 {
+  color: var(--color-gray-500) !important;
+  margin-top: 0 !important;
+}
+._buttonRow_1g9q5_6 {
+  align-items: center;
+  column-gap: var(--size-medium);
+  display: grid;
+  grid-template-columns: 1fr 120px;
+}
+._emailInput_1g9q5_13 {
+  height: 40px;
+}
+._inviteButton_1g9q5_17 {
+  width: 100%;
+}
+._hr_1g9q5_21 {
+  border: 0;
+  border-top: 1px solid var(--color-gray-300);
+  margin: var(--size-large) 0;
+}
+
+/* temp_stylePlugin:ni:sha-256;YwL9G6oRbMITFwU-4D_kPLzDpBEEhznvMup2y3VebLk */
+._inviteCard_b35ac_1 {
+  align-items: center;
+  column-gap: var(--size-small);
+  display: flex;
+  flex-direction: row;
+}
+._inviteCardWrapper_b35ac_8 {
+  margin-right: var(--size-xxLarge) !important;
+  max-width: 700px;
+  width: 100%;
+}
+._inviteTime_b35ac_14 {
+  color: var(--color-gray-500);
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+._role_b35ac_22 {
+  color: var(--color-gray-500);
+  font-size: 13px;
+  justify-content: flex-end;
+}
+._removeTeamMemberButton_b35ac_28 {
+  border: none;
+  flex-shrink: 0;
+  height: fit-content;
+  margin-left: auto;
+}
+
+/* temp_stylePlugin:ni:sha-256;IoyBQ1VA45qlD6Zu9-Bo74JcOexd8jHjvJcOkjrtxrw */
+._titleContainer_ov5oy_1 {
+  margin-bottom: var(--size-medium) !important;
+  margin-top: var(--size-xxLarge) !important;
+  max-width: 700px;
+}
+._titleContainer_ov5oy_1 #_subTitle_ov5oy_1 {
+  margin-bottom: 0 !important;
+  margin-top: var(--size-xSmall) !important;
+}
+._tabTitle_ov5oy_11 {
+  font-weight: 500 !important;
+}
+._teamTabs_ov5oy_15 .ant-tabs-tab.ant-tabs-tab-active .ant-tabs-tab-btn {
+  color: var(--color-purple) !important;
+}
+._teamTabs_ov5oy_15 .ant-tabs-ink-bar {
+  background: var(--color-purple) !important;
+}
+._teamTabs_ov5oy_15 .ant-tabs-tab {
+  margin-left: 0 !important;
+}
+
+/* temp_stylePlugin:ni:sha-256;Gulow90gNu7c7YDmims9UfFglllYW_pTWUw8Cga9X4g */
+._dangerRow_lvmhv_1 {
+  align-items: center;
+  display: grid;
+  grid-template-columns: 1fr 120px;
+  margin-top: 5px;
+}
+._deleteButton_lvmhv_8 {
+  background-color: var(--color-red-400);
+  margin-left: 15px;
+  padding-left: 30px;
+  padding-right: 30px;
+  width: max-content;
+}
+._dangerSubTitle_lvmhv_16 {
+  margin-bottom: 10px;
+  margin-top: 10px;
+}
+
+/* temp_stylePlugin:ni:sha-256;pEBciyyS-YTHsF_sOtgIZjAw6QL0Dj3dQzJeq0zFTiU */
+._inputAndButtonRow_ib336_1 {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 5px;
+}
+._input_ib336_1 {
+  width: 100%;
+}
+._saveButton_ib336_12 {
+  margin-left: 15px;
+  width: max-content;
+}
+
+/* temp_stylePlugin:ni:sha-256;0o8xMA5Gjd2FS1zgxsAJrM0t7LXbHrIiF--JEBX0kYA */
+._sourcemapInfo_16mzb_1 {
+  border-bottom: 1px solid var(--color-gray-300);
+  margin-bottom: var(--size-xLarge);
+  padding-bottom: var(--size-xLarge);
+}
+._list_16mzb_7 {
+  margin-top: var(--size-xxSmall);
+}
+._list_16mzb_7 .ant-table-cell {
+  cursor: default;
+}
+._listHeader_16mzb_14 {
+  margin-bottom: var(--size-medium);
+}
+._listHeader_16mzb_14 h3 {
+  margin-bottom: 0 !important;
+}
+._listHeader_16mzb_14 .ant-input-affix-wrapper {
+  width: 150px;
+}
+._listHeader_16mzb_14 ._versionSelect_16mzb_23 {
+  margin-bottom: var(--size-medium);
+  width: 100%;
+}
+._listRow_16mzb_28 {
+  display: block;
+  width: 100%;
+}
+._select_16mzb_33 {
+  margin-bottom: var(--size-medium);
+  width: 100%;
+}
+
+/* temp_stylePlugin:ni:sha-256;r8RPgmawaLQx53O4DjEPmKhUqnYFSfO6XEIpIzNop0k */
+._tabsContainer_lizta_1 {
+  margin-top: var(--size-large);
+}
+._tabsContainer_lizta_1 .ant-tabs-nav::before {
+  border-bottom: 0 !important;
+}
+._tabsContainer_lizta_1 .ant-tabs-tab {
+  margin: 0 var(--size-large) 0 0 !important;
+}
+._tabsContainer_lizta_1 .ant-tabs-content-holder {
+  margin-top: var(--size-large);
+}
+
+/* temp_stylePlugin:ni:sha-256;97MpC1KB1B36Ozk2gRwDZKBqSXHmMbPnxRwFC5kqBx8 */
+._error_fqrcl_1 {
+  margin: var(--size-medium) 0;
+}
+._signInAlert_fqrcl_5 {
+  margin: var(--size-medium) 0;
+}
+._4qdycv0 {
+  height: 12px;
+}
+._4qdycv1 {
+  border-radius: 4px;
+  color: var(--_1pyqka9y);
+  cursor: pointer;
+  padding: 8px 8px;
+  width: 325px;
+  height: 28px;
+  display: flex;
+}
+._4qdycv1:hover {
+  background-color: var(--_1pyqka91x);
+  color: var(--_1pyqka9w);
+}
+._4qdycv2 {
+  background-color: var(--_1pyqka91y);
+  color: var(--_1pyqka9w);
+}
+._4qdycv3 {
+  background-color: var(--_1pyqka91z);
+  color: var(--_1pyqka9x);
+  cursor: not-allowed;
+}
+._4qdycv3:hover {
+  background-color: var(--_1pyqka91z);
+  color: var(--_1pyqka9x);
+}
+._4qdycv5 + ._4qdycv5 {
+  border-top: var(--_1pyqka91o) solid 1px;
+}
+._1xxy0on0 {
+  width: 560px;
+  margin-top: 64px;
+  margin-bottom: 12px;
+}
+._1xxy0on1 {
+  height: 40px;
+  top: 0;
+  background-color: #ffffff;
+}
+._1xxy0on2 {
+  height: 4px;
+  border-radius: 2px;
+  background-color: #e9e8ea;
+  overflow: hidden;
+}
+._1xxy0on3 {
+  background-color: #6f6e77;
+}
+._1xxy0on4 {
+  background-color: #ad5700;
+}
+._1xxy0on5 {
+  width: 344px;
+}
+._1xxy0on6 {
+  width: 216px;
+}
+._1xxy0on7 {
+  background-color: #f9f8f9;
+}
+._1xxy0on8 {
+  height: 16px;
+}
+._1xxy0on9 {
+  padding-top: 8px;
+}
+._1xxy0ona {
+  height: 28px;
+}
+._1q3ayoh0 {
+  width: 560px;
+  margin-top: 36px;
+  margin-bottom: 12px;
+}
+._1q3ayoh1 {
+  height: 4px;
+  border-radius: 2px;
+  background-color: #e9e8ea;
+  overflow: hidden;
+}
+._1q3ayoh2 {
+  background-color: #6f6e77;
+}
+._1q3ayoh3 {
+  background-color: #ad5700;
+}
+._1q3ayoh4 {
+  height: 14px;
+}
+._1q3ayoh5 {
+  height: 20px;
+}
+._1q3ayoh6 {
+  height: 20px;
+}
+
+/* temp_stylePlugin:ni:sha-256;ZFk_xjnWGFe21cp_fK7vfFmDsVLWwbdZf3z2aG2YpW4 */
+._buttonBody_18sne_1 {
+  column-gap: 30px;
+  display: grid;
+  gap: 0 0;
+  grid-template-areas: ". Left-Panel Center-Panel Right-Panel .";
+  grid-template-columns: auto 300px minmax(200px, 700px) 300px auto;
+  padding-left: 100px;
+  padding-top: 100px;
+  width: 100%;
+}
+._hitTargets_18sne_12 {
+  column-gap: 30px;
+  height: 100%;
+  padding-left: 100px;
+  padding-top: 200px;
+  width: 100%;
+}
+._hitTargets_18sne_12 section {
+  margin-bottom: var(--size-xxLarge);
+}
+._container_18sne_23 {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+._sourcemapErrors_18sne_29 {
+  margin: 20px auto;
+  max-width: 980px;
+  padding: 0 20px;
+}


### PR DESCRIPTION
## Summary

This PR reverts back to outputting non-minified generated css for Reflame, in hopes that it could minimize frequency of merge conflicts in the generated file. 

Previously we had to start minifying because vanilla-extract's esbuild plugin outputted comments that depend on absolute path, so would differ between CI and local machines. In this PR we work around that by manually stripping out those comments with a regex.

Also reverts #5551, since treating the file as binary actually does the opposite of what we want (minimize frequency of merge conflicts), since no automatic conflict resolution could ever occur with binary files.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

Styles in latest Reflame deployment looks fine. Should be good to go if the Reflame generated files check passes in CI. Edit: looks like we're good to go!

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
