### PR TITLE
cache mark backend setup calls

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1142,52 +1142,57 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 }
 
 func (r *Resolver) MarkBackendSetupImpl(ctx context.Context, projectID int, setupType model.MarkBackendSetupType) error {
-	if setupType == model.MarkBackendSetupTypeLogs || setupType == model.MarkBackendSetupTypeError {
-		// Update Hubspot company and projects.backend_setup
-		var backendSetupCount int64
-		if err := r.DB.Model(&model.Project{}).Where("id = ? AND backend_setup=true", projectID).Count(&backendSetupCount).Error; err != nil {
-			return e.Wrap(err, "error querying backend_setup flag")
-		}
-		if backendSetupCount < 1 {
-			project, err := r.getProject(projectID)
-			if err != nil {
-				log.WithContext(ctx).Errorf("failed to query project %d: %s", projectID, err)
-			} else {
-				if util.IsHubspotEnabled() {
-					if err := r.HubspotApi.UpdateCompanyProperty(ctx, project.WorkspaceID, []hubspot.Property{{
-						Name:     "backend_setup",
-						Property: "backend_setup",
-						Value:    true,
-					}}); err != nil {
-						log.WithContext(ctx).Errorf("failed to update hubspot")
+	_, err := redis.CachedEval(ctx, r.Redis, fmt.Sprintf("mark-backend-setup-%d-%s", projectID, setupType), 150*time.Millisecond, time.Hour, func() (*bool, error) {
+		log.Infof("MarkBackendSetupImpl called for projectId %d", projectID)
+		if setupType == model.MarkBackendSetupTypeLogs || setupType == model.MarkBackendSetupTypeError {
+			// Update Hubspot company and projects.backend_setup
+			var backendSetupCount int64
+			if err := r.DB.Model(&model.Project{}).Where("id = ? AND backend_setup=true", projectID).Count(&backendSetupCount).Error; err != nil {
+				return nil, e.Wrap(err, "error querying backend_setup flag")
+			}
+			if backendSetupCount < 1 {
+				project, err := r.getProject(projectID)
+				if err != nil {
+					log.WithContext(ctx).Errorf("failed to query project %d: %s", projectID, err)
+				} else {
+					if util.IsHubspotEnabled() {
+						if err := r.HubspotApi.UpdateCompanyProperty(ctx, project.WorkspaceID, []hubspot.Property{{
+							Name:     "backend_setup",
+							Property: "backend_setup",
+							Value:    true,
+						}}); err != nil {
+							log.WithContext(ctx).Errorf("failed to update hubspot")
+						}
 					}
+					phonehome.ReportUsageMetrics(ctx, phonehome.WorkspaceUsage, project.WorkspaceID, []attribute.KeyValue{
+						attribute.Bool(phonehome.BackendSetup, true),
+					})
 				}
-				phonehome.ReportUsageMetrics(ctx, phonehome.WorkspaceUsage, project.WorkspaceID, []attribute.KeyValue{
-					attribute.Bool(phonehome.BackendSetup, true),
-				})
-			}
-			if err := r.DB.Model(&model.Project{}).Where("id = ?", projectID).Updates(&model.Project{BackendSetup: &model.T}).Error; err != nil {
-				return e.Wrap(err, "error updating backend_setup flag")
+				if err := r.DB.Model(&model.Project{}).Where("id = ?", projectID).Updates(&model.Project{BackendSetup: &model.T}).Error; err != nil {
+					return nil, e.Wrap(err, "error updating backend_setup flag")
+				}
 			}
 		}
-	}
 
-	// Create setup_events record
-	var setupEventsCount int64
-	if err := r.DB.Model(&model.SetupEvent{}).Where("project_id = ? AND type = ?", projectID, setupType).Count(&setupEventsCount).Error; err != nil {
-		return e.Wrap(err, "error querying setup events")
-	}
-	if setupEventsCount < 1 {
-		setupEvent := &model.SetupEvent{
-			ProjectID: projectID,
-			Type:      setupType,
+		// Create setup_events record
+		var setupEventsCount int64
+		if err := r.DB.Model(&model.SetupEvent{}).Where("project_id = ? AND type = ?", projectID, setupType).Count(&setupEventsCount).Error; err != nil {
+			return nil, e.Wrap(err, "error querying setup events")
 		}
-		if err := r.DB.Clauses(clause.OnConflict{DoNothing: true}).Create(&setupEvent).Error; err != nil {
-			return e.Wrap(err, "error creating setup event")
+		if setupEventsCount < 1 {
+			setupEvent := &model.SetupEvent{
+				ProjectID: projectID,
+				Type:      setupType,
+			}
+			if err := r.DB.Clauses(clause.OnConflict{DoNothing: true}).Create(&setupEvent).Error; err != nil {
+				return nil, e.Wrap(err, "error creating setup event")
+			}
 		}
-	}
 
-	return nil
+		return pointy.Bool(true), nil
+	})
+
+	return err
 }
 
 func (r *Resolver) AddSessionFeedbackImpl(ctx context.Context, input *kafka_queue.AddSessionFeedbackArgs) error {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1143,7 +1143,6 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 
 func (r *Resolver) MarkBackendSetupImpl(ctx context.Context, projectID int, setupType model.MarkBackendSetupType) error {
 	_, err := redis.CachedEval(ctx, r.Redis, fmt.Sprintf("mark-backend-setup-%d-%s", projectID, setupType), 150*time.Millisecond, time.Hour, func() (*bool, error) {
-		log.Infof("MarkBackendSetupImpl called for projectId %d", projectID)
 		if setupType == model.MarkBackendSetupTypeLogs || setupType == model.MarkBackendSetupTypeError {
 			// Update Hubspot company and projects.backend_setup
 			var backendSetupCount int64

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -42,10 +42,13 @@ func TestMain(m *testing.M) {
 		testLogger.Error(e.Wrap(err, "error creating testdb"))
 	}
 
+	redisClient := redis.NewClient()
+
 	resolver = &Resolver{
 		DB:    db,
 		TDB:   timeseries.New(context.TODO()),
-		Store: store.NewStore(db, &opensearch.Client{}, redis.NewClient()),
+		Store: store.NewStore(db, &opensearch.Client{}, redisClient),
+		Redis: redisClient,
 	}
 	code := m.Run()
 	os.Exit(code)


### PR DESCRIPTION
## Summary
- caches `MarkBackendSetupImpl` calls by projectId + type with an hour TTL
- fixes issue where `redis.ReleaseLock` would clear the cache key in redis
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested w/ debugger locally, verified keys were present in Redis
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
