### PR TITLE
Remove Emoji in Contributors Title

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Have an idea for what we should build next? Please share our [community](https:/
 
 All of our SDKs for highlight.io can be found in the `sdk` [directory](https://github.com/highlight/highlight/tree/main/sdk). To get started with these SDKs, we recommend the [getting started guide](https://www.highlight.io/docs/getting-started/overview) in our docs.
 
-## Contributors ✨
+## Contributors
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->


### PR DESCRIPTION
## Summary

Removes the emoji in the "Contributors" title on the readme because the link was otherwise broken. Also keeping it this way for consistency.
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
