### PR TITLE
fix undefined reference to navigator.storage.estimate

### DIFF
--- a/frontend/src/util/db.ts
+++ b/frontend/src/util/db.ts
@@ -323,6 +323,9 @@ export const indexedDBFetch = async function* (
 }
 
 const cleanup = async () => {
+	if (!navigator?.storage?.estimate) {
+		return
+	}
 	const fetchElems = await db.fetch.count()
 	const mapElems = await db.map.count()
 	const apolloElems = await db.apollo.count()


### PR DESCRIPTION
## Summary

Some browsers do not define `navigator.storage.estimate`.
Check if it available first.

## How did you test this change?

Reflame preview.

## Are there any deployment considerations?

No
