### PR TITLE
correct docs for fluentbit binary

### DIFF
--- a/highlight.io/components/QuickstartContent/logging/fluentd.tsx
+++ b/highlight.io/components/QuickstartContent/logging/fluentd.tsx
@@ -9,13 +9,19 @@ export const FluentForwardContent: QuickStartContent = {
 		{
 			title: 'Setup fluentd / fluent bit ingest.',
 			content:
-				'Route your [fluentd / fluent bit](https://docs.fluentbit.io/manual/pipeline/outputs/forward/) to forward://otel.highlight.io:24224.',
+				'Route your [fluentd / fluent bit](https://docs.fluentbit.io/manual/pipeline/outputs/forward/) to forward://otel.highlight.io:24224. ' +
+				'Regardless of the  way you are using fluentbit, configure the tag to `highlight.project_id=YOUR_PROJECT_ID` to route the logs to the given highlight project',
 			code: [
 				{
-					text: `bin/fluent-bit -i cpu -t fluent_bit -o forward://otel.highlight.io:24224`,
+					text: `bin/fluent-bit -i cpu -t highlight.project_id=YOUR_PROJECT_ID -o forward://otel.highlight.io:24224`,
 					language: 'bash',
 				},
 			],
+		},
+		{
+			title: 'Setting up for AWS ECS?',
+			content:
+				'If you are setting up for AWS Elastic Container Services, check out our dedicated [docs for AWS ECS.](/docs/getting-started/backend-logging/hosting/aws#aws-ecs-containers) .',
 		},
 		verifyLogs,
 	],


### PR DESCRIPTION
## Summary

* Updates docs for setting a tag on `bin/fluent-bit` to route to a project ID.
* Links the ECS docs from fluent-bit as that is a common search path.

## How did you test this change?

Vercel Preview

## Are there any deployment considerations?

No