### PR TITLE
Store session insights generated by Harold

### DIFF
--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -780,7 +780,7 @@ func FilterEventsForInsights(events []interface{}) ([]*Event, error) {
 					data, _ := json.Marshal(eMap["data"])
 					stringifiedData := string(data)
 
-					if !util.StringContainsAnyOf(stringifiedData, []string{"identify", "authenticate", "performance"}) {
+					if !util.StringContainsAnyOf(stringifiedData, []string{"identify", "authenticate", "performance", "jank"}) {
 						parsedEvents = append(parsedEvents, &Event{
 							Type:      eventType,
 							Timestamp: timestamp,

--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -780,7 +780,7 @@ func FilterEventsForInsights(events []interface{}) ([]*Event, error) {
 					data, _ := json.Marshal(eMap["data"])
 					stringifiedData := string(data)
 
-					if !util.StringContainsAnyOf(stringifiedData, []string{"identify", "authenticate", "performance", "jank"}) {
+					if !util.StringContainsAnyOf(strings.ToLower(stringifiedData), []string{"identify", "authenticate", "performance", "jank"}) {
 						parsedEvents = append(parsedEvents, &Event{
 							Type:      eventType,
 							Timestamp: timestamp,

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -190,6 +190,7 @@ var Models = []interface{}{
 	&ErrorGroupActivityLog{},
 	&UserJourneyStep{},
 	&SystemConfiguration{},
+	&SessionInsight{},
 }
 
 func init() {
@@ -682,6 +683,12 @@ type SessionAdminsView struct {
 	SessionID int       `gorm:"primaryKey"`
 	AdminID   int       `gorm:"primaryKey"`
 	ViewedAt  time.Time `gorm:"default:NOW()"`
+}
+
+type SessionInsight struct {
+	Model
+	SessionID int `gorm:"index"`
+	Insight   string
 }
 
 type EventChunk struct {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1119,8 +1119,9 @@ type ComplexityRoot struct {
 	}
 
 	SessionInsight struct {
-		ID      func(childComplexity int) int
-		Insight func(childComplexity int) int
+		ID        func(childComplexity int) int
+		Insight   func(childComplexity int) int
+		SessionID func(childComplexity int) int
 	}
 
 	SessionInterval struct {
@@ -1577,7 +1578,7 @@ type QueryResolver interface {
 	LogsKeyValues(ctx context.Context, projectID int, keyName string, dateRange model.DateRangeRequiredInput) ([]string, error)
 	LogsErrorObjects(ctx context.Context, logCursors []string) ([]*model1.ErrorObject, error)
 	ErrorResolutionSuggestion(ctx context.Context, errorObjectID int) (string, error)
-	SessionInsight(ctx context.Context, secureID string) (*model.SessionInsight, error)
+	SessionInsight(ctx context.Context, secureID string) (*model1.SessionInsight, error)
 	SystemConfiguration(ctx context.Context) (*model1.SystemConfiguration, error)
 	Services(ctx context.Context, projectID int, after *string, before *string, query *string) (*model.ServiceConnection, error)
 }
@@ -8066,6 +8067,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SessionInsight.Insight(childComplexity), true
 
+	case "SessionInsight.session_id":
+		if e.complexity.SessionInsight.SessionID == nil {
+			break
+		}
+
+		return e.complexity.SessionInsight.SessionID(childComplexity), true
+
 	case "SessionInterval.active":
 		if e.complexity.SessionInterval.Active == nil {
 			break
@@ -10038,6 +10046,7 @@ type SessionComment {
 
 type SessionInsight {
 	id: ID!
+	session_id: Int!
 	insight: String!
 }
 
@@ -49636,9 +49645,9 @@ func (ec *executionContext) _Query_session_insight(ctx context.Context, field gr
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.SessionInsight)
+	res := resTmp.(*model1.SessionInsight)
 	fc.Result = res
-	return ec.marshalOSessionInsight2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSessionInsight(ctx, field.Selections, res)
+	return ec.marshalOSessionInsight2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionInsight(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_session_insight(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -49651,6 +49660,8 @@ func (ec *executionContext) fieldContext_Query_session_insight(ctx context.Conte
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_SessionInsight_id(ctx, field)
+			case "session_id":
+				return ec.fieldContext_SessionInsight_session_id(ctx, field)
 			case "insight":
 				return ec.fieldContext_SessionInsight_insight(ctx, field)
 			}
@@ -56106,7 +56117,7 @@ func (ec *executionContext) fieldContext_SessionCommentTag_name(ctx context.Cont
 	return fc, nil
 }
 
-func (ec *executionContext) _SessionInsight_id(ctx context.Context, field graphql.CollectedField, obj *model.SessionInsight) (ret graphql.Marshaler) {
+func (ec *executionContext) _SessionInsight_id(ctx context.Context, field graphql.CollectedField, obj *model1.SessionInsight) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SessionInsight_id(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -56150,7 +56161,51 @@ func (ec *executionContext) fieldContext_SessionInsight_id(ctx context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _SessionInsight_insight(ctx context.Context, field graphql.CollectedField, obj *model.SessionInsight) (ret graphql.Marshaler) {
+func (ec *executionContext) _SessionInsight_session_id(ctx context.Context, field graphql.CollectedField, obj *model1.SessionInsight) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SessionInsight_session_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SessionID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SessionInsight_session_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SessionInsight",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SessionInsight_insight(ctx context.Context, field graphql.CollectedField, obj *model1.SessionInsight) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SessionInsight_insight(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -73939,7 +73994,7 @@ func (ec *executionContext) _SessionCommentTag(ctx context.Context, sel ast.Sele
 
 var sessionInsightImplementors = []string{"SessionInsight"}
 
-func (ec *executionContext) _SessionInsight(ctx context.Context, sel ast.SelectionSet, obj *model.SessionInsight) graphql.Marshaler {
+func (ec *executionContext) _SessionInsight(ctx context.Context, sel ast.SelectionSet, obj *model1.SessionInsight) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, sessionInsightImplementors)
 	out := graphql.NewFieldSet(fields)
 	var invalids uint32
@@ -73950,6 +74005,13 @@ func (ec *executionContext) _SessionInsight(ctx context.Context, sel ast.Selecti
 		case "id":
 
 			out.Values[i] = ec._SessionInsight_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "session_id":
+
+			out.Values[i] = ec._SessionInsight_session_id(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -81572,7 +81634,7 @@ func (ec *executionContext) marshalOSessionExcludedReason2ᚖgithubᚗcomᚋhigh
 	return v
 }
 
-func (ec *executionContext) marshalOSessionInsight2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSessionInsight(ctx context.Context, sel ast.SelectionSet, v *model.SessionInsight) graphql.Marshaler {
+func (ec *executionContext) marshalOSessionInsight2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionInsight(ctx context.Context, sel ast.SelectionSet, v *model1.SessionInsight) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -661,11 +661,6 @@ type SessionCommentTagInput struct {
 	Name string `json:"name"`
 }
 
-type SessionInsight struct {
-	ID      int    `json:"id"`
-	Insight string `json:"insight"`
-}
-
 type SessionQuery struct {
 	ID        int `json:"id"`
 	ProjectID int `json:"project_id"`

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1075,6 +1075,7 @@ type SessionComment {
 
 type SessionInsight {
 	id: ID!
+	session_id: Int!
 	insight: String!
 }
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7469,81 +7469,25 @@ func (r *queryResolver) ErrorResolutionSuggestion(ctx context.Context, errorObje
 }
 
 // SessionInsight is the resolver for the session_insight field.
-func (r *queryResolver) SessionInsight(ctx context.Context, secureID string) (*modelInputs.SessionInsight, error) {
-	apiKey := os.Getenv("OPENAI_API_KEY")
-	if apiKey == "" {
-		return nil, e.New("OPENAI_API_KEY is not set")
-	}
-
+func (r *queryResolver) SessionInsight(ctx context.Context, secureID string) (*model.SessionInsight, error) {
 	session, err := r.canAdminViewSession(ctx, secureID)
 	if err != nil {
 		return nil, nil
 	}
 
-	systemPrompt := fmt.Sprint(`
-	Given array of events performed by a user from a session recording for a web application, make inferences and justifications and summarize interesting things about the session in 3 insights.
-	Rules:
-	- Use less than 2 sentences for each point
-	- Provide high level insights, do not mention singular events
-	- Do not mention event types in the insights
-	- Insights must be different to each other
-	- Do not mention identification or authentication events
-	- Don't mention timestamps in <insight>, insights should be interesting inferences from the input
-	- Output timestamp that best represents the insight in <timestamp> of output
-	- Sort the insights by timestamp
+	var insight *model.SessionInsight
 
-	You must respond ONLY with JSON that looks like this:
-	[{"insight": "<Insight>", timestamp: number },{"insight": "<Insight>", timestamp: number },{"insight": "<Insight>", timestamp: number }]
-	Do not provide any other output other than this format.
-
-	Context:
-	- The events are JSON objects, where the "timestamp" field represents UNIX time of the event, the "type" field represents the type of event, and the "data" field represents more information about the event
-	- If the event is of type "Custom", the "tag" field provides the type of custom event, and the "payload" field represents more information about the event
-	- If the event is of tag "Track", it is a custom event where the actual type of the event is in the "event" field within "data.payload"
-
-	The "type" field follows this format:
-	0 - DomContentLoaded
-	1 - Load
-	2 -	FullSnapshot, the full page view was loaded
-	3 -	IncrementalSnapshot, some components were updated
-	4 -	Meta
-	5 -	Custom, the "tag" field provides the type of custom event, and the "payload" field represents more information about the event
-	6 -	Plugin
-	`)
-
-	events, err, _ := r.getEvents(ctx, session, model.EventsCursor{EventIndex: 0, EventObjectIndex: nil})
-	userPrompt, err := r.getSessionInsight(ctx, events)
-
-	const MAX_AI_SESSION_INSIGHT_PROMPT_LENGTH = 32000
-	if len(userPrompt) > MAX_AI_SESSION_INSIGHT_PROMPT_LENGTH {
-		userPrompt = userPrompt[:MAX_AI_SESSION_INSIGHT_PROMPT_LENGTH]
+	if err := r.DB.Model(&insight).Where(&model.SessionInsight{SessionID: session.ID}).Take(&insight).Error; err != nil {
+		if e.Is(err, gorm.ErrRecordNotFound) {
+			log.WithContext(ctx).Error(err, "SessionInsight: No record found")
+			insight, err = r.getSessionInsight(ctx, session)
+			if err != nil {
+				log.WithContext(ctx).Error(err, "SessionInsight: Error getting insight")
+			}
+		} else {
+			return nil, err
+		}
 	}
-
-	client := openai.NewClient(apiKey)
-	resp, err := client.CreateChatCompletion(
-		context.Background(),
-		openai.ChatCompletionRequest{
-			Model:       openai.GPT3Dot5Turbo16K,
-			Temperature: 0.7,
-			Messages: []openai.ChatCompletionMessage{
-				{
-					Role:    openai.ChatMessageRoleSystem,
-					Content: systemPrompt,
-				},
-				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: userPrompt,
-				},
-			},
-		},
-	)
-
-	if err != nil {
-		log.WithContext(ctx).Error(err, "SessionInsight: ChatCompletion error")
-		return nil, err
-	}
-
-	insight := &modelInputs.SessionInsight{ID: session.ID, Insight: resp.Choices[0].Message.Content}
 
 	return insight, nil
 }

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2670,6 +2670,7 @@ export type SessionInsight = {
 	__typename?: 'SessionInsight'
 	id: Scalars['ID']
 	insight: Scalars['String']
+	session_id: Scalars['Int']
 }
 
 export type SessionInterval = {


### PR DESCRIPTION
## Summary

This adds the SessionInsight model, where each row has the generated insight and the corresponding sessionID. 

If a session already has insights generated, the cache is used and no OpenAI API call is made. 

In the future, we might want to allow people to regenerate the session insights, but this will depend on usage of this feature. 

Also includes refining the event filtering. Now we filter out all Snapshots, Jank, and Performance events when generating insights since these are more related to metrics compared to actual interactions and experience of the user. 

Also moved the API calls into a resolver function, so the main SessionInsight function just takes care of whether a session already has an insight in the db. 

## How did you test this change?

Clicked through a few sessions and generated insights, and generating them again to check that it's using the stored insights. 

## Are there any deployment considerations?

This introduces a new table. 
