### PR TITLE
Add hover state of devtools multi selects

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5993,6 +5993,10 @@ body {
   gap: 4px;
   padding: 0 8px;
 }
+._1oemo0l1:hover {
+  cursor: pointer;
+  background: var(--_1pyqka91x);
+}
 ._1oemo0l2 {
   background-color: #ffffff;
   border: var(--_1pyqka91o) solid 1px;

--- a/packages/ui/src/components/MultiSelectButton/styles.css.ts
+++ b/packages/ui/src/components/MultiSelectButton/styles.css.ts
@@ -19,6 +19,13 @@ export const selectButton = style({
 	fontSize: 13,
 	gap: 4,
 	padding: '0 8px',
+
+	selectors: {
+		'&:hover': {
+			cursor: 'pointer',
+			background: vars.theme.interactive.overlay.secondary.hover,
+		},
+	},
 })
 
 export const selectPopover = style({


### PR DESCRIPTION
## Summary
Add a hover state to the multi select to make it clear that it is clickable.

## How did you test this change?
1. View a session and hover over the "Type" and "Status" multi filters
- [ ] Multi select has hover state
- [ ] Hover state is consistent with rest of page/app

https://github.com/highlight/highlight/assets/17744174/84689c9a-0f9d-4b6b-a2d9-c267427e2700

## Are there any deployment considerations?
N/A
