### PR TITLE
Fix long GitHub issue titles

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1534,7 +1534,7 @@ func (r *mutationResolver) CreateSessionComment(ctx context.Context, projectID i
 			IntegrationType:  *s,
 			SessionCommentID: sessionComment.ID,
 		}
-		desc := *issueDescription
+		title, desc := r.Store.BuildIssueTitleAndDescription(*issueTitle, issueDescription)
 		desc += "\n\nSee the error page on Highlight:\n"
 		desc += fmt.Sprintf("%s/%d/sessions/%s", os.Getenv("REACT_APP_FRONTEND_URI"), projectID, sessionComment.SessionSecureId)
 
@@ -1561,7 +1561,7 @@ func (r *mutationResolver) CreateSessionComment(ctx context.Context, projectID i
 			if err := r.CreateClickUpTaskAndAttachment(
 				workspace,
 				attachment,
-				*issueTitle,
+				title,
 				desc,
 				issueTeamID,
 			); err != nil {
@@ -1574,7 +1574,7 @@ func (r *mutationResolver) CreateSessionComment(ctx context.Context, projectID i
 				ctx,
 				workspace,
 				attachment,
-				*issueTitle,
+				title,
 				desc,
 				issueTeamID,
 			); err != nil {
@@ -1587,7 +1587,7 @@ func (r *mutationResolver) CreateSessionComment(ctx context.Context, projectID i
 				ctx,
 				workspace,
 				attachment,
-				*issueTitle,
+				title,
 				desc,
 				issueTeamID,
 				tags,
@@ -1642,7 +1642,7 @@ func (r *mutationResolver) CreateIssueForSessionComment(ctx context.Context, pro
 			SessionCommentID: sessionComment.ID,
 		}
 
-		desc := *issueDescription
+		title, desc := r.Store.BuildIssueTitleAndDescription(*issueTitle, issueDescription)
 		desc += "\n\nSee the error page on Highlight:\n"
 		desc += fmt.Sprintf("%s/%d/sessions/%s", os.Getenv("REACT_APP_FRONTEND_URI"), projectID, sessionComment.SessionSecureId)
 
@@ -1653,19 +1653,19 @@ func (r *mutationResolver) CreateIssueForSessionComment(ctx context.Context, pro
 
 			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
 		} else if *s == modelInputs.IntegrationTypeClickUp && workspace.ClickupAccessToken != nil && *workspace.ClickupAccessToken != "" {
-			if err := r.CreateClickUpTaskAndAttachment(workspace, attachment, *issueTitle, desc, issueTeamID); err != nil {
+			if err := r.CreateClickUpTaskAndAttachment(workspace, attachment, title, desc, issueTeamID); err != nil {
 				return nil, e.Wrap(err, "error creating ClickUp task")
 			}
 
 			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
 		} else if *s == modelInputs.IntegrationTypeHeight {
-			if err := r.CreateHeightTaskAndAttachment(ctx, workspace, attachment, *issueTitle, desc, issueTeamID); err != nil {
+			if err := r.CreateHeightTaskAndAttachment(ctx, workspace, attachment, title, desc, issueTeamID); err != nil {
 				return nil, e.Wrap(err, "error creating Height task")
 			}
 
 			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
 		} else if *s == modelInputs.IntegrationTypeGitHub {
-			if err := r.CreateGitHubTaskAndAttachment(ctx, workspace, attachment, *issueTitle, desc, issueTeamID, nil); err != nil {
+			if err := r.CreateGitHubTaskAndAttachment(ctx, workspace, attachment, title, desc, issueTeamID, nil); err != nil {
 				return nil, e.Wrap(err, "error creating GitHub task")
 			}
 
@@ -1961,7 +1961,7 @@ func (r *mutationResolver) CreateErrorComment(ctx context.Context, projectID int
 			if err := r.CreateLinearIssueAndAttachment(
 				workspace,
 				attachment,
-				title,
+				*issueTitle,
 				*issueDescription,
 				textForEmail,
 				authorName,
@@ -2118,7 +2118,7 @@ func (r *mutationResolver) CreateIssueForErrorComment(ctx context.Context, proje
 		return nil, e.New("issue description cannot be nil")
 	}
 
-	desc := *issueDescription
+	title, desc := r.Store.BuildIssueTitleAndDescription(*issueTitle, issueDescription)
 	desc += "\n\nSee the error page on Highlight:\n"
 	desc += fmt.Sprintf("%s/%d/errors/%s", os.Getenv("REACT_APP_FRONTEND_URI"), projectID, errorComment.ErrorSecureId)
 
@@ -2147,7 +2147,7 @@ func (r *mutationResolver) CreateIssueForErrorComment(ctx context.Context, proje
 			if err := r.CreateClickUpTaskAndAttachment(
 				workspace,
 				attachment,
-				*issueTitle,
+				title,
 				desc,
 				issueTeamID,
 			); err != nil {
@@ -2156,13 +2156,13 @@ func (r *mutationResolver) CreateIssueForErrorComment(ctx context.Context, proje
 
 			errorComment.Attachments = append(errorComment.Attachments, attachment)
 		} else if *s == modelInputs.IntegrationTypeHeight {
-			if err := r.CreateHeightTaskAndAttachment(ctx, workspace, attachment, *issueTitle, desc, issueTeamID); err != nil {
+			if err := r.CreateHeightTaskAndAttachment(ctx, workspace, attachment, title, desc, issueTeamID); err != nil {
 				return nil, e.Wrap(err, "error creating Height task")
 			}
 
 			errorComment.Attachments = append(errorComment.Attachments, attachment)
 		} else if *s == modelInputs.IntegrationTypeGitHub {
-			if err := r.CreateGitHubTaskAndAttachment(ctx, workspace, attachment, *issueTitle, desc, issueTeamID, nil); err != nil {
+			if err := r.CreateGitHubTaskAndAttachment(ctx, workspace, attachment, title, desc, issueTeamID, nil); err != nil {
 				return nil, e.Wrap(err, "error creating GitHub task")
 			}
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1953,15 +1953,15 @@ func (r *mutationResolver) CreateErrorComment(ctx context.Context, projectID int
 			ErrorCommentID:  errorComment.ID,
 		}
 
-		desc := *issueDescription
-		desc += "\n\nSee the error page on Highlight:\n"
+		title, desc := r.Store.BuildIssueTitleAndDescription(*issueTitle, issueDescription)
+		desc += "See the error page on Highlight:\n"
 		desc += fmt.Sprintf("%s/%d/errors/%s", os.Getenv("REACT_APP_FRONTEND_URI"), projectID, errorComment.ErrorSecureId)
 
 		if *s == modelInputs.IntegrationTypeLinear && workspace.LinearAccessToken != nil && *workspace.LinearAccessToken != "" {
 			if err := r.CreateLinearIssueAndAttachment(
 				workspace,
 				attachment,
-				*issueTitle,
+				title,
 				*issueDescription,
 				textForEmail,
 				authorName,
@@ -1976,7 +1976,7 @@ func (r *mutationResolver) CreateErrorComment(ctx context.Context, projectID int
 			if err := r.CreateClickUpTaskAndAttachment(
 				workspace,
 				attachment,
-				*issueTitle,
+				title,
 				desc,
 				issueTeamID,
 			); err != nil {
@@ -1985,13 +1985,13 @@ func (r *mutationResolver) CreateErrorComment(ctx context.Context, projectID int
 
 			errorComment.Attachments = append(errorComment.Attachments, attachment)
 		} else if *s == modelInputs.IntegrationTypeHeight {
-			if err := r.CreateHeightTaskAndAttachment(ctx, workspace, attachment, *issueTitle, desc, issueTeamID); err != nil {
+			if err := r.CreateHeightTaskAndAttachment(ctx, workspace, attachment, title, desc, issueTeamID); err != nil {
 				return nil, e.Wrap(err, "error creating Height task")
 			}
 
 			errorComment.Attachments = append(errorComment.Attachments, attachment)
 		} else if *s == modelInputs.IntegrationTypeGitHub {
-			if err := r.CreateGitHubTaskAndAttachment(ctx, workspace, attachment, *issueTitle, desc, issueTeamID, nil); err != nil {
+			if err := r.CreateGitHubTaskAndAttachment(ctx, workspace, attachment, title, desc, issueTeamID, nil); err != nil {
 				return nil, e.Wrap(err, "error creating GitHub task")
 			}
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1535,7 +1535,7 @@ func (r *mutationResolver) CreateSessionComment(ctx context.Context, projectID i
 			SessionCommentID: sessionComment.ID,
 		}
 		title, desc := r.Store.BuildIssueTitleAndDescription(*issueTitle, issueDescription)
-		desc += "\n\nSee the error page on Highlight:\n"
+		desc += "See the error page on Highlight:\n"
 		desc += fmt.Sprintf("%s/%d/sessions/%s", os.Getenv("REACT_APP_FRONTEND_URI"), projectID, sessionComment.SessionSecureId)
 
 		if *s == modelInputs.IntegrationTypeLinear &&
@@ -1643,7 +1643,7 @@ func (r *mutationResolver) CreateIssueForSessionComment(ctx context.Context, pro
 		}
 
 		title, desc := r.Store.BuildIssueTitleAndDescription(*issueTitle, issueDescription)
-		desc += "\n\nSee the error page on Highlight:\n"
+		desc += "See the error page on Highlight:\n"
 		desc += fmt.Sprintf("%s/%d/sessions/%s", os.Getenv("REACT_APP_FRONTEND_URI"), projectID, sessionComment.SessionSecureId)
 
 		if *s == modelInputs.IntegrationTypeLinear && workspace.LinearAccessToken != nil && *workspace.LinearAccessToken != "" {
@@ -2119,7 +2119,7 @@ func (r *mutationResolver) CreateIssueForErrorComment(ctx context.Context, proje
 	}
 
 	title, desc := r.Store.BuildIssueTitleAndDescription(*issueTitle, issueDescription)
-	desc += "\n\nSee the error page on Highlight:\n"
+	desc += "See the error page on Highlight:\n"
 	desc += fmt.Sprintf("%s/%d/errors/%s", os.Getenv("REACT_APP_FRONTEND_URI"), projectID, errorComment.ErrorSecureId)
 
 	for _, s := range integrations {

--- a/backend/store/issues.go
+++ b/backend/store/issues.go
@@ -1,0 +1,27 @@
+package store
+
+import (
+	"fmt"
+
+	"github.com/aws/smithy-go/ptr"
+)
+
+const MAX_ISSUE_TITLE_LENGTH = 200
+
+func (store *Store) BuildIssueTitleAndDescription(title string, description *string) (string, string) {
+	var workingTitle, workingDescription string
+
+	if len(title) > MAX_ISSUE_TITLE_LENGTH {
+		workingTitle = fmt.Sprintf("%s...", (title)[:MAX_ISSUE_TITLE_LENGTH])
+		workingDescription = fmt.Sprintf("...%s\n\n", (title)[MAX_ISSUE_TITLE_LENGTH:])
+	} else {
+		workingTitle = title
+		workingDescription = ""
+	}
+
+	if ptr.ToString(description) != "" {
+		workingDescription += fmt.Sprintf("%s\n\n", *description)
+	}
+
+	return workingTitle, workingDescription
+}

--- a/backend/store/issues_test.go
+++ b/backend/store/issues_test.go
@@ -1,0 +1,53 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildIssueTitleAndDescription(t *testing.T) {
+	defer teardown(t)
+	var tests = []struct {
+		Title               string
+		Description         *string
+		ExpectedTitle       string
+		ExpectedDescription string
+	}{
+		{
+			Title:               "This is a title",
+			Description:         ptr.String("This is a description"),
+			ExpectedTitle:       "This is a title",
+			ExpectedDescription: "This is a description\n\n",
+		},
+		{
+			Title:               "This is a title",
+			ExpectedTitle:       "This is a title",
+			ExpectedDescription: "",
+		},
+		{
+			Title:               "This is a title",
+			Description:         ptr.String(""),
+			ExpectedTitle:       "This is a title",
+			ExpectedDescription: "",
+		},
+		{
+			Title:               "This is a really long title (more than 200 characters): Nuremberg is the second-largest city of the German state of Bavaria after its capital Munich, and its 541,000 inhabitants make it the 14th-largest city in Germany.",
+			ExpectedTitle:       "This is a really long title (more than 200 characters): Nuremberg is the second-largest city of the German state of Bavaria after its capital Munich, and its 541,000 inhabitants make it the 14th-large...",
+			ExpectedDescription: "...st city in Germany.\n\n",
+		},
+		{
+			Title:               "This is a really long title (more than 200 characters): Nuremberg is the second-largest city of the German state of Bavaria after its capital Munich, and its 541,000 inhabitants make it the 14th-largest city in Germany.",
+			Description:         ptr.String("This is a description"),
+			ExpectedTitle:       "This is a really long title (more than 200 characters): Nuremberg is the second-largest city of the German state of Bavaria after its capital Munich, and its 541,000 inhabitants make it the 14th-large...",
+			ExpectedDescription: "...st city in Germany.\n\nThis is a description\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		title, desc := store.BuildIssueTitleAndDescription(tt.Title, tt.Description)
+		assert.Equal(t, tt.ExpectedTitle, title)
+		assert.Equal(t, tt.ExpectedDescription, desc)
+	}
+}


### PR DESCRIPTION
## Summary
The GitHub API is return 422 validation errors when we try to create an issue for an error with longer than 256 characters.

Update the API to take the first 200 characters of the proposed title, and keep them as the title. Move the rest of the characters to the description.

## How did you test this change?
Create an issue from Highlight on an error with > 200 characters
- [ ] Issue title includes first 200 characters
- [ ] Description includes the rest of the characters

https://www.loom.com/share/756699290db747088da287798a30872e?sid=676521f4-e499-4f14-af16-bf82549b136f

## Are there any deployment considerations?
N/A