### PR TITLE
disable lambda size verification in forks

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -76,6 +76,8 @@ jobs:
               run: yarn test:render
 
             - name: Validate session screenshot lambda size
+              # this can only run after `yarn test:render` runs
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
               run: yarn workspace render zip && yarn workspace render check
 
             - name: Validate project is ready to be published


### PR DESCRIPTION
## Summary

Disable lambda size checking in forks as it needs to run `yarn test:render` first (cannot run in forks).

## How did you test this change?

CI

## Are there any deployment considerations?

No