### PR TITLE
use default esm file naming

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -184,6 +184,7 @@ jobs:
 
                   if [[ "$REF" != "refs/heads/main" && "$REPO" == "highlight/highlight" ]]; then
                     export CYPRESS_CLIENT_VERSION="dev-${COMMIT_SHA}"
+                    export REACT_APP_COMMIT_SHA="${COMMIT_SHA}"
                   fi
 
                   # start highlight

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -193,7 +193,7 @@ jobs:
                   docker compose exec -e PSQL_HOST -e PSQL_USER -e PSQL_DB postgres bash -c 'psql -h $PSQL_HOST -U $PSQL_USER $PSQL_DB < /root/init.sql' >> /tmp/highlight.log 2>&1;
                   ./run-backend.sh >> /tmp/highlight.log 2>&1 &
                   yarn install >> /tmp/highlight.log 2>&1;
-                  doppler run -- yarn build:frontend >> /tmp/highlight.log 2>&1;
+                  doppler run --preserve-env -- yarn build:frontend >> /tmp/highlight.log 2>&1;
                   yarn workspace @highlight-run/client dev &
                   yarn workspace highlight.run dev &
                   yarn workspace @highlight-run/frontend vite preview --port 3000 &

--- a/cypress/pages/local.html
+++ b/cypress/pages/local.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<title>local highlight.run bundle</title>
-		<script src="http://localhost:8888/dist/index.umd.js"></script>
+		<script src="http://localhost:8888/dist/index.umd.cjs"></script>
 		<script>
 			H.init('1', {
 				backendUrl: 'https://localhost:8082/public',

--- a/e2e/html/index.html
+++ b/e2e/html/index.html
@@ -7,7 +7,7 @@
 		<title>Highlight HTML</title>
 		<style></style>
 		<!-- <script src="https://unpkg.com/highlight.run"></script> -->
-		<script src="http://localhost:8888/dist/index.umd.js"></script>
+		<script src="http://localhost:8888/dist/index.umd.cjs"></script>
 		<script>
 			// See https://www.highlight.io/docs/getting-started/client-sdk/other
 			H.init('2', {

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -13,12 +13,13 @@ interface ImportMetaEnv {
 	readonly REACT_APP_STRIPE_API_PK: string
 	readonly REACT_APP_VERCEL_INTEGRATION_NAME: string
 
+	readonly CYPRESS_CLIENT_VERSION: string
+	readonly DD_CLIENT_TOKEN: string
+	readonly DEMO_PROJECT_ID: string
 	readonly DISCORD_CLIENT_ID: string
 	readonly GITHUB_CLIENT_ID: string
 	readonly LINEAR_CLIENT_ID: string
 	readonly SLACK_CLIENT_ID: string
-	readonly DD_CLIENT_TOKEN: string
-	readonly DEMO_PROJECT_ID: string
 }
 
 interface ImportMeta {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -138,6 +138,11 @@ if (dev) {
 		import.meta.env.REACT_APP_COMMIT_SHA
 	}/index.js`
 }
+if (import.meta.env.CYPRESS_CLIENT_VERSION) {
+	options.scriptUrl = `https://static.highlight.io/${
+		import.meta.env.CYPRESS_CLIENT_VERSION
+	}/index.js`
+}
 H.init(import.meta.env.REACT_APP_FRONTEND_ORG ?? 1, options)
 analytics.track('attribution', getAttributionData())
 if (!isOnPrem) {

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.3.11",
+	"version": "7.3.12",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",
@@ -34,16 +34,16 @@
 		"typegen": "tsc && node scripts/replace-client-imports.mjs"
 	},
 	"type": "module",
-	"main": "./dist/index.es.js",
-	"unpkg": "./dist/index.umd.js",
-	"jsdelivr": "./dist/index.umd.js",
+	"main": "./dist/index.js",
+	"unpkg": "./dist/index.umd.cjs",
+	"jsdelivr": "./dist/index.umd.cjs",
 	"types": "./dist/firstload/src/index.d.ts",
 	"exports": {
 		"types": "./dist/firstload/src/index.d.ts",
-		"import": "./dist/index.es.js",
-		"require": "./dist/index.cjs.js",
-		"node": "./dist/index.cjs.js",
-		"default": "./dist/index.es.js"
+		"import": "./dist/index.js",
+		"require": "./dist/index.cjs",
+		"node": "./dist/index.cjs",
+		"default": "./dist/index.js"
 	},
 	"files": [
 		"dist"

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.3.11"
+export default "7.3.12"

--- a/sdk/firstload/vite.config.ts
+++ b/sdk/firstload/vite.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
 		rollupOptions: {
 			output: {
 				exports: 'named',
-				entryFileNames: '[name].[format].js',
 			},
 		},
 	},

--- a/turbo.json
+++ b/turbo.json
@@ -62,6 +62,7 @@
 			],
 			"env": [
 				"CLICKUP_CLIENT_ID",
+				"CYPRESS_CLIENT_VERSION",
 				"DD_CLIENT_TOKEN",
 				"DEMO_PROJECT_ID",
 				"DISCORD_CLIENT_ID",


### PR DESCRIPTION
## Summary

Was getting errors building next.js.
Switching to default file names (which @deltaepsilon also found was required for remix).
```
unhandledRejection Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/vkorolik/work/highlight/node_modules/highlight.run/dist/index.cjs.js from /Users/vkorolik/work/highlight/e2e/nextjs/node_modules/@highlight-run/next/dist/HighlightInit.js not supported.
index.cjs.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename index.cjs.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /Users/vkorolik/work/highlight/node_modules/highlight.run/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at Object.<anonymous> (/Users/vkorolik/work/highlight/e2e/nextjs/node_modules/@highlight-run/next/dist/HighlightInit.js:1:470)
```

## How did you test this change?

Local `yarn build` in e2e/nextjs

## Are there any deployment considerations?

New highlight.run package built