### PR TITLE
make asset replacement a workspace setting

### DIFF
--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -97,7 +97,8 @@ const (
 	ErrAssetSizeUnknown = "ErrAssetSizeUnknown"
 	ErrFailedToFetch    = "ErrFailedToFetch"
 	ErrFetchNotOk       = "ErrFetchNotOk"
-	MaxAssetSize        = 10 * 1024 * 1e6
+	// MaxAssetSize = 200 GB storage per ECS node / 64 parallel kafka workers
+	MaxAssetSize = 3 * 1e9
 )
 
 type fetcher interface {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -386,6 +386,7 @@ type AllWorkspaceSettings struct {
 	ErrorEmbeddingsWrite bool `gorm:"default:false"`
 	// use embeddings to group errors in this workspace
 	ErrorEmbeddingsGroup bool `gorm:"default:false"`
+	ReplaceAssets        bool `gorm:"default:false"`
 }
 
 type HasSecret interface {

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -872,9 +872,6 @@ func ErrorInputToParams(params *modelInputs.ErrorSearchParamsInput) *model.Error
 }
 
 func (r *Resolver) doesAdminOwnErrorGroup(ctx context.Context, errorGroupSecureID string) (*model.ErrorGroup, bool, error) {
-	s, ctx := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("doesAdminOwnErrorGroup"))
-	defer s.Finish()
-
 	eg := &model.ErrorGroup{}
 
 	if err := r.DB.Where(&model.ErrorGroup{SecureID: errorGroupSecureID}).Take(&eg).Error; err != nil {
@@ -886,13 +883,6 @@ func (r *Resolver) doesAdminOwnErrorGroup(ctx context.Context, errorGroupSecureI
 		return eg, false, err
 	}
 
-	start := time.Now()
-	defer func() {
-		log.WithContext(ctx).WithField("duration", time.Since(start)).Info("doesAdminOwnErrorGroup.GetErrorGroupOccurrences")
-	}()
-
-	s, ctx = tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("doesAdminOwnErrorGroup.GetErrorGroupOccurrences"))
-	defer s.Finish()
 	if eg.FirstOccurrence, eg.LastOccurrence, err = r.GetErrorGroupOccurrences(ctx, eg); err != nil {
 		return nil, false, e.Wrap(err, "error querying error group occurrences")
 	}

--- a/backend/store/workspace_settings.go
+++ b/backend/store/workspace_settings.go
@@ -16,3 +16,13 @@ func (store *Store) GetAllWorkspaceSettings(ctx context.Context, workspaceID int
 		return &workspaceSettings, nil
 	})
 }
+
+func (store *Store) GetAllWorkspaceSettingsByProject(ctx context.Context, projectID int) (*model.AllWorkspaceSettings, error) {
+	return cachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-project-%d", projectID), 250*time.Millisecond, 5*time.Second, func() (*model.AllWorkspaceSettings, error) {
+		var workspaceSettings model.AllWorkspaceSettings
+		if err := store.db.Model(&model.AllWorkspaceSettings{}).Joins("INNER JOIN projects ON projects.workspace_id = all_workspace_settings.workspace_id").Where("projects.id = ?", projectID).Take(&workspaceSettings).Error; err != nil {
+			return nil, err
+		}
+		return &workspaceSettings, nil
+	})
+}

--- a/deploy/public-worker-service.json
+++ b/deploy/public-worker-service.json
@@ -225,8 +225,11 @@
 	"pidMode": null,
 	"requiresCompatibilities": ["FARGATE"],
 	"networkMode": "awsvpc",
-	"cpu": "2048",
+	"cpu": "4096",
 	"memory": "16384",
+	"ephemeralStorage": {
+		"sizeInGiB": 200
+	},
 	"revision": 40,
 	"status": "ACTIVE",
 	"inferenceAccelerators": null,


### PR DESCRIPTION
## Summary

Adds a workspace setting for saving assets to make it easier to disable the setting when needed.
Configures the maximum asset size based on how much storage the ECS containers have.
Bumps the CPU and storage of the workers (cpu based on recent limits at the max partitions we have).

## How did you test this change?

ECS configuration deployed manually.
Checking with debugger that settings would load correctly and assets would be saved.

<img width="1800" alt="Screenshot 2023-07-25 at 11 15 20 PM" src="https://github.com/highlight/highlight/assets/1351531/be922db1-c9d5-4a78-a484-1551e1722073">

## Are there any deployment considerations?

No
