### PR TITLE
tune kafka message consumption

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -29,7 +29,7 @@ const ConsumerGroupName = "group-default"
 const (
 	taskRetries           = 5
 	prefetchQueueCapacity = 64
-	prefetchSizeBytes     = 16 * 1000 * 1000  // 16 MB
+	prefetchSizeBytes     = 1 * 1000 * 1000   // 1 MB
 	messageSizeBytes      = 500 * 1000 * 1000 // 500 MB
 )
 
@@ -136,7 +136,7 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *kafka.Rea
 		}
 	}
 
-	rebalanceTimeout := 30 * time.Second
+	rebalanceTimeout := 1 * time.Minute
 	if util.IsDevOrTestEnv() {
 		// faster rebalance for dev to start processing quicker
 		rebalanceTimeout = time.Second

--- a/backend/store/workspace_settings.go
+++ b/backend/store/workspace_settings.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (store *Store) GetAllWorkspaceSettings(ctx context.Context, workspaceID int) (*model.AllWorkspaceSettings, error) {
-	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-workspace-%d", workspaceID), 250*time.Millisecond, 5*time.Second, func() (*model.AllWorkspaceSettings, error) {
+	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-workspace-%d", workspaceID), 250*time.Millisecond, 5*time.Minute, func() (*model.AllWorkspaceSettings, error) {
 		var workspaceSettings model.AllWorkspaceSettings
 		if err := store.db.Where(model.AllWorkspaceSettings{WorkspaceID: workspaceID}).FirstOrCreate(&workspaceSettings).Error; err != nil {
 			return nil, err
@@ -19,7 +19,7 @@ func (store *Store) GetAllWorkspaceSettings(ctx context.Context, workspaceID int
 }
 
 func (store *Store) GetAllWorkspaceSettingsByProject(ctx context.Context, projectID int) (*model.AllWorkspaceSettings, error) {
-	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-project-%d", projectID), 250*time.Millisecond, 5*time.Second, func() (*model.AllWorkspaceSettings, error) {
+	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-project-%d", projectID), 250*time.Millisecond, 5*time.Minute, func() (*model.AllWorkspaceSettings, error) {
 		var workspaceSettings model.AllWorkspaceSettings
 		if err := store.db.Model(&model.AllWorkspaceSettings{}).Joins("INNER JOIN projects ON projects.workspace_id = all_workspace_settings.workspace_id").Where("projects.id = ?", projectID).Take(&workspaceSettings).Error; err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

Adjusting the number of messages down to prevent max-ing out kafka network bandwidth.
![image](https://github.com/highlight/highlight/assets/1351531/271e07b3-75b5-401f-ab4e-f41b40ec256d)


## How did you test this change?

CI

## Are there any deployment considerations?

Monitoring message consumption.
