### PR TITLE
fix OpenSearch indexing when appending both new and old fields in same request

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -228,7 +228,7 @@ func (r *Resolver) AppendFields(ctx context.Context, fields []*model.Field, sess
 	defer outerSpan.Finish()
 
 	result := r.DB.
-		Clauses(clause.Returning{}, clause.OnConflict{
+		Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "project_id"}, {Name: "type"}, {Name: "name"}, {Name: "value"}},
 			DoNothing: true}).
 		Create(&fields)

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -227,18 +227,30 @@ func (r *Resolver) AppendFields(ctx context.Context, fields []*model.Field, sess
 		tracer.ResourceName("go.sessions.AppendProperties"), tracer.Tag("sessionID", session.ID))
 	defer outerSpan.Finish()
 
-	if err := r.DB.
+	result := r.DB.
 		Clauses(clause.Returning{}, clause.OnConflict{
 			Columns:   []clause.Column{{Name: "project_id"}, {Name: "type"}, {Name: "name"}, {Name: "value"}},
 			DoNothing: true}).
-		Create(&fields).Error; err != nil {
+		Create(&fields)
+
+	if err := result.Error; err != nil {
 		return e.Wrap(err, "error inserting new fields")
 	}
 
-	// New fields have an ID after the insert above
-	newFields := lo.Filter(fields, func(field *model.Field, _ int) bool {
-		return field.ID != 0
-	})
+	updateCount := result.RowsAffected
+
+	var allFields []*model.Field
+	inClause := [][]interface{}{}
+	for _, f := range fields {
+		inClause = append(inClause, []interface{}{f.ProjectID, f.Type, f.Name, f.Value})
+	}
+	if err := r.DB.Where("(project_id, type, name, value) IN ?", inClause).Order("id DESC").
+		Find(&allFields).Error; err != nil {
+		return e.Wrap(err, "error retrieving all fields")
+	}
+
+	// the first N fields ordered by id DESC were added in the prior insert
+	newFields := allFields[:updateCount]
 
 	for _, field := range newFields {
 		if err := r.OpenSearch.IndexSynchronous(ctx,
@@ -249,16 +261,6 @@ func (r *Resolver) AppendFields(ctx context.Context, fields []*model.Field, sess
 			}); err != nil {
 			return e.Wrap(err, "error indexing new field")
 		}
-	}
-
-	var allFields []*model.Field
-	inClause := [][]interface{}{}
-	for _, f := range fields {
-		inClause = append(inClause, []interface{}{f.ProjectID, f.Type, f.Name, f.Value})
-	}
-	if err := r.DB.Where("(project_id, type, name, value) IN ?", inClause).
-		Find(&allFields).Error; err != nil {
-		return e.Wrap(err, "error retrieving all fields")
 	}
 
 	openSearchFields := make([]interface{}, len(allFields))


### PR DESCRIPTION
## Summary
- a gorm `Create` with a `Returning` clause was not associating the returned ids with the correct records. e.g. if we attempted to create 10 records but only 5 were inserted, the new ids would be set on the first 5 records regardless of which ones were actually inserted
- instead of relying on the `Returning` clause, get the count of rows updated and sort the results of the second query by id to get the latest N rows
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- set a watchpoint and confirmed via debugging
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will use the `init-opensearch` Make command to reindex the OpenSearch fields index
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
