### PR TITLE
drop errors from external hobby deployments

### DIFF
--- a/backend/otel/samples/external.json
+++ b/backend/otel/samples/external.json
@@ -1,0 +1,1 @@
+traces.json

--- a/backend/util/environment.go
+++ b/backend/util/environment.go
@@ -1,6 +1,9 @@
 package util
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 var (
 	env           = os.Getenv("ENVIRONMENT")
@@ -41,6 +44,6 @@ func IsBackendInDocker() bool {
 	return InDockerGo == "true"
 }
 
-func IsOnRender() bool {
-	return DopplerConfig == "prod_aws_render"
+func IsProduction() bool {
+	return strings.HasPrefix(DopplerConfig, "prod")
 }


### PR DESCRIPTION
## Summary

We've recently noticed that we have a bunch of errors for the highlight project
that seem to come from old code versions of highlight / do not have a service name associated.
We've traced this down to hobby deployments that are shipping phonehome data to our
cloud project as project 1, which means we record their errors (some of which are expected for a hobby deploy).
[This](https://app.highlight.io/1/errors/wvqgJG0ULiZ09vToq4wbnn2xH0Rb) is an example.
To filter them out, we can assume that for our production cloud deploy, all errors routed to project 1
will always be coming from one of our services, so we should check that the service name is defined.

## How did you test this change?

New unit test.

## Are there any deployment considerations?

No
