### PR TITLE
use strongly typed logs table

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -2,7 +2,7 @@ import { ApolloError } from '@apollo/client'
 import { Button } from '@components/Button'
 import { Link } from '@components/Link'
 import LoadingBox from '@components/LoadingBox'
-import { LogLevel as LogLevelType, ReservedLogKey } from '@graph/schemas'
+import { ReservedLogKey } from '@graph/schemas'
 import { LogEdge } from '@graph/schemas'
 import {
 	Box,
@@ -24,7 +24,7 @@ import {
 } from '@pages/LogsPage/SearchForm/utils'
 import { LogEdgeWithError } from '@pages/LogsPage/useGetLogs'
 import {
-	ColumnDef,
+	createColumnHelper,
 	ExpandedState,
 	flexRender,
 	getCoreRowModel,
@@ -119,56 +119,48 @@ const LogsTableInner = ({
 	const queryTerms = parseLogsQuery(query)
 	const [expanded, setExpanded] = useState<ExpandedState>({})
 
-	const columns = React.useMemo<ColumnDef<LogEdge>[]>(
-		() => [
-			{
-				accessorKey: 'node.timestamp',
-				cell: ({ row, getValue }) => (
-					<Box
-						flexShrink={0}
-						flexDirection="row"
-						display="flex"
-						alignItems="flex-start"
-						gap="6"
-					>
-						{row.getCanExpand() && (
-							<Box
-								display="flex"
-								alignItems="flex-start"
-								cssClass={styles.expandIcon}
-							>
-								{row.getIsExpanded() ? (
-									<IconExpanded />
-								) : (
-									<IconCollapsed />
-								)}
-							</Box>
-						)}
-						<LogTimestamp timestamp={getValue() as string} />
-					</Box>
-				),
-			},
-			{
-				accessorKey: 'node.level',
-				cell: ({ getValue }) => (
-					<LogLevel level={getValue() as LogLevelType} />
-				),
-			},
-			{
-				accessorKey: 'node.message',
-				cell: ({ row, getValue }) => (
-					<LogMessage
-						queryTerms={queryTerms}
-						message={getValue() as string}
-						expanded={row.getIsExpanded()}
-					/>
-				),
-			},
-		],
-		// Only want to update when the query string matches.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[query],
-	)
+	const columnHelper = createColumnHelper<LogEdge>()
+
+	const columns = [
+		columnHelper.accessor('node.timestamp', {
+			cell: ({ row, getValue }) => (
+				<Box
+					flexShrink={0}
+					flexDirection="row"
+					display="flex"
+					alignItems="flex-start"
+					gap="6"
+				>
+					{row.getCanExpand() && (
+						<Box
+							display="flex"
+							alignItems="flex-start"
+							cssClass={styles.expandIcon}
+						>
+							{row.getIsExpanded() ? (
+								<IconExpanded />
+							) : (
+								<IconCollapsed />
+							)}
+						</Box>
+					)}
+					<LogTimestamp timestamp={getValue()} />
+				</Box>
+			),
+		}),
+		columnHelper.accessor('node.level', {
+			cell: ({ getValue }) => <LogLevel level={getValue()} />,
+		}),
+		columnHelper.accessor('node.message', {
+			cell: ({ row, getValue }) => (
+				<LogMessage
+					queryTerms={queryTerms}
+					message={getValue()}
+					expanded={row.getIsExpanded()}
+				/>
+			),
+		}),
+	]
 
 	const table = useReactTable({
 		data: logEdges,


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

While working on a different table that uses react-table, I noticed that we can now make our react-table usages more typesafe (see #4142) and the utility in #4185

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed keys work with typeahead:

<img width="847" alt="Screenshot 2023-06-26 at 10 04 08 PM" src="https://github.com/highlight/highlight/assets/58678/02de085e-88c3-4043-82a1-1a467b084e73">


Confirmed that keys are typesafe:

<img width="937" alt="Screenshot 2023-06-26 at 10 03 46 PM" src="https://github.com/highlight/highlight/assets/58678/5ab86c7f-74c6-455e-ae7e-cbf195c848fd">


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A