### PR TITLE
Fix network request status codes

### DIFF
--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceInfo.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceInfo.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from '@highlight-run/ui'
-import { getNetworkStatusCode } from '@pages/Player/helpers'
+import { getResponseStatusCode } from '@pages/Player/helpers'
 
 import { TableList, TableListItem } from '@/components/TableList/TableList'
 import { ErrorObject } from '@/graph/generated/schemas'
@@ -34,7 +34,7 @@ export const NetworkResourceInfo = ({
 	const responseHeadersData: TableListItem[] = []
 	const responsePayloadData: TableListItem[] = []
 
-	const statusCode = getNetworkStatusCode(selectedNetworkResource)
+	const statusCode = getResponseStatusCode(selectedNetworkResource)
 
 	const generalData: TableListItem[] = [
 		{

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceInfo.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceInfo.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from '@highlight-run/ui'
+import { getNetworkStatusCode } from '@pages/Player/helpers'
 
 import { TableList, TableListItem } from '@/components/TableList/TableList'
 import { ErrorObject } from '@/graph/generated/schemas'
@@ -33,6 +34,8 @@ export const NetworkResourceInfo = ({
 	const responseHeadersData: TableListItem[] = []
 	const responsePayloadData: TableListItem[] = []
 
+	const statusCode = getNetworkStatusCode(selectedNetworkResource)
+
 	const generalData: TableListItem[] = [
 		{
 			keyDisplayValue: 'Request URL',
@@ -47,16 +50,15 @@ export const NetworkResourceInfo = ({
 		{
 			keyDisplayValue: 'Status',
 			valueDisplayValue:
-				selectedNetworkResource?.initiatorType === 'websocket'
-					? 101
-					: selectedNetworkResource?.requestResponsePairs?.response
-							.status ?? (
-							<UnknownRequestStatusCode
-								networkRequestAndResponseRecordingEnabled={
-									networkRecordingEnabledForSession
-								}
-							/>
-					  ),
+				statusCode === 'Unknown' ? (
+					<UnknownRequestStatusCode
+						networkRequestAndResponseRecordingEnabled={
+							networkRecordingEnabledForSession
+						}
+					/>
+				) : (
+					statusCode
+				),
 			valueInfoTooltipMessage:
 				selectedNetworkResource?.requestResponsePairs?.response
 					.status === 0 &&

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -7,7 +7,7 @@ import {
 	Tag,
 	Text,
 } from '@highlight-run/ui'
-import { getNetworkStatusCode } from '@pages/Player/helpers'
+import { getResponseStatusCode } from '@pages/Player/helpers'
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import {
 	LoadingError,
@@ -317,8 +317,8 @@ const ResourceRow = ({
 	const hasError =
 		!!errors?.length ||
 		!!resource.errors?.length ||
-		!!(responseStatus && (responseStatus === 0 || responseStatus >= 400))
-	const reponseStatuscode = getNetworkStatusCode(resource)
+		!!(responseStatus === 0 || (responseStatus && responseStatus >= 400))
+	const reponseStatuscode = getResponseStatusCode(resource)
 
 	return (
 		<Box

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -7,6 +7,7 @@ import {
 	Tag,
 	Text,
 } from '@highlight-run/ui'
+import { getNetworkStatusCode } from '@pages/Player/helpers'
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import {
 	LoadingError,
@@ -317,6 +318,7 @@ const ResourceRow = ({
 		!!errors?.length ||
 		!!resource.errors?.length ||
 		!!(responseStatus && (responseStatus === 0 || responseStatus >= 400))
+	const reponseStatuscode = getNetworkStatusCode(resource)
 
 	return (
 		<Box
@@ -337,19 +339,15 @@ const ResourceRow = ({
 					weight={showingDetails ? 'bold' : 'medium'}
 					lines="1"
 				>
-					{/* NOTE - Showing '200' for all requests that aren't 'xmlhttprequest' or 'fetch' */}
-					{resource.initiatorType === 'xmlhttprequest' ||
-					resource.initiatorType === 'fetch'
-						? resource.requestResponsePairs?.response.status ?? (
-								<UnknownRequestStatusCode
-									networkRequestAndResponseRecordingEnabled={
-										networkRequestAndResponseRecordingEnabled
-									}
-								/>
-						  )
-						: resource.initiatorType === 'websocket'
-						? '101'
-						: '200'}
+					{reponseStatuscode === 'Unknown' ? (
+						<UnknownRequestStatusCode
+							networkRequestAndResponseRecordingEnabled={
+								networkRequestAndResponseRecordingEnabled
+							}
+						/>
+					) : (
+						reponseStatuscode
+					)}
 				</Text>
 				<Text
 					size="small"

--- a/frontend/src/pages/Player/helpers.ts
+++ b/frontend/src/pages/Player/helpers.ts
@@ -1,16 +1,19 @@
 import { NetworkResource } from '@/pages/Player/Toolbar/DevToolsWindowV2/utils'
 
-export const getNetworkStatusCode = (resource?: NetworkResource): string => {
+export const getResponseStatusCode = (resource?: NetworkResource): string => {
 	if (!resource) {
 		return ''
 	}
 
 	// Showing '200' for all requests that aren't 'xmlhttprequest', 'fetch', or 'websocket'
 	if (['xmlhttprequest', 'fetch'].includes(resource.initiatorType)) {
-		return (
-			resource.requestResponsePairs?.response.status?.toString() ||
-			'Unknown'
-		)
+		const status = resource.requestResponsePairs?.response.status
+
+		if (status === 0) {
+			return 'Canceled'
+		}
+
+		return status?.toString() || 'Unknown'
 	}
 
 	if (resource.initiatorType === 'websocket') {

--- a/frontend/src/pages/Player/helpers.ts
+++ b/frontend/src/pages/Player/helpers.ts
@@ -1,0 +1,21 @@
+import { NetworkResource } from '@/pages/Player/Toolbar/DevToolsWindowV2/utils'
+
+export const getNetworkStatusCode = (resource?: NetworkResource): string => {
+	if (!resource) {
+		return ''
+	}
+
+	// Showing '200' for all requests that aren't 'xmlhttprequest', 'fetch', or 'websocket'
+	if (['xmlhttprequest', 'fetch'].includes(resource.initiatorType)) {
+		return (
+			resource.requestResponsePairs?.response.status?.toString() ||
+			'Unknown'
+		)
+	}
+
+	if (resource.initiatorType === 'websocket') {
+		return '101'
+	}
+
+	return '200'
+}


### PR DESCRIPTION
## Summary
Some logic for displaying the status codes of network requests is out of sync. Create a helper method to help keep this logic in sync

![Screenshot 2023-07-25 at 10 21 59 AM](https://github.com/highlight/highlight/assets/17744174/bbd69c4c-18d1-41a3-9661-48748fad6445)

Status code 0 causes confusion on the frontend. Replace the 0 status code with "Canceled" and mark as red

![Screenshot 2023-07-26 at 10 41 41 AM](https://github.com/highlight/highlight/assets/17744174/21215005-e571-4fbe-8bd0-4bed02b63037)

## How did you test this change?
1. View a session with a non websocket, XML, or fetch request.
2. Click on a 200 request
3. Confirm the request matches in the right panel

![Screenshot 2023-07-25 at 10 42 29 AM](https://github.com/highlight/highlight/assets/17744174/0476fb6a-a29e-4981-9184-357e7c16a1c8)

![Screenshot 2023-07-26 at 11 12 14 AM](https://github.com/highlight/highlight/assets/17744174/a3190f27-2cfd-4de4-909b-680e9eae8c16)

## Are there any deployment considerations?
N/A
