### PR TITLE
Add errors tab to network request details panel

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
@@ -20,9 +20,9 @@ import { Link } from 'react-router-dom'
 import * as style from './ErrorFeedCard.css'
 interface Props {
 	errorGroup: Maybe<Omit<ErrorGroup, 'metadata_log'>>
-	urlParams?: string
+	onClick?: React.MouseEventHandler<HTMLAnchorElement>
 }
-export const ErrorFeedCard = ({ errorGroup }: Props) => {
+export const ErrorFeedCard = ({ errorGroup, onClick }: Props) => {
 	const { projectId } = useProjectId()
 	const { error_secure_id } = useParams<{
 		error_secure_id?: string
@@ -38,10 +38,15 @@ export const ErrorFeedCard = ({ errorGroup }: Props) => {
 
 	return (
 		<Link
-			to={{
-				pathname: `/${projectId}/errors/${errorGroup?.secure_id}`,
-				search: location.search,
-			}}
+			to={
+				onClick
+					? {}
+					: {
+							pathname: `/${projectId}/errors/${errorGroup?.secure_id}`,
+							search: location.search,
+					  }
+			}
+			onClick={onClick}
 		>
 			<Box
 				paddingTop="8"

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
@@ -230,7 +230,14 @@ function NetworkResourceDetails({
 					onClick={hide}
 				/>
 			</Box>
-			<Box px="12" py="8" display="flex" flexDirection="column" gap="8">
+			<Box
+				pt="16"
+				px="12"
+				pb="12"
+				display="flex"
+				flexDirection="column"
+				gap="12"
+			>
 				<Heading level="h4">Network request</Heading>
 
 				<Box display="flex" alignItems="center" gap="4">

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
@@ -74,8 +74,10 @@ export const NetworkResourcePanel = () => {
 	useEffect(() => {
 		if (resource?.id !== undefined) {
 			networkResourceDialog.show()
+		} else {
+			hide()
 		}
-	}, [networkResourceDialog, resource?.id])
+	}, [hide, networkResourceDialog, resource?.id])
 
 	// Close the dialog and reset the active resource when the user interacts with
 	// the page outside the dialog.
@@ -254,6 +256,7 @@ function NetworkResourceDetails({
 						iconRight={<IconSolidArrowCircleRight />}
 						onClick={() => {
 							setTime(timestamp)
+							hide()
 						}}
 					>
 						Go to

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
@@ -95,6 +95,7 @@ export const NetworkResourcePanel = () => {
 		<Ariakit.Dialog
 			state={networkResourceDialog}
 			modal={false}
+			autoFocusOnShow={false}
 			className={sprinkles({
 				backgroundColor: 'white',
 				display: 'flex',


### PR DESCRIPTION
## Summary

Adds an Errors tab to the network request detail panel which shows a list of errors associated with the request.

<img width="1083" alt="Screenshot 2023-07-12 at 3 19 52 PM" src="https://github.com/highlight/highlight/assets/308182/d6c069a7-d532-4c9e-8ba7-07d0bff03d7e">

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A