### PR TITLE
Standardize the Histogram tooltip

### DIFF
--- a/frontend/src/components/Histogram/Histogram.tsx
+++ b/frontend/src/components/Histogram/Histogram.tsx
@@ -1,5 +1,5 @@
 import tinycolor from '@ctrl/tinycolor'
-import { Box, Text, vars } from '@highlight-run/ui'
+import { Box, Text, TooltipContent, vars } from '@highlight-run/ui'
 import { colors } from '@highlight-run/ui/src/css/colors'
 import moment from 'moment'
 import React, { useEffect, useMemo, useState } from 'react'
@@ -283,45 +283,43 @@ const CustomTooltip: React.FC<{
 	const currentTime = bucketTimes[label]
 
 	return (
-		<Box
-			alignItems="center"
-			borderRadius="6"
-			border="secondary"
-			display="flex"
-			gap="4"
-			p="4"
-			background="white"
-			onMouseOver={() => {
-				setTooltipWantHidden(false)
-			}}
-			onMouseLeave={() => {
-				setTooltipWantHidden(true)
-			}}
-		>
-			<Text color="n9" size="xSmall" weight="medium">
-				{moment(currentTime).format('MMM D')}
-			</Text>
+		<TooltipContent>
+			<Box
+				alignItems="center"
+				display="flex"
+				gap="4"
+				onMouseOver={() => {
+					setTooltipWantHidden(false)
+				}}
+				onMouseLeave={() => {
+					setTooltipWantHidden(true)
+				}}
+			>
+				<Text color="n9" size="xSmall" weight="medium">
+					{moment(currentTime).format('MMM D')}
+				</Text>
 
-			{payload.map((p, index) => {
-				const series = seriesList.find((s) => s.label === p.dataKey)
-				const color = series?.color || 'black'
-				const colorIsDark = tinycolor(p.color).getBrightness() < 165
-				const rawValue = p.payload[`${p.name}-raw`]
+				{payload.map((p, index) => {
+					const series = seriesList.find((s) => s.label === p.dataKey)
+					const color = series?.color || 'black'
+					const colorIsDark = tinycolor(p.color).getBrightness() < 165
+					const rawValue = p.payload[`${p.name}-raw`]
 
-				return (
-					<Box
-						key={index}
-						borderRadius="3"
-						backgroundColor={color}
-						p="4"
-					>
-						<Text color={colorIsDark ? 'white' : 'n12'}>
-							{rawValue} {p.name}
-						</Text>
-					</Box>
-				)
-			})}
-		</Box>
+					return (
+						<Box
+							key={index}
+							borderRadius="3"
+							backgroundColor={color}
+							p="4"
+						>
+							<Text color={colorIsDark ? 'white' : 'n12'}>
+								{rawValue} {p.name}
+							</Text>
+						</Box>
+					)
+				})}
+			</Box>
+		</TooltipContent>
 	)
 }
 

--- a/frontend/src/components/Histogram/Histogram.tsx
+++ b/frontend/src/components/Histogram/Histogram.tsx
@@ -312,7 +312,11 @@ const CustomTooltip: React.FC<{
 							backgroundColor={color}
 							p="4"
 						>
-							<Text color={colorIsDark ? 'white' : 'n12'}>
+							<Text
+								size="xSmall"
+								weight="medium"
+								color={colorIsDark ? 'white' : 'n12'}
+							>
 								{rawValue} {p.name}
 							</Text>
 						</Box>

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -42,14 +42,16 @@ export const Tooltip: React.FC<TooltipProps> = ({
 			</TooltipAnchor>
 			{!disabled && (
 				<AriakitTooltip state={tooltipState} style={{ zIndex: 100 }}>
-					<TooltipRenderer>{children}</TooltipRenderer>
+					<TooltipContent>{children}</TooltipContent>
 				</AriakitTooltip>
 			)}
 		</>
 	)
 }
 
-const TooltipRenderer: React.FC<React.PropsWithChildren> = ({ children }) => {
+export const TooltipContent: React.FC<React.PropsWithChildren> = ({
+	children,
+}) => {
 	return (
 		<Box
 			backgroundColor="white"

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -29,7 +29,7 @@ export { Tabs } from './Tabs/Tabs'
 export { Tag } from './Tag/Tag'
 export { Text } from './Text/Text'
 export { TextLink } from './TextLink/TextLink'
-export { Tooltip } from './Tooltip/Tooltip'
+export { Tooltip, TooltipContent } from './Tooltip/Tooltip'
 export * from './icons'
 
 // Expose Ariakit so you can access the building blocks if needed. Shouldn't be


### PR DESCRIPTION
## Summary
The histogram component uses Recharts tool tips that cannot be replaced by our UI package `Tooltip`. We can replace the content with the UI package `TooltipContent` to standardize the designs of the tooltips used throughout the app.

## How did you test this change?
1. View the sessions page.
2. Hover over the histogram below the Search results
- [ ] Tooltip is displayed and matches the UI component designs
3. View the errors page.
4. Hover over the histogram below the Search results
- [ ] Tooltip is displayed and matches the UI component designs

![Screenshot 2023-08-01 at 2 04 41 PM](https://github.com/highlight/highlight/assets/17744174/1e418c12-cb35-4590-a9cc-4b75e43bc912)

## Are there any deployment considerations?
N/A
