### PR TITLE
add service to backend errors

### DIFF
--- a/backend/lambda-functions/deleteSessions/deleteSessionBatchFromOpenSearch/main.go
+++ b/backend/lambda-functions/deleteSessions/deleteSessionBatchFromOpenSearch/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -15,7 +17,10 @@ func init() {
 
 func main() {
 	highlight.SetProjectID("1jdkoe52")
-	highlight.Start()
+	highlight.Start(
+		highlight.WithServiceName("lambda-functions--deleteSessionBatchFromOpenSearch"),
+		highlight.WithServiceVersion(os.Getenv("REACT_APP_COMMIT_SHA")),
+	)
 	defer highlight.Stop()
 	hlog.Init()
 	lambda.Start(h.DeleteSessionBatchFromOpenSearch)

--- a/backend/lambda-functions/deleteSessions/deleteSessionBatchFromPostgres/main.go
+++ b/backend/lambda-functions/deleteSessions/deleteSessionBatchFromPostgres/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -15,7 +17,10 @@ func init() {
 
 func main() {
 	highlight.SetProjectID("1jdkoe52")
-	highlight.Start()
+	highlight.Start(
+		highlight.WithServiceName("lambda-functions--deleteSessionBatchFromPostgres"),
+		highlight.WithServiceVersion(os.Getenv("REACT_APP_COMMIT_SHA")),
+	)
 	defer highlight.Stop()
 	hlog.Init()
 	lambda.Start(h.DeleteSessionBatchFromPostgres)

--- a/backend/lambda-functions/deleteSessions/deleteSessionBatchFromS3/main.go
+++ b/backend/lambda-functions/deleteSessions/deleteSessionBatchFromS3/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -15,7 +17,10 @@ func init() {
 
 func main() {
 	highlight.SetProjectID("1jdkoe52")
-	highlight.Start()
+	highlight.Start(
+		highlight.WithServiceName("lambda-functions--deleteSessionBatchFromS3"),
+		highlight.WithServiceVersion(os.Getenv("REACT_APP_COMMIT_SHA")),
+	)
 	defer highlight.Stop()
 	hlog.Init()
 	lambda.Start(h.DeleteSessionBatchFromS3)

--- a/backend/lambda-functions/deleteSessions/getSessionIdsByQuery/main.go
+++ b/backend/lambda-functions/deleteSessions/getSessionIdsByQuery/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
 	highlight "github.com/highlight/highlight/sdk/highlight-go"
@@ -15,7 +17,10 @@ func init() {
 
 func main() {
 	highlight.SetProjectID("1jdkoe52")
-	highlight.Start()
+	highlight.Start(
+		highlight.WithServiceName("lambda-functions--deleteSessions-getSessionIdsByQuery"),
+		highlight.WithServiceVersion(os.Getenv("REACT_APP_COMMIT_SHA")),
+	)
 	defer highlight.Stop()
 	hlog.Init()
 	lambda.Start(h.GetSessionIdsByQuery)

--- a/backend/lambda-functions/deleteSessions/main.go
+++ b/backend/lambda-functions/deleteSessions/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -19,7 +20,10 @@ func main() {
 	}
 
 	highlight.SetProjectID("1jdkoe52")
-	highlight.Start()
+	highlight.Start(
+		highlight.WithServiceName("lambda-functions--deleteSessions"),
+		highlight.WithServiceVersion(os.Getenv("REACT_APP_COMMIT_SHA")),
+	)
 	defer highlight.Stop()
 	hlog.Init()
 

--- a/backend/lambda-functions/deleteSessions/sendEmail/main.go
+++ b/backend/lambda-functions/deleteSessions/sendEmail/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/handlers"
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -15,7 +17,10 @@ func init() {
 
 func main() {
 	highlight.SetProjectID("1jdkoe52")
-	highlight.Start()
+	highlight.Start(
+		highlight.WithServiceName("lambda-functions--deleteSessions-sendEmail"),
+		highlight.WithServiceVersion(os.Getenv("REACT_APP_COMMIT_SHA")),
+	)
 	defer highlight.Stop()
 	hlog.Init()
 	lambda.Start(h.SendEmail)

--- a/backend/main.go
+++ b/backend/main.go
@@ -235,7 +235,18 @@ func main() {
 			highlight.SetOTLPEndpoint("http://collector:4318")
 		}
 	}
-	highlight.Start()
+
+	serviceName := string(runtimeParsed)
+	if runtimeParsed == util.Worker {
+		if handlerFlag != nil {
+			serviceName = *handlerFlag
+		}
+	}
+
+	highlight.Start(
+		highlight.WithServiceName(serviceName),
+		highlight.WithServiceVersion(os.Getenv("REACT_APP_COMMIT_SHA")),
+	)
 	defer highlight.Stop()
 	highlight.SetDebugMode(log.StandardLogger())
 

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -963,7 +963,7 @@ type ErrorGroup struct {
 	FirstOccurrence  *time.Time                           `gorm:"-"`
 	LastOccurrence   *time.Time                           `gorm:"-"`
 	ErrorObjects     []ErrorObject
-	ServiceName      *string
+	ServiceName      string
 
 	// Represents the admins that have viewed this session.
 	ViewedByAdmins []Admin `json:"viewed_by_admins" gorm:"many2many:error_group_admins_views;"`

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -928,8 +928,8 @@ type ErrorObject struct {
 	Environment      string
 	RequestID        *string // From X-Highlight-Request header
 	IsBeacon         bool    `gorm:"default:false"`
-	ServiceName      *string
-	ServiceVersion   *string
+	ServiceName      string
+	ServiceVersion   string
 }
 
 type ErrorObjectEmbeddings struct {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -928,6 +928,8 @@ type ErrorObject struct {
 	Environment      string
 	RequestID        *string // From X-Highlight-Request header
 	IsBeacon         bool    `gorm:"default:false"`
+	ServiceName      *string
+	ServiceVersion   *string
 }
 
 type ErrorObjectEmbeddings struct {
@@ -961,6 +963,7 @@ type ErrorGroup struct {
 	FirstOccurrence  *time.Time                           `gorm:"-"`
 	LastOccurrence   *time.Time                           `gorm:"-"`
 	ErrorObjects     []ErrorObject
+	ServiceName      *string
 
 	// Represents the admins that have viewed this session.
 	ViewedByAdmins []Admin `json:"viewed_by_admins" gorm:"many2many:error_group_admins_views;"`

--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -782,8 +782,8 @@ type OpenSearchErrorObject struct {
 	Browser        string    `json:"browser"`
 	Timestamp      time.Time `json:"timestamp"`
 	Environment    string    `json:"environment"`
-	ServiceName    *string   `json:"service_name"`
-	ServiceVersion *string   `json:"service_version"`
+	ServiceName    string    `json:"service_name"`
+	ServiceVersion string    `json:"service_version"`
 }
 
 type OpenSearchErrorField struct {

--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -777,11 +777,13 @@ type OpenSearchError struct {
 }
 
 type OpenSearchErrorObject struct {
-	Url         string    `json:"visited_url"`
-	Os          string    `json:"os_name"`
-	Browser     string    `json:"browser"`
-	Timestamp   time.Time `json:"timestamp"`
-	Environment string    `json:"environment"`
+	Url            string    `json:"visited_url"`
+	Os             string    `json:"os_name"`
+	Browser        string    `json:"browser"`
+	Timestamp      time.Time `json:"timestamp"`
+	Environment    string    `json:"environment"`
+	ServiceName    *string   `json:"service_name"`
+	ServiceVersion *string   `json:"service_version"`
 }
 
 type OpenSearchErrorField struct {

--- a/backend/opensearch/opensearch.go
+++ b/backend/opensearch/opensearch.go
@@ -777,13 +777,12 @@ type OpenSearchError struct {
 }
 
 type OpenSearchErrorObject struct {
-	Url            string    `json:"visited_url"`
-	Os             string    `json:"os_name"`
-	Browser        string    `json:"browser"`
-	Timestamp      time.Time `json:"timestamp"`
-	Environment    string    `json:"environment"`
-	ServiceName    string    `json:"service_name"`
-	ServiceVersion string    `json:"service_version"`
+	Url         string    `json:"visited_url"`
+	Os          string    `json:"os_name"`
+	Browser     string    `json:"browser"`
+	Timestamp   time.Time `json:"timestamp"`
+	Environment string    `json:"environment"`
+	ServiceName string    `json:"service_name"`
 }
 
 type OpenSearchErrorField struct {

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -72,6 +72,7 @@ func getBackendError(ctx context.Context, ts time.Time, fields extractedFields, 
 		Timestamp:       ts,
 		Payload:         pointy.String(string(payloadBytes)),
 		URL:             fields.errorUrl,
+		Service:         &model.ServiceInput{},
 	}
 	if fields.sessionID != "" {
 		return false, err

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -72,7 +72,10 @@ func getBackendError(ctx context.Context, ts time.Time, fields extractedFields, 
 		Timestamp:       ts,
 		Payload:         pointy.String(string(payloadBytes)),
 		URL:             fields.errorUrl,
-		Service:         &model.ServiceInput{},
+		Service: &model.ServiceInput{
+			Name:    fields.serviceName,
+			Version: fields.serviceVersion,
+		},
 	}
 	if fields.sessionID != "" {
 		return false, err

--- a/backend/public-graph/graph/generated/generated.go
+++ b/backend/public-graph/graph/generated/generated.go
@@ -266,6 +266,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputMetricTag,
 		ec.unmarshalInputReplayEventInput,
 		ec.unmarshalInputReplayEventsInput,
+		ec.unmarshalInputServiceInput,
 		ec.unmarshalInputStackFrameInput,
 	)
 	first := true
@@ -363,6 +364,11 @@ input ErrorObjectInput {
 	payload: String
 }
 
+input ServiceInput {
+	name: String
+	version: String
+}
+
 input BackendErrorObjectInput {
 	session_secure_id: String
 	request_id: String
@@ -376,6 +382,7 @@ input BackendErrorObjectInput {
 	stackTrace: String!
 	timestamp: Timestamp!
 	payload: String
+	service: ServiceInput!
 }
 
 input MetricTag {
@@ -3610,7 +3617,7 @@ func (ec *executionContext) unmarshalInputBackendErrorObjectInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"session_secure_id", "request_id", "trace_id", "span_id", "log_cursor", "event", "type", "url", "source", "stackTrace", "timestamp", "payload"}
+	fieldsInOrder := [...]string{"session_secure_id", "request_id", "trace_id", "span_id", "log_cursor", "event", "type", "url", "source", "stackTrace", "timestamp", "payload", "service"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -3710,6 +3717,14 @@ func (ec *executionContext) unmarshalInputBackendErrorObjectInput(ctx context.Co
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("payload"))
 			it.Payload, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "service":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("service"))
+			it.Service, err = ec.unmarshalNServiceInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋpublicᚑgraphᚋgraphᚋmodelᚐServiceInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -3994,6 +4009,42 @@ func (ec *executionContext) unmarshalInputReplayEventsInput(ctx context.Context,
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("events"))
 			it.Events, err = ec.unmarshalNReplayEventInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋpublicᚑgraphᚋgraphᚋmodelᚐReplayEventInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputServiceInput(ctx context.Context, obj interface{}) (model.ServiceInput, error) {
+	var it model.ServiceInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"name", "version"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "name":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			it.Name, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "version":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("version"))
+			it.Version, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -4797,6 +4848,11 @@ func (ec *executionContext) unmarshalNReplayEventInput2ᚕᚖgithubᚗcomᚋhigh
 func (ec *executionContext) unmarshalNReplayEventsInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋpublicᚑgraphᚋgraphᚋmodelᚐReplayEventsInput(ctx context.Context, v interface{}) (model.ReplayEventsInput, error) {
 	res, err := ec.unmarshalInputReplayEventsInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNServiceInput2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋpublicᚑgraphᚋgraphᚋmodelᚐServiceInput(ctx context.Context, v interface{}) (*model.ServiceInput, error) {
+	res, err := ec.unmarshalInputServiceInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNStackFrameInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋpublicᚑgraphᚋgraphᚋmodelᚐStackFrameInput(ctx context.Context, v interface{}) ([]*model.StackFrameInput, error) {

--- a/backend/public-graph/graph/generated/generated.go
+++ b/backend/public-graph/graph/generated/generated.go
@@ -365,8 +365,8 @@ input ErrorObjectInput {
 }
 
 input ServiceInput {
-	name: String
-	version: String
+	name: String!
+	version: String!
 }
 
 input BackendErrorObjectInput {
@@ -4036,7 +4036,7 @@ func (ec *executionContext) unmarshalInputServiceInput(ctx context.Context, obj 
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
-			it.Name, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.Name, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -4044,7 +4044,7 @@ func (ec *executionContext) unmarshalInputServiceInput(ctx context.Context, obj 
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("version"))
-			it.Version, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			it.Version, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/backend/public-graph/graph/model/models_gen.go
+++ b/backend/public-graph/graph/model/models_gen.go
@@ -69,8 +69,8 @@ type ReplayEventsInput struct {
 }
 
 type ServiceInput struct {
-	Name    *string `json:"name"`
-	Version *string `json:"version"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 type StackFrameInput struct {

--- a/backend/public-graph/graph/model/models_gen.go
+++ b/backend/public-graph/graph/model/models_gen.go
@@ -10,18 +10,19 @@ import (
 )
 
 type BackendErrorObjectInput struct {
-	SessionSecureID *string   `json:"session_secure_id"`
-	RequestID       *string   `json:"request_id"`
-	TraceID         *string   `json:"trace_id"`
-	SpanID          *string   `json:"span_id"`
-	LogCursor       *string   `json:"log_cursor"`
-	Event           string    `json:"event"`
-	Type            string    `json:"type"`
-	URL             string    `json:"url"`
-	Source          string    `json:"source"`
-	StackTrace      string    `json:"stackTrace"`
-	Timestamp       time.Time `json:"timestamp"`
-	Payload         *string   `json:"payload"`
+	SessionSecureID *string       `json:"session_secure_id"`
+	RequestID       *string       `json:"request_id"`
+	TraceID         *string       `json:"trace_id"`
+	SpanID          *string       `json:"span_id"`
+	LogCursor       *string       `json:"log_cursor"`
+	Event           string        `json:"event"`
+	Type            string        `json:"type"`
+	URL             string        `json:"url"`
+	Source          string        `json:"source"`
+	StackTrace      string        `json:"stackTrace"`
+	Timestamp       time.Time     `json:"timestamp"`
+	Payload         *string       `json:"payload"`
+	Service         *ServiceInput `json:"service"`
 }
 
 type ErrorObjectInput struct {
@@ -65,6 +66,11 @@ type ReplayEventInput struct {
 
 type ReplayEventsInput struct {
 	Events []*ReplayEventInput `json:"events"`
+}
+
+type ServiceInput struct {
+	Name    *string `json:"name"`
+	Version *string `json:"version"`
 }
 
 type StackFrameInput struct {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -693,13 +693,12 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 	}
 
 	opensearchErrorObject := &opensearch.OpenSearchErrorObject{
-		Url:            errorObj.URL,
-		Os:             errorObj.OS,
-		Browser:        errorObj.Browser,
-		Timestamp:      errorObj.Timestamp,
-		Environment:    errorObj.Environment,
-		ServiceName:    errorObj.ServiceName,
-		ServiceVersion: errorObj.ServiceVersion,
+		Url:         errorObj.URL,
+		Os:          errorObj.OS,
+		Browser:     errorObj.Browser,
+		Timestamp:   errorObj.Timestamp,
+		Environment: errorObj.Environment,
+		ServiceName: errorObj.ServiceName,
 	}
 	if err := r.OpenSearch.IndexSynchronous(ctx, opensearch.IndexParams{
 		Index:    opensearch.IndexErrorsCombined,

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -383,6 +383,7 @@ func (r *Resolver) GetOrCreateErrorGroup(ctx context.Context, errorObj *model.Er
 			State:            privateModel.ErrorStateOpen,
 			Fields:           []*model.ErrorField{},
 			Environments:     environmentsString,
+			ServiceName:      errorObj.ServiceName,
 		}
 		if err := r.DB.Create(newErrorGroup).Error; err != nil {
 			return nil, e.Wrap(err, "Error creating new error group")
@@ -691,11 +692,13 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 	}
 
 	opensearchErrorObject := &opensearch.OpenSearchErrorObject{
-		Url:         errorObj.URL,
-		Os:          errorObj.OS,
-		Browser:     errorObj.Browser,
-		Timestamp:   errorObj.Timestamp,
-		Environment: errorObj.Environment,
+		Url:            errorObj.URL,
+		Os:             errorObj.OS,
+		Browser:        errorObj.Browser,
+		Timestamp:      errorObj.Timestamp,
+		Environment:    errorObj.Environment,
+		ServiceName:    errorObj.ServiceName,
+		ServiceVersion: errorObj.ServiceVersion,
 	}
 	if err := r.OpenSearch.IndexSynchronous(ctx, opensearch.IndexParams{
 		Index:    opensearch.IndexErrorsCombined,
@@ -2016,22 +2019,24 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 		}
 
 		errorToInsert := &model.ErrorObject{
-			ProjectID:   projectID,
-			SessionID:   sessionID,
-			TraceID:     v.TraceID,
-			SpanID:      v.SpanID,
-			LogCursor:   v.LogCursor,
-			Environment: session.Environment,
-			Event:       v.Event,
-			Type:        model.ErrorType.BACKEND,
-			URL:         v.URL,
-			Source:      v.Source,
-			OS:          session.OSName,
-			Browser:     session.BrowserName,
-			StackTrace:  &v.StackTrace,
-			Timestamp:   v.Timestamp,
-			Payload:     v.Payload,
-			RequestID:   v.RequestID,
+			ProjectID:      projectID,
+			SessionID:      sessionID,
+			TraceID:        v.TraceID,
+			SpanID:         v.SpanID,
+			LogCursor:      v.LogCursor,
+			Environment:    session.Environment,
+			Event:          v.Event,
+			Type:           model.ErrorType.BACKEND,
+			URL:            v.URL,
+			Source:         v.Source,
+			OS:             session.OSName,
+			Browser:        session.BrowserName,
+			StackTrace:     &v.StackTrace,
+			Timestamp:      v.Timestamp,
+			Payload:        v.Payload,
+			RequestID:      v.RequestID,
+			ServiceName:    v.Service.Name,
+			ServiceVersion: v.Service.Version,
 		}
 
 		var structuredStackTrace []*privateModel.ErrorTrace

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -413,6 +413,7 @@ func (r *Resolver) GetOrCreateErrorGroup(ctx context.Context, errorObj *model.Er
 			Environments:     environmentsString,
 			Event:            errorObj.Event,
 			State:            updatedState,
+			ServiceName:      errorObj.ServiceName,
 		}).Error; err != nil {
 			return nil, e.Wrap(err, "Error updating error group")
 		}

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -73,7 +73,10 @@ func TestProcessBackendPayloadImpl(t *testing.T) {
 			StackTrace:      trpcTraceStr,
 			Timestamp:       time.Time{},
 			Payload:         nil,
-			Service:         &publicModel.ServiceInput{},
+			Service: &publicModel.ServiceInput{
+				Name:    "my-app",
+				Version: "abc123",
+			},
 		}})
 
 		var result *model.ErrorObject
@@ -85,6 +88,9 @@ func TestProcessBackendPayloadImpl(t *testing.T) {
 		if *result.StackTrace != trpcTraceStr {
 			t.Fatal("stacktrace changed after processing")
 		}
+
+		assert.Equal(t, "my-app", result.ServiceName)
+		assert.Equal(t, "abc123", result.ServiceVersion)
 	})
 }
 

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -3,12 +3,13 @@ package graph
 import (
 	"context"
 	"encoding/json"
-	"github.com/highlight-run/highlight/backend/redis"
 	"os"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/redis"
 
 	"github.com/aws/smithy-go/ptr"
 	"github.com/go-test/deep"
@@ -64,6 +65,7 @@ func TestProcessBackendPayloadImpl(t *testing.T) {
 			RequestID:       nil,
 			TraceID:         nil,
 			SpanID:          nil,
+			LogCursor:       new(string),
 			Event:           "dummy event",
 			Type:            "",
 			URL:             "",
@@ -71,6 +73,7 @@ func TestProcessBackendPayloadImpl(t *testing.T) {
 			StackTrace:      trpcTraceStr,
 			Timestamp:       time.Time{},
 			Payload:         nil,
+			Service:         &publicModel.ServiceInput{},
 		}})
 
 		var result *model.ErrorObject

--- a/backend/public-graph/graph/schema.graphqls
+++ b/backend/public-graph/graph/schema.graphqls
@@ -34,6 +34,11 @@ input ErrorObjectInput {
 	payload: String
 }
 
+input ServiceInput {
+	name: String
+	version: String
+}
+
 input BackendErrorObjectInput {
 	session_secure_id: String
 	request_id: String
@@ -47,6 +52,7 @@ input BackendErrorObjectInput {
 	stackTrace: String!
 	timestamp: Timestamp!
 	payload: String
+	service: ServiceInput!
 }
 
 input MetricTag {

--- a/backend/public-graph/graph/schema.graphqls
+++ b/backend/public-graph/graph/schema.graphqls
@@ -35,8 +35,8 @@ input ErrorObjectInput {
 }
 
 input ServiceInput {
-	name: String
-	version: String
+	name: String!
+	version: String!
 }
 
 input BackendErrorObjectInput {

--- a/e2e/go/README.md
+++ b/e2e/go/README.md
@@ -1,0 +1,10 @@
+## Getting Started
+
+This Go app randomly throws an error.
+
+`go run fiber.go`
+`open http://localhost:3456`
+
+Receive either `Hello, World!` if there is no error or `random error from go fiber!` if an error is thrown to Highlight.
+
+Currently, the app cannot be killed. Use `kill -9 $(lsof -t -i:3456)` to kill it manually.

--- a/e2e/go/fiber.go
+++ b/e2e/go/fiber.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"math/rand"
 
 	"github.com/gofiber/fiber/v2"
@@ -13,11 +14,13 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
 	highlight.SetProjectID("1jdkoe52")
 	highlight.SetOTLPEndpoint("http://localhost:4318")
-	highlight.SetServiceName("go-fiber-app")
-	highlight.SetServiceVersion("abc123")
-	highlight.Start()
+	highlight.StartWithContext(ctx,
+		highlight.WithServiceName("go-fiber-app"),
+		highlight.WithServiceVersion("abc123"),
+	)
 	defer highlight.Stop()
 	hlog.Init()
 

--- a/e2e/go/fiber.go
+++ b/e2e/go/fiber.go
@@ -15,6 +15,8 @@ import (
 func main() {
 	highlight.SetProjectID("1jdkoe52")
 	highlight.SetOTLPEndpoint("http://localhost:4318")
+	highlight.SetServiceName("go-fiber-app")
+	highlight.SetServiceVersion("abc123")
 	highlight.Start()
 	defer highlight.Stop()
 	hlog.Init()

--- a/e2e/go/fiber.go
+++ b/e2e/go/fiber.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"math/rand"
 
 	"github.com/gofiber/fiber/v2"
@@ -14,10 +13,9 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
 	highlight.SetProjectID("1jdkoe52")
 	highlight.SetOTLPEndpoint("http://localhost:4318")
-	highlight.StartWithContext(ctx,
+	highlight.Start(
 		highlight.WithServiceName("go-fiber-app"),
 		highlight.WithServiceVersion("abc123"),
 	)

--- a/e2e/go/fiber.go
+++ b/e2e/go/fiber.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"math/rand"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/logger"
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -24,11 +26,11 @@ func main() {
 	app.Use(highlightFiber.Middleware())
 
 	app.Get("/", func(c *fiber.Ctx) error {
-		//logrus.WithContext(c.Context()).Infof("hello from highlight.io")
-		//if rand.Float64() < 0.2 {
-		return e.New("random error from go fiber!")
-		//}
-		//return c.SendString("Hello, World!")
+		logrus.WithContext(c.Context()).Infof("hello from highlight.io")
+		if rand.Float64() < 0.2 {
+			return e.New("random error from go fiber!")
+		}
+		return c.SendString("Hello, World!")
 	})
 
 	logrus.Fatal(app.Listen(":3456"))

--- a/e2e/go/fiber.go
+++ b/e2e/go/fiber.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"math/rand"
-
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/logger"
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -26,11 +24,11 @@ func main() {
 	app.Use(highlightFiber.Middleware())
 
 	app.Get("/", func(c *fiber.Ctx) error {
-		logrus.WithContext(c.Context()).Infof("hello from highlight.io")
-		if rand.Float64() < 0.2 {
-			return e.New("random error from go fiber!")
-		}
-		return c.SendString("Hello, World!")
+		//logrus.WithContext(c.Context()).Infof("hello from highlight.io")
+		//if rand.Float64() < 0.2 {
+		return e.New("random error from go fiber!")
+		//}
+		//return c.SendString("Hello, World!")
 	})
 
 	logrus.Fatal(app.Listen(":3456"))

--- a/sdk/highlight-go/highlight.go
+++ b/sdk/highlight-go/highlight.go
@@ -11,15 +11,18 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 )
 
 var (
-	flushInterval time.Duration
-	interruptChan chan bool
-	signalChan    chan os.Signal
-	wg            sync.WaitGroup
-	otlpEndpoint  string
-	projectID     string
+	flushInterval      time.Duration
+	interruptChan      chan bool
+	signalChan         chan os.Signal
+	wg                 sync.WaitGroup
+	otlpEndpoint       string
+	projectID          string
+	resourceAttributes []attribute.KeyValue
 )
 
 // contextKey represents the keys that highlight may store in the users' context
@@ -166,6 +169,16 @@ func SetDebugMode(l Logger) {
 
 func SetProjectID(id string) {
 	projectID = id
+}
+
+func SetServiceName(serviceName string) {
+	attr := semconv.ServiceNameKey.String(serviceName)
+	resourceAttributes = append(resourceAttributes, attr)
+}
+
+func SetServiceVersion(serviceVersion string) {
+	attr := semconv.ServiceVersionKey.String(serviceVersion)
+	resourceAttributes = append(resourceAttributes, attr)
 }
 
 func GetProjectID() string {

--- a/sdk/highlight-go/highlight.go
+++ b/sdk/highlight-go/highlight.go
@@ -15,15 +15,43 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 )
 
-var (
-	flushInterval      time.Duration
-	interruptChan      chan bool
-	signalChan         chan os.Signal
-	wg                 sync.WaitGroup
+type config struct {
 	otlpEndpoint       string
 	projectID          string
 	resourceAttributes []attribute.KeyValue
+}
+
+var (
+	flushInterval time.Duration
+	interruptChan chan bool
+	signalChan    chan os.Signal
+	wg            sync.WaitGroup
+	conf          *config
 )
+
+type Option interface {
+	apply(conf *config)
+}
+
+type option func(conf *config)
+
+func (fn option) apply(conf *config) {
+	fn(conf)
+}
+
+func WithServiceName(serviceName string) Option {
+	return option(func(conf *config) {
+		attr := semconv.ServiceNameKey.String(serviceName)
+		conf.resourceAttributes = append(conf.resourceAttributes, attr)
+	})
+}
+
+func WithServiceVersion(serviceVersion string) Option {
+	return option(func(conf *config) {
+		attr := semconv.ServiceVersionKey.String(serviceVersion)
+		conf.resourceAttributes = append(conf.resourceAttributes, attr)
+	})
+}
 
 // contextKey represents the keys that highlight may store in the users' context
 // we append every contextKey with Highlight to avoid collisions
@@ -86,6 +114,7 @@ func (d deadLog) Errorf(_ string, _ ...interface{}) {}
 func init() {
 	interruptChan = make(chan bool, 1)
 	signalChan = make(chan os.Signal, 1)
+	conf = &config{}
 
 	signal.Notify(signalChan, syscall.SIGABRT, syscall.SIGTERM, syscall.SIGINT)
 	SetOTLPEndpoint(OTLPDefaultEndpoint)
@@ -94,14 +123,17 @@ func init() {
 }
 
 // Start is used to start the Highlight client's collection service.
-func Start() {
-	StartWithContext(context.Background())
+func Start(opts ...Option) {
+	StartWithContext(context.Background(), opts...)
 }
 
 // StartWithContext is used to start the Highlight client's collection
 // service, but allows the user to pass in their own context.Context.
 // This allows the user kill the highlight worker by canceling their context.CancelFunc.
-func StartWithContext(ctx context.Context) {
+func StartWithContext(ctx context.Context, opts ...Option) {
+	for _, opt := range opts {
+		opt.apply(conf)
+	}
 	stateMutex.Lock()
 	defer stateMutex.Unlock()
 	if state == started {
@@ -160,7 +192,7 @@ func SetFlushInterval(newFlushInterval time.Duration) {
 // SetOTLPEndpoint allows you to override the otlp address used for sending errors and traces.
 // Use the root http url. Eg: https://otel.highlight.io:4318
 func SetOTLPEndpoint(newOtlpEndpoint string) {
-	otlpEndpoint = newOtlpEndpoint
+	conf.otlpEndpoint = newOtlpEndpoint
 }
 
 func SetDebugMode(l Logger) {
@@ -168,21 +200,11 @@ func SetDebugMode(l Logger) {
 }
 
 func SetProjectID(id string) {
-	projectID = id
-}
-
-func SetServiceName(serviceName string) {
-	attr := semconv.ServiceNameKey.String(serviceName)
-	resourceAttributes = append(resourceAttributes, attr)
-}
-
-func SetServiceVersion(serviceVersion string) {
-	attr := semconv.ServiceVersionKey.String(serviceVersion)
-	resourceAttributes = append(resourceAttributes, attr)
+	conf.projectID = id
 }
 
 func GetProjectID() string {
-	return projectID
+	return conf.projectID
 }
 
 // InterceptRequest calls InterceptRequestWithContext using the request object's context

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -114,6 +114,7 @@ func StartTrace(ctx context.Context, name string, tags ...attribute.KeyValue) (t
 		attribute.String(SessionIDAttribute, sessionID),
 		attribute.String(RequestIDAttribute, requestID),
 	}
+	attrs = append(attrs, resourceAttributes...)
 	attrs = append(attrs, tags...)
 	span.SetAttributes(attrs...)
 	return span, ctx

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -84,6 +84,7 @@ func StartOTLP() (*OTLP, error) {
 		resource.WithContainer(),
 		resource.WithOS(),
 		resource.WithProcess(),
+		resource.WithAttributes(resourceAttributes...),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating OTLP resource context: %w", err)
@@ -114,7 +115,6 @@ func StartTrace(ctx context.Context, name string, tags ...attribute.KeyValue) (t
 		attribute.String(SessionIDAttribute, sessionID),
 		attribute.String(RequestIDAttribute, requestID),
 	}
-	attrs = append(attrs, resourceAttributes...)
 	attrs = append(attrs, tags...)
 	span.SetAttributes(attrs...)
 	return span, ctx

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -66,12 +66,12 @@ var (
 
 func StartOTLP() (*OTLP, error) {
 	var options []otlptracehttp.Option
-	if strings.HasPrefix(otlpEndpoint, "http://") {
-		options = append(options, otlptracehttp.WithEndpoint(otlpEndpoint[7:]), otlptracehttp.WithInsecure())
-	} else if strings.HasPrefix(otlpEndpoint, "https://") {
-		options = append(options, otlptracehttp.WithEndpoint(otlpEndpoint[8:]))
+	if strings.HasPrefix(conf.otlpEndpoint, "http://") {
+		options = append(options, otlptracehttp.WithEndpoint(conf.otlpEndpoint[7:]), otlptracehttp.WithInsecure())
+	} else if strings.HasPrefix(conf.otlpEndpoint, "https://") {
+		options = append(options, otlptracehttp.WithEndpoint(conf.otlpEndpoint[8:]))
 	} else {
-		logger.Errorf("an invalid otlp endpoint was configured %s", otlpEndpoint)
+		logger.Errorf("an invalid otlp endpoint was configured %s", conf.otlpEndpoint)
 	}
 	client := otlptracehttp.NewClient(options...)
 	exporter, err := otlptrace.New(context.Background(), client)
@@ -84,7 +84,7 @@ func StartOTLP() (*OTLP, error) {
 		resource.WithContainer(),
 		resource.WithOS(),
 		resource.WithProcess(),
-		resource.WithAttributes(resourceAttributes...),
+		resource.WithAttributes(conf.resourceAttributes...),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating OTLP resource context: %w", err)
@@ -111,7 +111,7 @@ func StartTrace(ctx context.Context, name string, tags ...attribute.KeyValue) (t
 	sessionID, requestID, _ := validateRequest(ctx)
 	ctx, span := tracer.Start(ctx, name)
 	attrs := []attribute.KeyValue{
-		attribute.String(ProjectIDAttribute, projectID),
+		attribute.String(ProjectIDAttribute, conf.projectID),
 		attribute.String(SessionIDAttribute, sessionID),
 		attribute.String(RequestIDAttribute, requestID),
 	}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR demonstrates populating service name and service version onto error_groups/objects.
I also added `WithServiceName` and `WithServiceVersion` to our go SDK (so one doesn't have to use curl) via options to `Start`. 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

https://www.loom.com/share/c73a4c3f58a74fb08a19faa1259329bb

I didn't mention it in the video but I also confirmed that we update open search correctly

![Screenshot_2023-07-27_at_4_23_19_PM](https://github.com/highlight/highlight/assets/58678/9eaaa8e5-e151-4e95-8c2a-6be0c3960ee0)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

We will hold off on making a new release of the Go SDK. When we are confident this is working correctly, we will create a new git tag for customers to use (tracked in #6149)
