### PR TITLE
update opentelemetry dependency to fix cjs error

### DIFF
--- a/sdk/highlight-cloudflare/package.json
+++ b/sdk/highlight-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/cloudflare",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"packageManager": "yarn@3.2.3",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -19,7 +19,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230518.0",
-		"@opentelemetry/resources": "^1.15.0",
+		"@opentelemetry/resources": "1.15.1",
 		"tsup": "^6.7.0"
 	}
 }

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "3.1.4",
+	"version": "3.1.5",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",
@@ -24,6 +24,12 @@
 			"require": "./dist/HighlightInit.js"
 		}
 	},
+	"installConfig": {
+		"hoistingLimits": "workspaces"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
 	"scripts": {
 		"typegen": "tsup --dts-only",
 		"dev": "tsup --watch && sh ./bin/clean-highlight-init.sh",
@@ -40,7 +46,6 @@
 	"dependencies": {
 		"@highlight-run/node": "workspace:*",
 		"@highlight-run/sourcemap-uploader": "workspace:*",
-		"@opentelemetry/api": "^1.4.1",
 		"highlight.run": "workspace:*",
 		"npm-run-all": "4.1.5"
 	},

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "3.1.4",
+	"version": "3.1.5",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -18,16 +18,21 @@
 		"build": "tsup src/index.ts --format cjs,esm --dts",
 		"test": "jest"
 	},
+	"installConfig": {
+		"hoistingLimits": "workspaces"
+	},
 	"publishConfig": {
 		"access": "public"
 	},
 	"dependencies": {
-		"@opentelemetry/api": "^1.4.1",
+		"@opentelemetry/api": "1.4.1",
 		"@opentelemetry/auto-instrumentations-node": "0.38.0",
-		"@opentelemetry/exporter-trace-otlp-http": "0.41.0",
-		"@opentelemetry/resources": "^1.15.0",
-		"@opentelemetry/sdk-node": "0.41.0",
-		"@opentelemetry/sdk-trace-base": "1.15.0",
+		"@opentelemetry/core": "1.15.1",
+		"@opentelemetry/exporter-trace-otlp-http": "0.41.1",
+		"@opentelemetry/resources": "1.15.1",
+		"@opentelemetry/sdk-node": "0.41.1",
+		"@opentelemetry/sdk-trace-base": "1.15.1",
+		"@opentelemetry/semantic-conventions": "1.15.1",
 		"error-stack-parser": "2.0.7",
 		"highlight.run": "workspace:*",
 		"lru-cache": "^7.14.0",

--- a/sdk/highlight-node/src/sdk.test.ts
+++ b/sdk/highlight-node/src/sdk.test.ts
@@ -1,4 +1,3 @@
-import { NextApiHandler } from 'next'
 import { H, HIGHLIGHT_REQUEST_HEADER } from './sdk.js'
 
 describe('parseHeaders', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12924,7 +12924,7 @@ __metadata:
   resolution: "@highlight-run/cloudflare@workspace:sdk/highlight-cloudflare"
   dependencies:
     "@cloudflare/workers-types": ^4.20230518.0
-    "@opentelemetry/resources": ^1.15.0
+    "@opentelemetry/resources": 1.15.1
     diary: ^0.4.4
     opentelemetry-sdk-workers: ^0.6.2
     tsup: ^6.7.0
@@ -13113,7 +13113,6 @@ __metadata:
   dependencies:
     "@highlight-run/node": "workspace:*"
     "@highlight-run/sourcemap-uploader": "workspace:*"
-    "@opentelemetry/api": ^1.4.1
     "@trpc/server": ^9.27.4
     "@types/jest": 27.4.1
     eslint: 8.39.0
@@ -13135,12 +13134,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@highlight-run/node@workspace:sdk/highlight-node"
   dependencies:
-    "@opentelemetry/api": ^1.4.1
+    "@opentelemetry/api": 1.4.1
     "@opentelemetry/auto-instrumentations-node": 0.38.0
-    "@opentelemetry/exporter-trace-otlp-http": 0.41.0
-    "@opentelemetry/resources": ^1.15.0
-    "@opentelemetry/sdk-node": 0.41.0
-    "@opentelemetry/sdk-trace-base": 1.15.0
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/exporter-trace-otlp-http": 0.41.1
+    "@opentelemetry/resources": 1.15.1
+    "@opentelemetry/sdk-node": 0.41.1
+    "@opentelemetry/sdk-trace-base": 1.15.1
+    "@opentelemetry/semantic-conventions": 1.15.1
     "@types/jest": ^29.2.0
     "@types/lru-cache": ^7.10.10
     "@types/node": 17.0.13
@@ -15536,7 +15537,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:^1.0.0, @opentelemetry/api@npm:^1.4.1":
+"@opentelemetry/api-logs@npm:0.41.1":
+  version: 0.41.1
+  resolution: "@opentelemetry/api-logs@npm:0.41.1"
+  dependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: f5a83b3daa59bec613ef2c44e787fbdc5cf91c962247272de8dfb1529ec05b9c111b8426d67d5143990e5dbeb5275287a6d57d10f23fa123fb4171e7963c91f9
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/api@npm:1.4.1, @opentelemetry/api@npm:^1.0.0":
   version: 1.4.1
   resolution: "@opentelemetry/api@npm:1.4.1"
   checksum: e783c40d1a518abf9c4c5d65223237c1392cd9a6c53ac6e2c3ef0c05ff7266e3dfc4fd9874316dae0dcb7a97950878deb513bcbadfaad653d48f0215f2a0911b
@@ -15615,6 +15625,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/context-async-hooks@npm:1.15.1":
+  version: 1.15.1
+  resolution: "@opentelemetry/context-async-hooks@npm:1.15.1"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.5.0"
+  checksum: 5bd625489ef53c122722724d8a5582f7749e88086ee81507efc44e3d92c302daf43e6cb40a21529140d75ac72bc581d724fb5cfb14a2d787647863e1674851f4
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/core@npm:1.12.0, @opentelemetry/core@npm:^1.8.0":
   version: 1.12.0
   resolution: "@opentelemetry/core@npm:1.12.0"
@@ -15635,6 +15654,17 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   checksum: 4fc99d1ecb4497d711e70b626b57b13272667fa54e15aea1f8249104b00d0906459594cf7dc4395ebc00be3dd8a9bf7d1df32cb2caa39a4a014a8f34809d647c
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:1.15.1":
+  version: 1.15.1
+  resolution: "@opentelemetry/core@npm:1.15.1"
+  dependencies:
+    "@opentelemetry/semantic-conventions": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.5.0"
+  checksum: 875c75870bc3b178db20edfde90052cc09086c41736b9e31587cce428c569421b87553c4cffbf4efee9b2919030b8150bcf95af26933d52207b344ae8b397040
   languageName: node
   linkType: hard
 
@@ -15664,6 +15694,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/exporter-jaeger@npm:1.15.1":
+  version: 1.15.1
+  resolution: "@opentelemetry/exporter-jaeger@npm:1.15.1"
+  dependencies:
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/sdk-trace-base": 1.15.1
+    "@opentelemetry/semantic-conventions": 1.15.1
+    jaeger-client: ^3.15.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: 571f29eddd22dfd909e8df587710e8127ab7d9e1141f83d87bf99c7a65191ddff3d9fba7f821f5a3473ffad600371ab0fe8f1656a554e8706ab0493241c31c19
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/exporter-trace-otlp-grpc@npm:0.41.0":
   version: 0.41.0
   resolution: "@opentelemetry/exporter-trace-otlp-grpc@npm:0.41.0"
@@ -15681,6 +15725,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/exporter-trace-otlp-grpc@npm:0.41.1":
+  version: 0.41.1
+  resolution: "@opentelemetry/exporter-trace-otlp-grpc@npm:0.41.1"
+  dependencies:
+    "@grpc/grpc-js": ^1.7.1
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/otlp-grpc-exporter-base": 0.41.1
+    "@opentelemetry/otlp-transformer": 0.41.1
+    "@opentelemetry/resources": 1.15.1
+    "@opentelemetry/sdk-trace-base": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: 1ccdfee1414c84851a0840a1dcd89d186cd1c2f0a770b46d33fbda9315fee3d76037fa29f9edc5d3a107161ba7a12cab3a729a6e9d0e0fc0c386a0af9430e6cd
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/exporter-trace-otlp-http@npm:0.41.0":
   version: 0.41.0
   resolution: "@opentelemetry/exporter-trace-otlp-http@npm:0.41.0"
@@ -15694,6 +15754,21 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.0.0
   checksum: 2713c9ef61ffc14d23071d8ac676c52cb860bfc37719cf846fba8e0c2202c5bebe03e179d4c460c7d8f46da7f1e5e6c471acb3d98c8f7b59e5e8252981bf3c8f
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-trace-otlp-http@npm:0.41.1":
+  version: 0.41.1
+  resolution: "@opentelemetry/exporter-trace-otlp-http@npm:0.41.1"
+  dependencies:
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/otlp-exporter-base": 0.41.1
+    "@opentelemetry/otlp-transformer": 0.41.1
+    "@opentelemetry/resources": 1.15.1
+    "@opentelemetry/sdk-trace-base": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: a5539b88cd57a51727b145073309134c3935f3c6ae920e1dcd9109fd334dfa9d8351beae35da9bab22916c36d67f18dccd60a83809230c1317a47c7dac7af7e9
   languageName: node
   linkType: hard
 
@@ -15714,6 +15789,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/exporter-trace-otlp-proto@npm:0.41.1":
+  version: 0.41.1
+  resolution: "@opentelemetry/exporter-trace-otlp-proto@npm:0.41.1"
+  dependencies:
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/otlp-exporter-base": 0.41.1
+    "@opentelemetry/otlp-proto-exporter-base": 0.41.1
+    "@opentelemetry/otlp-transformer": 0.41.1
+    "@opentelemetry/resources": 1.15.1
+    "@opentelemetry/sdk-trace-base": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: 7ee1c6a70d3deaf8ace1c9ed6ef1153d66f2b5421b6249949fc6f0deeedcde0e295e608a6cf7bb28c4ec570d8d7596989e2f059f13ed47d7e169c842e5873458
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/exporter-zipkin@npm:1.15.0":
   version: 1.15.0
   resolution: "@opentelemetry/exporter-zipkin@npm:1.15.0"
@@ -15726,6 +15817,20 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.0.0
   checksum: 3a66d579e2b6e08f56685a7177e1f10382a528b3ea98e7532221cd246385bd9b4b9360a8757f39ef8a28c8f61a497aa21c40a0286f33b5439202103927904443
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/exporter-zipkin@npm:1.15.1":
+  version: 1.15.1
+  resolution: "@opentelemetry/exporter-zipkin@npm:1.15.1"
+  dependencies:
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/resources": 1.15.1
+    "@opentelemetry/sdk-trace-base": 1.15.1
+    "@opentelemetry/semantic-conventions": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: c2714c47e06747796b679e599465d8af616b9e6108f3a4d46dc6d203361e0b24a21caa66b4ce13ff6ef0d9dd8944d17d2a97e3ecf3d7b93f6b1cd0f0d2cdcd01
   languageName: node
   linkType: hard
 
@@ -16243,6 +16348,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation@npm:0.41.1":
+  version: 0.41.1
+  resolution: "@opentelemetry/instrumentation@npm:0.41.1"
+  dependencies:
+    "@types/shimmer": ^1.0.2
+    import-in-the-middle: 1.4.1
+    require-in-the-middle: ^7.1.1
+    semver: ^7.5.1
+    shimmer: ^1.2.1
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 3b2b51cfd2ca645700097dd7c013ef1305b3c0aac8777c7a9bf3cbd07e538de7e88671ebb731924a8d77368b05a051b700ab90e12347af16ab54f6097b322142
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/otlp-exporter-base@npm:0.41.0":
   version: 0.41.0
   resolution: "@opentelemetry/otlp-exporter-base@npm:0.41.0"
@@ -16252,6 +16372,17 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.0.0
   checksum: 27bd1d0804752776ef6ff050c19517c4893dcc726c9f453edd2acf7d6b0fd0f765e05ddb0b88f7bfe17c0aa943a5da934eb6de5c45016985524f99ea81e6aa83
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/otlp-exporter-base@npm:0.41.1":
+  version: 0.41.1
+  resolution: "@opentelemetry/otlp-exporter-base@npm:0.41.1"
+  dependencies:
+    "@opentelemetry/core": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: 464e71773405a4fd647765dbbba9272f2594a9b74922947221510940a74a48468bbcff724cd4716a49be5b7159eb16eca7f062b84b49b99807b367d5d54e228a
   languageName: node
   linkType: hard
 
@@ -16281,6 +16412,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/otlp-grpc-exporter-base@npm:0.41.1":
+  version: 0.41.1
+  resolution: "@opentelemetry/otlp-grpc-exporter-base@npm:0.41.1"
+  dependencies:
+    "@grpc/grpc-js": ^1.7.1
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/otlp-exporter-base": 0.41.1
+    protobufjs: ^7.2.3
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: e4136cbf186d92d9d8b3dd90de9bba7c92eeeab46232332d8d9612e4842819d10d93058049bbaaee08521ce7a079da82a13fd0cbd1dd9db5aa0d6934de47ced0
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/otlp-proto-exporter-base@npm:0.41.0":
   version: 0.41.0
   resolution: "@opentelemetry/otlp-proto-exporter-base@npm:0.41.0"
@@ -16292,6 +16437,19 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.0.0
   checksum: b87da885cf43f8d50f8315c8f1dbca209baa8b17f426e7e53f514d3d53e69c41a55ffd7f3f70d8cf4eb3326d0c80a87c9a28c5467eb80c9befba38651e4ed0c1
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/otlp-proto-exporter-base@npm:0.41.1":
+  version: 0.41.1
+  resolution: "@opentelemetry/otlp-proto-exporter-base@npm:0.41.1"
+  dependencies:
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/otlp-exporter-base": 0.41.1
+    protobufjs: ^7.2.3
+  peerDependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: a392a7901b95ac11af64c45ccc38518e58e62e4f1426a2e4bae638db5c581a372268d3f2f38e95bd927217588c4889b92b9438d108570509a5035b083e9f28da
   languageName: node
   linkType: hard
 
@@ -16309,6 +16467,22 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.3.0 <1.5.0"
   checksum: 476280434fcdead4679c3b2d5075e0cc5c3cb6a2fed27fc39d3cbb49ef774901cc67b360e12c8faa5a3f07a6cb52bcf40f3d739ede90433e467664cf3d3500e4
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/otlp-transformer@npm:0.41.1":
+  version: 0.41.1
+  resolution: "@opentelemetry/otlp-transformer@npm:0.41.1"
+  dependencies:
+    "@opentelemetry/api-logs": 0.41.1
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/resources": 1.15.1
+    "@opentelemetry/sdk-logs": 0.41.1
+    "@opentelemetry/sdk-metrics": 1.15.1
+    "@opentelemetry/sdk-trace-base": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.5.0"
+  checksum: 388ccd0cecdd1a6aa6fdf092c03d3d68cae7004901f0860df4e529c9a3d5322ac02f3f52ca37d266c4ca63507e958f6274135579554804d1b7603fd53fcbac8a
   languageName: node
   linkType: hard
 
@@ -16361,6 +16535,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/propagator-b3@npm:1.15.1":
+  version: 1.15.1
+  resolution: "@opentelemetry/propagator-b3@npm:1.15.1"
+  dependencies:
+    "@opentelemetry/core": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.5.0"
+  checksum: 5e8c1068531bdd837c2a1cdd978e3e99b3a50ed9cfb48f3f6353d9bae839759a9641bc2d01ededdb3bd6b1668a810022e69b7f39dacefdf127c739125b067d51
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/propagator-jaeger@npm:1.15.0":
   version: 1.15.0
   resolution: "@opentelemetry/propagator-jaeger@npm:1.15.0"
@@ -16370,6 +16555,17 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   checksum: fc0dd356e2d1fc188bb98e439eefbc01fb37425b1a7d2912f462d8338ec6ce8aa47cb7d8f5640938486d86eedb9c776ee65c920e79603cf4d4f0d0e97fadaca5
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/propagator-jaeger@npm:1.15.1":
+  version: 1.15.1
+  resolution: "@opentelemetry/propagator-jaeger@npm:1.15.1"
+  dependencies:
+    "@opentelemetry/core": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.5.0"
+  checksum: 85111fd6b64848890d77a0b367a1fc86166cced61b4afa1cecfecac17bfc8a45ef221ad66b3b1bb9362ed57ea38f325521c0d75d2f78bd9bcbd57e298335fbde
   languageName: node
   linkType: hard
 
@@ -16437,7 +16633,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/resources@npm:1.15.0, @opentelemetry/resources@npm:^1.0.0, @opentelemetry/resources@npm:^1.12.0, @opentelemetry/resources@npm:^1.15.0":
+"@opentelemetry/resources@npm:1.15.0, @opentelemetry/resources@npm:^1.0.0, @opentelemetry/resources@npm:^1.12.0":
   version: 1.15.0
   resolution: "@opentelemetry/resources@npm:1.15.0"
   dependencies:
@@ -16447,6 +16643,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   checksum: d0075e1af2c24b1f28608fc5bfc03f1cbde1aeba3b83060e060d46f32169959ea01c7da4365323f13eba83fb66a3b23a7babf23e51196d54f554e753ff64dc2b
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/resources@npm:1.15.1":
+  version: 1.15.1
+  resolution: "@opentelemetry/resources@npm:1.15.1"
+  dependencies:
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/semantic-conventions": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.5.0"
+  checksum: be7b45827306d84e842fdbed2b19a96c8746ab8b6fba112645b2b0eb6d406c23bf8eefe5e22b3897b349cd00e906e59a7c82bf4dcaf61b87ac984c0516e63819
   languageName: node
   linkType: hard
 
@@ -16488,6 +16696,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/sdk-logs@npm:0.41.1":
+  version: 0.41.1
+  resolution: "@opentelemetry/sdk-logs@npm:0.41.1"
+  dependencies:
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/resources": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.4.0 <1.5.0"
+    "@opentelemetry/api-logs": ">=0.39.1"
+  checksum: 92db4e9ad367b08598d7ee5045275fbe038d2fdf513f3bbdefa0f8011f3afc3fceeedac102c475c485669f92569001bb1e6de722c3ffd6e9680ab5a07945b9d5
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-metrics@npm:1.15.0, @opentelemetry/sdk-metrics@npm:^1.9.1":
   version: 1.15.0
   resolution: "@opentelemetry/sdk-metrics@npm:1.15.0"
@@ -16499,6 +16720,19 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.3.0 <1.5.0"
   checksum: 6ca53712a7b9e0df778ff42f1ca7bdb0302fc12e89eff41347ab1c8fab37308444bebf55f13fa16c20932796a56ab7a61ed1a2d77899772d933b688133a5b985
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-metrics@npm:1.15.1":
+  version: 1.15.1
+  resolution: "@opentelemetry/sdk-metrics@npm:1.15.1"
+  dependencies:
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/resources": 1.15.1
+    lodash.merge: ^4.6.2
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.5.0"
+  checksum: b7007da9bde968c5a36b3c80021c9d6e987ce78cd8363d108c418375c843224a9dd1439e66878f9535983f59e2f5f0aab0aaf63761da9325249f6900f28cf3da
   languageName: node
   linkType: hard
 
@@ -16515,7 +16749,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-node@npm:0.41.0, @opentelemetry/sdk-node@npm:^0.41.0":
+"@opentelemetry/sdk-node@npm:0.41.1":
+  version: 0.41.1
+  resolution: "@opentelemetry/sdk-node@npm:0.41.1"
+  dependencies:
+    "@opentelemetry/api-logs": 0.41.1
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/exporter-jaeger": 1.15.1
+    "@opentelemetry/exporter-trace-otlp-grpc": 0.41.1
+    "@opentelemetry/exporter-trace-otlp-http": 0.41.1
+    "@opentelemetry/exporter-trace-otlp-proto": 0.41.1
+    "@opentelemetry/exporter-zipkin": 1.15.1
+    "@opentelemetry/instrumentation": 0.41.1
+    "@opentelemetry/resources": 1.15.1
+    "@opentelemetry/sdk-logs": 0.41.1
+    "@opentelemetry/sdk-metrics": 1.15.1
+    "@opentelemetry/sdk-trace-base": 1.15.1
+    "@opentelemetry/sdk-trace-node": 1.15.1
+    "@opentelemetry/semantic-conventions": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.3.0 <1.5.0"
+  checksum: 2bcc7e044f6993b1a51469066be5cffb64b90347e7afce7c0fbca87ffec9be20a4aa45f91b0fa09726d1a2063338d5477eff057a6fd58936447d61e4f73db82d
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sdk-node@npm:^0.41.0":
   version: 0.41.0
   resolution: "@opentelemetry/sdk-node@npm:0.41.0"
   dependencies:
@@ -16552,6 +16810,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/sdk-trace-base@npm:1.15.1":
+  version: 1.15.1
+  resolution: "@opentelemetry/sdk-trace-base@npm:1.15.1"
+  dependencies:
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/resources": 1.15.1
+    "@opentelemetry/semantic-conventions": 1.15.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.5.0"
+  checksum: 747e5dd60a64ebea3f2abb1e771b3afb4d1d0bbf9347602a1cfa41c276d4d512c83a52571bbfe7e211ec683d55f2b1180c057c5da6bb699be504fd1d8752150b
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-trace-base@npm:1.9.1, @opentelemetry/sdk-trace-base@npm:^1.9.1":
   version: 1.9.1
   resolution: "@opentelemetry/sdk-trace-base@npm:1.9.1"
@@ -16582,6 +16853,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/sdk-trace-node@npm:1.15.1":
+  version: 1.15.1
+  resolution: "@opentelemetry/sdk-trace-node@npm:1.15.1"
+  dependencies:
+    "@opentelemetry/context-async-hooks": 1.15.1
+    "@opentelemetry/core": 1.15.1
+    "@opentelemetry/propagator-b3": 1.15.1
+    "@opentelemetry/propagator-jaeger": 1.15.1
+    "@opentelemetry/sdk-trace-base": 1.15.1
+    semver: ^7.5.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.5.0"
+  checksum: 489510c7f75685092b97356d0fa5f0edba1d553a5b91bba8374b3645828093c55a1677544e5e17c9fe1c8cdeeb2ceda22fa3e32179b86b041858829fde75ce3c
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/semantic-conventions@npm:1.12.0":
   version: 1.12.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.12.0"
@@ -16595,6 +16882,13 @@ __metadata:
   dependencies:
     tslib: ^2.3.1
   checksum: 3254ff166d08d52ebbaa9711cdbc29718b431c04b8116423e68e20ca3df4c63206f2be52b471b3a0ed4e475b613e85cc447681d145b5c46ecf1c4aee77edd381
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:1.15.1":
+  version: 1.15.1
+  resolution: "@opentelemetry/semantic-conventions@npm:1.15.1"
+  checksum: 19fab8a805a13e4b6cfaacf31607301acdd2c415e8e8afa1f8313c68110b49d9cf02a6a1cc969f67ab71b1dbfcb5c5b063392c68f46fa32d05dbae9ce245e0d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Per 
https://github.com/contentlayerdev/contentlayer/issues/506
https://github.com/open-telemetry/opentelemetry-js/releases/tag/v1.15.1
https://github.com/open-telemetry/opentelemetry-js/pull/4016
opentelemetry has issues with running in ESM due to some incorrect imports.
See https://discord.com/channels/1026884757667188757/1132761273432539278 for more context.
This change bumps relevant versions to include the fixed opentelemetry SDKs.

## How did you test this change?

CI

## Are there any deployment considerations?

New node, next, cloudflare packages released.