### PR TITLE
move error/search context up so it's accessible from workspace / other pages

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5607,24 +5607,6 @@ body {
   display: flex;
   justify-content: flex-end;
 }
-._1ukfp2a0 {
-  border-radius: 0;
-  border: 0 !important;
-}
-._1ukfp2a0:focus,
-._1ukfp2a0:active {
-  background: inherit;
-}
-._1ukfp2a1 {
-  border-right: var(--_1pyqka91o) solid 1px !important;
-}
-._1ukfp2a2 {
-  background: var(--_1pyqka9t);
-}
-._1ukfp2a2:focus,
-._1ukfp2a2:active {
-  background: var(--_1pyqka9u);
-}
 ._155k3sw0 {
   height: 4.16rem;
 }
@@ -5887,6 +5869,24 @@ body {
 }
 .gadbsf1 {
   z-index: 1;
+}
+._1ukfp2a0 {
+  border-radius: 0;
+  border: 0 !important;
+}
+._1ukfp2a0:focus,
+._1ukfp2a0:active {
+  background: inherit;
+}
+._1ukfp2a1 {
+  border-right: var(--_1pyqka91o) solid 1px !important;
+}
+._1ukfp2a2 {
+  background: var(--_1pyqka9t);
+}
+._1ukfp2a2:focus,
+._1ukfp2a2:active {
+  background: var(--_1pyqka9u);
 }
 ._3dlaof0 {
   height: 20px;

--- a/frontend/src/routers/AppRouter/AppRouter.tsx
+++ b/frontend/src/routers/AppRouter/AppRouter.tsx
@@ -52,6 +52,8 @@ import {
 } from '@/graph/generated/operations'
 import { JoinWorkspace } from '@/pages/Auth/JoinWorkspace'
 import { WorkspaceInvitation } from '@/pages/Auth/WorkspaceInvitation'
+import WithErrorSearchContext from '@/routers/ProjectRouter/WithErrorSearchContext'
+import WithSessionSearchContext from '@/routers/ProjectRouter/WithSessionSearchContext'
 
 export const VERIFY_EMAIL_ROUTE = '/verify_email'
 export const ABOUT_YOU_ROUTE = '/about_you'
@@ -203,149 +205,161 @@ export const AppRouter = () => {
 						[],
 				}}
 			>
-				<Routes>
-					<Route path="/join_workspace" element={<JoinWorkspace />} />
-
-					<Route
-						path={VERIFY_EMAIL_ROUTE}
-						element={<VerifyEmail />}
-					/>
-
-					{/* used by google ads for conversion tracking */}
-					<Route path={ABOUT_YOU_ROUTE} element={<AdminForm />} />
-
-					<Route
-						path="/oauth/authorize"
-						element={
-							<Landing>
-								<OAuthApprovalPage />
-							</Landing>
-						}
-					/>
-
-					<Route
-						path="/callback/:integrationName"
-						element={<IntegrationAuthCallbackPage />}
-					/>
-
-					<Route
-						path="/subscriptions"
-						element={<EmailOptOutPage />}
-					/>
-
-					<Route
-						path="/new"
-						element={
-							isLoggedIn ? (
-								<Landing>
-									<NewProjectPage />
-								</Landing>
-							) : (
-								<Navigate to={SIGN_IN_ROUTE} />
-							)
-						}
-					/>
-
-					<Route
-						path="/switch"
-						element={
-							isLoggedIn ? (
-								<Landing>
-									<SwitchWorkspace />
-								</Landing>
-							) : (
-								<Navigate to={SIGN_IN_ROUTE} />
-							)
-						}
-					/>
-
-					<Route
-						path="/invite/:invite_id"
-						element={
-							isLoggedIn ? (
-								<WorkspaceInvitation />
-							) : (
-								<Navigate to={SIGN_UP_ROUTE} />
-							)
-						}
-					/>
-
-					<Route
-						path="/w/:workspace_id/new"
-						element={
-							isLoggedIn ? (
-								<Landing>
-									<NewProjectPage />
-								</Landing>
-							) : (
-								<Navigate to={SIGN_IN_ROUTE} />
-							)
-						}
-					/>
-
-					<Route
-						path="/w/:workspace_id/switch"
-						element={
-							isLoggedIn ? (
-								<Landing>
-									<SwitchProject />
-								</Landing>
-							) : (
-								<Navigate to={SIGN_IN_ROUTE} />
-							)
-						}
-					/>
-
-					<Route
-						path="/w/:workspace_id/*"
-						element={
-							isLoggedIn ? (
-								workspaceId &&
-								Number.isInteger(Number(workspaceId)) ? (
-									<WorkspaceRouter />
-								) : (
-									<DefaultWorkspaceRouter />
-								)
-							) : (
-								<Navigate
-									to={
-										inviteCode
-											? SIGN_UP_ROUTE
-											: SIGN_IN_ROUTE
-									}
-								/>
-							)
-						}
-					/>
-
-					<Route
-						path="/*"
-						element={
-							projectId &&
-							(isValidProjectId ||
-								projectId === DEMO_PROJECT_ID) ? (
-								<ProjectRouter />
-							) : isLoggedIn ? (
-								<ProjectRedirectionRouter />
-							) : (
-								<AuthRouter />
-							)
-						}
-					/>
-
-					{isHighlightAdmin && (
-						<>
+				<WithSessionSearchContext>
+					<WithErrorSearchContext>
+						<Routes>
 							<Route
-								path="/accounts/*"
-								element={<AccountsPage />}
+								path="/join_workspace"
+								element={<JoinWorkspace />}
 							/>
+
 							<Route
-								path="/_internal/*"
-								element={<InternalRouter />}
+								path={VERIFY_EMAIL_ROUTE}
+								element={<VerifyEmail />}
 							/>
-						</>
-					)}
-				</Routes>
+
+							{/* used by google ads for conversion tracking */}
+							<Route
+								path={ABOUT_YOU_ROUTE}
+								element={<AdminForm />}
+							/>
+
+							<Route
+								path="/oauth/authorize"
+								element={
+									<Landing>
+										<OAuthApprovalPage />
+									</Landing>
+								}
+							/>
+
+							<Route
+								path="/callback/:integrationName"
+								element={<IntegrationAuthCallbackPage />}
+							/>
+
+							<Route
+								path="/subscriptions"
+								element={<EmailOptOutPage />}
+							/>
+
+							<Route
+								path="/new"
+								element={
+									isLoggedIn ? (
+										<Landing>
+											<NewProjectPage />
+										</Landing>
+									) : (
+										<Navigate to={SIGN_IN_ROUTE} />
+									)
+								}
+							/>
+
+							<Route
+								path="/switch"
+								element={
+									isLoggedIn ? (
+										<Landing>
+											<SwitchWorkspace />
+										</Landing>
+									) : (
+										<Navigate to={SIGN_IN_ROUTE} />
+									)
+								}
+							/>
+
+							<Route
+								path="/invite/:invite_id"
+								element={
+									isLoggedIn ? (
+										<WorkspaceInvitation />
+									) : (
+										<Navigate to={SIGN_UP_ROUTE} />
+									)
+								}
+							/>
+
+							<Route
+								path="/w/:workspace_id/new"
+								element={
+									isLoggedIn ? (
+										<Landing>
+											<NewProjectPage />
+										</Landing>
+									) : (
+										<Navigate to={SIGN_IN_ROUTE} />
+									)
+								}
+							/>
+
+							<Route
+								path="/w/:workspace_id/switch"
+								element={
+									isLoggedIn ? (
+										<Landing>
+											<SwitchProject />
+										</Landing>
+									) : (
+										<Navigate to={SIGN_IN_ROUTE} />
+									)
+								}
+							/>
+
+							<Route
+								path="/w/:workspace_id/*"
+								element={
+									isLoggedIn ? (
+										workspaceId &&
+										Number.isInteger(
+											Number(workspaceId),
+										) ? (
+											<WorkspaceRouter />
+										) : (
+											<DefaultWorkspaceRouter />
+										)
+									) : (
+										<Navigate
+											to={
+												inviteCode
+													? SIGN_UP_ROUTE
+													: SIGN_IN_ROUTE
+											}
+										/>
+									)
+								}
+							/>
+
+							<Route
+								path="/*"
+								element={
+									projectId &&
+									(isValidProjectId ||
+										projectId === DEMO_PROJECT_ID) ? (
+										<ProjectRouter />
+									) : isLoggedIn ? (
+										<ProjectRedirectionRouter />
+									) : (
+										<AuthRouter />
+									)
+								}
+							/>
+
+							{isHighlightAdmin && (
+								<>
+									<Route
+										path="/accounts/*"
+										element={<AccountsPage />}
+									/>
+									<Route
+										path="/_internal/*"
+										element={<InternalRouter />}
+									/>
+								</>
+							)}
+						</Routes>
+					</WithErrorSearchContext>
+				</WithSessionSearchContext>
 			</ApplicationContextProvider>
 		</Box>
 	)

--- a/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
@@ -23,8 +23,6 @@ import { NetworkResource } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import { usePlayerFullscreen } from '@pages/Player/utils/PlayerHooks'
 import useLocalStorage from '@rehooks/local-storage'
 import { GlobalContextProvider } from '@routers/ProjectRouter/context/GlobalContext'
-import WithErrorSearchContext from '@routers/ProjectRouter/WithErrorSearchContext'
-import WithSessionSearchContext from '@routers/ProjectRouter/WithSessionSearchContext'
 import { auth } from '@util/auth'
 import { setIndexedDBEnabled } from '@util/db'
 import { isOnPrem } from '@util/onPrem/onPremUtils'
@@ -186,43 +184,28 @@ export const ProjectRouter = () => {
 			}}
 		>
 			<PlayerUIContextProvider value={playerUIContext}>
-				<WithSessionSearchContext>
-					<WithErrorSearchContext>
-						<Routes>
-							<Route
-								path=":project_id/front"
-								element={<FrontPlugin />}
-							/>
-							<Route
-								path=":project_id/*"
-								element={
-									<>
-										<Header
-											fullyIntegrated={fullyIntegrated}
-										/>
-										<KeyboardShortcutsEducation />
-										<div
-											className={clsx(
-												commonStyles.bodyWrapper,
-												{
-													[commonStyles.bannerShown]:
-														showBanner,
-												},
-											)}
-										>
-											<ApplicationOrError
-												error={error}
-												joinableWorkspace={
-													joinableWorkspace
-												}
-											/>
-										</div>
-									</>
-								}
-							/>
-						</Routes>
-					</WithErrorSearchContext>
-				</WithSessionSearchContext>
+				<Routes>
+					<Route path=":project_id/front" element={<FrontPlugin />} />
+					<Route
+						path=":project_id/*"
+						element={
+							<>
+								<Header fullyIntegrated={fullyIntegrated} />
+								<KeyboardShortcutsEducation />
+								<div
+									className={clsx(commonStyles.bodyWrapper, {
+										[commonStyles.bannerShown]: showBanner,
+									})}
+								>
+									<ApplicationOrError
+										error={error}
+										joinableWorkspace={joinableWorkspace}
+									/>
+								</div>
+							</>
+						}
+					/>
+				</Routes>
 			</PlayerUIContextProvider>
 		</GlobalContextProvider>
 	)


### PR DESCRIPTION
## Summary
- workspace level pages were breaking because of some code I added to the command bar to access the search context (the command bar is accessible outside of just the project-level pages)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally, tested other non-project-router pages (workspace settings, login, etc) to make sure they weren't crashing
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- need to turn on render autodeploys after this is merged
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
