### PR TITLE
also check for string keys in context

### DIFF
--- a/sdk/highlight-go/highlight.go
+++ b/sdk/highlight-go/highlight.go
@@ -232,8 +232,14 @@ func validateRequest(ctx context.Context) (sessionSecureID string, requestID str
 		err = errors.New(consumeErrorWorkerStopped)
 		return
 	}
+	if v := ctx.Value(string(ContextKeys.SessionSecureID)); v != nil {
+		sessionSecureID = v.(string)
+	}
 	if v := ctx.Value(ContextKeys.SessionSecureID); v != nil {
 		sessionSecureID = v.(string)
+	}
+	if v := ctx.Value(string(ContextKeys.RequestID)); v != nil {
+		requestID = v.(string)
 	}
 	if v := ctx.Value(ContextKeys.RequestID); v != nil {
 		requestID = v.(string)


### PR DESCRIPTION
## Summary
- `gin`'s `context.Set` method only allows string keys, and we're currently casting our context keys to strings in our `gin` middleware, causing the `ctx.Value()` lookup to fail for keys with type `contextKey`
- this changes the `validateRequest` function to also check for the keys after casting to string
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally on a basic `gin` app
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will tag a new release after deploying
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
