### PR TITLE
disable indexeddb when there is no way to read memory usage

### DIFF
--- a/docker/compose.hobby.yml
+++ b/docker/compose.hobby.yml
@@ -47,6 +47,9 @@ x-backend-env: &backend-env
         - PSQL_PORT
         - PSQL_USER
         - REACT_APP_AUTH_MODE=simple
+        - REACT_APP_COMMIT_SHA
+        - REACT_APP_FRONTEND_URI
+        - REACT_APP_PRIVATE_GRAPH_URI
         - PRIVATE_GRAPH_URI
         - PUBLIC_GRAPH_URI
         - REDIS_ADDRESS

--- a/frontend/src/util/db.ts
+++ b/frontend/src/util/db.ts
@@ -25,6 +25,10 @@ const getLocalStorage = function (): Storage | undefined {
 }
 
 export const isIndexedDBEnabled = function () {
+	// disabled indexeddb altogether if we cannot read indexeddb memory usage
+	if (!navigator?.storage?.estimate) {
+		return false
+	}
 	const defaultEnabled = import.meta.env.MODE !== 'development'
 	const storage = getLocalStorage()
 	if (!storage) {
@@ -323,9 +327,6 @@ export const indexedDBFetch = async function* (
 }
 
 const cleanup = async () => {
-	if (!navigator?.storage?.estimate) {
-		return
-	}
 	const fetchElems = await db.fetch.count()
 	const mapElems = await db.map.count()
 	const apolloElems = await db.apollo.count()


### PR DESCRIPTION
## Summary

On Safari, we don't have access to reading how much memory indexeddb is occupying.
This means we cannot clean up if we are getting close to memory usage limits.
Disable indexeddb altogether in this case to avoid https://app.highlight.io/1/errors/4E8fIhngcFgOOeWpkmG0A6Aq7bee

* Fixes backend env vars for the hobby deployment needed by the backend

## How did you test this change?

Reflame preview

## Are there any deployment considerations?

No
