### PR TITLE
adjust batched queue flushing

### DIFF
--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -78,7 +78,7 @@ func (k *KafkaWorker) ProcessMessages(ctx context.Context) {
 
 // BatchFlushSize set per https://clickhouse.com/docs/en/cloud/bestpractices/bulk-inserts
 const DefaultBatchFlushSize = 512
-const DefaultBatchedFlushTimeout = 1 * time.Second
+const DefaultBatchedFlushTimeout = 5 * time.Second
 
 type KafkaWorker struct {
 	KafkaQueue   *kafkaqueue.Queue

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -427,7 +427,7 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 
 func (w *Worker) PublicWorker(ctx context.Context) {
 	const parallelWorkers = 64
-	const parallelBatchWorkers = 32
+	const parallelBatchWorkers = 8
 	// creates N parallel kafka message consumers that process messages.
 	// each consumer is considered part of the same consumer group and gets
 	// allocated a slice of all partitions. this ensures that a particular subset of partitions


### PR DESCRIPTION
## Summary

Help increase the batched processing flush size to avoid clickhouse too many parts errors.

## How did you test this change?

N/A

## Are there any deployment considerations?

Monitoring for errors