### PR TITLE
queue datasync messages async

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -55,6 +55,7 @@ import (
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 	"github.com/leonelquinteros/hubspot"
+	"github.com/openlyinc/pointy"
 	e "github.com/pkg/errors"
 	"github.com/rs/cors"
 	"github.com/sendgrid/sendgrid-go"
@@ -324,7 +325,10 @@ func main() {
 
 	kafkaProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDefault}), kafkaqueue.Producer, nil)
 	kafkaBatchedProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}), kafkaqueue.Producer, nil)
-	kafkaDataSyncProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}), kafkaqueue.Producer, nil)
+	kafkaDataSyncProducer := kafkaqueue.New(ctx,
+		kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}),
+		kafkaqueue.Producer,
+		&kafkaqueue.ConfigOverride{Async: pointy.Bool(true)})
 
 	opensearchClient, err := opensearch.NewOpensearchClient(db)
 	if err != nil {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -39,7 +39,6 @@ import (
 	"github.com/openlyinc/pointy"
 	"github.com/pkg/errors"
 	e "github.com/pkg/errors"
-	"github.com/segmentio/kafka-go"
 	"github.com/shirou/gopsutil/mem"
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
@@ -461,7 +460,10 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 			messageQueue: make(chan *kafkaqueue.Message, DefaultBatchFlushSize),
 		}
 		k := KafkaBatchWorker{
-			KafkaQueue:          kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}), kafkaqueue.Consumer, &kafka.ReaderConfig{QueueCapacity: 2 * DefaultBatchFlushSize}),
+			KafkaQueue: kafkaqueue.New(ctx,
+				kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}),
+				kafkaqueue.Consumer,
+				&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(2 * DefaultBatchFlushSize)}),
 			Worker:              w,
 			BatchBuffer:         buffer,
 			BatchFlushSize:      DefaultBatchFlushSize,
@@ -477,7 +479,10 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 			messageQueue: make(chan *kafkaqueue.Message, flushSize+1),
 		}
 		k := KafkaBatchWorker{
-			KafkaQueue:          kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}), kafkaqueue.Consumer, &kafka.ReaderConfig{QueueCapacity: 2 * flushSize}),
+			KafkaQueue: kafkaqueue.New(ctx,
+				kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}),
+				kafkaqueue.Consumer,
+				&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(2 * flushSize)}),
 			Worker:              w,
 			WorkerThread:        0,
 			BatchBuffer:         buffer,


### PR DESCRIPTION
## Summary
- use the `Async` setting for the datasync producer
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ensured messages were still being submitted / processed locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
