### PR TITLE
use fingerprint as fallback in the error instances view

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -429,9 +429,10 @@ type ComplexityRoot struct {
 	}
 
 	ErrorObjectNodeSession struct {
-		AppVersion func(childComplexity int) int
-		Email      func(childComplexity int) int
-		SecureID   func(childComplexity int) int
+		AppVersion  func(childComplexity int) int
+		Email       func(childComplexity int) int
+		Fingerprint func(childComplexity int) int
+		SecureID    func(childComplexity int) int
 	}
 
 	ErrorResults struct {
@@ -3342,6 +3343,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ErrorObjectNodeSession.Email(childComplexity), true
+
+	case "ErrorObjectNodeSession.fingerprint":
+		if e.complexity.ErrorObjectNodeSession.Fingerprint == nil {
+			break
+		}
+
+		return e.complexity.ErrorObjectNodeSession.Fingerprint(childComplexity), true
 
 	case "ErrorObjectNodeSession.secureID":
 		if e.complexity.ErrorObjectNodeSession.SecureID == nil {
@@ -9326,6 +9334,7 @@ type ErrorObjectNodeSession {
 	secureID: String!
 	appVersion: String
 	email: String
+	fingerprint: Int
 }
 
 type ErrorObjectNode {
@@ -27563,6 +27572,8 @@ func (ec *executionContext) fieldContext_ErrorObjectNode_session(ctx context.Con
 				return ec.fieldContext_ErrorObjectNodeSession_appVersion(ctx, field)
 			case "email":
 				return ec.fieldContext_ErrorObjectNodeSession_email(ctx, field)
+			case "fingerprint":
+				return ec.fieldContext_ErrorObjectNodeSession_fingerprint(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorObjectNodeSession", field.Name)
 		},
@@ -27735,6 +27746,47 @@ func (ec *executionContext) fieldContext_ErrorObjectNodeSession_email(ctx contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ErrorObjectNodeSession_fingerprint(ctx context.Context, field graphql.CollectedField, obj *model.ErrorObjectNodeSession) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ErrorObjectNodeSession_fingerprint(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Fingerprint, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ErrorObjectNodeSession_fingerprint(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ErrorObjectNodeSession",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -65785,6 +65837,10 @@ func (ec *executionContext) _ErrorObjectNodeSession(ctx context.Context, sel ast
 		case "email":
 
 			out.Values[i] = ec._ErrorObjectNodeSession_email(ctx, field, obj)
+
+		case "fingerprint":
+
+			out.Values[i] = ec._ErrorObjectNodeSession_fingerprint(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -325,9 +325,10 @@ type ErrorObjectNode struct {
 }
 
 type ErrorObjectNodeSession struct {
-	SecureID   string  `json:"secureID"`
-	AppVersion *string `json:"appVersion"`
-	Email      *string `json:"email"`
+	SecureID    string  `json:"secureID"`
+	AppVersion  *string `json:"appVersion"`
+	Email       *string `json:"email"`
+	Fingerprint *int    `json:"fingerprint"`
 }
 
 type ErrorSearchParamsInput struct {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -613,6 +613,7 @@ type ErrorObjectNodeSession {
 	secureID: String!
 	appVersion: String
 	email: String
+	fingerprint: Int
 }
 
 type ErrorObjectNode {

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -27,7 +27,7 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 
 	var errorObjects []model.ErrorObject
 
-	query := store.db.
+	query := store.db.Debug().
 		Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).Limit(LIMIT + 1)
 
 	if params.Query != "" {
@@ -116,9 +116,10 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 			session, exists := sessionMap[*errorObject.SessionID]
 			if exists {
 				edge.Node.Session = &privateModel.ErrorObjectNodeSession{
-					SecureID:   session.SecureID,
-					Email:      session.Email,
-					AppVersion: session.AppVersion,
+					SecureID:    session.SecureID,
+					Email:       session.Email,
+					AppVersion:  session.AppVersion,
+					Fingerprint: &session.Fingerprint,
 				}
 			}
 		}

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -80,8 +80,9 @@ func TestListErrorObjectsOneObjectWithSession(t *testing.T) {
 		store.db.Create(&errorGroup)
 
 		session := model.Session{
-			AppVersion: ptr.String("123"),
-			Email:      ptr.String("chilly@mcwilly.com"),
+			AppVersion:  ptr.String("123"),
+			Email:       ptr.String("chilly@mcwilly.com"),
+			Fingerprint: 1234,
 		}
 
 		store.db.Create(&session)
@@ -104,9 +105,10 @@ func TestListErrorObjectsOneObjectWithSession(t *testing.T) {
 		assert.Equal(t, errorObject.Event, edge.Node.Event)
 		assert.Equal(t, errorGroup.SecureID, edge.Node.ErrorGroupSecureID)
 		assert.Equal(t, &privateModel.ErrorObjectNodeSession{
-			SecureID:   session.SecureID,
-			Email:      session.Email,
-			AppVersion: session.AppVersion,
+			SecureID:    session.SecureID,
+			Email:       session.Email,
+			AppVersion:  session.AppVersion,
+			Fingerprint: &session.Fingerprint,
 		}, edge.Node.Session)
 
 		assert.Equal(t, &privateModel.PageInfo{

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -13006,6 +13006,7 @@ export const GetErrorObjectsDocument = gql`
 						secureID
 						email
 						appVersion
+						fingerprint
 					}
 				}
 			}

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4391,7 +4391,10 @@ export type GetErrorObjectsQuery = { __typename?: 'Query' } & {
 									__typename?: 'ErrorObjectNodeSession'
 								} & Pick<
 									Types.ErrorObjectNodeSession,
-									'secureID' | 'email' | 'appVersion'
+									| 'secureID'
+									| 'email'
+									| 'appVersion'
+									| 'fingerprint'
 								>
 							>
 						}

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -544,6 +544,7 @@ export type ErrorObjectNodeSession = {
 	__typename?: 'ErrorObjectNodeSession'
 	appVersion?: Maybe<Scalars['String']>
 	email?: Maybe<Scalars['String']>
+	fingerprint?: Maybe<Scalars['Int']>
 	secureID: Scalars['String']
 }
 

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2107,6 +2107,7 @@ query GetErrorObjects(
 					secureID
 					email
 					appVersion
+					fingerprint
 				}
 			}
 		}

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -86,7 +86,10 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 				let sessionLink = ''
 
 				if (session) {
-					content = session.email ? session.email : '(no value)'
+					content =
+						session.email ??
+						session.fingerprint?.toString() ??
+						'(no value)'
 					const params = createSearchParams({
 						tsAbs: timestamp,
 						[PlayerSearchParameters.errorId]: errorObjectId,


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR uses the session's fingerprint as another fallback if email isn't available in the error instances listview.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Before:
![Screenshot 2023-07-13 at 12 49 44 PM](https://github.com/highlight/highlight/assets/58678/2565cc13-1557-4005-9c69-406f25f56a95)



After:
![Screenshot 2023-07-13 at 12 49 25 PM](https://github.com/highlight/highlight/assets/58678/58a0bb97-558d-434d-a377-2c1bfb81e302)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
