### PR TITLE
Fix logs loading state in network resource panel

### DIFF
--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
@@ -126,7 +126,7 @@ export const NetworkResourceLogs: React.FC<{
 						}
 						ref={tableContainerRef}
 					>
-						{logEdges.length === 0 || !requestId ? (
+						{(!loading && logEdges.length === 0) || !requestId ? (
 							<NoLogsFound />
 						) : (
 							<LogsTable


### PR DESCRIPTION
## Summary

Fixes an issue where we weren't ever getting into the loading state when viewing logs for a network resource.

https://www.loom.com/share/e7f2e2c3b7dd4f219527ab180d0c41b8

## How did you test this change?

Local + PR preview click test.

## Are there any deployment considerations?

N/A - client-side only change.