### PR TITLE
Fix dashboard link

### DIFF
--- a/frontend/src/pages/Dashboards/pages/DashboardsHomePage/DashboardsHomePage.tsx
+++ b/frontend/src/pages/Dashboards/pages/DashboardsHomePage/DashboardsHomePage.tsx
@@ -109,7 +109,7 @@ const TABLE_COLUMNS = [
 		key: 'view',
 		render: (_: any, record: any) => (
 			<Link
-				to={`dashboards/${record.id}`}
+				to={`/${record.project_id}/dashboards/${record.id}`}
 				state={{ dashboardName: record.name }}
 				className={alertStyles.configureButton}
 				onClick={(e) => {


### PR DESCRIPTION
## Summary

Fixes a broken link on the dashboards page. In prod, if you click the "View" button on a dashboard card it won't open and will cause the page to get in a weird state.

<img width="1476" alt="Screenshot 2023-06-27 at 1 31 29 PM" src="https://github.com/highlight/highlight/assets/308182/91e62b1b-13df-480d-8482-03b521f8de9a">

This PR makes the URL absolute and links to the correct project which fixes the issue.

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A