### PR TITLE
fix: change alignItems center to flex-start

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5948,10 +5948,13 @@ body {
   grid-template-columns: 90px 1fr;
   grid-gap: 8px;
   cursor: pointer;
-  align-items: center;
+  align-items: flex-start;
 }
 ._1ubqgtn2 {
   display: block;
+}
+._1ubqgtn3 {
+  padding: 6px;
 }
 ._1ecj17q0 {
   height: 28px;

--- a/frontend/src/__generated/ve/components/TableList/TableList.css.js
+++ b/frontend/src/__generated/ve/components/TableList/TableList.css.js
@@ -1,1 +1,1 @@
-import{createRuntimeFn as a}from"@vanilla-extract/recipes/createRuntimeFn";var s=a({defaultClassName:"_1ubqgtn0",variantClassNames:{json:{false:"_1ubqgtn1",true:"_1ubqgtn2"}},defaultVariants:{},compoundVariants:[]});export{s as sessionAttributeRow};
+import{createRuntimeFn as a}from"@vanilla-extract/recipes/createRuntimeFn";var e="_1ubqgtn3",s=a({defaultClassName:"_1ubqgtn0",variantClassNames:{json:{false:"_1ubqgtn1",true:"_1ubqgtn2"}},defaultVariants:{},compoundVariants:[]});export{e as keyDisplayValue,s as sessionAttributeRow};

--- a/frontend/src/components/TableList/TableList.css.ts
+++ b/frontend/src/components/TableList/TableList.css.ts
@@ -1,3 +1,4 @@
+import { style } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
 
 export const sessionAttributeRow = recipe({
@@ -6,7 +7,7 @@ export const sessionAttributeRow = recipe({
 		gridTemplateColumns: `90px 1fr`,
 		gridGap: 8,
 		cursor: 'pointer',
-		alignItems: 'center',
+		alignItems: 'flex-start',
 	},
 	variants: {
 		json: {
@@ -14,4 +15,8 @@ export const sessionAttributeRow = recipe({
 			true: { display: 'block' },
 		},
 	},
+})
+
+export const keyDisplayValue = style({
+	padding: '6px',
 })

--- a/frontend/src/components/TableList/TableList.tsx
+++ b/frontend/src/components/TableList/TableList.tsx
@@ -49,6 +49,7 @@ export const TableList = ({
 							as="span"
 							color="weak"
 							wrap="breakWord"
+							cssClass={style.keyDisplayValue}
 						>
 							{item.keyDisplayValue}
 						</Text>

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -504,7 +504,7 @@ const LogAttributeLine: React.FC<React.PropsWithChildren> = ({ children }) => {
 		<Box
 			cssClass={styles.logAttributeLine}
 			display="flex"
-			alignItems="center"
+			alignItems="flex-start"
 			flexDirection="row"
 			gap="4"
 			flexShrink={0}


### PR DESCRIPTION
## Summary
1. Change alignItems `center` to `flex-start` in TableList.css.ts and LogDetails.tsx
2. Add `keyDisplayValue` styles for padding 

Closes #6023 

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

<img width="1350" alt="Monosnap Logs 2023-08-19 17-21-58" src="https://github.com/highlight/highlight/assets/39362422/fe8ae3b8-f388-4a0c-969d-5d09c3f29ba8">

<img width="546" alt="Monosnap Sessions: demo@example com 2023-08-19 17-25-53" src="https://github.com/highlight/highlight/assets/39362422/929316e0-3d65-4967-815f-f3d1cbefa605">

## Are there any deployment considerations?


<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
