### PR TITLE
reverse arrows order when traversing error instances

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/PreviousNextInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/PreviousNextInstance.tsx
@@ -41,11 +41,11 @@ export const PreviousNextInstance = ({ data }: Props) => {
 
 	const errorInstance = data?.error_instance
 
-	useHotkeys(']', () => goToErrorInstance(errorInstance?.next_id, 'next'), [
+	useHotkeys('[', () => goToErrorInstance(errorInstance?.next_id, 'next'), [
 		errorInstance?.next_id,
 	])
 	useHotkeys(
-		'[',
+		']',
 		() => goToErrorInstance(errorInstance?.previous_id, 'previous'),
 		[errorInstance?.previous_id],
 	)
@@ -53,17 +53,17 @@ export const PreviousNextInstance = ({ data }: Props) => {
 	return (
 		<PreviousNextGroup
 			canMoveBackward={
-				!!errorInstance && Number(errorInstance.previous_id) !== 0
+				!!errorInstance && Number(errorInstance.next_id) !== 0
 			}
 			canMoveForward={
-				!!errorInstance && Number(errorInstance.next_id) !== 0
+				!!errorInstance && Number(errorInstance.previous_id) !== 0
 			}
 			prevShortcut="["
 			nextShortcut="]"
-			onPrev={() =>
+			onPrev={() => goToErrorInstance(errorInstance?.next_id, 'next')}
+			onNext={() =>
 				goToErrorInstance(errorInstance?.previous_id, 'previous')
 			}
-			onNext={() => goToErrorInstance(errorInstance?.next_id, 'next')}
 			size="medium"
 		/>
 	)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

See https://github.com/highlight/highlight/pull/5774#pullrequestreview-1505733636

This PR reverses the order for the arrows to traverse error instances.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed the following:

* Down arrow means "go to the next older instance"
* Up arrow means "go to the next newer instance"

* Up arrow is disabled when on the latest instance
* Down arrow is disabled when on the oldest instance

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
