### PR TITLE
enable toggling clickhouse for sessions search frontend

### DIFF
--- a/frontend/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder/QueryBuilder.tsx
@@ -53,7 +53,7 @@ import AsyncSelect from 'react-select/async'
 import Creatable from 'react-select/creatable'
 import { Styles } from 'react-select/src/styles'
 import { OptionTypeBase } from 'react-select/src/types'
-import { useToggle } from 'react-use'
+import { useLocalStorage, useToggle } from 'react-use'
 
 import CreateErrorSegmentModal from '@/pages/Errors/ErrorSegmentSidebar/SegmentButtons/CreateErrorSegmentModal'
 import DeleteErrorSegmentModal from '@/pages/Errors/ErrorSegmentSidebar/SegmentPicker/DeleteErrorSegmentModal/DeleteErrorSegmentModal'
@@ -1188,6 +1188,9 @@ export type FetchFieldVariables =
 				field_type: string
 				field_name: string
 				query: string
+				start_date: string
+				end_date: string
+				use_clickhouse: boolean
 			}>
 	  >
 	| undefined
@@ -1259,6 +1262,11 @@ function QueryBuilder(props: QueryBuilderProps) {
 	const { project_id: projectId } = useParams<{
 		project_id: string
 	}>()
+
+	const [useClickhouse] = useLocalStorage(
+		'highlight-session-search-use-clickhouse',
+		false,
+	)
 
 	const { loading: segmentsLoading, data: segmentData } =
 		useGetAnySegmentsQuery({
@@ -1550,6 +1558,9 @@ function QueryBuilder(props: QueryBuilderProps) {
 					field_type: getType(field.value),
 					field_name: label,
 					query: input,
+					start_date: moment(dateRange[0]).toISOString(),
+					end_date: moment(dateRange[1]).toISOString(),
+					use_clickhouse: useClickhouse,
 				}).then((res) => {
 					return res.map((val) => ({
 						label: val,
@@ -1563,6 +1574,8 @@ function QueryBuilder(props: QueryBuilderProps) {
 			fetchFields,
 			getCustomFieldOptions,
 			projectId,
+			dateRange,
+			useClickhouse,
 		],
 	)
 

--- a/frontend/src/pages/FrontPlugin/components/HighlightSessions.tsx
+++ b/frontend/src/pages/FrontPlugin/components/HighlightSessions.tsx
@@ -15,20 +15,29 @@ import { useParams } from '@util/react-router/useParams'
 import { GetBaseURL } from '@util/window'
 import moment from 'moment/moment'
 import React, { useEffect, useState } from 'react'
+import { useLocalStorage } from 'react-use'
 
 function HighlightSessions() {
 	const { setLoadingState } = useAppLoadingContext()
-	const { backendSearchQuery, setSearchQuery } = useSearchContext()
+	const { backendSearchQuery, setSearchQuery, searchQuery } =
+		useSearchContext()
 	const frontContext = useFrontContext()
 	const { project_id } = useParams<{
 		project_id: string
 	}>()
+	const [useClickhouse] = useLocalStorage(
+		'highlight-session-search-use-clickhouse',
+		false,
+	)
 	const { data, called } = useGetSessionsOpenSearchQuery({
 		variables: {
 			project_id: project_id!,
 			count: 100,
 			page: 1,
 			query: backendSearchQuery?.searchQuery || '',
+			clickhouse_query: useClickhouse
+				? JSON.parse(searchQuery)
+				: undefined,
 			sort_desc: true,
 		},
 		skip: !backendSearchQuery || !project_id,

--- a/frontend/src/pages/Player/SessionLevelBar/SessionLevelBarV2.tsx
+++ b/frontend/src/pages/Player/SessionLevelBar/SessionLevelBarV2.tsx
@@ -33,6 +33,7 @@ import { delay } from 'lodash'
 import React, { useEffect, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useNavigate } from 'react-router-dom'
+import { useLocalStorage } from 'react-use'
 
 import { PlayerModeSwitch } from '@/pages/Player/SessionLevelBar/PlayerModeSwitch/PlayerModeSwitch'
 
@@ -55,7 +56,7 @@ export const SessionLevelBarV2: React.FC<
 	}>()
 	const { viewport, currentUrl, sessionResults, setSessionResults, session } =
 		useReplayerContext()
-	const { page, backendSearchQuery } = useSearchContext()
+	const { page, backendSearchQuery, searchQuery } = useSearchContext()
 	const { isLoggedIn } = useAuthContext()
 	const {
 		showLeftPanel,
@@ -64,9 +65,16 @@ export const SessionLevelBarV2: React.FC<
 		setShowRightPanel,
 	} = usePlayerConfiguration()
 	const { rightPanelView, setRightPanelView } = usePlayerUIContext()
+	const [useClickhouse] = useLocalStorage(
+		'highlight-session-search-use-clickhouse',
+		false,
+	)
 	const { data } = useGetSessionsOpenSearchQuery({
 		variables: {
 			query: backendSearchQuery?.searchQuery || '',
+			clickhouse_query: useClickhouse
+				? JSON.parse(searchQuery)
+				: undefined,
 			count: DEFAULT_PAGE_SIZE,
 			page: page && page > 0 ? page : 1,
 			project_id: projectId!,

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/SessionQueryBuilder.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/SessionQueryBuilder.tsx
@@ -8,6 +8,7 @@ import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConf
 import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext'
 import { useParams } from '@util/react-router/useParams'
 import React from 'react'
+import { useLocalStorage } from 'react-use'
 
 import QueryBuilder, {
 	BOOLEAN_OPERATORS,
@@ -153,6 +154,11 @@ const SessionQueryBuilder = React.memo((props: { readonly?: boolean }) => {
 		(rule) => rule.field?.value === TIME_RANGE_FIELD.value,
 	)
 
+	const [useClickhouse] = useLocalStorage(
+		'highlight-session-search-use-clickhouse',
+		false,
+	)
+
 	const startDate = getAbsoluteStartTime(timeRange?.val?.options[0].value)
 	const endDate = getAbsoluteEndTime(timeRange?.val?.options[0].value)
 	const { data: fieldData } = useGetFieldTypesQuery({
@@ -160,6 +166,7 @@ const SessionQueryBuilder = React.memo((props: { readonly?: boolean }) => {
 			project_id: project_id!,
 			start_date: startDate,
 			end_date: endDate,
+			use_clickhouse: useClickhouse,
 		},
 		skip: !project_id,
 	})

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -45,6 +45,7 @@ import { roundFeedDate, serializeAbsoluteTimeRange } from '@util/time'
 import clsx from 'clsx'
 import moment from 'moment'
 import React, { useCallback, useEffect, useRef } from 'react'
+import { useLocalStorage } from 'react-use'
 
 import { AdditionalFeedResults } from '@/components/FeedResults/FeedResults'
 import {
@@ -192,9 +193,17 @@ export const SessionFeedV3 = React.memo(() => {
 		setSearchResultsLoading(false)
 	}
 
+	const [useClickhouse] = useLocalStorage(
+		'highlight-session-search-use-clickhouse',
+		false,
+	)
+
 	const { loading } = useGetSessionsOpenSearchQuery({
 		variables: {
 			query: backendSearchQuery?.searchQuery || '',
+			clickhouse_query: useClickhouse
+				? JSON.parse(searchQuery)
+				: undefined,
 			count: DEFAULT_PAGE_SIZE,
 			page: page && page > 0 ? page : 1,
 			project_id: project_id!,

--- a/frontend/src/pages/Setup/IntegrationBar.tsx
+++ b/frontend/src/pages/Setup/IntegrationBar.tsx
@@ -13,6 +13,7 @@ import { useProjectId } from '@hooks/useProjectId'
 import moment from 'moment'
 import React from 'react'
 import { useLocation } from 'react-router-dom'
+import { useLocalStorage } from 'react-use'
 
 import {
 	useGetErrorGroupsOpenSearchQuery,
@@ -52,10 +53,18 @@ export const IntegrationBar: React.FC<Props> = ({ integrationData }) => {
 	const integrated = integrationData?.integrated
 	const ctaText = CTA_TITLE_MAP[area!]
 
+	const [useClickhouse] = useLocalStorage(
+		'highlight-session-search-use-clickhouse',
+		false,
+	)
+
 	const { data: sessionData } = useGetSessionsOpenSearchQuery({
 		variables: {
 			project_id: projectId,
 			query: '{"match_all": {}}',
+			clickhouse_query: useClickhouse
+				? { isAnd: true, rules: [] }
+				: undefined,
 			count: 1,
 			page: 1,
 			sort_desc: true,


### PR DESCRIPTION
## Summary
- add a `highlight-session-search-use-clickhouse` local storage flag - when set to true, will use clickhouse for sessions / field searching
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- set flag and verified locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
