### PR TITLE
store error object embeddings

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -87,7 +87,7 @@ jobs:
         runs-on: ubuntu-latest
         services:
             postgres:
-                image: postgres
+                image: ankane/pgvector
                 env:
                     POSTGRES_PASSWORD: postgres
                     POSTGRES_USER: postgres

--- a/backend/errorgroups/embeddings.go
+++ b/backend/errorgroups/embeddings.go
@@ -1,0 +1,41 @@
+package errorgroups
+
+import (
+	"context"
+	"github.com/highlight-run/highlight/backend/model"
+	e "github.com/pkg/errors"
+	"github.com/sashabaranov/go-openai"
+	log "github.com/sirupsen/logrus"
+	"os"
+)
+
+func GetEmbeddings(ctx context.Context, error *model.ErrorObject) ([]float32, error) {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		return nil, e.New("OPENAI_API_KEY is not set")
+	}
+
+	client := openai.NewClient(apiKey)
+	resp, err := client.CreateEmbeddings(
+		context.Background(),
+		openai.EmbeddingRequest{
+			// TODO(vkorolik) batch this?
+			Input: []string{error.Event},
+			Model: openai.AdaEmbeddingV2,
+			User:  "highlight-io",
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	log.WithContext(ctx).
+		WithField("error_object_id", error.ID).
+		WithField("response_index", resp.Data[0].Index).
+		WithField("response_object", resp.Data[0].Object).
+		WithField("response_embedding_len", len(resp.Data[0].Embedding)).
+		Info("AI embedding generated.")
+
+	return resp.Data[0].Embedding, nil
+}

--- a/backend/errorgroups/embeddings.go
+++ b/backend/errorgroups/embeddings.go
@@ -2,7 +2,6 @@ package errorgroups
 
 import (
 	"context"
-	"fmt"
 	"github.com/highlight-run/highlight/backend/model"
 	e "github.com/pkg/errors"
 	"github.com/sashabaranov/go-openai"
@@ -11,13 +10,14 @@ import (
 	"time"
 )
 
-func GetEmbeddings(ctx context.Context, errors []*model.ErrorObject) (map[int][]float32, error) {
+func GetEmbeddings(ctx context.Context, errors []*model.ErrorObject) ([]*model.ErrorObjectEmbeddings, error) {
 	start := time.Now()
 	apiKey := os.Getenv("OPENAI_API_KEY")
 	if apiKey == "" {
 		return nil, e.New("OPENAI_API_KEY is not set")
 	}
 
+	var processedErrors []*model.ErrorObject
 	var inputs []string
 	for _, errorObject := range errors {
 		var stackTrace *string
@@ -26,7 +26,14 @@ func GetEmbeddings(ctx context.Context, errors []*model.ErrorObject) (map[int][]
 		} else {
 			stackTrace = errorObject.StackTrace
 		}
-		inputs = append(inputs, fmt.Sprintf(`Title: '%s' Stack trace: '%v'`, errorObject.Event, *stackTrace))
+		// only process errors with metadata and a stack trace
+		if stackTrace == nil || errorObject.Payload == nil {
+			continue
+		}
+		inputs = append(inputs, errorObject.Event)
+		inputs = append(inputs, *stackTrace)
+		inputs = append(inputs, *errorObject.Payload)
+		processedErrors = append(processedErrors, errorObject)
 	}
 
 	client := openai.NewClient(apiKey)
@@ -44,13 +51,19 @@ func GetEmbeddings(ctx context.Context, errors []*model.ErrorObject) (map[int][]
 	}
 
 	log.WithContext(ctx).
-		WithField("num_error_objects", len(errors)).
+		WithField("num_error_objects", len(processedErrors)).
 		WithField("time", time.Since(start)).
 		Info("AI embedding generated.")
 
-	results := map[int][]float32{}
-	for idx, errorObject := range errors {
-		results[errorObject.ID] = resp.Data[idx].Embedding
+	var results []*model.ErrorObjectEmbeddings
+	for i := 0; i < len(resp.Data); i += 3 {
+		errorObject := processedErrors[i/3]
+		results = append(results, &model.ErrorObjectEmbeddings{
+			ErrorObjectID:       errorObject.ID,
+			TitleEmbedding:      resp.Data[i].Embedding,
+			StackTraceEmbedding: resp.Data[i+1].Embedding,
+			PayloadEmbedding:    resp.Data[i+2].Embedding,
+		})
 	}
 	return results, nil
 }

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -927,7 +927,7 @@ type ErrorObject struct {
 type ErrorObjectEmbeddings struct {
 	Model
 	ErrorObjectID       int
-	TitleEmbedding      Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
+	EventEmbedding      Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
 	StackTraceEmbedding Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
 	PayloadEmbedding    Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
 }
@@ -1568,6 +1568,9 @@ func (j *JSONB) Scan(value interface{}) error {
 type Vector []float32
 
 func (j Vector) Value() (driver.Value, error) {
+	if len(j) == 0 {
+		return nil, nil
+	}
 	valueString, err := json.Marshal(j)
 	return string(valueString), err
 }

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -927,7 +927,7 @@ type ErrorObject struct {
 type ErrorObjectEmbeddings struct {
 	Model
 	ErrorObjectID int
-	Embeddings    Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
+	Embedding     Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
 }
 
 type ErrorGroup struct {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -926,8 +926,10 @@ type ErrorObject struct {
 
 type ErrorObjectEmbeddings struct {
 	Model
-	ErrorObjectID int
-	Embedding     Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
+	ErrorObjectID       int
+	TitleEmbedding      Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
+	StackTraceEmbedding Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
+	PayloadEmbedding    Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
 }
 
 type ErrorGroup struct {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -927,7 +927,7 @@ type ErrorObject struct {
 type ErrorObjectEmbeddings struct {
 	Model
 	ErrorObjectID int
-	Embeddings    Vector `gorm:"type:vector(1536)"`
+	Embeddings    Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
 }
 
 type ErrorGroup struct {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -754,7 +754,7 @@ func (r *Resolver) BatchGenerateEmbeddings(ctx context.Context, errorObjects []*
 	return r.Store.PutEmbeddings(lo.MapToSlice(embeddings, func(errorObjectID int, embedding []float32) *model.ErrorObjectEmbeddings {
 		return &model.ErrorObjectEmbeddings{
 			ErrorObjectID: errorObjectID,
-			Embeddings:    embedding,
+			Embedding:     embedding,
 		}
 	}))
 }

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -688,6 +688,11 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 		return nil, e.Wrap(err, "Error performing error insert for error")
 	}
 
+	embeddings, err := errorgroups.GetEmbeddings(ctx, errorObj)
+	if err := r.Store.PutEmbeddings(errorObj, embeddings); err != nil {
+		log.WithContext(ctx).WithError(err).WithField("errorObj", errorObj).Error("failed to write embeddings")
+	}
+
 	opensearchErrorObject := &opensearch.OpenSearchErrorObject{
 		Url:         errorObj.URL,
 		Os:          errorObj.OS,

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -747,6 +747,10 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 }
 
 func (r *Resolver) BatchGenerateEmbeddings(ctx context.Context, errorObjects []*model.ErrorObject) error {
+	if len(errorObjects) == 0 {
+		return nil
+	}
+
 	embeddings, err := errorgroups.GetEmbeddings(ctx, errorObjects)
 	if err != nil {
 		return err

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -755,12 +755,7 @@ func (r *Resolver) BatchGenerateEmbeddings(ctx context.Context, errorObjects []*
 	if err != nil {
 		return err
 	}
-	return r.Store.PutEmbeddings(lo.MapToSlice(embeddings, func(errorObjectID int, embedding []float32) *model.ErrorObjectEmbeddings {
-		return &model.ErrorObjectEmbeddings{
-			ErrorObjectID: errorObjectID,
-			Embedding:     embedding,
-		}
-	}))
+	return r.Store.PutEmbeddings(embeddings)
 }
 
 func (r *Resolver) AppendErrorFields(ctx context.Context, fields []*model.ErrorField, errorGroup *model.ErrorGroup) error {

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -3,10 +3,8 @@ package store
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/highlight-run/highlight/backend/model"
@@ -25,23 +23,8 @@ type ListErrorObjectsParams struct {
 // Number of results per page
 const LIMIT = 10
 
-func (store *Store) PutEmbeddings(error *model.ErrorObject, embeddings []float32) error {
-	if err := store.db.Debug().Exec(`CREATE EXTENSION IF NOT EXISTS vector`).Error; err != nil {
-		return err
-	}
-	if err := store.db.Debug().Exec(`
-	CREATE TABLE IF NOT EXISTS error_object_embeddings (id bigserial PRIMARY KEY, error_object_id bigint NOT NULL, embedding vector(1536));`).Error; err != nil {
-		return err
-	}
-	embeddingsString := fmt.Sprintf(`[%s]`, strings.Join(lo.Map(embeddings, func(item float32, _ int) string {
-		return strconv.FormatFloat(float64(item), 'f', 20, 64)
-	}), ","))
-	if err := store.db.Debug().Exec(`
-	INSERT INTO error_object_embeddings (error_object_id, embedding) VALUES (?, ?);
-`, error.ID, embeddingsString).Error; err != nil {
-		return err
-	}
-	return nil
+func (store *Store) PutEmbeddings(embeddings []*model.ErrorObjectEmbeddings) error {
+	return store.db.Model(&model.ErrorObjectEmbeddings{}).CreateInBatches(embeddings, 64).Error
 }
 
 func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErrorObjectsParams) (privateModel.ErrorObjectConnection, error) {

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -52,6 +52,7 @@ services:
     postgres:
         logging: *highlight-logging
         container_name: postgres
+        # a postgres image with pgvector installed
         image: ankane/pgvector
         ports:
             - 5432:5432

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -52,7 +52,7 @@ services:
     postgres:
         logging: *highlight-logging
         container_name: postgres
-        image: postgres
+        image: ankane/pgvector
         ports:
             - 5432:5432
         environment:


### PR DESCRIPTION
## Summary

* Sets up our postgres with [pgvector](https://github.com/pgvector/pgvector#docker) to store embeddings. In production, this will use the pgvector extension [available in aurora](https://aws.amazon.com/about-aws/whats-new/2023/07/amazon-aurora-postgresql-pgvector-vector-storage-similarity-search).
* Adds openai embeddings queries using the `AdaEmbeddingV2` model for each error object (gated for project 1).
    * The embedding is generated based on the title and the stack trace of the error object.
* Stores embeddings for our project in batches.

## How did you test this change?

Local deploy writing embeddings correctly.
Testing querying error groups locally. For example, the following query is trying to find error instances most similar to the one with title `"Uncaught Error: random error! 0.1871015092135686"`
```
with random_errors as (select *
                       from error_objects eo
                                inner join error_object_embeddings eoe on eoe.error_object_id = eo.id
                       where event = '"Uncaught Error: random error! 0.1871015092135686"'
                       limit 1)
SELECT eo.event,
       error_object_embeddings.embedding <=> r.embedding as distance,
       *
FROM error_object_embeddings
         INNER JOIN error_objects eo on error_object_embeddings.error_object_id = eo.id
         CROSS JOIN random_errors r
ORDER BY 2;
```
As you can see in the image, the other top errors are other ones with the `random error!` text. Errors are sorted by descending similarity.
![image](https://github.com/highlight/highlight/assets/1351531/acc74e26-e41c-4527-a2ef-fb151e437caf)


## Are there any deployment considerations?

Will be released after ensuring our [aurora is compatible with pgvector](https://aws.amazon.com/about-aws/whats-new/2023/07/amazon-aurora-postgresql-pgvector-vector-storage-similarity-search/). Needs to be upgraded to 15.3 first.
Related to #5695