### PR TITLE
cache workspace results to rate limit slack integrations

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -3054,77 +3054,84 @@ func (r *Resolver) getEvents(ctx context.Context, s *model.Session, cursor model
 }
 
 func (r *Resolver) GetSlackChannelsFromSlack(ctx context.Context, workspaceId int) (*[]model.SlackChannel, int, error) {
-	var filteredNewChannels []model.SlackChannel
-
-	workspace, _ := r.GetWorkspace(workspaceId)
-	// workspace is not integrated with slack
-	if workspace.SlackAccessToken == nil {
-		return &filteredNewChannels, 0, nil
+	type result struct {
+		existingChannels *[]model.SlackChannel
+		newChannelsCount int
 	}
+	res, err := redis.CachedEval(ctx, r.Redis, fmt.Sprintf(`slack-channels-workspace-%d`, workspaceId), time.Second, time.Minute, func() (*result, error) {
+		var filteredNewChannels []model.SlackChannel
 
-	slackClient := slack.New(*workspace.SlackAccessToken)
-	existingChannels, _ := workspace.IntegratedSlackChannels()
+		workspace, _ := r.GetWorkspace(workspaceId)
+		// workspace is not integrated with slack
+		if workspace.SlackAccessToken == nil {
+			return &result{&filteredNewChannels, 0}, nil
+		}
 
-	getConversationsParam := slack.GetConversationsParameters{
-		Limit: 1000,
-		// public_channel is for public channels in the Slack workspace
-		// private is for private channels in the Slack workspace that the Bot is included in
-		// im is for all individuals in the Slack workspace
-		// mpim is for multi-person conversations in the Slack workspace that the Bot is included in
-		Types: []string{"public_channel", "private_channel", "mpim", "im"},
-	}
-	allSlackChannelsFromAPI := []slack.Channel{}
+		slackClient := slack.New(*workspace.SlackAccessToken)
+		existingChannels, _ := workspace.IntegratedSlackChannels()
 
-	// Slack paginates the channels/people listing.
-	for {
-		channels, cursor, err := slackClient.GetConversations(&getConversationsParam)
+		getConversationsParam := slack.GetConversationsParameters{
+			Limit: 1000,
+			// public_channel is for public channels in the Slack workspace
+			// private is for private channels in the Slack workspace that the Bot is included in
+			// im is for all individuals in the Slack workspace
+			// mpim is for multi-person conversations in the Slack workspace that the Bot is included in
+			Types: []string{"public_channel", "private_channel", "mpim", "im"},
+		}
+		allSlackChannelsFromAPI := []slack.Channel{}
+
+		// Slack paginates the channels/people listing.
+		for {
+			channels, cursor, err := slackClient.GetConversations(&getConversationsParam)
+			if err != nil {
+				return &result{&filteredNewChannels, 0}, e.Wrap(err, "error getting Slack channels from Slack.")
+			}
+
+			allSlackChannelsFromAPI = append(allSlackChannelsFromAPI, channels...)
+
+			if cursor == "" {
+				break
+			}
+
+		}
+
+		// We need to get the users in the Slack channel in order to get their name.
+		// The conversations endpoint only returns the user's ID, we'll use the response from `GetUsers` to get the name.
+		users, err := slackClient.GetUsers()
 		if err != nil {
-			return &filteredNewChannels, 0, e.Wrap(err, "error getting Slack channels from Slack.")
+			log.WithContext(ctx).Error(e.Wrap(err, "failed to get users"))
 		}
 
-		allSlackChannelsFromAPI = append(allSlackChannelsFromAPI, channels...)
+		newChannelsCount := 0
 
-		if cursor == "" {
-			break
+		channelsAndUsers := map[string]model.SlackChannel{}
+		for _, channel := range existingChannels {
+			channelsAndUsers[channel.WebhookChannelID] = channel
 		}
 
-	}
-
-	// We need to get the users in the Slack channel in order to get their name.
-	// The conversations endpoint only returns the user's ID, we'll use the response from `GetUsers` to get the name.
-	users, err := slackClient.GetUsers()
-	if err != nil {
-		log.WithContext(ctx).Error(e.Wrap(err, "failed to get users"))
-	}
-
-	newChannelsCount := 0
-
-	channelsAndUsers := map[string]model.SlackChannel{}
-	for _, channel := range existingChannels {
-		channelsAndUsers[channel.WebhookChannelID] = channel
-	}
-
-	for _, channel := range allSlackChannelsFromAPI {
-		_, exists := channelsAndUsers[channel.ID]
-		if !exists && channel.IsChannel && channel.ID != "" {
-			newChannelsCount++
-			slackChannel := model.SlackChannel{WebhookChannelID: channel.ID, WebhookChannel: fmt.Sprintf("#%s", channel.Name)}
-			channelsAndUsers[channel.ID] = slackChannel
-			existingChannels = append(existingChannels, slackChannel)
+		for _, channel := range allSlackChannelsFromAPI {
+			_, exists := channelsAndUsers[channel.ID]
+			if !exists && channel.IsChannel && channel.ID != "" {
+				newChannelsCount++
+				slackChannel := model.SlackChannel{WebhookChannelID: channel.ID, WebhookChannel: fmt.Sprintf("#%s", channel.Name)}
+				channelsAndUsers[channel.ID] = slackChannel
+				existingChannels = append(existingChannels, slackChannel)
+			}
 		}
-	}
 
-	for _, user := range users {
-		_, exists := channelsAndUsers[user.ID]
-		if !exists && !user.IsBot && !user.Deleted && strings.ToLower(user.Name) != "slackbot" {
-			newChannelsCount++
-			slackChannel := model.SlackChannel{WebhookChannelID: user.ID, WebhookChannel: fmt.Sprintf("@%s", user.Name)}
-			channelsAndUsers[user.ID] = slackChannel
-			existingChannels = append(existingChannels, slackChannel)
+		for _, user := range users {
+			_, exists := channelsAndUsers[user.ID]
+			if !exists && !user.IsBot && !user.Deleted && strings.ToLower(user.Name) != "slackbot" {
+				newChannelsCount++
+				slackChannel := model.SlackChannel{WebhookChannelID: user.ID, WebhookChannel: fmt.Sprintf("@%s", user.Name)}
+				channelsAndUsers[user.ID] = slackChannel
+				existingChannels = append(existingChannels, slackChannel)
+			}
 		}
-	}
 
-	return &existingChannels, newChannelsCount, nil
+		return &result{&existingChannels, newChannelsCount}, nil
+	})
+	return res.existingChannels, res.newChannelsCount, err
 }
 
 func GetAggregateFluxStatement(ctx context.Context, aggregator modelInputs.MetricAggregator, resMins int) string {

--- a/backend/redis/cache.go
+++ b/backend/redis/cache.go
@@ -1,0 +1,37 @@
+package redis
+
+import (
+	"context"
+	"github.com/go-redis/cache/v8"
+	log "github.com/sirupsen/logrus"
+	"time"
+)
+
+// CachedEval will return the value at cacheKey if it exists.
+// If it does not exist or is nil, CachedEval calls `fn()` to evaluate the result, and stores it at the cache key.
+func CachedEval[T any](ctx context.Context, redis *Client, cacheKey string, lockTimeout, cacheExpiration time.Duration, fn func() (*T, error)) (value *T, err error) {
+	// wait here to check the cache in case another process is waiting for db query
+	if acquired := redis.AcquireLock(ctx, cacheKey, lockTimeout); acquired {
+		defer func() {
+			if err := redis.ReleaseLock(ctx, cacheKey); err != nil {
+				log.WithContext(ctx).WithError(err).Error("failed to release lock")
+			}
+		}()
+	}
+
+	if err = redis.Cache.Get(ctx, cacheKey, &value); err != nil {
+		if value, err = fn(); value == nil || err != nil {
+			return
+		}
+		if err = redis.Cache.Set(&cache.Item{
+			Ctx:   ctx,
+			Key:   cacheKey,
+			Value: &value,
+			TTL:   cacheExpiration,
+		}); err != nil {
+			return
+		}
+	}
+
+	return
+}

--- a/backend/store/sessions.go
+++ b/backend/store/sessions.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/redis"
 	log "github.com/sirupsen/logrus"
 	"time"
 )
 
 func (store *Store) GetSessionFromSecureID(ctx context.Context, secureID string) (*model.Session, error) {
-	return cachedEval(ctx, store.redis, fmt.Sprintf("session-secure-%s", secureID), 150*time.Millisecond, time.Second, func() (*model.Session, error) {
+	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("session-secure-%s", secureID), 150*time.Millisecond, time.Second, func() (*model.Session, error) {
 		var session model.Session
 		if err := store.db.Model(&session).Where(&model.Session{SecureID: secureID}).Take(&session).Error; err != nil {
 			log.WithContext(ctx).WithError(err).WithField("session_secure_id", secureID).Error("failed to get session by secure id")
@@ -20,7 +21,7 @@ func (store *Store) GetSessionFromSecureID(ctx context.Context, secureID string)
 }
 
 func (store *Store) GetSession(ctx context.Context, sessionID int) (*model.Session, error) {
-	return cachedEval(ctx, store.redis, fmt.Sprintf("session-id-%d", sessionID), 150*time.Millisecond, time.Second, func() (*model.Session, error) {
+	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("session-id-%d", sessionID), 150*time.Millisecond, time.Second, func() (*model.Session, error) {
 		var session model.Session
 		if err := store.db.Model(&session).Where(&model.Session{Model: model.Model{ID: sessionID}}).Take(&session).Error; err != nil {
 			log.WithContext(ctx).WithError(err).WithField("session_id", sessionID).Error("failed to get session by id")

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -1,13 +1,9 @@
 package store
 
 import (
-	"context"
-	"github.com/go-redis/cache/v8"
 	"github.com/highlight-run/highlight/backend/opensearch"
 	"github.com/highlight-run/highlight/backend/redis"
-	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
-	"time"
 )
 
 type Store struct {
@@ -22,33 +18,4 @@ func NewStore(db *gorm.DB, opensearch *opensearch.Client, redis *redis.Client) *
 		opensearch: opensearch,
 		redis:      redis,
 	}
-}
-
-// cachedEval will return the value at cacheKey if it exists.
-// If it does not exist or is nil, cachedEval calls `fn()` to evaluate the result, and stores it at the cache key.
-func cachedEval[T any](ctx context.Context, redis *redis.Client, cacheKey string, lockTimeout, cacheExpiration time.Duration, fn func() (*T, error)) (value *T, err error) {
-	// wait here to check the cache in case another process is waiting for db query
-	if acquired := redis.AcquireLock(ctx, cacheKey, lockTimeout); acquired {
-		defer func() {
-			if err := redis.ReleaseLock(ctx, cacheKey); err != nil {
-				log.WithContext(ctx).WithError(err).Error("failed to release lock")
-			}
-		}()
-	}
-
-	if err = redis.Cache.Get(ctx, cacheKey, &value); err != nil {
-		if value, err = fn(); value == nil || err != nil {
-			return
-		}
-		if err = redis.Cache.Set(&cache.Item{
-			Ctx:   ctx,
-			Key:   cacheKey,
-			Value: &value,
-			TTL:   cacheExpiration,
-		}); err != nil {
-			return
-		}
-	}
-
-	return
 }

--- a/backend/store/workspace_settings.go
+++ b/backend/store/workspace_settings.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/redis"
 	"time"
 )
 
 func (store *Store) GetAllWorkspaceSettings(ctx context.Context, workspaceID int) (*model.AllWorkspaceSettings, error) {
-	return cachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-workspace-%d", workspaceID), 250*time.Millisecond, 5*time.Second, func() (*model.AllWorkspaceSettings, error) {
+	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-workspace-%d", workspaceID), 250*time.Millisecond, 5*time.Second, func() (*model.AllWorkspaceSettings, error) {
 		var workspaceSettings model.AllWorkspaceSettings
 		if err := store.db.Where(model.AllWorkspaceSettings{WorkspaceID: workspaceID}).FirstOrCreate(&workspaceSettings).Error; err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

We've seen rate limits on our slack integration when fetching channels.
This is because the frontend makes many requests to update slack channels when the user provides a new input.
The request to slack has a pretty strict rate limit so we should cache the results on the backend for up to a minute.
https://api.slack.com/methods/conversations.list
[Discord context](https://discord.com/channels/1026884757667188757/1093566394844581919/1133490263491354655).

## How did you test this change?

TODO

## Are there any deployment considerations?

No.