### PR TITLE
Handle escaped JSON in nested logs view

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -316,9 +316,10 @@ const LogDetailsObject: React.FC<{
 	const [open, setOpen] = useState(false)
 
 	let stringIsJson = false
+	let parsedJson = ''
 	if (typeof attribute === 'string') {
 		try {
-			const parsedJson = JSON.parse(attribute)
+			parsedJson = JSON.parse(attribute)
 			stringIsJson = typeof parsedJson === 'object'
 		} catch {}
 	}
@@ -349,17 +350,19 @@ const LogDetailsObject: React.FC<{
 			</LogAttributeLine>
 
 			{open &&
-				Object.entries(attribute).map(([key, value], index) => (
-					<LogDetailsObject
-						key={index}
-						allExpanded={allExpanded}
-						attribute={value}
-						label={key}
-						matchedAttributes={matchedAttributes}
-						queryTerms={queryTerms}
-						queryBaseKeys={[...queryBaseKeys, key]}
-					/>
-				))}
+				Object.entries(stringIsJson ? parsedJson : attribute).map(
+					([key, value], index) => (
+						<LogDetailsObject
+							key={index}
+							allExpanded={allExpanded}
+							attribute={value}
+							label={key}
+							matchedAttributes={matchedAttributes}
+							queryTerms={queryTerms}
+							queryBaseKeys={[...queryBaseKeys, key]}
+						/>
+					),
+				)}
 		</Box>
 	) : (
 		<Box cssClass={styles.line}>

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -315,16 +315,13 @@ const LogDetailsObject: React.FC<{
 }) => {
 	const [open, setOpen] = useState(false)
 
-	let stringIsJson = false
-	let parsedJson = ''
 	if (typeof attribute === 'string') {
 		try {
-			parsedJson = JSON.parse(attribute)
-			stringIsJson = typeof parsedJson === 'object'
+			attribute = JSON.parse(attribute)
 		} catch {}
 	}
 
-	const isObject = typeof attribute === 'object' || stringIsJson
+	const isObject = typeof attribute === 'object'
 	const queryKey = queryBaseKeys.join('.') || label
 	const queryMatch = matchedAttributes[queryKey]
 
@@ -350,19 +347,17 @@ const LogDetailsObject: React.FC<{
 			</LogAttributeLine>
 
 			{open &&
-				Object.entries(stringIsJson ? parsedJson : attribute).map(
-					([key, value], index) => (
-						<LogDetailsObject
-							key={index}
-							allExpanded={allExpanded}
-							attribute={value}
-							label={key}
-							matchedAttributes={matchedAttributes}
-							queryTerms={queryTerms}
-							queryBaseKeys={[...queryBaseKeys, key]}
-						/>
-					),
-				)}
+				Object.entries(attribute).map(([key, value], index) => (
+					<LogDetailsObject
+						key={index}
+						allExpanded={allExpanded}
+						attribute={value}
+						label={key}
+						matchedAttributes={matchedAttributes}
+						queryTerms={queryTerms}
+						queryBaseKeys={[...queryBaseKeys, key]}
+					/>
+				))}
 		</Box>
 	) : (
 		<Box cssClass={styles.line}>

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -321,7 +321,6 @@ const LogDetailsObject: React.FC<{
 		} catch {}
 	}
 
-	const isObject = typeof attribute === 'object'
 	const queryKey = queryBaseKeys.join('.') || label
 	const queryMatch = matchedAttributes[queryKey]
 
@@ -329,7 +328,7 @@ const LogDetailsObject: React.FC<{
 		setOpen(allExpanded)
 	}, [allExpanded])
 
-	return isObject ? (
+	return typeof attribute === 'object' ? (
 		<Box
 			cssClass={styles.line}
 			onClick={(e) => {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

When we try to parse a string as JSON on the frontend, we don't correctly iterate over the parsed result. This results in some undesirable frontend UX (see Before in test plan below).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Send a log request via curl

```
curl -X POST http://localhost:4318/v1/logs \
-H 'Content-Type: application/json' \
-d '{
      "resourceLogs": [
        {
          "resource": {
            "attributes": []
          },
          "scopeLogs": [
            {
              "scope": {},
              "logRecords": [
                {
                  "timeUnixNano": "'$(date +%s000000000)'",
                  "severityNumber": 9,
                  "severityText": "Info",
                  "name": "logA",
                  "body": {
                    "stringValue": "Hello, world! This is sent from a curl command."
                  },
                  "attributes": [
                    {
                      "key": "highlight.project_id",
                      "value": {
                        "stringValue": "1"
                      }
                    },
                    {
                      "key": "response.body",
                      "value": {
                          "stringValue": "{\"code\":0,\"message\":\"User email not found. Please use the email registered with us.\",\"requestId\":\"59ca9343-5e21-494c-bb96-83f863ac2212\"}"
                      }
                    }
                  ],
                  "traceId": "08040201000000000000000000000000",
                  "spanId": "0102040800000000"
                }
              ]
            }
          ]
        }
      ]
    }'
```



Before:
![Screenshot 2023-07-21 at 10 44 36 AM](https://github.com/highlight/highlight/assets/58678/73c2a309-39f5-4908-b517-7b253cadf20b)


After:
![Screenshot 2023-07-21 at 10 44 11 AM](https://github.com/highlight/highlight/assets/58678/2ea71092-ebdd-47f6-ba10-e13e89aa9cb0)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
