### PR TITLE
addProperties - skip properties that cannot be serialized

### DIFF
--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -481,10 +481,20 @@ export class Highlight {
 	}
 
 	addProperties(properties_obj = {}, typeArg?: PropertyType) {
+		// Remove any properties which throw on structuredClone
+		// (structuredClone is used when posting messages to the worker)
+		const obj = { ...properties_obj } as any
+		Object.entries(obj).forEach(([key, val]) => {
+			try {
+				structuredClone(val)
+			} catch {
+				delete obj[key]
+			}
+		})
 		this._worker.postMessage({
 			message: {
 				type: MessageType.Properties,
-				propertiesObject: properties_obj,
+				propertiesObject: obj,
 				propertyType: typeArg,
 			},
 		})

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -290,3 +290,9 @@ Ensures H.stop() stops recording and that visibility events do not restart recor
 
 - Add easier testing of local `@highlight-run/client` and `highlight.run` scripts.
 - Look for `window.HighlightIO` instead of `window.Highlight` when waiting for client script to load.
+
+## 7.3.5
+
+### Patch Changes
+
+- Remove any properties that throw a `structuredClone` error in `addProperties` before calling `postMessage`

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.3.4",
+	"version": "7.3.5",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.3.4"
+export default "7.3.5"


### PR DESCRIPTION
## Summary
- in `addProperties`, remove any properties that throw an error when calling `structuredClone`
- these would previously cause the entire `addProperties` call to fail
- we could consider making this check stronger (e.g. only allow `string | boolean | number`) as the `H.track` method signature enforces this already
<img width="341" alt="Screen Shot 2023-07-07 at 11 09 44 AM" src="https://github.com/highlight/highlight/assets/86132398/37c16949-ca5d-4361-b879-8a82bba0ea14">

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested by calling `H.track` with invalid properties in prod vs locally
<img width="382" alt="Screen Shot 2023-07-07 at 10 54 35 AM" src="https://github.com/highlight/highlight/assets/86132398/3936ca4d-bd65-4207-a43e-1ea9eee8f404">
<img width="255" alt="Screen Shot 2023-07-07 at 10 51 59 AM" src="https://github.com/highlight/highlight/assets/86132398/bc62195f-d479-45e2-8842-15f974e9bc95">

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
