### PR TITLE
attach error group secure id to error objects request

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -420,10 +420,11 @@ type ComplexityRoot struct {
 	}
 
 	ErrorObjectNode struct {
-		CreatedAt func(childComplexity int) int
-		Event     func(childComplexity int) int
-		ID        func(childComplexity int) int
-		Session   func(childComplexity int) int
+		CreatedAt          func(childComplexity int) int
+		ErrorGroupSecureID func(childComplexity int) int
+		Event              func(childComplexity int) int
+		ID                 func(childComplexity int) int
+		Session            func(childComplexity int) int
 	}
 
 	ErrorObjectNodeSession struct {
@@ -3289,6 +3290,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ErrorObjectNode.CreatedAt(childComplexity), true
+
+	case "ErrorObjectNode.errorGroupSecureID":
+		if e.complexity.ErrorObjectNode.ErrorGroupSecureID == nil {
+			break
+		}
+
+		return e.complexity.ErrorObjectNode.ErrorGroupSecureID(childComplexity), true
 
 	case "ErrorObjectNode.event":
 		if e.complexity.ErrorObjectNode.Event == nil {
@@ -9307,6 +9315,7 @@ type ErrorObjectNode {
 	createdAt: Timestamp!
 	event: String!
 	session: ErrorObjectNodeSession
+	errorGroupSecureID: String!
 }
 
 type ErrorObjectEdge implements Edge {
@@ -27316,6 +27325,8 @@ func (ec *executionContext) fieldContext_ErrorObjectEdge_node(ctx context.Contex
 				return ec.fieldContext_ErrorObjectNode_event(ctx, field)
 			case "session":
 				return ec.fieldContext_ErrorObjectNode_session(ctx, field)
+			case "errorGroupSecureID":
+				return ec.fieldContext_ErrorObjectNode_errorGroupSecureID(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorObjectNode", field.Name)
 		},
@@ -27499,6 +27510,50 @@ func (ec *executionContext) fieldContext_ErrorObjectNode_session(ctx context.Con
 				return ec.fieldContext_ErrorObjectNodeSession_appVersion(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorObjectNodeSession", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ErrorObjectNode_errorGroupSecureID(ctx context.Context, field graphql.CollectedField, obj *model.ErrorObjectNode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ErrorObjectNode_errorGroupSecureID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ErrorGroupSecureID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ErrorObjectNode_errorGroupSecureID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ErrorObjectNode",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -65586,6 +65641,13 @@ func (ec *executionContext) _ErrorObjectNode(ctx context.Context, sel ast.Select
 
 			out.Values[i] = ec._ErrorObjectNode_session(ctx, field, obj)
 
+		case "errorGroupSecureID":
+
+			out.Values[i] = ec._ErrorObjectNode_errorGroupSecureID(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -316,10 +316,11 @@ func (ErrorObjectEdge) IsEdge()                {}
 func (this ErrorObjectEdge) GetCursor() string { return this.Cursor }
 
 type ErrorObjectNode struct {
-	ID        int                     `json:"id"`
-	CreatedAt time.Time               `json:"createdAt"`
-	Event     string                  `json:"event"`
-	Session   *ErrorObjectNodeSession `json:"session"`
+	ID                 int                     `json:"id"`
+	CreatedAt          time.Time               `json:"createdAt"`
+	Event              string                  `json:"event"`
+	Session            *ErrorObjectNodeSession `json:"session"`
+	ErrorGroupSecureID string                  `json:"errorGroupSecureID"`
 }
 
 type ErrorObjectNodeSession struct {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -619,6 +619,7 @@ type ErrorObjectNode {
 	createdAt: Timestamp!
 	event: String!
 	session: ErrorObjectNodeSession
+	errorGroupSecureID: String!
 }
 
 type ErrorObjectEdge implements Edge {

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -85,9 +85,10 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 		edge := &privateModel.ErrorObjectEdge{
 			Cursor: strconv.Itoa(errorObject.ID),
 			Node: &privateModel.ErrorObjectNode{
-				ID:        errorObject.ID,
-				CreatedAt: errorObject.CreatedAt,
-				Event:     errorObject.Event,
+				ID:                 errorObject.ID,
+				CreatedAt:          errorObject.CreatedAt,
+				Event:              errorObject.Event,
+				ErrorGroupSecureID: errorGroup.SecureID,
 			},
 		}
 

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -54,6 +54,7 @@ func TestListErrorObjectsOneObjectNoSession(t *testing.T) {
 		assert.Equal(t, errorObject.ID, edge.Node.ID)
 		assert.WithinDuration(t, errorObject.CreatedAt, edge.Node.CreatedAt, 10*time.Second)
 		assert.Equal(t, errorObject.Event, edge.Node.Event)
+		assert.Equal(t, errorGroup.SecureID, edge.Node.ErrorGroupSecureID)
 		assert.Nil(t, edge.Node.Session)
 
 		assert.Equal(t, &privateModel.PageInfo{
@@ -101,6 +102,7 @@ func TestListErrorObjectsOneObjectWithSession(t *testing.T) {
 		assert.Equal(t, errorObject.ID, edge.Node.ID)
 		assert.WithinDuration(t, errorObject.CreatedAt, edge.Node.CreatedAt, 10*time.Second)
 		assert.Equal(t, errorObject.Event, edge.Node.Event)
+		assert.Equal(t, errorGroup.SecureID, edge.Node.ErrorGroupSecureID)
 		assert.Equal(t, &privateModel.ErrorObjectNodeSession{
 			SecureID:       session.SecureID,
 			UserProperties: session.UserProperties,

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -1,167 +1,177 @@
-import * as Types from './operations';
+import * as Types from './operations'
 
-import { gql } from '@apollo/client';
-import * as Apollo from '@apollo/client';
+import { gql } from '@apollo/client'
+import * as Apollo from '@apollo/client'
 export const SessionPayloadFragmentFragmentDoc = gql`
-    fragment SessionPayloadFragment on SessionPayload {
-  events
-  errors {
-    id
-    error_group_secure_id
-    event
-    type
-    url
-    source
-    stack_trace
-    structured_stack_trace {
-      fileName
-      lineNumber
-      functionName
-      columnNumber
-    }
-    timestamp
-    payload
-    request_id
-  }
-  rage_clicks {
-    start_timestamp
-    end_timestamp
-    total_clicks
-  }
-  session_comments {
-    id
-    timestamp
-    session_id
-    session_secure_id
-    created_at
-    updated_at
-    project_id
-    text
-    author {
-      id
-      name
-      email
-      photo_url
-    }
-    attachments {
-      integration_type
-      external_id
-      title
-    }
-    x_coordinate
-    y_coordinate
-    type
-    metadata
-  }
-  last_user_interaction_time
-}
-    `;
+	fragment SessionPayloadFragment on SessionPayload {
+		events
+		errors {
+			id
+			error_group_secure_id
+			event
+			type
+			url
+			source
+			stack_trace
+			structured_stack_trace {
+				fileName
+				lineNumber
+				functionName
+				columnNumber
+			}
+			timestamp
+			payload
+			request_id
+		}
+		rage_clicks {
+			start_timestamp
+			end_timestamp
+			total_clicks
+		}
+		session_comments {
+			id
+			timestamp
+			session_id
+			session_secure_id
+			created_at
+			updated_at
+			project_id
+			text
+			author {
+				id
+				name
+				email
+				photo_url
+			}
+			attachments {
+				integration_type
+				external_id
+				title
+			}
+			x_coordinate
+			y_coordinate
+			type
+			metadata
+		}
+		last_user_interaction_time
+	}
+`
 export const DiscordChannelFragmentFragmentDoc = gql`
-    fragment DiscordChannelFragment on DiscordChannel {
-  name
-  id
-}
-    `;
+	fragment DiscordChannelFragment on DiscordChannel {
+		name
+		id
+	}
+`
 export const SessionAlertFragmentFragmentDoc = gql`
-    fragment SessionAlertFragment on SessionAlert {
-  ChannelsToNotify {
-    webhook_channel
-    webhook_channel_id
-  }
-  DiscordChannelsToNotify {
-    ...DiscordChannelFragment
-  }
-  CountThreshold
-  DailyFrequency
-  disabled
-  EmailsToNotify
-  ExcludedEnvironments
-  ExcludeRules
-  id
-  LastAdminToEditID
-  Name
-  updated_at
-  ThresholdWindow
-  TrackProperties {
-    id
-    name
-    value
-  }
-  Type
-}
-    ${DiscordChannelFragmentFragmentDoc}`;
+	fragment SessionAlertFragment on SessionAlert {
+		ChannelsToNotify {
+			webhook_channel
+			webhook_channel_id
+		}
+		DiscordChannelsToNotify {
+			...DiscordChannelFragment
+		}
+		CountThreshold
+		DailyFrequency
+		disabled
+		EmailsToNotify
+		ExcludedEnvironments
+		ExcludeRules
+		id
+		LastAdminToEditID
+		Name
+		updated_at
+		ThresholdWindow
+		TrackProperties {
+			id
+			name
+			value
+		}
+		Type
+	}
+	${DiscordChannelFragmentFragmentDoc}
+`
 export const ErrorObjectFragmentDoc = gql`
-    fragment ErrorObject on ErrorObject {
-  id
-  created_at
-  project_id
-  session_id
-  trace_id
-  span_id
-  log_cursor
-  session {
-    identifier
-    fingerprint
-    secure_id
-    city
-    state
-    country
-    user_properties
-    processed
-    excluded
-    excluded_reason
-  }
-  error_group_id
-  error_group_secure_id
-  event
-  type
-  url
-  source
-  lineNumber
-  columnNumber
-  stack_trace
-  structured_stack_trace {
-    fileName
-    lineNumber
-    functionName
-    columnNumber
-    lineContent
-    linesBefore
-    linesAfter
-    error
-    sourceMappingErrorMetadata {
-      errorCode
-      stackTraceFileURL
-      sourcemapFetchStrategy
-      sourceMapURL
-      minifiedFetchStrategy
-      actualMinifiedFetchedPath
-      minifiedLineNumber
-      minifiedColumnNumber
-      actualSourcemapFetchedPath
-      sourcemapFileSize
-      minifiedFileSize
-      mappedLineNumber
-      mappedColumnNumber
-    }
-  }
-  timestamp
-  payload
-  request_id
-  os
-  browser
-  environment
-}
-    `;
+	fragment ErrorObject on ErrorObject {
+		id
+		created_at
+		project_id
+		session_id
+		trace_id
+		span_id
+		log_cursor
+		session {
+			identifier
+			fingerprint
+			secure_id
+			city
+			state
+			country
+			user_properties
+			processed
+			excluded
+			excluded_reason
+		}
+		error_group_id
+		error_group_secure_id
+		event
+		type
+		url
+		source
+		lineNumber
+		columnNumber
+		stack_trace
+		structured_stack_trace {
+			fileName
+			lineNumber
+			functionName
+			columnNumber
+			lineContent
+			linesBefore
+			linesAfter
+			error
+			sourceMappingErrorMetadata {
+				errorCode
+				stackTraceFileURL
+				sourcemapFetchStrategy
+				sourceMapURL
+				minifiedFetchStrategy
+				actualMinifiedFetchedPath
+				minifiedLineNumber
+				minifiedColumnNumber
+				actualSourcemapFetchedPath
+				sourcemapFileSize
+				minifiedFileSize
+				mappedLineNumber
+				mappedColumnNumber
+			}
+		}
+		timestamp
+		payload
+		request_id
+		os
+		browser
+		environment
+	}
+`
 export const MarkErrorGroupAsViewedDocument = gql`
-    mutation MarkErrorGroupAsViewed($error_secure_id: String!, $viewed: Boolean!) {
-  markErrorGroupAsViewed(error_secure_id: $error_secure_id, viewed: $viewed) {
-    secure_id
-    viewed
-  }
-}
-    `;
-export type MarkErrorGroupAsViewedMutationFn = Apollo.MutationFunction<Types.MarkErrorGroupAsViewedMutation, Types.MarkErrorGroupAsViewedMutationVariables>;
+	mutation MarkErrorGroupAsViewed(
+		$error_secure_id: String!
+		$viewed: Boolean!
+	) {
+		markErrorGroupAsViewed(
+			error_secure_id: $error_secure_id
+			viewed: $viewed
+		) {
+			secure_id
+			viewed
+		}
+	}
+`
+export type MarkErrorGroupAsViewedMutationFn = Apollo.MutationFunction<
+	Types.MarkErrorGroupAsViewedMutation,
+	Types.MarkErrorGroupAsViewedMutationVariables
+>
 
 /**
  * __useMarkErrorGroupAsViewedMutation__
@@ -181,21 +191,38 @@ export type MarkErrorGroupAsViewedMutationFn = Apollo.MutationFunction<Types.Mar
  *   },
  * });
  */
-export function useMarkErrorGroupAsViewedMutation(baseOptions?: Apollo.MutationHookOptions<Types.MarkErrorGroupAsViewedMutation, Types.MarkErrorGroupAsViewedMutationVariables>) {
-        return Apollo.useMutation<Types.MarkErrorGroupAsViewedMutation, Types.MarkErrorGroupAsViewedMutationVariables>(MarkErrorGroupAsViewedDocument, baseOptions);
-      }
-export type MarkErrorGroupAsViewedMutationHookResult = ReturnType<typeof useMarkErrorGroupAsViewedMutation>;
-export type MarkErrorGroupAsViewedMutationResult = Apollo.MutationResult<Types.MarkErrorGroupAsViewedMutation>;
-export type MarkErrorGroupAsViewedMutationOptions = Apollo.BaseMutationOptions<Types.MarkErrorGroupAsViewedMutation, Types.MarkErrorGroupAsViewedMutationVariables>;
-export const MarkSessionAsViewedDocument = gql`
-    mutation MarkSessionAsViewed($secure_id: String!, $viewed: Boolean!) {
-  markSessionAsViewed(secure_id: $secure_id, viewed: $viewed) {
-    secure_id
-    viewed
-  }
+export function useMarkErrorGroupAsViewedMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.MarkErrorGroupAsViewedMutation,
+		Types.MarkErrorGroupAsViewedMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.MarkErrorGroupAsViewedMutation,
+		Types.MarkErrorGroupAsViewedMutationVariables
+	>(MarkErrorGroupAsViewedDocument, baseOptions)
 }
-    `;
-export type MarkSessionAsViewedMutationFn = Apollo.MutationFunction<Types.MarkSessionAsViewedMutation, Types.MarkSessionAsViewedMutationVariables>;
+export type MarkErrorGroupAsViewedMutationHookResult = ReturnType<
+	typeof useMarkErrorGroupAsViewedMutation
+>
+export type MarkErrorGroupAsViewedMutationResult =
+	Apollo.MutationResult<Types.MarkErrorGroupAsViewedMutation>
+export type MarkErrorGroupAsViewedMutationOptions = Apollo.BaseMutationOptions<
+	Types.MarkErrorGroupAsViewedMutation,
+	Types.MarkErrorGroupAsViewedMutationVariables
+>
+export const MarkSessionAsViewedDocument = gql`
+	mutation MarkSessionAsViewed($secure_id: String!, $viewed: Boolean!) {
+		markSessionAsViewed(secure_id: $secure_id, viewed: $viewed) {
+			secure_id
+			viewed
+		}
+	}
+`
+export type MarkSessionAsViewedMutationFn = Apollo.MutationFunction<
+	Types.MarkSessionAsViewedMutation,
+	Types.MarkSessionAsViewedMutationVariables
+>
 
 /**
  * __useMarkSessionAsViewedMutation__
@@ -215,21 +242,38 @@ export type MarkSessionAsViewedMutationFn = Apollo.MutationFunction<Types.MarkSe
  *   },
  * });
  */
-export function useMarkSessionAsViewedMutation(baseOptions?: Apollo.MutationHookOptions<Types.MarkSessionAsViewedMutation, Types.MarkSessionAsViewedMutationVariables>) {
-        return Apollo.useMutation<Types.MarkSessionAsViewedMutation, Types.MarkSessionAsViewedMutationVariables>(MarkSessionAsViewedDocument, baseOptions);
-      }
-export type MarkSessionAsViewedMutationHookResult = ReturnType<typeof useMarkSessionAsViewedMutation>;
-export type MarkSessionAsViewedMutationResult = Apollo.MutationResult<Types.MarkSessionAsViewedMutation>;
-export type MarkSessionAsViewedMutationOptions = Apollo.BaseMutationOptions<Types.MarkSessionAsViewedMutation, Types.MarkSessionAsViewedMutationVariables>;
-export const MarkSessionAsStarredDocument = gql`
-    mutation MarkSessionAsStarred($secure_id: String!, $starred: Boolean!) {
-  markSessionAsStarred(secure_id: $secure_id, starred: $starred) {
-    secure_id
-    starred
-  }
+export function useMarkSessionAsViewedMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.MarkSessionAsViewedMutation,
+		Types.MarkSessionAsViewedMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.MarkSessionAsViewedMutation,
+		Types.MarkSessionAsViewedMutationVariables
+	>(MarkSessionAsViewedDocument, baseOptions)
 }
-    `;
-export type MarkSessionAsStarredMutationFn = Apollo.MutationFunction<Types.MarkSessionAsStarredMutation, Types.MarkSessionAsStarredMutationVariables>;
+export type MarkSessionAsViewedMutationHookResult = ReturnType<
+	typeof useMarkSessionAsViewedMutation
+>
+export type MarkSessionAsViewedMutationResult =
+	Apollo.MutationResult<Types.MarkSessionAsViewedMutation>
+export type MarkSessionAsViewedMutationOptions = Apollo.BaseMutationOptions<
+	Types.MarkSessionAsViewedMutation,
+	Types.MarkSessionAsViewedMutationVariables
+>
+export const MarkSessionAsStarredDocument = gql`
+	mutation MarkSessionAsStarred($secure_id: String!, $starred: Boolean!) {
+		markSessionAsStarred(secure_id: $secure_id, starred: $starred) {
+			secure_id
+			starred
+		}
+	}
+`
+export type MarkSessionAsStarredMutationFn = Apollo.MutationFunction<
+	Types.MarkSessionAsStarredMutation,
+	Types.MarkSessionAsStarredMutationVariables
+>
 
 /**
  * __useMarkSessionAsStarredMutation__
@@ -249,18 +293,35 @@ export type MarkSessionAsStarredMutationFn = Apollo.MutationFunction<Types.MarkS
  *   },
  * });
  */
-export function useMarkSessionAsStarredMutation(baseOptions?: Apollo.MutationHookOptions<Types.MarkSessionAsStarredMutation, Types.MarkSessionAsStarredMutationVariables>) {
-        return Apollo.useMutation<Types.MarkSessionAsStarredMutation, Types.MarkSessionAsStarredMutationVariables>(MarkSessionAsStarredDocument, baseOptions);
-      }
-export type MarkSessionAsStarredMutationHookResult = ReturnType<typeof useMarkSessionAsStarredMutation>;
-export type MarkSessionAsStarredMutationResult = Apollo.MutationResult<Types.MarkSessionAsStarredMutation>;
-export type MarkSessionAsStarredMutationOptions = Apollo.BaseMutationOptions<Types.MarkSessionAsStarredMutation, Types.MarkSessionAsStarredMutationVariables>;
-export const MuteSessionCommentThreadDocument = gql`
-    mutation MuteSessionCommentThread($id: ID!, $has_muted: Boolean) {
-  muteSessionCommentThread(id: $id, has_muted: $has_muted)
+export function useMarkSessionAsStarredMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.MarkSessionAsStarredMutation,
+		Types.MarkSessionAsStarredMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.MarkSessionAsStarredMutation,
+		Types.MarkSessionAsStarredMutationVariables
+	>(MarkSessionAsStarredDocument, baseOptions)
 }
-    `;
-export type MuteSessionCommentThreadMutationFn = Apollo.MutationFunction<Types.MuteSessionCommentThreadMutation, Types.MuteSessionCommentThreadMutationVariables>;
+export type MarkSessionAsStarredMutationHookResult = ReturnType<
+	typeof useMarkSessionAsStarredMutation
+>
+export type MarkSessionAsStarredMutationResult =
+	Apollo.MutationResult<Types.MarkSessionAsStarredMutation>
+export type MarkSessionAsStarredMutationOptions = Apollo.BaseMutationOptions<
+	Types.MarkSessionAsStarredMutation,
+	Types.MarkSessionAsStarredMutationVariables
+>
+export const MuteSessionCommentThreadDocument = gql`
+	mutation MuteSessionCommentThread($id: ID!, $has_muted: Boolean) {
+		muteSessionCommentThread(id: $id, has_muted: $has_muted)
+	}
+`
+export type MuteSessionCommentThreadMutationFn = Apollo.MutationFunction<
+	Types.MuteSessionCommentThreadMutation,
+	Types.MuteSessionCommentThreadMutationVariables
+>
 
 /**
  * __useMuteSessionCommentThreadMutation__
@@ -280,23 +341,47 @@ export type MuteSessionCommentThreadMutationFn = Apollo.MutationFunction<Types.M
  *   },
  * });
  */
-export function useMuteSessionCommentThreadMutation(baseOptions?: Apollo.MutationHookOptions<Types.MuteSessionCommentThreadMutation, Types.MuteSessionCommentThreadMutationVariables>) {
-        return Apollo.useMutation<Types.MuteSessionCommentThreadMutation, Types.MuteSessionCommentThreadMutationVariables>(MuteSessionCommentThreadDocument, baseOptions);
-      }
-export type MuteSessionCommentThreadMutationHookResult = ReturnType<typeof useMuteSessionCommentThreadMutation>;
-export type MuteSessionCommentThreadMutationResult = Apollo.MutationResult<Types.MuteSessionCommentThreadMutation>;
-export type MuteSessionCommentThreadMutationOptions = Apollo.BaseMutationOptions<Types.MuteSessionCommentThreadMutation, Types.MuteSessionCommentThreadMutationVariables>;
-export const CreateOrUpdateStripeSubscriptionDocument = gql`
-    mutation CreateOrUpdateStripeSubscription($workspace_id: ID!, $plan_type: PlanType!, $interval: SubscriptionInterval!, $retention_period: RetentionPeriod!) {
-  createOrUpdateStripeSubscription(
-    workspace_id: $workspace_id
-    plan_type: $plan_type
-    interval: $interval
-    retention_period: $retention_period
-  )
+export function useMuteSessionCommentThreadMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.MuteSessionCommentThreadMutation,
+		Types.MuteSessionCommentThreadMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.MuteSessionCommentThreadMutation,
+		Types.MuteSessionCommentThreadMutationVariables
+	>(MuteSessionCommentThreadDocument, baseOptions)
 }
-    `;
-export type CreateOrUpdateStripeSubscriptionMutationFn = Apollo.MutationFunction<Types.CreateOrUpdateStripeSubscriptionMutation, Types.CreateOrUpdateStripeSubscriptionMutationVariables>;
+export type MuteSessionCommentThreadMutationHookResult = ReturnType<
+	typeof useMuteSessionCommentThreadMutation
+>
+export type MuteSessionCommentThreadMutationResult =
+	Apollo.MutationResult<Types.MuteSessionCommentThreadMutation>
+export type MuteSessionCommentThreadMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.MuteSessionCommentThreadMutation,
+		Types.MuteSessionCommentThreadMutationVariables
+	>
+export const CreateOrUpdateStripeSubscriptionDocument = gql`
+	mutation CreateOrUpdateStripeSubscription(
+		$workspace_id: ID!
+		$plan_type: PlanType!
+		$interval: SubscriptionInterval!
+		$retention_period: RetentionPeriod!
+	) {
+		createOrUpdateStripeSubscription(
+			workspace_id: $workspace_id
+			plan_type: $plan_type
+			interval: $interval
+			retention_period: $retention_period
+		)
+	}
+`
+export type CreateOrUpdateStripeSubscriptionMutationFn =
+	Apollo.MutationFunction<
+		Types.CreateOrUpdateStripeSubscriptionMutation,
+		Types.CreateOrUpdateStripeSubscriptionMutationVariables
+	>
 
 /**
  * __useCreateOrUpdateStripeSubscriptionMutation__
@@ -318,26 +403,52 @@ export type CreateOrUpdateStripeSubscriptionMutationFn = Apollo.MutationFunction
  *   },
  * });
  */
-export function useCreateOrUpdateStripeSubscriptionMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateOrUpdateStripeSubscriptionMutation, Types.CreateOrUpdateStripeSubscriptionMutationVariables>) {
-        return Apollo.useMutation<Types.CreateOrUpdateStripeSubscriptionMutation, Types.CreateOrUpdateStripeSubscriptionMutationVariables>(CreateOrUpdateStripeSubscriptionDocument, baseOptions);
-      }
-export type CreateOrUpdateStripeSubscriptionMutationHookResult = ReturnType<typeof useCreateOrUpdateStripeSubscriptionMutation>;
-export type CreateOrUpdateStripeSubscriptionMutationResult = Apollo.MutationResult<Types.CreateOrUpdateStripeSubscriptionMutation>;
-export type CreateOrUpdateStripeSubscriptionMutationOptions = Apollo.BaseMutationOptions<Types.CreateOrUpdateStripeSubscriptionMutation, Types.CreateOrUpdateStripeSubscriptionMutationVariables>;
-export const SaveBillingPlanDocument = gql`
-    mutation SaveBillingPlan($workspace_id: ID!, $sessionsLimitCents: Int, $sessionsRetention: RetentionPeriod!, $errorsLimitCents: Int, $errorsRetention: RetentionPeriod!, $logsLimitCents: Int, $logsRetention: RetentionPeriod!) {
-  saveBillingPlan(
-    workspace_id: $workspace_id
-    sessionsLimitCents: $sessionsLimitCents
-    sessionsRetention: $sessionsRetention
-    errorsLimitCents: $errorsLimitCents
-    errorsRetention: $errorsRetention
-    logsLimitCents: $logsLimitCents
-    logsRetention: $logsRetention
-  )
+export function useCreateOrUpdateStripeSubscriptionMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateOrUpdateStripeSubscriptionMutation,
+		Types.CreateOrUpdateStripeSubscriptionMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateOrUpdateStripeSubscriptionMutation,
+		Types.CreateOrUpdateStripeSubscriptionMutationVariables
+	>(CreateOrUpdateStripeSubscriptionDocument, baseOptions)
 }
-    `;
-export type SaveBillingPlanMutationFn = Apollo.MutationFunction<Types.SaveBillingPlanMutation, Types.SaveBillingPlanMutationVariables>;
+export type CreateOrUpdateStripeSubscriptionMutationHookResult = ReturnType<
+	typeof useCreateOrUpdateStripeSubscriptionMutation
+>
+export type CreateOrUpdateStripeSubscriptionMutationResult =
+	Apollo.MutationResult<Types.CreateOrUpdateStripeSubscriptionMutation>
+export type CreateOrUpdateStripeSubscriptionMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.CreateOrUpdateStripeSubscriptionMutation,
+		Types.CreateOrUpdateStripeSubscriptionMutationVariables
+	>
+export const SaveBillingPlanDocument = gql`
+	mutation SaveBillingPlan(
+		$workspace_id: ID!
+		$sessionsLimitCents: Int
+		$sessionsRetention: RetentionPeriod!
+		$errorsLimitCents: Int
+		$errorsRetention: RetentionPeriod!
+		$logsLimitCents: Int
+		$logsRetention: RetentionPeriod!
+	) {
+		saveBillingPlan(
+			workspace_id: $workspace_id
+			sessionsLimitCents: $sessionsLimitCents
+			sessionsRetention: $sessionsRetention
+			errorsLimitCents: $errorsLimitCents
+			errorsRetention: $errorsRetention
+			logsLimitCents: $logsLimitCents
+			logsRetention: $logsRetention
+		)
+	}
+`
+export type SaveBillingPlanMutationFn = Apollo.MutationFunction<
+	Types.SaveBillingPlanMutation,
+	Types.SaveBillingPlanMutationVariables
+>
 
 /**
  * __useSaveBillingPlanMutation__
@@ -362,18 +473,35 @@ export type SaveBillingPlanMutationFn = Apollo.MutationFunction<Types.SaveBillin
  *   },
  * });
  */
-export function useSaveBillingPlanMutation(baseOptions?: Apollo.MutationHookOptions<Types.SaveBillingPlanMutation, Types.SaveBillingPlanMutationVariables>) {
-        return Apollo.useMutation<Types.SaveBillingPlanMutation, Types.SaveBillingPlanMutationVariables>(SaveBillingPlanDocument, baseOptions);
-      }
-export type SaveBillingPlanMutationHookResult = ReturnType<typeof useSaveBillingPlanMutation>;
-export type SaveBillingPlanMutationResult = Apollo.MutationResult<Types.SaveBillingPlanMutation>;
-export type SaveBillingPlanMutationOptions = Apollo.BaseMutationOptions<Types.SaveBillingPlanMutation, Types.SaveBillingPlanMutationVariables>;
-export const UpdateBillingDetailsDocument = gql`
-    mutation UpdateBillingDetails($workspace_id: ID!) {
-  updateBillingDetails(workspace_id: $workspace_id)
+export function useSaveBillingPlanMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.SaveBillingPlanMutation,
+		Types.SaveBillingPlanMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.SaveBillingPlanMutation,
+		Types.SaveBillingPlanMutationVariables
+	>(SaveBillingPlanDocument, baseOptions)
 }
-    `;
-export type UpdateBillingDetailsMutationFn = Apollo.MutationFunction<Types.UpdateBillingDetailsMutation, Types.UpdateBillingDetailsMutationVariables>;
+export type SaveBillingPlanMutationHookResult = ReturnType<
+	typeof useSaveBillingPlanMutation
+>
+export type SaveBillingPlanMutationResult =
+	Apollo.MutationResult<Types.SaveBillingPlanMutation>
+export type SaveBillingPlanMutationOptions = Apollo.BaseMutationOptions<
+	Types.SaveBillingPlanMutation,
+	Types.SaveBillingPlanMutationVariables
+>
+export const UpdateBillingDetailsDocument = gql`
+	mutation UpdateBillingDetails($workspace_id: ID!) {
+		updateBillingDetails(workspace_id: $workspace_id)
+	}
+`
+export type UpdateBillingDetailsMutationFn = Apollo.MutationFunction<
+	Types.UpdateBillingDetailsMutation,
+	Types.UpdateBillingDetailsMutationVariables
+>
 
 /**
  * __useUpdateBillingDetailsMutation__
@@ -392,26 +520,47 @@ export type UpdateBillingDetailsMutationFn = Apollo.MutationFunction<Types.Updat
  *   },
  * });
  */
-export function useUpdateBillingDetailsMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateBillingDetailsMutation, Types.UpdateBillingDetailsMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateBillingDetailsMutation, Types.UpdateBillingDetailsMutationVariables>(UpdateBillingDetailsDocument, baseOptions);
-      }
-export type UpdateBillingDetailsMutationHookResult = ReturnType<typeof useUpdateBillingDetailsMutation>;
-export type UpdateBillingDetailsMutationResult = Apollo.MutationResult<Types.UpdateBillingDetailsMutation>;
-export type UpdateBillingDetailsMutationOptions = Apollo.BaseMutationOptions<Types.UpdateBillingDetailsMutation, Types.UpdateBillingDetailsMutationVariables>;
-export const UpdateErrorGroupStateDocument = gql`
-    mutation updateErrorGroupState($secure_id: String!, $state: ErrorState!, $snoozed_until: Timestamp) {
-  updateErrorGroupState(
-    secure_id: $secure_id
-    state: $state
-    snoozed_until: $snoozed_until
-  ) {
-    secure_id
-    state
-    snoozed_until
-  }
+export function useUpdateBillingDetailsMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateBillingDetailsMutation,
+		Types.UpdateBillingDetailsMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateBillingDetailsMutation,
+		Types.UpdateBillingDetailsMutationVariables
+	>(UpdateBillingDetailsDocument, baseOptions)
 }
-    `;
-export type UpdateErrorGroupStateMutationFn = Apollo.MutationFunction<Types.UpdateErrorGroupStateMutation, Types.UpdateErrorGroupStateMutationVariables>;
+export type UpdateBillingDetailsMutationHookResult = ReturnType<
+	typeof useUpdateBillingDetailsMutation
+>
+export type UpdateBillingDetailsMutationResult =
+	Apollo.MutationResult<Types.UpdateBillingDetailsMutation>
+export type UpdateBillingDetailsMutationOptions = Apollo.BaseMutationOptions<
+	Types.UpdateBillingDetailsMutation,
+	Types.UpdateBillingDetailsMutationVariables
+>
+export const UpdateErrorGroupStateDocument = gql`
+	mutation updateErrorGroupState(
+		$secure_id: String!
+		$state: ErrorState!
+		$snoozed_until: Timestamp
+	) {
+		updateErrorGroupState(
+			secure_id: $secure_id
+			state: $state
+			snoozed_until: $snoozed_until
+		) {
+			secure_id
+			state
+			snoozed_until
+		}
+	}
+`
+export type UpdateErrorGroupStateMutationFn = Apollo.MutationFunction<
+	Types.UpdateErrorGroupStateMutation,
+	Types.UpdateErrorGroupStateMutationVariables
+>
 
 /**
  * __useUpdateErrorGroupStateMutation__
@@ -432,18 +581,35 @@ export type UpdateErrorGroupStateMutationFn = Apollo.MutationFunction<Types.Upda
  *   },
  * });
  */
-export function useUpdateErrorGroupStateMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateErrorGroupStateMutation, Types.UpdateErrorGroupStateMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateErrorGroupStateMutation, Types.UpdateErrorGroupStateMutationVariables>(UpdateErrorGroupStateDocument, baseOptions);
-      }
-export type UpdateErrorGroupStateMutationHookResult = ReturnType<typeof useUpdateErrorGroupStateMutation>;
-export type UpdateErrorGroupStateMutationResult = Apollo.MutationResult<Types.UpdateErrorGroupStateMutation>;
-export type UpdateErrorGroupStateMutationOptions = Apollo.BaseMutationOptions<Types.UpdateErrorGroupStateMutation, Types.UpdateErrorGroupStateMutationVariables>;
-export const SendEmailSignupDocument = gql`
-    mutation SendEmailSignup($email: String!) {
-  emailSignup(email: $email)
+export function useUpdateErrorGroupStateMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateErrorGroupStateMutation,
+		Types.UpdateErrorGroupStateMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateErrorGroupStateMutation,
+		Types.UpdateErrorGroupStateMutationVariables
+	>(UpdateErrorGroupStateDocument, baseOptions)
 }
-    `;
-export type SendEmailSignupMutationFn = Apollo.MutationFunction<Types.SendEmailSignupMutation, Types.SendEmailSignupMutationVariables>;
+export type UpdateErrorGroupStateMutationHookResult = ReturnType<
+	typeof useUpdateErrorGroupStateMutation
+>
+export type UpdateErrorGroupStateMutationResult =
+	Apollo.MutationResult<Types.UpdateErrorGroupStateMutation>
+export type UpdateErrorGroupStateMutationOptions = Apollo.BaseMutationOptions<
+	Types.UpdateErrorGroupStateMutation,
+	Types.UpdateErrorGroupStateMutationVariables
+>
+export const SendEmailSignupDocument = gql`
+	mutation SendEmailSignup($email: String!) {
+		emailSignup(email: $email)
+	}
+`
+export type SendEmailSignupMutationFn = Apollo.MutationFunction<
+	Types.SendEmailSignupMutation,
+	Types.SendEmailSignupMutationVariables
+>
 
 /**
  * __useSendEmailSignupMutation__
@@ -462,18 +628,35 @@ export type SendEmailSignupMutationFn = Apollo.MutationFunction<Types.SendEmailS
  *   },
  * });
  */
-export function useSendEmailSignupMutation(baseOptions?: Apollo.MutationHookOptions<Types.SendEmailSignupMutation, Types.SendEmailSignupMutationVariables>) {
-        return Apollo.useMutation<Types.SendEmailSignupMutation, Types.SendEmailSignupMutationVariables>(SendEmailSignupDocument, baseOptions);
-      }
-export type SendEmailSignupMutationHookResult = ReturnType<typeof useSendEmailSignupMutation>;
-export type SendEmailSignupMutationResult = Apollo.MutationResult<Types.SendEmailSignupMutation>;
-export type SendEmailSignupMutationOptions = Apollo.BaseMutationOptions<Types.SendEmailSignupMutation, Types.SendEmailSignupMutationVariables>;
-export const AddAdminToWorkspaceDocument = gql`
-    mutation AddAdminToWorkspace($workspace_id: ID!, $invite_id: String!) {
-  addAdminToWorkspace(workspace_id: $workspace_id, invite_id: $invite_id)
+export function useSendEmailSignupMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.SendEmailSignupMutation,
+		Types.SendEmailSignupMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.SendEmailSignupMutation,
+		Types.SendEmailSignupMutationVariables
+	>(SendEmailSignupDocument, baseOptions)
 }
-    `;
-export type AddAdminToWorkspaceMutationFn = Apollo.MutationFunction<Types.AddAdminToWorkspaceMutation, Types.AddAdminToWorkspaceMutationVariables>;
+export type SendEmailSignupMutationHookResult = ReturnType<
+	typeof useSendEmailSignupMutation
+>
+export type SendEmailSignupMutationResult =
+	Apollo.MutationResult<Types.SendEmailSignupMutation>
+export type SendEmailSignupMutationOptions = Apollo.BaseMutationOptions<
+	Types.SendEmailSignupMutation,
+	Types.SendEmailSignupMutationVariables
+>
+export const AddAdminToWorkspaceDocument = gql`
+	mutation AddAdminToWorkspace($workspace_id: ID!, $invite_id: String!) {
+		addAdminToWorkspace(workspace_id: $workspace_id, invite_id: $invite_id)
+	}
+`
+export type AddAdminToWorkspaceMutationFn = Apollo.MutationFunction<
+	Types.AddAdminToWorkspaceMutation,
+	Types.AddAdminToWorkspaceMutationVariables
+>
 
 /**
  * __useAddAdminToWorkspaceMutation__
@@ -493,18 +676,35 @@ export type AddAdminToWorkspaceMutationFn = Apollo.MutationFunction<Types.AddAdm
  *   },
  * });
  */
-export function useAddAdminToWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.AddAdminToWorkspaceMutation, Types.AddAdminToWorkspaceMutationVariables>) {
-        return Apollo.useMutation<Types.AddAdminToWorkspaceMutation, Types.AddAdminToWorkspaceMutationVariables>(AddAdminToWorkspaceDocument, baseOptions);
-      }
-export type AddAdminToWorkspaceMutationHookResult = ReturnType<typeof useAddAdminToWorkspaceMutation>;
-export type AddAdminToWorkspaceMutationResult = Apollo.MutationResult<Types.AddAdminToWorkspaceMutation>;
-export type AddAdminToWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.AddAdminToWorkspaceMutation, Types.AddAdminToWorkspaceMutationVariables>;
-export const JoinWorkspaceDocument = gql`
-    mutation JoinWorkspace($workspace_id: ID!) {
-  joinWorkspace(workspace_id: $workspace_id)
+export function useAddAdminToWorkspaceMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.AddAdminToWorkspaceMutation,
+		Types.AddAdminToWorkspaceMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.AddAdminToWorkspaceMutation,
+		Types.AddAdminToWorkspaceMutationVariables
+	>(AddAdminToWorkspaceDocument, baseOptions)
 }
-    `;
-export type JoinWorkspaceMutationFn = Apollo.MutationFunction<Types.JoinWorkspaceMutation, Types.JoinWorkspaceMutationVariables>;
+export type AddAdminToWorkspaceMutationHookResult = ReturnType<
+	typeof useAddAdminToWorkspaceMutation
+>
+export type AddAdminToWorkspaceMutationResult =
+	Apollo.MutationResult<Types.AddAdminToWorkspaceMutation>
+export type AddAdminToWorkspaceMutationOptions = Apollo.BaseMutationOptions<
+	Types.AddAdminToWorkspaceMutation,
+	Types.AddAdminToWorkspaceMutationVariables
+>
+export const JoinWorkspaceDocument = gql`
+	mutation JoinWorkspace($workspace_id: ID!) {
+		joinWorkspace(workspace_id: $workspace_id)
+	}
+`
+export type JoinWorkspaceMutationFn = Apollo.MutationFunction<
+	Types.JoinWorkspaceMutation,
+	Types.JoinWorkspaceMutationVariables
+>
 
 /**
  * __useJoinWorkspaceMutation__
@@ -523,22 +723,43 @@ export type JoinWorkspaceMutationFn = Apollo.MutationFunction<Types.JoinWorkspac
  *   },
  * });
  */
-export function useJoinWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.JoinWorkspaceMutation, Types.JoinWorkspaceMutationVariables>) {
-        return Apollo.useMutation<Types.JoinWorkspaceMutation, Types.JoinWorkspaceMutationVariables>(JoinWorkspaceDocument, baseOptions);
-      }
-export type JoinWorkspaceMutationHookResult = ReturnType<typeof useJoinWorkspaceMutation>;
-export type JoinWorkspaceMutationResult = Apollo.MutationResult<Types.JoinWorkspaceMutation>;
-export type JoinWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.JoinWorkspaceMutation, Types.JoinWorkspaceMutationVariables>;
-export const ChangeAdminRoleDocument = gql`
-    mutation ChangeAdminRole($workspace_id: ID!, $admin_id: ID!, $new_role: String!) {
-  changeAdminRole(
-    workspace_id: $workspace_id
-    admin_id: $admin_id
-    new_role: $new_role
-  )
+export function useJoinWorkspaceMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.JoinWorkspaceMutation,
+		Types.JoinWorkspaceMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.JoinWorkspaceMutation,
+		Types.JoinWorkspaceMutationVariables
+	>(JoinWorkspaceDocument, baseOptions)
 }
-    `;
-export type ChangeAdminRoleMutationFn = Apollo.MutationFunction<Types.ChangeAdminRoleMutation, Types.ChangeAdminRoleMutationVariables>;
+export type JoinWorkspaceMutationHookResult = ReturnType<
+	typeof useJoinWorkspaceMutation
+>
+export type JoinWorkspaceMutationResult =
+	Apollo.MutationResult<Types.JoinWorkspaceMutation>
+export type JoinWorkspaceMutationOptions = Apollo.BaseMutationOptions<
+	Types.JoinWorkspaceMutation,
+	Types.JoinWorkspaceMutationVariables
+>
+export const ChangeAdminRoleDocument = gql`
+	mutation ChangeAdminRole(
+		$workspace_id: ID!
+		$admin_id: ID!
+		$new_role: String!
+	) {
+		changeAdminRole(
+			workspace_id: $workspace_id
+			admin_id: $admin_id
+			new_role: $new_role
+		)
+	}
+`
+export type ChangeAdminRoleMutationFn = Apollo.MutationFunction<
+	Types.ChangeAdminRoleMutation,
+	Types.ChangeAdminRoleMutationVariables
+>
 
 /**
  * __useChangeAdminRoleMutation__
@@ -559,18 +780,35 @@ export type ChangeAdminRoleMutationFn = Apollo.MutationFunction<Types.ChangeAdmi
  *   },
  * });
  */
-export function useChangeAdminRoleMutation(baseOptions?: Apollo.MutationHookOptions<Types.ChangeAdminRoleMutation, Types.ChangeAdminRoleMutationVariables>) {
-        return Apollo.useMutation<Types.ChangeAdminRoleMutation, Types.ChangeAdminRoleMutationVariables>(ChangeAdminRoleDocument, baseOptions);
-      }
-export type ChangeAdminRoleMutationHookResult = ReturnType<typeof useChangeAdminRoleMutation>;
-export type ChangeAdminRoleMutationResult = Apollo.MutationResult<Types.ChangeAdminRoleMutation>;
-export type ChangeAdminRoleMutationOptions = Apollo.BaseMutationOptions<Types.ChangeAdminRoleMutation, Types.ChangeAdminRoleMutationVariables>;
-export const DeleteAdminFromProjectDocument = gql`
-    mutation DeleteAdminFromProject($project_id: ID!, $admin_id: ID!) {
-  deleteAdminFromProject(project_id: $project_id, admin_id: $admin_id)
+export function useChangeAdminRoleMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.ChangeAdminRoleMutation,
+		Types.ChangeAdminRoleMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.ChangeAdminRoleMutation,
+		Types.ChangeAdminRoleMutationVariables
+	>(ChangeAdminRoleDocument, baseOptions)
 }
-    `;
-export type DeleteAdminFromProjectMutationFn = Apollo.MutationFunction<Types.DeleteAdminFromProjectMutation, Types.DeleteAdminFromProjectMutationVariables>;
+export type ChangeAdminRoleMutationHookResult = ReturnType<
+	typeof useChangeAdminRoleMutation
+>
+export type ChangeAdminRoleMutationResult =
+	Apollo.MutationResult<Types.ChangeAdminRoleMutation>
+export type ChangeAdminRoleMutationOptions = Apollo.BaseMutationOptions<
+	Types.ChangeAdminRoleMutation,
+	Types.ChangeAdminRoleMutationVariables
+>
+export const DeleteAdminFromProjectDocument = gql`
+	mutation DeleteAdminFromProject($project_id: ID!, $admin_id: ID!) {
+		deleteAdminFromProject(project_id: $project_id, admin_id: $admin_id)
+	}
+`
+export type DeleteAdminFromProjectMutationFn = Apollo.MutationFunction<
+	Types.DeleteAdminFromProjectMutation,
+	Types.DeleteAdminFromProjectMutationVariables
+>
 
 /**
  * __useDeleteAdminFromProjectMutation__
@@ -590,18 +828,38 @@ export type DeleteAdminFromProjectMutationFn = Apollo.MutationFunction<Types.Del
  *   },
  * });
  */
-export function useDeleteAdminFromProjectMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteAdminFromProjectMutation, Types.DeleteAdminFromProjectMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteAdminFromProjectMutation, Types.DeleteAdminFromProjectMutationVariables>(DeleteAdminFromProjectDocument, baseOptions);
-      }
-export type DeleteAdminFromProjectMutationHookResult = ReturnType<typeof useDeleteAdminFromProjectMutation>;
-export type DeleteAdminFromProjectMutationResult = Apollo.MutationResult<Types.DeleteAdminFromProjectMutation>;
-export type DeleteAdminFromProjectMutationOptions = Apollo.BaseMutationOptions<Types.DeleteAdminFromProjectMutation, Types.DeleteAdminFromProjectMutationVariables>;
-export const DeleteAdminFromWorkspaceDocument = gql`
-    mutation DeleteAdminFromWorkspace($workspace_id: ID!, $admin_id: ID!) {
-  deleteAdminFromWorkspace(workspace_id: $workspace_id, admin_id: $admin_id)
+export function useDeleteAdminFromProjectMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteAdminFromProjectMutation,
+		Types.DeleteAdminFromProjectMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteAdminFromProjectMutation,
+		Types.DeleteAdminFromProjectMutationVariables
+	>(DeleteAdminFromProjectDocument, baseOptions)
 }
-    `;
-export type DeleteAdminFromWorkspaceMutationFn = Apollo.MutationFunction<Types.DeleteAdminFromWorkspaceMutation, Types.DeleteAdminFromWorkspaceMutationVariables>;
+export type DeleteAdminFromProjectMutationHookResult = ReturnType<
+	typeof useDeleteAdminFromProjectMutation
+>
+export type DeleteAdminFromProjectMutationResult =
+	Apollo.MutationResult<Types.DeleteAdminFromProjectMutation>
+export type DeleteAdminFromProjectMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteAdminFromProjectMutation,
+	Types.DeleteAdminFromProjectMutationVariables
+>
+export const DeleteAdminFromWorkspaceDocument = gql`
+	mutation DeleteAdminFromWorkspace($workspace_id: ID!, $admin_id: ID!) {
+		deleteAdminFromWorkspace(
+			workspace_id: $workspace_id
+			admin_id: $admin_id
+		)
+	}
+`
+export type DeleteAdminFromWorkspaceMutationFn = Apollo.MutationFunction<
+	Types.DeleteAdminFromWorkspaceMutation,
+	Types.DeleteAdminFromWorkspaceMutationVariables
+>
 
 /**
  * __useDeleteAdminFromWorkspaceMutation__
@@ -621,22 +879,44 @@ export type DeleteAdminFromWorkspaceMutationFn = Apollo.MutationFunction<Types.D
  *   },
  * });
  */
-export function useDeleteAdminFromWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteAdminFromWorkspaceMutation, Types.DeleteAdminFromWorkspaceMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteAdminFromWorkspaceMutation, Types.DeleteAdminFromWorkspaceMutationVariables>(DeleteAdminFromWorkspaceDocument, baseOptions);
-      }
-export type DeleteAdminFromWorkspaceMutationHookResult = ReturnType<typeof useDeleteAdminFromWorkspaceMutation>;
-export type DeleteAdminFromWorkspaceMutationResult = Apollo.MutationResult<Types.DeleteAdminFromWorkspaceMutation>;
-export type DeleteAdminFromWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.DeleteAdminFromWorkspaceMutation, Types.DeleteAdminFromWorkspaceMutationVariables>;
-export const AddIntegrationToProjectDocument = gql`
-    mutation AddIntegrationToProject($integration_type: IntegrationType, $project_id: ID!, $code: String!) {
-  addIntegrationToProject(
-    integration_type: $integration_type
-    project_id: $project_id
-    code: $code
-  )
+export function useDeleteAdminFromWorkspaceMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteAdminFromWorkspaceMutation,
+		Types.DeleteAdminFromWorkspaceMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteAdminFromWorkspaceMutation,
+		Types.DeleteAdminFromWorkspaceMutationVariables
+	>(DeleteAdminFromWorkspaceDocument, baseOptions)
 }
-    `;
-export type AddIntegrationToProjectMutationFn = Apollo.MutationFunction<Types.AddIntegrationToProjectMutation, Types.AddIntegrationToProjectMutationVariables>;
+export type DeleteAdminFromWorkspaceMutationHookResult = ReturnType<
+	typeof useDeleteAdminFromWorkspaceMutation
+>
+export type DeleteAdminFromWorkspaceMutationResult =
+	Apollo.MutationResult<Types.DeleteAdminFromWorkspaceMutation>
+export type DeleteAdminFromWorkspaceMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.DeleteAdminFromWorkspaceMutation,
+		Types.DeleteAdminFromWorkspaceMutationVariables
+	>
+export const AddIntegrationToProjectDocument = gql`
+	mutation AddIntegrationToProject(
+		$integration_type: IntegrationType
+		$project_id: ID!
+		$code: String!
+	) {
+		addIntegrationToProject(
+			integration_type: $integration_type
+			project_id: $project_id
+			code: $code
+		)
+	}
+`
+export type AddIntegrationToProjectMutationFn = Apollo.MutationFunction<
+	Types.AddIntegrationToProjectMutation,
+	Types.AddIntegrationToProjectMutationVariables
+>
 
 /**
  * __useAddIntegrationToProjectMutation__
@@ -657,21 +937,41 @@ export type AddIntegrationToProjectMutationFn = Apollo.MutationFunction<Types.Ad
  *   },
  * });
  */
-export function useAddIntegrationToProjectMutation(baseOptions?: Apollo.MutationHookOptions<Types.AddIntegrationToProjectMutation, Types.AddIntegrationToProjectMutationVariables>) {
-        return Apollo.useMutation<Types.AddIntegrationToProjectMutation, Types.AddIntegrationToProjectMutationVariables>(AddIntegrationToProjectDocument, baseOptions);
-      }
-export type AddIntegrationToProjectMutationHookResult = ReturnType<typeof useAddIntegrationToProjectMutation>;
-export type AddIntegrationToProjectMutationResult = Apollo.MutationResult<Types.AddIntegrationToProjectMutation>;
-export type AddIntegrationToProjectMutationOptions = Apollo.BaseMutationOptions<Types.AddIntegrationToProjectMutation, Types.AddIntegrationToProjectMutationVariables>;
-export const RemoveIntegrationFromProjectDocument = gql`
-    mutation RemoveIntegrationFromProject($integration_type: IntegrationType, $project_id: ID!) {
-  removeIntegrationFromProject(
-    integration_type: $integration_type
-    project_id: $project_id
-  )
+export function useAddIntegrationToProjectMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.AddIntegrationToProjectMutation,
+		Types.AddIntegrationToProjectMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.AddIntegrationToProjectMutation,
+		Types.AddIntegrationToProjectMutationVariables
+	>(AddIntegrationToProjectDocument, baseOptions)
 }
-    `;
-export type RemoveIntegrationFromProjectMutationFn = Apollo.MutationFunction<Types.RemoveIntegrationFromProjectMutation, Types.RemoveIntegrationFromProjectMutationVariables>;
+export type AddIntegrationToProjectMutationHookResult = ReturnType<
+	typeof useAddIntegrationToProjectMutation
+>
+export type AddIntegrationToProjectMutationResult =
+	Apollo.MutationResult<Types.AddIntegrationToProjectMutation>
+export type AddIntegrationToProjectMutationOptions = Apollo.BaseMutationOptions<
+	Types.AddIntegrationToProjectMutation,
+	Types.AddIntegrationToProjectMutationVariables
+>
+export const RemoveIntegrationFromProjectDocument = gql`
+	mutation RemoveIntegrationFromProject(
+		$integration_type: IntegrationType
+		$project_id: ID!
+	) {
+		removeIntegrationFromProject(
+			integration_type: $integration_type
+			project_id: $project_id
+		)
+	}
+`
+export type RemoveIntegrationFromProjectMutationFn = Apollo.MutationFunction<
+	Types.RemoveIntegrationFromProjectMutation,
+	Types.RemoveIntegrationFromProjectMutationVariables
+>
 
 /**
  * __useRemoveIntegrationFromProjectMutation__
@@ -691,22 +991,44 @@ export type RemoveIntegrationFromProjectMutationFn = Apollo.MutationFunction<Typ
  *   },
  * });
  */
-export function useRemoveIntegrationFromProjectMutation(baseOptions?: Apollo.MutationHookOptions<Types.RemoveIntegrationFromProjectMutation, Types.RemoveIntegrationFromProjectMutationVariables>) {
-        return Apollo.useMutation<Types.RemoveIntegrationFromProjectMutation, Types.RemoveIntegrationFromProjectMutationVariables>(RemoveIntegrationFromProjectDocument, baseOptions);
-      }
-export type RemoveIntegrationFromProjectMutationHookResult = ReturnType<typeof useRemoveIntegrationFromProjectMutation>;
-export type RemoveIntegrationFromProjectMutationResult = Apollo.MutationResult<Types.RemoveIntegrationFromProjectMutation>;
-export type RemoveIntegrationFromProjectMutationOptions = Apollo.BaseMutationOptions<Types.RemoveIntegrationFromProjectMutation, Types.RemoveIntegrationFromProjectMutationVariables>;
-export const AddIntegrationToWorkspaceDocument = gql`
-    mutation AddIntegrationToWorkspace($integration_type: IntegrationType, $workspace_id: ID!, $code: String!) {
-  addIntegrationToWorkspace(
-    integration_type: $integration_type
-    workspace_id: $workspace_id
-    code: $code
-  )
+export function useRemoveIntegrationFromProjectMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.RemoveIntegrationFromProjectMutation,
+		Types.RemoveIntegrationFromProjectMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.RemoveIntegrationFromProjectMutation,
+		Types.RemoveIntegrationFromProjectMutationVariables
+	>(RemoveIntegrationFromProjectDocument, baseOptions)
 }
-    `;
-export type AddIntegrationToWorkspaceMutationFn = Apollo.MutationFunction<Types.AddIntegrationToWorkspaceMutation, Types.AddIntegrationToWorkspaceMutationVariables>;
+export type RemoveIntegrationFromProjectMutationHookResult = ReturnType<
+	typeof useRemoveIntegrationFromProjectMutation
+>
+export type RemoveIntegrationFromProjectMutationResult =
+	Apollo.MutationResult<Types.RemoveIntegrationFromProjectMutation>
+export type RemoveIntegrationFromProjectMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.RemoveIntegrationFromProjectMutation,
+		Types.RemoveIntegrationFromProjectMutationVariables
+	>
+export const AddIntegrationToWorkspaceDocument = gql`
+	mutation AddIntegrationToWorkspace(
+		$integration_type: IntegrationType
+		$workspace_id: ID!
+		$code: String!
+	) {
+		addIntegrationToWorkspace(
+			integration_type: $integration_type
+			workspace_id: $workspace_id
+			code: $code
+		)
+	}
+`
+export type AddIntegrationToWorkspaceMutationFn = Apollo.MutationFunction<
+	Types.AddIntegrationToWorkspaceMutation,
+	Types.AddIntegrationToWorkspaceMutationVariables
+>
 
 /**
  * __useAddIntegrationToWorkspaceMutation__
@@ -727,21 +1049,42 @@ export type AddIntegrationToWorkspaceMutationFn = Apollo.MutationFunction<Types.
  *   },
  * });
  */
-export function useAddIntegrationToWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.AddIntegrationToWorkspaceMutation, Types.AddIntegrationToWorkspaceMutationVariables>) {
-        return Apollo.useMutation<Types.AddIntegrationToWorkspaceMutation, Types.AddIntegrationToWorkspaceMutationVariables>(AddIntegrationToWorkspaceDocument, baseOptions);
-      }
-export type AddIntegrationToWorkspaceMutationHookResult = ReturnType<typeof useAddIntegrationToWorkspaceMutation>;
-export type AddIntegrationToWorkspaceMutationResult = Apollo.MutationResult<Types.AddIntegrationToWorkspaceMutation>;
-export type AddIntegrationToWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.AddIntegrationToWorkspaceMutation, Types.AddIntegrationToWorkspaceMutationVariables>;
-export const RemoveIntegrationFromWorkspaceDocument = gql`
-    mutation RemoveIntegrationFromWorkspace($integration_type: IntegrationType!, $workspace_id: ID!) {
-  removeIntegrationFromWorkspace(
-    integration_type: $integration_type
-    workspace_id: $workspace_id
-  )
+export function useAddIntegrationToWorkspaceMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.AddIntegrationToWorkspaceMutation,
+		Types.AddIntegrationToWorkspaceMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.AddIntegrationToWorkspaceMutation,
+		Types.AddIntegrationToWorkspaceMutationVariables
+	>(AddIntegrationToWorkspaceDocument, baseOptions)
 }
-    `;
-export type RemoveIntegrationFromWorkspaceMutationFn = Apollo.MutationFunction<Types.RemoveIntegrationFromWorkspaceMutation, Types.RemoveIntegrationFromWorkspaceMutationVariables>;
+export type AddIntegrationToWorkspaceMutationHookResult = ReturnType<
+	typeof useAddIntegrationToWorkspaceMutation
+>
+export type AddIntegrationToWorkspaceMutationResult =
+	Apollo.MutationResult<Types.AddIntegrationToWorkspaceMutation>
+export type AddIntegrationToWorkspaceMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.AddIntegrationToWorkspaceMutation,
+		Types.AddIntegrationToWorkspaceMutationVariables
+	>
+export const RemoveIntegrationFromWorkspaceDocument = gql`
+	mutation RemoveIntegrationFromWorkspace(
+		$integration_type: IntegrationType!
+		$workspace_id: ID!
+	) {
+		removeIntegrationFromWorkspace(
+			integration_type: $integration_type
+			workspace_id: $workspace_id
+		)
+	}
+`
+export type RemoveIntegrationFromWorkspaceMutationFn = Apollo.MutationFunction<
+	Types.RemoveIntegrationFromWorkspaceMutation,
+	Types.RemoveIntegrationFromWorkspaceMutationVariables
+>
 
 /**
  * __useRemoveIntegrationFromWorkspaceMutation__
@@ -761,21 +1104,42 @@ export type RemoveIntegrationFromWorkspaceMutationFn = Apollo.MutationFunction<T
  *   },
  * });
  */
-export function useRemoveIntegrationFromWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.RemoveIntegrationFromWorkspaceMutation, Types.RemoveIntegrationFromWorkspaceMutationVariables>) {
-        return Apollo.useMutation<Types.RemoveIntegrationFromWorkspaceMutation, Types.RemoveIntegrationFromWorkspaceMutationVariables>(RemoveIntegrationFromWorkspaceDocument, baseOptions);
-      }
-export type RemoveIntegrationFromWorkspaceMutationHookResult = ReturnType<typeof useRemoveIntegrationFromWorkspaceMutation>;
-export type RemoveIntegrationFromWorkspaceMutationResult = Apollo.MutationResult<Types.RemoveIntegrationFromWorkspaceMutation>;
-export type RemoveIntegrationFromWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.RemoveIntegrationFromWorkspaceMutation, Types.RemoveIntegrationFromWorkspaceMutationVariables>;
-export const UpdateAllowedEmailOriginsDocument = gql`
-    mutation UpdateAllowedEmailOrigins($workspace_id: ID!, $allowed_auto_join_email_origins: String!) {
-  updateAllowedEmailOrigins(
-    workspace_id: $workspace_id
-    allowed_auto_join_email_origins: $allowed_auto_join_email_origins
-  )
+export function useRemoveIntegrationFromWorkspaceMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.RemoveIntegrationFromWorkspaceMutation,
+		Types.RemoveIntegrationFromWorkspaceMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.RemoveIntegrationFromWorkspaceMutation,
+		Types.RemoveIntegrationFromWorkspaceMutationVariables
+	>(RemoveIntegrationFromWorkspaceDocument, baseOptions)
 }
-    `;
-export type UpdateAllowedEmailOriginsMutationFn = Apollo.MutationFunction<Types.UpdateAllowedEmailOriginsMutation, Types.UpdateAllowedEmailOriginsMutationVariables>;
+export type RemoveIntegrationFromWorkspaceMutationHookResult = ReturnType<
+	typeof useRemoveIntegrationFromWorkspaceMutation
+>
+export type RemoveIntegrationFromWorkspaceMutationResult =
+	Apollo.MutationResult<Types.RemoveIntegrationFromWorkspaceMutation>
+export type RemoveIntegrationFromWorkspaceMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.RemoveIntegrationFromWorkspaceMutation,
+		Types.RemoveIntegrationFromWorkspaceMutationVariables
+	>
+export const UpdateAllowedEmailOriginsDocument = gql`
+	mutation UpdateAllowedEmailOrigins(
+		$workspace_id: ID!
+		$allowed_auto_join_email_origins: String!
+	) {
+		updateAllowedEmailOrigins(
+			workspace_id: $workspace_id
+			allowed_auto_join_email_origins: $allowed_auto_join_email_origins
+		)
+	}
+`
+export type UpdateAllowedEmailOriginsMutationFn = Apollo.MutationFunction<
+	Types.UpdateAllowedEmailOriginsMutation,
+	Types.UpdateAllowedEmailOriginsMutationVariables
+>
 
 /**
  * __useUpdateAllowedEmailOriginsMutation__
@@ -795,21 +1159,39 @@ export type UpdateAllowedEmailOriginsMutationFn = Apollo.MutationFunction<Types.
  *   },
  * });
  */
-export function useUpdateAllowedEmailOriginsMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateAllowedEmailOriginsMutation, Types.UpdateAllowedEmailOriginsMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateAllowedEmailOriginsMutation, Types.UpdateAllowedEmailOriginsMutationVariables>(UpdateAllowedEmailOriginsDocument, baseOptions);
-      }
-export type UpdateAllowedEmailOriginsMutationHookResult = ReturnType<typeof useUpdateAllowedEmailOriginsMutation>;
-export type UpdateAllowedEmailOriginsMutationResult = Apollo.MutationResult<Types.UpdateAllowedEmailOriginsMutation>;
-export type UpdateAllowedEmailOriginsMutationOptions = Apollo.BaseMutationOptions<Types.UpdateAllowedEmailOriginsMutation, Types.UpdateAllowedEmailOriginsMutationVariables>;
-export const CreateProjectDocument = gql`
-    mutation CreateProject($name: String!, $workspace_id: ID!) {
-  createProject(name: $name, workspace_id: $workspace_id) {
-    id
-    name
-  }
+export function useUpdateAllowedEmailOriginsMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateAllowedEmailOriginsMutation,
+		Types.UpdateAllowedEmailOriginsMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateAllowedEmailOriginsMutation,
+		Types.UpdateAllowedEmailOriginsMutationVariables
+	>(UpdateAllowedEmailOriginsDocument, baseOptions)
 }
-    `;
-export type CreateProjectMutationFn = Apollo.MutationFunction<Types.CreateProjectMutation, Types.CreateProjectMutationVariables>;
+export type UpdateAllowedEmailOriginsMutationHookResult = ReturnType<
+	typeof useUpdateAllowedEmailOriginsMutation
+>
+export type UpdateAllowedEmailOriginsMutationResult =
+	Apollo.MutationResult<Types.UpdateAllowedEmailOriginsMutation>
+export type UpdateAllowedEmailOriginsMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.UpdateAllowedEmailOriginsMutation,
+		Types.UpdateAllowedEmailOriginsMutationVariables
+	>
+export const CreateProjectDocument = gql`
+	mutation CreateProject($name: String!, $workspace_id: ID!) {
+		createProject(name: $name, workspace_id: $workspace_id) {
+			id
+			name
+		}
+	}
+`
+export type CreateProjectMutationFn = Apollo.MutationFunction<
+	Types.CreateProjectMutation,
+	Types.CreateProjectMutationVariables
+>
 
 /**
  * __useCreateProjectMutation__
@@ -829,25 +1211,49 @@ export type CreateProjectMutationFn = Apollo.MutationFunction<Types.CreateProjec
  *   },
  * });
  */
-export function useCreateProjectMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateProjectMutation, Types.CreateProjectMutationVariables>) {
-        return Apollo.useMutation<Types.CreateProjectMutation, Types.CreateProjectMutationVariables>(CreateProjectDocument, baseOptions);
-      }
-export type CreateProjectMutationHookResult = ReturnType<typeof useCreateProjectMutation>;
-export type CreateProjectMutationResult = Apollo.MutationResult<Types.CreateProjectMutation>;
-export type CreateProjectMutationOptions = Apollo.BaseMutationOptions<Types.CreateProjectMutation, Types.CreateProjectMutationVariables>;
-export const SubmitRegistrationFormDocument = gql`
-    mutation SubmitRegistrationForm($workspace_id: ID!, $team_size: String!, $role: String!, $use_case: String!, $heard_about: String!, $pun: String) {
-  submitRegistrationForm(
-    workspace_id: $workspace_id
-    team_size: $team_size
-    role: $role
-    use_case: $use_case
-    heard_about: $heard_about
-    pun: $pun
-  )
+export function useCreateProjectMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateProjectMutation,
+		Types.CreateProjectMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateProjectMutation,
+		Types.CreateProjectMutationVariables
+	>(CreateProjectDocument, baseOptions)
 }
-    `;
-export type SubmitRegistrationFormMutationFn = Apollo.MutationFunction<Types.SubmitRegistrationFormMutation, Types.SubmitRegistrationFormMutationVariables>;
+export type CreateProjectMutationHookResult = ReturnType<
+	typeof useCreateProjectMutation
+>
+export type CreateProjectMutationResult =
+	Apollo.MutationResult<Types.CreateProjectMutation>
+export type CreateProjectMutationOptions = Apollo.BaseMutationOptions<
+	Types.CreateProjectMutation,
+	Types.CreateProjectMutationVariables
+>
+export const SubmitRegistrationFormDocument = gql`
+	mutation SubmitRegistrationForm(
+		$workspace_id: ID!
+		$team_size: String!
+		$role: String!
+		$use_case: String!
+		$heard_about: String!
+		$pun: String
+	) {
+		submitRegistrationForm(
+			workspace_id: $workspace_id
+			team_size: $team_size
+			role: $role
+			use_case: $use_case
+			heard_about: $heard_about
+			pun: $pun
+		)
+	}
+`
+export type SubmitRegistrationFormMutationFn = Apollo.MutationFunction<
+	Types.SubmitRegistrationFormMutation,
+	Types.SubmitRegistrationFormMutationVariables
+>
 
 /**
  * __useSubmitRegistrationFormMutation__
@@ -871,24 +1277,41 @@ export type SubmitRegistrationFormMutationFn = Apollo.MutationFunction<Types.Sub
  *   },
  * });
  */
-export function useSubmitRegistrationFormMutation(baseOptions?: Apollo.MutationHookOptions<Types.SubmitRegistrationFormMutation, Types.SubmitRegistrationFormMutationVariables>) {
-        return Apollo.useMutation<Types.SubmitRegistrationFormMutation, Types.SubmitRegistrationFormMutationVariables>(SubmitRegistrationFormDocument, baseOptions);
-      }
-export type SubmitRegistrationFormMutationHookResult = ReturnType<typeof useSubmitRegistrationFormMutation>;
-export type SubmitRegistrationFormMutationResult = Apollo.MutationResult<Types.SubmitRegistrationFormMutation>;
-export type SubmitRegistrationFormMutationOptions = Apollo.BaseMutationOptions<Types.SubmitRegistrationFormMutation, Types.SubmitRegistrationFormMutationVariables>;
-export const CreateAdminDocument = gql`
-    mutation CreateAdmin {
-  createAdmin {
-    id
-    name
-    email
-    email_verified
-    about_you_details_filled
-  }
+export function useSubmitRegistrationFormMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.SubmitRegistrationFormMutation,
+		Types.SubmitRegistrationFormMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.SubmitRegistrationFormMutation,
+		Types.SubmitRegistrationFormMutationVariables
+	>(SubmitRegistrationFormDocument, baseOptions)
 }
-    `;
-export type CreateAdminMutationFn = Apollo.MutationFunction<Types.CreateAdminMutation, Types.CreateAdminMutationVariables>;
+export type SubmitRegistrationFormMutationHookResult = ReturnType<
+	typeof useSubmitRegistrationFormMutation
+>
+export type SubmitRegistrationFormMutationResult =
+	Apollo.MutationResult<Types.SubmitRegistrationFormMutation>
+export type SubmitRegistrationFormMutationOptions = Apollo.BaseMutationOptions<
+	Types.SubmitRegistrationFormMutation,
+	Types.SubmitRegistrationFormMutationVariables
+>
+export const CreateAdminDocument = gql`
+	mutation CreateAdmin {
+		createAdmin {
+			id
+			name
+			email
+			email_verified
+			about_you_details_filled
+		}
+	}
+`
+export type CreateAdminMutationFn = Apollo.MutationFunction<
+	Types.CreateAdminMutation,
+	Types.CreateAdminMutationVariables
+>
 
 /**
  * __useCreateAdminMutation__
@@ -906,21 +1329,38 @@ export type CreateAdminMutationFn = Apollo.MutationFunction<Types.CreateAdminMut
  *   },
  * });
  */
-export function useCreateAdminMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateAdminMutation, Types.CreateAdminMutationVariables>) {
-        return Apollo.useMutation<Types.CreateAdminMutation, Types.CreateAdminMutationVariables>(CreateAdminDocument, baseOptions);
-      }
-export type CreateAdminMutationHookResult = ReturnType<typeof useCreateAdminMutation>;
-export type CreateAdminMutationResult = Apollo.MutationResult<Types.CreateAdminMutation>;
-export type CreateAdminMutationOptions = Apollo.BaseMutationOptions<Types.CreateAdminMutation, Types.CreateAdminMutationVariables>;
-export const CreateWorkspaceDocument = gql`
-    mutation CreateWorkspace($name: String!, $promo_code: String) {
-  createWorkspace(name: $name, promo_code: $promo_code) {
-    id
-    name
-  }
+export function useCreateAdminMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateAdminMutation,
+		Types.CreateAdminMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateAdminMutation,
+		Types.CreateAdminMutationVariables
+	>(CreateAdminDocument, baseOptions)
 }
-    `;
-export type CreateWorkspaceMutationFn = Apollo.MutationFunction<Types.CreateWorkspaceMutation, Types.CreateWorkspaceMutationVariables>;
+export type CreateAdminMutationHookResult = ReturnType<
+	typeof useCreateAdminMutation
+>
+export type CreateAdminMutationResult =
+	Apollo.MutationResult<Types.CreateAdminMutation>
+export type CreateAdminMutationOptions = Apollo.BaseMutationOptions<
+	Types.CreateAdminMutation,
+	Types.CreateAdminMutationVariables
+>
+export const CreateWorkspaceDocument = gql`
+	mutation CreateWorkspace($name: String!, $promo_code: String) {
+		createWorkspace(name: $name, promo_code: $promo_code) {
+			id
+			name
+		}
+	}
+`
+export type CreateWorkspaceMutationFn = Apollo.MutationFunction<
+	Types.CreateWorkspaceMutation,
+	Types.CreateWorkspaceMutationVariables
+>
 
 /**
  * __useCreateWorkspaceMutation__
@@ -940,42 +1380,71 @@ export type CreateWorkspaceMutationFn = Apollo.MutationFunction<Types.CreateWork
  *   },
  * });
  */
-export function useCreateWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateWorkspaceMutation, Types.CreateWorkspaceMutationVariables>) {
-        return Apollo.useMutation<Types.CreateWorkspaceMutation, Types.CreateWorkspaceMutationVariables>(CreateWorkspaceDocument, baseOptions);
-      }
-export type CreateWorkspaceMutationHookResult = ReturnType<typeof useCreateWorkspaceMutation>;
-export type CreateWorkspaceMutationResult = Apollo.MutationResult<Types.CreateWorkspaceMutation>;
-export type CreateWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.CreateWorkspaceMutation, Types.CreateWorkspaceMutationVariables>;
-export const EditProjectDocument = gql`
-    mutation EditProject($id: ID!, $name: String, $billing_email: String, $excluded_users: StringArray, $error_filters: StringArray, $error_json_paths: StringArray, $filter_chrome_extension: Boolean, $rage_click_window_seconds: Int, $rage_click_radius_pixels: Int, $rage_click_count: Int, $backend_domains: StringArray) {
-  editProject(
-    id: $id
-    name: $name
-    billing_email: $billing_email
-    excluded_users: $excluded_users
-    error_filters: $error_filters
-    error_json_paths: $error_json_paths
-    filter_chrome_extension: $filter_chrome_extension
-    rage_click_window_seconds: $rage_click_window_seconds
-    rage_click_radius_pixels: $rage_click_radius_pixels
-    rage_click_count: $rage_click_count
-    backend_domains: $backend_domains
-  ) {
-    id
-    name
-    billing_email
-    excluded_users
-    error_filters
-    error_json_paths
-    filter_chrome_extension
-    rage_click_window_seconds
-    rage_click_radius_pixels
-    rage_click_count
-    backend_domains
-  }
+export function useCreateWorkspaceMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateWorkspaceMutation,
+		Types.CreateWorkspaceMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateWorkspaceMutation,
+		Types.CreateWorkspaceMutationVariables
+	>(CreateWorkspaceDocument, baseOptions)
 }
-    `;
-export type EditProjectMutationFn = Apollo.MutationFunction<Types.EditProjectMutation, Types.EditProjectMutationVariables>;
+export type CreateWorkspaceMutationHookResult = ReturnType<
+	typeof useCreateWorkspaceMutation
+>
+export type CreateWorkspaceMutationResult =
+	Apollo.MutationResult<Types.CreateWorkspaceMutation>
+export type CreateWorkspaceMutationOptions = Apollo.BaseMutationOptions<
+	Types.CreateWorkspaceMutation,
+	Types.CreateWorkspaceMutationVariables
+>
+export const EditProjectDocument = gql`
+	mutation EditProject(
+		$id: ID!
+		$name: String
+		$billing_email: String
+		$excluded_users: StringArray
+		$error_filters: StringArray
+		$error_json_paths: StringArray
+		$filter_chrome_extension: Boolean
+		$rage_click_window_seconds: Int
+		$rage_click_radius_pixels: Int
+		$rage_click_count: Int
+		$backend_domains: StringArray
+	) {
+		editProject(
+			id: $id
+			name: $name
+			billing_email: $billing_email
+			excluded_users: $excluded_users
+			error_filters: $error_filters
+			error_json_paths: $error_json_paths
+			filter_chrome_extension: $filter_chrome_extension
+			rage_click_window_seconds: $rage_click_window_seconds
+			rage_click_radius_pixels: $rage_click_radius_pixels
+			rage_click_count: $rage_click_count
+			backend_domains: $backend_domains
+		) {
+			id
+			name
+			billing_email
+			excluded_users
+			error_filters
+			error_json_paths
+			filter_chrome_extension
+			rage_click_window_seconds
+			rage_click_radius_pixels
+			rage_click_count
+			backend_domains
+		}
+	}
+`
+export type EditProjectMutationFn = Apollo.MutationFunction<
+	Types.EditProjectMutation,
+	Types.EditProjectMutationVariables
+>
 
 /**
  * __useEditProjectMutation__
@@ -1004,46 +1473,77 @@ export type EditProjectMutationFn = Apollo.MutationFunction<Types.EditProjectMut
  *   },
  * });
  */
-export function useEditProjectMutation(baseOptions?: Apollo.MutationHookOptions<Types.EditProjectMutation, Types.EditProjectMutationVariables>) {
-        return Apollo.useMutation<Types.EditProjectMutation, Types.EditProjectMutationVariables>(EditProjectDocument, baseOptions);
-      }
-export type EditProjectMutationHookResult = ReturnType<typeof useEditProjectMutation>;
-export type EditProjectMutationResult = Apollo.MutationResult<Types.EditProjectMutation>;
-export type EditProjectMutationOptions = Apollo.BaseMutationOptions<Types.EditProjectMutation, Types.EditProjectMutationVariables>;
-export const EditProjectSettingsDocument = gql`
-    mutation EditProjectSettings($projectId: ID!, $name: String, $billing_email: String, $excluded_users: StringArray, $error_filters: StringArray, $error_json_paths: StringArray, $filter_chrome_extension: Boolean, $rage_click_window_seconds: Int, $rage_click_radius_pixels: Int, $rage_click_count: Int, $backend_domains: StringArray, $filterSessionsWithoutError: Boolean, $autoResolveStaleErrorsDayInterval: Int) {
-  editProjectSettings(
-    projectId: $projectId
-    name: $name
-    billing_email: $billing_email
-    excluded_users: $excluded_users
-    error_filters: $error_filters
-    error_json_paths: $error_json_paths
-    filter_chrome_extension: $filter_chrome_extension
-    rage_click_window_seconds: $rage_click_window_seconds
-    rage_click_radius_pixels: $rage_click_radius_pixels
-    rage_click_count: $rage_click_count
-    backend_domains: $backend_domains
-    filterSessionsWithoutError: $filterSessionsWithoutError
-    autoResolveStaleErrorsDayInterval: $autoResolveStaleErrorsDayInterval
-  ) {
-    id
-    name
-    billing_email
-    excluded_users
-    error_filters
-    error_json_paths
-    filter_chrome_extension
-    rage_click_window_seconds
-    rage_click_radius_pixels
-    rage_click_count
-    backend_domains
-    filterSessionsWithoutError
-    autoResolveStaleErrorsDayInterval
-  }
+export function useEditProjectMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.EditProjectMutation,
+		Types.EditProjectMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.EditProjectMutation,
+		Types.EditProjectMutationVariables
+	>(EditProjectDocument, baseOptions)
 }
-    `;
-export type EditProjectSettingsMutationFn = Apollo.MutationFunction<Types.EditProjectSettingsMutation, Types.EditProjectSettingsMutationVariables>;
+export type EditProjectMutationHookResult = ReturnType<
+	typeof useEditProjectMutation
+>
+export type EditProjectMutationResult =
+	Apollo.MutationResult<Types.EditProjectMutation>
+export type EditProjectMutationOptions = Apollo.BaseMutationOptions<
+	Types.EditProjectMutation,
+	Types.EditProjectMutationVariables
+>
+export const EditProjectSettingsDocument = gql`
+	mutation EditProjectSettings(
+		$projectId: ID!
+		$name: String
+		$billing_email: String
+		$excluded_users: StringArray
+		$error_filters: StringArray
+		$error_json_paths: StringArray
+		$filter_chrome_extension: Boolean
+		$rage_click_window_seconds: Int
+		$rage_click_radius_pixels: Int
+		$rage_click_count: Int
+		$backend_domains: StringArray
+		$filterSessionsWithoutError: Boolean
+		$autoResolveStaleErrorsDayInterval: Int
+	) {
+		editProjectSettings(
+			projectId: $projectId
+			name: $name
+			billing_email: $billing_email
+			excluded_users: $excluded_users
+			error_filters: $error_filters
+			error_json_paths: $error_json_paths
+			filter_chrome_extension: $filter_chrome_extension
+			rage_click_window_seconds: $rage_click_window_seconds
+			rage_click_radius_pixels: $rage_click_radius_pixels
+			rage_click_count: $rage_click_count
+			backend_domains: $backend_domains
+			filterSessionsWithoutError: $filterSessionsWithoutError
+			autoResolveStaleErrorsDayInterval: $autoResolveStaleErrorsDayInterval
+		) {
+			id
+			name
+			billing_email
+			excluded_users
+			error_filters
+			error_json_paths
+			filter_chrome_extension
+			rage_click_window_seconds
+			rage_click_radius_pixels
+			rage_click_count
+			backend_domains
+			filterSessionsWithoutError
+			autoResolveStaleErrorsDayInterval
+		}
+	}
+`
+export type EditProjectSettingsMutationFn = Apollo.MutationFunction<
+	Types.EditProjectSettingsMutation,
+	Types.EditProjectSettingsMutationVariables
+>
 
 /**
  * __useEditProjectSettingsMutation__
@@ -1074,18 +1574,35 @@ export type EditProjectSettingsMutationFn = Apollo.MutationFunction<Types.EditPr
  *   },
  * });
  */
-export function useEditProjectSettingsMutation(baseOptions?: Apollo.MutationHookOptions<Types.EditProjectSettingsMutation, Types.EditProjectSettingsMutationVariables>) {
-        return Apollo.useMutation<Types.EditProjectSettingsMutation, Types.EditProjectSettingsMutationVariables>(EditProjectSettingsDocument, baseOptions);
-      }
-export type EditProjectSettingsMutationHookResult = ReturnType<typeof useEditProjectSettingsMutation>;
-export type EditProjectSettingsMutationResult = Apollo.MutationResult<Types.EditProjectSettingsMutation>;
-export type EditProjectSettingsMutationOptions = Apollo.BaseMutationOptions<Types.EditProjectSettingsMutation, Types.EditProjectSettingsMutationVariables>;
-export const DeleteProjectDocument = gql`
-    mutation DeleteProject($id: ID!) {
-  deleteProject(id: $id)
+export function useEditProjectSettingsMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.EditProjectSettingsMutation,
+		Types.EditProjectSettingsMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.EditProjectSettingsMutation,
+		Types.EditProjectSettingsMutationVariables
+	>(EditProjectSettingsDocument, baseOptions)
 }
-    `;
-export type DeleteProjectMutationFn = Apollo.MutationFunction<Types.DeleteProjectMutation, Types.DeleteProjectMutationVariables>;
+export type EditProjectSettingsMutationHookResult = ReturnType<
+	typeof useEditProjectSettingsMutation
+>
+export type EditProjectSettingsMutationResult =
+	Apollo.MutationResult<Types.EditProjectSettingsMutation>
+export type EditProjectSettingsMutationOptions = Apollo.BaseMutationOptions<
+	Types.EditProjectSettingsMutation,
+	Types.EditProjectSettingsMutationVariables
+>
+export const DeleteProjectDocument = gql`
+	mutation DeleteProject($id: ID!) {
+		deleteProject(id: $id)
+	}
+`
+export type DeleteProjectMutationFn = Apollo.MutationFunction<
+	Types.DeleteProjectMutation,
+	Types.DeleteProjectMutationVariables
+>
 
 /**
  * __useDeleteProjectMutation__
@@ -1104,21 +1621,38 @@ export type DeleteProjectMutationFn = Apollo.MutationFunction<Types.DeleteProjec
  *   },
  * });
  */
-export function useDeleteProjectMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteProjectMutation, Types.DeleteProjectMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteProjectMutation, Types.DeleteProjectMutationVariables>(DeleteProjectDocument, baseOptions);
-      }
-export type DeleteProjectMutationHookResult = ReturnType<typeof useDeleteProjectMutation>;
-export type DeleteProjectMutationResult = Apollo.MutationResult<Types.DeleteProjectMutation>;
-export type DeleteProjectMutationOptions = Apollo.BaseMutationOptions<Types.DeleteProjectMutation, Types.DeleteProjectMutationVariables>;
-export const EditWorkspaceDocument = gql`
-    mutation EditWorkspace($id: ID!, $name: String) {
-  editWorkspace(id: $id, name: $name) {
-    id
-    name
-  }
+export function useDeleteProjectMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteProjectMutation,
+		Types.DeleteProjectMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteProjectMutation,
+		Types.DeleteProjectMutationVariables
+	>(DeleteProjectDocument, baseOptions)
 }
-    `;
-export type EditWorkspaceMutationFn = Apollo.MutationFunction<Types.EditWorkspaceMutation, Types.EditWorkspaceMutationVariables>;
+export type DeleteProjectMutationHookResult = ReturnType<
+	typeof useDeleteProjectMutation
+>
+export type DeleteProjectMutationResult =
+	Apollo.MutationResult<Types.DeleteProjectMutation>
+export type DeleteProjectMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteProjectMutation,
+	Types.DeleteProjectMutationVariables
+>
+export const EditWorkspaceDocument = gql`
+	mutation EditWorkspace($id: ID!, $name: String) {
+		editWorkspace(id: $id, name: $name) {
+			id
+			name
+		}
+	}
+`
+export type EditWorkspaceMutationFn = Apollo.MutationFunction<
+	Types.EditWorkspaceMutation,
+	Types.EditWorkspaceMutationVariables
+>
 
 /**
  * __useEditWorkspaceMutation__
@@ -1138,21 +1672,41 @@ export type EditWorkspaceMutationFn = Apollo.MutationFunction<Types.EditWorkspac
  *   },
  * });
  */
-export function useEditWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.EditWorkspaceMutation, Types.EditWorkspaceMutationVariables>) {
-        return Apollo.useMutation<Types.EditWorkspaceMutation, Types.EditWorkspaceMutationVariables>(EditWorkspaceDocument, baseOptions);
-      }
-export type EditWorkspaceMutationHookResult = ReturnType<typeof useEditWorkspaceMutation>;
-export type EditWorkspaceMutationResult = Apollo.MutationResult<Types.EditWorkspaceMutation>;
-export type EditWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.EditWorkspaceMutation, Types.EditWorkspaceMutationVariables>;
-export const EditWorkspaceSettingsDocument = gql`
-    mutation EditWorkspaceSettings($workspace_id: ID!, $ai_insights: Boolean) {
-  editWorkspaceSettings(workspace_id: $workspace_id, ai_insights: $ai_insights) {
-    workspace_id
-    ai_insights
-  }
+export function useEditWorkspaceMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.EditWorkspaceMutation,
+		Types.EditWorkspaceMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.EditWorkspaceMutation,
+		Types.EditWorkspaceMutationVariables
+	>(EditWorkspaceDocument, baseOptions)
 }
-    `;
-export type EditWorkspaceSettingsMutationFn = Apollo.MutationFunction<Types.EditWorkspaceSettingsMutation, Types.EditWorkspaceSettingsMutationVariables>;
+export type EditWorkspaceMutationHookResult = ReturnType<
+	typeof useEditWorkspaceMutation
+>
+export type EditWorkspaceMutationResult =
+	Apollo.MutationResult<Types.EditWorkspaceMutation>
+export type EditWorkspaceMutationOptions = Apollo.BaseMutationOptions<
+	Types.EditWorkspaceMutation,
+	Types.EditWorkspaceMutationVariables
+>
+export const EditWorkspaceSettingsDocument = gql`
+	mutation EditWorkspaceSettings($workspace_id: ID!, $ai_insights: Boolean) {
+		editWorkspaceSettings(
+			workspace_id: $workspace_id
+			ai_insights: $ai_insights
+		) {
+			workspace_id
+			ai_insights
+		}
+	}
+`
+export type EditWorkspaceSettingsMutationFn = Apollo.MutationFunction<
+	Types.EditWorkspaceSettingsMutation,
+	Types.EditWorkspaceSettingsMutationVariables
+>
 
 /**
  * __useEditWorkspaceSettingsMutation__
@@ -1172,18 +1726,35 @@ export type EditWorkspaceSettingsMutationFn = Apollo.MutationFunction<Types.Edit
  *   },
  * });
  */
-export function useEditWorkspaceSettingsMutation(baseOptions?: Apollo.MutationHookOptions<Types.EditWorkspaceSettingsMutation, Types.EditWorkspaceSettingsMutationVariables>) {
-        return Apollo.useMutation<Types.EditWorkspaceSettingsMutation, Types.EditWorkspaceSettingsMutationVariables>(EditWorkspaceSettingsDocument, baseOptions);
-      }
-export type EditWorkspaceSettingsMutationHookResult = ReturnType<typeof useEditWorkspaceSettingsMutation>;
-export type EditWorkspaceSettingsMutationResult = Apollo.MutationResult<Types.EditWorkspaceSettingsMutation>;
-export type EditWorkspaceSettingsMutationOptions = Apollo.BaseMutationOptions<Types.EditWorkspaceSettingsMutation, Types.EditWorkspaceSettingsMutationVariables>;
-export const DeleteSegmentDocument = gql`
-    mutation DeleteSegment($segment_id: ID!) {
-  deleteSegment(segment_id: $segment_id)
+export function useEditWorkspaceSettingsMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.EditWorkspaceSettingsMutation,
+		Types.EditWorkspaceSettingsMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.EditWorkspaceSettingsMutation,
+		Types.EditWorkspaceSettingsMutationVariables
+	>(EditWorkspaceSettingsDocument, baseOptions)
 }
-    `;
-export type DeleteSegmentMutationFn = Apollo.MutationFunction<Types.DeleteSegmentMutation, Types.DeleteSegmentMutationVariables>;
+export type EditWorkspaceSettingsMutationHookResult = ReturnType<
+	typeof useEditWorkspaceSettingsMutation
+>
+export type EditWorkspaceSettingsMutationResult =
+	Apollo.MutationResult<Types.EditWorkspaceSettingsMutation>
+export type EditWorkspaceSettingsMutationOptions = Apollo.BaseMutationOptions<
+	Types.EditWorkspaceSettingsMutation,
+	Types.EditWorkspaceSettingsMutationVariables
+>
+export const DeleteSegmentDocument = gql`
+	mutation DeleteSegment($segment_id: ID!) {
+		deleteSegment(segment_id: $segment_id)
+	}
+`
+export type DeleteSegmentMutationFn = Apollo.MutationFunction<
+	Types.DeleteSegmentMutation,
+	Types.DeleteSegmentMutationVariables
+>
 
 /**
  * __useDeleteSegmentMutation__
@@ -1202,18 +1773,45 @@ export type DeleteSegmentMutationFn = Apollo.MutationFunction<Types.DeleteSegmen
  *   },
  * });
  */
-export function useDeleteSegmentMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteSegmentMutation, Types.DeleteSegmentMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteSegmentMutation, Types.DeleteSegmentMutationVariables>(DeleteSegmentDocument, baseOptions);
-      }
-export type DeleteSegmentMutationHookResult = ReturnType<typeof useDeleteSegmentMutation>;
-export type DeleteSegmentMutationResult = Apollo.MutationResult<Types.DeleteSegmentMutation>;
-export type DeleteSegmentMutationOptions = Apollo.BaseMutationOptions<Types.DeleteSegmentMutation, Types.DeleteSegmentMutationVariables>;
-export const EditSegmentDocument = gql`
-    mutation EditSegment($project_id: ID!, $id: ID!, $params: SearchParamsInput!, $name: String!) {
-  editSegment(project_id: $project_id, id: $id, params: $params, name: $name)
+export function useDeleteSegmentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteSegmentMutation,
+		Types.DeleteSegmentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteSegmentMutation,
+		Types.DeleteSegmentMutationVariables
+	>(DeleteSegmentDocument, baseOptions)
 }
-    `;
-export type EditSegmentMutationFn = Apollo.MutationFunction<Types.EditSegmentMutation, Types.EditSegmentMutationVariables>;
+export type DeleteSegmentMutationHookResult = ReturnType<
+	typeof useDeleteSegmentMutation
+>
+export type DeleteSegmentMutationResult =
+	Apollo.MutationResult<Types.DeleteSegmentMutation>
+export type DeleteSegmentMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteSegmentMutation,
+	Types.DeleteSegmentMutationVariables
+>
+export const EditSegmentDocument = gql`
+	mutation EditSegment(
+		$project_id: ID!
+		$id: ID!
+		$params: SearchParamsInput!
+		$name: String!
+	) {
+		editSegment(
+			project_id: $project_id
+			id: $id
+			params: $params
+			name: $name
+		)
+	}
+`
+export type EditSegmentMutationFn = Apollo.MutationFunction<
+	Types.EditSegmentMutation,
+	Types.EditSegmentMutationVariables
+>
 
 /**
  * __useEditSegmentMutation__
@@ -1235,45 +1833,66 @@ export type EditSegmentMutationFn = Apollo.MutationFunction<Types.EditSegmentMut
  *   },
  * });
  */
-export function useEditSegmentMutation(baseOptions?: Apollo.MutationHookOptions<Types.EditSegmentMutation, Types.EditSegmentMutationVariables>) {
-        return Apollo.useMutation<Types.EditSegmentMutation, Types.EditSegmentMutationVariables>(EditSegmentDocument, baseOptions);
-      }
-export type EditSegmentMutationHookResult = ReturnType<typeof useEditSegmentMutation>;
-export type EditSegmentMutationResult = Apollo.MutationResult<Types.EditSegmentMutation>;
-export type EditSegmentMutationOptions = Apollo.BaseMutationOptions<Types.EditSegmentMutation, Types.EditSegmentMutationVariables>;
-export const CreateSegmentDocument = gql`
-    mutation CreateSegment($project_id: ID!, $name: String!, $params: SearchParamsInput!) {
-  createSegment(project_id: $project_id, name: $name, params: $params) {
-    name
-    id
-    params {
-      user_properties {
-        name
-        value
-      }
-      excluded_properties {
-        name
-        value
-      }
-      date_range {
-        start_date
-        end_date
-      }
-      os
-      browser
-      visited_url
-      referrer
-      identified
-      hide_viewed
-      app_versions
-      environments
-      device_id
-      show_live_sessions
-    }
-  }
+export function useEditSegmentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.EditSegmentMutation,
+		Types.EditSegmentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.EditSegmentMutation,
+		Types.EditSegmentMutationVariables
+	>(EditSegmentDocument, baseOptions)
 }
-    `;
-export type CreateSegmentMutationFn = Apollo.MutationFunction<Types.CreateSegmentMutation, Types.CreateSegmentMutationVariables>;
+export type EditSegmentMutationHookResult = ReturnType<
+	typeof useEditSegmentMutation
+>
+export type EditSegmentMutationResult =
+	Apollo.MutationResult<Types.EditSegmentMutation>
+export type EditSegmentMutationOptions = Apollo.BaseMutationOptions<
+	Types.EditSegmentMutation,
+	Types.EditSegmentMutationVariables
+>
+export const CreateSegmentDocument = gql`
+	mutation CreateSegment(
+		$project_id: ID!
+		$name: String!
+		$params: SearchParamsInput!
+	) {
+		createSegment(project_id: $project_id, name: $name, params: $params) {
+			name
+			id
+			params {
+				user_properties {
+					name
+					value
+				}
+				excluded_properties {
+					name
+					value
+				}
+				date_range {
+					start_date
+					end_date
+				}
+				os
+				browser
+				visited_url
+				referrer
+				identified
+				hide_viewed
+				app_versions
+				environments
+				device_id
+				show_live_sessions
+			}
+		}
+	}
+`
+export type CreateSegmentMutationFn = Apollo.MutationFunction<
+	Types.CreateSegmentMutation,
+	Types.CreateSegmentMutationVariables
+>
 
 /**
  * __useCreateSegmentMutation__
@@ -1294,57 +1913,94 @@ export type CreateSegmentMutationFn = Apollo.MutationFunction<Types.CreateSegmen
  *   },
  * });
  */
-export function useCreateSegmentMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateSegmentMutation, Types.CreateSegmentMutationVariables>) {
-        return Apollo.useMutation<Types.CreateSegmentMutation, Types.CreateSegmentMutationVariables>(CreateSegmentDocument, baseOptions);
-      }
-export type CreateSegmentMutationHookResult = ReturnType<typeof useCreateSegmentMutation>;
-export type CreateSegmentMutationResult = Apollo.MutationResult<Types.CreateSegmentMutation>;
-export type CreateSegmentMutationOptions = Apollo.BaseMutationOptions<Types.CreateSegmentMutation, Types.CreateSegmentMutationVariables>;
-export const CreateSessionCommentDocument = gql`
-    mutation CreateSessionComment($project_id: ID!, $session_secure_id: String!, $session_timestamp: Int!, $text: String!, $text_for_email: String!, $x_coordinate: Float!, $y_coordinate: Float!, $tagged_admins: [SanitizedAdminInput]!, $tagged_slack_users: [SanitizedSlackChannelInput]!, $session_url: String!, $time: Float!, $author_name: String!, $session_image: String, $tags: [SessionCommentTagInput]!, $integrations: [IntegrationType]!, $issue_title: String, $issue_team_id: String, $issue_description: String, $additional_context: String) {
-  createSessionComment(
-    project_id: $project_id
-    session_secure_id: $session_secure_id
-    session_timestamp: $session_timestamp
-    text: $text
-    text_for_email: $text_for_email
-    x_coordinate: $x_coordinate
-    y_coordinate: $y_coordinate
-    tagged_admins: $tagged_admins
-    tagged_slack_users: $tagged_slack_users
-    session_url: $session_url
-    time: $time
-    author_name: $author_name
-    session_image: $session_image
-    tags: $tags
-    integrations: $integrations
-    issue_title: $issue_title
-    issue_team_id: $issue_team_id
-    issue_description: $issue_description
-    additional_context: $additional_context
-  ) {
-    id
-    timestamp
-    created_at
-    updated_at
-    author {
-      id
-      name
-      email
-    }
-    text
-    x_coordinate
-    y_coordinate
-    attachments {
-      id
-      integration_type
-      external_id
-      title
-    }
-  }
+export function useCreateSegmentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateSegmentMutation,
+		Types.CreateSegmentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateSegmentMutation,
+		Types.CreateSegmentMutationVariables
+	>(CreateSegmentDocument, baseOptions)
 }
-    `;
-export type CreateSessionCommentMutationFn = Apollo.MutationFunction<Types.CreateSessionCommentMutation, Types.CreateSessionCommentMutationVariables>;
+export type CreateSegmentMutationHookResult = ReturnType<
+	typeof useCreateSegmentMutation
+>
+export type CreateSegmentMutationResult =
+	Apollo.MutationResult<Types.CreateSegmentMutation>
+export type CreateSegmentMutationOptions = Apollo.BaseMutationOptions<
+	Types.CreateSegmentMutation,
+	Types.CreateSegmentMutationVariables
+>
+export const CreateSessionCommentDocument = gql`
+	mutation CreateSessionComment(
+		$project_id: ID!
+		$session_secure_id: String!
+		$session_timestamp: Int!
+		$text: String!
+		$text_for_email: String!
+		$x_coordinate: Float!
+		$y_coordinate: Float!
+		$tagged_admins: [SanitizedAdminInput]!
+		$tagged_slack_users: [SanitizedSlackChannelInput]!
+		$session_url: String!
+		$time: Float!
+		$author_name: String!
+		$session_image: String
+		$tags: [SessionCommentTagInput]!
+		$integrations: [IntegrationType]!
+		$issue_title: String
+		$issue_team_id: String
+		$issue_description: String
+		$additional_context: String
+	) {
+		createSessionComment(
+			project_id: $project_id
+			session_secure_id: $session_secure_id
+			session_timestamp: $session_timestamp
+			text: $text
+			text_for_email: $text_for_email
+			x_coordinate: $x_coordinate
+			y_coordinate: $y_coordinate
+			tagged_admins: $tagged_admins
+			tagged_slack_users: $tagged_slack_users
+			session_url: $session_url
+			time: $time
+			author_name: $author_name
+			session_image: $session_image
+			tags: $tags
+			integrations: $integrations
+			issue_title: $issue_title
+			issue_team_id: $issue_team_id
+			issue_description: $issue_description
+			additional_context: $additional_context
+		) {
+			id
+			timestamp
+			created_at
+			updated_at
+			author {
+				id
+				name
+				email
+			}
+			text
+			x_coordinate
+			y_coordinate
+			attachments {
+				id
+				integration_type
+				external_id
+				title
+			}
+		}
+	}
+`
+export type CreateSessionCommentMutationFn = Apollo.MutationFunction<
+	Types.CreateSessionCommentMutation,
+	Types.CreateSessionCommentMutationVariables
+>
 
 /**
  * __useCreateSessionCommentMutation__
@@ -1381,48 +2037,76 @@ export type CreateSessionCommentMutationFn = Apollo.MutationFunction<Types.Creat
  *   },
  * });
  */
-export function useCreateSessionCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateSessionCommentMutation, Types.CreateSessionCommentMutationVariables>) {
-        return Apollo.useMutation<Types.CreateSessionCommentMutation, Types.CreateSessionCommentMutationVariables>(CreateSessionCommentDocument, baseOptions);
-      }
-export type CreateSessionCommentMutationHookResult = ReturnType<typeof useCreateSessionCommentMutation>;
-export type CreateSessionCommentMutationResult = Apollo.MutationResult<Types.CreateSessionCommentMutation>;
-export type CreateSessionCommentMutationOptions = Apollo.BaseMutationOptions<Types.CreateSessionCommentMutation, Types.CreateSessionCommentMutationVariables>;
-export const CreateIssueForSessionCommentDocument = gql`
-    mutation CreateIssueForSessionComment($project_id: ID!, $session_comment_id: Int!, $text_for_attachment: String!, $session_url: String!, $time: Float!, $author_name: String!, $integrations: [IntegrationType]!, $issue_title: String, $issue_team_id: String, $issue_description: String) {
-  createIssueForSessionComment(
-    project_id: $project_id
-    session_url: $session_url
-    session_comment_id: $session_comment_id
-    author_name: $author_name
-    text_for_attachment: $text_for_attachment
-    time: $time
-    issue_title: $issue_title
-    issue_description: $issue_description
-    issue_team_id: $issue_team_id
-    integrations: $integrations
-  ) {
-    id
-    timestamp
-    created_at
-    updated_at
-    author {
-      id
-      name
-      email
-    }
-    text
-    x_coordinate
-    y_coordinate
-    attachments {
-      id
-      integration_type
-      external_id
-      title
-    }
-  }
+export function useCreateSessionCommentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateSessionCommentMutation,
+		Types.CreateSessionCommentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateSessionCommentMutation,
+		Types.CreateSessionCommentMutationVariables
+	>(CreateSessionCommentDocument, baseOptions)
 }
-    `;
-export type CreateIssueForSessionCommentMutationFn = Apollo.MutationFunction<Types.CreateIssueForSessionCommentMutation, Types.CreateIssueForSessionCommentMutationVariables>;
+export type CreateSessionCommentMutationHookResult = ReturnType<
+	typeof useCreateSessionCommentMutation
+>
+export type CreateSessionCommentMutationResult =
+	Apollo.MutationResult<Types.CreateSessionCommentMutation>
+export type CreateSessionCommentMutationOptions = Apollo.BaseMutationOptions<
+	Types.CreateSessionCommentMutation,
+	Types.CreateSessionCommentMutationVariables
+>
+export const CreateIssueForSessionCommentDocument = gql`
+	mutation CreateIssueForSessionComment(
+		$project_id: ID!
+		$session_comment_id: Int!
+		$text_for_attachment: String!
+		$session_url: String!
+		$time: Float!
+		$author_name: String!
+		$integrations: [IntegrationType]!
+		$issue_title: String
+		$issue_team_id: String
+		$issue_description: String
+	) {
+		createIssueForSessionComment(
+			project_id: $project_id
+			session_url: $session_url
+			session_comment_id: $session_comment_id
+			author_name: $author_name
+			text_for_attachment: $text_for_attachment
+			time: $time
+			issue_title: $issue_title
+			issue_description: $issue_description
+			issue_team_id: $issue_team_id
+			integrations: $integrations
+		) {
+			id
+			timestamp
+			created_at
+			updated_at
+			author {
+				id
+				name
+				email
+			}
+			text
+			x_coordinate
+			y_coordinate
+			attachments {
+				id
+				integration_type
+				external_id
+				title
+			}
+		}
+	}
+`
+export type CreateIssueForSessionCommentMutationFn = Apollo.MutationFunction<
+	Types.CreateIssueForSessionCommentMutation,
+	Types.CreateIssueForSessionCommentMutationVariables
+>
 
 /**
  * __useCreateIssueForSessionCommentMutation__
@@ -1450,18 +2134,36 @@ export type CreateIssueForSessionCommentMutationFn = Apollo.MutationFunction<Typ
  *   },
  * });
  */
-export function useCreateIssueForSessionCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateIssueForSessionCommentMutation, Types.CreateIssueForSessionCommentMutationVariables>) {
-        return Apollo.useMutation<Types.CreateIssueForSessionCommentMutation, Types.CreateIssueForSessionCommentMutationVariables>(CreateIssueForSessionCommentDocument, baseOptions);
-      }
-export type CreateIssueForSessionCommentMutationHookResult = ReturnType<typeof useCreateIssueForSessionCommentMutation>;
-export type CreateIssueForSessionCommentMutationResult = Apollo.MutationResult<Types.CreateIssueForSessionCommentMutation>;
-export type CreateIssueForSessionCommentMutationOptions = Apollo.BaseMutationOptions<Types.CreateIssueForSessionCommentMutation, Types.CreateIssueForSessionCommentMutationVariables>;
-export const DeleteSessionCommentDocument = gql`
-    mutation DeleteSessionComment($id: ID!) {
-  deleteSessionComment(id: $id)
+export function useCreateIssueForSessionCommentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateIssueForSessionCommentMutation,
+		Types.CreateIssueForSessionCommentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateIssueForSessionCommentMutation,
+		Types.CreateIssueForSessionCommentMutationVariables
+	>(CreateIssueForSessionCommentDocument, baseOptions)
 }
-    `;
-export type DeleteSessionCommentMutationFn = Apollo.MutationFunction<Types.DeleteSessionCommentMutation, Types.DeleteSessionCommentMutationVariables>;
+export type CreateIssueForSessionCommentMutationHookResult = ReturnType<
+	typeof useCreateIssueForSessionCommentMutation
+>
+export type CreateIssueForSessionCommentMutationResult =
+	Apollo.MutationResult<Types.CreateIssueForSessionCommentMutation>
+export type CreateIssueForSessionCommentMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.CreateIssueForSessionCommentMutation,
+		Types.CreateIssueForSessionCommentMutationVariables
+	>
+export const DeleteSessionCommentDocument = gql`
+	mutation DeleteSessionComment($id: ID!) {
+		deleteSessionComment(id: $id)
+	}
+`
+export type DeleteSessionCommentMutationFn = Apollo.MutationFunction<
+	Types.DeleteSessionCommentMutation,
+	Types.DeleteSessionCommentMutationVariables
+>
 
 /**
  * __useDeleteSessionCommentMutation__
@@ -1480,36 +2182,60 @@ export type DeleteSessionCommentMutationFn = Apollo.MutationFunction<Types.Delet
  *   },
  * });
  */
-export function useDeleteSessionCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteSessionCommentMutation, Types.DeleteSessionCommentMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteSessionCommentMutation, Types.DeleteSessionCommentMutationVariables>(DeleteSessionCommentDocument, baseOptions);
-      }
-export type DeleteSessionCommentMutationHookResult = ReturnType<typeof useDeleteSessionCommentMutation>;
-export type DeleteSessionCommentMutationResult = Apollo.MutationResult<Types.DeleteSessionCommentMutation>;
-export type DeleteSessionCommentMutationOptions = Apollo.BaseMutationOptions<Types.DeleteSessionCommentMutation, Types.DeleteSessionCommentMutationVariables>;
-export const ReplyToSessionCommentDocument = gql`
-    mutation ReplyToSessionComment($comment_id: ID!, $text: String!, $text_for_email: String!, $sessionURL: String!, $tagged_admins: [SanitizedAdminInput]!, $tagged_slack_users: [SanitizedSlackChannelInput]!) {
-  replyToSessionComment(
-    comment_id: $comment_id
-    text: $text
-    text_for_email: $text_for_email
-    sessionURL: $sessionURL
-    tagged_admins: $tagged_admins
-    tagged_slack_users: $tagged_slack_users
-  ) {
-    id
-    created_at
-    updated_at
-    author {
-      id
-      name
-      email
-      photo_url
-    }
-    text
-  }
+export function useDeleteSessionCommentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteSessionCommentMutation,
+		Types.DeleteSessionCommentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteSessionCommentMutation,
+		Types.DeleteSessionCommentMutationVariables
+	>(DeleteSessionCommentDocument, baseOptions)
 }
-    `;
-export type ReplyToSessionCommentMutationFn = Apollo.MutationFunction<Types.ReplyToSessionCommentMutation, Types.ReplyToSessionCommentMutationVariables>;
+export type DeleteSessionCommentMutationHookResult = ReturnType<
+	typeof useDeleteSessionCommentMutation
+>
+export type DeleteSessionCommentMutationResult =
+	Apollo.MutationResult<Types.DeleteSessionCommentMutation>
+export type DeleteSessionCommentMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteSessionCommentMutation,
+	Types.DeleteSessionCommentMutationVariables
+>
+export const ReplyToSessionCommentDocument = gql`
+	mutation ReplyToSessionComment(
+		$comment_id: ID!
+		$text: String!
+		$text_for_email: String!
+		$sessionURL: String!
+		$tagged_admins: [SanitizedAdminInput]!
+		$tagged_slack_users: [SanitizedSlackChannelInput]!
+	) {
+		replyToSessionComment(
+			comment_id: $comment_id
+			text: $text
+			text_for_email: $text_for_email
+			sessionURL: $sessionURL
+			tagged_admins: $tagged_admins
+			tagged_slack_users: $tagged_slack_users
+		) {
+			id
+			created_at
+			updated_at
+			author {
+				id
+				name
+				email
+				photo_url
+			}
+			text
+		}
+	}
+`
+export type ReplyToSessionCommentMutationFn = Apollo.MutationFunction<
+	Types.ReplyToSessionCommentMutation,
+	Types.ReplyToSessionCommentMutationVariables
+>
 
 /**
  * __useReplyToSessionCommentMutation__
@@ -1533,41 +2259,71 @@ export type ReplyToSessionCommentMutationFn = Apollo.MutationFunction<Types.Repl
  *   },
  * });
  */
-export function useReplyToSessionCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.ReplyToSessionCommentMutation, Types.ReplyToSessionCommentMutationVariables>) {
-        return Apollo.useMutation<Types.ReplyToSessionCommentMutation, Types.ReplyToSessionCommentMutationVariables>(ReplyToSessionCommentDocument, baseOptions);
-      }
-export type ReplyToSessionCommentMutationHookResult = ReturnType<typeof useReplyToSessionCommentMutation>;
-export type ReplyToSessionCommentMutationResult = Apollo.MutationResult<Types.ReplyToSessionCommentMutation>;
-export type ReplyToSessionCommentMutationOptions = Apollo.BaseMutationOptions<Types.ReplyToSessionCommentMutation, Types.ReplyToSessionCommentMutationVariables>;
-export const CreateErrorCommentDocument = gql`
-    mutation CreateErrorComment($project_id: ID!, $error_group_secure_id: String!, $text: String!, $text_for_email: String!, $tagged_admins: [SanitizedAdminInput]!, $tagged_slack_users: [SanitizedSlackChannelInput]!, $error_url: String!, $author_name: String!, $integrations: [IntegrationType]!, $issue_title: String, $issue_team_id: String, $issue_description: String) {
-  createErrorComment(
-    project_id: $project_id
-    error_group_secure_id: $error_group_secure_id
-    text: $text
-    text_for_email: $text_for_email
-    tagged_admins: $tagged_admins
-    tagged_slack_users: $tagged_slack_users
-    error_url: $error_url
-    author_name: $author_name
-    integrations: $integrations
-    issue_title: $issue_title
-    issue_team_id: $issue_team_id
-    issue_description: $issue_description
-  ) {
-    id
-    created_at
-    updated_at
-    author {
-      id
-      name
-      email
-    }
-    text
-  }
+export function useReplyToSessionCommentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.ReplyToSessionCommentMutation,
+		Types.ReplyToSessionCommentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.ReplyToSessionCommentMutation,
+		Types.ReplyToSessionCommentMutationVariables
+	>(ReplyToSessionCommentDocument, baseOptions)
 }
-    `;
-export type CreateErrorCommentMutationFn = Apollo.MutationFunction<Types.CreateErrorCommentMutation, Types.CreateErrorCommentMutationVariables>;
+export type ReplyToSessionCommentMutationHookResult = ReturnType<
+	typeof useReplyToSessionCommentMutation
+>
+export type ReplyToSessionCommentMutationResult =
+	Apollo.MutationResult<Types.ReplyToSessionCommentMutation>
+export type ReplyToSessionCommentMutationOptions = Apollo.BaseMutationOptions<
+	Types.ReplyToSessionCommentMutation,
+	Types.ReplyToSessionCommentMutationVariables
+>
+export const CreateErrorCommentDocument = gql`
+	mutation CreateErrorComment(
+		$project_id: ID!
+		$error_group_secure_id: String!
+		$text: String!
+		$text_for_email: String!
+		$tagged_admins: [SanitizedAdminInput]!
+		$tagged_slack_users: [SanitizedSlackChannelInput]!
+		$error_url: String!
+		$author_name: String!
+		$integrations: [IntegrationType]!
+		$issue_title: String
+		$issue_team_id: String
+		$issue_description: String
+	) {
+		createErrorComment(
+			project_id: $project_id
+			error_group_secure_id: $error_group_secure_id
+			text: $text
+			text_for_email: $text_for_email
+			tagged_admins: $tagged_admins
+			tagged_slack_users: $tagged_slack_users
+			error_url: $error_url
+			author_name: $author_name
+			integrations: $integrations
+			issue_title: $issue_title
+			issue_team_id: $issue_team_id
+			issue_description: $issue_description
+		) {
+			id
+			created_at
+			updated_at
+			author {
+				id
+				name
+				email
+			}
+			text
+		}
+	}
+`
+export type CreateErrorCommentMutationFn = Apollo.MutationFunction<
+	Types.CreateErrorCommentMutation,
+	Types.CreateErrorCommentMutationVariables
+>
 
 /**
  * __useCreateErrorCommentMutation__
@@ -1597,44 +2353,71 @@ export type CreateErrorCommentMutationFn = Apollo.MutationFunction<Types.CreateE
  *   },
  * });
  */
-export function useCreateErrorCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateErrorCommentMutation, Types.CreateErrorCommentMutationVariables>) {
-        return Apollo.useMutation<Types.CreateErrorCommentMutation, Types.CreateErrorCommentMutationVariables>(CreateErrorCommentDocument, baseOptions);
-      }
-export type CreateErrorCommentMutationHookResult = ReturnType<typeof useCreateErrorCommentMutation>;
-export type CreateErrorCommentMutationResult = Apollo.MutationResult<Types.CreateErrorCommentMutation>;
-export type CreateErrorCommentMutationOptions = Apollo.BaseMutationOptions<Types.CreateErrorCommentMutation, Types.CreateErrorCommentMutationVariables>;
-export const CreateIssueForErrorCommentDocument = gql`
-    mutation CreateIssueForErrorComment($project_id: ID!, $error_comment_id: Int!, $text_for_attachment: String!, $error_url: String!, $author_name: String!, $integrations: [IntegrationType]!, $issue_title: String, $issue_team_id: String, $issue_description: String) {
-  createIssueForErrorComment(
-    project_id: $project_id
-    error_url: $error_url
-    error_comment_id: $error_comment_id
-    author_name: $author_name
-    text_for_attachment: $text_for_attachment
-    issue_title: $issue_title
-    issue_team_id: $issue_team_id
-    issue_description: $issue_description
-    integrations: $integrations
-  ) {
-    id
-    created_at
-    updated_at
-    author {
-      id
-      name
-      email
-    }
-    text
-    attachments {
-      id
-      integration_type
-      external_id
-      title
-    }
-  }
+export function useCreateErrorCommentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateErrorCommentMutation,
+		Types.CreateErrorCommentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateErrorCommentMutation,
+		Types.CreateErrorCommentMutationVariables
+	>(CreateErrorCommentDocument, baseOptions)
 }
-    `;
-export type CreateIssueForErrorCommentMutationFn = Apollo.MutationFunction<Types.CreateIssueForErrorCommentMutation, Types.CreateIssueForErrorCommentMutationVariables>;
+export type CreateErrorCommentMutationHookResult = ReturnType<
+	typeof useCreateErrorCommentMutation
+>
+export type CreateErrorCommentMutationResult =
+	Apollo.MutationResult<Types.CreateErrorCommentMutation>
+export type CreateErrorCommentMutationOptions = Apollo.BaseMutationOptions<
+	Types.CreateErrorCommentMutation,
+	Types.CreateErrorCommentMutationVariables
+>
+export const CreateIssueForErrorCommentDocument = gql`
+	mutation CreateIssueForErrorComment(
+		$project_id: ID!
+		$error_comment_id: Int!
+		$text_for_attachment: String!
+		$error_url: String!
+		$author_name: String!
+		$integrations: [IntegrationType]!
+		$issue_title: String
+		$issue_team_id: String
+		$issue_description: String
+	) {
+		createIssueForErrorComment(
+			project_id: $project_id
+			error_url: $error_url
+			error_comment_id: $error_comment_id
+			author_name: $author_name
+			text_for_attachment: $text_for_attachment
+			issue_title: $issue_title
+			issue_team_id: $issue_team_id
+			issue_description: $issue_description
+			integrations: $integrations
+		) {
+			id
+			created_at
+			updated_at
+			author {
+				id
+				name
+				email
+			}
+			text
+			attachments {
+				id
+				integration_type
+				external_id
+				title
+			}
+		}
+	}
+`
+export type CreateIssueForErrorCommentMutationFn = Apollo.MutationFunction<
+	Types.CreateIssueForErrorCommentMutation,
+	Types.CreateIssueForErrorCommentMutationVariables
+>
 
 /**
  * __useCreateIssueForErrorCommentMutation__
@@ -1661,18 +2444,36 @@ export type CreateIssueForErrorCommentMutationFn = Apollo.MutationFunction<Types
  *   },
  * });
  */
-export function useCreateIssueForErrorCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateIssueForErrorCommentMutation, Types.CreateIssueForErrorCommentMutationVariables>) {
-        return Apollo.useMutation<Types.CreateIssueForErrorCommentMutation, Types.CreateIssueForErrorCommentMutationVariables>(CreateIssueForErrorCommentDocument, baseOptions);
-      }
-export type CreateIssueForErrorCommentMutationHookResult = ReturnType<typeof useCreateIssueForErrorCommentMutation>;
-export type CreateIssueForErrorCommentMutationResult = Apollo.MutationResult<Types.CreateIssueForErrorCommentMutation>;
-export type CreateIssueForErrorCommentMutationOptions = Apollo.BaseMutationOptions<Types.CreateIssueForErrorCommentMutation, Types.CreateIssueForErrorCommentMutationVariables>;
-export const DeleteErrorCommentDocument = gql`
-    mutation DeleteErrorComment($id: ID!) {
-  deleteErrorComment(id: $id)
+export function useCreateIssueForErrorCommentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateIssueForErrorCommentMutation,
+		Types.CreateIssueForErrorCommentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateIssueForErrorCommentMutation,
+		Types.CreateIssueForErrorCommentMutationVariables
+	>(CreateIssueForErrorCommentDocument, baseOptions)
 }
-    `;
-export type DeleteErrorCommentMutationFn = Apollo.MutationFunction<Types.DeleteErrorCommentMutation, Types.DeleteErrorCommentMutationVariables>;
+export type CreateIssueForErrorCommentMutationHookResult = ReturnType<
+	typeof useCreateIssueForErrorCommentMutation
+>
+export type CreateIssueForErrorCommentMutationResult =
+	Apollo.MutationResult<Types.CreateIssueForErrorCommentMutation>
+export type CreateIssueForErrorCommentMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.CreateIssueForErrorCommentMutation,
+		Types.CreateIssueForErrorCommentMutationVariables
+	>
+export const DeleteErrorCommentDocument = gql`
+	mutation DeleteErrorComment($id: ID!) {
+		deleteErrorComment(id: $id)
+	}
+`
+export type DeleteErrorCommentMutationFn = Apollo.MutationFunction<
+	Types.DeleteErrorCommentMutation,
+	Types.DeleteErrorCommentMutationVariables
+>
 
 /**
  * __useDeleteErrorCommentMutation__
@@ -1691,18 +2492,35 @@ export type DeleteErrorCommentMutationFn = Apollo.MutationFunction<Types.DeleteE
  *   },
  * });
  */
-export function useDeleteErrorCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteErrorCommentMutation, Types.DeleteErrorCommentMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteErrorCommentMutation, Types.DeleteErrorCommentMutationVariables>(DeleteErrorCommentDocument, baseOptions);
-      }
-export type DeleteErrorCommentMutationHookResult = ReturnType<typeof useDeleteErrorCommentMutation>;
-export type DeleteErrorCommentMutationResult = Apollo.MutationResult<Types.DeleteErrorCommentMutation>;
-export type DeleteErrorCommentMutationOptions = Apollo.BaseMutationOptions<Types.DeleteErrorCommentMutation, Types.DeleteErrorCommentMutationVariables>;
-export const MuteErrorCommentThreadDocument = gql`
-    mutation MuteErrorCommentThread($id: ID!, $has_muted: Boolean) {
-  muteErrorCommentThread(id: $id, has_muted: $has_muted)
+export function useDeleteErrorCommentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteErrorCommentMutation,
+		Types.DeleteErrorCommentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteErrorCommentMutation,
+		Types.DeleteErrorCommentMutationVariables
+	>(DeleteErrorCommentDocument, baseOptions)
 }
-    `;
-export type MuteErrorCommentThreadMutationFn = Apollo.MutationFunction<Types.MuteErrorCommentThreadMutation, Types.MuteErrorCommentThreadMutationVariables>;
+export type DeleteErrorCommentMutationHookResult = ReturnType<
+	typeof useDeleteErrorCommentMutation
+>
+export type DeleteErrorCommentMutationResult =
+	Apollo.MutationResult<Types.DeleteErrorCommentMutation>
+export type DeleteErrorCommentMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteErrorCommentMutation,
+	Types.DeleteErrorCommentMutationVariables
+>
+export const MuteErrorCommentThreadDocument = gql`
+	mutation MuteErrorCommentThread($id: ID!, $has_muted: Boolean) {
+		muteErrorCommentThread(id: $id, has_muted: $has_muted)
+	}
+`
+export type MuteErrorCommentThreadMutationFn = Apollo.MutationFunction<
+	Types.MuteErrorCommentThreadMutation,
+	Types.MuteErrorCommentThreadMutationVariables
+>
 
 /**
  * __useMuteErrorCommentThreadMutation__
@@ -1722,18 +2540,35 @@ export type MuteErrorCommentThreadMutationFn = Apollo.MutationFunction<Types.Mut
  *   },
  * });
  */
-export function useMuteErrorCommentThreadMutation(baseOptions?: Apollo.MutationHookOptions<Types.MuteErrorCommentThreadMutation, Types.MuteErrorCommentThreadMutationVariables>) {
-        return Apollo.useMutation<Types.MuteErrorCommentThreadMutation, Types.MuteErrorCommentThreadMutationVariables>(MuteErrorCommentThreadDocument, baseOptions);
-      }
-export type MuteErrorCommentThreadMutationHookResult = ReturnType<typeof useMuteErrorCommentThreadMutation>;
-export type MuteErrorCommentThreadMutationResult = Apollo.MutationResult<Types.MuteErrorCommentThreadMutation>;
-export type MuteErrorCommentThreadMutationOptions = Apollo.BaseMutationOptions<Types.MuteErrorCommentThreadMutation, Types.MuteErrorCommentThreadMutationVariables>;
-export const RemoveErrorIssueDocument = gql`
-    mutation RemoveErrorIssue($error_issue_id: ID!) {
-  removeErrorIssue(error_issue_id: $error_issue_id)
+export function useMuteErrorCommentThreadMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.MuteErrorCommentThreadMutation,
+		Types.MuteErrorCommentThreadMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.MuteErrorCommentThreadMutation,
+		Types.MuteErrorCommentThreadMutationVariables
+	>(MuteErrorCommentThreadDocument, baseOptions)
 }
-    `;
-export type RemoveErrorIssueMutationFn = Apollo.MutationFunction<Types.RemoveErrorIssueMutation, Types.RemoveErrorIssueMutationVariables>;
+export type MuteErrorCommentThreadMutationHookResult = ReturnType<
+	typeof useMuteErrorCommentThreadMutation
+>
+export type MuteErrorCommentThreadMutationResult =
+	Apollo.MutationResult<Types.MuteErrorCommentThreadMutation>
+export type MuteErrorCommentThreadMutationOptions = Apollo.BaseMutationOptions<
+	Types.MuteErrorCommentThreadMutation,
+	Types.MuteErrorCommentThreadMutationVariables
+>
+export const RemoveErrorIssueDocument = gql`
+	mutation RemoveErrorIssue($error_issue_id: ID!) {
+		removeErrorIssue(error_issue_id: $error_issue_id)
+	}
+`
+export type RemoveErrorIssueMutationFn = Apollo.MutationFunction<
+	Types.RemoveErrorIssueMutation,
+	Types.RemoveErrorIssueMutationVariables
+>
 
 /**
  * __useRemoveErrorIssueMutation__
@@ -1752,36 +2587,60 @@ export type RemoveErrorIssueMutationFn = Apollo.MutationFunction<Types.RemoveErr
  *   },
  * });
  */
-export function useRemoveErrorIssueMutation(baseOptions?: Apollo.MutationHookOptions<Types.RemoveErrorIssueMutation, Types.RemoveErrorIssueMutationVariables>) {
-        return Apollo.useMutation<Types.RemoveErrorIssueMutation, Types.RemoveErrorIssueMutationVariables>(RemoveErrorIssueDocument, baseOptions);
-      }
-export type RemoveErrorIssueMutationHookResult = ReturnType<typeof useRemoveErrorIssueMutation>;
-export type RemoveErrorIssueMutationResult = Apollo.MutationResult<Types.RemoveErrorIssueMutation>;
-export type RemoveErrorIssueMutationOptions = Apollo.BaseMutationOptions<Types.RemoveErrorIssueMutation, Types.RemoveErrorIssueMutationVariables>;
-export const ReplyToErrorCommentDocument = gql`
-    mutation ReplyToErrorComment($comment_id: ID!, $text: String!, $text_for_email: String!, $errorURL: String!, $tagged_admins: [SanitizedAdminInput]!, $tagged_slack_users: [SanitizedSlackChannelInput]!) {
-  replyToErrorComment(
-    comment_id: $comment_id
-    text: $text
-    text_for_email: $text_for_email
-    errorURL: $errorURL
-    tagged_admins: $tagged_admins
-    tagged_slack_users: $tagged_slack_users
-  ) {
-    id
-    created_at
-    updated_at
-    author {
-      id
-      name
-      email
-      photo_url
-    }
-    text
-  }
+export function useRemoveErrorIssueMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.RemoveErrorIssueMutation,
+		Types.RemoveErrorIssueMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.RemoveErrorIssueMutation,
+		Types.RemoveErrorIssueMutationVariables
+	>(RemoveErrorIssueDocument, baseOptions)
 }
-    `;
-export type ReplyToErrorCommentMutationFn = Apollo.MutationFunction<Types.ReplyToErrorCommentMutation, Types.ReplyToErrorCommentMutationVariables>;
+export type RemoveErrorIssueMutationHookResult = ReturnType<
+	typeof useRemoveErrorIssueMutation
+>
+export type RemoveErrorIssueMutationResult =
+	Apollo.MutationResult<Types.RemoveErrorIssueMutation>
+export type RemoveErrorIssueMutationOptions = Apollo.BaseMutationOptions<
+	Types.RemoveErrorIssueMutation,
+	Types.RemoveErrorIssueMutationVariables
+>
+export const ReplyToErrorCommentDocument = gql`
+	mutation ReplyToErrorComment(
+		$comment_id: ID!
+		$text: String!
+		$text_for_email: String!
+		$errorURL: String!
+		$tagged_admins: [SanitizedAdminInput]!
+		$tagged_slack_users: [SanitizedSlackChannelInput]!
+	) {
+		replyToErrorComment(
+			comment_id: $comment_id
+			text: $text
+			text_for_email: $text_for_email
+			errorURL: $errorURL
+			tagged_admins: $tagged_admins
+			tagged_slack_users: $tagged_slack_users
+		) {
+			id
+			created_at
+			updated_at
+			author {
+				id
+				name
+				email
+				photo_url
+			}
+			text
+		}
+	}
+`
+export type ReplyToErrorCommentMutationFn = Apollo.MutationFunction<
+	Types.ReplyToErrorCommentMutation,
+	Types.ReplyToErrorCommentMutationVariables
+>
 
 /**
  * __useReplyToErrorCommentMutation__
@@ -1805,18 +2664,35 @@ export type ReplyToErrorCommentMutationFn = Apollo.MutationFunction<Types.ReplyT
  *   },
  * });
  */
-export function useReplyToErrorCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.ReplyToErrorCommentMutation, Types.ReplyToErrorCommentMutationVariables>) {
-        return Apollo.useMutation<Types.ReplyToErrorCommentMutation, Types.ReplyToErrorCommentMutationVariables>(ReplyToErrorCommentDocument, baseOptions);
-      }
-export type ReplyToErrorCommentMutationHookResult = ReturnType<typeof useReplyToErrorCommentMutation>;
-export type ReplyToErrorCommentMutationResult = Apollo.MutationResult<Types.ReplyToErrorCommentMutation>;
-export type ReplyToErrorCommentMutationOptions = Apollo.BaseMutationOptions<Types.ReplyToErrorCommentMutation, Types.ReplyToErrorCommentMutationVariables>;
-export const DeleteErrorSegmentDocument = gql`
-    mutation DeleteErrorSegment($segment_id: ID!) {
-  deleteErrorSegment(segment_id: $segment_id)
+export function useReplyToErrorCommentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.ReplyToErrorCommentMutation,
+		Types.ReplyToErrorCommentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.ReplyToErrorCommentMutation,
+		Types.ReplyToErrorCommentMutationVariables
+	>(ReplyToErrorCommentDocument, baseOptions)
 }
-    `;
-export type DeleteErrorSegmentMutationFn = Apollo.MutationFunction<Types.DeleteErrorSegmentMutation, Types.DeleteErrorSegmentMutationVariables>;
+export type ReplyToErrorCommentMutationHookResult = ReturnType<
+	typeof useReplyToErrorCommentMutation
+>
+export type ReplyToErrorCommentMutationResult =
+	Apollo.MutationResult<Types.ReplyToErrorCommentMutation>
+export type ReplyToErrorCommentMutationOptions = Apollo.BaseMutationOptions<
+	Types.ReplyToErrorCommentMutation,
+	Types.ReplyToErrorCommentMutationVariables
+>
+export const DeleteErrorSegmentDocument = gql`
+	mutation DeleteErrorSegment($segment_id: ID!) {
+		deleteErrorSegment(segment_id: $segment_id)
+	}
+`
+export type DeleteErrorSegmentMutationFn = Apollo.MutationFunction<
+	Types.DeleteErrorSegmentMutation,
+	Types.DeleteErrorSegmentMutationVariables
+>
 
 /**
  * __useDeleteErrorSegmentMutation__
@@ -1835,18 +2711,45 @@ export type DeleteErrorSegmentMutationFn = Apollo.MutationFunction<Types.DeleteE
  *   },
  * });
  */
-export function useDeleteErrorSegmentMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteErrorSegmentMutation, Types.DeleteErrorSegmentMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteErrorSegmentMutation, Types.DeleteErrorSegmentMutationVariables>(DeleteErrorSegmentDocument, baseOptions);
-      }
-export type DeleteErrorSegmentMutationHookResult = ReturnType<typeof useDeleteErrorSegmentMutation>;
-export type DeleteErrorSegmentMutationResult = Apollo.MutationResult<Types.DeleteErrorSegmentMutation>;
-export type DeleteErrorSegmentMutationOptions = Apollo.BaseMutationOptions<Types.DeleteErrorSegmentMutation, Types.DeleteErrorSegmentMutationVariables>;
-export const EditErrorSegmentDocument = gql`
-    mutation EditErrorSegment($project_id: ID!, $id: ID!, $params: ErrorSearchParamsInput!, $name: String!) {
-  editErrorSegment(project_id: $project_id, id: $id, params: $params, name: $name)
+export function useDeleteErrorSegmentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteErrorSegmentMutation,
+		Types.DeleteErrorSegmentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteErrorSegmentMutation,
+		Types.DeleteErrorSegmentMutationVariables
+	>(DeleteErrorSegmentDocument, baseOptions)
 }
-    `;
-export type EditErrorSegmentMutationFn = Apollo.MutationFunction<Types.EditErrorSegmentMutation, Types.EditErrorSegmentMutationVariables>;
+export type DeleteErrorSegmentMutationHookResult = ReturnType<
+	typeof useDeleteErrorSegmentMutation
+>
+export type DeleteErrorSegmentMutationResult =
+	Apollo.MutationResult<Types.DeleteErrorSegmentMutation>
+export type DeleteErrorSegmentMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteErrorSegmentMutation,
+	Types.DeleteErrorSegmentMutationVariables
+>
+export const EditErrorSegmentDocument = gql`
+	mutation EditErrorSegment(
+		$project_id: ID!
+		$id: ID!
+		$params: ErrorSearchParamsInput!
+		$name: String!
+	) {
+		editErrorSegment(
+			project_id: $project_id
+			id: $id
+			params: $params
+			name: $name
+		)
+	}
+`
+export type EditErrorSegmentMutationFn = Apollo.MutationFunction<
+	Types.EditErrorSegmentMutation,
+	Types.EditErrorSegmentMutationVariables
+>
 
 /**
  * __useEditErrorSegmentMutation__
@@ -1868,31 +2771,56 @@ export type EditErrorSegmentMutationFn = Apollo.MutationFunction<Types.EditError
  *   },
  * });
  */
-export function useEditErrorSegmentMutation(baseOptions?: Apollo.MutationHookOptions<Types.EditErrorSegmentMutation, Types.EditErrorSegmentMutationVariables>) {
-        return Apollo.useMutation<Types.EditErrorSegmentMutation, Types.EditErrorSegmentMutationVariables>(EditErrorSegmentDocument, baseOptions);
-      }
-export type EditErrorSegmentMutationHookResult = ReturnType<typeof useEditErrorSegmentMutation>;
-export type EditErrorSegmentMutationResult = Apollo.MutationResult<Types.EditErrorSegmentMutation>;
-export type EditErrorSegmentMutationOptions = Apollo.BaseMutationOptions<Types.EditErrorSegmentMutation, Types.EditErrorSegmentMutationVariables>;
-export const CreateErrorSegmentDocument = gql`
-    mutation CreateErrorSegment($project_id: ID!, $name: String!, $params: ErrorSearchParamsInput!) {
-  createErrorSegment(project_id: $project_id, name: $name, params: $params) {
-    name
-    id
-    params {
-      date_range {
-        start_date
-        end_date
-      }
-      os
-      browser
-      visited_url
-      state
-    }
-  }
+export function useEditErrorSegmentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.EditErrorSegmentMutation,
+		Types.EditErrorSegmentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.EditErrorSegmentMutation,
+		Types.EditErrorSegmentMutationVariables
+	>(EditErrorSegmentDocument, baseOptions)
 }
-    `;
-export type CreateErrorSegmentMutationFn = Apollo.MutationFunction<Types.CreateErrorSegmentMutation, Types.CreateErrorSegmentMutationVariables>;
+export type EditErrorSegmentMutationHookResult = ReturnType<
+	typeof useEditErrorSegmentMutation
+>
+export type EditErrorSegmentMutationResult =
+	Apollo.MutationResult<Types.EditErrorSegmentMutation>
+export type EditErrorSegmentMutationOptions = Apollo.BaseMutationOptions<
+	Types.EditErrorSegmentMutation,
+	Types.EditErrorSegmentMutationVariables
+>
+export const CreateErrorSegmentDocument = gql`
+	mutation CreateErrorSegment(
+		$project_id: ID!
+		$name: String!
+		$params: ErrorSearchParamsInput!
+	) {
+		createErrorSegment(
+			project_id: $project_id
+			name: $name
+			params: $params
+		) {
+			name
+			id
+			params {
+				date_range {
+					start_date
+					end_date
+				}
+				os
+				browser
+				visited_url
+				state
+			}
+		}
+	}
+`
+export type CreateErrorSegmentMutationFn = Apollo.MutationFunction<
+	Types.CreateErrorSegmentMutation,
+	Types.CreateErrorSegmentMutationVariables
+>
 
 /**
  * __useCreateErrorSegmentMutation__
@@ -1913,45 +2841,74 @@ export type CreateErrorSegmentMutationFn = Apollo.MutationFunction<Types.CreateE
  *   },
  * });
  */
-export function useCreateErrorSegmentMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateErrorSegmentMutation, Types.CreateErrorSegmentMutationVariables>) {
-        return Apollo.useMutation<Types.CreateErrorSegmentMutation, Types.CreateErrorSegmentMutationVariables>(CreateErrorSegmentDocument, baseOptions);
-      }
-export type CreateErrorSegmentMutationHookResult = ReturnType<typeof useCreateErrorSegmentMutation>;
-export type CreateErrorSegmentMutationResult = Apollo.MutationResult<Types.CreateErrorSegmentMutation>;
-export type CreateErrorSegmentMutationOptions = Apollo.BaseMutationOptions<Types.CreateErrorSegmentMutation, Types.CreateErrorSegmentMutationVariables>;
-export const CreateErrorAlertDocument = gql`
-    mutation CreateErrorAlert($project_id: ID!, $name: String!, $count_threshold: Int!, $threshold_window: Int!, $slack_channels: [SanitizedSlackChannelInput]!, $discord_channels: [DiscordChannelInput!]!, $webhook_destinations: [WebhookDestinationInput!]!, $emails: [String]!, $environments: [String]!, $regex_groups: [String]!, $frequency: Int!) {
-  createErrorAlert(
-    project_id: $project_id
-    count_threshold: $count_threshold
-    name: $name
-    slack_channels: $slack_channels
-    discord_channels: $discord_channels
-    webhook_destinations: $webhook_destinations
-    emails: $emails
-    environments: $environments
-    threshold_window: $threshold_window
-    regex_groups: $regex_groups
-    frequency: $frequency
-  ) {
-    id
-    ChannelsToNotify {
-      webhook_channel
-      webhook_channel_id
-    }
-    EmailsToNotify
-    Name
-    ExcludedEnvironments
-    CountThreshold
-    ThresholdWindow
-    LastAdminToEditID
-    RegexGroups
-    Frequency
-    disabled
-  }
+export function useCreateErrorSegmentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateErrorSegmentMutation,
+		Types.CreateErrorSegmentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateErrorSegmentMutation,
+		Types.CreateErrorSegmentMutationVariables
+	>(CreateErrorSegmentDocument, baseOptions)
 }
-    `;
-export type CreateErrorAlertMutationFn = Apollo.MutationFunction<Types.CreateErrorAlertMutation, Types.CreateErrorAlertMutationVariables>;
+export type CreateErrorSegmentMutationHookResult = ReturnType<
+	typeof useCreateErrorSegmentMutation
+>
+export type CreateErrorSegmentMutationResult =
+	Apollo.MutationResult<Types.CreateErrorSegmentMutation>
+export type CreateErrorSegmentMutationOptions = Apollo.BaseMutationOptions<
+	Types.CreateErrorSegmentMutation,
+	Types.CreateErrorSegmentMutationVariables
+>
+export const CreateErrorAlertDocument = gql`
+	mutation CreateErrorAlert(
+		$project_id: ID!
+		$name: String!
+		$count_threshold: Int!
+		$threshold_window: Int!
+		$slack_channels: [SanitizedSlackChannelInput]!
+		$discord_channels: [DiscordChannelInput!]!
+		$webhook_destinations: [WebhookDestinationInput!]!
+		$emails: [String]!
+		$environments: [String]!
+		$regex_groups: [String]!
+		$frequency: Int!
+	) {
+		createErrorAlert(
+			project_id: $project_id
+			count_threshold: $count_threshold
+			name: $name
+			slack_channels: $slack_channels
+			discord_channels: $discord_channels
+			webhook_destinations: $webhook_destinations
+			emails: $emails
+			environments: $environments
+			threshold_window: $threshold_window
+			regex_groups: $regex_groups
+			frequency: $frequency
+		) {
+			id
+			ChannelsToNotify {
+				webhook_channel
+				webhook_channel_id
+			}
+			EmailsToNotify
+			Name
+			ExcludedEnvironments
+			CountThreshold
+			ThresholdWindow
+			LastAdminToEditID
+			RegexGroups
+			Frequency
+			disabled
+		}
+	}
+`
+export type CreateErrorAlertMutationFn = Apollo.MutationFunction<
+	Types.CreateErrorAlertMutation,
+	Types.CreateErrorAlertMutationVariables
+>
 
 /**
  * __useCreateErrorAlertMutation__
@@ -1980,46 +2937,76 @@ export type CreateErrorAlertMutationFn = Apollo.MutationFunction<Types.CreateErr
  *   },
  * });
  */
-export function useCreateErrorAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateErrorAlertMutation, Types.CreateErrorAlertMutationVariables>) {
-        return Apollo.useMutation<Types.CreateErrorAlertMutation, Types.CreateErrorAlertMutationVariables>(CreateErrorAlertDocument, baseOptions);
-      }
-export type CreateErrorAlertMutationHookResult = ReturnType<typeof useCreateErrorAlertMutation>;
-export type CreateErrorAlertMutationResult = Apollo.MutationResult<Types.CreateErrorAlertMutation>;
-export type CreateErrorAlertMutationOptions = Apollo.BaseMutationOptions<Types.CreateErrorAlertMutation, Types.CreateErrorAlertMutationVariables>;
-export const CreateMetricMonitorDocument = gql`
-    mutation CreateMetricMonitor($project_id: ID!, $name: String!, $aggregator: MetricAggregator!, $threshold: Float!, $filters: [MetricTagFilterInput!], $units: String, $periodMinutes: Int, $metric_to_monitor: String!, $slack_channels: [SanitizedSlackChannelInput]!, $discord_channels: [DiscordChannelInput!]!, $webhook_destinations: [WebhookDestinationInput!]!, $emails: [String]!) {
-  createMetricMonitor(
-    project_id: $project_id
-    threshold: $threshold
-    filters: $filters
-    units: $units
-    name: $name
-    aggregator: $aggregator
-    periodMinutes: $periodMinutes
-    metric_to_monitor: $metric_to_monitor
-    slack_channels: $slack_channels
-    discord_channels: $discord_channels
-    webhook_destinations: $webhook_destinations
-    emails: $emails
-  ) {
-    id
-    updated_at
-    name
-    channels_to_notify {
-      webhook_channel
-      webhook_channel_id
-    }
-    emails_to_notify
-    aggregator
-    period_minutes
-    metric_to_monitor
-    last_admin_to_edit_id
-    threshold
-    units
-  }
+export function useCreateErrorAlertMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateErrorAlertMutation,
+		Types.CreateErrorAlertMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateErrorAlertMutation,
+		Types.CreateErrorAlertMutationVariables
+	>(CreateErrorAlertDocument, baseOptions)
 }
-    `;
-export type CreateMetricMonitorMutationFn = Apollo.MutationFunction<Types.CreateMetricMonitorMutation, Types.CreateMetricMonitorMutationVariables>;
+export type CreateErrorAlertMutationHookResult = ReturnType<
+	typeof useCreateErrorAlertMutation
+>
+export type CreateErrorAlertMutationResult =
+	Apollo.MutationResult<Types.CreateErrorAlertMutation>
+export type CreateErrorAlertMutationOptions = Apollo.BaseMutationOptions<
+	Types.CreateErrorAlertMutation,
+	Types.CreateErrorAlertMutationVariables
+>
+export const CreateMetricMonitorDocument = gql`
+	mutation CreateMetricMonitor(
+		$project_id: ID!
+		$name: String!
+		$aggregator: MetricAggregator!
+		$threshold: Float!
+		$filters: [MetricTagFilterInput!]
+		$units: String
+		$periodMinutes: Int
+		$metric_to_monitor: String!
+		$slack_channels: [SanitizedSlackChannelInput]!
+		$discord_channels: [DiscordChannelInput!]!
+		$webhook_destinations: [WebhookDestinationInput!]!
+		$emails: [String]!
+	) {
+		createMetricMonitor(
+			project_id: $project_id
+			threshold: $threshold
+			filters: $filters
+			units: $units
+			name: $name
+			aggregator: $aggregator
+			periodMinutes: $periodMinutes
+			metric_to_monitor: $metric_to_monitor
+			slack_channels: $slack_channels
+			discord_channels: $discord_channels
+			webhook_destinations: $webhook_destinations
+			emails: $emails
+		) {
+			id
+			updated_at
+			name
+			channels_to_notify {
+				webhook_channel
+				webhook_channel_id
+			}
+			emails_to_notify
+			aggregator
+			period_minutes
+			metric_to_monitor
+			last_admin_to_edit_id
+			threshold
+			units
+		}
+	}
+`
+export type CreateMetricMonitorMutationFn = Apollo.MutationFunction<
+	Types.CreateMetricMonitorMutation,
+	Types.CreateMetricMonitorMutationVariables
+>
 
 /**
  * __useCreateMetricMonitorMutation__
@@ -2049,48 +3036,80 @@ export type CreateMetricMonitorMutationFn = Apollo.MutationFunction<Types.Create
  *   },
  * });
  */
-export function useCreateMetricMonitorMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateMetricMonitorMutation, Types.CreateMetricMonitorMutationVariables>) {
-        return Apollo.useMutation<Types.CreateMetricMonitorMutation, Types.CreateMetricMonitorMutationVariables>(CreateMetricMonitorDocument, baseOptions);
-      }
-export type CreateMetricMonitorMutationHookResult = ReturnType<typeof useCreateMetricMonitorMutation>;
-export type CreateMetricMonitorMutationResult = Apollo.MutationResult<Types.CreateMetricMonitorMutation>;
-export type CreateMetricMonitorMutationOptions = Apollo.BaseMutationOptions<Types.CreateMetricMonitorMutation, Types.CreateMetricMonitorMutationVariables>;
-export const UpdateMetricMonitorDocument = gql`
-    mutation UpdateMetricMonitor($metric_monitor_id: ID!, $project_id: ID!, $name: String, $aggregator: MetricAggregator, $threshold: Float, $filters: [MetricTagFilterInput!], $units: String, $periodMinutes: Int, $metric_to_monitor: String, $slack_channels: [SanitizedSlackChannelInput], $discord_channels: [DiscordChannelInput!]!, $webhook_destinations: [WebhookDestinationInput!]!, $emails: [String], $disabled: Boolean) {
-  updateMetricMonitor(
-    metric_monitor_id: $metric_monitor_id
-    project_id: $project_id
-    threshold: $threshold
-    filters: $filters
-    units: $units
-    name: $name
-    aggregator: $aggregator
-    periodMinutes: $periodMinutes
-    metric_to_monitor: $metric_to_monitor
-    slack_channels: $slack_channels
-    discord_channels: $discord_channels
-    webhook_destinations: $webhook_destinations
-    emails: $emails
-    disabled: $disabled
-  ) {
-    id
-    updated_at
-    name
-    channels_to_notify {
-      webhook_channel
-      webhook_channel_id
-    }
-    emails_to_notify
-    aggregator
-    period_minutes
-    metric_to_monitor
-    last_admin_to_edit_id
-    threshold
-    units
-  }
+export function useCreateMetricMonitorMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateMetricMonitorMutation,
+		Types.CreateMetricMonitorMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateMetricMonitorMutation,
+		Types.CreateMetricMonitorMutationVariables
+	>(CreateMetricMonitorDocument, baseOptions)
 }
-    `;
-export type UpdateMetricMonitorMutationFn = Apollo.MutationFunction<Types.UpdateMetricMonitorMutation, Types.UpdateMetricMonitorMutationVariables>;
+export type CreateMetricMonitorMutationHookResult = ReturnType<
+	typeof useCreateMetricMonitorMutation
+>
+export type CreateMetricMonitorMutationResult =
+	Apollo.MutationResult<Types.CreateMetricMonitorMutation>
+export type CreateMetricMonitorMutationOptions = Apollo.BaseMutationOptions<
+	Types.CreateMetricMonitorMutation,
+	Types.CreateMetricMonitorMutationVariables
+>
+export const UpdateMetricMonitorDocument = gql`
+	mutation UpdateMetricMonitor(
+		$metric_monitor_id: ID!
+		$project_id: ID!
+		$name: String
+		$aggregator: MetricAggregator
+		$threshold: Float
+		$filters: [MetricTagFilterInput!]
+		$units: String
+		$periodMinutes: Int
+		$metric_to_monitor: String
+		$slack_channels: [SanitizedSlackChannelInput]
+		$discord_channels: [DiscordChannelInput!]!
+		$webhook_destinations: [WebhookDestinationInput!]!
+		$emails: [String]
+		$disabled: Boolean
+	) {
+		updateMetricMonitor(
+			metric_monitor_id: $metric_monitor_id
+			project_id: $project_id
+			threshold: $threshold
+			filters: $filters
+			units: $units
+			name: $name
+			aggregator: $aggregator
+			periodMinutes: $periodMinutes
+			metric_to_monitor: $metric_to_monitor
+			slack_channels: $slack_channels
+			discord_channels: $discord_channels
+			webhook_destinations: $webhook_destinations
+			emails: $emails
+			disabled: $disabled
+		) {
+			id
+			updated_at
+			name
+			channels_to_notify {
+				webhook_channel
+				webhook_channel_id
+			}
+			emails_to_notify
+			aggregator
+			period_minutes
+			metric_to_monitor
+			last_admin_to_edit_id
+			threshold
+			units
+		}
+	}
+`
+export type UpdateMetricMonitorMutationFn = Apollo.MutationFunction<
+	Types.UpdateMetricMonitorMutation,
+	Types.UpdateMetricMonitorMutationVariables
+>
 
 /**
  * __useUpdateMetricMonitorMutation__
@@ -2122,34 +3141,51 @@ export type UpdateMetricMonitorMutationFn = Apollo.MutationFunction<Types.Update
  *   },
  * });
  */
-export function useUpdateMetricMonitorMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateMetricMonitorMutation, Types.UpdateMetricMonitorMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateMetricMonitorMutation, Types.UpdateMetricMonitorMutationVariables>(UpdateMetricMonitorDocument, baseOptions);
-      }
-export type UpdateMetricMonitorMutationHookResult = ReturnType<typeof useUpdateMetricMonitorMutation>;
-export type UpdateMetricMonitorMutationResult = Apollo.MutationResult<Types.UpdateMetricMonitorMutation>;
-export type UpdateMetricMonitorMutationOptions = Apollo.BaseMutationOptions<Types.UpdateMetricMonitorMutation, Types.UpdateMetricMonitorMutationVariables>;
-export const DeleteMetricMonitorDocument = gql`
-    mutation DeleteMetricMonitor($metric_monitor_id: ID!, $project_id: ID!) {
-  deleteMetricMonitor(
-    metric_monitor_id: $metric_monitor_id
-    project_id: $project_id
-  ) {
-    id
-    updated_at
-    name
-    channels_to_notify {
-      webhook_channel
-      webhook_channel_id
-    }
-    emails_to_notify
-    aggregator
-    metric_to_monitor
-    last_admin_to_edit_id
-    threshold
-  }
+export function useUpdateMetricMonitorMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateMetricMonitorMutation,
+		Types.UpdateMetricMonitorMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateMetricMonitorMutation,
+		Types.UpdateMetricMonitorMutationVariables
+	>(UpdateMetricMonitorDocument, baseOptions)
 }
-    `;
-export type DeleteMetricMonitorMutationFn = Apollo.MutationFunction<Types.DeleteMetricMonitorMutation, Types.DeleteMetricMonitorMutationVariables>;
+export type UpdateMetricMonitorMutationHookResult = ReturnType<
+	typeof useUpdateMetricMonitorMutation
+>
+export type UpdateMetricMonitorMutationResult =
+	Apollo.MutationResult<Types.UpdateMetricMonitorMutation>
+export type UpdateMetricMonitorMutationOptions = Apollo.BaseMutationOptions<
+	Types.UpdateMetricMonitorMutation,
+	Types.UpdateMetricMonitorMutationVariables
+>
+export const DeleteMetricMonitorDocument = gql`
+	mutation DeleteMetricMonitor($metric_monitor_id: ID!, $project_id: ID!) {
+		deleteMetricMonitor(
+			metric_monitor_id: $metric_monitor_id
+			project_id: $project_id
+		) {
+			id
+			updated_at
+			name
+			channels_to_notify {
+				webhook_channel
+				webhook_channel_id
+			}
+			emails_to_notify
+			aggregator
+			metric_to_monitor
+			last_admin_to_edit_id
+			threshold
+		}
+	}
+`
+export type DeleteMetricMonitorMutationFn = Apollo.MutationFunction<
+	Types.DeleteMetricMonitorMutation,
+	Types.DeleteMetricMonitorMutationVariables
+>
 
 /**
  * __useDeleteMetricMonitorMutation__
@@ -2169,22 +3205,41 @@ export type DeleteMetricMonitorMutationFn = Apollo.MutationFunction<Types.Delete
  *   },
  * });
  */
-export function useDeleteMetricMonitorMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteMetricMonitorMutation, Types.DeleteMetricMonitorMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteMetricMonitorMutation, Types.DeleteMetricMonitorMutationVariables>(DeleteMetricMonitorDocument, baseOptions);
-      }
-export type DeleteMetricMonitorMutationHookResult = ReturnType<typeof useDeleteMetricMonitorMutation>;
-export type DeleteMetricMonitorMutationResult = Apollo.MutationResult<Types.DeleteMetricMonitorMutation>;
-export type DeleteMetricMonitorMutationOptions = Apollo.BaseMutationOptions<Types.DeleteMetricMonitorMutation, Types.DeleteMetricMonitorMutationVariables>;
-export const UpdateAdminAndCreateWorkspaceDocument = gql`
-    mutation UpdateAdminAndCreateWorkspace($admin_and_workspace_details: AdminAndWorkspaceDetails!) {
-  updateAdminAndCreateWorkspace(
-    admin_and_workspace_details: $admin_and_workspace_details
-  ) {
-    id
-  }
+export function useDeleteMetricMonitorMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteMetricMonitorMutation,
+		Types.DeleteMetricMonitorMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteMetricMonitorMutation,
+		Types.DeleteMetricMonitorMutationVariables
+	>(DeleteMetricMonitorDocument, baseOptions)
 }
-    `;
-export type UpdateAdminAndCreateWorkspaceMutationFn = Apollo.MutationFunction<Types.UpdateAdminAndCreateWorkspaceMutation, Types.UpdateAdminAndCreateWorkspaceMutationVariables>;
+export type DeleteMetricMonitorMutationHookResult = ReturnType<
+	typeof useDeleteMetricMonitorMutation
+>
+export type DeleteMetricMonitorMutationResult =
+	Apollo.MutationResult<Types.DeleteMetricMonitorMutation>
+export type DeleteMetricMonitorMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteMetricMonitorMutation,
+	Types.DeleteMetricMonitorMutationVariables
+>
+export const UpdateAdminAndCreateWorkspaceDocument = gql`
+	mutation UpdateAdminAndCreateWorkspace(
+		$admin_and_workspace_details: AdminAndWorkspaceDetails!
+	) {
+		updateAdminAndCreateWorkspace(
+			admin_and_workspace_details: $admin_and_workspace_details
+		) {
+			id
+		}
+	}
+`
+export type UpdateAdminAndCreateWorkspaceMutationFn = Apollo.MutationFunction<
+	Types.UpdateAdminAndCreateWorkspaceMutation,
+	Types.UpdateAdminAndCreateWorkspaceMutationVariables
+>
 
 /**
  * __useUpdateAdminAndCreateWorkspaceMutation__
@@ -2203,18 +3258,36 @@ export type UpdateAdminAndCreateWorkspaceMutationFn = Apollo.MutationFunction<Ty
  *   },
  * });
  */
-export function useUpdateAdminAndCreateWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateAdminAndCreateWorkspaceMutation, Types.UpdateAdminAndCreateWorkspaceMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateAdminAndCreateWorkspaceMutation, Types.UpdateAdminAndCreateWorkspaceMutationVariables>(UpdateAdminAndCreateWorkspaceDocument, baseOptions);
-      }
-export type UpdateAdminAndCreateWorkspaceMutationHookResult = ReturnType<typeof useUpdateAdminAndCreateWorkspaceMutation>;
-export type UpdateAdminAndCreateWorkspaceMutationResult = Apollo.MutationResult<Types.UpdateAdminAndCreateWorkspaceMutation>;
-export type UpdateAdminAndCreateWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.UpdateAdminAndCreateWorkspaceMutation, Types.UpdateAdminAndCreateWorkspaceMutationVariables>;
-export const UpdateAdminAboutYouDetailsDocument = gql`
-    mutation UpdateAdminAboutYouDetails($adminDetails: AdminAboutYouDetails!) {
-  updateAdminAboutYouDetails(adminDetails: $adminDetails)
+export function useUpdateAdminAndCreateWorkspaceMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateAdminAndCreateWorkspaceMutation,
+		Types.UpdateAdminAndCreateWorkspaceMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateAdminAndCreateWorkspaceMutation,
+		Types.UpdateAdminAndCreateWorkspaceMutationVariables
+	>(UpdateAdminAndCreateWorkspaceDocument, baseOptions)
 }
-    `;
-export type UpdateAdminAboutYouDetailsMutationFn = Apollo.MutationFunction<Types.UpdateAdminAboutYouDetailsMutation, Types.UpdateAdminAboutYouDetailsMutationVariables>;
+export type UpdateAdminAndCreateWorkspaceMutationHookResult = ReturnType<
+	typeof useUpdateAdminAndCreateWorkspaceMutation
+>
+export type UpdateAdminAndCreateWorkspaceMutationResult =
+	Apollo.MutationResult<Types.UpdateAdminAndCreateWorkspaceMutation>
+export type UpdateAdminAndCreateWorkspaceMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.UpdateAdminAndCreateWorkspaceMutation,
+		Types.UpdateAdminAndCreateWorkspaceMutationVariables
+	>
+export const UpdateAdminAboutYouDetailsDocument = gql`
+	mutation UpdateAdminAboutYouDetails($adminDetails: AdminAboutYouDetails!) {
+		updateAdminAboutYouDetails(adminDetails: $adminDetails)
+	}
+`
+export type UpdateAdminAboutYouDetailsMutationFn = Apollo.MutationFunction<
+	Types.UpdateAdminAboutYouDetailsMutation,
+	Types.UpdateAdminAboutYouDetailsMutationVariables
+>
 
 /**
  * __useUpdateAdminAboutYouDetailsMutation__
@@ -2233,50 +3306,82 @@ export type UpdateAdminAboutYouDetailsMutationFn = Apollo.MutationFunction<Types
  *   },
  * });
  */
-export function useUpdateAdminAboutYouDetailsMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateAdminAboutYouDetailsMutation, Types.UpdateAdminAboutYouDetailsMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateAdminAboutYouDetailsMutation, Types.UpdateAdminAboutYouDetailsMutationVariables>(UpdateAdminAboutYouDetailsDocument, baseOptions);
-      }
-export type UpdateAdminAboutYouDetailsMutationHookResult = ReturnType<typeof useUpdateAdminAboutYouDetailsMutation>;
-export type UpdateAdminAboutYouDetailsMutationResult = Apollo.MutationResult<Types.UpdateAdminAboutYouDetailsMutation>;
-export type UpdateAdminAboutYouDetailsMutationOptions = Apollo.BaseMutationOptions<Types.UpdateAdminAboutYouDetailsMutation, Types.UpdateAdminAboutYouDetailsMutationVariables>;
-export const UpdateErrorAlertDocument = gql`
-    mutation UpdateErrorAlert($project_id: ID!, $name: String, $error_alert_id: ID!, $count_threshold: Int, $threshold_window: Int, $slack_channels: [SanitizedSlackChannelInput], $discord_channels: [DiscordChannelInput!]!, $webhook_destinations: [WebhookDestinationInput!]!, $emails: [String], $environments: [String], $regex_groups: [String], $frequency: Int, $disabled: Boolean) {
-  updateErrorAlert(
-    project_id: $project_id
-    error_alert_id: $error_alert_id
-    name: $name
-    count_threshold: $count_threshold
-    slack_channels: $slack_channels
-    discord_channels: $discord_channels
-    webhook_destinations: $webhook_destinations
-    emails: $emails
-    environments: $environments
-    threshold_window: $threshold_window
-    regex_groups: $regex_groups
-    frequency: $frequency
-    disabled: $disabled
-  ) {
-    Name
-    ChannelsToNotify {
-      webhook_channel
-      webhook_channel_id
-    }
-    DiscordChannelsToNotify {
-      id
-      name
-    }
-    EmailsToNotify
-    ExcludedEnvironments
-    CountThreshold
-    ThresholdWindow
-    LastAdminToEditID
-    RegexGroups
-    Frequency
-    disabled
-  }
+export function useUpdateAdminAboutYouDetailsMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateAdminAboutYouDetailsMutation,
+		Types.UpdateAdminAboutYouDetailsMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateAdminAboutYouDetailsMutation,
+		Types.UpdateAdminAboutYouDetailsMutationVariables
+	>(UpdateAdminAboutYouDetailsDocument, baseOptions)
 }
-    `;
-export type UpdateErrorAlertMutationFn = Apollo.MutationFunction<Types.UpdateErrorAlertMutation, Types.UpdateErrorAlertMutationVariables>;
+export type UpdateAdminAboutYouDetailsMutationHookResult = ReturnType<
+	typeof useUpdateAdminAboutYouDetailsMutation
+>
+export type UpdateAdminAboutYouDetailsMutationResult =
+	Apollo.MutationResult<Types.UpdateAdminAboutYouDetailsMutation>
+export type UpdateAdminAboutYouDetailsMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.UpdateAdminAboutYouDetailsMutation,
+		Types.UpdateAdminAboutYouDetailsMutationVariables
+	>
+export const UpdateErrorAlertDocument = gql`
+	mutation UpdateErrorAlert(
+		$project_id: ID!
+		$name: String
+		$error_alert_id: ID!
+		$count_threshold: Int
+		$threshold_window: Int
+		$slack_channels: [SanitizedSlackChannelInput]
+		$discord_channels: [DiscordChannelInput!]!
+		$webhook_destinations: [WebhookDestinationInput!]!
+		$emails: [String]
+		$environments: [String]
+		$regex_groups: [String]
+		$frequency: Int
+		$disabled: Boolean
+	) {
+		updateErrorAlert(
+			project_id: $project_id
+			error_alert_id: $error_alert_id
+			name: $name
+			count_threshold: $count_threshold
+			slack_channels: $slack_channels
+			discord_channels: $discord_channels
+			webhook_destinations: $webhook_destinations
+			emails: $emails
+			environments: $environments
+			threshold_window: $threshold_window
+			regex_groups: $regex_groups
+			frequency: $frequency
+			disabled: $disabled
+		) {
+			Name
+			ChannelsToNotify {
+				webhook_channel
+				webhook_channel_id
+			}
+			DiscordChannelsToNotify {
+				id
+				name
+			}
+			EmailsToNotify
+			ExcludedEnvironments
+			CountThreshold
+			ThresholdWindow
+			LastAdminToEditID
+			RegexGroups
+			Frequency
+			disabled
+		}
+	}
+`
+export type UpdateErrorAlertMutationFn = Apollo.MutationFunction<
+	Types.UpdateErrorAlertMutation,
+	Types.UpdateErrorAlertMutationVariables
+>
 
 /**
  * __useUpdateErrorAlertMutation__
@@ -2307,20 +3412,40 @@ export type UpdateErrorAlertMutationFn = Apollo.MutationFunction<Types.UpdateErr
  *   },
  * });
  */
-export function useUpdateErrorAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateErrorAlertMutation, Types.UpdateErrorAlertMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateErrorAlertMutation, Types.UpdateErrorAlertMutationVariables>(UpdateErrorAlertDocument, baseOptions);
-      }
-export type UpdateErrorAlertMutationHookResult = ReturnType<typeof useUpdateErrorAlertMutation>;
-export type UpdateErrorAlertMutationResult = Apollo.MutationResult<Types.UpdateErrorAlertMutation>;
-export type UpdateErrorAlertMutationOptions = Apollo.BaseMutationOptions<Types.UpdateErrorAlertMutation, Types.UpdateErrorAlertMutationVariables>;
-export const DeleteErrorAlertDocument = gql`
-    mutation DeleteErrorAlert($project_id: ID!, $error_alert_id: ID!) {
-  deleteErrorAlert(project_id: $project_id, error_alert_id: $error_alert_id) {
-    id
-  }
+export function useUpdateErrorAlertMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateErrorAlertMutation,
+		Types.UpdateErrorAlertMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateErrorAlertMutation,
+		Types.UpdateErrorAlertMutationVariables
+	>(UpdateErrorAlertDocument, baseOptions)
 }
-    `;
-export type DeleteErrorAlertMutationFn = Apollo.MutationFunction<Types.DeleteErrorAlertMutation, Types.DeleteErrorAlertMutationVariables>;
+export type UpdateErrorAlertMutationHookResult = ReturnType<
+	typeof useUpdateErrorAlertMutation
+>
+export type UpdateErrorAlertMutationResult =
+	Apollo.MutationResult<Types.UpdateErrorAlertMutation>
+export type UpdateErrorAlertMutationOptions = Apollo.BaseMutationOptions<
+	Types.UpdateErrorAlertMutation,
+	Types.UpdateErrorAlertMutationVariables
+>
+export const DeleteErrorAlertDocument = gql`
+	mutation DeleteErrorAlert($project_id: ID!, $error_alert_id: ID!) {
+		deleteErrorAlert(
+			project_id: $project_id
+			error_alert_id: $error_alert_id
+		) {
+			id
+		}
+	}
+`
+export type DeleteErrorAlertMutationFn = Apollo.MutationFunction<
+	Types.DeleteErrorAlertMutation,
+	Types.DeleteErrorAlertMutationVariables
+>
 
 /**
  * __useDeleteErrorAlertMutation__
@@ -2340,20 +3465,40 @@ export type DeleteErrorAlertMutationFn = Apollo.MutationFunction<Types.DeleteErr
  *   },
  * });
  */
-export function useDeleteErrorAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteErrorAlertMutation, Types.DeleteErrorAlertMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteErrorAlertMutation, Types.DeleteErrorAlertMutationVariables>(DeleteErrorAlertDocument, baseOptions);
-      }
-export type DeleteErrorAlertMutationHookResult = ReturnType<typeof useDeleteErrorAlertMutation>;
-export type DeleteErrorAlertMutationResult = Apollo.MutationResult<Types.DeleteErrorAlertMutation>;
-export type DeleteErrorAlertMutationOptions = Apollo.BaseMutationOptions<Types.DeleteErrorAlertMutation, Types.DeleteErrorAlertMutationVariables>;
-export const DeleteSessionAlertDocument = gql`
-    mutation DeleteSessionAlert($project_id: ID!, $session_alert_id: ID!) {
-  deleteSessionAlert(project_id: $project_id, session_alert_id: $session_alert_id) {
-    id
-  }
+export function useDeleteErrorAlertMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteErrorAlertMutation,
+		Types.DeleteErrorAlertMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteErrorAlertMutation,
+		Types.DeleteErrorAlertMutationVariables
+	>(DeleteErrorAlertDocument, baseOptions)
 }
-    `;
-export type DeleteSessionAlertMutationFn = Apollo.MutationFunction<Types.DeleteSessionAlertMutation, Types.DeleteSessionAlertMutationVariables>;
+export type DeleteErrorAlertMutationHookResult = ReturnType<
+	typeof useDeleteErrorAlertMutation
+>
+export type DeleteErrorAlertMutationResult =
+	Apollo.MutationResult<Types.DeleteErrorAlertMutation>
+export type DeleteErrorAlertMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteErrorAlertMutation,
+	Types.DeleteErrorAlertMutationVariables
+>
+export const DeleteSessionAlertDocument = gql`
+	mutation DeleteSessionAlert($project_id: ID!, $session_alert_id: ID!) {
+		deleteSessionAlert(
+			project_id: $project_id
+			session_alert_id: $session_alert_id
+		) {
+			id
+		}
+	}
+`
+export type DeleteSessionAlertMutationFn = Apollo.MutationFunction<
+	Types.DeleteSessionAlertMutation,
+	Types.DeleteSessionAlertMutationVariables
+>
 
 /**
  * __useDeleteSessionAlertMutation__
@@ -2373,20 +3518,37 @@ export type DeleteSessionAlertMutationFn = Apollo.MutationFunction<Types.DeleteS
  *   },
  * });
  */
-export function useDeleteSessionAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteSessionAlertMutation, Types.DeleteSessionAlertMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteSessionAlertMutation, Types.DeleteSessionAlertMutationVariables>(DeleteSessionAlertDocument, baseOptions);
-      }
-export type DeleteSessionAlertMutationHookResult = ReturnType<typeof useDeleteSessionAlertMutation>;
-export type DeleteSessionAlertMutationResult = Apollo.MutationResult<Types.DeleteSessionAlertMutation>;
-export type DeleteSessionAlertMutationOptions = Apollo.BaseMutationOptions<Types.DeleteSessionAlertMutation, Types.DeleteSessionAlertMutationVariables>;
-export const UpdateLogAlertDocument = gql`
-    mutation UpdateLogAlert($id: ID!, $input: LogAlertInput!) {
-  updateLogAlert(id: $id, input: $input) {
-    id
-  }
+export function useDeleteSessionAlertMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteSessionAlertMutation,
+		Types.DeleteSessionAlertMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteSessionAlertMutation,
+		Types.DeleteSessionAlertMutationVariables
+	>(DeleteSessionAlertDocument, baseOptions)
 }
-    `;
-export type UpdateLogAlertMutationFn = Apollo.MutationFunction<Types.UpdateLogAlertMutation, Types.UpdateLogAlertMutationVariables>;
+export type DeleteSessionAlertMutationHookResult = ReturnType<
+	typeof useDeleteSessionAlertMutation
+>
+export type DeleteSessionAlertMutationResult =
+	Apollo.MutationResult<Types.DeleteSessionAlertMutation>
+export type DeleteSessionAlertMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteSessionAlertMutation,
+	Types.DeleteSessionAlertMutationVariables
+>
+export const UpdateLogAlertDocument = gql`
+	mutation UpdateLogAlert($id: ID!, $input: LogAlertInput!) {
+		updateLogAlert(id: $id, input: $input) {
+			id
+		}
+	}
+`
+export type UpdateLogAlertMutationFn = Apollo.MutationFunction<
+	Types.UpdateLogAlertMutation,
+	Types.UpdateLogAlertMutationVariables
+>
 
 /**
  * __useUpdateLogAlertMutation__
@@ -2406,20 +3568,37 @@ export type UpdateLogAlertMutationFn = Apollo.MutationFunction<Types.UpdateLogAl
  *   },
  * });
  */
-export function useUpdateLogAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateLogAlertMutation, Types.UpdateLogAlertMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateLogAlertMutation, Types.UpdateLogAlertMutationVariables>(UpdateLogAlertDocument, baseOptions);
-      }
-export type UpdateLogAlertMutationHookResult = ReturnType<typeof useUpdateLogAlertMutation>;
-export type UpdateLogAlertMutationResult = Apollo.MutationResult<Types.UpdateLogAlertMutation>;
-export type UpdateLogAlertMutationOptions = Apollo.BaseMutationOptions<Types.UpdateLogAlertMutation, Types.UpdateLogAlertMutationVariables>;
-export const CreateLogAlertDocument = gql`
-    mutation CreateLogAlert($input: LogAlertInput!) {
-  createLogAlert(input: $input) {
-    id
-  }
+export function useUpdateLogAlertMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateLogAlertMutation,
+		Types.UpdateLogAlertMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateLogAlertMutation,
+		Types.UpdateLogAlertMutationVariables
+	>(UpdateLogAlertDocument, baseOptions)
 }
-    `;
-export type CreateLogAlertMutationFn = Apollo.MutationFunction<Types.CreateLogAlertMutation, Types.CreateLogAlertMutationVariables>;
+export type UpdateLogAlertMutationHookResult = ReturnType<
+	typeof useUpdateLogAlertMutation
+>
+export type UpdateLogAlertMutationResult =
+	Apollo.MutationResult<Types.UpdateLogAlertMutation>
+export type UpdateLogAlertMutationOptions = Apollo.BaseMutationOptions<
+	Types.UpdateLogAlertMutation,
+	Types.UpdateLogAlertMutationVariables
+>
+export const CreateLogAlertDocument = gql`
+	mutation CreateLogAlert($input: LogAlertInput!) {
+		createLogAlert(input: $input) {
+			id
+		}
+	}
+`
+export type CreateLogAlertMutationFn = Apollo.MutationFunction<
+	Types.CreateLogAlertMutation,
+	Types.CreateLogAlertMutationVariables
+>
 
 /**
  * __useCreateLogAlertMutation__
@@ -2438,20 +3617,37 @@ export type CreateLogAlertMutationFn = Apollo.MutationFunction<Types.CreateLogAl
  *   },
  * });
  */
-export function useCreateLogAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateLogAlertMutation, Types.CreateLogAlertMutationVariables>) {
-        return Apollo.useMutation<Types.CreateLogAlertMutation, Types.CreateLogAlertMutationVariables>(CreateLogAlertDocument, baseOptions);
-      }
-export type CreateLogAlertMutationHookResult = ReturnType<typeof useCreateLogAlertMutation>;
-export type CreateLogAlertMutationResult = Apollo.MutationResult<Types.CreateLogAlertMutation>;
-export type CreateLogAlertMutationOptions = Apollo.BaseMutationOptions<Types.CreateLogAlertMutation, Types.CreateLogAlertMutationVariables>;
-export const DeleteLogAlertDocument = gql`
-    mutation DeleteLogAlert($project_id: ID!, $id: ID!) {
-  deleteLogAlert(project_id: $project_id, id: $id) {
-    id
-  }
+export function useCreateLogAlertMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateLogAlertMutation,
+		Types.CreateLogAlertMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateLogAlertMutation,
+		Types.CreateLogAlertMutationVariables
+	>(CreateLogAlertDocument, baseOptions)
 }
-    `;
-export type DeleteLogAlertMutationFn = Apollo.MutationFunction<Types.DeleteLogAlertMutation, Types.DeleteLogAlertMutationVariables>;
+export type CreateLogAlertMutationHookResult = ReturnType<
+	typeof useCreateLogAlertMutation
+>
+export type CreateLogAlertMutationResult =
+	Apollo.MutationResult<Types.CreateLogAlertMutation>
+export type CreateLogAlertMutationOptions = Apollo.BaseMutationOptions<
+	Types.CreateLogAlertMutation,
+	Types.CreateLogAlertMutationVariables
+>
+export const DeleteLogAlertDocument = gql`
+	mutation DeleteLogAlert($project_id: ID!, $id: ID!) {
+		deleteLogAlert(project_id: $project_id, id: $id) {
+			id
+		}
+	}
+`
+export type DeleteLogAlertMutationFn = Apollo.MutationFunction<
+	Types.DeleteLogAlertMutation,
+	Types.DeleteLogAlertMutationVariables
+>
 
 /**
  * __useDeleteLogAlertMutation__
@@ -2471,20 +3667,45 @@ export type DeleteLogAlertMutationFn = Apollo.MutationFunction<Types.DeleteLogAl
  *   },
  * });
  */
-export function useDeleteLogAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteLogAlertMutation, Types.DeleteLogAlertMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteLogAlertMutation, Types.DeleteLogAlertMutationVariables>(DeleteLogAlertDocument, baseOptions);
-      }
-export type DeleteLogAlertMutationHookResult = ReturnType<typeof useDeleteLogAlertMutation>;
-export type DeleteLogAlertMutationResult = Apollo.MutationResult<Types.DeleteLogAlertMutation>;
-export type DeleteLogAlertMutationOptions = Apollo.BaseMutationOptions<Types.DeleteLogAlertMutation, Types.DeleteLogAlertMutationVariables>;
-export const UpdateLogAlertIsDisabledDocument = gql`
-    mutation UpdateLogAlertIsDisabled($id: ID!, $project_id: ID!, $disabled: Boolean!) {
-  updateLogAlertIsDisabled(id: $id, project_id: $project_id, disabled: $disabled) {
-    id
-  }
+export function useDeleteLogAlertMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteLogAlertMutation,
+		Types.DeleteLogAlertMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteLogAlertMutation,
+		Types.DeleteLogAlertMutationVariables
+	>(DeleteLogAlertDocument, baseOptions)
 }
-    `;
-export type UpdateLogAlertIsDisabledMutationFn = Apollo.MutationFunction<Types.UpdateLogAlertIsDisabledMutation, Types.UpdateLogAlertIsDisabledMutationVariables>;
+export type DeleteLogAlertMutationHookResult = ReturnType<
+	typeof useDeleteLogAlertMutation
+>
+export type DeleteLogAlertMutationResult =
+	Apollo.MutationResult<Types.DeleteLogAlertMutation>
+export type DeleteLogAlertMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteLogAlertMutation,
+	Types.DeleteLogAlertMutationVariables
+>
+export const UpdateLogAlertIsDisabledDocument = gql`
+	mutation UpdateLogAlertIsDisabled(
+		$id: ID!
+		$project_id: ID!
+		$disabled: Boolean!
+	) {
+		updateLogAlertIsDisabled(
+			id: $id
+			project_id: $project_id
+			disabled: $disabled
+		) {
+			id
+		}
+	}
+`
+export type UpdateLogAlertIsDisabledMutationFn = Apollo.MutationFunction<
+	Types.UpdateLogAlertIsDisabledMutation,
+	Types.UpdateLogAlertIsDisabledMutationVariables
+>
 
 /**
  * __useUpdateLogAlertIsDisabledMutation__
@@ -2505,24 +3726,46 @@ export type UpdateLogAlertIsDisabledMutationFn = Apollo.MutationFunction<Types.U
  *   },
  * });
  */
-export function useUpdateLogAlertIsDisabledMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateLogAlertIsDisabledMutation, Types.UpdateLogAlertIsDisabledMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateLogAlertIsDisabledMutation, Types.UpdateLogAlertIsDisabledMutationVariables>(UpdateLogAlertIsDisabledDocument, baseOptions);
-      }
-export type UpdateLogAlertIsDisabledMutationHookResult = ReturnType<typeof useUpdateLogAlertIsDisabledMutation>;
-export type UpdateLogAlertIsDisabledMutationResult = Apollo.MutationResult<Types.UpdateLogAlertIsDisabledMutation>;
-export type UpdateLogAlertIsDisabledMutationOptions = Apollo.BaseMutationOptions<Types.UpdateLogAlertIsDisabledMutation, Types.UpdateLogAlertIsDisabledMutationVariables>;
-export const UpdateSessionAlertIsDisabledDocument = gql`
-    mutation UpdateSessionAlertIsDisabled($id: ID!, $project_id: ID!, $disabled: Boolean!) {
-  updateSessionAlertIsDisabled(
-    id: $id
-    project_id: $project_id
-    disabled: $disabled
-  ) {
-    id
-  }
+export function useUpdateLogAlertIsDisabledMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateLogAlertIsDisabledMutation,
+		Types.UpdateLogAlertIsDisabledMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateLogAlertIsDisabledMutation,
+		Types.UpdateLogAlertIsDisabledMutationVariables
+	>(UpdateLogAlertIsDisabledDocument, baseOptions)
 }
-    `;
-export type UpdateSessionAlertIsDisabledMutationFn = Apollo.MutationFunction<Types.UpdateSessionAlertIsDisabledMutation, Types.UpdateSessionAlertIsDisabledMutationVariables>;
+export type UpdateLogAlertIsDisabledMutationHookResult = ReturnType<
+	typeof useUpdateLogAlertIsDisabledMutation
+>
+export type UpdateLogAlertIsDisabledMutationResult =
+	Apollo.MutationResult<Types.UpdateLogAlertIsDisabledMutation>
+export type UpdateLogAlertIsDisabledMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.UpdateLogAlertIsDisabledMutation,
+		Types.UpdateLogAlertIsDisabledMutationVariables
+	>
+export const UpdateSessionAlertIsDisabledDocument = gql`
+	mutation UpdateSessionAlertIsDisabled(
+		$id: ID!
+		$project_id: ID!
+		$disabled: Boolean!
+	) {
+		updateSessionAlertIsDisabled(
+			id: $id
+			project_id: $project_id
+			disabled: $disabled
+		) {
+			id
+		}
+	}
+`
+export type UpdateSessionAlertIsDisabledMutationFn = Apollo.MutationFunction<
+	Types.UpdateSessionAlertIsDisabledMutation,
+	Types.UpdateSessionAlertIsDisabledMutationVariables
+>
 
 /**
  * __useUpdateSessionAlertIsDisabledMutation__
@@ -2543,24 +3786,46 @@ export type UpdateSessionAlertIsDisabledMutationFn = Apollo.MutationFunction<Typ
  *   },
  * });
  */
-export function useUpdateSessionAlertIsDisabledMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateSessionAlertIsDisabledMutation, Types.UpdateSessionAlertIsDisabledMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateSessionAlertIsDisabledMutation, Types.UpdateSessionAlertIsDisabledMutationVariables>(UpdateSessionAlertIsDisabledDocument, baseOptions);
-      }
-export type UpdateSessionAlertIsDisabledMutationHookResult = ReturnType<typeof useUpdateSessionAlertIsDisabledMutation>;
-export type UpdateSessionAlertIsDisabledMutationResult = Apollo.MutationResult<Types.UpdateSessionAlertIsDisabledMutation>;
-export type UpdateSessionAlertIsDisabledMutationOptions = Apollo.BaseMutationOptions<Types.UpdateSessionAlertIsDisabledMutation, Types.UpdateSessionAlertIsDisabledMutationVariables>;
-export const UpdateMetricMonitorIsDisabledDocument = gql`
-    mutation UpdateMetricMonitorIsDisabled($id: ID!, $project_id: ID!, $disabled: Boolean!) {
-  updateMetricMonitorIsDisabled(
-    id: $id
-    project_id: $project_id
-    disabled: $disabled
-  ) {
-    id
-  }
+export function useUpdateSessionAlertIsDisabledMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateSessionAlertIsDisabledMutation,
+		Types.UpdateSessionAlertIsDisabledMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateSessionAlertIsDisabledMutation,
+		Types.UpdateSessionAlertIsDisabledMutationVariables
+	>(UpdateSessionAlertIsDisabledDocument, baseOptions)
 }
-    `;
-export type UpdateMetricMonitorIsDisabledMutationFn = Apollo.MutationFunction<Types.UpdateMetricMonitorIsDisabledMutation, Types.UpdateMetricMonitorIsDisabledMutationVariables>;
+export type UpdateSessionAlertIsDisabledMutationHookResult = ReturnType<
+	typeof useUpdateSessionAlertIsDisabledMutation
+>
+export type UpdateSessionAlertIsDisabledMutationResult =
+	Apollo.MutationResult<Types.UpdateSessionAlertIsDisabledMutation>
+export type UpdateSessionAlertIsDisabledMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.UpdateSessionAlertIsDisabledMutation,
+		Types.UpdateSessionAlertIsDisabledMutationVariables
+	>
+export const UpdateMetricMonitorIsDisabledDocument = gql`
+	mutation UpdateMetricMonitorIsDisabled(
+		$id: ID!
+		$project_id: ID!
+		$disabled: Boolean!
+	) {
+		updateMetricMonitorIsDisabled(
+			id: $id
+			project_id: $project_id
+			disabled: $disabled
+		) {
+			id
+		}
+	}
+`
+export type UpdateMetricMonitorIsDisabledMutationFn = Apollo.MutationFunction<
+	Types.UpdateMetricMonitorIsDisabledMutation,
+	Types.UpdateMetricMonitorIsDisabledMutationVariables
+>
 
 /**
  * __useUpdateMetricMonitorIsDisabledMutation__
@@ -2581,24 +3846,46 @@ export type UpdateMetricMonitorIsDisabledMutationFn = Apollo.MutationFunction<Ty
  *   },
  * });
  */
-export function useUpdateMetricMonitorIsDisabledMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateMetricMonitorIsDisabledMutation, Types.UpdateMetricMonitorIsDisabledMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateMetricMonitorIsDisabledMutation, Types.UpdateMetricMonitorIsDisabledMutationVariables>(UpdateMetricMonitorIsDisabledDocument, baseOptions);
-      }
-export type UpdateMetricMonitorIsDisabledMutationHookResult = ReturnType<typeof useUpdateMetricMonitorIsDisabledMutation>;
-export type UpdateMetricMonitorIsDisabledMutationResult = Apollo.MutationResult<Types.UpdateMetricMonitorIsDisabledMutation>;
-export type UpdateMetricMonitorIsDisabledMutationOptions = Apollo.BaseMutationOptions<Types.UpdateMetricMonitorIsDisabledMutation, Types.UpdateMetricMonitorIsDisabledMutationVariables>;
-export const UpdateErrorAlertIsDisabledDocument = gql`
-    mutation UpdateErrorAlertIsDisabled($id: ID!, $project_id: ID!, $disabled: Boolean!) {
-  updateErrorAlertIsDisabled(
-    id: $id
-    project_id: $project_id
-    disabled: $disabled
-  ) {
-    id
-  }
+export function useUpdateMetricMonitorIsDisabledMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateMetricMonitorIsDisabledMutation,
+		Types.UpdateMetricMonitorIsDisabledMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateMetricMonitorIsDisabledMutation,
+		Types.UpdateMetricMonitorIsDisabledMutationVariables
+	>(UpdateMetricMonitorIsDisabledDocument, baseOptions)
 }
-    `;
-export type UpdateErrorAlertIsDisabledMutationFn = Apollo.MutationFunction<Types.UpdateErrorAlertIsDisabledMutation, Types.UpdateErrorAlertIsDisabledMutationVariables>;
+export type UpdateMetricMonitorIsDisabledMutationHookResult = ReturnType<
+	typeof useUpdateMetricMonitorIsDisabledMutation
+>
+export type UpdateMetricMonitorIsDisabledMutationResult =
+	Apollo.MutationResult<Types.UpdateMetricMonitorIsDisabledMutation>
+export type UpdateMetricMonitorIsDisabledMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.UpdateMetricMonitorIsDisabledMutation,
+		Types.UpdateMetricMonitorIsDisabledMutationVariables
+	>
+export const UpdateErrorAlertIsDisabledDocument = gql`
+	mutation UpdateErrorAlertIsDisabled(
+		$id: ID!
+		$project_id: ID!
+		$disabled: Boolean!
+	) {
+		updateErrorAlertIsDisabled(
+			id: $id
+			project_id: $project_id
+			disabled: $disabled
+		) {
+			id
+		}
+	}
+`
+export type UpdateErrorAlertIsDisabledMutationFn = Apollo.MutationFunction<
+	Types.UpdateErrorAlertIsDisabledMutation,
+	Types.UpdateErrorAlertIsDisabledMutationVariables
+>
 
 /**
  * __useUpdateErrorAlertIsDisabledMutation__
@@ -2619,31 +3906,49 @@ export type UpdateErrorAlertIsDisabledMutationFn = Apollo.MutationFunction<Types
  *   },
  * });
  */
-export function useUpdateErrorAlertIsDisabledMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateErrorAlertIsDisabledMutation, Types.UpdateErrorAlertIsDisabledMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateErrorAlertIsDisabledMutation, Types.UpdateErrorAlertIsDisabledMutationVariables>(UpdateErrorAlertIsDisabledDocument, baseOptions);
-      }
-export type UpdateErrorAlertIsDisabledMutationHookResult = ReturnType<typeof useUpdateErrorAlertIsDisabledMutation>;
-export type UpdateErrorAlertIsDisabledMutationResult = Apollo.MutationResult<Types.UpdateErrorAlertIsDisabledMutation>;
-export type UpdateErrorAlertIsDisabledMutationOptions = Apollo.BaseMutationOptions<Types.UpdateErrorAlertIsDisabledMutation, Types.UpdateErrorAlertIsDisabledMutationVariables>;
-export const CreateSessionAlertDocument = gql`
-    mutation CreateSessionAlert($input: SessionAlertInput!) {
-  createSessionAlert(input: $input) {
-    id
-    ChannelsToNotify {
-      webhook_channel
-      webhook_channel_id
-    }
-    EmailsToNotify
-    Name
-    ExcludedEnvironments
-    CountThreshold
-    ThresholdWindow
-    LastAdminToEditID
-    disabled
-  }
+export function useUpdateErrorAlertIsDisabledMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateErrorAlertIsDisabledMutation,
+		Types.UpdateErrorAlertIsDisabledMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateErrorAlertIsDisabledMutation,
+		Types.UpdateErrorAlertIsDisabledMutationVariables
+	>(UpdateErrorAlertIsDisabledDocument, baseOptions)
 }
-    `;
-export type CreateSessionAlertMutationFn = Apollo.MutationFunction<Types.CreateSessionAlertMutation, Types.CreateSessionAlertMutationVariables>;
+export type UpdateErrorAlertIsDisabledMutationHookResult = ReturnType<
+	typeof useUpdateErrorAlertIsDisabledMutation
+>
+export type UpdateErrorAlertIsDisabledMutationResult =
+	Apollo.MutationResult<Types.UpdateErrorAlertIsDisabledMutation>
+export type UpdateErrorAlertIsDisabledMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.UpdateErrorAlertIsDisabledMutation,
+		Types.UpdateErrorAlertIsDisabledMutationVariables
+	>
+export const CreateSessionAlertDocument = gql`
+	mutation CreateSessionAlert($input: SessionAlertInput!) {
+		createSessionAlert(input: $input) {
+			id
+			ChannelsToNotify {
+				webhook_channel
+				webhook_channel_id
+			}
+			EmailsToNotify
+			Name
+			ExcludedEnvironments
+			CountThreshold
+			ThresholdWindow
+			LastAdminToEditID
+			disabled
+		}
+	}
+`
+export type CreateSessionAlertMutationFn = Apollo.MutationFunction<
+	Types.CreateSessionAlertMutation,
+	Types.CreateSessionAlertMutationVariables
+>
 
 /**
  * __useCreateSessionAlertMutation__
@@ -2662,35 +3967,52 @@ export type CreateSessionAlertMutationFn = Apollo.MutationFunction<Types.CreateS
  *   },
  * });
  */
-export function useCreateSessionAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateSessionAlertMutation, Types.CreateSessionAlertMutationVariables>) {
-        return Apollo.useMutation<Types.CreateSessionAlertMutation, Types.CreateSessionAlertMutationVariables>(CreateSessionAlertDocument, baseOptions);
-      }
-export type CreateSessionAlertMutationHookResult = ReturnType<typeof useCreateSessionAlertMutation>;
-export type CreateSessionAlertMutationResult = Apollo.MutationResult<Types.CreateSessionAlertMutation>;
-export type CreateSessionAlertMutationOptions = Apollo.BaseMutationOptions<Types.CreateSessionAlertMutation, Types.CreateSessionAlertMutationVariables>;
-export const UpdateSessionAlertDocument = gql`
-    mutation UpdateSessionAlert($id: ID!, $input: SessionAlertInput!) {
-  updateSessionAlert(id: $id, input: $input) {
-    id
-    ChannelsToNotify {
-      webhook_channel
-      webhook_channel_id
-    }
-    DiscordChannelsToNotify {
-      id
-      name
-    }
-    EmailsToNotify
-    ExcludedEnvironments
-    CountThreshold
-    ThresholdWindow
-    Name
-    LastAdminToEditID
-    disabled
-  }
+export function useCreateSessionAlertMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateSessionAlertMutation,
+		Types.CreateSessionAlertMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateSessionAlertMutation,
+		Types.CreateSessionAlertMutationVariables
+	>(CreateSessionAlertDocument, baseOptions)
 }
-    `;
-export type UpdateSessionAlertMutationFn = Apollo.MutationFunction<Types.UpdateSessionAlertMutation, Types.UpdateSessionAlertMutationVariables>;
+export type CreateSessionAlertMutationHookResult = ReturnType<
+	typeof useCreateSessionAlertMutation
+>
+export type CreateSessionAlertMutationResult =
+	Apollo.MutationResult<Types.CreateSessionAlertMutation>
+export type CreateSessionAlertMutationOptions = Apollo.BaseMutationOptions<
+	Types.CreateSessionAlertMutation,
+	Types.CreateSessionAlertMutationVariables
+>
+export const UpdateSessionAlertDocument = gql`
+	mutation UpdateSessionAlert($id: ID!, $input: SessionAlertInput!) {
+		updateSessionAlert(id: $id, input: $input) {
+			id
+			ChannelsToNotify {
+				webhook_channel
+				webhook_channel_id
+			}
+			DiscordChannelsToNotify {
+				id
+				name
+			}
+			EmailsToNotify
+			ExcludedEnvironments
+			CountThreshold
+			ThresholdWindow
+			Name
+			LastAdminToEditID
+			disabled
+		}
+	}
+`
+export type UpdateSessionAlertMutationFn = Apollo.MutationFunction<
+	Types.UpdateSessionAlertMutation,
+	Types.UpdateSessionAlertMutationVariables
+>
 
 /**
  * __useUpdateSessionAlertMutation__
@@ -2710,24 +4032,44 @@ export type UpdateSessionAlertMutationFn = Apollo.MutationFunction<Types.UpdateS
  *   },
  * });
  */
-export function useUpdateSessionAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateSessionAlertMutation, Types.UpdateSessionAlertMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateSessionAlertMutation, Types.UpdateSessionAlertMutationVariables>(UpdateSessionAlertDocument, baseOptions);
-      }
-export type UpdateSessionAlertMutationHookResult = ReturnType<typeof useUpdateSessionAlertMutation>;
-export type UpdateSessionAlertMutationResult = Apollo.MutationResult<Types.UpdateSessionAlertMutation>;
-export type UpdateSessionAlertMutationOptions = Apollo.BaseMutationOptions<Types.UpdateSessionAlertMutation, Types.UpdateSessionAlertMutationVariables>;
-export const UpdateSessionIsPublicDocument = gql`
-    mutation UpdateSessionIsPublic($session_secure_id: String!, $is_public: Boolean!) {
-  updateSessionIsPublic(
-    session_secure_id: $session_secure_id
-    is_public: $is_public
-  ) {
-    secure_id
-    is_public
-  }
+export function useUpdateSessionAlertMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateSessionAlertMutation,
+		Types.UpdateSessionAlertMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateSessionAlertMutation,
+		Types.UpdateSessionAlertMutationVariables
+	>(UpdateSessionAlertDocument, baseOptions)
 }
-    `;
-export type UpdateSessionIsPublicMutationFn = Apollo.MutationFunction<Types.UpdateSessionIsPublicMutation, Types.UpdateSessionIsPublicMutationVariables>;
+export type UpdateSessionAlertMutationHookResult = ReturnType<
+	typeof useUpdateSessionAlertMutation
+>
+export type UpdateSessionAlertMutationResult =
+	Apollo.MutationResult<Types.UpdateSessionAlertMutation>
+export type UpdateSessionAlertMutationOptions = Apollo.BaseMutationOptions<
+	Types.UpdateSessionAlertMutation,
+	Types.UpdateSessionAlertMutationVariables
+>
+export const UpdateSessionIsPublicDocument = gql`
+	mutation UpdateSessionIsPublic(
+		$session_secure_id: String!
+		$is_public: Boolean!
+	) {
+		updateSessionIsPublic(
+			session_secure_id: $session_secure_id
+			is_public: $is_public
+		) {
+			secure_id
+			is_public
+		}
+	}
+`
+export type UpdateSessionIsPublicMutationFn = Apollo.MutationFunction<
+	Types.UpdateSessionIsPublicMutation,
+	Types.UpdateSessionIsPublicMutationVariables
+>
 
 /**
  * __useUpdateSessionIsPublicMutation__
@@ -2747,24 +4089,44 @@ export type UpdateSessionIsPublicMutationFn = Apollo.MutationFunction<Types.Upda
  *   },
  * });
  */
-export function useUpdateSessionIsPublicMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateSessionIsPublicMutation, Types.UpdateSessionIsPublicMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateSessionIsPublicMutation, Types.UpdateSessionIsPublicMutationVariables>(UpdateSessionIsPublicDocument, baseOptions);
-      }
-export type UpdateSessionIsPublicMutationHookResult = ReturnType<typeof useUpdateSessionIsPublicMutation>;
-export type UpdateSessionIsPublicMutationResult = Apollo.MutationResult<Types.UpdateSessionIsPublicMutation>;
-export type UpdateSessionIsPublicMutationOptions = Apollo.BaseMutationOptions<Types.UpdateSessionIsPublicMutation, Types.UpdateSessionIsPublicMutationVariables>;
-export const UpdateErrorGroupIsPublicDocument = gql`
-    mutation UpdateErrorGroupIsPublic($error_group_secure_id: String!, $is_public: Boolean!) {
-  updateErrorGroupIsPublic(
-    error_group_secure_id: $error_group_secure_id
-    is_public: $is_public
-  ) {
-    secure_id
-    is_public
-  }
+export function useUpdateSessionIsPublicMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateSessionIsPublicMutation,
+		Types.UpdateSessionIsPublicMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateSessionIsPublicMutation,
+		Types.UpdateSessionIsPublicMutationVariables
+	>(UpdateSessionIsPublicDocument, baseOptions)
 }
-    `;
-export type UpdateErrorGroupIsPublicMutationFn = Apollo.MutationFunction<Types.UpdateErrorGroupIsPublicMutation, Types.UpdateErrorGroupIsPublicMutationVariables>;
+export type UpdateSessionIsPublicMutationHookResult = ReturnType<
+	typeof useUpdateSessionIsPublicMutation
+>
+export type UpdateSessionIsPublicMutationResult =
+	Apollo.MutationResult<Types.UpdateSessionIsPublicMutation>
+export type UpdateSessionIsPublicMutationOptions = Apollo.BaseMutationOptions<
+	Types.UpdateSessionIsPublicMutation,
+	Types.UpdateSessionIsPublicMutationVariables
+>
+export const UpdateErrorGroupIsPublicDocument = gql`
+	mutation UpdateErrorGroupIsPublic(
+		$error_group_secure_id: String!
+		$is_public: Boolean!
+	) {
+		updateErrorGroupIsPublic(
+			error_group_secure_id: $error_group_secure_id
+			is_public: $is_public
+		) {
+			secure_id
+			is_public
+		}
+	}
+`
+export type UpdateErrorGroupIsPublicMutationFn = Apollo.MutationFunction<
+	Types.UpdateErrorGroupIsPublicMutation,
+	Types.UpdateErrorGroupIsPublicMutationVariables
+>
 
 /**
  * __useUpdateErrorGroupIsPublicMutation__
@@ -2784,24 +4146,45 @@ export type UpdateErrorGroupIsPublicMutationFn = Apollo.MutationFunction<Types.U
  *   },
  * });
  */
-export function useUpdateErrorGroupIsPublicMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateErrorGroupIsPublicMutation, Types.UpdateErrorGroupIsPublicMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateErrorGroupIsPublicMutation, Types.UpdateErrorGroupIsPublicMutationVariables>(UpdateErrorGroupIsPublicDocument, baseOptions);
-      }
-export type UpdateErrorGroupIsPublicMutationHookResult = ReturnType<typeof useUpdateErrorGroupIsPublicMutation>;
-export type UpdateErrorGroupIsPublicMutationResult = Apollo.MutationResult<Types.UpdateErrorGroupIsPublicMutation>;
-export type UpdateErrorGroupIsPublicMutationOptions = Apollo.BaseMutationOptions<Types.UpdateErrorGroupIsPublicMutation, Types.UpdateErrorGroupIsPublicMutationVariables>;
-export const UpdateAllowMeterOverageDocument = gql`
-    mutation UpdateAllowMeterOverage($workspace_id: ID!, $allow_meter_overage: Boolean!) {
-  updateAllowMeterOverage(
-    workspace_id: $workspace_id
-    allow_meter_overage: $allow_meter_overage
-  ) {
-    id
-    allow_meter_overage
-  }
+export function useUpdateErrorGroupIsPublicMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateErrorGroupIsPublicMutation,
+		Types.UpdateErrorGroupIsPublicMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateErrorGroupIsPublicMutation,
+		Types.UpdateErrorGroupIsPublicMutationVariables
+	>(UpdateErrorGroupIsPublicDocument, baseOptions)
 }
-    `;
-export type UpdateAllowMeterOverageMutationFn = Apollo.MutationFunction<Types.UpdateAllowMeterOverageMutation, Types.UpdateAllowMeterOverageMutationVariables>;
+export type UpdateErrorGroupIsPublicMutationHookResult = ReturnType<
+	typeof useUpdateErrorGroupIsPublicMutation
+>
+export type UpdateErrorGroupIsPublicMutationResult =
+	Apollo.MutationResult<Types.UpdateErrorGroupIsPublicMutation>
+export type UpdateErrorGroupIsPublicMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.UpdateErrorGroupIsPublicMutation,
+		Types.UpdateErrorGroupIsPublicMutationVariables
+	>
+export const UpdateAllowMeterOverageDocument = gql`
+	mutation UpdateAllowMeterOverage(
+		$workspace_id: ID!
+		$allow_meter_overage: Boolean!
+	) {
+		updateAllowMeterOverage(
+			workspace_id: $workspace_id
+			allow_meter_overage: $allow_meter_overage
+		) {
+			id
+			allow_meter_overage
+		}
+	}
+`
+export type UpdateAllowMeterOverageMutationFn = Apollo.MutationFunction<
+	Types.UpdateAllowMeterOverageMutation,
+	Types.UpdateAllowMeterOverageMutationVariables
+>
 
 /**
  * __useUpdateAllowMeterOverageMutation__
@@ -2821,21 +4204,38 @@ export type UpdateAllowMeterOverageMutationFn = Apollo.MutationFunction<Types.Up
  *   },
  * });
  */
-export function useUpdateAllowMeterOverageMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateAllowMeterOverageMutation, Types.UpdateAllowMeterOverageMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateAllowMeterOverageMutation, Types.UpdateAllowMeterOverageMutationVariables>(UpdateAllowMeterOverageDocument, baseOptions);
-      }
-export type UpdateAllowMeterOverageMutationHookResult = ReturnType<typeof useUpdateAllowMeterOverageMutation>;
-export type UpdateAllowMeterOverageMutationResult = Apollo.MutationResult<Types.UpdateAllowMeterOverageMutation>;
-export type UpdateAllowMeterOverageMutationOptions = Apollo.BaseMutationOptions<Types.UpdateAllowMeterOverageMutation, Types.UpdateAllowMeterOverageMutationVariables>;
-export const SyncSlackIntegrationDocument = gql`
-    mutation SyncSlackIntegration($project_id: ID!) {
-  syncSlackIntegration(project_id: $project_id) {
-    success
-    newChannelsAddedCount
-  }
+export function useUpdateAllowMeterOverageMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateAllowMeterOverageMutation,
+		Types.UpdateAllowMeterOverageMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateAllowMeterOverageMutation,
+		Types.UpdateAllowMeterOverageMutationVariables
+	>(UpdateAllowMeterOverageDocument, baseOptions)
 }
-    `;
-export type SyncSlackIntegrationMutationFn = Apollo.MutationFunction<Types.SyncSlackIntegrationMutation, Types.SyncSlackIntegrationMutationVariables>;
+export type UpdateAllowMeterOverageMutationHookResult = ReturnType<
+	typeof useUpdateAllowMeterOverageMutation
+>
+export type UpdateAllowMeterOverageMutationResult =
+	Apollo.MutationResult<Types.UpdateAllowMeterOverageMutation>
+export type UpdateAllowMeterOverageMutationOptions = Apollo.BaseMutationOptions<
+	Types.UpdateAllowMeterOverageMutation,
+	Types.UpdateAllowMeterOverageMutationVariables
+>
+export const SyncSlackIntegrationDocument = gql`
+	mutation SyncSlackIntegration($project_id: ID!) {
+		syncSlackIntegration(project_id: $project_id) {
+			success
+			newChannelsAddedCount
+		}
+	}
+`
+export type SyncSlackIntegrationMutationFn = Apollo.MutationFunction<
+	Types.SyncSlackIntegrationMutation,
+	Types.SyncSlackIntegrationMutationVariables
+>
 
 /**
  * __useSyncSlackIntegrationMutation__
@@ -2854,18 +4254,35 @@ export type SyncSlackIntegrationMutationFn = Apollo.MutationFunction<Types.SyncS
  *   },
  * });
  */
-export function useSyncSlackIntegrationMutation(baseOptions?: Apollo.MutationHookOptions<Types.SyncSlackIntegrationMutation, Types.SyncSlackIntegrationMutationVariables>) {
-        return Apollo.useMutation<Types.SyncSlackIntegrationMutation, Types.SyncSlackIntegrationMutationVariables>(SyncSlackIntegrationDocument, baseOptions);
-      }
-export type SyncSlackIntegrationMutationHookResult = ReturnType<typeof useSyncSlackIntegrationMutation>;
-export type SyncSlackIntegrationMutationResult = Apollo.MutationResult<Types.SyncSlackIntegrationMutation>;
-export type SyncSlackIntegrationMutationOptions = Apollo.BaseMutationOptions<Types.SyncSlackIntegrationMutation, Types.SyncSlackIntegrationMutationVariables>;
-export const RequestAccessDocument = gql`
-    mutation RequestAccess($project_id: ID!) {
-  requestAccess(project_id: $project_id)
+export function useSyncSlackIntegrationMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.SyncSlackIntegrationMutation,
+		Types.SyncSlackIntegrationMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.SyncSlackIntegrationMutation,
+		Types.SyncSlackIntegrationMutationVariables
+	>(SyncSlackIntegrationDocument, baseOptions)
 }
-    `;
-export type RequestAccessMutationFn = Apollo.MutationFunction<Types.RequestAccessMutation, Types.RequestAccessMutationVariables>;
+export type SyncSlackIntegrationMutationHookResult = ReturnType<
+	typeof useSyncSlackIntegrationMutation
+>
+export type SyncSlackIntegrationMutationResult =
+	Apollo.MutationResult<Types.SyncSlackIntegrationMutation>
+export type SyncSlackIntegrationMutationOptions = Apollo.BaseMutationOptions<
+	Types.SyncSlackIntegrationMutation,
+	Types.SyncSlackIntegrationMutationVariables
+>
+export const RequestAccessDocument = gql`
+	mutation RequestAccess($project_id: ID!) {
+		requestAccess(project_id: $project_id)
+	}
+`
+export type RequestAccessMutationFn = Apollo.MutationFunction<
+	Types.RequestAccessMutation,
+	Types.RequestAccessMutationVariables
+>
 
 /**
  * __useRequestAccessMutation__
@@ -2884,18 +4301,38 @@ export type RequestAccessMutationFn = Apollo.MutationFunction<Types.RequestAcces
  *   },
  * });
  */
-export function useRequestAccessMutation(baseOptions?: Apollo.MutationHookOptions<Types.RequestAccessMutation, Types.RequestAccessMutationVariables>) {
-        return Apollo.useMutation<Types.RequestAccessMutation, Types.RequestAccessMutationVariables>(RequestAccessDocument, baseOptions);
-      }
-export type RequestAccessMutationHookResult = ReturnType<typeof useRequestAccessMutation>;
-export type RequestAccessMutationResult = Apollo.MutationResult<Types.RequestAccessMutation>;
-export type RequestAccessMutationOptions = Apollo.BaseMutationOptions<Types.RequestAccessMutation, Types.RequestAccessMutationVariables>;
-export const ModifyClearbitIntegrationDocument = gql`
-    mutation ModifyClearbitIntegration($workspace_id: ID!, $enabled: Boolean!) {
-  modifyClearbitIntegration(workspace_id: $workspace_id, enabled: $enabled)
+export function useRequestAccessMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.RequestAccessMutation,
+		Types.RequestAccessMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.RequestAccessMutation,
+		Types.RequestAccessMutationVariables
+	>(RequestAccessDocument, baseOptions)
 }
-    `;
-export type ModifyClearbitIntegrationMutationFn = Apollo.MutationFunction<Types.ModifyClearbitIntegrationMutation, Types.ModifyClearbitIntegrationMutationVariables>;
+export type RequestAccessMutationHookResult = ReturnType<
+	typeof useRequestAccessMutation
+>
+export type RequestAccessMutationResult =
+	Apollo.MutationResult<Types.RequestAccessMutation>
+export type RequestAccessMutationOptions = Apollo.BaseMutationOptions<
+	Types.RequestAccessMutation,
+	Types.RequestAccessMutationVariables
+>
+export const ModifyClearbitIntegrationDocument = gql`
+	mutation ModifyClearbitIntegration($workspace_id: ID!, $enabled: Boolean!) {
+		modifyClearbitIntegration(
+			workspace_id: $workspace_id
+			enabled: $enabled
+		)
+	}
+`
+export type ModifyClearbitIntegrationMutationFn = Apollo.MutationFunction<
+	Types.ModifyClearbitIntegrationMutation,
+	Types.ModifyClearbitIntegrationMutationVariables
+>
 
 /**
  * __useModifyClearbitIntegrationMutation__
@@ -2915,25 +4352,50 @@ export type ModifyClearbitIntegrationMutationFn = Apollo.MutationFunction<Types.
  *   },
  * });
  */
-export function useModifyClearbitIntegrationMutation(baseOptions?: Apollo.MutationHookOptions<Types.ModifyClearbitIntegrationMutation, Types.ModifyClearbitIntegrationMutationVariables>) {
-        return Apollo.useMutation<Types.ModifyClearbitIntegrationMutation, Types.ModifyClearbitIntegrationMutationVariables>(ModifyClearbitIntegrationDocument, baseOptions);
-      }
-export type ModifyClearbitIntegrationMutationHookResult = ReturnType<typeof useModifyClearbitIntegrationMutation>;
-export type ModifyClearbitIntegrationMutationResult = Apollo.MutationResult<Types.ModifyClearbitIntegrationMutation>;
-export type ModifyClearbitIntegrationMutationOptions = Apollo.BaseMutationOptions<Types.ModifyClearbitIntegrationMutation, Types.ModifyClearbitIntegrationMutationVariables>;
-export const UpsertDashboardDocument = gql`
-    mutation UpsertDashboard($id: ID, $project_id: ID!, $name: String!, $metrics: [DashboardMetricConfigInput!]!, $layout: String, $is_default: Boolean) {
-  upsertDashboard(
-    id: $id
-    project_id: $project_id
-    name: $name
-    metrics: $metrics
-    layout: $layout
-    is_default: $is_default
-  )
+export function useModifyClearbitIntegrationMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.ModifyClearbitIntegrationMutation,
+		Types.ModifyClearbitIntegrationMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.ModifyClearbitIntegrationMutation,
+		Types.ModifyClearbitIntegrationMutationVariables
+	>(ModifyClearbitIntegrationDocument, baseOptions)
 }
-    `;
-export type UpsertDashboardMutationFn = Apollo.MutationFunction<Types.UpsertDashboardMutation, Types.UpsertDashboardMutationVariables>;
+export type ModifyClearbitIntegrationMutationHookResult = ReturnType<
+	typeof useModifyClearbitIntegrationMutation
+>
+export type ModifyClearbitIntegrationMutationResult =
+	Apollo.MutationResult<Types.ModifyClearbitIntegrationMutation>
+export type ModifyClearbitIntegrationMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.ModifyClearbitIntegrationMutation,
+		Types.ModifyClearbitIntegrationMutationVariables
+	>
+export const UpsertDashboardDocument = gql`
+	mutation UpsertDashboard(
+		$id: ID
+		$project_id: ID!
+		$name: String!
+		$metrics: [DashboardMetricConfigInput!]!
+		$layout: String
+		$is_default: Boolean
+	) {
+		upsertDashboard(
+			id: $id
+			project_id: $project_id
+			name: $name
+			metrics: $metrics
+			layout: $layout
+			is_default: $is_default
+		)
+	}
+`
+export type UpsertDashboardMutationFn = Apollo.MutationFunction<
+	Types.UpsertDashboardMutation,
+	Types.UpsertDashboardMutationVariables
+>
 
 /**
  * __useUpsertDashboardMutation__
@@ -2957,18 +4419,35 @@ export type UpsertDashboardMutationFn = Apollo.MutationFunction<Types.UpsertDash
  *   },
  * });
  */
-export function useUpsertDashboardMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpsertDashboardMutation, Types.UpsertDashboardMutationVariables>) {
-        return Apollo.useMutation<Types.UpsertDashboardMutation, Types.UpsertDashboardMutationVariables>(UpsertDashboardDocument, baseOptions);
-      }
-export type UpsertDashboardMutationHookResult = ReturnType<typeof useUpsertDashboardMutation>;
-export type UpsertDashboardMutationResult = Apollo.MutationResult<Types.UpsertDashboardMutation>;
-export type UpsertDashboardMutationOptions = Apollo.BaseMutationOptions<Types.UpsertDashboardMutation, Types.UpsertDashboardMutationVariables>;
-export const DeleteDashboardDocument = gql`
-    mutation DeleteDashboard($id: ID!) {
-  deleteDashboard(id: $id)
+export function useUpsertDashboardMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpsertDashboardMutation,
+		Types.UpsertDashboardMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpsertDashboardMutation,
+		Types.UpsertDashboardMutationVariables
+	>(UpsertDashboardDocument, baseOptions)
 }
-    `;
-export type DeleteDashboardMutationFn = Apollo.MutationFunction<Types.DeleteDashboardMutation, Types.DeleteDashboardMutationVariables>;
+export type UpsertDashboardMutationHookResult = ReturnType<
+	typeof useUpsertDashboardMutation
+>
+export type UpsertDashboardMutationResult =
+	Apollo.MutationResult<Types.UpsertDashboardMutation>
+export type UpsertDashboardMutationOptions = Apollo.BaseMutationOptions<
+	Types.UpsertDashboardMutation,
+	Types.UpsertDashboardMutationVariables
+>
+export const DeleteDashboardDocument = gql`
+	mutation DeleteDashboard($id: ID!) {
+		deleteDashboard(id: $id)
+	}
+`
+export type DeleteDashboardMutationFn = Apollo.MutationFunction<
+	Types.DeleteDashboardMutation,
+	Types.DeleteDashboardMutationVariables
+>
 
 /**
  * __useDeleteDashboardMutation__
@@ -2987,22 +4466,43 @@ export type DeleteDashboardMutationFn = Apollo.MutationFunction<Types.DeleteDash
  *   },
  * });
  */
-export function useDeleteDashboardMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteDashboardMutation, Types.DeleteDashboardMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteDashboardMutation, Types.DeleteDashboardMutationVariables>(DeleteDashboardDocument, baseOptions);
-      }
-export type DeleteDashboardMutationHookResult = ReturnType<typeof useDeleteDashboardMutation>;
-export type DeleteDashboardMutationResult = Apollo.MutationResult<Types.DeleteDashboardMutation>;
-export type DeleteDashboardMutationOptions = Apollo.BaseMutationOptions<Types.DeleteDashboardMutation, Types.DeleteDashboardMutationVariables>;
-export const DeleteSessionsDocument = gql`
-    mutation DeleteSessions($project_id: ID!, $query: String!, $sessionCount: Int!) {
-  deleteSessions(
-    project_id: $project_id
-    query: $query
-    sessionCount: $sessionCount
-  )
+export function useDeleteDashboardMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteDashboardMutation,
+		Types.DeleteDashboardMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteDashboardMutation,
+		Types.DeleteDashboardMutationVariables
+	>(DeleteDashboardDocument, baseOptions)
 }
-    `;
-export type DeleteSessionsMutationFn = Apollo.MutationFunction<Types.DeleteSessionsMutation, Types.DeleteSessionsMutationVariables>;
+export type DeleteDashboardMutationHookResult = ReturnType<
+	typeof useDeleteDashboardMutation
+>
+export type DeleteDashboardMutationResult =
+	Apollo.MutationResult<Types.DeleteDashboardMutation>
+export type DeleteDashboardMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteDashboardMutation,
+	Types.DeleteDashboardMutationVariables
+>
+export const DeleteSessionsDocument = gql`
+	mutation DeleteSessions(
+		$project_id: ID!
+		$query: String!
+		$sessionCount: Int!
+	) {
+		deleteSessions(
+			project_id: $project_id
+			query: $query
+			sessionCount: $sessionCount
+		)
+	}
+`
+export type DeleteSessionsMutationFn = Apollo.MutationFunction<
+	Types.DeleteSessionsMutation,
+	Types.DeleteSessionsMutationVariables
+>
 
 /**
  * __useDeleteSessionsMutation__
@@ -3023,21 +4523,41 @@ export type DeleteSessionsMutationFn = Apollo.MutationFunction<Types.DeleteSessi
  *   },
  * });
  */
-export function useDeleteSessionsMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteSessionsMutation, Types.DeleteSessionsMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteSessionsMutation, Types.DeleteSessionsMutationVariables>(DeleteSessionsDocument, baseOptions);
-      }
-export type DeleteSessionsMutationHookResult = ReturnType<typeof useDeleteSessionsMutation>;
-export type DeleteSessionsMutationResult = Apollo.MutationResult<Types.DeleteSessionsMutation>;
-export type DeleteSessionsMutationOptions = Apollo.BaseMutationOptions<Types.DeleteSessionsMutation, Types.DeleteSessionsMutationVariables>;
-export const UpdateVercelSettingsDocument = gql`
-    mutation UpdateVercelSettings($project_id: ID!, $project_mappings: [VercelProjectMappingInput!]!) {
-  updateVercelProjectMappings(
-    project_id: $project_id
-    project_mappings: $project_mappings
-  )
+export function useDeleteSessionsMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteSessionsMutation,
+		Types.DeleteSessionsMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteSessionsMutation,
+		Types.DeleteSessionsMutationVariables
+	>(DeleteSessionsDocument, baseOptions)
 }
-    `;
-export type UpdateVercelSettingsMutationFn = Apollo.MutationFunction<Types.UpdateVercelSettingsMutation, Types.UpdateVercelSettingsMutationVariables>;
+export type DeleteSessionsMutationHookResult = ReturnType<
+	typeof useDeleteSessionsMutation
+>
+export type DeleteSessionsMutationResult =
+	Apollo.MutationResult<Types.DeleteSessionsMutation>
+export type DeleteSessionsMutationOptions = Apollo.BaseMutationOptions<
+	Types.DeleteSessionsMutation,
+	Types.DeleteSessionsMutationVariables
+>
+export const UpdateVercelSettingsDocument = gql`
+	mutation UpdateVercelSettings(
+		$project_id: ID!
+		$project_mappings: [VercelProjectMappingInput!]!
+	) {
+		updateVercelProjectMappings(
+			project_id: $project_id
+			project_mappings: $project_mappings
+		)
+	}
+`
+export type UpdateVercelSettingsMutationFn = Apollo.MutationFunction<
+	Types.UpdateVercelSettingsMutation,
+	Types.UpdateVercelSettingsMutationVariables
+>
 
 /**
  * __useUpdateVercelSettingsMutation__
@@ -3057,21 +4577,41 @@ export type UpdateVercelSettingsMutationFn = Apollo.MutationFunction<Types.Updat
  *   },
  * });
  */
-export function useUpdateVercelSettingsMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateVercelSettingsMutation, Types.UpdateVercelSettingsMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateVercelSettingsMutation, Types.UpdateVercelSettingsMutationVariables>(UpdateVercelSettingsDocument, baseOptions);
-      }
-export type UpdateVercelSettingsMutationHookResult = ReturnType<typeof useUpdateVercelSettingsMutation>;
-export type UpdateVercelSettingsMutationResult = Apollo.MutationResult<Types.UpdateVercelSettingsMutation>;
-export type UpdateVercelSettingsMutationOptions = Apollo.BaseMutationOptions<Types.UpdateVercelSettingsMutation, Types.UpdateVercelSettingsMutationVariables>;
-export const UpdateClickUpSettingsDocument = gql`
-    mutation UpdateClickUpSettings($workspace_id: ID!, $project_mappings: [ClickUpProjectMappingInput!]!) {
-  updateClickUpProjectMappings(
-    workspace_id: $workspace_id
-    project_mappings: $project_mappings
-  )
+export function useUpdateVercelSettingsMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateVercelSettingsMutation,
+		Types.UpdateVercelSettingsMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateVercelSettingsMutation,
+		Types.UpdateVercelSettingsMutationVariables
+	>(UpdateVercelSettingsDocument, baseOptions)
 }
-    `;
-export type UpdateClickUpSettingsMutationFn = Apollo.MutationFunction<Types.UpdateClickUpSettingsMutation, Types.UpdateClickUpSettingsMutationVariables>;
+export type UpdateVercelSettingsMutationHookResult = ReturnType<
+	typeof useUpdateVercelSettingsMutation
+>
+export type UpdateVercelSettingsMutationResult =
+	Apollo.MutationResult<Types.UpdateVercelSettingsMutation>
+export type UpdateVercelSettingsMutationOptions = Apollo.BaseMutationOptions<
+	Types.UpdateVercelSettingsMutation,
+	Types.UpdateVercelSettingsMutationVariables
+>
+export const UpdateClickUpSettingsDocument = gql`
+	mutation UpdateClickUpSettings(
+		$workspace_id: ID!
+		$project_mappings: [ClickUpProjectMappingInput!]!
+	) {
+		updateClickUpProjectMappings(
+			workspace_id: $workspace_id
+			project_mappings: $project_mappings
+		)
+	}
+`
+export type UpdateClickUpSettingsMutationFn = Apollo.MutationFunction<
+	Types.UpdateClickUpSettingsMutation,
+	Types.UpdateClickUpSettingsMutationVariables
+>
 
 /**
  * __useUpdateClickUpSettingsMutation__
@@ -3091,22 +4631,44 @@ export type UpdateClickUpSettingsMutationFn = Apollo.MutationFunction<Types.Upda
  *   },
  * });
  */
-export function useUpdateClickUpSettingsMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateClickUpSettingsMutation, Types.UpdateClickUpSettingsMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateClickUpSettingsMutation, Types.UpdateClickUpSettingsMutationVariables>(UpdateClickUpSettingsDocument, baseOptions);
-      }
-export type UpdateClickUpSettingsMutationHookResult = ReturnType<typeof useUpdateClickUpSettingsMutation>;
-export type UpdateClickUpSettingsMutationResult = Apollo.MutationResult<Types.UpdateClickUpSettingsMutation>;
-export type UpdateClickUpSettingsMutationOptions = Apollo.BaseMutationOptions<Types.UpdateClickUpSettingsMutation, Types.UpdateClickUpSettingsMutationVariables>;
-export const UpdateIntegrationProjectSettingsDocument = gql`
-    mutation UpdateIntegrationProjectSettings($workspace_id: ID!, $integration_type: IntegrationType!, $project_mappings: [IntegrationProjectMappingInput!]!) {
-  updateIntegrationProjectMappings(
-    workspace_id: $workspace_id
-    integration_type: $integration_type
-    project_mappings: $project_mappings
-  )
+export function useUpdateClickUpSettingsMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateClickUpSettingsMutation,
+		Types.UpdateClickUpSettingsMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateClickUpSettingsMutation,
+		Types.UpdateClickUpSettingsMutationVariables
+	>(UpdateClickUpSettingsDocument, baseOptions)
 }
-    `;
-export type UpdateIntegrationProjectSettingsMutationFn = Apollo.MutationFunction<Types.UpdateIntegrationProjectSettingsMutation, Types.UpdateIntegrationProjectSettingsMutationVariables>;
+export type UpdateClickUpSettingsMutationHookResult = ReturnType<
+	typeof useUpdateClickUpSettingsMutation
+>
+export type UpdateClickUpSettingsMutationResult =
+	Apollo.MutationResult<Types.UpdateClickUpSettingsMutation>
+export type UpdateClickUpSettingsMutationOptions = Apollo.BaseMutationOptions<
+	Types.UpdateClickUpSettingsMutation,
+	Types.UpdateClickUpSettingsMutationVariables
+>
+export const UpdateIntegrationProjectSettingsDocument = gql`
+	mutation UpdateIntegrationProjectSettings(
+		$workspace_id: ID!
+		$integration_type: IntegrationType!
+		$project_mappings: [IntegrationProjectMappingInput!]!
+	) {
+		updateIntegrationProjectMappings(
+			workspace_id: $workspace_id
+			integration_type: $integration_type
+			project_mappings: $project_mappings
+		)
+	}
+`
+export type UpdateIntegrationProjectSettingsMutationFn =
+	Apollo.MutationFunction<
+		Types.UpdateIntegrationProjectSettingsMutation,
+		Types.UpdateIntegrationProjectSettingsMutationVariables
+	>
 
 /**
  * __useUpdateIntegrationProjectSettingsMutation__
@@ -3127,23 +4689,46 @@ export type UpdateIntegrationProjectSettingsMutationFn = Apollo.MutationFunction
  *   },
  * });
  */
-export function useUpdateIntegrationProjectSettingsMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateIntegrationProjectSettingsMutation, Types.UpdateIntegrationProjectSettingsMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateIntegrationProjectSettingsMutation, Types.UpdateIntegrationProjectSettingsMutationVariables>(UpdateIntegrationProjectSettingsDocument, baseOptions);
-      }
-export type UpdateIntegrationProjectSettingsMutationHookResult = ReturnType<typeof useUpdateIntegrationProjectSettingsMutation>;
-export type UpdateIntegrationProjectSettingsMutationResult = Apollo.MutationResult<Types.UpdateIntegrationProjectSettingsMutation>;
-export type UpdateIntegrationProjectSettingsMutationOptions = Apollo.BaseMutationOptions<Types.UpdateIntegrationProjectSettingsMutation, Types.UpdateIntegrationProjectSettingsMutationVariables>;
-export const UpdateEmailOptOutDocument = gql`
-    mutation UpdateEmailOptOut($token: String, $admin_id: ID, $category: EmailOptOutCategory!, $is_opt_out: Boolean!) {
-  updateEmailOptOut(
-    token: $token
-    admin_id: $admin_id
-    category: $category
-    is_opt_out: $is_opt_out
-  )
+export function useUpdateIntegrationProjectSettingsMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateIntegrationProjectSettingsMutation,
+		Types.UpdateIntegrationProjectSettingsMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateIntegrationProjectSettingsMutation,
+		Types.UpdateIntegrationProjectSettingsMutationVariables
+	>(UpdateIntegrationProjectSettingsDocument, baseOptions)
 }
-    `;
-export type UpdateEmailOptOutMutationFn = Apollo.MutationFunction<Types.UpdateEmailOptOutMutation, Types.UpdateEmailOptOutMutationVariables>;
+export type UpdateIntegrationProjectSettingsMutationHookResult = ReturnType<
+	typeof useUpdateIntegrationProjectSettingsMutation
+>
+export type UpdateIntegrationProjectSettingsMutationResult =
+	Apollo.MutationResult<Types.UpdateIntegrationProjectSettingsMutation>
+export type UpdateIntegrationProjectSettingsMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.UpdateIntegrationProjectSettingsMutation,
+		Types.UpdateIntegrationProjectSettingsMutationVariables
+	>
+export const UpdateEmailOptOutDocument = gql`
+	mutation UpdateEmailOptOut(
+		$token: String
+		$admin_id: ID
+		$category: EmailOptOutCategory!
+		$is_opt_out: Boolean!
+	) {
+		updateEmailOptOut(
+			token: $token
+			admin_id: $admin_id
+			category: $category
+			is_opt_out: $is_opt_out
+		)
+	}
+`
+export type UpdateEmailOptOutMutationFn = Apollo.MutationFunction<
+	Types.UpdateEmailOptOutMutation,
+	Types.UpdateEmailOptOutMutationVariables
+>
 
 /**
  * __useUpdateEmailOptOutMutation__
@@ -3165,21 +4750,41 @@ export type UpdateEmailOptOutMutationFn = Apollo.MutationFunction<Types.UpdateEm
  *   },
  * });
  */
-export function useUpdateEmailOptOutMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateEmailOptOutMutation, Types.UpdateEmailOptOutMutationVariables>) {
-        return Apollo.useMutation<Types.UpdateEmailOptOutMutation, Types.UpdateEmailOptOutMutationVariables>(UpdateEmailOptOutDocument, baseOptions);
-      }
-export type UpdateEmailOptOutMutationHookResult = ReturnType<typeof useUpdateEmailOptOutMutation>;
-export type UpdateEmailOptOutMutationResult = Apollo.MutationResult<Types.UpdateEmailOptOutMutation>;
-export type UpdateEmailOptOutMutationOptions = Apollo.BaseMutationOptions<Types.UpdateEmailOptOutMutation, Types.UpdateEmailOptOutMutationVariables>;
-export const DeleteInviteLinkFromWorkspaceDocument = gql`
-    mutation DeleteInviteLinkFromWorkspace($workspace_id: ID!, $workspace_invite_link_id: ID!) {
-  deleteInviteLinkFromWorkspace(
-    workspace_id: $workspace_id
-    workspace_invite_link_id: $workspace_invite_link_id
-  )
+export function useUpdateEmailOptOutMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.UpdateEmailOptOutMutation,
+		Types.UpdateEmailOptOutMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.UpdateEmailOptOutMutation,
+		Types.UpdateEmailOptOutMutationVariables
+	>(UpdateEmailOptOutDocument, baseOptions)
 }
-    `;
-export type DeleteInviteLinkFromWorkspaceMutationFn = Apollo.MutationFunction<Types.DeleteInviteLinkFromWorkspaceMutation, Types.DeleteInviteLinkFromWorkspaceMutationVariables>;
+export type UpdateEmailOptOutMutationHookResult = ReturnType<
+	typeof useUpdateEmailOptOutMutation
+>
+export type UpdateEmailOptOutMutationResult =
+	Apollo.MutationResult<Types.UpdateEmailOptOutMutation>
+export type UpdateEmailOptOutMutationOptions = Apollo.BaseMutationOptions<
+	Types.UpdateEmailOptOutMutation,
+	Types.UpdateEmailOptOutMutationVariables
+>
+export const DeleteInviteLinkFromWorkspaceDocument = gql`
+	mutation DeleteInviteLinkFromWorkspace(
+		$workspace_id: ID!
+		$workspace_invite_link_id: ID!
+	) {
+		deleteInviteLinkFromWorkspace(
+			workspace_id: $workspace_id
+			workspace_invite_link_id: $workspace_invite_link_id
+		)
+	}
+`
+export type DeleteInviteLinkFromWorkspaceMutationFn = Apollo.MutationFunction<
+	Types.DeleteInviteLinkFromWorkspaceMutation,
+	Types.DeleteInviteLinkFromWorkspaceMutationVariables
+>
 
 /**
  * __useDeleteInviteLinkFromWorkspaceMutation__
@@ -3199,26 +4804,45 @@ export type DeleteInviteLinkFromWorkspaceMutationFn = Apollo.MutationFunction<Ty
  *   },
  * });
  */
-export function useDeleteInviteLinkFromWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteInviteLinkFromWorkspaceMutation, Types.DeleteInviteLinkFromWorkspaceMutationVariables>) {
-        return Apollo.useMutation<Types.DeleteInviteLinkFromWorkspaceMutation, Types.DeleteInviteLinkFromWorkspaceMutationVariables>(DeleteInviteLinkFromWorkspaceDocument, baseOptions);
-      }
-export type DeleteInviteLinkFromWorkspaceMutationHookResult = ReturnType<typeof useDeleteInviteLinkFromWorkspaceMutation>;
-export type DeleteInviteLinkFromWorkspaceMutationResult = Apollo.MutationResult<Types.DeleteInviteLinkFromWorkspaceMutation>;
-export type DeleteInviteLinkFromWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.DeleteInviteLinkFromWorkspaceMutation, Types.DeleteInviteLinkFromWorkspaceMutationVariables>;
-export const GetMetricsTimelineDocument = gql`
-    query GetMetricsTimeline($project_id: ID!, $metric_name: String!, $params: DashboardParamsInput!) {
-  metrics_timeline(
-    project_id: $project_id
-    metric_name: $metric_name
-    params: $params
-  ) {
-    date
-    value
-    aggregator
-    group
-  }
+export function useDeleteInviteLinkFromWorkspaceMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.DeleteInviteLinkFromWorkspaceMutation,
+		Types.DeleteInviteLinkFromWorkspaceMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.DeleteInviteLinkFromWorkspaceMutation,
+		Types.DeleteInviteLinkFromWorkspaceMutationVariables
+	>(DeleteInviteLinkFromWorkspaceDocument, baseOptions)
 }
-    `;
+export type DeleteInviteLinkFromWorkspaceMutationHookResult = ReturnType<
+	typeof useDeleteInviteLinkFromWorkspaceMutation
+>
+export type DeleteInviteLinkFromWorkspaceMutationResult =
+	Apollo.MutationResult<Types.DeleteInviteLinkFromWorkspaceMutation>
+export type DeleteInviteLinkFromWorkspaceMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.DeleteInviteLinkFromWorkspaceMutation,
+		Types.DeleteInviteLinkFromWorkspaceMutationVariables
+	>
+export const GetMetricsTimelineDocument = gql`
+	query GetMetricsTimeline(
+		$project_id: ID!
+		$metric_name: String!
+		$params: DashboardParamsInput!
+	) {
+		metrics_timeline(
+			project_id: $project_id
+			metric_name: $metric_name
+			params: $params
+		) {
+			date
+			value
+			aggregator
+			group
+		}
+	}
+`
 
 /**
  * __useGetMetricsTimelineQuery__
@@ -3238,33 +4862,60 @@ export const GetMetricsTimelineDocument = gql`
  *   },
  * });
  */
-export function useGetMetricsTimelineQuery(baseOptions: Apollo.QueryHookOptions<Types.GetMetricsTimelineQuery, Types.GetMetricsTimelineQueryVariables>) {
-        return Apollo.useQuery<Types.GetMetricsTimelineQuery, Types.GetMetricsTimelineQueryVariables>(GetMetricsTimelineDocument, baseOptions);
-      }
-export function useGetMetricsTimelineLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetMetricsTimelineQuery, Types.GetMetricsTimelineQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetMetricsTimelineQuery, Types.GetMetricsTimelineQueryVariables>(GetMetricsTimelineDocument, baseOptions);
-        }
-export type GetMetricsTimelineQueryHookResult = ReturnType<typeof useGetMetricsTimelineQuery>;
-export type GetMetricsTimelineLazyQueryHookResult = ReturnType<typeof useGetMetricsTimelineLazyQuery>;
-export type GetMetricsTimelineQueryResult = Apollo.QueryResult<Types.GetMetricsTimelineQuery, Types.GetMetricsTimelineQueryVariables>;
-export const GetMetricsHistogramDocument = gql`
-    query GetMetricsHistogram($project_id: ID!, $metric_name: String!, $params: HistogramParamsInput!) {
-  metrics_histogram(
-    project_id: $project_id
-    metric_name: $metric_name
-    params: $params
-  ) {
-    buckets {
-      bucket
-      range_start
-      range_end
-      count
-    }
-    min
-    max
-  }
+export function useGetMetricsTimelineQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetMetricsTimelineQuery,
+		Types.GetMetricsTimelineQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetMetricsTimelineQuery,
+		Types.GetMetricsTimelineQueryVariables
+	>(GetMetricsTimelineDocument, baseOptions)
 }
-    `;
+export function useGetMetricsTimelineLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetMetricsTimelineQuery,
+		Types.GetMetricsTimelineQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetMetricsTimelineQuery,
+		Types.GetMetricsTimelineQueryVariables
+	>(GetMetricsTimelineDocument, baseOptions)
+}
+export type GetMetricsTimelineQueryHookResult = ReturnType<
+	typeof useGetMetricsTimelineQuery
+>
+export type GetMetricsTimelineLazyQueryHookResult = ReturnType<
+	typeof useGetMetricsTimelineLazyQuery
+>
+export type GetMetricsTimelineQueryResult = Apollo.QueryResult<
+	Types.GetMetricsTimelineQuery,
+	Types.GetMetricsTimelineQueryVariables
+>
+export const GetMetricsHistogramDocument = gql`
+	query GetMetricsHistogram(
+		$project_id: ID!
+		$metric_name: String!
+		$params: HistogramParamsInput!
+	) {
+		metrics_histogram(
+			project_id: $project_id
+			metric_name: $metric_name
+			params: $params
+		) {
+			buckets {
+				bucket
+				range_start
+				range_end
+				count
+			}
+			min
+			max
+		}
+	}
+`
 
 /**
  * __useGetMetricsHistogramQuery__
@@ -3284,25 +4935,51 @@ export const GetMetricsHistogramDocument = gql`
  *   },
  * });
  */
-export function useGetMetricsHistogramQuery(baseOptions: Apollo.QueryHookOptions<Types.GetMetricsHistogramQuery, Types.GetMetricsHistogramQueryVariables>) {
-        return Apollo.useQuery<Types.GetMetricsHistogramQuery, Types.GetMetricsHistogramQueryVariables>(GetMetricsHistogramDocument, baseOptions);
-      }
-export function useGetMetricsHistogramLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetMetricsHistogramQuery, Types.GetMetricsHistogramQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetMetricsHistogramQuery, Types.GetMetricsHistogramQueryVariables>(GetMetricsHistogramDocument, baseOptions);
-        }
-export type GetMetricsHistogramQueryHookResult = ReturnType<typeof useGetMetricsHistogramQuery>;
-export type GetMetricsHistogramLazyQueryHookResult = ReturnType<typeof useGetMetricsHistogramLazyQuery>;
-export type GetMetricsHistogramQueryResult = Apollo.QueryResult<Types.GetMetricsHistogramQuery, Types.GetMetricsHistogramQueryVariables>;
-export const GetNetworkHistogramDocument = gql`
-    query GetNetworkHistogram($project_id: ID!, $params: NetworkHistogramParamsInput!) {
-  network_histogram(project_id: $project_id, params: $params) {
-    buckets {
-      category
-      count
-    }
-  }
+export function useGetMetricsHistogramQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetMetricsHistogramQuery,
+		Types.GetMetricsHistogramQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetMetricsHistogramQuery,
+		Types.GetMetricsHistogramQueryVariables
+	>(GetMetricsHistogramDocument, baseOptions)
 }
-    `;
+export function useGetMetricsHistogramLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetMetricsHistogramQuery,
+		Types.GetMetricsHistogramQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetMetricsHistogramQuery,
+		Types.GetMetricsHistogramQueryVariables
+	>(GetMetricsHistogramDocument, baseOptions)
+}
+export type GetMetricsHistogramQueryHookResult = ReturnType<
+	typeof useGetMetricsHistogramQuery
+>
+export type GetMetricsHistogramLazyQueryHookResult = ReturnType<
+	typeof useGetMetricsHistogramLazyQuery
+>
+export type GetMetricsHistogramQueryResult = Apollo.QueryResult<
+	Types.GetMetricsHistogramQuery,
+	Types.GetMetricsHistogramQueryVariables
+>
+export const GetNetworkHistogramDocument = gql`
+	query GetNetworkHistogram(
+		$project_id: ID!
+		$params: NetworkHistogramParamsInput!
+	) {
+		network_histogram(project_id: $project_id, params: $params) {
+			buckets {
+				category
+				count
+			}
+		}
+	}
+`
 
 /**
  * __useGetNetworkHistogramQuery__
@@ -3321,70 +4998,96 @@ export const GetNetworkHistogramDocument = gql`
  *   },
  * });
  */
-export function useGetNetworkHistogramQuery(baseOptions: Apollo.QueryHookOptions<Types.GetNetworkHistogramQuery, Types.GetNetworkHistogramQueryVariables>) {
-        return Apollo.useQuery<Types.GetNetworkHistogramQuery, Types.GetNetworkHistogramQueryVariables>(GetNetworkHistogramDocument, baseOptions);
-      }
-export function useGetNetworkHistogramLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetNetworkHistogramQuery, Types.GetNetworkHistogramQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetNetworkHistogramQuery, Types.GetNetworkHistogramQueryVariables>(GetNetworkHistogramDocument, baseOptions);
-        }
-export type GetNetworkHistogramQueryHookResult = ReturnType<typeof useGetNetworkHistogramQuery>;
-export type GetNetworkHistogramLazyQueryHookResult = ReturnType<typeof useGetNetworkHistogramLazyQuery>;
-export type GetNetworkHistogramQueryResult = Apollo.QueryResult<Types.GetNetworkHistogramQuery, Types.GetNetworkHistogramQueryVariables>;
-export const GetSessionPayloadDocument = gql`
-    query GetSessionPayload($session_secure_id: String!, $skip_events: Boolean!) {
-  events(session_secure_id: $session_secure_id) @skip(if: $skip_events)
-  errors(session_secure_id: $session_secure_id) {
-    id
-    error_group_secure_id
-    event
-    type
-    url
-    source
-    stack_trace
-    structured_stack_trace {
-      fileName
-      lineNumber
-      functionName
-      columnNumber
-    }
-    timestamp
-    payload
-    request_id
-  }
-  rage_clicks(session_secure_id: $session_secure_id) {
-    start_timestamp
-    end_timestamp
-    total_clicks
-  }
-  session_comments(session_secure_id: $session_secure_id) {
-    id
-    timestamp
-    session_id
-    session_secure_id
-    created_at
-    updated_at
-    project_id
-    text
-    author {
-      id
-      name
-      email
-      photo_url
-    }
-    x_coordinate
-    y_coordinate
-    type
-    metadata
-    tags
-    attachments {
-      id
-      integration_type
-      external_id
-      title
-    }
-  }
+export function useGetNetworkHistogramQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetNetworkHistogramQuery,
+		Types.GetNetworkHistogramQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetNetworkHistogramQuery,
+		Types.GetNetworkHistogramQueryVariables
+	>(GetNetworkHistogramDocument, baseOptions)
 }
-    `;
+export function useGetNetworkHistogramLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetNetworkHistogramQuery,
+		Types.GetNetworkHistogramQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetNetworkHistogramQuery,
+		Types.GetNetworkHistogramQueryVariables
+	>(GetNetworkHistogramDocument, baseOptions)
+}
+export type GetNetworkHistogramQueryHookResult = ReturnType<
+	typeof useGetNetworkHistogramQuery
+>
+export type GetNetworkHistogramLazyQueryHookResult = ReturnType<
+	typeof useGetNetworkHistogramLazyQuery
+>
+export type GetNetworkHistogramQueryResult = Apollo.QueryResult<
+	Types.GetNetworkHistogramQuery,
+	Types.GetNetworkHistogramQueryVariables
+>
+export const GetSessionPayloadDocument = gql`
+	query GetSessionPayload(
+		$session_secure_id: String!
+		$skip_events: Boolean!
+	) {
+		events(session_secure_id: $session_secure_id) @skip(if: $skip_events)
+		errors(session_secure_id: $session_secure_id) {
+			id
+			error_group_secure_id
+			event
+			type
+			url
+			source
+			stack_trace
+			structured_stack_trace {
+				fileName
+				lineNumber
+				functionName
+				columnNumber
+			}
+			timestamp
+			payload
+			request_id
+		}
+		rage_clicks(session_secure_id: $session_secure_id) {
+			start_timestamp
+			end_timestamp
+			total_clicks
+		}
+		session_comments(session_secure_id: $session_secure_id) {
+			id
+			timestamp
+			session_id
+			session_secure_id
+			created_at
+			updated_at
+			project_id
+			text
+			author {
+				id
+				name
+				email
+				photo_url
+			}
+			x_coordinate
+			y_coordinate
+			type
+			metadata
+			tags
+			attachments {
+				id
+				integration_type
+				external_id
+				title
+			}
+		}
+	}
+`
 
 /**
  * __useGetSessionPayloadQuery__
@@ -3403,23 +5106,46 @@ export const GetSessionPayloadDocument = gql`
  *   },
  * });
  */
-export function useGetSessionPayloadQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionPayloadQuery, Types.GetSessionPayloadQueryVariables>) {
-        return Apollo.useQuery<Types.GetSessionPayloadQuery, Types.GetSessionPayloadQueryVariables>(GetSessionPayloadDocument, baseOptions);
-      }
-export function useGetSessionPayloadLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionPayloadQuery, Types.GetSessionPayloadQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSessionPayloadQuery, Types.GetSessionPayloadQueryVariables>(GetSessionPayloadDocument, baseOptions);
-        }
-export type GetSessionPayloadQueryHookResult = ReturnType<typeof useGetSessionPayloadQuery>;
-export type GetSessionPayloadLazyQueryHookResult = ReturnType<typeof useGetSessionPayloadLazyQuery>;
-export type GetSessionPayloadQueryResult = Apollo.QueryResult<Types.GetSessionPayloadQuery, Types.GetSessionPayloadQueryVariables>;
-export const GetCommentTagsForProjectDocument = gql`
-    query GetCommentTagsForProject($project_id: ID!) {
-  session_comment_tags_for_project(project_id: $project_id) {
-    id
-    name
-  }
+export function useGetSessionPayloadQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSessionPayloadQuery,
+		Types.GetSessionPayloadQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSessionPayloadQuery,
+		Types.GetSessionPayloadQueryVariables
+	>(GetSessionPayloadDocument, baseOptions)
 }
-    `;
+export function useGetSessionPayloadLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSessionPayloadQuery,
+		Types.GetSessionPayloadQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSessionPayloadQuery,
+		Types.GetSessionPayloadQueryVariables
+	>(GetSessionPayloadDocument, baseOptions)
+}
+export type GetSessionPayloadQueryHookResult = ReturnType<
+	typeof useGetSessionPayloadQuery
+>
+export type GetSessionPayloadLazyQueryHookResult = ReturnType<
+	typeof useGetSessionPayloadLazyQuery
+>
+export type GetSessionPayloadQueryResult = Apollo.QueryResult<
+	Types.GetSessionPayloadQuery,
+	Types.GetSessionPayloadQueryVariables
+>
+export const GetCommentTagsForProjectDocument = gql`
+	query GetCommentTagsForProject($project_id: ID!) {
+		session_comment_tags_for_project(project_id: $project_id) {
+			id
+			name
+		}
+	}
+`
 
 /**
  * __useGetCommentTagsForProjectQuery__
@@ -3437,20 +5163,43 @@ export const GetCommentTagsForProjectDocument = gql`
  *   },
  * });
  */
-export function useGetCommentTagsForProjectQuery(baseOptions: Apollo.QueryHookOptions<Types.GetCommentTagsForProjectQuery, Types.GetCommentTagsForProjectQueryVariables>) {
-        return Apollo.useQuery<Types.GetCommentTagsForProjectQuery, Types.GetCommentTagsForProjectQueryVariables>(GetCommentTagsForProjectDocument, baseOptions);
-      }
-export function useGetCommentTagsForProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetCommentTagsForProjectQuery, Types.GetCommentTagsForProjectQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetCommentTagsForProjectQuery, Types.GetCommentTagsForProjectQueryVariables>(GetCommentTagsForProjectDocument, baseOptions);
-        }
-export type GetCommentTagsForProjectQueryHookResult = ReturnType<typeof useGetCommentTagsForProjectQuery>;
-export type GetCommentTagsForProjectLazyQueryHookResult = ReturnType<typeof useGetCommentTagsForProjectLazyQuery>;
-export type GetCommentTagsForProjectQueryResult = Apollo.QueryResult<Types.GetCommentTagsForProjectQuery, Types.GetCommentTagsForProjectQueryVariables>;
-export const GetEventChunkUrlDocument = gql`
-    query GetEventChunkURL($secure_id: String!, $index: Int!) {
-  event_chunk_url(secure_id: $secure_id, index: $index)
+export function useGetCommentTagsForProjectQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetCommentTagsForProjectQuery,
+		Types.GetCommentTagsForProjectQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetCommentTagsForProjectQuery,
+		Types.GetCommentTagsForProjectQueryVariables
+	>(GetCommentTagsForProjectDocument, baseOptions)
 }
-    `;
+export function useGetCommentTagsForProjectLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetCommentTagsForProjectQuery,
+		Types.GetCommentTagsForProjectQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetCommentTagsForProjectQuery,
+		Types.GetCommentTagsForProjectQueryVariables
+	>(GetCommentTagsForProjectDocument, baseOptions)
+}
+export type GetCommentTagsForProjectQueryHookResult = ReturnType<
+	typeof useGetCommentTagsForProjectQuery
+>
+export type GetCommentTagsForProjectLazyQueryHookResult = ReturnType<
+	typeof useGetCommentTagsForProjectLazyQuery
+>
+export type GetCommentTagsForProjectQueryResult = Apollo.QueryResult<
+	Types.GetCommentTagsForProjectQuery,
+	Types.GetCommentTagsForProjectQueryVariables
+>
+export const GetEventChunkUrlDocument = gql`
+	query GetEventChunkURL($secure_id: String!, $index: Int!) {
+		event_chunk_url(secure_id: $secure_id, index: $index)
+	}
+`
 
 /**
  * __useGetEventChunkUrlQuery__
@@ -3469,24 +5218,47 @@ export const GetEventChunkUrlDocument = gql`
  *   },
  * });
  */
-export function useGetEventChunkUrlQuery(baseOptions: Apollo.QueryHookOptions<Types.GetEventChunkUrlQuery, Types.GetEventChunkUrlQueryVariables>) {
-        return Apollo.useQuery<Types.GetEventChunkUrlQuery, Types.GetEventChunkUrlQueryVariables>(GetEventChunkUrlDocument, baseOptions);
-      }
-export function useGetEventChunkUrlLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetEventChunkUrlQuery, Types.GetEventChunkUrlQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetEventChunkUrlQuery, Types.GetEventChunkUrlQueryVariables>(GetEventChunkUrlDocument, baseOptions);
-        }
-export type GetEventChunkUrlQueryHookResult = ReturnType<typeof useGetEventChunkUrlQuery>;
-export type GetEventChunkUrlLazyQueryHookResult = ReturnType<typeof useGetEventChunkUrlLazyQuery>;
-export type GetEventChunkUrlQueryResult = Apollo.QueryResult<Types.GetEventChunkUrlQuery, Types.GetEventChunkUrlQueryVariables>;
-export const GetEventChunksDocument = gql`
-    query GetEventChunks($secure_id: String!) {
-  event_chunks(secure_id: $secure_id) {
-    session_id
-    chunk_index
-    timestamp
-  }
+export function useGetEventChunkUrlQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetEventChunkUrlQuery,
+		Types.GetEventChunkUrlQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetEventChunkUrlQuery,
+		Types.GetEventChunkUrlQueryVariables
+	>(GetEventChunkUrlDocument, baseOptions)
 }
-    `;
+export function useGetEventChunkUrlLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetEventChunkUrlQuery,
+		Types.GetEventChunkUrlQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetEventChunkUrlQuery,
+		Types.GetEventChunkUrlQueryVariables
+	>(GetEventChunkUrlDocument, baseOptions)
+}
+export type GetEventChunkUrlQueryHookResult = ReturnType<
+	typeof useGetEventChunkUrlQuery
+>
+export type GetEventChunkUrlLazyQueryHookResult = ReturnType<
+	typeof useGetEventChunkUrlLazyQuery
+>
+export type GetEventChunkUrlQueryResult = Apollo.QueryResult<
+	Types.GetEventChunkUrlQuery,
+	Types.GetEventChunkUrlQueryVariables
+>
+export const GetEventChunksDocument = gql`
+	query GetEventChunks($secure_id: String!) {
+		event_chunks(secure_id: $secure_id) {
+			session_id
+			chunk_index
+			timestamp
+		}
+	}
+`
 
 /**
  * __useGetEventChunksQuery__
@@ -3504,70 +5276,93 @@ export const GetEventChunksDocument = gql`
  *   },
  * });
  */
-export function useGetEventChunksQuery(baseOptions: Apollo.QueryHookOptions<Types.GetEventChunksQuery, Types.GetEventChunksQueryVariables>) {
-        return Apollo.useQuery<Types.GetEventChunksQuery, Types.GetEventChunksQueryVariables>(GetEventChunksDocument, baseOptions);
-      }
-export function useGetEventChunksLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetEventChunksQuery, Types.GetEventChunksQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetEventChunksQuery, Types.GetEventChunksQueryVariables>(GetEventChunksDocument, baseOptions);
-        }
-export type GetEventChunksQueryHookResult = ReturnType<typeof useGetEventChunksQuery>;
-export type GetEventChunksLazyQueryHookResult = ReturnType<typeof useGetEventChunksLazyQuery>;
-export type GetEventChunksQueryResult = Apollo.QueryResult<Types.GetEventChunksQuery, Types.GetEventChunksQueryVariables>;
-export const GetSessionDocument = gql`
-    query GetSession($secure_id: String!) {
-  session(secure_id: $secure_id) {
-    secure_id
-    os_name
-    os_version
-    browser_name
-    browser_version
-    environment
-    app_version
-    city
-    state
-    country
-    postal
-    fingerprint
-    created_at
-    payload_updated_at
-    language
-    user_object
-    user_properties
-    identifier
-    identified
-    client_id
-    starred
-    enable_strict_privacy
-    enable_recording_network_contents
-    field_group
-    fields {
-      name
-      value
-      type
-    }
-    object_storage_enabled
-    payload_size
-    processed
-    excluded
-    has_rage_clicks
-    has_errors
-    within_billing_quota
-    client_version
-    firstload_version
-    client_config
-    is_public
-    event_counts
-    direct_download_url
-    resources_url
-    timeline_indicators_url
-    deviceMemory
-    last_user_interaction_time
-    length
-    active_length
-    chunked
-  }
+export function useGetEventChunksQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetEventChunksQuery,
+		Types.GetEventChunksQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetEventChunksQuery,
+		Types.GetEventChunksQueryVariables
+	>(GetEventChunksDocument, baseOptions)
 }
-    `;
+export function useGetEventChunksLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetEventChunksQuery,
+		Types.GetEventChunksQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetEventChunksQuery,
+		Types.GetEventChunksQueryVariables
+	>(GetEventChunksDocument, baseOptions)
+}
+export type GetEventChunksQueryHookResult = ReturnType<
+	typeof useGetEventChunksQuery
+>
+export type GetEventChunksLazyQueryHookResult = ReturnType<
+	typeof useGetEventChunksLazyQuery
+>
+export type GetEventChunksQueryResult = Apollo.QueryResult<
+	Types.GetEventChunksQuery,
+	Types.GetEventChunksQueryVariables
+>
+export const GetSessionDocument = gql`
+	query GetSession($secure_id: String!) {
+		session(secure_id: $secure_id) {
+			secure_id
+			os_name
+			os_version
+			browser_name
+			browser_version
+			environment
+			app_version
+			city
+			state
+			country
+			postal
+			fingerprint
+			created_at
+			payload_updated_at
+			language
+			user_object
+			user_properties
+			identifier
+			identified
+			client_id
+			starred
+			enable_strict_privacy
+			enable_recording_network_contents
+			field_group
+			fields {
+				name
+				value
+				type
+			}
+			object_storage_enabled
+			payload_size
+			processed
+			excluded
+			has_rage_clicks
+			has_errors
+			within_billing_quota
+			client_version
+			firstload_version
+			client_config
+			is_public
+			event_counts
+			direct_download_url
+			resources_url
+			timeline_indicators_url
+			deviceMemory
+			last_user_interaction_time
+			length
+			active_length
+			chunked
+		}
+	}
+`
 
 /**
  * __useGetSessionQuery__
@@ -3585,28 +5380,49 @@ export const GetSessionDocument = gql`
  *   },
  * });
  */
-export function useGetSessionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionQuery, Types.GetSessionQueryVariables>) {
-        return Apollo.useQuery<Types.GetSessionQuery, Types.GetSessionQueryVariables>(GetSessionDocument, baseOptions);
-      }
-export function useGetSessionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionQuery, Types.GetSessionQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSessionQuery, Types.GetSessionQueryVariables>(GetSessionDocument, baseOptions);
-        }
-export type GetSessionQueryHookResult = ReturnType<typeof useGetSessionQuery>;
-export type GetSessionLazyQueryHookResult = ReturnType<typeof useGetSessionLazyQuery>;
-export type GetSessionQueryResult = Apollo.QueryResult<Types.GetSessionQuery, Types.GetSessionQueryVariables>;
-export const GetWorkspaceAdminsByProjectIdDocument = gql`
-    query GetWorkspaceAdminsByProjectId($project_id: ID!) {
-  admins: workspace_admins_by_project_id(project_id: $project_id) {
-    admin {
-      id
-      name
-      email
-      photo_url
-    }
-    role
-  }
+export function useGetSessionQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSessionQuery,
+		Types.GetSessionQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSessionQuery,
+		Types.GetSessionQueryVariables
+	>(GetSessionDocument, baseOptions)
 }
-    `;
+export function useGetSessionLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSessionQuery,
+		Types.GetSessionQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSessionQuery,
+		Types.GetSessionQueryVariables
+	>(GetSessionDocument, baseOptions)
+}
+export type GetSessionQueryHookResult = ReturnType<typeof useGetSessionQuery>
+export type GetSessionLazyQueryHookResult = ReturnType<
+	typeof useGetSessionLazyQuery
+>
+export type GetSessionQueryResult = Apollo.QueryResult<
+	Types.GetSessionQuery,
+	Types.GetSessionQueryVariables
+>
+export const GetWorkspaceAdminsByProjectIdDocument = gql`
+	query GetWorkspaceAdminsByProjectId($project_id: ID!) {
+		admins: workspace_admins_by_project_id(project_id: $project_id) {
+			admin {
+				id
+				name
+				email
+				photo_url
+			}
+			role
+		}
+	}
+`
 
 /**
  * __useGetWorkspaceAdminsByProjectIdQuery__
@@ -3624,41 +5440,64 @@ export const GetWorkspaceAdminsByProjectIdDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceAdminsByProjectIdQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceAdminsByProjectIdQuery, Types.GetWorkspaceAdminsByProjectIdQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspaceAdminsByProjectIdQuery, Types.GetWorkspaceAdminsByProjectIdQueryVariables>(GetWorkspaceAdminsByProjectIdDocument, baseOptions);
-      }
-export function useGetWorkspaceAdminsByProjectIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceAdminsByProjectIdQuery, Types.GetWorkspaceAdminsByProjectIdQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspaceAdminsByProjectIdQuery, Types.GetWorkspaceAdminsByProjectIdQueryVariables>(GetWorkspaceAdminsByProjectIdDocument, baseOptions);
-        }
-export type GetWorkspaceAdminsByProjectIdQueryHookResult = ReturnType<typeof useGetWorkspaceAdminsByProjectIdQuery>;
-export type GetWorkspaceAdminsByProjectIdLazyQueryHookResult = ReturnType<typeof useGetWorkspaceAdminsByProjectIdLazyQuery>;
-export type GetWorkspaceAdminsByProjectIdQueryResult = Apollo.QueryResult<Types.GetWorkspaceAdminsByProjectIdQuery, Types.GetWorkspaceAdminsByProjectIdQueryVariables>;
-export const GetWorkspaceAdminsDocument = gql`
-    query GetWorkspaceAdmins($workspace_id: ID!) {
-  admins: workspace_admins(workspace_id: $workspace_id) {
-    admin {
-      id
-      name
-      email
-      photo_url
-    }
-    role
-  }
-  workspace(id: $workspace_id) {
-    id
-    name
-    secret
-    allowed_auto_join_email_origins
-  }
-  workspace_invite_links(workspace_id: $workspace_id) {
-    id
-    invitee_email
-    invitee_role
-    expiration_date
-    secret
-  }
+export function useGetWorkspaceAdminsByProjectIdQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceAdminsByProjectIdQuery,
+		Types.GetWorkspaceAdminsByProjectIdQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceAdminsByProjectIdQuery,
+		Types.GetWorkspaceAdminsByProjectIdQueryVariables
+	>(GetWorkspaceAdminsByProjectIdDocument, baseOptions)
 }
-    `;
+export function useGetWorkspaceAdminsByProjectIdLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceAdminsByProjectIdQuery,
+		Types.GetWorkspaceAdminsByProjectIdQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceAdminsByProjectIdQuery,
+		Types.GetWorkspaceAdminsByProjectIdQueryVariables
+	>(GetWorkspaceAdminsByProjectIdDocument, baseOptions)
+}
+export type GetWorkspaceAdminsByProjectIdQueryHookResult = ReturnType<
+	typeof useGetWorkspaceAdminsByProjectIdQuery
+>
+export type GetWorkspaceAdminsByProjectIdLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceAdminsByProjectIdLazyQuery
+>
+export type GetWorkspaceAdminsByProjectIdQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceAdminsByProjectIdQuery,
+	Types.GetWorkspaceAdminsByProjectIdQueryVariables
+>
+export const GetWorkspaceAdminsDocument = gql`
+	query GetWorkspaceAdmins($workspace_id: ID!) {
+		admins: workspace_admins(workspace_id: $workspace_id) {
+			admin {
+				id
+				name
+				email
+				photo_url
+			}
+			role
+		}
+		workspace(id: $workspace_id) {
+			id
+			name
+			secret
+			allowed_auto_join_email_origins
+		}
+		workspace_invite_links(workspace_id: $workspace_id) {
+			id
+			invitee_email
+			invitee_role
+			expiration_date
+			secret
+		}
+	}
+`
 
 /**
  * __useGetWorkspaceAdminsQuery__
@@ -3676,23 +5515,46 @@ export const GetWorkspaceAdminsDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceAdminsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceAdminsQuery, Types.GetWorkspaceAdminsQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspaceAdminsQuery, Types.GetWorkspaceAdminsQueryVariables>(GetWorkspaceAdminsDocument, baseOptions);
-      }
-export function useGetWorkspaceAdminsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceAdminsQuery, Types.GetWorkspaceAdminsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspaceAdminsQuery, Types.GetWorkspaceAdminsQueryVariables>(GetWorkspaceAdminsDocument, baseOptions);
-        }
-export type GetWorkspaceAdminsQueryHookResult = ReturnType<typeof useGetWorkspaceAdminsQuery>;
-export type GetWorkspaceAdminsLazyQueryHookResult = ReturnType<typeof useGetWorkspaceAdminsLazyQuery>;
-export type GetWorkspaceAdminsQueryResult = Apollo.QueryResult<Types.GetWorkspaceAdminsQuery, Types.GetWorkspaceAdminsQueryVariables>;
-export const GetSessionInsightDocument = gql`
-    query GetSessionInsight($secure_id: String!) {
-  session_insight(secure_id: $secure_id) {
-    id
-    insight
-  }
+export function useGetWorkspaceAdminsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceAdminsQuery,
+		Types.GetWorkspaceAdminsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceAdminsQuery,
+		Types.GetWorkspaceAdminsQueryVariables
+	>(GetWorkspaceAdminsDocument, baseOptions)
 }
-    `;
+export function useGetWorkspaceAdminsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceAdminsQuery,
+		Types.GetWorkspaceAdminsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceAdminsQuery,
+		Types.GetWorkspaceAdminsQueryVariables
+	>(GetWorkspaceAdminsDocument, baseOptions)
+}
+export type GetWorkspaceAdminsQueryHookResult = ReturnType<
+	typeof useGetWorkspaceAdminsQuery
+>
+export type GetWorkspaceAdminsLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceAdminsLazyQuery
+>
+export type GetWorkspaceAdminsQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceAdminsQuery,
+	Types.GetWorkspaceAdminsQueryVariables
+>
+export const GetSessionInsightDocument = gql`
+	query GetSessionInsight($secure_id: String!) {
+		session_insight(secure_id: $secure_id) {
+			id
+			insight
+		}
+	}
+`
 
 /**
  * __useGetSessionInsightQuery__
@@ -3710,58 +5572,81 @@ export const GetSessionInsightDocument = gql`
  *   },
  * });
  */
-export function useGetSessionInsightQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionInsightQuery, Types.GetSessionInsightQueryVariables>) {
-        return Apollo.useQuery<Types.GetSessionInsightQuery, Types.GetSessionInsightQueryVariables>(GetSessionInsightDocument, baseOptions);
-      }
-export function useGetSessionInsightLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionInsightQuery, Types.GetSessionInsightQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSessionInsightQuery, Types.GetSessionInsightQueryVariables>(GetSessionInsightDocument, baseOptions);
-        }
-export type GetSessionInsightQueryHookResult = ReturnType<typeof useGetSessionInsightQuery>;
-export type GetSessionInsightLazyQueryHookResult = ReturnType<typeof useGetSessionInsightLazyQuery>;
-export type GetSessionInsightQueryResult = Apollo.QueryResult<Types.GetSessionInsightQuery, Types.GetSessionInsightQueryVariables>;
-export const GetSessionCommentsDocument = gql`
-    query GetSessionComments($session_secure_id: String!) {
-  session_comments(session_secure_id: $session_secure_id) {
-    id
-    timestamp
-    session_id
-    session_secure_id
-    created_at
-    updated_at
-    project_id
-    text
-    author {
-      id
-      name
-      email
-      photo_url
-    }
-    x_coordinate
-    y_coordinate
-    type
-    metadata
-    tags
-    attachments {
-      id
-      integration_type
-      external_id
-      title
-    }
-    replies {
-      id
-      created_at
-      updated_at
-      author {
-        id
-        name
-        email
-        photo_url
-      }
-      text
-    }
-  }
+export function useGetSessionInsightQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSessionInsightQuery,
+		Types.GetSessionInsightQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSessionInsightQuery,
+		Types.GetSessionInsightQueryVariables
+	>(GetSessionInsightDocument, baseOptions)
 }
-    `;
+export function useGetSessionInsightLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSessionInsightQuery,
+		Types.GetSessionInsightQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSessionInsightQuery,
+		Types.GetSessionInsightQueryVariables
+	>(GetSessionInsightDocument, baseOptions)
+}
+export type GetSessionInsightQueryHookResult = ReturnType<
+	typeof useGetSessionInsightQuery
+>
+export type GetSessionInsightLazyQueryHookResult = ReturnType<
+	typeof useGetSessionInsightLazyQuery
+>
+export type GetSessionInsightQueryResult = Apollo.QueryResult<
+	Types.GetSessionInsightQuery,
+	Types.GetSessionInsightQueryVariables
+>
+export const GetSessionCommentsDocument = gql`
+	query GetSessionComments($session_secure_id: String!) {
+		session_comments(session_secure_id: $session_secure_id) {
+			id
+			timestamp
+			session_id
+			session_secure_id
+			created_at
+			updated_at
+			project_id
+			text
+			author {
+				id
+				name
+				email
+				photo_url
+			}
+			x_coordinate
+			y_coordinate
+			type
+			metadata
+			tags
+			attachments {
+				id
+				integration_type
+				external_id
+				title
+			}
+			replies {
+				id
+				created_at
+				updated_at
+				author {
+					id
+					name
+					email
+					photo_url
+				}
+				text
+			}
+		}
+	}
+`
 
 /**
  * __useGetSessionCommentsQuery__
@@ -3779,33 +5664,56 @@ export const GetSessionCommentsDocument = gql`
  *   },
  * });
  */
-export function useGetSessionCommentsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionCommentsQuery, Types.GetSessionCommentsQueryVariables>) {
-        return Apollo.useQuery<Types.GetSessionCommentsQuery, Types.GetSessionCommentsQueryVariables>(GetSessionCommentsDocument, baseOptions);
-      }
-export function useGetSessionCommentsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionCommentsQuery, Types.GetSessionCommentsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSessionCommentsQuery, Types.GetSessionCommentsQueryVariables>(GetSessionCommentsDocument, baseOptions);
-        }
-export type GetSessionCommentsQueryHookResult = ReturnType<typeof useGetSessionCommentsQuery>;
-export type GetSessionCommentsLazyQueryHookResult = ReturnType<typeof useGetSessionCommentsLazyQuery>;
-export type GetSessionCommentsQueryResult = Apollo.QueryResult<Types.GetSessionCommentsQuery, Types.GetSessionCommentsQueryVariables>;
-export const GetSessionCommentsForAdminDocument = gql`
-    query GetSessionCommentsForAdmin {
-  session_comments_for_admin {
-    id
-    timestamp
-    created_at
-    project_id
-    updated_at
-    text
-    author {
-      id
-      name
-      email
-      photo_url
-    }
-  }
+export function useGetSessionCommentsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSessionCommentsQuery,
+		Types.GetSessionCommentsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSessionCommentsQuery,
+		Types.GetSessionCommentsQueryVariables
+	>(GetSessionCommentsDocument, baseOptions)
 }
-    `;
+export function useGetSessionCommentsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSessionCommentsQuery,
+		Types.GetSessionCommentsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSessionCommentsQuery,
+		Types.GetSessionCommentsQueryVariables
+	>(GetSessionCommentsDocument, baseOptions)
+}
+export type GetSessionCommentsQueryHookResult = ReturnType<
+	typeof useGetSessionCommentsQuery
+>
+export type GetSessionCommentsLazyQueryHookResult = ReturnType<
+	typeof useGetSessionCommentsLazyQuery
+>
+export type GetSessionCommentsQueryResult = Apollo.QueryResult<
+	Types.GetSessionCommentsQuery,
+	Types.GetSessionCommentsQueryVariables
+>
+export const GetSessionCommentsForAdminDocument = gql`
+	query GetSessionCommentsForAdmin {
+		session_comments_for_admin {
+			id
+			timestamp
+			created_at
+			project_id
+			updated_at
+			text
+			author {
+				id
+				name
+				email
+				photo_url
+			}
+		}
+	}
+`
 
 /**
  * __useGetSessionCommentsForAdminQuery__
@@ -3822,20 +5730,43 @@ export const GetSessionCommentsForAdminDocument = gql`
  *   },
  * });
  */
-export function useGetSessionCommentsForAdminQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetSessionCommentsForAdminQuery, Types.GetSessionCommentsForAdminQueryVariables>) {
-        return Apollo.useQuery<Types.GetSessionCommentsForAdminQuery, Types.GetSessionCommentsForAdminQueryVariables>(GetSessionCommentsForAdminDocument, baseOptions);
-      }
-export function useGetSessionCommentsForAdminLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionCommentsForAdminQuery, Types.GetSessionCommentsForAdminQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSessionCommentsForAdminQuery, Types.GetSessionCommentsForAdminQueryVariables>(GetSessionCommentsForAdminDocument, baseOptions);
-        }
-export type GetSessionCommentsForAdminQueryHookResult = ReturnType<typeof useGetSessionCommentsForAdminQuery>;
-export type GetSessionCommentsForAdminLazyQueryHookResult = ReturnType<typeof useGetSessionCommentsForAdminLazyQuery>;
-export type GetSessionCommentsForAdminQueryResult = Apollo.QueryResult<Types.GetSessionCommentsForAdminQuery, Types.GetSessionCommentsForAdminQueryVariables>;
-export const IsSessionPendingDocument = gql`
-    query isSessionPending($session_secure_id: String!) {
-  isSessionPending(session_secure_id: $session_secure_id)
+export function useGetSessionCommentsForAdminQuery(
+	baseOptions?: Apollo.QueryHookOptions<
+		Types.GetSessionCommentsForAdminQuery,
+		Types.GetSessionCommentsForAdminQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSessionCommentsForAdminQuery,
+		Types.GetSessionCommentsForAdminQueryVariables
+	>(GetSessionCommentsForAdminDocument, baseOptions)
 }
-    `;
+export function useGetSessionCommentsForAdminLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSessionCommentsForAdminQuery,
+		Types.GetSessionCommentsForAdminQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSessionCommentsForAdminQuery,
+		Types.GetSessionCommentsForAdminQueryVariables
+	>(GetSessionCommentsForAdminDocument, baseOptions)
+}
+export type GetSessionCommentsForAdminQueryHookResult = ReturnType<
+	typeof useGetSessionCommentsForAdminQuery
+>
+export type GetSessionCommentsForAdminLazyQueryHookResult = ReturnType<
+	typeof useGetSessionCommentsForAdminLazyQuery
+>
+export type GetSessionCommentsForAdminQueryResult = Apollo.QueryResult<
+	Types.GetSessionCommentsForAdminQuery,
+	Types.GetSessionCommentsForAdminQueryVariables
+>
+export const IsSessionPendingDocument = gql`
+	query isSessionPending($session_secure_id: String!) {
+		isSessionPending(session_secure_id: $session_secure_id)
+	}
+`
 
 /**
  * __useIsSessionPendingQuery__
@@ -3853,37 +5784,60 @@ export const IsSessionPendingDocument = gql`
  *   },
  * });
  */
-export function useIsSessionPendingQuery(baseOptions: Apollo.QueryHookOptions<Types.IsSessionPendingQuery, Types.IsSessionPendingQueryVariables>) {
-        return Apollo.useQuery<Types.IsSessionPendingQuery, Types.IsSessionPendingQueryVariables>(IsSessionPendingDocument, baseOptions);
-      }
-export function useIsSessionPendingLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.IsSessionPendingQuery, Types.IsSessionPendingQueryVariables>) {
-          return Apollo.useLazyQuery<Types.IsSessionPendingQuery, Types.IsSessionPendingQueryVariables>(IsSessionPendingDocument, baseOptions);
-        }
-export type IsSessionPendingQueryHookResult = ReturnType<typeof useIsSessionPendingQuery>;
-export type IsSessionPendingLazyQueryHookResult = ReturnType<typeof useIsSessionPendingLazyQuery>;
-export type IsSessionPendingQueryResult = Apollo.QueryResult<Types.IsSessionPendingQuery, Types.IsSessionPendingQueryVariables>;
-export const GetAccountsDocument = gql`
-    query GetAccounts {
-  accounts {
-    id
-    name
-    session_count_cur
-    view_count_cur
-    session_count_prev
-    view_count_prev
-    session_count_prev_prev
-    session_limit
-    paid_prev
-    paid_prev_prev
-    email
-    subscription_start
-    plan_tier
-    stripe_customer_id
-    member_count
-    member_limit
-  }
+export function useIsSessionPendingQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.IsSessionPendingQuery,
+		Types.IsSessionPendingQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.IsSessionPendingQuery,
+		Types.IsSessionPendingQueryVariables
+	>(IsSessionPendingDocument, baseOptions)
 }
-    `;
+export function useIsSessionPendingLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.IsSessionPendingQuery,
+		Types.IsSessionPendingQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.IsSessionPendingQuery,
+		Types.IsSessionPendingQueryVariables
+	>(IsSessionPendingDocument, baseOptions)
+}
+export type IsSessionPendingQueryHookResult = ReturnType<
+	typeof useIsSessionPendingQuery
+>
+export type IsSessionPendingLazyQueryHookResult = ReturnType<
+	typeof useIsSessionPendingLazyQuery
+>
+export type IsSessionPendingQueryResult = Apollo.QueryResult<
+	Types.IsSessionPendingQuery,
+	Types.IsSessionPendingQueryVariables
+>
+export const GetAccountsDocument = gql`
+	query GetAccounts {
+		accounts {
+			id
+			name
+			session_count_cur
+			view_count_cur
+			session_count_prev
+			view_count_prev
+			session_count_prev_prev
+			session_limit
+			paid_prev
+			paid_prev_prev
+			email
+			subscription_start
+			plan_tier
+			stripe_customer_id
+			member_count
+			member_limit
+		}
+	}
+`
 
 /**
  * __useGetAccountsQuery__
@@ -3900,38 +5854,59 @@ export const GetAccountsDocument = gql`
  *   },
  * });
  */
-export function useGetAccountsQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetAccountsQuery, Types.GetAccountsQueryVariables>) {
-        return Apollo.useQuery<Types.GetAccountsQuery, Types.GetAccountsQueryVariables>(GetAccountsDocument, baseOptions);
-      }
-export function useGetAccountsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAccountsQuery, Types.GetAccountsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetAccountsQuery, Types.GetAccountsQueryVariables>(GetAccountsDocument, baseOptions);
-        }
-export type GetAccountsQueryHookResult = ReturnType<typeof useGetAccountsQuery>;
-export type GetAccountsLazyQueryHookResult = ReturnType<typeof useGetAccountsLazyQuery>;
-export type GetAccountsQueryResult = Apollo.QueryResult<Types.GetAccountsQuery, Types.GetAccountsQueryVariables>;
-export const GetAccountDetailsDocument = gql`
-    query GetAccountDetails($workspace_id: ID!) {
-  account_details(workspace_id: $workspace_id) {
-    id
-    name
-    session_count_per_month {
-      name
-      count
-    }
-    session_count_per_day {
-      name
-      count
-    }
-    stripe_customer_id
-    members {
-      id
-      name
-      email
-      last_active
-    }
-  }
+export function useGetAccountsQuery(
+	baseOptions?: Apollo.QueryHookOptions<
+		Types.GetAccountsQuery,
+		Types.GetAccountsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetAccountsQuery,
+		Types.GetAccountsQueryVariables
+	>(GetAccountsDocument, baseOptions)
 }
-    `;
+export function useGetAccountsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetAccountsQuery,
+		Types.GetAccountsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetAccountsQuery,
+		Types.GetAccountsQueryVariables
+	>(GetAccountsDocument, baseOptions)
+}
+export type GetAccountsQueryHookResult = ReturnType<typeof useGetAccountsQuery>
+export type GetAccountsLazyQueryHookResult = ReturnType<
+	typeof useGetAccountsLazyQuery
+>
+export type GetAccountsQueryResult = Apollo.QueryResult<
+	Types.GetAccountsQuery,
+	Types.GetAccountsQueryVariables
+>
+export const GetAccountDetailsDocument = gql`
+	query GetAccountDetails($workspace_id: ID!) {
+		account_details(workspace_id: $workspace_id) {
+			id
+			name
+			session_count_per_month {
+				name
+				count
+			}
+			session_count_per_day {
+				name
+				count
+			}
+			stripe_customer_id
+			members {
+				id
+				name
+				email
+				last_active
+			}
+		}
+	}
+`
 
 /**
  * __useGetAccountDetailsQuery__
@@ -3949,49 +5924,72 @@ export const GetAccountDetailsDocument = gql`
  *   },
  * });
  */
-export function useGetAccountDetailsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetAccountDetailsQuery, Types.GetAccountDetailsQueryVariables>) {
-        return Apollo.useQuery<Types.GetAccountDetailsQuery, Types.GetAccountDetailsQueryVariables>(GetAccountDetailsDocument, baseOptions);
-      }
-export function useGetAccountDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAccountDetailsQuery, Types.GetAccountDetailsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetAccountDetailsQuery, Types.GetAccountDetailsQueryVariables>(GetAccountDetailsDocument, baseOptions);
-        }
-export type GetAccountDetailsQueryHookResult = ReturnType<typeof useGetAccountDetailsQuery>;
-export type GetAccountDetailsLazyQueryHookResult = ReturnType<typeof useGetAccountDetailsLazyQuery>;
-export type GetAccountDetailsQueryResult = Apollo.QueryResult<Types.GetAccountDetailsQuery, Types.GetAccountDetailsQueryVariables>;
-export const GetErrorCommentsDocument = gql`
-    query GetErrorComments($error_group_secure_id: String!) {
-  error_comments(error_group_secure_id: $error_group_secure_id) {
-    id
-    created_at
-    updated_at
-    text
-    project_id
-    author {
-      id
-      name
-      email
-      photo_url
-    }
-    attachments {
-      integration_type
-      external_id
-      title
-    }
-    replies {
-      id
-      created_at
-      updated_at
-      author {
-        id
-        name
-        email
-        photo_url
-      }
-      text
-    }
-  }
+export function useGetAccountDetailsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetAccountDetailsQuery,
+		Types.GetAccountDetailsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetAccountDetailsQuery,
+		Types.GetAccountDetailsQueryVariables
+	>(GetAccountDetailsDocument, baseOptions)
 }
-    `;
+export function useGetAccountDetailsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetAccountDetailsQuery,
+		Types.GetAccountDetailsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetAccountDetailsQuery,
+		Types.GetAccountDetailsQueryVariables
+	>(GetAccountDetailsDocument, baseOptions)
+}
+export type GetAccountDetailsQueryHookResult = ReturnType<
+	typeof useGetAccountDetailsQuery
+>
+export type GetAccountDetailsLazyQueryHookResult = ReturnType<
+	typeof useGetAccountDetailsLazyQuery
+>
+export type GetAccountDetailsQueryResult = Apollo.QueryResult<
+	Types.GetAccountDetailsQuery,
+	Types.GetAccountDetailsQueryVariables
+>
+export const GetErrorCommentsDocument = gql`
+	query GetErrorComments($error_group_secure_id: String!) {
+		error_comments(error_group_secure_id: $error_group_secure_id) {
+			id
+			created_at
+			updated_at
+			text
+			project_id
+			author {
+				id
+				name
+				email
+				photo_url
+			}
+			attachments {
+				integration_type
+				external_id
+				title
+			}
+			replies {
+				id
+				created_at
+				updated_at
+				author {
+					id
+					name
+					email
+					photo_url
+				}
+				text
+			}
+		}
+	}
+`
 
 /**
  * __useGetErrorCommentsQuery__
@@ -4009,25 +6007,48 @@ export const GetErrorCommentsDocument = gql`
  *   },
  * });
  */
-export function useGetErrorCommentsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorCommentsQuery, Types.GetErrorCommentsQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorCommentsQuery, Types.GetErrorCommentsQueryVariables>(GetErrorCommentsDocument, baseOptions);
-      }
-export function useGetErrorCommentsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorCommentsQuery, Types.GetErrorCommentsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorCommentsQuery, Types.GetErrorCommentsQueryVariables>(GetErrorCommentsDocument, baseOptions);
-        }
-export type GetErrorCommentsQueryHookResult = ReturnType<typeof useGetErrorCommentsQuery>;
-export type GetErrorCommentsLazyQueryHookResult = ReturnType<typeof useGetErrorCommentsLazyQuery>;
-export type GetErrorCommentsQueryResult = Apollo.QueryResult<Types.GetErrorCommentsQuery, Types.GetErrorCommentsQueryVariables>;
-export const GetErrorIssuesDocument = gql`
-    query GetErrorIssues($error_group_secure_id: String!) {
-  error_issue(error_group_secure_id: $error_group_secure_id) {
-    id
-    integration_type
-    external_id
-    title
-  }
+export function useGetErrorCommentsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorCommentsQuery,
+		Types.GetErrorCommentsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorCommentsQuery,
+		Types.GetErrorCommentsQueryVariables
+	>(GetErrorCommentsDocument, baseOptions)
 }
-    `;
+export function useGetErrorCommentsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorCommentsQuery,
+		Types.GetErrorCommentsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorCommentsQuery,
+		Types.GetErrorCommentsQueryVariables
+	>(GetErrorCommentsDocument, baseOptions)
+}
+export type GetErrorCommentsQueryHookResult = ReturnType<
+	typeof useGetErrorCommentsQuery
+>
+export type GetErrorCommentsLazyQueryHookResult = ReturnType<
+	typeof useGetErrorCommentsLazyQuery
+>
+export type GetErrorCommentsQueryResult = Apollo.QueryResult<
+	Types.GetErrorCommentsQuery,
+	Types.GetErrorCommentsQueryVariables
+>
+export const GetErrorIssuesDocument = gql`
+	query GetErrorIssues($error_group_secure_id: String!) {
+		error_issue(error_group_secure_id: $error_group_secure_id) {
+			id
+			integration_type
+			external_id
+			title
+		}
+	}
+`
 
 /**
  * __useGetErrorIssuesQuery__
@@ -4045,30 +6066,53 @@ export const GetErrorIssuesDocument = gql`
  *   },
  * });
  */
-export function useGetErrorIssuesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorIssuesQuery, Types.GetErrorIssuesQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorIssuesQuery, Types.GetErrorIssuesQueryVariables>(GetErrorIssuesDocument, baseOptions);
-      }
-export function useGetErrorIssuesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorIssuesQuery, Types.GetErrorIssuesQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorIssuesQuery, Types.GetErrorIssuesQueryVariables>(GetErrorIssuesDocument, baseOptions);
-        }
-export type GetErrorIssuesQueryHookResult = ReturnType<typeof useGetErrorIssuesQuery>;
-export type GetErrorIssuesLazyQueryHookResult = ReturnType<typeof useGetErrorIssuesLazyQuery>;
-export type GetErrorIssuesQueryResult = Apollo.QueryResult<Types.GetErrorIssuesQuery, Types.GetErrorIssuesQueryVariables>;
-export const GetEnhancedUserDetailsDocument = gql`
-    query GetEnhancedUserDetails($session_secure_id: String!) {
-  enhanced_user_details(session_secure_id: $session_secure_id) {
-    id
-    name
-    bio
-    avatar
-    email
-    socials {
-      type
-      link
-    }
-  }
+export function useGetErrorIssuesQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorIssuesQuery,
+		Types.GetErrorIssuesQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorIssuesQuery,
+		Types.GetErrorIssuesQueryVariables
+	>(GetErrorIssuesDocument, baseOptions)
 }
-    `;
+export function useGetErrorIssuesLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorIssuesQuery,
+		Types.GetErrorIssuesQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorIssuesQuery,
+		Types.GetErrorIssuesQueryVariables
+	>(GetErrorIssuesDocument, baseOptions)
+}
+export type GetErrorIssuesQueryHookResult = ReturnType<
+	typeof useGetErrorIssuesQuery
+>
+export type GetErrorIssuesLazyQueryHookResult = ReturnType<
+	typeof useGetErrorIssuesLazyQuery
+>
+export type GetErrorIssuesQueryResult = Apollo.QueryResult<
+	Types.GetErrorIssuesQuery,
+	Types.GetErrorIssuesQueryVariables
+>
+export const GetEnhancedUserDetailsDocument = gql`
+	query GetEnhancedUserDetails($session_secure_id: String!) {
+		enhanced_user_details(session_secure_id: $session_secure_id) {
+			id
+			name
+			bio
+			avatar
+			email
+			socials {
+				type
+				link
+			}
+		}
+	}
+`
 
 /**
  * __useGetEnhancedUserDetailsQuery__
@@ -4086,36 +6130,59 @@ export const GetEnhancedUserDetailsDocument = gql`
  *   },
  * });
  */
-export function useGetEnhancedUserDetailsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetEnhancedUserDetailsQuery, Types.GetEnhancedUserDetailsQueryVariables>) {
-        return Apollo.useQuery<Types.GetEnhancedUserDetailsQuery, Types.GetEnhancedUserDetailsQueryVariables>(GetEnhancedUserDetailsDocument, baseOptions);
-      }
-export function useGetEnhancedUserDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetEnhancedUserDetailsQuery, Types.GetEnhancedUserDetailsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetEnhancedUserDetailsQuery, Types.GetEnhancedUserDetailsQueryVariables>(GetEnhancedUserDetailsDocument, baseOptions);
-        }
-export type GetEnhancedUserDetailsQueryHookResult = ReturnType<typeof useGetEnhancedUserDetailsQuery>;
-export type GetEnhancedUserDetailsLazyQueryHookResult = ReturnType<typeof useGetEnhancedUserDetailsLazyQuery>;
-export type GetEnhancedUserDetailsQueryResult = Apollo.QueryResult<Types.GetEnhancedUserDetailsQuery, Types.GetEnhancedUserDetailsQueryVariables>;
-export const GetOnboardingStepsDocument = gql`
-    query GetOnboardingSteps($project_id: ID!, $admin_id: ID!) {
-  workspace: workspace_for_project(project_id: $project_id) {
-    id
-    slack_channels
-  }
-  admins: workspace_admins_by_project_id(project_id: $project_id) {
-    admin {
-      id
-    }
-  }
-  isIntegrated(project_id: $project_id)
-  adminHasCreatedComment(admin_id: $admin_id)
-  projectHasViewedASession(project_id: $project_id) {
-    secure_id
-  }
-  admin {
-    slack_im_channel_id
-  }
+export function useGetEnhancedUserDetailsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetEnhancedUserDetailsQuery,
+		Types.GetEnhancedUserDetailsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetEnhancedUserDetailsQuery,
+		Types.GetEnhancedUserDetailsQueryVariables
+	>(GetEnhancedUserDetailsDocument, baseOptions)
 }
-    `;
+export function useGetEnhancedUserDetailsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetEnhancedUserDetailsQuery,
+		Types.GetEnhancedUserDetailsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetEnhancedUserDetailsQuery,
+		Types.GetEnhancedUserDetailsQueryVariables
+	>(GetEnhancedUserDetailsDocument, baseOptions)
+}
+export type GetEnhancedUserDetailsQueryHookResult = ReturnType<
+	typeof useGetEnhancedUserDetailsQuery
+>
+export type GetEnhancedUserDetailsLazyQueryHookResult = ReturnType<
+	typeof useGetEnhancedUserDetailsLazyQuery
+>
+export type GetEnhancedUserDetailsQueryResult = Apollo.QueryResult<
+	Types.GetEnhancedUserDetailsQuery,
+	Types.GetEnhancedUserDetailsQueryVariables
+>
+export const GetOnboardingStepsDocument = gql`
+	query GetOnboardingSteps($project_id: ID!, $admin_id: ID!) {
+		workspace: workspace_for_project(project_id: $project_id) {
+			id
+			slack_channels
+		}
+		admins: workspace_admins_by_project_id(project_id: $project_id) {
+			admin {
+				id
+			}
+		}
+		isIntegrated(project_id: $project_id)
+		adminHasCreatedComment(admin_id: $admin_id)
+		projectHasViewedASession(project_id: $project_id) {
+			secure_id
+		}
+		admin {
+			slack_im_channel_id
+		}
+	}
+`
 
 /**
  * __useGetOnboardingStepsQuery__
@@ -4134,26 +6201,57 @@ export const GetOnboardingStepsDocument = gql`
  *   },
  * });
  */
-export function useGetOnboardingStepsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetOnboardingStepsQuery, Types.GetOnboardingStepsQueryVariables>) {
-        return Apollo.useQuery<Types.GetOnboardingStepsQuery, Types.GetOnboardingStepsQueryVariables>(GetOnboardingStepsDocument, baseOptions);
-      }
-export function useGetOnboardingStepsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetOnboardingStepsQuery, Types.GetOnboardingStepsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetOnboardingStepsQuery, Types.GetOnboardingStepsQueryVariables>(GetOnboardingStepsDocument, baseOptions);
-        }
-export type GetOnboardingStepsQueryHookResult = ReturnType<typeof useGetOnboardingStepsQuery>;
-export type GetOnboardingStepsLazyQueryHookResult = ReturnType<typeof useGetOnboardingStepsLazyQuery>;
-export type GetOnboardingStepsQueryResult = Apollo.QueryResult<Types.GetOnboardingStepsQuery, Types.GetOnboardingStepsQueryVariables>;
-export const SendAdminWorkspaceInviteDocument = gql`
-    mutation SendAdminWorkspaceInvite($workspace_id: ID!, $email: String!, $base_url: String!, $role: String!) {
-  sendAdminWorkspaceInvite(
-    workspace_id: $workspace_id
-    email: $email
-    base_url: $base_url
-    role: $role
-  )
+export function useGetOnboardingStepsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetOnboardingStepsQuery,
+		Types.GetOnboardingStepsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetOnboardingStepsQuery,
+		Types.GetOnboardingStepsQueryVariables
+	>(GetOnboardingStepsDocument, baseOptions)
 }
-    `;
-export type SendAdminWorkspaceInviteMutationFn = Apollo.MutationFunction<Types.SendAdminWorkspaceInviteMutation, Types.SendAdminWorkspaceInviteMutationVariables>;
+export function useGetOnboardingStepsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetOnboardingStepsQuery,
+		Types.GetOnboardingStepsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetOnboardingStepsQuery,
+		Types.GetOnboardingStepsQueryVariables
+	>(GetOnboardingStepsDocument, baseOptions)
+}
+export type GetOnboardingStepsQueryHookResult = ReturnType<
+	typeof useGetOnboardingStepsQuery
+>
+export type GetOnboardingStepsLazyQueryHookResult = ReturnType<
+	typeof useGetOnboardingStepsLazyQuery
+>
+export type GetOnboardingStepsQueryResult = Apollo.QueryResult<
+	Types.GetOnboardingStepsQuery,
+	Types.GetOnboardingStepsQueryVariables
+>
+export const SendAdminWorkspaceInviteDocument = gql`
+	mutation SendAdminWorkspaceInvite(
+		$workspace_id: ID!
+		$email: String!
+		$base_url: String!
+		$role: String!
+	) {
+		sendAdminWorkspaceInvite(
+			workspace_id: $workspace_id
+			email: $email
+			base_url: $base_url
+			role: $role
+		)
+	}
+`
+export type SendAdminWorkspaceInviteMutationFn = Apollo.MutationFunction<
+	Types.SendAdminWorkspaceInviteMutation,
+	Types.SendAdminWorkspaceInviteMutationVariables
+>
 
 /**
  * __useSendAdminWorkspaceInviteMutation__
@@ -4175,22 +6273,37 @@ export type SendAdminWorkspaceInviteMutationFn = Apollo.MutationFunction<Types.S
  *   },
  * });
  */
-export function useSendAdminWorkspaceInviteMutation(baseOptions?: Apollo.MutationHookOptions<Types.SendAdminWorkspaceInviteMutation, Types.SendAdminWorkspaceInviteMutationVariables>) {
-        return Apollo.useMutation<Types.SendAdminWorkspaceInviteMutation, Types.SendAdminWorkspaceInviteMutationVariables>(SendAdminWorkspaceInviteDocument, baseOptions);
-      }
-export type SendAdminWorkspaceInviteMutationHookResult = ReturnType<typeof useSendAdminWorkspaceInviteMutation>;
-export type SendAdminWorkspaceInviteMutationResult = Apollo.MutationResult<Types.SendAdminWorkspaceInviteMutation>;
-export type SendAdminWorkspaceInviteMutationOptions = Apollo.BaseMutationOptions<Types.SendAdminWorkspaceInviteMutation, Types.SendAdminWorkspaceInviteMutationVariables>;
-export const GetSessionIntervalsDocument = gql`
-    query GetSessionIntervals($session_secure_id: String!) {
-  session_intervals(session_secure_id: $session_secure_id) {
-    start_time
-    end_time
-    active
-    duration
-  }
+export function useSendAdminWorkspaceInviteMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.SendAdminWorkspaceInviteMutation,
+		Types.SendAdminWorkspaceInviteMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.SendAdminWorkspaceInviteMutation,
+		Types.SendAdminWorkspaceInviteMutationVariables
+	>(SendAdminWorkspaceInviteDocument, baseOptions)
 }
-    `;
+export type SendAdminWorkspaceInviteMutationHookResult = ReturnType<
+	typeof useSendAdminWorkspaceInviteMutation
+>
+export type SendAdminWorkspaceInviteMutationResult =
+	Apollo.MutationResult<Types.SendAdminWorkspaceInviteMutation>
+export type SendAdminWorkspaceInviteMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.SendAdminWorkspaceInviteMutation,
+		Types.SendAdminWorkspaceInviteMutationVariables
+	>
+export const GetSessionIntervalsDocument = gql`
+	query GetSessionIntervals($session_secure_id: String!) {
+		session_intervals(session_secure_id: $session_secure_id) {
+			start_time
+			end_time
+			active
+			duration
+		}
+	}
+`
 
 /**
  * __useGetSessionIntervalsQuery__
@@ -4208,25 +6321,48 @@ export const GetSessionIntervalsDocument = gql`
  *   },
  * });
  */
-export function useGetSessionIntervalsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionIntervalsQuery, Types.GetSessionIntervalsQueryVariables>) {
-        return Apollo.useQuery<Types.GetSessionIntervalsQuery, Types.GetSessionIntervalsQueryVariables>(GetSessionIntervalsDocument, baseOptions);
-      }
-export function useGetSessionIntervalsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionIntervalsQuery, Types.GetSessionIntervalsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSessionIntervalsQuery, Types.GetSessionIntervalsQueryVariables>(GetSessionIntervalsDocument, baseOptions);
-        }
-export type GetSessionIntervalsQueryHookResult = ReturnType<typeof useGetSessionIntervalsQuery>;
-export type GetSessionIntervalsLazyQueryHookResult = ReturnType<typeof useGetSessionIntervalsLazyQuery>;
-export type GetSessionIntervalsQueryResult = Apollo.QueryResult<Types.GetSessionIntervalsQuery, Types.GetSessionIntervalsQueryVariables>;
-export const GetTimelineIndicatorEventsDocument = gql`
-    query GetTimelineIndicatorEvents($session_secure_id: String!) {
-  timeline_indicator_events(session_secure_id: $session_secure_id) {
-    timestamp
-    data
-    type
-    sid
-  }
+export function useGetSessionIntervalsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSessionIntervalsQuery,
+		Types.GetSessionIntervalsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSessionIntervalsQuery,
+		Types.GetSessionIntervalsQueryVariables
+	>(GetSessionIntervalsDocument, baseOptions)
 }
-    `;
+export function useGetSessionIntervalsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSessionIntervalsQuery,
+		Types.GetSessionIntervalsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSessionIntervalsQuery,
+		Types.GetSessionIntervalsQueryVariables
+	>(GetSessionIntervalsDocument, baseOptions)
+}
+export type GetSessionIntervalsQueryHookResult = ReturnType<
+	typeof useGetSessionIntervalsQuery
+>
+export type GetSessionIntervalsLazyQueryHookResult = ReturnType<
+	typeof useGetSessionIntervalsLazyQuery
+>
+export type GetSessionIntervalsQueryResult = Apollo.QueryResult<
+	Types.GetSessionIntervalsQuery,
+	Types.GetSessionIntervalsQueryVariables
+>
+export const GetTimelineIndicatorEventsDocument = gql`
+	query GetTimelineIndicatorEvents($session_secure_id: String!) {
+		timeline_indicator_events(session_secure_id: $session_secure_id) {
+			timestamp
+			data
+			type
+			sid
+		}
+	}
+`
 
 /**
  * __useGetTimelineIndicatorEventsQuery__
@@ -4244,27 +6380,54 @@ export const GetTimelineIndicatorEventsDocument = gql`
  *   },
  * });
  */
-export function useGetTimelineIndicatorEventsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetTimelineIndicatorEventsQuery, Types.GetTimelineIndicatorEventsQueryVariables>) {
-        return Apollo.useQuery<Types.GetTimelineIndicatorEventsQuery, Types.GetTimelineIndicatorEventsQueryVariables>(GetTimelineIndicatorEventsDocument, baseOptions);
-      }
-export function useGetTimelineIndicatorEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetTimelineIndicatorEventsQuery, Types.GetTimelineIndicatorEventsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetTimelineIndicatorEventsQuery, Types.GetTimelineIndicatorEventsQueryVariables>(GetTimelineIndicatorEventsDocument, baseOptions);
-        }
-export type GetTimelineIndicatorEventsQueryHookResult = ReturnType<typeof useGetTimelineIndicatorEventsQuery>;
-export type GetTimelineIndicatorEventsLazyQueryHookResult = ReturnType<typeof useGetTimelineIndicatorEventsLazyQuery>;
-export type GetTimelineIndicatorEventsQueryResult = Apollo.QueryResult<Types.GetTimelineIndicatorEventsQuery, Types.GetTimelineIndicatorEventsQueryVariables>;
-export const GetFieldTypesDocument = gql`
-    query GetFieldTypes($project_id: ID!, $start_date: Timestamp, $end_date: Timestamp) {
-  field_types(
-    project_id: $project_id
-    start_date: $start_date
-    end_date: $end_date
-  ) {
-    type
-    name
-  }
+export function useGetTimelineIndicatorEventsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetTimelineIndicatorEventsQuery,
+		Types.GetTimelineIndicatorEventsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetTimelineIndicatorEventsQuery,
+		Types.GetTimelineIndicatorEventsQueryVariables
+	>(GetTimelineIndicatorEventsDocument, baseOptions)
 }
-    `;
+export function useGetTimelineIndicatorEventsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetTimelineIndicatorEventsQuery,
+		Types.GetTimelineIndicatorEventsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetTimelineIndicatorEventsQuery,
+		Types.GetTimelineIndicatorEventsQueryVariables
+	>(GetTimelineIndicatorEventsDocument, baseOptions)
+}
+export type GetTimelineIndicatorEventsQueryHookResult = ReturnType<
+	typeof useGetTimelineIndicatorEventsQuery
+>
+export type GetTimelineIndicatorEventsLazyQueryHookResult = ReturnType<
+	typeof useGetTimelineIndicatorEventsLazyQuery
+>
+export type GetTimelineIndicatorEventsQueryResult = Apollo.QueryResult<
+	Types.GetTimelineIndicatorEventsQuery,
+	Types.GetTimelineIndicatorEventsQueryVariables
+>
+export const GetFieldTypesDocument = gql`
+	query GetFieldTypes(
+		$project_id: ID!
+		$start_date: Timestamp
+		$end_date: Timestamp
+	) {
+		field_types(
+			project_id: $project_id
+			start_date: $start_date
+			end_date: $end_date
+		) {
+			type
+			name
+		}
+	}
+`
 
 /**
  * __useGetFieldTypesQuery__
@@ -4284,26 +6447,55 @@ export const GetFieldTypesDocument = gql`
  *   },
  * });
  */
-export function useGetFieldTypesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetFieldTypesQuery, Types.GetFieldTypesQueryVariables>) {
-        return Apollo.useQuery<Types.GetFieldTypesQuery, Types.GetFieldTypesQueryVariables>(GetFieldTypesDocument, baseOptions);
-      }
-export function useGetFieldTypesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetFieldTypesQuery, Types.GetFieldTypesQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetFieldTypesQuery, Types.GetFieldTypesQueryVariables>(GetFieldTypesDocument, baseOptions);
-        }
-export type GetFieldTypesQueryHookResult = ReturnType<typeof useGetFieldTypesQuery>;
-export type GetFieldTypesLazyQueryHookResult = ReturnType<typeof useGetFieldTypesLazyQuery>;
-export type GetFieldTypesQueryResult = Apollo.QueryResult<Types.GetFieldTypesQuery, Types.GetFieldTypesQueryVariables>;
-export const GetFieldsOpensearchDocument = gql`
-    query GetFieldsOpensearch($project_id: ID!, $count: Int!, $field_type: String!, $field_name: String!, $query: String!) {
-  fields_opensearch(
-    project_id: $project_id
-    count: $count
-    field_type: $field_type
-    field_name: $field_name
-    query: $query
-  )
+export function useGetFieldTypesQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetFieldTypesQuery,
+		Types.GetFieldTypesQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetFieldTypesQuery,
+		Types.GetFieldTypesQueryVariables
+	>(GetFieldTypesDocument, baseOptions)
 }
-    `;
+export function useGetFieldTypesLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetFieldTypesQuery,
+		Types.GetFieldTypesQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetFieldTypesQuery,
+		Types.GetFieldTypesQueryVariables
+	>(GetFieldTypesDocument, baseOptions)
+}
+export type GetFieldTypesQueryHookResult = ReturnType<
+	typeof useGetFieldTypesQuery
+>
+export type GetFieldTypesLazyQueryHookResult = ReturnType<
+	typeof useGetFieldTypesLazyQuery
+>
+export type GetFieldTypesQueryResult = Apollo.QueryResult<
+	Types.GetFieldTypesQuery,
+	Types.GetFieldTypesQueryVariables
+>
+export const GetFieldsOpensearchDocument = gql`
+	query GetFieldsOpensearch(
+		$project_id: ID!
+		$count: Int!
+		$field_type: String!
+		$field_name: String!
+		$query: String!
+	) {
+		fields_opensearch(
+			project_id: $project_id
+			count: $count
+			field_type: $field_type
+			field_name: $field_name
+			query: $query
+		)
+	}
+`
 
 /**
  * __useGetFieldsOpensearchQuery__
@@ -4325,24 +6517,55 @@ export const GetFieldsOpensearchDocument = gql`
  *   },
  * });
  */
-export function useGetFieldsOpensearchQuery(baseOptions: Apollo.QueryHookOptions<Types.GetFieldsOpensearchQuery, Types.GetFieldsOpensearchQueryVariables>) {
-        return Apollo.useQuery<Types.GetFieldsOpensearchQuery, Types.GetFieldsOpensearchQueryVariables>(GetFieldsOpensearchDocument, baseOptions);
-      }
-export function useGetFieldsOpensearchLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetFieldsOpensearchQuery, Types.GetFieldsOpensearchQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetFieldsOpensearchQuery, Types.GetFieldsOpensearchQueryVariables>(GetFieldsOpensearchDocument, baseOptions);
-        }
-export type GetFieldsOpensearchQueryHookResult = ReturnType<typeof useGetFieldsOpensearchQuery>;
-export type GetFieldsOpensearchLazyQueryHookResult = ReturnType<typeof useGetFieldsOpensearchLazyQuery>;
-export type GetFieldsOpensearchQueryResult = Apollo.QueryResult<Types.GetFieldsOpensearchQuery, Types.GetFieldsOpensearchQueryVariables>;
-export const GetQuickFieldsOpensearchDocument = gql`
-    query GetQuickFieldsOpensearch($project_id: ID!, $count: Int!, $query: String!) {
-  quickFields_opensearch(project_id: $project_id, count: $count, query: $query) {
-    type
-    name
-    value
-  }
+export function useGetFieldsOpensearchQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetFieldsOpensearchQuery,
+		Types.GetFieldsOpensearchQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetFieldsOpensearchQuery,
+		Types.GetFieldsOpensearchQueryVariables
+	>(GetFieldsOpensearchDocument, baseOptions)
 }
-    `;
+export function useGetFieldsOpensearchLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetFieldsOpensearchQuery,
+		Types.GetFieldsOpensearchQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetFieldsOpensearchQuery,
+		Types.GetFieldsOpensearchQueryVariables
+	>(GetFieldsOpensearchDocument, baseOptions)
+}
+export type GetFieldsOpensearchQueryHookResult = ReturnType<
+	typeof useGetFieldsOpensearchQuery
+>
+export type GetFieldsOpensearchLazyQueryHookResult = ReturnType<
+	typeof useGetFieldsOpensearchLazyQuery
+>
+export type GetFieldsOpensearchQueryResult = Apollo.QueryResult<
+	Types.GetFieldsOpensearchQuery,
+	Types.GetFieldsOpensearchQueryVariables
+>
+export const GetQuickFieldsOpensearchDocument = gql`
+	query GetQuickFieldsOpensearch(
+		$project_id: ID!
+		$count: Int!
+		$query: String!
+	) {
+		quickFields_opensearch(
+			project_id: $project_id
+			count: $count
+			query: $query
+		) {
+			type
+			name
+			value
+		}
+	}
+`
 
 /**
  * __useGetQuickFieldsOpensearchQuery__
@@ -4362,26 +6585,55 @@ export const GetQuickFieldsOpensearchDocument = gql`
  *   },
  * });
  */
-export function useGetQuickFieldsOpensearchQuery(baseOptions: Apollo.QueryHookOptions<Types.GetQuickFieldsOpensearchQuery, Types.GetQuickFieldsOpensearchQueryVariables>) {
-        return Apollo.useQuery<Types.GetQuickFieldsOpensearchQuery, Types.GetQuickFieldsOpensearchQueryVariables>(GetQuickFieldsOpensearchDocument, baseOptions);
-      }
-export function useGetQuickFieldsOpensearchLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetQuickFieldsOpensearchQuery, Types.GetQuickFieldsOpensearchQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetQuickFieldsOpensearchQuery, Types.GetQuickFieldsOpensearchQueryVariables>(GetQuickFieldsOpensearchDocument, baseOptions);
-        }
-export type GetQuickFieldsOpensearchQueryHookResult = ReturnType<typeof useGetQuickFieldsOpensearchQuery>;
-export type GetQuickFieldsOpensearchLazyQueryHookResult = ReturnType<typeof useGetQuickFieldsOpensearchLazyQuery>;
-export type GetQuickFieldsOpensearchQueryResult = Apollo.QueryResult<Types.GetQuickFieldsOpensearchQuery, Types.GetQuickFieldsOpensearchQueryVariables>;
-export const GetErrorFieldsOpensearchDocument = gql`
-    query GetErrorFieldsOpensearch($project_id: ID!, $count: Int!, $field_type: String!, $field_name: String!, $query: String!) {
-  error_fields_opensearch(
-    project_id: $project_id
-    count: $count
-    field_type: $field_type
-    field_name: $field_name
-    query: $query
-  )
+export function useGetQuickFieldsOpensearchQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetQuickFieldsOpensearchQuery,
+		Types.GetQuickFieldsOpensearchQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetQuickFieldsOpensearchQuery,
+		Types.GetQuickFieldsOpensearchQueryVariables
+	>(GetQuickFieldsOpensearchDocument, baseOptions)
 }
-    `;
+export function useGetQuickFieldsOpensearchLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetQuickFieldsOpensearchQuery,
+		Types.GetQuickFieldsOpensearchQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetQuickFieldsOpensearchQuery,
+		Types.GetQuickFieldsOpensearchQueryVariables
+	>(GetQuickFieldsOpensearchDocument, baseOptions)
+}
+export type GetQuickFieldsOpensearchQueryHookResult = ReturnType<
+	typeof useGetQuickFieldsOpensearchQuery
+>
+export type GetQuickFieldsOpensearchLazyQueryHookResult = ReturnType<
+	typeof useGetQuickFieldsOpensearchLazyQuery
+>
+export type GetQuickFieldsOpensearchQueryResult = Apollo.QueryResult<
+	Types.GetQuickFieldsOpensearchQuery,
+	Types.GetQuickFieldsOpensearchQueryVariables
+>
+export const GetErrorFieldsOpensearchDocument = gql`
+	query GetErrorFieldsOpensearch(
+		$project_id: ID!
+		$count: Int!
+		$field_type: String!
+		$field_name: String!
+		$query: String!
+	) {
+		error_fields_opensearch(
+			project_id: $project_id
+			count: $count
+			field_type: $field_type
+			field_name: $field_name
+			query: $query
+		)
+	}
+`
 
 /**
  * __useGetErrorFieldsOpensearchQuery__
@@ -4403,67 +6655,97 @@ export const GetErrorFieldsOpensearchDocument = gql`
  *   },
  * });
  */
-export function useGetErrorFieldsOpensearchQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorFieldsOpensearchQuery, Types.GetErrorFieldsOpensearchQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorFieldsOpensearchQuery, Types.GetErrorFieldsOpensearchQueryVariables>(GetErrorFieldsOpensearchDocument, baseOptions);
-      }
-export function useGetErrorFieldsOpensearchLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorFieldsOpensearchQuery, Types.GetErrorFieldsOpensearchQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorFieldsOpensearchQuery, Types.GetErrorFieldsOpensearchQueryVariables>(GetErrorFieldsOpensearchDocument, baseOptions);
-        }
-export type GetErrorFieldsOpensearchQueryHookResult = ReturnType<typeof useGetErrorFieldsOpensearchQuery>;
-export type GetErrorFieldsOpensearchLazyQueryHookResult = ReturnType<typeof useGetErrorFieldsOpensearchLazyQuery>;
-export type GetErrorFieldsOpensearchQueryResult = Apollo.QueryResult<Types.GetErrorFieldsOpensearchQuery, Types.GetErrorFieldsOpensearchQueryVariables>;
-export const GetSessionsOpenSearchDocument = gql`
-    query GetSessionsOpenSearch($project_id: ID!, $count: Int!, $query: String!, $sort_desc: Boolean!, $sort_field: String, $page: Int) {
-  sessions_opensearch(
-    project_id: $project_id
-    count: $count
-    query: $query
-    sort_field: $sort_field
-    sort_desc: $sort_desc
-    page: $page
-  ) {
-    sessions {
-      id
-      secure_id
-      client_id
-      fingerprint
-      identifier
-      identified
-      os_name
-      os_version
-      browser_name
-      browser_version
-      city
-      state
-      country
-      postal
-      created_at
-      language
-      length
-      active_length
-      enable_recording_network_contents
-      viewed
-      starred
-      processed
-      has_rage_clicks
-      has_errors
-      fields {
-        name
-        value
-        type
-        id
-      }
-      first_time
-      user_properties
-      event_counts
-      last_user_interaction_time
-      is_public
-      excluded
-    }
-    totalCount
-  }
+export function useGetErrorFieldsOpensearchQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorFieldsOpensearchQuery,
+		Types.GetErrorFieldsOpensearchQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorFieldsOpensearchQuery,
+		Types.GetErrorFieldsOpensearchQueryVariables
+	>(GetErrorFieldsOpensearchDocument, baseOptions)
 }
-    `;
+export function useGetErrorFieldsOpensearchLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorFieldsOpensearchQuery,
+		Types.GetErrorFieldsOpensearchQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorFieldsOpensearchQuery,
+		Types.GetErrorFieldsOpensearchQueryVariables
+	>(GetErrorFieldsOpensearchDocument, baseOptions)
+}
+export type GetErrorFieldsOpensearchQueryHookResult = ReturnType<
+	typeof useGetErrorFieldsOpensearchQuery
+>
+export type GetErrorFieldsOpensearchLazyQueryHookResult = ReturnType<
+	typeof useGetErrorFieldsOpensearchLazyQuery
+>
+export type GetErrorFieldsOpensearchQueryResult = Apollo.QueryResult<
+	Types.GetErrorFieldsOpensearchQuery,
+	Types.GetErrorFieldsOpensearchQueryVariables
+>
+export const GetSessionsOpenSearchDocument = gql`
+	query GetSessionsOpenSearch(
+		$project_id: ID!
+		$count: Int!
+		$query: String!
+		$sort_desc: Boolean!
+		$sort_field: String
+		$page: Int
+	) {
+		sessions_opensearch(
+			project_id: $project_id
+			count: $count
+			query: $query
+			sort_field: $sort_field
+			sort_desc: $sort_desc
+			page: $page
+		) {
+			sessions {
+				id
+				secure_id
+				client_id
+				fingerprint
+				identifier
+				identified
+				os_name
+				os_version
+				browser_name
+				browser_version
+				city
+				state
+				country
+				postal
+				created_at
+				language
+				length
+				active_length
+				enable_recording_network_contents
+				viewed
+				starred
+				processed
+				has_rage_clicks
+				has_errors
+				fields {
+					name
+					value
+					type
+					id
+				}
+				first_time
+				user_properties
+				event_counts
+				last_user_interaction_time
+				is_public
+				excluded
+			}
+			totalCount
+		}
+	}
+`
 
 /**
  * __useGetSessionsOpenSearchQuery__
@@ -4486,29 +6768,56 @@ export const GetSessionsOpenSearchDocument = gql`
  *   },
  * });
  */
-export function useGetSessionsOpenSearchQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionsOpenSearchQuery, Types.GetSessionsOpenSearchQueryVariables>) {
-        return Apollo.useQuery<Types.GetSessionsOpenSearchQuery, Types.GetSessionsOpenSearchQueryVariables>(GetSessionsOpenSearchDocument, baseOptions);
-      }
-export function useGetSessionsOpenSearchLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionsOpenSearchQuery, Types.GetSessionsOpenSearchQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSessionsOpenSearchQuery, Types.GetSessionsOpenSearchQueryVariables>(GetSessionsOpenSearchDocument, baseOptions);
-        }
-export type GetSessionsOpenSearchQueryHookResult = ReturnType<typeof useGetSessionsOpenSearchQuery>;
-export type GetSessionsOpenSearchLazyQueryHookResult = ReturnType<typeof useGetSessionsOpenSearchLazyQuery>;
-export type GetSessionsOpenSearchQueryResult = Apollo.QueryResult<Types.GetSessionsOpenSearchQuery, Types.GetSessionsOpenSearchQueryVariables>;
-export const GetSessionsHistogramDocument = gql`
-    query GetSessionsHistogram($project_id: ID!, $query: String!, $histogram_options: DateHistogramOptions!) {
-  sessions_histogram(
-    project_id: $project_id
-    query: $query
-    histogram_options: $histogram_options
-  ) {
-    bucket_times
-    sessions_without_errors
-    sessions_with_errors
-    total_sessions
-  }
+export function useGetSessionsOpenSearchQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSessionsOpenSearchQuery,
+		Types.GetSessionsOpenSearchQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSessionsOpenSearchQuery,
+		Types.GetSessionsOpenSearchQueryVariables
+	>(GetSessionsOpenSearchDocument, baseOptions)
 }
-    `;
+export function useGetSessionsOpenSearchLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSessionsOpenSearchQuery,
+		Types.GetSessionsOpenSearchQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSessionsOpenSearchQuery,
+		Types.GetSessionsOpenSearchQueryVariables
+	>(GetSessionsOpenSearchDocument, baseOptions)
+}
+export type GetSessionsOpenSearchQueryHookResult = ReturnType<
+	typeof useGetSessionsOpenSearchQuery
+>
+export type GetSessionsOpenSearchLazyQueryHookResult = ReturnType<
+	typeof useGetSessionsOpenSearchLazyQuery
+>
+export type GetSessionsOpenSearchQueryResult = Apollo.QueryResult<
+	Types.GetSessionsOpenSearchQuery,
+	Types.GetSessionsOpenSearchQueryVariables
+>
+export const GetSessionsHistogramDocument = gql`
+	query GetSessionsHistogram(
+		$project_id: ID!
+		$query: String!
+		$histogram_options: DateHistogramOptions!
+	) {
+		sessions_histogram(
+			project_id: $project_id
+			query: $query
+			histogram_options: $histogram_options
+		) {
+			bucket_times
+			sessions_without_errors
+			sessions_with_errors
+			total_sessions
+		}
+	}
+`
 
 /**
  * __useGetSessionsHistogramQuery__
@@ -4528,55 +6837,83 @@ export const GetSessionsHistogramDocument = gql`
  *   },
  * });
  */
-export function useGetSessionsHistogramQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionsHistogramQuery, Types.GetSessionsHistogramQueryVariables>) {
-        return Apollo.useQuery<Types.GetSessionsHistogramQuery, Types.GetSessionsHistogramQueryVariables>(GetSessionsHistogramDocument, baseOptions);
-      }
-export function useGetSessionsHistogramLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionsHistogramQuery, Types.GetSessionsHistogramQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSessionsHistogramQuery, Types.GetSessionsHistogramQueryVariables>(GetSessionsHistogramDocument, baseOptions);
-        }
-export type GetSessionsHistogramQueryHookResult = ReturnType<typeof useGetSessionsHistogramQuery>;
-export type GetSessionsHistogramLazyQueryHookResult = ReturnType<typeof useGetSessionsHistogramLazyQuery>;
-export type GetSessionsHistogramQueryResult = Apollo.QueryResult<Types.GetSessionsHistogramQuery, Types.GetSessionsHistogramQueryVariables>;
-export const GetErrorGroupsOpenSearchDocument = gql`
-    query GetErrorGroupsOpenSearch($project_id: ID!, $count: Int!, $query: String!, $page: Int) {
-  error_groups_opensearch(
-    project_id: $project_id
-    count: $count
-    query: $query
-    page: $page
-  ) {
-    error_groups {
-      created_at
-      updated_at
-      id
-      secure_id
-      type
-      event
-      state
-      state
-      snoozed_until
-      environments
-      stack_trace
-      structured_stack_trace {
-        fileName
-        lineNumber
-        functionName
-        columnNumber
-      }
-      error_frequency
-      error_metrics {
-        error_group_id
-        date
-        name
-        value
-      }
-      is_public
-      project_id
-    }
-    totalCount
-  }
+export function useGetSessionsHistogramQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSessionsHistogramQuery,
+		Types.GetSessionsHistogramQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSessionsHistogramQuery,
+		Types.GetSessionsHistogramQueryVariables
+	>(GetSessionsHistogramDocument, baseOptions)
 }
-    `;
+export function useGetSessionsHistogramLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSessionsHistogramQuery,
+		Types.GetSessionsHistogramQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSessionsHistogramQuery,
+		Types.GetSessionsHistogramQueryVariables
+	>(GetSessionsHistogramDocument, baseOptions)
+}
+export type GetSessionsHistogramQueryHookResult = ReturnType<
+	typeof useGetSessionsHistogramQuery
+>
+export type GetSessionsHistogramLazyQueryHookResult = ReturnType<
+	typeof useGetSessionsHistogramLazyQuery
+>
+export type GetSessionsHistogramQueryResult = Apollo.QueryResult<
+	Types.GetSessionsHistogramQuery,
+	Types.GetSessionsHistogramQueryVariables
+>
+export const GetErrorGroupsOpenSearchDocument = gql`
+	query GetErrorGroupsOpenSearch(
+		$project_id: ID!
+		$count: Int!
+		$query: String!
+		$page: Int
+	) {
+		error_groups_opensearch(
+			project_id: $project_id
+			count: $count
+			query: $query
+			page: $page
+		) {
+			error_groups {
+				created_at
+				updated_at
+				id
+				secure_id
+				type
+				event
+				state
+				state
+				snoozed_until
+				environments
+				stack_trace
+				structured_stack_trace {
+					fileName
+					lineNumber
+					functionName
+					columnNumber
+				}
+				error_frequency
+				error_metrics {
+					error_group_id
+					date
+					name
+					value
+				}
+				is_public
+				project_id
+			}
+			totalCount
+		}
+	}
+`
 
 /**
  * __useGetErrorGroupsOpenSearchQuery__
@@ -4597,27 +6934,54 @@ export const GetErrorGroupsOpenSearchDocument = gql`
  *   },
  * });
  */
-export function useGetErrorGroupsOpenSearchQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorGroupsOpenSearchQuery, Types.GetErrorGroupsOpenSearchQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorGroupsOpenSearchQuery, Types.GetErrorGroupsOpenSearchQueryVariables>(GetErrorGroupsOpenSearchDocument, baseOptions);
-      }
-export function useGetErrorGroupsOpenSearchLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorGroupsOpenSearchQuery, Types.GetErrorGroupsOpenSearchQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorGroupsOpenSearchQuery, Types.GetErrorGroupsOpenSearchQueryVariables>(GetErrorGroupsOpenSearchDocument, baseOptions);
-        }
-export type GetErrorGroupsOpenSearchQueryHookResult = ReturnType<typeof useGetErrorGroupsOpenSearchQuery>;
-export type GetErrorGroupsOpenSearchLazyQueryHookResult = ReturnType<typeof useGetErrorGroupsOpenSearchLazyQuery>;
-export type GetErrorGroupsOpenSearchQueryResult = Apollo.QueryResult<Types.GetErrorGroupsOpenSearchQuery, Types.GetErrorGroupsOpenSearchQueryVariables>;
-export const GetErrorsHistogramDocument = gql`
-    query GetErrorsHistogram($project_id: ID!, $query: String!, $histogram_options: DateHistogramOptions!) {
-  errors_histogram(
-    project_id: $project_id
-    query: $query
-    histogram_options: $histogram_options
-  ) {
-    bucket_times
-    error_objects
-  }
+export function useGetErrorGroupsOpenSearchQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorGroupsOpenSearchQuery,
+		Types.GetErrorGroupsOpenSearchQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorGroupsOpenSearchQuery,
+		Types.GetErrorGroupsOpenSearchQueryVariables
+	>(GetErrorGroupsOpenSearchDocument, baseOptions)
 }
-    `;
+export function useGetErrorGroupsOpenSearchLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorGroupsOpenSearchQuery,
+		Types.GetErrorGroupsOpenSearchQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorGroupsOpenSearchQuery,
+		Types.GetErrorGroupsOpenSearchQueryVariables
+	>(GetErrorGroupsOpenSearchDocument, baseOptions)
+}
+export type GetErrorGroupsOpenSearchQueryHookResult = ReturnType<
+	typeof useGetErrorGroupsOpenSearchQuery
+>
+export type GetErrorGroupsOpenSearchLazyQueryHookResult = ReturnType<
+	typeof useGetErrorGroupsOpenSearchLazyQuery
+>
+export type GetErrorGroupsOpenSearchQueryResult = Apollo.QueryResult<
+	Types.GetErrorGroupsOpenSearchQuery,
+	Types.GetErrorGroupsOpenSearchQueryVariables
+>
+export const GetErrorsHistogramDocument = gql`
+	query GetErrorsHistogram(
+		$project_id: ID!
+		$query: String!
+		$histogram_options: DateHistogramOptions!
+	) {
+		errors_histogram(
+			project_id: $project_id
+			query: $query
+			histogram_options: $histogram_options
+		) {
+			bucket_times
+			error_objects
+		}
+	}
+`
 
 /**
  * __useGetErrorsHistogramQuery__
@@ -4637,24 +7001,47 @@ export const GetErrorsHistogramDocument = gql`
  *   },
  * });
  */
-export function useGetErrorsHistogramQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorsHistogramQuery, Types.GetErrorsHistogramQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorsHistogramQuery, Types.GetErrorsHistogramQueryVariables>(GetErrorsHistogramDocument, baseOptions);
-      }
-export function useGetErrorsHistogramLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorsHistogramQuery, Types.GetErrorsHistogramQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorsHistogramQuery, Types.GetErrorsHistogramQueryVariables>(GetErrorsHistogramDocument, baseOptions);
-        }
-export type GetErrorsHistogramQueryHookResult = ReturnType<typeof useGetErrorsHistogramQuery>;
-export type GetErrorsHistogramLazyQueryHookResult = ReturnType<typeof useGetErrorsHistogramLazyQuery>;
-export type GetErrorsHistogramQueryResult = Apollo.QueryResult<Types.GetErrorsHistogramQuery, Types.GetErrorsHistogramQueryVariables>;
-export const GetProjectsDocument = gql`
-    query GetProjects {
-  projects {
-    id
-    name
-    workspace_id
-  }
+export function useGetErrorsHistogramQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorsHistogramQuery,
+		Types.GetErrorsHistogramQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorsHistogramQuery,
+		Types.GetErrorsHistogramQueryVariables
+	>(GetErrorsHistogramDocument, baseOptions)
 }
-    `;
+export function useGetErrorsHistogramLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorsHistogramQuery,
+		Types.GetErrorsHistogramQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorsHistogramQuery,
+		Types.GetErrorsHistogramQueryVariables
+	>(GetErrorsHistogramDocument, baseOptions)
+}
+export type GetErrorsHistogramQueryHookResult = ReturnType<
+	typeof useGetErrorsHistogramQuery
+>
+export type GetErrorsHistogramLazyQueryHookResult = ReturnType<
+	typeof useGetErrorsHistogramLazyQuery
+>
+export type GetErrorsHistogramQueryResult = Apollo.QueryResult<
+	Types.GetErrorsHistogramQuery,
+	Types.GetErrorsHistogramQueryVariables
+>
+export const GetProjectsDocument = gql`
+	query GetProjects {
+		projects {
+			id
+			name
+			workspace_id
+		}
+	}
+`
 
 /**
  * __useGetProjectsQuery__
@@ -4671,31 +7058,52 @@ export const GetProjectsDocument = gql`
  *   },
  * });
  */
-export function useGetProjectsQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetProjectsQuery, Types.GetProjectsQueryVariables>) {
-        return Apollo.useQuery<Types.GetProjectsQuery, Types.GetProjectsQueryVariables>(GetProjectsDocument, baseOptions);
-      }
-export function useGetProjectsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectsQuery, Types.GetProjectsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetProjectsQuery, Types.GetProjectsQueryVariables>(GetProjectsDocument, baseOptions);
-        }
-export type GetProjectsQueryHookResult = ReturnType<typeof useGetProjectsQuery>;
-export type GetProjectsLazyQueryHookResult = ReturnType<typeof useGetProjectsLazyQuery>;
-export type GetProjectsQueryResult = Apollo.QueryResult<Types.GetProjectsQuery, Types.GetProjectsQueryVariables>;
-export const GetWorkspaceDocument = gql`
-    query GetWorkspace($id: ID!) {
-  workspace(id: $id) {
-    id
-    name
-    secret
-    plan_tier
-    unlimited_members
-    clearbit_enabled
-    projects {
-      id
-      name
-    }
-  }
+export function useGetProjectsQuery(
+	baseOptions?: Apollo.QueryHookOptions<
+		Types.GetProjectsQuery,
+		Types.GetProjectsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetProjectsQuery,
+		Types.GetProjectsQueryVariables
+	>(GetProjectsDocument, baseOptions)
 }
-    `;
+export function useGetProjectsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetProjectsQuery,
+		Types.GetProjectsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetProjectsQuery,
+		Types.GetProjectsQueryVariables
+	>(GetProjectsDocument, baseOptions)
+}
+export type GetProjectsQueryHookResult = ReturnType<typeof useGetProjectsQuery>
+export type GetProjectsLazyQueryHookResult = ReturnType<
+	typeof useGetProjectsLazyQuery
+>
+export type GetProjectsQueryResult = Apollo.QueryResult<
+	Types.GetProjectsQuery,
+	Types.GetProjectsQueryVariables
+>
+export const GetWorkspaceDocument = gql`
+	query GetWorkspace($id: ID!) {
+		workspace(id: $id) {
+			id
+			name
+			secret
+			plan_tier
+			unlimited_members
+			clearbit_enabled
+			projects {
+				id
+				name
+			}
+		}
+	}
+`
 
 /**
  * __useGetWorkspaceQuery__
@@ -4713,27 +7121,50 @@ export const GetWorkspaceDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceQuery, Types.GetWorkspaceQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspaceQuery, Types.GetWorkspaceQueryVariables>(GetWorkspaceDocument, baseOptions);
-      }
-export function useGetWorkspaceLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceQuery, Types.GetWorkspaceQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspaceQuery, Types.GetWorkspaceQueryVariables>(GetWorkspaceDocument, baseOptions);
-        }
-export type GetWorkspaceQueryHookResult = ReturnType<typeof useGetWorkspaceQuery>;
-export type GetWorkspaceLazyQueryHookResult = ReturnType<typeof useGetWorkspaceLazyQuery>;
-export type GetWorkspaceQueryResult = Apollo.QueryResult<Types.GetWorkspaceQuery, Types.GetWorkspaceQueryVariables>;
-export const GetWorkspaceForInviteLinkDocument = gql`
-    query GetWorkspaceForInviteLink($secret: String!) {
-  workspace_for_invite_link(secret: $secret) {
-    expiration_date
-    existing_account
-    invitee_email
-    secret
-    workspace_id
-    workspace_name
-  }
+export function useGetWorkspaceQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceQuery,
+		Types.GetWorkspaceQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceQuery,
+		Types.GetWorkspaceQueryVariables
+	>(GetWorkspaceDocument, baseOptions)
 }
-    `;
+export function useGetWorkspaceLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceQuery,
+		Types.GetWorkspaceQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceQuery,
+		Types.GetWorkspaceQueryVariables
+	>(GetWorkspaceDocument, baseOptions)
+}
+export type GetWorkspaceQueryHookResult = ReturnType<
+	typeof useGetWorkspaceQuery
+>
+export type GetWorkspaceLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceLazyQuery
+>
+export type GetWorkspaceQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceQuery,
+	Types.GetWorkspaceQueryVariables
+>
+export const GetWorkspaceForInviteLinkDocument = gql`
+	query GetWorkspaceForInviteLink($secret: String!) {
+		workspace_for_invite_link(secret: $secret) {
+			expiration_date
+			existing_account
+			invitee_email
+			secret
+			workspace_id
+			workspace_name
+		}
+	}
+`
 
 /**
  * __useGetWorkspaceForInviteLinkQuery__
@@ -4751,30 +7182,53 @@ export const GetWorkspaceForInviteLinkDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceForInviteLinkQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceForInviteLinkQuery, Types.GetWorkspaceForInviteLinkQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspaceForInviteLinkQuery, Types.GetWorkspaceForInviteLinkQueryVariables>(GetWorkspaceForInviteLinkDocument, baseOptions);
-      }
-export function useGetWorkspaceForInviteLinkLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceForInviteLinkQuery, Types.GetWorkspaceForInviteLinkQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspaceForInviteLinkQuery, Types.GetWorkspaceForInviteLinkQueryVariables>(GetWorkspaceForInviteLinkDocument, baseOptions);
-        }
-export type GetWorkspaceForInviteLinkQueryHookResult = ReturnType<typeof useGetWorkspaceForInviteLinkQuery>;
-export type GetWorkspaceForInviteLinkLazyQueryHookResult = ReturnType<typeof useGetWorkspaceForInviteLinkLazyQuery>;
-export type GetWorkspaceForInviteLinkQueryResult = Apollo.QueryResult<Types.GetWorkspaceForInviteLinkQuery, Types.GetWorkspaceForInviteLinkQueryVariables>;
-export const GetWorkspacesDocument = gql`
-    query GetWorkspaces {
-  workspaces {
-    id
-    name
-  }
-  joinable_workspaces {
-    id
-    name
-    projects {
-      id
-    }
-  }
+export function useGetWorkspaceForInviteLinkQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceForInviteLinkQuery,
+		Types.GetWorkspaceForInviteLinkQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceForInviteLinkQuery,
+		Types.GetWorkspaceForInviteLinkQueryVariables
+	>(GetWorkspaceForInviteLinkDocument, baseOptions)
 }
-    `;
+export function useGetWorkspaceForInviteLinkLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceForInviteLinkQuery,
+		Types.GetWorkspaceForInviteLinkQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceForInviteLinkQuery,
+		Types.GetWorkspaceForInviteLinkQueryVariables
+	>(GetWorkspaceForInviteLinkDocument, baseOptions)
+}
+export type GetWorkspaceForInviteLinkQueryHookResult = ReturnType<
+	typeof useGetWorkspaceForInviteLinkQuery
+>
+export type GetWorkspaceForInviteLinkLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceForInviteLinkLazyQuery
+>
+export type GetWorkspaceForInviteLinkQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceForInviteLinkQuery,
+	Types.GetWorkspaceForInviteLinkQueryVariables
+>
+export const GetWorkspacesDocument = gql`
+	query GetWorkspaces {
+		workspaces {
+			id
+			name
+		}
+		joinable_workspaces {
+			id
+			name
+			projects {
+				id
+			}
+		}
+	}
+`
 
 /**
  * __useGetWorkspacesQuery__
@@ -4791,20 +7245,43 @@ export const GetWorkspacesDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspacesQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetWorkspacesQuery, Types.GetWorkspacesQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspacesQuery, Types.GetWorkspacesQueryVariables>(GetWorkspacesDocument, baseOptions);
-      }
-export function useGetWorkspacesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspacesQuery, Types.GetWorkspacesQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspacesQuery, Types.GetWorkspacesQueryVariables>(GetWorkspacesDocument, baseOptions);
-        }
-export type GetWorkspacesQueryHookResult = ReturnType<typeof useGetWorkspacesQuery>;
-export type GetWorkspacesLazyQueryHookResult = ReturnType<typeof useGetWorkspacesLazyQuery>;
-export type GetWorkspacesQueryResult = Apollo.QueryResult<Types.GetWorkspacesQuery, Types.GetWorkspacesQueryVariables>;
-export const GetWorkspacesCountDocument = gql`
-    query GetWorkspacesCount {
-  workspaces_count
+export function useGetWorkspacesQuery(
+	baseOptions?: Apollo.QueryHookOptions<
+		Types.GetWorkspacesQuery,
+		Types.GetWorkspacesQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspacesQuery,
+		Types.GetWorkspacesQueryVariables
+	>(GetWorkspacesDocument, baseOptions)
 }
-    `;
+export function useGetWorkspacesLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspacesQuery,
+		Types.GetWorkspacesQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspacesQuery,
+		Types.GetWorkspacesQueryVariables
+	>(GetWorkspacesDocument, baseOptions)
+}
+export type GetWorkspacesQueryHookResult = ReturnType<
+	typeof useGetWorkspacesQuery
+>
+export type GetWorkspacesLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspacesLazyQuery
+>
+export type GetWorkspacesQueryResult = Apollo.QueryResult<
+	Types.GetWorkspacesQuery,
+	Types.GetWorkspacesQueryVariables
+>
+export const GetWorkspacesCountDocument = gql`
+	query GetWorkspacesCount {
+		workspaces_count
+	}
+`
 
 /**
  * __useGetWorkspacesCountQuery__
@@ -4821,27 +7298,50 @@ export const GetWorkspacesCountDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspacesCountQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetWorkspacesCountQuery, Types.GetWorkspacesCountQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspacesCountQuery, Types.GetWorkspacesCountQueryVariables>(GetWorkspacesCountDocument, baseOptions);
-      }
-export function useGetWorkspacesCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspacesCountQuery, Types.GetWorkspacesCountQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspacesCountQuery, Types.GetWorkspacesCountQueryVariables>(GetWorkspacesCountDocument, baseOptions);
-        }
-export type GetWorkspacesCountQueryHookResult = ReturnType<typeof useGetWorkspacesCountQuery>;
-export type GetWorkspacesCountLazyQueryHookResult = ReturnType<typeof useGetWorkspacesCountLazyQuery>;
-export type GetWorkspacesCountQueryResult = Apollo.QueryResult<Types.GetWorkspacesCountQuery, Types.GetWorkspacesCountQueryVariables>;
-export const GetProjectsAndWorkspacesDocument = gql`
-    query GetProjectsAndWorkspaces {
-  projects {
-    id
-    name
-  }
-  workspaces {
-    id
-    name
-  }
+export function useGetWorkspacesCountQuery(
+	baseOptions?: Apollo.QueryHookOptions<
+		Types.GetWorkspacesCountQuery,
+		Types.GetWorkspacesCountQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspacesCountQuery,
+		Types.GetWorkspacesCountQueryVariables
+	>(GetWorkspacesCountDocument, baseOptions)
 }
-    `;
+export function useGetWorkspacesCountLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspacesCountQuery,
+		Types.GetWorkspacesCountQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspacesCountQuery,
+		Types.GetWorkspacesCountQueryVariables
+	>(GetWorkspacesCountDocument, baseOptions)
+}
+export type GetWorkspacesCountQueryHookResult = ReturnType<
+	typeof useGetWorkspacesCountQuery
+>
+export type GetWorkspacesCountLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspacesCountLazyQuery
+>
+export type GetWorkspacesCountQueryResult = Apollo.QueryResult<
+	Types.GetWorkspacesCountQuery,
+	Types.GetWorkspacesCountQueryVariables
+>
+export const GetProjectsAndWorkspacesDocument = gql`
+	query GetProjectsAndWorkspaces {
+		projects {
+			id
+			name
+		}
+		workspaces {
+			id
+			name
+		}
+	}
+`
 
 /**
  * __useGetProjectsAndWorkspacesQuery__
@@ -4858,28 +7358,55 @@ export const GetProjectsAndWorkspacesDocument = gql`
  *   },
  * });
  */
-export function useGetProjectsAndWorkspacesQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetProjectsAndWorkspacesQuery, Types.GetProjectsAndWorkspacesQueryVariables>) {
-        return Apollo.useQuery<Types.GetProjectsAndWorkspacesQuery, Types.GetProjectsAndWorkspacesQueryVariables>(GetProjectsAndWorkspacesDocument, baseOptions);
-      }
-export function useGetProjectsAndWorkspacesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectsAndWorkspacesQuery, Types.GetProjectsAndWorkspacesQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetProjectsAndWorkspacesQuery, Types.GetProjectsAndWorkspacesQueryVariables>(GetProjectsAndWorkspacesDocument, baseOptions);
-        }
-export type GetProjectsAndWorkspacesQueryHookResult = ReturnType<typeof useGetProjectsAndWorkspacesQuery>;
-export type GetProjectsAndWorkspacesLazyQueryHookResult = ReturnType<typeof useGetProjectsAndWorkspacesLazyQuery>;
-export type GetProjectsAndWorkspacesQueryResult = Apollo.QueryResult<Types.GetProjectsAndWorkspacesQuery, Types.GetProjectsAndWorkspacesQueryVariables>;
-export const GetProjectOrWorkspaceDocument = gql`
-    query GetProjectOrWorkspace($project_id: ID!, $workspace_id: ID!, $is_workspace: Boolean!) {
-  project(id: $project_id) @skip(if: $is_workspace) {
-    id
-    name
-    billing_email
-  }
-  workspace(id: $workspace_id) @include(if: $is_workspace) {
-    id
-    name
-  }
+export function useGetProjectsAndWorkspacesQuery(
+	baseOptions?: Apollo.QueryHookOptions<
+		Types.GetProjectsAndWorkspacesQuery,
+		Types.GetProjectsAndWorkspacesQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetProjectsAndWorkspacesQuery,
+		Types.GetProjectsAndWorkspacesQueryVariables
+	>(GetProjectsAndWorkspacesDocument, baseOptions)
 }
-    `;
+export function useGetProjectsAndWorkspacesLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetProjectsAndWorkspacesQuery,
+		Types.GetProjectsAndWorkspacesQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetProjectsAndWorkspacesQuery,
+		Types.GetProjectsAndWorkspacesQueryVariables
+	>(GetProjectsAndWorkspacesDocument, baseOptions)
+}
+export type GetProjectsAndWorkspacesQueryHookResult = ReturnType<
+	typeof useGetProjectsAndWorkspacesQuery
+>
+export type GetProjectsAndWorkspacesLazyQueryHookResult = ReturnType<
+	typeof useGetProjectsAndWorkspacesLazyQuery
+>
+export type GetProjectsAndWorkspacesQueryResult = Apollo.QueryResult<
+	Types.GetProjectsAndWorkspacesQuery,
+	Types.GetProjectsAndWorkspacesQueryVariables
+>
+export const GetProjectOrWorkspaceDocument = gql`
+	query GetProjectOrWorkspace(
+		$project_id: ID!
+		$workspace_id: ID!
+		$is_workspace: Boolean!
+	) {
+		project(id: $project_id) @skip(if: $is_workspace) {
+			id
+			name
+			billing_email
+		}
+		workspace(id: $workspace_id) @include(if: $is_workspace) {
+			id
+			name
+		}
+	}
+`
 
 /**
  * __useGetProjectOrWorkspaceQuery__
@@ -4899,47 +7426,70 @@ export const GetProjectOrWorkspaceDocument = gql`
  *   },
  * });
  */
-export function useGetProjectOrWorkspaceQuery(baseOptions: Apollo.QueryHookOptions<Types.GetProjectOrWorkspaceQuery, Types.GetProjectOrWorkspaceQueryVariables>) {
-        return Apollo.useQuery<Types.GetProjectOrWorkspaceQuery, Types.GetProjectOrWorkspaceQueryVariables>(GetProjectOrWorkspaceDocument, baseOptions);
-      }
-export function useGetProjectOrWorkspaceLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectOrWorkspaceQuery, Types.GetProjectOrWorkspaceQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetProjectOrWorkspaceQuery, Types.GetProjectOrWorkspaceQueryVariables>(GetProjectOrWorkspaceDocument, baseOptions);
-        }
-export type GetProjectOrWorkspaceQueryHookResult = ReturnType<typeof useGetProjectOrWorkspaceQuery>;
-export type GetProjectOrWorkspaceLazyQueryHookResult = ReturnType<typeof useGetProjectOrWorkspaceLazyQuery>;
-export type GetProjectOrWorkspaceQueryResult = Apollo.QueryResult<Types.GetProjectOrWorkspaceQuery, Types.GetProjectOrWorkspaceQueryVariables>;
-export const GetProjectDropdownOptionsDocument = gql`
-    query GetProjectDropdownOptions($project_id: ID!) {
-  project(id: $project_id) {
-    id
-    name
-    verbose_id
-    billing_email
-    secret
-    workspace_id
-    error_filters
-  }
-  workspace: workspace_for_project(project_id: $project_id) {
-    id
-    name
-    projects {
-      id
-      name
-    }
-  }
-  workspaces {
-    id
-    name
-  }
-  joinable_workspaces {
-    id
-    name
-    projects {
-      id
-    }
-  }
+export function useGetProjectOrWorkspaceQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetProjectOrWorkspaceQuery,
+		Types.GetProjectOrWorkspaceQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetProjectOrWorkspaceQuery,
+		Types.GetProjectOrWorkspaceQueryVariables
+	>(GetProjectOrWorkspaceDocument, baseOptions)
 }
-    `;
+export function useGetProjectOrWorkspaceLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetProjectOrWorkspaceQuery,
+		Types.GetProjectOrWorkspaceQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetProjectOrWorkspaceQuery,
+		Types.GetProjectOrWorkspaceQueryVariables
+	>(GetProjectOrWorkspaceDocument, baseOptions)
+}
+export type GetProjectOrWorkspaceQueryHookResult = ReturnType<
+	typeof useGetProjectOrWorkspaceQuery
+>
+export type GetProjectOrWorkspaceLazyQueryHookResult = ReturnType<
+	typeof useGetProjectOrWorkspaceLazyQuery
+>
+export type GetProjectOrWorkspaceQueryResult = Apollo.QueryResult<
+	Types.GetProjectOrWorkspaceQuery,
+	Types.GetProjectOrWorkspaceQueryVariables
+>
+export const GetProjectDropdownOptionsDocument = gql`
+	query GetProjectDropdownOptions($project_id: ID!) {
+		project(id: $project_id) {
+			id
+			name
+			verbose_id
+			billing_email
+			secret
+			workspace_id
+			error_filters
+		}
+		workspace: workspace_for_project(project_id: $project_id) {
+			id
+			name
+			projects {
+				id
+				name
+			}
+		}
+		workspaces {
+			id
+			name
+		}
+		joinable_workspaces {
+			id
+			name
+			projects {
+				id
+			}
+		}
+	}
+`
 
 /**
  * __useGetProjectDropdownOptionsQuery__
@@ -4957,38 +7507,61 @@ export const GetProjectDropdownOptionsDocument = gql`
  *   },
  * });
  */
-export function useGetProjectDropdownOptionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetProjectDropdownOptionsQuery, Types.GetProjectDropdownOptionsQueryVariables>) {
-        return Apollo.useQuery<Types.GetProjectDropdownOptionsQuery, Types.GetProjectDropdownOptionsQueryVariables>(GetProjectDropdownOptionsDocument, baseOptions);
-      }
-export function useGetProjectDropdownOptionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectDropdownOptionsQuery, Types.GetProjectDropdownOptionsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetProjectDropdownOptionsQuery, Types.GetProjectDropdownOptionsQueryVariables>(GetProjectDropdownOptionsDocument, baseOptions);
-        }
-export type GetProjectDropdownOptionsQueryHookResult = ReturnType<typeof useGetProjectDropdownOptionsQuery>;
-export type GetProjectDropdownOptionsLazyQueryHookResult = ReturnType<typeof useGetProjectDropdownOptionsLazyQuery>;
-export type GetProjectDropdownOptionsQueryResult = Apollo.QueryResult<Types.GetProjectDropdownOptionsQuery, Types.GetProjectDropdownOptionsQueryVariables>;
-export const GetWorkspaceDropdownOptionsDocument = gql`
-    query GetWorkspaceDropdownOptions($workspace_id: ID!) {
-  workspace(id: $workspace_id) {
-    id
-    name
-    projects {
-      id
-      name
-    }
-  }
-  workspaces {
-    id
-    name
-  }
-  joinable_workspaces {
-    id
-    name
-    projects {
-      id
-    }
-  }
+export function useGetProjectDropdownOptionsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetProjectDropdownOptionsQuery,
+		Types.GetProjectDropdownOptionsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetProjectDropdownOptionsQuery,
+		Types.GetProjectDropdownOptionsQueryVariables
+	>(GetProjectDropdownOptionsDocument, baseOptions)
 }
-    `;
+export function useGetProjectDropdownOptionsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetProjectDropdownOptionsQuery,
+		Types.GetProjectDropdownOptionsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetProjectDropdownOptionsQuery,
+		Types.GetProjectDropdownOptionsQueryVariables
+	>(GetProjectDropdownOptionsDocument, baseOptions)
+}
+export type GetProjectDropdownOptionsQueryHookResult = ReturnType<
+	typeof useGetProjectDropdownOptionsQuery
+>
+export type GetProjectDropdownOptionsLazyQueryHookResult = ReturnType<
+	typeof useGetProjectDropdownOptionsLazyQuery
+>
+export type GetProjectDropdownOptionsQueryResult = Apollo.QueryResult<
+	Types.GetProjectDropdownOptionsQuery,
+	Types.GetProjectDropdownOptionsQueryVariables
+>
+export const GetWorkspaceDropdownOptionsDocument = gql`
+	query GetWorkspaceDropdownOptions($workspace_id: ID!) {
+		workspace(id: $workspace_id) {
+			id
+			name
+			projects {
+				id
+				name
+			}
+		}
+		workspaces {
+			id
+			name
+		}
+		joinable_workspaces {
+			id
+			name
+			projects {
+				id
+			}
+		}
+	}
+`
 
 /**
  * __useGetWorkspaceDropdownOptionsQuery__
@@ -5006,31 +7579,54 @@ export const GetWorkspaceDropdownOptionsDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceDropdownOptionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceDropdownOptionsQuery, Types.GetWorkspaceDropdownOptionsQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspaceDropdownOptionsQuery, Types.GetWorkspaceDropdownOptionsQueryVariables>(GetWorkspaceDropdownOptionsDocument, baseOptions);
-      }
-export function useGetWorkspaceDropdownOptionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceDropdownOptionsQuery, Types.GetWorkspaceDropdownOptionsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspaceDropdownOptionsQuery, Types.GetWorkspaceDropdownOptionsQueryVariables>(GetWorkspaceDropdownOptionsDocument, baseOptions);
-        }
-export type GetWorkspaceDropdownOptionsQueryHookResult = ReturnType<typeof useGetWorkspaceDropdownOptionsQuery>;
-export type GetWorkspaceDropdownOptionsLazyQueryHookResult = ReturnType<typeof useGetWorkspaceDropdownOptionsLazyQuery>;
-export type GetWorkspaceDropdownOptionsQueryResult = Apollo.QueryResult<Types.GetWorkspaceDropdownOptionsQuery, Types.GetWorkspaceDropdownOptionsQueryVariables>;
-export const GetAdminDocument = gql`
-    query GetAdmin {
-  admin {
-    id
-    uid
-    name
-    email
-    phone
-    photo_url
-    slack_im_channel_id
-    email_verified
-    user_defined_role
-    about_you_details_filled
-  }
+export function useGetWorkspaceDropdownOptionsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceDropdownOptionsQuery,
+		Types.GetWorkspaceDropdownOptionsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceDropdownOptionsQuery,
+		Types.GetWorkspaceDropdownOptionsQueryVariables
+	>(GetWorkspaceDropdownOptionsDocument, baseOptions)
 }
-    `;
+export function useGetWorkspaceDropdownOptionsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceDropdownOptionsQuery,
+		Types.GetWorkspaceDropdownOptionsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceDropdownOptionsQuery,
+		Types.GetWorkspaceDropdownOptionsQueryVariables
+	>(GetWorkspaceDropdownOptionsDocument, baseOptions)
+}
+export type GetWorkspaceDropdownOptionsQueryHookResult = ReturnType<
+	typeof useGetWorkspaceDropdownOptionsQuery
+>
+export type GetWorkspaceDropdownOptionsLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceDropdownOptionsLazyQuery
+>
+export type GetWorkspaceDropdownOptionsQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceDropdownOptionsQuery,
+	Types.GetWorkspaceDropdownOptionsQueryVariables
+>
+export const GetAdminDocument = gql`
+	query GetAdmin {
+		admin {
+			id
+			uid
+			name
+			email
+			phone
+			photo_url
+			slack_im_channel_id
+			email_verified
+			user_defined_role
+			about_you_details_filled
+		}
+	}
+`
 
 /**
  * __useGetAdminQuery__
@@ -5047,34 +7643,55 @@ export const GetAdminDocument = gql`
  *   },
  * });
  */
-export function useGetAdminQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetAdminQuery, Types.GetAdminQueryVariables>) {
-        return Apollo.useQuery<Types.GetAdminQuery, Types.GetAdminQueryVariables>(GetAdminDocument, baseOptions);
-      }
-export function useGetAdminLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAdminQuery, Types.GetAdminQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetAdminQuery, Types.GetAdminQueryVariables>(GetAdminDocument, baseOptions);
-        }
-export type GetAdminQueryHookResult = ReturnType<typeof useGetAdminQuery>;
-export type GetAdminLazyQueryHookResult = ReturnType<typeof useGetAdminLazyQuery>;
-export type GetAdminQueryResult = Apollo.QueryResult<Types.GetAdminQuery, Types.GetAdminQueryVariables>;
-export const GetAdminRoleDocument = gql`
-    query GetAdminRole($workspace_id: ID!) {
-  admin_role(workspace_id: $workspace_id) {
-    admin {
-      id
-      uid
-      name
-      email
-      phone
-      photo_url
-      slack_im_channel_id
-      email_verified
-      user_defined_role
-      about_you_details_filled
-    }
-    role
-  }
+export function useGetAdminQuery(
+	baseOptions?: Apollo.QueryHookOptions<
+		Types.GetAdminQuery,
+		Types.GetAdminQueryVariables
+	>,
+) {
+	return Apollo.useQuery<Types.GetAdminQuery, Types.GetAdminQueryVariables>(
+		GetAdminDocument,
+		baseOptions,
+	)
 }
-    `;
+export function useGetAdminLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetAdminQuery,
+		Types.GetAdminQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetAdminQuery,
+		Types.GetAdminQueryVariables
+	>(GetAdminDocument, baseOptions)
+}
+export type GetAdminQueryHookResult = ReturnType<typeof useGetAdminQuery>
+export type GetAdminLazyQueryHookResult = ReturnType<
+	typeof useGetAdminLazyQuery
+>
+export type GetAdminQueryResult = Apollo.QueryResult<
+	Types.GetAdminQuery,
+	Types.GetAdminQueryVariables
+>
+export const GetAdminRoleDocument = gql`
+	query GetAdminRole($workspace_id: ID!) {
+		admin_role(workspace_id: $workspace_id) {
+			admin {
+				id
+				uid
+				name
+				email
+				phone
+				photo_url
+				slack_im_channel_id
+				email_verified
+				user_defined_role
+				about_you_details_filled
+			}
+			role
+		}
+	}
+`
 
 /**
  * __useGetAdminRoleQuery__
@@ -5092,34 +7709,57 @@ export const GetAdminRoleDocument = gql`
  *   },
  * });
  */
-export function useGetAdminRoleQuery(baseOptions: Apollo.QueryHookOptions<Types.GetAdminRoleQuery, Types.GetAdminRoleQueryVariables>) {
-        return Apollo.useQuery<Types.GetAdminRoleQuery, Types.GetAdminRoleQueryVariables>(GetAdminRoleDocument, baseOptions);
-      }
-export function useGetAdminRoleLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAdminRoleQuery, Types.GetAdminRoleQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetAdminRoleQuery, Types.GetAdminRoleQueryVariables>(GetAdminRoleDocument, baseOptions);
-        }
-export type GetAdminRoleQueryHookResult = ReturnType<typeof useGetAdminRoleQuery>;
-export type GetAdminRoleLazyQueryHookResult = ReturnType<typeof useGetAdminRoleLazyQuery>;
-export type GetAdminRoleQueryResult = Apollo.QueryResult<Types.GetAdminRoleQuery, Types.GetAdminRoleQueryVariables>;
-export const GetAdminRoleByProjectDocument = gql`
-    query GetAdminRoleByProject($project_id: ID!) {
-  admin_role_by_project(project_id: $project_id) {
-    admin {
-      id
-      uid
-      name
-      email
-      phone
-      photo_url
-      slack_im_channel_id
-      email_verified
-      user_defined_role
-      about_you_details_filled
-    }
-    role
-  }
+export function useGetAdminRoleQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetAdminRoleQuery,
+		Types.GetAdminRoleQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetAdminRoleQuery,
+		Types.GetAdminRoleQueryVariables
+	>(GetAdminRoleDocument, baseOptions)
 }
-    `;
+export function useGetAdminRoleLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetAdminRoleQuery,
+		Types.GetAdminRoleQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetAdminRoleQuery,
+		Types.GetAdminRoleQueryVariables
+	>(GetAdminRoleDocument, baseOptions)
+}
+export type GetAdminRoleQueryHookResult = ReturnType<
+	typeof useGetAdminRoleQuery
+>
+export type GetAdminRoleLazyQueryHookResult = ReturnType<
+	typeof useGetAdminRoleLazyQuery
+>
+export type GetAdminRoleQueryResult = Apollo.QueryResult<
+	Types.GetAdminRoleQuery,
+	Types.GetAdminRoleQueryVariables
+>
+export const GetAdminRoleByProjectDocument = gql`
+	query GetAdminRoleByProject($project_id: ID!) {
+		admin_role_by_project(project_id: $project_id) {
+			admin {
+				id
+				uid
+				name
+				email
+				phone
+				photo_url
+				slack_im_channel_id
+				email_verified
+				user_defined_role
+				about_you_details_filled
+			}
+			role
+		}
+	}
+`
 
 /**
  * __useGetAdminRoleByProjectQuery__
@@ -5137,25 +7777,48 @@ export const GetAdminRoleByProjectDocument = gql`
  *   },
  * });
  */
-export function useGetAdminRoleByProjectQuery(baseOptions: Apollo.QueryHookOptions<Types.GetAdminRoleByProjectQuery, Types.GetAdminRoleByProjectQueryVariables>) {
-        return Apollo.useQuery<Types.GetAdminRoleByProjectQuery, Types.GetAdminRoleByProjectQueryVariables>(GetAdminRoleByProjectDocument, baseOptions);
-      }
-export function useGetAdminRoleByProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAdminRoleByProjectQuery, Types.GetAdminRoleByProjectQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetAdminRoleByProjectQuery, Types.GetAdminRoleByProjectQueryVariables>(GetAdminRoleByProjectDocument, baseOptions);
-        }
-export type GetAdminRoleByProjectQueryHookResult = ReturnType<typeof useGetAdminRoleByProjectQuery>;
-export type GetAdminRoleByProjectLazyQueryHookResult = ReturnType<typeof useGetAdminRoleByProjectLazyQuery>;
-export type GetAdminRoleByProjectQueryResult = Apollo.QueryResult<Types.GetAdminRoleByProjectQuery, Types.GetAdminRoleByProjectQueryVariables>;
-export const GetAdminAboutYouDocument = gql`
-    query GetAdminAboutYou {
-  admin {
-    id
-    name
-    user_defined_role
-    referral
-  }
+export function useGetAdminRoleByProjectQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetAdminRoleByProjectQuery,
+		Types.GetAdminRoleByProjectQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetAdminRoleByProjectQuery,
+		Types.GetAdminRoleByProjectQueryVariables
+	>(GetAdminRoleByProjectDocument, baseOptions)
 }
-    `;
+export function useGetAdminRoleByProjectLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetAdminRoleByProjectQuery,
+		Types.GetAdminRoleByProjectQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetAdminRoleByProjectQuery,
+		Types.GetAdminRoleByProjectQueryVariables
+	>(GetAdminRoleByProjectDocument, baseOptions)
+}
+export type GetAdminRoleByProjectQueryHookResult = ReturnType<
+	typeof useGetAdminRoleByProjectQuery
+>
+export type GetAdminRoleByProjectLazyQueryHookResult = ReturnType<
+	typeof useGetAdminRoleByProjectLazyQuery
+>
+export type GetAdminRoleByProjectQueryResult = Apollo.QueryResult<
+	Types.GetAdminRoleByProjectQuery,
+	Types.GetAdminRoleByProjectQueryVariables
+>
+export const GetAdminAboutYouDocument = gql`
+	query GetAdminAboutYou {
+		admin {
+			id
+			name
+			user_defined_role
+			referral
+		}
+	}
+`
 
 /**
  * __useGetAdminAboutYouQuery__
@@ -5172,38 +7835,61 @@ export const GetAdminAboutYouDocument = gql`
  *   },
  * });
  */
-export function useGetAdminAboutYouQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetAdminAboutYouQuery, Types.GetAdminAboutYouQueryVariables>) {
-        return Apollo.useQuery<Types.GetAdminAboutYouQuery, Types.GetAdminAboutYouQueryVariables>(GetAdminAboutYouDocument, baseOptions);
-      }
-export function useGetAdminAboutYouLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAdminAboutYouQuery, Types.GetAdminAboutYouQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetAdminAboutYouQuery, Types.GetAdminAboutYouQueryVariables>(GetAdminAboutYouDocument, baseOptions);
-        }
-export type GetAdminAboutYouQueryHookResult = ReturnType<typeof useGetAdminAboutYouQuery>;
-export type GetAdminAboutYouLazyQueryHookResult = ReturnType<typeof useGetAdminAboutYouLazyQuery>;
-export type GetAdminAboutYouQueryResult = Apollo.QueryResult<Types.GetAdminAboutYouQuery, Types.GetAdminAboutYouQueryVariables>;
-export const GetProjectDocument = gql`
-    query GetProject($id: ID!) {
-  project(id: $id) {
-    id
-    name
-    verbose_id
-    billing_email
-    excluded_users
-    error_filters
-    error_json_paths
-    filter_chrome_extension
-    rage_click_window_seconds
-    rage_click_radius_pixels
-    rage_click_count
-    backend_domains
-    secret
-  }
-  workspace: workspace_for_project(project_id: $id) {
-    id
-    slack_webhook_channel
-  }
+export function useGetAdminAboutYouQuery(
+	baseOptions?: Apollo.QueryHookOptions<
+		Types.GetAdminAboutYouQuery,
+		Types.GetAdminAboutYouQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetAdminAboutYouQuery,
+		Types.GetAdminAboutYouQueryVariables
+	>(GetAdminAboutYouDocument, baseOptions)
 }
-    `;
+export function useGetAdminAboutYouLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetAdminAboutYouQuery,
+		Types.GetAdminAboutYouQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetAdminAboutYouQuery,
+		Types.GetAdminAboutYouQueryVariables
+	>(GetAdminAboutYouDocument, baseOptions)
+}
+export type GetAdminAboutYouQueryHookResult = ReturnType<
+	typeof useGetAdminAboutYouQuery
+>
+export type GetAdminAboutYouLazyQueryHookResult = ReturnType<
+	typeof useGetAdminAboutYouLazyQuery
+>
+export type GetAdminAboutYouQueryResult = Apollo.QueryResult<
+	Types.GetAdminAboutYouQuery,
+	Types.GetAdminAboutYouQueryVariables
+>
+export const GetProjectDocument = gql`
+	query GetProject($id: ID!) {
+		project(id: $id) {
+			id
+			name
+			verbose_id
+			billing_email
+			excluded_users
+			error_filters
+			error_json_paths
+			filter_chrome_extension
+			rage_click_window_seconds
+			rage_click_radius_pixels
+			rage_click_count
+			backend_domains
+			secret
+		}
+		workspace: workspace_for_project(project_id: $id) {
+			id
+			slack_webhook_channel
+		}
+	}
+`
 
 /**
  * __useGetProjectQuery__
@@ -5221,45 +7907,66 @@ export const GetProjectDocument = gql`
  *   },
  * });
  */
-export function useGetProjectQuery(baseOptions: Apollo.QueryHookOptions<Types.GetProjectQuery, Types.GetProjectQueryVariables>) {
-        return Apollo.useQuery<Types.GetProjectQuery, Types.GetProjectQueryVariables>(GetProjectDocument, baseOptions);
-      }
-export function useGetProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectQuery, Types.GetProjectQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetProjectQuery, Types.GetProjectQueryVariables>(GetProjectDocument, baseOptions);
-        }
-export type GetProjectQueryHookResult = ReturnType<typeof useGetProjectQuery>;
-export type GetProjectLazyQueryHookResult = ReturnType<typeof useGetProjectLazyQuery>;
-export type GetProjectQueryResult = Apollo.QueryResult<Types.GetProjectQuery, Types.GetProjectQueryVariables>;
-export const GetBillingDetailsForProjectDocument = gql`
-    query GetBillingDetailsForProject($project_id: ID!) {
-  billingDetailsForProject(project_id: $project_id) {
-    plan {
-      type
-      quota
-      interval
-      membersLimit
-      errorsLimit
-      logsLimit
-    }
-    meter
-    membersMeter
-    errorsMeter
-    logsMeter
-    sessionsBillingLimit
-    errorsBillingLimit
-    logsBillingLimit
-  }
-  workspace_for_project(project_id: $project_id) {
-    id
-    trial_end_date
-    billing_period_end
-    next_invoice_date
-    allow_meter_overage
-    eligible_for_trial_extension
-    trial_extension_enabled
-  }
+export function useGetProjectQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetProjectQuery,
+		Types.GetProjectQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetProjectQuery,
+		Types.GetProjectQueryVariables
+	>(GetProjectDocument, baseOptions)
 }
-    `;
+export function useGetProjectLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetProjectQuery,
+		Types.GetProjectQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetProjectQuery,
+		Types.GetProjectQueryVariables
+	>(GetProjectDocument, baseOptions)
+}
+export type GetProjectQueryHookResult = ReturnType<typeof useGetProjectQuery>
+export type GetProjectLazyQueryHookResult = ReturnType<
+	typeof useGetProjectLazyQuery
+>
+export type GetProjectQueryResult = Apollo.QueryResult<
+	Types.GetProjectQuery,
+	Types.GetProjectQueryVariables
+>
+export const GetBillingDetailsForProjectDocument = gql`
+	query GetBillingDetailsForProject($project_id: ID!) {
+		billingDetailsForProject(project_id: $project_id) {
+			plan {
+				type
+				quota
+				interval
+				membersLimit
+				errorsLimit
+				logsLimit
+			}
+			meter
+			membersMeter
+			errorsMeter
+			logsMeter
+			sessionsBillingLimit
+			errorsBillingLimit
+			logsBillingLimit
+		}
+		workspace_for_project(project_id: $project_id) {
+			id
+			trial_end_date
+			billing_period_end
+			next_invoice_date
+			allow_meter_overage
+			eligible_for_trial_extension
+			trial_extension_enabled
+		}
+	}
+`
 
 /**
  * __useGetBillingDetailsForProjectQuery__
@@ -5277,65 +7984,88 @@ export const GetBillingDetailsForProjectDocument = gql`
  *   },
  * });
  */
-export function useGetBillingDetailsForProjectQuery(baseOptions: Apollo.QueryHookOptions<Types.GetBillingDetailsForProjectQuery, Types.GetBillingDetailsForProjectQueryVariables>) {
-        return Apollo.useQuery<Types.GetBillingDetailsForProjectQuery, Types.GetBillingDetailsForProjectQueryVariables>(GetBillingDetailsForProjectDocument, baseOptions);
-      }
-export function useGetBillingDetailsForProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetBillingDetailsForProjectQuery, Types.GetBillingDetailsForProjectQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetBillingDetailsForProjectQuery, Types.GetBillingDetailsForProjectQueryVariables>(GetBillingDetailsForProjectDocument, baseOptions);
-        }
-export type GetBillingDetailsForProjectQueryHookResult = ReturnType<typeof useGetBillingDetailsForProjectQuery>;
-export type GetBillingDetailsForProjectLazyQueryHookResult = ReturnType<typeof useGetBillingDetailsForProjectLazyQuery>;
-export type GetBillingDetailsForProjectQueryResult = Apollo.QueryResult<Types.GetBillingDetailsForProjectQuery, Types.GetBillingDetailsForProjectQueryVariables>;
-export const GetBillingDetailsDocument = gql`
-    query GetBillingDetails($workspace_id: ID!) {
-  billingDetails(workspace_id: $workspace_id) {
-    plan {
-      type
-      quota
-      interval
-      membersLimit
-      errorsLimit
-      logsLimit
-    }
-    meter
-    membersMeter
-    errorsMeter
-    logsMeter
-    sessionsBillingLimit
-    errorsBillingLimit
-    logsBillingLimit
-    sessionsDailyAverage
-    errorsDailyAverage
-    logsDailyAverage
-  }
-  subscription_details(workspace_id: $workspace_id) {
-    baseAmount
-    discountAmount
-    discountPercent
-    lastInvoice {
-      amountDue
-      amountPaid
-      attemptCount
-      date
-      url
-      status
-    }
-  }
-  workspace(id: $workspace_id) {
-    id
-    trial_end_date
-    billing_period_end
-    next_invoice_date
-    allow_meter_overage
-    eligible_for_trial_extension
-    retention_period
-    errors_retention_period
-    sessions_max_cents
-    errors_max_cents
-    logs_max_cents
-  }
+export function useGetBillingDetailsForProjectQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetBillingDetailsForProjectQuery,
+		Types.GetBillingDetailsForProjectQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetBillingDetailsForProjectQuery,
+		Types.GetBillingDetailsForProjectQueryVariables
+	>(GetBillingDetailsForProjectDocument, baseOptions)
 }
-    `;
+export function useGetBillingDetailsForProjectLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetBillingDetailsForProjectQuery,
+		Types.GetBillingDetailsForProjectQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetBillingDetailsForProjectQuery,
+		Types.GetBillingDetailsForProjectQueryVariables
+	>(GetBillingDetailsForProjectDocument, baseOptions)
+}
+export type GetBillingDetailsForProjectQueryHookResult = ReturnType<
+	typeof useGetBillingDetailsForProjectQuery
+>
+export type GetBillingDetailsForProjectLazyQueryHookResult = ReturnType<
+	typeof useGetBillingDetailsForProjectLazyQuery
+>
+export type GetBillingDetailsForProjectQueryResult = Apollo.QueryResult<
+	Types.GetBillingDetailsForProjectQuery,
+	Types.GetBillingDetailsForProjectQueryVariables
+>
+export const GetBillingDetailsDocument = gql`
+	query GetBillingDetails($workspace_id: ID!) {
+		billingDetails(workspace_id: $workspace_id) {
+			plan {
+				type
+				quota
+				interval
+				membersLimit
+				errorsLimit
+				logsLimit
+			}
+			meter
+			membersMeter
+			errorsMeter
+			logsMeter
+			sessionsBillingLimit
+			errorsBillingLimit
+			logsBillingLimit
+			sessionsDailyAverage
+			errorsDailyAverage
+			logsDailyAverage
+		}
+		subscription_details(workspace_id: $workspace_id) {
+			baseAmount
+			discountAmount
+			discountPercent
+			lastInvoice {
+				amountDue
+				amountPaid
+				attemptCount
+				date
+				url
+				status
+			}
+		}
+		workspace(id: $workspace_id) {
+			id
+			trial_end_date
+			billing_period_end
+			next_invoice_date
+			allow_meter_overage
+			eligible_for_trial_extension
+			retention_period
+			errors_retention_period
+			sessions_max_cents
+			errors_max_cents
+			logs_max_cents
+		}
+	}
+`
 
 /**
  * __useGetBillingDetailsQuery__
@@ -5353,32 +8083,55 @@ export const GetBillingDetailsDocument = gql`
  *   },
  * });
  */
-export function useGetBillingDetailsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetBillingDetailsQuery, Types.GetBillingDetailsQueryVariables>) {
-        return Apollo.useQuery<Types.GetBillingDetailsQuery, Types.GetBillingDetailsQueryVariables>(GetBillingDetailsDocument, baseOptions);
-      }
-export function useGetBillingDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetBillingDetailsQuery, Types.GetBillingDetailsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetBillingDetailsQuery, Types.GetBillingDetailsQueryVariables>(GetBillingDetailsDocument, baseOptions);
-        }
-export type GetBillingDetailsQueryHookResult = ReturnType<typeof useGetBillingDetailsQuery>;
-export type GetBillingDetailsLazyQueryHookResult = ReturnType<typeof useGetBillingDetailsLazyQuery>;
-export type GetBillingDetailsQueryResult = Apollo.QueryResult<Types.GetBillingDetailsQuery, Types.GetBillingDetailsQueryVariables>;
-export const GetSubscriptionDetailsDocument = gql`
-    query GetSubscriptionDetails($workspace_id: ID!) {
-  subscription_details(workspace_id: $workspace_id) {
-    baseAmount
-    discountAmount
-    discountPercent
-    lastInvoice {
-      amountDue
-      amountPaid
-      attemptCount
-      date
-      url
-      status
-    }
-  }
+export function useGetBillingDetailsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetBillingDetailsQuery,
+		Types.GetBillingDetailsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetBillingDetailsQuery,
+		Types.GetBillingDetailsQueryVariables
+	>(GetBillingDetailsDocument, baseOptions)
 }
-    `;
+export function useGetBillingDetailsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetBillingDetailsQuery,
+		Types.GetBillingDetailsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetBillingDetailsQuery,
+		Types.GetBillingDetailsQueryVariables
+	>(GetBillingDetailsDocument, baseOptions)
+}
+export type GetBillingDetailsQueryHookResult = ReturnType<
+	typeof useGetBillingDetailsQuery
+>
+export type GetBillingDetailsLazyQueryHookResult = ReturnType<
+	typeof useGetBillingDetailsLazyQuery
+>
+export type GetBillingDetailsQueryResult = Apollo.QueryResult<
+	Types.GetBillingDetailsQuery,
+	Types.GetBillingDetailsQueryVariables
+>
+export const GetSubscriptionDetailsDocument = gql`
+	query GetSubscriptionDetails($workspace_id: ID!) {
+		subscription_details(workspace_id: $workspace_id) {
+			baseAmount
+			discountAmount
+			discountPercent
+			lastInvoice {
+				amountDue
+				amountPaid
+				attemptCount
+				date
+				url
+				status
+			}
+		}
+	}
+`
 
 /**
  * __useGetSubscriptionDetailsQuery__
@@ -5396,56 +8149,79 @@ export const GetSubscriptionDetailsDocument = gql`
  *   },
  * });
  */
-export function useGetSubscriptionDetailsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSubscriptionDetailsQuery, Types.GetSubscriptionDetailsQueryVariables>) {
-        return Apollo.useQuery<Types.GetSubscriptionDetailsQuery, Types.GetSubscriptionDetailsQueryVariables>(GetSubscriptionDetailsDocument, baseOptions);
-      }
-export function useGetSubscriptionDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSubscriptionDetailsQuery, Types.GetSubscriptionDetailsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSubscriptionDetailsQuery, Types.GetSubscriptionDetailsQueryVariables>(GetSubscriptionDetailsDocument, baseOptions);
-        }
-export type GetSubscriptionDetailsQueryHookResult = ReturnType<typeof useGetSubscriptionDetailsQuery>;
-export type GetSubscriptionDetailsLazyQueryHookResult = ReturnType<typeof useGetSubscriptionDetailsLazyQuery>;
-export type GetSubscriptionDetailsQueryResult = Apollo.QueryResult<Types.GetSubscriptionDetailsQuery, Types.GetSubscriptionDetailsQueryVariables>;
-export const GetErrorGroupDocument = gql`
-    query GetErrorGroup($secure_id: String!) {
-  error_group(secure_id: $secure_id) {
-    created_at
-    updated_at
-    id
-    secure_id
-    type
-    project_id
-    event
-    state
-    snoozed_until
-    structured_stack_trace {
-      fileName
-      lineNumber
-      functionName
-      columnNumber
-      lineContent
-      linesBefore
-      linesAfter
-      error
-    }
-    mapped_stack_trace
-    stack_trace
-    fields {
-      name
-      value
-    }
-    error_frequency
-    error_metrics {
-      error_group_id
-      date
-      name
-      value
-    }
-    is_public
-    last_occurrence
-    first_occurrence
-  }
+export function useGetSubscriptionDetailsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSubscriptionDetailsQuery,
+		Types.GetSubscriptionDetailsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSubscriptionDetailsQuery,
+		Types.GetSubscriptionDetailsQueryVariables
+	>(GetSubscriptionDetailsDocument, baseOptions)
 }
-    `;
+export function useGetSubscriptionDetailsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSubscriptionDetailsQuery,
+		Types.GetSubscriptionDetailsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSubscriptionDetailsQuery,
+		Types.GetSubscriptionDetailsQueryVariables
+	>(GetSubscriptionDetailsDocument, baseOptions)
+}
+export type GetSubscriptionDetailsQueryHookResult = ReturnType<
+	typeof useGetSubscriptionDetailsQuery
+>
+export type GetSubscriptionDetailsLazyQueryHookResult = ReturnType<
+	typeof useGetSubscriptionDetailsLazyQuery
+>
+export type GetSubscriptionDetailsQueryResult = Apollo.QueryResult<
+	Types.GetSubscriptionDetailsQuery,
+	Types.GetSubscriptionDetailsQueryVariables
+>
+export const GetErrorGroupDocument = gql`
+	query GetErrorGroup($secure_id: String!) {
+		error_group(secure_id: $secure_id) {
+			created_at
+			updated_at
+			id
+			secure_id
+			type
+			project_id
+			event
+			state
+			snoozed_until
+			structured_stack_trace {
+				fileName
+				lineNumber
+				functionName
+				columnNumber
+				lineContent
+				linesBefore
+				linesAfter
+				error
+			}
+			mapped_stack_trace
+			stack_trace
+			fields {
+				name
+				value
+			}
+			error_frequency
+			error_metrics {
+				error_group_id
+				date
+				name
+				value
+			}
+			is_public
+			last_occurrence
+			first_occurrence
+		}
+	}
+`
 
 /**
  * __useGetErrorGroupQuery__
@@ -5463,24 +8239,47 @@ export const GetErrorGroupDocument = gql`
  *   },
  * });
  */
-export function useGetErrorGroupQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorGroupQuery, Types.GetErrorGroupQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorGroupQuery, Types.GetErrorGroupQueryVariables>(GetErrorGroupDocument, baseOptions);
-      }
-export function useGetErrorGroupLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorGroupQuery, Types.GetErrorGroupQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorGroupQuery, Types.GetErrorGroupQueryVariables>(GetErrorGroupDocument, baseOptions);
-        }
-export type GetErrorGroupQueryHookResult = ReturnType<typeof useGetErrorGroupQuery>;
-export type GetErrorGroupLazyQueryHookResult = ReturnType<typeof useGetErrorGroupLazyQuery>;
-export type GetErrorGroupQueryResult = Apollo.QueryResult<Types.GetErrorGroupQuery, Types.GetErrorGroupQueryVariables>;
-export const GetErrorObjectForLogDocument = gql`
-    query GetErrorObjectForLog($log_cursor: String!) {
-  error_object_for_log(log_cursor: $log_cursor) {
-    id
-    error_group_secure_id
-    project_id
-  }
+export function useGetErrorGroupQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorGroupQuery,
+		Types.GetErrorGroupQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorGroupQuery,
+		Types.GetErrorGroupQueryVariables
+	>(GetErrorGroupDocument, baseOptions)
 }
-    `;
+export function useGetErrorGroupLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorGroupQuery,
+		Types.GetErrorGroupQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorGroupQuery,
+		Types.GetErrorGroupQueryVariables
+	>(GetErrorGroupDocument, baseOptions)
+}
+export type GetErrorGroupQueryHookResult = ReturnType<
+	typeof useGetErrorGroupQuery
+>
+export type GetErrorGroupLazyQueryHookResult = ReturnType<
+	typeof useGetErrorGroupLazyQuery
+>
+export type GetErrorGroupQueryResult = Apollo.QueryResult<
+	Types.GetErrorGroupQuery,
+	Types.GetErrorGroupQueryVariables
+>
+export const GetErrorObjectForLogDocument = gql`
+	query GetErrorObjectForLog($log_cursor: String!) {
+		error_object_for_log(log_cursor: $log_cursor) {
+			id
+			error_group_secure_id
+			project_id
+		}
+	}
+`
 
 /**
  * __useGetErrorObjectForLogQuery__
@@ -5498,22 +8297,46 @@ export const GetErrorObjectForLogDocument = gql`
  *   },
  * });
  */
-export function useGetErrorObjectForLogQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorObjectForLogQuery, Types.GetErrorObjectForLogQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorObjectForLogQuery, Types.GetErrorObjectForLogQueryVariables>(GetErrorObjectForLogDocument, baseOptions);
-      }
-export function useGetErrorObjectForLogLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorObjectForLogQuery, Types.GetErrorObjectForLogQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorObjectForLogQuery, Types.GetErrorObjectForLogQueryVariables>(GetErrorObjectForLogDocument, baseOptions);
-        }
-export type GetErrorObjectForLogQueryHookResult = ReturnType<typeof useGetErrorObjectForLogQuery>;
-export type GetErrorObjectForLogLazyQueryHookResult = ReturnType<typeof useGetErrorObjectForLogLazyQuery>;
-export type GetErrorObjectForLogQueryResult = Apollo.QueryResult<Types.GetErrorObjectForLogQuery, Types.GetErrorObjectForLogQueryVariables>;
-export const GetErrorObjectDocument = gql`
-    query GetErrorObject($id: ID!) {
-  error_object(id: $id) {
-    ...ErrorObject
-  }
+export function useGetErrorObjectForLogQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorObjectForLogQuery,
+		Types.GetErrorObjectForLogQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorObjectForLogQuery,
+		Types.GetErrorObjectForLogQueryVariables
+	>(GetErrorObjectForLogDocument, baseOptions)
 }
-    ${ErrorObjectFragmentDoc}`;
+export function useGetErrorObjectForLogLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorObjectForLogQuery,
+		Types.GetErrorObjectForLogQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorObjectForLogQuery,
+		Types.GetErrorObjectForLogQueryVariables
+	>(GetErrorObjectForLogDocument, baseOptions)
+}
+export type GetErrorObjectForLogQueryHookResult = ReturnType<
+	typeof useGetErrorObjectForLogQuery
+>
+export type GetErrorObjectForLogLazyQueryHookResult = ReturnType<
+	typeof useGetErrorObjectForLogLazyQuery
+>
+export type GetErrorObjectForLogQueryResult = Apollo.QueryResult<
+	Types.GetErrorObjectForLogQuery,
+	Types.GetErrorObjectForLogQueryVariables
+>
+export const GetErrorObjectDocument = gql`
+	query GetErrorObject($id: ID!) {
+		error_object(id: $id) {
+			...ErrorObject
+		}
+	}
+	${ErrorObjectFragmentDoc}
+`
 
 /**
  * __useGetErrorObjectQuery__
@@ -5531,29 +8354,56 @@ export const GetErrorObjectDocument = gql`
  *   },
  * });
  */
-export function useGetErrorObjectQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorObjectQuery, Types.GetErrorObjectQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorObjectQuery, Types.GetErrorObjectQueryVariables>(GetErrorObjectDocument, baseOptions);
-      }
-export function useGetErrorObjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorObjectQuery, Types.GetErrorObjectQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorObjectQuery, Types.GetErrorObjectQueryVariables>(GetErrorObjectDocument, baseOptions);
-        }
-export type GetErrorObjectQueryHookResult = ReturnType<typeof useGetErrorObjectQuery>;
-export type GetErrorObjectLazyQueryHookResult = ReturnType<typeof useGetErrorObjectLazyQuery>;
-export type GetErrorObjectQueryResult = Apollo.QueryResult<Types.GetErrorObjectQuery, Types.GetErrorObjectQueryVariables>;
-export const GetErrorInstanceDocument = gql`
-    query GetErrorInstance($error_group_secure_id: String!, $error_object_id: ID) {
-  error_instance(
-    error_group_secure_id: $error_group_secure_id
-    error_object_id: $error_object_id
-  ) {
-    error_object {
-      ...ErrorObject
-    }
-    next_id
-    previous_id
-  }
+export function useGetErrorObjectQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorObjectQuery,
+		Types.GetErrorObjectQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorObjectQuery,
+		Types.GetErrorObjectQueryVariables
+	>(GetErrorObjectDocument, baseOptions)
 }
-    ${ErrorObjectFragmentDoc}`;
+export function useGetErrorObjectLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorObjectQuery,
+		Types.GetErrorObjectQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorObjectQuery,
+		Types.GetErrorObjectQueryVariables
+	>(GetErrorObjectDocument, baseOptions)
+}
+export type GetErrorObjectQueryHookResult = ReturnType<
+	typeof useGetErrorObjectQuery
+>
+export type GetErrorObjectLazyQueryHookResult = ReturnType<
+	typeof useGetErrorObjectLazyQuery
+>
+export type GetErrorObjectQueryResult = Apollo.QueryResult<
+	Types.GetErrorObjectQuery,
+	Types.GetErrorObjectQueryVariables
+>
+export const GetErrorInstanceDocument = gql`
+	query GetErrorInstance(
+		$error_group_secure_id: String!
+		$error_object_id: ID
+	) {
+		error_instance(
+			error_group_secure_id: $error_group_secure_id
+			error_object_id: $error_object_id
+		) {
+			error_object {
+				...ErrorObject
+			}
+			next_id
+			previous_id
+		}
+	}
+	${ErrorObjectFragmentDoc}
+`
 
 /**
  * __useGetErrorInstanceQuery__
@@ -5572,36 +8422,59 @@ export const GetErrorInstanceDocument = gql`
  *   },
  * });
  */
-export function useGetErrorInstanceQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorInstanceQuery, Types.GetErrorInstanceQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorInstanceQuery, Types.GetErrorInstanceQueryVariables>(GetErrorInstanceDocument, baseOptions);
-      }
-export function useGetErrorInstanceLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorInstanceQuery, Types.GetErrorInstanceQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorInstanceQuery, Types.GetErrorInstanceQueryVariables>(GetErrorInstanceDocument, baseOptions);
-        }
-export type GetErrorInstanceQueryHookResult = ReturnType<typeof useGetErrorInstanceQuery>;
-export type GetErrorInstanceLazyQueryHookResult = ReturnType<typeof useGetErrorInstanceLazyQuery>;
-export type GetErrorInstanceQueryResult = Apollo.QueryResult<Types.GetErrorInstanceQuery, Types.GetErrorInstanceQueryVariables>;
-export const GetRecentErrorsDocument = gql`
-    query GetRecentErrors($secure_id: String!) {
-  error_group(secure_id: $secure_id) {
-    secure_id
-    metadata_log {
-      error_id
-      session_secure_id
-      environment
-      timestamp
-      os
-      browser
-      visited_url
-      fingerprint
-      identifier
-      user_properties
-      request_id
-      payload
-    }
-  }
+export function useGetErrorInstanceQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorInstanceQuery,
+		Types.GetErrorInstanceQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorInstanceQuery,
+		Types.GetErrorInstanceQueryVariables
+	>(GetErrorInstanceDocument, baseOptions)
 }
-    `;
+export function useGetErrorInstanceLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorInstanceQuery,
+		Types.GetErrorInstanceQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorInstanceQuery,
+		Types.GetErrorInstanceQueryVariables
+	>(GetErrorInstanceDocument, baseOptions)
+}
+export type GetErrorInstanceQueryHookResult = ReturnType<
+	typeof useGetErrorInstanceQuery
+>
+export type GetErrorInstanceLazyQueryHookResult = ReturnType<
+	typeof useGetErrorInstanceLazyQuery
+>
+export type GetErrorInstanceQueryResult = Apollo.QueryResult<
+	Types.GetErrorInstanceQuery,
+	Types.GetErrorInstanceQueryVariables
+>
+export const GetRecentErrorsDocument = gql`
+	query GetRecentErrors($secure_id: String!) {
+		error_group(secure_id: $secure_id) {
+			secure_id
+			metadata_log {
+				error_id
+				session_secure_id
+				environment
+				timestamp
+				os
+				browser
+				visited_url
+				fingerprint
+				identifier
+				user_properties
+				request_id
+				payload
+			}
+		}
+	}
+`
 
 /**
  * __useGetRecentErrorsQuery__
@@ -5619,20 +8492,43 @@ export const GetRecentErrorsDocument = gql`
  *   },
  * });
  */
-export function useGetRecentErrorsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetRecentErrorsQuery, Types.GetRecentErrorsQueryVariables>) {
-        return Apollo.useQuery<Types.GetRecentErrorsQuery, Types.GetRecentErrorsQueryVariables>(GetRecentErrorsDocument, baseOptions);
-      }
-export function useGetRecentErrorsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetRecentErrorsQuery, Types.GetRecentErrorsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetRecentErrorsQuery, Types.GetRecentErrorsQueryVariables>(GetRecentErrorsDocument, baseOptions);
-        }
-export type GetRecentErrorsQueryHookResult = ReturnType<typeof useGetRecentErrorsQuery>;
-export type GetRecentErrorsLazyQueryHookResult = ReturnType<typeof useGetRecentErrorsLazyQuery>;
-export type GetRecentErrorsQueryResult = Apollo.QueryResult<Types.GetRecentErrorsQuery, Types.GetRecentErrorsQueryVariables>;
-export const GetResourcesDocument = gql`
-    query GetResources($session_secure_id: String!) {
-  resources(session_secure_id: $session_secure_id)
+export function useGetRecentErrorsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetRecentErrorsQuery,
+		Types.GetRecentErrorsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetRecentErrorsQuery,
+		Types.GetRecentErrorsQueryVariables
+	>(GetRecentErrorsDocument, baseOptions)
 }
-    `;
+export function useGetRecentErrorsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetRecentErrorsQuery,
+		Types.GetRecentErrorsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetRecentErrorsQuery,
+		Types.GetRecentErrorsQueryVariables
+	>(GetRecentErrorsDocument, baseOptions)
+}
+export type GetRecentErrorsQueryHookResult = ReturnType<
+	typeof useGetRecentErrorsQuery
+>
+export type GetRecentErrorsLazyQueryHookResult = ReturnType<
+	typeof useGetRecentErrorsLazyQuery
+>
+export type GetRecentErrorsQueryResult = Apollo.QueryResult<
+	Types.GetRecentErrorsQuery,
+	Types.GetRecentErrorsQueryVariables
+>
+export const GetResourcesDocument = gql`
+	query GetResources($session_secure_id: String!) {
+		resources(session_secure_id: $session_secure_id)
+	}
+`
 
 /**
  * __useGetResourcesQuery__
@@ -5650,23 +8546,50 @@ export const GetResourcesDocument = gql`
  *   },
  * });
  */
-export function useGetResourcesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetResourcesQuery, Types.GetResourcesQueryVariables>) {
-        return Apollo.useQuery<Types.GetResourcesQuery, Types.GetResourcesQueryVariables>(GetResourcesDocument, baseOptions);
-      }
-export function useGetResourcesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetResourcesQuery, Types.GetResourcesQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetResourcesQuery, Types.GetResourcesQueryVariables>(GetResourcesDocument, baseOptions);
-        }
-export type GetResourcesQueryHookResult = ReturnType<typeof useGetResourcesQuery>;
-export type GetResourcesLazyQueryHookResult = ReturnType<typeof useGetResourcesLazyQuery>;
-export type GetResourcesQueryResult = Apollo.QueryResult<Types.GetResourcesQuery, Types.GetResourcesQueryVariables>;
-export const GetFieldSuggestionDocument = gql`
-    query GetFieldSuggestion($project_id: ID!, $name: String!, $query: String!) {
-  field_suggestion(project_id: $project_id, name: $name, query: $query) {
-    name
-    value
-  }
+export function useGetResourcesQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetResourcesQuery,
+		Types.GetResourcesQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetResourcesQuery,
+		Types.GetResourcesQueryVariables
+	>(GetResourcesDocument, baseOptions)
 }
-    `;
+export function useGetResourcesLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetResourcesQuery,
+		Types.GetResourcesQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetResourcesQuery,
+		Types.GetResourcesQueryVariables
+	>(GetResourcesDocument, baseOptions)
+}
+export type GetResourcesQueryHookResult = ReturnType<
+	typeof useGetResourcesQuery
+>
+export type GetResourcesLazyQueryHookResult = ReturnType<
+	typeof useGetResourcesLazyQuery
+>
+export type GetResourcesQueryResult = Apollo.QueryResult<
+	Types.GetResourcesQuery,
+	Types.GetResourcesQueryVariables
+>
+export const GetFieldSuggestionDocument = gql`
+	query GetFieldSuggestion(
+		$project_id: ID!
+		$name: String!
+		$query: String!
+	) {
+		field_suggestion(project_id: $project_id, name: $name, query: $query) {
+			name
+			value
+		}
+	}
+`
 
 /**
  * __useGetFieldSuggestionQuery__
@@ -5686,23 +8609,46 @@ export const GetFieldSuggestionDocument = gql`
  *   },
  * });
  */
-export function useGetFieldSuggestionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetFieldSuggestionQuery, Types.GetFieldSuggestionQueryVariables>) {
-        return Apollo.useQuery<Types.GetFieldSuggestionQuery, Types.GetFieldSuggestionQueryVariables>(GetFieldSuggestionDocument, baseOptions);
-      }
-export function useGetFieldSuggestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetFieldSuggestionQuery, Types.GetFieldSuggestionQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetFieldSuggestionQuery, Types.GetFieldSuggestionQueryVariables>(GetFieldSuggestionDocument, baseOptions);
-        }
-export type GetFieldSuggestionQueryHookResult = ReturnType<typeof useGetFieldSuggestionQuery>;
-export type GetFieldSuggestionLazyQueryHookResult = ReturnType<typeof useGetFieldSuggestionLazyQuery>;
-export type GetFieldSuggestionQueryResult = Apollo.QueryResult<Types.GetFieldSuggestionQuery, Types.GetFieldSuggestionQueryVariables>;
-export const GetEnvironmentsDocument = gql`
-    query GetEnvironments($project_id: ID!) {
-  environment_suggestion(project_id: $project_id) {
-    name
-    value
-  }
+export function useGetFieldSuggestionQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetFieldSuggestionQuery,
+		Types.GetFieldSuggestionQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetFieldSuggestionQuery,
+		Types.GetFieldSuggestionQueryVariables
+	>(GetFieldSuggestionDocument, baseOptions)
 }
-    `;
+export function useGetFieldSuggestionLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetFieldSuggestionQuery,
+		Types.GetFieldSuggestionQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetFieldSuggestionQuery,
+		Types.GetFieldSuggestionQueryVariables
+	>(GetFieldSuggestionDocument, baseOptions)
+}
+export type GetFieldSuggestionQueryHookResult = ReturnType<
+	typeof useGetFieldSuggestionQuery
+>
+export type GetFieldSuggestionLazyQueryHookResult = ReturnType<
+	typeof useGetFieldSuggestionLazyQuery
+>
+export type GetFieldSuggestionQueryResult = Apollo.QueryResult<
+	Types.GetFieldSuggestionQuery,
+	Types.GetFieldSuggestionQueryVariables
+>
+export const GetEnvironmentsDocument = gql`
+	query GetEnvironments($project_id: ID!) {
+		environment_suggestion(project_id: $project_id) {
+			name
+			value
+		}
+	}
+`
 
 /**
  * __useGetEnvironmentsQuery__
@@ -5720,20 +8666,43 @@ export const GetEnvironmentsDocument = gql`
  *   },
  * });
  */
-export function useGetEnvironmentsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetEnvironmentsQuery, Types.GetEnvironmentsQueryVariables>) {
-        return Apollo.useQuery<Types.GetEnvironmentsQuery, Types.GetEnvironmentsQueryVariables>(GetEnvironmentsDocument, baseOptions);
-      }
-export function useGetEnvironmentsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetEnvironmentsQuery, Types.GetEnvironmentsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetEnvironmentsQuery, Types.GetEnvironmentsQueryVariables>(GetEnvironmentsDocument, baseOptions);
-        }
-export type GetEnvironmentsQueryHookResult = ReturnType<typeof useGetEnvironmentsQuery>;
-export type GetEnvironmentsLazyQueryHookResult = ReturnType<typeof useGetEnvironmentsLazyQuery>;
-export type GetEnvironmentsQueryResult = Apollo.QueryResult<Types.GetEnvironmentsQuery, Types.GetEnvironmentsQueryVariables>;
-export const GetAppVersionsDocument = gql`
-    query GetAppVersions($project_id: ID!) {
-  app_version_suggestion(project_id: $project_id)
+export function useGetEnvironmentsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetEnvironmentsQuery,
+		Types.GetEnvironmentsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetEnvironmentsQuery,
+		Types.GetEnvironmentsQueryVariables
+	>(GetEnvironmentsDocument, baseOptions)
 }
-    `;
+export function useGetEnvironmentsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetEnvironmentsQuery,
+		Types.GetEnvironmentsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetEnvironmentsQuery,
+		Types.GetEnvironmentsQueryVariables
+	>(GetEnvironmentsDocument, baseOptions)
+}
+export type GetEnvironmentsQueryHookResult = ReturnType<
+	typeof useGetEnvironmentsQuery
+>
+export type GetEnvironmentsLazyQueryHookResult = ReturnType<
+	typeof useGetEnvironmentsLazyQuery
+>
+export type GetEnvironmentsQueryResult = Apollo.QueryResult<
+	Types.GetEnvironmentsQuery,
+	Types.GetEnvironmentsQueryVariables
+>
+export const GetAppVersionsDocument = gql`
+	query GetAppVersions($project_id: ID!) {
+		app_version_suggestion(project_id: $project_id)
+	}
+`
 
 /**
  * __useGetAppVersionsQuery__
@@ -5751,28 +8720,51 @@ export const GetAppVersionsDocument = gql`
  *   },
  * });
  */
-export function useGetAppVersionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetAppVersionsQuery, Types.GetAppVersionsQueryVariables>) {
-        return Apollo.useQuery<Types.GetAppVersionsQuery, Types.GetAppVersionsQueryVariables>(GetAppVersionsDocument, baseOptions);
-      }
-export function useGetAppVersionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAppVersionsQuery, Types.GetAppVersionsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetAppVersionsQuery, Types.GetAppVersionsQueryVariables>(GetAppVersionsDocument, baseOptions);
-        }
-export type GetAppVersionsQueryHookResult = ReturnType<typeof useGetAppVersionsQuery>;
-export type GetAppVersionsLazyQueryHookResult = ReturnType<typeof useGetAppVersionsLazyQuery>;
-export type GetAppVersionsQueryResult = Apollo.QueryResult<Types.GetAppVersionsQuery, Types.GetAppVersionsQueryVariables>;
-export const GetProjectSuggestionDocument = gql`
-    query GetProjectSuggestion($query: String!) {
-  projectSuggestion(query: $query) {
-    id
-    name
-    workspace_id
-  }
-  workspaceSuggestion(query: $query) {
-    id
-    name
-  }
+export function useGetAppVersionsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetAppVersionsQuery,
+		Types.GetAppVersionsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetAppVersionsQuery,
+		Types.GetAppVersionsQueryVariables
+	>(GetAppVersionsDocument, baseOptions)
 }
-    `;
+export function useGetAppVersionsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetAppVersionsQuery,
+		Types.GetAppVersionsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetAppVersionsQuery,
+		Types.GetAppVersionsQueryVariables
+	>(GetAppVersionsDocument, baseOptions)
+}
+export type GetAppVersionsQueryHookResult = ReturnType<
+	typeof useGetAppVersionsQuery
+>
+export type GetAppVersionsLazyQueryHookResult = ReturnType<
+	typeof useGetAppVersionsLazyQuery
+>
+export type GetAppVersionsQueryResult = Apollo.QueryResult<
+	Types.GetAppVersionsQuery,
+	Types.GetAppVersionsQueryVariables
+>
+export const GetProjectSuggestionDocument = gql`
+	query GetProjectSuggestion($query: String!) {
+		projectSuggestion(query: $query) {
+			id
+			name
+			workspace_id
+		}
+		workspaceSuggestion(query: $query) {
+			id
+			name
+		}
+	}
+`
 
 /**
  * __useGetProjectSuggestionQuery__
@@ -5790,23 +8782,54 @@ export const GetProjectSuggestionDocument = gql`
  *   },
  * });
  */
-export function useGetProjectSuggestionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetProjectSuggestionQuery, Types.GetProjectSuggestionQueryVariables>) {
-        return Apollo.useQuery<Types.GetProjectSuggestionQuery, Types.GetProjectSuggestionQueryVariables>(GetProjectSuggestionDocument, baseOptions);
-      }
-export function useGetProjectSuggestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectSuggestionQuery, Types.GetProjectSuggestionQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetProjectSuggestionQuery, Types.GetProjectSuggestionQueryVariables>(GetProjectSuggestionDocument, baseOptions);
-        }
-export type GetProjectSuggestionQueryHookResult = ReturnType<typeof useGetProjectSuggestionQuery>;
-export type GetProjectSuggestionLazyQueryHookResult = ReturnType<typeof useGetProjectSuggestionLazyQuery>;
-export type GetProjectSuggestionQueryResult = Apollo.QueryResult<Types.GetProjectSuggestionQuery, Types.GetProjectSuggestionQueryVariables>;
-export const GetErrorFieldSuggestionDocument = gql`
-    query GetErrorFieldSuggestion($project_id: ID!, $name: String!, $query: String!) {
-  error_field_suggestion(project_id: $project_id, name: $name, query: $query) {
-    name
-    value
-  }
+export function useGetProjectSuggestionQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetProjectSuggestionQuery,
+		Types.GetProjectSuggestionQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetProjectSuggestionQuery,
+		Types.GetProjectSuggestionQueryVariables
+	>(GetProjectSuggestionDocument, baseOptions)
 }
-    `;
+export function useGetProjectSuggestionLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetProjectSuggestionQuery,
+		Types.GetProjectSuggestionQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetProjectSuggestionQuery,
+		Types.GetProjectSuggestionQueryVariables
+	>(GetProjectSuggestionDocument, baseOptions)
+}
+export type GetProjectSuggestionQueryHookResult = ReturnType<
+	typeof useGetProjectSuggestionQuery
+>
+export type GetProjectSuggestionLazyQueryHookResult = ReturnType<
+	typeof useGetProjectSuggestionLazyQuery
+>
+export type GetProjectSuggestionQueryResult = Apollo.QueryResult<
+	Types.GetProjectSuggestionQuery,
+	Types.GetProjectSuggestionQueryVariables
+>
+export const GetErrorFieldSuggestionDocument = gql`
+	query GetErrorFieldSuggestion(
+		$project_id: ID!
+		$name: String!
+		$query: String!
+	) {
+		error_field_suggestion(
+			project_id: $project_id
+			name: $name
+			query: $query
+		) {
+			name
+			value
+		}
+	}
+`
 
 /**
  * __useGetErrorFieldSuggestionQuery__
@@ -5826,35 +8849,58 @@ export const GetErrorFieldSuggestionDocument = gql`
  *   },
  * });
  */
-export function useGetErrorFieldSuggestionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorFieldSuggestionQuery, Types.GetErrorFieldSuggestionQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorFieldSuggestionQuery, Types.GetErrorFieldSuggestionQueryVariables>(GetErrorFieldSuggestionDocument, baseOptions);
-      }
-export function useGetErrorFieldSuggestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorFieldSuggestionQuery, Types.GetErrorFieldSuggestionQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorFieldSuggestionQuery, Types.GetErrorFieldSuggestionQueryVariables>(GetErrorFieldSuggestionDocument, baseOptions);
-        }
-export type GetErrorFieldSuggestionQueryHookResult = ReturnType<typeof useGetErrorFieldSuggestionQuery>;
-export type GetErrorFieldSuggestionLazyQueryHookResult = ReturnType<typeof useGetErrorFieldSuggestionLazyQuery>;
-export type GetErrorFieldSuggestionQueryResult = Apollo.QueryResult<Types.GetErrorFieldSuggestionQuery, Types.GetErrorFieldSuggestionQueryVariables>;
-export const GetErrorSearchSuggestionsDocument = gql`
-    query GetErrorSearchSuggestions($project_id: ID!, $query: String!) {
-  visitedUrls: error_field_suggestion(
-    project_id: $project_id
-    name: "visited_url"
-    query: $query
-  ) {
-    name
-    value
-  }
-  fields: error_field_suggestion(
-    project_id: $project_id
-    name: "event"
-    query: $query
-  ) {
-    name
-    value
-  }
+export function useGetErrorFieldSuggestionQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorFieldSuggestionQuery,
+		Types.GetErrorFieldSuggestionQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorFieldSuggestionQuery,
+		Types.GetErrorFieldSuggestionQueryVariables
+	>(GetErrorFieldSuggestionDocument, baseOptions)
 }
-    `;
+export function useGetErrorFieldSuggestionLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorFieldSuggestionQuery,
+		Types.GetErrorFieldSuggestionQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorFieldSuggestionQuery,
+		Types.GetErrorFieldSuggestionQueryVariables
+	>(GetErrorFieldSuggestionDocument, baseOptions)
+}
+export type GetErrorFieldSuggestionQueryHookResult = ReturnType<
+	typeof useGetErrorFieldSuggestionQuery
+>
+export type GetErrorFieldSuggestionLazyQueryHookResult = ReturnType<
+	typeof useGetErrorFieldSuggestionLazyQuery
+>
+export type GetErrorFieldSuggestionQueryResult = Apollo.QueryResult<
+	Types.GetErrorFieldSuggestionQuery,
+	Types.GetErrorFieldSuggestionQueryVariables
+>
+export const GetErrorSearchSuggestionsDocument = gql`
+	query GetErrorSearchSuggestions($project_id: ID!, $query: String!) {
+		visitedUrls: error_field_suggestion(
+			project_id: $project_id
+			name: "visited_url"
+			query: $query
+		) {
+			name
+			value
+		}
+		fields: error_field_suggestion(
+			project_id: $project_id
+			name: "event"
+			query: $query
+		) {
+			name
+			value
+		}
+	}
+`
 
 /**
  * __useGetErrorSearchSuggestionsQuery__
@@ -5873,55 +8919,78 @@ export const GetErrorSearchSuggestionsDocument = gql`
  *   },
  * });
  */
-export function useGetErrorSearchSuggestionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorSearchSuggestionsQuery, Types.GetErrorSearchSuggestionsQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorSearchSuggestionsQuery, Types.GetErrorSearchSuggestionsQueryVariables>(GetErrorSearchSuggestionsDocument, baseOptions);
-      }
-export function useGetErrorSearchSuggestionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorSearchSuggestionsQuery, Types.GetErrorSearchSuggestionsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorSearchSuggestionsQuery, Types.GetErrorSearchSuggestionsQueryVariables>(GetErrorSearchSuggestionsDocument, baseOptions);
-        }
-export type GetErrorSearchSuggestionsQueryHookResult = ReturnType<typeof useGetErrorSearchSuggestionsQuery>;
-export type GetErrorSearchSuggestionsLazyQueryHookResult = ReturnType<typeof useGetErrorSearchSuggestionsLazyQuery>;
-export type GetErrorSearchSuggestionsQueryResult = Apollo.QueryResult<Types.GetErrorSearchSuggestionsQuery, Types.GetErrorSearchSuggestionsQueryVariables>;
-export const GetSessionSearchResultsDocument = gql`
-    query GetSessionSearchResults($project_id: ID!, $query: String!) {
-  trackProperties: property_suggestion(
-    project_id: $project_id
-    query: $query
-    type: "track"
-  ) {
-    id
-    name
-    value
-  }
-  userProperties: property_suggestion(
-    project_id: $project_id
-    query: $query
-    type: "user"
-  ) {
-    id
-    name
-    value
-  }
-  visitedUrls: field_suggestion(
-    project_id: $project_id
-    name: "visited-url"
-    query: $query
-  ) {
-    id
-    name
-    value
-  }
-  referrers: field_suggestion(
-    project_id: $project_id
-    name: "referrer"
-    query: $query
-  ) {
-    id
-    name
-    value
-  }
+export function useGetErrorSearchSuggestionsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorSearchSuggestionsQuery,
+		Types.GetErrorSearchSuggestionsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorSearchSuggestionsQuery,
+		Types.GetErrorSearchSuggestionsQueryVariables
+	>(GetErrorSearchSuggestionsDocument, baseOptions)
 }
-    `;
+export function useGetErrorSearchSuggestionsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorSearchSuggestionsQuery,
+		Types.GetErrorSearchSuggestionsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorSearchSuggestionsQuery,
+		Types.GetErrorSearchSuggestionsQueryVariables
+	>(GetErrorSearchSuggestionsDocument, baseOptions)
+}
+export type GetErrorSearchSuggestionsQueryHookResult = ReturnType<
+	typeof useGetErrorSearchSuggestionsQuery
+>
+export type GetErrorSearchSuggestionsLazyQueryHookResult = ReturnType<
+	typeof useGetErrorSearchSuggestionsLazyQuery
+>
+export type GetErrorSearchSuggestionsQueryResult = Apollo.QueryResult<
+	Types.GetErrorSearchSuggestionsQuery,
+	Types.GetErrorSearchSuggestionsQueryVariables
+>
+export const GetSessionSearchResultsDocument = gql`
+	query GetSessionSearchResults($project_id: ID!, $query: String!) {
+		trackProperties: property_suggestion(
+			project_id: $project_id
+			query: $query
+			type: "track"
+		) {
+			id
+			name
+			value
+		}
+		userProperties: property_suggestion(
+			project_id: $project_id
+			query: $query
+			type: "user"
+		) {
+			id
+			name
+			value
+		}
+		visitedUrls: field_suggestion(
+			project_id: $project_id
+			name: "visited-url"
+			query: $query
+		) {
+			id
+			name
+			value
+		}
+		referrers: field_suggestion(
+			project_id: $project_id
+			name: "referrer"
+			query: $query
+		) {
+			id
+			name
+			value
+		}
+	}
+`
 
 /**
  * __useGetSessionSearchResultsQuery__
@@ -5940,24 +9009,51 @@ export const GetSessionSearchResultsDocument = gql`
  *   },
  * });
  */
-export function useGetSessionSearchResultsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionSearchResultsQuery, Types.GetSessionSearchResultsQueryVariables>) {
-        return Apollo.useQuery<Types.GetSessionSearchResultsQuery, Types.GetSessionSearchResultsQueryVariables>(GetSessionSearchResultsDocument, baseOptions);
-      }
-export function useGetSessionSearchResultsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionSearchResultsQuery, Types.GetSessionSearchResultsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSessionSearchResultsQuery, Types.GetSessionSearchResultsQueryVariables>(GetSessionSearchResultsDocument, baseOptions);
-        }
-export type GetSessionSearchResultsQueryHookResult = ReturnType<typeof useGetSessionSearchResultsQuery>;
-export type GetSessionSearchResultsLazyQueryHookResult = ReturnType<typeof useGetSessionSearchResultsLazyQuery>;
-export type GetSessionSearchResultsQueryResult = Apollo.QueryResult<Types.GetSessionSearchResultsQuery, Types.GetSessionSearchResultsQueryVariables>;
-export const GetTrackSuggestionDocument = gql`
-    query GetTrackSuggestion($project_id: ID!, $query: String!) {
-  property_suggestion(project_id: $project_id, query: $query, type: "track") {
-    id
-    name
-    value
-  }
+export function useGetSessionSearchResultsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSessionSearchResultsQuery,
+		Types.GetSessionSearchResultsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSessionSearchResultsQuery,
+		Types.GetSessionSearchResultsQueryVariables
+	>(GetSessionSearchResultsDocument, baseOptions)
 }
-    `;
+export function useGetSessionSearchResultsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSessionSearchResultsQuery,
+		Types.GetSessionSearchResultsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSessionSearchResultsQuery,
+		Types.GetSessionSearchResultsQueryVariables
+	>(GetSessionSearchResultsDocument, baseOptions)
+}
+export type GetSessionSearchResultsQueryHookResult = ReturnType<
+	typeof useGetSessionSearchResultsQuery
+>
+export type GetSessionSearchResultsLazyQueryHookResult = ReturnType<
+	typeof useGetSessionSearchResultsLazyQuery
+>
+export type GetSessionSearchResultsQueryResult = Apollo.QueryResult<
+	Types.GetSessionSearchResultsQuery,
+	Types.GetSessionSearchResultsQueryVariables
+>
+export const GetTrackSuggestionDocument = gql`
+	query GetTrackSuggestion($project_id: ID!, $query: String!) {
+		property_suggestion(
+			project_id: $project_id
+			query: $query
+			type: "track"
+		) {
+			id
+			name
+			value
+		}
+	}
+`
 
 /**
  * __useGetTrackSuggestionQuery__
@@ -5976,24 +9072,51 @@ export const GetTrackSuggestionDocument = gql`
  *   },
  * });
  */
-export function useGetTrackSuggestionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetTrackSuggestionQuery, Types.GetTrackSuggestionQueryVariables>) {
-        return Apollo.useQuery<Types.GetTrackSuggestionQuery, Types.GetTrackSuggestionQueryVariables>(GetTrackSuggestionDocument, baseOptions);
-      }
-export function useGetTrackSuggestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetTrackSuggestionQuery, Types.GetTrackSuggestionQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetTrackSuggestionQuery, Types.GetTrackSuggestionQueryVariables>(GetTrackSuggestionDocument, baseOptions);
-        }
-export type GetTrackSuggestionQueryHookResult = ReturnType<typeof useGetTrackSuggestionQuery>;
-export type GetTrackSuggestionLazyQueryHookResult = ReturnType<typeof useGetTrackSuggestionLazyQuery>;
-export type GetTrackSuggestionQueryResult = Apollo.QueryResult<Types.GetTrackSuggestionQuery, Types.GetTrackSuggestionQueryVariables>;
-export const GetUserSuggestionDocument = gql`
-    query GetUserSuggestion($project_id: ID!, $query: String!) {
-  property_suggestion(project_id: $project_id, query: $query, type: "user") {
-    id
-    name
-    value
-  }
+export function useGetTrackSuggestionQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetTrackSuggestionQuery,
+		Types.GetTrackSuggestionQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetTrackSuggestionQuery,
+		Types.GetTrackSuggestionQueryVariables
+	>(GetTrackSuggestionDocument, baseOptions)
 }
-    `;
+export function useGetTrackSuggestionLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetTrackSuggestionQuery,
+		Types.GetTrackSuggestionQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetTrackSuggestionQuery,
+		Types.GetTrackSuggestionQueryVariables
+	>(GetTrackSuggestionDocument, baseOptions)
+}
+export type GetTrackSuggestionQueryHookResult = ReturnType<
+	typeof useGetTrackSuggestionQuery
+>
+export type GetTrackSuggestionLazyQueryHookResult = ReturnType<
+	typeof useGetTrackSuggestionLazyQuery
+>
+export type GetTrackSuggestionQueryResult = Apollo.QueryResult<
+	Types.GetTrackSuggestionQuery,
+	Types.GetTrackSuggestionQueryVariables
+>
+export const GetUserSuggestionDocument = gql`
+	query GetUserSuggestion($project_id: ID!, $query: String!) {
+		property_suggestion(
+			project_id: $project_id
+			query: $query
+			type: "user"
+		) {
+			id
+			name
+			value
+		}
+	}
+`
 
 /**
  * __useGetUserSuggestionQuery__
@@ -6012,57 +9135,80 @@ export const GetUserSuggestionDocument = gql`
  *   },
  * });
  */
-export function useGetUserSuggestionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetUserSuggestionQuery, Types.GetUserSuggestionQueryVariables>) {
-        return Apollo.useQuery<Types.GetUserSuggestionQuery, Types.GetUserSuggestionQueryVariables>(GetUserSuggestionDocument, baseOptions);
-      }
-export function useGetUserSuggestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetUserSuggestionQuery, Types.GetUserSuggestionQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetUserSuggestionQuery, Types.GetUserSuggestionQueryVariables>(GetUserSuggestionDocument, baseOptions);
-        }
-export type GetUserSuggestionQueryHookResult = ReturnType<typeof useGetUserSuggestionQuery>;
-export type GetUserSuggestionLazyQueryHookResult = ReturnType<typeof useGetUserSuggestionLazyQuery>;
-export type GetUserSuggestionQueryResult = Apollo.QueryResult<Types.GetUserSuggestionQuery, Types.GetUserSuggestionQueryVariables>;
-export const GetSegmentsDocument = gql`
-    query GetSegments($project_id: ID!) {
-  segments(project_id: $project_id) {
-    id
-    name
-    params {
-      user_properties {
-        name
-        value
-      }
-      excluded_properties {
-        name
-        value
-      }
-      track_properties {
-        name
-        value
-      }
-      date_range {
-        start_date
-        end_date
-      }
-      length_range {
-        min
-        max
-      }
-      os
-      browser
-      visited_url
-      referrer
-      identified
-      hide_viewed
-      first_time
-      app_versions
-      environments
-      device_id
-      show_live_sessions
-      query
-    }
-  }
+export function useGetUserSuggestionQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetUserSuggestionQuery,
+		Types.GetUserSuggestionQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetUserSuggestionQuery,
+		Types.GetUserSuggestionQueryVariables
+	>(GetUserSuggestionDocument, baseOptions)
 }
-    `;
+export function useGetUserSuggestionLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetUserSuggestionQuery,
+		Types.GetUserSuggestionQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetUserSuggestionQuery,
+		Types.GetUserSuggestionQueryVariables
+	>(GetUserSuggestionDocument, baseOptions)
+}
+export type GetUserSuggestionQueryHookResult = ReturnType<
+	typeof useGetUserSuggestionQuery
+>
+export type GetUserSuggestionLazyQueryHookResult = ReturnType<
+	typeof useGetUserSuggestionLazyQuery
+>
+export type GetUserSuggestionQueryResult = Apollo.QueryResult<
+	Types.GetUserSuggestionQuery,
+	Types.GetUserSuggestionQueryVariables
+>
+export const GetSegmentsDocument = gql`
+	query GetSegments($project_id: ID!) {
+		segments(project_id: $project_id) {
+			id
+			name
+			params {
+				user_properties {
+					name
+					value
+				}
+				excluded_properties {
+					name
+					value
+				}
+				track_properties {
+					name
+					value
+				}
+				date_range {
+					start_date
+					end_date
+				}
+				length_range {
+					min
+					max
+				}
+				os
+				browser
+				visited_url
+				referrer
+				identified
+				hide_viewed
+				first_time
+				app_versions
+				environments
+				device_id
+				show_live_sessions
+				query
+			}
+		}
+	}
+`
 
 /**
  * __useGetSegmentsQuery__
@@ -6080,35 +9226,56 @@ export const GetSegmentsDocument = gql`
  *   },
  * });
  */
-export function useGetSegmentsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSegmentsQuery, Types.GetSegmentsQueryVariables>) {
-        return Apollo.useQuery<Types.GetSegmentsQuery, Types.GetSegmentsQueryVariables>(GetSegmentsDocument, baseOptions);
-      }
-export function useGetSegmentsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSegmentsQuery, Types.GetSegmentsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSegmentsQuery, Types.GetSegmentsQueryVariables>(GetSegmentsDocument, baseOptions);
-        }
-export type GetSegmentsQueryHookResult = ReturnType<typeof useGetSegmentsQuery>;
-export type GetSegmentsLazyQueryHookResult = ReturnType<typeof useGetSegmentsLazyQuery>;
-export type GetSegmentsQueryResult = Apollo.QueryResult<Types.GetSegmentsQuery, Types.GetSegmentsQueryVariables>;
-export const GetErrorSegmentsDocument = gql`
-    query GetErrorSegments($project_id: ID!) {
-  segments: error_segments(project_id: $project_id) {
-    id
-    name
-    params {
-      date_range {
-        start_date
-        end_date
-      }
-      os
-      browser
-      visited_url
-      state
-      event
-      query
-    }
-  }
+export function useGetSegmentsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSegmentsQuery,
+		Types.GetSegmentsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSegmentsQuery,
+		Types.GetSegmentsQueryVariables
+	>(GetSegmentsDocument, baseOptions)
 }
-    `;
+export function useGetSegmentsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSegmentsQuery,
+		Types.GetSegmentsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSegmentsQuery,
+		Types.GetSegmentsQueryVariables
+	>(GetSegmentsDocument, baseOptions)
+}
+export type GetSegmentsQueryHookResult = ReturnType<typeof useGetSegmentsQuery>
+export type GetSegmentsLazyQueryHookResult = ReturnType<
+	typeof useGetSegmentsLazyQuery
+>
+export type GetSegmentsQueryResult = Apollo.QueryResult<
+	Types.GetSegmentsQuery,
+	Types.GetSegmentsQueryVariables
+>
+export const GetErrorSegmentsDocument = gql`
+	query GetErrorSegments($project_id: ID!) {
+		segments: error_segments(project_id: $project_id) {
+			id
+			name
+			params {
+				date_range {
+					start_date
+					end_date
+				}
+				os
+				browser
+				visited_url
+				state
+				event
+				query
+			}
+		}
+	}
+`
 
 /**
  * __useGetErrorSegmentsQuery__
@@ -6126,20 +9293,43 @@ export const GetErrorSegmentsDocument = gql`
  *   },
  * });
  */
-export function useGetErrorSegmentsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorSegmentsQuery, Types.GetErrorSegmentsQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorSegmentsQuery, Types.GetErrorSegmentsQueryVariables>(GetErrorSegmentsDocument, baseOptions);
-      }
-export function useGetErrorSegmentsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorSegmentsQuery, Types.GetErrorSegmentsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorSegmentsQuery, Types.GetErrorSegmentsQueryVariables>(GetErrorSegmentsDocument, baseOptions);
-        }
-export type GetErrorSegmentsQueryHookResult = ReturnType<typeof useGetErrorSegmentsQuery>;
-export type GetErrorSegmentsLazyQueryHookResult = ReturnType<typeof useGetErrorSegmentsLazyQuery>;
-export type GetErrorSegmentsQueryResult = Apollo.QueryResult<Types.GetErrorSegmentsQuery, Types.GetErrorSegmentsQueryVariables>;
-export const IsIntegratedDocument = gql`
-    query IsIntegrated($project_id: ID!) {
-  isIntegrated(project_id: $project_id)
+export function useGetErrorSegmentsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorSegmentsQuery,
+		Types.GetErrorSegmentsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorSegmentsQuery,
+		Types.GetErrorSegmentsQueryVariables
+	>(GetErrorSegmentsDocument, baseOptions)
 }
-    `;
+export function useGetErrorSegmentsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorSegmentsQuery,
+		Types.GetErrorSegmentsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorSegmentsQuery,
+		Types.GetErrorSegmentsQueryVariables
+	>(GetErrorSegmentsDocument, baseOptions)
+}
+export type GetErrorSegmentsQueryHookResult = ReturnType<
+	typeof useGetErrorSegmentsQuery
+>
+export type GetErrorSegmentsLazyQueryHookResult = ReturnType<
+	typeof useGetErrorSegmentsLazyQuery
+>
+export type GetErrorSegmentsQueryResult = Apollo.QueryResult<
+	Types.GetErrorSegmentsQuery,
+	Types.GetErrorSegmentsQueryVariables
+>
+export const IsIntegratedDocument = gql`
+	query IsIntegrated($project_id: ID!) {
+		isIntegrated(project_id: $project_id)
+	}
+`
 
 /**
  * __useIsIntegratedQuery__
@@ -6157,20 +9347,43 @@ export const IsIntegratedDocument = gql`
  *   },
  * });
  */
-export function useIsIntegratedQuery(baseOptions: Apollo.QueryHookOptions<Types.IsIntegratedQuery, Types.IsIntegratedQueryVariables>) {
-        return Apollo.useQuery<Types.IsIntegratedQuery, Types.IsIntegratedQueryVariables>(IsIntegratedDocument, baseOptions);
-      }
-export function useIsIntegratedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.IsIntegratedQuery, Types.IsIntegratedQueryVariables>) {
-          return Apollo.useLazyQuery<Types.IsIntegratedQuery, Types.IsIntegratedQueryVariables>(IsIntegratedDocument, baseOptions);
-        }
-export type IsIntegratedQueryHookResult = ReturnType<typeof useIsIntegratedQuery>;
-export type IsIntegratedLazyQueryHookResult = ReturnType<typeof useIsIntegratedLazyQuery>;
-export type IsIntegratedQueryResult = Apollo.QueryResult<Types.IsIntegratedQuery, Types.IsIntegratedQueryVariables>;
-export const IsBackendIntegratedDocument = gql`
-    query IsBackendIntegrated($project_id: ID!) {
-  isBackendIntegrated(project_id: $project_id)
+export function useIsIntegratedQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.IsIntegratedQuery,
+		Types.IsIntegratedQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.IsIntegratedQuery,
+		Types.IsIntegratedQueryVariables
+	>(IsIntegratedDocument, baseOptions)
 }
-    `;
+export function useIsIntegratedLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.IsIntegratedQuery,
+		Types.IsIntegratedQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.IsIntegratedQuery,
+		Types.IsIntegratedQueryVariables
+	>(IsIntegratedDocument, baseOptions)
+}
+export type IsIntegratedQueryHookResult = ReturnType<
+	typeof useIsIntegratedQuery
+>
+export type IsIntegratedLazyQueryHookResult = ReturnType<
+	typeof useIsIntegratedLazyQuery
+>
+export type IsIntegratedQueryResult = Apollo.QueryResult<
+	Types.IsIntegratedQuery,
+	Types.IsIntegratedQueryVariables
+>
+export const IsBackendIntegratedDocument = gql`
+	query IsBackendIntegrated($project_id: ID!) {
+		isBackendIntegrated(project_id: $project_id)
+	}
+`
 
 /**
  * __useIsBackendIntegratedQuery__
@@ -6188,24 +9401,47 @@ export const IsBackendIntegratedDocument = gql`
  *   },
  * });
  */
-export function useIsBackendIntegratedQuery(baseOptions: Apollo.QueryHookOptions<Types.IsBackendIntegratedQuery, Types.IsBackendIntegratedQueryVariables>) {
-        return Apollo.useQuery<Types.IsBackendIntegratedQuery, Types.IsBackendIntegratedQueryVariables>(IsBackendIntegratedDocument, baseOptions);
-      }
-export function useIsBackendIntegratedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.IsBackendIntegratedQuery, Types.IsBackendIntegratedQueryVariables>) {
-          return Apollo.useLazyQuery<Types.IsBackendIntegratedQuery, Types.IsBackendIntegratedQueryVariables>(IsBackendIntegratedDocument, baseOptions);
-        }
-export type IsBackendIntegratedQueryHookResult = ReturnType<typeof useIsBackendIntegratedQuery>;
-export type IsBackendIntegratedLazyQueryHookResult = ReturnType<typeof useIsBackendIntegratedLazyQuery>;
-export type IsBackendIntegratedQueryResult = Apollo.QueryResult<Types.IsBackendIntegratedQuery, Types.IsBackendIntegratedQueryVariables>;
-export const GetClientIntegrationDocument = gql`
-    query GetClientIntegration($project_id: ID!) {
-  clientIntegration(project_id: $project_id) {
-    integrated
-    resourceType
-    createdAt
-  }
+export function useIsBackendIntegratedQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.IsBackendIntegratedQuery,
+		Types.IsBackendIntegratedQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.IsBackendIntegratedQuery,
+		Types.IsBackendIntegratedQueryVariables
+	>(IsBackendIntegratedDocument, baseOptions)
 }
-    `;
+export function useIsBackendIntegratedLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.IsBackendIntegratedQuery,
+		Types.IsBackendIntegratedQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.IsBackendIntegratedQuery,
+		Types.IsBackendIntegratedQueryVariables
+	>(IsBackendIntegratedDocument, baseOptions)
+}
+export type IsBackendIntegratedQueryHookResult = ReturnType<
+	typeof useIsBackendIntegratedQuery
+>
+export type IsBackendIntegratedLazyQueryHookResult = ReturnType<
+	typeof useIsBackendIntegratedLazyQuery
+>
+export type IsBackendIntegratedQueryResult = Apollo.QueryResult<
+	Types.IsBackendIntegratedQuery,
+	Types.IsBackendIntegratedQueryVariables
+>
+export const GetClientIntegrationDocument = gql`
+	query GetClientIntegration($project_id: ID!) {
+		clientIntegration(project_id: $project_id) {
+			integrated
+			resourceType
+			createdAt
+		}
+	}
+`
 
 /**
  * __useGetClientIntegrationQuery__
@@ -6223,24 +9459,47 @@ export const GetClientIntegrationDocument = gql`
  *   },
  * });
  */
-export function useGetClientIntegrationQuery(baseOptions: Apollo.QueryHookOptions<Types.GetClientIntegrationQuery, Types.GetClientIntegrationQueryVariables>) {
-        return Apollo.useQuery<Types.GetClientIntegrationQuery, Types.GetClientIntegrationQueryVariables>(GetClientIntegrationDocument, baseOptions);
-      }
-export function useGetClientIntegrationLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetClientIntegrationQuery, Types.GetClientIntegrationQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetClientIntegrationQuery, Types.GetClientIntegrationQueryVariables>(GetClientIntegrationDocument, baseOptions);
-        }
-export type GetClientIntegrationQueryHookResult = ReturnType<typeof useGetClientIntegrationQuery>;
-export type GetClientIntegrationLazyQueryHookResult = ReturnType<typeof useGetClientIntegrationLazyQuery>;
-export type GetClientIntegrationQueryResult = Apollo.QueryResult<Types.GetClientIntegrationQuery, Types.GetClientIntegrationQueryVariables>;
-export const GetServerIntegrationDocument = gql`
-    query GetServerIntegration($project_id: ID!) {
-  serverIntegration(project_id: $project_id) {
-    integrated
-    resourceType
-    createdAt
-  }
+export function useGetClientIntegrationQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetClientIntegrationQuery,
+		Types.GetClientIntegrationQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetClientIntegrationQuery,
+		Types.GetClientIntegrationQueryVariables
+	>(GetClientIntegrationDocument, baseOptions)
 }
-    `;
+export function useGetClientIntegrationLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetClientIntegrationQuery,
+		Types.GetClientIntegrationQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetClientIntegrationQuery,
+		Types.GetClientIntegrationQueryVariables
+	>(GetClientIntegrationDocument, baseOptions)
+}
+export type GetClientIntegrationQueryHookResult = ReturnType<
+	typeof useGetClientIntegrationQuery
+>
+export type GetClientIntegrationLazyQueryHookResult = ReturnType<
+	typeof useGetClientIntegrationLazyQuery
+>
+export type GetClientIntegrationQueryResult = Apollo.QueryResult<
+	Types.GetClientIntegrationQuery,
+	Types.GetClientIntegrationQueryVariables
+>
+export const GetServerIntegrationDocument = gql`
+	query GetServerIntegration($project_id: ID!) {
+		serverIntegration(project_id: $project_id) {
+			integrated
+			resourceType
+			createdAt
+		}
+	}
+`
 
 /**
  * __useGetServerIntegrationQuery__
@@ -6258,24 +9517,47 @@ export const GetServerIntegrationDocument = gql`
  *   },
  * });
  */
-export function useGetServerIntegrationQuery(baseOptions: Apollo.QueryHookOptions<Types.GetServerIntegrationQuery, Types.GetServerIntegrationQueryVariables>) {
-        return Apollo.useQuery<Types.GetServerIntegrationQuery, Types.GetServerIntegrationQueryVariables>(GetServerIntegrationDocument, baseOptions);
-      }
-export function useGetServerIntegrationLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetServerIntegrationQuery, Types.GetServerIntegrationQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetServerIntegrationQuery, Types.GetServerIntegrationQueryVariables>(GetServerIntegrationDocument, baseOptions);
-        }
-export type GetServerIntegrationQueryHookResult = ReturnType<typeof useGetServerIntegrationQuery>;
-export type GetServerIntegrationLazyQueryHookResult = ReturnType<typeof useGetServerIntegrationLazyQuery>;
-export type GetServerIntegrationQueryResult = Apollo.QueryResult<Types.GetServerIntegrationQuery, Types.GetServerIntegrationQueryVariables>;
-export const GetLogsIntegrationDocument = gql`
-    query GetLogsIntegration($project_id: ID!) {
-  logsIntegration(project_id: $project_id) {
-    integrated
-    resourceType
-    createdAt
-  }
+export function useGetServerIntegrationQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetServerIntegrationQuery,
+		Types.GetServerIntegrationQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetServerIntegrationQuery,
+		Types.GetServerIntegrationQueryVariables
+	>(GetServerIntegrationDocument, baseOptions)
 }
-    `;
+export function useGetServerIntegrationLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetServerIntegrationQuery,
+		Types.GetServerIntegrationQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetServerIntegrationQuery,
+		Types.GetServerIntegrationQueryVariables
+	>(GetServerIntegrationDocument, baseOptions)
+}
+export type GetServerIntegrationQueryHookResult = ReturnType<
+	typeof useGetServerIntegrationQuery
+>
+export type GetServerIntegrationLazyQueryHookResult = ReturnType<
+	typeof useGetServerIntegrationLazyQuery
+>
+export type GetServerIntegrationQueryResult = Apollo.QueryResult<
+	Types.GetServerIntegrationQuery,
+	Types.GetServerIntegrationQueryVariables
+>
+export const GetLogsIntegrationDocument = gql`
+	query GetLogsIntegration($project_id: ID!) {
+		logsIntegration(project_id: $project_id) {
+			integrated
+			resourceType
+			createdAt
+		}
+	}
+`
 
 /**
  * __useGetLogsIntegrationQuery__
@@ -6293,30 +9575,62 @@ export const GetLogsIntegrationDocument = gql`
  *   },
  * });
  */
-export function useGetLogsIntegrationQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsIntegrationQuery, Types.GetLogsIntegrationQueryVariables>) {
-        return Apollo.useQuery<Types.GetLogsIntegrationQuery, Types.GetLogsIntegrationQueryVariables>(GetLogsIntegrationDocument, baseOptions);
-      }
-export function useGetLogsIntegrationLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsIntegrationQuery, Types.GetLogsIntegrationQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetLogsIntegrationQuery, Types.GetLogsIntegrationQueryVariables>(GetLogsIntegrationDocument, baseOptions);
-        }
-export type GetLogsIntegrationQueryHookResult = ReturnType<typeof useGetLogsIntegrationQuery>;
-export type GetLogsIntegrationLazyQueryHookResult = ReturnType<typeof useGetLogsIntegrationLazyQuery>;
-export type GetLogsIntegrationQueryResult = Apollo.QueryResult<Types.GetLogsIntegrationQuery, Types.GetLogsIntegrationQueryVariables>;
-export const GetKeyPerformanceIndicatorsDocument = gql`
-    query GetKeyPerformanceIndicators($project_id: ID!, $lookBackPeriod: Int!) {
-  unprocessedSessionsCount(project_id: $project_id)
-  liveUsersCount(project_id: $project_id)
-  newUsersCount(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
-    count
-  }
-  averageSessionLength(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
-    length
-  }
-  userFingerprintCount(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
-    count
-  }
+export function useGetLogsIntegrationQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogsIntegrationQuery,
+		Types.GetLogsIntegrationQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetLogsIntegrationQuery,
+		Types.GetLogsIntegrationQueryVariables
+	>(GetLogsIntegrationDocument, baseOptions)
 }
-    `;
+export function useGetLogsIntegrationLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogsIntegrationQuery,
+		Types.GetLogsIntegrationQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetLogsIntegrationQuery,
+		Types.GetLogsIntegrationQueryVariables
+	>(GetLogsIntegrationDocument, baseOptions)
+}
+export type GetLogsIntegrationQueryHookResult = ReturnType<
+	typeof useGetLogsIntegrationQuery
+>
+export type GetLogsIntegrationLazyQueryHookResult = ReturnType<
+	typeof useGetLogsIntegrationLazyQuery
+>
+export type GetLogsIntegrationQueryResult = Apollo.QueryResult<
+	Types.GetLogsIntegrationQuery,
+	Types.GetLogsIntegrationQueryVariables
+>
+export const GetKeyPerformanceIndicatorsDocument = gql`
+	query GetKeyPerformanceIndicators($project_id: ID!, $lookBackPeriod: Int!) {
+		unprocessedSessionsCount(project_id: $project_id)
+		liveUsersCount(project_id: $project_id)
+		newUsersCount(
+			project_id: $project_id
+			lookBackPeriod: $lookBackPeriod
+		) {
+			count
+		}
+		averageSessionLength(
+			project_id: $project_id
+			lookBackPeriod: $lookBackPeriod
+		) {
+			length
+		}
+		userFingerprintCount(
+			project_id: $project_id
+			lookBackPeriod: $lookBackPeriod
+		) {
+			count
+		}
+	}
+`
 
 /**
  * __useGetKeyPerformanceIndicatorsQuery__
@@ -6335,24 +9649,47 @@ export const GetKeyPerformanceIndicatorsDocument = gql`
  *   },
  * });
  */
-export function useGetKeyPerformanceIndicatorsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetKeyPerformanceIndicatorsQuery, Types.GetKeyPerformanceIndicatorsQueryVariables>) {
-        return Apollo.useQuery<Types.GetKeyPerformanceIndicatorsQuery, Types.GetKeyPerformanceIndicatorsQueryVariables>(GetKeyPerformanceIndicatorsDocument, baseOptions);
-      }
-export function useGetKeyPerformanceIndicatorsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetKeyPerformanceIndicatorsQuery, Types.GetKeyPerformanceIndicatorsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetKeyPerformanceIndicatorsQuery, Types.GetKeyPerformanceIndicatorsQueryVariables>(GetKeyPerformanceIndicatorsDocument, baseOptions);
-        }
-export type GetKeyPerformanceIndicatorsQueryHookResult = ReturnType<typeof useGetKeyPerformanceIndicatorsQuery>;
-export type GetKeyPerformanceIndicatorsLazyQueryHookResult = ReturnType<typeof useGetKeyPerformanceIndicatorsLazyQuery>;
-export type GetKeyPerformanceIndicatorsQueryResult = Apollo.QueryResult<Types.GetKeyPerformanceIndicatorsQuery, Types.GetKeyPerformanceIndicatorsQueryVariables>;
-export const GetReferrersCountDocument = gql`
-    query GetReferrersCount($project_id: ID!, $lookBackPeriod: Int!) {
-  referrers(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
-    host
-    count
-    percent
-  }
+export function useGetKeyPerformanceIndicatorsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetKeyPerformanceIndicatorsQuery,
+		Types.GetKeyPerformanceIndicatorsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetKeyPerformanceIndicatorsQuery,
+		Types.GetKeyPerformanceIndicatorsQueryVariables
+	>(GetKeyPerformanceIndicatorsDocument, baseOptions)
 }
-    `;
+export function useGetKeyPerformanceIndicatorsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetKeyPerformanceIndicatorsQuery,
+		Types.GetKeyPerformanceIndicatorsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetKeyPerformanceIndicatorsQuery,
+		Types.GetKeyPerformanceIndicatorsQueryVariables
+	>(GetKeyPerformanceIndicatorsDocument, baseOptions)
+}
+export type GetKeyPerformanceIndicatorsQueryHookResult = ReturnType<
+	typeof useGetKeyPerformanceIndicatorsQuery
+>
+export type GetKeyPerformanceIndicatorsLazyQueryHookResult = ReturnType<
+	typeof useGetKeyPerformanceIndicatorsLazyQuery
+>
+export type GetKeyPerformanceIndicatorsQueryResult = Apollo.QueryResult<
+	Types.GetKeyPerformanceIndicatorsQuery,
+	Types.GetKeyPerformanceIndicatorsQueryVariables
+>
+export const GetReferrersCountDocument = gql`
+	query GetReferrersCount($project_id: ID!, $lookBackPeriod: Int!) {
+		referrers(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
+			host
+			count
+			percent
+		}
+	}
+`
 
 /**
  * __useGetReferrersCountQuery__
@@ -6371,22 +9708,48 @@ export const GetReferrersCountDocument = gql`
  *   },
  * });
  */
-export function useGetReferrersCountQuery(baseOptions: Apollo.QueryHookOptions<Types.GetReferrersCountQuery, Types.GetReferrersCountQueryVariables>) {
-        return Apollo.useQuery<Types.GetReferrersCountQuery, Types.GetReferrersCountQueryVariables>(GetReferrersCountDocument, baseOptions);
-      }
-export function useGetReferrersCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetReferrersCountQuery, Types.GetReferrersCountQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetReferrersCountQuery, Types.GetReferrersCountQueryVariables>(GetReferrersCountDocument, baseOptions);
-        }
-export type GetReferrersCountQueryHookResult = ReturnType<typeof useGetReferrersCountQuery>;
-export type GetReferrersCountLazyQueryHookResult = ReturnType<typeof useGetReferrersCountLazyQuery>;
-export type GetReferrersCountQueryResult = Apollo.QueryResult<Types.GetReferrersCountQuery, Types.GetReferrersCountQueryVariables>;
-export const GetNewUsersCountDocument = gql`
-    query GetNewUsersCount($project_id: ID!, $lookBackPeriod: Int!) {
-  newUsersCount(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
-    count
-  }
+export function useGetReferrersCountQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetReferrersCountQuery,
+		Types.GetReferrersCountQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetReferrersCountQuery,
+		Types.GetReferrersCountQueryVariables
+	>(GetReferrersCountDocument, baseOptions)
 }
-    `;
+export function useGetReferrersCountLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetReferrersCountQuery,
+		Types.GetReferrersCountQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetReferrersCountQuery,
+		Types.GetReferrersCountQueryVariables
+	>(GetReferrersCountDocument, baseOptions)
+}
+export type GetReferrersCountQueryHookResult = ReturnType<
+	typeof useGetReferrersCountQuery
+>
+export type GetReferrersCountLazyQueryHookResult = ReturnType<
+	typeof useGetReferrersCountLazyQuery
+>
+export type GetReferrersCountQueryResult = Apollo.QueryResult<
+	Types.GetReferrersCountQuery,
+	Types.GetReferrersCountQueryVariables
+>
+export const GetNewUsersCountDocument = gql`
+	query GetNewUsersCount($project_id: ID!, $lookBackPeriod: Int!) {
+		newUsersCount(
+			project_id: $project_id
+			lookBackPeriod: $lookBackPeriod
+		) {
+			count
+		}
+	}
+`
 
 /**
  * __useGetNewUsersCountQuery__
@@ -6405,22 +9768,48 @@ export const GetNewUsersCountDocument = gql`
  *   },
  * });
  */
-export function useGetNewUsersCountQuery(baseOptions: Apollo.QueryHookOptions<Types.GetNewUsersCountQuery, Types.GetNewUsersCountQueryVariables>) {
-        return Apollo.useQuery<Types.GetNewUsersCountQuery, Types.GetNewUsersCountQueryVariables>(GetNewUsersCountDocument, baseOptions);
-      }
-export function useGetNewUsersCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetNewUsersCountQuery, Types.GetNewUsersCountQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetNewUsersCountQuery, Types.GetNewUsersCountQueryVariables>(GetNewUsersCountDocument, baseOptions);
-        }
-export type GetNewUsersCountQueryHookResult = ReturnType<typeof useGetNewUsersCountQuery>;
-export type GetNewUsersCountLazyQueryHookResult = ReturnType<typeof useGetNewUsersCountLazyQuery>;
-export type GetNewUsersCountQueryResult = Apollo.QueryResult<Types.GetNewUsersCountQuery, Types.GetNewUsersCountQueryVariables>;
-export const GetAverageSessionLengthDocument = gql`
-    query GetAverageSessionLength($project_id: ID!, $lookBackPeriod: Int!) {
-  averageSessionLength(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
-    length
-  }
+export function useGetNewUsersCountQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetNewUsersCountQuery,
+		Types.GetNewUsersCountQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetNewUsersCountQuery,
+		Types.GetNewUsersCountQueryVariables
+	>(GetNewUsersCountDocument, baseOptions)
 }
-    `;
+export function useGetNewUsersCountLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetNewUsersCountQuery,
+		Types.GetNewUsersCountQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetNewUsersCountQuery,
+		Types.GetNewUsersCountQueryVariables
+	>(GetNewUsersCountDocument, baseOptions)
+}
+export type GetNewUsersCountQueryHookResult = ReturnType<
+	typeof useGetNewUsersCountQuery
+>
+export type GetNewUsersCountLazyQueryHookResult = ReturnType<
+	typeof useGetNewUsersCountLazyQuery
+>
+export type GetNewUsersCountQueryResult = Apollo.QueryResult<
+	Types.GetNewUsersCountQuery,
+	Types.GetNewUsersCountQueryVariables
+>
+export const GetAverageSessionLengthDocument = gql`
+	query GetAverageSessionLength($project_id: ID!, $lookBackPeriod: Int!) {
+		averageSessionLength(
+			project_id: $project_id
+			lookBackPeriod: $lookBackPeriod
+		) {
+			length
+		}
+	}
+`
 
 /**
  * __useGetAverageSessionLengthQuery__
@@ -6439,26 +9828,49 @@ export const GetAverageSessionLengthDocument = gql`
  *   },
  * });
  */
-export function useGetAverageSessionLengthQuery(baseOptions: Apollo.QueryHookOptions<Types.GetAverageSessionLengthQuery, Types.GetAverageSessionLengthQueryVariables>) {
-        return Apollo.useQuery<Types.GetAverageSessionLengthQuery, Types.GetAverageSessionLengthQueryVariables>(GetAverageSessionLengthDocument, baseOptions);
-      }
-export function useGetAverageSessionLengthLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAverageSessionLengthQuery, Types.GetAverageSessionLengthQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetAverageSessionLengthQuery, Types.GetAverageSessionLengthQueryVariables>(GetAverageSessionLengthDocument, baseOptions);
-        }
-export type GetAverageSessionLengthQueryHookResult = ReturnType<typeof useGetAverageSessionLengthQuery>;
-export type GetAverageSessionLengthLazyQueryHookResult = ReturnType<typeof useGetAverageSessionLengthLazyQuery>;
-export type GetAverageSessionLengthQueryResult = Apollo.QueryResult<Types.GetAverageSessionLengthQuery, Types.GetAverageSessionLengthQueryVariables>;
-export const GetTopUsersDocument = gql`
-    query GetTopUsers($project_id: ID!, $lookBackPeriod: Int!) {
-  topUsers(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
-    identifier
-    total_active_time
-    active_time_percentage
-    id
-    user_properties
-  }
+export function useGetAverageSessionLengthQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetAverageSessionLengthQuery,
+		Types.GetAverageSessionLengthQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetAverageSessionLengthQuery,
+		Types.GetAverageSessionLengthQueryVariables
+	>(GetAverageSessionLengthDocument, baseOptions)
 }
-    `;
+export function useGetAverageSessionLengthLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetAverageSessionLengthQuery,
+		Types.GetAverageSessionLengthQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetAverageSessionLengthQuery,
+		Types.GetAverageSessionLengthQueryVariables
+	>(GetAverageSessionLengthDocument, baseOptions)
+}
+export type GetAverageSessionLengthQueryHookResult = ReturnType<
+	typeof useGetAverageSessionLengthQuery
+>
+export type GetAverageSessionLengthLazyQueryHookResult = ReturnType<
+	typeof useGetAverageSessionLengthLazyQuery
+>
+export type GetAverageSessionLengthQueryResult = Apollo.QueryResult<
+	Types.GetAverageSessionLengthQuery,
+	Types.GetAverageSessionLengthQueryVariables
+>
+export const GetTopUsersDocument = gql`
+	query GetTopUsers($project_id: ID!, $lookBackPeriod: Int!) {
+		topUsers(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
+			identifier
+			total_active_time
+			active_time_percentage
+			id
+			user_properties
+		}
+	}
+`
 
 /**
  * __useGetTopUsersQuery__
@@ -6477,23 +9889,47 @@ export const GetTopUsersDocument = gql`
  *   },
  * });
  */
-export function useGetTopUsersQuery(baseOptions: Apollo.QueryHookOptions<Types.GetTopUsersQuery, Types.GetTopUsersQueryVariables>) {
-        return Apollo.useQuery<Types.GetTopUsersQuery, Types.GetTopUsersQueryVariables>(GetTopUsersDocument, baseOptions);
-      }
-export function useGetTopUsersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetTopUsersQuery, Types.GetTopUsersQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetTopUsersQuery, Types.GetTopUsersQueryVariables>(GetTopUsersDocument, baseOptions);
-        }
-export type GetTopUsersQueryHookResult = ReturnType<typeof useGetTopUsersQuery>;
-export type GetTopUsersLazyQueryHookResult = ReturnType<typeof useGetTopUsersLazyQuery>;
-export type GetTopUsersQueryResult = Apollo.QueryResult<Types.GetTopUsersQuery, Types.GetTopUsersQueryVariables>;
-export const GetDailySessionsCountDocument = gql`
-    query GetDailySessionsCount($project_id: ID!, $date_range: DateRangeInput!) {
-  dailySessionsCount(project_id: $project_id, date_range: $date_range) {
-    date
-    count
-  }
+export function useGetTopUsersQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetTopUsersQuery,
+		Types.GetTopUsersQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetTopUsersQuery,
+		Types.GetTopUsersQueryVariables
+	>(GetTopUsersDocument, baseOptions)
 }
-    `;
+export function useGetTopUsersLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetTopUsersQuery,
+		Types.GetTopUsersQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetTopUsersQuery,
+		Types.GetTopUsersQueryVariables
+	>(GetTopUsersDocument, baseOptions)
+}
+export type GetTopUsersQueryHookResult = ReturnType<typeof useGetTopUsersQuery>
+export type GetTopUsersLazyQueryHookResult = ReturnType<
+	typeof useGetTopUsersLazyQuery
+>
+export type GetTopUsersQueryResult = Apollo.QueryResult<
+	Types.GetTopUsersQuery,
+	Types.GetTopUsersQueryVariables
+>
+export const GetDailySessionsCountDocument = gql`
+	query GetDailySessionsCount(
+		$project_id: ID!
+		$date_range: DateRangeInput!
+	) {
+		dailySessionsCount(project_id: $project_id, date_range: $date_range) {
+			date
+			count
+		}
+	}
+`
 
 /**
  * __useGetDailySessionsCountQuery__
@@ -6512,23 +9948,46 @@ export const GetDailySessionsCountDocument = gql`
  *   },
  * });
  */
-export function useGetDailySessionsCountQuery(baseOptions: Apollo.QueryHookOptions<Types.GetDailySessionsCountQuery, Types.GetDailySessionsCountQueryVariables>) {
-        return Apollo.useQuery<Types.GetDailySessionsCountQuery, Types.GetDailySessionsCountQueryVariables>(GetDailySessionsCountDocument, baseOptions);
-      }
-export function useGetDailySessionsCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetDailySessionsCountQuery, Types.GetDailySessionsCountQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetDailySessionsCountQuery, Types.GetDailySessionsCountQueryVariables>(GetDailySessionsCountDocument, baseOptions);
-        }
-export type GetDailySessionsCountQueryHookResult = ReturnType<typeof useGetDailySessionsCountQuery>;
-export type GetDailySessionsCountLazyQueryHookResult = ReturnType<typeof useGetDailySessionsCountLazyQuery>;
-export type GetDailySessionsCountQueryResult = Apollo.QueryResult<Types.GetDailySessionsCountQuery, Types.GetDailySessionsCountQueryVariables>;
-export const GetDailyErrorsCountDocument = gql`
-    query GetDailyErrorsCount($project_id: ID!, $date_range: DateRangeInput!) {
-  dailyErrorsCount(project_id: $project_id, date_range: $date_range) {
-    date
-    count
-  }
+export function useGetDailySessionsCountQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetDailySessionsCountQuery,
+		Types.GetDailySessionsCountQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetDailySessionsCountQuery,
+		Types.GetDailySessionsCountQueryVariables
+	>(GetDailySessionsCountDocument, baseOptions)
 }
-    `;
+export function useGetDailySessionsCountLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetDailySessionsCountQuery,
+		Types.GetDailySessionsCountQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetDailySessionsCountQuery,
+		Types.GetDailySessionsCountQueryVariables
+	>(GetDailySessionsCountDocument, baseOptions)
+}
+export type GetDailySessionsCountQueryHookResult = ReturnType<
+	typeof useGetDailySessionsCountQuery
+>
+export type GetDailySessionsCountLazyQueryHookResult = ReturnType<
+	typeof useGetDailySessionsCountLazyQuery
+>
+export type GetDailySessionsCountQueryResult = Apollo.QueryResult<
+	Types.GetDailySessionsCountQuery,
+	Types.GetDailySessionsCountQueryVariables
+>
+export const GetDailyErrorsCountDocument = gql`
+	query GetDailyErrorsCount($project_id: ID!, $date_range: DateRangeInput!) {
+		dailyErrorsCount(project_id: $project_id, date_range: $date_range) {
+			date
+			count
+		}
+	}
+`
 
 /**
  * __useGetDailyErrorsCountQuery__
@@ -6547,25 +10006,51 @@ export const GetDailyErrorsCountDocument = gql`
  *   },
  * });
  */
-export function useGetDailyErrorsCountQuery(baseOptions: Apollo.QueryHookOptions<Types.GetDailyErrorsCountQuery, Types.GetDailyErrorsCountQueryVariables>) {
-        return Apollo.useQuery<Types.GetDailyErrorsCountQuery, Types.GetDailyErrorsCountQueryVariables>(GetDailyErrorsCountDocument, baseOptions);
-      }
-export function useGetDailyErrorsCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetDailyErrorsCountQuery, Types.GetDailyErrorsCountQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetDailyErrorsCountQuery, Types.GetDailyErrorsCountQueryVariables>(GetDailyErrorsCountDocument, baseOptions);
-        }
-export type GetDailyErrorsCountQueryHookResult = ReturnType<typeof useGetDailyErrorsCountQuery>;
-export type GetDailyErrorsCountLazyQueryHookResult = ReturnType<typeof useGetDailyErrorsCountLazyQuery>;
-export type GetDailyErrorsCountQueryResult = Apollo.QueryResult<Types.GetDailyErrorsCountQuery, Types.GetDailyErrorsCountQueryVariables>;
-export const GetRageClicksForProjectDocument = gql`
-    query GetRageClicksForProject($project_id: ID!, $lookBackPeriod: Int!) {
-  rageClicksForProject(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
-    identifier
-    session_secure_id
-    total_clicks
-    user_properties
-  }
+export function useGetDailyErrorsCountQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetDailyErrorsCountQuery,
+		Types.GetDailyErrorsCountQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetDailyErrorsCountQuery,
+		Types.GetDailyErrorsCountQueryVariables
+	>(GetDailyErrorsCountDocument, baseOptions)
 }
-    `;
+export function useGetDailyErrorsCountLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetDailyErrorsCountQuery,
+		Types.GetDailyErrorsCountQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetDailyErrorsCountQuery,
+		Types.GetDailyErrorsCountQueryVariables
+	>(GetDailyErrorsCountDocument, baseOptions)
+}
+export type GetDailyErrorsCountQueryHookResult = ReturnType<
+	typeof useGetDailyErrorsCountQuery
+>
+export type GetDailyErrorsCountLazyQueryHookResult = ReturnType<
+	typeof useGetDailyErrorsCountLazyQuery
+>
+export type GetDailyErrorsCountQueryResult = Apollo.QueryResult<
+	Types.GetDailyErrorsCountQuery,
+	Types.GetDailyErrorsCountQueryVariables
+>
+export const GetRageClicksForProjectDocument = gql`
+	query GetRageClicksForProject($project_id: ID!, $lookBackPeriod: Int!) {
+		rageClicksForProject(
+			project_id: $project_id
+			lookBackPeriod: $lookBackPeriod
+		) {
+			identifier
+			session_secure_id
+			total_clicks
+			user_properties
+		}
+	}
+`
 
 /**
  * __useGetRageClicksForProjectQuery__
@@ -6584,24 +10069,51 @@ export const GetRageClicksForProjectDocument = gql`
  *   },
  * });
  */
-export function useGetRageClicksForProjectQuery(baseOptions: Apollo.QueryHookOptions<Types.GetRageClicksForProjectQuery, Types.GetRageClicksForProjectQueryVariables>) {
-        return Apollo.useQuery<Types.GetRageClicksForProjectQuery, Types.GetRageClicksForProjectQueryVariables>(GetRageClicksForProjectDocument, baseOptions);
-      }
-export function useGetRageClicksForProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetRageClicksForProjectQuery, Types.GetRageClicksForProjectQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetRageClicksForProjectQuery, Types.GetRageClicksForProjectQueryVariables>(GetRageClicksForProjectDocument, baseOptions);
-        }
-export type GetRageClicksForProjectQueryHookResult = ReturnType<typeof useGetRageClicksForProjectQuery>;
-export type GetRageClicksForProjectLazyQueryHookResult = ReturnType<typeof useGetRageClicksForProjectLazyQuery>;
-export type GetRageClicksForProjectQueryResult = Apollo.QueryResult<Types.GetRageClicksForProjectQuery, Types.GetRageClicksForProjectQueryVariables>;
-export const GetDailyErrorFrequencyDocument = gql`
-    query GetDailyErrorFrequency($project_id: ID!, $error_group_secure_id: String!, $date_offset: Int!) {
-  dailyErrorFrequency(
-    project_id: $project_id
-    error_group_secure_id: $error_group_secure_id
-    date_offset: $date_offset
-  )
+export function useGetRageClicksForProjectQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetRageClicksForProjectQuery,
+		Types.GetRageClicksForProjectQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetRageClicksForProjectQuery,
+		Types.GetRageClicksForProjectQueryVariables
+	>(GetRageClicksForProjectDocument, baseOptions)
 }
-    `;
+export function useGetRageClicksForProjectLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetRageClicksForProjectQuery,
+		Types.GetRageClicksForProjectQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetRageClicksForProjectQuery,
+		Types.GetRageClicksForProjectQueryVariables
+	>(GetRageClicksForProjectDocument, baseOptions)
+}
+export type GetRageClicksForProjectQueryHookResult = ReturnType<
+	typeof useGetRageClicksForProjectQuery
+>
+export type GetRageClicksForProjectLazyQueryHookResult = ReturnType<
+	typeof useGetRageClicksForProjectLazyQuery
+>
+export type GetRageClicksForProjectQueryResult = Apollo.QueryResult<
+	Types.GetRageClicksForProjectQuery,
+	Types.GetRageClicksForProjectQueryVariables
+>
+export const GetDailyErrorFrequencyDocument = gql`
+	query GetDailyErrorFrequency(
+		$project_id: ID!
+		$error_group_secure_id: String!
+		$date_offset: Int!
+	) {
+		dailyErrorFrequency(
+			project_id: $project_id
+			error_group_secure_id: $error_group_secure_id
+			date_offset: $date_offset
+		)
+	}
+`
 
 /**
  * __useGetDailyErrorFrequencyQuery__
@@ -6621,27 +10133,54 @@ export const GetDailyErrorFrequencyDocument = gql`
  *   },
  * });
  */
-export function useGetDailyErrorFrequencyQuery(baseOptions: Apollo.QueryHookOptions<Types.GetDailyErrorFrequencyQuery, Types.GetDailyErrorFrequencyQueryVariables>) {
-        return Apollo.useQuery<Types.GetDailyErrorFrequencyQuery, Types.GetDailyErrorFrequencyQueryVariables>(GetDailyErrorFrequencyDocument, baseOptions);
-      }
-export function useGetDailyErrorFrequencyLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetDailyErrorFrequencyQuery, Types.GetDailyErrorFrequencyQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetDailyErrorFrequencyQuery, Types.GetDailyErrorFrequencyQueryVariables>(GetDailyErrorFrequencyDocument, baseOptions);
-        }
-export type GetDailyErrorFrequencyQueryHookResult = ReturnType<typeof useGetDailyErrorFrequencyQuery>;
-export type GetDailyErrorFrequencyLazyQueryHookResult = ReturnType<typeof useGetDailyErrorFrequencyLazyQuery>;
-export type GetDailyErrorFrequencyQueryResult = Apollo.QueryResult<Types.GetDailyErrorFrequencyQuery, Types.GetDailyErrorFrequencyQueryVariables>;
-export const GetErrorDistributionDocument = gql`
-    query GetErrorDistribution($project_id: ID!, $error_group_secure_id: String!, $property: String!) {
-  errorDistribution(
-    project_id: $project_id
-    error_group_secure_id: $error_group_secure_id
-    property: $property
-  ) {
-    name
-    value
-  }
+export function useGetDailyErrorFrequencyQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetDailyErrorFrequencyQuery,
+		Types.GetDailyErrorFrequencyQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetDailyErrorFrequencyQuery,
+		Types.GetDailyErrorFrequencyQueryVariables
+	>(GetDailyErrorFrequencyDocument, baseOptions)
 }
-    `;
+export function useGetDailyErrorFrequencyLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetDailyErrorFrequencyQuery,
+		Types.GetDailyErrorFrequencyQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetDailyErrorFrequencyQuery,
+		Types.GetDailyErrorFrequencyQueryVariables
+	>(GetDailyErrorFrequencyDocument, baseOptions)
+}
+export type GetDailyErrorFrequencyQueryHookResult = ReturnType<
+	typeof useGetDailyErrorFrequencyQuery
+>
+export type GetDailyErrorFrequencyLazyQueryHookResult = ReturnType<
+	typeof useGetDailyErrorFrequencyLazyQuery
+>
+export type GetDailyErrorFrequencyQueryResult = Apollo.QueryResult<
+	Types.GetDailyErrorFrequencyQuery,
+	Types.GetDailyErrorFrequencyQueryVariables
+>
+export const GetErrorDistributionDocument = gql`
+	query GetErrorDistribution(
+		$project_id: ID!
+		$error_group_secure_id: String!
+		$property: String!
+	) {
+		errorDistribution(
+			project_id: $project_id
+			error_group_secure_id: $error_group_secure_id
+			property: $property
+		) {
+			name
+			value
+		}
+	}
+`
 
 /**
  * __useGetErrorDistributionQuery__
@@ -6661,23 +10200,46 @@ export const GetErrorDistributionDocument = gql`
  *   },
  * });
  */
-export function useGetErrorDistributionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorDistributionQuery, Types.GetErrorDistributionQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorDistributionQuery, Types.GetErrorDistributionQueryVariables>(GetErrorDistributionDocument, baseOptions);
-      }
-export function useGetErrorDistributionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorDistributionQuery, Types.GetErrorDistributionQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorDistributionQuery, Types.GetErrorDistributionQueryVariables>(GetErrorDistributionDocument, baseOptions);
-        }
-export type GetErrorDistributionQueryHookResult = ReturnType<typeof useGetErrorDistributionQuery>;
-export type GetErrorDistributionLazyQueryHookResult = ReturnType<typeof useGetErrorDistributionLazyQuery>;
-export type GetErrorDistributionQueryResult = Apollo.QueryResult<Types.GetErrorDistributionQuery, Types.GetErrorDistributionQueryVariables>;
-export const GetSlackChannelSuggestionDocument = gql`
-    query GetSlackChannelSuggestion($project_id: ID!) {
-  slack_channel_suggestion(project_id: $project_id) {
-    webhook_channel
-    webhook_channel_id
-  }
+export function useGetErrorDistributionQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorDistributionQuery,
+		Types.GetErrorDistributionQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorDistributionQuery,
+		Types.GetErrorDistributionQueryVariables
+	>(GetErrorDistributionDocument, baseOptions)
 }
-    `;
+export function useGetErrorDistributionLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorDistributionQuery,
+		Types.GetErrorDistributionQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorDistributionQuery,
+		Types.GetErrorDistributionQueryVariables
+	>(GetErrorDistributionDocument, baseOptions)
+}
+export type GetErrorDistributionQueryHookResult = ReturnType<
+	typeof useGetErrorDistributionQuery
+>
+export type GetErrorDistributionLazyQueryHookResult = ReturnType<
+	typeof useGetErrorDistributionLazyQuery
+>
+export type GetErrorDistributionQueryResult = Apollo.QueryResult<
+	Types.GetErrorDistributionQuery,
+	Types.GetErrorDistributionQueryVariables
+>
+export const GetSlackChannelSuggestionDocument = gql`
+	query GetSlackChannelSuggestion($project_id: ID!) {
+		slack_channel_suggestion(project_id: $project_id) {
+			webhook_channel
+			webhook_channel_id
+		}
+	}
+`
 
 /**
  * __useGetSlackChannelSuggestionQuery__
@@ -6695,23 +10257,46 @@ export const GetSlackChannelSuggestionDocument = gql`
  *   },
  * });
  */
-export function useGetSlackChannelSuggestionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSlackChannelSuggestionQuery, Types.GetSlackChannelSuggestionQueryVariables>) {
-        return Apollo.useQuery<Types.GetSlackChannelSuggestionQuery, Types.GetSlackChannelSuggestionQueryVariables>(GetSlackChannelSuggestionDocument, baseOptions);
-      }
-export function useGetSlackChannelSuggestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSlackChannelSuggestionQuery, Types.GetSlackChannelSuggestionQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSlackChannelSuggestionQuery, Types.GetSlackChannelSuggestionQueryVariables>(GetSlackChannelSuggestionDocument, baseOptions);
-        }
-export type GetSlackChannelSuggestionQueryHookResult = ReturnType<typeof useGetSlackChannelSuggestionQuery>;
-export type GetSlackChannelSuggestionLazyQueryHookResult = ReturnType<typeof useGetSlackChannelSuggestionLazyQuery>;
-export type GetSlackChannelSuggestionQueryResult = Apollo.QueryResult<Types.GetSlackChannelSuggestionQuery, Types.GetSlackChannelSuggestionQueryVariables>;
-export const GetWorkspaceIsIntegratedWithSlackDocument = gql`
-    query GetWorkspaceIsIntegratedWithSlack($project_id: ID!) {
-  is_integrated_with_slack: is_integrated_with(
-    integration_type: Slack
-    project_id: $project_id
-  )
+export function useGetSlackChannelSuggestionQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSlackChannelSuggestionQuery,
+		Types.GetSlackChannelSuggestionQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSlackChannelSuggestionQuery,
+		Types.GetSlackChannelSuggestionQueryVariables
+	>(GetSlackChannelSuggestionDocument, baseOptions)
 }
-    `;
+export function useGetSlackChannelSuggestionLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSlackChannelSuggestionQuery,
+		Types.GetSlackChannelSuggestionQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSlackChannelSuggestionQuery,
+		Types.GetSlackChannelSuggestionQueryVariables
+	>(GetSlackChannelSuggestionDocument, baseOptions)
+}
+export type GetSlackChannelSuggestionQueryHookResult = ReturnType<
+	typeof useGetSlackChannelSuggestionQuery
+>
+export type GetSlackChannelSuggestionLazyQueryHookResult = ReturnType<
+	typeof useGetSlackChannelSuggestionLazyQuery
+>
+export type GetSlackChannelSuggestionQueryResult = Apollo.QueryResult<
+	Types.GetSlackChannelSuggestionQuery,
+	Types.GetSlackChannelSuggestionQueryVariables
+>
+export const GetWorkspaceIsIntegratedWithSlackDocument = gql`
+	query GetWorkspaceIsIntegratedWithSlack($project_id: ID!) {
+		is_integrated_with_slack: is_integrated_with(
+			integration_type: Slack
+			project_id: $project_id
+		)
+	}
+`
 
 /**
  * __useGetWorkspaceIsIntegratedWithSlackQuery__
@@ -6729,28 +10314,51 @@ export const GetWorkspaceIsIntegratedWithSlackDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceIsIntegratedWithSlackQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceIsIntegratedWithSlackQuery, Types.GetWorkspaceIsIntegratedWithSlackQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspaceIsIntegratedWithSlackQuery, Types.GetWorkspaceIsIntegratedWithSlackQueryVariables>(GetWorkspaceIsIntegratedWithSlackDocument, baseOptions);
-      }
-export function useGetWorkspaceIsIntegratedWithSlackLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceIsIntegratedWithSlackQuery, Types.GetWorkspaceIsIntegratedWithSlackQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspaceIsIntegratedWithSlackQuery, Types.GetWorkspaceIsIntegratedWithSlackQueryVariables>(GetWorkspaceIsIntegratedWithSlackDocument, baseOptions);
-        }
-export type GetWorkspaceIsIntegratedWithSlackQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithSlackQuery>;
-export type GetWorkspaceIsIntegratedWithSlackLazyQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithSlackLazyQuery>;
-export type GetWorkspaceIsIntegratedWithSlackQueryResult = Apollo.QueryResult<Types.GetWorkspaceIsIntegratedWithSlackQuery, Types.GetWorkspaceIsIntegratedWithSlackQueryVariables>;
-export const GetWorkspaceIsIntegratedWithLinearDocument = gql`
-    query GetWorkspaceIsIntegratedWithLinear($project_id: ID!) {
-  is_integrated_with_linear: is_integrated_with(
-    integration_type: Linear
-    project_id: $project_id
-  )
-  linear_teams(project_id: $project_id) {
-    team_id
-    name
-    key
-  }
+export function useGetWorkspaceIsIntegratedWithSlackQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceIsIntegratedWithSlackQuery,
+		Types.GetWorkspaceIsIntegratedWithSlackQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceIsIntegratedWithSlackQuery,
+		Types.GetWorkspaceIsIntegratedWithSlackQueryVariables
+	>(GetWorkspaceIsIntegratedWithSlackDocument, baseOptions)
 }
-    `;
+export function useGetWorkspaceIsIntegratedWithSlackLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceIsIntegratedWithSlackQuery,
+		Types.GetWorkspaceIsIntegratedWithSlackQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceIsIntegratedWithSlackQuery,
+		Types.GetWorkspaceIsIntegratedWithSlackQueryVariables
+	>(GetWorkspaceIsIntegratedWithSlackDocument, baseOptions)
+}
+export type GetWorkspaceIsIntegratedWithSlackQueryHookResult = ReturnType<
+	typeof useGetWorkspaceIsIntegratedWithSlackQuery
+>
+export type GetWorkspaceIsIntegratedWithSlackLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceIsIntegratedWithSlackLazyQuery
+>
+export type GetWorkspaceIsIntegratedWithSlackQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceIsIntegratedWithSlackQuery,
+	Types.GetWorkspaceIsIntegratedWithSlackQueryVariables
+>
+export const GetWorkspaceIsIntegratedWithLinearDocument = gql`
+	query GetWorkspaceIsIntegratedWithLinear($project_id: ID!) {
+		is_integrated_with_linear: is_integrated_with(
+			integration_type: Linear
+			project_id: $project_id
+		)
+		linear_teams(project_id: $project_id) {
+			team_id
+			name
+			key
+		}
+	}
+`
 
 /**
  * __useGetWorkspaceIsIntegratedWithLinearQuery__
@@ -6768,23 +10376,46 @@ export const GetWorkspaceIsIntegratedWithLinearDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceIsIntegratedWithLinearQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceIsIntegratedWithLinearQuery, Types.GetWorkspaceIsIntegratedWithLinearQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspaceIsIntegratedWithLinearQuery, Types.GetWorkspaceIsIntegratedWithLinearQueryVariables>(GetWorkspaceIsIntegratedWithLinearDocument, baseOptions);
-      }
-export function useGetWorkspaceIsIntegratedWithLinearLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceIsIntegratedWithLinearQuery, Types.GetWorkspaceIsIntegratedWithLinearQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspaceIsIntegratedWithLinearQuery, Types.GetWorkspaceIsIntegratedWithLinearQueryVariables>(GetWorkspaceIsIntegratedWithLinearDocument, baseOptions);
-        }
-export type GetWorkspaceIsIntegratedWithLinearQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithLinearQuery>;
-export type GetWorkspaceIsIntegratedWithLinearLazyQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithLinearLazyQuery>;
-export type GetWorkspaceIsIntegratedWithLinearQueryResult = Apollo.QueryResult<Types.GetWorkspaceIsIntegratedWithLinearQuery, Types.GetWorkspaceIsIntegratedWithLinearQueryVariables>;
-export const GetWorkspaceIsIntegratedWithZapierDocument = gql`
-    query GetWorkspaceIsIntegratedWithZapier($project_id: ID!) {
-  is_integrated_with_linear: is_integrated_with(
-    integration_type: Zapier
-    project_id: $project_id
-  )
+export function useGetWorkspaceIsIntegratedWithLinearQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceIsIntegratedWithLinearQuery,
+		Types.GetWorkspaceIsIntegratedWithLinearQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceIsIntegratedWithLinearQuery,
+		Types.GetWorkspaceIsIntegratedWithLinearQueryVariables
+	>(GetWorkspaceIsIntegratedWithLinearDocument, baseOptions)
 }
-    `;
+export function useGetWorkspaceIsIntegratedWithLinearLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceIsIntegratedWithLinearQuery,
+		Types.GetWorkspaceIsIntegratedWithLinearQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceIsIntegratedWithLinearQuery,
+		Types.GetWorkspaceIsIntegratedWithLinearQueryVariables
+	>(GetWorkspaceIsIntegratedWithLinearDocument, baseOptions)
+}
+export type GetWorkspaceIsIntegratedWithLinearQueryHookResult = ReturnType<
+	typeof useGetWorkspaceIsIntegratedWithLinearQuery
+>
+export type GetWorkspaceIsIntegratedWithLinearLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceIsIntegratedWithLinearLazyQuery
+>
+export type GetWorkspaceIsIntegratedWithLinearQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceIsIntegratedWithLinearQuery,
+	Types.GetWorkspaceIsIntegratedWithLinearQueryVariables
+>
+export const GetWorkspaceIsIntegratedWithZapierDocument = gql`
+	query GetWorkspaceIsIntegratedWithZapier($project_id: ID!) {
+		is_integrated_with_linear: is_integrated_with(
+			integration_type: Zapier
+			project_id: $project_id
+		)
+	}
+`
 
 /**
  * __useGetWorkspaceIsIntegratedWithZapierQuery__
@@ -6802,23 +10433,46 @@ export const GetWorkspaceIsIntegratedWithZapierDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceIsIntegratedWithZapierQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceIsIntegratedWithZapierQuery, Types.GetWorkspaceIsIntegratedWithZapierQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspaceIsIntegratedWithZapierQuery, Types.GetWorkspaceIsIntegratedWithZapierQueryVariables>(GetWorkspaceIsIntegratedWithZapierDocument, baseOptions);
-      }
-export function useGetWorkspaceIsIntegratedWithZapierLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceIsIntegratedWithZapierQuery, Types.GetWorkspaceIsIntegratedWithZapierQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspaceIsIntegratedWithZapierQuery, Types.GetWorkspaceIsIntegratedWithZapierQueryVariables>(GetWorkspaceIsIntegratedWithZapierDocument, baseOptions);
-        }
-export type GetWorkspaceIsIntegratedWithZapierQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithZapierQuery>;
-export type GetWorkspaceIsIntegratedWithZapierLazyQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithZapierLazyQuery>;
-export type GetWorkspaceIsIntegratedWithZapierQueryResult = Apollo.QueryResult<Types.GetWorkspaceIsIntegratedWithZapierQuery, Types.GetWorkspaceIsIntegratedWithZapierQueryVariables>;
-export const GetWorkspaceIsIntegratedWithFrontDocument = gql`
-    query GetWorkspaceIsIntegratedWithFront($project_id: ID!) {
-  is_integrated_with_front: is_integrated_with(
-    integration_type: Front
-    project_id: $project_id
-  )
+export function useGetWorkspaceIsIntegratedWithZapierQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceIsIntegratedWithZapierQuery,
+		Types.GetWorkspaceIsIntegratedWithZapierQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceIsIntegratedWithZapierQuery,
+		Types.GetWorkspaceIsIntegratedWithZapierQueryVariables
+	>(GetWorkspaceIsIntegratedWithZapierDocument, baseOptions)
 }
-    `;
+export function useGetWorkspaceIsIntegratedWithZapierLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceIsIntegratedWithZapierQuery,
+		Types.GetWorkspaceIsIntegratedWithZapierQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceIsIntegratedWithZapierQuery,
+		Types.GetWorkspaceIsIntegratedWithZapierQueryVariables
+	>(GetWorkspaceIsIntegratedWithZapierDocument, baseOptions)
+}
+export type GetWorkspaceIsIntegratedWithZapierQueryHookResult = ReturnType<
+	typeof useGetWorkspaceIsIntegratedWithZapierQuery
+>
+export type GetWorkspaceIsIntegratedWithZapierLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceIsIntegratedWithZapierLazyQuery
+>
+export type GetWorkspaceIsIntegratedWithZapierQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceIsIntegratedWithZapierQuery,
+	Types.GetWorkspaceIsIntegratedWithZapierQueryVariables
+>
+export const GetWorkspaceIsIntegratedWithFrontDocument = gql`
+	query GetWorkspaceIsIntegratedWithFront($project_id: ID!) {
+		is_integrated_with_front: is_integrated_with(
+			integration_type: Front
+			project_id: $project_id
+		)
+	}
+`
 
 /**
  * __useGetWorkspaceIsIntegratedWithFrontQuery__
@@ -6836,23 +10490,46 @@ export const GetWorkspaceIsIntegratedWithFrontDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceIsIntegratedWithFrontQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceIsIntegratedWithFrontQuery, Types.GetWorkspaceIsIntegratedWithFrontQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspaceIsIntegratedWithFrontQuery, Types.GetWorkspaceIsIntegratedWithFrontQueryVariables>(GetWorkspaceIsIntegratedWithFrontDocument, baseOptions);
-      }
-export function useGetWorkspaceIsIntegratedWithFrontLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceIsIntegratedWithFrontQuery, Types.GetWorkspaceIsIntegratedWithFrontQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspaceIsIntegratedWithFrontQuery, Types.GetWorkspaceIsIntegratedWithFrontQueryVariables>(GetWorkspaceIsIntegratedWithFrontDocument, baseOptions);
-        }
-export type GetWorkspaceIsIntegratedWithFrontQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithFrontQuery>;
-export type GetWorkspaceIsIntegratedWithFrontLazyQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithFrontLazyQuery>;
-export type GetWorkspaceIsIntegratedWithFrontQueryResult = Apollo.QueryResult<Types.GetWorkspaceIsIntegratedWithFrontQuery, Types.GetWorkspaceIsIntegratedWithFrontQueryVariables>;
-export const GetWorkspaceIsIntegratedWithDiscordDocument = gql`
-    query GetWorkspaceIsIntegratedWithDiscord($project_id: ID!) {
-  is_integrated_with_discord: is_integrated_with(
-    integration_type: Discord
-    project_id: $project_id
-  )
+export function useGetWorkspaceIsIntegratedWithFrontQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceIsIntegratedWithFrontQuery,
+		Types.GetWorkspaceIsIntegratedWithFrontQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceIsIntegratedWithFrontQuery,
+		Types.GetWorkspaceIsIntegratedWithFrontQueryVariables
+	>(GetWorkspaceIsIntegratedWithFrontDocument, baseOptions)
 }
-    `;
+export function useGetWorkspaceIsIntegratedWithFrontLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceIsIntegratedWithFrontQuery,
+		Types.GetWorkspaceIsIntegratedWithFrontQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceIsIntegratedWithFrontQuery,
+		Types.GetWorkspaceIsIntegratedWithFrontQueryVariables
+	>(GetWorkspaceIsIntegratedWithFrontDocument, baseOptions)
+}
+export type GetWorkspaceIsIntegratedWithFrontQueryHookResult = ReturnType<
+	typeof useGetWorkspaceIsIntegratedWithFrontQuery
+>
+export type GetWorkspaceIsIntegratedWithFrontLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceIsIntegratedWithFrontLazyQuery
+>
+export type GetWorkspaceIsIntegratedWithFrontQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceIsIntegratedWithFrontQuery,
+	Types.GetWorkspaceIsIntegratedWithFrontQueryVariables
+>
+export const GetWorkspaceIsIntegratedWithDiscordDocument = gql`
+	query GetWorkspaceIsIntegratedWithDiscord($project_id: ID!) {
+		is_integrated_with_discord: is_integrated_with(
+			integration_type: Discord
+			project_id: $project_id
+		)
+	}
+`
 
 /**
  * __useGetWorkspaceIsIntegratedWithDiscordQuery__
@@ -6870,31 +10547,54 @@ export const GetWorkspaceIsIntegratedWithDiscordDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceIsIntegratedWithDiscordQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceIsIntegratedWithDiscordQuery, Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspaceIsIntegratedWithDiscordQuery, Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables>(GetWorkspaceIsIntegratedWithDiscordDocument, baseOptions);
-      }
-export function useGetWorkspaceIsIntegratedWithDiscordLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceIsIntegratedWithDiscordQuery, Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspaceIsIntegratedWithDiscordQuery, Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables>(GetWorkspaceIsIntegratedWithDiscordDocument, baseOptions);
-        }
-export type GetWorkspaceIsIntegratedWithDiscordQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithDiscordQuery>;
-export type GetWorkspaceIsIntegratedWithDiscordLazyQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithDiscordLazyQuery>;
-export type GetWorkspaceIsIntegratedWithDiscordQueryResult = Apollo.QueryResult<Types.GetWorkspaceIsIntegratedWithDiscordQuery, Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables>;
-export const GetWorkspaceIsIntegratedWithVercelDocument = gql`
-    query GetWorkspaceIsIntegratedWithVercel($project_id: ID!) {
-  is_integrated_with_vercel: is_integrated_with(
-    integration_type: Vercel
-    project_id: $project_id
-  )
-  vercel_projects(project_id: $project_id) {
-    id
-    name
-  }
-  vercel_project_mappings(project_id: $project_id) {
-    vercel_project_id
-    project_id
-  }
+export function useGetWorkspaceIsIntegratedWithDiscordQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceIsIntegratedWithDiscordQuery,
+		Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceIsIntegratedWithDiscordQuery,
+		Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables
+	>(GetWorkspaceIsIntegratedWithDiscordDocument, baseOptions)
 }
-    `;
+export function useGetWorkspaceIsIntegratedWithDiscordLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceIsIntegratedWithDiscordQuery,
+		Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceIsIntegratedWithDiscordQuery,
+		Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables
+	>(GetWorkspaceIsIntegratedWithDiscordDocument, baseOptions)
+}
+export type GetWorkspaceIsIntegratedWithDiscordQueryHookResult = ReturnType<
+	typeof useGetWorkspaceIsIntegratedWithDiscordQuery
+>
+export type GetWorkspaceIsIntegratedWithDiscordLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceIsIntegratedWithDiscordLazyQuery
+>
+export type GetWorkspaceIsIntegratedWithDiscordQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceIsIntegratedWithDiscordQuery,
+	Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables
+>
+export const GetWorkspaceIsIntegratedWithVercelDocument = gql`
+	query GetWorkspaceIsIntegratedWithVercel($project_id: ID!) {
+		is_integrated_with_vercel: is_integrated_with(
+			integration_type: Vercel
+			project_id: $project_id
+		)
+		vercel_projects(project_id: $project_id) {
+			id
+			name
+		}
+		vercel_project_mappings(project_id: $project_id) {
+			vercel_project_id
+			project_id
+		}
+	}
+`
 
 /**
  * __useGetWorkspaceIsIntegratedWithVercelQuery__
@@ -6912,35 +10612,60 @@ export const GetWorkspaceIsIntegratedWithVercelDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceIsIntegratedWithVercelQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceIsIntegratedWithVercelQuery, Types.GetWorkspaceIsIntegratedWithVercelQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspaceIsIntegratedWithVercelQuery, Types.GetWorkspaceIsIntegratedWithVercelQueryVariables>(GetWorkspaceIsIntegratedWithVercelDocument, baseOptions);
-      }
-export function useGetWorkspaceIsIntegratedWithVercelLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceIsIntegratedWithVercelQuery, Types.GetWorkspaceIsIntegratedWithVercelQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspaceIsIntegratedWithVercelQuery, Types.GetWorkspaceIsIntegratedWithVercelQueryVariables>(GetWorkspaceIsIntegratedWithVercelDocument, baseOptions);
-        }
-export type GetWorkspaceIsIntegratedWithVercelQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithVercelQuery>;
-export type GetWorkspaceIsIntegratedWithVercelLazyQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithVercelLazyQuery>;
-export type GetWorkspaceIsIntegratedWithVercelQueryResult = Apollo.QueryResult<Types.GetWorkspaceIsIntegratedWithVercelQuery, Types.GetWorkspaceIsIntegratedWithVercelQueryVariables>;
-export const GetClickUpIntegrationSettingsDocument = gql`
-    query GetClickUpIntegrationSettings($workspace_id: ID!) {
-  is_integrated: is_workspace_integrated_with(
-    integration_type: ClickUp
-    workspace_id: $workspace_id
-  )
-  clickup_teams(workspace_id: $workspace_id) {
-    id
-    name
-    spaces {
-      id
-      name
-    }
-  }
-  project_mappings: clickup_project_mappings(workspace_id: $workspace_id) {
-    project_id
-    clickup_space_id
-  }
+export function useGetWorkspaceIsIntegratedWithVercelQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceIsIntegratedWithVercelQuery,
+		Types.GetWorkspaceIsIntegratedWithVercelQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceIsIntegratedWithVercelQuery,
+		Types.GetWorkspaceIsIntegratedWithVercelQueryVariables
+	>(GetWorkspaceIsIntegratedWithVercelDocument, baseOptions)
 }
-    `;
+export function useGetWorkspaceIsIntegratedWithVercelLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceIsIntegratedWithVercelQuery,
+		Types.GetWorkspaceIsIntegratedWithVercelQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceIsIntegratedWithVercelQuery,
+		Types.GetWorkspaceIsIntegratedWithVercelQueryVariables
+	>(GetWorkspaceIsIntegratedWithVercelDocument, baseOptions)
+}
+export type GetWorkspaceIsIntegratedWithVercelQueryHookResult = ReturnType<
+	typeof useGetWorkspaceIsIntegratedWithVercelQuery
+>
+export type GetWorkspaceIsIntegratedWithVercelLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceIsIntegratedWithVercelLazyQuery
+>
+export type GetWorkspaceIsIntegratedWithVercelQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceIsIntegratedWithVercelQuery,
+	Types.GetWorkspaceIsIntegratedWithVercelQueryVariables
+>
+export const GetClickUpIntegrationSettingsDocument = gql`
+	query GetClickUpIntegrationSettings($workspace_id: ID!) {
+		is_integrated: is_workspace_integrated_with(
+			integration_type: ClickUp
+			workspace_id: $workspace_id
+		)
+		clickup_teams(workspace_id: $workspace_id) {
+			id
+			name
+			spaces {
+				id
+				name
+			}
+		}
+		project_mappings: clickup_project_mappings(
+			workspace_id: $workspace_id
+		) {
+			project_id
+			clickup_space_id
+		}
+	}
+`
 
 /**
  * __useGetClickUpIntegrationSettingsQuery__
@@ -6958,36 +10683,59 @@ export const GetClickUpIntegrationSettingsDocument = gql`
  *   },
  * });
  */
-export function useGetClickUpIntegrationSettingsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetClickUpIntegrationSettingsQuery, Types.GetClickUpIntegrationSettingsQueryVariables>) {
-        return Apollo.useQuery<Types.GetClickUpIntegrationSettingsQuery, Types.GetClickUpIntegrationSettingsQueryVariables>(GetClickUpIntegrationSettingsDocument, baseOptions);
-      }
-export function useGetClickUpIntegrationSettingsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetClickUpIntegrationSettingsQuery, Types.GetClickUpIntegrationSettingsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetClickUpIntegrationSettingsQuery, Types.GetClickUpIntegrationSettingsQueryVariables>(GetClickUpIntegrationSettingsDocument, baseOptions);
-        }
-export type GetClickUpIntegrationSettingsQueryHookResult = ReturnType<typeof useGetClickUpIntegrationSettingsQuery>;
-export type GetClickUpIntegrationSettingsLazyQueryHookResult = ReturnType<typeof useGetClickUpIntegrationSettingsLazyQuery>;
-export type GetClickUpIntegrationSettingsQueryResult = Apollo.QueryResult<Types.GetClickUpIntegrationSettingsQuery, Types.GetClickUpIntegrationSettingsQueryVariables>;
-export const GetHeightIntegrationSettingsDocument = gql`
-    query GetHeightIntegrationSettings($workspace_id: ID!) {
-  is_integrated: is_workspace_integrated_with(
-    integration_type: Height
-    workspace_id: $workspace_id
-  )
-  height_workspaces(workspace_id: $workspace_id) {
-    id
-    model
-    name
-    url
-  }
-  integration_project_mappings(
-    workspace_id: $workspace_id
-    integration_type: Height
-  ) {
-    project_id
-    external_id
-  }
+export function useGetClickUpIntegrationSettingsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetClickUpIntegrationSettingsQuery,
+		Types.GetClickUpIntegrationSettingsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetClickUpIntegrationSettingsQuery,
+		Types.GetClickUpIntegrationSettingsQueryVariables
+	>(GetClickUpIntegrationSettingsDocument, baseOptions)
 }
-    `;
+export function useGetClickUpIntegrationSettingsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetClickUpIntegrationSettingsQuery,
+		Types.GetClickUpIntegrationSettingsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetClickUpIntegrationSettingsQuery,
+		Types.GetClickUpIntegrationSettingsQueryVariables
+	>(GetClickUpIntegrationSettingsDocument, baseOptions)
+}
+export type GetClickUpIntegrationSettingsQueryHookResult = ReturnType<
+	typeof useGetClickUpIntegrationSettingsQuery
+>
+export type GetClickUpIntegrationSettingsLazyQueryHookResult = ReturnType<
+	typeof useGetClickUpIntegrationSettingsLazyQuery
+>
+export type GetClickUpIntegrationSettingsQueryResult = Apollo.QueryResult<
+	Types.GetClickUpIntegrationSettingsQuery,
+	Types.GetClickUpIntegrationSettingsQueryVariables
+>
+export const GetHeightIntegrationSettingsDocument = gql`
+	query GetHeightIntegrationSettings($workspace_id: ID!) {
+		is_integrated: is_workspace_integrated_with(
+			integration_type: Height
+			workspace_id: $workspace_id
+		)
+		height_workspaces(workspace_id: $workspace_id) {
+			id
+			model
+			name
+			url
+		}
+		integration_project_mappings(
+			workspace_id: $workspace_id
+			integration_type: Height
+		) {
+			project_id
+			external_id
+		}
+	}
+`
 
 /**
  * __useGetHeightIntegrationSettingsQuery__
@@ -7005,28 +10753,51 @@ export const GetHeightIntegrationSettingsDocument = gql`
  *   },
  * });
  */
-export function useGetHeightIntegrationSettingsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetHeightIntegrationSettingsQuery, Types.GetHeightIntegrationSettingsQueryVariables>) {
-        return Apollo.useQuery<Types.GetHeightIntegrationSettingsQuery, Types.GetHeightIntegrationSettingsQueryVariables>(GetHeightIntegrationSettingsDocument, baseOptions);
-      }
-export function useGetHeightIntegrationSettingsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetHeightIntegrationSettingsQuery, Types.GetHeightIntegrationSettingsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetHeightIntegrationSettingsQuery, Types.GetHeightIntegrationSettingsQueryVariables>(GetHeightIntegrationSettingsDocument, baseOptions);
-        }
-export type GetHeightIntegrationSettingsQueryHookResult = ReturnType<typeof useGetHeightIntegrationSettingsQuery>;
-export type GetHeightIntegrationSettingsLazyQueryHookResult = ReturnType<typeof useGetHeightIntegrationSettingsLazyQuery>;
-export type GetHeightIntegrationSettingsQueryResult = Apollo.QueryResult<Types.GetHeightIntegrationSettingsQuery, Types.GetHeightIntegrationSettingsQueryVariables>;
-export const GetGitHubIntegrationSettingsDocument = gql`
-    query GetGitHubIntegrationSettings($workspace_id: ID!) {
-  is_integrated: is_workspace_integrated_with(
-    integration_type: GitHub
-    workspace_id: $workspace_id
-  )
-  github_repos(workspace_id: $workspace_id) {
-    repo_id
-    name
-    key
-  }
+export function useGetHeightIntegrationSettingsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetHeightIntegrationSettingsQuery,
+		Types.GetHeightIntegrationSettingsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetHeightIntegrationSettingsQuery,
+		Types.GetHeightIntegrationSettingsQueryVariables
+	>(GetHeightIntegrationSettingsDocument, baseOptions)
 }
-    `;
+export function useGetHeightIntegrationSettingsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetHeightIntegrationSettingsQuery,
+		Types.GetHeightIntegrationSettingsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetHeightIntegrationSettingsQuery,
+		Types.GetHeightIntegrationSettingsQueryVariables
+	>(GetHeightIntegrationSettingsDocument, baseOptions)
+}
+export type GetHeightIntegrationSettingsQueryHookResult = ReturnType<
+	typeof useGetHeightIntegrationSettingsQuery
+>
+export type GetHeightIntegrationSettingsLazyQueryHookResult = ReturnType<
+	typeof useGetHeightIntegrationSettingsLazyQuery
+>
+export type GetHeightIntegrationSettingsQueryResult = Apollo.QueryResult<
+	Types.GetHeightIntegrationSettingsQuery,
+	Types.GetHeightIntegrationSettingsQueryVariables
+>
+export const GetGitHubIntegrationSettingsDocument = gql`
+	query GetGitHubIntegrationSettings($workspace_id: ID!) {
+		is_integrated: is_workspace_integrated_with(
+			integration_type: GitHub
+			workspace_id: $workspace_id
+		)
+		github_repos(workspace_id: $workspace_id) {
+			repo_id
+			name
+			key
+		}
+	}
+`
 
 /**
  * __useGetGitHubIntegrationSettingsQuery__
@@ -7044,20 +10815,46 @@ export const GetGitHubIntegrationSettingsDocument = gql`
  *   },
  * });
  */
-export function useGetGitHubIntegrationSettingsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetGitHubIntegrationSettingsQuery, Types.GetGitHubIntegrationSettingsQueryVariables>) {
-        return Apollo.useQuery<Types.GetGitHubIntegrationSettingsQuery, Types.GetGitHubIntegrationSettingsQueryVariables>(GetGitHubIntegrationSettingsDocument, baseOptions);
-      }
-export function useGetGitHubIntegrationSettingsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetGitHubIntegrationSettingsQuery, Types.GetGitHubIntegrationSettingsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetGitHubIntegrationSettingsQuery, Types.GetGitHubIntegrationSettingsQueryVariables>(GetGitHubIntegrationSettingsDocument, baseOptions);
-        }
-export type GetGitHubIntegrationSettingsQueryHookResult = ReturnType<typeof useGetGitHubIntegrationSettingsQuery>;
-export type GetGitHubIntegrationSettingsLazyQueryHookResult = ReturnType<typeof useGetGitHubIntegrationSettingsLazyQuery>;
-export type GetGitHubIntegrationSettingsQueryResult = Apollo.QueryResult<Types.GetGitHubIntegrationSettingsQuery, Types.GetGitHubIntegrationSettingsQueryVariables>;
-export const GetGitHubIssueLabelsDocument = gql`
-    query GetGitHubIssueLabels($workspace_id: ID!, $repository: String!) {
-  github_issue_labels(workspace_id: $workspace_id, repository: $repository)
+export function useGetGitHubIntegrationSettingsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetGitHubIntegrationSettingsQuery,
+		Types.GetGitHubIntegrationSettingsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetGitHubIntegrationSettingsQuery,
+		Types.GetGitHubIntegrationSettingsQueryVariables
+	>(GetGitHubIntegrationSettingsDocument, baseOptions)
 }
-    `;
+export function useGetGitHubIntegrationSettingsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetGitHubIntegrationSettingsQuery,
+		Types.GetGitHubIntegrationSettingsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetGitHubIntegrationSettingsQuery,
+		Types.GetGitHubIntegrationSettingsQueryVariables
+	>(GetGitHubIntegrationSettingsDocument, baseOptions)
+}
+export type GetGitHubIntegrationSettingsQueryHookResult = ReturnType<
+	typeof useGetGitHubIntegrationSettingsQuery
+>
+export type GetGitHubIntegrationSettingsLazyQueryHookResult = ReturnType<
+	typeof useGetGitHubIntegrationSettingsLazyQuery
+>
+export type GetGitHubIntegrationSettingsQueryResult = Apollo.QueryResult<
+	Types.GetGitHubIntegrationSettingsQuery,
+	Types.GetGitHubIntegrationSettingsQueryVariables
+>
+export const GetGitHubIssueLabelsDocument = gql`
+	query GetGitHubIssueLabels($workspace_id: ID!, $repository: String!) {
+		github_issue_labels(
+			workspace_id: $workspace_id
+			repository: $repository
+		)
+	}
+`
 
 /**
  * __useGetGitHubIssueLabelsQuery__
@@ -7076,23 +10873,49 @@ export const GetGitHubIssueLabelsDocument = gql`
  *   },
  * });
  */
-export function useGetGitHubIssueLabelsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetGitHubIssueLabelsQuery, Types.GetGitHubIssueLabelsQueryVariables>) {
-        return Apollo.useQuery<Types.GetGitHubIssueLabelsQuery, Types.GetGitHubIssueLabelsQueryVariables>(GetGitHubIssueLabelsDocument, baseOptions);
-      }
-export function useGetGitHubIssueLabelsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetGitHubIssueLabelsQuery, Types.GetGitHubIssueLabelsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetGitHubIssueLabelsQuery, Types.GetGitHubIssueLabelsQueryVariables>(GetGitHubIssueLabelsDocument, baseOptions);
-        }
-export type GetGitHubIssueLabelsQueryHookResult = ReturnType<typeof useGetGitHubIssueLabelsQuery>;
-export type GetGitHubIssueLabelsLazyQueryHookResult = ReturnType<typeof useGetGitHubIssueLabelsLazyQuery>;
-export type GetGitHubIssueLabelsQueryResult = Apollo.QueryResult<Types.GetGitHubIssueLabelsQuery, Types.GetGitHubIssueLabelsQueryVariables>;
-export const GetProjectIntegratedWithDocument = gql`
-    query GetProjectIntegratedWith($project_id: ID!, $integration_type: IntegrationType!) {
-  is_project_integrated_with(
-    integration_type: $integration_type
-    project_id: $project_id
-  )
+export function useGetGitHubIssueLabelsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetGitHubIssueLabelsQuery,
+		Types.GetGitHubIssueLabelsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetGitHubIssueLabelsQuery,
+		Types.GetGitHubIssueLabelsQueryVariables
+	>(GetGitHubIssueLabelsDocument, baseOptions)
 }
-    `;
+export function useGetGitHubIssueLabelsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetGitHubIssueLabelsQuery,
+		Types.GetGitHubIssueLabelsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetGitHubIssueLabelsQuery,
+		Types.GetGitHubIssueLabelsQueryVariables
+	>(GetGitHubIssueLabelsDocument, baseOptions)
+}
+export type GetGitHubIssueLabelsQueryHookResult = ReturnType<
+	typeof useGetGitHubIssueLabelsQuery
+>
+export type GetGitHubIssueLabelsLazyQueryHookResult = ReturnType<
+	typeof useGetGitHubIssueLabelsLazyQuery
+>
+export type GetGitHubIssueLabelsQueryResult = Apollo.QueryResult<
+	Types.GetGitHubIssueLabelsQuery,
+	Types.GetGitHubIssueLabelsQueryVariables
+>
+export const GetProjectIntegratedWithDocument = gql`
+	query GetProjectIntegratedWith(
+		$project_id: ID!
+		$integration_type: IntegrationType!
+	) {
+		is_project_integrated_with(
+			integration_type: $integration_type
+			project_id: $project_id
+		)
+	}
+`
 
 /**
  * __useGetProjectIntegratedWithQuery__
@@ -7111,31 +10934,54 @@ export const GetProjectIntegratedWithDocument = gql`
  *   },
  * });
  */
-export function useGetProjectIntegratedWithQuery(baseOptions: Apollo.QueryHookOptions<Types.GetProjectIntegratedWithQuery, Types.GetProjectIntegratedWithQueryVariables>) {
-        return Apollo.useQuery<Types.GetProjectIntegratedWithQuery, Types.GetProjectIntegratedWithQueryVariables>(GetProjectIntegratedWithDocument, baseOptions);
-      }
-export function useGetProjectIntegratedWithLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectIntegratedWithQuery, Types.GetProjectIntegratedWithQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetProjectIntegratedWithQuery, Types.GetProjectIntegratedWithQueryVariables>(GetProjectIntegratedWithDocument, baseOptions);
-        }
-export type GetProjectIntegratedWithQueryHookResult = ReturnType<typeof useGetProjectIntegratedWithQuery>;
-export type GetProjectIntegratedWithLazyQueryHookResult = ReturnType<typeof useGetProjectIntegratedWithLazyQuery>;
-export type GetProjectIntegratedWithQueryResult = Apollo.QueryResult<Types.GetProjectIntegratedWithQuery, Types.GetProjectIntegratedWithQueryVariables>;
-export const GetClickUpFoldersDocument = gql`
-    query GetClickUpFolders($project_id: ID!) {
-  clickup_folders(project_id: $project_id) {
-    id
-    name
-    lists {
-      id
-      name
-    }
-  }
-  clickup_folderless_lists(project_id: $project_id) {
-    id
-    name
-  }
+export function useGetProjectIntegratedWithQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetProjectIntegratedWithQuery,
+		Types.GetProjectIntegratedWithQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetProjectIntegratedWithQuery,
+		Types.GetProjectIntegratedWithQueryVariables
+	>(GetProjectIntegratedWithDocument, baseOptions)
 }
-    `;
+export function useGetProjectIntegratedWithLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetProjectIntegratedWithQuery,
+		Types.GetProjectIntegratedWithQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetProjectIntegratedWithQuery,
+		Types.GetProjectIntegratedWithQueryVariables
+	>(GetProjectIntegratedWithDocument, baseOptions)
+}
+export type GetProjectIntegratedWithQueryHookResult = ReturnType<
+	typeof useGetProjectIntegratedWithQuery
+>
+export type GetProjectIntegratedWithLazyQueryHookResult = ReturnType<
+	typeof useGetProjectIntegratedWithLazyQuery
+>
+export type GetProjectIntegratedWithQueryResult = Apollo.QueryResult<
+	Types.GetProjectIntegratedWithQuery,
+	Types.GetProjectIntegratedWithQueryVariables
+>
+export const GetClickUpFoldersDocument = gql`
+	query GetClickUpFolders($project_id: ID!) {
+		clickup_folders(project_id: $project_id) {
+			id
+			name
+			lists {
+				id
+				name
+			}
+		}
+		clickup_folderless_lists(project_id: $project_id) {
+			id
+			name
+		}
+	}
+`
 
 /**
  * __useGetClickUpFoldersQuery__
@@ -7153,23 +10999,46 @@ export const GetClickUpFoldersDocument = gql`
  *   },
  * });
  */
-export function useGetClickUpFoldersQuery(baseOptions: Apollo.QueryHookOptions<Types.GetClickUpFoldersQuery, Types.GetClickUpFoldersQueryVariables>) {
-        return Apollo.useQuery<Types.GetClickUpFoldersQuery, Types.GetClickUpFoldersQueryVariables>(GetClickUpFoldersDocument, baseOptions);
-      }
-export function useGetClickUpFoldersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetClickUpFoldersQuery, Types.GetClickUpFoldersQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetClickUpFoldersQuery, Types.GetClickUpFoldersQueryVariables>(GetClickUpFoldersDocument, baseOptions);
-        }
-export type GetClickUpFoldersQueryHookResult = ReturnType<typeof useGetClickUpFoldersQuery>;
-export type GetClickUpFoldersLazyQueryHookResult = ReturnType<typeof useGetClickUpFoldersLazyQuery>;
-export type GetClickUpFoldersQueryResult = Apollo.QueryResult<Types.GetClickUpFoldersQuery, Types.GetClickUpFoldersQueryVariables>;
-export const GetHeightListsDocument = gql`
-    query GetHeightLists($project_id: ID!) {
-  height_lists(project_id: $project_id) {
-    id
-    name
-  }
+export function useGetClickUpFoldersQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetClickUpFoldersQuery,
+		Types.GetClickUpFoldersQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetClickUpFoldersQuery,
+		Types.GetClickUpFoldersQueryVariables
+	>(GetClickUpFoldersDocument, baseOptions)
 }
-    `;
+export function useGetClickUpFoldersLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetClickUpFoldersQuery,
+		Types.GetClickUpFoldersQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetClickUpFoldersQuery,
+		Types.GetClickUpFoldersQueryVariables
+	>(GetClickUpFoldersDocument, baseOptions)
+}
+export type GetClickUpFoldersQueryHookResult = ReturnType<
+	typeof useGetClickUpFoldersQuery
+>
+export type GetClickUpFoldersLazyQueryHookResult = ReturnType<
+	typeof useGetClickUpFoldersLazyQuery
+>
+export type GetClickUpFoldersQueryResult = Apollo.QueryResult<
+	Types.GetClickUpFoldersQuery,
+	Types.GetClickUpFoldersQueryVariables
+>
+export const GetHeightListsDocument = gql`
+	query GetHeightLists($project_id: ID!) {
+		height_lists(project_id: $project_id) {
+			id
+			name
+		}
+	}
+`
 
 /**
  * __useGetHeightListsQuery__
@@ -7187,20 +11056,43 @@ export const GetHeightListsDocument = gql`
  *   },
  * });
  */
-export function useGetHeightListsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetHeightListsQuery, Types.GetHeightListsQueryVariables>) {
-        return Apollo.useQuery<Types.GetHeightListsQuery, Types.GetHeightListsQueryVariables>(GetHeightListsDocument, baseOptions);
-      }
-export function useGetHeightListsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetHeightListsQuery, Types.GetHeightListsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetHeightListsQuery, Types.GetHeightListsQueryVariables>(GetHeightListsDocument, baseOptions);
-        }
-export type GetHeightListsQueryHookResult = ReturnType<typeof useGetHeightListsQuery>;
-export type GetHeightListsLazyQueryHookResult = ReturnType<typeof useGetHeightListsLazyQuery>;
-export type GetHeightListsQueryResult = Apollo.QueryResult<Types.GetHeightListsQuery, Types.GetHeightListsQueryVariables>;
-export const GenerateNewZapierAccessTokenJwtDocument = gql`
-    query GenerateNewZapierAccessTokenJwt($project_id: ID!) {
-  generate_zapier_access_token(project_id: $project_id)
+export function useGetHeightListsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetHeightListsQuery,
+		Types.GetHeightListsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetHeightListsQuery,
+		Types.GetHeightListsQueryVariables
+	>(GetHeightListsDocument, baseOptions)
 }
-    `;
+export function useGetHeightListsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetHeightListsQuery,
+		Types.GetHeightListsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetHeightListsQuery,
+		Types.GetHeightListsQueryVariables
+	>(GetHeightListsDocument, baseOptions)
+}
+export type GetHeightListsQueryHookResult = ReturnType<
+	typeof useGetHeightListsQuery
+>
+export type GetHeightListsLazyQueryHookResult = ReturnType<
+	typeof useGetHeightListsLazyQuery
+>
+export type GetHeightListsQueryResult = Apollo.QueryResult<
+	Types.GetHeightListsQuery,
+	Types.GetHeightListsQueryVariables
+>
+export const GenerateNewZapierAccessTokenJwtDocument = gql`
+	query GenerateNewZapierAccessTokenJwt($project_id: ID!) {
+		generate_zapier_access_token(project_id: $project_id)
+	}
+`
 
 /**
  * __useGenerateNewZapierAccessTokenJwtQuery__
@@ -7218,20 +11110,43 @@ export const GenerateNewZapierAccessTokenJwtDocument = gql`
  *   },
  * });
  */
-export function useGenerateNewZapierAccessTokenJwtQuery(baseOptions: Apollo.QueryHookOptions<Types.GenerateNewZapierAccessTokenJwtQuery, Types.GenerateNewZapierAccessTokenJwtQueryVariables>) {
-        return Apollo.useQuery<Types.GenerateNewZapierAccessTokenJwtQuery, Types.GenerateNewZapierAccessTokenJwtQueryVariables>(GenerateNewZapierAccessTokenJwtDocument, baseOptions);
-      }
-export function useGenerateNewZapierAccessTokenJwtLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GenerateNewZapierAccessTokenJwtQuery, Types.GenerateNewZapierAccessTokenJwtQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GenerateNewZapierAccessTokenJwtQuery, Types.GenerateNewZapierAccessTokenJwtQueryVariables>(GenerateNewZapierAccessTokenJwtDocument, baseOptions);
-        }
-export type GenerateNewZapierAccessTokenJwtQueryHookResult = ReturnType<typeof useGenerateNewZapierAccessTokenJwtQuery>;
-export type GenerateNewZapierAccessTokenJwtLazyQueryHookResult = ReturnType<typeof useGenerateNewZapierAccessTokenJwtLazyQuery>;
-export type GenerateNewZapierAccessTokenJwtQueryResult = Apollo.QueryResult<Types.GenerateNewZapierAccessTokenJwtQuery, Types.GenerateNewZapierAccessTokenJwtQueryVariables>;
-export const GetIdentifierSuggestionsDocument = gql`
-    query GetIdentifierSuggestions($project_id: ID!, $query: String!) {
-  identifier_suggestion(project_id: $project_id, query: $query)
+export function useGenerateNewZapierAccessTokenJwtQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GenerateNewZapierAccessTokenJwtQuery,
+		Types.GenerateNewZapierAccessTokenJwtQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GenerateNewZapierAccessTokenJwtQuery,
+		Types.GenerateNewZapierAccessTokenJwtQueryVariables
+	>(GenerateNewZapierAccessTokenJwtDocument, baseOptions)
 }
-    `;
+export function useGenerateNewZapierAccessTokenJwtLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GenerateNewZapierAccessTokenJwtQuery,
+		Types.GenerateNewZapierAccessTokenJwtQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GenerateNewZapierAccessTokenJwtQuery,
+		Types.GenerateNewZapierAccessTokenJwtQueryVariables
+	>(GenerateNewZapierAccessTokenJwtDocument, baseOptions)
+}
+export type GenerateNewZapierAccessTokenJwtQueryHookResult = ReturnType<
+	typeof useGenerateNewZapierAccessTokenJwtQuery
+>
+export type GenerateNewZapierAccessTokenJwtLazyQueryHookResult = ReturnType<
+	typeof useGenerateNewZapierAccessTokenJwtLazyQuery
+>
+export type GenerateNewZapierAccessTokenJwtQueryResult = Apollo.QueryResult<
+	Types.GenerateNewZapierAccessTokenJwtQuery,
+	Types.GenerateNewZapierAccessTokenJwtQueryVariables
+>
+export const GetIdentifierSuggestionsDocument = gql`
+	query GetIdentifierSuggestions($project_id: ID!, $query: String!) {
+		identifier_suggestion(project_id: $project_id, query: $query)
+	}
+`
 
 /**
  * __useGetIdentifierSuggestionsQuery__
@@ -7250,45 +11165,69 @@ export const GetIdentifierSuggestionsDocument = gql`
  *   },
  * });
  */
-export function useGetIdentifierSuggestionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetIdentifierSuggestionsQuery, Types.GetIdentifierSuggestionsQueryVariables>) {
-        return Apollo.useQuery<Types.GetIdentifierSuggestionsQuery, Types.GetIdentifierSuggestionsQueryVariables>(GetIdentifierSuggestionsDocument, baseOptions);
-      }
-export function useGetIdentifierSuggestionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetIdentifierSuggestionsQuery, Types.GetIdentifierSuggestionsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetIdentifierSuggestionsQuery, Types.GetIdentifierSuggestionsQueryVariables>(GetIdentifierSuggestionsDocument, baseOptions);
-        }
-export type GetIdentifierSuggestionsQueryHookResult = ReturnType<typeof useGetIdentifierSuggestionsQuery>;
-export type GetIdentifierSuggestionsLazyQueryHookResult = ReturnType<typeof useGetIdentifierSuggestionsLazyQuery>;
-export type GetIdentifierSuggestionsQueryResult = Apollo.QueryResult<Types.GetIdentifierSuggestionsQuery, Types.GetIdentifierSuggestionsQueryVariables>;
-export const GetLogAlertDocument = gql`
-    query GetLogAlert($id: ID!) {
-  log_alert(id: $id) {
-    ChannelsToNotify {
-      webhook_channel
-      webhook_channel_id
-    }
-    DiscordChannelsToNotify {
-      ...DiscordChannelFragment
-    }
-    WebhookDestinations {
-      url
-      authorization
-    }
-    CountThreshold
-    DailyFrequency
-    disabled
-    EmailsToNotify
-    ExcludedEnvironments
-    id
-    LastAdminToEditID
-    Name
-    updated_at
-    BelowThreshold
-    ThresholdWindow
-    Type
-    query
-  }
+export function useGetIdentifierSuggestionsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetIdentifierSuggestionsQuery,
+		Types.GetIdentifierSuggestionsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetIdentifierSuggestionsQuery,
+		Types.GetIdentifierSuggestionsQueryVariables
+	>(GetIdentifierSuggestionsDocument, baseOptions)
 }
-    ${DiscordChannelFragmentFragmentDoc}`;
+export function useGetIdentifierSuggestionsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetIdentifierSuggestionsQuery,
+		Types.GetIdentifierSuggestionsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetIdentifierSuggestionsQuery,
+		Types.GetIdentifierSuggestionsQueryVariables
+	>(GetIdentifierSuggestionsDocument, baseOptions)
+}
+export type GetIdentifierSuggestionsQueryHookResult = ReturnType<
+	typeof useGetIdentifierSuggestionsQuery
+>
+export type GetIdentifierSuggestionsLazyQueryHookResult = ReturnType<
+	typeof useGetIdentifierSuggestionsLazyQuery
+>
+export type GetIdentifierSuggestionsQueryResult = Apollo.QueryResult<
+	Types.GetIdentifierSuggestionsQuery,
+	Types.GetIdentifierSuggestionsQueryVariables
+>
+export const GetLogAlertDocument = gql`
+	query GetLogAlert($id: ID!) {
+		log_alert(id: $id) {
+			ChannelsToNotify {
+				webhook_channel
+				webhook_channel_id
+			}
+			DiscordChannelsToNotify {
+				...DiscordChannelFragment
+			}
+			WebhookDestinations {
+				url
+				authorization
+			}
+			CountThreshold
+			DailyFrequency
+			disabled
+			EmailsToNotify
+			ExcludedEnvironments
+			id
+			LastAdminToEditID
+			Name
+			updated_at
+			BelowThreshold
+			ThresholdWindow
+			Type
+			query
+		}
+	}
+	${DiscordChannelFragmentFragmentDoc}
+`
 
 /**
  * __useGetLogAlertQuery__
@@ -7306,46 +11245,68 @@ export const GetLogAlertDocument = gql`
  *   },
  * });
  */
-export function useGetLogAlertQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogAlertQuery, Types.GetLogAlertQueryVariables>) {
-        return Apollo.useQuery<Types.GetLogAlertQuery, Types.GetLogAlertQueryVariables>(GetLogAlertDocument, baseOptions);
-      }
-export function useGetLogAlertLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogAlertQuery, Types.GetLogAlertQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetLogAlertQuery, Types.GetLogAlertQueryVariables>(GetLogAlertDocument, baseOptions);
-        }
-export type GetLogAlertQueryHookResult = ReturnType<typeof useGetLogAlertQuery>;
-export type GetLogAlertLazyQueryHookResult = ReturnType<typeof useGetLogAlertLazyQuery>;
-export type GetLogAlertQueryResult = Apollo.QueryResult<Types.GetLogAlertQuery, Types.GetLogAlertQueryVariables>;
-export const GetLogAlertsPagePayloadDocument = gql`
-    query GetLogAlertsPagePayload($project_id: ID!) {
-  is_integrated_with_slack: is_integrated_with(
-    integration_type: Slack
-    project_id: $project_id
-  )
-  is_integrated_with_discord: is_integrated_with(
-    integration_type: Discord
-    project_id: $project_id
-  )
-  slack_channel_suggestion(project_id: $project_id) {
-    webhook_channel
-    webhook_channel_id
-  }
-  discord_channel_suggestions(project_id: $project_id) {
-    ...DiscordChannelFragment
-  }
-  admins: workspace_admins_by_project_id(project_id: $project_id) {
-    admin {
-      id
-      name
-      email
-      photo_url
-    }
-  }
-  environment_suggestion(project_id: $project_id) {
-    name
-    value
-  }
+export function useGetLogAlertQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogAlertQuery,
+		Types.GetLogAlertQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetLogAlertQuery,
+		Types.GetLogAlertQueryVariables
+	>(GetLogAlertDocument, baseOptions)
 }
-    ${DiscordChannelFragmentFragmentDoc}`;
+export function useGetLogAlertLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogAlertQuery,
+		Types.GetLogAlertQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetLogAlertQuery,
+		Types.GetLogAlertQueryVariables
+	>(GetLogAlertDocument, baseOptions)
+}
+export type GetLogAlertQueryHookResult = ReturnType<typeof useGetLogAlertQuery>
+export type GetLogAlertLazyQueryHookResult = ReturnType<
+	typeof useGetLogAlertLazyQuery
+>
+export type GetLogAlertQueryResult = Apollo.QueryResult<
+	Types.GetLogAlertQuery,
+	Types.GetLogAlertQueryVariables
+>
+export const GetLogAlertsPagePayloadDocument = gql`
+	query GetLogAlertsPagePayload($project_id: ID!) {
+		is_integrated_with_slack: is_integrated_with(
+			integration_type: Slack
+			project_id: $project_id
+		)
+		is_integrated_with_discord: is_integrated_with(
+			integration_type: Discord
+			project_id: $project_id
+		)
+		slack_channel_suggestion(project_id: $project_id) {
+			webhook_channel
+			webhook_channel_id
+		}
+		discord_channel_suggestions(project_id: $project_id) {
+			...DiscordChannelFragment
+		}
+		admins: workspace_admins_by_project_id(project_id: $project_id) {
+			admin {
+				id
+				name
+				email
+				photo_url
+			}
+		}
+		environment_suggestion(project_id: $project_id) {
+			name
+			value
+		}
+	}
+	${DiscordChannelFragmentFragmentDoc}
+`
 
 /**
  * __useGetLogAlertsPagePayloadQuery__
@@ -7363,139 +11324,163 @@ export const GetLogAlertsPagePayloadDocument = gql`
  *   },
  * });
  */
-export function useGetLogAlertsPagePayloadQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogAlertsPagePayloadQuery, Types.GetLogAlertsPagePayloadQueryVariables>) {
-        return Apollo.useQuery<Types.GetLogAlertsPagePayloadQuery, Types.GetLogAlertsPagePayloadQueryVariables>(GetLogAlertsPagePayloadDocument, baseOptions);
-      }
-export function useGetLogAlertsPagePayloadLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogAlertsPagePayloadQuery, Types.GetLogAlertsPagePayloadQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetLogAlertsPagePayloadQuery, Types.GetLogAlertsPagePayloadQueryVariables>(GetLogAlertsPagePayloadDocument, baseOptions);
-        }
-export type GetLogAlertsPagePayloadQueryHookResult = ReturnType<typeof useGetLogAlertsPagePayloadQuery>;
-export type GetLogAlertsPagePayloadLazyQueryHookResult = ReturnType<typeof useGetLogAlertsPagePayloadLazyQuery>;
-export type GetLogAlertsPagePayloadQueryResult = Apollo.QueryResult<Types.GetLogAlertsPagePayloadQuery, Types.GetLogAlertsPagePayloadQueryVariables>;
-export const GetAlertsPagePayloadDocument = gql`
-    query GetAlertsPagePayload($project_id: ID!) {
-  is_integrated_with_slack: is_integrated_with(
-    integration_type: Slack
-    project_id: $project_id
-  )
-  is_integrated_with_discord: is_integrated_with(
-    integration_type: Discord
-    project_id: $project_id
-  )
-  slack_channel_suggestion(project_id: $project_id) {
-    webhook_channel
-    webhook_channel_id
-  }
-  discord_channel_suggestions(project_id: $project_id) {
-    ...DiscordChannelFragment
-  }
-  admins: workspace_admins_by_project_id(project_id: $project_id) {
-    admin {
-      id
-      name
-      email
-      photo_url
-    }
-  }
-  environment_suggestion(project_id: $project_id) {
-    name
-    value
-  }
-  error_alerts(project_id: $project_id) {
-    ChannelsToNotify {
-      webhook_channel
-      webhook_channel_id
-    }
-    DiscordChannelsToNotify {
-      ...DiscordChannelFragment
-    }
-    WebhookDestinations {
-      url
-      authorization
-    }
-    EmailsToNotify
-    ExcludedEnvironments
-    updated_at
-    CountThreshold
-    LastAdminToEditID
-    ThresholdWindow
-    RegexGroups
-    Frequency
-    id
-    Type
-    Name
-    DailyFrequency
-    disabled
-  }
-  new_session_alerts(project_id: $project_id) {
-    ...SessionAlertFragment
-  }
-  rage_click_alerts(project_id: $project_id) {
-    ...SessionAlertFragment
-  }
-  new_user_alerts(project_id: $project_id) {
-    ...SessionAlertFragment
-  }
-  track_properties_alerts(project_id: $project_id) {
-    ...SessionAlertFragment
-  }
-  user_properties_alerts(project_id: $project_id) {
-    ...SessionAlertFragment
-  }
-  metric_monitors(project_id: $project_id) {
-    id
-    updated_at
-    name
-    channels_to_notify {
-      webhook_channel
-      webhook_channel_id
-    }
-    discord_channels_to_notify {
-      id
-      name
-    }
-    webhook_destinations {
-      url
-      authorization
-    }
-    emails_to_notify
-    aggregator
-    period_minutes
-    metric_to_monitor
-    last_admin_to_edit_id
-    threshold
-    filters {
-      tag
-      op
-      value
-    }
-    units
-    disabled
-  }
-  log_alerts(project_id: $project_id) {
-    ChannelsToNotify {
-      webhook_channel
-      webhook_channel_id
-    }
-    DiscordChannelsToNotify {
-      ...DiscordChannelFragment
-    }
-    CountThreshold
-    DailyFrequency
-    disabled
-    EmailsToNotify
-    ExcludedEnvironments
-    id
-    LastAdminToEditID
-    Name
-    updated_at
-    ThresholdWindow
-    Type
-    query
-  }
+export function useGetLogAlertsPagePayloadQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogAlertsPagePayloadQuery,
+		Types.GetLogAlertsPagePayloadQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetLogAlertsPagePayloadQuery,
+		Types.GetLogAlertsPagePayloadQueryVariables
+	>(GetLogAlertsPagePayloadDocument, baseOptions)
 }
-    ${DiscordChannelFragmentFragmentDoc}
-${SessionAlertFragmentFragmentDoc}`;
+export function useGetLogAlertsPagePayloadLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogAlertsPagePayloadQuery,
+		Types.GetLogAlertsPagePayloadQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetLogAlertsPagePayloadQuery,
+		Types.GetLogAlertsPagePayloadQueryVariables
+	>(GetLogAlertsPagePayloadDocument, baseOptions)
+}
+export type GetLogAlertsPagePayloadQueryHookResult = ReturnType<
+	typeof useGetLogAlertsPagePayloadQuery
+>
+export type GetLogAlertsPagePayloadLazyQueryHookResult = ReturnType<
+	typeof useGetLogAlertsPagePayloadLazyQuery
+>
+export type GetLogAlertsPagePayloadQueryResult = Apollo.QueryResult<
+	Types.GetLogAlertsPagePayloadQuery,
+	Types.GetLogAlertsPagePayloadQueryVariables
+>
+export const GetAlertsPagePayloadDocument = gql`
+	query GetAlertsPagePayload($project_id: ID!) {
+		is_integrated_with_slack: is_integrated_with(
+			integration_type: Slack
+			project_id: $project_id
+		)
+		is_integrated_with_discord: is_integrated_with(
+			integration_type: Discord
+			project_id: $project_id
+		)
+		slack_channel_suggestion(project_id: $project_id) {
+			webhook_channel
+			webhook_channel_id
+		}
+		discord_channel_suggestions(project_id: $project_id) {
+			...DiscordChannelFragment
+		}
+		admins: workspace_admins_by_project_id(project_id: $project_id) {
+			admin {
+				id
+				name
+				email
+				photo_url
+			}
+		}
+		environment_suggestion(project_id: $project_id) {
+			name
+			value
+		}
+		error_alerts(project_id: $project_id) {
+			ChannelsToNotify {
+				webhook_channel
+				webhook_channel_id
+			}
+			DiscordChannelsToNotify {
+				...DiscordChannelFragment
+			}
+			WebhookDestinations {
+				url
+				authorization
+			}
+			EmailsToNotify
+			ExcludedEnvironments
+			updated_at
+			CountThreshold
+			LastAdminToEditID
+			ThresholdWindow
+			RegexGroups
+			Frequency
+			id
+			Type
+			Name
+			DailyFrequency
+			disabled
+		}
+		new_session_alerts(project_id: $project_id) {
+			...SessionAlertFragment
+		}
+		rage_click_alerts(project_id: $project_id) {
+			...SessionAlertFragment
+		}
+		new_user_alerts(project_id: $project_id) {
+			...SessionAlertFragment
+		}
+		track_properties_alerts(project_id: $project_id) {
+			...SessionAlertFragment
+		}
+		user_properties_alerts(project_id: $project_id) {
+			...SessionAlertFragment
+		}
+		metric_monitors(project_id: $project_id) {
+			id
+			updated_at
+			name
+			channels_to_notify {
+				webhook_channel
+				webhook_channel_id
+			}
+			discord_channels_to_notify {
+				id
+				name
+			}
+			webhook_destinations {
+				url
+				authorization
+			}
+			emails_to_notify
+			aggregator
+			period_minutes
+			metric_to_monitor
+			last_admin_to_edit_id
+			threshold
+			filters {
+				tag
+				op
+				value
+			}
+			units
+			disabled
+		}
+		log_alerts(project_id: $project_id) {
+			ChannelsToNotify {
+				webhook_channel
+				webhook_channel_id
+			}
+			DiscordChannelsToNotify {
+				...DiscordChannelFragment
+			}
+			CountThreshold
+			DailyFrequency
+			disabled
+			EmailsToNotify
+			ExcludedEnvironments
+			id
+			LastAdminToEditID
+			Name
+			updated_at
+			ThresholdWindow
+			Type
+			query
+		}
+	}
+	${DiscordChannelFragmentFragmentDoc}
+	${SessionAlertFragmentFragmentDoc}
+`
 
 /**
  * __useGetAlertsPagePayloadQuery__
@@ -7513,25 +11498,48 @@ ${SessionAlertFragmentFragmentDoc}`;
  *   },
  * });
  */
-export function useGetAlertsPagePayloadQuery(baseOptions: Apollo.QueryHookOptions<Types.GetAlertsPagePayloadQuery, Types.GetAlertsPagePayloadQueryVariables>) {
-        return Apollo.useQuery<Types.GetAlertsPagePayloadQuery, Types.GetAlertsPagePayloadQueryVariables>(GetAlertsPagePayloadDocument, baseOptions);
-      }
-export function useGetAlertsPagePayloadLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAlertsPagePayloadQuery, Types.GetAlertsPagePayloadQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetAlertsPagePayloadQuery, Types.GetAlertsPagePayloadQueryVariables>(GetAlertsPagePayloadDocument, baseOptions);
-        }
-export type GetAlertsPagePayloadQueryHookResult = ReturnType<typeof useGetAlertsPagePayloadQuery>;
-export type GetAlertsPagePayloadLazyQueryHookResult = ReturnType<typeof useGetAlertsPagePayloadLazyQuery>;
-export type GetAlertsPagePayloadQueryResult = Apollo.QueryResult<Types.GetAlertsPagePayloadQuery, Types.GetAlertsPagePayloadQueryVariables>;
-export const GetMetricMonitorsDocument = gql`
-    query GetMetricMonitors($project_id: ID!, $metric_name: String!) {
-  metric_monitors(project_id: $project_id, metric_name: $metric_name) {
-    id
-    updated_at
-    name
-    metric_to_monitor
-  }
+export function useGetAlertsPagePayloadQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetAlertsPagePayloadQuery,
+		Types.GetAlertsPagePayloadQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetAlertsPagePayloadQuery,
+		Types.GetAlertsPagePayloadQueryVariables
+	>(GetAlertsPagePayloadDocument, baseOptions)
 }
-    `;
+export function useGetAlertsPagePayloadLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetAlertsPagePayloadQuery,
+		Types.GetAlertsPagePayloadQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetAlertsPagePayloadQuery,
+		Types.GetAlertsPagePayloadQueryVariables
+	>(GetAlertsPagePayloadDocument, baseOptions)
+}
+export type GetAlertsPagePayloadQueryHookResult = ReturnType<
+	typeof useGetAlertsPagePayloadQuery
+>
+export type GetAlertsPagePayloadLazyQueryHookResult = ReturnType<
+	typeof useGetAlertsPagePayloadLazyQuery
+>
+export type GetAlertsPagePayloadQueryResult = Apollo.QueryResult<
+	Types.GetAlertsPagePayloadQuery,
+	Types.GetAlertsPagePayloadQueryVariables
+>
+export const GetMetricMonitorsDocument = gql`
+	query GetMetricMonitors($project_id: ID!, $metric_name: String!) {
+		metric_monitors(project_id: $project_id, metric_name: $metric_name) {
+			id
+			updated_at
+			name
+			metric_to_monitor
+		}
+	}
+`
 
 /**
  * __useGetMetricMonitorsQuery__
@@ -7550,31 +11558,54 @@ export const GetMetricMonitorsDocument = gql`
  *   },
  * });
  */
-export function useGetMetricMonitorsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetMetricMonitorsQuery, Types.GetMetricMonitorsQueryVariables>) {
-        return Apollo.useQuery<Types.GetMetricMonitorsQuery, Types.GetMetricMonitorsQueryVariables>(GetMetricMonitorsDocument, baseOptions);
-      }
-export function useGetMetricMonitorsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetMetricMonitorsQuery, Types.GetMetricMonitorsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetMetricMonitorsQuery, Types.GetMetricMonitorsQueryVariables>(GetMetricMonitorsDocument, baseOptions);
-        }
-export type GetMetricMonitorsQueryHookResult = ReturnType<typeof useGetMetricMonitorsQuery>;
-export type GetMetricMonitorsLazyQueryHookResult = ReturnType<typeof useGetMetricMonitorsLazyQuery>;
-export type GetMetricMonitorsQueryResult = Apollo.QueryResult<Types.GetMetricMonitorsQuery, Types.GetMetricMonitorsQueryVariables>;
-export const GetCommentMentionSuggestionsDocument = gql`
-    query GetCommentMentionSuggestions($project_id: ID!) {
-  admins: workspace_admins_by_project_id(project_id: $project_id) {
-    admin {
-      id
-      name
-      email
-      photo_url
-    }
-  }
-  slack_channel_suggestion(project_id: $project_id) {
-    webhook_channel
-    webhook_channel_id
-  }
+export function useGetMetricMonitorsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetMetricMonitorsQuery,
+		Types.GetMetricMonitorsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetMetricMonitorsQuery,
+		Types.GetMetricMonitorsQueryVariables
+	>(GetMetricMonitorsDocument, baseOptions)
 }
-    `;
+export function useGetMetricMonitorsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetMetricMonitorsQuery,
+		Types.GetMetricMonitorsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetMetricMonitorsQuery,
+		Types.GetMetricMonitorsQueryVariables
+	>(GetMetricMonitorsDocument, baseOptions)
+}
+export type GetMetricMonitorsQueryHookResult = ReturnType<
+	typeof useGetMetricMonitorsQuery
+>
+export type GetMetricMonitorsLazyQueryHookResult = ReturnType<
+	typeof useGetMetricMonitorsLazyQuery
+>
+export type GetMetricMonitorsQueryResult = Apollo.QueryResult<
+	Types.GetMetricMonitorsQuery,
+	Types.GetMetricMonitorsQueryVariables
+>
+export const GetCommentMentionSuggestionsDocument = gql`
+	query GetCommentMentionSuggestions($project_id: ID!) {
+		admins: workspace_admins_by_project_id(project_id: $project_id) {
+			admin {
+				id
+				name
+				email
+				photo_url
+			}
+		}
+		slack_channel_suggestion(project_id: $project_id) {
+			webhook_channel
+			webhook_channel_id
+		}
+	}
+`
 
 /**
  * __useGetCommentMentionSuggestionsQuery__
@@ -7592,20 +11623,43 @@ export const GetCommentMentionSuggestionsDocument = gql`
  *   },
  * });
  */
-export function useGetCommentMentionSuggestionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetCommentMentionSuggestionsQuery, Types.GetCommentMentionSuggestionsQueryVariables>) {
-        return Apollo.useQuery<Types.GetCommentMentionSuggestionsQuery, Types.GetCommentMentionSuggestionsQueryVariables>(GetCommentMentionSuggestionsDocument, baseOptions);
-      }
-export function useGetCommentMentionSuggestionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetCommentMentionSuggestionsQuery, Types.GetCommentMentionSuggestionsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetCommentMentionSuggestionsQuery, Types.GetCommentMentionSuggestionsQueryVariables>(GetCommentMentionSuggestionsDocument, baseOptions);
-        }
-export type GetCommentMentionSuggestionsQueryHookResult = ReturnType<typeof useGetCommentMentionSuggestionsQuery>;
-export type GetCommentMentionSuggestionsLazyQueryHookResult = ReturnType<typeof useGetCommentMentionSuggestionsLazyQuery>;
-export type GetCommentMentionSuggestionsQueryResult = Apollo.QueryResult<Types.GetCommentMentionSuggestionsQuery, Types.GetCommentMentionSuggestionsQueryVariables>;
-export const GetCustomerPortalUrlDocument = gql`
-    query GetCustomerPortalURL($workspace_id: ID!) {
-  customer_portal_url(workspace_id: $workspace_id)
+export function useGetCommentMentionSuggestionsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetCommentMentionSuggestionsQuery,
+		Types.GetCommentMentionSuggestionsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetCommentMentionSuggestionsQuery,
+		Types.GetCommentMentionSuggestionsQueryVariables
+	>(GetCommentMentionSuggestionsDocument, baseOptions)
 }
-    `;
+export function useGetCommentMentionSuggestionsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetCommentMentionSuggestionsQuery,
+		Types.GetCommentMentionSuggestionsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetCommentMentionSuggestionsQuery,
+		Types.GetCommentMentionSuggestionsQueryVariables
+	>(GetCommentMentionSuggestionsDocument, baseOptions)
+}
+export type GetCommentMentionSuggestionsQueryHookResult = ReturnType<
+	typeof useGetCommentMentionSuggestionsQuery
+>
+export type GetCommentMentionSuggestionsLazyQueryHookResult = ReturnType<
+	typeof useGetCommentMentionSuggestionsLazyQuery
+>
+export type GetCommentMentionSuggestionsQueryResult = Apollo.QueryResult<
+	Types.GetCommentMentionSuggestionsQuery,
+	Types.GetCommentMentionSuggestionsQueryVariables
+>
+export const GetCustomerPortalUrlDocument = gql`
+	query GetCustomerPortalURL($workspace_id: ID!) {
+		customer_portal_url(workspace_id: $workspace_id)
+	}
+`
 
 /**
  * __useGetCustomerPortalUrlQuery__
@@ -7623,25 +11677,52 @@ export const GetCustomerPortalUrlDocument = gql`
  *   },
  * });
  */
-export function useGetCustomerPortalUrlQuery(baseOptions: Apollo.QueryHookOptions<Types.GetCustomerPortalUrlQuery, Types.GetCustomerPortalUrlQueryVariables>) {
-        return Apollo.useQuery<Types.GetCustomerPortalUrlQuery, Types.GetCustomerPortalUrlQueryVariables>(GetCustomerPortalUrlDocument, baseOptions);
-      }
-export function useGetCustomerPortalUrlLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetCustomerPortalUrlQuery, Types.GetCustomerPortalUrlQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetCustomerPortalUrlQuery, Types.GetCustomerPortalUrlQueryVariables>(GetCustomerPortalUrlDocument, baseOptions);
-        }
-export type GetCustomerPortalUrlQueryHookResult = ReturnType<typeof useGetCustomerPortalUrlQuery>;
-export type GetCustomerPortalUrlLazyQueryHookResult = ReturnType<typeof useGetCustomerPortalUrlLazyQuery>;
-export type GetCustomerPortalUrlQueryResult = Apollo.QueryResult<Types.GetCustomerPortalUrlQuery, Types.GetCustomerPortalUrlQueryVariables>;
-export const OnSessionPayloadAppendedDocument = gql`
-    subscription OnSessionPayloadAppended($session_secure_id: String!, $initial_events_count: Int!) {
-  session_payload_appended(
-    session_secure_id: $session_secure_id
-    initial_events_count: $initial_events_count
-  ) {
-    ...SessionPayloadFragment
-  }
+export function useGetCustomerPortalUrlQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetCustomerPortalUrlQuery,
+		Types.GetCustomerPortalUrlQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetCustomerPortalUrlQuery,
+		Types.GetCustomerPortalUrlQueryVariables
+	>(GetCustomerPortalUrlDocument, baseOptions)
 }
-    ${SessionPayloadFragmentFragmentDoc}`;
+export function useGetCustomerPortalUrlLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetCustomerPortalUrlQuery,
+		Types.GetCustomerPortalUrlQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetCustomerPortalUrlQuery,
+		Types.GetCustomerPortalUrlQueryVariables
+	>(GetCustomerPortalUrlDocument, baseOptions)
+}
+export type GetCustomerPortalUrlQueryHookResult = ReturnType<
+	typeof useGetCustomerPortalUrlQuery
+>
+export type GetCustomerPortalUrlLazyQueryHookResult = ReturnType<
+	typeof useGetCustomerPortalUrlLazyQuery
+>
+export type GetCustomerPortalUrlQueryResult = Apollo.QueryResult<
+	Types.GetCustomerPortalUrlQuery,
+	Types.GetCustomerPortalUrlQueryVariables
+>
+export const OnSessionPayloadAppendedDocument = gql`
+	subscription OnSessionPayloadAppended(
+		$session_secure_id: String!
+		$initial_events_count: Int!
+	) {
+		session_payload_appended(
+			session_secure_id: $session_secure_id
+			initial_events_count: $initial_events_count
+		) {
+			...SessionPayloadFragment
+		}
+	}
+	${SessionPayloadFragmentFragmentDoc}
+`
 
 /**
  * __useOnSessionPayloadAppendedSubscription__
@@ -7660,19 +11741,30 @@ export const OnSessionPayloadAppendedDocument = gql`
  *   },
  * });
  */
-export function useOnSessionPayloadAppendedSubscription(baseOptions: Apollo.SubscriptionHookOptions<Types.OnSessionPayloadAppendedSubscription, Types.OnSessionPayloadAppendedSubscriptionVariables>) {
-        return Apollo.useSubscription<Types.OnSessionPayloadAppendedSubscription, Types.OnSessionPayloadAppendedSubscriptionVariables>(OnSessionPayloadAppendedDocument, baseOptions);
-      }
-export type OnSessionPayloadAppendedSubscriptionHookResult = ReturnType<typeof useOnSessionPayloadAppendedSubscription>;
-export type OnSessionPayloadAppendedSubscriptionResult = Apollo.SubscriptionResult<Types.OnSessionPayloadAppendedSubscription>;
-export const GetWebVitalsDocument = gql`
-    query GetWebVitals($session_secure_id: String!) {
-  web_vitals(session_secure_id: $session_secure_id) {
-    name
-    value
-  }
+export function useOnSessionPayloadAppendedSubscription(
+	baseOptions: Apollo.SubscriptionHookOptions<
+		Types.OnSessionPayloadAppendedSubscription,
+		Types.OnSessionPayloadAppendedSubscriptionVariables
+	>,
+) {
+	return Apollo.useSubscription<
+		Types.OnSessionPayloadAppendedSubscription,
+		Types.OnSessionPayloadAppendedSubscriptionVariables
+	>(OnSessionPayloadAppendedDocument, baseOptions)
 }
-    `;
+export type OnSessionPayloadAppendedSubscriptionHookResult = ReturnType<
+	typeof useOnSessionPayloadAppendedSubscription
+>
+export type OnSessionPayloadAppendedSubscriptionResult =
+	Apollo.SubscriptionResult<Types.OnSessionPayloadAppendedSubscription>
+export const GetWebVitalsDocument = gql`
+	query GetWebVitals($session_secure_id: String!) {
+		web_vitals(session_secure_id: $session_secure_id) {
+			name
+			value
+		}
+	}
+`
 
 /**
  * __useGetWebVitalsQuery__
@@ -7690,50 +11782,73 @@ export const GetWebVitalsDocument = gql`
  *   },
  * });
  */
-export function useGetWebVitalsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWebVitalsQuery, Types.GetWebVitalsQueryVariables>) {
-        return Apollo.useQuery<Types.GetWebVitalsQuery, Types.GetWebVitalsQueryVariables>(GetWebVitalsDocument, baseOptions);
-      }
-export function useGetWebVitalsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWebVitalsQuery, Types.GetWebVitalsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWebVitalsQuery, Types.GetWebVitalsQueryVariables>(GetWebVitalsDocument, baseOptions);
-        }
-export type GetWebVitalsQueryHookResult = ReturnType<typeof useGetWebVitalsQuery>;
-export type GetWebVitalsLazyQueryHookResult = ReturnType<typeof useGetWebVitalsLazyQuery>;
-export type GetWebVitalsQueryResult = Apollo.QueryResult<Types.GetWebVitalsQuery, Types.GetWebVitalsQueryVariables>;
-export const GetDashboardDefinitionsDocument = gql`
-    query GetDashboardDefinitions($project_id: ID!) {
-  dashboard_definitions(project_id: $project_id) {
-    id
-    updated_at
-    project_id
-    name
-    is_default
-    metrics {
-      component_type
-      name
-      description
-      max_good_value
-      max_needs_improvement_value
-      poor_value
-      units
-      help_article
-      chart_type
-      aggregator
-      min_value
-      min_percentile
-      max_value
-      max_percentile
-      filters {
-        value
-        op
-        tag
-      }
-      groups
-    }
-    last_admin_to_edit_id
-    layout
-  }
+export function useGetWebVitalsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWebVitalsQuery,
+		Types.GetWebVitalsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWebVitalsQuery,
+		Types.GetWebVitalsQueryVariables
+	>(GetWebVitalsDocument, baseOptions)
 }
-    `;
+export function useGetWebVitalsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWebVitalsQuery,
+		Types.GetWebVitalsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWebVitalsQuery,
+		Types.GetWebVitalsQueryVariables
+	>(GetWebVitalsDocument, baseOptions)
+}
+export type GetWebVitalsQueryHookResult = ReturnType<
+	typeof useGetWebVitalsQuery
+>
+export type GetWebVitalsLazyQueryHookResult = ReturnType<
+	typeof useGetWebVitalsLazyQuery
+>
+export type GetWebVitalsQueryResult = Apollo.QueryResult<
+	Types.GetWebVitalsQuery,
+	Types.GetWebVitalsQueryVariables
+>
+export const GetDashboardDefinitionsDocument = gql`
+	query GetDashboardDefinitions($project_id: ID!) {
+		dashboard_definitions(project_id: $project_id) {
+			id
+			updated_at
+			project_id
+			name
+			is_default
+			metrics {
+				component_type
+				name
+				description
+				max_good_value
+				max_needs_improvement_value
+				poor_value
+				units
+				help_article
+				chart_type
+				aggregator
+				min_value
+				min_percentile
+				max_value
+				max_percentile
+				filters {
+					value
+					op
+					tag
+				}
+				groups
+			}
+			last_admin_to_edit_id
+			layout
+		}
+	}
+`
 
 /**
  * __useGetDashboardDefinitionsQuery__
@@ -7751,20 +11866,43 @@ export const GetDashboardDefinitionsDocument = gql`
  *   },
  * });
  */
-export function useGetDashboardDefinitionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetDashboardDefinitionsQuery, Types.GetDashboardDefinitionsQueryVariables>) {
-        return Apollo.useQuery<Types.GetDashboardDefinitionsQuery, Types.GetDashboardDefinitionsQueryVariables>(GetDashboardDefinitionsDocument, baseOptions);
-      }
-export function useGetDashboardDefinitionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetDashboardDefinitionsQuery, Types.GetDashboardDefinitionsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetDashboardDefinitionsQuery, Types.GetDashboardDefinitionsQueryVariables>(GetDashboardDefinitionsDocument, baseOptions);
-        }
-export type GetDashboardDefinitionsQueryHookResult = ReturnType<typeof useGetDashboardDefinitionsQuery>;
-export type GetDashboardDefinitionsLazyQueryHookResult = ReturnType<typeof useGetDashboardDefinitionsLazyQuery>;
-export type GetDashboardDefinitionsQueryResult = Apollo.QueryResult<Types.GetDashboardDefinitionsQuery, Types.GetDashboardDefinitionsQueryVariables>;
-export const GetSuggestedMetricsDocument = gql`
-    query GetSuggestedMetrics($project_id: ID!, $prefix: String!) {
-  suggested_metrics(project_id: $project_id, prefix: $prefix)
+export function useGetDashboardDefinitionsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetDashboardDefinitionsQuery,
+		Types.GetDashboardDefinitionsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetDashboardDefinitionsQuery,
+		Types.GetDashboardDefinitionsQueryVariables
+	>(GetDashboardDefinitionsDocument, baseOptions)
 }
-    `;
+export function useGetDashboardDefinitionsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetDashboardDefinitionsQuery,
+		Types.GetDashboardDefinitionsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetDashboardDefinitionsQuery,
+		Types.GetDashboardDefinitionsQueryVariables
+	>(GetDashboardDefinitionsDocument, baseOptions)
+}
+export type GetDashboardDefinitionsQueryHookResult = ReturnType<
+	typeof useGetDashboardDefinitionsQuery
+>
+export type GetDashboardDefinitionsLazyQueryHookResult = ReturnType<
+	typeof useGetDashboardDefinitionsLazyQuery
+>
+export type GetDashboardDefinitionsQueryResult = Apollo.QueryResult<
+	Types.GetDashboardDefinitionsQuery,
+	Types.GetDashboardDefinitionsQueryVariables
+>
+export const GetSuggestedMetricsDocument = gql`
+	query GetSuggestedMetrics($project_id: ID!, $prefix: String!) {
+		suggested_metrics(project_id: $project_id, prefix: $prefix)
+	}
+`
 
 /**
  * __useGetSuggestedMetricsQuery__
@@ -7783,20 +11921,43 @@ export const GetSuggestedMetricsDocument = gql`
  *   },
  * });
  */
-export function useGetSuggestedMetricsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSuggestedMetricsQuery, Types.GetSuggestedMetricsQueryVariables>) {
-        return Apollo.useQuery<Types.GetSuggestedMetricsQuery, Types.GetSuggestedMetricsQueryVariables>(GetSuggestedMetricsDocument, baseOptions);
-      }
-export function useGetSuggestedMetricsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSuggestedMetricsQuery, Types.GetSuggestedMetricsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSuggestedMetricsQuery, Types.GetSuggestedMetricsQueryVariables>(GetSuggestedMetricsDocument, baseOptions);
-        }
-export type GetSuggestedMetricsQueryHookResult = ReturnType<typeof useGetSuggestedMetricsQuery>;
-export type GetSuggestedMetricsLazyQueryHookResult = ReturnType<typeof useGetSuggestedMetricsLazyQuery>;
-export type GetSuggestedMetricsQueryResult = Apollo.QueryResult<Types.GetSuggestedMetricsQuery, Types.GetSuggestedMetricsQueryVariables>;
-export const GetMetricTagsDocument = gql`
-    query GetMetricTags($project_id: ID!, $metric_name: String!) {
-  metric_tags(project_id: $project_id, metric_name: $metric_name)
+export function useGetSuggestedMetricsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSuggestedMetricsQuery,
+		Types.GetSuggestedMetricsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSuggestedMetricsQuery,
+		Types.GetSuggestedMetricsQueryVariables
+	>(GetSuggestedMetricsDocument, baseOptions)
 }
-    `;
+export function useGetSuggestedMetricsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSuggestedMetricsQuery,
+		Types.GetSuggestedMetricsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSuggestedMetricsQuery,
+		Types.GetSuggestedMetricsQueryVariables
+	>(GetSuggestedMetricsDocument, baseOptions)
+}
+export type GetSuggestedMetricsQueryHookResult = ReturnType<
+	typeof useGetSuggestedMetricsQuery
+>
+export type GetSuggestedMetricsLazyQueryHookResult = ReturnType<
+	typeof useGetSuggestedMetricsLazyQuery
+>
+export type GetSuggestedMetricsQueryResult = Apollo.QueryResult<
+	Types.GetSuggestedMetricsQuery,
+	Types.GetSuggestedMetricsQueryVariables
+>
+export const GetMetricTagsDocument = gql`
+	query GetMetricTags($project_id: ID!, $metric_name: String!) {
+		metric_tags(project_id: $project_id, metric_name: $metric_name)
+	}
+`
 
 /**
  * __useGetMetricTagsQuery__
@@ -7815,24 +11976,51 @@ export const GetMetricTagsDocument = gql`
  *   },
  * });
  */
-export function useGetMetricTagsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetMetricTagsQuery, Types.GetMetricTagsQueryVariables>) {
-        return Apollo.useQuery<Types.GetMetricTagsQuery, Types.GetMetricTagsQueryVariables>(GetMetricTagsDocument, baseOptions);
-      }
-export function useGetMetricTagsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetMetricTagsQuery, Types.GetMetricTagsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetMetricTagsQuery, Types.GetMetricTagsQueryVariables>(GetMetricTagsDocument, baseOptions);
-        }
-export type GetMetricTagsQueryHookResult = ReturnType<typeof useGetMetricTagsQuery>;
-export type GetMetricTagsLazyQueryHookResult = ReturnType<typeof useGetMetricTagsLazyQuery>;
-export type GetMetricTagsQueryResult = Apollo.QueryResult<Types.GetMetricTagsQuery, Types.GetMetricTagsQueryVariables>;
-export const GetMetricTagValuesDocument = gql`
-    query GetMetricTagValues($project_id: ID!, $metric_name: String!, $tag_name: String!) {
-  metric_tag_values(
-    project_id: $project_id
-    metric_name: $metric_name
-    tag_name: $tag_name
-  )
+export function useGetMetricTagsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetMetricTagsQuery,
+		Types.GetMetricTagsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetMetricTagsQuery,
+		Types.GetMetricTagsQueryVariables
+	>(GetMetricTagsDocument, baseOptions)
 }
-    `;
+export function useGetMetricTagsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetMetricTagsQuery,
+		Types.GetMetricTagsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetMetricTagsQuery,
+		Types.GetMetricTagsQueryVariables
+	>(GetMetricTagsDocument, baseOptions)
+}
+export type GetMetricTagsQueryHookResult = ReturnType<
+	typeof useGetMetricTagsQuery
+>
+export type GetMetricTagsLazyQueryHookResult = ReturnType<
+	typeof useGetMetricTagsLazyQuery
+>
+export type GetMetricTagsQueryResult = Apollo.QueryResult<
+	Types.GetMetricTagsQuery,
+	Types.GetMetricTagsQueryVariables
+>
+export const GetMetricTagValuesDocument = gql`
+	query GetMetricTagValues(
+		$project_id: ID!
+		$metric_name: String!
+		$tag_name: String!
+	) {
+		metric_tag_values(
+			project_id: $project_id
+			metric_name: $metric_name
+			tag_name: $tag_name
+		)
+	}
+`
 
 /**
  * __useGetMetricTagValuesQuery__
@@ -7852,22 +12040,45 @@ export const GetMetricTagValuesDocument = gql`
  *   },
  * });
  */
-export function useGetMetricTagValuesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetMetricTagValuesQuery, Types.GetMetricTagValuesQueryVariables>) {
-        return Apollo.useQuery<Types.GetMetricTagValuesQuery, Types.GetMetricTagValuesQueryVariables>(GetMetricTagValuesDocument, baseOptions);
-      }
-export function useGetMetricTagValuesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetMetricTagValuesQuery, Types.GetMetricTagValuesQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetMetricTagValuesQuery, Types.GetMetricTagValuesQueryVariables>(GetMetricTagValuesDocument, baseOptions);
-        }
-export type GetMetricTagValuesQueryHookResult = ReturnType<typeof useGetMetricTagValuesQuery>;
-export type GetMetricTagValuesLazyQueryHookResult = ReturnType<typeof useGetMetricTagValuesLazyQuery>;
-export type GetMetricTagValuesQueryResult = Apollo.QueryResult<Types.GetMetricTagValuesQuery, Types.GetMetricTagValuesQueryVariables>;
-export const GetSourcemapFilesDocument = gql`
-    query GetSourcemapFiles($project_id: ID!, $version: String) {
-  sourcemap_files(project_id: $project_id, version: $version) {
-    key
-  }
+export function useGetMetricTagValuesQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetMetricTagValuesQuery,
+		Types.GetMetricTagValuesQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetMetricTagValuesQuery,
+		Types.GetMetricTagValuesQueryVariables
+	>(GetMetricTagValuesDocument, baseOptions)
 }
-    `;
+export function useGetMetricTagValuesLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetMetricTagValuesQuery,
+		Types.GetMetricTagValuesQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetMetricTagValuesQuery,
+		Types.GetMetricTagValuesQueryVariables
+	>(GetMetricTagValuesDocument, baseOptions)
+}
+export type GetMetricTagValuesQueryHookResult = ReturnType<
+	typeof useGetMetricTagValuesQuery
+>
+export type GetMetricTagValuesLazyQueryHookResult = ReturnType<
+	typeof useGetMetricTagValuesLazyQuery
+>
+export type GetMetricTagValuesQueryResult = Apollo.QueryResult<
+	Types.GetMetricTagValuesQuery,
+	Types.GetMetricTagValuesQueryVariables
+>
+export const GetSourcemapFilesDocument = gql`
+	query GetSourcemapFiles($project_id: ID!, $version: String) {
+		sourcemap_files(project_id: $project_id, version: $version) {
+			key
+		}
+	}
+`
 
 /**
  * __useGetSourcemapFilesQuery__
@@ -7886,20 +12097,43 @@ export const GetSourcemapFilesDocument = gql`
  *   },
  * });
  */
-export function useGetSourcemapFilesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSourcemapFilesQuery, Types.GetSourcemapFilesQueryVariables>) {
-        return Apollo.useQuery<Types.GetSourcemapFilesQuery, Types.GetSourcemapFilesQueryVariables>(GetSourcemapFilesDocument, baseOptions);
-      }
-export function useGetSourcemapFilesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSourcemapFilesQuery, Types.GetSourcemapFilesQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSourcemapFilesQuery, Types.GetSourcemapFilesQueryVariables>(GetSourcemapFilesDocument, baseOptions);
-        }
-export type GetSourcemapFilesQueryHookResult = ReturnType<typeof useGetSourcemapFilesQuery>;
-export type GetSourcemapFilesLazyQueryHookResult = ReturnType<typeof useGetSourcemapFilesLazyQuery>;
-export type GetSourcemapFilesQueryResult = Apollo.QueryResult<Types.GetSourcemapFilesQuery, Types.GetSourcemapFilesQueryVariables>;
-export const GetSourcemapVersionsDocument = gql`
-    query GetSourcemapVersions($project_id: ID!) {
-  sourcemap_versions(project_id: $project_id)
+export function useGetSourcemapFilesQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSourcemapFilesQuery,
+		Types.GetSourcemapFilesQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSourcemapFilesQuery,
+		Types.GetSourcemapFilesQueryVariables
+	>(GetSourcemapFilesDocument, baseOptions)
 }
-    `;
+export function useGetSourcemapFilesLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSourcemapFilesQuery,
+		Types.GetSourcemapFilesQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSourcemapFilesQuery,
+		Types.GetSourcemapFilesQueryVariables
+	>(GetSourcemapFilesDocument, baseOptions)
+}
+export type GetSourcemapFilesQueryHookResult = ReturnType<
+	typeof useGetSourcemapFilesQuery
+>
+export type GetSourcemapFilesLazyQueryHookResult = ReturnType<
+	typeof useGetSourcemapFilesLazyQuery
+>
+export type GetSourcemapFilesQueryResult = Apollo.QueryResult<
+	Types.GetSourcemapFilesQuery,
+	Types.GetSourcemapFilesQueryVariables
+>
+export const GetSourcemapVersionsDocument = gql`
+	query GetSourcemapVersions($project_id: ID!) {
+		sourcemap_versions(project_id: $project_id)
+	}
+`
 
 /**
  * __useGetSourcemapVersionsQuery__
@@ -7917,24 +12151,47 @@ export const GetSourcemapVersionsDocument = gql`
  *   },
  * });
  */
-export function useGetSourcemapVersionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSourcemapVersionsQuery, Types.GetSourcemapVersionsQueryVariables>) {
-        return Apollo.useQuery<Types.GetSourcemapVersionsQuery, Types.GetSourcemapVersionsQueryVariables>(GetSourcemapVersionsDocument, baseOptions);
-      }
-export function useGetSourcemapVersionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSourcemapVersionsQuery, Types.GetSourcemapVersionsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSourcemapVersionsQuery, Types.GetSourcemapVersionsQueryVariables>(GetSourcemapVersionsDocument, baseOptions);
-        }
-export type GetSourcemapVersionsQueryHookResult = ReturnType<typeof useGetSourcemapVersionsQuery>;
-export type GetSourcemapVersionsLazyQueryHookResult = ReturnType<typeof useGetSourcemapVersionsLazyQuery>;
-export type GetSourcemapVersionsQueryResult = Apollo.QueryResult<Types.GetSourcemapVersionsQuery, Types.GetSourcemapVersionsQueryVariables>;
-export const GetOAuthClientMetadataDocument = gql`
-    query GetOAuthClientMetadata($client_id: String!) {
-  oauth_client_metadata(client_id: $client_id) {
-    id
-    created_at
-    app_name
-  }
+export function useGetSourcemapVersionsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSourcemapVersionsQuery,
+		Types.GetSourcemapVersionsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSourcemapVersionsQuery,
+		Types.GetSourcemapVersionsQueryVariables
+	>(GetSourcemapVersionsDocument, baseOptions)
 }
-    `;
+export function useGetSourcemapVersionsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSourcemapVersionsQuery,
+		Types.GetSourcemapVersionsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSourcemapVersionsQuery,
+		Types.GetSourcemapVersionsQueryVariables
+	>(GetSourcemapVersionsDocument, baseOptions)
+}
+export type GetSourcemapVersionsQueryHookResult = ReturnType<
+	typeof useGetSourcemapVersionsQuery
+>
+export type GetSourcemapVersionsLazyQueryHookResult = ReturnType<
+	typeof useGetSourcemapVersionsLazyQuery
+>
+export type GetSourcemapVersionsQueryResult = Apollo.QueryResult<
+	Types.GetSourcemapVersionsQuery,
+	Types.GetSourcemapVersionsQueryVariables
+>
+export const GetOAuthClientMetadataDocument = gql`
+	query GetOAuthClientMetadata($client_id: String!) {
+		oauth_client_metadata(client_id: $client_id) {
+			id
+			created_at
+			app_name
+		}
+	}
+`
 
 /**
  * __useGetOAuthClientMetadataQuery__
@@ -7952,30 +12209,58 @@ export const GetOAuthClientMetadataDocument = gql`
  *   },
  * });
  */
-export function useGetOAuthClientMetadataQuery(baseOptions: Apollo.QueryHookOptions<Types.GetOAuthClientMetadataQuery, Types.GetOAuthClientMetadataQueryVariables>) {
-        return Apollo.useQuery<Types.GetOAuthClientMetadataQuery, Types.GetOAuthClientMetadataQueryVariables>(GetOAuthClientMetadataDocument, baseOptions);
-      }
-export function useGetOAuthClientMetadataLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetOAuthClientMetadataQuery, Types.GetOAuthClientMetadataQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetOAuthClientMetadataQuery, Types.GetOAuthClientMetadataQueryVariables>(GetOAuthClientMetadataDocument, baseOptions);
-        }
-export type GetOAuthClientMetadataQueryHookResult = ReturnType<typeof useGetOAuthClientMetadataQuery>;
-export type GetOAuthClientMetadataLazyQueryHookResult = ReturnType<typeof useGetOAuthClientMetadataLazyQuery>;
-export type GetOAuthClientMetadataQueryResult = Apollo.QueryResult<Types.GetOAuthClientMetadataQuery, Types.GetOAuthClientMetadataQueryVariables>;
-export const GetErrorGroupFrequenciesDocument = gql`
-    query GetErrorGroupFrequencies($project_id: ID!, $error_group_secure_ids: [String!]!, $params: ErrorGroupFrequenciesParamsInput!, $metric: String!) {
-  errorGroupFrequencies(
-    project_id: $project_id
-    error_group_secure_ids: $error_group_secure_ids
-    params: $params
-    metric: $metric
-  ) {
-    error_group_id
-    date
-    name
-    value
-  }
+export function useGetOAuthClientMetadataQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetOAuthClientMetadataQuery,
+		Types.GetOAuthClientMetadataQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetOAuthClientMetadataQuery,
+		Types.GetOAuthClientMetadataQueryVariables
+	>(GetOAuthClientMetadataDocument, baseOptions)
 }
-    `;
+export function useGetOAuthClientMetadataLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetOAuthClientMetadataQuery,
+		Types.GetOAuthClientMetadataQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetOAuthClientMetadataQuery,
+		Types.GetOAuthClientMetadataQueryVariables
+	>(GetOAuthClientMetadataDocument, baseOptions)
+}
+export type GetOAuthClientMetadataQueryHookResult = ReturnType<
+	typeof useGetOAuthClientMetadataQuery
+>
+export type GetOAuthClientMetadataLazyQueryHookResult = ReturnType<
+	typeof useGetOAuthClientMetadataLazyQuery
+>
+export type GetOAuthClientMetadataQueryResult = Apollo.QueryResult<
+	Types.GetOAuthClientMetadataQuery,
+	Types.GetOAuthClientMetadataQueryVariables
+>
+export const GetErrorGroupFrequenciesDocument = gql`
+	query GetErrorGroupFrequencies(
+		$project_id: ID!
+		$error_group_secure_ids: [String!]!
+		$params: ErrorGroupFrequenciesParamsInput!
+		$metric: String!
+	) {
+		errorGroupFrequencies(
+			project_id: $project_id
+			error_group_secure_ids: $error_group_secure_ids
+			params: $params
+			metric: $metric
+		) {
+			error_group_id
+			date
+			name
+			value
+		}
+	}
+`
 
 /**
  * __useGetErrorGroupFrequenciesQuery__
@@ -7996,27 +12281,50 @@ export const GetErrorGroupFrequenciesDocument = gql`
  *   },
  * });
  */
-export function useGetErrorGroupFrequenciesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorGroupFrequenciesQuery, Types.GetErrorGroupFrequenciesQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorGroupFrequenciesQuery, Types.GetErrorGroupFrequenciesQueryVariables>(GetErrorGroupFrequenciesDocument, baseOptions);
-      }
-export function useGetErrorGroupFrequenciesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorGroupFrequenciesQuery, Types.GetErrorGroupFrequenciesQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorGroupFrequenciesQuery, Types.GetErrorGroupFrequenciesQueryVariables>(GetErrorGroupFrequenciesDocument, baseOptions);
-        }
-export type GetErrorGroupFrequenciesQueryHookResult = ReturnType<typeof useGetErrorGroupFrequenciesQuery>;
-export type GetErrorGroupFrequenciesLazyQueryHookResult = ReturnType<typeof useGetErrorGroupFrequenciesLazyQuery>;
-export type GetErrorGroupFrequenciesQueryResult = Apollo.QueryResult<Types.GetErrorGroupFrequenciesQuery, Types.GetErrorGroupFrequenciesQueryVariables>;
-export const GetErrorGroupTagsDocument = gql`
-    query GetErrorGroupTags($error_group_secure_id: String!) {
-  errorGroupTags(error_group_secure_id: $error_group_secure_id) {
-    key
-    buckets {
-      key
-      doc_count
-      percent
-    }
-  }
+export function useGetErrorGroupFrequenciesQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorGroupFrequenciesQuery,
+		Types.GetErrorGroupFrequenciesQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorGroupFrequenciesQuery,
+		Types.GetErrorGroupFrequenciesQueryVariables
+	>(GetErrorGroupFrequenciesDocument, baseOptions)
 }
-    `;
+export function useGetErrorGroupFrequenciesLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorGroupFrequenciesQuery,
+		Types.GetErrorGroupFrequenciesQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorGroupFrequenciesQuery,
+		Types.GetErrorGroupFrequenciesQueryVariables
+	>(GetErrorGroupFrequenciesDocument, baseOptions)
+}
+export type GetErrorGroupFrequenciesQueryHookResult = ReturnType<
+	typeof useGetErrorGroupFrequenciesQuery
+>
+export type GetErrorGroupFrequenciesLazyQueryHookResult = ReturnType<
+	typeof useGetErrorGroupFrequenciesLazyQuery
+>
+export type GetErrorGroupFrequenciesQueryResult = Apollo.QueryResult<
+	Types.GetErrorGroupFrequenciesQuery,
+	Types.GetErrorGroupFrequenciesQueryVariables
+>
+export const GetErrorGroupTagsDocument = gql`
+	query GetErrorGroupTags($error_group_secure_id: String!) {
+		errorGroupTags(error_group_secure_id: $error_group_secure_id) {
+			key
+			buckets {
+				key
+				doc_count
+				percent
+			}
+		}
+	}
+`
 
 /**
  * __useGetErrorGroupTagsQuery__
@@ -8034,20 +12342,43 @@ export const GetErrorGroupTagsDocument = gql`
  *   },
  * });
  */
-export function useGetErrorGroupTagsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorGroupTagsQuery, Types.GetErrorGroupTagsQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorGroupTagsQuery, Types.GetErrorGroupTagsQueryVariables>(GetErrorGroupTagsDocument, baseOptions);
-      }
-export function useGetErrorGroupTagsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorGroupTagsQuery, Types.GetErrorGroupTagsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorGroupTagsQuery, Types.GetErrorGroupTagsQueryVariables>(GetErrorGroupTagsDocument, baseOptions);
-        }
-export type GetErrorGroupTagsQueryHookResult = ReturnType<typeof useGetErrorGroupTagsQuery>;
-export type GetErrorGroupTagsLazyQueryHookResult = ReturnType<typeof useGetErrorGroupTagsLazyQuery>;
-export type GetErrorGroupTagsQueryResult = Apollo.QueryResult<Types.GetErrorGroupTagsQuery, Types.GetErrorGroupTagsQueryVariables>;
-export const GetEmailOptOutsDocument = gql`
-    query GetEmailOptOuts($token: String, $admin_id: ID) {
-  email_opt_outs(token: $token, admin_id: $admin_id)
+export function useGetErrorGroupTagsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorGroupTagsQuery,
+		Types.GetErrorGroupTagsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorGroupTagsQuery,
+		Types.GetErrorGroupTagsQueryVariables
+	>(GetErrorGroupTagsDocument, baseOptions)
 }
-    `;
+export function useGetErrorGroupTagsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorGroupTagsQuery,
+		Types.GetErrorGroupTagsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorGroupTagsQuery,
+		Types.GetErrorGroupTagsQueryVariables
+	>(GetErrorGroupTagsDocument, baseOptions)
+}
+export type GetErrorGroupTagsQueryHookResult = ReturnType<
+	typeof useGetErrorGroupTagsQuery
+>
+export type GetErrorGroupTagsLazyQueryHookResult = ReturnType<
+	typeof useGetErrorGroupTagsLazyQuery
+>
+export type GetErrorGroupTagsQueryResult = Apollo.QueryResult<
+	Types.GetErrorGroupTagsQuery,
+	Types.GetErrorGroupTagsQueryVariables
+>
+export const GetEmailOptOutsDocument = gql`
+	query GetEmailOptOuts($token: String, $admin_id: ID) {
+		email_opt_outs(token: $token, admin_id: $admin_id)
+	}
+`
 
 /**
  * __useGetEmailOptOutsQuery__
@@ -8066,48 +12397,78 @@ export const GetEmailOptOutsDocument = gql`
  *   },
  * });
  */
-export function useGetEmailOptOutsQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetEmailOptOutsQuery, Types.GetEmailOptOutsQueryVariables>) {
-        return Apollo.useQuery<Types.GetEmailOptOutsQuery, Types.GetEmailOptOutsQueryVariables>(GetEmailOptOutsDocument, baseOptions);
-      }
-export function useGetEmailOptOutsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetEmailOptOutsQuery, Types.GetEmailOptOutsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetEmailOptOutsQuery, Types.GetEmailOptOutsQueryVariables>(GetEmailOptOutsDocument, baseOptions);
-        }
-export type GetEmailOptOutsQueryHookResult = ReturnType<typeof useGetEmailOptOutsQuery>;
-export type GetEmailOptOutsLazyQueryHookResult = ReturnType<typeof useGetEmailOptOutsLazyQuery>;
-export type GetEmailOptOutsQueryResult = Apollo.QueryResult<Types.GetEmailOptOutsQuery, Types.GetEmailOptOutsQueryVariables>;
-export const GetLogsDocument = gql`
-    query GetLogs($project_id: ID!, $params: LogsParamsInput!, $after: String, $before: String, $at: String, $direction: LogDirection!) {
-  logs(
-    project_id: $project_id
-    params: $params
-    after: $after
-    before: $before
-    at: $at
-    direction: $direction
-  ) {
-    edges {
-      cursor
-      node {
-        timestamp
-        level
-        message
-        logAttributes
-        traceID
-        spanID
-        secureSessionID
-        source
-        serviceName
-      }
-    }
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      startCursor
-      endCursor
-    }
-  }
+export function useGetEmailOptOutsQuery(
+	baseOptions?: Apollo.QueryHookOptions<
+		Types.GetEmailOptOutsQuery,
+		Types.GetEmailOptOutsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetEmailOptOutsQuery,
+		Types.GetEmailOptOutsQueryVariables
+	>(GetEmailOptOutsDocument, baseOptions)
 }
-    `;
+export function useGetEmailOptOutsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetEmailOptOutsQuery,
+		Types.GetEmailOptOutsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetEmailOptOutsQuery,
+		Types.GetEmailOptOutsQueryVariables
+	>(GetEmailOptOutsDocument, baseOptions)
+}
+export type GetEmailOptOutsQueryHookResult = ReturnType<
+	typeof useGetEmailOptOutsQuery
+>
+export type GetEmailOptOutsLazyQueryHookResult = ReturnType<
+	typeof useGetEmailOptOutsLazyQuery
+>
+export type GetEmailOptOutsQueryResult = Apollo.QueryResult<
+	Types.GetEmailOptOutsQuery,
+	Types.GetEmailOptOutsQueryVariables
+>
+export const GetLogsDocument = gql`
+	query GetLogs(
+		$project_id: ID!
+		$params: LogsParamsInput!
+		$after: String
+		$before: String
+		$at: String
+		$direction: LogDirection!
+	) {
+		logs(
+			project_id: $project_id
+			params: $params
+			after: $after
+			before: $before
+			at: $at
+			direction: $direction
+		) {
+			edges {
+				cursor
+				node {
+					timestamp
+					level
+					message
+					logAttributes
+					traceID
+					spanID
+					secureSessionID
+					source
+					serviceName
+				}
+			}
+			pageInfo {
+				hasNextPage
+				hasPreviousPage
+				startCursor
+				endCursor
+			}
+		}
+	}
+`
 
 /**
  * __useGetLogsQuery__
@@ -8130,27 +12491,46 @@ export const GetLogsDocument = gql`
  *   },
  * });
  */
-export function useGetLogsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsQuery, Types.GetLogsQueryVariables>) {
-        return Apollo.useQuery<Types.GetLogsQuery, Types.GetLogsQueryVariables>(GetLogsDocument, baseOptions);
-      }
-export function useGetLogsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsQuery, Types.GetLogsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetLogsQuery, Types.GetLogsQueryVariables>(GetLogsDocument, baseOptions);
-        }
-export type GetLogsQueryHookResult = ReturnType<typeof useGetLogsQuery>;
-export type GetLogsLazyQueryHookResult = ReturnType<typeof useGetLogsLazyQuery>;
-export type GetLogsQueryResult = Apollo.QueryResult<Types.GetLogsQuery, Types.GetLogsQueryVariables>;
-export const GetSessionLogsDocument = gql`
-    query GetSessionLogs($project_id: ID!, $params: LogsParamsInput!) {
-  sessionLogs(project_id: $project_id, params: $params) {
-    cursor
-    node {
-      timestamp
-      level
-      message
-    }
-  }
+export function useGetLogsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogsQuery,
+		Types.GetLogsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<Types.GetLogsQuery, Types.GetLogsQueryVariables>(
+		GetLogsDocument,
+		baseOptions,
+	)
 }
-    `;
+export function useGetLogsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogsQuery,
+		Types.GetLogsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<Types.GetLogsQuery, Types.GetLogsQueryVariables>(
+		GetLogsDocument,
+		baseOptions,
+	)
+}
+export type GetLogsQueryHookResult = ReturnType<typeof useGetLogsQuery>
+export type GetLogsLazyQueryHookResult = ReturnType<typeof useGetLogsLazyQuery>
+export type GetLogsQueryResult = Apollo.QueryResult<
+	Types.GetLogsQuery,
+	Types.GetLogsQueryVariables
+>
+export const GetSessionLogsDocument = gql`
+	query GetSessionLogs($project_id: ID!, $params: LogsParamsInput!) {
+		sessionLogs(project_id: $project_id, params: $params) {
+			cursor
+			node {
+				timestamp
+				level
+				message
+			}
+		}
+	}
+`
 
 /**
  * __useGetSessionLogsQuery__
@@ -8169,20 +12549,43 @@ export const GetSessionLogsDocument = gql`
  *   },
  * });
  */
-export function useGetSessionLogsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionLogsQuery, Types.GetSessionLogsQueryVariables>) {
-        return Apollo.useQuery<Types.GetSessionLogsQuery, Types.GetSessionLogsQueryVariables>(GetSessionLogsDocument, baseOptions);
-      }
-export function useGetSessionLogsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionLogsQuery, Types.GetSessionLogsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetSessionLogsQuery, Types.GetSessionLogsQueryVariables>(GetSessionLogsDocument, baseOptions);
-        }
-export type GetSessionLogsQueryHookResult = ReturnType<typeof useGetSessionLogsQuery>;
-export type GetSessionLogsLazyQueryHookResult = ReturnType<typeof useGetSessionLogsLazyQuery>;
-export type GetSessionLogsQueryResult = Apollo.QueryResult<Types.GetSessionLogsQuery, Types.GetSessionLogsQueryVariables>;
-export const GetLogsTotalCountDocument = gql`
-    query GetLogsTotalCount($project_id: ID!, $params: LogsParamsInput!) {
-  logs_total_count(project_id: $project_id, params: $params)
+export function useGetSessionLogsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetSessionLogsQuery,
+		Types.GetSessionLogsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetSessionLogsQuery,
+		Types.GetSessionLogsQueryVariables
+	>(GetSessionLogsDocument, baseOptions)
 }
-    `;
+export function useGetSessionLogsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetSessionLogsQuery,
+		Types.GetSessionLogsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetSessionLogsQuery,
+		Types.GetSessionLogsQueryVariables
+	>(GetSessionLogsDocument, baseOptions)
+}
+export type GetSessionLogsQueryHookResult = ReturnType<
+	typeof useGetSessionLogsQuery
+>
+export type GetSessionLogsLazyQueryHookResult = ReturnType<
+	typeof useGetSessionLogsLazyQuery
+>
+export type GetSessionLogsQueryResult = Apollo.QueryResult<
+	Types.GetSessionLogsQuery,
+	Types.GetSessionLogsQueryVariables
+>
+export const GetLogsTotalCountDocument = gql`
+	query GetLogsTotalCount($project_id: ID!, $params: LogsParamsInput!) {
+		logs_total_count(project_id: $project_id, params: $params)
+	}
+`
 
 /**
  * __useGetLogsTotalCountQuery__
@@ -8201,29 +12604,52 @@ export const GetLogsTotalCountDocument = gql`
  *   },
  * });
  */
-export function useGetLogsTotalCountQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsTotalCountQuery, Types.GetLogsTotalCountQueryVariables>) {
-        return Apollo.useQuery<Types.GetLogsTotalCountQuery, Types.GetLogsTotalCountQueryVariables>(GetLogsTotalCountDocument, baseOptions);
-      }
-export function useGetLogsTotalCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsTotalCountQuery, Types.GetLogsTotalCountQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetLogsTotalCountQuery, Types.GetLogsTotalCountQueryVariables>(GetLogsTotalCountDocument, baseOptions);
-        }
-export type GetLogsTotalCountQueryHookResult = ReturnType<typeof useGetLogsTotalCountQuery>;
-export type GetLogsTotalCountLazyQueryHookResult = ReturnType<typeof useGetLogsTotalCountLazyQuery>;
-export type GetLogsTotalCountQueryResult = Apollo.QueryResult<Types.GetLogsTotalCountQuery, Types.GetLogsTotalCountQueryVariables>;
-export const GetLogsHistogramDocument = gql`
-    query GetLogsHistogram($project_id: ID!, $params: LogsParamsInput!) {
-  logs_histogram(project_id: $project_id, params: $params) {
-    totalCount
-    buckets {
-      bucketId
-      counts {
-        count
-        level
-      }
-    }
-  }
+export function useGetLogsTotalCountQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogsTotalCountQuery,
+		Types.GetLogsTotalCountQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetLogsTotalCountQuery,
+		Types.GetLogsTotalCountQueryVariables
+	>(GetLogsTotalCountDocument, baseOptions)
 }
-    `;
+export function useGetLogsTotalCountLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogsTotalCountQuery,
+		Types.GetLogsTotalCountQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetLogsTotalCountQuery,
+		Types.GetLogsTotalCountQueryVariables
+	>(GetLogsTotalCountDocument, baseOptions)
+}
+export type GetLogsTotalCountQueryHookResult = ReturnType<
+	typeof useGetLogsTotalCountQuery
+>
+export type GetLogsTotalCountLazyQueryHookResult = ReturnType<
+	typeof useGetLogsTotalCountLazyQuery
+>
+export type GetLogsTotalCountQueryResult = Apollo.QueryResult<
+	Types.GetLogsTotalCountQuery,
+	Types.GetLogsTotalCountQueryVariables
+>
+export const GetLogsHistogramDocument = gql`
+	query GetLogsHistogram($project_id: ID!, $params: LogsParamsInput!) {
+		logs_histogram(project_id: $project_id, params: $params) {
+			totalCount
+			buckets {
+				bucketId
+				counts {
+					count
+					level
+				}
+			}
+		}
+	}
+`
 
 /**
  * __useGetLogsHistogramQuery__
@@ -8242,23 +12668,46 @@ export const GetLogsHistogramDocument = gql`
  *   },
  * });
  */
-export function useGetLogsHistogramQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsHistogramQuery, Types.GetLogsHistogramQueryVariables>) {
-        return Apollo.useQuery<Types.GetLogsHistogramQuery, Types.GetLogsHistogramQueryVariables>(GetLogsHistogramDocument, baseOptions);
-      }
-export function useGetLogsHistogramLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsHistogramQuery, Types.GetLogsHistogramQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetLogsHistogramQuery, Types.GetLogsHistogramQueryVariables>(GetLogsHistogramDocument, baseOptions);
-        }
-export type GetLogsHistogramQueryHookResult = ReturnType<typeof useGetLogsHistogramQuery>;
-export type GetLogsHistogramLazyQueryHookResult = ReturnType<typeof useGetLogsHistogramLazyQuery>;
-export type GetLogsHistogramQueryResult = Apollo.QueryResult<Types.GetLogsHistogramQuery, Types.GetLogsHistogramQueryVariables>;
-export const GetLogsKeysDocument = gql`
-    query GetLogsKeys($project_id: ID!, $date_range: DateRangeRequiredInput!) {
-  logs_keys(project_id: $project_id, date_range: $date_range) {
-    name
-    type
-  }
+export function useGetLogsHistogramQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogsHistogramQuery,
+		Types.GetLogsHistogramQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetLogsHistogramQuery,
+		Types.GetLogsHistogramQueryVariables
+	>(GetLogsHistogramDocument, baseOptions)
 }
-    `;
+export function useGetLogsHistogramLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogsHistogramQuery,
+		Types.GetLogsHistogramQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetLogsHistogramQuery,
+		Types.GetLogsHistogramQueryVariables
+	>(GetLogsHistogramDocument, baseOptions)
+}
+export type GetLogsHistogramQueryHookResult = ReturnType<
+	typeof useGetLogsHistogramQuery
+>
+export type GetLogsHistogramLazyQueryHookResult = ReturnType<
+	typeof useGetLogsHistogramLazyQuery
+>
+export type GetLogsHistogramQueryResult = Apollo.QueryResult<
+	Types.GetLogsHistogramQuery,
+	Types.GetLogsHistogramQueryVariables
+>
+export const GetLogsKeysDocument = gql`
+	query GetLogsKeys($project_id: ID!, $date_range: DateRangeRequiredInput!) {
+		logs_keys(project_id: $project_id, date_range: $date_range) {
+			name
+			type
+		}
+	}
+`
 
 /**
  * __useGetLogsKeysQuery__
@@ -8277,24 +12726,49 @@ export const GetLogsKeysDocument = gql`
  *   },
  * });
  */
-export function useGetLogsKeysQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsKeysQuery, Types.GetLogsKeysQueryVariables>) {
-        return Apollo.useQuery<Types.GetLogsKeysQuery, Types.GetLogsKeysQueryVariables>(GetLogsKeysDocument, baseOptions);
-      }
-export function useGetLogsKeysLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsKeysQuery, Types.GetLogsKeysQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetLogsKeysQuery, Types.GetLogsKeysQueryVariables>(GetLogsKeysDocument, baseOptions);
-        }
-export type GetLogsKeysQueryHookResult = ReturnType<typeof useGetLogsKeysQuery>;
-export type GetLogsKeysLazyQueryHookResult = ReturnType<typeof useGetLogsKeysLazyQuery>;
-export type GetLogsKeysQueryResult = Apollo.QueryResult<Types.GetLogsKeysQuery, Types.GetLogsKeysQueryVariables>;
-export const GetLogsKeyValuesDocument = gql`
-    query GetLogsKeyValues($project_id: ID!, $key_name: String!, $date_range: DateRangeRequiredInput!) {
-  logs_key_values(
-    project_id: $project_id
-    key_name: $key_name
-    date_range: $date_range
-  )
+export function useGetLogsKeysQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogsKeysQuery,
+		Types.GetLogsKeysQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetLogsKeysQuery,
+		Types.GetLogsKeysQueryVariables
+	>(GetLogsKeysDocument, baseOptions)
 }
-    `;
+export function useGetLogsKeysLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogsKeysQuery,
+		Types.GetLogsKeysQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetLogsKeysQuery,
+		Types.GetLogsKeysQueryVariables
+	>(GetLogsKeysDocument, baseOptions)
+}
+export type GetLogsKeysQueryHookResult = ReturnType<typeof useGetLogsKeysQuery>
+export type GetLogsKeysLazyQueryHookResult = ReturnType<
+	typeof useGetLogsKeysLazyQuery
+>
+export type GetLogsKeysQueryResult = Apollo.QueryResult<
+	Types.GetLogsKeysQuery,
+	Types.GetLogsKeysQueryVariables
+>
+export const GetLogsKeyValuesDocument = gql`
+	query GetLogsKeyValues(
+		$project_id: ID!
+		$key_name: String!
+		$date_range: DateRangeRequiredInput!
+	) {
+		logs_key_values(
+			project_id: $project_id
+			key_name: $key_name
+			date_range: $date_range
+		)
+	}
+`
 
 /**
  * __useGetLogsKeyValuesQuery__
@@ -8314,24 +12788,47 @@ export const GetLogsKeyValuesDocument = gql`
  *   },
  * });
  */
-export function useGetLogsKeyValuesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsKeyValuesQuery, Types.GetLogsKeyValuesQueryVariables>) {
-        return Apollo.useQuery<Types.GetLogsKeyValuesQuery, Types.GetLogsKeyValuesQueryVariables>(GetLogsKeyValuesDocument, baseOptions);
-      }
-export function useGetLogsKeyValuesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsKeyValuesQuery, Types.GetLogsKeyValuesQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetLogsKeyValuesQuery, Types.GetLogsKeyValuesQueryVariables>(GetLogsKeyValuesDocument, baseOptions);
-        }
-export type GetLogsKeyValuesQueryHookResult = ReturnType<typeof useGetLogsKeyValuesQuery>;
-export type GetLogsKeyValuesLazyQueryHookResult = ReturnType<typeof useGetLogsKeyValuesLazyQuery>;
-export type GetLogsKeyValuesQueryResult = Apollo.QueryResult<Types.GetLogsKeyValuesQuery, Types.GetLogsKeyValuesQueryVariables>;
-export const GetLogsErrorObjectsDocument = gql`
-    query GetLogsErrorObjects($log_cursors: [String!]!) {
-  logs_error_objects(log_cursors: $log_cursors) {
-    log_cursor
-    error_group_secure_id
-    id
-  }
+export function useGetLogsKeyValuesQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogsKeyValuesQuery,
+		Types.GetLogsKeyValuesQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetLogsKeyValuesQuery,
+		Types.GetLogsKeyValuesQueryVariables
+	>(GetLogsKeyValuesDocument, baseOptions)
 }
-    `;
+export function useGetLogsKeyValuesLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogsKeyValuesQuery,
+		Types.GetLogsKeyValuesQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetLogsKeyValuesQuery,
+		Types.GetLogsKeyValuesQueryVariables
+	>(GetLogsKeyValuesDocument, baseOptions)
+}
+export type GetLogsKeyValuesQueryHookResult = ReturnType<
+	typeof useGetLogsKeyValuesQuery
+>
+export type GetLogsKeyValuesLazyQueryHookResult = ReturnType<
+	typeof useGetLogsKeyValuesLazyQuery
+>
+export type GetLogsKeyValuesQueryResult = Apollo.QueryResult<
+	Types.GetLogsKeyValuesQuery,
+	Types.GetLogsKeyValuesQueryVariables
+>
+export const GetLogsErrorObjectsDocument = gql`
+	query GetLogsErrorObjects($log_cursors: [String!]!) {
+		logs_error_objects(log_cursors: $log_cursors) {
+			log_cursor
+			error_group_secure_id
+			id
+		}
+	}
+`
 
 /**
  * __useGetLogsErrorObjectsQuery__
@@ -8349,35 +12846,58 @@ export const GetLogsErrorObjectsDocument = gql`
  *   },
  * });
  */
-export function useGetLogsErrorObjectsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsErrorObjectsQuery, Types.GetLogsErrorObjectsQueryVariables>) {
-        return Apollo.useQuery<Types.GetLogsErrorObjectsQuery, Types.GetLogsErrorObjectsQueryVariables>(GetLogsErrorObjectsDocument, baseOptions);
-      }
-export function useGetLogsErrorObjectsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsErrorObjectsQuery, Types.GetLogsErrorObjectsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetLogsErrorObjectsQuery, Types.GetLogsErrorObjectsQueryVariables>(GetLogsErrorObjectsDocument, baseOptions);
-        }
-export type GetLogsErrorObjectsQueryHookResult = ReturnType<typeof useGetLogsErrorObjectsQuery>;
-export type GetLogsErrorObjectsLazyQueryHookResult = ReturnType<typeof useGetLogsErrorObjectsLazyQuery>;
-export type GetLogsErrorObjectsQueryResult = Apollo.QueryResult<Types.GetLogsErrorObjectsQuery, Types.GetLogsErrorObjectsQueryVariables>;
-export const GetProjectSettingsDocument = gql`
-    query GetProjectSettings($projectId: ID!) {
-  projectSettings(projectId: $projectId) {
-    id
-    name
-    verbose_id
-    billing_email
-    excluded_users
-    error_filters
-    error_json_paths
-    filter_chrome_extension
-    rage_click_window_seconds
-    rage_click_radius_pixels
-    rage_click_count
-    backend_domains
-    filterSessionsWithoutError
-    autoResolveStaleErrorsDayInterval
-  }
+export function useGetLogsErrorObjectsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetLogsErrorObjectsQuery,
+		Types.GetLogsErrorObjectsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetLogsErrorObjectsQuery,
+		Types.GetLogsErrorObjectsQueryVariables
+	>(GetLogsErrorObjectsDocument, baseOptions)
 }
-    `;
+export function useGetLogsErrorObjectsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetLogsErrorObjectsQuery,
+		Types.GetLogsErrorObjectsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetLogsErrorObjectsQuery,
+		Types.GetLogsErrorObjectsQueryVariables
+	>(GetLogsErrorObjectsDocument, baseOptions)
+}
+export type GetLogsErrorObjectsQueryHookResult = ReturnType<
+	typeof useGetLogsErrorObjectsQuery
+>
+export type GetLogsErrorObjectsLazyQueryHookResult = ReturnType<
+	typeof useGetLogsErrorObjectsLazyQuery
+>
+export type GetLogsErrorObjectsQueryResult = Apollo.QueryResult<
+	Types.GetLogsErrorObjectsQuery,
+	Types.GetLogsErrorObjectsQueryVariables
+>
+export const GetProjectSettingsDocument = gql`
+	query GetProjectSettings($projectId: ID!) {
+		projectSettings(projectId: $projectId) {
+			id
+			name
+			verbose_id
+			billing_email
+			excluded_users
+			error_filters
+			error_json_paths
+			filter_chrome_extension
+			rage_click_window_seconds
+			rage_click_radius_pixels
+			rage_click_count
+			backend_domains
+			filterSessionsWithoutError
+			autoResolveStaleErrorsDayInterval
+		}
+	}
+`
 
 /**
  * __useGetProjectSettingsQuery__
@@ -8395,25 +12915,48 @@ export const GetProjectSettingsDocument = gql`
  *   },
  * });
  */
-export function useGetProjectSettingsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetProjectSettingsQuery, Types.GetProjectSettingsQueryVariables>) {
-        return Apollo.useQuery<Types.GetProjectSettingsQuery, Types.GetProjectSettingsQueryVariables>(GetProjectSettingsDocument, baseOptions);
-      }
-export function useGetProjectSettingsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectSettingsQuery, Types.GetProjectSettingsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetProjectSettingsQuery, Types.GetProjectSettingsQueryVariables>(GetProjectSettingsDocument, baseOptions);
-        }
-export type GetProjectSettingsQueryHookResult = ReturnType<typeof useGetProjectSettingsQuery>;
-export type GetProjectSettingsLazyQueryHookResult = ReturnType<typeof useGetProjectSettingsLazyQuery>;
-export type GetProjectSettingsQueryResult = Apollo.QueryResult<Types.GetProjectSettingsQuery, Types.GetProjectSettingsQueryVariables>;
-export const GetWorkspacePendingInvitesDocument = gql`
-    query GetWorkspacePendingInvites($workspace_id: ID!) {
-  workspacePendingInvites(workspace_id: $workspace_id) {
-    id
-    invitee_email
-    invitee_role
-    created_at
-  }
+export function useGetProjectSettingsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetProjectSettingsQuery,
+		Types.GetProjectSettingsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetProjectSettingsQuery,
+		Types.GetProjectSettingsQueryVariables
+	>(GetProjectSettingsDocument, baseOptions)
 }
-    `;
+export function useGetProjectSettingsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetProjectSettingsQuery,
+		Types.GetProjectSettingsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetProjectSettingsQuery,
+		Types.GetProjectSettingsQueryVariables
+	>(GetProjectSettingsDocument, baseOptions)
+}
+export type GetProjectSettingsQueryHookResult = ReturnType<
+	typeof useGetProjectSettingsQuery
+>
+export type GetProjectSettingsLazyQueryHookResult = ReturnType<
+	typeof useGetProjectSettingsLazyQuery
+>
+export type GetProjectSettingsQueryResult = Apollo.QueryResult<
+	Types.GetProjectSettingsQuery,
+	Types.GetProjectSettingsQueryVariables
+>
+export const GetWorkspacePendingInvitesDocument = gql`
+	query GetWorkspacePendingInvites($workspace_id: ID!) {
+		workspacePendingInvites(workspace_id: $workspace_id) {
+			id
+			invitee_email
+			invitee_role
+			created_at
+		}
+	}
+`
 
 /**
  * __useGetWorkspacePendingInvitesQuery__
@@ -8431,23 +12974,46 @@ export const GetWorkspacePendingInvitesDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspacePendingInvitesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspacePendingInvitesQuery, Types.GetWorkspacePendingInvitesQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspacePendingInvitesQuery, Types.GetWorkspacePendingInvitesQueryVariables>(GetWorkspacePendingInvitesDocument, baseOptions);
-      }
-export function useGetWorkspacePendingInvitesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspacePendingInvitesQuery, Types.GetWorkspacePendingInvitesQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspacePendingInvitesQuery, Types.GetWorkspacePendingInvitesQueryVariables>(GetWorkspacePendingInvitesDocument, baseOptions);
-        }
-export type GetWorkspacePendingInvitesQueryHookResult = ReturnType<typeof useGetWorkspacePendingInvitesQuery>;
-export type GetWorkspacePendingInvitesLazyQueryHookResult = ReturnType<typeof useGetWorkspacePendingInvitesLazyQuery>;
-export type GetWorkspacePendingInvitesQueryResult = Apollo.QueryResult<Types.GetWorkspacePendingInvitesQuery, Types.GetWorkspacePendingInvitesQueryVariables>;
-export const GetWorkspaceSettingsDocument = gql`
-    query GetWorkspaceSettings($workspace_id: ID!) {
-  workspaceSettings(workspace_id: $workspace_id) {
-    workspace_id
-    ai_insights
-  }
+export function useGetWorkspacePendingInvitesQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspacePendingInvitesQuery,
+		Types.GetWorkspacePendingInvitesQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspacePendingInvitesQuery,
+		Types.GetWorkspacePendingInvitesQueryVariables
+	>(GetWorkspacePendingInvitesDocument, baseOptions)
 }
-    `;
+export function useGetWorkspacePendingInvitesLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspacePendingInvitesQuery,
+		Types.GetWorkspacePendingInvitesQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspacePendingInvitesQuery,
+		Types.GetWorkspacePendingInvitesQueryVariables
+	>(GetWorkspacePendingInvitesDocument, baseOptions)
+}
+export type GetWorkspacePendingInvitesQueryHookResult = ReturnType<
+	typeof useGetWorkspacePendingInvitesQuery
+>
+export type GetWorkspacePendingInvitesLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspacePendingInvitesLazyQuery
+>
+export type GetWorkspacePendingInvitesQueryResult = Apollo.QueryResult<
+	Types.GetWorkspacePendingInvitesQuery,
+	Types.GetWorkspacePendingInvitesQueryVariables
+>
+export const GetWorkspaceSettingsDocument = gql`
+	query GetWorkspaceSettings($workspace_id: ID!) {
+		workspaceSettings(workspace_id: $workspace_id) {
+			workspace_id
+			ai_insights
+		}
+	}
+`
 
 /**
  * __useGetWorkspaceSettingsQuery__
@@ -8465,45 +13031,72 @@ export const GetWorkspaceSettingsDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceSettingsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceSettingsQuery, Types.GetWorkspaceSettingsQueryVariables>) {
-        return Apollo.useQuery<Types.GetWorkspaceSettingsQuery, Types.GetWorkspaceSettingsQueryVariables>(GetWorkspaceSettingsDocument, baseOptions);
-      }
-export function useGetWorkspaceSettingsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceSettingsQuery, Types.GetWorkspaceSettingsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetWorkspaceSettingsQuery, Types.GetWorkspaceSettingsQueryVariables>(GetWorkspaceSettingsDocument, baseOptions);
-        }
-export type GetWorkspaceSettingsQueryHookResult = ReturnType<typeof useGetWorkspaceSettingsQuery>;
-export type GetWorkspaceSettingsLazyQueryHookResult = ReturnType<typeof useGetWorkspaceSettingsLazyQuery>;
-export type GetWorkspaceSettingsQueryResult = Apollo.QueryResult<Types.GetWorkspaceSettingsQuery, Types.GetWorkspaceSettingsQueryVariables>;
-export const GetErrorObjectsDocument = gql`
-    query GetErrorObjects($errorGroupSecureID: String!, $after: String, $before: String) {
-  error_objects(
-    error_group_secure_id: $errorGroupSecureID
-    after: $after
-    before: $before
-  ) {
-    edges {
-      cursor
-      node {
-        id
-        createdAt
-        event
-        errorGroupSecureID
-        session {
-          secureID
-          userProperties
-          appVersion
-        }
-      }
-    }
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      startCursor
-      endCursor
-    }
-  }
+export function useGetWorkspaceSettingsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetWorkspaceSettingsQuery,
+		Types.GetWorkspaceSettingsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetWorkspaceSettingsQuery,
+		Types.GetWorkspaceSettingsQueryVariables
+	>(GetWorkspaceSettingsDocument, baseOptions)
 }
-    `;
+export function useGetWorkspaceSettingsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetWorkspaceSettingsQuery,
+		Types.GetWorkspaceSettingsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetWorkspaceSettingsQuery,
+		Types.GetWorkspaceSettingsQueryVariables
+	>(GetWorkspaceSettingsDocument, baseOptions)
+}
+export type GetWorkspaceSettingsQueryHookResult = ReturnType<
+	typeof useGetWorkspaceSettingsQuery
+>
+export type GetWorkspaceSettingsLazyQueryHookResult = ReturnType<
+	typeof useGetWorkspaceSettingsLazyQuery
+>
+export type GetWorkspaceSettingsQueryResult = Apollo.QueryResult<
+	Types.GetWorkspaceSettingsQuery,
+	Types.GetWorkspaceSettingsQueryVariables
+>
+export const GetErrorObjectsDocument = gql`
+	query GetErrorObjects(
+		$errorGroupSecureID: String!
+		$after: String
+		$before: String
+	) {
+		error_objects(
+			error_group_secure_id: $errorGroupSecureID
+			after: $after
+			before: $before
+		) {
+			edges {
+				cursor
+				node {
+					id
+					createdAt
+					event
+					errorGroupSecureID
+					session {
+						secureID
+						userProperties
+						appVersion
+					}
+				}
+			}
+			pageInfo {
+				hasNextPage
+				hasPreviousPage
+				startCursor
+				endCursor
+			}
+		}
+	}
+`
 
 /**
  * __useGetErrorObjectsQuery__
@@ -8523,12 +13116,35 @@ export const GetErrorObjectsDocument = gql`
  *   },
  * });
  */
-export function useGetErrorObjectsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorObjectsQuery, Types.GetErrorObjectsQueryVariables>) {
-        return Apollo.useQuery<Types.GetErrorObjectsQuery, Types.GetErrorObjectsQueryVariables>(GetErrorObjectsDocument, baseOptions);
-      }
-export function useGetErrorObjectsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorObjectsQuery, Types.GetErrorObjectsQueryVariables>) {
-          return Apollo.useLazyQuery<Types.GetErrorObjectsQuery, Types.GetErrorObjectsQueryVariables>(GetErrorObjectsDocument, baseOptions);
-        }
-export type GetErrorObjectsQueryHookResult = ReturnType<typeof useGetErrorObjectsQuery>;
-export type GetErrorObjectsLazyQueryHookResult = ReturnType<typeof useGetErrorObjectsLazyQuery>;
-export type GetErrorObjectsQueryResult = Apollo.QueryResult<Types.GetErrorObjectsQuery, Types.GetErrorObjectsQueryVariables>;
+export function useGetErrorObjectsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetErrorObjectsQuery,
+		Types.GetErrorObjectsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetErrorObjectsQuery,
+		Types.GetErrorObjectsQueryVariables
+	>(GetErrorObjectsDocument, baseOptions)
+}
+export function useGetErrorObjectsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetErrorObjectsQuery,
+		Types.GetErrorObjectsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetErrorObjectsQuery,
+		Types.GetErrorObjectsQueryVariables
+	>(GetErrorObjectsDocument, baseOptions)
+}
+export type GetErrorObjectsQueryHookResult = ReturnType<
+	typeof useGetErrorObjectsQuery
+>
+export type GetErrorObjectsLazyQueryHookResult = ReturnType<
+	typeof useGetErrorObjectsLazyQuery
+>
+export type GetErrorObjectsQueryResult = Apollo.QueryResult<
+	Types.GetErrorObjectsQuery,
+	Types.GetErrorObjectsQueryVariables
+>

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -1,177 +1,167 @@
-import * as Types from './operations'
+import * as Types from './operations';
 
-import { gql } from '@apollo/client'
-import * as Apollo from '@apollo/client'
+import { gql } from '@apollo/client';
+import * as Apollo from '@apollo/client';
 export const SessionPayloadFragmentFragmentDoc = gql`
-	fragment SessionPayloadFragment on SessionPayload {
-		events
-		errors {
-			id
-			error_group_secure_id
-			event
-			type
-			url
-			source
-			stack_trace
-			structured_stack_trace {
-				fileName
-				lineNumber
-				functionName
-				columnNumber
-			}
-			timestamp
-			payload
-			request_id
-		}
-		rage_clicks {
-			start_timestamp
-			end_timestamp
-			total_clicks
-		}
-		session_comments {
-			id
-			timestamp
-			session_id
-			session_secure_id
-			created_at
-			updated_at
-			project_id
-			text
-			author {
-				id
-				name
-				email
-				photo_url
-			}
-			attachments {
-				integration_type
-				external_id
-				title
-			}
-			x_coordinate
-			y_coordinate
-			type
-			metadata
-		}
-		last_user_interaction_time
-	}
-`
+    fragment SessionPayloadFragment on SessionPayload {
+  events
+  errors {
+    id
+    error_group_secure_id
+    event
+    type
+    url
+    source
+    stack_trace
+    structured_stack_trace {
+      fileName
+      lineNumber
+      functionName
+      columnNumber
+    }
+    timestamp
+    payload
+    request_id
+  }
+  rage_clicks {
+    start_timestamp
+    end_timestamp
+    total_clicks
+  }
+  session_comments {
+    id
+    timestamp
+    session_id
+    session_secure_id
+    created_at
+    updated_at
+    project_id
+    text
+    author {
+      id
+      name
+      email
+      photo_url
+    }
+    attachments {
+      integration_type
+      external_id
+      title
+    }
+    x_coordinate
+    y_coordinate
+    type
+    metadata
+  }
+  last_user_interaction_time
+}
+    `;
 export const DiscordChannelFragmentFragmentDoc = gql`
-	fragment DiscordChannelFragment on DiscordChannel {
-		name
-		id
-	}
-`
+    fragment DiscordChannelFragment on DiscordChannel {
+  name
+  id
+}
+    `;
 export const SessionAlertFragmentFragmentDoc = gql`
-	fragment SessionAlertFragment on SessionAlert {
-		ChannelsToNotify {
-			webhook_channel
-			webhook_channel_id
-		}
-		DiscordChannelsToNotify {
-			...DiscordChannelFragment
-		}
-		CountThreshold
-		DailyFrequency
-		disabled
-		EmailsToNotify
-		ExcludedEnvironments
-		ExcludeRules
-		id
-		LastAdminToEditID
-		Name
-		updated_at
-		ThresholdWindow
-		TrackProperties {
-			id
-			name
-			value
-		}
-		Type
-	}
-	${DiscordChannelFragmentFragmentDoc}
-`
+    fragment SessionAlertFragment on SessionAlert {
+  ChannelsToNotify {
+    webhook_channel
+    webhook_channel_id
+  }
+  DiscordChannelsToNotify {
+    ...DiscordChannelFragment
+  }
+  CountThreshold
+  DailyFrequency
+  disabled
+  EmailsToNotify
+  ExcludedEnvironments
+  ExcludeRules
+  id
+  LastAdminToEditID
+  Name
+  updated_at
+  ThresholdWindow
+  TrackProperties {
+    id
+    name
+    value
+  }
+  Type
+}
+    ${DiscordChannelFragmentFragmentDoc}`;
 export const ErrorObjectFragmentDoc = gql`
-	fragment ErrorObject on ErrorObject {
-		id
-		created_at
-		project_id
-		session_id
-		trace_id
-		span_id
-		log_cursor
-		session {
-			identifier
-			fingerprint
-			secure_id
-			city
-			state
-			country
-			user_properties
-			processed
-			excluded
-			excluded_reason
-		}
-		error_group_id
-		error_group_secure_id
-		event
-		type
-		url
-		source
-		lineNumber
-		columnNumber
-		stack_trace
-		structured_stack_trace {
-			fileName
-			lineNumber
-			functionName
-			columnNumber
-			lineContent
-			linesBefore
-			linesAfter
-			error
-			sourceMappingErrorMetadata {
-				errorCode
-				stackTraceFileURL
-				sourcemapFetchStrategy
-				sourceMapURL
-				minifiedFetchStrategy
-				actualMinifiedFetchedPath
-				minifiedLineNumber
-				minifiedColumnNumber
-				actualSourcemapFetchedPath
-				sourcemapFileSize
-				minifiedFileSize
-				mappedLineNumber
-				mappedColumnNumber
-			}
-		}
-		timestamp
-		payload
-		request_id
-		os
-		browser
-		environment
-	}
-`
+    fragment ErrorObject on ErrorObject {
+  id
+  created_at
+  project_id
+  session_id
+  trace_id
+  span_id
+  log_cursor
+  session {
+    identifier
+    fingerprint
+    secure_id
+    city
+    state
+    country
+    user_properties
+    processed
+    excluded
+    excluded_reason
+  }
+  error_group_id
+  error_group_secure_id
+  event
+  type
+  url
+  source
+  lineNumber
+  columnNumber
+  stack_trace
+  structured_stack_trace {
+    fileName
+    lineNumber
+    functionName
+    columnNumber
+    lineContent
+    linesBefore
+    linesAfter
+    error
+    sourceMappingErrorMetadata {
+      errorCode
+      stackTraceFileURL
+      sourcemapFetchStrategy
+      sourceMapURL
+      minifiedFetchStrategy
+      actualMinifiedFetchedPath
+      minifiedLineNumber
+      minifiedColumnNumber
+      actualSourcemapFetchedPath
+      sourcemapFileSize
+      minifiedFileSize
+      mappedLineNumber
+      mappedColumnNumber
+    }
+  }
+  timestamp
+  payload
+  request_id
+  os
+  browser
+  environment
+}
+    `;
 export const MarkErrorGroupAsViewedDocument = gql`
-	mutation MarkErrorGroupAsViewed(
-		$error_secure_id: String!
-		$viewed: Boolean!
-	) {
-		markErrorGroupAsViewed(
-			error_secure_id: $error_secure_id
-			viewed: $viewed
-		) {
-			secure_id
-			viewed
-		}
-	}
-`
-export type MarkErrorGroupAsViewedMutationFn = Apollo.MutationFunction<
-	Types.MarkErrorGroupAsViewedMutation,
-	Types.MarkErrorGroupAsViewedMutationVariables
->
+    mutation MarkErrorGroupAsViewed($error_secure_id: String!, $viewed: Boolean!) {
+  markErrorGroupAsViewed(error_secure_id: $error_secure_id, viewed: $viewed) {
+    secure_id
+    viewed
+  }
+}
+    `;
+export type MarkErrorGroupAsViewedMutationFn = Apollo.MutationFunction<Types.MarkErrorGroupAsViewedMutation, Types.MarkErrorGroupAsViewedMutationVariables>;
 
 /**
  * __useMarkErrorGroupAsViewedMutation__
@@ -191,38 +181,21 @@ export type MarkErrorGroupAsViewedMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useMarkErrorGroupAsViewedMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.MarkErrorGroupAsViewedMutation,
-		Types.MarkErrorGroupAsViewedMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.MarkErrorGroupAsViewedMutation,
-		Types.MarkErrorGroupAsViewedMutationVariables
-	>(MarkErrorGroupAsViewedDocument, baseOptions)
-}
-export type MarkErrorGroupAsViewedMutationHookResult = ReturnType<
-	typeof useMarkErrorGroupAsViewedMutation
->
-export type MarkErrorGroupAsViewedMutationResult =
-	Apollo.MutationResult<Types.MarkErrorGroupAsViewedMutation>
-export type MarkErrorGroupAsViewedMutationOptions = Apollo.BaseMutationOptions<
-	Types.MarkErrorGroupAsViewedMutation,
-	Types.MarkErrorGroupAsViewedMutationVariables
->
+export function useMarkErrorGroupAsViewedMutation(baseOptions?: Apollo.MutationHookOptions<Types.MarkErrorGroupAsViewedMutation, Types.MarkErrorGroupAsViewedMutationVariables>) {
+        return Apollo.useMutation<Types.MarkErrorGroupAsViewedMutation, Types.MarkErrorGroupAsViewedMutationVariables>(MarkErrorGroupAsViewedDocument, baseOptions);
+      }
+export type MarkErrorGroupAsViewedMutationHookResult = ReturnType<typeof useMarkErrorGroupAsViewedMutation>;
+export type MarkErrorGroupAsViewedMutationResult = Apollo.MutationResult<Types.MarkErrorGroupAsViewedMutation>;
+export type MarkErrorGroupAsViewedMutationOptions = Apollo.BaseMutationOptions<Types.MarkErrorGroupAsViewedMutation, Types.MarkErrorGroupAsViewedMutationVariables>;
 export const MarkSessionAsViewedDocument = gql`
-	mutation MarkSessionAsViewed($secure_id: String!, $viewed: Boolean!) {
-		markSessionAsViewed(secure_id: $secure_id, viewed: $viewed) {
-			secure_id
-			viewed
-		}
-	}
-`
-export type MarkSessionAsViewedMutationFn = Apollo.MutationFunction<
-	Types.MarkSessionAsViewedMutation,
-	Types.MarkSessionAsViewedMutationVariables
->
+    mutation MarkSessionAsViewed($secure_id: String!, $viewed: Boolean!) {
+  markSessionAsViewed(secure_id: $secure_id, viewed: $viewed) {
+    secure_id
+    viewed
+  }
+}
+    `;
+export type MarkSessionAsViewedMutationFn = Apollo.MutationFunction<Types.MarkSessionAsViewedMutation, Types.MarkSessionAsViewedMutationVariables>;
 
 /**
  * __useMarkSessionAsViewedMutation__
@@ -242,38 +215,21 @@ export type MarkSessionAsViewedMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useMarkSessionAsViewedMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.MarkSessionAsViewedMutation,
-		Types.MarkSessionAsViewedMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.MarkSessionAsViewedMutation,
-		Types.MarkSessionAsViewedMutationVariables
-	>(MarkSessionAsViewedDocument, baseOptions)
-}
-export type MarkSessionAsViewedMutationHookResult = ReturnType<
-	typeof useMarkSessionAsViewedMutation
->
-export type MarkSessionAsViewedMutationResult =
-	Apollo.MutationResult<Types.MarkSessionAsViewedMutation>
-export type MarkSessionAsViewedMutationOptions = Apollo.BaseMutationOptions<
-	Types.MarkSessionAsViewedMutation,
-	Types.MarkSessionAsViewedMutationVariables
->
+export function useMarkSessionAsViewedMutation(baseOptions?: Apollo.MutationHookOptions<Types.MarkSessionAsViewedMutation, Types.MarkSessionAsViewedMutationVariables>) {
+        return Apollo.useMutation<Types.MarkSessionAsViewedMutation, Types.MarkSessionAsViewedMutationVariables>(MarkSessionAsViewedDocument, baseOptions);
+      }
+export type MarkSessionAsViewedMutationHookResult = ReturnType<typeof useMarkSessionAsViewedMutation>;
+export type MarkSessionAsViewedMutationResult = Apollo.MutationResult<Types.MarkSessionAsViewedMutation>;
+export type MarkSessionAsViewedMutationOptions = Apollo.BaseMutationOptions<Types.MarkSessionAsViewedMutation, Types.MarkSessionAsViewedMutationVariables>;
 export const MarkSessionAsStarredDocument = gql`
-	mutation MarkSessionAsStarred($secure_id: String!, $starred: Boolean!) {
-		markSessionAsStarred(secure_id: $secure_id, starred: $starred) {
-			secure_id
-			starred
-		}
-	}
-`
-export type MarkSessionAsStarredMutationFn = Apollo.MutationFunction<
-	Types.MarkSessionAsStarredMutation,
-	Types.MarkSessionAsStarredMutationVariables
->
+    mutation MarkSessionAsStarred($secure_id: String!, $starred: Boolean!) {
+  markSessionAsStarred(secure_id: $secure_id, starred: $starred) {
+    secure_id
+    starred
+  }
+}
+    `;
+export type MarkSessionAsStarredMutationFn = Apollo.MutationFunction<Types.MarkSessionAsStarredMutation, Types.MarkSessionAsStarredMutationVariables>;
 
 /**
  * __useMarkSessionAsStarredMutation__
@@ -293,35 +249,18 @@ export type MarkSessionAsStarredMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useMarkSessionAsStarredMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.MarkSessionAsStarredMutation,
-		Types.MarkSessionAsStarredMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.MarkSessionAsStarredMutation,
-		Types.MarkSessionAsStarredMutationVariables
-	>(MarkSessionAsStarredDocument, baseOptions)
-}
-export type MarkSessionAsStarredMutationHookResult = ReturnType<
-	typeof useMarkSessionAsStarredMutation
->
-export type MarkSessionAsStarredMutationResult =
-	Apollo.MutationResult<Types.MarkSessionAsStarredMutation>
-export type MarkSessionAsStarredMutationOptions = Apollo.BaseMutationOptions<
-	Types.MarkSessionAsStarredMutation,
-	Types.MarkSessionAsStarredMutationVariables
->
+export function useMarkSessionAsStarredMutation(baseOptions?: Apollo.MutationHookOptions<Types.MarkSessionAsStarredMutation, Types.MarkSessionAsStarredMutationVariables>) {
+        return Apollo.useMutation<Types.MarkSessionAsStarredMutation, Types.MarkSessionAsStarredMutationVariables>(MarkSessionAsStarredDocument, baseOptions);
+      }
+export type MarkSessionAsStarredMutationHookResult = ReturnType<typeof useMarkSessionAsStarredMutation>;
+export type MarkSessionAsStarredMutationResult = Apollo.MutationResult<Types.MarkSessionAsStarredMutation>;
+export type MarkSessionAsStarredMutationOptions = Apollo.BaseMutationOptions<Types.MarkSessionAsStarredMutation, Types.MarkSessionAsStarredMutationVariables>;
 export const MuteSessionCommentThreadDocument = gql`
-	mutation MuteSessionCommentThread($id: ID!, $has_muted: Boolean) {
-		muteSessionCommentThread(id: $id, has_muted: $has_muted)
-	}
-`
-export type MuteSessionCommentThreadMutationFn = Apollo.MutationFunction<
-	Types.MuteSessionCommentThreadMutation,
-	Types.MuteSessionCommentThreadMutationVariables
->
+    mutation MuteSessionCommentThread($id: ID!, $has_muted: Boolean) {
+  muteSessionCommentThread(id: $id, has_muted: $has_muted)
+}
+    `;
+export type MuteSessionCommentThreadMutationFn = Apollo.MutationFunction<Types.MuteSessionCommentThreadMutation, Types.MuteSessionCommentThreadMutationVariables>;
 
 /**
  * __useMuteSessionCommentThreadMutation__
@@ -341,47 +280,23 @@ export type MuteSessionCommentThreadMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useMuteSessionCommentThreadMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.MuteSessionCommentThreadMutation,
-		Types.MuteSessionCommentThreadMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.MuteSessionCommentThreadMutation,
-		Types.MuteSessionCommentThreadMutationVariables
-	>(MuteSessionCommentThreadDocument, baseOptions)
-}
-export type MuteSessionCommentThreadMutationHookResult = ReturnType<
-	typeof useMuteSessionCommentThreadMutation
->
-export type MuteSessionCommentThreadMutationResult =
-	Apollo.MutationResult<Types.MuteSessionCommentThreadMutation>
-export type MuteSessionCommentThreadMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.MuteSessionCommentThreadMutation,
-		Types.MuteSessionCommentThreadMutationVariables
-	>
+export function useMuteSessionCommentThreadMutation(baseOptions?: Apollo.MutationHookOptions<Types.MuteSessionCommentThreadMutation, Types.MuteSessionCommentThreadMutationVariables>) {
+        return Apollo.useMutation<Types.MuteSessionCommentThreadMutation, Types.MuteSessionCommentThreadMutationVariables>(MuteSessionCommentThreadDocument, baseOptions);
+      }
+export type MuteSessionCommentThreadMutationHookResult = ReturnType<typeof useMuteSessionCommentThreadMutation>;
+export type MuteSessionCommentThreadMutationResult = Apollo.MutationResult<Types.MuteSessionCommentThreadMutation>;
+export type MuteSessionCommentThreadMutationOptions = Apollo.BaseMutationOptions<Types.MuteSessionCommentThreadMutation, Types.MuteSessionCommentThreadMutationVariables>;
 export const CreateOrUpdateStripeSubscriptionDocument = gql`
-	mutation CreateOrUpdateStripeSubscription(
-		$workspace_id: ID!
-		$plan_type: PlanType!
-		$interval: SubscriptionInterval!
-		$retention_period: RetentionPeriod!
-	) {
-		createOrUpdateStripeSubscription(
-			workspace_id: $workspace_id
-			plan_type: $plan_type
-			interval: $interval
-			retention_period: $retention_period
-		)
-	}
-`
-export type CreateOrUpdateStripeSubscriptionMutationFn =
-	Apollo.MutationFunction<
-		Types.CreateOrUpdateStripeSubscriptionMutation,
-		Types.CreateOrUpdateStripeSubscriptionMutationVariables
-	>
+    mutation CreateOrUpdateStripeSubscription($workspace_id: ID!, $plan_type: PlanType!, $interval: SubscriptionInterval!, $retention_period: RetentionPeriod!) {
+  createOrUpdateStripeSubscription(
+    workspace_id: $workspace_id
+    plan_type: $plan_type
+    interval: $interval
+    retention_period: $retention_period
+  )
+}
+    `;
+export type CreateOrUpdateStripeSubscriptionMutationFn = Apollo.MutationFunction<Types.CreateOrUpdateStripeSubscriptionMutation, Types.CreateOrUpdateStripeSubscriptionMutationVariables>;
 
 /**
  * __useCreateOrUpdateStripeSubscriptionMutation__
@@ -403,52 +318,26 @@ export type CreateOrUpdateStripeSubscriptionMutationFn =
  *   },
  * });
  */
-export function useCreateOrUpdateStripeSubscriptionMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateOrUpdateStripeSubscriptionMutation,
-		Types.CreateOrUpdateStripeSubscriptionMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateOrUpdateStripeSubscriptionMutation,
-		Types.CreateOrUpdateStripeSubscriptionMutationVariables
-	>(CreateOrUpdateStripeSubscriptionDocument, baseOptions)
-}
-export type CreateOrUpdateStripeSubscriptionMutationHookResult = ReturnType<
-	typeof useCreateOrUpdateStripeSubscriptionMutation
->
-export type CreateOrUpdateStripeSubscriptionMutationResult =
-	Apollo.MutationResult<Types.CreateOrUpdateStripeSubscriptionMutation>
-export type CreateOrUpdateStripeSubscriptionMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.CreateOrUpdateStripeSubscriptionMutation,
-		Types.CreateOrUpdateStripeSubscriptionMutationVariables
-	>
+export function useCreateOrUpdateStripeSubscriptionMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateOrUpdateStripeSubscriptionMutation, Types.CreateOrUpdateStripeSubscriptionMutationVariables>) {
+        return Apollo.useMutation<Types.CreateOrUpdateStripeSubscriptionMutation, Types.CreateOrUpdateStripeSubscriptionMutationVariables>(CreateOrUpdateStripeSubscriptionDocument, baseOptions);
+      }
+export type CreateOrUpdateStripeSubscriptionMutationHookResult = ReturnType<typeof useCreateOrUpdateStripeSubscriptionMutation>;
+export type CreateOrUpdateStripeSubscriptionMutationResult = Apollo.MutationResult<Types.CreateOrUpdateStripeSubscriptionMutation>;
+export type CreateOrUpdateStripeSubscriptionMutationOptions = Apollo.BaseMutationOptions<Types.CreateOrUpdateStripeSubscriptionMutation, Types.CreateOrUpdateStripeSubscriptionMutationVariables>;
 export const SaveBillingPlanDocument = gql`
-	mutation SaveBillingPlan(
-		$workspace_id: ID!
-		$sessionsLimitCents: Int
-		$sessionsRetention: RetentionPeriod!
-		$errorsLimitCents: Int
-		$errorsRetention: RetentionPeriod!
-		$logsLimitCents: Int
-		$logsRetention: RetentionPeriod!
-	) {
-		saveBillingPlan(
-			workspace_id: $workspace_id
-			sessionsLimitCents: $sessionsLimitCents
-			sessionsRetention: $sessionsRetention
-			errorsLimitCents: $errorsLimitCents
-			errorsRetention: $errorsRetention
-			logsLimitCents: $logsLimitCents
-			logsRetention: $logsRetention
-		)
-	}
-`
-export type SaveBillingPlanMutationFn = Apollo.MutationFunction<
-	Types.SaveBillingPlanMutation,
-	Types.SaveBillingPlanMutationVariables
->
+    mutation SaveBillingPlan($workspace_id: ID!, $sessionsLimitCents: Int, $sessionsRetention: RetentionPeriod!, $errorsLimitCents: Int, $errorsRetention: RetentionPeriod!, $logsLimitCents: Int, $logsRetention: RetentionPeriod!) {
+  saveBillingPlan(
+    workspace_id: $workspace_id
+    sessionsLimitCents: $sessionsLimitCents
+    sessionsRetention: $sessionsRetention
+    errorsLimitCents: $errorsLimitCents
+    errorsRetention: $errorsRetention
+    logsLimitCents: $logsLimitCents
+    logsRetention: $logsRetention
+  )
+}
+    `;
+export type SaveBillingPlanMutationFn = Apollo.MutationFunction<Types.SaveBillingPlanMutation, Types.SaveBillingPlanMutationVariables>;
 
 /**
  * __useSaveBillingPlanMutation__
@@ -473,35 +362,18 @@ export type SaveBillingPlanMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useSaveBillingPlanMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.SaveBillingPlanMutation,
-		Types.SaveBillingPlanMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.SaveBillingPlanMutation,
-		Types.SaveBillingPlanMutationVariables
-	>(SaveBillingPlanDocument, baseOptions)
-}
-export type SaveBillingPlanMutationHookResult = ReturnType<
-	typeof useSaveBillingPlanMutation
->
-export type SaveBillingPlanMutationResult =
-	Apollo.MutationResult<Types.SaveBillingPlanMutation>
-export type SaveBillingPlanMutationOptions = Apollo.BaseMutationOptions<
-	Types.SaveBillingPlanMutation,
-	Types.SaveBillingPlanMutationVariables
->
+export function useSaveBillingPlanMutation(baseOptions?: Apollo.MutationHookOptions<Types.SaveBillingPlanMutation, Types.SaveBillingPlanMutationVariables>) {
+        return Apollo.useMutation<Types.SaveBillingPlanMutation, Types.SaveBillingPlanMutationVariables>(SaveBillingPlanDocument, baseOptions);
+      }
+export type SaveBillingPlanMutationHookResult = ReturnType<typeof useSaveBillingPlanMutation>;
+export type SaveBillingPlanMutationResult = Apollo.MutationResult<Types.SaveBillingPlanMutation>;
+export type SaveBillingPlanMutationOptions = Apollo.BaseMutationOptions<Types.SaveBillingPlanMutation, Types.SaveBillingPlanMutationVariables>;
 export const UpdateBillingDetailsDocument = gql`
-	mutation UpdateBillingDetails($workspace_id: ID!) {
-		updateBillingDetails(workspace_id: $workspace_id)
-	}
-`
-export type UpdateBillingDetailsMutationFn = Apollo.MutationFunction<
-	Types.UpdateBillingDetailsMutation,
-	Types.UpdateBillingDetailsMutationVariables
->
+    mutation UpdateBillingDetails($workspace_id: ID!) {
+  updateBillingDetails(workspace_id: $workspace_id)
+}
+    `;
+export type UpdateBillingDetailsMutationFn = Apollo.MutationFunction<Types.UpdateBillingDetailsMutation, Types.UpdateBillingDetailsMutationVariables>;
 
 /**
  * __useUpdateBillingDetailsMutation__
@@ -520,47 +392,26 @@ export type UpdateBillingDetailsMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateBillingDetailsMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateBillingDetailsMutation,
-		Types.UpdateBillingDetailsMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateBillingDetailsMutation,
-		Types.UpdateBillingDetailsMutationVariables
-	>(UpdateBillingDetailsDocument, baseOptions)
-}
-export type UpdateBillingDetailsMutationHookResult = ReturnType<
-	typeof useUpdateBillingDetailsMutation
->
-export type UpdateBillingDetailsMutationResult =
-	Apollo.MutationResult<Types.UpdateBillingDetailsMutation>
-export type UpdateBillingDetailsMutationOptions = Apollo.BaseMutationOptions<
-	Types.UpdateBillingDetailsMutation,
-	Types.UpdateBillingDetailsMutationVariables
->
+export function useUpdateBillingDetailsMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateBillingDetailsMutation, Types.UpdateBillingDetailsMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateBillingDetailsMutation, Types.UpdateBillingDetailsMutationVariables>(UpdateBillingDetailsDocument, baseOptions);
+      }
+export type UpdateBillingDetailsMutationHookResult = ReturnType<typeof useUpdateBillingDetailsMutation>;
+export type UpdateBillingDetailsMutationResult = Apollo.MutationResult<Types.UpdateBillingDetailsMutation>;
+export type UpdateBillingDetailsMutationOptions = Apollo.BaseMutationOptions<Types.UpdateBillingDetailsMutation, Types.UpdateBillingDetailsMutationVariables>;
 export const UpdateErrorGroupStateDocument = gql`
-	mutation updateErrorGroupState(
-		$secure_id: String!
-		$state: ErrorState!
-		$snoozed_until: Timestamp
-	) {
-		updateErrorGroupState(
-			secure_id: $secure_id
-			state: $state
-			snoozed_until: $snoozed_until
-		) {
-			secure_id
-			state
-			snoozed_until
-		}
-	}
-`
-export type UpdateErrorGroupStateMutationFn = Apollo.MutationFunction<
-	Types.UpdateErrorGroupStateMutation,
-	Types.UpdateErrorGroupStateMutationVariables
->
+    mutation updateErrorGroupState($secure_id: String!, $state: ErrorState!, $snoozed_until: Timestamp) {
+  updateErrorGroupState(
+    secure_id: $secure_id
+    state: $state
+    snoozed_until: $snoozed_until
+  ) {
+    secure_id
+    state
+    snoozed_until
+  }
+}
+    `;
+export type UpdateErrorGroupStateMutationFn = Apollo.MutationFunction<Types.UpdateErrorGroupStateMutation, Types.UpdateErrorGroupStateMutationVariables>;
 
 /**
  * __useUpdateErrorGroupStateMutation__
@@ -581,35 +432,18 @@ export type UpdateErrorGroupStateMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateErrorGroupStateMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateErrorGroupStateMutation,
-		Types.UpdateErrorGroupStateMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateErrorGroupStateMutation,
-		Types.UpdateErrorGroupStateMutationVariables
-	>(UpdateErrorGroupStateDocument, baseOptions)
-}
-export type UpdateErrorGroupStateMutationHookResult = ReturnType<
-	typeof useUpdateErrorGroupStateMutation
->
-export type UpdateErrorGroupStateMutationResult =
-	Apollo.MutationResult<Types.UpdateErrorGroupStateMutation>
-export type UpdateErrorGroupStateMutationOptions = Apollo.BaseMutationOptions<
-	Types.UpdateErrorGroupStateMutation,
-	Types.UpdateErrorGroupStateMutationVariables
->
+export function useUpdateErrorGroupStateMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateErrorGroupStateMutation, Types.UpdateErrorGroupStateMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateErrorGroupStateMutation, Types.UpdateErrorGroupStateMutationVariables>(UpdateErrorGroupStateDocument, baseOptions);
+      }
+export type UpdateErrorGroupStateMutationHookResult = ReturnType<typeof useUpdateErrorGroupStateMutation>;
+export type UpdateErrorGroupStateMutationResult = Apollo.MutationResult<Types.UpdateErrorGroupStateMutation>;
+export type UpdateErrorGroupStateMutationOptions = Apollo.BaseMutationOptions<Types.UpdateErrorGroupStateMutation, Types.UpdateErrorGroupStateMutationVariables>;
 export const SendEmailSignupDocument = gql`
-	mutation SendEmailSignup($email: String!) {
-		emailSignup(email: $email)
-	}
-`
-export type SendEmailSignupMutationFn = Apollo.MutationFunction<
-	Types.SendEmailSignupMutation,
-	Types.SendEmailSignupMutationVariables
->
+    mutation SendEmailSignup($email: String!) {
+  emailSignup(email: $email)
+}
+    `;
+export type SendEmailSignupMutationFn = Apollo.MutationFunction<Types.SendEmailSignupMutation, Types.SendEmailSignupMutationVariables>;
 
 /**
  * __useSendEmailSignupMutation__
@@ -628,35 +462,18 @@ export type SendEmailSignupMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useSendEmailSignupMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.SendEmailSignupMutation,
-		Types.SendEmailSignupMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.SendEmailSignupMutation,
-		Types.SendEmailSignupMutationVariables
-	>(SendEmailSignupDocument, baseOptions)
-}
-export type SendEmailSignupMutationHookResult = ReturnType<
-	typeof useSendEmailSignupMutation
->
-export type SendEmailSignupMutationResult =
-	Apollo.MutationResult<Types.SendEmailSignupMutation>
-export type SendEmailSignupMutationOptions = Apollo.BaseMutationOptions<
-	Types.SendEmailSignupMutation,
-	Types.SendEmailSignupMutationVariables
->
+export function useSendEmailSignupMutation(baseOptions?: Apollo.MutationHookOptions<Types.SendEmailSignupMutation, Types.SendEmailSignupMutationVariables>) {
+        return Apollo.useMutation<Types.SendEmailSignupMutation, Types.SendEmailSignupMutationVariables>(SendEmailSignupDocument, baseOptions);
+      }
+export type SendEmailSignupMutationHookResult = ReturnType<typeof useSendEmailSignupMutation>;
+export type SendEmailSignupMutationResult = Apollo.MutationResult<Types.SendEmailSignupMutation>;
+export type SendEmailSignupMutationOptions = Apollo.BaseMutationOptions<Types.SendEmailSignupMutation, Types.SendEmailSignupMutationVariables>;
 export const AddAdminToWorkspaceDocument = gql`
-	mutation AddAdminToWorkspace($workspace_id: ID!, $invite_id: String!) {
-		addAdminToWorkspace(workspace_id: $workspace_id, invite_id: $invite_id)
-	}
-`
-export type AddAdminToWorkspaceMutationFn = Apollo.MutationFunction<
-	Types.AddAdminToWorkspaceMutation,
-	Types.AddAdminToWorkspaceMutationVariables
->
+    mutation AddAdminToWorkspace($workspace_id: ID!, $invite_id: String!) {
+  addAdminToWorkspace(workspace_id: $workspace_id, invite_id: $invite_id)
+}
+    `;
+export type AddAdminToWorkspaceMutationFn = Apollo.MutationFunction<Types.AddAdminToWorkspaceMutation, Types.AddAdminToWorkspaceMutationVariables>;
 
 /**
  * __useAddAdminToWorkspaceMutation__
@@ -676,35 +493,18 @@ export type AddAdminToWorkspaceMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useAddAdminToWorkspaceMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.AddAdminToWorkspaceMutation,
-		Types.AddAdminToWorkspaceMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.AddAdminToWorkspaceMutation,
-		Types.AddAdminToWorkspaceMutationVariables
-	>(AddAdminToWorkspaceDocument, baseOptions)
-}
-export type AddAdminToWorkspaceMutationHookResult = ReturnType<
-	typeof useAddAdminToWorkspaceMutation
->
-export type AddAdminToWorkspaceMutationResult =
-	Apollo.MutationResult<Types.AddAdminToWorkspaceMutation>
-export type AddAdminToWorkspaceMutationOptions = Apollo.BaseMutationOptions<
-	Types.AddAdminToWorkspaceMutation,
-	Types.AddAdminToWorkspaceMutationVariables
->
+export function useAddAdminToWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.AddAdminToWorkspaceMutation, Types.AddAdminToWorkspaceMutationVariables>) {
+        return Apollo.useMutation<Types.AddAdminToWorkspaceMutation, Types.AddAdminToWorkspaceMutationVariables>(AddAdminToWorkspaceDocument, baseOptions);
+      }
+export type AddAdminToWorkspaceMutationHookResult = ReturnType<typeof useAddAdminToWorkspaceMutation>;
+export type AddAdminToWorkspaceMutationResult = Apollo.MutationResult<Types.AddAdminToWorkspaceMutation>;
+export type AddAdminToWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.AddAdminToWorkspaceMutation, Types.AddAdminToWorkspaceMutationVariables>;
 export const JoinWorkspaceDocument = gql`
-	mutation JoinWorkspace($workspace_id: ID!) {
-		joinWorkspace(workspace_id: $workspace_id)
-	}
-`
-export type JoinWorkspaceMutationFn = Apollo.MutationFunction<
-	Types.JoinWorkspaceMutation,
-	Types.JoinWorkspaceMutationVariables
->
+    mutation JoinWorkspace($workspace_id: ID!) {
+  joinWorkspace(workspace_id: $workspace_id)
+}
+    `;
+export type JoinWorkspaceMutationFn = Apollo.MutationFunction<Types.JoinWorkspaceMutation, Types.JoinWorkspaceMutationVariables>;
 
 /**
  * __useJoinWorkspaceMutation__
@@ -723,43 +523,22 @@ export type JoinWorkspaceMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useJoinWorkspaceMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.JoinWorkspaceMutation,
-		Types.JoinWorkspaceMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.JoinWorkspaceMutation,
-		Types.JoinWorkspaceMutationVariables
-	>(JoinWorkspaceDocument, baseOptions)
-}
-export type JoinWorkspaceMutationHookResult = ReturnType<
-	typeof useJoinWorkspaceMutation
->
-export type JoinWorkspaceMutationResult =
-	Apollo.MutationResult<Types.JoinWorkspaceMutation>
-export type JoinWorkspaceMutationOptions = Apollo.BaseMutationOptions<
-	Types.JoinWorkspaceMutation,
-	Types.JoinWorkspaceMutationVariables
->
+export function useJoinWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.JoinWorkspaceMutation, Types.JoinWorkspaceMutationVariables>) {
+        return Apollo.useMutation<Types.JoinWorkspaceMutation, Types.JoinWorkspaceMutationVariables>(JoinWorkspaceDocument, baseOptions);
+      }
+export type JoinWorkspaceMutationHookResult = ReturnType<typeof useJoinWorkspaceMutation>;
+export type JoinWorkspaceMutationResult = Apollo.MutationResult<Types.JoinWorkspaceMutation>;
+export type JoinWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.JoinWorkspaceMutation, Types.JoinWorkspaceMutationVariables>;
 export const ChangeAdminRoleDocument = gql`
-	mutation ChangeAdminRole(
-		$workspace_id: ID!
-		$admin_id: ID!
-		$new_role: String!
-	) {
-		changeAdminRole(
-			workspace_id: $workspace_id
-			admin_id: $admin_id
-			new_role: $new_role
-		)
-	}
-`
-export type ChangeAdminRoleMutationFn = Apollo.MutationFunction<
-	Types.ChangeAdminRoleMutation,
-	Types.ChangeAdminRoleMutationVariables
->
+    mutation ChangeAdminRole($workspace_id: ID!, $admin_id: ID!, $new_role: String!) {
+  changeAdminRole(
+    workspace_id: $workspace_id
+    admin_id: $admin_id
+    new_role: $new_role
+  )
+}
+    `;
+export type ChangeAdminRoleMutationFn = Apollo.MutationFunction<Types.ChangeAdminRoleMutation, Types.ChangeAdminRoleMutationVariables>;
 
 /**
  * __useChangeAdminRoleMutation__
@@ -780,35 +559,18 @@ export type ChangeAdminRoleMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useChangeAdminRoleMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.ChangeAdminRoleMutation,
-		Types.ChangeAdminRoleMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.ChangeAdminRoleMutation,
-		Types.ChangeAdminRoleMutationVariables
-	>(ChangeAdminRoleDocument, baseOptions)
-}
-export type ChangeAdminRoleMutationHookResult = ReturnType<
-	typeof useChangeAdminRoleMutation
->
-export type ChangeAdminRoleMutationResult =
-	Apollo.MutationResult<Types.ChangeAdminRoleMutation>
-export type ChangeAdminRoleMutationOptions = Apollo.BaseMutationOptions<
-	Types.ChangeAdminRoleMutation,
-	Types.ChangeAdminRoleMutationVariables
->
+export function useChangeAdminRoleMutation(baseOptions?: Apollo.MutationHookOptions<Types.ChangeAdminRoleMutation, Types.ChangeAdminRoleMutationVariables>) {
+        return Apollo.useMutation<Types.ChangeAdminRoleMutation, Types.ChangeAdminRoleMutationVariables>(ChangeAdminRoleDocument, baseOptions);
+      }
+export type ChangeAdminRoleMutationHookResult = ReturnType<typeof useChangeAdminRoleMutation>;
+export type ChangeAdminRoleMutationResult = Apollo.MutationResult<Types.ChangeAdminRoleMutation>;
+export type ChangeAdminRoleMutationOptions = Apollo.BaseMutationOptions<Types.ChangeAdminRoleMutation, Types.ChangeAdminRoleMutationVariables>;
 export const DeleteAdminFromProjectDocument = gql`
-	mutation DeleteAdminFromProject($project_id: ID!, $admin_id: ID!) {
-		deleteAdminFromProject(project_id: $project_id, admin_id: $admin_id)
-	}
-`
-export type DeleteAdminFromProjectMutationFn = Apollo.MutationFunction<
-	Types.DeleteAdminFromProjectMutation,
-	Types.DeleteAdminFromProjectMutationVariables
->
+    mutation DeleteAdminFromProject($project_id: ID!, $admin_id: ID!) {
+  deleteAdminFromProject(project_id: $project_id, admin_id: $admin_id)
+}
+    `;
+export type DeleteAdminFromProjectMutationFn = Apollo.MutationFunction<Types.DeleteAdminFromProjectMutation, Types.DeleteAdminFromProjectMutationVariables>;
 
 /**
  * __useDeleteAdminFromProjectMutation__
@@ -828,38 +590,18 @@ export type DeleteAdminFromProjectMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteAdminFromProjectMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteAdminFromProjectMutation,
-		Types.DeleteAdminFromProjectMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteAdminFromProjectMutation,
-		Types.DeleteAdminFromProjectMutationVariables
-	>(DeleteAdminFromProjectDocument, baseOptions)
-}
-export type DeleteAdminFromProjectMutationHookResult = ReturnType<
-	typeof useDeleteAdminFromProjectMutation
->
-export type DeleteAdminFromProjectMutationResult =
-	Apollo.MutationResult<Types.DeleteAdminFromProjectMutation>
-export type DeleteAdminFromProjectMutationOptions = Apollo.BaseMutationOptions<
-	Types.DeleteAdminFromProjectMutation,
-	Types.DeleteAdminFromProjectMutationVariables
->
+export function useDeleteAdminFromProjectMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteAdminFromProjectMutation, Types.DeleteAdminFromProjectMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteAdminFromProjectMutation, Types.DeleteAdminFromProjectMutationVariables>(DeleteAdminFromProjectDocument, baseOptions);
+      }
+export type DeleteAdminFromProjectMutationHookResult = ReturnType<typeof useDeleteAdminFromProjectMutation>;
+export type DeleteAdminFromProjectMutationResult = Apollo.MutationResult<Types.DeleteAdminFromProjectMutation>;
+export type DeleteAdminFromProjectMutationOptions = Apollo.BaseMutationOptions<Types.DeleteAdminFromProjectMutation, Types.DeleteAdminFromProjectMutationVariables>;
 export const DeleteAdminFromWorkspaceDocument = gql`
-	mutation DeleteAdminFromWorkspace($workspace_id: ID!, $admin_id: ID!) {
-		deleteAdminFromWorkspace(
-			workspace_id: $workspace_id
-			admin_id: $admin_id
-		)
-	}
-`
-export type DeleteAdminFromWorkspaceMutationFn = Apollo.MutationFunction<
-	Types.DeleteAdminFromWorkspaceMutation,
-	Types.DeleteAdminFromWorkspaceMutationVariables
->
+    mutation DeleteAdminFromWorkspace($workspace_id: ID!, $admin_id: ID!) {
+  deleteAdminFromWorkspace(workspace_id: $workspace_id, admin_id: $admin_id)
+}
+    `;
+export type DeleteAdminFromWorkspaceMutationFn = Apollo.MutationFunction<Types.DeleteAdminFromWorkspaceMutation, Types.DeleteAdminFromWorkspaceMutationVariables>;
 
 /**
  * __useDeleteAdminFromWorkspaceMutation__
@@ -879,44 +621,22 @@ export type DeleteAdminFromWorkspaceMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteAdminFromWorkspaceMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteAdminFromWorkspaceMutation,
-		Types.DeleteAdminFromWorkspaceMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteAdminFromWorkspaceMutation,
-		Types.DeleteAdminFromWorkspaceMutationVariables
-	>(DeleteAdminFromWorkspaceDocument, baseOptions)
-}
-export type DeleteAdminFromWorkspaceMutationHookResult = ReturnType<
-	typeof useDeleteAdminFromWorkspaceMutation
->
-export type DeleteAdminFromWorkspaceMutationResult =
-	Apollo.MutationResult<Types.DeleteAdminFromWorkspaceMutation>
-export type DeleteAdminFromWorkspaceMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.DeleteAdminFromWorkspaceMutation,
-		Types.DeleteAdminFromWorkspaceMutationVariables
-	>
+export function useDeleteAdminFromWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteAdminFromWorkspaceMutation, Types.DeleteAdminFromWorkspaceMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteAdminFromWorkspaceMutation, Types.DeleteAdminFromWorkspaceMutationVariables>(DeleteAdminFromWorkspaceDocument, baseOptions);
+      }
+export type DeleteAdminFromWorkspaceMutationHookResult = ReturnType<typeof useDeleteAdminFromWorkspaceMutation>;
+export type DeleteAdminFromWorkspaceMutationResult = Apollo.MutationResult<Types.DeleteAdminFromWorkspaceMutation>;
+export type DeleteAdminFromWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.DeleteAdminFromWorkspaceMutation, Types.DeleteAdminFromWorkspaceMutationVariables>;
 export const AddIntegrationToProjectDocument = gql`
-	mutation AddIntegrationToProject(
-		$integration_type: IntegrationType
-		$project_id: ID!
-		$code: String!
-	) {
-		addIntegrationToProject(
-			integration_type: $integration_type
-			project_id: $project_id
-			code: $code
-		)
-	}
-`
-export type AddIntegrationToProjectMutationFn = Apollo.MutationFunction<
-	Types.AddIntegrationToProjectMutation,
-	Types.AddIntegrationToProjectMutationVariables
->
+    mutation AddIntegrationToProject($integration_type: IntegrationType, $project_id: ID!, $code: String!) {
+  addIntegrationToProject(
+    integration_type: $integration_type
+    project_id: $project_id
+    code: $code
+  )
+}
+    `;
+export type AddIntegrationToProjectMutationFn = Apollo.MutationFunction<Types.AddIntegrationToProjectMutation, Types.AddIntegrationToProjectMutationVariables>;
 
 /**
  * __useAddIntegrationToProjectMutation__
@@ -937,41 +657,21 @@ export type AddIntegrationToProjectMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useAddIntegrationToProjectMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.AddIntegrationToProjectMutation,
-		Types.AddIntegrationToProjectMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.AddIntegrationToProjectMutation,
-		Types.AddIntegrationToProjectMutationVariables
-	>(AddIntegrationToProjectDocument, baseOptions)
-}
-export type AddIntegrationToProjectMutationHookResult = ReturnType<
-	typeof useAddIntegrationToProjectMutation
->
-export type AddIntegrationToProjectMutationResult =
-	Apollo.MutationResult<Types.AddIntegrationToProjectMutation>
-export type AddIntegrationToProjectMutationOptions = Apollo.BaseMutationOptions<
-	Types.AddIntegrationToProjectMutation,
-	Types.AddIntegrationToProjectMutationVariables
->
+export function useAddIntegrationToProjectMutation(baseOptions?: Apollo.MutationHookOptions<Types.AddIntegrationToProjectMutation, Types.AddIntegrationToProjectMutationVariables>) {
+        return Apollo.useMutation<Types.AddIntegrationToProjectMutation, Types.AddIntegrationToProjectMutationVariables>(AddIntegrationToProjectDocument, baseOptions);
+      }
+export type AddIntegrationToProjectMutationHookResult = ReturnType<typeof useAddIntegrationToProjectMutation>;
+export type AddIntegrationToProjectMutationResult = Apollo.MutationResult<Types.AddIntegrationToProjectMutation>;
+export type AddIntegrationToProjectMutationOptions = Apollo.BaseMutationOptions<Types.AddIntegrationToProjectMutation, Types.AddIntegrationToProjectMutationVariables>;
 export const RemoveIntegrationFromProjectDocument = gql`
-	mutation RemoveIntegrationFromProject(
-		$integration_type: IntegrationType
-		$project_id: ID!
-	) {
-		removeIntegrationFromProject(
-			integration_type: $integration_type
-			project_id: $project_id
-		)
-	}
-`
-export type RemoveIntegrationFromProjectMutationFn = Apollo.MutationFunction<
-	Types.RemoveIntegrationFromProjectMutation,
-	Types.RemoveIntegrationFromProjectMutationVariables
->
+    mutation RemoveIntegrationFromProject($integration_type: IntegrationType, $project_id: ID!) {
+  removeIntegrationFromProject(
+    integration_type: $integration_type
+    project_id: $project_id
+  )
+}
+    `;
+export type RemoveIntegrationFromProjectMutationFn = Apollo.MutationFunction<Types.RemoveIntegrationFromProjectMutation, Types.RemoveIntegrationFromProjectMutationVariables>;
 
 /**
  * __useRemoveIntegrationFromProjectMutation__
@@ -991,44 +691,22 @@ export type RemoveIntegrationFromProjectMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useRemoveIntegrationFromProjectMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.RemoveIntegrationFromProjectMutation,
-		Types.RemoveIntegrationFromProjectMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.RemoveIntegrationFromProjectMutation,
-		Types.RemoveIntegrationFromProjectMutationVariables
-	>(RemoveIntegrationFromProjectDocument, baseOptions)
-}
-export type RemoveIntegrationFromProjectMutationHookResult = ReturnType<
-	typeof useRemoveIntegrationFromProjectMutation
->
-export type RemoveIntegrationFromProjectMutationResult =
-	Apollo.MutationResult<Types.RemoveIntegrationFromProjectMutation>
-export type RemoveIntegrationFromProjectMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.RemoveIntegrationFromProjectMutation,
-		Types.RemoveIntegrationFromProjectMutationVariables
-	>
+export function useRemoveIntegrationFromProjectMutation(baseOptions?: Apollo.MutationHookOptions<Types.RemoveIntegrationFromProjectMutation, Types.RemoveIntegrationFromProjectMutationVariables>) {
+        return Apollo.useMutation<Types.RemoveIntegrationFromProjectMutation, Types.RemoveIntegrationFromProjectMutationVariables>(RemoveIntegrationFromProjectDocument, baseOptions);
+      }
+export type RemoveIntegrationFromProjectMutationHookResult = ReturnType<typeof useRemoveIntegrationFromProjectMutation>;
+export type RemoveIntegrationFromProjectMutationResult = Apollo.MutationResult<Types.RemoveIntegrationFromProjectMutation>;
+export type RemoveIntegrationFromProjectMutationOptions = Apollo.BaseMutationOptions<Types.RemoveIntegrationFromProjectMutation, Types.RemoveIntegrationFromProjectMutationVariables>;
 export const AddIntegrationToWorkspaceDocument = gql`
-	mutation AddIntegrationToWorkspace(
-		$integration_type: IntegrationType
-		$workspace_id: ID!
-		$code: String!
-	) {
-		addIntegrationToWorkspace(
-			integration_type: $integration_type
-			workspace_id: $workspace_id
-			code: $code
-		)
-	}
-`
-export type AddIntegrationToWorkspaceMutationFn = Apollo.MutationFunction<
-	Types.AddIntegrationToWorkspaceMutation,
-	Types.AddIntegrationToWorkspaceMutationVariables
->
+    mutation AddIntegrationToWorkspace($integration_type: IntegrationType, $workspace_id: ID!, $code: String!) {
+  addIntegrationToWorkspace(
+    integration_type: $integration_type
+    workspace_id: $workspace_id
+    code: $code
+  )
+}
+    `;
+export type AddIntegrationToWorkspaceMutationFn = Apollo.MutationFunction<Types.AddIntegrationToWorkspaceMutation, Types.AddIntegrationToWorkspaceMutationVariables>;
 
 /**
  * __useAddIntegrationToWorkspaceMutation__
@@ -1049,42 +727,21 @@ export type AddIntegrationToWorkspaceMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useAddIntegrationToWorkspaceMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.AddIntegrationToWorkspaceMutation,
-		Types.AddIntegrationToWorkspaceMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.AddIntegrationToWorkspaceMutation,
-		Types.AddIntegrationToWorkspaceMutationVariables
-	>(AddIntegrationToWorkspaceDocument, baseOptions)
-}
-export type AddIntegrationToWorkspaceMutationHookResult = ReturnType<
-	typeof useAddIntegrationToWorkspaceMutation
->
-export type AddIntegrationToWorkspaceMutationResult =
-	Apollo.MutationResult<Types.AddIntegrationToWorkspaceMutation>
-export type AddIntegrationToWorkspaceMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.AddIntegrationToWorkspaceMutation,
-		Types.AddIntegrationToWorkspaceMutationVariables
-	>
+export function useAddIntegrationToWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.AddIntegrationToWorkspaceMutation, Types.AddIntegrationToWorkspaceMutationVariables>) {
+        return Apollo.useMutation<Types.AddIntegrationToWorkspaceMutation, Types.AddIntegrationToWorkspaceMutationVariables>(AddIntegrationToWorkspaceDocument, baseOptions);
+      }
+export type AddIntegrationToWorkspaceMutationHookResult = ReturnType<typeof useAddIntegrationToWorkspaceMutation>;
+export type AddIntegrationToWorkspaceMutationResult = Apollo.MutationResult<Types.AddIntegrationToWorkspaceMutation>;
+export type AddIntegrationToWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.AddIntegrationToWorkspaceMutation, Types.AddIntegrationToWorkspaceMutationVariables>;
 export const RemoveIntegrationFromWorkspaceDocument = gql`
-	mutation RemoveIntegrationFromWorkspace(
-		$integration_type: IntegrationType!
-		$workspace_id: ID!
-	) {
-		removeIntegrationFromWorkspace(
-			integration_type: $integration_type
-			workspace_id: $workspace_id
-		)
-	}
-`
-export type RemoveIntegrationFromWorkspaceMutationFn = Apollo.MutationFunction<
-	Types.RemoveIntegrationFromWorkspaceMutation,
-	Types.RemoveIntegrationFromWorkspaceMutationVariables
->
+    mutation RemoveIntegrationFromWorkspace($integration_type: IntegrationType!, $workspace_id: ID!) {
+  removeIntegrationFromWorkspace(
+    integration_type: $integration_type
+    workspace_id: $workspace_id
+  )
+}
+    `;
+export type RemoveIntegrationFromWorkspaceMutationFn = Apollo.MutationFunction<Types.RemoveIntegrationFromWorkspaceMutation, Types.RemoveIntegrationFromWorkspaceMutationVariables>;
 
 /**
  * __useRemoveIntegrationFromWorkspaceMutation__
@@ -1104,42 +761,21 @@ export type RemoveIntegrationFromWorkspaceMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useRemoveIntegrationFromWorkspaceMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.RemoveIntegrationFromWorkspaceMutation,
-		Types.RemoveIntegrationFromWorkspaceMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.RemoveIntegrationFromWorkspaceMutation,
-		Types.RemoveIntegrationFromWorkspaceMutationVariables
-	>(RemoveIntegrationFromWorkspaceDocument, baseOptions)
-}
-export type RemoveIntegrationFromWorkspaceMutationHookResult = ReturnType<
-	typeof useRemoveIntegrationFromWorkspaceMutation
->
-export type RemoveIntegrationFromWorkspaceMutationResult =
-	Apollo.MutationResult<Types.RemoveIntegrationFromWorkspaceMutation>
-export type RemoveIntegrationFromWorkspaceMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.RemoveIntegrationFromWorkspaceMutation,
-		Types.RemoveIntegrationFromWorkspaceMutationVariables
-	>
+export function useRemoveIntegrationFromWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.RemoveIntegrationFromWorkspaceMutation, Types.RemoveIntegrationFromWorkspaceMutationVariables>) {
+        return Apollo.useMutation<Types.RemoveIntegrationFromWorkspaceMutation, Types.RemoveIntegrationFromWorkspaceMutationVariables>(RemoveIntegrationFromWorkspaceDocument, baseOptions);
+      }
+export type RemoveIntegrationFromWorkspaceMutationHookResult = ReturnType<typeof useRemoveIntegrationFromWorkspaceMutation>;
+export type RemoveIntegrationFromWorkspaceMutationResult = Apollo.MutationResult<Types.RemoveIntegrationFromWorkspaceMutation>;
+export type RemoveIntegrationFromWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.RemoveIntegrationFromWorkspaceMutation, Types.RemoveIntegrationFromWorkspaceMutationVariables>;
 export const UpdateAllowedEmailOriginsDocument = gql`
-	mutation UpdateAllowedEmailOrigins(
-		$workspace_id: ID!
-		$allowed_auto_join_email_origins: String!
-	) {
-		updateAllowedEmailOrigins(
-			workspace_id: $workspace_id
-			allowed_auto_join_email_origins: $allowed_auto_join_email_origins
-		)
-	}
-`
-export type UpdateAllowedEmailOriginsMutationFn = Apollo.MutationFunction<
-	Types.UpdateAllowedEmailOriginsMutation,
-	Types.UpdateAllowedEmailOriginsMutationVariables
->
+    mutation UpdateAllowedEmailOrigins($workspace_id: ID!, $allowed_auto_join_email_origins: String!) {
+  updateAllowedEmailOrigins(
+    workspace_id: $workspace_id
+    allowed_auto_join_email_origins: $allowed_auto_join_email_origins
+  )
+}
+    `;
+export type UpdateAllowedEmailOriginsMutationFn = Apollo.MutationFunction<Types.UpdateAllowedEmailOriginsMutation, Types.UpdateAllowedEmailOriginsMutationVariables>;
 
 /**
  * __useUpdateAllowedEmailOriginsMutation__
@@ -1159,39 +795,21 @@ export type UpdateAllowedEmailOriginsMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateAllowedEmailOriginsMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateAllowedEmailOriginsMutation,
-		Types.UpdateAllowedEmailOriginsMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateAllowedEmailOriginsMutation,
-		Types.UpdateAllowedEmailOriginsMutationVariables
-	>(UpdateAllowedEmailOriginsDocument, baseOptions)
-}
-export type UpdateAllowedEmailOriginsMutationHookResult = ReturnType<
-	typeof useUpdateAllowedEmailOriginsMutation
->
-export type UpdateAllowedEmailOriginsMutationResult =
-	Apollo.MutationResult<Types.UpdateAllowedEmailOriginsMutation>
-export type UpdateAllowedEmailOriginsMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.UpdateAllowedEmailOriginsMutation,
-		Types.UpdateAllowedEmailOriginsMutationVariables
-	>
+export function useUpdateAllowedEmailOriginsMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateAllowedEmailOriginsMutation, Types.UpdateAllowedEmailOriginsMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateAllowedEmailOriginsMutation, Types.UpdateAllowedEmailOriginsMutationVariables>(UpdateAllowedEmailOriginsDocument, baseOptions);
+      }
+export type UpdateAllowedEmailOriginsMutationHookResult = ReturnType<typeof useUpdateAllowedEmailOriginsMutation>;
+export type UpdateAllowedEmailOriginsMutationResult = Apollo.MutationResult<Types.UpdateAllowedEmailOriginsMutation>;
+export type UpdateAllowedEmailOriginsMutationOptions = Apollo.BaseMutationOptions<Types.UpdateAllowedEmailOriginsMutation, Types.UpdateAllowedEmailOriginsMutationVariables>;
 export const CreateProjectDocument = gql`
-	mutation CreateProject($name: String!, $workspace_id: ID!) {
-		createProject(name: $name, workspace_id: $workspace_id) {
-			id
-			name
-		}
-	}
-`
-export type CreateProjectMutationFn = Apollo.MutationFunction<
-	Types.CreateProjectMutation,
-	Types.CreateProjectMutationVariables
->
+    mutation CreateProject($name: String!, $workspace_id: ID!) {
+  createProject(name: $name, workspace_id: $workspace_id) {
+    id
+    name
+  }
+}
+    `;
+export type CreateProjectMutationFn = Apollo.MutationFunction<Types.CreateProjectMutation, Types.CreateProjectMutationVariables>;
 
 /**
  * __useCreateProjectMutation__
@@ -1211,49 +829,25 @@ export type CreateProjectMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateProjectMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateProjectMutation,
-		Types.CreateProjectMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateProjectMutation,
-		Types.CreateProjectMutationVariables
-	>(CreateProjectDocument, baseOptions)
-}
-export type CreateProjectMutationHookResult = ReturnType<
-	typeof useCreateProjectMutation
->
-export type CreateProjectMutationResult =
-	Apollo.MutationResult<Types.CreateProjectMutation>
-export type CreateProjectMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateProjectMutation,
-	Types.CreateProjectMutationVariables
->
+export function useCreateProjectMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateProjectMutation, Types.CreateProjectMutationVariables>) {
+        return Apollo.useMutation<Types.CreateProjectMutation, Types.CreateProjectMutationVariables>(CreateProjectDocument, baseOptions);
+      }
+export type CreateProjectMutationHookResult = ReturnType<typeof useCreateProjectMutation>;
+export type CreateProjectMutationResult = Apollo.MutationResult<Types.CreateProjectMutation>;
+export type CreateProjectMutationOptions = Apollo.BaseMutationOptions<Types.CreateProjectMutation, Types.CreateProjectMutationVariables>;
 export const SubmitRegistrationFormDocument = gql`
-	mutation SubmitRegistrationForm(
-		$workspace_id: ID!
-		$team_size: String!
-		$role: String!
-		$use_case: String!
-		$heard_about: String!
-		$pun: String
-	) {
-		submitRegistrationForm(
-			workspace_id: $workspace_id
-			team_size: $team_size
-			role: $role
-			use_case: $use_case
-			heard_about: $heard_about
-			pun: $pun
-		)
-	}
-`
-export type SubmitRegistrationFormMutationFn = Apollo.MutationFunction<
-	Types.SubmitRegistrationFormMutation,
-	Types.SubmitRegistrationFormMutationVariables
->
+    mutation SubmitRegistrationForm($workspace_id: ID!, $team_size: String!, $role: String!, $use_case: String!, $heard_about: String!, $pun: String) {
+  submitRegistrationForm(
+    workspace_id: $workspace_id
+    team_size: $team_size
+    role: $role
+    use_case: $use_case
+    heard_about: $heard_about
+    pun: $pun
+  )
+}
+    `;
+export type SubmitRegistrationFormMutationFn = Apollo.MutationFunction<Types.SubmitRegistrationFormMutation, Types.SubmitRegistrationFormMutationVariables>;
 
 /**
  * __useSubmitRegistrationFormMutation__
@@ -1277,41 +871,24 @@ export type SubmitRegistrationFormMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useSubmitRegistrationFormMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.SubmitRegistrationFormMutation,
-		Types.SubmitRegistrationFormMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.SubmitRegistrationFormMutation,
-		Types.SubmitRegistrationFormMutationVariables
-	>(SubmitRegistrationFormDocument, baseOptions)
-}
-export type SubmitRegistrationFormMutationHookResult = ReturnType<
-	typeof useSubmitRegistrationFormMutation
->
-export type SubmitRegistrationFormMutationResult =
-	Apollo.MutationResult<Types.SubmitRegistrationFormMutation>
-export type SubmitRegistrationFormMutationOptions = Apollo.BaseMutationOptions<
-	Types.SubmitRegistrationFormMutation,
-	Types.SubmitRegistrationFormMutationVariables
->
+export function useSubmitRegistrationFormMutation(baseOptions?: Apollo.MutationHookOptions<Types.SubmitRegistrationFormMutation, Types.SubmitRegistrationFormMutationVariables>) {
+        return Apollo.useMutation<Types.SubmitRegistrationFormMutation, Types.SubmitRegistrationFormMutationVariables>(SubmitRegistrationFormDocument, baseOptions);
+      }
+export type SubmitRegistrationFormMutationHookResult = ReturnType<typeof useSubmitRegistrationFormMutation>;
+export type SubmitRegistrationFormMutationResult = Apollo.MutationResult<Types.SubmitRegistrationFormMutation>;
+export type SubmitRegistrationFormMutationOptions = Apollo.BaseMutationOptions<Types.SubmitRegistrationFormMutation, Types.SubmitRegistrationFormMutationVariables>;
 export const CreateAdminDocument = gql`
-	mutation CreateAdmin {
-		createAdmin {
-			id
-			name
-			email
-			email_verified
-			about_you_details_filled
-		}
-	}
-`
-export type CreateAdminMutationFn = Apollo.MutationFunction<
-	Types.CreateAdminMutation,
-	Types.CreateAdminMutationVariables
->
+    mutation CreateAdmin {
+  createAdmin {
+    id
+    name
+    email
+    email_verified
+    about_you_details_filled
+  }
+}
+    `;
+export type CreateAdminMutationFn = Apollo.MutationFunction<Types.CreateAdminMutation, Types.CreateAdminMutationVariables>;
 
 /**
  * __useCreateAdminMutation__
@@ -1329,38 +906,21 @@ export type CreateAdminMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateAdminMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateAdminMutation,
-		Types.CreateAdminMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateAdminMutation,
-		Types.CreateAdminMutationVariables
-	>(CreateAdminDocument, baseOptions)
-}
-export type CreateAdminMutationHookResult = ReturnType<
-	typeof useCreateAdminMutation
->
-export type CreateAdminMutationResult =
-	Apollo.MutationResult<Types.CreateAdminMutation>
-export type CreateAdminMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateAdminMutation,
-	Types.CreateAdminMutationVariables
->
+export function useCreateAdminMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateAdminMutation, Types.CreateAdminMutationVariables>) {
+        return Apollo.useMutation<Types.CreateAdminMutation, Types.CreateAdminMutationVariables>(CreateAdminDocument, baseOptions);
+      }
+export type CreateAdminMutationHookResult = ReturnType<typeof useCreateAdminMutation>;
+export type CreateAdminMutationResult = Apollo.MutationResult<Types.CreateAdminMutation>;
+export type CreateAdminMutationOptions = Apollo.BaseMutationOptions<Types.CreateAdminMutation, Types.CreateAdminMutationVariables>;
 export const CreateWorkspaceDocument = gql`
-	mutation CreateWorkspace($name: String!, $promo_code: String) {
-		createWorkspace(name: $name, promo_code: $promo_code) {
-			id
-			name
-		}
-	}
-`
-export type CreateWorkspaceMutationFn = Apollo.MutationFunction<
-	Types.CreateWorkspaceMutation,
-	Types.CreateWorkspaceMutationVariables
->
+    mutation CreateWorkspace($name: String!, $promo_code: String) {
+  createWorkspace(name: $name, promo_code: $promo_code) {
+    id
+    name
+  }
+}
+    `;
+export type CreateWorkspaceMutationFn = Apollo.MutationFunction<Types.CreateWorkspaceMutation, Types.CreateWorkspaceMutationVariables>;
 
 /**
  * __useCreateWorkspaceMutation__
@@ -1380,71 +940,42 @@ export type CreateWorkspaceMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateWorkspaceMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateWorkspaceMutation,
-		Types.CreateWorkspaceMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateWorkspaceMutation,
-		Types.CreateWorkspaceMutationVariables
-	>(CreateWorkspaceDocument, baseOptions)
-}
-export type CreateWorkspaceMutationHookResult = ReturnType<
-	typeof useCreateWorkspaceMutation
->
-export type CreateWorkspaceMutationResult =
-	Apollo.MutationResult<Types.CreateWorkspaceMutation>
-export type CreateWorkspaceMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateWorkspaceMutation,
-	Types.CreateWorkspaceMutationVariables
->
+export function useCreateWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateWorkspaceMutation, Types.CreateWorkspaceMutationVariables>) {
+        return Apollo.useMutation<Types.CreateWorkspaceMutation, Types.CreateWorkspaceMutationVariables>(CreateWorkspaceDocument, baseOptions);
+      }
+export type CreateWorkspaceMutationHookResult = ReturnType<typeof useCreateWorkspaceMutation>;
+export type CreateWorkspaceMutationResult = Apollo.MutationResult<Types.CreateWorkspaceMutation>;
+export type CreateWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.CreateWorkspaceMutation, Types.CreateWorkspaceMutationVariables>;
 export const EditProjectDocument = gql`
-	mutation EditProject(
-		$id: ID!
-		$name: String
-		$billing_email: String
-		$excluded_users: StringArray
-		$error_filters: StringArray
-		$error_json_paths: StringArray
-		$filter_chrome_extension: Boolean
-		$rage_click_window_seconds: Int
-		$rage_click_radius_pixels: Int
-		$rage_click_count: Int
-		$backend_domains: StringArray
-	) {
-		editProject(
-			id: $id
-			name: $name
-			billing_email: $billing_email
-			excluded_users: $excluded_users
-			error_filters: $error_filters
-			error_json_paths: $error_json_paths
-			filter_chrome_extension: $filter_chrome_extension
-			rage_click_window_seconds: $rage_click_window_seconds
-			rage_click_radius_pixels: $rage_click_radius_pixels
-			rage_click_count: $rage_click_count
-			backend_domains: $backend_domains
-		) {
-			id
-			name
-			billing_email
-			excluded_users
-			error_filters
-			error_json_paths
-			filter_chrome_extension
-			rage_click_window_seconds
-			rage_click_radius_pixels
-			rage_click_count
-			backend_domains
-		}
-	}
-`
-export type EditProjectMutationFn = Apollo.MutationFunction<
-	Types.EditProjectMutation,
-	Types.EditProjectMutationVariables
->
+    mutation EditProject($id: ID!, $name: String, $billing_email: String, $excluded_users: StringArray, $error_filters: StringArray, $error_json_paths: StringArray, $filter_chrome_extension: Boolean, $rage_click_window_seconds: Int, $rage_click_radius_pixels: Int, $rage_click_count: Int, $backend_domains: StringArray) {
+  editProject(
+    id: $id
+    name: $name
+    billing_email: $billing_email
+    excluded_users: $excluded_users
+    error_filters: $error_filters
+    error_json_paths: $error_json_paths
+    filter_chrome_extension: $filter_chrome_extension
+    rage_click_window_seconds: $rage_click_window_seconds
+    rage_click_radius_pixels: $rage_click_radius_pixels
+    rage_click_count: $rage_click_count
+    backend_domains: $backend_domains
+  ) {
+    id
+    name
+    billing_email
+    excluded_users
+    error_filters
+    error_json_paths
+    filter_chrome_extension
+    rage_click_window_seconds
+    rage_click_radius_pixels
+    rage_click_count
+    backend_domains
+  }
+}
+    `;
+export type EditProjectMutationFn = Apollo.MutationFunction<Types.EditProjectMutation, Types.EditProjectMutationVariables>;
 
 /**
  * __useEditProjectMutation__
@@ -1473,77 +1004,46 @@ export type EditProjectMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useEditProjectMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.EditProjectMutation,
-		Types.EditProjectMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.EditProjectMutation,
-		Types.EditProjectMutationVariables
-	>(EditProjectDocument, baseOptions)
-}
-export type EditProjectMutationHookResult = ReturnType<
-	typeof useEditProjectMutation
->
-export type EditProjectMutationResult =
-	Apollo.MutationResult<Types.EditProjectMutation>
-export type EditProjectMutationOptions = Apollo.BaseMutationOptions<
-	Types.EditProjectMutation,
-	Types.EditProjectMutationVariables
->
+export function useEditProjectMutation(baseOptions?: Apollo.MutationHookOptions<Types.EditProjectMutation, Types.EditProjectMutationVariables>) {
+        return Apollo.useMutation<Types.EditProjectMutation, Types.EditProjectMutationVariables>(EditProjectDocument, baseOptions);
+      }
+export type EditProjectMutationHookResult = ReturnType<typeof useEditProjectMutation>;
+export type EditProjectMutationResult = Apollo.MutationResult<Types.EditProjectMutation>;
+export type EditProjectMutationOptions = Apollo.BaseMutationOptions<Types.EditProjectMutation, Types.EditProjectMutationVariables>;
 export const EditProjectSettingsDocument = gql`
-	mutation EditProjectSettings(
-		$projectId: ID!
-		$name: String
-		$billing_email: String
-		$excluded_users: StringArray
-		$error_filters: StringArray
-		$error_json_paths: StringArray
-		$filter_chrome_extension: Boolean
-		$rage_click_window_seconds: Int
-		$rage_click_radius_pixels: Int
-		$rage_click_count: Int
-		$backend_domains: StringArray
-		$filterSessionsWithoutError: Boolean
-		$autoResolveStaleErrorsDayInterval: Int
-	) {
-		editProjectSettings(
-			projectId: $projectId
-			name: $name
-			billing_email: $billing_email
-			excluded_users: $excluded_users
-			error_filters: $error_filters
-			error_json_paths: $error_json_paths
-			filter_chrome_extension: $filter_chrome_extension
-			rage_click_window_seconds: $rage_click_window_seconds
-			rage_click_radius_pixels: $rage_click_radius_pixels
-			rage_click_count: $rage_click_count
-			backend_domains: $backend_domains
-			filterSessionsWithoutError: $filterSessionsWithoutError
-			autoResolveStaleErrorsDayInterval: $autoResolveStaleErrorsDayInterval
-		) {
-			id
-			name
-			billing_email
-			excluded_users
-			error_filters
-			error_json_paths
-			filter_chrome_extension
-			rage_click_window_seconds
-			rage_click_radius_pixels
-			rage_click_count
-			backend_domains
-			filterSessionsWithoutError
-			autoResolveStaleErrorsDayInterval
-		}
-	}
-`
-export type EditProjectSettingsMutationFn = Apollo.MutationFunction<
-	Types.EditProjectSettingsMutation,
-	Types.EditProjectSettingsMutationVariables
->
+    mutation EditProjectSettings($projectId: ID!, $name: String, $billing_email: String, $excluded_users: StringArray, $error_filters: StringArray, $error_json_paths: StringArray, $filter_chrome_extension: Boolean, $rage_click_window_seconds: Int, $rage_click_radius_pixels: Int, $rage_click_count: Int, $backend_domains: StringArray, $filterSessionsWithoutError: Boolean, $autoResolveStaleErrorsDayInterval: Int) {
+  editProjectSettings(
+    projectId: $projectId
+    name: $name
+    billing_email: $billing_email
+    excluded_users: $excluded_users
+    error_filters: $error_filters
+    error_json_paths: $error_json_paths
+    filter_chrome_extension: $filter_chrome_extension
+    rage_click_window_seconds: $rage_click_window_seconds
+    rage_click_radius_pixels: $rage_click_radius_pixels
+    rage_click_count: $rage_click_count
+    backend_domains: $backend_domains
+    filterSessionsWithoutError: $filterSessionsWithoutError
+    autoResolveStaleErrorsDayInterval: $autoResolveStaleErrorsDayInterval
+  ) {
+    id
+    name
+    billing_email
+    excluded_users
+    error_filters
+    error_json_paths
+    filter_chrome_extension
+    rage_click_window_seconds
+    rage_click_radius_pixels
+    rage_click_count
+    backend_domains
+    filterSessionsWithoutError
+    autoResolveStaleErrorsDayInterval
+  }
+}
+    `;
+export type EditProjectSettingsMutationFn = Apollo.MutationFunction<Types.EditProjectSettingsMutation, Types.EditProjectSettingsMutationVariables>;
 
 /**
  * __useEditProjectSettingsMutation__
@@ -1574,35 +1074,18 @@ export type EditProjectSettingsMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useEditProjectSettingsMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.EditProjectSettingsMutation,
-		Types.EditProjectSettingsMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.EditProjectSettingsMutation,
-		Types.EditProjectSettingsMutationVariables
-	>(EditProjectSettingsDocument, baseOptions)
-}
-export type EditProjectSettingsMutationHookResult = ReturnType<
-	typeof useEditProjectSettingsMutation
->
-export type EditProjectSettingsMutationResult =
-	Apollo.MutationResult<Types.EditProjectSettingsMutation>
-export type EditProjectSettingsMutationOptions = Apollo.BaseMutationOptions<
-	Types.EditProjectSettingsMutation,
-	Types.EditProjectSettingsMutationVariables
->
+export function useEditProjectSettingsMutation(baseOptions?: Apollo.MutationHookOptions<Types.EditProjectSettingsMutation, Types.EditProjectSettingsMutationVariables>) {
+        return Apollo.useMutation<Types.EditProjectSettingsMutation, Types.EditProjectSettingsMutationVariables>(EditProjectSettingsDocument, baseOptions);
+      }
+export type EditProjectSettingsMutationHookResult = ReturnType<typeof useEditProjectSettingsMutation>;
+export type EditProjectSettingsMutationResult = Apollo.MutationResult<Types.EditProjectSettingsMutation>;
+export type EditProjectSettingsMutationOptions = Apollo.BaseMutationOptions<Types.EditProjectSettingsMutation, Types.EditProjectSettingsMutationVariables>;
 export const DeleteProjectDocument = gql`
-	mutation DeleteProject($id: ID!) {
-		deleteProject(id: $id)
-	}
-`
-export type DeleteProjectMutationFn = Apollo.MutationFunction<
-	Types.DeleteProjectMutation,
-	Types.DeleteProjectMutationVariables
->
+    mutation DeleteProject($id: ID!) {
+  deleteProject(id: $id)
+}
+    `;
+export type DeleteProjectMutationFn = Apollo.MutationFunction<Types.DeleteProjectMutation, Types.DeleteProjectMutationVariables>;
 
 /**
  * __useDeleteProjectMutation__
@@ -1621,38 +1104,21 @@ export type DeleteProjectMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteProjectMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteProjectMutation,
-		Types.DeleteProjectMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteProjectMutation,
-		Types.DeleteProjectMutationVariables
-	>(DeleteProjectDocument, baseOptions)
-}
-export type DeleteProjectMutationHookResult = ReturnType<
-	typeof useDeleteProjectMutation
->
-export type DeleteProjectMutationResult =
-	Apollo.MutationResult<Types.DeleteProjectMutation>
-export type DeleteProjectMutationOptions = Apollo.BaseMutationOptions<
-	Types.DeleteProjectMutation,
-	Types.DeleteProjectMutationVariables
->
+export function useDeleteProjectMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteProjectMutation, Types.DeleteProjectMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteProjectMutation, Types.DeleteProjectMutationVariables>(DeleteProjectDocument, baseOptions);
+      }
+export type DeleteProjectMutationHookResult = ReturnType<typeof useDeleteProjectMutation>;
+export type DeleteProjectMutationResult = Apollo.MutationResult<Types.DeleteProjectMutation>;
+export type DeleteProjectMutationOptions = Apollo.BaseMutationOptions<Types.DeleteProjectMutation, Types.DeleteProjectMutationVariables>;
 export const EditWorkspaceDocument = gql`
-	mutation EditWorkspace($id: ID!, $name: String) {
-		editWorkspace(id: $id, name: $name) {
-			id
-			name
-		}
-	}
-`
-export type EditWorkspaceMutationFn = Apollo.MutationFunction<
-	Types.EditWorkspaceMutation,
-	Types.EditWorkspaceMutationVariables
->
+    mutation EditWorkspace($id: ID!, $name: String) {
+  editWorkspace(id: $id, name: $name) {
+    id
+    name
+  }
+}
+    `;
+export type EditWorkspaceMutationFn = Apollo.MutationFunction<Types.EditWorkspaceMutation, Types.EditWorkspaceMutationVariables>;
 
 /**
  * __useEditWorkspaceMutation__
@@ -1672,41 +1138,21 @@ export type EditWorkspaceMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useEditWorkspaceMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.EditWorkspaceMutation,
-		Types.EditWorkspaceMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.EditWorkspaceMutation,
-		Types.EditWorkspaceMutationVariables
-	>(EditWorkspaceDocument, baseOptions)
-}
-export type EditWorkspaceMutationHookResult = ReturnType<
-	typeof useEditWorkspaceMutation
->
-export type EditWorkspaceMutationResult =
-	Apollo.MutationResult<Types.EditWorkspaceMutation>
-export type EditWorkspaceMutationOptions = Apollo.BaseMutationOptions<
-	Types.EditWorkspaceMutation,
-	Types.EditWorkspaceMutationVariables
->
+export function useEditWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.EditWorkspaceMutation, Types.EditWorkspaceMutationVariables>) {
+        return Apollo.useMutation<Types.EditWorkspaceMutation, Types.EditWorkspaceMutationVariables>(EditWorkspaceDocument, baseOptions);
+      }
+export type EditWorkspaceMutationHookResult = ReturnType<typeof useEditWorkspaceMutation>;
+export type EditWorkspaceMutationResult = Apollo.MutationResult<Types.EditWorkspaceMutation>;
+export type EditWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.EditWorkspaceMutation, Types.EditWorkspaceMutationVariables>;
 export const EditWorkspaceSettingsDocument = gql`
-	mutation EditWorkspaceSettings($workspace_id: ID!, $ai_insights: Boolean) {
-		editWorkspaceSettings(
-			workspace_id: $workspace_id
-			ai_insights: $ai_insights
-		) {
-			workspace_id
-			ai_insights
-		}
-	}
-`
-export type EditWorkspaceSettingsMutationFn = Apollo.MutationFunction<
-	Types.EditWorkspaceSettingsMutation,
-	Types.EditWorkspaceSettingsMutationVariables
->
+    mutation EditWorkspaceSettings($workspace_id: ID!, $ai_insights: Boolean) {
+  editWorkspaceSettings(workspace_id: $workspace_id, ai_insights: $ai_insights) {
+    workspace_id
+    ai_insights
+  }
+}
+    `;
+export type EditWorkspaceSettingsMutationFn = Apollo.MutationFunction<Types.EditWorkspaceSettingsMutation, Types.EditWorkspaceSettingsMutationVariables>;
 
 /**
  * __useEditWorkspaceSettingsMutation__
@@ -1726,35 +1172,18 @@ export type EditWorkspaceSettingsMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useEditWorkspaceSettingsMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.EditWorkspaceSettingsMutation,
-		Types.EditWorkspaceSettingsMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.EditWorkspaceSettingsMutation,
-		Types.EditWorkspaceSettingsMutationVariables
-	>(EditWorkspaceSettingsDocument, baseOptions)
-}
-export type EditWorkspaceSettingsMutationHookResult = ReturnType<
-	typeof useEditWorkspaceSettingsMutation
->
-export type EditWorkspaceSettingsMutationResult =
-	Apollo.MutationResult<Types.EditWorkspaceSettingsMutation>
-export type EditWorkspaceSettingsMutationOptions = Apollo.BaseMutationOptions<
-	Types.EditWorkspaceSettingsMutation,
-	Types.EditWorkspaceSettingsMutationVariables
->
+export function useEditWorkspaceSettingsMutation(baseOptions?: Apollo.MutationHookOptions<Types.EditWorkspaceSettingsMutation, Types.EditWorkspaceSettingsMutationVariables>) {
+        return Apollo.useMutation<Types.EditWorkspaceSettingsMutation, Types.EditWorkspaceSettingsMutationVariables>(EditWorkspaceSettingsDocument, baseOptions);
+      }
+export type EditWorkspaceSettingsMutationHookResult = ReturnType<typeof useEditWorkspaceSettingsMutation>;
+export type EditWorkspaceSettingsMutationResult = Apollo.MutationResult<Types.EditWorkspaceSettingsMutation>;
+export type EditWorkspaceSettingsMutationOptions = Apollo.BaseMutationOptions<Types.EditWorkspaceSettingsMutation, Types.EditWorkspaceSettingsMutationVariables>;
 export const DeleteSegmentDocument = gql`
-	mutation DeleteSegment($segment_id: ID!) {
-		deleteSegment(segment_id: $segment_id)
-	}
-`
-export type DeleteSegmentMutationFn = Apollo.MutationFunction<
-	Types.DeleteSegmentMutation,
-	Types.DeleteSegmentMutationVariables
->
+    mutation DeleteSegment($segment_id: ID!) {
+  deleteSegment(segment_id: $segment_id)
+}
+    `;
+export type DeleteSegmentMutationFn = Apollo.MutationFunction<Types.DeleteSegmentMutation, Types.DeleteSegmentMutationVariables>;
 
 /**
  * __useDeleteSegmentMutation__
@@ -1773,45 +1202,18 @@ export type DeleteSegmentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteSegmentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteSegmentMutation,
-		Types.DeleteSegmentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteSegmentMutation,
-		Types.DeleteSegmentMutationVariables
-	>(DeleteSegmentDocument, baseOptions)
-}
-export type DeleteSegmentMutationHookResult = ReturnType<
-	typeof useDeleteSegmentMutation
->
-export type DeleteSegmentMutationResult =
-	Apollo.MutationResult<Types.DeleteSegmentMutation>
-export type DeleteSegmentMutationOptions = Apollo.BaseMutationOptions<
-	Types.DeleteSegmentMutation,
-	Types.DeleteSegmentMutationVariables
->
+export function useDeleteSegmentMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteSegmentMutation, Types.DeleteSegmentMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteSegmentMutation, Types.DeleteSegmentMutationVariables>(DeleteSegmentDocument, baseOptions);
+      }
+export type DeleteSegmentMutationHookResult = ReturnType<typeof useDeleteSegmentMutation>;
+export type DeleteSegmentMutationResult = Apollo.MutationResult<Types.DeleteSegmentMutation>;
+export type DeleteSegmentMutationOptions = Apollo.BaseMutationOptions<Types.DeleteSegmentMutation, Types.DeleteSegmentMutationVariables>;
 export const EditSegmentDocument = gql`
-	mutation EditSegment(
-		$project_id: ID!
-		$id: ID!
-		$params: SearchParamsInput!
-		$name: String!
-	) {
-		editSegment(
-			project_id: $project_id
-			id: $id
-			params: $params
-			name: $name
-		)
-	}
-`
-export type EditSegmentMutationFn = Apollo.MutationFunction<
-	Types.EditSegmentMutation,
-	Types.EditSegmentMutationVariables
->
+    mutation EditSegment($project_id: ID!, $id: ID!, $params: SearchParamsInput!, $name: String!) {
+  editSegment(project_id: $project_id, id: $id, params: $params, name: $name)
+}
+    `;
+export type EditSegmentMutationFn = Apollo.MutationFunction<Types.EditSegmentMutation, Types.EditSegmentMutationVariables>;
 
 /**
  * __useEditSegmentMutation__
@@ -1833,66 +1235,45 @@ export type EditSegmentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useEditSegmentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.EditSegmentMutation,
-		Types.EditSegmentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.EditSegmentMutation,
-		Types.EditSegmentMutationVariables
-	>(EditSegmentDocument, baseOptions)
-}
-export type EditSegmentMutationHookResult = ReturnType<
-	typeof useEditSegmentMutation
->
-export type EditSegmentMutationResult =
-	Apollo.MutationResult<Types.EditSegmentMutation>
-export type EditSegmentMutationOptions = Apollo.BaseMutationOptions<
-	Types.EditSegmentMutation,
-	Types.EditSegmentMutationVariables
->
+export function useEditSegmentMutation(baseOptions?: Apollo.MutationHookOptions<Types.EditSegmentMutation, Types.EditSegmentMutationVariables>) {
+        return Apollo.useMutation<Types.EditSegmentMutation, Types.EditSegmentMutationVariables>(EditSegmentDocument, baseOptions);
+      }
+export type EditSegmentMutationHookResult = ReturnType<typeof useEditSegmentMutation>;
+export type EditSegmentMutationResult = Apollo.MutationResult<Types.EditSegmentMutation>;
+export type EditSegmentMutationOptions = Apollo.BaseMutationOptions<Types.EditSegmentMutation, Types.EditSegmentMutationVariables>;
 export const CreateSegmentDocument = gql`
-	mutation CreateSegment(
-		$project_id: ID!
-		$name: String!
-		$params: SearchParamsInput!
-	) {
-		createSegment(project_id: $project_id, name: $name, params: $params) {
-			name
-			id
-			params {
-				user_properties {
-					name
-					value
-				}
-				excluded_properties {
-					name
-					value
-				}
-				date_range {
-					start_date
-					end_date
-				}
-				os
-				browser
-				visited_url
-				referrer
-				identified
-				hide_viewed
-				app_versions
-				environments
-				device_id
-				show_live_sessions
-			}
-		}
-	}
-`
-export type CreateSegmentMutationFn = Apollo.MutationFunction<
-	Types.CreateSegmentMutation,
-	Types.CreateSegmentMutationVariables
->
+    mutation CreateSegment($project_id: ID!, $name: String!, $params: SearchParamsInput!) {
+  createSegment(project_id: $project_id, name: $name, params: $params) {
+    name
+    id
+    params {
+      user_properties {
+        name
+        value
+      }
+      excluded_properties {
+        name
+        value
+      }
+      date_range {
+        start_date
+        end_date
+      }
+      os
+      browser
+      visited_url
+      referrer
+      identified
+      hide_viewed
+      app_versions
+      environments
+      device_id
+      show_live_sessions
+    }
+  }
+}
+    `;
+export type CreateSegmentMutationFn = Apollo.MutationFunction<Types.CreateSegmentMutation, Types.CreateSegmentMutationVariables>;
 
 /**
  * __useCreateSegmentMutation__
@@ -1913,94 +1294,57 @@ export type CreateSegmentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateSegmentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateSegmentMutation,
-		Types.CreateSegmentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateSegmentMutation,
-		Types.CreateSegmentMutationVariables
-	>(CreateSegmentDocument, baseOptions)
-}
-export type CreateSegmentMutationHookResult = ReturnType<
-	typeof useCreateSegmentMutation
->
-export type CreateSegmentMutationResult =
-	Apollo.MutationResult<Types.CreateSegmentMutation>
-export type CreateSegmentMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateSegmentMutation,
-	Types.CreateSegmentMutationVariables
->
+export function useCreateSegmentMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateSegmentMutation, Types.CreateSegmentMutationVariables>) {
+        return Apollo.useMutation<Types.CreateSegmentMutation, Types.CreateSegmentMutationVariables>(CreateSegmentDocument, baseOptions);
+      }
+export type CreateSegmentMutationHookResult = ReturnType<typeof useCreateSegmentMutation>;
+export type CreateSegmentMutationResult = Apollo.MutationResult<Types.CreateSegmentMutation>;
+export type CreateSegmentMutationOptions = Apollo.BaseMutationOptions<Types.CreateSegmentMutation, Types.CreateSegmentMutationVariables>;
 export const CreateSessionCommentDocument = gql`
-	mutation CreateSessionComment(
-		$project_id: ID!
-		$session_secure_id: String!
-		$session_timestamp: Int!
-		$text: String!
-		$text_for_email: String!
-		$x_coordinate: Float!
-		$y_coordinate: Float!
-		$tagged_admins: [SanitizedAdminInput]!
-		$tagged_slack_users: [SanitizedSlackChannelInput]!
-		$session_url: String!
-		$time: Float!
-		$author_name: String!
-		$session_image: String
-		$tags: [SessionCommentTagInput]!
-		$integrations: [IntegrationType]!
-		$issue_title: String
-		$issue_team_id: String
-		$issue_description: String
-		$additional_context: String
-	) {
-		createSessionComment(
-			project_id: $project_id
-			session_secure_id: $session_secure_id
-			session_timestamp: $session_timestamp
-			text: $text
-			text_for_email: $text_for_email
-			x_coordinate: $x_coordinate
-			y_coordinate: $y_coordinate
-			tagged_admins: $tagged_admins
-			tagged_slack_users: $tagged_slack_users
-			session_url: $session_url
-			time: $time
-			author_name: $author_name
-			session_image: $session_image
-			tags: $tags
-			integrations: $integrations
-			issue_title: $issue_title
-			issue_team_id: $issue_team_id
-			issue_description: $issue_description
-			additional_context: $additional_context
-		) {
-			id
-			timestamp
-			created_at
-			updated_at
-			author {
-				id
-				name
-				email
-			}
-			text
-			x_coordinate
-			y_coordinate
-			attachments {
-				id
-				integration_type
-				external_id
-				title
-			}
-		}
-	}
-`
-export type CreateSessionCommentMutationFn = Apollo.MutationFunction<
-	Types.CreateSessionCommentMutation,
-	Types.CreateSessionCommentMutationVariables
->
+    mutation CreateSessionComment($project_id: ID!, $session_secure_id: String!, $session_timestamp: Int!, $text: String!, $text_for_email: String!, $x_coordinate: Float!, $y_coordinate: Float!, $tagged_admins: [SanitizedAdminInput]!, $tagged_slack_users: [SanitizedSlackChannelInput]!, $session_url: String!, $time: Float!, $author_name: String!, $session_image: String, $tags: [SessionCommentTagInput]!, $integrations: [IntegrationType]!, $issue_title: String, $issue_team_id: String, $issue_description: String, $additional_context: String) {
+  createSessionComment(
+    project_id: $project_id
+    session_secure_id: $session_secure_id
+    session_timestamp: $session_timestamp
+    text: $text
+    text_for_email: $text_for_email
+    x_coordinate: $x_coordinate
+    y_coordinate: $y_coordinate
+    tagged_admins: $tagged_admins
+    tagged_slack_users: $tagged_slack_users
+    session_url: $session_url
+    time: $time
+    author_name: $author_name
+    session_image: $session_image
+    tags: $tags
+    integrations: $integrations
+    issue_title: $issue_title
+    issue_team_id: $issue_team_id
+    issue_description: $issue_description
+    additional_context: $additional_context
+  ) {
+    id
+    timestamp
+    created_at
+    updated_at
+    author {
+      id
+      name
+      email
+    }
+    text
+    x_coordinate
+    y_coordinate
+    attachments {
+      id
+      integration_type
+      external_id
+      title
+    }
+  }
+}
+    `;
+export type CreateSessionCommentMutationFn = Apollo.MutationFunction<Types.CreateSessionCommentMutation, Types.CreateSessionCommentMutationVariables>;
 
 /**
  * __useCreateSessionCommentMutation__
@@ -2037,76 +1381,48 @@ export type CreateSessionCommentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateSessionCommentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateSessionCommentMutation,
-		Types.CreateSessionCommentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateSessionCommentMutation,
-		Types.CreateSessionCommentMutationVariables
-	>(CreateSessionCommentDocument, baseOptions)
-}
-export type CreateSessionCommentMutationHookResult = ReturnType<
-	typeof useCreateSessionCommentMutation
->
-export type CreateSessionCommentMutationResult =
-	Apollo.MutationResult<Types.CreateSessionCommentMutation>
-export type CreateSessionCommentMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateSessionCommentMutation,
-	Types.CreateSessionCommentMutationVariables
->
+export function useCreateSessionCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateSessionCommentMutation, Types.CreateSessionCommentMutationVariables>) {
+        return Apollo.useMutation<Types.CreateSessionCommentMutation, Types.CreateSessionCommentMutationVariables>(CreateSessionCommentDocument, baseOptions);
+      }
+export type CreateSessionCommentMutationHookResult = ReturnType<typeof useCreateSessionCommentMutation>;
+export type CreateSessionCommentMutationResult = Apollo.MutationResult<Types.CreateSessionCommentMutation>;
+export type CreateSessionCommentMutationOptions = Apollo.BaseMutationOptions<Types.CreateSessionCommentMutation, Types.CreateSessionCommentMutationVariables>;
 export const CreateIssueForSessionCommentDocument = gql`
-	mutation CreateIssueForSessionComment(
-		$project_id: ID!
-		$session_comment_id: Int!
-		$text_for_attachment: String!
-		$session_url: String!
-		$time: Float!
-		$author_name: String!
-		$integrations: [IntegrationType]!
-		$issue_title: String
-		$issue_team_id: String
-		$issue_description: String
-	) {
-		createIssueForSessionComment(
-			project_id: $project_id
-			session_url: $session_url
-			session_comment_id: $session_comment_id
-			author_name: $author_name
-			text_for_attachment: $text_for_attachment
-			time: $time
-			issue_title: $issue_title
-			issue_description: $issue_description
-			issue_team_id: $issue_team_id
-			integrations: $integrations
-		) {
-			id
-			timestamp
-			created_at
-			updated_at
-			author {
-				id
-				name
-				email
-			}
-			text
-			x_coordinate
-			y_coordinate
-			attachments {
-				id
-				integration_type
-				external_id
-				title
-			}
-		}
-	}
-`
-export type CreateIssueForSessionCommentMutationFn = Apollo.MutationFunction<
-	Types.CreateIssueForSessionCommentMutation,
-	Types.CreateIssueForSessionCommentMutationVariables
->
+    mutation CreateIssueForSessionComment($project_id: ID!, $session_comment_id: Int!, $text_for_attachment: String!, $session_url: String!, $time: Float!, $author_name: String!, $integrations: [IntegrationType]!, $issue_title: String, $issue_team_id: String, $issue_description: String) {
+  createIssueForSessionComment(
+    project_id: $project_id
+    session_url: $session_url
+    session_comment_id: $session_comment_id
+    author_name: $author_name
+    text_for_attachment: $text_for_attachment
+    time: $time
+    issue_title: $issue_title
+    issue_description: $issue_description
+    issue_team_id: $issue_team_id
+    integrations: $integrations
+  ) {
+    id
+    timestamp
+    created_at
+    updated_at
+    author {
+      id
+      name
+      email
+    }
+    text
+    x_coordinate
+    y_coordinate
+    attachments {
+      id
+      integration_type
+      external_id
+      title
+    }
+  }
+}
+    `;
+export type CreateIssueForSessionCommentMutationFn = Apollo.MutationFunction<Types.CreateIssueForSessionCommentMutation, Types.CreateIssueForSessionCommentMutationVariables>;
 
 /**
  * __useCreateIssueForSessionCommentMutation__
@@ -2134,36 +1450,18 @@ export type CreateIssueForSessionCommentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateIssueForSessionCommentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateIssueForSessionCommentMutation,
-		Types.CreateIssueForSessionCommentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateIssueForSessionCommentMutation,
-		Types.CreateIssueForSessionCommentMutationVariables
-	>(CreateIssueForSessionCommentDocument, baseOptions)
-}
-export type CreateIssueForSessionCommentMutationHookResult = ReturnType<
-	typeof useCreateIssueForSessionCommentMutation
->
-export type CreateIssueForSessionCommentMutationResult =
-	Apollo.MutationResult<Types.CreateIssueForSessionCommentMutation>
-export type CreateIssueForSessionCommentMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.CreateIssueForSessionCommentMutation,
-		Types.CreateIssueForSessionCommentMutationVariables
-	>
+export function useCreateIssueForSessionCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateIssueForSessionCommentMutation, Types.CreateIssueForSessionCommentMutationVariables>) {
+        return Apollo.useMutation<Types.CreateIssueForSessionCommentMutation, Types.CreateIssueForSessionCommentMutationVariables>(CreateIssueForSessionCommentDocument, baseOptions);
+      }
+export type CreateIssueForSessionCommentMutationHookResult = ReturnType<typeof useCreateIssueForSessionCommentMutation>;
+export type CreateIssueForSessionCommentMutationResult = Apollo.MutationResult<Types.CreateIssueForSessionCommentMutation>;
+export type CreateIssueForSessionCommentMutationOptions = Apollo.BaseMutationOptions<Types.CreateIssueForSessionCommentMutation, Types.CreateIssueForSessionCommentMutationVariables>;
 export const DeleteSessionCommentDocument = gql`
-	mutation DeleteSessionComment($id: ID!) {
-		deleteSessionComment(id: $id)
-	}
-`
-export type DeleteSessionCommentMutationFn = Apollo.MutationFunction<
-	Types.DeleteSessionCommentMutation,
-	Types.DeleteSessionCommentMutationVariables
->
+    mutation DeleteSessionComment($id: ID!) {
+  deleteSessionComment(id: $id)
+}
+    `;
+export type DeleteSessionCommentMutationFn = Apollo.MutationFunction<Types.DeleteSessionCommentMutation, Types.DeleteSessionCommentMutationVariables>;
 
 /**
  * __useDeleteSessionCommentMutation__
@@ -2182,60 +1480,36 @@ export type DeleteSessionCommentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteSessionCommentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteSessionCommentMutation,
-		Types.DeleteSessionCommentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteSessionCommentMutation,
-		Types.DeleteSessionCommentMutationVariables
-	>(DeleteSessionCommentDocument, baseOptions)
-}
-export type DeleteSessionCommentMutationHookResult = ReturnType<
-	typeof useDeleteSessionCommentMutation
->
-export type DeleteSessionCommentMutationResult =
-	Apollo.MutationResult<Types.DeleteSessionCommentMutation>
-export type DeleteSessionCommentMutationOptions = Apollo.BaseMutationOptions<
-	Types.DeleteSessionCommentMutation,
-	Types.DeleteSessionCommentMutationVariables
->
+export function useDeleteSessionCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteSessionCommentMutation, Types.DeleteSessionCommentMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteSessionCommentMutation, Types.DeleteSessionCommentMutationVariables>(DeleteSessionCommentDocument, baseOptions);
+      }
+export type DeleteSessionCommentMutationHookResult = ReturnType<typeof useDeleteSessionCommentMutation>;
+export type DeleteSessionCommentMutationResult = Apollo.MutationResult<Types.DeleteSessionCommentMutation>;
+export type DeleteSessionCommentMutationOptions = Apollo.BaseMutationOptions<Types.DeleteSessionCommentMutation, Types.DeleteSessionCommentMutationVariables>;
 export const ReplyToSessionCommentDocument = gql`
-	mutation ReplyToSessionComment(
-		$comment_id: ID!
-		$text: String!
-		$text_for_email: String!
-		$sessionURL: String!
-		$tagged_admins: [SanitizedAdminInput]!
-		$tagged_slack_users: [SanitizedSlackChannelInput]!
-	) {
-		replyToSessionComment(
-			comment_id: $comment_id
-			text: $text
-			text_for_email: $text_for_email
-			sessionURL: $sessionURL
-			tagged_admins: $tagged_admins
-			tagged_slack_users: $tagged_slack_users
-		) {
-			id
-			created_at
-			updated_at
-			author {
-				id
-				name
-				email
-				photo_url
-			}
-			text
-		}
-	}
-`
-export type ReplyToSessionCommentMutationFn = Apollo.MutationFunction<
-	Types.ReplyToSessionCommentMutation,
-	Types.ReplyToSessionCommentMutationVariables
->
+    mutation ReplyToSessionComment($comment_id: ID!, $text: String!, $text_for_email: String!, $sessionURL: String!, $tagged_admins: [SanitizedAdminInput]!, $tagged_slack_users: [SanitizedSlackChannelInput]!) {
+  replyToSessionComment(
+    comment_id: $comment_id
+    text: $text
+    text_for_email: $text_for_email
+    sessionURL: $sessionURL
+    tagged_admins: $tagged_admins
+    tagged_slack_users: $tagged_slack_users
+  ) {
+    id
+    created_at
+    updated_at
+    author {
+      id
+      name
+      email
+      photo_url
+    }
+    text
+  }
+}
+    `;
+export type ReplyToSessionCommentMutationFn = Apollo.MutationFunction<Types.ReplyToSessionCommentMutation, Types.ReplyToSessionCommentMutationVariables>;
 
 /**
  * __useReplyToSessionCommentMutation__
@@ -2259,71 +1533,41 @@ export type ReplyToSessionCommentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useReplyToSessionCommentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.ReplyToSessionCommentMutation,
-		Types.ReplyToSessionCommentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.ReplyToSessionCommentMutation,
-		Types.ReplyToSessionCommentMutationVariables
-	>(ReplyToSessionCommentDocument, baseOptions)
-}
-export type ReplyToSessionCommentMutationHookResult = ReturnType<
-	typeof useReplyToSessionCommentMutation
->
-export type ReplyToSessionCommentMutationResult =
-	Apollo.MutationResult<Types.ReplyToSessionCommentMutation>
-export type ReplyToSessionCommentMutationOptions = Apollo.BaseMutationOptions<
-	Types.ReplyToSessionCommentMutation,
-	Types.ReplyToSessionCommentMutationVariables
->
+export function useReplyToSessionCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.ReplyToSessionCommentMutation, Types.ReplyToSessionCommentMutationVariables>) {
+        return Apollo.useMutation<Types.ReplyToSessionCommentMutation, Types.ReplyToSessionCommentMutationVariables>(ReplyToSessionCommentDocument, baseOptions);
+      }
+export type ReplyToSessionCommentMutationHookResult = ReturnType<typeof useReplyToSessionCommentMutation>;
+export type ReplyToSessionCommentMutationResult = Apollo.MutationResult<Types.ReplyToSessionCommentMutation>;
+export type ReplyToSessionCommentMutationOptions = Apollo.BaseMutationOptions<Types.ReplyToSessionCommentMutation, Types.ReplyToSessionCommentMutationVariables>;
 export const CreateErrorCommentDocument = gql`
-	mutation CreateErrorComment(
-		$project_id: ID!
-		$error_group_secure_id: String!
-		$text: String!
-		$text_for_email: String!
-		$tagged_admins: [SanitizedAdminInput]!
-		$tagged_slack_users: [SanitizedSlackChannelInput]!
-		$error_url: String!
-		$author_name: String!
-		$integrations: [IntegrationType]!
-		$issue_title: String
-		$issue_team_id: String
-		$issue_description: String
-	) {
-		createErrorComment(
-			project_id: $project_id
-			error_group_secure_id: $error_group_secure_id
-			text: $text
-			text_for_email: $text_for_email
-			tagged_admins: $tagged_admins
-			tagged_slack_users: $tagged_slack_users
-			error_url: $error_url
-			author_name: $author_name
-			integrations: $integrations
-			issue_title: $issue_title
-			issue_team_id: $issue_team_id
-			issue_description: $issue_description
-		) {
-			id
-			created_at
-			updated_at
-			author {
-				id
-				name
-				email
-			}
-			text
-		}
-	}
-`
-export type CreateErrorCommentMutationFn = Apollo.MutationFunction<
-	Types.CreateErrorCommentMutation,
-	Types.CreateErrorCommentMutationVariables
->
+    mutation CreateErrorComment($project_id: ID!, $error_group_secure_id: String!, $text: String!, $text_for_email: String!, $tagged_admins: [SanitizedAdminInput]!, $tagged_slack_users: [SanitizedSlackChannelInput]!, $error_url: String!, $author_name: String!, $integrations: [IntegrationType]!, $issue_title: String, $issue_team_id: String, $issue_description: String) {
+  createErrorComment(
+    project_id: $project_id
+    error_group_secure_id: $error_group_secure_id
+    text: $text
+    text_for_email: $text_for_email
+    tagged_admins: $tagged_admins
+    tagged_slack_users: $tagged_slack_users
+    error_url: $error_url
+    author_name: $author_name
+    integrations: $integrations
+    issue_title: $issue_title
+    issue_team_id: $issue_team_id
+    issue_description: $issue_description
+  ) {
+    id
+    created_at
+    updated_at
+    author {
+      id
+      name
+      email
+    }
+    text
+  }
+}
+    `;
+export type CreateErrorCommentMutationFn = Apollo.MutationFunction<Types.CreateErrorCommentMutation, Types.CreateErrorCommentMutationVariables>;
 
 /**
  * __useCreateErrorCommentMutation__
@@ -2353,71 +1597,44 @@ export type CreateErrorCommentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateErrorCommentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateErrorCommentMutation,
-		Types.CreateErrorCommentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateErrorCommentMutation,
-		Types.CreateErrorCommentMutationVariables
-	>(CreateErrorCommentDocument, baseOptions)
-}
-export type CreateErrorCommentMutationHookResult = ReturnType<
-	typeof useCreateErrorCommentMutation
->
-export type CreateErrorCommentMutationResult =
-	Apollo.MutationResult<Types.CreateErrorCommentMutation>
-export type CreateErrorCommentMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateErrorCommentMutation,
-	Types.CreateErrorCommentMutationVariables
->
+export function useCreateErrorCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateErrorCommentMutation, Types.CreateErrorCommentMutationVariables>) {
+        return Apollo.useMutation<Types.CreateErrorCommentMutation, Types.CreateErrorCommentMutationVariables>(CreateErrorCommentDocument, baseOptions);
+      }
+export type CreateErrorCommentMutationHookResult = ReturnType<typeof useCreateErrorCommentMutation>;
+export type CreateErrorCommentMutationResult = Apollo.MutationResult<Types.CreateErrorCommentMutation>;
+export type CreateErrorCommentMutationOptions = Apollo.BaseMutationOptions<Types.CreateErrorCommentMutation, Types.CreateErrorCommentMutationVariables>;
 export const CreateIssueForErrorCommentDocument = gql`
-	mutation CreateIssueForErrorComment(
-		$project_id: ID!
-		$error_comment_id: Int!
-		$text_for_attachment: String!
-		$error_url: String!
-		$author_name: String!
-		$integrations: [IntegrationType]!
-		$issue_title: String
-		$issue_team_id: String
-		$issue_description: String
-	) {
-		createIssueForErrorComment(
-			project_id: $project_id
-			error_url: $error_url
-			error_comment_id: $error_comment_id
-			author_name: $author_name
-			text_for_attachment: $text_for_attachment
-			issue_title: $issue_title
-			issue_team_id: $issue_team_id
-			issue_description: $issue_description
-			integrations: $integrations
-		) {
-			id
-			created_at
-			updated_at
-			author {
-				id
-				name
-				email
-			}
-			text
-			attachments {
-				id
-				integration_type
-				external_id
-				title
-			}
-		}
-	}
-`
-export type CreateIssueForErrorCommentMutationFn = Apollo.MutationFunction<
-	Types.CreateIssueForErrorCommentMutation,
-	Types.CreateIssueForErrorCommentMutationVariables
->
+    mutation CreateIssueForErrorComment($project_id: ID!, $error_comment_id: Int!, $text_for_attachment: String!, $error_url: String!, $author_name: String!, $integrations: [IntegrationType]!, $issue_title: String, $issue_team_id: String, $issue_description: String) {
+  createIssueForErrorComment(
+    project_id: $project_id
+    error_url: $error_url
+    error_comment_id: $error_comment_id
+    author_name: $author_name
+    text_for_attachment: $text_for_attachment
+    issue_title: $issue_title
+    issue_team_id: $issue_team_id
+    issue_description: $issue_description
+    integrations: $integrations
+  ) {
+    id
+    created_at
+    updated_at
+    author {
+      id
+      name
+      email
+    }
+    text
+    attachments {
+      id
+      integration_type
+      external_id
+      title
+    }
+  }
+}
+    `;
+export type CreateIssueForErrorCommentMutationFn = Apollo.MutationFunction<Types.CreateIssueForErrorCommentMutation, Types.CreateIssueForErrorCommentMutationVariables>;
 
 /**
  * __useCreateIssueForErrorCommentMutation__
@@ -2444,36 +1661,18 @@ export type CreateIssueForErrorCommentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateIssueForErrorCommentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateIssueForErrorCommentMutation,
-		Types.CreateIssueForErrorCommentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateIssueForErrorCommentMutation,
-		Types.CreateIssueForErrorCommentMutationVariables
-	>(CreateIssueForErrorCommentDocument, baseOptions)
-}
-export type CreateIssueForErrorCommentMutationHookResult = ReturnType<
-	typeof useCreateIssueForErrorCommentMutation
->
-export type CreateIssueForErrorCommentMutationResult =
-	Apollo.MutationResult<Types.CreateIssueForErrorCommentMutation>
-export type CreateIssueForErrorCommentMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.CreateIssueForErrorCommentMutation,
-		Types.CreateIssueForErrorCommentMutationVariables
-	>
+export function useCreateIssueForErrorCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateIssueForErrorCommentMutation, Types.CreateIssueForErrorCommentMutationVariables>) {
+        return Apollo.useMutation<Types.CreateIssueForErrorCommentMutation, Types.CreateIssueForErrorCommentMutationVariables>(CreateIssueForErrorCommentDocument, baseOptions);
+      }
+export type CreateIssueForErrorCommentMutationHookResult = ReturnType<typeof useCreateIssueForErrorCommentMutation>;
+export type CreateIssueForErrorCommentMutationResult = Apollo.MutationResult<Types.CreateIssueForErrorCommentMutation>;
+export type CreateIssueForErrorCommentMutationOptions = Apollo.BaseMutationOptions<Types.CreateIssueForErrorCommentMutation, Types.CreateIssueForErrorCommentMutationVariables>;
 export const DeleteErrorCommentDocument = gql`
-	mutation DeleteErrorComment($id: ID!) {
-		deleteErrorComment(id: $id)
-	}
-`
-export type DeleteErrorCommentMutationFn = Apollo.MutationFunction<
-	Types.DeleteErrorCommentMutation,
-	Types.DeleteErrorCommentMutationVariables
->
+    mutation DeleteErrorComment($id: ID!) {
+  deleteErrorComment(id: $id)
+}
+    `;
+export type DeleteErrorCommentMutationFn = Apollo.MutationFunction<Types.DeleteErrorCommentMutation, Types.DeleteErrorCommentMutationVariables>;
 
 /**
  * __useDeleteErrorCommentMutation__
@@ -2492,35 +1691,18 @@ export type DeleteErrorCommentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteErrorCommentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteErrorCommentMutation,
-		Types.DeleteErrorCommentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteErrorCommentMutation,
-		Types.DeleteErrorCommentMutationVariables
-	>(DeleteErrorCommentDocument, baseOptions)
-}
-export type DeleteErrorCommentMutationHookResult = ReturnType<
-	typeof useDeleteErrorCommentMutation
->
-export type DeleteErrorCommentMutationResult =
-	Apollo.MutationResult<Types.DeleteErrorCommentMutation>
-export type DeleteErrorCommentMutationOptions = Apollo.BaseMutationOptions<
-	Types.DeleteErrorCommentMutation,
-	Types.DeleteErrorCommentMutationVariables
->
+export function useDeleteErrorCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteErrorCommentMutation, Types.DeleteErrorCommentMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteErrorCommentMutation, Types.DeleteErrorCommentMutationVariables>(DeleteErrorCommentDocument, baseOptions);
+      }
+export type DeleteErrorCommentMutationHookResult = ReturnType<typeof useDeleteErrorCommentMutation>;
+export type DeleteErrorCommentMutationResult = Apollo.MutationResult<Types.DeleteErrorCommentMutation>;
+export type DeleteErrorCommentMutationOptions = Apollo.BaseMutationOptions<Types.DeleteErrorCommentMutation, Types.DeleteErrorCommentMutationVariables>;
 export const MuteErrorCommentThreadDocument = gql`
-	mutation MuteErrorCommentThread($id: ID!, $has_muted: Boolean) {
-		muteErrorCommentThread(id: $id, has_muted: $has_muted)
-	}
-`
-export type MuteErrorCommentThreadMutationFn = Apollo.MutationFunction<
-	Types.MuteErrorCommentThreadMutation,
-	Types.MuteErrorCommentThreadMutationVariables
->
+    mutation MuteErrorCommentThread($id: ID!, $has_muted: Boolean) {
+  muteErrorCommentThread(id: $id, has_muted: $has_muted)
+}
+    `;
+export type MuteErrorCommentThreadMutationFn = Apollo.MutationFunction<Types.MuteErrorCommentThreadMutation, Types.MuteErrorCommentThreadMutationVariables>;
 
 /**
  * __useMuteErrorCommentThreadMutation__
@@ -2540,35 +1722,18 @@ export type MuteErrorCommentThreadMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useMuteErrorCommentThreadMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.MuteErrorCommentThreadMutation,
-		Types.MuteErrorCommentThreadMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.MuteErrorCommentThreadMutation,
-		Types.MuteErrorCommentThreadMutationVariables
-	>(MuteErrorCommentThreadDocument, baseOptions)
-}
-export type MuteErrorCommentThreadMutationHookResult = ReturnType<
-	typeof useMuteErrorCommentThreadMutation
->
-export type MuteErrorCommentThreadMutationResult =
-	Apollo.MutationResult<Types.MuteErrorCommentThreadMutation>
-export type MuteErrorCommentThreadMutationOptions = Apollo.BaseMutationOptions<
-	Types.MuteErrorCommentThreadMutation,
-	Types.MuteErrorCommentThreadMutationVariables
->
+export function useMuteErrorCommentThreadMutation(baseOptions?: Apollo.MutationHookOptions<Types.MuteErrorCommentThreadMutation, Types.MuteErrorCommentThreadMutationVariables>) {
+        return Apollo.useMutation<Types.MuteErrorCommentThreadMutation, Types.MuteErrorCommentThreadMutationVariables>(MuteErrorCommentThreadDocument, baseOptions);
+      }
+export type MuteErrorCommentThreadMutationHookResult = ReturnType<typeof useMuteErrorCommentThreadMutation>;
+export type MuteErrorCommentThreadMutationResult = Apollo.MutationResult<Types.MuteErrorCommentThreadMutation>;
+export type MuteErrorCommentThreadMutationOptions = Apollo.BaseMutationOptions<Types.MuteErrorCommentThreadMutation, Types.MuteErrorCommentThreadMutationVariables>;
 export const RemoveErrorIssueDocument = gql`
-	mutation RemoveErrorIssue($error_issue_id: ID!) {
-		removeErrorIssue(error_issue_id: $error_issue_id)
-	}
-`
-export type RemoveErrorIssueMutationFn = Apollo.MutationFunction<
-	Types.RemoveErrorIssueMutation,
-	Types.RemoveErrorIssueMutationVariables
->
+    mutation RemoveErrorIssue($error_issue_id: ID!) {
+  removeErrorIssue(error_issue_id: $error_issue_id)
+}
+    `;
+export type RemoveErrorIssueMutationFn = Apollo.MutationFunction<Types.RemoveErrorIssueMutation, Types.RemoveErrorIssueMutationVariables>;
 
 /**
  * __useRemoveErrorIssueMutation__
@@ -2587,60 +1752,36 @@ export type RemoveErrorIssueMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useRemoveErrorIssueMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.RemoveErrorIssueMutation,
-		Types.RemoveErrorIssueMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.RemoveErrorIssueMutation,
-		Types.RemoveErrorIssueMutationVariables
-	>(RemoveErrorIssueDocument, baseOptions)
-}
-export type RemoveErrorIssueMutationHookResult = ReturnType<
-	typeof useRemoveErrorIssueMutation
->
-export type RemoveErrorIssueMutationResult =
-	Apollo.MutationResult<Types.RemoveErrorIssueMutation>
-export type RemoveErrorIssueMutationOptions = Apollo.BaseMutationOptions<
-	Types.RemoveErrorIssueMutation,
-	Types.RemoveErrorIssueMutationVariables
->
+export function useRemoveErrorIssueMutation(baseOptions?: Apollo.MutationHookOptions<Types.RemoveErrorIssueMutation, Types.RemoveErrorIssueMutationVariables>) {
+        return Apollo.useMutation<Types.RemoveErrorIssueMutation, Types.RemoveErrorIssueMutationVariables>(RemoveErrorIssueDocument, baseOptions);
+      }
+export type RemoveErrorIssueMutationHookResult = ReturnType<typeof useRemoveErrorIssueMutation>;
+export type RemoveErrorIssueMutationResult = Apollo.MutationResult<Types.RemoveErrorIssueMutation>;
+export type RemoveErrorIssueMutationOptions = Apollo.BaseMutationOptions<Types.RemoveErrorIssueMutation, Types.RemoveErrorIssueMutationVariables>;
 export const ReplyToErrorCommentDocument = gql`
-	mutation ReplyToErrorComment(
-		$comment_id: ID!
-		$text: String!
-		$text_for_email: String!
-		$errorURL: String!
-		$tagged_admins: [SanitizedAdminInput]!
-		$tagged_slack_users: [SanitizedSlackChannelInput]!
-	) {
-		replyToErrorComment(
-			comment_id: $comment_id
-			text: $text
-			text_for_email: $text_for_email
-			errorURL: $errorURL
-			tagged_admins: $tagged_admins
-			tagged_slack_users: $tagged_slack_users
-		) {
-			id
-			created_at
-			updated_at
-			author {
-				id
-				name
-				email
-				photo_url
-			}
-			text
-		}
-	}
-`
-export type ReplyToErrorCommentMutationFn = Apollo.MutationFunction<
-	Types.ReplyToErrorCommentMutation,
-	Types.ReplyToErrorCommentMutationVariables
->
+    mutation ReplyToErrorComment($comment_id: ID!, $text: String!, $text_for_email: String!, $errorURL: String!, $tagged_admins: [SanitizedAdminInput]!, $tagged_slack_users: [SanitizedSlackChannelInput]!) {
+  replyToErrorComment(
+    comment_id: $comment_id
+    text: $text
+    text_for_email: $text_for_email
+    errorURL: $errorURL
+    tagged_admins: $tagged_admins
+    tagged_slack_users: $tagged_slack_users
+  ) {
+    id
+    created_at
+    updated_at
+    author {
+      id
+      name
+      email
+      photo_url
+    }
+    text
+  }
+}
+    `;
+export type ReplyToErrorCommentMutationFn = Apollo.MutationFunction<Types.ReplyToErrorCommentMutation, Types.ReplyToErrorCommentMutationVariables>;
 
 /**
  * __useReplyToErrorCommentMutation__
@@ -2664,35 +1805,18 @@ export type ReplyToErrorCommentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useReplyToErrorCommentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.ReplyToErrorCommentMutation,
-		Types.ReplyToErrorCommentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.ReplyToErrorCommentMutation,
-		Types.ReplyToErrorCommentMutationVariables
-	>(ReplyToErrorCommentDocument, baseOptions)
-}
-export type ReplyToErrorCommentMutationHookResult = ReturnType<
-	typeof useReplyToErrorCommentMutation
->
-export type ReplyToErrorCommentMutationResult =
-	Apollo.MutationResult<Types.ReplyToErrorCommentMutation>
-export type ReplyToErrorCommentMutationOptions = Apollo.BaseMutationOptions<
-	Types.ReplyToErrorCommentMutation,
-	Types.ReplyToErrorCommentMutationVariables
->
+export function useReplyToErrorCommentMutation(baseOptions?: Apollo.MutationHookOptions<Types.ReplyToErrorCommentMutation, Types.ReplyToErrorCommentMutationVariables>) {
+        return Apollo.useMutation<Types.ReplyToErrorCommentMutation, Types.ReplyToErrorCommentMutationVariables>(ReplyToErrorCommentDocument, baseOptions);
+      }
+export type ReplyToErrorCommentMutationHookResult = ReturnType<typeof useReplyToErrorCommentMutation>;
+export type ReplyToErrorCommentMutationResult = Apollo.MutationResult<Types.ReplyToErrorCommentMutation>;
+export type ReplyToErrorCommentMutationOptions = Apollo.BaseMutationOptions<Types.ReplyToErrorCommentMutation, Types.ReplyToErrorCommentMutationVariables>;
 export const DeleteErrorSegmentDocument = gql`
-	mutation DeleteErrorSegment($segment_id: ID!) {
-		deleteErrorSegment(segment_id: $segment_id)
-	}
-`
-export type DeleteErrorSegmentMutationFn = Apollo.MutationFunction<
-	Types.DeleteErrorSegmentMutation,
-	Types.DeleteErrorSegmentMutationVariables
->
+    mutation DeleteErrorSegment($segment_id: ID!) {
+  deleteErrorSegment(segment_id: $segment_id)
+}
+    `;
+export type DeleteErrorSegmentMutationFn = Apollo.MutationFunction<Types.DeleteErrorSegmentMutation, Types.DeleteErrorSegmentMutationVariables>;
 
 /**
  * __useDeleteErrorSegmentMutation__
@@ -2711,45 +1835,18 @@ export type DeleteErrorSegmentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteErrorSegmentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteErrorSegmentMutation,
-		Types.DeleteErrorSegmentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteErrorSegmentMutation,
-		Types.DeleteErrorSegmentMutationVariables
-	>(DeleteErrorSegmentDocument, baseOptions)
-}
-export type DeleteErrorSegmentMutationHookResult = ReturnType<
-	typeof useDeleteErrorSegmentMutation
->
-export type DeleteErrorSegmentMutationResult =
-	Apollo.MutationResult<Types.DeleteErrorSegmentMutation>
-export type DeleteErrorSegmentMutationOptions = Apollo.BaseMutationOptions<
-	Types.DeleteErrorSegmentMutation,
-	Types.DeleteErrorSegmentMutationVariables
->
+export function useDeleteErrorSegmentMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteErrorSegmentMutation, Types.DeleteErrorSegmentMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteErrorSegmentMutation, Types.DeleteErrorSegmentMutationVariables>(DeleteErrorSegmentDocument, baseOptions);
+      }
+export type DeleteErrorSegmentMutationHookResult = ReturnType<typeof useDeleteErrorSegmentMutation>;
+export type DeleteErrorSegmentMutationResult = Apollo.MutationResult<Types.DeleteErrorSegmentMutation>;
+export type DeleteErrorSegmentMutationOptions = Apollo.BaseMutationOptions<Types.DeleteErrorSegmentMutation, Types.DeleteErrorSegmentMutationVariables>;
 export const EditErrorSegmentDocument = gql`
-	mutation EditErrorSegment(
-		$project_id: ID!
-		$id: ID!
-		$params: ErrorSearchParamsInput!
-		$name: String!
-	) {
-		editErrorSegment(
-			project_id: $project_id
-			id: $id
-			params: $params
-			name: $name
-		)
-	}
-`
-export type EditErrorSegmentMutationFn = Apollo.MutationFunction<
-	Types.EditErrorSegmentMutation,
-	Types.EditErrorSegmentMutationVariables
->
+    mutation EditErrorSegment($project_id: ID!, $id: ID!, $params: ErrorSearchParamsInput!, $name: String!) {
+  editErrorSegment(project_id: $project_id, id: $id, params: $params, name: $name)
+}
+    `;
+export type EditErrorSegmentMutationFn = Apollo.MutationFunction<Types.EditErrorSegmentMutation, Types.EditErrorSegmentMutationVariables>;
 
 /**
  * __useEditErrorSegmentMutation__
@@ -2771,56 +1868,31 @@ export type EditErrorSegmentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useEditErrorSegmentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.EditErrorSegmentMutation,
-		Types.EditErrorSegmentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.EditErrorSegmentMutation,
-		Types.EditErrorSegmentMutationVariables
-	>(EditErrorSegmentDocument, baseOptions)
-}
-export type EditErrorSegmentMutationHookResult = ReturnType<
-	typeof useEditErrorSegmentMutation
->
-export type EditErrorSegmentMutationResult =
-	Apollo.MutationResult<Types.EditErrorSegmentMutation>
-export type EditErrorSegmentMutationOptions = Apollo.BaseMutationOptions<
-	Types.EditErrorSegmentMutation,
-	Types.EditErrorSegmentMutationVariables
->
+export function useEditErrorSegmentMutation(baseOptions?: Apollo.MutationHookOptions<Types.EditErrorSegmentMutation, Types.EditErrorSegmentMutationVariables>) {
+        return Apollo.useMutation<Types.EditErrorSegmentMutation, Types.EditErrorSegmentMutationVariables>(EditErrorSegmentDocument, baseOptions);
+      }
+export type EditErrorSegmentMutationHookResult = ReturnType<typeof useEditErrorSegmentMutation>;
+export type EditErrorSegmentMutationResult = Apollo.MutationResult<Types.EditErrorSegmentMutation>;
+export type EditErrorSegmentMutationOptions = Apollo.BaseMutationOptions<Types.EditErrorSegmentMutation, Types.EditErrorSegmentMutationVariables>;
 export const CreateErrorSegmentDocument = gql`
-	mutation CreateErrorSegment(
-		$project_id: ID!
-		$name: String!
-		$params: ErrorSearchParamsInput!
-	) {
-		createErrorSegment(
-			project_id: $project_id
-			name: $name
-			params: $params
-		) {
-			name
-			id
-			params {
-				date_range {
-					start_date
-					end_date
-				}
-				os
-				browser
-				visited_url
-				state
-			}
-		}
-	}
-`
-export type CreateErrorSegmentMutationFn = Apollo.MutationFunction<
-	Types.CreateErrorSegmentMutation,
-	Types.CreateErrorSegmentMutationVariables
->
+    mutation CreateErrorSegment($project_id: ID!, $name: String!, $params: ErrorSearchParamsInput!) {
+  createErrorSegment(project_id: $project_id, name: $name, params: $params) {
+    name
+    id
+    params {
+      date_range {
+        start_date
+        end_date
+      }
+      os
+      browser
+      visited_url
+      state
+    }
+  }
+}
+    `;
+export type CreateErrorSegmentMutationFn = Apollo.MutationFunction<Types.CreateErrorSegmentMutation, Types.CreateErrorSegmentMutationVariables>;
 
 /**
  * __useCreateErrorSegmentMutation__
@@ -2841,74 +1913,45 @@ export type CreateErrorSegmentMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateErrorSegmentMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateErrorSegmentMutation,
-		Types.CreateErrorSegmentMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateErrorSegmentMutation,
-		Types.CreateErrorSegmentMutationVariables
-	>(CreateErrorSegmentDocument, baseOptions)
-}
-export type CreateErrorSegmentMutationHookResult = ReturnType<
-	typeof useCreateErrorSegmentMutation
->
-export type CreateErrorSegmentMutationResult =
-	Apollo.MutationResult<Types.CreateErrorSegmentMutation>
-export type CreateErrorSegmentMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateErrorSegmentMutation,
-	Types.CreateErrorSegmentMutationVariables
->
+export function useCreateErrorSegmentMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateErrorSegmentMutation, Types.CreateErrorSegmentMutationVariables>) {
+        return Apollo.useMutation<Types.CreateErrorSegmentMutation, Types.CreateErrorSegmentMutationVariables>(CreateErrorSegmentDocument, baseOptions);
+      }
+export type CreateErrorSegmentMutationHookResult = ReturnType<typeof useCreateErrorSegmentMutation>;
+export type CreateErrorSegmentMutationResult = Apollo.MutationResult<Types.CreateErrorSegmentMutation>;
+export type CreateErrorSegmentMutationOptions = Apollo.BaseMutationOptions<Types.CreateErrorSegmentMutation, Types.CreateErrorSegmentMutationVariables>;
 export const CreateErrorAlertDocument = gql`
-	mutation CreateErrorAlert(
-		$project_id: ID!
-		$name: String!
-		$count_threshold: Int!
-		$threshold_window: Int!
-		$slack_channels: [SanitizedSlackChannelInput]!
-		$discord_channels: [DiscordChannelInput!]!
-		$webhook_destinations: [WebhookDestinationInput!]!
-		$emails: [String]!
-		$environments: [String]!
-		$regex_groups: [String]!
-		$frequency: Int!
-	) {
-		createErrorAlert(
-			project_id: $project_id
-			count_threshold: $count_threshold
-			name: $name
-			slack_channels: $slack_channels
-			discord_channels: $discord_channels
-			webhook_destinations: $webhook_destinations
-			emails: $emails
-			environments: $environments
-			threshold_window: $threshold_window
-			regex_groups: $regex_groups
-			frequency: $frequency
-		) {
-			id
-			ChannelsToNotify {
-				webhook_channel
-				webhook_channel_id
-			}
-			EmailsToNotify
-			Name
-			ExcludedEnvironments
-			CountThreshold
-			ThresholdWindow
-			LastAdminToEditID
-			RegexGroups
-			Frequency
-			disabled
-		}
-	}
-`
-export type CreateErrorAlertMutationFn = Apollo.MutationFunction<
-	Types.CreateErrorAlertMutation,
-	Types.CreateErrorAlertMutationVariables
->
+    mutation CreateErrorAlert($project_id: ID!, $name: String!, $count_threshold: Int!, $threshold_window: Int!, $slack_channels: [SanitizedSlackChannelInput]!, $discord_channels: [DiscordChannelInput!]!, $webhook_destinations: [WebhookDestinationInput!]!, $emails: [String]!, $environments: [String]!, $regex_groups: [String]!, $frequency: Int!) {
+  createErrorAlert(
+    project_id: $project_id
+    count_threshold: $count_threshold
+    name: $name
+    slack_channels: $slack_channels
+    discord_channels: $discord_channels
+    webhook_destinations: $webhook_destinations
+    emails: $emails
+    environments: $environments
+    threshold_window: $threshold_window
+    regex_groups: $regex_groups
+    frequency: $frequency
+  ) {
+    id
+    ChannelsToNotify {
+      webhook_channel
+      webhook_channel_id
+    }
+    EmailsToNotify
+    Name
+    ExcludedEnvironments
+    CountThreshold
+    ThresholdWindow
+    LastAdminToEditID
+    RegexGroups
+    Frequency
+    disabled
+  }
+}
+    `;
+export type CreateErrorAlertMutationFn = Apollo.MutationFunction<Types.CreateErrorAlertMutation, Types.CreateErrorAlertMutationVariables>;
 
 /**
  * __useCreateErrorAlertMutation__
@@ -2937,76 +1980,46 @@ export type CreateErrorAlertMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateErrorAlertMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateErrorAlertMutation,
-		Types.CreateErrorAlertMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateErrorAlertMutation,
-		Types.CreateErrorAlertMutationVariables
-	>(CreateErrorAlertDocument, baseOptions)
-}
-export type CreateErrorAlertMutationHookResult = ReturnType<
-	typeof useCreateErrorAlertMutation
->
-export type CreateErrorAlertMutationResult =
-	Apollo.MutationResult<Types.CreateErrorAlertMutation>
-export type CreateErrorAlertMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateErrorAlertMutation,
-	Types.CreateErrorAlertMutationVariables
->
+export function useCreateErrorAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateErrorAlertMutation, Types.CreateErrorAlertMutationVariables>) {
+        return Apollo.useMutation<Types.CreateErrorAlertMutation, Types.CreateErrorAlertMutationVariables>(CreateErrorAlertDocument, baseOptions);
+      }
+export type CreateErrorAlertMutationHookResult = ReturnType<typeof useCreateErrorAlertMutation>;
+export type CreateErrorAlertMutationResult = Apollo.MutationResult<Types.CreateErrorAlertMutation>;
+export type CreateErrorAlertMutationOptions = Apollo.BaseMutationOptions<Types.CreateErrorAlertMutation, Types.CreateErrorAlertMutationVariables>;
 export const CreateMetricMonitorDocument = gql`
-	mutation CreateMetricMonitor(
-		$project_id: ID!
-		$name: String!
-		$aggregator: MetricAggregator!
-		$threshold: Float!
-		$filters: [MetricTagFilterInput!]
-		$units: String
-		$periodMinutes: Int
-		$metric_to_monitor: String!
-		$slack_channels: [SanitizedSlackChannelInput]!
-		$discord_channels: [DiscordChannelInput!]!
-		$webhook_destinations: [WebhookDestinationInput!]!
-		$emails: [String]!
-	) {
-		createMetricMonitor(
-			project_id: $project_id
-			threshold: $threshold
-			filters: $filters
-			units: $units
-			name: $name
-			aggregator: $aggregator
-			periodMinutes: $periodMinutes
-			metric_to_monitor: $metric_to_monitor
-			slack_channels: $slack_channels
-			discord_channels: $discord_channels
-			webhook_destinations: $webhook_destinations
-			emails: $emails
-		) {
-			id
-			updated_at
-			name
-			channels_to_notify {
-				webhook_channel
-				webhook_channel_id
-			}
-			emails_to_notify
-			aggregator
-			period_minutes
-			metric_to_monitor
-			last_admin_to_edit_id
-			threshold
-			units
-		}
-	}
-`
-export type CreateMetricMonitorMutationFn = Apollo.MutationFunction<
-	Types.CreateMetricMonitorMutation,
-	Types.CreateMetricMonitorMutationVariables
->
+    mutation CreateMetricMonitor($project_id: ID!, $name: String!, $aggregator: MetricAggregator!, $threshold: Float!, $filters: [MetricTagFilterInput!], $units: String, $periodMinutes: Int, $metric_to_monitor: String!, $slack_channels: [SanitizedSlackChannelInput]!, $discord_channels: [DiscordChannelInput!]!, $webhook_destinations: [WebhookDestinationInput!]!, $emails: [String]!) {
+  createMetricMonitor(
+    project_id: $project_id
+    threshold: $threshold
+    filters: $filters
+    units: $units
+    name: $name
+    aggregator: $aggregator
+    periodMinutes: $periodMinutes
+    metric_to_monitor: $metric_to_monitor
+    slack_channels: $slack_channels
+    discord_channels: $discord_channels
+    webhook_destinations: $webhook_destinations
+    emails: $emails
+  ) {
+    id
+    updated_at
+    name
+    channels_to_notify {
+      webhook_channel
+      webhook_channel_id
+    }
+    emails_to_notify
+    aggregator
+    period_minutes
+    metric_to_monitor
+    last_admin_to_edit_id
+    threshold
+    units
+  }
+}
+    `;
+export type CreateMetricMonitorMutationFn = Apollo.MutationFunction<Types.CreateMetricMonitorMutation, Types.CreateMetricMonitorMutationVariables>;
 
 /**
  * __useCreateMetricMonitorMutation__
@@ -3036,80 +2049,48 @@ export type CreateMetricMonitorMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateMetricMonitorMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateMetricMonitorMutation,
-		Types.CreateMetricMonitorMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateMetricMonitorMutation,
-		Types.CreateMetricMonitorMutationVariables
-	>(CreateMetricMonitorDocument, baseOptions)
-}
-export type CreateMetricMonitorMutationHookResult = ReturnType<
-	typeof useCreateMetricMonitorMutation
->
-export type CreateMetricMonitorMutationResult =
-	Apollo.MutationResult<Types.CreateMetricMonitorMutation>
-export type CreateMetricMonitorMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateMetricMonitorMutation,
-	Types.CreateMetricMonitorMutationVariables
->
+export function useCreateMetricMonitorMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateMetricMonitorMutation, Types.CreateMetricMonitorMutationVariables>) {
+        return Apollo.useMutation<Types.CreateMetricMonitorMutation, Types.CreateMetricMonitorMutationVariables>(CreateMetricMonitorDocument, baseOptions);
+      }
+export type CreateMetricMonitorMutationHookResult = ReturnType<typeof useCreateMetricMonitorMutation>;
+export type CreateMetricMonitorMutationResult = Apollo.MutationResult<Types.CreateMetricMonitorMutation>;
+export type CreateMetricMonitorMutationOptions = Apollo.BaseMutationOptions<Types.CreateMetricMonitorMutation, Types.CreateMetricMonitorMutationVariables>;
 export const UpdateMetricMonitorDocument = gql`
-	mutation UpdateMetricMonitor(
-		$metric_monitor_id: ID!
-		$project_id: ID!
-		$name: String
-		$aggregator: MetricAggregator
-		$threshold: Float
-		$filters: [MetricTagFilterInput!]
-		$units: String
-		$periodMinutes: Int
-		$metric_to_monitor: String
-		$slack_channels: [SanitizedSlackChannelInput]
-		$discord_channels: [DiscordChannelInput!]!
-		$webhook_destinations: [WebhookDestinationInput!]!
-		$emails: [String]
-		$disabled: Boolean
-	) {
-		updateMetricMonitor(
-			metric_monitor_id: $metric_monitor_id
-			project_id: $project_id
-			threshold: $threshold
-			filters: $filters
-			units: $units
-			name: $name
-			aggregator: $aggregator
-			periodMinutes: $periodMinutes
-			metric_to_monitor: $metric_to_monitor
-			slack_channels: $slack_channels
-			discord_channels: $discord_channels
-			webhook_destinations: $webhook_destinations
-			emails: $emails
-			disabled: $disabled
-		) {
-			id
-			updated_at
-			name
-			channels_to_notify {
-				webhook_channel
-				webhook_channel_id
-			}
-			emails_to_notify
-			aggregator
-			period_minutes
-			metric_to_monitor
-			last_admin_to_edit_id
-			threshold
-			units
-		}
-	}
-`
-export type UpdateMetricMonitorMutationFn = Apollo.MutationFunction<
-	Types.UpdateMetricMonitorMutation,
-	Types.UpdateMetricMonitorMutationVariables
->
+    mutation UpdateMetricMonitor($metric_monitor_id: ID!, $project_id: ID!, $name: String, $aggregator: MetricAggregator, $threshold: Float, $filters: [MetricTagFilterInput!], $units: String, $periodMinutes: Int, $metric_to_monitor: String, $slack_channels: [SanitizedSlackChannelInput], $discord_channels: [DiscordChannelInput!]!, $webhook_destinations: [WebhookDestinationInput!]!, $emails: [String], $disabled: Boolean) {
+  updateMetricMonitor(
+    metric_monitor_id: $metric_monitor_id
+    project_id: $project_id
+    threshold: $threshold
+    filters: $filters
+    units: $units
+    name: $name
+    aggregator: $aggregator
+    periodMinutes: $periodMinutes
+    metric_to_monitor: $metric_to_monitor
+    slack_channels: $slack_channels
+    discord_channels: $discord_channels
+    webhook_destinations: $webhook_destinations
+    emails: $emails
+    disabled: $disabled
+  ) {
+    id
+    updated_at
+    name
+    channels_to_notify {
+      webhook_channel
+      webhook_channel_id
+    }
+    emails_to_notify
+    aggregator
+    period_minutes
+    metric_to_monitor
+    last_admin_to_edit_id
+    threshold
+    units
+  }
+}
+    `;
+export type UpdateMetricMonitorMutationFn = Apollo.MutationFunction<Types.UpdateMetricMonitorMutation, Types.UpdateMetricMonitorMutationVariables>;
 
 /**
  * __useUpdateMetricMonitorMutation__
@@ -3141,51 +2122,34 @@ export type UpdateMetricMonitorMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateMetricMonitorMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateMetricMonitorMutation,
-		Types.UpdateMetricMonitorMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateMetricMonitorMutation,
-		Types.UpdateMetricMonitorMutationVariables
-	>(UpdateMetricMonitorDocument, baseOptions)
-}
-export type UpdateMetricMonitorMutationHookResult = ReturnType<
-	typeof useUpdateMetricMonitorMutation
->
-export type UpdateMetricMonitorMutationResult =
-	Apollo.MutationResult<Types.UpdateMetricMonitorMutation>
-export type UpdateMetricMonitorMutationOptions = Apollo.BaseMutationOptions<
-	Types.UpdateMetricMonitorMutation,
-	Types.UpdateMetricMonitorMutationVariables
->
+export function useUpdateMetricMonitorMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateMetricMonitorMutation, Types.UpdateMetricMonitorMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateMetricMonitorMutation, Types.UpdateMetricMonitorMutationVariables>(UpdateMetricMonitorDocument, baseOptions);
+      }
+export type UpdateMetricMonitorMutationHookResult = ReturnType<typeof useUpdateMetricMonitorMutation>;
+export type UpdateMetricMonitorMutationResult = Apollo.MutationResult<Types.UpdateMetricMonitorMutation>;
+export type UpdateMetricMonitorMutationOptions = Apollo.BaseMutationOptions<Types.UpdateMetricMonitorMutation, Types.UpdateMetricMonitorMutationVariables>;
 export const DeleteMetricMonitorDocument = gql`
-	mutation DeleteMetricMonitor($metric_monitor_id: ID!, $project_id: ID!) {
-		deleteMetricMonitor(
-			metric_monitor_id: $metric_monitor_id
-			project_id: $project_id
-		) {
-			id
-			updated_at
-			name
-			channels_to_notify {
-				webhook_channel
-				webhook_channel_id
-			}
-			emails_to_notify
-			aggregator
-			metric_to_monitor
-			last_admin_to_edit_id
-			threshold
-		}
-	}
-`
-export type DeleteMetricMonitorMutationFn = Apollo.MutationFunction<
-	Types.DeleteMetricMonitorMutation,
-	Types.DeleteMetricMonitorMutationVariables
->
+    mutation DeleteMetricMonitor($metric_monitor_id: ID!, $project_id: ID!) {
+  deleteMetricMonitor(
+    metric_monitor_id: $metric_monitor_id
+    project_id: $project_id
+  ) {
+    id
+    updated_at
+    name
+    channels_to_notify {
+      webhook_channel
+      webhook_channel_id
+    }
+    emails_to_notify
+    aggregator
+    metric_to_monitor
+    last_admin_to_edit_id
+    threshold
+  }
+}
+    `;
+export type DeleteMetricMonitorMutationFn = Apollo.MutationFunction<Types.DeleteMetricMonitorMutation, Types.DeleteMetricMonitorMutationVariables>;
 
 /**
  * __useDeleteMetricMonitorMutation__
@@ -3205,41 +2169,22 @@ export type DeleteMetricMonitorMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteMetricMonitorMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteMetricMonitorMutation,
-		Types.DeleteMetricMonitorMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteMetricMonitorMutation,
-		Types.DeleteMetricMonitorMutationVariables
-	>(DeleteMetricMonitorDocument, baseOptions)
-}
-export type DeleteMetricMonitorMutationHookResult = ReturnType<
-	typeof useDeleteMetricMonitorMutation
->
-export type DeleteMetricMonitorMutationResult =
-	Apollo.MutationResult<Types.DeleteMetricMonitorMutation>
-export type DeleteMetricMonitorMutationOptions = Apollo.BaseMutationOptions<
-	Types.DeleteMetricMonitorMutation,
-	Types.DeleteMetricMonitorMutationVariables
->
+export function useDeleteMetricMonitorMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteMetricMonitorMutation, Types.DeleteMetricMonitorMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteMetricMonitorMutation, Types.DeleteMetricMonitorMutationVariables>(DeleteMetricMonitorDocument, baseOptions);
+      }
+export type DeleteMetricMonitorMutationHookResult = ReturnType<typeof useDeleteMetricMonitorMutation>;
+export type DeleteMetricMonitorMutationResult = Apollo.MutationResult<Types.DeleteMetricMonitorMutation>;
+export type DeleteMetricMonitorMutationOptions = Apollo.BaseMutationOptions<Types.DeleteMetricMonitorMutation, Types.DeleteMetricMonitorMutationVariables>;
 export const UpdateAdminAndCreateWorkspaceDocument = gql`
-	mutation UpdateAdminAndCreateWorkspace(
-		$admin_and_workspace_details: AdminAndWorkspaceDetails!
-	) {
-		updateAdminAndCreateWorkspace(
-			admin_and_workspace_details: $admin_and_workspace_details
-		) {
-			id
-		}
-	}
-`
-export type UpdateAdminAndCreateWorkspaceMutationFn = Apollo.MutationFunction<
-	Types.UpdateAdminAndCreateWorkspaceMutation,
-	Types.UpdateAdminAndCreateWorkspaceMutationVariables
->
+    mutation UpdateAdminAndCreateWorkspace($admin_and_workspace_details: AdminAndWorkspaceDetails!) {
+  updateAdminAndCreateWorkspace(
+    admin_and_workspace_details: $admin_and_workspace_details
+  ) {
+    id
+  }
+}
+    `;
+export type UpdateAdminAndCreateWorkspaceMutationFn = Apollo.MutationFunction<Types.UpdateAdminAndCreateWorkspaceMutation, Types.UpdateAdminAndCreateWorkspaceMutationVariables>;
 
 /**
  * __useUpdateAdminAndCreateWorkspaceMutation__
@@ -3258,36 +2203,18 @@ export type UpdateAdminAndCreateWorkspaceMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateAdminAndCreateWorkspaceMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateAdminAndCreateWorkspaceMutation,
-		Types.UpdateAdminAndCreateWorkspaceMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateAdminAndCreateWorkspaceMutation,
-		Types.UpdateAdminAndCreateWorkspaceMutationVariables
-	>(UpdateAdminAndCreateWorkspaceDocument, baseOptions)
-}
-export type UpdateAdminAndCreateWorkspaceMutationHookResult = ReturnType<
-	typeof useUpdateAdminAndCreateWorkspaceMutation
->
-export type UpdateAdminAndCreateWorkspaceMutationResult =
-	Apollo.MutationResult<Types.UpdateAdminAndCreateWorkspaceMutation>
-export type UpdateAdminAndCreateWorkspaceMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.UpdateAdminAndCreateWorkspaceMutation,
-		Types.UpdateAdminAndCreateWorkspaceMutationVariables
-	>
+export function useUpdateAdminAndCreateWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateAdminAndCreateWorkspaceMutation, Types.UpdateAdminAndCreateWorkspaceMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateAdminAndCreateWorkspaceMutation, Types.UpdateAdminAndCreateWorkspaceMutationVariables>(UpdateAdminAndCreateWorkspaceDocument, baseOptions);
+      }
+export type UpdateAdminAndCreateWorkspaceMutationHookResult = ReturnType<typeof useUpdateAdminAndCreateWorkspaceMutation>;
+export type UpdateAdminAndCreateWorkspaceMutationResult = Apollo.MutationResult<Types.UpdateAdminAndCreateWorkspaceMutation>;
+export type UpdateAdminAndCreateWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.UpdateAdminAndCreateWorkspaceMutation, Types.UpdateAdminAndCreateWorkspaceMutationVariables>;
 export const UpdateAdminAboutYouDetailsDocument = gql`
-	mutation UpdateAdminAboutYouDetails($adminDetails: AdminAboutYouDetails!) {
-		updateAdminAboutYouDetails(adminDetails: $adminDetails)
-	}
-`
-export type UpdateAdminAboutYouDetailsMutationFn = Apollo.MutationFunction<
-	Types.UpdateAdminAboutYouDetailsMutation,
-	Types.UpdateAdminAboutYouDetailsMutationVariables
->
+    mutation UpdateAdminAboutYouDetails($adminDetails: AdminAboutYouDetails!) {
+  updateAdminAboutYouDetails(adminDetails: $adminDetails)
+}
+    `;
+export type UpdateAdminAboutYouDetailsMutationFn = Apollo.MutationFunction<Types.UpdateAdminAboutYouDetailsMutation, Types.UpdateAdminAboutYouDetailsMutationVariables>;
 
 /**
  * __useUpdateAdminAboutYouDetailsMutation__
@@ -3306,82 +2233,50 @@ export type UpdateAdminAboutYouDetailsMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateAdminAboutYouDetailsMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateAdminAboutYouDetailsMutation,
-		Types.UpdateAdminAboutYouDetailsMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateAdminAboutYouDetailsMutation,
-		Types.UpdateAdminAboutYouDetailsMutationVariables
-	>(UpdateAdminAboutYouDetailsDocument, baseOptions)
-}
-export type UpdateAdminAboutYouDetailsMutationHookResult = ReturnType<
-	typeof useUpdateAdminAboutYouDetailsMutation
->
-export type UpdateAdminAboutYouDetailsMutationResult =
-	Apollo.MutationResult<Types.UpdateAdminAboutYouDetailsMutation>
-export type UpdateAdminAboutYouDetailsMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.UpdateAdminAboutYouDetailsMutation,
-		Types.UpdateAdminAboutYouDetailsMutationVariables
-	>
+export function useUpdateAdminAboutYouDetailsMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateAdminAboutYouDetailsMutation, Types.UpdateAdminAboutYouDetailsMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateAdminAboutYouDetailsMutation, Types.UpdateAdminAboutYouDetailsMutationVariables>(UpdateAdminAboutYouDetailsDocument, baseOptions);
+      }
+export type UpdateAdminAboutYouDetailsMutationHookResult = ReturnType<typeof useUpdateAdminAboutYouDetailsMutation>;
+export type UpdateAdminAboutYouDetailsMutationResult = Apollo.MutationResult<Types.UpdateAdminAboutYouDetailsMutation>;
+export type UpdateAdminAboutYouDetailsMutationOptions = Apollo.BaseMutationOptions<Types.UpdateAdminAboutYouDetailsMutation, Types.UpdateAdminAboutYouDetailsMutationVariables>;
 export const UpdateErrorAlertDocument = gql`
-	mutation UpdateErrorAlert(
-		$project_id: ID!
-		$name: String
-		$error_alert_id: ID!
-		$count_threshold: Int
-		$threshold_window: Int
-		$slack_channels: [SanitizedSlackChannelInput]
-		$discord_channels: [DiscordChannelInput!]!
-		$webhook_destinations: [WebhookDestinationInput!]!
-		$emails: [String]
-		$environments: [String]
-		$regex_groups: [String]
-		$frequency: Int
-		$disabled: Boolean
-	) {
-		updateErrorAlert(
-			project_id: $project_id
-			error_alert_id: $error_alert_id
-			name: $name
-			count_threshold: $count_threshold
-			slack_channels: $slack_channels
-			discord_channels: $discord_channels
-			webhook_destinations: $webhook_destinations
-			emails: $emails
-			environments: $environments
-			threshold_window: $threshold_window
-			regex_groups: $regex_groups
-			frequency: $frequency
-			disabled: $disabled
-		) {
-			Name
-			ChannelsToNotify {
-				webhook_channel
-				webhook_channel_id
-			}
-			DiscordChannelsToNotify {
-				id
-				name
-			}
-			EmailsToNotify
-			ExcludedEnvironments
-			CountThreshold
-			ThresholdWindow
-			LastAdminToEditID
-			RegexGroups
-			Frequency
-			disabled
-		}
-	}
-`
-export type UpdateErrorAlertMutationFn = Apollo.MutationFunction<
-	Types.UpdateErrorAlertMutation,
-	Types.UpdateErrorAlertMutationVariables
->
+    mutation UpdateErrorAlert($project_id: ID!, $name: String, $error_alert_id: ID!, $count_threshold: Int, $threshold_window: Int, $slack_channels: [SanitizedSlackChannelInput], $discord_channels: [DiscordChannelInput!]!, $webhook_destinations: [WebhookDestinationInput!]!, $emails: [String], $environments: [String], $regex_groups: [String], $frequency: Int, $disabled: Boolean) {
+  updateErrorAlert(
+    project_id: $project_id
+    error_alert_id: $error_alert_id
+    name: $name
+    count_threshold: $count_threshold
+    slack_channels: $slack_channels
+    discord_channels: $discord_channels
+    webhook_destinations: $webhook_destinations
+    emails: $emails
+    environments: $environments
+    threshold_window: $threshold_window
+    regex_groups: $regex_groups
+    frequency: $frequency
+    disabled: $disabled
+  ) {
+    Name
+    ChannelsToNotify {
+      webhook_channel
+      webhook_channel_id
+    }
+    DiscordChannelsToNotify {
+      id
+      name
+    }
+    EmailsToNotify
+    ExcludedEnvironments
+    CountThreshold
+    ThresholdWindow
+    LastAdminToEditID
+    RegexGroups
+    Frequency
+    disabled
+  }
+}
+    `;
+export type UpdateErrorAlertMutationFn = Apollo.MutationFunction<Types.UpdateErrorAlertMutation, Types.UpdateErrorAlertMutationVariables>;
 
 /**
  * __useUpdateErrorAlertMutation__
@@ -3412,40 +2307,20 @@ export type UpdateErrorAlertMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateErrorAlertMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateErrorAlertMutation,
-		Types.UpdateErrorAlertMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateErrorAlertMutation,
-		Types.UpdateErrorAlertMutationVariables
-	>(UpdateErrorAlertDocument, baseOptions)
-}
-export type UpdateErrorAlertMutationHookResult = ReturnType<
-	typeof useUpdateErrorAlertMutation
->
-export type UpdateErrorAlertMutationResult =
-	Apollo.MutationResult<Types.UpdateErrorAlertMutation>
-export type UpdateErrorAlertMutationOptions = Apollo.BaseMutationOptions<
-	Types.UpdateErrorAlertMutation,
-	Types.UpdateErrorAlertMutationVariables
->
+export function useUpdateErrorAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateErrorAlertMutation, Types.UpdateErrorAlertMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateErrorAlertMutation, Types.UpdateErrorAlertMutationVariables>(UpdateErrorAlertDocument, baseOptions);
+      }
+export type UpdateErrorAlertMutationHookResult = ReturnType<typeof useUpdateErrorAlertMutation>;
+export type UpdateErrorAlertMutationResult = Apollo.MutationResult<Types.UpdateErrorAlertMutation>;
+export type UpdateErrorAlertMutationOptions = Apollo.BaseMutationOptions<Types.UpdateErrorAlertMutation, Types.UpdateErrorAlertMutationVariables>;
 export const DeleteErrorAlertDocument = gql`
-	mutation DeleteErrorAlert($project_id: ID!, $error_alert_id: ID!) {
-		deleteErrorAlert(
-			project_id: $project_id
-			error_alert_id: $error_alert_id
-		) {
-			id
-		}
-	}
-`
-export type DeleteErrorAlertMutationFn = Apollo.MutationFunction<
-	Types.DeleteErrorAlertMutation,
-	Types.DeleteErrorAlertMutationVariables
->
+    mutation DeleteErrorAlert($project_id: ID!, $error_alert_id: ID!) {
+  deleteErrorAlert(project_id: $project_id, error_alert_id: $error_alert_id) {
+    id
+  }
+}
+    `;
+export type DeleteErrorAlertMutationFn = Apollo.MutationFunction<Types.DeleteErrorAlertMutation, Types.DeleteErrorAlertMutationVariables>;
 
 /**
  * __useDeleteErrorAlertMutation__
@@ -3465,40 +2340,20 @@ export type DeleteErrorAlertMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteErrorAlertMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteErrorAlertMutation,
-		Types.DeleteErrorAlertMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteErrorAlertMutation,
-		Types.DeleteErrorAlertMutationVariables
-	>(DeleteErrorAlertDocument, baseOptions)
-}
-export type DeleteErrorAlertMutationHookResult = ReturnType<
-	typeof useDeleteErrorAlertMutation
->
-export type DeleteErrorAlertMutationResult =
-	Apollo.MutationResult<Types.DeleteErrorAlertMutation>
-export type DeleteErrorAlertMutationOptions = Apollo.BaseMutationOptions<
-	Types.DeleteErrorAlertMutation,
-	Types.DeleteErrorAlertMutationVariables
->
+export function useDeleteErrorAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteErrorAlertMutation, Types.DeleteErrorAlertMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteErrorAlertMutation, Types.DeleteErrorAlertMutationVariables>(DeleteErrorAlertDocument, baseOptions);
+      }
+export type DeleteErrorAlertMutationHookResult = ReturnType<typeof useDeleteErrorAlertMutation>;
+export type DeleteErrorAlertMutationResult = Apollo.MutationResult<Types.DeleteErrorAlertMutation>;
+export type DeleteErrorAlertMutationOptions = Apollo.BaseMutationOptions<Types.DeleteErrorAlertMutation, Types.DeleteErrorAlertMutationVariables>;
 export const DeleteSessionAlertDocument = gql`
-	mutation DeleteSessionAlert($project_id: ID!, $session_alert_id: ID!) {
-		deleteSessionAlert(
-			project_id: $project_id
-			session_alert_id: $session_alert_id
-		) {
-			id
-		}
-	}
-`
-export type DeleteSessionAlertMutationFn = Apollo.MutationFunction<
-	Types.DeleteSessionAlertMutation,
-	Types.DeleteSessionAlertMutationVariables
->
+    mutation DeleteSessionAlert($project_id: ID!, $session_alert_id: ID!) {
+  deleteSessionAlert(project_id: $project_id, session_alert_id: $session_alert_id) {
+    id
+  }
+}
+    `;
+export type DeleteSessionAlertMutationFn = Apollo.MutationFunction<Types.DeleteSessionAlertMutation, Types.DeleteSessionAlertMutationVariables>;
 
 /**
  * __useDeleteSessionAlertMutation__
@@ -3518,37 +2373,20 @@ export type DeleteSessionAlertMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteSessionAlertMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteSessionAlertMutation,
-		Types.DeleteSessionAlertMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteSessionAlertMutation,
-		Types.DeleteSessionAlertMutationVariables
-	>(DeleteSessionAlertDocument, baseOptions)
-}
-export type DeleteSessionAlertMutationHookResult = ReturnType<
-	typeof useDeleteSessionAlertMutation
->
-export type DeleteSessionAlertMutationResult =
-	Apollo.MutationResult<Types.DeleteSessionAlertMutation>
-export type DeleteSessionAlertMutationOptions = Apollo.BaseMutationOptions<
-	Types.DeleteSessionAlertMutation,
-	Types.DeleteSessionAlertMutationVariables
->
+export function useDeleteSessionAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteSessionAlertMutation, Types.DeleteSessionAlertMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteSessionAlertMutation, Types.DeleteSessionAlertMutationVariables>(DeleteSessionAlertDocument, baseOptions);
+      }
+export type DeleteSessionAlertMutationHookResult = ReturnType<typeof useDeleteSessionAlertMutation>;
+export type DeleteSessionAlertMutationResult = Apollo.MutationResult<Types.DeleteSessionAlertMutation>;
+export type DeleteSessionAlertMutationOptions = Apollo.BaseMutationOptions<Types.DeleteSessionAlertMutation, Types.DeleteSessionAlertMutationVariables>;
 export const UpdateLogAlertDocument = gql`
-	mutation UpdateLogAlert($id: ID!, $input: LogAlertInput!) {
-		updateLogAlert(id: $id, input: $input) {
-			id
-		}
-	}
-`
-export type UpdateLogAlertMutationFn = Apollo.MutationFunction<
-	Types.UpdateLogAlertMutation,
-	Types.UpdateLogAlertMutationVariables
->
+    mutation UpdateLogAlert($id: ID!, $input: LogAlertInput!) {
+  updateLogAlert(id: $id, input: $input) {
+    id
+  }
+}
+    `;
+export type UpdateLogAlertMutationFn = Apollo.MutationFunction<Types.UpdateLogAlertMutation, Types.UpdateLogAlertMutationVariables>;
 
 /**
  * __useUpdateLogAlertMutation__
@@ -3568,37 +2406,20 @@ export type UpdateLogAlertMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateLogAlertMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateLogAlertMutation,
-		Types.UpdateLogAlertMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateLogAlertMutation,
-		Types.UpdateLogAlertMutationVariables
-	>(UpdateLogAlertDocument, baseOptions)
-}
-export type UpdateLogAlertMutationHookResult = ReturnType<
-	typeof useUpdateLogAlertMutation
->
-export type UpdateLogAlertMutationResult =
-	Apollo.MutationResult<Types.UpdateLogAlertMutation>
-export type UpdateLogAlertMutationOptions = Apollo.BaseMutationOptions<
-	Types.UpdateLogAlertMutation,
-	Types.UpdateLogAlertMutationVariables
->
+export function useUpdateLogAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateLogAlertMutation, Types.UpdateLogAlertMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateLogAlertMutation, Types.UpdateLogAlertMutationVariables>(UpdateLogAlertDocument, baseOptions);
+      }
+export type UpdateLogAlertMutationHookResult = ReturnType<typeof useUpdateLogAlertMutation>;
+export type UpdateLogAlertMutationResult = Apollo.MutationResult<Types.UpdateLogAlertMutation>;
+export type UpdateLogAlertMutationOptions = Apollo.BaseMutationOptions<Types.UpdateLogAlertMutation, Types.UpdateLogAlertMutationVariables>;
 export const CreateLogAlertDocument = gql`
-	mutation CreateLogAlert($input: LogAlertInput!) {
-		createLogAlert(input: $input) {
-			id
-		}
-	}
-`
-export type CreateLogAlertMutationFn = Apollo.MutationFunction<
-	Types.CreateLogAlertMutation,
-	Types.CreateLogAlertMutationVariables
->
+    mutation CreateLogAlert($input: LogAlertInput!) {
+  createLogAlert(input: $input) {
+    id
+  }
+}
+    `;
+export type CreateLogAlertMutationFn = Apollo.MutationFunction<Types.CreateLogAlertMutation, Types.CreateLogAlertMutationVariables>;
 
 /**
  * __useCreateLogAlertMutation__
@@ -3617,37 +2438,20 @@ export type CreateLogAlertMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateLogAlertMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateLogAlertMutation,
-		Types.CreateLogAlertMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateLogAlertMutation,
-		Types.CreateLogAlertMutationVariables
-	>(CreateLogAlertDocument, baseOptions)
-}
-export type CreateLogAlertMutationHookResult = ReturnType<
-	typeof useCreateLogAlertMutation
->
-export type CreateLogAlertMutationResult =
-	Apollo.MutationResult<Types.CreateLogAlertMutation>
-export type CreateLogAlertMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateLogAlertMutation,
-	Types.CreateLogAlertMutationVariables
->
+export function useCreateLogAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateLogAlertMutation, Types.CreateLogAlertMutationVariables>) {
+        return Apollo.useMutation<Types.CreateLogAlertMutation, Types.CreateLogAlertMutationVariables>(CreateLogAlertDocument, baseOptions);
+      }
+export type CreateLogAlertMutationHookResult = ReturnType<typeof useCreateLogAlertMutation>;
+export type CreateLogAlertMutationResult = Apollo.MutationResult<Types.CreateLogAlertMutation>;
+export type CreateLogAlertMutationOptions = Apollo.BaseMutationOptions<Types.CreateLogAlertMutation, Types.CreateLogAlertMutationVariables>;
 export const DeleteLogAlertDocument = gql`
-	mutation DeleteLogAlert($project_id: ID!, $id: ID!) {
-		deleteLogAlert(project_id: $project_id, id: $id) {
-			id
-		}
-	}
-`
-export type DeleteLogAlertMutationFn = Apollo.MutationFunction<
-	Types.DeleteLogAlertMutation,
-	Types.DeleteLogAlertMutationVariables
->
+    mutation DeleteLogAlert($project_id: ID!, $id: ID!) {
+  deleteLogAlert(project_id: $project_id, id: $id) {
+    id
+  }
+}
+    `;
+export type DeleteLogAlertMutationFn = Apollo.MutationFunction<Types.DeleteLogAlertMutation, Types.DeleteLogAlertMutationVariables>;
 
 /**
  * __useDeleteLogAlertMutation__
@@ -3667,45 +2471,20 @@ export type DeleteLogAlertMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteLogAlertMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteLogAlertMutation,
-		Types.DeleteLogAlertMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteLogAlertMutation,
-		Types.DeleteLogAlertMutationVariables
-	>(DeleteLogAlertDocument, baseOptions)
-}
-export type DeleteLogAlertMutationHookResult = ReturnType<
-	typeof useDeleteLogAlertMutation
->
-export type DeleteLogAlertMutationResult =
-	Apollo.MutationResult<Types.DeleteLogAlertMutation>
-export type DeleteLogAlertMutationOptions = Apollo.BaseMutationOptions<
-	Types.DeleteLogAlertMutation,
-	Types.DeleteLogAlertMutationVariables
->
+export function useDeleteLogAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteLogAlertMutation, Types.DeleteLogAlertMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteLogAlertMutation, Types.DeleteLogAlertMutationVariables>(DeleteLogAlertDocument, baseOptions);
+      }
+export type DeleteLogAlertMutationHookResult = ReturnType<typeof useDeleteLogAlertMutation>;
+export type DeleteLogAlertMutationResult = Apollo.MutationResult<Types.DeleteLogAlertMutation>;
+export type DeleteLogAlertMutationOptions = Apollo.BaseMutationOptions<Types.DeleteLogAlertMutation, Types.DeleteLogAlertMutationVariables>;
 export const UpdateLogAlertIsDisabledDocument = gql`
-	mutation UpdateLogAlertIsDisabled(
-		$id: ID!
-		$project_id: ID!
-		$disabled: Boolean!
-	) {
-		updateLogAlertIsDisabled(
-			id: $id
-			project_id: $project_id
-			disabled: $disabled
-		) {
-			id
-		}
-	}
-`
-export type UpdateLogAlertIsDisabledMutationFn = Apollo.MutationFunction<
-	Types.UpdateLogAlertIsDisabledMutation,
-	Types.UpdateLogAlertIsDisabledMutationVariables
->
+    mutation UpdateLogAlertIsDisabled($id: ID!, $project_id: ID!, $disabled: Boolean!) {
+  updateLogAlertIsDisabled(id: $id, project_id: $project_id, disabled: $disabled) {
+    id
+  }
+}
+    `;
+export type UpdateLogAlertIsDisabledMutationFn = Apollo.MutationFunction<Types.UpdateLogAlertIsDisabledMutation, Types.UpdateLogAlertIsDisabledMutationVariables>;
 
 /**
  * __useUpdateLogAlertIsDisabledMutation__
@@ -3726,46 +2505,24 @@ export type UpdateLogAlertIsDisabledMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateLogAlertIsDisabledMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateLogAlertIsDisabledMutation,
-		Types.UpdateLogAlertIsDisabledMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateLogAlertIsDisabledMutation,
-		Types.UpdateLogAlertIsDisabledMutationVariables
-	>(UpdateLogAlertIsDisabledDocument, baseOptions)
-}
-export type UpdateLogAlertIsDisabledMutationHookResult = ReturnType<
-	typeof useUpdateLogAlertIsDisabledMutation
->
-export type UpdateLogAlertIsDisabledMutationResult =
-	Apollo.MutationResult<Types.UpdateLogAlertIsDisabledMutation>
-export type UpdateLogAlertIsDisabledMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.UpdateLogAlertIsDisabledMutation,
-		Types.UpdateLogAlertIsDisabledMutationVariables
-	>
+export function useUpdateLogAlertIsDisabledMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateLogAlertIsDisabledMutation, Types.UpdateLogAlertIsDisabledMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateLogAlertIsDisabledMutation, Types.UpdateLogAlertIsDisabledMutationVariables>(UpdateLogAlertIsDisabledDocument, baseOptions);
+      }
+export type UpdateLogAlertIsDisabledMutationHookResult = ReturnType<typeof useUpdateLogAlertIsDisabledMutation>;
+export type UpdateLogAlertIsDisabledMutationResult = Apollo.MutationResult<Types.UpdateLogAlertIsDisabledMutation>;
+export type UpdateLogAlertIsDisabledMutationOptions = Apollo.BaseMutationOptions<Types.UpdateLogAlertIsDisabledMutation, Types.UpdateLogAlertIsDisabledMutationVariables>;
 export const UpdateSessionAlertIsDisabledDocument = gql`
-	mutation UpdateSessionAlertIsDisabled(
-		$id: ID!
-		$project_id: ID!
-		$disabled: Boolean!
-	) {
-		updateSessionAlertIsDisabled(
-			id: $id
-			project_id: $project_id
-			disabled: $disabled
-		) {
-			id
-		}
-	}
-`
-export type UpdateSessionAlertIsDisabledMutationFn = Apollo.MutationFunction<
-	Types.UpdateSessionAlertIsDisabledMutation,
-	Types.UpdateSessionAlertIsDisabledMutationVariables
->
+    mutation UpdateSessionAlertIsDisabled($id: ID!, $project_id: ID!, $disabled: Boolean!) {
+  updateSessionAlertIsDisabled(
+    id: $id
+    project_id: $project_id
+    disabled: $disabled
+  ) {
+    id
+  }
+}
+    `;
+export type UpdateSessionAlertIsDisabledMutationFn = Apollo.MutationFunction<Types.UpdateSessionAlertIsDisabledMutation, Types.UpdateSessionAlertIsDisabledMutationVariables>;
 
 /**
  * __useUpdateSessionAlertIsDisabledMutation__
@@ -3786,46 +2543,24 @@ export type UpdateSessionAlertIsDisabledMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateSessionAlertIsDisabledMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateSessionAlertIsDisabledMutation,
-		Types.UpdateSessionAlertIsDisabledMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateSessionAlertIsDisabledMutation,
-		Types.UpdateSessionAlertIsDisabledMutationVariables
-	>(UpdateSessionAlertIsDisabledDocument, baseOptions)
-}
-export type UpdateSessionAlertIsDisabledMutationHookResult = ReturnType<
-	typeof useUpdateSessionAlertIsDisabledMutation
->
-export type UpdateSessionAlertIsDisabledMutationResult =
-	Apollo.MutationResult<Types.UpdateSessionAlertIsDisabledMutation>
-export type UpdateSessionAlertIsDisabledMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.UpdateSessionAlertIsDisabledMutation,
-		Types.UpdateSessionAlertIsDisabledMutationVariables
-	>
+export function useUpdateSessionAlertIsDisabledMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateSessionAlertIsDisabledMutation, Types.UpdateSessionAlertIsDisabledMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateSessionAlertIsDisabledMutation, Types.UpdateSessionAlertIsDisabledMutationVariables>(UpdateSessionAlertIsDisabledDocument, baseOptions);
+      }
+export type UpdateSessionAlertIsDisabledMutationHookResult = ReturnType<typeof useUpdateSessionAlertIsDisabledMutation>;
+export type UpdateSessionAlertIsDisabledMutationResult = Apollo.MutationResult<Types.UpdateSessionAlertIsDisabledMutation>;
+export type UpdateSessionAlertIsDisabledMutationOptions = Apollo.BaseMutationOptions<Types.UpdateSessionAlertIsDisabledMutation, Types.UpdateSessionAlertIsDisabledMutationVariables>;
 export const UpdateMetricMonitorIsDisabledDocument = gql`
-	mutation UpdateMetricMonitorIsDisabled(
-		$id: ID!
-		$project_id: ID!
-		$disabled: Boolean!
-	) {
-		updateMetricMonitorIsDisabled(
-			id: $id
-			project_id: $project_id
-			disabled: $disabled
-		) {
-			id
-		}
-	}
-`
-export type UpdateMetricMonitorIsDisabledMutationFn = Apollo.MutationFunction<
-	Types.UpdateMetricMonitorIsDisabledMutation,
-	Types.UpdateMetricMonitorIsDisabledMutationVariables
->
+    mutation UpdateMetricMonitorIsDisabled($id: ID!, $project_id: ID!, $disabled: Boolean!) {
+  updateMetricMonitorIsDisabled(
+    id: $id
+    project_id: $project_id
+    disabled: $disabled
+  ) {
+    id
+  }
+}
+    `;
+export type UpdateMetricMonitorIsDisabledMutationFn = Apollo.MutationFunction<Types.UpdateMetricMonitorIsDisabledMutation, Types.UpdateMetricMonitorIsDisabledMutationVariables>;
 
 /**
  * __useUpdateMetricMonitorIsDisabledMutation__
@@ -3846,46 +2581,24 @@ export type UpdateMetricMonitorIsDisabledMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateMetricMonitorIsDisabledMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateMetricMonitorIsDisabledMutation,
-		Types.UpdateMetricMonitorIsDisabledMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateMetricMonitorIsDisabledMutation,
-		Types.UpdateMetricMonitorIsDisabledMutationVariables
-	>(UpdateMetricMonitorIsDisabledDocument, baseOptions)
-}
-export type UpdateMetricMonitorIsDisabledMutationHookResult = ReturnType<
-	typeof useUpdateMetricMonitorIsDisabledMutation
->
-export type UpdateMetricMonitorIsDisabledMutationResult =
-	Apollo.MutationResult<Types.UpdateMetricMonitorIsDisabledMutation>
-export type UpdateMetricMonitorIsDisabledMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.UpdateMetricMonitorIsDisabledMutation,
-		Types.UpdateMetricMonitorIsDisabledMutationVariables
-	>
+export function useUpdateMetricMonitorIsDisabledMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateMetricMonitorIsDisabledMutation, Types.UpdateMetricMonitorIsDisabledMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateMetricMonitorIsDisabledMutation, Types.UpdateMetricMonitorIsDisabledMutationVariables>(UpdateMetricMonitorIsDisabledDocument, baseOptions);
+      }
+export type UpdateMetricMonitorIsDisabledMutationHookResult = ReturnType<typeof useUpdateMetricMonitorIsDisabledMutation>;
+export type UpdateMetricMonitorIsDisabledMutationResult = Apollo.MutationResult<Types.UpdateMetricMonitorIsDisabledMutation>;
+export type UpdateMetricMonitorIsDisabledMutationOptions = Apollo.BaseMutationOptions<Types.UpdateMetricMonitorIsDisabledMutation, Types.UpdateMetricMonitorIsDisabledMutationVariables>;
 export const UpdateErrorAlertIsDisabledDocument = gql`
-	mutation UpdateErrorAlertIsDisabled(
-		$id: ID!
-		$project_id: ID!
-		$disabled: Boolean!
-	) {
-		updateErrorAlertIsDisabled(
-			id: $id
-			project_id: $project_id
-			disabled: $disabled
-		) {
-			id
-		}
-	}
-`
-export type UpdateErrorAlertIsDisabledMutationFn = Apollo.MutationFunction<
-	Types.UpdateErrorAlertIsDisabledMutation,
-	Types.UpdateErrorAlertIsDisabledMutationVariables
->
+    mutation UpdateErrorAlertIsDisabled($id: ID!, $project_id: ID!, $disabled: Boolean!) {
+  updateErrorAlertIsDisabled(
+    id: $id
+    project_id: $project_id
+    disabled: $disabled
+  ) {
+    id
+  }
+}
+    `;
+export type UpdateErrorAlertIsDisabledMutationFn = Apollo.MutationFunction<Types.UpdateErrorAlertIsDisabledMutation, Types.UpdateErrorAlertIsDisabledMutationVariables>;
 
 /**
  * __useUpdateErrorAlertIsDisabledMutation__
@@ -3906,49 +2619,31 @@ export type UpdateErrorAlertIsDisabledMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateErrorAlertIsDisabledMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateErrorAlertIsDisabledMutation,
-		Types.UpdateErrorAlertIsDisabledMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateErrorAlertIsDisabledMutation,
-		Types.UpdateErrorAlertIsDisabledMutationVariables
-	>(UpdateErrorAlertIsDisabledDocument, baseOptions)
-}
-export type UpdateErrorAlertIsDisabledMutationHookResult = ReturnType<
-	typeof useUpdateErrorAlertIsDisabledMutation
->
-export type UpdateErrorAlertIsDisabledMutationResult =
-	Apollo.MutationResult<Types.UpdateErrorAlertIsDisabledMutation>
-export type UpdateErrorAlertIsDisabledMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.UpdateErrorAlertIsDisabledMutation,
-		Types.UpdateErrorAlertIsDisabledMutationVariables
-	>
+export function useUpdateErrorAlertIsDisabledMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateErrorAlertIsDisabledMutation, Types.UpdateErrorAlertIsDisabledMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateErrorAlertIsDisabledMutation, Types.UpdateErrorAlertIsDisabledMutationVariables>(UpdateErrorAlertIsDisabledDocument, baseOptions);
+      }
+export type UpdateErrorAlertIsDisabledMutationHookResult = ReturnType<typeof useUpdateErrorAlertIsDisabledMutation>;
+export type UpdateErrorAlertIsDisabledMutationResult = Apollo.MutationResult<Types.UpdateErrorAlertIsDisabledMutation>;
+export type UpdateErrorAlertIsDisabledMutationOptions = Apollo.BaseMutationOptions<Types.UpdateErrorAlertIsDisabledMutation, Types.UpdateErrorAlertIsDisabledMutationVariables>;
 export const CreateSessionAlertDocument = gql`
-	mutation CreateSessionAlert($input: SessionAlertInput!) {
-		createSessionAlert(input: $input) {
-			id
-			ChannelsToNotify {
-				webhook_channel
-				webhook_channel_id
-			}
-			EmailsToNotify
-			Name
-			ExcludedEnvironments
-			CountThreshold
-			ThresholdWindow
-			LastAdminToEditID
-			disabled
-		}
-	}
-`
-export type CreateSessionAlertMutationFn = Apollo.MutationFunction<
-	Types.CreateSessionAlertMutation,
-	Types.CreateSessionAlertMutationVariables
->
+    mutation CreateSessionAlert($input: SessionAlertInput!) {
+  createSessionAlert(input: $input) {
+    id
+    ChannelsToNotify {
+      webhook_channel
+      webhook_channel_id
+    }
+    EmailsToNotify
+    Name
+    ExcludedEnvironments
+    CountThreshold
+    ThresholdWindow
+    LastAdminToEditID
+    disabled
+  }
+}
+    `;
+export type CreateSessionAlertMutationFn = Apollo.MutationFunction<Types.CreateSessionAlertMutation, Types.CreateSessionAlertMutationVariables>;
 
 /**
  * __useCreateSessionAlertMutation__
@@ -3967,52 +2662,35 @@ export type CreateSessionAlertMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useCreateSessionAlertMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.CreateSessionAlertMutation,
-		Types.CreateSessionAlertMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.CreateSessionAlertMutation,
-		Types.CreateSessionAlertMutationVariables
-	>(CreateSessionAlertDocument, baseOptions)
-}
-export type CreateSessionAlertMutationHookResult = ReturnType<
-	typeof useCreateSessionAlertMutation
->
-export type CreateSessionAlertMutationResult =
-	Apollo.MutationResult<Types.CreateSessionAlertMutation>
-export type CreateSessionAlertMutationOptions = Apollo.BaseMutationOptions<
-	Types.CreateSessionAlertMutation,
-	Types.CreateSessionAlertMutationVariables
->
+export function useCreateSessionAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.CreateSessionAlertMutation, Types.CreateSessionAlertMutationVariables>) {
+        return Apollo.useMutation<Types.CreateSessionAlertMutation, Types.CreateSessionAlertMutationVariables>(CreateSessionAlertDocument, baseOptions);
+      }
+export type CreateSessionAlertMutationHookResult = ReturnType<typeof useCreateSessionAlertMutation>;
+export type CreateSessionAlertMutationResult = Apollo.MutationResult<Types.CreateSessionAlertMutation>;
+export type CreateSessionAlertMutationOptions = Apollo.BaseMutationOptions<Types.CreateSessionAlertMutation, Types.CreateSessionAlertMutationVariables>;
 export const UpdateSessionAlertDocument = gql`
-	mutation UpdateSessionAlert($id: ID!, $input: SessionAlertInput!) {
-		updateSessionAlert(id: $id, input: $input) {
-			id
-			ChannelsToNotify {
-				webhook_channel
-				webhook_channel_id
-			}
-			DiscordChannelsToNotify {
-				id
-				name
-			}
-			EmailsToNotify
-			ExcludedEnvironments
-			CountThreshold
-			ThresholdWindow
-			Name
-			LastAdminToEditID
-			disabled
-		}
-	}
-`
-export type UpdateSessionAlertMutationFn = Apollo.MutationFunction<
-	Types.UpdateSessionAlertMutation,
-	Types.UpdateSessionAlertMutationVariables
->
+    mutation UpdateSessionAlert($id: ID!, $input: SessionAlertInput!) {
+  updateSessionAlert(id: $id, input: $input) {
+    id
+    ChannelsToNotify {
+      webhook_channel
+      webhook_channel_id
+    }
+    DiscordChannelsToNotify {
+      id
+      name
+    }
+    EmailsToNotify
+    ExcludedEnvironments
+    CountThreshold
+    ThresholdWindow
+    Name
+    LastAdminToEditID
+    disabled
+  }
+}
+    `;
+export type UpdateSessionAlertMutationFn = Apollo.MutationFunction<Types.UpdateSessionAlertMutation, Types.UpdateSessionAlertMutationVariables>;
 
 /**
  * __useUpdateSessionAlertMutation__
@@ -4032,44 +2710,24 @@ export type UpdateSessionAlertMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateSessionAlertMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateSessionAlertMutation,
-		Types.UpdateSessionAlertMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateSessionAlertMutation,
-		Types.UpdateSessionAlertMutationVariables
-	>(UpdateSessionAlertDocument, baseOptions)
-}
-export type UpdateSessionAlertMutationHookResult = ReturnType<
-	typeof useUpdateSessionAlertMutation
->
-export type UpdateSessionAlertMutationResult =
-	Apollo.MutationResult<Types.UpdateSessionAlertMutation>
-export type UpdateSessionAlertMutationOptions = Apollo.BaseMutationOptions<
-	Types.UpdateSessionAlertMutation,
-	Types.UpdateSessionAlertMutationVariables
->
+export function useUpdateSessionAlertMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateSessionAlertMutation, Types.UpdateSessionAlertMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateSessionAlertMutation, Types.UpdateSessionAlertMutationVariables>(UpdateSessionAlertDocument, baseOptions);
+      }
+export type UpdateSessionAlertMutationHookResult = ReturnType<typeof useUpdateSessionAlertMutation>;
+export type UpdateSessionAlertMutationResult = Apollo.MutationResult<Types.UpdateSessionAlertMutation>;
+export type UpdateSessionAlertMutationOptions = Apollo.BaseMutationOptions<Types.UpdateSessionAlertMutation, Types.UpdateSessionAlertMutationVariables>;
 export const UpdateSessionIsPublicDocument = gql`
-	mutation UpdateSessionIsPublic(
-		$session_secure_id: String!
-		$is_public: Boolean!
-	) {
-		updateSessionIsPublic(
-			session_secure_id: $session_secure_id
-			is_public: $is_public
-		) {
-			secure_id
-			is_public
-		}
-	}
-`
-export type UpdateSessionIsPublicMutationFn = Apollo.MutationFunction<
-	Types.UpdateSessionIsPublicMutation,
-	Types.UpdateSessionIsPublicMutationVariables
->
+    mutation UpdateSessionIsPublic($session_secure_id: String!, $is_public: Boolean!) {
+  updateSessionIsPublic(
+    session_secure_id: $session_secure_id
+    is_public: $is_public
+  ) {
+    secure_id
+    is_public
+  }
+}
+    `;
+export type UpdateSessionIsPublicMutationFn = Apollo.MutationFunction<Types.UpdateSessionIsPublicMutation, Types.UpdateSessionIsPublicMutationVariables>;
 
 /**
  * __useUpdateSessionIsPublicMutation__
@@ -4089,44 +2747,24 @@ export type UpdateSessionIsPublicMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateSessionIsPublicMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateSessionIsPublicMutation,
-		Types.UpdateSessionIsPublicMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateSessionIsPublicMutation,
-		Types.UpdateSessionIsPublicMutationVariables
-	>(UpdateSessionIsPublicDocument, baseOptions)
-}
-export type UpdateSessionIsPublicMutationHookResult = ReturnType<
-	typeof useUpdateSessionIsPublicMutation
->
-export type UpdateSessionIsPublicMutationResult =
-	Apollo.MutationResult<Types.UpdateSessionIsPublicMutation>
-export type UpdateSessionIsPublicMutationOptions = Apollo.BaseMutationOptions<
-	Types.UpdateSessionIsPublicMutation,
-	Types.UpdateSessionIsPublicMutationVariables
->
+export function useUpdateSessionIsPublicMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateSessionIsPublicMutation, Types.UpdateSessionIsPublicMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateSessionIsPublicMutation, Types.UpdateSessionIsPublicMutationVariables>(UpdateSessionIsPublicDocument, baseOptions);
+      }
+export type UpdateSessionIsPublicMutationHookResult = ReturnType<typeof useUpdateSessionIsPublicMutation>;
+export type UpdateSessionIsPublicMutationResult = Apollo.MutationResult<Types.UpdateSessionIsPublicMutation>;
+export type UpdateSessionIsPublicMutationOptions = Apollo.BaseMutationOptions<Types.UpdateSessionIsPublicMutation, Types.UpdateSessionIsPublicMutationVariables>;
 export const UpdateErrorGroupIsPublicDocument = gql`
-	mutation UpdateErrorGroupIsPublic(
-		$error_group_secure_id: String!
-		$is_public: Boolean!
-	) {
-		updateErrorGroupIsPublic(
-			error_group_secure_id: $error_group_secure_id
-			is_public: $is_public
-		) {
-			secure_id
-			is_public
-		}
-	}
-`
-export type UpdateErrorGroupIsPublicMutationFn = Apollo.MutationFunction<
-	Types.UpdateErrorGroupIsPublicMutation,
-	Types.UpdateErrorGroupIsPublicMutationVariables
->
+    mutation UpdateErrorGroupIsPublic($error_group_secure_id: String!, $is_public: Boolean!) {
+  updateErrorGroupIsPublic(
+    error_group_secure_id: $error_group_secure_id
+    is_public: $is_public
+  ) {
+    secure_id
+    is_public
+  }
+}
+    `;
+export type UpdateErrorGroupIsPublicMutationFn = Apollo.MutationFunction<Types.UpdateErrorGroupIsPublicMutation, Types.UpdateErrorGroupIsPublicMutationVariables>;
 
 /**
  * __useUpdateErrorGroupIsPublicMutation__
@@ -4146,45 +2784,24 @@ export type UpdateErrorGroupIsPublicMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateErrorGroupIsPublicMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateErrorGroupIsPublicMutation,
-		Types.UpdateErrorGroupIsPublicMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateErrorGroupIsPublicMutation,
-		Types.UpdateErrorGroupIsPublicMutationVariables
-	>(UpdateErrorGroupIsPublicDocument, baseOptions)
-}
-export type UpdateErrorGroupIsPublicMutationHookResult = ReturnType<
-	typeof useUpdateErrorGroupIsPublicMutation
->
-export type UpdateErrorGroupIsPublicMutationResult =
-	Apollo.MutationResult<Types.UpdateErrorGroupIsPublicMutation>
-export type UpdateErrorGroupIsPublicMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.UpdateErrorGroupIsPublicMutation,
-		Types.UpdateErrorGroupIsPublicMutationVariables
-	>
+export function useUpdateErrorGroupIsPublicMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateErrorGroupIsPublicMutation, Types.UpdateErrorGroupIsPublicMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateErrorGroupIsPublicMutation, Types.UpdateErrorGroupIsPublicMutationVariables>(UpdateErrorGroupIsPublicDocument, baseOptions);
+      }
+export type UpdateErrorGroupIsPublicMutationHookResult = ReturnType<typeof useUpdateErrorGroupIsPublicMutation>;
+export type UpdateErrorGroupIsPublicMutationResult = Apollo.MutationResult<Types.UpdateErrorGroupIsPublicMutation>;
+export type UpdateErrorGroupIsPublicMutationOptions = Apollo.BaseMutationOptions<Types.UpdateErrorGroupIsPublicMutation, Types.UpdateErrorGroupIsPublicMutationVariables>;
 export const UpdateAllowMeterOverageDocument = gql`
-	mutation UpdateAllowMeterOverage(
-		$workspace_id: ID!
-		$allow_meter_overage: Boolean!
-	) {
-		updateAllowMeterOverage(
-			workspace_id: $workspace_id
-			allow_meter_overage: $allow_meter_overage
-		) {
-			id
-			allow_meter_overage
-		}
-	}
-`
-export type UpdateAllowMeterOverageMutationFn = Apollo.MutationFunction<
-	Types.UpdateAllowMeterOverageMutation,
-	Types.UpdateAllowMeterOverageMutationVariables
->
+    mutation UpdateAllowMeterOverage($workspace_id: ID!, $allow_meter_overage: Boolean!) {
+  updateAllowMeterOverage(
+    workspace_id: $workspace_id
+    allow_meter_overage: $allow_meter_overage
+  ) {
+    id
+    allow_meter_overage
+  }
+}
+    `;
+export type UpdateAllowMeterOverageMutationFn = Apollo.MutationFunction<Types.UpdateAllowMeterOverageMutation, Types.UpdateAllowMeterOverageMutationVariables>;
 
 /**
  * __useUpdateAllowMeterOverageMutation__
@@ -4204,38 +2821,21 @@ export type UpdateAllowMeterOverageMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateAllowMeterOverageMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateAllowMeterOverageMutation,
-		Types.UpdateAllowMeterOverageMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateAllowMeterOverageMutation,
-		Types.UpdateAllowMeterOverageMutationVariables
-	>(UpdateAllowMeterOverageDocument, baseOptions)
-}
-export type UpdateAllowMeterOverageMutationHookResult = ReturnType<
-	typeof useUpdateAllowMeterOverageMutation
->
-export type UpdateAllowMeterOverageMutationResult =
-	Apollo.MutationResult<Types.UpdateAllowMeterOverageMutation>
-export type UpdateAllowMeterOverageMutationOptions = Apollo.BaseMutationOptions<
-	Types.UpdateAllowMeterOverageMutation,
-	Types.UpdateAllowMeterOverageMutationVariables
->
+export function useUpdateAllowMeterOverageMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateAllowMeterOverageMutation, Types.UpdateAllowMeterOverageMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateAllowMeterOverageMutation, Types.UpdateAllowMeterOverageMutationVariables>(UpdateAllowMeterOverageDocument, baseOptions);
+      }
+export type UpdateAllowMeterOverageMutationHookResult = ReturnType<typeof useUpdateAllowMeterOverageMutation>;
+export type UpdateAllowMeterOverageMutationResult = Apollo.MutationResult<Types.UpdateAllowMeterOverageMutation>;
+export type UpdateAllowMeterOverageMutationOptions = Apollo.BaseMutationOptions<Types.UpdateAllowMeterOverageMutation, Types.UpdateAllowMeterOverageMutationVariables>;
 export const SyncSlackIntegrationDocument = gql`
-	mutation SyncSlackIntegration($project_id: ID!) {
-		syncSlackIntegration(project_id: $project_id) {
-			success
-			newChannelsAddedCount
-		}
-	}
-`
-export type SyncSlackIntegrationMutationFn = Apollo.MutationFunction<
-	Types.SyncSlackIntegrationMutation,
-	Types.SyncSlackIntegrationMutationVariables
->
+    mutation SyncSlackIntegration($project_id: ID!) {
+  syncSlackIntegration(project_id: $project_id) {
+    success
+    newChannelsAddedCount
+  }
+}
+    `;
+export type SyncSlackIntegrationMutationFn = Apollo.MutationFunction<Types.SyncSlackIntegrationMutation, Types.SyncSlackIntegrationMutationVariables>;
 
 /**
  * __useSyncSlackIntegrationMutation__
@@ -4254,35 +2854,18 @@ export type SyncSlackIntegrationMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useSyncSlackIntegrationMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.SyncSlackIntegrationMutation,
-		Types.SyncSlackIntegrationMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.SyncSlackIntegrationMutation,
-		Types.SyncSlackIntegrationMutationVariables
-	>(SyncSlackIntegrationDocument, baseOptions)
-}
-export type SyncSlackIntegrationMutationHookResult = ReturnType<
-	typeof useSyncSlackIntegrationMutation
->
-export type SyncSlackIntegrationMutationResult =
-	Apollo.MutationResult<Types.SyncSlackIntegrationMutation>
-export type SyncSlackIntegrationMutationOptions = Apollo.BaseMutationOptions<
-	Types.SyncSlackIntegrationMutation,
-	Types.SyncSlackIntegrationMutationVariables
->
+export function useSyncSlackIntegrationMutation(baseOptions?: Apollo.MutationHookOptions<Types.SyncSlackIntegrationMutation, Types.SyncSlackIntegrationMutationVariables>) {
+        return Apollo.useMutation<Types.SyncSlackIntegrationMutation, Types.SyncSlackIntegrationMutationVariables>(SyncSlackIntegrationDocument, baseOptions);
+      }
+export type SyncSlackIntegrationMutationHookResult = ReturnType<typeof useSyncSlackIntegrationMutation>;
+export type SyncSlackIntegrationMutationResult = Apollo.MutationResult<Types.SyncSlackIntegrationMutation>;
+export type SyncSlackIntegrationMutationOptions = Apollo.BaseMutationOptions<Types.SyncSlackIntegrationMutation, Types.SyncSlackIntegrationMutationVariables>;
 export const RequestAccessDocument = gql`
-	mutation RequestAccess($project_id: ID!) {
-		requestAccess(project_id: $project_id)
-	}
-`
-export type RequestAccessMutationFn = Apollo.MutationFunction<
-	Types.RequestAccessMutation,
-	Types.RequestAccessMutationVariables
->
+    mutation RequestAccess($project_id: ID!) {
+  requestAccess(project_id: $project_id)
+}
+    `;
+export type RequestAccessMutationFn = Apollo.MutationFunction<Types.RequestAccessMutation, Types.RequestAccessMutationVariables>;
 
 /**
  * __useRequestAccessMutation__
@@ -4301,38 +2884,18 @@ export type RequestAccessMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useRequestAccessMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.RequestAccessMutation,
-		Types.RequestAccessMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.RequestAccessMutation,
-		Types.RequestAccessMutationVariables
-	>(RequestAccessDocument, baseOptions)
-}
-export type RequestAccessMutationHookResult = ReturnType<
-	typeof useRequestAccessMutation
->
-export type RequestAccessMutationResult =
-	Apollo.MutationResult<Types.RequestAccessMutation>
-export type RequestAccessMutationOptions = Apollo.BaseMutationOptions<
-	Types.RequestAccessMutation,
-	Types.RequestAccessMutationVariables
->
+export function useRequestAccessMutation(baseOptions?: Apollo.MutationHookOptions<Types.RequestAccessMutation, Types.RequestAccessMutationVariables>) {
+        return Apollo.useMutation<Types.RequestAccessMutation, Types.RequestAccessMutationVariables>(RequestAccessDocument, baseOptions);
+      }
+export type RequestAccessMutationHookResult = ReturnType<typeof useRequestAccessMutation>;
+export type RequestAccessMutationResult = Apollo.MutationResult<Types.RequestAccessMutation>;
+export type RequestAccessMutationOptions = Apollo.BaseMutationOptions<Types.RequestAccessMutation, Types.RequestAccessMutationVariables>;
 export const ModifyClearbitIntegrationDocument = gql`
-	mutation ModifyClearbitIntegration($workspace_id: ID!, $enabled: Boolean!) {
-		modifyClearbitIntegration(
-			workspace_id: $workspace_id
-			enabled: $enabled
-		)
-	}
-`
-export type ModifyClearbitIntegrationMutationFn = Apollo.MutationFunction<
-	Types.ModifyClearbitIntegrationMutation,
-	Types.ModifyClearbitIntegrationMutationVariables
->
+    mutation ModifyClearbitIntegration($workspace_id: ID!, $enabled: Boolean!) {
+  modifyClearbitIntegration(workspace_id: $workspace_id, enabled: $enabled)
+}
+    `;
+export type ModifyClearbitIntegrationMutationFn = Apollo.MutationFunction<Types.ModifyClearbitIntegrationMutation, Types.ModifyClearbitIntegrationMutationVariables>;
 
 /**
  * __useModifyClearbitIntegrationMutation__
@@ -4352,50 +2915,25 @@ export type ModifyClearbitIntegrationMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useModifyClearbitIntegrationMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.ModifyClearbitIntegrationMutation,
-		Types.ModifyClearbitIntegrationMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.ModifyClearbitIntegrationMutation,
-		Types.ModifyClearbitIntegrationMutationVariables
-	>(ModifyClearbitIntegrationDocument, baseOptions)
-}
-export type ModifyClearbitIntegrationMutationHookResult = ReturnType<
-	typeof useModifyClearbitIntegrationMutation
->
-export type ModifyClearbitIntegrationMutationResult =
-	Apollo.MutationResult<Types.ModifyClearbitIntegrationMutation>
-export type ModifyClearbitIntegrationMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.ModifyClearbitIntegrationMutation,
-		Types.ModifyClearbitIntegrationMutationVariables
-	>
+export function useModifyClearbitIntegrationMutation(baseOptions?: Apollo.MutationHookOptions<Types.ModifyClearbitIntegrationMutation, Types.ModifyClearbitIntegrationMutationVariables>) {
+        return Apollo.useMutation<Types.ModifyClearbitIntegrationMutation, Types.ModifyClearbitIntegrationMutationVariables>(ModifyClearbitIntegrationDocument, baseOptions);
+      }
+export type ModifyClearbitIntegrationMutationHookResult = ReturnType<typeof useModifyClearbitIntegrationMutation>;
+export type ModifyClearbitIntegrationMutationResult = Apollo.MutationResult<Types.ModifyClearbitIntegrationMutation>;
+export type ModifyClearbitIntegrationMutationOptions = Apollo.BaseMutationOptions<Types.ModifyClearbitIntegrationMutation, Types.ModifyClearbitIntegrationMutationVariables>;
 export const UpsertDashboardDocument = gql`
-	mutation UpsertDashboard(
-		$id: ID
-		$project_id: ID!
-		$name: String!
-		$metrics: [DashboardMetricConfigInput!]!
-		$layout: String
-		$is_default: Boolean
-	) {
-		upsertDashboard(
-			id: $id
-			project_id: $project_id
-			name: $name
-			metrics: $metrics
-			layout: $layout
-			is_default: $is_default
-		)
-	}
-`
-export type UpsertDashboardMutationFn = Apollo.MutationFunction<
-	Types.UpsertDashboardMutation,
-	Types.UpsertDashboardMutationVariables
->
+    mutation UpsertDashboard($id: ID, $project_id: ID!, $name: String!, $metrics: [DashboardMetricConfigInput!]!, $layout: String, $is_default: Boolean) {
+  upsertDashboard(
+    id: $id
+    project_id: $project_id
+    name: $name
+    metrics: $metrics
+    layout: $layout
+    is_default: $is_default
+  )
+}
+    `;
+export type UpsertDashboardMutationFn = Apollo.MutationFunction<Types.UpsertDashboardMutation, Types.UpsertDashboardMutationVariables>;
 
 /**
  * __useUpsertDashboardMutation__
@@ -4419,35 +2957,18 @@ export type UpsertDashboardMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpsertDashboardMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpsertDashboardMutation,
-		Types.UpsertDashboardMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpsertDashboardMutation,
-		Types.UpsertDashboardMutationVariables
-	>(UpsertDashboardDocument, baseOptions)
-}
-export type UpsertDashboardMutationHookResult = ReturnType<
-	typeof useUpsertDashboardMutation
->
-export type UpsertDashboardMutationResult =
-	Apollo.MutationResult<Types.UpsertDashboardMutation>
-export type UpsertDashboardMutationOptions = Apollo.BaseMutationOptions<
-	Types.UpsertDashboardMutation,
-	Types.UpsertDashboardMutationVariables
->
+export function useUpsertDashboardMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpsertDashboardMutation, Types.UpsertDashboardMutationVariables>) {
+        return Apollo.useMutation<Types.UpsertDashboardMutation, Types.UpsertDashboardMutationVariables>(UpsertDashboardDocument, baseOptions);
+      }
+export type UpsertDashboardMutationHookResult = ReturnType<typeof useUpsertDashboardMutation>;
+export type UpsertDashboardMutationResult = Apollo.MutationResult<Types.UpsertDashboardMutation>;
+export type UpsertDashboardMutationOptions = Apollo.BaseMutationOptions<Types.UpsertDashboardMutation, Types.UpsertDashboardMutationVariables>;
 export const DeleteDashboardDocument = gql`
-	mutation DeleteDashboard($id: ID!) {
-		deleteDashboard(id: $id)
-	}
-`
-export type DeleteDashboardMutationFn = Apollo.MutationFunction<
-	Types.DeleteDashboardMutation,
-	Types.DeleteDashboardMutationVariables
->
+    mutation DeleteDashboard($id: ID!) {
+  deleteDashboard(id: $id)
+}
+    `;
+export type DeleteDashboardMutationFn = Apollo.MutationFunction<Types.DeleteDashboardMutation, Types.DeleteDashboardMutationVariables>;
 
 /**
  * __useDeleteDashboardMutation__
@@ -4466,43 +2987,22 @@ export type DeleteDashboardMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteDashboardMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteDashboardMutation,
-		Types.DeleteDashboardMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteDashboardMutation,
-		Types.DeleteDashboardMutationVariables
-	>(DeleteDashboardDocument, baseOptions)
-}
-export type DeleteDashboardMutationHookResult = ReturnType<
-	typeof useDeleteDashboardMutation
->
-export type DeleteDashboardMutationResult =
-	Apollo.MutationResult<Types.DeleteDashboardMutation>
-export type DeleteDashboardMutationOptions = Apollo.BaseMutationOptions<
-	Types.DeleteDashboardMutation,
-	Types.DeleteDashboardMutationVariables
->
+export function useDeleteDashboardMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteDashboardMutation, Types.DeleteDashboardMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteDashboardMutation, Types.DeleteDashboardMutationVariables>(DeleteDashboardDocument, baseOptions);
+      }
+export type DeleteDashboardMutationHookResult = ReturnType<typeof useDeleteDashboardMutation>;
+export type DeleteDashboardMutationResult = Apollo.MutationResult<Types.DeleteDashboardMutation>;
+export type DeleteDashboardMutationOptions = Apollo.BaseMutationOptions<Types.DeleteDashboardMutation, Types.DeleteDashboardMutationVariables>;
 export const DeleteSessionsDocument = gql`
-	mutation DeleteSessions(
-		$project_id: ID!
-		$query: String!
-		$sessionCount: Int!
-	) {
-		deleteSessions(
-			project_id: $project_id
-			query: $query
-			sessionCount: $sessionCount
-		)
-	}
-`
-export type DeleteSessionsMutationFn = Apollo.MutationFunction<
-	Types.DeleteSessionsMutation,
-	Types.DeleteSessionsMutationVariables
->
+    mutation DeleteSessions($project_id: ID!, $query: String!, $sessionCount: Int!) {
+  deleteSessions(
+    project_id: $project_id
+    query: $query
+    sessionCount: $sessionCount
+  )
+}
+    `;
+export type DeleteSessionsMutationFn = Apollo.MutationFunction<Types.DeleteSessionsMutation, Types.DeleteSessionsMutationVariables>;
 
 /**
  * __useDeleteSessionsMutation__
@@ -4523,41 +3023,21 @@ export type DeleteSessionsMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteSessionsMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteSessionsMutation,
-		Types.DeleteSessionsMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteSessionsMutation,
-		Types.DeleteSessionsMutationVariables
-	>(DeleteSessionsDocument, baseOptions)
-}
-export type DeleteSessionsMutationHookResult = ReturnType<
-	typeof useDeleteSessionsMutation
->
-export type DeleteSessionsMutationResult =
-	Apollo.MutationResult<Types.DeleteSessionsMutation>
-export type DeleteSessionsMutationOptions = Apollo.BaseMutationOptions<
-	Types.DeleteSessionsMutation,
-	Types.DeleteSessionsMutationVariables
->
+export function useDeleteSessionsMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteSessionsMutation, Types.DeleteSessionsMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteSessionsMutation, Types.DeleteSessionsMutationVariables>(DeleteSessionsDocument, baseOptions);
+      }
+export type DeleteSessionsMutationHookResult = ReturnType<typeof useDeleteSessionsMutation>;
+export type DeleteSessionsMutationResult = Apollo.MutationResult<Types.DeleteSessionsMutation>;
+export type DeleteSessionsMutationOptions = Apollo.BaseMutationOptions<Types.DeleteSessionsMutation, Types.DeleteSessionsMutationVariables>;
 export const UpdateVercelSettingsDocument = gql`
-	mutation UpdateVercelSettings(
-		$project_id: ID!
-		$project_mappings: [VercelProjectMappingInput!]!
-	) {
-		updateVercelProjectMappings(
-			project_id: $project_id
-			project_mappings: $project_mappings
-		)
-	}
-`
-export type UpdateVercelSettingsMutationFn = Apollo.MutationFunction<
-	Types.UpdateVercelSettingsMutation,
-	Types.UpdateVercelSettingsMutationVariables
->
+    mutation UpdateVercelSettings($project_id: ID!, $project_mappings: [VercelProjectMappingInput!]!) {
+  updateVercelProjectMappings(
+    project_id: $project_id
+    project_mappings: $project_mappings
+  )
+}
+    `;
+export type UpdateVercelSettingsMutationFn = Apollo.MutationFunction<Types.UpdateVercelSettingsMutation, Types.UpdateVercelSettingsMutationVariables>;
 
 /**
  * __useUpdateVercelSettingsMutation__
@@ -4577,41 +3057,21 @@ export type UpdateVercelSettingsMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateVercelSettingsMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateVercelSettingsMutation,
-		Types.UpdateVercelSettingsMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateVercelSettingsMutation,
-		Types.UpdateVercelSettingsMutationVariables
-	>(UpdateVercelSettingsDocument, baseOptions)
-}
-export type UpdateVercelSettingsMutationHookResult = ReturnType<
-	typeof useUpdateVercelSettingsMutation
->
-export type UpdateVercelSettingsMutationResult =
-	Apollo.MutationResult<Types.UpdateVercelSettingsMutation>
-export type UpdateVercelSettingsMutationOptions = Apollo.BaseMutationOptions<
-	Types.UpdateVercelSettingsMutation,
-	Types.UpdateVercelSettingsMutationVariables
->
+export function useUpdateVercelSettingsMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateVercelSettingsMutation, Types.UpdateVercelSettingsMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateVercelSettingsMutation, Types.UpdateVercelSettingsMutationVariables>(UpdateVercelSettingsDocument, baseOptions);
+      }
+export type UpdateVercelSettingsMutationHookResult = ReturnType<typeof useUpdateVercelSettingsMutation>;
+export type UpdateVercelSettingsMutationResult = Apollo.MutationResult<Types.UpdateVercelSettingsMutation>;
+export type UpdateVercelSettingsMutationOptions = Apollo.BaseMutationOptions<Types.UpdateVercelSettingsMutation, Types.UpdateVercelSettingsMutationVariables>;
 export const UpdateClickUpSettingsDocument = gql`
-	mutation UpdateClickUpSettings(
-		$workspace_id: ID!
-		$project_mappings: [ClickUpProjectMappingInput!]!
-	) {
-		updateClickUpProjectMappings(
-			workspace_id: $workspace_id
-			project_mappings: $project_mappings
-		)
-	}
-`
-export type UpdateClickUpSettingsMutationFn = Apollo.MutationFunction<
-	Types.UpdateClickUpSettingsMutation,
-	Types.UpdateClickUpSettingsMutationVariables
->
+    mutation UpdateClickUpSettings($workspace_id: ID!, $project_mappings: [ClickUpProjectMappingInput!]!) {
+  updateClickUpProjectMappings(
+    workspace_id: $workspace_id
+    project_mappings: $project_mappings
+  )
+}
+    `;
+export type UpdateClickUpSettingsMutationFn = Apollo.MutationFunction<Types.UpdateClickUpSettingsMutation, Types.UpdateClickUpSettingsMutationVariables>;
 
 /**
  * __useUpdateClickUpSettingsMutation__
@@ -4631,44 +3091,22 @@ export type UpdateClickUpSettingsMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateClickUpSettingsMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateClickUpSettingsMutation,
-		Types.UpdateClickUpSettingsMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateClickUpSettingsMutation,
-		Types.UpdateClickUpSettingsMutationVariables
-	>(UpdateClickUpSettingsDocument, baseOptions)
-}
-export type UpdateClickUpSettingsMutationHookResult = ReturnType<
-	typeof useUpdateClickUpSettingsMutation
->
-export type UpdateClickUpSettingsMutationResult =
-	Apollo.MutationResult<Types.UpdateClickUpSettingsMutation>
-export type UpdateClickUpSettingsMutationOptions = Apollo.BaseMutationOptions<
-	Types.UpdateClickUpSettingsMutation,
-	Types.UpdateClickUpSettingsMutationVariables
->
+export function useUpdateClickUpSettingsMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateClickUpSettingsMutation, Types.UpdateClickUpSettingsMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateClickUpSettingsMutation, Types.UpdateClickUpSettingsMutationVariables>(UpdateClickUpSettingsDocument, baseOptions);
+      }
+export type UpdateClickUpSettingsMutationHookResult = ReturnType<typeof useUpdateClickUpSettingsMutation>;
+export type UpdateClickUpSettingsMutationResult = Apollo.MutationResult<Types.UpdateClickUpSettingsMutation>;
+export type UpdateClickUpSettingsMutationOptions = Apollo.BaseMutationOptions<Types.UpdateClickUpSettingsMutation, Types.UpdateClickUpSettingsMutationVariables>;
 export const UpdateIntegrationProjectSettingsDocument = gql`
-	mutation UpdateIntegrationProjectSettings(
-		$workspace_id: ID!
-		$integration_type: IntegrationType!
-		$project_mappings: [IntegrationProjectMappingInput!]!
-	) {
-		updateIntegrationProjectMappings(
-			workspace_id: $workspace_id
-			integration_type: $integration_type
-			project_mappings: $project_mappings
-		)
-	}
-`
-export type UpdateIntegrationProjectSettingsMutationFn =
-	Apollo.MutationFunction<
-		Types.UpdateIntegrationProjectSettingsMutation,
-		Types.UpdateIntegrationProjectSettingsMutationVariables
-	>
+    mutation UpdateIntegrationProjectSettings($workspace_id: ID!, $integration_type: IntegrationType!, $project_mappings: [IntegrationProjectMappingInput!]!) {
+  updateIntegrationProjectMappings(
+    workspace_id: $workspace_id
+    integration_type: $integration_type
+    project_mappings: $project_mappings
+  )
+}
+    `;
+export type UpdateIntegrationProjectSettingsMutationFn = Apollo.MutationFunction<Types.UpdateIntegrationProjectSettingsMutation, Types.UpdateIntegrationProjectSettingsMutationVariables>;
 
 /**
  * __useUpdateIntegrationProjectSettingsMutation__
@@ -4689,46 +3127,23 @@ export type UpdateIntegrationProjectSettingsMutationFn =
  *   },
  * });
  */
-export function useUpdateIntegrationProjectSettingsMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateIntegrationProjectSettingsMutation,
-		Types.UpdateIntegrationProjectSettingsMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateIntegrationProjectSettingsMutation,
-		Types.UpdateIntegrationProjectSettingsMutationVariables
-	>(UpdateIntegrationProjectSettingsDocument, baseOptions)
-}
-export type UpdateIntegrationProjectSettingsMutationHookResult = ReturnType<
-	typeof useUpdateIntegrationProjectSettingsMutation
->
-export type UpdateIntegrationProjectSettingsMutationResult =
-	Apollo.MutationResult<Types.UpdateIntegrationProjectSettingsMutation>
-export type UpdateIntegrationProjectSettingsMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.UpdateIntegrationProjectSettingsMutation,
-		Types.UpdateIntegrationProjectSettingsMutationVariables
-	>
+export function useUpdateIntegrationProjectSettingsMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateIntegrationProjectSettingsMutation, Types.UpdateIntegrationProjectSettingsMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateIntegrationProjectSettingsMutation, Types.UpdateIntegrationProjectSettingsMutationVariables>(UpdateIntegrationProjectSettingsDocument, baseOptions);
+      }
+export type UpdateIntegrationProjectSettingsMutationHookResult = ReturnType<typeof useUpdateIntegrationProjectSettingsMutation>;
+export type UpdateIntegrationProjectSettingsMutationResult = Apollo.MutationResult<Types.UpdateIntegrationProjectSettingsMutation>;
+export type UpdateIntegrationProjectSettingsMutationOptions = Apollo.BaseMutationOptions<Types.UpdateIntegrationProjectSettingsMutation, Types.UpdateIntegrationProjectSettingsMutationVariables>;
 export const UpdateEmailOptOutDocument = gql`
-	mutation UpdateEmailOptOut(
-		$token: String
-		$admin_id: ID
-		$category: EmailOptOutCategory!
-		$is_opt_out: Boolean!
-	) {
-		updateEmailOptOut(
-			token: $token
-			admin_id: $admin_id
-			category: $category
-			is_opt_out: $is_opt_out
-		)
-	}
-`
-export type UpdateEmailOptOutMutationFn = Apollo.MutationFunction<
-	Types.UpdateEmailOptOutMutation,
-	Types.UpdateEmailOptOutMutationVariables
->
+    mutation UpdateEmailOptOut($token: String, $admin_id: ID, $category: EmailOptOutCategory!, $is_opt_out: Boolean!) {
+  updateEmailOptOut(
+    token: $token
+    admin_id: $admin_id
+    category: $category
+    is_opt_out: $is_opt_out
+  )
+}
+    `;
+export type UpdateEmailOptOutMutationFn = Apollo.MutationFunction<Types.UpdateEmailOptOutMutation, Types.UpdateEmailOptOutMutationVariables>;
 
 /**
  * __useUpdateEmailOptOutMutation__
@@ -4750,41 +3165,21 @@ export type UpdateEmailOptOutMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useUpdateEmailOptOutMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.UpdateEmailOptOutMutation,
-		Types.UpdateEmailOptOutMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.UpdateEmailOptOutMutation,
-		Types.UpdateEmailOptOutMutationVariables
-	>(UpdateEmailOptOutDocument, baseOptions)
-}
-export type UpdateEmailOptOutMutationHookResult = ReturnType<
-	typeof useUpdateEmailOptOutMutation
->
-export type UpdateEmailOptOutMutationResult =
-	Apollo.MutationResult<Types.UpdateEmailOptOutMutation>
-export type UpdateEmailOptOutMutationOptions = Apollo.BaseMutationOptions<
-	Types.UpdateEmailOptOutMutation,
-	Types.UpdateEmailOptOutMutationVariables
->
+export function useUpdateEmailOptOutMutation(baseOptions?: Apollo.MutationHookOptions<Types.UpdateEmailOptOutMutation, Types.UpdateEmailOptOutMutationVariables>) {
+        return Apollo.useMutation<Types.UpdateEmailOptOutMutation, Types.UpdateEmailOptOutMutationVariables>(UpdateEmailOptOutDocument, baseOptions);
+      }
+export type UpdateEmailOptOutMutationHookResult = ReturnType<typeof useUpdateEmailOptOutMutation>;
+export type UpdateEmailOptOutMutationResult = Apollo.MutationResult<Types.UpdateEmailOptOutMutation>;
+export type UpdateEmailOptOutMutationOptions = Apollo.BaseMutationOptions<Types.UpdateEmailOptOutMutation, Types.UpdateEmailOptOutMutationVariables>;
 export const DeleteInviteLinkFromWorkspaceDocument = gql`
-	mutation DeleteInviteLinkFromWorkspace(
-		$workspace_id: ID!
-		$workspace_invite_link_id: ID!
-	) {
-		deleteInviteLinkFromWorkspace(
-			workspace_id: $workspace_id
-			workspace_invite_link_id: $workspace_invite_link_id
-		)
-	}
-`
-export type DeleteInviteLinkFromWorkspaceMutationFn = Apollo.MutationFunction<
-	Types.DeleteInviteLinkFromWorkspaceMutation,
-	Types.DeleteInviteLinkFromWorkspaceMutationVariables
->
+    mutation DeleteInviteLinkFromWorkspace($workspace_id: ID!, $workspace_invite_link_id: ID!) {
+  deleteInviteLinkFromWorkspace(
+    workspace_id: $workspace_id
+    workspace_invite_link_id: $workspace_invite_link_id
+  )
+}
+    `;
+export type DeleteInviteLinkFromWorkspaceMutationFn = Apollo.MutationFunction<Types.DeleteInviteLinkFromWorkspaceMutation, Types.DeleteInviteLinkFromWorkspaceMutationVariables>;
 
 /**
  * __useDeleteInviteLinkFromWorkspaceMutation__
@@ -4804,45 +3199,26 @@ export type DeleteInviteLinkFromWorkspaceMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useDeleteInviteLinkFromWorkspaceMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.DeleteInviteLinkFromWorkspaceMutation,
-		Types.DeleteInviteLinkFromWorkspaceMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.DeleteInviteLinkFromWorkspaceMutation,
-		Types.DeleteInviteLinkFromWorkspaceMutationVariables
-	>(DeleteInviteLinkFromWorkspaceDocument, baseOptions)
-}
-export type DeleteInviteLinkFromWorkspaceMutationHookResult = ReturnType<
-	typeof useDeleteInviteLinkFromWorkspaceMutation
->
-export type DeleteInviteLinkFromWorkspaceMutationResult =
-	Apollo.MutationResult<Types.DeleteInviteLinkFromWorkspaceMutation>
-export type DeleteInviteLinkFromWorkspaceMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.DeleteInviteLinkFromWorkspaceMutation,
-		Types.DeleteInviteLinkFromWorkspaceMutationVariables
-	>
+export function useDeleteInviteLinkFromWorkspaceMutation(baseOptions?: Apollo.MutationHookOptions<Types.DeleteInviteLinkFromWorkspaceMutation, Types.DeleteInviteLinkFromWorkspaceMutationVariables>) {
+        return Apollo.useMutation<Types.DeleteInviteLinkFromWorkspaceMutation, Types.DeleteInviteLinkFromWorkspaceMutationVariables>(DeleteInviteLinkFromWorkspaceDocument, baseOptions);
+      }
+export type DeleteInviteLinkFromWorkspaceMutationHookResult = ReturnType<typeof useDeleteInviteLinkFromWorkspaceMutation>;
+export type DeleteInviteLinkFromWorkspaceMutationResult = Apollo.MutationResult<Types.DeleteInviteLinkFromWorkspaceMutation>;
+export type DeleteInviteLinkFromWorkspaceMutationOptions = Apollo.BaseMutationOptions<Types.DeleteInviteLinkFromWorkspaceMutation, Types.DeleteInviteLinkFromWorkspaceMutationVariables>;
 export const GetMetricsTimelineDocument = gql`
-	query GetMetricsTimeline(
-		$project_id: ID!
-		$metric_name: String!
-		$params: DashboardParamsInput!
-	) {
-		metrics_timeline(
-			project_id: $project_id
-			metric_name: $metric_name
-			params: $params
-		) {
-			date
-			value
-			aggregator
-			group
-		}
-	}
-`
+    query GetMetricsTimeline($project_id: ID!, $metric_name: String!, $params: DashboardParamsInput!) {
+  metrics_timeline(
+    project_id: $project_id
+    metric_name: $metric_name
+    params: $params
+  ) {
+    date
+    value
+    aggregator
+    group
+  }
+}
+    `;
 
 /**
  * __useGetMetricsTimelineQuery__
@@ -4862,60 +3238,33 @@ export const GetMetricsTimelineDocument = gql`
  *   },
  * });
  */
-export function useGetMetricsTimelineQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetMetricsTimelineQuery,
-		Types.GetMetricsTimelineQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetMetricsTimelineQuery,
-		Types.GetMetricsTimelineQueryVariables
-	>(GetMetricsTimelineDocument, baseOptions)
-}
-export function useGetMetricsTimelineLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetMetricsTimelineQuery,
-		Types.GetMetricsTimelineQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetMetricsTimelineQuery,
-		Types.GetMetricsTimelineQueryVariables
-	>(GetMetricsTimelineDocument, baseOptions)
-}
-export type GetMetricsTimelineQueryHookResult = ReturnType<
-	typeof useGetMetricsTimelineQuery
->
-export type GetMetricsTimelineLazyQueryHookResult = ReturnType<
-	typeof useGetMetricsTimelineLazyQuery
->
-export type GetMetricsTimelineQueryResult = Apollo.QueryResult<
-	Types.GetMetricsTimelineQuery,
-	Types.GetMetricsTimelineQueryVariables
->
+export function useGetMetricsTimelineQuery(baseOptions: Apollo.QueryHookOptions<Types.GetMetricsTimelineQuery, Types.GetMetricsTimelineQueryVariables>) {
+        return Apollo.useQuery<Types.GetMetricsTimelineQuery, Types.GetMetricsTimelineQueryVariables>(GetMetricsTimelineDocument, baseOptions);
+      }
+export function useGetMetricsTimelineLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetMetricsTimelineQuery, Types.GetMetricsTimelineQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetMetricsTimelineQuery, Types.GetMetricsTimelineQueryVariables>(GetMetricsTimelineDocument, baseOptions);
+        }
+export type GetMetricsTimelineQueryHookResult = ReturnType<typeof useGetMetricsTimelineQuery>;
+export type GetMetricsTimelineLazyQueryHookResult = ReturnType<typeof useGetMetricsTimelineLazyQuery>;
+export type GetMetricsTimelineQueryResult = Apollo.QueryResult<Types.GetMetricsTimelineQuery, Types.GetMetricsTimelineQueryVariables>;
 export const GetMetricsHistogramDocument = gql`
-	query GetMetricsHistogram(
-		$project_id: ID!
-		$metric_name: String!
-		$params: HistogramParamsInput!
-	) {
-		metrics_histogram(
-			project_id: $project_id
-			metric_name: $metric_name
-			params: $params
-		) {
-			buckets {
-				bucket
-				range_start
-				range_end
-				count
-			}
-			min
-			max
-		}
-	}
-`
+    query GetMetricsHistogram($project_id: ID!, $metric_name: String!, $params: HistogramParamsInput!) {
+  metrics_histogram(
+    project_id: $project_id
+    metric_name: $metric_name
+    params: $params
+  ) {
+    buckets {
+      bucket
+      range_start
+      range_end
+      count
+    }
+    min
+    max
+  }
+}
+    `;
 
 /**
  * __useGetMetricsHistogramQuery__
@@ -4935,51 +3284,25 @@ export const GetMetricsHistogramDocument = gql`
  *   },
  * });
  */
-export function useGetMetricsHistogramQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetMetricsHistogramQuery,
-		Types.GetMetricsHistogramQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetMetricsHistogramQuery,
-		Types.GetMetricsHistogramQueryVariables
-	>(GetMetricsHistogramDocument, baseOptions)
-}
-export function useGetMetricsHistogramLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetMetricsHistogramQuery,
-		Types.GetMetricsHistogramQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetMetricsHistogramQuery,
-		Types.GetMetricsHistogramQueryVariables
-	>(GetMetricsHistogramDocument, baseOptions)
-}
-export type GetMetricsHistogramQueryHookResult = ReturnType<
-	typeof useGetMetricsHistogramQuery
->
-export type GetMetricsHistogramLazyQueryHookResult = ReturnType<
-	typeof useGetMetricsHistogramLazyQuery
->
-export type GetMetricsHistogramQueryResult = Apollo.QueryResult<
-	Types.GetMetricsHistogramQuery,
-	Types.GetMetricsHistogramQueryVariables
->
+export function useGetMetricsHistogramQuery(baseOptions: Apollo.QueryHookOptions<Types.GetMetricsHistogramQuery, Types.GetMetricsHistogramQueryVariables>) {
+        return Apollo.useQuery<Types.GetMetricsHistogramQuery, Types.GetMetricsHistogramQueryVariables>(GetMetricsHistogramDocument, baseOptions);
+      }
+export function useGetMetricsHistogramLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetMetricsHistogramQuery, Types.GetMetricsHistogramQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetMetricsHistogramQuery, Types.GetMetricsHistogramQueryVariables>(GetMetricsHistogramDocument, baseOptions);
+        }
+export type GetMetricsHistogramQueryHookResult = ReturnType<typeof useGetMetricsHistogramQuery>;
+export type GetMetricsHistogramLazyQueryHookResult = ReturnType<typeof useGetMetricsHistogramLazyQuery>;
+export type GetMetricsHistogramQueryResult = Apollo.QueryResult<Types.GetMetricsHistogramQuery, Types.GetMetricsHistogramQueryVariables>;
 export const GetNetworkHistogramDocument = gql`
-	query GetNetworkHistogram(
-		$project_id: ID!
-		$params: NetworkHistogramParamsInput!
-	) {
-		network_histogram(project_id: $project_id, params: $params) {
-			buckets {
-				category
-				count
-			}
-		}
-	}
-`
+    query GetNetworkHistogram($project_id: ID!, $params: NetworkHistogramParamsInput!) {
+  network_histogram(project_id: $project_id, params: $params) {
+    buckets {
+      category
+      count
+    }
+  }
+}
+    `;
 
 /**
  * __useGetNetworkHistogramQuery__
@@ -4998,96 +3321,70 @@ export const GetNetworkHistogramDocument = gql`
  *   },
  * });
  */
-export function useGetNetworkHistogramQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetNetworkHistogramQuery,
-		Types.GetNetworkHistogramQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetNetworkHistogramQuery,
-		Types.GetNetworkHistogramQueryVariables
-	>(GetNetworkHistogramDocument, baseOptions)
-}
-export function useGetNetworkHistogramLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetNetworkHistogramQuery,
-		Types.GetNetworkHistogramQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetNetworkHistogramQuery,
-		Types.GetNetworkHistogramQueryVariables
-	>(GetNetworkHistogramDocument, baseOptions)
-}
-export type GetNetworkHistogramQueryHookResult = ReturnType<
-	typeof useGetNetworkHistogramQuery
->
-export type GetNetworkHistogramLazyQueryHookResult = ReturnType<
-	typeof useGetNetworkHistogramLazyQuery
->
-export type GetNetworkHistogramQueryResult = Apollo.QueryResult<
-	Types.GetNetworkHistogramQuery,
-	Types.GetNetworkHistogramQueryVariables
->
+export function useGetNetworkHistogramQuery(baseOptions: Apollo.QueryHookOptions<Types.GetNetworkHistogramQuery, Types.GetNetworkHistogramQueryVariables>) {
+        return Apollo.useQuery<Types.GetNetworkHistogramQuery, Types.GetNetworkHistogramQueryVariables>(GetNetworkHistogramDocument, baseOptions);
+      }
+export function useGetNetworkHistogramLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetNetworkHistogramQuery, Types.GetNetworkHistogramQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetNetworkHistogramQuery, Types.GetNetworkHistogramQueryVariables>(GetNetworkHistogramDocument, baseOptions);
+        }
+export type GetNetworkHistogramQueryHookResult = ReturnType<typeof useGetNetworkHistogramQuery>;
+export type GetNetworkHistogramLazyQueryHookResult = ReturnType<typeof useGetNetworkHistogramLazyQuery>;
+export type GetNetworkHistogramQueryResult = Apollo.QueryResult<Types.GetNetworkHistogramQuery, Types.GetNetworkHistogramQueryVariables>;
 export const GetSessionPayloadDocument = gql`
-	query GetSessionPayload(
-		$session_secure_id: String!
-		$skip_events: Boolean!
-	) {
-		events(session_secure_id: $session_secure_id) @skip(if: $skip_events)
-		errors(session_secure_id: $session_secure_id) {
-			id
-			error_group_secure_id
-			event
-			type
-			url
-			source
-			stack_trace
-			structured_stack_trace {
-				fileName
-				lineNumber
-				functionName
-				columnNumber
-			}
-			timestamp
-			payload
-			request_id
-		}
-		rage_clicks(session_secure_id: $session_secure_id) {
-			start_timestamp
-			end_timestamp
-			total_clicks
-		}
-		session_comments(session_secure_id: $session_secure_id) {
-			id
-			timestamp
-			session_id
-			session_secure_id
-			created_at
-			updated_at
-			project_id
-			text
-			author {
-				id
-				name
-				email
-				photo_url
-			}
-			x_coordinate
-			y_coordinate
-			type
-			metadata
-			tags
-			attachments {
-				id
-				integration_type
-				external_id
-				title
-			}
-		}
-	}
-`
+    query GetSessionPayload($session_secure_id: String!, $skip_events: Boolean!) {
+  events(session_secure_id: $session_secure_id) @skip(if: $skip_events)
+  errors(session_secure_id: $session_secure_id) {
+    id
+    error_group_secure_id
+    event
+    type
+    url
+    source
+    stack_trace
+    structured_stack_trace {
+      fileName
+      lineNumber
+      functionName
+      columnNumber
+    }
+    timestamp
+    payload
+    request_id
+  }
+  rage_clicks(session_secure_id: $session_secure_id) {
+    start_timestamp
+    end_timestamp
+    total_clicks
+  }
+  session_comments(session_secure_id: $session_secure_id) {
+    id
+    timestamp
+    session_id
+    session_secure_id
+    created_at
+    updated_at
+    project_id
+    text
+    author {
+      id
+      name
+      email
+      photo_url
+    }
+    x_coordinate
+    y_coordinate
+    type
+    metadata
+    tags
+    attachments {
+      id
+      integration_type
+      external_id
+      title
+    }
+  }
+}
+    `;
 
 /**
  * __useGetSessionPayloadQuery__
@@ -5106,46 +3403,23 @@ export const GetSessionPayloadDocument = gql`
  *   },
  * });
  */
-export function useGetSessionPayloadQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSessionPayloadQuery,
-		Types.GetSessionPayloadQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSessionPayloadQuery,
-		Types.GetSessionPayloadQueryVariables
-	>(GetSessionPayloadDocument, baseOptions)
-}
-export function useGetSessionPayloadLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSessionPayloadQuery,
-		Types.GetSessionPayloadQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSessionPayloadQuery,
-		Types.GetSessionPayloadQueryVariables
-	>(GetSessionPayloadDocument, baseOptions)
-}
-export type GetSessionPayloadQueryHookResult = ReturnType<
-	typeof useGetSessionPayloadQuery
->
-export type GetSessionPayloadLazyQueryHookResult = ReturnType<
-	typeof useGetSessionPayloadLazyQuery
->
-export type GetSessionPayloadQueryResult = Apollo.QueryResult<
-	Types.GetSessionPayloadQuery,
-	Types.GetSessionPayloadQueryVariables
->
+export function useGetSessionPayloadQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionPayloadQuery, Types.GetSessionPayloadQueryVariables>) {
+        return Apollo.useQuery<Types.GetSessionPayloadQuery, Types.GetSessionPayloadQueryVariables>(GetSessionPayloadDocument, baseOptions);
+      }
+export function useGetSessionPayloadLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionPayloadQuery, Types.GetSessionPayloadQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSessionPayloadQuery, Types.GetSessionPayloadQueryVariables>(GetSessionPayloadDocument, baseOptions);
+        }
+export type GetSessionPayloadQueryHookResult = ReturnType<typeof useGetSessionPayloadQuery>;
+export type GetSessionPayloadLazyQueryHookResult = ReturnType<typeof useGetSessionPayloadLazyQuery>;
+export type GetSessionPayloadQueryResult = Apollo.QueryResult<Types.GetSessionPayloadQuery, Types.GetSessionPayloadQueryVariables>;
 export const GetCommentTagsForProjectDocument = gql`
-	query GetCommentTagsForProject($project_id: ID!) {
-		session_comment_tags_for_project(project_id: $project_id) {
-			id
-			name
-		}
-	}
-`
+    query GetCommentTagsForProject($project_id: ID!) {
+  session_comment_tags_for_project(project_id: $project_id) {
+    id
+    name
+  }
+}
+    `;
 
 /**
  * __useGetCommentTagsForProjectQuery__
@@ -5163,43 +3437,20 @@ export const GetCommentTagsForProjectDocument = gql`
  *   },
  * });
  */
-export function useGetCommentTagsForProjectQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetCommentTagsForProjectQuery,
-		Types.GetCommentTagsForProjectQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetCommentTagsForProjectQuery,
-		Types.GetCommentTagsForProjectQueryVariables
-	>(GetCommentTagsForProjectDocument, baseOptions)
-}
-export function useGetCommentTagsForProjectLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetCommentTagsForProjectQuery,
-		Types.GetCommentTagsForProjectQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetCommentTagsForProjectQuery,
-		Types.GetCommentTagsForProjectQueryVariables
-	>(GetCommentTagsForProjectDocument, baseOptions)
-}
-export type GetCommentTagsForProjectQueryHookResult = ReturnType<
-	typeof useGetCommentTagsForProjectQuery
->
-export type GetCommentTagsForProjectLazyQueryHookResult = ReturnType<
-	typeof useGetCommentTagsForProjectLazyQuery
->
-export type GetCommentTagsForProjectQueryResult = Apollo.QueryResult<
-	Types.GetCommentTagsForProjectQuery,
-	Types.GetCommentTagsForProjectQueryVariables
->
+export function useGetCommentTagsForProjectQuery(baseOptions: Apollo.QueryHookOptions<Types.GetCommentTagsForProjectQuery, Types.GetCommentTagsForProjectQueryVariables>) {
+        return Apollo.useQuery<Types.GetCommentTagsForProjectQuery, Types.GetCommentTagsForProjectQueryVariables>(GetCommentTagsForProjectDocument, baseOptions);
+      }
+export function useGetCommentTagsForProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetCommentTagsForProjectQuery, Types.GetCommentTagsForProjectQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetCommentTagsForProjectQuery, Types.GetCommentTagsForProjectQueryVariables>(GetCommentTagsForProjectDocument, baseOptions);
+        }
+export type GetCommentTagsForProjectQueryHookResult = ReturnType<typeof useGetCommentTagsForProjectQuery>;
+export type GetCommentTagsForProjectLazyQueryHookResult = ReturnType<typeof useGetCommentTagsForProjectLazyQuery>;
+export type GetCommentTagsForProjectQueryResult = Apollo.QueryResult<Types.GetCommentTagsForProjectQuery, Types.GetCommentTagsForProjectQueryVariables>;
 export const GetEventChunkUrlDocument = gql`
-	query GetEventChunkURL($secure_id: String!, $index: Int!) {
-		event_chunk_url(secure_id: $secure_id, index: $index)
-	}
-`
+    query GetEventChunkURL($secure_id: String!, $index: Int!) {
+  event_chunk_url(secure_id: $secure_id, index: $index)
+}
+    `;
 
 /**
  * __useGetEventChunkUrlQuery__
@@ -5218,47 +3469,24 @@ export const GetEventChunkUrlDocument = gql`
  *   },
  * });
  */
-export function useGetEventChunkUrlQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetEventChunkUrlQuery,
-		Types.GetEventChunkUrlQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetEventChunkUrlQuery,
-		Types.GetEventChunkUrlQueryVariables
-	>(GetEventChunkUrlDocument, baseOptions)
-}
-export function useGetEventChunkUrlLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetEventChunkUrlQuery,
-		Types.GetEventChunkUrlQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetEventChunkUrlQuery,
-		Types.GetEventChunkUrlQueryVariables
-	>(GetEventChunkUrlDocument, baseOptions)
-}
-export type GetEventChunkUrlQueryHookResult = ReturnType<
-	typeof useGetEventChunkUrlQuery
->
-export type GetEventChunkUrlLazyQueryHookResult = ReturnType<
-	typeof useGetEventChunkUrlLazyQuery
->
-export type GetEventChunkUrlQueryResult = Apollo.QueryResult<
-	Types.GetEventChunkUrlQuery,
-	Types.GetEventChunkUrlQueryVariables
->
+export function useGetEventChunkUrlQuery(baseOptions: Apollo.QueryHookOptions<Types.GetEventChunkUrlQuery, Types.GetEventChunkUrlQueryVariables>) {
+        return Apollo.useQuery<Types.GetEventChunkUrlQuery, Types.GetEventChunkUrlQueryVariables>(GetEventChunkUrlDocument, baseOptions);
+      }
+export function useGetEventChunkUrlLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetEventChunkUrlQuery, Types.GetEventChunkUrlQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetEventChunkUrlQuery, Types.GetEventChunkUrlQueryVariables>(GetEventChunkUrlDocument, baseOptions);
+        }
+export type GetEventChunkUrlQueryHookResult = ReturnType<typeof useGetEventChunkUrlQuery>;
+export type GetEventChunkUrlLazyQueryHookResult = ReturnType<typeof useGetEventChunkUrlLazyQuery>;
+export type GetEventChunkUrlQueryResult = Apollo.QueryResult<Types.GetEventChunkUrlQuery, Types.GetEventChunkUrlQueryVariables>;
 export const GetEventChunksDocument = gql`
-	query GetEventChunks($secure_id: String!) {
-		event_chunks(secure_id: $secure_id) {
-			session_id
-			chunk_index
-			timestamp
-		}
-	}
-`
+    query GetEventChunks($secure_id: String!) {
+  event_chunks(secure_id: $secure_id) {
+    session_id
+    chunk_index
+    timestamp
+  }
+}
+    `;
 
 /**
  * __useGetEventChunksQuery__
@@ -5276,93 +3504,70 @@ export const GetEventChunksDocument = gql`
  *   },
  * });
  */
-export function useGetEventChunksQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetEventChunksQuery,
-		Types.GetEventChunksQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetEventChunksQuery,
-		Types.GetEventChunksQueryVariables
-	>(GetEventChunksDocument, baseOptions)
-}
-export function useGetEventChunksLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetEventChunksQuery,
-		Types.GetEventChunksQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetEventChunksQuery,
-		Types.GetEventChunksQueryVariables
-	>(GetEventChunksDocument, baseOptions)
-}
-export type GetEventChunksQueryHookResult = ReturnType<
-	typeof useGetEventChunksQuery
->
-export type GetEventChunksLazyQueryHookResult = ReturnType<
-	typeof useGetEventChunksLazyQuery
->
-export type GetEventChunksQueryResult = Apollo.QueryResult<
-	Types.GetEventChunksQuery,
-	Types.GetEventChunksQueryVariables
->
+export function useGetEventChunksQuery(baseOptions: Apollo.QueryHookOptions<Types.GetEventChunksQuery, Types.GetEventChunksQueryVariables>) {
+        return Apollo.useQuery<Types.GetEventChunksQuery, Types.GetEventChunksQueryVariables>(GetEventChunksDocument, baseOptions);
+      }
+export function useGetEventChunksLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetEventChunksQuery, Types.GetEventChunksQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetEventChunksQuery, Types.GetEventChunksQueryVariables>(GetEventChunksDocument, baseOptions);
+        }
+export type GetEventChunksQueryHookResult = ReturnType<typeof useGetEventChunksQuery>;
+export type GetEventChunksLazyQueryHookResult = ReturnType<typeof useGetEventChunksLazyQuery>;
+export type GetEventChunksQueryResult = Apollo.QueryResult<Types.GetEventChunksQuery, Types.GetEventChunksQueryVariables>;
 export const GetSessionDocument = gql`
-	query GetSession($secure_id: String!) {
-		session(secure_id: $secure_id) {
-			secure_id
-			os_name
-			os_version
-			browser_name
-			browser_version
-			environment
-			app_version
-			city
-			state
-			country
-			postal
-			fingerprint
-			created_at
-			payload_updated_at
-			language
-			user_object
-			user_properties
-			identifier
-			identified
-			client_id
-			starred
-			enable_strict_privacy
-			enable_recording_network_contents
-			field_group
-			fields {
-				name
-				value
-				type
-			}
-			object_storage_enabled
-			payload_size
-			processed
-			excluded
-			has_rage_clicks
-			has_errors
-			within_billing_quota
-			client_version
-			firstload_version
-			client_config
-			is_public
-			event_counts
-			direct_download_url
-			resources_url
-			timeline_indicators_url
-			deviceMemory
-			last_user_interaction_time
-			length
-			active_length
-			chunked
-		}
-	}
-`
+    query GetSession($secure_id: String!) {
+  session(secure_id: $secure_id) {
+    secure_id
+    os_name
+    os_version
+    browser_name
+    browser_version
+    environment
+    app_version
+    city
+    state
+    country
+    postal
+    fingerprint
+    created_at
+    payload_updated_at
+    language
+    user_object
+    user_properties
+    identifier
+    identified
+    client_id
+    starred
+    enable_strict_privacy
+    enable_recording_network_contents
+    field_group
+    fields {
+      name
+      value
+      type
+    }
+    object_storage_enabled
+    payload_size
+    processed
+    excluded
+    has_rage_clicks
+    has_errors
+    within_billing_quota
+    client_version
+    firstload_version
+    client_config
+    is_public
+    event_counts
+    direct_download_url
+    resources_url
+    timeline_indicators_url
+    deviceMemory
+    last_user_interaction_time
+    length
+    active_length
+    chunked
+  }
+}
+    `;
 
 /**
  * __useGetSessionQuery__
@@ -5380,49 +3585,28 @@ export const GetSessionDocument = gql`
  *   },
  * });
  */
-export function useGetSessionQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSessionQuery,
-		Types.GetSessionQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSessionQuery,
-		Types.GetSessionQueryVariables
-	>(GetSessionDocument, baseOptions)
-}
-export function useGetSessionLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSessionQuery,
-		Types.GetSessionQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSessionQuery,
-		Types.GetSessionQueryVariables
-	>(GetSessionDocument, baseOptions)
-}
-export type GetSessionQueryHookResult = ReturnType<typeof useGetSessionQuery>
-export type GetSessionLazyQueryHookResult = ReturnType<
-	typeof useGetSessionLazyQuery
->
-export type GetSessionQueryResult = Apollo.QueryResult<
-	Types.GetSessionQuery,
-	Types.GetSessionQueryVariables
->
+export function useGetSessionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionQuery, Types.GetSessionQueryVariables>) {
+        return Apollo.useQuery<Types.GetSessionQuery, Types.GetSessionQueryVariables>(GetSessionDocument, baseOptions);
+      }
+export function useGetSessionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionQuery, Types.GetSessionQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSessionQuery, Types.GetSessionQueryVariables>(GetSessionDocument, baseOptions);
+        }
+export type GetSessionQueryHookResult = ReturnType<typeof useGetSessionQuery>;
+export type GetSessionLazyQueryHookResult = ReturnType<typeof useGetSessionLazyQuery>;
+export type GetSessionQueryResult = Apollo.QueryResult<Types.GetSessionQuery, Types.GetSessionQueryVariables>;
 export const GetWorkspaceAdminsByProjectIdDocument = gql`
-	query GetWorkspaceAdminsByProjectId($project_id: ID!) {
-		admins: workspace_admins_by_project_id(project_id: $project_id) {
-			admin {
-				id
-				name
-				email
-				photo_url
-			}
-			role
-		}
-	}
-`
+    query GetWorkspaceAdminsByProjectId($project_id: ID!) {
+  admins: workspace_admins_by_project_id(project_id: $project_id) {
+    admin {
+      id
+      name
+      email
+      photo_url
+    }
+    role
+  }
+}
+    `;
 
 /**
  * __useGetWorkspaceAdminsByProjectIdQuery__
@@ -5440,64 +3624,41 @@ export const GetWorkspaceAdminsByProjectIdDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceAdminsByProjectIdQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspaceAdminsByProjectIdQuery,
-		Types.GetWorkspaceAdminsByProjectIdQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspaceAdminsByProjectIdQuery,
-		Types.GetWorkspaceAdminsByProjectIdQueryVariables
-	>(GetWorkspaceAdminsByProjectIdDocument, baseOptions)
-}
-export function useGetWorkspaceAdminsByProjectIdLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspaceAdminsByProjectIdQuery,
-		Types.GetWorkspaceAdminsByProjectIdQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspaceAdminsByProjectIdQuery,
-		Types.GetWorkspaceAdminsByProjectIdQueryVariables
-	>(GetWorkspaceAdminsByProjectIdDocument, baseOptions)
-}
-export type GetWorkspaceAdminsByProjectIdQueryHookResult = ReturnType<
-	typeof useGetWorkspaceAdminsByProjectIdQuery
->
-export type GetWorkspaceAdminsByProjectIdLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspaceAdminsByProjectIdLazyQuery
->
-export type GetWorkspaceAdminsByProjectIdQueryResult = Apollo.QueryResult<
-	Types.GetWorkspaceAdminsByProjectIdQuery,
-	Types.GetWorkspaceAdminsByProjectIdQueryVariables
->
+export function useGetWorkspaceAdminsByProjectIdQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceAdminsByProjectIdQuery, Types.GetWorkspaceAdminsByProjectIdQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspaceAdminsByProjectIdQuery, Types.GetWorkspaceAdminsByProjectIdQueryVariables>(GetWorkspaceAdminsByProjectIdDocument, baseOptions);
+      }
+export function useGetWorkspaceAdminsByProjectIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceAdminsByProjectIdQuery, Types.GetWorkspaceAdminsByProjectIdQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspaceAdminsByProjectIdQuery, Types.GetWorkspaceAdminsByProjectIdQueryVariables>(GetWorkspaceAdminsByProjectIdDocument, baseOptions);
+        }
+export type GetWorkspaceAdminsByProjectIdQueryHookResult = ReturnType<typeof useGetWorkspaceAdminsByProjectIdQuery>;
+export type GetWorkspaceAdminsByProjectIdLazyQueryHookResult = ReturnType<typeof useGetWorkspaceAdminsByProjectIdLazyQuery>;
+export type GetWorkspaceAdminsByProjectIdQueryResult = Apollo.QueryResult<Types.GetWorkspaceAdminsByProjectIdQuery, Types.GetWorkspaceAdminsByProjectIdQueryVariables>;
 export const GetWorkspaceAdminsDocument = gql`
-	query GetWorkspaceAdmins($workspace_id: ID!) {
-		admins: workspace_admins(workspace_id: $workspace_id) {
-			admin {
-				id
-				name
-				email
-				photo_url
-			}
-			role
-		}
-		workspace(id: $workspace_id) {
-			id
-			name
-			secret
-			allowed_auto_join_email_origins
-		}
-		workspace_invite_links(workspace_id: $workspace_id) {
-			id
-			invitee_email
-			invitee_role
-			expiration_date
-			secret
-		}
-	}
-`
+    query GetWorkspaceAdmins($workspace_id: ID!) {
+  admins: workspace_admins(workspace_id: $workspace_id) {
+    admin {
+      id
+      name
+      email
+      photo_url
+    }
+    role
+  }
+  workspace(id: $workspace_id) {
+    id
+    name
+    secret
+    allowed_auto_join_email_origins
+  }
+  workspace_invite_links(workspace_id: $workspace_id) {
+    id
+    invitee_email
+    invitee_role
+    expiration_date
+    secret
+  }
+}
+    `;
 
 /**
  * __useGetWorkspaceAdminsQuery__
@@ -5515,46 +3676,23 @@ export const GetWorkspaceAdminsDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceAdminsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspaceAdminsQuery,
-		Types.GetWorkspaceAdminsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspaceAdminsQuery,
-		Types.GetWorkspaceAdminsQueryVariables
-	>(GetWorkspaceAdminsDocument, baseOptions)
-}
-export function useGetWorkspaceAdminsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspaceAdminsQuery,
-		Types.GetWorkspaceAdminsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspaceAdminsQuery,
-		Types.GetWorkspaceAdminsQueryVariables
-	>(GetWorkspaceAdminsDocument, baseOptions)
-}
-export type GetWorkspaceAdminsQueryHookResult = ReturnType<
-	typeof useGetWorkspaceAdminsQuery
->
-export type GetWorkspaceAdminsLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspaceAdminsLazyQuery
->
-export type GetWorkspaceAdminsQueryResult = Apollo.QueryResult<
-	Types.GetWorkspaceAdminsQuery,
-	Types.GetWorkspaceAdminsQueryVariables
->
+export function useGetWorkspaceAdminsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceAdminsQuery, Types.GetWorkspaceAdminsQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspaceAdminsQuery, Types.GetWorkspaceAdminsQueryVariables>(GetWorkspaceAdminsDocument, baseOptions);
+      }
+export function useGetWorkspaceAdminsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceAdminsQuery, Types.GetWorkspaceAdminsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspaceAdminsQuery, Types.GetWorkspaceAdminsQueryVariables>(GetWorkspaceAdminsDocument, baseOptions);
+        }
+export type GetWorkspaceAdminsQueryHookResult = ReturnType<typeof useGetWorkspaceAdminsQuery>;
+export type GetWorkspaceAdminsLazyQueryHookResult = ReturnType<typeof useGetWorkspaceAdminsLazyQuery>;
+export type GetWorkspaceAdminsQueryResult = Apollo.QueryResult<Types.GetWorkspaceAdminsQuery, Types.GetWorkspaceAdminsQueryVariables>;
 export const GetSessionInsightDocument = gql`
-	query GetSessionInsight($secure_id: String!) {
-		session_insight(secure_id: $secure_id) {
-			id
-			insight
-		}
-	}
-`
+    query GetSessionInsight($secure_id: String!) {
+  session_insight(secure_id: $secure_id) {
+    id
+    insight
+  }
+}
+    `;
 
 /**
  * __useGetSessionInsightQuery__
@@ -5572,81 +3710,58 @@ export const GetSessionInsightDocument = gql`
  *   },
  * });
  */
-export function useGetSessionInsightQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSessionInsightQuery,
-		Types.GetSessionInsightQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSessionInsightQuery,
-		Types.GetSessionInsightQueryVariables
-	>(GetSessionInsightDocument, baseOptions)
-}
-export function useGetSessionInsightLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSessionInsightQuery,
-		Types.GetSessionInsightQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSessionInsightQuery,
-		Types.GetSessionInsightQueryVariables
-	>(GetSessionInsightDocument, baseOptions)
-}
-export type GetSessionInsightQueryHookResult = ReturnType<
-	typeof useGetSessionInsightQuery
->
-export type GetSessionInsightLazyQueryHookResult = ReturnType<
-	typeof useGetSessionInsightLazyQuery
->
-export type GetSessionInsightQueryResult = Apollo.QueryResult<
-	Types.GetSessionInsightQuery,
-	Types.GetSessionInsightQueryVariables
->
+export function useGetSessionInsightQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionInsightQuery, Types.GetSessionInsightQueryVariables>) {
+        return Apollo.useQuery<Types.GetSessionInsightQuery, Types.GetSessionInsightQueryVariables>(GetSessionInsightDocument, baseOptions);
+      }
+export function useGetSessionInsightLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionInsightQuery, Types.GetSessionInsightQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSessionInsightQuery, Types.GetSessionInsightQueryVariables>(GetSessionInsightDocument, baseOptions);
+        }
+export type GetSessionInsightQueryHookResult = ReturnType<typeof useGetSessionInsightQuery>;
+export type GetSessionInsightLazyQueryHookResult = ReturnType<typeof useGetSessionInsightLazyQuery>;
+export type GetSessionInsightQueryResult = Apollo.QueryResult<Types.GetSessionInsightQuery, Types.GetSessionInsightQueryVariables>;
 export const GetSessionCommentsDocument = gql`
-	query GetSessionComments($session_secure_id: String!) {
-		session_comments(session_secure_id: $session_secure_id) {
-			id
-			timestamp
-			session_id
-			session_secure_id
-			created_at
-			updated_at
-			project_id
-			text
-			author {
-				id
-				name
-				email
-				photo_url
-			}
-			x_coordinate
-			y_coordinate
-			type
-			metadata
-			tags
-			attachments {
-				id
-				integration_type
-				external_id
-				title
-			}
-			replies {
-				id
-				created_at
-				updated_at
-				author {
-					id
-					name
-					email
-					photo_url
-				}
-				text
-			}
-		}
-	}
-`
+    query GetSessionComments($session_secure_id: String!) {
+  session_comments(session_secure_id: $session_secure_id) {
+    id
+    timestamp
+    session_id
+    session_secure_id
+    created_at
+    updated_at
+    project_id
+    text
+    author {
+      id
+      name
+      email
+      photo_url
+    }
+    x_coordinate
+    y_coordinate
+    type
+    metadata
+    tags
+    attachments {
+      id
+      integration_type
+      external_id
+      title
+    }
+    replies {
+      id
+      created_at
+      updated_at
+      author {
+        id
+        name
+        email
+        photo_url
+      }
+      text
+    }
+  }
+}
+    `;
 
 /**
  * __useGetSessionCommentsQuery__
@@ -5664,56 +3779,33 @@ export const GetSessionCommentsDocument = gql`
  *   },
  * });
  */
-export function useGetSessionCommentsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSessionCommentsQuery,
-		Types.GetSessionCommentsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSessionCommentsQuery,
-		Types.GetSessionCommentsQueryVariables
-	>(GetSessionCommentsDocument, baseOptions)
-}
-export function useGetSessionCommentsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSessionCommentsQuery,
-		Types.GetSessionCommentsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSessionCommentsQuery,
-		Types.GetSessionCommentsQueryVariables
-	>(GetSessionCommentsDocument, baseOptions)
-}
-export type GetSessionCommentsQueryHookResult = ReturnType<
-	typeof useGetSessionCommentsQuery
->
-export type GetSessionCommentsLazyQueryHookResult = ReturnType<
-	typeof useGetSessionCommentsLazyQuery
->
-export type GetSessionCommentsQueryResult = Apollo.QueryResult<
-	Types.GetSessionCommentsQuery,
-	Types.GetSessionCommentsQueryVariables
->
+export function useGetSessionCommentsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionCommentsQuery, Types.GetSessionCommentsQueryVariables>) {
+        return Apollo.useQuery<Types.GetSessionCommentsQuery, Types.GetSessionCommentsQueryVariables>(GetSessionCommentsDocument, baseOptions);
+      }
+export function useGetSessionCommentsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionCommentsQuery, Types.GetSessionCommentsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSessionCommentsQuery, Types.GetSessionCommentsQueryVariables>(GetSessionCommentsDocument, baseOptions);
+        }
+export type GetSessionCommentsQueryHookResult = ReturnType<typeof useGetSessionCommentsQuery>;
+export type GetSessionCommentsLazyQueryHookResult = ReturnType<typeof useGetSessionCommentsLazyQuery>;
+export type GetSessionCommentsQueryResult = Apollo.QueryResult<Types.GetSessionCommentsQuery, Types.GetSessionCommentsQueryVariables>;
 export const GetSessionCommentsForAdminDocument = gql`
-	query GetSessionCommentsForAdmin {
-		session_comments_for_admin {
-			id
-			timestamp
-			created_at
-			project_id
-			updated_at
-			text
-			author {
-				id
-				name
-				email
-				photo_url
-			}
-		}
-	}
-`
+    query GetSessionCommentsForAdmin {
+  session_comments_for_admin {
+    id
+    timestamp
+    created_at
+    project_id
+    updated_at
+    text
+    author {
+      id
+      name
+      email
+      photo_url
+    }
+  }
+}
+    `;
 
 /**
  * __useGetSessionCommentsForAdminQuery__
@@ -5730,43 +3822,20 @@ export const GetSessionCommentsForAdminDocument = gql`
  *   },
  * });
  */
-export function useGetSessionCommentsForAdminQuery(
-	baseOptions?: Apollo.QueryHookOptions<
-		Types.GetSessionCommentsForAdminQuery,
-		Types.GetSessionCommentsForAdminQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSessionCommentsForAdminQuery,
-		Types.GetSessionCommentsForAdminQueryVariables
-	>(GetSessionCommentsForAdminDocument, baseOptions)
-}
-export function useGetSessionCommentsForAdminLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSessionCommentsForAdminQuery,
-		Types.GetSessionCommentsForAdminQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSessionCommentsForAdminQuery,
-		Types.GetSessionCommentsForAdminQueryVariables
-	>(GetSessionCommentsForAdminDocument, baseOptions)
-}
-export type GetSessionCommentsForAdminQueryHookResult = ReturnType<
-	typeof useGetSessionCommentsForAdminQuery
->
-export type GetSessionCommentsForAdminLazyQueryHookResult = ReturnType<
-	typeof useGetSessionCommentsForAdminLazyQuery
->
-export type GetSessionCommentsForAdminQueryResult = Apollo.QueryResult<
-	Types.GetSessionCommentsForAdminQuery,
-	Types.GetSessionCommentsForAdminQueryVariables
->
+export function useGetSessionCommentsForAdminQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetSessionCommentsForAdminQuery, Types.GetSessionCommentsForAdminQueryVariables>) {
+        return Apollo.useQuery<Types.GetSessionCommentsForAdminQuery, Types.GetSessionCommentsForAdminQueryVariables>(GetSessionCommentsForAdminDocument, baseOptions);
+      }
+export function useGetSessionCommentsForAdminLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionCommentsForAdminQuery, Types.GetSessionCommentsForAdminQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSessionCommentsForAdminQuery, Types.GetSessionCommentsForAdminQueryVariables>(GetSessionCommentsForAdminDocument, baseOptions);
+        }
+export type GetSessionCommentsForAdminQueryHookResult = ReturnType<typeof useGetSessionCommentsForAdminQuery>;
+export type GetSessionCommentsForAdminLazyQueryHookResult = ReturnType<typeof useGetSessionCommentsForAdminLazyQuery>;
+export type GetSessionCommentsForAdminQueryResult = Apollo.QueryResult<Types.GetSessionCommentsForAdminQuery, Types.GetSessionCommentsForAdminQueryVariables>;
 export const IsSessionPendingDocument = gql`
-	query isSessionPending($session_secure_id: String!) {
-		isSessionPending(session_secure_id: $session_secure_id)
-	}
-`
+    query isSessionPending($session_secure_id: String!) {
+  isSessionPending(session_secure_id: $session_secure_id)
+}
+    `;
 
 /**
  * __useIsSessionPendingQuery__
@@ -5784,60 +3853,37 @@ export const IsSessionPendingDocument = gql`
  *   },
  * });
  */
-export function useIsSessionPendingQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.IsSessionPendingQuery,
-		Types.IsSessionPendingQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.IsSessionPendingQuery,
-		Types.IsSessionPendingQueryVariables
-	>(IsSessionPendingDocument, baseOptions)
-}
-export function useIsSessionPendingLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.IsSessionPendingQuery,
-		Types.IsSessionPendingQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.IsSessionPendingQuery,
-		Types.IsSessionPendingQueryVariables
-	>(IsSessionPendingDocument, baseOptions)
-}
-export type IsSessionPendingQueryHookResult = ReturnType<
-	typeof useIsSessionPendingQuery
->
-export type IsSessionPendingLazyQueryHookResult = ReturnType<
-	typeof useIsSessionPendingLazyQuery
->
-export type IsSessionPendingQueryResult = Apollo.QueryResult<
-	Types.IsSessionPendingQuery,
-	Types.IsSessionPendingQueryVariables
->
+export function useIsSessionPendingQuery(baseOptions: Apollo.QueryHookOptions<Types.IsSessionPendingQuery, Types.IsSessionPendingQueryVariables>) {
+        return Apollo.useQuery<Types.IsSessionPendingQuery, Types.IsSessionPendingQueryVariables>(IsSessionPendingDocument, baseOptions);
+      }
+export function useIsSessionPendingLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.IsSessionPendingQuery, Types.IsSessionPendingQueryVariables>) {
+          return Apollo.useLazyQuery<Types.IsSessionPendingQuery, Types.IsSessionPendingQueryVariables>(IsSessionPendingDocument, baseOptions);
+        }
+export type IsSessionPendingQueryHookResult = ReturnType<typeof useIsSessionPendingQuery>;
+export type IsSessionPendingLazyQueryHookResult = ReturnType<typeof useIsSessionPendingLazyQuery>;
+export type IsSessionPendingQueryResult = Apollo.QueryResult<Types.IsSessionPendingQuery, Types.IsSessionPendingQueryVariables>;
 export const GetAccountsDocument = gql`
-	query GetAccounts {
-		accounts {
-			id
-			name
-			session_count_cur
-			view_count_cur
-			session_count_prev
-			view_count_prev
-			session_count_prev_prev
-			session_limit
-			paid_prev
-			paid_prev_prev
-			email
-			subscription_start
-			plan_tier
-			stripe_customer_id
-			member_count
-			member_limit
-		}
-	}
-`
+    query GetAccounts {
+  accounts {
+    id
+    name
+    session_count_cur
+    view_count_cur
+    session_count_prev
+    view_count_prev
+    session_count_prev_prev
+    session_limit
+    paid_prev
+    paid_prev_prev
+    email
+    subscription_start
+    plan_tier
+    stripe_customer_id
+    member_count
+    member_limit
+  }
+}
+    `;
 
 /**
  * __useGetAccountsQuery__
@@ -5854,59 +3900,38 @@ export const GetAccountsDocument = gql`
  *   },
  * });
  */
-export function useGetAccountsQuery(
-	baseOptions?: Apollo.QueryHookOptions<
-		Types.GetAccountsQuery,
-		Types.GetAccountsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetAccountsQuery,
-		Types.GetAccountsQueryVariables
-	>(GetAccountsDocument, baseOptions)
-}
-export function useGetAccountsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetAccountsQuery,
-		Types.GetAccountsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetAccountsQuery,
-		Types.GetAccountsQueryVariables
-	>(GetAccountsDocument, baseOptions)
-}
-export type GetAccountsQueryHookResult = ReturnType<typeof useGetAccountsQuery>
-export type GetAccountsLazyQueryHookResult = ReturnType<
-	typeof useGetAccountsLazyQuery
->
-export type GetAccountsQueryResult = Apollo.QueryResult<
-	Types.GetAccountsQuery,
-	Types.GetAccountsQueryVariables
->
+export function useGetAccountsQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetAccountsQuery, Types.GetAccountsQueryVariables>) {
+        return Apollo.useQuery<Types.GetAccountsQuery, Types.GetAccountsQueryVariables>(GetAccountsDocument, baseOptions);
+      }
+export function useGetAccountsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAccountsQuery, Types.GetAccountsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetAccountsQuery, Types.GetAccountsQueryVariables>(GetAccountsDocument, baseOptions);
+        }
+export type GetAccountsQueryHookResult = ReturnType<typeof useGetAccountsQuery>;
+export type GetAccountsLazyQueryHookResult = ReturnType<typeof useGetAccountsLazyQuery>;
+export type GetAccountsQueryResult = Apollo.QueryResult<Types.GetAccountsQuery, Types.GetAccountsQueryVariables>;
 export const GetAccountDetailsDocument = gql`
-	query GetAccountDetails($workspace_id: ID!) {
-		account_details(workspace_id: $workspace_id) {
-			id
-			name
-			session_count_per_month {
-				name
-				count
-			}
-			session_count_per_day {
-				name
-				count
-			}
-			stripe_customer_id
-			members {
-				id
-				name
-				email
-				last_active
-			}
-		}
-	}
-`
+    query GetAccountDetails($workspace_id: ID!) {
+  account_details(workspace_id: $workspace_id) {
+    id
+    name
+    session_count_per_month {
+      name
+      count
+    }
+    session_count_per_day {
+      name
+      count
+    }
+    stripe_customer_id
+    members {
+      id
+      name
+      email
+      last_active
+    }
+  }
+}
+    `;
 
 /**
  * __useGetAccountDetailsQuery__
@@ -5924,72 +3949,49 @@ export const GetAccountDetailsDocument = gql`
  *   },
  * });
  */
-export function useGetAccountDetailsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetAccountDetailsQuery,
-		Types.GetAccountDetailsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetAccountDetailsQuery,
-		Types.GetAccountDetailsQueryVariables
-	>(GetAccountDetailsDocument, baseOptions)
-}
-export function useGetAccountDetailsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetAccountDetailsQuery,
-		Types.GetAccountDetailsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetAccountDetailsQuery,
-		Types.GetAccountDetailsQueryVariables
-	>(GetAccountDetailsDocument, baseOptions)
-}
-export type GetAccountDetailsQueryHookResult = ReturnType<
-	typeof useGetAccountDetailsQuery
->
-export type GetAccountDetailsLazyQueryHookResult = ReturnType<
-	typeof useGetAccountDetailsLazyQuery
->
-export type GetAccountDetailsQueryResult = Apollo.QueryResult<
-	Types.GetAccountDetailsQuery,
-	Types.GetAccountDetailsQueryVariables
->
+export function useGetAccountDetailsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetAccountDetailsQuery, Types.GetAccountDetailsQueryVariables>) {
+        return Apollo.useQuery<Types.GetAccountDetailsQuery, Types.GetAccountDetailsQueryVariables>(GetAccountDetailsDocument, baseOptions);
+      }
+export function useGetAccountDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAccountDetailsQuery, Types.GetAccountDetailsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetAccountDetailsQuery, Types.GetAccountDetailsQueryVariables>(GetAccountDetailsDocument, baseOptions);
+        }
+export type GetAccountDetailsQueryHookResult = ReturnType<typeof useGetAccountDetailsQuery>;
+export type GetAccountDetailsLazyQueryHookResult = ReturnType<typeof useGetAccountDetailsLazyQuery>;
+export type GetAccountDetailsQueryResult = Apollo.QueryResult<Types.GetAccountDetailsQuery, Types.GetAccountDetailsQueryVariables>;
 export const GetErrorCommentsDocument = gql`
-	query GetErrorComments($error_group_secure_id: String!) {
-		error_comments(error_group_secure_id: $error_group_secure_id) {
-			id
-			created_at
-			updated_at
-			text
-			project_id
-			author {
-				id
-				name
-				email
-				photo_url
-			}
-			attachments {
-				integration_type
-				external_id
-				title
-			}
-			replies {
-				id
-				created_at
-				updated_at
-				author {
-					id
-					name
-					email
-					photo_url
-				}
-				text
-			}
-		}
-	}
-`
+    query GetErrorComments($error_group_secure_id: String!) {
+  error_comments(error_group_secure_id: $error_group_secure_id) {
+    id
+    created_at
+    updated_at
+    text
+    project_id
+    author {
+      id
+      name
+      email
+      photo_url
+    }
+    attachments {
+      integration_type
+      external_id
+      title
+    }
+    replies {
+      id
+      created_at
+      updated_at
+      author {
+        id
+        name
+        email
+        photo_url
+      }
+      text
+    }
+  }
+}
+    `;
 
 /**
  * __useGetErrorCommentsQuery__
@@ -6007,48 +4009,25 @@ export const GetErrorCommentsDocument = gql`
  *   },
  * });
  */
-export function useGetErrorCommentsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorCommentsQuery,
-		Types.GetErrorCommentsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorCommentsQuery,
-		Types.GetErrorCommentsQueryVariables
-	>(GetErrorCommentsDocument, baseOptions)
-}
-export function useGetErrorCommentsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorCommentsQuery,
-		Types.GetErrorCommentsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorCommentsQuery,
-		Types.GetErrorCommentsQueryVariables
-	>(GetErrorCommentsDocument, baseOptions)
-}
-export type GetErrorCommentsQueryHookResult = ReturnType<
-	typeof useGetErrorCommentsQuery
->
-export type GetErrorCommentsLazyQueryHookResult = ReturnType<
-	typeof useGetErrorCommentsLazyQuery
->
-export type GetErrorCommentsQueryResult = Apollo.QueryResult<
-	Types.GetErrorCommentsQuery,
-	Types.GetErrorCommentsQueryVariables
->
+export function useGetErrorCommentsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorCommentsQuery, Types.GetErrorCommentsQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorCommentsQuery, Types.GetErrorCommentsQueryVariables>(GetErrorCommentsDocument, baseOptions);
+      }
+export function useGetErrorCommentsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorCommentsQuery, Types.GetErrorCommentsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorCommentsQuery, Types.GetErrorCommentsQueryVariables>(GetErrorCommentsDocument, baseOptions);
+        }
+export type GetErrorCommentsQueryHookResult = ReturnType<typeof useGetErrorCommentsQuery>;
+export type GetErrorCommentsLazyQueryHookResult = ReturnType<typeof useGetErrorCommentsLazyQuery>;
+export type GetErrorCommentsQueryResult = Apollo.QueryResult<Types.GetErrorCommentsQuery, Types.GetErrorCommentsQueryVariables>;
 export const GetErrorIssuesDocument = gql`
-	query GetErrorIssues($error_group_secure_id: String!) {
-		error_issue(error_group_secure_id: $error_group_secure_id) {
-			id
-			integration_type
-			external_id
-			title
-		}
-	}
-`
+    query GetErrorIssues($error_group_secure_id: String!) {
+  error_issue(error_group_secure_id: $error_group_secure_id) {
+    id
+    integration_type
+    external_id
+    title
+  }
+}
+    `;
 
 /**
  * __useGetErrorIssuesQuery__
@@ -6066,53 +4045,30 @@ export const GetErrorIssuesDocument = gql`
  *   },
  * });
  */
-export function useGetErrorIssuesQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorIssuesQuery,
-		Types.GetErrorIssuesQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorIssuesQuery,
-		Types.GetErrorIssuesQueryVariables
-	>(GetErrorIssuesDocument, baseOptions)
-}
-export function useGetErrorIssuesLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorIssuesQuery,
-		Types.GetErrorIssuesQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorIssuesQuery,
-		Types.GetErrorIssuesQueryVariables
-	>(GetErrorIssuesDocument, baseOptions)
-}
-export type GetErrorIssuesQueryHookResult = ReturnType<
-	typeof useGetErrorIssuesQuery
->
-export type GetErrorIssuesLazyQueryHookResult = ReturnType<
-	typeof useGetErrorIssuesLazyQuery
->
-export type GetErrorIssuesQueryResult = Apollo.QueryResult<
-	Types.GetErrorIssuesQuery,
-	Types.GetErrorIssuesQueryVariables
->
+export function useGetErrorIssuesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorIssuesQuery, Types.GetErrorIssuesQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorIssuesQuery, Types.GetErrorIssuesQueryVariables>(GetErrorIssuesDocument, baseOptions);
+      }
+export function useGetErrorIssuesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorIssuesQuery, Types.GetErrorIssuesQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorIssuesQuery, Types.GetErrorIssuesQueryVariables>(GetErrorIssuesDocument, baseOptions);
+        }
+export type GetErrorIssuesQueryHookResult = ReturnType<typeof useGetErrorIssuesQuery>;
+export type GetErrorIssuesLazyQueryHookResult = ReturnType<typeof useGetErrorIssuesLazyQuery>;
+export type GetErrorIssuesQueryResult = Apollo.QueryResult<Types.GetErrorIssuesQuery, Types.GetErrorIssuesQueryVariables>;
 export const GetEnhancedUserDetailsDocument = gql`
-	query GetEnhancedUserDetails($session_secure_id: String!) {
-		enhanced_user_details(session_secure_id: $session_secure_id) {
-			id
-			name
-			bio
-			avatar
-			email
-			socials {
-				type
-				link
-			}
-		}
-	}
-`
+    query GetEnhancedUserDetails($session_secure_id: String!) {
+  enhanced_user_details(session_secure_id: $session_secure_id) {
+    id
+    name
+    bio
+    avatar
+    email
+    socials {
+      type
+      link
+    }
+  }
+}
+    `;
 
 /**
  * __useGetEnhancedUserDetailsQuery__
@@ -6130,59 +4086,36 @@ export const GetEnhancedUserDetailsDocument = gql`
  *   },
  * });
  */
-export function useGetEnhancedUserDetailsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetEnhancedUserDetailsQuery,
-		Types.GetEnhancedUserDetailsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetEnhancedUserDetailsQuery,
-		Types.GetEnhancedUserDetailsQueryVariables
-	>(GetEnhancedUserDetailsDocument, baseOptions)
-}
-export function useGetEnhancedUserDetailsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetEnhancedUserDetailsQuery,
-		Types.GetEnhancedUserDetailsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetEnhancedUserDetailsQuery,
-		Types.GetEnhancedUserDetailsQueryVariables
-	>(GetEnhancedUserDetailsDocument, baseOptions)
-}
-export type GetEnhancedUserDetailsQueryHookResult = ReturnType<
-	typeof useGetEnhancedUserDetailsQuery
->
-export type GetEnhancedUserDetailsLazyQueryHookResult = ReturnType<
-	typeof useGetEnhancedUserDetailsLazyQuery
->
-export type GetEnhancedUserDetailsQueryResult = Apollo.QueryResult<
-	Types.GetEnhancedUserDetailsQuery,
-	Types.GetEnhancedUserDetailsQueryVariables
->
+export function useGetEnhancedUserDetailsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetEnhancedUserDetailsQuery, Types.GetEnhancedUserDetailsQueryVariables>) {
+        return Apollo.useQuery<Types.GetEnhancedUserDetailsQuery, Types.GetEnhancedUserDetailsQueryVariables>(GetEnhancedUserDetailsDocument, baseOptions);
+      }
+export function useGetEnhancedUserDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetEnhancedUserDetailsQuery, Types.GetEnhancedUserDetailsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetEnhancedUserDetailsQuery, Types.GetEnhancedUserDetailsQueryVariables>(GetEnhancedUserDetailsDocument, baseOptions);
+        }
+export type GetEnhancedUserDetailsQueryHookResult = ReturnType<typeof useGetEnhancedUserDetailsQuery>;
+export type GetEnhancedUserDetailsLazyQueryHookResult = ReturnType<typeof useGetEnhancedUserDetailsLazyQuery>;
+export type GetEnhancedUserDetailsQueryResult = Apollo.QueryResult<Types.GetEnhancedUserDetailsQuery, Types.GetEnhancedUserDetailsQueryVariables>;
 export const GetOnboardingStepsDocument = gql`
-	query GetOnboardingSteps($project_id: ID!, $admin_id: ID!) {
-		workspace: workspace_for_project(project_id: $project_id) {
-			id
-			slack_channels
-		}
-		admins: workspace_admins_by_project_id(project_id: $project_id) {
-			admin {
-				id
-			}
-		}
-		isIntegrated(project_id: $project_id)
-		adminHasCreatedComment(admin_id: $admin_id)
-		projectHasViewedASession(project_id: $project_id) {
-			secure_id
-		}
-		admin {
-			slack_im_channel_id
-		}
-	}
-`
+    query GetOnboardingSteps($project_id: ID!, $admin_id: ID!) {
+  workspace: workspace_for_project(project_id: $project_id) {
+    id
+    slack_channels
+  }
+  admins: workspace_admins_by_project_id(project_id: $project_id) {
+    admin {
+      id
+    }
+  }
+  isIntegrated(project_id: $project_id)
+  adminHasCreatedComment(admin_id: $admin_id)
+  projectHasViewedASession(project_id: $project_id) {
+    secure_id
+  }
+  admin {
+    slack_im_channel_id
+  }
+}
+    `;
 
 /**
  * __useGetOnboardingStepsQuery__
@@ -6201,57 +4134,26 @@ export const GetOnboardingStepsDocument = gql`
  *   },
  * });
  */
-export function useGetOnboardingStepsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetOnboardingStepsQuery,
-		Types.GetOnboardingStepsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetOnboardingStepsQuery,
-		Types.GetOnboardingStepsQueryVariables
-	>(GetOnboardingStepsDocument, baseOptions)
-}
-export function useGetOnboardingStepsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetOnboardingStepsQuery,
-		Types.GetOnboardingStepsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetOnboardingStepsQuery,
-		Types.GetOnboardingStepsQueryVariables
-	>(GetOnboardingStepsDocument, baseOptions)
-}
-export type GetOnboardingStepsQueryHookResult = ReturnType<
-	typeof useGetOnboardingStepsQuery
->
-export type GetOnboardingStepsLazyQueryHookResult = ReturnType<
-	typeof useGetOnboardingStepsLazyQuery
->
-export type GetOnboardingStepsQueryResult = Apollo.QueryResult<
-	Types.GetOnboardingStepsQuery,
-	Types.GetOnboardingStepsQueryVariables
->
+export function useGetOnboardingStepsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetOnboardingStepsQuery, Types.GetOnboardingStepsQueryVariables>) {
+        return Apollo.useQuery<Types.GetOnboardingStepsQuery, Types.GetOnboardingStepsQueryVariables>(GetOnboardingStepsDocument, baseOptions);
+      }
+export function useGetOnboardingStepsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetOnboardingStepsQuery, Types.GetOnboardingStepsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetOnboardingStepsQuery, Types.GetOnboardingStepsQueryVariables>(GetOnboardingStepsDocument, baseOptions);
+        }
+export type GetOnboardingStepsQueryHookResult = ReturnType<typeof useGetOnboardingStepsQuery>;
+export type GetOnboardingStepsLazyQueryHookResult = ReturnType<typeof useGetOnboardingStepsLazyQuery>;
+export type GetOnboardingStepsQueryResult = Apollo.QueryResult<Types.GetOnboardingStepsQuery, Types.GetOnboardingStepsQueryVariables>;
 export const SendAdminWorkspaceInviteDocument = gql`
-	mutation SendAdminWorkspaceInvite(
-		$workspace_id: ID!
-		$email: String!
-		$base_url: String!
-		$role: String!
-	) {
-		sendAdminWorkspaceInvite(
-			workspace_id: $workspace_id
-			email: $email
-			base_url: $base_url
-			role: $role
-		)
-	}
-`
-export type SendAdminWorkspaceInviteMutationFn = Apollo.MutationFunction<
-	Types.SendAdminWorkspaceInviteMutation,
-	Types.SendAdminWorkspaceInviteMutationVariables
->
+    mutation SendAdminWorkspaceInvite($workspace_id: ID!, $email: String!, $base_url: String!, $role: String!) {
+  sendAdminWorkspaceInvite(
+    workspace_id: $workspace_id
+    email: $email
+    base_url: $base_url
+    role: $role
+  )
+}
+    `;
+export type SendAdminWorkspaceInviteMutationFn = Apollo.MutationFunction<Types.SendAdminWorkspaceInviteMutation, Types.SendAdminWorkspaceInviteMutationVariables>;
 
 /**
  * __useSendAdminWorkspaceInviteMutation__
@@ -6273,37 +4175,22 @@ export type SendAdminWorkspaceInviteMutationFn = Apollo.MutationFunction<
  *   },
  * });
  */
-export function useSendAdminWorkspaceInviteMutation(
-	baseOptions?: Apollo.MutationHookOptions<
-		Types.SendAdminWorkspaceInviteMutation,
-		Types.SendAdminWorkspaceInviteMutationVariables
-	>,
-) {
-	return Apollo.useMutation<
-		Types.SendAdminWorkspaceInviteMutation,
-		Types.SendAdminWorkspaceInviteMutationVariables
-	>(SendAdminWorkspaceInviteDocument, baseOptions)
-}
-export type SendAdminWorkspaceInviteMutationHookResult = ReturnType<
-	typeof useSendAdminWorkspaceInviteMutation
->
-export type SendAdminWorkspaceInviteMutationResult =
-	Apollo.MutationResult<Types.SendAdminWorkspaceInviteMutation>
-export type SendAdminWorkspaceInviteMutationOptions =
-	Apollo.BaseMutationOptions<
-		Types.SendAdminWorkspaceInviteMutation,
-		Types.SendAdminWorkspaceInviteMutationVariables
-	>
+export function useSendAdminWorkspaceInviteMutation(baseOptions?: Apollo.MutationHookOptions<Types.SendAdminWorkspaceInviteMutation, Types.SendAdminWorkspaceInviteMutationVariables>) {
+        return Apollo.useMutation<Types.SendAdminWorkspaceInviteMutation, Types.SendAdminWorkspaceInviteMutationVariables>(SendAdminWorkspaceInviteDocument, baseOptions);
+      }
+export type SendAdminWorkspaceInviteMutationHookResult = ReturnType<typeof useSendAdminWorkspaceInviteMutation>;
+export type SendAdminWorkspaceInviteMutationResult = Apollo.MutationResult<Types.SendAdminWorkspaceInviteMutation>;
+export type SendAdminWorkspaceInviteMutationOptions = Apollo.BaseMutationOptions<Types.SendAdminWorkspaceInviteMutation, Types.SendAdminWorkspaceInviteMutationVariables>;
 export const GetSessionIntervalsDocument = gql`
-	query GetSessionIntervals($session_secure_id: String!) {
-		session_intervals(session_secure_id: $session_secure_id) {
-			start_time
-			end_time
-			active
-			duration
-		}
-	}
-`
+    query GetSessionIntervals($session_secure_id: String!) {
+  session_intervals(session_secure_id: $session_secure_id) {
+    start_time
+    end_time
+    active
+    duration
+  }
+}
+    `;
 
 /**
  * __useGetSessionIntervalsQuery__
@@ -6321,48 +4208,25 @@ export const GetSessionIntervalsDocument = gql`
  *   },
  * });
  */
-export function useGetSessionIntervalsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSessionIntervalsQuery,
-		Types.GetSessionIntervalsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSessionIntervalsQuery,
-		Types.GetSessionIntervalsQueryVariables
-	>(GetSessionIntervalsDocument, baseOptions)
-}
-export function useGetSessionIntervalsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSessionIntervalsQuery,
-		Types.GetSessionIntervalsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSessionIntervalsQuery,
-		Types.GetSessionIntervalsQueryVariables
-	>(GetSessionIntervalsDocument, baseOptions)
-}
-export type GetSessionIntervalsQueryHookResult = ReturnType<
-	typeof useGetSessionIntervalsQuery
->
-export type GetSessionIntervalsLazyQueryHookResult = ReturnType<
-	typeof useGetSessionIntervalsLazyQuery
->
-export type GetSessionIntervalsQueryResult = Apollo.QueryResult<
-	Types.GetSessionIntervalsQuery,
-	Types.GetSessionIntervalsQueryVariables
->
+export function useGetSessionIntervalsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionIntervalsQuery, Types.GetSessionIntervalsQueryVariables>) {
+        return Apollo.useQuery<Types.GetSessionIntervalsQuery, Types.GetSessionIntervalsQueryVariables>(GetSessionIntervalsDocument, baseOptions);
+      }
+export function useGetSessionIntervalsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionIntervalsQuery, Types.GetSessionIntervalsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSessionIntervalsQuery, Types.GetSessionIntervalsQueryVariables>(GetSessionIntervalsDocument, baseOptions);
+        }
+export type GetSessionIntervalsQueryHookResult = ReturnType<typeof useGetSessionIntervalsQuery>;
+export type GetSessionIntervalsLazyQueryHookResult = ReturnType<typeof useGetSessionIntervalsLazyQuery>;
+export type GetSessionIntervalsQueryResult = Apollo.QueryResult<Types.GetSessionIntervalsQuery, Types.GetSessionIntervalsQueryVariables>;
 export const GetTimelineIndicatorEventsDocument = gql`
-	query GetTimelineIndicatorEvents($session_secure_id: String!) {
-		timeline_indicator_events(session_secure_id: $session_secure_id) {
-			timestamp
-			data
-			type
-			sid
-		}
-	}
-`
+    query GetTimelineIndicatorEvents($session_secure_id: String!) {
+  timeline_indicator_events(session_secure_id: $session_secure_id) {
+    timestamp
+    data
+    type
+    sid
+  }
+}
+    `;
 
 /**
  * __useGetTimelineIndicatorEventsQuery__
@@ -6380,54 +4244,27 @@ export const GetTimelineIndicatorEventsDocument = gql`
  *   },
  * });
  */
-export function useGetTimelineIndicatorEventsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetTimelineIndicatorEventsQuery,
-		Types.GetTimelineIndicatorEventsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetTimelineIndicatorEventsQuery,
-		Types.GetTimelineIndicatorEventsQueryVariables
-	>(GetTimelineIndicatorEventsDocument, baseOptions)
-}
-export function useGetTimelineIndicatorEventsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetTimelineIndicatorEventsQuery,
-		Types.GetTimelineIndicatorEventsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetTimelineIndicatorEventsQuery,
-		Types.GetTimelineIndicatorEventsQueryVariables
-	>(GetTimelineIndicatorEventsDocument, baseOptions)
-}
-export type GetTimelineIndicatorEventsQueryHookResult = ReturnType<
-	typeof useGetTimelineIndicatorEventsQuery
->
-export type GetTimelineIndicatorEventsLazyQueryHookResult = ReturnType<
-	typeof useGetTimelineIndicatorEventsLazyQuery
->
-export type GetTimelineIndicatorEventsQueryResult = Apollo.QueryResult<
-	Types.GetTimelineIndicatorEventsQuery,
-	Types.GetTimelineIndicatorEventsQueryVariables
->
+export function useGetTimelineIndicatorEventsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetTimelineIndicatorEventsQuery, Types.GetTimelineIndicatorEventsQueryVariables>) {
+        return Apollo.useQuery<Types.GetTimelineIndicatorEventsQuery, Types.GetTimelineIndicatorEventsQueryVariables>(GetTimelineIndicatorEventsDocument, baseOptions);
+      }
+export function useGetTimelineIndicatorEventsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetTimelineIndicatorEventsQuery, Types.GetTimelineIndicatorEventsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetTimelineIndicatorEventsQuery, Types.GetTimelineIndicatorEventsQueryVariables>(GetTimelineIndicatorEventsDocument, baseOptions);
+        }
+export type GetTimelineIndicatorEventsQueryHookResult = ReturnType<typeof useGetTimelineIndicatorEventsQuery>;
+export type GetTimelineIndicatorEventsLazyQueryHookResult = ReturnType<typeof useGetTimelineIndicatorEventsLazyQuery>;
+export type GetTimelineIndicatorEventsQueryResult = Apollo.QueryResult<Types.GetTimelineIndicatorEventsQuery, Types.GetTimelineIndicatorEventsQueryVariables>;
 export const GetFieldTypesDocument = gql`
-	query GetFieldTypes(
-		$project_id: ID!
-		$start_date: Timestamp
-		$end_date: Timestamp
-	) {
-		field_types(
-			project_id: $project_id
-			start_date: $start_date
-			end_date: $end_date
-		) {
-			type
-			name
-		}
-	}
-`
+    query GetFieldTypes($project_id: ID!, $start_date: Timestamp, $end_date: Timestamp) {
+  field_types(
+    project_id: $project_id
+    start_date: $start_date
+    end_date: $end_date
+  ) {
+    type
+    name
+  }
+}
+    `;
 
 /**
  * __useGetFieldTypesQuery__
@@ -6447,55 +4284,26 @@ export const GetFieldTypesDocument = gql`
  *   },
  * });
  */
-export function useGetFieldTypesQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetFieldTypesQuery,
-		Types.GetFieldTypesQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetFieldTypesQuery,
-		Types.GetFieldTypesQueryVariables
-	>(GetFieldTypesDocument, baseOptions)
-}
-export function useGetFieldTypesLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetFieldTypesQuery,
-		Types.GetFieldTypesQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetFieldTypesQuery,
-		Types.GetFieldTypesQueryVariables
-	>(GetFieldTypesDocument, baseOptions)
-}
-export type GetFieldTypesQueryHookResult = ReturnType<
-	typeof useGetFieldTypesQuery
->
-export type GetFieldTypesLazyQueryHookResult = ReturnType<
-	typeof useGetFieldTypesLazyQuery
->
-export type GetFieldTypesQueryResult = Apollo.QueryResult<
-	Types.GetFieldTypesQuery,
-	Types.GetFieldTypesQueryVariables
->
+export function useGetFieldTypesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetFieldTypesQuery, Types.GetFieldTypesQueryVariables>) {
+        return Apollo.useQuery<Types.GetFieldTypesQuery, Types.GetFieldTypesQueryVariables>(GetFieldTypesDocument, baseOptions);
+      }
+export function useGetFieldTypesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetFieldTypesQuery, Types.GetFieldTypesQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetFieldTypesQuery, Types.GetFieldTypesQueryVariables>(GetFieldTypesDocument, baseOptions);
+        }
+export type GetFieldTypesQueryHookResult = ReturnType<typeof useGetFieldTypesQuery>;
+export type GetFieldTypesLazyQueryHookResult = ReturnType<typeof useGetFieldTypesLazyQuery>;
+export type GetFieldTypesQueryResult = Apollo.QueryResult<Types.GetFieldTypesQuery, Types.GetFieldTypesQueryVariables>;
 export const GetFieldsOpensearchDocument = gql`
-	query GetFieldsOpensearch(
-		$project_id: ID!
-		$count: Int!
-		$field_type: String!
-		$field_name: String!
-		$query: String!
-	) {
-		fields_opensearch(
-			project_id: $project_id
-			count: $count
-			field_type: $field_type
-			field_name: $field_name
-			query: $query
-		)
-	}
-`
+    query GetFieldsOpensearch($project_id: ID!, $count: Int!, $field_type: String!, $field_name: String!, $query: String!) {
+  fields_opensearch(
+    project_id: $project_id
+    count: $count
+    field_type: $field_type
+    field_name: $field_name
+    query: $query
+  )
+}
+    `;
 
 /**
  * __useGetFieldsOpensearchQuery__
@@ -6517,55 +4325,24 @@ export const GetFieldsOpensearchDocument = gql`
  *   },
  * });
  */
-export function useGetFieldsOpensearchQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetFieldsOpensearchQuery,
-		Types.GetFieldsOpensearchQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetFieldsOpensearchQuery,
-		Types.GetFieldsOpensearchQueryVariables
-	>(GetFieldsOpensearchDocument, baseOptions)
-}
-export function useGetFieldsOpensearchLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetFieldsOpensearchQuery,
-		Types.GetFieldsOpensearchQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetFieldsOpensearchQuery,
-		Types.GetFieldsOpensearchQueryVariables
-	>(GetFieldsOpensearchDocument, baseOptions)
-}
-export type GetFieldsOpensearchQueryHookResult = ReturnType<
-	typeof useGetFieldsOpensearchQuery
->
-export type GetFieldsOpensearchLazyQueryHookResult = ReturnType<
-	typeof useGetFieldsOpensearchLazyQuery
->
-export type GetFieldsOpensearchQueryResult = Apollo.QueryResult<
-	Types.GetFieldsOpensearchQuery,
-	Types.GetFieldsOpensearchQueryVariables
->
+export function useGetFieldsOpensearchQuery(baseOptions: Apollo.QueryHookOptions<Types.GetFieldsOpensearchQuery, Types.GetFieldsOpensearchQueryVariables>) {
+        return Apollo.useQuery<Types.GetFieldsOpensearchQuery, Types.GetFieldsOpensearchQueryVariables>(GetFieldsOpensearchDocument, baseOptions);
+      }
+export function useGetFieldsOpensearchLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetFieldsOpensearchQuery, Types.GetFieldsOpensearchQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetFieldsOpensearchQuery, Types.GetFieldsOpensearchQueryVariables>(GetFieldsOpensearchDocument, baseOptions);
+        }
+export type GetFieldsOpensearchQueryHookResult = ReturnType<typeof useGetFieldsOpensearchQuery>;
+export type GetFieldsOpensearchLazyQueryHookResult = ReturnType<typeof useGetFieldsOpensearchLazyQuery>;
+export type GetFieldsOpensearchQueryResult = Apollo.QueryResult<Types.GetFieldsOpensearchQuery, Types.GetFieldsOpensearchQueryVariables>;
 export const GetQuickFieldsOpensearchDocument = gql`
-	query GetQuickFieldsOpensearch(
-		$project_id: ID!
-		$count: Int!
-		$query: String!
-	) {
-		quickFields_opensearch(
-			project_id: $project_id
-			count: $count
-			query: $query
-		) {
-			type
-			name
-			value
-		}
-	}
-`
+    query GetQuickFieldsOpensearch($project_id: ID!, $count: Int!, $query: String!) {
+  quickFields_opensearch(project_id: $project_id, count: $count, query: $query) {
+    type
+    name
+    value
+  }
+}
+    `;
 
 /**
  * __useGetQuickFieldsOpensearchQuery__
@@ -6585,55 +4362,26 @@ export const GetQuickFieldsOpensearchDocument = gql`
  *   },
  * });
  */
-export function useGetQuickFieldsOpensearchQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetQuickFieldsOpensearchQuery,
-		Types.GetQuickFieldsOpensearchQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetQuickFieldsOpensearchQuery,
-		Types.GetQuickFieldsOpensearchQueryVariables
-	>(GetQuickFieldsOpensearchDocument, baseOptions)
-}
-export function useGetQuickFieldsOpensearchLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetQuickFieldsOpensearchQuery,
-		Types.GetQuickFieldsOpensearchQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetQuickFieldsOpensearchQuery,
-		Types.GetQuickFieldsOpensearchQueryVariables
-	>(GetQuickFieldsOpensearchDocument, baseOptions)
-}
-export type GetQuickFieldsOpensearchQueryHookResult = ReturnType<
-	typeof useGetQuickFieldsOpensearchQuery
->
-export type GetQuickFieldsOpensearchLazyQueryHookResult = ReturnType<
-	typeof useGetQuickFieldsOpensearchLazyQuery
->
-export type GetQuickFieldsOpensearchQueryResult = Apollo.QueryResult<
-	Types.GetQuickFieldsOpensearchQuery,
-	Types.GetQuickFieldsOpensearchQueryVariables
->
+export function useGetQuickFieldsOpensearchQuery(baseOptions: Apollo.QueryHookOptions<Types.GetQuickFieldsOpensearchQuery, Types.GetQuickFieldsOpensearchQueryVariables>) {
+        return Apollo.useQuery<Types.GetQuickFieldsOpensearchQuery, Types.GetQuickFieldsOpensearchQueryVariables>(GetQuickFieldsOpensearchDocument, baseOptions);
+      }
+export function useGetQuickFieldsOpensearchLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetQuickFieldsOpensearchQuery, Types.GetQuickFieldsOpensearchQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetQuickFieldsOpensearchQuery, Types.GetQuickFieldsOpensearchQueryVariables>(GetQuickFieldsOpensearchDocument, baseOptions);
+        }
+export type GetQuickFieldsOpensearchQueryHookResult = ReturnType<typeof useGetQuickFieldsOpensearchQuery>;
+export type GetQuickFieldsOpensearchLazyQueryHookResult = ReturnType<typeof useGetQuickFieldsOpensearchLazyQuery>;
+export type GetQuickFieldsOpensearchQueryResult = Apollo.QueryResult<Types.GetQuickFieldsOpensearchQuery, Types.GetQuickFieldsOpensearchQueryVariables>;
 export const GetErrorFieldsOpensearchDocument = gql`
-	query GetErrorFieldsOpensearch(
-		$project_id: ID!
-		$count: Int!
-		$field_type: String!
-		$field_name: String!
-		$query: String!
-	) {
-		error_fields_opensearch(
-			project_id: $project_id
-			count: $count
-			field_type: $field_type
-			field_name: $field_name
-			query: $query
-		)
-	}
-`
+    query GetErrorFieldsOpensearch($project_id: ID!, $count: Int!, $field_type: String!, $field_name: String!, $query: String!) {
+  error_fields_opensearch(
+    project_id: $project_id
+    count: $count
+    field_type: $field_type
+    field_name: $field_name
+    query: $query
+  )
+}
+    `;
 
 /**
  * __useGetErrorFieldsOpensearchQuery__
@@ -6655,97 +4403,67 @@ export const GetErrorFieldsOpensearchDocument = gql`
  *   },
  * });
  */
-export function useGetErrorFieldsOpensearchQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorFieldsOpensearchQuery,
-		Types.GetErrorFieldsOpensearchQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorFieldsOpensearchQuery,
-		Types.GetErrorFieldsOpensearchQueryVariables
-	>(GetErrorFieldsOpensearchDocument, baseOptions)
-}
-export function useGetErrorFieldsOpensearchLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorFieldsOpensearchQuery,
-		Types.GetErrorFieldsOpensearchQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorFieldsOpensearchQuery,
-		Types.GetErrorFieldsOpensearchQueryVariables
-	>(GetErrorFieldsOpensearchDocument, baseOptions)
-}
-export type GetErrorFieldsOpensearchQueryHookResult = ReturnType<
-	typeof useGetErrorFieldsOpensearchQuery
->
-export type GetErrorFieldsOpensearchLazyQueryHookResult = ReturnType<
-	typeof useGetErrorFieldsOpensearchLazyQuery
->
-export type GetErrorFieldsOpensearchQueryResult = Apollo.QueryResult<
-	Types.GetErrorFieldsOpensearchQuery,
-	Types.GetErrorFieldsOpensearchQueryVariables
->
+export function useGetErrorFieldsOpensearchQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorFieldsOpensearchQuery, Types.GetErrorFieldsOpensearchQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorFieldsOpensearchQuery, Types.GetErrorFieldsOpensearchQueryVariables>(GetErrorFieldsOpensearchDocument, baseOptions);
+      }
+export function useGetErrorFieldsOpensearchLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorFieldsOpensearchQuery, Types.GetErrorFieldsOpensearchQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorFieldsOpensearchQuery, Types.GetErrorFieldsOpensearchQueryVariables>(GetErrorFieldsOpensearchDocument, baseOptions);
+        }
+export type GetErrorFieldsOpensearchQueryHookResult = ReturnType<typeof useGetErrorFieldsOpensearchQuery>;
+export type GetErrorFieldsOpensearchLazyQueryHookResult = ReturnType<typeof useGetErrorFieldsOpensearchLazyQuery>;
+export type GetErrorFieldsOpensearchQueryResult = Apollo.QueryResult<Types.GetErrorFieldsOpensearchQuery, Types.GetErrorFieldsOpensearchQueryVariables>;
 export const GetSessionsOpenSearchDocument = gql`
-	query GetSessionsOpenSearch(
-		$project_id: ID!
-		$count: Int!
-		$query: String!
-		$sort_desc: Boolean!
-		$sort_field: String
-		$page: Int
-	) {
-		sessions_opensearch(
-			project_id: $project_id
-			count: $count
-			query: $query
-			sort_field: $sort_field
-			sort_desc: $sort_desc
-			page: $page
-		) {
-			sessions {
-				id
-				secure_id
-				client_id
-				fingerprint
-				identifier
-				identified
-				os_name
-				os_version
-				browser_name
-				browser_version
-				city
-				state
-				country
-				postal
-				created_at
-				language
-				length
-				active_length
-				enable_recording_network_contents
-				viewed
-				starred
-				processed
-				has_rage_clicks
-				has_errors
-				fields {
-					name
-					value
-					type
-					id
-				}
-				first_time
-				user_properties
-				event_counts
-				last_user_interaction_time
-				is_public
-				excluded
-			}
-			totalCount
-		}
-	}
-`
+    query GetSessionsOpenSearch($project_id: ID!, $count: Int!, $query: String!, $sort_desc: Boolean!, $sort_field: String, $page: Int) {
+  sessions_opensearch(
+    project_id: $project_id
+    count: $count
+    query: $query
+    sort_field: $sort_field
+    sort_desc: $sort_desc
+    page: $page
+  ) {
+    sessions {
+      id
+      secure_id
+      client_id
+      fingerprint
+      identifier
+      identified
+      os_name
+      os_version
+      browser_name
+      browser_version
+      city
+      state
+      country
+      postal
+      created_at
+      language
+      length
+      active_length
+      enable_recording_network_contents
+      viewed
+      starred
+      processed
+      has_rage_clicks
+      has_errors
+      fields {
+        name
+        value
+        type
+        id
+      }
+      first_time
+      user_properties
+      event_counts
+      last_user_interaction_time
+      is_public
+      excluded
+    }
+    totalCount
+  }
+}
+    `;
 
 /**
  * __useGetSessionsOpenSearchQuery__
@@ -6768,56 +4486,29 @@ export const GetSessionsOpenSearchDocument = gql`
  *   },
  * });
  */
-export function useGetSessionsOpenSearchQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSessionsOpenSearchQuery,
-		Types.GetSessionsOpenSearchQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSessionsOpenSearchQuery,
-		Types.GetSessionsOpenSearchQueryVariables
-	>(GetSessionsOpenSearchDocument, baseOptions)
-}
-export function useGetSessionsOpenSearchLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSessionsOpenSearchQuery,
-		Types.GetSessionsOpenSearchQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSessionsOpenSearchQuery,
-		Types.GetSessionsOpenSearchQueryVariables
-	>(GetSessionsOpenSearchDocument, baseOptions)
-}
-export type GetSessionsOpenSearchQueryHookResult = ReturnType<
-	typeof useGetSessionsOpenSearchQuery
->
-export type GetSessionsOpenSearchLazyQueryHookResult = ReturnType<
-	typeof useGetSessionsOpenSearchLazyQuery
->
-export type GetSessionsOpenSearchQueryResult = Apollo.QueryResult<
-	Types.GetSessionsOpenSearchQuery,
-	Types.GetSessionsOpenSearchQueryVariables
->
+export function useGetSessionsOpenSearchQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionsOpenSearchQuery, Types.GetSessionsOpenSearchQueryVariables>) {
+        return Apollo.useQuery<Types.GetSessionsOpenSearchQuery, Types.GetSessionsOpenSearchQueryVariables>(GetSessionsOpenSearchDocument, baseOptions);
+      }
+export function useGetSessionsOpenSearchLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionsOpenSearchQuery, Types.GetSessionsOpenSearchQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSessionsOpenSearchQuery, Types.GetSessionsOpenSearchQueryVariables>(GetSessionsOpenSearchDocument, baseOptions);
+        }
+export type GetSessionsOpenSearchQueryHookResult = ReturnType<typeof useGetSessionsOpenSearchQuery>;
+export type GetSessionsOpenSearchLazyQueryHookResult = ReturnType<typeof useGetSessionsOpenSearchLazyQuery>;
+export type GetSessionsOpenSearchQueryResult = Apollo.QueryResult<Types.GetSessionsOpenSearchQuery, Types.GetSessionsOpenSearchQueryVariables>;
 export const GetSessionsHistogramDocument = gql`
-	query GetSessionsHistogram(
-		$project_id: ID!
-		$query: String!
-		$histogram_options: DateHistogramOptions!
-	) {
-		sessions_histogram(
-			project_id: $project_id
-			query: $query
-			histogram_options: $histogram_options
-		) {
-			bucket_times
-			sessions_without_errors
-			sessions_with_errors
-			total_sessions
-		}
-	}
-`
+    query GetSessionsHistogram($project_id: ID!, $query: String!, $histogram_options: DateHistogramOptions!) {
+  sessions_histogram(
+    project_id: $project_id
+    query: $query
+    histogram_options: $histogram_options
+  ) {
+    bucket_times
+    sessions_without_errors
+    sessions_with_errors
+    total_sessions
+  }
+}
+    `;
 
 /**
  * __useGetSessionsHistogramQuery__
@@ -6837,83 +4528,55 @@ export const GetSessionsHistogramDocument = gql`
  *   },
  * });
  */
-export function useGetSessionsHistogramQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSessionsHistogramQuery,
-		Types.GetSessionsHistogramQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSessionsHistogramQuery,
-		Types.GetSessionsHistogramQueryVariables
-	>(GetSessionsHistogramDocument, baseOptions)
-}
-export function useGetSessionsHistogramLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSessionsHistogramQuery,
-		Types.GetSessionsHistogramQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSessionsHistogramQuery,
-		Types.GetSessionsHistogramQueryVariables
-	>(GetSessionsHistogramDocument, baseOptions)
-}
-export type GetSessionsHistogramQueryHookResult = ReturnType<
-	typeof useGetSessionsHistogramQuery
->
-export type GetSessionsHistogramLazyQueryHookResult = ReturnType<
-	typeof useGetSessionsHistogramLazyQuery
->
-export type GetSessionsHistogramQueryResult = Apollo.QueryResult<
-	Types.GetSessionsHistogramQuery,
-	Types.GetSessionsHistogramQueryVariables
->
+export function useGetSessionsHistogramQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionsHistogramQuery, Types.GetSessionsHistogramQueryVariables>) {
+        return Apollo.useQuery<Types.GetSessionsHistogramQuery, Types.GetSessionsHistogramQueryVariables>(GetSessionsHistogramDocument, baseOptions);
+      }
+export function useGetSessionsHistogramLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionsHistogramQuery, Types.GetSessionsHistogramQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSessionsHistogramQuery, Types.GetSessionsHistogramQueryVariables>(GetSessionsHistogramDocument, baseOptions);
+        }
+export type GetSessionsHistogramQueryHookResult = ReturnType<typeof useGetSessionsHistogramQuery>;
+export type GetSessionsHistogramLazyQueryHookResult = ReturnType<typeof useGetSessionsHistogramLazyQuery>;
+export type GetSessionsHistogramQueryResult = Apollo.QueryResult<Types.GetSessionsHistogramQuery, Types.GetSessionsHistogramQueryVariables>;
 export const GetErrorGroupsOpenSearchDocument = gql`
-	query GetErrorGroupsOpenSearch(
-		$project_id: ID!
-		$count: Int!
-		$query: String!
-		$page: Int
-	) {
-		error_groups_opensearch(
-			project_id: $project_id
-			count: $count
-			query: $query
-			page: $page
-		) {
-			error_groups {
-				created_at
-				updated_at
-				id
-				secure_id
-				type
-				event
-				state
-				state
-				snoozed_until
-				environments
-				stack_trace
-				structured_stack_trace {
-					fileName
-					lineNumber
-					functionName
-					columnNumber
-				}
-				error_frequency
-				error_metrics {
-					error_group_id
-					date
-					name
-					value
-				}
-				is_public
-				project_id
-			}
-			totalCount
-		}
-	}
-`
+    query GetErrorGroupsOpenSearch($project_id: ID!, $count: Int!, $query: String!, $page: Int) {
+  error_groups_opensearch(
+    project_id: $project_id
+    count: $count
+    query: $query
+    page: $page
+  ) {
+    error_groups {
+      created_at
+      updated_at
+      id
+      secure_id
+      type
+      event
+      state
+      state
+      snoozed_until
+      environments
+      stack_trace
+      structured_stack_trace {
+        fileName
+        lineNumber
+        functionName
+        columnNumber
+      }
+      error_frequency
+      error_metrics {
+        error_group_id
+        date
+        name
+        value
+      }
+      is_public
+      project_id
+    }
+    totalCount
+  }
+}
+    `;
 
 /**
  * __useGetErrorGroupsOpenSearchQuery__
@@ -6934,54 +4597,27 @@ export const GetErrorGroupsOpenSearchDocument = gql`
  *   },
  * });
  */
-export function useGetErrorGroupsOpenSearchQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorGroupsOpenSearchQuery,
-		Types.GetErrorGroupsOpenSearchQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorGroupsOpenSearchQuery,
-		Types.GetErrorGroupsOpenSearchQueryVariables
-	>(GetErrorGroupsOpenSearchDocument, baseOptions)
-}
-export function useGetErrorGroupsOpenSearchLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorGroupsOpenSearchQuery,
-		Types.GetErrorGroupsOpenSearchQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorGroupsOpenSearchQuery,
-		Types.GetErrorGroupsOpenSearchQueryVariables
-	>(GetErrorGroupsOpenSearchDocument, baseOptions)
-}
-export type GetErrorGroupsOpenSearchQueryHookResult = ReturnType<
-	typeof useGetErrorGroupsOpenSearchQuery
->
-export type GetErrorGroupsOpenSearchLazyQueryHookResult = ReturnType<
-	typeof useGetErrorGroupsOpenSearchLazyQuery
->
-export type GetErrorGroupsOpenSearchQueryResult = Apollo.QueryResult<
-	Types.GetErrorGroupsOpenSearchQuery,
-	Types.GetErrorGroupsOpenSearchQueryVariables
->
+export function useGetErrorGroupsOpenSearchQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorGroupsOpenSearchQuery, Types.GetErrorGroupsOpenSearchQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorGroupsOpenSearchQuery, Types.GetErrorGroupsOpenSearchQueryVariables>(GetErrorGroupsOpenSearchDocument, baseOptions);
+      }
+export function useGetErrorGroupsOpenSearchLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorGroupsOpenSearchQuery, Types.GetErrorGroupsOpenSearchQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorGroupsOpenSearchQuery, Types.GetErrorGroupsOpenSearchQueryVariables>(GetErrorGroupsOpenSearchDocument, baseOptions);
+        }
+export type GetErrorGroupsOpenSearchQueryHookResult = ReturnType<typeof useGetErrorGroupsOpenSearchQuery>;
+export type GetErrorGroupsOpenSearchLazyQueryHookResult = ReturnType<typeof useGetErrorGroupsOpenSearchLazyQuery>;
+export type GetErrorGroupsOpenSearchQueryResult = Apollo.QueryResult<Types.GetErrorGroupsOpenSearchQuery, Types.GetErrorGroupsOpenSearchQueryVariables>;
 export const GetErrorsHistogramDocument = gql`
-	query GetErrorsHistogram(
-		$project_id: ID!
-		$query: String!
-		$histogram_options: DateHistogramOptions!
-	) {
-		errors_histogram(
-			project_id: $project_id
-			query: $query
-			histogram_options: $histogram_options
-		) {
-			bucket_times
-			error_objects
-		}
-	}
-`
+    query GetErrorsHistogram($project_id: ID!, $query: String!, $histogram_options: DateHistogramOptions!) {
+  errors_histogram(
+    project_id: $project_id
+    query: $query
+    histogram_options: $histogram_options
+  ) {
+    bucket_times
+    error_objects
+  }
+}
+    `;
 
 /**
  * __useGetErrorsHistogramQuery__
@@ -7001,47 +4637,24 @@ export const GetErrorsHistogramDocument = gql`
  *   },
  * });
  */
-export function useGetErrorsHistogramQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorsHistogramQuery,
-		Types.GetErrorsHistogramQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorsHistogramQuery,
-		Types.GetErrorsHistogramQueryVariables
-	>(GetErrorsHistogramDocument, baseOptions)
-}
-export function useGetErrorsHistogramLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorsHistogramQuery,
-		Types.GetErrorsHistogramQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorsHistogramQuery,
-		Types.GetErrorsHistogramQueryVariables
-	>(GetErrorsHistogramDocument, baseOptions)
-}
-export type GetErrorsHistogramQueryHookResult = ReturnType<
-	typeof useGetErrorsHistogramQuery
->
-export type GetErrorsHistogramLazyQueryHookResult = ReturnType<
-	typeof useGetErrorsHistogramLazyQuery
->
-export type GetErrorsHistogramQueryResult = Apollo.QueryResult<
-	Types.GetErrorsHistogramQuery,
-	Types.GetErrorsHistogramQueryVariables
->
+export function useGetErrorsHistogramQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorsHistogramQuery, Types.GetErrorsHistogramQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorsHistogramQuery, Types.GetErrorsHistogramQueryVariables>(GetErrorsHistogramDocument, baseOptions);
+      }
+export function useGetErrorsHistogramLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorsHistogramQuery, Types.GetErrorsHistogramQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorsHistogramQuery, Types.GetErrorsHistogramQueryVariables>(GetErrorsHistogramDocument, baseOptions);
+        }
+export type GetErrorsHistogramQueryHookResult = ReturnType<typeof useGetErrorsHistogramQuery>;
+export type GetErrorsHistogramLazyQueryHookResult = ReturnType<typeof useGetErrorsHistogramLazyQuery>;
+export type GetErrorsHistogramQueryResult = Apollo.QueryResult<Types.GetErrorsHistogramQuery, Types.GetErrorsHistogramQueryVariables>;
 export const GetProjectsDocument = gql`
-	query GetProjects {
-		projects {
-			id
-			name
-			workspace_id
-		}
-	}
-`
+    query GetProjects {
+  projects {
+    id
+    name
+    workspace_id
+  }
+}
+    `;
 
 /**
  * __useGetProjectsQuery__
@@ -7058,52 +4671,31 @@ export const GetProjectsDocument = gql`
  *   },
  * });
  */
-export function useGetProjectsQuery(
-	baseOptions?: Apollo.QueryHookOptions<
-		Types.GetProjectsQuery,
-		Types.GetProjectsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetProjectsQuery,
-		Types.GetProjectsQueryVariables
-	>(GetProjectsDocument, baseOptions)
-}
-export function useGetProjectsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetProjectsQuery,
-		Types.GetProjectsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetProjectsQuery,
-		Types.GetProjectsQueryVariables
-	>(GetProjectsDocument, baseOptions)
-}
-export type GetProjectsQueryHookResult = ReturnType<typeof useGetProjectsQuery>
-export type GetProjectsLazyQueryHookResult = ReturnType<
-	typeof useGetProjectsLazyQuery
->
-export type GetProjectsQueryResult = Apollo.QueryResult<
-	Types.GetProjectsQuery,
-	Types.GetProjectsQueryVariables
->
+export function useGetProjectsQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetProjectsQuery, Types.GetProjectsQueryVariables>) {
+        return Apollo.useQuery<Types.GetProjectsQuery, Types.GetProjectsQueryVariables>(GetProjectsDocument, baseOptions);
+      }
+export function useGetProjectsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectsQuery, Types.GetProjectsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetProjectsQuery, Types.GetProjectsQueryVariables>(GetProjectsDocument, baseOptions);
+        }
+export type GetProjectsQueryHookResult = ReturnType<typeof useGetProjectsQuery>;
+export type GetProjectsLazyQueryHookResult = ReturnType<typeof useGetProjectsLazyQuery>;
+export type GetProjectsQueryResult = Apollo.QueryResult<Types.GetProjectsQuery, Types.GetProjectsQueryVariables>;
 export const GetWorkspaceDocument = gql`
-	query GetWorkspace($id: ID!) {
-		workspace(id: $id) {
-			id
-			name
-			secret
-			plan_tier
-			unlimited_members
-			clearbit_enabled
-			projects {
-				id
-				name
-			}
-		}
-	}
-`
+    query GetWorkspace($id: ID!) {
+  workspace(id: $id) {
+    id
+    name
+    secret
+    plan_tier
+    unlimited_members
+    clearbit_enabled
+    projects {
+      id
+      name
+    }
+  }
+}
+    `;
 
 /**
  * __useGetWorkspaceQuery__
@@ -7121,50 +4713,27 @@ export const GetWorkspaceDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspaceQuery,
-		Types.GetWorkspaceQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspaceQuery,
-		Types.GetWorkspaceQueryVariables
-	>(GetWorkspaceDocument, baseOptions)
-}
-export function useGetWorkspaceLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspaceQuery,
-		Types.GetWorkspaceQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspaceQuery,
-		Types.GetWorkspaceQueryVariables
-	>(GetWorkspaceDocument, baseOptions)
-}
-export type GetWorkspaceQueryHookResult = ReturnType<
-	typeof useGetWorkspaceQuery
->
-export type GetWorkspaceLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspaceLazyQuery
->
-export type GetWorkspaceQueryResult = Apollo.QueryResult<
-	Types.GetWorkspaceQuery,
-	Types.GetWorkspaceQueryVariables
->
+export function useGetWorkspaceQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceQuery, Types.GetWorkspaceQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspaceQuery, Types.GetWorkspaceQueryVariables>(GetWorkspaceDocument, baseOptions);
+      }
+export function useGetWorkspaceLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceQuery, Types.GetWorkspaceQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspaceQuery, Types.GetWorkspaceQueryVariables>(GetWorkspaceDocument, baseOptions);
+        }
+export type GetWorkspaceQueryHookResult = ReturnType<typeof useGetWorkspaceQuery>;
+export type GetWorkspaceLazyQueryHookResult = ReturnType<typeof useGetWorkspaceLazyQuery>;
+export type GetWorkspaceQueryResult = Apollo.QueryResult<Types.GetWorkspaceQuery, Types.GetWorkspaceQueryVariables>;
 export const GetWorkspaceForInviteLinkDocument = gql`
-	query GetWorkspaceForInviteLink($secret: String!) {
-		workspace_for_invite_link(secret: $secret) {
-			expiration_date
-			existing_account
-			invitee_email
-			secret
-			workspace_id
-			workspace_name
-		}
-	}
-`
+    query GetWorkspaceForInviteLink($secret: String!) {
+  workspace_for_invite_link(secret: $secret) {
+    expiration_date
+    existing_account
+    invitee_email
+    secret
+    workspace_id
+    workspace_name
+  }
+}
+    `;
 
 /**
  * __useGetWorkspaceForInviteLinkQuery__
@@ -7182,53 +4751,30 @@ export const GetWorkspaceForInviteLinkDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceForInviteLinkQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspaceForInviteLinkQuery,
-		Types.GetWorkspaceForInviteLinkQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspaceForInviteLinkQuery,
-		Types.GetWorkspaceForInviteLinkQueryVariables
-	>(GetWorkspaceForInviteLinkDocument, baseOptions)
-}
-export function useGetWorkspaceForInviteLinkLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspaceForInviteLinkQuery,
-		Types.GetWorkspaceForInviteLinkQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspaceForInviteLinkQuery,
-		Types.GetWorkspaceForInviteLinkQueryVariables
-	>(GetWorkspaceForInviteLinkDocument, baseOptions)
-}
-export type GetWorkspaceForInviteLinkQueryHookResult = ReturnType<
-	typeof useGetWorkspaceForInviteLinkQuery
->
-export type GetWorkspaceForInviteLinkLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspaceForInviteLinkLazyQuery
->
-export type GetWorkspaceForInviteLinkQueryResult = Apollo.QueryResult<
-	Types.GetWorkspaceForInviteLinkQuery,
-	Types.GetWorkspaceForInviteLinkQueryVariables
->
+export function useGetWorkspaceForInviteLinkQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceForInviteLinkQuery, Types.GetWorkspaceForInviteLinkQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspaceForInviteLinkQuery, Types.GetWorkspaceForInviteLinkQueryVariables>(GetWorkspaceForInviteLinkDocument, baseOptions);
+      }
+export function useGetWorkspaceForInviteLinkLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceForInviteLinkQuery, Types.GetWorkspaceForInviteLinkQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspaceForInviteLinkQuery, Types.GetWorkspaceForInviteLinkQueryVariables>(GetWorkspaceForInviteLinkDocument, baseOptions);
+        }
+export type GetWorkspaceForInviteLinkQueryHookResult = ReturnType<typeof useGetWorkspaceForInviteLinkQuery>;
+export type GetWorkspaceForInviteLinkLazyQueryHookResult = ReturnType<typeof useGetWorkspaceForInviteLinkLazyQuery>;
+export type GetWorkspaceForInviteLinkQueryResult = Apollo.QueryResult<Types.GetWorkspaceForInviteLinkQuery, Types.GetWorkspaceForInviteLinkQueryVariables>;
 export const GetWorkspacesDocument = gql`
-	query GetWorkspaces {
-		workspaces {
-			id
-			name
-		}
-		joinable_workspaces {
-			id
-			name
-			projects {
-				id
-			}
-		}
-	}
-`
+    query GetWorkspaces {
+  workspaces {
+    id
+    name
+  }
+  joinable_workspaces {
+    id
+    name
+    projects {
+      id
+    }
+  }
+}
+    `;
 
 /**
  * __useGetWorkspacesQuery__
@@ -7245,43 +4791,20 @@ export const GetWorkspacesDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspacesQuery(
-	baseOptions?: Apollo.QueryHookOptions<
-		Types.GetWorkspacesQuery,
-		Types.GetWorkspacesQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspacesQuery,
-		Types.GetWorkspacesQueryVariables
-	>(GetWorkspacesDocument, baseOptions)
-}
-export function useGetWorkspacesLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspacesQuery,
-		Types.GetWorkspacesQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspacesQuery,
-		Types.GetWorkspacesQueryVariables
-	>(GetWorkspacesDocument, baseOptions)
-}
-export type GetWorkspacesQueryHookResult = ReturnType<
-	typeof useGetWorkspacesQuery
->
-export type GetWorkspacesLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspacesLazyQuery
->
-export type GetWorkspacesQueryResult = Apollo.QueryResult<
-	Types.GetWorkspacesQuery,
-	Types.GetWorkspacesQueryVariables
->
+export function useGetWorkspacesQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetWorkspacesQuery, Types.GetWorkspacesQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspacesQuery, Types.GetWorkspacesQueryVariables>(GetWorkspacesDocument, baseOptions);
+      }
+export function useGetWorkspacesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspacesQuery, Types.GetWorkspacesQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspacesQuery, Types.GetWorkspacesQueryVariables>(GetWorkspacesDocument, baseOptions);
+        }
+export type GetWorkspacesQueryHookResult = ReturnType<typeof useGetWorkspacesQuery>;
+export type GetWorkspacesLazyQueryHookResult = ReturnType<typeof useGetWorkspacesLazyQuery>;
+export type GetWorkspacesQueryResult = Apollo.QueryResult<Types.GetWorkspacesQuery, Types.GetWorkspacesQueryVariables>;
 export const GetWorkspacesCountDocument = gql`
-	query GetWorkspacesCount {
-		workspaces_count
-	}
-`
+    query GetWorkspacesCount {
+  workspaces_count
+}
+    `;
 
 /**
  * __useGetWorkspacesCountQuery__
@@ -7298,50 +4821,27 @@ export const GetWorkspacesCountDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspacesCountQuery(
-	baseOptions?: Apollo.QueryHookOptions<
-		Types.GetWorkspacesCountQuery,
-		Types.GetWorkspacesCountQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspacesCountQuery,
-		Types.GetWorkspacesCountQueryVariables
-	>(GetWorkspacesCountDocument, baseOptions)
-}
-export function useGetWorkspacesCountLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspacesCountQuery,
-		Types.GetWorkspacesCountQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspacesCountQuery,
-		Types.GetWorkspacesCountQueryVariables
-	>(GetWorkspacesCountDocument, baseOptions)
-}
-export type GetWorkspacesCountQueryHookResult = ReturnType<
-	typeof useGetWorkspacesCountQuery
->
-export type GetWorkspacesCountLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspacesCountLazyQuery
->
-export type GetWorkspacesCountQueryResult = Apollo.QueryResult<
-	Types.GetWorkspacesCountQuery,
-	Types.GetWorkspacesCountQueryVariables
->
+export function useGetWorkspacesCountQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetWorkspacesCountQuery, Types.GetWorkspacesCountQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspacesCountQuery, Types.GetWorkspacesCountQueryVariables>(GetWorkspacesCountDocument, baseOptions);
+      }
+export function useGetWorkspacesCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspacesCountQuery, Types.GetWorkspacesCountQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspacesCountQuery, Types.GetWorkspacesCountQueryVariables>(GetWorkspacesCountDocument, baseOptions);
+        }
+export type GetWorkspacesCountQueryHookResult = ReturnType<typeof useGetWorkspacesCountQuery>;
+export type GetWorkspacesCountLazyQueryHookResult = ReturnType<typeof useGetWorkspacesCountLazyQuery>;
+export type GetWorkspacesCountQueryResult = Apollo.QueryResult<Types.GetWorkspacesCountQuery, Types.GetWorkspacesCountQueryVariables>;
 export const GetProjectsAndWorkspacesDocument = gql`
-	query GetProjectsAndWorkspaces {
-		projects {
-			id
-			name
-		}
-		workspaces {
-			id
-			name
-		}
-	}
-`
+    query GetProjectsAndWorkspaces {
+  projects {
+    id
+    name
+  }
+  workspaces {
+    id
+    name
+  }
+}
+    `;
 
 /**
  * __useGetProjectsAndWorkspacesQuery__
@@ -7358,55 +4858,28 @@ export const GetProjectsAndWorkspacesDocument = gql`
  *   },
  * });
  */
-export function useGetProjectsAndWorkspacesQuery(
-	baseOptions?: Apollo.QueryHookOptions<
-		Types.GetProjectsAndWorkspacesQuery,
-		Types.GetProjectsAndWorkspacesQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetProjectsAndWorkspacesQuery,
-		Types.GetProjectsAndWorkspacesQueryVariables
-	>(GetProjectsAndWorkspacesDocument, baseOptions)
-}
-export function useGetProjectsAndWorkspacesLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetProjectsAndWorkspacesQuery,
-		Types.GetProjectsAndWorkspacesQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetProjectsAndWorkspacesQuery,
-		Types.GetProjectsAndWorkspacesQueryVariables
-	>(GetProjectsAndWorkspacesDocument, baseOptions)
-}
-export type GetProjectsAndWorkspacesQueryHookResult = ReturnType<
-	typeof useGetProjectsAndWorkspacesQuery
->
-export type GetProjectsAndWorkspacesLazyQueryHookResult = ReturnType<
-	typeof useGetProjectsAndWorkspacesLazyQuery
->
-export type GetProjectsAndWorkspacesQueryResult = Apollo.QueryResult<
-	Types.GetProjectsAndWorkspacesQuery,
-	Types.GetProjectsAndWorkspacesQueryVariables
->
+export function useGetProjectsAndWorkspacesQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetProjectsAndWorkspacesQuery, Types.GetProjectsAndWorkspacesQueryVariables>) {
+        return Apollo.useQuery<Types.GetProjectsAndWorkspacesQuery, Types.GetProjectsAndWorkspacesQueryVariables>(GetProjectsAndWorkspacesDocument, baseOptions);
+      }
+export function useGetProjectsAndWorkspacesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectsAndWorkspacesQuery, Types.GetProjectsAndWorkspacesQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetProjectsAndWorkspacesQuery, Types.GetProjectsAndWorkspacesQueryVariables>(GetProjectsAndWorkspacesDocument, baseOptions);
+        }
+export type GetProjectsAndWorkspacesQueryHookResult = ReturnType<typeof useGetProjectsAndWorkspacesQuery>;
+export type GetProjectsAndWorkspacesLazyQueryHookResult = ReturnType<typeof useGetProjectsAndWorkspacesLazyQuery>;
+export type GetProjectsAndWorkspacesQueryResult = Apollo.QueryResult<Types.GetProjectsAndWorkspacesQuery, Types.GetProjectsAndWorkspacesQueryVariables>;
 export const GetProjectOrWorkspaceDocument = gql`
-	query GetProjectOrWorkspace(
-		$project_id: ID!
-		$workspace_id: ID!
-		$is_workspace: Boolean!
-	) {
-		project(id: $project_id) @skip(if: $is_workspace) {
-			id
-			name
-			billing_email
-		}
-		workspace(id: $workspace_id) @include(if: $is_workspace) {
-			id
-			name
-		}
-	}
-`
+    query GetProjectOrWorkspace($project_id: ID!, $workspace_id: ID!, $is_workspace: Boolean!) {
+  project(id: $project_id) @skip(if: $is_workspace) {
+    id
+    name
+    billing_email
+  }
+  workspace(id: $workspace_id) @include(if: $is_workspace) {
+    id
+    name
+  }
+}
+    `;
 
 /**
  * __useGetProjectOrWorkspaceQuery__
@@ -7426,70 +4899,47 @@ export const GetProjectOrWorkspaceDocument = gql`
  *   },
  * });
  */
-export function useGetProjectOrWorkspaceQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetProjectOrWorkspaceQuery,
-		Types.GetProjectOrWorkspaceQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetProjectOrWorkspaceQuery,
-		Types.GetProjectOrWorkspaceQueryVariables
-	>(GetProjectOrWorkspaceDocument, baseOptions)
-}
-export function useGetProjectOrWorkspaceLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetProjectOrWorkspaceQuery,
-		Types.GetProjectOrWorkspaceQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetProjectOrWorkspaceQuery,
-		Types.GetProjectOrWorkspaceQueryVariables
-	>(GetProjectOrWorkspaceDocument, baseOptions)
-}
-export type GetProjectOrWorkspaceQueryHookResult = ReturnType<
-	typeof useGetProjectOrWorkspaceQuery
->
-export type GetProjectOrWorkspaceLazyQueryHookResult = ReturnType<
-	typeof useGetProjectOrWorkspaceLazyQuery
->
-export type GetProjectOrWorkspaceQueryResult = Apollo.QueryResult<
-	Types.GetProjectOrWorkspaceQuery,
-	Types.GetProjectOrWorkspaceQueryVariables
->
+export function useGetProjectOrWorkspaceQuery(baseOptions: Apollo.QueryHookOptions<Types.GetProjectOrWorkspaceQuery, Types.GetProjectOrWorkspaceQueryVariables>) {
+        return Apollo.useQuery<Types.GetProjectOrWorkspaceQuery, Types.GetProjectOrWorkspaceQueryVariables>(GetProjectOrWorkspaceDocument, baseOptions);
+      }
+export function useGetProjectOrWorkspaceLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectOrWorkspaceQuery, Types.GetProjectOrWorkspaceQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetProjectOrWorkspaceQuery, Types.GetProjectOrWorkspaceQueryVariables>(GetProjectOrWorkspaceDocument, baseOptions);
+        }
+export type GetProjectOrWorkspaceQueryHookResult = ReturnType<typeof useGetProjectOrWorkspaceQuery>;
+export type GetProjectOrWorkspaceLazyQueryHookResult = ReturnType<typeof useGetProjectOrWorkspaceLazyQuery>;
+export type GetProjectOrWorkspaceQueryResult = Apollo.QueryResult<Types.GetProjectOrWorkspaceQuery, Types.GetProjectOrWorkspaceQueryVariables>;
 export const GetProjectDropdownOptionsDocument = gql`
-	query GetProjectDropdownOptions($project_id: ID!) {
-		project(id: $project_id) {
-			id
-			name
-			verbose_id
-			billing_email
-			secret
-			workspace_id
-			error_filters
-		}
-		workspace: workspace_for_project(project_id: $project_id) {
-			id
-			name
-			projects {
-				id
-				name
-			}
-		}
-		workspaces {
-			id
-			name
-		}
-		joinable_workspaces {
-			id
-			name
-			projects {
-				id
-			}
-		}
-	}
-`
+    query GetProjectDropdownOptions($project_id: ID!) {
+  project(id: $project_id) {
+    id
+    name
+    verbose_id
+    billing_email
+    secret
+    workspace_id
+    error_filters
+  }
+  workspace: workspace_for_project(project_id: $project_id) {
+    id
+    name
+    projects {
+      id
+      name
+    }
+  }
+  workspaces {
+    id
+    name
+  }
+  joinable_workspaces {
+    id
+    name
+    projects {
+      id
+    }
+  }
+}
+    `;
 
 /**
  * __useGetProjectDropdownOptionsQuery__
@@ -7507,61 +4957,38 @@ export const GetProjectDropdownOptionsDocument = gql`
  *   },
  * });
  */
-export function useGetProjectDropdownOptionsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetProjectDropdownOptionsQuery,
-		Types.GetProjectDropdownOptionsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetProjectDropdownOptionsQuery,
-		Types.GetProjectDropdownOptionsQueryVariables
-	>(GetProjectDropdownOptionsDocument, baseOptions)
-}
-export function useGetProjectDropdownOptionsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetProjectDropdownOptionsQuery,
-		Types.GetProjectDropdownOptionsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetProjectDropdownOptionsQuery,
-		Types.GetProjectDropdownOptionsQueryVariables
-	>(GetProjectDropdownOptionsDocument, baseOptions)
-}
-export type GetProjectDropdownOptionsQueryHookResult = ReturnType<
-	typeof useGetProjectDropdownOptionsQuery
->
-export type GetProjectDropdownOptionsLazyQueryHookResult = ReturnType<
-	typeof useGetProjectDropdownOptionsLazyQuery
->
-export type GetProjectDropdownOptionsQueryResult = Apollo.QueryResult<
-	Types.GetProjectDropdownOptionsQuery,
-	Types.GetProjectDropdownOptionsQueryVariables
->
+export function useGetProjectDropdownOptionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetProjectDropdownOptionsQuery, Types.GetProjectDropdownOptionsQueryVariables>) {
+        return Apollo.useQuery<Types.GetProjectDropdownOptionsQuery, Types.GetProjectDropdownOptionsQueryVariables>(GetProjectDropdownOptionsDocument, baseOptions);
+      }
+export function useGetProjectDropdownOptionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectDropdownOptionsQuery, Types.GetProjectDropdownOptionsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetProjectDropdownOptionsQuery, Types.GetProjectDropdownOptionsQueryVariables>(GetProjectDropdownOptionsDocument, baseOptions);
+        }
+export type GetProjectDropdownOptionsQueryHookResult = ReturnType<typeof useGetProjectDropdownOptionsQuery>;
+export type GetProjectDropdownOptionsLazyQueryHookResult = ReturnType<typeof useGetProjectDropdownOptionsLazyQuery>;
+export type GetProjectDropdownOptionsQueryResult = Apollo.QueryResult<Types.GetProjectDropdownOptionsQuery, Types.GetProjectDropdownOptionsQueryVariables>;
 export const GetWorkspaceDropdownOptionsDocument = gql`
-	query GetWorkspaceDropdownOptions($workspace_id: ID!) {
-		workspace(id: $workspace_id) {
-			id
-			name
-			projects {
-				id
-				name
-			}
-		}
-		workspaces {
-			id
-			name
-		}
-		joinable_workspaces {
-			id
-			name
-			projects {
-				id
-			}
-		}
-	}
-`
+    query GetWorkspaceDropdownOptions($workspace_id: ID!) {
+  workspace(id: $workspace_id) {
+    id
+    name
+    projects {
+      id
+      name
+    }
+  }
+  workspaces {
+    id
+    name
+  }
+  joinable_workspaces {
+    id
+    name
+    projects {
+      id
+    }
+  }
+}
+    `;
 
 /**
  * __useGetWorkspaceDropdownOptionsQuery__
@@ -7579,54 +5006,31 @@ export const GetWorkspaceDropdownOptionsDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceDropdownOptionsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspaceDropdownOptionsQuery,
-		Types.GetWorkspaceDropdownOptionsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspaceDropdownOptionsQuery,
-		Types.GetWorkspaceDropdownOptionsQueryVariables
-	>(GetWorkspaceDropdownOptionsDocument, baseOptions)
-}
-export function useGetWorkspaceDropdownOptionsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspaceDropdownOptionsQuery,
-		Types.GetWorkspaceDropdownOptionsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspaceDropdownOptionsQuery,
-		Types.GetWorkspaceDropdownOptionsQueryVariables
-	>(GetWorkspaceDropdownOptionsDocument, baseOptions)
-}
-export type GetWorkspaceDropdownOptionsQueryHookResult = ReturnType<
-	typeof useGetWorkspaceDropdownOptionsQuery
->
-export type GetWorkspaceDropdownOptionsLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspaceDropdownOptionsLazyQuery
->
-export type GetWorkspaceDropdownOptionsQueryResult = Apollo.QueryResult<
-	Types.GetWorkspaceDropdownOptionsQuery,
-	Types.GetWorkspaceDropdownOptionsQueryVariables
->
+export function useGetWorkspaceDropdownOptionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceDropdownOptionsQuery, Types.GetWorkspaceDropdownOptionsQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspaceDropdownOptionsQuery, Types.GetWorkspaceDropdownOptionsQueryVariables>(GetWorkspaceDropdownOptionsDocument, baseOptions);
+      }
+export function useGetWorkspaceDropdownOptionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceDropdownOptionsQuery, Types.GetWorkspaceDropdownOptionsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspaceDropdownOptionsQuery, Types.GetWorkspaceDropdownOptionsQueryVariables>(GetWorkspaceDropdownOptionsDocument, baseOptions);
+        }
+export type GetWorkspaceDropdownOptionsQueryHookResult = ReturnType<typeof useGetWorkspaceDropdownOptionsQuery>;
+export type GetWorkspaceDropdownOptionsLazyQueryHookResult = ReturnType<typeof useGetWorkspaceDropdownOptionsLazyQuery>;
+export type GetWorkspaceDropdownOptionsQueryResult = Apollo.QueryResult<Types.GetWorkspaceDropdownOptionsQuery, Types.GetWorkspaceDropdownOptionsQueryVariables>;
 export const GetAdminDocument = gql`
-	query GetAdmin {
-		admin {
-			id
-			uid
-			name
-			email
-			phone
-			photo_url
-			slack_im_channel_id
-			email_verified
-			user_defined_role
-			about_you_details_filled
-		}
-	}
-`
+    query GetAdmin {
+  admin {
+    id
+    uid
+    name
+    email
+    phone
+    photo_url
+    slack_im_channel_id
+    email_verified
+    user_defined_role
+    about_you_details_filled
+  }
+}
+    `;
 
 /**
  * __useGetAdminQuery__
@@ -7643,55 +5047,34 @@ export const GetAdminDocument = gql`
  *   },
  * });
  */
-export function useGetAdminQuery(
-	baseOptions?: Apollo.QueryHookOptions<
-		Types.GetAdminQuery,
-		Types.GetAdminQueryVariables
-	>,
-) {
-	return Apollo.useQuery<Types.GetAdminQuery, Types.GetAdminQueryVariables>(
-		GetAdminDocument,
-		baseOptions,
-	)
-}
-export function useGetAdminLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetAdminQuery,
-		Types.GetAdminQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetAdminQuery,
-		Types.GetAdminQueryVariables
-	>(GetAdminDocument, baseOptions)
-}
-export type GetAdminQueryHookResult = ReturnType<typeof useGetAdminQuery>
-export type GetAdminLazyQueryHookResult = ReturnType<
-	typeof useGetAdminLazyQuery
->
-export type GetAdminQueryResult = Apollo.QueryResult<
-	Types.GetAdminQuery,
-	Types.GetAdminQueryVariables
->
+export function useGetAdminQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetAdminQuery, Types.GetAdminQueryVariables>) {
+        return Apollo.useQuery<Types.GetAdminQuery, Types.GetAdminQueryVariables>(GetAdminDocument, baseOptions);
+      }
+export function useGetAdminLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAdminQuery, Types.GetAdminQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetAdminQuery, Types.GetAdminQueryVariables>(GetAdminDocument, baseOptions);
+        }
+export type GetAdminQueryHookResult = ReturnType<typeof useGetAdminQuery>;
+export type GetAdminLazyQueryHookResult = ReturnType<typeof useGetAdminLazyQuery>;
+export type GetAdminQueryResult = Apollo.QueryResult<Types.GetAdminQuery, Types.GetAdminQueryVariables>;
 export const GetAdminRoleDocument = gql`
-	query GetAdminRole($workspace_id: ID!) {
-		admin_role(workspace_id: $workspace_id) {
-			admin {
-				id
-				uid
-				name
-				email
-				phone
-				photo_url
-				slack_im_channel_id
-				email_verified
-				user_defined_role
-				about_you_details_filled
-			}
-			role
-		}
-	}
-`
+    query GetAdminRole($workspace_id: ID!) {
+  admin_role(workspace_id: $workspace_id) {
+    admin {
+      id
+      uid
+      name
+      email
+      phone
+      photo_url
+      slack_im_channel_id
+      email_verified
+      user_defined_role
+      about_you_details_filled
+    }
+    role
+  }
+}
+    `;
 
 /**
  * __useGetAdminRoleQuery__
@@ -7709,57 +5092,34 @@ export const GetAdminRoleDocument = gql`
  *   },
  * });
  */
-export function useGetAdminRoleQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetAdminRoleQuery,
-		Types.GetAdminRoleQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetAdminRoleQuery,
-		Types.GetAdminRoleQueryVariables
-	>(GetAdminRoleDocument, baseOptions)
-}
-export function useGetAdminRoleLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetAdminRoleQuery,
-		Types.GetAdminRoleQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetAdminRoleQuery,
-		Types.GetAdminRoleQueryVariables
-	>(GetAdminRoleDocument, baseOptions)
-}
-export type GetAdminRoleQueryHookResult = ReturnType<
-	typeof useGetAdminRoleQuery
->
-export type GetAdminRoleLazyQueryHookResult = ReturnType<
-	typeof useGetAdminRoleLazyQuery
->
-export type GetAdminRoleQueryResult = Apollo.QueryResult<
-	Types.GetAdminRoleQuery,
-	Types.GetAdminRoleQueryVariables
->
+export function useGetAdminRoleQuery(baseOptions: Apollo.QueryHookOptions<Types.GetAdminRoleQuery, Types.GetAdminRoleQueryVariables>) {
+        return Apollo.useQuery<Types.GetAdminRoleQuery, Types.GetAdminRoleQueryVariables>(GetAdminRoleDocument, baseOptions);
+      }
+export function useGetAdminRoleLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAdminRoleQuery, Types.GetAdminRoleQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetAdminRoleQuery, Types.GetAdminRoleQueryVariables>(GetAdminRoleDocument, baseOptions);
+        }
+export type GetAdminRoleQueryHookResult = ReturnType<typeof useGetAdminRoleQuery>;
+export type GetAdminRoleLazyQueryHookResult = ReturnType<typeof useGetAdminRoleLazyQuery>;
+export type GetAdminRoleQueryResult = Apollo.QueryResult<Types.GetAdminRoleQuery, Types.GetAdminRoleQueryVariables>;
 export const GetAdminRoleByProjectDocument = gql`
-	query GetAdminRoleByProject($project_id: ID!) {
-		admin_role_by_project(project_id: $project_id) {
-			admin {
-				id
-				uid
-				name
-				email
-				phone
-				photo_url
-				slack_im_channel_id
-				email_verified
-				user_defined_role
-				about_you_details_filled
-			}
-			role
-		}
-	}
-`
+    query GetAdminRoleByProject($project_id: ID!) {
+  admin_role_by_project(project_id: $project_id) {
+    admin {
+      id
+      uid
+      name
+      email
+      phone
+      photo_url
+      slack_im_channel_id
+      email_verified
+      user_defined_role
+      about_you_details_filled
+    }
+    role
+  }
+}
+    `;
 
 /**
  * __useGetAdminRoleByProjectQuery__
@@ -7777,48 +5137,25 @@ export const GetAdminRoleByProjectDocument = gql`
  *   },
  * });
  */
-export function useGetAdminRoleByProjectQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetAdminRoleByProjectQuery,
-		Types.GetAdminRoleByProjectQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetAdminRoleByProjectQuery,
-		Types.GetAdminRoleByProjectQueryVariables
-	>(GetAdminRoleByProjectDocument, baseOptions)
-}
-export function useGetAdminRoleByProjectLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetAdminRoleByProjectQuery,
-		Types.GetAdminRoleByProjectQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetAdminRoleByProjectQuery,
-		Types.GetAdminRoleByProjectQueryVariables
-	>(GetAdminRoleByProjectDocument, baseOptions)
-}
-export type GetAdminRoleByProjectQueryHookResult = ReturnType<
-	typeof useGetAdminRoleByProjectQuery
->
-export type GetAdminRoleByProjectLazyQueryHookResult = ReturnType<
-	typeof useGetAdminRoleByProjectLazyQuery
->
-export type GetAdminRoleByProjectQueryResult = Apollo.QueryResult<
-	Types.GetAdminRoleByProjectQuery,
-	Types.GetAdminRoleByProjectQueryVariables
->
+export function useGetAdminRoleByProjectQuery(baseOptions: Apollo.QueryHookOptions<Types.GetAdminRoleByProjectQuery, Types.GetAdminRoleByProjectQueryVariables>) {
+        return Apollo.useQuery<Types.GetAdminRoleByProjectQuery, Types.GetAdminRoleByProjectQueryVariables>(GetAdminRoleByProjectDocument, baseOptions);
+      }
+export function useGetAdminRoleByProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAdminRoleByProjectQuery, Types.GetAdminRoleByProjectQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetAdminRoleByProjectQuery, Types.GetAdminRoleByProjectQueryVariables>(GetAdminRoleByProjectDocument, baseOptions);
+        }
+export type GetAdminRoleByProjectQueryHookResult = ReturnType<typeof useGetAdminRoleByProjectQuery>;
+export type GetAdminRoleByProjectLazyQueryHookResult = ReturnType<typeof useGetAdminRoleByProjectLazyQuery>;
+export type GetAdminRoleByProjectQueryResult = Apollo.QueryResult<Types.GetAdminRoleByProjectQuery, Types.GetAdminRoleByProjectQueryVariables>;
 export const GetAdminAboutYouDocument = gql`
-	query GetAdminAboutYou {
-		admin {
-			id
-			name
-			user_defined_role
-			referral
-		}
-	}
-`
+    query GetAdminAboutYou {
+  admin {
+    id
+    name
+    user_defined_role
+    referral
+  }
+}
+    `;
 
 /**
  * __useGetAdminAboutYouQuery__
@@ -7835,61 +5172,38 @@ export const GetAdminAboutYouDocument = gql`
  *   },
  * });
  */
-export function useGetAdminAboutYouQuery(
-	baseOptions?: Apollo.QueryHookOptions<
-		Types.GetAdminAboutYouQuery,
-		Types.GetAdminAboutYouQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetAdminAboutYouQuery,
-		Types.GetAdminAboutYouQueryVariables
-	>(GetAdminAboutYouDocument, baseOptions)
-}
-export function useGetAdminAboutYouLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetAdminAboutYouQuery,
-		Types.GetAdminAboutYouQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetAdminAboutYouQuery,
-		Types.GetAdminAboutYouQueryVariables
-	>(GetAdminAboutYouDocument, baseOptions)
-}
-export type GetAdminAboutYouQueryHookResult = ReturnType<
-	typeof useGetAdminAboutYouQuery
->
-export type GetAdminAboutYouLazyQueryHookResult = ReturnType<
-	typeof useGetAdminAboutYouLazyQuery
->
-export type GetAdminAboutYouQueryResult = Apollo.QueryResult<
-	Types.GetAdminAboutYouQuery,
-	Types.GetAdminAboutYouQueryVariables
->
+export function useGetAdminAboutYouQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetAdminAboutYouQuery, Types.GetAdminAboutYouQueryVariables>) {
+        return Apollo.useQuery<Types.GetAdminAboutYouQuery, Types.GetAdminAboutYouQueryVariables>(GetAdminAboutYouDocument, baseOptions);
+      }
+export function useGetAdminAboutYouLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAdminAboutYouQuery, Types.GetAdminAboutYouQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetAdminAboutYouQuery, Types.GetAdminAboutYouQueryVariables>(GetAdminAboutYouDocument, baseOptions);
+        }
+export type GetAdminAboutYouQueryHookResult = ReturnType<typeof useGetAdminAboutYouQuery>;
+export type GetAdminAboutYouLazyQueryHookResult = ReturnType<typeof useGetAdminAboutYouLazyQuery>;
+export type GetAdminAboutYouQueryResult = Apollo.QueryResult<Types.GetAdminAboutYouQuery, Types.GetAdminAboutYouQueryVariables>;
 export const GetProjectDocument = gql`
-	query GetProject($id: ID!) {
-		project(id: $id) {
-			id
-			name
-			verbose_id
-			billing_email
-			excluded_users
-			error_filters
-			error_json_paths
-			filter_chrome_extension
-			rage_click_window_seconds
-			rage_click_radius_pixels
-			rage_click_count
-			backend_domains
-			secret
-		}
-		workspace: workspace_for_project(project_id: $id) {
-			id
-			slack_webhook_channel
-		}
-	}
-`
+    query GetProject($id: ID!) {
+  project(id: $id) {
+    id
+    name
+    verbose_id
+    billing_email
+    excluded_users
+    error_filters
+    error_json_paths
+    filter_chrome_extension
+    rage_click_window_seconds
+    rage_click_radius_pixels
+    rage_click_count
+    backend_domains
+    secret
+  }
+  workspace: workspace_for_project(project_id: $id) {
+    id
+    slack_webhook_channel
+  }
+}
+    `;
 
 /**
  * __useGetProjectQuery__
@@ -7907,66 +5221,45 @@ export const GetProjectDocument = gql`
  *   },
  * });
  */
-export function useGetProjectQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetProjectQuery,
-		Types.GetProjectQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetProjectQuery,
-		Types.GetProjectQueryVariables
-	>(GetProjectDocument, baseOptions)
-}
-export function useGetProjectLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetProjectQuery,
-		Types.GetProjectQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetProjectQuery,
-		Types.GetProjectQueryVariables
-	>(GetProjectDocument, baseOptions)
-}
-export type GetProjectQueryHookResult = ReturnType<typeof useGetProjectQuery>
-export type GetProjectLazyQueryHookResult = ReturnType<
-	typeof useGetProjectLazyQuery
->
-export type GetProjectQueryResult = Apollo.QueryResult<
-	Types.GetProjectQuery,
-	Types.GetProjectQueryVariables
->
+export function useGetProjectQuery(baseOptions: Apollo.QueryHookOptions<Types.GetProjectQuery, Types.GetProjectQueryVariables>) {
+        return Apollo.useQuery<Types.GetProjectQuery, Types.GetProjectQueryVariables>(GetProjectDocument, baseOptions);
+      }
+export function useGetProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectQuery, Types.GetProjectQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetProjectQuery, Types.GetProjectQueryVariables>(GetProjectDocument, baseOptions);
+        }
+export type GetProjectQueryHookResult = ReturnType<typeof useGetProjectQuery>;
+export type GetProjectLazyQueryHookResult = ReturnType<typeof useGetProjectLazyQuery>;
+export type GetProjectQueryResult = Apollo.QueryResult<Types.GetProjectQuery, Types.GetProjectQueryVariables>;
 export const GetBillingDetailsForProjectDocument = gql`
-	query GetBillingDetailsForProject($project_id: ID!) {
-		billingDetailsForProject(project_id: $project_id) {
-			plan {
-				type
-				quota
-				interval
-				membersLimit
-				errorsLimit
-				logsLimit
-			}
-			meter
-			membersMeter
-			errorsMeter
-			logsMeter
-			sessionsBillingLimit
-			errorsBillingLimit
-			logsBillingLimit
-		}
-		workspace_for_project(project_id: $project_id) {
-			id
-			trial_end_date
-			billing_period_end
-			next_invoice_date
-			allow_meter_overage
-			eligible_for_trial_extension
-			trial_extension_enabled
-		}
-	}
-`
+    query GetBillingDetailsForProject($project_id: ID!) {
+  billingDetailsForProject(project_id: $project_id) {
+    plan {
+      type
+      quota
+      interval
+      membersLimit
+      errorsLimit
+      logsLimit
+    }
+    meter
+    membersMeter
+    errorsMeter
+    logsMeter
+    sessionsBillingLimit
+    errorsBillingLimit
+    logsBillingLimit
+  }
+  workspace_for_project(project_id: $project_id) {
+    id
+    trial_end_date
+    billing_period_end
+    next_invoice_date
+    allow_meter_overage
+    eligible_for_trial_extension
+    trial_extension_enabled
+  }
+}
+    `;
 
 /**
  * __useGetBillingDetailsForProjectQuery__
@@ -7984,88 +5277,65 @@ export const GetBillingDetailsForProjectDocument = gql`
  *   },
  * });
  */
-export function useGetBillingDetailsForProjectQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetBillingDetailsForProjectQuery,
-		Types.GetBillingDetailsForProjectQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetBillingDetailsForProjectQuery,
-		Types.GetBillingDetailsForProjectQueryVariables
-	>(GetBillingDetailsForProjectDocument, baseOptions)
-}
-export function useGetBillingDetailsForProjectLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetBillingDetailsForProjectQuery,
-		Types.GetBillingDetailsForProjectQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetBillingDetailsForProjectQuery,
-		Types.GetBillingDetailsForProjectQueryVariables
-	>(GetBillingDetailsForProjectDocument, baseOptions)
-}
-export type GetBillingDetailsForProjectQueryHookResult = ReturnType<
-	typeof useGetBillingDetailsForProjectQuery
->
-export type GetBillingDetailsForProjectLazyQueryHookResult = ReturnType<
-	typeof useGetBillingDetailsForProjectLazyQuery
->
-export type GetBillingDetailsForProjectQueryResult = Apollo.QueryResult<
-	Types.GetBillingDetailsForProjectQuery,
-	Types.GetBillingDetailsForProjectQueryVariables
->
+export function useGetBillingDetailsForProjectQuery(baseOptions: Apollo.QueryHookOptions<Types.GetBillingDetailsForProjectQuery, Types.GetBillingDetailsForProjectQueryVariables>) {
+        return Apollo.useQuery<Types.GetBillingDetailsForProjectQuery, Types.GetBillingDetailsForProjectQueryVariables>(GetBillingDetailsForProjectDocument, baseOptions);
+      }
+export function useGetBillingDetailsForProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetBillingDetailsForProjectQuery, Types.GetBillingDetailsForProjectQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetBillingDetailsForProjectQuery, Types.GetBillingDetailsForProjectQueryVariables>(GetBillingDetailsForProjectDocument, baseOptions);
+        }
+export type GetBillingDetailsForProjectQueryHookResult = ReturnType<typeof useGetBillingDetailsForProjectQuery>;
+export type GetBillingDetailsForProjectLazyQueryHookResult = ReturnType<typeof useGetBillingDetailsForProjectLazyQuery>;
+export type GetBillingDetailsForProjectQueryResult = Apollo.QueryResult<Types.GetBillingDetailsForProjectQuery, Types.GetBillingDetailsForProjectQueryVariables>;
 export const GetBillingDetailsDocument = gql`
-	query GetBillingDetails($workspace_id: ID!) {
-		billingDetails(workspace_id: $workspace_id) {
-			plan {
-				type
-				quota
-				interval
-				membersLimit
-				errorsLimit
-				logsLimit
-			}
-			meter
-			membersMeter
-			errorsMeter
-			logsMeter
-			sessionsBillingLimit
-			errorsBillingLimit
-			logsBillingLimit
-			sessionsDailyAverage
-			errorsDailyAverage
-			logsDailyAverage
-		}
-		subscription_details(workspace_id: $workspace_id) {
-			baseAmount
-			discountAmount
-			discountPercent
-			lastInvoice {
-				amountDue
-				amountPaid
-				attemptCount
-				date
-				url
-				status
-			}
-		}
-		workspace(id: $workspace_id) {
-			id
-			trial_end_date
-			billing_period_end
-			next_invoice_date
-			allow_meter_overage
-			eligible_for_trial_extension
-			retention_period
-			errors_retention_period
-			sessions_max_cents
-			errors_max_cents
-			logs_max_cents
-		}
-	}
-`
+    query GetBillingDetails($workspace_id: ID!) {
+  billingDetails(workspace_id: $workspace_id) {
+    plan {
+      type
+      quota
+      interval
+      membersLimit
+      errorsLimit
+      logsLimit
+    }
+    meter
+    membersMeter
+    errorsMeter
+    logsMeter
+    sessionsBillingLimit
+    errorsBillingLimit
+    logsBillingLimit
+    sessionsDailyAverage
+    errorsDailyAverage
+    logsDailyAverage
+  }
+  subscription_details(workspace_id: $workspace_id) {
+    baseAmount
+    discountAmount
+    discountPercent
+    lastInvoice {
+      amountDue
+      amountPaid
+      attemptCount
+      date
+      url
+      status
+    }
+  }
+  workspace(id: $workspace_id) {
+    id
+    trial_end_date
+    billing_period_end
+    next_invoice_date
+    allow_meter_overage
+    eligible_for_trial_extension
+    retention_period
+    errors_retention_period
+    sessions_max_cents
+    errors_max_cents
+    logs_max_cents
+  }
+}
+    `;
 
 /**
  * __useGetBillingDetailsQuery__
@@ -8083,55 +5353,32 @@ export const GetBillingDetailsDocument = gql`
  *   },
  * });
  */
-export function useGetBillingDetailsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetBillingDetailsQuery,
-		Types.GetBillingDetailsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetBillingDetailsQuery,
-		Types.GetBillingDetailsQueryVariables
-	>(GetBillingDetailsDocument, baseOptions)
-}
-export function useGetBillingDetailsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetBillingDetailsQuery,
-		Types.GetBillingDetailsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetBillingDetailsQuery,
-		Types.GetBillingDetailsQueryVariables
-	>(GetBillingDetailsDocument, baseOptions)
-}
-export type GetBillingDetailsQueryHookResult = ReturnType<
-	typeof useGetBillingDetailsQuery
->
-export type GetBillingDetailsLazyQueryHookResult = ReturnType<
-	typeof useGetBillingDetailsLazyQuery
->
-export type GetBillingDetailsQueryResult = Apollo.QueryResult<
-	Types.GetBillingDetailsQuery,
-	Types.GetBillingDetailsQueryVariables
->
+export function useGetBillingDetailsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetBillingDetailsQuery, Types.GetBillingDetailsQueryVariables>) {
+        return Apollo.useQuery<Types.GetBillingDetailsQuery, Types.GetBillingDetailsQueryVariables>(GetBillingDetailsDocument, baseOptions);
+      }
+export function useGetBillingDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetBillingDetailsQuery, Types.GetBillingDetailsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetBillingDetailsQuery, Types.GetBillingDetailsQueryVariables>(GetBillingDetailsDocument, baseOptions);
+        }
+export type GetBillingDetailsQueryHookResult = ReturnType<typeof useGetBillingDetailsQuery>;
+export type GetBillingDetailsLazyQueryHookResult = ReturnType<typeof useGetBillingDetailsLazyQuery>;
+export type GetBillingDetailsQueryResult = Apollo.QueryResult<Types.GetBillingDetailsQuery, Types.GetBillingDetailsQueryVariables>;
 export const GetSubscriptionDetailsDocument = gql`
-	query GetSubscriptionDetails($workspace_id: ID!) {
-		subscription_details(workspace_id: $workspace_id) {
-			baseAmount
-			discountAmount
-			discountPercent
-			lastInvoice {
-				amountDue
-				amountPaid
-				attemptCount
-				date
-				url
-				status
-			}
-		}
-	}
-`
+    query GetSubscriptionDetails($workspace_id: ID!) {
+  subscription_details(workspace_id: $workspace_id) {
+    baseAmount
+    discountAmount
+    discountPercent
+    lastInvoice {
+      amountDue
+      amountPaid
+      attemptCount
+      date
+      url
+      status
+    }
+  }
+}
+    `;
 
 /**
  * __useGetSubscriptionDetailsQuery__
@@ -8149,79 +5396,56 @@ export const GetSubscriptionDetailsDocument = gql`
  *   },
  * });
  */
-export function useGetSubscriptionDetailsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSubscriptionDetailsQuery,
-		Types.GetSubscriptionDetailsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSubscriptionDetailsQuery,
-		Types.GetSubscriptionDetailsQueryVariables
-	>(GetSubscriptionDetailsDocument, baseOptions)
-}
-export function useGetSubscriptionDetailsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSubscriptionDetailsQuery,
-		Types.GetSubscriptionDetailsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSubscriptionDetailsQuery,
-		Types.GetSubscriptionDetailsQueryVariables
-	>(GetSubscriptionDetailsDocument, baseOptions)
-}
-export type GetSubscriptionDetailsQueryHookResult = ReturnType<
-	typeof useGetSubscriptionDetailsQuery
->
-export type GetSubscriptionDetailsLazyQueryHookResult = ReturnType<
-	typeof useGetSubscriptionDetailsLazyQuery
->
-export type GetSubscriptionDetailsQueryResult = Apollo.QueryResult<
-	Types.GetSubscriptionDetailsQuery,
-	Types.GetSubscriptionDetailsQueryVariables
->
+export function useGetSubscriptionDetailsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSubscriptionDetailsQuery, Types.GetSubscriptionDetailsQueryVariables>) {
+        return Apollo.useQuery<Types.GetSubscriptionDetailsQuery, Types.GetSubscriptionDetailsQueryVariables>(GetSubscriptionDetailsDocument, baseOptions);
+      }
+export function useGetSubscriptionDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSubscriptionDetailsQuery, Types.GetSubscriptionDetailsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSubscriptionDetailsQuery, Types.GetSubscriptionDetailsQueryVariables>(GetSubscriptionDetailsDocument, baseOptions);
+        }
+export type GetSubscriptionDetailsQueryHookResult = ReturnType<typeof useGetSubscriptionDetailsQuery>;
+export type GetSubscriptionDetailsLazyQueryHookResult = ReturnType<typeof useGetSubscriptionDetailsLazyQuery>;
+export type GetSubscriptionDetailsQueryResult = Apollo.QueryResult<Types.GetSubscriptionDetailsQuery, Types.GetSubscriptionDetailsQueryVariables>;
 export const GetErrorGroupDocument = gql`
-	query GetErrorGroup($secure_id: String!) {
-		error_group(secure_id: $secure_id) {
-			created_at
-			updated_at
-			id
-			secure_id
-			type
-			project_id
-			event
-			state
-			snoozed_until
-			structured_stack_trace {
-				fileName
-				lineNumber
-				functionName
-				columnNumber
-				lineContent
-				linesBefore
-				linesAfter
-				error
-			}
-			mapped_stack_trace
-			stack_trace
-			fields {
-				name
-				value
-			}
-			error_frequency
-			error_metrics {
-				error_group_id
-				date
-				name
-				value
-			}
-			is_public
-			last_occurrence
-			first_occurrence
-		}
-	}
-`
+    query GetErrorGroup($secure_id: String!) {
+  error_group(secure_id: $secure_id) {
+    created_at
+    updated_at
+    id
+    secure_id
+    type
+    project_id
+    event
+    state
+    snoozed_until
+    structured_stack_trace {
+      fileName
+      lineNumber
+      functionName
+      columnNumber
+      lineContent
+      linesBefore
+      linesAfter
+      error
+    }
+    mapped_stack_trace
+    stack_trace
+    fields {
+      name
+      value
+    }
+    error_frequency
+    error_metrics {
+      error_group_id
+      date
+      name
+      value
+    }
+    is_public
+    last_occurrence
+    first_occurrence
+  }
+}
+    `;
 
 /**
  * __useGetErrorGroupQuery__
@@ -8239,47 +5463,24 @@ export const GetErrorGroupDocument = gql`
  *   },
  * });
  */
-export function useGetErrorGroupQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorGroupQuery,
-		Types.GetErrorGroupQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorGroupQuery,
-		Types.GetErrorGroupQueryVariables
-	>(GetErrorGroupDocument, baseOptions)
-}
-export function useGetErrorGroupLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorGroupQuery,
-		Types.GetErrorGroupQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorGroupQuery,
-		Types.GetErrorGroupQueryVariables
-	>(GetErrorGroupDocument, baseOptions)
-}
-export type GetErrorGroupQueryHookResult = ReturnType<
-	typeof useGetErrorGroupQuery
->
-export type GetErrorGroupLazyQueryHookResult = ReturnType<
-	typeof useGetErrorGroupLazyQuery
->
-export type GetErrorGroupQueryResult = Apollo.QueryResult<
-	Types.GetErrorGroupQuery,
-	Types.GetErrorGroupQueryVariables
->
+export function useGetErrorGroupQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorGroupQuery, Types.GetErrorGroupQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorGroupQuery, Types.GetErrorGroupQueryVariables>(GetErrorGroupDocument, baseOptions);
+      }
+export function useGetErrorGroupLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorGroupQuery, Types.GetErrorGroupQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorGroupQuery, Types.GetErrorGroupQueryVariables>(GetErrorGroupDocument, baseOptions);
+        }
+export type GetErrorGroupQueryHookResult = ReturnType<typeof useGetErrorGroupQuery>;
+export type GetErrorGroupLazyQueryHookResult = ReturnType<typeof useGetErrorGroupLazyQuery>;
+export type GetErrorGroupQueryResult = Apollo.QueryResult<Types.GetErrorGroupQuery, Types.GetErrorGroupQueryVariables>;
 export const GetErrorObjectForLogDocument = gql`
-	query GetErrorObjectForLog($log_cursor: String!) {
-		error_object_for_log(log_cursor: $log_cursor) {
-			id
-			error_group_secure_id
-			project_id
-		}
-	}
-`
+    query GetErrorObjectForLog($log_cursor: String!) {
+  error_object_for_log(log_cursor: $log_cursor) {
+    id
+    error_group_secure_id
+    project_id
+  }
+}
+    `;
 
 /**
  * __useGetErrorObjectForLogQuery__
@@ -8297,46 +5498,22 @@ export const GetErrorObjectForLogDocument = gql`
  *   },
  * });
  */
-export function useGetErrorObjectForLogQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorObjectForLogQuery,
-		Types.GetErrorObjectForLogQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorObjectForLogQuery,
-		Types.GetErrorObjectForLogQueryVariables
-	>(GetErrorObjectForLogDocument, baseOptions)
-}
-export function useGetErrorObjectForLogLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorObjectForLogQuery,
-		Types.GetErrorObjectForLogQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorObjectForLogQuery,
-		Types.GetErrorObjectForLogQueryVariables
-	>(GetErrorObjectForLogDocument, baseOptions)
-}
-export type GetErrorObjectForLogQueryHookResult = ReturnType<
-	typeof useGetErrorObjectForLogQuery
->
-export type GetErrorObjectForLogLazyQueryHookResult = ReturnType<
-	typeof useGetErrorObjectForLogLazyQuery
->
-export type GetErrorObjectForLogQueryResult = Apollo.QueryResult<
-	Types.GetErrorObjectForLogQuery,
-	Types.GetErrorObjectForLogQueryVariables
->
+export function useGetErrorObjectForLogQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorObjectForLogQuery, Types.GetErrorObjectForLogQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorObjectForLogQuery, Types.GetErrorObjectForLogQueryVariables>(GetErrorObjectForLogDocument, baseOptions);
+      }
+export function useGetErrorObjectForLogLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorObjectForLogQuery, Types.GetErrorObjectForLogQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorObjectForLogQuery, Types.GetErrorObjectForLogQueryVariables>(GetErrorObjectForLogDocument, baseOptions);
+        }
+export type GetErrorObjectForLogQueryHookResult = ReturnType<typeof useGetErrorObjectForLogQuery>;
+export type GetErrorObjectForLogLazyQueryHookResult = ReturnType<typeof useGetErrorObjectForLogLazyQuery>;
+export type GetErrorObjectForLogQueryResult = Apollo.QueryResult<Types.GetErrorObjectForLogQuery, Types.GetErrorObjectForLogQueryVariables>;
 export const GetErrorObjectDocument = gql`
-	query GetErrorObject($id: ID!) {
-		error_object(id: $id) {
-			...ErrorObject
-		}
-	}
-	${ErrorObjectFragmentDoc}
-`
+    query GetErrorObject($id: ID!) {
+  error_object(id: $id) {
+    ...ErrorObject
+  }
+}
+    ${ErrorObjectFragmentDoc}`;
 
 /**
  * __useGetErrorObjectQuery__
@@ -8354,56 +5531,29 @@ export const GetErrorObjectDocument = gql`
  *   },
  * });
  */
-export function useGetErrorObjectQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorObjectQuery,
-		Types.GetErrorObjectQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorObjectQuery,
-		Types.GetErrorObjectQueryVariables
-	>(GetErrorObjectDocument, baseOptions)
-}
-export function useGetErrorObjectLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorObjectQuery,
-		Types.GetErrorObjectQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorObjectQuery,
-		Types.GetErrorObjectQueryVariables
-	>(GetErrorObjectDocument, baseOptions)
-}
-export type GetErrorObjectQueryHookResult = ReturnType<
-	typeof useGetErrorObjectQuery
->
-export type GetErrorObjectLazyQueryHookResult = ReturnType<
-	typeof useGetErrorObjectLazyQuery
->
-export type GetErrorObjectQueryResult = Apollo.QueryResult<
-	Types.GetErrorObjectQuery,
-	Types.GetErrorObjectQueryVariables
->
+export function useGetErrorObjectQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorObjectQuery, Types.GetErrorObjectQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorObjectQuery, Types.GetErrorObjectQueryVariables>(GetErrorObjectDocument, baseOptions);
+      }
+export function useGetErrorObjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorObjectQuery, Types.GetErrorObjectQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorObjectQuery, Types.GetErrorObjectQueryVariables>(GetErrorObjectDocument, baseOptions);
+        }
+export type GetErrorObjectQueryHookResult = ReturnType<typeof useGetErrorObjectQuery>;
+export type GetErrorObjectLazyQueryHookResult = ReturnType<typeof useGetErrorObjectLazyQuery>;
+export type GetErrorObjectQueryResult = Apollo.QueryResult<Types.GetErrorObjectQuery, Types.GetErrorObjectQueryVariables>;
 export const GetErrorInstanceDocument = gql`
-	query GetErrorInstance(
-		$error_group_secure_id: String!
-		$error_object_id: ID
-	) {
-		error_instance(
-			error_group_secure_id: $error_group_secure_id
-			error_object_id: $error_object_id
-		) {
-			error_object {
-				...ErrorObject
-			}
-			next_id
-			previous_id
-		}
-	}
-	${ErrorObjectFragmentDoc}
-`
+    query GetErrorInstance($error_group_secure_id: String!, $error_object_id: ID) {
+  error_instance(
+    error_group_secure_id: $error_group_secure_id
+    error_object_id: $error_object_id
+  ) {
+    error_object {
+      ...ErrorObject
+    }
+    next_id
+    previous_id
+  }
+}
+    ${ErrorObjectFragmentDoc}`;
 
 /**
  * __useGetErrorInstanceQuery__
@@ -8422,59 +5572,36 @@ export const GetErrorInstanceDocument = gql`
  *   },
  * });
  */
-export function useGetErrorInstanceQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorInstanceQuery,
-		Types.GetErrorInstanceQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorInstanceQuery,
-		Types.GetErrorInstanceQueryVariables
-	>(GetErrorInstanceDocument, baseOptions)
-}
-export function useGetErrorInstanceLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorInstanceQuery,
-		Types.GetErrorInstanceQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorInstanceQuery,
-		Types.GetErrorInstanceQueryVariables
-	>(GetErrorInstanceDocument, baseOptions)
-}
-export type GetErrorInstanceQueryHookResult = ReturnType<
-	typeof useGetErrorInstanceQuery
->
-export type GetErrorInstanceLazyQueryHookResult = ReturnType<
-	typeof useGetErrorInstanceLazyQuery
->
-export type GetErrorInstanceQueryResult = Apollo.QueryResult<
-	Types.GetErrorInstanceQuery,
-	Types.GetErrorInstanceQueryVariables
->
+export function useGetErrorInstanceQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorInstanceQuery, Types.GetErrorInstanceQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorInstanceQuery, Types.GetErrorInstanceQueryVariables>(GetErrorInstanceDocument, baseOptions);
+      }
+export function useGetErrorInstanceLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorInstanceQuery, Types.GetErrorInstanceQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorInstanceQuery, Types.GetErrorInstanceQueryVariables>(GetErrorInstanceDocument, baseOptions);
+        }
+export type GetErrorInstanceQueryHookResult = ReturnType<typeof useGetErrorInstanceQuery>;
+export type GetErrorInstanceLazyQueryHookResult = ReturnType<typeof useGetErrorInstanceLazyQuery>;
+export type GetErrorInstanceQueryResult = Apollo.QueryResult<Types.GetErrorInstanceQuery, Types.GetErrorInstanceQueryVariables>;
 export const GetRecentErrorsDocument = gql`
-	query GetRecentErrors($secure_id: String!) {
-		error_group(secure_id: $secure_id) {
-			secure_id
-			metadata_log {
-				error_id
-				session_secure_id
-				environment
-				timestamp
-				os
-				browser
-				visited_url
-				fingerprint
-				identifier
-				user_properties
-				request_id
-				payload
-			}
-		}
-	}
-`
+    query GetRecentErrors($secure_id: String!) {
+  error_group(secure_id: $secure_id) {
+    secure_id
+    metadata_log {
+      error_id
+      session_secure_id
+      environment
+      timestamp
+      os
+      browser
+      visited_url
+      fingerprint
+      identifier
+      user_properties
+      request_id
+      payload
+    }
+  }
+}
+    `;
 
 /**
  * __useGetRecentErrorsQuery__
@@ -8492,43 +5619,20 @@ export const GetRecentErrorsDocument = gql`
  *   },
  * });
  */
-export function useGetRecentErrorsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetRecentErrorsQuery,
-		Types.GetRecentErrorsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetRecentErrorsQuery,
-		Types.GetRecentErrorsQueryVariables
-	>(GetRecentErrorsDocument, baseOptions)
-}
-export function useGetRecentErrorsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetRecentErrorsQuery,
-		Types.GetRecentErrorsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetRecentErrorsQuery,
-		Types.GetRecentErrorsQueryVariables
-	>(GetRecentErrorsDocument, baseOptions)
-}
-export type GetRecentErrorsQueryHookResult = ReturnType<
-	typeof useGetRecentErrorsQuery
->
-export type GetRecentErrorsLazyQueryHookResult = ReturnType<
-	typeof useGetRecentErrorsLazyQuery
->
-export type GetRecentErrorsQueryResult = Apollo.QueryResult<
-	Types.GetRecentErrorsQuery,
-	Types.GetRecentErrorsQueryVariables
->
+export function useGetRecentErrorsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetRecentErrorsQuery, Types.GetRecentErrorsQueryVariables>) {
+        return Apollo.useQuery<Types.GetRecentErrorsQuery, Types.GetRecentErrorsQueryVariables>(GetRecentErrorsDocument, baseOptions);
+      }
+export function useGetRecentErrorsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetRecentErrorsQuery, Types.GetRecentErrorsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetRecentErrorsQuery, Types.GetRecentErrorsQueryVariables>(GetRecentErrorsDocument, baseOptions);
+        }
+export type GetRecentErrorsQueryHookResult = ReturnType<typeof useGetRecentErrorsQuery>;
+export type GetRecentErrorsLazyQueryHookResult = ReturnType<typeof useGetRecentErrorsLazyQuery>;
+export type GetRecentErrorsQueryResult = Apollo.QueryResult<Types.GetRecentErrorsQuery, Types.GetRecentErrorsQueryVariables>;
 export const GetResourcesDocument = gql`
-	query GetResources($session_secure_id: String!) {
-		resources(session_secure_id: $session_secure_id)
-	}
-`
+    query GetResources($session_secure_id: String!) {
+  resources(session_secure_id: $session_secure_id)
+}
+    `;
 
 /**
  * __useGetResourcesQuery__
@@ -8546,50 +5650,23 @@ export const GetResourcesDocument = gql`
  *   },
  * });
  */
-export function useGetResourcesQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetResourcesQuery,
-		Types.GetResourcesQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetResourcesQuery,
-		Types.GetResourcesQueryVariables
-	>(GetResourcesDocument, baseOptions)
-}
-export function useGetResourcesLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetResourcesQuery,
-		Types.GetResourcesQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetResourcesQuery,
-		Types.GetResourcesQueryVariables
-	>(GetResourcesDocument, baseOptions)
-}
-export type GetResourcesQueryHookResult = ReturnType<
-	typeof useGetResourcesQuery
->
-export type GetResourcesLazyQueryHookResult = ReturnType<
-	typeof useGetResourcesLazyQuery
->
-export type GetResourcesQueryResult = Apollo.QueryResult<
-	Types.GetResourcesQuery,
-	Types.GetResourcesQueryVariables
->
+export function useGetResourcesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetResourcesQuery, Types.GetResourcesQueryVariables>) {
+        return Apollo.useQuery<Types.GetResourcesQuery, Types.GetResourcesQueryVariables>(GetResourcesDocument, baseOptions);
+      }
+export function useGetResourcesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetResourcesQuery, Types.GetResourcesQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetResourcesQuery, Types.GetResourcesQueryVariables>(GetResourcesDocument, baseOptions);
+        }
+export type GetResourcesQueryHookResult = ReturnType<typeof useGetResourcesQuery>;
+export type GetResourcesLazyQueryHookResult = ReturnType<typeof useGetResourcesLazyQuery>;
+export type GetResourcesQueryResult = Apollo.QueryResult<Types.GetResourcesQuery, Types.GetResourcesQueryVariables>;
 export const GetFieldSuggestionDocument = gql`
-	query GetFieldSuggestion(
-		$project_id: ID!
-		$name: String!
-		$query: String!
-	) {
-		field_suggestion(project_id: $project_id, name: $name, query: $query) {
-			name
-			value
-		}
-	}
-`
+    query GetFieldSuggestion($project_id: ID!, $name: String!, $query: String!) {
+  field_suggestion(project_id: $project_id, name: $name, query: $query) {
+    name
+    value
+  }
+}
+    `;
 
 /**
  * __useGetFieldSuggestionQuery__
@@ -8609,46 +5686,23 @@ export const GetFieldSuggestionDocument = gql`
  *   },
  * });
  */
-export function useGetFieldSuggestionQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetFieldSuggestionQuery,
-		Types.GetFieldSuggestionQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetFieldSuggestionQuery,
-		Types.GetFieldSuggestionQueryVariables
-	>(GetFieldSuggestionDocument, baseOptions)
-}
-export function useGetFieldSuggestionLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetFieldSuggestionQuery,
-		Types.GetFieldSuggestionQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetFieldSuggestionQuery,
-		Types.GetFieldSuggestionQueryVariables
-	>(GetFieldSuggestionDocument, baseOptions)
-}
-export type GetFieldSuggestionQueryHookResult = ReturnType<
-	typeof useGetFieldSuggestionQuery
->
-export type GetFieldSuggestionLazyQueryHookResult = ReturnType<
-	typeof useGetFieldSuggestionLazyQuery
->
-export type GetFieldSuggestionQueryResult = Apollo.QueryResult<
-	Types.GetFieldSuggestionQuery,
-	Types.GetFieldSuggestionQueryVariables
->
+export function useGetFieldSuggestionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetFieldSuggestionQuery, Types.GetFieldSuggestionQueryVariables>) {
+        return Apollo.useQuery<Types.GetFieldSuggestionQuery, Types.GetFieldSuggestionQueryVariables>(GetFieldSuggestionDocument, baseOptions);
+      }
+export function useGetFieldSuggestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetFieldSuggestionQuery, Types.GetFieldSuggestionQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetFieldSuggestionQuery, Types.GetFieldSuggestionQueryVariables>(GetFieldSuggestionDocument, baseOptions);
+        }
+export type GetFieldSuggestionQueryHookResult = ReturnType<typeof useGetFieldSuggestionQuery>;
+export type GetFieldSuggestionLazyQueryHookResult = ReturnType<typeof useGetFieldSuggestionLazyQuery>;
+export type GetFieldSuggestionQueryResult = Apollo.QueryResult<Types.GetFieldSuggestionQuery, Types.GetFieldSuggestionQueryVariables>;
 export const GetEnvironmentsDocument = gql`
-	query GetEnvironments($project_id: ID!) {
-		environment_suggestion(project_id: $project_id) {
-			name
-			value
-		}
-	}
-`
+    query GetEnvironments($project_id: ID!) {
+  environment_suggestion(project_id: $project_id) {
+    name
+    value
+  }
+}
+    `;
 
 /**
  * __useGetEnvironmentsQuery__
@@ -8666,43 +5720,20 @@ export const GetEnvironmentsDocument = gql`
  *   },
  * });
  */
-export function useGetEnvironmentsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetEnvironmentsQuery,
-		Types.GetEnvironmentsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetEnvironmentsQuery,
-		Types.GetEnvironmentsQueryVariables
-	>(GetEnvironmentsDocument, baseOptions)
-}
-export function useGetEnvironmentsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetEnvironmentsQuery,
-		Types.GetEnvironmentsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetEnvironmentsQuery,
-		Types.GetEnvironmentsQueryVariables
-	>(GetEnvironmentsDocument, baseOptions)
-}
-export type GetEnvironmentsQueryHookResult = ReturnType<
-	typeof useGetEnvironmentsQuery
->
-export type GetEnvironmentsLazyQueryHookResult = ReturnType<
-	typeof useGetEnvironmentsLazyQuery
->
-export type GetEnvironmentsQueryResult = Apollo.QueryResult<
-	Types.GetEnvironmentsQuery,
-	Types.GetEnvironmentsQueryVariables
->
+export function useGetEnvironmentsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetEnvironmentsQuery, Types.GetEnvironmentsQueryVariables>) {
+        return Apollo.useQuery<Types.GetEnvironmentsQuery, Types.GetEnvironmentsQueryVariables>(GetEnvironmentsDocument, baseOptions);
+      }
+export function useGetEnvironmentsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetEnvironmentsQuery, Types.GetEnvironmentsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetEnvironmentsQuery, Types.GetEnvironmentsQueryVariables>(GetEnvironmentsDocument, baseOptions);
+        }
+export type GetEnvironmentsQueryHookResult = ReturnType<typeof useGetEnvironmentsQuery>;
+export type GetEnvironmentsLazyQueryHookResult = ReturnType<typeof useGetEnvironmentsLazyQuery>;
+export type GetEnvironmentsQueryResult = Apollo.QueryResult<Types.GetEnvironmentsQuery, Types.GetEnvironmentsQueryVariables>;
 export const GetAppVersionsDocument = gql`
-	query GetAppVersions($project_id: ID!) {
-		app_version_suggestion(project_id: $project_id)
-	}
-`
+    query GetAppVersions($project_id: ID!) {
+  app_version_suggestion(project_id: $project_id)
+}
+    `;
 
 /**
  * __useGetAppVersionsQuery__
@@ -8720,51 +5751,28 @@ export const GetAppVersionsDocument = gql`
  *   },
  * });
  */
-export function useGetAppVersionsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetAppVersionsQuery,
-		Types.GetAppVersionsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetAppVersionsQuery,
-		Types.GetAppVersionsQueryVariables
-	>(GetAppVersionsDocument, baseOptions)
-}
-export function useGetAppVersionsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetAppVersionsQuery,
-		Types.GetAppVersionsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetAppVersionsQuery,
-		Types.GetAppVersionsQueryVariables
-	>(GetAppVersionsDocument, baseOptions)
-}
-export type GetAppVersionsQueryHookResult = ReturnType<
-	typeof useGetAppVersionsQuery
->
-export type GetAppVersionsLazyQueryHookResult = ReturnType<
-	typeof useGetAppVersionsLazyQuery
->
-export type GetAppVersionsQueryResult = Apollo.QueryResult<
-	Types.GetAppVersionsQuery,
-	Types.GetAppVersionsQueryVariables
->
+export function useGetAppVersionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetAppVersionsQuery, Types.GetAppVersionsQueryVariables>) {
+        return Apollo.useQuery<Types.GetAppVersionsQuery, Types.GetAppVersionsQueryVariables>(GetAppVersionsDocument, baseOptions);
+      }
+export function useGetAppVersionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAppVersionsQuery, Types.GetAppVersionsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetAppVersionsQuery, Types.GetAppVersionsQueryVariables>(GetAppVersionsDocument, baseOptions);
+        }
+export type GetAppVersionsQueryHookResult = ReturnType<typeof useGetAppVersionsQuery>;
+export type GetAppVersionsLazyQueryHookResult = ReturnType<typeof useGetAppVersionsLazyQuery>;
+export type GetAppVersionsQueryResult = Apollo.QueryResult<Types.GetAppVersionsQuery, Types.GetAppVersionsQueryVariables>;
 export const GetProjectSuggestionDocument = gql`
-	query GetProjectSuggestion($query: String!) {
-		projectSuggestion(query: $query) {
-			id
-			name
-			workspace_id
-		}
-		workspaceSuggestion(query: $query) {
-			id
-			name
-		}
-	}
-`
+    query GetProjectSuggestion($query: String!) {
+  projectSuggestion(query: $query) {
+    id
+    name
+    workspace_id
+  }
+  workspaceSuggestion(query: $query) {
+    id
+    name
+  }
+}
+    `;
 
 /**
  * __useGetProjectSuggestionQuery__
@@ -8782,54 +5790,23 @@ export const GetProjectSuggestionDocument = gql`
  *   },
  * });
  */
-export function useGetProjectSuggestionQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetProjectSuggestionQuery,
-		Types.GetProjectSuggestionQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetProjectSuggestionQuery,
-		Types.GetProjectSuggestionQueryVariables
-	>(GetProjectSuggestionDocument, baseOptions)
-}
-export function useGetProjectSuggestionLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetProjectSuggestionQuery,
-		Types.GetProjectSuggestionQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetProjectSuggestionQuery,
-		Types.GetProjectSuggestionQueryVariables
-	>(GetProjectSuggestionDocument, baseOptions)
-}
-export type GetProjectSuggestionQueryHookResult = ReturnType<
-	typeof useGetProjectSuggestionQuery
->
-export type GetProjectSuggestionLazyQueryHookResult = ReturnType<
-	typeof useGetProjectSuggestionLazyQuery
->
-export type GetProjectSuggestionQueryResult = Apollo.QueryResult<
-	Types.GetProjectSuggestionQuery,
-	Types.GetProjectSuggestionQueryVariables
->
+export function useGetProjectSuggestionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetProjectSuggestionQuery, Types.GetProjectSuggestionQueryVariables>) {
+        return Apollo.useQuery<Types.GetProjectSuggestionQuery, Types.GetProjectSuggestionQueryVariables>(GetProjectSuggestionDocument, baseOptions);
+      }
+export function useGetProjectSuggestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectSuggestionQuery, Types.GetProjectSuggestionQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetProjectSuggestionQuery, Types.GetProjectSuggestionQueryVariables>(GetProjectSuggestionDocument, baseOptions);
+        }
+export type GetProjectSuggestionQueryHookResult = ReturnType<typeof useGetProjectSuggestionQuery>;
+export type GetProjectSuggestionLazyQueryHookResult = ReturnType<typeof useGetProjectSuggestionLazyQuery>;
+export type GetProjectSuggestionQueryResult = Apollo.QueryResult<Types.GetProjectSuggestionQuery, Types.GetProjectSuggestionQueryVariables>;
 export const GetErrorFieldSuggestionDocument = gql`
-	query GetErrorFieldSuggestion(
-		$project_id: ID!
-		$name: String!
-		$query: String!
-	) {
-		error_field_suggestion(
-			project_id: $project_id
-			name: $name
-			query: $query
-		) {
-			name
-			value
-		}
-	}
-`
+    query GetErrorFieldSuggestion($project_id: ID!, $name: String!, $query: String!) {
+  error_field_suggestion(project_id: $project_id, name: $name, query: $query) {
+    name
+    value
+  }
+}
+    `;
 
 /**
  * __useGetErrorFieldSuggestionQuery__
@@ -8849,58 +5826,35 @@ export const GetErrorFieldSuggestionDocument = gql`
  *   },
  * });
  */
-export function useGetErrorFieldSuggestionQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorFieldSuggestionQuery,
-		Types.GetErrorFieldSuggestionQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorFieldSuggestionQuery,
-		Types.GetErrorFieldSuggestionQueryVariables
-	>(GetErrorFieldSuggestionDocument, baseOptions)
-}
-export function useGetErrorFieldSuggestionLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorFieldSuggestionQuery,
-		Types.GetErrorFieldSuggestionQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorFieldSuggestionQuery,
-		Types.GetErrorFieldSuggestionQueryVariables
-	>(GetErrorFieldSuggestionDocument, baseOptions)
-}
-export type GetErrorFieldSuggestionQueryHookResult = ReturnType<
-	typeof useGetErrorFieldSuggestionQuery
->
-export type GetErrorFieldSuggestionLazyQueryHookResult = ReturnType<
-	typeof useGetErrorFieldSuggestionLazyQuery
->
-export type GetErrorFieldSuggestionQueryResult = Apollo.QueryResult<
-	Types.GetErrorFieldSuggestionQuery,
-	Types.GetErrorFieldSuggestionQueryVariables
->
+export function useGetErrorFieldSuggestionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorFieldSuggestionQuery, Types.GetErrorFieldSuggestionQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorFieldSuggestionQuery, Types.GetErrorFieldSuggestionQueryVariables>(GetErrorFieldSuggestionDocument, baseOptions);
+      }
+export function useGetErrorFieldSuggestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorFieldSuggestionQuery, Types.GetErrorFieldSuggestionQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorFieldSuggestionQuery, Types.GetErrorFieldSuggestionQueryVariables>(GetErrorFieldSuggestionDocument, baseOptions);
+        }
+export type GetErrorFieldSuggestionQueryHookResult = ReturnType<typeof useGetErrorFieldSuggestionQuery>;
+export type GetErrorFieldSuggestionLazyQueryHookResult = ReturnType<typeof useGetErrorFieldSuggestionLazyQuery>;
+export type GetErrorFieldSuggestionQueryResult = Apollo.QueryResult<Types.GetErrorFieldSuggestionQuery, Types.GetErrorFieldSuggestionQueryVariables>;
 export const GetErrorSearchSuggestionsDocument = gql`
-	query GetErrorSearchSuggestions($project_id: ID!, $query: String!) {
-		visitedUrls: error_field_suggestion(
-			project_id: $project_id
-			name: "visited_url"
-			query: $query
-		) {
-			name
-			value
-		}
-		fields: error_field_suggestion(
-			project_id: $project_id
-			name: "event"
-			query: $query
-		) {
-			name
-			value
-		}
-	}
-`
+    query GetErrorSearchSuggestions($project_id: ID!, $query: String!) {
+  visitedUrls: error_field_suggestion(
+    project_id: $project_id
+    name: "visited_url"
+    query: $query
+  ) {
+    name
+    value
+  }
+  fields: error_field_suggestion(
+    project_id: $project_id
+    name: "event"
+    query: $query
+  ) {
+    name
+    value
+  }
+}
+    `;
 
 /**
  * __useGetErrorSearchSuggestionsQuery__
@@ -8919,78 +5873,55 @@ export const GetErrorSearchSuggestionsDocument = gql`
  *   },
  * });
  */
-export function useGetErrorSearchSuggestionsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorSearchSuggestionsQuery,
-		Types.GetErrorSearchSuggestionsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorSearchSuggestionsQuery,
-		Types.GetErrorSearchSuggestionsQueryVariables
-	>(GetErrorSearchSuggestionsDocument, baseOptions)
-}
-export function useGetErrorSearchSuggestionsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorSearchSuggestionsQuery,
-		Types.GetErrorSearchSuggestionsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorSearchSuggestionsQuery,
-		Types.GetErrorSearchSuggestionsQueryVariables
-	>(GetErrorSearchSuggestionsDocument, baseOptions)
-}
-export type GetErrorSearchSuggestionsQueryHookResult = ReturnType<
-	typeof useGetErrorSearchSuggestionsQuery
->
-export type GetErrorSearchSuggestionsLazyQueryHookResult = ReturnType<
-	typeof useGetErrorSearchSuggestionsLazyQuery
->
-export type GetErrorSearchSuggestionsQueryResult = Apollo.QueryResult<
-	Types.GetErrorSearchSuggestionsQuery,
-	Types.GetErrorSearchSuggestionsQueryVariables
->
+export function useGetErrorSearchSuggestionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorSearchSuggestionsQuery, Types.GetErrorSearchSuggestionsQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorSearchSuggestionsQuery, Types.GetErrorSearchSuggestionsQueryVariables>(GetErrorSearchSuggestionsDocument, baseOptions);
+      }
+export function useGetErrorSearchSuggestionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorSearchSuggestionsQuery, Types.GetErrorSearchSuggestionsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorSearchSuggestionsQuery, Types.GetErrorSearchSuggestionsQueryVariables>(GetErrorSearchSuggestionsDocument, baseOptions);
+        }
+export type GetErrorSearchSuggestionsQueryHookResult = ReturnType<typeof useGetErrorSearchSuggestionsQuery>;
+export type GetErrorSearchSuggestionsLazyQueryHookResult = ReturnType<typeof useGetErrorSearchSuggestionsLazyQuery>;
+export type GetErrorSearchSuggestionsQueryResult = Apollo.QueryResult<Types.GetErrorSearchSuggestionsQuery, Types.GetErrorSearchSuggestionsQueryVariables>;
 export const GetSessionSearchResultsDocument = gql`
-	query GetSessionSearchResults($project_id: ID!, $query: String!) {
-		trackProperties: property_suggestion(
-			project_id: $project_id
-			query: $query
-			type: "track"
-		) {
-			id
-			name
-			value
-		}
-		userProperties: property_suggestion(
-			project_id: $project_id
-			query: $query
-			type: "user"
-		) {
-			id
-			name
-			value
-		}
-		visitedUrls: field_suggestion(
-			project_id: $project_id
-			name: "visited-url"
-			query: $query
-		) {
-			id
-			name
-			value
-		}
-		referrers: field_suggestion(
-			project_id: $project_id
-			name: "referrer"
-			query: $query
-		) {
-			id
-			name
-			value
-		}
-	}
-`
+    query GetSessionSearchResults($project_id: ID!, $query: String!) {
+  trackProperties: property_suggestion(
+    project_id: $project_id
+    query: $query
+    type: "track"
+  ) {
+    id
+    name
+    value
+  }
+  userProperties: property_suggestion(
+    project_id: $project_id
+    query: $query
+    type: "user"
+  ) {
+    id
+    name
+    value
+  }
+  visitedUrls: field_suggestion(
+    project_id: $project_id
+    name: "visited-url"
+    query: $query
+  ) {
+    id
+    name
+    value
+  }
+  referrers: field_suggestion(
+    project_id: $project_id
+    name: "referrer"
+    query: $query
+  ) {
+    id
+    name
+    value
+  }
+}
+    `;
 
 /**
  * __useGetSessionSearchResultsQuery__
@@ -9009,51 +5940,24 @@ export const GetSessionSearchResultsDocument = gql`
  *   },
  * });
  */
-export function useGetSessionSearchResultsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSessionSearchResultsQuery,
-		Types.GetSessionSearchResultsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSessionSearchResultsQuery,
-		Types.GetSessionSearchResultsQueryVariables
-	>(GetSessionSearchResultsDocument, baseOptions)
-}
-export function useGetSessionSearchResultsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSessionSearchResultsQuery,
-		Types.GetSessionSearchResultsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSessionSearchResultsQuery,
-		Types.GetSessionSearchResultsQueryVariables
-	>(GetSessionSearchResultsDocument, baseOptions)
-}
-export type GetSessionSearchResultsQueryHookResult = ReturnType<
-	typeof useGetSessionSearchResultsQuery
->
-export type GetSessionSearchResultsLazyQueryHookResult = ReturnType<
-	typeof useGetSessionSearchResultsLazyQuery
->
-export type GetSessionSearchResultsQueryResult = Apollo.QueryResult<
-	Types.GetSessionSearchResultsQuery,
-	Types.GetSessionSearchResultsQueryVariables
->
+export function useGetSessionSearchResultsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionSearchResultsQuery, Types.GetSessionSearchResultsQueryVariables>) {
+        return Apollo.useQuery<Types.GetSessionSearchResultsQuery, Types.GetSessionSearchResultsQueryVariables>(GetSessionSearchResultsDocument, baseOptions);
+      }
+export function useGetSessionSearchResultsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionSearchResultsQuery, Types.GetSessionSearchResultsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSessionSearchResultsQuery, Types.GetSessionSearchResultsQueryVariables>(GetSessionSearchResultsDocument, baseOptions);
+        }
+export type GetSessionSearchResultsQueryHookResult = ReturnType<typeof useGetSessionSearchResultsQuery>;
+export type GetSessionSearchResultsLazyQueryHookResult = ReturnType<typeof useGetSessionSearchResultsLazyQuery>;
+export type GetSessionSearchResultsQueryResult = Apollo.QueryResult<Types.GetSessionSearchResultsQuery, Types.GetSessionSearchResultsQueryVariables>;
 export const GetTrackSuggestionDocument = gql`
-	query GetTrackSuggestion($project_id: ID!, $query: String!) {
-		property_suggestion(
-			project_id: $project_id
-			query: $query
-			type: "track"
-		) {
-			id
-			name
-			value
-		}
-	}
-`
+    query GetTrackSuggestion($project_id: ID!, $query: String!) {
+  property_suggestion(project_id: $project_id, query: $query, type: "track") {
+    id
+    name
+    value
+  }
+}
+    `;
 
 /**
  * __useGetTrackSuggestionQuery__
@@ -9072,51 +5976,24 @@ export const GetTrackSuggestionDocument = gql`
  *   },
  * });
  */
-export function useGetTrackSuggestionQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetTrackSuggestionQuery,
-		Types.GetTrackSuggestionQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetTrackSuggestionQuery,
-		Types.GetTrackSuggestionQueryVariables
-	>(GetTrackSuggestionDocument, baseOptions)
-}
-export function useGetTrackSuggestionLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetTrackSuggestionQuery,
-		Types.GetTrackSuggestionQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetTrackSuggestionQuery,
-		Types.GetTrackSuggestionQueryVariables
-	>(GetTrackSuggestionDocument, baseOptions)
-}
-export type GetTrackSuggestionQueryHookResult = ReturnType<
-	typeof useGetTrackSuggestionQuery
->
-export type GetTrackSuggestionLazyQueryHookResult = ReturnType<
-	typeof useGetTrackSuggestionLazyQuery
->
-export type GetTrackSuggestionQueryResult = Apollo.QueryResult<
-	Types.GetTrackSuggestionQuery,
-	Types.GetTrackSuggestionQueryVariables
->
+export function useGetTrackSuggestionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetTrackSuggestionQuery, Types.GetTrackSuggestionQueryVariables>) {
+        return Apollo.useQuery<Types.GetTrackSuggestionQuery, Types.GetTrackSuggestionQueryVariables>(GetTrackSuggestionDocument, baseOptions);
+      }
+export function useGetTrackSuggestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetTrackSuggestionQuery, Types.GetTrackSuggestionQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetTrackSuggestionQuery, Types.GetTrackSuggestionQueryVariables>(GetTrackSuggestionDocument, baseOptions);
+        }
+export type GetTrackSuggestionQueryHookResult = ReturnType<typeof useGetTrackSuggestionQuery>;
+export type GetTrackSuggestionLazyQueryHookResult = ReturnType<typeof useGetTrackSuggestionLazyQuery>;
+export type GetTrackSuggestionQueryResult = Apollo.QueryResult<Types.GetTrackSuggestionQuery, Types.GetTrackSuggestionQueryVariables>;
 export const GetUserSuggestionDocument = gql`
-	query GetUserSuggestion($project_id: ID!, $query: String!) {
-		property_suggestion(
-			project_id: $project_id
-			query: $query
-			type: "user"
-		) {
-			id
-			name
-			value
-		}
-	}
-`
+    query GetUserSuggestion($project_id: ID!, $query: String!) {
+  property_suggestion(project_id: $project_id, query: $query, type: "user") {
+    id
+    name
+    value
+  }
+}
+    `;
 
 /**
  * __useGetUserSuggestionQuery__
@@ -9135,80 +6012,57 @@ export const GetUserSuggestionDocument = gql`
  *   },
  * });
  */
-export function useGetUserSuggestionQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetUserSuggestionQuery,
-		Types.GetUserSuggestionQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetUserSuggestionQuery,
-		Types.GetUserSuggestionQueryVariables
-	>(GetUserSuggestionDocument, baseOptions)
-}
-export function useGetUserSuggestionLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetUserSuggestionQuery,
-		Types.GetUserSuggestionQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetUserSuggestionQuery,
-		Types.GetUserSuggestionQueryVariables
-	>(GetUserSuggestionDocument, baseOptions)
-}
-export type GetUserSuggestionQueryHookResult = ReturnType<
-	typeof useGetUserSuggestionQuery
->
-export type GetUserSuggestionLazyQueryHookResult = ReturnType<
-	typeof useGetUserSuggestionLazyQuery
->
-export type GetUserSuggestionQueryResult = Apollo.QueryResult<
-	Types.GetUserSuggestionQuery,
-	Types.GetUserSuggestionQueryVariables
->
+export function useGetUserSuggestionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetUserSuggestionQuery, Types.GetUserSuggestionQueryVariables>) {
+        return Apollo.useQuery<Types.GetUserSuggestionQuery, Types.GetUserSuggestionQueryVariables>(GetUserSuggestionDocument, baseOptions);
+      }
+export function useGetUserSuggestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetUserSuggestionQuery, Types.GetUserSuggestionQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetUserSuggestionQuery, Types.GetUserSuggestionQueryVariables>(GetUserSuggestionDocument, baseOptions);
+        }
+export type GetUserSuggestionQueryHookResult = ReturnType<typeof useGetUserSuggestionQuery>;
+export type GetUserSuggestionLazyQueryHookResult = ReturnType<typeof useGetUserSuggestionLazyQuery>;
+export type GetUserSuggestionQueryResult = Apollo.QueryResult<Types.GetUserSuggestionQuery, Types.GetUserSuggestionQueryVariables>;
 export const GetSegmentsDocument = gql`
-	query GetSegments($project_id: ID!) {
-		segments(project_id: $project_id) {
-			id
-			name
-			params {
-				user_properties {
-					name
-					value
-				}
-				excluded_properties {
-					name
-					value
-				}
-				track_properties {
-					name
-					value
-				}
-				date_range {
-					start_date
-					end_date
-				}
-				length_range {
-					min
-					max
-				}
-				os
-				browser
-				visited_url
-				referrer
-				identified
-				hide_viewed
-				first_time
-				app_versions
-				environments
-				device_id
-				show_live_sessions
-				query
-			}
-		}
-	}
-`
+    query GetSegments($project_id: ID!) {
+  segments(project_id: $project_id) {
+    id
+    name
+    params {
+      user_properties {
+        name
+        value
+      }
+      excluded_properties {
+        name
+        value
+      }
+      track_properties {
+        name
+        value
+      }
+      date_range {
+        start_date
+        end_date
+      }
+      length_range {
+        min
+        max
+      }
+      os
+      browser
+      visited_url
+      referrer
+      identified
+      hide_viewed
+      first_time
+      app_versions
+      environments
+      device_id
+      show_live_sessions
+      query
+    }
+  }
+}
+    `;
 
 /**
  * __useGetSegmentsQuery__
@@ -9226,56 +6080,35 @@ export const GetSegmentsDocument = gql`
  *   },
  * });
  */
-export function useGetSegmentsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSegmentsQuery,
-		Types.GetSegmentsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSegmentsQuery,
-		Types.GetSegmentsQueryVariables
-	>(GetSegmentsDocument, baseOptions)
-}
-export function useGetSegmentsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSegmentsQuery,
-		Types.GetSegmentsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSegmentsQuery,
-		Types.GetSegmentsQueryVariables
-	>(GetSegmentsDocument, baseOptions)
-}
-export type GetSegmentsQueryHookResult = ReturnType<typeof useGetSegmentsQuery>
-export type GetSegmentsLazyQueryHookResult = ReturnType<
-	typeof useGetSegmentsLazyQuery
->
-export type GetSegmentsQueryResult = Apollo.QueryResult<
-	Types.GetSegmentsQuery,
-	Types.GetSegmentsQueryVariables
->
+export function useGetSegmentsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSegmentsQuery, Types.GetSegmentsQueryVariables>) {
+        return Apollo.useQuery<Types.GetSegmentsQuery, Types.GetSegmentsQueryVariables>(GetSegmentsDocument, baseOptions);
+      }
+export function useGetSegmentsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSegmentsQuery, Types.GetSegmentsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSegmentsQuery, Types.GetSegmentsQueryVariables>(GetSegmentsDocument, baseOptions);
+        }
+export type GetSegmentsQueryHookResult = ReturnType<typeof useGetSegmentsQuery>;
+export type GetSegmentsLazyQueryHookResult = ReturnType<typeof useGetSegmentsLazyQuery>;
+export type GetSegmentsQueryResult = Apollo.QueryResult<Types.GetSegmentsQuery, Types.GetSegmentsQueryVariables>;
 export const GetErrorSegmentsDocument = gql`
-	query GetErrorSegments($project_id: ID!) {
-		segments: error_segments(project_id: $project_id) {
-			id
-			name
-			params {
-				date_range {
-					start_date
-					end_date
-				}
-				os
-				browser
-				visited_url
-				state
-				event
-				query
-			}
-		}
-	}
-`
+    query GetErrorSegments($project_id: ID!) {
+  segments: error_segments(project_id: $project_id) {
+    id
+    name
+    params {
+      date_range {
+        start_date
+        end_date
+      }
+      os
+      browser
+      visited_url
+      state
+      event
+      query
+    }
+  }
+}
+    `;
 
 /**
  * __useGetErrorSegmentsQuery__
@@ -9293,43 +6126,20 @@ export const GetErrorSegmentsDocument = gql`
  *   },
  * });
  */
-export function useGetErrorSegmentsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorSegmentsQuery,
-		Types.GetErrorSegmentsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorSegmentsQuery,
-		Types.GetErrorSegmentsQueryVariables
-	>(GetErrorSegmentsDocument, baseOptions)
-}
-export function useGetErrorSegmentsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorSegmentsQuery,
-		Types.GetErrorSegmentsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorSegmentsQuery,
-		Types.GetErrorSegmentsQueryVariables
-	>(GetErrorSegmentsDocument, baseOptions)
-}
-export type GetErrorSegmentsQueryHookResult = ReturnType<
-	typeof useGetErrorSegmentsQuery
->
-export type GetErrorSegmentsLazyQueryHookResult = ReturnType<
-	typeof useGetErrorSegmentsLazyQuery
->
-export type GetErrorSegmentsQueryResult = Apollo.QueryResult<
-	Types.GetErrorSegmentsQuery,
-	Types.GetErrorSegmentsQueryVariables
->
+export function useGetErrorSegmentsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorSegmentsQuery, Types.GetErrorSegmentsQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorSegmentsQuery, Types.GetErrorSegmentsQueryVariables>(GetErrorSegmentsDocument, baseOptions);
+      }
+export function useGetErrorSegmentsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorSegmentsQuery, Types.GetErrorSegmentsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorSegmentsQuery, Types.GetErrorSegmentsQueryVariables>(GetErrorSegmentsDocument, baseOptions);
+        }
+export type GetErrorSegmentsQueryHookResult = ReturnType<typeof useGetErrorSegmentsQuery>;
+export type GetErrorSegmentsLazyQueryHookResult = ReturnType<typeof useGetErrorSegmentsLazyQuery>;
+export type GetErrorSegmentsQueryResult = Apollo.QueryResult<Types.GetErrorSegmentsQuery, Types.GetErrorSegmentsQueryVariables>;
 export const IsIntegratedDocument = gql`
-	query IsIntegrated($project_id: ID!) {
-		isIntegrated(project_id: $project_id)
-	}
-`
+    query IsIntegrated($project_id: ID!) {
+  isIntegrated(project_id: $project_id)
+}
+    `;
 
 /**
  * __useIsIntegratedQuery__
@@ -9347,43 +6157,20 @@ export const IsIntegratedDocument = gql`
  *   },
  * });
  */
-export function useIsIntegratedQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.IsIntegratedQuery,
-		Types.IsIntegratedQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.IsIntegratedQuery,
-		Types.IsIntegratedQueryVariables
-	>(IsIntegratedDocument, baseOptions)
-}
-export function useIsIntegratedLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.IsIntegratedQuery,
-		Types.IsIntegratedQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.IsIntegratedQuery,
-		Types.IsIntegratedQueryVariables
-	>(IsIntegratedDocument, baseOptions)
-}
-export type IsIntegratedQueryHookResult = ReturnType<
-	typeof useIsIntegratedQuery
->
-export type IsIntegratedLazyQueryHookResult = ReturnType<
-	typeof useIsIntegratedLazyQuery
->
-export type IsIntegratedQueryResult = Apollo.QueryResult<
-	Types.IsIntegratedQuery,
-	Types.IsIntegratedQueryVariables
->
+export function useIsIntegratedQuery(baseOptions: Apollo.QueryHookOptions<Types.IsIntegratedQuery, Types.IsIntegratedQueryVariables>) {
+        return Apollo.useQuery<Types.IsIntegratedQuery, Types.IsIntegratedQueryVariables>(IsIntegratedDocument, baseOptions);
+      }
+export function useIsIntegratedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.IsIntegratedQuery, Types.IsIntegratedQueryVariables>) {
+          return Apollo.useLazyQuery<Types.IsIntegratedQuery, Types.IsIntegratedQueryVariables>(IsIntegratedDocument, baseOptions);
+        }
+export type IsIntegratedQueryHookResult = ReturnType<typeof useIsIntegratedQuery>;
+export type IsIntegratedLazyQueryHookResult = ReturnType<typeof useIsIntegratedLazyQuery>;
+export type IsIntegratedQueryResult = Apollo.QueryResult<Types.IsIntegratedQuery, Types.IsIntegratedQueryVariables>;
 export const IsBackendIntegratedDocument = gql`
-	query IsBackendIntegrated($project_id: ID!) {
-		isBackendIntegrated(project_id: $project_id)
-	}
-`
+    query IsBackendIntegrated($project_id: ID!) {
+  isBackendIntegrated(project_id: $project_id)
+}
+    `;
 
 /**
  * __useIsBackendIntegratedQuery__
@@ -9401,47 +6188,24 @@ export const IsBackendIntegratedDocument = gql`
  *   },
  * });
  */
-export function useIsBackendIntegratedQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.IsBackendIntegratedQuery,
-		Types.IsBackendIntegratedQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.IsBackendIntegratedQuery,
-		Types.IsBackendIntegratedQueryVariables
-	>(IsBackendIntegratedDocument, baseOptions)
-}
-export function useIsBackendIntegratedLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.IsBackendIntegratedQuery,
-		Types.IsBackendIntegratedQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.IsBackendIntegratedQuery,
-		Types.IsBackendIntegratedQueryVariables
-	>(IsBackendIntegratedDocument, baseOptions)
-}
-export type IsBackendIntegratedQueryHookResult = ReturnType<
-	typeof useIsBackendIntegratedQuery
->
-export type IsBackendIntegratedLazyQueryHookResult = ReturnType<
-	typeof useIsBackendIntegratedLazyQuery
->
-export type IsBackendIntegratedQueryResult = Apollo.QueryResult<
-	Types.IsBackendIntegratedQuery,
-	Types.IsBackendIntegratedQueryVariables
->
+export function useIsBackendIntegratedQuery(baseOptions: Apollo.QueryHookOptions<Types.IsBackendIntegratedQuery, Types.IsBackendIntegratedQueryVariables>) {
+        return Apollo.useQuery<Types.IsBackendIntegratedQuery, Types.IsBackendIntegratedQueryVariables>(IsBackendIntegratedDocument, baseOptions);
+      }
+export function useIsBackendIntegratedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.IsBackendIntegratedQuery, Types.IsBackendIntegratedQueryVariables>) {
+          return Apollo.useLazyQuery<Types.IsBackendIntegratedQuery, Types.IsBackendIntegratedQueryVariables>(IsBackendIntegratedDocument, baseOptions);
+        }
+export type IsBackendIntegratedQueryHookResult = ReturnType<typeof useIsBackendIntegratedQuery>;
+export type IsBackendIntegratedLazyQueryHookResult = ReturnType<typeof useIsBackendIntegratedLazyQuery>;
+export type IsBackendIntegratedQueryResult = Apollo.QueryResult<Types.IsBackendIntegratedQuery, Types.IsBackendIntegratedQueryVariables>;
 export const GetClientIntegrationDocument = gql`
-	query GetClientIntegration($project_id: ID!) {
-		clientIntegration(project_id: $project_id) {
-			integrated
-			resourceType
-			createdAt
-		}
-	}
-`
+    query GetClientIntegration($project_id: ID!) {
+  clientIntegration(project_id: $project_id) {
+    integrated
+    resourceType
+    createdAt
+  }
+}
+    `;
 
 /**
  * __useGetClientIntegrationQuery__
@@ -9459,47 +6223,24 @@ export const GetClientIntegrationDocument = gql`
  *   },
  * });
  */
-export function useGetClientIntegrationQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetClientIntegrationQuery,
-		Types.GetClientIntegrationQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetClientIntegrationQuery,
-		Types.GetClientIntegrationQueryVariables
-	>(GetClientIntegrationDocument, baseOptions)
-}
-export function useGetClientIntegrationLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetClientIntegrationQuery,
-		Types.GetClientIntegrationQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetClientIntegrationQuery,
-		Types.GetClientIntegrationQueryVariables
-	>(GetClientIntegrationDocument, baseOptions)
-}
-export type GetClientIntegrationQueryHookResult = ReturnType<
-	typeof useGetClientIntegrationQuery
->
-export type GetClientIntegrationLazyQueryHookResult = ReturnType<
-	typeof useGetClientIntegrationLazyQuery
->
-export type GetClientIntegrationQueryResult = Apollo.QueryResult<
-	Types.GetClientIntegrationQuery,
-	Types.GetClientIntegrationQueryVariables
->
+export function useGetClientIntegrationQuery(baseOptions: Apollo.QueryHookOptions<Types.GetClientIntegrationQuery, Types.GetClientIntegrationQueryVariables>) {
+        return Apollo.useQuery<Types.GetClientIntegrationQuery, Types.GetClientIntegrationQueryVariables>(GetClientIntegrationDocument, baseOptions);
+      }
+export function useGetClientIntegrationLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetClientIntegrationQuery, Types.GetClientIntegrationQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetClientIntegrationQuery, Types.GetClientIntegrationQueryVariables>(GetClientIntegrationDocument, baseOptions);
+        }
+export type GetClientIntegrationQueryHookResult = ReturnType<typeof useGetClientIntegrationQuery>;
+export type GetClientIntegrationLazyQueryHookResult = ReturnType<typeof useGetClientIntegrationLazyQuery>;
+export type GetClientIntegrationQueryResult = Apollo.QueryResult<Types.GetClientIntegrationQuery, Types.GetClientIntegrationQueryVariables>;
 export const GetServerIntegrationDocument = gql`
-	query GetServerIntegration($project_id: ID!) {
-		serverIntegration(project_id: $project_id) {
-			integrated
-			resourceType
-			createdAt
-		}
-	}
-`
+    query GetServerIntegration($project_id: ID!) {
+  serverIntegration(project_id: $project_id) {
+    integrated
+    resourceType
+    createdAt
+  }
+}
+    `;
 
 /**
  * __useGetServerIntegrationQuery__
@@ -9517,47 +6258,24 @@ export const GetServerIntegrationDocument = gql`
  *   },
  * });
  */
-export function useGetServerIntegrationQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetServerIntegrationQuery,
-		Types.GetServerIntegrationQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetServerIntegrationQuery,
-		Types.GetServerIntegrationQueryVariables
-	>(GetServerIntegrationDocument, baseOptions)
-}
-export function useGetServerIntegrationLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetServerIntegrationQuery,
-		Types.GetServerIntegrationQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetServerIntegrationQuery,
-		Types.GetServerIntegrationQueryVariables
-	>(GetServerIntegrationDocument, baseOptions)
-}
-export type GetServerIntegrationQueryHookResult = ReturnType<
-	typeof useGetServerIntegrationQuery
->
-export type GetServerIntegrationLazyQueryHookResult = ReturnType<
-	typeof useGetServerIntegrationLazyQuery
->
-export type GetServerIntegrationQueryResult = Apollo.QueryResult<
-	Types.GetServerIntegrationQuery,
-	Types.GetServerIntegrationQueryVariables
->
+export function useGetServerIntegrationQuery(baseOptions: Apollo.QueryHookOptions<Types.GetServerIntegrationQuery, Types.GetServerIntegrationQueryVariables>) {
+        return Apollo.useQuery<Types.GetServerIntegrationQuery, Types.GetServerIntegrationQueryVariables>(GetServerIntegrationDocument, baseOptions);
+      }
+export function useGetServerIntegrationLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetServerIntegrationQuery, Types.GetServerIntegrationQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetServerIntegrationQuery, Types.GetServerIntegrationQueryVariables>(GetServerIntegrationDocument, baseOptions);
+        }
+export type GetServerIntegrationQueryHookResult = ReturnType<typeof useGetServerIntegrationQuery>;
+export type GetServerIntegrationLazyQueryHookResult = ReturnType<typeof useGetServerIntegrationLazyQuery>;
+export type GetServerIntegrationQueryResult = Apollo.QueryResult<Types.GetServerIntegrationQuery, Types.GetServerIntegrationQueryVariables>;
 export const GetLogsIntegrationDocument = gql`
-	query GetLogsIntegration($project_id: ID!) {
-		logsIntegration(project_id: $project_id) {
-			integrated
-			resourceType
-			createdAt
-		}
-	}
-`
+    query GetLogsIntegration($project_id: ID!) {
+  logsIntegration(project_id: $project_id) {
+    integrated
+    resourceType
+    createdAt
+  }
+}
+    `;
 
 /**
  * __useGetLogsIntegrationQuery__
@@ -9575,62 +6293,30 @@ export const GetLogsIntegrationDocument = gql`
  *   },
  * });
  */
-export function useGetLogsIntegrationQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetLogsIntegrationQuery,
-		Types.GetLogsIntegrationQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetLogsIntegrationQuery,
-		Types.GetLogsIntegrationQueryVariables
-	>(GetLogsIntegrationDocument, baseOptions)
-}
-export function useGetLogsIntegrationLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetLogsIntegrationQuery,
-		Types.GetLogsIntegrationQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetLogsIntegrationQuery,
-		Types.GetLogsIntegrationQueryVariables
-	>(GetLogsIntegrationDocument, baseOptions)
-}
-export type GetLogsIntegrationQueryHookResult = ReturnType<
-	typeof useGetLogsIntegrationQuery
->
-export type GetLogsIntegrationLazyQueryHookResult = ReturnType<
-	typeof useGetLogsIntegrationLazyQuery
->
-export type GetLogsIntegrationQueryResult = Apollo.QueryResult<
-	Types.GetLogsIntegrationQuery,
-	Types.GetLogsIntegrationQueryVariables
->
+export function useGetLogsIntegrationQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsIntegrationQuery, Types.GetLogsIntegrationQueryVariables>) {
+        return Apollo.useQuery<Types.GetLogsIntegrationQuery, Types.GetLogsIntegrationQueryVariables>(GetLogsIntegrationDocument, baseOptions);
+      }
+export function useGetLogsIntegrationLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsIntegrationQuery, Types.GetLogsIntegrationQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetLogsIntegrationQuery, Types.GetLogsIntegrationQueryVariables>(GetLogsIntegrationDocument, baseOptions);
+        }
+export type GetLogsIntegrationQueryHookResult = ReturnType<typeof useGetLogsIntegrationQuery>;
+export type GetLogsIntegrationLazyQueryHookResult = ReturnType<typeof useGetLogsIntegrationLazyQuery>;
+export type GetLogsIntegrationQueryResult = Apollo.QueryResult<Types.GetLogsIntegrationQuery, Types.GetLogsIntegrationQueryVariables>;
 export const GetKeyPerformanceIndicatorsDocument = gql`
-	query GetKeyPerformanceIndicators($project_id: ID!, $lookBackPeriod: Int!) {
-		unprocessedSessionsCount(project_id: $project_id)
-		liveUsersCount(project_id: $project_id)
-		newUsersCount(
-			project_id: $project_id
-			lookBackPeriod: $lookBackPeriod
-		) {
-			count
-		}
-		averageSessionLength(
-			project_id: $project_id
-			lookBackPeriod: $lookBackPeriod
-		) {
-			length
-		}
-		userFingerprintCount(
-			project_id: $project_id
-			lookBackPeriod: $lookBackPeriod
-		) {
-			count
-		}
-	}
-`
+    query GetKeyPerformanceIndicators($project_id: ID!, $lookBackPeriod: Int!) {
+  unprocessedSessionsCount(project_id: $project_id)
+  liveUsersCount(project_id: $project_id)
+  newUsersCount(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
+    count
+  }
+  averageSessionLength(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
+    length
+  }
+  userFingerprintCount(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
+    count
+  }
+}
+    `;
 
 /**
  * __useGetKeyPerformanceIndicatorsQuery__
@@ -9649,47 +6335,24 @@ export const GetKeyPerformanceIndicatorsDocument = gql`
  *   },
  * });
  */
-export function useGetKeyPerformanceIndicatorsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetKeyPerformanceIndicatorsQuery,
-		Types.GetKeyPerformanceIndicatorsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetKeyPerformanceIndicatorsQuery,
-		Types.GetKeyPerformanceIndicatorsQueryVariables
-	>(GetKeyPerformanceIndicatorsDocument, baseOptions)
-}
-export function useGetKeyPerformanceIndicatorsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetKeyPerformanceIndicatorsQuery,
-		Types.GetKeyPerformanceIndicatorsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetKeyPerformanceIndicatorsQuery,
-		Types.GetKeyPerformanceIndicatorsQueryVariables
-	>(GetKeyPerformanceIndicatorsDocument, baseOptions)
-}
-export type GetKeyPerformanceIndicatorsQueryHookResult = ReturnType<
-	typeof useGetKeyPerformanceIndicatorsQuery
->
-export type GetKeyPerformanceIndicatorsLazyQueryHookResult = ReturnType<
-	typeof useGetKeyPerformanceIndicatorsLazyQuery
->
-export type GetKeyPerformanceIndicatorsQueryResult = Apollo.QueryResult<
-	Types.GetKeyPerformanceIndicatorsQuery,
-	Types.GetKeyPerformanceIndicatorsQueryVariables
->
+export function useGetKeyPerformanceIndicatorsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetKeyPerformanceIndicatorsQuery, Types.GetKeyPerformanceIndicatorsQueryVariables>) {
+        return Apollo.useQuery<Types.GetKeyPerformanceIndicatorsQuery, Types.GetKeyPerformanceIndicatorsQueryVariables>(GetKeyPerformanceIndicatorsDocument, baseOptions);
+      }
+export function useGetKeyPerformanceIndicatorsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetKeyPerformanceIndicatorsQuery, Types.GetKeyPerformanceIndicatorsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetKeyPerformanceIndicatorsQuery, Types.GetKeyPerformanceIndicatorsQueryVariables>(GetKeyPerformanceIndicatorsDocument, baseOptions);
+        }
+export type GetKeyPerformanceIndicatorsQueryHookResult = ReturnType<typeof useGetKeyPerformanceIndicatorsQuery>;
+export type GetKeyPerformanceIndicatorsLazyQueryHookResult = ReturnType<typeof useGetKeyPerformanceIndicatorsLazyQuery>;
+export type GetKeyPerformanceIndicatorsQueryResult = Apollo.QueryResult<Types.GetKeyPerformanceIndicatorsQuery, Types.GetKeyPerformanceIndicatorsQueryVariables>;
 export const GetReferrersCountDocument = gql`
-	query GetReferrersCount($project_id: ID!, $lookBackPeriod: Int!) {
-		referrers(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
-			host
-			count
-			percent
-		}
-	}
-`
+    query GetReferrersCount($project_id: ID!, $lookBackPeriod: Int!) {
+  referrers(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
+    host
+    count
+    percent
+  }
+}
+    `;
 
 /**
  * __useGetReferrersCountQuery__
@@ -9708,48 +6371,22 @@ export const GetReferrersCountDocument = gql`
  *   },
  * });
  */
-export function useGetReferrersCountQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetReferrersCountQuery,
-		Types.GetReferrersCountQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetReferrersCountQuery,
-		Types.GetReferrersCountQueryVariables
-	>(GetReferrersCountDocument, baseOptions)
-}
-export function useGetReferrersCountLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetReferrersCountQuery,
-		Types.GetReferrersCountQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetReferrersCountQuery,
-		Types.GetReferrersCountQueryVariables
-	>(GetReferrersCountDocument, baseOptions)
-}
-export type GetReferrersCountQueryHookResult = ReturnType<
-	typeof useGetReferrersCountQuery
->
-export type GetReferrersCountLazyQueryHookResult = ReturnType<
-	typeof useGetReferrersCountLazyQuery
->
-export type GetReferrersCountQueryResult = Apollo.QueryResult<
-	Types.GetReferrersCountQuery,
-	Types.GetReferrersCountQueryVariables
->
+export function useGetReferrersCountQuery(baseOptions: Apollo.QueryHookOptions<Types.GetReferrersCountQuery, Types.GetReferrersCountQueryVariables>) {
+        return Apollo.useQuery<Types.GetReferrersCountQuery, Types.GetReferrersCountQueryVariables>(GetReferrersCountDocument, baseOptions);
+      }
+export function useGetReferrersCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetReferrersCountQuery, Types.GetReferrersCountQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetReferrersCountQuery, Types.GetReferrersCountQueryVariables>(GetReferrersCountDocument, baseOptions);
+        }
+export type GetReferrersCountQueryHookResult = ReturnType<typeof useGetReferrersCountQuery>;
+export type GetReferrersCountLazyQueryHookResult = ReturnType<typeof useGetReferrersCountLazyQuery>;
+export type GetReferrersCountQueryResult = Apollo.QueryResult<Types.GetReferrersCountQuery, Types.GetReferrersCountQueryVariables>;
 export const GetNewUsersCountDocument = gql`
-	query GetNewUsersCount($project_id: ID!, $lookBackPeriod: Int!) {
-		newUsersCount(
-			project_id: $project_id
-			lookBackPeriod: $lookBackPeriod
-		) {
-			count
-		}
-	}
-`
+    query GetNewUsersCount($project_id: ID!, $lookBackPeriod: Int!) {
+  newUsersCount(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
+    count
+  }
+}
+    `;
 
 /**
  * __useGetNewUsersCountQuery__
@@ -9768,48 +6405,22 @@ export const GetNewUsersCountDocument = gql`
  *   },
  * });
  */
-export function useGetNewUsersCountQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetNewUsersCountQuery,
-		Types.GetNewUsersCountQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetNewUsersCountQuery,
-		Types.GetNewUsersCountQueryVariables
-	>(GetNewUsersCountDocument, baseOptions)
-}
-export function useGetNewUsersCountLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetNewUsersCountQuery,
-		Types.GetNewUsersCountQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetNewUsersCountQuery,
-		Types.GetNewUsersCountQueryVariables
-	>(GetNewUsersCountDocument, baseOptions)
-}
-export type GetNewUsersCountQueryHookResult = ReturnType<
-	typeof useGetNewUsersCountQuery
->
-export type GetNewUsersCountLazyQueryHookResult = ReturnType<
-	typeof useGetNewUsersCountLazyQuery
->
-export type GetNewUsersCountQueryResult = Apollo.QueryResult<
-	Types.GetNewUsersCountQuery,
-	Types.GetNewUsersCountQueryVariables
->
+export function useGetNewUsersCountQuery(baseOptions: Apollo.QueryHookOptions<Types.GetNewUsersCountQuery, Types.GetNewUsersCountQueryVariables>) {
+        return Apollo.useQuery<Types.GetNewUsersCountQuery, Types.GetNewUsersCountQueryVariables>(GetNewUsersCountDocument, baseOptions);
+      }
+export function useGetNewUsersCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetNewUsersCountQuery, Types.GetNewUsersCountQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetNewUsersCountQuery, Types.GetNewUsersCountQueryVariables>(GetNewUsersCountDocument, baseOptions);
+        }
+export type GetNewUsersCountQueryHookResult = ReturnType<typeof useGetNewUsersCountQuery>;
+export type GetNewUsersCountLazyQueryHookResult = ReturnType<typeof useGetNewUsersCountLazyQuery>;
+export type GetNewUsersCountQueryResult = Apollo.QueryResult<Types.GetNewUsersCountQuery, Types.GetNewUsersCountQueryVariables>;
 export const GetAverageSessionLengthDocument = gql`
-	query GetAverageSessionLength($project_id: ID!, $lookBackPeriod: Int!) {
-		averageSessionLength(
-			project_id: $project_id
-			lookBackPeriod: $lookBackPeriod
-		) {
-			length
-		}
-	}
-`
+    query GetAverageSessionLength($project_id: ID!, $lookBackPeriod: Int!) {
+  averageSessionLength(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
+    length
+  }
+}
+    `;
 
 /**
  * __useGetAverageSessionLengthQuery__
@@ -9828,49 +6439,26 @@ export const GetAverageSessionLengthDocument = gql`
  *   },
  * });
  */
-export function useGetAverageSessionLengthQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetAverageSessionLengthQuery,
-		Types.GetAverageSessionLengthQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetAverageSessionLengthQuery,
-		Types.GetAverageSessionLengthQueryVariables
-	>(GetAverageSessionLengthDocument, baseOptions)
-}
-export function useGetAverageSessionLengthLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetAverageSessionLengthQuery,
-		Types.GetAverageSessionLengthQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetAverageSessionLengthQuery,
-		Types.GetAverageSessionLengthQueryVariables
-	>(GetAverageSessionLengthDocument, baseOptions)
-}
-export type GetAverageSessionLengthQueryHookResult = ReturnType<
-	typeof useGetAverageSessionLengthQuery
->
-export type GetAverageSessionLengthLazyQueryHookResult = ReturnType<
-	typeof useGetAverageSessionLengthLazyQuery
->
-export type GetAverageSessionLengthQueryResult = Apollo.QueryResult<
-	Types.GetAverageSessionLengthQuery,
-	Types.GetAverageSessionLengthQueryVariables
->
+export function useGetAverageSessionLengthQuery(baseOptions: Apollo.QueryHookOptions<Types.GetAverageSessionLengthQuery, Types.GetAverageSessionLengthQueryVariables>) {
+        return Apollo.useQuery<Types.GetAverageSessionLengthQuery, Types.GetAverageSessionLengthQueryVariables>(GetAverageSessionLengthDocument, baseOptions);
+      }
+export function useGetAverageSessionLengthLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAverageSessionLengthQuery, Types.GetAverageSessionLengthQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetAverageSessionLengthQuery, Types.GetAverageSessionLengthQueryVariables>(GetAverageSessionLengthDocument, baseOptions);
+        }
+export type GetAverageSessionLengthQueryHookResult = ReturnType<typeof useGetAverageSessionLengthQuery>;
+export type GetAverageSessionLengthLazyQueryHookResult = ReturnType<typeof useGetAverageSessionLengthLazyQuery>;
+export type GetAverageSessionLengthQueryResult = Apollo.QueryResult<Types.GetAverageSessionLengthQuery, Types.GetAverageSessionLengthQueryVariables>;
 export const GetTopUsersDocument = gql`
-	query GetTopUsers($project_id: ID!, $lookBackPeriod: Int!) {
-		topUsers(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
-			identifier
-			total_active_time
-			active_time_percentage
-			id
-			user_properties
-		}
-	}
-`
+    query GetTopUsers($project_id: ID!, $lookBackPeriod: Int!) {
+  topUsers(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
+    identifier
+    total_active_time
+    active_time_percentage
+    id
+    user_properties
+  }
+}
+    `;
 
 /**
  * __useGetTopUsersQuery__
@@ -9889,47 +6477,23 @@ export const GetTopUsersDocument = gql`
  *   },
  * });
  */
-export function useGetTopUsersQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetTopUsersQuery,
-		Types.GetTopUsersQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetTopUsersQuery,
-		Types.GetTopUsersQueryVariables
-	>(GetTopUsersDocument, baseOptions)
-}
-export function useGetTopUsersLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetTopUsersQuery,
-		Types.GetTopUsersQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetTopUsersQuery,
-		Types.GetTopUsersQueryVariables
-	>(GetTopUsersDocument, baseOptions)
-}
-export type GetTopUsersQueryHookResult = ReturnType<typeof useGetTopUsersQuery>
-export type GetTopUsersLazyQueryHookResult = ReturnType<
-	typeof useGetTopUsersLazyQuery
->
-export type GetTopUsersQueryResult = Apollo.QueryResult<
-	Types.GetTopUsersQuery,
-	Types.GetTopUsersQueryVariables
->
+export function useGetTopUsersQuery(baseOptions: Apollo.QueryHookOptions<Types.GetTopUsersQuery, Types.GetTopUsersQueryVariables>) {
+        return Apollo.useQuery<Types.GetTopUsersQuery, Types.GetTopUsersQueryVariables>(GetTopUsersDocument, baseOptions);
+      }
+export function useGetTopUsersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetTopUsersQuery, Types.GetTopUsersQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetTopUsersQuery, Types.GetTopUsersQueryVariables>(GetTopUsersDocument, baseOptions);
+        }
+export type GetTopUsersQueryHookResult = ReturnType<typeof useGetTopUsersQuery>;
+export type GetTopUsersLazyQueryHookResult = ReturnType<typeof useGetTopUsersLazyQuery>;
+export type GetTopUsersQueryResult = Apollo.QueryResult<Types.GetTopUsersQuery, Types.GetTopUsersQueryVariables>;
 export const GetDailySessionsCountDocument = gql`
-	query GetDailySessionsCount(
-		$project_id: ID!
-		$date_range: DateRangeInput!
-	) {
-		dailySessionsCount(project_id: $project_id, date_range: $date_range) {
-			date
-			count
-		}
-	}
-`
+    query GetDailySessionsCount($project_id: ID!, $date_range: DateRangeInput!) {
+  dailySessionsCount(project_id: $project_id, date_range: $date_range) {
+    date
+    count
+  }
+}
+    `;
 
 /**
  * __useGetDailySessionsCountQuery__
@@ -9948,46 +6512,23 @@ export const GetDailySessionsCountDocument = gql`
  *   },
  * });
  */
-export function useGetDailySessionsCountQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetDailySessionsCountQuery,
-		Types.GetDailySessionsCountQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetDailySessionsCountQuery,
-		Types.GetDailySessionsCountQueryVariables
-	>(GetDailySessionsCountDocument, baseOptions)
-}
-export function useGetDailySessionsCountLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetDailySessionsCountQuery,
-		Types.GetDailySessionsCountQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetDailySessionsCountQuery,
-		Types.GetDailySessionsCountQueryVariables
-	>(GetDailySessionsCountDocument, baseOptions)
-}
-export type GetDailySessionsCountQueryHookResult = ReturnType<
-	typeof useGetDailySessionsCountQuery
->
-export type GetDailySessionsCountLazyQueryHookResult = ReturnType<
-	typeof useGetDailySessionsCountLazyQuery
->
-export type GetDailySessionsCountQueryResult = Apollo.QueryResult<
-	Types.GetDailySessionsCountQuery,
-	Types.GetDailySessionsCountQueryVariables
->
+export function useGetDailySessionsCountQuery(baseOptions: Apollo.QueryHookOptions<Types.GetDailySessionsCountQuery, Types.GetDailySessionsCountQueryVariables>) {
+        return Apollo.useQuery<Types.GetDailySessionsCountQuery, Types.GetDailySessionsCountQueryVariables>(GetDailySessionsCountDocument, baseOptions);
+      }
+export function useGetDailySessionsCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetDailySessionsCountQuery, Types.GetDailySessionsCountQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetDailySessionsCountQuery, Types.GetDailySessionsCountQueryVariables>(GetDailySessionsCountDocument, baseOptions);
+        }
+export type GetDailySessionsCountQueryHookResult = ReturnType<typeof useGetDailySessionsCountQuery>;
+export type GetDailySessionsCountLazyQueryHookResult = ReturnType<typeof useGetDailySessionsCountLazyQuery>;
+export type GetDailySessionsCountQueryResult = Apollo.QueryResult<Types.GetDailySessionsCountQuery, Types.GetDailySessionsCountQueryVariables>;
 export const GetDailyErrorsCountDocument = gql`
-	query GetDailyErrorsCount($project_id: ID!, $date_range: DateRangeInput!) {
-		dailyErrorsCount(project_id: $project_id, date_range: $date_range) {
-			date
-			count
-		}
-	}
-`
+    query GetDailyErrorsCount($project_id: ID!, $date_range: DateRangeInput!) {
+  dailyErrorsCount(project_id: $project_id, date_range: $date_range) {
+    date
+    count
+  }
+}
+    `;
 
 /**
  * __useGetDailyErrorsCountQuery__
@@ -10006,51 +6547,25 @@ export const GetDailyErrorsCountDocument = gql`
  *   },
  * });
  */
-export function useGetDailyErrorsCountQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetDailyErrorsCountQuery,
-		Types.GetDailyErrorsCountQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetDailyErrorsCountQuery,
-		Types.GetDailyErrorsCountQueryVariables
-	>(GetDailyErrorsCountDocument, baseOptions)
-}
-export function useGetDailyErrorsCountLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetDailyErrorsCountQuery,
-		Types.GetDailyErrorsCountQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetDailyErrorsCountQuery,
-		Types.GetDailyErrorsCountQueryVariables
-	>(GetDailyErrorsCountDocument, baseOptions)
-}
-export type GetDailyErrorsCountQueryHookResult = ReturnType<
-	typeof useGetDailyErrorsCountQuery
->
-export type GetDailyErrorsCountLazyQueryHookResult = ReturnType<
-	typeof useGetDailyErrorsCountLazyQuery
->
-export type GetDailyErrorsCountQueryResult = Apollo.QueryResult<
-	Types.GetDailyErrorsCountQuery,
-	Types.GetDailyErrorsCountQueryVariables
->
+export function useGetDailyErrorsCountQuery(baseOptions: Apollo.QueryHookOptions<Types.GetDailyErrorsCountQuery, Types.GetDailyErrorsCountQueryVariables>) {
+        return Apollo.useQuery<Types.GetDailyErrorsCountQuery, Types.GetDailyErrorsCountQueryVariables>(GetDailyErrorsCountDocument, baseOptions);
+      }
+export function useGetDailyErrorsCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetDailyErrorsCountQuery, Types.GetDailyErrorsCountQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetDailyErrorsCountQuery, Types.GetDailyErrorsCountQueryVariables>(GetDailyErrorsCountDocument, baseOptions);
+        }
+export type GetDailyErrorsCountQueryHookResult = ReturnType<typeof useGetDailyErrorsCountQuery>;
+export type GetDailyErrorsCountLazyQueryHookResult = ReturnType<typeof useGetDailyErrorsCountLazyQuery>;
+export type GetDailyErrorsCountQueryResult = Apollo.QueryResult<Types.GetDailyErrorsCountQuery, Types.GetDailyErrorsCountQueryVariables>;
 export const GetRageClicksForProjectDocument = gql`
-	query GetRageClicksForProject($project_id: ID!, $lookBackPeriod: Int!) {
-		rageClicksForProject(
-			project_id: $project_id
-			lookBackPeriod: $lookBackPeriod
-		) {
-			identifier
-			session_secure_id
-			total_clicks
-			user_properties
-		}
-	}
-`
+    query GetRageClicksForProject($project_id: ID!, $lookBackPeriod: Int!) {
+  rageClicksForProject(project_id: $project_id, lookBackPeriod: $lookBackPeriod) {
+    identifier
+    session_secure_id
+    total_clicks
+    user_properties
+  }
+}
+    `;
 
 /**
  * __useGetRageClicksForProjectQuery__
@@ -10069,51 +6584,24 @@ export const GetRageClicksForProjectDocument = gql`
  *   },
  * });
  */
-export function useGetRageClicksForProjectQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetRageClicksForProjectQuery,
-		Types.GetRageClicksForProjectQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetRageClicksForProjectQuery,
-		Types.GetRageClicksForProjectQueryVariables
-	>(GetRageClicksForProjectDocument, baseOptions)
-}
-export function useGetRageClicksForProjectLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetRageClicksForProjectQuery,
-		Types.GetRageClicksForProjectQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetRageClicksForProjectQuery,
-		Types.GetRageClicksForProjectQueryVariables
-	>(GetRageClicksForProjectDocument, baseOptions)
-}
-export type GetRageClicksForProjectQueryHookResult = ReturnType<
-	typeof useGetRageClicksForProjectQuery
->
-export type GetRageClicksForProjectLazyQueryHookResult = ReturnType<
-	typeof useGetRageClicksForProjectLazyQuery
->
-export type GetRageClicksForProjectQueryResult = Apollo.QueryResult<
-	Types.GetRageClicksForProjectQuery,
-	Types.GetRageClicksForProjectQueryVariables
->
+export function useGetRageClicksForProjectQuery(baseOptions: Apollo.QueryHookOptions<Types.GetRageClicksForProjectQuery, Types.GetRageClicksForProjectQueryVariables>) {
+        return Apollo.useQuery<Types.GetRageClicksForProjectQuery, Types.GetRageClicksForProjectQueryVariables>(GetRageClicksForProjectDocument, baseOptions);
+      }
+export function useGetRageClicksForProjectLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetRageClicksForProjectQuery, Types.GetRageClicksForProjectQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetRageClicksForProjectQuery, Types.GetRageClicksForProjectQueryVariables>(GetRageClicksForProjectDocument, baseOptions);
+        }
+export type GetRageClicksForProjectQueryHookResult = ReturnType<typeof useGetRageClicksForProjectQuery>;
+export type GetRageClicksForProjectLazyQueryHookResult = ReturnType<typeof useGetRageClicksForProjectLazyQuery>;
+export type GetRageClicksForProjectQueryResult = Apollo.QueryResult<Types.GetRageClicksForProjectQuery, Types.GetRageClicksForProjectQueryVariables>;
 export const GetDailyErrorFrequencyDocument = gql`
-	query GetDailyErrorFrequency(
-		$project_id: ID!
-		$error_group_secure_id: String!
-		$date_offset: Int!
-	) {
-		dailyErrorFrequency(
-			project_id: $project_id
-			error_group_secure_id: $error_group_secure_id
-			date_offset: $date_offset
-		)
-	}
-`
+    query GetDailyErrorFrequency($project_id: ID!, $error_group_secure_id: String!, $date_offset: Int!) {
+  dailyErrorFrequency(
+    project_id: $project_id
+    error_group_secure_id: $error_group_secure_id
+    date_offset: $date_offset
+  )
+}
+    `;
 
 /**
  * __useGetDailyErrorFrequencyQuery__
@@ -10133,54 +6621,27 @@ export const GetDailyErrorFrequencyDocument = gql`
  *   },
  * });
  */
-export function useGetDailyErrorFrequencyQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetDailyErrorFrequencyQuery,
-		Types.GetDailyErrorFrequencyQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetDailyErrorFrequencyQuery,
-		Types.GetDailyErrorFrequencyQueryVariables
-	>(GetDailyErrorFrequencyDocument, baseOptions)
-}
-export function useGetDailyErrorFrequencyLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetDailyErrorFrequencyQuery,
-		Types.GetDailyErrorFrequencyQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetDailyErrorFrequencyQuery,
-		Types.GetDailyErrorFrequencyQueryVariables
-	>(GetDailyErrorFrequencyDocument, baseOptions)
-}
-export type GetDailyErrorFrequencyQueryHookResult = ReturnType<
-	typeof useGetDailyErrorFrequencyQuery
->
-export type GetDailyErrorFrequencyLazyQueryHookResult = ReturnType<
-	typeof useGetDailyErrorFrequencyLazyQuery
->
-export type GetDailyErrorFrequencyQueryResult = Apollo.QueryResult<
-	Types.GetDailyErrorFrequencyQuery,
-	Types.GetDailyErrorFrequencyQueryVariables
->
+export function useGetDailyErrorFrequencyQuery(baseOptions: Apollo.QueryHookOptions<Types.GetDailyErrorFrequencyQuery, Types.GetDailyErrorFrequencyQueryVariables>) {
+        return Apollo.useQuery<Types.GetDailyErrorFrequencyQuery, Types.GetDailyErrorFrequencyQueryVariables>(GetDailyErrorFrequencyDocument, baseOptions);
+      }
+export function useGetDailyErrorFrequencyLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetDailyErrorFrequencyQuery, Types.GetDailyErrorFrequencyQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetDailyErrorFrequencyQuery, Types.GetDailyErrorFrequencyQueryVariables>(GetDailyErrorFrequencyDocument, baseOptions);
+        }
+export type GetDailyErrorFrequencyQueryHookResult = ReturnType<typeof useGetDailyErrorFrequencyQuery>;
+export type GetDailyErrorFrequencyLazyQueryHookResult = ReturnType<typeof useGetDailyErrorFrequencyLazyQuery>;
+export type GetDailyErrorFrequencyQueryResult = Apollo.QueryResult<Types.GetDailyErrorFrequencyQuery, Types.GetDailyErrorFrequencyQueryVariables>;
 export const GetErrorDistributionDocument = gql`
-	query GetErrorDistribution(
-		$project_id: ID!
-		$error_group_secure_id: String!
-		$property: String!
-	) {
-		errorDistribution(
-			project_id: $project_id
-			error_group_secure_id: $error_group_secure_id
-			property: $property
-		) {
-			name
-			value
-		}
-	}
-`
+    query GetErrorDistribution($project_id: ID!, $error_group_secure_id: String!, $property: String!) {
+  errorDistribution(
+    project_id: $project_id
+    error_group_secure_id: $error_group_secure_id
+    property: $property
+  ) {
+    name
+    value
+  }
+}
+    `;
 
 /**
  * __useGetErrorDistributionQuery__
@@ -10200,46 +6661,23 @@ export const GetErrorDistributionDocument = gql`
  *   },
  * });
  */
-export function useGetErrorDistributionQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorDistributionQuery,
-		Types.GetErrorDistributionQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorDistributionQuery,
-		Types.GetErrorDistributionQueryVariables
-	>(GetErrorDistributionDocument, baseOptions)
-}
-export function useGetErrorDistributionLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorDistributionQuery,
-		Types.GetErrorDistributionQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorDistributionQuery,
-		Types.GetErrorDistributionQueryVariables
-	>(GetErrorDistributionDocument, baseOptions)
-}
-export type GetErrorDistributionQueryHookResult = ReturnType<
-	typeof useGetErrorDistributionQuery
->
-export type GetErrorDistributionLazyQueryHookResult = ReturnType<
-	typeof useGetErrorDistributionLazyQuery
->
-export type GetErrorDistributionQueryResult = Apollo.QueryResult<
-	Types.GetErrorDistributionQuery,
-	Types.GetErrorDistributionQueryVariables
->
+export function useGetErrorDistributionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorDistributionQuery, Types.GetErrorDistributionQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorDistributionQuery, Types.GetErrorDistributionQueryVariables>(GetErrorDistributionDocument, baseOptions);
+      }
+export function useGetErrorDistributionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorDistributionQuery, Types.GetErrorDistributionQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorDistributionQuery, Types.GetErrorDistributionQueryVariables>(GetErrorDistributionDocument, baseOptions);
+        }
+export type GetErrorDistributionQueryHookResult = ReturnType<typeof useGetErrorDistributionQuery>;
+export type GetErrorDistributionLazyQueryHookResult = ReturnType<typeof useGetErrorDistributionLazyQuery>;
+export type GetErrorDistributionQueryResult = Apollo.QueryResult<Types.GetErrorDistributionQuery, Types.GetErrorDistributionQueryVariables>;
 export const GetSlackChannelSuggestionDocument = gql`
-	query GetSlackChannelSuggestion($project_id: ID!) {
-		slack_channel_suggestion(project_id: $project_id) {
-			webhook_channel
-			webhook_channel_id
-		}
-	}
-`
+    query GetSlackChannelSuggestion($project_id: ID!) {
+  slack_channel_suggestion(project_id: $project_id) {
+    webhook_channel
+    webhook_channel_id
+  }
+}
+    `;
 
 /**
  * __useGetSlackChannelSuggestionQuery__
@@ -10257,46 +6695,23 @@ export const GetSlackChannelSuggestionDocument = gql`
  *   },
  * });
  */
-export function useGetSlackChannelSuggestionQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSlackChannelSuggestionQuery,
-		Types.GetSlackChannelSuggestionQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSlackChannelSuggestionQuery,
-		Types.GetSlackChannelSuggestionQueryVariables
-	>(GetSlackChannelSuggestionDocument, baseOptions)
-}
-export function useGetSlackChannelSuggestionLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSlackChannelSuggestionQuery,
-		Types.GetSlackChannelSuggestionQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSlackChannelSuggestionQuery,
-		Types.GetSlackChannelSuggestionQueryVariables
-	>(GetSlackChannelSuggestionDocument, baseOptions)
-}
-export type GetSlackChannelSuggestionQueryHookResult = ReturnType<
-	typeof useGetSlackChannelSuggestionQuery
->
-export type GetSlackChannelSuggestionLazyQueryHookResult = ReturnType<
-	typeof useGetSlackChannelSuggestionLazyQuery
->
-export type GetSlackChannelSuggestionQueryResult = Apollo.QueryResult<
-	Types.GetSlackChannelSuggestionQuery,
-	Types.GetSlackChannelSuggestionQueryVariables
->
+export function useGetSlackChannelSuggestionQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSlackChannelSuggestionQuery, Types.GetSlackChannelSuggestionQueryVariables>) {
+        return Apollo.useQuery<Types.GetSlackChannelSuggestionQuery, Types.GetSlackChannelSuggestionQueryVariables>(GetSlackChannelSuggestionDocument, baseOptions);
+      }
+export function useGetSlackChannelSuggestionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSlackChannelSuggestionQuery, Types.GetSlackChannelSuggestionQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSlackChannelSuggestionQuery, Types.GetSlackChannelSuggestionQueryVariables>(GetSlackChannelSuggestionDocument, baseOptions);
+        }
+export type GetSlackChannelSuggestionQueryHookResult = ReturnType<typeof useGetSlackChannelSuggestionQuery>;
+export type GetSlackChannelSuggestionLazyQueryHookResult = ReturnType<typeof useGetSlackChannelSuggestionLazyQuery>;
+export type GetSlackChannelSuggestionQueryResult = Apollo.QueryResult<Types.GetSlackChannelSuggestionQuery, Types.GetSlackChannelSuggestionQueryVariables>;
 export const GetWorkspaceIsIntegratedWithSlackDocument = gql`
-	query GetWorkspaceIsIntegratedWithSlack($project_id: ID!) {
-		is_integrated_with_slack: is_integrated_with(
-			integration_type: Slack
-			project_id: $project_id
-		)
-	}
-`
+    query GetWorkspaceIsIntegratedWithSlack($project_id: ID!) {
+  is_integrated_with_slack: is_integrated_with(
+    integration_type: Slack
+    project_id: $project_id
+  )
+}
+    `;
 
 /**
  * __useGetWorkspaceIsIntegratedWithSlackQuery__
@@ -10314,51 +6729,28 @@ export const GetWorkspaceIsIntegratedWithSlackDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceIsIntegratedWithSlackQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspaceIsIntegratedWithSlackQuery,
-		Types.GetWorkspaceIsIntegratedWithSlackQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspaceIsIntegratedWithSlackQuery,
-		Types.GetWorkspaceIsIntegratedWithSlackQueryVariables
-	>(GetWorkspaceIsIntegratedWithSlackDocument, baseOptions)
-}
-export function useGetWorkspaceIsIntegratedWithSlackLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspaceIsIntegratedWithSlackQuery,
-		Types.GetWorkspaceIsIntegratedWithSlackQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspaceIsIntegratedWithSlackQuery,
-		Types.GetWorkspaceIsIntegratedWithSlackQueryVariables
-	>(GetWorkspaceIsIntegratedWithSlackDocument, baseOptions)
-}
-export type GetWorkspaceIsIntegratedWithSlackQueryHookResult = ReturnType<
-	typeof useGetWorkspaceIsIntegratedWithSlackQuery
->
-export type GetWorkspaceIsIntegratedWithSlackLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspaceIsIntegratedWithSlackLazyQuery
->
-export type GetWorkspaceIsIntegratedWithSlackQueryResult = Apollo.QueryResult<
-	Types.GetWorkspaceIsIntegratedWithSlackQuery,
-	Types.GetWorkspaceIsIntegratedWithSlackQueryVariables
->
+export function useGetWorkspaceIsIntegratedWithSlackQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceIsIntegratedWithSlackQuery, Types.GetWorkspaceIsIntegratedWithSlackQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspaceIsIntegratedWithSlackQuery, Types.GetWorkspaceIsIntegratedWithSlackQueryVariables>(GetWorkspaceIsIntegratedWithSlackDocument, baseOptions);
+      }
+export function useGetWorkspaceIsIntegratedWithSlackLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceIsIntegratedWithSlackQuery, Types.GetWorkspaceIsIntegratedWithSlackQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspaceIsIntegratedWithSlackQuery, Types.GetWorkspaceIsIntegratedWithSlackQueryVariables>(GetWorkspaceIsIntegratedWithSlackDocument, baseOptions);
+        }
+export type GetWorkspaceIsIntegratedWithSlackQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithSlackQuery>;
+export type GetWorkspaceIsIntegratedWithSlackLazyQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithSlackLazyQuery>;
+export type GetWorkspaceIsIntegratedWithSlackQueryResult = Apollo.QueryResult<Types.GetWorkspaceIsIntegratedWithSlackQuery, Types.GetWorkspaceIsIntegratedWithSlackQueryVariables>;
 export const GetWorkspaceIsIntegratedWithLinearDocument = gql`
-	query GetWorkspaceIsIntegratedWithLinear($project_id: ID!) {
-		is_integrated_with_linear: is_integrated_with(
-			integration_type: Linear
-			project_id: $project_id
-		)
-		linear_teams(project_id: $project_id) {
-			team_id
-			name
-			key
-		}
-	}
-`
+    query GetWorkspaceIsIntegratedWithLinear($project_id: ID!) {
+  is_integrated_with_linear: is_integrated_with(
+    integration_type: Linear
+    project_id: $project_id
+  )
+  linear_teams(project_id: $project_id) {
+    team_id
+    name
+    key
+  }
+}
+    `;
 
 /**
  * __useGetWorkspaceIsIntegratedWithLinearQuery__
@@ -10376,46 +6768,23 @@ export const GetWorkspaceIsIntegratedWithLinearDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceIsIntegratedWithLinearQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspaceIsIntegratedWithLinearQuery,
-		Types.GetWorkspaceIsIntegratedWithLinearQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspaceIsIntegratedWithLinearQuery,
-		Types.GetWorkspaceIsIntegratedWithLinearQueryVariables
-	>(GetWorkspaceIsIntegratedWithLinearDocument, baseOptions)
-}
-export function useGetWorkspaceIsIntegratedWithLinearLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspaceIsIntegratedWithLinearQuery,
-		Types.GetWorkspaceIsIntegratedWithLinearQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspaceIsIntegratedWithLinearQuery,
-		Types.GetWorkspaceIsIntegratedWithLinearQueryVariables
-	>(GetWorkspaceIsIntegratedWithLinearDocument, baseOptions)
-}
-export type GetWorkspaceIsIntegratedWithLinearQueryHookResult = ReturnType<
-	typeof useGetWorkspaceIsIntegratedWithLinearQuery
->
-export type GetWorkspaceIsIntegratedWithLinearLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspaceIsIntegratedWithLinearLazyQuery
->
-export type GetWorkspaceIsIntegratedWithLinearQueryResult = Apollo.QueryResult<
-	Types.GetWorkspaceIsIntegratedWithLinearQuery,
-	Types.GetWorkspaceIsIntegratedWithLinearQueryVariables
->
+export function useGetWorkspaceIsIntegratedWithLinearQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceIsIntegratedWithLinearQuery, Types.GetWorkspaceIsIntegratedWithLinearQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspaceIsIntegratedWithLinearQuery, Types.GetWorkspaceIsIntegratedWithLinearQueryVariables>(GetWorkspaceIsIntegratedWithLinearDocument, baseOptions);
+      }
+export function useGetWorkspaceIsIntegratedWithLinearLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceIsIntegratedWithLinearQuery, Types.GetWorkspaceIsIntegratedWithLinearQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspaceIsIntegratedWithLinearQuery, Types.GetWorkspaceIsIntegratedWithLinearQueryVariables>(GetWorkspaceIsIntegratedWithLinearDocument, baseOptions);
+        }
+export type GetWorkspaceIsIntegratedWithLinearQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithLinearQuery>;
+export type GetWorkspaceIsIntegratedWithLinearLazyQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithLinearLazyQuery>;
+export type GetWorkspaceIsIntegratedWithLinearQueryResult = Apollo.QueryResult<Types.GetWorkspaceIsIntegratedWithLinearQuery, Types.GetWorkspaceIsIntegratedWithLinearQueryVariables>;
 export const GetWorkspaceIsIntegratedWithZapierDocument = gql`
-	query GetWorkspaceIsIntegratedWithZapier($project_id: ID!) {
-		is_integrated_with_linear: is_integrated_with(
-			integration_type: Zapier
-			project_id: $project_id
-		)
-	}
-`
+    query GetWorkspaceIsIntegratedWithZapier($project_id: ID!) {
+  is_integrated_with_linear: is_integrated_with(
+    integration_type: Zapier
+    project_id: $project_id
+  )
+}
+    `;
 
 /**
  * __useGetWorkspaceIsIntegratedWithZapierQuery__
@@ -10433,46 +6802,23 @@ export const GetWorkspaceIsIntegratedWithZapierDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceIsIntegratedWithZapierQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspaceIsIntegratedWithZapierQuery,
-		Types.GetWorkspaceIsIntegratedWithZapierQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspaceIsIntegratedWithZapierQuery,
-		Types.GetWorkspaceIsIntegratedWithZapierQueryVariables
-	>(GetWorkspaceIsIntegratedWithZapierDocument, baseOptions)
-}
-export function useGetWorkspaceIsIntegratedWithZapierLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspaceIsIntegratedWithZapierQuery,
-		Types.GetWorkspaceIsIntegratedWithZapierQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspaceIsIntegratedWithZapierQuery,
-		Types.GetWorkspaceIsIntegratedWithZapierQueryVariables
-	>(GetWorkspaceIsIntegratedWithZapierDocument, baseOptions)
-}
-export type GetWorkspaceIsIntegratedWithZapierQueryHookResult = ReturnType<
-	typeof useGetWorkspaceIsIntegratedWithZapierQuery
->
-export type GetWorkspaceIsIntegratedWithZapierLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspaceIsIntegratedWithZapierLazyQuery
->
-export type GetWorkspaceIsIntegratedWithZapierQueryResult = Apollo.QueryResult<
-	Types.GetWorkspaceIsIntegratedWithZapierQuery,
-	Types.GetWorkspaceIsIntegratedWithZapierQueryVariables
->
+export function useGetWorkspaceIsIntegratedWithZapierQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceIsIntegratedWithZapierQuery, Types.GetWorkspaceIsIntegratedWithZapierQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspaceIsIntegratedWithZapierQuery, Types.GetWorkspaceIsIntegratedWithZapierQueryVariables>(GetWorkspaceIsIntegratedWithZapierDocument, baseOptions);
+      }
+export function useGetWorkspaceIsIntegratedWithZapierLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceIsIntegratedWithZapierQuery, Types.GetWorkspaceIsIntegratedWithZapierQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspaceIsIntegratedWithZapierQuery, Types.GetWorkspaceIsIntegratedWithZapierQueryVariables>(GetWorkspaceIsIntegratedWithZapierDocument, baseOptions);
+        }
+export type GetWorkspaceIsIntegratedWithZapierQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithZapierQuery>;
+export type GetWorkspaceIsIntegratedWithZapierLazyQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithZapierLazyQuery>;
+export type GetWorkspaceIsIntegratedWithZapierQueryResult = Apollo.QueryResult<Types.GetWorkspaceIsIntegratedWithZapierQuery, Types.GetWorkspaceIsIntegratedWithZapierQueryVariables>;
 export const GetWorkspaceIsIntegratedWithFrontDocument = gql`
-	query GetWorkspaceIsIntegratedWithFront($project_id: ID!) {
-		is_integrated_with_front: is_integrated_with(
-			integration_type: Front
-			project_id: $project_id
-		)
-	}
-`
+    query GetWorkspaceIsIntegratedWithFront($project_id: ID!) {
+  is_integrated_with_front: is_integrated_with(
+    integration_type: Front
+    project_id: $project_id
+  )
+}
+    `;
 
 /**
  * __useGetWorkspaceIsIntegratedWithFrontQuery__
@@ -10490,46 +6836,23 @@ export const GetWorkspaceIsIntegratedWithFrontDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceIsIntegratedWithFrontQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspaceIsIntegratedWithFrontQuery,
-		Types.GetWorkspaceIsIntegratedWithFrontQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspaceIsIntegratedWithFrontQuery,
-		Types.GetWorkspaceIsIntegratedWithFrontQueryVariables
-	>(GetWorkspaceIsIntegratedWithFrontDocument, baseOptions)
-}
-export function useGetWorkspaceIsIntegratedWithFrontLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspaceIsIntegratedWithFrontQuery,
-		Types.GetWorkspaceIsIntegratedWithFrontQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspaceIsIntegratedWithFrontQuery,
-		Types.GetWorkspaceIsIntegratedWithFrontQueryVariables
-	>(GetWorkspaceIsIntegratedWithFrontDocument, baseOptions)
-}
-export type GetWorkspaceIsIntegratedWithFrontQueryHookResult = ReturnType<
-	typeof useGetWorkspaceIsIntegratedWithFrontQuery
->
-export type GetWorkspaceIsIntegratedWithFrontLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspaceIsIntegratedWithFrontLazyQuery
->
-export type GetWorkspaceIsIntegratedWithFrontQueryResult = Apollo.QueryResult<
-	Types.GetWorkspaceIsIntegratedWithFrontQuery,
-	Types.GetWorkspaceIsIntegratedWithFrontQueryVariables
->
+export function useGetWorkspaceIsIntegratedWithFrontQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceIsIntegratedWithFrontQuery, Types.GetWorkspaceIsIntegratedWithFrontQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspaceIsIntegratedWithFrontQuery, Types.GetWorkspaceIsIntegratedWithFrontQueryVariables>(GetWorkspaceIsIntegratedWithFrontDocument, baseOptions);
+      }
+export function useGetWorkspaceIsIntegratedWithFrontLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceIsIntegratedWithFrontQuery, Types.GetWorkspaceIsIntegratedWithFrontQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspaceIsIntegratedWithFrontQuery, Types.GetWorkspaceIsIntegratedWithFrontQueryVariables>(GetWorkspaceIsIntegratedWithFrontDocument, baseOptions);
+        }
+export type GetWorkspaceIsIntegratedWithFrontQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithFrontQuery>;
+export type GetWorkspaceIsIntegratedWithFrontLazyQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithFrontLazyQuery>;
+export type GetWorkspaceIsIntegratedWithFrontQueryResult = Apollo.QueryResult<Types.GetWorkspaceIsIntegratedWithFrontQuery, Types.GetWorkspaceIsIntegratedWithFrontQueryVariables>;
 export const GetWorkspaceIsIntegratedWithDiscordDocument = gql`
-	query GetWorkspaceIsIntegratedWithDiscord($project_id: ID!) {
-		is_integrated_with_discord: is_integrated_with(
-			integration_type: Discord
-			project_id: $project_id
-		)
-	}
-`
+    query GetWorkspaceIsIntegratedWithDiscord($project_id: ID!) {
+  is_integrated_with_discord: is_integrated_with(
+    integration_type: Discord
+    project_id: $project_id
+  )
+}
+    `;
 
 /**
  * __useGetWorkspaceIsIntegratedWithDiscordQuery__
@@ -10547,54 +6870,31 @@ export const GetWorkspaceIsIntegratedWithDiscordDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceIsIntegratedWithDiscordQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspaceIsIntegratedWithDiscordQuery,
-		Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspaceIsIntegratedWithDiscordQuery,
-		Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables
-	>(GetWorkspaceIsIntegratedWithDiscordDocument, baseOptions)
-}
-export function useGetWorkspaceIsIntegratedWithDiscordLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspaceIsIntegratedWithDiscordQuery,
-		Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspaceIsIntegratedWithDiscordQuery,
-		Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables
-	>(GetWorkspaceIsIntegratedWithDiscordDocument, baseOptions)
-}
-export type GetWorkspaceIsIntegratedWithDiscordQueryHookResult = ReturnType<
-	typeof useGetWorkspaceIsIntegratedWithDiscordQuery
->
-export type GetWorkspaceIsIntegratedWithDiscordLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspaceIsIntegratedWithDiscordLazyQuery
->
-export type GetWorkspaceIsIntegratedWithDiscordQueryResult = Apollo.QueryResult<
-	Types.GetWorkspaceIsIntegratedWithDiscordQuery,
-	Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables
->
+export function useGetWorkspaceIsIntegratedWithDiscordQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceIsIntegratedWithDiscordQuery, Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspaceIsIntegratedWithDiscordQuery, Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables>(GetWorkspaceIsIntegratedWithDiscordDocument, baseOptions);
+      }
+export function useGetWorkspaceIsIntegratedWithDiscordLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceIsIntegratedWithDiscordQuery, Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspaceIsIntegratedWithDiscordQuery, Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables>(GetWorkspaceIsIntegratedWithDiscordDocument, baseOptions);
+        }
+export type GetWorkspaceIsIntegratedWithDiscordQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithDiscordQuery>;
+export type GetWorkspaceIsIntegratedWithDiscordLazyQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithDiscordLazyQuery>;
+export type GetWorkspaceIsIntegratedWithDiscordQueryResult = Apollo.QueryResult<Types.GetWorkspaceIsIntegratedWithDiscordQuery, Types.GetWorkspaceIsIntegratedWithDiscordQueryVariables>;
 export const GetWorkspaceIsIntegratedWithVercelDocument = gql`
-	query GetWorkspaceIsIntegratedWithVercel($project_id: ID!) {
-		is_integrated_with_vercel: is_integrated_with(
-			integration_type: Vercel
-			project_id: $project_id
-		)
-		vercel_projects(project_id: $project_id) {
-			id
-			name
-		}
-		vercel_project_mappings(project_id: $project_id) {
-			vercel_project_id
-			project_id
-		}
-	}
-`
+    query GetWorkspaceIsIntegratedWithVercel($project_id: ID!) {
+  is_integrated_with_vercel: is_integrated_with(
+    integration_type: Vercel
+    project_id: $project_id
+  )
+  vercel_projects(project_id: $project_id) {
+    id
+    name
+  }
+  vercel_project_mappings(project_id: $project_id) {
+    vercel_project_id
+    project_id
+  }
+}
+    `;
 
 /**
  * __useGetWorkspaceIsIntegratedWithVercelQuery__
@@ -10612,60 +6912,35 @@ export const GetWorkspaceIsIntegratedWithVercelDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceIsIntegratedWithVercelQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspaceIsIntegratedWithVercelQuery,
-		Types.GetWorkspaceIsIntegratedWithVercelQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspaceIsIntegratedWithVercelQuery,
-		Types.GetWorkspaceIsIntegratedWithVercelQueryVariables
-	>(GetWorkspaceIsIntegratedWithVercelDocument, baseOptions)
-}
-export function useGetWorkspaceIsIntegratedWithVercelLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspaceIsIntegratedWithVercelQuery,
-		Types.GetWorkspaceIsIntegratedWithVercelQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspaceIsIntegratedWithVercelQuery,
-		Types.GetWorkspaceIsIntegratedWithVercelQueryVariables
-	>(GetWorkspaceIsIntegratedWithVercelDocument, baseOptions)
-}
-export type GetWorkspaceIsIntegratedWithVercelQueryHookResult = ReturnType<
-	typeof useGetWorkspaceIsIntegratedWithVercelQuery
->
-export type GetWorkspaceIsIntegratedWithVercelLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspaceIsIntegratedWithVercelLazyQuery
->
-export type GetWorkspaceIsIntegratedWithVercelQueryResult = Apollo.QueryResult<
-	Types.GetWorkspaceIsIntegratedWithVercelQuery,
-	Types.GetWorkspaceIsIntegratedWithVercelQueryVariables
->
+export function useGetWorkspaceIsIntegratedWithVercelQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceIsIntegratedWithVercelQuery, Types.GetWorkspaceIsIntegratedWithVercelQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspaceIsIntegratedWithVercelQuery, Types.GetWorkspaceIsIntegratedWithVercelQueryVariables>(GetWorkspaceIsIntegratedWithVercelDocument, baseOptions);
+      }
+export function useGetWorkspaceIsIntegratedWithVercelLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceIsIntegratedWithVercelQuery, Types.GetWorkspaceIsIntegratedWithVercelQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspaceIsIntegratedWithVercelQuery, Types.GetWorkspaceIsIntegratedWithVercelQueryVariables>(GetWorkspaceIsIntegratedWithVercelDocument, baseOptions);
+        }
+export type GetWorkspaceIsIntegratedWithVercelQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithVercelQuery>;
+export type GetWorkspaceIsIntegratedWithVercelLazyQueryHookResult = ReturnType<typeof useGetWorkspaceIsIntegratedWithVercelLazyQuery>;
+export type GetWorkspaceIsIntegratedWithVercelQueryResult = Apollo.QueryResult<Types.GetWorkspaceIsIntegratedWithVercelQuery, Types.GetWorkspaceIsIntegratedWithVercelQueryVariables>;
 export const GetClickUpIntegrationSettingsDocument = gql`
-	query GetClickUpIntegrationSettings($workspace_id: ID!) {
-		is_integrated: is_workspace_integrated_with(
-			integration_type: ClickUp
-			workspace_id: $workspace_id
-		)
-		clickup_teams(workspace_id: $workspace_id) {
-			id
-			name
-			spaces {
-				id
-				name
-			}
-		}
-		project_mappings: clickup_project_mappings(
-			workspace_id: $workspace_id
-		) {
-			project_id
-			clickup_space_id
-		}
-	}
-`
+    query GetClickUpIntegrationSettings($workspace_id: ID!) {
+  is_integrated: is_workspace_integrated_with(
+    integration_type: ClickUp
+    workspace_id: $workspace_id
+  )
+  clickup_teams(workspace_id: $workspace_id) {
+    id
+    name
+    spaces {
+      id
+      name
+    }
+  }
+  project_mappings: clickup_project_mappings(workspace_id: $workspace_id) {
+    project_id
+    clickup_space_id
+  }
+}
+    `;
 
 /**
  * __useGetClickUpIntegrationSettingsQuery__
@@ -10683,59 +6958,36 @@ export const GetClickUpIntegrationSettingsDocument = gql`
  *   },
  * });
  */
-export function useGetClickUpIntegrationSettingsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetClickUpIntegrationSettingsQuery,
-		Types.GetClickUpIntegrationSettingsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetClickUpIntegrationSettingsQuery,
-		Types.GetClickUpIntegrationSettingsQueryVariables
-	>(GetClickUpIntegrationSettingsDocument, baseOptions)
-}
-export function useGetClickUpIntegrationSettingsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetClickUpIntegrationSettingsQuery,
-		Types.GetClickUpIntegrationSettingsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetClickUpIntegrationSettingsQuery,
-		Types.GetClickUpIntegrationSettingsQueryVariables
-	>(GetClickUpIntegrationSettingsDocument, baseOptions)
-}
-export type GetClickUpIntegrationSettingsQueryHookResult = ReturnType<
-	typeof useGetClickUpIntegrationSettingsQuery
->
-export type GetClickUpIntegrationSettingsLazyQueryHookResult = ReturnType<
-	typeof useGetClickUpIntegrationSettingsLazyQuery
->
-export type GetClickUpIntegrationSettingsQueryResult = Apollo.QueryResult<
-	Types.GetClickUpIntegrationSettingsQuery,
-	Types.GetClickUpIntegrationSettingsQueryVariables
->
+export function useGetClickUpIntegrationSettingsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetClickUpIntegrationSettingsQuery, Types.GetClickUpIntegrationSettingsQueryVariables>) {
+        return Apollo.useQuery<Types.GetClickUpIntegrationSettingsQuery, Types.GetClickUpIntegrationSettingsQueryVariables>(GetClickUpIntegrationSettingsDocument, baseOptions);
+      }
+export function useGetClickUpIntegrationSettingsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetClickUpIntegrationSettingsQuery, Types.GetClickUpIntegrationSettingsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetClickUpIntegrationSettingsQuery, Types.GetClickUpIntegrationSettingsQueryVariables>(GetClickUpIntegrationSettingsDocument, baseOptions);
+        }
+export type GetClickUpIntegrationSettingsQueryHookResult = ReturnType<typeof useGetClickUpIntegrationSettingsQuery>;
+export type GetClickUpIntegrationSettingsLazyQueryHookResult = ReturnType<typeof useGetClickUpIntegrationSettingsLazyQuery>;
+export type GetClickUpIntegrationSettingsQueryResult = Apollo.QueryResult<Types.GetClickUpIntegrationSettingsQuery, Types.GetClickUpIntegrationSettingsQueryVariables>;
 export const GetHeightIntegrationSettingsDocument = gql`
-	query GetHeightIntegrationSettings($workspace_id: ID!) {
-		is_integrated: is_workspace_integrated_with(
-			integration_type: Height
-			workspace_id: $workspace_id
-		)
-		height_workspaces(workspace_id: $workspace_id) {
-			id
-			model
-			name
-			url
-		}
-		integration_project_mappings(
-			workspace_id: $workspace_id
-			integration_type: Height
-		) {
-			project_id
-			external_id
-		}
-	}
-`
+    query GetHeightIntegrationSettings($workspace_id: ID!) {
+  is_integrated: is_workspace_integrated_with(
+    integration_type: Height
+    workspace_id: $workspace_id
+  )
+  height_workspaces(workspace_id: $workspace_id) {
+    id
+    model
+    name
+    url
+  }
+  integration_project_mappings(
+    workspace_id: $workspace_id
+    integration_type: Height
+  ) {
+    project_id
+    external_id
+  }
+}
+    `;
 
 /**
  * __useGetHeightIntegrationSettingsQuery__
@@ -10753,51 +7005,28 @@ export const GetHeightIntegrationSettingsDocument = gql`
  *   },
  * });
  */
-export function useGetHeightIntegrationSettingsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetHeightIntegrationSettingsQuery,
-		Types.GetHeightIntegrationSettingsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetHeightIntegrationSettingsQuery,
-		Types.GetHeightIntegrationSettingsQueryVariables
-	>(GetHeightIntegrationSettingsDocument, baseOptions)
-}
-export function useGetHeightIntegrationSettingsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetHeightIntegrationSettingsQuery,
-		Types.GetHeightIntegrationSettingsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetHeightIntegrationSettingsQuery,
-		Types.GetHeightIntegrationSettingsQueryVariables
-	>(GetHeightIntegrationSettingsDocument, baseOptions)
-}
-export type GetHeightIntegrationSettingsQueryHookResult = ReturnType<
-	typeof useGetHeightIntegrationSettingsQuery
->
-export type GetHeightIntegrationSettingsLazyQueryHookResult = ReturnType<
-	typeof useGetHeightIntegrationSettingsLazyQuery
->
-export type GetHeightIntegrationSettingsQueryResult = Apollo.QueryResult<
-	Types.GetHeightIntegrationSettingsQuery,
-	Types.GetHeightIntegrationSettingsQueryVariables
->
+export function useGetHeightIntegrationSettingsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetHeightIntegrationSettingsQuery, Types.GetHeightIntegrationSettingsQueryVariables>) {
+        return Apollo.useQuery<Types.GetHeightIntegrationSettingsQuery, Types.GetHeightIntegrationSettingsQueryVariables>(GetHeightIntegrationSettingsDocument, baseOptions);
+      }
+export function useGetHeightIntegrationSettingsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetHeightIntegrationSettingsQuery, Types.GetHeightIntegrationSettingsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetHeightIntegrationSettingsQuery, Types.GetHeightIntegrationSettingsQueryVariables>(GetHeightIntegrationSettingsDocument, baseOptions);
+        }
+export type GetHeightIntegrationSettingsQueryHookResult = ReturnType<typeof useGetHeightIntegrationSettingsQuery>;
+export type GetHeightIntegrationSettingsLazyQueryHookResult = ReturnType<typeof useGetHeightIntegrationSettingsLazyQuery>;
+export type GetHeightIntegrationSettingsQueryResult = Apollo.QueryResult<Types.GetHeightIntegrationSettingsQuery, Types.GetHeightIntegrationSettingsQueryVariables>;
 export const GetGitHubIntegrationSettingsDocument = gql`
-	query GetGitHubIntegrationSettings($workspace_id: ID!) {
-		is_integrated: is_workspace_integrated_with(
-			integration_type: GitHub
-			workspace_id: $workspace_id
-		)
-		github_repos(workspace_id: $workspace_id) {
-			repo_id
-			name
-			key
-		}
-	}
-`
+    query GetGitHubIntegrationSettings($workspace_id: ID!) {
+  is_integrated: is_workspace_integrated_with(
+    integration_type: GitHub
+    workspace_id: $workspace_id
+  )
+  github_repos(workspace_id: $workspace_id) {
+    repo_id
+    name
+    key
+  }
+}
+    `;
 
 /**
  * __useGetGitHubIntegrationSettingsQuery__
@@ -10815,46 +7044,20 @@ export const GetGitHubIntegrationSettingsDocument = gql`
  *   },
  * });
  */
-export function useGetGitHubIntegrationSettingsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetGitHubIntegrationSettingsQuery,
-		Types.GetGitHubIntegrationSettingsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetGitHubIntegrationSettingsQuery,
-		Types.GetGitHubIntegrationSettingsQueryVariables
-	>(GetGitHubIntegrationSettingsDocument, baseOptions)
-}
-export function useGetGitHubIntegrationSettingsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetGitHubIntegrationSettingsQuery,
-		Types.GetGitHubIntegrationSettingsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetGitHubIntegrationSettingsQuery,
-		Types.GetGitHubIntegrationSettingsQueryVariables
-	>(GetGitHubIntegrationSettingsDocument, baseOptions)
-}
-export type GetGitHubIntegrationSettingsQueryHookResult = ReturnType<
-	typeof useGetGitHubIntegrationSettingsQuery
->
-export type GetGitHubIntegrationSettingsLazyQueryHookResult = ReturnType<
-	typeof useGetGitHubIntegrationSettingsLazyQuery
->
-export type GetGitHubIntegrationSettingsQueryResult = Apollo.QueryResult<
-	Types.GetGitHubIntegrationSettingsQuery,
-	Types.GetGitHubIntegrationSettingsQueryVariables
->
+export function useGetGitHubIntegrationSettingsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetGitHubIntegrationSettingsQuery, Types.GetGitHubIntegrationSettingsQueryVariables>) {
+        return Apollo.useQuery<Types.GetGitHubIntegrationSettingsQuery, Types.GetGitHubIntegrationSettingsQueryVariables>(GetGitHubIntegrationSettingsDocument, baseOptions);
+      }
+export function useGetGitHubIntegrationSettingsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetGitHubIntegrationSettingsQuery, Types.GetGitHubIntegrationSettingsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetGitHubIntegrationSettingsQuery, Types.GetGitHubIntegrationSettingsQueryVariables>(GetGitHubIntegrationSettingsDocument, baseOptions);
+        }
+export type GetGitHubIntegrationSettingsQueryHookResult = ReturnType<typeof useGetGitHubIntegrationSettingsQuery>;
+export type GetGitHubIntegrationSettingsLazyQueryHookResult = ReturnType<typeof useGetGitHubIntegrationSettingsLazyQuery>;
+export type GetGitHubIntegrationSettingsQueryResult = Apollo.QueryResult<Types.GetGitHubIntegrationSettingsQuery, Types.GetGitHubIntegrationSettingsQueryVariables>;
 export const GetGitHubIssueLabelsDocument = gql`
-	query GetGitHubIssueLabels($workspace_id: ID!, $repository: String!) {
-		github_issue_labels(
-			workspace_id: $workspace_id
-			repository: $repository
-		)
-	}
-`
+    query GetGitHubIssueLabels($workspace_id: ID!, $repository: String!) {
+  github_issue_labels(workspace_id: $workspace_id, repository: $repository)
+}
+    `;
 
 /**
  * __useGetGitHubIssueLabelsQuery__
@@ -10873,49 +7076,23 @@ export const GetGitHubIssueLabelsDocument = gql`
  *   },
  * });
  */
-export function useGetGitHubIssueLabelsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetGitHubIssueLabelsQuery,
-		Types.GetGitHubIssueLabelsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetGitHubIssueLabelsQuery,
-		Types.GetGitHubIssueLabelsQueryVariables
-	>(GetGitHubIssueLabelsDocument, baseOptions)
-}
-export function useGetGitHubIssueLabelsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetGitHubIssueLabelsQuery,
-		Types.GetGitHubIssueLabelsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetGitHubIssueLabelsQuery,
-		Types.GetGitHubIssueLabelsQueryVariables
-	>(GetGitHubIssueLabelsDocument, baseOptions)
-}
-export type GetGitHubIssueLabelsQueryHookResult = ReturnType<
-	typeof useGetGitHubIssueLabelsQuery
->
-export type GetGitHubIssueLabelsLazyQueryHookResult = ReturnType<
-	typeof useGetGitHubIssueLabelsLazyQuery
->
-export type GetGitHubIssueLabelsQueryResult = Apollo.QueryResult<
-	Types.GetGitHubIssueLabelsQuery,
-	Types.GetGitHubIssueLabelsQueryVariables
->
+export function useGetGitHubIssueLabelsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetGitHubIssueLabelsQuery, Types.GetGitHubIssueLabelsQueryVariables>) {
+        return Apollo.useQuery<Types.GetGitHubIssueLabelsQuery, Types.GetGitHubIssueLabelsQueryVariables>(GetGitHubIssueLabelsDocument, baseOptions);
+      }
+export function useGetGitHubIssueLabelsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetGitHubIssueLabelsQuery, Types.GetGitHubIssueLabelsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetGitHubIssueLabelsQuery, Types.GetGitHubIssueLabelsQueryVariables>(GetGitHubIssueLabelsDocument, baseOptions);
+        }
+export type GetGitHubIssueLabelsQueryHookResult = ReturnType<typeof useGetGitHubIssueLabelsQuery>;
+export type GetGitHubIssueLabelsLazyQueryHookResult = ReturnType<typeof useGetGitHubIssueLabelsLazyQuery>;
+export type GetGitHubIssueLabelsQueryResult = Apollo.QueryResult<Types.GetGitHubIssueLabelsQuery, Types.GetGitHubIssueLabelsQueryVariables>;
 export const GetProjectIntegratedWithDocument = gql`
-	query GetProjectIntegratedWith(
-		$project_id: ID!
-		$integration_type: IntegrationType!
-	) {
-		is_project_integrated_with(
-			integration_type: $integration_type
-			project_id: $project_id
-		)
-	}
-`
+    query GetProjectIntegratedWith($project_id: ID!, $integration_type: IntegrationType!) {
+  is_project_integrated_with(
+    integration_type: $integration_type
+    project_id: $project_id
+  )
+}
+    `;
 
 /**
  * __useGetProjectIntegratedWithQuery__
@@ -10934,54 +7111,31 @@ export const GetProjectIntegratedWithDocument = gql`
  *   },
  * });
  */
-export function useGetProjectIntegratedWithQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetProjectIntegratedWithQuery,
-		Types.GetProjectIntegratedWithQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetProjectIntegratedWithQuery,
-		Types.GetProjectIntegratedWithQueryVariables
-	>(GetProjectIntegratedWithDocument, baseOptions)
-}
-export function useGetProjectIntegratedWithLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetProjectIntegratedWithQuery,
-		Types.GetProjectIntegratedWithQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetProjectIntegratedWithQuery,
-		Types.GetProjectIntegratedWithQueryVariables
-	>(GetProjectIntegratedWithDocument, baseOptions)
-}
-export type GetProjectIntegratedWithQueryHookResult = ReturnType<
-	typeof useGetProjectIntegratedWithQuery
->
-export type GetProjectIntegratedWithLazyQueryHookResult = ReturnType<
-	typeof useGetProjectIntegratedWithLazyQuery
->
-export type GetProjectIntegratedWithQueryResult = Apollo.QueryResult<
-	Types.GetProjectIntegratedWithQuery,
-	Types.GetProjectIntegratedWithQueryVariables
->
+export function useGetProjectIntegratedWithQuery(baseOptions: Apollo.QueryHookOptions<Types.GetProjectIntegratedWithQuery, Types.GetProjectIntegratedWithQueryVariables>) {
+        return Apollo.useQuery<Types.GetProjectIntegratedWithQuery, Types.GetProjectIntegratedWithQueryVariables>(GetProjectIntegratedWithDocument, baseOptions);
+      }
+export function useGetProjectIntegratedWithLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectIntegratedWithQuery, Types.GetProjectIntegratedWithQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetProjectIntegratedWithQuery, Types.GetProjectIntegratedWithQueryVariables>(GetProjectIntegratedWithDocument, baseOptions);
+        }
+export type GetProjectIntegratedWithQueryHookResult = ReturnType<typeof useGetProjectIntegratedWithQuery>;
+export type GetProjectIntegratedWithLazyQueryHookResult = ReturnType<typeof useGetProjectIntegratedWithLazyQuery>;
+export type GetProjectIntegratedWithQueryResult = Apollo.QueryResult<Types.GetProjectIntegratedWithQuery, Types.GetProjectIntegratedWithQueryVariables>;
 export const GetClickUpFoldersDocument = gql`
-	query GetClickUpFolders($project_id: ID!) {
-		clickup_folders(project_id: $project_id) {
-			id
-			name
-			lists {
-				id
-				name
-			}
-		}
-		clickup_folderless_lists(project_id: $project_id) {
-			id
-			name
-		}
-	}
-`
+    query GetClickUpFolders($project_id: ID!) {
+  clickup_folders(project_id: $project_id) {
+    id
+    name
+    lists {
+      id
+      name
+    }
+  }
+  clickup_folderless_lists(project_id: $project_id) {
+    id
+    name
+  }
+}
+    `;
 
 /**
  * __useGetClickUpFoldersQuery__
@@ -10999,46 +7153,23 @@ export const GetClickUpFoldersDocument = gql`
  *   },
  * });
  */
-export function useGetClickUpFoldersQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetClickUpFoldersQuery,
-		Types.GetClickUpFoldersQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetClickUpFoldersQuery,
-		Types.GetClickUpFoldersQueryVariables
-	>(GetClickUpFoldersDocument, baseOptions)
-}
-export function useGetClickUpFoldersLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetClickUpFoldersQuery,
-		Types.GetClickUpFoldersQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetClickUpFoldersQuery,
-		Types.GetClickUpFoldersQueryVariables
-	>(GetClickUpFoldersDocument, baseOptions)
-}
-export type GetClickUpFoldersQueryHookResult = ReturnType<
-	typeof useGetClickUpFoldersQuery
->
-export type GetClickUpFoldersLazyQueryHookResult = ReturnType<
-	typeof useGetClickUpFoldersLazyQuery
->
-export type GetClickUpFoldersQueryResult = Apollo.QueryResult<
-	Types.GetClickUpFoldersQuery,
-	Types.GetClickUpFoldersQueryVariables
->
+export function useGetClickUpFoldersQuery(baseOptions: Apollo.QueryHookOptions<Types.GetClickUpFoldersQuery, Types.GetClickUpFoldersQueryVariables>) {
+        return Apollo.useQuery<Types.GetClickUpFoldersQuery, Types.GetClickUpFoldersQueryVariables>(GetClickUpFoldersDocument, baseOptions);
+      }
+export function useGetClickUpFoldersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetClickUpFoldersQuery, Types.GetClickUpFoldersQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetClickUpFoldersQuery, Types.GetClickUpFoldersQueryVariables>(GetClickUpFoldersDocument, baseOptions);
+        }
+export type GetClickUpFoldersQueryHookResult = ReturnType<typeof useGetClickUpFoldersQuery>;
+export type GetClickUpFoldersLazyQueryHookResult = ReturnType<typeof useGetClickUpFoldersLazyQuery>;
+export type GetClickUpFoldersQueryResult = Apollo.QueryResult<Types.GetClickUpFoldersQuery, Types.GetClickUpFoldersQueryVariables>;
 export const GetHeightListsDocument = gql`
-	query GetHeightLists($project_id: ID!) {
-		height_lists(project_id: $project_id) {
-			id
-			name
-		}
-	}
-`
+    query GetHeightLists($project_id: ID!) {
+  height_lists(project_id: $project_id) {
+    id
+    name
+  }
+}
+    `;
 
 /**
  * __useGetHeightListsQuery__
@@ -11056,43 +7187,20 @@ export const GetHeightListsDocument = gql`
  *   },
  * });
  */
-export function useGetHeightListsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetHeightListsQuery,
-		Types.GetHeightListsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetHeightListsQuery,
-		Types.GetHeightListsQueryVariables
-	>(GetHeightListsDocument, baseOptions)
-}
-export function useGetHeightListsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetHeightListsQuery,
-		Types.GetHeightListsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetHeightListsQuery,
-		Types.GetHeightListsQueryVariables
-	>(GetHeightListsDocument, baseOptions)
-}
-export type GetHeightListsQueryHookResult = ReturnType<
-	typeof useGetHeightListsQuery
->
-export type GetHeightListsLazyQueryHookResult = ReturnType<
-	typeof useGetHeightListsLazyQuery
->
-export type GetHeightListsQueryResult = Apollo.QueryResult<
-	Types.GetHeightListsQuery,
-	Types.GetHeightListsQueryVariables
->
+export function useGetHeightListsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetHeightListsQuery, Types.GetHeightListsQueryVariables>) {
+        return Apollo.useQuery<Types.GetHeightListsQuery, Types.GetHeightListsQueryVariables>(GetHeightListsDocument, baseOptions);
+      }
+export function useGetHeightListsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetHeightListsQuery, Types.GetHeightListsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetHeightListsQuery, Types.GetHeightListsQueryVariables>(GetHeightListsDocument, baseOptions);
+        }
+export type GetHeightListsQueryHookResult = ReturnType<typeof useGetHeightListsQuery>;
+export type GetHeightListsLazyQueryHookResult = ReturnType<typeof useGetHeightListsLazyQuery>;
+export type GetHeightListsQueryResult = Apollo.QueryResult<Types.GetHeightListsQuery, Types.GetHeightListsQueryVariables>;
 export const GenerateNewZapierAccessTokenJwtDocument = gql`
-	query GenerateNewZapierAccessTokenJwt($project_id: ID!) {
-		generate_zapier_access_token(project_id: $project_id)
-	}
-`
+    query GenerateNewZapierAccessTokenJwt($project_id: ID!) {
+  generate_zapier_access_token(project_id: $project_id)
+}
+    `;
 
 /**
  * __useGenerateNewZapierAccessTokenJwtQuery__
@@ -11110,43 +7218,20 @@ export const GenerateNewZapierAccessTokenJwtDocument = gql`
  *   },
  * });
  */
-export function useGenerateNewZapierAccessTokenJwtQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GenerateNewZapierAccessTokenJwtQuery,
-		Types.GenerateNewZapierAccessTokenJwtQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GenerateNewZapierAccessTokenJwtQuery,
-		Types.GenerateNewZapierAccessTokenJwtQueryVariables
-	>(GenerateNewZapierAccessTokenJwtDocument, baseOptions)
-}
-export function useGenerateNewZapierAccessTokenJwtLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GenerateNewZapierAccessTokenJwtQuery,
-		Types.GenerateNewZapierAccessTokenJwtQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GenerateNewZapierAccessTokenJwtQuery,
-		Types.GenerateNewZapierAccessTokenJwtQueryVariables
-	>(GenerateNewZapierAccessTokenJwtDocument, baseOptions)
-}
-export type GenerateNewZapierAccessTokenJwtQueryHookResult = ReturnType<
-	typeof useGenerateNewZapierAccessTokenJwtQuery
->
-export type GenerateNewZapierAccessTokenJwtLazyQueryHookResult = ReturnType<
-	typeof useGenerateNewZapierAccessTokenJwtLazyQuery
->
-export type GenerateNewZapierAccessTokenJwtQueryResult = Apollo.QueryResult<
-	Types.GenerateNewZapierAccessTokenJwtQuery,
-	Types.GenerateNewZapierAccessTokenJwtQueryVariables
->
+export function useGenerateNewZapierAccessTokenJwtQuery(baseOptions: Apollo.QueryHookOptions<Types.GenerateNewZapierAccessTokenJwtQuery, Types.GenerateNewZapierAccessTokenJwtQueryVariables>) {
+        return Apollo.useQuery<Types.GenerateNewZapierAccessTokenJwtQuery, Types.GenerateNewZapierAccessTokenJwtQueryVariables>(GenerateNewZapierAccessTokenJwtDocument, baseOptions);
+      }
+export function useGenerateNewZapierAccessTokenJwtLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GenerateNewZapierAccessTokenJwtQuery, Types.GenerateNewZapierAccessTokenJwtQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GenerateNewZapierAccessTokenJwtQuery, Types.GenerateNewZapierAccessTokenJwtQueryVariables>(GenerateNewZapierAccessTokenJwtDocument, baseOptions);
+        }
+export type GenerateNewZapierAccessTokenJwtQueryHookResult = ReturnType<typeof useGenerateNewZapierAccessTokenJwtQuery>;
+export type GenerateNewZapierAccessTokenJwtLazyQueryHookResult = ReturnType<typeof useGenerateNewZapierAccessTokenJwtLazyQuery>;
+export type GenerateNewZapierAccessTokenJwtQueryResult = Apollo.QueryResult<Types.GenerateNewZapierAccessTokenJwtQuery, Types.GenerateNewZapierAccessTokenJwtQueryVariables>;
 export const GetIdentifierSuggestionsDocument = gql`
-	query GetIdentifierSuggestions($project_id: ID!, $query: String!) {
-		identifier_suggestion(project_id: $project_id, query: $query)
-	}
-`
+    query GetIdentifierSuggestions($project_id: ID!, $query: String!) {
+  identifier_suggestion(project_id: $project_id, query: $query)
+}
+    `;
 
 /**
  * __useGetIdentifierSuggestionsQuery__
@@ -11165,69 +7250,45 @@ export const GetIdentifierSuggestionsDocument = gql`
  *   },
  * });
  */
-export function useGetIdentifierSuggestionsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetIdentifierSuggestionsQuery,
-		Types.GetIdentifierSuggestionsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetIdentifierSuggestionsQuery,
-		Types.GetIdentifierSuggestionsQueryVariables
-	>(GetIdentifierSuggestionsDocument, baseOptions)
-}
-export function useGetIdentifierSuggestionsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetIdentifierSuggestionsQuery,
-		Types.GetIdentifierSuggestionsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetIdentifierSuggestionsQuery,
-		Types.GetIdentifierSuggestionsQueryVariables
-	>(GetIdentifierSuggestionsDocument, baseOptions)
-}
-export type GetIdentifierSuggestionsQueryHookResult = ReturnType<
-	typeof useGetIdentifierSuggestionsQuery
->
-export type GetIdentifierSuggestionsLazyQueryHookResult = ReturnType<
-	typeof useGetIdentifierSuggestionsLazyQuery
->
-export type GetIdentifierSuggestionsQueryResult = Apollo.QueryResult<
-	Types.GetIdentifierSuggestionsQuery,
-	Types.GetIdentifierSuggestionsQueryVariables
->
+export function useGetIdentifierSuggestionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetIdentifierSuggestionsQuery, Types.GetIdentifierSuggestionsQueryVariables>) {
+        return Apollo.useQuery<Types.GetIdentifierSuggestionsQuery, Types.GetIdentifierSuggestionsQueryVariables>(GetIdentifierSuggestionsDocument, baseOptions);
+      }
+export function useGetIdentifierSuggestionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetIdentifierSuggestionsQuery, Types.GetIdentifierSuggestionsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetIdentifierSuggestionsQuery, Types.GetIdentifierSuggestionsQueryVariables>(GetIdentifierSuggestionsDocument, baseOptions);
+        }
+export type GetIdentifierSuggestionsQueryHookResult = ReturnType<typeof useGetIdentifierSuggestionsQuery>;
+export type GetIdentifierSuggestionsLazyQueryHookResult = ReturnType<typeof useGetIdentifierSuggestionsLazyQuery>;
+export type GetIdentifierSuggestionsQueryResult = Apollo.QueryResult<Types.GetIdentifierSuggestionsQuery, Types.GetIdentifierSuggestionsQueryVariables>;
 export const GetLogAlertDocument = gql`
-	query GetLogAlert($id: ID!) {
-		log_alert(id: $id) {
-			ChannelsToNotify {
-				webhook_channel
-				webhook_channel_id
-			}
-			DiscordChannelsToNotify {
-				...DiscordChannelFragment
-			}
-			WebhookDestinations {
-				url
-				authorization
-			}
-			CountThreshold
-			DailyFrequency
-			disabled
-			EmailsToNotify
-			ExcludedEnvironments
-			id
-			LastAdminToEditID
-			Name
-			updated_at
-			BelowThreshold
-			ThresholdWindow
-			Type
-			query
-		}
-	}
-	${DiscordChannelFragmentFragmentDoc}
-`
+    query GetLogAlert($id: ID!) {
+  log_alert(id: $id) {
+    ChannelsToNotify {
+      webhook_channel
+      webhook_channel_id
+    }
+    DiscordChannelsToNotify {
+      ...DiscordChannelFragment
+    }
+    WebhookDestinations {
+      url
+      authorization
+    }
+    CountThreshold
+    DailyFrequency
+    disabled
+    EmailsToNotify
+    ExcludedEnvironments
+    id
+    LastAdminToEditID
+    Name
+    updated_at
+    BelowThreshold
+    ThresholdWindow
+    Type
+    query
+  }
+}
+    ${DiscordChannelFragmentFragmentDoc}`;
 
 /**
  * __useGetLogAlertQuery__
@@ -11245,68 +7306,46 @@ export const GetLogAlertDocument = gql`
  *   },
  * });
  */
-export function useGetLogAlertQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetLogAlertQuery,
-		Types.GetLogAlertQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetLogAlertQuery,
-		Types.GetLogAlertQueryVariables
-	>(GetLogAlertDocument, baseOptions)
-}
-export function useGetLogAlertLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetLogAlertQuery,
-		Types.GetLogAlertQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetLogAlertQuery,
-		Types.GetLogAlertQueryVariables
-	>(GetLogAlertDocument, baseOptions)
-}
-export type GetLogAlertQueryHookResult = ReturnType<typeof useGetLogAlertQuery>
-export type GetLogAlertLazyQueryHookResult = ReturnType<
-	typeof useGetLogAlertLazyQuery
->
-export type GetLogAlertQueryResult = Apollo.QueryResult<
-	Types.GetLogAlertQuery,
-	Types.GetLogAlertQueryVariables
->
+export function useGetLogAlertQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogAlertQuery, Types.GetLogAlertQueryVariables>) {
+        return Apollo.useQuery<Types.GetLogAlertQuery, Types.GetLogAlertQueryVariables>(GetLogAlertDocument, baseOptions);
+      }
+export function useGetLogAlertLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogAlertQuery, Types.GetLogAlertQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetLogAlertQuery, Types.GetLogAlertQueryVariables>(GetLogAlertDocument, baseOptions);
+        }
+export type GetLogAlertQueryHookResult = ReturnType<typeof useGetLogAlertQuery>;
+export type GetLogAlertLazyQueryHookResult = ReturnType<typeof useGetLogAlertLazyQuery>;
+export type GetLogAlertQueryResult = Apollo.QueryResult<Types.GetLogAlertQuery, Types.GetLogAlertQueryVariables>;
 export const GetLogAlertsPagePayloadDocument = gql`
-	query GetLogAlertsPagePayload($project_id: ID!) {
-		is_integrated_with_slack: is_integrated_with(
-			integration_type: Slack
-			project_id: $project_id
-		)
-		is_integrated_with_discord: is_integrated_with(
-			integration_type: Discord
-			project_id: $project_id
-		)
-		slack_channel_suggestion(project_id: $project_id) {
-			webhook_channel
-			webhook_channel_id
-		}
-		discord_channel_suggestions(project_id: $project_id) {
-			...DiscordChannelFragment
-		}
-		admins: workspace_admins_by_project_id(project_id: $project_id) {
-			admin {
-				id
-				name
-				email
-				photo_url
-			}
-		}
-		environment_suggestion(project_id: $project_id) {
-			name
-			value
-		}
-	}
-	${DiscordChannelFragmentFragmentDoc}
-`
+    query GetLogAlertsPagePayload($project_id: ID!) {
+  is_integrated_with_slack: is_integrated_with(
+    integration_type: Slack
+    project_id: $project_id
+  )
+  is_integrated_with_discord: is_integrated_with(
+    integration_type: Discord
+    project_id: $project_id
+  )
+  slack_channel_suggestion(project_id: $project_id) {
+    webhook_channel
+    webhook_channel_id
+  }
+  discord_channel_suggestions(project_id: $project_id) {
+    ...DiscordChannelFragment
+  }
+  admins: workspace_admins_by_project_id(project_id: $project_id) {
+    admin {
+      id
+      name
+      email
+      photo_url
+    }
+  }
+  environment_suggestion(project_id: $project_id) {
+    name
+    value
+  }
+}
+    ${DiscordChannelFragmentFragmentDoc}`;
 
 /**
  * __useGetLogAlertsPagePayloadQuery__
@@ -11324,163 +7363,139 @@ export const GetLogAlertsPagePayloadDocument = gql`
  *   },
  * });
  */
-export function useGetLogAlertsPagePayloadQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetLogAlertsPagePayloadQuery,
-		Types.GetLogAlertsPagePayloadQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetLogAlertsPagePayloadQuery,
-		Types.GetLogAlertsPagePayloadQueryVariables
-	>(GetLogAlertsPagePayloadDocument, baseOptions)
-}
-export function useGetLogAlertsPagePayloadLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetLogAlertsPagePayloadQuery,
-		Types.GetLogAlertsPagePayloadQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetLogAlertsPagePayloadQuery,
-		Types.GetLogAlertsPagePayloadQueryVariables
-	>(GetLogAlertsPagePayloadDocument, baseOptions)
-}
-export type GetLogAlertsPagePayloadQueryHookResult = ReturnType<
-	typeof useGetLogAlertsPagePayloadQuery
->
-export type GetLogAlertsPagePayloadLazyQueryHookResult = ReturnType<
-	typeof useGetLogAlertsPagePayloadLazyQuery
->
-export type GetLogAlertsPagePayloadQueryResult = Apollo.QueryResult<
-	Types.GetLogAlertsPagePayloadQuery,
-	Types.GetLogAlertsPagePayloadQueryVariables
->
+export function useGetLogAlertsPagePayloadQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogAlertsPagePayloadQuery, Types.GetLogAlertsPagePayloadQueryVariables>) {
+        return Apollo.useQuery<Types.GetLogAlertsPagePayloadQuery, Types.GetLogAlertsPagePayloadQueryVariables>(GetLogAlertsPagePayloadDocument, baseOptions);
+      }
+export function useGetLogAlertsPagePayloadLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogAlertsPagePayloadQuery, Types.GetLogAlertsPagePayloadQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetLogAlertsPagePayloadQuery, Types.GetLogAlertsPagePayloadQueryVariables>(GetLogAlertsPagePayloadDocument, baseOptions);
+        }
+export type GetLogAlertsPagePayloadQueryHookResult = ReturnType<typeof useGetLogAlertsPagePayloadQuery>;
+export type GetLogAlertsPagePayloadLazyQueryHookResult = ReturnType<typeof useGetLogAlertsPagePayloadLazyQuery>;
+export type GetLogAlertsPagePayloadQueryResult = Apollo.QueryResult<Types.GetLogAlertsPagePayloadQuery, Types.GetLogAlertsPagePayloadQueryVariables>;
 export const GetAlertsPagePayloadDocument = gql`
-	query GetAlertsPagePayload($project_id: ID!) {
-		is_integrated_with_slack: is_integrated_with(
-			integration_type: Slack
-			project_id: $project_id
-		)
-		is_integrated_with_discord: is_integrated_with(
-			integration_type: Discord
-			project_id: $project_id
-		)
-		slack_channel_suggestion(project_id: $project_id) {
-			webhook_channel
-			webhook_channel_id
-		}
-		discord_channel_suggestions(project_id: $project_id) {
-			...DiscordChannelFragment
-		}
-		admins: workspace_admins_by_project_id(project_id: $project_id) {
-			admin {
-				id
-				name
-				email
-				photo_url
-			}
-		}
-		environment_suggestion(project_id: $project_id) {
-			name
-			value
-		}
-		error_alerts(project_id: $project_id) {
-			ChannelsToNotify {
-				webhook_channel
-				webhook_channel_id
-			}
-			DiscordChannelsToNotify {
-				...DiscordChannelFragment
-			}
-			WebhookDestinations {
-				url
-				authorization
-			}
-			EmailsToNotify
-			ExcludedEnvironments
-			updated_at
-			CountThreshold
-			LastAdminToEditID
-			ThresholdWindow
-			RegexGroups
-			Frequency
-			id
-			Type
-			Name
-			DailyFrequency
-			disabled
-		}
-		new_session_alerts(project_id: $project_id) {
-			...SessionAlertFragment
-		}
-		rage_click_alerts(project_id: $project_id) {
-			...SessionAlertFragment
-		}
-		new_user_alerts(project_id: $project_id) {
-			...SessionAlertFragment
-		}
-		track_properties_alerts(project_id: $project_id) {
-			...SessionAlertFragment
-		}
-		user_properties_alerts(project_id: $project_id) {
-			...SessionAlertFragment
-		}
-		metric_monitors(project_id: $project_id) {
-			id
-			updated_at
-			name
-			channels_to_notify {
-				webhook_channel
-				webhook_channel_id
-			}
-			discord_channels_to_notify {
-				id
-				name
-			}
-			webhook_destinations {
-				url
-				authorization
-			}
-			emails_to_notify
-			aggregator
-			period_minutes
-			metric_to_monitor
-			last_admin_to_edit_id
-			threshold
-			filters {
-				tag
-				op
-				value
-			}
-			units
-			disabled
-		}
-		log_alerts(project_id: $project_id) {
-			ChannelsToNotify {
-				webhook_channel
-				webhook_channel_id
-			}
-			DiscordChannelsToNotify {
-				...DiscordChannelFragment
-			}
-			CountThreshold
-			DailyFrequency
-			disabled
-			EmailsToNotify
-			ExcludedEnvironments
-			id
-			LastAdminToEditID
-			Name
-			updated_at
-			ThresholdWindow
-			Type
-			query
-		}
-	}
-	${DiscordChannelFragmentFragmentDoc}
-	${SessionAlertFragmentFragmentDoc}
-`
+    query GetAlertsPagePayload($project_id: ID!) {
+  is_integrated_with_slack: is_integrated_with(
+    integration_type: Slack
+    project_id: $project_id
+  )
+  is_integrated_with_discord: is_integrated_with(
+    integration_type: Discord
+    project_id: $project_id
+  )
+  slack_channel_suggestion(project_id: $project_id) {
+    webhook_channel
+    webhook_channel_id
+  }
+  discord_channel_suggestions(project_id: $project_id) {
+    ...DiscordChannelFragment
+  }
+  admins: workspace_admins_by_project_id(project_id: $project_id) {
+    admin {
+      id
+      name
+      email
+      photo_url
+    }
+  }
+  environment_suggestion(project_id: $project_id) {
+    name
+    value
+  }
+  error_alerts(project_id: $project_id) {
+    ChannelsToNotify {
+      webhook_channel
+      webhook_channel_id
+    }
+    DiscordChannelsToNotify {
+      ...DiscordChannelFragment
+    }
+    WebhookDestinations {
+      url
+      authorization
+    }
+    EmailsToNotify
+    ExcludedEnvironments
+    updated_at
+    CountThreshold
+    LastAdminToEditID
+    ThresholdWindow
+    RegexGroups
+    Frequency
+    id
+    Type
+    Name
+    DailyFrequency
+    disabled
+  }
+  new_session_alerts(project_id: $project_id) {
+    ...SessionAlertFragment
+  }
+  rage_click_alerts(project_id: $project_id) {
+    ...SessionAlertFragment
+  }
+  new_user_alerts(project_id: $project_id) {
+    ...SessionAlertFragment
+  }
+  track_properties_alerts(project_id: $project_id) {
+    ...SessionAlertFragment
+  }
+  user_properties_alerts(project_id: $project_id) {
+    ...SessionAlertFragment
+  }
+  metric_monitors(project_id: $project_id) {
+    id
+    updated_at
+    name
+    channels_to_notify {
+      webhook_channel
+      webhook_channel_id
+    }
+    discord_channels_to_notify {
+      id
+      name
+    }
+    webhook_destinations {
+      url
+      authorization
+    }
+    emails_to_notify
+    aggregator
+    period_minutes
+    metric_to_monitor
+    last_admin_to_edit_id
+    threshold
+    filters {
+      tag
+      op
+      value
+    }
+    units
+    disabled
+  }
+  log_alerts(project_id: $project_id) {
+    ChannelsToNotify {
+      webhook_channel
+      webhook_channel_id
+    }
+    DiscordChannelsToNotify {
+      ...DiscordChannelFragment
+    }
+    CountThreshold
+    DailyFrequency
+    disabled
+    EmailsToNotify
+    ExcludedEnvironments
+    id
+    LastAdminToEditID
+    Name
+    updated_at
+    ThresholdWindow
+    Type
+    query
+  }
+}
+    ${DiscordChannelFragmentFragmentDoc}
+${SessionAlertFragmentFragmentDoc}`;
 
 /**
  * __useGetAlertsPagePayloadQuery__
@@ -11498,48 +7513,25 @@ export const GetAlertsPagePayloadDocument = gql`
  *   },
  * });
  */
-export function useGetAlertsPagePayloadQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetAlertsPagePayloadQuery,
-		Types.GetAlertsPagePayloadQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetAlertsPagePayloadQuery,
-		Types.GetAlertsPagePayloadQueryVariables
-	>(GetAlertsPagePayloadDocument, baseOptions)
-}
-export function useGetAlertsPagePayloadLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetAlertsPagePayloadQuery,
-		Types.GetAlertsPagePayloadQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetAlertsPagePayloadQuery,
-		Types.GetAlertsPagePayloadQueryVariables
-	>(GetAlertsPagePayloadDocument, baseOptions)
-}
-export type GetAlertsPagePayloadQueryHookResult = ReturnType<
-	typeof useGetAlertsPagePayloadQuery
->
-export type GetAlertsPagePayloadLazyQueryHookResult = ReturnType<
-	typeof useGetAlertsPagePayloadLazyQuery
->
-export type GetAlertsPagePayloadQueryResult = Apollo.QueryResult<
-	Types.GetAlertsPagePayloadQuery,
-	Types.GetAlertsPagePayloadQueryVariables
->
+export function useGetAlertsPagePayloadQuery(baseOptions: Apollo.QueryHookOptions<Types.GetAlertsPagePayloadQuery, Types.GetAlertsPagePayloadQueryVariables>) {
+        return Apollo.useQuery<Types.GetAlertsPagePayloadQuery, Types.GetAlertsPagePayloadQueryVariables>(GetAlertsPagePayloadDocument, baseOptions);
+      }
+export function useGetAlertsPagePayloadLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetAlertsPagePayloadQuery, Types.GetAlertsPagePayloadQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetAlertsPagePayloadQuery, Types.GetAlertsPagePayloadQueryVariables>(GetAlertsPagePayloadDocument, baseOptions);
+        }
+export type GetAlertsPagePayloadQueryHookResult = ReturnType<typeof useGetAlertsPagePayloadQuery>;
+export type GetAlertsPagePayloadLazyQueryHookResult = ReturnType<typeof useGetAlertsPagePayloadLazyQuery>;
+export type GetAlertsPagePayloadQueryResult = Apollo.QueryResult<Types.GetAlertsPagePayloadQuery, Types.GetAlertsPagePayloadQueryVariables>;
 export const GetMetricMonitorsDocument = gql`
-	query GetMetricMonitors($project_id: ID!, $metric_name: String!) {
-		metric_monitors(project_id: $project_id, metric_name: $metric_name) {
-			id
-			updated_at
-			name
-			metric_to_monitor
-		}
-	}
-`
+    query GetMetricMonitors($project_id: ID!, $metric_name: String!) {
+  metric_monitors(project_id: $project_id, metric_name: $metric_name) {
+    id
+    updated_at
+    name
+    metric_to_monitor
+  }
+}
+    `;
 
 /**
  * __useGetMetricMonitorsQuery__
@@ -11558,54 +7550,31 @@ export const GetMetricMonitorsDocument = gql`
  *   },
  * });
  */
-export function useGetMetricMonitorsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetMetricMonitorsQuery,
-		Types.GetMetricMonitorsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetMetricMonitorsQuery,
-		Types.GetMetricMonitorsQueryVariables
-	>(GetMetricMonitorsDocument, baseOptions)
-}
-export function useGetMetricMonitorsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetMetricMonitorsQuery,
-		Types.GetMetricMonitorsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetMetricMonitorsQuery,
-		Types.GetMetricMonitorsQueryVariables
-	>(GetMetricMonitorsDocument, baseOptions)
-}
-export type GetMetricMonitorsQueryHookResult = ReturnType<
-	typeof useGetMetricMonitorsQuery
->
-export type GetMetricMonitorsLazyQueryHookResult = ReturnType<
-	typeof useGetMetricMonitorsLazyQuery
->
-export type GetMetricMonitorsQueryResult = Apollo.QueryResult<
-	Types.GetMetricMonitorsQuery,
-	Types.GetMetricMonitorsQueryVariables
->
+export function useGetMetricMonitorsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetMetricMonitorsQuery, Types.GetMetricMonitorsQueryVariables>) {
+        return Apollo.useQuery<Types.GetMetricMonitorsQuery, Types.GetMetricMonitorsQueryVariables>(GetMetricMonitorsDocument, baseOptions);
+      }
+export function useGetMetricMonitorsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetMetricMonitorsQuery, Types.GetMetricMonitorsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetMetricMonitorsQuery, Types.GetMetricMonitorsQueryVariables>(GetMetricMonitorsDocument, baseOptions);
+        }
+export type GetMetricMonitorsQueryHookResult = ReturnType<typeof useGetMetricMonitorsQuery>;
+export type GetMetricMonitorsLazyQueryHookResult = ReturnType<typeof useGetMetricMonitorsLazyQuery>;
+export type GetMetricMonitorsQueryResult = Apollo.QueryResult<Types.GetMetricMonitorsQuery, Types.GetMetricMonitorsQueryVariables>;
 export const GetCommentMentionSuggestionsDocument = gql`
-	query GetCommentMentionSuggestions($project_id: ID!) {
-		admins: workspace_admins_by_project_id(project_id: $project_id) {
-			admin {
-				id
-				name
-				email
-				photo_url
-			}
-		}
-		slack_channel_suggestion(project_id: $project_id) {
-			webhook_channel
-			webhook_channel_id
-		}
-	}
-`
+    query GetCommentMentionSuggestions($project_id: ID!) {
+  admins: workspace_admins_by_project_id(project_id: $project_id) {
+    admin {
+      id
+      name
+      email
+      photo_url
+    }
+  }
+  slack_channel_suggestion(project_id: $project_id) {
+    webhook_channel
+    webhook_channel_id
+  }
+}
+    `;
 
 /**
  * __useGetCommentMentionSuggestionsQuery__
@@ -11623,43 +7592,20 @@ export const GetCommentMentionSuggestionsDocument = gql`
  *   },
  * });
  */
-export function useGetCommentMentionSuggestionsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetCommentMentionSuggestionsQuery,
-		Types.GetCommentMentionSuggestionsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetCommentMentionSuggestionsQuery,
-		Types.GetCommentMentionSuggestionsQueryVariables
-	>(GetCommentMentionSuggestionsDocument, baseOptions)
-}
-export function useGetCommentMentionSuggestionsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetCommentMentionSuggestionsQuery,
-		Types.GetCommentMentionSuggestionsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetCommentMentionSuggestionsQuery,
-		Types.GetCommentMentionSuggestionsQueryVariables
-	>(GetCommentMentionSuggestionsDocument, baseOptions)
-}
-export type GetCommentMentionSuggestionsQueryHookResult = ReturnType<
-	typeof useGetCommentMentionSuggestionsQuery
->
-export type GetCommentMentionSuggestionsLazyQueryHookResult = ReturnType<
-	typeof useGetCommentMentionSuggestionsLazyQuery
->
-export type GetCommentMentionSuggestionsQueryResult = Apollo.QueryResult<
-	Types.GetCommentMentionSuggestionsQuery,
-	Types.GetCommentMentionSuggestionsQueryVariables
->
+export function useGetCommentMentionSuggestionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetCommentMentionSuggestionsQuery, Types.GetCommentMentionSuggestionsQueryVariables>) {
+        return Apollo.useQuery<Types.GetCommentMentionSuggestionsQuery, Types.GetCommentMentionSuggestionsQueryVariables>(GetCommentMentionSuggestionsDocument, baseOptions);
+      }
+export function useGetCommentMentionSuggestionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetCommentMentionSuggestionsQuery, Types.GetCommentMentionSuggestionsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetCommentMentionSuggestionsQuery, Types.GetCommentMentionSuggestionsQueryVariables>(GetCommentMentionSuggestionsDocument, baseOptions);
+        }
+export type GetCommentMentionSuggestionsQueryHookResult = ReturnType<typeof useGetCommentMentionSuggestionsQuery>;
+export type GetCommentMentionSuggestionsLazyQueryHookResult = ReturnType<typeof useGetCommentMentionSuggestionsLazyQuery>;
+export type GetCommentMentionSuggestionsQueryResult = Apollo.QueryResult<Types.GetCommentMentionSuggestionsQuery, Types.GetCommentMentionSuggestionsQueryVariables>;
 export const GetCustomerPortalUrlDocument = gql`
-	query GetCustomerPortalURL($workspace_id: ID!) {
-		customer_portal_url(workspace_id: $workspace_id)
-	}
-`
+    query GetCustomerPortalURL($workspace_id: ID!) {
+  customer_portal_url(workspace_id: $workspace_id)
+}
+    `;
 
 /**
  * __useGetCustomerPortalUrlQuery__
@@ -11677,52 +7623,25 @@ export const GetCustomerPortalUrlDocument = gql`
  *   },
  * });
  */
-export function useGetCustomerPortalUrlQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetCustomerPortalUrlQuery,
-		Types.GetCustomerPortalUrlQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetCustomerPortalUrlQuery,
-		Types.GetCustomerPortalUrlQueryVariables
-	>(GetCustomerPortalUrlDocument, baseOptions)
-}
-export function useGetCustomerPortalUrlLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetCustomerPortalUrlQuery,
-		Types.GetCustomerPortalUrlQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetCustomerPortalUrlQuery,
-		Types.GetCustomerPortalUrlQueryVariables
-	>(GetCustomerPortalUrlDocument, baseOptions)
-}
-export type GetCustomerPortalUrlQueryHookResult = ReturnType<
-	typeof useGetCustomerPortalUrlQuery
->
-export type GetCustomerPortalUrlLazyQueryHookResult = ReturnType<
-	typeof useGetCustomerPortalUrlLazyQuery
->
-export type GetCustomerPortalUrlQueryResult = Apollo.QueryResult<
-	Types.GetCustomerPortalUrlQuery,
-	Types.GetCustomerPortalUrlQueryVariables
->
+export function useGetCustomerPortalUrlQuery(baseOptions: Apollo.QueryHookOptions<Types.GetCustomerPortalUrlQuery, Types.GetCustomerPortalUrlQueryVariables>) {
+        return Apollo.useQuery<Types.GetCustomerPortalUrlQuery, Types.GetCustomerPortalUrlQueryVariables>(GetCustomerPortalUrlDocument, baseOptions);
+      }
+export function useGetCustomerPortalUrlLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetCustomerPortalUrlQuery, Types.GetCustomerPortalUrlQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetCustomerPortalUrlQuery, Types.GetCustomerPortalUrlQueryVariables>(GetCustomerPortalUrlDocument, baseOptions);
+        }
+export type GetCustomerPortalUrlQueryHookResult = ReturnType<typeof useGetCustomerPortalUrlQuery>;
+export type GetCustomerPortalUrlLazyQueryHookResult = ReturnType<typeof useGetCustomerPortalUrlLazyQuery>;
+export type GetCustomerPortalUrlQueryResult = Apollo.QueryResult<Types.GetCustomerPortalUrlQuery, Types.GetCustomerPortalUrlQueryVariables>;
 export const OnSessionPayloadAppendedDocument = gql`
-	subscription OnSessionPayloadAppended(
-		$session_secure_id: String!
-		$initial_events_count: Int!
-	) {
-		session_payload_appended(
-			session_secure_id: $session_secure_id
-			initial_events_count: $initial_events_count
-		) {
-			...SessionPayloadFragment
-		}
-	}
-	${SessionPayloadFragmentFragmentDoc}
-`
+    subscription OnSessionPayloadAppended($session_secure_id: String!, $initial_events_count: Int!) {
+  session_payload_appended(
+    session_secure_id: $session_secure_id
+    initial_events_count: $initial_events_count
+  ) {
+    ...SessionPayloadFragment
+  }
+}
+    ${SessionPayloadFragmentFragmentDoc}`;
 
 /**
  * __useOnSessionPayloadAppendedSubscription__
@@ -11741,30 +7660,19 @@ export const OnSessionPayloadAppendedDocument = gql`
  *   },
  * });
  */
-export function useOnSessionPayloadAppendedSubscription(
-	baseOptions: Apollo.SubscriptionHookOptions<
-		Types.OnSessionPayloadAppendedSubscription,
-		Types.OnSessionPayloadAppendedSubscriptionVariables
-	>,
-) {
-	return Apollo.useSubscription<
-		Types.OnSessionPayloadAppendedSubscription,
-		Types.OnSessionPayloadAppendedSubscriptionVariables
-	>(OnSessionPayloadAppendedDocument, baseOptions)
-}
-export type OnSessionPayloadAppendedSubscriptionHookResult = ReturnType<
-	typeof useOnSessionPayloadAppendedSubscription
->
-export type OnSessionPayloadAppendedSubscriptionResult =
-	Apollo.SubscriptionResult<Types.OnSessionPayloadAppendedSubscription>
+export function useOnSessionPayloadAppendedSubscription(baseOptions: Apollo.SubscriptionHookOptions<Types.OnSessionPayloadAppendedSubscription, Types.OnSessionPayloadAppendedSubscriptionVariables>) {
+        return Apollo.useSubscription<Types.OnSessionPayloadAppendedSubscription, Types.OnSessionPayloadAppendedSubscriptionVariables>(OnSessionPayloadAppendedDocument, baseOptions);
+      }
+export type OnSessionPayloadAppendedSubscriptionHookResult = ReturnType<typeof useOnSessionPayloadAppendedSubscription>;
+export type OnSessionPayloadAppendedSubscriptionResult = Apollo.SubscriptionResult<Types.OnSessionPayloadAppendedSubscription>;
 export const GetWebVitalsDocument = gql`
-	query GetWebVitals($session_secure_id: String!) {
-		web_vitals(session_secure_id: $session_secure_id) {
-			name
-			value
-		}
-	}
-`
+    query GetWebVitals($session_secure_id: String!) {
+  web_vitals(session_secure_id: $session_secure_id) {
+    name
+    value
+  }
+}
+    `;
 
 /**
  * __useGetWebVitalsQuery__
@@ -11782,73 +7690,50 @@ export const GetWebVitalsDocument = gql`
  *   },
  * });
  */
-export function useGetWebVitalsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWebVitalsQuery,
-		Types.GetWebVitalsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWebVitalsQuery,
-		Types.GetWebVitalsQueryVariables
-	>(GetWebVitalsDocument, baseOptions)
-}
-export function useGetWebVitalsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWebVitalsQuery,
-		Types.GetWebVitalsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWebVitalsQuery,
-		Types.GetWebVitalsQueryVariables
-	>(GetWebVitalsDocument, baseOptions)
-}
-export type GetWebVitalsQueryHookResult = ReturnType<
-	typeof useGetWebVitalsQuery
->
-export type GetWebVitalsLazyQueryHookResult = ReturnType<
-	typeof useGetWebVitalsLazyQuery
->
-export type GetWebVitalsQueryResult = Apollo.QueryResult<
-	Types.GetWebVitalsQuery,
-	Types.GetWebVitalsQueryVariables
->
+export function useGetWebVitalsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWebVitalsQuery, Types.GetWebVitalsQueryVariables>) {
+        return Apollo.useQuery<Types.GetWebVitalsQuery, Types.GetWebVitalsQueryVariables>(GetWebVitalsDocument, baseOptions);
+      }
+export function useGetWebVitalsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWebVitalsQuery, Types.GetWebVitalsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWebVitalsQuery, Types.GetWebVitalsQueryVariables>(GetWebVitalsDocument, baseOptions);
+        }
+export type GetWebVitalsQueryHookResult = ReturnType<typeof useGetWebVitalsQuery>;
+export type GetWebVitalsLazyQueryHookResult = ReturnType<typeof useGetWebVitalsLazyQuery>;
+export type GetWebVitalsQueryResult = Apollo.QueryResult<Types.GetWebVitalsQuery, Types.GetWebVitalsQueryVariables>;
 export const GetDashboardDefinitionsDocument = gql`
-	query GetDashboardDefinitions($project_id: ID!) {
-		dashboard_definitions(project_id: $project_id) {
-			id
-			updated_at
-			project_id
-			name
-			is_default
-			metrics {
-				component_type
-				name
-				description
-				max_good_value
-				max_needs_improvement_value
-				poor_value
-				units
-				help_article
-				chart_type
-				aggregator
-				min_value
-				min_percentile
-				max_value
-				max_percentile
-				filters {
-					value
-					op
-					tag
-				}
-				groups
-			}
-			last_admin_to_edit_id
-			layout
-		}
-	}
-`
+    query GetDashboardDefinitions($project_id: ID!) {
+  dashboard_definitions(project_id: $project_id) {
+    id
+    updated_at
+    project_id
+    name
+    is_default
+    metrics {
+      component_type
+      name
+      description
+      max_good_value
+      max_needs_improvement_value
+      poor_value
+      units
+      help_article
+      chart_type
+      aggregator
+      min_value
+      min_percentile
+      max_value
+      max_percentile
+      filters {
+        value
+        op
+        tag
+      }
+      groups
+    }
+    last_admin_to_edit_id
+    layout
+  }
+}
+    `;
 
 /**
  * __useGetDashboardDefinitionsQuery__
@@ -11866,43 +7751,20 @@ export const GetDashboardDefinitionsDocument = gql`
  *   },
  * });
  */
-export function useGetDashboardDefinitionsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetDashboardDefinitionsQuery,
-		Types.GetDashboardDefinitionsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetDashboardDefinitionsQuery,
-		Types.GetDashboardDefinitionsQueryVariables
-	>(GetDashboardDefinitionsDocument, baseOptions)
-}
-export function useGetDashboardDefinitionsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetDashboardDefinitionsQuery,
-		Types.GetDashboardDefinitionsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetDashboardDefinitionsQuery,
-		Types.GetDashboardDefinitionsQueryVariables
-	>(GetDashboardDefinitionsDocument, baseOptions)
-}
-export type GetDashboardDefinitionsQueryHookResult = ReturnType<
-	typeof useGetDashboardDefinitionsQuery
->
-export type GetDashboardDefinitionsLazyQueryHookResult = ReturnType<
-	typeof useGetDashboardDefinitionsLazyQuery
->
-export type GetDashboardDefinitionsQueryResult = Apollo.QueryResult<
-	Types.GetDashboardDefinitionsQuery,
-	Types.GetDashboardDefinitionsQueryVariables
->
+export function useGetDashboardDefinitionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetDashboardDefinitionsQuery, Types.GetDashboardDefinitionsQueryVariables>) {
+        return Apollo.useQuery<Types.GetDashboardDefinitionsQuery, Types.GetDashboardDefinitionsQueryVariables>(GetDashboardDefinitionsDocument, baseOptions);
+      }
+export function useGetDashboardDefinitionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetDashboardDefinitionsQuery, Types.GetDashboardDefinitionsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetDashboardDefinitionsQuery, Types.GetDashboardDefinitionsQueryVariables>(GetDashboardDefinitionsDocument, baseOptions);
+        }
+export type GetDashboardDefinitionsQueryHookResult = ReturnType<typeof useGetDashboardDefinitionsQuery>;
+export type GetDashboardDefinitionsLazyQueryHookResult = ReturnType<typeof useGetDashboardDefinitionsLazyQuery>;
+export type GetDashboardDefinitionsQueryResult = Apollo.QueryResult<Types.GetDashboardDefinitionsQuery, Types.GetDashboardDefinitionsQueryVariables>;
 export const GetSuggestedMetricsDocument = gql`
-	query GetSuggestedMetrics($project_id: ID!, $prefix: String!) {
-		suggested_metrics(project_id: $project_id, prefix: $prefix)
-	}
-`
+    query GetSuggestedMetrics($project_id: ID!, $prefix: String!) {
+  suggested_metrics(project_id: $project_id, prefix: $prefix)
+}
+    `;
 
 /**
  * __useGetSuggestedMetricsQuery__
@@ -11921,43 +7783,20 @@ export const GetSuggestedMetricsDocument = gql`
  *   },
  * });
  */
-export function useGetSuggestedMetricsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSuggestedMetricsQuery,
-		Types.GetSuggestedMetricsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSuggestedMetricsQuery,
-		Types.GetSuggestedMetricsQueryVariables
-	>(GetSuggestedMetricsDocument, baseOptions)
-}
-export function useGetSuggestedMetricsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSuggestedMetricsQuery,
-		Types.GetSuggestedMetricsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSuggestedMetricsQuery,
-		Types.GetSuggestedMetricsQueryVariables
-	>(GetSuggestedMetricsDocument, baseOptions)
-}
-export type GetSuggestedMetricsQueryHookResult = ReturnType<
-	typeof useGetSuggestedMetricsQuery
->
-export type GetSuggestedMetricsLazyQueryHookResult = ReturnType<
-	typeof useGetSuggestedMetricsLazyQuery
->
-export type GetSuggestedMetricsQueryResult = Apollo.QueryResult<
-	Types.GetSuggestedMetricsQuery,
-	Types.GetSuggestedMetricsQueryVariables
->
+export function useGetSuggestedMetricsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSuggestedMetricsQuery, Types.GetSuggestedMetricsQueryVariables>) {
+        return Apollo.useQuery<Types.GetSuggestedMetricsQuery, Types.GetSuggestedMetricsQueryVariables>(GetSuggestedMetricsDocument, baseOptions);
+      }
+export function useGetSuggestedMetricsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSuggestedMetricsQuery, Types.GetSuggestedMetricsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSuggestedMetricsQuery, Types.GetSuggestedMetricsQueryVariables>(GetSuggestedMetricsDocument, baseOptions);
+        }
+export type GetSuggestedMetricsQueryHookResult = ReturnType<typeof useGetSuggestedMetricsQuery>;
+export type GetSuggestedMetricsLazyQueryHookResult = ReturnType<typeof useGetSuggestedMetricsLazyQuery>;
+export type GetSuggestedMetricsQueryResult = Apollo.QueryResult<Types.GetSuggestedMetricsQuery, Types.GetSuggestedMetricsQueryVariables>;
 export const GetMetricTagsDocument = gql`
-	query GetMetricTags($project_id: ID!, $metric_name: String!) {
-		metric_tags(project_id: $project_id, metric_name: $metric_name)
-	}
-`
+    query GetMetricTags($project_id: ID!, $metric_name: String!) {
+  metric_tags(project_id: $project_id, metric_name: $metric_name)
+}
+    `;
 
 /**
  * __useGetMetricTagsQuery__
@@ -11976,51 +7815,24 @@ export const GetMetricTagsDocument = gql`
  *   },
  * });
  */
-export function useGetMetricTagsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetMetricTagsQuery,
-		Types.GetMetricTagsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetMetricTagsQuery,
-		Types.GetMetricTagsQueryVariables
-	>(GetMetricTagsDocument, baseOptions)
-}
-export function useGetMetricTagsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetMetricTagsQuery,
-		Types.GetMetricTagsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetMetricTagsQuery,
-		Types.GetMetricTagsQueryVariables
-	>(GetMetricTagsDocument, baseOptions)
-}
-export type GetMetricTagsQueryHookResult = ReturnType<
-	typeof useGetMetricTagsQuery
->
-export type GetMetricTagsLazyQueryHookResult = ReturnType<
-	typeof useGetMetricTagsLazyQuery
->
-export type GetMetricTagsQueryResult = Apollo.QueryResult<
-	Types.GetMetricTagsQuery,
-	Types.GetMetricTagsQueryVariables
->
+export function useGetMetricTagsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetMetricTagsQuery, Types.GetMetricTagsQueryVariables>) {
+        return Apollo.useQuery<Types.GetMetricTagsQuery, Types.GetMetricTagsQueryVariables>(GetMetricTagsDocument, baseOptions);
+      }
+export function useGetMetricTagsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetMetricTagsQuery, Types.GetMetricTagsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetMetricTagsQuery, Types.GetMetricTagsQueryVariables>(GetMetricTagsDocument, baseOptions);
+        }
+export type GetMetricTagsQueryHookResult = ReturnType<typeof useGetMetricTagsQuery>;
+export type GetMetricTagsLazyQueryHookResult = ReturnType<typeof useGetMetricTagsLazyQuery>;
+export type GetMetricTagsQueryResult = Apollo.QueryResult<Types.GetMetricTagsQuery, Types.GetMetricTagsQueryVariables>;
 export const GetMetricTagValuesDocument = gql`
-	query GetMetricTagValues(
-		$project_id: ID!
-		$metric_name: String!
-		$tag_name: String!
-	) {
-		metric_tag_values(
-			project_id: $project_id
-			metric_name: $metric_name
-			tag_name: $tag_name
-		)
-	}
-`
+    query GetMetricTagValues($project_id: ID!, $metric_name: String!, $tag_name: String!) {
+  metric_tag_values(
+    project_id: $project_id
+    metric_name: $metric_name
+    tag_name: $tag_name
+  )
+}
+    `;
 
 /**
  * __useGetMetricTagValuesQuery__
@@ -12040,45 +7852,22 @@ export const GetMetricTagValuesDocument = gql`
  *   },
  * });
  */
-export function useGetMetricTagValuesQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetMetricTagValuesQuery,
-		Types.GetMetricTagValuesQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetMetricTagValuesQuery,
-		Types.GetMetricTagValuesQueryVariables
-	>(GetMetricTagValuesDocument, baseOptions)
-}
-export function useGetMetricTagValuesLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetMetricTagValuesQuery,
-		Types.GetMetricTagValuesQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetMetricTagValuesQuery,
-		Types.GetMetricTagValuesQueryVariables
-	>(GetMetricTagValuesDocument, baseOptions)
-}
-export type GetMetricTagValuesQueryHookResult = ReturnType<
-	typeof useGetMetricTagValuesQuery
->
-export type GetMetricTagValuesLazyQueryHookResult = ReturnType<
-	typeof useGetMetricTagValuesLazyQuery
->
-export type GetMetricTagValuesQueryResult = Apollo.QueryResult<
-	Types.GetMetricTagValuesQuery,
-	Types.GetMetricTagValuesQueryVariables
->
+export function useGetMetricTagValuesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetMetricTagValuesQuery, Types.GetMetricTagValuesQueryVariables>) {
+        return Apollo.useQuery<Types.GetMetricTagValuesQuery, Types.GetMetricTagValuesQueryVariables>(GetMetricTagValuesDocument, baseOptions);
+      }
+export function useGetMetricTagValuesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetMetricTagValuesQuery, Types.GetMetricTagValuesQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetMetricTagValuesQuery, Types.GetMetricTagValuesQueryVariables>(GetMetricTagValuesDocument, baseOptions);
+        }
+export type GetMetricTagValuesQueryHookResult = ReturnType<typeof useGetMetricTagValuesQuery>;
+export type GetMetricTagValuesLazyQueryHookResult = ReturnType<typeof useGetMetricTagValuesLazyQuery>;
+export type GetMetricTagValuesQueryResult = Apollo.QueryResult<Types.GetMetricTagValuesQuery, Types.GetMetricTagValuesQueryVariables>;
 export const GetSourcemapFilesDocument = gql`
-	query GetSourcemapFiles($project_id: ID!, $version: String) {
-		sourcemap_files(project_id: $project_id, version: $version) {
-			key
-		}
-	}
-`
+    query GetSourcemapFiles($project_id: ID!, $version: String) {
+  sourcemap_files(project_id: $project_id, version: $version) {
+    key
+  }
+}
+    `;
 
 /**
  * __useGetSourcemapFilesQuery__
@@ -12097,43 +7886,20 @@ export const GetSourcemapFilesDocument = gql`
  *   },
  * });
  */
-export function useGetSourcemapFilesQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSourcemapFilesQuery,
-		Types.GetSourcemapFilesQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSourcemapFilesQuery,
-		Types.GetSourcemapFilesQueryVariables
-	>(GetSourcemapFilesDocument, baseOptions)
-}
-export function useGetSourcemapFilesLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSourcemapFilesQuery,
-		Types.GetSourcemapFilesQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSourcemapFilesQuery,
-		Types.GetSourcemapFilesQueryVariables
-	>(GetSourcemapFilesDocument, baseOptions)
-}
-export type GetSourcemapFilesQueryHookResult = ReturnType<
-	typeof useGetSourcemapFilesQuery
->
-export type GetSourcemapFilesLazyQueryHookResult = ReturnType<
-	typeof useGetSourcemapFilesLazyQuery
->
-export type GetSourcemapFilesQueryResult = Apollo.QueryResult<
-	Types.GetSourcemapFilesQuery,
-	Types.GetSourcemapFilesQueryVariables
->
+export function useGetSourcemapFilesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSourcemapFilesQuery, Types.GetSourcemapFilesQueryVariables>) {
+        return Apollo.useQuery<Types.GetSourcemapFilesQuery, Types.GetSourcemapFilesQueryVariables>(GetSourcemapFilesDocument, baseOptions);
+      }
+export function useGetSourcemapFilesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSourcemapFilesQuery, Types.GetSourcemapFilesQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSourcemapFilesQuery, Types.GetSourcemapFilesQueryVariables>(GetSourcemapFilesDocument, baseOptions);
+        }
+export type GetSourcemapFilesQueryHookResult = ReturnType<typeof useGetSourcemapFilesQuery>;
+export type GetSourcemapFilesLazyQueryHookResult = ReturnType<typeof useGetSourcemapFilesLazyQuery>;
+export type GetSourcemapFilesQueryResult = Apollo.QueryResult<Types.GetSourcemapFilesQuery, Types.GetSourcemapFilesQueryVariables>;
 export const GetSourcemapVersionsDocument = gql`
-	query GetSourcemapVersions($project_id: ID!) {
-		sourcemap_versions(project_id: $project_id)
-	}
-`
+    query GetSourcemapVersions($project_id: ID!) {
+  sourcemap_versions(project_id: $project_id)
+}
+    `;
 
 /**
  * __useGetSourcemapVersionsQuery__
@@ -12151,47 +7917,24 @@ export const GetSourcemapVersionsDocument = gql`
  *   },
  * });
  */
-export function useGetSourcemapVersionsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSourcemapVersionsQuery,
-		Types.GetSourcemapVersionsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSourcemapVersionsQuery,
-		Types.GetSourcemapVersionsQueryVariables
-	>(GetSourcemapVersionsDocument, baseOptions)
-}
-export function useGetSourcemapVersionsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSourcemapVersionsQuery,
-		Types.GetSourcemapVersionsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSourcemapVersionsQuery,
-		Types.GetSourcemapVersionsQueryVariables
-	>(GetSourcemapVersionsDocument, baseOptions)
-}
-export type GetSourcemapVersionsQueryHookResult = ReturnType<
-	typeof useGetSourcemapVersionsQuery
->
-export type GetSourcemapVersionsLazyQueryHookResult = ReturnType<
-	typeof useGetSourcemapVersionsLazyQuery
->
-export type GetSourcemapVersionsQueryResult = Apollo.QueryResult<
-	Types.GetSourcemapVersionsQuery,
-	Types.GetSourcemapVersionsQueryVariables
->
+export function useGetSourcemapVersionsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSourcemapVersionsQuery, Types.GetSourcemapVersionsQueryVariables>) {
+        return Apollo.useQuery<Types.GetSourcemapVersionsQuery, Types.GetSourcemapVersionsQueryVariables>(GetSourcemapVersionsDocument, baseOptions);
+      }
+export function useGetSourcemapVersionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSourcemapVersionsQuery, Types.GetSourcemapVersionsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSourcemapVersionsQuery, Types.GetSourcemapVersionsQueryVariables>(GetSourcemapVersionsDocument, baseOptions);
+        }
+export type GetSourcemapVersionsQueryHookResult = ReturnType<typeof useGetSourcemapVersionsQuery>;
+export type GetSourcemapVersionsLazyQueryHookResult = ReturnType<typeof useGetSourcemapVersionsLazyQuery>;
+export type GetSourcemapVersionsQueryResult = Apollo.QueryResult<Types.GetSourcemapVersionsQuery, Types.GetSourcemapVersionsQueryVariables>;
 export const GetOAuthClientMetadataDocument = gql`
-	query GetOAuthClientMetadata($client_id: String!) {
-		oauth_client_metadata(client_id: $client_id) {
-			id
-			created_at
-			app_name
-		}
-	}
-`
+    query GetOAuthClientMetadata($client_id: String!) {
+  oauth_client_metadata(client_id: $client_id) {
+    id
+    created_at
+    app_name
+  }
+}
+    `;
 
 /**
  * __useGetOAuthClientMetadataQuery__
@@ -12209,58 +7952,30 @@ export const GetOAuthClientMetadataDocument = gql`
  *   },
  * });
  */
-export function useGetOAuthClientMetadataQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetOAuthClientMetadataQuery,
-		Types.GetOAuthClientMetadataQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetOAuthClientMetadataQuery,
-		Types.GetOAuthClientMetadataQueryVariables
-	>(GetOAuthClientMetadataDocument, baseOptions)
-}
-export function useGetOAuthClientMetadataLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetOAuthClientMetadataQuery,
-		Types.GetOAuthClientMetadataQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetOAuthClientMetadataQuery,
-		Types.GetOAuthClientMetadataQueryVariables
-	>(GetOAuthClientMetadataDocument, baseOptions)
-}
-export type GetOAuthClientMetadataQueryHookResult = ReturnType<
-	typeof useGetOAuthClientMetadataQuery
->
-export type GetOAuthClientMetadataLazyQueryHookResult = ReturnType<
-	typeof useGetOAuthClientMetadataLazyQuery
->
-export type GetOAuthClientMetadataQueryResult = Apollo.QueryResult<
-	Types.GetOAuthClientMetadataQuery,
-	Types.GetOAuthClientMetadataQueryVariables
->
+export function useGetOAuthClientMetadataQuery(baseOptions: Apollo.QueryHookOptions<Types.GetOAuthClientMetadataQuery, Types.GetOAuthClientMetadataQueryVariables>) {
+        return Apollo.useQuery<Types.GetOAuthClientMetadataQuery, Types.GetOAuthClientMetadataQueryVariables>(GetOAuthClientMetadataDocument, baseOptions);
+      }
+export function useGetOAuthClientMetadataLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetOAuthClientMetadataQuery, Types.GetOAuthClientMetadataQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetOAuthClientMetadataQuery, Types.GetOAuthClientMetadataQueryVariables>(GetOAuthClientMetadataDocument, baseOptions);
+        }
+export type GetOAuthClientMetadataQueryHookResult = ReturnType<typeof useGetOAuthClientMetadataQuery>;
+export type GetOAuthClientMetadataLazyQueryHookResult = ReturnType<typeof useGetOAuthClientMetadataLazyQuery>;
+export type GetOAuthClientMetadataQueryResult = Apollo.QueryResult<Types.GetOAuthClientMetadataQuery, Types.GetOAuthClientMetadataQueryVariables>;
 export const GetErrorGroupFrequenciesDocument = gql`
-	query GetErrorGroupFrequencies(
-		$project_id: ID!
-		$error_group_secure_ids: [String!]!
-		$params: ErrorGroupFrequenciesParamsInput!
-		$metric: String!
-	) {
-		errorGroupFrequencies(
-			project_id: $project_id
-			error_group_secure_ids: $error_group_secure_ids
-			params: $params
-			metric: $metric
-		) {
-			error_group_id
-			date
-			name
-			value
-		}
-	}
-`
+    query GetErrorGroupFrequencies($project_id: ID!, $error_group_secure_ids: [String!]!, $params: ErrorGroupFrequenciesParamsInput!, $metric: String!) {
+  errorGroupFrequencies(
+    project_id: $project_id
+    error_group_secure_ids: $error_group_secure_ids
+    params: $params
+    metric: $metric
+  ) {
+    error_group_id
+    date
+    name
+    value
+  }
+}
+    `;
 
 /**
  * __useGetErrorGroupFrequenciesQuery__
@@ -12281,50 +7996,27 @@ export const GetErrorGroupFrequenciesDocument = gql`
  *   },
  * });
  */
-export function useGetErrorGroupFrequenciesQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorGroupFrequenciesQuery,
-		Types.GetErrorGroupFrequenciesQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorGroupFrequenciesQuery,
-		Types.GetErrorGroupFrequenciesQueryVariables
-	>(GetErrorGroupFrequenciesDocument, baseOptions)
-}
-export function useGetErrorGroupFrequenciesLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorGroupFrequenciesQuery,
-		Types.GetErrorGroupFrequenciesQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorGroupFrequenciesQuery,
-		Types.GetErrorGroupFrequenciesQueryVariables
-	>(GetErrorGroupFrequenciesDocument, baseOptions)
-}
-export type GetErrorGroupFrequenciesQueryHookResult = ReturnType<
-	typeof useGetErrorGroupFrequenciesQuery
->
-export type GetErrorGroupFrequenciesLazyQueryHookResult = ReturnType<
-	typeof useGetErrorGroupFrequenciesLazyQuery
->
-export type GetErrorGroupFrequenciesQueryResult = Apollo.QueryResult<
-	Types.GetErrorGroupFrequenciesQuery,
-	Types.GetErrorGroupFrequenciesQueryVariables
->
+export function useGetErrorGroupFrequenciesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorGroupFrequenciesQuery, Types.GetErrorGroupFrequenciesQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorGroupFrequenciesQuery, Types.GetErrorGroupFrequenciesQueryVariables>(GetErrorGroupFrequenciesDocument, baseOptions);
+      }
+export function useGetErrorGroupFrequenciesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorGroupFrequenciesQuery, Types.GetErrorGroupFrequenciesQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorGroupFrequenciesQuery, Types.GetErrorGroupFrequenciesQueryVariables>(GetErrorGroupFrequenciesDocument, baseOptions);
+        }
+export type GetErrorGroupFrequenciesQueryHookResult = ReturnType<typeof useGetErrorGroupFrequenciesQuery>;
+export type GetErrorGroupFrequenciesLazyQueryHookResult = ReturnType<typeof useGetErrorGroupFrequenciesLazyQuery>;
+export type GetErrorGroupFrequenciesQueryResult = Apollo.QueryResult<Types.GetErrorGroupFrequenciesQuery, Types.GetErrorGroupFrequenciesQueryVariables>;
 export const GetErrorGroupTagsDocument = gql`
-	query GetErrorGroupTags($error_group_secure_id: String!) {
-		errorGroupTags(error_group_secure_id: $error_group_secure_id) {
-			key
-			buckets {
-				key
-				doc_count
-				percent
-			}
-		}
-	}
-`
+    query GetErrorGroupTags($error_group_secure_id: String!) {
+  errorGroupTags(error_group_secure_id: $error_group_secure_id) {
+    key
+    buckets {
+      key
+      doc_count
+      percent
+    }
+  }
+}
+    `;
 
 /**
  * __useGetErrorGroupTagsQuery__
@@ -12342,43 +8034,20 @@ export const GetErrorGroupTagsDocument = gql`
  *   },
  * });
  */
-export function useGetErrorGroupTagsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetErrorGroupTagsQuery,
-		Types.GetErrorGroupTagsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetErrorGroupTagsQuery,
-		Types.GetErrorGroupTagsQueryVariables
-	>(GetErrorGroupTagsDocument, baseOptions)
-}
-export function useGetErrorGroupTagsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetErrorGroupTagsQuery,
-		Types.GetErrorGroupTagsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetErrorGroupTagsQuery,
-		Types.GetErrorGroupTagsQueryVariables
-	>(GetErrorGroupTagsDocument, baseOptions)
-}
-export type GetErrorGroupTagsQueryHookResult = ReturnType<
-	typeof useGetErrorGroupTagsQuery
->
-export type GetErrorGroupTagsLazyQueryHookResult = ReturnType<
-	typeof useGetErrorGroupTagsLazyQuery
->
-export type GetErrorGroupTagsQueryResult = Apollo.QueryResult<
-	Types.GetErrorGroupTagsQuery,
-	Types.GetErrorGroupTagsQueryVariables
->
+export function useGetErrorGroupTagsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorGroupTagsQuery, Types.GetErrorGroupTagsQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorGroupTagsQuery, Types.GetErrorGroupTagsQueryVariables>(GetErrorGroupTagsDocument, baseOptions);
+      }
+export function useGetErrorGroupTagsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorGroupTagsQuery, Types.GetErrorGroupTagsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorGroupTagsQuery, Types.GetErrorGroupTagsQueryVariables>(GetErrorGroupTagsDocument, baseOptions);
+        }
+export type GetErrorGroupTagsQueryHookResult = ReturnType<typeof useGetErrorGroupTagsQuery>;
+export type GetErrorGroupTagsLazyQueryHookResult = ReturnType<typeof useGetErrorGroupTagsLazyQuery>;
+export type GetErrorGroupTagsQueryResult = Apollo.QueryResult<Types.GetErrorGroupTagsQuery, Types.GetErrorGroupTagsQueryVariables>;
 export const GetEmailOptOutsDocument = gql`
-	query GetEmailOptOuts($token: String, $admin_id: ID) {
-		email_opt_outs(token: $token, admin_id: $admin_id)
-	}
-`
+    query GetEmailOptOuts($token: String, $admin_id: ID) {
+  email_opt_outs(token: $token, admin_id: $admin_id)
+}
+    `;
 
 /**
  * __useGetEmailOptOutsQuery__
@@ -12397,78 +8066,48 @@ export const GetEmailOptOutsDocument = gql`
  *   },
  * });
  */
-export function useGetEmailOptOutsQuery(
-	baseOptions?: Apollo.QueryHookOptions<
-		Types.GetEmailOptOutsQuery,
-		Types.GetEmailOptOutsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetEmailOptOutsQuery,
-		Types.GetEmailOptOutsQueryVariables
-	>(GetEmailOptOutsDocument, baseOptions)
-}
-export function useGetEmailOptOutsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetEmailOptOutsQuery,
-		Types.GetEmailOptOutsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetEmailOptOutsQuery,
-		Types.GetEmailOptOutsQueryVariables
-	>(GetEmailOptOutsDocument, baseOptions)
-}
-export type GetEmailOptOutsQueryHookResult = ReturnType<
-	typeof useGetEmailOptOutsQuery
->
-export type GetEmailOptOutsLazyQueryHookResult = ReturnType<
-	typeof useGetEmailOptOutsLazyQuery
->
-export type GetEmailOptOutsQueryResult = Apollo.QueryResult<
-	Types.GetEmailOptOutsQuery,
-	Types.GetEmailOptOutsQueryVariables
->
+export function useGetEmailOptOutsQuery(baseOptions?: Apollo.QueryHookOptions<Types.GetEmailOptOutsQuery, Types.GetEmailOptOutsQueryVariables>) {
+        return Apollo.useQuery<Types.GetEmailOptOutsQuery, Types.GetEmailOptOutsQueryVariables>(GetEmailOptOutsDocument, baseOptions);
+      }
+export function useGetEmailOptOutsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetEmailOptOutsQuery, Types.GetEmailOptOutsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetEmailOptOutsQuery, Types.GetEmailOptOutsQueryVariables>(GetEmailOptOutsDocument, baseOptions);
+        }
+export type GetEmailOptOutsQueryHookResult = ReturnType<typeof useGetEmailOptOutsQuery>;
+export type GetEmailOptOutsLazyQueryHookResult = ReturnType<typeof useGetEmailOptOutsLazyQuery>;
+export type GetEmailOptOutsQueryResult = Apollo.QueryResult<Types.GetEmailOptOutsQuery, Types.GetEmailOptOutsQueryVariables>;
 export const GetLogsDocument = gql`
-	query GetLogs(
-		$project_id: ID!
-		$params: LogsParamsInput!
-		$after: String
-		$before: String
-		$at: String
-		$direction: LogDirection!
-	) {
-		logs(
-			project_id: $project_id
-			params: $params
-			after: $after
-			before: $before
-			at: $at
-			direction: $direction
-		) {
-			edges {
-				cursor
-				node {
-					timestamp
-					level
-					message
-					logAttributes
-					traceID
-					spanID
-					secureSessionID
-					source
-					serviceName
-				}
-			}
-			pageInfo {
-				hasNextPage
-				hasPreviousPage
-				startCursor
-				endCursor
-			}
-		}
-	}
-`
+    query GetLogs($project_id: ID!, $params: LogsParamsInput!, $after: String, $before: String, $at: String, $direction: LogDirection!) {
+  logs(
+    project_id: $project_id
+    params: $params
+    after: $after
+    before: $before
+    at: $at
+    direction: $direction
+  ) {
+    edges {
+      cursor
+      node {
+        timestamp
+        level
+        message
+        logAttributes
+        traceID
+        spanID
+        secureSessionID
+        source
+        serviceName
+      }
+    }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+  }
+}
+    `;
 
 /**
  * __useGetLogsQuery__
@@ -12491,46 +8130,27 @@ export const GetLogsDocument = gql`
  *   },
  * });
  */
-export function useGetLogsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetLogsQuery,
-		Types.GetLogsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<Types.GetLogsQuery, Types.GetLogsQueryVariables>(
-		GetLogsDocument,
-		baseOptions,
-	)
-}
-export function useGetLogsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetLogsQuery,
-		Types.GetLogsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<Types.GetLogsQuery, Types.GetLogsQueryVariables>(
-		GetLogsDocument,
-		baseOptions,
-	)
-}
-export type GetLogsQueryHookResult = ReturnType<typeof useGetLogsQuery>
-export type GetLogsLazyQueryHookResult = ReturnType<typeof useGetLogsLazyQuery>
-export type GetLogsQueryResult = Apollo.QueryResult<
-	Types.GetLogsQuery,
-	Types.GetLogsQueryVariables
->
+export function useGetLogsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsQuery, Types.GetLogsQueryVariables>) {
+        return Apollo.useQuery<Types.GetLogsQuery, Types.GetLogsQueryVariables>(GetLogsDocument, baseOptions);
+      }
+export function useGetLogsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsQuery, Types.GetLogsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetLogsQuery, Types.GetLogsQueryVariables>(GetLogsDocument, baseOptions);
+        }
+export type GetLogsQueryHookResult = ReturnType<typeof useGetLogsQuery>;
+export type GetLogsLazyQueryHookResult = ReturnType<typeof useGetLogsLazyQuery>;
+export type GetLogsQueryResult = Apollo.QueryResult<Types.GetLogsQuery, Types.GetLogsQueryVariables>;
 export const GetSessionLogsDocument = gql`
-	query GetSessionLogs($project_id: ID!, $params: LogsParamsInput!) {
-		sessionLogs(project_id: $project_id, params: $params) {
-			cursor
-			node {
-				timestamp
-				level
-				message
-			}
-		}
-	}
-`
+    query GetSessionLogs($project_id: ID!, $params: LogsParamsInput!) {
+  sessionLogs(project_id: $project_id, params: $params) {
+    cursor
+    node {
+      timestamp
+      level
+      message
+    }
+  }
+}
+    `;
 
 /**
  * __useGetSessionLogsQuery__
@@ -12549,43 +8169,20 @@ export const GetSessionLogsDocument = gql`
  *   },
  * });
  */
-export function useGetSessionLogsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetSessionLogsQuery,
-		Types.GetSessionLogsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetSessionLogsQuery,
-		Types.GetSessionLogsQueryVariables
-	>(GetSessionLogsDocument, baseOptions)
-}
-export function useGetSessionLogsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetSessionLogsQuery,
-		Types.GetSessionLogsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetSessionLogsQuery,
-		Types.GetSessionLogsQueryVariables
-	>(GetSessionLogsDocument, baseOptions)
-}
-export type GetSessionLogsQueryHookResult = ReturnType<
-	typeof useGetSessionLogsQuery
->
-export type GetSessionLogsLazyQueryHookResult = ReturnType<
-	typeof useGetSessionLogsLazyQuery
->
-export type GetSessionLogsQueryResult = Apollo.QueryResult<
-	Types.GetSessionLogsQuery,
-	Types.GetSessionLogsQueryVariables
->
+export function useGetSessionLogsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetSessionLogsQuery, Types.GetSessionLogsQueryVariables>) {
+        return Apollo.useQuery<Types.GetSessionLogsQuery, Types.GetSessionLogsQueryVariables>(GetSessionLogsDocument, baseOptions);
+      }
+export function useGetSessionLogsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetSessionLogsQuery, Types.GetSessionLogsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetSessionLogsQuery, Types.GetSessionLogsQueryVariables>(GetSessionLogsDocument, baseOptions);
+        }
+export type GetSessionLogsQueryHookResult = ReturnType<typeof useGetSessionLogsQuery>;
+export type GetSessionLogsLazyQueryHookResult = ReturnType<typeof useGetSessionLogsLazyQuery>;
+export type GetSessionLogsQueryResult = Apollo.QueryResult<Types.GetSessionLogsQuery, Types.GetSessionLogsQueryVariables>;
 export const GetLogsTotalCountDocument = gql`
-	query GetLogsTotalCount($project_id: ID!, $params: LogsParamsInput!) {
-		logs_total_count(project_id: $project_id, params: $params)
-	}
-`
+    query GetLogsTotalCount($project_id: ID!, $params: LogsParamsInput!) {
+  logs_total_count(project_id: $project_id, params: $params)
+}
+    `;
 
 /**
  * __useGetLogsTotalCountQuery__
@@ -12604,52 +8201,29 @@ export const GetLogsTotalCountDocument = gql`
  *   },
  * });
  */
-export function useGetLogsTotalCountQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetLogsTotalCountQuery,
-		Types.GetLogsTotalCountQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetLogsTotalCountQuery,
-		Types.GetLogsTotalCountQueryVariables
-	>(GetLogsTotalCountDocument, baseOptions)
-}
-export function useGetLogsTotalCountLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetLogsTotalCountQuery,
-		Types.GetLogsTotalCountQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetLogsTotalCountQuery,
-		Types.GetLogsTotalCountQueryVariables
-	>(GetLogsTotalCountDocument, baseOptions)
-}
-export type GetLogsTotalCountQueryHookResult = ReturnType<
-	typeof useGetLogsTotalCountQuery
->
-export type GetLogsTotalCountLazyQueryHookResult = ReturnType<
-	typeof useGetLogsTotalCountLazyQuery
->
-export type GetLogsTotalCountQueryResult = Apollo.QueryResult<
-	Types.GetLogsTotalCountQuery,
-	Types.GetLogsTotalCountQueryVariables
->
+export function useGetLogsTotalCountQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsTotalCountQuery, Types.GetLogsTotalCountQueryVariables>) {
+        return Apollo.useQuery<Types.GetLogsTotalCountQuery, Types.GetLogsTotalCountQueryVariables>(GetLogsTotalCountDocument, baseOptions);
+      }
+export function useGetLogsTotalCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsTotalCountQuery, Types.GetLogsTotalCountQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetLogsTotalCountQuery, Types.GetLogsTotalCountQueryVariables>(GetLogsTotalCountDocument, baseOptions);
+        }
+export type GetLogsTotalCountQueryHookResult = ReturnType<typeof useGetLogsTotalCountQuery>;
+export type GetLogsTotalCountLazyQueryHookResult = ReturnType<typeof useGetLogsTotalCountLazyQuery>;
+export type GetLogsTotalCountQueryResult = Apollo.QueryResult<Types.GetLogsTotalCountQuery, Types.GetLogsTotalCountQueryVariables>;
 export const GetLogsHistogramDocument = gql`
-	query GetLogsHistogram($project_id: ID!, $params: LogsParamsInput!) {
-		logs_histogram(project_id: $project_id, params: $params) {
-			totalCount
-			buckets {
-				bucketId
-				counts {
-					count
-					level
-				}
-			}
-		}
-	}
-`
+    query GetLogsHistogram($project_id: ID!, $params: LogsParamsInput!) {
+  logs_histogram(project_id: $project_id, params: $params) {
+    totalCount
+    buckets {
+      bucketId
+      counts {
+        count
+        level
+      }
+    }
+  }
+}
+    `;
 
 /**
  * __useGetLogsHistogramQuery__
@@ -12668,46 +8242,23 @@ export const GetLogsHistogramDocument = gql`
  *   },
  * });
  */
-export function useGetLogsHistogramQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetLogsHistogramQuery,
-		Types.GetLogsHistogramQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetLogsHistogramQuery,
-		Types.GetLogsHistogramQueryVariables
-	>(GetLogsHistogramDocument, baseOptions)
-}
-export function useGetLogsHistogramLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetLogsHistogramQuery,
-		Types.GetLogsHistogramQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetLogsHistogramQuery,
-		Types.GetLogsHistogramQueryVariables
-	>(GetLogsHistogramDocument, baseOptions)
-}
-export type GetLogsHistogramQueryHookResult = ReturnType<
-	typeof useGetLogsHistogramQuery
->
-export type GetLogsHistogramLazyQueryHookResult = ReturnType<
-	typeof useGetLogsHistogramLazyQuery
->
-export type GetLogsHistogramQueryResult = Apollo.QueryResult<
-	Types.GetLogsHistogramQuery,
-	Types.GetLogsHistogramQueryVariables
->
+export function useGetLogsHistogramQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsHistogramQuery, Types.GetLogsHistogramQueryVariables>) {
+        return Apollo.useQuery<Types.GetLogsHistogramQuery, Types.GetLogsHistogramQueryVariables>(GetLogsHistogramDocument, baseOptions);
+      }
+export function useGetLogsHistogramLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsHistogramQuery, Types.GetLogsHistogramQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetLogsHistogramQuery, Types.GetLogsHistogramQueryVariables>(GetLogsHistogramDocument, baseOptions);
+        }
+export type GetLogsHistogramQueryHookResult = ReturnType<typeof useGetLogsHistogramQuery>;
+export type GetLogsHistogramLazyQueryHookResult = ReturnType<typeof useGetLogsHistogramLazyQuery>;
+export type GetLogsHistogramQueryResult = Apollo.QueryResult<Types.GetLogsHistogramQuery, Types.GetLogsHistogramQueryVariables>;
 export const GetLogsKeysDocument = gql`
-	query GetLogsKeys($project_id: ID!, $date_range: DateRangeRequiredInput!) {
-		logs_keys(project_id: $project_id, date_range: $date_range) {
-			name
-			type
-		}
-	}
-`
+    query GetLogsKeys($project_id: ID!, $date_range: DateRangeRequiredInput!) {
+  logs_keys(project_id: $project_id, date_range: $date_range) {
+    name
+    type
+  }
+}
+    `;
 
 /**
  * __useGetLogsKeysQuery__
@@ -12726,49 +8277,24 @@ export const GetLogsKeysDocument = gql`
  *   },
  * });
  */
-export function useGetLogsKeysQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetLogsKeysQuery,
-		Types.GetLogsKeysQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetLogsKeysQuery,
-		Types.GetLogsKeysQueryVariables
-	>(GetLogsKeysDocument, baseOptions)
-}
-export function useGetLogsKeysLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetLogsKeysQuery,
-		Types.GetLogsKeysQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetLogsKeysQuery,
-		Types.GetLogsKeysQueryVariables
-	>(GetLogsKeysDocument, baseOptions)
-}
-export type GetLogsKeysQueryHookResult = ReturnType<typeof useGetLogsKeysQuery>
-export type GetLogsKeysLazyQueryHookResult = ReturnType<
-	typeof useGetLogsKeysLazyQuery
->
-export type GetLogsKeysQueryResult = Apollo.QueryResult<
-	Types.GetLogsKeysQuery,
-	Types.GetLogsKeysQueryVariables
->
+export function useGetLogsKeysQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsKeysQuery, Types.GetLogsKeysQueryVariables>) {
+        return Apollo.useQuery<Types.GetLogsKeysQuery, Types.GetLogsKeysQueryVariables>(GetLogsKeysDocument, baseOptions);
+      }
+export function useGetLogsKeysLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsKeysQuery, Types.GetLogsKeysQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetLogsKeysQuery, Types.GetLogsKeysQueryVariables>(GetLogsKeysDocument, baseOptions);
+        }
+export type GetLogsKeysQueryHookResult = ReturnType<typeof useGetLogsKeysQuery>;
+export type GetLogsKeysLazyQueryHookResult = ReturnType<typeof useGetLogsKeysLazyQuery>;
+export type GetLogsKeysQueryResult = Apollo.QueryResult<Types.GetLogsKeysQuery, Types.GetLogsKeysQueryVariables>;
 export const GetLogsKeyValuesDocument = gql`
-	query GetLogsKeyValues(
-		$project_id: ID!
-		$key_name: String!
-		$date_range: DateRangeRequiredInput!
-	) {
-		logs_key_values(
-			project_id: $project_id
-			key_name: $key_name
-			date_range: $date_range
-		)
-	}
-`
+    query GetLogsKeyValues($project_id: ID!, $key_name: String!, $date_range: DateRangeRequiredInput!) {
+  logs_key_values(
+    project_id: $project_id
+    key_name: $key_name
+    date_range: $date_range
+  )
+}
+    `;
 
 /**
  * __useGetLogsKeyValuesQuery__
@@ -12788,47 +8314,24 @@ export const GetLogsKeyValuesDocument = gql`
  *   },
  * });
  */
-export function useGetLogsKeyValuesQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetLogsKeyValuesQuery,
-		Types.GetLogsKeyValuesQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetLogsKeyValuesQuery,
-		Types.GetLogsKeyValuesQueryVariables
-	>(GetLogsKeyValuesDocument, baseOptions)
-}
-export function useGetLogsKeyValuesLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetLogsKeyValuesQuery,
-		Types.GetLogsKeyValuesQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetLogsKeyValuesQuery,
-		Types.GetLogsKeyValuesQueryVariables
-	>(GetLogsKeyValuesDocument, baseOptions)
-}
-export type GetLogsKeyValuesQueryHookResult = ReturnType<
-	typeof useGetLogsKeyValuesQuery
->
-export type GetLogsKeyValuesLazyQueryHookResult = ReturnType<
-	typeof useGetLogsKeyValuesLazyQuery
->
-export type GetLogsKeyValuesQueryResult = Apollo.QueryResult<
-	Types.GetLogsKeyValuesQuery,
-	Types.GetLogsKeyValuesQueryVariables
->
+export function useGetLogsKeyValuesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsKeyValuesQuery, Types.GetLogsKeyValuesQueryVariables>) {
+        return Apollo.useQuery<Types.GetLogsKeyValuesQuery, Types.GetLogsKeyValuesQueryVariables>(GetLogsKeyValuesDocument, baseOptions);
+      }
+export function useGetLogsKeyValuesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsKeyValuesQuery, Types.GetLogsKeyValuesQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetLogsKeyValuesQuery, Types.GetLogsKeyValuesQueryVariables>(GetLogsKeyValuesDocument, baseOptions);
+        }
+export type GetLogsKeyValuesQueryHookResult = ReturnType<typeof useGetLogsKeyValuesQuery>;
+export type GetLogsKeyValuesLazyQueryHookResult = ReturnType<typeof useGetLogsKeyValuesLazyQuery>;
+export type GetLogsKeyValuesQueryResult = Apollo.QueryResult<Types.GetLogsKeyValuesQuery, Types.GetLogsKeyValuesQueryVariables>;
 export const GetLogsErrorObjectsDocument = gql`
-	query GetLogsErrorObjects($log_cursors: [String!]!) {
-		logs_error_objects(log_cursors: $log_cursors) {
-			log_cursor
-			error_group_secure_id
-			id
-		}
-	}
-`
+    query GetLogsErrorObjects($log_cursors: [String!]!) {
+  logs_error_objects(log_cursors: $log_cursors) {
+    log_cursor
+    error_group_secure_id
+    id
+  }
+}
+    `;
 
 /**
  * __useGetLogsErrorObjectsQuery__
@@ -12846,58 +8349,35 @@ export const GetLogsErrorObjectsDocument = gql`
  *   },
  * });
  */
-export function useGetLogsErrorObjectsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetLogsErrorObjectsQuery,
-		Types.GetLogsErrorObjectsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetLogsErrorObjectsQuery,
-		Types.GetLogsErrorObjectsQueryVariables
-	>(GetLogsErrorObjectsDocument, baseOptions)
-}
-export function useGetLogsErrorObjectsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetLogsErrorObjectsQuery,
-		Types.GetLogsErrorObjectsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetLogsErrorObjectsQuery,
-		Types.GetLogsErrorObjectsQueryVariables
-	>(GetLogsErrorObjectsDocument, baseOptions)
-}
-export type GetLogsErrorObjectsQueryHookResult = ReturnType<
-	typeof useGetLogsErrorObjectsQuery
->
-export type GetLogsErrorObjectsLazyQueryHookResult = ReturnType<
-	typeof useGetLogsErrorObjectsLazyQuery
->
-export type GetLogsErrorObjectsQueryResult = Apollo.QueryResult<
-	Types.GetLogsErrorObjectsQuery,
-	Types.GetLogsErrorObjectsQueryVariables
->
+export function useGetLogsErrorObjectsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetLogsErrorObjectsQuery, Types.GetLogsErrorObjectsQueryVariables>) {
+        return Apollo.useQuery<Types.GetLogsErrorObjectsQuery, Types.GetLogsErrorObjectsQueryVariables>(GetLogsErrorObjectsDocument, baseOptions);
+      }
+export function useGetLogsErrorObjectsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetLogsErrorObjectsQuery, Types.GetLogsErrorObjectsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetLogsErrorObjectsQuery, Types.GetLogsErrorObjectsQueryVariables>(GetLogsErrorObjectsDocument, baseOptions);
+        }
+export type GetLogsErrorObjectsQueryHookResult = ReturnType<typeof useGetLogsErrorObjectsQuery>;
+export type GetLogsErrorObjectsLazyQueryHookResult = ReturnType<typeof useGetLogsErrorObjectsLazyQuery>;
+export type GetLogsErrorObjectsQueryResult = Apollo.QueryResult<Types.GetLogsErrorObjectsQuery, Types.GetLogsErrorObjectsQueryVariables>;
 export const GetProjectSettingsDocument = gql`
-	query GetProjectSettings($projectId: ID!) {
-		projectSettings(projectId: $projectId) {
-			id
-			name
-			verbose_id
-			billing_email
-			excluded_users
-			error_filters
-			error_json_paths
-			filter_chrome_extension
-			rage_click_window_seconds
-			rage_click_radius_pixels
-			rage_click_count
-			backend_domains
-			filterSessionsWithoutError
-			autoResolveStaleErrorsDayInterval
-		}
-	}
-`
+    query GetProjectSettings($projectId: ID!) {
+  projectSettings(projectId: $projectId) {
+    id
+    name
+    verbose_id
+    billing_email
+    excluded_users
+    error_filters
+    error_json_paths
+    filter_chrome_extension
+    rage_click_window_seconds
+    rage_click_radius_pixels
+    rage_click_count
+    backend_domains
+    filterSessionsWithoutError
+    autoResolveStaleErrorsDayInterval
+  }
+}
+    `;
 
 /**
  * __useGetProjectSettingsQuery__
@@ -12915,48 +8395,25 @@ export const GetProjectSettingsDocument = gql`
  *   },
  * });
  */
-export function useGetProjectSettingsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetProjectSettingsQuery,
-		Types.GetProjectSettingsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetProjectSettingsQuery,
-		Types.GetProjectSettingsQueryVariables
-	>(GetProjectSettingsDocument, baseOptions)
-}
-export function useGetProjectSettingsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetProjectSettingsQuery,
-		Types.GetProjectSettingsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetProjectSettingsQuery,
-		Types.GetProjectSettingsQueryVariables
-	>(GetProjectSettingsDocument, baseOptions)
-}
-export type GetProjectSettingsQueryHookResult = ReturnType<
-	typeof useGetProjectSettingsQuery
->
-export type GetProjectSettingsLazyQueryHookResult = ReturnType<
-	typeof useGetProjectSettingsLazyQuery
->
-export type GetProjectSettingsQueryResult = Apollo.QueryResult<
-	Types.GetProjectSettingsQuery,
-	Types.GetProjectSettingsQueryVariables
->
+export function useGetProjectSettingsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetProjectSettingsQuery, Types.GetProjectSettingsQueryVariables>) {
+        return Apollo.useQuery<Types.GetProjectSettingsQuery, Types.GetProjectSettingsQueryVariables>(GetProjectSettingsDocument, baseOptions);
+      }
+export function useGetProjectSettingsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetProjectSettingsQuery, Types.GetProjectSettingsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetProjectSettingsQuery, Types.GetProjectSettingsQueryVariables>(GetProjectSettingsDocument, baseOptions);
+        }
+export type GetProjectSettingsQueryHookResult = ReturnType<typeof useGetProjectSettingsQuery>;
+export type GetProjectSettingsLazyQueryHookResult = ReturnType<typeof useGetProjectSettingsLazyQuery>;
+export type GetProjectSettingsQueryResult = Apollo.QueryResult<Types.GetProjectSettingsQuery, Types.GetProjectSettingsQueryVariables>;
 export const GetWorkspacePendingInvitesDocument = gql`
-	query GetWorkspacePendingInvites($workspace_id: ID!) {
-		workspacePendingInvites(workspace_id: $workspace_id) {
-			id
-			invitee_email
-			invitee_role
-			created_at
-		}
-	}
-`
+    query GetWorkspacePendingInvites($workspace_id: ID!) {
+  workspacePendingInvites(workspace_id: $workspace_id) {
+    id
+    invitee_email
+    invitee_role
+    created_at
+  }
+}
+    `;
 
 /**
  * __useGetWorkspacePendingInvitesQuery__
@@ -12974,46 +8431,23 @@ export const GetWorkspacePendingInvitesDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspacePendingInvitesQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspacePendingInvitesQuery,
-		Types.GetWorkspacePendingInvitesQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspacePendingInvitesQuery,
-		Types.GetWorkspacePendingInvitesQueryVariables
-	>(GetWorkspacePendingInvitesDocument, baseOptions)
-}
-export function useGetWorkspacePendingInvitesLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspacePendingInvitesQuery,
-		Types.GetWorkspacePendingInvitesQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspacePendingInvitesQuery,
-		Types.GetWorkspacePendingInvitesQueryVariables
-	>(GetWorkspacePendingInvitesDocument, baseOptions)
-}
-export type GetWorkspacePendingInvitesQueryHookResult = ReturnType<
-	typeof useGetWorkspacePendingInvitesQuery
->
-export type GetWorkspacePendingInvitesLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspacePendingInvitesLazyQuery
->
-export type GetWorkspacePendingInvitesQueryResult = Apollo.QueryResult<
-	Types.GetWorkspacePendingInvitesQuery,
-	Types.GetWorkspacePendingInvitesQueryVariables
->
+export function useGetWorkspacePendingInvitesQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspacePendingInvitesQuery, Types.GetWorkspacePendingInvitesQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspacePendingInvitesQuery, Types.GetWorkspacePendingInvitesQueryVariables>(GetWorkspacePendingInvitesDocument, baseOptions);
+      }
+export function useGetWorkspacePendingInvitesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspacePendingInvitesQuery, Types.GetWorkspacePendingInvitesQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspacePendingInvitesQuery, Types.GetWorkspacePendingInvitesQueryVariables>(GetWorkspacePendingInvitesDocument, baseOptions);
+        }
+export type GetWorkspacePendingInvitesQueryHookResult = ReturnType<typeof useGetWorkspacePendingInvitesQuery>;
+export type GetWorkspacePendingInvitesLazyQueryHookResult = ReturnType<typeof useGetWorkspacePendingInvitesLazyQuery>;
+export type GetWorkspacePendingInvitesQueryResult = Apollo.QueryResult<Types.GetWorkspacePendingInvitesQuery, Types.GetWorkspacePendingInvitesQueryVariables>;
 export const GetWorkspaceSettingsDocument = gql`
-	query GetWorkspaceSettings($workspace_id: ID!) {
-		workspaceSettings(workspace_id: $workspace_id) {
-			workspace_id
-			ai_insights
-		}
-	}
-`
+    query GetWorkspaceSettings($workspace_id: ID!) {
+  workspaceSettings(workspace_id: $workspace_id) {
+    workspace_id
+    ai_insights
+  }
+}
+    `;
 
 /**
  * __useGetWorkspaceSettingsQuery__
@@ -13031,35 +8465,70 @@ export const GetWorkspaceSettingsDocument = gql`
  *   },
  * });
  */
-export function useGetWorkspaceSettingsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetWorkspaceSettingsQuery,
-		Types.GetWorkspaceSettingsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetWorkspaceSettingsQuery,
-		Types.GetWorkspaceSettingsQueryVariables
-	>(GetWorkspaceSettingsDocument, baseOptions)
+export function useGetWorkspaceSettingsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetWorkspaceSettingsQuery, Types.GetWorkspaceSettingsQueryVariables>) {
+        return Apollo.useQuery<Types.GetWorkspaceSettingsQuery, Types.GetWorkspaceSettingsQueryVariables>(GetWorkspaceSettingsDocument, baseOptions);
+      }
+export function useGetWorkspaceSettingsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetWorkspaceSettingsQuery, Types.GetWorkspaceSettingsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetWorkspaceSettingsQuery, Types.GetWorkspaceSettingsQueryVariables>(GetWorkspaceSettingsDocument, baseOptions);
+        }
+export type GetWorkspaceSettingsQueryHookResult = ReturnType<typeof useGetWorkspaceSettingsQuery>;
+export type GetWorkspaceSettingsLazyQueryHookResult = ReturnType<typeof useGetWorkspaceSettingsLazyQuery>;
+export type GetWorkspaceSettingsQueryResult = Apollo.QueryResult<Types.GetWorkspaceSettingsQuery, Types.GetWorkspaceSettingsQueryVariables>;
+export const GetErrorObjectsDocument = gql`
+    query GetErrorObjects($errorGroupSecureID: String!, $after: String, $before: String) {
+  error_objects(
+    error_group_secure_id: $errorGroupSecureID
+    after: $after
+    before: $before
+  ) {
+    edges {
+      cursor
+      node {
+        id
+        createdAt
+        event
+        errorGroupSecureID
+        session {
+          secureID
+          userProperties
+          appVersion
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+  }
 }
-export function useGetWorkspaceSettingsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetWorkspaceSettingsQuery,
-		Types.GetWorkspaceSettingsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetWorkspaceSettingsQuery,
-		Types.GetWorkspaceSettingsQueryVariables
-	>(GetWorkspaceSettingsDocument, baseOptions)
-}
-export type GetWorkspaceSettingsQueryHookResult = ReturnType<
-	typeof useGetWorkspaceSettingsQuery
->
-export type GetWorkspaceSettingsLazyQueryHookResult = ReturnType<
-	typeof useGetWorkspaceSettingsLazyQuery
->
-export type GetWorkspaceSettingsQueryResult = Apollo.QueryResult<
-	Types.GetWorkspaceSettingsQuery,
-	Types.GetWorkspaceSettingsQueryVariables
->
+    `;
+
+/**
+ * __useGetErrorObjectsQuery__
+ *
+ * To run a query within a React component, call `useGetErrorObjectsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetErrorObjectsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetErrorObjectsQuery({
+ *   variables: {
+ *      errorGroupSecureID: // value for 'errorGroupSecureID'
+ *      after: // value for 'after'
+ *      before: // value for 'before'
+ *   },
+ * });
+ */
+export function useGetErrorObjectsQuery(baseOptions: Apollo.QueryHookOptions<Types.GetErrorObjectsQuery, Types.GetErrorObjectsQueryVariables>) {
+        return Apollo.useQuery<Types.GetErrorObjectsQuery, Types.GetErrorObjectsQueryVariables>(GetErrorObjectsDocument, baseOptions);
+      }
+export function useGetErrorObjectsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Types.GetErrorObjectsQuery, Types.GetErrorObjectsQueryVariables>) {
+          return Apollo.useLazyQuery<Types.GetErrorObjectsQuery, Types.GetErrorObjectsQueryVariables>(GetErrorObjectsDocument, baseOptions);
+        }
+export type GetErrorObjectsQueryHookResult = ReturnType<typeof useGetErrorObjectsQuery>;
+export type GetErrorObjectsLazyQueryHookResult = ReturnType<typeof useGetErrorObjectsLazyQuery>;
+export type GetErrorObjectsQueryResult = Apollo.QueryResult<Types.GetErrorObjectsQuery, Types.GetErrorObjectsQueryVariables>;

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4401,6 +4401,41 @@ export type GetWorkspaceSettingsQuery = { __typename?: 'Query' } & {
 	>
 }
 
+export type GetErrorObjectsQueryVariables = Types.Exact<{
+	errorGroupSecureID: Types.Scalars['String']
+	after?: Types.Maybe<Types.Scalars['String']>
+	before?: Types.Maybe<Types.Scalars['String']>
+}>
+
+export type GetErrorObjectsQuery = { __typename?: 'Query' } & {
+	error_objects: { __typename?: 'ErrorObjectConnection' } & {
+		edges: Array<
+			{ __typename?: 'ErrorObjectEdge' } & Pick<
+				Types.ErrorObjectEdge,
+				'cursor'
+			> & {
+					node: { __typename?: 'ErrorObjectNode' } & Pick<
+						Types.ErrorObjectNode,
+						'id' | 'createdAt' | 'event' | 'errorGroupSecureID'
+					> & {
+							session?: Types.Maybe<
+								{
+									__typename?: 'ErrorObjectNodeSession'
+								} & Pick<
+									Types.ErrorObjectNodeSession,
+									'secureID' | 'userProperties' | 'appVersion'
+								>
+							>
+						}
+				}
+		>
+		pageInfo: { __typename?: 'PageInfo' } & Pick<
+			Types.PageInfo,
+			'hasNextPage' | 'hasPreviousPage' | 'startCursor' | 'endCursor'
+		>
+	}
+}
+
 export const namedOperations = {
 	Query: {
 		GetMetricsTimeline: 'GetMetricsTimeline' as const,
@@ -4532,6 +4567,7 @@ export const namedOperations = {
 		GetProjectSettings: 'GetProjectSettings' as const,
 		GetWorkspacePendingInvites: 'GetWorkspacePendingInvites' as const,
 		GetWorkspaceSettings: 'GetWorkspaceSettings' as const,
+		GetErrorObjects: 'GetErrorObjects' as const,
 	},
 	Mutation: {
 		MarkErrorGroupAsViewed: 'MarkErrorGroupAsViewed' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -533,6 +533,7 @@ export type ErrorObjectEdge = Edge & {
 export type ErrorObjectNode = {
 	__typename?: 'ErrorObjectNode'
 	createdAt: Scalars['Timestamp']
+	errorGroupSecureID: Scalars['String']
 	event: Scalars['String']
 	id: Scalars['ID']
 	session?: Maybe<ErrorObjectNodeSession>

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2112,3 +2112,36 @@ query GetWorkspaceSettings($workspace_id: ID!) {
 		ai_insights
 	}
 }
+
+query GetErrorObjects(
+	$errorGroupSecureID: String!
+	$after: String
+	$before: String
+) {
+	error_objects(
+		error_group_secure_id: $errorGroupSecureID
+		after: $after
+		before: $before
+	) {
+		edges {
+			cursor
+			node {
+				id
+				createdAt
+				event
+				errorGroupSecureID
+				session {
+					secureID
+					userProperties
+					appVersion
+				}
+			}
+		}
+		pageInfo {
+			hasNextPage
+			hasPreviousPage
+			startCursor
+			endCursor
+		}
+	}
+}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR attaches the error group secure id when fetching a list of error objects. This is useful at the time we render the error instances table (not available yet) when linking out:

https://github.com/highlight/highlight/blob/b35d9614871ed9a498eba365e71ebad0e98ab05e/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx#L80-L84

and not having to deal with conditional logic. 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Unit tests

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A