### PR TITLE
simplify loading state for the error instance page

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -4,7 +4,6 @@ import { Avatar } from '@components/Avatar/Avatar'
 import { Button } from '@components/Button'
 import JsonViewer from '@components/JsonViewer/JsonViewer'
 import LoadingBox from '@components/LoadingBox'
-import { Skeleton } from '@components/Skeleton/Skeleton'
 import {
 	GetErrorInstanceDocument,
 	useGetErrorInstanceQuery,
@@ -13,6 +12,7 @@ import { ErrorObjectFragment, GetErrorGroupQuery } from '@graph/operations'
 import {
 	Badge,
 	Box,
+	Callout,
 	IconSolidCode,
 	IconSolidExternalLink,
 	Stack,
@@ -60,7 +60,7 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 	}>()
 	const client = useApolloClient()
 
-	const { loading, data } = useGetErrorInstanceQuery({
+	const { loading, error, data } = useGetErrorInstanceQuery({
 		variables: {
 			error_group_secure_id: String(errorGroup?.secure_id),
 			error_object_id,
@@ -99,56 +99,23 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 		},
 	})
 
-	const errorInstance = data?.error_instance
-
 	useEffect(() => analytics.page(), [])
 
-	if (!errorInstance || !errorInstance?.error_object) {
-		if (!loading) return null
+	if (loading) {
+		return <LoadingBox />
+	}
 
+	const errorInstance = data?.error_instance
+	if (error || !errorInstance) {
 		return (
-			<Box id="error-instance-container">
-				<Stack direction="row" my="12">
-					<Stack direction="row" flexGrow={1}>
-						<SeeAllInstances data={data} />
-						<PreviousNextInstance data={data} />
-					</Stack>
-					<Stack direction="row" gap="4">
-						<RelatedSession data={data} />
-						<RelatedLogs data={data} />
-					</Stack>
-				</Stack>
-
-				<Box display="flex" flexDirection="row" mb="40" gap="40">
-					<div style={{ flexBasis: 0, flexGrow: 1 }}>
-						<Box>
-							<Box bb="secondary" pb="20" my="12">
-								<Text weight="bold" size="large">
-									Instance metadata
-								</Text>
-							</Box>
-							<LoadingBox height={128} />
-						</Box>
-					</div>
-
-					<div style={{ flexBasis: 0, flexGrow: 1 }}>
-						<Box width="full">
-							<Box pb="20" mt="12">
-								<Text weight="bold" size="large">
-									User details
-								</Text>
-							</Box>
-							<LoadingBox height={128} />
-						</Box>
-					</div>
-				</Box>
-
-				<Text size="large" weight="bold">
-					Stack trace
-				</Text>
-				<Box bt="secondary" mt="12" pt="16">
-					<Skeleton count={10} />
-				</Box>
+			<Box m="auto" mt="10" style={{ maxWidth: 300 }}>
+				<Callout title="Failed to load error instance" kind="error">
+					<Box mb="6">
+						<Text color="moderate">
+							There was an error loading this error instance.
+						</Text>
+					</Box>
+				</Callout>
 			</Box>
 		)
 	}

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -102,7 +102,11 @@ const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 	useEffect(() => analytics.page(), [])
 
 	if (loading) {
-		return <LoadingBox />
+		return (
+			<Box mt="10">
+				<LoadingBox />
+			</Box>
+		)
 	}
 
 	const errorInstance = data?.error_instance


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR simplifies the loading state for loading the error instance data. I also added an error state if we fail to load the data (previously we just returned `null`).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Before:
![Screenshot 2023-07-17 at 3 23 56 PM](https://github.com/highlight/highlight/assets/58678/08e6c098-8dc1-4bfb-9779-29342ca260b2)


After:
![Screenshot 2023-07-17 at 3 22 02 PM](https://github.com/highlight/highlight/assets/58678/26728a5a-af39-4ab6-952d-f3f682d5d067)


Error state
![Screenshot 2023-07-17 at 3 20 08 PM](https://github.com/highlight/highlight/assets/58678/3e8cde5a-0f26-4663-a825-78943b4a217e)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A