### PR TITLE
Run Cypress tests on a static frontend build

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,8 @@ jobs:
               uses: dopplerhq/cli-action@v2
 
             - name: Start docker containers & run cypress
+              env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
               run: |
                   start_time=$(date -Isecond)
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,7 @@ jobs:
                   yarn install >> /tmp/highlight.log 2>&1;
                   doppler run -- yarn build:frontend >> /tmp/highlight.log 2>&1;
                   yarn workspace @highlight-run/client dev &
+                  yarn workspace highlight.run dev &
                   yarn workspace @highlight-run/frontend vite preview --port 3000 &
                   popd;
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,9 @@ jobs:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v2
+
             - name: Start docker containers & run cypress
               run: |
                   start_time=$(date -Isecond)
@@ -48,7 +51,7 @@ jobs:
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
                   ./run-backend.sh >> /tmp/highlight.log 2>&1 &
                   yarn install >> /tmp/highlight.log 2>&1;
-                  yarn build:frontend >> /tmp/highlight.log 2>&1;
+                  doppler run -- yarn build:frontend >> /tmp/highlight.log 2>&1;
                   yarn workspace @highlight-run/client dev &
                   yarn workspace @highlight-run/frontend vite preview --port 3000 &
                   popd;

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,12 +45,10 @@ jobs:
               run: |
                   start_time=$(date -Isecond)
 
-                  # setup environment
-                  ls
-                  source ./env.sh
-
                   # start highlight
                   pushd docker;
+                  ls
+                  source ./env.sh
                   ./start-infra.sh > /tmp/highlight.log 2>&1;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
                   ./run-backend.sh >> /tmp/highlight.log 2>&1 &

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,18 +42,18 @@ jobs:
               uses: dopplerhq/cli-action@v2
 
             - name: Start docker containers & run cypress
+              env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
               run: |
                   start_time=$(date -Isecond)
 
                   # start highlight
                   pushd docker;
-                  ls
-                  source ./env.sh
                   ./start-infra.sh > /tmp/highlight.log 2>&1;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
                   ./run-backend.sh >> /tmp/highlight.log 2>&1 &
                   yarn install >> /tmp/highlight.log 2>&1;
-                  yarn build:frontend >> /tmp/highlight.log 2>&1;
+                  doppler run -- yarn build:frontend >> /tmp/highlight.log 2>&1;
                   yarn workspace @highlight-run/client dev &
                   yarn workspace @highlight-run/frontend vite preview --port 3000 &
                   popd;

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
 
                   # start highlight
                   pushd docker;
-                  doppler secrets GET REACT_APP_AUTH_MODE;
+                  doppler secrets get REACT_APP_AUTH_MODE;
                   ./start-infra.sh > /tmp/highlight.log 2>&1;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
                   ./run-backend.sh >> /tmp/highlight.log 2>&1 &

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,6 +49,7 @@ jobs:
                   ./run-backend.sh >> /tmp/highlight.log 2>&1 &
                   yarn install >> /tmp/highlight.log 2>&1;
                   yarn build:frontend >> /tmp/highlight.log 2>&1;
+                  yarn workspace @highlight-run/client dev &
                   yarn workspace @highlight-run/frontend vite preview --port 3000 &
                   popd;
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,7 @@ jobs:
                   ./start-infra.sh > /tmp/highlight.log 2>&1;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
                   ./run-backend.sh >> /tmp/highlight.log 2>&1 &
+                  yarn install >> /tmp/highlight.log 2>&1;
                   yarn build:frontend >> /tmp/highlight.log 2>&1;
                   yarn workspace @highlight-run/frontend vite preview --port 3000 &
                   popd;

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,7 +46,9 @@ jobs:
                   pushd docker;
                   ./start-infra.sh > /tmp/highlight.log 2>&1;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
-                  ./run-frontend.sh  >> /tmp/highlight.log 2>&1 & ./run-backend.sh >> /tmp/highlight.log 2>&1 &
+                  ./run-backend.sh >> /tmp/highlight.log 2>&1 &
+                  yarn build:frontend >> /tmp/highlight.log 2>&1;
+                  yarn workspace @highlight-run/frontend vite preview --port 3000 &
                   popd;
 
                   # run opentelemetry file watcher
@@ -55,7 +57,7 @@ jobs:
                   popd;
 
                   # wait for highlight to be ready
-                  yarn dlx wait-on -l -s 4 https://127.0.0.1:3000/index.html  https://127.0.0.1:3000/src/routers/AppRouter/AppRouter.tsx http://127.0.0.1:8080/dist/index.js https://127.0.0.1:8082/health;
+                  yarn dlx wait-on -l -s 4 https://127.0.0.1:3000/index.html http://127.0.0.1:8080/dist/index.js https://127.0.0.1:8082/health;
 
                   # run cypress tests
                   yarn cy:run;

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,7 +46,8 @@ jobs:
                   start_time=$(date -Isecond)
 
                   # setup environment
-                  source env.sh;
+                  ls
+                  source ./env.sh
 
                   # start highlight
                   pushd docker;

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,10 +42,11 @@ jobs:
               uses: dopplerhq/cli-action@v2
 
             - name: Start docker containers & run cypress
-              env:
-                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
               run: |
                   start_time=$(date -Isecond)
+
+                  # setup environment
+                  source env.sh;
 
                   # start highlight
                   pushd docker;
@@ -53,7 +54,7 @@ jobs:
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
                   ./run-backend.sh >> /tmp/highlight.log 2>&1 &
                   yarn install >> /tmp/highlight.log 2>&1;
-                  doppler run -- yarn build:frontend >> /tmp/highlight.log 2>&1;
+                  yarn build:frontend >> /tmp/highlight.log 2>&1;
                   yarn workspace @highlight-run/client dev &
                   yarn workspace @highlight-run/frontend vite preview --port 3000 &
                   popd;

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
 
             - name: Start docker containers & run cypress
               env:
-                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_E2E_TOKEN }}
               run: |
                   start_time=$(date -Isecond)
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,6 +49,7 @@ jobs:
 
                   # start highlight
                   pushd docker;
+                  doppler secrets GET REACT_APP_AUTH_MODE;
                   ./start-infra.sh > /tmp/highlight.log 2>&1;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
                   ./run-backend.sh >> /tmp/highlight.log 2>&1 &

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,6 @@ jobs:
 
                   # start highlight
                   pushd docker;
-                  doppler secrets get REACT_APP_AUTH_MODE;
                   ./start-infra.sh > /tmp/highlight.log 2>&1;
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
                   ./run-backend.sh >> /tmp/highlight.log 2>&1 &


### PR DESCRIPTION
## Summary

Runs Cypress against a static frontend build. Cypress is [notoriously slow loading assets from Vite](https://github.com/cypress-io/cypress/issues/22968) so we want to try running them against a static build so we only need to load a single file. We are hoping this drastically speeds up E2E test times.

**Before**
<img width="556" alt="Screenshot 2023-07-19 at 2 07 54 PM" src="https://github.com/highlight/highlight/assets/308182/ae7e98ed-344d-4890-97d5-a699e94506f5">

**After**
<img width="840" alt="Screenshot 2023-07-20 at 8 46 28 AM" src="https://github.com/highlight/highlight/assets/308182/6a83aecf-e803-417f-82d8-422b84c63324">

## How did you test this change?

Running `yarn cy:run:chrome` locally and the CI step passing ✅

## Are there any deployment considerations?

N/A