### PR TITLE
error instances table

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -425,6 +425,7 @@ type ComplexityRoot struct {
 		Event              func(childComplexity int) int
 		ID                 func(childComplexity int) int
 		Session            func(childComplexity int) int
+		Timestamp          func(childComplexity int) int
 	}
 
 	ErrorObjectNodeSession struct {
@@ -3322,6 +3323,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ErrorObjectNode.Session(childComplexity), true
+
+	case "ErrorObjectNode.timestamp":
+		if e.complexity.ErrorObjectNode.Timestamp == nil {
+			break
+		}
+
+		return e.complexity.ErrorObjectNode.Timestamp(childComplexity), true
 
 	case "ErrorObjectNodeSession.appVersion":
 		if e.complexity.ErrorObjectNodeSession.AppVersion == nil {
@@ -9338,6 +9346,7 @@ type ErrorObjectNode {
 	id: ID!
 	createdAt: Timestamp!
 	event: String!
+	timestamp: Timestamp!
 	session: ErrorObjectNodeSession
 	errorGroupSecureID: String!
 }
@@ -27375,6 +27384,8 @@ func (ec *executionContext) fieldContext_ErrorObjectEdge_node(ctx context.Contex
 				return ec.fieldContext_ErrorObjectNode_createdAt(ctx, field)
 			case "event":
 				return ec.fieldContext_ErrorObjectNode_event(ctx, field)
+			case "timestamp":
+				return ec.fieldContext_ErrorObjectNode_timestamp(ctx, field)
 			case "session":
 				return ec.fieldContext_ErrorObjectNode_session(ctx, field)
 			case "errorGroupSecureID":
@@ -27513,6 +27524,50 @@ func (ec *executionContext) fieldContext_ErrorObjectNode_event(ctx context.Conte
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ErrorObjectNode_timestamp(ctx context.Context, field graphql.CollectedField, obj *model.ErrorObjectNode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ErrorObjectNode_timestamp(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Timestamp, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTimestamp2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ErrorObjectNode_timestamp(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ErrorObjectNode",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Timestamp does not have child fields")
 		},
 	}
 	return fc, nil
@@ -65789,6 +65844,13 @@ func (ec *executionContext) _ErrorObjectNode(ctx context.Context, sel ast.Select
 		case "event":
 
 			out.Values[i] = ec._ErrorObjectNode_event(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "timestamp":
+
+			out.Values[i] = ec._ErrorObjectNode_timestamp(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -319,6 +319,7 @@ type ErrorObjectNode struct {
 	ID                 int                     `json:"id"`
 	CreatedAt          time.Time               `json:"createdAt"`
 	Event              string                  `json:"event"`
+	Timestamp          time.Time               `json:"timestamp"`
 	Session            *ErrorObjectNodeSession `json:"session"`
 	ErrorGroupSecureID string                  `json:"errorGroupSecureID"`
 }

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -619,6 +619,7 @@ type ErrorObjectNode {
 	id: ID!
 	createdAt: Timestamp!
 	event: String!
+	timestamp: Timestamp!
 	session: ErrorObjectNodeSession
 	errorGroupSecureID: String!
 }

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -67,7 +67,10 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 	}
 
 	if len(errorObjects) == 0 {
-		return privateModel.ErrorObjectConnection{}, nil
+		return privateModel.ErrorObjectConnection{
+			Edges:    []*privateModel.ErrorObjectEdge{},
+			PageInfo: &privateModel.PageInfo{},
+		}, nil
 	}
 
 	// Extract the non-null session IDs

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -48,15 +48,18 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 	)
 
 	if params.After != nil {
-		query = query.Order("id DESC").Where("id < ?", *params.After)
+		query = query.Order("error_objects.id DESC").Where("error_objects.id < ?", *params.After)
 	} else if params.Before != nil {
-		query = query.Order("id ASC").Where("id > ?", *params.Before)
+		query = query.Order("error_objects.id ASC").Where("error_objects.id > ?", *params.Before)
 	} else {
-		query = query.Order("id DESC")
+		query = query.Order("error_objects.id DESC")
 	}
 
 	if err := query.Find(&errorObjects).Error; err != nil {
-		return privateModel.ErrorObjectConnection{}, err
+		return privateModel.ErrorObjectConnection{
+			Edges:    []*privateModel.ErrorObjectEdge{},
+			PageInfo: &privateModel.PageInfo{},
+		}, err
 	}
 
 	if params.Before != nil {

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -103,6 +103,7 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 				ID:                 errorObject.ID,
 				CreatedAt:          errorObject.CreatedAt,
 				Event:              errorObject.Event,
+				Timestamp:          errorObject.Timestamp,
 				ErrorGroupSecureID: errorGroup.SecureID,
 			},
 		}

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -57,6 +57,7 @@ func TestListErrorObjectsOneObjectNoSession(t *testing.T) {
 		assert.Equal(t, errorObject.ID, edge.Node.ID)
 		assert.WithinDuration(t, errorObject.CreatedAt, edge.Node.CreatedAt, 10*time.Second)
 		assert.Equal(t, errorObject.Event, edge.Node.Event)
+		assert.WithinDuration(t, errorObject.Timestamp, edge.Node.Timestamp, 10*time.Second)
 		assert.Equal(t, errorGroup.SecureID, edge.Node.ErrorGroupSecureID)
 		assert.Nil(t, edge.Node.Session)
 

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -26,7 +26,10 @@ func TestListErrorObjectsNoData(t *testing.T) {
 		connection, err := store.ListErrorObjects(errorGroup, ListErrorObjectsParams{})
 		assert.NoError(t, err)
 
-		assert.Equal(t, privateModel.ErrorObjectConnection{}, connection)
+		assert.Equal(t, privateModel.ErrorObjectConnection{
+			Edges:    []*privateModel.ErrorObjectEdge{},
+			PageInfo: &privateModel.PageInfo{},
+		}, connection)
 	})
 }
 

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5863,6 +5863,11 @@ body {
 ._1vb6x0p0:hover {
   color: var(--_1pyqka9y);
 }
+._6soxly0 {
+  position: absolute;
+  top: 12px;
+  left: 7px;
+}
 ._1g045pm0 {
   color: var(--_1pyqka9b) !important;
 }

--- a/frontend/src/__generated/ve/pages/ErrorsV2/ErrorInstances/ErrorInstances.css.js
+++ b/frontend/src/__generated/ve/pages/ErrorsV2/ErrorInstances/ErrorInstances.css.js
@@ -1,0 +1,1 @@
+var o="_6soxly0";export{o as searchIcon};

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -13053,11 +13053,13 @@ export const GetErrorObjectsDocument = gql`
 		$errorGroupSecureID: String!
 		$after: String
 		$before: String
+		$query: String!
 	) {
 		error_objects(
 			error_group_secure_id: $errorGroupSecureID
 			after: $after
 			before: $before
+			query: $query
 		) {
 			edges {
 				cursor
@@ -13068,7 +13070,7 @@ export const GetErrorObjectsDocument = gql`
 					errorGroupSecureID
 					session {
 						secureID
-						userProperties
+						email
 						appVersion
 					}
 				}
@@ -13098,6 +13100,7 @@ export const GetErrorObjectsDocument = gql`
  *      errorGroupSecureID: // value for 'errorGroupSecureID'
  *      after: // value for 'after'
  *      before: // value for 'before'
+ *      query: // value for 'query'
  *   },
  * });
  */

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -13067,6 +13067,7 @@ export const GetErrorObjectsDocument = gql`
 					id
 					createdAt
 					event
+					timestamp
 					errorGroupSecureID
 					session {
 						secureID

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4385,6 +4385,7 @@ export type GetErrorObjectsQueryVariables = Types.Exact<{
 	errorGroupSecureID: Types.Scalars['String']
 	after?: Types.Maybe<Types.Scalars['String']>
 	before?: Types.Maybe<Types.Scalars['String']>
+	query: Types.Scalars['String']
 }>
 
 export type GetErrorObjectsQuery = { __typename?: 'Query' } & {
@@ -4403,7 +4404,7 @@ export type GetErrorObjectsQuery = { __typename?: 'Query' } & {
 									__typename?: 'ErrorObjectNodeSession'
 								} & Pick<
 									Types.ErrorObjectNodeSession,
-									'secureID' | 'userProperties' | 'appVersion'
+									'secureID' | 'email' | 'appVersion'
 								>
 							>
 						}

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4397,7 +4397,11 @@ export type GetErrorObjectsQuery = { __typename?: 'Query' } & {
 			> & {
 					node: { __typename?: 'ErrorObjectNode' } & Pick<
 						Types.ErrorObjectNode,
-						'id' | 'createdAt' | 'event' | 'errorGroupSecureID'
+						| 'id'
+						| 'createdAt'
+						| 'event'
+						| 'timestamp'
+						| 'errorGroupSecureID'
 					> & {
 							session?: Types.Maybe<
 								{

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -537,6 +537,7 @@ export type ErrorObjectNode = {
 	event: Scalars['String']
 	id: Scalars['ID']
 	session?: Maybe<ErrorObjectNodeSession>
+	timestamp: Scalars['Timestamp']
 }
 
 export type ErrorObjectNodeSession = {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -542,8 +542,8 @@ export type ErrorObjectNode = {
 export type ErrorObjectNodeSession = {
 	__typename?: 'ErrorObjectNodeSession'
 	appVersion?: Maybe<Scalars['String']>
+	email?: Maybe<Scalars['String']>
 	secureID: Scalars['String']
-	userProperties: Scalars['String']
 }
 
 export type ErrorResults = {
@@ -1929,6 +1929,7 @@ export type QueryError_ObjectsArgs = {
 	after?: InputMaybe<Scalars['String']>
 	before?: InputMaybe<Scalars['String']>
 	error_group_secure_id: Scalars['String']
+	query: Scalars['String']
 }
 
 export type QueryError_Resolution_SuggestionArgs = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2116,6 +2116,7 @@ query GetErrorObjects(
 				id
 				createdAt
 				event
+				timestamp
 				errorGroupSecureID
 				session {
 					secureID

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -59,6 +59,7 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 		error_object_id: string
 	}>()
 	const client = useApolloClient()
+	const { isHighlightAdmin } = useAuthContext()
 
 	const { loading, data } = useGetErrorInstanceQuery({
 		variables: {
@@ -110,7 +111,7 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 			<Box id="error-instance-container">
 				<Stack direction="row" my="12">
 					<Stack direction="row" flexGrow={1}>
-						<SeeAllInstances data={data} />
+						{isHighlightAdmin && <SeeAllInstances data={data} />}
 						<PreviousNextInstance data={data} />
 					</Stack>
 					<Stack direction="row" gap="4">
@@ -157,7 +158,7 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 		<Box id="error-instance-container">
 			<Stack direction="row" my="12">
 				<Stack direction="row" flexGrow={1}>
-					<SeeAllInstances data={data} />
+					{isHighlightAdmin && <SeeAllInstances data={data} />}
 					<PreviousNextInstance data={data} />
 				</Stack>
 				<Stack direction="row" gap="4">

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -40,6 +40,7 @@ import { ErrorSessionMissingOrExcluded } from '@/pages/ErrorsV2/ErrorInstance/Er
 import { PreviousNextInstance } from '@/pages/ErrorsV2/ErrorInstance/PreviousNextInstance'
 import { RelatedLogs } from '@/pages/ErrorsV2/ErrorInstance/RelatedLogs'
 import { RelatedSession } from '@/pages/ErrorsV2/ErrorInstance/RelatedSession'
+import { SeeAllInstances } from '@/pages/ErrorsV2/ErrorInstance/SeeAllInstances'
 import { isSessionAvailable } from '@/pages/ErrorsV2/ErrorInstance/utils'
 
 const MAX_USER_PROPERTIES = 4
@@ -108,9 +109,10 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 		return (
 			<Box id="error-instance-container">
 				<Stack direction="row" my="12">
-					<Box flexGrow={1}>
+					<Stack direction="row" flexGrow={1}>
+						<SeeAllInstances data={data} />
 						<PreviousNextInstance data={data} />
-					</Box>
+					</Stack>
 					<Stack direction="row" gap="4">
 						<RelatedSession data={data} />
 						<RelatedLogs data={data} />
@@ -154,9 +156,10 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 	return (
 		<Box id="error-instance-container">
 			<Stack direction="row" my="12">
-				<Box flexGrow={1}>
+				<Stack direction="row" flexGrow={1}>
+					<SeeAllInstances data={data} />
 					<PreviousNextInstance data={data} />
-				</Box>
+				</Stack>
 				<Stack direction="row" gap="4">
 					<RelatedSession data={data} />
 					<RelatedLogs data={data} />

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/SeeAllInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/SeeAllInstances.tsx
@@ -1,0 +1,31 @@
+import { IconSolidArrowSmLeft } from '@highlight-run/ui'
+
+import { useAuthContext } from '@/authentication/AuthContext'
+import { LinkButton } from '@/components/LinkButton'
+import { GetErrorInstanceQuery } from '@/graph/generated/operations'
+import { useProjectId } from '@/hooks/useProjectId'
+
+type Props = {
+	data: GetErrorInstanceQuery | undefined
+}
+
+export const SeeAllInstances = ({ data }: Props) => {
+	const { isLoggedIn } = useAuthContext()
+	const { projectId } = useProjectId()
+	const errorGroupSecureID =
+		data?.error_instance?.error_object.error_group_secure_id
+
+	return (
+		<LinkButton
+			kind="secondary"
+			size="xSmall"
+			emphasis="medium"
+			trackingId="seeAllInstance"
+			iconLeft={<IconSolidArrowSmLeft />}
+			disabled={!isLoggedIn || !errorGroupSecureID}
+			to={`/${projectId}/errors/${errorGroupSecureID}/instances`}
+		>
+			See all instances
+		</LinkButton>
+	)
+}

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.css.ts
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css'
+
+export const searchIcon = style({
+	position: 'absolute',
+	top: 12,
+	left: 7,
+})

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
@@ -1,4 +1,4 @@
-import { Box, Callout, Card, Stack, Text } from '@highlight-run/ui'
+import { Box, Callout, Stack, Text } from '@highlight-run/ui'
 import React, { useState } from 'react'
 
 import { Button } from '@/components/Button'
@@ -38,9 +38,7 @@ export const ErrorInstances = ({ errorGroup }: Props) => {
 				canMoveBackward={false}
 				canMoveForward={false}
 			>
-				<Card>
-					<LoadingBox height={156} />
-				</Card>
+				<LoadingBox height={156} />
 			</ErrorInstancesContainer>
 		)
 	}

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
@@ -28,6 +28,7 @@ export const ErrorInstances = ({ errorGroup }: Props) => {
 			errorGroupSecureID: errorGroup?.secure_id ?? '',
 			after: pagination.after,
 			before: pagination.before,
+			query: '', // unused, will be used to search by email (https://github.com/highlight/highlight/issues/5850)
 		},
 		skip: !errorGroup?.secure_id,
 	})

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
@@ -1,0 +1,146 @@
+import { Box, Callout, Card, Stack, Text } from '@highlight-run/ui'
+import React, { useState } from 'react'
+
+import { Button } from '@/components/Button'
+import LoadingBox from '@/components/LoadingBox'
+import { useGetErrorObjectsQuery } from '@/graph/generated/hooks'
+import { GetErrorGroupQuery } from '@/graph/generated/operations'
+import { ErrorObjectEdge } from '@/graph/generated/schemas'
+import { ErrorInstancesTable } from '@/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable'
+import { NoErrorInstancesFound } from '@/pages/ErrorsV2/ErrorInstances/NoErrorInstancesFound'
+
+type Props = {
+	errorGroup: GetErrorGroupQuery['error_group']
+}
+
+type Pagination = {
+	after: string | null
+	before: string | null
+}
+
+export const ErrorInstances = ({ errorGroup }: Props) => {
+	const [pagination, setPagination] = useState<Pagination>({
+		after: null,
+		before: null,
+	})
+	const { data, loading, error } = useGetErrorObjectsQuery({
+		variables: {
+			errorGroupSecureID: errorGroup?.secure_id ?? '',
+			after: pagination.after,
+			before: pagination.before,
+		},
+		skip: !errorGroup?.secure_id,
+	})
+
+	if (loading) {
+		return (
+			<ErrorInstancesContainer
+				canMoveBackward={false}
+				canMoveForward={false}
+			>
+				<Card>
+					<LoadingBox height={156} />
+				</Card>
+			</ErrorInstancesContainer>
+		)
+	}
+	if (error || !data)
+		return (
+			<ErrorInstancesContainer
+				canMoveBackward={false}
+				canMoveForward={false}
+			>
+				<Box m="auto" style={{ maxWidth: 300 }}>
+					<Callout
+						title="Failed to load error instances"
+						kind="error"
+					>
+						<Box mb="6">
+							<Text color="moderate">
+								There was an error loading error instances.
+								Reach out to us if this might be a bug.
+							</Text>
+						</Box>
+					</Callout>
+				</Box>
+			</ErrorInstancesContainer>
+		)
+
+	const handlePreviousPage = () => {
+		setPagination({
+			after: null,
+			before: data.error_objects.pageInfo.startCursor,
+		})
+	}
+
+	const handleNextPage = () => {
+		setPagination({
+			after: data.error_objects.pageInfo.endCursor,
+			before: null,
+		})
+	}
+
+	const edges: ErrorObjectEdge[] =
+		data.error_objects?.edges.map((edge) => edge) || []
+
+	if (edges.length === 0) {
+		return (
+			<ErrorInstancesContainer
+				canMoveBackward={false}
+				canMoveForward={false}
+			>
+				<NoErrorInstancesFound />
+			</ErrorInstancesContainer>
+		)
+	}
+
+	const pageInfo = data?.error_objects.pageInfo
+
+	return (
+		<ErrorInstancesContainer
+			canMoveBackward={pageInfo?.hasPreviousPage ?? false}
+			canMoveForward={pageInfo?.hasNextPage ?? false}
+			onPrevious={handlePreviousPage}
+			onNext={handleNextPage}
+		>
+			<ErrorInstancesTable edges={edges} />
+		</ErrorInstancesContainer>
+	)
+}
+
+type ErrorInstancesContainerProps = {
+	canMoveBackward: boolean
+	canMoveForward: boolean
+	onPrevious?: () => void
+	onNext?: () => void
+}
+
+const ErrorInstancesContainer: React.FC<
+	React.PropsWithChildren<ErrorInstancesContainerProps>
+> = ({ canMoveBackward, canMoveForward, onPrevious, onNext, children }) => {
+	return (
+		<>
+			<Box my="20" borderBottom="secondary">
+				{children}
+			</Box>
+			<Stack direction="row" justifyContent="flex-end">
+				<Button
+					kind="secondary"
+					trackingId="errorInstancesPreviousButton"
+					disabled={!canMoveBackward}
+					onClick={onPrevious}
+				>
+					Previous
+				</Button>
+				<Button
+					kind="secondary"
+					trackingId="errorInstancesNextButton"
+					disabled={!canMoveForward}
+					onClick={onNext}
+				>
+					Next
+				</Button>
+			</Stack>
+		</>
+	)
+}

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
@@ -58,7 +58,6 @@ export const ErrorInstances = ({ errorGroup }: Props) => {
 						<Box mb="6">
 							<Text color="moderate">
 								There was an error loading error instances.
-								Reach out to us if this might be a bug.
 							</Text>
 						</Box>
 					</Callout>

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -19,7 +19,6 @@ import { useAuthContext } from '@/authentication/AuthContext'
 import { Link } from '@/components/Link'
 import { ErrorObjectEdge } from '@/graph/generated/schemas'
 import { useProjectId } from '@/hooks/useProjectId'
-import { getUserProperties } from '@/pages/Sessions/SessionsFeedV3/MinimalSessionCard/utils/utils'
 
 const toYearMonthDay = (timestamp: string) => {
 	const date = new Date(timestamp)
@@ -83,11 +82,7 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 				let sessionLink = ''
 
 				if (session) {
-					const parsedUserProperties = getUserProperties(
-						session.userProperties,
-					)
-					content = parsedUserProperties.email
-					if (!content) {
+					if (!session.email) {
 						content = '(no value)'
 					}
 					// TODO - link directly to the timestamp like RelatedSession does

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -87,6 +87,9 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 						session.userProperties,
 					)
 					content = parsedUserProperties.email
+					if (!content) {
+						content = '(no value)'
+					}
 					// TODO - link directly to the timestamp like RelatedSession does
 					sessionLink = `/${projectId}/sessions/${session.secureID}`
 				}

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -22,6 +22,15 @@ type Props = {
 	edges: ErrorObjectEdge[]
 }
 
+function truncateVersion(version: string) {
+	const maxLength = 6
+	if (version.length > maxLength) {
+		return version.slice(0, maxLength) + '...'
+	} else {
+		return version
+	}
+}
+
 export const ErrorInstancesTable = ({ edges }: Props) => {
 	const { projectId } = useProjectId()
 	const columnHelper = createColumnHelper<ErrorObjectEdge>()
@@ -52,7 +61,7 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 					<Badge
 						size="medium"
 						color="weak"
-						label={session.appVersion}
+						label={truncateVersion(session.appVersion)}
 					></Badge>
 				)
 			},

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -14,11 +14,13 @@ import {
 } from '@tanstack/react-table'
 import moment from 'moment'
 import React from 'react'
+import { createSearchParams } from 'react-router-dom'
 
 import { useAuthContext } from '@/authentication/AuthContext'
 import { Link } from '@/components/Link'
 import { ErrorObjectEdge } from '@/graph/generated/schemas'
 import { useProjectId } from '@/hooks/useProjectId'
+import { PlayerSearchParameters } from '@/pages/Player/PlayerHook/utils'
 
 const toYearMonthDay = (timestamp: string) => {
 	const date = new Date(timestamp)
@@ -76,6 +78,8 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 		}),
 		columnHelper.accessor('node', {
 			cell: ({ getValue }) => {
+				const errorObjectId = getValue().id
+				const timestamp = getValue().timestamp
 				const session = getValue().session
 
 				let content = 'no session'
@@ -83,8 +87,12 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 
 				if (session) {
 					content = session.email ? session.email : '(no value)'
-					// TODO - link directly to the timestamp like RelatedSession does
-					sessionLink = `/${projectId}/sessions/${session.secureID}`
+					const params = createSearchParams({
+						tsAbs: timestamp,
+						[PlayerSearchParameters.errorId]: errorObjectId,
+					})
+
+					sessionLink = `/${projectId}/sessions/${session.secureID}?${params}`
 				}
 
 				return (

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -1,0 +1,123 @@
+import { Badge, Box, Stack, Tag, Text } from '@highlight-run/ui'
+import {
+	createColumnHelper,
+	flexRender,
+	getCoreRowModel,
+	useReactTable,
+} from '@tanstack/react-table'
+import moment from 'moment'
+import React from 'react'
+
+import { Link } from '@/components/Link'
+import { ErrorObjectEdge } from '@/graph/generated/schemas'
+import { useProjectId } from '@/hooks/useProjectId'
+import { getUserProperties } from '@/pages/Sessions/SessionsFeedV3/MinimalSessionCard/utils/utils'
+
+const toYearMonthDay = (timestamp: string) => {
+	const date = new Date(timestamp)
+	return moment(date).format('YYYY-MM-DD HH:mm:ss')
+}
+
+type Props = {
+	edges: ErrorObjectEdge[]
+}
+
+export const ErrorInstancesTable = ({ edges }: Props) => {
+	const { projectId } = useProjectId()
+	const columnHelper = createColumnHelper<ErrorObjectEdge>()
+
+	const columns = [
+		columnHelper.accessor('node.event', {
+			cell: ({ getValue }) => (
+				<Box display="flex" flexGrow={1}>
+					<Text>{getValue()}</Text>
+				</Box>
+			),
+		}),
+		columnHelper.accessor('node.createdAt', {
+			cell: ({ getValue }) => (
+				<Box display="flex">
+					<Tag shape="basic" kind="secondary">
+						{toYearMonthDay(getValue())}
+					</Tag>
+				</Box>
+			),
+		}),
+		columnHelper.accessor('node.session', {
+			cell: ({ getValue }) => {
+				const session = getValue()
+				if (!session?.appVersion) {
+					return null
+				}
+
+				return (
+					<Box display="flex">
+						<Badge
+							size="medium"
+							color="weak"
+							label={session.appVersion}
+						></Badge>
+					</Box>
+				)
+			},
+		}),
+		columnHelper.accessor('node.session', {
+			cell: ({ getValue }) => {
+				const session = getValue()
+				if (!session) {
+					return null
+				}
+
+				const parsedUserProperties = getUserProperties(
+					session.userProperties,
+				)
+
+				return (
+					<Box display="flex">
+						<Text>{parsedUserProperties.email}</Text>
+					</Box>
+				)
+			},
+		}),
+	]
+
+	const table = useReactTable({
+		columns,
+		data: edges,
+		getCoreRowModel: getCoreRowModel(),
+	})
+
+	return (
+		<>
+			{table.getRowModel().rows.map((row) => {
+				return (
+					<Link
+						to={`/${projectId}/errors/${row.original.node.errorGroupSecureID}/instances/${row.original.cursor}`}
+						key={row.id}
+					>
+						<Stack
+							key={row.id}
+							direction="row"
+							mb="8"
+							px="8"
+							py="2"
+							alignItems="center"
+							cursor="pointer"
+						>
+							{row.getVisibleCells().map((cell) => {
+								return (
+									<React.Fragment key={cell.id}>
+										{flexRender(
+											cell.column.columnDef.cell,
+											cell.getContext(),
+										)}
+									</React.Fragment>
+								)
+							})}
+						</Stack>
+					</Link>
+				)
+			})}
+		</>
+	)
+}

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -1,4 +1,11 @@
-import { Badge, Box, Stack, Tag, Text } from '@highlight-run/ui'
+import {
+	Badge,
+	Box,
+	IconSolidPlayCircle,
+	Stack,
+	Tag,
+	Text,
+} from '@highlight-run/ui'
 import {
 	createColumnHelper,
 	flexRender,
@@ -8,6 +15,7 @@ import {
 import moment from 'moment'
 import React from 'react'
 
+import { useAuthContext } from '@/authentication/AuthContext'
 import { Link } from '@/components/Link'
 import { ErrorObjectEdge } from '@/graph/generated/schemas'
 import { useProjectId } from '@/hooks/useProjectId'
@@ -33,6 +41,7 @@ function truncateVersion(version: string) {
 
 export const ErrorInstancesTable = ({ edges }: Props) => {
 	const { projectId } = useProjectId()
+	const { isLoggedIn } = useAuthContext()
 	const columnHelper = createColumnHelper<ErrorObjectEdge>()
 
 	const columns = [
@@ -66,18 +75,36 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 				)
 			},
 		}),
-		columnHelper.accessor('node.session', {
+		columnHelper.accessor('node', {
 			cell: ({ getValue }) => {
-				const session = getValue()
-				if (!session) {
-					return null
+				const session = getValue().session
+
+				let content = 'no session'
+				let sessionLink = ''
+
+				if (session) {
+					const parsedUserProperties = getUserProperties(
+						session.userProperties,
+					)
+					content = parsedUserProperties.email
+					// TODO - link directly to the timestamp like RelatedSession does
+					sessionLink = `/${projectId}/sessions/${session.secureID}`
 				}
 
-				const parsedUserProperties = getUserProperties(
-					session.userProperties,
+				return (
+					<Link to={sessionLink}>
+						<Tag
+							kind="secondary"
+							emphasis="low"
+							size="medium"
+							shape="basic"
+							disabled={!isLoggedIn || sessionLink === ''}
+							iconLeft={<IconSolidPlayCircle />}
+						>
+							{content}
+						</Tag>
+					</Link>
 				)
-
-				return <Text>{parsedUserProperties.email}</Text>
 			},
 		}),
 	]

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -30,17 +30,15 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 		columnHelper.accessor('node.event', {
 			cell: ({ getValue }) => (
 				<Box display="flex" flexGrow={1}>
-					<Text>{getValue()}</Text>
+					<Text lines="1">{getValue()}</Text>
 				</Box>
 			),
 		}),
 		columnHelper.accessor('node.createdAt', {
 			cell: ({ getValue }) => (
-				<Box display="flex">
-					<Tag shape="basic" kind="secondary">
-						{toYearMonthDay(getValue())}
-					</Tag>
-				</Box>
+				<Tag shape="basic" kind="secondary">
+					{toYearMonthDay(getValue())}
+				</Tag>
 			),
 		}),
 		columnHelper.accessor('node.session', {
@@ -51,13 +49,11 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 				}
 
 				return (
-					<Box display="flex">
-						<Badge
-							size="medium"
-							color="weak"
-							label={session.appVersion}
-						></Badge>
-					</Box>
+					<Badge
+						size="medium"
+						color="weak"
+						label={session.appVersion}
+					></Badge>
 				)
 			},
 		}),
@@ -72,11 +68,7 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 					session.userProperties,
 				)
 
-				return (
-					<Box display="flex">
-						<Text>{parsedUserProperties.email}</Text>
-					</Box>
-				)
+				return <Text>{parsedUserProperties.email}</Text>
 			},
 		}),
 	]

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -48,7 +48,7 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 	const columns = [
 		columnHelper.accessor('node.event', {
 			cell: ({ getValue }) => (
-				<Box display="flex" flexGrow={1}>
+				<Box display="flex" flexGrow={1} flexBasis={1}>
 					<Text lines="1">{getValue()}</Text>
 				</Box>
 			),

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -82,9 +82,7 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 				let sessionLink = ''
 
 				if (session) {
-					if (!session.email) {
-						content = '(no value)'
-					}
+					content = session.email ? session.email : '(no value)'
 					// TODO - link directly to the timestamp like RelatedSession does
 					sessionLink = `/${projectId}/sessions/${session.secureID}`
 				}

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/NoErrorInstancesFound.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/NoErrorInstancesFound.tsx
@@ -1,21 +1,9 @@
-import { Box, Callout, Text } from '@highlight-run/ui'
+import { Box, Callout } from '@highlight-run/ui'
 
 export const NoErrorInstancesFound = () => {
 	return (
-		<Box style={{ maxWidth: '300px' }}>
-			<Callout title="No error instances found">
-				<Box
-					display="flex"
-					flexDirection="column"
-					gap="16"
-					alignItems="flex-start"
-				>
-					<Text color="moderate">
-						This is a bug. Please reach out to us to report an
-						issue.
-					</Text>
-				</Box>
-			</Callout>
+		<Box style={{ maxWidth: '300px' }} margin="auto" mb="20">
+			<Callout title="No error instances found" />
 		</Box>
 	)
 }

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/NoErrorInstancesFound.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/NoErrorInstancesFound.tsx
@@ -1,0 +1,21 @@
+import { Box, Callout, Text } from '@highlight-run/ui'
+
+export const NoErrorInstancesFound = () => {
+	return (
+		<Box style={{ maxWidth: '300px' }}>
+			<Callout title="No error instances found">
+				<Box
+					display="flex"
+					flexDirection="column"
+					gap="16"
+					alignItems="flex-start"
+				>
+					<Text color="moderate">
+						This is a bug. Please reach out to us to report an
+						issue.
+					</Text>
+				</Box>
+			</Callout>
+		</Box>
+	)
+}

--- a/frontend/src/pages/ErrorsV2/ErrorTabContent/ErrorTabContent.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorTabContent/ErrorTabContent.tsx
@@ -14,6 +14,8 @@ import React from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useNavigate } from 'react-router-dom'
 
+import { ErrorInstances } from '@/pages/ErrorsV2/ErrorInstances/ErrorInstances'
+
 import styles from './ErrorTabContent.module.css'
 
 type Props = React.PropsWithChildren & {
@@ -22,15 +24,13 @@ type Props = React.PropsWithChildren & {
 
 const ErrorTabContent: React.FC<Props> = ({ errorGroup }) => {
 	const navigate = useNavigate()
-	const {
-		project_id,
-		error_secure_id,
-		error_tab_key = 'instances',
-	} = useParams<{
-		project_id: string
-		error_secure_id: string
-		error_tab_key?: 'instances' | 'metrics'
-	}>()
+	const { project_id, error_secure_id, error_object_id, error_tab_key } =
+		useParams<{
+			project_id: string
+			error_secure_id: string
+			error_object_id?: string
+			error_tab_key?: 'instances' | 'metrics'
+		}>()
 
 	useHotkeys(
 		'm',
@@ -56,6 +56,12 @@ const ErrorTabContent: React.FC<Props> = ({ errorGroup }) => {
 		[project_id, error_secure_id, error_tab_key],
 	)
 
+	// /:project_id/errors/:error_group_secure_id -> load latest instance
+	// /:project_id/errors/:error_group_secure_id/instances -> load instances list view
+	// /:project_id/errors/:error_group_secure_id/instances/:error_object_id -> load instance
+	const showAllInstances =
+		error_tab_key === 'instances' && error_object_id === undefined
+
 	return (
 		<Tabs
 			animated={false}
@@ -64,12 +70,17 @@ const ErrorTabContent: React.FC<Props> = ({ errorGroup }) => {
 			noHeaderPadding
 			noPadding
 			unsetOverflowY
-			activeKeyOverride={error_tab_key}
-			onChange={(activeKey) =>
-				navigate(
-					`/${project_id}/errors/${error_secure_id}/${activeKey}`,
-				)
-			}
+			activeKeyOverride={error_tab_key ?? 'instances'}
+			onChange={(activeKey) => {
+				if (activeKey === 'instances') {
+					// we want instances to load the latest instance, not the list view
+					navigate(`/${project_id}/errors/${error_secure_id}`)
+				} else {
+					navigate(
+						`/${project_id}/errors/${error_secure_id}/${activeKey}`,
+					)
+				}
+			}}
 			tabs={[
 				{
 					key: 'instances',
@@ -80,7 +91,11 @@ const ErrorTabContent: React.FC<Props> = ({ errorGroup }) => {
 							shortcut="i"
 						/>
 					),
-					panelContent: <ErrorInstance errorGroup={errorGroup} />,
+					panelContent: showAllInstances ? (
+						<ErrorInstances errorGroup={errorGroup} />
+					) : (
+						<ErrorInstance errorGroup={errorGroup} />
+					),
 				},
 				{
 					key: 'metrics',


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR adds an error instances table for easier navigation (see [figma](https://www.figma.com/file/rdBPNzn7Klk6RG1LHUCE5B/Screen-Designs?type=design&node-id=9059-234557&mode=dev)) along with the ability to search by email.

The table contains:
* error instance message (required)
* error instance created data (required)
* version (available if `session.appVersion` present)
* email (available if `session.userProperties.email` present)

The API uses the relay cursor spec and was already wired up in #5557.

Fixes #5599

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

https://www.loom.com/share/37351d0ef71c4089b5363bfeb19459e6


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

I am still trying to get the backfill from #5837 to finish hence this is guarded to only be visible to Highlight admins.