### PR TITLE
write a separate fields table in Clickhouse

### DIFF
--- a/backend/clickhouse/migrations/000014_create_fields_table.down.sql
+++ b/backend/clickhouse/migrations/000014_create_fields_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS fields;

--- a/backend/clickhouse/migrations/000014_create_fields_table.up.sql
+++ b/backend/clickhouse/migrations/000014_create_fields_table.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS fields (
+    ProjectID Int32,
+    Type LowCardinality(String),
+    Name LowCardinality(String),
+    Value String,
+    SessionID Int64
+) ENGINE = MergeTree
+ORDER BY (ProjectID, Type, Name, SessionID);
+-- @block
+select *
+from fields
+order by SessionID desc
+limit 10;
+-- @block
+select *
+from sessions
+order by CreatedAt desc
+limit 2;

--- a/backend/clickhouse/migrations/000014_create_fields_table.up.sql
+++ b/backend/clickhouse/migrations/000014_create_fields_table.up.sql
@@ -2,17 +2,7 @@ CREATE TABLE IF NOT EXISTS fields (
     ProjectID Int32,
     Type LowCardinality(String),
     Name LowCardinality(String),
-    Value String,
-    SessionID Int64
-) ENGINE = MergeTree
-ORDER BY (ProjectID, Type, Name, SessionID);
--- @block
-select *
-from fields
-order by SessionID desc
-limit 10;
--- @block
-select *
-from sessions
-order by CreatedAt desc
-limit 2;
+    SessionID Int64,
+    Value String
+) ENGINE = ReplacingMergeTree
+ORDER BY (ProjectID, Type, Name, SessionID, Value);

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/huandu/go-sqlbuilder"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -148,6 +149,10 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 		NewStruct(new(ClickhouseSession)).
 		InsertInto(SessionsTable, chSessions...).
 		BuildWithFlavor(sqlbuilder.ClickHouse)
+
+	logrus.WithContext(ctx).Info(fieldsSql)
+	logrus.WithContext(ctx).Info(sessionsSql)
+	logrus.WithContext(ctx).Infof("%#v", sessionsArgs)
 
 	var g errgroup.Group
 	g.Go(func() error {

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -4,36 +4,62 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/highlight-run/highlight/backend/model"
-	e "github.com/pkg/errors"
+	"github.com/huandu/go-sqlbuilder"
+	"golang.org/x/sync/errgroup"
 )
 
 type ClickhouseSession struct {
-	model.Session
-	ID             int64
-	Fingerprint    int32
-	ProjectID      int32
-	PagesVisited   int32
-	ViewedByAdmins []int32
-	FieldKeys      []string
-	FieldKeyValues []string
+	ID                 int64
+	Fingerprint        int32
+	ProjectID          int32
+	PagesVisited       int32
+	ViewedByAdmins     []int32
+	FieldKeys          []string
+	FieldKeyValues     []string
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+	SecureID           string
+	Identified         bool
+	Identifier         string
+	City               string
+	Country            string
+	OSName             string
+	OSVersion          string
+	BrowserName        string
+	BrowserVersion     string
+	Processed          *bool
+	HasRageClicks      *bool
+	HasErrors          *bool
+	Length             int64
+	ActiveLength       int64
+	Environment        string
+	AppVersion         *string
+	FirstTime          *bool
+	Viewed             *bool
+	WithinBillingQuota *bool
+	EventCounts        *string
+	Excluded           bool
+	Normalness         *float64
+}
+
+type ClickhouseField struct {
+	ProjectID int32
+	Type      string
+	Name      string
+	Value     string
+	SessionID int64
 }
 
 const SessionsTable = "sessions"
+const FieldsTable = "fields"
 
 func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Session) error {
-	// Not sure if these settings work with batching and the native protocol
-	chCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
-		"async_insert":          1,
-		"wait_for_async_insert": 1,
-	}))
-
-	batch, err := client.conn.PrepareBatch(chCtx, fmt.Sprintf("INSERT INTO %s", SessionsTable))
-	if err != nil {
-		return e.Wrap(err, "failed to create sessions batch")
-	}
+	chFields := []interface{}{}
+	chSessions := []interface{}{}
 
 	for _, session := range sessions {
 		if session == nil {
@@ -52,10 +78,18 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 		fieldKeyValues := []string{}
 		for _, field := range session.Fields {
 			if field == nil {
-				return fmt.Errorf("nil field for session %d", session.ID)
+				continue
 			}
 			fieldKeys = append(fieldKeys, field.Type+"_"+field.Name)
 			fieldKeyValues = append(fieldKeyValues, field.Type+"_"+field.Name+"_"+field.Value)
+			chf := ClickhouseField{
+				ProjectID: int32(session.ProjectID),
+				Type:      field.Type,
+				Name:      field.Name,
+				Value:     field.Value,
+				SessionID: int64(session.ID),
+			}
+			chFields = append(chFields, &chf)
 		}
 
 		viewedByAdmins := []int32{}
@@ -63,21 +97,66 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 			viewedByAdmins = append(viewedByAdmins, int32(admin.ID))
 		}
 
-		ch := ClickhouseSession{
-			Session:        *session,
-			ID:             int64(session.ID),
-			Fingerprint:    int32(session.Fingerprint),
-			ProjectID:      int32(session.ProjectID),
-			PagesVisited:   int32(session.PagesVisited),
-			ViewedByAdmins: viewedByAdmins,
-			FieldKeys:      fieldKeys,
-			FieldKeyValues: fieldKeyValues,
+		chs := ClickhouseSession{
+			ID:                 int64(session.ID),
+			Fingerprint:        int32(session.Fingerprint),
+			ProjectID:          int32(session.ProjectID),
+			PagesVisited:       int32(session.PagesVisited),
+			ViewedByAdmins:     viewedByAdmins,
+			FieldKeys:          fieldKeys,
+			FieldKeyValues:     fieldKeyValues,
+			CreatedAt:          session.CreatedAt,
+			UpdatedAt:          session.UpdatedAt,
+			SecureID:           session.SecureID,
+			Identified:         session.Identified,
+			Identifier:         session.Identifier,
+			City:               session.City,
+			Country:            session.Country,
+			OSName:             session.OSName,
+			OSVersion:          session.OSVersion,
+			BrowserName:        session.BrowserName,
+			BrowserVersion:     session.BrowserVersion,
+			Processed:          session.Processed,
+			HasRageClicks:      session.HasRageClicks,
+			HasErrors:          session.HasErrors,
+			Length:             session.Length,
+			ActiveLength:       session.ActiveLength,
+			Environment:        session.Environment,
+			AppVersion:         session.AppVersion,
+			FirstTime:          session.FirstTime,
+			Viewed:             session.Viewed,
+			WithinBillingQuota: session.WithinBillingQuota,
+			EventCounts:        session.EventCounts,
+			Excluded:           session.Excluded,
+			Normalness:         session.Normalness,
 		}
 
-		if err := batch.AppendStruct(&ch); err != nil {
-			return err
-		}
+		chSessions = append(chSessions, &chs)
 	}
 
-	return batch.Send()
+	chCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"async_insert":          1,
+		"wait_for_async_insert": 1,
+	}))
+
+	fieldsSql, fieldsArgs := sqlbuilder.
+		NewStruct(new(ClickhouseField)).
+		InsertInto(FieldsTable, chFields...).
+		BuildWithFlavor(sqlbuilder.ClickHouse)
+
+	sessionsSql, sessionsArgs := sqlbuilder.
+		NewStruct(new(ClickhouseSession)).
+		InsertInto(SessionsTable, chSessions...).
+		BuildWithFlavor(sqlbuilder.ClickHouse)
+
+	var g errgroup.Group
+	g.Go(func() error {
+		return client.conn.Exec(chCtx, fieldsSql, fieldsArgs...)
+	})
+
+	g.Go(func() error {
+		return client.conn.Exec(chCtx, sessionsSql, sessionsArgs...)
+	})
+
+	return g.Wait()
 }

--- a/backend/clickhouse/sessions_test.go
+++ b/backend/clickhouse/sessions_test.go
@@ -16,6 +16,8 @@ func setupSessionsTest(tb testing.TB) (*Client, func(tb testing.TB)) {
 	return client, func(tb testing.TB) {
 		err := client.conn.Exec(context.Background(), fmt.Sprintf("TRUNCATE TABLE %s", SessionsTable))
 		assert.NoError(tb, err)
+		err = client.conn.Exec(context.Background(), fmt.Sprintf("TRUNCATE TABLE %s", FieldsTable))
+		assert.NoError(tb, err)
 	}
 }
 

--- a/backend/migrations/cmd/backfill-sessions-clickhouse/main.go
+++ b/backend/migrations/cmd/backfill-sessions-clickhouse/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/highlight-run/highlight/backend/clickhouse"
+	"github.com/highlight-run/highlight/backend/model"
+	"github.com/samber/lo"
+	log "github.com/sirupsen/logrus"
+)
+
+const SessionsMaxRowsPostgres = 500
+
+func main() {
+	ctx := context.Background()
+
+	db, err := model.SetupDB(ctx, os.Getenv("PSQL_DB"))
+	if err != nil {
+		log.WithContext(ctx).Fatalf("error setting up db: %+v", err)
+	}
+
+	clickhouseClient, err := clickhouse.NewClient(clickhouse.PrimaryDatabase)
+	if err != nil {
+		log.WithContext(ctx).Fatalf("error creating clickhouse client: %v", err)
+	}
+
+	log.WithContext(ctx).Info("set up clients")
+
+	var sessionIds []int
+	if err := db.Raw(`
+		SELECT id
+		FROM sessions
+		WHERE created_at >= now() - interval '30 days'
+		AND project_id = 898
+	`).Scan(&sessionIds).Error; err != nil {
+		log.WithContext(ctx).Fatal(err)
+	}
+
+	log.WithContext(ctx).Infof("got %d sessions", sessionIds)
+
+	sessionIdChunks := lo.Chunk(lo.Uniq(sessionIds), SessionsMaxRowsPostgres)
+	if len(sessionIdChunks) > 0 {
+		allSessionObjs := []*model.Session{}
+		for idx, chunk := range sessionIdChunks {
+			log.WithContext(ctx).Infof("running chunk %d of %d", idx+1, len(sessionIdChunks))
+
+			sessionObjs := []*model.Session{}
+			if err := db.Model(&model.Session{}).Preload("ViewedByAdmins").Where("id in ?", chunk).Find(&sessionObjs).Error; err != nil {
+				log.WithContext(ctx).Fatal(err)
+			}
+
+			fieldObjs := []*model.Field{}
+			if err := db.Model(&model.Field{}).Where("id IN (SELECT field_id FROM session_fields sf WHERE sf.session_id IN ?)", chunk).Find(&fieldObjs).Error; err != nil {
+				log.WithContext(ctx).Fatal(err)
+			}
+			fieldsById := lo.KeyBy(fieldObjs, func(f *model.Field) int64 {
+				return f.ID
+			})
+
+			type sessionField struct {
+				SessionID int
+				FieldID   int64
+			}
+			sessionFieldObjs := []*sessionField{}
+			if err := db.Table("session_fields").Where("session_id IN ?", chunk).Find(&sessionFieldObjs).Error; err != nil {
+				log.WithContext(ctx).Fatal(err)
+			}
+			sessionToFields := lo.GroupBy(sessionFieldObjs, func(sf *sessionField) int {
+				return sf.SessionID
+			})
+
+			for _, session := range sessionObjs {
+				session.Fields = lo.Map(sessionToFields[session.ID], func(sf *sessionField, _ int) *model.Field {
+					return fieldsById[sf.FieldID]
+				})
+			}
+
+			allSessionObjs = append(allSessionObjs, sessionObjs...)
+
+			if len(allSessionObjs) >= 10000 {
+				log.WithContext(ctx).Infof("flushing with %d sessions", len(allSessionObjs))
+
+				if err := clickhouseClient.WriteSessions(ctx, allSessionObjs); err != nil {
+					log.WithContext(ctx).Fatal(err)
+				}
+				allSessionObjs = []*model.Session{}
+			}
+		}
+
+		if len(allSessionObjs) > 0 {
+			log.WithContext(ctx).Infof("final flush with %d sessions", len(allSessionObjs))
+			if err := clickhouseClient.WriteSessions(ctx, allSessionObjs); err != nil {
+				log.WithContext(ctx).Fatal(err)
+			}
+		}
+	}
+}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -34,6 +34,7 @@ import (
 	"github.com/highlight-run/highlight/backend/front"
 	"github.com/highlight-run/highlight/backend/hlog"
 	"github.com/highlight-run/highlight/backend/integrations/height"
+	kafka_queue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/lambda-functions/deleteSessions/utils"
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/opensearch"
@@ -828,6 +829,10 @@ func (r *mutationResolver) MarkSessionAsViewed(ctx context.Context, secureID str
 
 	if err := r.DB.Model(&s).Association("ViewedByAdmins").Append(admin); err != nil {
 		return nil, e.Wrap(err, "error adding admin to ViewedByAdmins")
+	}
+
+	if err := r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: s.ID}}, strconv.Itoa(s.ID)); err != nil {
+		return nil, err
 	}
 
 	return newSession, nil

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -309,6 +309,10 @@ func (r *Resolver) AppendFields(ctx context.Context, fields []*model.Field, sess
 		return e.Wrap(err, "error updating fields")
 	}
 
+	if err := r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: session.ID}}, strconv.Itoa(session.ID)); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -930,7 +934,7 @@ func (r *Resolver) IndexSessionOpensearch(ctx context.Context, session *model.Se
 	if err := r.AppendProperties(ctx, session.ID, sessionProperties, PropertyType.SESSION); err != nil {
 		log.WithContext(ctx).Error(e.Wrap(err, "error adding set of properties to db"))
 	}
-	return nil
+	return r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: session.ID}}, strconv.Itoa(session.ID))
 }
 
 func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue.InitializeSessionArgs) (*model.Session, error) {
@@ -1400,6 +1404,10 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 
 	if err := r.DB.Save(&session).Error; err != nil {
 		return e.Wrap(err, "[IdentifySession] failed to update session")
+	}
+
+	if err := r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionID}}, strconv.Itoa(sessionID)); err != nil {
+		return err
 	}
 
 	tags := []*publicModel.MetricTag{
@@ -2714,6 +2722,9 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 				log.WithContext(ctx).Error(e.Wrap(err, "error updating session in opensearch"))
 				return err
 			}
+			if err := r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionObj.ID}}, strconv.Itoa(sessionObj.ID)); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -2732,6 +2743,9 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			log.WithContext(osCtx).Error(e.Wrap(err, "error updating session in opensearch"))
 			return err
 		}
+		if err := r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionObj.ID}}, strconv.Itoa(sessionObj.ID)); err != nil {
+			return err
+		}
 	}
 
 	if sessionHasErrors && (sessionObj.HasErrors == nil || !*sessionObj.HasErrors) {
@@ -2739,6 +2753,9 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			"has_errors": true,
 		}); err != nil {
 			log.WithContext(osCtx).Error(e.Wrap(err, "error setting has_errors on session in opensearch"))
+			return err
+		}
+		if err := r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionObj.ID}}, strconv.Itoa(sessionObj.ID)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- did some benchmarking, having a separate table is significantly faster for field searches on projects with lots of fields
- use async inserts for writing sessions / fields
- reenable datasync producers
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally + benchmarked w/ 30 days worth of data for a large project in prod
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- if all is looking good, will backfill existing sessions (for the past month) by writing their ids to the datasync queue
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
