### PR TITLE
update logs cache keys

### DIFF
--- a/frontend/src/util/graph.tsx
+++ b/frontend/src/util/graph.tsx
@@ -121,7 +121,13 @@ const cache = new InMemoryCache({
 		},
 		Query: {
 			fields: {
-				logs: relayStylePagination(),
+				logs: relayStylePagination([
+					'project_id',
+					'at',
+					'direction',
+					'params',
+					['query', 'date_range', ['start_date', 'end_date']],
+				]),
 			},
 		},
 	},


### PR DESCRIPTION
## Summary

Digging into why logs results are sometimes incorrect and out of order, found that
the results from our `fetchMore` query are sometimes using stale variables and hence showing
previous results for a page incorrectly.

## How did you test this change?

Reflame preview trying but unable to reproduce the behavior described [here](https://highlightcorp.slack.com/archives/C02N2AZS8BV/p1691471534516159).

## Are there any deployment considerations?

No