### PR TITLE
feat: preserve scroll position when go back to events list

### DIFF
--- a/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
@@ -37,7 +37,12 @@ const EventStreamV2 = function () {
 		currentEvent,
 		setCurrentEvent,
 	} = useReplayerContext()
-	const { setActiveEvent, setRightPanelView } = usePlayerUIContext()
+	const {
+		setActiveEvent,
+		setRightPanelView,
+		activeEventIndex,
+		setActiveEventIndex,
+	} = usePlayerUIContext()
 	const [isInteractingWithStreamEvents, setIsInteractingWithStreamEvents] =
 		useState(false)
 	const [events, setEvents] = useState<HighlightEvent[]>([])
@@ -158,6 +163,7 @@ const EventStreamV2 = function () {
 							data={filteredEvents}
 							totalCount={filteredEvents.length}
 							className={styledVerticalScrollbar}
+							initialTopMostItemIndex={activeEventIndex}
 							itemContent={(index, event) => (
 								<StreamEventV2
 									e={event}
@@ -171,6 +177,7 @@ const EventStreamV2 = function () {
 										setCurrentEvent(e)
 										setActiveEvent(event)
 										setRightPanelView(RightPanelView.Event)
+										setActiveEventIndex(index)
 									}}
 								/>
 							)}

--- a/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
@@ -42,15 +42,18 @@ const EventStreamV2 = function () {
 		setRightPanelView,
 		activeEventIndex,
 		setActiveEventIndex,
+		searchItem,
+		setSearchItem,
 	} = usePlayerUIContext()
 	const [isInteractingWithStreamEvents, setIsInteractingWithStreamEvents] =
 		useState(false)
 	const [events, setEvents] = useState<HighlightEvent[]>([])
 	const form = useFormState({
 		defaultValues: {
-			search: '',
+			search: searchItem,
 		},
 	})
+
 	const searchQuery = form.getValue('search')
 	const eventTypeFilters = useEventTypeFilters()
 	const virtuoso = useRef<VirtuosoHandle>(null)
@@ -178,6 +181,7 @@ const EventStreamV2 = function () {
 										setActiveEvent(event)
 										setRightPanelView(RightPanelView.Event)
 										setActiveEventIndex(index)
+										setSearchItem(searchQuery)
 									}}
 								/>
 							)}

--- a/frontend/src/pages/Player/components/EventStreamV2/StreamEventV2/StreamEventV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/StreamEventV2/StreamEventV2.tsx
@@ -1,5 +1,5 @@
 import { EventType } from '@highlight-run/rrweb'
-import { Badge, Box, Tag, Text } from '@highlight-run/ui'
+import { Badge, Box, IconSolidArrowCircleRight, Text } from '@highlight-run/ui'
 import { colors } from '@highlight-run/ui/src/css/colors'
 import { HighlightEvent } from '@pages/Player/HighlightEvent'
 import usePlayerConfiguration from '@pages/Player/PlayerHook/utils/usePlayerConfiguration'
@@ -97,20 +97,25 @@ export const StreamEventV2 = function ({
 				<Text lines="1" display="flex">
 					{details.displayValue}
 				</Text>
-				<Box display="flex" alignItems="center" gap="4">
+				<Box
+					display="flex"
+					alignItems="center"
+					gap="4"
+					justifyContent="space-between"
+				>
 					<Badge
 						size="small"
 						variant={EVENT_TYPES_TO_VARIANTS[displayName]}
 						label={displayName}
 					/>
 					{shouldShowTimestamp && (
-						<Tag
-							kind="secondary"
-							size="small"
-							emphasis="high"
-							shape="basic"
+						<Box
+							display="flex"
+							alignItems="center"
+							gap="2"
+							justifyContent="space-between"
 						>
-							<Text>
+							<Text size="xxSmall">
 								{showPlayerAbsoluteTime
 									? playerTimeToSessionAbsoluteTime({
 											sessionStartTime: start,
@@ -118,7 +123,20 @@ export const StreamEventV2 = function ({
 									  })
 									: MillisToMinutesAndSeconds(timeSinceStart)}
 							</Text>
-						</Tag>
+							<IconSolidArrowCircleRight
+								onClick={(e) => {
+									e.stopPropagation()
+									pause(timeSinceStart)
+									message.success(
+										`Changed player time showing you ${
+											details.title
+										} at ${MillisToMinutesAndSeconds(
+											timeSinceStart,
+										)}`,
+									)
+								}}
+							/>
+						</Box>
 					)}
 				</Box>
 			</Box>

--- a/frontend/src/pages/Player/context/PlayerUIContext.ts
+++ b/frontend/src/pages/Player/context/PlayerUIContext.ts
@@ -27,6 +27,9 @@ interface PlayerUIContext {
 	activeEventIndex?: number
 	setActiveEventIndex: React.Dispatch<React.SetStateAction<number>>
 
+	searchItem?: string
+	setSearchItem: React.Dispatch<React.SetStateAction<string | undefined>>
+
 	rightPanelView: RightPanelView
 	setRightPanelView: (newValue: RightPanelView) => void
 

--- a/frontend/src/pages/Player/context/PlayerUIContext.ts
+++ b/frontend/src/pages/Player/context/PlayerUIContext.ts
@@ -23,6 +23,10 @@ interface PlayerUIContext {
 	setActiveEvent: React.Dispatch<
 		React.SetStateAction<HighlightEvent | undefined>
 	>
+
+	activeEventIndex?: number
+	setActiveEventIndex: React.Dispatch<React.SetStateAction<number>>
+
 	rightPanelView: RightPanelView
 	setRightPanelView: (newValue: RightPanelView) => void
 

--- a/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
@@ -138,6 +138,8 @@ export const ProjectRouter = () => {
 		undefined,
 	)
 
+	const [activeEventIndex, setActiveEventIndex] = useState<number>(0)
+
 	const [activeError, setActiveError] = useState<ErrorObject | undefined>(
 		undefined,
 	)
@@ -161,6 +163,8 @@ export const ProjectRouter = () => {
 		setSelectedRightPanelTab,
 		activeEvent,
 		setActiveEvent,
+		activeEventIndex,
+		setActiveEventIndex,
 		activeError,
 		setActiveError,
 		rightPanelView,

--- a/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
@@ -140,6 +140,8 @@ export const ProjectRouter = () => {
 
 	const [activeEventIndex, setActiveEventIndex] = useState<number>(0)
 
+	const [searchItem, setSearchItem] = useState<string | undefined>('')
+
 	const [activeError, setActiveError] = useState<ErrorObject | undefined>(
 		undefined,
 	)
@@ -165,6 +167,8 @@ export const ProjectRouter = () => {
 		setActiveEvent,
 		activeEventIndex,
 		setActiveEventIndex,
+		searchItem,
+		setSearchItem,
 		activeError,
 		setActiveError,
 		rightPanelView,


### PR DESCRIPTION
## Summary
1. Added `activeEventIndex` and `setActiveEventIndex` in PlayerUIContext
2. Used `initialTopMostItemIndex` prop of react-virtuoso library. Checkout this prop in [API reference](https://virtuoso.dev/virtuoso-api-reference/)
3. Added `IconSolidArrowCircleRight` as per design and `onClick` Handler
4. Added `searchItem` and `setSearchItem` to preserve search state

/claim #6277 
closes #6277 

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

https://github.com/highlight/highlight/assets/39362422/2df4e9c3-0730-4ffe-a580-20c8c963592f


<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
