### PR TITLE
support huggingface hosted model

### DIFF
--- a/backend/embeddings/embeddings.go
+++ b/backend/embeddings/embeddings.go
@@ -34,8 +34,8 @@ type OpenAIClient struct {
 
 func (c *OpenAIClient) GetEmbeddings(ctx context.Context, errors []*model.ErrorObject) ([]*model.ErrorObjectEmbeddings, error) {
 	start := time.Now()
-	var combinedErrors, eventErrors, stacktraceErrors, payloadErrors []*model.ErrorObject
-	var combinedInputs, eventInputs, stacktraceInputs, payloadInputs []string
+	var combinedErrors []*model.ErrorObject
+	var combinedInputs []string
 	for _, errorObject := range errors {
 		var stackTrace *string
 		if errorObject.MappedStackTrace != nil {
@@ -45,21 +45,13 @@ func (c *OpenAIClient) GetEmbeddings(ctx context.Context, errors []*model.ErrorO
 		}
 		combinedInput := errorObject.Event
 		if stackTrace != nil {
-			stacktraceInputs = append(stacktraceInputs, *stackTrace)
-			stacktraceErrors = append(stacktraceErrors, errorObject)
 			combinedInput = combinedInput + " " + *stackTrace
 		}
 		if errorObject.Payload != nil {
-			payloadInputs = append(payloadInputs, *errorObject.Payload)
-			payloadErrors = append(payloadErrors, errorObject)
 			combinedInput = combinedInput + " " + *errorObject.Payload
 		}
 		combinedInputs = append(combinedInputs, combinedInput)
 		combinedErrors = append(combinedErrors, errorObject)
-		if combinedInput != errorObject.Event {
-			eventInputs = append(eventInputs, errorObject.Event)
-			eventErrors = append(eventErrors, errorObject)
-		}
 	}
 
 	results := map[int]*model.ErrorObjectEmbeddings{}
@@ -69,9 +61,6 @@ func (c *OpenAIClient) GetEmbeddings(ctx context.Context, errors []*model.ErrorO
 		embedding EmbeddingType
 	}{
 		{inputs: combinedInputs, errors: combinedErrors, embedding: CombinedEmbedding},
-		{inputs: eventInputs, errors: eventErrors, embedding: EventEmbedding},
-		{inputs: stacktraceInputs, errors: stacktraceErrors, embedding: StackTraceEmbedding},
-		{inputs: payloadInputs, errors: payloadErrors, embedding: PayloadEmbedding},
 	} {
 		if len(inputs.inputs) == 0 {
 			continue
@@ -107,12 +96,6 @@ func (c *OpenAIClient) GetEmbeddings(ctx context.Context, errors []*model.ErrorO
 			switch inputs.embedding {
 			case CombinedEmbedding:
 				results[errorObject.ID].CombinedEmbedding = resp.Data[idx].Embedding
-			case EventEmbedding:
-				results[errorObject.ID].EventEmbedding = resp.Data[idx].Embedding
-			case StackTraceEmbedding:
-				results[errorObject.ID].StackTraceEmbedding = resp.Data[idx].Embedding
-			case PayloadEmbedding:
-				results[errorObject.ID].PayloadEmbedding = resp.Data[idx].Embedding
 			}
 		}
 	}
@@ -127,7 +110,27 @@ type HuggingfaceModelClient struct {
 }
 
 type HuggingfaceModelInputs struct {
-	Inputs []string `json:"inputs"`
+	Inputs string `json:"inputs"`
+}
+
+func (c *HuggingfaceModelClient) makeRequest(b []byte) ([]byte, error) {
+	req, _ := http.NewRequest(http.MethodPost, c.url, bytes.NewReader(b))
+	req.Header.Add("Authorization", "Bearer "+c.token)
+	req.Header.Add("Content-Type", "application/json")
+	response, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.StatusCode >= 400 {
+		return nil, e.New(fmt.Sprintf("huggingface api request failed: %s", body))
+	}
+	return body, nil
 }
 
 func (c *HuggingfaceModelClient) GetEmbeddings(ctx context.Context, errors []*model.ErrorObject) ([]*model.ErrorObjectEmbeddings, error) {
@@ -150,45 +153,34 @@ func (c *HuggingfaceModelClient) GetEmbeddings(ctx context.Context, errors []*mo
 		combinedInputs = append(combinedInputs, combinedInput)
 	}
 
-	b, err := json.Marshal(HuggingfaceModelInputs{Inputs: combinedInputs})
-	if err != nil {
-		return nil, err
-	}
-	req, _ := http.NewRequest(http.MethodPost, c.url, bytes.NewReader(b))
-	req.Header.Add("Authorization", "Bearer "+c.token)
-	response, err := c.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
+	var results []*model.ErrorObjectEmbeddings
+	for idx, input := range combinedInputs {
+		b, err := json.Marshal(HuggingfaceModelInputs{Inputs: input})
+		if err != nil {
+			return nil, err
+		}
+		body, err := c.makeRequest(b)
+		if err != nil {
+			return nil, err
+		}
 
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, err
-	}
+		var resp struct{ Embeddings []float32 }
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, err
+		}
 
-	if response.StatusCode >= 400 {
-		return nil, e.New(fmt.Sprintf("huggingface api request failed: %s", body))
-	}
-
-	var resp [][]float32
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, err
+		results = append(results, &model.ErrorObjectEmbeddings{
+			ErrorObjectID:     errors[idx].ID,
+			GteLargeEmbedding: resp.Embeddings,
+		})
 	}
 
 	log.WithContext(ctx).
 		WithField("time", time.Since(start)).
-		WithField("body", body).
-		WithField("length", response.ContentLength).
+		WithField("errors", len(errors)).
+		WithField("type", "huggingface").
 		Info("AI embedding generated.")
 
-	var results []*model.ErrorObjectEmbeddings
-	for idx, embedding := range resp {
-		errorObj := errors[idx]
-		results = append(results, &model.ErrorObjectEmbeddings{
-			ErrorObjectID:     errorObj.ID,
-			CombinedEmbedding: embedding,
-		})
-	}
 	return results, nil
 }
 

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -914,7 +914,7 @@ type ErrorGroupingMethod string
 const (
 	ErrorGroupingMethodClassic             ErrorGroupingMethod = "Classic"
 	ErrorGroupingMethodAdaEmbeddingV2      ErrorGroupingMethod = "AdaV2"
-	ErrorGroupingMethodGteLargeEmbeddingV2 ErrorGroupingMethod = "gte-large"
+	ErrorGroupingMethodGteLargeEmbeddingV2 ErrorGroupingMethod = "thenlper/gte-large"
 )
 
 type ErrorObject struct {
@@ -952,11 +952,9 @@ type ErrorObject struct {
 
 type ErrorObjectEmbeddings struct {
 	Model
-	ErrorObjectID       int
-	CombinedEmbedding   Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
-	EventEmbedding      Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
-	StackTraceEmbedding Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
-	PayloadEmbedding    Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
+	ErrorObjectID     int
+	CombinedEmbedding Vector `gorm:"type:vector(1536)"` // 1536 dimensions in the AdaEmbeddingV2 model
+	GteLargeEmbedding Vector `gorm:"type:vector(1024)"` // 1024 dimensions in the thenlper/gte-large model
 }
 
 type ErrorGroup struct {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -912,8 +912,9 @@ type ErrorSegment struct {
 type ErrorGroupingMethod string
 
 const (
-	ErrorGroupingMethodClassic        ErrorGroupingMethod = "Classic"
-	ErrorGroupingMethodAdaEmbeddingV2 ErrorGroupingMethod = "AdaV2"
+	ErrorGroupingMethodClassic             ErrorGroupingMethod = "Classic"
+	ErrorGroupingMethodAdaEmbeddingV2      ErrorGroupingMethod = "AdaV2"
+	ErrorGroupingMethodGteLargeEmbeddingV2 ErrorGroupingMethod = "gte-large"
 )
 
 type ErrorObject struct {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -458,7 +458,7 @@ func (r *Resolver) GetOrCreateErrorGroup(ctx context.Context, errorObj *model.Er
 	return errorGroup, nil
 }
 
-func (r *Resolver) GetTopErrorGroupMatchByEmbedding(ctx context.Context, method model.ErrorGroupingMethod, combinedEmbedding, eventEmbedding, stackTraceEmbedding, payloadEmbedding model.Vector, threshold float64) (*int, error) {
+func (r *Resolver) GetTopErrorGroupMatchByEmbedding(ctx context.Context, method model.ErrorGroupingMethod, embedding model.Vector, threshold float64) (*int, error) {
 	span, _ := tracer.StartSpanFromContext(ctx, "public-resolver", tracer.ResourceName("GetTopErrorGroupMatchByEmbedding"))
 	defer span.Finish()
 
@@ -470,23 +470,24 @@ func (r *Resolver) GetTopErrorGroupMatchByEmbedding(ctx context.Context, method 
 	// an alternative query to consider: for M error objects of every error group,
 	// find the average score. then pick the error group
 	// with the lowest average score.
-	if err := r.DB.Raw(`
-select eoe.combined_embedding <=> @combined_embedding as score,
-       @event_weight * (eoe.event_embedding <=> @event_embedding)
-		   + @trace_weight * (eoe.stack_trace_embedding <=> @stack_trace_embedding)
-		   + @meta_weight * (eoe.payload_embedding <=> @payload_embedding) as combined_score,
+	var column string
+	switch method {
+	case model.ErrorGroupingMethodAdaEmbeddingV2:
+		column = "combined_embedding"
+	case model.ErrorGroupingMethodGteLargeEmbeddingV2:
+		column = "gte_large_embedding"
+	}
+	if err := r.DB.Raw(fmt.Sprintf(`
+select eoe.%s <=> @embedding as score,
        eo.error_group_id                              as error_group_id
 from error_object_embeddings eoe
          inner join error_objects eo on eo.id = eoe.error_object_id
 order by 1
-limit 1;`, map[string]interface{}{
-		"combined_embedding":    combinedEmbedding,
-		"event_embedding":       eventEmbedding,
-		"stack_trace_embedding": stackTraceEmbedding,
-		"payload_embedding":     payloadEmbedding,
-		"event_weight":          1,
-		"trace_weight":          0.4,
-		"meta_weight":           0.2,
+limit 1;`, column), map[string]interface{}{
+		"embedding":    embedding,
+		"event_weight": 1,
+		"trace_weight": 0.4,
+		"meta_weight":  0.2,
 	}).
 		Scan(&result).Error; err != nil {
 		return nil, e.Wrap(err, "error querying top error group match")
@@ -778,7 +779,7 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 		} else {
 			embedding = emb[0]
 			errorGroup, err = r.GetOrCreateErrorGroup(ctx, errorObj, func() (*int, error) {
-				match, err := r.GetTopErrorGroupMatchByEmbedding(ctx, model.ErrorGroupingMethodGteLargeEmbeddingV2, embedding.CombinedEmbedding, embedding.EventEmbedding, embedding.StackTraceEmbedding, embedding.PayloadEmbedding, settings.ErrorEmbeddingsThreshold)
+				match, err := r.GetTopErrorGroupMatchByEmbedding(ctx, model.ErrorGroupingMethodGteLargeEmbeddingV2, embedding.GteLargeEmbedding, settings.ErrorEmbeddingsThreshold)
 				if err != nil {
 					log.WithContext(ctx).WithError(err).WithField("error_object_id", errorObj.ID).Error("failed to group error using embeddings")
 				}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -768,7 +768,7 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 		settings, _ = r.Store.GetAllWorkspaceSettings(ctx, workspace.ID)
 	}
 	var embedding *model.ErrorObjectEmbeddings
-	if util.IsDevEnv() || (settings != nil && settings.ErrorEmbeddingsGroup) {
+	if settings != nil && settings.ErrorEmbeddingsGroup {
 		// keep the classic match as the alternative error group
 		errorGroup, errorGroupAlt = nil, errorGroup
 		emb, err := r.EmbeddingsClient.GetEmbeddings(ctx, []*model.ErrorObject{errorObj})

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -41,11 +41,8 @@ func (c *mockEmbeddingsClient) GetEmbeddings(ctx context.Context, errors []*mode
 	vec[0] += 0.01
 	return []*model.ErrorObjectEmbeddings{
 		{
-			ErrorObjectID:       1,
-			CombinedEmbedding:   vec,
-			EventEmbedding:      vec,
-			StackTraceEmbedding: vec,
-			PayloadEmbedding:    vec,
+			ErrorObjectID:     1,
+			CombinedEmbedding: vec,
 		},
 	}, nil
 }
@@ -150,16 +147,10 @@ func TestHandleErrorAndGroup(t *testing.T) {
 			expectedErrorGroups: []model.ErrorGroup{},
 			embeddingsToInsert: []model.ErrorObjectEmbeddings{
 				{
-					CombinedEmbedding:   vector,
-					EventEmbedding:      vector,
-					StackTraceEmbedding: vector,
-					PayloadEmbedding:    vector,
+					CombinedEmbedding: vector,
 				},
 				{
-					CombinedEmbedding:   vector,
-					EventEmbedding:      vector,
-					StackTraceEmbedding: vector,
-					PayloadEmbedding:    vector,
+					CombinedEmbedding: vector,
 				},
 			},
 			withEmbeddings: pointy.Bool(true),
@@ -321,11 +312,8 @@ func TestHandleErrorAndGroup(t *testing.T) {
 				resolver.DB.Create(&eo)
 
 				embedding := model.ErrorObjectEmbeddings{
-					ErrorObjectID:       eo.ID,
-					CombinedEmbedding:   emb.CombinedEmbedding,
-					EventEmbedding:      emb.EventEmbedding,
-					StackTraceEmbedding: emb.StackTraceEmbedding,
-					PayloadEmbedding:    emb.PayloadEmbedding,
+					ErrorObjectID:     eo.ID,
+					CombinedEmbedding: emb.CombinedEmbedding,
 				}
 				resolver.DB.Create(&embedding)
 			}


### PR DESCRIPTION
## Summary

Switches our OpenAI embeddings usage to a self-hosted huggingface gte-large model.
<img width="1358" alt="image" src="https://github.com/highlight/highlight/assets/1351531/1e9334aa-03dc-4669-b4fc-2192a55112a2">

Starts writing the new vectors and using them to group errors.

## How did you test this change?

Locally grouping errors using new vectors.
<img width="1003" alt="Screenshot 2023-08-17 at 11 56 39 AM" src="https://github.com/highlight/highlight/assets/1351531/a81decb8-8a8e-49e8-b69d-5305ccc8891a">


## Are there any deployment considerations?

Hosted model inference may be slower, but this is only for our project for now. Will monitor.
