### PR TITLE
Add pagination and query to services

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -890,7 +890,7 @@ type ComplexityRoot struct {
 		Resources                    func(childComplexity int, sessionSecureID string) int
 		Segments                     func(childComplexity int, projectID int) int
 		ServerIntegration            func(childComplexity int, projectID int) int
-		Services                     func(childComplexity int, projectID int) int
+		Services                     func(childComplexity int, projectID int, after *string, before *string, query *string) int
 		Session                      func(childComplexity int, secureID string) int
 		SessionCommentTagsForProject func(childComplexity int, projectID int) int
 		SessionComments              func(childComplexity int, sessionSecureID string) int
@@ -996,6 +996,24 @@ type ComplexityRoot struct {
 	}
 
 	Service struct {
+		GithubRepoPath func(childComplexity int) int
+		ID             func(childComplexity int) int
+		Name           func(childComplexity int) int
+		ProjectID      func(childComplexity int) int
+		Status         func(childComplexity int) int
+	}
+
+	ServiceConnection struct {
+		Edges    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
+	}
+
+	ServiceEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
+	}
+
+	ServiceNode struct {
 		GithubRepoPath func(childComplexity int) int
 		ID             func(childComplexity int) int
 		Name           func(childComplexity int) int
@@ -1562,7 +1580,7 @@ type QueryResolver interface {
 	ErrorResolutionSuggestion(ctx context.Context, errorObjectID int) (string, error)
 	SessionInsight(ctx context.Context, secureID string) (*model.SessionInsight, error)
 	SystemConfiguration(ctx context.Context) (*model1.SystemConfiguration, error)
-	Services(ctx context.Context, projectID int) ([]*model1.Service, error)
+	Services(ctx context.Context, projectID int, after *string, before *string, query *string) (*model.ServiceConnection, error)
 }
 type SegmentResolver interface {
 	Params(ctx context.Context, obj *model1.Segment) (*model1.SearchParams, error)
@@ -6639,7 +6657,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Services(childComplexity, args["project_id"].(int)), true
+		return e.complexity.Query.Services(childComplexity, args["project_id"].(int), args["after"].(*string), args["before"].(*string), args["query"].(*string)), true
 
 	case "Query.session":
 		if e.complexity.Query.Session == nil {
@@ -7381,6 +7399,69 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Service.Status(childComplexity), true
+
+	case "ServiceConnection.edges":
+		if e.complexity.ServiceConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.ServiceConnection.Edges(childComplexity), true
+
+	case "ServiceConnection.pageInfo":
+		if e.complexity.ServiceConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.ServiceConnection.PageInfo(childComplexity), true
+
+	case "ServiceEdge.cursor":
+		if e.complexity.ServiceEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.ServiceEdge.Cursor(childComplexity), true
+
+	case "ServiceEdge.node":
+		if e.complexity.ServiceEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.ServiceEdge.Node(childComplexity), true
+
+	case "ServiceNode.githubRepoPath":
+		if e.complexity.ServiceNode.GithubRepoPath == nil {
+			break
+		}
+
+		return e.complexity.ServiceNode.GithubRepoPath(childComplexity), true
+
+	case "ServiceNode.id":
+		if e.complexity.ServiceNode.ID == nil {
+			break
+		}
+
+		return e.complexity.ServiceNode.ID(childComplexity), true
+
+	case "ServiceNode.name":
+		if e.complexity.ServiceNode.Name == nil {
+			break
+		}
+
+		return e.complexity.ServiceNode.Name(childComplexity), true
+
+	case "ServiceNode.projectID":
+		if e.complexity.ServiceNode.ProjectID == nil {
+			break
+		}
+
+		return e.complexity.ServiceNode.ProjectID(childComplexity), true
+
+	case "ServiceNode.status":
+		if e.complexity.ServiceNode.Status == nil {
+			break
+		}
+
+		return e.complexity.ServiceNode.Status(childComplexity), true
 
 	case "Session.active_length":
 		if e.complexity.Session.ActiveLength == nil {
@@ -9549,6 +9630,24 @@ type Service {
 	githubRepoPath: String
 }
 
+type ServiceNode {
+	id: ID!
+	projectID: ID!
+	name: String!
+	status: ServiceStatus!
+	githubRepoPath: String
+}
+
+type ServiceEdge implements Edge {
+	cursor: String!
+	node: ServiceNode!
+}
+
+type ServiceConnection implements Connection {
+	edges: [ServiceEdge]!
+	pageInfo: PageInfo!
+}
+
 enum ReservedLogKey {
 	"""
 	Keep this in alpha order
@@ -10612,7 +10711,12 @@ type Query {
 	error_resolution_suggestion(error_object_id: ID!): String!
 	session_insight(secure_id: String!): SessionInsight
 	system_configuration: SystemConfiguration!
-	services(project_id: ID!): [Service!]!
+	services(
+		project_id: ID!
+		after: String
+		before: String
+		query: String
+	): ServiceConnection
 }
 
 type Mutation {
@@ -16094,6 +16198,33 @@ func (ec *executionContext) field_Query_services_args(ctx context.Context, rawAr
 		}
 	}
 	args["project_id"] = arg0
+	var arg1 *string
+	if tmp, ok := rawArgs["after"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+		arg1, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["after"] = arg1
+	var arg2 *string
+	if tmp, ok := rawArgs["before"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+		arg2, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["before"] = arg2
+	var arg3 *string
+	if tmp, ok := rawArgs["query"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
+		arg3, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["query"] = arg3
 	return args, nil
 }
 
@@ -49735,20 +49866,17 @@ func (ec *executionContext) _Query_services(ctx context.Context, field graphql.C
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Services(rctx, fc.Args["project_id"].(int))
+		return ec.resolvers.Query().Services(rctx, fc.Args["project_id"].(int), fc.Args["after"].(*string), fc.Args["before"].(*string), fc.Args["query"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model1.Service)
+	res := resTmp.(*model.ServiceConnection)
 	fc.Result = res
-	return ec.marshalNService2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐServiceᚄ(ctx, field.Selections, res)
+	return ec.marshalOServiceConnection2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_services(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -49759,18 +49887,12 @@ func (ec *executionContext) fieldContext_Query_services(ctx context.Context, fie
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "id":
-				return ec.fieldContext_Service_id(ctx, field)
-			case "projectID":
-				return ec.fieldContext_Service_projectID(ctx, field)
-			case "name":
-				return ec.fieldContext_Service_name(ctx, field)
-			case "status":
-				return ec.fieldContext_Service_status(ctx, field)
-			case "githubRepoPath":
-				return ec.fieldContext_Service_githubRepoPath(ctx, field)
+			case "edges":
+				return ec.fieldContext_ServiceConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_ServiceConnection_pageInfo(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type Service", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type ServiceConnection", field.Name)
 		},
 	}
 	defer func() {
@@ -51982,6 +52104,427 @@ func (ec *executionContext) _Service_githubRepoPath(ctx context.Context, field g
 func (ec *executionContext) fieldContext_Service_githubRepoPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Service",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.ServiceConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.ServiceEdge)
+	fc.Result = res
+	return ec.marshalNServiceEdge2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceConnection_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cursor":
+				return ec.fieldContext_ServiceEdge_cursor(ctx, field)
+			case "node":
+				return ec.fieldContext_ServiceEdge_node(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ServiceEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.ServiceConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.ServiceEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceEdge_cursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.ServiceEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.ServiceNode)
+	fc.Result = res
+	return ec.marshalNServiceNode2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceNode(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceEdge_node(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ServiceNode_id(ctx, field)
+			case "projectID":
+				return ec.fieldContext_ServiceNode_projectID(ctx, field)
+			case "name":
+				return ec.fieldContext_ServiceNode_name(ctx, field)
+			case "status":
+				return ec.fieldContext_ServiceNode_status(ctx, field)
+			case "githubRepoPath":
+				return ec.fieldContext_ServiceNode_githubRepoPath(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ServiceNode", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceNode_id(ctx context.Context, field graphql.CollectedField, obj *model.ServiceNode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceNode_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNID2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceNode_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceNode",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceNode_projectID(ctx context.Context, field graphql.CollectedField, obj *model.ServiceNode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceNode_projectID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ProjectID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNID2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceNode_projectID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceNode",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceNode_name(ctx context.Context, field graphql.CollectedField, obj *model.ServiceNode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceNode_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceNode_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceNode",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceNode_status(ctx context.Context, field graphql.CollectedField, obj *model.ServiceNode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceNode_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.ServiceStatus)
+	fc.Result = res
+	return ec.marshalNServiceStatus2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceNode_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceNode",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ServiceStatus does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceNode_githubRepoPath(ctx context.Context, field graphql.CollectedField, obj *model.ServiceNode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceNode_githubRepoPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GithubRepoPath, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceNode_githubRepoPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceNode",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -64357,6 +64900,13 @@ func (ec *executionContext) _Connection(ctx context.Context, sel ast.SelectionSe
 			return graphql.Null
 		}
 		return ec._ErrorObjectConnection(ctx, sel, obj)
+	case model.ServiceConnection:
+		return ec._ServiceConnection(ctx, sel, &obj)
+	case *model.ServiceConnection:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ServiceConnection(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -64380,6 +64930,13 @@ func (ec *executionContext) _Edge(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._ErrorObjectEdge(ctx, sel, obj)
+	case model.ServiceEdge:
+		return ec._ServiceEdge(ctx, sel, &obj)
+	case *model.ServiceEdge:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ServiceEdge(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -72580,6 +73137,129 @@ func (ec *executionContext) _Service(ctx context.Context, sel ast.SelectionSet, 
 	return out
 }
 
+var serviceConnectionImplementors = []string{"ServiceConnection", "Connection"}
+
+func (ec *executionContext) _ServiceConnection(ctx context.Context, sel ast.SelectionSet, obj *model.ServiceConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, serviceConnectionImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ServiceConnection")
+		case "edges":
+
+			out.Values[i] = ec._ServiceConnection_edges(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "pageInfo":
+
+			out.Values[i] = ec._ServiceConnection_pageInfo(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var serviceEdgeImplementors = []string{"ServiceEdge", "Edge"}
+
+func (ec *executionContext) _ServiceEdge(ctx context.Context, sel ast.SelectionSet, obj *model.ServiceEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, serviceEdgeImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ServiceEdge")
+		case "cursor":
+
+			out.Values[i] = ec._ServiceEdge_cursor(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "node":
+
+			out.Values[i] = ec._ServiceEdge_node(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var serviceNodeImplementors = []string{"ServiceNode"}
+
+func (ec *executionContext) _ServiceNode(ctx context.Context, sel ast.SelectionSet, obj *model.ServiceNode) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, serviceNodeImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ServiceNode")
+		case "id":
+
+			out.Values[i] = ec._ServiceNode_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "projectID":
+
+			out.Values[i] = ec._ServiceNode_projectID(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "name":
+
+			out.Values[i] = ec._ServiceNode_name(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "status":
+
+			out.Values[i] = ec._ServiceNode_status(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "githubRepoPath":
+
+			out.Values[i] = ec._ServiceNode_githubRepoPath(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var sessionImplementors = []string{"Session"}
 
 func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, obj *model1.Session) graphql.Marshaler {
@@ -78312,7 +78992,7 @@ func (ec *executionContext) unmarshalNSearchParamsInput2githubᚗcomᚋhighlight
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNService2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐServiceᚄ(ctx context.Context, sel ast.SelectionSet, v []*model1.Service) graphql.Marshaler {
+func (ec *executionContext) marshalNServiceEdge2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceEdge(ctx context.Context, sel ast.SelectionSet, v []*model.ServiceEdge) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -78336,7 +79016,7 @@ func (ec *executionContext) marshalNService2ᚕᚖgithubᚗcomᚋhighlightᚑrun
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNService2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐService(ctx, sel, v[i])
+			ret[i] = ec.marshalOServiceEdge2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceEdge(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -78347,23 +79027,17 @@ func (ec *executionContext) marshalNService2ᚕᚖgithubᚗcomᚋhighlightᚑrun
 	}
 	wg.Wait()
 
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
 	return ret
 }
 
-func (ec *executionContext) marshalNService2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐService(ctx context.Context, sel ast.SelectionSet, v *model1.Service) graphql.Marshaler {
+func (ec *executionContext) marshalNServiceNode2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceNode(ctx context.Context, sel ast.SelectionSet, v *model.ServiceNode) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
 		}
 		return graphql.Null
 	}
-	return ec._Service(ctx, sel, v)
+	return ec._ServiceNode(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNServiceStatus2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceStatus(ctx context.Context, v interface{}) (model.ServiceStatus, error) {
@@ -80924,6 +81598,20 @@ func (ec *executionContext) marshalOService2ᚖgithubᚗcomᚋhighlightᚑrunᚋ
 		return graphql.Null
 	}
 	return ec._Service(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOServiceConnection2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceConnection(ctx context.Context, sel ast.SelectionSet, v *model.ServiceConnection) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ServiceConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOServiceEdge2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐServiceEdge(ctx context.Context, sel ast.SelectionSet, v *model.ServiceEdge) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ServiceEdge(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOSession2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSession(ctx context.Context, sel ast.SelectionSet, v *model1.Session) graphql.Marshaler {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -615,6 +615,30 @@ type SearchParamsInput struct {
 	Query                   *string              `json:"query"`
 }
 
+type ServiceConnection struct {
+	Edges    []*ServiceEdge `json:"edges"`
+	PageInfo *PageInfo      `json:"pageInfo"`
+}
+
+func (ServiceConnection) IsConnection()               {}
+func (this ServiceConnection) GetPageInfo() *PageInfo { return this.PageInfo }
+
+type ServiceEdge struct {
+	Cursor string       `json:"cursor"`
+	Node   *ServiceNode `json:"node"`
+}
+
+func (ServiceEdge) IsEdge()                {}
+func (this ServiceEdge) GetCursor() string { return this.Cursor }
+
+type ServiceNode struct {
+	ID             int           `json:"id"`
+	ProjectID      int           `json:"projectID"`
+	Name           string        `json:"name"`
+	Status         ServiceStatus `json:"status"`
+	GithubRepoPath *string       `json:"githubRepoPath"`
+}
+
 type SessionAlertInput struct {
 	ProjectID           int                           `json:"project_id"`
 	Name                string                        `json:"name"`

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -661,6 +661,24 @@ type Service {
 	githubRepoPath: String
 }
 
+type ServiceNode {
+	id: ID!
+	projectID: ID!
+	name: String!
+	status: ServiceStatus!
+	githubRepoPath: String
+}
+
+type ServiceEdge implements Edge {
+	cursor: String!
+	node: ServiceNode!
+}
+
+type ServiceConnection implements Connection {
+	edges: [ServiceEdge]!
+	pageInfo: PageInfo!
+}
+
 enum ReservedLogKey {
 	"""
 	Keep this in alpha order
@@ -1724,7 +1742,12 @@ type Query {
 	error_resolution_suggestion(error_object_id: ID!): String!
 	session_insight(secure_id: String!): SessionInsight
 	system_configuration: SystemConfiguration!
-	services(project_id: ID!): [Service!]!
+	services(
+		project_id: ID!
+		after: String
+		before: String
+		query: String
+	): ServiceConnection
 }
 
 type Mutation {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7512,7 +7512,7 @@ func (r *queryResolver) SystemConfiguration(ctx context.Context) (*model.SystemC
 }
 
 // Services is the resolver for the services field.
-func (r *queryResolver) Services(ctx context.Context, projectID int) ([]*model.Service, error) {
+func (r *queryResolver) Services(ctx context.Context, projectID int, after *string, before *string, query *string) (*modelInputs.ServiceConnection, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
 		return nil, err
@@ -7523,7 +7523,13 @@ func (r *queryResolver) Services(ctx context.Context, projectID int) ([]*model.S
 		return nil, err
 	}
 
-	return services, nil
+	connection, err := r.Store.ListServices(*project, store.ListServicesParams{
+		After:  after,
+		Before: before,
+		Query:  query,
+	})
+
+	return &connection, err
 }
 
 // Params is the resolver for the params field.

--- a/backend/store/services.go
+++ b/backend/store/services.go
@@ -1,7 +1,13 @@
 package store
 
 import (
+	"sort"
+	"strconv"
+
 	"github.com/highlight-run/highlight/backend/model"
+	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/highlight-run/highlight/backend/queryparser"
+	"github.com/samber/lo"
 )
 
 func (store *Store) FindOrCreateService(project model.Project, name string) (model.Service, error) {
@@ -13,4 +19,118 @@ func (store *Store) FindOrCreateService(project model.Project, name string) (mod
 	}).FirstOrCreate(&service).Error
 
 	return service, err
+}
+
+// Number of results per page
+const SERVICE_LIMIT = 2
+
+type ListServicesParams struct {
+	After  *string
+	Before *string
+	Query  *string
+}
+
+func (store *Store) ListServices(project model.Project, params ListServicesParams) (privateModel.ServiceConnection, error) {
+
+	var services []model.Service
+
+	query := store.db.Where(&model.Service{ProjectID: project.ID}).Limit(SERVICE_LIMIT + 1)
+
+	if params.Query != nil {
+		filters := queryparser.Parse(*params.Query)
+
+		if len(filters.Body) > 0 && filters.Body[0] != "" {
+			query.Where("services.name ILIKE ?", "%"+filters.Body[0]+"%")
+		}
+	}
+
+	var (
+		endCursor       string
+		startCursor     string
+		hasNextPage     bool
+		hasPreviousPage bool
+	)
+
+	if params.After != nil {
+		query = query.Order("services.id DESC").Where("services.id < ?", *params.After)
+	} else if params.Before != nil {
+		query = query.Order("services.id ASC").Where("services.id > ?", *params.Before)
+	} else {
+		query = query.Order("services.id DESC")
+	}
+
+	if err := query.Find(&services).Error; err != nil {
+		return privateModel.ServiceConnection{
+			Edges:    []*privateModel.ServiceEdge{},
+			PageInfo: &privateModel.PageInfo{},
+		}, err
+	}
+
+	if params.Before != nil {
+		// Reverse the slice to maintain a descending order view
+		sort.Slice(services, func(i, j int) bool {
+			return services[i].ID < services[j].ID
+		})
+	}
+
+	if len(services) == 0 {
+		return privateModel.ServiceConnection{
+			Edges:    []*privateModel.ServiceEdge{},
+			PageInfo: &privateModel.PageInfo{},
+		}, nil
+	}
+
+	edges := []*privateModel.ServiceEdge{}
+
+	for _, service := range services {
+		edge := &privateModel.ServiceEdge{
+			Cursor: strconv.Itoa(service.ID),
+			Node: &privateModel.ServiceNode{
+				ID:             service.ID,
+				ProjectID:      service.ProjectID,
+				Name:           service.Name,
+				Status:         service.Status,
+				GithubRepoPath: service.GithubRepoPath,
+			},
+		}
+
+		edges = append(edges, edge)
+	}
+
+	if params.After != nil {
+		hasPreviousPage = true // Assume we have a previous page if `after` is provided
+
+		if len(edges) == SERVICE_LIMIT+1 {
+			edges = edges[:SERVICE_LIMIT]
+			hasNextPage = true
+		}
+	} else if params.Before != nil {
+		hasNextPage = true // Assume we have a next page if `before` is provided
+
+		if len(edges) == SERVICE_LIMIT+1 {
+			edges = edges[:SERVICE_LIMIT]
+			hasPreviousPage = true
+		}
+
+		edges = lo.Reverse(edges)
+	} else {
+		if len(edges) > SERVICE_LIMIT {
+			edges = edges[:SERVICE_LIMIT]
+			hasNextPage = true
+		}
+	}
+
+	startCursor = edges[0].Cursor
+	endCursor = edges[len(edges)-1].Cursor
+
+	return privateModel.ServiceConnection{
+		Edges: edges,
+		PageInfo: &privateModel.PageInfo{
+			HasNextPage:     hasNextPage,
+			HasPreviousPage: hasPreviousPage,
+			StartCursor:     startCursor,
+			EndCursor:       endCursor,
+		},
+	}, nil
+
 }

--- a/backend/store/services.go
+++ b/backend/store/services.go
@@ -22,7 +22,7 @@ func (store *Store) FindOrCreateService(project model.Project, name string) (mod
 }
 
 // Number of results per page
-const SERVICE_LIMIT = 2
+const SERVICE_LIMIT = 10
 
 type ListServicesParams struct {
 	After  *string

--- a/backend/store/services_test.go
+++ b/backend/store/services_test.go
@@ -98,7 +98,7 @@ func TestListServicesTraversing(t *testing.T) {
 		}, connection.PageInfo)
 
 		// Go back to second page using `Before` cursor
-		connection, err = store.ListServices(project, ListServicesParams{Before: ptr.String("1")})
+		connection, err = store.ListServices(project, ListServicesParams{Before: ptr.String(servicesIds[0])})
 		assert.NoError(t, err)
 
 		assert.Len(t, connection.Edges, 10)

--- a/backend/store/services_test.go
+++ b/backend/store/services_test.go
@@ -1,10 +1,15 @@
 package store
 
 import (
+	"fmt"
+	"strconv"
 	"testing"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/model"
+	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,5 +26,108 @@ func TestFindOrCreateService(t *testing.T) {
 		foundService, err := store.FindOrCreateService(project, "public-graph")
 		assert.NoError(t, err)
 		assert.Equal(t, service.ID, foundService.ID)
+	})
+}
+
+func TestListServicesTraversing(t *testing.T) {
+	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
+		project := model.Project{}
+		store.db.Create(&project)
+
+		// Create three pages
+		// The first page has 10 items (hasPreviousPage = false, hasNextPage = true)
+		// The second page has 10 items (hasPreviousPage = true, hasNextPage = true)
+		// The last page has 1 item (hasPreviousPage = true, hasNextPage = false)
+		var servicesIds []string
+		for i := 0; i <= 20; i++ {
+			newService := model.Service{
+				Name:      fmt.Sprintf("Service-%d", i),
+				ProjectID: project.ID,
+				Status:    "healthy",
+			}
+			store.db.Create(&newService)
+			servicesIds = append(servicesIds, strconv.Itoa(newService.ID))
+		}
+
+		// Get first page
+		connection, err := store.ListServices(project, ListServicesParams{})
+		assert.NoError(t, err)
+
+		assert.Len(t, connection.Edges, 10)
+		cursors := lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+			return edge.Cursor
+		})
+		assert.Equal(t, []string{servicesIds[20], servicesIds[19], servicesIds[18], servicesIds[17], servicesIds[16], servicesIds[15], servicesIds[14], servicesIds[13], servicesIds[12], servicesIds[11]}, cursors)
+		assert.Equal(t, &privateModel.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: false,
+			StartCursor:     "21",
+			EndCursor:       "12",
+		}, connection.PageInfo)
+
+		// Get second page using `After` cursor
+		connection, err = store.ListServices(project, ListServicesParams{After: ptr.String(servicesIds[11])})
+		assert.NoError(t, err)
+
+		assert.Len(t, connection.Edges, 10)
+		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+			return edge.Cursor
+		})
+		assert.Equal(t, []string{servicesIds[10], servicesIds[9], servicesIds[8], servicesIds[7], servicesIds[6], servicesIds[5], servicesIds[4], servicesIds[3], servicesIds[2], servicesIds[1]}, cursors)
+		assert.Equal(t, &privateModel.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: true,
+			StartCursor:     servicesIds[10],
+			EndCursor:       servicesIds[1],
+		}, connection.PageInfo)
+
+		// Get last page using `After` cursor
+		connection, err = store.ListServices(project, ListServicesParams{After: ptr.String(servicesIds[1])})
+		assert.NoError(t, err)
+
+		assert.Len(t, connection.Edges, 1)
+		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+			return edge.Cursor
+		})
+		assert.Equal(t, []string{servicesIds[0]}, cursors)
+		assert.Equal(t, &privateModel.PageInfo{
+			HasNextPage:     false,
+			HasPreviousPage: true,
+			StartCursor:     servicesIds[0],
+			EndCursor:       servicesIds[0],
+		}, connection.PageInfo)
+
+		// Go back to second page using `Before` cursor
+		connection, err = store.ListServices(project, ListServicesParams{Before: ptr.String("1")})
+		assert.NoError(t, err)
+
+		assert.Len(t, connection.Edges, 10)
+		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+			return edge.Cursor
+		})
+		assert.Equal(t, []string{servicesIds[10], servicesIds[9], servicesIds[8], servicesIds[7], servicesIds[6], servicesIds[5], servicesIds[4], servicesIds[3], servicesIds[2], servicesIds[1]}, cursors)
+		assert.Equal(t, &privateModel.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: true,
+			StartCursor:     servicesIds[10],
+			EndCursor:       servicesIds[1],
+		}, connection.PageInfo)
+
+		// Go back to first page using `Before` cursor
+		connection, err = store.ListServices(project, ListServicesParams{Before: ptr.String(servicesIds[10])})
+		assert.NoError(t, err)
+
+		assert.Len(t, connection.Edges, 10)
+		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+			return edge.Cursor
+		})
+		assert.Equal(t, []string{servicesIds[20], servicesIds[19], servicesIds[18], servicesIds[17], servicesIds[16], servicesIds[15], servicesIds[14], servicesIds[13], servicesIds[12], servicesIds[11]}, cursors)
+		assert.Equal(t, &privateModel.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: false,
+			StartCursor:     servicesIds[20],
+			EndCursor:       servicesIds[11],
+		}, connection.PageInfo)
+
 	})
 }

--- a/backend/store/services_test.go
+++ b/backend/store/services_test.go
@@ -61,8 +61,8 @@ func TestListServicesTraversing(t *testing.T) {
 		assert.Equal(t, &privateModel.PageInfo{
 			HasNextPage:     true,
 			HasPreviousPage: false,
-			StartCursor:     "21",
-			EndCursor:       "12",
+			StartCursor:     servicesIds[20],
+			EndCursor:       servicesIds[11],
 		}, connection.PageInfo)
 
 		// Get second page using `After` cursor

--- a/backend/store/sessions_test.go
+++ b/backend/store/sessions_test.go
@@ -2,14 +2,10 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
-	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/model"
-	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,104 +20,5 @@ func TestGetSession(t *testing.T) {
 		foundSession, err := store.GetSession(context.Background(), session.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, session.ID, foundSession.ID)
-	})
-}
-
-func TestListServicesTraversing(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		project := model.Project{}
-		store.db.Create(&project)
-
-		// Create three pages
-		// The first page has 10 items (hasPreviousPage = false, hasNextPage = true)
-		// The second page has 10 items (hasPreviousPage = true, hasNextPage = true)
-		// The last page has 1 item (hasPreviousPage = true, hasNextPage = false)
-		for i := 1; i <= 21; i++ {
-			store.db.Create(&model.Service{
-				Name:      fmt.Sprintf("Service-%d", i),
-				ProjectID: project.ID,
-			})
-		}
-
-		// Get first page
-		connection, err := store.ListServices(project, ListServicesParams{})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 10)
-		cursors := lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{"21", "20", "19", "18", "17", "16", "15", "14", "13", "12"}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     true,
-			HasPreviousPage: false,
-			StartCursor:     "21",
-			EndCursor:       "12",
-		}, connection.PageInfo)
-
-		// Get second page using `After` cursor
-		connection, err = store.ListServices(project, ListServicesParams{After: ptr.String("12")})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 10)
-		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{"11", "10", "9", "8", "7", "6", "5", "4", "3", "2"}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     true,
-			HasPreviousPage: true,
-			StartCursor:     "11",
-			EndCursor:       "2",
-		}, connection.PageInfo)
-
-		// Get last page using `After` cursor
-		connection, err = store.ListServices(project, ListServicesParams{After: ptr.String("2")})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 1)
-		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{"1"}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     false,
-			HasPreviousPage: true,
-			StartCursor:     "1",
-			EndCursor:       "1",
-		}, connection.PageInfo)
-
-		// Go back to second page using `Before` cursor
-		connection, err = store.ListServices(project, ListServicesParams{Before: ptr.String("1")})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 10)
-		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{"11", "10", "9", "8", "7", "6", "5", "4", "3", "2"}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     true,
-			HasPreviousPage: true,
-			StartCursor:     "11",
-			EndCursor:       "2",
-		}, connection.PageInfo)
-
-		// Go back to first page using `Before` cursor
-		connection, err = store.ListServices(project, ListServicesParams{Before: ptr.String("11")})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 10)
-		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{"21", "20", "19", "18", "17", "16", "15", "14", "13", "12"}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     true,
-			HasPreviousPage: false,
-			StartCursor:     "21",
-			EndCursor:       "12",
-		}, connection.PageInfo)
-
 	})
 }

--- a/backend/store/sessions_test.go
+++ b/backend/store/sessions_test.go
@@ -2,10 +2,14 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/model"
+	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,5 +24,104 @@ func TestGetSession(t *testing.T) {
 		foundSession, err := store.GetSession(context.Background(), session.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, session.ID, foundSession.ID)
+	})
+}
+
+func TestListServicesTraversing(t *testing.T) {
+	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
+		project := model.Project{}
+		store.db.Create(&project)
+
+		// Create three pages
+		// The first page has 10 items (hasPreviousPage = false, hasNextPage = true)
+		// The second page has 10 items (hasPreviousPage = true, hasNextPage = true)
+		// The last page has 1 item (hasPreviousPage = true, hasNextPage = false)
+		for i := 1; i <= 21; i++ {
+			store.db.Create(&model.Service{
+				Name:      fmt.Sprintf("Service-%d", i),
+				ProjectID: project.ID,
+			})
+		}
+
+		// Get first page
+		connection, err := store.ListServices(project, ListServicesParams{})
+		assert.NoError(t, err)
+
+		assert.Len(t, connection.Edges, 10)
+		cursors := lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+			return edge.Cursor
+		})
+		assert.Equal(t, []string{"21", "20", "19", "18", "17", "16", "15", "14", "13", "12"}, cursors)
+		assert.Equal(t, &privateModel.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: false,
+			StartCursor:     "21",
+			EndCursor:       "12",
+		}, connection.PageInfo)
+
+		// Get second page using `After` cursor
+		connection, err = store.ListServices(project, ListServicesParams{After: ptr.String("12")})
+		assert.NoError(t, err)
+
+		assert.Len(t, connection.Edges, 10)
+		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+			return edge.Cursor
+		})
+		assert.Equal(t, []string{"11", "10", "9", "8", "7", "6", "5", "4", "3", "2"}, cursors)
+		assert.Equal(t, &privateModel.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: true,
+			StartCursor:     "11",
+			EndCursor:       "2",
+		}, connection.PageInfo)
+
+		// Get last page using `After` cursor
+		connection, err = store.ListServices(project, ListServicesParams{After: ptr.String("2")})
+		assert.NoError(t, err)
+
+		assert.Len(t, connection.Edges, 1)
+		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+			return edge.Cursor
+		})
+		assert.Equal(t, []string{"1"}, cursors)
+		assert.Equal(t, &privateModel.PageInfo{
+			HasNextPage:     false,
+			HasPreviousPage: true,
+			StartCursor:     "1",
+			EndCursor:       "1",
+		}, connection.PageInfo)
+
+		// Go back to second page using `Before` cursor
+		connection, err = store.ListServices(project, ListServicesParams{Before: ptr.String("1")})
+		assert.NoError(t, err)
+
+		assert.Len(t, connection.Edges, 10)
+		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+			return edge.Cursor
+		})
+		assert.Equal(t, []string{"11", "10", "9", "8", "7", "6", "5", "4", "3", "2"}, cursors)
+		assert.Equal(t, &privateModel.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: true,
+			StartCursor:     "11",
+			EndCursor:       "2",
+		}, connection.PageInfo)
+
+		// Go back to first page using `Before` cursor
+		connection, err = store.ListServices(project, ListServicesParams{Before: ptr.String("11")})
+		assert.NoError(t, err)
+
+		assert.Len(t, connection.Edges, 10)
+		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+			return edge.Cursor
+		})
+		assert.Equal(t, []string{"21", "20", "19", "18", "17", "16", "15", "14", "13", "12"}, cursors)
+		assert.Equal(t, &privateModel.PageInfo{
+			HasNextPage:     true,
+			HasPreviousPage: false,
+			StartCursor:     "21",
+			EndCursor:       "12",
+		}, connection.PageInfo)
+
 	})
 }

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1729,7 +1729,7 @@ export type Query = {
 	resources?: Maybe<Array<Maybe<Scalars['Any']>>>
 	segments?: Maybe<Array<Maybe<Segment>>>
 	serverIntegration: IntegrationStatus
-	services: Array<Service>
+	services?: Maybe<ServiceConnection>
 	session?: Maybe<Session>
 	sessionLogs: Array<LogEdge>
 	session_comment_tags_for_project: Array<SessionCommentTag>
@@ -2215,7 +2215,10 @@ export type QueryServerIntegrationArgs = {
 }
 
 export type QueryServicesArgs = {
+	after?: InputMaybe<Scalars['String']>
+	before?: InputMaybe<Scalars['String']>
 	project_id: Scalars['ID']
+	query?: InputMaybe<Scalars['String']>
 }
 
 export type QuerySessionArgs = {
@@ -2485,6 +2488,27 @@ export type Segment = {
 
 export type Service = {
 	__typename?: 'Service'
+	githubRepoPath?: Maybe<Scalars['String']>
+	id: Scalars['ID']
+	name: Scalars['String']
+	projectID: Scalars['ID']
+	status: ServiceStatus
+}
+
+export type ServiceConnection = Connection & {
+	__typename?: 'ServiceConnection'
+	edges: Array<Maybe<ServiceEdge>>
+	pageInfo: PageInfo
+}
+
+export type ServiceEdge = Edge & {
+	__typename?: 'ServiceEdge'
+	cursor: Scalars['String']
+	node: ServiceNode
+}
+
+export type ServiceNode = {
+	__typename?: 'ServiceNode'
 	githubRepoPath?: Maybe<Scalars['String']>
 	id: Scalars['ID']
 	name: Scalars['String']


### PR DESCRIPTION
## Summary
We want to add pagination to services now instead of needing to come back later and add it

## How did you test this change?
1) Create a services via PSQL
2) Update the `SERVICE_LIMIT` to a number less than the number of services you created (or create more than 10)
3) Open postman to hit the `services` query
4) Hit the query with no additional parameters
5) Use the `endCursor` value in the `after` param
6) Use the `startCursor` value in the `before` param
7) Test with a `query` param

https://www.loom.com/share/bbf5a62c3f744a4fad5a0dcaefec8b14?sid=5e7e0cd1-e76c-4f6e-a1ba-fcbb957fb01a

## Are there any deployment considerations?
N/A
