### PR TITLE
Add additional columns to Services

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2007,7 +2007,7 @@ type Service struct {
 	BuildPrefix     *string
 	GithubPrefix    *string
 	LastSeenVersion *string
-	ErrorDetails    *string
+	ErrorDetails    pq.StringArray `gorm:"type:text[]"`
 }
 
 type LogAlert struct {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2000,10 +2000,14 @@ func (obj *SessionAlert) SendAlerts(ctx context.Context, db *gorm.DB, mailClient
 
 type Service struct {
 	Model
-	ProjectID      int                       `gorm:"not null;uniqueIndex:idx_project_id_name"`
-	Name           string                    `gorm:"not null;uniqueIndex:idx_project_id_name"`
-	Status         modelInputs.ServiceStatus `gorm:"not null;default:created"`
-	GithubRepoPath *string
+	ProjectID       int                       `gorm:"not null;uniqueIndex:idx_project_id_name"`
+	Name            string                    `gorm:"not null;uniqueIndex:idx_project_id_name"`
+	Status          modelInputs.ServiceStatus `gorm:"not null;default:created"`
+	GithubRepoPath  *string
+	BuildPrefix     *string
+	GithubPrefix    *string
+	LastSeenVersion *string
+	ErrorDetails    *string
 }
 
 type LogAlert struct {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -700,7 +700,7 @@ type ComplexityRoot struct {
 		EditProject                      func(childComplexity int, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool) int
 		EditProjectSettings              func(childComplexity int, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, backendDomains pq.StringArray, filterChromeExtension *bool, filterSessionsWithoutError *bool, autoResolveStaleErrorsDayInterval *int) int
 		EditSegment                      func(childComplexity int, id int, projectID int, params model.SearchParamsInput, name string) int
-		EditService                      func(childComplexity int, id int, projectID int, githubRepoPath *string) int
+		EditServiceGithubSettings        func(childComplexity int, id int, projectID int, githubRepoPath *string, buildPrefix *string, githubPrefix *string) int
 		EditWorkspace                    func(childComplexity int, id int, name *string) int
 		EditWorkspaceSettings            func(childComplexity int, workspaceID int, aiApplication *bool, aiInsights *bool) int
 		EmailSignup                      func(childComplexity int, email string) int
@@ -1451,7 +1451,7 @@ type MutationResolver interface {
 	UpdateClickUpProjectMappings(ctx context.Context, workspaceID int, projectMappings []*model.ClickUpProjectMappingInput) (bool, error)
 	UpdateIntegrationProjectMappings(ctx context.Context, workspaceID int, integrationType model.IntegrationType, projectMappings []*model.IntegrationProjectMappingInput) (bool, error)
 	UpdateEmailOptOut(ctx context.Context, token *string, adminID *int, category model.EmailOptOutCategory, isOptOut bool, projectID *int) (bool, error)
-	EditService(ctx context.Context, id int, projectID int, githubRepoPath *string) (*model1.Service, error)
+	EditServiceGithubSettings(ctx context.Context, id int, projectID int, githubRepoPath *string, buildPrefix *string, githubPrefix *string) (*model1.Service, error)
 }
 type QueryResolver interface {
 	Accounts(ctx context.Context) ([]*model.Account, error)
@@ -4789,17 +4789,17 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.EditSegment(childComplexity, args["id"].(int), args["project_id"].(int), args["params"].(model.SearchParamsInput), args["name"].(string)), true
 
-	case "Mutation.editService":
-		if e.complexity.Mutation.EditService == nil {
+	case "Mutation.editServiceGithubSettings":
+		if e.complexity.Mutation.EditServiceGithubSettings == nil {
 			break
 		}
 
-		args, err := ec.field_Mutation_editService_args(context.TODO(), rawArgs)
+		args, err := ec.field_Mutation_editServiceGithubSettings_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
-		return e.complexity.Mutation.EditService(childComplexity, args["id"].(int), args["project_id"].(int), args["github_repo_path"].(*string)), true
+		return e.complexity.Mutation.EditServiceGithubSettings(childComplexity, args["id"].(int), args["project_id"].(int), args["github_repo_path"].(*string), args["build_prefix"].(*string), args["github_prefix"].(*string)), true
 
 	case "Mutation.editWorkspace":
 		if e.complexity.Mutation.EditWorkspace == nil {
@@ -11175,7 +11175,13 @@ type Mutation {
 		is_opt_out: Boolean!
 		project_id: Int
 	): Boolean!
-	editService(id: ID!, project_id: ID!, github_repo_path: String): Service
+	editServiceGithubSettings(
+		id: ID!
+		project_id: ID!
+		github_repo_path: String
+		build_prefix: String
+		github_prefix: String
+	): Service
 }
 
 type Subscription {
@@ -12797,7 +12803,7 @@ func (ec *executionContext) field_Mutation_editSegment_args(ctx context.Context,
 	return args, nil
 }
 
-func (ec *executionContext) field_Mutation_editService_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Mutation_editServiceGithubSettings_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 int
@@ -12827,6 +12833,24 @@ func (ec *executionContext) field_Mutation_editService_args(ctx context.Context,
 		}
 	}
 	args["github_repo_path"] = arg2
+	var arg3 *string
+	if tmp, ok := rawArgs["build_prefix"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("build_prefix"))
+		arg3, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["build_prefix"] = arg3
+	var arg4 *string
+	if tmp, ok := rawArgs["github_prefix"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("github_prefix"))
+		arg4, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["github_prefix"] = arg4
 	return args, nil
 }
 
@@ -39526,8 +39550,8 @@ func (ec *executionContext) fieldContext_Mutation_updateEmailOptOut(ctx context.
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_editService(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_editService(ctx, field)
+func (ec *executionContext) _Mutation_editServiceGithubSettings(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_editServiceGithubSettings(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -39540,7 +39564,7 @@ func (ec *executionContext) _Mutation_editService(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().EditService(rctx, fc.Args["id"].(int), fc.Args["project_id"].(int), fc.Args["github_repo_path"].(*string))
+		return ec.resolvers.Mutation().EditServiceGithubSettings(rctx, fc.Args["id"].(int), fc.Args["project_id"].(int), fc.Args["github_repo_path"].(*string), fc.Args["build_prefix"].(*string), fc.Args["github_prefix"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -39553,7 +39577,7 @@ func (ec *executionContext) _Mutation_editService(ctx context.Context, field gra
 	return ec.marshalOService2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐService(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Mutation_editService(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Mutation_editServiceGithubSettings(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Mutation",
 		Field:      field,
@@ -39590,7 +39614,7 @@ func (ec *executionContext) fieldContext_Mutation_editService(ctx context.Contex
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_editService_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Mutation_editServiceGithubSettings_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -70037,10 +70061,10 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 				return ec._Mutation_updateEmailOptOut(ctx, field)
 			})
 
-		case "editService":
+		case "editServiceGithubSettings":
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_editService(ctx, field)
+				return ec._Mutation_editServiceGithubSettings(ctx, field)
 			})
 
 		default:

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -998,11 +998,15 @@ type ComplexityRoot struct {
 	}
 
 	Service struct {
-		GithubRepoPath func(childComplexity int) int
-		ID             func(childComplexity int) int
-		Name           func(childComplexity int) int
-		ProjectID      func(childComplexity int) int
-		Status         func(childComplexity int) int
+		BuildPrefix     func(childComplexity int) int
+		ErrorDetails    func(childComplexity int) int
+		GithubPrefix    func(childComplexity int) int
+		GithubRepoPath  func(childComplexity int) int
+		ID              func(childComplexity int) int
+		LastSeenVersion func(childComplexity int) int
+		Name            func(childComplexity int) int
+		ProjectID       func(childComplexity int) int
+		Status          func(childComplexity int) int
 	}
 
 	ServiceConnection struct {
@@ -1016,11 +1020,15 @@ type ComplexityRoot struct {
 	}
 
 	ServiceNode struct {
-		GithubRepoPath func(childComplexity int) int
-		ID             func(childComplexity int) int
-		Name           func(childComplexity int) int
-		ProjectID      func(childComplexity int) int
-		Status         func(childComplexity int) int
+		BuildPrefix     func(childComplexity int) int
+		ErrorDetails    func(childComplexity int) int
+		GithubPrefix    func(childComplexity int) int
+		GithubRepoPath  func(childComplexity int) int
+		ID              func(childComplexity int) int
+		LastSeenVersion func(childComplexity int) int
+		Name            func(childComplexity int) int
+		ProjectID       func(childComplexity int) int
+		Status          func(childComplexity int) int
 	}
 
 	Session struct {
@@ -7376,6 +7384,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Segment.ProjectID(childComplexity), true
 
+	case "Service.buildPrefix":
+		if e.complexity.Service.BuildPrefix == nil {
+			break
+		}
+
+		return e.complexity.Service.BuildPrefix(childComplexity), true
+
+	case "Service.errorDetails":
+		if e.complexity.Service.ErrorDetails == nil {
+			break
+		}
+
+		return e.complexity.Service.ErrorDetails(childComplexity), true
+
+	case "Service.githubPrefix":
+		if e.complexity.Service.GithubPrefix == nil {
+			break
+		}
+
+		return e.complexity.Service.GithubPrefix(childComplexity), true
+
 	case "Service.githubRepoPath":
 		if e.complexity.Service.GithubRepoPath == nil {
 			break
@@ -7389,6 +7418,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Service.ID(childComplexity), true
+
+	case "Service.lastSeenVersion":
+		if e.complexity.Service.LastSeenVersion == nil {
+			break
+		}
+
+		return e.complexity.Service.LastSeenVersion(childComplexity), true
 
 	case "Service.name":
 		if e.complexity.Service.Name == nil {
@@ -7439,6 +7475,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ServiceEdge.Node(childComplexity), true
 
+	case "ServiceNode.buildPrefix":
+		if e.complexity.ServiceNode.BuildPrefix == nil {
+			break
+		}
+
+		return e.complexity.ServiceNode.BuildPrefix(childComplexity), true
+
+	case "ServiceNode.errorDetails":
+		if e.complexity.ServiceNode.ErrorDetails == nil {
+			break
+		}
+
+		return e.complexity.ServiceNode.ErrorDetails(childComplexity), true
+
+	case "ServiceNode.githubPrefix":
+		if e.complexity.ServiceNode.GithubPrefix == nil {
+			break
+		}
+
+		return e.complexity.ServiceNode.GithubPrefix(childComplexity), true
+
 	case "ServiceNode.githubRepoPath":
 		if e.complexity.ServiceNode.GithubRepoPath == nil {
 			break
@@ -7452,6 +7509,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ServiceNode.ID(childComplexity), true
+
+	case "ServiceNode.lastSeenVersion":
+		if e.complexity.ServiceNode.LastSeenVersion == nil {
+			break
+		}
+
+		return e.complexity.ServiceNode.LastSeenVersion(childComplexity), true
 
 	case "ServiceNode.name":
 		if e.complexity.ServiceNode.Name == nil {
@@ -9649,6 +9713,10 @@ type Service {
 	name: String!
 	status: ServiceStatus!
 	githubRepoPath: String
+	buildPrefix: String
+	githubPrefix: String
+	lastSeenVersion: String
+	errorDetails: String
 }
 
 type ServiceNode {
@@ -9657,6 +9725,10 @@ type ServiceNode {
 	name: String!
 	status: ServiceStatus!
 	githubRepoPath: String
+	buildPrefix: String
+	githubPrefix: String
+	lastSeenVersion: String
+	errorDetails: String
 }
 
 type ServiceEdge implements Edge {
@@ -39499,6 +39571,14 @@ func (ec *executionContext) fieldContext_Mutation_editService(ctx context.Contex
 				return ec.fieldContext_Service_status(ctx, field)
 			case "githubRepoPath":
 				return ec.fieldContext_Service_githubRepoPath(ctx, field)
+			case "buildPrefix":
+				return ec.fieldContext_Service_buildPrefix(ctx, field)
+			case "githubPrefix":
+				return ec.fieldContext_Service_githubPrefix(ctx, field)
+			case "lastSeenVersion":
+				return ec.fieldContext_Service_lastSeenVersion(ctx, field)
+			case "errorDetails":
+				return ec.fieldContext_Service_errorDetails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Service", field.Name)
 		},
@@ -52106,6 +52186,170 @@ func (ec *executionContext) fieldContext_Service_githubRepoPath(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _Service_buildPrefix(ctx context.Context, field graphql.CollectedField, obj *model1.Service) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Service_buildPrefix(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BuildPrefix, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Service_buildPrefix(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Service",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Service_githubPrefix(ctx context.Context, field graphql.CollectedField, obj *model1.Service) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Service_githubPrefix(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GithubPrefix, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Service_githubPrefix(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Service",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Service_lastSeenVersion(ctx context.Context, field graphql.CollectedField, obj *model1.Service) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Service_lastSeenVersion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LastSeenVersion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Service_lastSeenVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Service",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Service_errorDetails(ctx context.Context, field graphql.CollectedField, obj *model1.Service) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Service_errorDetails(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ErrorDetails, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Service_errorDetails(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Service",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ServiceConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.ServiceConnection) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ServiceConnection_edges(ctx, field)
 	if err != nil {
@@ -52303,6 +52547,14 @@ func (ec *executionContext) fieldContext_ServiceEdge_node(ctx context.Context, f
 				return ec.fieldContext_ServiceNode_status(ctx, field)
 			case "githubRepoPath":
 				return ec.fieldContext_ServiceNode_githubRepoPath(ctx, field)
+			case "buildPrefix":
+				return ec.fieldContext_ServiceNode_buildPrefix(ctx, field)
+			case "githubPrefix":
+				return ec.fieldContext_ServiceNode_githubPrefix(ctx, field)
+			case "lastSeenVersion":
+				return ec.fieldContext_ServiceNode_lastSeenVersion(ctx, field)
+			case "errorDetails":
+				return ec.fieldContext_ServiceNode_errorDetails(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ServiceNode", field.Name)
 		},
@@ -52515,6 +52767,170 @@ func (ec *executionContext) _ServiceNode_githubRepoPath(ctx context.Context, fie
 }
 
 func (ec *executionContext) fieldContext_ServiceNode_githubRepoPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceNode",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceNode_buildPrefix(ctx context.Context, field graphql.CollectedField, obj *model.ServiceNode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceNode_buildPrefix(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BuildPrefix, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceNode_buildPrefix(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceNode",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceNode_githubPrefix(ctx context.Context, field graphql.CollectedField, obj *model.ServiceNode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceNode_githubPrefix(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GithubPrefix, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceNode_githubPrefix(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceNode",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceNode_lastSeenVersion(ctx context.Context, field graphql.CollectedField, obj *model.ServiceNode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceNode_lastSeenVersion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LastSeenVersion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceNode_lastSeenVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceNode",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceNode_errorDetails(ctx context.Context, field graphql.CollectedField, obj *model.ServiceNode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ServiceNode_errorDetails(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ErrorDetails, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ServiceNode_errorDetails(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ServiceNode",
 		Field:      field,
@@ -73164,6 +73580,22 @@ func (ec *executionContext) _Service(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Values[i] = ec._Service_githubRepoPath(ctx, field, obj)
 
+		case "buildPrefix":
+
+			out.Values[i] = ec._Service_buildPrefix(ctx, field, obj)
+
+		case "githubPrefix":
+
+			out.Values[i] = ec._Service_githubPrefix(ctx, field, obj)
+
+		case "lastSeenVersion":
+
+			out.Values[i] = ec._Service_lastSeenVersion(ctx, field, obj)
+
+		case "errorDetails":
+
+			out.Values[i] = ec._Service_errorDetails(ctx, field, obj)
+
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -73286,6 +73718,22 @@ func (ec *executionContext) _ServiceNode(ctx context.Context, sel ast.SelectionS
 		case "githubRepoPath":
 
 			out.Values[i] = ec._ServiceNode_githubRepoPath(ctx, field, obj)
+
+		case "buildPrefix":
+
+			out.Values[i] = ec._ServiceNode_buildPrefix(ctx, field, obj)
+
+		case "githubPrefix":
+
+			out.Values[i] = ec._ServiceNode_githubPrefix(ctx, field, obj)
+
+		case "lastSeenVersion":
+
+			out.Values[i] = ec._ServiceNode_lastSeenVersion(ctx, field, obj)
+
+		case "errorDetails":
+
+			out.Values[i] = ec._ServiceNode_errorDetails(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -633,11 +633,15 @@ func (ServiceEdge) IsEdge()                {}
 func (this ServiceEdge) GetCursor() string { return this.Cursor }
 
 type ServiceNode struct {
-	ID             int           `json:"id"`
-	ProjectID      int           `json:"projectID"`
-	Name           string        `json:"name"`
-	Status         ServiceStatus `json:"status"`
-	GithubRepoPath *string       `json:"githubRepoPath"`
+	ID              int           `json:"id"`
+	ProjectID       int           `json:"projectID"`
+	Name            string        `json:"name"`
+	Status          ServiceStatus `json:"status"`
+	GithubRepoPath  *string       `json:"githubRepoPath"`
+	BuildPrefix     *string       `json:"buildPrefix"`
+	GithubPrefix    *string       `json:"githubPrefix"`
+	LastSeenVersion *string       `json:"lastSeenVersion"`
+	ErrorDetails    *string       `json:"errorDetails"`
 }
 
 type SessionAlertInput struct {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -641,7 +641,7 @@ type ServiceNode struct {
 	BuildPrefix     *string       `json:"buildPrefix"`
 	GithubPrefix    *string       `json:"githubPrefix"`
 	LastSeenVersion *string       `json:"lastSeenVersion"`
-	ErrorDetails    *string       `json:"errorDetails"`
+	ErrorDetails    []string      `json:"errorDetails"`
 }
 
 type SessionAlertInput struct {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -665,7 +665,7 @@ type Service {
 	buildPrefix: String
 	githubPrefix: String
 	lastSeenVersion: String
-	errorDetails: String
+	errorDetails: [String!]
 }
 
 type ServiceNode {
@@ -677,7 +677,7 @@ type ServiceNode {
 	buildPrefix: String
 	githubPrefix: String
 	lastSeenVersion: String
-	errorDetails: String
+	errorDetails: [String!]
 }
 
 type ServiceEdge implements Edge {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2124,7 +2124,13 @@ type Mutation {
 		is_opt_out: Boolean!
 		project_id: Int
 	): Boolean!
-	editService(id: ID!, project_id: ID!, github_repo_path: String): Service
+	editServiceGithubSettings(
+		id: ID!
+		project_id: ID!
+		github_repo_path: String
+		build_prefix: String
+		github_prefix: String
+	): Service
 }
 
 type Subscription {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -662,6 +662,10 @@ type Service {
 	name: String!
 	status: ServiceStatus!
 	githubRepoPath: String
+	buildPrefix: String
+	githubPrefix: String
+	lastSeenVersion: String
+	errorDetails: String
 }
 
 type ServiceNode {
@@ -670,6 +674,10 @@ type ServiceNode {
 	name: String!
 	status: ServiceStatus!
 	githubRepoPath: String
+	buildPrefix: String
+	githubPrefix: String
+	lastSeenVersion: String
+	errorDetails: String
 }
 
 type ServiceEdge implements Edge {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3626,7 +3626,7 @@ func (r *mutationResolver) EditServiceGithubSettings(ctx context.Context, id int
 	}
 
 	serviceUpdates := map[string]interface{}{
-		"ErrorDetails": nil,
+		"ErrorDetails": make([]string, 0),
 		"BuildPrefix":  buildPrefix,
 		"GithubPrefix": githubPrefix,
 	}
@@ -7543,6 +7543,11 @@ func (r *segmentResolver) Params(ctx context.Context, obj *model.Segment) (*mode
 	return params, nil
 }
 
+// ErrorDetails is the resolver for the errorDetails field.
+func (r *serviceResolver) ErrorDetails(ctx context.Context, obj *model.Service) ([]string, error) {
+	panic(fmt.Errorf("not implemented: ErrorDetails - errorDetails"))
+}
+
 // UserObject is the resolver for the user_object field.
 func (r *sessionResolver) UserObject(ctx context.Context, obj *model.Session) (interface{}, error) {
 	return obj.UserObject, nil
@@ -7860,6 +7865,9 @@ func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 // Segment returns generated.SegmentResolver implementation.
 func (r *Resolver) Segment() generated.SegmentResolver { return &segmentResolver{r} }
 
+// Service returns generated.ServiceResolver implementation.
+func (r *Resolver) Service() generated.ServiceResolver { return &serviceResolver{r} }
+
 // Session returns generated.SessionResolver implementation.
 func (r *Resolver) Session() generated.SessionResolver { return &sessionResolver{r} }
 
@@ -7890,6 +7898,7 @@ type metricMonitorResolver struct{ *Resolver }
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type segmentResolver struct{ *Resolver }
+type serviceResolver struct{ *Resolver }
 type sessionResolver struct{ *Resolver }
 type sessionAlertResolver struct{ *Resolver }
 type sessionCommentResolver struct{ *Resolver }

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3618,21 +3618,23 @@ func (r *mutationResolver) UpdateEmailOptOut(ctx context.Context, token *string,
 	return true, nil
 }
 
-// EditService is the resolver for the editService field.
-func (r *mutationResolver) EditService(ctx context.Context, id int, projectID int, githubRepoPath *string) (*model.Service, error) {
+// EditServiceGithubSettings is the resolver for the editServiceGithubSettings field.
+func (r *mutationResolver) EditServiceGithubSettings(ctx context.Context, id int, projectID int, githubRepoPath *string, buildPrefix *string, githubPrefix *string) (*model.Service, error) {
 	project, err := r.isAdminInProject(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 
 	serviceUpdates := map[string]interface{}{
-		"ErrorDetails": "",
+		"ErrorDetails": nil,
+		"BuildPrefix":  buildPrefix,
+		"GithubPrefix": githubPrefix,
 	}
 	if githubRepoPath != nil {
 		serviceUpdates["GithubRepoPath"] = *githubRepoPath
 		serviceUpdates["Status"] = "healthy"
 	} else {
-		serviceUpdates["GithubRepoPath"] = ""
+		serviceUpdates["GithubRepoPath"] = nil
 		serviceUpdates["Status"] = "created"
 	}
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3625,7 +3625,9 @@ func (r *mutationResolver) EditService(ctx context.Context, id int, projectID in
 		return nil, err
 	}
 
-	serviceUpdates := map[string]interface{}{}
+	serviceUpdates := map[string]interface{}{
+		"ErrorDetails": "",
+	}
 	if githubRepoPath != nil {
 		serviceUpdates["GithubRepoPath"] = *githubRepoPath
 		serviceUpdates["Status"] = "healthy"

--- a/backend/store/services.go
+++ b/backend/store/services.go
@@ -86,11 +86,15 @@ func (store *Store) ListServices(project model.Project, params ListServicesParam
 		edge := &privateModel.ServiceEdge{
 			Cursor: strconv.Itoa(service.ID),
 			Node: &privateModel.ServiceNode{
-				ID:             service.ID,
-				ProjectID:      service.ProjectID,
-				Name:           service.Name,
-				Status:         service.Status,
-				GithubRepoPath: service.GithubRepoPath,
+				ID:              service.ID,
+				ProjectID:       service.ProjectID,
+				Name:            service.Name,
+				Status:          service.Status,
+				GithubRepoPath:  service.GithubRepoPath,
+				BuildPrefix:     service.BuildPrefix,
+				GithubPrefix:    service.GithubPrefix,
+				LastSeenVersion: service.LastSeenVersion,
+				ErrorDetails:    service.ErrorDetails,
 			},
 		}
 

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2489,7 +2489,7 @@ export type Segment = {
 export type Service = {
 	__typename?: 'Service'
 	buildPrefix?: Maybe<Scalars['String']>
-	errorDetails?: Maybe<Scalars['String']>
+	errorDetails?: Maybe<Array<Scalars['String']>>
 	githubPrefix?: Maybe<Scalars['String']>
 	githubRepoPath?: Maybe<Scalars['String']>
 	id: Scalars['ID']
@@ -2514,7 +2514,7 @@ export type ServiceEdge = Edge & {
 export type ServiceNode = {
 	__typename?: 'ServiceNode'
 	buildPrefix?: Maybe<Scalars['String']>
-	errorDetails?: Maybe<Scalars['String']>
+	errorDetails?: Maybe<Array<Scalars['String']>>
 	githubPrefix?: Maybe<Scalars['String']>
 	githubRepoPath?: Maybe<Scalars['String']>
 	id: Scalars['ID']

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2486,8 +2486,12 @@ export type Segment = {
 
 export type Service = {
 	__typename?: 'Service'
+	buildPrefix?: Maybe<Scalars['String']>
+	errorDetails?: Maybe<Scalars['String']>
+	githubPrefix?: Maybe<Scalars['String']>
 	githubRepoPath?: Maybe<Scalars['String']>
 	id: Scalars['ID']
+	lastSeenVersion?: Maybe<Scalars['String']>
 	name: Scalars['String']
 	projectID: Scalars['ID']
 	status: ServiceStatus
@@ -2507,8 +2511,12 @@ export type ServiceEdge = Edge & {
 
 export type ServiceNode = {
 	__typename?: 'ServiceNode'
+	buildPrefix?: Maybe<Scalars['String']>
+	errorDetails?: Maybe<Scalars['String']>
+	githubPrefix?: Maybe<Scalars['String']>
 	githubRepoPath?: Maybe<Scalars['String']>
 	id: Scalars['ID']
+	lastSeenVersion?: Maybe<Scalars['String']>
 	name: Scalars['String']
 	projectID: Scalars['ID']
 	status: ServiceStatus

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -971,7 +971,7 @@ export type Mutation = {
 	editProject?: Maybe<Project>
 	editProjectSettings?: Maybe<AllProjectSettings>
 	editSegment?: Maybe<Scalars['Boolean']>
-	editService?: Maybe<Service>
+	editServiceGithubSettings?: Maybe<Service>
 	editWorkspace?: Maybe<Workspace>
 	editWorkspaceSettings?: Maybe<AllWorkspaceSettings>
 	emailSignup: Scalars['String']
@@ -1274,7 +1274,9 @@ export type MutationEditSegmentArgs = {
 	project_id: Scalars['ID']
 }
 
-export type MutationEditServiceArgs = {
+export type MutationEditServiceGithubSettingsArgs = {
+	build_prefix?: InputMaybe<Scalars['String']>
+	github_prefix?: InputMaybe<Scalars['String']>
 	github_repo_path?: InputMaybe<Scalars['String']>
 	id: Scalars['ID']
 	project_id: Scalars['ID']


### PR DESCRIPTION
## Summary
Add the following fields to the `Service` table:
- BuildPrefix: path that code is moved to for deployment that is displayed on the error stacktrace
- GithubPrefix: path that is removed in deployment that is needed to fetch from GitHub appropriately
- LastSeenVersion: string representation of the version last seen in logs
- ErrorDetails: details around why a service may be in the error state

## How did you test this change?
1) Test the `service` query in postman to return fields
2) Test the `editServiceGithubSettings` mutation in postman to edit fields

https://www.loom.com/share/0f9349c7cbfa46a79973c175e9a1a979?sid=c1c4ebf2-1567-487d-ade8-60c7145aac68

## Are there any deployment considerations?
N/A - not being used