### PR TITLE
add session rendering lambda to CI

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -106,5 +106,5 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Publish render
-              #              if: github.ref == 'refs/heads/main'
+              if: github.ref == 'refs/heads/main'
               run: yarn publish:render

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -104,3 +104,7 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Publish render
+              if: github.ref == 'refs/heads/main'
+              run: yarn publish:render

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -106,5 +106,5 @@ jobs:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
             - name: Publish render
-              if: github.ref == 'refs/heads/main'
+              #              if: github.ref == 'refs/heads/main'
               run: yarn publish:render

--- a/render/src/render.ts
+++ b/render/src/render.ts
@@ -136,8 +136,11 @@ export async function render(
 		files.push(file)
 	}
 
-	await page.close()
-	await browser.close()
+	// puppeteer shutdown should not happen in lambda as it causes the lambda to hang
+	if (process.env.DEV?.length) {
+		await page.close()
+		await browser.close()
+	}
 	console.log(`done`, { files })
 
 	return files


### PR DESCRIPTION
## Summary

Session render lambda was not published as part of CI.

## How did you test this change?

CI with temp commit.
https://github.com/highlight/highlight/actions/runs/5337247107/jobs/9673025799

## Are there any deployment considerations?

No