### PR TITLE
add lint step to ruby sdk

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,7 +28,7 @@ jobs:
             - name: Test
               run: bundle exec rake
             - name: Rubocop
-              run: rubocop
+              run: bundle exec rubocop
             # TODO - replace with https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby#publishing-gems
             #- name: Publish
             #  if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,6 +27,8 @@ jobs:
               run: bundle install
             - name: Test
               run: bundle exec rake
+            - name: Rubocop
+              run: rubocop
             # TODO - replace with https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby#publishing-gems
             #- name: Publish
             #  if: github.ref == 'refs/heads/main'

--- a/sdk/highlight-ruby/highlight/.rubocop.yml
+++ b/sdk/highlight-ruby/highlight/.rubocop.yml
@@ -1,0 +1,14 @@
+AllCops:
+    TargetRubyVersion: 2.6
+
+Style/FrozenStringLiteralComment:
+    Enabled: false
+
+Style/Documentation:
+    Enabled: false
+
+Metrics/MethodLength:
+    Enabled: false
+
+Naming/MethodParameterName:
+    Enabled: false

--- a/sdk/highlight-ruby/highlight/Gemfile
+++ b/sdk/highlight-ruby/highlight/Gemfile
@@ -5,3 +5,8 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "minitest", "~> 5.0"
+
+# Gemfile
+group :development do
+  gem 'rubocop', require: false
+end

--- a/sdk/highlight-ruby/highlight/Gemfile
+++ b/sdk/highlight-ruby/highlight/Gemfile
@@ -1,10 +1,10 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in highlight.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
-gem "minitest", "~> 5.0"
+gem 'minitest', '~> 5.0'
+gem 'rake', '~> 12.0'
 
 # Gemfile
 group :development do

--- a/sdk/highlight-ruby/highlight/Gemfile.lock
+++ b/sdk/highlight-ruby/highlight/Gemfile.lock
@@ -1,27 +1,30 @@
 PATH
   remote: .
   specs:
-    highlight (0.1.0)
+    highlight_io (0.1.1)
       grpc (~> 1.52)
-      opentelemetry-exporter-otlp
-      opentelemetry-instrumentation-all
-      opentelemetry-sdk
-      opentelemetry-semantic_conventions
+      opentelemetry-exporter-otlp (~> 0.24.0)
+      opentelemetry-instrumentation-all (~> 0.32.0)
+      opentelemetry-sdk (~> 1.2)
+      opentelemetry-semantic_conventions (~> 1.8.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    google-protobuf (3.22.2)
-    googleapis-common-protos-types (1.5.0)
+    ast (2.4.2)
+    google-protobuf (3.23.4)
+    googleapis-common-protos-types (1.7.0)
       google-protobuf (~> 3.14)
-    grpc (1.52.0)
-      google-protobuf (~> 3.21)
+    grpc (1.56.2)
+      google-protobuf (~> 3.23)
       googleapis-common-protos-types (~> 1.0)
+    json (2.6.3)
+    language_server-protocol (3.17.0.3)
     minitest (5.18.0)
-    opentelemetry-api (1.1.0)
-    opentelemetry-common (0.19.6)
+    opentelemetry-api (1.2.1)
+    opentelemetry-common (0.19.7)
       opentelemetry-api (~> 1.0)
-    opentelemetry-exporter-otlp (0.24.0)
+    opentelemetry-exporter-otlp (0.24.2)
       google-protobuf (~> 3.19)
       googleapis-common-protos-types (~> 1.3)
       opentelemetry-api (~> 1.1)
@@ -145,7 +148,7 @@ GEM
     opentelemetry-instrumentation-que (0.5.1)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.21.0)
-    opentelemetry-instrumentation-racecar (0.1.1)
+    opentelemetry-instrumentation-racecar (0.1.2)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.21.0)
     opentelemetry-instrumentation-rack (0.22.1)
@@ -163,7 +166,7 @@ GEM
     opentelemetry-instrumentation-rake (0.1.1)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.21.0)
-    opentelemetry-instrumentation-rdkafka (0.2.2)
+    opentelemetry-instrumentation-rdkafka (0.2.3)
       opentelemetry-api (~> 1.0)
       opentelemetry-common (~> 0.19.3)
       opentelemetry-instrumentation-base (~> 0.21.0)
@@ -194,25 +197,49 @@ GEM
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.21.0)
       opentelemetry-semantic_conventions (>= 1.8.0)
-    opentelemetry-registry (0.2.0)
+    opentelemetry-registry (0.3.0)
       opentelemetry-api (~> 1.1)
-    opentelemetry-sdk (1.2.0)
+    opentelemetry-sdk (1.2.1)
       opentelemetry-api (~> 1.1)
       opentelemetry-common (~> 0.19.3)
       opentelemetry-registry (~> 0.2)
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.8.0)
       opentelemetry-api (~> 1.0)
+    parallel (1.23.0)
+    parser (3.2.2.3)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.1)
+    rainbow (3.1.1)
     rake (12.3.3)
+    regexp_parser (2.8.1)
+    rexml (3.2.6)
+    rubocop (1.55.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.3)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    unicode-display_width (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  highlight!
+  highlight_io!
   minitest (~> 5.0)
   rake (~> 12.0)
+  rubocop
 
 BUNDLED WITH
    2.1.4

--- a/sdk/highlight-ruby/highlight/README.md
+++ b/sdk/highlight-ruby/highlight/README.md
@@ -1,16 +1,8 @@
 # Highlight
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/highlight`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+This is the Highlight Ruby SDK
 
 ## Installation
-
-Add this line to your application's Gemfile:
-
-```ruby
-gem 'highlight_io'
-```
 
 And then execute:
 
@@ -20,21 +12,18 @@ Or install it yourself as:
 
     $ gem install highlight
 
-## Usage
-
-TODO: Write usage instructions here
-
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/highlight/highlight.
+* Install [rbenv](https://github.com/rbenv/rbenv)
+* Install ruby `rbenv install`
+* Install bundle `gem install bundler`
+* Install dependencies `bundle install`
 
+### Testing
 
-## License
+* `bundle exec rake`
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+### Linting
+
+* `bundle exec rubocop` (use with `-a` to autocorrect)

--- a/sdk/highlight-ruby/highlight/Rakefile
+++ b/sdk/highlight-ruby/highlight/Rakefile
@@ -1,10 +1,10 @@
-require "bundler/gem_tasks"
-require "rake/testtask"
+require 'bundler/gem_tasks'
+require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
 end
 
-task :default => :test
+task default: :test

--- a/sdk/highlight-ruby/highlight/bin/console
+++ b/sdk/highlight-ruby/highlight/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "highlight"
+require 'bundler/setup'
+require 'highlight'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +10,5 @@ require "highlight"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/sdk/highlight-ruby/highlight/highlight.gemspec
+++ b/sdk/highlight-ruby/highlight/highlight.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'The Highlight SDK for Ruby'
   spec.homepage      = 'https://www.highlight.io'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
 

--- a/sdk/highlight-ruby/highlight/highlight.gemspec
+++ b/sdk/highlight-ruby/highlight/highlight.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'opentelemetry-sdk'
-  spec.add_runtime_dependency 'opentelemetry-exporter-otlp'
-  spec.add_runtime_dependency 'opentelemetry-instrumentation-all'
-  spec.add_runtime_dependency 'opentelemetry-semantic_conventions'
+  spec.add_runtime_dependency 'opentelemetry-sdk', '~> 1.2'
+  spec.add_runtime_dependency 'opentelemetry-exporter-otlp', '~> 0.24.0'
+  spec.add_runtime_dependency 'opentelemetry-instrumentation-all', '~> 0.32.0'
+  spec.add_runtime_dependency 'opentelemetry-semantic_conventions', '~> 1.8.0'
   spec.add_runtime_dependency 'grpc', '~> 1.52'
 end

--- a/sdk/highlight-ruby/highlight/highlight.gemspec
+++ b/sdk/highlight-ruby/highlight/highlight.gemspec
@@ -1,30 +1,30 @@
 require_relative 'lib/highlight/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "highlight_io"
+  spec.name          = 'highlight_io'
   spec.version       = Highlight::VERSION
-  spec.authors       = ["Highlight"]
-  spec.email         = ["support@highlight.io"]
+  spec.authors       = ['Highlight']
+  spec.email         = ['support@highlight.io']
 
-  spec.summary       = "The Highlight SDK for Ruby"
-  spec.homepage      = "https://www.highlight.io"
-  spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.summary       = 'The Highlight SDK for Ruby'
+  spec.homepage      = 'https://www.highlight.io'
+  spec.license       = 'MIT'
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
 
-  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata['homepage_uri'] = spec.homepage
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'opentelemetry-sdk', '~> 1.2'
+  spec.add_runtime_dependency 'grpc', '~> 1.52'
   spec.add_runtime_dependency 'opentelemetry-exporter-otlp', '~> 0.24.0'
   spec.add_runtime_dependency 'opentelemetry-instrumentation-all', '~> 0.32.0'
+  spec.add_runtime_dependency 'opentelemetry-sdk', '~> 1.2'
   spec.add_runtime_dependency 'opentelemetry-semantic_conventions', '~> 1.8.0'
-  spec.add_runtime_dependency 'grpc', '~> 1.52'
 end

--- a/sdk/highlight-ruby/highlight/lib/highlight.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight.rb
@@ -6,14 +6,14 @@ require 'logger'
 
 module Highlight
   class H
-    HIGHLIGHT_REQUEST_HEADER = 'X-Highlight-Request'
-    OTLP_HTTP = 'https://otel.highlight.io:4318'
-    HIGHLIGHT_PROJECT_ATTRIBUTE = 'highlight.project_id'
-    HIGHLIGHT_SESSION_ATTRIBUTE = 'highlight.session_id'
-    HIGHLIGHT_TRACE_ATTRIBUTE = 'highlight.trace_id'
-    LOG_EVENT = 'log'
-    LOG_SEVERITY_ATTRIBUTE = 'log.severity'
-    LOG_MESSAGE_ATTRIBUTE = 'log.message'
+    HIGHLIGHT_REQUEST_HEADER = 'X-Highlight-Request'.freeze
+    OTLP_HTTP = 'https://otel.highlight.io:4318'.freeze
+    HIGHLIGHT_PROJECT_ATTRIBUTE = 'highlight.project_id'.freeze
+    HIGHLIGHT_SESSION_ATTRIBUTE = 'highlight.session_id'.freeze
+    HIGHLIGHT_TRACE_ATTRIBUTE = 'highlight.trace_id'.freeze
+    LOG_EVENT = 'log'.freeze
+    LOG_SEVERITY_ATTRIBUTE = 'log.severity'.freeze
+    LOG_MESSAGE_ATTRIBUTE = 'log.message'.freeze
     CODE_FILEPATH = OpenTelemetry::SemanticConventions::Trace::CODE_FILEPATH
     CODE_LINENO = OpenTelemetry::SemanticConventions::Trace::CODE_LINENO
     CODE_FUNCTION = OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION
@@ -23,14 +23,14 @@ module Highlight
     end
 
     def initialize(project_id, otlp_endpoint = OTLP_HTTP)
-      @@instance = self
+      @@instance = self # rubocop:disable Style/ClassVars
 
       @project_id = project_id
       @otlp_endpoint = otlp_endpoint
 
       OpenTelemetry::SDK.configure do |c|
         c.add_span_processor(OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
-                               OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: @otlp_endpoint + '/v1/traces')
+                               OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: "#{@otlp_endpoint}/v1/traces")
                              ))
       end
 
@@ -119,7 +119,7 @@ module Highlight
     def add(severity, message = nil, progname = nil)
       # https://github.com/ruby/logger/blob/master/lib/logger.rb
       severity ||= UNKNOWN
-      return true if @logdev.nil? or severity < level
+      return true if @logdev.nil? or severity < level # rubocop:disable Style/AndOr
 
       progname = @progname if progname.nil?
       if message.nil?

--- a/sdk/highlight-ruby/highlight/lib/highlight.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight.rb
@@ -1,154 +1,146 @@
-require "opentelemetry/sdk"
-require "opentelemetry/exporter/otlp"
-require "opentelemetry/instrumentation/all"
-require "opentelemetry/semantic_conventions"
-require "logger"
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporter/otlp'
+require 'opentelemetry/instrumentation/all'
+require 'opentelemetry/semantic_conventions'
+require 'logger'
 
 module Highlight
-    class H
-        HIGHLIGHT_REQUEST_HEADER = "X-Highlight-Request"
-        OTLP_HTTP = "https://otel.highlight.io:4318"
-        HIGHLIGHT_PROJECT_ATTRIBUTE = "highlight.project_id"
-        HIGHLIGHT_SESSION_ATTRIBUTE = "highlight.session_id"
-        HIGHLIGHT_TRACE_ATTRIBUTE = "highlight.trace_id"
-        LOG_EVENT = "log"
-        LOG_SEVERITY_ATTRIBUTE = "log.severity"
-        LOG_MESSAGE_ATTRIBUTE = "log.message"
-        CODE_FILEPATH = OpenTelemetry::SemanticConventions::Trace::CODE_FILEPATH
-        CODE_LINENO = OpenTelemetry::SemanticConventions::Trace::CODE_LINENO
-        CODE_FUNCTION = OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION
+  class H
+    HIGHLIGHT_REQUEST_HEADER = 'X-Highlight-Request'
+    OTLP_HTTP = 'https://otel.highlight.io:4318'
+    HIGHLIGHT_PROJECT_ATTRIBUTE = 'highlight.project_id'
+    HIGHLIGHT_SESSION_ATTRIBUTE = 'highlight.session_id'
+    HIGHLIGHT_TRACE_ATTRIBUTE = 'highlight.trace_id'
+    LOG_EVENT = 'log'
+    LOG_SEVERITY_ATTRIBUTE = 'log.severity'
+    LOG_MESSAGE_ATTRIBUTE = 'log.message'
+    CODE_FILEPATH = OpenTelemetry::SemanticConventions::Trace::CODE_FILEPATH
+    CODE_LINENO = OpenTelemetry::SemanticConventions::Trace::CODE_LINENO
+    CODE_FUNCTION = OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION
 
-        def self.instance
-            return @@instance
-        end
-
-        def initialize(project_id, otlp_endpoint=OTLP_HTTP)
-            @@instance = self
-
-            @project_id = project_id
-            @otlp_endpoint = otlp_endpoint
-
-            OpenTelemetry::SDK.configure do |c|
-                c.add_span_processor(OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
-                    OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: @otlp_endpoint + "/v1/traces")
-                ))
-            end
-
-            @tracer_provider = OpenTelemetry.tracer_provider
-            @tracer = @tracer_provider.tracer("highlight-tracer")
-        end
-
-        def flush
-            @tracer_provider.force_flush
-        end
-
-        def trace(session_id, request_id)
-            @tracer.in_span("highlight-ctx", attributes: { 
-                HIGHLIGHT_PROJECT_ATTRIBUTE => @project_id, 
-                HIGHLIGHT_SESSION_ATTRIBUTE => session_id,
-                HIGHLIGHT_TRACE_ATTRIBUTE => request_id,
-            }.compact) do |span|
-                begin
-                    yield
-                rescue => e
-                    record_exception(e)
-                    raise
-                end
-            end
-        end
-
-        def record_exception(e)
-            span = OpenTelemetry::Trace.current_span
-            return unless span
-            span.record_exception(e)
-        end
-
-        def record_log(session_id, request_id, level, message, attrs = {})
-            caller_info = caller[0].split(":", 3)
-            function = caller_info[2]
-            if function
-                # format: "in `<function_name>""
-                function.delete_prefix!("in `")
-                function.delete_suffix!("\"")
-            end
-            @tracer.in_span("highlight-ctx", attributes: { 
-                HIGHLIGHT_PROJECT_ATTRIBUTE => @project_id, 
-                HIGHLIGHT_SESSION_ATTRIBUTE => session_id,
-                HIGHLIGHT_TRACE_ATTRIBUTE => request_id,
-            }.compact) do |span|
-                if level == Logger::ERROR || level == Logger::FATAL
-                    span.status = OpenTelemetry::Trace::Status.error(message)
-                end
-                span.add_event(LOG_EVENT, attributes: {
-                    LOG_SEVERITY_ATTRIBUTE => H.log_level_string(level),
-                    LOG_MESSAGE_ATTRIBUTE => message,
-                    CODE_FILEPATH => caller_info[0],
-                    CODE_LINENO => caller_info[1],
-                    CODE_FUNCTION => function,
-                }.merge(attrs))
-            end
-        end
-
-        HighlightHeaders = Struct.new("HighlightHeaders", :session_id, :request_id)
-        def self.parse_headers(headers)
-            if headers && headers[HIGHLIGHT_REQUEST_HEADER]
-                session_id, request_id = headers[HIGHLIGHT_REQUEST_HEADER].split("/")
-                return HighlightHeaders.new(session_id, request_id)
-            end
-            return HighlightHeaders.new(nil, nil)
-        end
-
-        private
-        
-        def self.log_level_string(level)
-            case level
-            when Logger::UNKNOWN
-                "UNKNOWN"
-            when Logger::FATAL
-                "FATAL"
-            when Logger::ERROR
-                "ERROR"
-            when Logger::WARN
-                "WARN"
-            when Logger::INFO
-                "INFO"
-            when Logger::DEBUG
-                "DEBUG"
-            else
-                "UNKNOWN"
-            end
-        end
+    def self.instance
+      @@instance
     end
 
-    class Logger < ::Logger
-        def add(severity, message = nil, progname = nil)
-            # https://github.com/ruby/logger/blob/master/lib/logger.rb
-            severity ||= UNKNOWN
-            if @logdev.nil? or severity < level
-                return true
-            end
-            if progname.nil?
-                progname = @progname
-            end
-            if message.nil?
-                if block_given?
-                    message = yield
-                else
-                    message = progname
-                    progname = @progname
-                end
-            end
-            super
-            H.instance.record_log(nil, nil, severity, message)
-        end
+    def initialize(project_id, otlp_endpoint = OTLP_HTTP)
+      @@instance = self
+
+      @project_id = project_id
+      @otlp_endpoint = otlp_endpoint
+
+      OpenTelemetry::SDK.configure do |c|
+        c.add_span_processor(OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
+                               OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: @otlp_endpoint + '/v1/traces')
+                             ))
+      end
+
+      @tracer_provider = OpenTelemetry.tracer_provider
+      @tracer = @tracer_provider.tracer('highlight-tracer')
     end
 
-    module Integrations
-        module Rails
-            def with_highlight_context
-                highlight_headers = H.parse_headers(request.headers)
-                H.instance.trace(highlight_headers.session_id, highlight_headers.request_id) { yield }
-            end
-        end
+    def flush
+      @tracer_provider.force_flush
     end
+
+    def trace(session_id, request_id)
+      @tracer.in_span('highlight-ctx', attributes: {
+        HIGHLIGHT_PROJECT_ATTRIBUTE => @project_id,
+        HIGHLIGHT_SESSION_ATTRIBUTE => session_id,
+        HIGHLIGHT_TRACE_ATTRIBUTE => request_id
+      }.compact) do |_span|
+        yield
+      rescue StandardError => e
+        record_exception(e)
+        raise
+      end
+    end
+
+    def record_exception(e)
+      span = OpenTelemetry::Trace.current_span
+      return unless span
+
+      span.record_exception(e)
+    end
+
+    def record_log(session_id, request_id, level, message, attrs = {})
+      caller_info = caller[0].split(':', 3)
+      function = caller_info[2]
+      if function
+        # format: "in `<function_name>""
+        function.delete_prefix!('in `')
+        function.delete_suffix!('"')
+      end
+      @tracer.in_span('highlight-ctx', attributes: {
+        HIGHLIGHT_PROJECT_ATTRIBUTE => @project_id,
+        HIGHLIGHT_SESSION_ATTRIBUTE => session_id,
+        HIGHLIGHT_TRACE_ATTRIBUTE => request_id
+      }.compact) do |span|
+        span.status = OpenTelemetry::Trace::Status.error(message) if [Logger::ERROR, Logger::FATAL].include?(level)
+        span.add_event(LOG_EVENT, attributes: {
+          LOG_SEVERITY_ATTRIBUTE => H.log_level_string(level),
+          LOG_MESSAGE_ATTRIBUTE => message,
+          CODE_FILEPATH => caller_info[0],
+          CODE_LINENO => caller_info[1],
+          CODE_FUNCTION => function
+        }.merge(attrs))
+      end
+    end
+
+    HighlightHeaders = Struct.new('HighlightHeaders', :session_id, :request_id)
+    def self.parse_headers(headers)
+      if headers && headers[HIGHLIGHT_REQUEST_HEADER]
+        session_id, request_id = headers[HIGHLIGHT_REQUEST_HEADER].split('/')
+        return HighlightHeaders.new(session_id, request_id)
+      end
+      HighlightHeaders.new(nil, nil)
+    end
+
+    def self.log_level_string(level)
+      case level
+      when Logger::UNKNOWN
+        'UNKNOWN'
+      when Logger::FATAL
+        'FATAL'
+      when Logger::ERROR
+        'ERROR'
+      when Logger::WARN
+        'WARN'
+      when Logger::INFO
+        'INFO'
+      when Logger::DEBUG
+        'DEBUG'
+      else
+        'UNKNOWN'
+      end
+    end
+  end
+
+  class Logger < ::Logger
+    def add(severity, message = nil, progname = nil)
+      # https://github.com/ruby/logger/blob/master/lib/logger.rb
+      severity ||= UNKNOWN
+      return true if @logdev.nil? or severity < level
+
+      progname = @progname if progname.nil?
+      if message.nil?
+        if block_given?
+          message = yield
+        else
+          message = progname
+          progname = @progname
+        end
+      end
+      super
+      H.instance.record_log(nil, nil, severity, message)
+    end
+  end
+
+  module Integrations
+    module Rails
+      def with_highlight_context(&block)
+        highlight_headers = H.parse_headers(request.headers)
+        H.instance.trace(highlight_headers.session_id, highlight_headers.request_id, &block)
+      end
+    end
+  end
 end

--- a/sdk/highlight-ruby/highlight/lib/highlight/version.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight/version.rb
@@ -1,3 +1,3 @@
 module Highlight
-  VERSION = "0.1.1"
+  VERSION = '0.1.1'
 end

--- a/sdk/highlight-ruby/highlight/lib/highlight/version.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight/version.rb
@@ -1,3 +1,3 @@
 module Highlight
-  VERSION = '0.1.1'
+  VERSION = '0.1.1'.freeze
 end

--- a/sdk/highlight-ruby/highlight/test/highlight_test.rb
+++ b/sdk/highlight-ruby/highlight/test/highlight_test.rb
@@ -3,7 +3,7 @@ require_relative './test_helper'
 class HighlightTest < Minitest::Test
   def test_logger
     Highlight::H.new('qe9y4yg1')
-    logger = Highlight::Logger.new(STDOUT)
+    logger = Highlight::Logger.new($stdout)
     logger.add(Logger::INFO, 'ruby test log add!')
     logger.info('ruby test log info!')
     logger.info { 'ruby test log block!' }
@@ -23,6 +23,6 @@ class HighlightTest < Minitest::Test
       raise 'ruby test error handler!'
     end
     Highlight::H.instance.flush
-  rescue StandardError
+  rescue StandardError # rubocop:disable Lint/SuppressedException
   end
 end

--- a/sdk/highlight-ruby/highlight/test/highlight_test.rb
+++ b/sdk/highlight-ruby/highlight/test/highlight_test.rb
@@ -1,9 +1,8 @@
-require_relative "./test_helper"
+require_relative './test_helper'
 
 class HighlightTest < Minitest::Test
   def test_logger
-
-    Highlight::H.new("qe9y4yg1")
+    Highlight::H.new('qe9y4yg1')
     logger = Highlight::Logger.new(STDOUT)
     logger.add(Logger::INFO, 'ruby test log add!')
     logger.info('ruby test log info!')
@@ -12,20 +11,18 @@ class HighlightTest < Minitest::Test
   end
 
   def test_record_log
-    Highlight::H.new("qe9y4yg1")
+    Highlight::H.new('qe9y4yg1')
     Highlight::H.instance.record_log(nil, nil, Logger::INFO, 'ruby test record_log info!')
     Highlight::H.instance.record_log(nil, nil, Logger::ERROR, 'ruby test record_log error!')
     Highlight::H.instance.flush
   end
 
   def test_trace
-    begin
-      Highlight::H.new("qe9y4yg1")
-      Highlight::H.instance.trace(nil, nil) do
-          raise RuntimeError.new('ruby test error handler!')
-      end
-      Highlight::H.instance.flush
-    rescue
+    Highlight::H.new('qe9y4yg1')
+    Highlight::H.instance.trace(nil, nil) do
+      raise 'ruby test error handler!'
     end
+    Highlight::H.instance.flush
+  rescue StandardError
   end
 end

--- a/sdk/highlight-ruby/highlight/test/test_helper.rb
+++ b/sdk/highlight-ruby/highlight/test/test_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
-require "highlight"
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'highlight'
 
-require "minitest/autorun"
+require 'minitest/autorun'


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR lints the ruby sdk using [rubocop](https://github.com/rubocop/rubocop) which is the ubiquitous ruby linter. 

I used `bundle exec rubocop -a` to autocorrect as much as possible. From there, I used manual correction on everything else (or disabled in `.rubocop.yml`). For things I wasn't sure on, I added an inline comment to ignore that specific check.

Since a lot of this PR is formatting, [remove](https://github.com/highlight/highlight/pull/6254/files?w=1) whitespace changes when reviewing.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Build passes

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
