### PR TITLE
flush logs every ~10k log rows until local queue is empty

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -452,16 +452,16 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 	for i := 0; i < parallelBatchWorkers; i++ {
 		go func(workerId int) {
 			buffer := &KafkaBatchBuffer{
-				messageQueue: make(chan *kafkaqueue.Message, 4*DefaultBatchFlushSize),
+				messageQueue: make(chan *kafkaqueue.Message, 8*DefaultBatchFlushSize),
 			}
 			k := KafkaBatchWorker{
 				KafkaQueue: kafkaqueue.New(ctx,
 					kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}),
 					kafkaqueue.Consumer,
-					&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(8 * DefaultBatchFlushSize)}),
+					&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(16 * DefaultBatchFlushSize)}),
 				Worker:              w,
 				BatchBuffer:         buffer,
-				BatchFlushSize:      4 * DefaultBatchFlushSize,
+				BatchFlushSize:      8 * DefaultBatchFlushSize,
 				BatchedFlushTimeout: DefaultBatchedFlushTimeout,
 				Name:                "batched",
 			}


### PR DESCRIPTION
## Summary
- flush logs should flush every ~10k log rows (ideal per the clickhouse docs)
- previously, it was using the Kafka batch size, but each Kafka message has multiple log rows, so there would be unread messages until the next flush
- now, loop and flush all messages until the message queue is empty
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally to make sure log ingestion was working, will monitor in prod
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
