### PR TITLE
prevent jumping in viewport in the listview

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
@@ -172,6 +172,7 @@ const ErrorInstancesContainer: React.FC<
 	}
 
 	if (verticallyAlign) {
+		childrenBoxProps.display = 'flex'
 		childrenBoxProps.alignItems = 'center'
 	}
 

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
@@ -1,5 +1,6 @@
 import {
 	Box,
+	BoxProps,
 	Callout,
 	Form,
 	FormState,
@@ -67,8 +68,9 @@ export const ErrorInstances = ({ errorGroup }: Props) => {
 				canMoveForward={false}
 				form={form}
 				onSubmit={handleSubmit}
+				verticallyAlign
 			>
-				<LoadingBox height={156} />
+				<LoadingBox />
 			</ErrorInstancesContainer>
 		)
 	}
@@ -148,6 +150,7 @@ type ErrorInstancesContainerProps = {
 	onSubmit: (e: React.FormEvent<HTMLFormElement>) => void
 	onPrevious?: () => void
 	onNext?: () => void
+	verticallyAlign?: boolean
 }
 
 const ErrorInstancesContainer: React.FC<
@@ -160,9 +163,20 @@ const ErrorInstancesContainer: React.FC<
 	onSubmit,
 	form,
 	children,
+	verticallyAlign = false,
 }) => {
+	const childrenBoxProps: BoxProps = {
+		mb: '20',
+		borderBottom: 'secondary',
+		style: { minHeight: '300px' },
+	}
+
+	if (verticallyAlign) {
+		childrenBoxProps.alignItems = 'center'
+	}
+
 	return (
-		<>
+		<Stack direction="column">
 			<Box my="8">
 				<Form state={form} onSubmit={onSubmit}>
 					<Box
@@ -184,9 +198,7 @@ const ErrorInstancesContainer: React.FC<
 					</Box>
 				</Form>
 			</Box>
-			<Box mb="20" borderBottom="secondary">
-				{children}
-			</Box>
+			<Box {...childrenBoxProps}>{children}</Box>
 			<Stack direction="row" justifyContent="flex-end">
 				<Button
 					kind="secondary"
@@ -205,6 +217,6 @@ const ErrorInstancesContainer: React.FC<
 					Next
 				</Button>
 			</Stack>
-		</>
+		</Stack>
 	)
 }

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
@@ -168,7 +168,7 @@ const ErrorInstancesContainer: React.FC<
 	const childrenBoxProps: BoxProps = {
 		mb: '20',
 		borderBottom: 'secondary',
-		style: { minHeight: '300px' },
+		style: { minHeight: '351px' },
 	}
 
 	if (verticallyAlign) {

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -114,7 +114,7 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 	})
 
 	return (
-		<>
+		<Box>
 			{table.getRowModel().rows.map((row) => {
 				return (
 					<Link
@@ -145,6 +145,6 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 					</Link>
 				)
 			})}
-		</>
+		</Box>
 	)
 }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

The error instances listview jumps when we are loading the page. This PR sets a min height on the listview to prevent the jumping. I tried figuring out a different solution that doesn't require a fixed value like this but nothing really seemed to do the job.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

There is now a stable height on the loading and table view.

![Screenshot 2023-07-14 at 3 25 04 PM](https://github.com/highlight/highlight/assets/58678/d7508fd4-22d1-4b13-93f9-140dc31e7647)

![Screenshot 2023-07-14 at 3 25 26 PM](https://github.com/highlight/highlight/assets/58678/3c61a104-e7cb-4cde-be01-75f4de1cd58d)




## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->


N/A