### PR TITLE
ensure REACT_APP_COMMIT_SHA is set for backend services deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,5 @@
 name: Deploy to AWS
 on:
-    pull_request:
-        types: [opened, synchronize]
     push:
         branches:
             - 'main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,7 @@
 name: Deploy to AWS
 on:
+    pull_request:
+        types: [opened, synchronize]
     push:
         branches:
             - 'main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,17 +62,18 @@ jobs:
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionIdsByQuery \
-                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromPostgres \
-                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromOpenSearch \
-                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromS3 \
-                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name sendEmail \
-                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
             - name: Deploy getSessionIdsByQuery
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -144,13 +145,14 @@ jobs:
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getProjectIds \
-                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name getDigestData \
-                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name sendDigestEmails \
-                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
             - name: Deploy getProjectIds
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -204,11 +206,12 @@ jobs:
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionInsightsData \
-                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name sendSessionInsightsEmails \
-                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
             - name: Deploy getSessionInsightsData
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -252,9 +255,10 @@ jobs:
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name updateNormalnessScores \
-                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
             - name: Deploy updateNormalnessScores
               uses: appleboy/lambda-action@v0.1.9
               with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,18 +62,17 @@ jobs:
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
-                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionIdsByQuery \
-                    --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromPostgres \
-                    --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromOpenSearch \
-                    --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromS3 \
-                    --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
                   aws lambda update-function-configuration --function-name sendEmail \
-                    --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
             - name: Deploy getSessionIdsByQuery
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -145,14 +144,13 @@ jobs:
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
-                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getProjectIds \
-                    --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
                   aws lambda update-function-configuration --function-name getDigestData \
-                    --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
                   aws lambda update-function-configuration --function-name sendDigestEmails \
-                    --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
             - name: Deploy getProjectIds
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -206,12 +204,11 @@ jobs:
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
-                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionInsightsData \
-                    --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
                   aws lambda update-function-configuration --function-name sendSessionInsightsEmails \
-                    --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
             - name: Deploy getSessionInsightsData
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -255,10 +252,9 @@ jobs:
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
-                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name updateNormalnessScores \
-                    --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq '. + {REACT_APP_COMMIT_SHA: ${{github.sha}} }' | jq '{Variables: .}'"
             - name: Deploy updateNormalnessScores
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -290,9 +286,8 @@ jobs:
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
                   ECR_REPOSITORY: highlight-production-ecr-repo
                   IMAGE_TAG: ${{ github.sha }}
-                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
-                  docker buildx build --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64 -f deploy/Dockerfile.prod.arm64 .
+                  docker buildx build --build-arg REACT_APP_COMMIT_SHA=${{ github.sha }} --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64 -f deploy/Dockerfile.prod.arm64 .
                   docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64
 
             # Edit and deploy private-graph
@@ -410,7 +405,6 @@ jobs:
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
                   ECR_REPOSITORY: highlight-collector
                   IMAGE_TAG: ${{ github.sha }}
-                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   cd deploy
                   docker buildx build --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64 -f opentelemetry-collector.Dockerfile .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,15 +67,15 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionIdsByQuery \
-                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromPostgres \
-                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromOpenSearch \
-                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromS3 \
-                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name sendEmail \
-                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
             - name: Deploy getSessionIdsByQuery
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -150,11 +150,11 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getProjectIds \
-                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name getDigestData \
-                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name sendDigestEmails \
-                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
             - name: Deploy getProjectIds
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -211,9 +211,9 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionInsightsData \
-                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name sendSessionInsightsEmails \
-                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
             - name: Deploy getSessionInsightsData
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -260,7 +260,7 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name updateNormalnessScores \
-                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
             - name: Deploy updateNormalnessScores
               uses: appleboy/lambda-action@v0.1.9
               with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,15 +67,15 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionIdsByQuery \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromPostgres \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromOpenSearch \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromS3 \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name sendEmail \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
             - name: Deploy getSessionIdsByQuery
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -150,11 +150,11 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getProjectIds \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name getDigestData \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name sendDigestEmails \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
             - name: Deploy getProjectIds
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -211,9 +211,9 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionInsightsData \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name sendSessionInsightsEmails \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
             - name: Deploy getSessionInsightsData
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -260,7 +260,7 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name updateNormalnessScores \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq \". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }\" | jq '{Variables: .}')"
             - name: Deploy updateNormalnessScores
               uses: appleboy/lambda-action@v0.1.9
               with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -211,9 +211,9 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionInsightsData \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name sendSessionInsightsEmails \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
             - name: Deploy getSessionInsightsData
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -260,7 +260,7 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name updateNormalnessScores \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
             - name: Deploy updateNormalnessScores
               uses: appleboy/lambda-action@v0.1.9
               with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,15 +67,15 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionIdsByQuery \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromPostgres \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromOpenSearch \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name deleteSessionBatchFromS3 \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name sendEmail \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
             - name: Deploy getSessionIdsByQuery
               uses: appleboy/lambda-action@v0.1.9
               with:
@@ -150,11 +150,11 @@ jobs:
                   REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getProjectIds \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name getDigestData \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
                   aws lambda update-function-configuration --function-name sendDigestEmails \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: $REACT_APP_COMMIT_SHA }" | jq '{Variables: .}')"
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
             - name: Deploy getProjectIds
               uses: appleboy/lambda-action@v0.1.9
               with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,7 @@ jobs:
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionIdsByQuery \
                     --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
@@ -144,6 +145,7 @@ jobs:
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getProjectIds \
                     --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
@@ -204,6 +206,7 @@ jobs:
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name getSessionInsightsData \
                     --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
@@ -252,6 +255,7 @@ jobs:
             - name: Update Lambda secrets
               env:
                   DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   aws lambda update-function-configuration --function-name updateNormalnessScores \
                     --environment "$(doppler secrets download --no-file | jq '{Variables: .}')"
@@ -286,6 +290,7 @@ jobs:
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
                   ECR_REPOSITORY: highlight-production-ecr-repo
                   IMAGE_TAG: ${{ github.sha }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   docker buildx build --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64 -f deploy/Dockerfile.prod.arm64 .
                   docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64
@@ -405,6 +410,7 @@ jobs:
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
                   ECR_REPOSITORY: highlight-collector
                   IMAGE_TAG: ${{ github.sha }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
               run: |
                   cd deploy
                   docker buildx build --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64 -f opentelemetry-collector.Dockerfile .

--- a/deploy/Dockerfile.prod.arm64
+++ b/deploy/Dockerfile.prod.arm64
@@ -1,6 +1,6 @@
 FROM golang:alpine as backend-builder
 ARG REACT_APP_COMMIT_SHA
-REACT_APP_COMMIT_SHA=$REACT_APP_COMMIT_SHA
+ENV REACT_APP_COMMIT_SHA=$REACT_APP_COMMIT_SHA
 RUN apk update && apk add git && apk add build-base
 RUN mkdir /build
 WORKDIR /build

--- a/deploy/Dockerfile.prod.arm64
+++ b/deploy/Dockerfile.prod.arm64
@@ -1,4 +1,6 @@
 FROM golang:alpine as backend-builder
+ARG REACT_APP_COMMIT_SHA
+REACT_APP_COMMIT_SHA=$REACT_APP_COMMIT_SHA
 RUN apk update && apk add git && apk add build-base
 RUN mkdir /build
 WORKDIR /build


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Sets the github deploy sha for backend services and lambdas such that the service version is correctly populated (#6108).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Unsure without actually just merging this and validating it's set in clickhouse (see linked ticket #6168). I just copied the existing pattern for setting this for the frontend deploy so I assume it'll just work.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
