### PR TITLE
filter number fields out of UI

### DIFF
--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -79,6 +79,7 @@ type TermsAggregation struct {
 	Missing        *string // Optional: The value to use when the field is missing.
 	SubAggregation Aggregation
 	Include        *string
+	Exclude        *string
 	Size           *int
 }
 
@@ -91,6 +92,11 @@ func (t *TermsAggregation) GetAggsString() string {
 	includePart := ""
 	if t.Include != nil {
 		includePart = fmt.Sprintf(`, "include": "%s"`, *t.Include)
+	}
+
+	excludePart := ""
+	if t.Exclude != nil {
+		excludePart = fmt.Sprintf(`, "exclude": "%s"`, *t.Exclude)
 	}
 
 	sizePart := ""
@@ -109,12 +115,13 @@ func (t *TermsAggregation) GetAggsString() string {
 				%s
 				%s
 				%s
+				%s
 			},
 			"aggs": {
 				%s
 			}
 		}
-	`, t.Field, includePart, sizePart, missing, subAggString)
+	`, t.Field, includePart, excludePart, sizePart, missing, subAggString)
 }
 
 type DateBounds struct {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5253,7 +5253,7 @@ func (r *queryResolver) FieldTypes(ctx context.Context, projectID int, startDate
 		Aggregation: &opensearch.TermsAggregation{
 			Field:   "fields.Key.raw",
 			Include: pointy.String("(session|track|user)_.*"),
-			Exclude: pointy.String("(session)_[0-9]+"), // Exclude numeric field types
+			Exclude: pointy.String("(session|track|user)_[0-9]+"), // Exclude numeric field types
 			Size:    pointy.Int(500),
 		},
 	}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5253,6 +5253,7 @@ func (r *queryResolver) FieldTypes(ctx context.Context, projectID int, startDate
 		Aggregation: &opensearch.TermsAggregation{
 			Field:   "fields.Key.raw",
 			Include: pointy.String("(session|track|user)_.*"),
+			Exclude: pointy.String("(session)_[0-9]+"), // Exclude numeric field types
 			Size:    pointy.Int(500),
 		},
 	}


### PR DESCRIPTION
## Summary
- there are a lot of fields with numeric keys that were inadvertently created for certain projects
- while the job is running to delete these, filter out the numeric fields in the opensearch query so they won't be visible in the UI
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally before / after change
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
