### PR TITLE
Fix handling of network resources with errors

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -506,7 +506,6 @@ const hasErrorsInBody = (resource: NetworkResource): boolean => {
 		}
 
 		const errors = parsedResponseBody.errors
-		console.log('::: errors', errors)
 		return Array.isArray(errors) ? errors.length > 0 : !!errors
 	} catch (error) {
 		return false

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -314,7 +314,10 @@ const ResourceRow = ({
 	const { activeNetworkResourceId } = useActiveNetworkResourceId()
 	const showingDetails = activeNetworkResourceId === resource.id
 	const responseStatus = resource.requestResponsePairs?.response.status
+	const bodyErrors = hasErrorsInBody(resource)
+
 	const hasError =
+		bodyErrors ||
 		!!errors?.length ||
 		!!resource.errors?.length ||
 		!!(responseStatus === 0 || (responseStatus && responseStatus >= 400))
@@ -485,4 +488,27 @@ const ResourceLoadingErrorCallout = function ({
 			/>
 		</Box>
 	)
+}
+
+const hasErrorsInBody = (resource: NetworkResource): boolean => {
+	const body = resource?.requestResponsePairs?.response.body
+
+	if (!body) {
+		return false
+	}
+
+	try {
+		let parsedResponseBody: { [key: string]: any } = {}
+		if (typeof body === 'object') {
+			parsedResponseBody = JSON.parse(JSON.stringify(body))
+		} else {
+			parsedResponseBody = JSON.parse(body)
+		}
+
+		const errors = parsedResponseBody.errors
+		console.log('::: errors', errors)
+		return Array.isArray(errors) ? errors.length > 0 : !!errors
+	} catch (error) {
+		return false
+	}
 }


### PR DESCRIPTION
## Summary

Our GraphQL requests all return a `200` status. When the request has errors there is an `errors` key in the response body which we should be checking for and marking requests as failed that have that populated.

## How did you test this change?

Confirmed [a failed request that wasn't being displayed as failed](https://app.highlight.io/1/sessions/cO4nEWf3booIJzbyXFDJhhMYr1ui?errorId=198180084&network-resource-id=32) was being displayed as failed in the PR preview.

**Before**
<img width="1512" alt="Screenshot 2023-07-28 at 8 03 01 AM" src="https://github.com/highlight/highlight/assets/308182/bf86916b-57a7-4c97-bdc0-b00597197c42">

**After**
<img width="1512" alt="Screenshot 2023-07-28 at 8 02 37 AM" src="https://github.com/highlight/highlight/assets/308182/29c85b12-8107-4939-be02-2ecb943c0756">

## Are there any deployment considerations?

N/A
