### PR TITLE
Fix gem name usage in README.md

### DIFF
--- a/sdk/highlight-ruby/highlight/README.md
+++ b/sdk/highlight-ruby/highlight/README.md
@@ -9,7 +9,7 @@ TODO: Delete this and the text above, and describe your gem
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'highlight'
+gem 'highlight_io'
 ```
 
 And then execute:


### PR DESCRIPTION
Tiny update, just noticed this looking over the SDK implementation. `highlight_io` is the correct gem to mention here