### PR TITLE
Fix column default for Project.FilterChromeExtension

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -341,7 +341,7 @@ type Project struct {
 	// Minimum count of clicks in a rage click event
 	RageClickCount int `gorm:"default:5"`
 
-	FilterChromeExtension bool `gorm:"default:false"`
+	FilterChromeExtension *bool `gorm:"default:false"`
 }
 
 type MarkBackendSetupType = string

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -341,7 +341,7 @@ type Project struct {
 	// Minimum count of clicks in a rage click event
 	RageClickCount int `gorm:"default:5"`
 
-	FilterChromeExtension *bool `gorm:"default:true"`
+	FilterChromeExtension bool `gorm:"default:false"`
 }
 
 type MarkBackendSetupType = string


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

See [slack](https://highlightcorp.slack.com/archives/C02N2AZS8BV/p1686325059574279). 

This setting should be opt-in, not opt-out (see original [ticket](https://github.com/highlight/highlight/issues/4744)).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

![Screenshot 2023-06-09 at 11 49 08 AM](https://github.com/highlight/highlight/assets/58678/32d97b91-5661-4fb2-b3df-3e9832f1ac72)


Confirmed that this setting is disabled for a new project.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

I've already ran `ALTER TABLE projects ALTER COLUMN filter_chrome_extension SET DEFAULT false;` on prod
