### PR TITLE
update node.js console recording for arguments

### DIFF
--- a/sdk/highlight-apollo/package.json
+++ b/sdk/highlight-apollo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/apollo",
-	"version": "3.1.9",
+	"version": "3.1.10",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-nest/package.json
+++ b/sdk/highlight-nest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/nest",
-	"version": "3.1.9",
+	"version": "3.1.10",
 	"description": "Client for interfacing with Highlight in nestjs",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "4.0.1",
+	"version": "4.0.2",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-node/CHANGELOG.md
+++ b/sdk/highlight-node/CHANGELOG.md
@@ -73,3 +73,9 @@
 ### Patch Changes
 
 - Updates opentelemetry dependencies to the next patch version.
+
+## 3.1.10
+
+### Patch Changes
+
+- Ensures `console.log(...args)`-type arguments are serialized correctly.

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "3.1.9",
+	"version": "3.1.10",
 	"license": "MIT",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-node/src/hooks.ts
+++ b/sdk/highlight-node/src/hooks.ts
@@ -62,7 +62,11 @@ export function hookConsole(
 				cb({
 					date,
 					level: highlightLevel,
-					message: data.join(' '),
+					message: data
+						.map((o) =>
+							typeof o === 'object' ? JSON.stringify(o) : o,
+						)
+						.join(' '),
 					stack: o.stack,
 				})
 			}


### PR DESCRIPTION
## Summary

Serialize node.js console method arguments.
This makes sure that a node.js call like `console.log('hey', {hello: 'world'})` will be correctly recorded.
See [discord](https://discord.com/channels/1026884757667188757/1139191530091974718) for customer report.

## How did you test this change?

Local e2e nextjs app recording `console.log('whoa there', {hello: 'world'})`

## Are there any deployment considerations?

New JS sdk versions released.
