### PR TITLE
fix e2e test on main

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -174,9 +174,14 @@ jobs:
             - name: Start docker containers & run cypress
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_E2E_TOKEN }}
-                  CYPRESS_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+                  COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+                  REF: ${{ github.ref }}
               run: |
                   start_time=$(date -Isecond)
+
+                  if [[ "$REF" != "refs/heads/main" ]]; then
+                    export CYPRESS_CLIENT_VERSION="dev-${COMMIT_SHA}"
+                  fi
 
                   # start highlight
                   pushd docker;

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -95,7 +95,7 @@ jobs:
               run: yarn validate --has-sdk-changes=${{ steps.filter.outputs.npm-changed }}
 
             - name: Publish client bundle (preview)
-              if: github.ref != 'refs/heads/main'
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref != 'refs/heads/main'
               run: yarn publish:client --preview ${GIT_SHA} --replace
               env:
                   # this cannot use ${{ github.sha }} as that commit will be a merge ref
@@ -176,10 +176,11 @@ jobs:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_E2E_TOKEN }}
                   COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
                   REF: ${{ github.ref }}
+                  REPO: ${{ github.event.pull_request.head.repo.full_name }}
               run: |
                   start_time=$(date -Isecond)
 
-                  if [[ "$REF" != "refs/heads/main" ]]; then
+                  if [[ "$REF" != "refs/heads/main" && "$REPO" == "highlight/highlight" ]]; then
                     export CYPRESS_CLIENT_VERSION="dev-${COMMIT_SHA}"
                   fi
 

--- a/cypress/e2e/umd.cy.js
+++ b/cypress/e2e/umd.cy.js
@@ -10,9 +10,10 @@ describe('web client recording spec', () => {
 				})
 				cy.visit(`./cypress/pages/${source}.html`, {
 					onBeforeLoad(win) {
-						win.scriptUrl = `https://static.highlight.io/dev-${Cypress.env(
-							'COMMIT_SHA',
-						)}/index.js`
+						const clientVersion = Cypress.env('CLIENT_VERSION')
+						if (clientVersion) {
+							win.scriptUrl = `https://static.highlight.io/${clientVersion}/index.js`
+						}
 					},
 				})
 				cy.window().then((win) => {


### PR DESCRIPTION
## Summary

After #6015, the e2e test was broken in main as it would be trying to reference a dev client version.
This PR makes the e2e test default to `undefined` (script version set by the firstload package.json) in main.

## How did you test this change?

CI

## Are there any deployment considerations?

No
