### PR TITLE
update opentelemetry collector memory configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,7 @@
 name: Deploy to AWS
 on:
+    pull_request:
+        types: [opened, synchronize]
     push:
         branches:
             - 'main'
@@ -10,374 +12,374 @@ on:
             - 'deploy/**'
             - '.github/workflows/deploy.yml'
 jobs:
-    migrate-database:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-            - name: Setup Go
-              uses: actions/setup-go@v4
-              with:
-                  go-version-file: 'backend/go.mod'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v2
-            - name: Migrate database
-              run: |
-                  cd backend/
-                  make migrate
-              env:
-                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-
-    deploy-session-delete-lambdas:
-        needs: migrate-database
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-            - name: Setup Go
-              uses: actions/setup-go@v4
-              with:
-                  go-version-file: 'backend/go.mod'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v2
-            - name: Build and zip
-              run: |
-                  cd backend/
-                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/getSessionIdsByQuery
-                  zip getSessionIdsByQuery.zip getSessionIdsByQuery
-                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromPostgres
-                  zip deleteSessionBatchFromPostgres.zip deleteSessionBatchFromPostgres
-                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromOpenSearch
-                  zip deleteSessionBatchFromOpenSearch.zip deleteSessionBatchFromOpenSearch
-                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromS3
-                  zip deleteSessionBatchFromS3.zip deleteSessionBatchFromS3
-                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/sendEmail
-                  zip sendEmail.zip sendEmail
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v2
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
-            - name: Update Lambda secrets
-              env:
-                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
-                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
-              run: |
-                  aws lambda update-function-configuration --function-name getSessionIdsByQuery \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-                  aws lambda update-function-configuration --function-name deleteSessionBatchFromPostgres \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-                  aws lambda update-function-configuration --function-name deleteSessionBatchFromOpenSearch \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-                  aws lambda update-function-configuration --function-name deleteSessionBatchFromS3 \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-                  aws lambda update-function-configuration --function-name sendEmail \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-            - name: Deploy getSessionIdsByQuery
-              uses: appleboy/lambda-action@v0.1.9
-              with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws_region: us-east-2
-                  function_name: getSessionIdsByQuery
-                  zip_file: backend/getSessionIdsByQuery.zip
-            - name: Deploy deleteSessionBatchFromPostgres
-              uses: appleboy/lambda-action@v0.1.9
-              with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws_region: us-east-2
-                  function_name: deleteSessionBatchFromPostgres
-                  zip_file: backend/deleteSessionBatchFromPostgres.zip
-            - name: Deploy deleteSessionBatchFromOpenSearch
-              uses: appleboy/lambda-action@v0.1.9
-              with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws_region: us-east-2
-                  function_name: deleteSessionBatchFromOpenSearch
-                  zip_file: backend/deleteSessionBatchFromOpenSearch.zip
-            - name: Deploy deleteSessionBatchFromS3
-              uses: appleboy/lambda-action@v0.1.9
-              with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws_region: us-east-2
-                  function_name: deleteSessionBatchFromS3
-                  zip_file: backend/deleteSessionBatchFromS3.zip
-            - name: Deploy sendEmail
-              uses: appleboy/lambda-action@v0.1.9
-              with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws_region: us-east-2
-                  function_name: sendEmail
-                  zip_file: backend/sendEmail.zip
-
-    deploy-digest-lambdas:
-        needs: migrate-database
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-            - name: Setup Go
-              uses: actions/setup-go@v4
-              with:
-                  go-version-file: 'backend/go.mod'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v2
-            - name: Build and zip
-              run: |
-                  cd backend/
-                  CGO_ENABLED=0 go build ./lambda-functions/digests/getProjectIds
-                  zip getProjectIds.zip getProjectIds
-                  CGO_ENABLED=0 go build ./lambda-functions/digests/getDigestData
-                  zip getDigestData.zip getDigestData
-                  CGO_ENABLED=0 go build ./lambda-functions/digests/sendDigestEmails
-                  zip sendDigestEmails.zip sendDigestEmails
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v2
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
-            - name: Update Lambda secrets
-              env:
-                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
-                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
-              run: |
-                  aws lambda update-function-configuration --function-name getProjectIds \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-                  aws lambda update-function-configuration --function-name getDigestData \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-                  aws lambda update-function-configuration --function-name sendDigestEmails \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-            - name: Deploy getProjectIds
-              uses: appleboy/lambda-action@v0.1.9
-              with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws_region: us-east-2
-                  function_name: getProjectIds
-                  zip_file: backend/getProjectIds.zip
-            - name: Deploy getDigestData
-              uses: appleboy/lambda-action@v0.1.9
-              with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws_region: us-east-2
-                  function_name: getDigestData
-                  zip_file: backend/getDigestData.zip
-            - name: Deploy sendDigestEmails
-              uses: appleboy/lambda-action@v0.1.9
-              with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws_region: us-east-2
-                  function_name: sendDigestEmails
-                  zip_file: backend/sendDigestEmails.zip
-
-    deploy-session-insights-lambdas:
-        needs: migrate-database
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-            - name: Setup Go
-              uses: actions/setup-go@v4
-              with:
-                  go-version-file: 'backend/go.mod'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v2
-            - name: Build and zip
-              run: |
-                  cd backend/
-                  CGO_ENABLED=0 go build ./lambda-functions/sessionInsights/getSessionInsightsData
-                  zip getSessionInsightsData.zip getSessionInsightsData
-                  CGO_ENABLED=0 go build ./lambda-functions/sessionInsights/sendSessionInsightsEmails
-                  zip sendSessionInsightsEmails.zip sendSessionInsightsEmails
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v2
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
-            - name: Update Lambda secrets
-              env:
-                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
-                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
-              run: |
-                  aws lambda update-function-configuration --function-name getSessionInsightsData \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-                  aws lambda update-function-configuration --function-name sendSessionInsightsEmails \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-            - name: Deploy getSessionInsightsData
-              uses: appleboy/lambda-action@v0.1.9
-              with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws_region: us-east-2
-                  function_name: getSessionInsightsData
-                  zip_file: backend/getSessionInsightsData.zip
-            - name: Deploy sendSessionInsightsEmails
-              uses: appleboy/lambda-action@v0.1.9
-              with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws_region: us-east-2
-                  function_name: sendSessionInsightsEmails
-                  zip_file: backend/sendSessionInsightsEmails.zip
-
-    deploy-user-journey-lambdas:
-        needs: migrate-database
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-            - name: Setup Go
-              uses: actions/setup-go@v4
-              with:
-                  go-version-file: 'backend/go.mod'
-            - name: Install Doppler CLI
-              uses: dopplerhq/cli-action@v2
-            - name: Build and zip
-              run: |
-                  cd backend/
-                  CGO_ENABLED=0 go build ./lambda-functions/journeys/updateNormalnessScores
-                  zip updateNormalnessScores.zip updateNormalnessScores
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v2
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
-            - name: Update Lambda secrets
-              env:
-                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
-                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
-              run: |
-                  aws lambda update-function-configuration --function-name updateNormalnessScores \
-                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-            - name: Deploy updateNormalnessScores
-              uses: appleboy/lambda-action@v0.1.9
-              with:
-                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws_region: us-east-2
-                  function_name: updateNormalnessScores
-                  zip_file: backend/updateNormalnessScores.zip
-
-    deploy_backend:
-        needs: migrate-database
-        runs-on: buildjet-2vcpu-ubuntu-2204-arm
-        steps:
-            - name: Check out the repo
-              uses: actions/checkout@v3
-
-            - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v2
-              with:
-                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-                  aws-region: us-east-2
-            - name: Login to Amazon ECR
-              id: login-ecr
-              uses: aws-actions/amazon-ecr-login@v1
-
-            - name: Build, tag, and push arm64 image to Amazon ECR
-              env:
-                  ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-                  ECR_REPOSITORY: highlight-production-ecr-repo
-                  IMAGE_TAG: ${{ github.sha }}
-              run: |
-                  docker buildx build --build-arg REACT_APP_COMMIT_SHA=${{ github.sha }} --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64 -f deploy/Dockerfile.prod.arm64 .
-                  docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64
-
-            # Edit and deploy private-graph
-            - name: Replace image label for private-graph task
-              id: image-private-graph
-              uses: aws-actions/amazon-ecs-render-task-definition@v1
-              with:
-                  task-definition: deploy/private-graph-task.json
-                  container-name: highlight-backend
-                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
-            - name: Deploy to Amazon ECS private-graph service
-              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-              with:
-                  task-definition: ${{ steps.image-private-graph.outputs.task-definition }}
-                  service: private-graph-service
-                  cluster: highlight-production-cluster
-            # Edit and deploy public-graph
-            - name: Replace image label for public-graph task
-              id: image-public-graph
-              uses: aws-actions/amazon-ecs-render-task-definition@v1
-              with:
-                  task-definition: deploy/public-graph-task.json
-                  container-name: highlight-backend
-                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
-            - name: Deploy to Amazon ECS public-graph service
-              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-              with:
-                  task-definition: ${{ steps.image-public-graph.outputs.task-definition }}
-                  service: public-graph-service
-                  cluster: highlight-production-cluster
-            # Edit and deploy worker
-            - name: Replace image label for worker task
-              id: image-worker
-              uses: aws-actions/amazon-ecs-render-task-definition@v1
-              with:
-                  task-definition: deploy/worker-task.json
-                  container-name: highlight-backend
-                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
-            - name: Deploy to Amazon ECS worker service
-              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-              with:
-                  task-definition: ${{ steps.image-worker.outputs.task-definition }}
-                  service: worker-service-v2
-                  cluster: highlight-production-cluster
-            # Edit and deploy metric monitors
-            - name: Replace image label for metric monitors task
-              id: image-metric-monitor
-              uses: aws-actions/amazon-ecs-render-task-definition@v1
-              with:
-                  task-definition: deploy/metric-monitor-task.json
-                  container-name: highlight-backend
-                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
-            - name: Deploy to Amazon ECS metric monitor service
-              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-              with:
-                  task-definition: ${{ steps.image-metric-monitor.outputs.task-definition }}
-                  service: metric-monitor
-                  cluster: highlight-production-cluster
-            # Edit and deploy log alerts
-            - name: Replace image label for log alerts task
-              id: image-log-alerts
-              uses: aws-actions/amazon-ecs-render-task-definition@v1
-              with:
-                  task-definition: deploy/log-alerts-task.json
-                  container-name: highlight-backend
-                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
-            - name: Deploy to Amazon ECS log alerts service
-              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-              with:
-                  task-definition: ${{ steps.image-log-alerts.outputs.task-definition }}
-                  service: log-alerts-service
-                  cluster: highlight-production-cluster
-            # Edit and deploy public worker
-            - name: Replace image label for public worker service
-              id: image-public-worker
-              uses: aws-actions/amazon-ecs-render-task-definition@v1
-              with:
-                  task-definition: deploy/public-worker-service.json
-                  container-name: highlight-backend
-                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
-            - name: Deploy to Amazon ECS public worker service
-              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-              with:
-                  task-definition: ${{ steps.image-public-worker.outputs.task-definition }}
-                  service: public-worker-service
-                  cluster: highlight-production-cluster
+    #    migrate-database:
+    #        runs-on: ubuntu-latest
+    #        steps:
+    #            - name: Checkout
+    #              uses: actions/checkout@v3
+    #            - name: Setup Go
+    #              uses: actions/setup-go@v4
+    #              with:
+    #                  go-version-file: 'backend/go.mod'
+    #            - name: Install Doppler CLI
+    #              uses: dopplerhq/cli-action@v2
+    #            - name: Migrate database
+    #              run: |
+    #                  cd backend/
+    #                  make migrate
+    #              env:
+    #                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+    #
+    #    deploy-session-delete-lambdas:
+    #        needs: migrate-database
+    #        runs-on: ubuntu-latest
+    #        steps:
+    #            - name: Checkout
+    #              uses: actions/checkout@v3
+    #            - name: Setup Go
+    #              uses: actions/setup-go@v4
+    #              with:
+    #                  go-version-file: 'backend/go.mod'
+    #            - name: Install Doppler CLI
+    #              uses: dopplerhq/cli-action@v2
+    #            - name: Build and zip
+    #              run: |
+    #                  cd backend/
+    #                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/getSessionIdsByQuery
+    #                  zip getSessionIdsByQuery.zip getSessionIdsByQuery
+    #                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromPostgres
+    #                  zip deleteSessionBatchFromPostgres.zip deleteSessionBatchFromPostgres
+    #                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromOpenSearch
+    #                  zip deleteSessionBatchFromOpenSearch.zip deleteSessionBatchFromOpenSearch
+    #                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromS3
+    #                  zip deleteSessionBatchFromS3.zip deleteSessionBatchFromS3
+    #                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/sendEmail
+    #                  zip sendEmail.zip sendEmail
+    #            - name: Configure AWS credentials
+    #              uses: aws-actions/configure-aws-credentials@v2
+    #              with:
+    #                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws-region: us-east-2
+    #            - name: Update Lambda secrets
+    #              env:
+    #                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+    #                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
+    #              run: |
+    #                  aws lambda update-function-configuration --function-name getSessionIdsByQuery \
+    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+    #                  aws lambda update-function-configuration --function-name deleteSessionBatchFromPostgres \
+    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+    #                  aws lambda update-function-configuration --function-name deleteSessionBatchFromOpenSearch \
+    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+    #                  aws lambda update-function-configuration --function-name deleteSessionBatchFromS3 \
+    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+    #                  aws lambda update-function-configuration --function-name sendEmail \
+    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+    #            - name: Deploy getSessionIdsByQuery
+    #              uses: appleboy/lambda-action@v0.1.9
+    #              with:
+    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws_region: us-east-2
+    #                  function_name: getSessionIdsByQuery
+    #                  zip_file: backend/getSessionIdsByQuery.zip
+    #            - name: Deploy deleteSessionBatchFromPostgres
+    #              uses: appleboy/lambda-action@v0.1.9
+    #              with:
+    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws_region: us-east-2
+    #                  function_name: deleteSessionBatchFromPostgres
+    #                  zip_file: backend/deleteSessionBatchFromPostgres.zip
+    #            - name: Deploy deleteSessionBatchFromOpenSearch
+    #              uses: appleboy/lambda-action@v0.1.9
+    #              with:
+    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws_region: us-east-2
+    #                  function_name: deleteSessionBatchFromOpenSearch
+    #                  zip_file: backend/deleteSessionBatchFromOpenSearch.zip
+    #            - name: Deploy deleteSessionBatchFromS3
+    #              uses: appleboy/lambda-action@v0.1.9
+    #              with:
+    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws_region: us-east-2
+    #                  function_name: deleteSessionBatchFromS3
+    #                  zip_file: backend/deleteSessionBatchFromS3.zip
+    #            - name: Deploy sendEmail
+    #              uses: appleboy/lambda-action@v0.1.9
+    #              with:
+    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws_region: us-east-2
+    #                  function_name: sendEmail
+    #                  zip_file: backend/sendEmail.zip
+    #
+    #    deploy-digest-lambdas:
+    #        needs: migrate-database
+    #        runs-on: ubuntu-latest
+    #        steps:
+    #            - name: Checkout
+    #              uses: actions/checkout@v3
+    #            - name: Setup Go
+    #              uses: actions/setup-go@v4
+    #              with:
+    #                  go-version-file: 'backend/go.mod'
+    #            - name: Install Doppler CLI
+    #              uses: dopplerhq/cli-action@v2
+    #            - name: Build and zip
+    #              run: |
+    #                  cd backend/
+    #                  CGO_ENABLED=0 go build ./lambda-functions/digests/getProjectIds
+    #                  zip getProjectIds.zip getProjectIds
+    #                  CGO_ENABLED=0 go build ./lambda-functions/digests/getDigestData
+    #                  zip getDigestData.zip getDigestData
+    #                  CGO_ENABLED=0 go build ./lambda-functions/digests/sendDigestEmails
+    #                  zip sendDigestEmails.zip sendDigestEmails
+    #            - name: Configure AWS credentials
+    #              uses: aws-actions/configure-aws-credentials@v2
+    #              with:
+    #                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws-region: us-east-2
+    #            - name: Update Lambda secrets
+    #              env:
+    #                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+    #                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
+    #              run: |
+    #                  aws lambda update-function-configuration --function-name getProjectIds \
+    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+    #                  aws lambda update-function-configuration --function-name getDigestData \
+    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+    #                  aws lambda update-function-configuration --function-name sendDigestEmails \
+    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+    #            - name: Deploy getProjectIds
+    #              uses: appleboy/lambda-action@v0.1.9
+    #              with:
+    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws_region: us-east-2
+    #                  function_name: getProjectIds
+    #                  zip_file: backend/getProjectIds.zip
+    #            - name: Deploy getDigestData
+    #              uses: appleboy/lambda-action@v0.1.9
+    #              with:
+    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws_region: us-east-2
+    #                  function_name: getDigestData
+    #                  zip_file: backend/getDigestData.zip
+    #            - name: Deploy sendDigestEmails
+    #              uses: appleboy/lambda-action@v0.1.9
+    #              with:
+    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws_region: us-east-2
+    #                  function_name: sendDigestEmails
+    #                  zip_file: backend/sendDigestEmails.zip
+    #
+    #    deploy-session-insights-lambdas:
+    #        needs: migrate-database
+    #        runs-on: ubuntu-latest
+    #        steps:
+    #            - name: Checkout
+    #              uses: actions/checkout@v3
+    #            - name: Setup Go
+    #              uses: actions/setup-go@v4
+    #              with:
+    #                  go-version-file: 'backend/go.mod'
+    #            - name: Install Doppler CLI
+    #              uses: dopplerhq/cli-action@v2
+    #            - name: Build and zip
+    #              run: |
+    #                  cd backend/
+    #                  CGO_ENABLED=0 go build ./lambda-functions/sessionInsights/getSessionInsightsData
+    #                  zip getSessionInsightsData.zip getSessionInsightsData
+    #                  CGO_ENABLED=0 go build ./lambda-functions/sessionInsights/sendSessionInsightsEmails
+    #                  zip sendSessionInsightsEmails.zip sendSessionInsightsEmails
+    #            - name: Configure AWS credentials
+    #              uses: aws-actions/configure-aws-credentials@v2
+    #              with:
+    #                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws-region: us-east-2
+    #            - name: Update Lambda secrets
+    #              env:
+    #                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+    #                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
+    #              run: |
+    #                  aws lambda update-function-configuration --function-name getSessionInsightsData \
+    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+    #                  aws lambda update-function-configuration --function-name sendSessionInsightsEmails \
+    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+    #            - name: Deploy getSessionInsightsData
+    #              uses: appleboy/lambda-action@v0.1.9
+    #              with:
+    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws_region: us-east-2
+    #                  function_name: getSessionInsightsData
+    #                  zip_file: backend/getSessionInsightsData.zip
+    #            - name: Deploy sendSessionInsightsEmails
+    #              uses: appleboy/lambda-action@v0.1.9
+    #              with:
+    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws_region: us-east-2
+    #                  function_name: sendSessionInsightsEmails
+    #                  zip_file: backend/sendSessionInsightsEmails.zip
+    #
+    #    deploy-user-journey-lambdas:
+    #        needs: migrate-database
+    #        runs-on: ubuntu-latest
+    #        steps:
+    #            - name: Checkout
+    #              uses: actions/checkout@v3
+    #            - name: Setup Go
+    #              uses: actions/setup-go@v4
+    #              with:
+    #                  go-version-file: 'backend/go.mod'
+    #            - name: Install Doppler CLI
+    #              uses: dopplerhq/cli-action@v2
+    #            - name: Build and zip
+    #              run: |
+    #                  cd backend/
+    #                  CGO_ENABLED=0 go build ./lambda-functions/journeys/updateNormalnessScores
+    #                  zip updateNormalnessScores.zip updateNormalnessScores
+    #            - name: Configure AWS credentials
+    #              uses: aws-actions/configure-aws-credentials@v2
+    #              with:
+    #                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws-region: us-east-2
+    #            - name: Update Lambda secrets
+    #              env:
+    #                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+    #                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
+    #              run: |
+    #                  aws lambda update-function-configuration --function-name updateNormalnessScores \
+    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+    #            - name: Deploy updateNormalnessScores
+    #              uses: appleboy/lambda-action@v0.1.9
+    #              with:
+    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws_region: us-east-2
+    #                  function_name: updateNormalnessScores
+    #                  zip_file: backend/updateNormalnessScores.zip
+    #
+    #    deploy_backend:
+    #        needs: migrate-database
+    #        runs-on: buildjet-2vcpu-ubuntu-2204-arm
+    #        steps:
+    #            - name: Check out the repo
+    #              uses: actions/checkout@v3
+    #
+    #            - name: Configure AWS credentials
+    #              uses: aws-actions/configure-aws-credentials@v2
+    #              with:
+    #                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #                  aws-region: us-east-2
+    #            - name: Login to Amazon ECR
+    #              id: login-ecr
+    #              uses: aws-actions/amazon-ecr-login@v1
+    #
+    #            - name: Build, tag, and push arm64 image to Amazon ECR
+    #              env:
+    #                  ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+    #                  ECR_REPOSITORY: highlight-production-ecr-repo
+    #                  IMAGE_TAG: ${{ github.sha }}
+    #              run: |
+    #                  docker buildx build --build-arg REACT_APP_COMMIT_SHA=${{ github.sha }} --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64 -f deploy/Dockerfile.prod.arm64 .
+    #                  docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64
+    #
+    #            # Edit and deploy private-graph
+    #            - name: Replace image label for private-graph task
+    #              id: image-private-graph
+    #              uses: aws-actions/amazon-ecs-render-task-definition@v1
+    #              with:
+    #                  task-definition: deploy/private-graph-task.json
+    #                  container-name: highlight-backend
+    #                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+    #            - name: Deploy to Amazon ECS private-graph service
+    #              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+    #              with:
+    #                  task-definition: ${{ steps.image-private-graph.outputs.task-definition }}
+    #                  service: private-graph-service
+    #                  cluster: highlight-production-cluster
+    #            # Edit and deploy public-graph
+    #            - name: Replace image label for public-graph task
+    #              id: image-public-graph
+    #              uses: aws-actions/amazon-ecs-render-task-definition@v1
+    #              with:
+    #                  task-definition: deploy/public-graph-task.json
+    #                  container-name: highlight-backend
+    #                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+    #            - name: Deploy to Amazon ECS public-graph service
+    #              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+    #              with:
+    #                  task-definition: ${{ steps.image-public-graph.outputs.task-definition }}
+    #                  service: public-graph-service
+    #                  cluster: highlight-production-cluster
+    #            # Edit and deploy worker
+    #            - name: Replace image label for worker task
+    #              id: image-worker
+    #              uses: aws-actions/amazon-ecs-render-task-definition@v1
+    #              with:
+    #                  task-definition: deploy/worker-task.json
+    #                  container-name: highlight-backend
+    #                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+    #            - name: Deploy to Amazon ECS worker service
+    #              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+    #              with:
+    #                  task-definition: ${{ steps.image-worker.outputs.task-definition }}
+    #                  service: worker-service-v2
+    #                  cluster: highlight-production-cluster
+    #            # Edit and deploy metric monitors
+    #            - name: Replace image label for metric monitors task
+    #              id: image-metric-monitor
+    #              uses: aws-actions/amazon-ecs-render-task-definition@v1
+    #              with:
+    #                  task-definition: deploy/metric-monitor-task.json
+    #                  container-name: highlight-backend
+    #                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+    #            - name: Deploy to Amazon ECS metric monitor service
+    #              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+    #              with:
+    #                  task-definition: ${{ steps.image-metric-monitor.outputs.task-definition }}
+    #                  service: metric-monitor
+    #                  cluster: highlight-production-cluster
+    #            # Edit and deploy log alerts
+    #            - name: Replace image label for log alerts task
+    #              id: image-log-alerts
+    #              uses: aws-actions/amazon-ecs-render-task-definition@v1
+    #              with:
+    #                  task-definition: deploy/log-alerts-task.json
+    #                  container-name: highlight-backend
+    #                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+    #            - name: Deploy to Amazon ECS log alerts service
+    #              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+    #              with:
+    #                  task-definition: ${{ steps.image-log-alerts.outputs.task-definition }}
+    #                  service: log-alerts-service
+    #                  cluster: highlight-production-cluster
+    #            # Edit and deploy public worker
+    #            - name: Replace image label for public worker service
+    #              id: image-public-worker
+    #              uses: aws-actions/amazon-ecs-render-task-definition@v1
+    #              with:
+    #                  task-definition: deploy/public-worker-service.json
+    #                  container-name: highlight-backend
+    #                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+    #            - name: Deploy to Amazon ECS public worker service
+    #              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+    #              with:
+    #                  task-definition: ${{ steps.image-public-worker.outputs.task-definition }}
+    #                  service: public-worker-service
+    #                  cluster: highlight-production-cluster
 
     deploy_opentelemetry_collector:
         runs-on: buildjet-2vcpu-ubuntu-2204-arm
@@ -394,17 +396,9 @@ jobs:
 
             - name: Check out the repo
               uses: actions/checkout@v3
-            - uses: dorny/paths-filter@v2
-              id: filter
-              with:
-                  filters: |
-                      otel-changed:
-                        - 'deploy/opentelemetry-collector.Dockerfile'
-                        - 'deploy/otel-collector.yaml'
 
             # Edit and deploy opentelemetry collector
             - name: Build, tag, and push arm64 image to Amazon ECR
-              if: steps.filter.outputs.otel-changed == 'true'
               env:
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
                   ECR_REPOSITORY: highlight-collector
@@ -414,7 +408,6 @@ jobs:
                   docker buildx build --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64 -f opentelemetry-collector.Dockerfile .
                   docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64
             - name: Replace image label for opentelemetry collector
-              if: steps.filter.outputs.otel-changed == 'true'
               id: image-opentelemetry-collector
               uses: aws-actions/amazon-ecs-render-task-definition@v1
               with:
@@ -422,7 +415,6 @@ jobs:
                   container-name: highlight-collector
                   image: ${{ steps.login-ecr.outputs.registry }}/highlight-collector:${{ github.sha }}.arm64
             - name: Deploy to Amazon ECS opentelemetry collector service
-              if: steps.filter.outputs.otel-changed == 'true'
               uses: aws-actions/amazon-ecs-deploy-task-definition@v1
               with:
                   task-definition: ${{ steps.image-opentelemetry-collector.outputs.task-definition }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,5 @@
 name: Deploy to AWS
 on:
-    pull_request:
-        types: [opened, synchronize]
     push:
         branches:
             - 'main'
@@ -12,374 +10,374 @@ on:
             - 'deploy/**'
             - '.github/workflows/deploy.yml'
 jobs:
-    #    migrate-database:
-    #        runs-on: ubuntu-latest
-    #        steps:
-    #            - name: Checkout
-    #              uses: actions/checkout@v3
-    #            - name: Setup Go
-    #              uses: actions/setup-go@v4
-    #              with:
-    #                  go-version-file: 'backend/go.mod'
-    #            - name: Install Doppler CLI
-    #              uses: dopplerhq/cli-action@v2
-    #            - name: Migrate database
-    #              run: |
-    #                  cd backend/
-    #                  make migrate
-    #              env:
-    #                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-    #
-    #    deploy-session-delete-lambdas:
-    #        needs: migrate-database
-    #        runs-on: ubuntu-latest
-    #        steps:
-    #            - name: Checkout
-    #              uses: actions/checkout@v3
-    #            - name: Setup Go
-    #              uses: actions/setup-go@v4
-    #              with:
-    #                  go-version-file: 'backend/go.mod'
-    #            - name: Install Doppler CLI
-    #              uses: dopplerhq/cli-action@v2
-    #            - name: Build and zip
-    #              run: |
-    #                  cd backend/
-    #                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/getSessionIdsByQuery
-    #                  zip getSessionIdsByQuery.zip getSessionIdsByQuery
-    #                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromPostgres
-    #                  zip deleteSessionBatchFromPostgres.zip deleteSessionBatchFromPostgres
-    #                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromOpenSearch
-    #                  zip deleteSessionBatchFromOpenSearch.zip deleteSessionBatchFromOpenSearch
-    #                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromS3
-    #                  zip deleteSessionBatchFromS3.zip deleteSessionBatchFromS3
-    #                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/sendEmail
-    #                  zip sendEmail.zip sendEmail
-    #            - name: Configure AWS credentials
-    #              uses: aws-actions/configure-aws-credentials@v2
-    #              with:
-    #                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws-region: us-east-2
-    #            - name: Update Lambda secrets
-    #              env:
-    #                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
-    #                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
-    #              run: |
-    #                  aws lambda update-function-configuration --function-name getSessionIdsByQuery \
-    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-    #                  aws lambda update-function-configuration --function-name deleteSessionBatchFromPostgres \
-    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-    #                  aws lambda update-function-configuration --function-name deleteSessionBatchFromOpenSearch \
-    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-    #                  aws lambda update-function-configuration --function-name deleteSessionBatchFromS3 \
-    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-    #                  aws lambda update-function-configuration --function-name sendEmail \
-    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-    #            - name: Deploy getSessionIdsByQuery
-    #              uses: appleboy/lambda-action@v0.1.9
-    #              with:
-    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws_region: us-east-2
-    #                  function_name: getSessionIdsByQuery
-    #                  zip_file: backend/getSessionIdsByQuery.zip
-    #            - name: Deploy deleteSessionBatchFromPostgres
-    #              uses: appleboy/lambda-action@v0.1.9
-    #              with:
-    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws_region: us-east-2
-    #                  function_name: deleteSessionBatchFromPostgres
-    #                  zip_file: backend/deleteSessionBatchFromPostgres.zip
-    #            - name: Deploy deleteSessionBatchFromOpenSearch
-    #              uses: appleboy/lambda-action@v0.1.9
-    #              with:
-    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws_region: us-east-2
-    #                  function_name: deleteSessionBatchFromOpenSearch
-    #                  zip_file: backend/deleteSessionBatchFromOpenSearch.zip
-    #            - name: Deploy deleteSessionBatchFromS3
-    #              uses: appleboy/lambda-action@v0.1.9
-    #              with:
-    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws_region: us-east-2
-    #                  function_name: deleteSessionBatchFromS3
-    #                  zip_file: backend/deleteSessionBatchFromS3.zip
-    #            - name: Deploy sendEmail
-    #              uses: appleboy/lambda-action@v0.1.9
-    #              with:
-    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws_region: us-east-2
-    #                  function_name: sendEmail
-    #                  zip_file: backend/sendEmail.zip
-    #
-    #    deploy-digest-lambdas:
-    #        needs: migrate-database
-    #        runs-on: ubuntu-latest
-    #        steps:
-    #            - name: Checkout
-    #              uses: actions/checkout@v3
-    #            - name: Setup Go
-    #              uses: actions/setup-go@v4
-    #              with:
-    #                  go-version-file: 'backend/go.mod'
-    #            - name: Install Doppler CLI
-    #              uses: dopplerhq/cli-action@v2
-    #            - name: Build and zip
-    #              run: |
-    #                  cd backend/
-    #                  CGO_ENABLED=0 go build ./lambda-functions/digests/getProjectIds
-    #                  zip getProjectIds.zip getProjectIds
-    #                  CGO_ENABLED=0 go build ./lambda-functions/digests/getDigestData
-    #                  zip getDigestData.zip getDigestData
-    #                  CGO_ENABLED=0 go build ./lambda-functions/digests/sendDigestEmails
-    #                  zip sendDigestEmails.zip sendDigestEmails
-    #            - name: Configure AWS credentials
-    #              uses: aws-actions/configure-aws-credentials@v2
-    #              with:
-    #                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws-region: us-east-2
-    #            - name: Update Lambda secrets
-    #              env:
-    #                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
-    #                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
-    #              run: |
-    #                  aws lambda update-function-configuration --function-name getProjectIds \
-    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-    #                  aws lambda update-function-configuration --function-name getDigestData \
-    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-    #                  aws lambda update-function-configuration --function-name sendDigestEmails \
-    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-    #            - name: Deploy getProjectIds
-    #              uses: appleboy/lambda-action@v0.1.9
-    #              with:
-    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws_region: us-east-2
-    #                  function_name: getProjectIds
-    #                  zip_file: backend/getProjectIds.zip
-    #            - name: Deploy getDigestData
-    #              uses: appleboy/lambda-action@v0.1.9
-    #              with:
-    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws_region: us-east-2
-    #                  function_name: getDigestData
-    #                  zip_file: backend/getDigestData.zip
-    #            - name: Deploy sendDigestEmails
-    #              uses: appleboy/lambda-action@v0.1.9
-    #              with:
-    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws_region: us-east-2
-    #                  function_name: sendDigestEmails
-    #                  zip_file: backend/sendDigestEmails.zip
-    #
-    #    deploy-session-insights-lambdas:
-    #        needs: migrate-database
-    #        runs-on: ubuntu-latest
-    #        steps:
-    #            - name: Checkout
-    #              uses: actions/checkout@v3
-    #            - name: Setup Go
-    #              uses: actions/setup-go@v4
-    #              with:
-    #                  go-version-file: 'backend/go.mod'
-    #            - name: Install Doppler CLI
-    #              uses: dopplerhq/cli-action@v2
-    #            - name: Build and zip
-    #              run: |
-    #                  cd backend/
-    #                  CGO_ENABLED=0 go build ./lambda-functions/sessionInsights/getSessionInsightsData
-    #                  zip getSessionInsightsData.zip getSessionInsightsData
-    #                  CGO_ENABLED=0 go build ./lambda-functions/sessionInsights/sendSessionInsightsEmails
-    #                  zip sendSessionInsightsEmails.zip sendSessionInsightsEmails
-    #            - name: Configure AWS credentials
-    #              uses: aws-actions/configure-aws-credentials@v2
-    #              with:
-    #                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws-region: us-east-2
-    #            - name: Update Lambda secrets
-    #              env:
-    #                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
-    #                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
-    #              run: |
-    #                  aws lambda update-function-configuration --function-name getSessionInsightsData \
-    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-    #                  aws lambda update-function-configuration --function-name sendSessionInsightsEmails \
-    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-    #            - name: Deploy getSessionInsightsData
-    #              uses: appleboy/lambda-action@v0.1.9
-    #              with:
-    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws_region: us-east-2
-    #                  function_name: getSessionInsightsData
-    #                  zip_file: backend/getSessionInsightsData.zip
-    #            - name: Deploy sendSessionInsightsEmails
-    #              uses: appleboy/lambda-action@v0.1.9
-    #              with:
-    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws_region: us-east-2
-    #                  function_name: sendSessionInsightsEmails
-    #                  zip_file: backend/sendSessionInsightsEmails.zip
-    #
-    #    deploy-user-journey-lambdas:
-    #        needs: migrate-database
-    #        runs-on: ubuntu-latest
-    #        steps:
-    #            - name: Checkout
-    #              uses: actions/checkout@v3
-    #            - name: Setup Go
-    #              uses: actions/setup-go@v4
-    #              with:
-    #                  go-version-file: 'backend/go.mod'
-    #            - name: Install Doppler CLI
-    #              uses: dopplerhq/cli-action@v2
-    #            - name: Build and zip
-    #              run: |
-    #                  cd backend/
-    #                  CGO_ENABLED=0 go build ./lambda-functions/journeys/updateNormalnessScores
-    #                  zip updateNormalnessScores.zip updateNormalnessScores
-    #            - name: Configure AWS credentials
-    #              uses: aws-actions/configure-aws-credentials@v2
-    #              with:
-    #                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws-region: us-east-2
-    #            - name: Update Lambda secrets
-    #              env:
-    #                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
-    #                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
-    #              run: |
-    #                  aws lambda update-function-configuration --function-name updateNormalnessScores \
-    #                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
-    #            - name: Deploy updateNormalnessScores
-    #              uses: appleboy/lambda-action@v0.1.9
-    #              with:
-    #                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws_region: us-east-2
-    #                  function_name: updateNormalnessScores
-    #                  zip_file: backend/updateNormalnessScores.zip
-    #
-    #    deploy_backend:
-    #        needs: migrate-database
-    #        runs-on: buildjet-2vcpu-ubuntu-2204-arm
-    #        steps:
-    #            - name: Check out the repo
-    #              uses: actions/checkout@v3
-    #
-    #            - name: Configure AWS credentials
-    #              uses: aws-actions/configure-aws-credentials@v2
-    #              with:
-    #                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-    #                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    #                  aws-region: us-east-2
-    #            - name: Login to Amazon ECR
-    #              id: login-ecr
-    #              uses: aws-actions/amazon-ecr-login@v1
-    #
-    #            - name: Build, tag, and push arm64 image to Amazon ECR
-    #              env:
-    #                  ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-    #                  ECR_REPOSITORY: highlight-production-ecr-repo
-    #                  IMAGE_TAG: ${{ github.sha }}
-    #              run: |
-    #                  docker buildx build --build-arg REACT_APP_COMMIT_SHA=${{ github.sha }} --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64 -f deploy/Dockerfile.prod.arm64 .
-    #                  docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64
-    #
-    #            # Edit and deploy private-graph
-    #            - name: Replace image label for private-graph task
-    #              id: image-private-graph
-    #              uses: aws-actions/amazon-ecs-render-task-definition@v1
-    #              with:
-    #                  task-definition: deploy/private-graph-task.json
-    #                  container-name: highlight-backend
-    #                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
-    #            - name: Deploy to Amazon ECS private-graph service
-    #              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-    #              with:
-    #                  task-definition: ${{ steps.image-private-graph.outputs.task-definition }}
-    #                  service: private-graph-service
-    #                  cluster: highlight-production-cluster
-    #            # Edit and deploy public-graph
-    #            - name: Replace image label for public-graph task
-    #              id: image-public-graph
-    #              uses: aws-actions/amazon-ecs-render-task-definition@v1
-    #              with:
-    #                  task-definition: deploy/public-graph-task.json
-    #                  container-name: highlight-backend
-    #                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
-    #            - name: Deploy to Amazon ECS public-graph service
-    #              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-    #              with:
-    #                  task-definition: ${{ steps.image-public-graph.outputs.task-definition }}
-    #                  service: public-graph-service
-    #                  cluster: highlight-production-cluster
-    #            # Edit and deploy worker
-    #            - name: Replace image label for worker task
-    #              id: image-worker
-    #              uses: aws-actions/amazon-ecs-render-task-definition@v1
-    #              with:
-    #                  task-definition: deploy/worker-task.json
-    #                  container-name: highlight-backend
-    #                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
-    #            - name: Deploy to Amazon ECS worker service
-    #              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-    #              with:
-    #                  task-definition: ${{ steps.image-worker.outputs.task-definition }}
-    #                  service: worker-service-v2
-    #                  cluster: highlight-production-cluster
-    #            # Edit and deploy metric monitors
-    #            - name: Replace image label for metric monitors task
-    #              id: image-metric-monitor
-    #              uses: aws-actions/amazon-ecs-render-task-definition@v1
-    #              with:
-    #                  task-definition: deploy/metric-monitor-task.json
-    #                  container-name: highlight-backend
-    #                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
-    #            - name: Deploy to Amazon ECS metric monitor service
-    #              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-    #              with:
-    #                  task-definition: ${{ steps.image-metric-monitor.outputs.task-definition }}
-    #                  service: metric-monitor
-    #                  cluster: highlight-production-cluster
-    #            # Edit and deploy log alerts
-    #            - name: Replace image label for log alerts task
-    #              id: image-log-alerts
-    #              uses: aws-actions/amazon-ecs-render-task-definition@v1
-    #              with:
-    #                  task-definition: deploy/log-alerts-task.json
-    #                  container-name: highlight-backend
-    #                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
-    #            - name: Deploy to Amazon ECS log alerts service
-    #              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-    #              with:
-    #                  task-definition: ${{ steps.image-log-alerts.outputs.task-definition }}
-    #                  service: log-alerts-service
-    #                  cluster: highlight-production-cluster
-    #            # Edit and deploy public worker
-    #            - name: Replace image label for public worker service
-    #              id: image-public-worker
-    #              uses: aws-actions/amazon-ecs-render-task-definition@v1
-    #              with:
-    #                  task-definition: deploy/public-worker-service.json
-    #                  container-name: highlight-backend
-    #                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
-    #            - name: Deploy to Amazon ECS public worker service
-    #              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-    #              with:
-    #                  task-definition: ${{ steps.image-public-worker.outputs.task-definition }}
-    #                  service: public-worker-service
-    #                  cluster: highlight-production-cluster
+    migrate-database:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Setup Go
+              uses: actions/setup-go@v4
+              with:
+                  go-version-file: 'backend/go.mod'
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v2
+            - name: Migrate database
+              run: |
+                  cd backend/
+                  make migrate
+              env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+
+    deploy-session-delete-lambdas:
+        needs: migrate-database
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Setup Go
+              uses: actions/setup-go@v4
+              with:
+                  go-version-file: 'backend/go.mod'
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v2
+            - name: Build and zip
+              run: |
+                  cd backend/
+                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/getSessionIdsByQuery
+                  zip getSessionIdsByQuery.zip getSessionIdsByQuery
+                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromPostgres
+                  zip deleteSessionBatchFromPostgres.zip deleteSessionBatchFromPostgres
+                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromOpenSearch
+                  zip deleteSessionBatchFromOpenSearch.zip deleteSessionBatchFromOpenSearch
+                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/deleteSessionBatchFromS3
+                  zip deleteSessionBatchFromS3.zip deleteSessionBatchFromS3
+                  CGO_ENABLED=0 go build ./lambda-functions/deleteSessions/sendEmail
+                  zip sendEmail.zip sendEmail
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v2
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: us-east-2
+            - name: Update Lambda secrets
+              env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
+              run: |
+                  aws lambda update-function-configuration --function-name getSessionIdsByQuery \
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                  aws lambda update-function-configuration --function-name deleteSessionBatchFromPostgres \
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                  aws lambda update-function-configuration --function-name deleteSessionBatchFromOpenSearch \
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                  aws lambda update-function-configuration --function-name deleteSessionBatchFromS3 \
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                  aws lambda update-function-configuration --function-name sendEmail \
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+            - name: Deploy getSessionIdsByQuery
+              uses: appleboy/lambda-action@v0.1.9
+              with:
+                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws_region: us-east-2
+                  function_name: getSessionIdsByQuery
+                  zip_file: backend/getSessionIdsByQuery.zip
+            - name: Deploy deleteSessionBatchFromPostgres
+              uses: appleboy/lambda-action@v0.1.9
+              with:
+                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws_region: us-east-2
+                  function_name: deleteSessionBatchFromPostgres
+                  zip_file: backend/deleteSessionBatchFromPostgres.zip
+            - name: Deploy deleteSessionBatchFromOpenSearch
+              uses: appleboy/lambda-action@v0.1.9
+              with:
+                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws_region: us-east-2
+                  function_name: deleteSessionBatchFromOpenSearch
+                  zip_file: backend/deleteSessionBatchFromOpenSearch.zip
+            - name: Deploy deleteSessionBatchFromS3
+              uses: appleboy/lambda-action@v0.1.9
+              with:
+                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws_region: us-east-2
+                  function_name: deleteSessionBatchFromS3
+                  zip_file: backend/deleteSessionBatchFromS3.zip
+            - name: Deploy sendEmail
+              uses: appleboy/lambda-action@v0.1.9
+              with:
+                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws_region: us-east-2
+                  function_name: sendEmail
+                  zip_file: backend/sendEmail.zip
+
+    deploy-digest-lambdas:
+        needs: migrate-database
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Setup Go
+              uses: actions/setup-go@v4
+              with:
+                  go-version-file: 'backend/go.mod'
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v2
+            - name: Build and zip
+              run: |
+                  cd backend/
+                  CGO_ENABLED=0 go build ./lambda-functions/digests/getProjectIds
+                  zip getProjectIds.zip getProjectIds
+                  CGO_ENABLED=0 go build ./lambda-functions/digests/getDigestData
+                  zip getDigestData.zip getDigestData
+                  CGO_ENABLED=0 go build ./lambda-functions/digests/sendDigestEmails
+                  zip sendDigestEmails.zip sendDigestEmails
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v2
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: us-east-2
+            - name: Update Lambda secrets
+              env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
+              run: |
+                  aws lambda update-function-configuration --function-name getProjectIds \
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                  aws lambda update-function-configuration --function-name getDigestData \
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                  aws lambda update-function-configuration --function-name sendDigestEmails \
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+            - name: Deploy getProjectIds
+              uses: appleboy/lambda-action@v0.1.9
+              with:
+                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws_region: us-east-2
+                  function_name: getProjectIds
+                  zip_file: backend/getProjectIds.zip
+            - name: Deploy getDigestData
+              uses: appleboy/lambda-action@v0.1.9
+              with:
+                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws_region: us-east-2
+                  function_name: getDigestData
+                  zip_file: backend/getDigestData.zip
+            - name: Deploy sendDigestEmails
+              uses: appleboy/lambda-action@v0.1.9
+              with:
+                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws_region: us-east-2
+                  function_name: sendDigestEmails
+                  zip_file: backend/sendDigestEmails.zip
+
+    deploy-session-insights-lambdas:
+        needs: migrate-database
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Setup Go
+              uses: actions/setup-go@v4
+              with:
+                  go-version-file: 'backend/go.mod'
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v2
+            - name: Build and zip
+              run: |
+                  cd backend/
+                  CGO_ENABLED=0 go build ./lambda-functions/sessionInsights/getSessionInsightsData
+                  zip getSessionInsightsData.zip getSessionInsightsData
+                  CGO_ENABLED=0 go build ./lambda-functions/sessionInsights/sendSessionInsightsEmails
+                  zip sendSessionInsightsEmails.zip sendSessionInsightsEmails
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v2
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: us-east-2
+            - name: Update Lambda secrets
+              env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
+              run: |
+                  aws lambda update-function-configuration --function-name getSessionInsightsData \
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+                  aws lambda update-function-configuration --function-name sendSessionInsightsEmails \
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+            - name: Deploy getSessionInsightsData
+              uses: appleboy/lambda-action@v0.1.9
+              with:
+                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws_region: us-east-2
+                  function_name: getSessionInsightsData
+                  zip_file: backend/getSessionInsightsData.zip
+            - name: Deploy sendSessionInsightsEmails
+              uses: appleboy/lambda-action@v0.1.9
+              with:
+                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws_region: us-east-2
+                  function_name: sendSessionInsightsEmails
+                  zip_file: backend/sendSessionInsightsEmails.zip
+
+    deploy-user-journey-lambdas:
+        needs: migrate-database
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Setup Go
+              uses: actions/setup-go@v4
+              with:
+                  go-version-file: 'backend/go.mod'
+            - name: Install Doppler CLI
+              uses: dopplerhq/cli-action@v2
+            - name: Build and zip
+              run: |
+                  cd backend/
+                  CGO_ENABLED=0 go build ./lambda-functions/journeys/updateNormalnessScores
+                  zip updateNormalnessScores.zip updateNormalnessScores
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v2
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: us-east-2
+            - name: Update Lambda secrets
+              env:
+                  DOPPLER_TOKEN: ${{ secrets.DOPPLER_PROD_AWS_LAMBDAS_SECRET }}
+                  REACT_APP_COMMIT_SHA: ${{ github.sha }}
+              run: |
+                  aws lambda update-function-configuration --function-name updateNormalnessScores \
+                    --environment "$(doppler secrets download --no-file | jq ". + {REACT_APP_COMMIT_SHA: \"$REACT_APP_COMMIT_SHA\" }" | jq '{Variables: .}')"
+            - name: Deploy updateNormalnessScores
+              uses: appleboy/lambda-action@v0.1.9
+              with:
+                  aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws_region: us-east-2
+                  function_name: updateNormalnessScores
+                  zip_file: backend/updateNormalnessScores.zip
+
+    deploy_backend:
+        needs: migrate-database
+        runs-on: buildjet-2vcpu-ubuntu-2204-arm
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v3
+
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v2
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: us-east-2
+            - name: Login to Amazon ECR
+              id: login-ecr
+              uses: aws-actions/amazon-ecr-login@v1
+
+            - name: Build, tag, and push arm64 image to Amazon ECR
+              env:
+                  ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+                  ECR_REPOSITORY: highlight-production-ecr-repo
+                  IMAGE_TAG: ${{ github.sha }}
+              run: |
+                  docker buildx build --build-arg REACT_APP_COMMIT_SHA=${{ github.sha }} --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64 -f deploy/Dockerfile.prod.arm64 .
+                  docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64
+
+            # Edit and deploy private-graph
+            - name: Replace image label for private-graph task
+              id: image-private-graph
+              uses: aws-actions/amazon-ecs-render-task-definition@v1
+              with:
+                  task-definition: deploy/private-graph-task.json
+                  container-name: highlight-backend
+                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+            - name: Deploy to Amazon ECS private-graph service
+              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+              with:
+                  task-definition: ${{ steps.image-private-graph.outputs.task-definition }}
+                  service: private-graph-service
+                  cluster: highlight-production-cluster
+            # Edit and deploy public-graph
+            - name: Replace image label for public-graph task
+              id: image-public-graph
+              uses: aws-actions/amazon-ecs-render-task-definition@v1
+              with:
+                  task-definition: deploy/public-graph-task.json
+                  container-name: highlight-backend
+                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+            - name: Deploy to Amazon ECS public-graph service
+              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+              with:
+                  task-definition: ${{ steps.image-public-graph.outputs.task-definition }}
+                  service: public-graph-service
+                  cluster: highlight-production-cluster
+            # Edit and deploy worker
+            - name: Replace image label for worker task
+              id: image-worker
+              uses: aws-actions/amazon-ecs-render-task-definition@v1
+              with:
+                  task-definition: deploy/worker-task.json
+                  container-name: highlight-backend
+                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+            - name: Deploy to Amazon ECS worker service
+              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+              with:
+                  task-definition: ${{ steps.image-worker.outputs.task-definition }}
+                  service: worker-service-v2
+                  cluster: highlight-production-cluster
+            # Edit and deploy metric monitors
+            - name: Replace image label for metric monitors task
+              id: image-metric-monitor
+              uses: aws-actions/amazon-ecs-render-task-definition@v1
+              with:
+                  task-definition: deploy/metric-monitor-task.json
+                  container-name: highlight-backend
+                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+            - name: Deploy to Amazon ECS metric monitor service
+              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+              with:
+                  task-definition: ${{ steps.image-metric-monitor.outputs.task-definition }}
+                  service: metric-monitor
+                  cluster: highlight-production-cluster
+            # Edit and deploy log alerts
+            - name: Replace image label for log alerts task
+              id: image-log-alerts
+              uses: aws-actions/amazon-ecs-render-task-definition@v1
+              with:
+                  task-definition: deploy/log-alerts-task.json
+                  container-name: highlight-backend
+                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+            - name: Deploy to Amazon ECS log alerts service
+              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+              with:
+                  task-definition: ${{ steps.image-log-alerts.outputs.task-definition }}
+                  service: log-alerts-service
+                  cluster: highlight-production-cluster
+            # Edit and deploy public worker
+            - name: Replace image label for public worker service
+              id: image-public-worker
+              uses: aws-actions/amazon-ecs-render-task-definition@v1
+              with:
+                  task-definition: deploy/public-worker-service.json
+                  container-name: highlight-backend
+                  image: ${{ steps.login-ecr.outputs.registry }}/highlight-production-ecr-repo:${{ github.sha }}.arm64
+            - name: Deploy to Amazon ECS public worker service
+              uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+              with:
+                  task-definition: ${{ steps.image-public-worker.outputs.task-definition }}
+                  service: public-worker-service
+                  cluster: highlight-production-cluster
 
     deploy_opentelemetry_collector:
         runs-on: buildjet-2vcpu-ubuntu-2204-arm
@@ -396,9 +394,17 @@ jobs:
 
             - name: Check out the repo
               uses: actions/checkout@v3
+            - uses: dorny/paths-filter@v2
+              id: filter
+              with:
+                  filters: |
+                      otel-changed:
+                        - 'deploy/opentelemetry-collector.Dockerfile'
+                        - 'deploy/otel-collector.yaml'
 
             # Edit and deploy opentelemetry collector
             - name: Build, tag, and push arm64 image to Amazon ECR
+              if: steps.filter.outputs.otel-changed == 'true'
               env:
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
                   ECR_REPOSITORY: highlight-collector
@@ -408,6 +414,7 @@ jobs:
                   docker buildx build --platform linux/arm64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64 -f opentelemetry-collector.Dockerfile .
                   docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG.arm64
             - name: Replace image label for opentelemetry collector
+              if: steps.filter.outputs.otel-changed == 'true'
               id: image-opentelemetry-collector
               uses: aws-actions/amazon-ecs-render-task-definition@v1
               with:
@@ -415,6 +422,7 @@ jobs:
                   container-name: highlight-collector
                   image: ${{ steps.login-ecr.outputs.registry }}/highlight-collector:${{ github.sha }}.arm64
             - name: Deploy to Amazon ECS opentelemetry collector service
+              if: steps.filter.outputs.otel-changed == 'true'
               uses: aws-actions/amazon-ecs-deploy-task-definition@v1
               with:
                   task-definition: ${{ steps.image-opentelemetry-collector.outputs.task-definition }}

--- a/deploy/collector-task.json
+++ b/deploy/collector-task.json
@@ -87,7 +87,7 @@
 	"compatibilities": ["EC2", "FARGATE"],
 	"requiresCompatibilities": ["FARGATE"],
 	"cpu": "1024",
-	"memory": "2048",
+	"memory": "4096",
 	"runtimePlatform": {
 		"cpuArchitecture": "ARM64"
 	},

--- a/deploy/otel-collector.yaml
+++ b/deploy/otel-collector.yaml
@@ -17,8 +17,8 @@ processors:
     batch:
     memory_limiter:
         check_interval: 1s
-        limit_percentage: 75
-        spike_limit_percentage: 15
+        limit_mib: 3072
+        spike_limit_mib: 614
 service:
     extensions: [health_check, memory_ballast]
     pipelines:
@@ -39,4 +39,4 @@ extensions:
         endpoint: '0.0.0.0:4319'
         path: '/health/status'
     memory_ballast:
-        size_in_percentage: 10
+        size_mib: 410

--- a/deploy/otel-collector.yaml
+++ b/deploy/otel-collector.yaml
@@ -16,9 +16,9 @@ exporters:
 processors:
     batch:
     memory_limiter:
-        check_interval: 1s
-        limit_mib: 3072
-        spike_limit_mib: 614
+        check_interval: 0.1s
+        limit_mib: 2048
+        spike_limit_mib: 128
 service:
     extensions: [health_check, memory_ballast]
     pipelines:
@@ -39,4 +39,4 @@ extensions:
         endpoint: '0.0.0.0:4319'
         path: '/health/status'
     memory_ballast:
-        size_mib: 410
+        size_mib: 512


### PR DESCRIPTION
## Summary

Noticed that our OTEL collectors were killed by running OOM.

Percentage values in the configuration were incorrect because of how 
the container is calculating the memory available (for some reason 2x what it actually is).

Switching to the static values to make this more robust.
<img width="722" alt="Screenshot 2023-08-14 at 7 11 14 PM" src="https://github.com/highlight/highlight/assets/1351531/e23cbf00-38c0-4236-9cf3-5eaade469ec6">

<img width="1165" alt="Screenshot 2023-08-14 at 7 10 00 PM" src="https://github.com/highlight/highlight/assets/1351531/c670f6c7-0825-48b2-a6ac-a806a697c94a">

<img width="758" alt="Screenshot 2023-08-14 at 7 10 41 PM" src="https://github.com/highlight/highlight/assets/1351531/0a79c249-2d61-4b33-a55d-6b0cd8783972">

## How did you test this change?

Forcing a deploy from this PR.

<img width="1314" alt="Screenshot 2023-08-14 at 7 13 31 PM" src="https://github.com/highlight/highlight/assets/1351531/76ba83bd-24d7-4dac-854a-c0480082a9ff">

## Are there any deployment considerations?

Monitoring new CloudWatch [alert](https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#alarmsV2:alarm/OpenTelemetry+Receiver+Unhealthy?).