### PR TITLE
extend session length for a given project

### DIFF
--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -135,6 +135,7 @@ const SEND_FREQUENCY = 1000 * 2
  * Maximum length of a session
  */
 const MAX_SESSION_LENGTH = 4 * 60 * 60 * 1000
+const EXTENDED_MAX_SESSION_LENGTH = 12 * 60 * 60 * 1000
 
 const HIGHLIGHT_URL = 'app.highlight.run'
 
@@ -1215,12 +1216,15 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 	// Reset the events array and push to a backend.
 	async _save() {
 		try {
+			let maxLength = MAX_SESSION_LENGTH
+			if (this.organizationID === 'odzl0xep') {
+				maxLength = EXTENDED_MAX_SESSION_LENGTH
+			}
 			if (
 				this.state === 'Recording' &&
 				this.listeners &&
 				this.sessionData.sessionStartTime &&
-				Date.now() - this.sessionData.sessionStartTime >
-					MAX_SESSION_LENGTH
+				Date.now() - this.sessionData.sessionStartTime > maxLength
 			) {
 				await this._reset()
 			}

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -241,3 +241,10 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Minor Changes
 
 - Improves the experience of configuring cross-origin `<iframe>` recording.
+
+
+## 7.1.1
+
+### Patch Changes
+
+- Extends the length of recorded sessions for a given project.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.1.0",
+	"version": "7.1.1",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.1.0"
+export default "7.1.1"


### PR DESCRIPTION
## Summary

Extends the maximum session length to 12 hours for a given project that needs longer sessions.

## How did you test this change?

Reflame preview.

## Are there any deployment considerations?

New patch version of the client.