### PR TITLE
added EmbeddedVideo component for docs

### DIFF
--- a/docs-content/general/changelog/changelog-19.md
+++ b/docs-content/general/changelog/changelog-19.md
@@ -3,7 +3,11 @@ title: Changelog 19 (05/22)
 slug: changelog-19
 ---
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/AcIfUZeJjjs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<EmbeddedVideo 
+  src="https://www.youtube.com/embed/AcIfUZeJjjs"
+  title="Youtube"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+/>
 
 ## Demo Project
 
@@ -17,11 +21,11 @@ Look closely. You might be able to find your own `highlight.io` sessions recorde
 
 ## Comment UI Facelift
 
-We've given the Comment UI a facelift. 
+We've given the Comment UI a facelift.
 
-- It fits better with our design system. 
-- We have a new draggable handle just below the session timeline.
-- New inline issue creation for connected issue trackers (GitHub, Linear, Height)
+-   It fits better with our design system.
+-   We have a new draggable handle just below the session timeline.
+-   New inline issue creation for connected issue trackers (GitHub, Linear, Height)
 
 ![comment ui facelift](/images/changelog/19/comment-ui.png)
 

--- a/docs-content/general/changelog/changelog-20.md
+++ b/docs-content/general/changelog/changelog-20.md
@@ -3,7 +3,11 @@ title: Changelog 20 (06/06)
 slug: changelog-20
 ---
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/3t5d8Jyg044" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<EmbeddedVideo 
+  src="https://www.youtube.com/embed/3t5d8Jyg044"
+  title="Youtube"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+/>
 
 ## User management features
 
@@ -16,16 +20,14 @@ We can now create, view and delete Highlight team invites.
 And the email that invited users receive is now cleaner and easier to understand.
 ![invite email](/images/changelog/20/invite-email.png)
 
-
 ## New Logging connectors
 
-- [AWS Kinesis](../../getting-started/backend-logging/5_hosting/aws.md#aws-kinesis-firehose-for-logs-from-infrastructure-or-other-services)
+-   [AWS Kinesis](../../getting-started/backend-logging/5_hosting/aws.md#aws-kinesis-firehose-for-logs-from-infrastructure-or-other-services)
 
-- [Fluent Forward](../../getting-started/backend-logging/9_fluentforward.md)
-- [Filesystem](../../getting-started/backend-logging/8_file.md)
-- [Loguru](../../getting-started/backend-logging/3_python/loguru.md)
+-   [Fluent Forward](../../getting-started/backend-logging/9_fluentforward.md)
+-   [Filesystem](../../getting-started/backend-logging/8_file.md)
+-   [Loguru](../../getting-started/backend-logging/3_python/loguru.md)
 
 These new connectors make Highlight much easier to use with AWS, Docker, custom VMs and Python!
 
 We've long supported Open Telemetry's logging protocol, but now we also support Fluent Forward, which will make working with AWS and other Fluent-Forward-compatible systems much easier.
-

--- a/highlight.io/components/Blog/Blog.module.scss
+++ b/highlight.io/components/Blog/Blog.module.scss
@@ -41,7 +41,7 @@
 	.cardImage {
 		min-height: 160px;
 		max-height: 170px;
-		border: 1px solid var(--color-copy-on-light);
+		border: 2px solid #30294e;
 	}
 
 	.cardSection {
@@ -167,7 +167,7 @@
 	min-height: 400px;
 	border-radius: var(--border-radius);
 	overflow: hidden;
-	border: 1px solid #30294e;
+	border: 2px solid #30294e;
 }
 
 .youtubeEmbed {
@@ -414,7 +414,7 @@
 	img {
 		margin: 12px 0;
 		border-radius: 8px;
-		border: solid #30294e 1px;
+		border: solid #30294e 4px;
 		overflow: hidden;
 		display: flex;
 	}

--- a/highlight.io/components/Comments/CommentsBox.tsx
+++ b/highlight.io/components/Comments/CommentsBox.tsx
@@ -6,13 +6,13 @@ import { Typography } from '../common/Typography/Typography'
 import type { Comment } from './Comments'
 
 const upvoteButton = classNames(
-	'bg-[#131032] rounded border-2 border-[#1E2848] p-2',
+	'bg-[#131032] rounded border-2 border-[#30294e] p-2',
 )
 const section = classNames(
-	'col-4 border-2 border-[#1E2848] rounded-xl p-6 my-3',
+	'col-4 border-2 border-[#30294e] rounded-xl p-6 my-3',
 )
 const input = classNames(
-	'p-3 h-12 leading-none bg-transparent outline-none text-copy-on-dark text-[17px] rounded-xl bg-[#72E4FC0F] border-2 border-[#72E4FC1C]',
+	'p-3 h-12 leading-none bg-transparent outline-none text-copy-on-dark text-[17px] rounded-xl bg-[#72E4FC0F] border-2 border-[#30294e]',
 )
 
 export const CommentsBox = function ({

--- a/highlight.io/components/MDXRemote/EmbeddedVideo.tsx
+++ b/highlight.io/components/MDXRemote/EmbeddedVideo.tsx
@@ -4,7 +4,7 @@ export function EmbeddedVideo(props: {
 	allowString?: string
 }) {
 	return (
-		<div className="overflow-hidden my-3 border-[1px] border-[#30294e] rounded-[8px] aspect-video">
+		<div className="overflow-hidden my-3 border-[2px] border-[#30294e] rounded-[8px] aspect-video">
 			<iframe
 				className="w-full h-full"
 				src={props.src}

--- a/highlight.io/components/MDXRemote/EmbeddedVideo.tsx
+++ b/highlight.io/components/MDXRemote/EmbeddedVideo.tsx
@@ -1,10 +1,10 @@
 export function EmbeddedVideo(props: {
 	title: string
 	src: string
-	allowString: string
+	allowString?: string
 }) {
 	return (
-		<div className="overflow-hidden border-[2px] border-darker-copy-on-dark rounded-[8px] aspect-video">
+		<div className="overflow-hidden my-3 border-[1px] border-[#30294e] rounded-[8px] aspect-video">
 			<iframe
 				className="w-full h-full"
 				src={props.src}

--- a/highlight.io/components/MDXRemote/EmbeddedVideo.tsx
+++ b/highlight.io/components/MDXRemote/EmbeddedVideo.tsx
@@ -1,0 +1,16 @@
+export function EmbeddedVideo(props: {
+	title: string
+	src: string
+	allowString: string
+}) {
+	return (
+		<div className="overflow-hidden border-[2px] border-darker-copy-on-dark rounded-[8px] aspect-video">
+			<iframe
+				className="w-full h-full"
+				src={props.src}
+				title={props.title}
+				allow={props.allowString || ''}
+			></iframe>
+		</div>
+	)
+}

--- a/highlight.io/components/MDXRemote/index.ts
+++ b/highlight.io/components/MDXRemote/index.ts
@@ -1,6 +1,7 @@
 export * from './AutoplayVideo'
 export * from './DocsCard'
 export * from './DocsCardGroup'
+export * from './EmbeddedVideo'
 export * from './MarkdownList'
 export * from './MissingFrameworkCopy'
 export * from './QuickStart'

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -8,6 +8,7 @@ import {
 	AutoplayVideo,
 	DocsCard,
 	DocsCardGroup,
+	EmbeddedVideo,
 	MarkdownList,
 	MissingFrameworkCopy,
 	QuickStart,
@@ -986,6 +987,7 @@ export default function DocPage({
 										<MDXRemote
 											components={{
 												AutoplayVideo,
+												EmbeddedVideo,
 												MissingFrameworkCopy,
 												Roadmap,
 												RoadmapItem,


### PR DESCRIPTION
## Summary

Videos in our docs were smaller than expected and looked weird without a border. Added a new EmbeddedVideo component that can be used in the docs that styles videos correctly.

Also went ahead and made the image borders in the blog pages consistent.

## How did you test this change?

Checked embedded videos on all screen sizes

https://highlight-landing-pmnr4h2v7-highlight-run.vercel.app/docs/general/changelog/changelog-20

https://highlight-landing-pmnr4h2v7-highlight-run.vercel.app/blog/launch-week-1-day-5


