### PR TITLE
fix nil pointer references and remove noisy frontend errors

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -474,9 +474,6 @@ func (r *Resolver) isAdminInProject(ctx context.Context, project_id int) (*model
 
 	span.SetTag("ProjectID", project_id)
 
-	if util.IsTestEnv() {
-		return nil, nil
-	}
 	if r.isWhitelistedAccount(ctx) {
 		project := &model.Project{}
 		if err := r.DB.Where(&model.Project{Model: model.Model{ID: project_id}}).First(&project).Error; err != nil {
@@ -924,7 +921,7 @@ func (r *Resolver) canAdminModifyErrorGroup(ctx context.Context, errorGroupSecur
 func (r *Resolver) _doesAdminOwnSession(ctx context.Context, session_secure_id string) (session *model.Session, ownsSession bool, err error) {
 	session = &model.Session{}
 	if err := r.DB.Order("secure_id").Model(&session).Where(&model.Session{SecureID: session_secure_id}).Limit(1).Find(&session).Error; err != nil || session.ID == 0 {
-		return nil, false, e.Wrap(err, "error querying session by secure_id: "+session_secure_id)
+		return nil, false, e.New("error querying session by secure_id: " + session_secure_id)
 	}
 
 	_, err = r.isAdminInProjectOrDemoProject(ctx, session.ProjectID)

--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -27,6 +27,7 @@ func TestMain(m *testing.M) {
 	testLogger := log.WithContext(context.TODO()).WithFields(log.Fields{"DB_HOST": os.Getenv("PSQL_HOST"), "DB_NAME": dbName})
 	var err error
 	DB, err = util.CreateAndMigrateTestDB(dbName)
+	SetupAuthClient(context.Background(), Simple, nil, nil)
 	if err != nil {
 		testLogger.Error(e.Wrap(err, "error creating testdb"))
 	}
@@ -416,6 +417,111 @@ func TestResolver_GetSlackChannelsFromSlack(t *testing.T) {
 			}
 			if err == nil && num != v.expNumChannels {
 				t.Fatalf("received invalid num channels %d, expected %d", num, v.expNumChannels)
+			}
+		})
+	}
+}
+
+func TestResolver_canAdminViewSession(t *testing.T) {
+	tests := map[string]struct {
+		secureID string
+		expError bool
+	}{
+		"valid session": {
+			secureID: "abc123",
+			expError: false,
+		},
+		"invalid session": {
+			secureID: "a1b2c3",
+			expError: true,
+		},
+	}
+	for testName, v := range tests {
+		util.RunTestWithDBWipe(t, testName, DB, func(t *testing.T) {
+			ctx := context.Background()
+			r := &queryResolver{Resolver: &Resolver{DB: DB}}
+
+			w := model.Workspace{}
+			if err := DB.Create(&w).Error; err != nil {
+				t.Fatal(e.Wrap(err, "error inserting workspace"))
+			}
+
+			admin, _ := r.getCurrentAdmin(ctx)
+			if err := DB.Model(&w).Association("Admins").Append(admin); err != nil {
+				t.Fatal(e.Wrap(err, "error inserting workspace"))
+			}
+
+			p := model.Project{WorkspaceID: w.ID}
+			if err := DB.Create(&p).Error; err != nil {
+				t.Fatal(e.Wrap(err, "error inserting project"))
+			}
+
+			session := model.Session{
+				SecureID:  "abc123",
+				ProjectID: p.ID,
+			}
+			if err := DB.Create(&session).Error; err != nil {
+				t.Fatal(e.Wrap(err, "error inserting session"))
+			}
+
+			s, err := r.canAdminViewSession(ctx, v.secureID)
+			if v.expError {
+				if err == nil {
+					t.Fatalf("error result invalid, saw %s", err)
+				}
+			} else if err != nil {
+				t.Fatalf("saw unexpected error %s", err)
+			} else if s.SecureID != v.secureID {
+				t.Fatalf("received invalid session %s, expected %s", s.SecureID, v.secureID)
+			}
+		})
+	}
+}
+
+func TestResolver_isAdminInProjectOrDemoProject(t *testing.T) {
+	tests := map[string]struct {
+		expError bool
+	}{
+		"valid session": {
+			expError: false,
+		},
+		"invalid session": {
+			expError: true,
+		},
+	}
+	for testName, v := range tests {
+		util.RunTestWithDBWipe(t, testName, DB, func(t *testing.T) {
+			ctx := context.Background()
+			r := &queryResolver{Resolver: &Resolver{DB: DB}}
+
+			w := model.Workspace{}
+			if err := DB.Create(&w).Error; err != nil {
+				t.Fatal(e.Wrap(err, "error inserting workspace"))
+			}
+
+			admin, _ := r.getCurrentAdmin(ctx)
+			if err := DB.Model(&w).Association("Admins").Append(admin); err != nil {
+				t.Fatal(e.Wrap(err, "error inserting workspace"))
+			}
+
+			p := model.Project{WorkspaceID: w.ID}
+			if err := DB.Create(&p).Error; err != nil {
+				t.Fatal(e.Wrap(err, "error inserting project"))
+			}
+
+			id := p.ID
+			if v.expError {
+				id += 1
+			}
+			pr, err := r.isAdminInProjectOrDemoProject(ctx, id)
+			if v.expError {
+				if err == nil {
+					t.Fatalf("error result invalid, saw %s", err)
+				}
+			} else if err != nil {
+				t.Fatalf("saw unexpected error %s", err)
+			} else if pr.ID != id {
+				t.Fatalf("received invalid project %d, expected %d", pr.ID, id)
 			}
 		})
 	}

--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -436,8 +436,8 @@ func TestResolver_canAdminViewSession(t *testing.T) {
 			expError: true,
 		},
 	}
-	for testName, v := range tests {
-		util.RunTestWithDBWipe(t, testName, DB, func(t *testing.T) {
+	for _, v := range tests {
+		util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
 			ctx := context.Background()
 			r := &queryResolver{Resolver: &Resolver{DB: DB}}
 
@@ -489,8 +489,8 @@ func TestResolver_isAdminInProjectOrDemoProject(t *testing.T) {
 			expError: true,
 		},
 	}
-	for testName, v := range tests {
-		util.RunTestWithDBWipe(t, testName, DB, func(t *testing.T) {
+	for _, v := range tests {
+		util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
 			ctx := context.Background()
 			r := &queryResolver{Resolver: &Resolver{DB: DB}}
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6338,7 +6338,7 @@ func (r *queryResolver) GithubIssueLabels(ctx context.Context, workspaceID int, 
 func (r *queryResolver) Project(ctx context.Context, id int) (*model.Project, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, id)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	return project, nil
 }
@@ -6710,6 +6710,9 @@ func (r *queryResolver) SubscriptionDetails(ctx context.Context, workspaceID int
 	workspace, err := r.isAdminInWorkspace(ctx, workspaceID)
 	if err != nil {
 		return nil, nil
+	}
+	if workspace.StripeCustomerID == nil {
+		return nil, e.New("workspace has no stripe customer ID")
 	}
 
 	if err := r.validateAdminRole(ctx, workspaceID); err != nil {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3823,7 +3823,7 @@ func (r *queryResolver) Session(ctx context.Context, secureID string) (*model.Se
 
 	s, err := r.canAdminViewSession(ctx, secureID)
 	if s == nil || err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	retentionDate, err := r.GetProjectRetentionDate(s.ProjectID)
@@ -4095,7 +4095,7 @@ func (r *queryResolver) ErrorObjects(ctx context.Context, errorGroupSecureID str
 func (r *queryResolver) ErrorObjectForLog(ctx context.Context, logCursor string) (*model.ErrorObject, error) {
 	errorObject := &model.ErrorObject{}
 	if err := r.DB.Order("log_cursor").Model(&errorObject).Where(&model.ErrorObject{LogCursor: pointy.String(logCursor)}).Limit(1).Find(&errorObject).Error; err != nil || errorObject.ID == 0 {
-		return nil, e.Wrapf(err, "no error found for log cursor %s", logCursor)
+		return nil, e.New("no error found for log cursor " + logCursor)
 	}
 	errorObject, err := r.canAdminViewErrorObject(ctx, errorObject.ID)
 	if err != nil {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1275,7 +1275,7 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 	}
 	session := &model.Session{}
 	if err := r.DB.Order("secure_id").Where(&model.Session{SecureID: sessionSecureID}).Limit(1).Find(&session).Error; err != nil || session.ID == 0 {
-		return e.Wrap(err, "[IdentifySession] error querying session by sessionID")
+		return e.New("[IdentifySession] error querying session by sessionID")
 	}
 	getSessionSpan.Finish()
 	sessionID := session.ID
@@ -1730,7 +1730,7 @@ func (r *Resolver) PushMetricsImpl(ctx context.Context, sessionSecureID string, 
 	session := &model.Session{}
 	if err := r.DB.Order("secure_id").Model(&session).Where(&model.Session{SecureID: sessionSecureID}).Limit(1).Find(&session).Error; err != nil || session.ID == 0 {
 		log.WithContext(ctx).Error(e.Wrapf(err, "no session found for push metrics: %s", sessionSecureID))
-		return err
+		return e.New("no session found for push metrics: " + sessionSecureID)
 	}
 	sessionID := session.ID
 	projectID := session.ProjectID
@@ -2229,7 +2229,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	}
 	sessionObj := &model.Session{}
 	if err := r.DB.Order("secure_id").Where(&model.Session{SecureID: sessionSecureID}).Limit(1).Find(&sessionObj).Error; err != nil || sessionObj.ID == 0 {
-		retErr := e.Wrapf(err, "error reading from session %v", sessionSecureID)
+		retErr := e.New("error reading from session %v" + sessionSecureID)
 		querySessionSpan.Finish(tracer.WithError(retErr))
 		return retErr
 	}

--- a/frontend/src/util/log.ts
+++ b/frontend/src/util/log.ts
@@ -1,7 +1,9 @@
+const verboseLoggingEnabled =
+	window.localStorage.getItem(`highlight-verbose-logging-enabled`) === 'true'
 const start = Date.now()
 // Prints the statement to console log when running a development environment.
 export default function log(from: string, ...data: any[]) {
-	if (import.meta.env.DEV || window.location.href.includes('onrender')) {
+	if (verboseLoggingEnabled) {
 		const prefix = `[${(Date.now() - start) / 1000}s] - {${from}}`
 		console.log.apply(console, [prefix, ...data])
 	}

--- a/frontend/src/util/preload.ts
+++ b/frontend/src/util/preload.ts
@@ -312,9 +312,7 @@ export const loadSession = async function (secureID: string) {
 			},
 		])
 	} catch (e: any) {
-		const msg = `failed to preload session ${secureID}`
-		console.warn(msg)
-		H.consumeError(e, msg)
+		log('preload.ts', `failed to preload session ${secureID}`)
 	}
 }
 
@@ -417,8 +415,6 @@ const loadErrorGroup = async function (projectID: string, secureID: string) {
 			},
 		])
 	} catch (e: any) {
-		const msg = `failed to preload error group ${secureID}`
-		console.warn(msg)
-		H.consumeError(e, msg)
+		log('preload.ts', `failed to preload session ${secureID}`)
 	}
 }

--- a/sdk/highlight-go/tracer.go
+++ b/sdk/highlight-go/tracer.go
@@ -95,7 +95,7 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	EndTrace(span)
 
 	RecordMetric(ctx, name+".duration", end.Sub(start).Seconds())
-	if resp.Errors != nil {
+	if resp != nil && resp.Errors != nil {
 		RecordMetric(ctx, name+".errorsCount", float64(len(resp.Errors)))
 	}
 	return resp


### PR DESCRIPTION
## Summary

Fixes resolver logic that's causing nil pointers in our frontend.
Removes noisy frontend errors that are reported from the preload code.

Closes #5556
Closes #5590

## How did you test this change?

New unit tests.
Testing the relevant graphql operations locally.

## Are there any deployment considerations?

No
