### PR TITLE
Fix infinite loading on excluded sessions

### DIFF
--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -105,7 +105,7 @@ const PlayerPage = () => {
 		session_secure_id,
 	])
 
-	const { data: isSessionPendingData, loading } = useIsSessionPendingQuery({
+	const { data: isSessionPendingData } = useIsSessionPendingQuery({
 		variables: {
 			session_secure_id: session_secure_id!,
 		},

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -265,10 +265,7 @@ const PlayerPage = () => {
 	const replayerWrapperBbox = replayer?.wrapper.getBoundingClientRect()
 
 	const showSession =
-		(sessionViewability === SessionViewability.VIEWABLE && !!session) ||
-		(replayerState !== ReplayerState.Empty &&
-			sessionViewability !== SessionViewability.ERROR) ||
-		(replayerState === ReplayerState.Empty && !!session_secure_id)
+		sessionViewability === SessionViewability.VIEWABLE && !!session
 
 	const { isPlayerFullscreen, playerCenterPanelRef } = usePlayerUIContext()
 
@@ -365,9 +362,7 @@ const PlayerPage = () => {
 	const sessionFiller = useMemo(() => {
 		switch (sessionViewability) {
 			case SessionViewability.ERROR:
-				if (loading) {
-					return <LoadingBox />
-				} else if (isSessionPendingData?.isSessionPending) {
+				if (isSessionPendingData?.isSessionPending) {
 					return (
 						<Box m="auto" style={{ maxWidth: 300 }}>
 							<Callout
@@ -477,7 +472,6 @@ const PlayerPage = () => {
 	}, [
 		currentWorkspace?.id,
 		isSessionPendingData?.isSessionPending,
-		loading,
 		sessionViewability,
 		integrated,
 		session?.excluded_reason,


### PR DESCRIPTION
## Summary

The session player can get stuck in an infinite loading state sometimes when trying to view a session that is outside a project's billing quota. This simplifies the logic for determining whether the session should be shown vs an empty state and resolves this issue. It also prevents the loading state from being displayed after we have a session and know that it is excluded.

<img width="1512" alt="Screenshot 2023-08-16 at 12 40 00 PM" src="https://github.com/highlight/highlight/assets/308182/7894dfba-b4e0-4577-82a7-378202801ba0">

## How did you test this change?

Local + PR preview click test. Here is [a session to click test with](https://app.highlight.io/7689/sessions/vpzADDKcO5l86X0ECOejKuNRcR1m).

## Are there any deployment considerations?

N/A - client-side change only.