### PR TITLE
skip health check kafka messages

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -105,12 +105,12 @@ func healthRouter(runtimeFlag util.Runtime, db *gorm.DB, tdb timeseries.DB, rCli
 	batchedTopic := kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Batched: true})
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		if err := queue.Submit(ctx, &kafkaqueue.Message{Type: kafkaqueue.HealthCheck}, "health"); err != nil {
+		if err := queue.Submit(ctx, &kafkaqueue.Message{Type: kafkaqueue.HealthCheck}, ""); err != nil {
 			log.WithContext(ctx).Error(fmt.Sprintf("failed kafka health check: %s", err))
 			http.Error(w, fmt.Sprintf("failed to write message to kafka %s", topic), 500)
 			return
 		}
-		if err := batchedQueue.Submit(ctx, &kafkaqueue.Message{Type: kafkaqueue.HealthCheck}, "health"); err != nil {
+		if err := batchedQueue.Submit(ctx, &kafkaqueue.Message{Type: kafkaqueue.HealthCheck}, ""); err != nil {
 			log.WithContext(ctx).Error(fmt.Sprintf("failed kafka batched health check: %s", err))
 			http.Error(w, fmt.Sprintf("failed to write message to kafka %s", batchedTopic), 500)
 			return

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -15,7 +15,6 @@ import (
 	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 
 	"github.com/go-chi/chi"
-	"github.com/google/uuid"
 	"github.com/highlight-run/highlight/backend/clickhouse"
 	kafkaqueue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/public-graph/graph"
@@ -266,7 +265,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 			PushBackendPayload: &kafkaqueue.PushBackendPayloadArgs{
 				ProjectVerboseID: &projectID,
 				Errors:           errors,
-			}}, uuid.New().String())
+			}}, "")
 		if err != nil {
 			log.WithContext(ctx).WithError(err).Error("failed to submit otel project errors to public worker queue")
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -280,7 +279,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 			PushMetrics: &kafkaqueue.PushMetricsArgs{
 				SessionSecureID: sessionID,
 				Metrics:         metrics,
-			}}, uuid.New().String())
+			}}, "")
 		if err != nil {
 			log.WithContext(ctx).WithError(err).Error("failed to submit otel project metrics to public worker queue")
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -389,7 +388,7 @@ func (o *Handler) submitProjectLogs(ctx context.Context, projectLogs map[string]
 			Type: kafkaqueue.PushLogs,
 			PushLogs: &kafkaqueue.PushLogsArgs{
 				LogRows: logRows,
-			}}, uuid.New().String())
+			}}, "")
 		if err != nil {
 			return e.Wrap(err, "failed to submit otel project logs to public worker queue")
 		}

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -46,6 +46,8 @@ func (k *KafkaWorker) ProcessMessages(ctx context.Context) {
 
 			if task == nil {
 				return
+			} else if task.Type == kafkaqueue.HealthCheck {
+				return
 			}
 			s.SetTag("taskType", task.Type)
 			s.SetTag("partition", task.KafkaMessage.Partition)
@@ -263,6 +265,8 @@ func (k *KafkaBatchWorker) ProcessMessages(ctx context.Context) {
 			task := k.KafkaQueue.Receive(ctx)
 			s1.Finish()
 			if task == nil {
+				return
+			} else if task.Type == kafkaqueue.HealthCheck {
 				return
 			}
 

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -73,7 +73,8 @@ func (k *KafkaWorker) ProcessMessages(ctx context.Context) {
 	}
 }
 
-const BatchFlushSize = 1024
+// BatchFlushSize set per https://clickhouse.com/docs/en/cloud/bestpractices/bulk-inserts
+const BatchFlushSize = 8192
 const BatchedFlushTimeout = 1 * time.Second
 
 type KafkaWorker struct {


### PR DESCRIPTION
## Summary

batched queue is behind in just one partition

<img width="1619" alt="Screenshot 2023-07-26 at 12 53 52 PM" src="https://github.com/highlight/highlight/assets/1351531/42e39d9b-b815-4373-a5f7-af3a7c8b253f">

<img width="1510" alt="Screenshot 2023-07-26 at 12 53 13 PM" src="https://github.com/highlight/highlight/assets/1351531/87c9accb-6485-4f12-a4a4-ccb1cb1ee230">

seems like a bunch of health messages are queued up and potentially not getting processed.

this change also consolidates the default random partition key logic (calling `.Submit()` with partition key `""` will generate one).

## How did you test this change?

Local backend deploy.

## Are there any deployment considerations?

No