### PR TITLE
consolidate duplicate kafka worker code

### DIFF
--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -83,7 +83,7 @@ func (client *Client) BatchWriteTraceRows(ctx context.Context, traceRows []*Trac
 	batch, err := client.conn.PrepareBatch(ctx, fmt.Sprintf("INSERT INTO %s", TracesTable))
 	if err != nil {
 		span.Finish(tracer.WithError(err))
-		return e.Wrap(err, "failed to create logs batch")
+		return e.Wrap(err, "failed to create traces batch")
 	}
 
 	for _, traceRow := range rows {

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -28,7 +28,6 @@ const ConsumerGroupName = "group-default"
 const (
 	TaskRetries           = 5
 	prefetchQueueCapacity = 64
-	prefetchSizeBytes     = 64 * 1000         // 64 KB
 	messageSizeBytes      = 500 * 1000 * 1000 // 500 MB
 )
 
@@ -198,10 +197,11 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 			HeartbeatInterval: time.Second,
 			SessionTimeout:    10 * time.Second,
 			RebalanceTimeout:  rebalanceTimeout,
+			ReadBatchTimeout:  KafkaOperationTimeout,
 			Topic:             pool.Topic,
 			GroupID:           pool.ConsumerGroup,
-			MinBytes:          prefetchSizeBytes,
 			MaxBytes:          messageSizeBytes,
+			MaxWait:           time.Second,
 			QueueCapacity:     prefetchQueueCapacity,
 			// in the future, we would commit only on successful processing of a message.
 			// this means we commit very often to avoid repeating tasks on worker restart.
@@ -234,6 +234,10 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 	}()
 
 	return pool
+}
+
+func (p *Queue) metricPrefix() string {
+	return fmt.Sprintf("worker.kafka.%s", p.Topic)
 }
 
 func (p *Queue) Stop(ctx context.Context) {
@@ -269,7 +273,7 @@ func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...*Me
 			Key:   []byte(partitionKey),
 			Value: msgBytes,
 		})
-		hlog.Incr("worker.kafka.produceMessageCount", nil, 1)
+		hlog.Incr(p.metricPrefix()+"produceMessageCount", nil, 1)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, KafkaOperationTimeout)
@@ -279,7 +283,7 @@ func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...*Me
 		log.WithContext(ctx).WithError(err).WithField("partition_key", partitionKey).WithField("num_messages", len(messages)).Errorf("failed to send kafka messages")
 		return err
 	}
-	hlog.Histogram("worker.kafka.submitSec", time.Since(start).Seconds(), nil, 1)
+	hlog.Histogram(p.metricPrefix()+"submitSec", time.Since(start).Seconds(), nil, 1)
 	return nil
 }
 
@@ -300,8 +304,8 @@ func (p *Queue) Receive(ctx context.Context) (msg *Message) {
 		return nil
 	}
 	msg.KafkaMessage = &m
-	hlog.Incr("worker.kafka.consumeMessageCount", nil, 1)
-	hlog.Histogram("worker.kafka.receiveSec", time.Since(start).Seconds(), nil, 1)
+	hlog.Incr(p.metricPrefix()+"consumeMessageCount", nil, 1)
+	hlog.Histogram(p.metricPrefix()+"receiveSec", time.Since(start).Seconds(), nil, 1)
 	return
 }
 
@@ -357,8 +361,8 @@ func (p *Queue) Commit(ctx context.Context, msg *kafka.Message) {
 	if err != nil {
 		log.WithContext(ctx).Error(errors.Wrap(err, "failed to commit message"))
 	} else {
-		hlog.Incr("worker.kafka.commitMessageCount", nil, 1)
-		hlog.Histogram("worker.kafka.commitSec", time.Since(start).Seconds(), nil, 1)
+		hlog.Incr(p.metricPrefix()+"commitMessageCount", nil, 1)
+		hlog.Histogram(p.metricPrefix()+"commitSec", time.Since(start).Seconds(), nil, 1)
 	}
 }
 
@@ -367,28 +371,28 @@ func (p *Queue) LogStats() {
 		stats := p.kafkaP.Stats()
 		log.WithContext(context.Background()).WithField("topic", stats.Topic).WithField("stats", stats).Debug("Kafka Producer Stats")
 
-		hlog.Histogram("worker.kafka.produceBatchAvgSec", stats.BatchTime.Avg.Seconds(), nil, 1)
-		hlog.Histogram("worker.kafka.produceWriteAvgSec", stats.WriteTime.Avg.Seconds(), nil, 1)
-		hlog.Histogram("worker.kafka.produceWaitAvgSec", stats.WaitTime.Avg.Seconds(), nil, 1)
-		hlog.Histogram("worker.kafka.produceBatchSize", float64(stats.BatchSize.Avg), nil, 1)
-		hlog.Histogram("worker.kafka.produceBatchBytes", float64(stats.BatchBytes.Avg), nil, 1)
-		hlog.Histogram("worker.kafka.produceQueueCapacity", float64(stats.QueueCapacity), nil, 1)
-		hlog.Histogram("worker.kafka.produceQueueLength", float64(stats.QueueLength), nil, 1)
-		hlog.Histogram("worker.kafka.produceBytes", float64(stats.Bytes), nil, 1)
-		hlog.Histogram("worker.kafka.produceErrors", float64(stats.Errors), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceBatchAvgSec", stats.BatchTime.Avg.Seconds(), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceWriteAvgSec", stats.WriteTime.Avg.Seconds(), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceWaitAvgSec", stats.WaitTime.Avg.Seconds(), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceBatchSize", float64(stats.BatchSize.Avg), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceBatchBytes", float64(stats.BatchBytes.Avg), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceQueueCapacity", float64(stats.QueueCapacity), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceQueueLength", float64(stats.QueueLength), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceBytes", float64(stats.Bytes), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"produceErrors", float64(stats.Errors), nil, 1)
 	}
 	if p.kafkaC != nil {
 		stats := p.kafkaC.Stats()
 		log.WithContext(context.Background()).WithField("topic", stats.Topic).WithField("partition", stats.Partition).WithField("stats", stats).Debug("Kafka Consumer Stats")
 
-		hlog.Histogram("worker.kafka.consumeReadAvgSec", stats.ReadTime.Avg.Seconds(), nil, 1)
-		hlog.Histogram("worker.kafka.consumeWaitAvgSec", stats.WaitTime.Avg.Seconds(), nil, 1)
-		hlog.Histogram("worker.kafka.consumeFetchSize", float64(stats.FetchSize.Avg), nil, 1)
-		hlog.Histogram("worker.kafka.consumeFetchBytes", float64(stats.FetchBytes.Avg), nil, 1)
-		hlog.Histogram("worker.kafka.consumeQueueCapacity", float64(stats.QueueCapacity), nil, 1)
-		hlog.Histogram("worker.kafka.consumeQueueLength", float64(stats.QueueLength), nil, 1)
-		hlog.Histogram("worker.kafka.consumeBytes", float64(stats.Bytes), nil, 1)
-		hlog.Histogram("worker.kafka.consumeErrors", float64(stats.Errors), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeReadAvgSec", stats.ReadTime.Avg.Seconds(), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeWaitAvgSec", stats.WaitTime.Avg.Seconds(), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeFetchSize", float64(stats.FetchSize.Avg), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeFetchBytes", float64(stats.FetchBytes.Avg), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeQueueCapacity", float64(stats.QueueCapacity), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeQueueLength", float64(stats.QueueLength), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeBytes", float64(stats.Bytes), nil, 1)
+		hlog.Histogram(p.metricPrefix()+"consumeErrors", float64(stats.Errors), nil, 1)
 	}
 }
 

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -237,7 +237,7 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 }
 
 func (p *Queue) metricPrefix() string {
-	return fmt.Sprintf("worker.kafka.%s", p.Topic)
+	return fmt.Sprintf("worker.kafka.%s.", p.Topic)
 }
 
 func (p *Queue) Stop(ctx context.Context) {

--- a/backend/main.go
+++ b/backend/main.go
@@ -57,7 +57,6 @@ import (
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 	"github.com/leonelquinteros/hubspot"
-	"github.com/openlyinc/pointy"
 	e "github.com/pkg/errors"
 	"github.com/rs/cors"
 	"github.com/sendgrid/sendgrid-go"
@@ -330,8 +329,7 @@ func main() {
 	kafkaTracesProducer := kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeTraces}), kafkaqueue.Producer, nil)
 	kafkaDataSyncProducer := kafkaqueue.New(ctx,
 		kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}),
-		kafkaqueue.Producer,
-		&kafkaqueue.ConfigOverride{Async: pointy.Bool(true)})
+		kafkaqueue.Producer, nil)
 
 	opensearchClient, err := opensearch.NewOpensearchClient(db)
 	if err != nil {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1267,13 +1267,21 @@ type UserJourneyStep struct {
 }
 
 type SystemConfiguration struct {
-	Active           bool `gorm:"primary_key;default:true"`
-	MaintenanceStart time.Time
-	MaintenanceEnd   time.Time
-	ErrorFilters     pq.StringArray `gorm:"type:text[];default:'{\"ENOENT.*\", \"connect ECONNREFUSED.*\"}'"`
-	IgnoredFiles     pq.StringArray `gorm:"type:text[];default:'{\".*\\/node_modules\\/.*\", \".*\\/go\\/pkg\\/mod\\/.*\"}'"`
-	TraceWorkers     int            `gorm:"default:1"`
-	TraceFlushSize   int            `gorm:"type:bigint;default:10000"`
+	Active            bool `gorm:"primary_key;default:true"`
+	MaintenanceStart  time.Time
+	MaintenanceEnd    time.Time
+	ErrorFilters      pq.StringArray `gorm:"type:text[];default:'{\"ENOENT.*\", \"connect ECONNREFUSED.*\"}'"`
+	IgnoredFiles      pq.StringArray `gorm:"type:text[];default:'{\".*\\/node_modules\\/.*\", \".*\\/go\\/pkg\\/mod\\/.*\"}'"`
+	MainWorkers       int            `gorm:"default:64"`
+	LogsWorkers       int            `gorm:"default:1"`
+	LogsFlushSize     int            `gorm:"type:bigint;default:10000"`
+	LogsFlushTimeout  time.Duration  `gorm:"type:bigint;default:5000000000"`
+	DataSyncWorkers   int            `gorm:"default:1"`
+	DataSyncFlushSize int            `gorm:"type:bigint;default:10000"`
+	DataSyncTimeout   time.Duration  `gorm:"type:bigint;default:5000000000"`
+	TraceWorkers      int            `gorm:"default:1"`
+	TraceFlushSize    int            `gorm:"type:bigint;default:10000"`
+	TraceFlushTimeout time.Duration  `gorm:"type:bigint;default:5000000000"`
 }
 
 type RetryableType string

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -101,20 +101,20 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 	var lastMsg *kafkaqueue.Message
 	var oldestMsg = time.Now()
 	readSpan, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readMessages", k.Name)))
-	for _, msg := range k.messages {
-		if msg.KafkaMessage.Time.Before(oldestMsg) {
-			oldestMsg = msg.KafkaMessage.Time
+	for _, lastMsg = range k.messages {
+		if lastMsg.KafkaMessage.Time.Before(oldestMsg) {
+			oldestMsg = lastMsg.KafkaMessage.Time
 		}
-		switch msg.Type {
+		switch lastMsg.Type {
 		case kafkaqueue.SessionDataSync:
-			dataSyncRows = append(dataSyncRows, msg.SessionDataSync.SessionID)
+			dataSyncRows = append(dataSyncRows, lastMsg.SessionDataSync.SessionID)
 		case kafkaqueue.PushLogs:
-			logRow := msg.PushLogs.LogRow
+			logRow := lastMsg.PushLogs.LogRow
 			if logRow != nil {
 				logRows = append(logRows, logRow)
 			}
 		case kafkaqueue.PushTraces:
-			traceRow := msg.PushTraces.TraceRow
+			traceRow := lastMsg.PushTraces.TraceRow
 			if traceRow != nil {
 				traceRows = append(traceRows, traceRow)
 			}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -444,18 +444,49 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 	return nil
 }
 
+type WorkerConfig struct {
+	Workers      int
+	FlushSize    int
+	FlushTimeout time.Duration
+	Topic        kafkaqueue.TopicType
+}
+
 func (w *Worker) PublicWorker(ctx context.Context) {
-	const parallelWorkers = 64
-	const parallelBatchWorkers = 32
 	// creates N parallel kafka message consumers that process messages.
 	// each consumer is considered part of the same consumer group and gets
 	// allocated a slice of all partitions. this ensures that a particular subset of partitions
 	// is processed serially, so messages in that slice are processed in order.
 
-	wg := sync.WaitGroup{}
+	mainWorkers := 64
+	sys, cfgErr := w.PublicResolver.Store.GetSystemConfiguration(ctx)
+	if cfgErr == nil {
+		mainWorkers = sys.MainWorkers
+	}
 
-	wg.Add(parallelWorkers)
-	for i := 0; i < parallelWorkers; i++ {
+	logsConfig := WorkerConfig{
+		Topic:        kafkaqueue.TopicTypeBatched,
+		Workers:      sys.LogsWorkers,
+		FlushSize:    sys.LogsFlushSize,
+		FlushTimeout: sys.LogsFlushTimeout,
+	}
+
+	tracesConfig := WorkerConfig{
+		Topic:        kafkaqueue.TopicTypeTraces,
+		Workers:      sys.TraceWorkers,
+		FlushSize:    sys.TraceFlushSize,
+		FlushTimeout: sys.TraceFlushTimeout,
+	}
+
+	dataSyncConfig := WorkerConfig{
+		Topic:        kafkaqueue.TopicTypeDataSync,
+		Workers:      sys.DataSyncWorkers,
+		FlushSize:    sys.DataSyncFlushSize,
+		FlushTimeout: sys.DataSyncTimeout,
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(mainWorkers)
+	for i := 0; i < mainWorkers; i++ {
 		go func(workerId int) {
 			k := KafkaWorker{
 				KafkaQueue:   kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDefault}), kafkaqueue.Consumer, nil),
@@ -467,81 +498,36 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 		}(i)
 	}
 
-	wg.Add(parallelBatchWorkers)
-	batchedBuffer := &KafkaBatchBuffer{
-		messageQueue: make(chan *kafkaqueue.Message, DefaultBatchFlushSize),
-	}
-	for i := 0; i < parallelBatchWorkers; i++ {
-		go func(workerId int) {
-			k := KafkaBatchWorker{
-				KafkaQueue: kafkaqueue.New(
-					ctx,
-					kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeBatched}),
-					kafkaqueue.Consumer, nil,
-				),
-				Worker:              w,
-				BatchBuffer:         batchedBuffer,
-				BatchFlushSize:      DefaultBatchFlushSize,
-				BatchedFlushTimeout: DefaultBatchedFlushTimeout,
-				Name:                "batched",
-			}
-			k.ProcessMessages(ctx, k.flushLogs)
-			wg.Done()
-		}(i)
-	}
-
-	traceWorkers := 1
-	traceFlushSize := DefaultBatchFlushSize
-	if cfg, err := w.PublicResolver.Store.GetSystemConfiguration(ctx); err == nil {
-		traceWorkers = cfg.TraceWorkers
-		traceFlushSize = cfg.TraceFlushSize
-	}
-	wg.Add(traceWorkers)
-	for i := 0; i < traceWorkers; i++ {
-		go func(workerId int) {
-			traceBuffer := &KafkaBatchBuffer{
-				messageQueue: make(chan *kafkaqueue.Message, traceFlushSize),
-			}
-			k := KafkaBatchWorker{
-				KafkaQueue: kafkaqueue.New(
-					ctx,
-					kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeTraces}),
-					kafkaqueue.Consumer, &kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(traceFlushSize)},
-				),
-				Worker:              w,
-				BatchBuffer:         traceBuffer,
-				BatchFlushSize:      traceFlushSize,
-				BatchedFlushTimeout: DefaultBatchedFlushTimeout,
-				Name:                "traces",
-			}
-			k.ProcessMessages(ctx, k.flushTraces)
-			wg.Done()
-		}(i)
-	}
-
-	wg.Add(1)
-	datasyncBuffer := &KafkaBatchBuffer{
-		messageQueue: make(chan *kafkaqueue.Message, DefaultBatchFlushSize),
-	}
-	go func() {
-		k := KafkaBatchWorker{
-			KafkaQueue: kafkaqueue.New(ctx,
-				kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDataSync}),
-				kafkaqueue.Consumer,
-				&kafkaqueue.ConfigOverride{
-					QueueCapacity: pointy.Int(2 * DefaultBatchFlushSize),
-					MinBytes:      pointy.Int(1),
-				}),
-			Worker:              w,
-			WorkerThread:        0,
-			BatchBuffer:         datasyncBuffer,
-			BatchFlushSize:      DefaultBatchFlushSize,
-			BatchedFlushTimeout: DefaultBatchedFlushTimeout,
-			Name:                "datasync",
+	for _, cfg := range []WorkerConfig{logsConfig, tracesConfig, dataSyncConfig} {
+		if cfg.Workers == 0 {
+			cfg.Workers = 1
 		}
-		k.ProcessMessages(ctx, k.flushDataSync)
-		wg.Done()
-	}()
+		if cfg.FlushSize == 0 {
+			cfg.FlushSize = DefaultBatchFlushSize
+		}
+		if cfg.FlushTimeout == 0 {
+			cfg.FlushTimeout = DefaultBatchedFlushTimeout
+		}
+		wg.Add(cfg.Workers)
+		for i := 0; i < cfg.Workers; i++ {
+			go func(config WorkerConfig, workerId int) {
+				ctx := context.Background()
+				k := KafkaBatchWorker{
+					KafkaQueue: kafkaqueue.New(
+						ctx,
+						kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: config.Topic}),
+						kafkaqueue.Consumer, &kafkaqueue.ConfigOverride{QueueCapacity: pointy.Int(config.FlushSize)},
+					),
+					Worker:              w,
+					BatchFlushSize:      config.FlushSize,
+					BatchedFlushTimeout: config.FlushTimeout,
+					Name:                string(config.Topic),
+				}
+				k.ProcessMessages(ctx)
+				wg.Done()
+			}(cfg, i)
+		}
+	}
 
 	wg.Wait()
 }


### PR DESCRIPTION
## Summary

Brings back #6424 with fixes to ensure we commit batched message processing.

## How did you test this change?

running locally and checking for duplicate logs
```
select UUID, count(*)
from logs
group by 1
order by 2 desc;
```
<img width="649" alt="Screenshot 2023-08-28 at 4 24 16 PM" src="https://github.com/highlight/highlight/assets/1351531/42c2192c-d08d-427f-bde4-f5f13ece9281">


## Are there any deployment considerations?

Updating datadog metrics.
