### PR TITLE
add global error filters

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1252,6 +1252,7 @@ type SystemConfiguration struct {
 	Active           bool `gorm:"primary_key;default:true"`
 	MaintenanceStart time.Time
 	MaintenanceEnd   time.Time
+	ErrorFilters     pq.StringArray `gorm:"type:text[];default:'{\"ENOENT.*\", \"connect ECONNREFUSED.*\"}'"`
 }
 
 type RetryableType string

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7503,11 +7503,7 @@ func (r *queryResolver) SessionInsight(ctx context.Context, secureID string) (*m
 
 // SystemConfiguration is the resolver for the system_configuration field.
 func (r *queryResolver) SystemConfiguration(ctx context.Context) (*model.SystemConfiguration, error) {
-	config := model.SystemConfiguration{Active: true}
-	if err := r.DB.Model(&config).Where(&config).FirstOrCreate(&config).Error; err != nil {
-		return nil, err
-	}
-	return &config, nil
+	return r.Store.GetSystemConfiguration(ctx)
 }
 
 // Services is the resolver for the services field.

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -3325,12 +3325,16 @@ func (r *Resolver) isSessionUserExcluded(ctx context.Context, s *model.Session, 
 	return false
 }
 
-func isExcludedError(ctx context.Context, errorFilters []string, errorEvent string, projectID int) bool {
+func (r *Resolver) isExcludedError(ctx context.Context, errorFilters []string, errorEvent string, projectID int) bool {
 	if errorEvent == "[{}]" {
 		log.WithContext(ctx).
 			WithField("project_id", projectID).
 			Warn("ignoring empty error")
 		return true
+	}
+
+	if cfg, err := r.Store.GetSystemConfiguration(ctx); err == nil {
+		errorFilters = append(errorFilters, cfg.ErrorFilters...)
 	}
 
 	// Filter out by project.ErrorFilters, aka regexp filters

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2097,7 +2097,7 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 	// Filter out empty errors
 	var filteredErrors []*publicModel.BackendErrorObjectInput
 	for _, errorObject := range errorObjects {
-		if isExcludedError(ctx, project.ErrorFilters, errorObject.Event, project.ID) {
+		if r.isExcludedError(ctx, project.ErrorFilters, errorObject.Event, project.ID) {
 			continue
 		}
 		filteredErrors = append(filteredErrors, errorObject)
@@ -2630,7 +2630,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		// filter out empty errors
 		seenEvents := map[string]*publicModel.ErrorObjectInput{}
 		for _, errorObject := range errors {
-			if isExcludedError(ctx, project.ErrorFilters, errorObject.Event, project.ID) {
+			if r.isExcludedError(ctx, project.ErrorFilters, errorObject.Event, project.ID) {
 				continue
 			}
 			seenEvents[errorObject.Event] = errorObject

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -476,10 +476,10 @@ func TestUpdatingErrorState(t *testing.T) {
 }
 
 func TestResolver_isExcludedError(t *testing.T) {
-	assert.False(t, isExcludedError(context.Background(), []string{}, "", 1))
-	assert.True(t, isExcludedError(context.Background(), []string{}, "[{}]", 2))
-	assert.True(t, isExcludedError(context.Background(), []string{".*a+.*"}, "foo bar baz", 3))
-	assert.False(t, isExcludedError(context.Background(), []string{"("}, "foo bar baz", 4))
+	assert.False(t, resolver.isExcludedError(context.Background(), []string{}, "", 1))
+	assert.True(t, resolver.isExcludedError(context.Background(), []string{}, "[{}]", 2))
+	assert.True(t, resolver.isExcludedError(context.Background(), []string{".*a+.*"}, "foo bar baz", 3))
+	assert.False(t, resolver.isExcludedError(context.Background(), []string{"("}, "foo bar baz", 4))
 }
 
 // areErrorGroupsEqual compares two error objects while ignoring the Model and SecureID field

--- a/backend/store/system_configuration.go
+++ b/backend/store/system_configuration.go
@@ -1,0 +1,18 @@
+package store
+
+import (
+	"context"
+	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/redis"
+	"time"
+)
+
+func (store *Store) GetSystemConfiguration(ctx context.Context) (*model.SystemConfiguration, error) {
+	return redis.CachedEval(ctx, store.redis, "system-configuration", 250*time.Millisecond, 5*time.Minute, func() (*model.SystemConfiguration, error) {
+		config := model.SystemConfiguration{Active: true}
+		if err := store.db.Model(&config).Where(&config).FirstOrCreate(&config).Error; err != nil {
+			return nil, err
+		}
+		return &config, nil
+	})
+}

--- a/backend/store/system_configuration_test.go
+++ b/backend/store/system_configuration_test.go
@@ -1,0 +1,18 @@
+package store
+
+import (
+	"context"
+	"github.com/lib/pq"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	_ "gorm.io/driver/postgres"
+)
+
+func TestStore_GetSystemConfiguration(t *testing.T) {
+	defer teardown(t)
+
+	cfg, err := store.GetSystemConfiguration(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, pq.StringArray{"ENOENT.*", "connect ECONNREFUSED.*"}, cfg.ErrorFilters)
+}


### PR DESCRIPTION
## Summary

Adds a column for global error filters for next.js noisy errors.

## How did you test this change?

Unit test

## Are there any deployment considerations?

No
