### PR TITLE
fix broken/dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Good for <10k sessions and <50k errors ingested monthly. See our  [docs for more
 
 ### Enterprise self-hosted
 
-See our [enterprise self-hosted docs](https://www.highlight.io/docs/general/company/open-source/self-host-enterprise) to deploy a scalable, production-ready instance with support from our team.
+See our [enterprise self-hosted docs](https://www.highlight.io/docs/general/company/open-source/hosting/self-host-enterprise) to deploy a scalable, production-ready instance with support from our team.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ After a brief frontend load time, the app should be accessible at https://localh
 
 Good for <10k sessions and <50k errors ingested monthly. See our  [docs for more info and limitations](https://www.highlight.io/docs/general/company/open-source/hosting/self-host-hobby).
 
-### Developing on Highlight
-
-Want to contribute to Highlight? See our [onboarding](./DEVELOPER_ONBOARDING.md) guide.
-
 ### Enterprise self-hosted
 
 See our [enterprise self-hosted docs](https://www.highlight.io/docs/general/company/open-source/self-host-enterprise) to deploy a scalable, production-ready instance with support from our team.


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Found using a new linter as part of mega-linter, see [failing build](https://github.com/highlight/highlight/actions/runs/5258960794/jobs/9503888068)

<img width="797" alt="Screenshot 2023-06-13 at 3 06 48 PM" src="https://github.com/highlight/highlight/assets/58678/e25f2be5-c5f0-44aa-a859-a117f8741a22">


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Viewed readme

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
