### PR TITLE
better error messaging for Vercel env var patch error

### DIFF
--- a/backend/vercel/vercel.go
+++ b/backend/vercel/vercel.go
@@ -4,12 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/go-chi/chi"
-	model2 "github.com/highlight-run/highlight/backend/model"
-	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
-	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
-	"github.com/samber/lo"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
 	"net/url"
@@ -17,6 +11,13 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/go-chi/chi"
+	model2 "github.com/highlight-run/highlight/backend/model"
+	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
+	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
+	"github.com/samber/lo"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/pkg/errors"
@@ -121,6 +122,9 @@ func SetEnvVariable(projectId string, apiKey string, accessToken string, teamId 
 	b, err := io.ReadAll(res.Body)
 
 	if res.StatusCode != 200 {
+		if method == "PATCH" {
+			return errors.New(fmt.Sprintf("Could not patch environment variable %s - If this environment variable is already defined in Vercel, please remove it from your Vercel project and retry.", key))
+		}
 		return errors.New("Vercel Project Env API responded with error; status_code=" + res.Status + "; body=" + string(b))
 	}
 


### PR DESCRIPTION

<img width="1412" alt="Screen Shot 2023-06-16 at 2 27 55 PM" src="https://github.com/highlight/highlight/assets/86132398/af0959a1-5391-45bf-88cc-6d61375815c4">

## Summary
- patching a Vercel environment variable will fail if it's already been defined (since the Highlight integration does not own it)
-  show the user a message indicating which variable is causing the issue so they can fix it
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
