### PR TITLE
support ingesting logs without a span

### DIFF
--- a/sdk/highlight-py/e2e/highlight_azure/HttpTrigger/__init__.py
+++ b/sdk/highlight-py/e2e/highlight_azure/HttpTrigger/__init__.py
@@ -27,7 +27,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
                 "customer": req.headers.get("customer") or "unknown",
                 "idx": idx,
                 "float": 1.2345,
-                "duration": datetime.now() - start,
+                "duration": (datetime.now() - start).total_seconds(),
             },
         )
 
@@ -51,7 +51,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
             "customer": req.headers.get("customer") or "unknown",
             "name": name,
             "float": 1.2345,
-            "duration": datetime.now() - start,
+            "duration": (datetime.now() - start).total_seconds(),
         },
     )
 

--- a/sdk/highlight-py/e2e/highlight_script/main.py
+++ b/sdk/highlight-py/e2e/highlight_script/main.py
@@ -4,10 +4,11 @@ import time
 
 import highlight_io
 
-H = highlight_io.H("1", instrument_logging=True)
+H = highlight_io.H("1", instrument_logging=True, otlp_endpoint="http://localhost:4318")
 
 
 def main():
+    logging.info("hello main", {"customer": "world", "trace": "outside"})
     with H.trace():
         logging.info("hello handler", {"customer": "unknown"})
         for idx in range(1000):
@@ -20,3 +21,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    H.flush()

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -196,29 +196,28 @@ class H(object):
         return self._log_handler
 
     def log_hook(self, span: Span, record: logging.LogRecord):
-        if not span.is_recording():
-            return
-        ctx = span.get_span_context()
-        # record.created is sec but timestamp should be ns
-        ts = int(record.created * 1000.0 * 1000.0 * 1000.0)
-        attributes = span.attributes.copy()
-        attributes["code.function"] = record.funcName
-        attributes["code.namespace"] = record.module
-        attributes["code.filepath"] = record.pathname
-        attributes["code.lineno"] = record.lineno
-        attributes.update(record.args or {})
-        r = LogRecord(
-            timestamp=ts,
-            trace_id=ctx.trace_id,
-            span_id=ctx.span_id,
-            trace_flags=ctx.trace_flags,
-            severity_text=record.levelname,
-            severity_number=std_to_otel(record.levelno),
-            body=record.getMessage(),
-            resource=span.resource,
-            attributes=attributes,
-        )
-        self.log.emit(r)
+        if span and span.is_recording():
+            ctx = span.get_span_context()
+            # record.created is sec but timestamp should be ns
+            ts = int(record.created * 1000.0 * 1000.0 * 1000.0)
+            attributes = span.attributes.copy()
+            attributes["code.function"] = record.funcName
+            attributes["code.namespace"] = record.module
+            attributes["code.filepath"] = record.pathname
+            attributes["code.lineno"] = record.lineno
+            attributes.update(record.args or {})
+            r = LogRecord(
+                timestamp=ts,
+                trace_id=ctx.trace_id,
+                span_id=ctx.span_id,
+                trace_flags=ctx.trace_flags,
+                severity_text=record.levelname,
+                severity_number=std_to_otel(record.levelno),
+                body=record.getMessage(),
+                resource=span.resource,
+                attributes=attributes,
+            )
+            self.log.emit(r)
 
     def _instrument_logging(self):
         if H._logging_instrumented:

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -132,8 +132,13 @@ class H(object):
 
         :param session_id: the highlight session that initiated this network request.
         :param request_id: the identifier of the current network request.
-        :return: None
+        :return: Span
         """
+        # in case the otel library is in a non-recording context, do nothing
+        if not hasattr(self, "tracer") or not self.tracer:
+            yield
+            return
+
         with self.tracer.start_as_current_span("highlight-ctx") as span:
             span.set_attributes({"highlight.project_id": self._project_id})
             span.set_attributes({"highlight.session_id": session_id})

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -235,7 +235,12 @@ class H(object):
             else:
                 manager = self.trace()
 
-            with manager:
+            try:
+                with manager:
+                    return otel_factory(*args, **kwargs)
+            except RecursionError:
+                # in case we are hitting a recusrive log from the `self.trace()` invocation
+                # (happens when we exceed the otel log queue depth)
                 return otel_factory(*args, **kwargs)
 
         logging.setLogRecordFactory(factory)

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -125,7 +125,7 @@ class H(object):
             H = highlight_io.H('project_id', ...)
 
             def my_fn():
-                with H.guard(headers={'X-Highlight-Request': '...'}):
+                with H.trace(headers={'X-Highlight-Request': '...'}):
                     raise Exception('fake error!')
 
 
@@ -192,13 +192,13 @@ class H(object):
 
     def log_hook(self, span: Span, record: logging.LogRecord):
         if span:
-            if not span.is_recording():
-                return
             manager = contextlib.nullcontext(enter_result=span)
         else:
             manager = self.trace()
 
         with manager as span:
+            if not span.is_recording():
+                return
             ctx = span.get_span_context()
             # record.created is sec but timestamp should be ns
             ts = int(record.created * 1000.0 * 1000.0 * 1000.0)

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -194,11 +194,11 @@ class H(object):
         if span:
             if not span.is_recording():
                 return
-            ctx = contextlib.nullcontext(enter_result=span)
+            manager = contextlib.nullcontext(enter_result=span)
         else:
-            ctx = self.trace()
+            manager = self.trace()
 
-        with ctx() as span:
+        with manager as span:
             ctx = span.get_span_context()
             # record.created is sec but timestamp should be ns
             ts = int(record.created * 1000.0 * 1000.0 * 1000.0)

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -36,6 +36,7 @@ class H(object):
     REQUEST_HEADER = "X-Highlight-Request"
     OTLP_HTTP = "https://otel.highlight.io:4318"
     _instance: "H" = None
+    _logging_instrumented = False
 
     @classmethod
     def get_instance(cls) -> "H":
@@ -82,7 +83,6 @@ class H(object):
                     f"{self._otlp_endpoint}/v1/traces", compression=Compression.Gzip
                 ),
                 schedule_delay_millis=1000,
-                max_export_batch_size=64,
                 export_timeout_millis=5000,
             )
         )
@@ -96,7 +96,6 @@ class H(object):
                     f"{self._otlp_endpoint}/v1/logs", compression=Compression.Gzip
                 ),
                 schedule_delay_millis=1000,
-                max_export_batch_size=64,
                 export_timeout_millis=5000,
             )
         )
@@ -222,6 +221,9 @@ class H(object):
         self.log.emit(r)
 
     def _instrument_logging(self):
+        if H._logging_instrumented:
+            return
+
         LoggingInstrumentor().instrument(
             set_logging_format=True, log_hook=self.log_hook
         )
@@ -238,3 +240,4 @@ class H(object):
                 return otel_factory(*args, **kwargs)
 
         logging.setLogRecordFactory(factory)
+        H._logging_instrumented = True

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.5.0"
+version = "0.5.1"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [

--- a/sdk/highlight-py/tests/test_aws.py
+++ b/sdk/highlight-py/tests/test_aws.py
@@ -6,7 +6,7 @@ from highlight_io import H
 
 def test_aws(mocker):
     mocker.patch("random.random", return_value=0.1)
-    mock_trace = mocker.patch("highlight_io.H.trace")
+    mock_trace = mocker.spy(H, "trace")
     # Construct a mock HTTP request.
     req = {
         H.REQUEST_HEADER: "a1b2c3/1234",
@@ -15,4 +15,4 @@ def test_aws(mocker):
     with pytest.raises(expected_exception=ValueError):
         lambda_handler(req, None)
 
-    mock_trace.assert_called_with("a1b2c3", "1234")
+    mock_trace.assert_called_with(H.get_instance(), "a1b2c3", "1234")

--- a/sdk/highlight-py/tests/test_azure.py
+++ b/sdk/highlight-py/tests/test_azure.py
@@ -7,7 +7,7 @@ from highlight_io import H
 
 def test_azure(mocker):
     mocker.patch("random.random", return_value=0.1)
-    mock_trace = mocker.patch("highlight_io.H.trace")
+    mock_trace = mocker.spy(H, "trace")
     # Construct a mock HTTP request.
     req = func.HttpRequest(
         method="GET",
@@ -20,4 +20,4 @@ def test_azure(mocker):
     with pytest.raises(expected_exception=ValueError):
         main(req)
 
-    mock_trace.assert_called_with("a1b2c3", "1234")
+    mock_trace.assert_called_with(H.get_instance(), "a1b2c3", "1234")

--- a/sdk/highlight-py/tests/test_gcp.py
+++ b/sdk/highlight-py/tests/test_gcp.py
@@ -1,14 +1,15 @@
 import pytest
 from flask import Request
 
-import highlight_io
 from e2e.highlight_gcp.hello_http import hello_http
+from highlight_io import H
 
 
 def test_gcp(mocker):
-    highlight_io.H("1", instrument_logging=True)
+    H("1", instrument_logging=True)
+
     mocker.patch("random.random", return_value=0.1)
-    mock_trace = mocker.spy(highlight_io.H, "trace")
+    mock_trace = mocker.spy(H, "trace")
 
     # Construct a mock HTTP request.
     request = Request(environ={"HTTP_X_HIGHLIGHT_REQUEST": "a1b2c3/1234"})
@@ -16,4 +17,4 @@ def test_gcp(mocker):
     with pytest.raises(expected_exception=ValueError):
         hello_http(request)
 
-    mock_trace.assert_called_with(highlight_io.H.get_instance(), "a1b2c3", "1234")
+    mock_trace.assert_called_with(H.get_instance(), "a1b2c3", "1234")

--- a/sdk/highlight-py/tests/test_gcp.py
+++ b/sdk/highlight-py/tests/test_gcp.py
@@ -8,11 +8,12 @@ from e2e.highlight_gcp.hello_http import hello_http
 def test_gcp(mocker):
     highlight_io.H("1", instrument_logging=True)
     mocker.patch("random.random", return_value=0.1)
-    mock_trace = mocker.patch("highlight_io.H.trace")
+    mock_trace = mocker.spy(highlight_io.H, "trace")
+
     # Construct a mock HTTP request.
     request = Request(environ={"HTTP_X_HIGHLIGHT_REQUEST": "a1b2c3/1234"})
 
     with pytest.raises(expected_exception=ValueError):
         hello_http(request)
 
-    mock_trace.assert_called_with("a1b2c3", "1234")
+    mock_trace.assert_called_with(highlight_io.H.get_instance(), "a1b2c3", "1234")

--- a/sdk/highlight-py/tests/test_sdk.py
+++ b/sdk/highlight-py/tests/test_sdk.py
@@ -46,3 +46,24 @@ def test_record_exception(mock_otlp, project_id, session_id, request_id):
         with h.trace(session_id, request_id):
             logging.info(f"trace! {i}")
         h.record_exception(FileNotFoundError(f"test! {i}"))
+
+
+def test_log_no_trace(mocker):
+    span = mocker.patch("highlight_io.sdk.OTLPSpanExporter")
+    log = mocker.patch("highlight_io.sdk.OTLPLogExporter")
+    sp = mocker.patch(
+        "highlight_io.sdk.BatchSpanProcessor", return_value=BatchSpanProcessor(span)
+    )
+    lg = mocker.patch(
+        "highlight_io.sdk.BatchLogRecordProcessor",
+        return_value=BatchLogRecordProcessor(log),
+    )
+    mock_trace = mocker.spy(highlight_io.H, "trace")
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    h = highlight_io.H("1", instrument_logging=True)
+    logger.info(f"hey there!")
+    h.flush()
+
+    assert mock_trace.call_args_list[0].args[1:] == ()

--- a/sdk/highlight-py/tests/test_sdk.py
+++ b/sdk/highlight-py/tests/test_sdk.py
@@ -42,6 +42,7 @@ def test_record_exception(mock_otlp, project_id, session_id, request_id):
     )
 
     for i in range(10):
+        logging.info(f"hey there! {i}")
         with h.trace(session_id, request_id):
             logging.info(f"trace! {i}")
         h.record_exception(FileNotFoundError(f"test! {i}"))


### PR DESCRIPTION
## Summary

Ensure that logs emitted in a python app instrumented with the highlight SDK
outside of the context of a opentelemetry span are ingested. This allows using
highlight in an app without the `with H.trace():` contextmanager for the logging use-case.

## How did you test this change?

New e2e that prints a log outside of a trace
<img width="1173" alt="Screenshot 2023-06-21 at 4 06 59 PM" src="https://github.com/highlight/highlight/assets/1351531/97227bff-2e41-4a36-a169-c6e45e85dc2c">

trace-based spans still work
<img width="1229" alt="Screenshot 2023-06-21 at 4 07 30 PM" src="https://github.com/highlight/highlight/assets/1351531/331f508e-e1fd-4fae-966e-20600a379130">

new unit test

## Are there any deployment considerations?

New version of the python SDK published.
