### PR TITLE
run js build in forks without doppler

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -73,11 +73,10 @@ jobs:
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
 
-            - name: Build & test (in a fork without render environment)
+            - name: Build & test (in a fork without doppler)
               if: github.event.pull_request.head.repo.full_name != 'highlight/highlight' && github.ref != 'refs/heads/main'
-              run: doppler run -- bash -c 'RENDER_PREVIEW=false yarn test:all'
+              run: yarn test:all
               env:
-                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
                   GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -64,7 +64,17 @@ jobs:
             - name: Install Doppler CLI
               uses: dopplerhq/cli-action@v2
 
-            - name: Build & test
+            - name: Build & test (with render environment)
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
+              run: doppler run -- bash -c 'RENDER_PREVIEW=false yarn test:all'
+              env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
+                  GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
+                  NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
+
+            - name: Build & test (in a fork without render environment)
+              if: github.event.pull_request.head.repo.full_name != 'highlight/highlight' && github.ref != 'refs/heads/main'
               run: doppler run -- bash -c 'RENDER_PREVIEW=false yarn test:all'
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}


### PR DESCRIPTION
## Summary

Forks (#5950) are unable to run turborepo build because the doppler credentials are not accessible.
In forks, run the build without doppler (doesn't affect the frontend sourcemaps since they would not be uploaded in a fork)

## How did you test this change?

CI

## Are there any deployment considerations?

No