### PR TITLE
use a threshold setting for matching by embedding

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -386,8 +386,9 @@ type AllWorkspaceSettings struct {
 	// store embeddings for errors in this workspace
 	ErrorEmbeddingsWrite bool `gorm:"default:false"`
 	// use embeddings to group errors in this workspace
-	ErrorEmbeddingsGroup bool `gorm:"default:false"`
-	ReplaceAssets        bool `gorm:"default:false"`
+	ErrorEmbeddingsGroup     bool    `gorm:"default:false"`
+	ErrorEmbeddingsThreshold float64 `gorm:"default:0.2"`
+	ReplaceAssets            bool    `gorm:"default:false"`
 }
 
 type HasSecret interface {

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -304,7 +304,7 @@ func TestHandleErrorAndGroup(t *testing.T) {
 			resolver.DB.Create(&settings)
 
 			if tc.withEmbeddings != nil {
-				resolver.DB.Where(&model.AllWorkspaceSettings{WorkspaceID: workspaceID}).Updates(&model.AllWorkspaceSettings{ErrorEmbeddingsGroup: *tc.withEmbeddings})
+				resolver.DB.Where(&model.AllWorkspaceSettings{WorkspaceID: workspaceID}).Updates(&model.AllWorkspaceSettings{ErrorEmbeddingsGroup: *tc.withEmbeddings, ErrorEmbeddingsThreshold: 0.2})
 			}
 
 			// create the error group to match against


### PR DESCRIPTION
## Summary

We're seeing that the embedding match is too precise at the static 0.1 threshold.
This PR allows setting the threshold based on a workspace setting.

## How did you test this change?

Unit test

## Are there any deployment considerations?

No