### PR TITLE
wildcard searching for email in error instances view

### DIFF
--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -36,7 +36,7 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 		if parsedQuery["email"] != "" {
 			query.Joins("LEFT JOIN sessions ON error_objects.session_id = sessions.id").
 				Where("sessions.project_id = ?", errorGroup.ProjectID). // Attaching project id so we can utilize the composite index sessions
-				Where("sessions.email = ?", parsedQuery["email"])
+				Where("sessions.email ILIKE ?", "%"+parsedQuery["email"]+"%")
 		}
 	}
 

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -158,6 +158,13 @@ func TestListErrorObjectsSearchByEmail(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Len(t, connection.Edges, 1)
+
+		connection, err = store.ListErrorObjects(errorGroup, ListErrorObjectsParams{
+			Query: "email:mcwoutie",
+		})
+		assert.NoError(t, err)
+
+		assert.Len(t, connection.Edges, 1)
 	})
 }
 

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
@@ -35,7 +35,7 @@ export interface SearchFormState {
 }
 
 export const ErrorInstances = ({ errorGroup }: Props) => {
-	const [currentSearchedEmail, setCurrentSearchEmail] = React.useState('')
+	const [currentSearchEmail, setCurrentSearchEmail] = React.useState('')
 	const form = useFormState<SearchFormState>({
 		defaultValues: {
 			email: '',
@@ -142,7 +142,7 @@ export const ErrorInstances = ({ errorGroup }: Props) => {
 		>
 			<ErrorInstancesTable
 				edges={edges}
-				searchedEmail={currentSearchedEmail}
+				searchedEmail={currentSearchEmail}
 			/>
 		</ErrorInstancesContainer>
 	)

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
@@ -35,6 +35,7 @@ export interface SearchFormState {
 }
 
 export const ErrorInstances = ({ errorGroup }: Props) => {
+	const [currentSearchedEmail, setCurrentSearchEmail] = React.useState('')
 	const form = useFormState<SearchFormState>({
 		defaultValues: {
 			email: '',
@@ -59,6 +60,7 @@ export const ErrorInstances = ({ errorGroup }: Props) => {
 	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault()
 		setQuery(`email:${form.values.email}`)
+		setCurrentSearchEmail(form.values.email)
 	}
 
 	if (loading) {
@@ -138,7 +140,10 @@ export const ErrorInstances = ({ errorGroup }: Props) => {
 			form={form}
 			onSubmit={handleSubmit}
 		>
-			<ErrorInstancesTable edges={edges} />
+			<ErrorInstancesTable
+				edges={edges}
+				searchedEmail={currentSearchedEmail}
+			/>
 		</ErrorInstancesContainer>
 	)
 }

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -11,6 +11,7 @@ import { createSearchParams } from 'react-router-dom'
 
 import { useAuthContext } from '@/authentication/AuthContext'
 import { Link } from '@/components/Link'
+import TextHighlighter from '@/components/TextHighlighter/TextHighlighter'
 import { ErrorObjectEdge } from '@/graph/generated/schemas'
 import { useProjectId } from '@/hooks/useProjectId'
 import { PlayerSearchParameters } from '@/pages/Player/PlayerHook/utils'
@@ -22,6 +23,7 @@ const toYearMonthDay = (timestamp: string) => {
 
 type Props = {
 	edges: ErrorObjectEdge[]
+	searchedEmail: string
 }
 
 function truncateVersion(version: string) {
@@ -33,7 +35,7 @@ function truncateVersion(version: string) {
 	}
 }
 
-export const ErrorInstancesTable = ({ edges }: Props) => {
+export const ErrorInstancesTable = ({ edges, searchedEmail }: Props) => {
 	const { projectId } = useProjectId()
 	const { isLoggedIn } = useAuthContext()
 	const columnHelper = createColumnHelper<ErrorObjectEdge>()
@@ -73,14 +75,22 @@ export const ErrorInstancesTable = ({ edges }: Props) => {
 				const timestamp = getValue().timestamp
 				const session = getValue().session
 
-				let content = 'no session'
+				let content = <>no session</>
 				let sessionLink = ''
 
 				if (session) {
-					content =
-						session.email ??
-						session.fingerprint?.toString() ??
-						'(no value)'
+					if (session.email) {
+						content = (
+							<TextHighlighter
+								searchWords={[searchedEmail]}
+								textToHighlight={session.email}
+							/>
+						)
+					} else {
+						content = <>{session.fingerprint?.toString()}</> ?? (
+							<>(no value)</>
+						)
+					}
 					const params = createSearchParams({
 						tsAbs: timestamp,
 						[PlayerSearchParameters.errorId]: errorObjectId,


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Adjusts the logic for searching an error instance's email to use a case insensitive, wildcard search. 
This also highlights what part of the email matched.


_Note: this makes the query slower since it won't utilize an index but we opted for usability over performance ([slack](https://highlightcorp.slack.com/archives/C02N2AZS8BV/p1689273119805889?thread_ts=1689185062.220409&cid=C02N2AZS8BV))._

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

https://www.loom.com/share/3a22bac77fc6480c8ac5c3dc163d28b3

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
