### PR TITLE
Pin react-resize-aware to 3.1.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
 		"react-markdown": "^8.0.5",
 		"react-nice-avatar": "^1.2.1",
 		"react-resizable": "^3.0.4",
-		"react-resize-aware": "^3.0.1",
+		"react-resize-aware": "3.1.0",
 		"react-router-dom": "^6.8.1",
 		"react-select": "^3.1.1",
 		"react-slider": "^2.0.1",

--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -25,7 +25,8 @@ import ReactCollapsibleModule from 'react-collapsible'
 // FIXME: this is a temporary workaround for Reflame not handling minified UMD modules properly
 // Fix coming up soon
 // @ts-ignore
-const ReactCollapsible = ReactCollapsibleModule.default ?? ReactCollapsible
+const ReactCollapsible =
+	ReactCollapsibleModule.default ?? ReactCollapsibleModule
 
 import { ErrorObjectFragment } from '@/graph/generated/operations'
 

--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -20,7 +20,12 @@ import { SourcemapErrorDetails } from '@pages/ErrorsV2/SourcemapErrorDetails/Sou
 import { UnstructuredStackTrace } from '@pages/ErrorsV2/UnstructuredStackTrace/UnstructuredStackTrace'
 import clsx from 'clsx'
 import React from 'react'
-import ReactCollapsible from 'react-collapsible'
+import ReactCollapsibleModule from 'react-collapsible'
+
+// FIXME: this is a temporary workaround for Reflame not handling minified UMD modules properly
+// Fix coming up soon
+// @ts-ignore
+const ReactCollapsible = ReactCollapsibleModule.default ?? ReactCollapsible
 
 import { ErrorObjectFragment } from '@/graph/generated/operations'
 

--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -24,8 +24,8 @@ import ReactCollapsibleModule from 'react-collapsible'
 
 // FIXME: this is a temporary workaround for Reflame not handling minified UMD modules properly
 // Fix coming up soon
-// @ts-ignore
 const ReactCollapsible =
+	// @ts-ignore
 	ReactCollapsibleModule.default ?? ReactCollapsibleModule
 
 import { ErrorObjectFragment } from '@/graph/generated/operations'

--- a/yarn.lock
+++ b/yarn.lock
@@ -11332,7 +11332,7 @@ __metadata:
     react-markdown: ^8.0.5
     react-nice-avatar: ^1.2.1
     react-resizable: ^3.0.4
-    react-resize-aware: ^3.0.1
+    react-resize-aware: 3.1.0
     react-router-dom: ^6.8.1
     react-select: ^3.1.1
     react-slider: ^2.0.1
@@ -46049,7 +46049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resize-aware@npm:^3.0.1":
+"react-resize-aware@npm:3.1.0":
   version: 3.1.0
   resolution: "react-resize-aware@npm:3.1.0"
   peerDependencies:


### PR DESCRIPTION
## Summary

3.1.2 seems to have a broken build that references jsx without importing react: https://github.com/FezVrasta/react-resize-aware/issues/58

Pinning to the current version in the lockfile so there's no room for deviation in Reflame deploys.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
