### PR TITLE
support new frequencies in log alerts

### DIFF
--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -65,6 +65,8 @@ import SlackLoadOrConnect from '@/pages/Alerts/AlertConfigurationCard/SlackLoadO
 
 import * as styles from './styles.css'
 
+const LOG_ALERT_MINIMUM_FREQUENCY = 15
+
 export const LogAlertPage = () => {
 	const [startDateParam] = useQueryParam('start_date', DateTimeParam)
 	const [endDateParam] = useQueryParam('end_date', DateTimeParam)
@@ -571,7 +573,11 @@ const LogAlertForm = ({
 							<option value="" disabled>
 								Select alert frequency
 							</option>
-							{FREQUENCIES.map((freq: any) => (
+							{FREQUENCIES.filter(
+								(freq) =>
+									Number(freq.value) >=
+									LOG_ALERT_MINIMUM_FREQUENCY,
+							).map((freq: any) => (
 								<option
 									key={freq.id}
 									value={Number(freq.value)}


### PR DESCRIPTION
## Summary
- log alerts weren't firing for frequencies > 30 mins due to hardcoded values
- remove hardcoding
- limit log alert options to >= 15 seconds (below that, I'm not sure if we can run a clickhouse query fast enough; existing alerts < 15 seconds will trigger at 15 second intervals)
- avoid resetting the timer on deploys
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- created a 30 second log alert, ran `make start-log-alerts-watch` locally, validated that it triggered every 30 seconds
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
