### PR TITLE
fix session insights formatting for outlook

### DIFF
--- a/packages/react-email-templates/emails/session-insights.tsx
+++ b/packages/react-email-templates/emails/session-insights.tsx
@@ -1,6 +1,5 @@
 import {
 	Body,
-	Button,
 	Column,
 	Container,
 	Head,
@@ -46,7 +45,7 @@ const sessionExample = {
 	country: 'Germany',
 	activeLength: '1h 25m',
 	insights: [
-		`The user viewed an error page with the URL 'https://app.highlight.io/1/errors/7YboUB1obqGbOZV95X40gZrTGyRC/instances/196875448/?page=1&query=and%7C%7Cerror_state%2Cis%2COPEN%7C%7Cerror-field_timestamp%2Cbetween_date%2C2023-06-05T18%3A32%3A16.319Z_2023-07-05T18%3A32%3A16.319Z'`,
+		`The user viewed an error page with the URL 'https://app.highlight.io/1/errors/7YboUB1obqGbOZV95X40gZrTGyRC/instances/196875448/?page=1&query=and%7C%7Cerror_state%2Cis%2COPEN%7C%7Cerror-field_timestamp%2Cbetween_date%2C2023-06-05T18%3A32%3A16.319Z_2023-07-05T18%3A32%3A16.319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z319Z'`,
 		'The customer changed their billing settings on the billing page. This is a really long insight. I wonder what happens when the insight is this long.',
 		'The customer logged out at 45:32.',
 	],
@@ -64,114 +63,122 @@ export const SessionInsightsEmail = ({
 		<Preview>Session insights for {projectName}</Preview>
 		<Body style={main}>
 			<Container style={container}>
-				<Container style={contentContainer}>
-					<Section>
-						<Img
-							src="https://static.highlight.io/assets/digest/logo-on-dark.png"
-							width="32"
-							height="32"
-							alt="Highlight"
-							style={logo}
-						/>
-						<Heading style={{ ...text, fontSize: '36px' }}>
-							<a style={highlightedText}>{projectName}</a>
-							<br />
-							Session Insights
-						</Heading>
-					</Section>
-					{interestingSessions.map((s, idx) => (
-						<Section key={idx} style={infoCard}>
+				<Img
+					src="https://static.highlight.io/assets/digest/logo-on-dark.png"
+					width="32"
+					height="32"
+					alt="Highlight"
+					style={logo}
+				/>
+				<Heading style={headingText}>
+					<span style={highlightedText}>
+						<a style={highlightedText}>{projectName}</a>
+					</span>
+					<br />
+					Session Insights
+				</Heading>
+				<Text style={subtitleText}>
+					Three interesting sessions recorded in your project this
+					week.
+				</Text>
+				<Hr style={hr} />
+				{interestingSessions.map((s, idx) => (
+					<>
+						<Section width={400}>
 							<Link href={s.url}>
 								<Img
 									src={s.screenshotUrl}
 									style={sessionScreenshot}
-									width="368"
-									height="200"
+									width="400"
+									height="218"
 								/>
 							</Link>
-							<Section>
-								<Column style={sessionProperties}>
-									<Section>
-										<Text style={identifier}>
-											{s.avatarUrl && (
+						</Section>
+						<Section width={400} style={sessionAttributes}>
+							<Column width={280} style={sessionProperties}>
+								<Section>
+									<Text style={identifier}>
+										{s.avatarUrl && (
+											<>
 												<Img
 													src={s.avatarUrl}
 													width="22"
 													height="22"
 													style={avatar}
 												/>
-											)}
-											<a style={identifierText}>
-												{s.identifier}
-											</a>
-										</Text>
-									</Section>
-									<Section>
-										<span style={sessionProperty}>
-											{s.country}
-										</span>
-										<span style={sessionProperty}>
-											{s.activeLength}
-										</span>
-									</Section>
+												&nbsp;
+											</>
+										)}
+										<a style={identifierText}>
+											{s.identifier}
+										</a>
+									</Text>
+								</Section>
+								<Section>
+									<span style={sessionProperty}>
+										{s.country}
+									</span>
+									&nbsp;
+									<span style={sessionProperty}>
+										{s.activeLength}
+									</span>
+								</Section>
+							</Column>
+							<Column width={120}>
+								<Img
+									style={activityGraph}
+									src={s.activityGraphUrl}
+									width="120"
+									height="52"
+									alt="activity"
+								/>
+							</Column>
+						</Section>
+						{s.insights.map((i, idx) => (
+							<Section width={400} key={idx} style={insight}>
+								<Column width={24} style={numberLabel}>
+									{idx + 1}
 								</Column>
-								<Column>
-									<Img
-										style={activityGraph}
-										src={s.activityGraphUrl}
-										width="120"
-										height="60"
-										alt="activity"
-									/>
+								<Column
+									width={360}
+									style={{ wordBreak: 'break-all' }}
+								>
+									<Text style={insightText}>{i}</Text>
+									{/* <Link style={hoverAnchor} href={s.url}>
+										<Text style={insightText}>{i}</Text>
+									</Link> */}
 								</Column>
 							</Section>
-							{s.insights.map((i, idx) => (
-								<Section key={idx} style={insight}>
-									<Column style={numberLabel} width={24}>
-										{idx + 1}
-									</Column>
-									<Column width={326}>
-										<Link style={hoverAnchor} href={s.url}>
-											<Text style={insightText}>{i}</Text>
-										</Link>
-									</Column>
-								</Section>
-							))}
-						</Section>
-					))}
-				</Container>
-
+						))}
+						<Hr style={hr} />
+					</>
+				))}
 				{!useHarold && (
-					<Section style={paragraph}>
-						<Text style={text}>
-							Your workspace has AI insights turned off. If you
-							would like this digest to include a summary of each
-							session, you can turn on AI insights{' '}
-							<Link
-								style={anchor}
-								href="https://app.highlight.io/w/harold-ai"
-							>
-								here
-							</Link>
-							.
-						</Text>
-					</Section>
-				)}
-
-				<Section style={paragraph}>
-					<Text style={text}>
-						This digest was sent to{' '}
-						<Link style={anchor} href={`mailto:${toEmail}`}>
-							{toEmail}
-						</Link>
-						. If you don't want to receive emails like this in the
-						future, you can{' '}
-						<Link style={anchor} href={unsubscribeUrl}>
-							unsubscribe
+					<Text style={paragraph}>
+						Your workspace has AI insights turned off. If you would
+						like this digest to include a summary of each session,
+						you can turn on AI insights{' '}
+						<Link
+							style={anchor}
+							href="https://app.highlight.io/w/harold-ai"
+						>
+							here
 						</Link>
 						.
 					</Text>
-				</Section>
+				)}
+				<Text style={paragraph}>
+					This digest was sent to{' '}
+					<Link style={anchor} href={`mailto:${toEmail}`}>
+						{toEmail}
+					</Link>
+					. If you don't want to receive emails like this in the
+					future, you can{' '}
+					<Link style={anchor} href={unsubscribeUrl}>
+						unsubscribe
+					</Link>
+					.
+				</Text>
 				<Hr style={hr} />
 				<Img
 					style={logoFull}
@@ -195,7 +202,6 @@ const main = {
 }
 
 const container = {
-	margin: '0 auto',
 	padding: '0 16px',
 	marginBottom: '64px',
 	textAlign: 'center' as const,
@@ -212,10 +218,6 @@ const text = {
 
 const highlightedText = {
 	color: '#ebff5e',
-}
-
-const hoverAnchor = {
-	color: '#ffffff',
 }
 
 const anchor = {
@@ -241,17 +243,7 @@ const paragraph = {
 	fontSize: '14px',
 	fontWeight: '600',
 	lineHeight: '22px',
-}
-
-const infoCard = {
-	border: '1px solid #30294e',
-	borderRadius: '12px',
-	padding: '16px',
-	marginBottom: '24px',
-}
-
-const contentContainer = {
-	width: '400px',
+	color: '#ffffff',
 }
 
 const insight = {
@@ -259,7 +251,6 @@ const insight = {
 	borderRadius: '6px',
 	padding: '8px',
 	marginTop: '8px',
-	minHeight: '68px',
 	fontSize: '14px',
 }
 
@@ -271,8 +262,8 @@ const numberLabel = {
 
 const sessionScreenshot = {
 	backgroundColor: '#6c37f4',
-	width: '368px',
-	height: '200px',
+	width: '400px',
+	height: '218px',
 	borderRadius: '6px',
 	objectFit: 'cover' as const,
 }
@@ -290,10 +281,19 @@ const identifierText = {
 	textDecoration: 'none',
 }
 
+const sessionAttributes = {
+	marginBottom: '16px',
+	marginTop: '8px',
+}
+
+const subtitleText = {
+	...text,
+	fontSize: '16px',
+}
+
 const sessionProperties = {
 	textAlign: 'left' as const,
 	fontSize: '16px',
-	width: '248px',
 }
 
 const sessionProperty = {
@@ -317,8 +317,17 @@ const insightText = {
 	paddingLeft: '8px',
 	textAlign: 'left' as const,
 	wordBreak: 'break-word' as const,
+	margin: '8px 0',
 }
 
 const activityGraph = {
-	marginTop: '4px',
+	marginTop: '8px',
+	width: '120px',
+	height: '52px',
+}
+
+const headingText = {
+	...text,
+	fontSize: '36px',
+	lineHeight: '44px',
 }

--- a/packages/react-email-templates/emails/session-insights.tsx
+++ b/packages/react-email-templates/emails/session-insights.tsx
@@ -51,6 +51,13 @@ const sessionExample = {
 	],
 }
 
+const css = `
+    a {
+        color: unset;
+		text-decoration: none;
+    }
+`
+
 export const SessionInsightsEmail = ({
 	projectName = 'Highlight Production (app.highlight.io)',
 	toEmail = 'zane@highlight.io',
@@ -59,10 +66,12 @@ export const SessionInsightsEmail = ({
 	interestingSessions = [sessionExample, sessionExample, sessionExample],
 }: SessionInsightsEmailProps) => (
 	<Html>
-		<Head />
+		<Head>
+			<style>{css}</style>
+		</Head>
 		<Preview>Session insights for {projectName}</Preview>
 		<Body style={main}>
-			<Container style={container}>
+			<Container width={600} style={container}>
 				<Img
 					src="https://static.highlight.io/assets/digest/logo-on-dark.png"
 					width="32"
@@ -78,25 +87,28 @@ export const SessionInsightsEmail = ({
 					Session Insights
 				</Heading>
 				<Text style={subtitleText}>
-					Three interesting sessions recorded in your project this
-					week.
+					Here are 3 interesting sessions recorded in your project
+					this week:
 				</Text>
 				<Hr style={hr} />
 				{interestingSessions.map((s, idx) => (
 					<>
 						<Section width={400}>
-							<Link href={s.url}>
-								<Img
-									src={s.screenshotUrl}
-									style={sessionScreenshot}
-									width="400"
-									height="218"
-								/>
-							</Link>
+							<Img
+								alt="session"
+								src={s.screenshotUrl}
+								style={sessionScreenshot}
+								width={400}
+								height={218}
+							/>
 						</Section>
 						<Section width={400} style={sessionAttributes}>
-							<Column width={280} style={sessionProperties}>
-								<Section>
+							<Column
+								align="left"
+								width={280}
+								style={sessionProperties}
+							>
+								<Section align="left" style={leftAlign}>
 									<Text style={identifier}>
 										{s.avatarUrl && (
 											<>
@@ -114,7 +126,7 @@ export const SessionInsightsEmail = ({
 										</a>
 									</Text>
 								</Section>
-								<Section>
+								<Section align="left" style={leftAlign}>
 									<span style={sessionProperty}>
 										{s.country}
 									</span>
@@ -144,9 +156,6 @@ export const SessionInsightsEmail = ({
 									style={{ wordBreak: 'break-all' }}
 								>
 									<Text style={insightText}>{i}</Text>
-									{/* <Link style={hoverAnchor} href={s.url}>
-										<Text style={insightText}>{i}</Text>
-									</Link> */}
 								</Column>
 							</Section>
 						))}
@@ -202,13 +211,14 @@ const main = {
 }
 
 const container = {
+	width: '600px',
 	padding: '0 16px',
-	marginBottom: '64px',
 	textAlign: 'center' as const,
 }
 
 const hr = {
-	borderColor: '#30294e',
+	color: '#30294e',
+	borderTop: '1px solid #30294e',
 	margin: '20px 0',
 }
 
@@ -261,11 +271,10 @@ const numberLabel = {
 }
 
 const sessionScreenshot = {
-	backgroundColor: '#6c37f4',
-	width: '400px',
-	height: '218px',
 	borderRadius: '6px',
 	objectFit: 'cover' as const,
+	width: '400px',
+	height: '218px',
 }
 
 const identifier = {
@@ -274,6 +283,7 @@ const identifier = {
 	fontSize: '16px',
 	height: '24px',
 	overflow: 'hidden',
+	textAlign: 'left' as const,
 }
 
 const identifierText = {
@@ -289,6 +299,10 @@ const sessionAttributes = {
 const subtitleText = {
 	...text,
 	fontSize: '16px',
+}
+
+const leftAlign = {
+	textAlign: 'left' as const,
 }
 
 const sessionProperties = {

--- a/render/src/activity.ts
+++ b/render/src/activity.ts
@@ -3,7 +3,7 @@ import puppeteer, { Browser } from 'puppeteer-core'
 import chromium from '@sparticuz/chromium'
 
 const WIDTH = 480
-const HEIGHT = 240
+const HEIGHT = 208
 const STROKE_WIDTH = 6.4
 
 const graphAsSvg = (yValues: number[]) => `


### PR DESCRIPTION
## Summary
- remove the outer borders from each session in the template and use horizontal dividers instead
- add some properties to prevent outlook from expanding the table past its 400px width
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- deployed and verified on outlook and other browsers
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
