### PR TITLE
hide lambda update output

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -872,12 +872,12 @@ const MaintenanceBanner = () => {
 			style={{ backgroundColor: vars.color.y9 }}
 		>
 			<Text color="black">
-				We are performing maintenance which may delay data. Apologies
-				for the inconvenience. Follow on Discord{' '}
+				We are performing maintenance which may delay data ingest.
+				Follow in{' '}
 				<TextLink color="none" href="https://highlight.io/community">
 					#incidents
 				</TextLink>{' '}
-				for updates.
+				on our Discord for updates.
 			</Text>
 		</Box>
 	)

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -5,7 +5,7 @@
 		"build": "tsc --build ./",
 		"dev": "DEV=true nodemon",
 		"publish": "yarn zip && aws s3 cp function.zip s3://highlight-lambda-code/ai-insights.zip && rm function.zip && yarn update",
-		"update": "aws lambda update-function-code --function-name ai-insights --s3-bucket highlight-lambda-code --s3-key ai-insights.zip > /dev/null && echo 'session-activity lambda updated'",
+		"update": "aws lambda update-function-code --function-name ai-insights --s3-bucket highlight-lambda-code --s3-key ai-insights.zip > /dev/null && echo 'ai-insights lambda updated'",
 		"zip": "zip -r function.zip node_modules package.json && cd dist && zip ../function.zip *.js && cd .. "
 	},
 	"type": "commonjs",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -4,7 +4,9 @@
 	"scripts": {
 		"build": "tsc --build ./",
 		"dev": "DEV=true nodemon",
-		"publish": "zip -r function.zip node_modules package.json && cd dist && zip ../function.zip *.js && cd .. && aws s3 cp function.zip s3://highlight-lambda-code/ai-insights.zip && rm function.zip && aws lambda update-function-code --function-name ai-insights --s3-bucket highlight-lambda-code --s3-key ai-insights.zip"
+		"publish": "yarn zip && aws s3 cp function.zip s3://highlight-lambda-code/ai-insights.zip && rm function.zip && yarn update",
+		"update": "aws lambda update-function-code --function-name ai-insights --s3-bucket highlight-lambda-code --s3-key ai-insights.zip > /dev/null && echo 'session-activity lambda updated'",
+		"zip": "zip -r function.zip node_modules package.json && cd dist && zip ../function.zip *.js && cd .. "
 	},
 	"type": "commonjs",
 	"nodemonConfig": {

--- a/render/package.json
+++ b/render/package.json
@@ -12,7 +12,7 @@
 		"test": "yarn test:activity && yarn test:screenshots",
 		"zip": "zip -9 -r function.zip node_modules package.json -x node_modules/typescript/\\* -x node_modules/tsup/\\* -x node_modules/@types/\\* -x node_modules/@highlight-run/node/node_modules/typescript/\\* -x node_modules/@highlight-run/rrweb/node_modules/typescript/\\* && cd dist && zip ../function.zip * && cd ..",
 		"check": "node dist/check.js",
-		"update:screenshots": "aws lambda update-function-code --function-name session-screenshots --s3-bucket highlight-lambda-code --s3-key session-screenshots.zip > /dev/null && echo 'session-activity lambda updated'",
+		"update:screenshots": "aws lambda update-function-code --function-name session-screenshots --s3-bucket highlight-lambda-code --s3-key session-screenshots.zip > /dev/null && echo 'session-screenshots lambda updated'",
 		"update:activity": "aws lambda update-function-code --function-name session-activity --s3-bucket highlight-lambda-code --s3-key session-screenshots.zip > /dev/null && echo 'session-activity lambda updated'",
 		"publish": "yarn zip && aws s3 cp function.zip s3://highlight-lambda-code/session-screenshots.zip && rm function.zip && yarn update:screenshots && yarn update:activity"
 	},

--- a/render/package.json
+++ b/render/package.json
@@ -12,8 +12,8 @@
 		"test": "yarn test:activity && yarn test:screenshots",
 		"zip": "zip -9 -r function.zip node_modules package.json -x node_modules/typescript/\\* -x node_modules/tsup/\\* -x node_modules/@types/\\* -x node_modules/@highlight-run/node/node_modules/typescript/\\* -x node_modules/@highlight-run/rrweb/node_modules/typescript/\\* && cd dist && zip ../function.zip * && cd ..",
 		"check": "node dist/check.js",
-		"update:screenshots": "aws lambda update-function-code --function-name session-screenshots --s3-bucket highlight-lambda-code --s3-key session-screenshots.zip",
-		"update:activity": "aws lambda update-function-code --function-name session-activity --s3-bucket highlight-lambda-code --s3-key session-screenshots.zip",
+		"update:screenshots": "aws lambda update-function-code --function-name session-screenshots --s3-bucket highlight-lambda-code --s3-key session-screenshots.zip > /dev/null && echo 'session-activity lambda updated'",
+		"update:activity": "aws lambda update-function-code --function-name session-activity --s3-bucket highlight-lambda-code --s3-key session-screenshots.zip > /dev/null && echo 'session-activity lambda updated'",
 		"publish": "yarn zip && aws s3 cp function.zip s3://highlight-lambda-code/session-screenshots.zip && rm function.zip && yarn update:screenshots && yarn update:activity"
 	},
 	"installConfig": {


### PR DESCRIPTION
## Summary

`aws update-lambda` would be showing a lot of unnecessary details in the build step.

## How did you test this change?

Local `yarn workspace render publish`

## Are there any deployment considerations?

No
