### PR TITLE
Modified bullet styling for docs

### DIFF
--- a/docs-content/general/4_company/open-source/contributing/code-spaces.md
+++ b/docs-content/general/4_company/open-source/contributing/code-spaces.md
@@ -6,11 +6,13 @@ updatedAt: 2023-01-24T02:07:22.000Z
 ---
 
 ## Running on GitHub Codepsaces (in browser or in VS Code)
-* Make sure you've forked the repo
-* Visit https://github.com/codespaces and start a codepsace for highlight/highlight
-* Install the VS Code Extension "GitHub Codespaces"
-* Using VS Code, enter codespace - `CMD + Shift + P`, type `codespace`, select the Highlight codespace
-* If docker is not running (try `docker ps`), run a full rebuild: press `CMD + Shift + P`, select `Codespaces: Full Rebuild Container`
+
+-   Make sure you've forked the repo
+-   Visit https://github.com/codespaces and start a codepsace for highlight/highlight
+-   Install the VS Code Extension "GitHub Codespaces"
+-   Using VS Code, enter codespace - `CMD + Shift + P`, type `codespace`, select the Highlight codespace
+-   If docker is not running (try `docker ps`), run a full rebuild: press `CMD + Shift + P`, select `Codespaces: Full Rebuild Container`
+
 ```bash
 # from highlight/
 cd docker

--- a/docs-content/general/7_integrations/clickup-integration.md
+++ b/docs-content/general/7_integrations/clickup-integration.md
@@ -12,5 +12,4 @@ To get started, go to the [integrations](https://app.highlight.io/integrations) 
 ## Features
 
 1.  [Comments](../6_product-features/3_general-features/comments.md) can create a ClickUp task filled out with the body of the comment and link back to the Session.
-
 2.  [Grouping Errors](../6_product-features/2_error-monitoring/grouping-errors.md) shows a shortcut to create a ClickUp task pre-populated with the error linking to the full context of how the error occurred.

--- a/highlight.io/components/Docs/Docs.module.scss
+++ b/highlight.io/components/Docs/Docs.module.scss
@@ -247,6 +247,16 @@
 		width: 100%;
 		border-radius: var(--border-radius);
 	}
+
+	li {
+		font-size: 18px;
+		line-height: 34px !important;
+		color: var(--copy-on-dark);
+
+		img {
+			width: 100%;
+		}
+	}
 }
 
 .sdkRightColumn {

--- a/highlight.io/components/MDXRemote/MarkdownList.tsx
+++ b/highlight.io/components/MDXRemote/MarkdownList.tsx
@@ -1,27 +1,37 @@
-import styles from '../../components/Docs/Docs.module.scss'
-
 export function MarkdownList(
 	props: React.DetailedHTMLProps<
 		React.HTMLAttributes<HTMLUListElement | HTMLOListElement>,
 		HTMLUListElement | HTMLOListElement
 	>,
 ) {
+	console.log('HI')
 	return (
 		<>
-			{Array.isArray(props.children)
-				? props?.children?.map((c: any, i: number) => {
-						return (
-							c.props &&
-							c.props.children && (
-								<li className={styles.listItem} key={i}>
+			{Array.isArray(props.children) &&
+				props?.children?.map((c: any, i: number) => {
+					return (
+						c.props &&
+						c.props.children && (
+							<ul
+								style={{
+									paddingLeft: 40,
+								}}
+							>
+								<li
+									style={{
+										listStyleType: 'disc',
+										listStylePosition: 'outside',
+									}}
+									key={i}
+								>
 									{c.props.children.map
-										? c.props.children.map((e: any) => e)
-										: c.props.children}
+										? c?.props?.children?.map((e: any) => e)
+										: c?.props?.children}
 								</li>
-							)
+							</ul>
 						)
-				  })
-				: null}
+					)
+				})}
 		</>
 	)
 }


### PR DESCRIPTION
## Summary

Some of the markdown bullet points in Docs were styled incorrectly. Newlines would not be indented properly.

Before:
![image](https://github.com/highlight/highlight/assets/25088104/1e78a740-65fc-4ad4-af56-a16664875d8e)

After:
<img width="770" alt="image" src="https://github.com/highlight/highlight/assets/25088104/e48cdda2-89c5-4f0d-ba2d-8f41585d4b49">
