### PR TITLE
Removing empty 'string' from Error filters form on a new workspace

### DIFF
--- a/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
+++ b/frontend/src/pages/ProjectSettings/ErrorFiltersForm/ErrorFiltersForm.tsx
@@ -42,7 +42,7 @@ export const ErrorFiltersForm = () => {
 						className={styles.input}
 						mode="tags"
 						placeholder="TypeError: Failed to fetch"
-						value={data?.projectSettings?.error_filters}
+						value={data?.projectSettings?.error_filters || []}
 						notFoundContent={
 							<Text>
 								Provide a regex pattern to filter out errors.


### PR DESCRIPTION
## Summary

The error filters form was showing an empty string for new workspaces:

![image](https://github.com/highlight/highlight/assets/878947/e62878b1-9021-47df-a6cc-6c6a35811ee9)

## How did you test this change?

Visual test

## Are there any deployment considerations?

Nope