### PR TITLE
Fix broken network tab in session dev tools

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -87,15 +87,6 @@ const roundOff = (value: number, decimal = 1) => {
 	return Math.round(value * base) / base
 }
 
-export const findResourceWithMatchingHighlightHeader = (
-	headerValue: string,
-	resources: NetworkResource[],
-) => {
-	return resources.find(
-		(resource) => getHighlightRequestId(resource) === headerValue,
-	)
-}
-
 export const getHighlightRequestId = (resource?: NetworkResource) => {
 	return resource?.requestResponsePairs?.request?.id
 }


### PR DESCRIPTION
## Summary

Fixes an issue where you couldn't access the `Network` tab in the dev tools when an `errorId` param was present in the URL. This triggered [a `useEffect` callback](https://github.com/highlight/highlight/blob/521c12ab2cede7c3d76ff8e54ca7e4bc9d16c90c/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx#L225-L230) which would set the active tab back to `Errors`.

Digging into this more, I realized this logic is just trying to select the error based on the `errorId` param on page load, but we also [handle that in `useSetPlayerTimestampFromSearchParam`](https://github.com/highlight/highlight/blob/521c12ab2cede7c3d76ff8e54ca7e4bc9d16c90c/frontend/src/pages/Player/PlayerHook/utils/index.tsx#L236-L267) so I was able to delete that callback entirely.

## How did you test this change?

I click tested locally and then used [the session shared to help repro from the original ticket](https://app.highlight.io/1/sessions/gpR5PZCYpad3o1SwYWCBh6ssGAb6?page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue%7C%7Ccustom_created_at%2Cbetween_date%2C2023-06-17T18%3A53%3A24.934Z_2023-07-17T18%3A53%3A24.934Z%7C%7Ccustom_has_errors%2Cis%2Ctrue) to confirm it was fixed on a PR preview.

## Are there any deployment considerations?

N/A
