### PR TITLE
default dashboards to last 7 days

### DIFF
--- a/frontend/src/hooks/useDataTimeRange.ts
+++ b/frontend/src/hooks/useDataTimeRange.ts
@@ -4,7 +4,7 @@ import moment from 'moment'
 export const FORMAT = 'YYYY-MM-DDTHH:mm:00.000000000Z'
 
 export const defaultEndDate = moment()
-export const defaultLookback = 24 * 60
+export const defaultLookback = 7 * 24 * 60
 export const defaultStartDate = moment(defaultEndDate).subtract(
 	defaultLookback,
 	'minutes',


### PR DESCRIPTION
## Summary

The `/analytics` page `Key App Visitor Metrics` does not work for intervals of <= 24 hours.

## How did you test this change?

Reflame preview

## Are there any deployment considerations?

No