### PR TITLE
cache GetProject

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -567,7 +567,7 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 		return nil, errors.New("error object stacktrace was empty")
 	}
 
-	project, err := r.Store.GetProject(projectID)
+	project, err := r.Store.GetProject(ctx, projectID)
 	if err != nil {
 		return nil, e.Wrap(err, "error querying project")
 	}
@@ -621,7 +621,7 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 		}
 	}
 
-	if errorgroups.IsErrorTraceFiltered(project, structuredStackTrace) {
+	if errorgroups.IsErrorTraceFiltered(*project, structuredStackTrace) {
 		return nil, ErrUserFilteredError
 	}
 

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -502,3 +502,7 @@ func (r *Client) AcquireLock(ctx context.Context, key string, timeout time.Durat
 func (r *Client) ReleaseLock(ctx context.Context, key string) (err error) {
 	return r.redisClient.Del(ctx, key).Err()
 }
+
+func (r *Client) FlushDB(ctx context.Context) error {
+	return r.redisClient.FlushDB(ctx).Err()
+}

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -504,5 +504,8 @@ func (r *Client) ReleaseLock(ctx context.Context, key string) (err error) {
 }
 
 func (r *Client) FlushDB(ctx context.Context) error {
-	return r.redisClient.FlushDB(ctx).Err()
+	if util.IsDevOrTestEnv() {
+		return r.redisClient.FlushDB(ctx).Err()
+	}
+	return nil
 }

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -9,340 +9,333 @@ import (
 	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/model"
 	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
-	"github.com/highlight-run/highlight/backend/util"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestListErrorObjectsNoData(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		errorGroup := model.ErrorGroup{
-			State: privateModel.ErrorStateOpen,
-			Event: "something broke!",
-		}
-		store.db.Create(&errorGroup)
+	defer teardown(t)
 
-		// No error objects
-		connection, err := store.ListErrorObjects(errorGroup, ListErrorObjectsParams{})
-		assert.NoError(t, err)
+	errorGroup := model.ErrorGroup{
+		State: privateModel.ErrorStateOpen,
+		Event: "something broke!",
+	}
+	store.db.Create(&errorGroup)
 
-		assert.Equal(t, privateModel.ErrorObjectConnection{
-			Edges:    []*privateModel.ErrorObjectEdge{},
-			PageInfo: &privateModel.PageInfo{},
-		}, connection)
-	})
+	// No error objects
+	connection, err := store.ListErrorObjects(errorGroup, ListErrorObjectsParams{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, privateModel.ErrorObjectConnection{
+		Edges:    []*privateModel.ErrorObjectEdge{},
+		PageInfo: &privateModel.PageInfo{},
+	}, connection)
 }
 
 func TestListErrorObjectsOneObjectNoSession(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		errorGroup := model.ErrorGroup{
-			State: privateModel.ErrorStateOpen,
-			Event: "something broke!",
-		}
-		store.db.Create(&errorGroup)
+	defer teardown(t)
+	errorGroup := model.ErrorGroup{
+		State: privateModel.ErrorStateOpen,
+		Event: "something broke!",
+	}
+	store.db.Create(&errorGroup)
 
-		// One error object, no session
-		errorObject := model.ErrorObject{
-			ErrorGroupID: errorGroup.ID,
-		}
-		store.db.Create(&errorObject)
-		connection, err := store.ListErrorObjects(errorGroup, ListErrorObjectsParams{})
-		assert.NoError(t, err)
+	// One error object, no session
+	errorObject := model.ErrorObject{
+		ErrorGroupID: errorGroup.ID,
+	}
+	store.db.Create(&errorObject)
+	connection, err := store.ListErrorObjects(errorGroup, ListErrorObjectsParams{})
+	assert.NoError(t, err)
 
-		assert.Len(t, connection.Edges, 1)
+	assert.Len(t, connection.Edges, 1)
 
-		edge := connection.Edges[0]
+	edge := connection.Edges[0]
 
-		assert.Equal(t, strconv.Itoa(errorObject.ID), edge.Cursor)
-		assert.Equal(t, errorObject.ID, edge.Node.ID)
-		assert.WithinDuration(t, errorObject.CreatedAt, edge.Node.CreatedAt, 10*time.Second)
-		assert.Equal(t, errorObject.Event, edge.Node.Event)
-		assert.WithinDuration(t, errorObject.Timestamp, edge.Node.Timestamp, 10*time.Second)
-		assert.Equal(t, errorGroup.SecureID, edge.Node.ErrorGroupSecureID)
-		assert.Nil(t, edge.Node.Session)
+	assert.Equal(t, strconv.Itoa(errorObject.ID), edge.Cursor)
+	assert.Equal(t, errorObject.ID, edge.Node.ID)
+	assert.WithinDuration(t, errorObject.CreatedAt, edge.Node.CreatedAt, 10*time.Second)
+	assert.Equal(t, errorObject.Event, edge.Node.Event)
+	assert.WithinDuration(t, errorObject.Timestamp, edge.Node.Timestamp, 10*time.Second)
+	assert.Equal(t, errorGroup.SecureID, edge.Node.ErrorGroupSecureID)
+	assert.Nil(t, edge.Node.Session)
 
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     false,
-			HasPreviousPage: false,
-			StartCursor:     strconv.Itoa(errorObject.ID),
-			EndCursor:       strconv.Itoa(errorObject.ID),
-		}, connection.PageInfo)
-
-	})
+	assert.Equal(t, &privateModel.PageInfo{
+		HasNextPage:     false,
+		HasPreviousPage: false,
+		StartCursor:     strconv.Itoa(errorObject.ID),
+		EndCursor:       strconv.Itoa(errorObject.ID),
+	}, connection.PageInfo)
 }
 
 func TestListErrorObjectsOneObjectWithSession(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		errorGroup := model.ErrorGroup{
-			State: privateModel.ErrorStateOpen,
-			Event: "something broke!",
-		}
-		store.db.Create(&errorGroup)
+	teardown(t)
 
-		session := model.Session{
-			AppVersion:  ptr.String("123"),
-			Email:       ptr.String("chilly@mcwilly.com"),
-			Fingerprint: 1234,
-		}
+	errorGroup := model.ErrorGroup{
+		State: privateModel.ErrorStateOpen,
+		Event: "something broke!",
+	}
+	store.db.Create(&errorGroup)
 
-		store.db.Create(&session)
+	session := model.Session{
+		AppVersion:  ptr.String("123"),
+		Email:       ptr.String("chilly@mcwilly.com"),
+		Fingerprint: 1234,
+	}
 
-		errorObject := model.ErrorObject{
-			ErrorGroupID: errorGroup.ID,
-			SessionID:    &session.ID,
-		}
-		store.db.Create(&errorObject)
-		connection, err := store.ListErrorObjects(errorGroup, ListErrorObjectsParams{})
-		assert.NoError(t, err)
+	store.db.Create(&session)
 
-		assert.Len(t, connection.Edges, 1)
+	errorObject := model.ErrorObject{
+		ErrorGroupID: errorGroup.ID,
+		SessionID:    &session.ID,
+	}
+	store.db.Create(&errorObject)
+	connection, err := store.ListErrorObjects(errorGroup, ListErrorObjectsParams{})
+	assert.NoError(t, err)
 
-		edge := connection.Edges[0]
+	assert.Len(t, connection.Edges, 1)
 
-		assert.Equal(t, strconv.Itoa(errorObject.ID), edge.Cursor)
-		assert.Equal(t, errorObject.ID, edge.Node.ID)
-		assert.WithinDuration(t, errorObject.CreatedAt, edge.Node.CreatedAt, 10*time.Second)
-		assert.Equal(t, errorObject.Event, edge.Node.Event)
-		assert.Equal(t, errorGroup.SecureID, edge.Node.ErrorGroupSecureID)
-		assert.Equal(t, &privateModel.ErrorObjectNodeSession{
-			SecureID:    session.SecureID,
-			Email:       session.Email,
-			AppVersion:  session.AppVersion,
-			Fingerprint: &session.Fingerprint,
-		}, edge.Node.Session)
+	edge := connection.Edges[0]
 
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     false,
-			HasPreviousPage: false,
-			StartCursor:     strconv.Itoa(errorObject.ID),
-			EndCursor:       strconv.Itoa(errorObject.ID),
-		}, connection.PageInfo)
-	})
+	assert.Equal(t, strconv.Itoa(errorObject.ID), edge.Cursor)
+	assert.Equal(t, errorObject.ID, edge.Node.ID)
+	assert.WithinDuration(t, errorObject.CreatedAt, edge.Node.CreatedAt, 10*time.Second)
+	assert.Equal(t, errorObject.Event, edge.Node.Event)
+	assert.Equal(t, errorGroup.SecureID, edge.Node.ErrorGroupSecureID)
+	assert.Equal(t, &privateModel.ErrorObjectNodeSession{
+		SecureID:    session.SecureID,
+		Email:       session.Email,
+		AppVersion:  session.AppVersion,
+		Fingerprint: &session.Fingerprint,
+	}, edge.Node.Session)
+
+	assert.Equal(t, &privateModel.PageInfo{
+		HasNextPage:     false,
+		HasPreviousPage: false,
+		StartCursor:     strconv.Itoa(errorObject.ID),
+		EndCursor:       strconv.Itoa(errorObject.ID),
+	}, connection.PageInfo)
 }
 
 func TestListErrorObjectsSearchByEmail(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		errorGroup := model.ErrorGroup{
-			State:     privateModel.ErrorStateOpen,
-			Event:     "something broke!",
-			ProjectID: 1,
-		}
-		store.db.Create(&errorGroup)
+	defer teardown(t)
+	errorGroup := model.ErrorGroup{
+		State:     privateModel.ErrorStateOpen,
+		Event:     "something broke!",
+		ProjectID: 1,
+	}
+	store.db.Create(&errorGroup)
 
-		session1 := model.Session{
-			Email:     ptr.String("chilly@mcwilly.com"),
-			ProjectID: 1,
-		}
+	session1 := model.Session{
+		Email:     ptr.String("chilly@mcwilly.com"),
+		ProjectID: 1,
+	}
 
-		session2 := model.Session{
-			Email:     ptr.String("scoutie@mcwoutie.com"),
-			ProjectID: 1,
-		}
+	session2 := model.Session{
+		Email:     ptr.String("scoutie@mcwoutie.com"),
+		ProjectID: 1,
+	}
 
-		store.db.Create(&session1)
-		store.db.Create(&session2)
+	store.db.Create(&session1)
+	store.db.Create(&session2)
 
-		store.db.Create(&model.ErrorObject{
-			ErrorGroupID: errorGroup.ID,
-			SessionID:    &session1.ID,
-		})
-
-		store.db.Create(&model.ErrorObject{
-			ErrorGroupID: errorGroup.ID,
-			SessionID:    &session2.ID,
-		})
-
-		connection, err := store.ListErrorObjects(errorGroup, ListErrorObjectsParams{
-			Query: "email:scoutie@mcwoutie.com",
-		})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 1)
-
-		connection, err = store.ListErrorObjects(errorGroup, ListErrorObjectsParams{
-			Query: "email:mcwoutie",
-		})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 1)
+	store.db.Create(&model.ErrorObject{
+		ErrorGroupID: errorGroup.ID,
+		SessionID:    &session1.ID,
 	})
+
+	store.db.Create(&model.ErrorObject{
+		ErrorGroupID: errorGroup.ID,
+		SessionID:    &session2.ID,
+	})
+
+	connection, err := store.ListErrorObjects(errorGroup, ListErrorObjectsParams{
+		Query: "email:scoutie@mcwoutie.com",
+	})
+	assert.NoError(t, err)
+
+	assert.Len(t, connection.Edges, 1)
+
+	connection, err = store.ListErrorObjects(errorGroup, ListErrorObjectsParams{
+		Query: "email:mcwoutie",
+	})
+	assert.NoError(t, err)
+
+	assert.Len(t, connection.Edges, 1)
 }
 
 func TestListErrorObjectsTraversing(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		errorGroup := model.ErrorGroup{
-			State: privateModel.ErrorStateOpen,
-		}
-		store.db.Create(&errorGroup)
+	defer teardown(t)
 
-		// Create three pages
-		// The first page has 10 items (hasPreviousPage = false, hasNextPage = true)
-		// The second page has 10 items (hasPreviousPage = true, hasNextPage = true)
-		// The last page has 1 item (hasPreviousPage = true, hasNextPage = false)
-		for i := 1; i <= 21; i++ {
-			store.db.Create(&model.ErrorObject{
-				ErrorGroupID: errorGroup.ID,
-				ID:           i,
-			})
-		}
+	errorGroup := model.ErrorGroup{
+		State: privateModel.ErrorStateOpen,
+	}
+	store.db.Create(&errorGroup)
 
-		// Get first page
-		connection, err := store.ListErrorObjects(errorGroup, ListErrorObjectsParams{})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 10)
-		cursors := lo.Map(connection.Edges, func(edge *privateModel.ErrorObjectEdge, index int) string {
-			return edge.Cursor
+	// Create three pages
+	// The first page has 10 items (hasPreviousPage = false, hasNextPage = true)
+	// The second page has 10 items (hasPreviousPage = true, hasNextPage = true)
+	// The last page has 1 item (hasPreviousPage = true, hasNextPage = false)
+	for i := 1; i <= 21; i++ {
+		store.db.Create(&model.ErrorObject{
+			ErrorGroupID: errorGroup.ID,
+			ID:           i,
 		})
-		assert.Equal(t, []string{"21", "20", "19", "18", "17", "16", "15", "14", "13", "12"}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     true,
-			HasPreviousPage: false,
-			StartCursor:     "21",
-			EndCursor:       "12",
-		}, connection.PageInfo)
+	}
 
-		// Get second page using `After` cursor
-		connection, err = store.ListErrorObjects(errorGroup, ListErrorObjectsParams{After: ptr.String("12")})
-		assert.NoError(t, err)
+	// Get first page
+	connection, err := store.ListErrorObjects(errorGroup, ListErrorObjectsParams{})
+	assert.NoError(t, err)
 
-		assert.Len(t, connection.Edges, 10)
-		cursors = lo.Map(connection.Edges, func(edge *privateModel.ErrorObjectEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{"11", "10", "9", "8", "7", "6", "5", "4", "3", "2"}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     true,
-			HasPreviousPage: true,
-			StartCursor:     "11",
-			EndCursor:       "2",
-		}, connection.PageInfo)
-
-		// Get last page using `After` cursor
-		connection, err = store.ListErrorObjects(errorGroup, ListErrorObjectsParams{After: ptr.String("2")})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 1)
-		cursors = lo.Map(connection.Edges, func(edge *privateModel.ErrorObjectEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{"1"}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     false,
-			HasPreviousPage: true,
-			StartCursor:     "1",
-			EndCursor:       "1",
-		}, connection.PageInfo)
-
-		// Go back to second page using `Before` cursor
-		connection, err = store.ListErrorObjects(errorGroup, ListErrorObjectsParams{Before: ptr.String("1")})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 10)
-		cursors = lo.Map(connection.Edges, func(edge *privateModel.ErrorObjectEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{"11", "10", "9", "8", "7", "6", "5", "4", "3", "2"}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     true,
-			HasPreviousPage: true,
-			StartCursor:     "11",
-			EndCursor:       "2",
-		}, connection.PageInfo)
-
-		// Go back to first page using `Before` cursor
-		connection, err = store.ListErrorObjects(errorGroup, ListErrorObjectsParams{Before: ptr.String("11")})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 10)
-		cursors = lo.Map(connection.Edges, func(edge *privateModel.ErrorObjectEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{"21", "20", "19", "18", "17", "16", "15", "14", "13", "12"}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     true,
-			HasPreviousPage: false,
-			StartCursor:     "21",
-			EndCursor:       "12",
-		}, connection.PageInfo)
-
+	assert.Len(t, connection.Edges, 10)
+	cursors := lo.Map(connection.Edges, func(edge *privateModel.ErrorObjectEdge, index int) string {
+		return edge.Cursor
 	})
+	assert.Equal(t, []string{"21", "20", "19", "18", "17", "16", "15", "14", "13", "12"}, cursors)
+	assert.Equal(t, &privateModel.PageInfo{
+		HasNextPage:     true,
+		HasPreviousPage: false,
+		StartCursor:     "21",
+		EndCursor:       "12",
+	}, connection.PageInfo)
+
+	// Get second page using `After` cursor
+	connection, err = store.ListErrorObjects(errorGroup, ListErrorObjectsParams{After: ptr.String("12")})
+	assert.NoError(t, err)
+
+	assert.Len(t, connection.Edges, 10)
+	cursors = lo.Map(connection.Edges, func(edge *privateModel.ErrorObjectEdge, index int) string {
+		return edge.Cursor
+	})
+	assert.Equal(t, []string{"11", "10", "9", "8", "7", "6", "5", "4", "3", "2"}, cursors)
+	assert.Equal(t, &privateModel.PageInfo{
+		HasNextPage:     true,
+		HasPreviousPage: true,
+		StartCursor:     "11",
+		EndCursor:       "2",
+	}, connection.PageInfo)
+
+	// Get last page using `After` cursor
+	connection, err = store.ListErrorObjects(errorGroup, ListErrorObjectsParams{After: ptr.String("2")})
+	assert.NoError(t, err)
+
+	assert.Len(t, connection.Edges, 1)
+	cursors = lo.Map(connection.Edges, func(edge *privateModel.ErrorObjectEdge, index int) string {
+		return edge.Cursor
+	})
+	assert.Equal(t, []string{"1"}, cursors)
+	assert.Equal(t, &privateModel.PageInfo{
+		HasNextPage:     false,
+		HasPreviousPage: true,
+		StartCursor:     "1",
+		EndCursor:       "1",
+	}, connection.PageInfo)
+
+	// Go back to second page using `Before` cursor
+	connection, err = store.ListErrorObjects(errorGroup, ListErrorObjectsParams{Before: ptr.String("1")})
+	assert.NoError(t, err)
+
+	assert.Len(t, connection.Edges, 10)
+	cursors = lo.Map(connection.Edges, func(edge *privateModel.ErrorObjectEdge, index int) string {
+		return edge.Cursor
+	})
+	assert.Equal(t, []string{"11", "10", "9", "8", "7", "6", "5", "4", "3", "2"}, cursors)
+	assert.Equal(t, &privateModel.PageInfo{
+		HasNextPage:     true,
+		HasPreviousPage: true,
+		StartCursor:     "11",
+		EndCursor:       "2",
+	}, connection.PageInfo)
+
+	// Go back to first page using `Before` cursor
+	connection, err = store.ListErrorObjects(errorGroup, ListErrorObjectsParams{Before: ptr.String("11")})
+	assert.NoError(t, err)
+
+	assert.Len(t, connection.Edges, 10)
+	cursors = lo.Map(connection.Edges, func(edge *privateModel.ErrorObjectEdge, index int) string {
+		return edge.Cursor
+	})
+	assert.Equal(t, []string{"21", "20", "19", "18", "17", "16", "15", "14", "13", "12"}, cursors)
+	assert.Equal(t, &privateModel.PageInfo{
+		HasNextPage:     true,
+		HasPreviousPage: false,
+		StartCursor:     "21",
+		EndCursor:       "12",
+	}, connection.PageInfo)
 }
 
 func TestUpdateErrorGroupStateByAdmin(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
+	defer teardown(t)
 
-		errorGroup := model.ErrorGroup{
-			State: privateModel.ErrorStateOpen,
-		}
+	errorGroup := model.ErrorGroup{
+		State: privateModel.ErrorStateOpen,
+	}
 
-		admin := model.Admin{}
-		store.db.Create(&admin)
+	admin := model.Admin{}
+	store.db.Create(&admin)
 
-		now := time.Now()
-		params := UpdateErrorGroupParams{
-			ID:           -1,
-			State:        privateModel.ErrorStateIgnored,
-			SnoozedUntil: &now,
-		}
+	now := time.Now()
+	params := UpdateErrorGroupParams{
+		ID:           -1,
+		State:        privateModel.ErrorStateIgnored,
+		SnoozedUntil: &now,
+	}
 
-		_, err := store.UpdateErrorGroupStateByAdmin(context.TODO(), admin, params)
-		assert.EqualError(t, err, "record not found")
+	_, err := store.UpdateErrorGroupStateByAdmin(context.TODO(), admin, params)
+	assert.EqualError(t, err, "record not found")
 
-		store.db.Create(&errorGroup)
+	store.db.Create(&errorGroup)
 
-		params.ID = errorGroup.ID
+	params.ID = errorGroup.ID
 
-		updatedErrorGroup, err := store.UpdateErrorGroupStateByAdmin(context.TODO(), admin, params)
-		assert.NoError(t, err)
+	updatedErrorGroup, err := store.UpdateErrorGroupStateByAdmin(context.TODO(), admin, params)
+	assert.NoError(t, err)
 
-		assert.Equal(t, updatedErrorGroup.State, params.State)
-		assert.Equal(t, updatedErrorGroup.SnoozedUntil, params.SnoozedUntil)
+	assert.Equal(t, updatedErrorGroup.State, params.State)
+	assert.Equal(t, updatedErrorGroup.SnoozedUntil, params.SnoozedUntil)
 
-		activityLogs, err := store.GetErrorGroupActivityLogs(errorGroup.ID)
-		assert.NoError(t, err)
+	activityLogs, err := store.GetErrorGroupActivityLogs(errorGroup.ID)
+	assert.NoError(t, err)
 
-		assert.Len(t, activityLogs, 1)
-		assert.Equal(t, activityLogs[0].AdminID, admin.ID)
-		assert.Equal(t, activityLogs[0].ErrorGroupID, errorGroup.ID)
-		assert.Equal(t, activityLogs[0].EventType, model.ErrorGroupIgnoredEvent)
-		assert.NotNil(t, activityLogs[0].EventData)
-	})
+	assert.Len(t, activityLogs, 1)
+	assert.Equal(t, activityLogs[0].AdminID, admin.ID)
+	assert.Equal(t, activityLogs[0].ErrorGroupID, errorGroup.ID)
+	assert.Equal(t, activityLogs[0].EventType, model.ErrorGroupIgnoredEvent)
+	assert.NotNil(t, activityLogs[0].EventData)
 }
 
 func TestUpdateErrorGroupStateBySystem(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		errorGroup := model.ErrorGroup{
-			State: privateModel.ErrorStateOpen,
-		}
+	defer teardown(t)
+	errorGroup := model.ErrorGroup{
+		State: privateModel.ErrorStateOpen,
+	}
 
-		now := time.Now()
-		params := UpdateErrorGroupParams{
-			ID:           -1,
-			State:        privateModel.ErrorStateIgnored,
-			SnoozedUntil: &now,
-		}
+	now := time.Now()
+	params := UpdateErrorGroupParams{
+		ID:           -1,
+		State:        privateModel.ErrorStateIgnored,
+		SnoozedUntil: &now,
+	}
 
-		_, err := store.UpdateErrorGroupStateBySystem(context.TODO(), params)
-		assert.EqualError(t, err, "record not found")
+	_, err := store.UpdateErrorGroupStateBySystem(context.TODO(), params)
+	assert.EqualError(t, err, "record not found")
 
-		store.db.Create(&errorGroup)
+	store.db.Create(&errorGroup)
 
-		params.ID = errorGroup.ID
+	params.ID = errorGroup.ID
 
-		updatedErrorGroup, err := store.UpdateErrorGroupStateBySystem(context.TODO(), params)
-		assert.NoError(t, err)
+	updatedErrorGroup, err := store.UpdateErrorGroupStateBySystem(context.TODO(), params)
+	assert.NoError(t, err)
 
-		assert.Equal(t, updatedErrorGroup.State, params.State)
-		assert.Equal(t, updatedErrorGroup.SnoozedUntil, params.SnoozedUntil)
+	assert.Equal(t, updatedErrorGroup.State, params.State)
+	assert.Equal(t, updatedErrorGroup.SnoozedUntil, params.SnoozedUntil)
 
-		activityLogs, err := store.GetErrorGroupActivityLogs(errorGroup.ID)
-		assert.NoError(t, err)
+	activityLogs, err := store.GetErrorGroupActivityLogs(errorGroup.ID)
+	assert.NoError(t, err)
 
-		assert.Len(t, activityLogs, 1)
-		assert.Equal(t, activityLogs[0].AdminID, 0) // 0 means the system generated this
-		assert.Equal(t, activityLogs[0].ErrorGroupID, errorGroup.ID)
-		assert.Equal(t, activityLogs[0].EventType, model.ErrorGroupIgnoredEvent)
-		assert.NotNil(t, activityLogs[0].EventData)
-	})
+	assert.Len(t, activityLogs, 1)
+	assert.Equal(t, activityLogs[0].AdminID, 0) // 0 means the system generated this
+	assert.Equal(t, activityLogs[0].ErrorGroupID, errorGroup.ID)
+	assert.Equal(t, activityLogs[0].EventType, model.ErrorGroupIgnoredEvent)
+	assert.NotNil(t, activityLogs[0].EventData)
 }

--- a/backend/store/main_test.go
+++ b/backend/store/main_test.go
@@ -2,9 +2,10 @@ package store
 
 import (
 	"context"
-	"github.com/highlight-run/highlight/backend/redis"
 	"os"
 	"testing"
+
+	"github.com/highlight-run/highlight/backend/redis"
 
 	log "github.com/sirupsen/logrus"
 
@@ -27,4 +28,16 @@ func TestMain(m *testing.M) {
 	store = NewStore(db, &opensearch.Client{}, redis.NewClient())
 	code := m.Run()
 	os.Exit(code)
+}
+
+func teardown(t *testing.T) {
+	err := util.ClearTablesInDB(store.db)
+	if err != nil {
+		t.Fatal(e.Wrap(err, "error clearing database"))
+	}
+
+	err = store.redis.FlushDB(context.TODO())
+	if err != nil {
+		t.Fatal(e.Wrap(err, "error clearing database"))
+	}
 }

--- a/backend/store/project_filter_settings_test.go
+++ b/backend/store/project_filter_settings_test.go
@@ -6,73 +6,71 @@ import (
 
 	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/model"
-	"github.com/highlight-run/highlight/backend/util"
 	"github.com/stretchr/testify/assert"
 	_ "gorm.io/driver/postgres"
 )
 
 func TestGetProjectFilterSettings(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		project := model.Project{}
-		store.db.Create(&project)
+	defer teardown(t)
 
-		originalSettings, err := store.GetProjectFilterSettings(project)
-		assert.NoError(t, err)
-		assert.NotNil(t, originalSettings.ID)
+	project := model.Project{}
+	store.db.Create(&project)
 
-		settings, err := store.GetProjectFilterSettings(project)
-		assert.NoError(t, err)
-		assert.Equal(t, settings.ID, originalSettings.ID)
+	originalSettings, err := store.GetProjectFilterSettings(project)
+	assert.NoError(t, err)
+	assert.NotNil(t, originalSettings.ID)
 
-	})
+	settings, err := store.GetProjectFilterSettings(project)
+	assert.NoError(t, err)
+	assert.Equal(t, settings.ID, originalSettings.ID)
 }
 
 func TestUpdateProjectFilterSettings(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		project := model.Project{}
-		store.db.Create(&project)
+	defer teardown(t)
 
-		originalSettings, err := store.UpdateProjectFilterSettings(project, UpdateProjectFilterSettingsParams{
-			FilterSessionsWithoutError: ptr.Bool(true),
-		})
-		assert.NoError(t, err)
-		assert.True(t, originalSettings.FilterSessionsWithoutError)
-		assert.Equal(t, originalSettings.ProjectID, project.ID)
+	project := model.Project{}
+	store.db.Create(&project)
 
-		updatedSettings, err := store.UpdateProjectFilterSettings(project, UpdateProjectFilterSettingsParams{
-			FilterSessionsWithoutError: ptr.Bool(false),
-		})
-		assert.NoError(t, err)
-		assert.False(t, updatedSettings.FilterSessionsWithoutError)
-		assert.Equal(t, updatedSettings.ProjectID, project.ID)
-		assert.Equal(t, originalSettings.ID, updatedSettings.ID)
-
+	originalSettings, err := store.UpdateProjectFilterSettings(project, UpdateProjectFilterSettingsParams{
+		FilterSessionsWithoutError: ptr.Bool(true),
 	})
+	assert.NoError(t, err)
+	assert.True(t, originalSettings.FilterSessionsWithoutError)
+	assert.Equal(t, originalSettings.ProjectID, project.ID)
+
+	updatedSettings, err := store.UpdateProjectFilterSettings(project, UpdateProjectFilterSettingsParams{
+		FilterSessionsWithoutError: ptr.Bool(false),
+	})
+	assert.NoError(t, err)
+	assert.False(t, updatedSettings.FilterSessionsWithoutError)
+	assert.Equal(t, updatedSettings.ProjectID, project.ID)
+	assert.Equal(t, originalSettings.ID, updatedSettings.ID)
+
 }
 
 func TestFindProjectsWithAutoResolveSetting(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		project1 := model.Project{}
-		store.db.Create(&project1)
+	defer teardown(t)
 
-		project2 := model.Project{}
-		store.db.Create(&project2)
+	project1 := model.Project{}
+	store.db.Create(&project1)
 
-		_, err := store.GetProjectFilterSettings(project1)
-		assert.NoError(t, err)
-		_, err = store.UpdateProjectFilterSettings(project1, UpdateProjectFilterSettingsParams{})
-		assert.NoError(t, err)
+	project2 := model.Project{}
+	store.db.Create(&project2)
 
-		_, err = store.GetProjectFilterSettings(project2)
-		assert.NoError(t, err)
-		projectWithAutoResolveSetting, err := store.UpdateProjectFilterSettings(project1, UpdateProjectFilterSettingsParams{
-			AutoResolveStaleErrorsDayInterval: ptr.Int(1),
-		})
-		assert.NoError(t, err)
+	_, err := store.GetProjectFilterSettings(project1)
+	assert.NoError(t, err)
+	_, err = store.UpdateProjectFilterSettings(project1, UpdateProjectFilterSettingsParams{})
+	assert.NoError(t, err)
 
-		projectFilterSettings := store.FindProjectsWithAutoResolveSetting(context.TODO())
-
-		assert.Len(t, projectFilterSettings, 1)
-		assert.Equal(t, projectFilterSettings[0].ID, projectWithAutoResolveSetting.ID)
+	_, err = store.GetProjectFilterSettings(project2)
+	assert.NoError(t, err)
+	projectWithAutoResolveSetting, err := store.UpdateProjectFilterSettings(project1, UpdateProjectFilterSettingsParams{
+		AutoResolveStaleErrorsDayInterval: ptr.Int(1),
 	})
+	assert.NoError(t, err)
+
+	projectFilterSettings := store.FindProjectsWithAutoResolveSetting(context.TODO())
+
+	assert.Len(t, projectFilterSettings, 1)
+	assert.Equal(t, projectFilterSettings[0].ID, projectWithAutoResolveSetting.ID)
 }

--- a/backend/store/projects.go
+++ b/backend/store/projects.go
@@ -1,17 +1,24 @@
 package store
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/redis"
 )
 
-func (store *Store) GetProject(id int) (model.Project, error) {
-	var project model.Project
+func (store *Store) GetProject(ctx context.Context, id int) (*model.Project, error) {
+	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("project-id-%d", id), 150*time.Millisecond, time.Minute, func() (*model.Project, error) {
+		var project model.Project
 
-	err := store.db.Where(&model.Project{
-		Model: model.Model{
-			ID: id,
-		},
-	}).Take(&project).Error
+		err := store.db.Where(&model.Project{
+			Model: model.Model{
+				ID: id,
+			},
+		}).Take(&project).Error
 
-	return project, err
+		return &project, err
+	})
 }

--- a/backend/store/projects_test.go
+++ b/backend/store/projects_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"testing"
 
 	"github.com/highlight-run/highlight/backend/model"
@@ -10,13 +11,14 @@ import (
 
 func TestGetProject(t *testing.T) {
 	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		_, err := store.GetProject(1)
+		ctx := context.Background()
+		_, err := store.GetProject(ctx, 1)
 		assert.Error(t, err)
 
 		project := model.Project{}
 		store.db.Create(&project)
 
-		foundProject, err := store.GetProject(project.ID)
+		foundProject, err := store.GetProject(ctx, project.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, project.ID, foundProject.ID)
 	})

--- a/backend/store/projects_test.go
+++ b/backend/store/projects_test.go
@@ -5,21 +5,21 @@ import (
 	"testing"
 
 	"github.com/highlight-run/highlight/backend/model"
-	"github.com/highlight-run/highlight/backend/util"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetProject(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		ctx := context.Background()
-		_, err := store.GetProject(ctx, 1)
-		assert.Error(t, err)
+	ctx := context.Background()
 
-		project := model.Project{}
-		store.db.Create(&project)
+	defer teardown(t)
 
-		foundProject, err := store.GetProject(ctx, project.ID)
-		assert.NoError(t, err)
-		assert.Equal(t, project.ID, foundProject.ID)
-	})
+	_, err := store.GetProject(ctx, 1)
+	assert.Error(t, err)
+
+	project := model.Project{}
+	store.db.Create(&project)
+
+	foundProject, err := store.GetProject(ctx, project.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, project.ID, foundProject.ID)
 }

--- a/backend/store/services_test.go
+++ b/backend/store/services_test.go
@@ -8,126 +8,122 @@ import (
 	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/model"
 	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
-	"github.com/highlight-run/highlight/backend/util"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFindOrCreateService(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		project := model.Project{}
-		store.db.Create(&project)
+	defer teardown(t)
+	project := model.Project{}
+	store.db.Create(&project)
 
-		service, err := store.FindOrCreateService(project, "public-graph")
-		assert.NoError(t, err)
+	service, err := store.FindOrCreateService(project, "public-graph")
+	assert.NoError(t, err)
 
-		assert.NotNil(t, service.ID)
+	assert.NotNil(t, service.ID)
 
-		foundService, err := store.FindOrCreateService(project, "public-graph")
-		assert.NoError(t, err)
-		assert.Equal(t, service.ID, foundService.ID)
-	})
+	foundService, err := store.FindOrCreateService(project, "public-graph")
+	assert.NoError(t, err)
+	assert.Equal(t, service.ID, foundService.ID)
 }
 
 func TestListServicesTraversing(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		project := model.Project{}
-		store.db.Create(&project)
+	defer teardown(t)
+	project := model.Project{}
+	store.db.Create(&project)
 
-		// Create three pages
-		// The first page has 10 items (hasPreviousPage = false, hasNextPage = true)
-		// The second page has 10 items (hasPreviousPage = true, hasNextPage = true)
-		// The last page has 1 item (hasPreviousPage = true, hasNextPage = false)
-		var servicesIds []string
-		for i := 0; i <= 20; i++ {
-			newService := model.Service{
-				Name:      fmt.Sprintf("Service-%d", i),
-				ProjectID: project.ID,
-				Status:    "healthy",
-			}
-			store.db.Create(&newService)
-			servicesIds = append(servicesIds, strconv.Itoa(newService.ID))
+	// Create three pages
+	// The first page has 10 items (hasPreviousPage = false, hasNextPage = true)
+	// The second page has 10 items (hasPreviousPage = true, hasNextPage = true)
+	// The last page has 1 item (hasPreviousPage = true, hasNextPage = false)
+	var servicesIds []string
+	for i := 0; i <= 20; i++ {
+		newService := model.Service{
+			Name:      fmt.Sprintf("Service-%d", i),
+			ProjectID: project.ID,
+			Status:    "healthy",
 		}
+		store.db.Create(&newService)
+		servicesIds = append(servicesIds, strconv.Itoa(newService.ID))
+	}
 
-		// Get first page
-		connection, err := store.ListServices(project, ListServicesParams{})
-		assert.NoError(t, err)
+	// Get first page
+	connection, err := store.ListServices(project, ListServicesParams{})
+	assert.NoError(t, err)
 
-		assert.Len(t, connection.Edges, 10)
-		cursors := lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{servicesIds[20], servicesIds[19], servicesIds[18], servicesIds[17], servicesIds[16], servicesIds[15], servicesIds[14], servicesIds[13], servicesIds[12], servicesIds[11]}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     true,
-			HasPreviousPage: false,
-			StartCursor:     servicesIds[20],
-			EndCursor:       servicesIds[11],
-		}, connection.PageInfo)
-
-		// Get second page using `After` cursor
-		connection, err = store.ListServices(project, ListServicesParams{After: ptr.String(servicesIds[11])})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 10)
-		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{servicesIds[10], servicesIds[9], servicesIds[8], servicesIds[7], servicesIds[6], servicesIds[5], servicesIds[4], servicesIds[3], servicesIds[2], servicesIds[1]}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     true,
-			HasPreviousPage: true,
-			StartCursor:     servicesIds[10],
-			EndCursor:       servicesIds[1],
-		}, connection.PageInfo)
-
-		// Get last page using `After` cursor
-		connection, err = store.ListServices(project, ListServicesParams{After: ptr.String(servicesIds[1])})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 1)
-		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{servicesIds[0]}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     false,
-			HasPreviousPage: true,
-			StartCursor:     servicesIds[0],
-			EndCursor:       servicesIds[0],
-		}, connection.PageInfo)
-
-		// Go back to second page using `Before` cursor
-		connection, err = store.ListServices(project, ListServicesParams{Before: ptr.String(servicesIds[0])})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 10)
-		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{servicesIds[10], servicesIds[9], servicesIds[8], servicesIds[7], servicesIds[6], servicesIds[5], servicesIds[4], servicesIds[3], servicesIds[2], servicesIds[1]}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     true,
-			HasPreviousPage: true,
-			StartCursor:     servicesIds[10],
-			EndCursor:       servicesIds[1],
-		}, connection.PageInfo)
-
-		// Go back to first page using `Before` cursor
-		connection, err = store.ListServices(project, ListServicesParams{Before: ptr.String(servicesIds[10])})
-		assert.NoError(t, err)
-
-		assert.Len(t, connection.Edges, 10)
-		cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
-			return edge.Cursor
-		})
-		assert.Equal(t, []string{servicesIds[20], servicesIds[19], servicesIds[18], servicesIds[17], servicesIds[16], servicesIds[15], servicesIds[14], servicesIds[13], servicesIds[12], servicesIds[11]}, cursors)
-		assert.Equal(t, &privateModel.PageInfo{
-			HasNextPage:     true,
-			HasPreviousPage: false,
-			StartCursor:     servicesIds[20],
-			EndCursor:       servicesIds[11],
-		}, connection.PageInfo)
-
+	assert.Len(t, connection.Edges, 10)
+	cursors := lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+		return edge.Cursor
 	})
+	assert.Equal(t, []string{servicesIds[20], servicesIds[19], servicesIds[18], servicesIds[17], servicesIds[16], servicesIds[15], servicesIds[14], servicesIds[13], servicesIds[12], servicesIds[11]}, cursors)
+	assert.Equal(t, &privateModel.PageInfo{
+		HasNextPage:     true,
+		HasPreviousPage: false,
+		StartCursor:     servicesIds[20],
+		EndCursor:       servicesIds[11],
+	}, connection.PageInfo)
+
+	// Get second page using `After` cursor
+	connection, err = store.ListServices(project, ListServicesParams{After: ptr.String(servicesIds[11])})
+	assert.NoError(t, err)
+
+	assert.Len(t, connection.Edges, 10)
+	cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+		return edge.Cursor
+	})
+	assert.Equal(t, []string{servicesIds[10], servicesIds[9], servicesIds[8], servicesIds[7], servicesIds[6], servicesIds[5], servicesIds[4], servicesIds[3], servicesIds[2], servicesIds[1]}, cursors)
+	assert.Equal(t, &privateModel.PageInfo{
+		HasNextPage:     true,
+		HasPreviousPage: true,
+		StartCursor:     servicesIds[10],
+		EndCursor:       servicesIds[1],
+	}, connection.PageInfo)
+
+	// Get last page using `After` cursor
+	connection, err = store.ListServices(project, ListServicesParams{After: ptr.String(servicesIds[1])})
+	assert.NoError(t, err)
+
+	assert.Len(t, connection.Edges, 1)
+	cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+		return edge.Cursor
+	})
+	assert.Equal(t, []string{servicesIds[0]}, cursors)
+	assert.Equal(t, &privateModel.PageInfo{
+		HasNextPage:     false,
+		HasPreviousPage: true,
+		StartCursor:     servicesIds[0],
+		EndCursor:       servicesIds[0],
+	}, connection.PageInfo)
+
+	// Go back to second page using `Before` cursor
+	connection, err = store.ListServices(project, ListServicesParams{Before: ptr.String(servicesIds[0])})
+	assert.NoError(t, err)
+
+	assert.Len(t, connection.Edges, 10)
+	cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+		return edge.Cursor
+	})
+	assert.Equal(t, []string{servicesIds[10], servicesIds[9], servicesIds[8], servicesIds[7], servicesIds[6], servicesIds[5], servicesIds[4], servicesIds[3], servicesIds[2], servicesIds[1]}, cursors)
+	assert.Equal(t, &privateModel.PageInfo{
+		HasNextPage:     true,
+		HasPreviousPage: true,
+		StartCursor:     servicesIds[10],
+		EndCursor:       servicesIds[1],
+	}, connection.PageInfo)
+
+	// Go back to first page using `Before` cursor
+	connection, err = store.ListServices(project, ListServicesParams{Before: ptr.String(servicesIds[10])})
+	assert.NoError(t, err)
+
+	assert.Len(t, connection.Edges, 10)
+	cursors = lo.Map(connection.Edges, func(edge *privateModel.ServiceEdge, index int) string {
+		return edge.Cursor
+	})
+	assert.Equal(t, []string{servicesIds[20], servicesIds[19], servicesIds[18], servicesIds[17], servicesIds[16], servicesIds[15], servicesIds[14], servicesIds[13], servicesIds[12], servicesIds[11]}, cursors)
+	assert.Equal(t, &privateModel.PageInfo{
+		HasNextPage:     true,
+		HasPreviousPage: false,
+		StartCursor:     servicesIds[20],
+		EndCursor:       servicesIds[11],
+	}, connection.PageInfo)
 }

--- a/backend/store/sessions_test.go
+++ b/backend/store/sessions_test.go
@@ -5,20 +5,18 @@ import (
 	"testing"
 
 	"github.com/highlight-run/highlight/backend/model"
-	"github.com/highlight-run/highlight/backend/util"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetSession(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		_, err := store.GetSession(context.Background(), 1)
-		assert.Error(t, err)
+	defer teardown(t)
+	_, err := store.GetSession(context.Background(), 1)
+	assert.Error(t, err)
 
-		session := model.Session{}
-		store.db.Create(&session)
+	session := model.Session{}
+	store.db.Create(&session)
 
-		foundSession, err := store.GetSession(context.Background(), session.ID)
-		assert.NoError(t, err)
-		assert.Equal(t, session.ID, foundSession.ID)
-	})
+	foundSession, err := store.GetSession(context.Background(), session.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, session.ID, foundSession.ID)
 }

--- a/backend/store/workspace_settings_test.go
+++ b/backend/store/workspace_settings_test.go
@@ -5,24 +5,23 @@ import (
 	"testing"
 
 	"github.com/highlight-run/highlight/backend/model"
-	"github.com/highlight-run/highlight/backend/util"
 	"github.com/stretchr/testify/assert"
 	_ "gorm.io/driver/postgres"
 )
 
 func TestGetAllWorkspaceSettings(t *testing.T) {
-	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
-		s := model.AllWorkspaceSettings{WorkspaceID: 1}
-		store.db.Create(&s)
+	defer teardown(t)
 
-		newSettings, err := store.GetAllWorkspaceSettings(context.Background(), 1)
-		assert.NoError(t, err)
-		assert.Equal(t, 1, newSettings.WorkspaceID)
+	s := model.AllWorkspaceSettings{WorkspaceID: 1}
+	store.db.Create(&s)
 
-		w2Settings, _ := store.GetAllWorkspaceSettings(context.Background(), 2)
-		assert.NoError(t, err)
-		assert.Equal(t, 2, w2Settings.WorkspaceID)
-	})
+	newSettings, err := store.GetAllWorkspaceSettings(context.Background(), 1)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, newSettings.WorkspaceID)
+
+	w2Settings, _ := store.GetAllWorkspaceSettings(context.Background(), 2)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, w2Settings.WorkspaceID)
 }
 
 func BenchmarkStore_GetAllWorkspaceSettings(b *testing.B) {

--- a/backend/worker/autoresolver.go
+++ b/backend/worker/autoresolver.go
@@ -34,13 +34,13 @@ func (autoResolver *AutoResolver) AutoResolveStaleErrors(ctx context.Context) {
 			}).Info("Finding stale errors for project")
 		interval := projectFilterSettings.AutoResolveStaleErrorsDayInterval
 
-		project, err := autoResolver.store.GetProject(projectFilterSettings.ProjectID)
+		project, err := autoResolver.store.GetProject(ctx, projectFilterSettings.ProjectID)
 		if err != nil {
 			log.WithContext(ctx).WithFields(log.Fields{"project_id": projectFilterSettings.ProjectID}).Error(err)
 			continue
 		}
 
-		err = autoResolver.resolveStaleErrorsForProject(ctx, project, interval)
+		err = autoResolver.resolveStaleErrorsForProject(ctx, *project, interval)
 
 		if err != nil {
 			log.WithContext(ctx).WithFields(log.Fields{"project_id": projectFilterSettings.ProjectID}).Error(err)

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -164,9 +164,8 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context) {
 		// check if that workspace is within the logs quota,
 		// and write the result to redis.
 		for _, projectId := range projectsToQuery {
-			var project model.Project
-			if err := k.Worker.Resolver.DB.Model(&project).
-				Where("id = ?", projectId).Find(&project).Error; err != nil {
+			project, err := k.Worker.Resolver.Store.GetProject(ctx, int(projectId))
+			if err != nil {
 				log.WithContext(ctxW).Error(e.Wrap(err, "error querying project"))
 				continue
 			}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR caches `GetProject` with redis for faster lookups. Since projects don't typically change, I did set the expiration to one minute.

The motivation here is that I would like restore #6214 but that was doing many project lookups in a loop. Hence, adding caching will ensure we don't bottleneck that code path.

Additionally this fixes an issue whereby redis was not cleaning itself up on test runs (see the first failing build on this PR).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Tests pass

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A
