### PR TITLE
make xhr listener compatible with older browsers

### DIFF
--- a/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
@@ -7,7 +7,6 @@ import {
 	shouldNetworkRequestBeRecorded,
 	shouldNetworkRequestBeTraced,
 } from './utils'
-import { instanceOf } from 'graphql/jsutils/instanceOf'
 
 interface BrowserXHR extends XMLHttpRequest {
 	_method: string

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -348,3 +348,9 @@ Reserved for the Boeing 737
 
 - Return `{ sessionSecureID }` from `H.init` for consumption by Remix SDK
 - Persist `sessionSecureID` to `sessionStorage`
+
+## 7.4.1
+
+### Patch Changes
+
+- Ensure compatibility with older browser XHR implementations.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.4.0",
+	"version": "7.4.1",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.4.0"
+export default "7.4.1"


### PR DESCRIPTION
## Summary

As reported in [discord](https://discord.com/channels/1026884757667188757/1052834249868324895/1138879337639186635),
some browsers do not have the `response.text` method available.
![image](https://github.com/highlight/highlight/assets/1351531/88f843d1-6fad-4317-beac-22392f5f6f37)

## How did you test this change?

Local deploy correctly recording XHR requests.
<img width="1435" alt="Screenshot 2023-08-17 at 1 40 50 PM" src="https://github.com/highlight/highlight/assets/1351531/22d67dc6-8502-497a-b3fb-a28423dd9566">


## Are there any deployment considerations?

New firstload version released.