### PR TITLE
enable analytics page for a certain workspace

### DIFF
--- a/frontend/src/components/TimeRangePicker/TimeRangePicker.tsx
+++ b/frontend/src/components/TimeRangePicker/TimeRangePicker.tsx
@@ -43,7 +43,7 @@ const minDate = moment(defaultDataTimeRange.end_date)
 
 const TimeRangePicker: React.FC<React.PropsWithChildren<unknown>> = () => {
 	const [customDateRange, setCustomDateRange] = useState<Date[]>([
-		presets[4].startDate,
+		presets[5].startDate,
 		moment().toDate(),
 	])
 	const { setTimeRange } = useDataTimeRange()

--- a/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
+++ b/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
@@ -47,6 +47,8 @@ export const FeatureConfig: { [key: number]: Config } = {
 		workspaceOverride: new Set<string>([
 			// Numero
 			'701',
+			// MediaJel
+			'9634',
 		]),
 	},
 } as const


### PR DESCRIPTION
## Summary

Per a thread with a customer, this changes enables the analytics page.
This also changes the analytics date picker to use a 7 day range by default,
which makes more sense given the data shown.

## How did you test this change?

[Preview](https://frontend-pr-6474.onrender.com/9637/analytics)
<img width="1648" alt="Screenshot 2023-08-30 at 2 17 52 PM" src="https://github.com/highlight/highlight/assets/1351531/59d15bdb-00b5-4d52-8ed7-a0755ece746b">


## Are there any deployment considerations?

No
