### PR TITLE
fix panic in stacktrace parsing code

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -8936,6 +8936,7 @@ enum ErrorState {
 enum SourceMappingErrorCode {
 	File_Name_Missing_From_Source_Path
 	Error_Parsing_Stack_Trace_File_Url
+	Error_Constructing_Source_Map_URL
 	Missing_Source_Map_File_In_S3
 	Minified_File_Missing_In_S3_And_URL
 	Sourcemap_File_Missing_In_S3_And_URL

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1774,6 +1774,7 @@ type SourceMappingErrorCode string
 const (
 	SourceMappingErrorCodeFileNameMissingFromSourcePath         SourceMappingErrorCode = "File_Name_Missing_From_Source_Path"
 	SourceMappingErrorCodeErrorParsingStackTraceFileURL         SourceMappingErrorCode = "Error_Parsing_Stack_Trace_File_Url"
+	SourceMappingErrorCodeErrorConstructingSourceMapURL         SourceMappingErrorCode = "Error_Constructing_Source_Map_URL"
 	SourceMappingErrorCodeMissingSourceMapFileInS3              SourceMappingErrorCode = "Missing_Source_Map_File_In_S3"
 	SourceMappingErrorCodeMinifiedFileMissingInS3AndURL         SourceMappingErrorCode = "Minified_File_Missing_In_S3_And_URL"
 	SourceMappingErrorCodeSourcemapFileMissingInS3AndURL        SourceMappingErrorCode = "Sourcemap_File_Missing_In_S3_And_URL"
@@ -1787,6 +1788,7 @@ const (
 var AllSourceMappingErrorCode = []SourceMappingErrorCode{
 	SourceMappingErrorCodeFileNameMissingFromSourcePath,
 	SourceMappingErrorCodeErrorParsingStackTraceFileURL,
+	SourceMappingErrorCodeErrorConstructingSourceMapURL,
 	SourceMappingErrorCodeMissingSourceMapFileInS3,
 	SourceMappingErrorCodeMinifiedFileMissingInS3AndURL,
 	SourceMappingErrorCodeSourcemapFileMissingInS3AndURL,
@@ -1799,7 +1801,7 @@ var AllSourceMappingErrorCode = []SourceMappingErrorCode{
 
 func (e SourceMappingErrorCode) IsValid() bool {
 	switch e {
-	case SourceMappingErrorCodeFileNameMissingFromSourcePath, SourceMappingErrorCodeErrorParsingStackTraceFileURL, SourceMappingErrorCodeMissingSourceMapFileInS3, SourceMappingErrorCodeMinifiedFileMissingInS3AndURL, SourceMappingErrorCodeSourcemapFileMissingInS3AndURL, SourceMappingErrorCodeMinifiedFileLarger, SourceMappingErrorCodeSourceMapFileLarger, SourceMappingErrorCodeInvalidSourceMapURL, SourceMappingErrorCodeSourcemapLibraryCouldntParse, SourceMappingErrorCodeSourcemapLibraryCouldntRetrieveSource:
+	case SourceMappingErrorCodeFileNameMissingFromSourcePath, SourceMappingErrorCodeErrorParsingStackTraceFileURL, SourceMappingErrorCodeErrorConstructingSourceMapURL, SourceMappingErrorCodeMissingSourceMapFileInS3, SourceMappingErrorCodeMinifiedFileMissingInS3AndURL, SourceMappingErrorCodeSourcemapFileMissingInS3AndURL, SourceMappingErrorCodeMinifiedFileLarger, SourceMappingErrorCodeSourceMapFileLarger, SourceMappingErrorCodeInvalidSourceMapURL, SourceMappingErrorCodeSourcemapLibraryCouldntParse, SourceMappingErrorCodeSourcemapLibraryCouldntRetrieveSource:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -295,6 +295,7 @@ enum ErrorState {
 enum SourceMappingErrorCode {
 	File_Name_Missing_From_Source_Path
 	Error_Parsing_Stack_Trace_File_Url
+	Error_Constructing_Source_Map_URL
 	Missing_Source_Map_File_In_S3
 	Minified_File_Missing_In_S3_And_URL
 	Sourcemap_File_Missing_In_S3_And_URL

--- a/backend/stacktraces/enhancer.go
+++ b/backend/stacktraces/enhancer.go
@@ -234,7 +234,22 @@ func getURLSourcemap(ctx context.Context, projectId int, version *string, stackT
 		}
 	} else {
 		// construct sourcemap url from searched file
-		sourceMapURL = (stackTraceFileURL)[:stackFileNameIndex] + sourceMapFileName
+		if stackFileNameIndex <= len(stackTraceFileURL) {
+			sourceMapURL = (stackTraceFileURL)[:stackFileNameIndex] + sourceMapFileName
+		} else {
+			err := e.New("failed to construct sourcemap url from stack trace file")
+			log.WithContext(ctx).
+				WithError(err).
+				WithField("project_id", projectId).
+				WithField("sourcemap_url", sourceMapURL).
+				WithField("stacktrace_file_url", stackTraceFileURL).
+				WithField("sourcemap_file_name", sourceMapFileName).
+				WithField("stack_file_name_idx", stackFileNameIndex).
+				Error(err.Error())
+			stackTraceErrorCode = privateModel.SourceMappingErrorCodeErrorConstructingSourceMapURL
+			stackTraceError.ErrorCode = &stackTraceErrorCode
+			return "", nil, err
+		}
 		// get path from url
 		u2, err := url.Parse(sourceMapURL)
 		stackTraceError.SourceMapURL = &sourceMapURL

--- a/backend/stacktraces/enhancer_test.go
+++ b/backend/stacktraces/enhancer_test.go
@@ -261,7 +261,7 @@ func TestGetURLSourcemap(t *testing.T) {
 	}
 	sm := modelInput.SourceMappingError{}
 	_, _, err = getURLSourcemap(ctx, 1, nil, "", "", 100, fsClient, &sm)
-	if err != nil {
-		t.Errorf("failed to get sourcemap: %v", err)
+	if err == nil {
+		t.Error("expected an error")
 	}
 }

--- a/backend/stacktraces/enhancer_test.go
+++ b/backend/stacktraces/enhancer_test.go
@@ -252,3 +252,16 @@ func TestEnhanceStackTrace(t *testing.T) {
 		}
 	}
 }
+
+func TestGetURLSourcemap(t *testing.T) {
+	ctx := context.Background()
+	fsClient, err := storage.NewFSClient(ctx, "https://localhost:8082/public", "")
+	if err != nil {
+		t.Fatalf("error creating storage client: %v", err)
+	}
+	sm := modelInput.SourceMappingError{}
+	_, _, err = getURLSourcemap(ctx, 1, nil, "", "", 100, fsClient, &sm)
+	if err != nil {
+		t.Errorf("failed to get sourcemap: %v", err)
+	}
+}

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2678,6 +2678,7 @@ export type SourceMappingError = {
 }
 
 export enum SourceMappingErrorCode {
+	ErrorConstructingSourceMapUrl = 'Error_Constructing_Source_Map_URL',
 	ErrorParsingStackTraceFileUrl = 'Error_Parsing_Stack_Trace_File_Url',
 	FileNameMissingFromSourcePath = 'File_Name_Missing_From_Source_Path',
 	InvalidSourceMapUrl = 'Invalid_SourceMapURL',

--- a/frontend/src/pages/ErrorsV2/SourcemapErrorDetails/SourcemapErrorDetails.tsx
+++ b/frontend/src/pages/ErrorsV2/SourcemapErrorDetails/SourcemapErrorDetails.tsx
@@ -200,6 +200,19 @@ export const SourcemapErrorDetails: React.FC<Props> = ({ error }) => {
 				<Code>{error.mappedColumnNumber}</Code>
 			</StackSectionError>
 		)
+	} else if (
+		error.errorCode == SourceMappingErrorCode.ErrorConstructingSourceMapUrl
+	) {
+		return (
+			<StackSectionError
+				error={error}
+				keys={sourcemapParseErrorMetadata}
+				title={fileParseTitle}
+			>
+				Failed to construct the sourcemap URL from the stacktrace{' '}
+				<Code>{error.stackTraceFileURL}</Code>
+			</StackSectionError>
+		)
 	} else {
 		return null
 	}

--- a/sdk/client/src/graph/generated/operations.ts
+++ b/sdk/client/src/graph/generated/operations.ts
@@ -144,7 +144,7 @@ export type MutationPushPayloadArgs = {
 	payload_id?: InputMaybe<Scalars['ID']>
 	resources: Scalars['String']
 	session_secure_id: Scalars['String']
-	web_socket_events: Scalars['String']
+	web_socket_events?: InputMaybe<Scalars['String']>
 }
 
 export enum PublicGraphError {

--- a/sdk/client/src/graph/generated/schemas.ts
+++ b/sdk/client/src/graph/generated/schemas.ts
@@ -141,7 +141,7 @@ export type MutationPushPayloadArgs = {
 	payload_id?: InputMaybe<Scalars['ID']>
 	resources: Scalars['String']
 	session_secure_id: Scalars['String']
-	web_socket_events: Scalars['String']
+	web_socket_events?: InputMaybe<Scalars['String']>
 }
 
 export enum PublicGraphError {

--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,7 @@
 			"dependsOn": ["^build"]
 		},
 		"codegen": {
-			"inputs": ["./**/*.gql", "./**/*.graphqls"],
+			"inputs": ["../**/*.gql", "../**/*.graphqls"],
 			"outputs": ["src/graph/generated/**"]
 		},
 		"typegen": {


### PR DESCRIPTION
## Summary

Some stacktraces included a sourcemap URL that would cause a panic.
Fixes the panic and adds logging to make sure we can pinpoint what invalid sourcemap URL is provided.

## How did you test this change?

Ingesting valid errors correctly.
![image](https://github.com/highlight/highlight/assets/1351531/38641f0c-f4e1-418f-a37b-1808164f1bc4)


Ingesting a fake sourcemap error of this type into the frontend.
![image](https://github.com/highlight/highlight/assets/1351531/48ce2cb0-c5af-464a-9275-a1c3da0c20a6)

## Are there any deployment considerations?

Will monitor new log.
