### PR TITLE
cleanup some errors

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4177,10 +4177,12 @@ func (r *queryResolver) ErrorInstance(ctx context.Context, errorGroupSecureID st
 		return nil, e.Wrap(err, "error reading previous error object in group")
 	}
 
-	errorInstance := model.ErrorInstance{
-		ErrorObject: errorObject,
-		NextID:      &nextID,
-		PreviousID:  &previousID,
+	errorInstance := model.ErrorInstance{ErrorObject: errorObject}
+	if nextID != 0 {
+		errorInstance.NextID = &nextID
+	}
+	if previousID != 0 {
+		errorInstance.PreviousID = &previousID
 	}
 
 	return &errorInstance, nil

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -346,7 +346,7 @@ export const usePlayer = (): ReplayerContextInterface => {
 			const lastChunkIdx =
 				eventChunksData?.event_chunks[
 					eventChunksData?.event_chunks.length - 1
-				].chunk_index
+				]?.chunk_index
 			if (lastChunkIdx !== undefined)
 				endIdx = Math.min(lastChunkIdx, endIdx)
 


### PR DESCRIPTION
## Summary

* fixes undefined access to chunk_index when a chunk does not exist
* ensure error instance query returns nil instead of 0 for next/previous ids when they do not exist

## How did you test this change?

![image](https://github.com/highlight/highlight/assets/1351531/eed15973-c4e9-4a7a-afb8-3f179d3a7984)
![image](https://github.com/highlight/highlight/assets/1351531/db3bd333-86c7-4c74-9213-54277e8ba77f)


## Are there any deployment considerations?

No
