### PR TITLE
avoid writing service.* for frontend logs

### DIFF
--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -223,7 +223,7 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 
 	if val, ok := fields.attrs[highlight.MetricEventValue]; ok {
 		float64Value, err := strconv.ParseFloat(val, 64)
-		if err != nil {
+		if err == nil {
 			fields.metricEventValue = float64Value
 		}
 		delete(fields.attrs, highlight.MetricEventValue)

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -55,6 +55,13 @@ type extractedFields struct {
 	attrs map[string]string
 }
 
+func newExtractedFields() *extractedFields {
+	return &extractedFields{
+		source: modelInputs.LogSourceBackend,
+		attrs:  make(map[string]string),
+	}
+}
+
 type extractFieldsParams struct {
 	resource  *pcommon.Resource
 	span      *ptrace.Span
@@ -64,9 +71,7 @@ type extractFieldsParams struct {
 }
 
 func extractFields(ctx context.Context, params extractFieldsParams) (extractedFields, error) {
-	fields := extractedFields{
-		source: modelInputs.LogSourceBackend,
-	}
+	fields := newExtractedFields()
 
 	var resourceAttributes, spanAttributes, eventAttributes, scopeAttributes, logAttributes map[string]any
 	if params.resource != nil {
@@ -127,7 +132,7 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 		}
 	}
 
-	attrs := mergeMaps(
+	originalAttrs := mergeMaps(
 		resourceAttributes,
 		spanAttributes,
 		eventAttributes,
@@ -135,130 +140,21 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 		logAttributes,
 	)
 
-	// process potential syslog message
-	if len(fields.logBody) > 0 && fields.logBody[0] == '<' {
-		extractSyslog(&fields, attrs)
-	}
-
-	if val, ok := attrs[highlight.DeprecatedProjectIDAttribute]; ok {
-		fields.projectID = val.(string)
-		delete(attrs, highlight.DeprecatedProjectIDAttribute)
-	}
-
-	if val, ok := attrs[highlight.ProjectIDAttribute]; ok {
-		fields.projectID = val.(string)
-		delete(attrs, highlight.ProjectIDAttribute)
-	}
-
-	if val, ok := attrs[highlight.DeprecatedSessionIDAttribute]; ok {
-		fields.sessionID = val.(string)
-		delete(attrs, highlight.DeprecatedSessionIDAttribute)
-	}
-
-	if val, ok := attrs[highlight.SessionIDAttribute]; ok {
-		fields.sessionID = val.(string)
-		delete(attrs, highlight.SessionIDAttribute)
-	}
-
-	if val, ok := attrs[highlight.DeprecatedSourceAttribute]; ok {
+	if val, ok := originalAttrs[highlight.DeprecatedSourceAttribute]; ok {
 		if val == modelInputs.LogSourceFrontend.String() {
 			fields.source = modelInputs.LogSourceFrontend
 		}
-		delete(attrs, highlight.DeprecatedSourceAttribute)
+		delete(originalAttrs, highlight.DeprecatedSourceAttribute)
 	}
 
-	if val, ok := attrs[highlight.SourceAttribute]; ok {
+	if val, ok := originalAttrs[highlight.SourceAttribute]; ok {
 		if val == modelInputs.LogSourceFrontend.String() {
 			fields.source = modelInputs.LogSourceFrontend
 		}
-		delete(attrs, highlight.SourceAttribute)
+		delete(originalAttrs, highlight.SourceAttribute)
 	}
 
-	if val, ok := attrs[highlight.RequestIDAttribute]; ok {
-		fields.requestID = val.(string)
-		delete(attrs, highlight.RequestIDAttribute)
-	}
-
-	if val, ok := attrs[highlight.LogSeverityAttribute]; ok {
-		fields.logSeverity = val.(string)
-		delete(attrs, highlight.LogSeverityAttribute)
-	}
-
-	if val, ok := attrs[highlight.LogMessageAttribute]; ok {
-		fields.logMessage = val.(string)
-		delete(attrs, highlight.LogMessageAttribute)
-	}
-
-	if val, ok := attrs[highlight.MetricEventName]; ok {
-		fields.metricEventName = val.(string)
-		delete(attrs, highlight.MetricEventName)
-	}
-
-	if val, ok := attrs[highlight.MetricEventValue]; ok {
-		float64Value, ok := val.(float64)
-		if ok {
-			fields.metricEventValue = float64Value
-			delete(attrs, highlight.MetricEventValue)
-		} else {
-			stringValue, ok := val.(string)
-			if ok {
-				parsedFloat64Value, err := strconv.ParseFloat(stringValue, 64)
-				if err == nil {
-					fields.metricEventValue = parsedFloat64Value
-					delete(attrs, highlight.MetricEventValue)
-				}
-			}
-		}
-	}
-
-	if val, ok := eventAttributes[string(semconv.ExceptionTypeKey)]; ok { // we know that exception.type will be in the event attributes map
-		fields.exceptionType = val.(string)
-		delete(attrs, string(semconv.ExceptionTypeKey))
-	}
-
-	if val, ok := eventAttributes[string(semconv.ExceptionMessageKey)]; ok { // we know that exception.message will be in the event attributes map
-		fields.exceptionMessage = val.(string)
-		delete(attrs, string(semconv.ExceptionMessageKey))
-	}
-
-	if val, ok := eventAttributes[string(semconv.ExceptionStacktraceKey)]; ok { // we know that exception.stacktrace will be in the event attributes map
-		fields.exceptionStackTrace = val.(string)
-		delete(attrs, string(semconv.ExceptionStacktraceKey))
-	}
-
-	if val, ok := eventAttributes[highlight.ErrorURLAttribute]; ok { // we know that URL will be in the event attributes map
-		fields.errorUrl = val.(string)
-		delete(attrs, highlight.ErrorURLAttribute)
-	}
-
-	if val, ok := resourceAttributes[string(semconv.ServiceNameKey)]; ok { // we know that service name will be in the resource map
-		fields.serviceName = val.(string)
-		if strings.Contains(fields.serviceName, "unknown_service") || fields.serviceName == "highlight-sdk" {
-			fields.serviceName = ""
-		}
-
-		delete(attrs, string(semconv.ServiceNameKey))
-	}
-
-	if val, ok := resourceAttributes[string(semconv.ServiceVersionKey)]; ok { // we know that service version will be in the resource hash
-		fields.serviceVersion = val.(string)
-		delete(attrs, string(semconv.ServiceVersionKey))
-	}
-
-	if fields.projectID == "" {
-		if tag := attrs["fluent.tag"]; tag != nil {
-			if v, _ := tag.(string); v != "" {
-				project := fluentProjectPattern.FindStringSubmatch(v)
-				if project != nil {
-					fields.projectID = project[1]
-				}
-			}
-			delete(attrs, "fluent.tag")
-		}
-	}
-
-	attributesMap := make(map[string]string)
-	for k, v := range attrs {
+	for k, v := range originalAttrs {
 		prefixes := []string{}
 		if fields.source == modelInputs.LogSourceFrontend {
 			prefixes = append(prefixes, highlight.BackendOnlyAttributePrefixes...)
@@ -276,20 +172,116 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 		}
 
 		for key, value := range util.FormatLogAttributes(ctx, k, v) {
-			attributesMap[key] = value
+			fields.attrs[key] = value
 		}
 	}
-	fields.attrs = attributesMap
+
+	// process potential syslog message
+	if len(fields.logBody) > 0 && fields.logBody[0] == '<' {
+		extractSyslog(fields)
+	}
+
+	if val, ok := fields.attrs[highlight.DeprecatedProjectIDAttribute]; ok {
+		fields.projectID = val
+		delete(fields.attrs, highlight.DeprecatedProjectIDAttribute)
+	}
+
+	if val, ok := fields.attrs[highlight.ProjectIDAttribute]; ok {
+		fields.projectID = val
+		delete(fields.attrs, highlight.ProjectIDAttribute)
+	}
+
+	if val, ok := fields.attrs[highlight.DeprecatedSessionIDAttribute]; ok {
+		fields.sessionID = val
+		delete(fields.attrs, highlight.DeprecatedSessionIDAttribute)
+	}
+
+	if val, ok := fields.attrs[highlight.SessionIDAttribute]; ok {
+		fields.sessionID = val
+		delete(fields.attrs, highlight.SessionIDAttribute)
+	}
+
+	if val, ok := fields.attrs[highlight.RequestIDAttribute]; ok {
+		fields.requestID = val
+		delete(fields.attrs, highlight.RequestIDAttribute)
+	}
+
+	if val, ok := fields.attrs[highlight.LogSeverityAttribute]; ok {
+		fields.logSeverity = val
+		delete(fields.attrs, highlight.LogSeverityAttribute)
+	}
+
+	if val, ok := fields.attrs[highlight.LogMessageAttribute]; ok {
+		fields.logMessage = val
+		delete(fields.attrs, highlight.LogMessageAttribute)
+	}
+
+	if val, ok := fields.attrs[highlight.MetricEventName]; ok {
+		fields.metricEventName = val
+		delete(fields.attrs, highlight.MetricEventName)
+	}
+
+	if val, ok := fields.attrs[highlight.MetricEventValue]; ok {
+		float64Value, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			fields.metricEventValue = float64Value
+		}
+		delete(fields.attrs, highlight.MetricEventValue)
+	}
+
+	if val, ok := eventAttributes[string(semconv.ExceptionTypeKey)]; ok { // we know that exception.type will be in the event attributes map
+		fields.exceptionType = val.(string)
+		delete(fields.attrs, string(semconv.ExceptionTypeKey))
+	}
+
+	if val, ok := eventAttributes[string(semconv.ExceptionMessageKey)]; ok { // we know that exception.message will be in the event attributes map
+		fields.exceptionMessage = val.(string)
+		delete(fields.attrs, string(semconv.ExceptionMessageKey))
+	}
+
+	if val, ok := eventAttributes[string(semconv.ExceptionStacktraceKey)]; ok { // we know that exception.stacktrace will be in the event attributes map
+		fields.exceptionStackTrace = val.(string)
+		delete(fields.attrs, string(semconv.ExceptionStacktraceKey))
+	}
+
+	if val, ok := eventAttributes[highlight.ErrorURLAttribute]; ok { // we know that URL will be in the event attributes map
+		fields.errorUrl = val.(string)
+		delete(fields.attrs, highlight.ErrorURLAttribute)
+	}
+
+	if val, ok := fields.attrs[string(semconv.ServiceNameKey)]; ok {
+		fields.serviceName = val
+		if strings.Contains(fields.serviceName, "unknown_service") || fields.serviceName == "highlight-sdk" {
+			fields.serviceName = ""
+		}
+
+		delete(fields.attrs, string(semconv.ServiceNameKey))
+	}
+
+	if val, ok := fields.attrs[string(semconv.ServiceVersionKey)]; ok {
+		fields.serviceVersion = val
+		delete(fields.attrs, string(semconv.ServiceVersionKey))
+	}
+
+	if fields.projectID == "" {
+		if tag := fields.attrs["fluent.tag"]; tag != "" {
+			project := fluentProjectPattern.FindStringSubmatch(tag)
+			if project != nil {
+				fields.projectID = project[1]
+			}
+			delete(fields.attrs, "fluent.tag")
+		}
+	}
 
 	projectIDInt, err := projectToInt(fields.projectID)
 
 	if err != nil {
-		return fields, err
+		return *fields, err
 	}
 
 	fields.projectIDInt = projectIDInt
 
-	return fields, nil
+	return *fields, nil
 }
 
 func mergeMaps(maps ...map[string]any) map[string]any {

--- a/backend/otel/syslog.go
+++ b/backend/otel/syslog.go
@@ -38,10 +38,13 @@ func extractSyslog(fields *extractedFields) {
 		if msg.MsgID != nil {
 			fields.attrs["msg_id"] = *msg.MsgID
 		}
-		// if msg.StructuredData != nil {
-		// 	for k, vMap := range *msg.StructuredData {
-		// 		fields.attrs[k] = v
-		// 	}
-		// }
+		if msg.StructuredData != nil {
+
+			for _, vMap := range *msg.StructuredData {
+				for k, v := range vMap {
+					fields.attrs[k] = v
+				}
+			}
+		}
 	}
 }

--- a/backend/otel/syslog.go
+++ b/backend/otel/syslog.go
@@ -1,12 +1,13 @@
 package otel
 
 import (
+	"strconv"
+
 	"github.com/influxdata/go-syslog/v3/rfc5424"
 	"go.opentelemetry.io/collector/pdata/plog"
-	"strconv"
 )
 
-func extractSyslog(fields *extractedFields, attrs map[string]any) {
+func extractSyslog(fields *extractedFields) {
 	p := rfc5424.NewParser(rfc5424.WithBestEffort())
 	message, err := p.Parse([]byte(fields.logBody))
 	if msg, ok := message.(*rfc5424.SyslogMessage); err == nil && ok {
@@ -14,33 +15,33 @@ func extractSyslog(fields *extractedFields, attrs map[string]any) {
 			fields.logBody = *msg.Message
 		}
 		if msg.Facility != nil {
-			attrs["facility"] = strconv.Itoa(int(*msg.Facility))
+			fields.attrs["facility"] = strconv.Itoa(int(*msg.Facility))
 		}
 		if msg.Severity != nil {
 			fields.logSeverity = plog.SeverityNumber(*msg.Severity).String()
 		}
 		if msg.Priority != nil {
-			attrs["priority"] = strconv.Itoa(int(*msg.Priority))
+			fields.attrs["priority"] = strconv.Itoa(int(*msg.Priority))
 		}
 		if msg.Timestamp != nil {
 			fields.timestamp = *msg.Timestamp
 		}
 		if msg.Hostname != nil {
-			attrs["hostname"] = *msg.Hostname
+			fields.attrs["hostname"] = *msg.Hostname
 		}
 		if msg.Appname != nil {
-			attrs["app_name"] = *msg.Appname
+			fields.attrs["app_name"] = *msg.Appname
 		}
 		if msg.ProcID != nil {
-			attrs["proc_id"] = *msg.ProcID
+			fields.attrs["proc_id"] = *msg.ProcID
 		}
 		if msg.MsgID != nil {
-			attrs["msg_id"] = *msg.MsgID
+			fields.attrs["msg_id"] = *msg.MsgID
 		}
-		if msg.StructuredData != nil {
-			for k, v := range *msg.StructuredData {
-				attrs[k] = v
-			}
-		}
+		// if msg.StructuredData != nil {
+		// 	for k, vMap := range *msg.StructuredData {
+		// 		fields.attrs[k] = v
+		// 	}
+		// }
 	}
 }

--- a/backend/otel/syslog.go
+++ b/backend/otel/syslog.go
@@ -40,9 +40,9 @@ func extractSyslog(fields *extractedFields) {
 		}
 		if msg.StructuredData != nil {
 
-			for _, vMap := range *msg.StructuredData {
+			for topLevelKey, vMap := range *msg.StructuredData {
 				for k, v := range vMap {
-					fields.attrs[k] = v
+					fields.attrs[topLevelKey+"."+k] = v
 				}
 			}
 		}

--- a/backend/otel/syslog_test.go
+++ b/backend/otel/syslog_test.go
@@ -1,16 +1,16 @@
 package otel
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_extractSyslog(t *testing.T) {
-	fields := extractedFields{
-		logBody: "<1>1 2023-07-27T05:43:22.401882Z render render-log-endpoint-test 1 render-log-endpoint-test - Render test log",
-	}
-	attrs := map[string]any{}
-	extractSyslog(&fields, attrs)
-	assert.Equal(t, "render", attrs["hostname"])
+	fields := newExtractedFields()
+
+	fields.logBody = "<1>1 2023-07-27T05:43:22.401882Z render render-log-endpoint-test 1 render-log-endpoint-test - Render test log"
+	extractSyslog(fields)
+	assert.Equal(t, "render", fields.attrs["hostname"])
 	assert.Equal(t, "Render test log", fields.logBody)
 }

--- a/backend/otel/syslog_test.go
+++ b/backend/otel/syslog_test.go
@@ -22,7 +22,7 @@ func Test_extractSyslogWithStructuredData(t *testing.T) {
 	extractSyslog(fields)
 	assert.Equal(t, "mymachine.example.com", fields.attrs["hostname"])
 	assert.Equal(t, "BOMAn application event log entry", fields.logBody)
-	assert.Equal(t, "3", fields.attrs["iut"])
-	assert.Equal(t, "Application", fields.attrs["eventSource"])
-	assert.Equal(t, "1011", fields.attrs["eventID"])
+	assert.Equal(t, "3", fields.attrs["exampleSDID@32473.iut"])
+	assert.Equal(t, "Application", fields.attrs["exampleSDID@32473.eventSource"])
+	assert.Equal(t, "1011", fields.attrs["exampleSDID@32473.eventID"])
 }

--- a/backend/otel/syslog_test.go
+++ b/backend/otel/syslog_test.go
@@ -14,3 +14,15 @@ func Test_extractSyslog(t *testing.T) {
 	assert.Equal(t, "render", fields.attrs["hostname"])
 	assert.Equal(t, "Render test log", fields.logBody)
 }
+
+func Test_extractSyslogWithStructuredData(t *testing.T) {
+	fields := newExtractedFields()
+
+	fields.logBody = "<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"] BOMAn application event log entry"
+	extractSyslog(fields)
+	assert.Equal(t, "mymachine.example.com", fields.attrs["hostname"])
+	assert.Equal(t, "BOMAn application event log entry", fields.logBody)
+	assert.Equal(t, "3", fields.attrs["iut"])
+	assert.Equal(t, "Application", fields.attrs["eventSource"])
+	assert.Equal(t, "1011", fields.attrs["eventID"])
+}

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -45,6 +45,7 @@ var BackendOnlyAttributePrefixes = []string{
 	"os.",
 	"process.",
 	"exception.",
+	"service.",
 }
 
 type OTLP struct {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We are leaking public graph service name and version into customer's frontend logs. The reason this is happening is because our OTEL endpoint serves as the backend for client SDK (i.e. the client SDK calls pub.highlight.io).

We actually already have similar code that guarded against this for leaking our public graph's OTEL information:
https://github.com/highlight/highlight/blob/6268-public-graph-service-information-leaking/backend/otel/extract.go#L263-L265
https://github.com/highlight/highlight/blob/6268-public-graph-service-information-leaking/sdk/highlight-go/otel.go#L42-L48

But we didn't update this when we introduced the service notion. This is also the reason why we were having issues when writing a service record on ingest (see [slack](https://highlightcorp.slack.com/archives/C02CJANPHQS/p1691081920973589?thread_ts=1691080057.488759&cid=C02CJANPHQS)).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Create a new project locally (it's important for this to be different from project id = 1)
* Spin up a local react app and use this config:

```js
H.init('<NEW_PROJECT_ID>', {
    backendUrl: 'https://localhost:8082/public',
    tracingOrigins: true,
    networkRecording: {
      enabled: true,
      recordHeadersAndBody: true,
    },
});
```

Observe that we do not have the `service_name` and `service_version` populated:
![Screenshot_2023-08-08_at_4_12_08_PM](https://github.com/highlight/highlight/assets/58678/103b6136-7e5e-4cc0-97fa-ceff175ffa1c)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
