### PR TITLE
fix getting slack channels

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -3104,25 +3104,26 @@ func (r *Resolver) GetSlackChannelsFromSlack(ctx context.Context, workspaceId in
 			Limit: 1000,
 			// public_channel is for public channels in the Slack workspace
 			// private is for private channels in the Slack workspace that the Bot is included in
-			// im is for all individuals in the Slack workspace
 			// mpim is for multi-person conversations in the Slack workspace that the Bot is included in
-			Types: []string{"public_channel", "private_channel", "mpim", "im"},
+			Types: []string{"public_channel", "private_channel", "mpim"},
 		}
 		allSlackChannelsFromAPI := []slack.Channel{}
 
 		// Slack paginates the channels/people listing.
 		for {
 			channels, cursor, err := slackClient.GetConversations(&getConversationsParam)
+			getConversationsParam.Cursor = cursor
 			if err != nil {
 				return nil, e.Wrap(err, "error getting Slack channels from Slack.")
 			}
 
 			allSlackChannelsFromAPI = append(allSlackChannelsFromAPI, channels...)
 
-			if cursor == "" {
+			if getConversationsParam.Cursor == "" {
 				break
 			}
-
+			// delay the next slack call to avoid getting rate limited
+			time.Sleep(time.Second)
 		}
 
 		// We need to get the users in the Slack channel in order to get their name.

--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/highlight-run/highlight/backend/opensearch"
 	"github.com/highlight-run/highlight/backend/redis"
 	"github.com/highlight-run/highlight/backend/store"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"strconv"
 	"testing"
@@ -546,4 +547,20 @@ func TestResolver_isAdminInProjectOrDemoProject(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetSlackChannelsFromSlack(t *testing.T) {
+	util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
+		w := model.Workspace{SlackAccessToken: pointy.String(os.Getenv("TEST_SLACK_ACCESS_TOKEN"))}
+		if err := DB.Create(&w).Error; err != nil {
+			t.Fatal(e.Wrap(err, "error inserting workspace"))
+		}
+
+		r := &queryResolver{Resolver: &Resolver{DB: DB, Redis: redis.NewClient()}}
+		channels, count, err := r.GetSlackChannelsFromSlack(context.Background(), w.ID)
+		assert.NoError(t, err)
+		assert.NotNil(t, channels)
+		assert.Greater(t, count, 0)
+		assert.Greater(t, len(*channels), 0)
+	})
 }

--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -550,8 +550,12 @@ func TestResolver_isAdminInProjectOrDemoProject(t *testing.T) {
 }
 
 func TestGetSlackChannelsFromSlack(t *testing.T) {
+	token := os.Getenv("TEST_SLACK_ACCESS_TOKEN")
+	if token == "" {
+		t.Skip("TEST_SLACK_ACCESS_TOKEN is not set")
+	}
 	util.RunTestWithDBWipe(t, DB, func(t *testing.T) {
-		w := model.Workspace{SlackAccessToken: pointy.String(os.Getenv("TEST_SLACK_ACCESS_TOKEN"))}
+		w := model.Workspace{SlackAccessToken: pointy.String(token)}
 		if err := DB.Create(&w).Error; err != nil {
 			t.Fatal(e.Wrap(err, "error inserting workspace"))
 		}


### PR DESCRIPTION
## Summary

Our slack channel fetching code had a bug if a workspace had more than 1k channels.
We would infinitely loop fetching more channels rather than using the cursor.

## How did you test this change?

Adds a test, locally tested with access key of customer that was affected.

## Are there any deployment considerations?

No
