### PR TITLE
improve kafka rebalance performance

### DIFF
--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -71,7 +71,7 @@ func (k *KafkaWorker) ProcessMessages(ctx context.Context) {
 	}
 }
 
-const BatchFlushSize = 512
+const BatchFlushSize = 1024
 const BatchedFlushTimeout = 1 * time.Second
 
 type KafkaWorker struct {


### PR DESCRIPTION
## Summary

With a lot of consumers, kafka gets into a rebalance loop where it takes longer to rebalance 
consumers than the rebalance timeout. As a result, no consumers can do work while the topic is rebalancing.
<img width="430" alt="Screenshot 2023-07-26 at 11 37 57 AM" src="https://github.com/highlight/highlight/assets/1351531/3cc0dbda-dfa0-45b7-b5d4-a907d19bc523">
This value could be set higher, but it also means that when we scale consumers, we have a window
where no messages are processed. 30s seems like a reasonable time for that.

On the producer, not sure what the `ReadTimeout` means, but this may help with preventing
connection errors when we have high broker load.

## How did you test this change?

N/A

## Are there any deployment considerations?

Will monitor release.