### PR TITLE
track identify metadata in mixpanel

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -95,6 +95,9 @@ const options: HighlightOptions = {
 		amplitude: {
 			apiKey: 'fb83ae15d6122ef1b3f0ecdaa3393fea',
 		},
+		mixpanel: {
+			projectToken: 'e70039b6a5b93e7c86b8afb02b6d2300',
+		},
 	},
 	enableSegmentIntegration: true,
 	enableCanvasRecording: true,

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -296,3 +296,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 ### Patch Changes
 
 - Remove any properties that throw a `structuredClone` error in `addProperties` before calling `postMessage`
+
+## 7.3.6
+
+### Patch Changes
+
+- Track identify metadata in the mixpanel integration as a tracked event.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.3.5",
+	"version": "7.3.6",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.3.5"
+export default "7.3.6"

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -284,7 +284,15 @@ const H: HighlightPublicInterface = {
 		}
 		if (!H.options?.integrations?.mixpanel?.disabled) {
 			if (window.mixpanel?.identify) {
-				window.mixpanel.identify(identifier)
+				window.mixpanel.identify(
+					typeof metadata?.email === 'string'
+						? metadata?.email
+						: identifier,
+				)
+				if (metadata) {
+					window.mixpanel.track('identify', metadata)
+					window.mixpanel.people.set(metadata)
+				}
 			}
 		}
 

--- a/sdk/firstload/src/integrations/mixpanel.ts
+++ b/sdk/firstload/src/integrations/mixpanel.ts
@@ -88,8 +88,13 @@ export const setupMixpanelIntegration: Integration = ({
 
 const MixpanelBundle = 'https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js'
 
+export interface MixpanelPeopleAPI {
+	set: (metadata: { [k: string]: any }) => void
+}
+
 export interface MixpanelAPI {
 	init: (token: string, config?: any, name?: string) => void
 	track: (event_name: string, properties?: any, options?: any) => void
 	identify: (unique_id: string) => void
+	people: MixpanelPeopleAPI
 }


### PR DESCRIPTION
## Summary

When the mixpanel integration is enabled, forward the `H.identify` metadata to mixpanel
using the `mixpanel.people` [api](https://github.com/mixpanel/mixpanel-js/blob/master/doc/readme.io/javascript-full-api-reference.md#mixpanelpeople).
This change also send an `identify` event to mixpanel when `H.identify` is called.
If an `email` key is provided to the metadata, that value is used instead of the `identifier` to mimic
the `H.identify` behavior in the highlight app.

## How did you test this change?

Enabling mixpanel integration in a local deploy.

## Are there any deployment considerations?

New version `7.3.6`.