### PR TITLE
write logs on every request in private graph and demo landing page app

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -477,8 +477,8 @@ func main() {
 				Cache: lru.New(100),
 			})
 
-			privateServer.Use(util.NewTracer(util.PrivateGraph))
 			privateServer.Use(highlight.NewGraphqlTracer(string(util.PrivateGraph)).WithRequestFieldLogging())
+			privateServer.Use(util.NewTracer(util.PrivateGraph))
 			privateServer.SetErrorPresenter(highlight.GraphQLErrorPresenter(string(util.PrivateGraph)))
 			privateServer.SetRecoverFunc(highlight.GraphQLRecoverFunc())
 			r.Handle("/",
@@ -522,8 +522,8 @@ func main() {
 				publicgen.Config{
 					Resolvers: publicResolver,
 				}))
-			publicServer.Use(util.NewTracer(util.PublicGraph))
 			publicServer.Use(highlight.NewGraphqlTracer(string(util.PublicGraph)))
+			publicServer.Use(util.NewTracer(util.PublicGraph))
 			publicServer.SetErrorPresenter(highlight.GraphQLErrorPresenter(string(util.PublicGraph)))
 			publicServer.SetRecoverFunc(highlight.GraphQLRecoverFunc())
 			r.Handle("/",

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -5,8 +5,10 @@ package util
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql"
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -32,6 +34,7 @@ func (t Tracer) Validate(graphql.ExecutableSchema) error {
 }
 
 func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (interface{}, error) {
+	start := time.Now()
 	// taken from: https://docs.datadoghq.com/tracing/setup_overview/custom_instrumentation/go/#manually-creating-a-new-span
 	fc := graphql.GetFieldContext(ctx)
 	fieldSpan, ctx := tracer.StartSpanFromContext(ctx, "operation.field", tracer.ResourceName(fc.Field.Name))
@@ -41,16 +44,25 @@ func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 			fieldSpan.SetTag("field.arguments", bs)
 		}
 	}
-	start := graphql.Now()
 	res, err := next(ctx)
-	end := graphql.Now()
-	fieldSpan.SetTag("field.duration", end.Sub(start))
 	fieldSpan.Finish(tracer.WithError(err))
 
+	if t.serverType == PrivateGraph {
+		fields := log.Fields{
+			"duration":        time.Since(start),
+			"error":           err,
+			"operation.field": fc.Field.Name,
+			"graph":           t.serverType,
+		}
+		log.WithContext(ctx).
+			WithFields(fields).
+			Infof("graphql field")
+	}
 	return res, err
 }
 
 func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
+	start := time.Now()
 	var oc *graphql.OperationContext
 	if graphql.HasOperationContext(ctx) {
 		oc = graphql.GetOperationContext(ctx)
@@ -71,6 +83,17 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 			errs = append(errs, tracer.WithError(err))
 		}
 		span.Finish(errs...)
+	}
+	if t.serverType == PrivateGraph {
+		fields := log.Fields{
+			"duration":          time.Since(start),
+			"errors":            resp.Errors,
+			"graphql.operation": opName,
+			"graph":             t.serverType,
+		}
+		log.WithContext(ctx).
+			WithFields(fields).
+			Infof("graphql request")
 	}
 	return resp
 }

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -50,13 +50,15 @@ func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 	if t.serverType == PrivateGraph {
 		fields := log.Fields{
 			"duration":        time.Since(start),
-			"error":           err,
 			"operation.field": fc.Field.Name,
 			"graph":           t.serverType,
 		}
+		if err != nil {
+			fields["error"] = err
+		}
 		log.WithContext(ctx).
 			WithFields(fields).
-			Infof("graphql field")
+			Debugf("graphql field")
 	}
 	return res, err
 }
@@ -87,9 +89,11 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	if t.serverType == PrivateGraph {
 		fields := log.Fields{
 			"duration":          time.Since(start),
-			"errors":            resp.Errors,
 			"graphql.operation": opName,
 			"graph":             t.serverType,
+		}
+		if len(resp.Errors) > 0 {
+			fields["errors"] = resp.Errors
 		}
 		log.WithContext(ctx).
 			WithFields(fields).


### PR DESCRIPTION
## Summary

Prints a log on every request to the private graph to help with
demoing the network logs association panel.

## How did you test this change?

For every private graph request, we now have a log line printed and correctly associated.
![image](https://github.com/highlight/highlight/assets/1351531/b3f1e6dc-33cb-4a57-89ec-11d433614be1)


## Are there any deployment considerations?

No
