### PR TITLE
skip properties if the key is just a number

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -157,6 +157,8 @@ const ERROR_EVENT_MAX_LENGTH = 10000
 
 const SESSION_FIELD_MAX_LENGTH = 2000
 
+var NumberRegex = regexp.MustCompile(`^\d+$`)
+
 var ErrNoisyError = e.New("Filtering out noisy error")
 var ErrQuotaExceeded = e.New(string(publicModel.PublicGraphErrorBillingQuotaExceeded))
 var ErrUserFilteredError = e.New("User filtered error")
@@ -186,6 +188,9 @@ func (r *Resolver) AppendProperties(ctx context.Context, sessionID int, properti
 			log.WithContext(ctx).Warnf("property %s from session %d exceeds max expected field length, skipping", k, sessionID)
 		} else if fv == "" {
 			// Skip when the field value is blank
+		} else if NumberRegex.MatchString(k) {
+			// Skip when the field name is a number
+			// (this can be sent by clients if a string is passed as an `addProperties` payload)
 		} else {
 			modelFields = append(modelFields, &model.Field{ProjectID: projectID, Name: k, Value: fv, Type: string(propType)})
 		}


### PR DESCRIPTION
## Summary
- even though the type definitions disallow it, `H.track` can be passed a string as the payload argument, which will then be expanded into an object with numeric fields and single character values
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested `H.track` locally to confirm that:
1. a string payload argument was not saved as a field
2. for an object with numeric and non-numeric keys, the numeric ones are discarded
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- after this is deployed, will:
1. run a sql script to delete the existing `session_fields` rows for fields with numeric names
2. reindex all sessions in opensearch
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
