### PR TITLE
deprecate LastSeenVersion from services table

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2065,7 +2065,6 @@ type Service struct {
 	GithubRepoPath     *string
 	BuildPrefix        *string
 	GithubPrefix       *string
-	LastSeenVersion    *string
 	ErrorDetails       pq.StringArray `gorm:"type:text[]"`
 	ProcessName        *string
 	ProcessVersion     *string

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1037,15 +1037,14 @@ type ComplexityRoot struct {
 	}
 
 	Service struct {
-		BuildPrefix     func(childComplexity int) int
-		ErrorDetails    func(childComplexity int) int
-		GithubPrefix    func(childComplexity int) int
-		GithubRepoPath  func(childComplexity int) int
-		ID              func(childComplexity int) int
-		LastSeenVersion func(childComplexity int) int
-		Name            func(childComplexity int) int
-		ProjectID       func(childComplexity int) int
-		Status          func(childComplexity int) int
+		BuildPrefix    func(childComplexity int) int
+		ErrorDetails   func(childComplexity int) int
+		GithubPrefix   func(childComplexity int) int
+		GithubRepoPath func(childComplexity int) int
+		ID             func(childComplexity int) int
+		Name           func(childComplexity int) int
+		ProjectID      func(childComplexity int) int
+		Status         func(childComplexity int) int
 	}
 
 	ServiceConnection struct {
@@ -1059,15 +1058,14 @@ type ComplexityRoot struct {
 	}
 
 	ServiceNode struct {
-		BuildPrefix     func(childComplexity int) int
-		ErrorDetails    func(childComplexity int) int
-		GithubPrefix    func(childComplexity int) int
-		GithubRepoPath  func(childComplexity int) int
-		ID              func(childComplexity int) int
-		LastSeenVersion func(childComplexity int) int
-		Name            func(childComplexity int) int
-		ProjectID       func(childComplexity int) int
-		Status          func(childComplexity int) int
+		BuildPrefix    func(childComplexity int) int
+		ErrorDetails   func(childComplexity int) int
+		GithubPrefix   func(childComplexity int) int
+		GithubRepoPath func(childComplexity int) int
+		ID             func(childComplexity int) int
+		Name           func(childComplexity int) int
+		ProjectID      func(childComplexity int) int
+		Status         func(childComplexity int) int
 	}
 
 	Session struct {
@@ -7756,13 +7754,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Service.ID(childComplexity), true
 
-	case "Service.lastSeenVersion":
-		if e.complexity.Service.LastSeenVersion == nil {
-			break
-		}
-
-		return e.complexity.Service.LastSeenVersion(childComplexity), true
-
 	case "Service.name":
 		if e.complexity.Service.Name == nil {
 			break
@@ -7846,13 +7837,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ServiceNode.ID(childComplexity), true
-
-	case "ServiceNode.lastSeenVersion":
-		if e.complexity.ServiceNode.LastSeenVersion == nil {
-			break
-		}
-
-		return e.complexity.ServiceNode.LastSeenVersion(childComplexity), true
 
 	case "ServiceNode.name":
 		if e.complexity.ServiceNode.Name == nil {
@@ -10293,7 +10277,6 @@ type Service {
 	githubRepoPath: String
 	buildPrefix: String
 	githubPrefix: String
-	lastSeenVersion: String
 	errorDetails: [String!]
 }
 
@@ -10305,7 +10288,6 @@ type ServiceNode {
 	githubRepoPath: String
 	buildPrefix: String
 	githubPrefix: String
-	lastSeenVersion: String
 	errorDetails: [String!]
 }
 
@@ -41391,8 +41373,6 @@ func (ec *executionContext) fieldContext_Mutation_editServiceGithubSettings(ctx 
 				return ec.fieldContext_Service_buildPrefix(ctx, field)
 			case "githubPrefix":
 				return ec.fieldContext_Service_githubPrefix(ctx, field)
-			case "lastSeenVersion":
-				return ec.fieldContext_Service_lastSeenVersion(ctx, field)
 			case "errorDetails":
 				return ec.fieldContext_Service_errorDetails(ctx, field)
 			}
@@ -54804,47 +54784,6 @@ func (ec *executionContext) fieldContext_Service_githubPrefix(ctx context.Contex
 	return fc, nil
 }
 
-func (ec *executionContext) _Service_lastSeenVersion(ctx context.Context, field graphql.CollectedField, obj *model1.Service) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Service_lastSeenVersion(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.LastSeenVersion, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Service_lastSeenVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Service",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Service_errorDetails(ctx context.Context, field graphql.CollectedField, obj *model1.Service) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Service_errorDetails(ctx, field)
 	if err != nil {
@@ -55087,8 +55026,6 @@ func (ec *executionContext) fieldContext_ServiceEdge_node(ctx context.Context, f
 				return ec.fieldContext_ServiceNode_buildPrefix(ctx, field)
 			case "githubPrefix":
 				return ec.fieldContext_ServiceNode_githubPrefix(ctx, field)
-			case "lastSeenVersion":
-				return ec.fieldContext_ServiceNode_lastSeenVersion(ctx, field)
 			case "errorDetails":
 				return ec.fieldContext_ServiceNode_errorDetails(ctx, field)
 			}
@@ -55385,47 +55322,6 @@ func (ec *executionContext) _ServiceNode_githubPrefix(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext_ServiceNode_githubPrefix(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ServiceNode",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _ServiceNode_lastSeenVersion(ctx context.Context, field graphql.CollectedField, obj *model.ServiceNode) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ServiceNode_lastSeenVersion(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.LastSeenVersion, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ServiceNode_lastSeenVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ServiceNode",
 		Field:      field,
@@ -77751,10 +77647,6 @@ func (ec *executionContext) _Service(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Values[i] = ec._Service_githubPrefix(ctx, field, obj)
 
-		case "lastSeenVersion":
-
-			out.Values[i] = ec._Service_lastSeenVersion(ctx, field, obj)
-
 		case "errorDetails":
 			field := field
 
@@ -77902,10 +77794,6 @@ func (ec *executionContext) _ServiceNode(ctx context.Context, sel ast.SelectionS
 		case "githubPrefix":
 
 			out.Values[i] = ec._ServiceNode_githubPrefix(ctx, field, obj)
-
-		case "lastSeenVersion":
-
-			out.Values[i] = ec._ServiceNode_lastSeenVersion(ctx, field, obj)
 
 		case "errorDetails":
 

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -648,15 +648,14 @@ func (ServiceEdge) IsEdge()                {}
 func (this ServiceEdge) GetCursor() string { return this.Cursor }
 
 type ServiceNode struct {
-	ID              int           `json:"id"`
-	ProjectID       int           `json:"projectID"`
-	Name            string        `json:"name"`
-	Status          ServiceStatus `json:"status"`
-	GithubRepoPath  *string       `json:"githubRepoPath"`
-	BuildPrefix     *string       `json:"buildPrefix"`
-	GithubPrefix    *string       `json:"githubPrefix"`
-	LastSeenVersion *string       `json:"lastSeenVersion"`
-	ErrorDetails    []string      `json:"errorDetails"`
+	ID             int           `json:"id"`
+	ProjectID      int           `json:"projectID"`
+	Name           string        `json:"name"`
+	Status         ServiceStatus `json:"status"`
+	GithubRepoPath *string       `json:"githubRepoPath"`
+	BuildPrefix    *string       `json:"buildPrefix"`
+	GithubPrefix   *string       `json:"githubPrefix"`
+	ErrorDetails   []string      `json:"errorDetails"`
 }
 
 type SessionAlertInput struct {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -721,7 +721,6 @@ type Service {
 	githubRepoPath: String
 	buildPrefix: String
 	githubPrefix: String
-	lastSeenVersion: String
 	errorDetails: [String!]
 }
 
@@ -733,7 +732,6 @@ type ServiceNode {
 	githubRepoPath: String
 	buildPrefix: String
 	githubPrefix: String
-	lastSeenVersion: String
 	errorDetails: [String!]
 }
 

--- a/backend/store/services.go
+++ b/backend/store/services.go
@@ -130,15 +130,14 @@ func (store *Store) ListServices(project model.Project, params ListServicesParam
 		edge := &privateModel.ServiceEdge{
 			Cursor: strconv.Itoa(service.ID),
 			Node: &privateModel.ServiceNode{
-				ID:              service.ID,
-				ProjectID:       service.ProjectID,
-				Name:            service.Name,
-				Status:          service.Status,
-				GithubRepoPath:  service.GithubRepoPath,
-				BuildPrefix:     service.BuildPrefix,
-				GithubPrefix:    service.GithubPrefix,
-				LastSeenVersion: service.LastSeenVersion,
-				ErrorDetails:    service.ErrorDetails,
+				ID:             service.ID,
+				ProjectID:      service.ProjectID,
+				Name:           service.Name,
+				Status:         service.Status,
+				GithubRepoPath: service.GithubRepoPath,
+				BuildPrefix:    service.BuildPrefix,
+				GithubPrefix:   service.GithubPrefix,
+				ErrorDetails:   service.ErrorDetails,
 			},
 		}
 

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2607,7 +2607,6 @@ export type Service = {
 	githubPrefix?: Maybe<Scalars['String']>
 	githubRepoPath?: Maybe<Scalars['String']>
 	id: Scalars['ID']
-	lastSeenVersion?: Maybe<Scalars['String']>
 	name: Scalars['String']
 	projectID: Scalars['ID']
 	status: ServiceStatus
@@ -2632,7 +2631,6 @@ export type ServiceNode = {
 	githubPrefix?: Maybe<Scalars['String']>
 	githubRepoPath?: Maybe<Scalars['String']>
 	id: Scalars['ID']
-	lastSeenVersion?: Maybe<Scalars['String']>
 	name: Scalars['String']
 	projectID: Scalars['ID']
 	status: ServiceStatus


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

We thought tracking this might be useful for debugging but instead decided against it.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Confirmed services table still loads as expected.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

Will manually drop the column on prod.
