### PR TITLE
edit launch week banner copy

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -885,14 +885,6 @@ const MaintenanceBanner = () => {
 
 const LaunchWeekBanner = () => {
 	const { toggleShowBanner } = useGlobalContext()
-	const LaunchWeekSchedule = [
-		'',
-		'error monitoring',
-		'session replay',
-		'logging',
-		'AI',
-		'our community',
-	] as const
 
 	const day = moment().diff(moment('2023-07-17T16:00:00Z'), 'days') + 1
 	if (day < 1 || day > 5) {
@@ -903,11 +895,10 @@ const LaunchWeekBanner = () => {
 
 	const bannerMessage = (
 		<span>
-			Launch Week 2 is here! Day {day} is all about{' '}
-			{LaunchWeekSchedule[day]}.{' '}
+			Launch Week 2 is here.{' '}
 			<a
 				target="_blank"
-				href={`https://www.highlight.io/launch-week-2#day-${day}`}
+				href="https://www.highlight.io/launch-week-2"
 				className={styles.trialLink}
 				rel="noreferrer"
 			>

--- a/highlight.io/components/common/Navbar/Navbar.tsx
+++ b/highlight.io/components/common/Navbar/Navbar.tsx
@@ -20,15 +20,6 @@ import Banner from '../Banner/Banner'
 import FeatureDropdown from './FeatureDropdown'
 
 const LaunchWeekBanner = () => {
-	const LaunchWeekSchedule = [
-		'',
-		'error monitoring',
-		'session replay',
-		'logging',
-		'AI',
-		'our community',
-	] as const
-
 	const day = moment().diff(moment('2023-07-17T16:00:00Z'), 'days') + 1
 	if (day < 1 || day > 5) {
 		return null
@@ -36,11 +27,10 @@ const LaunchWeekBanner = () => {
 
 	const bannerMessage = (
 		<div className={styles.launchWeekText}>
-			Launch Week 2 is here! Day {day} is all about{' '}
-			{LaunchWeekSchedule[day]}.{' '}
+			Launch Week 2 is here.{' '}
 			<a
 				target="_blank"
-				href={`https://www.highlight.io/launch-week-2#day-${day}`}
+				href="https://www.highlight.io/launch-week-2"
 				rel="noreferrer"
 			>
 				Follow along


### PR DESCRIPTION
## Summary
- simplify launch week banner copy
<img width="1512" alt="Screen Shot 2023-07-17 at 6 27 06 PM" src="https://github.com/highlight/highlight/assets/86132398/4992a823-ac51-4076-b12b-aa9991640281">
<img width="1512" alt="Screen Shot 2023-07-17 at 6 27 23 PM" src="https://github.com/highlight/highlight/assets/86132398/efbca0e9-fd28-4a78-b95c-4511f349d22c">

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- local click test
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
