### PR TITLE
only send new session alerts when transitioning from excluded to not excluded

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2633,8 +2633,8 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		}
 	}
 
-	// if the session is not excluded, it is viewable, so send any relevant alerts
-	if !excluded {
+	// if the session changed from excluded to not excluded, it is viewable, so send any relevant alerts
+	if sessionObj.Excluded && !excluded {
 		return r.HandleSessionViewable(ctx, projectID, sessionObj)
 	}
 


### PR DESCRIPTION
## Summary
- new session alert code was being triggered on every push payload for non-excluded sessions even though they would only be sent once (some logic checks the DB to make sure they aren't sent more than once)
- >30% of CPU was spent in `SendSessionInitAlert` according to datadog, most of this for preloading session fields to get the visited url
- only trigger the code when transitioning from excluded to not (may happen a couple times during session processing but should be way less frequent)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor prod after deploying
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
