### PR TITLE
Add launch week banner to app and landing page

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -773,8 +773,16 @@ const BillingBanner: React.FC = () => {
 	}
 
 	if (!bannerMessage && !hasTrial) {
-		toggleShowBanner(false)
-		return null
+		const isLaunchWeek = moment().isBetween(
+			'2023-07-17T00:00:00Z',
+			'2023-07-22T00:00:00Z',
+		)
+		if (isLaunchWeek) {
+			return <LaunchWeekBanner />
+		} else {
+			toggleShowBanner(false)
+			return null
+		}
 	}
 
 	if (hasTrial) {
@@ -870,6 +878,47 @@ const MaintenanceBanner = () => {
 
 	return (
 		<div className={clsx(styles.trialWrapper, styles.maintenance)}>
+			<div className={clsx(styles.trialTimeText)}>{bannerMessage}</div>
+		</div>
+	)
+}
+
+const LaunchWeekBanner = () => {
+	const { toggleShowBanner } = useGlobalContext()
+	const LaunchWeekSchedule = [
+		'',
+		'error monitoring',
+		'session replay',
+		'logging',
+		'AI',
+		'our community',
+	] as const
+
+	const day = moment().diff(moment('2023-07-17T16:00:00Z'), 'days') + 1
+	if (day > 5) {
+		toggleShowBanner(false)
+		return null
+	}
+	toggleShowBanner(true)
+
+	const bannerMessage = (
+		<span>
+			Launch Week 2 is here! Day {day} is all about{' '}
+			{LaunchWeekSchedule[day]}.{' '}
+			<a
+				target="_blank"
+				href={`https://www.highlight.io/launch-week-2#day-${day}`}
+				className={styles.trialLink}
+				rel="noreferrer"
+			>
+				Follow along
+			</a>{' '}
+			to see what we've been building.
+		</span>
+	)
+
+	return (
+		<div className={clsx(styles.trialWrapper, styles.launchWeek)}>
 			<div className={clsx(styles.trialTimeText)}>{bannerMessage}</div>
 		</div>
 	)

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -895,7 +895,7 @@ const LaunchWeekBanner = () => {
 	] as const
 
 	const day = moment().diff(moment('2023-07-17T16:00:00Z'), 'days') + 1
-	if (day > 5) {
+	if (day < 1 || day > 5) {
 		toggleShowBanner(false)
 		return null
 	}
@@ -913,7 +913,7 @@ const LaunchWeekBanner = () => {
 			>
 				Follow along
 			</a>{' '}
-			to see what we've been building.
+			to see what we've been building!
 		</span>
 	)
 

--- a/highlight.io/components/common/Navbar/Navbar.module.scss
+++ b/highlight.io/components/common/Navbar/Navbar.module.scss
@@ -386,6 +386,12 @@
 	position: relative;
 }
 
+.launchWeekText {
+	text-align: center;
+	width: 100%;
+	font-weight: 300;
+}
+
 @media screen and (max-width: 800px) {
 	.navPostTitle {
 		display: none;

--- a/highlight.io/components/common/Navbar/Navbar.module.scss.d.ts
+++ b/highlight.io/components/common/Navbar/Navbar.module.scss.d.ts
@@ -23,6 +23,7 @@ export const hide: string
 export const hideNavbar: string
 export const innerGridContainer: string
 export const innerPopoverPanel: string
+export const launchWeekText: string
 export const loadingBar: string
 export const menuButtons: string
 export const menuDropdown: string

--- a/highlight.io/components/common/Navbar/Navbar.tsx
+++ b/highlight.io/components/common/Navbar/Navbar.tsx
@@ -15,7 +15,42 @@ import styles from './Navbar.module.scss'
 import ResourceDropdown from './ResourceDropdown'
 
 import '@docsearch/css'
+import moment from 'moment'
+import Banner from '../Banner/Banner'
 import FeatureDropdown from './FeatureDropdown'
+
+const LaunchWeekBanner = () => {
+	const LaunchWeekSchedule = [
+		'',
+		'error monitoring',
+		'session replay',
+		'logging',
+		'AI',
+		'our community',
+	] as const
+
+	const day = moment().diff(moment('2023-07-17T16:00:00Z'), 'days') + 1
+	if (day < 1 || day > 5) {
+		return null
+	}
+
+	const bannerMessage = (
+		<div className={styles.launchWeekText}>
+			Launch Week 2 is here! Day {day} is all about{' '}
+			{LaunchWeekSchedule[day]}.{' '}
+			<a
+				target="_blank"
+				href={`https://www.highlight.io/launch-week-2#day-${day}`}
+				rel="noreferrer"
+			>
+				Follow along
+			</a>{' '}
+			to see what we&apos;ve been building!
+		</div>
+	)
+
+	return <Banner>{bannerMessage}</Banner>
+}
 
 const Navbar = ({
 	hideFreeTrialText,
@@ -58,6 +93,7 @@ const Navbar = ({
 					[styles.fixed]: fixed,
 				})}
 			>
+				<LaunchWeekBanner />
 				<header
 					className={classNames({
 						[styles.mobileHeader]: isOpen,


### PR DESCRIPTION
## Summary
- launch week banners w/ dynamic link and text depending on day
<img width="1512" alt="Screen Shot 2023-07-17 at 11 14 51 AM" src="https://github.com/highlight/highlight/assets/86132398/61e0571a-9308-483b-ac14-4f9a3168c784">
<img width="1512" alt="Screen Shot 2023-07-17 at 11 14 55 AM" src="https://github.com/highlight/highlight/assets/86132398/c33bd890-aad9-4b36-bff8-8571a905d72f">

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
