### PR TITLE
disable timepicker unless both a start and end time are chosen

### DIFF
--- a/packages/ui/src/components/DatePicker/PreviousDateRangePicker.tsx
+++ b/packages/ui/src/components/DatePicker/PreviousDateRangePicker.tsx
@@ -264,6 +264,11 @@ const PreviousDateRangePickerImpl = ({
 		[selectedDates[1]],
 	)
 
+	const isTimepickerDisabled = useMemo(
+		() => selectedDates.length != 2,
+		[selectedDates],
+	)
+
 	const [buttonLabel, setButtonLabel] = useState<string>(
 		getLabel({ selectedDates, presets }),
 	)
@@ -586,7 +591,11 @@ const PreviousDateRangePickerImpl = ({
 								p={'7'}
 								display={'flex'}
 								justifyContent={'center'}
-								cursor="pointer"
+								cursor={
+									isTimepickerDisabled
+										? 'not-allowed'
+										: 'pointer'
+								}
 								background={'n4'}
 								alignItems={'center'}
 								style={{
@@ -599,6 +608,7 @@ const PreviousDateRangePickerImpl = ({
 										? '0px -1px 0px rgba(0, 0, 0, 0.32) inset'
 										: undefined,
 								}}
+								disabled={isTimepickerDisabled}
 								onClick={handleShowingTimeToggle}
 							>
 								<IconSolidClock


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

When we added a timepicker in #5629, we didn't consider an edge case where by someone might try to choose a time without both the start/end date being selected.

Specifically, this line: https://github.com/highlight/highlight/pull/5629/files#diff-cbeeacd5af75faf0a293a5be799a26ed033c8232dbafe25e57f3713bd30bfb60R297

`selectedDates[1]` isn't valid since there is no end date chosen.

Here's a loom show how to reproduce the bug: https://www.loom.com/share/dca5353e88d74a1da9b88080deab9542

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed that the timepicker cannot be clicked when an end date is not selected.
https://www.loom.com/share/22127f1f53324681bf896d756d22785e

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
