### PR TITLE
Handle serialized logs sent via loguru

### DIFF
--- a/highlight.io/components/QuickstartContent/logging/python/loguru.tsx
+++ b/highlight.io/components/QuickstartContent/logging/python/loguru.tsx
@@ -46,10 +46,11 @@ logger.add(
 	format="{message}",
 	level="INFO",
 	backtrace=True,
+	serialize=True,
 )
 
 def main():
-    logger.debug("That's it, beautiful and simple logging!", {"nice": "one"})
+    logger.debug("That's it, beautiful and simple logging!", nice="one")
     context_logger = logger.bind(ip="192.168.0.1", user="someone")
 	context_logger.info("Contextualize your logger easily")
 `,

--- a/sdk/highlight-py/CHANGELOG.md
+++ b/sdk/highlight-py/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## v0.5.4 (2023-08-02)
+## v0.5.5 (2023-08-05)
+
+### Feature
+### Fix
+
+- Fixed formatting of serialized loguru logs
+### Tests
+
+## v0.5.4 (2023-08-04)
 
 ### Feature
 

--- a/sdk/highlight-py/CHANGELOG.md
+++ b/sdk/highlight-py/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fix
 
 - Fixed formatting of serialized loguru logs
+- Update fastapi version requirement
 ### Tests
 
 ## v0.5.4 (2023-08-04)

--- a/sdk/highlight-py/CHANGELOG.md
+++ b/sdk/highlight-py/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## v0.5.5 (2023-08-05)
 
 ### Feature
+
 ### Fix
 
 - Fixed formatting of serialized loguru logs
 - Update fastapi version requirement
+
 ### Tests
 
 ## v0.5.4 (2023-08-04)

--- a/sdk/highlight-py/README.md
+++ b/sdk/highlight-py/README.md
@@ -11,7 +11,29 @@ Do not use the snippets verbatim as they are configured for local development an
 ## Install
 
 * Install [poetry](https://python-poetry.org/docs/#installing-with-the-official-installer)
-* `poetry install`
+* `poetry install --all-extras`
+
+## Run e2e apps
+
+### Django
+
+* `cd e2e/highlight_django`
+* `poetry run python manage.py runserver`
+
+### Flask
+
+* `cd e2e/highlight_flask`
+* `poetry run flask run`
+
+### Fastapi
+
+* `cd e2e/highlight_fastapi`
+* `poetry run uvicorn main:app`
+
+### Loguru
+
+* `cd e2e/highlight_loguru`
+* `poetry run python main.py`
 
 ## Run tests
 
@@ -19,4 +41,4 @@ Do not use the snippets verbatim as they are configured for local development an
 
 ## Lint
 
-* poetry run black  .
+* `poetry run black  .`

--- a/sdk/highlight-py/e2e/highlight_loguru/main.py
+++ b/sdk/highlight-py/e2e/highlight_loguru/main.py
@@ -10,6 +10,7 @@ H = highlight_io.H(
     instrument_logging=False,
     service_name="my-app",
     service_version="1.0.0",
+    otlp_endpoint="http://localhost:4318",
 )
 
 logger.add(

--- a/sdk/highlight-py/e2e/highlight_loguru/main.py
+++ b/sdk/highlight-py/e2e/highlight_loguru/main.py
@@ -8,14 +8,14 @@ from loguru import logger
 H = highlight_io.H(
     "1",
     instrument_logging=False,
-    service_name="my-app",
+    service_name="my-loguru-app",
     service_version="1.0.0",
     otlp_endpoint="http://localhost:4318",
 )
 
 logger.add(
     H.logging_handler,
-    format="{message}",
+    format="{message} {extra}",
     level="INFO",
     backtrace=True,
     serialize=True,

--- a/sdk/highlight-py/e2e/highlight_loguru/main.py
+++ b/sdk/highlight-py/e2e/highlight_loguru/main.py
@@ -17,6 +17,7 @@ logger.add(
     format="{message}",
     level="INFO",
     backtrace=True,
+    serialize=True,
 )
 
 

--- a/sdk/highlight-py/e2e/highlight_loguru/main.py
+++ b/sdk/highlight-py/e2e/highlight_loguru/main.py
@@ -23,7 +23,7 @@ logger.add(
 
 
 def main():
-    logger.info("hello handler", customer="unknown")
+    logger.info("hello handler", customer_id="99")
     for idx in range(1):
         with H.trace(session_id="session-abc123", request_id="request-abc123"):
             logger.info(f"hello from loguru with trace {idx}")

--- a/sdk/highlight-py/e2e/highlight_loguru/main.py
+++ b/sdk/highlight-py/e2e/highlight_loguru/main.py
@@ -23,8 +23,8 @@ logger.add(
 
 
 def main():
-    logger.info("hello handler", {"customer": "unknown"})
-    for idx in range(1000):
+    logger.info("hello handler", customer="unknown")
+    for idx in range(1):
         with H.trace(session_id="session-abc123", request_id="request-abc123"):
             logger.info(f"hello from loguru with trace {idx}")
             logging.info(f"hello from logging with trace {idx}")

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -292,10 +292,10 @@ class H(object):
                 # See: https://loguru.readthedocs.io/en/stable/api/logger.html#record
                 obj = json.loads(message)
                 extra = obj["record"]["extra"]
-                for key in extra:
-                    attributes[key] = extra[key]
+                message = obj["text"]
 
-                message = obj["message"]
+                for key, value in extra.items():
+                    attributes[key] = value
             except:
                 pass
 

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -29,6 +29,7 @@ class LogHandler(logging.Handler):
     def emit(self, record: logging.LogRecord):
         ctx = contextlib.nullcontext
         span = trace.get_current_span()
+
         if span is None or not span.is_recording():
             ctx = self.highlight.trace
 
@@ -284,6 +285,20 @@ class H(object):
             attributes["code.filepath"] = record.pathname
             attributes["code.lineno"] = record.lineno
             attributes.update(record.args or {})
+
+            message = record.getMessage()
+            try:
+                # Handle loguru's serialize=True format
+                # See: https://loguru.readthedocs.io/en/stable/api/logger.html#record
+                obj = json.loads(message)
+                extra = obj["record"]["extra"]
+                for key in extra:
+                    attributes[key] = extra[key]
+
+                message = obj["message"]
+            except:
+                pass
+
             r = LogRecord(
                 timestamp=ts,
                 trace_id=ctx.trace_id,
@@ -291,7 +306,7 @@ class H(object):
                 trace_flags=ctx.trace_flags,
                 severity_text=record.levelname,
                 severity_number=std_to_otel(record.levelno),
-                body=record.getMessage(),
+                body=message,
                 resource=span.resource,
                 attributes=attributes,
             )

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.5.4"
+version = "0.5.5"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [
@@ -29,7 +29,7 @@ python = "^3.8"
 blinker = { version = "^1.5", optional = true }
 django = { version = "^4.1", optional = true }
 flask = { version = "^2.2", optional = true }
-fastapi = { version = "^0.92", optional = true }
+fastapi = { version = ">=0.92", optional = true }
 uvicorn = {version = "^0.20", extras = ["standard"], optional = true }
 opentelemetry-api = "1.19.0"
 opentelemetry-distro = { extras = ["otlp"], version = "0.40b0" }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Serialized logs sent through loguru don't look great. This PR fixes that.


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->


`cd sdk/highlight-py/e2e/highlight_loguru && poetry run python main.py`

Confirmed extra attributes are serialized properly:

![image](https://github.com/highlight/highlight/assets/58678/c4ca82ae-75a2-4b00-a2ab-86d6197ffe46)



## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

Bumped the python SDK version.