### PR TITLE
write service version to clickhouse

### DIFF
--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -22,12 +22,13 @@ var fluentProjectPattern = regexp.MustCompile(fmt.Sprintf(`%s=([\S]+)`, highligh
 
 // Extracted fields
 type extractedFields struct {
-	projectID    string
-	projectIDInt int
-	sessionID    string
-	requestID    string
-	source       modelInputs.LogSource
-	serviceName  string
+	projectID      string
+	projectIDInt   int
+	sessionID      string
+	requestID      string
+	source         modelInputs.LogSource
+	serviceName    string
+	serviceVersion string
 
 	// This represents the merged result of resource, span...log attributes
 	// _after_ we extract fields out. In other words, if `serviceName` is extracted, it won't be included
@@ -120,6 +121,11 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 	if val, ok := resourceAttributes[string(semconv.ServiceNameKey)]; ok { // we know that service name will be in the resource hash
 		fields.serviceName = val.(string)
 		delete(attrs, string(semconv.ServiceNameKey))
+	}
+
+	if val, ok := resourceAttributes[string(semconv.ServiceVersionKey)]; ok { // we know that service version will be in the resource hash
+		fields.serviceVersion = val.(string)
+		delete(attrs, string(semconv.ServiceVersionKey))
 	}
 
 	if fields.projectID == "" {

--- a/backend/otel/extract_test.go
+++ b/backend/otel/extract_test.go
@@ -122,6 +122,16 @@ func TestExtractFields_ExtractServiceName(t *testing.T) {
 	assert.Equal(t, fields.attrs, map[string]string{})
 }
 
+func TestExtractFields_ExtractServiceVersion(t *testing.T) {
+	resource := newResource(map[string]string{
+		"service.version": "abc123",
+	})
+	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
+	assert.NoError(t, err)
+	assert.Equal(t, fields.serviceVersion, "abc123")
+	assert.Equal(t, fields.attrs, map[string]string{})
+}
+
 func TestExtractFields_OmitLogSeverity(t *testing.T) {
 	resource := newResource(map[string]string{
 		"os.description": "Debian GNU/Linux 11 (bullseye)",

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -356,6 +356,7 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 					clickhouse.WithBody(ctx, logRecord.Body().Str()),
 					clickhouse.WithLogAttributes(fields.attrs),
 					clickhouse.WithServiceName(fields.serviceName),
+					clickhouse.WithServiceVersion(fields.serviceVersion),
 					clickhouse.WithSeverityText(logRecord.SeverityText()),
 					clickhouse.WithSource(fields.source),
 				)

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -190,6 +190,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 							clickhouse.WithBody(ctx, excMessage),
 							clickhouse.WithLogAttributes(fields.attrs),
 							clickhouse.WithServiceName(fields.serviceName),
+							clickhouse.WithServiceVersion(fields.serviceVersion),
 							clickhouse.WithSeverityText("ERROR"),
 							clickhouse.WithSource(fields.source),
 						)
@@ -223,6 +224,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 							clickhouse.WithBody(ctx, logMessage),
 							clickhouse.WithLogAttributes(fields.attrs),
 							clickhouse.WithServiceName(fields.serviceName),
+							clickhouse.WithServiceVersion(fields.serviceVersion),
 							clickhouse.WithSeverityText(logSev),
 							clickhouse.WithSource(fields.source),
 						)


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR writes `service.version` to clickhouse (stored in the column from #6107). This is not currently queryable in the UI, it just writes to the DB. 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

[Confirm](http://localhost:8123/play) no records with `ServiceVersion` populated:

```sql
select * from logs where ServiceVersion != ''
```
=> Returns 0 results

Send curl request with `service.version` populated

```
curl -X POST http://localhost:4318/v1/logs \
-H 'Content-Type: application/json' \
-d '{
      "resourceLogs": [
        {
          "resource": {
            "attributes": [
                {
                    "key": "service.name",
                    "value": {
                        "stringValue": "my service"
                    }
                },
                {
                  "key": "service.version",
                  "value": {
                      "stringValue": "abc123"
                  }
              }
            ]
        },
          "scopeLogs": [
            {
              "scope": {},
              "logRecords": [
                {
                  "timeUnixNano": "'$(date +%s000000000)'",
                  "severityNumber": 9,
                  "severityText": "Info",
                  "name": "logA",
                  "body": {
                    "stringValue": "Hello, world! This is sent from a curl command."
                  },
                  "attributes": [
                    {
                      "key": "highlight.project_id",
                      "value": {
                        "stringValue": "1"
                      }
                    },
                    {
                      "key": "foo",
                      "value": {
                        "stringValue": "bar"
                      }
                    }
                  ],
                  "traceId": "08040201000000000000000000000000",
                  "spanId": "0102040800000000"
                }
              ]
            }
          ]
        }
      ]
    }'
````

[Confirm](http://localhost:8123/play) one record has `ServiceVersion` populated:

```sql
select * from logs where ServiceVersion != ''
```
![Screenshot 2023-07-26 at 10 22 48 AM](https://github.com/highlight/highlight/assets/58678/8379ae3e-3ba5-4b29-bbe3-d529a8de6a4a)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
