### PR TITLE
cleanup sdk unused dependencies

### DIFF
--- a/sdk/highlight-apollo/CHANGELOG.md
+++ b/sdk/highlight-apollo/CHANGELOG.md
@@ -9,3 +9,7 @@
 ### 3.1.2
 
 - Bumping to match `@highlight-run/node`
+
+### 3.1.6
+
+- Bumping to match `@highlight-run/node`

--- a/sdk/highlight-apollo/package.json
+++ b/sdk/highlight-apollo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/apollo",
-	"version": "3.1.2",
+	"version": "3.1.6",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-cloudflare/package.json
+++ b/sdk/highlight-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/cloudflare",
-	"version": "2.0.6",
+	"version": "2.0.7",
 	"packageManager": "yarn@3.2.3",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -14,12 +14,11 @@
 		"access": "public"
 	},
 	"dependencies": {
-		"diary": "^0.4.4",
+		"@opentelemetry/resources": "1.15.1",
 		"opentelemetry-sdk-workers": "^0.6.2"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20230518.0",
-		"@opentelemetry/resources": "1.15.1",
 		"tsup": "^6.7.0"
 	}
 }

--- a/sdk/highlight-nest/CHANGELOG.md
+++ b/sdk/highlight-nest/CHANGELOG.md
@@ -15,3 +15,7 @@
 ### 3.1.2
 
 - Bumping to match `@highlight-run/node`
+
+### 3.1.6
+
+- Bumping to match `@highlight-run/node`

--- a/sdk/highlight-nest/package.json
+++ b/sdk/highlight-nest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/nest",
-	"version": "3.1.2",
+	"version": "3.1.6",
 	"description": "Client for interfacing with Highlight in nestjs",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "3.1.5",
+	"version": "3.1.6",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",
@@ -46,8 +46,7 @@
 	"dependencies": {
 		"@highlight-run/node": "workspace:*",
 		"@highlight-run/sourcemap-uploader": "workspace:*",
-		"highlight.run": "workspace:*",
-		"npm-run-all": "4.1.5"
+		"highlight.run": "workspace:*"
 	},
 	"devDependencies": {
 		"@trpc/server": "^9.27.4",

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "3.1.5",
+	"version": "3.1.6",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -33,10 +33,7 @@
 		"@opentelemetry/sdk-node": "0.41.1",
 		"@opentelemetry/sdk-trace-base": "1.15.1",
 		"@opentelemetry/semantic-conventions": "1.15.1",
-		"error-stack-parser": "2.0.7",
-		"highlight.run": "workspace:*",
-		"lru-cache": "^7.14.0",
-		"npm-run-all": "4.1.5"
+		"highlight.run": "workspace:*"
 	},
 	"devDependencies": {
 		"@types/jest": "^29.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12686,7 +12686,6 @@ __metadata:
   dependencies:
     "@cloudflare/workers-types": ^4.20230518.0
     "@opentelemetry/resources": 1.15.1
-    diary: ^0.4.4
     opentelemetry-sdk-workers: ^0.6.2
     tsup: ^6.7.0
   languageName: unknown
@@ -12880,7 +12879,6 @@ __metadata:
     highlight.run: "workspace:*"
     jest: ^29.2.0
     next: ^13.3.4
-    npm-run-all: 4.1.5
     ts-jest: ^29.0.3
     tsup: ^6.7.0
     typescript: ^5.0.4
@@ -12906,11 +12904,8 @@ __metadata:
     "@types/jest": ^29.2.0
     "@types/lru-cache": ^7.10.10
     "@types/node": 17.0.13
-    error-stack-parser: 2.0.7
     highlight.run: "workspace:*"
     jest: ^29.2.2
-    lru-cache: ^7.14.0
-    npm-run-all: 4.1.5
     ts-jest: ^29.0.3
     tsup: ^6.2.3
     typescript: ^5.0.4
@@ -29735,13 +29730,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diary@npm:^0.4.4":
-  version: 0.4.4
-  resolution: "diary@npm:0.4.4"
-  checksum: 906a276d05fae33e7d8330b26846448d09ce5d8d7457e8a559e938d8267788bb667718bbcd74b184b4203602d0acebf1259c229fbfb639b7f4226285deca824a
-  languageName: node
-  linkType: hard
-
 "didyoumean@npm:^1.2.1, didyoumean@npm:^1.2.2":
   version: 1.2.2
   resolution: "didyoumean@npm:1.2.2"
@@ -30438,15 +30426,6 @@ __metadata:
   dependencies:
     stackframe: ^1.1.1
   checksum: bd8e048fcb1c0c74ab201271fec3b39c097a7c24bdef1718828d053c0584da5d7ad845253b5e4773803ee8e7450b23b0920e60a3b60dd403c1568c843058cb12
-  languageName: node
-  linkType: hard
-
-"error-stack-parser@npm:2.0.7":
-  version: 2.0.7
-  resolution: "error-stack-parser@npm:2.0.7"
-  dependencies:
-    stackframe: ^1.1.1
-  checksum: fe30bba934db08487dd2c5a8dfe785f64debf4948b5c79a531b610b4468d96b918a806c0f3d44f634e70945533d23f44cb3af0a2d2f934b1c698930307d1b73b
   languageName: node
   linkType: hard
 
@@ -40765,7 +40744,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:*, lru-cache@npm:^7.14.0, lru-cache@npm:^7.7.1":
+"lru-cache@npm:*, lru-cache@npm:^7.7.1":
   version: 7.14.0
   resolution: "lru-cache@npm:7.14.0"
   checksum: efdd329f2c1bb790b71d497c6c59272e6bc2d7dd060ba55fc136becd3dd31fc8346edb446275504d94cb60d3c8385dbf5267b79b23789e409b2bdf302d13f0d7
@@ -43196,7 +43175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-run-all@npm:4.1.5, npm-run-all@npm:^4.1.5":
+"npm-run-all@npm:^4.1.5":
   version: 4.1.5
   resolution: "npm-run-all@npm:4.1.5"
   dependencies:


### PR DESCRIPTION
## Summary

As reported on [discord](https://discord.com/channels/1026884757667188757/1133363145885372517), our sdks have some unneeded dependencies. ie: https://npmgraph.js.org/?q=%40highlight-run%2Fnest

## How did you test this change?

E2E test.

## Are there any deployment considerations?

New package versions released. Bumping all node-dependent versions to be the same.
