### PR TITLE
optimize ingest and report log ingest delay

### DIFF
--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -227,7 +227,9 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 	span.SetTag("NumLogRows", len(logRows))
 	span.SetTag("NumFilteredRows", len(filteredRows))
 	span.SetTag("PayloadSizeBytes", binary.Size(filteredRows))
-	span.SetTag("MaxIngestDelay", time.Since(oldestLogRow.Timestamp))
+	if oldestLogRow != nil {
+		span.SetTag("MaxIngestDelay", time.Since(oldestLogRow.Timestamp))
+	}
 	err := k.Worker.PublicResolver.Clickhouse.BatchWriteLogRows(ctxT, filteredRows)
 	if err != nil {
 		log.WithContext(ctxT).WithError(err).Error("failed to batch write to clickhouse")

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -71,7 +71,7 @@ func (k *KafkaWorker) ProcessMessages(ctx context.Context) {
 	}
 }
 
-const BatchFlushSize = 128
+const BatchFlushSize = 512
 const BatchedFlushTimeout = 1 * time.Second
 
 type KafkaWorker struct {
@@ -85,6 +85,7 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 	s.SetTag("BatchSize", len(k.BatchBuffer.messageQueue))
 	defer s.Finish()
 
+	var oldestLogRow *clickhouse.LogRow
 	var logRows []*clickhouse.LogRow
 
 	var received int
@@ -96,6 +97,11 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 				switch lastMsg.Type {
 				case kafkaqueue.PushLogs:
 					logRows = append(logRows, lastMsg.PushLogs.LogRows...)
+					for _, row := range lastMsg.PushLogs.LogRows {
+						if oldestLogRow == nil || row.Timestamp.Before(oldestLogRow.Timestamp) {
+							oldestLogRow = row
+						}
+					}
 					received += len(lastMsg.PushLogs.LogRows)
 				}
 				if received >= BatchFlushSize {
@@ -220,7 +226,8 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) {
 	span, ctxT := tracer.StartSpanFromContext(wCtx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.batched.clickhouse"))
 	span.SetTag("NumLogRows", len(logRows))
 	span.SetTag("NumFilteredRows", len(filteredRows))
-	span.SetTag("PayloadSizeBytes", binary.Size(logRows))
+	span.SetTag("PayloadSizeBytes", binary.Size(filteredRows))
+	span.SetTag("MaxIngestDelay", time.Since(oldestLogRow.Timestamp))
 	err := k.Worker.PublicResolver.Clickhouse.BatchWriteLogRows(ctxT, filteredRows)
 	if err != nil {
 		log.WithContext(ctxT).WithError(err).Error("failed to batch write to clickhouse")

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -439,7 +439,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 
 func (w *Worker) PublicWorker(ctx context.Context) {
 	const parallelWorkers = 64
-	const parallelBatchWorkers = 8
+	const parallelBatchWorkers = 32
 	// creates N parallel kafka message consumers that process messages.
 	// each consumer is considered part of the same consumer group and gets
 	// allocated a slice of all partitions. this ensures that a particular subset of partitions


### PR DESCRIPTION
## Summary

Increase the number of batched queue workers for the larger number of partitions.
Report the write delay for log rows.

## How did you test this change?

Local backend deploy.

## Are there any deployment considerations?

No