### PR TITLE
Improve comment slack message UI/UX

### DIFF
--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
@@ -243,9 +243,7 @@ export const NewCommentForm = ({
 						? issueDescription
 						: null,
 					additional_context: currentUrl
-						? `• From ${
-								error_secure_id ? 'error' : 'session'
-						  } URL: <${currentUrl}|${currentUrl}>`
+						? `*User\'s URL:* <${currentUrl}|${currentUrl}>`
 						: null,
 				},
 				refetchQueries: [namedOperations.Query.GetSessionComments],


### PR DESCRIPTION
## Summary
There was some confusion in the "From session url", so update the comment slack message to:
- Move the CTA button to the bottom with primary styles
- Rename urls to make more clear
- Combine additional info with error/session info

More info: https://highlightcorp.slack.com/archives/C02N2AZS8BV/p1691511184945239

## How did you test this change?
1. View a sesion
2. Comment and tag the #spencer-test slack channel

<img width="671" alt="Screenshot 2023-08-09 at 6 57 12 PM" src="https://github.com/highlight/highlight/assets/17744174/a5a040ed-f2e0-430a-b90e-9b2d70ce4aa9">

## Are there any deployment considerations?
N/A
