### PR TITLE
email style fixes, get middle chunk for screenshot

### DIFF
--- a/backend/lambda-functions/sessionInsights/utils/utils.go
+++ b/backend/lambda-functions/sessionInsights/utils/utils.go
@@ -22,6 +22,7 @@ type InterestingSessionSql struct {
 	ActiveLength   time.Duration `json:"activeLength"`
 	SecureId       string        `json:"secureId"`
 	Id             int           `json:"id"`
+	ChunkIndex     int           `json:"chunkIndex"`
 }
 
 type InterestingSession struct {
@@ -33,6 +34,7 @@ type InterestingSession struct {
 	ScreenshotUrl string   `json:"screenshotUrl"`
 	Insights      []string `json:"insights"`
 	Id            int      `json:"id"`
+	ChunkIndex    int      `json:"chunkIndex"`
 }
 
 type SessionInsightsData struct {

--- a/packages/react-email-templates/emails/session-insights.tsx
+++ b/packages/react-email-templates/emails/session-insights.tsx
@@ -295,7 +295,7 @@ const sessionProperty = {
 	color: '#ffffff',
 	backgroundColor: 'rgba(255,255,255,0.32)',
 	borderRadius: '100px',
-	height: '26px',
+	lineHeight: '26px',
 	padding: '2px 12px',
 	marginRight: '6px',
 }
@@ -311,5 +311,5 @@ const insightText = {
 	...text,
 	paddingLeft: '8px',
 	textAlign: 'left' as const,
-	lineBreak: 'anywhere' as const,
+	wordBreak: 'break-word' as const,
 }

--- a/packages/react-email-templates/emails/session-insights.tsx
+++ b/packages/react-email-templates/emails/session-insights.tsx
@@ -270,6 +270,7 @@ const sessionScreenshot = {
 	width: '368px',
 	height: '200px',
 	borderRadius: '6px',
+	objectFit: 'cover' as const,
 }
 
 const identifier = {

--- a/render/src/render.ts
+++ b/render/src/render.ts
@@ -109,7 +109,7 @@ export async function render(
 	const width = Number(await page.evaluate(`viewport.width`))
 	const height = Number(await page.evaluate(`viewport.height`))
 	console.log(`puppeteer meta`, { meta, width, height })
-	await page.setViewport({ width: width + 16, height: height + 16 })
+	await page.setViewport({ width: width, height: height })
 
 	let interval = 1000
 	let start = ts || meta.startTime


### PR DESCRIPTION
## Summary
- select distinct on fingerprint so we don't get multiple sessions for the same user
- use the middle chunk index for the screenshot (using chunk 0 / ts 0 often shows a loading state, not super aesthetic)
- email style fixes
- remove the 8px border from the screenshots
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- deployed lambdas and tested
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
