### PR TITLE
avoid overwriting native `window.Highlight` class

### DIFF
--- a/experiments/chrome-extension/README.md
+++ b/experiments/chrome-extension/README.md
@@ -51,7 +51,7 @@ steps:
 
 -   `cd experiments/chrome-extension`
 -   `yarn build`
--   replace `new window.Highlight` with `Highlight.create` in `firstload/index.tsx`
+-   replace `new window.HighlightIO` with `Highlight.create` in `firstload/index.tsx`
 -   `yarn firstload:update`
 -   open chrome extensions page on chrome or sidekick
 -   enable developer mode on the top right

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -1378,7 +1378,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 	}
 }
 
-;(window as any).Highlight = Highlight
+;(window as any).HighlightIO = Highlight
 
 interface HighlightWindow extends Window {
 	Highlight: Highlight

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -271,3 +271,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Patch Changes
 
 - Increase data transmission retry delays.
+
+## 7.3.2
+
+### Patch Changes
+
+- Ensure compatibility with native `window.Highlight` [class](https://developer.mozilla.org/en-US/docs/Web/API/Highlight).

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.3.1",
+	"version": "7.3.2",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.3.1"
+export default "7.3.2"

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -36,7 +36,7 @@ const HighlightWarning = (context: string, msg: any) => {
 }
 
 interface HighlightWindow extends Window {
-	Highlight: new (
+	HighlightIO: new (
 		options: HighlightClassOptions,
 		firstLoadListeners: FirstLoadListeners,
 	) => Highlight
@@ -127,7 +127,7 @@ const H: HighlightPublicInterface = {
 			}
 			script.addEventListener('load', () => {
 				const startFunction = () => {
-					highlight_obj = new window.Highlight(
+					highlight_obj = new window.HighlightIO(
 						client_options,
 						first_load_listeners,
 					)


### PR DESCRIPTION
## Summary

Our client would set `window.Highlight` so that firstload could reference the class.
However, this would replace the native `window.Highlight` [class ](https://developer.mozilla.org/en-US/docs/Web/API/Highlight)defined by browsers.
This change renamed `window.Highlight` to `window.HighlightIO` to avoid this problem.

## How did you test this change?

Render / reflame preview.

## Are there any deployment considerations?

No