### PR TITLE
hubspot contact/company creation performance improvements

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1286,6 +1286,7 @@ func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
 		ErrorCountLastDay    int64      `json:"error_count_last_day"`
 		LogCountLastDay      int64      `json:"log_count_last_day"`
 		TrialEndDate         *time.Time `json:"trial_end_date"`
+		PlanTier             string     `json:"plan_tier"`
 	}
 	var counts []*AggregateSessionCount
 
@@ -1322,6 +1323,7 @@ func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
 			continue
 		}
 		c.TrialEndDate = workspace.TrialEndDate
+		c.PlanTier = workspace.PlanTier
 		for _, p := range workspace.Projects {
 			count, _ := w.Resolver.ClickhouseClient.ReadLogsTotalCount(ctx, p.ID, backend.LogsParamsInput{DateRange: &backend.DateRangeRequiredInput{
 				StartDate: time.Now().Add(-time.Hour * 24 * 30),
@@ -1385,6 +1387,10 @@ func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
 				Name:     "logs_last_day",
 				Property: "logs_last_day",
 				Value:    c.LogCountLastDay,
+			}, {
+				Name:     "plan_tier",
+				Property: "plan_tier",
+				Value:    c.PlanTier,
 			}}
 			if c.TrialEndDate != nil {
 				properties = append(properties, hubspot.Property{


### PR DESCRIPTION
## Summary

hubspot tasks seem to be taking a long time, potentially because of a recent change
to be creating association requests from the account creation flow with the longer timeout.
this change reduces the timeouts and also reports the plan tier to hubspot

## How did you test this change?

Local backend deploy with hubspot enabled

## Are there any deployment considerations?

No