### PR TITLE
filter out firefox extension errors

### DIFF
--- a/backend/errorgroups/filtering.go
+++ b/backend/errorgroups/filtering.go
@@ -13,13 +13,17 @@ func IsErrorTraceFiltered(project model.Project, structuredStackTrace []*private
 		return false
 	}
 
-	hasChromeExtensionFrame := lo.SomeBy(structuredStackTrace, func(frame *privateModel.ErrorTrace) bool {
-		return IsFrameChromeExtension(*frame)
+	hasBrowserExtensionFrame := lo.SomeBy(structuredStackTrace, func(frame *privateModel.ErrorTrace) bool {
+		return IsFrameChromeExtension(*frame) || IsFrameFirefoxExtension(*frame)
 	})
 
-	return hasChromeExtensionFrame
+	return hasBrowserExtensionFrame
 }
 
 func IsFrameChromeExtension(frame privateModel.ErrorTrace) bool {
 	return frame.FileName != nil && strings.HasPrefix(*frame.FileName, "chrome-extension")
+}
+
+func IsFrameFirefoxExtension(frame privateModel.ErrorTrace) bool {
+	return frame.FileName != nil && strings.HasPrefix(*frame.FileName, "moz-extension")
 }

--- a/backend/errorgroups/filtering_test.go
+++ b/backend/errorgroups/filtering_test.go
@@ -24,14 +24,59 @@ func TestIsErrorTraceFilteredForChromeExtension(t *testing.T) {
 		},
 	}
 
-	// Disabling chrome extension filtering
+	// Disabling browser extension filtering
 	project := model.Project{
 		FilterChromeExtension: ptr.Bool(false),
 	}
 
 	assert.False(t, IsErrorTraceFiltered(project, chromeTrace))
 
-	// Enabling chrome extension filtering
+	// Enabling browser extension filtering
+	project = model.Project{
+		FilterChromeExtension: ptr.Bool(true),
+	}
+	assert.True(t, IsErrorTraceFiltered(project, chromeTrace))
+
+	nonChromeTrace := []*privateModel.ErrorTrace{
+		{
+			FileName:                   ptr.String("/build/backend/private-graph/graph/schema.resolvers.go"),
+			LineNumber:                 nil,
+			FunctionName:               nil,
+			ColumnNumber:               nil,
+			Error:                      nil,
+			SourceMappingErrorMetadata: &privateModel.SourceMappingError{},
+			LineContent:                nil,
+			LinesBefore:                nil,
+			LinesAfter:                 nil,
+		},
+	}
+
+	assert.False(t, IsErrorTraceFiltered(project, nonChromeTrace))
+}
+
+func TestIsErrorTraceFilteredForFirefoxExtension(t *testing.T) {
+	chromeTrace := []*privateModel.ErrorTrace{
+		{
+			FileName:                   ptr.String("moz-extension://bfnaelmomeimhlpmgjnjophhpkkoljpa/content-script/inpageSol.js"),
+			LineNumber:                 nil,
+			FunctionName:               nil,
+			ColumnNumber:               nil,
+			Error:                      nil,
+			SourceMappingErrorMetadata: &privateModel.SourceMappingError{},
+			LineContent:                nil,
+			LinesBefore:                nil,
+			LinesAfter:                 nil,
+		},
+	}
+
+	// Disabling browser extension filtering
+	project := model.Project{
+		FilterChromeExtension: ptr.Bool(false),
+	}
+
+	assert.False(t, IsErrorTraceFiltered(project, chromeTrace))
+
+	// Enabling browser extension filtering
 	project = model.Project{
 		FilterChromeExtension: ptr.Bool(true),
 	}

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -341,6 +341,7 @@ type Project struct {
 	// Minimum count of clicks in a rage click event
 	RageClickCount int `gorm:"default:5"`
 
+	// Applies to all browser extensions
 	FilterChromeExtension *bool `gorm:"default:false"`
 }
 

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -342,6 +342,7 @@ type Project struct {
 	RageClickCount int `gorm:"default:5"`
 
 	// Applies to all browser extensions
+	// TODO - rename to FilterBrowserExtension #5811
 	FilterChromeExtension *bool `gorm:"default:false"`
 }
 

--- a/docs-content/general/6_product-features/2_error-monitoring/ignoring-errors.md
+++ b/docs-content/general/6_product-features/2_error-monitoring/ignoring-errors.md
@@ -9,8 +9,8 @@ updatedAt: 2022-06-27T03:34:47.000Z
 
 There are several options for ignoring errors, all of which can be found in the "Error Monitoring" tab of your [project settings](https://app.highlight.io/settings). Details on each option are below.
 
-## Ignore errors emitted by Chrome extensions
-If your users are using Chrome extensions, you may see errors that are not relevant to your application. You can ignore these errors by checking the "Filter errors thrown by Chrome extensions" box in your [project settings](https://app.highlight.io/settings).
+## Ignore errors emitted by browser extensions
+If your users are using browser extensions, you may see errors that are not relevant to your application. You can ignore these errors by checking the "Filter errors thrown by browser extensions" box in your [project settings](https://app.highlight.io/settings).
 
 ## Ignoring error groups from alerts
 If you have alerts set up for your project, you can ignore specific error groups from triggering alerts. You can do this by clicking the "Ignore" button on the error group page.

--- a/frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx
+++ b/frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx
@@ -29,7 +29,7 @@ export const FilterExtensionForm = () => {
 	const categories = [
 		{
 			key: 'Extension errors',
-			message: 'Filter out errors thrown by chrome extensions',
+			message: 'Filter out errors thrown by browser extensions',
 			checked: filterChromeExtension,
 		},
 	]


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR filters out Firefox extension errors. See #5610
Rather than creating a new setting for this, we decided to overload the existing setting for filtering Chrome extension errors and now we filter for all browser errors.

<img width="634" alt="Screenshot 2023-07-03 at 2 40 12 PM" src="https://github.com/highlight/highlight/assets/58678/b56e9088-f41d-4bf0-a071-e3789e14b0c8">

This sets us up for adding additional functionality (like filtering for Safari extension errors).


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Unfortunately, I still have not been able to replicate this behavior, but I did find an example of the error on prod (see #5606) and I wrote a unit test around it.


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

I've tracked #5811 to handle renaming the db column.