### PR TITLE
create service record on log ingest

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1993,10 +1993,13 @@ func (obj *SessionAlert) SendAlerts(ctx context.Context, db *gorm.DB, mailClient
 
 type Service struct {
 	Model
-	ProjectID      int                       `gorm:"not null;uniqueIndex:idx_project_id_name"`
-	Name           string                    `gorm:"not null;uniqueIndex:idx_project_id_name"`
-	Status         modelInputs.ServiceStatus `gorm:"not null;default:created"`
-	GithubRepoPath *string
+	ProjectID          int                       `gorm:"not null;uniqueIndex:idx_project_id_name"`
+	Name               string                    `gorm:"not null;uniqueIndex:idx_project_id_name"`
+	Status             modelInputs.ServiceStatus `gorm:"not null;default:created"`
+	GithubRepoPath     *string
+	ProcessName        *string
+	ProcessVersion     *string
+	ProcessDescription *string
 }
 
 type LogAlert struct {

--- a/backend/store/services.go
+++ b/backend/store/services.go
@@ -8,10 +8,23 @@ import (
 	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/queryparser"
 	"github.com/samber/lo"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 )
 
-func (store *Store) FindOrCreateService(project model.Project, name string) (model.Service, error) {
+func (store *Store) FindOrCreateService(project model.Project, name string, attributes map[string]string) (model.Service, error) {
 	var service model.Service
+
+	if val, ok := attributes[string(semconv.ProcessRuntimeNameKey)]; ok {
+		service.ProcessName = &val
+	}
+
+	if val, ok := attributes[string(semconv.ProcessRuntimeVersionKey)]; ok {
+		service.ProcessVersion = &val
+	}
+
+	if val, ok := attributes[string(semconv.ProcessRuntimeDescriptionKey)]; ok {
+		service.ProcessDescription = &val
+	}
 
 	err := store.db.Where(&model.Service{
 		ProjectID: project.ID,

--- a/backend/store/services_test.go
+++ b/backend/store/services_test.go
@@ -18,14 +18,32 @@ func TestFindOrCreateService(t *testing.T) {
 		project := model.Project{}
 		store.db.Create(&project)
 
-		service, err := store.FindOrCreateService(project, "public-graph")
+		service, err := store.FindOrCreateService(project, "public-graph", map[string]string{})
 		assert.NoError(t, err)
 
 		assert.NotNil(t, service.ID)
 
-		foundService, err := store.FindOrCreateService(project, "public-graph")
+		foundService, err := store.FindOrCreateService(project, "public-graph", map[string]string{})
 		assert.NoError(t, err)
 		assert.Equal(t, service.ID, foundService.ID)
+	})
+}
+
+func TestFindOrCreateServiceWithAttributes(t *testing.T) {
+	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
+		project := model.Project{}
+		store.db.Create(&project)
+
+		service, err := store.FindOrCreateService(project, "public-graph", map[string]string{
+			"process.runtime.name":        "go",
+			"process.runtime.version":     "go1.20.5",
+			"process.runtime.description": "go version go1.20.5 darwin/arm64",
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, service.ID)
+		assert.Equal(t, ptr.String("go"), service.ProcessName)
+		assert.Equal(t, ptr.String("go1.20.5"), service.ProcessVersion)
+		assert.Equal(t, ptr.String("go version go1.20.5 darwin/arm64"), service.ProcessDescription)
 	})
 }
 

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -222,6 +222,17 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context) {
 		if !strings.HasPrefix(logRow.Body, "ENOENT: no such file or directory") && !strings.HasPrefix(logRow.Body, "connect ECONNREFUSED") {
 			filteredRows = append(filteredRows, logRow)
 		}
+
+		if logRow.ServiceName != "" {
+			project, err := k.Worker.Resolver.Store.GetProject(int(logRow.ProjectId))
+			if err == nil {
+				_, err := k.Worker.Resolver.Store.FindOrCreateService(project, logRow.ServiceName, logRow.LogAttributes)
+
+				if err != nil {
+					log.WithContext(ctx).Error(e.Wrap(err, "failed to create service"))
+				}
+			}
+		}
 	}
 
 	wSpan, wCtx := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.batched.process"))


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR creates a service record when we process a log along with `process.*` data ([docs](https://opentelemetry.io/docs/specs/otel/resource/semantic_conventions/process/#process-runtimes)). We plan to only use `process.name` on the frontend (to show a logo of the language) but we are storing all the data in case we need it later on.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed I have one service record:
![Screenshot 2023-08-02 at 12 55 51 PM](https://github.com/highlight/highlight/assets/58678/9b016015-42e7-4f8a-ba39-a5f95639565f)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
