### PR TITLE
Allow non-admin emails to receive alerts

### DIFF
--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -23,8 +23,9 @@ import { useSlackSync } from '@hooks/useSlackSync'
 import alertConfigurationCardStyles from '@pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.module.css'
 import { DiscordChannnelsSection } from '@pages/Alerts/AlertConfigurationCard/DiscordChannelsSection'
 import { useParams } from '@util/react-router/useParams'
-import { Form, message, Tag } from 'antd'
+import { Form, message } from 'antd'
 import clsx from 'clsx'
+import { uniq } from 'lodash'
 import React, { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
@@ -497,19 +498,23 @@ export const AlertConfigurationCard = ({
 		}),
 	)
 
-	const emails = emailSuggestions.map((email) => ({
+	const emails = uniq([
+		...(emailSuggestions ?? []),
+		// Add values from the form to ensure custom emails are included
+		...(form.getFieldValue('emails') ?? []),
+	]).map((email) => ({
 		displayValue: email,
 		value: email,
 		id: email,
 	}))
 
-	// if (!!customEmail.split('@')[1]) {
-	// 	emails.unshift({
-	// 		displayValue: `Send email alerts to: ${customEmail}`,
-	// 		value: customEmail,
-	// 		id: customEmail,
-	// 	})
-	// }
+	if (!!customEmail.split('@')[1]) {
+		emails.unshift({
+			displayValue: `Send email alerts to: ${customEmail}`,
+			value: customEmail,
+			id: customEmail,
+		})
+	}
 
 	const environments = [
 		...dedupeEnvironments(environmentOptions).map(
@@ -819,38 +824,6 @@ export const AlertConfigurationCard = ({
 										className={styles.channelSelect}
 										options={emails}
 										mode="multiple"
-										tagRender={(props) => {
-											const { value, closable, onClose } =
-												props
-
-											const onPreventMouseDown = (
-												event: React.MouseEvent<HTMLSpanElement>,
-											) => {
-												event.preventDefault()
-												event.stopPropagation()
-											}
-
-											return (
-												<Tag
-													onMouseDown={
-														onPreventMouseDown
-													}
-													closable={closable}
-													onClose={onClose}
-													style={{
-														// A few custom styles to match default tags on selects
-														backgroundColor: `var(--color-gray-200)`,
-														border: 0,
-														fontSize: 14,
-														height: 24,
-														lineHeight: `24px`, // set in px to avoid being set as a ratio of the font size
-														marginRight: 4,
-													}}
-												>
-													{value}
-												</Tag>
-											)
-										}}
 										filterOption={(searchValue, option) => {
 											return (
 												option?.children

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -500,7 +500,8 @@ export const AlertConfigurationCard = ({
 
 	const emails = uniq([
 		...emailSuggestions,
-		...form.getFieldValue('emails'),
+		// Add values from the form to ensure custom emails are included
+		...(form.getFieldValue('emails') ?? []),
 	]).map((email) => ({
 		displayValue: email,
 		value: email,

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -498,10 +498,11 @@ export const AlertConfigurationCard = ({
 		}),
 	)
 
+	const formEmails = form.getFieldValue('emails') ?? []
 	const emails = uniq([
 		...(emailSuggestions ?? []),
 		// Add values from the form to ensure custom emails are included
-		...(form.getFieldValue('emails') ?? []),
+		...formEmails,
 	]).map((email) => ({
 		displayValue: email,
 		value: email,

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -25,7 +25,6 @@ import { DiscordChannnelsSection } from '@pages/Alerts/AlertConfigurationCard/Di
 import { useParams } from '@util/react-router/useParams'
 import { Form, message, Tag } from 'antd'
 import clsx from 'clsx'
-import { uniq } from 'lodash'
 import React, { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
@@ -498,24 +497,19 @@ export const AlertConfigurationCard = ({
 		}),
 	)
 
-	const formEmails = form.getFieldValue('emails') ?? []
-	const emails = uniq([
-		...(emailSuggestions ?? []),
-		// Add values from the form to ensure custom emails are included
-		...formEmails,
-	]).map((email) => ({
+	const emails = emailSuggestions.map((email) => ({
 		displayValue: email,
 		value: email,
 		id: email,
 	}))
 
-	if (!!customEmail.split('@')[1]) {
-		emails.unshift({
-			displayValue: `Send email alerts to: ${customEmail}`,
-			value: customEmail,
-			id: customEmail,
-		})
-	}
+	// if (!!customEmail.split('@')[1]) {
+	// 	emails.unshift({
+	// 		displayValue: `Send email alerts to: ${customEmail}`,
+	// 		value: customEmail,
+	// 		id: customEmail,
+	// 	})
+	// }
 
 	const environments = [
 		...dedupeEnvironments(environmentOptions).map(

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -499,7 +499,7 @@ export const AlertConfigurationCard = ({
 	)
 
 	const emails = uniq([
-		...emailSuggestions,
+		...(emailSuggestions ?? []),
 		// Add values from the form to ensure custom emails are included
 		...(form.getFieldValue('emails') ?? []),
 	]).map((email) => ({

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -23,7 +23,7 @@ import { useSlackSync } from '@hooks/useSlackSync'
 import alertConfigurationCardStyles from '@pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.module.css'
 import { DiscordChannnelsSection } from '@pages/Alerts/AlertConfigurationCard/DiscordChannelsSection'
 import { useParams } from '@util/react-router/useParams'
-import { Form, message } from 'antd'
+import { Form, message, Tag } from 'antd'
 import clsx from 'clsx'
 import { uniq } from 'lodash'
 import React, { useEffect, useState } from 'react'
@@ -824,6 +824,38 @@ export const AlertConfigurationCard = ({
 										className={styles.channelSelect}
 										options={emails}
 										mode="multiple"
+										tagRender={(props) => {
+											const { value, closable, onClose } =
+												props
+
+											const onPreventMouseDown = (
+												event: React.MouseEvent<HTMLSpanElement>,
+											) => {
+												event.preventDefault()
+												event.stopPropagation()
+											}
+
+											return (
+												<Tag
+													onMouseDown={
+														onPreventMouseDown
+													}
+													closable={closable}
+													onClose={onClose}
+													style={{
+														// A few custom styles to match default tags on selects
+														backgroundColor: `var(--color-gray-200)`,
+														border: 0,
+														fontSize: 14,
+														height: 24,
+														lineHeight: `24px`, // set in px to avoid being set as a ratio of the font size
+														marginRight: 4,
+													}}
+												>
+													{value}
+												</Tag>
+											)
+										}}
 										filterOption={(searchValue, option) => {
 											return (
 												option?.children

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -815,8 +815,7 @@ export const AlertConfigurationCard = ({
 							<h3>Emails to Notify</h3>
 							<p>
 								Pick email addresses to email when an alert is
-								created. These are email addresses for people in
-								your workspace.
+								created.
 							</p>
 							<Form.Item shouldUpdate>
 								{() => (

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -22,10 +22,10 @@ import {
 import { useSlackSync } from '@hooks/useSlackSync'
 import alertConfigurationCardStyles from '@pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.module.css'
 import { DiscordChannnelsSection } from '@pages/Alerts/AlertConfigurationCard/DiscordChannelsSection'
-import { useApplicationContext } from '@routers/AppRouter/context/ApplicationContext'
 import { useParams } from '@util/react-router/useParams'
-import { Form, message } from 'antd'
+import { Form, message, Tag } from 'antd'
 import clsx from 'clsx'
+import { uniq } from 'lodash'
 import React, { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
@@ -33,6 +33,7 @@ import { Link, useLocation } from 'react-router-dom'
 import TextTransition from 'react-text-transition'
 
 import SlackLoadOrConnect from '@/pages/Alerts/AlertConfigurationCard/SlackLoadOrConnect'
+import { useApplicationContext } from '@/routers/AppRouter/context/ApplicationContext'
 
 import Button from '../../../components/Button/Button/Button'
 import InputNumber from '../../../components/InputNumber/InputNumber'
@@ -89,6 +90,7 @@ export const AlertConfigurationCard = ({
 	const [frequency, setFrequency] = useState(
 		getFrequencyOption(alert?.Frequency).value,
 	)
+	const [customEmail, setCustomEmail] = useState('')
 
 	const { slackLoading, syncSlack } = useSlackSync()
 	const [isDisabled, setIsDisabled] = useState(alert?.disabled || false)
@@ -496,11 +498,22 @@ export const AlertConfigurationCard = ({
 		}),
 	)
 
-	const emails = emailSuggestions.map((email) => ({
+	const emails = uniq([
+		...emailSuggestions,
+		...form.getFieldValue('emails'),
+	]).map((email) => ({
 		displayValue: email,
 		value: email,
 		id: email,
 	}))
+
+	if (!!customEmail.split('@')[1]) {
+		emails.unshift({
+			displayValue: `Send email alerts to: ${customEmail}`,
+			value: customEmail,
+			id: customEmail,
+		})
+	}
 
 	const environments = [
 		...dedupeEnvironments(environmentOptions).map(
@@ -567,6 +580,7 @@ export const AlertConfigurationCard = ({
 		form.setFieldsValue({ emails })
 		setEmailsToNotify(emails)
 		setFormTouched(true)
+		setCustomEmail('')
 	}
 
 	const onWebhooksChange = (webhooks: WebhookDestination[]) => {
@@ -810,6 +824,38 @@ export const AlertConfigurationCard = ({
 										className={styles.channelSelect}
 										options={emails}
 										mode="multiple"
+										tagRender={(props) => {
+											const { value, closable, onClose } =
+												props
+
+											const onPreventMouseDown = (
+												event: React.MouseEvent<HTMLSpanElement>,
+											) => {
+												event.preventDefault()
+												event.stopPropagation()
+											}
+
+											return (
+												<Tag
+													onMouseDown={
+														onPreventMouseDown
+													}
+													closable={closable}
+													onClose={onClose}
+													style={{
+														// A few custom styles to match default tags on selects
+														backgroundColor: `var(--color-gray-200)`,
+														border: 0,
+														fontSize: 14,
+														height: 24,
+														lineHeight: `24px`, // set in px to avoid being set as a ratio of the font size
+														marginRight: 4,
+													}}
+												>
+													{value}
+												</Tag>
+											)
+										}}
 										filterOption={(searchValue, option) => {
 											return (
 												option?.children
@@ -820,7 +866,11 @@ export const AlertConfigurationCard = ({
 													) || false
 											)
 										}}
-										placeholder={`Select a email address to send ${defaultName} to.`}
+										onKeyUp={(e: any) => {
+											setCustomEmail(e.target.value)
+										}}
+										onBlur={() => setCustomEmail('')}
+										placeholder={`Select an email address to send ${defaultName} to.`}
 										onChange={onEmailsChange}
 										notFoundContent={
 											<div
@@ -834,8 +884,10 @@ export const AlertConfigurationCard = ({
 													to={`/w/${currentWorkspace?.id}/team`}
 												>
 													invite someone to the
-													workspace?
+													workspace
 												</Link>
+												? Or enter an external email
+												address to send alerts to.
 											</div>
 										}
 										defaultValue={


### PR DESCRIPTION
## Summary

We want to allow non-Highlight admins to receive alerts. This can be helpful if someone wants to send alerts via email to an external service, like Opsgenie, as requested in #5732.

This PR adds some custom logic + styles to the emails input on the alert page allowing a user to enter a custom email address to receive email updates.

https://www.loom.com/share/9c0e69540fc84943addbe3121cae7cfa

## How did you test this change?

Local click test.

## Are there any deployment considerations?

I did not verify that the alerts were being sent locally because I wasn't sure how to trigger alert emails in local dev.