### PR TITLE
fix hobby docker image backend domain routing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
                   ANNOTATIONS="$ANNOTATIONS,annotation-index.org.opencontainers.image.licenses=Apache 2.0"
 
                   if [[ ${{ github.event_name }} == 'release' ]]; then
-                    push="--push"
+                    push="--push -t ghcr.io/highlight/$IMAGE_NAME:$IMAGE_TAG -t ghcr.io/highlight/$IMAGE_NAME:latest"
                   fi
 
                   # build docker image with common environment
@@ -63,8 +63,6 @@ jobs:
                     --build-arg REACT_APP_COMMIT_SHA=${{ github.sha }} \
                     $push \
                     --platform linux/arm64,linux/amd64 \
-                    -t ghcr.io/highlight/$IMAGE_NAME:$IMAGE_TAG \
-                    -t ghcr.io/highlight/$IMAGE_NAME:latest \
                     -f docker/${{ matrix.container }}.Dockerfile \
                     --target ${{ matrix.container }}-prod \
                     --output "type=image,name=target,$ANNOTATIONS" .

--- a/docker/compose.hobby.yml
+++ b/docker/compose.hobby.yml
@@ -112,6 +112,7 @@ services:
         environment:
             - REACT_APP_PRIVATE_GRAPH_URI
             - REACT_APP_PUBLIC_GRAPH_URI
+            - REACT_APP_FRONTEND_URI
 
 volumes:
     highlight-data:

--- a/docker/frontend-entrypoint.py
+++ b/docker/frontend-entrypoint.py
@@ -1,15 +1,24 @@
+import os
+import re
+import subprocess
+
 CONSTANTS_FILE = '/build/frontend/build/assets/constants.js'
+
 
 def main():
     private = os.environ.get('REACT_APP_PRIVATE_GRAPH_URI')
     public = os.environ.get('REACT_APP_PUBLIC_GRAPH_URI')
-    with open(CONSTANTS_FILE, 'rw') as f:
+
+    with open(CONSTANTS_FILE, 'r') as f:
         data = f.read()
-        data = re.replace(data, 'https://localhost:8082/private', private)
-        data = re.replace(data, 'https://localhost:8082/public', public)
+        data = re.sub('https://localhost:8082/private', private, data)
+        data = re.sub('https://localhost:8082/public', public, data)
+
+    with open(CONSTANTS_FILE, 'w') as f:
         f.write(data)
 
     return subprocess.check_call(["nginx", "-g", "daemon off;"])
+
 
 if __name__ == '__main__':
     main()

--- a/docker/frontend-entrypoint.py
+++ b/docker/frontend-entrypoint.py
@@ -8,15 +8,22 @@ CONSTANTS_FILE = '/build/frontend/build/assets/constants.js'
 def main():
     private = os.environ.get('REACT_APP_PRIVATE_GRAPH_URI')
     public = os.environ.get('REACT_APP_PUBLIC_GRAPH_URI')
+    frontend = os.environ.get('REACT_APP_FRONTEND_URI')
+    print("replacing", {"private": private, "public": public, "frontend": frontend})
 
     with open(CONSTANTS_FILE, 'r') as f:
         data = f.read()
-        data = re.sub('https://localhost:8082/private', private, data)
-        data = re.sub('https://localhost:8082/public', public, data)
+        if private:
+            data = re.sub('https://localhost:8082/private', private, data)
+        if public:
+            data = re.sub('https://localhost:8082/public', public, data)
+        if frontend:
+            data = re.sub('https://localhost:3000', frontend, data)
 
     with open(CONSTANTS_FILE, 'w') as f:
         f.write(data)
 
+    print("wrote back constants file", data, flush=True)
     return subprocess.check_call(["nginx", "-g", "daemon off;"])
 
 

--- a/docker/frontend-entrypoint.py
+++ b/docker/frontend-entrypoint.py
@@ -1,0 +1,15 @@
+CONSTANTS_FILE = '/build/frontend/build/assets/constants.js'
+
+def main():
+    private = os.environ.get('REACT_APP_PRIVATE_GRAPH_URI')
+    public = os.environ.get('REACT_APP_PUBLIC_GRAPH_URI')
+    with open(CONSTANTS_FILE, 'rw') as f:
+        data = f.read()
+        data = re.replace(data, 'https://localhost:8082/private', private)
+        data = re.replace(data, 'https://localhost:8082/public', public)
+        f.write(data)
+
+    return subprocess.check_call(["nginx", "-g", "daemon off;"])
+
+if __name__ == '__main__':
+    main()

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -55,4 +55,4 @@ ARG REACT_APP_PRIVATE_GRAPH_URI
 ARG REACT_APP_PUBLIC_GRAPH_URI
 ENV REACT_APP_PRIVATE_GRAPH_URI=$REACT_APP_PRIVATE_GRAPH_URI
 ENV REACT_APP_PUBLIC_GRAPH_URI=$REACT_APP_PUBLIC_GRAPH_URI
-CMD ["sh", "-c", "sed -i -e \"s/https:\/\/localhost:8082\/private/${REACT_APP_PRIVATE_GRAPH_URI}/g\" /build/frontend/build/assets/*.js; sed -i -e \"s/https:\/\/localhost:8082\/public/${REACT_APP_PUBLIC_GRAPH_URI}/g\" /build/frontend/build/assets/*.js; nginx -g 'daemon off;'"]
+CMD ["sh", "-c", "sed -i -e \"s/https:\/\/localhost:8082\/private/${REACT_APP_PRIVATE_GRAPH_URI}/g\" /build/frontend/build/assets/constants.js && sed -i -e \"s/https:\/\/localhost:8082\/public/${REACT_APP_PUBLIC_GRAPH_URI}/g\" /build/frontend/build/assets/constants.js && nginx -g 'daemon off;'"]

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,4 +1,8 @@
 export const PRIVATE_GRAPH_URI =
 	import.meta.env.REACT_APP_PRIVATE_GRAPH_URI ??
 	window.location.origin + '/private'
-export const PUBLIC_GRAPH_URI = import.meta.env.REACT_APP_PUBLIC_GRAPH_URI
+export const PUBLIC_GRAPH_URI =
+	import.meta.env.REACT_APP_PUBLIC_GRAPH_URI || 'https://pub.highlight.io'
+export const FRONTEND_URI =
+	import.meta.env.REACT_APP_FRONTEND_URI ||
+	window.location.protocol + '//' + window.location.host

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,0 +1,4 @@
+export const PRIVATE_GRAPH_URI =
+	import.meta.env.REACT_APP_PRIVATE_GRAPH_URI ??
+	window.location.origin + '/private'
+export const PUBLIC_GRAPH_URI = import.meta.env.REACT_APP_PUBLIC_GRAPH_URI

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -48,6 +48,7 @@ import {
 import { QueryParamProvider } from 'use-query-params'
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6'
 
+import { PUBLIC_GRAPH_URI } from '@/constants'
 import { SIGN_IN_ROUTE } from '@/pages/Auth/AuthRouter'
 import { onlyAllowHighlightStaff } from '@/util/authorization/authorizationUtils'
 
@@ -65,6 +66,7 @@ const options: HighlightOptions = {
 	debug: shouldDebugLog
 		? { clientInteractions: true, domRecording: true }
 		: undefined,
+	backendUrl: PUBLIC_GRAPH_URI,
 	manualStart: true,
 	enableStrictPrivacy: Math.floor(Math.random() * 8) === 0,
 	networkRecording: {
@@ -108,7 +110,6 @@ const options: HighlightOptions = {
 const favicon = document.querySelector("link[rel~='icon']") as any
 if (dev) {
 	options.scriptUrl = 'http://localhost:8080/dist/index.js'
-	options.backendUrl = import.meta.env.REACT_APP_PUBLIC_GRAPH_URI
 
 	options.integrations = undefined
 

--- a/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
@@ -34,6 +34,7 @@ import { useEffect, useState } from 'react'
 import { Route, Routes } from 'react-router-dom'
 import { useToggle } from 'react-use'
 
+import { PRIVATE_GRAPH_URI } from '@/constants'
 import {
 	useClientIntegration,
 	useLogsIntegration,
@@ -74,14 +75,11 @@ export const ProjectRouter = () => {
 	}, [projectId])
 
 	useEffect(() => {
-		const uri =
-			import.meta.env.REACT_APP_PRIVATE_GRAPH_URI ??
-			window.location.origin + '/private'
 		let intervalId: NodeJS.Timeout
 
 		auth.currentUser?.getIdToken().then((t) => {
 			const fetchToken = () => {
-				fetch(`${uri}/project-token/${projectId}`, {
+				fetch(`${PRIVATE_GRAPH_URI}/project-token/${projectId}`, {
 					credentials: 'include',
 					headers: {
 						token: t,

--- a/frontend/src/util/graph.tsx
+++ b/frontend/src/util/graph.tsx
@@ -24,21 +24,20 @@ import {
 	DEMO_PROJECT_ID,
 	DEMO_WORKSPACE_PROXY_APPLICATION_ID,
 } from '@/components/DemoWorkspaceButton/DemoWorkspaceButton'
+import { PRIVATE_GRAPH_URI } from '@/constants'
 
-const uri =
-	import.meta.env.REACT_APP_PRIVATE_GRAPH_URI ??
-	window.location.origin + '/private'
 const highlightGraph = new IndexedDBLink(
 	createHttpLink({
-		uri,
+		uri: PRIVATE_GRAPH_URI,
 		credentials: 'include',
 	}),
 )
 let splitLink = null
 try {
-	const socketUri = uri
-		.replace('http://', 'ws://')
-		.replace('https://', 'wss://')
+	const socketUri = PRIVATE_GRAPH_URI.replace('http://', 'ws://').replace(
+		'https://',
+		'wss://',
+	)
 	const highlightSocket = new WebSocketLink({
 		uri: socketUri,
 		options: {
@@ -71,7 +70,7 @@ const graphCdnGraph = new HttpLink({
 	uri: 'https://graphcdn.highlight.run',
 })
 if (isOnPrem) {
-	console.log('Private Graph URI: ', uri)
+	console.log('Private Graph URI: ', PRIVATE_GRAPH_URI)
 }
 
 const authLink = setContext((_, { headers }) => {

--- a/frontend/src/util/window.ts
+++ b/frontend/src/util/window.ts
@@ -1,12 +1,10 @@
 import { Admin } from '@graph/schemas'
 import { INTERCOM_APP_ID } from '@util/constants/constants'
 import { H } from 'highlight.run'
+import { FRONTEND_URI } from '@/constants'
 
 export function GetBaseURL(): string {
-	return (
-		import.meta.env.REACT_APP_FRONTEND_URI ||
-		window.location.protocol + '//' + window.location.host
-	)
+	return FRONTEND_URI
 }
 
 interface IntercomInit {

--- a/frontend/src/util/window.ts
+++ b/frontend/src/util/window.ts
@@ -1,6 +1,7 @@
 import { Admin } from '@graph/schemas'
 import { INTERCOM_APP_ID } from '@util/constants/constants'
 import { H } from 'highlight.run'
+
 import { FRONTEND_URI } from '@/constants'
 
 export function GetBaseURL(): string {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -96,6 +96,12 @@ export default defineConfig(({ mode }): UserConfig => {
 			sourcemap: env.RENDER_PREVIEW !== 'true' && mode !== 'development',
 			rollupOptions: {
 				output: {
+					manualChunks: (id: string) => {
+						if (id.endsWith('frontend/src/constants.ts')) {
+							return 'constants'
+						}
+						return null
+					},
 					entryFileNames: `assets/[name].js`,
 					chunkFileNames: `assets/[name].js`,
 					assetFileNames: `assets/[name].[ext]`,


### PR DESCRIPTION
## Summary

Docker image was not correctly replacing the backend endpoint from the frontend 
when the endpoint is a numeric ip addresses.
Changes the build process to use a python script to make this easier to test.

Closes #5245

## How did you test this change?

Testing deploy on EC2 instance.
https://www.loom.com/share/750c244a37384e2dbff42fc210f0090b

![Screenshot 2023-06-26 115250](https://github.com/highlight/highlight/assets/1351531/913edc5f-6f52-49a7-8fa3-408185e12799)
![image](https://github.com/highlight/highlight/assets/1351531/2e687b94-a11f-4806-9ce7-13dac8c2f3ba)

## Are there any deployment considerations?

Will deploy a new docker image.