### PR TITLE
don't publish client in non-main

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -89,7 +89,7 @@ jobs:
             # any previous builds, while doing this in PR will allow the PR frontend preview
             # to reference the PR's latest version of client
             - name: Publish client bundle
-              if: steps.filter.outputs.npm-changed == 'true' && (github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main')
+              if: steps.filter.outputs.npm-changed == 'true' && github.ref == 'refs/heads/main'
               run: yarn publish:client
 
             - name: Upload frontend sourcemaps


### PR DESCRIPTION
## Summary
- don't publish versions of the client bundle in PRs
- this causes 2 issues otherwise:
  - earlier versions of the bundle can be cached in Cloudfront
  - later PRs can overwrite published versions with old code
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor change in Prod after deployment to ensure `Publish client bundle` is skipped
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
