### PR TITLE
fix exclusion reason updated too frequently

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2613,7 +2613,14 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		}
 	} else if excluded {
 		// Only update the excluded flag and reason if either have changed
-		if sessionObj.Excluded != excluded || sessionObj.ExcludedReason != reason {
+		var reasonDeref, newReasonDeref privateModel.SessionExcludedReason
+		if sessionObj.ExcludedReason != nil {
+			reasonDeref = *sessionObj.ExcludedReason
+		}
+		if reason != nil {
+			newReasonDeref = *reason
+		}
+		if sessionObj.Excluded != excluded || reasonDeref != newReasonDeref {
 			if err := r.DB.Model(&model.Session{Model: model.Model{ID: sessionID}}).
 				Select("Excluded", "ExcludedReason").Updates(&model.Session{
 				Excluded:       excluded,


### PR DESCRIPTION
## Summary
- `sessionObj.ExcludedReason != reason` was doing a pointer comparison and always returning true if both were non nil
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- debugged locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
