### PR TITLE
Fix merge conflict comment in generated hooks

### DIFF
--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -4838,11 +4838,8 @@ export type EditServiceGithubSettingsMutationFn = Apollo.MutationFunction<
  *      id: // value for 'id'
  *      project_id: // value for 'project_id'
  *      github_repo_path: // value for 'github_repo_path'
-<<<<<<< HEAD
  *      build_prefix: // value for 'build_prefix'
  *      github_prefix: // value for 'github_prefix'
-=======
->>>>>>> main
  *   },
  * });
  */


### PR DESCRIPTION
## Summary
A merge comment wasn't fixed in https://github.com/highlight/highlight/pull/6305, but not caught since it was within a comment and hidden in the GitHub view

## How did you test this change?
N/A

## Are there any deployment considerations?
N/A
