### PR TITLE
Use AND instead of OR for log attribute filters

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -605,7 +605,7 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 		}
 	}
 	if len(conditions) > 0 {
-		sb.Where(sb.Or(conditions...))
+		sb.Where(sb.And(conditions...))
 	}
 
 	return sb, nil

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -596,12 +596,23 @@ func makeSelectBuilder(selectStr string, projectID int, params modelInputs.LogsP
 
 	conditions := []string{}
 	for key, values := range filters.attributes {
-		for _, value := range values {
+		if len(values) == 1 {
+			value := values[0]
 			if strings.Contains(value, "%") {
 				conditions = append(conditions, sb.Var(sqlbuilder.Buildf("LogAttributes[%s] LIKE %s", key, value)))
 			} else {
 				conditions = append(conditions, sb.Var(sqlbuilder.Buildf("LogAttributes[%s] = %s", key, value)))
 			}
+		} else {
+			innerConditions := []string{}
+			for _, value := range values {
+				if strings.Contains(value, "%") {
+					innerConditions = append(innerConditions, sb.Var(sqlbuilder.Buildf("LogAttributes[%s] LIKE %s", key, value)))
+				} else {
+					innerConditions = append(innerConditions, sb.Var(sqlbuilder.Buildf("LogAttributes[%s] = %s", key, value)))
+				}
+			}
+			conditions = append(conditions, sb.Or(innerConditions...))
 		}
 	}
 	if len(conditions) > 0 {

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -629,14 +629,12 @@ func TestReadLogsWithKeyFilter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 1)
 
-	// TODO: Re-enable if we want to support applying multiple conditions to the
-	// same key as an OR clause.
-	// payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
-	// 	DateRange: makeDateWithinRange(now),
-	// 	Query:     `service:"image processor" service:"different processor"`,
-	// }, Pagination{})
-	// assert.NoError(t, err)
-	// assert.Len(t, payload.Edges, 2)
+	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     `service:"image processor" service:"different processor"`,
+	}, Pagination{})
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 2)
 
 	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
 		DateRange: makeDateWithinRange(now),
@@ -977,6 +975,9 @@ func TestReadLogsWithMultipleFilters(t *testing.T) {
 		NewLogRow(now, 1,
 			WithServiceName("matched"),
 			WithLogAttributes(map[string]string{"code.lineno": "162", "os.type": "linux"})),
+		NewLogRow(now, 1,
+			WithServiceName("matched"),
+			WithLogAttributes(map[string]string{"code.lineno": "163", "os.type": "darwin"})),
 		NewLogRow(now, 1, WithServiceName(("no-match"))),
 	}
 
@@ -996,6 +997,13 @@ func TestReadLogsWithMultipleFilters(t *testing.T) {
 	}, Pagination{})
 	assert.NoError(t, err)
 	assert.Len(t, payload.Edges, 0)
+
+	payload, err = client.ReadLogs(ctx, 1, modelInputs.LogsParamsInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     "code.lineno:*63 code.lineno:*62 service_name:matched",
+	}, Pagination{})
+	assert.NoError(t, err)
+	assert.Len(t, payload.Edges, 2)
 }
 
 func TestLogsKeys(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes an issue where multiple filters applied on log attributes weren't filtering on all the attributes. The problem was that we were using an `OR` clause on all the log attribute filters. I changed this to an `AND`, but it introduces a regression in the existing behavior which supported applying multiple filters on the same key and applying them as an `OR`. I commented out a test flexing logic to support that use case and we should discuss if we truly want to support it.

## How did you test this change?

Local click test + updated tests.

## Are there any deployment considerations?

Should be a fairly straightforward change, but should keep an eye on query performance for logs.