### PR TITLE
add a publish step for ruby sdk

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,9 +29,13 @@ jobs:
               run: bundle exec rake
             - name: Rubocop
               run: bundle exec rubocop
-            # TODO - replace with https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby#publishing-gems
-            #- name: Publish
-            #  if: github.ref == 'refs/heads/main'
-            #  run: poetry publish -u $PYPI_USERNAME -p $PYPI_PASSWORD --skip-existing
-            #  env:
-            #      RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+            - name: Publish to RubyGems
+              env:
+                  RUBYGEMS_API_KEY: '${{secrets.RUBYGEMS_API_KEY}}'
+              run: |
+                  mkdir -p $HOME/.gem
+                  touch $HOME/.gem/credentials
+                  chmod 0600 $HOME/.gem/credentials
+                  printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
+                  gem build *.gemspec
+                  gem push *.gem

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,8 +30,7 @@ jobs:
             - name: Rubocop
               run: bundle exec rubocop
             - name: Publish to RubyGems
-              env:
-                  RUBYGEMS_API_KEY: '${{secrets.RUBYGEMS_API_KEY}}'
+              if: github.ref == 'refs/heads/main'
               run: |
                   mkdir -p $HOME/.gem
                   touch $HOME/.gem/credentials
@@ -39,3 +38,5 @@ jobs:
                   printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
                   gem build *.gemspec
                   gem push *.gem
+              env:
+                  RUBYGEMS_API_KEY: '${{secrets.RUBYGEMS_API_KEY}}'


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Similar to our [python publish](https://github.com/highlight/highlight/blob/main/.github/workflows/python.yml#L46-L51) build step, this adds a workflow for automating publishing ruby gems.

One distinction is that `poetry` has a `--skip-existing` flag which means that it won't error if an existing package with the same version exists. From what I could tell `gem push` doesn't have a equivalent behavior ([docs](https://guides.rubygems.org/command-reference/#gem-push)). 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Before adding a guard for running only on main (`if: github.ref == 'refs/heads/main'`), I verified that publish complains about the existing version (see [build output](https://github.com/highlight/highlight/actions/runs/5800263362/job/15751530260)). 

I intend to update the version when adding a service config (#6229) and will be able to confirm that the published version is correctly uploaded to rubygems.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

N/A