### PR TITLE
ui fixes on log alerts page

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5419,7 +5419,6 @@ body {
 ._155k3sw6 {
   opacity: 0.2;
   left: 0;
-  z-index: 1;
   width: calc(100% - 4px);
   pointer-events: none;
 }

--- a/frontend/src/pages/LogsPage/LogsHistogram/LogsHistogram.css.ts
+++ b/frontend/src/pages/LogsPage/LogsHistogram/LogsHistogram.css.ts
@@ -44,7 +44,6 @@ export const dragSelection = style({
 export const thresholdArea = style({
 	opacity: 0.2,
 	left: 0,
-	zIndex: 1,
 	width: 'calc(100% - 4px)',
 	pointerEvents: 'none',
 })

--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -200,6 +200,7 @@ export const Search: React.FC<{
 	className?: string
 	keysLoading: boolean
 	disableSearch?: boolean
+	placeholder?: string
 }> = ({
 	initialQuery,
 	startDate,
@@ -209,6 +210,7 @@ export const Search: React.FC<{
 	keys,
 	keysLoading,
 	disableSearch,
+	placeholder,
 }) => {
 	const formState = useForm()
 	const { project_id } = useParams()
@@ -347,7 +349,7 @@ export const Search: React.FC<{
 					autoSelect
 					state={state}
 					name="search"
-					placeholder="Search your logs..."
+					placeholder={placeholder ?? 'Search your logs...'}
 					className={className ?? styles.combobox}
 					style={{
 						paddingLeft: hideIcon ? undefined : 40,


### PR DESCRIPTION
## Summary
- fix bug where search box wouldn't let you enter in more than one value
- move search box to top of page
- only rerender histogram when the search form submits (avoid rerendering while the user is actively typing)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
