### PR TITLE
increase batch size for batched processing perf

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -453,16 +453,16 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 	}(&wg)
 	go func(_wg *sync.WaitGroup) {
 		buffer := &KafkaBatchBuffer{
-			messageQueue: make(chan *kafkaqueue.Message, DefaultBatchFlushSize),
+			messageQueue: make(chan *kafkaqueue.Message, 4*DefaultBatchFlushSize),
 		}
 		k := KafkaBatchWorker{
 			KafkaQueue: kafkaqueue.New(ctx,
 				kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}),
 				kafkaqueue.Consumer,
-				&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(2 * DefaultBatchFlushSize)}),
+				&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(8 * DefaultBatchFlushSize)}),
 			Worker:              w,
 			BatchBuffer:         buffer,
-			BatchFlushSize:      DefaultBatchFlushSize,
+			BatchFlushSize:      4 * DefaultBatchFlushSize,
 			BatchedFlushTimeout: DefaultBatchedFlushTimeout,
 			Name:                "batched",
 		}


### PR DESCRIPTION
## Summary
- we have a backlog of 4m records in our batched topic
- try increasing the batch size to 4x what it was previously
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor in prod after deployment
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
