### PR TITLE
Fix env script not updating config with trailing comma

### DIFF
--- a/frontend/scripts/update-reflame-environment.mjs
+++ b/frontend/scripts/update-reflame-environment.mjs
@@ -1,5 +1,6 @@
 import * as jsoncParser from 'jsonc-parser'
 import * as fs from 'node:fs'
+import prettier from 'prettier'
 
 const configPath = '../.reflame.config.jsonc'
 const configText = fs.readFileSync(configPath, 'utf8')
@@ -56,7 +57,16 @@ const result = jsoncParser.applyEdits(
 	),
 )
 
-if (result !== configText) {
+const prettierConfigFile = await prettier.resolveConfigFile(process.cwd())
+
+const prettierConfig = JSON.parse(fs.readFileSync(prettierConfigFile))
+
+const formatted = prettier.format(result, {
+	...prettierConfig,
+	...prettierConfig.overrides[0].options,
+})
+
+if (formatted !== configText) {
 	console.log(`updating Reflame config with '${name}' environment`)
-	fs.writeFileSync(configPath, result)
+	fs.writeFileSync(configPath, formatted)
 }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Fixes https://github.com/highlight/highlight/pull/5639#discussion_r1228794392, so you shouldn't need to manually run prettier-fix after the env script updates it. In fact it should no longer try to update it in the first place if it's identical (trailing comma included).

## How did you test this change?

Ran the script locally and made sure trailing commas were added.

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
