### PR TITLE
Remove references to alert_events

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1979,7 +1979,7 @@ func (obj *Alert) GetEmailsToNotify() ([]*string, error) {
 	return emailsToNotify, err
 }
 
-func (obj *Alert) GetDailyFrequency(db *gorm.DB, id int) ([]*int64, error) {
+func (obj *Alert) GetDailyErrorEventFrequency(db *gorm.DB, id int) ([]*int64, error) {
 	var dailyAlerts []*int64
 	if err := db.Raw(`
 		SELECT COUNT(e.id)
@@ -1987,15 +1987,66 @@ func (obj *Alert) GetDailyFrequency(db *gorm.DB, id int) ([]*int64, error) {
 			SELECT to_char(date_trunc('day', (current_date - offs)), 'YYYY-MM-DD') AS date
 			FROM generate_series(0, 6, 1)
 			AS offs
-		) d LEFT OUTER JOIN
-		alert_events e
-		ON d.date = to_char(date_trunc('day', e.created_at), 'YYYY-MM-DD')
-			AND e.type=?
-			AND e.alert_id=?
-			AND e.project_id=?
+		) d
+		LEFT OUTER JOIN (
+			error_alert_events e
+			INNER JOIN error_objects obj
+			ON obj.id = e.error_object_id
+				AND e.error_alert_id=?
+				AND obj.project_id=?
+		)
+		ON d.date = to_char(date_trunc('day', e.sent_at), 'YYYY-MM-DD')
 		GROUP BY d.date
 		ORDER BY d.date;
-	`, obj.Type, id, obj.ProjectID).Scan(&dailyAlerts).Error; err != nil {
+	`, id, obj.ProjectID).Scan(&dailyAlerts).Error; err != nil {
+		return nil, e.Wrap(err, "error querying daily error event frequency")
+	}
+
+	return dailyAlerts, nil
+}
+
+func (obj *Alert) GetDailySessionEventFrequency(db *gorm.DB, id int) ([]*int64, error) {
+	var dailyAlerts []*int64
+	if err := db.Raw(`
+		SELECT COUNT(e.id)
+		FROM (
+			SELECT to_char(date_trunc('day', (current_date - offs)), 'YYYY-MM-DD') AS date
+			FROM generate_series(0, 6, 1)
+			AS offs
+		) d
+		LEFT OUTER JOIN (
+			session_alert_events e
+			INNER JOIN sessions s
+			ON s.secure_id = e.session_secure_id
+				AND e.session_alert_id=?
+				AND s.project_id=?
+		)
+		ON d.date = to_char(date_trunc('day', e.sent_at), 'YYYY-MM-DD')
+		GROUP BY d.date
+		ORDER BY d.date;
+	`, id, obj.ProjectID).Scan(&dailyAlerts).Error; err != nil {
+		return nil, e.Wrap(err, "error querying daily session event frequency")
+	}
+
+	return dailyAlerts, nil
+}
+
+func (obj *Alert) GetDailyLogEventFrequency(db *gorm.DB, id int) ([]*int64, error) {
+	var dailyAlerts []*int64
+	// TODO(spenny): figure out where to filter by project_id
+	if err := db.Raw(`
+		SELECT COUNT(e.id)
+		FROM (
+			SELECT to_char(date_trunc('day', (current_date - offs)), 'YYYY-MM-DD') AS date
+			FROM generate_series(0, 6, 1)
+			AS offs
+		) d LEFT OUTER JOIN
+		log_alert_events e
+		ON d.date = to_char(date_trunc('day', e.created_at), 'YYYY-MM-DD')
+			AND e.log_alert_id=?
+		GROUP BY d.date
+		ORDER BY d.date;
+	`, id).Scan(&dailyAlerts).Error; err != nil {
 		return nil, e.Wrap(err, "error querying daily alert frequency")
 	}
 

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1988,17 +1988,12 @@ func (obj *Alert) GetDailyErrorEventFrequency(db *gorm.DB, id int) ([]*int64, er
 			FROM generate_series(0, 6, 1)
 			AS offs
 		) d
-		LEFT OUTER JOIN (
-			error_alert_events e
-			INNER JOIN error_objects obj
-			ON obj.id = e.error_object_id
-				AND e.error_alert_id=?
-				AND obj.project_id=?
-		)
+		LEFT OUTER JOIN error_alert_events e
 		ON d.date = to_char(date_trunc('day', e.sent_at), 'YYYY-MM-DD')
+			AND e.error_alert_id=?
 		GROUP BY d.date
 		ORDER BY d.date;
-	`, id, obj.ProjectID).Scan(&dailyAlerts).Error; err != nil {
+	`, id).Scan(&dailyAlerts).Error; err != nil {
 		return nil, e.Wrap(err, "error querying daily error event frequency")
 	}
 
@@ -2014,14 +2009,9 @@ func (obj *Alert) GetDailySessionEventFrequency(db *gorm.DB, id int) ([]*int64, 
 			FROM generate_series(0, 6, 1)
 			AS offs
 		) d
-		LEFT OUTER JOIN (
-			session_alert_events e
-			INNER JOIN sessions s
-			ON s.secure_id = e.session_secure_id
-				AND e.session_alert_id=?
-				AND s.project_id=?
-		)
+		LEFT OUTER JOIN session_alert_events e
 		ON d.date = to_char(date_trunc('day', e.sent_at), 'YYYY-MM-DD')
+			AND e.session_alert_id=?
 		GROUP BY d.date
 		ORDER BY d.date;
 	`, id, obj.ProjectID).Scan(&dailyAlerts).Error; err != nil {
@@ -2040,14 +2030,9 @@ func (obj *Alert) GetDailyLogEventFrequency(db *gorm.DB, id int) ([]*int64, erro
 			FROM generate_series(0, 6, 1)
 			AS offs
 		) d
-		LEFT OUTER JOIN (
-			log_alert_events e
-			INNER JOIN log_alerts la
-			ON la.id = e.log_alert_id
-				AND e.log_alert_id=?
-				AND la.project_id=?
-		)
+		LEFT OUTER JOIN log_alert_events e
 		ON d.date = to_char(date_trunc('day', e.sent_at), 'YYYY-MM-DD')
+			AND e.log_alert_id=?
 		GROUP BY d.date
 		ORDER BY d.date;
 	`, id, obj.ProjectID).Scan(&dailyAlerts).Error; err != nil {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -104,7 +104,7 @@ func (r *errorAlertResolver) RegexGroups(ctx context.Context, obj *model.ErrorAl
 
 // DailyFrequency is the resolver for the DailyFrequency field.
 func (r *errorAlertResolver) DailyFrequency(ctx context.Context, obj *model.ErrorAlert) ([]*int64, error) {
-	return obj.GetDailyFrequency(r.DB, obj.ID)
+	return obj.GetDailyErrorEventFrequency(r.DB, obj.ID)
 }
 
 // Author is the resolver for the author field.
@@ -282,7 +282,7 @@ func (r *logAlertResolver) ExcludedEnvironments(ctx context.Context, obj *model.
 
 // DailyFrequency is the resolver for the DailyFrequency field.
 func (r *logAlertResolver) DailyFrequency(ctx context.Context, obj *model.LogAlert) ([]*int64, error) {
-	return obj.GetDailyFrequency(r.DB, obj.ID)
+	return obj.GetDailyLogEventFrequency(r.DB, obj.ID)
 }
 
 // ChannelsToNotify is the resolver for the channels_to_notify field.
@@ -7458,7 +7458,7 @@ func (r *sessionAlertResolver) ExcludeRules(ctx context.Context, obj *model.Sess
 
 // DailyFrequency is the resolver for the DailyFrequency field.
 func (r *sessionAlertResolver) DailyFrequency(ctx context.Context, obj *model.SessionAlert) ([]*int64, error) {
-	return obj.GetDailyFrequency(r.DB, obj.ID)
+	return obj.GetDailySessionEventFrequency(r.DB, obj.ID)
 }
 
 // Author is the resolver for the author field.

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1628,15 +1628,16 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 			numAlerts := int64(-1)
 			if err := r.DB.Raw(`
 				SELECT COUNT(*)
-				FROM alert_events
+				FROM error_alert_events ev
+				INNER JOIN error_objects obj
+				ON obj.id = ev.error_object_id
 				WHERE
-					project_id=?
-					AND type=?
-					AND (error_group_id IS NOT NULL
-						AND error_group_id=?)
-					AND alert_id=?
-					AND created_at > NOW() - ? * (INTERVAL '1 SECOND')
-			`, projectID, model.AlertType.ERROR, group.ID, errorAlert.ID, errorAlert.Frequency).Scan(&numAlerts).Error; err != nil {
+					obj.project_id=?
+					AND (obj.error_group_id IS NOT NULL
+						AND obj.error_group_id=?)
+					AND ev.error_alert_id=?
+					AND ev.sent_at > NOW() - ? * (INTERVAL '1 SECOND')
+			`, projectID, group.ID, errorAlert.ID, errorAlert.Frequency).Scan(&numAlerts).Error; err != nil {
 				log.WithContext(ctx).Error(e.Wrapf(err, "error counting alert events from past %d seconds", errorAlert.Frequency))
 				return
 			}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1632,8 +1632,7 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 				INNER JOIN error_objects obj
 				ON obj.id = ev.error_object_id
 				WHERE
-					obj.project_id=?
-					AND (obj.error_group_id IS NOT NULL
+					(obj.error_group_id IS NOT NULL
 						AND obj.error_group_id=?)
 					AND ev.error_alert_id=?
 					AND ev.sent_at > NOW() - ? * (INTERVAL '1 SECOND')


### PR DESCRIPTION
## Summary
We are not respecting the frequency setting set on alerts. This is due to a reference to a table that is no longer used, `AlertEvents`. Update the references to this table to use the respective table based on the type of event.

## How did you test this change?
Click test:
1) Create a new error alert
  a) set it to send to #chris-errors-test
  b) Set the Alert Frequency to 5 minutes
2) Navigate to the buttons page (`/1/buttons`)
3) Clock on "Throw an Error" button
- [ ] Error is sent to slack channel
4) Click on "Throw an Error" again
- [ ] Error is not sent to slack channel
5) Click on "Throw a randomized Error"
- [ ] Error is sent to slack channel
6) Wait 5 minutes
7) Click on "Throw an Error" again
- [ ] Error is sent to slack channel

<img width="787" alt="Screenshot 2023-06-22 at 1 18 41 PM" src="https://github.com/highlight/highlight/assets/17744174/33ef49c8-4848-4664-ad7a-fdd1bab47950">

![Screenshot 2023-06-22 at 5 01 12 PM](https://github.com/highlight/highlight/assets/17744174/57a037ce-2cb5-4e47-92fb-733f16ac6ced)

## Are there any deployment considerations?
N/A
