### PR TITLE
add new hubspot company fields

### DIFF
--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -94,15 +94,23 @@ func getDomain(adminEmail string) (domain string) {
 	return
 }
 
-type HubspotApi struct {
+type Api interface {
+	CreateContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) error
+	CreateCompanyForWorkspace(ctx context.Context, workspaceID int, adminEmail string, name string) error
+	CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int) error
+	UpdateContactProperty(ctx context.Context, adminID int, properties []hubspot.Property) error
+	UpdateCompanyProperty(ctx context.Context, workspaceID int, properties []hubspot.Property) error
+}
+
+type Client struct {
 	db            *gorm.DB
 	hubspotClient hubspot.Client
 	redisClient   *redis.Client
 	kafkaProducer *kafka_queue.Queue
 }
 
-func NewHubspotAPI(client hubspot.Client, db *gorm.DB, redisClient *redis.Client, kafkaProducer *kafka_queue.Queue) *HubspotApi {
-	return &HubspotApi{
+func NewHubspotAPI(client hubspot.Client, db *gorm.DB, redisClient *redis.Client, kafkaProducer *kafka_queue.Queue) *Client {
+	return &Client{
 		db:            db,
 		hubspotClient: client,
 		redisClient:   redisClient,
@@ -201,7 +209,7 @@ type DoppelgangersResponse struct {
 	LastScoredTimestamp int64                             `json:"lastScoredTimestamp"`
 }
 
-func (h *HubspotApi) doRequest(url string, result interface{}, params map[string]string, method string, b io.Reader) error {
+func (h *Client) doRequest(url string, result interface{}, params map[string]string, method string, b io.Reader) error {
 	req, _ := http.NewRequest(method, fmt.Sprintf("https://api.hubapi.com%s", url), b)
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
@@ -249,7 +257,7 @@ func (h *HubspotApi) doRequest(url string, result interface{}, params map[string
 	return nil
 }
 
-func (h *HubspotApi) getDoppelgangers(ctx context.Context) (results []*DoppelgangersResult, objects map[int]*DoppelgangersObject, err error) {
+func (h *Client) getDoppelgangers(ctx context.Context) (results []*DoppelgangersResult, objects map[int]*DoppelgangersObject, err error) {
 	objects = make(map[int]*DoppelgangersObject)
 	for {
 		r := DoppelgangersResponse{}
@@ -293,19 +301,19 @@ func (h *HubspotApi) getDoppelgangers(ctx context.Context) (results []*Doppelgan
 	return
 }
 
-func (h *HubspotApi) mergeCompanies(keepID, mergeID int) error {
+func (h *Client) mergeCompanies(keepID, mergeID int) error {
 	return h.doRequest(fmt.Sprintf("/companies/v2/companies/%d/merge", keepID), nil, map[string]string{
 		"portalId": "20473940",
 	}, "PUT", strings.NewReader(fmt.Sprintf(`{"companyIdToMerge":%d}`, mergeID)))
 }
 
-func (h *HubspotApi) mergeContacts(keepID, mergeID int) error {
+func (h *Client) mergeContacts(keepID, mergeID int) error {
 	return h.doRequest(fmt.Sprintf("/contacts/v1/contact/%d/merge", keepID), nil, map[string]string{
 		"portalId": "20473940",
 	}, "POST", strings.NewReader(fmt.Sprintf(`{"vidToMerge":%d}`, mergeID)))
 }
 
-func (h *HubspotApi) getAllCompanies(ctx context.Context) (companies []*CompanyResponse, err error) {
+func (h *Client) getAllCompanies(ctx context.Context) (companies []*CompanyResponse, err error) {
 	span, _ := tracer.StartSpanFromContext(ctx, "hubspot.getAllCompanies")
 	defer span.Finish()
 	if h.redisClient != nil {
@@ -333,7 +341,7 @@ func (h *HubspotApi) getAllCompanies(ctx context.Context) (companies []*CompanyR
 	return
 }
 
-func (h *HubspotApi) getCompany(ctx context.Context, name, domain string) (*int, error) {
+func (h *Client) getCompany(ctx context.Context, name, domain string) (*int, error) {
 	r := struct {
 		Results []struct {
 			CompanyId int `json:"companyId"`
@@ -378,7 +386,7 @@ func (h *HubspotApi) getCompany(ctx context.Context, name, domain string) (*int,
 	}
 }
 
-func (h *HubspotApi) getContactForAdmin(email string) (contactId *int, err error) {
+func (h *Client) getContactForAdmin(email string) (contactId *int, err error) {
 	r := CustomContactsResponse{}
 	if err := h.hubspotClient.Contacts().Client.Request("GET", "/contacts/v1/contact/email/"+email+"/profile", nil, &r); err != nil {
 		return nil, err
@@ -387,7 +395,7 @@ func (h *HubspotApi) getContactForAdmin(email string) (contactId *int, err error
 	}
 }
 
-func (h *HubspotApi) createContactForAdmin(ctx context.Context, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
+func (h *Client) createContactForAdmin(ctx context.Context, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
 	var hubspotContactId int
 	if resp, err := h.hubspotClient.Contacts().Create(hubspot.ContactsRequest{
 		Properties: []hubspot.Property{
@@ -440,7 +448,7 @@ func (h *HubspotApi) createContactForAdmin(ctx context.Context, email string, us
 	return &hubspotContactId, nil
 }
 
-func (h *HubspotApi) CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int) error {
+func (h *Client) CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int) error {
 	return h.kafkaProducer.Submit(ctx, PartitionKey, &kafka_queue.Message{
 		Type: kafka_queue.HubSpotCreateContactCompanyAssociation,
 		HubSpotCreateContactCompanyAssociation: &kafka_queue.HubSpotCreateContactCompanyAssociationArgs{
@@ -450,7 +458,7 @@ func (h *HubspotApi) CreateContactCompanyAssociation(ctx context.Context, adminI
 	})
 }
 
-func (h *HubspotApi) CreateContactCompanyAssociationImpl(ctx context.Context, adminID int, workspaceID int) error {
+func (h *Client) CreateContactCompanyAssociationImpl(ctx context.Context, adminID int, workspaceID int) error {
 	key := fmt.Sprintf("hubspot-CreateContactCompanyAssociationImpl-%d-%d", adminID, workspaceID)
 	if mutex, err := h.redisClient.AcquireLock(ctx, key, ClientSideAssociationTimeout); err == nil {
 		defer func() {
@@ -504,7 +512,7 @@ func (h *HubspotApi) CreateContactCompanyAssociationImpl(ctx context.Context, ad
 	return nil
 }
 
-func (h *HubspotApi) CreateContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) error {
+func (h *Client) CreateContactForAdmin(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) error {
 	return h.kafkaProducer.Submit(ctx, PartitionKey, &kafka_queue.Message{
 		Type: kafka_queue.HubSpotCreateContactForAdmin,
 		HubSpotCreateContactForAdmin: &kafka_queue.HubSpotCreateContactForAdminArgs{
@@ -520,7 +528,7 @@ func (h *HubspotApi) CreateContactForAdmin(ctx context.Context, adminID int, ema
 	})
 }
 
-func (h *HubspotApi) CreateContactForAdminImpl(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
+func (h *Client) CreateContactForAdminImpl(ctx context.Context, adminID int, email string, userDefinedRole string, userDefinedPersona string, first string, last string, phone string, referral string) (contactId *int, err error) {
 	key := fmt.Sprintf("hubspot-CreateContactForAdminImpl-%d", adminID)
 	if mutex, err := h.redisClient.AcquireLock(ctx, key, ClientSideContactCreationTimeout); err == nil {
 		defer func() {
@@ -553,7 +561,7 @@ func (h *HubspotApi) CreateContactForAdminImpl(ctx context.Context, adminID int,
 	return
 }
 
-func (h *HubspotApi) CreateCompanyForWorkspace(ctx context.Context, workspaceID int, adminEmail string, name string) error {
+func (h *Client) CreateCompanyForWorkspace(ctx context.Context, workspaceID int, adminEmail string, name string) error {
 	return h.kafkaProducer.Submit(ctx, PartitionKey, &kafka_queue.Message{
 		Type: kafka_queue.HubSpotCreateCompanyForWorkspace,
 		HubSpotCreateCompanyForWorkspace: &kafka_queue.HubSpotCreateCompanyForWorkspaceArgs{
@@ -564,7 +572,7 @@ func (h *HubspotApi) CreateCompanyForWorkspace(ctx context.Context, workspaceID 
 	})
 }
 
-func (h *HubspotApi) CreateCompanyForWorkspaceImpl(ctx context.Context, workspaceID int, adminEmail, name string) (companyID *int, err error) {
+func (h *Client) CreateCompanyForWorkspaceImpl(ctx context.Context, workspaceID int, adminEmail, name string) (companyID *int, err error) {
 	key := fmt.Sprintf("hubspot-CreateCompanyForWorkspaceImpl-%d-%s-%s", workspaceID, adminEmail, name)
 	if mutex, err := h.redisClient.AcquireLock(ctx, key, ClientSideCompanyCreationTimeout); err == nil {
 		defer func() {
@@ -634,7 +642,7 @@ func (h *HubspotApi) CreateCompanyForWorkspaceImpl(ctx context.Context, workspac
 	return
 }
 
-func (h *HubspotApi) UpdateContactProperty(ctx context.Context, adminID int, properties []hubspot.Property) error {
+func (h *Client) UpdateContactProperty(ctx context.Context, adminID int, properties []hubspot.Property) error {
 	return h.kafkaProducer.Submit(ctx, PartitionKey, &kafka_queue.Message{
 		Type: kafka_queue.HubSpotUpdateContactProperty,
 		HubSpotUpdateContactProperty: &kafka_queue.HubSpotUpdateContactPropertyArgs{
@@ -644,7 +652,7 @@ func (h *HubspotApi) UpdateContactProperty(ctx context.Context, adminID int, pro
 	})
 }
 
-func (h *HubspotApi) UpdateContactPropertyImpl(ctx context.Context, adminID int, properties []hubspot.Property) error {
+func (h *Client) UpdateContactPropertyImpl(ctx context.Context, adminID int, properties []hubspot.Property) error {
 	key := fmt.Sprintf("hubspot-UpdateContactPropertyImpl-%d", adminID)
 	if mutex, err := h.redisClient.AcquireLock(ctx, key, DefaultLockTimeout); err == nil {
 		defer func() {
@@ -676,7 +684,7 @@ func (h *HubspotApi) UpdateContactPropertyImpl(ctx context.Context, adminID int,
 	return nil
 }
 
-func (h *HubspotApi) UpdateCompanyProperty(ctx context.Context, workspaceID int, properties []hubspot.Property) error {
+func (h *Client) UpdateCompanyProperty(ctx context.Context, workspaceID int, properties []hubspot.Property) error {
 	return h.kafkaProducer.Submit(ctx, PartitionKey, &kafka_queue.Message{
 		Type: kafka_queue.HubSpotUpdateCompanyProperty,
 		HubSpotUpdateCompanyProperty: &kafka_queue.HubSpotUpdateCompanyPropertyArgs{
@@ -686,7 +694,7 @@ func (h *HubspotApi) UpdateCompanyProperty(ctx context.Context, workspaceID int,
 	})
 }
 
-func (h *HubspotApi) UpdateCompanyPropertyImpl(ctx context.Context, workspaceID int, properties []hubspot.Property) error {
+func (h *Client) UpdateCompanyPropertyImpl(ctx context.Context, workspaceID int, properties []hubspot.Property) error {
 	key := fmt.Sprintf("hubspot-UpdateCompanyPropertyImpl-%d", workspaceID)
 	if mutex, err := h.redisClient.AcquireLock(ctx, key, DefaultLockTimeout); err == nil {
 		defer func() {

--- a/backend/hubspot/merge.go
+++ b/backend/hubspot/merge.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func MergeSimilarCompanies(ctx context.Context, h *HubspotApi) error {
+func MergeSimilarCompanies(ctx context.Context, h *Client) error {
 	time.Sleep(time.Second * 10)
 	results, objects, err := h.getDoppelgangers(ctx)
 	if err != nil {
@@ -124,14 +124,14 @@ func compareCompanies(ctx context.Context, c1, c2 *DoppelgangersObject) bool {
 	}
 }
 
-func MergeCompanies(ctx context.Context, h *HubspotApi, keep, merge *DoppelgangersObject) {
+func MergeCompanies(ctx context.Context, h *Client, keep, merge *DoppelgangersObject) {
 	log.WithContext(ctx).Infof("merging %d into %d", merge.ObjectID, keep.ObjectID)
 	if err := h.mergeCompanies(keep.ObjectID, merge.ObjectID); err != nil {
 		log.WithContext(ctx).WithError(err).Errorf("failed to merge %d into %d", merge.ObjectID, keep.ObjectID)
 	}
 }
 
-func MergeContacts(ctx context.Context, h *HubspotApi, keep, merge *DoppelgangersObject) {
+func MergeContacts(ctx context.Context, h *Client, keep, merge *DoppelgangersObject) {
 	log.WithContext(ctx).Infof("merging %d into %d", merge.ObjectID, keep.ObjectID)
 	if err := h.mergeContacts(keep.ObjectID, merge.ObjectID); err != nil {
 		log.WithContext(ctx).WithError(err).Errorf("failed to merge %d into %d", merge.ObjectID, keep.ObjectID)

--- a/backend/main.go
+++ b/backend/main.go
@@ -632,7 +632,7 @@ func main() {
 			}()
 			// for the 'All' worker, explicitly run the PublicWorker as well
 			go w.PublicWorker(ctx)
-			// in `all` mode, refresh materialized views every hour
+			// in `all` mode, report stripe usage every hour
 			go func() {
 				w.ReportStripeUsage(ctx)
 				for range time.Tick(time.Hour) {

--- a/backend/main.go
+++ b/backend/main.go
@@ -634,6 +634,13 @@ func main() {
 			go w.PublicWorker(ctx)
 			// in `all` mode, refresh materialized views every hour
 			go func() {
+				w.ReportStripeUsage(ctx)
+				for range time.Tick(time.Hour) {
+					w.ReportStripeUsage(ctx)
+				}
+			}()
+			// in `all` mode, refresh materialized views every hour
+			go func() {
 				w.RefreshMaterializedViews(ctx)
 				for range time.Tick(time.Hour) {
 					w.RefreshMaterializedViews(ctx)

--- a/backend/model/pricing.go
+++ b/backend/model/pricing.go
@@ -1,18 +1,18 @@
 package model
 
-type ProductType string
+type PricingProductType string
 
 const (
-	ProductTypeBase     ProductType = "BASE"
-	ProductTypeMembers  ProductType = "MEMBERS"
-	ProductTypeSessions ProductType = "SESSIONS"
-	ProductTypeErrors   ProductType = "ERRORS"
-	ProductTypeLogs     ProductType = "LOGS"
+	PricingProductTypeBase     PricingProductType = "BASE"
+	PricingProductTypeMembers  PricingProductType = "MEMBERS"
+	PricingProductTypeSessions PricingProductType = "SESSIONS"
+	PricingProductTypeErrors   PricingProductType = "ERRORS"
+	PricingProductTypeLogs     PricingProductType = "LOGS"
 )
 
-type SubscriptionInterval string
+type PricingSubscriptionInterval string
 
 const (
-	SubscriptionIntervalMonthly SubscriptionInterval = "MONTHLY"
-	SubscriptionIntervalAnnual  SubscriptionInterval = "ANNUAL"
+	PricingSubscriptionIntervalMonthly PricingSubscriptionInterval = "MONTHLY"
+	PricingSubscriptionIntervalAnnual  PricingSubscriptionInterval = "ANNUAL"
 )

--- a/backend/model/pricing.go
+++ b/backend/model/pricing.go
@@ -1,0 +1,18 @@
+package model
+
+type ProductType string
+
+const (
+	ProductTypeBase     ProductType = "BASE"
+	ProductTypeMembers  ProductType = "MEMBERS"
+	ProductTypeSessions ProductType = "SESSIONS"
+	ProductTypeErrors   ProductType = "ERRORS"
+	ProductTypeLogs     ProductType = "LOGS"
+)
+
+type SubscriptionInterval string
+
+const (
+	SubscriptionIntervalMonthly SubscriptionInterval = "MONTHLY"
+	SubscriptionIntervalAnnual  SubscriptionInterval = "ANNUAL"
+)

--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -9,14 +9,17 @@ import (
 
 	"github.com/highlight-run/highlight/backend/clickhouse"
 	"github.com/highlight-run/highlight/backend/email"
+	hubspotApi "github.com/highlight-run/highlight/backend/hubspot"
 	"github.com/highlight-run/highlight/backend/model"
 	backend "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/highlight-run/highlight/backend/util"
+	"github.com/leonelquinteros/hubspot"
 	"github.com/openlyinc/pointy"
 	e "github.com/pkg/errors"
 	"github.com/samber/lo"
 	"github.com/sendgrid/sendgrid-go"
 	log "github.com/sirupsen/logrus"
-	stripe "github.com/stripe/stripe-go/v72"
+	"github.com/stripe/stripe-go/v72"
 	"github.com/stripe/stripe-go/v72/client"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gorm.io/gorm"
@@ -27,23 +30,6 @@ const (
 	highlightProductTier             string = "highlightProductTier"
 	highlightProductUnlimitedMembers string = "highlightProductUnlimitedMembers"
 	highlightRetentionPeriod         string = "highlightRetentionPeriod"
-)
-
-type ProductType string
-
-const (
-	ProductTypeBase     ProductType = "BASE"
-	ProductTypeMembers  ProductType = "MEMBERS"
-	ProductTypeSessions ProductType = "SESSIONS"
-	ProductTypeErrors   ProductType = "ERRORS"
-	ProductTypeLogs     ProductType = "LOGS"
-)
-
-type SubscriptionInterval string
-
-const (
-	SubscriptionIntervalMonthly SubscriptionInterval = "MONTHLY"
-	SubscriptionIntervalAnnual  SubscriptionInterval = "ANNUAL"
 )
 
 func GetWorkspaceMembersMeter(DB *gorm.DB, workspaceID int) int64 {
@@ -199,7 +185,7 @@ func GetWorkspaceLogsMeter(ctx context.Context, DB *gorm.DB, ccClient *clickhous
 	return int64(count), nil
 }
 
-func GetLimitAmount(limitCostCents *int, productType ProductType, planType backend.PlanType, retentionPeriod backend.RetentionPeriod) *int64 {
+func GetLimitAmount(limitCostCents *int, productType model.ProductType, planType backend.PlanType, retentionPeriod backend.RetentionPeriod) *int64 {
 	included := int64(IncludedAmount(planType, productType))
 	if planType == backend.PlanTypeFree {
 		return pointy.Int64(included)
@@ -214,25 +200,25 @@ func GetLimitAmount(limitCostCents *int, productType ProductType, planType backe
 		float64(*limitCostCents)/basePrice/retentionMultiplier) + included)
 }
 
-func ProductToBasePriceCents(productType ProductType, planType backend.PlanType) float64 {
+func ProductToBasePriceCents(productType model.ProductType, planType backend.PlanType) float64 {
 	if planType == backend.PlanTypeUsageBased {
 		switch productType {
-		case ProductTypeSessions:
+		case model.ProductTypeSessions:
 			return 2
-		case ProductTypeErrors:
+		case model.ProductTypeErrors:
 			return .02
-		case ProductTypeLogs:
+		case model.ProductTypeLogs:
 			return .00015
 		default:
 			return 0
 		}
 	} else {
 		switch productType {
-		case ProductTypeSessions:
+		case model.ProductTypeSessions:
 			return .5
-		case ProductTypeErrors:
+		case model.ProductTypeErrors:
 			return .02
-		case ProductTypeLogs:
+		case model.ProductTypeLogs:
 			return .00015
 		default:
 			return 0
@@ -275,13 +261,13 @@ func TypeToMemberLimit(planType backend.PlanType, unlimitedMembers bool) *int {
 	}
 }
 
-func IncludedAmount(planType backend.PlanType, productType ProductType) int {
+func IncludedAmount(planType backend.PlanType, productType model.ProductType) int {
 	switch productType {
-	case ProductTypeSessions:
+	case model.ProductTypeSessions:
 		return TypeToSessionsLimit(planType)
-	case ProductTypeErrors:
+	case model.ProductTypeErrors:
 		return TypeToErrorsLimit(planType)
-	case ProductTypeLogs:
+	case model.ProductTypeLogs:
 		return TypeToLogsLimit(planType)
 	default:
 		return 0
@@ -360,11 +346,11 @@ func MustUpgradeForClearbit(tier string) bool {
 }
 
 // Returns a Stripe lookup key which maps to a single Stripe Price
-func GetBaseLookupKey(productTier backend.PlanType, interval SubscriptionInterval, unlimitedMembers bool, retentionPeriod backend.RetentionPeriod) (result string) {
+func GetBaseLookupKey(productTier backend.PlanType, interval model.SubscriptionInterval, unlimitedMembers bool, retentionPeriod backend.RetentionPeriod) (result string) {
 	if productTier == backend.PlanTypeUsageBased {
-		return fmt.Sprintf("%s|%s", ProductTypeBase, backend.PlanTypeUsageBased)
+		return fmt.Sprintf("%s|%s", model.ProductTypeBase, backend.PlanTypeUsageBased)
 	}
-	result = fmt.Sprintf("%s|%s|%s", ProductTypeBase, string(productTier), string(interval))
+	result = fmt.Sprintf("%s|%s|%s", model.ProductTypeBase, string(productTier), string(interval))
 	if unlimitedMembers {
 		result += "|UNLIMITED_MEMBERS"
 	}
@@ -374,22 +360,22 @@ func GetBaseLookupKey(productTier backend.PlanType, interval SubscriptionInterva
 	return
 }
 
-func GetOverageKey(productType ProductType, retentionPeriod backend.RetentionPeriod, planType backend.PlanType) string {
+func GetOverageKey(productType model.ProductType, retentionPeriod backend.RetentionPeriod, planType backend.PlanType) string {
 	result := string(productType)
 	if retentionPeriod != backend.RetentionPeriodThreeMonths {
 		result += "|" + string(retentionPeriod)
 	}
-	if productType == ProductTypeSessions && planType == backend.PlanTypeUsageBased {
+	if productType == model.ProductTypeSessions && planType == backend.PlanTypeUsageBased {
 		result += "|UsageBased"
 	}
 	return result
 }
 
-// Returns the Highlight ProductType, Tier, and Interval for the Stripe Price
-func GetProductMetadata(price *stripe.Price) (*ProductType, *backend.PlanType, bool, SubscriptionInterval, backend.RetentionPeriod) {
-	interval := SubscriptionIntervalMonthly
+// Returns the Highlight model.ProductType, Tier, and Interval for the Stripe Price
+func GetProductMetadata(price *stripe.Price) (*model.ProductType, *backend.PlanType, bool, model.SubscriptionInterval, backend.RetentionPeriod) {
+	interval := model.SubscriptionIntervalMonthly
 	if price.Recurring != nil && price.Recurring.Interval == stripe.PriceRecurringIntervalYear {
-		interval = SubscriptionIntervalAnnual
+		interval = model.SubscriptionIntervalAnnual
 	}
 
 	retentionPeriod := backend.RetentionPeriodSixMonths
@@ -398,15 +384,15 @@ func GetProductMetadata(price *stripe.Price) (*ProductType, *backend.PlanType, b
 	// return it for backward compatibility
 	oldTier := FromPriceID(price.ID)
 	if oldTier != backend.PlanTypeFree {
-		base := ProductTypeBase
+		base := model.ProductTypeBase
 		return &base, &oldTier, false, interval, retentionPeriod
 	}
 
-	var productTypePtr *ProductType
+	var productTypePtr *model.ProductType
 	var tierPtr *backend.PlanType
 
 	if typeStr, ok := price.Product.Metadata[highlightProductType]; ok {
-		productType := ProductType(typeStr)
+		productType := model.ProductType(typeStr)
 		productTypePtr = &productType
 	}
 
@@ -460,7 +446,7 @@ func FillProducts(stripeClient *client.API, subscriptions []*stripe.Subscription
 }
 
 // Returns the Stripe Prices for the associated tier and interval
-func GetStripePrices(stripeClient *client.API, productTier backend.PlanType, interval SubscriptionInterval, unlimitedMembers bool, retentionPeriod *backend.RetentionPeriod) (map[ProductType]*stripe.Price, error) {
+func GetStripePrices(stripeClient *client.API, productTier backend.PlanType, interval model.SubscriptionInterval, unlimitedMembers bool, retentionPeriod *backend.RetentionPeriod) (map[model.ProductType]*stripe.Price, error) {
 	// Default to the `RetentionPeriodThreeMonths` prices for customers grandfathered into 6 month retention
 	rp := backend.RetentionPeriodThreeMonths
 	if retentionPeriod != nil {
@@ -468,10 +454,10 @@ func GetStripePrices(stripeClient *client.API, productTier backend.PlanType, int
 	}
 	baseLookupKey := GetBaseLookupKey(productTier, interval, unlimitedMembers, rp)
 
-	sessionsLookupKey := GetOverageKey(ProductTypeSessions, rp, productTier)
-	membersLookupKey := string(ProductTypeMembers)
-	errorsLookupKey := GetOverageKey(ProductTypeErrors, rp, productTier)
-	logsLookupKey := string(ProductTypeLogs)
+	sessionsLookupKey := GetOverageKey(model.ProductTypeSessions, rp, productTier)
+	membersLookupKey := string(model.ProductTypeMembers)
+	errorsLookupKey := GetOverageKey(model.ProductTypeErrors, rp, productTier)
+	logsLookupKey := string(model.ProductTypeLogs)
 
 	priceListParams := stripe.PriceListParams{}
 	priceListParams.LookupKeys = []*string{&baseLookupKey, &sessionsLookupKey, &membersLookupKey, &errorsLookupKey, &logsLookupKey}
@@ -490,19 +476,19 @@ func GetStripePrices(stripeClient *client.API, productTier backend.PlanType, int
 		return nil, e.Errorf("expected %d prices, received %d; searched %#v, found %#v", expected, actual, searchedKeys, foundKeys)
 	}
 
-	priceMap := map[ProductType]*stripe.Price{}
+	priceMap := map[model.ProductType]*stripe.Price{}
 	for _, price := range prices {
 		switch price.LookupKey {
 		case baseLookupKey:
-			priceMap[ProductTypeBase] = price
+			priceMap[model.ProductTypeBase] = price
 		case sessionsLookupKey:
-			priceMap[ProductTypeSessions] = price
+			priceMap[model.ProductTypeSessions] = price
 		case membersLookupKey:
-			priceMap[ProductTypeMembers] = price
+			priceMap[model.ProductTypeMembers] = price
 		case errorsLookupKey:
-			priceMap[ProductTypeErrors] = price
+			priceMap[model.ProductTypeErrors] = price
 		case logsLookupKey:
-			priceMap[ProductTypeLogs] = price
+			priceMap[model.ProductTypeLogs] = price
 		}
 	}
 
@@ -513,17 +499,35 @@ func GetStripePrices(stripeClient *client.API, productTier backend.PlanType, int
 	return priceMap, nil
 }
 
-func ReportUsageForWorkspace(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, stripeClient *client.API, mailClient *sendgrid.Client, workspaceID int) error {
-	return reportUsage(ctx, DB, ccClient, stripeClient, mailClient, workspaceID, nil)
+type Worker struct {
+	db           *gorm.DB
+	ccClient     *clickhouse.Client
+	stripeClient *client.API
+	mailClient   *sendgrid.Client
+	hs           hubspotApi.Api
 }
 
-func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, stripeClient *client.API, mailClient *sendgrid.Client, workspaceID int, productType *ProductType) error {
+func NewWorker(db *gorm.DB, ccClient *clickhouse.Client, stripeClient *client.API, mailClient *sendgrid.Client, hs hubspotApi.Api) *Worker {
+	return &Worker{
+		db:           db,
+		ccClient:     ccClient,
+		stripeClient: stripeClient,
+		mailClient:   mailClient,
+		hs:           hs,
+	}
+}
+
+func (w *Worker) ReportUsageForWorkspace(ctx context.Context, workspaceID int) error {
+	return w.reportUsage(ctx, workspaceID, nil)
+}
+
+func (w *Worker) reportUsage(ctx context.Context, workspaceID int, productType *model.ProductType) error {
 	var workspace model.Workspace
-	if err := DB.Model(&workspace).Where("id = ?", workspaceID).Take(&workspace).Error; err != nil {
+	if err := w.db.Model(&workspace).Where("id = ?", workspaceID).Take(&workspace).Error; err != nil {
 		return e.Wrap(err, "error querying workspace")
 	}
 	var projects []model.Project
-	if err := DB.Model(&model.Project{}).Where("workspace_id = ?", workspaceID).Find(&projects).Error; err != nil {
+	if err := w.db.Model(&model.Project{}).Where("workspace_id = ?", workspaceID).Find(&projects).Error; err != nil {
 		return e.Wrap(err, "error querying projects in workspace")
 	}
 	workspace.Projects = projects
@@ -533,12 +537,12 @@ func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, 
 	if workspace.TrialEndDate != nil && workspace.TrialEndDate.After(time.Now().AddDate(0, 0, -7)) {
 		if workspace.TrialEndDate.Before(time.Now()) {
 			// If the trial has ended, send an email
-			if err := model.SendBillingNotifications(ctx, DB, mailClient, email.BillingHighlightTrialEnded, &workspace); err != nil {
+			if err := model.SendBillingNotifications(ctx, w.db, w.mailClient, email.BillingHighlightTrialEnded, &workspace); err != nil {
 				log.WithContext(ctx).Error(e.Wrap(err, "failed to send billing notifications"))
 			}
 		} else if workspace.TrialEndDate.Before(time.Now().AddDate(0, 0, 7)) {
 			// If the trial is ending within 7 days, send an email
-			if err := model.SendBillingNotifications(ctx, DB, mailClient, email.BillingHighlightTrial7Days, &workspace); err != nil {
+			if err := model.SendBillingNotifications(ctx, w.db, w.mailClient, email.BillingHighlightTrial7Days, &workspace); err != nil {
 				log.WithContext(ctx).Error(e.Wrap(err, "failed to send billing notifications"))
 			}
 		}
@@ -560,7 +564,7 @@ func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, 
 	customerParams.AddExpand("subscriptions")
 	customerParams.AddExpand("subscriptions.data.discount")
 	customerParams.AddExpand("subscriptions.data.discount.coupon")
-	c, err := stripeClient.Customers.Get(*workspace.StripeCustomerID, customerParams)
+	c, err := w.stripeClient.Customers.Get(*workspace.StripeCustomerID, customerParams)
 	if err != nil {
 		return e.Wrap(err, "couldn't retrieve stripe customer data")
 	}
@@ -573,7 +577,7 @@ func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, 
 	}
 
 	subscriptions := c.Subscriptions.Data
-	FillProducts(stripeClient, subscriptions)
+	FillProducts(w.stripeClient, subscriptions)
 
 	subscription := subscriptions[0]
 
@@ -594,21 +598,21 @@ func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, 
 		subscriptionEnd := time.Unix(subscription.Discount.End, 0)
 		if subscriptionEnd.Before(time.Now().AddDate(0, 0, 3)) {
 			// If the Stripe trial is ending within 3 days, send an email
-			if err := model.SendBillingNotifications(ctx, DB, mailClient, email.BillingStripeTrial3Days, &workspace); err != nil {
+			if err := model.SendBillingNotifications(ctx, w.db, w.mailClient, email.BillingStripeTrial3Days, &workspace); err != nil {
 				log.WithContext(ctx).Error(e.Wrap(err, "failed to send billing notifications"))
 			}
 		} else if subscriptionEnd.Before(time.Now().AddDate(0, 0, 7)) {
 			// If the Stripe trial is ending within 7 days, send an email
-			if err := model.SendBillingNotifications(ctx, DB, mailClient, email.BillingStripeTrial7Days, &workspace); err != nil {
+			if err := model.SendBillingNotifications(ctx, w.db, w.mailClient, email.BillingStripeTrial7Days, &workspace); err != nil {
 				log.WithContext(ctx).Error(e.Wrap(err, "failed to send billing notifications"))
 			}
 		}
 	}
 
 	// For annual subscriptions, set PendingInvoiceItemInterval to 'month' if not set
-	if interval == SubscriptionIntervalAnnual &&
+	if interval == model.SubscriptionIntervalAnnual &&
 		subscription.PendingInvoiceItemInterval.Interval != stripe.SubscriptionPendingInvoiceItemIntervalIntervalMonth {
-		updated, err := stripeClient.Subscriptions.Update(subscription.ID, &stripe.SubscriptionParams{
+		updated, err := w.stripeClient.Subscriptions.Update(subscription.ID, &stripe.SubscriptionParams{
 			PendingInvoiceItemInterval: &stripe.SubscriptionPendingInvoiceItemIntervalParams{
 				Interval: stripe.String(string(stripe.SubscriptionPendingInvoiceItemIntervalIntervalMonth)),
 			},
@@ -619,7 +623,7 @@ func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, 
 
 		if updated.NextPendingInvoiceItemInvoice != 0 {
 			timestamp := time.Unix(updated.NextPendingInvoiceItemInvoice, 0)
-			if err := DB.Model(&workspace).Where("id = ?", workspaceID).
+			if err := w.db.Model(&workspace).Where("id = ?", workspaceID).
 				Updates(&model.Workspace{
 					NextInvoiceDate: &timestamp,
 				}).Error; err != nil {
@@ -628,7 +632,7 @@ func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, 
 		}
 	}
 
-	prices, err := GetStripePrices(stripeClient, *productTier, interval, workspace.UnlimitedMembers, workspace.RetentionPeriod)
+	prices, err := GetStripePrices(w.stripeClient, *productTier, interval, workspace.UnlimitedMembers, workspace.RetentionPeriod)
 	if err != nil {
 		return e.Wrap(err, "STRIPE_INTEGRATION_ERROR cannot report usage - failed to get Stripe prices")
 	}
@@ -639,7 +643,7 @@ func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, 
 	}
 	invoiceParams.AddExpand("lines.data.price.product")
 
-	invoice, err := stripeClient.Invoices.GetNext(invoiceParams)
+	invoice, err := w.stripeClient.Invoices.GetNext(invoiceParams)
 	// Cancelled subscriptions have no upcoming invoice - we can skip these since we won't
 	// be charging any overage for their next billing period.
 	if err != nil {
@@ -651,7 +655,7 @@ func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, 
 		}
 	}
 
-	invoiceLines := map[ProductType]*stripe.InvoiceLine{}
+	invoiceLines := map[model.ProductType]*stripe.InvoiceLine{}
 	for _, line := range invoice.Lines.Data {
 		productType, _, _, _, _ := GetProductMetadata(line.Price)
 		if productType != nil {
@@ -660,17 +664,17 @@ func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, 
 	}
 
 	// Update members overage
-	membersMeter := GetWorkspaceMembersMeter(DB, workspaceID)
+	membersMeter := GetWorkspaceMembersMeter(w.db, workspaceID)
 	membersLimit := TypeToMemberLimit(backend.PlanType(workspace.PlanTier), workspace.UnlimitedMembers)
 	if membersLimit != nil && workspace.MonthlyMembersLimit != nil {
 		membersLimit = workspace.MonthlyMembersLimit
 	}
-	if err := AddOrUpdateOverageItem(stripeClient, &workspace, prices[ProductTypeMembers], invoiceLines[ProductTypeMembers], c, subscription, membersLimit, membersMeter); err != nil {
+	if err := AddOrUpdateOverageItem(w.stripeClient, &workspace, prices[model.ProductTypeMembers], invoiceLines[model.ProductTypeMembers], c, subscription, membersLimit, membersMeter); err != nil {
 		return e.Wrap(err, "error updating overage item")
 	}
 
 	// Update sessions overage
-	sessionsMeter, err := GetWorkspaceSessionsMeter(ctx, DB, ccClient, &workspace)
+	sessionsMeter, err := GetWorkspaceSessionsMeter(ctx, w.db, w.ccClient, &workspace)
 	if err != nil {
 		return e.Wrap(err, "error getting sessions meter")
 	}
@@ -678,12 +682,12 @@ func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, 
 	if workspace.MonthlySessionLimit != nil {
 		sessionsLimit = *workspace.MonthlySessionLimit
 	}
-	if err := AddOrUpdateOverageItem(stripeClient, &workspace, prices[ProductTypeSessions], invoiceLines[ProductTypeSessions], c, subscription, &sessionsLimit, sessionsMeter); err != nil {
+	if err := AddOrUpdateOverageItem(w.stripeClient, &workspace, prices[model.ProductTypeSessions], invoiceLines[model.ProductTypeSessions], c, subscription, &sessionsLimit, sessionsMeter); err != nil {
 		return e.Wrap(err, "error updating overage item")
 	}
 
 	// Update errors overage
-	errorsMeter, err := GetWorkspaceErrorsMeter(ctx, DB, ccClient, &workspace)
+	errorsMeter, err := GetWorkspaceErrorsMeter(ctx, w.db, w.ccClient, &workspace)
 	if err != nil {
 		return e.Wrap(err, "error getting errors meter")
 	}
@@ -691,12 +695,12 @@ func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, 
 	if workspace.MonthlyErrorsLimit != nil {
 		errorsLimit = *workspace.MonthlyErrorsLimit
 	}
-	if err := AddOrUpdateOverageItem(stripeClient, &workspace, prices[ProductTypeErrors], invoiceLines[ProductTypeErrors], c, subscription, &errorsLimit, errorsMeter); err != nil {
+	if err := AddOrUpdateOverageItem(w.stripeClient, &workspace, prices[model.ProductTypeErrors], invoiceLines[model.ProductTypeErrors], c, subscription, &errorsLimit, errorsMeter); err != nil {
 		return e.Wrap(err, "error updating overage item")
 	}
 
 	// Update logs overage
-	logsMeter, err := GetWorkspaceLogsMeter(ctx, DB, ccClient, &workspace)
+	logsMeter, err := GetWorkspaceLogsMeter(ctx, w.db, w.ccClient, &workspace)
 	if err != nil {
 		return e.Wrap(err, "error getting errors meter")
 	}
@@ -704,8 +708,42 @@ func reportUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, 
 	if workspace.MonthlyLogsLimit != nil {
 		errorsLimit = *workspace.MonthlyErrorsLimit
 	}
-	if err := AddOrUpdateOverageItem(stripeClient, &workspace, prices[ProductTypeLogs], invoiceLines[ProductTypeLogs], c, subscription, &logsLimit, logsMeter); err != nil {
+	if err := AddOrUpdateOverageItem(w.stripeClient, &workspace, prices[model.ProductTypeLogs], invoiceLines[model.ProductTypeLogs], c, subscription, &logsLimit, logsMeter); err != nil {
 		return e.Wrap(err, "error updating overage item")
+	}
+
+	if util.IsHubspotEnabled() {
+		props := []hubspot.Property{{
+			Name:     "sessions_overage",
+			Property: "sessions_overage",
+			Value:    sessionsMeter - int64(sessionsLimit),
+		}, {
+			Name:     "errors_overage",
+			Property: "errors_overage",
+			Value:    errorsMeter - int64(errorsLimit),
+		}, {
+			Name:     "logs_overage",
+			Property: "logs_overage",
+			Value:    logsMeter - int64(logsLimit),
+		}, {
+			Name:     "discount",
+			Property: "discount",
+			Value:    subscription.Discount,
+		}}
+		if len(subscription.Items.Data) > 0 {
+			props = append(props, []hubspot.Property{{
+				Name:     "product",
+				Property: "product",
+				Value:    subscription.Items.Data[0].Price.Product.Name,
+			}, {
+				Name:     "price",
+				Property: "price",
+				Value:    subscription.Items.Data[0].Price.UnitAmountDecimal,
+			}}...)
+		}
+		if err := w.hs.UpdateCompanyProperty(ctx, workspace.ID, props); err != nil {
+			log.WithContext(ctx).WithField("props", props).Error(e.Wrap(err, "hubspot error processing stripe webhook"))
+		}
 	}
 
 	return nil
@@ -743,10 +781,10 @@ func AddOrUpdateOverageItem(stripeClient *client.API, workspace *model.Workspace
 	return nil
 }
 
-func ReportAllUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, stripeClient *client.API, mailClient *sendgrid.Client) {
+func (w *Worker) ReportAllUsage(ctx context.Context) {
 	// Get all workspace IDs
 	var workspaceIDs []int
-	if err := DB.Raw(`
+	if err := w.db.Raw(`
 		SELECT id
 		FROM workspaces
 		WHERE billing_period_start is not null
@@ -757,7 +795,7 @@ func ReportAllUsage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Clien
 	}
 
 	for _, workspaceID := range workspaceIDs {
-		if err := reportUsage(ctx, DB, ccClient, stripeClient, mailClient, workspaceID, nil); err != nil {
+		if err := w.reportUsage(ctx, workspaceID, nil); err != nil {
 			log.WithContext(ctx).Error(e.Wrapf(err, "error reporting usage for workspace %d", workspaceID))
 		}
 	}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1251,9 +1251,9 @@ func (r *mutationResolver) CreateOrUpdateStripeSubscription(ctx context.Context,
 	subscriptions := c.Subscriptions.Data
 	pricing.FillProducts(r.StripeClient, subscriptions)
 
-	pricingInterval := model.SubscriptionIntervalMonthly
+	pricingInterval := model.PricingSubscriptionIntervalMonthly
 	if planType != modelInputs.PlanTypeFree && interval == modelInputs.SubscriptionIntervalAnnual {
-		pricingInterval = model.SubscriptionIntervalAnnual
+		pricingInterval = model.PricingSubscriptionIntervalAnnual
 	}
 
 	// default to unlimited members pricing
@@ -1262,7 +1262,7 @@ func (r *mutationResolver) CreateOrUpdateStripeSubscription(ctx context.Context,
 		return nil, e.Wrap(err, "STRIPE_INTEGRATION_ERROR cannot update stripe subscription - failed to get Stripe prices")
 	}
 
-	newBasePrice := prices[model.ProductTypeBase]
+	newBasePrice := prices[model.PricingProductTypeBase]
 
 	// If there's an existing subscription, update it
 	if len(subscriptions) == 1 {
@@ -1276,7 +1276,7 @@ func (r *mutationResolver) CreateOrUpdateStripeSubscription(ctx context.Context,
 		if productType == nil {
 			return nil, e.New(fmt.Sprintf("STRIPE_INTEGRATION_ERROR cannot update stripe subscription - nil product from sub %s price %s", subscription.ID, subscriptionItem.Price.ID))
 		}
-		if *productType != model.ProductTypeBase {
+		if *productType != model.PricingProductTypeBase {
 			return nil, e.New(fmt.Sprintf("STRIPE_INTEGRATION_ERROR cannot update stripe subscription - expecting base product from sub %s price %s: %s", subscription.ID, subscriptionItem.Price.ID, *productType))
 		}
 
@@ -5620,9 +5620,9 @@ func (r *queryResolver) BillingDetails(ctx context.Context, workspaceID int) (*m
 
 	var sessionsLimit, errorsLimit, logsLimit *int64
 	if workspace.TrialEndDate == nil || workspace.TrialEndDate.Before(time.Now()) {
-		sessionsLimit = pricing.GetLimitAmount(workspace.SessionsMaxCents, model.ProductTypeSessions, planType, retentionPeriod)
-		errorsLimit = pricing.GetLimitAmount(workspace.ErrorsMaxCents, model.ProductTypeErrors, planType, retentionPeriod)
-		logsLimit = pricing.GetLimitAmount(workspace.LogsMaxCents, model.ProductTypeLogs, planType, retentionPeriod)
+		sessionsLimit = pricing.GetLimitAmount(workspace.SessionsMaxCents, model.PricingProductTypeSessions, planType, retentionPeriod)
+		errorsLimit = pricing.GetLimitAmount(workspace.ErrorsMaxCents, model.PricingProductTypeErrors, planType, retentionPeriod)
+		logsLimit = pricing.GetLimitAmount(workspace.LogsMaxCents, model.PricingProductTypeLogs, planType, retentionPeriod)
 	}
 
 	details := &modelInputs.BillingDetails{

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1251,9 +1251,9 @@ func (r *mutationResolver) CreateOrUpdateStripeSubscription(ctx context.Context,
 	subscriptions := c.Subscriptions.Data
 	pricing.FillProducts(r.StripeClient, subscriptions)
 
-	pricingInterval := pricing.SubscriptionIntervalMonthly
+	pricingInterval := model.SubscriptionIntervalMonthly
 	if planType != modelInputs.PlanTypeFree && interval == modelInputs.SubscriptionIntervalAnnual {
-		pricingInterval = pricing.SubscriptionIntervalAnnual
+		pricingInterval = model.SubscriptionIntervalAnnual
 	}
 
 	// default to unlimited members pricing
@@ -1262,7 +1262,7 @@ func (r *mutationResolver) CreateOrUpdateStripeSubscription(ctx context.Context,
 		return nil, e.Wrap(err, "STRIPE_INTEGRATION_ERROR cannot update stripe subscription - failed to get Stripe prices")
 	}
 
-	newBasePrice := prices[pricing.ProductTypeBase]
+	newBasePrice := prices[model.ProductTypeBase]
 
 	// If there's an existing subscription, update it
 	if len(subscriptions) == 1 {
@@ -1276,7 +1276,7 @@ func (r *mutationResolver) CreateOrUpdateStripeSubscription(ctx context.Context,
 		if productType == nil {
 			return nil, e.New(fmt.Sprintf("STRIPE_INTEGRATION_ERROR cannot update stripe subscription - nil product from sub %s price %s", subscription.ID, subscriptionItem.Price.ID))
 		}
-		if *productType != pricing.ProductTypeBase {
+		if *productType != model.ProductTypeBase {
 			return nil, e.New(fmt.Sprintf("STRIPE_INTEGRATION_ERROR cannot update stripe subscription - expecting base product from sub %s price %s: %s", subscription.ID, subscriptionItem.Price.ID, *productType))
 		}
 
@@ -5620,9 +5620,9 @@ func (r *queryResolver) BillingDetails(ctx context.Context, workspaceID int) (*m
 
 	var sessionsLimit, errorsLimit, logsLimit *int64
 	if workspace.TrialEndDate == nil || workspace.TrialEndDate.Before(time.Now()) {
-		sessionsLimit = pricing.GetLimitAmount(workspace.SessionsMaxCents, pricing.ProductTypeSessions, planType, retentionPeriod)
-		errorsLimit = pricing.GetLimitAmount(workspace.ErrorsMaxCents, pricing.ProductTypeErrors, planType, retentionPeriod)
-		logsLimit = pricing.GetLimitAmount(workspace.LogsMaxCents, pricing.ProductTypeLogs, planType, retentionPeriod)
+		sessionsLimit = pricing.GetLimitAmount(workspace.SessionsMaxCents, model.ProductTypeSessions, planType, retentionPeriod)
+		errorsLimit = pricing.GetLimitAmount(workspace.ErrorsMaxCents, model.ProductTypeErrors, planType, retentionPeriod)
+		logsLimit = pricing.GetLimitAmount(workspace.LogsMaxCents, model.ProductTypeLogs, planType, retentionPeriod)
 	}
 
 	details := &modelInputs.BillingDetails{

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -691,7 +691,7 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 		return nil, ErrUserFilteredError
 	}
 
-	withinBillingQuota, quotaPercent := r.IsWithinQuota(ctx, model.ProductTypeErrors, workspace, time.Now())
+	withinBillingQuota, quotaPercent := r.IsWithinQuota(ctx, model.PricingProductTypeErrors, workspace, time.Now())
 	go func() {
 		defer util.Recover()
 		if quotaPercent >= 1 {
@@ -1132,10 +1132,10 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 	}
 
 	// determine if session is within billing quota
-	withinBillingQuota, quotaPercent := r.IsWithinQuota(ctx, model.ProductTypeSessions, workspace, time.Now())
+	withinBillingQuota, quotaPercent := r.IsWithinQuota(ctx, model.PricingProductTypeSessions, workspace, time.Now())
 	setupSpan.Finish()
 
-	if err := r.Redis.SetBillingQuotaExceeded(ctx, projectID, model.ProductTypeSessions, !withinBillingQuota); err != nil {
+	if err := r.Redis.SetBillingQuotaExceeded(ctx, projectID, model.PricingProductTypeSessions, !withinBillingQuota); err != nil {
 		return nil, e.Wrap(err, "error setting billing quota exceeded")
 	}
 
@@ -1599,13 +1599,13 @@ func (r *Resolver) getProject(projectID int) (*model.Project, error) {
 	return &project, nil
 }
 
-var productTypeToQuotaConfig = map[model.ProductType]struct {
+var productTypeToQuotaConfig = map[model.PricingProductType]struct {
 	maxCostCents    func(*model.Workspace) *int
 	meter           func(context.Context, *gorm.DB, *clickhouse.Client, *model.Workspace) (int64, error)
 	retentionPeriod func(*model.Workspace) privateModel.RetentionPeriod
 	included        func(*model.Workspace) int64
 }{
-	model.ProductTypeSessions: {
+	model.PricingProductTypeSessions: {
 		func(w *model.Workspace) *int { return w.SessionsMaxCents },
 		pricing.GetWorkspaceSessionsMeter,
 		func(w *model.Workspace) privateModel.RetentionPeriod {
@@ -1622,7 +1622,7 @@ var productTypeToQuotaConfig = map[model.ProductType]struct {
 			return int64(limit)
 		},
 	},
-	model.ProductTypeErrors: {
+	model.PricingProductTypeErrors: {
 		func(w *model.Workspace) *int { return w.ErrorsMaxCents },
 		pricing.GetWorkspaceErrorsMeter,
 		func(w *model.Workspace) privateModel.RetentionPeriod {
@@ -1639,7 +1639,7 @@ var productTypeToQuotaConfig = map[model.ProductType]struct {
 			return int64(limit)
 		},
 	},
-	model.ProductTypeLogs: {
+	model.PricingProductTypeLogs: {
 		func(w *model.Workspace) *int { return w.LogsMaxCents },
 		pricing.GetWorkspaceLogsMeter,
 		func(w *model.Workspace) privateModel.RetentionPeriod {
@@ -1655,7 +1655,7 @@ var productTypeToQuotaConfig = map[model.ProductType]struct {
 	},
 }
 
-func (r *Resolver) IsWithinQuota(ctx context.Context, productType model.ProductType, workspace *model.Workspace, now time.Time) (bool, float64) {
+func (r *Resolver) IsWithinQuota(ctx context.Context, productType model.PricingProductType, workspace *model.Workspace, now time.Time) (bool, float64) {
 	if workspace == nil {
 		return true, 0
 	}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -73,7 +73,7 @@ type Resolver struct {
 	MailClient       *sendgrid.Client
 	StorageClient    storage.Client
 	OpenSearch       *opensearch.Client
-	HubspotApi       *highlightHubspot.HubspotApi
+	HubspotApi       *highlightHubspot.Client
 	EmbeddingsClient embeddings.Client
 	Redis            *redis.Client
 	Clickhouse       *clickhouse.Client
@@ -691,7 +691,7 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 		return nil, ErrUserFilteredError
 	}
 
-	withinBillingQuota, quotaPercent := r.IsWithinQuota(ctx, pricing.ProductTypeErrors, workspace, time.Now())
+	withinBillingQuota, quotaPercent := r.IsWithinQuota(ctx, model.ProductTypeErrors, workspace, time.Now())
 	go func() {
 		defer util.Recover()
 		if quotaPercent >= 1 {
@@ -1132,10 +1132,10 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 	}
 
 	// determine if session is within billing quota
-	withinBillingQuota, quotaPercent := r.IsWithinQuota(ctx, pricing.ProductTypeSessions, workspace, time.Now())
+	withinBillingQuota, quotaPercent := r.IsWithinQuota(ctx, model.ProductTypeSessions, workspace, time.Now())
 	setupSpan.Finish()
 
-	if err := r.Redis.SetBillingQuotaExceeded(ctx, projectID, pricing.ProductTypeSessions, !withinBillingQuota); err != nil {
+	if err := r.Redis.SetBillingQuotaExceeded(ctx, projectID, model.ProductTypeSessions, !withinBillingQuota); err != nil {
 		return nil, e.Wrap(err, "error setting billing quota exceeded")
 	}
 
@@ -1599,13 +1599,13 @@ func (r *Resolver) getProject(projectID int) (*model.Project, error) {
 	return &project, nil
 }
 
-var productTypeToQuotaConfig = map[pricing.ProductType]struct {
+var productTypeToQuotaConfig = map[model.ProductType]struct {
 	maxCostCents    func(*model.Workspace) *int
 	meter           func(context.Context, *gorm.DB, *clickhouse.Client, *model.Workspace) (int64, error)
 	retentionPeriod func(*model.Workspace) privateModel.RetentionPeriod
 	included        func(*model.Workspace) int64
 }{
-	pricing.ProductTypeSessions: {
+	model.ProductTypeSessions: {
 		func(w *model.Workspace) *int { return w.SessionsMaxCents },
 		pricing.GetWorkspaceSessionsMeter,
 		func(w *model.Workspace) privateModel.RetentionPeriod {
@@ -1622,7 +1622,7 @@ var productTypeToQuotaConfig = map[pricing.ProductType]struct {
 			return int64(limit)
 		},
 	},
-	pricing.ProductTypeErrors: {
+	model.ProductTypeErrors: {
 		func(w *model.Workspace) *int { return w.ErrorsMaxCents },
 		pricing.GetWorkspaceErrorsMeter,
 		func(w *model.Workspace) privateModel.RetentionPeriod {
@@ -1639,7 +1639,7 @@ var productTypeToQuotaConfig = map[pricing.ProductType]struct {
 			return int64(limit)
 		},
 	},
-	pricing.ProductTypeLogs: {
+	model.ProductTypeLogs: {
 		func(w *model.Workspace) *int { return w.LogsMaxCents },
 		pricing.GetWorkspaceLogsMeter,
 		func(w *model.Workspace) privateModel.RetentionPeriod {
@@ -1655,7 +1655,7 @@ var productTypeToQuotaConfig = map[pricing.ProductType]struct {
 	},
 }
 
-func (r *Resolver) IsWithinQuota(ctx context.Context, productType pricing.ProductType, workspace *model.Workspace, now time.Time) (bool, float64) {
+func (r *Resolver) IsWithinQuota(ctx context.Context, productType model.ProductType, workspace *model.Workspace, now time.Time) (bool, float64) {
 	if workspace == nil {
 		return true, 0
 	}

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -592,10 +592,10 @@ func Test_WithinQuota_CommittedPricing(t *testing.T) {
 				union all select 2, '2023-01-02'::date, 0) a
 		`)
 
-		basicWithinBillingQuota, _ := resolver.IsWithinQuota(ctx, model.ProductTypeSessions, &workspaceBasic, time.Now())
+		basicWithinBillingQuota, _ := resolver.IsWithinQuota(ctx, model.PricingProductTypeSessions, &workspaceBasic, time.Now())
 		assert.True(t, basicWithinBillingQuota)
 
-		usageBasedWithinBillingQuota, _ := resolver.IsWithinQuota(ctx, model.ProductTypeSessions, &workspaceUsageBased, time.Now())
+		usageBasedWithinBillingQuota, _ := resolver.IsWithinQuota(ctx, model.PricingProductTypeSessions, &workspaceUsageBased, time.Now())
 		assert.False(t, usageBasedWithinBillingQuota)
 	})
 }

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/smithy-go/ptr"
 	"github.com/go-test/deep"
 	"github.com/highlight-run/highlight/backend/opensearch"
-	"github.com/highlight-run/highlight/backend/pricing"
 	"github.com/highlight-run/highlight/backend/store"
 	"github.com/highlight-run/highlight/backend/timeseries"
 	"github.com/openlyinc/pointy"
@@ -593,10 +592,10 @@ func Test_WithinQuota_CommittedPricing(t *testing.T) {
 				union all select 2, '2023-01-02'::date, 0) a
 		`)
 
-		basicWithinBillingQuota, _ := resolver.IsWithinQuota(ctx, pricing.ProductTypeSessions, &workspaceBasic, time.Now())
+		basicWithinBillingQuota, _ := resolver.IsWithinQuota(ctx, model.ProductTypeSessions, &workspaceBasic, time.Now())
 		assert.True(t, basicWithinBillingQuota)
 
-		usageBasedWithinBillingQuota, _ := resolver.IsWithinQuota(ctx, pricing.ProductTypeSessions, &workspaceUsageBased, time.Now())
+		usageBasedWithinBillingQuota, _ := resolver.IsWithinQuota(ctx, model.ProductTypeSessions, &workspaceUsageBased, time.Now())
 		assert.False(t, usageBasedWithinBillingQuota)
 	})
 }

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -14,7 +14,6 @@ import (
 	"github.com/highlight-run/highlight/backend/hlog"
 	kafkaqueue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/model"
-	"github.com/highlight-run/highlight/backend/pricing"
 	generated1 "github.com/highlight-run/highlight/backend/public-graph/graph/generated"
 	customModels "github.com/highlight-run/highlight/backend/public-graph/graph/model"
 	"github.com/openlyinc/pointy"
@@ -64,7 +63,7 @@ func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureI
 			err = r.Redis.SetIsPendingSession(ctx, sessionSecureID, true)
 		}
 		if err == nil {
-			exceeded, err := r.Redis.IsBillingQuotaExceeded(ctx, projectID, pricing.ProductTypeSessions)
+			exceeded, err := r.Redis.IsBillingQuotaExceeded(ctx, projectID, model.ProductTypeSessions)
 			if err == nil && exceeded != nil && *exceeded {
 				err = e.New(string(customModels.PublicGraphErrorBillingQuotaExceeded))
 			}

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -63,7 +63,7 @@ func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureI
 			err = r.Redis.SetIsPendingSession(ctx, sessionSecureID, true)
 		}
 		if err == nil {
-			exceeded, err := r.Redis.IsBillingQuotaExceeded(ctx, projectID, model.ProductTypeSessions)
+			exceeded, err := r.Redis.IsBillingQuotaExceeded(ctx, projectID, model.PricingProductTypeSessions)
 			if err == nil && exceeded != nil && *exceeded {
 				err = e.New(string(customModels.PublicGraphErrorBillingQuotaExceeded))
 			}

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -52,7 +52,7 @@ func SessionInitializedKey(sessionSecureId string) string {
 	return fmt.Sprintf("session-init-%s", sessionSecureId)
 }
 
-func BillingQuotaExceededKey(projectId int, productType model.ProductType) string {
+func BillingQuotaExceededKey(projectId int, productType model.PricingProductType) string {
 	return fmt.Sprintf("billing-quota-exceeded-%d-%s", projectId, productType)
 }
 
@@ -415,11 +415,11 @@ func (r *Client) SetIsPendingSession(ctx context.Context, sessionSecureId string
 	return r.setFlag(ctx, SessionInitializedKey(sessionSecureId), initialized, 24*time.Hour)
 }
 
-func (r *Client) IsBillingQuotaExceeded(ctx context.Context, projectId int, productType model.ProductType) (*bool, error) {
+func (r *Client) IsBillingQuotaExceeded(ctx context.Context, projectId int, productType model.PricingProductType) (*bool, error) {
 	return r.getFlagOrNil(ctx, BillingQuotaExceededKey(projectId, productType))
 }
 
-func (r *Client) SetBillingQuotaExceeded(ctx context.Context, projectId int, productType model.ProductType, exceeded bool) error {
+func (r *Client) SetBillingQuotaExceeded(ctx context.Context, projectId int, productType model.PricingProductType, exceeded bool) error {
 	return r.setFlag(ctx, BillingQuotaExceededKey(projectId, productType), exceeded, 5*time.Minute)
 }
 

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -15,7 +15,6 @@ import (
 	"github.com/golang/snappy"
 	"github.com/highlight-run/highlight/backend/hlog"
 	"github.com/highlight-run/highlight/backend/model"
-	"github.com/highlight-run/highlight/backend/pricing"
 	"github.com/highlight-run/highlight/backend/util"
 	"github.com/openlyinc/pointy"
 	"github.com/pkg/errors"
@@ -53,7 +52,7 @@ func SessionInitializedKey(sessionSecureId string) string {
 	return fmt.Sprintf("session-init-%s", sessionSecureId)
 }
 
-func BillingQuotaExceededKey(projectId int, productType pricing.ProductType) string {
+func BillingQuotaExceededKey(projectId int, productType model.ProductType) string {
 	return fmt.Sprintf("billing-quota-exceeded-%d-%s", projectId, productType)
 }
 
@@ -416,11 +415,11 @@ func (r *Client) SetIsPendingSession(ctx context.Context, sessionSecureId string
 	return r.setFlag(ctx, SessionInitializedKey(sessionSecureId), initialized, 24*time.Hour)
 }
 
-func (r *Client) IsBillingQuotaExceeded(ctx context.Context, projectId int, productType pricing.ProductType) (*bool, error) {
+func (r *Client) IsBillingQuotaExceeded(ctx context.Context, projectId int, productType model.ProductType) (*bool, error) {
 	return r.getFlagOrNil(ctx, BillingQuotaExceededKey(projectId, productType))
 }
 
-func (r *Client) SetBillingQuotaExceeded(ctx context.Context, projectId int, productType pricing.ProductType, exceeded bool) error {
+func (r *Client) SetBillingQuotaExceeded(ctx context.Context, projectId int, productType model.ProductType, exceeded bool) error {
 	return r.setFlag(ctx, BillingQuotaExceededKey(projectId, productType), exceeded, 5*time.Minute)
 }
 

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -149,7 +149,7 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context) error {
 		quotaExceededByProject := map[uint32]bool{}
 		projectsToQuery := []uint32{}
 		for projectId := range workspaceByProject {
-			exceeded, err := k.Worker.Resolver.Redis.IsBillingQuotaExceeded(ctxW, int(projectId), model.ProductTypeLogs)
+			exceeded, err := k.Worker.Resolver.Redis.IsBillingQuotaExceeded(ctxW, int(projectId), model.PricingProductTypeLogs)
 			if err != nil {
 				log.WithContext(ctxW).Error(err)
 				continue
@@ -185,9 +185,9 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context) error {
 			}
 			workspace.Projects = projects
 
-			withinBillingQuota, quotaPercent := k.Worker.PublicResolver.IsWithinQuota(ctxW, model.ProductTypeLogs, &workspace, time.Now())
+			withinBillingQuota, quotaPercent := k.Worker.PublicResolver.IsWithinQuota(ctxW, model.PricingProductTypeLogs, &workspace, time.Now())
 			quotaExceededByProject[projectId] = !withinBillingQuota
-			if err := k.Worker.Resolver.Redis.SetBillingQuotaExceeded(ctxW, int(projectId), model.ProductTypeLogs, !withinBillingQuota); err != nil {
+			if err := k.Worker.Resolver.Redis.SetBillingQuotaExceeded(ctxW, int(projectId), model.PricingProductTypeLogs, !withinBillingQuota); err != nil {
 				log.WithContext(ctxW).Error(err)
 				return err
 			}

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -18,7 +18,6 @@ import (
 	"github.com/highlight-run/highlight/backend/hlog"
 	kafkaqueue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/model"
-	"github.com/highlight-run/highlight/backend/pricing"
 	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"
 	log "github.com/sirupsen/logrus"
@@ -150,7 +149,7 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context) error {
 		quotaExceededByProject := map[uint32]bool{}
 		projectsToQuery := []uint32{}
 		for projectId := range workspaceByProject {
-			exceeded, err := k.Worker.Resolver.Redis.IsBillingQuotaExceeded(ctxW, int(projectId), pricing.ProductTypeLogs)
+			exceeded, err := k.Worker.Resolver.Redis.IsBillingQuotaExceeded(ctxW, int(projectId), model.ProductTypeLogs)
 			if err != nil {
 				log.WithContext(ctxW).Error(err)
 				continue
@@ -186,9 +185,9 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context) error {
 			}
 			workspace.Projects = projects
 
-			withinBillingQuota, quotaPercent := k.Worker.PublicResolver.IsWithinQuota(ctxW, pricing.ProductTypeLogs, &workspace, time.Now())
+			withinBillingQuota, quotaPercent := k.Worker.PublicResolver.IsWithinQuota(ctxW, model.ProductTypeLogs, &workspace, time.Now())
 			quotaExceededByProject[projectId] = !withinBillingQuota
-			if err := k.Worker.Resolver.Redis.SetBillingQuotaExceeded(ctxW, int(projectId), pricing.ProductTypeLogs, !withinBillingQuota); err != nil {
+			if err := k.Worker.Resolver.Redis.SetBillingQuotaExceeded(ctxW, int(projectId), model.ProductTypeLogs, !withinBillingQuota); err != nil {
 				log.WithContext(ctxW).Error(err)
 				return err
 			}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -855,7 +855,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 	if err != nil {
 		return err
 	}
-	withinBillingQuota, _ := w.PublicResolver.IsWithinQuota(ctx, model.ProductTypeSessions, workspace, time.Now())
+	withinBillingQuota, _ := w.PublicResolver.IsWithinQuota(ctx, model.PricingProductTypeSessions, workspace, time.Now())
 
 	if err := w.Resolver.DB.Model(&model.Session{}).Where(
 		&model.Session{Model: model.Model{ID: s.ID}},

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1370,7 +1370,7 @@ func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
 			model.MarkBackendSetupTypeLogs:    &c.BackendLoggingIntegrated,
 		} {
 			setupEvent := model.SetupEvent{}
-			if err := w.Resolver.DB.Model(&model.SetupEvent{}).Joins("INNER JOIN projects p on p.id = project_id").Joins("INNER JOIN workspaces w on w.id = p.workspace_id").Where("w.id = ? AND type = ?", workspace.ID, t).Take(&setupEvent).Error; err != nil {
+			if err := w.Resolver.DB.Model(&model.SetupEvent{}).Joins("INNER JOIN projects p on p.id = project_id").Joins("INNER JOIN workspaces w on w.id = p.workspace_id").Where("w.id = ? AND type = ?", workspace.ID, t).Take(&setupEvent).Error; err == nil {
 				*ptr = setupEvent.ID != 0
 			}
 		}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -855,7 +855,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 	if err != nil {
 		return err
 	}
-	withinBillingQuota, _ := w.PublicResolver.IsWithinQuota(ctx, pricing.ProductTypeSessions, workspace, time.Now())
+	withinBillingQuota, _ := w.PublicResolver.IsWithinQuota(ctx, model.ProductTypeSessions, workspace, time.Now())
 
 	if err := w.Resolver.DB.Model(&model.Session{}).Where(
 		&model.Session{Model: model.Model{ID: s.ID}},
@@ -1198,7 +1198,7 @@ func (w *Worker) Start(ctx context.Context) {
 }
 
 func (w *Worker) ReportStripeUsage(ctx context.Context) {
-	pricing.ReportAllUsage(ctx, w.Resolver.DB, w.Resolver.ClickhouseClient, w.Resolver.StripeClient, w.Resolver.MailClient)
+	pricing.NewWorker(w.Resolver.DB, w.Resolver.ClickhouseClient, w.Resolver.StripeClient, w.Resolver.MailClient, w.Resolver.HubspotApi).ReportAllUsage(ctx)
 }
 
 func (w *Worker) UpdateOpenSearchIndex(ctx context.Context) {
@@ -1312,18 +1312,21 @@ func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
 	}
 
 	type AggregateSessionCount struct {
-		WorkspaceID          int        `json:"workspace_id"`
-		SessionCount         int64      `json:"session_count"`
-		ErrorCount           int64      `json:"error_count"`
-		LogCount             int64      `json:"log_count"`
-		SessionCountLastWeek int64      `json:"session_count_last_week"`
-		ErrorCountLastWeek   int64      `json:"error_count_last_week"`
-		LogCountLastWeek     int64      `json:"log_count_last_week"`
-		SessionCountLastDay  int64      `json:"session_count_last_day"`
-		ErrorCountLastDay    int64      `json:"error_count_last_day"`
-		LogCountLastDay      int64      `json:"log_count_last_day"`
-		TrialEndDate         *time.Time `json:"trial_end_date"`
-		PlanTier             string     `json:"plan_tier"`
+		WorkspaceID                      int        `json:"workspace_id"`
+		SessionCount                     int64      `json:"session_count"`
+		ErrorCount                       int64      `json:"error_count"`
+		LogCount                         int64      `json:"log_count"`
+		SessionCountLastWeek             int64      `json:"session_count_last_week"`
+		ErrorCountLastWeek               int64      `json:"error_count_last_week"`
+		LogCountLastWeek                 int64      `json:"log_count_last_week"`
+		SessionCountLastDay              int64      `json:"session_count_last_day"`
+		ErrorCountLastDay                int64      `json:"error_count_last_day"`
+		LogCountLastDay                  int64      `json:"log_count_last_day"`
+		TrialEndDate                     *time.Time `json:"trial_end_date"`
+		PlanTier                         string     `json:"plan_tier"`
+		SessionReplayIntegrated          bool       `json:"session_replay_integrated"`
+		BackendErrorMonitoringIntegrated bool       `json:"backend_error_monitoring_integrated"`
+		BackendLoggingIntegrated         bool       `json:"backend_logging_integrated"`
 	}
 	var counts []*AggregateSessionCount
 
@@ -1362,6 +1365,18 @@ func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
 		c.TrialEndDate = workspace.TrialEndDate
 		c.PlanTier = workspace.PlanTier
 		for _, p := range workspace.Projects {
+			sessionRecording, err := w.Resolver.Query().ClientIntegration(ctx, p.ID)
+			if err == nil {
+				c.SessionReplayIntegrated = c.SessionReplayIntegrated || sessionRecording.Integrated
+			}
+			backendErrors, err := w.Resolver.Query().ServerIntegration(ctx, p.ID)
+			if err == nil && backendErrors.Integrated {
+				c.BackendErrorMonitoringIntegrated = c.BackendErrorMonitoringIntegrated || backendErrors.Integrated
+			}
+			logs, err := w.Resolver.Query().LogsIntegration(ctx, p.ID)
+			if err == nil && logs.Integrated {
+				c.BackendLoggingIntegrated = c.BackendLoggingIntegrated || logs.Integrated
+			}
 			count, _ := w.Resolver.ClickhouseClient.ReadLogsTotalCount(ctx, p.ID, backend.LogsParamsInput{DateRange: &backend.DateRangeRequiredInput{
 				StartDate: time.Now().Add(-time.Hour * 24 * 30),
 				EndDate:   time.Now(),
@@ -1428,6 +1443,18 @@ func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
 				Name:     "plan_tier",
 				Property: "plan_tier",
 				Value:    c.PlanTier,
+			}, {
+				Name:     "is_session_replay_integrated",
+				Property: "is_session_replay_integrated",
+				Value:    c.SessionReplayIntegrated,
+			}, {
+				Name:     "is_backend_error_monitoring_integrated",
+				Property: "is_backend_error_monitoring_integrated",
+				Value:    c.BackendErrorMonitoringIntegrated,
+			}, {
+				Name:     "is_backend_logging_integrated",
+				Property: "is_backend_logging_integrated",
+				Value:    c.BackendLoggingIntegrated,
 			}}
 			if c.TrialEndDate != nil {
 				properties = append(properties, hubspot.Property{


### PR DESCRIPTION
## Summary

Report a bunch of new hubspot fields.
* is_session_replay_integrated
* is_backend_error_monitoring_integrated
* is_backend_logging_integrated
* sessions_overage - number of sessions over the limit in the billing period
* errors_overage - number of errors over the limit in the billing period
* logs_overage - number of logs over the limit in the billing period
* discount
* product - subscription name
* price - subscription price, for non usage-based accounts

## How did you test this change?

Local deploy enabling hubspot.
<img width="462" alt="Screenshot 2023-08-17 at 12 32 36 AM" src="https://github.com/highlight/highlight/assets/1351531/6ca9290c-368e-464e-b66c-8e336d20ba9e">

## Are there any deployment considerations?

Creating fields in hubspot.