### PR TITLE
fix writing a backend error stacktrace

### DIFF
--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -37,6 +37,9 @@ type extractedFields struct {
 	exceptionStackTrace string
 	errorUrl            string
 
+	metricEventName  string
+	metricEventValue string // up to the consumer to parse this into an expected format
+
 	// This represents the merged result of resource, span...log attributes
 	// _after_ we extract fields out. In other words, if `serviceName` is extracted, it won't be included
 	// in this map.
@@ -133,6 +136,16 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 	if val, ok := attrs[highlight.LogMessageAttribute]; ok {
 		fields.logMessage = val.(string)
 		delete(attrs, highlight.LogMessageAttribute)
+	}
+
+	if val, ok := attrs[highlight.MetricEventName]; ok {
+		fields.metricEventName = val.(string)
+		delete(attrs, highlight.MetricEventName)
+	}
+
+	if val, ok := attrs[highlight.MetricEventValue]; ok {
+		fields.metricEventValue = val.(string)
+		delete(attrs, highlight.MetricEventValue)
 	}
 
 	if val, ok := eventAttributes[string(semconv.ExceptionTypeKey)]; ok { // we know that exception.type will be in the event attributes map

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -29,7 +29,7 @@ type extractedFields struct {
 	source         modelInputs.LogSource
 	serviceName    string
 	serviceVersion string
-	logLevel       string
+	logSeverity    string
 	logMessage     string
 
 	exceptionType       string
@@ -125,14 +125,14 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 		delete(attrs, highlight.RequestIDAttribute)
 	}
 
+	if val, ok := attrs[highlight.LogSeverityAttribute]; ok {
+		fields.logSeverity = val.(string)
+		delete(attrs, highlight.LogSeverityAttribute)
+	}
+
 	if val, ok := attrs[highlight.LogMessageAttribute]; ok {
 		fields.logMessage = val.(string)
 		delete(attrs, highlight.LogMessageAttribute)
-	}
-
-	if val, ok := attrs[highlight.LogSeverityAttribute]; ok {
-		fields.logLevel = val.(string)
-		delete(attrs, highlight.LogSeverityAttribute)
 	}
 
 	if val, ok := eventAttributes[string(semconv.ExceptionTypeKey)]; ok { // we know that exception.type will be in the event attributes map
@@ -145,14 +145,14 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 		delete(attrs, string(semconv.ExceptionMessageKey))
 	}
 
-	if val, ok := eventAttributes[highlight.ErrorURLAttribute]; ok { // we know that URL will be in the event attributes map
-		fields.errorUrl = val.(string)
-		delete(attrs, string(semconv.ExceptionStacktraceKey))
-	}
-
 	if val, ok := eventAttributes[string(semconv.ExceptionStacktraceKey)]; ok { // we know that exception.stacktrace will be in the event attributes map
 		fields.exceptionStackTrace = val.(string)
 		delete(attrs, string(semconv.ExceptionStacktraceKey))
+	}
+
+	if val, ok := eventAttributes[highlight.ErrorURLAttribute]; ok { // we know that URL will be in the event attributes map
+		fields.errorUrl = val.(string)
+		delete(attrs, highlight.ErrorURLAttribute)
 	}
 
 	if val, ok := resourceAttributes[string(semconv.ServiceNameKey)]; ok { // we know that service name will be in the resource map

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -29,6 +29,13 @@ type extractedFields struct {
 	source         modelInputs.LogSource
 	serviceName    string
 	serviceVersion string
+	logLevel       string
+	logMessage     string
+
+	exceptionType       string
+	exceptionMessage    string
+	exceptionStackTrace string
+	errorUrl            string
 
 	// This represents the merged result of resource, span...log attributes
 	// _after_ we extract fields out. In other words, if `serviceName` is extracted, it won't be included
@@ -118,7 +125,37 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 		delete(attrs, highlight.RequestIDAttribute)
 	}
 
-	if val, ok := resourceAttributes[string(semconv.ServiceNameKey)]; ok { // we know that service name will be in the resource hash
+	if val, ok := attrs[highlight.LogMessageAttribute]; ok {
+		fields.logMessage = val.(string)
+		delete(attrs, highlight.LogMessageAttribute)
+	}
+
+	if val, ok := attrs[highlight.LogSeverityAttribute]; ok {
+		fields.logLevel = val.(string)
+		delete(attrs, highlight.LogSeverityAttribute)
+	}
+
+	if val, ok := eventAttributes[string(semconv.ExceptionTypeKey)]; ok { // we know that exception.type will be in the event attributes map
+		fields.exceptionType = val.(string)
+		delete(attrs, string(semconv.ExceptionTypeKey))
+	}
+
+	if val, ok := eventAttributes[string(semconv.ExceptionMessageKey)]; ok { // we know that exception.message will be in the event attributes map
+		fields.exceptionMessage = val.(string)
+		delete(attrs, string(semconv.ExceptionMessageKey))
+	}
+
+	if val, ok := eventAttributes[highlight.ErrorURLAttribute]; ok { // we know that URL will be in the event attributes map
+		fields.errorUrl = val.(string)
+		delete(attrs, string(semconv.ExceptionStacktraceKey))
+	}
+
+	if val, ok := eventAttributes[string(semconv.ExceptionStacktraceKey)]; ok { // we know that exception.stacktrace will be in the event attributes map
+		fields.exceptionStackTrace = val.(string)
+		delete(attrs, string(semconv.ExceptionStacktraceKey))
+	}
+
+	if val, ok := resourceAttributes[string(semconv.ServiceNameKey)]; ok { // we know that service name will be in the resource map
 		fields.serviceName = val.(string)
 		delete(attrs, string(semconv.ServiceNameKey))
 	}
@@ -142,7 +179,7 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 
 	attributesMap := make(map[string]string)
 	for k, v := range attrs {
-		prefixes := highlight.InternalAttributePrefixes
+		prefixes := []string{}
 		if fields.source == modelInputs.LogSourceFrontend {
 			prefixes = append(prefixes, highlight.BackendOnlyAttributePrefixes...)
 		}

--- a/backend/otel/extract_test.go
+++ b/backend/otel/extract_test.go
@@ -122,6 +122,26 @@ func TestExtractFields_ExtractRequestID(t *testing.T) {
 	assert.Equal(t, fields.attrs, map[string]string{})
 }
 
+func TestExtractFields_ExtractMetricEventName(t *testing.T) {
+	resource := newResource(map[string]string{
+		highlight.MetricEventName: "metric_name",
+	})
+	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
+	assert.NoError(t, err)
+	assert.Equal(t, fields.metricEventName, "metric_name")
+	assert.Equal(t, fields.attrs, map[string]string{})
+}
+
+func TestExtractFields_ExtractMetricEventValue(t *testing.T) {
+	resource := newResource(map[string]string{
+		highlight.MetricEventValue: "99",
+	})
+	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
+	assert.NoError(t, err)
+	assert.Equal(t, fields.metricEventValue, "99")
+	assert.Equal(t, fields.attrs, map[string]string{})
+}
+
 func TestExtractFields_ExtractLogSeverity(t *testing.T) {
 	resource := newResource(map[string]string{})
 	event := newEvent(map[string]string{

--- a/backend/otel/extract_test.go
+++ b/backend/otel/extract_test.go
@@ -250,19 +250,6 @@ func TestExtractFields_OmitBackendPropertiesForFrontendSource(t *testing.T) {
 	assert.Equal(t, fields.attrs, map[string]string{})
 }
 
-func TestExtractFields_OmitExceptionProperties(t *testing.T) {
-	resource := newResource(map[string]string{
-		"exception.message":    "foo",
-		"exception.stacktrace": "bar",
-		"exception.type":       "baz",
-	})
-	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
-	assert.NoError(t, err)
-	assert.Equal(t, fields.attrs, map[string]string{
-		"exception.type": "baz",
-	})
-}
-
 func TestExtractFields_TrimLongFields(t *testing.T) {
 	var value string
 	for i := 0; i < 2<<16; i++ {

--- a/backend/otel/extract_test.go
+++ b/backend/otel/extract_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 )
 
 func newResource(attrs map[string]string) pcommon.Resource {
@@ -31,6 +33,14 @@ func newResource(attrs map[string]string) pcommon.Resource {
 		resource.Attributes().PutStr(k, v)
 	}
 	return resource
+}
+
+func newEvent(attrs map[string]string) ptrace.SpanEvent {
+	event := ptrace.NewSpanEvent()
+	for k, v := range attrs {
+		event.Attributes().PutStr(k, v)
+	}
+	return event
 }
 
 func TestExtractFields_ExtractProjectID(t *testing.T) {
@@ -109,6 +119,72 @@ func TestExtractFields_ExtractRequestID(t *testing.T) {
 	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
 	assert.NoError(t, err)
 	assert.Equal(t, fields.requestID, "request_id")
+	assert.Equal(t, fields.attrs, map[string]string{})
+}
+
+func TestExtractFields_ExtractLogSeverity(t *testing.T) {
+	resource := newResource(map[string]string{})
+	event := newEvent(map[string]string{
+		highlight.LogSeverityAttribute: "log_severity",
+	})
+	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource, event: &event})
+	assert.NoError(t, err)
+	assert.Equal(t, fields.logSeverity, "log_severity")
+	assert.Equal(t, fields.attrs, map[string]string{})
+}
+
+func TestExtractFields_ExtractLogMessage(t *testing.T) {
+	resource := newResource(map[string]string{})
+	event := newEvent(map[string]string{
+		highlight.LogMessageAttribute: "log_message",
+	})
+	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource, event: &event})
+	assert.NoError(t, err)
+	assert.Equal(t, fields.logMessage, "log_message")
+	assert.Equal(t, fields.attrs, map[string]string{})
+}
+
+func TestExtractFields_ExtractExceptionType(t *testing.T) {
+	resource := newResource(map[string]string{})
+	event := newEvent(map[string]string{
+		string(semconv.ExceptionTypeKey): "exception_type",
+	})
+	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource, event: &event})
+	assert.NoError(t, err)
+	assert.Equal(t, fields.exceptionType, "exception_type")
+	assert.Equal(t, fields.attrs, map[string]string{})
+}
+
+func TestExtractFields_ExtractExceptionMessage(t *testing.T) {
+	resource := newResource(map[string]string{})
+	event := newEvent(map[string]string{
+		string(semconv.ExceptionMessageKey): "exception_message",
+	})
+	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource, event: &event})
+	assert.NoError(t, err)
+	assert.Equal(t, fields.exceptionMessage, "exception_message")
+	assert.Equal(t, fields.attrs, map[string]string{})
+}
+
+func TestExtractFields_ExtractExceptionStacktrace(t *testing.T) {
+	resource := newResource(map[string]string{})
+	event := newEvent(map[string]string{
+		string(semconv.ExceptionStacktraceKey): "exception_stacktrace",
+	})
+	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource, event: &event})
+	assert.NoError(t, err)
+	assert.Equal(t, fields.exceptionStackTrace, "exception_stacktrace")
+	assert.Equal(t, fields.attrs, map[string]string{})
+}
+
+func TestExtractFields_ExtractErrorURL(t *testing.T) {
+	resource := newResource(map[string]string{})
+	event := newEvent(map[string]string{
+		highlight.ErrorURLAttribute: "error_url",
+	})
+	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource, event: &event})
+	assert.NoError(t, err)
+	assert.Equal(t, fields.errorUrl, "error_url")
 	assert.Equal(t, fields.attrs, map[string]string{})
 }
 

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -85,11 +85,10 @@ func getBackendError(ctx context.Context, ts time.Time, fields extractedFields, 
 }
 
 func getMetric(ctx context.Context, ts time.Time, fields extractedFields, traceID, spanID string) (*model.MetricInput, error) {
-	name, ok := fields.attrs[highlight.MetricEventName]
-	if !ok {
+	if fields.metricEventName == "" {
 		return nil, e.New("otel received metric with no name")
 	}
-	value, err := strconv.ParseFloat(fields.attrs[highlight.MetricEventValue], 64)
+	value, err := strconv.ParseFloat(fields.metricEventValue, 64)
 
 	if err != nil {
 		return nil, e.New("otel received metric with no value")
@@ -97,7 +96,7 @@ func getMetric(ctx context.Context, ts time.Time, fields extractedFields, traceI
 	return &model.MetricInput{
 		SessionSecureID: fields.sessionID,
 		Group:           pointy.String(fields.requestID),
-		Name:            name,
+		Name:            fields.metricEventName,
 		Value:           value,
 		Category:        pointy.String(fields.source.String()),
 		Timestamp:       ts,

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -219,7 +219,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 							clickhouse.WithLogAttributes(fields.attrs),
 							clickhouse.WithServiceName(fields.serviceName),
 							clickhouse.WithServiceVersion(fields.serviceVersion),
-							clickhouse.WithSeverityText(logSev),
+							clickhouse.WithSeverityText(fields.logSeverity),
 							clickhouse.WithSource(fields.source),
 						)
 

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -3,6 +3,10 @@ package highlight
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"reflect"
+	"strings"
+
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -12,9 +16,6 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
-	"net/url"
-	"reflect"
-	"strings"
 )
 
 const OTLPDefaultEndpoint = "https://otel.highlight.io:4318"
@@ -37,23 +38,6 @@ const LogMessageAttribute = "log.message"
 const MetricEvent = "metric"
 const MetricEventName = "metric.name"
 const MetricEventValue = "metric.value"
-
-var InternalAttributePrefixes = []string{
-	DeprecatedProjectIDAttribute,
-	DeprecatedSessionIDAttribute,
-	DeprecatedRequestIDAttribute,
-	DeprecatedSourceAttribute,
-	ProjectIDAttribute,
-	SessionIDAttribute,
-	RequestIDAttribute,
-	SourceAttribute,
-	LogMessageAttribute,
-	LogSeverityAttribute,
-	// exception should be parsed as structured and not included as part of log attributes
-	"exception.message",
-	"exception.stacktrace",
-	"fluent.",
-}
 
 var BackendOnlyAttributePrefixes = []string{
 	"container.",


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

A regression was introduced in #6053 whereby backend errors were missing their stacktraces. This was due to the fact that we weren't plucking the data out ahead of time in the `extractFields` function.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Verified stacktrace (and other error data) is populated:
![Screenshot 2023-07-26 at 12 53 15 PM](https://github.com/highlight/highlight/assets/58678/5677e04c-8b52-4a0f-bf43-aa8dd2fed1ac)

Verified we have a stacktrace with a new error in the UI:
![Screenshot 2023-07-26 at 12 55 26 PM](https://github.com/highlight/highlight/assets/58678/50e288f1-0bba-4e8a-a51c-dd7e45dc32e8)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
