### PR TITLE
Retry session insight lambda request on 500 errors

### DIFF
--- a/frontend/src/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.tsx
@@ -64,63 +64,62 @@ const SessionInsights = () => {
 						flexDirection="column"
 						position="relative"
 					>
-						{[
-							...JSON.parse(insightData),
-							...JSON.parse(insightData),
-						].map((insight: SessionInsight, idx: number) => {
-							const timeSinceStart =
-								new Date(insight.timestamp).getTime() -
-								startTime
-							return (
-								<Box cursor="pointer" key={idx}>
-									<Box
-										className={style.insight}
-										onClick={() => {
-											setTime(timeSinceStart)
-										}}
-									>
-										<Box display="flex" gap="4">
-											<Badge
-												size="small"
-												variant="purple"
-												label={String(idx + 1)}
-											/>
-											<Tag
-												kind="secondary"
-												size="small"
-												shape="basic"
-												emphasis="low"
-												iconRight={
-													<IconSolidArrowCircleRight />
-												}
-											>
-												{showPlayerAbsoluteTime
-													? playerTimeToSessionAbsoluteTime(
-															{
-																sessionStartTime:
-																	startTime,
-																relativeTime:
-																	timeSinceStart,
-															},
-													  )
-													: MillisToMinutesAndSeconds(
-															timeSinceStart,
-													  )}
-											</Tag>
-										</Box>
-										<Box overflowWrap="breakWord">
-											<Text
-												size="small"
-												weight="medium"
-												color="strong"
-											>
-												{insight.insight}
-											</Text>
+						{[...JSON.parse(insightData)].map(
+							(insight: SessionInsight, idx: number) => {
+								const timeSinceStart =
+									new Date(insight.timestamp).getTime() -
+									startTime
+								return (
+									<Box cursor="pointer" key={idx}>
+										<Box
+											className={style.insight}
+											onClick={() => {
+												setTime(timeSinceStart)
+											}}
+										>
+											<Box display="flex" gap="4">
+												<Badge
+													size="small"
+													variant="purple"
+													label={String(idx + 1)}
+												/>
+												<Tag
+													kind="secondary"
+													size="small"
+													shape="basic"
+													emphasis="low"
+													iconRight={
+														<IconSolidArrowCircleRight />
+													}
+												>
+													{showPlayerAbsoluteTime
+														? playerTimeToSessionAbsoluteTime(
+																{
+																	sessionStartTime:
+																		startTime,
+																	relativeTime:
+																		timeSinceStart,
+																},
+														  )
+														: MillisToMinutesAndSeconds(
+																timeSinceStart,
+														  )}
+												</Tag>
+											</Box>
+											<Box overflowWrap="breakWord">
+												<Text
+													size="small"
+													weight="medium"
+													color="strong"
+												>
+													{insight.insight}
+												</Text>
+											</Box>
 										</Box>
 									</Box>
-								</Box>
-							)
-						})}
+								)
+							},
+						)}
 					</Box>
 				</Box>
 			) : (


### PR DESCRIPTION
## Summary
https://github.com/highlight/highlight/issues/5775

The lambda often returns 500 and 503s, not sure if it's something to do with OpenAI's API being unreliable/inconsistent or the API Gateway timing out. Either way, the backend will now retry up to 5 times on error

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
