### PR TITLE
Add service config to python SDK

### DIFF
--- a/docs-content/sdk/go.md
+++ b/docs-content/sdk/go.md
@@ -20,10 +20,20 @@ slug: go
   <div className="left">
     <h3>highlight.Start()</h3>
     <p>Starts the background goroutine for transmitting metrics and errors.</p>
+    <h6>Options</h6>
+    <aside className="parameter">
+      <h5><code>WithServiceName</code> <code>optional</code></h5>
+      <p>The name of your app.</p>
+      <h5><code>WithServiceVersion</code> <code>optional</code></h5>
+      <p>The version of this app. We recommend setting this to the most recent deploy SHA of your app.</p>
+    </aside>
   </div>
   <div className="right">
     <code>
-        highlight.Start()
+        highlight.Start(
+          highlight.WithServiceName("my-app"),
+          highlight.WithServiceVersion("1.0.0"),
+        )
     </code>
   </div>
 </section>
@@ -39,12 +49,22 @@ This allows the user kill the highlight worker by canceling their context.Cancel
       <h5>ctx <code>context.Context</code> <code>required</code></h5>
       <p>The context provided for starting the Highlight daemon.</p>
     </aside>
+    <h6>Options</h6>
+    <aside className="parameter">
+      <h5><code>WithServiceName</code> <code>optional</code></h5>
+      <p>The name of your app.</p>
+      <h5><code>WithServiceVersion</code> <code>optional</code></h5>
+      <p>The version of this app. We recommend setting this to the most recent deploy SHA of your app.</p>
+    </aside>
   </div>
   <div className="right">
     <code>
         ctx := context.Background()
         ...
-        highlight.startWithContext(ctx)
+        highlight.startWithContext(ctx,
+          highlight.WithServiceName("my-app"),
+          highlight.WithServiceVersion("1.0.0"),
+        )
     </code>
   </div>
 </section>

--- a/docs-content/sdk/go.md
+++ b/docs-content/sdk/go.md
@@ -32,7 +32,7 @@ slug: go
     <code>
         highlight.Start(
           highlight.WithServiceName("my-app"),
-          highlight.WithServiceVersion("1.0.0"),
+          highlight.WithServiceVersion("git-sha"),
         )
     </code>
   </div>
@@ -63,7 +63,7 @@ This allows the user kill the highlight worker by canceling their context.Cancel
         ...
         highlight.startWithContext(ctx,
           highlight.WithServiceName("my-app"),
-          highlight.WithServiceVersion("1.0.0"),
+          highlight.WithServiceVersion("git-sha"),
         )
     </code>
   </div>

--- a/docs-content/sdk/python.md
+++ b/docs-content/sdk/python.md
@@ -62,7 +62,7 @@ slug: python
           integrations=[FlaskIntegration()],
           instrument_logging=True,
           service_name="my-flask-app",
-          service_version="1.0.0", 
+          service_version="git-sha", 
         )
     </code>
     In Django, you'll add Highlight to your settings.py file:
@@ -74,7 +74,7 @@ slug: python
           integrations=[DjangoIntegration()],
           instrument_logging=True,
           service_name="my-django-app",
-          service_version="1.0.0", 
+          service_version="git-sha", 
         )
     </code>
     In FastAPI, you'll add Highlight as a middleware:
@@ -85,7 +85,7 @@ slug: python
           "<YOUR_PROJECT_ID>",
           instrument_logging=True,
           service_name="my-fastapi-app",
-          service_version="1.0.0", 
+          service_version="git-sha", 
         )
         app = FastAPI()
         app.add_middleware(FastAPIMiddleware)

--- a/docs-content/sdk/python.md
+++ b/docs-content/sdk/python.md
@@ -42,6 +42,14 @@ slug: python
       <h5>instrument_logging<code>boolean</code> <code>optional</code></h5>
       <p>If enabled, Highlight will record log output from the logging module.</p>
     </aside>
+    <aside className="parameter">
+      <h5>service_name<code>string</code> <code>optional</code></h5>
+      <p>The name of your app.</p>
+    </aside>
+    <aside className="parameter">
+      <h5>service_version<code>string</code> <code>optional</code></h5>
+      <p>The version of this app. We recommend setting this to the most recent deploy SHA of your app.</p>
+    </aside>
   </div>
   <div className="right">
     In Flask, you'll add Highlight in your main app.py entrypoint.
@@ -49,19 +57,36 @@ slug: python
         import highlight_io
         from highlight_io.integrations.flask import FlaskIntegration
         app = Flask('test-app')
-        H = highlight_io.H("<YOUR_PROJECT_ID>", integrations=[FlaskIntegration()], instrument_logging=True)
+        H = highlight_io.H(
+          "<YOUR_PROJECT_ID>",
+          integrations=[FlaskIntegration()],
+          instrument_logging=True,
+          service_name="my-flask-app",
+          service_version="1.0.0", 
+        )
     </code>
     In Django, you'll add Highlight to your settings.py file:
     <code>
         import highlight_io
         from highlight_io.integrations.django import DjangoIntegration
-        H = highlight_io.H("<YOUR_PROJECT_ID>", integrations=[DjangoIntegration()], instrument_logging=True)
+        H = highlight_io.H(
+          "<YOUR_PROJECT_ID>",
+          integrations=[DjangoIntegration()],
+          instrument_logging=True,
+          service_name="my-django-app",
+          service_version="1.0.0", 
+        )
     </code>
     In FastAPI, you'll add Highlight as a middleware:
     <code>
         import highlight_io
         from highlight_io.integrations.fastapi import FastAPIMiddleware
-        H = highlight_io.H("<YOUR_PROJECT_ID>", instrument_logging=True)
+        H = highlight_io.H(
+          "<YOUR_PROJECT_ID>",
+          instrument_logging=True,
+          service_name="my-fastapi-app",
+          service_version="1.0.0", 
+        )
         app = FastAPI()
         app.add_middleware(FastAPIMiddleware)
     </code>

--- a/highlight.io/components/QuickstartContent/backend/go/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/backend/go/shared-snippets.tsx
@@ -25,7 +25,10 @@ export const initializeGoSdk: QuickStartStep = {
 func main() {
   // ...
   highlight.SetProjectID("<YOUR_PROJECT_ID>")
-  highlight.Start()
+  highlight.Start(
+	highlight.WithServiceName("my-app"),
+	highlight.WithServiceVersion("1.0.0"),
+  )
   defer highlight.Stop()
   // ...
 }`,

--- a/highlight.io/components/QuickstartContent/backend/go/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/backend/go/shared-snippets.tsx
@@ -27,7 +27,7 @@ func main() {
   highlight.SetProjectID("<YOUR_PROJECT_ID>")
   highlight.Start(
 	highlight.WithServiceName("my-app"),
-	highlight.WithServiceVersion("1.0.0"),
+	highlight.WithServiceVersion("git-sha"),
   )
   defer highlight.Stop()
   // ...

--- a/highlight.io/components/QuickstartContent/backend/python/django.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/django.tsx
@@ -30,7 +30,7 @@ H = highlight_io.H(
 	integrations=[DjangoIntegration()],
 	instrument_logging=True,
 	service_name="my-django-app",
-	service_version="1.0.0",
+	service_version="git-sha",
 )`,
 					language: 'python',
 				},

--- a/highlight.io/components/QuickstartContent/backend/python/django.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/django.tsx
@@ -25,7 +25,13 @@ from highlight_io.integrations.django import DjangoIntegration
 
 # \`instrument_logging=True\` sets up logging instrumentation.
 # if you do not want to send logs or are using \`loguru\`, pass \`instrument_logging=False\`
-H = highlight_io.H("<YOUR_PROJECT_ID>", integrations=[DjangoIntegration()], instrument_logging=True)`,
+H = highlight_io.H(
+	"<YOUR_PROJECT_ID>",
+	integrations=[DjangoIntegration()],
+	instrument_logging=True,
+	service_name="my-django-app",
+	service_version="1.0.0",
+)`,
 					language: 'python',
 				},
 			],

--- a/highlight.io/components/QuickstartContent/backend/python/flask.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/flask.tsx
@@ -33,7 +33,7 @@ H = highlight_io.H(
 	integrations=[FlaskIntegration()],
 	instrument_logging=True,
 	service_name="my-flask-app",
-	service_version="1.0.0",
+	service_version="git-sha",
 )`,
 					language: 'python',
 				},
@@ -67,7 +67,7 @@ H = highlight_io.H(
 	integrations=[FlaskIntegration()],
 	instrument_logging=True,
 	service_name="my-flask-app",
-	service_version="1.0.0",
+	service_version="git-sha",
 )
 
 

--- a/highlight.io/components/QuickstartContent/backend/python/flask.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/flask.tsx
@@ -28,7 +28,13 @@ app = Flask(__name__)
 
 # \`instrument_logging=True\` sets up logging instrumentation.
 # if you do not want to send logs or are using \`loguru\`, pass \`instrument_logging=False\`
-H = highlight_io.H("<YOUR_PROJECT_ID>", integrations=[FlaskIntegration()], instrument_logging=True)`,
+H = highlight_io.H(
+	"<YOUR_PROJECT_ID>",
+	integrations=[FlaskIntegration()],
+	instrument_logging=True,
+	service_name="my-flask-app",
+	service_version="1.0.0",
+)`,
 					language: 'python',
 				},
 			],
@@ -56,7 +62,13 @@ app = Flask(__name__)
 
 # \`instrument_logging=True\` sets up logging instrumentation.
 # if you do not want to send logs or are using \`loguru\`, pass \`instrument_logging=False\`
-H = highlight_io.H("<YOUR_PROJECT_ID>", integrations=[FlaskIntegration()], instrument_logging=True)
+H = highlight_io.H(
+	"<YOUR_PROJECT_ID>",
+	integrations=[FlaskIntegration()],
+	instrument_logging=True,
+	service_name="my-flask-app",
+	service_version="1.0.0",
+)
 
 
 @app.route("/hello")

--- a/highlight.io/components/QuickstartContent/backend/python/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/shared-snippets.tsx
@@ -57,5 +57,5 @@ H = highlight_io.H(
 	"<YOUR_PROJECT_ID>",
 	instrument_logging=True,
 	service_name="my-app",
-	service_version="1.0.0",
+	service_version="git-sha",
 )`

--- a/highlight.io/components/QuickstartContent/backend/python/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/shared-snippets.tsx
@@ -53,4 +53,9 @@ export const setupLogging: (slug: string) => QuickStartStep = (slug) => ({
 
 export const init = `# \`instrument_logging=True\` sets up logging instrumentation.
 # if you do not want to send logs or are using \`loguru\`, pass \`instrument_logging=False\`
-H = highlight_io.H("<YOUR_PROJECT_ID>", instrument_logging=True)`
+H = highlight_io.H(
+	"<YOUR_PROJECT_ID>",
+	instrument_logging=True,
+	service_name="my-app",
+	service_version="1.0.0",
+)`

--- a/highlight.io/components/QuickstartContent/logging/go/fiber.tsx
+++ b/highlight.io/components/QuickstartContent/logging/go/fiber.tsx
@@ -25,7 +25,7 @@ func main() {
   highlight.SetProjectID("<YOUR_PROJECT_ID>")
   highlight.Start(
     highlight.WithServiceName("my-fiber-app"),
-    highlight.WithServiceVersion("1.0.0"),
+    highlight.WithServiceVersion("git-sha"),
   )
   defer highlight.Stop()
 

--- a/highlight.io/components/QuickstartContent/logging/go/fiber.tsx
+++ b/highlight.io/components/QuickstartContent/logging/go/fiber.tsx
@@ -23,7 +23,10 @@ import (
 func main() {
   // setup the highlight SDK
   highlight.SetProjectID("<YOUR_PROJECT_ID>")
-  highlight.Start()
+  highlight.Start(
+    highlight.WithServiceName("my-fiber-app"),
+    highlight.WithServiceVersion("1.0.0"),
+  )
   defer highlight.Stop()
 
   // setup highlight logrus hook

--- a/highlight.io/components/QuickstartContent/logging/go/other.tsx
+++ b/highlight.io/components/QuickstartContent/logging/go/other.tsx
@@ -25,7 +25,7 @@ func main() {
   highlight.SetProjectID("<YOUR_PROJECT_ID>")
   highlight.Start(
     highlight.WithServiceName("my-app"),
-    highlight.WithServiceVersion("1.0.0"),
+    highlight.WithServiceVersion("git-sha"),
   )
   defer highlight.Stop()
 

--- a/highlight.io/components/QuickstartContent/logging/go/other.tsx
+++ b/highlight.io/components/QuickstartContent/logging/go/other.tsx
@@ -23,7 +23,10 @@ import (
 func main() {
   // setup the highlight SDK
   highlight.SetProjectID("<YOUR_PROJECT_ID>")
-  highlight.Start()
+  highlight.Start(
+    highlight.WithServiceName("my-app"),
+    highlight.WithServiceVersion("1.0.0"),
+  )
   defer highlight.Stop()
 
   // setup highlight logrus hook

--- a/highlight.io/components/QuickstartContent/logging/python/loguru.tsx
+++ b/highlight.io/components/QuickstartContent/logging/python/loguru.tsx
@@ -34,7 +34,12 @@ H = highlight_io.H("<YOUR_PROJECT_ID>", instrument_logging=False)`,
 					text: `import highlight_io
 from loguru import logger
 
-H = highlight_io.H("<YOUR_PROJECT_ID>", instrument_logging=False)
+H = highlight_io.H(
+	"<YOUR_PROJECT_ID>",
+	instrument_logging=False,
+	service_name="my-app",
+	service_version="1.0.0",
+)
 
 logger.add(
 	H.logging_handler,

--- a/highlight.io/components/QuickstartContent/logging/python/loguru.tsx
+++ b/highlight.io/components/QuickstartContent/logging/python/loguru.tsx
@@ -38,7 +38,7 @@ H = highlight_io.H(
 	"<YOUR_PROJECT_ID>",
 	instrument_logging=False,
 	service_name="my-app",
-	service_version="1.0.0",
+	service_version="git-sha",
 )
 
 logger.add(

--- a/sdk/highlight-py/CHANGELOG.md
+++ b/sdk/highlight-py/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## v0.5.4 (2023-08-02)
+
+### Feature
+
+- Added config options for `service_name` and `service_version`.
+
+### Fix
+
+### Tests

--- a/sdk/highlight-py/README.md
+++ b/sdk/highlight-py/README.md
@@ -6,3 +6,17 @@ This directory contains the source code for the Highlight Python SDK.
 
 The `e2e` directory contains supported Python frameworks integrated with our SDK for local development and testing.
 Do not use the snippets verbatim as they are configured for local development and will not work in production without changes.
+
+
+## Install
+
+* Install [poetry](https://python-poetry.org/docs/#installing-with-the-official-installer)
+* `poetry install`
+
+## Run tests
+
+* `poetry run pytest`
+
+## Lint
+
+* poetry run black  .

--- a/sdk/highlight-py/e2e/highlight_django/highlight_django/settings.py
+++ b/sdk/highlight-py/e2e/highlight_django/highlight_django/settings.py
@@ -130,4 +130,6 @@ H = highlight_io.H(
     integrations=[DjangoIntegration()],
     instrument_logging=True,
     otlp_endpoint="http://localhost:4318",
+    service_name="my-django-app",
+    service_version="git-sha"
 )

--- a/sdk/highlight-py/e2e/highlight_django/highlight_django/settings.py
+++ b/sdk/highlight-py/e2e/highlight_django/highlight_django/settings.py
@@ -131,5 +131,5 @@ H = highlight_io.H(
     instrument_logging=True,
     otlp_endpoint="http://localhost:4318",
     service_name="my-django-app",
-    service_version="git-sha"
+    service_version="git-sha",
 )

--- a/sdk/highlight-py/e2e/highlight_fastapi/main.py
+++ b/sdk/highlight-py/e2e/highlight_fastapi/main.py
@@ -12,7 +12,7 @@ H = highlight_io.H(
     instrument_logging=True,
     otlp_endpoint="http://localhost:4318",
     service_name="my-fastapi-app",
-    service_version="git-sha",
+    service_version="1.0.0",
 )
 
 app = FastAPI()

--- a/sdk/highlight-py/e2e/highlight_fastapi/main.py
+++ b/sdk/highlight-py/e2e/highlight_fastapi/main.py
@@ -12,7 +12,7 @@ H = highlight_io.H(
     instrument_logging=True,
     otlp_endpoint="http://localhost:4318",
     service_name="my-fastapi-app",
-    service_version="git-sha"
+    service_version="git-sha",
 )
 
 app = FastAPI()

--- a/sdk/highlight-py/e2e/highlight_fastapi/main.py
+++ b/sdk/highlight-py/e2e/highlight_fastapi/main.py
@@ -11,6 +11,8 @@ H = highlight_io.H(
     "1",
     instrument_logging=True,
     otlp_endpoint="http://localhost:4318",
+    service_name="my-fastapi-app",
+    service_version="git-sha"
 )
 
 app = FastAPI()

--- a/sdk/highlight-py/e2e/highlight_flask/app.py
+++ b/sdk/highlight-py/e2e/highlight_flask/app.py
@@ -14,7 +14,7 @@ H = highlight_io.H(
     instrument_logging=True,
     otlp_endpoint="http://localhost:4318",
     service_name="my-flask-app",
-    service_version="git-sha"
+    service_version="git-sha",
 )
 
 

--- a/sdk/highlight-py/e2e/highlight_flask/app.py
+++ b/sdk/highlight-py/e2e/highlight_flask/app.py
@@ -13,6 +13,8 @@ H = highlight_io.H(
     integrations=[FlaskIntegration()],
     instrument_logging=True,
     otlp_endpoint="http://localhost:4318",
+    service_name="my-flask-app",
+    service_version="git-sha"
 )
 
 

--- a/sdk/highlight-py/e2e/highlight_flask/app.py
+++ b/sdk/highlight-py/e2e/highlight_flask/app.py
@@ -14,7 +14,7 @@ H = highlight_io.H(
     instrument_logging=True,
     otlp_endpoint="http://localhost:4318",
     service_name="my-flask-app",
-    service_version="git-sha",
+    service_version="1.0.0",
 )
 
 

--- a/sdk/highlight-py/e2e/highlight_loguru/main.py
+++ b/sdk/highlight-py/e2e/highlight_loguru/main.py
@@ -5,7 +5,12 @@ import time
 import highlight_io
 from loguru import logger
 
-H = highlight_io.H("1", instrument_logging=False)
+H = highlight_io.H(
+    "1",
+    instrument_logging=False,
+    service_name="my-app",
+    service_version="1.0.0",
+)
 
 logger.add(
     H.logging_handler,

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -88,9 +88,7 @@ class H(object):
             service_name=service_name,
             service_version=service_version,
         )
-        self._trace_provider = TracerProvider(
-            resource=resource
-        )
+        self._trace_provider = TracerProvider(resource=resource)
         self._trace_provider.add_span_processor(
             BatchSpanProcessor(
                 OTLPSpanExporter(
@@ -325,6 +323,7 @@ class H(object):
 
         logging.setLogRecordFactory(factory)
         H._logging_instrumented = True
+
 
 def _build_resource(
     service_name: str,

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -16,6 +16,7 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.trace import TracerProvider, Span
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.trace import INVALID_SPAN
+from opentelemetry.sdk.resources import Attributes, Resource
 
 from highlight_io.integrations import Integration
 
@@ -56,6 +57,8 @@ class H(object):
         otlp_endpoint: str = "",
         instrument_logging: bool = True,
         log_level=logging.DEBUG,
+        service_name: str = "",
+        service_version: str = "",
     ):
         """
         Setup Highlight backend instrumentation.
@@ -69,6 +72,8 @@ class H(object):
         :param integrations: a list of Integrations that allow connecting with your framework, like Flask or Django.
         :param instrument_logging: defaults to True. set False to disable auto-instrumentation of python `logging` methods.
         :param otlp_endpoint: set to a custom otlp destination
+        :param service_name: a string to name this app
+        :param service_version: a string to set this app's version (typically a Git deploy sha).
         :return: a configured H instance
         """
         H._instance = self
@@ -79,7 +84,13 @@ class H(object):
         if instrument_logging:
             self._instrument_logging()
 
-        self._trace_provider = TracerProvider()
+        resource = _build_resource(
+            service_name=service_name,
+            service_version=service_version,
+        )
+        self._trace_provider = TracerProvider(
+            resource=resource
+        )
         self._trace_provider.add_span_processor(
             BatchSpanProcessor(
                 OTLPSpanExporter(
@@ -92,7 +103,9 @@ class H(object):
         trace.set_tracer_provider(self._trace_provider)
         self.tracer = trace.get_tracer(__name__)
 
-        self._log_provider = LoggerProvider()
+        self._log_provider = LoggerProvider(
+            resource=resource,
+        )
         self._log_provider.add_log_record_processor(
             BatchLogRecordProcessor(
                 OTLPLogExporter(
@@ -306,9 +319,22 @@ class H(object):
                 with manager:
                     return otel_factory(*args, **kwargs)
             except RecursionError:
-                # in case we are hitting a recusrive log from the `self.trace()` invocation
+                # in case we are hitting a recursive log from the `self.trace()` invocation
                 # (happens when we exceed the otel log queue depth)
                 return otel_factory(*args, **kwargs)
 
         logging.setLogRecordFactory(factory)
         H._logging_instrumented = True
+
+def _build_resource(
+    service_name: str,
+    service_version: str,
+) -> Resource:
+    attrs = {}
+
+    if service_name:
+        attrs["service.name"] = service_name
+    if service_version:
+        attrs["service.version"] = service_version
+
+    return Resource.create(attrs)

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.5.3"
+version = "0.5.4"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This adds support to the python SDK to specify service information (similar to what I did for Go, see #6108).

* Python docs added
* Go docs added

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Run the e2e flask app locally (`cd sdk/highlight-py/e2e/highlight_flask && poetry run flask run`) and confirmed logs and errors have `service_name` and `service_version` set:

![Screenshot 2023-08-03 at 11 17 07 AM](https://github.com/highlight/highlight/assets/58678/450757dd-bd29-4375-9515-3fda7b5b4b4a)

![Screenshot 2023-08-03 at 11 17 22 AM](https://github.com/highlight/highlight/assets/58678/ab4a80ae-0626-4010-8172-276af9dd6ec1)





Lots of docs added ([preview](https://highlight-landing-e4l9h1yo9-highlight-run.vercel.app/docs/general/welcome)).

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

* Python SDK should create a new release (`0.5.4`) automatically when merged ([source](https://github.com/highlight/highlight/blob/cea182f3a79d8c34d946b46cd5109c34bbb262f1/.github/workflows/python.yml#L46-L52)). See [package](https://pypi.org/project/highlight-io/) on pypi. 
* Will manually create git tag for releasing a new Go SDK (bumping up to `v0.9.10` from [last tag](https://github.com/highlight/highlight/releases/tag/sdk%2Fhighlight-go%2Fv0.9.9)).