### PR TITLE
Use matching version of antd

### DIFF
--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -356,6 +356,6 @@
 		"graphql": "16.6.0",
 		"react-transition-group": "4.4.1",
 		"lodash": "npm:lodash-es",
-		"antd": "4.24.12",
+		"antd": "4.21.7",
 	},
 }


### PR DESCRIPTION
## Summary

Looks like we were overriding to a version of antd that was different than the one in our lockfile, which caused some subtle CSS differences between Reflame and production that affected tab layout.

Using the version in the lockfile fixes this.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

Checked Errors page in Reflame previews.

Before:
![image](https://github.com/highlight/highlight/assets/6934200/252c31b4-d652-4e48-8398-b936819b9c66)

After:
![image](https://github.com/highlight/highlight/assets/6934200/8628999e-1d42-42f8-9534-66479ca371b1)

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
