### PR TITLE
remove sessions outside billing quota from meter

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1320,6 +1320,7 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 			SELECT project_id, DATE_TRUNC('day', created_at, 'UTC') as date, COUNT(*) as count
 			FROM sessions
 			WHERE excluded <> true
+			AND within_billing_quota
 			AND (active_length >= 1000 OR (active_length is null and length >= 1000))
 			AND processed = true
 			AND created_at > now() - interval '3 months'

--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -93,6 +93,7 @@ func GetWorkspaceSessionsMeter(ctx context.Context, DB *gorm.DB, ccClient *click
 			FROM workspaces
 			WHERE id=@workspace_id)
 			AND excluded <> true
+			AND within_billing_quota
 			AND (active_length >= 1000 OR (active_length is null and length >= 1000))
 			AND processed = true
 			UNION ALL SELECT COALESCE(SUM(count), 0) FROM materialized_rows


### PR DESCRIPTION
## Summary
- billing meter was including sessions outside billing quota after the materialized view's end date, remove those
- add filter to the materialized view definition in code (was already included in prod)
- currently adding another index in prod to include `within_billing_quota`
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locallly
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
