### PR TITLE
document distributed tracing with highlight

### DIFF
--- a/docs-content/getting-started/2_frontend-backend-mapping.md
+++ b/docs-content/getting-started/2_frontend-backend-mapping.md
@@ -59,6 +59,26 @@ Below are solutions for what we support today. If you'd like us to support a new
 
 - [Python Backend Integration](4_backend-sdk/python)
 
+## Distributed Tracing
+
+Your backend might be a distributed system with multiple services. Say, for example, your
+frontend Next.js application uses a Next.js backend which in turn makes HTTP requests to
+a Python FastAPI microservice. You would want errors and logs from your Python service to be
+attributes to the frontend sessions in Highlight.
+
+Our frontend -> backend tracing is based on the `x-highlight-request` HTTP header. If your Next.js backend issues an HTTP request to a FastAPI backend and you forward the `x-highlight-request` header along, the trace will carry over information about the frontend session.
+
+A more complex application might not make HTTP requests between backend services, but instead
+use a message broker like Kafka to queue up jobs. In that case, you'll need to add a way to
+store the `x-highlight-request` you receive from the frontend along with your enqueued messages.
+The service that consumes the messages can pass the value to the highlight SDK via custom
+error wrapping or logging code.
+
+```javascript
+const parsed = H.parseHeaders(request.headers)
+H.consumeError(error, parsed.secureSessionId, parsed.requestId)
+```
+
 ## Troubleshooting
 
 1.  Ensure `tracingOrigins` and `networkRecording` are properly set.

--- a/docs-content/getting-started/2_frontend-backend-mapping.md
+++ b/docs-content/getting-started/2_frontend-backend-mapping.md
@@ -66,15 +66,20 @@ frontend Next.js application with a Next.js backend ,which makes HTTP requests t
 a Python FastAPI microservice. In a case like that, you may want errors and logs from your Python service to be
 attributed to the frontend sessions in Highlight.
 
-Our frontend -> backend tracing uses the `x-highlight-request` HTTP header to attribute frontend requests with backend errors and logs. So in the case of the example above, assuming all of your services have the highlight sdk installed, if your Next.js backend peforms an HTTP request to a FastAPI backend and you forward the `x-highlight-request` header along, the trace will carry over information about the frontend session.
+Our frontend -> backend tracing uses the `x-highlight-request` HTTP header to attribute frontend requests with backend errors and logs. So, in the case of the example above, assuming all of your services have the highlight sdk installed, if your Next.js backend performs an HTTP request to a FastAPI backend and you forward the `x-highlight-request` header along, the trace will carry over information about the frontend session.
 
-A more complex application might not make HTTP requests between backend services, however. Instead it may
+```javascript
+await fetch('my-fastapi-backend:8000/api', { headers: {'x-highlight-request': request.headers.get(`x-highlight-request`)} })
+```
+
+A more complex application might not make HTTP requests between backend services, however. Instead, it may
 use a message broker like Kafka to queue up jobs. In that case, you'll need to add a way to
 store the `x-highlight-request` you receive from the frontend along with your enqueued messages.
 The service that consumes the messages can then pass the value to the highlight SDK via custom
 error wrapping or logging code as per usual.
 
 ```javascript
+// the receiving example references `request.headers`, but this could be read from another service-to-service protocol (ie. gRPC, Apache Kafka message)
 const parsed = H.parseHeaders(request.headers)
 H.consumeError(error, parsed.secureSessionId, parsed.requestId)
 ```
@@ -87,4 +92,4 @@ H.consumeError(error, parsed.secureSessionId, parsed.requestId)
 
 3.  For debugging the backend SDK of your choice, in order to debug, we suggest enabling verbose logging. For example, in Go, add `highlight.SetDebugMode(myLogger)`
 
-4.  If all else fails, please send us an email at support@highlight.io or join the #support channel on our [discord](https://discord.gg/yxaXEAqgwN).
+4.  If all else fails, please email us at support@highlight.io or join the #support channel on our [discord](https://discord.gg/yxaXEAqgwN).

--- a/docs-content/getting-started/2_frontend-backend-mapping.md
+++ b/docs-content/getting-started/2_frontend-backend-mapping.md
@@ -61,18 +61,18 @@ Below are solutions for what we support today. If you'd like us to support a new
 
 ## Distributed Tracing
 
-Your backend might be a distributed system with multiple services. Say, for example, your
-frontend Next.js application uses a Next.js backend which in turn makes HTTP requests to
-a Python FastAPI microservice. You would want errors and logs from your Python service to be
-attributes to the frontend sessions in Highlight.
+Your backend might be a distributed system with multiple services. Say, for example, a
+frontend Next.js application with a Next.js backend ,which makes HTTP requests to
+a Python FastAPI microservice. In a case like that, you may want errors and logs from your Python service to be
+attributed to the frontend sessions in Highlight.
 
-Our frontend -> backend tracing is based on the `x-highlight-request` HTTP header. If your Next.js backend issues an HTTP request to a FastAPI backend and you forward the `x-highlight-request` header along, the trace will carry over information about the frontend session.
+Our frontend -> backend tracing uses the `x-highlight-request` HTTP header to attribute frontend requests with backend errors and logs. So in the case of the example above, assuming all of your services have the highlight sdk installed, if your Next.js backend peforms an HTTP request to a FastAPI backend and you forward the `x-highlight-request` header along, the trace will carry over information about the frontend session.
 
-A more complex application might not make HTTP requests between backend services, but instead
+A more complex application might not make HTTP requests between backend services, however. Instead it may
 use a message broker like Kafka to queue up jobs. In that case, you'll need to add a way to
 store the `x-highlight-request` you receive from the frontend along with your enqueued messages.
-The service that consumes the messages can pass the value to the highlight SDK via custom
-error wrapping or logging code.
+The service that consumes the messages can then pass the value to the highlight SDK via custom
+error wrapping or logging code as per usual.
 
 ```javascript
 const parsed = H.parseHeaders(request.headers)


### PR DESCRIPTION
## Summary

Per [slack](https://highlightcorp.slack.com/archives/C05F8UHA4KZ/p1691644783628959), documenting how
a distributed application can instrument highlight to connect the frontend to the backend.

## How did you test this change?

[Vercel preview](https://highlight-landing-git-vadim-distributed-tr-fcf178-highlight-run.vercel.app/docs/getting-started/frontend-backend-mapping).

## Are there any deployment considerations?

No