### PR TITLE
ensure session screenshot lambda generates gifs with frames in the correct order

### DIFF
--- a/render/src/ffmpeg.ts
+++ b/render/src/ffmpeg.ts
@@ -4,8 +4,8 @@ import { promisify } from 'util'
 export const encodeGIF = async function (dir: string) {
 	const exec = promisify(execAsync)
 	const { stdout, stderr } = await exec(
-		`ffmpeg -y -f image2 -pattern_type glob ` +
-			`-i '${dir}/*.png' -i /tmp/palette.png ` +
+		`ffmpeg -y -f image2 ` +
+			`-i ${dir}/%d.png ` +
 			`-vf "fps=40,scale=720:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" ` +
 			`/tmp/out.gif`,
 	)
@@ -16,8 +16,8 @@ export const encodeGIF = async function (dir: string) {
 export const encodeMP4 = async function (dir: string) {
 	const exec = promisify(execAsync)
 	const { stdout, stderr } = await exec(
-		`ffmpeg -y -framerate 40 -pattern_type glob ` +
-			`-i '${dir}/*.png' -c:v libx264 /tmp/out.mp4`,
+		`ffmpeg -y -framerate 40 ` +
+			`-i ${dir}/%d.png -c:v libx264 /tmp/out.mp4`,
 	)
 	console.log('ffmpeg', { stdout, stderr })
 	return '/tmp/out.mp4'

--- a/render/src/render.ts
+++ b/render/src/render.ts
@@ -129,10 +129,11 @@ export async function render(
 	})
 	const files: string[] = []
 	for (let i = start; i <= end; i += interval) {
-		const file = path.join(dir, `${i}.png`)
+		const idx = files.length
+		const file = path.join(dir, `${idx}.png`)
 		await page.evaluate(`r.pause(${i})`)
 		await page.screenshot({ path: file })
-		console.log(`screenshotted`, { start, end, interval, i })
+		console.log(`screenshotted`, { start, end, interval, i, idx })
 		files.push(file)
 	}
 


### PR DESCRIPTION
## Summary

Because of how the frames were indexed, ffmpeg would generate the gif with frames in a random order.

## How did you test this change?

https://highlight-session-render.s3.us-east-2.amazonaws.com/1/245336777.gif
![image](https://highlight-session-render.s3.us-east-2.amazonaws.com/1/245336777.gif)


## Are there any deployment considerations?

Lambda will auto-depoy.