### PR TITLE
Extract query parsing logic out of logs

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -620,6 +620,7 @@ func makeFilters(query string) filtersWithReservedKeys {
 	}
 
 	filtersWithReservedKeys.body = filters.Body
+
 	if val, ok := filters.Attributes[modelInputs.ReservedLogKeyLevel.String()]; ok {
 		filtersWithReservedKeys.level = val
 		delete(filters.Attributes, modelInputs.ReservedLogKeyLevel.String())

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -622,26 +622,32 @@ func makeFilters(query string) filtersWithReservedKeys {
 	filtersWithReservedKeys.body = filters.Body
 	if val, ok := filters.Attributes[modelInputs.ReservedLogKeyLevel.String()]; ok {
 		filtersWithReservedKeys.level = val
+		delete(filters.Attributes, modelInputs.ReservedLogKeyLevel.String())
 	}
 
 	if val, ok := filters.Attributes[modelInputs.ReservedLogKeyTraceID.String()]; ok {
 		filtersWithReservedKeys.trace_id = val
+		delete(filters.Attributes, modelInputs.ReservedLogKeyTraceID.String())
 	}
 
 	if val, ok := filters.Attributes[modelInputs.ReservedLogKeySpanID.String()]; ok {
 		filtersWithReservedKeys.span_id = val
+		delete(filters.Attributes, modelInputs.ReservedLogKeySpanID.String())
 	}
 
 	if val, ok := filters.Attributes[modelInputs.ReservedLogKeySecureSessionID.String()]; ok {
 		filtersWithReservedKeys.secure_session_id = val
+		delete(filters.Attributes, modelInputs.ReservedLogKeySecureSessionID.String())
 	}
 
 	if val, ok := filters.Attributes[modelInputs.ReservedLogKeySource.String()]; ok {
 		filtersWithReservedKeys.source = val
+		delete(filters.Attributes, modelInputs.ReservedLogKeySource.String())
 	}
 
 	if val, ok := filters.Attributes[modelInputs.ReservedLogKeyServiceName.String()]; ok {
 		filtersWithReservedKeys.service_name = val
+		delete(filters.Attributes, modelInputs.ReservedLogKeyServiceName.String())
 	}
 
 	filtersWithReservedKeys.attributes = filters.Attributes

--- a/backend/queryparser/queryparser.go
+++ b/backend/queryparser/queryparser.go
@@ -1,19 +1,69 @@
 package queryparser
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
 
-func Parse(query string) map[string]string {
-	parsed := map[string]string{}
+type Filters struct {
+	Body       []string
+	Attributes map[string][]string
+}
 
-	queries := strings.Split(query, " ")
+func Parse(query string) Filters {
+	filters := Filters{
+		Attributes: make(map[string][]string),
+	}
+
+	queries := splitQuery(query)
 
 	for _, q := range queries {
-		parts := strings.Split(q, ":")
+		parts := strings.SplitN(q, ":", 2)
 
-		if len(parts) == 2 {
-			parsed[parts[0]] = parts[1]
+		if len(parts) == 1 && len(parts[0]) > 0 {
+			body := parts[0]
+
+			if strings.Contains(body, "*") {
+				body = strings.ReplaceAll(body, "*", "%")
+				filters.Body = append(filters.Body, body)
+			} else {
+				splitBody := strings.FieldsFunc(body, isSeparator)
+				filters.Body = append(filters.Body, splitBody...)
+			}
+		} else if len(parts) == 2 {
+			key, value := parts[0], parts[1]
+
+			wildcardValue := strings.ReplaceAll(value, "*", "%")
+
+			filters.Attributes[key] = append(filters.Attributes[key], wildcardValue)
 		}
 	}
 
-	return parsed
+	return filters
+}
+
+func isSeparator(r rune) bool {
+	return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+}
+
+// Splits the query by spaces _unless_ it is quoted
+// "some thing" => ["some", "thing"]
+// "some thing 'spaced string' else" => ["some", "thing", "spaced string", "else"]
+func splitQuery(query string) []string {
+	var result []string
+	inquote := false
+	i := 0
+	for j, c := range query {
+		if c == '"' {
+			inquote = !inquote
+		} else if c == ' ' && !inquote {
+			result = append(result, unquoteAndTrim(query[i:j]))
+			i = j + 1
+		}
+	}
+	return append(result, unquoteAndTrim(query[i:]))
+}
+
+func unquoteAndTrim(s string) string {
+	return strings.ReplaceAll(strings.Trim(s, " "), `"`, "")
 }

--- a/backend/queryparser/queryparser.go
+++ b/backend/queryparser/queryparser.go
@@ -10,6 +10,11 @@ type Filters struct {
 	Attributes map[string][]string
 }
 
+// Parses a query string into Attributes and Body (not keyed attributes)
+// Example: some message email:foo@bar.com service:image-processor email:baz@buzz.com
+// =>
+// Body -> []string{"some", "message"}
+// Attributes -> map[string][]string{"email": {"foo@bar.com", "baz@buzz.com"}, "service": {"image-processor"}}
 func Parse(query string) Filters {
 	filters := Filters{
 		Attributes: make(map[string][]string),

--- a/backend/queryparser/queryparser_test.go
+++ b/backend/queryparser/queryparser_test.go
@@ -27,6 +27,27 @@ func TestParseEmptyString(t *testing.T) {
 	assert.Equal(t, want, Parse(""))
 }
 
+func TestParseMultipleValues(t *testing.T) {
+	want := Filters{
+		Attributes: map[string][]string{"email": {"foo@bar.com", "baz@buzz.com"}},
+	}
+	assert.Equal(t, want, Parse("email:foo@bar.com email:baz@buzz.com"))
+}
+
+func TestParseMultipleKeys(t *testing.T) {
+	want := Filters{
+		Attributes: map[string][]string{"email": {"foo@bar.com"}, "service": {"image-processor"}},
+	}
+	assert.Equal(t, want, Parse("email:foo@bar.com service:image-processor"))
+}
+
+func TestParseWildcard(t *testing.T) {
+	want := Filters{
+		Attributes: map[string][]string{"email": {"%bar.com"}},
+	}
+	assert.Equal(t, want, Parse("email:*bar.com"))
+}
+
 func TestParseBody(t *testing.T) {
 	want := Filters{
 		Body:       []string{"email"},

--- a/backend/queryparser/queryparser_test.go
+++ b/backend/queryparser/queryparser_test.go
@@ -7,24 +7,30 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	var tests = []struct {
-		got  string
-		want map[string]string
-	}{
-		{"email:foo@bar.com", map[string]string{
-			"email": "foo@bar.com",
-		}},
-		{"email", map[string]string{}},
-		{"email:", map[string]string{
-			"email": "",
-		}},
-		{"", map[string]string{}},
+	want := Filters{
+		Attributes: map[string][]string{"email": {"foo@bar.com"}},
 	}
+	assert.Equal(t, want, Parse("email:foo@bar.com"))
+}
 
-	for _, tt := range tests {
-		t.Run(tt.got, func(t *testing.T) {
-			assert.Equal(t, tt.want, Parse(tt.got))
-		})
+func TestParseNoValue(t *testing.T) {
+	want := Filters{
+		Attributes: map[string][]string{"email": {""}},
 	}
+	assert.Equal(t, want, Parse("email:"))
+}
 
+func TestParseEmptyString(t *testing.T) {
+	want := Filters{
+		Attributes: map[string][]string{},
+	}
+	assert.Equal(t, want, Parse(""))
+}
+
+func TestParseBody(t *testing.T) {
+	want := Filters{
+		Body:       []string{"email"},
+		Attributes: map[string][]string{},
+	}
+	assert.Equal(t, want, Parse("email"))
 }

--- a/backend/queryparser/queryparser_test.go
+++ b/backend/queryparser/queryparser_test.go
@@ -78,7 +78,7 @@ func TestParseBodyWithWildcard(t *testing.T) {
 	assert.Equal(t, want, Parse("*email*"))
 }
 
-// TODO(et) - https://github.com/highlight/highlight/issues/4713
+// Failing test to be fixed by https://github.com/highlight/highlight/issues/4713
 // func TestParseBodyWithQuotes(t *testing.T) {
 // 	want := Filters{
 // 		Body:       []string{"something went wrong"},

--- a/backend/queryparser/queryparser_test.go
+++ b/backend/queryparser/queryparser_test.go
@@ -41,6 +41,13 @@ func TestParseMultipleKeys(t *testing.T) {
 	assert.Equal(t, want, Parse("email:foo@bar.com service:image-processor"))
 }
 
+func TestParseValueWithColon(t *testing.T) {
+	want := Filters{
+		Attributes: map[string][]string{"service": {"foo:bar:buzz"}},
+	}
+	assert.Equal(t, want, Parse("service:foo:bar:buzz"))
+}
+
 func TestParseWildcard(t *testing.T) {
 	want := Filters{
 		Attributes: map[string][]string{"email": {"%bar.com"}},

--- a/backend/queryparser/queryparser_test.go
+++ b/backend/queryparser/queryparser_test.go
@@ -48,6 +48,13 @@ func TestParseValueWithColon(t *testing.T) {
 	assert.Equal(t, want, Parse("service:foo:bar:buzz"))
 }
 
+func TestParseWithSpaces(t *testing.T) {
+	want := Filters{
+		Attributes: map[string][]string{"service": {"image processor"}},
+	}
+	assert.Equal(t, want, Parse("service:\"image processor\""))
+}
+
 func TestParseWildcard(t *testing.T) {
 	want := Filters{
 		Attributes: map[string][]string{"email": {"%bar.com"}},
@@ -69,4 +76,21 @@ func TestParseBodyWithWildcard(t *testing.T) {
 		Attributes: map[string][]string{},
 	}
 	assert.Equal(t, want, Parse("*email*"))
+}
+
+// TODO(et) - https://github.com/highlight/highlight/issues/4713
+// func TestParseBodyWithQuotes(t *testing.T) {
+// 	want := Filters{
+// 		Body:       []string{"something went wrong"},
+// 		Attributes: map[string][]string{},
+// 	}
+// 	assert.Equal(t, want, Parse("\"something went wrong\""))
+// }
+
+func TestParseBodyWithAttributes(t *testing.T) {
+	want := Filters{
+		Body:       []string{"some", "message"},
+		Attributes: map[string][]string{"email": {"foo@bar.com", "baz@buzz.com"}, "service": {"image-processor"}},
+	}
+	assert.Equal(t, want, Parse("some message email:foo@bar.com service:image-processor email:baz@buzz.com"))
 }

--- a/backend/queryparser/queryparser_test.go
+++ b/backend/queryparser/queryparser_test.go
@@ -34,3 +34,11 @@ func TestParseBody(t *testing.T) {
 	}
 	assert.Equal(t, want, Parse("email"))
 }
+
+func TestParseBodyWithWildcard(t *testing.T) {
+	want := Filters{
+		Body:       []string{"%email%"},
+		Attributes: map[string][]string{},
+	}
+	assert.Equal(t, want, Parse("*email*"))
+}

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -31,12 +31,13 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 
 	if params.Query != "" {
 		filters := queryparser.Parse(params.Query)
-		emails := filters.Attributes["email"]
 
-		if len(emails) > 0 && emails[0] == "" {
-			query.Joins("LEFT JOIN sessions ON error_objects.session_id = sessions.id").
-				Where("sessions.project_id = ?", errorGroup.ProjectID). // Attaching project id so we can utilize the composite index sessions
-				Where("sessions.email ILIKE ?", "%"+emails[0]+"%")
+		if val, ok := filters.Attributes["email"]; ok {
+			if len(val) > 0 && val[0] != "" {
+				query.Joins("LEFT JOIN sessions ON error_objects.session_id = sessions.id").
+					Where("sessions.project_id = ?", errorGroup.ProjectID). // Attaching project id so we can utilize the composite index sessions
+					Where("sessions.email ILIKE ?", "%"+val[0]+"%")
+			}
 		}
 	}
 

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -30,12 +30,13 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 	query := store.db.Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).Limit(LIMIT + 1)
 
 	if params.Query != "" {
-		parsedQuery := queryparser.Parse(params.Query)
+		filters := queryparser.Parse(params.Query)
+		emails := filters.Attributes["email"]
 
-		if parsedQuery["email"] != "" {
+		if len(emails) > 0 && emails[0] == "" {
 			query.Joins("LEFT JOIN sessions ON error_objects.session_id = sessions.id").
 				Where("sessions.project_id = ?", errorGroup.ProjectID). // Attaching project id so we can utilize the composite index sessions
-				Where("sessions.email ILIKE ?", "%"+parsedQuery["email"]+"%")
+				Where("sessions.email ILIKE ?", "%"+emails[0]+"%")
 		}
 	}
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR extracts out the query parsing logic from logs. The intention here is that the syntax can be re-used easily without being tied to a specific table or database.

Furthermore, it becomes incredibly easier to write additional unit tests without a clickhouse dependency (see `queryparser_test.go`).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

This was already heavily tested in `logs_test.go`. I added additional tests for sanity.

Confirmed searching for logs and error instances works as expected

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
