### PR TITLE
remove frequency lookup from common code

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -888,14 +888,18 @@ func (r *Resolver) doesAdminOwnErrorGroup(ctx context.Context, errorGroupSecureI
 		return eg, false, err
 	}
 
+	return eg, true, nil
+}
+
+func (r *Resolver) loadErrorGroupFrequencies(ctx context.Context, eg *model.ErrorGroup) error {
+	var err error
 	if eg.FirstOccurrence, eg.LastOccurrence, err = r.GetErrorGroupOccurrences(ctx, eg); err != nil {
-		return nil, false, e.Wrap(err, "error querying error group occurrences")
+		return e.Wrap(err, "error querying error group occurrences")
 	}
 	if err := r.SetErrorFrequencies(ctx, eg.ProjectID, []*model.ErrorGroup{eg}, ErrorGroupLookbackDays); err != nil {
-		return nil, false, e.Wrap(err, "error querying error group frequencies")
+		return e.Wrap(err, "error querying error group frequencies")
 	}
-
-	return eg, true, nil
+	return nil
 }
 
 func (r *Resolver) canAdminViewErrorObject(ctx context.Context, errorObjectID int) (*model.ErrorObject, error) {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4124,6 +4124,9 @@ func (r *queryResolver) ErrorGroup(ctx context.Context, secureID string) (*model
 	if err != nil {
 		return nil, err
 	}
+	if err := r.loadErrorGroupFrequencies(ctx, eg); err != nil {
+		return nil, err
+	}
 	retentionDate, err := r.GetProjectRetentionDate(eg.ProjectID)
 	if err != nil {
 		return nil, err
@@ -4851,6 +4854,9 @@ func (r *queryResolver) DailyErrorsCount(ctx context.Context, projectID int, dat
 func (r *queryResolver) DailyErrorFrequency(ctx context.Context, projectID int, errorGroupSecureID string, dateOffset int) ([]int64, error) {
 	errGroup, err := r.canAdminViewErrorGroup(ctx, errorGroupSecureID)
 	if err != nil {
+		return nil, err
+	}
+	if err := r.loadErrorGroupFrequencies(ctx, errGroup); err != nil {
 		return nil, err
 	}
 

--- a/frontend/src/components/NewIssueModal/NewIssueModal.tsx
+++ b/frontend/src/components/NewIssueModal/NewIssueModal.tsx
@@ -280,7 +280,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 							kind={loading ? 'secondary' : 'primary'}
 							size="small"
 							emphasis="high"
-							disabled={loading}
+							loading={loading}
 						>
 							Submit
 						</Button>


### PR DESCRIPTION
## Summary
- load error group frequencies only when necessary
- issue submit button should use loading state instead of disabled
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally, validated frequency graphs were displaying
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
