### PR TITLE
programmatic number of trace workers

### DIFF
--- a/backend/clickhouse/trace_row.go
+++ b/backend/clickhouse/trace_row.go
@@ -22,8 +22,8 @@ type TraceRow struct {
 	Duration        int64
 	StatusCode      string
 	StatusMessage   string
-	Events          []Event
-	Links           []Link
+	Events          []*Event
+	Links           []*Link
 	ProjectId       uint32
 	SecureSessionId string
 }
@@ -117,9 +117,9 @@ func (t *TraceRow) WithTraceAttributes(attributes map[string]string) *TraceRow {
 }
 
 func (t *TraceRow) WithEvents(events []map[string]any) *TraceRow {
-	traceEvents := make([]Event, len(events))
+	traceEvents := make([]*Event, len(events))
 	for i, event := range events {
-		traceEvents[i] = Event{
+		traceEvents[i] = &Event{
 			Timestamp:  event["Timestamp"].(time.Time),
 			Name:       event["Name"].(string),
 			Attributes: attributesToMap(event["Attributes"].(map[string]any)),
@@ -131,9 +131,9 @@ func (t *TraceRow) WithEvents(events []map[string]any) *TraceRow {
 }
 
 func (t *TraceRow) WithLinks(links []map[string]any) *TraceRow {
-	traceLinks := make([]Link, len(links))
+	traceLinks := make([]*Link, len(links))
 	for i, link := range links {
-		traceLinks[i] = Link{
+		traceLinks[i] = &Link{
 			TraceId:    link["TraceId"].(string),
 			SpanId:     link["SpanId"].(string),
 			TraceState: link["TraceState"].(string),

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -33,13 +33,13 @@ type ClickhouseTraceRow struct {
 	TraceAttributes  map[string]string
 	StatusCode       string
 	StatusMessage    string
-	EventsTimestamp  clickhouse.ArraySet `db:"Events.Timestamp"`
-	EventsName       clickhouse.ArraySet `db:"Events.Name"`
-	EventsAttributes clickhouse.ArraySet `db:"Events.Attributes"`
-	LinksTraceId     clickhouse.ArraySet `db:"Links.TraceId"`
-	LinksSpanId      clickhouse.ArraySet `db:"Links.SpanId"`
-	LinksTraceState  clickhouse.ArraySet `db:"Links.TraceState"`
-	LinksAttributes  clickhouse.ArraySet `db:"Links.Attributes"`
+	EventsTimestamp  clickhouse.ArraySet `ch:"Events.Timestamp"`
+	EventsName       clickhouse.ArraySet `ch:"Events.Name"`
+	EventsAttributes clickhouse.ArraySet `ch:"Events.Attributes"`
+	LinksTraceId     clickhouse.ArraySet `ch:"Links.TraceId"`
+	LinksSpanId      clickhouse.ArraySet `ch:"Links.SpanId"`
+	LinksTraceState  clickhouse.ArraySet `ch:"Links.TraceState"`
+	LinksAttributes  clickhouse.ArraySet `ch:"Links.Attributes"`
 }
 
 func (client *Client) BatchWriteTraceRows(ctx context.Context, traceRows []*TraceRow) error {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1273,6 +1273,7 @@ type SystemConfiguration struct {
 	ErrorFilters     pq.StringArray `gorm:"type:text[];default:'{\"ENOENT.*\", \"connect ECONNREFUSED.*\"}'"`
 	IgnoredFiles     pq.StringArray `gorm:"type:text[];default:'{\".*\\/node_modules\\/.*\", \".*\\/go\\/pkg\\/mod\\/.*\"}'"`
 	TraceWorkers     int            `gorm:"default:1"`
+	TraceFlushSize   int            `gorm:"type:bigint;default:10000"`
 }
 
 type RetryableType string

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1272,6 +1272,7 @@ type SystemConfiguration struct {
 	MaintenanceEnd   time.Time
 	ErrorFilters     pq.StringArray `gorm:"type:text[];default:'{\"ENOENT.*\", \"connect ECONNREFUSED.*\"}'"`
 	IgnoredFiles     pq.StringArray `gorm:"type:text[];default:'{\".*\\/node_modules\\/.*\", \".*\\/go\\/pkg\\/mod\\/.*\"}'"`
+	TraceWorkers     int            `gorm:"default:1"`
 }
 
 type RetryableType string

--- a/backend/store/system_configuration.go
+++ b/backend/store/system_configuration.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (store *Store) GetSystemConfiguration(ctx context.Context) (*model.SystemConfiguration, error) {
-	return redis.CachedEval(ctx, store.redis, "system-configuration", 250*time.Millisecond, 5*time.Minute, func() (*model.SystemConfiguration, error) {
+	return redis.CachedEval(ctx, store.redis, "system-configuration", 250*time.Millisecond, time.Minute, func() (*model.SystemConfiguration, error) {
 		config := model.SystemConfiguration{Active: true}
 		if err := store.db.Model(&config).Where(&config).FirstOrCreate(&config).Error; err != nil {
 			return nil, err

--- a/backend/store/workspace_settings.go
+++ b/backend/store/workspace_settings.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (store *Store) GetAllWorkspaceSettings(ctx context.Context, workspaceID int) (*model.AllWorkspaceSettings, error) {
-	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-workspace-%d", workspaceID), 250*time.Millisecond, 5*time.Minute, func() (*model.AllWorkspaceSettings, error) {
+	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-workspace-%d", workspaceID), 250*time.Millisecond, time.Minute, func() (*model.AllWorkspaceSettings, error) {
 		var workspaceSettings model.AllWorkspaceSettings
 		if err := store.db.Where(model.AllWorkspaceSettings{WorkspaceID: workspaceID}).FirstOrCreate(&workspaceSettings).Error; err != nil {
 			return nil, err
@@ -19,7 +19,7 @@ func (store *Store) GetAllWorkspaceSettings(ctx context.Context, workspaceID int
 }
 
 func (store *Store) GetAllWorkspaceSettingsByProject(ctx context.Context, projectID int) (*model.AllWorkspaceSettings, error) {
-	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-project-%d", projectID), 250*time.Millisecond, 5*time.Minute, func() (*model.AllWorkspaceSettings, error) {
+	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-project-%d", projectID), 250*time.Millisecond, time.Minute, func() (*model.AllWorkspaceSettings, error) {
 		var workspaceSettings model.AllWorkspaceSettings
 		if err := store.db.Model(&model.AllWorkspaceSettings{}).Joins("INNER JOIN projects ON projects.workspace_id = all_workspace_settings.workspace_id").Where("projects.id = ?", projectID).Take(&workspaceSettings).Error; err != nil {
 			return nil, err

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -314,6 +314,7 @@ func (k *KafkaBatchWorker) flushTraces(ctx context.Context) error {
 	err := k.Worker.PublicResolver.Clickhouse.BatchWriteTraceRows(ctxT, traceRows)
 	if err != nil {
 		log.WithContext(ctxT).WithError(err).Error("failed to batch write traces to clickhouse")
+		span.Finish(tracer.WithError(err))
 		return err
 	}
 	span.Finish(tracer.WithError(err))

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -498,10 +498,10 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 	}
 	wg.Add(traceWorkers)
 	for i := 0; i < traceWorkers; i++ {
-		traceBuffer := &KafkaBatchBuffer{
-			messageQueue: make(chan *kafkaqueue.Message, traceFlushSize),
-		}
 		go func(workerId int) {
+			traceBuffer := &KafkaBatchBuffer{
+				messageQueue: make(chan *kafkaqueue.Message, traceFlushSize),
+			}
 			k := KafkaBatchWorker{
 				KafkaQueue: kafkaqueue.New(
 					ctx,

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -491,10 +491,11 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 	}
 
 	traceWorkers := 1
+	traceFlushSize := DefaultBatchFlushSize
 	if cfg, err := w.PublicResolver.Store.GetSystemConfiguration(ctx); err == nil {
 		traceWorkers = cfg.TraceWorkers
+		traceFlushSize = cfg.TraceFlushSize
 	}
-	traceFlushSize := DefaultBatchFlushSize
 	wg.Add(traceWorkers)
 	for i := 0; i < traceWorkers; i++ {
 		traceBuffer := &KafkaBatchBuffer{


### PR DESCRIPTION
## Summary

Reduce trace writing batch size and make the number of workers programmatic. 

## How did you test this change?

Local deploy writing traces.
![image](https://github.com/highlight/highlight/assets/1351531/ec48ed83-baea-4a4e-8da8-9f7ffde70fa3)


## Are there any deployment considerations?

No
