### PR TITLE
support manual canvas snapshotting

### DIFF
--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/canvas.md
@@ -29,6 +29,8 @@ With these settings, the canvas is serialized as a 480p video at 2FPS.
 
 `samplingStrategy.canvas` is the frame per second rate used to record the HTML canvas. A value < 5 is recommended to ensure the recording is not too large and does not have issues with playback.
 
+`samplingStrategy.canvasManual` is the frame per second rate used in manual snapshotting mode. See `Manual Snapshotting` below.
+
 `samplingStrategy.canvasFactor`: a resolution scaling factor applied to both dimensions of the canvas.
 
 `samplingStrategy.canvasMaxSnapshotDimension`: max recording resolution of the largest dimension of the canvas.
@@ -48,6 +50,41 @@ Enabling canvas recording should not have any impact on the performance your app
 Highlight is able to record websites that use WebGL in the `<canvas>` element. 
 
 To enable WebGL recording, enable canvas recording by following the steps above.
+
+```hint
+If you use WebGL(2) and fail to see a canvas recorded or see a transparent image, setup manual snapshotting.
+```
+
+## Manual Snapshotting
+
+A canvas may fail to be recorded (recorded as a transparent image) because of WebGL 
+double buffering. The canvas is not accessible from the javascript thread because it may
+no longer be loaded in memory, despite being rendered by the GPU (see this [chrome bug report](https://bugs.chromium.org/p/chromium/issues/detail?id=838108) for additional context). 
+
+Manual snapshotting hooks into your WebGL render function to call `H.snapshot(canvas)` after
+you paint to the WebGL context. To set this up, pass the following options to highlight first:
+
+```javascript
+H.init('<YOUR_PROJECT_ID>', {
+  enableCanvasRecording: true,        // enable canvas recording
+  samplingStrategy: {
+    canvasManual: 2,                        // snapshot at 2 fps
+    canvasMaxSnapshotDimension: 480,  // snapshot at a max 480p resolution
+    // any other settings...
+  },
+})
+```
+
+Now, hook into your WebGL rendering code and call `H.snapshot`.
+```typescript
+// babylon.js
+engine.runRenderLoop(() => {
+    scene.render()
+    H.snapshot(canvasElementRef.current)
+})
+```
+
+Libraries like Three.js export an [onAfterRender](https://threejs.org/docs/#api/en/core/Object3D.onAfterRender) method that you can use to call `H.snapshot`.
 
 ## Webcam Recording and Inlining Video Resources
 

--- a/e2e/nextjs/pages/_app.tsx
+++ b/e2e/nextjs/pages/_app.tsx
@@ -16,21 +16,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 
 	return (
 		<>
-			<HighlightInit
-				projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
-				tracingOrigins
-				networkRecording={{
-					enabled: true,
-					recordHeadersAndBody: true,
-				}}
-				// inlineImages={true} // Set to false to disable inline images and resolve CORS issue
-				// run `yarn dev` from the sdk/client directory to serve the scriptUrl
-				scriptUrl={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_SCRIPT_URL}
-				backendUrl={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_BACKEND_URL}
-			/>
-
 			<Component {...pageProps} />
-
 			<img src="https://i.travelapi.com/lodging/11000000/10140000/10130300/10130300/c9095011_z.jpg" />
 		</>
 	)

--- a/e2e/nextjs/src/app/components/canvas.tsx
+++ b/e2e/nextjs/src/app/components/canvas.tsx
@@ -27,12 +27,6 @@ export const Canvas = ({
 	adaptToDeviceRatio?: boolean
 	sceneOptions?: SceneOptions
 }) => {
-	const onRender = (scene: Scene) => {
-		// console.debug('onRender', scene)
-	}
-	const onSceneReady = (scene: Scene) => {
-		console.debug('onSceneReady', scene)
-	}
 	const reactCanvas = useRef(null)
 	const loadTimer = useRef<number>()
 	const load = useRef<() => void>()
@@ -42,6 +36,16 @@ export const Canvas = ({
 		engine: Engine | null
 		scene: Scene | null
 	}>({ engine: null, scene: null })
+
+	const onRender = (scene: Scene) => {
+		// console.debug('onRender', scene)
+		if (reactCanvas.current) {
+			H.snapshot(reactCanvas.current)
+		}
+	}
+	const onSceneReady = (scene: Scene) => {
+		console.debug('onSceneReady', scene)
+	}
 
 	useEffect(() => {
 		H.identify('vadim@highlight.io')

--- a/e2e/nextjs/src/app/components/canvas.tsx
+++ b/e2e/nextjs/src/app/components/canvas.tsx
@@ -161,10 +161,10 @@ export const Canvas = ({
 			})
 
 			engine.runRenderLoop(() => {
+				scene.render()
 				if (typeof onRender === 'function') {
 					onRender(scene)
 				}
-				scene.render()
 			})
 
 			loadTimer.current = undefined

--- a/e2e/nextjs/src/app/layout.tsx
+++ b/e2e/nextjs/src/app/layout.tsx
@@ -27,11 +27,11 @@ export default function RootLayout({
 				// inlineImages={false}
 				enableCanvasRecording={true}
 				samplingStrategy={{
-					canvas: 1,
+					canvas: undefined,
+					canvasManualSnapshot: 1,
 					canvasMaxSnapshotDimension: 480,
 					canvasFactor: 0.5,
-					canvasClearWebGLBuffer: true,
-					canvasInitialSnapshotDelay: 5000,
+					canvasClearWebGLBuffer: false,
 				}}
 				backendUrl={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_BACKEND_URL}
 				scriptUrl={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_SCRIPT_URL}

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -1205,6 +1205,10 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 		return null
 	}
 
+	async snapshot(element: HTMLCanvasElement) {
+		await record.snapshotCanvas(element)
+	}
+
 	addSessionFeedback({
 		timestamp,
 		verbatim,

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -342,9 +342,9 @@ export class Highlight {
 		this.inlineImages = options.inlineImages ?? this._isOnLocalHost
 		this.inlineStylesheet = options.inlineStylesheet ?? this._isOnLocalHost
 		this.samplingStrategy = {
-			canvas: 1,
 			canvasFactor: 0.5,
 			canvasMaxSnapshotDimension: 360,
+			canvasClearWebGLBuffer: true,
 			...(options.samplingStrategy ?? {}),
 		}
 		this._backendUrl = options?.backendUrl ?? 'https://pub.highlight.run'
@@ -724,6 +724,8 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 					sampling: {
 						canvas: {
 							fps: this.samplingStrategy.canvas,
+							fpsManual:
+								this.samplingStrategy.canvasManualSnapshot,
 							resizeFactor: this.samplingStrategy.canvasFactor,
 							clearWebGLBuffer:
 								this.samplingStrategy.canvasClearWebGLBuffer,

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -19,10 +19,16 @@ export declare interface Metric {
 export declare type SamplingStrategy = {
 	/**
 	 * 'all' will record every single canvas call.
-	 * a number between 1 and 60, will record an image snapshots in a web-worker a (maximum) number of times per second.
+	 * a number will record an image snapshots in a web-worker a (maximum) number of times per second.
 	 * Number is only supported where [`OffscreenCanvas`](http://mdn.io/offscreencanvas) is supported.
 	 */
 	canvas?: 'all' | number
+	/**
+	 * For manual usage of `H.snapshot(element) from your canvas rendering function.
+	 * See https://www.highlight.io/docs/getting-started/client-sdk/replay-configuration/canvas for setup.`
+	 * a number will record an image snapshots in a web-worker a (maximum) number of times per second.
+	 */
+	canvasManualSnapshot?: number
 	/**
 	 * A quality at which to take canvas snapshots. See https://developer.mozilla.org/en-US/docs/Web/API/createImageBitmap
 	 * @deprecated This value is no longer used.

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -239,6 +239,7 @@ export declare interface HighlightPublicInterface {
 	 * Calling this will add a feedback comment to the session.
 	 */
 	addSessionFeedback: (feedbackOptions: SessionFeedbackOptions) => void
+	snapshot: (element: HTMLCanvasElement) => Promise<void>
 }
 
 export declare interface SessionDetails {

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -166,6 +166,13 @@ const H: HighlightPublicInterface = {
 			HighlightWarning('init', e)
 		}
 	},
+	snapshot: async (element: HTMLCanvasElement) => {
+		try {
+			H.onHighlightReady(() => highlight_obj.snapshot(element))
+		} catch (e) {
+			HighlightWarning('snapshot', e)
+		}
+	},
 	addSessionFeedback: ({
 		verbatim,
 		userName,


### PR DESCRIPTION
## Summary

WebGL canvas elements can be double buffered, meaning that the canvas bitmap is not in javascript memory
when we try to call `createImageBitmap`. If we hook into the webgl render loop of a given library to do the
snapshotting, we have access to the canvas as it is still in memory.

Adds a new manual snapshotting mode that exposes this functionality.

Adds new rrweb logic in https://github.com/highlight/rrweb/pull/108

## How did you test this change?

Babylon.js canvas snapshotting correctly in manual mode.
<img width="1234" alt="Screenshot 2023-07-27 at 2 33 46 PM" src="https://github.com/highlight/highlight/assets/1351531/5e06a582-ebf1-45e3-af9b-2360e028cb58">

New docs on [vercel preview](https://highlight-landing-ld05dz2bn-highlight-run.vercel.app/docs/getting-started/client-sdk/replay-configuration/canvas).

## Are there any deployment considerations?

New highlight.run minor version.