### PR TITLE
Implement redesign for error alert page

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5389,6 +5389,77 @@ body {
   display: flex;
   justify-content: flex-end;
 }
+._1hht64e1 {
+  height: 20px;
+}
+._1hht64e2 {
+  color: var(--_1pyqka9b) !important;
+}
+._1hht64e2:hover {
+  background: var(--_1pyqka91x);
+}
+._1hht64e2 .ant-select-selector {
+  padding: 0 6px !important;
+  border-radius: 6px !important;
+  border: var(--_1pyqka91o) solid 1px !important;
+  box-shadow: none !important;
+}
+._1hht64e2 .ant-select-selector:hover {
+  background: var(--_1pyqka91x) !important;
+}
+._1hht64e2 .ant-select-selection-item {
+  display: flex;
+  align-items: center;
+}
+._4ocsjw0 {
+  height: 40px;
+}
+._4ocsjw1 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto;
+  grid-column-gap: 40px;
+  grid-row-gap: 40px;
+}
+._4ocsjw5 {
+  border: 0;
+  background: transparent;
+  color: var(--_1pyqka9b);
+  display: flex;
+  font-size: 13px;
+  width: 100%;
+}
+._4ocsjw5:focus {
+  outline: 0;
+}
+._4ocsjw5::placeholder {
+  color: var(--_1pyqka9x);
+}
+._4ocsjw7 {
+  height: 20px;
+}
+._4ocsjw9 {
+  height: 20px;
+}
+._4ocsjwa {
+  color: var(--_1pyqka9b) !important;
+}
+._4ocsjwa:hover {
+  background: var(--_1pyqka91x);
+}
+._4ocsjwa .ant-select-selector {
+  padding: 0 6px !important;
+  border-radius: 6px !important;
+  border: var(--_1pyqka91o) solid 1px !important;
+  box-shadow: none !important;
+}
+._4ocsjwa .ant-select-selector:hover {
+  background: var(--_1pyqka91x) !important;
+}
+._4ocsjwa .ant-select-selection-item {
+  display: flex;
+  align-items: center;
+}
 ._155k3sw0 {
   height: 4.16rem;
 }

--- a/frontend/src/__generated/ve/pages/Alerts/AlertConfigurationCard/styles.css.js
+++ b/frontend/src/__generated/ve/pages/Alerts/AlertConfigurationCard/styles.css.js
@@ -1,0 +1,1 @@
+var t="_6oimg15 mt0ih23f mt0ih23w mt0ih24e",i="_6oimg11",r="_6oimg10",e="mt0ih24u mt0ih28 mt0ih2el",m="_6oimg17 mt0ih21w mt0ih22 mt0ih2t7 mt0ih27r",o="_6oimg1a",h="_6oimg19 mt0ih24d mt0ih24u mt0ih23d mt0ih23u";export{t as combobox,i as grid,r as header,e as queryContainer,m as sectionHeader,o as selectContainer,h as thresholdTypeButton};

--- a/frontend/src/__generated/ve/pages/Alerts/ErrorAlert/styles.css.js
+++ b/frontend/src/__generated/ve/pages/Alerts/ErrorAlert/styles.css.js
@@ -1,0 +1,1 @@
+var t="_4ocsjw5 mt0ih23f mt0ih23w mt0ih24e",r="_4ocsjw1",e="_4ocsjw0",o="mt0ih24u mt0ih28 mt0ih2el",i="_4ocsjw7 mt0ih21w mt0ih22 mt0ih2t7 mt0ih27r",h="_4ocsjwa",m="_4ocsjw9 mt0ih24d mt0ih24u mt0ih23d mt0ih23u";export{t as combobox,r as grid,e as header,o as queryContainer,i as sectionHeader,h as selectContainer,m as thresholdTypeButton};

--- a/frontend/src/__generated/ve/pages/Alerts/LogAlert copy/styles.css.js
+++ b/frontend/src/__generated/ve/pages/Alerts/LogAlert copy/styles.css.js
@@ -1,0 +1,1 @@
+var t="_16tn3jx5 mt0ih23f mt0ih23w mt0ih24e",r="_16tn3jx1",e="_16tn3jx0",i="mt0ih24u mt0ih28 mt0ih2el",h="_16tn3jx7 mt0ih21w mt0ih22 mt0ih2t7 mt0ih27r",m="_16tn3jxa",o="_16tn3jx9 mt0ih24d mt0ih24u mt0ih23d mt0ih23u";export{t as combobox,r as grid,e as header,i as queryContainer,h as sectionHeader,m as selectContainer,o as thresholdTypeButton};

--- a/frontend/src/__generated/ve/pages/Alerts/components/AlertNotifyForm/styles.css.js
+++ b/frontend/src/__generated/ve/pages/Alerts/components/AlertNotifyForm/styles.css.js
@@ -1,0 +1,1 @@
+var t="_1hht64e1 mt0ih21w mt0ih22 mt0ih2t7 mt0ih27r",e="_1hht64e2";export{t as sectionHeader,e as selectContainer};

--- a/frontend/src/pages/Alerts/Alerts.module.css
+++ b/frontend/src/pages/Alerts/Alerts.module.css
@@ -30,7 +30,7 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-		width: 500px;
+		width: 300px;
 	}
 }
 

--- a/frontend/src/pages/Alerts/Alerts.tsx
+++ b/frontend/src/pages/Alerts/Alerts.tsx
@@ -1,12 +1,19 @@
 import BarChart from '@components/BarChart/BarChart'
-import ButtonLink from '@components/Button/ButtonLink/ButtonLink'
 import Card from '@components/Card/Card'
 import LoadingBox from '@components/LoadingBox'
 import { SearchEmptyState } from '@components/SearchEmptyState/SearchEmptyState'
 import Table from '@components/Table/Table'
 import Tag from '@components/Tag/Tag'
 import { GetAlertsPagePayloadQuery } from '@graph/operations'
-import { IconSolidLogs } from '@highlight-run/ui'
+import {
+	Box,
+	Container,
+	Heading,
+	IconSolidLogs,
+	IconSolidPlus,
+	Stack,
+	Text,
+} from '@highlight-run/ui'
 import SvgBugIcon from '@icons/BugIcon'
 import SvgChevronRightIcon from '@icons/ChevronRightIcon'
 import SvgCursorClickIcon from '@icons/CursorClickIcon'
@@ -23,6 +30,8 @@ import { useParams } from '@util/react-router/useParams'
 import { compact } from 'lodash'
 import React from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+
+import { LinkButton } from '@/components/LinkButton'
 
 import styles from './Alerts.module.css'
 
@@ -245,20 +254,23 @@ const TABLE_COLUMNS = [
 export default function AlertsPage() {
 	const { alertsPayload, loading } = useAlertsContext()
 
-	if (loading) {
-		return (
-			<>
-				<div className={styles.subTitleContainer}>
-					<p>Manage the alerts for your project.</p>
-				</div>
-				<Card noPadding>
-					<LoadingBox height={640} />
-				</Card>
-			</>
-		)
-	}
-
-	return <AlertsPageLoaded alertsPayload={alertsPayload} />
+	return (
+		<Box width="full" background="raised" p="8">
+			<Box
+				border="dividerWeak"
+				borderRadius="6"
+				width="full"
+				shadow="medium"
+				background="default"
+				display="flex"
+				flexDirection="column"
+				height="full"
+			>
+				{loading && <LoadingBox />}
+				{!loading && <AlertsPageLoaded alertsPayload={alertsPayload} />}
+			</Box>
+		</Box>
+	)
 }
 
 function AlertsPageLoaded({
@@ -386,70 +398,95 @@ function AlertsPageLoaded({
 	]
 
 	return (
-		<>
-			<div className={styles.subTitleContainer}>
-				<p>Manage the alerts for your project.</p>
-				{alertsAsTableRows.length > 0 && (
-					<ButtonLink
-						trackingId="NewAlert"
-						className={styles.callToAction}
-						to={`/${project_id}/alerts/new`}
-					>
-						New Alert
-					</ButtonLink>
-				)}
-			</div>
-			{alertsPayload && (
-				<Card noPadding>
-					<Table
-						columns={TABLE_COLUMNS}
-						dataSource={alertsAsTableRows}
-						pagination={false}
-						showHeader={false}
-						rowHasPadding
-						renderEmptyComponent={
-							<SearchEmptyState
-								className={styles.emptyContainer}
-								item="alerts"
-								customTitle={`Your project doesn't have any alerts yet 😔`}
-								customDescription={
-									<>
-										<ButtonLink
-											trackingId="NewAlert"
-											className={styles.callToAction}
-											to={`/${project_id}/alerts/new`}
-										>
-											New Alert
-										</ButtonLink>
-									</>
-								}
-							/>
-						}
-						onRow={(record) => ({
-							onClick: () => {
-								if (
-									record.type ===
-									ALERT_NAMES['METRIC_MONITOR']
-								) {
-									navigate(
-										`/${project_id}/alerts/monitor/${record.id}`,
-									)
-								} else if (
-									record.type === ALERT_NAMES['LOG_ALERT']
-								) {
-									navigate(
-										`/${project_id}/alerts/logs/${record.id}`,
-									)
-								} else {
-									navigate(
-										`/${project_id}/alerts/${record.id}`,
-									)
-								}
-							},
-						})}
-					/>
-				</Card>
-			)}
-		</>
+		<Container display="flex" flexDirection="column" gap="24">
+			<Box style={{ maxWidth: 860 }} my="40" mx="auto">
+				<Stack gap="24">
+					<Stack gap="16" direction="column">
+						<Heading mt="16" level="h4">
+							Alerts
+						</Heading>
+						<Text weight="medium" size="small" color="default">
+							Manage all the alerts for your currently selected
+							project.
+						</Text>
+					</Stack>
+					<Stack gap="8">
+						{alertsAsTableRows.length > 0 && (
+							<Box
+								display="flex"
+								justifyContent="space-between"
+								alignItems="center"
+								width="full"
+							>
+								<Text weight="bold" size="small" color="strong">
+									All alerts
+								</Text>
+								<LinkButton
+									iconLeft={<IconSolidPlus />}
+									trackingId="NewAlert"
+									to={`/${project_id}/alerts/new`}
+								>
+									Create new alert
+								</LinkButton>
+							</Box>
+						)}
+						{alertsPayload && (
+							<Card noPadding>
+								<Table
+									columns={TABLE_COLUMNS}
+									dataSource={alertsAsTableRows}
+									pagination={false}
+									showHeader={false}
+									rowHasPadding
+									renderEmptyComponent={
+										<SearchEmptyState
+											className={styles.emptyContainer}
+											item="alerts"
+											customTitle={`Your project doesn't have any alerts yet 😔`}
+											customDescription={
+												<>
+													<LinkButton
+														iconLeft={
+															<IconSolidPlus />
+														}
+														trackingId="NewAlert"
+														to={`/${project_id}/alerts/new`}
+													>
+														Create new alert
+													</LinkButton>
+												</>
+											}
+										/>
+									}
+									onRow={(record) => ({
+										onClick: () => {
+											if (
+												record.type ===
+												ALERT_NAMES['METRIC_MONITOR']
+											) {
+												navigate(
+													`/${project_id}/alerts/monitor/${record.id}`,
+												)
+											} else if (
+												record.type ===
+												ALERT_NAMES['LOG_ALERT']
+											) {
+												navigate(
+													`/${project_id}/alerts/logs/${record.id}`,
+												)
+											} else {
+												navigate(
+													`/${project_id}/alerts/${record.id}`,
+												)
+											}
+										},
+									})}
+								/>
+							</Card>
+						)}
+					</Stack>
+				</Stack>
+			</Box>
+		</Container>
 	)
 }

--- a/frontend/src/pages/Alerts/AlertsRouter.tsx
+++ b/frontend/src/pages/Alerts/AlertsRouter.tsx
@@ -1,6 +1,4 @@
-import Breadcrumb from '@components/Breadcrumb/Breadcrumb'
 import { getSlackUrl } from '@components/Header/components/ConnectHighlightWithSlackButton/utils/utils'
-import LeadAlignLayout from '@components/layout/LeadAlignLayout'
 import { useGetAlertsPagePayloadQuery } from '@graph/hooks'
 import { GetAlertsPagePayloadQuery } from '@graph/operations'
 import AlertsPage from '@pages/Alerts/Alerts'
@@ -11,9 +9,11 @@ import NewAlertPage from '@pages/Alerts/NewAlertPage'
 import NewMonitorPage from '@pages/Alerts/NewMonitorPage'
 import analytics from '@util/analytics'
 import { useParams } from '@util/react-router/useParams'
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Helmet } from 'react-helmet'
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
+import { Navigate, Route, Routes } from 'react-router-dom'
+
+import ErrorAlertPage from '@/pages/Alerts/ErrorAlert/ErrorAlertPage'
 
 const AlertsRouter = () => {
 	const { project_id } = useParams<{ project_id: string }>()
@@ -26,7 +26,6 @@ const AlertsRouter = () => {
 		skip: !project_id,
 	})
 	const slackUrl = getSlackUrl(projectId)
-	const location = useLocation()
 
 	useEffect(() => {
 		if (!loading) {
@@ -48,103 +47,73 @@ const AlertsRouter = () => {
 			<Helmet>
 				<title>Alerts</title>
 			</Helmet>
-			<LeadAlignLayout maxWidth={1200}>
-				<Breadcrumb
-					getBreadcrumbName={(url) =>
-						getAlertsBreadcrumbNames(location.state)(url)
-					}
-					linkRenderAs="h2"
+			<Routes>
+				<Route path="*" element={<AlertsPage />} />
+				<Route path="new" element={<NewAlertPage />} />
+				<Route
+					path="monitor"
+					element={<Navigate to={`/${project_id}/alerts`} replace />}
 				/>
-				<Routes>
-					<Route path="*" element={<AlertsPage />} />
-					<Route path="new" element={<NewAlertPage />} />
-					<Route
-						path="monitor"
-						element={
-							<Navigate to={`/${project_id}/alerts`} replace />
-						}
-					/>
-					<Route
-						path="new/monitor"
-						element={
-							<NewMonitorPage
-								channelSuggestions={
-									data?.slack_channel_suggestion ?? []
-								}
-								discordChannelSuggestions={
-									data?.discord_channel_suggestions ?? []
-								}
-								isSlackIntegrated={
-									data?.is_integrated_with_slack ?? false
-								}
-								isDiscordIntegrated={
-									data?.is_integrated_with_discord ?? false
-								}
-								emailSuggestions={(data?.admins ?? []).map(
-									(wa) => wa.admin!.email,
-								)}
-							/>
-						}
-					/>
-					<Route
-						path="monitor/:id"
-						element={
-							<EditMonitorPage
-								channelSuggestions={
-									data?.slack_channel_suggestion ?? []
-								}
-								discordChannelSuggestions={
-									data?.discord_channel_suggestions ?? []
-								}
-								isSlackIntegrated={
-									data?.is_integrated_with_slack ?? false
-								}
-								isDiscordIntegrated={
-									data?.is_integrated_with_discord ?? false
-								}
-								emailSuggestions={(data?.admins ?? []).map(
-									(wa) => wa.admin!.email,
-								)}
-							/>
-						}
-					/>
-					<Route
-						path="new/logs"
-						element={
-							<Navigate
-								to={`/${projectId}/alerts/logs/new`}
-								replace
-							/>
-						}
-					/>
-					<Route path="new/:type" element={<NewAlertPage />} />
-					<Route path=":id" element={<EditAlertsPage />} />
-				</Routes>
-			</LeadAlignLayout>
+				<Route
+					path="new/monitor"
+					element={
+						<NewMonitorPage
+							channelSuggestions={
+								data?.slack_channel_suggestion ?? []
+							}
+							discordChannelSuggestions={
+								data?.discord_channel_suggestions ?? []
+							}
+							isSlackIntegrated={
+								data?.is_integrated_with_slack ?? false
+							}
+							isDiscordIntegrated={
+								data?.is_integrated_with_discord ?? false
+							}
+							emailSuggestions={(data?.admins ?? []).map(
+								(wa) => wa.admin!.email,
+							)}
+						/>
+					}
+				/>
+				<Route
+					path="monitor/:id"
+					element={
+						<EditMonitorPage
+							channelSuggestions={
+								data?.slack_channel_suggestion ?? []
+							}
+							discordChannelSuggestions={
+								data?.discord_channel_suggestions ?? []
+							}
+							isSlackIntegrated={
+								data?.is_integrated_with_slack ?? false
+							}
+							isDiscordIntegrated={
+								data?.is_integrated_with_discord ?? false
+							}
+							emailSuggestions={(data?.admins ?? []).map(
+								(wa) => wa.admin!.email,
+							)}
+						/>
+					}
+				/>
+				<Route
+					path="new/logs"
+					element={
+						<Navigate
+							to={`/${projectId}/alerts/logs/new`}
+							replace
+						/>
+					}
+				/>
+				<Route path="new/errors" element={<ErrorAlertPage />} />
+				<Route path="errors/:alert_id" element={<ErrorAlertPage />} />
+				<Route path="new/:type" element={<NewAlertPage />} />
+				<Route path=":id" element={<EditAlertsPage />} />
+			</Routes>
 		</AlertsContextProvider>
 	)
 }
 
 export default AlertsRouter
-
-const getAlertsBreadcrumbNames = (suffixes: { [key: string]: string }) => {
-	return (url: string) => {
-		if (url.endsWith('/alerts')) {
-			return 'Alerts'
-		}
-
-		if (url.endsWith('/monitor')) {
-			return 'Metric Monitor'
-		}
-
-		if (url.endsWith('/alerts/new')) {
-			return 'Create'
-		}
-
-		if (url.includes('/alerts/new/')) {
-			return `${suffixes?.errorName}`
-		}
-
-		return `Edit ${suffixes?.errorName || ''}`
-	}
-}

--- a/frontend/src/pages/Alerts/EditAlertsPage.tsx
+++ b/frontend/src/pages/Alerts/EditAlertsPage.tsx
@@ -2,15 +2,18 @@ import {
 	useDeleteErrorAlertMutation,
 	useDeleteSessionAlertMutation,
 } from '@graph/hooks'
-import { GetAlertsPagePayloadQuery, namedOperations } from '@graph/operations'
+import { namedOperations } from '@graph/operations'
 import { AlertConfigurationCard } from '@pages/Alerts/AlertConfigurationCard/AlertConfigurationCard'
-import { ALERT_CONFIGURATIONS } from '@pages/Alerts/Alerts'
+import { ALERT_CONFIGURATIONS, ALERT_TYPE } from '@pages/Alerts/Alerts'
 import { useAlertsContext } from '@pages/Alerts/AlertsContext/AlertsContext'
 import { useParams } from '@util/react-router/useParams'
 import { message } from 'antd'
+import { useEffect } from 'react'
 import { Helmet } from 'react-helmet'
 import Skeleton from 'react-loading-skeleton'
 import { useNavigate } from 'react-router-dom'
+
+import { findAlert } from '@/pages/Alerts/utils/AlertsUtils'
 
 const EditAlertsPage = () => {
 	const { id, project_id } = useParams<{ id: string; project_id: string }>()
@@ -32,6 +35,15 @@ const EditAlertsPage = () => {
 			cache.gc()
 		},
 	})
+
+	useEffect(() => {
+		if (
+			alert?.Type &&
+			ALERT_CONFIGURATIONS[alert?.Type].type === ALERT_TYPE.Error
+		) {
+			navigate(`/${project_id}/alerts/errors/${id}`)
+		}
+	}, [alert?.Type, id, navigate, project_id])
 
 	return (
 		<>
@@ -107,20 +119,3 @@ const EditAlertsPage = () => {
 }
 
 export default EditAlertsPage
-
-const findAlert = (id: string, alertsPayload?: GetAlertsPagePayloadQuery) => {
-	if (!alertsPayload) {
-		return undefined
-	}
-
-	const allAlerts = [
-		...alertsPayload.error_alerts,
-		...alertsPayload.new_session_alerts,
-		...(alertsPayload.new_user_alerts || []),
-		...alertsPayload.track_properties_alerts,
-		...alertsPayload.user_properties_alerts,
-		...alertsPayload.rage_click_alerts,
-	]
-
-	return allAlerts.find((alert) => alert?.id === id)
-}

--- a/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
+++ b/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
@@ -1,0 +1,600 @@
+import { Button } from '@components/Button'
+import Select from '@components/Select/Select'
+import {
+	useCreateErrorAlertMutation,
+	useDeleteErrorAlertMutation,
+	useUpdateErrorAlertMutation,
+} from '@graph/hooks'
+import {
+	Badge,
+	Box,
+	Column,
+	Container,
+	Form,
+	FormState,
+	IconSolidCheveronDown,
+	IconSolidCheveronRight,
+	IconSolidCheveronUp,
+	IconSolidSpeakerphone,
+	Menu,
+	Stack,
+	Tag,
+	Text,
+	useForm,
+	useFormState,
+	useMenu,
+} from '@highlight-run/ui'
+import {
+	DEFAULT_FREQUENCY,
+	FREQUENCIES,
+} from '@pages/Alerts/AlertConfigurationCard/AlertConfigurationConstants'
+import {
+	AlertForm,
+	dedupeEnvironments,
+	EnvironmentSuggestion,
+	findAlert,
+	getFrequencyOption,
+} from '@pages/Alerts/utils/AlertsUtils'
+import { LOG_TIME_PRESETS, now } from '@pages/LogsPage/constants'
+import { useParams } from '@util/react-router/useParams'
+import { message } from 'antd'
+import { capitalize } from 'lodash'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { DateTimeParam, useQueryParam } from 'use-query-params'
+
+import LoadingBox from '@/components/LoadingBox'
+import { namedOperations } from '@/graph/generated/operations'
+import { useAlertsContext } from '@/pages/Alerts/AlertsContext/AlertsContext'
+import AlertNotifyForm from '@/pages/Alerts/components/AlertNotifyForm/AlertNotifyForm'
+
+import * as styles from './styles.css'
+
+export const ErrorAlertPage = () => {
+	const [startDateParam] = useQueryParam('start_date', DateTimeParam)
+	const [endDateParam] = useQueryParam('end_date', DateTimeParam)
+
+	const [startDate, setStartDate] = useState(
+		startDateParam ?? LOG_TIME_PRESETS[0].startDate,
+	)
+
+	const [endDate, setEndDate] = useState(endDateParam ?? now.toDate())
+	const [selectedDates] = useState<Date[]>([startDate, endDate])
+
+	const { alert_id } = useParams<{
+		alert_id: string
+	}>()
+
+	const isCreate = alert_id === undefined
+	const createStr = isCreate ? 'create' : 'update'
+
+	useEffect(() => {
+		if (selectedDates.length === 2) {
+			setStartDate(selectedDates[0])
+			setEndDate(selectedDates[1])
+		}
+	}, [selectedDates])
+
+	const { alertsPayload } = useAlertsContext()
+	const alert = alert_id
+		? (findAlert(alert_id, alertsPayload) as any)
+		: undefined
+
+	const form = useFormState<ErrorAlertFormItem>({
+		defaultValues: {
+			name: '',
+			belowThreshold: false,
+			excludedEnvironments: [],
+			slackChannels: [],
+			discordChannels: [],
+			webhookDestinations: [],
+			emails: [],
+			threshold: undefined,
+			regex_groups: [],
+			frequency: Number(DEFAULT_FREQUENCY),
+			threshold_window: Number(DEFAULT_FREQUENCY),
+			loaded: false,
+		},
+	})
+
+	console.log(alert)
+
+	useEffect(() => {
+		if (alert) {
+			form.setValues({
+				name: alert.Name ?? 'Error',
+				belowThreshold: false,
+				excludedEnvironments: alert.ExcludedEnvironments,
+				slackChannels: alert.ChannelsToNotify.map((c: any) => ({
+					...c,
+					webhook_channel_name: c.webhook_channel,
+					displayValue: c.webhook_channel,
+					value: c.webhook_channel_id,
+					id: c.webhook_channel_id,
+				})),
+				discordChannels: alert.DiscordChannelsToNotify.map(
+					(c: any) => ({
+						...c,
+						displayValue: c.name,
+						value: c.id,
+						id: c.id,
+					}),
+				),
+				webhookDestinations: alert.WebhookDestinations.map(
+					(d: any) => d.url,
+				),
+				emails: alert.EmailsToNotify,
+				threshold: alert.CountThreshold,
+				frequency: getFrequencyOption(alert.Frequency).value,
+				regex_groups: alert.RegexGroups || [],
+				threshold_window: alert.ThresholdWindow,
+				loaded: true,
+			})
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [])
+
+	const [updateErrorAlertMutation] = useUpdateErrorAlertMutation({
+		refetchQueries: [namedOperations.Query.GetAlertsPagePayload],
+	})
+	const [createErrorAlertMutation] = useCreateErrorAlertMutation({
+		refetchQueries: [namedOperations.Query.GetAlertsPagePayload],
+	})
+	const [deleteErrorAlertMutation] = useDeleteErrorAlertMutation({
+		refetchQueries: [namedOperations.Query.GetAlertsPagePayload],
+	})
+
+	const { project_id } = useParams<{
+		project_id: string
+	}>()
+
+	const navigate = useNavigate()
+
+	const header = (
+		<Box
+			display="flex"
+			justifyContent="flex-end"
+			alignItems="center"
+			borderBottom="dividerWeak"
+			px="8"
+			py="6"
+			cssClass={styles.header}
+		>
+			<Box display="flex" alignItems="center" gap="4">
+				<Button
+					kind="secondary"
+					size="small"
+					emphasis="low"
+					trackingId="closeErrorAlert"
+					onClick={() => {
+						navigate(`/${project_id}/alerts`)
+					}}
+				>
+					Cancel
+				</Button>
+				{!isCreate && (
+					<Button
+						kind="danger"
+						size="small"
+						emphasis="low"
+						trackingId="deleteErrorAlert"
+						onClick={() => {
+							deleteErrorAlertMutation({
+								variables: {
+									project_id: project_id ?? '',
+									error_alert_id: alert_id,
+								},
+							})
+								.then(() => {
+									message.success(`Error alert deleted!`)
+									navigate(`/${project_id}/alerts`)
+								})
+								.catch(() => {
+									message.error(
+										`Failed to delete error alert!`,
+									)
+								})
+						}}
+					>
+						Delete Alert
+					</Button>
+				)}
+				<Button
+					kind="primary"
+					size="small"
+					emphasis="high"
+					trackingId="saveErrorMonitoringAlert"
+					onClick={() => {
+						const input = {
+							count_threshold: form.getValue(
+								form.names.threshold,
+							),
+							disabled: false,
+							discord_channels: form.values.discordChannels.map(
+								(c) => ({
+									name: c.name,
+									id: c.id,
+								}),
+							),
+							emails: form.getValue(form.names.emails),
+							environments: form.getValue(
+								form.names.excludedEnvironments,
+							),
+							name: form.getValue(form.names.name),
+							project_id: project_id || '0',
+							slack_channels: form.values.slackChannels.map(
+								(c) => ({
+									webhook_channel_id: c.webhook_channel_id,
+									webhook_channel_name:
+										c.webhook_channel_name,
+								}),
+							),
+							webhook_destinations: form
+								.getValue(form.names.webhookDestinations)
+								.map((d: string) => ({ url: d })),
+							threshold_window: form.getValue(
+								form.names.threshold_window,
+							),
+							regex_groups: form.getValue(
+								form.names.regex_groups,
+							),
+							frequency: form.getValue(form.names.frequency),
+						}
+
+						const nameErr = !input.name
+						const thresholdErr = !input.count_threshold
+						if (nameErr || thresholdErr) {
+							const errs = []
+							if (nameErr) {
+								form.setError(
+									form.names.name,
+									'Name is required',
+								)
+								errs.push('name')
+							}
+
+							if (thresholdErr) {
+								form.setError(
+									form.names.threshold,
+									'Threshold is required',
+								)
+								errs.push('threshold')
+							}
+
+							message.error(
+								`Missing required field(s): ${errs.join(
+									', ',
+								)}.`,
+							)
+
+							return
+						}
+
+						if (isCreate) {
+							createErrorAlertMutation({
+								variables: input,
+							})
+								.then(() => {
+									message.success(
+										`Error alert ${createStr}d!`,
+									)
+									navigate(`/${project_id}/alerts`)
+								})
+								.catch(() => {
+									message.error(
+										`Failed to ${createStr} error alert!`,
+									)
+								})
+						} else {
+							updateErrorAlertMutation({
+								variables: {
+									...input,
+									error_alert_id: alert_id,
+								},
+							})
+								.then(() => {
+									message.success(
+										`Error alert ${createStr}d!`,
+									)
+									navigate(`/${project_id}/alerts`)
+								})
+								.catch(() => {
+									message.error(
+										`Failed to ${createStr} error alert!`,
+									)
+								})
+						}
+					}}
+				>
+					{capitalize(createStr)} alert
+				</Button>
+			</Box>
+		</Box>
+	)
+
+	const isLoading = !isCreate && !form.values.loaded
+
+	return (
+		<Box width="full" background="raised" p="8">
+			<Box
+				border="dividerWeak"
+				borderRadius="6"
+				width="full"
+				shadow="medium"
+				background="default"
+				display="flex"
+				flexDirection="column"
+				height="full"
+			>
+				{isLoading && <LoadingBox />}
+				{!isLoading && (
+					<>
+						{header}
+						<Container
+							display="flex"
+							flexDirection="column"
+							py="24"
+							gap="40"
+						>
+							<Box
+								display="flex"
+								flexDirection="column"
+								width="full"
+								height="full"
+								gap="12"
+							>
+								<Box
+									display="flex"
+									alignItems="center"
+									width="full"
+									justifyContent="space-between"
+								>
+									<Box
+										display="flex"
+										alignItems="center"
+										gap="4"
+										color="weak"
+									>
+										<Tag
+											kind="secondary"
+											size="medium"
+											shape="basic"
+											emphasis="high"
+											iconLeft={<IconSolidSpeakerphone />}
+											onClick={() => {
+												navigate(
+													`/${project_id}/alerts`,
+												)
+											}}
+										>
+											Alerts
+										</Tag>
+										<IconSolidCheveronRight />
+										<Text
+											color="moderate"
+											size="small"
+											weight="medium"
+											userSelect="none"
+										>
+											Error alert
+										</Text>
+									</Box>
+								</Box>
+							</Box>
+
+							<Form state={form} resetOnSubmit={false}>
+								<ErrorAlertForm />
+							</Form>
+						</Container>
+					</>
+				)}
+			</Box>
+		</Box>
+	)
+}
+
+const ErrorAlertForm = () => {
+	const form = useForm() as FormState<ErrorAlertFormItem>
+
+	const { alertsPayload } = useAlertsContext()
+	const environments = dedupeEnvironments(
+		(alertsPayload?.environment_suggestion ??
+			[]) as EnvironmentSuggestion[],
+	).map((environmentSuggestion) => ({
+		displayValue: environmentSuggestion,
+		value: environmentSuggestion,
+		id: environmentSuggestion,
+	}))
+
+	return (
+		<Box cssClass={styles.grid}>
+			<Stack gap="40">
+				<Stack gap="12">
+					<Box
+						cssClass={styles.sectionHeader}
+						justifyContent="space-between"
+					>
+						<Text size="large" weight="bold" color="strong">
+							Alert conditions
+						</Text>
+						<Menu>
+							<ThresholdTypeConfiguration />
+						</Menu>
+					</Box>
+					<Box borderTop="dividerWeak" width="full" />
+					<Form.NamedSection
+						label="Regex Patterns to Ignore"
+						name={form.names.regex_groups}
+					>
+						<Select
+							aria-label="Regex Patterns to Ignore list"
+							placeholder={`Input any valid regex, like: \\d{5}(-\\d{4})?, Hello\\nworld, [b-chm-pP]at|ot`}
+							onChange={(values: any): any =>
+								form.setValue(form.names.regex_groups, values)
+							}
+							value={form.values.regex_groups}
+							className={styles.selectContainer}
+							mode="tags"
+						/>
+					</Form.NamedSection>
+					<Column.Container gap="12">
+						<Column>
+							<Form.Input
+								name={form.names.threshold}
+								type="number"
+								label="Alert threshold"
+								tag={
+									<Badge
+										shape="basic"
+										variant="red"
+										size="small"
+										label="Red"
+									/>
+								}
+								style={{
+									borderColor: form.errors.threshold
+										? 'var(--color-red-500)'
+										: undefined,
+								}}
+							/>
+						</Column>
+
+						<Column>
+							<Form.Select
+								label="Alert threshold window"
+								name={form.names.threshold_window.toString()}
+								value={form.values.threshold_window}
+								onChange={(e) =>
+									form.setValue(
+										form.names.threshold_window,
+										e.target.value,
+									)
+								}
+							>
+								<option value="" disabled>
+									Select alert threshold window
+								</option>
+								{FREQUENCIES.map((freq: any) => (
+									<option
+										key={freq.id}
+										value={Number(freq.value)}
+									>
+										{freq.displayValue}
+									</option>
+								))}
+							</Form.Select>
+						</Column>
+					</Column.Container>
+					<Form.Select
+						label="Alert frequency"
+						name={form.names.frequency.toString()}
+						value={form.values.frequency}
+						onChange={(e) =>
+							form.setValue(form.names.frequency, e.target.value)
+						}
+					>
+						<option value="" disabled>
+							Select alert frequency
+						</option>
+						{FREQUENCIES.map((freq: any) => (
+							<option key={freq.id} value={Number(freq.value)}>
+								{freq.displayValue}
+							</option>
+						))}
+					</Form.Select>
+				</Stack>
+
+				<Stack gap="12">
+					<Box cssClass={styles.sectionHeader}>
+						<Text size="large" weight="bold" color="strong">
+							General
+						</Text>
+					</Box>
+
+					<Box borderTop="dividerWeak" width="full" />
+
+					<Form.Input
+						name={form.names.name}
+						type="text"
+						placeholder="Alert name"
+						label="Name"
+						style={{
+							borderColor: form.errors.name
+								? 'var(--color-red-500)'
+								: undefined,
+						}}
+					/>
+
+					<Form.NamedSection
+						label="Excluded environments"
+						name={form.names.excludedEnvironments}
+					>
+						<Select
+							aria-label="Excluded environments list"
+							placeholder="Select excluded environments"
+							options={environments}
+							onChange={(values: any): any =>
+								form.setValue(
+									form.names.excludedEnvironments,
+									values,
+								)
+							}
+							value={form.values.excludedEnvironments}
+							notFoundContent={<p>No environment suggestions</p>}
+							className={styles.selectContainer}
+							mode="multiple"
+						/>
+					</Form.NamedSection>
+				</Stack>
+			</Stack>
+			<AlertNotifyForm />
+		</Box>
+	)
+}
+
+const ThresholdTypeConfiguration = () => {
+	const form = useForm()
+	const menu = useMenu()
+	const belowThreshold = form.values.belowThreshold
+	return (
+		<>
+			<Menu.Button
+				kind="secondary"
+				size="small"
+				emphasis="high"
+				cssClass={styles.thresholdTypeButton}
+				iconRight={
+					menu.open ? (
+						<IconSolidCheveronUp />
+					) : (
+						<IconSolidCheveronDown />
+					)
+				}
+			>
+				{belowThreshold ? 'Below' : 'Above'} threshold
+			</Menu.Button>
+			<Menu.List>
+				<Menu.Item
+					onClick={() => {
+						form.setValue('belowThreshold', false)
+					}}
+				>
+					Above threshold
+				</Menu.Item>
+				<Menu.Item
+					onClick={() => {
+						form.setValue('belowThreshold', true)
+					}}
+				>
+					Below threshold
+				</Menu.Item>
+			</Menu.List>
+		</>
+	)
+}
+
+interface ErrorAlertFormItem extends AlertForm {
+	regex_groups: string[]
+}
+
+export default ErrorAlertPage

--- a/frontend/src/pages/Alerts/ErrorAlert/styles.css.ts
+++ b/frontend/src/pages/Alerts/ErrorAlert/styles.css.ts
@@ -1,0 +1,93 @@
+import { vars } from '@highlight-run/ui'
+import { sprinkles } from '@highlight-run/ui/src/css/sprinkles.css'
+import { globalStyle, style } from '@vanilla-extract/css'
+
+export const header = style({
+	height: 40,
+})
+
+export const grid = style({
+	display: 'grid',
+	gridTemplateColumns: '1fr 1fr',
+	gridTemplateRows: 'auto auto',
+	gridColumnGap: 40,
+	gridRowGap: 40,
+})
+
+export const queryContainer = style([
+	sprinkles({
+		borderRadius: '6',
+		border: 'secondary',
+		pr: '4',
+	}),
+])
+
+export const combobox = style([
+	sprinkles({
+		py: '4',
+		pl: '6',
+	}),
+	{
+		border: 0,
+		background: 'transparent',
+		color: vars.theme.static.content.default,
+		display: 'flex',
+		fontSize: 13,
+		width: '100%',
+		selectors: {
+			'&:focus': {
+				outline: 0,
+			},
+			'&::placeholder': {
+				color: vars.theme.interactive.fill.secondary.content.onDisabled,
+			},
+		},
+	},
+])
+
+export const sectionHeader = style([
+	sprinkles({
+		display: 'flex',
+		alignItems: 'center',
+		gap: '8',
+		width: 'full',
+	}),
+	{
+		height: 20,
+	},
+])
+
+export const thresholdTypeButton = style([
+	sprinkles({
+		px: '4',
+		py: '2',
+	}),
+	{
+		height: 20,
+	},
+])
+
+export const selectContainer = style({
+	color: `${vars.theme.static.content.default} !important`,
+	selectors: {
+		'&:hover': {
+			background: vars.theme.interactive.overlay.secondary.hover,
+		},
+	},
+})
+
+globalStyle(`${selectContainer} .ant-select-selector`, {
+	padding: `0 6px !important`,
+	borderRadius: `6px !important`,
+	border: `${vars.border.secondary} !important`,
+	boxShadow: 'none !important',
+})
+
+globalStyle(`${selectContainer} .ant-select-selector:hover`, {
+	background: `${vars.theme.interactive.overlay.secondary.hover} !important`,
+})
+
+globalStyle(`${selectContainer} .ant-select-selection-item`, {
+	display: 'flex',
+	alignItems: 'center',
+})

--- a/frontend/src/pages/Alerts/NewAlertPage.tsx
+++ b/frontend/src/pages/Alerts/NewAlertPage.tsx
@@ -1,4 +1,13 @@
 import Card from '@components/Card/Card'
+import {
+	Box,
+	Container,
+	IconSolidCheveronRight,
+	IconSolidSpeakerphone,
+	Stack,
+	Tag,
+	Text,
+} from '@highlight-run/ui'
 import SvgMonitorIcon from '@icons/MonitorIcon'
 import { AlertConfigurationCard } from '@pages/Alerts/AlertConfigurationCard/AlertConfigurationCard'
 import {
@@ -10,7 +19,6 @@ import { useAlertsContext } from '@pages/Alerts/AlertsContext/AlertsContext'
 import { getAlertTypeColor } from '@pages/Alerts/utils/AlertsUtils'
 import { useParams } from '@util/react-router/useParams'
 import { snakeCaseString } from '@util/string'
-import React from 'react'
 import { Helmet } from 'react-helmet'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
@@ -39,123 +47,216 @@ const NewAlertPage = () => {
 	}
 
 	return (
-		<div>
+		<Box width="full" background="raised" p="8">
 			<Helmet>
 				<title>Create New Alert</title>
 			</Helmet>
-			{!type ? (
-				<>
-					<p className={layoutStyles.subTitle}>
-						👋 Let's create an alert! Alerts are a way to keep your
-						team in the loop as to what is happening on your app.
-					</p>
-					<div className={styles.cardGrid}>
-						{Object.keys(ALERT_CONFIGURATIONS).map((_key) => {
-							const key =
-								_key as keyof typeof ALERT_CONFIGURATIONS
-							const configuration = ALERT_CONFIGURATIONS[key]
-							const alertColor = getAlertTypeColor(
-								configuration.name,
-							)
-
-							if (configuration.name === 'Metric Monitor') {
-								return null
-							}
-
-							return (
-								<Link
-									className={styles.cardContent}
-									key={key}
-									state={{
-										errorName: `${configuration.name} Alert`,
+			<Box
+				border="dividerWeak"
+				borderRadius="6"
+				width="full"
+				shadow="medium"
+				background="default"
+				display="flex"
+				flexDirection="column"
+				height="full"
+			>
+				<Container display="flex" flexDirection="column" gap="24">
+					<Box style={{ maxWidth: 860 }} my="40" mx="auto">
+						<Stack gap="24">
+							<Box
+								display="flex"
+								alignItems="center"
+								gap="4"
+								color="weak"
+							>
+								<Tag
+									kind="secondary"
+									size="medium"
+									shape="basic"
+									emphasis="high"
+									iconLeft={<IconSolidSpeakerphone />}
+									onClick={() => {
+										navigate(`/${project_id}/alerts`)
 									}}
-									to={`${url}/${snakeCaseString(
-										configuration.name,
-									)}`}
 								>
-									<Card
-										interactable
-										className={styles.cardContainer}
-									>
-										<h2 id={styles.title}>
-											<span
-												className={styles.icon}
-												style={{
-													backgroundColor: alertColor,
-												}}
+									Alerts
+								</Tag>
+								<IconSolidCheveronRight />
+								<Text
+									color="moderate"
+									size="small"
+									weight="medium"
+									userSelect="none"
+								>
+									{type ? 'Session alert' : 'New alert'}
+								</Text>
+							</Box>
+							{!type ? (
+								<>
+									<p className={layoutStyles.subTitle}>
+										👋 Let's create an alert! Alerts are a
+										way to keep your team in the loop as to
+										what is happening on your app.
+									</p>
+									<div className={styles.cardGrid}>
+										{Object.keys(ALERT_CONFIGURATIONS).map(
+											(_key) => {
+												const key =
+													_key as keyof typeof ALERT_CONFIGURATIONS
+												const configuration =
+													ALERT_CONFIGURATIONS[key]
+												const alertColor =
+													getAlertTypeColor(
+														configuration.name,
+													)
+
+												if (
+													configuration.name ===
+													'Metric Monitor'
+												) {
+													return null
+												}
+
+												return (
+													<Link
+														className={
+															styles.cardContent
+														}
+														key={key}
+														state={{
+															errorName: `${configuration.name} Alert`,
+														}}
+														to={`${url}/${snakeCaseString(
+															configuration.name,
+														)}`}
+													>
+														<Card
+															interactable
+															className={
+																styles.cardContainer
+															}
+														>
+															<h2
+																id={
+																	styles.title
+																}
+															>
+																<span
+																	className={
+																		styles.icon
+																	}
+																	style={{
+																		backgroundColor:
+																			alertColor,
+																	}}
+																>
+																	{
+																		ALERT_CONFIGURATIONS[
+																			key
+																		].icon
+																	}
+																</span>
+																{
+																	ALERT_CONFIGURATIONS[
+																		key
+																	].name
+																}
+															</h2>
+															<p
+																className={
+																	styles.description
+																}
+															>
+																{
+																	ALERT_CONFIGURATIONS[
+																		key
+																	]
+																		.description
+																}
+															</p>
+														</Card>
+													</Link>
+												)
+											},
+										)}
+										<Link
+											className={styles.cardContent}
+											to={`${url}/monitor`}
+											state={{
+												errorName: `New Monitor`,
+											}}
+										>
+											<Card
+												interactable
+												className={styles.cardContainer}
 											>
-												{ALERT_CONFIGURATIONS[key].icon}
-											</span>
-											{ALERT_CONFIGURATIONS[key].name}
-										</h2>
-										<p className={styles.description}>
-											{
-												ALERT_CONFIGURATIONS[key]
-													.description
-											}
-										</p>
-									</Card>
-								</Link>
-							)
-						})}
-						<Link
-							className={styles.cardContent}
-							to={`${url}/monitor`}
-							state={{
-								errorName: `New Monitor`,
-							}}
-						>
-							<Card interactable className={styles.cardContainer}>
-								<h2 id={styles.title}>
-									<span
-										className={styles.icon}
-										style={{
-											backgroundColor:
-												'var(--color-orange-500)',
-										}}
-									>
-										<SvgMonitorIcon />
-									</span>
-									Metric Monitor
-								</h2>
-								<p className={styles.description}>
-									Get alerted when a metric value is larger
-									than a threshold.
-								</p>
-							</Card>
-						</Link>
-					</div>
-				</>
-			) : (
-				<AlertConfigurationCard
-					alert={{
-						...getNewAlert(type)?.alert,
-					}}
-					slackUrl={slackUrl}
-					isSlackIntegrated={
-						alertsPayload?.is_integrated_with_slack || false
-					}
-					isDiscordIntegrated={
-						alertsPayload?.is_integrated_with_discord || false
-					}
-					emailSuggestions={(alertsPayload?.admins || []).map(
-						(wa) => wa.admin!.email,
-					)}
-					channelSuggestions={
-						alertsPayload?.slack_channel_suggestion || []
-					}
-					discordChannelSuggestions={
-						alertsPayload?.discord_channel_suggestions || []
-					}
-					environmentOptions={
-						alertsPayload?.environment_suggestion || []
-					}
-					// @ts-expect-error
-					configuration={getNewAlert(type)?.configuration}
-					isCreatingNewAlert
-				/>
-			)}
-		</div>
+												<h2 id={styles.title}>
+													<span
+														className={styles.icon}
+														style={{
+															backgroundColor:
+																'var(--color-orange-500)',
+														}}
+													>
+														<SvgMonitorIcon />
+													</span>
+													Metric Monitor
+												</h2>
+												<p
+													className={
+														styles.description
+													}
+												>
+													Get alerted when a metric
+													value is larger than a
+													threshold.
+												</p>
+											</Card>
+										</Link>
+									</div>
+								</>
+							) : (
+								<AlertConfigurationCard
+									alert={{
+										...getNewAlert(type)?.alert,
+									}}
+									slackUrl={slackUrl}
+									isSlackIntegrated={
+										alertsPayload?.is_integrated_with_slack ||
+										false
+									}
+									isDiscordIntegrated={
+										alertsPayload?.is_integrated_with_discord ||
+										false
+									}
+									emailSuggestions={(
+										alertsPayload?.admins || []
+									).map((wa) => wa.admin!.email)}
+									channelSuggestions={
+										alertsPayload?.slack_channel_suggestion ||
+										[]
+									}
+									discordChannelSuggestions={
+										alertsPayload?.discord_channel_suggestions ||
+										[]
+									}
+									environmentOptions={
+										alertsPayload?.environment_suggestion ||
+										[]
+									}
+									// @ts-expect-error
+									configuration={
+										getNewAlert(type)?.configuration
+									}
+									isCreatingNewAlert
+								/>
+							)}
+						</Stack>
+					</Box>
+				</Container>
+			</Box>
+		</Box>
 	)
 }
 

--- a/frontend/src/pages/Alerts/components/AlertNotifyForm/AlertNotifyForm.tsx
+++ b/frontend/src/pages/Alerts/components/AlertNotifyForm/AlertNotifyForm.tsx
@@ -1,0 +1,165 @@
+import Select from '@components/Select/Select'
+import { Box, Form, FormState, Stack, Text, useForm } from '@highlight-run/ui'
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import { useSlackSync } from '@/hooks/useSlackSync'
+import SlackLoadOrConnect from '@/pages/Alerts/AlertConfigurationCard/SlackLoadOrConnect'
+import { useAlertsContext } from '@/pages/Alerts/AlertsContext/AlertsContext'
+import { AlertForm } from '@/pages/Alerts/utils/AlertsUtils'
+
+import * as styles from './styles.css'
+
+const AlertNotifyForm = () => {
+	const { alertsPayload, slackUrl } = useAlertsContext()
+	const { slackLoading, syncSlack } = useSlackSync()
+	const [slackSearchQuery, setSlackSearchQuery] = useState('')
+	const form = useForm() as FormState<AlertForm>
+
+	const slackChannels = (alertsPayload?.slack_channel_suggestion ?? []).map(
+		({ webhook_channel, webhook_channel_id }) => ({
+			displayValue: webhook_channel!,
+			value: webhook_channel_id!,
+			id: webhook_channel_id!,
+		}),
+	)
+
+	const discordChannels = (
+		alertsPayload?.discord_channel_suggestions ?? []
+	).map(({ name, id }) => ({
+		displayValue: name,
+		value: id,
+		id: id,
+	}))
+
+	const emails = (alertsPayload?.admins ?? [])
+		.map((wa) => wa.admin!.email)
+		.map((email) => ({
+			displayValue: email,
+			value: email,
+			id: email,
+		}))
+
+	return (
+		<Stack gap="12">
+			<Box cssClass={styles.sectionHeader}>
+				<Text size="large" weight="bold" color="strong">
+					Notify team
+				</Text>
+			</Box>
+
+			<Box borderTop="dividerWeak" width="full" />
+			<Form.NamedSection
+				label="Slack channels to notify"
+				name={form.names.slackChannels}
+			>
+				<Select
+					aria-label="Slack channels to notify"
+					placeholder="Select Slack channels"
+					options={slackChannels}
+					optionFilterProp="label"
+					onFocus={syncSlack}
+					onSearch={(value) => {
+						setSlackSearchQuery(value)
+					}}
+					onChange={(values) => {
+						form.setValue(
+							form.names.slackChannels,
+							values.map((v: any) => ({
+								webhook_channel_name: v.label,
+								webhook_channel_id: v.value,
+								...v,
+							})),
+						)
+					}}
+					value={form.values.slackChannels}
+					notFoundContent={
+						<SlackLoadOrConnect
+							isLoading={slackLoading}
+							searchQuery={slackSearchQuery}
+							slackUrl={slackUrl}
+							isSlackIntegrated={
+								alertsPayload?.is_integrated_with_slack ?? false
+							}
+						/>
+					}
+					className={styles.selectContainer}
+					mode="multiple"
+					labelInValue
+				/>
+			</Form.NamedSection>
+
+			<Form.NamedSection
+				label="Discord channels to notify"
+				name={form.names.discordChannels}
+			>
+				<Select
+					aria-label="Discord channels to notify"
+					placeholder="Select Discord channels"
+					options={discordChannels}
+					optionFilterProp="label"
+					onChange={(values) => {
+						form.setValue(
+							form.names.discordChannels,
+							values.map((v: any) => ({
+								name: v.label,
+								id: v.value,
+								...v,
+							})),
+						)
+					}}
+					value={form.values.discordChannels}
+					notFoundContent={
+						discordChannels.length === 0 ? (
+							<Link to="/integrations">
+								Connect Highlight with Discord
+							</Link>
+						) : (
+							'Discord channel not found'
+						)
+					}
+					className={styles.selectContainer}
+					mode="multiple"
+					labelInValue
+				/>
+			</Form.NamedSection>
+
+			<Form.NamedSection
+				label="Emails to notify"
+				name={form.names.emails}
+			>
+				<Select
+					aria-label="Emails to notify"
+					placeholder="Select emails"
+					options={emails}
+					onChange={(values: any): any =>
+						form.setValue(form.names.emails, values)
+					}
+					value={form.values.emails}
+					notFoundContent={<p>No email suggestions</p>}
+					className={styles.selectContainer}
+					mode="multiple"
+				/>
+			</Form.NamedSection>
+
+			<Form.NamedSection
+				label="Webhooks to notify"
+				name={form.names.emails}
+			>
+				<Select
+					aria-label="Webhooks to notify"
+					placeholder="Enter webhook addresses"
+					onChange={(values: any): any =>
+						form.setValue(form.names.webhookDestinations, values)
+					}
+					value={form.values.webhookDestinations}
+					notFoundContent={null}
+					className={styles.selectContainer}
+					mode="tags"
+				/>
+			</Form.NamedSection>
+		</Stack>
+	)
+}
+
+export default AlertNotifyForm

--- a/frontend/src/pages/Alerts/components/AlertNotifyForm/styles.css.ts
+++ b/frontend/src/pages/Alerts/components/AlertNotifyForm/styles.css.ts
@@ -1,0 +1,40 @@
+import { vars } from '@highlight-run/ui'
+import { sprinkles } from '@highlight-run/ui/src/css/sprinkles.css'
+import { globalStyle, style } from '@vanilla-extract/css'
+
+export const sectionHeader = style([
+	sprinkles({
+		display: 'flex',
+		alignItems: 'center',
+		gap: '8',
+		width: 'full',
+	}),
+	{
+		height: 20,
+	},
+])
+
+export const selectContainer = style({
+	color: `${vars.theme.static.content.default} !important`,
+	selectors: {
+		'&:hover': {
+			background: vars.theme.interactive.overlay.secondary.hover,
+		},
+	},
+})
+
+globalStyle(`${selectContainer} .ant-select-selector`, {
+	padding: `0 6px !important`,
+	borderRadius: `6px !important`,
+	border: `${vars.border.secondary} !important`,
+	boxShadow: 'none !important',
+})
+
+globalStyle(`${selectContainer} .ant-select-selector:hover`, {
+	background: `${vars.theme.interactive.overlay.secondary.hover} !important`,
+})
+
+globalStyle(`${selectContainer} .ant-select-selection-item`, {
+	display: 'flex',
+	alignItems: 'center',
+})

--- a/frontend/src/pages/Alerts/utils/AlertsUtils.ts
+++ b/frontend/src/pages/Alerts/utils/AlertsUtils.ts
@@ -1,3 +1,13 @@
+import { GetAlertsPagePayloadQuery } from '@/graph/generated/operations'
+import {
+	DiscordChannelInput,
+	SanitizedSlackChannelInput,
+} from '@/graph/generated/schemas'
+import {
+	DEFAULT_FREQUENCY,
+	FREQUENCIES,
+} from '@/pages/Alerts/AlertConfigurationCard/AlertConfigurationConstants'
+
 export interface EnvironmentSuggestion {
 	name: string
 	value: string
@@ -44,4 +54,59 @@ export const getAlertTypeColor = (type: string) => {
 		default:
 			return '#bdbdbd'
 	}
+}
+
+/**
+ * All form fields for alerts
+ */
+export interface AlertForm {
+	name: string
+	belowThreshold: boolean
+	threshold: number | undefined
+	frequency: number
+	threshold_window: number
+	excludedEnvironments: string[]
+	slackChannels: SanitizedSlackChannelInput[]
+	discordChannels: DiscordChannelInput[]
+	emails: string[]
+	webhookDestinations: string[]
+	loaded: boolean
+}
+
+/**
+ * Gets specific alert given an id
+ * @param id
+ * @param alertsPayload
+ * @returns
+ */
+export const findAlert = (
+	id: string,
+	alertsPayload?: GetAlertsPagePayloadQuery,
+) => {
+	if (!alertsPayload) {
+		return undefined
+	}
+
+	const allAlerts = [
+		...alertsPayload.error_alerts,
+		...alertsPayload.new_session_alerts,
+		...(alertsPayload.new_user_alerts || []),
+		...alertsPayload.track_properties_alerts,
+		...alertsPayload.user_properties_alerts,
+		...alertsPayload.rage_click_alerts,
+	]
+
+	return allAlerts.find((alert) => alert?.id === id)
+}
+
+export const getFrequencyOption = (seconds = DEFAULT_FREQUENCY): any => {
+	const option = FREQUENCIES.find(
+		(option) => option.value === seconds?.toString(),
+	)
+
+	if (!option) {
+		return FREQUENCIES.find((option) => option.value === DEFAULT_FREQUENCY)
+	}
+
+	return option
 }


### PR DESCRIPTION
## Summary

Work towards: https://github.com/highlight/highlight/issues/6077

Updated the components and ui for the Error alerts creation to match the redesign, matching the Log alert creation page. Currently the model for alerts is similar for error and other alerts, so they're all fetch with a single hook `GetAlertsPagePayload`. With 3 main types of alert being planned, I think it might make sense to separate the files, with ErrorAlertPage calling all the ErrorAlert mutations, and a future SessionAlertPage calling all SessionAlert mutations. 

The new Error alert page differs from the Figma redesign in a few ways: 
- The old error alert page does not have a `query` input field, it's not on the error alert data model either. Unsure what this would be. 
- The old error alert page does not have data for a histogram. The only data we have is some DailyFrequency array. 
- The log alert page and the Figma design labels the `threshold_window` parameter "Alert frequency". However, we also have a `frequency` parameter for some alerts, that limits it so that users get a maximum of 1 alert every XX minutes/hours. 

Also added a new path for viewing/updating error alerts, instead of `/alerts/:id` like all other alerts, it uses `/alerts/errors/:id`. A redirect is implemented so it's backwards compatible. 

The Alerts home page and New Alert type selection haven't been implemented yet, adapted slightly to fit some top router-level ui changes for now. Creation page for all other alerts will be implemented in the next PR

## How did you test this change?

<img width="1436" alt="Screenshot 2023-08-10 at 4 19 47 PM" src="https://github.com/highlight/highlight/assets/29858539/4e44e39e-6fa6-48fe-a4d5-f9e56df90ccd">
<img width="1436" alt="Screenshot 2023-08-10 at 4 19 54 PM" src="https://github.com/highlight/highlight/assets/29858539/8fcc4add-0e22-4bd9-93d3-bb64f072390d">
<img width="1436" alt="Screenshot 2023-08-10 at 4 20 03 PM" src="https://github.com/highlight/highlight/assets/29858539/9add3e7a-73b4-4798-8228-5a4e491d9edb">
<img width="1436" alt="Screenshot 2023-08-10 at 4 20 35 PM" src="https://github.com/highlight/highlight/assets/29858539/8b0486e8-b480-4c2c-a6bb-ba661c637386">

## Are there any deployment considerations?

No backend changes
