### PR TITLE
simplify db test util

### DIFF
--- a/backend/integrations/integrations_test.go
+++ b/backend/integrations/integrations_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestIsProjectIntegrated(t *testing.T) {
-	util.RunTestWithDBWipe(t, "UpdateProjectFilterSettings", client.db, func(t *testing.T) {
+	util.RunTestWithDBWipe(t, client.db, func(t *testing.T) {
 		project := model.Project{}
 		err := client.db.Create(&project).Error
 		assert.NoError(t, err)

--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -2,9 +2,10 @@ package graph
 
 import (
 	"context"
-	pointy "github.com/openlyinc/pointy"
 	"os"
 	"testing"
+
+	pointy "github.com/openlyinc/pointy"
 
 	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/workerpool"
@@ -44,7 +45,7 @@ func TestResolver_GetSessionChunk(t *testing.T) {
 		1651074284153,
 		1651074417161,
 	}
-	util.RunTestWithDBWipe(t, "Test Chunk", DB, func(t *testing.T) {
+	util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
 		// inserting the data
 		sessionsToInsert := []model.Session{
 			{ActiveLength: 1000, ProjectID: 1, Viewed: nil},
@@ -124,7 +125,7 @@ func TestMutationResolver_AddAdminToWorkspace(t *testing.T) {
 		},
 	}
 	for testName, v := range tests {
-		util.RunTestWithDBWipe(t, "Test AddAdminToWorkspace", DB, func(t *testing.T) {
+		util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
 			// inserting the data
 			admin := model.Admin{
 				Model:         model.Model{ID: 1},
@@ -198,7 +199,7 @@ func TestMutationResolver_ChangeAdminRole(t *testing.T) {
 		},
 	}
 	for _, v := range tests {
-		util.RunTestWithDBWipe(t, "Test AddAdminToWorkspace", DB, func(t *testing.T) {
+		util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
 			// inserting the data
 			workspace := model.Workspace{
 				Name: ptr.String("test1"),
@@ -304,7 +305,7 @@ func TestMutationResolver_DeleteInviteLinkFromWorkspace(t *testing.T) {
 		},
 	}
 	for _, v := range tests {
-		util.RunTestWithDBWipe(t, "Test DeleteInviteLinkFromWorkspace", DB, func(t *testing.T) {
+		util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
 			// inserting the data
 			workspace := model.Workspace{
 				Name: ptr.String("test1"),
@@ -396,8 +397,8 @@ func TestResolver_GetSlackChannelsFromSlack(t *testing.T) {
 			expError: true,
 		},
 	}
-	for testName, v := range tests {
-		util.RunTestWithDBWipe(t, testName, DB, func(t *testing.T) {
+	for _, v := range tests {
+		util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
 			workspace := model.Workspace{
 				Name:             ptr.String("test1"),
 				SlackAccessToken: v.accessToken,

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 
 func TestProcessBackendPayloadImpl(t *testing.T) {
 	trpcTraceStr := "[{\"columnNumber\":11,\"lineNumber\":80,\"fileName\":\"/workspace/src/trpc/instance.ts\",\"source\":\"    at /workspace/src/trpc/instance.ts:80:11\",\"lineContent\":\"    throw new TRPCError({\\n\",\"linesBefore\":\"        organizationId,\\n        supabaseAccessToken,\\n      },\\n    });\\n  } catch (error) {\\n\",\"linesAfter\":\"      code: \\\"UNAUTHORIZED\\\",\\n    });\\n  }\\n});\\n\\n\"},{\"columnNumber\":38,\"lineNumber\":421,\"fileName\":\"/workspace/node_modules/@trpc/server/dist/index.js\",\"functionName\":\"callRecursive\",\"source\":\"    at callRecursive (/workspace/node_modules/@trpc/server/dist/index.js:421:38)\",\"lineContent\":\"                const result = await middleware({\\n\",\"linesBefore\":\"            ctx: opts.ctx\\n        })=\u003e{\\n            try {\\n                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion\\n                const middleware = _def.middlewares[callOpts.index];\\n\",\"linesAfter\":\"                    ctx: callOpts.ctx,\\n                    type: opts.type,\\n                    path: opts.path,\\n                    rawInput: opts.rawInput,\\n                    meta: _def.meta,\\n\"},{\"columnNumber\":30,\"lineNumber\":449,\"fileName\":\"/workspace/node_modules/@trpc/server/dist/index.js\",\"functionName\":\"resolve\",\"source\":\"    at resolve (/workspace/node_modules/@trpc/server/dist/index.js:449:30)\",\"lineContent\":\"        const result = await callRecursive();\\n\",\"linesBefore\":\"                    marker: middlewareMarker\\n                };\\n            }\\n        };\\n        // there's always at least one \\\"next\\\" since we wrap this.resolver in a middleware\\n\",\"linesAfter\":\"        if (!result) {\\n            throw new TRPCError.TRPCError({\\n                code: 'INTERNAL_SERVER_ERROR',\\n                message: 'No result from middlewares - did you forget to `return next()`?'\\n            });\\n\"},{\"columnNumber\":12,\"lineNumber\":228,\"fileName\":\"/workspace/node_modules/@trpc/server/dist/config-7b65d7da.js\",\"functionName\":\"Object.callProcedure\",\"source\":\"    at Object.callProcedure (/workspace/node_modules/@trpc/server/dist/config-7b65d7da.js:228:12)\",\"lineContent\":\"    return procedure(opts);\\n\",\"linesBefore\":\"            code: 'NOT_FOUND',\\n            message: `No \\\"${type}\\\"-procedure on path \\\"${path}\\\"`\\n        });\\n    }\\n    const procedure = opts.procedures[path];\\n\",\"linesAfter\":\"}\\n\\n/**\\n * The default check to see if we're in a server\\n */ const isServerDefault = typeof window === 'undefined' || 'Deno' in window || globalThis.process?.env?.NODE_ENV === 'test' || !!globalThis.process?.env?.JEST_WORKER_ID;\\n\"},{\"columnNumber\":45,\"lineNumber\":125,\"fileName\":\"/workspace/node_modules/@trpc/server/dist/resolveHTTPResponse-83d9b5ff.js\",\"source\":\"    at /workspace/node_modules/@trpc/server/dist/resolveHTTPResponse-83d9b5ff.js:125:45\",\"lineContent\":\"                const output = await config.callProcedure({\\n\",\"linesBefore\":\"        };\\n        const inputs = getInputs();\\n        const rawResults = await Promise.all(paths.map(async (path, index)=\u003e{\\n            const input = inputs[index];\\n            try {\\n\",\"linesAfter\":\"                    procedures: router._def.procedures,\\n                    path,\\n                    rawInput: input,\\n                    ctx,\\n                    type\\n\"},{\"columnNumber\":52,\"lineNumber\":122,\"fileName\":\"/workspace/node_modules/@trpc/server/dist/resolveHTTPResponse-83d9b5ff.js\",\"functionName\":\"Object.resolveHTTPResponse\",\"source\":\"    at Object.resolveHTTPResponse (/workspace/node_modules/@trpc/server/dist/resolveHTTPResponse-83d9b5ff.js:122:52)\",\"lineContent\":\"        const rawResults = await Promise.all(paths.map(async (path, index)=\u003e{\\n\",\"linesBefore\":\"                input[k] = value;\\n            }\\n            return input;\\n        };\\n        const inputs = getInputs();\\n\",\"linesAfter\":\"            const input = inputs[index];\\n            try {\\n                const output = await config.callProcedure({\\n                    procedures: router._def.procedures,\\n                    path,\\n\"},{\"columnNumber\":5,\"lineNumber\":96,\"fileName\":\"node:internal/process/task_queues\",\"functionName\":\"processTicksAndRejections\",\"source\":\"    at processTicksAndRejections (node:internal/process/task_queues:96:5)\"},{\"columnNumber\":20,\"lineNumber\":53,\"fileName\":\"/workspace/node_modules/@trpc/server/dist/nodeHTTPRequestHandler-e6a535cb.js\",\"functionName\":\"Object.nodeHTTPRequestHandler\",\"source\":\"    at Object.nodeHTTPRequestHandler (/workspace/node_modules/@trpc/server/dist/nodeHTTPRequestHandler-e6a535cb.js:53:20)\",\"lineContent\":\"    const result = await resolveHTTPResponse.resolveHTTPResponse({\\n\",\"linesBefore\":\"        method: opts.req.method,\\n        headers: opts.req.headers,\\n        query,\\n        body: bodyResult.ok ? bodyResult.data : undefined\\n    };\\n\",\"linesAfter\":\"        batching: opts.batching,\\n        responseMeta: opts.responseMeta,\\n        path,\\n        createContext,\\n        router,\\n\"}]"
-	util.RunTestWithDBWipe(t, "trpc test", DB, func(t *testing.T) {
+	util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
 		r := &Resolver{DB: DB, TDB: timeseries.New(context.TODO())}
 		r.ProcessBackendPayloadImpl(context.Background(), nil, nil, []*publicModel.BackendErrorObjectInput{{
 			SessionSecureID: nil,
@@ -202,8 +202,8 @@ func TestHandleErrorAndGroup(t *testing.T) {
 		},
 	}
 	//run tests
-	for name, tc := range tests {
-		util.RunTestWithDBWipe(t, name, DB, func(t *testing.T) {
+	for _, tc := range tests {
+		util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
 			r := &Resolver{DB: DB}
 			receivedErrorGroups := make(map[string]model.ErrorGroup)
 			for _, errorObj := range tc.errorsToInsert {
@@ -252,7 +252,7 @@ func TestMatchErrorsWithSameTracesDifferentBodies(t *testing.T) {
 		t.Fatal("failed to generate structured stacktrace")
 	}
 
-	util.RunTestWithDBWipe(t, "error matching", DB, func(t *testing.T) {
+	util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
 		r := &Resolver{DB: DB, TDB: timeseries.New(context.TODO())}
 
 		errorObject := model.ErrorObject{
@@ -288,7 +288,7 @@ func TestUpdatingErrorState(t *testing.T) {
 		t.Fatal("failed to generate structured stacktrace")
 	}
 
-	util.RunTestWithDBWipe(t, "error updating state", DB, func(t *testing.T) {
+	util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
 		r := &Resolver{DB: DB, TDB: timeseries.New(context.TODO())}
 		s := store.NewStore(r.DB, r.OpenSearch)
 

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -53,7 +53,7 @@ func TestUpdateErrorGroupStateByAdmin(t *testing.T) {
 }
 
 func TestUpdateErrorGroupStateBySystem(t *testing.T) {
-	util.RunTestWithDBWipe(t, "UpdateErrorGroupStateBySystem", store.db, func(t *testing.T) {
+	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
 		errorGroup := model.ErrorGroup{
 			State: privateModel.ErrorStateOpen,
 		}

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestUpdateErrorGroupStateByAdmin(t *testing.T) {
-	util.RunTestWithDBWipe(t, "TestUpdateErrorGroupStateByAdmin", store.db, func(t *testing.T) {
+	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
 
 		errorGroup := model.ErrorGroup{
 			State: privateModel.ErrorStateOpen,

--- a/backend/store/project_filter_settings_test.go
+++ b/backend/store/project_filter_settings_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestGetProjectFilterSettings(t *testing.T) {
-	util.RunTestWithDBWipe(t, "GetProjectFilterSettings", store.db, func(t *testing.T) {
+	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
 		project := model.Project{}
 		store.db.Create(&project)
 
@@ -28,7 +28,7 @@ func TestGetProjectFilterSettings(t *testing.T) {
 }
 
 func TestUpdateProjectFilterSettings(t *testing.T) {
-	util.RunTestWithDBWipe(t, "UpdateProjectFilterSettings", store.db, func(t *testing.T) {
+	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
 		project := model.Project{}
 		store.db.Create(&project)
 
@@ -51,7 +51,7 @@ func TestUpdateProjectFilterSettings(t *testing.T) {
 }
 
 func TestFindProjectsWithAutoResolveSetting(t *testing.T) {
-	util.RunTestWithDBWipe(t, "FindProjectsWithAutoResolveSetting", store.db, func(t *testing.T) {
+	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
 		project1 := model.Project{}
 		store.db.Create(&project1)
 

--- a/backend/util/tests.go
+++ b/backend/util/tests.go
@@ -14,14 +14,14 @@ import (
 	"github.com/highlight-run/highlight/backend/model"
 )
 
-func RunTestWithDBWipe(t *testing.T, name string, db *gorm.DB, f func(t *testing.T)) {
+func RunTestWithDBWipe(t *testing.T, db *gorm.DB, f func(t *testing.T)) {
 	defer func(db *gorm.DB) {
 		err := ClearTablesInDB(db)
 		if err != nil {
 			t.Fatal(e.Wrap(err, "error clearing database"))
 		}
 	}(db)
-	t.Run(name, f)
+	t.Run(t.Name(), f)
 }
 
 func CreateAndMigrateTestDB(dbName string) (*gorm.DB, error) {

--- a/backend/worker/autoresolver_test.go
+++ b/backend/worker/autoresolver_test.go
@@ -34,7 +34,7 @@ func TestAutoResolveStaleErrors(t *testing.T) {
 	autoResolver := createAutoResolver()
 	db := autoResolver.db
 
-	util.RunTestWithDBWipe(t, "AutoResolveStaleErrors", db, func(t *testing.T) {
+	util.RunTestWithDBWipe(t, db, func(t *testing.T) {
 		project := model.Project{}
 		db.Create(&project)
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We have a util we use in tests to clean the postgres test db between test runs. It currently has a requirement to pass in the test name which is really unnecessary given we can derive that off of the `*testing.T` param.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Build passes

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A