### PR TITLE
Add explicit button for session summary

### DIFF
--- a/backend/lambda/lambda.go
+++ b/backend/lambda/lambda.go
@@ -77,11 +77,7 @@ func (s *Client) GetSessionInsight(ctx context.Context, projectID int, sessionID
 			ID:        232563428,
 			ProjectID: 1,
 		})
-		var localServerErr error
-		req, localServerErr = http.NewRequest(http.MethodPost, "http://localhost:8765/session/insight", bytes.NewBuffer(b))
-		if localServerErr != nil {
-			req, _ = http.NewRequest(http.MethodPost, "https://ohw2ocqp0d.execute-api.us-east-2.amazonaws.com/default/ai-insights", bytes.NewBuffer(b))
-		}
+		req, _ = http.NewRequest(http.MethodPost, "http://localhost:8765/session/insight", bytes.NewBuffer(b))
 	} else {
 		req, _ = http.NewRequest(http.MethodPost, "https://ohw2ocqp0d.execute-api.us-east-2.amazonaws.com/default/ai-insights", bytes.NewBuffer(b))
 	}

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6462,6 +6462,12 @@ body {
 ._1bsjoph0:hover {
   background-color: var(--_1pyqka91x);
 }
+._1bsjoph1 {
+  max-height: calc(100vh - 160px - 32px - 42px - 32px - var(--header-height));
+}
+._1bsjoph2 {
+  max-height: calc(100vh - 160px - 32px - 42px - 32px - var(--header-height) - var(--banner-height));
+}
 .ltrwrc0 {
   height: calc(100vh - 108px - var(--banner-height));
 }

--- a/frontend/src/__generated/ve/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.css.js
+++ b/frontend/src/__generated/ve/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.css.js
@@ -1,1 +1,1 @@
-var h="_1bsjoph0";export{h as insight};
+var h="_1bsjoph0",i="_1bsjoph1",n="_1bsjoph2";export{h as insight,i as insightPanel,n as insightPanelWithBanner};

--- a/frontend/src/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.css.ts
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.css.ts
@@ -14,3 +14,13 @@ export const insight = style({
 	},
 	width: '100%',
 })
+
+export const insightPanel = style({
+	maxHeight:
+		'calc(100vh - 160px - 32px - 42px - 32px - var(--header-height))',
+})
+
+export const insightPanelWithBanner = style({
+	maxHeight:
+		'calc(100vh - 160px - 32px - 42px - 32px - var(--header-height) - var(--banner-height))',
+})

--- a/frontend/src/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.tsx
@@ -2,12 +2,14 @@ import {
 	Badge,
 	Box,
 	IconSolidArrowCircleRight,
+	IconSolidSparkles,
 	Tag,
 	Text,
 } from '@highlight-run/ui'
 
+import { Button } from '@/components/Button'
 import LoadingBox from '@/components/LoadingBox'
-import { useGetSessionInsightQuery } from '@/graph/generated/hooks'
+import { useGetSessionInsightLazyQuery } from '@/graph/generated/hooks'
 import usePlayerConfiguration from '@/pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import { useReplayerContext } from '@/pages/Player/ReplayerContext'
 import { useParams } from '@/util/react-router/useParams'
@@ -30,24 +32,24 @@ const SessionInsights = () => {
 	} = useReplayerContext()
 	const { showPlayerAbsoluteTime } = usePlayerConfiguration()
 
-	const { data, loading } = useGetSessionInsightQuery({
-		variables: {
-			secure_id: session_secure_id!,
-		},
-		skip: !session_secure_id,
-	})
+	const [getSessionInsight, { data, loading }] =
+		useGetSessionInsightLazyQuery({
+			variables: {
+				secure_id: session_secure_id!,
+			},
+		})
 
 	return (
-		<Box py="8" display="flex" flexDirection="column">
+		<Box p="8" display="flex" flexDirection="column" height="full">
 			{loading ? (
 				<LoadingBox />
-			) : (
+			) : data ? (
 				JSON.parse(data?.session_insight?.insight || '[]').map(
 					(insight: SessionInsight, idx: number) => {
 						const timeSinceStart =
 							new Date(insight.timestamp).getTime() - startTime
 						return (
-							<Box px="8" cursor="pointer" key={idx}>
+							<Box cursor="pointer" key={idx}>
 								<Box
 									className={style.insight}
 									onClick={() => {
@@ -97,6 +99,26 @@ const SessionInsights = () => {
 						)
 					},
 				)
+			) : (
+				<Box
+					background="raised"
+					height="full"
+					width="full"
+					display="flex"
+					alignItems="center"
+					justifyContent="center"
+					borderRadius="6"
+				>
+					<Button
+						trackingId="GetSessionInsight"
+						onClick={() => {
+							getSessionInsight()
+						}}
+						iconLeft={<IconSolidSparkles />}
+					>
+						Generate summary
+					</Button>
+				</Box>
 			)}
 		</Box>
 	)

--- a/frontend/src/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.tsx
@@ -6,6 +6,7 @@ import {
 	Tag,
 	Text,
 } from '@highlight-run/ui'
+import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/Button'
@@ -13,6 +14,7 @@ import LoadingBox from '@/components/LoadingBox'
 import { useGetSessionInsightLazyQuery } from '@/graph/generated/hooks'
 import usePlayerConfiguration from '@/pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import { useReplayerContext } from '@/pages/Player/ReplayerContext'
+import { useGlobalContext } from '@/routers/ProjectRouter/context/GlobalContext'
 import { useParams } from '@/util/react-router/useParams'
 import { playerTimeToSessionAbsoluteTime } from '@/util/session/utils'
 import { MillisToMinutesAndSeconds } from '@/util/time'
@@ -32,6 +34,7 @@ const SessionInsights = () => {
 		sessionMetadata: { startTime },
 	} = useReplayerContext()
 	const { showPlayerAbsoluteTime } = usePlayerConfiguration()
+	const { showBanner } = useGlobalContext()
 	const [insightData, setInsightData] = useState('')
 
 	const [getSessionInsight, { loading }] = useGetSessionInsightLazyQuery({
@@ -45,65 +48,81 @@ const SessionInsights = () => {
 	}, [session_secure_id])
 
 	return (
-		<Box p="8" display="flex" flexDirection="column" height="full">
+		<Box p="8" height="full" overflow="auto">
 			{loading ? (
 				<LoadingBox />
 			) : insightData ? (
-				JSON.parse(insightData).map(
-					(insight: SessionInsight, idx: number) => {
-						const timeSinceStart =
-							new Date(insight.timestamp).getTime() - startTime
-						return (
-							<Box cursor="pointer" key={idx}>
-								<Box
-									className={style.insight}
-									onClick={() => {
-										setTime(timeSinceStart)
-									}}
-								>
-									<Box display="flex" gap="4">
-										<Badge
-											size="small"
-											variant="purple"
-											label={String(idx + 1)}
-										/>
-										<Tag
-											kind="secondary"
-											size="small"
-											shape="basic"
-											emphasis="low"
-											iconRight={
-												<IconSolidArrowCircleRight />
-											}
-										>
-											{showPlayerAbsoluteTime
-												? playerTimeToSessionAbsoluteTime(
-														{
-															sessionStartTime:
-																startTime,
-															relativeTime:
-																timeSinceStart,
-														},
-												  )
-												: MillisToMinutesAndSeconds(
-														timeSinceStart,
-												  )}
-										</Tag>
-									</Box>
-									<Box overflowWrap="breakWord">
-										<Text
-											size="small"
-											weight="medium"
-											color="strong"
-										>
-											{insight.insight}
-										</Text>
+				<Box
+					cssClass={clsx(style.insightPanel, {
+						[style.insightPanelWithBanner]: showBanner,
+					})}
+				>
+					<Box
+						height="full"
+						width="full"
+						display="flex"
+						flexDirection="column"
+						position="relative"
+					>
+						{[
+							...JSON.parse(insightData),
+							...JSON.parse(insightData),
+						].map((insight: SessionInsight, idx: number) => {
+							const timeSinceStart =
+								new Date(insight.timestamp).getTime() -
+								startTime
+							return (
+								<Box cursor="pointer" key={idx}>
+									<Box
+										className={style.insight}
+										onClick={() => {
+											setTime(timeSinceStart)
+										}}
+									>
+										<Box display="flex" gap="4">
+											<Badge
+												size="small"
+												variant="purple"
+												label={String(idx + 1)}
+											/>
+											<Tag
+												kind="secondary"
+												size="small"
+												shape="basic"
+												emphasis="low"
+												iconRight={
+													<IconSolidArrowCircleRight />
+												}
+											>
+												{showPlayerAbsoluteTime
+													? playerTimeToSessionAbsoluteTime(
+															{
+																sessionStartTime:
+																	startTime,
+																relativeTime:
+																	timeSinceStart,
+															},
+													  )
+													: MillisToMinutesAndSeconds(
+															timeSinceStart,
+													  )}
+											</Tag>
+										</Box>
+										<Box overflowWrap="breakWord">
+											<Text
+												size="small"
+												weight="medium"
+												color="strong"
+											>
+												{insight.insight}
+											</Text>
+										</Box>
 									</Box>
 								</Box>
-							</Box>
-						)
-					},
-				)
+							)
+						})}
+					</Box>
+				</Box>
 			) : (
 				<Box
 					background="raised"

--- a/frontend/src/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.tsx
@@ -6,6 +6,7 @@ import {
 	Tag,
 	Text,
 } from '@highlight-run/ui'
+import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/Button'
 import LoadingBox from '@/components/LoadingBox'
@@ -31,20 +32,24 @@ const SessionInsights = () => {
 		sessionMetadata: { startTime },
 	} = useReplayerContext()
 	const { showPlayerAbsoluteTime } = usePlayerConfiguration()
+	const [insightData, setInsightData] = useState('')
 
-	const [getSessionInsight, { data, loading }] =
-		useGetSessionInsightLazyQuery({
-			variables: {
-				secure_id: session_secure_id!,
-			},
-		})
+	const [getSessionInsight, { loading }] = useGetSessionInsightLazyQuery({
+		onCompleted: (data) => {
+			setInsightData(data?.session_insight?.insight || '[]')
+		},
+	})
+
+	useEffect(() => {
+		setInsightData('')
+	}, [session_secure_id])
 
 	return (
 		<Box p="8" display="flex" flexDirection="column" height="full">
 			{loading ? (
 				<LoadingBox />
-			) : data ? (
-				JSON.parse(data?.session_insight?.insight || '[]').map(
+			) : insightData ? (
+				JSON.parse(insightData).map(
 					(insight: SessionInsight, idx: number) => {
 						const timeSinceStart =
 							new Date(insight.timestamp).getTime() - startTime
@@ -112,7 +117,11 @@ const SessionInsights = () => {
 					<Button
 						trackingId="GetSessionInsight"
 						onClick={() => {
-							getSessionInsight()
+							getSessionInsight({
+								variables: {
+									secure_id: session_secure_id!,
+								},
+							})
 						}}
 						iconLeft={<IconSolidSparkles />}
 					>

--- a/packages/ai/src/prompts.ts
+++ b/packages/ai/src/prompts.ts
@@ -1,13 +1,15 @@
 export const getSessionHighlightPrompt = (events: string) =>
-	`Given an array of events performed by a customer from a session recording for a web application, make inferences and output 3 insights from the session and provide specific details. 
+	`Given an array of events performed by a user from a session recording for a web application, make inferences and justifications and summarize interesting things about the session in 3 insights. 
 
 Rules: 
 - Use less than 2 sentences for each point
-- Do not solely recite the different type of events
-- There is no need to mention every event
+- Provide high level insights, do not mention singular events
+- Do not mention event types in the insights
 - Insights must be different to each other
+- Do not mention identification or authentication events
 - Don't mention timestamps in <insight>, insights should be interesting inferences from the input
 - Output timestamp that best represents the insight in <timestamp> of output
+- Sort the insights by timestamp
 
 ${JSON_FORMAT_INSTRUCTION}
 


### PR DESCRIPTION
## Summary

Added button to trigger session insights as specified in https://github.com/highlight/highlight/issues/5687

Also fixed the backend insights retry function when local server is unavailable. 

<img width="1439" alt="Screenshot 2023-06-27 at 12 43 11 PM" src="https://github.com/highlight/highlight/assets/29858539/b4d1f9c2-a963-441e-b59a-2d6336cc11b1">
