### PR TITLE
decode single redis msg at a time

### DIFF
--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -164,7 +164,7 @@ func GetKey(sessionId int, payloadType model.RawPayloadType) string {
 	}
 }
 
-func (r *Client) GetSessionData(ctx context.Context, sessionId int, payloadType model.RawPayloadType, objects map[int]string) ([]model.SessionData, error) {
+func (r *Client) GetSessionData(ctx context.Context, sessionId int, payloadType model.RawPayloadType, objects map[int]string) ([]string, error) {
 	key := GetKey(sessionId, payloadType)
 
 	vals, err := r.redisClient.ZRangeByScoreWithScores(ctx, key, &redis.ZRangeBy{
@@ -191,24 +191,13 @@ func (r *Client) GetSessionData(ctx context.Context, sessionId int, payloadType 
 	}
 	sort.Ints(keys)
 
-	results := []model.SessionData{}
+	results := []string{}
 	if len(keys) == 0 {
 		return results, nil
 	}
 
 	for _, k := range keys {
-		asBytes := []byte(objects[k])
-
-		// Messages may be encoded with `snappy`.
-		// Try decoding them, but if decoding fails, use the original message.
-		decoded, err := snappy.Decode(nil, asBytes)
-		if err != nil {
-			decoded = asBytes
-		}
-
-		results = append(results, model.SessionData{
-			Data: string(decoded),
-		})
+		results = append(results, objects[k])
 	}
 
 	return results, nil


### PR DESCRIPTION
## Summary
- not necessary for the current performance issues, but noticed that the worker had a consistently high heap live size due to `GetSessionData`
- instead of decoding all data, return encoded data, then decode per row so the decoded row can be garbage collected
<img width="998" alt="Screen Shot 2023-08-10 at 8 35 36 AM" src="https://github.com/highlight/highlight/assets/86132398/851cf0fd-5b88-4c48-8326-ef19e6f73bb3">

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally to make sure session could be played back, wasn't corrupted
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
