### PR TITLE
Fix mismatched graphl peer dep version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
 		"dinero.js": "2.0.0-alpha.14",
 		"firebase": "^9.19.1",
 		"framer-motion": "^6.3.15",
-		"graphql": "^15.5.0",
+		"graphql": "^15.7.2",
 		"highlight.io": "workspace:*",
 		"highlight.run": "workspace:*",
 		"js-cookie": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12802,7 +12802,7 @@ __metadata:
     eslint-plugin-unused-imports: ^1.1.2
     firebase: ^9.19.1
     framer-motion: ^6.3.15
-    graphql: ^15.5.0
+    graphql: ^15.7.2
     happy-dom: ^6.0.4
     highlight.io: "workspace:*"
     highlight.run: "workspace:*"
@@ -35754,10 +35754,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:^15.5.0":
-  version: 15.5.0
-  resolution: "graphql@npm:15.5.0"
-  checksum: 58a69f7274ae94c690bfa2517f96bbaf1327e1ca1fc46606e772ba2f7ca517adeb375346301373351e693022f448b7866163034209623d7c5315819ef8c5e7c0
+"graphql@npm:^15.7.2":
+  version: 15.8.0
+  resolution: "graphql@npm:15.8.0"
+  checksum: 423325271db8858428641b9aca01699283d1fe5b40ef6d4ac622569ecca927019fce8196208b91dd1d8eb8114f00263fe661d241d0eb40c10e5bfd650f86ec5e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


## Summary

`subscriptions-transport-ws` has a peer dependency on `graphql` specified as `graphql: ^15.7.2 || ^16.0.0`, which is incompatible with the range `^15.5.0` specified in frontend.

This made the dep tree unresolvable if we adhered to the versions specified in yarn.lock when I tested out the new yarn lockfile sync feature on the highlight repo locally. Bumping to ^15.7.2 resolves the issue.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
