### PR TITLE
include project id in the service name for vercel log drains

### DIFF
--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -157,7 +157,7 @@ func submitVercelLog(ctx context.Context, projectID int, log VercelLog) {
 	attrs := []attribute.KeyValue{
 		LogSeverityKey.String(log.Type),
 		LogMessageKey.String(log.Message),
-		semconv.ServiceNameKey.String("vercel-log-drain"),
+		semconv.ServiceNameKey.String("vercel-log-drain-" + log.ProjectId),
 		semconv.ServiceVersionKey.String(log.DeploymentId),
 		semconv.CodeNamespaceKey.String(log.Source),
 		semconv.CodeFilepathKey.String(log.Path),


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Multiple vercel log drains can be created and we need to distinguish them (e.g. this vercel project sent X number of logs). This PR includes the vercel project id in the service name.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Used the test log drain feature and verified that a service is created with the project id included
![Screenshot 2023-08-30 at 1 41 29 PM](https://github.com/highlight/highlight/assets/58678/615faefa-3a11-4a72-a123-90e40b347561)

Note: the test log drain doesn't use a real project id. 


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

* We should verify the project id looks good for non test log drains
* We should clean up vercel log drains services without project ids in our prod db
