### PR TITLE
fix permalinked log not staying open

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -194,7 +194,7 @@ const LogsTableInner = ({
 	useEffect(() => {
 		// Collapse all rows when search changes
 		table.toggleAllRowsExpanded(false)
-	}, [logEdges, table])
+	}, [query, table])
 
 	useEffect(() => {
 		const foundRow = rows.find(


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

When a log is permalinked, the log line is closing. This is due to the fact that we make two requests:
* one to load the logs (`logEdges`)
* one to load and attach the errors for each logs (`logEdges.error_object`).

They latter happens after the logs table is rendered. We have a hook that would autoclose all logs when the search query changes. However, it was looking at `logEdges` (which changes when the latter query is performed) and not `query`.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed the log line stays open when permalinked:
https://www.loom.com/share/a03727668aaa48e4a2d5a135465bce04

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
