### PR TITLE
Revert workaround for minified umd package

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -20,13 +20,7 @@ import { SourcemapErrorDetails } from '@pages/ErrorsV2/SourcemapErrorDetails/Sou
 import { UnstructuredStackTrace } from '@pages/ErrorsV2/UnstructuredStackTrace/UnstructuredStackTrace'
 import clsx from 'clsx'
 import React from 'react'
-import ReactCollapsibleModule from 'react-collapsible'
-
-// FIXME: this is a temporary workaround for Reflame not handling minified UMD modules properly
-// Fix coming up soon
-const ReactCollapsible =
-	// @ts-ignore
-	ReactCollapsibleModule.default ?? ReactCollapsibleModule
+import ReactCollapsible from 'react-collapsible'
 
 import { ErrorObjectFragment } from '@/graph/generated/operations'
 


### PR DESCRIPTION
## Summary

Just shipped an update to our exports detection for several common minified UMD module patterns. This means we should see errors like `module does not have named export` and `minified react error #130`(often caused by the entire module namespace being dumped into the default export, causing us to use an object as a jsx component instead of an actual component) much less often.

It also means we can remove the workaround we had in place for `react-collapsible` which uses a minified umd module format that will now get properly transformed into proper esm with named exports.


<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

Click into error details page using react-collapsible, no longer crashes.

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
