### PR TITLE
add stale bot for external issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: 'Close stale issues and PRs'
+on:
+    schedule:
+        - cron: '30 1 * * *'
+
+jobs:
+    stale:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/stale@v8
+              with:
+                  any-of-labels: 'external bug / request'
+                  stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. Remove stale label or comment to avoid issue being closed in 5 days.'
+                  close-issue-message: 'This issue was closed because it has been stale for 5 days with no activity.'
+                  days-before-issue-stale: 30
+                  days-before-issue-close: 5


### PR DESCRIPTION
## Summary

Setup a bot to mark external issues at stale after 30 days, and close than after another 5 days.
This bot will help focus our efforts as we improve efforts to triage our external tickets.
It will also help us with getting updates on issues that are waiting for customer input.

## How did you test this change?

N/A

## Are there any deployment considerations?

Will be checking in on the action / issues with the label.
