### PR TITLE
introduce concurrent flush workers for batched queues

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -427,66 +427,70 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 
 func (w *Worker) PublicWorker(ctx context.Context) {
 	const parallelWorkers = 64
+	const parallelBatchWorkers = 32
 	// creates N parallel kafka message consumers that process messages.
 	// each consumer is considered part of the same consumer group and gets
 	// allocated a slice of all partitions. this ensures that a particular subset of partitions
 	// is processed serially, so messages in that slice are processed in order.
 
 	wg := sync.WaitGroup{}
-	wg.Add(3)
-	go func(_wg *sync.WaitGroup) {
-		wg := sync.WaitGroup{}
-		wg.Add(parallelWorkers)
-		for i := 0; i < parallelWorkers; i++ {
-			go func(workerId int) {
-				k := KafkaWorker{
-					KafkaQueue:   kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDefault}), kafkaqueue.Consumer, nil),
-					Worker:       w,
-					WorkerThread: workerId,
-				}
-				k.ProcessMessages(ctx)
-				wg.Done()
-			}(i)
-		}
-		wg.Wait()
-		_wg.Done()
-	}(&wg)
-	go func(_wg *sync.WaitGroup) {
-		buffer := &KafkaBatchBuffer{
-			messageQueue: make(chan *kafkaqueue.Message, 4*DefaultBatchFlushSize),
-		}
-		k := KafkaBatchWorker{
-			KafkaQueue: kafkaqueue.New(ctx,
-				kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}),
-				kafkaqueue.Consumer,
-				&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(8 * DefaultBatchFlushSize)}),
-			Worker:              w,
-			BatchBuffer:         buffer,
-			BatchFlushSize:      4 * DefaultBatchFlushSize,
-			BatchedFlushTimeout: DefaultBatchedFlushTimeout,
-			Name:                "batched",
-		}
-		k.ProcessMessages(ctx, k.flushLogs)
-		_wg.Done()
-	}(&wg)
-	go func(_wg *sync.WaitGroup) {
-		buffer := &KafkaBatchBuffer{
-			messageQueue: make(chan *kafkaqueue.Message, DefaultBatchFlushSize),
-		}
-		k := KafkaBatchWorker{
-			KafkaQueue: kafkaqueue.New(ctx,
-				kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeTraces}),
-				kafkaqueue.Consumer,
-				&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(2 * DefaultBatchFlushSize)}),
-			Worker:              w,
-			BatchBuffer:         buffer,
-			BatchFlushSize:      DefaultBatchFlushSize,
-			BatchedFlushTimeout: DefaultBatchedFlushTimeout,
-			Name:                "batched",
-		}
-		k.ProcessMessages(ctx, k.flushTraces)
-		wg.Done()
-	}(&wg)
+
+	wg.Add(parallelWorkers)
+	for i := 0; i < parallelWorkers; i++ {
+		go func(workerId int) {
+			k := KafkaWorker{
+				KafkaQueue:   kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDefault}), kafkaqueue.Consumer, nil),
+				Worker:       w,
+				WorkerThread: workerId,
+			}
+			k.ProcessMessages(ctx)
+			wg.Done()
+		}(i)
+	}
+
+	wg.Add(parallelBatchWorkers)
+	for i := 0; i < parallelBatchWorkers; i++ {
+		go func(workerId int) {
+			buffer := &KafkaBatchBuffer{
+				messageQueue: make(chan *kafkaqueue.Message, 4*DefaultBatchFlushSize),
+			}
+			k := KafkaBatchWorker{
+				KafkaQueue: kafkaqueue.New(ctx,
+					kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}),
+					kafkaqueue.Consumer,
+					&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(8 * DefaultBatchFlushSize)}),
+				Worker:              w,
+				BatchBuffer:         buffer,
+				BatchFlushSize:      4 * DefaultBatchFlushSize,
+				BatchedFlushTimeout: DefaultBatchedFlushTimeout,
+				Name:                "batched",
+			}
+			k.ProcessMessages(ctx, k.flushLogs)
+			wg.Done()
+		}(i)
+	}
+
+	wg.Add(parallelBatchWorkers)
+	for i := 0; i < parallelBatchWorkers; i++ {
+		go func(workerId int) {
+			buffer := &KafkaBatchBuffer{
+				messageQueue: make(chan *kafkaqueue.Message, DefaultBatchFlushSize),
+			}
+			k := KafkaBatchWorker{
+				KafkaQueue: kafkaqueue.New(ctx,
+					kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeTraces}),
+					kafkaqueue.Consumer,
+					&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(2 * DefaultBatchFlushSize)}),
+				Worker:              w,
+				BatchBuffer:         buffer,
+				BatchFlushSize:      DefaultBatchFlushSize,
+				BatchedFlushTimeout: DefaultBatchedFlushTimeout,
+				Name:                "traces",
+			}
+			k.ProcessMessages(ctx, k.flushTraces)
+			wg.Done()
+		}(i)
+	}
 	wg.Wait()
 }
 


### PR DESCRIPTION
## Summary

Flush for logs is taking about 8 seconds, and since there is only one flush worker per ECS container,
we are not keeping up with writing logs fast enough.
This change adds concurrent flush workers to increase number of concurrent writes to clickhouse.

## How did you test this change?

Local deploy ingesting logs.
<img width="1785" alt="Screenshot 2023-08-03 at 9 01 39 AM" src="https://github.com/highlight/highlight/assets/1351531/e3c191f7-f943-4b31-8eb1-2ddc4f5d8ec5">


## Are there any deployment considerations?

No