### PR TITLE
fix: Error Issue Form Values

### DIFF
--- a/frontend/src/components/NewIssueModal/NewIssueModal.tsx
+++ b/frontend/src/components/NewIssueModal/NewIssueModal.tsx
@@ -59,6 +59,18 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 		},
 	})
 
+	React.useEffect(() => {
+		if(!defaultIssueTitle && !commentText ) return
+
+		form.setValues(prev => ({
+			...prev,
+			'issueTitle': defaultIssueTitle,
+			'issueDescription': commentText
+		}))
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [defaultIssueTitle, commentText])
+
 	const [containerId, setContainerId] = useState('')
 
 	const { project_id } = useParams<{
@@ -96,6 +108,12 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 			const issueTitle = form.getValue(form.names.issueTitle)
 			const issueDescription =
 				form.getValue(form.names.issueDescription) ?? ''
+
+			console.log({
+				issueTitle,
+				issueDescription,
+				"submitting": "submitting",
+			})
 
 			const issueTeamId = containerId || ''
 			const text = commentText ?? 'Open in Highlight'


### PR DESCRIPTION
## Summary

The PR introduces a React effect that updates the form's values for `issueTitle` and `issueDescription` whenever `defaultIssueTitle` or `commentText` changes. The update only occurs if either defaultIssueTitle or commentText has a truthy value.

## How did you test this change?

https://github.com/highlight/highlight/assets/31691737/de5a4099-c58e-435f-b2cc-6ece9bf5e1b4

## Are there any deployment considerations?



