### PR TITLE
simplify props to <ErrorTitle /> component

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorTitle/ErrorTitle.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorTitle/ErrorTitle.tsx
@@ -1,6 +1,5 @@
 import LoadingBox from '@components/LoadingBox'
 import { GetErrorGroupQuery } from '@graph/operations'
-import { ErrorObject } from '@graph/schemas'
 import { Box, Heading } from '@highlight-run/ui'
 import ErrorIssueButton from '@pages/ErrorsV2/ErrorIssueButton/ErrorIssueButton'
 import ErrorShareButton from '@pages/ErrorsV2/ErrorShareButton/ErrorShareButton'
@@ -12,11 +11,10 @@ import React, { useMemo } from 'react'
 
 interface Props {
 	errorGroup: GetErrorGroupQuery['error_group']
-	errorObject?: ErrorObject
 }
 
-const ErrorTitle = ({ errorGroup, errorObject }: Props) => {
-	const event = errorObject?.event ?? errorGroup?.event
+const ErrorTitle = ({ errorGroup }: Props) => {
+	const event = errorGroup?.event
 	const headerText = useMemo(() => {
 		let header = getHeaderFromError(event ?? [])
 		if (header && event) {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We never pass an `errorObject` into this component. No need to support that flow if it's unused.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Build passes.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A