### PR TITLE
Update Service model with Github repo

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1986,8 +1986,10 @@ func (obj *SessionAlert) SendAlerts(ctx context.Context, db *gorm.DB, mailClient
 
 type Service struct {
 	Model
-	ProjectID int    `gorm:"not null;uniqueIndex:idx_project_id_name"`
-	Name      string `gorm:"not null;uniqueIndex:idx_project_id_name"`
+	ProjectID      int    `gorm:"not null;uniqueIndex:idx_project_id_name"`
+	Name           string `gorm:"not null;uniqueIndex:idx_project_id_name"`
+	Status         string `gorm:"not null;default:created"`
+	GithubRepoPath *string
 }
 
 type LogAlert struct {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1986,9 +1986,9 @@ func (obj *SessionAlert) SendAlerts(ctx context.Context, db *gorm.DB, mailClient
 
 type Service struct {
 	Model
-	ProjectID      int    `gorm:"not null;uniqueIndex:idx_project_id_name"`
-	Name           string `gorm:"not null;uniqueIndex:idx_project_id_name"`
-	Status         string `gorm:"not null;default:created"`
+	ProjectID      int                       `gorm:"not null;uniqueIndex:idx_project_id_name"`
+	Name           string                    `gorm:"not null;uniqueIndex:idx_project_id_name"`
+	Status         modelInputs.ServiceStatus `gorm:"not null;default:created"`
 	GithubRepoPath *string
 }
 

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -9526,11 +9526,17 @@ type ErrorObjectConnection implements Connection {
 	pageInfo: PageInfo!
 }
 
+enum ServiceStatus {
+	healthy
+	error
+	created
+}
+
 type Service {
 	id: ID!
 	projectID: ID!
 	name: String!
-	status: String!
+	status: ServiceStatus!
 	githubRepoPath: String
 }
 
@@ -51899,9 +51905,9 @@ func (ec *executionContext) _Service_status(ctx context.Context, field graphql.C
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(model.ServiceStatus)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNServiceStatus2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceStatus(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Service_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -51911,7 +51917,7 @@ func (ec *executionContext) fieldContext_Service_status(ctx context.Context, fie
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type ServiceStatus does not have child fields")
 		},
 	}
 	return fc, nil
@@ -78260,6 +78266,16 @@ func (ec *executionContext) marshalNService2ᚖgithubᚗcomᚋhighlightᚑrunᚋ
 		return graphql.Null
 	}
 	return ec._Service(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNServiceStatus2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceStatus(ctx context.Context, v interface{}) (model.ServiceStatus, error) {
+	var res model.ServiceStatus
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNServiceStatus2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceStatus(ctx context.Context, sel ast.SelectionSet, v model.ServiceStatus) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) marshalNSession2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSession(ctx context.Context, sel ast.SelectionSet, v model1.Session) graphql.Marshaler {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1554,6 +1554,49 @@ func (e RetentionPeriod) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+type ServiceStatus string
+
+const (
+	ServiceStatusHealthy ServiceStatus = "healthy"
+	ServiceStatusError   ServiceStatus = "error"
+	ServiceStatusCreated ServiceStatus = "created"
+)
+
+var AllServiceStatus = []ServiceStatus{
+	ServiceStatusHealthy,
+	ServiceStatusError,
+	ServiceStatusCreated,
+}
+
+func (e ServiceStatus) IsValid() bool {
+	switch e {
+	case ServiceStatusHealthy, ServiceStatusError, ServiceStatusCreated:
+		return true
+	}
+	return false
+}
+
+func (e ServiceStatus) String() string {
+	return string(e)
+}
+
+func (e *ServiceStatus) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ServiceStatus(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ServiceStatus", str)
+	}
+	return nil
+}
+
+func (e ServiceStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 type SessionAlertType string
 
 const (

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -647,6 +647,14 @@ type ErrorObjectConnection implements Connection {
 	pageInfo: PageInfo!
 }
 
+type Service {
+	id: ID!
+	projectID: ID!
+	name: String!
+	status: String!
+	githubRepoPath: String
+}
+
 enum ReservedLogKey {
 	"""
 	Keep this in alpha order
@@ -1709,6 +1717,7 @@ type Query {
 	error_resolution_suggestion(error_object_id: ID!): String!
 	session_insight(secure_id: String!): SessionInsight
 	system_configuration: SystemConfiguration!
+	services(project_id: ID!): [Service!]!
 }
 
 type Mutation {
@@ -2073,6 +2082,7 @@ type Mutation {
 		is_opt_out: Boolean!
 		project_id: Int
 	): Boolean!
+	editService(id: ID!, project_id: ID!, github_repo_path: String): Service
 }
 
 type Subscription {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -647,11 +647,17 @@ type ErrorObjectConnection implements Connection {
 	pageInfo: PageInfo!
 }
 
+enum ServiceStatus {
+	healthy
+	error
+	created
+}
+
 type Service {
 	id: ID!
 	projectID: ID!
 	name: String!
-	status: String!
+	status: ServiceStatus!
 	githubRepoPath: String
 }
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3632,6 +3632,30 @@ func (r *mutationResolver) UpdateEmailOptOut(ctx context.Context, token *string,
 	return true, nil
 }
 
+// EditService is the resolver for the editService field.
+func (r *mutationResolver) EditService(ctx context.Context, id int, projectID int, githubRepoPath *string) (*model.Service, error) {
+	project, err := r.isAdminInProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceUpdates := map[string]interface{}{}
+	if githubRepoPath != nil {
+		serviceUpdates["GithubRepoPath"] = *githubRepoPath
+		serviceUpdates["Status"] = "healthy"
+	} else {
+		serviceUpdates["GithubRepoPath"] = ""
+		serviceUpdates["Status"] = "created"
+	}
+
+	service := &model.Service{}
+	updateErr := r.DB.Where(&model.Service{Model: model.Model{ID: id}, ProjectID: project.ID}).Take(&service).Updates(&serviceUpdates).Error
+	if updateErr != nil {
+		return nil, updateErr
+	}
+	return service, nil
+}
+
 // Accounts is the resolver for the accounts field.
 func (r *queryResolver) Accounts(ctx context.Context) ([]*modelInputs.Account, error) {
 	if !r.isWhitelistedAccount(ctx) {
@@ -7489,6 +7513,21 @@ func (r *queryResolver) SystemConfiguration(ctx context.Context) (*model.SystemC
 		return nil, err
 	}
 	return &config, nil
+}
+
+// Services is the resolver for the services field.
+func (r *queryResolver) Services(ctx context.Context, projectID int) ([]*model.Service, error) {
+	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	services := []*model.Service{}
+	if err := r.DB.Order("name ASC").Model(&model.Service{}).Where(&model.Service{ProjectID: project.ID}).Scan(&services).Error; err != nil {
+		return nil, e.Wrap(err, "error getting associated services")
+	}
+
+	return services, nil
 }
 
 // Params is the resolver for the params field.

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7524,7 +7524,7 @@ func (r *queryResolver) Services(ctx context.Context, projectID int) ([]*model.S
 
 	services := []*model.Service{}
 	if err := r.DB.Order("name ASC").Model(&model.Service{}).Where(&model.Service{ProjectID: project.ID}).Scan(&services).Error; err != nil {
-		return nil, e.Wrap(err, "error getting associated services")
+		return nil, err
 	}
 
 	return services, nil

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -968,6 +968,7 @@ export type Mutation = {
 	editProject?: Maybe<Project>
 	editProjectSettings?: Maybe<AllProjectSettings>
 	editSegment?: Maybe<Scalars['Boolean']>
+	editService?: Maybe<Service>
 	editWorkspace?: Maybe<Workspace>
 	editWorkspaceSettings?: Maybe<AllWorkspaceSettings>
 	emailSignup: Scalars['String']
@@ -1268,6 +1269,12 @@ export type MutationEditSegmentArgs = {
 	id: Scalars['ID']
 	name: Scalars['String']
 	params: SearchParamsInput
+	project_id: Scalars['ID']
+}
+
+export type MutationEditServiceArgs = {
+	github_repo_path?: InputMaybe<Scalars['String']>
+	id: Scalars['ID']
 	project_id: Scalars['ID']
 }
 
@@ -1722,6 +1729,7 @@ export type Query = {
 	resources?: Maybe<Array<Maybe<Scalars['Any']>>>
 	segments?: Maybe<Array<Maybe<Segment>>>
 	serverIntegration: IntegrationStatus
+	services: Array<Service>
 	session?: Maybe<Session>
 	sessionLogs: Array<LogEdge>
 	session_comment_tags_for_project: Array<SessionCommentTag>
@@ -2206,6 +2214,10 @@ export type QueryServerIntegrationArgs = {
 	project_id: Scalars['ID']
 }
 
+export type QueryServicesArgs = {
+	project_id: Scalars['ID']
+}
+
 export type QuerySessionArgs = {
 	secure_id: Scalars['String']
 }
@@ -2469,6 +2481,15 @@ export type Segment = {
 	name: Scalars['String']
 	params: SearchParams
 	project_id: Scalars['ID']
+}
+
+export type Service = {
+	__typename?: 'Service'
+	githubRepoPath?: Maybe<Scalars['String']>
+	id: Scalars['ID']
+	name: Scalars['String']
+	projectID: Scalars['ID']
+	status: Scalars['String']
 }
 
 export type Session = {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2489,7 +2489,13 @@ export type Service = {
 	id: Scalars['ID']
 	name: Scalars['String']
 	projectID: Scalars['ID']
-	status: Scalars['String']
+	status: ServiceStatus
+}
+
+export enum ServiceStatus {
+	Created = 'created',
+	Error = 'error',
+	Healthy = 'healthy',
 }
 
 export type Session = {


### PR DESCRIPTION
## Summary
Update the Service model to have:
- github repo link so we can fetch when appropriate
- status incase the repo link causes errors

Adds a query to fetch services by project id
Adds a mutation to update the service object

## How did you test this change?
Postman - send GraphQL requests to the new Service query and EditService mutation

https://www.loom.com/share/6d46202e8fc0494ca798a571b87754c9?sid=69238973-4045-411f-b0df-4db3873ce5ee

## Are there any deployment considerations?
N/A
