### PR TITLE
real time billing meters for sessions/errors

### DIFF
--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -18,6 +18,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	stripe "github.com/stripe/stripe-go/v72"
 	"github.com/stripe/stripe-go/v72/client"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gorm.io/gorm"
 )
 
@@ -64,6 +65,11 @@ func GetSessions7DayAverage(ctx context.Context, DB *gorm.DB, ccClient *clickhou
 }
 
 func GetWorkspaceSessionsMeter(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, workspace *model.Workspace) (int64, error) {
+	meterSpan, _ := tracer.StartSpanFromContext(ctx, "pricing.GetWorkspaceSessionsMeter",
+		tracer.ResourceName("GetWorkspaceSessionsMeter"),
+		tracer.Tag("workspace_id", workspace.ID))
+	defer meterSpan.Finish()
+
 	var meter int64
 	if err := DB.Raw(`
 		WITH materialized_rows AS (
@@ -113,6 +119,11 @@ func GetErrors7DayAverage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse
 }
 
 func GetWorkspaceErrorsMeter(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, workspace *model.Workspace) (int64, error) {
+	meterSpan, _ := tracer.StartSpanFromContext(ctx, "pricing.GetWorkspaceErrorsMeter",
+		tracer.ResourceName("GetWorkspaceErrorsMeter"),
+		tracer.Tag("workspace_id", workspace.ID))
+	defer meterSpan.Finish()
+
 	var meter int64
 	if err := DB.Raw(`
 		WITH materialized_rows AS (


### PR DESCRIPTION
## Summary
- union the materialized view results with the count of sessions / errors after the materialized view was last updated (>= the latest date from the materialized view)
- added relevant indexes:
```
CREATE INDEX idx_error_objects_project_id_created_at ON public.error_objects USING btree (project_id, created_at)

CREATE INDEX idx_recent_sessions_billing ON public.sessions USING btree (project_id, created_at) WHERE ((excluded <> true) AND ((active_length >= 1000) OR ((active_length IS NULL) AND (length >= 1000))) AND (processed = true))
```
- slightly worse performance against the prod db (~.2s vs .06s for a larger project), difference will be more noticeable on ECS due to colocation so will monitor prod after deploying
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested query in prod to make sure results were reasonable, click tested locally to make sure stuff wasn't breaking
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
