### PR TITLE
Add Github as a more developer friendly authentication flow

### DIFF
--- a/frontend/src/pages/Auth/SignIn.tsx
+++ b/frontend/src/pages/Auth/SignIn.tsx
@@ -190,6 +190,18 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 							Sign in with Google <IconSolidSparkles />
 						</Box>
 					</Button>
+					<Button
+						kind="secondary"
+						type="button"
+						trackingId="sign-in-with-github"
+						onClick={() => {
+							auth.signInWithPopup(auth.githubProvider!).catch(
+								handleAuthError,
+							)
+						}}
+					>
+						Sign in with Github
+					</Button>
 				</Stack>
 			</AuthFooter>
 		</Form>

--- a/frontend/src/pages/Auth/SignIn.tsx
+++ b/frontend/src/pages/Auth/SignIn.tsx
@@ -63,6 +63,10 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 					provider: additionalUserInfo.providerId,
 				})
 
+				if (!user?.emailVerified) {
+					auth.currentUser?.sendEmailVerification()
+				}
+
 				await createAdmin()
 			}
 

--- a/frontend/src/pages/Auth/SignIn.tsx
+++ b/frontend/src/pages/Auth/SignIn.tsx
@@ -7,7 +7,8 @@ import {
 	Box,
 	Form,
 	Heading,
-	IconSolidSparkles,
+	IconSolidGithub,
+	IconSolidGoogle,
 	Stack,
 	Text,
 	useFormState,
@@ -190,7 +191,8 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 						}}
 					>
 						<Box display="flex" alignItems="center" gap="6">
-							Sign in with Google <IconSolidSparkles />
+							<IconSolidGoogle />
+							Sign in with Google
 						</Box>
 					</Button>
 					<Button
@@ -201,7 +203,10 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 							handleExternalAuthClick(auth.githubProvider!)
 						}}
 					>
-						Sign in with Github
+						<Box display="flex" alignItems="center" gap="6">
+							<IconSolidGithub />
+							Sign in with Github
+						</Box>
 					</Button>
 				</Stack>
 			</AuthFooter>

--- a/frontend/src/pages/Auth/SignIn.tsx
+++ b/frontend/src/pages/Auth/SignIn.tsx
@@ -93,7 +93,7 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 	)
 
 	const handleExternalAuthClick = (provider: Firebase.auth.AuthProvider) => {
-		auth.signInWithPopup(provider).catch(handleAuthError)
+		auth.signInWithPopup(provider).then(handleAuth).catch(handleAuthError)
 	}
 
 	useEffect(() => analytics.page(), [])

--- a/frontend/src/pages/Auth/SignIn.tsx
+++ b/frontend/src/pages/Auth/SignIn.tsx
@@ -17,6 +17,7 @@ import { AuthBody, AuthError, AuthFooter, AuthHeader } from '@pages/Auth/Layout'
 import useLocalStorage from '@rehooks/local-storage'
 import { auth } from '@util/auth'
 import firebase from 'firebase/compat/app'
+import Firebase from 'firebase/compat/app'
 import React, { useCallback, useEffect } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
@@ -90,6 +91,10 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 		},
 		[navigate, setResolver],
 	)
+
+	const handleExternalAuthClick = (provider: Firebase.auth.AuthProvider) => {
+		auth.signInWithPopup(provider).catch(handleAuthError)
+	}
 
 	useEffect(() => analytics.page(), [])
 
@@ -181,9 +186,7 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 						type="button"
 						trackingId="sign-in-with-google"
 						onClick={() => {
-							auth.signInWithPopup(auth.googleProvider!)
-								.then(handleAuth)
-								.catch(handleAuthError)
+							handleExternalAuthClick(auth.googleProvider!)
 						}}
 					>
 						<Box display="flex" alignItems="center" gap="6">
@@ -195,9 +198,7 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 						type="button"
 						trackingId="sign-in-with-github"
 						onClick={() => {
-							auth.signInWithPopup(auth.githubProvider!).catch(
-								handleAuthError,
-							)
+							handleExternalAuthClick(auth.githubProvider!)
 						}}
 					>
 						Sign in with Github

--- a/frontend/src/pages/Auth/SignIn.tsx
+++ b/frontend/src/pages/Auth/SignIn.tsx
@@ -18,7 +18,6 @@ import { AuthBody, AuthError, AuthFooter, AuthHeader } from '@pages/Auth/Layout'
 import useLocalStorage from '@rehooks/local-storage'
 import { auth } from '@util/auth'
 import firebase from 'firebase/compat/app'
-import Firebase from 'firebase/compat/app'
 import React, { useCallback, useEffect } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
@@ -97,7 +96,7 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 		[navigate, setResolver],
 	)
 
-	const handleExternalAuthClick = (provider: Firebase.auth.AuthProvider) => {
+	const handleExternalAuthClick = (provider: firebase.auth.AuthProvider) => {
 		auth.signInWithPopup(provider).then(handleAuth).catch(handleAuthError)
 	}
 

--- a/frontend/src/pages/Auth/SignUp.tsx
+++ b/frontend/src/pages/Auth/SignUp.tsx
@@ -8,7 +8,8 @@ import {
 	Callout,
 	Form,
 	Heading,
-	IconSolidSparkles,
+	IconSolidGithub,
+	IconSolidGoogle,
 	Stack,
 	Text,
 	useFormState,
@@ -188,7 +189,10 @@ export const SignUp: React.FC = () => {
 							handleExternalAuthClick(auth.googleProvider!)
 						}}
 					>
-						Sign up with Google <IconSolidSparkles />
+						<Box display="flex" alignItems="center" gap="6">
+							<IconSolidGoogle />
+							Sign up with Google
+						</Box>
 					</Button>
 					<Button
 						kind="secondary"
@@ -198,7 +202,10 @@ export const SignUp: React.FC = () => {
 							handleExternalAuthClick(auth.githubProvider!)
 						}
 					>
-						Sign in with Github
+						<Box display="flex" alignItems="center" gap="6">
+							<IconSolidGithub />
+							Sign up with Github
+						</Box>
 					</Button>
 				</Stack>
 			</AuthFooter>

--- a/frontend/src/pages/Auth/SignUp.tsx
+++ b/frontend/src/pages/Auth/SignUp.tsx
@@ -78,6 +78,21 @@ export const SignUp: React.FC = () => {
 		[createAdmin, navigate, signIn],
 	)
 
+	const handleExternalAuthClick = (provider: any) => {
+		auth.signInWithPopup(provider)
+			.then(handleSubmit)
+			.catch((error: firebase.auth.MultiFactorError) => {
+				let errorMessage = error.message
+
+				if (error.code === 'auth/popup-closed-by-user') {
+					errorMessage =
+						'Pop-up closed without successfully authenticating. Please try again.'
+				}
+
+				setError(errorMessage)
+			})
+	}
+
 	useEffect(() => analytics.page(), [])
 
 	return (
@@ -169,26 +184,20 @@ export const SignUp: React.FC = () => {
 						type="button"
 						trackingId="sign-up-with-google"
 						onClick={() => {
-							auth.signInWithPopup(auth.googleProvider!)
-								.then(handleSubmit)
-								.catch(
-									(error: firebase.auth.MultiFactorError) => {
-										let errorMessage = error.message
-
-										if (
-											error.code ===
-											'auth/popup-closed-by-user'
-										) {
-											errorMessage =
-												'Pop-up closed without successfully authenticating. Please try again.'
-										}
-
-										setError(errorMessage)
-									},
-								)
+							handleExternalAuthClick(auth.googleProvider!)
 						}}
 					>
 						Sign up with Google <IconSolidSparkles />
+					</Button>
+					<Button
+						kind="secondary"
+						type="button"
+						trackingId="sign-up-with-github"
+						onClick={() =>
+							handleExternalAuthClick(auth.githubProvider!)
+						}
+					>
+						Sign in with Github
 					</Button>
 				</Stack>
 			</AuthFooter>

--- a/frontend/src/pages/Auth/SignUp.tsx
+++ b/frontend/src/pages/Auth/SignUp.tsx
@@ -22,7 +22,6 @@ import analytics from '@util/analytics'
 import { auth } from '@util/auth'
 import { message } from 'antd'
 import firebase from 'firebase/compat/app'
-import Firebase from 'firebase/compat/app'
 import React, { useCallback, useEffect } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
@@ -84,7 +83,7 @@ export const SignUp: React.FC = () => {
 		[createAdmin, navigate, signIn],
 	)
 
-	const handleExternalAuthClick = (provider: Firebase.auth.AuthProvider) => {
+	const handleExternalAuthClick = (provider: firebase.auth.AuthProvider) => {
 		auth.signInWithPopup(provider)
 			.then(handleSubmit)
 			.catch((error: firebase.auth.MultiFactorError) => {

--- a/frontend/src/pages/Auth/SignUp.tsx
+++ b/frontend/src/pages/Auth/SignUp.tsx
@@ -71,6 +71,10 @@ export const SignUp: React.FC = () => {
 				})
 			}
 
+			if (!user?.emailVerified) {
+				auth.currentUser?.sendEmailVerification()
+			}
+
 			await createAdmin()
 			message.success('Account created succesfully!')
 
@@ -109,7 +113,6 @@ export const SignUp: React.FC = () => {
 					formState.values.password,
 				)
 					.then(async (credential) => {
-						auth.currentUser?.sendEmailVerification()
 						handleSubmit(credential)
 					})
 					.catch((error) => {

--- a/frontend/src/pages/Auth/SignUp.tsx
+++ b/frontend/src/pages/Auth/SignUp.tsx
@@ -21,6 +21,7 @@ import analytics from '@util/analytics'
 import { auth } from '@util/auth'
 import { message } from 'antd'
 import firebase from 'firebase/compat/app'
+import Firebase from 'firebase/compat/app'
 import React, { useCallback, useEffect } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
@@ -78,7 +79,7 @@ export const SignUp: React.FC = () => {
 		[createAdmin, navigate, signIn],
 	)
 
-	const handleExternalAuthClick = (provider: any) => {
+	const handleExternalAuthClick = (provider: Firebase.auth.AuthProvider) => {
 		auth.signInWithPopup(provider)
 			.then(handleSubmit)
 			.catch((error: firebase.auth.MultiFactorError) => {

--- a/frontend/src/util/auth.tsx
+++ b/frontend/src/util/auth.tsx
@@ -38,6 +38,7 @@ const getFakeFirebaseCredentials: () => Promise<Firebase.auth.UserCredential> =
 class SimpleAuth {
 	currentUser: User | null = fakeFirebaseUser
 	googleProvider?: Firebase.auth.GoogleAuthProvider
+	githubProvider?: Firebase.auth.GithubAuthProvider
 
 	async createUserWithEmailAndPassword(
 		email: string,
@@ -104,6 +105,8 @@ if (import.meta.env.REACT_APP_AUTH_MODE === 'simple') {
 
 	Firebase.initializeApp(firebaseConfig)
 	const googleProvider = new Firebase.auth.GoogleAuthProvider()
+	const githubProvider = new Firebase.auth.GithubAuthProvider()
 	auth = Firebase.auth()
 	auth.googleProvider = googleProvider
+	auth.githubProvider = githubProvider
 }


### PR DESCRIPTION
## Summary
Allow users to authenticate with their Github accounts

Other none code changes:
- Added Github as an Authentication app to Firebase
- Added a redirect_url to out Github app
- Updated asks from users to give us "Read email" privileges from their Github account

## How did you test this change?
https://www.loom.com/share/39f9c7b794cc46dfb5ad82d54264f561

**Some gotchas**
- Make sure to delete your admin record from psql
- Make sure to delete your user from Firebase Authentication (used my personal email to avoid deleting admin account)

**Sign up**
1. Confirm you can sign up with email and password
- [ ] Can only sign up from the `/sign_up` page
- [ ] Email confirmation send
- [ ] Able to create account
2. Confirm you can sign up with Google
- [ ] Can sign up from `/sign_up` or `/sign_in`
- [ ] No email confirmation sent
- [ ] Able to create account
3. Confirm you can sign up with Github
- [ ] Can sign up from `/sign_up` or `/sign_in`
- [ ] Email confirmation sent
- [ ] Able to create account

**Sign in**
1. Confirm you can sign in with email and password
- [ ] Can only sign in from the `/sign_in` page
- [ ] Able to sign in
2. Confirm you can sign up with Google
- [ ] Can sign in from `/sign_up` or `/sign_in`
- [ ] Able to sign in
3. Confirm you can sign up with Github
- [ ] Can sign in from `/sign_up` or `/sign_in`
- [ ] Able to sign in

## Are there any deployment considerations?
N/A