### PR TITLE
Fix handling of integers in nested log attributes

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -133,7 +133,7 @@ export const LogDetails: React.FC<Props> = ({
 						) : (
 							<LogValue
 								label={key}
-								value={value as string}
+								value={String(value)}
 								queryKey={key}
 								queryTerms={queryTerms}
 							/>
@@ -303,7 +303,7 @@ export const LogDetails: React.FC<Props> = ({
 
 const LogDetailsObject: React.FC<{
 	allExpanded: boolean
-	attribute: string | object
+	attribute: string | object | number
 	label: string
 	queryBaseKeys: string[]
 	queryTerms: LogsSearchParam[]
@@ -365,7 +365,7 @@ const LogDetailsObject: React.FC<{
 		<Box cssClass={styles.line}>
 			<LogValue
 				label={label}
-				value={attribute}
+				value={String(attribute)}
 				queryKey={queryKey}
 				queryTerms={queryTerms}
 				queryMatch={queryMatch?.match}


### PR DESCRIPTION
## Summary

Fixes an error we were seeing when we have a wildcard filter applied that matches log attributes containing integer values (e.g. `code.lineno:*08`).

## How did you test this change?

Local and PR preview click test.

Reproduce the error in prod: https://app.highlight.io/1/logs?query=code.lineno%3A%2A01
See issue fixed in PR preview: https://preview.highlight.io/1/logs?query=code.lineno%3A%2A01

## Are there any deployment considerations?

N/A