### PR TITLE
consolidate duplicate kafka worker code

### DIFF
--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	e "github.com/pkg/errors"
 	"strconv"
 	"strings"
 	"time"
@@ -171,31 +172,39 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 		chSessions = append(chSessions, &chs)
 	}
 
-	chCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
-		"async_insert":          1,
-		"wait_for_async_insert": 1,
-	}))
-
 	var g errgroup.Group
 
 	if len(chSessions) > 0 {
-		sessionsSql, sessionsArgs := sqlbuilder.
-			NewStruct(new(ClickhouseSession)).
-			InsertInto(SessionsTable, chSessions...).
-			BuildWithFlavor(sqlbuilder.ClickHouse)
 		g.Go(func() error {
-			return client.conn.Exec(chCtx, sessionsSql, sessionsArgs...)
+			batch, err := client.conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", SessionsTable))
+			if err != nil {
+				return e.Wrap(err, "failed to create sessions batch")
+			}
+
+			for _, session := range chSessions {
+				err = batch.AppendStruct(session)
+				if err != nil {
+					return err
+				}
+			}
+			return batch.Send()
 		})
 	}
 
 	if len(chFields) > 0 {
-		fieldsSql, fieldsArgs := sqlbuilder.
-			NewStruct(new(ClickhouseField)).
-			InsertInto(FieldsTable, chFields...).
-			BuildWithFlavor(sqlbuilder.ClickHouse)
-
 		g.Go(func() error {
-			return client.conn.Exec(chCtx, fieldsSql, fieldsArgs...)
+			batch, err := client.conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", FieldsTable))
+			if err != nil {
+				return e.Wrap(err, "failed to create session fields batch")
+			}
+
+			for _, field := range chFields {
+				err = batch.AppendStruct(field)
+				if err != nil {
+					return err
+				}
+			}
+			return batch.Send()
 		})
 	}
 

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -83,7 +83,7 @@ func (client *Client) BatchWriteTraceRows(ctx context.Context, traceRows []*Trac
 	batch, err := client.conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", TracesTable))
 	if err != nil {
 		span.Finish(tracer.WithError(err))
-		return e.Wrap(err, "failed to create logs batch")
+		return e.Wrap(err, "failed to create traces batch")
 	}
 
 	for _, traceRow := range rows {

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -197,6 +197,7 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 			HeartbeatInterval: time.Second,
 			SessionTimeout:    10 * time.Second,
 			RebalanceTimeout:  rebalanceTimeout,
+			ReadBatchTimeout:  KafkaOperationTimeout,
 			Topic:             pool.Topic,
 			GroupID:           pool.ConsumerGroup,
 			MaxBytes:          messageSizeBytes,

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -28,7 +28,6 @@ const ConsumerGroupName = "group-default"
 const (
 	TaskRetries           = 5
 	prefetchQueueCapacity = 64
-	prefetchSizeBytes     = 64 * 1000         // 64 KB
 	messageSizeBytes      = 500 * 1000 * 1000 // 500 MB
 )
 
@@ -200,8 +199,8 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 			RebalanceTimeout:  rebalanceTimeout,
 			Topic:             pool.Topic,
 			GroupID:           pool.ConsumerGroup,
-			MinBytes:          prefetchSizeBytes,
 			MaxBytes:          messageSizeBytes,
+			MaxWait:           time.Second,
 			QueueCapacity:     prefetchQueueCapacity,
 			// in the future, we would commit only on successful processing of a message.
 			// this means we commit very often to avoid repeating tasks on worker restart.
@@ -234,6 +233,10 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 	}()
 
 	return pool
+}
+
+func (p *Queue) metricPrefix() string {
+	return fmt.Sprintf("worker.kafka.%s", p.Topic)
 }
 
 func (p *Queue) Stop(ctx context.Context) {
@@ -269,7 +272,7 @@ func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...*Me
 			Key:   []byte(partitionKey),
 			Value: msgBytes,
 		})
-		hlog.Incr("worker.kafka.produceMessageCount", nil, 1)
+		hlog.Incr(p.metricPrefix()+"produceMessageCount", nil, 1)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, KafkaOperationTimeout)
@@ -279,7 +282,7 @@ func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...*Me
 		log.WithContext(ctx).WithError(err).WithField("partition_key", partitionKey).WithField("num_messages", len(messages)).Errorf("failed to send kafka messages")
 		return err
 	}
-	hlog.Histogram("worker.kafka.submitSec", time.Since(start).Seconds(), nil, 1)
+	hlog.Histogram(p.metricPrefix()+"submitSec", time.Since(start).Seconds(), nil, 1)
 	return nil
 }
 
@@ -300,8 +303,8 @@ func (p *Queue) Receive(ctx context.Context) (msg *Message) {
 		return nil
 	}
 	msg.KafkaMessage = &m
-	hlog.Incr("worker.kafka.consumeMessageCount", nil, 1)
-	hlog.Histogram("worker.kafka.receiveSec", time.Since(start).Seconds(), nil, 1)
+	hlog.Incr(p.metricPrefix()+"consumeMessageCount", nil, 1)
+	hlog.Histogram(p.metricPrefix()+"receiveSec", time.Since(start).Seconds(), nil, 1)
 	return
 }
 
@@ -357,8 +360,8 @@ func (p *Queue) Commit(ctx context.Context, msg *kafka.Message) {
 	if err != nil {
 		log.WithContext(ctx).Error(errors.Wrap(err, "failed to commit message"))
 	} else {
-		hlog.Incr("worker.kafka.commitMessageCount", nil, 1)
-		hlog.Histogram("worker.kafka.commitSec", time.Since(start).Seconds(), nil, 1)
+		hlog.Incr(p.metricPrefix()+"commitMessageCount", nil, 1)
+		hlog.Histogram(p.metricPrefix()+"commitSec", time.Since(start).Seconds(), nil, 1)
 	}
 }
 
@@ -367,28 +370,28 @@ func (p *Queue) LogStats() {
 		stats := p.kafkaP.Stats()
 		log.WithContext(context.Background()).WithField("topic", stats.Topic).WithField("stats", stats).Debug("Kafka Producer Stats")
 
-		hlog.Histogram("worker.kafka.produceBatchAvgSec", stats.BatchTime.Avg.Seconds(), nil, 1)
-		hlog.Histogram("worker.kafka.produceWriteAvgSec", stats.WriteTime.Avg.Seconds(), nil, 1)
-		hlog.Histogram("worker.kafka.produceWaitAvgSec", stats.WaitTime.Avg.Seconds(), nil, 1)
-		hlog.Histogram("worker.kafka.produceBatchSize", float64(stats.BatchSize.Avg), nil, 1)
-		hlog.Histogram("worker.kafka.produceBatchBytes", float64(stats.BatchBytes.Avg), nil, 1)
-		hlog.Histogram("worker.kafka.produceQueueCapacity", float64(stats.QueueCapacity), nil, 1)
-		hlog.Histogram("worker.kafka.produceQueueLength", float64(stats.QueueLength), nil, 1)
-		hlog.Histogram("worker.kafka.produceBytes", float64(stats.Bytes), nil, 1)
-		hlog.Histogram("worker.kafka.produceErrors", float64(stats.Errors), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceBatchAvgSec", stats.BatchTime.Avg.Seconds(), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceWriteAvgSec", stats.WriteTime.Avg.Seconds(), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceWaitAvgSec", stats.WaitTime.Avg.Seconds(), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceBatchSize", float64(stats.BatchSize.Avg), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceBatchBytes", float64(stats.BatchBytes.Avg), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceQueueCapacity", float64(stats.QueueCapacity), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceQueueLength", float64(stats.QueueLength), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceBytes", float64(stats.Bytes), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceErrors", float64(stats.Errors), nil, 1)
 	}
 	if p.kafkaC != nil {
 		stats := p.kafkaC.Stats()
 		log.WithContext(context.Background()).WithField("topic", stats.Topic).WithField("partition", stats.Partition).WithField("stats", stats).Debug("Kafka Consumer Stats")
 
-		hlog.Histogram("worker.kafka.consumeReadAvgSec", stats.ReadTime.Avg.Seconds(), nil, 1)
-		hlog.Histogram("worker.kafka.consumeWaitAvgSec", stats.WaitTime.Avg.Seconds(), nil, 1)
-		hlog.Histogram("worker.kafka.consumeFetchSize", float64(stats.FetchSize.Avg), nil, 1)
-		hlog.Histogram("worker.kafka.consumeFetchBytes", float64(stats.FetchBytes.Avg), nil, 1)
-		hlog.Histogram("worker.kafka.consumeQueueCapacity", float64(stats.QueueCapacity), nil, 1)
-		hlog.Histogram("worker.kafka.consumeQueueLength", float64(stats.QueueLength), nil, 1)
-		hlog.Histogram("worker.kafka.consumeBytes", float64(stats.Bytes), nil, 1)
-		hlog.Histogram("worker.kafka.consumeErrors", float64(stats.Errors), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeReadAvgSec", stats.ReadTime.Avg.Seconds(), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeWaitAvgSec", stats.WaitTime.Avg.Seconds(), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeFetchSize", float64(stats.FetchSize.Avg), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeFetchBytes", float64(stats.FetchBytes.Avg), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeQueueCapacity", float64(stats.QueueCapacity), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeQueueLength", float64(stats.QueueLength), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeBytes", float64(stats.Bytes), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeErrors", float64(stats.Errors), nil, 1)
 	}
 }
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -57,7 +57,6 @@ import (
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 	"github.com/leonelquinteros/hubspot"
-	"github.com/openlyinc/pointy"
 	e "github.com/pkg/errors"
 	"github.com/rs/cors"
 	"github.com/sendgrid/sendgrid-go"
@@ -330,8 +329,7 @@ func main() {
 	kafkaTracesProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeTraces}), kafkaqueue.Producer, nil)
 	kafkaDataSyncProducer := kafkaqueue.New(ctx,
 		kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}),
-		kafkaqueue.Producer,
-		&kafkaqueue.ConfigOverride{Async: pointy.Bool(true)})
+		kafkaqueue.Producer, nil)
 
 	opensearchClient, err := opensearch.NewOpensearchClient(db)
 	if err != nil {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1267,13 +1267,18 @@ type UserJourneyStep struct {
 }
 
 type SystemConfiguration struct {
-	Active           bool `gorm:"primary_key;default:true"`
-	MaintenanceStart time.Time
-	MaintenanceEnd   time.Time
-	ErrorFilters     pq.StringArray `gorm:"type:text[];default:'{\"ENOENT.*\", \"connect ECONNREFUSED.*\"}'"`
-	IgnoredFiles     pq.StringArray `gorm:"type:text[];default:'{\".*\\/node_modules\\/.*\", \".*\\/go\\/pkg\\/mod\\/.*\"}'"`
-	TraceWorkers     int            `gorm:"default:1"`
-	TraceFlushSize   int            `gorm:"type:bigint;default:10000"`
+	Active            bool `gorm:"primary_key;default:true"`
+	MaintenanceStart  time.Time
+	MaintenanceEnd    time.Time
+	ErrorFilters      pq.StringArray `gorm:"type:text[];default:'{\"ENOENT.*\", \"connect ECONNREFUSED.*\"}'"`
+	IgnoredFiles      pq.StringArray `gorm:"type:text[];default:'{\".*\\/node_modules\\/.*\", \".*\\/go\\/pkg\\/mod\\/.*\"}'"`
+	MainWorkers       int            `gorm:"default:64"`
+	LogsWorkers       int            `gorm:"default:1"`
+	LogsFlushSize     int            `gorm:"type:bigint;default:10000"`
+	DataSyncWorkers   int            `gorm:"default:1"`
+	DataSyncFlushSize int            `gorm:"type:bigint;default:10000"`
+	TraceWorkers      int            `gorm:"default:1"`
+	TraceFlushSize    int            `gorm:"type:bigint;default:10000"`
 }
 
 type RetryableType string

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1275,10 +1275,13 @@ type SystemConfiguration struct {
 	MainWorkers       int            `gorm:"default:64"`
 	LogsWorkers       int            `gorm:"default:1"`
 	LogsFlushSize     int            `gorm:"type:bigint;default:10000"`
+	LogsFlushTimeout  time.Duration  `gorm:"type:bigint;default:5000000000"`
 	DataSyncWorkers   int            `gorm:"default:1"`
 	DataSyncFlushSize int            `gorm:"type:bigint;default:10000"`
+	DataSyncTimeout   time.Duration  `gorm:"type:bigint;default:5000000000"`
 	TraceWorkers      int            `gorm:"default:1"`
 	TraceFlushSize    int            `gorm:"type:bigint;default:10000"`
+	TraceFlushTimeout time.Duration  `gorm:"type:bigint;default:5000000000"`
 }
 
 type RetryableType string

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -24,6 +24,8 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
+const KafkaBatchWorkerOp = "KafkaBatchWorker"
+
 func (k *KafkaWorker) processWorkerError(ctx context.Context, task *kafkaqueue.Message, err error) {
 	log.WithContext(ctx).WithError(err).WithField("type", task.Type).Errorf("task %+v failed: %s", *task, err)
 	if task.Failures >= task.MaxRetries {
@@ -78,7 +80,7 @@ func (k *KafkaWorker) ProcessMessages(ctx context.Context) {
 
 // DefaultBatchFlushSize set per https://clickhouse.com/docs/en/cloud/bestpractices/bulk-inserts
 const DefaultBatchFlushSize = 10000
-const DefaultBatchedFlushTimeout = 5 * time.Second
+const DefaultBatchedFlushTimeout = 30 * time.Second
 const SessionsMaxRowsPostgres = 500
 const MinRetryDelay = 250 * time.Millisecond
 
@@ -88,210 +90,33 @@ type KafkaWorker struct {
 	WorkerThread int
 }
 
-func (k *KafkaBatchWorker) flushLogs(ctx context.Context) error {
-	s, _ := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.batched.flushLogs"))
+func (k *KafkaBatchWorker) flush(ctx context.Context) error {
+	s, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush", k.Name)))
 	s.SetTag("BatchSize", len(k.BatchBuffer.messageQueue))
 	defer s.Finish()
 
-	hasMore := true
-	for hasMore {
-		var oldestLogRow *clickhouse.LogRow
-		var logRows []*clickhouse.LogRow
-
-		var received int
-		var lastMsg *kafkaqueue.Message
-		hasMore = func() bool {
-			for {
-				select {
-				case lastMsg = <-k.BatchBuffer.messageQueue:
-					switch lastMsg.Type {
-					case kafkaqueue.PushLogs:
-						if lastMsg.PushLogs.LogRow != nil {
-							logRows = append(logRows, lastMsg.PushLogs.LogRow)
-							received += 1
-							if oldestLogRow == nil || lastMsg.PushLogs.LogRow.Timestamp.Before(oldestLogRow.Timestamp) {
-								oldestLogRow = lastMsg.PushLogs.LogRow
-							}
-						}
-					}
-					if received >= k.BatchFlushSize {
-						return true
-					}
-				default:
-					return false
-				}
-			}
-		}()
-
-		timestampByProject := map[uint32]time.Time{}
-		workspaceByProject := map[uint32]*model.Workspace{}
-		for _, row := range logRows {
-			if row.Timestamp.After(timestampByProject[row.ProjectId]) {
-				timestampByProject[row.ProjectId] = row.Timestamp
-				workspaceByProject[row.ProjectId] = nil
-			}
-		}
-
-		spanTs, ctxTs := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.batched.setTimestamps"))
-		for projectId, timestamp := range timestampByProject {
-			err := k.Worker.Resolver.Redis.SetLastLogTimestamp(ctxTs, int(projectId), timestamp)
-			if err != nil {
-				log.WithContext(ctxTs).WithError(err).Errorf("failed to set last log timestamp for project %d", projectId)
-			}
-		}
-		spanTs.Finish()
-
-		spanW, ctxW := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.batched.checkBillingQuotas"))
-
-		// If it's saved in Redis that a project has exceeded / not exceeded
-		// its quota, use that value. Else, add the projectId to a list of
-		// projects to query.
-		quotaExceededByProject := map[uint32]bool{}
-		projectsToQuery := []uint32{}
-		for projectId := range workspaceByProject {
-			exceeded, err := k.Worker.Resolver.Redis.IsBillingQuotaExceeded(ctxW, int(projectId), model.PricingProductTypeLogs)
-			if err != nil {
-				log.WithContext(ctxW).Error(err)
-				continue
-			}
-			if exceeded != nil {
-				quotaExceededByProject[projectId] = *exceeded
-			} else {
-				projectsToQuery = append(projectsToQuery, projectId)
-			}
-		}
-
-		// For any projects to query, get the associated workspace,
-		// check if that workspace is within the logs quota,
-		// and write the result to redis.
-		for _, projectId := range projectsToQuery {
-			project, err := k.Worker.Resolver.Store.GetProject(ctx, int(projectId))
-			if err != nil {
-				log.WithContext(ctxW).Error(e.Wrap(err, "error querying project"))
-				continue
-			}
-
-			var workspace model.Workspace
-			if err := k.Worker.Resolver.DB.Model(&workspace).
-				Where("id = ?", project.WorkspaceID).Find(&workspace).Error; err != nil {
-				log.WithContext(ctxW).Error(e.Wrap(err, "error querying workspace"))
-				continue
-			}
-
-			projects := []model.Project{}
-			if err := k.Worker.Resolver.DB.Order("name ASC").Model(&workspace).Association("Projects").Find(&projects); err != nil {
-				log.WithContext(ctxW).Error(e.Wrap(err, "error querying associated projects"))
-				continue
-			}
-			workspace.Projects = projects
-
-			withinBillingQuota, quotaPercent := k.Worker.PublicResolver.IsWithinQuota(ctxW, model.PricingProductTypeLogs, &workspace, time.Now())
-			quotaExceededByProject[projectId] = !withinBillingQuota
-			if err := k.Worker.Resolver.Redis.SetBillingQuotaExceeded(ctxW, int(projectId), model.PricingProductTypeLogs, !withinBillingQuota); err != nil {
-				log.WithContext(ctxW).Error(err)
-				return err
-			}
-
-			// Send alert emails if above the relevant thresholds
-			go func() {
-				defer util.Recover()
-				if quotaPercent >= 1 {
-					if err := model.SendBillingNotifications(ctx, k.Worker.PublicResolver.DB, k.Worker.PublicResolver.MailClient, email.BillingLogsUsage100Percent, &workspace); err != nil {
-						log.WithContext(ctx).Error(e.Wrap(err, "failed to send billing notifications"))
-					}
-				} else if quotaPercent >= .8 {
-					if err := model.SendBillingNotifications(ctx, k.Worker.PublicResolver.DB, k.Worker.PublicResolver.MailClient, email.BillingLogsUsage80Percent, &workspace); err != nil {
-						log.WithContext(ctx).Error(e.Wrap(err, "failed to send billing notifications"))
-					}
-				}
-			}()
-		}
-
-		spanW.Finish()
-
-		var markBackendSetupProjectIds []uint32
-		var filteredRows []*clickhouse.LogRow
-		for _, logRow := range logRows {
-			// create service record for any services found in ingested logs
-			if logRow.ServiceName != "" {
-				spanX, ctxX := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.batched.findOrCreateService"))
-
-				project, err := k.Worker.Resolver.Store.GetProject(ctx, int(logRow.ProjectId))
-				if err == nil && project != nil {
-					_, err := k.Worker.Resolver.Store.FindOrCreateService(ctx, *project, logRow.ServiceName, logRow.LogAttributes)
-
-					if err != nil {
-						log.WithContext(ctxX).Error(e.Wrap(err, "failed to create service"))
-					}
-				}
-
-				spanX.Finish()
-			}
-
-			if logRow.Source == privateModel.LogSourceBackend {
-				markBackendSetupProjectIds = append(markBackendSetupProjectIds, logRow.ProjectId)
-			}
-
-			// Filter out any log rows for projects where the log quota has been exceeded
-			if quotaExceededByProject[logRow.ProjectId] {
-				continue
-			}
-
-			// Temporarily filter NextJS logs
-			// TODO - remove this condition when https://github.com/highlight/highlight/issues/6181 is fixed
-			if !strings.HasPrefix(logRow.Body, "ENOENT: no such file or directory") && !strings.HasPrefix(logRow.Body, "connect ECONNREFUSED") {
-				filteredRows = append(filteredRows, logRow)
-			}
-		}
-
-		wSpan, wCtx := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.batched.process"))
-		wSpan.SetTag("BatchSize", len(k.BatchBuffer.messageQueue))
-		wSpan.SetTag("NumProjects", len(workspaceByProject))
-		for _, projectId := range markBackendSetupProjectIds {
-			err := k.Worker.PublicResolver.MarkBackendSetupImpl(wCtx, int(projectId), model.MarkBackendSetupTypeLogs)
-			if err != nil {
-				log.WithContext(wCtx).WithError(err).Error("failed to mark backend logs setup")
-				return err
-			}
-		}
-
-		span, ctxT := tracer.StartSpanFromContext(wCtx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.batched.clickhouse.logs"))
-		span.SetTag("NumLogRows", len(logRows))
-		span.SetTag("NumFilteredRows", len(filteredRows))
-		span.SetTag("PayloadSizeBytes", binary.Size(filteredRows))
-		if oldestLogRow != nil {
-			span.SetTag("MaxIngestDelay", time.Since(oldestLogRow.Timestamp))
-		}
-		err := k.Worker.PublicResolver.Clickhouse.BatchWriteLogRows(ctxT, filteredRows)
-		if err != nil {
-			log.WithContext(ctxT).WithError(err).Error("failed to batch write logs to clickhouse")
-			return err
-		}
-		span.Finish(tracer.WithError(err))
-		wSpan.Finish()
-
-		if lastMsg != nil {
-			k.KafkaQueue.Commit(ctx, lastMsg.KafkaMessage)
-		}
-	}
-	k.BatchBuffer.lastMessage = nil
-	return nil
-}
-
-func (k *KafkaBatchWorker) flushTraces(ctx context.Context) error {
-	s, _ := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.batched.flushTraces"))
-	s.SetTag("BatchSize", len(k.BatchBuffer.messageQueue))
-	defer s.Finish()
-
+	var dataSyncRows []int
+	var logRows []*clickhouse.LogRow
 	var traceRows []*clickhouse.TraceRow
 
 	var received int
 	var lastMsg *kafkaqueue.Message
+	var oldestMsg = time.Now()
+	readSpan, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readMessages", k.Name)))
 	func() {
 		for {
 			select {
 			case lastMsg = <-k.BatchBuffer.messageQueue:
+				if lastMsg.KafkaMessage.Time.Before(oldestMsg) {
+					oldestMsg = lastMsg.KafkaMessage.Time
+				}
 				switch lastMsg.Type {
+				case kafkaqueue.SessionDataSync:
+					dataSyncRows = append(dataSyncRows, lastMsg.SessionDataSync.SessionID)
+					received += 1
+				case kafkaqueue.PushLogs:
+					logRows = append(logRows, lastMsg.PushLogs.LogRow)
+					received += 1
 				case kafkaqueue.PushTraces:
 					traceRow := lastMsg.PushTraces.TraceRow
 					if traceRow != nil {
@@ -307,58 +132,201 @@ func (k *KafkaBatchWorker) flushTraces(ctx context.Context) error {
 			}
 		}
 	}()
+	readSpan.SetTag("MaxIngestDelay", time.Since(oldestMsg))
+	readSpan.Finish()
 
-	span, ctxT := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.batched.clickhouse.traces"))
+	workSpan, wCtx := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.work", k.Name)))
+	if err := k.flushDataSync(wCtx, dataSyncRows); err != nil {
+		workSpan.Finish(tracer.WithError(err))
+		return err
+	}
+	if err := k.flushLogs(wCtx, logRows); err != nil {
+		workSpan.Finish(tracer.WithError(err))
+		return err
+	}
+	if err := k.flushTraces(wCtx, traceRows); err != nil {
+		workSpan.Finish(tracer.WithError(err))
+		return err
+	}
+	workSpan.Finish()
+
+	commitSpan, cCtx := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.commit", k.Name)))
+	if lastMsg != nil {
+		k.KafkaQueue.Commit(cCtx, lastMsg.KafkaMessage)
+	}
+	k.BatchBuffer.lastMessage = nil
+	commitSpan.Finish()
+
+	return nil
+}
+
+func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.LogRow) error {
+	timestampByProject := map[uint32]time.Time{}
+	workspaceByProject := map[uint32]*model.Workspace{}
+	for _, row := range logRows {
+		if row.Timestamp.After(timestampByProject[row.ProjectId]) {
+			timestampByProject[row.ProjectId] = row.Timestamp
+			workspaceByProject[row.ProjectId] = nil
+		}
+	}
+
+	spanTs, ctxTs := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.setTimestamps", k.Name)))
+	for projectId, timestamp := range timestampByProject {
+		err := k.Worker.Resolver.Redis.SetLastLogTimestamp(ctxTs, int(projectId), timestamp)
+		if err != nil {
+			log.WithContext(ctxTs).WithError(err).Errorf("failed to set last log timestamp for project %d", projectId)
+		}
+	}
+	spanTs.Finish()
+
+	spanW, ctxW := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.checkBillingQuotas", k.Name)))
+
+	// If it's saved in Redis that a project has exceeded / not exceeded
+	// its quota, use that value. Else, add the projectId to a list of
+	// projects to query.
+	quotaExceededByProject := map[uint32]bool{}
+	projectsToQuery := []uint32{}
+	for projectId := range workspaceByProject {
+		exceeded, err := k.Worker.Resolver.Redis.IsBillingQuotaExceeded(ctxW, int(projectId), model.PricingProductTypeLogs)
+		if err != nil {
+			log.WithContext(ctxW).Error(err)
+			continue
+		}
+		if exceeded != nil {
+			quotaExceededByProject[projectId] = *exceeded
+		} else {
+			projectsToQuery = append(projectsToQuery, projectId)
+		}
+	}
+
+	// For any projects to query, get the associated workspace,
+	// check if that workspace is within the logs quota,
+	// and write the result to redis.
+	for _, projectId := range projectsToQuery {
+		project, err := k.Worker.Resolver.Store.GetProject(ctx, int(projectId))
+		if err != nil {
+			log.WithContext(ctxW).Error(e.Wrap(err, "error querying project"))
+			continue
+		}
+
+		var workspace model.Workspace
+		if err := k.Worker.Resolver.DB.Model(&workspace).
+			Where("id = ?", project.WorkspaceID).Find(&workspace).Error; err != nil {
+			log.WithContext(ctxW).Error(e.Wrap(err, "error querying workspace"))
+			continue
+		}
+
+		projects := []model.Project{}
+		if err := k.Worker.Resolver.DB.Order("name ASC").Model(&workspace).Association("Projects").Find(&projects); err != nil {
+			log.WithContext(ctxW).Error(e.Wrap(err, "error querying associated projects"))
+			continue
+		}
+		workspace.Projects = projects
+
+		withinBillingQuota, quotaPercent := k.Worker.PublicResolver.IsWithinQuota(ctxW, model.PricingProductTypeLogs, &workspace, time.Now())
+		quotaExceededByProject[projectId] = !withinBillingQuota
+		if err := k.Worker.Resolver.Redis.SetBillingQuotaExceeded(ctxW, int(projectId), model.PricingProductTypeLogs, !withinBillingQuota); err != nil {
+			log.WithContext(ctxW).Error(err)
+			return err
+		}
+
+		// Send alert emails if above the relevant thresholds
+		go func() {
+			defer util.Recover()
+			if quotaPercent >= 1 {
+				if err := model.SendBillingNotifications(ctx, k.Worker.PublicResolver.DB, k.Worker.PublicResolver.MailClient, email.BillingLogsUsage100Percent, &workspace); err != nil {
+					log.WithContext(ctx).Error(e.Wrap(err, "failed to send billing notifications"))
+				}
+			} else if quotaPercent >= .8 {
+				if err := model.SendBillingNotifications(ctx, k.Worker.PublicResolver.DB, k.Worker.PublicResolver.MailClient, email.BillingLogsUsage80Percent, &workspace); err != nil {
+					log.WithContext(ctx).Error(e.Wrap(err, "failed to send billing notifications"))
+				}
+			}
+		}()
+	}
+
+	spanW.Finish()
+
+	var markBackendSetupProjectIds []uint32
+	var filteredRows []*clickhouse.LogRow
+	for _, logRow := range logRows {
+		// create service record for any services found in ingested logs
+		if logRow.ServiceName != "" {
+			spanX, ctxX := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.findOrCreateService", k.Name)))
+
+			project, err := k.Worker.Resolver.Store.GetProject(ctx, int(logRow.ProjectId))
+			if err == nil && project != nil {
+				_, err := k.Worker.Resolver.Store.FindOrCreateService(ctx, *project, logRow.ServiceName, logRow.LogAttributes)
+
+				if err != nil {
+					log.WithContext(ctxX).Error(e.Wrap(err, "failed to create service"))
+				}
+			}
+
+			spanX.Finish()
+		}
+
+		if logRow.Source == privateModel.LogSourceBackend {
+			markBackendSetupProjectIds = append(markBackendSetupProjectIds, logRow.ProjectId)
+		}
+
+		// Filter out any log rows for projects where the log quota has been exceeded
+		if quotaExceededByProject[logRow.ProjectId] {
+			continue
+		}
+
+		// Temporarily filter NextJS logs
+		// TODO - remove this condition when https://github.com/highlight/highlight/issues/6181 is fixed
+		if !strings.HasPrefix(logRow.Body, "ENOENT: no such file or directory") && !strings.HasPrefix(logRow.Body, "connect ECONNREFUSED") {
+			filteredRows = append(filteredRows, logRow)
+		}
+	}
+
+	wSpan, wCtx := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.process", k.Name)))
+	wSpan.SetTag("BatchSize", len(k.BatchBuffer.messageQueue))
+	wSpan.SetTag("NumProjects", len(workspaceByProject))
+	for _, projectId := range markBackendSetupProjectIds {
+		err := k.Worker.PublicResolver.MarkBackendSetupImpl(wCtx, int(projectId), model.MarkBackendSetupTypeLogs)
+		if err != nil {
+			log.WithContext(wCtx).WithError(err).Error("failed to mark backend logs setup")
+			return err
+		}
+	}
+
+	span, ctxT := tracer.StartSpanFromContext(wCtx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse.logs", k.Name)))
+	span.SetTag("NumLogRows", len(logRows))
+	span.SetTag("NumFilteredRows", len(filteredRows))
+	err := k.Worker.PublicResolver.Clickhouse.BatchWriteLogRows(ctxT, filteredRows)
+	span.Finish(tracer.WithError(err))
+	if err != nil {
+		log.WithContext(ctxT).WithError(err).Error("failed to batch write logs to clickhouse")
+		return err
+	}
+	wSpan.Finish()
+	return nil
+}
+
+func (k *KafkaBatchWorker) flushTraces(ctx context.Context, traceRows []*clickhouse.TraceRow) error {
+	span, ctxT := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse", k.Name)))
 	span.SetTag("NumTraceRows", len(traceRows))
 	span.SetTag("PayloadSizeBytes", binary.Size(traceRows))
 	err := k.Worker.PublicResolver.Clickhouse.BatchWriteTraceRows(ctxT, traceRows)
+	defer span.Finish(tracer.WithError(err))
 	if err != nil {
 		log.WithContext(ctxT).WithError(err).Error("failed to batch write traces to clickhouse")
 		span.Finish(tracer.WithError(err))
 		return err
 	}
-	span.Finish(tracer.WithError(err))
-
-	if lastMsg != nil {
-		k.KafkaQueue.Commit(ctx, lastMsg.KafkaMessage)
-	}
-	k.BatchBuffer.lastMessage = nil
 	return nil
 }
 
-func (k *KafkaBatchWorker) flushDataSync(ctx context.Context) error {
-	s, iCtx := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.datasync.flush"))
-	s.SetTag("BatchSize", len(k.BatchBuffer.messageQueue))
-	defer s.Finish()
-
-	var sessionIds []int
-
-	readSpan, _ := tracer.StartSpanFromContext(iCtx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.datasync.readMessages"))
-	var lastMsg *kafkaqueue.Message
-	func() {
-		for {
-			select {
-			case lastMsg = <-k.BatchBuffer.messageQueue:
-				switch lastMsg.Type {
-				case kafkaqueue.SessionDataSync:
-					sessionIds = append(sessionIds, lastMsg.SessionDataSync.SessionID)
-				}
-				if len(sessionIds) >= k.BatchFlushSize {
-					return
-				}
-			default:
-				return
-			}
-		}
-	}()
-	readSpan.Finish()
-
+func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int) error {
 	sessionIdChunks := lo.Chunk(lo.Uniq(sessionIds), SessionsMaxRowsPostgres)
 	if len(sessionIdChunks) > 0 {
 		allSessionObjs := []*model.Session{}
 		for _, chunk := range sessionIdChunks {
 			sessionObjs := []*model.Session{}
-			sessionSpan, _ := tracer.StartSpanFromContext(iCtx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.datasync.readSessions"))
+			sessionSpan, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readSessions", k.Name)))
 			if err := k.Worker.PublicResolver.DB.Model(&model.Session{}).Preload("ViewedByAdmins").Where("id in ?", chunk).Find(&sessionObjs).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -366,7 +334,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context) error {
 			sessionSpan.Finish()
 
 			fieldObjs := []*model.Field{}
-			fieldSpan, _ := tracer.StartSpanFromContext(iCtx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.datasync.readFields"))
+			fieldSpan, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readFields", k.Name)))
 			if err := k.Worker.PublicResolver.DB.Model(&model.Field{}).Where("id IN (SELECT field_id FROM session_fields sf WHERE sf.session_id IN ?)", chunk).Find(&fieldObjs).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -381,7 +349,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context) error {
 				FieldID   int64
 			}
 			sessionFieldObjs := []*sessionField{}
-			sessionFieldSpan, _ := tracer.StartSpanFromContext(iCtx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.datasync.readSessionFields"))
+			sessionFieldSpan, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readSessionFields", k.Name)))
 			if err := k.Worker.PublicResolver.DB.Table("session_fields").Where("session_id IN ?", chunk).Find(&sessionFieldObjs).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -400,20 +368,14 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context) error {
 			allSessionObjs = append(allSessionObjs, sessionObjs...)
 		}
 
-		chSpan, _ := tracer.StartSpanFromContext(iCtx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.datasync.writeClickhouse"))
-		if err := k.Worker.PublicResolver.Clickhouse.WriteSessions(ctx, allSessionObjs); err != nil {
+		chSpan, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse", k.Name)))
+		err := k.Worker.PublicResolver.Clickhouse.WriteSessions(ctx, allSessionObjs)
+		defer chSpan.Finish(tracer.WithError(err))
+		if err != nil {
 			log.WithContext(ctx).Error(err)
 			return err
 		}
-		chSpan.Finish()
 	}
-
-	kafkaSpan, _ := tracer.StartSpanFromContext(iCtx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.datasync.commit"))
-	if lastMsg != nil {
-		k.KafkaQueue.Commit(ctx, lastMsg.KafkaMessage)
-	}
-	kafkaSpan.Finish()
-	k.BatchBuffer.lastMessage = nil
 	return nil
 }
 
@@ -423,7 +385,7 @@ func (k *KafkaBatchWorker) processWorkerError(ctx context.Context, attempt int, 
 	time.Sleep(MinRetryDelay * time.Duration(math.Pow(2, float64(attempt))))
 }
 
-func (k *KafkaBatchWorker) ProcessMessages(ctx context.Context, flush func(context.Context) error) {
+func (k *KafkaBatchWorker) ProcessMessages(ctx context.Context) {
 	for {
 		func() {
 			defer util.Recover()
@@ -431,20 +393,6 @@ func (k *KafkaBatchWorker) ProcessMessages(ctx context.Context, flush func(conte
 			s.SetTag("worker.goroutine", k.WorkerThread)
 			s.SetTag("BatchSize", len(k.BatchBuffer.messageQueue))
 			defer s.Finish()
-
-			k.BatchBuffer.flushLock.Lock()
-			if k.BatchBuffer.lastMessage != nil && time.Since(*k.BatchBuffer.lastMessage) > k.BatchedFlushTimeout {
-				s.SetTag("OldestMessage", time.Since(*k.BatchBuffer.lastMessage))
-
-				for i := 0; i <= kafkaqueue.TaskRetries; i++ {
-					if err := flush(ctx); err != nil {
-						k.processWorkerError(ctx, i, err)
-					} else {
-						break
-					}
-				}
-			}
-			k.BatchBuffer.flushLock.Unlock()
 
 			s1, _ := tracer.StartSpanFromContext(ctx, "kafkaWorker", tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.receive", k.Name)))
 			task := k.KafkaQueue.Receive(ctx)
@@ -458,20 +406,26 @@ func (k *KafkaBatchWorker) ProcessMessages(ctx context.Context, flush func(conte
 			k.BatchBuffer.messageQueue <- task
 
 			k.BatchBuffer.flushLock.Lock()
-			if k.BatchBuffer.lastMessage == nil {
-				t := time.Now()
-				k.BatchBuffer.lastMessage = &t
-			}
-			if len(k.BatchBuffer.messageQueue) >= k.BatchFlushSize {
+			defer k.BatchBuffer.flushLock.Unlock()
+
+			if k.BatchBuffer.lastMessage != nil && time.Since(*k.BatchBuffer.lastMessage) > k.BatchedFlushTimeout ||
+				len(k.BatchBuffer.messageQueue) >= k.BatchFlushSize {
+				if k.BatchBuffer.lastMessage != nil {
+					s.SetTag("OldestMessage", time.Since(*k.BatchBuffer.lastMessage))
+				}
+
 				for i := 0; i <= kafkaqueue.TaskRetries; i++ {
-					if err := flush(ctx); err != nil {
+					if err := k.flush(ctx); err != nil {
 						k.processWorkerError(ctx, i, err)
 					} else {
 						break
 					}
 				}
 			}
-			k.BatchBuffer.flushLock.Unlock()
+			if k.BatchBuffer.lastMessage == nil {
+				t := time.Now()
+				k.BatchBuffer.lastMessage = &t
+			}
 		}()
 	}
 }

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -80,7 +80,7 @@ func (k *KafkaWorker) ProcessMessages(ctx context.Context) {
 
 // DefaultBatchFlushSize set per https://clickhouse.com/docs/en/cloud/bestpractices/bulk-inserts
 const DefaultBatchFlushSize = 10000
-const DefaultBatchedFlushTimeout = 30 * time.Second
+const DefaultBatchedFlushTimeout = 5 * time.Second
 const SessionsMaxRowsPostgres = 500
 const MinRetryDelay = 250 * time.Millisecond
 

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -512,9 +512,6 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 		for i := 0; i < cfg.Workers; i++ {
 			go func(config WorkerConfig, workerId int) {
 				ctx := context.Background()
-				buffer := &KafkaBatchBuffer{
-					messageQueue: make(chan *kafkaqueue.Message, config.FlushSize),
-				}
 				k := KafkaBatchWorker{
 					KafkaQueue: kafkaqueue.New(
 						ctx,
@@ -522,7 +519,6 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 						kafkaqueue.Consumer, &kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(config.FlushSize)},
 					),
 					Worker:              w,
-					BatchBuffer:         buffer,
 					BatchFlushSize:      config.FlushSize,
 					BatchedFlushTimeout: config.FlushTimeout,
 					Name:                string(config.Topic),

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -485,7 +485,7 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 				BatchedFlushTimeout: DefaultBatchedFlushTimeout,
 				Name:                "batched",
 			}
-			k.ProcessMessages(ctx, k.flushLogs)
+			k.ProcessMessages(ctx)
 			wg.Done()
 		}(i)
 	}
@@ -514,7 +514,7 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 				BatchedFlushTimeout: DefaultBatchedFlushTimeout,
 				Name:                "traces",
 			}
-			k.ProcessMessages(ctx, k.flushTraces)
+			k.ProcessMessages(ctx)
 			wg.Done()
 		}(i)
 	}
@@ -539,7 +539,7 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 			BatchedFlushTimeout: DefaultBatchedFlushTimeout,
 			Name:                "datasync",
 		}
-		k.ProcessMessages(ctx, k.flushDataSync)
+		k.ProcessMessages(ctx)
 		wg.Done()
 	}()
 

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -510,25 +510,25 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 		}
 		wg.Add(cfg.Workers)
 		for i := 0; i < cfg.Workers; i++ {
-			go func(workerId int) {
+			go func(config *WorkerConfig, workerId int) {
 				buffer := &KafkaBatchBuffer{
-					messageQueue: make(chan *kafkaqueue.Message, cfg.FlushSize),
+					messageQueue: make(chan *kafkaqueue.Message, config.FlushSize),
 				}
 				k := KafkaBatchWorker{
 					KafkaQueue: kafkaqueue.New(
 						ctx,
-						kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: cfg.Topic}),
-						kafkaqueue.Consumer, &kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(cfg.FlushSize)},
+						kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: config.Topic}),
+						kafkaqueue.Consumer, &kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(config.FlushSize)},
 					),
 					Worker:              w,
 					BatchBuffer:         buffer,
-					BatchFlushSize:      cfg.FlushSize,
-					BatchedFlushTimeout: cfg.FlushTimeout,
-					Name:                string(cfg.Topic),
+					BatchFlushSize:      config.FlushSize,
+					BatchedFlushTimeout: config.FlushTimeout,
+					Name:                string(config.Topic),
 				}
 				k.ProcessMessages(ctx)
 				wg.Done()
-			}(i)
+			}(&cfg, i)
 		}
 	}
 

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -510,7 +510,8 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 		}
 		wg.Add(cfg.Workers)
 		for i := 0; i < cfg.Workers; i++ {
-			go func(config *WorkerConfig, workerId int) {
+			go func(config WorkerConfig, workerId int) {
+				ctx := context.Background()
 				buffer := &KafkaBatchBuffer{
 					messageQueue: make(chan *kafkaqueue.Message, config.FlushSize),
 				}
@@ -528,7 +529,7 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 				}
 				k.ProcessMessages(ctx)
 				wg.Done()
-			}(&cfg, i)
+			}(cfg, i)
 		}
 	}
 


### PR DESCRIPTION
## Summary

With #6430, we found that async inserts were actually hindering out trace writing
because the async write flush was happening too frequently (only writing about 1MB/s).
It seemed impossible to configure the async flush settings with clickhouse cloud to write
the async batches with a larger batch and less frequently.

This PR moves away from async inserts for some of the clickhouse writes
and allows customizing the flush behavior programmatically per topic.

* Cleanup logic for batched flush workers across topics.
* Add programmatic flush parameters for all queues.
* Disable async inserts for logs writes.

## How did you test this change?

Local backend deploy.
<img width="925" alt="Screenshot 2023-08-24 at 11 13 34 PM" src="https://github.com/highlight/highlight/assets/1351531/35f5a102-1987-45e8-96c1-f28bd6d91b26">

local performance is great writing 2 million logs in ~ 1 minute with just the 1 dev backend instance
for posterity, testing with `ab -k -f TLS1.2 -s 180 -t 600 -n 10000000 -c 8 -p CODE_OF_CONDUCT.md 'https://localhost:8082/v1/logs/raw?project=1&service=apache-bench'`
![image](https://github.com/highlight/highlight/assets/1351531/fa255452-c088-45fd-b6f5-a085e327d2a0)

## Are there any deployment considerations?

Monitoring queue consumption.
