### PR TITLE
escape backtick and dollar signs in events string

### DIFF
--- a/render/src/index.ts
+++ b/render/src/index.ts
@@ -95,13 +95,5 @@ if (process.env.DEV?.length) {
 				tsEnd: '20000',
 			},
 		} as unknown as APIGatewayEvent),
-		handler({
-			queryStringParameters: {
-				project: '1',
-				session: '262083663',
-				ts: '1',
-				chunk: '0',
-			},
-		} as unknown as APIGatewayEvent),
 	])
 }

--- a/render/src/index.ts
+++ b/render/src/index.ts
@@ -95,5 +95,13 @@ if (process.env.DEV?.length) {
 				tsEnd: '20000',
 			},
 		} as unknown as APIGatewayEvent),
+		handler({
+			queryStringParameters: {
+				project: '1',
+				session: '262083663',
+				ts: '1',
+				chunk: '0',
+			},
+		} as unknown as APIGatewayEvent),
 	])
 }

--- a/render/src/render.ts
+++ b/render/src/render.ts
@@ -37,6 +37,8 @@ export async function render(
 		throw new Error('timestamp or fps must be provided')
 	}
 	events = events.replace(/\\/g, '\\\\')
+	events = events.replace(/`/g, '\\`')
+	events = events.replace(/\$/g, '\\$')
 	console.log('events', { events })
 	if (!dir?.length) {
 		const prefix = path.join(tmpdir(), 'render_')


### PR DESCRIPTION
## Summary
- screenshot lambda was failing because the events payload had a template expression in it
<img width="404" alt="Screen Shot 2023-07-17 at 12 16 27 PM" src="https://github.com/highlight/highlight/assets/86132398/7d30ea7a-ae50-4ecd-95dd-93d181f64383">

- escape backticks and dollar signs to prevent these issues
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- added problem session to the tests - it failed before and succeeded after this change
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
