### PR TITLE
Added pages for new AI settings

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -183,6 +183,7 @@ var Models = []interface{}{
 	&ErrorGroupAdminsView{},
 	&LogAdminsView{},
 	&ProjectFilterSettings{},
+	&AllWorkspaceSettings{},
 	&ErrorGroupActivityLog{},
 }
 
@@ -367,6 +368,12 @@ type ProjectFilterSettings struct {
 	ProjectID                         int
 	FilterSessionsWithoutError        bool `gorm:"default:false"`
 	AutoResolveStaleErrorsDayInterval int  `gorm:"default:0"`
+}
+
+type AllWorkspaceSettings struct {
+	Model
+	WorkspaceID int
+	AIInsights  bool `gorm:"default:false"`
 }
 
 type HasSecret interface {
@@ -1170,8 +1177,9 @@ var ErrorType = struct {
 
 type EmailOptOut struct {
 	Model
-	AdminID  int                             `gorm:"uniqueIndex:email_opt_out_admin_category_idx"`
-	Category modelInputs.EmailOptOutCategory `gorm:"uniqueIndex:email_opt_out_admin_category_idx"`
+	AdminID   int                             `gorm:"uniqueIndex:email_opt_out_admin_category_idx"`
+	Category  modelInputs.EmailOptOutCategory `gorm:"uniqueIndex:email_opt_out_admin_category_idx"`
+	ProjectID *int                            `gorm:"uniqueIndex:email_opt_out_admin_category_idx"`
 }
 
 type RawPayloadType string

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1179,7 +1179,7 @@ type EmailOptOut struct {
 	Model
 	AdminID   int                             `gorm:"uniqueIndex:email_opt_out_admin_category_idx"`
 	Category  modelInputs.EmailOptOutCategory `gorm:"uniqueIndex:email_opt_out_admin_category_idx"`
-	ProjectID *int                            `gorm:"uniqueIndex:email_opt_out_admin_category_idx"`
+	ProjectID *int                            `gorm:"uniqueIndex:email_opt_out_admin_category_project_idx"`
 }
 
 type RawPayloadType string

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -788,20 +788,22 @@ func (e DashboardChartType) MarshalGQL(w io.Writer) {
 type EmailOptOutCategory string
 
 const (
-	EmailOptOutCategoryAll     EmailOptOutCategory = "All"
-	EmailOptOutCategoryDigests EmailOptOutCategory = "Digests"
-	EmailOptOutCategoryBilling EmailOptOutCategory = "Billing"
+	EmailOptOutCategoryAll            EmailOptOutCategory = "All"
+	EmailOptOutCategoryDigests        EmailOptOutCategory = "Digests"
+	EmailOptOutCategoryBilling        EmailOptOutCategory = "Billing"
+	EmailOptOutCategorySessionDigests EmailOptOutCategory = "SessionDigests"
 )
 
 var AllEmailOptOutCategory = []EmailOptOutCategory{
 	EmailOptOutCategoryAll,
 	EmailOptOutCategoryDigests,
 	EmailOptOutCategoryBilling,
+	EmailOptOutCategorySessionDigests,
 }
 
 func (e EmailOptOutCategory) IsValid() bool {
 	switch e {
-	case EmailOptOutCategoryAll, EmailOptOutCategoryDigests, EmailOptOutCategoryBilling:
+	case EmailOptOutCategoryAll, EmailOptOutCategoryDigests, EmailOptOutCategoryBilling, EmailOptOutCategorySessionDigests:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -375,6 +375,11 @@ type AllProjectSettings {
 	autoResolveStaleErrorsDayInterval: Int!
 }
 
+type AllWorkspaceSettings {
+	workspace_id: ID!
+	ai_insights: Boolean!
+}
+
 type Account {
 	id: ID!
 	name: String!
@@ -1422,6 +1427,7 @@ enum EmailOptOutCategory {
 	All
 	Digests
 	Billing
+	SessionDigests
 }
 
 scalar Upload
@@ -1623,6 +1629,7 @@ type Query {
 	workspace_for_invite_link(secret: String!): WorkspaceForInviteLink!
 	workspace_invite_links(workspace_id: ID!): WorkspaceInviteLink!
 	workspacePendingInvites(workspace_id: ID!): [WorkspaceInviteLink]!
+	workspaceSettings(workspace_id: ID!): AllWorkspaceSettings
 	workspace_for_project(project_id: ID!): Workspace
 	admin: Admin
 	admin_role(workspace_id: ID!): WorkspaceAdminRole
@@ -1720,6 +1727,10 @@ type Mutation {
 		autoResolveStaleErrorsDayInterval: Int
 	): AllProjectSettings
 	editWorkspace(id: ID!, name: String): Workspace
+	editWorkspaceSettings(
+		workspace_id: ID!
+		ai_insights: Boolean
+	): AllWorkspaceSettings
 	markErrorGroupAsViewed(
 		error_secure_id: String!
 		viewed: Boolean
@@ -2038,6 +2049,7 @@ type Mutation {
 		admin_id: ID
 		category: EmailOptOutCategory!
 		is_opt_out: Boolean!
+		project_id: Int
 	): Boolean!
 }
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -620,6 +620,23 @@ func (r *mutationResolver) EditWorkspace(ctx context.Context, id int, name *stri
 	return workspace, nil
 }
 
+// EditWorkspaceSettings is the resolver for the editWorkspaceSettings field.
+func (r *mutationResolver) EditWorkspaceSettings(ctx context.Context, workspaceID int, aiInsights *bool) (*model.AllWorkspaceSettings, error) {
+	_, err := r.isAdminInWorkspace(ctx, workspaceID)
+	if err != nil {
+		return nil, e.Wrap(err, "error querying workspace")
+	}
+	workspaceSettings := &model.AllWorkspaceSettings{
+		WorkspaceID: workspaceID,
+	}
+	if err := r.DB.Where(workspaceSettings).Updates(&model.AllWorkspaceSettings{
+		AIInsights: *aiInsights,
+	}).Error; err != nil {
+		return nil, e.Wrap(err, "error updating workspace settings fields")
+	}
+	return workspaceSettings, nil
+}
+
 // MarkErrorGroupAsViewed is the resolver for the markErrorGroupAsViewed field.
 func (r *mutationResolver) MarkErrorGroupAsViewed(ctx context.Context, errorSecureID string, viewed *bool) (*model.ErrorGroup, error) {
 	eg, err := r.canAdminModifyErrorGroup(ctx, errorSecureID)
@@ -3563,7 +3580,7 @@ func (r *mutationResolver) UpdateIntegrationProjectMappings(ctx context.Context,
 }
 
 // UpdateEmailOptOut is the resolver for the updateEmailOptOut field.
-func (r *mutationResolver) UpdateEmailOptOut(ctx context.Context, token *string, adminID *int, category modelInputs.EmailOptOutCategory, isOptOut bool) (bool, error) {
+func (r *mutationResolver) UpdateEmailOptOut(ctx context.Context, token *string, adminID *int, category modelInputs.EmailOptOutCategory, isOptOut bool, projectID *int) (bool, error) {
 	var adminIdDeref int
 	if adminID != nil && token != nil {
 		if !IsOptOutTokenValid(*adminID, *token) {
@@ -3580,8 +3597,9 @@ func (r *mutationResolver) UpdateEmailOptOut(ctx context.Context, token *string,
 
 	if isOptOut {
 		if err := r.DB.Create(&model.EmailOptOut{
-			AdminID:  adminIdDeref,
-			Category: category,
+			AdminID:   adminIdDeref,
+			Category:  category,
+			ProjectID: projectID,
 		}).Error; err != nil {
 			return false, err
 		}
@@ -6491,6 +6509,21 @@ func (r *queryResolver) WorkspacePendingInvites(ctx context.Context, workspaceID
 	}
 
 	return pendingInvites, nil
+}
+
+// WorkspaceSettings is the resolver for the workspaceSettings field.
+func (r *queryResolver) WorkspaceSettings(ctx context.Context, workspaceID int) (*model.AllWorkspaceSettings, error) {
+	_, err := r.isAdminInWorkspace(ctx, workspaceID)
+	if err != nil {
+		return nil, nil
+	}
+
+	workspaceSettings := model.AllWorkspaceSettings{}
+	if err := r.DB.Where(model.AllWorkspaceSettings{WorkspaceID: workspaceID}).FirstOrCreate(&workspaceSettings).Error; err != nil {
+		return nil, err
+	}
+
+	return &workspaceSettings, nil
 }
 
 // WorkspaceForProject is the resolver for the workspace_for_project field.

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -624,7 +624,7 @@ func (r *mutationResolver) EditWorkspace(ctx context.Context, id int, name *stri
 func (r *mutationResolver) EditWorkspaceSettings(ctx context.Context, workspaceID int, aiInsights *bool) (*model.AllWorkspaceSettings, error) {
 	_, err := r.isAdminInWorkspace(ctx, workspaceID)
 	if err != nil {
-		return nil, e.Wrap(err, "error querying workspace")
+		return nil, err
 	}
 	workspaceSettings := &model.AllWorkspaceSettings{
 		WorkspaceID: workspaceID,
@@ -632,7 +632,7 @@ func (r *mutationResolver) EditWorkspaceSettings(ctx context.Context, workspaceI
 	if err := r.DB.Where(workspaceSettings).Updates(&model.AllWorkspaceSettings{
 		AIInsights: *aiInsights,
 	}).Error; err != nil {
-		return nil, e.Wrap(err, "error updating workspace settings fields")
+		return nil, err
 	}
 	return workspaceSettings, nil
 }
@@ -6515,7 +6515,7 @@ func (r *queryResolver) WorkspacePendingInvites(ctx context.Context, workspaceID
 func (r *queryResolver) WorkspaceSettings(ctx context.Context, workspaceID int) (*model.AllWorkspaceSettings, error) {
 	_, err := r.isAdminInWorkspace(ctx, workspaceID)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	workspaceSettings := model.AllWorkspaceSettings{}

--- a/frontend/src/components/ToggleRow/ToggleRow.tsx
+++ b/frontend/src/components/ToggleRow/ToggleRow.tsx
@@ -11,7 +11,7 @@ export const ToggleRow = (
 ) => {
 	return (
 		<Box
-			pr="4"
+			pr="8"
 			display="flex"
 			gap="12"
 			justifyContent="space-between"

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -1692,6 +1692,60 @@ export type EditWorkspaceMutationOptions = Apollo.BaseMutationOptions<
 	Types.EditWorkspaceMutation,
 	Types.EditWorkspaceMutationVariables
 >
+export const EditWorkspaceSettingsDocument = gql`
+	mutation EditWorkspaceSettings($workspace_id: ID!, $ai_insights: Boolean) {
+		editWorkspaceSettings(
+			workspace_id: $workspace_id
+			ai_insights: $ai_insights
+		) {
+			workspace_id
+			ai_insights
+		}
+	}
+`
+export type EditWorkspaceSettingsMutationFn = Apollo.MutationFunction<
+	Types.EditWorkspaceSettingsMutation,
+	Types.EditWorkspaceSettingsMutationVariables
+>
+
+/**
+ * __useEditWorkspaceSettingsMutation__
+ *
+ * To run a mutation, you first call `useEditWorkspaceSettingsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useEditWorkspaceSettingsMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [editWorkspaceSettingsMutation, { data, loading, error }] = useEditWorkspaceSettingsMutation({
+ *   variables: {
+ *      workspace_id: // value for 'workspace_id'
+ *      ai_insights: // value for 'ai_insights'
+ *   },
+ * });
+ */
+export function useEditWorkspaceSettingsMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.EditWorkspaceSettingsMutation,
+		Types.EditWorkspaceSettingsMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.EditWorkspaceSettingsMutation,
+		Types.EditWorkspaceSettingsMutationVariables
+	>(EditWorkspaceSettingsDocument, baseOptions)
+}
+export type EditWorkspaceSettingsMutationHookResult = ReturnType<
+	typeof useEditWorkspaceSettingsMutation
+>
+export type EditWorkspaceSettingsMutationResult =
+	Apollo.MutationResult<Types.EditWorkspaceSettingsMutation>
+export type EditWorkspaceSettingsMutationOptions = Apollo.BaseMutationOptions<
+	Types.EditWorkspaceSettingsMutation,
+	Types.EditWorkspaceSettingsMutationVariables
+>
 export const DeleteSegmentDocument = gql`
 	mutation DeleteSegment($segment_id: ID!) {
 		deleteSegment(segment_id: $segment_id)
@@ -12948,4 +13002,61 @@ export type GetWorkspacePendingInvitesLazyQueryHookResult = ReturnType<
 export type GetWorkspacePendingInvitesQueryResult = Apollo.QueryResult<
 	Types.GetWorkspacePendingInvitesQuery,
 	Types.GetWorkspacePendingInvitesQueryVariables
+>
+export const GetWorkspaceSettingsDocument = gql`
+	query GetWorkspaceSettings($workspace_id: ID!) {
+		workspaceSettings(workspace_id: $workspace_id) {
+			workspace_id
+			ai_insights
+		}
+	}
+`
+
+/**
+ * __useGetWorkspaceSettingsQuery__
+ *
+ * To run a query within a React component, call `useGetWorkspaceSettingsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetWorkspaceSettingsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetWorkspaceSettingsQuery({
+ *   variables: {
+ *      workspace_id: // value for 'workspace_id'
+ *   },
+ * });
+ */
+export function useGetWorkspaceSettingsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceSettingsQuery,
+		Types.GetWorkspaceSettingsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceSettingsQuery,
+		Types.GetWorkspaceSettingsQueryVariables
+	>(GetWorkspaceSettingsDocument, baseOptions)
+}
+export function useGetWorkspaceSettingsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceSettingsQuery,
+		Types.GetWorkspaceSettingsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceSettingsQuery,
+		Types.GetWorkspaceSettingsQueryVariables
+	>(GetWorkspaceSettingsDocument, baseOptions)
+}
+export type GetWorkspaceSettingsQueryHookResult = ReturnType<
+	typeof useGetWorkspaceSettingsQuery
+>
+export type GetWorkspaceSettingsLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceSettingsLazyQuery
+>
+export type GetWorkspaceSettingsQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceSettingsQuery,
+	Types.GetWorkspaceSettingsQueryVariables
 >

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -338,6 +338,20 @@ export type EditWorkspaceMutation = { __typename?: 'Mutation' } & {
 	>
 }
 
+export type EditWorkspaceSettingsMutationVariables = Types.Exact<{
+	workspace_id: Types.Scalars['ID']
+	ai_insights?: Types.Maybe<Types.Scalars['Boolean']>
+}>
+
+export type EditWorkspaceSettingsMutation = { __typename?: 'Mutation' } & {
+	editWorkspaceSettings?: Types.Maybe<
+		{ __typename?: 'AllWorkspaceSettings' } & Pick<
+			Types.AllWorkspaceSettings,
+			'workspace_id' | 'ai_insights'
+		>
+	>
+}
+
 export type DeleteSegmentMutationVariables = Types.Exact<{
 	segment_id: Types.Scalars['ID']
 }>
@@ -4373,6 +4387,19 @@ export type GetWorkspacePendingInvitesQuery = { __typename?: 'Query' } & {
 	>
 }
 
+export type GetWorkspaceSettingsQueryVariables = Types.Exact<{
+	workspace_id: Types.Scalars['ID']
+}>
+
+export type GetWorkspaceSettingsQuery = { __typename?: 'Query' } & {
+	workspaceSettings?: Types.Maybe<
+		{ __typename?: 'AllWorkspaceSettings' } & Pick<
+			Types.AllWorkspaceSettings,
+			'workspace_id' | 'ai_insights'
+		>
+	>
+}
+
 export const namedOperations = {
 	Query: {
 		GetMetricsTimeline: 'GetMetricsTimeline' as const,
@@ -4503,6 +4530,7 @@ export const namedOperations = {
 		GetLogsErrorObjects: 'GetLogsErrorObjects' as const,
 		GetProjectSettings: 'GetProjectSettings' as const,
 		GetWorkspacePendingInvites: 'GetWorkspacePendingInvites' as const,
+		GetWorkspaceSettings: 'GetWorkspaceSettings' as const,
 	},
 	Mutation: {
 		MarkErrorGroupAsViewed: 'MarkErrorGroupAsViewed' as const,
@@ -4534,6 +4562,7 @@ export const namedOperations = {
 		EditProjectSettings: 'EditProjectSettings' as const,
 		DeleteProject: 'DeleteProject' as const,
 		EditWorkspace: 'EditWorkspace' as const,
+		EditWorkspaceSettings: 'EditWorkspaceSettings' as const,
 		DeleteSegment: 'DeleteSegment' as const,
 		EditSegment: 'EditSegment' as const,
 		CreateSegment: 'CreateSegment' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -124,6 +124,12 @@ export type AllProjectSettings = {
 	workspace_id: Scalars['ID']
 }
 
+export type AllWorkspaceSettings = {
+	__typename?: 'AllWorkspaceSettings'
+	ai_insights: Scalars['Boolean']
+	workspace_id: Scalars['ID']
+}
+
 export type AverageSessionLength = {
 	__typename?: 'AverageSessionLength'
 	length: Scalars['Float']
@@ -355,6 +361,7 @@ export enum EmailOptOutCategory {
 	All = 'All',
 	Billing = 'Billing',
 	Digests = 'Digests',
+	SessionDigests = 'SessionDigests',
 }
 
 export type EnhancedUserDetailsResult = {
@@ -958,6 +965,7 @@ export type Mutation = {
 	editProjectSettings?: Maybe<AllProjectSettings>
 	editSegment?: Maybe<Scalars['Boolean']>
 	editWorkspace?: Maybe<Workspace>
+	editWorkspaceSettings?: Maybe<AllWorkspaceSettings>
 	emailSignup: Scalars['String']
 	joinWorkspace?: Maybe<Scalars['ID']>
 	markErrorGroupAsViewed?: Maybe<ErrorGroup>
@@ -1264,6 +1272,11 @@ export type MutationEditWorkspaceArgs = {
 	name?: InputMaybe<Scalars['String']>
 }
 
+export type MutationEditWorkspaceSettingsArgs = {
+	ai_insights?: InputMaybe<Scalars['Boolean']>
+	workspace_id: Scalars['ID']
+}
+
 export type MutationEmailSignupArgs = {
 	email: Scalars['String']
 }
@@ -1399,6 +1412,7 @@ export type MutationUpdateEmailOptOutArgs = {
 	admin_id?: InputMaybe<Scalars['ID']>
 	category: EmailOptOutCategory
 	is_opt_out: Scalars['Boolean']
+	project_id?: InputMaybe<Scalars['Int']>
 	token?: InputMaybe<Scalars['String']>
 }
 
@@ -1729,6 +1743,7 @@ export type Query = {
 	web_vitals: Array<Metric>
 	workspace?: Maybe<Workspace>
 	workspacePendingInvites: Array<Maybe<WorkspaceInviteLink>>
+	workspaceSettings?: Maybe<AllWorkspaceSettings>
 	workspaceSuggestion: Array<Maybe<Workspace>>
 	workspace_admins: Array<WorkspaceAdminRole>
 	workspace_admins_by_project_id: Array<WorkspaceAdminRole>
@@ -2294,6 +2309,10 @@ export type QueryWorkspaceArgs = {
 }
 
 export type QueryWorkspacePendingInvitesArgs = {
+	workspace_id: Scalars['ID']
+}
+
+export type QueryWorkspaceSettingsArgs = {
 	workspace_id: Scalars['ID']
 }
 

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -302,6 +302,16 @@ mutation EditWorkspace($id: ID!, $name: String) {
 	}
 }
 
+mutation EditWorkspaceSettings($workspace_id: ID!, $ai_insights: Boolean) {
+	editWorkspaceSettings(
+		workspace_id: $workspace_id
+		ai_insights: $ai_insights
+	) {
+		workspace_id
+		ai_insights
+	}
+}
+
 mutation DeleteSegment($segment_id: ID!) {
 	deleteSegment(segment_id: $segment_id)
 }

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2103,3 +2103,10 @@ query GetWorkspacePendingInvites($workspace_id: ID!) {
 		created_at
 	}
 }
+
+query GetWorkspaceSettings($workspace_id: ID!) {
+	workspaceSettings(workspace_id: $workspace_id) {
+		workspace_id
+		ai_insights
+	}
+}

--- a/frontend/src/hooks/useIsSettingsPath.ts
+++ b/frontend/src/hooks/useIsSettingsPath.ts
@@ -7,6 +7,7 @@ export type WorkspaceSettingsTab =
 	| 'settings'
 	| 'current-plan'
 	| 'upgrade-plan'
+	| 'harold-ai'
 
 export const isSettingsPath = (path: string[]) => {
 	const settingsPaths: (WorkspaceSettingsTab | SettingGroups)[] = [
@@ -15,6 +16,7 @@ export const isSettingsPath = (path: string[]) => {
 		'team',
 		'current-plan',
 		'upgrade-plan',
+		'harold-ai',
 	]
 	return settingsPaths.some(
 		(settingsPath) => path.indexOf(settingsPath) !== -1,

--- a/frontend/src/pages/EmailOptOut/EmailOptOut.tsx
+++ b/frontend/src/pages/EmailOptOut/EmailOptOut.tsx
@@ -8,7 +8,7 @@ import {
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
 import { EmailOptOutCategory } from '@graph/schemas'
-import { Heading, Stack } from '@highlight-run/ui'
+import { Heading, Stack, Text } from '@highlight-run/ui'
 import { GlobalContextProvider } from '@routers/ProjectRouter/context/GlobalContext'
 import { message } from 'antd'
 import { useDialogState } from 'ariakit/dialog'
@@ -55,18 +55,26 @@ export const EmailOptOutPanel = ({ token, admin_id }: Props) => {
 			</>
 		)
 	} else {
-		const categories = [
-			{
-				label: 'Digests',
-				info: 'Weekly summaries of user activity and errors for your projects',
-				type: EmailOptOutCategory.Digests,
-			},
+		const general = [
 			{
 				label: 'Billing',
 				info: 'Notifications about billing and plan usage',
 				type: EmailOptOutCategory.Billing,
 			},
 		]
+		const digests = [
+			{
+				label: 'Project Overview',
+				info: 'Weekly summaries of user activity and errors for your projects',
+				type: EmailOptOutCategory.Digests,
+			},
+			{
+				label: 'Session Insights',
+				info: 'Weekly summaries of your most interesting sessions',
+				type: EmailOptOutCategory.SessionDigests,
+			},
+		]
+		const categories = [...general, ...digests]
 
 		let optOutAll = false
 		const optOuts = new Set<EmailOptOutCategory>()
@@ -87,7 +95,42 @@ export const EmailOptOutPanel = ({ token, admin_id }: Props) => {
 					Notifications
 				</Heading>
 				<Stack gap="12" direction="column">
-					{categories.map((c) => (
+					{general.map((c) => (
+						<BorderBox key={c.label}>
+							{ToggleRow(
+								c.label,
+								c.info,
+								!optOuts.has(c.type),
+								(isOptIn: boolean) => {
+									updateEmailOptOut({
+										variables: {
+											token,
+											admin_id,
+											category: c.type,
+											is_opt_out: !isOptIn,
+										},
+									})
+										.then(() => {
+											message.success(
+												`Opted ${
+													isOptIn ? 'in to' : 'out of'
+												} ${c.type} emails.`,
+											)
+										})
+										.catch((reason: any) => {
+											message.error(String(reason))
+										})
+								},
+								optOutAll,
+							)}
+						</BorderBox>
+					))}
+				</Stack>
+				<Stack gap="12" direction="column" paddingTop="24">
+					<Text weight="bold" size="small" color="default">
+						Digests
+					</Text>
+					{digests.map((c) => (
 						<BorderBox key={c.label}>
 							{ToggleRow(
 								c.label,

--- a/frontend/src/pages/HaroldAISettings/HaroldAISettings.tsx
+++ b/frontend/src/pages/HaroldAISettings/HaroldAISettings.tsx
@@ -1,0 +1,102 @@
+import { Box, Heading, Stack, Text } from '@highlight-run/ui'
+import { message } from 'antd'
+
+import BorderBox from '@/components/BorderBox/BorderBox'
+import { ToggleRow } from '@/components/ToggleRow/ToggleRow'
+import {
+	useEditWorkspaceSettingsMutation,
+	useGetWorkspaceSettingsQuery,
+} from '@/graph/generated/hooks'
+import { namedOperations } from '@/graph/generated/operations'
+import { useParams } from '@/util/react-router/useParams'
+
+export const HaroldAISettings = () => {
+	const { workspace_id } = useParams<{ workspace_id: string }>()
+
+	const [editWorkspaceSettings] = useEditWorkspaceSettingsMutation({
+		refetchQueries: [namedOperations.Query.GetWorkspaceSettings],
+	})
+	const { data, loading } = useGetWorkspaceSettingsQuery({
+		variables: { workspace_id: workspace_id! },
+		skip: !workspace_id,
+	})
+
+	const features = [
+		{
+			label: 'Session Insight Digest',
+			info: 'Supercharge your session insight digests with AI',
+		},
+	]
+
+	return (
+		<Box>
+			<Box style={{ maxWidth: 560 }} my="40" mx="auto">
+				<Stack gap="24" direction="column">
+					<Stack gap="16" direction="column">
+						<Heading mt="16" level="h4">
+							Harold AI
+						</Heading>
+						<Text weight="medium" size="small" color="default">
+							Highlight's Harold AI is an assistant that is
+							helping you get data quicker, and fix bugs easier.
+							Harold AI is based on OpenAI GPT-4.
+						</Text>
+					</Stack>
+					<BorderBox>
+						<Box py="4">
+							<Stack gap="12" direction="column">
+								<Text weight="bold" size="small" color="strong">
+									Learn more about Highlight's AI
+								</Text>
+								<Text color="moderate">
+									Curious to know more about how we use
+									OpenAI's GPT-4 to power our AI services?
+									Take a look at our docs!
+								</Text>
+							</Stack>
+						</Box>
+					</BorderBox>
+					<Stack gap="12" direction="column" paddingTop="24">
+						<Text weight="bold" size="small" color="default">
+							Features
+						</Text>
+						{features.map((c) => (
+							<BorderBox key={c.label}>
+								{ToggleRow(
+									c.label,
+									c.info,
+									data?.workspaceSettings?.ai_insights ??
+										false,
+									(isOptIn: boolean) => {
+										if (!workspace_id) {
+											return
+										}
+										editWorkspaceSettings({
+											variables: {
+												workspace_id: workspace_id,
+												ai_insights: isOptIn,
+											},
+										})
+											.then(() => {
+												message.success(
+													`${
+														isOptIn
+															? 'Enabled'
+															: 'Disabled'
+													} Harold AI for Session Insights Digests.`,
+												)
+											})
+											.catch((reason: any) => {
+												message.error(String(reason))
+											})
+									},
+									loading,
+								)}
+							</BorderBox>
+						))}
+					</Stack>
+				</Stack>
+			</Box>
+		</Box>
+	)
+}

--- a/frontend/src/pages/SettingsRouter/SettingsRouter.tsx
+++ b/frontend/src/pages/SettingsRouter/SettingsRouter.tsx
@@ -18,6 +18,7 @@ import {
 
 import { WorkspaceSettingsTab } from '@/hooks/useIsSettingsPath'
 import { EmailOptOutPanel } from '@/pages/EmailOptOut/EmailOptOut'
+import { HaroldAISettings } from '@/pages/HaroldAISettings/HaroldAISettings'
 import { ProjectColorLabel } from '@/pages/ProjectSettings/ProjectColorLabel/ProjectColorLabel'
 import ProjectSettings from '@/pages/ProjectSettings/ProjectSettings'
 import Auth from '@/pages/UserSettings/Auth/Auth'
@@ -39,6 +40,8 @@ const getTitle = (tab: WorkspaceSettingsTab | string): string => {
 			return 'Billing plans'
 		case 'upgrade-plan':
 			return 'Upgrade plan'
+		case 'harold-ai':
+			return 'Harold AI'
 		default:
 			return ''
 	}
@@ -98,6 +101,11 @@ export const SettingsRouter = () => {
 			key: 'current-plan',
 			title: getTitle('current-plan'),
 			panelContent: billingContent,
+		},
+		{
+			key: 'harold-ai',
+			title: getTitle('harold-ai'),
+			panelContent: <HaroldAISettings />,
 		},
 	]
 


### PR DESCRIPTION
## Summary

First part of https://github.com/highlight/highlight/issues/5717

Add the Harold AI settings page, and a new setting to turn on emails for session insight digests

Set up the emailOptOut data model to handle specific projects

This should allow for users to turn on/off our new ai features, will have another PR addressing more advanced functionality shown in the designs

TODO: 
- Implement opting out for specific projects on the ui and backend (v2)
- Show the number of times a user calls the AI features on the Harold page.  (v2)
  - this can be added once we add the ai output caching functionality
- Button leading to the docs page to learn more about AI
  - Will add once the docs page is up

## How did you test this change?

- Toggled the digests settings and check that it persists
- Toggled Harold settings and check it persists

<img width="1438" alt="Screenshot 2023-06-29 at 8 52 42 PM" src="https://github.com/highlight/highlight/assets/29858539/8dd78729-4484-4fe0-804f-d8d23b4f61ae">
<img width="1438" alt="Screenshot 2023-06-29 at 8 52 51 PM" src="https://github.com/highlight/highlight/assets/29858539/e398d1f0-2e3c-4759-abe4-e02e2ffbc325">

## Are there any deployment considerations?

The data model is changed for EmailOptOut, and a new data model AllWorkspaceSettings is added. 
