### PR TITLE
activity graph lambda

### DIFF
--- a/render/package.json
+++ b/render/package.json
@@ -7,8 +7,9 @@
 	"module": "./dist/index.js",
 	"scripts": {
 		"build": "tsup",
-		"test": "DEV=true node dist/index.js",
+		"test:screenshots": "DEV=true node dist/index.js",
 		"test:activity": "DEV=true node dist/activity.js",
+		"test": "yarn test:activity && yarn test:screenshots",
 		"zip": "zip -9 -r function.zip node_modules package.json -x node_modules/typescript/\\* -x node_modules/tsup/\\* -x node_modules/@types/\\* -x node_modules/@highlight-run/node/node_modules/typescript/\\* -x node_modules/@highlight-run/rrweb/node_modules/typescript/\\* && cd dist && zip ../function.zip * && cd ..",
 		"check": "node dist/check.js",
 		"update:screenshots": "aws lambda update-function-code --function-name session-screenshots --s3-bucket highlight-lambda-code --s3-key session-screenshots.zip",

--- a/render/package.json
+++ b/render/package.json
@@ -8,9 +8,12 @@
 	"scripts": {
 		"build": "tsup",
 		"test": "DEV=true node dist/index.js",
+		"test:activity": "DEV=true node dist/activity.js",
 		"zip": "zip -9 -r function.zip node_modules package.json -x node_modules/typescript/\\* -x node_modules/tsup/\\* -x node_modules/@types/\\* -x node_modules/@highlight-run/node/node_modules/typescript/\\* -x node_modules/@highlight-run/rrweb/node_modules/typescript/\\* && cd dist && zip ../function.zip * && cd ..",
 		"check": "node dist/check.js",
-		"publish": "yarn zip && aws s3 cp function.zip s3://highlight-lambda-code/session-screenshots.zip && rm function.zip && aws lambda update-function-code --function-name session-screenshots --s3-bucket highlight-lambda-code --s3-key session-screenshots.zip"
+		"update:screenshots": "aws lambda update-function-code --function-name session-screenshots --s3-bucket highlight-lambda-code --s3-key session-screenshots.zip",
+		"update:activity": "aws lambda update-function-code --function-name session-activity --s3-bucket highlight-lambda-code --s3-key session-screenshots.zip",
+		"publish": "yarn zip && aws s3 cp function.zip s3://highlight-lambda-code/session-screenshots.zip && rm function.zip && yarn update:screenshots && yarn update:activity"
 	},
 	"installConfig": {
 		"hoistingLimits": "dependencies"

--- a/render/src/activity.ts
+++ b/render/src/activity.ts
@@ -1,0 +1,9 @@
+import { APIGatewayEvent } from 'aws-lambda'
+
+export const handler = (event?: APIGatewayEvent) => {
+	const body = event?.body
+	if (!body) {
+		return media(event)
+	}
+	return screenshot(event)
+}

--- a/render/src/activity.ts
+++ b/render/src/activity.ts
@@ -1,9 +1,138 @@
 import { APIGatewayEvent } from 'aws-lambda'
+import puppeteer, { Browser } from 'puppeteer-core'
+import chromium from '@sparticuz/chromium'
 
-export const handler = (event?: APIGatewayEvent) => {
+const WIDTH = 480
+const HEIGHT = 240
+const STROKE_WIDTH = 6.4
+
+const graphAsSvg = (yValues: number[]) => `
+<svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="
+	M ${(0 / 9) * WIDTH} ${yValues[0]}
+	L ${(1 / 9) * WIDTH} ${yValues[1]}
+	L ${(2 / 9) * WIDTH} ${yValues[2]}
+	L ${(3 / 9) * WIDTH} ${yValues[3]}
+	L ${(4 / 9) * WIDTH} ${yValues[4]}
+	L ${(5 / 9) * WIDTH} ${yValues[5]}
+	L ${(6 / 9) * WIDTH} ${yValues[6]}
+	L ${(7 / 9) * WIDTH} ${yValues[7]}
+	L ${(8 / 9) * WIDTH} ${yValues[8]}
+	L ${(9 / 9) * WIDTH} ${yValues[9]}" 
+	stroke="#744ED4" stroke-width="${STROKE_WIDTH}" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+<path d="
+	M ${(0 / 9) * WIDTH} ${yValues[0]}
+	L ${(1 / 9) * WIDTH} ${yValues[1]}
+	L ${(2 / 9) * WIDTH} ${yValues[2]}
+	L ${(3 / 9) * WIDTH} ${yValues[3]}
+	L ${(4 / 9) * WIDTH} ${yValues[4]}
+	L ${(5 / 9) * WIDTH} ${yValues[5]}
+	L ${(6 / 9) * WIDTH} ${yValues[6]}
+	L ${(7 / 9) * WIDTH} ${yValues[7]}
+	L ${(8 / 9) * WIDTH} ${yValues[8]}
+	L ${(9 / 9) * WIDTH} ${yValues[9]}
+	L ${WIDTH} ${HEIGHT}
+	L 0 ${HEIGHT}
+	Z" 
+	opacity="0.4" stroke="none" fill="url(#paint0_linear_5794_49639)"/>
+<defs>
+<linearGradient id="paint0_linear_5794_49639" x1="${WIDTH / 2}" 
+y1="${HEIGHT / 2}" x2="${
+	WIDTH / 2
+}" y2="${HEIGHT}" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6C37F4"/>
+<stop offset="1" stop-color="#6C37F4" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>
+`
+
+const svgToPng = async (svg: string) => {
+	let browser: Browser
+	if (process.env.DEV?.length) {
+		browser = await puppeteer.launch({
+			channel: 'chrome',
+			headless: 'new',
+		})
+	} else {
+		browser = await puppeteer.launch({
+			args: chromium.args,
+			defaultViewport: chromium.defaultViewport,
+			executablePath: await chromium.executablePath(),
+			headless: chromium.headless,
+			ignoreHTTPSErrors: true,
+		})
+	}
+
+	const page = await browser.newPage()
+	await page.goto('about:blank')
+	await page.setContent(svg)
+
+	await page.setViewport({ width: WIDTH + 16, height: HEIGHT + 16 })
+	const res = await page.screenshot({
+		encoding: 'base64',
+		omitBackground: true,
+		clip: {
+			x: 8,
+			y: 8,
+			width: WIDTH,
+			height: HEIGHT,
+		},
+	})
+	return res
+}
+
+export const handler = async (event?: APIGatewayEvent) => {
 	const body = event?.body
 	if (!body) {
-		return media(event)
+		console.error('event does not contain a body')
+		return {
+			statusCode: 400,
+		}
 	}
-	return screenshot(event)
+
+	const activity = JSON.parse(body) as number[]
+	if (activity.length !== 100) {
+		console.error(`activity length !== 100; actual: ${activity.length}`)
+		return {
+			statusCode: 400,
+		}
+	}
+
+	const condensed: number[] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+	activity.forEach((a, idx) => {
+		condensed[Math.floor(idx / 10)] += a
+	})
+
+	var max = 0
+	condensed.forEach((a) => {
+		if (a > max) {
+			max = a
+		}
+	})
+
+	const normalized = condensed.map((a) => a / max)
+	const yValues = normalized.map(
+		(a) => HEIGHT - (HEIGHT - STROKE_WIDTH) * a - STROKE_WIDTH / 2,
+	)
+
+	const svg = graphAsSvg(yValues)
+	const pngBase64 = await svgToPng(svg)
+
+	return {
+		statusCode: 200,
+		isBase64Encoded: true,
+		body: pngBase64,
+		headers: {
+			'content-type': 'image/png',
+		},
+	}
+}
+
+if (process.env.DEV?.length) {
+	Promise.all([
+		handler({
+			body: '[0,1,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,1,0,0,0,1,0,0,0,0,0,0,0,2,0,0,0,0,0,0,2,0,0,0,0,0,0,0,2,0,0,0,0,0,1,1,1,0,0,0,0,0,0,0,2,3,5,0,0,0,1,0,1,0,0,0,0,0,0,0,0,0,0]',
+		} as unknown as APIGatewayEvent),
+	])
 }

--- a/render/src/activity.ts
+++ b/render/src/activity.ts
@@ -79,6 +79,12 @@ const svgToPng = async (svg: string) => {
 			height: HEIGHT,
 		},
 	})
+
+	if (process.env.DEV?.length) {
+		await page.close()
+		await browser.close()
+	}
+
 	return res
 }
 
@@ -134,5 +140,9 @@ if (process.env.DEV?.length) {
 		handler({
 			body: '[0,1,0,0,0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,0,0,0,1,0,0,0,1,0,0,0,0,0,0,0,2,0,0,0,0,0,0,2,0,0,0,0,0,0,0,2,0,0,0,0,0,1,1,1,0,0,0,0,0,0,0,2,3,5,0,0,0,1,0,1,0,0,0,0,0,0,0,0,0,0]',
 		} as unknown as APIGatewayEvent),
-	])
+	]).then((res) => {
+		for (const r of res) {
+			console.log(r.body)
+		}
+	})
 }

--- a/render/tsup.config.ts
+++ b/render/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-	entry: ['src/index.ts', 'src/check.ts'],
+	entry: ['src/index.ts', 'src/check.ts', 'src/activity.ts'],
 	format: ['esm'],
 	target: 'esnext',
 	dts: false,


### PR DESCRIPTION
## Summary
- given an events count array (e.g. "[1, 3, 6, 3, 2, 2, ...]"), return a base64 png for the activity graph, to be included in the email
- uses puppeteer to screenshot the SVG and save as a PNG, so I've included it in the `render` package and created a new lambda in AWS - the entry point for the lambda is `activity.handler`
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally and viewed the output png:
![test](https://github.com/highlight/highlight/assets/86132398/534a7e81-cb89-4eb8-93f6-944509d6498b)
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will add this to the session insights digest email, there's a placeholder rn
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
