### PR TITLE
Fix nextjs link

### DIFF
--- a/docs-content/getting-started/4_backend-sdk/js/1_overview.md
+++ b/docs-content/getting-started/4_backend-sdk/js/1_overview.md
@@ -21,7 +21,7 @@ updatedAt: 2022-04-01T19:52:59.000Z
     <DocsCard title="Firebase Functions" href="../js/firebase">
         {"Get started with Firebase Functions"}
     </DocsCard>
-    <DocsCard title="Next.js" href="../../fullstack-frameworks/next-js/1_overview.md">
+    <DocsCard title="Next.js" href="../../fullstack-frameworks/next-js">
         {"Get started with Next.js"}
     </DocsCard>
     <DocsCard title="Node.js" href="../js/nodejs">


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

The next js link is broken from this page
https://www.highlight.io/docs/getting-started/backend-sdk/js/overview

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Verified link works locally with `npm run dev`

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
