### PR TITLE
Next.js Walkthrough updates

### DIFF
--- a/docs-content/getting-started/fullstack-frameworks/next-js.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js.md
@@ -18,8 +18,18 @@ Our Next.js SDK gives you access to frontend session replays and server-side mon
 all-in-one. 
 
 1. On the frontend, the `<HighlightInit/>` component sets up client-side session replays.
-2. On the backend, the `withHighlight` wrapper captures server-side errors and logs from your API.
-3. The `withHighlightConfig` configuration wrapper automatically proxies highlight data to bypass ad-blockers and uploads source maps so your frontend errors include stack traces to your source code.
+2. On the backend, the `withHighlight` wrapper captures server-side errors and logs from Page Router API endpoints.
+3. On the backend, `instrumentation.ts` and `registerHighlight` capture Page Router SSR errors and App Router API endpoint errors.
+4. The `withHighlightConfig` configuration wrapper automatically proxies highlight data to bypass ad-blockers and uploads source maps so your frontend errors include stack traces to your source code.
+
+### How Highlight captures Next.js errors
+
+|              | Page Router         | App Router          |
+|--------------|---------------------|---------------------|
+| API Errors   | withHighlight       | instrumentation.ts  |
+| SSR Errors   | instrumentation.ts  | error.tsx           |
+| Client       | `<HighlightInit />` | `<HighlightInit />` |
+| Edge runtime | not supported       | not supported       |
 
 ## Installation
 
@@ -232,7 +242,7 @@ This section adds server-side error monitoring and log capture to Highlight.
 Next.js comes out of the box instrumented for Open Telemetry. Our example Highlight implementation will use Next's [experimental instrumentation feature](https://nextjs.org/docs/advanced-features/instrumentation) to configure Open Telemetry on our Next.js server. There are probably other ways to configure Open Telemetry with Next, but this is our favorite.
 
 
-4. Create `instrumentation.ts` at the root of your project as explained in the [instrumentation guide](https://nextjs.org/docs/advanced-features/instrumentation). Call `registerHighlight` from within the exported `register` function.
+1. Create `instrumentation.ts` at the root of your project as explained in the [instrumentation guide](https://nextjs.org/docs/advanced-features/instrumentation). Call `registerHighlight` from within the exported `register` function.
 
 ```javascript
 // instrumentation.ts
@@ -251,12 +261,55 @@ export async function register() {
 }
 ```
 
-5. If you're using the App Router, copy `instrumentation.ts` to `src/instrumentation.ts`. See this [Next.js discussion](https://github.com/vercel/next.js/discussions/48273#discussioncomment-5587441) regarding `instrumentation.ts` with App Router. You could also simply export the `register` function from `instrumentation.ts` in `src/instrumentation.ts` like so:
+2. If you're using the App Router, copy `instrumentation.ts` to `src/instrumentation.ts`. See this [Next.js discussion](https://github.com/vercel/next.js/discussions/48273#discussioncomment-5587441) regarding `instrumentation.ts` with App Router. You could also simply export the `register` function from `instrumentation.ts` in `src/instrumentation.ts` like so:
 
 ```javascript
 // src/instrumentation.ts:
 export { register } from '../instrumentation'
 ```
+
+## `error.tsx` (App Router)
+
+`instrumentation.ts` does not catch SSR errors from the App Router. App Router instead uses [`error.tsx`](https://nextjs.org/docs/app/api-reference/file-conventions/error) to send server-side rendering errors to the client. We can catch and consume those error with a custom error page.
+
+These error will display as client errors, even though we know that they're 
+
+```javascript
+// src/app/error.tsx
+'use client' // Error components must be Client Components
+
+import { H } from '@highlight-run/next/client'
+import { useEffect } from 'react'
+
+export default function Error({
+	error,
+	reset,
+}: {
+	error: Error & { digest?: string }
+	reset: () => void
+}) {
+	useEffect(() => {
+		// Log the error to Highlight
+		H.consumeError(error)
+	}, [error])
+
+	return (
+		<div>
+			<h2>Something went wrong!</h2>
+			<button
+				onClick={
+					// Attempt to recover by trying to re-render the segment
+					() => reset()
+				}
+			>
+				Try again
+			</button>
+		</div>
+	)
+}
+```
+
+
 
 ## Private Sourcemaps and Request Proxying (optional)
 

--- a/e2e/nextjs/src/app/error.tsx
+++ b/e2e/nextjs/src/app/error.tsx
@@ -1,0 +1,33 @@
+// src/app/error.tsx
+'use client' // Error components must be Client Components
+
+import { H } from '@highlight-run/next/client'
+import { useEffect } from 'react'
+
+export default function Error({
+	error,
+	reset,
+}: {
+	error: Error & { digest?: string }
+	reset: () => void
+}) {
+	useEffect(() => {
+		// Log the error to an error reporting service
+		console.error(error)
+		H.consumeError(error)
+	}, [error])
+
+	return (
+		<div>
+			<h2>Something went wrong!</h2>
+			<button
+				onClick={
+					// Attempt to recover by trying to re-render the segment
+					() => reset()
+				}
+			>
+				Try again
+			</button>
+		</div>
+	)
+}


### PR DESCRIPTION
## Summary

I did a ton of testing and discovered that `instrumentation.ts` and `withHighlight` cannot capture App Router SSR errors; however, `error.tsx` **can** capture them.

I documented my findings.

![image](https://github.com/highlight/highlight/assets/878947/9fc8862e-b569-479c-acb4-125403915bb2)

## How did you test this change?

Click test

## Are there any deployment considerations?

nope