### PR TITLE
increase number of clickhouse connections

### DIFF
--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	clickhouseMigrate "github.com/golang-migrate/migrate/v4/database/clickhouse"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/highlight-run/highlight/backend/hlog"
 	"github.com/highlight-run/highlight/backend/projectpath"
 	e "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -32,6 +33,16 @@ var (
 
 func NewClient(dbName string) (*Client, error) {
 	conn, err := clickhouse.Open(getClickhouseOptions(dbName))
+
+	go func() {
+		for {
+			stats := conn.Stats()
+			log.WithContext(context.Background()).WithField("Open", stats.Open).WithField("Idle", stats.Idle).WithField("MaxOpenConns", stats.MaxOpenConns).WithField("MaxIdleConns", stats.MaxIdleConns).Debug("Clickhouse Connection Stats")
+			hlog.Histogram("clickhouse.open", float64(stats.Open), nil, 1)
+			hlog.Histogram("clickhouse.idle", float64(stats.Idle), nil, 1)
+			time.Sleep(5 * time.Second)
+		}
+	}()
 
 	return &Client{
 		conn: conn,

--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -95,7 +95,9 @@ func getClickhouseOptions(dbName string) *clickhouse.Options {
 			Username: Username,
 			Password: Password,
 		},
-		DialTimeout: time.Duration(25) * time.Second,
+		DialTimeout:  time.Duration(25) * time.Second,
+		MaxIdleConns: 8,
+		MaxOpenConns: 64,
 	}
 
 	if useTLS() {

--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -32,7 +32,11 @@ var (
 )
 
 func NewClient(dbName string) (*Client, error) {
-	conn, err := clickhouse.Open(getClickhouseOptions(dbName))
+	opts := getClickhouseOptions(dbName)
+	opts.MaxIdleConns = 10
+	opts.MaxOpenConns = 100
+
+	conn, err := clickhouse.Open(opts)
 
 	go func() {
 		for {
@@ -106,9 +110,7 @@ func getClickhouseOptions(dbName string) *clickhouse.Options {
 			Username: Username,
 			Password: Password,
 		},
-		DialTimeout:  time.Duration(25) * time.Second,
-		MaxIdleConns: 10,
-		MaxOpenConns: 100,
+		DialTimeout: time.Duration(25) * time.Second,
 	}
 
 	if useTLS() {

--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -96,8 +96,8 @@ func getClickhouseOptions(dbName string) *clickhouse.Options {
 			Password: Password,
 		},
 		DialTimeout:  time.Duration(25) * time.Second,
-		MaxIdleConns: 8,
-		MaxOpenConns: 64,
+		MaxIdleConns: 10,
+		MaxOpenConns: 100,
 	}
 
 	if useTLS() {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -467,18 +467,19 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 	}
 
 	wg.Add(parallelBatchWorkers)
+	batchedBuffer := &KafkaBatchBuffer{
+		messageQueue: make(chan *kafkaqueue.Message, DefaultBatchFlushSize),
+	}
 	for i := 0; i < parallelBatchWorkers; i++ {
 		go func(workerId int) {
-			buffer := &KafkaBatchBuffer{
-				messageQueue: make(chan *kafkaqueue.Message, DefaultBatchFlushSize),
-			}
 			k := KafkaBatchWorker{
-				KafkaQueue: kafkaqueue.New(ctx,
+				KafkaQueue: kafkaqueue.New(
+					ctx,
 					kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}),
-					kafkaqueue.Consumer,
-					&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(2 * DefaultBatchFlushSize)}),
+					kafkaqueue.Consumer, nil,
+				),
 				Worker:              w,
-				BatchBuffer:         buffer,
+				BatchBuffer:         batchedBuffer,
 				BatchFlushSize:      DefaultBatchFlushSize,
 				BatchedFlushTimeout: DefaultBatchedFlushTimeout,
 				Name:                "batched",
@@ -489,18 +490,19 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 	}
 
 	wg.Add(parallelBatchWorkers)
+	traceBuffer := &KafkaBatchBuffer{
+		messageQueue: make(chan *kafkaqueue.Message, DefaultBatchFlushSize),
+	}
 	for i := 0; i < parallelBatchWorkers; i++ {
 		go func(workerId int) {
-			buffer := &KafkaBatchBuffer{
-				messageQueue: make(chan *kafkaqueue.Message, DefaultBatchFlushSize),
-			}
 			k := KafkaBatchWorker{
-				KafkaQueue: kafkaqueue.New(ctx,
+				KafkaQueue: kafkaqueue.New(
+					ctx,
 					kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeTraces}),
-					kafkaqueue.Consumer,
-					&kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(2 * DefaultBatchFlushSize)}),
+					kafkaqueue.Consumer, nil,
+				),
 				Worker:              w,
-				BatchBuffer:         buffer,
+				BatchBuffer:         traceBuffer,
 				BatchFlushSize:      DefaultBatchFlushSize,
 				BatchedFlushTimeout: DefaultBatchedFlushTimeout,
 				Name:                "traces",
@@ -511,26 +513,23 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 	}
 
 	wg.Add(1)
+	datasyncBuffer := &KafkaBatchBuffer{
+		messageQueue: make(chan *kafkaqueue.Message, DefaultBatchFlushSize),
+	}
 	go func() {
-		flushSize := 10000
-		maxWait := 100 * time.Millisecond
-		buffer := &KafkaBatchBuffer{
-			messageQueue: make(chan *kafkaqueue.Message, flushSize+1),
-		}
 		k := KafkaBatchWorker{
 			KafkaQueue: kafkaqueue.New(ctx,
 				kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}),
 				kafkaqueue.Consumer,
 				&kafkaqueue.ConfigOverride{
-					QueueCapacity: pointy.Int(2 * flushSize),
+					QueueCapacity: pointy.Int(2 * DefaultBatchFlushSize),
 					MinBytes:      pointy.Int(1),
-					MaxWait:       &maxWait,
 				}),
 			Worker:              w,
 			WorkerThread:        0,
-			BatchBuffer:         buffer,
-			BatchFlushSize:      flushSize,
-			BatchedFlushTimeout: 5 * time.Second,
+			BatchBuffer:         datasyncBuffer,
+			BatchFlushSize:      DefaultBatchFlushSize,
+			BatchedFlushTimeout: DefaultBatchedFlushTimeout,
 			Name:                "datasync",
 		}
 		k.ProcessMessages(ctx, k.flushDataSync)


### PR DESCRIPTION
## Summary

Increase the number of connections per [slack](https://highlightcorp.slack.com/archives/C04NLEQMGF6/p1692854899861889).
Since we have 32+32+1 goroutines per ecs container writing to clickhouse, we need this to be a higher value.

## How did you test this change?

clickhouse writing locally
![image](https://github.com/highlight/highlight/assets/1351531/fb861c66-1877-4e3c-bf8e-fe3038c8c73d)


## Are there any deployment considerations?

Monitoring clickhouse write performance.
