### PR TITLE
update excluded / excluded reason in opensearch w/ sql update

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2628,6 +2628,13 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			}).Error; err != nil {
 				return err
 			}
+			if err := r.OpenSearch.UpdateAsync(ctx, opensearch.IndexSessions, sessionObj.ID, map[string]interface{}{
+				"Excluded":       excluded,
+				"ExcludedReason": reason,
+			}); err != nil {
+				log.WithContext(ctx).Error(e.Wrap(err, "error updating session in opensearch"))
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- if a session was being excluded for an ignored user, its excluded flag / reason was updated in postgres but not updated in opensearch
- these sessions would keep showing as live since excluded sessions are skipped by the session processing worker
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- local click test
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
