### PR TITLE
add service information to ruby sdk

### DIFF
--- a/highlight.io/components/QuickstartContent/backend/ruby/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/backend/ruby/shared-snippets.tsx
@@ -22,7 +22,10 @@ export const initializeSdk: QuickStartStep = {
 		{
 			text: `require "highlight"
 
-Highlight::H.new("<YOUR_PROJECT_ID>")`,
+Highlight::H.new("<YOUR_PROJECT_ID>") do |c|
+  c.service_name = "my-app"
+  c.service_version = "1.0.0"
+end`,
 			language: 'ruby',
 		},
 	],

--- a/highlight.io/components/QuickstartContent/logging/ruby/other.tsx
+++ b/highlight.io/components/QuickstartContent/logging/ruby/other.tsx
@@ -16,7 +16,10 @@ export const RubyOtherLogContent: QuickStartContent = {
 				{
 					text: `require "highlight"
 
-Highlight::H.new("<YOUR_PROJECT_ID>")
+Highlight::H.new("<YOUR_PROJECT_ID>") do |c|
+  c.service_name = "my-ruby-app"
+  c.service_version = "git-sha"
+end
 
 logger = Highlight::Logger.new(STDOUT)
 logger.info('hello, world!')

--- a/highlight.io/components/QuickstartContent/logging/ruby/rails.tsx
+++ b/highlight.io/components/QuickstartContent/logging/ruby/rails.tsx
@@ -16,7 +16,10 @@ export const RubyRailsLogContent: QuickStartContent = {
 				{
 					text: `require "highlight"
 
-Highlight::H.new("<YOUR_PROJECT_ID>")
+Highlight::H.new("<YOUR_PROJECT_ID>") do |c|
+  c.service_name = "my-rails-app"
+  c.service_version = "git-sha"
+end
 
 # you can replace the Rails.logger with Highlight's
 Rails.logger = Highlight::Logger.new(STDOUT)

--- a/sdk/highlight-ruby/e2e/rails/blog/config/initializers/highlight.rb
+++ b/sdk/highlight-ruby/e2e/rails/blog/config/initializers/highlight.rb
@@ -1,4 +1,7 @@
 require "highlight"
 
-Highlight::H.new("1jdkoe52", "http://localhost:4318")
+Highlight::H.new("1jdkoe52", "http://localhost:4318") do |c|
+    c.service_name = "my-rails-app"
+    c.service_verion = "1.0.0"
+end
 Rails.logger = Highlight::Logger.new(STDOUT)

--- a/sdk/highlight-ruby/highlight/CHANGELOG.md
+++ b/sdk/highlight-ruby/highlight/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 0.1.2
+
+### Patch Changes
+
+- Add ability to set service_name and service_version

--- a/sdk/highlight-ruby/highlight/CHANGELOG.md
+++ b/sdk/highlight-ruby/highlight/CHANGELOG.md
@@ -1,3 +1,3 @@
 ## 0.1.2
 
-- Add ability to set service_name and service_version
+- Add ability to set `service_name` and `service_version`

--- a/sdk/highlight-ruby/highlight/CHANGELOG.md
+++ b/sdk/highlight-ruby/highlight/CHANGELOG.md
@@ -1,5 +1,3 @@
 ## 0.1.2
 
-### Patch Changes
-
 - Add ability to set service_name and service_version

--- a/sdk/highlight-ruby/highlight/Gemfile.lock
+++ b/sdk/highlight-ruby/highlight/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    highlight_io (0.1.1)
+    highlight_io (0.1.2)
       grpc (~> 1.52)
       opentelemetry-exporter-otlp (~> 0.24.0)
       opentelemetry-instrumentation-all (~> 0.32.0)
@@ -12,7 +12,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    google-protobuf (3.23.4)
+    google-protobuf (3.23.4-arm64-darwin)
     googleapis-common-protos-types (1.7.0)
       google-protobuf (~> 3.14)
     grpc (1.56.2)

--- a/sdk/highlight-ruby/highlight/lib/highlight.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight.rb
@@ -32,6 +32,7 @@ module Highlight
         c.add_span_processor(OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
                                OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: "#{@otlp_endpoint}/v1/traces")
                              ))
+        yield c if block_given?
       end
 
       @tracer_provider = OpenTelemetry.tracer_provider

--- a/sdk/highlight-ruby/highlight/lib/highlight/version.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight/version.rb
@@ -1,3 +1,3 @@
 module Highlight
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end

--- a/sdk/highlight-ruby/highlight/test/highlight_test.rb
+++ b/sdk/highlight-ruby/highlight/test/highlight_test.rb
@@ -2,7 +2,10 @@ require_relative './test_helper'
 
 class HighlightTest < Minitest::Test
   def test_logger
-    Highlight::H.new('qe9y4yg1')
+    Highlight::H.new("qe9y4yg1") do |c|
+      c.service_name = "my-app"
+      c.service_version = "1.0.0"
+    end
     logger = Highlight::Logger.new($stdout)
     logger.add(Logger::INFO, 'ruby test log add!')
     logger.info('ruby test log info!')

--- a/sdk/highlight-ruby/highlight/test/highlight_test.rb
+++ b/sdk/highlight-ruby/highlight/test/highlight_test.rb
@@ -2,9 +2,9 @@ require_relative './test_helper'
 
 class HighlightTest < Minitest::Test
   def test_logger
-    Highlight::H.new("qe9y4yg1") do |c|
-      c.service_name = "my-app"
-      c.service_version = "1.0.0"
+    Highlight::H.new('qe9y4yg1') do |c|
+      c.service_name = 'my-app'
+      c.service_version = '1.0.0'
     end
     logger = Highlight::Logger.new($stdout)
     logger.add(Logger::INFO, 'ruby test log add!')


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Adds service name and service version to ruby sdk.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

The tests hit a live account which actually makes the testing easier.

```
bundle exec rake
```

Observe log ([permalink](https://app.highlight.io/1394/logs/MjAyMy0wOC0wOVQyMDowNjowNVosOWU1YzY1MDktNWMxZS00ZGJkLWIwNTMtZDE2MGQzZTM2MzQ0)).

![Screenshot 2023-08-09 at 2 07 26 PM](https://github.com/highlight/highlight/assets/58678/181c4e7a-a34e-4691-964c-3a6138c870ee)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

Docs updated and bumped ruby version (should autodeploy now per #6269 but will verify on [rubygems](https://rubygems.org/gems/highlight_io) after this is merged).
