### PR TITLE
fix unlisted public session access

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -961,8 +961,15 @@ func (r *Resolver) canAdminViewSession(ctx context.Context, session_secure_id st
 	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("canAdminViewSession"))
 	defer authSpan.Finish()
 	session, isOwner, err := r._doesAdminOwnSession(ctx, session_secure_id)
-	if err != nil && !isAuthError(err) {
-		return nil, err
+	if err != nil {
+		if !isAuthError(err) {
+			return nil, err
+		} else {
+			if session == nil {
+				return nil, AuthorizationError
+			}
+			// auth error, but we should check if this is demo / public session
+		}
 	}
 	if isOwner {
 		return session, nil

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -114,6 +114,10 @@ var PromoCodes = map[string]PromoCode{
 	},
 }
 
+func isAuthError(err error) bool {
+	return e.Is(err, AuthenticationError) || e.Is(err, AuthenticationError)
+}
+
 type Resolver struct {
 	DB                     *gorm.DB
 	TDB                    timeseries.DB
@@ -957,7 +961,7 @@ func (r *Resolver) canAdminViewSession(ctx context.Context, session_secure_id st
 	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("canAdminViewSession"))
 	defer authSpan.Finish()
 	session, isOwner, err := r._doesAdminOwnSession(ctx, session_secure_id)
-	if err != nil {
+	if err != nil && !isAuthError(err) {
 		return nil, err
 	}
 	if isOwner {

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -115,7 +115,7 @@ var PromoCodes = map[string]PromoCode{
 }
 
 func isAuthError(err error) bool {
-	return e.Is(err, AuthenticationError) || e.Is(err, AuthenticationError)
+	return e.Is(err, AuthenticationError) || e.Is(err, AuthorizationError)
 }
 
 type Resolver struct {


### PR DESCRIPTION
## Summary

Recent auth changes mean that our session query would return an auth error even if the session is public.
Adds a check for sessions and errors to make sure both work for public sessions.

## How did you test this change?

Viewing a public session locally.
<img width="1782" alt="Screenshot 2023-07-14 at 6 39 24 PM" src="https://github.com/highlight/highlight/assets/1351531/b52d46f6-6656-47c0-a287-55a0534fdb2f">

Viewing a public error locally.
<img width="1764" alt="Screenshot 2023-07-14 at 6 39 44 PM" src="https://github.com/highlight/highlight/assets/1351531/6ca252d2-6b1a-45bc-8b1d-ab3113687892">

## Are there any deployment considerations?

No