### PR TITLE
fix semantic service name key for firehose logs

### DIFF
--- a/backend/http/logging.go
+++ b/backend/http/logging.go
@@ -166,11 +166,11 @@ func HandleFirehoseLog(w http.ResponseWriter, r *http.Request) {
 					Timestamp: time.UnixMilli(event.Timestamp).UTC().Format(hlog.TimestampFormat),
 					Level:     "info",
 					Attributes: map[string]string{
-						"service_name": "firehose",
-						"message_type": cloudwatchPayload.MessageType,
-						"owner":        cloudwatchPayload.Owner,
-						"log_group":    cloudwatchPayload.LogGroup,
-						"log_stream":   cloudwatchPayload.LogStream,
+						string(semconv.ServiceNameKey): "firehose",
+						"message_type":                 cloudwatchPayload.MessageType,
+						"owner":                        cloudwatchPayload.Owner,
+						"log_group":                    cloudwatchPayload.LogGroup,
+						"log_stream":                   cloudwatchPayload.LogStream,
 					},
 				}
 				if err := hlog.SubmitHTTPLog(r.Context(), projectID, hl); err != nil {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Firehose logs are not using the OTEL semantic key. As a result, we get an extra `service_name` when fetching keys because one is the "reserved key" (which needs to be renamed #6098) and one is from `LogAttributes`:

![Screenshot 2023-07-26 at 1 34 37 PM](https://github.com/highlight/highlight/assets/58678/4cbd951e-834e-4403-94c2-8d99f1d07759)

![Screenshot 2023-07-26 at 1 35 43 PM](https://github.com/highlight/highlight/assets/58678/ebc0e2a9-b08a-43eb-9ea5-610b7bb6db2b)

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Should be extracted out per the work in #6053

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A