### PR TITLE
improve monorepo build time

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -64,6 +64,8 @@ jobs:
             - name: Install Doppler CLI
               uses: dopplerhq/cli-action@v2
 
+            # avoid setting REACT_APP_COMMIT_SHA in CI to allow turborepo caching
+
             - name: Build & test (with render environment)
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
               run: doppler run -- bash -c 'RENDER_PREVIEW=false yarn test:all'
@@ -71,7 +73,6 @@ jobs:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
                   GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
-                  REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
             - name: Build & test (in a fork without doppler)
               if: github.event.pull_request.head.repo.full_name != 'highlight/highlight' && github.ref != 'refs/heads/main'
@@ -79,7 +80,6 @@ jobs:
               env:
                   GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
-                  REACT_APP_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
             - name: Test session screenshot lambda
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -64,7 +64,7 @@ jobs:
             - name: Install Doppler CLI
               uses: dopplerhq/cli-action@v2
 
-            # avoid setting REACT_APP_COMMIT_SHA in CI to allow turborepo caching
+            # setting REACT_APP_COMMIT_SHA to a dummy value in CI to allow consistent turborepo remote caching
 
             - name: Build & test (with render environment)
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
@@ -73,6 +73,7 @@ jobs:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_RENDER_SECRET }}
                   GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
+                  REACT_APP_COMMIT_SHA: abcdef1234567890a1b2c3d4e5f6fedcba098765
 
             - name: Build & test (in a fork without doppler)
               if: github.event.pull_request.head.repo.full_name != 'highlight/highlight' && github.ref != 'refs/heads/main'
@@ -80,6 +81,7 @@ jobs:
               env:
                   GRAPHCMS_TOKEN: ${{ secrets.GRAPHCMS_TOKEN }}
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
+                  REACT_APP_COMMIT_SHA: abcdef1234567890a1b2c3d4e5f6fedcba098765
 
             - name: Test session screenshot lambda
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

Allow `turborepo` to cache more of the `monorepo` job by setting the `REACT_APP_COMMIT_SHA`
to a dummy value which does not affect the CI build anyway. Setting it to a dummy value allows
the sourcemap to stay correct wrt. the line/col numbers.

## How did you test this change?

CI

## Are there any deployment considerations?

No.