### PR TITLE
replace first with take

### DIFF
--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -393,11 +393,11 @@ func (h *HubspotApi) CreateContactCompanyAssociationImpl(ctx context.Context, ad
 	}
 
 	admin := &model.Admin{}
-	if err := h.db.Model(&model.Admin{}).Where("id = ?", adminID).First(&admin).Error; err != nil {
+	if err := h.db.Model(&model.Admin{}).Where("id = ?", adminID).Take(&admin).Error; err != nil {
 		return err
 	}
 	workspace := &model.Workspace{}
-	if err := h.db.Model(&model.Workspace{}).Where("id = ?", workspaceID).First(&workspace).Error; err != nil {
+	if err := h.db.Model(&model.Workspace{}).Where("id = ?", workspaceID).Take(&workspace).Error; err != nil {
 		return err
 	}
 	if workspace.HubspotCompanyID == nil {
@@ -564,7 +564,7 @@ func (h *HubspotApi) CreateCompanyForWorkspaceImpl(ctx context.Context, workspac
 
 	if adminEmail != "" {
 		admin := model.Admin{}
-		if err = h.db.Model(&model.Admin{}).Where(&model.Admin{Email: &adminEmail}).First(&admin).Error; err != nil {
+		if err = h.db.Model(&model.Admin{}).Where(&model.Admin{Email: &adminEmail}).Take(&admin).Error; err != nil {
 			return
 		}
 		if err := h.CreateContactCompanyAssociation(ctx, admin.ID, workspaceID); err != nil {
@@ -586,7 +586,7 @@ func (h *HubspotApi) UpdateContactProperty(ctx context.Context, adminID int, pro
 
 func (h *HubspotApi) UpdateContactPropertyImpl(ctx context.Context, adminID int, properties []hubspot.Property) error {
 	admin := &model.Admin{}
-	if err := h.db.Model(&model.Admin{}).Where("id = ?", adminID).First(&admin).Error; err != nil {
+	if err := h.db.Model(&model.Admin{}).Where("id = ?", adminID).Take(&admin).Error; err != nil {
 		return err
 	}
 	hubspotContactID := admin.HubspotContactID
@@ -627,7 +627,7 @@ func (h *HubspotApi) UpdateCompanyProperty(ctx context.Context, workspaceID int,
 
 func (h *HubspotApi) UpdateCompanyPropertyImpl(ctx context.Context, workspaceID int, properties []hubspot.Property) error {
 	workspace := &model.Workspace{}
-	if err := h.db.Model(&model.Workspace{}).Where("id = ?", workspaceID).First(&workspace).Error; err != nil {
+	if err := h.db.Model(&model.Workspace{}).Where("id = ?", workspaceID).Take(&workspace).Error; err != nil {
 		return err
 	}
 	hubspotWorkspaceID := workspace.HubspotCompanyID

--- a/backend/integrations/integrations.go
+++ b/backend/integrations/integrations.go
@@ -83,7 +83,7 @@ func (c *Client) GetWorkspaceAccessToken(ctx context.Context, workspace *model.W
 	if err := c.db.Where(&model.IntegrationWorkspaceMapping{
 		WorkspaceID:     workspace.ID,
 		IntegrationType: integrationType,
-	}).First(&workspaceMapping).Error; err != nil {
+	}).Take(&workspaceMapping).Error; err != nil {
 		return nil, nil
 	}
 
@@ -121,7 +121,7 @@ func (c *Client) IsProjectIntegrated(ctx context.Context, project *model.Project
 		if err := c.db.Where(&model.IntegrationProjectMapping{
 			ProjectID:       project.ID,
 			IntegrationType: integrationType,
-		}).First(&projectMapping).Error; err != nil {
+		}).Take(&projectMapping).Error; err != nil {
 			return false, nil
 		}
 
@@ -133,7 +133,7 @@ func (c *Client) IsProjectIntegrated(ctx context.Context, project *model.Project
 	}
 
 	var workspace model.Workspace
-	if err := c.db.Where(&model.Workspace{Model: model.Model{ID: project.WorkspaceID}}).First(&workspace).Error; err != nil {
+	if err := c.db.Where(&model.Workspace{Model: model.Model{ID: project.WorkspaceID}}).Take(&workspace).Error; err != nil {
 		return false, nil
 	}
 
@@ -151,7 +151,7 @@ func (c *Client) IsProjectIntegrated(ctx context.Context, project *model.Project
 	if err := c.db.Where(&model.IntegrationProjectMapping{
 		ProjectID:       project.ID,
 		IntegrationType: integrationType,
-	}).First(&projectMapping).Error; err != nil {
+	}).Take(&projectMapping).Error; err != nil {
 		return false, nil
 	}
 

--- a/backend/jobs/log-alerts/log-alerts.go
+++ b/backend/jobs/log-alerts/log-alerts.go
@@ -144,11 +144,11 @@ func processLogAlert(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, MailCl
 
 	if alertCondition {
 		var project model.Project
-		if err := DB.Model(&model.Project{}).Where("id = ?", alert.ProjectID).First(&project).Error; err != nil {
+		if err := DB.Model(&model.Project{}).Where("id = ?", alert.ProjectID).Take(&project).Error; err != nil {
 			return errors.Wrap(err, "error querying project for processMetricMonitor")
 		}
 		var workspace model.Workspace
-		if err := DB.Where(&model.Workspace{Model: model.Model{ID: project.WorkspaceID}}).First(&workspace).Error; err != nil {
+		if err := DB.Where(&model.Workspace{Model: model.Model{ID: project.WorkspaceID}}).Take(&workspace).Error; err != nil {
 			return errors.Wrap(err, "error querying workspace for processMetricMonitor")
 		}
 

--- a/backend/jobs/metric-monitor/metric-monitor.go
+++ b/backend/jobs/metric-monitor/metric-monitor.go
@@ -93,12 +93,12 @@ func processMetricMonitors(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, 
 
 		if value >= metricMonitor.Threshold {
 			var project model.Project
-			if err := DB.Model(&model.Project{}).Where("id = ?", metricMonitor.ProjectID).First(&project).Error; err != nil {
+			if err := DB.Model(&model.Project{}).Where("id = ?", metricMonitor.ProjectID).Take(&project).Error; err != nil {
 				log.WithContext(ctx).Error("error querying project for processMetricMonitor", err)
 				return
 			}
 			var workspace model.Workspace
-			if err := DB.Where(&model.Workspace{Model: model.Model{ID: project.WorkspaceID}}).First(&workspace).Error; err != nil {
+			if err := DB.Where(&model.Workspace{Model: model.Model{ID: project.WorkspaceID}}).Take(&workspace).Error; err != nil {
 				log.WithContext(ctx).Error("error querying workspace for processMetricMonitor", err)
 				return
 			}

--- a/backend/oauth/oauth.go
+++ b/backend/oauth/oauth.go
@@ -58,7 +58,7 @@ func getTokenStore() *oredis.TokenStore {
 
 func (s *Server) getClientSecret(clientID string) (clientSecret string, err error) {
 	client := &model.OAuthClientStore{}
-	if err := s.db.Model(&client).Where(&model.OAuthClientStore{ID: clientID}).First(&client).Error; err != nil {
+	if err := s.db.Model(&client).Where(&model.OAuthClientStore{ID: clientID}).Take(&client).Error; err != nil {
 		return "", errors.ErrInvalidClient
 	}
 
@@ -142,7 +142,7 @@ func CreateServer(ctx context.Context, db *gorm.DB) (*Server, error) {
 func (s *Server) UserAuthorizationHandler(_ http.ResponseWriter, r *http.Request) (userID string, err error) {
 	uid := fmt.Sprintf("%v", r.Context().Value(model.ContextKeys.UID))
 	admin := &model.Admin{UID: &uid}
-	if err := s.db.Where(&model.Admin{UID: &uid}).First(&admin).Error; err != nil {
+	if err := s.db.Where(&model.Admin{UID: &uid}).Take(&admin).Error; err != nil {
 		return "", errors.ErrUnauthorizedClient
 	}
 	return fmt.Sprintf("%s:%s", *admin.UID, *admin.Email), nil

--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -519,7 +519,7 @@ func ReportUsageForWorkspace(ctx context.Context, DB *gorm.DB, ccClient *clickho
 
 func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, stripeClient *client.API, mailClient *sendgrid.Client, workspaceID int, productType *ProductType) error {
 	var workspace model.Workspace
-	if err := DB.Model(&workspace).Where("id = ?", workspaceID).First(&workspace).Error; err != nil {
+	if err := DB.Model(&workspace).Where("id = ?", workspaceID).Take(&workspace).Error; err != nil {
 		return e.Wrap(err, "error querying workspace")
 	}
 	var projects []model.Project

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -868,6 +868,9 @@ func ErrorInputToParams(params *modelInputs.ErrorSearchParamsInput) *model.Error
 }
 
 func (r *Resolver) doesAdminOwnErrorGroup(ctx context.Context, errorGroupSecureID string) (*model.ErrorGroup, bool, error) {
+	s, ctx := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("doesAdminOwnErrorGroup"))
+	defer s.Finish()
+
 	eg := &model.ErrorGroup{}
 
 	if err := r.DB.Where(&model.ErrorGroup{SecureID: errorGroupSecureID}).Take(&eg).Error; err != nil {
@@ -879,6 +882,13 @@ func (r *Resolver) doesAdminOwnErrorGroup(ctx context.Context, errorGroupSecureI
 		return eg, false, err
 	}
 
+	start := time.Now()
+	defer func() {
+		log.WithContext(ctx).WithField("duration", time.Since(start)).Info("doesAdminOwnErrorGroup.GetErrorGroupOccurrences")
+	}()
+
+	s, ctx = tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("doesAdminOwnErrorGroup.GetErrorGroupOccurrences"))
+	defer s.Finish()
 	if eg.FirstOccurrence, eg.LastOccurrence, err = r.GetErrorGroupOccurrences(ctx, eg); err != nil {
 		return nil, false, e.Wrap(err, "error querying error group occurrences")
 	}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -66,7 +66,7 @@ import (
 // Author is the resolver for the author field.
 func (r *commentReplyResolver) Author(ctx context.Context, obj *model.CommentReply) (*modelInputs.SanitizedAdmin, error) {
 	admin := &model.Admin{}
-	if err := r.DB.Where(&model.Admin{Model: model.Model{ID: obj.AdminId}}).First(&admin).Error; err != nil {
+	if err := r.DB.Where(&model.Admin{Model: model.Model{ID: obj.AdminId}}).Take(&admin).Error; err != nil {
 		return nil, e.Wrap(err, "Error finding admin author for comment reply")
 	}
 
@@ -111,7 +111,7 @@ func (r *errorAlertResolver) DailyFrequency(ctx context.Context, obj *model.Erro
 // Author is the resolver for the author field.
 func (r *errorCommentResolver) Author(ctx context.Context, obj *model.ErrorComment) (*modelInputs.SanitizedAdmin, error) {
 	admin := &model.Admin{}
-	if err := r.DB.Where(&model.Admin{Model: model.Model{ID: obj.AdminId}}).First(&admin).Error; err != nil {
+	if err := r.DB.Where(&model.Admin{Model: model.Model{ID: obj.AdminId}}).Take(&admin).Error; err != nil {
 		return nil, e.Wrap(err, "Error finding admin for comment")
 	}
 
@@ -226,7 +226,7 @@ func (r *errorObjectResolver) Session(ctx context.Context, obj *model.ErrorObjec
 		return nil, nil
 	}
 	session := &model.Session{}
-	if err := r.DB.Where("id = ?", obj.SessionID).First(&session).Error; err != nil {
+	if err := r.DB.Where("id = ?", obj.SessionID).Take(&session).Error; err != nil {
 		return nil, e.Wrap(err, "error reading session from error object")
 	}
 	return session, nil
@@ -706,7 +706,7 @@ func (r *mutationResolver) MarkErrorGroupAsViewed(ctx context.Context, errorSecu
 	updatedFields := &model.ErrorGroup{
 		Viewed: viewed,
 	}
-	if err := r.DB.Where(&model.ErrorGroup{Model: model.Model{ID: eg.ID}}).First(&newErrorGroup).Updates(updatedFields).Error; err != nil {
+	if err := r.DB.Where(&model.ErrorGroup{Model: model.Model{ID: eg.ID}}).Take(&newErrorGroup).Updates(updatedFields).Error; err != nil {
 		return nil, e.Wrap(err, "error writing error as viewed")
 	}
 
@@ -800,7 +800,7 @@ func (r *mutationResolver) MarkSessionAsViewed(ctx context.Context, secureID str
 	updatedFields := &model.Session{
 		Viewed: viewed,
 	}
-	if err := r.DB.Where(&model.Session{Model: model.Model{ID: s.ID}}).First(&newSession).Updates(updatedFields).Error; err != nil {
+	if err := r.DB.Where(&model.Session{Model: model.Model{ID: s.ID}}).Take(&newSession).Updates(updatedFields).Error; err != nil {
 		return nil, e.Wrap(err, "error writing session as viewed")
 	}
 
@@ -833,7 +833,7 @@ func (r *mutationResolver) MarkSessionAsStarred(ctx context.Context, secureID st
 		return nil, err
 	}
 	session := &model.Session{}
-	if err := r.DB.Where(&model.Session{Model: model.Model{ID: s.ID}}).First(&session).Updates(&model.Session{
+	if err := r.DB.Where(&model.Session{Model: model.Model{ID: s.ID}}).Take(&session).Updates(&model.Session{
 		Starred: starred,
 	}).Error; err != nil {
 		return nil, e.Wrap(err, "error writing session as starred")
@@ -949,6 +949,7 @@ func (r *mutationResolver) JoinWorkspace(ctx context.Context, workspaceID int) (
 	if err != nil {
 		return nil, e.Wrap(err, "error getting custom verified admin email domain")
 	}
+	// if more than one workspace has the auto join email origin, pick the first (oldest) one
 	workspace := &model.Workspace{Model: model.Model{ID: workspaceID}}
 	if err := r.DB.Model(&workspace).Where("jsonb_exists(allowed_auto_join_email_origins::jsonb, LOWER(?))", domain).First(workspace).Error; err != nil {
 		return nil, e.Wrap(err, "error querying workspace")
@@ -1381,7 +1382,7 @@ func (r *mutationResolver) CreateSessionComment(ctx context.Context, projectID i
 	}
 
 	var project model.Project
-	if err := r.DB.Where(&model.Project{Model: model.Model{ID: projectID}}).First(&project).Error; err != nil {
+	if err := r.DB.Where(&model.Project{Model: model.Model{ID: projectID}}).Take(&project).Error; err != nil {
 		return nil, err
 	}
 
@@ -1618,7 +1619,7 @@ func (r *mutationResolver) CreateSessionComment(ctx context.Context, projectID i
 // CreateIssueForSessionComment is the resolver for the createIssueForSessionComment field.
 func (r *mutationResolver) CreateIssueForSessionComment(ctx context.Context, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueDescription *string, issueTeamID *string, integrations []*modelInputs.IntegrationType) (*model.SessionComment, error) {
 	var project model.Project
-	if err := r.DB.Where("id = ?", projectID).First(&project).Error; err != nil {
+	if err := r.DB.Where("id = ?", projectID).Take(&project).Error; err != nil {
 		return nil, err
 	}
 
@@ -1677,7 +1678,7 @@ func (r *mutationResolver) CreateIssueForSessionComment(ctx context.Context, pro
 // DeleteSessionComment is the resolver for the deleteSessionComment field.
 func (r *mutationResolver) DeleteSessionComment(ctx context.Context, id int) (*bool, error) {
 	var sessionComment model.SessionComment
-	if err := r.DB.Where(model.SessionComment{Model: model.Model{ID: id}}).First(&sessionComment).Error; err != nil {
+	if err := r.DB.Where(model.SessionComment{Model: model.Model{ID: id}}).Take(&sessionComment).Error; err != nil {
 		return nil, e.Wrap(err, "error querying session comment")
 	}
 
@@ -1725,7 +1726,7 @@ func (r *mutationResolver) DeleteSessionComment(ctx context.Context, id int) (*b
 // MuteSessionCommentThread is the resolver for the muteSessionCommentThread field.
 func (r *mutationResolver) MuteSessionCommentThread(ctx context.Context, id int, hasMuted *bool) (*bool, error) {
 	var sessionComment model.SessionComment
-	if err := r.DB.Where(model.SessionComment{Model: model.Model{ID: id}}).First(&sessionComment).Error; err != nil {
+	if err := r.DB.Where(model.SessionComment{Model: model.Model{ID: id}}).Take(&sessionComment).Error; err != nil {
 		return nil, e.Wrap(err, "error querying session comment")
 	}
 
@@ -1740,7 +1741,7 @@ func (r *mutationResolver) MuteSessionCommentThread(ctx context.Context, id int,
 	}
 
 	var commentFollower model.CommentFollower
-	if err := r.DB.Where(&model.CommentFollower{SessionCommentID: id, AdminId: admin.ID}).First(&commentFollower).Updates(
+	if err := r.DB.Where(&model.CommentFollower{SessionCommentID: id, AdminId: admin.ID}).Take(&commentFollower).Updates(
 		&model.CommentFollower{
 			HasMuted: hasMuted,
 		}).Error; err != nil {
@@ -1758,7 +1759,7 @@ func (r *mutationResolver) ReplyToSessionComment(ctx context.Context, commentID 
 	}
 
 	var sessionComment model.SessionComment
-	if err := r.DB.Preload("Followers").Preload("Threads").Where(model.SessionComment{Model: model.Model{ID: commentID}}).First(&sessionComment).Error; err != nil {
+	if err := r.DB.Preload("Followers").Preload("Threads").Where(model.SessionComment{Model: model.Model{ID: commentID}}).Take(&sessionComment).Error; err != nil {
 		return nil, e.Wrap(err, "error querying session comment")
 	}
 
@@ -1769,7 +1770,7 @@ func (r *mutationResolver) ReplyToSessionComment(ctx context.Context, commentID 
 	}
 
 	var project model.Project
-	if err := r.DB.Where(&model.Project{Model: model.Model{ID: sessionComment.ProjectID}}).First(&project).Error; err != nil {
+	if err := r.DB.Where(&model.Project{Model: model.Model{ID: sessionComment.ProjectID}}).Take(&project).Error; err != nil {
 		return nil, err
 	}
 
@@ -1868,7 +1869,7 @@ func (r *mutationResolver) CreateErrorComment(ctx context.Context, projectID int
 	}
 
 	var project model.Project
-	if err := r.DB.Where(&model.Project{Model: model.Model{ID: projectID}}).First(&project).Error; err != nil {
+	if err := r.DB.Where(&model.Project{Model: model.Model{ID: projectID}}).Take(&project).Error; err != nil {
 		return nil, err
 	}
 
@@ -2096,7 +2097,7 @@ func (r *mutationResolver) MuteErrorCommentThread(ctx context.Context, id int, h
 // CreateIssueForErrorComment is the resolver for the createIssueForErrorComment field.
 func (r *mutationResolver) CreateIssueForErrorComment(ctx context.Context, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueTeamID *string, integrations []*modelInputs.IntegrationType) (*model.ErrorComment, error) {
 	var project model.Project
-	if err := r.DB.Where(&model.Project{Model: model.Model{ID: projectID}}).First(&project).Error; err != nil {
+	if err := r.DB.Where(&model.Project{Model: model.Model{ID: projectID}}).Take(&project).Error; err != nil {
 		return nil, err
 	}
 
@@ -2198,7 +2199,7 @@ func (r *mutationResolver) ReplyToErrorComment(ctx context.Context, commentID in
 	}
 
 	var errorComment model.ErrorComment
-	if err := r.DB.Preload("Threads").Preload("Followers").Where(model.ErrorComment{Model: model.Model{ID: commentID}}).First(&errorComment).Error; err != nil {
+	if err := r.DB.Preload("Threads").Preload("Followers").Where(model.ErrorComment{Model: model.Model{ID: commentID}}).Take(&errorComment).Error; err != nil {
 		return nil, e.Wrap(err, "error querying error comment")
 	}
 
@@ -2208,7 +2209,7 @@ func (r *mutationResolver) ReplyToErrorComment(ctx context.Context, commentID in
 	}
 
 	var project model.Project
-	if err := r.DB.Where(&model.Project{Model: model.Model{ID: errorComment.ProjectID}}).First(&project).Error; err != nil {
+	if err := r.DB.Where(&model.Project{Model: model.Model{ID: errorComment.ProjectID}}).Take(&project).Error; err != nil {
 		return nil, err
 	}
 
@@ -3155,7 +3156,7 @@ func (r *mutationResolver) RequestAccess(ctx context.Context, projectID int) (*b
 	}
 
 	var project model.Project
-	if err := r.DB.Select("workspace_id").Where(&model.Project{Model: model.Model{ID: projectID}}).First(&project).Error; err != nil {
+	if err := r.DB.Select("workspace_id").Where(&model.Project{Model: model.Model{ID: projectID}}).Take(&project).Error; err != nil {
 		log.WithContext(ctx).Error(err)
 		return &model.T, nil
 	}
@@ -3313,7 +3314,7 @@ func (r *mutationResolver) UpsertDashboard(ctx context.Context, id *int, project
 // DeleteDashboard is the resolver for the deleteDashboard field.
 func (r *mutationResolver) DeleteDashboard(ctx context.Context, id int) (bool, error) {
 	var dashboard model.Dashboard
-	if result := r.DB.First(&dashboard, id); result.Error != nil {
+	if result := r.DB.Take(&dashboard, id); result.Error != nil {
 		return false, result.Error
 	}
 
@@ -3558,7 +3559,7 @@ func (r *mutationResolver) UpdateIntegrationProjectMappings(ctx context.Context,
 	if err := r.DB.Where(&model.IntegrationWorkspaceMapping{
 		WorkspaceID:     workspace.ID,
 		IntegrationType: integrationType,
-	}).First(&workspaceMapping).Error; err != nil {
+	}).Take(&workspaceMapping).Error; err != nil {
 		return false, e.Wrap(err, fmt.Sprintf("workspace does not have a %s integration", integrationType))
 	}
 
@@ -3837,7 +3838,7 @@ func (r *queryResolver) AccountDetails(ctx context.Context, workspaceID int) (*m
 func (r *queryResolver) Session(ctx context.Context, secureID string) (*model.Session, error) {
 	if util.IsDevEnv() && secureID == "repro" {
 		sessionObj := &model.Session{}
-		if err := r.DB.Preload("Fields").Where(&model.Session{Model: model.Model{ID: 0}}).First(&sessionObj).Error; err != nil {
+		if err := r.DB.Preload("Fields").Where(&model.Session{Model: model.Model{ID: 0}}).Take(&sessionObj).Error; err != nil {
 			return nil, e.Wrap(err, "error reading from session")
 		}
 		return sessionObj, nil
@@ -4117,7 +4118,7 @@ func (r *queryResolver) ErrorObjects(ctx context.Context, errorGroupSecureID str
 // ErrorObjectForLog is the resolver for the error_object_for_log field.
 func (r *queryResolver) ErrorObjectForLog(ctx context.Context, logCursor string) (*model.ErrorObject, error) {
 	errorObject := &model.ErrorObject{}
-	if err := r.DB.Order("log_cursor").Model(&errorObject).Where(&model.ErrorObject{LogCursor: pointy.String(logCursor)}).Limit(1).Find(&errorObject).Error; err != nil || errorObject.ID == 0 {
+	if err := r.DB.Model(&errorObject).Where(&model.ErrorObject{LogCursor: pointy.String(logCursor)}).Take(&errorObject).Error; err != nil {
 		return nil, e.New("no error found for log cursor " + logCursor)
 	}
 	errorObject, err := r.canAdminViewErrorObject(ctx, errorObject.ID)
@@ -4147,7 +4148,7 @@ func (r *queryResolver) ErrorInstance(ctx context.Context, errorGroupSecureID st
 			return nil, e.Wrap(err, "error reading error object for instance")
 		}
 	} else {
-		if err := errorObjectQuery.Where(&model.ErrorObject{Model: model.Model{ID: *errorObjectID}}).First(&errorObject).Error; err != nil {
+		if err := errorObjectQuery.Where(&model.ErrorObject{Model: model.Model{ID: *errorObjectID}}).Take(&errorObject).Error; err != nil {
 			return nil, e.Wrap(err, "error reading error object for instance")
 		}
 	}
@@ -4206,7 +4207,7 @@ func (r *queryResolver) EnhancedUserDetails(ctx context.Context, sessionSecureID
 	// preload `Fields` children
 	sessionObj := &model.Session{}
 	// TODO: filter fields by type='user'.
-	if err := r.DB.Preload("Fields").Where(&model.Session{Model: model.Model{ID: s.ID}}).First(&sessionObj).Error; err != nil {
+	if err := r.DB.Preload("Fields").Where(&model.Session{Model: model.Model{ID: s.ID}}).Take(&sessionObj).Error; err != nil {
 		return nil, e.Wrap(err, "error reading from session")
 	}
 	details := &modelInputs.EnhancedUserDetailsResult{}
@@ -4227,7 +4228,7 @@ func (r *queryResolver) EnhancedUserDetails(ctx context.Context, sessionSecureID
 		// If so, return it
 		userDetailsModel := &model.EnhancedUserDetails{}
 		p, co := clearbit.Person{}, clearbit.Company{}
-		if err := r.DB.Where(&model.EnhancedUserDetails{Email: &email}).First(&userDetailsModel).Error; err != nil {
+		if err := r.DB.Where(&model.EnhancedUserDetails{Email: &email}).Take(&userDetailsModel).Error; err != nil {
 			if !w.ClearbitEnabled {
 				return nil, nil
 			}
@@ -4573,7 +4574,7 @@ func (r *queryResolver) IsIntegrated(ctx context.Context, projectID int) (*bool,
 	}
 
 	firstSession := model.Session{}
-	err := r.DB.Model(&model.Session{}).Where("project_id = ?", projectID).First(&firstSession).Error
+	err := r.DB.Model(&model.Session{}).Where("project_id = ?", projectID).Take(&firstSession).Error
 	if e.Is(err, gorm.ErrRecordNotFound) {
 		return &model.F, nil
 	}
@@ -4611,8 +4612,10 @@ func (r *queryResolver) ClientIntegration(ctx context.Context, projectID int) (*
 	}
 
 	setupEvent := model.SetupEvent{}
-	if err := r.DB.Model(&model.SetupEvent{}).Where("project_id = ? AND type = ?", projectID, model.MarkBackendSetupTypeSession).Limit(1).Find(&setupEvent).Error; err != nil {
-		return nil, e.Wrap(err, "error querying logging setup event")
+	if err := r.DB.Model(&model.SetupEvent{}).Where("project_id = ? AND type = ?", projectID, model.MarkBackendSetupTypeSession).Take(&setupEvent).Error; err != nil {
+		if !e.Is(err, gorm.ErrRecordNotFound) {
+			return nil, e.Wrap(err, "error querying logging setup event")
+		}
 	}
 
 	if setupEvent.ID != 0 {
@@ -4634,8 +4637,10 @@ func (r *queryResolver) ServerIntegration(ctx context.Context, projectID int) (*
 	}
 
 	setupEvent := model.SetupEvent{}
-	if err := r.DB.Model(&model.SetupEvent{}).Where("project_id = ? AND type = ?", projectID, model.MarkBackendSetupTypeError).Limit(1).Find(&setupEvent).Error; err != nil {
-		return nil, e.Wrap(err, "error querying error setup event")
+	if err := r.DB.Model(&model.SetupEvent{}).Where("project_id = ? AND type = ?", projectID, model.MarkBackendSetupTypeError).Take(&setupEvent).Error; err != nil {
+		if !e.Is(err, gorm.ErrRecordNotFound) {
+			return nil, e.Wrap(err, "error querying error setup event")
+		}
 	}
 
 	if setupEvent.ID != 0 {
@@ -4658,9 +4663,11 @@ func (r *queryResolver) LogsIntegration(ctx context.Context, projectID int) (*mo
 	}
 
 	setupEvent := model.SetupEvent{}
-	err = r.DB.Model(&model.SetupEvent{}).Where("project_id = ? AND type = ?", projectID, model.MarkBackendSetupTypeLogs).Limit(1).Find(&setupEvent).Error
+	err = r.DB.Model(&model.SetupEvent{}).Where("project_id = ? AND type = ?", projectID, model.MarkBackendSetupTypeLogs).Take(&setupEvent).Error
 	if err != nil {
-		return nil, e.Wrap(err, "error querying logging setup event")
+		if !e.Is(err, gorm.ErrRecordNotFound) {
+			return nil, e.Wrap(err, "error querying logging setup event")
+		}
 	}
 
 	if setupEvent.ID != 0 {
@@ -4728,7 +4735,7 @@ func (r *queryResolver) LiveUsersCount(ctx context.Context, projectID int) (*int
 func (r *queryResolver) AdminHasCreatedComment(ctx context.Context, adminID int) (*bool, error) {
 	if err := r.DB.Model(&model.SessionComment{}).Where(&model.SessionComment{
 		AdminId: adminID,
-	}).First(&model.SessionComment{}).Error; err != nil {
+	}).Take(&model.SessionComment{}).Error; err != nil {
 		return &model.F, nil
 	}
 
@@ -4742,7 +4749,7 @@ func (r *queryResolver) ProjectHasViewedASession(ctx context.Context, projectID 
 	}
 
 	session := model.Session{}
-	if err := r.DB.Model(&session).Where("project_id = ?", projectID).Where(&model.Session{Viewed: &model.T, Excluded: false}).First(&session).Error; err != nil {
+	if err := r.DB.Model(&session).Where("project_id = ?", projectID).Where(&model.Session{Viewed: &model.T, Excluded: false}).Take(&session).Error; err != nil {
 		return &session, nil
 	}
 	return &session, nil
@@ -6028,7 +6035,7 @@ func (r *queryResolver) IsWorkspaceIntegratedWith(ctx context.Context, integrati
 		if err := r.DB.Where(&model.IntegrationWorkspaceMapping{
 			WorkspaceID:     workspace.ID,
 			IntegrationType: integrationType,
-		}).First(&workspaceMapping).Error; err != nil {
+		}).Take(&workspaceMapping).Error; err != nil {
 			return false, nil
 		}
 
@@ -6402,7 +6409,7 @@ func (r *queryResolver) Workspace(ctx context.Context, id int) (*model.Workspace
 // WorkspaceForInviteLink is the resolver for the workspace_for_invite_link field.
 func (r *queryResolver) WorkspaceForInviteLink(ctx context.Context, secret string) (*modelInputs.WorkspaceForInviteLink, error) {
 	var workspaceInviteLink model.WorkspaceInviteLink
-	if err := r.DB.Where(&model.WorkspaceInviteLink{Secret: &secret}).First(&workspaceInviteLink).Error; err != nil {
+	if err := r.DB.Where(&model.WorkspaceInviteLink{Secret: &secret}).Take(&workspaceInviteLink).Error; err != nil {
 		return nil, e.Wrap(err, "error querying workspace invite link")
 	}
 
@@ -6411,13 +6418,13 @@ func (r *queryResolver) WorkspaceForInviteLink(ctx context.Context, secret strin
 	}
 
 	var workspace model.Workspace
-	if err := r.DB.Model(&model.Workspace{}).Where("id = ?", *workspaceInviteLink.WorkspaceID).First(&workspace).Error; err != nil {
+	if err := r.DB.Model(&model.Workspace{}).Where("id = ?", *workspaceInviteLink.WorkspaceID).Take(&workspace).Error; err != nil {
 		return nil, e.Wrap(err, "error querying workspace for invite link")
 	}
 
 	var admin *model.Admin
 	if workspaceInviteLink.InviteeEmail != nil {
-		if err := r.DB.Model(&model.Admin{Email: workspaceInviteLink.InviteeEmail}).First(&admin).Error; err != nil {
+		if err := r.DB.Model(&model.Admin{Email: workspaceInviteLink.InviteeEmail}).Take(&admin).Error; err != nil {
 			return nil, e.Wrap(err, "error querying admin for invitee_email")
 		}
 	}
@@ -6444,7 +6451,7 @@ func (r *queryResolver) WorkspaceInviteLinks(ctx context.Context, workspaceID in
 	var workspaceInviteLink *model.WorkspaceInviteLink
 	shouldCreateNewInviteLink := false
 
-	if err := r.DB.Where(&model.WorkspaceInviteLink{WorkspaceID: &workspaceID, InviteeEmail: nil}).Where("invitee_email IS NULL").Order("created_at desc").First(&workspaceInviteLink).Error; err != nil {
+	if err := r.DB.Where(&model.WorkspaceInviteLink{WorkspaceID: &workspaceID, InviteeEmail: nil}).Where("invitee_email IS NULL").Order("created_at desc").Take(&workspaceInviteLink).Error; err != nil {
 		if e.Is(err, gorm.ErrRecordNotFound) {
 			shouldCreateNewInviteLink = true
 		} else {
@@ -6543,7 +6550,7 @@ func (r *queryResolver) Admin(ctx context.Context) (*model.Admin, error) {
 	adminSpan, ctx := tracer.StartSpanFromContext(ctx, "resolver.getAdmin", tracer.ResourceName("db.admin"),
 		tracer.Tag("admin_uid", admin.UID))
 
-	if err := r.DB.Where(&model.Admin{UID: admin.UID}).First(&admin).Error; err != nil {
+	if err := r.DB.Where(&model.Admin{UID: admin.UID}).Take(&admin).Error; err != nil {
 		if e.Is(err, gorm.ErrRecordNotFound) {
 			// Sometimes users don't exist in our DB because they authenticated with
 			// Google auth and never went through the sign up flow. In this case, we
@@ -7193,8 +7200,11 @@ func (r *queryResolver) SourcemapVersions(ctx context.Context, projectID int) ([
 
 // OauthClientMetadata is the resolver for the oauth_client_metadata field.
 func (r *queryResolver) OauthClientMetadata(ctx context.Context, clientID string) (*modelInputs.OAuthClient, error) {
+	if clientID == "" {
+		return nil, e.New("oauth client query received empty client id")
+	}
 	client := &model.OAuthClientStore{ID: clientID}
-	if err := r.DB.Model(&client).Select("id", "created_at", "app_name").Where(&client).First(&client).Error; err != nil {
+	if err := r.DB.Model(&client).Select("id", "created_at", "app_name").Where(&client).Take(&client).Error; err != nil {
 		return nil, e.Wrap(err, "error querying oauth client")
 	}
 	return &modelInputs.OAuthClient{
@@ -7543,7 +7553,7 @@ func (r *sessionResolver) DeviceMemory(ctx context.Context, obj *model.Session) 
 	  SELECT metrics.*
 	  FROM metrics
 	  WHERE metrics.name = ?
-	  AND metric_group_id in (SELECT * FROM filtered_group_ids)`, obj.ID, "DeviceMemory").First(&metric).Error; err != nil {
+	  AND metric_group_id in (SELECT * FROM filtered_group_ids)`, obj.ID, "DeviceMemory").Take(&metric).Error; err != nil {
 		if !e.Is(err, gorm.ErrRecordNotFound) {
 			log.WithContext(ctx).Error(err)
 		}
@@ -7632,7 +7642,7 @@ func (r *sessionCommentResolver) Author(ctx context.Context, obj *model.SessionC
 		return feedbackAdmin, nil
 	}
 
-	if err := r.DB.Where(&model.Admin{Model: model.Model{ID: obj.AdminId}}).First(&admin).Error; err != nil {
+	if err := r.DB.Where(&model.Admin{Model: model.Model{ID: obj.AdminId}}).Take(&admin).Error; err != nil {
 		return nil, e.Wrap(err, "Error finding admin for comment")
 	}
 

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -72,7 +72,7 @@ func TestProcessBackendPayloadImpl(t *testing.T) {
 		var result *model.ErrorObject
 		err := resolver.DB.Model(&model.ErrorObject{
 			ProjectID: project.ID,
-		}).Where(&model.ErrorObject{Event: "dummy event"}).First(&result).Error
+		}).Where(&model.ErrorObject{Event: "dummy event"}).Take(&result).Error
 		assert.NoError(t, err)
 
 		if *result.StackTrace != trpcTraceStr {

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -189,7 +189,7 @@ func (store *Store) updateErrorGroupState(ctx context.Context,
 		Model: model.Model{
 			ID: params.ID,
 		},
-	}).First(&errorGroup).Updates(map[string]interface{}{
+	}).Take(&errorGroup).Updates(map[string]interface{}{
 		"State":        params.State,
 		"SnoozedUntil": params.SnoozedUntil,
 	}).Error; err != nil {

--- a/backend/store/projects.go
+++ b/backend/store/projects.go
@@ -11,7 +11,7 @@ func (store *Store) GetProject(id int) (model.Project, error) {
 		Model: model.Model{
 			ID: id,
 		},
-	}).First(&project).Error
+	}).Take(&project).Error
 
 	return project, err
 }

--- a/backend/store/sessions.go
+++ b/backend/store/sessions.go
@@ -9,7 +9,7 @@ func (store *Store) GetSession(sessionID int) (model.Session, error) {
 		Model: model.Model{
 			ID: sessionID,
 		},
-	}).First(&session).Error
+	}).Take(&session).Error
 
 	return session, err
 }

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -271,7 +271,7 @@ func (w *Worker) getSessionID(ctx context.Context, sessionSecureID string) (id i
 		return 0, e.New("getSessionID called with no secure id")
 	}
 	session := &model.Session{}
-	w.Resolver.DB.Order("secure_id").Select("id").Where(&model.Session{SecureID: sessionSecureID}).Limit(1).Find(&session)
+	w.Resolver.DB.Select("id").Where(&model.Session{SecureID: sessionSecureID}).Take(&session)
 	if session.ID == 0 {
 		return 0, e.New(fmt.Sprintf("no session found for secure id: '%s'", sessionSecureID))
 	}
@@ -539,7 +539,7 @@ func (w *Worker) excludeSession(ctx context.Context, s *model.Session, reason ba
 
 func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 	project := &model.Project{}
-	if err := w.Resolver.DB.Where(&model.Project{Model: model.Model{ID: s.ProjectID}}).First(&project).Error; err != nil {
+	if err := w.Resolver.DB.Where(&model.Project{Model: model.Model{ID: s.ProjectID}}).Take(&project).Error; err != nil {
 		return e.Wrap(err, "error querying project")
 	}
 
@@ -1254,7 +1254,7 @@ func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
 
 	for _, c := range counts {
 		workspace := &model.Workspace{}
-		if err := w.Resolver.DB.Preload("Projects").Model(&model.Workspace{}).Where("id = ?", c.WorkspaceID).First(&workspace).Error; err != nil {
+		if err := w.Resolver.DB.Preload("Projects").Model(&model.Workspace{}).Where("id = ?", c.WorkspaceID).Take(&workspace).Error; err != nil {
 			continue
 		}
 		for _, p := range workspace.Projects {

--- a/backend/zapier/hook_store.go
+++ b/backend/zapier/hook_store.go
@@ -52,7 +52,7 @@ func (s *ZapierResthookStore) Save(sub *resthooks.Subscription, r *http.Request)
 func (s *ZapierResthookStore) FindById(id int) (*resthooks.Subscription, error) {
 	hookSub := model.ResthookSubscription{}
 
-	if err := s.DB.Where(&model.ResthookSubscription{Model: model.Model{ID: id}}).First(&hookSub).Error; err != nil {
+	if err := s.DB.Where(&model.ResthookSubscription{Model: model.Model{ID: id}}).Take(&hookSub).Error; err != nil {
 		return nil, e.Wrap(err, "error finding resthook subscription by id")
 	}
 
@@ -69,7 +69,7 @@ func (s *ZapierResthookStore) FindById(id int) (*resthooks.Subscription, error) 
 func (s *ZapierResthookStore) FindByUserId(project_id int, event string) (*resthooks.Subscription, error) {
 	hookSub := model.ResthookSubscription{}
 
-	if err := s.DB.Where(&model.ResthookSubscription{ProjectID: project_id, Event: &event}).First(&hookSub).Error; err != nil {
+	if err := s.DB.Where(&model.ResthookSubscription{ProjectID: project_id, Event: &event}).Take(&hookSub).Error; err != nil {
 		return nil, e.Wrap(err, "error finding resthook subscription by event and project id")
 	}
 

--- a/backend/zapier/zapier.go
+++ b/backend/zapier/zapier.go
@@ -25,7 +25,7 @@ var (
 func getProjectForToken(parsedToken *ParsedZapierToken, db *gorm.DB) (*model.Project, error) {
 	project := model.Project{}
 
-	if err := db.Where(&model.Project{Model: model.Model{ID: parsedToken.ProjectID}}).First(&project).Error; err != nil {
+	if err := db.Where(&model.Project{Model: model.Model{ID: parsedToken.ProjectID}}).Take(&project).Error; err != nil {
 		return nil, e.Wrap(err, "error querying project")
 	}
 


### PR DESCRIPTION
## Summary

GORM's `Take` is essentially a `Limit(1).Find()` for one item, where if no item is found, an error is returned.
In most places, this makes more sense than our use of `First()` because we do not actually care about the ordering.
`First()` always adds a `ORDER BY` clause on the primary key, causing us to miss indexes in some situations
(we've had to manually bypass this for querying sessions by secure id). This cleans up the code and
makes it consistent for faster loading of error groups. 

## How did you test this change?

Testing locally. https://www.loom.com/share/faaf23aafa5049fdb63aa08f06ef50e4

before
```sql
SELECT *
FROM "error_groups"
WHERE "error_groups"."secure_id" = 'O5am2YlVI3A6Cj8V9sUIgzDxTjkl'
ORDER BY "error_groups"."id"
LIMIT 1;
```
after
```sql
SELECT * 
FROM "error_groups" 
WHERE "error_groups"."secure_id" = 'D8Bon2X2pbnA0TCSTUO0sr9zaPeM' 
LIMIT 1
```

some new instrumentation on the influx part of the loading
![image](https://github.com/highlight/highlight/assets/1351531/1aba2569-6057-4263-bbbf-6a8928bfaba6)


## Are there any deployment considerations?

Will monitor deployment for errors. The risky part is that changing from `First()` to `Take()` means the `.Error` will return something now if no results are found, while `First()` would return `nil`. I've tried to vet the changes to make sure that's ok (and make according adjustments where necessary to check the error type), but let me know if I missed any.