### PR TITLE
add more spans for datasync queue tuning

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -483,7 +483,7 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 		_wg.Done()
 	}(&wg)
 	go func(_wg *sync.WaitGroup) {
-		flushSize := 1000
+		flushSize := 500
 		buffer := &KafkaBatchBuffer{
 			messageQueue: make(chan *kafkaqueue.Message, flushSize+1),
 		}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -472,6 +472,7 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 					BatchBuffer:         buffer,
 					BatchFlushSize:      DefaultBatchFlushSize,
 					BatchedFlushTimeout: DefaultBatchedFlushTimeout,
+					Name:                "batched",
 				}
 				k.ProcessMessages(ctx, k.flushLogs)
 				wg.Done()
@@ -492,6 +493,7 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 			BatchBuffer:         buffer,
 			BatchFlushSize:      flushSize,
 			BatchedFlushTimeout: 5 * time.Second,
+			Name:                "datasync",
 		}
 		k.ProcessMessages(ctx, k.flushDataSync)
 		_wg.Done()

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -465,17 +465,15 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 		}
 		for i := 0; i < parallelBatchWorkers; i++ {
 			go func(workerId int) {
-				s, wCtx := tracer.StartSpanFromContext(ctx, "kafkaWorker", tracer.ResourceName("worker.kafka.batched.outer"))
-				defer s.Finish()
 				k := KafkaBatchWorker{
-					KafkaQueue:          kafkaqueue.New(wCtx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}), kafkaqueue.Consumer, nil),
+					KafkaQueue:          kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}), kafkaqueue.Consumer, nil),
 					Worker:              w,
 					WorkerThread:        workerId,
 					BatchBuffer:         buffer,
 					BatchFlushSize:      DefaultBatchFlushSize,
 					BatchedFlushTimeout: DefaultBatchedFlushTimeout,
 				}
-				k.ProcessMessages(wCtx, k.flushLogs)
+				k.ProcessMessages(ctx, k.flushLogs)
 				wg.Done()
 			}(i)
 		}
@@ -487,17 +485,15 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 		buffer := &KafkaBatchBuffer{
 			messageQueue: make(chan *kafkaqueue.Message, flushSize+1),
 		}
-		s, wCtx := tracer.StartSpanFromContext(ctx, "kafkaWorker", tracer.ResourceName("worker.kafka.datasync.outer"))
-		defer s.Finish()
 		k := KafkaBatchWorker{
-			KafkaQueue:          kafkaqueue.New(wCtx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}), kafkaqueue.Consumer, &kafka.ReaderConfig{QueueCapacity: 1000}),
+			KafkaQueue:          kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}), kafkaqueue.Consumer, &kafka.ReaderConfig{QueueCapacity: 1000}),
 			Worker:              w,
 			WorkerThread:        0,
 			BatchBuffer:         buffer,
 			BatchFlushSize:      flushSize,
 			BatchedFlushTimeout: 5 * time.Second,
 		}
-		k.ProcessMessages(wCtx, k.flushDataSync)
+		k.ProcessMessages(ctx, k.flushDataSync)
 		_wg.Done()
 	}(&wg)
 	wg.Wait()


### PR DESCRIPTION
## Summary
- fixes issue where top level span wasn't finished
- add more spans in the datasync flush function
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor in prod after deploying
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
