### PR TITLE
move error body down to the instance level

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -10279,9 +10279,6 @@ span:last-child ._ruleItem_1yzqu_148 {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }
-._33eaux0 {
-  max-height: 16em;
-}
 
 /* temp_stylePlugin:ni:sha-256;rMrQRyZrKw_rd6RipEc2Ve-7bXKt5YqAsAeoQ0Mt554 */
 ._tabPane_19cqh_1 {
@@ -10380,6 +10377,9 @@ span:last-child ._ruleItem_1yzqu_148 {
   display: flex;
   justify-content: center;
   width: 100%;
+}
+._33eaux0 {
+  max-height: 16em;
 }
 
 /* temp_stylePlugin:ni:sha-256;BtqyzEEtG8ThljpH4yzPm1T9yuUz6xMGDnI9IWq9o3c */

--- a/frontend/src/pages/ErrorsV2/ErrorBody/ErrorBody.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorBody/ErrorBody.tsx
@@ -4,14 +4,12 @@ import {
 	Box,
 	ButtonLink,
 	IconSolidCheveronRight,
-	IconSolidCode,
 	IconSolidUsers,
 	IconSolidViewGrid,
 	Text,
 } from '@highlight-run/ui'
 import { useProjectId } from '@hooks/useProjectId'
 import AffectedUserCount from '@pages/ErrorsV2/ErrorBody/components/AffectedUserCount'
-import ErrorBodyText from '@pages/ErrorsV2/ErrorBody/components/ErrorBodyText'
 import ErrorFrequencyChart from '@pages/ErrorsV2/ErrorBody/components/ErrorFrequencyChart'
 import ErrorObjectCount from '@pages/ErrorsV2/ErrorBody/components/ErrorObjectCount'
 import ErrorOccurenceDate from '@pages/ErrorsV2/ErrorBody/components/ErrorOccurenceDate'
@@ -130,19 +128,6 @@ const ErrorBody: React.FC<React.PropsWithChildren<Props>> = ({
 				>
 					<ErrorFrequencyChart errorGroup={errorGroup} />
 				</Stat>
-			</Box>
-			<Box py="12" px="16">
-				<Box
-					mb="20"
-					display="flex"
-					gap="6"
-					alignItems="center"
-					color="weak"
-				>
-					<IconSolidCode />
-					<Text color="moderate">Error Body</Text>
-				</Box>
-				<ErrorBodyText errorGroup={errorGroup} />
 			</Box>
 		</Box>
 	)

--- a/frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorBodyText/index.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorBodyText/index.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@components/Button'
-import { ErrorGroup, Maybe } from '@graph/schemas'
+import { Maybe } from '@graph/schemas'
 import { Box, Text } from '@highlight-run/ui'
 import { getErrorBody } from '@util/errors/errorUtils'
 import { useEffect, useRef, useState } from 'react'
@@ -7,13 +7,13 @@ import { useEffect, useRef, useState } from 'react'
 import * as style from './style.css'
 
 interface Props {
-	errorGroup?: Maybe<Omit<ErrorGroup, 'metadata_log'>>
+	errorBody: Maybe<string>[] | undefined
 }
 
-const ErrorBodyText = ({ errorGroup }: Props) => {
+const ErrorBodyText = ({ errorBody }: Props) => {
 	const [truncated, setTruncated] = useState(true)
 	const [truncateable, setTruncateable] = useState(true)
-	const body = getErrorBody(errorGroup?.event)
+	const body = getErrorBody(errorBody)
 	const bodyRef = useRef<HTMLElement | undefined>()
 
 	useEffect(() => {
@@ -26,12 +26,7 @@ const ErrorBodyText = ({ errorGroup }: Props) => {
 
 	return (
 		<Box display="flex" flexDirection="column" gap="8">
-			<Box
-				py="8"
-				cssClass={style.errorBodyContainer}
-				overflowY="scroll"
-				overflowX="auto"
-			>
+			<Box py="8" cssClass={style.errorBodyContainer}>
 				<Text
 					family="monospace"
 					lines={truncated ? '3' : undefined}

--- a/frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorBodyText/index.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorBodyText/index.tsx
@@ -7,7 +7,7 @@ import { useEffect, useRef, useState } from 'react'
 import * as style from './style.css'
 
 interface Props {
-	errorBody: Maybe<string>[] | undefined
+	errorBody: Maybe<string>[]
 }
 
 const ErrorBodyText = ({ errorBody }: Props) => {

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -16,6 +16,7 @@ import { Maybe, ReservedLogKey } from '@graph/schemas'
 import {
 	Box,
 	Heading,
+	IconSolidCode,
 	IconSolidExternalLink,
 	IconSolidLogs,
 	Text,
@@ -43,6 +44,7 @@ import React, { useEffect, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { createSearchParams, useNavigate } from 'react-router-dom'
 
+import ErrorBodyText from '@/pages/ErrorsV2/ErrorBody/components/ErrorBodyText'
 import { ErrorSessionMissingOrExcluded } from '@/pages/ErrorsV2/ErrorInstance/ErrorSessionMissingOrExcluded'
 import { ShowSessionButton } from '@/pages/ErrorsV2/ErrorInstance/ShowSessionButton'
 import { isSessionAvailable } from '@/pages/ErrorsV2/ErrorInstance/utils'
@@ -180,7 +182,7 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 			<Box id="error-instance-container">
 				<Box my="28" display="flex" justifyContent="space-between">
 					<Box display="flex" flexDirection="column" gap="16">
-						<Heading level="h4">Error Instance</Heading>
+						<Heading level="h4">Instance Details</Heading>
 					</Box>
 
 					<Box>
@@ -257,7 +259,7 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 		<Box id="error-instance-container">
 			<Box my="28" display="flex" justifyContent="space-between">
 				<Box display="flex" flexDirection="column" gap="16">
-					<Heading level="h4">Error Instance</Heading>
+					<Heading level="h4">Instance Details</Heading>
 				</Box>
 
 				<Box>
@@ -333,6 +335,20 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 						/>
 					</Box>
 				</Box>
+			</Box>
+
+			<Box py="16" px="16" mb="40" border="secondary">
+				<Box
+					mb="20"
+					display="flex"
+					gap="6"
+					alignItems="center"
+					color="weak"
+				>
+					<IconSolidCode />
+					<Text color="moderate">Instance Error Body</Text>
+				</Box>
+				<ErrorBodyText errorBody={errorInstance.error_object.event} />
 			</Box>
 
 			<Box display="flex" flexDirection="column" mb="40" gap="40">

--- a/frontend/src/pages/Player/RightPlayerPanel/components/ErrorDetails/ErrorDetails.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/ErrorDetails/ErrorDetails.tsx
@@ -298,7 +298,7 @@ const ErrorDetails = React.memo(({ error }: Props) => {
 							</>
 						}
 					>
-						<ErrorBodyText errorGroup={errorGroup} />
+						<ErrorBodyText errorBody={event} />
 					</Stat>
 					{context ? (
 						<Stat


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR moves the error body (internally called `event`) down from the error group level to the error instance (internally called `error_object`) level. The reason for doing this is that the error group's body is set to whatever the latest error instance body is. However, error instances with different error bodies can be grouped together (e.g. same stacktrace but different error bodies due to using [variable interpolation](https://github.com/highlight/highlight/pull/5310)).

See [figma](https://www.figma.com/file/rdBPNzn7Klk6RG1LHUCE5B/Screen-Designs?type=design&node-id=8467-347211&t=iCRRrIXANlJHENtH-0).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Find an error group with different error instance bodies.
* Traverse the error instances and observe the different error bodies.


![Kapture 2023-06-08 at 09 57 35](https://github.com/highlight/highlight/assets/58678/cc969675-7ea6-4b4c-976f-1bd8f2b05d1a)

Confirmed via [slack](https://highlightcorp.slack.com/archives/C0524MRA4NA/p1686239690884379?thread_ts=1685625555.000169&cid=C0524MRA4NA) that we don't want to change the main header when traversing error instances.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A