### PR TITLE
add a node.js error handler for aws lambda

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -71,6 +71,10 @@ jobs:
                   GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
 
+            - name: Test session screenshot lambda
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
+              run: yarn test:render
+
             - name: Validate project is ready to be published
               if: steps.filter.outputs.npm-changed == 'true' && (github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main')
               run: yarn validate

--- a/docs-content/getting-started/4_backend-sdk/js/aws-lambda.md
+++ b/docs-content/getting-started/4_backend-sdk/js/aws-lambda.md
@@ -1,0 +1,9 @@
+---
+title: tRPC
+slug: trpc
+createdAt: 2022-03-28T20:31:15.000Z
+updatedAt: 2022-04-06T20:22:54.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["backend"]["js"]["trpc"]}/>

--- a/docs-content/getting-started/4_backend-sdk/js/aws-lambda.md
+++ b/docs-content/getting-started/4_backend-sdk/js/aws-lambda.md
@@ -1,9 +1,9 @@
 ---
-title: tRPC
-slug: trpc
+title: AWS Lambda Node.JS
+slug: aws-lambda-node
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z
 quickstart: true
 ---
 
-<QuickStart content={quickStartContent["backend"]["js"]["trpc"]}/>
+<QuickStart content={quickStartContent["backend"]["js"]["aws-lambda"]}/>

--- a/docs-content/getting-started/4_backend-sdk/js/aws-lambda.md
+++ b/docs-content/getting-started/4_backend-sdk/js/aws-lambda.md
@@ -6,4 +6,4 @@ updatedAt: 2022-04-06T20:22:54.000Z
 quickstart: true
 ---
 
-<QuickStart content={quickStartContent["backend"]["js"]["aws-lambda"]}/>
+<QuickStart content={quickStartContent["backend"]["js"]["aws-lambda-node"]}/>

--- a/docs-content/getting-started/4_backend-sdk/python/aws-lambda.md
+++ b/docs-content/getting-started/4_backend-sdk/python/aws-lambda.md
@@ -1,7 +1,7 @@
 ---
-title: AWS Lambda
+title: AWS Lambda Python
 heading: Using highlight.io with Python on AWS Lambda
-slug: aws-lambda
+slug: aws-lambda-python
 quickstart: true
 ---
 

--- a/docs-content/getting-started/4_backend-sdk/python/aws-lambda.md
+++ b/docs-content/getting-started/4_backend-sdk/python/aws-lambda.md
@@ -5,4 +5,4 @@ slug: aws-lambda-python
 quickstart: true
 ---
 
-<QuickStart content={quickStartContent["backend"]["python"]["aws-lambda"]}/>
+<QuickStart content={quickStartContent["backend"]["python"]["aws-lambda-python"]}/>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -45,6 +45,7 @@ import { RubyOtherLogContent } from './logging/ruby/other'
 import { RubyRailsLogContent } from './logging/ruby/rails'
 import { DevDeploymentContent } from './self-host/dev-deploy'
 import { SelfHostContent } from './self-host/self-host'
+import { JSAWSLambdaContent } from './backend/js/aws-lambda'
 
 export type QuickStartOptions = {
 	title: string
@@ -89,7 +90,7 @@ export enum QuickStartType {
 	PythonFastAPI = 'fastapi',
 	PythonLoguru = 'loguru',
 	PythonOther = 'other',
-	PythonAWSFn = 'aws-lambda',
+	PythonAWSFn = 'aws-lambda-python',
 	PythonAzureFn = 'azure-functions',
 	PythonGCPFn = 'google-cloud-functions',
 	GoGqlgen = 'gqlgen',
@@ -100,6 +101,7 @@ export enum QuickStartType {
 	GoLogrus = 'logrus',
 	GoOther = 'other',
 	JSApollo = 'apollo',
+	JSAWSFn = 'aws-lambda-node',
 	JSCloudflare = 'cloudflare',
 	JSExpress = 'express',
 	JSFirebase = 'firebase',
@@ -169,6 +171,7 @@ export const quickStartContent = {
 				'Select your JavaScript framework to install error monitoring for your application.',
 			logoUrl: siteUrl('/images/quickstart/javascript.svg'),
 			[QuickStartType.JSApollo]: JSApolloContent,
+			[QuickStartType.JSAWSFn]: JSAWSLambdaContent,
 			[QuickStartType.JSCloudflare]: JSCloudflareContent,
 			[QuickStartType.JSExpress]: JSExpressContent,
 			[QuickStartType.JSFirebase]: JSFirebaseContent,

--- a/highlight.io/components/QuickstartContent/backend/js/aws-lambda.tsx
+++ b/highlight.io/components/QuickstartContent/backend/js/aws-lambda.tsx
@@ -1,0 +1,46 @@
+import { siteUrl } from '../../../../utils/urls'
+import { QuickStartContent } from '../../QuickstartContent'
+import { frontendInstallSnippet } from '../shared-snippets'
+import {
+	addIntegrationContent,
+	initializeNodeSDK,
+	jsGetSnippet,
+	setupLogging,
+	verifyError,
+} from './shared-snippets'
+
+export const JSAWSLambdaContent: QuickStartContent = {
+	title: 'Error Handling from Python AWS Lambda',
+	subtitle: 'Learn how to set up highlight.io on AWS Lambda.',
+	logoUrl: siteUrl('/images/quickstart/aws-lambda.svg'),
+	entries: [
+		frontendInstallSnippet,
+		jsGetSnippet(['node']),
+		initializeNodeSDK('node'),
+		{
+			title: 'Add the AWS Lambda Node.js Highlight integration.',
+			content: addIntegrationContent('Node Highlight SDK', 'nodejs'),
+			code: [
+				{
+					text: `import { APIGatewayEvent } from 'aws-lambda'
+import { H, Handlers } from '@highlight-run/node'
+
+// setup console log recording
+H.init({ projectID: '<YOUR_PROJECT_ID>' })
+// wrap your lambda with an error handler
+export const handler = Handlers.serverlessFunction(
+  (event?: APIGatewayEvent) => {
+    console.log('hello, world!', {queryString: event?.queryStringParameters});
+    return {statusCode: 200};
+  },
+  { projectID: '<YOUR_PROJECT_ID>' },
+)
+`,
+					language: 'js',
+				},
+			],
+		},
+		verifyError('AWS Lambda'),
+		setupLogging('aws'),
+	],
+}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
 		"publish:client": "yarn workspace scripts publish:client",
 		"publish:render": "yarn workspace render publish",
 		"publish:turbo": "yarn workspaces foreach --no-private --from '@highlight-run/*' npm publish --access public --tolerate-republish && yarn workspace highlight.run npm publish --access public --tolerate-republish",
-		"test:all": "yarn turbo run test --filter=!@highlight-run/rrweb --filter=!@highlight-run/rrweb-types --filter=!@highlight-run/rrweb-snapshot --filter=!@highlight-run/rrweb-player --filter=!@highlight-run/rrdom --filter=!@highlight-run/rrdom-nodejs",
+		"test:all": "yarn turbo run test --filter=!render --filter=!@highlight-run/rrweb --filter=!@highlight-run/rrweb-types --filter=!@highlight-run/rrweb-snapshot --filter=!@highlight-run/rrweb-player --filter=!@highlight-run/rrdom --filter=!@highlight-run/rrdom-nodejs",
+		"test:render": "yarn turbo run test --filter=render",
 		"sourcemaps:frontend": "yarn workspace @highlight-run/frontend sourcemaps"
 	},
 	"devDependencies": {

--- a/render/package.json
+++ b/render/package.json
@@ -15,6 +15,7 @@
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.352.0",
+		"@highlight-run/node": "workspace:*",
 		"@highlight-run/rrweb": "workspace:*",
 		"@sparticuz/chromium": "^114.0.0",
 		"puppeteer-core": "^19.11.1"

--- a/render/src/index.ts
+++ b/render/src/index.ts
@@ -3,6 +3,7 @@ import { serialRender } from './serial'
 import { readFileSync } from 'fs'
 import { encodeGIF, encodeMP4 } from './ffmpeg'
 import { getRenderExport, uploadRenderExport } from './s3'
+import { H, Handlers } from '@highlight-run/node'
 
 interface Args {
 	project?: string
@@ -68,13 +69,18 @@ const media = async (event?: APIGatewayEvent) => {
 	}
 }
 
-export const handler = (event?: APIGatewayEvent) => {
-	const args = event?.queryStringParameters as unknown as Args | undefined
-	if (args?.format === 'image/gif' || args?.format === 'video/mp4') {
-		return media(event)
-	}
-	return screenshot(event)
-}
+export const handler = Handlers.serverlessFunction(
+	(event?: APIGatewayEvent) => {
+		const args = event?.queryStringParameters as unknown as Args | undefined
+		if (args?.format === 'image/gif' || args?.format === 'video/mp4') {
+			return media(event)
+		}
+		return screenshot(event)
+	},
+	{ projectID: '1' },
+)
+
+H.init({ projectID: '1' })
 
 if (process.env.DEV?.length) {
 	screenshot({

--- a/render/src/index.ts
+++ b/render/src/index.ts
@@ -83,7 +83,7 @@ export const handler = Handlers.serverlessFunction(
 H.init({ projectID: '1' })
 
 if (process.env.DEV?.length) {
-	screenshot({
+	handler({
 		queryStringParameters: {
 			project: '1',
 			session: '239571781',
@@ -91,11 +91,11 @@ if (process.env.DEV?.length) {
 			chunk: '0',
 		},
 	} as unknown as APIGatewayEvent).then(console.info)
-	media({
+	handler({
 		queryStringParameters: {
+			format: 'image/gif',
 			project: '1',
 			session: '239571781',
-			format: 'image/gif',
 			ts: '15000',
 			tsEnd: '20000',
 		},

--- a/render/src/index.ts
+++ b/render/src/index.ts
@@ -83,21 +83,23 @@ export const handler = Handlers.serverlessFunction(
 H.init({ projectID: '1' })
 
 if (process.env.DEV?.length) {
-	handler({
-		queryStringParameters: {
-			project: '1',
-			session: '239571781',
-			ts: '1',
-			chunk: '0',
-		},
-	} as unknown as APIGatewayEvent).then(console.info)
-	handler({
-		queryStringParameters: {
-			format: 'image/gif',
-			project: '1',
-			session: '239571781',
-			ts: '15000',
-			tsEnd: '20000',
-		},
-	} as unknown as APIGatewayEvent).then(console.info)
+	Promise.all([
+		handler({
+			queryStringParameters: {
+				project: '1',
+				session: '239571781',
+				ts: '1',
+				chunk: '0',
+			},
+		} as unknown as APIGatewayEvent),
+		handler({
+			queryStringParameters: {
+				format: 'image/gif',
+				project: '1',
+				session: '239571781',
+				ts: '15000',
+				tsEnd: '20000',
+			},
+		} as unknown as APIGatewayEvent),
+	]).then(() => H.stop())
 }

--- a/sdk/highlight-node/CHANGELOG.md
+++ b/sdk/highlight-node/CHANGELOG.md
@@ -41,3 +41,16 @@
 ### Minor Changes
 
 -   Ensures `flush` method will send opentelemetry spans to highlight.
+
+## 3.0.0
+
+### Major Changes
+
+- Entirely replaces highlight graphql calls with opentelemetry.
+- Removes dependency on graphql libraries.
+
+## 3.1.0
+
+### Minor Changes
+
+- Adds a `Handlers.serverlessFunction` for use as a error wrapper in AWS Lambda.

--- a/sdk/highlight-node/CHANGELOG.md
+++ b/sdk/highlight-node/CHANGELOG.md
@@ -54,3 +54,4 @@
 ### Minor Changes
 
 - Adds a `Handlers.serverlessFunction` for use as a error wrapper in AWS Lambda.
+- Adds a `H.stop()` method for shutting down the SDK and flushing unsent data.

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "3.0.1",
+	"version": "3.1.0",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -11,6 +11,7 @@ import { Resource } from '@opentelemetry/resources'
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
 import { hookConsole } from './hooks'
 import log from './log'
+import { clearInterval } from 'timers'
 
 const OTLP_HTTP = 'https://otel.highlight.io:4318'
 
@@ -73,6 +74,14 @@ export class Highlight {
 		}
 
 		this._log(`Initialized SDK for project ${this._projectID}`)
+	}
+
+	async stop() {
+		await this.flush()
+		await this.otel.shutdown()
+		if (this._intervalFunction) {
+			clearInterval(this._intervalFunction)
+		}
 	}
 
 	_log(...data: any[]) {

--- a/sdk/highlight-node/src/handlers.ts
+++ b/sdk/highlight-node/src/handlers.ts
@@ -96,7 +96,7 @@ const makeHandler = (
 ) => {
 	return async (...args: any) => {
 		try {
-			return await origHandler(args)
+			return await origHandler(...args)
 		} catch (e) {
 			try {
 				if (e instanceof Error) {

--- a/sdk/highlight-node/src/handlers.ts
+++ b/sdk/highlight-node/src/handlers.ts
@@ -152,6 +152,6 @@ declare type ServerlessCallableFunctionHandler = (event?: any) => any
 export function serverlessFunction(
 	origHandler: ServerlessCallableFunctionHandler,
 	options: NodeOptions,
-): FirebaseCallableFunctionHandler {
+): ServerlessCallableFunctionHandler {
 	return makeHandler(origHandler, options, (event) => event?.headers)
 }

--- a/sdk/highlight-node/src/sdk.ts
+++ b/sdk/highlight-node/src/sdk.ts
@@ -7,6 +7,7 @@ export const HIGHLIGHT_REQUEST_HEADER = 'x-highlight-request'
 
 export interface HighlightInterface {
 	init: (options: NodeOptions) => void
+	stop: () => Promise<void>
 	isInitialized: () => boolean
 	parseHeaders: (
 		headers: IncomingHttpHeaders,
@@ -37,6 +38,16 @@ export const H: HighlightInterface = {
 			highlight_obj = new Highlight(options)
 		} catch (e) {
 			console.warn('highlight-node init error: ', e)
+		}
+	},
+	stop: async () => {
+		if (!highlight_obj) {
+			return
+		}
+		try {
+			await highlight_obj.stop()
+		} catch (e) {
+			console.warn('highlight-node stop error: ', e)
 		}
 	},
 	isInitialized: () => !!highlight_obj,

--- a/yarn.lock
+++ b/yarn.lock
@@ -46881,6 +46881,7 @@ __metadata:
   resolution: "render@workspace:render"
   dependencies:
     "@aws-sdk/client-s3": ^3.352.0
+    "@highlight-run/node": "workspace:*"
     "@highlight-run/rrweb": "workspace:*"
     "@sparticuz/chromium": ^114.0.0
     "@types/aws-lambda": ^8.10.114


### PR DESCRIPTION
## Summary

Adds a `Handlers.serverlessFunction` wrapper to the `@highlight-run/node` SDK for
capturing errors raised in AWS Lambda functions written in node.js
Closes #5625

## How did you test this change?

Adding the new wrapper to the session-screenshot lambda written in node.js.

## Are there any deployment considerations?

New minor version of `@highlight-run/node` released.