### PR TITLE
Add logging for webhooks

### DIFF
--- a/backend/alerts/integrations/webhook/webhook.go
+++ b/backend/alerts/integrations/webhook/webhook.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"github.com/highlight-run/highlight/backend/alerts/integrations"
 	"github.com/highlight-run/highlight/backend/model"
 	e "github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 type ErrorAlertWebhook struct {
@@ -23,6 +25,14 @@ func sendWebhookData(destination *model.WebhookDestination, body []byte) error {
 	}
 
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		logFields := log.Fields{}
+		if err := json.Unmarshal(body, &logFields); err == nil {
+			ctx := context.TODO()
+			logFields["Destination"] = destination
+			logFields["StatusCode"] = resp.StatusCode
+			log.WithContext(ctx).WithFields(logFields).Info("webhook sent successfully")
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

We are having some reports of webhooks not behaving as expected for users. This PR adds some logging with details for successful webhook requests so we have some information to use for troubleshooting.

## How did you test this change?

Local click test.

<img width="1512" alt="Screenshot 2023-08-07 at 3 02 22 PM" src="https://github.com/highlight/highlight/assets/308182/bdd76fc6-d325-4f6e-9c6d-297748d0770d">
<img width="1510" alt="Screenshot 2023-08-07 at 3 03 05 PM" src="https://github.com/highlight/highlight/assets/308182/20fda516-7fd8-408b-ad1e-78a93b8b9471">

## Are there any deployment considerations?

N/A - only adding some logging
