### PR TITLE
fix: change order of sub steps in dev deploy optional step

### DIFF
--- a/highlight.io/components/QuickstartContent/self-host/dev-deploy.tsx
+++ b/highlight.io/components/QuickstartContent/self-host/dev-deploy.tsx
@@ -30,14 +30,14 @@ cd highlight/docker;
 				},
 				{
 					key: 'backend',
-					text: `# in a second terminal, start the backend. this will run make start-no-doppler in backend and block until you stop it with ctrl+c.
+					text: `# start the backend. this will run make start-no-doppler in backend and block until you stop it with ctrl+c.
 cd highlight/docker;
 ./run-backend.sh`,
 					language: 'bash',
 				},
 				{
 					key: 'frontend',
-					text: `# now, start the frontend in a third terminal. this will run yarn docker:frontend in the monorepo and block until you stop it with ctrl+c.
+					text: `# now, start the frontend in a second terminal. this will run yarn docker:frontend in the monorepo and block until you stop it with ctrl+c.
 ./run-frontend.sh`,
 					language: 'bash',
 				},

--- a/highlight.io/components/QuickstartContent/self-host/dev-deploy.tsx
+++ b/highlight.io/components/QuickstartContent/self-host/dev-deploy.tsx
@@ -29,16 +29,16 @@ cd highlight/docker;
 					language: 'bash',
 				},
 				{
-					key: 'frontend',
-					text: `# now, start the frontend. this will run yarn docker:frontend in the monorepo and block until you stop it with ctrl+c.
-./run-frontend.sh`,
-					language: 'bash',
-				},
-				{
 					key: 'backend',
 					text: `# in a second terminal, start the backend. this will run make start-no-doppler in backend and block until you stop it with ctrl+c.
 cd highlight/docker;
 ./run-backend.sh`,
+					language: 'bash',
+				},
+				{
+					key: 'frontend',
+					text: `# now, start the frontend in a third terminal. this will run yarn docker:frontend in the monorepo and block until you stop it with ctrl+c.
+./run-frontend.sh`,
 					language: 'bash',
 				},
 			],


### PR DESCRIPTION
## Summary

1. Change order of sub steps in `(Optional) Running in different terminals` step of https://www.highlight.io/docs/getting-started/self-host/dev-deployment-guide.
frontend depends on backend and backend depends on infra

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
