### PR TITLE
chore: fix the text overflow on DateInput

### DIFF
--- a/packages/ui/src/components/DatePicker/PreviousDateRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/PreviousDateRangePicker.tsx
@@ -328,6 +328,10 @@ const PreviousDateRangePickerImpl = ({
 			<Menu.Button
 				kind="secondary"
 				iconRight={<IconSolidCheveronDown />}
+				style={{
+					whiteSpace: 'nowrap',
+					overflow: 'hidden',
+				}}
 				{...(props as Omit<MenuButtonProps, 'ref'>)}
 			>
 				{buttonLabel}


### PR DESCRIPTION
## Summary

This PR is the first pass for issue #5693 

This PR enhances the control bar functionality by addressing the issue of text overflow when selecting date and time for large date ranges.

Here's a video of how it works now:



https://github.com/highlight/highlight/assets/94234459/3616af33-673d-47a4-b842-241bed4ebdf6

