### PR TITLE
Embedding YT vid into Next.js Walkthrough

### DIFF
--- a/docs-content/getting-started/fullstack-frameworks/next-js.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js.md
@@ -6,6 +6,12 @@ createdAt: 2023-05-10T00:00:00.000Z
 updatedAt: 2023-05-10T00:00:00.000Z
 ---
 
+<EmbeddedVideo 
+  src="https://www.youtube.com/embed/Dyoba16wE-o"
+  title="Youtube Video Player"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+/>
+
 ## Limitations 
 
 ⚠️ App Directory support on Vercel is a work-in-progress. Session Replay, Vercel Log Drain and non-Vercel-deployed Error Monitoring are fully operational; however, Vercel's `edge` runtime is not yet compatible with OpenTelemetry. Vercel's `nodejs` runtime **is** instrumented for OpenTelemetry, but we're having trouble ingesting Server-side Rendering (SSR) errors. We expect to solve the `nodejs` runtime issues first. In the meantime, we're hoping to find an `edge` runtime-compatible version of OpenTelemetry.


### PR DESCRIPTION
I'll update the video title to "Next.js + Highlight Walkthrough"

![image](https://github.com/highlight/highlight/assets/878947/38dd6534-2ce9-4652-9d82-acb57cc0d97f)