### PR TITLE
improve user property alert

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2863,6 +2863,17 @@ func (r *Resolver) SendSessionTrackPropertiesAlert(ctx context.Context, workspac
 	}
 
 	for _, sessionAlert := range sessionAlerts {
+		// skip alerts that have already been sent for this session
+		var count int64
+		if err := r.DB.Model(&model.SessionAlertEvent{}).Where(&model.SessionAlertEvent{
+			SessionAlertID:  sessionAlert.ID,
+			SessionSecureID: session.SecureID,
+		}).Count(&count).Error; err != nil {
+			continue
+		}
+		if count > 0 {
+			continue
+		}
 		excludedEnvironments, err := sessionAlert.GetExcludedEnvironments()
 		if err != nil {
 			log.WithContext(ctx).Error(e.Wrapf(err, "[project_id: %d] error getting excluded environments from track properties alert", session.ProjectID))
@@ -3023,6 +3034,17 @@ func (r *Resolver) SendSessionUserPropertiesAlert(ctx context.Context, workspace
 	}
 
 	for _, sessionAlert := range sessionAlerts {
+		// skip alerts that have already been sent for this session
+		var count int64
+		if err := r.DB.Model(&model.SessionAlertEvent{}).Where(&model.SessionAlertEvent{
+			SessionAlertID:  sessionAlert.ID,
+			SessionSecureID: session.SecureID,
+		}).Count(&count).Error; err != nil {
+			continue
+		}
+		if count > 0 {
+			continue
+		}
 		// check if session was produced from an excluded environment
 		excludedEnvironments, err := sessionAlert.GetExcludedEnvironments()
 		if err != nil {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -429,6 +429,8 @@ func (r *Resolver) GetOrCreateErrorGroup(ctx context.Context, errorObj *model.Er
 	return errorGroup, nil
 }
 
+// TODO(vkorolik) GetTopErrorGroupMatchByEmbedding
+
 func (r *Resolver) GetTopErrorGroupMatch(event string, projectID int, fingerprints []*model.ErrorFingerprint) (*int, error) {
 	firstCode := ""
 	firstMeta := ""

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1327,8 +1327,12 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 			allUserProperties[k] = fmt.Sprintf("%v", v)
 		}
 	}
+	newUserProperties["identified_email"] = "false"
+	allUserProperties["identified_email"] = "false"
 	// auto-set domain if email is provided
 	if em, ok := allUserProperties["email"]; ok {
+		newUserProperties["identified_email"] = "true"
+		allUserProperties["identified_email"] = "true"
 		if parts := strings.Split(em, "@"); len(parts) == 2 {
 			newUserProperties["domain"] = parts[1]
 			allUserProperties["domain"] = parts[1]

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -87,6 +87,11 @@ export const SessionAlertFragmentFragmentDoc = gql`
 			name
 			value
 		}
+		UserProperties {
+			id
+			name
+			value
+		}
 		Type
 	}
 	${DiscordChannelFragmentFragmentDoc}

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -1464,6 +1464,14 @@ export type SessionAlertFragmentFragment = {
 				>
 			>
 		>
+		UserProperties: Array<
+			Types.Maybe<
+				{ __typename?: 'UserProperty' } & Pick<
+					Types.UserProperty,
+					'id' | 'name' | 'value'
+				>
+			>
+		>
 	}
 
 export type DiscordChannelFragmentFragment = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -75,6 +75,11 @@ fragment SessionAlertFragment on SessionAlert {
 		name
 		value
 	}
+	UserProperties {
+		id
+		name
+		value
+	}
 	Type
 }
 

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/AlertConfigurationCard.tsx
@@ -49,6 +49,8 @@ import {
 	LOOKBACK_PERIODS,
 } from './AlertConfigurationConstants'
 
+const SEPARATOR = ':$&'
+
 interface AlertConfiguration {
 	name: string
 	canControlThreshold: boolean
@@ -266,8 +268,11 @@ export const AlertConfigurationCard = ({
 									track_properties: form
 										.getFieldValue('trackProperties')
 										.map((trackProperty: any) => {
-											const [value, name, id] =
-												trackProperty.split(':')
+											const [id, name, value] =
+												trackProperty.split(
+													SEPARATOR,
+													3,
+												)
 											return {
 												id,
 												value,
@@ -292,8 +297,8 @@ export const AlertConfigurationCard = ({
 									user_properties: form
 										.getFieldValue('userProperties')
 										.map((userProperty: any) => {
-											const [value, name, id] =
-												userProperty.split(':')
+											const [id, name, value] =
+												userProperty.split(SEPARATOR, 3)
 											return {
 												id,
 												value,
@@ -361,8 +366,8 @@ export const AlertConfigurationCard = ({
 									user_properties: form
 										.getFieldValue('userProperties')
 										.map((userProperty: any) => {
-											const [value, name, id] =
-												userProperty.split(':')
+											const [id, name, value] =
+												userProperty.split(SEPARATOR, 3)
 											return {
 												id,
 												value,
@@ -389,8 +394,11 @@ export const AlertConfigurationCard = ({
 									track_properties: form
 										.getFieldValue('trackProperties')
 										.map((trackProperty: any) => {
-											const [value, name, id] =
-												trackProperty.split(':')
+											const [id, name, value] =
+												trackProperty.split(
+													SEPARATOR,
+													3,
+												)
 											return {
 												id,
 												value,
@@ -599,7 +607,8 @@ export const AlertConfigurationCard = ({
 	const onUserPropertiesChange = (_value: any, options: any) => {
 		const userProperties = options.map(
 			({ value: valueAndName }: { key: string; value: string }) => {
-				const [value, name, id] = valueAndName.split(':')
+				const [id, name, value] = valueAndName.split(SEPARATOR, 3)
+				console.log('vadim', { valueAndName, value, name, id })
 				return {
 					id,
 					value,
@@ -614,7 +623,7 @@ export const AlertConfigurationCard = ({
 	const onTrackPropertiesChange = (_value: any, options: any) => {
 		const trackProperties = options.map(
 			({ value: valueAndName }: { key: string; value: string }) => {
-				const [value, name, id] = valueAndName.split(':')
+				const [id, name, value] = valueAndName.split(SEPARATOR, 3)
 				return {
 					id,
 					value,
@@ -1200,7 +1209,9 @@ const getPropertiesOption = (option: any) => ({
 				{option?.value}
 			</>
 		) || '',
-	value: `${option?.value}:${option?.name}:${option?.id}` || '',
-	id: `${option?.value}:${option?.name}` || '',
+	value:
+		`${option?.id}${SEPARATOR}${option?.name}${SEPARATOR}${option?.value}` ||
+		'',
+	id: `${option?.name}${SEPARATOR}${option?.value}` || '',
 	name: option?.id || '',
 })

--- a/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
+++ b/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
@@ -15,7 +15,7 @@ import { getChromeExtensionURL } from '@pages/Player/SessionLevelBar/utils/utils
 import { bytesToPrettyString } from '@util/string'
 import { buildQueryStateString } from '@util/url/params'
 import { message } from 'antd'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { useSearchContext } from '../../Sessions/SearchContext/SearchContext'
 import { useReplayerContext } from '../ReplayerContext'
@@ -42,20 +42,6 @@ const MetadataPanel = () => {
 	const { session, browserExtensionScriptURLs } = useReplayerContext()
 	const { setSearchQuery, removeSelectedSegment } = useSearchContext()
 	const { isHighlightAdmin } = useAuthContext()
-
-	const [parsedFields, setParsedFields] = useState<Field[]>([])
-
-	useEffect(() => {
-		const fields = session?.fields?.filter((f) => {
-			return (
-				f &&
-				f.type === 'user' &&
-				f.name !== 'identifier' &&
-				f.value.length
-			)
-		}) as Field[]
-		setParsedFields(fields)
-	}, [session?.fields])
 
 	const sessionData: TableListItem[] = [
 		{
@@ -200,13 +186,11 @@ const MetadataPanel = () => {
 		},
 	]
 
-	if (session?.city) {
-		userData.push({
-			keyDisplayValue: 'Location',
-			valueDisplayValue: `${session?.city}, ${session?.state} ${session?.postal}`,
-		})
-	}
-
+	const parsedFields = session?.fields?.filter((f) => {
+		return (
+			f && f.type === 'user' && f.name !== 'identifier' && f.value.length
+		)
+	}) as Field[]
 	parsedFields?.forEach((field) => {
 		if (field.name !== 'avatar') {
 			userData.push({
@@ -215,6 +199,26 @@ const MetadataPanel = () => {
 			})
 		}
 	})
+
+	if (session?.user_properties) {
+		for (const [k, v] of Object.entries(
+			JSON.parse(session?.user_properties),
+		)) {
+			if (k !== 'avatar') {
+				userData.push({
+					keyDisplayValue: k,
+					valueDisplayValue: v?.toString(),
+				})
+			}
+		}
+	}
+
+	if (session?.city) {
+		userData.push({
+			keyDisplayValue: 'Location',
+			valueDisplayValue: `${session?.city}, ${session?.state} ${session?.postal}`,
+		})
+	}
 
 	const deviceData: TableListItem[] = []
 


### PR DESCRIPTION
## Summary

Adds support for setting up a session property by user domain by auto-reporting on `H.identify` calls.
* ensure multiple alerts are processed even when one is skipped
* fix user properties alert input not showing in the frontend
* ensure only one notification is sent per alert per session
* auto reports a `domain` user property when a session is identified.
* shows `H.identify` user properties in the session metadata panel

## How did you test this change?

<img width="373" alt="image" src="https://github.com/highlight/highlight/assets/1351531/4c6a58ea-a30e-4dd4-9220-e09e0279145f">

https://www.loom.com/share/e5fb8b3cbf3c469fba9882a8fe013184

## Are there any deployment considerations?

No
Closes #5708
