### PR TITLE
Suggested blog posts sometimes do not have images

### DIFF
--- a/highlight.io/components/Blog/Blog.module.scss
+++ b/highlight.io/components/Blog/Blog.module.scss
@@ -40,6 +40,8 @@
 
 	.cardImage {
 		min-height: 160px;
+		max-height: 170px;
+		border: 1px solid var(--color-copy-on-light);
 	}
 
 	.cardSection {

--- a/highlight.io/components/Blog/BlogPost/BlogPost.tsx
+++ b/highlight.io/components/Blog/BlogPost/BlogPost.tsx
@@ -19,7 +19,7 @@ export interface Post {
 	description: string
 	youtubeVideoId?: string
 	metaDescription?: string
-	image?: {
+	image: {
 		url: string
 	}
 	title: string

--- a/highlight.io/components/Blog/SuggestedBlogPost/SuggestedBlogPost.tsx
+++ b/highlight.io/components/Blog/SuggestedBlogPost/SuggestedBlogPost.tsx
@@ -1,9 +1,9 @@
-import styles from '../Blog.module.scss'
+import classNames from 'classnames'
 import Image from 'next/legacy/image'
 import Link from 'next/link'
 import { Typography } from '../../common/Typography/Typography'
+import styles from '../Blog.module.scss'
 import { Post } from '../BlogPost/BlogPost'
-import classNames from 'classnames'
 import { PostTag } from '../Tag'
 
 export const SuggestedBlogPost = ({

--- a/highlight.io/pages/blog/[slug].tsx
+++ b/highlight.io/pages/blog/[slug].tsx
@@ -156,9 +156,9 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 			params.set('lname', suggestedPost.author?.lastName || '')
 			params.set('role', suggestedPost.author?.title || '')
 
-			const metaImageURL = `https://${
-				process.env.NEXT_PUBLIC_VERCEL_URL || 'www.highlight.io'
-			}/api/og/blog/${suggestedPost.slug}?${params.toString()}`
+			const metaImageURL = `https://${'www.highlight.io'}/api/og/blog/${
+				suggestedPost.slug
+			}?${params.toString()}`
 
 			suggestedPost.image.url = metaImageURL
 		}

--- a/highlight.io/pages/blog/[slug].tsx
+++ b/highlight.io/pages/blog/[slug].tsx
@@ -147,8 +147,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 			1,
 		)[0]
 
-		console.log(suggestedPost.image)
-
 		if (suggestedPost.image.url == null) {
 			const params = new URLSearchParams()
 			params.set('title', suggestedPost.title || '')

--- a/highlight.io/pages/blog/[slug].tsx
+++ b/highlight.io/pages/blog/[slug].tsx
@@ -142,12 +142,28 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 		i < Math.min(NUM_SUGGESTED_POSTS, githubPosts.length - 1);
 		i++
 	) {
-		suggestedPosts.push(
-			otherPosts.splice(
-				Math.floor(Math.random() * otherPosts.length),
-				1,
-			)[0],
-		)
+		let suggestedPost = otherPosts.splice(
+			Math.floor(Math.random() * otherPosts.length),
+			1,
+		)[0]
+
+		console.log(suggestedPost.image)
+
+		if (suggestedPost.image.url == null) {
+			const params = new URLSearchParams()
+			params.set('title', suggestedPost.title || '')
+			params.set('fname', suggestedPost.author?.firstName || '')
+			params.set('lname', suggestedPost.author?.lastName || '')
+			params.set('role', suggestedPost.author?.title || '')
+
+			const metaImageURL = `https://${
+				process.env.NEXT_PUBLIC_VERCEL_URL || 'www.highlight.io'
+			}/api/og/blog/${suggestedPost.slug}?${params.toString()}`
+
+			suggestedPost.image.url = metaImageURL
+		}
+
+		suggestedPosts.push(suggestedPost)
 	}
 
 	const githubPost = await getGithubPostBySlug(slug, githubPosts)

--- a/highlight.io/pages/blog/[slug].tsx
+++ b/highlight.io/pages/blog/[slug].tsx
@@ -241,6 +241,11 @@ const PostPage = ({
 				endPosition={endPosition}
 				singleTag={singleTag}
 			/>
+			<div className="hidden">
+				{suggestedPosts.map((p, i) => (
+					<SuggestedBlogPost {...p} key={i} />
+				))}
+			</div>
 			<main
 				ref={blogBody}
 				className={classNames(styles.mainBlogPadding, 'relative')}


### PR DESCRIPTION
## Summary

See [attached issue](https://github.com/highlight/highlight/issues/5265).

If a post does not have an image, then it defaults to the OG image which is currently used for previews.

Fixed Suggested Post:
<img width="801" alt="image" src="https://github.com/highlight/highlight/assets/25088104/689cffa7-f6fa-4484-8e1d-6f919abceab4">

Secondly, images don't scale infinitely depending on post title length anymore.

Before:
<img width="786" alt="image" src="https://github.com/highlight/highlight/assets/25088104/2711f474-fe81-43a3-9027-3d5118557cc8">

After:
<img width="822" alt="image" src="https://github.com/highlight/highlight/assets/25088104/12b22032-96e2-48b3-9d9e-a0dc447173b0">


