### PR TITLE
fix next app directory error capture

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -31,6 +32,8 @@ import (
 type Handler struct {
 	resolver *graph.Resolver
 }
+
+var IgnoredSpanNamePrefixes = []string{"fs "}
 
 func lg(ctx context.Context, fields extractedFields) *log.Entry {
 	return log.WithContext(ctx).
@@ -155,6 +158,12 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 				span := spans.At(k)
 				events := span.Events()
 
+				for _, prefix := range IgnoredSpanNamePrefixes {
+					if strings.HasPrefix(span.Name(), prefix) {
+						continue
+					}
+				}
+
 				isLog := false
 				for l := 0; l < events.Len() && !isLog; l++ {
 					e := events.At(l)
@@ -166,9 +175,11 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 				// Only process spans that are not logs
 				if !isLog {
 					fields, err := extractFields(ctx, extractFieldsParams{
-						span: &span,
+						resource: &resource,
+						span:     &span,
 					})
 					if err != nil {
+						lg(ctx, fields).WithError(err).Error("failed to extract fields from span")
 						continue
 					}
 
@@ -201,6 +212,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						event:    &event,
 					})
 					if err != nil {
+						lg(ctx, fields).WithError(err).Error("failed to extract fields from span")
 						continue
 					}
 
@@ -380,6 +392,7 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 					logRecord: &logRecord,
 				})
 				if err != nil {
+					lg(ctx, fields).WithError(err).Error("failed to extract fields from log")
 					continue
 				}
 

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -158,10 +158,16 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 				span := spans.At(k)
 				events := span.Events()
 
+				// skip a subset of spans (ie. fs spans
+				skipped := false
 				for _, prefix := range IgnoredSpanNamePrefixes {
 					if strings.HasPrefix(span.Name(), prefix) {
-						continue
+						skipped = true
+						break
 					}
+				}
+				if skipped {
+					continue
 				}
 
 				isLog := false

--- a/backend/otel/otel_test.go
+++ b/backend/otel/otel_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	model2 "github.com/highlight-run/highlight/backend/public-graph/graph/model"
+	"github.com/openlyinc/pointy"
 	"net/http"
 	"os"
 	"strings"
@@ -53,119 +54,97 @@ func TestHandler_HandleLog(t *testing.T) {
 }
 
 func TestHandler_HandleTrace(t *testing.T) {
-	inputBytes, err := os.ReadFile("./samples/traces.json")
-	if err != nil {
-		t.Fatalf("error reading: %v", err)
-	}
-
-	req := ptraceotlp.NewExportRequest()
-	if err := req.UnmarshalJSON(inputBytes); err != nil {
-		t.Fatal(err)
-	}
-
-	body, err := req.MarshalProto()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	b := bytes.Buffer{}
-	gz := gzip.NewWriter(&b)
-	if _, err := gz.Write(body); err != nil {
-		t.Fatal(err)
-	}
-	if err := gz.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	producer := MockKafkaProducer{}
-	w := &MockResponseWriter{}
-	r, _ := http.NewRequest("POST", "", bytes.NewReader(b.Bytes()))
-	h := Handler{
-		resolver: &public.Resolver{
-			ProducerQueue: &producer,
-			BatchedQueue:  &producer,
-			TracesQueue:   &producer,
+	for file, tc := range map[string]struct {
+		expectedMessageCounts map[kafkaqueue.PayloadType]int
+		expectedLogCounts     map[model.LogSource]int
+		expectedErrors        *int
+		expectedErrorEvent    *string
+	}{
+		"./samples/traces.json": {
+			expectedMessageCounts: map[kafkaqueue.PayloadType]int{
+				kafkaqueue.PushBackendPayload: 1,
+				kafkaqueue.PushLogs:           15,  // 4 exceptions, 11 logs
+				kafkaqueue.PushTraces:         501, // 512 spans - 11 logs
+			},
+			expectedLogCounts: map[model.LogSource]int{
+				model.LogSourceFrontend: 1,
+				model.LogSourceBackend:  14,
+			},
 		},
-	}
-	h.HandleTrace(w, r)
+		"./samples/nextjs.json": {
+			expectedErrorEvent: pointy.String("Error: /api/app-directory-test"),
+		},
+		"./samples/fs.json": {
+			expectedErrors: pointy.Int(0),
+		},
+	} {
+		inputBytes, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("error reading: %v", err)
+		}
 
-	logCountsBySource := map[model.LogSource]int{}
-	messageCountsByType := map[kafkaqueue.PayloadType]int{}
-	for _, message := range producer.messages {
-		messageCountsByType[message.Type]++
-		if message.Type == kafkaqueue.PushLogs {
-			log := message.PushLogs.LogRow
-			logCountsBySource[log.Source]++
+		req := ptraceotlp.NewExportRequest()
+		if err := req.UnmarshalJSON(inputBytes); err != nil {
+			t.Fatal(err)
+		}
+
+		body, err := req.MarshalProto()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		b := bytes.Buffer{}
+		gz := gzip.NewWriter(&b)
+		if _, err := gz.Write(body); err != nil {
+			t.Fatal(err)
+		}
+		if err := gz.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		producer := MockKafkaProducer{}
+		w := &MockResponseWriter{}
+		r, _ := http.NewRequest("POST", "", bytes.NewReader(b.Bytes()))
+		h := Handler{
+			resolver: &public.Resolver{
+				ProducerQueue: &producer,
+				BatchedQueue:  &producer,
+				TracesQueue:   &producer,
+			},
+		}
+		h.HandleTrace(w, r)
+
+		var appDirError *model2.BackendErrorObjectInput
+		numErrors := 0
+		logCountsBySource := map[model.LogSource]int{}
+		messageCountsByType := map[kafkaqueue.PayloadType]int{}
+		for _, message := range producer.messages {
+			messageCountsByType[message.Type]++
+			if message.Type == kafkaqueue.PushLogs {
+				log := message.PushLogs.LogRow
+				logCountsBySource[log.Source]++
+			} else if message.Type == kafkaqueue.PushBackendPayload {
+				appDirError = message.PushBackendPayload.Errors[0]
+				numErrors += len(message.PushBackendPayload.Errors)
+			}
+		}
+
+		if tc.expectedMessageCounts != nil {
+			assert.Equal(t, fmt.Sprintf("%+v", tc.expectedMessageCounts), fmt.Sprintf("%+v", messageCountsByType))
+		}
+
+		if tc.expectedErrors != nil {
+			assert.Equal(t, *tc.expectedErrors, numErrors)
+		}
+
+		if tc.expectedErrorEvent != nil {
+			assert.Equal(t, appDirError.Event, *tc.expectedErrorEvent)
+			assert.Greater(t, len(appDirError.StackTrace), 100)
+		}
+
+		if tc.expectedLogCounts != nil {
+			assert.Equal(t, fmt.Sprintf("%+v", tc.expectedLogCounts), fmt.Sprintf("%+v", logCountsBySource))
 		}
 	}
 
-	expectedMessageCountsByType := fmt.Sprintf("%+v", map[kafkaqueue.PayloadType]int{
-		kafkaqueue.PushBackendPayload: 1,
-		kafkaqueue.PushLogs:           15,  // 4 exceptions, 11 logs
-		kafkaqueue.PushTraces:         501, // 512 spans - 11 logs
-	})
-	assert.Equal(t, expectedMessageCountsByType, fmt.Sprintf("%+v", messageCountsByType))
-
-	expectedLogCountsByType := fmt.Sprintf("%+v", map[model.LogSource]int{
-		model.LogSourceFrontend: 1,
-		model.LogSourceBackend:  14,
-	})
-	assert.Equal(t, expectedLogCountsByType, fmt.Sprintf("%+v", logCountsBySource))
-}
-
-func TestHandler_HandleTrace_NextJS(t *testing.T) {
-	inputBytes, err := os.ReadFile("./samples/nextjs.json")
-	if err != nil {
-		t.Fatalf("error reading: %v", err)
-	}
-
-	req := ptraceotlp.NewExportRequest()
-	if err := req.UnmarshalJSON(inputBytes); err != nil {
-		t.Fatal(err)
-	}
-
-	body, err := req.MarshalProto()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	b := bytes.Buffer{}
-	gz := gzip.NewWriter(&b)
-	if _, err := gz.Write(body); err != nil {
-		t.Fatal(err)
-	}
-	if err := gz.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	producer := MockKafkaProducer{}
-	w := &MockResponseWriter{}
-	r, _ := http.NewRequest("POST", "", bytes.NewReader(b.Bytes()))
-	h := Handler{
-		resolver: &public.Resolver{
-			ProducerQueue: &producer,
-			BatchedQueue:  &producer,
-			TracesQueue:   &producer,
-		},
-	}
-	h.HandleTrace(w, r)
-
-	var appDirError *model2.BackendErrorObjectInput
-	messageCountsByType := map[kafkaqueue.PayloadType]int{}
-	for _, message := range producer.messages {
-		messageCountsByType[message.Type]++
-		if message.Type == kafkaqueue.PushBackendPayload {
-			appDirError = message.PushBackendPayload.Errors[0]
-		}
-	}
-
-	assert.Equal(t, appDirError.Event, "Error: /api/app-directory-test")
-	assert.Greater(t, len(appDirError.StackTrace), 100)
-
-	expectedMessageCountsByType := fmt.Sprintf("%+v", map[kafkaqueue.PayloadType]int{
-		kafkaqueue.PushBackendPayload: 1,
-		kafkaqueue.PushLogs:           3,
-		kafkaqueue.PushTraces:         6,
-	})
-	assert.Equal(t, expectedMessageCountsByType, fmt.Sprintf("%+v", messageCountsByType))
 }

--- a/backend/otel/samples/fs.json
+++ b/backend/otel/samples/fs.json
@@ -1,0 +1,6138 @@
+{
+	"resourceSpans": [
+		{
+			"resource": {
+				"attributes": [
+					{
+						"key": "service.name",
+						"value": {
+							"stringValue": "unknown_service:/home/vkorolik/.local/share/nvm/v18.16.0/bin/node"
+						}
+					},
+					{
+						"key": "telemetry.sdk.language",
+						"value": { "stringValue": "nodejs" }
+					},
+					{
+						"key": "telemetry.sdk.name",
+						"value": { "stringValue": "opentelemetry" }
+					},
+					{
+						"key": "telemetry.sdk.version",
+						"value": { "stringValue": "1.15.2" }
+					},
+					{
+						"key": "highlight.project_id",
+						"value": { "stringValue": "1" }
+					}
+				]
+			},
+			"scopeSpans": [
+				{
+					"scope": {
+						"name": "@opentelemetry/instrumentation-fs",
+						"version": "0.8.0"
+					},
+					"spans": [
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "99e0909e43347c91",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030427000000",
+							"endTimeUnixNano": "1692652030427344600",
+							"events": [
+								{
+									"timeUnixNano": "1692652030427340300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "9853cc85ef89f669",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030427000000",
+							"endTimeUnixNano": "1692652030427332000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030427330800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "c66f97636195c890",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030427000000",
+							"endTimeUnixNano": "1692652030427305000",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "78b31bbe6ddabee9",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030427000000",
+							"endTimeUnixNano": "1692652030427289300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030427288300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "6fbdf0f537f4026b",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030427000000",
+							"endTimeUnixNano": "1692652030427279000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030427278000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "ff94e14f7dc3236b",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030427000000",
+							"endTimeUnixNano": "1692652030427274200",
+							"events": [
+								{
+									"timeUnixNano": "1692652030427273200",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "e966b8d682af2c2c",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030427000000",
+							"endTimeUnixNano": "1692652030427267000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030427266000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "e8424d079e1d55e9",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030427000000",
+							"endTimeUnixNano": "1692652030427257300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030427256600",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "b4b0a13f6b41464a",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030427000000",
+							"endTimeUnixNano": "1692652030427088400",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "c1400e3d486569c4",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030427000000",
+							"endTimeUnixNano": "1692652030427195000",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "14028679b60efbf4",
+							"parentSpanId": "70e9a479585e9bfb",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030430000000",
+							"endTimeUnixNano": "1692652030430179800",
+							"events": [
+								{
+									"timeUnixNano": "1692652030430178300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "70ea77a5688df55c",
+							"parentSpanId": "70e9a479585e9bfb",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030430000000",
+							"endTimeUnixNano": "1692652030430168800",
+							"events": [
+								{
+									"timeUnixNano": "1692652030430167800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "8ab5c52527a5b98b",
+							"parentSpanId": "70e9a479585e9bfb",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030430000000",
+							"endTimeUnixNano": "1692652030430153200",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "52bea5ff797abe18",
+							"parentSpanId": "70e9a479585e9bfb",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030430000000",
+							"endTimeUnixNano": "1692652030430144800",
+							"events": [
+								{
+									"timeUnixNano": "1692652030430144300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "2d89c80c448da220",
+							"parentSpanId": "70e9a479585e9bfb",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030430000000",
+							"endTimeUnixNano": "1692652030430138600",
+							"events": [
+								{
+									"timeUnixNano": "1692652030430138000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "d16cfd70d3d2728c",
+							"parentSpanId": "70e9a479585e9bfb",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030430000000",
+							"endTimeUnixNano": "1692652030430133500",
+							"events": [
+								{
+									"timeUnixNano": "1692652030430132700",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "eae161d0088d5463",
+							"parentSpanId": "70e9a479585e9bfb",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030430000000",
+							"endTimeUnixNano": "1692652030430124800",
+							"events": [
+								{
+									"timeUnixNano": "1692652030430124300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "7265bb20b365cb93",
+							"parentSpanId": "70e9a479585e9bfb",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030430000000",
+							"endTimeUnixNano": "1692652030430120000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030430119400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "83618884168e264d",
+							"parentSpanId": "70e9a479585e9bfb",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030430000000",
+							"endTimeUnixNano": "1692652030430058800",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "6da78bf0c01eff76",
+							"parentSpanId": "70e9a479585e9bfb",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030431000000",
+							"endTimeUnixNano": "1692652030431090700",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "4494e1f64f9f9ba3",
+							"parentSpanId": "65542791dae7b2ff",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030432000000",
+							"endTimeUnixNano": "1692652030432170800",
+							"events": [
+								{
+									"timeUnixNano": "1692652030432169200",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "53c0d0b1d8497d88",
+							"parentSpanId": "65542791dae7b2ff",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030432000000",
+							"endTimeUnixNano": "1692652030432156400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030432156000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "b4b3627e5e0c5e65",
+							"parentSpanId": "65542791dae7b2ff",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030432000000",
+							"endTimeUnixNano": "1692652030432142000",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "69a4eb06a6838d22",
+							"parentSpanId": "65542791dae7b2ff",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030432000000",
+							"endTimeUnixNano": "1692652030432137500",
+							"events": [
+								{
+									"timeUnixNano": "1692652030432137000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "f71a5670b5a625c8",
+							"parentSpanId": "65542791dae7b2ff",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030432000000",
+							"endTimeUnixNano": "1692652030432133400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030432132600",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "d18f65264a66cc5c",
+							"parentSpanId": "65542791dae7b2ff",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030432000000",
+							"endTimeUnixNano": "1692652030432128500",
+							"events": [
+								{
+									"timeUnixNano": "1692652030432128000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "3d8b534cab873db8",
+							"parentSpanId": "65542791dae7b2ff",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030432000000",
+							"endTimeUnixNano": "1692652030432122400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030432121600",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "fd2b1ad62d1b48f7",
+							"parentSpanId": "65542791dae7b2ff",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030432000000",
+							"endTimeUnixNano": "1692652030432116500",
+							"events": [
+								{
+									"timeUnixNano": "1692652030432116000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "f616e44c506c4716",
+							"parentSpanId": "65542791dae7b2ff",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030432000000",
+							"endTimeUnixNano": "1692652030432048000",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "a70afc0293f1f6c9",
+							"parentSpanId": "65542791dae7b2ff",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030432000000",
+							"endTimeUnixNano": "1692652030432077800",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "5d2df0d30e4a9181",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs stat",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030435094300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030435092700",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, stat '/home/vkorolik/work/highlight/e2e/nextjs/public/api/trpc/helloWorld'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, stat '/home/vkorolik/work/highlight/e2e/nextjs/public/api/trpc/helloWorld'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, stat '/home/vkorolik/work/highlight/e2e/nextjs/public/api/trpc/helloWorld'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "3d1172dce07821a6",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030435148000",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "4acc252fea692681",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030435171000",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "3f17293fd873ce1a",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030435140000",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "85bb54c5f688f356",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030435116300",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "23f48aa10dbb01b1",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030435106600",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "8849f74cff68baf5",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030435097900",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "816a105a79364352",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030435091500",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "c3ebfa778a69dc61",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030435086000",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "ec66694be4c11d05",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030435080200",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "07ff6a1e2ecbcb9b",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030436341500",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "1e82de6ffbbfc597",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030436298800",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "96a424e72349e09c",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030436294400",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "3273790f2e17ae7e",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030436288500",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "35492652483302a6",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030436282400",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "13fb14dd6be2f660",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030435000000",
+							"endTimeUnixNano": "1692652030436276700",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "9d4729caa5888ca6",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437054500",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "a4c13f383f76be7c",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437067500",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "8588343c56cbe3d8",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437118200",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "fcd29a5fac59c20c",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437099300",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "94e24d880ce4f668",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437090600",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "1bb4490773a396c9",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437084400",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "ac607388f4df1c56",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437077800",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "8db241aa8d0967e8",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437074700",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "abe94156a5880506",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437070300",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "084b460cc9de32c8",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437134800",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "53473f2593cd8612",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437073700",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "0793918e20428d68",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437065500",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "a0fa870ede9546bc",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437058800",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "5513fe5646ea419a",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437049600",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "139c4a0098cd219b",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437044500",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "74d1f3ffa01e5a98",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030437000000",
+							"endTimeUnixNano": "1692652030437078300",
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "77f0214608cf45be",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030438000000",
+							"endTimeUnixNano": "1692652030438096400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030438094600",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/trpc/helloWorld/page.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/trpc/helloWorld/page.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/trpc/helloWorld/page.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "d043dd5ec6e3b83c",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030438000000",
+							"endTimeUnixNano": "1692652030438082600",
+							"events": [
+								{
+									"timeUnixNano": "1692652030438081800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/trpc/helloWorld/page.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/trpc/helloWorld/page.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/trpc/helloWorld/page.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "ab1c137b2d858a80",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030438000000",
+							"endTimeUnixNano": "1692652030438077400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030438076700",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/trpc/helloWorld/page.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/trpc/helloWorld/page.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/trpc/helloWorld/page.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "c5ce6e86c131ba52",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030438000000",
+							"endTimeUnixNano": "1692652030438074400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030438073300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/trpc/helloWorld/page.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/trpc/helloWorld/page.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/trpc/helloWorld/page.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "aef0d954e4069917",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030438000000",
+							"endTimeUnixNano": "1692652030438141000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030438139600",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "65c3745e17a8f32c",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030438000000",
+							"endTimeUnixNano": "1692652030438128600",
+							"events": [
+								{
+									"timeUnixNano": "1692652030438128000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld/index.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld/index.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld/index.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "d1fc7f47faf22279",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030438000000",
+							"endTimeUnixNano": "1692652030438121000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030438120400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "abaf732008165158",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030438000000",
+							"endTimeUnixNano": "1692652030438114600",
+							"events": [
+								{
+									"timeUnixNano": "1692652030438114000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld/index.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld/index.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld/index.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "977e5069f00aacde",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030438000000",
+							"endTimeUnixNano": "1692652030438109000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030438108400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "cf17975036c0a013",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030438000000",
+							"endTimeUnixNano": "1692652030438104300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030438103800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld/index.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld/index.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld/index.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "a7d36abc51054980",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030438000000",
+							"endTimeUnixNano": "1692652030438101200",
+							"events": [
+								{
+									"timeUnixNano": "1692652030438100700",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "6d018b37700e9e98",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030438000000",
+							"endTimeUnixNano": "1692652030438094600",
+							"events": [
+								{
+									"timeUnixNano": "1692652030438094000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld/index.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld/index.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/trpc/helloWorld/index.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "423d3a169ae20a7b",
+							"parentSpanId": "ac1c187be572ab23",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030441000000",
+							"endTimeUnixNano": "1692652030441095400",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "9a6fa50c8e872170",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030493000000",
+							"endTimeUnixNano": "1692652030493206300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030493204200",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "a7f03f66a1f07711",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030493000000",
+							"endTimeUnixNano": "1692652030493167900",
+							"events": [
+								{
+									"timeUnixNano": "1692652030493167000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "586f1ebc1b7203c5",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030493000000",
+							"endTimeUnixNano": "1692652030493152500",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "863d838a1a36a50e",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030493000000",
+							"endTimeUnixNano": "1692652030493147100",
+							"events": [
+								{
+									"timeUnixNano": "1692652030493146400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "206a49781388a653",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030493000000",
+							"endTimeUnixNano": "1692652030493142300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030493141800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "998de35498d47625",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030493000000",
+							"endTimeUnixNano": "1692652030493134800",
+							"events": [
+								{
+									"timeUnixNano": "1692652030493134300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "28ab865354b4adc9",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030493000000",
+							"endTimeUnixNano": "1692652030493129700",
+							"events": [
+								{
+									"timeUnixNano": "1692652030493129200",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "6b70f62eb61fbb13",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030493000000",
+							"endTimeUnixNano": "1692652030493126000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030493125000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "012ee1b8c3532ce8",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030493000000",
+							"endTimeUnixNano": "1692652030493053400",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "091771963cdaf1ed",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030493000000",
+							"endTimeUnixNano": "1692652030493106000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "3ed3829e01f9c3d2",
+							"parentSpanId": "a7a565e0d6550277",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030495000000",
+							"endTimeUnixNano": "1692652030495170600",
+							"events": [
+								{
+									"timeUnixNano": "1692652030495168800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "0a0eba6a5ed068aa",
+							"parentSpanId": "a7a565e0d6550277",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030495000000",
+							"endTimeUnixNano": "1692652030495156700",
+							"events": [
+								{
+									"timeUnixNano": "1692652030495156000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "b7dbabc6f0efb433",
+							"parentSpanId": "a7a565e0d6550277",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030495000000",
+							"endTimeUnixNano": "1692652030495145200",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "15a5cea544388d42",
+							"parentSpanId": "a7a565e0d6550277",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030495000000",
+							"endTimeUnixNano": "1692652030495137500",
+							"events": [
+								{
+									"timeUnixNano": "1692652030495137000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "d774030d7c15ddde",
+							"parentSpanId": "a7a565e0d6550277",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030495000000",
+							"endTimeUnixNano": "1692652030495132400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030495132000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "47155dd8845fdf7e",
+							"parentSpanId": "a7a565e0d6550277",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030495000000",
+							"endTimeUnixNano": "1692652030495129300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030495128800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "c503c40cbaf29df7",
+							"parentSpanId": "a7a565e0d6550277",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030495000000",
+							"endTimeUnixNano": "1692652030495124000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030495123500",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "94357fd754ce7cf4",
+							"parentSpanId": "a7a565e0d6550277",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030495000000",
+							"endTimeUnixNano": "1692652030495119400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030495118800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "fd292e7b517877f1",
+							"parentSpanId": "a7a565e0d6550277",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030495000000",
+							"endTimeUnixNano": "1692652030495051000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "60d4a5cb89acd74e",
+							"parentSpanId": "a7a565e0d6550277",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030496000000",
+							"endTimeUnixNano": "1692652030496084000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "fa85f20b84daf345",
+							"parentSpanId": "23a70f95dc9d96ed",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030497000000",
+							"endTimeUnixNano": "1692652030497199600",
+							"events": [
+								{
+									"timeUnixNano": "1692652030497198000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "44036074abba96d6",
+							"parentSpanId": "23a70f95dc9d96ed",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030497000000",
+							"endTimeUnixNano": "1692652030497189000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030497188400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "7586fd34bbfffacb",
+							"parentSpanId": "23a70f95dc9d96ed",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030497000000",
+							"endTimeUnixNano": "1692652030497175300",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "87f2a693b918b10a",
+							"parentSpanId": "23a70f95dc9d96ed",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030497000000",
+							"endTimeUnixNano": "1692652030497169200",
+							"events": [
+								{
+									"timeUnixNano": "1692652030497168400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "8510db77d31a99de",
+							"parentSpanId": "23a70f95dc9d96ed",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030497000000",
+							"endTimeUnixNano": "1692652030497159000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030497158400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "1a3ce298332211f4",
+							"parentSpanId": "23a70f95dc9d96ed",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030497000000",
+							"endTimeUnixNano": "1692652030497153000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030497152500",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "a9b9db01da29ea81",
+							"parentSpanId": "23a70f95dc9d96ed",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030497000000",
+							"endTimeUnixNano": "1692652030497148200",
+							"events": [
+								{
+									"timeUnixNano": "1692652030497147600",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "cec77b7a91da450a",
+							"parentSpanId": "23a70f95dc9d96ed",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030497000000",
+							"endTimeUnixNano": "1692652030497143300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030497142800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/middleware/index.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "7d290244d332967f",
+							"parentSpanId": "23a70f95dc9d96ed",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030497000000",
+							"endTimeUnixNano": "1692652030497047000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "74c9e5b5495717dd",
+							"parentSpanId": "23a70f95dc9d96ed",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030497000000",
+							"endTimeUnixNano": "1692652030497085200",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "010cb27909421c82",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs stat",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499069700",
+							"events": [
+								{
+									"timeUnixNano": "1692652030499068400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, stat '/home/vkorolik/work/highlight/e2e/nextjs/public/api/app-directory-test'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, stat '/home/vkorolik/work/highlight/e2e/nextjs/public/api/app-directory-test'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, stat '/home/vkorolik/work/highlight/e2e/nextjs/public/api/app-directory-test'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "8eb2dd0d95e66624",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499112000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "2560807ca37af827",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499130400",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "06a28b01b32ef42d",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499130000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "103def4bf34c52a0",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499111200",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "60c08f07fa74c0d3",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499102500",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "2f2ae16b71056748",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499097900",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "7ab2404961ab5ed4",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499090200",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "f6732fda89b9283c",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499086300",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "d8797b4f41c6ac20",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499077000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "e4fab2fa685d7b9a",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499137300",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "cc5934811a6c7d7c",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499073500",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "aad98ef92fd9eb3e",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499065600",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "65b925c10819f884",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499058200",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "3f8e60a46ec96eb2",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499052500",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "07fb06ad0808d0c2",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499047400",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "763f42f3ad7557a6",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030499000000",
+							"endTimeUnixNano": "1692652030499080400",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "58068d067d21fd10",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030500000000",
+							"endTimeUnixNano": "1692652030500038000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030500036900",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "8085d34bc78f6c74",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030500000000",
+							"endTimeUnixNano": "1692652030500028200",
+							"events": [
+								{
+									"timeUnixNano": "1692652030500027100",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "345fdee60ffe53f8",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030500000000",
+							"endTimeUnixNano": "1692652030500621300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030500618500",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "fcbedf8ca36d4459",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030500000000",
+							"endTimeUnixNano": "1692652030500042500",
+							"events": [
+								{
+									"timeUnixNano": "1692652030500041200",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "d7b88f1048b67a78",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030500000000",
+							"endTimeUnixNano": "1692652030500027000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030500025900",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "df43ba8085e67a24",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030500000000",
+							"endTimeUnixNano": "1692652030500026000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030500025000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "43662633902dd0ad",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030500000000",
+							"endTimeUnixNano": "1692652030500028000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030500027000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "b24046c24ca2a4dd",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501023700",
+							"events": [
+								{
+									"timeUnixNano": "1692652030501023000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "8af7ace83f21c3f2",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501015600",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "1a8fab5e21cbe608",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501023700",
+							"events": [
+								{
+									"timeUnixNano": "1692652030501022700",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "cb5f51e0014b11d7",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501022200",
+							"events": [
+								{
+									"timeUnixNano": "1692652030501021400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "dd449a2e87d668b7",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501023500",
+							"events": [
+								{
+									"timeUnixNano": "1692652030501022500",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "2e9e5ce82ba6d905",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501090300",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "3325786ce24e0df5",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501058300",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "f0c146437888e2d4",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501099800",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "e5a2acdb40ecd1bb",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501236200",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "0c805d53950b75b2",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501220400",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "03a6e73432b42d48",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501204200",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "7a79de96db0e7d27",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501191000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "1765556cb465b6f0",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501179400",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "9663d66a7dca38bf",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501169000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "9f2536e9abe87c92",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030501000000",
+							"endTimeUnixNano": "1692652030501155300",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "3f64bc1771dc41ca",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502255600",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "32df92f8668b2c4b",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502119400",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "9e81c79505bc5dfb",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502100000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "1d01790c7a0108c5",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502087000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "7fc8783173a024ec",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502076700",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "ca330f8c2bb0f324",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readdir",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502070300",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "7a4d5b371fd8849c",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502110500",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "d81eb77bde2e9433",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502054000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030502052400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "9307b52a52aa4a3f",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502032000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030502031000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "05a67b881dfdb095",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502025000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030502024000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "1afa7205d9b715bd",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502024700",
+							"events": [
+								{
+									"timeUnixNano": "1692652030502023700",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "58250f36114e3321",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502024000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030502023200",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "cb5057044e7ae328",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502024200",
+							"events": [
+								{
+									"timeUnixNano": "1692652030502023200",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "175a95622b507c5a",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502023700",
+							"events": [
+								{
+									"timeUnixNano": "1692652030502023000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "9211995cb4c7de1b",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502023000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030502022100",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "1ac2e6786e5fff80",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502015200",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "a65955a51be941a7",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502022700",
+							"events": [
+								{
+									"timeUnixNano": "1692652030502021600",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "8890ec6a9a1cc412",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030502000000",
+							"endTimeUnixNano": "1692652030502023700",
+							"events": [
+								{
+									"timeUnixNano": "1692652030502023000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "a79d396a45dc18f0",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503022800",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503021800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "d986da77298ec16b",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503072000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "b487f889e3d80cfd",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503098400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503095800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/page.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/page.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/page.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "0b2346b8a91aba83",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503085300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503084800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/page.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/page.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/page.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "c8dbe4d54ecafe5e",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503080400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503079700",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/page.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/page.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/page.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "3351bb6a9e4c43c7",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503068200",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503067600",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/page.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/page.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/page.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "7a28fdae75276922",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503127000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503125800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "bd71cd64fd51126a",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503118000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503117300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test/index.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test/index.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test/index.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "e0195940bd9e3741",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503111200",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503110700",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "b73469d503673613",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503106300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503105800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test/index.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test/index.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test/index.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "b5a85c038195986e",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503102200",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503101700",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "8e3ac9743581ca74",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503097300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503096800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test/index.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test/index.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test/index.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "b9b31804e58bbcd3",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503094300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503093800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "80ceafb982b5c3cf",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030503000000",
+							"endTimeUnixNano": "1692652030503089000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030503088400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test/index.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test/index.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/pages/api/app-directory-test/index.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "53fbf4ef4a48adca",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030507000000",
+							"endTimeUnixNano": "1692652030507088600",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "e4e211fa4cf6ebc4",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030507000000",
+							"endTimeUnixNano": "1692652030507038700",
+							"events": [
+								{
+									"timeUnixNano": "1692652030507037200",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "afee3e0ff13b6824",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030508000000",
+							"endTimeUnixNano": "1692652030508028700",
+							"events": [
+								{
+									"timeUnixNano": "1692652030508027600",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "fa39d749611f96d4",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030508000000",
+							"endTimeUnixNano": "1692652030508025000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030508024300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "301eb95639b0cad1",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030508000000",
+							"endTimeUnixNano": "1692652030508032500",
+							"events": [
+								{
+									"timeUnixNano": "1692652030508031500",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "8c88c10a56d26bc7",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030508000000",
+							"endTimeUnixNano": "1692652030508025000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030508024300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "4eb3bb295b681e86",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030508000000",
+							"endTimeUnixNano": "1692652030508023600",
+							"events": [
+								{
+									"timeUnixNano": "1692652030508022800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "85a3472080470cbd",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030508000000",
+							"endTimeUnixNano": "1692652030508023800",
+							"events": [
+								{
+									"timeUnixNano": "1692652030508023000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "87d9e9044ab1d49a",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030508000000",
+							"endTimeUnixNano": "1692652030508022300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030508021500",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "4f09bd0428e31c5a",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030508000000",
+							"endTimeUnixNano": "1692652030508030500",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "4988c85c731ff824",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030508000000",
+							"endTimeUnixNano": "1692652030508026600",
+							"events": [
+								{
+									"timeUnixNano": "1692652030508025600",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "9c5f413277c03691",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030508000000",
+							"endTimeUnixNano": "1692652030508026000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030508025300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "620e1513e267adef",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030508000000",
+							"endTimeUnixNano": "1692652030508024000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030508023000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "dc3b62b88daff167",
+							"parentSpanId": "d8f7825bfce79f1d",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030508000000",
+							"endTimeUnixNano": "1692652030508069600",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "61bbaefb74546d56",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030510000000",
+							"endTimeUnixNano": "1692652030510095000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "0548ea210a7bdcf6",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030510000000",
+							"endTimeUnixNano": "1692652030510038300",
+							"events": [
+								{
+									"timeUnixNano": "1692652030510037000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "c2c8199bb4cf68f8",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030510000000",
+							"endTimeUnixNano": "1692652030510028800",
+							"events": [
+								{
+									"timeUnixNano": "1692652030510027800",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "f98a151f93b051bd",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030510000000",
+							"endTimeUnixNano": "1692652030510025200",
+							"events": [
+								{
+									"timeUnixNano": "1692652030510024200",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "12da48f190be1c23",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030510000000",
+							"endTimeUnixNano": "1692652030510024700",
+							"events": [
+								{
+									"timeUnixNano": "1692652030510024000",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/app-directory-test/layout.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "71b59be7bcef98bb",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030510000000",
+							"endTimeUnixNano": "1692652030510023200",
+							"events": [
+								{
+									"timeUnixNano": "1692652030510022100",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.tsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.tsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.tsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "87534094814c9375",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030510000000",
+							"endTimeUnixNano": "1692652030510024000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030510023200",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "68afc2dd59c00960",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030510000000",
+							"endTimeUnixNano": "1692652030510033400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030510032400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "a6e16b2f73399918",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030510000000",
+							"endTimeUnixNano": "1692652030510024000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030510023200",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/api/layout.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "bcbc26d22bc4efc8",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030511000000",
+							"endTimeUnixNano": "1692652030511016000",
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "5f8dfd91b2f7458d",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030511000000",
+							"endTimeUnixNano": "1692652030511023600",
+							"events": [
+								{
+									"timeUnixNano": "1692652030511022300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.ts'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.ts'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.ts'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "37a457b54f97c995",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030511000000",
+							"endTimeUnixNano": "1692652030511025400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030511024400",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.jsx'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.jsx'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.jsx'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "ac8b91a949bf9755",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs access",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030511000000",
+							"endTimeUnixNano": "1692652030511023000",
+							"events": [
+								{
+									"timeUnixNano": "1692652030511022300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "ENOENT" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.js'"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.js'"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "ENOENT: no such file or directory, access '/home/vkorolik/work/highlight/e2e/nextjs/src/app/layout.js'",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "81f596c961c16d53",
+							"parentSpanId": "a291f3e6bebd8f23",
+							"name": "fs readFile",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030511000000",
+							"endTimeUnixNano": "1692652030511072000",
+							"status": {}
+						}
+					]
+				},
+				{
+					"scope": {
+						"name": "@opentelemetry/instrumentation-http",
+						"version": "0.41.0"
+					},
+					"spans": [
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "70e9a479585e9bfb",
+							"parentSpanId": "bb7da80dbf5f8670",
+							"name": "GET",
+							"kind": 2,
+							"startTimeUnixNano": "1692652030430000000",
+							"endTimeUnixNano": "1692652030430888200",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:36663/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22page%22%3A%22%2Fmiddleware%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.host",
+									"value": {
+										"stringValue": "127.0.0.1:36663"
+									}
+								},
+								{
+									"key": "net.host.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.scheme",
+									"value": { "stringValue": "http" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22page%22%3A%22%2Fmiddleware%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								},
+								{
+									"key": "net.host.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.host.port",
+									"value": { "intValue": "36663" }
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "52114" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "65542791dae7b2ff",
+							"parentSpanId": "9662bff0796929c8",
+							"name": "GET",
+							"kind": 2,
+							"startTimeUnixNano": "1692652030432000000",
+							"endTimeUnixNano": "1692652030432571000",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:36663/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22page%22%3A%22%2Fmiddleware%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.host",
+									"value": {
+										"stringValue": "127.0.0.1:36663"
+									}
+								},
+								{
+									"key": "net.host.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.scheme",
+									"value": { "stringValue": "http" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22page%22%3A%22%2Fmiddleware%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								},
+								{
+									"key": "net.host.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.host.port",
+									"value": { "intValue": "36663" }
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "52126" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "9927a220d5343a08",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "GET",
+							"kind": 3,
+							"startTimeUnixNano": "1692652030428000000",
+							"endTimeUnixNano": "1692652030435029500",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:38081/api/trpc/helloWorld?batch=1\u0026input=%7B%220%22%3A%7B%22message%22%3A%22Hello%20Chris%22%7D%7D"
+									}
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/api/trpc/helloWorld?batch=1\u0026input=%7B%220%22%3A%7B%22message%22%3A%22Hello%20Chris%22%7D%7D"
+									}
+								},
+								{
+									"key": "net.peer.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.host",
+									"value": { "stringValue": "localhost:3005" }
+								},
+								{
+									"key": "http.user_agent",
+									"value": {
+										"stringValue": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+									}
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "38081" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "ac1c187be572ab23",
+							"parentSpanId": "c8d8f956e57f2eb4",
+							"name": "GET",
+							"kind": 2,
+							"startTimeUnixNano": "1692652030440000000",
+							"endTimeUnixNano": "1692652030440342300",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:36663/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22match%22%3A%7B%22definition%22%3A%7B%22kind%22%3A%22PAGES_API%22%2C%22pathname%22%3A%22%2Fapi%2Ftrpc%2F%5Btrpc%5D%22%2C%22page%22%3A%22%2Fapi%2Ftrpc%2F%5Btrpc%5D%22%2C%22bundlePath%22%3A%22pages%2Fapi%2Ftrpc%2F%5Btrpc%5D%22%2C%22filename%22%3A%22%2Fhome%2Fvkorolik%2Fwork%2Fhighlight%2Fe2e%2Fnextjs%2Fpages%2Fapi%2Ftrpc%2F%5Btrpc%5D.ts%22%7D%2C%22params%22%3A%7B%22trpc%22%3A%22helloWorld%22%7D%7D%2C%22page%22%3A%22%2Fapi%2Ftrpc%2F%5Btrpc%5D%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.host",
+									"value": {
+										"stringValue": "127.0.0.1:36663"
+									}
+								},
+								{
+									"key": "net.host.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.scheme",
+									"value": { "stringValue": "http" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22match%22%3A%7B%22definition%22%3A%7B%22kind%22%3A%22PAGES_API%22%2C%22pathname%22%3A%22%2Fapi%2Ftrpc%2F%5Btrpc%5D%22%2C%22page%22%3A%22%2Fapi%2Ftrpc%2F%5Btrpc%5D%22%2C%22bundlePath%22%3A%22pages%2Fapi%2Ftrpc%2F%5Btrpc%5D%22%2C%22filename%22%3A%22%2Fhome%2Fvkorolik%2Fwork%2Fhighlight%2Fe2e%2Fnextjs%2Fpages%2Fapi%2Ftrpc%2F%5Btrpc%5D.ts%22%7D%2C%22params%22%3A%7B%22trpc%22%3A%22helloWorld%22%7D%7D%2C%22page%22%3A%22%2Fapi%2Ftrpc%2F%5Btrpc%5D%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								},
+								{
+									"key": "net.host.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.host.port",
+									"value": { "intValue": "36663" }
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "52134" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "4918d4a8d8a1ebc3",
+							"parentSpanId": "b65f7ab290256fa1",
+							"name": "GET",
+							"kind": 3,
+							"startTimeUnixNano": "1692652030439000000",
+							"endTimeUnixNano": "1692652030444181800",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:38081/api/trpc/helloWorld?batch=1\u0026input=%7B%220%22%3A%7B%22message%22%3A%22Hello%20Chris%22%7D%7D"
+									}
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/api/trpc/helloWorld?batch=1\u0026input=%7B%220%22%3A%7B%22message%22%3A%22Hello%20Chris%22%7D%7D"
+									}
+								},
+								{
+									"key": "net.peer.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.host",
+									"value": { "stringValue": "localhost:3005" }
+								},
+								{
+									"key": "http.user_agent",
+									"value": {
+										"stringValue": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+									}
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "38081" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "0d2f4e56d58b009144ec8d38926c5606",
+							"spanId": "b65f7ab290256fa1",
+							"parentSpanId": "",
+							"name": "GET",
+							"kind": 2,
+							"startTimeUnixNano": "1692652030425000000",
+							"endTimeUnixNano": "1692652030443828700",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://localhost:3005/api/trpc/helloWorld?batch=1\u0026input=%7B%220%22%3A%7B%22message%22%3A%22Hello%20Chris%22%7D%7D"
+									}
+								},
+								{
+									"key": "http.host",
+									"value": { "stringValue": "localhost:3005" }
+								},
+								{
+									"key": "net.host.name",
+									"value": { "stringValue": "localhost" }
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.scheme",
+									"value": { "stringValue": "http" }
+								},
+								{
+									"key": "http.client_ip",
+									"value": { "stringValue": "::1" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/api/trpc/helloWorld?batch=1\u0026input=%7B%220%22%3A%7B%22message%22%3A%22Hello%20Chris%22%7D%7D"
+									}
+								},
+								{
+									"key": "http.user_agent",
+									"value": {
+										"stringValue": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+									}
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								},
+								{
+									"key": "net.host.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.host.port",
+									"value": { "intValue": "42525" }
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "57970" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "a7a565e0d6550277",
+							"parentSpanId": "43cc3170254a21ac",
+							"name": "GET",
+							"kind": 2,
+							"startTimeUnixNano": "1692652030495000000",
+							"endTimeUnixNano": "1692652030495628300",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:36663/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22page%22%3A%22%2Fmiddleware%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.host",
+									"value": {
+										"stringValue": "127.0.0.1:36663"
+									}
+								},
+								{
+									"key": "net.host.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.scheme",
+									"value": { "stringValue": "http" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22page%22%3A%22%2Fmiddleware%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								},
+								{
+									"key": "net.host.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.host.port",
+									"value": { "intValue": "36663" }
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "52138" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "23a70f95dc9d96ed",
+							"parentSpanId": "5e7cabd032ff19c1",
+							"name": "GET",
+							"kind": 2,
+							"startTimeUnixNano": "1692652030497000000",
+							"endTimeUnixNano": "1692652030497608200",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:36663/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22page%22%3A%22%2Fmiddleware%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.host",
+									"value": {
+										"stringValue": "127.0.0.1:36663"
+									}
+								},
+								{
+									"key": "net.host.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.scheme",
+									"value": { "stringValue": "http" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22page%22%3A%22%2Fmiddleware%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								},
+								{
+									"key": "net.host.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.host.port",
+									"value": { "intValue": "36663" }
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "52142" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "1d9eb4504a18a2d6",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "GET",
+							"kind": 3,
+							"startTimeUnixNano": "1692652030494000000",
+							"endTimeUnixNano": "1692652030499239000",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:38081/api/app-directory-test?success=false"
+									}
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/api/app-directory-test?success=false"
+									}
+								},
+								{
+									"key": "net.peer.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.host",
+									"value": { "stringValue": "localhost:3005" }
+								},
+								{
+									"key": "http.user_agent",
+									"value": {
+										"stringValue": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+									}
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "38081" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "d8f7825bfce79f1d",
+							"parentSpanId": "d6a6a8e465ac625e",
+							"name": "GET",
+							"kind": 2,
+							"startTimeUnixNano": "1692652030507000000",
+							"endTimeUnixNano": "1692652030507939300",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:36663/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22match%22%3A%7B%22definition%22%3A%7B%22kind%22%3A%22APP_ROUTE%22%2C%22pathname%22%3A%22%2Fapi%2Fapp-directory-test%22%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22bundlePath%22%3A%22app%2Fapi%2Fapp-directory-test%2Froute%22%2C%22filename%22%3A%22%2Fhome%2Fvkorolik%2Fwork%2Fhighlight%2Fe2e%2Fnextjs%2Fsrc%2Fapp%2Fapi%2Fapp-directory-test%2Froute.ts%22%7D%7D%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.host",
+									"value": {
+										"stringValue": "127.0.0.1:36663"
+									}
+								},
+								{
+									"key": "net.host.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.scheme",
+									"value": { "stringValue": "http" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22match%22%3A%7B%22definition%22%3A%7B%22kind%22%3A%22APP_ROUTE%22%2C%22pathname%22%3A%22%2Fapi%2Fapp-directory-test%22%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22bundlePath%22%3A%22app%2Fapi%2Fapp-directory-test%2Froute%22%2C%22filename%22%3A%22%2Fhome%2Fvkorolik%2Fwork%2Fhighlight%2Fe2e%2Fnextjs%2Fsrc%2Fapp%2Fapi%2Fapp-directory-test%2Froute.ts%22%7D%7D%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								},
+								{
+									"key": "net.host.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.host.port",
+									"value": { "intValue": "36663" }
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "52146" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "a291f3e6bebd8f23",
+							"parentSpanId": "06adc36be1e8a305",
+							"name": "GET",
+							"kind": 2,
+							"startTimeUnixNano": "1692652030510000000",
+							"endTimeUnixNano": "1692652030510897700",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:36663/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22match%22%3A%7B%22definition%22%3A%7B%22kind%22%3A%22APP_ROUTE%22%2C%22pathname%22%3A%22%2Fapi%2Fapp-directory-test%22%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22bundlePath%22%3A%22app%2Fapi%2Fapp-directory-test%2Froute%22%2C%22filename%22%3A%22%2Fhome%2Fvkorolik%2Fwork%2Fhighlight%2Fe2e%2Fnextjs%2Fsrc%2Fapp%2Fapi%2Fapp-directory-test%2Froute.ts%22%7D%7D%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.host",
+									"value": {
+										"stringValue": "127.0.0.1:36663"
+									}
+								},
+								{
+									"key": "net.host.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.scheme",
+									"value": { "stringValue": "http" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22match%22%3A%7B%22definition%22%3A%7B%22kind%22%3A%22APP_ROUTE%22%2C%22pathname%22%3A%22%2Fapi%2Fapp-directory-test%22%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22bundlePath%22%3A%22app%2Fapi%2Fapp-directory-test%2Froute%22%2C%22filename%22%3A%22%2Fhome%2Fvkorolik%2Fwork%2Fhighlight%2Fe2e%2Fnextjs%2Fsrc%2Fapp%2Fapi%2Fapp-directory-test%2Froute.ts%22%7D%7D%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								},
+								{
+									"key": "net.host.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.host.port",
+									"value": { "intValue": "36663" }
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "52152" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "d6e3aa6d8ac8267b",
+							"parentSpanId": "5e88997360e63bbf",
+							"name": "GET",
+							"kind": 2,
+							"startTimeUnixNano": "1692652030512000000",
+							"endTimeUnixNano": "1692652030512199000",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:36663/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=getCompilationError\u0026args=%5B%22%2Fapi%2Fapp-directory-test%2Froute%22%5D"
+									}
+								},
+								{
+									"key": "http.host",
+									"value": {
+										"stringValue": "127.0.0.1:36663"
+									}
+								},
+								{
+									"key": "net.host.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.scheme",
+									"value": { "stringValue": "http" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=getCompilationError\u0026args=%5B%22%2Fapi%2Fapp-directory-test%2Froute%22%5D"
+									}
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								},
+								{
+									"key": "net.host.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.host.port",
+									"value": { "intValue": "36663" }
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "52162" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "5ffdc8bbaaa82aef",
+							"parentSpanId": "6ce0b168117bb1ce",
+							"name": "GET",
+							"kind": 3,
+							"startTimeUnixNano": "1692652030504000000",
+							"endTimeUnixNano": "1692652030527884300",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:43843/api/app-directory-test?success=false"
+									}
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/api/app-directory-test?success=false"
+									}
+								},
+								{
+									"key": "net.peer.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.host",
+									"value": { "stringValue": "localhost:3005" }
+								},
+								{
+									"key": "http.user_agent",
+									"value": {
+										"stringValue": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+									}
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "43843" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "500" }
+								},
+								{
+									"key": "http.status_text",
+									"value": {
+										"stringValue": "INTERNAL SERVER ERROR"
+									}
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								}
+							],
+							"status": { "code": 2 }
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "6ce0b168117bb1ce",
+							"parentSpanId": "",
+							"name": "GET",
+							"kind": 2,
+							"startTimeUnixNano": "1692652030492000000",
+							"endTimeUnixNano": "1692652030528251000",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://localhost:3005/api/app-directory-test?success=false"
+									}
+								},
+								{
+									"key": "http.host",
+									"value": { "stringValue": "localhost:3005" }
+								},
+								{
+									"key": "net.host.name",
+									"value": { "stringValue": "localhost" }
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.scheme",
+									"value": { "stringValue": "http" }
+								},
+								{
+									"key": "http.client_ip",
+									"value": { "stringValue": "::1" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/api/app-directory-test?success=false"
+									}
+								},
+								{
+									"key": "http.user_agent",
+									"value": {
+										"stringValue": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+									}
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								},
+								{
+									"key": "net.host.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.host.port",
+									"value": { "intValue": "42525" }
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "57984" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "500" }
+								},
+								{
+									"key": "http.status_text",
+									"value": {
+										"stringValue": "INTERNAL SERVER ERROR"
+									}
+								}
+							],
+							"status": { "code": 2 }
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/backend/otel/samples/nextjs.json
+++ b/backend/otel/samples/nextjs.json
@@ -1,0 +1,505 @@
+{
+	"resourceSpans": [
+		{
+			"resource": {
+				"attributes": [
+					{
+						"key": "service.name",
+						"value": {
+							"stringValue": "unknown_service:/home/vkorolik/.local/share/nvm/v18.16.0/bin/node"
+						}
+					},
+					{
+						"key": "telemetry.sdk.language",
+						"value": { "stringValue": "nodejs" }
+					},
+					{
+						"key": "telemetry.sdk.name",
+						"value": { "stringValue": "opentelemetry" }
+					},
+					{
+						"key": "telemetry.sdk.version",
+						"value": { "stringValue": "1.15.2" }
+					},
+					{
+						"key": "highlight.project_id",
+						"value": { "stringValue": "1" }
+					}
+				]
+			},
+			"scopeSpans": [
+				{
+					"scope": {
+						"name": "@opentelemetry/instrumentation-http",
+						"version": "0.41.0"
+					},
+					"spans": [
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "d6a6a8e465ac625e",
+							"parentSpanId": "38c100c79c6b9943",
+							"name": "GET",
+							"kind": 3,
+							"startTimeUnixNano": "1692652030507000000",
+							"endTimeUnixNano": "1692652030508813000",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:36663/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22match%22%3A%7B%22definition%22%3A%7B%22kind%22%3A%22APP_ROUTE%22%2C%22pathname%22%3A%22%2Fapi%2Fapp-directory-test%22%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22bundlePath%22%3A%22app%2Fapi%2Fapp-directory-test%2Froute%22%2C%22filename%22%3A%22%2Fhome%2Fvkorolik%2Fwork%2Fhighlight%2Fe2e%2Fnextjs%2Fsrc%2Fapp%2Fapi%2Fapp-directory-test%2Froute.ts%22%7D%7D%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22match%22%3A%7B%22definition%22%3A%7B%22kind%22%3A%22APP_ROUTE%22%2C%22pathname%22%3A%22%2Fapi%2Fapp-directory-test%22%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22bundlePath%22%3A%22app%2Fapi%2Fapp-directory-test%2Froute%22%2C%22filename%22%3A%22%2Fhome%2Fvkorolik%2Fwork%2Fhighlight%2Fe2e%2Fnextjs%2Fsrc%2Fapp%2Fapi%2Fapp-directory-test%2Froute.ts%22%7D%7D%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "net.peer.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.host",
+									"value": {
+										"stringValue": "127.0.0.1:36663"
+									}
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "36663" }
+								},
+								{
+									"key": "http.response_content_length_uncompressed",
+									"value": { "intValue": "2" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "06adc36be1e8a305",
+							"parentSpanId": "38c100c79c6b9943",
+							"name": "GET",
+							"kind": 3,
+							"startTimeUnixNano": "1692652030510000000",
+							"endTimeUnixNano": "1692652030511381000",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:36663/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22match%22%3A%7B%22definition%22%3A%7B%22kind%22%3A%22APP_ROUTE%22%2C%22pathname%22%3A%22%2Fapi%2Fapp-directory-test%22%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22bundlePath%22%3A%22app%2Fapi%2Fapp-directory-test%2Froute%22%2C%22filename%22%3A%22%2Fhome%2Fvkorolik%2Fwork%2Fhighlight%2Fe2e%2Fnextjs%2Fsrc%2Fapp%2Fapi%2Fapp-directory-test%2Froute.ts%22%7D%7D%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=ensurePage\u0026args=%5B%7B%22match%22%3A%7B%22definition%22%3A%7B%22kind%22%3A%22APP_ROUTE%22%2C%22pathname%22%3A%22%2Fapi%2Fapp-directory-test%22%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22bundlePath%22%3A%22app%2Fapi%2Fapp-directory-test%2Froute%22%2C%22filename%22%3A%22%2Fhome%2Fvkorolik%2Fwork%2Fhighlight%2Fe2e%2Fnextjs%2Fsrc%2Fapp%2Fapi%2Fapp-directory-test%2Froute.ts%22%7D%7D%2C%22page%22%3A%22%2Fapi%2Fapp-directory-test%2Froute%22%2C%22clientOnly%22%3Afalse%7D%5D"
+									}
+								},
+								{
+									"key": "net.peer.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.host",
+									"value": {
+										"stringValue": "127.0.0.1:36663"
+									}
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "36663" }
+								},
+								{
+									"key": "http.response_content_length_uncompressed",
+									"value": { "intValue": "2" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "5e88997360e63bbf",
+							"parentSpanId": "38c100c79c6b9943",
+							"name": "GET",
+							"kind": 3,
+							"startTimeUnixNano": "1692652030511000000",
+							"endTimeUnixNano": "1692652030511957200",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://127.0.0.1:36663/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=getCompilationError\u0026args=%5B%22%2Fapi%2Fapp-directory-test%2Froute%22%5D"
+									}
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/?key=b278380e14755cbbd0d28fe4baabd0fa7c99fb72b7824ae3497acbd9dbc9f2ca\u0026method=getCompilationError\u0026args=%5B%22%2Fapi%2Fapp-directory-test%2Froute%22%5D"
+									}
+								},
+								{
+									"key": "net.peer.name",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "http.host",
+									"value": {
+										"stringValue": "127.0.0.1:36663"
+									}
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "36663" }
+								},
+								{
+									"key": "http.response_content_length_uncompressed",
+									"value": { "intValue": "2" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "200" }
+								},
+								{
+									"key": "http.status_text",
+									"value": { "stringValue": "OK" }
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "5e66c7bc054bfad5",
+							"parentSpanId": "5ffdc8bbaaa82aef",
+							"name": "GET",
+							"kind": 2,
+							"startTimeUnixNano": "1692652030505000000",
+							"endTimeUnixNano": "1692652030527929300",
+							"attributes": [
+								{
+									"key": "http.url",
+									"value": {
+										"stringValue": "http://localhost:3005/api/app-directory-test?success=false"
+									}
+								},
+								{
+									"key": "http.host",
+									"value": { "stringValue": "localhost:3005" }
+								},
+								{
+									"key": "net.host.name",
+									"value": { "stringValue": "localhost" }
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.scheme",
+									"value": { "stringValue": "http" }
+								},
+								{
+									"key": "http.client_ip",
+									"value": { "stringValue": "::1" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/api/app-directory-test?success=false"
+									}
+								},
+								{
+									"key": "http.user_agent",
+									"value": {
+										"stringValue": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
+									}
+								},
+								{
+									"key": "http.flavor",
+									"value": { "stringValue": "1.1" }
+								},
+								{
+									"key": "net.transport",
+									"value": { "stringValue": "ip_tcp" }
+								},
+								{
+									"key": "net.host.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.host.port",
+									"value": { "intValue": "43843" }
+								},
+								{
+									"key": "net.peer.ip",
+									"value": { "stringValue": "127.0.0.1" }
+								},
+								{
+									"key": "net.peer.port",
+									"value": { "intValue": "55564" }
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "500" }
+								},
+								{
+									"key": "http.status_text",
+									"value": {
+										"stringValue": "INTERNAL SERVER ERROR"
+									}
+								}
+							],
+							"status": { "code": 2 }
+						}
+					]
+				},
+				{
+					"scope": { "name": "highlight-node" },
+					"spans": [
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "80f61318613c3f27",
+							"parentSpanId": "7eec5681722614d8",
+							"name": "highlight-ctx",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030527000000",
+							"endTimeUnixNano": "1692652030527045400",
+							"events": [
+								{
+									"timeUnixNano": "1692652030527000000",
+									"name": "log",
+									"attributes": [
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "\"Error\\n    at console.\u003ccomputed\u003e [as info] (webpack-internal:///../../sdk/highlight-node/dist/index.mjs:153:15)\\n    at GET (webpack-internal:///(rsc)/./src/app/api/app-directory-test/route.ts:17:13)\\n    at eval (webpack-internal:///(rsc)/./node_modules/next/dist/server/future/route-modules/app-route/module.js:253:43)\\n    at eval (webpack-internal:///(rsc)/./node_modules/next/dist/server/lib/trace/tracer.js:111:36)\\n    at AsyncLocalStorage.run (node:async_hooks:338:14)\\n    at AsyncLocalStorageContextManager.with (webpack-internal:///../../sdk/highlight-node/node_modules/@opentelemetry/context-async-hooks/build/src/AsyncLocalStorageContextManager.js:33:40)\\n    at ContextAPI.with (webpack-internal:///../../sdk/highlight-node/node_modules/@opentelemetry/api/build/src/api/context.js:60:46)\\n    at Tracer.startActiveSpan (webpack-internal:///../../sdk/highlight-node/node_modules/@opentelemetry/sdk-trace-base/build/src/Tracer.js:122:32)\\n    at eval (webpack-internal:///(rsc)/./node_modules/next/dist/server/lib/trace/tracer.js:100:107)\\n    at AsyncLocalStorage.run (node:async_hooks:338:14)\\n    at AsyncLocalStorageContextManager.with (webpack-internal:///../../sdk/highlight-node/node_modules/@opentelemetry/context-async-hooks/build/src/AsyncLocalStorageContextManager.js:33:40)\\n    at ContextAPI.with (webpack-internal:///(rsc)/../../node_modules/@opentelemetry/api/build/src/api/context.js:55:46)\\n    at NextTracerImpl.trace (webpack-internal:///(rsc)/./node_modules/next/dist/server/lib/trace/tracer.js:100:32)\\n    at eval (webpack-internal:///(rsc)/./node_modules/next/dist/server/future/route-modules/app-route/module.js:241:53)\\n    at AsyncLocalStorage.run (node:async_hooks:338:14)\\n    at Object.wrap (webpack-internal:///(rsc)/./node_modules/next/dist/server/async-storage/static-generation-async-storage-wrapper.js:42:24)\\n    at eval (webpack-internal:///(rsc)/./node_modules/next/dist/server/future/route-modules/app-route/module.js:195:97)\\n    at AsyncLocalStorage.run (node:async_hooks:338:14)\\n    at Object.wrap (webpack-internal:///(rsc)/./node_modules/next/dist/server/async-storage/request-async-storage-wrapper.js:77:24)\\n    at eval (webpack-internal:///(rsc)/./node_modules/next/dist/server/future/route-modules/app-route/module.js:194:75)\\n    at AsyncLocalStorage.run (node:async_hooks:338:14)\\n    at AppRouteRouteModule.execute (webpack-internal:///(rsc)/./node_modules/next/dist/server/future/route-modules/app-route/module.js:191:56)\\n    at AppRouteRouteModule.handle (webpack-internal:///(rsc)/./node_modules/next/dist/server/future/route-modules/app-route/module.js:314:41)\\n    at RouteHandlerManager.handle (/home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/server/future/route-handler-managers/route-handler-manager.js:24:29)\\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\\n    at async doRender (/home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/server/base-server.js:1009:38)\\n    at async cacheEntry.responseCache.get.incrementalCache.incrementalCache (/home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/server/base-server.js:1218:28)\\n    at async /home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/server/response-cache/index.js:99:36\""
+											}
+										},
+										{
+											"key": "highlight.project_id",
+											"value": { "stringValue": "1" }
+										},
+										{
+											"key": "log.severity",
+											"value": { "stringValue": "info" }
+										},
+										{
+											"key": "log.message",
+											"value": {
+												"stringValue": "Here: /api/app-directory-test/route.ts [object Object]"
+											}
+										}
+									]
+								}
+							],
+							"status": {}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "61453d01a5b0c54b",
+							"parentSpanId": "38c100c79c6b9943",
+							"name": "highlight-ctx",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030527000000",
+							"endTimeUnixNano": "1692652030527018800",
+							"events": [
+								{
+									"timeUnixNano": "1692652030527000000",
+									"name": "log",
+									"attributes": [
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "\"Error\\n    at console.\u003ccomputed\u003e (webpack-internal:///../../sdk/highlight-node/dist/index.mjs:153:15)\\n    at console.error (/home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/compiled/@next/react-dev-overlay/dist/client.js:1:912)\\n    at Object.error (/home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/build/output/log.js:70:13)\\n    at doRender (/home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/server/base-server.js:1044:26)\\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\\n    at async cacheEntry.responseCache.get.incrementalCache.incrementalCache (/home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/server/base-server.js:1218:28)\\n    at async /home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/server/response-cache/index.js:99:36\""
+											}
+										},
+										{
+											"key": "highlight.project_id",
+											"value": { "stringValue": "1" }
+										},
+										{
+											"key": "log.severity",
+											"value": { "stringValue": "error" }
+										},
+										{
+											"key": "log.message",
+											"value": {
+												"stringValue": "- \u001b[31merror\u001b[39m Error: Error: /api/app-directory-test"
+											}
+										}
+									]
+								}
+							],
+							"status": {}
+						}
+					]
+				},
+				{
+					"scope": { "name": "next.js", "version": "0.0.1" },
+					"spans": [
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "7eec5681722614d8",
+							"parentSpanId": "38c100c79c6b9943",
+							"name": "executing api route (app) /api/app-directory-test/route",
+							"kind": 1,
+							"startTimeUnixNano": "1692652030526000000",
+							"endTimeUnixNano": "1692652030526570800",
+							"attributes": [
+								{
+									"key": "next.span_name",
+									"value": {
+										"stringValue": "executing api route (app) /api/app-directory-test/route"
+									}
+								},
+								{
+									"key": "next.span_type",
+									"value": {
+										"stringValue": "AppRouteRouteHandlers.runHandler"
+									}
+								},
+								{
+									"key": "next.route",
+									"value": {
+										"stringValue": "/api/app-directory-test/route"
+									}
+								}
+							],
+							"events": [
+								{
+									"timeUnixNano": "1692652030526563300",
+									"name": "exception",
+									"attributes": [
+										{
+											"key": "exception.type",
+											"value": { "stringValue": "Error" }
+										},
+										{
+											"key": "exception.message",
+											"value": {
+												"stringValue": "Error: /api/app-directory-test"
+											}
+										},
+										{
+											"key": "exception.stacktrace",
+											"value": {
+												"stringValue": "Error: Error: /api/app-directory-test\n    at GET (webpack-internal:///(rsc)/./src/app/api/app-directory-test/route.ts:23:15)\n    at eval (webpack-internal:///(rsc)/./node_modules/next/dist/server/future/route-modules/app-route/module.js:253:43)\n    at eval (webpack-internal:///(rsc)/./node_modules/next/dist/server/lib/trace/tracer.js:111:36)\n    at AsyncLocalStorage.run (node:async_hooks:338:14)\n    at AsyncLocalStorageContextManager.with (webpack-internal:///../../sdk/highlight-node/node_modules/@opentelemetry/context-async-hooks/build/src/AsyncLocalStorageContextManager.js:33:40)\n    at ContextAPI.with (webpack-internal:///../../sdk/highlight-node/node_modules/@opentelemetry/api/build/src/api/context.js:60:46)\n    at Tracer.startActiveSpan (webpack-internal:///../../sdk/highlight-node/node_modules/@opentelemetry/sdk-trace-base/build/src/Tracer.js:122:32)\n    at eval (webpack-internal:///(rsc)/./node_modules/next/dist/server/lib/trace/tracer.js:100:107)\n    at AsyncLocalStorage.run (node:async_hooks:338:14)\n    at AsyncLocalStorageContextManager.with (webpack-internal:///../../sdk/highlight-node/node_modules/@opentelemetry/context-async-hooks/build/src/AsyncLocalStorageContextManager.js:33:40)\n    at ContextAPI.with (webpack-internal:///(rsc)/../../node_modules/@opentelemetry/api/build/src/api/context.js:55:46)\n    at NextTracerImpl.trace (webpack-internal:///(rsc)/./node_modules/next/dist/server/lib/trace/tracer.js:100:32)\n    at eval (webpack-internal:///(rsc)/./node_modules/next/dist/server/future/route-modules/app-route/module.js:241:53)\n    at AsyncLocalStorage.run (node:async_hooks:338:14)\n    at Object.wrap (webpack-internal:///(rsc)/./node_modules/next/dist/server/async-storage/static-generation-async-storage-wrapper.js:42:24)\n    at eval (webpack-internal:///(rsc)/./node_modules/next/dist/server/future/route-modules/app-route/module.js:195:97)\n    at AsyncLocalStorage.run (node:async_hooks:338:14)\n    at Object.wrap (webpack-internal:///(rsc)/./node_modules/next/dist/server/async-storage/request-async-storage-wrapper.js:77:24)\n    at eval (webpack-internal:///(rsc)/./node_modules/next/dist/server/future/route-modules/app-route/module.js:194:75)\n    at AsyncLocalStorage.run (node:async_hooks:338:14)\n    at AppRouteRouteModule.execute (webpack-internal:///(rsc)/./node_modules/next/dist/server/future/route-modules/app-route/module.js:191:56)\n    at AppRouteRouteModule.handle (webpack-internal:///(rsc)/./node_modules/next/dist/server/future/route-modules/app-route/module.js:314:41)\n    at RouteHandlerManager.handle (/home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/server/future/route-handler-managers/route-handler-manager.js:24:29)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async doRender (/home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/server/base-server.js:1009:38)\n    at async cacheEntry.responseCache.get.incrementalCache.incrementalCache (/home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/server/base-server.js:1218:28)\n    at async /home/vkorolik/work/highlight/e2e/nextjs/node_modules/next/dist/server/response-cache/index.js:99:36"
+											}
+										}
+									]
+								}
+							],
+							"status": {
+								"message": "Error: /api/app-directory-test",
+								"code": 2
+							}
+						},
+						{
+							"traceId": "fac38f0e83dff2d0b09cab93acb2753f",
+							"spanId": "38c100c79c6b9943",
+							"parentSpanId": "5e66c7bc054bfad5",
+							"name": "GET /api/app-directory-test?success=false",
+							"kind": 2,
+							"startTimeUnixNano": "1692652030505000000",
+							"endTimeUnixNano": "1692652030527231000",
+							"attributes": [
+								{
+									"key": "next.span_name",
+									"value": {
+										"stringValue": "GET /api/app-directory-test?success=false"
+									}
+								},
+								{
+									"key": "next.span_type",
+									"value": {
+										"stringValue": "BaseServer.handleRequest"
+									}
+								},
+								{
+									"key": "http.method",
+									"value": { "stringValue": "GET" }
+								},
+								{
+									"key": "http.target",
+									"value": {
+										"stringValue": "/api/app-directory-test?success=false"
+									}
+								},
+								{
+									"key": "http.status_code",
+									"value": { "intValue": "500" }
+								}
+							],
+							"status": {}
+						}
+					]
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
## Summary

Recent changes in the otel ingest code caused us to drop next.js errors
because next.js reported spans would have the highlight project reported as a resource attribute.

## How did you test this change?

New unit test.
Manually ingesting next.js app directory error.
![image](https://github.com/highlight/highlight/assets/1351531/eb0bcd33-4dec-4489-bf8b-ac0c8a9c3120)


## Are there any deployment considerations?

No