### PR TITLE
Limit suggestions of slack channels with other clean up

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
 		"@frontapp/plugin-sdk": "^1.1.2",
 		"@highlight-run/client": "workspace:*",
 		"@highlight-run/react": "workspace:*",
-		"@highlight-run/react-mentions": "4.4.1",
+		"@highlight-run/react-mentions": "4.4.2",
 		"@highlight-run/rrweb": "workspace:*",
 		"@highlight-run/ui": "workspace:*",
 		"@rehooks/local-storage": "^2.4.0",

--- a/frontend/src/components/Comment/CommentReplyForm/CommentReplyForm.tsx
+++ b/frontend/src/components/Comment/CommentReplyForm/CommentReplyForm.tsx
@@ -20,7 +20,7 @@ import {
 	IconSolidPaperAirplane,
 	Stack,
 } from '@highlight-run/ui'
-import CommentTextBody from '@pages/Player/Toolbar/NewCommentForm/CommentTextBody/CommentTextBody'
+import { CommentTextBody } from '@pages/Player/Toolbar/NewCommentForm/CommentTextBody/CommentTextBody'
 import analytics from '@util/analytics'
 import { getCommentMentionSuggestions } from '@util/comment/util'
 import { useParams } from '@util/react-router/useParams'

--- a/frontend/src/components/Comment/ReplyList/ReplyList.tsx
+++ b/frontend/src/components/Comment/ReplyList/ReplyList.tsx
@@ -2,7 +2,7 @@ import { CommentReply, Maybe } from '@graph/schemas'
 import { Box } from '@highlight-run/ui'
 import React from 'react'
 
-import SessionComment from '@/components/Comment/SessionComment/SessionComment'
+import { SessionComment } from '@/components/Comment/SessionComment/SessionComment'
 import { ParsedSessionComment } from '@/pages/Player/ReplayerContext'
 
 interface Props {

--- a/frontend/src/components/Comment/SessionComment/SessionComment.tsx
+++ b/frontend/src/components/Comment/SessionComment/SessionComment.tsx
@@ -5,8 +5,7 @@ import CommentReplyForm, {
 import ReplyList from '@components/Comment/ReplyList/ReplyList'
 import { Box, IconSolidReply, Stack, Tag, Text } from '@highlight-run/ui'
 import { ParsedSessionComment } from '@pages/Player/ReplayerContext'
-import { H } from 'highlight.run'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import {
 	getDeepLinkedCommentId,
@@ -14,8 +13,7 @@ import {
 } from '@/components/Comment/utils/utils'
 import { formatTimeAsHMS } from '@/util/time'
 
-import CommentTextBody from '../../../pages/Player/Toolbar/NewCommentForm/CommentTextBody/CommentTextBody'
-import styles from './SessionComment.module.css'
+import { CommentTextBody } from '../../../pages/Player/Toolbar/NewCommentForm/CommentTextBody/CommentTextBody'
 import SessionCommentHeader from './SessionCommentHeader'
 
 interface Props {
@@ -150,37 +148,3 @@ export const SessionComment = ({
 		</>
 	)
 }
-
-type SessionCommentTextBodyProps = Pick<Props, 'comment'>
-export const SessionCommentTextBody = ({
-	comment,
-}: SessionCommentTextBodyProps) => {
-	const [tags, setTags] = useState<string[]>([])
-
-	useEffect(() => {
-		if (comment.tags && comment.tags.length > 0) {
-			try {
-				// @ts-expect-error
-				setTags(JSON.parse(comment.tags[0]))
-			} catch (_e) {
-				const e = _e as Error
-				H.consumeError(e)
-			}
-		}
-	}, [comment.tags])
-
-	return (
-		<>
-			<CommentTextBody commentText={comment.text} />
-			{tags.length > 0 && (
-				<div className={styles.tagsContainer}>
-					{tags.map((tag) => (
-						<Tag key={tag}>{tag}</Tag>
-					))}
-				</div>
-			)}
-		</>
-	)
-}
-
-export default SessionComment

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/CommentTextBody/CommentTextBody.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/CommentTextBody/CommentTextBody.tsx
@@ -11,7 +11,7 @@ import { useSlackSync } from '@hooks/useSlackSync'
 import { useParams } from '@util/react-router/useParams'
 import { splitTaggedUsers } from '@util/string'
 import clsx from 'clsx'
-import React from 'react'
+import React, { useState } from 'react'
 import Linkify from 'react-linkify'
 
 import { AdminSuggestion } from '@/components/Comment/utils/utils'
@@ -31,7 +31,7 @@ interface Props {
 	inputRef?: React.RefObject<HTMLTextAreaElement>
 }
 
-const CommentTextBody = ({
+export const CommentTextBody = ({
 	commentText,
 	placeholder,
 	onChangeHandler,
@@ -46,6 +46,14 @@ const CommentTextBody = ({
 	}>()
 	const slackUrl = getSlackUrl(project_id ?? '')
 	const { slackLoading, syncSlack } = useSlackSync()
+	const [slackSynced, setSlackSynced] = useState(false)
+
+	const handleMentionsInputFocus = () => {
+		if (!slackSynced) {
+			setSlackSynced(true)
+			syncSlack()
+		}
+	}
 
 	const mentions = commentText.split('@')
 	const latestMention = `@${mentions.at(-1)}`
@@ -108,7 +116,7 @@ const CommentTextBody = ({
 			value={commentText}
 			className="mentions"
 			classNames={mentionsClassNames}
-			onFocus={syncSlack}
+			onFocus={handleMentionsInputFocus}
 			onChange={onChangeHandler}
 			placeholder={placeholder}
 			aria-readonly={!onChangeHandler}
@@ -145,6 +153,7 @@ const CommentTextBody = ({
 				data={suggestions}
 				displayTransform={onDisplayTransformHandler}
 				appendSpaceOnAdd
+				suggestionLimit={15}
 				renderSuggestion={(
 					suggestion,
 					search,
@@ -164,8 +173,6 @@ const CommentTextBody = ({
 		</MentionsInput>
 	)
 }
-
-export default CommentTextBody
 
 const Suggestion = ({
 	suggestion,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12743,7 +12743,7 @@ __metadata:
     "@graphql-codegen/typescript-react-apollo": ^2.2.1
     "@highlight-run/client": "workspace:*"
     "@highlight-run/react": "workspace:*"
-    "@highlight-run/react-mentions": 4.4.1
+    "@highlight-run/react-mentions": 4.4.2
     "@highlight-run/rrweb": "workspace:*"
     "@highlight-run/rrweb-types": "workspace:*"
     "@highlight-run/ui": "workspace:*"
@@ -12936,9 +12936,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@highlight-run/react-mentions@npm:4.4.1":
-  version: 4.4.1
-  resolution: "@highlight-run/react-mentions@npm:4.4.1"
+"@highlight-run/react-mentions@npm:4.4.2":
+  version: 4.4.2
+  resolution: "@highlight-run/react-mentions@npm:4.4.2"
   dependencies:
     "@babel/runtime": 7.4.5
     invariant: ^2.2.4
@@ -12947,7 +12947,7 @@ __metadata:
   peerDependencies:
     react: ">=16.8.3"
     react-dom: ">=16.8.3"
-  checksum: cd37e9a76103d397e155dbeaed9dc9efdf731ba3a1e9e969de66484f5c1ef11f9ac3543b50b72e212bcd7a74617a06ec7fd779594aef94882f1d6c9c856058cb
+  checksum: 82de13e45674fbb2ba33de1baa511b80fc0e9ca758b44d573013cbe54bc808e2e79b3cae8fa0c7a2dc0c5ac5999434dc8fb44853525b39244f7436fa022aa73b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Leaving a comment on the frontend can be laggy if the customer has a lot of slack channels that are fetched and displayed. Limit the filtering and displaying to the top 15 results.

## How did you test this change?
1) View a session
2) Click to leave a comment
3) Test filtering
- [ ] Only 15 options are displayed on the mentions
- [ ] Filtering works correctly

[<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->](https://www.loom.com/share/359448ea4ece4683aee865a1e9e7638b?sid=f0bb7714-90ab-4b69-a40f-3823d352b152)

## Are there any deployment considerations?
N/A
