### PR TITLE
Convert BarChart to use new tooltip

### DIFF
--- a/frontend/src/components/BarChart/BarChart.tsx
+++ b/frontend/src/components/BarChart/BarChart.tsx
@@ -1,4 +1,4 @@
-import Tooltip from '@components/Tooltip/Tooltip'
+import { Tooltip } from '@highlight-run/ui'
 import clsx from 'clsx'
 import React from 'react'
 
@@ -40,27 +40,30 @@ const BarChart = ({
 					: minBarHeight ?? 0
 				return (
 					<Tooltip
-						title={`${
+						key={ind}
+						trigger={
+							<div
+								className={style.barDiv}
+								style={{
+									paddingLeft: barGap / 2,
+									paddingRight: barGap / 2,
+								}}
+							>
+								<div
+									className={clsx(style.bar, {
+										[style.barSelected]: !!selected,
+									})}
+									style={{
+										height: `${barHeight}px`,
+										width: 3,
+									}}
+								/>
+							</div>
+						}
+					>
+						{`${
 							data.length - 1 - ind
 						} ${xAxis}(s) ago\n ${num} ${yAxis}(s)`}
-						key={ind}
-					>
-						<div
-							className={style.barDiv}
-							style={{
-								paddingLeft: barGap / 2,
-								paddingRight: barGap / 2,
-							}}
-						>
-							<div
-								className={clsx(style.bar, {
-									[style.barSelected]: !!selected,
-								})}
-								style={{
-									height: `${barHeight}px`,
-								}}
-							/>
-						</div>
 					</Tooltip>
 				)
 			})}


### PR DESCRIPTION
## Summary
We want to start using our new UI tooltip on the Errors page. This includes updating the BarChart to use the new component.

This component is used on the:
- Error result card
- Error details
- Alert table

## How did you test this change?
View each of the components in the app, and confirm the tooltip works properly:
1.  Error result card (`/1/errors`)
2. Error Details (Click on error on `/1/errors`)
3. Alert Table (`/1/alerts`)

![Screenshot 2023-07-26 at 2 28 52 PM](https://github.com/highlight/highlight/assets/17744174/cf782822-795a-4780-acd2-be3d4e703829)

![Screenshot 2023-07-26 at 2 28 58 PM](https://github.com/highlight/highlight/assets/17744174/2aa78ec6-b8d5-4993-812c-42d6434a29c8)

![Screenshot 2023-07-26 at 2 29 31 PM](https://github.com/highlight/highlight/assets/17744174/5a48e209-1f92-494b-8412-aa2918e41de9)

## Are there any deployment considerations?
N/A
