### PR TITLE
Limit Stacktrace to 5000 characters when querying OpenAI

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7428,7 +7428,7 @@ func (r *queryResolver) ErrorResolutionSuggestion(ctx context.Context, errorObje
 	}
 
 	const MAX_AI_STACKTRACE_LENGTH = 5000
-	if len(*stackTrace) > MAX_AI_STACKTRACE_LENGTH {
+	if stackTrace != nil && len(*stackTrace) > MAX_AI_STACKTRACE_LENGTH {
 		stackTrace = ptr.String((*stackTrace)[:MAX_AI_STACKTRACE_LENGTH])
 	}
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7427,6 +7427,11 @@ func (r *queryResolver) ErrorResolutionSuggestion(ctx context.Context, errorObje
 		stackTrace = errorObject.StackTrace
 	}
 
+	const MAX_AI_STACKTRACE_LENGTH = 5000
+	if len(*stackTrace) > MAX_AI_STACKTRACE_LENGTH {
+		stackTrace = ptr.String((*stackTrace)[:MAX_AI_STACKTRACE_LENGTH])
+	}
+
 	userPrompt := fmt.Sprintf(`
 	Here is some information about the error.
 


### PR DESCRIPTION
## Summary
**Describe the bug**
A customer tried to ask Harold for help on an error that had a stacktrace > 27k characters (~9000 tokens). OpenAI returns an error when we use more than the `4097` token max. Frontend errors that use `MappedStackTrace` are more susceptible to this due to the enhancement of other lines and information.

**Proposed solution**
Limit the length from the stack trace to 5000 characters that are provided to AI

## How did you test this change?
1) Found an error with a stack trace more than 5000 characters (`Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`)
2) Ask Harold for help
- [ ] Suggestion is returned
- [ ] Suggestion is still relevant

![Screenshot 2023-07-31 at 10 57 42 AM](https://github.com/highlight/highlight/assets/17744174/c90de356-6dd1-4245-a38d-e0877a1d9625)

## Are there any deployment considerations?
N/A
