### PR TITLE
gate analytics pages

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -42,6 +42,7 @@ import {
 	TextLink,
 } from '@highlight-run/ui'
 import { vars } from '@highlight-run/ui/src/css/vars'
+import useFeatureFlag, { Feature } from '@hooks/useFeatureFlag/useFeatureFlag'
 import { useProjectId } from '@hooks/useProjectId'
 import SvgHighlightLogoOnLight from '@icons/HighlightLogoOnLight'
 import SvgXIcon from '@icons/XIcon'
@@ -117,6 +118,7 @@ export const useBillingHook = ({
 export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 	const { projectId } = useProjectId()
 	const { isLoggedIn, signOut } = useAuthContext()
+	const showAnalytics = useFeatureFlag(Feature.Analytics)
 	const { currentProject, currentWorkspace } = useApplicationContext()
 	const workspaceId = currentWorkspace?.id
 
@@ -245,31 +247,33 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 											kind="secondary"
 										/>
 										<Menu.List>
-											<Link
-												to={`/${projectId}/dashboards`}
-												className={linkStyle}
-											>
-												<Menu.Item>
-													<Box
-														display="flex"
-														alignItems="center"
-														gap="4"
-													>
-														<IconSolidChartBar
-															size={14}
-															color={
-																vars.theme
-																	.interactive
-																	.fill
-																	.secondary
-																	.content
-																	.text
-															}
-														/>
-														Dashboards
-													</Box>
-												</Menu.Item>
-											</Link>
+											{showAnalytics && (
+												<Link
+													to={`/${projectId}/dashboards`}
+													className={linkStyle}
+												>
+													<Menu.Item>
+														<Box
+															display="flex"
+															alignItems="center"
+															gap="4"
+														>
+															<IconSolidChartBar
+																size={14}
+																color={
+																	vars.theme
+																		.interactive
+																		.fill
+																		.secondary
+																		.content
+																		.text
+																}
+															/>
+															Dashboards
+														</Box>
+													</Menu.Item>
+												</Link>
+											)}
 											<Link
 												to={`/${projectId}/integrations`}
 												className={linkStyle}
@@ -295,31 +299,33 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 													</Box>
 												</Menu.Item>
 											</Link>
-											<Link
-												to={`/${projectId}/analytics`}
-												className={linkStyle}
-											>
-												<Menu.Item>
-													<Box
-														display="flex"
-														alignItems="center"
-														gap="4"
-													>
-														<IconSolidChartPie
-															size={14}
-															color={
-																vars.theme
-																	.interactive
-																	.fill
-																	.secondary
-																	.content
-																	.text
-															}
-														/>
-														Analytics
-													</Box>
-												</Menu.Item>
-											</Link>
+											{showAnalytics && (
+												<Link
+													to={`/${projectId}/analytics`}
+													className={linkStyle}
+												>
+													<Menu.Item>
+														<Box
+															display="flex"
+															alignItems="center"
+															gap="4"
+														>
+															<IconSolidChartPie
+																size={14}
+																color={
+																	vars.theme
+																		.interactive
+																		.fill
+																		.secondary
+																		.content
+																		.text
+																}
+															/>
+															Analytics
+														</Box>
+													</Menu.Item>
+												</Link>
+											)}
 											<Link
 												to={`/${projectId}/setup`}
 												className={linkStyle}

--- a/frontend/src/hooks/useDataTimeRange.ts
+++ b/frontend/src/hooks/useDataTimeRange.ts
@@ -4,7 +4,7 @@ import moment from 'moment'
 export const FORMAT = 'YYYY-MM-DDTHH:mm:00.000000000Z'
 
 export const defaultEndDate = moment()
-export const defaultLookback = 24 * 60
+export const defaultLookback = 7 * 24 * 60
 export const defaultStartDate = moment(defaultEndDate).subtract(
 	defaultLookback,
 	'minutes',

--- a/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
+++ b/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
@@ -15,6 +15,7 @@ interface Config {
 export enum Feature {
 	HistogramTimelineV2,
 	AiSessionInsights,
+	Analytics,
 }
 
 // configures the criteria and percentage of population for which the feature is active.
@@ -39,6 +40,14 @@ export const FeatureConfig: { [key: number]: Config } = {
 	[Feature.AiSessionInsights]: {
 		workspace: true,
 		percent: 100,
+	},
+	[Feature.Analytics]: {
+		workspace: true,
+		percent: 0,
+		workspaceOverride: new Set<string>([
+			// Numero
+			'701',
+		]),
 	},
 } as const
 


### PR DESCRIPTION
## Summary

Gates the analytics and dashboards pages to our project for now (and for a customer that wants to preview them).
Will be bringing the pages back in the future when we revamp the implementation.

## How did you test this change?

any project
<img width="875" alt="Screenshot 2023-08-09 at 4 15 54 PM" src="https://github.com/highlight/highlight/assets/1351531/aa3b1ed3-2180-4853-aa71-089190ac1a2b">

customer that still wants this page
<img width="733" alt="Screenshot 2023-08-09 at 4 16 08 PM" src="https://github.com/highlight/highlight/assets/1351531/22fe07b0-af0c-472a-b811-12fc0201e933">

## Are there any deployment considerations?

No