### PR TITLE
catch possible nil dereferences

### DIFF
--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -2,7 +2,6 @@ package clickhouse
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -36,17 +35,24 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 	}
 
 	for _, session := range sessions {
+		if session == nil {
+			return fmt.Errorf("nil session for session %d", session.ID)
+		}
+
 		if session.Fields == nil {
-			return errors.New("session.Fields is required")
+			return fmt.Errorf("session.Fields is required for session %d", session.ID)
 		}
 
 		if session.ViewedByAdmins == nil {
-			return errors.New("session.ViewedByAdmins is required")
+			return fmt.Errorf("session.ViewedByAdmins is required for session %d", session.ID)
 		}
 
 		fieldKeys := []string{}
 		fieldKeyValues := []string{}
 		for _, field := range session.Fields {
+			if field == nil {
+				return fmt.Errorf("nil field for session %d", session.ID)
+			}
 			fieldKeys = append(fieldKeys, field.Type+"_"+field.Name)
 			fieldKeyValues = append(fieldKeyValues, field.Type+"_"+field.Name+"_"+field.Value)
 		}

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -36,7 +37,7 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 
 	for _, session := range sessions {
 		if session == nil {
-			return fmt.Errorf("nil session for session %d", session.ID)
+			return errors.New("nil session")
 		}
 
 		if session.Fields == nil {


### PR DESCRIPTION
## Summary
- seeing panics when dereferencing nil fields in the datasync code that eventually causes all the datasync workers to die out
- weird that these fields are nil so I'll investigate more
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor in prod
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
