### PR TITLE
cleanup nextjs docs

### DIFF
--- a/docs-content/getting-started/fullstack-frameworks/next-js.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js.md
@@ -19,7 +19,7 @@ all-in-one.
 
 1. On the frontend, the `<HighlightInit/>` component sets up client-side session replays.
 2. On the backend, the `withHighlight` wrapper captures server-side errors and logs from your API.
-3. It also automatically proxies highlight data to avoid ad-blockers and uploads source maps so your frontend errors include stack traces to your source code.
+3. The `withHighlightConfig` configuration wrapper automatically proxies highlight data to bypass ad-blockers and uploads source maps so your frontend errors include stack traces to your source code.
 
 ## Installation
 

--- a/docs-content/getting-started/fullstack-frameworks/next-js.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js.md
@@ -1,5 +1,5 @@
 ---
-title: Next.js
+title: Next.js Walkthrough
 slug: next-js
 heading: Next.js Walkthrough
 createdAt: 2023-05-10T00:00:00.000Z
@@ -12,6 +12,14 @@ updatedAt: 2023-05-10T00:00:00.000Z
   allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
 />
 
+## Overview
+
+Our Next.js SDK gives you access to frontend session replays and server-side monitoring,
+all-in-one. 
+
+1. On the frontend, the `<HighlightInit/>` component sets up client-side session replays.
+2. On the backend, the `withHighlight` wrapper captures server-side errors and logs. It also automatically proxies highlight data to avoid ad-blockers and uploads source maps so your frontend errors include stack traces to your source code.
+
 ## Installation
 
 ```shell
@@ -19,7 +27,7 @@ updatedAt: 2023-05-10T00:00:00.000Z
 yarn add @highlight-run/next @highlight-run/react highlight.run
 ```
 
-## Instrument the client
+## Client Instrumentation
 
 This implementation requires React 17 or greater. If you're behind on React versions, follow our [React.js docs](../3_client-sdk/1_reactjs.md)
 
@@ -80,7 +88,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
-## Instrument your API routes
+## API Route Instrumentation
 1. Create a file to export your `Highlight` wrapper function:
 
  ```javascript
@@ -115,7 +123,7 @@ export default withHighlight(function handler(
 })
 ```
 
-## Instrument the server
+## Server Instrumentation
 
 ```hint
 Excluding the Vercel edge runtime (which is a work in progress), Session Replay, Vercel Log Drain and Error Monitoring are fully operational for Next.js 13 App Directory
@@ -195,7 +203,7 @@ See [Fullstack Mapping](https://www.highlight.io/docs/getting-started/frontend-b
 
 You likely want to associate your back-end errors to client sessions.
 
-## Test source maps
+## Source Map Validation
 
 ```hint
 Source maps do not work in development mode. Run `yarn build && yarn start` to test compiled source maps in Highlight.

--- a/docs-content/getting-started/fullstack-frameworks/next-js.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js.md
@@ -12,12 +12,6 @@ updatedAt: 2023-05-10T00:00:00.000Z
   allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
 />
 
-## Limitations 
-
-⚠️ App Directory support on Vercel is a work-in-progress. Session Replay, Vercel Log Drain and non-Vercel-deployed Error Monitoring are fully operational; however, Vercel's `edge` runtime is not yet compatible with OpenTelemetry. Vercel's `nodejs` runtime **is** instrumented for OpenTelemetry, but we're having trouble ingesting Server-side Rendering (SSR) errors. We expect to solve the `nodejs` runtime issues first. In the meantime, we're hoping to find an `edge` runtime-compatible version of OpenTelemetry.
-
-⚠️ Source maps do not work in development mode. Run `yarn build && yarn start` to test compiled source maps in Highlight.
-
 ## Installation
 
 ```shell
@@ -124,6 +118,11 @@ export default withHighlight(function handler(
 ```
 
 ## Instrument the server
+
+```hint
+⚠️ Excluding the Vercel edge runtime (which is a work in progress), Session Replay, Vercel Log Drain and Error Monitoring are fully operational for App Directory
+```
+
 
 Next.js comes out of the box instrumented for Open Telemetry. Our example Highlight implementation will use Next's [experimental instrumentation feature](https://nextjs.org/docs/advanced-features/instrumentation) to configure Open Telemetry on our Next.js server. There are probably other ways to configure Open Telemetry with Next... but this is our favorite.
 
@@ -287,6 +286,10 @@ See [Fullstack Mapping](https://www.highlight.io/docs/getting-started/frontend-b
 You likely want to associate your back-end errors to client sessions.
 
 ## Test source maps
+
+```hint
+⚠️ Source maps do not work in development mode. Run `yarn build && yarn start` to test compiled source maps in Highlight.
+```
 
 We recommend shipping your source maps to your production server. Your client-side JavaScript is always public, and code decompilation tools are so powerful that obscuring your source code may not be helpful.
 

--- a/e2e/nextjs/README.md
+++ b/e2e/nextjs/README.md
@@ -173,8 +173,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 				tracingOrigins
 				networkRecording={{
 					enabled: true,
-					recordHeadersAndBody: true,
-					urlBlocklist: [],
+					recordHeadersAndBody: true
 				}}
 				backendUrl={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_BACKEND_URL}
 			/>
@@ -207,8 +206,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 				tracingOrigins
 				networkRecording={{
 					enabled: true,
-					recordHeadersAndBody: true,
-					urlBlocklist: [],
+					recordHeadersAndBody: true
 				}}
 				backendUrl={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_BACKEND_URL}
 			/>

--- a/e2e/nextjs/pages/_app.tsx
+++ b/e2e/nextjs/pages/_app.tsx
@@ -12,7 +12,6 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 				networkRecording={{
 					enabled: true,
 					recordHeadersAndBody: true,
-					urlBlocklist: [],
 				}}
 				backendUrl={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_BACKEND_URL}
 			/>

--- a/e2e/nextjs/src/app/layout.tsx
+++ b/e2e/nextjs/src/app/layout.tsx
@@ -22,7 +22,6 @@ export default function RootLayout({
 				networkRecording={{
 					enabled: true,
 					recordHeadersAndBody: true,
-					urlBlocklist: [],
 				}}
 				backendUrl={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_BACKEND_URL}
 			/>


### PR DESCRIPTION
## Summary

Wanted to clean up the next.js docs to make it a bit more concise, as it is the main
entrypoint for folks getting set up on next.js. We want to make it as bare-bones as possible
to avoid confusing folks (as is, there are three steps to instrumenting in the client, api fns, and serverless,
and it can get overwhelming where to start as an end user). Also, the warning about limitations
seemed a bit strong and discouraging, so I've refactored it to be in the relevant sections.

@deltaepsilon appreciate the work you did to build these docs. if there is anything you disagree with and think 
we should preserve, please comment!

## How did you test this change?

[Vercel preview](https://highlight-landing-git-vadim-cleanup-nextjs-docs-highlight-run.vercel.app/docs/getting-started/fullstack-frameworks/next-js).

## Are there any deployment considerations?

No