### PR TITLE
update docs for hobby networking

### DIFF
--- a/highlight.io/components/Docs/HighlightCodeBlock/HighlightCodeBlock.tsx
+++ b/highlight.io/components/Docs/HighlightCodeBlock/HighlightCodeBlock.tsx
@@ -1,24 +1,19 @@
-import styles from '../Docs.module.scss'
-import { CodeBlock } from 'react-code-blocks'
-import {
-	PropsWithChildren,
-	useState,
-	Fragment,
-	Key,
-	CSSProperties,
-} from 'react'
-import highlightCodeTheme from '../../../components/common/CodeBlock/highlight-code-theme'
-import Image from 'next/legacy/image'
-import CopyIcon from '../../../public/images/document-duplicate.svg'
-import CheckmarkIcon from '../../../public/images/checkmark_circle.svg'
-import { Typography } from '../../common/Typography/Typography'
-import classNames from 'classnames'
 import { Listbox, Transition } from '@headlessui/react'
 import { ChevronUpDownIcon } from '@heroicons/react/20/solid'
+import classNames from 'classnames'
+import Image from 'next/legacy/image'
+import { CSSProperties, Fragment, Key, useState } from 'react'
+import { CodeBlock } from 'react-code-blocks'
+import highlightCodeTheme from '../../../components/common/CodeBlock/highlight-code-theme'
+import CheckmarkIcon from '../../../public/images/checkmark_circle.svg'
+import CopyIcon from '../../../public/images/document-duplicate.svg'
+import { Typography } from '../../common/Typography/Typography'
+import styles from '../Docs.module.scss'
 
 export const HighlightCodeBlock = (props: {
 	language: string
 	text?: string
+	copy?: string
 	topbar?: boolean
 	showLineNumbers?: boolean
 	product?: any
@@ -112,7 +107,9 @@ export const HighlightCodeBlock = (props: {
 					`${props.topbar ? 'mt-1' : ''}`,
 				)}
 				onClick={() => {
-					navigator.clipboard.writeText(props.text ?? '')
+					navigator.clipboard.writeText(
+						props.copy ?? props.text ?? '',
+					)
 					setCopied(true)
 					setTimeout(() => setCopied(false), 1000)
 				}}

--- a/highlight.io/components/MDXRemote/QuickStart.tsx
+++ b/highlight.io/components/MDXRemote/QuickStart.tsx
@@ -79,6 +79,7 @@ export function QuickStart({ content: c }: Props) {
 												}}
 												language={codeBlock.language}
 												text={codeBlock.text}
+												copy={codeBlock.copy}
 												showLineNumbers={false}
 											/>
 										)

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -67,6 +67,7 @@ export type QuickStartCodeBlock = {
 	key?: string
 	text: string
 	language: string
+	copy?: string
 }
 
 export type QuickStartStep = {

--- a/highlight.io/components/QuickstartContent/self-host/self-host.tsx
+++ b/highlight.io/components/QuickstartContent/self-host/self-host.tsx
@@ -9,14 +9,21 @@ export const SelfHostContent: QuickStartContent = {
 		{
 			title: 'Prerequisites',
 			content:
-				'Before we get started, you should have the latest version of [Docker](https://docs.docker.com/engine/install/) (19.03.0+) ' +
+				'Before we get started, you should install [Go](https://go.dev/) (1.20), [Node.js](https://nodejs.org/en) (18), and [yarn](https://yarnpkg.com/getting-started/install) (v3+).' +
+				'You should have the latest version of [Docker](https://docs.docker.com/engine/install/) (19.03.0+) ' +
 				'and [Git](https://git-scm.com/downloads) (2.13+) installed. ' +
 				'For a local hobby deploy, we suggest [configuring docker](https://docs.docker.com/desktop/settings/mac/#resources) ' +
 				'to use at least 8GB of RAM, 4 CPUs, and 64 GB of disk space.',
 			code: [
 				{
 					language: 'bash',
-					text: `$ docker --version
+					text: `$ go version
+go version go1.20.3 darwin/arm64
+$ node --version
+v18.15.0
+$ yarn --version
+v3.5.0
+$ docker --version
 Docker version 20.10.23, build 7155243
 $ docker compose version
 Docker Compose version v2.15.1`,
@@ -24,6 +31,24 @@ Docker Compose version v2.15.1`,
 			],
 		},
 		clone,
+		{
+			title: 'Configure networking.',
+			content:
+				'If this hobby deploy is running on a remote server, make changes to the `docker/.env` file for your deployment. ' +
+				'Update the following values to your backend IP address.',
+			code: [
+				{
+					text: `PRIVATE_GRAPH_URI=https://your-ip-address:8082/private
+PUBLIC_GRAPH_URI=https://your-ip-address:8082/public
+REACT_APP_PRIVATE_GRAPH_URI=https://your-ip-address:8082/private
+REACT_APP_PUBLIC_GRAPH_URI=https://your-ip-address:8082/public
+REACT_APP_FRONTEND_URI=https://your-ip-address:3000
+REACT_APP_FRONTEND_URI=https://your-ip-address:3000
+`,
+					language: 'bash',
+				},
+			],
+		},
 		{
 			title: 'Start highlight.',
 			content:

--- a/highlight.io/components/QuickstartContent/self-host/self-host.tsx
+++ b/highlight.io/components/QuickstartContent/self-host/self-host.tsx
@@ -1,35 +1,12 @@
 import { QuickStartContent } from '../QuickstartContent'
-import { clone, dashboard, troubleshoot } from './shared-snippets'
+import { clone, dashboard, dependencies, troubleshoot } from './shared-snippets'
 
 export const SelfHostContent: QuickStartContent = {
 	title: 'Self-hosted (Hobby) Deployment',
 	subtitle:
 		'Learn how to set up the self-hosted hobby deployment of highlight.io.',
 	entries: [
-		{
-			title: 'Prerequisites',
-			content:
-				'Before we get started, you should install [Go](https://go.dev/) (1.20), [Node.js](https://nodejs.org/en) (18), and [yarn](https://yarnpkg.com/getting-started/install) (v3+).' +
-				'You should have the latest version of [Docker](https://docs.docker.com/engine/install/) (19.03.0+) ' +
-				'and [Git](https://git-scm.com/downloads) (2.13+) installed. ' +
-				'For a local hobby deploy, we suggest [configuring docker](https://docs.docker.com/desktop/settings/mac/#resources) ' +
-				'to use at least 8GB of RAM, 4 CPUs, and 64 GB of disk space.',
-			code: [
-				{
-					language: 'bash',
-					text: `$ go version
-go version go1.20.3 darwin/arm64
-$ node --version
-v18.15.0
-$ yarn --version
-v3.5.0
-$ docker --version
-Docker version 20.10.23, build 7155243
-$ docker compose version
-Docker Compose version v2.15.1`,
-				},
-			],
-		},
+		dependencies,
 		clone,
 		{
 			title: 'Configure networking.',

--- a/highlight.io/components/QuickstartContent/self-host/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/self-host/shared-snippets.tsx
@@ -3,7 +3,7 @@ import { QuickStartStep } from '../QuickstartContent'
 export const dependencies: QuickStartStep = {
 	title: 'Prerequisites',
 	content:
-		'Before we get started, you should install [Go](https://go.dev/) (1.20) and [Node.js](https://nodejs.org/en) (18).' +
+		'Before we get started, you should install [Go](https://go.dev/) (1.20), [Node.js](https://nodejs.org/en) (18), and [yarn](https://yarnpkg.com/getting-started/install) (v3+).' +
 		'You should have the latest version of [Docker](https://docs.docker.com/engine/install/) (19.03.0+) ' +
 		'and [Git](https://git-scm.com/downloads) (2.13+) installed. ' +
 		'For a local deploy, we suggest [configuring docker](https://docs.docker.com/desktop/settings/mac/#resources) ' +
@@ -14,7 +14,9 @@ export const dependencies: QuickStartStep = {
 			text: `$ go version
 go version go1.20.3 darwin/arm64
 $ node --version
-v18.15.0`,
+v18.15.0
+$ yarn --version
+v3.5.0`,
 		},
 	],
 }

--- a/highlight.io/components/QuickstartContent/self-host/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/self-host/shared-snippets.tsx
@@ -6,17 +6,38 @@ export const dependencies: QuickStartStep = {
 		'Before we get started, you should install [Go](https://go.dev/) (1.20), [Node.js](https://nodejs.org/en) (18), and [yarn](https://yarnpkg.com/getting-started/install) (v3+).' +
 		'You should have the latest version of [Docker](https://docs.docker.com/engine/install/) (19.03.0+) ' +
 		'and [Git](https://git-scm.com/downloads) (2.13+) installed. ' +
-		'For a local deploy, we suggest [configuring docker](https://docs.docker.com/desktop/settings/mac/#resources) ' +
+		'We suggest [configuring docker](https://docs.docker.com/desktop/settings/mac/#resources) ' +
 		'to use at least 8GB of RAM, 4 CPUs, and 64 GB of disk space.',
 	code: [
 		{
 			language: 'bash',
+			copy: 'go version',
 			text: `$ go version
-go version go1.20.3 darwin/arm64
-$ node --version
-v18.15.0
-$ yarn --version
+go version go1.20.3 darwin/arm64`,
+		},
+		{
+			language: 'bash',
+			copy: 'node --version',
+			text: `$ node --version
+v18.15.0`,
+		},
+		{
+			language: 'bash',
+			copy: 'yarn --version',
+			text: `$ yarn --version
 v3.5.0`,
+		},
+		{
+			language: 'bash',
+			copy: 'docker --version',
+			text: `$ docker --version
+Docker version 20.10.23, build 7155243`,
+		},
+		{
+			language: 'bash',
+			copy: 'docker compose version',
+			text: `$ docker compose version
+Docker Compose version v2.15.1`,
 		},
 	],
 }


### PR DESCRIPTION
## Summary

As mentioned in #5828, our hobby deploy would not work for EC2 / remote-server deploys because
the frontend did not route correctly to the remote backend.
Confirmed that setting these env. vars solved the issue for this customer.

## How did you test this change?

[Docs preview](https://highlight-landing-k9ikag77h-highlight-run.vercel.app/docs/getting-started/self-host/self-hosted-hobby-guide).

## Are there any deployment considerations?

No