### PR TITLE
Zane/vercel log drains

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3453,6 +3453,10 @@ func (r *mutationResolver) UpdateVercelProjectMappings(ctx context.Context, proj
 		})
 	}
 
+	if err := vercel.RemoveLogDrains(ctx, workspace.VercelTeamID, *workspace.VercelAccessToken); err != nil {
+		return false, err
+	}
+
 	// Group configs by Highlight project id, then create a log drain for each
 	byHighlightProject := lo.GroupBy(configs, func(c *model.VercelIntegrationConfig) int {
 		return c.ProjectID

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3453,10 +3453,21 @@ func (r *mutationResolver) UpdateVercelProjectMappings(ctx context.Context, proj
 		})
 	}
 
-	if err := vercel.CreateLogDrain(ctx, workspace.VercelTeamID, lo.Map(projectMappings, func(t *modelInputs.VercelProjectMappingInput, i int) string {
-		return t.VercelProjectID
-	}), project.VerboseID(), "Highlight Log Drain", *workspace.VercelAccessToken); err != nil {
-		return false, err
+	// Group configs by Highlight project id, then create a log drain for each
+	byHighlightProject := lo.GroupBy(configs, func(c *model.VercelIntegrationConfig) int {
+		return c.ProjectID
+	})
+	for highlightProjectId, configs := range byHighlightProject {
+		project := model.Project{
+			Model: model.Model{
+				ID: highlightProjectId,
+			},
+		}
+		if err := vercel.CreateLogDrain(ctx, workspace.VercelTeamID, lo.Map(configs, func(t *model.VercelIntegrationConfig, i int) string {
+			return t.VercelProjectID
+		}), project.VerboseID(), "Highlight Log Drain", *workspace.VercelAccessToken); err != nil {
+			return false, err
+		}
 	}
 
 	if err := r.DB.Where("workspace_id = ?", workspaceId).Delete(&model.VercelIntegrationConfig{}).Error; err != nil {

--- a/backend/vercel/vercel.go
+++ b/backend/vercel/vercel.go
@@ -168,6 +168,39 @@ func RemoveConfiguration(configId string, accessToken string, teamId *string) er
 	return nil
 }
 
+func RemoveLogDrain(logDrainId string, accessToken string, teamId *string) error {
+	client := &http.Client{}
+
+	teamIdParam := ""
+	if teamId != nil {
+		teamIdParam = "?teamId=" + *teamId
+	}
+
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/v1/integrations/log-drains/%s%s", ApiBaseUrl, logDrainId, teamIdParam), nil)
+	if err != nil {
+		return errors.Wrap(err, "error creating api request to Vercel")
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+
+	res, err := client.Do(req)
+
+	if err != nil {
+		return errors.Wrap(err, "error getting response from Vercel log drains endpoint")
+	}
+
+	b, err := io.ReadAll(res.Body)
+
+	if res.StatusCode != 204 {
+		return errors.New("Vercel log drains API responded with error; status_code=" + res.Status + "; body=" + string(b))
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "error reading response body from Vercel log drains endpoint")
+	}
+
+	return nil
+}
+
 func GetProjects(accessToken string, teamId *string) ([]*model.VercelProject, error) {
 	client := &http.Client{}
 
@@ -232,21 +265,16 @@ func GetProjects(accessToken string, teamId *string) ([]*model.VercelProject, er
 	return projects, nil
 }
 
-func RemoveLogDrains(ctx context.Context, vercelTeamID *string, vercelProjectIDs []string, projectVerboseID string, name string, accessToken string) error {
+func RemoveLogDrains(ctx context.Context, vercelTeamID *string, accessToken string) error {
 	client := &http.Client{}
 
-	headers := fmt.Sprintf(`{"%s":"%s"}`, LogDrainProjectHeader, projectVerboseID)
-	projectIds := fmt.Sprintf(`[%s]`, strings.Join(lo.Map(vercelProjectIDs, func(t string, i int) string {
-		return fmt.Sprintf("\"%s\"", t)
-	}), ","))
-	body := fmt.Sprintf(`{"url":"https://pub.highlight.run/vercel/v1/logs", "name":"%s", "headers":%s, "projectIds":%s, "deliveryFormat":"ndjson", "secret": "%s", "sources": ["static", "lambda", "edge", "build", "external"]}`, name, headers, projectIds, projectVerboseID)
 	u := fmt.Sprintf("%s/v2/integrations/log-drains", ApiBaseUrl)
 	if vercelTeamID != nil {
 		u = fmt.Sprintf("%s?teamId=%s", u, *vercelTeamID)
 	}
-	req, err := http.NewRequest("POST", u, strings.NewReader(body))
+	req, err := http.NewRequest("GET", u, strings.NewReader(""))
 	if err != nil {
-		return errors.Wrap(err, "error creating api request to Vercel")
+		return errors.Wrap(err, "error creating log drains request to Vercel")
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 
@@ -259,14 +287,25 @@ func RemoveLogDrains(ctx context.Context, vercelTeamID *string, vercelProjectIDs
 	b, err := io.ReadAll(res.Body)
 
 	if res.StatusCode != 200 {
-		log.WithContext(ctx).WithField("Body", string(b)).
-			WithField("Url", u).
-			Errorf("Vercel Log Drain API responded with error")
-		return errors.New("Vercel Log Drain API responded with error; status_code=" + res.Status + "; body=" + string(b))
+		return errors.New("Vercel log drains API responded with error; status_code=" + res.Status + "; body=" + string(b))
 	}
 
 	if err != nil {
-		return errors.Wrap(err, "error reading response body from Vercel log-drain endpoint")
+		return errors.Wrap(err, "error reading response body from Vercel log drains endpoint")
+	}
+
+	var logDrainsResponse []struct {
+		Id string `json:"id"`
+	}
+	err = json.Unmarshal(b, &logDrainsResponse)
+	if err != nil {
+		return errors.Wrap(err, "error unmarshaling Vercel log drains response")
+	}
+
+	for _, ld := range logDrainsResponse {
+		if err := RemoveLogDrain(ld.Id, accessToken, vercelTeamID); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- fixes #5616
- deletes existing log drains before creating new ones (confirmed via API spec and testing that only Highlight-owned log drains are listed and able to be deleted)
- creates separate log drains for each Highlight project
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally, validated the resulting log drains via the GET log-drains API
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
