### PR TITLE
ensure hubspot contacts and companies are associated

### DIFF
--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -371,6 +371,27 @@ func (h *HubspotApi) createContactForAdmin(ctx context.Context, email string, us
 }
 
 func (h *HubspotApi) CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int) error {
+	return h.kafkaProducer.Submit(ctx, &kafka_queue.Message{
+		Type: kafka_queue.HubSpotCreateContactCompanyAssociation,
+		HubSpotCreateContactCompanyAssociation: &kafka_queue.HubSpotCreateContactCompanyAssociationArgs{
+			AdminID:     adminID,
+			WorkspaceID: workspaceID,
+		},
+	}, "")
+}
+
+func (h *HubspotApi) CreateContactCompanyAssociationImpl(ctx context.Context, adminID int, workspaceID int) error {
+	key := fmt.Sprintf("hubspot-association-%d-%d", adminID, workspaceID)
+	if err := h.redisClient.AcquireLock(ctx, key, ClientSideCreationPollInterval); err != nil {
+		return e.New("failed to acquire hubspot association lock")
+	} else {
+		defer func() {
+			if err := h.redisClient.ReleaseLock(ctx, key); err != nil {
+				log.WithContext(ctx).WithError(err).WithField("url", key).Error("failed to release hubspot association lock")
+			}
+		}()
+	}
+
 	admin := &model.Admin{}
 	if err := h.db.Model(&model.Admin{}).Where("id = ?", adminID).First(&admin).Error; err != nil {
 		return err
@@ -422,23 +443,33 @@ func (h *HubspotApi) CreateContactForAdmin(ctx context.Context, adminID int, ema
 }
 
 func (h *HubspotApi) CreateContactForAdminImpl(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
+	key := fmt.Sprintf("contact-%s", email)
+	if err := h.redisClient.AcquireLock(ctx, key, ClientSideContactCreationTimeout); err != nil {
+		return nil, e.New("failed to acquire hubspot contact creation lock")
+	} else {
+		defer func() {
+			if err := h.redisClient.ReleaseLock(ctx, key); err != nil {
+				log.WithContext(ctx).WithError(err).WithField("url", key).Error("failed to release hubspot contact creation lock")
+			}
+		}()
+	}
+
 	if contactId, err = pollHubspot(func() (*int, error) {
 		return h.getContactForAdmin(email)
-	}, ClientSideContactCreationTimeout); contactId != nil {
-		return
+	}, ClientSideContactCreationTimeout); contactId == nil {
+		log.WithContext(ctx).
+			WithField("email", email).
+			Warnf("failed to get client-side hubspot contact. creating")
+		contactId, err = retry(func() (*int, error) {
+			return h.createContactForAdmin(ctx, email, userDefinedRole, userDefinedPersona, first, last, phone, referral)
+		})
+
+		if err != nil || contactId == nil {
+			return nil, err
+		}
+		log.WithContext(ctx).Infof("succesfully created a hubspot contact with id: %v", contactId)
 	}
 
-	log.WithContext(ctx).
-		WithField("email", email).
-		Warnf("failed to get client-side hubspot contact. creating")
-	contactId, err = retry(func() (*int, error) {
-		return h.createContactForAdmin(ctx, email, userDefinedRole, userDefinedPersona, first, last, phone, referral)
-	})
-
-	if err != nil || contactId == nil {
-		return nil, err
-	}
-	log.WithContext(ctx).Infof("succesfully created a hubspot contact with id: %v", contactId)
 	if err := h.db.Model(&model.Admin{Model: model.Model{ID: adminID}}).
 		Updates(&model.Admin{HubspotContactID: contactId}).Error; err != nil {
 		return nil, err
@@ -463,13 +494,23 @@ func (h *HubspotApi) CreateCompanyForWorkspaceImpl(ctx context.Context, workspac
 		return
 	}
 
-	if emailproviders.Exists(adminEmail) {
-		adminEmail = ""
+	key := fmt.Sprintf("company-%s", name)
+	if err := h.redisClient.AcquireLock(ctx, key, ClientSideCompanyCreationTimeout); err != nil {
+		return nil, e.New("failed to acquire hubspot company creation lock")
+	} else {
+		defer func() {
+			if err := h.redisClient.ReleaseLock(ctx, key); err != nil {
+				log.WithContext(ctx).WithError(err).WithField("url", key).Error("failed to release hubspot company creation lock")
+			}
+		}()
 	}
-	components := strings.Split(adminEmail, "@")
+
 	var domain string
-	if len(components) > 1 {
-		domain = components[1]
+	if !emailproviders.Exists(adminEmail) {
+		components := strings.Split(adminEmail, "@")
+		if len(components) > 1 {
+			domain = components[1]
+		}
 	}
 	hexLink := fmt.Sprintf("https://workspace-details.highlight.io?_workspace_id=%v", workspaceID)
 	companyProperties := hubspot.CompaniesRequest{
@@ -500,28 +541,37 @@ func (h *HubspotApi) CreateCompanyForWorkspaceImpl(ctx context.Context, workspac
 			WithField("domain", domain).
 			Infof("company already exists in Hubspot. updating")
 
-		_, er := h.hubspotClient.Companies().Update(*companyID, companyProperties)
-		if er != nil {
-			return nil, er
+		if _, err := h.hubspotClient.Companies().Update(*companyID, companyProperties); err != nil {
+			return nil, err
 		}
+	} else {
+		log.WithContext(ctx).
+			WithField("name", name).
+			Warnf("failed to get client-side hubspot company. creating")
 
+		resp, err := h.hubspotClient.Companies().Create(companyProperties)
+		if err != nil {
+			return nil, err
+		}
+		companyID = &resp.CompanyID
+		log.WithContext(ctx).Infof("succesfully created a hubspot company with id: %v", resp.CompanyID)
+	}
+
+	if err = h.db.Model(&model.Workspace{Model: model.Model{ID: workspaceID}}).
+		Updates(&model.Workspace{HubspotCompanyID: companyID}).Error; err != nil {
 		return
 	}
 
-	log.WithContext(ctx).
-		WithField("name", name).
-		Warnf("failed to get client-side hubspot company. creating")
-
-	resp, err := h.hubspotClient.Companies().Create(companyProperties)
-	if err != nil {
-		return nil, err
+	if adminEmail != "" {
+		admin := model.Admin{}
+		if err = h.db.Model(&model.Admin{}).Where(&model.Admin{Email: &adminEmail}).First(&admin).Error; err != nil {
+			return
+		}
+		if err := h.CreateContactCompanyAssociation(ctx, admin.ID, workspaceID); err != nil {
+			return companyID, err
+		}
 	}
-	log.WithContext(ctx).Infof("succesfully created a hubspot company with id: %v", resp.CompanyID)
-	if err := h.db.Model(&model.Workspace{Model: model.Model{ID: workspaceID}}).
-		Updates(&model.Workspace{HubspotCompanyID: &resp.CompanyID}).Error; err != nil {
-		return &resp.CompanyID, err
-	}
-	return &resp.CompanyID, nil
+	return
 }
 
 func (h *HubspotApi) UpdateContactProperty(ctx context.Context, adminID int, properties []hubspot.Property) error {

--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -15,21 +15,22 @@ import (
 type PayloadType = int
 
 const (
-	PushPayload                      PayloadType = iota
-	InitializeSession                PayloadType = iota
-	IdentifySession                  PayloadType = iota
-	AddTrackProperties               PayloadType = iota // Deprecated: track events are now processed in pushPayload
-	AddSessionProperties             PayloadType = iota
-	PushBackendPayload               PayloadType = iota
-	PushMetrics                      PayloadType = iota
-	MarkBackendSetup                 PayloadType = iota // Deprecated: setup events are written from other payload processing
-	AddSessionFeedback               PayloadType = iota
-	PushLogs                         PayloadType = iota
-	HubSpotCreateContactForAdmin     PayloadType = iota
-	HubSpotCreateCompanyForWorkspace PayloadType = iota
-	HubSpotUpdateContactProperty     PayloadType = iota
-	HubSpotUpdateCompanyProperty     PayloadType = iota
-	HealthCheck                      PayloadType = math.MaxInt
+	PushPayload                            PayloadType = iota
+	InitializeSession                      PayloadType = iota
+	IdentifySession                        PayloadType = iota
+	AddTrackProperties                     PayloadType = iota // Deprecated: track events are now processed in pushPayload
+	AddSessionProperties                   PayloadType = iota
+	PushBackendPayload                     PayloadType = iota
+	PushMetrics                            PayloadType = iota
+	MarkBackendSetup                       PayloadType = iota // Deprecated: setup events are written from other payload processing
+	AddSessionFeedback                     PayloadType = iota
+	PushLogs                               PayloadType = iota
+	HubSpotCreateContactForAdmin           PayloadType = iota
+	HubSpotCreateCompanyForWorkspace       PayloadType = iota
+	HubSpotUpdateContactProperty           PayloadType = iota
+	HubSpotUpdateCompanyProperty           PayloadType = iota
+	HubSpotCreateContactCompanyAssociation PayloadType = iota
+	HealthCheck                            PayloadType = math.MaxInt
 )
 
 type PushPayloadArgs struct {
@@ -131,24 +132,30 @@ type HubSpotUpdateCompanyPropertyArgs struct {
 	Properties  []hubspot.Property
 }
 
+type HubSpotCreateContactCompanyAssociationArgs struct {
+	AdminID     int
+	WorkspaceID int
+}
+
 type Message struct {
-	Type                             PayloadType
-	Failures                         int
-	MaxRetries                       int
-	KafkaMessage                     *kafka.Message
-	PushPayload                      *PushPayloadArgs
-	InitializeSession                *InitializeSessionArgs
-	IdentifySession                  *IdentifySessionArgs
-	AddTrackProperties               *AddTrackPropertiesArgs
-	AddSessionProperties             *AddSessionPropertiesArgs
-	PushBackendPayload               *PushBackendPayloadArgs
-	PushMetrics                      *PushMetricsArgs
-	AddSessionFeedback               *AddSessionFeedbackArgs
-	PushLogs                         *PushLogsArgs
-	HubSpotCreateContactForAdmin     *HubSpotCreateContactForAdminArgs
-	HubSpotCreateCompanyForWorkspace *HubSpotCreateCompanyForWorkspaceArgs
-	HubSpotUpdateContactProperty     *HubSpotUpdateContactPropertyArgs
-	HubSpotUpdateCompanyProperty     *HubSpotUpdateCompanyPropertyArgs
+	Type                                   PayloadType
+	Failures                               int
+	MaxRetries                             int
+	KafkaMessage                           *kafka.Message
+	PushPayload                            *PushPayloadArgs
+	InitializeSession                      *InitializeSessionArgs
+	IdentifySession                        *IdentifySessionArgs
+	AddTrackProperties                     *AddTrackPropertiesArgs
+	AddSessionProperties                   *AddSessionPropertiesArgs
+	PushBackendPayload                     *PushBackendPayloadArgs
+	PushMetrics                            *PushMetricsArgs
+	AddSessionFeedback                     *AddSessionFeedbackArgs
+	PushLogs                               *PushLogsArgs
+	HubSpotCreateContactForAdmin           *HubSpotCreateContactForAdminArgs
+	HubSpotCreateCompanyForWorkspace       *HubSpotCreateCompanyForWorkspaceArgs
+	HubSpotUpdateContactProperty           *HubSpotUpdateContactPropertyArgs
+	HubSpotUpdateCompanyProperty           *HubSpotUpdateCompanyPropertyArgs
+	HubSpotCreateContactCompanyAssociation *HubSpotCreateContactCompanyAssociationArgs
 }
 
 type PartitionMessage struct {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -418,6 +418,17 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
 			return err
 		}
+	case kafkaqueue.HubSpotCreateContactCompanyAssociation:
+		if task.HubSpotCreateContactCompanyAssociation == nil {
+			break
+		}
+		if err := w.PublicResolver.HubspotApi.CreateContactCompanyAssociationImpl(ctx,
+			task.HubSpotCreateContactCompanyAssociation.AdminID,
+			task.HubSpotCreateContactCompanyAssociation.WorkspaceID,
+		); err != nil {
+			log.WithContext(ctx).WithError(err).WithField("type", task.Type).Error("failed to process task")
+			return err
+		}
 	case kafkaqueue.HealthCheck:
 	default:
 		log.WithContext(ctx).Errorf("Unknown task type %+v", task.Type)


### PR DESCRIPTION
## Summary

Hubspot contact <-> company associations would not be created by our backend
because we would lose track of the contact / company hubspot IDs.
We would also have a race condition where the order of the two creations affected whether
an association would be created. This change makes that more robust and adds locking to make sure
there are no other races where two workers could try to create a duplicate contact / company.

## How did you test this change?

Local testing: https://www.loom.com/share/87789a42e959446b9d88e03c7fafe9ed
Earlier testing: https://www.loom.com/share/2ca2439d433e46e298b18fe4cbeda8a6

## Are there any deployment considerations?

No