### PR TITLE
remove deprecated kafka logs type

### DIFF
--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -104,9 +104,7 @@ type AddSessionFeedbackArgs struct {
 }
 
 type PushLogsArgs struct {
-	// deprecated, write individual LogRow messages instead
-	LogRows []*clickhouse.LogRow
-	LogRow  *clickhouse.LogRow
+	LogRow *clickhouse.LogRow
 }
 
 type PushTracesArgs struct {
@@ -153,7 +151,7 @@ type Message struct {
 	Type                                   PayloadType
 	Failures                               int
 	MaxRetries                             int
-	KafkaMessage                           *kafka.Message
+	KafkaMessage                           *kafka.Message                              `json:",omitempty"`
 	PushPayload                            *PushPayloadArgs                            `json:",omitempty"`
 	InitializeSession                      *InitializeSessionArgs                      `json:",omitempty"`
 	IdentifySession                        *IdentifySessionArgs                        `json:",omitempty"`


### PR DESCRIPTION
## Summary

* remove type deprecated in #6307 now that all batched messages have been processed
* update another optional message field to omit empty

## How did you test this change?

Local deploy ingesting logs.

## Are there any deployment considerations?

No
