### PR TITLE
build frontend to be more similar to render

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -95,7 +95,7 @@ jobs:
               run: yarn publish:client
 
             - name: Upload frontend sourcemaps
-              if: github.ref == 'refs/heads/main'
+              #              if: github.ref == 'refs/heads/main'
               run: yarn && yarn sourcemaps:frontend
               env:
                   HIGHLIGHT_API_KEY: ${{ secrets.HIGHLIGHT_SOURCEMAP_API_KEY }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -18,9 +18,6 @@ jobs:
             TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
         steps:
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v2
-
             - name: Checkout
               uses: actions/checkout@v3
               with:
@@ -63,6 +60,9 @@ jobs:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   aws-region: us-east-2
+
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v2
 
             - name: Build & test
               run: doppler run -- yarn test:all

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -65,13 +65,12 @@ jobs:
               uses: dopplerhq/cli-action@v2
 
             - name: Build & test
-              run: doppler run -- yarn test:all
+              run: doppler run -- bash -c 'RENDER_PREVIEW=false yarn test:all'
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
                   GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
-                  RENDER_PREVIEW: false
 
             - name: Test session screenshot lambda
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -94,7 +94,7 @@ jobs:
               run: yarn publish:client
 
             - name: Upload frontend sourcemaps
-              #              if: github.ref == 'refs/heads/main'
+              if: github.ref == 'refs/heads/main'
               run: yarn && yarn sourcemaps:frontend
               env:
                   HIGHLIGHT_API_KEY: ${{ secrets.HIGHLIGHT_SOURCEMAP_API_KEY }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -65,11 +65,12 @@ jobs:
                   aws-region: us-east-2
 
             - name: Build & test
-              run: yarn test:all
+              run: doppler run -- RENDER_PREVIEW=false yarn test:all
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
                   GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
 
             - name: Test session screenshot lambda
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -65,12 +65,13 @@ jobs:
                   aws-region: us-east-2
 
             - name: Build & test
-              run: doppler run -- RENDER_PREVIEW=false yarn test:all
+              run: doppler run -- yarn test:all
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
                   GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
+                  RENDER_PREVIEW: false
 
             - name: Test session screenshot lambda
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'

--- a/highlight.io/components/MDXRemote/MarkdownList.tsx
+++ b/highlight.io/components/MDXRemote/MarkdownList.tsx
@@ -4,7 +4,6 @@ export function MarkdownList(
 		HTMLUListElement | HTMLOListElement
 	>,
 ) {
-	console.log('HI')
 	return (
 		<>
 			{Array.isArray(props.children) &&


### PR DESCRIPTION
## Summary

Based on [slack thread](https://highlightcorp.slack.com/archives/C02N2AZS8BV/p1689260173138899), we've seen 
a number of errors for our project in highlight having an invalid stack trace when enhanced. The root cause
seems to be that our sourcemap uploader uploads the `.js` and `.map` files from the github actions build,
but the app is hosted from a different build done by render.com. Since the code differs in the inlined environment,
the sourcemap lines/columns do not match up resulting in incorrect stack traces.

## How did you test this change?

Diffing the s3 sourcemap-uploaded index.js file against the prod app.highlight.run index.js
and comparing that to a local build with these changes.

## Are there any deployment considerations?

No, will monitor future sourcemaps on errors in our project.
