### PR TITLE
use proper links for Related Logs / Related Session

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5864,6 +5864,13 @@ body {
   padding: 0 0 0 1.5rem !important;
   margin: 0 0 1rem 0 !important;
 }
+._1vb6x0p0 {
+  text-decoration: none;
+  color: var(--_1pyqka9y);
+}
+._1vb6x0p0:hover {
+  color: var(--_1pyqka9y);
+}
 ._1g045pm0 {
   color: var(--_1pyqka9b) !important;
 }
@@ -6013,13 +6020,6 @@ body {
 }
 ._1f99hkr0 {
   height: 2.305rem;
-}
-._1vb6x0p0 {
-  text-decoration: none;
-  color: var(--_1pyqka9y);
-}
-._1vb6x0p0:hover {
-  color: var(--_1pyqka9y);
 }
 .szxd8q0 .szxd8q0 {
   padding-left: 22px;

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/RelatedLogs.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/RelatedLogs.tsx
@@ -1,8 +1,9 @@
 import { IconSolidLogs, Tag } from '@highlight-run/ui'
 import moment from 'moment'
-import { createSearchParams, useNavigate } from 'react-router-dom'
+import { createSearchParams } from 'react-router-dom'
 
 import { useAuthContext } from '@/authentication/AuthContext'
+import { Link } from '@/components/Link'
 import { GetErrorInstanceQuery } from '@/graph/generated/operations'
 import { ReservedLogKey } from '@/graph/generated/schemas'
 import {
@@ -58,21 +59,21 @@ type Props = {
 
 export const RelatedLogs = ({ data }: Props) => {
 	const { isLoggedIn } = useAuthContext()
-	const navigate = useNavigate()
 
 	const logsLink = getLogsLink(data)
 
 	return (
-		<Tag
-			kind="secondary"
-			emphasis="low"
-			size="medium"
-			shape="basic"
-			disabled={!isLoggedIn || logsLink === ''}
-			onClick={() => navigate(logsLink)}
-			iconLeft={<IconSolidLogs />}
-		>
-			Related logs
-		</Tag>
+		<Link to={logsLink}>
+			<Tag
+				kind="secondary"
+				emphasis="low"
+				size="medium"
+				shape="basic"
+				disabled={!isLoggedIn || logsLink === ''}
+				iconLeft={<IconSolidLogs />}
+			>
+				Related logs
+			</Tag>
+		</Link>
 	)
 }

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/RelatedSession.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/RelatedSession.tsx
@@ -1,7 +1,8 @@
 import { IconSolidPlayCircle, Tag, Tooltip } from '@highlight-run/ui'
-import { createSearchParams, useNavigate } from 'react-router-dom'
+import { createSearchParams } from 'react-router-dom'
 
 import { useAuthContext } from '@/authentication/AuthContext'
+import { Link } from '@/components/Link'
 import { GetErrorInstanceQuery } from '@/graph/generated/operations'
 import { PlayerSearchParameters } from '@/pages/Player/PlayerHook/utils'
 
@@ -34,21 +35,21 @@ type Props = {
 
 export const RelatedSession = ({ data }: Props) => {
 	const { isLoggedIn } = useAuthContext()
-	const navigate = useNavigate()
 	const sessionLink = getSessionLink(data)
 
 	const tag = (
-		<Tag
-			kind="secondary"
-			emphasis="low"
-			size="medium"
-			shape="basic"
-			onClick={() => navigate(sessionLink)}
-			disabled={!isLoggedIn || sessionLink === ''}
-			iconLeft={<IconSolidPlayCircle />}
-		>
-			Related session
-		</Tag>
+		<Link to={sessionLink}>
+			<Tag
+				kind="secondary"
+				emphasis="low"
+				size="medium"
+				shape="basic"
+				disabled={!isLoggedIn || sessionLink === ''}
+				iconLeft={<IconSolidPlayCircle />}
+			>
+				Related session
+			</Tag>
+		</Link>
 	)
 
 	if (data?.error_instance?.error_object.session?.processed === false) {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Use proper links for Related session / Related logs on the error instance view so these elements can be used as native links. For example, they can be cmd+clicked or have a right click context menu.


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Verified these are links as expected:
![Screenshot 2023-07-11 at 1 03 33 PM](https://github.com/highlight/highlight/assets/58678/3cbe4566-12c0-4cb1-a214-69b3d8c9d6e5)

![Screenshot_2023-07-11_at_1_09_45_PM](https://github.com/highlight/highlight/assets/58678/1e3c2f9e-2780-463f-9e76-998ad553ff8e)



## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
