### PR TITLE
disable client verbose logging by default

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -55,9 +55,10 @@ document.body.className = 'highlight-light-theme'
 
 analytics.initialize()
 const dev = import.meta.env.DEV
-const clientDebug = window.localStorage.getItem('highlight-client-debug')
-if (clientDebug === undefined) {
-	window.localStorage.setItem('highlight-client-debug', 'false')
+const clientDebugKey = 'highlight-client-debug'
+const clientDebug = window.localStorage.getItem(clientDebugKey)
+if (!clientDebug) {
+	window.localStorage.setItem(clientDebugKey, 'false')
 }
 const shouldDebugLog = clientDebug === 'true'
 const options: HighlightOptions = {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -55,8 +55,15 @@ document.body.className = 'highlight-light-theme'
 
 analytics.initialize()
 const dev = import.meta.env.DEV
+const clientDebug = window.localStorage.getItem('highlight-client-debug')
+if (clientDebug === undefined) {
+	window.localStorage.setItem('highlight-client-debug', 'false')
+}
+const shouldDebugLog = clientDebug === 'true'
 const options: HighlightOptions = {
-	debug: { clientInteractions: true, domRecording: true },
+	debug: shouldDebugLog
+		? { clientInteractions: true, domRecording: true }
+		: undefined,
 	manualStart: true,
 	enableStrictPrivacy: Math.floor(Math.random() * 8) === 0,
 	networkRecording: {

--- a/frontend/src/util/log.ts
+++ b/frontend/src/util/log.ts
@@ -1,5 +1,9 @@
-const verboseLoggingEnabled =
-	window.localStorage.getItem(`highlight-verbose-logging-enabled`) === 'true'
+const verboseLoggingKey = `highlight-verbose-logging-enabled`
+const verboseLogging = window.localStorage.getItem(verboseLoggingKey)
+if (!verboseLogging) {
+	window.localStorage.setItem(verboseLoggingKey, 'false')
+}
+const verboseLoggingEnabled = verboseLogging === 'true'
 const start = Date.now()
 // Prints the statement to console log when running a development environment.
 export default function log(from: string, ...data: any[]) {


### PR DESCRIPTION
## Summary

Per our eng retro, we should not have verbose client logs in our frontend by default.
Adds a local storage variable that can be used to enable verbose logs for player debugging.
<img width="1115" alt="Screenshot 2023-06-16 at 2 37 17 PM" src="https://github.com/highlight/highlight/assets/1351531/6320db5b-a7ca-4ba8-a7cc-e5046981324e">

## How did you test this change?

Reflame preview.

## Are there any deployment considerations?

No
