### PR TITLE
Add killswitch to indexDB

### DIFF
--- a/frontend/src/util/db.ts
+++ b/frontend/src/util/db.ts
@@ -10,6 +10,7 @@ import moment from 'moment'
 
 import log from './log'
 
+let indexedDBKillswitch = false
 const CLEANUP_CHECK_MS = 1000
 const CLEANUP_DELAY_MS = 10000
 const CLEANUP_THRESHOLD_MB = 4000
@@ -25,6 +26,9 @@ const getLocalStorage = function (): Storage | undefined {
 }
 
 export const isIndexedDBEnabled = function () {
+	console.log('indexedDBKillswitch', indexedDBKillswitch)
+	if (indexedDBKillswitch) return false
+
 	// disabled indexeddb altogether if we cannot read indexeddb memory usage
 	if (!navigator?.storage?.estimate) {
 		return false
@@ -100,23 +104,28 @@ export class IndexedDBCache {
 		GetSession: moment.duration(15, 'minutes').asMilliseconds(),
 	}
 	getItem = async function (key: { operation: string; variables: any }) {
-		const result = await db.apollo
-			.where('key')
-			.equals(JSON.stringify(key))
-			.first()
-		if (result) {
-			if (IndexedDBCache.expiryMS[key.operation]) {
-				if (
-					moment().diff(moment(result.created)) >=
-					IndexedDBCache.expiryMS[key.operation]
-				) {
-					db.apollo.delete(result.key)
-					return null
+		try {
+			const result = await db.apollo
+				.where('key')
+				.equals(JSON.stringify(key))
+				.first()
+			if (result) {
+				if (IndexedDBCache.expiryMS[key.operation]) {
+					if (
+						moment().diff(moment(result.created)) >=
+						IndexedDBCache.expiryMS[key.operation]
+					) {
+						db.apollo.delete(result.key)
+						return null
+					}
 				}
+				db.apollo.update(result.key, { updated: moment().format() })
 			}
-			db.apollo.update(result.key, { updated: moment().format() })
+			return result?.data ?? null
+		} catch {
+			indexedDBKillswitch = true
+			return null
 		}
-		return result?.data ?? null
 	}
 	setItem = async function (
 		key: {
@@ -125,20 +134,28 @@ export class IndexedDBCache {
 		},
 		value: FetchResult<Record<string, any>>,
 	) {
-		await db.apollo.put({
-			key: JSON.stringify(key),
-			created: moment().format(),
-			updated: moment().format(),
-			data: value,
-		})
+		try {
+			await db.apollo.put({
+				key: JSON.stringify(key),
+				created: moment().format(),
+				updated: moment().format(),
+				data: value,
+			})
+		} catch {
+			indexedDBKillswitch = true
+		}
 	}
 	deleteItem = async function (key: { operation: string; variables: any }) {
-		const q = db.apollo.where('key').equals(JSON.stringify(key))
-		log('db.ts', 'IndexedDBLink cache deleting', {
-			key,
-			count: await q.count(),
-		})
-		await q.delete()
+		try {
+			const q = db.apollo.where('key').equals(JSON.stringify(key))
+			log('db.ts', 'IndexedDBLink cache deleting', {
+				key,
+				count: await q.count(),
+			})
+			await q.delete()
+		} catch {
+			indexedDBKillswitch = true
+		}
 	}
 }
 

--- a/frontend/src/util/db.ts
+++ b/frontend/src/util/db.ts
@@ -26,8 +26,9 @@ const getLocalStorage = function (): Storage | undefined {
 }
 
 export const isIndexedDBEnabled = function () {
-	console.log('indexedDBKillswitch', indexedDBKillswitch)
-	if (indexedDBKillswitch) return false
+	if (indexedDBKillswitch) {
+		return false
+	}
 
 	// disabled indexeddb altogether if we cannot read indexeddb memory usage
 	if (!navigator?.storage?.estimate) {


### PR DESCRIPTION
## Summary
Some users are running into issues with IndexedDb that may be caused by browser settings or limited storage. Add a killswitch that will not crash the app when IndexedDB fails to complete an action.

![image](https://github.com/highlight/highlight/assets/17744174/a4b05fac-b58c-4481-8571-b50a5f23d7ea)

Error: https://app.highlight.io/1/errors/eN8JNCVob09aKNV1cSrtrqwcn0JJ?page=1&query=and%7C%7Cerror_state%2Cis%2COPEN%7C%7Cerror-field_timestamp%2Cbetween_date%2C2023-06-21T15%3A37%3A59.586Z_2023-07-21T15%3A37%3A59.586Z
Discord: https://discord.com/channels/1026884757667188757/1026884757667188763/1131149181298429972

## How did you test this change?
TBD

## Are there any deployment considerations?
Monitor errors
