### PR TITLE
improve embedding grouping quality

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -3765,12 +3765,12 @@ func (r *Resolver) MatchErrorTag(ctx context.Context, query string) ([]*modelInp
 
 	var matchedErrorTags []*modelInputs.MatchedErrorTag
 	if err := r.DB.Raw(`
-		select error_tags.embedding <=> @string_embedding as score,
+		select error_tags.embedding <-> @string_embedding as score,
 					error_tags.id as id,
 					error_tags.title as title,
 					error_tags.description as description
 		from error_tags
-		order by score asc
+		order by score
 		limit 5;
 	`, sql.Named("string_embedding", model.Vector(stringEmbedding))).
 		Scan(&matchedErrorTags).Error; err != nil {
@@ -3789,10 +3789,13 @@ func (r *Resolver) FindSimilarErrors(ctx context.Context, query string) ([]*mode
 
 	var matchedErrorObjects []*model.MatchedErrorObject
 	if err := r.DB.Raw(`
-		select error_object_embeddings.gte_large_embedding <=> @string_embedding as score, 			
-			error_objects.*
-		from error_object_embeddings
-		join error_objects on error_object_embeddings.error_object_id = error_objects.id 
+		select eoep.gte_large_embedding <-> @string_embedding as score,
+			   error_objects.*
+		from error_object_embeddings_partitioned eoep
+				 inner join error_objects on eoep.error_object_id = error_objects.id
+		where eoep.gte_large_embedding is not null
+		  and eoep.project_id = 1
+		order by score
 		limit 10;
 	`, sql.Named("string_embedding", model.Vector(stringEmbedding))).
 		Scan(&matchedErrorObjects).Error; err != nil {

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -3789,13 +3789,13 @@ func (r *Resolver) FindSimilarErrors(ctx context.Context, query string) ([]*mode
 
 	var matchedErrorObjects []*model.MatchedErrorObject
 	if err := r.DB.Raw(`
-		select eoep.gte_large_embedding <-> @string_embedding as score,
-			   error_objects.*
+		select distinct on (1, error_group_id) eoep.gte_large_embedding <-> @string_embedding as score,
+											   eo.*
 		from error_object_embeddings_partitioned eoep
-				 inner join error_objects on eoep.error_object_id = error_objects.id
+				 inner join error_objects eo on eoep.error_object_id = eo.id
 		where eoep.gte_large_embedding is not null
 		  and eoep.project_id = 1
-		order by score
+		order by 1
 		limit 10;
 	`, sql.Named("string_embedding", model.Vector(stringEmbedding))).
 		Scan(&matchedErrorObjects).Error; err != nil {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -477,7 +477,7 @@ func (r *Resolver) GetTopErrorGroupMatchByEmbedding(ctx context.Context, project
 		column = "gte_large_embedding"
 	}
 	if err := r.DB.Raw(fmt.Sprintf(`
-select eoe.%s <=> @embedding as score,
+select eoe.%s <-> @embedding as score,
        eo.error_group_id                              as error_group_id
 from error_object_embeddings_partitioned eoe
          inner join error_objects eo on eo.id = eoe.error_object_id

--- a/frontend/src/pages/ErrorTags/FindSimilarErrors.tsx
+++ b/frontend/src/pages/ErrorTags/FindSimilarErrors.tsx
@@ -41,7 +41,7 @@ export function FindSimilarErrors() {
 					<Table>
 						<Table.Head>
 							<Table.Row gridColumns={['5rem', '10rem', '1fr']}>
-								<Table.Header>Type</Table.Header>
+								<Table.Header>Score</Table.Header>
 								<Table.Header>Title</Table.Header>
 								<Table.Header>Description</Table.Header>
 							</Table.Row>


### PR DESCRIPTION
## Summary

Paired with @deltaepsilon to improve the quality of the error-tags embeddings matching.
* l2 distance appears to work better than cosine distance for this model
* ensures only similar errors from our project are matched
* reduce the number of duplicate similar errors shown
* scores similar errors by similarity

## How did you test this change?

Local deploy error-tags page

## Are there any deployment considerations?

No