### PR TITLE
make PushPayload processing use async opensearch updates

### DIFF
--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -240,7 +240,7 @@ func NewOpensearchClient(db *gorm.DB) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) UpdateAsync(index Index, id int, obj interface{}) error {
+func (c *Client) UpdateAsync(ctx context.Context, index Index, id int, obj interface{}) error {
 	if c == nil || !c.isInitialized {
 		return nil
 	}
@@ -263,7 +263,7 @@ func (c *Client) UpdateAsync(index Index, id int, obj interface{}) error {
 		RetryOnConflict: pointy.Int(3),
 	}
 
-	if err := c.BulkIndexer.Add(context.Background(), item); err != nil {
+	if err := c.BulkIndexer.Add(ctx, item); err != nil {
 		return e.Wrap(err, "OPENSEARCH_ERROR error adding bulk indexer item for update")
 	}
 

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2633,7 +2633,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	// If the session was previously excluded (as we do with new sessions by default),
 	// clear it so it is shown as live in OpenSearch since we now have data for it.
 	if (sessionObj.Processed != nil && *sessionObj.Processed) || (!excluded) {
-		if err := r.OpenSearch.UpdateSynchronous(opensearch.IndexSessions, sessionObj.ID, map[string]interface{}{
+		if err := r.OpenSearch.UpdateAsync(opensearch.IndexSessions, sessionObj.ID, map[string]interface{}{
 			"processed":  false,
 			"Excluded":   false,
 			"has_errors": sessionHasErrors,
@@ -2644,7 +2644,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	}
 
 	if sessionHasErrors {
-		if err := r.OpenSearch.UpdateSynchronous(opensearch.IndexSessions, sessionObj.ID, map[string]interface{}{
+		if err := r.OpenSearch.UpdateAsync(opensearch.IndexSessions, sessionObj.ID, map[string]interface{}{
 			"has_errors": true,
 		}); err != nil {
 			log.WithContext(ctx).Error(e.Wrap(err, "error setting has_errors on session in opensearch"))


### PR DESCRIPTION
## Summary

Still seeing the opensearch updates here taking up >50% of the ProcessPayload time in most cases. 
![image](https://github.com/highlight/highlight/assets/1351531/6b4093bd-4625-46d4-a079-1d3d7ad5d4f7)
![image](https://github.com/highlight/highlight/assets/1351531/a63389da-1c5c-48fe-96fe-f97916488335)

Ruling out the postgres part of the trace because the postgres load doesn't look bad. 
![image](https://github.com/highlight/highlight/assets/1351531/4ee5cb13-7aa4-4889-95c7-97a141259032)

## How did you test this change?

Local session recording and showing in the feed correctly.
![image](https://github.com/highlight/highlight/assets/1351531/db36d2f6-6259-4824-9842-fdceae2126f2)


## Are there any deployment considerations?

Monitoring kafka message consumption.
