### PR TITLE
return a proper err instead of getting a graphql error

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5098,7 +5098,7 @@ func (r *queryResolver) UserFingerprintCount(ctx context.Context, projectID int,
 func (r *queryResolver) SessionsOpensearch(ctx context.Context, projectID int, count int, query string, sortField *string, sortDesc bool, page *int) (*model.SessionResults, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	workspace, err := r.GetWorkspace(project.WorkspaceID)
 	if err != nil {
@@ -5145,7 +5145,7 @@ func (r *queryResolver) SessionsOpensearch(ctx context.Context, projectID int, c
 func (r *queryResolver) SessionsHistogram(ctx context.Context, projectID int, query string, histogramOptions modelInputs.DateHistogramOptions) (*model.SessionsHistogram, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	workspace, err := r.GetWorkspace(project.WorkspaceID)
 	if err != nil {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

These endpoints should be returning proper errors otherwise there will be a graphql schema issue:

Incorrect:
![Screenshot 2023-07-12 at 12 53 01 PM](https://github.com/highlight/highlight/assets/58678/d59300ee-428e-4af7-869c-c8d5f52c15c4)

Correct:
![Screenshot 2023-07-12 at 12 53 11 PM](https://github.com/highlight/highlight/assets/58678/fa6d0021-0a51-4314-b8d4-9055ff7df4e7)




Related to #5818

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

There may be other graphql schema errors but this should get some of them.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A