### PR TITLE
fix logs avg calc when no logs

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 	"unicode"
@@ -265,6 +266,13 @@ func readLogsDailyImpl[N number](ctx context.Context, client *Client, aggFn stri
 		sql,
 		args...,
 	).Scan(&out)
+
+	switch v := any(out).(type) {
+	case float64:
+		if math.IsNaN(v) {
+			return 0, err
+		}
+	}
 
 	return out, err
 }


### PR DESCRIPTION
## Summary
- avg() in clickhouse returns `NaN` when the input set is empty, not sure how to coalesce it correctly in SQL
- currently results in an error for projects with no logs recorded in the past 7 days
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally w/ mocked input
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
