### PR TITLE
send a trace with blank resource attributes

### DIFF
--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -172,9 +172,7 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 		}
 
 		for key, value := range util.FormatLogAttributes(ctx, k, v) {
-			if value != "" {
-				fields.attrs[key] = value
-			}
+			fields.attrs[key] = value
 		}
 	}
 

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -172,7 +172,9 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 		}
 
 		for key, value := range util.FormatLogAttributes(ctx, k, v) {
-			fields.attrs[key] = value
+			if v != "" {
+				fields.attrs[key] = value
+			}
 		}
 	}
 

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -172,7 +172,9 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 		}
 
 		for key, value := range util.FormatLogAttributes(ctx, k, v) {
-			fields.attrs[key] = value
+			if value != "" {
+				fields.attrs[key] = value
+			}
 		}
 	}
 

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -155,22 +155,6 @@ func extractFields(ctx context.Context, params extractFieldsParams) (extractedFi
 	}
 
 	for k, v := range originalAttrs {
-		prefixes := []string{}
-		if fields.source == modelInputs.LogSourceFrontend {
-			prefixes = append(prefixes, highlight.BackendOnlyAttributePrefixes...)
-		}
-
-		shouldSkip := false
-		for _, prefix := range prefixes {
-			if strings.HasPrefix(k, prefix) {
-				shouldSkip = true
-				break
-			}
-		}
-		if shouldSkip {
-			continue
-		}
-
 		for key, value := range util.FormatLogAttributes(ctx, k, v) {
 			if v != "" {
 				fields.attrs[key] = value

--- a/backend/otel/extract_test.go
+++ b/backend/otel/extract_test.go
@@ -252,22 +252,6 @@ func TestExtractFields_ExtractServiceName(t *testing.T) {
 	assert.Equal(t, fields.attrs, map[string]string{})
 }
 
-func TestExtractFields_ExtractServiceNameForFrontendSource(t *testing.T) {
-	resource := newResource(t, map[string]any{
-		"service.name": "my_service",
-	})
-
-	span := newSpan(map[string]string{
-		"highlight.source": string(modelInputs.LogSourceFrontend),
-	})
-	fields, err := extractFields(context.TODO(), extractFieldsParams{
-		resource: &resource,
-		span:     &span,
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "", fields.serviceName)
-}
-
 func TestExtractFields_RewriteServiceName(t *testing.T) {
 	resource := newResource(t, map[string]any{
 		"service.name": "unknown_service:/opt/homebrew/Cellar/node/19.6.0/bin/node",

--- a/backend/otel/extract_test.go
+++ b/backend/otel/extract_test.go
@@ -321,16 +321,6 @@ func TestExtractFields_OmitLogSeverity(t *testing.T) {
 	})
 }
 
-func TestExtractFields_OmitBackendPropertiesForFrontendSource(t *testing.T) {
-	resource := newResource(t, map[string]any{
-		"os.description":   "Debian GNU/Linux 11 (bullseye)", // should be skipped since this is a frontend source
-		"highlight.source": "frontend",
-	})
-	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
-	assert.NoError(t, err)
-	assert.Equal(t, fields.attrs, map[string]string{})
-}
-
 func TestExtractFields_TrimLongFields(t *testing.T) {
 	var value string
 	for i := 0; i < 2<<16; i++ {

--- a/backend/vercel/README.md
+++ b/backend/vercel/README.md
@@ -1,0 +1,39 @@
+## Testing locally
+
+Start ngrok: `ngrok http https://localhost:8082`
+
+Grab the generated URL, example: `https://c0fd-75-166-97-48.ngrok-free.app`
+
+Modify the projectID check in `vercel.HandleLog`
+
+```diff
+-       projectVerboseID := r.Header.Get(LogDrainProjectHeader)
+-       projectID, err := model2.FromVerboseID(projectVerboseID)
+-       if err != nil {
+-               log.WithContext(r.Context()).WithError(err).WithField("projectVerboseID", projectVerboseID).Error("failed to parse highlight project id from vercel request")
+-               http.Error(w, err.Error(), http.StatusBadRequest)
+-               return
+-       }
++       // projectVerboseID := r.Header.Get(LogDrainProjectHeader)
++       // projectID, err := model2.FromVerboseID(projectVerboseID)
++       // if err != nil {
++       //      log.WithContext(r.Context()).WithError(err).WithField("projectVerboseID", projectVerboseID).Error("failed to parse highlight project id from
+ vercel request")
++       //      http.Error(w, err.Error(), http.StatusBadRequest)
++       //      return
++       // }
++       projectID := 3
+```
+
+
+Set up a log drain using the following config
+
+![Screenshot 2023-08-10 at 1 06 16 PM](https://github.com/highlight/highlight/assets/58678/cf1d18ea-257e-414c-85fc-bf3e46a242c3)
+
+Click "Test Log Drain"
+
+Wait about a minute for the logs to go through the OTEL pipeline
+
+Observe logs in app with the start date set to 2022 (Vercel hardcodes the timestamp to something really old using Test Log Drain)
+
+![Screenshot 2023-08-10 at 1 07 55 PM](https://github.com/highlight/highlight/assets/58678/32e160ea-07c4-4a2a-88a1-8226a12ab50d)

--- a/backend/vercel/README.md
+++ b/backend/vercel/README.md
@@ -36,4 +36,4 @@ Wait about a minute for the logs to go through the OTEL pipeline
 
 Observe logs in app with the start date set to 2022 (Vercel hardcodes the timestamp to something really old using Test Log Drain)
 
-![Screenshot 2023-08-10 at 1 07 55 PM](https://github.com/highlight/highlight/assets/58678/32e160ea-07c4-4a2a-88a1-8226a12ab50d)
+![Screenshot 2023-08-10 at 1 07 55 PM](https://user-images.githubusercontent.com/58678/259855002-39529705-c85d-4187-90c5-710171665807.png)

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -71,7 +71,7 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 	}
 
 	for _, row := range logRows {
-		span, _ := highlight.StartTrace(
+		span, _ := highlight.StartTraceWithoutResourceAttributes(
 			ctx, "highlight-ctx",
 			attribute.String(highlight.SourceAttribute, modelInputs.LogSourceFrontend.String()),
 			attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -136,27 +136,23 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 }
 
 func submitVercelLog(ctx context.Context, projectID int, log VercelLog) {
-	span, _ := highlight.StartTrace(
+	span, _ := highlight.StartTraceWithoutResourceAttributes(
 		ctx, "highlight-ctx",
-		attribute.String(highlight.SourceAttribute, "SubmitVercelLogs"),
 		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
 	)
 	defer highlight.EndTrace(span)
 
-	attrs := []attribute.KeyValue{
+	eventAttrs := []attribute.KeyValue{
 		LogSeverityKey.String(log.Type),
 		LogMessageKey.String(log.Message),
-	}
-	attrs = append(
-		attrs,
 		semconv.CodeNamespaceKey.String(log.Source),
 		semconv.CodeFilepathKey.String(log.Path),
 		semconv.CodeFunctionKey.String(log.Entrypoint),
 		semconv.HostNameKey.String(log.Host),
 		semconv.HTTPMethodKey.Int64(log.StatusCode),
-	)
+	}
 
-	span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(log.Timestamp)))
+	span.AddEvent(highlight.LogEvent, trace.WithAttributes(eventAttrs...), trace.WithTimestamp(time.UnixMilli(log.Timestamp)))
 	if log.Type == "error" {
 		span.SetStatus(codes.Error, log.Message)
 	}

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -161,6 +161,10 @@ func submitVercelLog(ctx context.Context, projectID int, log VercelLog) {
 		attrs = append(attrs, semconv.HTTPStatusCodeKey.Int64(log.StatusCode))
 	}
 
+	if len(log.Proxy.UserAgent) > 0 {
+		attrs = append(attrs, semconv.HTTPUserAgentKey.String(strings.Join(log.Proxy.UserAgent, ",")))
+	}
+
 	span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(log.Timestamp)))
 	if log.Type == "error" {
 		span.SetStatus(codes.Error, log.Message)

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -142,7 +142,7 @@ func submitVercelLog(ctx context.Context, projectID int, log VercelLog) {
 	)
 	defer highlight.EndTrace(span)
 
-	eventAttrs := []attribute.KeyValue{
+	attrs := []attribute.KeyValue{
 		LogSeverityKey.String(log.Type),
 		LogMessageKey.String(log.Message),
 		semconv.ServiceNameKey.String("vercel-log-drain"),
@@ -154,14 +154,14 @@ func submitVercelLog(ctx context.Context, projectID int, log VercelLog) {
 	}
 
 	if log.Proxy.Method != "" {
-		eventAttrs = append(eventAttrs, semconv.HTTPMethodKey.String(log.Proxy.Method))
+		attrs = append(attrs, semconv.HTTPMethodKey.String(log.Proxy.Method))
 	}
 
 	if log.StatusCode != 0 {
-		eventAttrs = append(eventAttrs, semconv.HTTPStatusCodeKey.Int64(log.StatusCode))
+		attrs = append(attrs, semconv.HTTPStatusCodeKey.Int64(log.StatusCode))
 	}
 
-	span.AddEvent(highlight.LogEvent, trace.WithAttributes(eventAttrs...), trace.WithTimestamp(time.UnixMilli(log.Timestamp)))
+	span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(log.Timestamp)))
 	if log.Type == "error" {
 		span.SetStatus(codes.Error, log.Message)
 	}

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -39,15 +39,6 @@ const MetricEvent = "metric"
 const MetricEventName = "metric.name"
 const MetricEventValue = "metric.value"
 
-var BackendOnlyAttributePrefixes = []string{
-	"container.",
-	"host.",
-	"os.",
-	"process.",
-	"exception.",
-	"service.",
-}
-
 type OTLP struct {
 	tracerProvider *sdktrace.TracerProvider
 }

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -121,6 +121,28 @@ func StartTrace(ctx context.Context, name string, tags ...attribute.KeyValue) (t
 	return span, ctx
 }
 
+func StartTraceWithoutResourceAttributes(ctx context.Context, name string, tags ...attribute.KeyValue) (trace.Span, context.Context) {
+	resourceAttributes := []attribute.KeyValue{
+		semconv.ServiceNameKey.String(""),
+		semconv.ServiceVersionKey.String(""),
+		semconv.ContainerIDKey.String(""),
+		semconv.HostNameKey.String(""),
+		semconv.OSDescriptionKey.String(""),
+		semconv.OSTypeKey.String(""),
+		semconv.ProcessExecutableNameKey.String(""),
+		semconv.ProcessExecutablePathKey.String(""),
+		semconv.ProcessOwnerKey.String(""),
+		semconv.ProcessPIDKey.String(""),
+		semconv.ProcessRuntimeDescriptionKey.String(""),
+		semconv.ProcessRuntimeNameKey.String(""),
+		semconv.ProcessRuntimeVersionKey.String(""),
+	}
+
+	attrs := append(resourceAttributes, tags...)
+
+	return StartTrace(ctx, name, attrs...)
+}
+
 func EndTrace(span trace.Span) {
 	span.End(trace.WithStackTrace(true))
 }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->


This PR ensures that our public graph service information doesn't leak into a vercel log drain. The previous way of slicing this out was checking if this is a frontend log (#6273). However, that approach wasn't robust since vercel logs aren't necessarily a frontend log.

Instead, we blank out the resource data (use `StartTraceWithoutResourceAttributes` instead of `StartTrace`) at the start of the trace (instead of chopping it off at the OTEL processing side). This approach makes more sense given we understand very clearly that this was sent from a 3rd party. The same logic is applied for submitting a frontend console log (`SubmitFrontendConsoleMessages`) and for `SubmitHTTPLog`

This PR also fixes some bugs with how the vercel logs were being formatted. Here is the payload that vercel sends us:

![Screenshot 2023-08-10 at 1 23 28 PM](https://github.com/highlight/highlight/assets/58678/feea6b3b-c821-469e-b7e7-74c380639fae)



* http.method was the status code, not the actual method
* http.method (GET|POST) wasn't even included in the log
* hardcoded `service.name` to `vercel-log-drain` (I considered using using the vercel project id but wasn't sure if that was confusing. We can revisit this if we want to adjust).
* set `service.version` to be the vercel deployment id

Here is the rest of the information in that vercel log payload:



I've also fixed an issue whereby blank values are scrubbed from the output (`code.function` is a good example of this).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

See README for how to set this up locally. 

Before:
![Screenshot 2023-08-10 at 1 37 32 PM](https://github.com/highlight/highlight/assets/58678/42bde1ff-4fad-4e0d-997a-b362044a2fdb)


After:

![Screenshot 2023-08-10 at 1 29 23 PM](https://github.com/highlight/highlight/assets/58678/39529705-c85d-4187-90c5-710171665807)


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
