### PR TITLE
update docs for reportConsoleErrors

### DIFF
--- a/docs-content/sdk/client.md
+++ b/docs-content/sdk/client.md
@@ -48,6 +48,10 @@ slug: client
           <p>The value here will be ignored if disabledConsoleRecording is true. The default value is ['assert', 'count', 'countReset', 'debug', 'dir', 'dirxml', 'error', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log', 'table', 'time', 'timeEnd', 'timeLog', 'trace', 'warn'].</p>
         </aside>
         <aside className="parameter">
+          <h5>reportConsoleErrors <code>boolean</code> <code>optional</code></h5>
+          <p>If true, <code>console.error</code> calls will be logged as errors. The default value is false.</p>
+        </aside>
+        <aside className="parameter">
           <h5>enableSegmentIntegration <code>boolean</code> <code>optional</code></h5>
           <p>Allows patching of segment requests to enhance data automatically in your application (i.e. identify, track, etc.). The default value is false.</p>
         </aside>

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -102,7 +102,7 @@ export declare type HighlightOptions = {
 	disableSessionRecording?: boolean
 	/**
 	 * Specifies whether Highlight will report `console.error` invocations as Highlight Errors.
-	 * @default true
+	 * @default false
 	 */
 	reportConsoleErrors?: boolean
 	/**


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

* Adds `reportConsoleErrors` to the SDK docs
* Updates the default value comment (the behavior was flipped [here](https://github.com/highlight/highlight/pull/4809/files#diff-a9b14a05444fa154939000009533ef701b98ad1a561962e9d9905953bd96b2b8L44) but missed a doc update).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

`cd highlight.io && yarn run dev && open http://localhost:4000`

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
