### PR TITLE
Handle milliseconds in tsAbs param

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/utils/index.tsx
+++ b/frontend/src/pages/Player/PlayerHook/utils/index.tsx
@@ -220,15 +220,21 @@ export const useSetPlayerTimestampFromSearchParam = (
 				searchParamsObject.get(PlayerSearchParameters.tsAbs)
 			) {
 				const startTimestamp = moment(sessionStartTimeMilliseconds)
-				const absoluteTimestamp = moment(
-					searchParamsObject.get(
-						PlayerSearchParameters.tsAbs,
-					) as string,
+				const tsParam = searchParamsObject.get(
+					PlayerSearchParameters.tsAbs,
 				)
-				const relativeTimestampMilliseconds = absoluteTimestamp.diff(
-					startTimestamp,
-					'milliseconds',
-				)
+
+				// Sometimes we have a timestamp in milliseconds, other times it's a
+				// formatted time string. This accounts for both cases. I believe
+				// formatted time strings are built in the client, and millisecond
+				// values are being sent in alerts.
+				const absoluteTimestamp = isNaN(Number(tsParam))
+					? tsParam
+					: Number(tsParam)
+
+				const relativeTimestampMilliseconds = moment(
+					absoluteTimestamp,
+				).diff(startTimestamp, 'milliseconds')
 
 				setTime(relativeTimestampMilliseconds)
 				setHasSearchParam(true)


### PR DESCRIPTION
## Summary

We have a `tsAbs` param which allows people to link to a specific point in a session. Sometimes we have a formatted timestamp in that param (`tsAbs=2023-01-01-12:00:00`) and others it's a raw millisecond value (`tsAbs=1234567890`). The client sets formatted strings and [our Slack alerts set it in milliseconds](https://github.com/highlight/highlight/blob/main/backend/worker/worker.go/#L1007).

## How did you test this change?

I confirmed I can repro the error accessing sessions from a rage click alert and that it _does_ work when I open the same link in a PR preview.

## Are there any deployment considerations?

N/A