### PR TITLE
remove arbitrary sleep

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorStateSelect/ErrorStateSelect.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStateSelect/ErrorStateSelect.tsx
@@ -13,7 +13,6 @@ import {
 	Text,
 	useMenu,
 } from '@highlight-run/ui'
-import { delayedRefetch } from '@util/gql'
 import { useParams } from '@util/react-router/useParams'
 import { DatePicker, message } from 'antd'
 import moment from 'moment'
@@ -59,7 +58,6 @@ const ErrorStateSelectImpl: React.FC<Props> = ({
 			namedOperations.Query.GetErrorGroup,
 			namedOperations.Query.GetErrorGroupsOpenSearch,
 		],
-		onQueryUpdated: delayedRefetch,
 		awaitRefetchQueries: true,
 	})
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

When we update the error group state, we wait an arbitrary 500ms before refetching the list of error groups from opensearch:

https://github.com/highlight/highlight/blob/33db036268b6d9a173e162024510fb6ba95ba792/frontend/src/util/gql.ts#L12-L17

I believe the reason for this is that we used to update opensearch async and were waiting some arbitrary time and hoping the update happened in that time. However, this operation is now entirely synchronous in the lifecycle of the request:

https://github.com/highlight/highlight/blob/fbc5096be3a2519a634787142c47085a63ba002c/backend/store/error_groups.go#L67-L69

Hence, this sleep is now unnecessary.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Tested on [reflame preview](https://preview.highlight.io/?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22variantId%22%3A%2201H3XBV6SAJPRP2XSHP1A7K4M2%22%2C%22region%22%3A%22sjc%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%225744-optimistically-update-the-error-cache-when-error-status-is-updated%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
