### PR TITLE
ensure number of events passed to rrweb is bounded

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -914,13 +914,11 @@ export const getEvents = (
 	>,
 ) => {
 	const events = []
-	let eventIdx = 0
 	for (const [, v] of [...chunkEvents.entries()].sort(
 		(a, b) => a[0] - b[0],
 	)) {
 		for (const val of v) {
-			eventIdx = eventIdx + 1
-			if (eventIdx >= MAX_SHORT_INT_SIZE) {
+			if (events.length + 1 >= MAX_SHORT_INT_SIZE) {
 				// events are passed into an rrweb function which does an array.splice
 				// When the number of events is too high, the browser can crash.
 				return events

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -905,6 +905,8 @@ export const getTimeFromReplayer = function (
 	)
 }
 
+const MAX_SHORT_INT_SIZE = 65536
+
 export const getEvents = (
 	chunkEvents: Omit<
 		Map<number, HighlightEvent[]>,
@@ -912,10 +914,18 @@ export const getEvents = (
 	>,
 ) => {
 	const events = []
+	let eventIdx = 0
 	for (const [, v] of [...chunkEvents.entries()].sort(
 		(a, b) => a[0] - b[0],
 	)) {
 		for (const val of v) {
+			eventIdx = eventIdx + 1
+			if (eventIdx >= MAX_SHORT_INT_SIZE) {
+				// events are passed into an rrweb function which does an array.splice
+				// When the number of events is too high, the browser can crash.
+				return events
+			}
+
 			events.push(val)
 		}
 	}

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -918,14 +918,23 @@ export const getEvents = (
 		(a, b) => a[0] - b[0],
 	)) {
 		for (const val of v) {
-			if (events.length + 1 >= MAX_SHORT_INT_SIZE) {
-				// events are passed into an rrweb function which does an array.splice
-				// When the number of events is too high, the browser can crash.
-				return events
-			}
-
 			events.push(val)
 		}
+	}
+
+	// events are passed into an rrweb function which does an array.splice
+	// When the number of events is greater than MAX_SHORT_INT_SIZE, the browser can crash.
+	// Hence, we instead take a sample of events to ensure we stay under MAX_SHORT_INT_SIZE.
+	if (events.length + 1 >= MAX_SHORT_INT_SIZE) {
+		const stepSize = events.length / MAX_SHORT_INT_SIZE
+		const sampledEvents = []
+
+		for (let i = 0; i < events.length; i += stepSize) {
+			const index = Math.floor(i)
+			sampledEvents.push(events[index])
+		}
+
+		return sampledEvents
 	}
 	return events
 }


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

https://www.notion.so/runhighlight/replayer-crash-max-call-stack-exceeded-f11f6c24098b430f80359588a45140d9

and this slack: https://highlightcorp.slack.com/archives/C02N2AZS8BV/p1691715318507679?thread_ts=1691686829.763469&cid=C02N2AZS8BV

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Tested on customer account with many events (see slack link above).

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
