### PR TITLE
chore: fix the text overflow on DateInput controlbar

### DIFF
--- a/frontend/src/components/QueryBuilder/QueryBuilder.module.scss
+++ b/frontend/src/components/QueryBuilder/QueryBuilder.module.scss
@@ -258,6 +258,9 @@ span:last-child {
 .controlBar {
 	flex-shrink: 0;
 	height: 44px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .menuList {


### PR DESCRIPTION
This PR is the first pass for issue #5693

This PR enhances the control bar functionality by addressing the issue of text overflow when selecting date and time for large date ranges.



