### PR TITLE
improve performance of session loading

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -103,6 +103,10 @@ jobs:
                 image: clickhouse/clickhouse-server
                 ports:
                     - 9000:9000
+            redis:
+                image: redis
+                ports:
+                    - 6379:6379
         env:
             CLICKHOUSE_ADDRESS: 'localhost:9000'
             CLICKHOUSE_DATABASE: 'default'

--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -453,9 +453,7 @@ func getOrCreateUrls(ctx context.Context, projectId int, originalUrls []string, 
 	}, len(urlMap))
 	lo.ForEach(lo.Entries(urlMap), func(u lo.Entry[string, string], i int) {
 		eg.Go(func() error {
-			if err := redis.AcquireLock(ctx, u.Value, 3*time.Minute); err != nil {
-				log.WithContext(ctx).WithError(err).WithField("url", u.Value).Error("failed to acquire asset lock")
-			} else {
+			if acquired := redis.AcquireLock(ctx, u.Value, 3*time.Minute); acquired {
 				defer func() {
 					if err := redis.ReleaseLock(ctx, u.Value); err != nil {
 						log.WithContext(ctx).WithError(err).WithField("url", u.Value).Error("failed to release asset lock")

--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -382,9 +382,7 @@ func (h *HubspotApi) CreateContactCompanyAssociation(ctx context.Context, adminI
 
 func (h *HubspotApi) CreateContactCompanyAssociationImpl(ctx context.Context, adminID int, workspaceID int) error {
 	key := fmt.Sprintf("hubspot-association-%d-%d", adminID, workspaceID)
-	if err := h.redisClient.AcquireLock(ctx, key, ClientSideCreationPollInterval); err != nil {
-		return e.New("failed to acquire hubspot association lock")
-	} else {
+	if acquired := h.redisClient.AcquireLock(ctx, key, ClientSideCreationPollInterval); acquired {
 		defer func() {
 			if err := h.redisClient.ReleaseLock(ctx, key); err != nil {
 				log.WithContext(ctx).WithError(err).WithField("url", key).Error("failed to release hubspot association lock")
@@ -444,9 +442,7 @@ func (h *HubspotApi) CreateContactForAdmin(ctx context.Context, adminID int, ema
 
 func (h *HubspotApi) CreateContactForAdminImpl(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
 	key := fmt.Sprintf("contact-%s", email)
-	if err := h.redisClient.AcquireLock(ctx, key, ClientSideContactCreationTimeout); err != nil {
-		return nil, e.New("failed to acquire hubspot contact creation lock")
-	} else {
+	if acquired := h.redisClient.AcquireLock(ctx, key, ClientSideContactCreationTimeout); acquired {
 		defer func() {
 			if err := h.redisClient.ReleaseLock(ctx, key); err != nil {
 				log.WithContext(ctx).WithError(err).WithField("url", key).Error("failed to release hubspot contact creation lock")
@@ -495,9 +491,7 @@ func (h *HubspotApi) CreateCompanyForWorkspaceImpl(ctx context.Context, workspac
 	}
 
 	key := fmt.Sprintf("company-%s", name)
-	if err := h.redisClient.AcquireLock(ctx, key, ClientSideCompanyCreationTimeout); err != nil {
-		return nil, e.New("failed to acquire hubspot company creation lock")
-	} else {
+	if acquired := h.redisClient.AcquireLock(ctx, key, ClientSideCompanyCreationTimeout); acquired {
 		defer func() {
 			if err := h.redisClient.ReleaseLock(ctx, key); err != nil {
 				log.WithContext(ctx).WithError(err).WithField("url", key).Error("failed to release hubspot company creation lock")

--- a/backend/main.go
+++ b/backend/main.go
@@ -362,7 +362,7 @@ func main() {
 		OAuthServer:            oauthSrv,
 		IntegrationsClient:     integrationsClient,
 		ClickhouseClient:       clickhouseClient,
-		Store:                  store.NewStore(db, opensearchClient),
+		Store:                  store.NewStore(db, opensearchClient, redisClient),
 	}
 	private.SetupAuthClient(ctx, private.GetEnvAuthMode(), oauthSrv, privateResolver.Query().APIKeyToOrgID)
 	r := chi.NewMux()
@@ -483,7 +483,7 @@ func main() {
 			HubspotApi:    hubspotApi.NewHubspotAPI(hubspot.NewClient(hubspot.NewClientConfig()), db, redisClient, kafkaProducer),
 			Redis:         redisClient,
 			RH:            &rh,
-			Store:         store.NewStore(db, opensearchClient),
+			Store:         store.NewStore(db, opensearchClient, redisClient),
 		}
 		publicEndpoint := "/public"
 		if runtimeParsed == util.PublicGraph {
@@ -573,7 +573,7 @@ func main() {
 			Redis:         redisClient,
 			Clickhouse:    clickhouseClient,
 			RH:            &rh,
-			Store:         store.NewStore(db, opensearchClient),
+			Store:         store.NewStore(db, opensearchClient, redisClient),
 		}
 		w := &worker.Worker{Resolver: privateResolver, PublicResolver: publicResolver, StorageClient: storageClient}
 		if runtimeParsed == util.Worker {

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -944,12 +944,10 @@ func (r *Resolver) canAdminModifyErrorGroup(ctx context.Context, errorGroupSecur
 	return nil, err
 }
 
-func (r *Resolver) _doesAdminOwnSession(ctx context.Context, session_secure_id string) (session *model.Session, ownsSession bool, err error) {
-	session = &model.Session{}
-	if err := r.DB.Model(&session).Where(&model.Session{SecureID: session_secure_id}).Take(&session).Error; err != nil {
+func (r *Resolver) _doesAdminOwnSession(ctx context.Context, sessionSecureId string) (session *model.Session, ownsSession bool, err error) {
+	if session, err = r.Store.GetSessionFromSecureID(ctx, sessionSecureId); err != nil {
 		return nil, false, AuthorizationError
 	}
-
 	_, err = r.isAdminInProjectOrDemoProject(ctx, session.ProjectID)
 	if err != nil {
 		return session, false, err

--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -2,6 +2,9 @@ package graph
 
 import (
 	"context"
+	"github.com/highlight-run/highlight/backend/opensearch"
+	"github.com/highlight-run/highlight/backend/redis"
+	"github.com/highlight-run/highlight/backend/store"
 	"os"
 	"strconv"
 	"testing"
@@ -449,7 +452,7 @@ func TestResolver_canAdminViewSession(t *testing.T) {
 	for _, v := range tests {
 		util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
 			ctx := context.Background()
-			r := &queryResolver{Resolver: &Resolver{DB: DB}}
+			r := &queryResolver{Resolver: &Resolver{DB: DB, Store: store.NewStore(DB, &opensearch.Client{}, redis.NewClient())}}
 
 			w := model.Workspace{}
 			if err := DB.Create(&w).Error; err != nil {

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"encoding/json"
+	"github.com/highlight-run/highlight/backend/redis"
 	"os"
 	"reflect"
 	"strconv"
@@ -43,7 +44,7 @@ func TestMain(m *testing.M) {
 	resolver = &Resolver{
 		DB:    db,
 		TDB:   timeseries.New(context.TODO()),
-		Store: store.NewStore(db, &opensearch.Client{}),
+		Store: store.NewStore(db, &opensearch.Client{}, redis.NewClient()),
 	}
 	code := m.Run()
 	os.Exit(code)

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -27,8 +27,7 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 
 	var errorObjects []model.ErrorObject
 
-	query := store.db.Debug().
-		Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).Limit(LIMIT + 1)
+	query := store.db.Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).Limit(LIMIT + 1)
 
 	if params.Query != "" {
 		parsedQuery := queryparser.Parse(params.Query)

--- a/backend/store/main_test.go
+++ b/backend/store/main_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"github.com/highlight-run/highlight/backend/redis"
 	"os"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestMain(m *testing.M) {
 		testLogger.Error(e.Wrap(err, "error creating testdb"))
 	}
 
-	store = NewStore(db, &opensearch.Client{})
+	store = NewStore(db, &opensearch.Client{}, redis.NewClient())
 	code := m.Run()
 	os.Exit(code)
 }

--- a/backend/store/sessions.go
+++ b/backend/store/sessions.go
@@ -1,15 +1,58 @@
 package store
 
-import "github.com/highlight-run/highlight/backend/model"
+import (
+	"context"
+	"fmt"
+	"github.com/go-redis/cache/v8"
+	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/redis"
+	log "github.com/sirupsen/logrus"
+	"time"
+)
 
-func (store *Store) GetSession(sessionID int) (model.Session, error) {
-	var session model.Session
+func cachedEval[T any](ctx context.Context, redis *redis.Client, cacheKey string, lockTimeout, cacheExpiration time.Duration, fn func() (*T, error)) (value *T, err error) {
+	// wait here to check the cache in case another process is waiting for db query
+	if acquired := redis.AcquireLock(ctx, cacheKey, lockTimeout); acquired {
+		defer func() {
+			if err := redis.ReleaseLock(ctx, cacheKey); err != nil {
+				log.WithContext(ctx).WithError(err).Error("failed to release lock")
+			}
+		}()
+	}
 
-	err := store.db.Where(&model.Session{
-		Model: model.Model{
-			ID: sessionID,
-		},
-	}).Take(&session).Error
+	if err = redis.Cache.Get(ctx, cacheKey, &value); err != nil {
+		if value, err = fn(); value == nil || err != nil {
+			return
+		}
+		if err = redis.Cache.Set(&cache.Item{
+			Ctx:   ctx,
+			Key:   cacheKey,
+			Value: &value,
+			TTL:   cacheExpiration,
+		}); err != nil {
+			return
+		}
+	}
 
-	return session, err
+	return
+}
+
+func (store *Store) GetSessionFromSecureID(ctx context.Context, secureID string) (*model.Session, error) {
+	return cachedEval(ctx, store.redis, fmt.Sprintf("session-secure-%s", secureID), 150*time.Millisecond, time.Second, func() (*model.Session, error) {
+		var session model.Session
+		if err := store.db.Model(&session).Where(&model.Session{SecureID: secureID}).Take(&session).Error; err != nil {
+			return nil, err
+		}
+		return &session, nil
+	})
+}
+
+func (store *Store) GetSession(ctx context.Context, sessionID int) (*model.Session, error) {
+	return cachedEval(ctx, store.redis, fmt.Sprintf("session-id-%d", sessionID), 150*time.Millisecond, time.Second, func() (*model.Session, error) {
+		var session model.Session
+		if err := store.db.Model(&session).Where(&model.Session{Model: model.Model{ID: sessionID}}).Take(&session).Error; err != nil {
+			return nil, err
+		}
+		return &session, nil
+	})
 }

--- a/backend/store/sessions.go
+++ b/backend/store/sessions.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+// cachedEval will return the value at cacheKey if it exists.
+// If it does not exist or is nil, cachedEval calls `fn()` to evaluate the result, and stores it at the cache key.
 func cachedEval[T any](ctx context.Context, redis *redis.Client, cacheKey string, lockTimeout, cacheExpiration time.Duration, fn func() (*T, error)) (value *T, err error) {
 	// wait here to check the cache in case another process is waiting for db query
 	if acquired := redis.AcquireLock(ctx, cacheKey, lockTimeout); acquired {

--- a/backend/store/sessions_test.go
+++ b/backend/store/sessions_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"testing"
 
 	"github.com/highlight-run/highlight/backend/model"
@@ -10,13 +11,13 @@ import (
 
 func TestGetSession(t *testing.T) {
 	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		_, err := store.GetSession(1)
+		_, err := store.GetSession(context.Background(), 1)
 		assert.Error(t, err)
 
 		session := model.Session{}
 		store.db.Create(&session)
 
-		foundSession, err := store.GetSession(session.ID)
+		foundSession, err := store.GetSession(context.Background(), session.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, session.ID, foundSession.ID)
 	})

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -2,17 +2,20 @@ package store
 
 import (
 	"github.com/highlight-run/highlight/backend/opensearch"
+	"github.com/highlight-run/highlight/backend/redis"
 	"gorm.io/gorm"
 )
 
 type Store struct {
 	db         *gorm.DB
 	opensearch *opensearch.Client
+	redis      *redis.Client
 }
 
-func NewStore(db *gorm.DB, opensearch *opensearch.Client) *Store {
+func NewStore(db *gorm.DB, opensearch *opensearch.Client, redis *redis.Client) *Store {
 	return &Store{
 		db:         db,
 		opensearch: opensearch,
+		redis:      redis,
 	}
 }

--- a/backend/worker/autoresolver_test.go
+++ b/backend/worker/autoresolver_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"github.com/highlight-run/highlight/backend/redis"
 	"os"
 	"testing"
 	"time"
@@ -26,7 +27,7 @@ func createAutoResolver() *AutoResolver {
 		testLogger.Error(e.Wrap(err, "error creating testdb"))
 	}
 
-	store := store.NewStore(db, &opensearch.Client{})
+	store := store.NewStore(db, &opensearch.Client{}, redis.NewClient())
 	return NewAutoResolver(store, db)
 }
 

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -204,7 +204,6 @@ interface addLiveEvents {
 interface loadSession {
 	type: PlayerActionType.loadSession
 	data: GetSessionQuery
-	fetchEventChunkURL: FetchEventChunkURLFn
 }
 
 interface reset {
@@ -361,7 +360,6 @@ export const PlayerReducer = (
 			break
 		case PlayerActionType.loadSession:
 			s.session_secure_id = action.data!.session?.secure_id ?? ''
-			s.fetchEventChunkURL = action.fetchEventChunkURL
 			if (action.data.session) {
 				s.session = action.data?.session as Session
 				s.isLiveMode = false

--- a/highlight.io/pages/_app.tsx
+++ b/highlight.io/pages/_app.tsx
@@ -26,7 +26,7 @@ Router.events.on('routeChangeComplete', () => {
 	nProgress.done()
 })
 
-H.init('<YOUR_PROJECT_ID>', {
+H.init('4d7k1xeo', {
 	networkRecording: {
 		enabled: true,
 		recordHeadersAndBody: true,


### PR DESCRIPTION
## Summary

Improve performance of loading sessions.
On the frontend:
* parallelizes graphql operations responsible for loading parts of the session.
On the backend:
* improves performance of the backend queries loading parts of the session by avoiding concurrent session queries.
    * ie. `GetSessionPayload` queries `errors` `rage_clicks` and `session_comments`, all of which make a db query to the `session`.
    * this PR introduces a redis + LRU in-memory caching layer to the query so that multiple follow-up queries can reuse the database query result. 
Fixes a bug with hubspot that failed to create contacts because the redis locking logic would error on timeouts.

## How did you test this change?

Local deploy and reflame preview for frontend.

Inspecting load times for `GetSessionPayload` (among other graphql operations responsible for loading a session)

Before:
![image](https://github.com/highlight/highlight/assets/1351531/351162c3-783b-4e35-ba53-62bfad31bd37)

After:
![image](https://github.com/highlight/highlight/assets/1351531/ab823186-f480-4913-ba1e-2143d4d589d6)

## Are there any deployment considerations?

No
