### PR TITLE
disable inputs on integration submit

### DIFF
--- a/frontend/src/components/NewIssueModal/NewIssueModal.tsx
+++ b/frontend/src/components/NewIssueModal/NewIssueModal.tsx
@@ -210,6 +210,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 								}
 							/>
 						}
+						disabled={loading}
 					/>
 				</Box>
 			}
@@ -230,6 +231,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 					>
 						{selectedIntegration.containerSelection({
 							setSelectionId: setContainerId,
+							disabled: loading,
 						})}
 						<Form.Input
 							name={form.names.issueTitle}
@@ -238,6 +240,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 							outline
 							truncate
 							required
+							disabled={loading}
 						/>
 						<Form.Input
 							name={form.names.issueDescription}
@@ -248,6 +251,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 							outline
 							aria-multiline
 							rows={5}
+							disabled={loading}
 						/>
 					</Box>
 					<Box
@@ -266,6 +270,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 							kind="secondary"
 							size="small"
 							emphasis="high"
+							disabled={loading}
 						>
 							Cancel
 						</Button>
@@ -275,6 +280,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 							kind={loading ? 'secondary' : 'primary'}
 							size="small"
 							emphasis="high"
+							disabled={loading}
 						>
 							Submit
 						</Button>

--- a/frontend/src/pages/IntegrationsPage/IssueTrackerIntegrations.ts
+++ b/frontend/src/pages/IntegrationsPage/IssueTrackerIntegrations.ts
@@ -10,6 +10,7 @@ import React from 'react'
 
 export interface ContainerSelectionProps {
 	setSelectionId: (id: string) => void
+	disabled: boolean
 }
 
 export type IssueTrackerIntegration = Integration & {

--- a/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpListSelector.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/ClickUpIntegration/ClickUpListSelector.tsx
@@ -10,6 +10,7 @@ import * as style from '../style.css'
 
 const ClickUpListSelector: React.FC<ContainerSelectionProps> = ({
 	setSelectionId,
+	disabled,
 }) => {
 	const { project_id } = useParams<{ project_id: string }>()
 	const { data, loading } = useGetClickUpFoldersQuery({
@@ -61,6 +62,7 @@ const ClickUpListSelector: React.FC<ContainerSelectionProps> = ({
 				notFoundContent={<p>No lists found</p>}
 				loading={loading}
 				className={style.selectContainer}
+				disabled={disabled}
 			/>
 		</Form.NamedSection>
 	)

--- a/frontend/src/pages/IntegrationsPage/components/GitHubIntegration/GitHubRepoSelector.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/GitHubIntegration/GitHubRepoSelector.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo } from 'react'
 
 const GitHubRepoSelector: React.FC<ContainerSelectionProps> = ({
 	setSelectionId,
+	disabled,
 }) => {
 	const { data } = useGitHubIntegration()
 
@@ -60,6 +61,7 @@ const GitHubRepoSelector: React.FC<ContainerSelectionProps> = ({
 				value={selectedGitHubRepoId}
 				notFoundContent={<p>No repos found</p>}
 				className={style.selectContainer}
+				disabled={disabled}
 			/>
 		</Form.NamedSection>
 	)

--- a/frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightListSelector.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/HeightIntegration/HeightListSelector.tsx
@@ -10,6 +10,7 @@ import * as style from '../style.css'
 
 const HeightListSelector: React.FC<ContainerSelectionProps> = ({
 	setSelectionId,
+	disabled,
 }) => {
 	const { project_id } = useParams<{ project_id: string }>()
 	const { data, loading } = useGetHeightListsQuery({
@@ -55,6 +56,7 @@ const HeightListSelector: React.FC<ContainerSelectionProps> = ({
 				notFoundContent={<p>No lists found</p>}
 				loading={loading}
 				className={style.selectContainer}
+				disabled={disabled}
 			/>
 		</Form.NamedSection>
 	)

--- a/frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearTeamSelector.tsx
+++ b/frontend/src/pages/IntegrationsPage/components/LinearIntegration/LinearTeamSelector.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo } from 'react'
 
 const LinearTeamSelector: React.FC<ContainerSelectionProps> = ({
 	setSelectionId,
+	disabled,
 }) => {
 	const { teams } = useLinearIntegration()
 
@@ -57,6 +58,7 @@ const LinearTeamSelector: React.FC<ContainerSelectionProps> = ({
 				value={selectedLinearTeamId}
 				notFoundContent={<p>No teams found</p>}
 				className={style.selectContainer}
+				disabled={disabled}
 			/>
 		</Form.NamedSection>
 	)

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
@@ -459,23 +459,27 @@ export const NewCommentForm = ({
 									kind="secondary"
 									emphasis="low"
 									icon={<IconSolidX size={14} />}
+									disabled={isCreatingComment}
 								/>
 							</Stack>
 						</Box>
 						<Stack direction="column" gap="12" p="12">
 							{issueServiceDetail?.containerSelection({
+								disabled: isCreatingComment,
 								setSelectionId: setContainerId,
 							})}
 							<Form.Input
 								name="issueTitle"
 								label="Title"
 								placeholder="Title"
+								disabled={isCreatingComment}
 							/>
 							<Form.Input
 								name="issueDescription"
 								label="Description"
 								// @ts-expect-error
 								as="textarea"
+								disabled={isCreatingComment}
 							/>
 						</Stack>
 						<Stack
@@ -503,6 +507,7 @@ export const NewCommentForm = ({
 									setSelectedIssueService(undefined)
 									setSection(CommentFormSection.CommentForm)
 								}}
+								disabled={isCreatingComment}
 							>
 								Cancel
 							</Button>
@@ -514,6 +519,7 @@ export const NewCommentForm = ({
 								onClick={() => {
 									setSection(CommentFormSection.CommentForm)
 								}}
+								disabled={isCreatingComment}
 							>
 								Save
 							</Button>


### PR DESCRIPTION
## Summary
- fixes #5699 
- toggles disabled state for integration forms on submit
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
