### PR TITLE
Standardize Reflame config formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,3 +18,4 @@ scripts/venv
 **/.eslintrc.json
 .yarnrc.yml
 __generated
+.reflame.config.jsonc

--- a/.prettierrc
+++ b/.prettierrc
@@ -10,16 +10,5 @@
 	"arrowParens": "always",
 	"requirePragma": false,
 	"insertPragma": false,
-	"proseWrap": "preserve",
-	"overrides": [
-		{
-			"files": [".reflame.config.jsonc"],
-			"options": {
-				"parser": "json5",
-				"quoteProps": "preserve",
-				"singleQuote": false,
-				"trailingComma": "all"
-			}
-		}
-	]
+	"proseWrap": "preserve"
 }

--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -1,347 +1,397 @@
 {
-	// This is a JSON with Comments file.
-	// It's basically JSON, with the addition of comments, and looser syntax
-	// (trailing commas!).
-	// Reflame uses this to identify your app.
-	"appId": "01GVH35S71FJP26W72V3K7CB2N", // prod
-	// "appId": "01GSXZYQT1W0TZDJAG94P9S4BZ", // prod fork
-	// "appId": "01GR550WASJY2G2NSYZ4P54JJV", // dev
-	// This is what shows up in the browser's tab bar.
-	"title": "Reflame App",
-	// This is the description that shows up in Google search.
-	"description": "A new Reflame app.",
-	// Reflame will watch this directory for your React source code and ship changes
-	// instantly.
-	"sourceDirectory": "frontend/src",
-	// Reflame will use this to keep your app up to date as we make improvements.
-	"foundation": {
-		"name": "ts-react",
-		"version": 1,
-	},
-	"themeColor": "#5629c6",
-	"filesIgnored": ["**/**.css.ts"],
-	"environments": {
-		"production": {
-			"REACT_APP_FIREBASE_CONFIG_OBJECT": "{    apiKey: 'AIzaSyD7g86A3EzEKmoE7aZ04Re3HZ0B4bWlL68',    authDomain: 'auth.highlight.run',    databaseURL: 'https://highlight-f5c5b.firebaseio.com',    projectId: 'highlight-f5c5b',    storageBucket: 'highlight-f5c5b.appspot.com',    messagingSenderId: '263184175068',    appId: '1:263184175068:web:f8190c20320087d1c6c919',}",
-			"REACT_APP_COMMIT_SHA": {
-				"type": "expression",
-				"value": "Reflame.gitCommitSha",
-			},
-			"REACT_APP_PRIVATE_GRAPH_URI": "https://pri.highlight.io",
-			"REACT_APP_ONPREM": "false",
-			"REACT_APP_FRONTEND_URI": {
-				"type": "expression",
-				"value": "window.location.origin",
-			},
-			"REACT_APP_FRONTEND_ORG": "1jdkoe52",
-			"REACT_APP_PUBLIC_GRAPH_URI": "https://pub.highlight.run",
-			"REACT_APP_AUTH_MODE": "firebase",
-			"SLACK_CLIENT_ID": "1354469824468.1868913469441",
-			"REACT_APP_STRIPE_API_PK": "pk_live_51Hlqh1Gz4ry65q42eza36EDSeIpFng39KpZVJzPpsYg5AM7h1rpysaCcZQHnC4J5uNmbjXP6rmSRuf9yr6rfGNOB00aZ73tU9f",
-			"DEMO_ERROR_URL": "/1/errors/RxxaYWFKZPsIa1lF1phmFqTQ04BO",
-			"CLICKUP_CLIENT_ID": "7IRYQ44K5NKLWWFPBPJII08BW7KS4063",
-			"DISCORD_CLIENT_ID": "1024079182013149185",
-			"REACT_APP_FRONT_INTEGRATION_CLIENT_ID": "e77eb8f15b02423c9525",
-			"HEIGHT_CLIENT_ID": "w8GzB4GI8gGUE2iEAQMY8Wck44gK2ek2i4Q8q4myKQY",
-			"DEMO_SESSION_URL": "/1/sessions/SGKFqG4mE8au2UmHjT0BhjO5Q15f",
-			"LINEAR_CLIENT_ID": "f60ff43c7376d0aceaa1e111db39e60d",
-			"DEMO_PROJECT_ID": "1344",
-		},
-		"development": {
-			"REACT_APP_FIREBASE_CONFIG_OBJECT": "{    apiKey: 'AIzaSyD7g86A3EzEKmoE7aZ04Re3HZ0B4bWlL68',    authDomain: 'auth.highlight.run',    databaseURL: 'https://highlight-f5c5b.firebaseio.com',    projectId: 'highlight-f5c5b',    storageBucket: 'highlight-f5c5b.appspot.com',    messagingSenderId: '263184175068',    appId: '1:263184175068:web:f8190c20320087d1c6c919',}",
-			"REACT_APP_COMMIT_SHA": {
-				"type": "expression",
-				"value": "Reflame.gitCommitSha",
-			},
-			"REACT_APP_PRIVATE_GRAPH_URI": "https://localhost:8082/private",
-			"REACT_APP_ONPREM": "false",
-			"REACT_APP_FRONTEND_URI": {
-				"type": "expression",
-				"value": "window.location.origin",
-			},
-			"REACT_APP_FRONTEND_ORG": "1",
-			"REACT_APP_PUBLIC_GRAPH_URI": "https://localhost:8082/public",
-			"REACT_APP_AUTH_MODE": "firebase",
-			"SLACK_CLIENT_ID": "1354469824468.1868913469441",
-			"REACT_APP_STRIPE_API_PK": "pk_test_51Hlqh1Gz4ry65q42v4lYEnAGIB4Tq5rzWwE7PgpdCpQjqJjg1iVuosCzEGFbaJNTxDpo77F3YwOfrSlUp8g4wZYB00ojMQX0DP",
-			"DEMO_ERROR_URL": "/1/errors/RxxaYWFKZPsIa1lF1phmFqTQ04BO",
-			"CLICKUP_CLIENT_ID": "7DAKQO04LB9AT9J9I7ZA37T9HKJO2PPD",
-			"DISCORD_CLIENT_ID": "1024079182013149185",
-			"REACT_APP_FRONT_INTEGRATION_CLIENT_ID": "e77eb8f15b02423c9525",
-			"HEIGHT_CLIENT_ID": "N58AdgpuOi2AmSeG2wKc8Osayo8WIU0UoQGwACiYqyI",
-			"DEMO_SESSION_URL": "/1/sessions/SGKFqG4mE8au2UmHjT0BhjO5Q15f",
-			"LINEAR_CLIENT_ID": "f60ff43c7376d0aceaa1e111db39e60d",
-			"DEMO_PROJECT_ID": "2",
-		},
-	},
-	"environment": "production",
-	"scripts": [
-		"/intercom.js",
-		"/index",
-		"/canny.js",
-		"https://js.hs-scripts.com/20473940.js",
-		// TODO: google tag manager
-	],
-	"stylesheets": [
-		"https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap",
-		"https://unpkg.com/@highlight-run/rrweb@0.9.27/dist/index.css",
-		"/public.css",
-	],
-	"nodejsCompatibility": {
-		"omitModuleExtension": true,
-		"mapIndexToDirectory": true,
-		"packageJson": {
-			"versionIncluded": true,
-			"dependenciesSynced": true,
-		},
-	},
-	"specifierTransforms": [
-		{
-			"from": "/",
-			"to": "@/",
-		},
-		{
-			"from": "/components/",
-			"to": "@components/",
-		},
-		{
-			"from": "/static/",
-			"to": "@icons/",
-		},
-		{
-			"from": "/util/",
-			"to": "@util/",
-		},
-		{
-			"from": "/hooks/",
-			"to": "@hooks/",
-		},
-		{
-			"from": "/pages/",
-			"to": "@pages/",
-		},
-		{
-			"from": "/routers/",
-			"to": "@routers/",
-		},
-		{
-			"from": "/graph/generated/",
-			"to": "@graph/",
-		},
-		{
-			"from": "/authentication/",
-			"to": "@authentication/",
-		},
-		{
-			"from": "/context/",
-			"to": "@context/",
-		},
-		{
-			"from": "/lottie/",
-			"to": "@lottie/",
-		},
-		{
-			"from": "/__generated/index.css",
-			"to": "/style/tailwind.css",
-		},
-		{
-			"from": "/__generated/rr/rr.js",
-			"to": "@highlight-run/rrweb",
-		},
-		{
-			"from": "/__generated/rr/rrTypes.js",
-			"to": "@highlight-run/rrweb-types",
-		},
-		{
-			"from": "/__generated/rr/rr.min.css",
-			"to": "@highlight-run/rrweb/dist/rrweb.min.css",
-		},
-		{
-			"from": "^/__generated/ve/(.*).css.js$",
-			"to": "/$1.css",
-			"phase": "pre",
-		},
-		{
-			"from": "^/__generated/svgr/(.*).svg.js$",
-			"to": "/$1.svg",
-			"phase": "pre",
-		},
-	],
-	"libraries": {
-		"@highlight-run/ui": {
-			"sourceDirectory": "packages/ui/src",
-			"entryPoints": {
-				"/": "/index.ts",
-				"/src": "/index.ts",
-				"/src/components/Box/Box": "/components/Box/Box.tsx",
-				"/src/components/DatePicker/PreviousDateRangePicker": "/components/DatePicker/PreviousDateRangePicker.tsx",
-				"/src/css/vars": "/css/vars.ts",
-				"/src/css/colors": "/css/colors.ts",
-				"/src/css/sprinkles.css": "/css/sprinkles.css",
-				"/src/css/theme.css": "/css/theme.css",
-			},
-			"npmPackages": {
-				"ariakit": {
-					"entryPoints": [
-						"/",
-						"/button",
-						"/combobox",
-						"/form",
-						"/checkbox",
-					],
-				},
-				"@vanilla-extract/sprinkles": {
-					"entryPoints": ["/createRuntimeSprinkles"],
-				},
-				"@vanilla-extract/recipes": {
-					"entryPoints": ["/createRuntimeFn"],
-				},
-			},
-			"nodejsCompatibility": {
-				"omitModuleExtension": true,
-				"mapIndexToDirectory": true,
-				"packageJson": {
-					"dependenciesSynced": true,
-				},
-			},
-			"filesIgnored": ["**/**.css.ts"],
-			"specifierTransforms": {
-				"^/__generated/ve/(.*).css.js$": "/$1.css",
-			},
-		},
-		"highlight.run": {
-			"sourceDirectory": "sdk/firstload/src",
-			"entryPoint": "/index.tsx",
-			"nodejsCompatibility": {
-				"omitModuleExtension": true,
-				"mapIndexToDirectory": true,
-			},
-			"npmPackages": {},
-		},
-		"highlight.io": {
-			"sourceDirectory": "highlight.io",
-			"entryPoint": "/index.ts",
-			"nodejsCompatibility": {
-				"omitModuleExtension": true,
-				"mapIndexToDirectory": true,
-			},
-			"filesIgnored": [
-				"**/**",
-				"!components/**/**",
-				"!content/**/**",
-				"!styles/**/**",
-				"!utils/**/**",
-				"!index.ts",
-			],
-		},
-		"@highlight-run/client": {
-			"sourceDirectory": "sdk/client/src",
-			"entryPoints": {
-				"/src/listeners/first-load-listeners": "/listeners/first-load-listeners.tsx",
-				"/src/listeners/network-listener/utils/utils": "/listeners/network-listener/utils/utils.ts",
-				"/src/utils/secure-id": "/utils/secure-id.ts",
-				"/src/utils/sessionStorage/highlightSession": "/utils/sessionStorage/highlightSession.ts",
-			},
-			"nodejsCompatibility": {
-				"omitModuleExtension": true,
-				"mapIndexToDirectory": true,
-				"packageJson": {
-					"dependenciesSynced": true,
-				},
-			},
-			"specifierTransforms": {
-				"/publicGraphURI.ts": "consts:publicGraphURI",
-			},
-			"npmPackages": {},
-		},
-	},
-	// NPM packages listed here will be installed by Reflame every time you update this file.
-	//
-	// It's important to only include packages that will be used by your app in browsers here.
-	// Including dev-time dependencies that run in node can result in deploy failures and poor
-	// performance.
-	"npmPackages": {
-		"@apollo/client": {
-			"entryPoints": ["/", "/link/context", "/link/ws", "/utilities"],
-		},
-		"@vanilla-extract/recipes": {
-			"entryPoints": ["/createRuntimeFn"],
-		},
-		// TODO: create a library for this
-		// Might need a shim entry point for .css?
-		"@highlight-run/react": {
-			"version": "^3.2.0",
-		},
-		"antd": {
-			"entryPoints": [
-				"/",
-				"/es/menu",
-				"/es/checkbox",
-				"/es/tooltip",
-				"/es/table",
-				"/es/input",
-				"/es/dropdown",
-				"/es/message",
-				"/dist/antd.css",
-			],
-		},
-		"firebase": {
-			"entryPoints": ["/compat/auth", "/compat/app"],
-		},
-		"lodash": {
-			"entryPoints": ["/", "/isEqual"],
-		},
-		"moment": {
-			"entryPoints": ["/", "/moment"],
-		},
-		"rc-slider": {
-			"entryPoints": ["/", "/assets/index.css"],
-		},
-		"react-resizable": {
-			"entryPoints": ["/css/styles.css"],
-		},
-		"react-awesome-query-builder": {
-			"entryPoints": [
-				"/",
-				"/lib/config/antd",
-				"/lib/css/compact_styles.css",
-				"/lib/css/styles.css",
-			],
-		},
-		"react-grid-layout": {
-			"entryPoints": ["/", "/css/styles.css"],
-		},
-		"react-icons": {
-			"entryPoints": ["/fa", "/fi", "/ri", "/vsc"],
-		},
-		"react-loading-skeleton": {
-			"entryPoints": ["/", "/dist/skeleton.css"],
-		},
-		"react-select": {
-			"entryPoints": ["/", "/async", "/async-creatable", "/creatable"],
-		},
-		"react-spinners": {
-			"entryPoints": ["/BarLoader"],
-		},
-		"react-syntax-highlighter": {
-			"entryPoints": [
-				// FIXME: Seems to create ~1000 chunks with esbuild
-				// https://github.com/evanw/esbuild/issues/1836
-				// "/",
-				"/dist/esm/prism",
-				"/dist/esm/light",
-				"/dist/esm/styles/prism",
-			],
-		},
-		"react-use": {
-			"entryPoints": [
-				"/",
-				"/esm/useSessionStorage",
-				"/esm/useLocalStorage",
-			],
-		},
-		"use-query-params": {
-			"entryPoints": ["/", "/adapters/react-router-6"],
-		},
-	},
+  // This is a JSON with Comments file.
+  // It's basically JSON, with the addition of comments, and looser syntax
+  // (trailing commas!).
+  // Reflame uses this to identify your app.
+  "appId": "01GVH35S71FJP26W72V3K7CB2N", // prod
+  // "appId": "01GSXZYQT1W0TZDJAG94P9S4BZ", // prod fork
+  // "appId": "01GR550WASJY2G2NSYZ4P54JJV", // dev
+  // This is what shows up in the browser's tab bar.
+  "title": "Reflame App",
+  // This is the description that shows up in Google search.
+  "description": "A new Reflame app.",
+  // Reflame will watch this directory for your React source code and ship changes
+  // instantly.
+  "sourceDirectory": "frontend/src",
+  // Reflame will use this to keep your app up to date as we make improvements.
+  "foundation": {
+    "name": "ts-react",
+    "version": 1,
+  },
+  "themeColor": "#5629c6",
+  "filesIgnored": [
+    "**/**.css.ts"
+  ],
+  "environments": {
+    "production": {
+      "REACT_APP_FIREBASE_CONFIG_OBJECT": "{    apiKey: 'AIzaSyD7g86A3EzEKmoE7aZ04Re3HZ0B4bWlL68',    authDomain: 'auth.highlight.run',    databaseURL: 'https://highlight-f5c5b.firebaseio.com',    projectId: 'highlight-f5c5b',    storageBucket: 'highlight-f5c5b.appspot.com',    messagingSenderId: '263184175068',    appId: '1:263184175068:web:f8190c20320087d1c6c919',}",
+      "REACT_APP_COMMIT_SHA": {
+        "type": "expression",
+        "value": "Reflame.gitCommitSha",
+      },
+      "REACT_APP_PRIVATE_GRAPH_URI": "https://pri.highlight.io",
+      "REACT_APP_ONPREM": "false",
+      "REACT_APP_FRONTEND_URI": {
+        "type": "expression",
+        "value": "window.location.origin",
+      },
+      "REACT_APP_FRONTEND_ORG": "1jdkoe52",
+      "REACT_APP_PUBLIC_GRAPH_URI": "https://pub.highlight.run",
+      "REACT_APP_AUTH_MODE": "firebase",
+      "SLACK_CLIENT_ID": "1354469824468.1868913469441",
+      "REACT_APP_STRIPE_API_PK": "pk_live_51Hlqh1Gz4ry65q42eza36EDSeIpFng39KpZVJzPpsYg5AM7h1rpysaCcZQHnC4J5uNmbjXP6rmSRuf9yr6rfGNOB00aZ73tU9f",
+      "DEMO_ERROR_URL": "/1/errors/RxxaYWFKZPsIa1lF1phmFqTQ04BO",
+      "CLICKUP_CLIENT_ID": "7IRYQ44K5NKLWWFPBPJII08BW7KS4063",
+      "DISCORD_CLIENT_ID": "1024079182013149185",
+      "REACT_APP_FRONT_INTEGRATION_CLIENT_ID": "e77eb8f15b02423c9525",
+      "HEIGHT_CLIENT_ID": "w8GzB4GI8gGUE2iEAQMY8Wck44gK2ek2i4Q8q4myKQY",
+      "DEMO_SESSION_URL": "/1/sessions/SGKFqG4mE8au2UmHjT0BhjO5Q15f",
+      "LINEAR_CLIENT_ID": "f60ff43c7376d0aceaa1e111db39e60d",
+      "DEMO_PROJECT_ID": "1344",
+    },
+    "development": {
+      "REACT_APP_FIREBASE_CONFIG_OBJECT": "{    apiKey: 'AIzaSyD7g86A3EzEKmoE7aZ04Re3HZ0B4bWlL68',    authDomain: 'auth.highlight.run',    databaseURL: 'https://highlight-f5c5b.firebaseio.com',    projectId: 'highlight-f5c5b',    storageBucket: 'highlight-f5c5b.appspot.com',    messagingSenderId: '263184175068',    appId: '1:263184175068:web:f8190c20320087d1c6c919',}",
+      "REACT_APP_COMMIT_SHA": {
+        "type": "expression",
+        "value": "Reflame.gitCommitSha",
+      },
+      "REACT_APP_PRIVATE_GRAPH_URI": "https://localhost:8082/private",
+      "REACT_APP_ONPREM": "false",
+      "REACT_APP_FRONTEND_URI": {
+        "type": "expression",
+        "value": "window.location.origin",
+      },
+      "REACT_APP_FRONTEND_ORG": "1",
+      "REACT_APP_PUBLIC_GRAPH_URI": "https://localhost:8082/public",
+      "REACT_APP_AUTH_MODE": "firebase",
+      "SLACK_CLIENT_ID": "1354469824468.1868913469441",
+      "REACT_APP_STRIPE_API_PK": "pk_test_51Hlqh1Gz4ry65q42v4lYEnAGIB4Tq5rzWwE7PgpdCpQjqJjg1iVuosCzEGFbaJNTxDpo77F3YwOfrSlUp8g4wZYB00ojMQX0DP",
+      "DEMO_ERROR_URL": "/1/errors/RxxaYWFKZPsIa1lF1phmFqTQ04BO",
+      "CLICKUP_CLIENT_ID": "7DAKQO04LB9AT9J9I7ZA37T9HKJO2PPD",
+      "DISCORD_CLIENT_ID": "1024079182013149185",
+      "REACT_APP_FRONT_INTEGRATION_CLIENT_ID": "e77eb8f15b02423c9525",
+      "HEIGHT_CLIENT_ID": "N58AdgpuOi2AmSeG2wKc8Osayo8WIU0UoQGwACiYqyI",
+      "DEMO_SESSION_URL": "/1/sessions/SGKFqG4mE8au2UmHjT0BhjO5Q15f",
+      "LINEAR_CLIENT_ID": "f60ff43c7376d0aceaa1e111db39e60d",
+      "DEMO_PROJECT_ID": "2",
+    },
+  },
+  "environment": "production",
+  "scripts": [
+    "/intercom.js",
+    "/index",
+    "/canny.js",
+    "https://js.hs-scripts.com/20473940.js",
+    // TODO: google tag manager
+  ],
+  "stylesheets": [
+    "https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap",
+    "https://unpkg.com/@highlight-run/rrweb@0.9.27/dist/index.css",
+    "/public.css",
+  ],
+  "nodejsCompatibility": {
+    "omitModuleExtension": true,
+    "mapIndexToDirectory": true,
+    "packageJson": {
+      "versionIncluded": true,
+      "dependenciesSynced": true,
+    },
+  },
+  "specifierTransforms": [
+    {
+      "from": "/",
+      "to": "@/",
+    },
+    {
+      "from": "/components/",
+      "to": "@components/",
+    },
+    {
+      "from": "/static/",
+      "to": "@icons/",
+    },
+    {
+      "from": "/util/",
+      "to": "@util/",
+    },
+    {
+      "from": "/hooks/",
+      "to": "@hooks/",
+    },
+    {
+      "from": "/pages/",
+      "to": "@pages/",
+    },
+    {
+      "from": "/routers/",
+      "to": "@routers/",
+    },
+    {
+      "from": "/graph/generated/",
+      "to": "@graph/",
+    },
+    {
+      "from": "/authentication/",
+      "to": "@authentication/",
+    },
+    {
+      "from": "/context/",
+      "to": "@context/",
+    },
+    {
+      "from": "/lottie/",
+      "to": "@lottie/",
+    },
+    {
+      "from": "/__generated/index.css",
+      "to": "/style/tailwind.css",
+    },
+    {
+      "from": "/__generated/rr/rr.js",
+      "to": "@highlight-run/rrweb",
+    },
+    {
+      "from": "/__generated/rr/rrTypes.js",
+      "to": "@highlight-run/rrweb-types",
+    },
+    {
+      "from": "/__generated/rr/rr.min.css",
+      "to": "@highlight-run/rrweb/dist/rrweb.min.css",
+    },
+    {
+      "from": "^/__generated/ve/(.*).css.js$",
+      "to": "/$1.css",
+      "phase": "pre",
+    },
+    {
+      "from": "^/__generated/svgr/(.*).svg.js$",
+      "to": "/$1.svg",
+      "phase": "pre",
+    },
+  ],
+  "libraries": {
+    "@highlight-run/ui": {
+      "sourceDirectory": "packages/ui/src",
+      "entryPoints": {
+        "/": "/index.ts",
+        "/src": "/index.ts",
+        "/src/components/Box/Box": "/components/Box/Box.tsx",
+        "/src/components/DatePicker/PreviousDateRangePicker": "/components/DatePicker/PreviousDateRangePicker.tsx",
+        "/src/css/vars": "/css/vars.ts",
+        "/src/css/colors": "/css/colors.ts",
+        "/src/css/sprinkles.css": "/css/sprinkles.css",
+        "/src/css/theme.css": "/css/theme.css",
+      },
+      "npmPackages": {
+        "ariakit": {
+          "entryPoints": [
+            "/",
+            "/button",
+            "/combobox",
+            "/form",
+            "/checkbox",
+          ],
+        },
+        "@vanilla-extract/sprinkles": {
+          "entryPoints": [
+            "/createRuntimeSprinkles"
+          ],
+        },
+        "@vanilla-extract/recipes": {
+          "entryPoints": [
+            "/createRuntimeFn"
+          ],
+        },
+      },
+      "nodejsCompatibility": {
+        "omitModuleExtension": true,
+        "mapIndexToDirectory": true,
+        "packageJson": {
+          "dependenciesSynced": true,
+        },
+      },
+      "filesIgnored": [
+        "**/**.css.ts"
+      ],
+      "specifierTransforms": {
+        "^/__generated/ve/(.*).css.js$": "/$1.css",
+      },
+    },
+    "highlight.run": {
+      "sourceDirectory": "sdk/firstload/src",
+      "entryPoint": "/index.tsx",
+      "nodejsCompatibility": {
+        "omitModuleExtension": true,
+        "mapIndexToDirectory": true,
+      },
+      "npmPackages": {},
+    },
+    "highlight.io": {
+      "sourceDirectory": "highlight.io",
+      "entryPoint": "/index.ts",
+      "nodejsCompatibility": {
+        "omitModuleExtension": true,
+        "mapIndexToDirectory": true,
+      },
+      "filesIgnored": [
+        "**/**",
+        "!components/**/**",
+        "!content/**/**",
+        "!styles/**/**",
+        "!utils/**/**",
+        "!index.ts",
+      ],
+    },
+    "@highlight-run/client": {
+      "sourceDirectory": "sdk/client/src",
+      "entryPoints": {
+        "/src/listeners/first-load-listeners": "/listeners/first-load-listeners.tsx",
+        "/src/listeners/network-listener/utils/utils": "/listeners/network-listener/utils/utils.ts",
+        "/src/utils/secure-id": "/utils/secure-id.ts",
+        "/src/utils/sessionStorage/highlightSession": "/utils/sessionStorage/highlightSession.ts",
+      },
+      "nodejsCompatibility": {
+        "omitModuleExtension": true,
+        "mapIndexToDirectory": true,
+        "packageJson": {
+          "dependenciesSynced": true,
+        },
+      },
+      "specifierTransforms": {
+        "/publicGraphURI.ts": "consts:publicGraphURI",
+      },
+      "npmPackages": {},
+    },
+  },
+  // NPM packages listed here will be installed by Reflame every time you update this file.
+  //
+  // It's important to only include packages that will be used by your app in browsers here.
+  // Including dev-time dependencies that run in node can result in deploy failures and poor
+  // performance.
+  "npmPackages": {
+    "@apollo/client": {
+      "entryPoints": [
+        "/",
+        "/link/context",
+        "/link/ws",
+        "/utilities"
+      ],
+    },
+    "@vanilla-extract/recipes": {
+      "entryPoints": [
+        "/createRuntimeFn"
+      ],
+    },
+    // TODO: create a library for this
+    // Might need a shim entry point for .css?
+    "@highlight-run/react": {
+      "version": "^3.2.0",
+    },
+    "antd": {
+      "entryPoints": [
+        "/",
+        "/es/menu",
+        "/es/checkbox",
+        "/es/tooltip",
+        "/es/table",
+        "/es/input",
+        "/es/dropdown",
+        "/es/message",
+        "/dist/antd.css",
+      ],
+    },
+    "firebase": {
+      "entryPoints": [
+        "/compat/auth",
+        "/compat/app"
+      ],
+    },
+    "lodash": {
+      "entryPoints": [
+        "/",
+        "/isEqual"
+      ],
+    },
+    "moment": {
+      "entryPoints": [
+        "/",
+        "/moment"
+      ],
+    },
+    "rc-slider": {
+      "entryPoints": [
+        "/",
+        "/assets/index.css"
+      ],
+    },
+    "react-resizable": {
+      "entryPoints": [
+        "/css/styles.css"
+      ],
+    },
+    "react-awesome-query-builder": {
+      "entryPoints": [
+        "/",
+        "/lib/config/antd",
+        "/lib/css/compact_styles.css",
+        "/lib/css/styles.css",
+      ],
+    },
+    "react-grid-layout": {
+      "entryPoints": [
+        "/",
+        "/css/styles.css"
+      ],
+    },
+    "react-icons": {
+      "entryPoints": [
+        "/fa",
+        "/fi",
+        "/ri",
+        "/vsc"
+      ],
+    },
+    "react-loading-skeleton": {
+      "entryPoints": [
+        "/",
+        "/dist/skeleton.css"
+      ],
+    },
+    "react-select": {
+      "entryPoints": [
+        "/",
+        "/async",
+        "/async-creatable",
+        "/creatable"
+      ],
+    },
+    "react-spinners": {
+      "entryPoints": [
+        "/BarLoader"
+      ],
+    },
+    "react-syntax-highlighter": {
+      "entryPoints": [
+        // FIXME: Seems to create ~1000 chunks with esbuild
+        // https://github.com/evanw/esbuild/issues/1836
+        // "/",
+        "/dist/esm/prism",
+        "/dist/esm/light",
+        "/dist/esm/styles/prism",
+      ],
+    },
+    "react-use": {
+      "entryPoints": [
+        "/",
+        "/esm/useSessionStorage",
+        "/esm/useLocalStorage",
+      ],
+    },
+    "use-query-params": {
+      "entryPoints": [
+        "/",
+        "/adapters/react-router-6"
+      ],
+    },
+  },
 }

--- a/frontend/scripts/update-reflame-environment.mjs
+++ b/frontend/scripts/update-reflame-environment.mjs
@@ -1,6 +1,5 @@
 import * as jsoncParser from 'jsonc-parser'
 import * as fs from 'node:fs'
-import prettier from 'prettier'
 
 const configPath = '../.reflame.config.jsonc'
 const configText = fs.readFileSync(configPath, 'utf8')
@@ -53,18 +52,17 @@ const result = jsoncParser.applyEdits(
 			LINEAR_CLIENT_ID: process.env.LINEAR_CLIENT_ID ?? null,
 			DEMO_PROJECT_ID: process.env.DEMO_PROJECT_ID ?? '2',
 		},
-		{ formattingOptions: { insertSpaces: false } },
+		{ formattingOptions: { insertSpaces: true, tabSize: 2 } },
 	),
 )
 
-const prettierConfigFile = await prettier.resolveConfigFile(process.cwd())
-
-const prettierConfig = JSON.parse(fs.readFileSync(prettierConfigFile))
-
-const formatted = prettier.format(result, {
-	...prettierConfig,
-	...prettierConfig.overrides[0].options,
-})
+const formatted = jsoncParser.applyEdits(
+	result,
+	jsoncParser.format(result, undefined, {
+		insertSpaces: true,
+		tabSize: 2,
+	}),
+)
 
 if (formatted !== configText) {
 	console.log(`updating Reflame config with '${name}' environment`)


### PR DESCRIPTION
## Summary

I've been working on a new feature to programmatically update the Reflame config based on the NPM package entry points that are actually used (sneak peak [here](https://github.com/lewisl9029/highlight/pull/15/commits/05c4b7f817aa60f73a580e3dd560de886b354af5)). Realized that we need to take over formatting duties for the config from individual projects' prettier configurations, or otherwise there will always be discrepancies between our programmatic updates and prettier output, leading to issues in CI. This PR formats the config according to our new standard and updates prettier configs to ignore it to prevent CI failures.

Prettier's handling of jsonc files was a bit of a hack anyways (it's actually treating it as json5, which can result in subtle bugs and inconsistencies), so this should also make the formatting a bit more robust going forward.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
