### PR TITLE
increase batch timeout to 5 seconds

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -462,7 +462,7 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 				Worker:              w,
 				BatchBuffer:         buffer,
 				BatchFlushSize:      4 * DefaultBatchFlushSize,
-				BatchedFlushTimeout: DefaultBatchedFlushTimeout,
+				BatchedFlushTimeout: 5 * time.Second,
 				Name:                "batched",
 			}
 			k.ProcessMessages(ctx, k.flushLogs)


### PR DESCRIPTION
## Summary
- lots of clickhouse writes have single digit batch sizes now that the queue has caught up, still getting occasional `too many parts` errors, try reducing the flush frequency
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor in prod
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
