### PR TITLE
allow mentioning slack channels in comments

### DIFF
--- a/frontend/src/components/Comment/utils/utils.ts
+++ b/frontend/src/components/Comment/utils/utils.ts
@@ -159,9 +159,7 @@ export const parseAdminSuggestions = (
 					!mentionedAdmins.some(
 						(mentionedAdmin) =>
 							mentionedAdmin.id === suggestion?.id,
-					) &&
-					// 3. Non-user results
-					suggestion.name?.startsWith('@'),
+					),
 			)
 			.map((suggestion) => {
 				return {


### PR DESCRIPTION
## Summary

Remove the logic that would filter out slack channels from comment mentions.

## How did you test this change?

Reflame preview.

## Are there any deployment considerations?

No