### PR TITLE
prevent next sdk from stopping build due to sourcemaps missing

### DIFF
--- a/sdk/highlight-apollo/CHANGELOG.md
+++ b/sdk/highlight-apollo/CHANGELOG.md
@@ -13,3 +13,7 @@
 ### 3.1.6
 
 - Bumping to match `@highlight-run/node`
+
+### 3.1.7
+
+- Bumping to match `@highlight-run/node`

--- a/sdk/highlight-apollo/package.json
+++ b/sdk/highlight-apollo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/apollo",
-	"version": "3.1.6",
+	"version": "3.1.7",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-nest/CHANGELOG.md
+++ b/sdk/highlight-nest/CHANGELOG.md
@@ -19,3 +19,7 @@
 ### 3.1.6
 
 - Bumping to match `@highlight-run/node`
+
+### 3.1.7
+
+- Bumping to match `@highlight-run/node`

--- a/sdk/highlight-nest/package.json
+++ b/sdk/highlight-nest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/nest",
-	"version": "3.1.6",
+	"version": "3.1.7",
 	"description": "Client for interfacing with Highlight in nestjs",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "3.1.6",
+	"version": "3.1.7",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-next/src/util/highlightWebpackPlugin.ts
+++ b/sdk/highlight-next/src/util/highlightWebpackPlugin.ts
@@ -25,6 +25,7 @@ export default class HighlightWebpackPlugin {
 				appVersion: this.appVersion,
 				path: this.path,
 				basePath: this.basePath,
+				allowNoop: true,
 			})
 		})
 		return compiler

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "3.1.6",
+	"version": "3.1.7",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sourcemap-uploader/src/lib.ts
+++ b/sourcemap-uploader/src/lib.ts
@@ -21,11 +21,13 @@ export const uploadSourcemaps = async ({
   appVersion,
   path,
   basePath,
+  allowNoop,
 }: {
   apiKey: string;
   appVersion: string;
   path: string;
   basePath: string;
+  allowNoop?: boolean;
 }) => {
   if (!apiKey || apiKey === "") {
     if (process.env.HIGHLIGHT_SOURCEMAP_UPLOAD_API_KEY) {
@@ -71,7 +73,7 @@ export const uploadSourcemaps = async ({
 
   console.info(`Starting to upload source maps from ${path}`);
 
-  const fileList = await getAllSourceMapFiles([path]);
+  const fileList = await getAllSourceMapFiles([path], { allowNoop });
 
   if (fileList.length === 0) {
     console.error(
@@ -124,7 +126,10 @@ export const uploadSourcemaps = async ({
   );
 };
 
-async function getAllSourceMapFiles(paths: string[]) {
+async function getAllSourceMapFiles(
+  paths: string[],
+  { allowNoop }: { allowNoop?: boolean }
+) {
   const map: { path: string; name: string }[] = [];
 
   await Promise.all(
@@ -141,6 +146,7 @@ async function getAllSourceMapFiles(paths: string[]) {
       }
 
       if (
+        !allowNoop &&
         !globSync("**/*.js.map", {
           cwd: realPath,
           nodir: true,


### PR DESCRIPTION
## Summary

A recent change broke how the node SDK would upload sourcemaps because
we would be triggering the upload more than once in webpack, but at the time of some of the
triggers, the sourcemaps were not yet generated.
Context: https://discord.com/channels/1026884757667188757/1133401705212563536

## How did you test this change?

highlight.io preview uploading sourcemaps

## Are there any deployment considerations?

New SDK versions released.
