### PR TITLE
optimize trace flushing

### DIFF
--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -111,6 +111,9 @@ func getClickhouseOptions(dbName string) *clickhouse.Options {
 			Password: Password,
 		},
 		DialTimeout: time.Duration(25) * time.Second,
+		Compression: &clickhouse.Compression{
+			Method: clickhouse.CompressionZSTD,
+		},
 	}
 
 	if useTLS() {

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -45,11 +45,6 @@ func (client *Client) BatchWriteTraceRows(ctx context.Context, traceRows []*Trac
 		return nil
 	}
 
-	// TODO: Figure out how we are getting some nil trace rows
-	traceRows = lo.Filter(traceRows, func(traceRow *TraceRow, _ int) bool {
-		return traceRow != nil
-	})
-
 	rows := lo.Map(traceRows, func(traceRow *TraceRow, _ int) interface{} {
 		traceTimes, traceNames, traceAttrs := convertEvents(traceRow)
 		linkTraceIds, linkSpanIds, linkStates, linkAttrs := convertLinks(traceRow)

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -45,6 +45,7 @@ func (client *Client) BatchWriteTraceRows(ctx context.Context, traceRows []*Trac
 		return nil
 	}
 
+	span, _ := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.batched.flushTraces.prepareRows"))
 	rows := lo.Map(traceRows, func(traceRow *TraceRow, _ int) interface{} {
 		traceTimes, traceNames, traceAttrs := convertEvents(traceRow)
 		linkTraceIds, linkSpanIds, linkStates, linkAttrs := convertLinks(traceRow)
@@ -77,6 +78,7 @@ func (client *Client) BatchWriteTraceRows(ctx context.Context, traceRows []*Trac
 
 		return row
 	})
+	span.Finish()
 
 	ib := sqlbuilder.NewStruct(new(ClickhouseTraceRow)).InsertInto(TracesTable, rows...)
 	sql, args := ib.BuildWithFlavor(sqlbuilder.ClickHouse)

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -293,8 +293,11 @@ func (k *KafkaBatchWorker) flushTraces(ctx context.Context) error {
 			case lastMsg = <-k.BatchBuffer.messageQueue:
 				switch lastMsg.Type {
 				case kafkaqueue.PushTraces:
-					traceRows = append(traceRows, lastMsg.PushTraces.TraceRow)
-					received += 1
+					traceRow := lastMsg.PushTraces.TraceRow
+					if traceRow != nil {
+						traceRows = append(traceRows, traceRow)
+						received += 1
+					}
 				}
 				if received >= k.BatchFlushSize {
 					return

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -490,29 +490,27 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 		}(i)
 	}
 
-	wg.Add(parallelBatchWorkers)
-	traceFlushSize := 10 * DefaultBatchFlushSize
+	wg.Add(1)
+	traceFlushSize := 32 * DefaultBatchFlushSize
 	traceBuffer := &KafkaBatchBuffer{
 		messageQueue: make(chan *kafkaqueue.Message, traceFlushSize),
 	}
-	for i := 0; i < parallelBatchWorkers; i++ {
-		go func(workerId int) {
-			k := KafkaBatchWorker{
-				KafkaQueue: kafkaqueue.New(
-					ctx,
-					kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeTraces}),
-					kafkaqueue.Consumer, &kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(traceFlushSize)},
-				),
-				Worker:              w,
-				BatchBuffer:         traceBuffer,
-				BatchFlushSize:      traceFlushSize,
-				BatchedFlushTimeout: DefaultBatchedFlushTimeout,
-				Name:                "traces",
-			}
-			k.ProcessMessages(ctx, k.flushTraces)
-			wg.Done()
-		}(i)
-	}
+	go func(workerId int) {
+		k := KafkaBatchWorker{
+			KafkaQueue: kafkaqueue.New(
+				ctx,
+				kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeTraces}),
+				kafkaqueue.Consumer, &kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(traceFlushSize)},
+			),
+			Worker:              w,
+			BatchBuffer:         traceBuffer,
+			BatchFlushSize:      traceFlushSize,
+			BatchedFlushTimeout: DefaultBatchedFlushTimeout,
+			Name:                "traces",
+		}
+		k.ProcessMessages(ctx, k.flushTraces)
+		wg.Done()
+	}(0)
 
 	wg.Add(1)
 	datasyncBuffer := &KafkaBatchBuffer{


### PR DESCRIPTION
## Summary

Traces still flushing slowly, with the bottleneck being the clickhouse write.
Trying to increase the flush count in lieu of having more concurrent writes.

## How did you test this change?

Traces writing locally
![image](https://github.com/highlight/highlight/assets/1351531/13cc26c3-85e4-496e-bab0-97d3da6719c8)


## Are there any deployment considerations?

No
