### PR TITLE
remove unneeded utils

### DIFF
--- a/backend/apolloio/apolloio.go
+++ b/backend/apolloio/apolloio.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/util"
 	"github.com/pkg/errors"
 )
@@ -30,7 +31,7 @@ func Enrich(email string) (short *string, long *string, err error) {
 
 	contactBytes, err := json.MarshalIndent(matchResponse.Person, "", "  ")
 	if err == nil {
-		long = util.MakeStringPointer(string(contactBytes))
+		long = ptr.String(string(contactBytes))
 	} else {
 		return nil, nil, errors.Wrap(err, "error marshaling")
 	}
@@ -43,7 +44,7 @@ func Enrich(email string) (short *string, long *string, err error) {
 	}
 	contactBytesShort, err := json.MarshalIndent(shortContactMap, "", "  ")
 	if err == nil {
-		short = util.MakeStringPointer(string(contactBytesShort))
+		short = ptr.String(string(contactBytesShort))
 	} else {
 		return nil, nil, errors.Wrap(err, "error marshaling short")
 	}

--- a/backend/stacktraces/enhancer_test.go
+++ b/backend/stacktraces/enhancer_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/go-test/deep"
 	modelInput "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	publicModelInput "github.com/highlight-run/highlight/backend/public-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/storage"
-	"github.com/highlight-run/highlight/backend/util"
 	e "github.com/pkg/errors"
 )
 
@@ -23,42 +23,42 @@ type Testcase struct {
 var proper = Testcase{
 	stackFrameInput: []*publicModelInput.StackFrameInput{
 		{
-			FileName:     util.MakeStringPointer("./test-files/lodash.min.js?400"),
-			LineNumber:   util.MakeIntPointer(1),
-			ColumnNumber: util.MakeIntPointer(813),
+			FileName:     ptr.String("./test-files/lodash.min.js?400"),
+			LineNumber:   ptr.Int(1),
+			ColumnNumber: ptr.Int(813),
 		},
 		{
-			FileName:     util.MakeStringPointer("./test-files/lodash.min.js?ts=123&foo=bar"),
-			LineNumber:   util.MakeIntPointer(1),
-			ColumnNumber: util.MakeIntPointer(799),
+			FileName:     ptr.String("./test-files/lodash.min.js?ts=123&foo=bar"),
+			LineNumber:   ptr.Int(1),
+			ColumnNumber: ptr.Int(799),
 		},
 		{
-			FileName:     util.MakeStringPointer("./test-files/vendors.js"),
-			LineNumber:   util.MakeIntPointer(1),
-			ColumnNumber: util.MakeIntPointer(422367),
+			FileName:     ptr.String("./test-files/vendors.js"),
+			LineNumber:   ptr.Int(1),
+			ColumnNumber: ptr.Int(422367),
 		},
 	},
 	expectedStackTrace: []modelInput.ErrorTrace{
 		{
-			FileName:     util.MakeStringPointer("lodash.js"),
-			LineNumber:   util.MakeIntPointer(634),
-			ColumnNumber: util.MakeIntPointer(4),
-			FunctionName: util.MakeStringPointer(""),
+			FileName:     ptr.String("lodash.js"),
+			LineNumber:   ptr.Int(634),
+			ColumnNumber: ptr.Int(4),
+			FunctionName: ptr.String(""),
 		},
 		{
-			FileName:     util.MakeStringPointer("lodash.js"),
-			LineNumber:   util.MakeIntPointer(633),
-			ColumnNumber: util.MakeIntPointer(11),
-			FunctionName: util.MakeStringPointer("arrayIncludesWith"),
+			FileName:     ptr.String("lodash.js"),
+			LineNumber:   ptr.Int(633),
+			ColumnNumber: ptr.Int(11),
+			FunctionName: ptr.String("arrayIncludesWith"),
 		},
 		{
-			FileName:     util.MakeStringPointer("pages/Buttons/Buttons.tsx"),
-			LineNumber:   util.MakeIntPointer(13),
-			ColumnNumber: util.MakeIntPointer(30),
-			LineContent:  util.MakeStringPointer("                        throw new Error('errors page');\n"),
-			FunctionName: util.MakeStringPointer(""),
-			LinesBefore:  util.MakeStringPointer("        <div className={styles.buttonBody}>\n            <div>\n                <button\n                    className={commonStyles.submitButton}\n                    onClick={() => {\n"),
-			LinesAfter:   util.MakeStringPointer("                    }}\n                >\n                    Throw an Error\n                </button>\n                <button\n"),
+			FileName:     ptr.String("pages/Buttons/Buttons.tsx"),
+			LineNumber:   ptr.Int(13),
+			ColumnNumber: ptr.Int(30),
+			LineContent:  ptr.String("                        throw new Error('errors page');\n"),
+			FunctionName: ptr.String(""),
+			LinesBefore:  ptr.String("        <div className={styles.buttonBody}>\n            <div>\n                <button\n                    className={commonStyles.submitButton}\n                    onClick={() => {\n"),
+			LinesAfter:   ptr.String("                    }}\n                >\n                    Throw an Error\n                </button>\n                <button\n"),
 		},
 	},
 	fetcher: DiskFetcher{},
@@ -78,28 +78,28 @@ func TestEnhanceStackTrace(t *testing.T) {
 		"test source mapping with proper stack trace with network fetcher": {
 			stackFrameInput: []*publicModelInput.StackFrameInput{
 				{
-					FileName:     util.MakeStringPointer("https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js"),
-					LineNumber:   util.MakeIntPointer(1),
-					ColumnNumber: util.MakeIntPointer(813),
+					FileName:     ptr.String("https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js"),
+					LineNumber:   ptr.Int(1),
+					ColumnNumber: ptr.Int(813),
 				},
 				{
-					FileName:     util.MakeStringPointer("https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js"),
-					LineNumber:   util.MakeIntPointer(1),
-					ColumnNumber: util.MakeIntPointer(799),
+					FileName:     ptr.String("https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.min.js"),
+					LineNumber:   ptr.Int(1),
+					ColumnNumber: ptr.Int(799),
 				},
 			},
 			expectedStackTrace: []modelInput.ErrorTrace{
 				{
-					FileName:     util.MakeStringPointer("https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"),
-					LineNumber:   util.MakeIntPointer(634),
-					ColumnNumber: util.MakeIntPointer(4),
-					FunctionName: util.MakeStringPointer(""),
+					FileName:     ptr.String("https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"),
+					LineNumber:   ptr.Int(634),
+					ColumnNumber: ptr.Int(4),
+					FunctionName: ptr.String(""),
 				},
 				{
-					FileName:     util.MakeStringPointer("https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"),
-					LineNumber:   util.MakeIntPointer(633),
-					ColumnNumber: util.MakeIntPointer(11),
-					FunctionName: util.MakeStringPointer("arrayIncludesWith"),
+					FileName:     ptr.String("https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.4/lodash.js"),
+					LineNumber:   ptr.Int(633),
+					ColumnNumber: ptr.Int(11),
+					FunctionName: ptr.String("arrayIncludesWith"),
 				},
 			},
 			fetcher: NetworkFetcher{},
@@ -108,22 +108,22 @@ func TestEnhanceStackTrace(t *testing.T) {
 		"test source mapping invalid trace:no related source map": {
 			stackFrameInput: []*publicModelInput.StackFrameInput{
 				{
-					FileName:     util.MakeStringPointer("./test-files/foo.js"),
-					LineNumber:   util.MakeIntPointer(0),
-					ColumnNumber: util.MakeIntPointer(0),
+					FileName:     ptr.String("./test-files/foo.js"),
+					LineNumber:   ptr.Int(0),
+					ColumnNumber: ptr.Int(0),
 				},
 			},
 			expectedStackTrace: []modelInput.ErrorTrace{
 				{
-					FileName:     util.MakeStringPointer("./test-files/foo.js"),
-					LineNumber:   util.MakeIntPointer(0),
-					ColumnNumber: util.MakeIntPointer(0),
-					Error:        util.MakeStringPointer("error fetching file: ./test-files/foo.js: error fetching file from disk: open ./test-files/foo.js: no such file or directory"),
+					FileName:     ptr.String("./test-files/foo.js"),
+					LineNumber:   ptr.Int(0),
+					ColumnNumber: ptr.Int(0),
+					Error:        ptr.String("error fetching file: ./test-files/foo.js: error fetching file from disk: open ./test-files/foo.js: no such file or directory"),
 					SourceMappingErrorMetadata: &modelInput.SourceMappingError{
 						ErrorCode:                 &stackTraceErrorCode,
-						StackTraceFileURL:         util.MakeStringPointer("./test-files/foo.js"),
-						MinifiedFetchStrategy:     util.MakeStringPointer("S3 and URL"),
-						ActualMinifiedFetchedPath: util.MakeStringPointer("./test-files/foo.js"),
+						StackTraceFileURL:         ptr.String("./test-files/foo.js"),
+						MinifiedFetchStrategy:     ptr.String("S3 and URL"),
+						ActualMinifiedFetchedPath: ptr.String("./test-files/foo.js"),
 					},
 				},
 			},
@@ -133,22 +133,22 @@ func TestEnhanceStackTrace(t *testing.T) {
 		"test source mapping invalid trace:file doesn't exist": {
 			stackFrameInput: []*publicModelInput.StackFrameInput{
 				{
-					FileName:     util.MakeStringPointer("https://cdnjs.cloudflare.com/ajax/libs/lodash.js"),
-					LineNumber:   util.MakeIntPointer(0),
-					ColumnNumber: util.MakeIntPointer(0),
+					FileName:     ptr.String("https://cdnjs.cloudflare.com/ajax/libs/lodash.js"),
+					LineNumber:   ptr.Int(0),
+					ColumnNumber: ptr.Int(0),
 				},
 			},
 			expectedStackTrace: []modelInput.ErrorTrace{
 				{
-					FileName:     util.MakeStringPointer("https://cdnjs.cloudflare.com/ajax/libs/lodash.js"),
-					LineNumber:   util.MakeIntPointer(0),
-					ColumnNumber: util.MakeIntPointer(0),
-					Error:        util.MakeStringPointer("error fetching file: https://cdnjs.cloudflare.com/ajax/libs/lodash.js: status code not OK"),
+					FileName:     ptr.String("https://cdnjs.cloudflare.com/ajax/libs/lodash.js"),
+					LineNumber:   ptr.Int(0),
+					ColumnNumber: ptr.Int(0),
+					Error:        ptr.String("error fetching file: https://cdnjs.cloudflare.com/ajax/libs/lodash.js: status code not OK"),
 					SourceMappingErrorMetadata: &modelInput.SourceMappingError{
 						ErrorCode:                 &stackTraceErrorCode,
-						StackTraceFileURL:         util.MakeStringPointer("https://cdnjs.cloudflare.com/ajax/libs/lodash.js"),
-						MinifiedFetchStrategy:     util.MakeStringPointer("S3 and URL"),
-						ActualMinifiedFetchedPath: util.MakeStringPointer("ajax/libs/lodash.js"),
+						StackTraceFileURL:         ptr.String("https://cdnjs.cloudflare.com/ajax/libs/lodash.js"),
+						MinifiedFetchStrategy:     ptr.String("S3 and URL"),
+						ActualMinifiedFetchedPath: ptr.String("ajax/libs/lodash.js"),
 					},
 				},
 			},
@@ -158,22 +158,22 @@ func TestEnhanceStackTrace(t *testing.T) {
 		"test source mapping invalid trace:filename is not a url": {
 			stackFrameInput: []*publicModelInput.StackFrameInput{
 				{
-					FileName:     util.MakeStringPointer("/file/local/domain.js"),
-					LineNumber:   util.MakeIntPointer(0),
-					ColumnNumber: util.MakeIntPointer(0),
+					FileName:     ptr.String("/file/local/domain.js"),
+					LineNumber:   ptr.Int(0),
+					ColumnNumber: ptr.Int(0),
 				},
 			},
 			expectedStackTrace: []modelInput.ErrorTrace{
 				{
-					FileName:     util.MakeStringPointer("/file/local/domain.js"),
-					LineNumber:   util.MakeIntPointer(0),
-					ColumnNumber: util.MakeIntPointer(0),
-					Error:        util.MakeStringPointer(`error fetching file: /file/local/domain.js: error getting source file: Get "/file/local/domain.js": unsupported protocol scheme ""`),
+					FileName:     ptr.String("/file/local/domain.js"),
+					LineNumber:   ptr.Int(0),
+					ColumnNumber: ptr.Int(0),
+					Error:        ptr.String(`error fetching file: /file/local/domain.js: error getting source file: Get "/file/local/domain.js": unsupported protocol scheme ""`),
 					SourceMappingErrorMetadata: &modelInput.SourceMappingError{
 						ErrorCode:                 &stackTraceErrorCode,
-						StackTraceFileURL:         util.MakeStringPointer("/file/local/domain.js"),
-						MinifiedFetchStrategy:     util.MakeStringPointer("S3 and URL"),
-						ActualMinifiedFetchedPath: util.MakeStringPointer("file/local/domain.js"),
+						StackTraceFileURL:         ptr.String("/file/local/domain.js"),
+						MinifiedFetchStrategy:     ptr.String("S3 and URL"),
+						ActualMinifiedFetchedPath: ptr.String("file/local/domain.js"),
 					},
 				},
 			},
@@ -195,20 +195,20 @@ func TestEnhanceStackTrace(t *testing.T) {
 		"test tsx mapping": {
 			stackFrameInput: []*publicModelInput.StackFrameInput{
 				{
-					FileName:     util.MakeStringPointer("./test-files/main.8344d167.chunk.js"),
-					LineNumber:   util.MakeIntPointer(1),
-					ColumnNumber: util.MakeIntPointer(422367),
+					FileName:     ptr.String("./test-files/main.8344d167.chunk.js"),
+					LineNumber:   ptr.Int(1),
+					ColumnNumber: ptr.Int(422367),
 				},
 			},
 			expectedStackTrace: []modelInput.ErrorTrace{
 				{
-					FileName:     util.MakeStringPointer("pages/Buttons/Buttons.tsx"),
-					LineNumber:   util.MakeIntPointer(13),
-					ColumnNumber: util.MakeIntPointer(30),
-					FunctionName: util.MakeStringPointer(""),
-					LineContent:  util.MakeStringPointer("                        throw new Error('errors page');\n"),
-					LinesBefore:  util.MakeStringPointer("        <div className={styles.buttonBody}>\n            <div>\n                <button\n                    className={commonStyles.submitButton}\n                    onClick={() => {\n"),
-					LinesAfter:   util.MakeStringPointer("                    }}\n                >\n                    Throw an Error\n                </button>\n                <button\n"),
+					FileName:     ptr.String("pages/Buttons/Buttons.tsx"),
+					LineNumber:   ptr.Int(13),
+					ColumnNumber: ptr.Int(30),
+					FunctionName: ptr.String(""),
+					LineContent:  ptr.String("                        throw new Error('errors page');\n"),
+					LinesBefore:  ptr.String("        <div className={styles.buttonBody}>\n            <div>\n                <button\n                    className={commonStyles.submitButton}\n                    onClick={() => {\n"),
+					LinesAfter:   ptr.String("                    }}\n                >\n                    Throw an Error\n                </button>\n                <button\n"),
 				},
 			},
 			fetcher: DiskFetcher{},

--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/cloudfront/sign"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/payload"
 	"github.com/highlight-run/highlight/backend/util"
@@ -512,8 +513,8 @@ func (s *S3Client) pushFileToS3WithOptions(ctx context.Context, sessionId, proje
 // PushCompressedFile pushes a compressed file to S3, adding the relevant metadata
 func (s *S3Client) PushCompressedFile(ctx context.Context, sessionId, projectId int, file *os.File, payloadType PayloadType) (*int64, error) {
 	options := s3.PutObjectInput{
-		ContentType:     util.MakeStringPointer(MIME_TYPE_JSON),
-		ContentEncoding: util.MakeStringPointer(CONTENT_ENCODING_BROTLI),
+		ContentType:     ptr.String(MIME_TYPE_JSON),
+		ContentEncoding: ptr.String(CONTENT_ENCODING_BROTLI),
 	}
 	return s.pushFileToS3WithOptions(ctx, sessionId, projectId, file, payloadType, options)
 }
@@ -639,8 +640,8 @@ func (s *S3Client) ReadResources(ctx context.Context, sessionId int, projectId i
 	output, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket:                  bucket,
 		Key:                     bucketKey(sessionId, projectId, NetworkResourcesCompressed),
-		ResponseContentType:     util.MakeStringPointer(MIME_TYPE_JSON),
-		ResponseContentEncoding: util.MakeStringPointer(CONTENT_ENCODING_BROTLI),
+		ResponseContentType:     ptr.String(MIME_TYPE_JSON),
+		ResponseContentEncoding: ptr.String(CONTENT_ENCODING_BROTLI),
 	})
 	if err != nil {
 		// compressed file doesn't exist, fall back to reading uncompressed
@@ -701,8 +702,8 @@ func (s *S3Client) ReadTimelineIndicatorEvents(ctx context.Context, sessionId in
 	output, err := client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket:                  bucket,
 		Key:                     bucketKey(sessionId, projectId, TimelineIndicatorEvents),
-		ResponseContentType:     util.MakeStringPointer(MIME_TYPE_JSON),
-		ResponseContentEncoding: util.MakeStringPointer(CONTENT_ENCODING_BROTLI),
+		ResponseContentType:     ptr.String(MIME_TYPE_JSON),
+		ResponseContentEncoding: ptr.String(CONTENT_ENCODING_BROTLI),
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "NoSuchKey") {

--- a/backend/util/tests.go
+++ b/backend/util/tests.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -69,18 +68,4 @@ func ClearTablesInDB(db *gorm.DB) error {
 		}
 	}
 	return nil
-}
-
-func MakeIntPointer(v int) *int {
-	return &v
-}
-
-func MakeStringPointer(v string) *string {
-	return &v
-}
-
-func MakeStringPointerFromInterface(v interface{}) *string {
-	exampleErrorTraceBytes, _ := json.Marshal(&v)
-	exampleErrorTraceString := string(exampleErrorTraceBytes)
-	return &exampleErrorTraceString
 }

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/alerts"
 	parse "github.com/highlight-run/highlight/backend/event-parse"
 	"github.com/highlight-run/highlight/backend/hlog"
@@ -905,7 +906,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 			}
 
 			if sessionAlert.ThresholdWindow == nil {
-				sessionAlert.ThresholdWindow = util.MakeIntPointer(30)
+				sessionAlert.ThresholdWindow = ptr.Int(30)
 			}
 			var count int
 			if err := w.Resolver.DB.Raw(`


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We have some custom util code to get a pointer from a variable. While we use both [pointy](https://github.com/openlyinc/pointy) and [ptr](https://pkg.go.dev/github.com/aws/smithy-go@v1.13.5/ptr) in the codebase and probably need to pick one, we certainly don't need custom code.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Did a find and replace.
Build should pass.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A