### PR TITLE
capture warning from otel flush

### DIFF
--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "3.1.3",
+	"version": "3.1.4",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "3.1.2",
+	"version": "3.1.4",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -174,6 +174,8 @@ export class Highlight {
 	}
 
 	async flush() {
-		await this.processor.forceFlush()
+		await this.processor
+			.forceFlush()
+			.catch((e) => console.warn('highlight-node failed to flush: ', e))
 	}
 }


### PR DESCRIPTION
## Summary

Capture possible otel `.forceFlush()` exceptions to avoid a `window.onunhandledrejection` error on timeouts.
See [discord](https://discord.com/channels/1026884757667188757/1124636931200929892) for context.

## How did you test this change?

`yarn build:sdk`

## Are there any deployment considerations?

New next/node package versions.