### PR TITLE
Fix crash in alert details page

### DIFF
--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -356,5 +356,6 @@
 		"graphql": "16.6.0",
 		"react-transition-group": "4.4.1",
 		"lodash": "npm:lodash-es",
+		"antd": "4.24.12",
 	},
 }


### PR DESCRIPTION
Turns out the crash was due to the reflame build resolving to a buggy antd version that doesn't properly handle objects as values (used in the Discord select, couldn't repro before because I didn't have Discord integration enabled).

Fixed by adding a version override to the latest antd v4.

## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

Navigated to an alert with a discord channel set up in a [Reflame preview](https://preview.highlight.io/?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22variantId%22%3A%2201H470H2MBBDRDQD4HT68MK2VJ%22%2C%22region%22%3A%22sjc%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22fix-alert-config-crash%5C%22%2C%5C%22forkSpecifier%5C%22%3A%5C%22lewisl9029%2Fhighlight%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D) and verified there was no longer a crash.

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
