### PR TITLE
fix panic when extracting metric value

### DIFF
--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -144,10 +144,19 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 	}
 
 	if val, ok := attrs[highlight.MetricEventValue]; ok {
-		castedValue, ok := val.(float64)
+		float64Value, ok := val.(float64)
 		if ok {
-			fields.metricEventValue = castedValue
+			fields.metricEventValue = float64Value
 			delete(attrs, highlight.MetricEventValue)
+		} else {
+			stringValue, ok := val.(string)
+			if ok {
+				parsedFloat64Value, err := strconv.ParseFloat(stringValue, 64)
+				if err == nil {
+					fields.metricEventValue = parsedFloat64Value
+					delete(attrs, highlight.MetricEventValue)
+				}
+			}
 		}
 	}
 

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -144,8 +144,11 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 	}
 
 	if val, ok := attrs[highlight.MetricEventValue]; ok {
-		fields.metricEventValue = val.(float64)
-		delete(attrs, highlight.MetricEventValue)
+		castedValue, ok := val.(float64)
+		if ok {
+			fields.metricEventValue = castedValue
+			delete(attrs, highlight.MetricEventValue)
+		}
 	}
 
 	if val, ok := eventAttributes[string(semconv.ExceptionTypeKey)]; ok { // we know that exception.type will be in the event attributes map

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -38,7 +38,7 @@ type extractedFields struct {
 	errorUrl            string
 
 	metricEventName  string
-	metricEventValue string // up to the consumer to parse this into an expected format
+	metricEventValue float64
 
 	// This represents the merged result of resource, span...log attributes
 	// _after_ we extract fields out. In other words, if `serviceName` is extracted, it won't be included
@@ -144,7 +144,7 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 	}
 
 	if val, ok := attrs[highlight.MetricEventValue]; ok {
-		fields.metricEventValue = val.(string)
+		fields.metricEventValue = val.(float64)
 		delete(attrs, highlight.MetricEventValue)
 	}
 

--- a/backend/otel/extract_test.go
+++ b/backend/otel/extract_test.go
@@ -12,7 +12,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 )
 
-func newResource(attrs map[string]string) pcommon.Resource {
+func newResource(t *testing.T, attrs map[string]any) pcommon.Resource {
 	resource := pcommon.NewResource()
 
 	containsProjectID := false
@@ -30,7 +30,17 @@ func newResource(attrs map[string]string) pcommon.Resource {
 	}
 
 	for k, v := range attrs {
-		resource.Attributes().PutStr(k, v)
+		c, ok := v.(string)
+		if ok {
+			resource.Attributes().PutStr(k, c)
+		} else {
+			c, ok := v.(float64)
+			if ok {
+				resource.Attributes().PutDouble(k, c)
+			} else {
+				assert.Fail(t, "Failed to set resource value.")
+			}
+		}
 	}
 	return resource
 }
@@ -44,7 +54,7 @@ func newEvent(attrs map[string]string) ptrace.SpanEvent {
 }
 
 func TestExtractFields_ExtractProjectID(t *testing.T) {
-	resource := newResource(map[string]string{
+	resource := newResource(t, map[string]any{
 		highlight.DeprecatedProjectIDAttribute: "1",
 	})
 	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
@@ -52,7 +62,7 @@ func TestExtractFields_ExtractProjectID(t *testing.T) {
 	assert.Equal(t, fields.projectID, "1")
 	assert.Equal(t, fields.attrs, map[string]string{})
 
-	resource = newResource(map[string]string{
+	resource = newResource(t, map[string]any{
 		highlight.ProjectIDAttribute: "1",
 	})
 	fields, err = extractFields(context.TODO(), extractFieldsParams{resource: &resource})
@@ -69,7 +79,7 @@ func TestExtractFields_ExtractProjectID(t *testing.T) {
 }
 
 func TestExtractFields_ExtractSessionID(t *testing.T) {
-	resource := newResource(map[string]string{
+	resource := newResource(t, map[string]any{
 		highlight.DeprecatedSessionIDAttribute: "session_abc",
 	})
 	fields, err := extractFields(context.TODO(), extractFieldsParams{
@@ -79,7 +89,7 @@ func TestExtractFields_ExtractSessionID(t *testing.T) {
 	assert.Equal(t, fields.sessionID, "session_abc")
 	assert.Equal(t, fields.attrs, map[string]string{})
 
-	resource = newResource(map[string]string{
+	resource = newResource(t, map[string]any{
 		highlight.SessionIDAttribute: "session_abc",
 	})
 	fields, err = extractFields(context.TODO(), extractFieldsParams{resource: &resource})
@@ -89,13 +99,13 @@ func TestExtractFields_ExtractSessionID(t *testing.T) {
 }
 
 func TestExtractFields_ExtractSource(t *testing.T) {
-	resource := newResource(map[string]string{})
+	resource := newResource(t, map[string]any{})
 	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
 	assert.NoError(t, err)
 	assert.Equal(t, fields.source, modelInputs.LogSourceBackend) // defaults to backend
 	assert.Equal(t, fields.attrs, map[string]string{})
 
-	resource = newResource(map[string]string{
+	resource = newResource(t, map[string]any{
 		highlight.DeprecatedSourceAttribute: modelInputs.LogSourceFrontend.String(),
 	})
 	fields, err = extractFields(context.TODO(), extractFieldsParams{resource: &resource})
@@ -103,7 +113,7 @@ func TestExtractFields_ExtractSource(t *testing.T) {
 	assert.Equal(t, fields.source, modelInputs.LogSourceFrontend)
 	assert.Equal(t, fields.attrs, map[string]string{})
 
-	resource = newResource(map[string]string{
+	resource = newResource(t, map[string]any{
 		highlight.SourceAttribute: modelInputs.LogSourceFrontend.String(),
 	})
 	fields, err = extractFields(context.TODO(), extractFieldsParams{resource: &resource})
@@ -113,7 +123,7 @@ func TestExtractFields_ExtractSource(t *testing.T) {
 }
 
 func TestExtractFields_ExtractRequestID(t *testing.T) {
-	resource := newResource(map[string]string{
+	resource := newResource(t, map[string]any{
 		highlight.RequestIDAttribute: "request_id",
 	})
 	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
@@ -123,7 +133,7 @@ func TestExtractFields_ExtractRequestID(t *testing.T) {
 }
 
 func TestExtractFields_ExtractMetricEventName(t *testing.T) {
-	resource := newResource(map[string]string{
+	resource := newResource(t, map[string]any{
 		highlight.MetricEventName: "metric_name",
 	})
 	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
@@ -133,17 +143,27 @@ func TestExtractFields_ExtractMetricEventName(t *testing.T) {
 }
 
 func TestExtractFields_ExtractMetricEventValue(t *testing.T) {
-	resource := newResource(map[string]string{
+	resource := newResource(t, map[string]any{
+		highlight.MetricEventValue: float64(99),
+	})
+	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
+	assert.NoError(t, err)
+	assert.Equal(t, fields.metricEventValue, float64(99))
+	assert.Equal(t, fields.attrs, map[string]string{})
+}
+
+func TestExtractFields_ExtractMetricEventValueHandlesBadInput(t *testing.T) {
+	resource := newResource(t, map[string]any{
 		highlight.MetricEventValue: "99",
 	})
 	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
 	assert.NoError(t, err)
-	assert.Equal(t, fields.metricEventValue, "99")
+	assert.Equal(t, fields.metricEventValue, float64(0))
 	assert.Equal(t, fields.attrs, map[string]string{})
 }
 
 func TestExtractFields_ExtractLogSeverity(t *testing.T) {
-	resource := newResource(map[string]string{})
+	resource := newResource(t, map[string]any{})
 	event := newEvent(map[string]string{
 		highlight.LogSeverityAttribute: "log_severity",
 	})
@@ -154,7 +174,7 @@ func TestExtractFields_ExtractLogSeverity(t *testing.T) {
 }
 
 func TestExtractFields_ExtractLogMessage(t *testing.T) {
-	resource := newResource(map[string]string{})
+	resource := newResource(t, map[string]any{})
 	event := newEvent(map[string]string{
 		highlight.LogMessageAttribute: "log_message",
 	})
@@ -165,7 +185,7 @@ func TestExtractFields_ExtractLogMessage(t *testing.T) {
 }
 
 func TestExtractFields_ExtractExceptionType(t *testing.T) {
-	resource := newResource(map[string]string{})
+	resource := newResource(t, map[string]any{})
 	event := newEvent(map[string]string{
 		string(semconv.ExceptionTypeKey): "exception_type",
 	})
@@ -176,7 +196,7 @@ func TestExtractFields_ExtractExceptionType(t *testing.T) {
 }
 
 func TestExtractFields_ExtractExceptionMessage(t *testing.T) {
-	resource := newResource(map[string]string{})
+	resource := newResource(t, map[string]any{})
 	event := newEvent(map[string]string{
 		string(semconv.ExceptionMessageKey): "exception_message",
 	})
@@ -187,7 +207,7 @@ func TestExtractFields_ExtractExceptionMessage(t *testing.T) {
 }
 
 func TestExtractFields_ExtractExceptionStacktrace(t *testing.T) {
-	resource := newResource(map[string]string{})
+	resource := newResource(t, map[string]any{})
 	event := newEvent(map[string]string{
 		string(semconv.ExceptionStacktraceKey): "exception_stacktrace",
 	})
@@ -198,7 +218,7 @@ func TestExtractFields_ExtractExceptionStacktrace(t *testing.T) {
 }
 
 func TestExtractFields_ExtractErrorURL(t *testing.T) {
-	resource := newResource(map[string]string{})
+	resource := newResource(t, map[string]any{})
 	event := newEvent(map[string]string{
 		highlight.ErrorURLAttribute: "error_url",
 	})
@@ -209,7 +229,7 @@ func TestExtractFields_ExtractErrorURL(t *testing.T) {
 }
 
 func TestExtractFields_ExtractServiceName(t *testing.T) {
-	resource := newResource(map[string]string{
+	resource := newResource(t, map[string]any{
 		"service.name": "my_service",
 	})
 	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
@@ -219,7 +239,7 @@ func TestExtractFields_ExtractServiceName(t *testing.T) {
 }
 
 func TestExtractFields_ExtractServiceVersion(t *testing.T) {
-	resource := newResource(map[string]string{
+	resource := newResource(t, map[string]any{
 		"service.version": "abc123",
 	})
 	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
@@ -229,7 +249,7 @@ func TestExtractFields_ExtractServiceVersion(t *testing.T) {
 }
 
 func TestExtractFields_OmitLogSeverity(t *testing.T) {
-	resource := newResource(map[string]string{
+	resource := newResource(t, map[string]any{
 		"os.description": "Debian GNU/Linux 11 (bullseye)",
 		"log.severity":   "info", // should be skipped since this is an internal attribute
 	})
@@ -241,7 +261,7 @@ func TestExtractFields_OmitLogSeverity(t *testing.T) {
 }
 
 func TestExtractFields_OmitBackendPropertiesForFrontendSource(t *testing.T) {
-	resource := newResource(map[string]string{
+	resource := newResource(t, map[string]any{
 		"os.description":   "Debian GNU/Linux 11 (bullseye)", // should be skipped since this is a frontend source
 		"highlight.source": "frontend",
 	})
@@ -256,7 +276,7 @@ func TestExtractFields_TrimLongFields(t *testing.T) {
 		value += "a"
 	}
 
-	resource := newResource(map[string]string{
+	resource := newResource(t, map[string]any{
 		"foo": value,
 	})
 	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})

--- a/backend/otel/extract_test.go
+++ b/backend/otel/extract_test.go
@@ -158,7 +158,7 @@ func TestExtractFields_ExtractMetricEventValueHandlesBadInput(t *testing.T) {
 	})
 	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
 	assert.NoError(t, err)
-	assert.Equal(t, fields.metricEventValue, float64(0))
+	assert.Equal(t, fields.metricEventValue, float64(99))
 	assert.Equal(t, fields.attrs, map[string]string{})
 }
 

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/samber/lo"
@@ -87,16 +86,11 @@ func getMetric(ctx context.Context, ts time.Time, fields extractedFields, traceI
 	if fields.metricEventName == "" {
 		return nil, e.New("otel received metric with no name")
 	}
-	value, err := strconv.ParseFloat(fields.metricEventValue, 64)
-
-	if err != nil {
-		return nil, e.New("otel received metric with no value")
-	}
 	return &model.MetricInput{
 		SessionSecureID: fields.sessionID,
 		Group:           pointy.String(fields.requestID),
 		Name:            fields.metricEventName,
-		Value:           value,
+		Value:           fields.metricEventValue,
 		Category:        pointy.String(fields.source.String()),
 		Timestamp:       ts,
 		Tags: lo.Map(lo.Entries(fields.attrs), func(t lo.Entry[string, string], i int) *model.MetricTag {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

A regression was introduced in #6121 such that metric values were being casted to a string and causing a panic.

![Screenshot 2023-07-27 at 10 22 26 AM](https://github.com/highlight/highlight/assets/58678/bb4be26a-4544-4ba9-8ecd-81884c9ab459)

Long term, we probably need to consider whether this `.(type)` syntax is actually safe to be using. It would be better to try and use builtin functions that return errors when we can't safely parse a value.


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed that the panic does not occur when a new metric comes in.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
