### PR TITLE
throttle client retries to avoid PushPayload storm on kafka errors

### DIFF
--- a/e2e/go/fiber.go
+++ b/e2e/go/fiber.go
@@ -14,7 +14,6 @@ import (
 
 func main() {
 	highlight.SetProjectID("1jdkoe52")
-	highlight.SetGraphqlClientAddress("https://localhost:8082/public")
 	highlight.SetOTLPEndpoint("http://localhost:4318")
 	highlight.Start()
 	defer highlight.Stop()

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -265,3 +265,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Minor Changes
 
 - Update format of data sent in for WebSocket events
+
+## 7.3.1
+
+### Patch Changes
+
+- Increase data transmission retry delays.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.3.0",
+	"version": "7.3.1",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.3.0"
+export default "7.3.1"


### PR DESCRIPTION
## Summary

Increases the backoff on client graphql retries to make sure we do not
send many requests to our public graph when there is an interruption.

Fixes issue in the web worker retry logic to avoid using window.localStorage which is not accessible.

## How did you test this change?

Local deploy verifying that a fake backend error would throttle frontend requests correctly.
Adding a test 75% PushPayload failure rate to the backend:
![image](https://github.com/highlight/highlight/assets/1351531/c154a37f-94a6-4fd1-98c2-3dbb788a14e2)
![image](https://github.com/highlight/highlight/assets/1351531/554f8eeb-a96f-427c-946f-6258bb6cee11)


## Are there any deployment considerations?

New version of highlight.run client released.
