### PR TITLE
Fix error - Catch and log empty content from stack trace enhancement

### DIFF
--- a/backend/store/stacktraces.go
+++ b/backend/store/stacktraces.go
@@ -127,6 +127,10 @@ func (store *Store) EnhanceTraceWithGitHub(ctx context.Context, trace *privateMo
 			return trace, err
 		}
 
+		if encodedFileContent == nil {
+			return trace, fmt.Errorf("GitHub returned empty content for %s in %s", fileName, *service.GithubRepoPath)
+		}
+
 		gitHubFileBytes = []byte(*encodedFileContent)
 
 		_, err = store.storageClient.PushGitHubFile(ctx, *service.GithubRepoPath, fileName, serviceVersion, gitHubFileBytes)

--- a/backend/store/stacktraces.go
+++ b/backend/store/stacktraces.go
@@ -128,7 +128,7 @@ func (store *Store) EnhanceTraceWithGitHub(ctx context.Context, trace *privateMo
 		}
 
 		if encodedFileContent == nil {
-			return trace, fmt.Errorf("GitHub returned empty content for %s in %s", fileName, *service.GithubRepoPath)
+			return trace, fmt.Errorf("Unable to fetch %s in %s", fileName, *service.GithubRepoPath)
 		}
 
 		gitHubFileBytes = []byte(*encodedFileContent)


### PR DESCRIPTION
## Summary
Since merging in https://github.com/highlight/highlight/pull/6458, our services have flipped to an error state with a dereferencing pointer message

<img width="1703" alt="Screenshot 2023-08-30 at 9 41 50 AM" src="https://github.com/highlight/highlight/assets/17744174/11131b3d-af88-4b80-9bd6-0aad431b250b">

Catch this case and log it, so we have more information on debugging this edge case

## How did you test this change?
Not able to repro pointer error as errors still get enhanced properly locally

## Are there any deployment considerations?
N/A
