### PR TITLE
batch submission of kafka messages

### DIFF
--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -415,13 +415,13 @@ func (h *HubspotApi) createContactForAdmin(ctx context.Context, email string, us
 }
 
 func (h *HubspotApi) CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int) error {
-	return h.kafkaProducer.Submit(ctx, &kafka_queue.Message{
+	return h.kafkaProducer.Submit(ctx, PartitionKey, &kafka_queue.Message{
 		Type: kafka_queue.HubSpotCreateContactCompanyAssociation,
 		HubSpotCreateContactCompanyAssociation: &kafka_queue.HubSpotCreateContactCompanyAssociationArgs{
 			AdminID:     adminID,
 			WorkspaceID: workspaceID,
 		},
-	}, PartitionKey)
+	})
 }
 
 func (h *HubspotApi) CreateContactCompanyAssociationImpl(ctx context.Context, adminID int, workspaceID int) error {
@@ -479,7 +479,7 @@ func (h *HubspotApi) CreateContactCompanyAssociationImpl(ctx context.Context, ad
 }
 
 func (h *HubspotApi) CreateContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) error {
-	return h.kafkaProducer.Submit(ctx, &kafka_queue.Message{
+	return h.kafkaProducer.Submit(ctx, PartitionKey, &kafka_queue.Message{
 		Type: kafka_queue.HubSpotCreateContactForAdmin,
 		HubSpotCreateContactForAdmin: &kafka_queue.HubSpotCreateContactForAdminArgs{
 			AdminID:            adminID,
@@ -491,7 +491,7 @@ func (h *HubspotApi) CreateContactForAdmin(ctx context.Context, adminID int, ema
 			Phone:              phone,
 			Referral:           referral,
 		},
-	}, PartitionKey)
+	})
 }
 
 func (h *HubspotApi) CreateContactForAdminImpl(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
@@ -528,14 +528,14 @@ func (h *HubspotApi) CreateContactForAdminImpl(ctx context.Context, adminID int,
 }
 
 func (h *HubspotApi) CreateCompanyForWorkspace(ctx context.Context, workspaceID int, adminEmail string, name string) error {
-	return h.kafkaProducer.Submit(ctx, &kafka_queue.Message{
+	return h.kafkaProducer.Submit(ctx, PartitionKey, &kafka_queue.Message{
 		Type: kafka_queue.HubSpotCreateCompanyForWorkspace,
 		HubSpotCreateCompanyForWorkspace: &kafka_queue.HubSpotCreateCompanyForWorkspaceArgs{
 			WorkspaceID: workspaceID,
 			AdminEmail:  adminEmail,
 			Name:        name,
 		},
-	}, PartitionKey)
+	})
 }
 
 func (h *HubspotApi) CreateCompanyForWorkspaceImpl(ctx context.Context, workspaceID int, adminEmail, name string) (companyID *int, err error) {
@@ -609,13 +609,13 @@ func (h *HubspotApi) CreateCompanyForWorkspaceImpl(ctx context.Context, workspac
 }
 
 func (h *HubspotApi) UpdateContactProperty(ctx context.Context, adminID int, properties []hubspot.Property) error {
-	return h.kafkaProducer.Submit(ctx, &kafka_queue.Message{
+	return h.kafkaProducer.Submit(ctx, PartitionKey, &kafka_queue.Message{
 		Type: kafka_queue.HubSpotUpdateContactProperty,
 		HubSpotUpdateContactProperty: &kafka_queue.HubSpotUpdateContactPropertyArgs{
 			AdminID:    adminID,
 			Properties: properties,
 		},
-	}, PartitionKey)
+	})
 }
 
 func (h *HubspotApi) UpdateContactPropertyImpl(ctx context.Context, adminID int, properties []hubspot.Property) error {
@@ -651,13 +651,13 @@ func (h *HubspotApi) UpdateContactPropertyImpl(ctx context.Context, adminID int,
 }
 
 func (h *HubspotApi) UpdateCompanyProperty(ctx context.Context, workspaceID int, properties []hubspot.Property) error {
-	return h.kafkaProducer.Submit(ctx, &kafka_queue.Message{
+	return h.kafkaProducer.Submit(ctx, PartitionKey, &kafka_queue.Message{
 		Type: kafka_queue.HubSpotUpdateCompanyProperty,
 		HubSpotUpdateCompanyProperty: &kafka_queue.HubSpotUpdateCompanyPropertyArgs{
 			WorkspaceID: workspaceID,
 			Properties:  properties,
 		},
-	}, PartitionKey)
+	})
 }
 
 func (h *HubspotApi) UpdateCompanyPropertyImpl(ctx context.Context, workspaceID int, properties []hubspot.Property) error {

--- a/backend/kafka-queue/kafkaqueue_test.go
+++ b/backend/kafka-queue/kafkaqueue_test.go
@@ -46,7 +46,7 @@ func BenchmarkQueue_Submit(b *testing.B) {
 					log.WithContext(ctx).Error(err)
 				}
 
-				err = writer.Submit(ctx, &Message{
+				err = writer.Submit(ctx, fmt.Sprintf("test-%d", w), &Message{
 					Type: PushPayload,
 					PushPayload: &PushPayloadArgs{
 						Events: model.ReplayEventsInput{
@@ -65,7 +65,7 @@ func BenchmarkQueue_Submit(b *testing.B) {
 						HighlightLogs:      nil,
 						PayloadID:          nil,
 					},
-				}, fmt.Sprintf("test-%d", w))
+				})
 				if err != nil {
 					log.WithContext(ctx).Error(err)
 				}

--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -104,7 +104,7 @@ type AddSessionFeedbackArgs struct {
 }
 
 type PushLogsArgs struct {
-	LogRows []*clickhouse.LogRow
+	LogRow *clickhouse.LogRow
 }
 
 type PushTracesArgs struct {
@@ -152,22 +152,22 @@ type Message struct {
 	Failures                               int
 	MaxRetries                             int
 	KafkaMessage                           *kafka.Message
-	PushPayload                            *PushPayloadArgs
-	InitializeSession                      *InitializeSessionArgs
-	IdentifySession                        *IdentifySessionArgs
-	AddTrackProperties                     *AddTrackPropertiesArgs
-	AddSessionProperties                   *AddSessionPropertiesArgs
-	PushBackendPayload                     *PushBackendPayloadArgs
-	PushMetrics                            *PushMetricsArgs
-	AddSessionFeedback                     *AddSessionFeedbackArgs
-	PushLogs                               *PushLogsArgs
-	PushTraces                             *PushTracesArgs
-	HubSpotCreateContactForAdmin           *HubSpotCreateContactForAdminArgs
-	HubSpotCreateCompanyForWorkspace       *HubSpotCreateCompanyForWorkspaceArgs
-	HubSpotUpdateContactProperty           *HubSpotUpdateContactPropertyArgs
-	HubSpotUpdateCompanyProperty           *HubSpotUpdateCompanyPropertyArgs
-	HubSpotCreateContactCompanyAssociation *HubSpotCreateContactCompanyAssociationArgs
-	SessionDataSync                        *SessionDataSyncArgs
+	PushPayload                            *PushPayloadArgs                            `json:"PushPayload,omitempty"`
+	InitializeSession                      *InitializeSessionArgs                      `json:"InitializeSession,omitempty"`
+	IdentifySession                        *IdentifySessionArgs                        `json:"IdentifySession,omitempty"`
+	AddTrackProperties                     *AddTrackPropertiesArgs                     `json:"AddTrackProperties,omitempty"`
+	AddSessionProperties                   *AddSessionPropertiesArgs                   `json:"AddSessionProperties,omitempty"`
+	PushBackendPayload                     *PushBackendPayloadArgs                     `json:"PushBackendPayload,omitempty"`
+	PushMetrics                            *PushMetricsArgs                            `json:"PushMetrics,omitempty"`
+	AddSessionFeedback                     *AddSessionFeedbackArgs                     `json:"AddSessionFeedback,omitempty"`
+	PushLogs                               *PushLogsArgs                               `json:"PushLogs,omitempty"`
+	PushTraces                             *PushTracesArgs                             `json:"PushTraces,omitempty"`
+	HubSpotCreateContactForAdmin           *HubSpotCreateContactForAdminArgs           `json:"HubSpotCreateContactForAdmin,omitempty"`
+	HubSpotCreateCompanyForWorkspace       *HubSpotCreateCompanyForWorkspaceArgs       `json:"HubSpotCreateCompanyForWorkspace,omitempty"`
+	HubSpotUpdateContactProperty           *HubSpotUpdateContactPropertyArgs           `json:"HubSpotUpdateContactProperty,omitempty"`
+	HubSpotUpdateCompanyProperty           *HubSpotUpdateCompanyPropertyArgs           `json:"HubSpotUpdateCompanyProperty,omitempty"`
+	HubSpotCreateContactCompanyAssociation *HubSpotCreateContactCompanyAssociationArgs `json:"HubSpotCreateContactCompanyAssociation,omitempty"`
+	SessionDataSync                        *SessionDataSyncArgs                        `json:"SessionDataSync,omitempty"`
 }
 
 type PartitionMessage struct {

--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -154,22 +154,22 @@ type Message struct {
 	Failures                               int
 	MaxRetries                             int
 	KafkaMessage                           *kafka.Message
-	PushPayload                            *PushPayloadArgs                            `json:"PushPayload,omitempty"`
-	InitializeSession                      *InitializeSessionArgs                      `json:"InitializeSession,omitempty"`
-	IdentifySession                        *IdentifySessionArgs                        `json:"IdentifySession,omitempty"`
-	AddTrackProperties                     *AddTrackPropertiesArgs                     `json:"AddTrackProperties,omitempty"`
-	AddSessionProperties                   *AddSessionPropertiesArgs                   `json:"AddSessionProperties,omitempty"`
-	PushBackendPayload                     *PushBackendPayloadArgs                     `json:"PushBackendPayload,omitempty"`
-	PushMetrics                            *PushMetricsArgs                            `json:"PushMetrics,omitempty"`
-	AddSessionFeedback                     *AddSessionFeedbackArgs                     `json:"AddSessionFeedback,omitempty"`
-	PushLogs                               *PushLogsArgs                               `json:"PushLogs,omitempty"`
-	PushTraces                             *PushTracesArgs                             `json:"PushTraces,omitempty"`
-	HubSpotCreateContactForAdmin           *HubSpotCreateContactForAdminArgs           `json:"HubSpotCreateContactForAdmin,omitempty"`
-	HubSpotCreateCompanyForWorkspace       *HubSpotCreateCompanyForWorkspaceArgs       `json:"HubSpotCreateCompanyForWorkspace,omitempty"`
-	HubSpotUpdateContactProperty           *HubSpotUpdateContactPropertyArgs           `json:"HubSpotUpdateContactProperty,omitempty"`
-	HubSpotUpdateCompanyProperty           *HubSpotUpdateCompanyPropertyArgs           `json:"HubSpotUpdateCompanyProperty,omitempty"`
-	HubSpotCreateContactCompanyAssociation *HubSpotCreateContactCompanyAssociationArgs `json:"HubSpotCreateContactCompanyAssociation,omitempty"`
-	SessionDataSync                        *SessionDataSyncArgs                        `json:"SessionDataSync,omitempty"`
+	PushPayload                            *PushPayloadArgs                            `json:",omitempty"`
+	InitializeSession                      *InitializeSessionArgs                      `json:",omitempty"`
+	IdentifySession                        *IdentifySessionArgs                        `json:",omitempty"`
+	AddTrackProperties                     *AddTrackPropertiesArgs                     `json:",omitempty"`
+	AddSessionProperties                   *AddSessionPropertiesArgs                   `json:",omitempty"`
+	PushBackendPayload                     *PushBackendPayloadArgs                     `json:",omitempty"`
+	PushMetrics                            *PushMetricsArgs                            `json:",omitempty"`
+	AddSessionFeedback                     *AddSessionFeedbackArgs                     `json:",omitempty"`
+	PushLogs                               *PushLogsArgs                               `json:",omitempty"`
+	PushTraces                             *PushTracesArgs                             `json:",omitempty"`
+	HubSpotCreateContactForAdmin           *HubSpotCreateContactForAdminArgs           `json:",omitempty"`
+	HubSpotCreateCompanyForWorkspace       *HubSpotCreateCompanyForWorkspaceArgs       `json:",omitempty"`
+	HubSpotUpdateContactProperty           *HubSpotUpdateContactPropertyArgs           `json:",omitempty"`
+	HubSpotUpdateCompanyProperty           *HubSpotUpdateCompanyPropertyArgs           `json:",omitempty"`
+	HubSpotCreateContactCompanyAssociation *HubSpotCreateContactCompanyAssociationArgs `json:",omitempty"`
+	SessionDataSync                        *SessionDataSyncArgs                        `json:",omitempty"`
 }
 
 type PartitionMessage struct {

--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -104,7 +104,9 @@ type AddSessionFeedbackArgs struct {
 }
 
 type PushLogsArgs struct {
-	LogRow *clickhouse.LogRow
+	// deprecated, write individual LogRow messages instead
+	LogRows []*clickhouse.LogRow
+	LogRow  *clickhouse.LogRow
 }
 
 type PushTracesArgs struct {

--- a/backend/main.go
+++ b/backend/main.go
@@ -107,12 +107,12 @@ func healthRouter(runtimeFlag util.Runtime, db *gorm.DB, tdb timeseries.DB, rCli
 	batchedTopic := kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched})
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		if err := queue.Submit(ctx, &kafkaqueue.Message{Type: kafkaqueue.HealthCheck}, ""); err != nil {
+		if err := queue.Submit(ctx, "", &kafkaqueue.Message{Type: kafkaqueue.HealthCheck}); err != nil {
 			log.WithContext(ctx).Error(fmt.Sprintf("failed kafka health check: %s", err))
 			http.Error(w, fmt.Sprintf("failed to write message to kafka %s", topic), 500)
 			return
 		}
-		if err := batchedQueue.Submit(ctx, &kafkaqueue.Message{Type: kafkaqueue.HealthCheck}, ""); err != nil {
+		if err := batchedQueue.Submit(ctx, "", &kafkaqueue.Message{Type: kafkaqueue.HealthCheck}); err != nil {
 			log.WithContext(ctx).Error(fmt.Sprintf("failed kafka batched health check: %s", err))
 			http.Error(w, fmt.Sprintf("failed to write message to kafka %s", batchedTopic), 500)
 			return

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -409,13 +409,15 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 
 func (o *Handler) submitProjectLogs(ctx context.Context, projectLogs map[string][]*clickhouse.LogRow) error {
 	for _, logRows := range projectLogs {
-		err := o.resolver.BatchedQueue.Submit(ctx, &kafkaqueue.Message{
-			Type: kafkaqueue.PushLogs,
-			PushLogs: &kafkaqueue.PushLogsArgs{
-				LogRows: logRows,
-			}}, "")
-		if err != nil {
-			return e.Wrap(err, "failed to submit otel project logs to public worker queue")
+		for _, logRow := range logRows {
+			err := o.resolver.BatchedQueue.Submit(ctx, &kafkaqueue.Message{
+				Type: kafkaqueue.PushLogs,
+				PushLogs: &kafkaqueue.PushLogsArgs{
+					LogRow: logRow,
+				}}, "")
+			if err != nil {
+				return e.Wrap(err, "failed to submit otel project logs to public worker queue")
+			}
 		}
 	}
 	return nil

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -265,12 +265,12 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for sessionID, errors := range traceErrors {
-		err = o.resolver.ProducerQueue.Submit(ctx, &kafkaqueue.Message{
+		err = o.resolver.ProducerQueue.Submit(ctx, sessionID, &kafkaqueue.Message{
 			Type: kafkaqueue.PushBackendPayload,
 			PushBackendPayload: &kafkaqueue.PushBackendPayloadArgs{
 				SessionSecureID: &sessionID,
 				Errors:          errors,
-			}}, sessionID)
+			}})
 		if err != nil {
 			log.WithContext(ctx).WithError(err).Error("failed to submit otel session errors to public worker queue")
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -279,12 +279,12 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for projectID, errors := range projectErrors {
-		err = o.resolver.ProducerQueue.Submit(ctx, &kafkaqueue.Message{
+		err = o.resolver.ProducerQueue.Submit(ctx, "", &kafkaqueue.Message{
 			Type: kafkaqueue.PushBackendPayload,
 			PushBackendPayload: &kafkaqueue.PushBackendPayloadArgs{
 				ProjectVerboseID: &projectID,
 				Errors:           errors,
-			}}, "")
+			}})
 		if err != nil {
 			log.WithContext(ctx).WithError(err).Error("failed to submit otel project errors to public worker queue")
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -293,12 +293,12 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for sessionID, metrics := range traceMetrics {
-		err = o.resolver.ProducerQueue.Submit(ctx, &kafkaqueue.Message{
+		err = o.resolver.ProducerQueue.Submit(ctx, sessionID, &kafkaqueue.Message{
 			Type: kafkaqueue.PushMetrics,
 			PushMetrics: &kafkaqueue.PushMetricsArgs{
 				SessionSecureID: sessionID,
 				Metrics:         metrics,
-			}}, "")
+			}})
 		if err != nil {
 			log.WithContext(ctx).WithError(err).Error("failed to submit otel project metrics to public worker queue")
 			w.WriteHeader(http.StatusServiceUnavailable)
@@ -409,15 +409,17 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 
 func (o *Handler) submitProjectLogs(ctx context.Context, projectLogs map[string][]*clickhouse.LogRow) error {
 	for _, logRows := range projectLogs {
+		var messages []*kafkaqueue.Message
 		for _, logRow := range logRows {
-			err := o.resolver.BatchedQueue.Submit(ctx, &kafkaqueue.Message{
+			messages = append(messages, &kafkaqueue.Message{
 				Type: kafkaqueue.PushLogs,
 				PushLogs: &kafkaqueue.PushLogsArgs{
 					LogRow: logRow,
-				}}, "")
-			if err != nil {
-				return e.Wrap(err, "failed to submit otel project logs to public worker queue")
-			}
+				}})
+		}
+		err := o.resolver.BatchedQueue.Submit(ctx, "", messages...)
+		if err != nil {
+			return e.Wrap(err, "failed to submit otel project logs to public worker queue")
 		}
 	}
 	return nil
@@ -435,12 +437,12 @@ func (o *Handler) submitProjectSpans(ctx context.Context, projectTraceRows map[i
 
 		traceRows := append(traceRows, traceRows...)
 
-		err := o.resolver.TracesQueue.Submit(ctx, &kafkaqueue.Message{
+		err := o.resolver.TracesQueue.Submit(ctx, "", &kafkaqueue.Message{
 			Type: kafkaqueue.PushTraces,
 			PushTraces: &kafkaqueue.PushTracesArgs{
 				TraceRows: traceRows,
 			},
-		}, "")
+		})
 
 		if err != nil {
 			return e.Wrap(err, "failed to submit otel project traces to public worker queue")

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -831,7 +831,7 @@ func (r *mutationResolver) MarkSessionAsViewed(ctx context.Context, secureID str
 		return nil, e.Wrap(err, "error adding admin to ViewedByAdmins")
 	}
 
-	if err := r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: s.ID}}, strconv.Itoa(s.ID)); err != nil {
+	if err := r.DataSyncQueue.Submit(ctx, strconv.Itoa(s.ID), &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: s.ID}}); err != nil {
 		return nil, err
 	}
 

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -311,7 +311,7 @@ func (r *Resolver) AppendFields(ctx context.Context, fields []*model.Field, sess
 		return e.Wrap(err, "error updating fields")
 	}
 
-	if err := r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: session.ID}}, strconv.Itoa(session.ID)); err != nil {
+	if err := r.DataSyncQueue.Submit(ctx, strconv.Itoa(session.ID), &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: session.ID}}); err != nil {
 		return err
 	}
 
@@ -1013,7 +1013,7 @@ func (r *Resolver) IndexSessionOpensearch(ctx context.Context, session *model.Se
 	if err := r.AppendProperties(ctx, session.ID, sessionProperties, PropertyType.SESSION); err != nil {
 		log.WithContext(ctx).Error(e.Wrap(err, "error adding set of properties to db"))
 	}
-	return r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: session.ID}}, strconv.Itoa(session.ID))
+	return r.DataSyncQueue.Submit(ctx, strconv.Itoa(session.ID), &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: session.ID}})
 }
 
 func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue.InitializeSessionArgs) (*model.Session, error) {
@@ -1485,7 +1485,7 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 		return e.Wrap(err, "[IdentifySession] failed to update session")
 	}
 
-	if err := r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionID}}, strconv.Itoa(sessionID)); err != nil {
+	if err := r.DataSyncQueue.Submit(ctx, strconv.Itoa(sessionID), &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionID}}); err != nil {
 		return err
 	}
 
@@ -1840,12 +1840,12 @@ func (r *Resolver) SubmitMetricsMessage(ctx context.Context, metrics []*publicMo
 	}
 
 	for secureID, metrics := range sessionMetrics {
-		err := r.ProducerQueue.Submit(ctx, &kafka_queue.Message{
+		err := r.ProducerQueue.Submit(ctx, secureID, &kafka_queue.Message{
 			Type: kafka_queue.PushMetrics,
 			PushMetrics: &kafka_queue.PushMetricsArgs{
 				SessionSecureID: secureID,
 				Metrics:         metrics,
-			}}, secureID)
+			}})
 		if err != nil {
 			log.WithContext(ctx).Error(err)
 		}
@@ -2778,7 +2778,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 				log.WithContext(ctx).Error(e.Wrap(err, "error updating session in opensearch"))
 				return err
 			}
-			if err := r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionObj.ID}}, strconv.Itoa(sessionObj.ID)); err != nil {
+			if err := r.DataSyncQueue.Submit(ctx, strconv.Itoa(sessionObj.ID), &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionObj.ID}}); err != nil {
 				return err
 			}
 		}
@@ -2799,7 +2799,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			log.WithContext(osCtx).Error(e.Wrap(err, "error updating session in opensearch"))
 			return err
 		}
-		if err := r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionObj.ID}}, strconv.Itoa(sessionObj.ID)); err != nil {
+		if err := r.DataSyncQueue.Submit(ctx, strconv.Itoa(sessionObj.ID), &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionObj.ID}}); err != nil {
 			return err
 		}
 	}
@@ -2811,7 +2811,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			log.WithContext(osCtx).Error(e.Wrap(err, "error setting has_errors on session in opensearch"))
 			return err
 		}
-		if err := r.DataSyncQueue.Submit(ctx, &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionObj.ID}}, strconv.Itoa(sessionObj.ID)); err != nil {
+		if err := r.DataSyncQueue.Submit(ctx, strconv.Itoa(sessionObj.ID), &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionObj.ID}}); err != nil {
 			return err
 		}
 	}

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -477,6 +477,7 @@ func (r *Client) GetHubspotCompanies(ctx context.Context, companies interface{})
 	return
 }
 
+// TODO(vkorolik) redlock
 func (r *Client) AcquireLock(ctx context.Context, key string, timeout time.Duration) (acquired bool) {
 	start := time.Now()
 	for {

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -477,7 +477,6 @@ func (r *Client) GetHubspotCompanies(ctx context.Context, companies interface{})
 	return
 }
 
-// TODO(vkorolik) redlock
 func (r *Client) AcquireLock(ctx context.Context, key string, timeout time.Duration) (acquired bool) {
 	start := time.Now()
 	for {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -93,7 +93,7 @@ func (w *Worker) pushToObjectStorage(ctx context.Context, s *model.Session, payl
 		return e.Wrap(err, "error updating session in opensearch")
 	}
 
-	if err := w.Resolver.DataSyncQueue.Submit(ctx, &kafkaqueue.Message{Type: kafkaqueue.SessionDataSync, SessionDataSync: &kafkaqueue.SessionDataSyncArgs{SessionID: s.ID}}, strconv.Itoa(s.ID)); err != nil {
+	if err := w.Resolver.DataSyncQueue.Submit(ctx, strconv.Itoa(s.ID), &kafkaqueue.Message{Type: kafkaqueue.SessionDataSync, SessionDataSync: &kafkaqueue.SessionDataSyncArgs{SessionID: s.ID}}); err != nil {
 		return err
 	}
 
@@ -582,7 +582,7 @@ func (w *Worker) excludeSession(ctx context.Context, s *model.Session, reason ba
 		return e.Wrap(err, "error updating session in opensearch")
 	}
 
-	if err := w.Resolver.DataSyncQueue.Submit(ctx, &kafkaqueue.Message{Type: kafkaqueue.SessionDataSync, SessionDataSync: &kafkaqueue.SessionDataSyncArgs{SessionID: s.ID}}, strconv.Itoa(s.ID)); err != nil {
+	if err := w.Resolver.DataSyncQueue.Submit(ctx, strconv.Itoa(s.ID), &kafkaqueue.Message{Type: kafkaqueue.SessionDataSync, SessionDataSync: &kafkaqueue.SessionDataSyncArgs{SessionID: s.ID}}); err != nil {
 		return err
 	}
 
@@ -881,7 +881,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 		return e.Wrap(err, "error updating session in opensearch")
 	}
 
-	if err := w.Resolver.DataSyncQueue.Submit(ctx, &kafkaqueue.Message{Type: kafkaqueue.SessionDataSync, SessionDataSync: &kafkaqueue.SessionDataSyncArgs{SessionID: s.ID}}, strconv.Itoa(s.ID)); err != nil {
+	if err := w.Resolver.DataSyncQueue.Submit(ctx, strconv.Itoa(s.ID), &kafkaqueue.Message{Type: kafkaqueue.SessionDataSync, SessionDataSync: &kafkaqueue.SessionDataSyncArgs{SessionID: s.ID}}); err != nil {
 		return err
 	}
 
@@ -1168,7 +1168,7 @@ func (w *Worker) Start(ctx context.Context) {
 							log.WithContext(ctx).WithField("session_secure_id", session.SecureID).Error(e.Wrap(err, "error updating session in opensearch"))
 						}
 
-						if err := w.Resolver.DataSyncQueue.Submit(ctx, &kafkaqueue.Message{Type: kafkaqueue.SessionDataSync, SessionDataSync: &kafkaqueue.SessionDataSyncArgs{SessionID: session.ID}}, strconv.Itoa(session.ID)); err != nil {
+						if err := w.Resolver.DataSyncQueue.Submit(ctx, strconv.Itoa(session.ID), &kafkaqueue.Message{Type: kafkaqueue.SessionDataSync, SessionDataSync: &kafkaqueue.SessionDataSyncArgs{SessionID: session.ID}}); err != nil {
 							log.WithContext(ctx).WithField("session_secure_id", session.SecureID).Error(e.Wrap(err, "error submitting data sync message"))
 						}
 

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -470,16 +470,16 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 	for i := 0; i < parallelBatchWorkers; i++ {
 		go func(workerId int) {
 			buffer := &KafkaBatchBuffer{
-				messageQueue: make(chan *kafkaqueue.Message, 8*DefaultBatchFlushSize),
+				messageQueue: make(chan *kafkaqueue.Message, DefaultBatchFlushSize),
 			}
 			k := KafkaBatchWorker{
 				KafkaQueue: kafkaqueue.New(ctx,
 					kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}),
 					kafkaqueue.Consumer,
-					&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(16 * DefaultBatchFlushSize)}),
+					&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(2 * DefaultBatchFlushSize)}),
 				Worker:              w,
 				BatchBuffer:         buffer,
-				BatchFlushSize:      8 * DefaultBatchFlushSize,
+				BatchFlushSize:      DefaultBatchFlushSize,
 				BatchedFlushTimeout: DefaultBatchedFlushTimeout,
 				Name:                "batched",
 			}


### PR DESCRIPTION
## Summary

* adds the ability to batch kafka message submission to break up larger kafka messages
* splits the bulk batched logs messages into individual small messages submitted in a batch
* reduce size of batched kafka messages by omitting empty keys

## How did you test this change?

Local deploy processing logs correctly.
<img width="1791" alt="Screenshot 2023-08-10 at 4 22 58 PM" src="https://github.com/highlight/highlight/assets/1351531/53b43042-b207-4099-955a-541c6de1e363">

Updated kafka unit test.

## Are there any deployment considerations?

Will monitor deploy.
