### PR TITLE
change flush size to 500 for session_fields lookup

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -483,7 +483,7 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 		_wg.Done()
 	}(&wg)
 	go func(_wg *sync.WaitGroup) {
-		flushSize := 1000
+		flushSize := 500
 		buffer := &KafkaBatchBuffer{
 			messageQueue: make(chan *kafkaqueue.Message, flushSize+1),
 		}


### PR DESCRIPTION
## Summary
- `select * from session_fields where session_id in (...)` is doing a sequential scan with 1000 elements in the in clause, but an index scan if there are 500
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- looked at query plans in prod postgres
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
