### PR TITLE
move harold AI above the fold

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -181,6 +181,18 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 				<ErrorBodyText errorBody={errorInstance.error_object.event} />
 			</Box>
 
+			<Box display="flex" flexDirection="column" mb="40">
+				<Stack direction="row" align="center" pb="20" gap="8">
+					<Text size="large" weight="bold">
+						Harold AI
+					</Text>
+					<Badge label="Beta" size="medium" variant="purple" />
+				</Stack>
+				<AiErrorSuggestion
+					errorObjectId={errorInstance.error_object.id}
+				/>
+			</Box>
+
 			<Box display="flex" flexDirection="column" mb="40" gap="40">
 				<div style={{ flexBasis: 0, flexGrow: 1 }}>
 					<Metadata errorObject={errorInstance.error_object} />
@@ -203,18 +215,6 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 						</Box>
 					</>
 				)}
-
-			<Box display="flex" flexDirection="column" mb="40">
-				<Stack direction="row" align="center" pb="20" gap="8">
-					<Text size="large" weight="bold">
-						Harold AI
-					</Text>
-					<Badge label="Beta" size="medium" variant="purple" />
-				</Stack>
-				<AiErrorSuggestion
-					errorObjectId={errorInstance.error_object.id}
-				/>
-			</Box>
 
 			{(errorInstance.error_object.stack_trace !== '' &&
 				errorInstance.error_object.stack_trace !== 'null') ||


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Moves Harold above the fold on the error instance view. Previously below User Details, now below the Instance Error Body.

[Slack request](https://highlightcorp.slack.com/archives/C01FJL7V630/p1689147405946569)

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Before:

![Screenshot 2023-07-14 at 8 54 21 AM](https://github.com/highlight/highlight/assets/58678/40ae63c5-80f2-454a-a663-314913dbbb35)

After:
![Screenshot 2023-07-14 at 8 53 54 AM](https://github.com/highlight/highlight/assets/58678/930b77df-2294-4ddf-9d4d-55bf53a260c4)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
