### PR TITLE
Fix popover transparency issues

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5682,7 +5682,7 @@ body {
 }
 ._1ec5cce1 {
   container-name: _1ec5cce0;
-  container-type: inline-size;
+  container-type: normal;
   overflow-y: scroll;
   width: 100%;
   height: 100%;

--- a/packages/ui/src/components/Container/styles.css.ts
+++ b/packages/ui/src/components/Container/styles.css.ts
@@ -8,7 +8,7 @@ const containerName = createContainer()
 
 export const container = style({
 	containerName,
-	containerType: 'inline-size',
+	containerType: 'normal',
 	overflowY: 'scroll',
 	width: '100%',
 	height: '100%',


### PR DESCRIPTION
## Summary
https://github.com/highlight/highlight/issues/5666

The popover on the errors page is appearing under the error content. This is due to the container's css sets the [container type](https://developer.mozilla.org/en-US/docs/Web/CSS/container-type) to `inline-size` which seems to ignore other component's `z-index`. Update the container's type to `normal`

## How did you test this change?
1. Visit the errors page
2. Click an error
3. Click the `...` by the filters
- [ ] Confirm the menu is displayed over the error content

<img width="1716" alt="Screenshot 2023-06-16 at 3 19 52 PM" src="https://github.com/highlight/highlight/assets/17744174/69e8ced0-2a8d-401b-ac81-556fa833243b">

<details><summary>Other uses of container</summary>

<img width="1494" alt="Screenshot 2023-06-16 at 3 19 27 PM" src="https://github.com/highlight/highlight/assets/17744174/3d1a95d3-9cd9-4064-8ef5-b74e2d4c3199">

</details>

## Are there any deployment considerations?
No
