### PR TITLE
allow service version to be queried via clickhouse

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -62,7 +62,7 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 	sb := sqlbuilder.NewSelectBuilder()
 	var err error
 	var args []interface{}
-	selectStr := "Timestamp, UUID, SeverityText, Body, LogAttributes, TraceId, SpanId, SecureSessionId, Source, ServiceName"
+	selectStr := "Timestamp, UUID, SeverityText, Body, LogAttributes, TraceId, SpanId, SecureSessionId, Source, ServiceName, ServiceVersion"
 
 	orderForward := OrderForwardNatural
 	orderBackward := OrderBackwardNatural
@@ -141,6 +141,7 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 			SecureSessionId string
 			Source          string
 			ServiceName     string
+			ServiceVersion  string
 		}
 		if err := rows.ScanStruct(&result); err != nil {
 			return nil, err
@@ -158,6 +159,7 @@ func (client *Client) ReadLogs(ctx context.Context, projectID int, params modelI
 				SecureSessionID: &result.SecureSessionId,
 				Source:          &result.Source,
 				ServiceName:     &result.ServiceName,
+				ServiceVersion:  &result.ServiceVersion,
 			},
 		})
 	}
@@ -472,6 +474,12 @@ func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName 
 			Where(sb.Equal("ProjectId", projectID)).
 			Where(sb.NotEqual("service_name", "")).
 			Limit(KeyValuesLimit)
+	case modelInputs.ReservedLogKeyServiceVersion.String():
+		sb.Select("DISTINCT ServiceVersion service_version").
+			From(LogsTable).
+			Where(sb.Equal("ProjectId", projectID)).
+			Where(sb.NotEqual("service_version", "")).
+			Limit(KeyValuesLimit)
 	default:
 		sb.Select("DISTINCT LogAttributes [" + sb.Var(keyName) + "] as value").
 			From(LogsTable).
@@ -584,6 +592,7 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 	makeFilterConditions(sb, filters.trace_id, "TraceId")
 	makeFilterConditions(sb, filters.source, "Source")
 	makeFilterConditions(sb, filters.service_name, "ServiceName")
+	makeFilterConditions(sb, filters.service_version, "ServiceVersion")
 
 	conditions := []string{}
 	for key, values := range filters.attributes {
@@ -610,6 +619,7 @@ type filtersWithReservedKeys struct {
 	secure_session_id []string
 	source            []string
 	service_name      []string
+	service_version   []string
 	attributes        map[string][]string
 }
 
@@ -649,6 +659,11 @@ func makeFilters(query string) filtersWithReservedKeys {
 	if val, ok := filters.Attributes[modelInputs.ReservedLogKeyServiceName.String()]; ok {
 		filtersWithReservedKeys.service_name = val
 		delete(filters.Attributes, modelInputs.ReservedLogKeyServiceName.String())
+	}
+
+	if val, ok := filters.Attributes[modelInputs.ReservedLogKeyServiceVersion.String()]; ok {
+		filtersWithReservedKeys.service_version = val
+		delete(filters.Attributes, modelInputs.ReservedLogKeyServiceVersion.String())
 	}
 
 	filtersWithReservedKeys.attributes = filters.Attributes

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -571,6 +571,7 @@ type ComplexityRoot struct {
 		Message         func(childComplexity int) int
 		SecureSessionID func(childComplexity int) int
 		ServiceName     func(childComplexity int) int
+		ServiceVersion  func(childComplexity int) int
 		Source          func(childComplexity int) int
 		SpanID          func(childComplexity int) int
 		Timestamp       func(childComplexity int) int
@@ -3950,6 +3951,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Log.ServiceName(childComplexity), true
+
+	case "Log.serviceVersion":
+		if e.complexity.Log.ServiceVersion == nil {
+			break
+		}
+
+		return e.complexity.Log.ServiceVersion(childComplexity), true
 
 	case "Log.source":
 		if e.complexity.Log.Source == nil {
@@ -9564,6 +9572,7 @@ type Log {
 	secureSessionID: String
 	source: String
 	serviceName: String
+	serviceVersion: String
 }
 
 type LogEdge implements Edge {
@@ -9645,6 +9654,7 @@ enum ReservedLogKey {
 	trace_id
 	source
 	service_name
+	service_version
 }
 
 enum LogSource {
@@ -31754,6 +31764,47 @@ func (ec *executionContext) fieldContext_Log_serviceName(ctx context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _Log_serviceVersion(ctx context.Context, field graphql.CollectedField, obj *model.Log) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Log_serviceVersion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ServiceVersion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Log_serviceVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Log",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _LogAlert_id(ctx context.Context, field graphql.CollectedField, obj *model1.LogAlert) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_LogAlert_id(ctx, field)
 	if err != nil {
@@ -32678,6 +32729,8 @@ func (ec *executionContext) fieldContext_LogEdge_node(ctx context.Context, field
 				return ec.fieldContext_Log_source(ctx, field)
 			case "serviceName":
 				return ec.fieldContext_Log_serviceName(ctx, field)
+			case "serviceVersion":
+				return ec.fieldContext_Log_serviceVersion(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Log", field.Name)
 		},
@@ -68187,6 +68240,10 @@ func (ec *executionContext) _Log(ctx context.Context, sel ast.SelectionSet, obj 
 		case "serviceName":
 
 			out.Values[i] = ec._Log_serviceName(ctx, field, obj)
+
+		case "serviceVersion":
+
+			out.Values[i] = ec._Log_serviceVersion(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -443,6 +443,7 @@ type Log struct {
 	SecureSessionID *string                `json:"secureSessionID"`
 	Source          *string                `json:"source"`
 	ServiceName     *string                `json:"serviceName"`
+	ServiceVersion  *string                `json:"serviceVersion"`
 }
 
 type LogAlertInput struct {
@@ -1490,6 +1491,7 @@ const (
 	ReservedLogKeyTraceID         ReservedLogKey = "trace_id"
 	ReservedLogKeySource          ReservedLogKey = "source"
 	ReservedLogKeyServiceName     ReservedLogKey = "service_name"
+	ReservedLogKeyServiceVersion  ReservedLogKey = "service_version"
 )
 
 var AllReservedLogKey = []ReservedLogKey{
@@ -1500,11 +1502,12 @@ var AllReservedLogKey = []ReservedLogKey{
 	ReservedLogKeyTraceID,
 	ReservedLogKeySource,
 	ReservedLogKeyServiceName,
+	ReservedLogKeyServiceVersion,
 }
 
 func (e ReservedLogKey) IsValid() bool {
 	switch e {
-	case ReservedLogKeyLevel, ReservedLogKeyMessage, ReservedLogKeySecureSessionID, ReservedLogKeySpanID, ReservedLogKeyTraceID, ReservedLogKeySource, ReservedLogKeyServiceName:
+	case ReservedLogKeyLevel, ReservedLogKeyMessage, ReservedLogKeySecureSessionID, ReservedLogKeySpanID, ReservedLogKeyTraceID, ReservedLogKeySource, ReservedLogKeyServiceName, ReservedLogKeyServiceVersion:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -609,6 +609,7 @@ type Log {
 	secureSessionID: String
 	source: String
 	serviceName: String
+	serviceVersion: String
 }
 
 type LogEdge implements Edge {
@@ -690,6 +691,7 @@ enum ReservedLogKey {
 	trace_id
 	source
 	service_name
+	service_version
 }
 
 enum LogSource {

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -12338,6 +12338,7 @@ export const GetLogsDocument = gql`
 					secureSessionID
 					source
 					serviceName
+					serviceVersion
 				}
 			}
 			pageInfo {

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4210,6 +4210,7 @@ export type GetLogsQuery = { __typename?: 'Query' } & {
 						| 'secureSessionID'
 						| 'source'
 						| 'serviceName'
+						| 'serviceVersion'
 					>
 				}
 		>

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -754,6 +754,7 @@ export type Log = {
 	message: Scalars['String']
 	secureSessionID?: Maybe<Scalars['String']>
 	serviceName?: Maybe<Scalars['String']>
+	serviceVersion?: Maybe<Scalars['String']>
 	source?: Maybe<Scalars['String']>
 	spanID?: Maybe<Scalars['String']>
 	timestamp: Scalars['Timestamp']
@@ -2386,6 +2387,7 @@ export enum ReservedLogKey {
 	Message = 'message',
 	SecureSessionId = 'secure_session_id',
 	ServiceName = 'service_name',
+	ServiceVersion = 'service_version',
 	Source = 'source',
 	SpanId = 'span_id',
 	TraceId = 'trace_id',

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1988,6 +1988,7 @@ query GetLogs(
 				secureSessionID
 				source
 				serviceName
+				serviceVersion
 			}
 		}
 		pageInfo {

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -83,6 +83,7 @@ export const LogDetails: React.FC<Props> = ({
 		level,
 		source,
 		serviceName,
+		serviceVersion,
 	} = row.original.node
 	const expanded = row.getIsExpanded()
 	const expandable = Object.values(logAttributes).some(
@@ -101,6 +102,7 @@ export const LogDetails: React.FC<Props> = ({
 		secure_session_id: secureSessionID,
 		source,
 		service_name: serviceName,
+		service_version: serviceVersion,
 	}
 
 	if (!expanded) {

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -228,6 +228,7 @@ const LogsTableInner = ({
 						message: log.message,
 						secure_session_id: log.secureSessionID,
 						service_name: log.serviceName,
+						service_version: log.serviceName,
 						source: log.source,
 						span_id: log.spanID,
 						trace_id: log.traceID,

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -228,7 +228,7 @@ const LogsTableInner = ({
 						message: log.message,
 						secure_session_id: log.secureSessionID,
 						service_name: log.serviceName,
-						service_version: log.serviceName,
+						service_version: log.serviceVersion,
 						source: log.source,
 						span_id: log.spanID,
 						trace_id: log.traceID,


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Allows searching logs for a service's version via `service_version:version`. 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Per #6108, we are setting the service version on logs (via the Go SDK) via the `REACT_APP_COMMIT_SHA` env var. On dev using doppler (using `yarn dev:frontend` and `cd backend && make start`), this evaluates to `asdf`

![Screenshot 2023-07-31 at 3 14 55 PM](https://github.com/highlight/highlight/assets/58678/4e11489c-9103-42b7-b2e6-f43e26329cc3)


Direct match works:
![Screenshot 2023-07-31 at 3 33 35 PM](https://github.com/highlight/highlight/assets/58678/ccd7f97f-0dc9-456b-b70b-c27a76177d17)



No match works as expected:
![Screenshot 2023-07-31 at 3 11 12 PM](https://github.com/highlight/highlight/assets/58678/51c6743f-df6d-4923-a5b1-c748816357d0)

Wildcard works:
![Screenshot 2023-07-31 at 3 11 39 PM](https://github.com/highlight/highlight/assets/58678/407678ca-a487-4b05-add7-70ffa0e08b98)
Note: there is a different bug on wildcard searches not highlighting correctly (#6162)

On prod, `REACT_APP_COMMIT_SHA`, evaluates to the deploy sha (see #6168). I confirmed this column is being populated:

![image](https://github.com/highlight/highlight/assets/58678/a82fb9e9-baf4-49a5-8850-1f9d5531a7e9)



## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
