### PR TITLE
Use multi select component on session log filters

### DIFF
--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -7,7 +7,6 @@ import {
 	IconSolidLogs,
 	IconSolidSearch,
 	IconSolidSwitchHorizontal,
-	MenuButton,
 	Tabs,
 	Text,
 	useFormState,
@@ -27,6 +26,7 @@ import {
 } from '@pages/Player/Toolbar/DevToolsWindowV2/ResizePanel'
 import {
 	LogLevelValue,
+	LogSourceValue,
 	RequestStatus,
 	RequestType,
 	Tab,
@@ -37,6 +37,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 
 import { useLinkLogCursor } from '@/pages/Player/PlayerHook/utils'
+import { LogSourceFilter } from '@/pages/Player/Toolbar/DevToolsWindowV2/LogSourceFilter/LogSourceFilter'
 import { styledVerticalScrollbar } from '@/style/common.css'
 
 import { ConsolePage } from './ConsolePage/ConsolePage'
@@ -45,8 +46,6 @@ import { LogLevelFilter } from './LogLevelFilter/LogLevelFilter'
 import { RequestStatusFilter } from './RequestStatusFilter/RequestStatusFilter'
 import { RequestTypeFilter } from './RequestTypeFilter/RequestTypeFilter'
 import * as styles from './style.css'
-
-const LogSourceValues = ['All', LogSource.Frontend, LogSource.Backend] as const
 
 const DevToolsWindowV2: React.FC<
 	React.PropsWithChildren & {
@@ -72,15 +71,20 @@ const DevToolsWindowV2: React.FC<
 	>([RequestStatus.All])
 
 	const [searchShown, setSearchShown] = React.useState<boolean>(false)
-	const [levels, setLevels] = React.useState<LogLevelValue[]>([])
-	const [sources, setSources] = React.useState<LogSource[]>(
-		logCursor ? [] : [LogSource.Frontend],
+	const [levels, setLevels] = React.useState<LogLevelValue[]>([
+		LogLevelValue.All,
+	])
+	const [sources, setSources] = React.useState<LogSourceValue[]>(
+		logCursor ? [] : [LogSourceValue.Frontend],
 	)
 
 	// filter out All values to send to via request
 	const relevantLevelsForRequest = levels.filter(
 		(level) => level !== LogLevelValue.All,
 	) as unknown as LogLevel[]
+	const relevantSourcesForRequest = sources.filter(
+		(level) => level !== LogSourceValue.All,
+	) as unknown as LogSource[]
 
 	const form = useFormState({
 		defaultValues: {
@@ -193,7 +197,7 @@ const DevToolsWindowV2: React.FC<
 											autoScroll={autoScroll}
 											logCursor={logCursor}
 											levels={relevantLevelsForRequest}
-											sources={sources}
+											sources={relevantSourcesForRequest}
 											filter={filter}
 										/>
 									),
@@ -283,35 +287,9 @@ const DevToolsWindowV2: React.FC<
 													logLevels={levels}
 													setLogLevels={setLevels}
 												/>
-												<MenuButton
-													divider
-													size="medium"
-													selectedKey={
-														sources.includes(
-															LogSource.Frontend,
-														)
-															? LogSource.Frontend
-															: 'All'
-													}
-													options={LogSourceValues.map(
-														(source) => ({
-															key: source,
-															render: (
-																<Text case="capital">
-																	{source}
-																</Text>
-															),
-														}),
-													)}
-													onChange={(source) => {
-														if (source === 'All') {
-															setSources([])
-														} else {
-															setSources([
-																source as LogSource,
-															])
-														}
-													}}
+												<LogSourceFilter
+													logSources={sources}
+													setLogSources={setSources}
 												/>
 											</>
 										) : selectedDevToolsTab ===
@@ -348,7 +326,8 @@ const DevToolsWindowV2: React.FC<
 													projectId,
 													session,
 													levels: relevantLevelsForRequest,
-													sources,
+													sources:
+														relevantSourcesForRequest,
 												})}
 												target="_blank"
 												style={{ display: 'flex' }}

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/LogLevelFilter/LogLevelFilter.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/LogLevelFilter/LogLevelFilter.tsx
@@ -1,5 +1,8 @@
 import { Box, IconSolidFilter, MultiSelectButton } from '@highlight-run/ui'
-import { LogLevelValue } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
+import {
+	LogLevelValue,
+	titilize,
+} from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import React from 'react'
 
 type Props = {
@@ -49,7 +52,7 @@ const LogLevelFilter = ({ logLevels, setLogLevels }: Props) => {
 		}
 
 		if (logLevels.length === 1) {
-			return `${FILTER_LABEL}: ${logLevels[0]}`
+			return `${FILTER_LABEL}: ${titilize(logLevels[0])}`
 		}
 
 		return `${FILTER_LABEL}: ${logLevels.length} selected`

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/LogLevelFilter/LogLevelFilter.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/LogLevelFilter/LogLevelFilter.tsx
@@ -43,8 +43,6 @@ const LogLevelFilter = ({ logLevels, setLogLevels }: Props) => {
 		),
 	}))
 
-	console.log('Options', options)
-
 	const valueRender = () => {
 		if (logLevels.includes(LogLevelValue.All)) {
 			return FILTER_LABEL

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/LogLevelFilter/LogLevelFilter.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/LogLevelFilter/LogLevelFilter.tsx
@@ -1,0 +1,73 @@
+import { Box, IconSolidFilter, MultiSelectButton } from '@highlight-run/ui'
+import { LogLevelValue } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
+import React from 'react'
+
+type Props = {
+	logLevels: LogLevelValue[]
+	setLogLevels: (values: LogLevelValue[]) => void
+}
+
+const FILTER_LABEL = 'Level'
+
+const LogLevelFilter = ({ logLevels, setLogLevels }: Props) => {
+	const handleRequestTypeChange = (valueNames: string[]) => {
+		const allPreviouslySelected = logLevels.includes(LogLevelValue.All)
+		const allCurrentlySelected = valueNames.includes(LogLevelValue.All)
+		const clearOtherTypes = !allPreviouslySelected && allCurrentlySelected
+		const deselectAllType = allPreviouslySelected && valueNames.length > 1
+
+		if (!valueNames.length || clearOtherTypes) {
+			return setLogLevels([LogLevelValue.All])
+		}
+
+		//-- Set type to be the logLevel value --//
+		const updatedLogLevels = valueNames.filter(
+			(name) => !deselectAllType || name !== LogLevelValue.All,
+		) as LogLevelValue[]
+
+		setLogLevels(updatedLogLevels)
+	}
+
+	const options = Object.entries(LogLevelValue).map(([logKey, logValue]) => ({
+		key: logValue,
+		clearsOnClick: logKey === LogLevelValue.All,
+		render: (
+			<Box
+				display="flex"
+				justifyContent="space-between"
+				width="full"
+				gap="8"
+			>
+				<span>{logKey}</span>
+			</Box>
+		),
+	}))
+
+	console.log('Options', options)
+
+	const valueRender = () => {
+		if (logLevels.includes(LogLevelValue.All)) {
+			return FILTER_LABEL
+		}
+
+		if (logLevels.length === 1) {
+			return `${FILTER_LABEL}: ${logLevels[0]}`
+		}
+
+		return `${FILTER_LABEL}: ${logLevels.length} selected`
+	}
+
+	return (
+		<MultiSelectButton
+			label={FILTER_LABEL}
+			icon={<IconSolidFilter />}
+			defaultValue={options[0].key}
+			value={logLevels}
+			valueRender={valueRender}
+			options={options}
+			onChange={handleRequestTypeChange}
+		/>
+	)
+}
+
+export { LogLevelFilter }

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/LogSourceFilter/LogSourceFilter.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/LogSourceFilter/LogSourceFilter.tsx
@@ -1,0 +1,73 @@
+import { Box, IconSolidFilter, MultiSelectButton } from '@highlight-run/ui'
+import { LogSourceValue } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
+import React from 'react'
+
+type Props = {
+	logSources: LogSourceValue[]
+	setLogSources: (values: LogSourceValue[]) => void
+}
+
+const FILTER_LABEL = 'Source'
+
+const LogSourceFilter = ({ logSources, setLogSources }: Props) => {
+	const handleRequestTypeChange = (valueNames: string[]) => {
+		const allPreviouslySelected = logSources.includes(LogSourceValue.All)
+		const allCurrentlySelected = valueNames.includes(LogSourceValue.All)
+		const clearOtherTypes = !allPreviouslySelected && allCurrentlySelected
+		const deselectAllType = allPreviouslySelected && valueNames.length > 1
+
+		if (!valueNames.length || clearOtherTypes) {
+			return setLogSources([LogSourceValue.All])
+		}
+
+		//-- Set type to be the logLevel value --//
+		const updatedLogSources = valueNames.filter(
+			(name) => !deselectAllType || name !== LogSourceValue.All,
+		) as LogSourceValue[]
+
+		setLogSources(updatedLogSources)
+	}
+
+	const options = Object.entries(LogSourceValue).map(
+		([logKey, logValue]) => ({
+			key: logValue,
+			clearsOnClick: logKey === LogSourceValue.All,
+			render: (
+				<Box
+					display="flex"
+					justifyContent="space-between"
+					width="full"
+					gap="8"
+				>
+					<span>{logKey}</span>
+				</Box>
+			),
+		}),
+	)
+
+	const valueRender = () => {
+		if (logSources.includes(LogSourceValue.All)) {
+			return FILTER_LABEL
+		}
+
+		if (logSources.length === 1) {
+			return `${FILTER_LABEL}: ${logSources[0]}`
+		}
+
+		return `${FILTER_LABEL}: ${logSources.length} selected`
+	}
+
+	return (
+		<MultiSelectButton
+			label={FILTER_LABEL}
+			icon={<IconSolidFilter />}
+			defaultValue={options[0].key}
+			value={logSources}
+			valueRender={valueRender}
+			options={options}
+			onChange={handleRequestTypeChange}
+		/>
+	)
+}
+
+export { LogSourceFilter }

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/LogSourceFilter/LogSourceFilter.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/LogSourceFilter/LogSourceFilter.tsx
@@ -1,5 +1,8 @@
 import { Box, IconSolidFilter, MultiSelectButton } from '@highlight-run/ui'
-import { LogSourceValue } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
+import {
+	LogSourceValue,
+	titilize,
+} from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import React from 'react'
 
 type Props = {
@@ -51,7 +54,7 @@ const LogSourceFilter = ({ logSources, setLogSources }: Props) => {
 		}
 
 		if (logSources.length === 1) {
-			return `${FILTER_LABEL}: ${logSources[0]}`
+			return `${FILTER_LABEL}: ${titilize(logSources[0])}`
 		}
 
 		return `${FILTER_LABEL}: ${logSources.length} selected`

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/RequestStatusFilter/RequestStatusFilter.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/RequestStatusFilter/RequestStatusFilter.tsx
@@ -145,7 +145,7 @@ const RequestStatusFilter = ({
 
 	return (
 		<MultiSelectButton
-			label="Status"
+			label={FILTER_LABEL}
 			icon={<IconSolidFilter />}
 			defaultValue={options[0].key}
 			value={requestStatuses}

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -98,9 +98,9 @@ export enum Tab {
 	Events = 'Events',
 }
 
-// TODO(spenny): use enum from schema with 'All' addition
 export enum LogLevelValue {
 	All = 'All',
+	// keep up to date with LogLevel schema
 	Debug = 'debug',
 	Error = 'error',
 	Fatal = 'fatal',
@@ -109,9 +109,9 @@ export enum LogLevelValue {
 	Warn = 'warn',
 }
 
-// TODO(spenny): use enum from schema with 'All' addition
 export enum LogSourceValue {
 	All = 'All',
+	// keep up to date with LogSource schema
 	Backend = 'backend',
 	Frontend = 'frontend',
 }
@@ -163,5 +163,9 @@ export const getNetworkResourcesDisplayName = (value: string): string => {
 			return displayName
 		}
 	}
+	return titilize(value)
+}
+
+export const titilize = (value: string): string => {
 	return value?.charAt(0).toUpperCase() + value?.slice(1)
 }

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -98,19 +98,16 @@ export enum Tab {
 	Events = 'Events',
 }
 
-export enum LogLevel {
+// TODO(spenny): use enum from schema with 'All' addition
+export enum LogLevelValue {
 	All = 'All',
-	Info = 'Info',
-	Warn = 'Warn',
-	Error = 'Error',
+	Debug = 'debug',
+	Error = 'error',
+	Fatal = 'fatal',
+	Info = 'info',
+	Trace = 'trace',
+	Warn = 'warn',
 }
-
-export const LogLevelVariants = {
-	[LogLevel.All]: 'white',
-	[LogLevel.Info]: 'white',
-	[LogLevel.Warn]: 'yellow',
-	[LogLevel.Error]: 'red',
-} as const
 
 export enum RequestType {
 	/* [displayName]: requestName */

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -109,6 +109,13 @@ export enum LogLevelValue {
 	Warn = 'warn',
 }
 
+// TODO(spenny): use enum from schema with 'All' addition
+export enum LogSourceValue {
+	All = 'All',
+	Backend = 'backend',
+	Frontend = 'frontend',
+}
+
 export enum RequestType {
 	/* [displayName]: requestName */
 	All = 'All',


### PR DESCRIPTION
## Summary
All users to select multiple levels and sources (soon to be services) on the log viewer of a session.

## How did you test this change?
1. View a session
2. Click into the DevTools, and switch to the Console Logs tab
3. Click around with the Level and Source filters
- [ ] Can select multiple types
- [ ] Selecting 'All' clears the selected types

![Screenshot 2023-08-01 at 5 27 12 PM](https://github.com/highlight/highlight/assets/17744174/fd2bc836-e2c7-4196-b589-fd75adc9beea)

## Are there any deployment considerations?
N/A
