### PR TITLE
ensure first frame of console.error is not dropped

### DIFF
--- a/sdk/client/src/listeners/console-listener.tsx
+++ b/sdk/client/src/listeners/console-listener.tsx
@@ -76,7 +76,7 @@ export function ConsoleListener(
 				]
 				callback({
 					type: 'Error',
-					trace: trace.slice(1),
+					trace,
 					time: Date.now(),
 					value: payload,
 				})

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -277,3 +277,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Patch Changes
 
 - Ensure compatibility with native `window.Highlight` [class](https://developer.mozilla.org/en-US/docs/Web/API/Highlight).
+
+## 7.3.3
+
+### Patch Changes
+
+- Ensure `console.error` caught stack traces are not missing the top frame.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.3.2",
+	"version": "7.3.3",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.3.2"
+export default "7.3.3"


### PR DESCRIPTION
## Summary

Our console error listener would drop the first frame of errors even when they were caught with a full stack trace.
It seems like this was an error when sharing the logic with the other console listeners that need to drop
the first frame of the stack trace because it is produced from the console listener itself (keeping that top frame
would be redundant).
Issue originally reported by a customer.
https://highlightcorp.slack.com/archives/C04NQ25RV8B/p1687896259977009

## How did you test this change?

Local deploy triggering a frontend error.

before
![image](https://github.com/highlight/highlight/assets/1351531/340839b5-61a5-4a21-ac9e-3bbc5ff952a6)

after
![image](https://github.com/highlight/highlight/assets/1351531/add81007-bafe-4c1a-a3f6-069ada7350e2)

## Are there any deployment considerations?

New patch version of the SDK released.
