### PR TITLE
add pino to backend logging overview docs

### DIFF
--- a/docs-content/general/4_company/our-competitors.md
+++ b/docs-content/general/4_company/our-competitors.md
@@ -28,6 +28,9 @@ We respect our competitors. In fact, we're not in the business of trying to conv
     <DocsCard title="Datadog" href="https://highlight.io/compare/highlight-vs-datadog">
         {"Learn more about how we compare to Datadog."}
     </DocsCard>
+    <DocsCard title="Sentry" href="https://highlight.io/compare/highlight-vs-sentry">
+        {"Learn more about how we compare to Sentry."}
+    </DocsCard>
 </DocsCardGroup>
 
 ## Error Monitoring Competitors

--- a/docs-content/getting-started/1_overview.md
+++ b/docs-content/getting-started/1_overview.md
@@ -71,11 +71,11 @@ Highlight.io also supports logging from your backend and mapping these to corres
     <DocsCard title="JS / TS" href="./backend-logging/2_js/1_overview.md">
         {"Get started with logging in Javascript"}
     </DocsCard>
-    <DocsCard title="Ruby" href="./backend-logging/4_ruby/1_overview.md">
-        {"Get started with logging in Ruby"}
-    </DocsCard>
     <DocsCard title="Python" href="./backend-logging/3_python/1_overview.md">
         {"Get started with logging in Python"}
+    </DocsCard>
+    <DocsCard title="Ruby" href="./backend-logging/4_ruby/1_overview.md">
+        {"Get started with logging in Ruby"}
     </DocsCard>
 </DocsCardGroup>
 

--- a/docs-content/getting-started/backend-logging/2_js/1_overview.md
+++ b/docs-content/getting-started/backend-logging/2_js/1_overview.md
@@ -20,6 +20,9 @@ If you don't see one of your languages / frameworks below, reach out to us in ou
     <DocsCard title="Winston" href="./winston.md">
         {"Integrate logging in Winston.js."}
     </DocsCard>
+    <DocsCard title="Pino" href="./pino.md">
+        {"Integrate logging in Pino.js."}
+    </DocsCard>
     <DocsCard title="Cloudflare" href="./cloudflare.md">
         {"Integrate logging in Cloudflare Workers."}
     </DocsCard>


### PR DESCRIPTION
## Summary

Updates logging docs.

## How did you test this change?

[Vercel preview](https://highlight-landing-git-6351-add-pino-to-bac-bcbef3-highlight-run.vercel.app/docs/getting-started/backend-logging/js/overview).

## Are there any deployment considerations?

No.