### PR TITLE
update kafka settings for datasync queue

### DIFF
--- a/backend/kafka-queue/kafkaqueue_test.go
+++ b/backend/kafka-queue/kafkaqueue_test.go
@@ -27,8 +27,8 @@ func BenchmarkQueue_Submit(b *testing.B) {
 
 	rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	writer := New(ctx, "dev", Producer)
-	reader := New(ctx, "dev", Consumer)
+	writer := New(ctx, "dev", Producer, nil)
+	reader := New(ctx, "dev", Consumer, nil)
 
 	sendWg := sync.WaitGroup{}
 	sendWg.Add(workers)

--- a/backend/main.go
+++ b/backend/main.go
@@ -322,9 +322,9 @@ func main() {
 		}
 	}
 
-	kafkaProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDefault}), kafkaqueue.Producer)
-	kafkaBatchedProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}), kafkaqueue.Producer)
-	kafkaDataSyncProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}), kafkaqueue.Producer)
+	kafkaProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDefault}), kafkaqueue.Producer, nil)
+	kafkaBatchedProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}), kafkaqueue.Producer, nil)
+	kafkaDataSyncProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}), kafkaqueue.Producer, nil)
 
 	opensearchClient, err := opensearch.NewOpensearchClient(db)
 	if err != nil {

--- a/backend/scripts/reset-kafka-offset/main.go
+++ b/backend/scripts/reset-kafka-offset/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	ctx := context.TODO()
-	k := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDefault}), kafkaqueue.Consumer)
+	k := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDefault}), kafkaqueue.Consumer, nil)
 	err := k.Rewind(ctx, 24*7*time.Hour)
 	if err != nil {
 		log.WithContext(ctx).Error(err)


### PR DESCRIPTION
## Summary
- allow overriding for topic settings (`QueueCapacity` for now)
- don't set delete policy for all topics
- add outer span to differentiate between batched and datasync topics
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will clicktest locally to make sure the 3 topics are still working
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
