### PR TITLE
fix unpkg export

### DIFF
--- a/e2e/html/index.html
+++ b/e2e/html/index.html
@@ -6,6 +6,7 @@
 		<meta http-equiv="X-UA-Compatible" content="ie=edge" />
 		<title>Highlight HTML</title>
 		<style></style>
+		<!-- UNCOMMENT THE FOLLOWING TO TEST UNPKG BUNDLE -->
 		<!-- <script src="https://unpkg.com/highlight.run"></script> -->
 		<script src="http://localhost:8888/dist/index.umd.cjs"></script>
 		<script>

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -329,3 +329,15 @@ Reserved for the Boeing 737
 ### Patch Changes
 
 - Improve `canvasInitialSnapshotDelay` logic for `<canvas>` recording to delay per-canvas.
+
+## 7.3.12
+
+### Patch Changes
+
+- Update naming of exports for Remix compatability.
+
+## 7.3.13
+
+### Patch Changes
+
+- Fix export names for unpkg / jsdelivr.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.3.12",
+	"version": "7.3.13",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",
@@ -25,7 +25,8 @@
 		}
 	},
 	"scripts": {
-		"build": "yarn typegen && vite build",
+		"build": "yarn typegen && vite build && vite build:umd",
+		"build:umd": "cp dist/index.umd.cjs dist/index.umd.js",
 		"build:watch": "yarn build --watch",
 		"dev": "vite dev",
 		"dev:watch": "run-p dev build:watch",
@@ -35,8 +36,8 @@
 	},
 	"type": "module",
 	"main": "./dist/index.js",
-	"unpkg": "./dist/index.umd.cjs",
-	"jsdelivr": "./dist/index.umd.cjs",
+	"unpkg": "./dist/index.umd.js",
+	"jsdelivr": "./dist/index.umd.js",
 	"types": "./dist/firstload/src/index.d.ts",
 	"exports": {
 		"types": "./dist/firstload/src/index.d.ts",

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -25,7 +25,7 @@
 		}
 	},
 	"scripts": {
-		"build": "yarn typegen && vite build && vite build:umd",
+		"build": "yarn typegen && vite build && yarn build:umd",
 		"build:umd": "cp dist/index.umd.cjs dist/index.umd.js",
 		"build:watch": "yarn build --watch",
 		"dev": "vite dev",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.3.12"
+export default "7.3.13"


### PR DESCRIPTION
## Summary

Unpkg does not like `.cjs` files because it does not treat them as browser-javascript.
See https://highlightcorp.slack.com/archives/C02N2AZS8BV/p1690917075492479 for full context.

## How did you test this change?

Will be testing with the `e2e/html` unpkg script.

## Are there any deployment considerations?

New firstload package version.
