### PR TITLE
ensure stacktraces from promises are recorded correctly

### DIFF
--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -470,14 +470,7 @@ export class Highlight {
 	}
 
 	async consumeCustomError(error: Error, message?: string, payload?: string) {
-		let res: ErrorStackParser.StackFrame[] = []
-		try {
-			res = ErrorStackParser.parse(error)
-		} catch (e) {
-			if (this._isOnLocalHost) {
-				console.error(e)
-			}
-		}
+		const res = ErrorStackParser.parse(error)
 		this._firstLoadListeners.errors.push({
 			event: message ? message + ':' + error.message : error.message,
 			type: 'custom',

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -366,3 +366,9 @@ Reserved for the Boeing 737
 ### Patch Changes
 
 - Support passing `recordCrossOriginIframe: false` in a cross-origin iframe to record a session for the iframe contents.
+
+## 7.4.4
+
+### Patch Changes
+
+- Ensure stacktraces from Promises are parsed correctly.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.4.3",
+	"version": "7.4.4",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.4.3"
+export default "7.4.4"


### PR DESCRIPTION
## Summary

We noticed that we get browser-side errors like [this](https://app.highlight.io/1/errors/uIzopzx1FAGMCkXv0SxeoGwcK1f0?page=2&query=and%7C%7Cerror_state%2Cis%2COPEN%7C%7Cerror-field_timestamp%2Cbetween_date%2C2023-07-26T18%3A05%3A17.091Z_2023-08-25T18%3A05%3A17.091Z) recorded without a stacktrace.
The stacktrace is sent from the client as `[]` because we had fallen back to that value when the
stacktrace parsing library would error. 
That library should only error when a stack trace of `null` or `undefined` was passed in,
so we should take care of cases where that could be happening. Otherwise, we should
be explicit about raising the error about a custom-passed stacktrace.

## How did you test this change?

![image](https://github.com/highlight/highlight/assets/1351531/6c5dcd50-4ad9-46e5-bd7a-1fbd8a245506)


## Are there any deployment considerations?

New highlight.run version released.