### PR TITLE
batch job for normalness scoring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -224,6 +224,44 @@ jobs:
                   function_name: sendSessionInsightsEmails
                   zip_file: backend/sendSessionInsightsEmails.zip
 
+    deploy-user-journey-lambdas:
+        needs: migrate-database
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Setup Go
+              uses: actions/setup-go@v4
+              with:
+                  go-version-file: 'backend/go.mod'
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v2
+            - name: Build and zip
+              run: |
+                  cd backend/
+                  CGO_ENABLED=0 go build ./lambda-functions/journeys/updateNormalnessScores
+                  zip updateNormalnessScores.zip updateNormalnessScores
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v2
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: us-east-2
+            - name: Update Lambda secrets
+              env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+              run: |
+                  aws lambda update-function-configuration --function-name updateNormalnessScores \
+                    --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
+            - name: Deploy updateNormalnessScores
+              uses: appleboy/lambda-action@v0.1.9
+              with:
+                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws_region: us-east-2
+                  function_name: updateNormalnessScores
+                  zip_file: backend/updateNormalnessScores.zip
+
     deploy_backend:
         needs: migrate-database
         runs-on: buildjet-2vcpu-ubuntu-2204-arm

--- a/backend/lambda-functions/journeys/updateNormalnessScores/main.go
+++ b/backend/lambda-functions/journeys/updateNormalnessScores/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/highlight-run/highlight/backend/lambda-functions/journeys/handlers"
+)
+
+var h handlers.Handlers
+
+func init() {
+	h = handlers.NewHandlers()
+}
+
+func main() {
+	lambda.Start(h.UpdateNormalnessScores)
+}


### PR DESCRIPTION
## Summary
- adds a lambda for updating sessions' normalness scores in batches (runs for all processed and not excluded sessions without a score)
- after the last change to remove normalness scoring in the worker, re-processed sessions have a score of 0, so they will be re-scored by this job too
- originally wanted to do this in the worker outside of `processSession`, but looking at the logs, most processing batches have <10 sessions so the speedup won't be huge
- it's reasonably fast (depending on how large the input size is, the first was for about 2 hours worth of unscored sessions)
```
UPDATE 28202
Time: 101.153s (1 minute 41 seconds), executed in: 101.153s (1 minute 41 seconds)
UPDATE 274
Time: 10.094s (10 seconds), executed in: 10.094s (10 seconds)
```
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran script in prod
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will create a step function for it and schedule it to run every 5 mins
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
