### PR TITLE
Revert "add service name to client config"

### DIFF
--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -69,7 +69,6 @@ type InitializeSessionArgs struct {
 	ClientID                       string
 	NetworkRecordingDomains        []string
 	DisableSessionRecording        *bool
-	ServiceName                    string
 }
 
 type IdentifySessionArgs struct {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -630,9 +630,8 @@ type Session struct {
 	Fields         []*Field `json:"fields" gorm:"many2many:session_fields;"`
 	Environment    string   `json:"environment"`
 	AppVersion     *string  `json:"app_version"`
-	ServiceName    string
-	UserObject     JSONB  `json:"user_object" sql:"type:jsonb"`
-	UserProperties string `json:"user_properties"`
+	UserObject     JSONB    `json:"user_object" sql:"type:jsonb"`
+	UserProperties string   `json:"user_properties"`
 	// Whether this is the first session created by this user.
 	FirstTime               *bool      `json:"first_time" gorm:"default:false"`
 	PayloadUpdatedAt        *time.Time `json:"payload_updated_at"`

--- a/backend/public-graph/graph/generated/generated.go
+++ b/backend/public-graph/graph/generated/generated.go
@@ -54,7 +54,7 @@ type ComplexityRoot struct {
 		AddSessionFeedback   func(childComplexity int, sessionSecureID string, userName *string, userEmail *string, verbatim string, timestamp time.Time) int
 		AddSessionProperties func(childComplexity int, sessionSecureID string, propertiesObject interface{}) int
 		IdentifySession      func(childComplexity int, sessionSecureID string, userIdentifier string, userObject interface{}) int
-		InitializeSession    func(childComplexity int, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, serviceName string, fingerprint string, clientID string, networkRecordingDomains []string, disableSessionRecording *bool) int
+		InitializeSession    func(childComplexity int, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, fingerprint string, clientID string, networkRecordingDomains []string, disableSessionRecording *bool) int
 		MarkBackendSetup     func(childComplexity int, projectID *string, sessionSecureID *string, typeArg *string) int
 		PushBackendPayload   func(childComplexity int, projectID *string, errors []*model.BackendErrorObjectInput) int
 		PushMetrics          func(childComplexity int, metrics []*model.MetricInput) int
@@ -74,7 +74,7 @@ type ComplexityRoot struct {
 }
 
 type MutationResolver interface {
-	InitializeSession(ctx context.Context, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, serviceName string, fingerprint string, clientID string, networkRecordingDomains []string, disableSessionRecording *bool) (*model.InitializeSessionResponse, error)
+	InitializeSession(ctx context.Context, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, fingerprint string, clientID string, networkRecordingDomains []string, disableSessionRecording *bool) (*model.InitializeSessionResponse, error)
 	IdentifySession(ctx context.Context, sessionSecureID string, userIdentifier string, userObject interface{}) (string, error)
 	AddSessionProperties(ctx context.Context, sessionSecureID string, propertiesObject interface{}) (string, error)
 	PushPayload(ctx context.Context, sessionSecureID string, events model.ReplayEventsInput, messages string, resources string, webSocketEvents *string, errors []*model.ErrorObjectInput, isBeacon *bool, hasSessionUnloaded *bool, highlightLogs *string, payloadID *int) (int, error)
@@ -162,7 +162,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.InitializeSession(childComplexity, args["session_secure_id"].(string), args["organization_verbose_id"].(string), args["enable_strict_privacy"].(bool), args["enable_recording_network_contents"].(bool), args["clientVersion"].(string), args["firstloadVersion"].(string), args["clientConfig"].(string), args["environment"].(string), args["appVersion"].(*string), args["serviceName"].(string), args["fingerprint"].(string), args["client_id"].(string), args["network_recording_domains"].([]string), args["disable_session_recording"].(*bool)), true
+		return e.complexity.Mutation.InitializeSession(childComplexity, args["session_secure_id"].(string), args["organization_verbose_id"].(string), args["enable_strict_privacy"].(bool), args["enable_recording_network_contents"].(bool), args["clientVersion"].(string), args["firstloadVersion"].(string), args["clientConfig"].(string), args["environment"].(string), args["appVersion"].(*string), args["fingerprint"].(string), args["client_id"].(string), args["network_recording_domains"].([]string), args["disable_session_recording"].(*bool)), true
 
 	case "Mutation.markBackendSetup":
 		if e.complexity.Mutation.MarkBackendSetup == nil {
@@ -427,7 +427,6 @@ type Mutation {
 		clientConfig: String!
 		environment: String!
 		appVersion: String
-		serviceName: String!
 		fingerprint: String!
 		client_id: String!
 		network_recording_domains: [String!]
@@ -681,50 +680,41 @@ func (ec *executionContext) field_Mutation_initializeSession_args(ctx context.Co
 	}
 	args["appVersion"] = arg8
 	var arg9 string
-	if tmp, ok := rawArgs["serviceName"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("serviceName"))
+	if tmp, ok := rawArgs["fingerprint"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("fingerprint"))
 		arg9, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["serviceName"] = arg9
+	args["fingerprint"] = arg9
 	var arg10 string
-	if tmp, ok := rawArgs["fingerprint"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("fingerprint"))
+	if tmp, ok := rawArgs["client_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("client_id"))
 		arg10, err = ec.unmarshalNString2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["fingerprint"] = arg10
-	var arg11 string
-	if tmp, ok := rawArgs["client_id"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("client_id"))
-		arg11, err = ec.unmarshalNString2string(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["client_id"] = arg11
-	var arg12 []string
+	args["client_id"] = arg10
+	var arg11 []string
 	if tmp, ok := rawArgs["network_recording_domains"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("network_recording_domains"))
-		arg12, err = ec.unmarshalOString2ᚕstringᚄ(ctx, tmp)
+		arg11, err = ec.unmarshalOString2ᚕstringᚄ(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["network_recording_domains"] = arg12
-	var arg13 *bool
+	args["network_recording_domains"] = arg11
+	var arg12 *bool
 	if tmp, ok := rawArgs["disable_session_recording"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("disable_session_recording"))
-		arg13, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		arg12, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
 	}
-	args["disable_session_recording"] = arg13
+	args["disable_session_recording"] = arg12
 	return args, nil
 }
 
@@ -1066,7 +1056,7 @@ func (ec *executionContext) _Mutation_initializeSession(ctx context.Context, fie
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().InitializeSession(rctx, fc.Args["session_secure_id"].(string), fc.Args["organization_verbose_id"].(string), fc.Args["enable_strict_privacy"].(bool), fc.Args["enable_recording_network_contents"].(bool), fc.Args["clientVersion"].(string), fc.Args["firstloadVersion"].(string), fc.Args["clientConfig"].(string), fc.Args["environment"].(string), fc.Args["appVersion"].(*string), fc.Args["serviceName"].(string), fc.Args["fingerprint"].(string), fc.Args["client_id"].(string), fc.Args["network_recording_domains"].([]string), fc.Args["disable_session_recording"].(*bool))
+		return ec.resolvers.Mutation().InitializeSession(rctx, fc.Args["session_secure_id"].(string), fc.Args["organization_verbose_id"].(string), fc.Args["enable_strict_privacy"].(bool), fc.Args["enable_recording_network_contents"].(bool), fc.Args["clientVersion"].(string), fc.Args["firstloadVersion"].(string), fc.Args["clientConfig"].(string), fc.Args["environment"].(string), fc.Args["appVersion"].(*string), fc.Args["fingerprint"].(string), fc.Args["client_id"].(string), fc.Args["network_recording_domains"].([]string), fc.Args["disable_session_recording"].(*bool))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1127,7 +1127,6 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 		ClientConfig:                   &input.ClientConfig,
 		Environment:                    input.Environment,
 		AppVersion:                     input.AppVersion,
-		ServiceName:                    input.ServiceName,
 		VerboseID:                      input.ProjectVerboseID,
 		Fields:                         []*model.Field{},
 		ViewedByAdmins:                 []model.Admin{},
@@ -2688,30 +2687,23 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 
 			traceString := string(traceBytes)
 
-			serviceVersion := ""
-			if sessionObj.AppVersion != nil {
-				serviceVersion = *sessionObj.AppVersion
-			}
-
 			errorToInsert := &model.ErrorObject{
-				ProjectID:      projectID,
-				SessionID:      &sessionID,
-				Environment:    sessionObj.Environment,
-				Event:          v.Event,
-				Type:           v.Type,
-				URL:            v.URL,
-				Source:         v.Source,
-				LineNumber:     v.LineNumber,
-				ColumnNumber:   v.ColumnNumber,
-				OS:             sessionObj.OSName,
-				Browser:        sessionObj.BrowserName,
-				StackTrace:     &traceString,
-				Timestamp:      v.Timestamp,
-				Payload:        v.Payload,
-				RequestID:      nil,
-				IsBeacon:       isBeacon,
-				ServiceVersion: serviceVersion,
-				ServiceName:    sessionObj.ServiceName,
+				ProjectID:    projectID,
+				SessionID:    &sessionID,
+				Environment:  sessionObj.Environment,
+				Event:        v.Event,
+				Type:         v.Type,
+				URL:          v.URL,
+				Source:       v.Source,
+				LineNumber:   v.LineNumber,
+				ColumnNumber: v.ColumnNumber,
+				OS:           sessionObj.OSName,
+				Browser:      sessionObj.BrowserName,
+				StackTrace:   &traceString,
+				Timestamp:    v.Timestamp,
+				Payload:      v.Payload,
+				RequestID:    nil,
+				IsBeacon:     isBeacon,
 			}
 
 			mappedStackTrace, structuredStackTrace, err := r.getMappedStackTraceString(ctx, v.StackTrace, projectID, errorToInsert)

--- a/backend/public-graph/graph/schema.graphqls
+++ b/backend/public-graph/graph/schema.graphqls
@@ -97,7 +97,6 @@ type Mutation {
 		clientConfig: String!
 		environment: String!
 		appVersion: String
-		serviceName: String!
 		fingerprint: String!
 		client_id: String!
 		network_recording_domains: [String!]

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -23,7 +23,7 @@ import (
 )
 
 // InitializeSession is the resolver for the initializeSession field.
-func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, serviceName string, fingerprint string, clientID string, networkRecordingDomains []string, disableSessionRecording *bool) (*customModels.InitializeSessionResponse, error) {
+func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, fingerprint string, clientID string, networkRecordingDomains []string, disableSessionRecording *bool) (*customModels.InitializeSessionResponse, error) {
 	s, _ := tracer.StartSpanFromContext(ctx, "InitializeSession", tracer.ResourceName("gql.initializeSession"))
 	s.SetTag("secure_id", sessionSecureID)
 	s.SetTag("client_version", clientVersion)
@@ -50,7 +50,6 @@ func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureI
 				ClientConfig:                   clientConfig,
 				Environment:                    environment,
 				AppVersion:                     appVersion,
-				ServiceName:                    serviceName,
 				Fingerprint:                    fingerprint,
 				UserAgent:                      userAgentString,
 				AcceptLanguage:                 acceptLanguageString,

--- a/docs-content/sdk/client.md
+++ b/docs-content/sdk/client.md
@@ -68,10 +68,6 @@ slug: client
           <p>Specifies the version of your application. See [Versioning Sessions](../getting-started/3_client-sdk/7_replay-configuration/versioning-sessions-and-errors.md) and [Versioning Errors](../getting-started/3_client-sdk/7_replay-configuration/versioning-sessions-and-errors.md) to see how setting the version can help you move faster.</p>
         </aside>
         <aside className="parameter">
-          <h5>serviceName <code>string</code> <code>optional</code></h5>
-          <p>Specifies the name of your application.</p>
-        </aside>
-        <aside className="parameter">
           <h5>enableStrictPrivacy <code>boolean</code> <code>optional</code></h5>
           <p>Specifies whether Highlight should redact all text and image data during recording. This is useful to make sure you are not recording any personally identifiable information without having to manually add annotations to elements you don't want to be recorded. See [Privacy](../general/6_product-features/1_session-replay/privacy.md) to learn more about the privacy options. The default value is false.</p>
         </aside>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -107,8 +107,7 @@ const options: HighlightOptions = {
 	inlineStylesheet: true,
 	inlineImages: true,
 	sessionShortcut: 'alt+1,command+`,alt+esc',
-	version: import.meta.env.REACT_APP_COMMIT_SHA ?? '1.0.0',
-	serviceName: 'frontend',
+	version: import.meta.env.REACT_APP_COMMIT_SHA || undefined,
 }
 const favicon = document.querySelector("link[rel~='icon']") as any
 if (dev) {

--- a/highlight.io/components/QuickstartContent/frontend/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/shared-snippets.tsx
@@ -74,7 +74,6 @@ To get started, we recommend setting \`tracingOrigins\` and \`networkRecording\`
 import { H } from 'highlight.run';
 
 H.init('<YOUR_PROJECT_ID>', {
-	serviceName: "frontend-app",
 	tracingOrigins: true,
 	networkRecording: {
 		enabled: true,

--- a/sdk/client/src/graph/generated/operations.ts
+++ b/sdk/client/src/graph/generated/operations.ts
@@ -117,7 +117,6 @@ export type MutationInitializeSessionArgs = {
 	firstloadVersion: Scalars['String']
 	network_recording_domains?: InputMaybe<Array<Scalars['String']>>
 	organization_verbose_id: Scalars['String']
-	serviceName: Scalars['String']
 	session_secure_id: Scalars['String']
 }
 
@@ -269,7 +268,6 @@ export type InitializeSessionMutationVariables = Exact<{
 	environment: Scalars['String']
 	id: Scalars['String']
 	appVersion?: InputMaybe<Scalars['String']>
-	serviceName: Scalars['String']
 	client_id: Scalars['String']
 	network_recording_domains?: InputMaybe<
 		Array<Scalars['String']> | Scalars['String']
@@ -377,7 +375,6 @@ export const InitializeSessionDocument = gql`
 		$environment: String!
 		$id: String!
 		$appVersion: String
-		$serviceName: String!
 		$client_id: String!
 		$network_recording_domains: [String!]
 		$disable_session_recording: Boolean
@@ -392,7 +389,6 @@ export const InitializeSessionDocument = gql`
 			clientConfig: $clientConfig
 			environment: $environment
 			appVersion: $appVersion
-			serviceName: $serviceName
 			fingerprint: $id
 			client_id: $client_id
 			network_recording_domains: $network_recording_domains

--- a/sdk/client/src/graph/generated/schemas.ts
+++ b/sdk/client/src/graph/generated/schemas.ts
@@ -114,7 +114,6 @@ export type MutationInitializeSessionArgs = {
 	firstloadVersion: Scalars['String']
 	network_recording_domains?: InputMaybe<Array<Scalars['String']>>
 	organization_verbose_id: Scalars['String']
-	serviceName: Scalars['String']
 	session_secure_id: Scalars['String']
 }
 

--- a/sdk/client/src/graph/operators/mutation.gql
+++ b/sdk/client/src/graph/operators/mutation.gql
@@ -77,7 +77,6 @@ mutation initializeSession(
 	$environment: String!
 	$id: String!
 	$appVersion: String
-	$serviceName: String!
 	$client_id: String!
 	$network_recording_domains: [String!]
 	$disable_session_recording: Boolean
@@ -92,7 +91,6 @@ mutation initializeSession(
 		clientConfig: $clientConfig
 		environment: $environment
 		appVersion: $appVersion
-		serviceName: $serviceName
 		fingerprint: $id
 		client_id: $client_id
 		network_recording_domains: $network_recording_domains

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -110,7 +110,6 @@ export type HighlightClassOptions = {
 	firstloadVersion?: string
 	environment?: 'development' | 'production' | 'staging' | string
 	appVersion?: string
-	serviceName?: string
 	sessionShortcut?: SessionShortcutOptions
 	sessionSecureID: string // Introduced in firstLoad 3.0.1
 	storageMode?: 'sessionStorage' | 'localStorage'
@@ -188,7 +187,6 @@ export class Highlight {
 	sessionShortcut!: SessionShortcutOptions
 	/** The end-user's app version. This isn't Highlight's version. */
 	appVersion!: string | undefined
-	serviceName!: string
 	_worker!: HighlightClientRequestWorker
 	_optionsInternal!: HighlightClassOptionsInternal
 	_backendUrl!: string
@@ -380,7 +378,6 @@ export class Highlight {
 		)
 		this.environment = options.environment ?? 'production'
 		this.appVersion = options.appVersion
-		this.serviceName = options.serviceName ?? ''
 
 		if (typeof options.organizationID === 'string') {
 			this.organizationID = options.organizationID
@@ -592,7 +589,6 @@ export class Highlight {
 					environment: this.environment,
 					id: clientID,
 					appVersion: this.appVersion,
-					serviceName: this.serviceName,
 					session_secure_id: this.sessionData.sessionSecureID,
 					client_id: clientID,
 					network_recording_domains: destinationDomains,

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -141,10 +141,6 @@ export declare type HighlightOptions = {
 	 */
 	version?: string
 	/**
-	 * Specifies the name of your app.
-	 */
-	serviceName?: string
-	/**
 	 * Specifies whether Highlight should redact data during recording.
 	 * Enabling this will disable recording of text data on the page. This is useful if you do not want to record personally identifiable information and don't want to manually annotate your code with the class name "highlight-block".
 	 * @example

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -372,9 +372,3 @@ Reserved for the Boeing 737
 ### Patch Changes
 
 - Ensure stacktraces from Promises are parsed correctly.
-
-## 7.5.0
-
-### Minor Changes
-
-- Added support to specify `serviceName`.

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -372,3 +372,15 @@ Reserved for the Boeing 737
 ### Patch Changes
 
 - Ensure stacktraces from Promises are parsed correctly.
+
+## 7.5.0
+
+### Minor Changes
+
+- Added support to specify `serviceName`.
+
+## 7.5.1
+
+### Patch Changes
+
+- Rollback support to specify `serviceName`.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.4.4",
+	"version": "7.5.1",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.5.0",
+	"version": "7.4.4",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.4.4"
+export default "7.5.1"

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.5.0"
+export default "7.4.4"

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -133,7 +133,6 @@ const H: HighlightPublicInterface = {
 				firstloadVersion,
 				environment: options?.environment || 'production',
 				appVersion: options?.version,
-				serviceName: options?.serviceName,
 				sessionShortcut: options?.sessionShortcut,
 				sessionSecureID: sessionSecureID,
 				storageMode: options?.storageMode,


### PR DESCRIPTION
Reverts highlight/highlight#6453

Seeing a lot of errors related to missing serviceName, and believe it is related to this PR requiring the name when it should be optional

Error logs: https://app.highlight.io/1/logs/MjAyMy0wOC0zMFQxODozNzowNVosOTg1MTgwYmEtZmE2MC00ZTRkLTlhOTUtZWEzZDlmMDU1NTQy

![Screenshot 2023-08-30 at 2 37 43 PM](https://github.com/highlight/highlight/assets/17744174/87d978ab-6a4c-4797-b627-984f06802ed3)
