### PR TITLE
improve performance of redis.CachedEval

### DIFF
--- a/backend/redis/cache.go
+++ b/backend/redis/cache.go
@@ -10,16 +10,15 @@ import (
 // CachedEval will return the value at cacheKey if it exists.
 // If it does not exist or is nil, CachedEval calls `fn()` to evaluate the result, and stores it at the cache key.
 func CachedEval[T any](ctx context.Context, redis *Client, cacheKey string, lockTimeout, cacheExpiration time.Duration, fn func() (*T, error)) (value *T, err error) {
-	// wait here to check the cache in case another process is waiting for db query
-	if acquired := redis.AcquireLock(ctx, cacheKey, lockTimeout); acquired {
-		defer func() {
-			if err := redis.ReleaseLock(ctx, cacheKey); err != nil {
-				log.WithContext(ctx).WithError(err).Error("failed to release lock")
-			}
-		}()
-	}
-
 	if err = redis.Cache.Get(ctx, cacheKey, &value); err != nil {
+		// if we do not have a cache hit, take a lock to avoid running fn() more than once
+		if acquired := redis.AcquireLock(ctx, cacheKey, lockTimeout); acquired {
+			defer func() {
+				if err := redis.ReleaseLock(ctx, cacheKey); err != nil {
+					log.WithContext(ctx).WithError(err).Error("failed to release lock")
+				}
+			}()
+		}
 		if value, err = fn(); value == nil || err != nil {
 			return
 		}

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -77,7 +77,7 @@ func NewClient() *Client {
 			redisClient: client,
 			Cache: cache.New(&cache.Options{
 				Redis:      client,
-				LocalCache: cache.NewTinyLFU(1000, time.Minute),
+				LocalCache: cache.NewTinyLFU(10000, time.Minute),
 			}),
 		}
 	} else {

--- a/backend/store/workspace_settings_test.go
+++ b/backend/store/workspace_settings_test.go
@@ -29,6 +29,6 @@ func BenchmarkStore_GetAllWorkspaceSettings(b *testing.B) {
 	s := model.AllWorkspaceSettings{WorkspaceID: 1}
 	store.db.Create(&s)
 	for i := 0; i < b.N; i++ {
-		store.GetAllWorkspaceSettings(context.Background(), 1)
+		_, _ = store.GetAllWorkspaceSettings(context.Background(), 1)
 	}
 }

--- a/backend/store/workspace_settings_test.go
+++ b/backend/store/workspace_settings_test.go
@@ -24,3 +24,11 @@ func TestGetAllWorkspaceSettings(t *testing.T) {
 		assert.Equal(t, 2, w2Settings.WorkspaceID)
 	})
 }
+
+func BenchmarkStore_GetAllWorkspaceSettings(b *testing.B) {
+	s := model.AllWorkspaceSettings{WorkspaceID: 1}
+	store.db.Create(&s)
+	for i := 0; i < b.N; i++ {
+		store.GetAllWorkspaceSettings(context.Background(), 1)
+	}
+}


### PR DESCRIPTION
## Summary

`redis.CachedEval` can't use the [local LRU cache](https://github.com/highlight/highlight/blob/32a1326ebbf152e713c4cb2c0d9c8f65084f656f/backend/redis/utils.go#L78-L81) because we would always be acquiring a lock.
 

## How did you test this change?

Before
<img width="694" alt="Screenshot 2023-08-02 at 10 36 00 AM" src="https://github.com/highlight/highlight/assets/1351531/196f2a23-e142-49f9-8991-fff31a0d2f79">

After
<img width="675" alt="Screenshot 2023-08-02 at 10 35 27 AM" src="https://github.com/highlight/highlight/assets/1351531/3532d136-1e0c-4ec8-b00a-9aca9d630dda">


## Are there any deployment considerations?

No