### PR TITLE
handle service updates during otel ingestion

### DIFF
--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -532,3 +532,7 @@ func (r *Client) FlushDB(ctx context.Context) error {
 	}
 	return nil
 }
+
+func (r *Client) Del(ctx context.Context, key string) (int64, error) {
+	return r.redisClient.Del(ctx, key).Result()
+}

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -533,6 +533,9 @@ func (r *Client) FlushDB(ctx context.Context) error {
 	return nil
 }
 
-func (r *Client) Del(ctx context.Context, key string) (int64, error) {
-	return r.redisClient.Del(ctx, key).Result()
+func (r *Client) Del(ctx context.Context, key string) error {
+	if util.IsDevOrTestEnv() {
+		return r.redisClient.Del(ctx, key).Err()
+	}
+	return nil
 }

--- a/backend/store/services.go
+++ b/backend/store/services.go
@@ -13,31 +13,33 @@ import (
 	"github.com/highlight-run/highlight/backend/redis"
 	"github.com/samber/lo"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"gorm.io/gorm/clause"
 )
 
-func (store *Store) FindOrCreateService(ctx context.Context, project model.Project, name string, attributes map[string]string) (*model.Service, error) {
-	return redis.CachedEval(ctx, store.redis, CacheServiceKey(name, project.ID), 150*time.Millisecond, time.Minute, func() (*model.Service, error) {
-		var service model.Service
+func (store *Store) UpsertService(ctx context.Context, project model.Project, name string, attributes map[string]string) (*model.Service, error) {
+	service := model.Service{
+		Name:      name,
+		ProjectID: project.ID,
+	}
 
-		if val, ok := attributes[string(semconv.ProcessRuntimeNameKey)]; ok {
-			service.ProcessName = &val
-		}
+	if val, ok := attributes[string(semconv.ProcessRuntimeNameKey)]; ok {
+		service.ProcessName = &val
+	}
 
-		if val, ok := attributes[string(semconv.ProcessRuntimeVersionKey)]; ok {
-			service.ProcessVersion = &val
-		}
+	if val, ok := attributes[string(semconv.ProcessRuntimeVersionKey)]; ok {
+		service.ProcessVersion = &val
+	}
 
-		if val, ok := attributes[string(semconv.ProcessRuntimeDescriptionKey)]; ok {
-			service.ProcessDescription = &val
-		}
+	if val, ok := attributes[string(semconv.ProcessRuntimeDescriptionKey)]; ok {
+		service.ProcessDescription = &val
+	}
 
-		err := store.db.Where(&model.Service{
-			ProjectID: project.ID,
-			Name:      name,
-		}).FirstOrCreate(&service).Error
+	err := store.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "name"}, {Name: "project_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"process_name", "process_version", "process_description"}),
+	}).Create(&service).Error
 
-		return &service, err
-	})
+	return &service, err
 }
 
 func (store *Store) FindService(ctx context.Context, projectID int, name string) (*model.Service, error) {

--- a/backend/store/services_test.go
+++ b/backend/store/services_test.go
@@ -38,7 +38,7 @@ func TestUpsertServiceWithAttributes(t *testing.T) {
 		store.db.Create(&project)
 
 		cacheKey := fmt.Sprintf("service-public-graph-%d", project.ID)
-		_, err := store.redis.Del(context.TODO(), cacheKey)
+		err := store.redis.Del(context.TODO(), cacheKey)
 		assert.NoError(t, err)
 
 		service, err := store.UpsertService(ctx, project, "public-graph", map[string]string{
@@ -52,7 +52,7 @@ func TestUpsertServiceWithAttributes(t *testing.T) {
 		assert.Equal(t, ptr.String("go1.20.5"), service.ProcessVersion)
 		assert.Equal(t, ptr.String("go version go1.20.5 darwin/arm64"), service.ProcessDescription)
 
-		_, err = store.redis.Del(context.TODO(), cacheKey)
+		err = store.redis.Del(context.TODO(), cacheKey)
 		assert.NoError(t, err)
 
 		service, err = store.UpsertService(ctx, project, "public-graph", map[string]string{

--- a/backend/store/services_test.go
+++ b/backend/store/services_test.go
@@ -14,30 +14,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFindOrCreateService(t *testing.T) {
+func TestUpsertService(t *testing.T) {
 	defer teardown(t)
 	ctx := context.Background()
 	project := model.Project{}
 	store.db.Create(&project)
 
-	service, err := store.FindOrCreateService(ctx, project, "public-graph", map[string]string{})
+	service, err := store.UpsertService(ctx, project, "public-graph", map[string]string{})
 	assert.NoError(t, err)
 
 	assert.NotNil(t, service.ID)
 
-	foundService, err := store.FindOrCreateService(ctx, project, "public-graph", map[string]string{})
+	foundService, err := store.UpsertService(ctx, project, "public-graph", map[string]string{})
 	assert.NoError(t, err)
 	assert.Equal(t, service.ID, foundService.ID)
 }
 
-func TestFindOrCreateServiceWithAttributes(t *testing.T) {
+func TestUpsertServiceWithAttributes(t *testing.T) {
 	ctx := context.Background()
 
 	util.RunTestWithDBWipe(t, store.db, func(t *testing.T) {
 		project := model.Project{}
 		store.db.Create(&project)
 
-		service, err := store.FindOrCreateService(ctx, project, "public-graph", map[string]string{
+		service, err := store.UpsertService(ctx, project, "public-graph", map[string]string{
 			"process.runtime.name":        "go",
 			"process.runtime.version":     "go1.20.5",
 			"process.runtime.description": "go version go1.20.5 darwin/arm64",
@@ -47,6 +47,18 @@ func TestFindOrCreateServiceWithAttributes(t *testing.T) {
 		assert.Equal(t, ptr.String("go"), service.ProcessName)
 		assert.Equal(t, ptr.String("go1.20.5"), service.ProcessVersion)
 		assert.Equal(t, ptr.String("go version go1.20.5 darwin/arm64"), service.ProcessDescription)
+
+		service, err = store.UpsertService(ctx, project, "public-graph", map[string]string{
+			"process.runtime.name":        "ruby",
+			"process.runtime.version":     "2.6.10",
+			"process.runtime.description": "ruby 2.6.10p210 (2022-04-12 revision 67958) [x86_64-linux]",
+		})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, service.ID)
+		assert.Equal(t, ptr.String("ruby"), service.ProcessName)
+		assert.Equal(t, ptr.String("2.6.10"), service.ProcessVersion)
+		assert.Equal(t, ptr.String("ruby 2.6.10p210 (2022-04-12 revision 67958) [x86_64-linux]"), service.ProcessDescription)
 	})
 }
 

--- a/backend/store/services_test.go
+++ b/backend/store/services_test.go
@@ -37,6 +37,10 @@ func TestUpsertServiceWithAttributes(t *testing.T) {
 		project := model.Project{}
 		store.db.Create(&project)
 
+		cacheKey := fmt.Sprintf("service-public-graph-%d", project.ID)
+		_, err := store.redis.Del(context.TODO(), cacheKey)
+		assert.NoError(t, err)
+
 		service, err := store.UpsertService(ctx, project, "public-graph", map[string]string{
 			"process.runtime.name":        "go",
 			"process.runtime.version":     "go1.20.5",
@@ -47,6 +51,9 @@ func TestUpsertServiceWithAttributes(t *testing.T) {
 		assert.Equal(t, ptr.String("go"), service.ProcessName)
 		assert.Equal(t, ptr.String("go1.20.5"), service.ProcessVersion)
 		assert.Equal(t, ptr.String("go version go1.20.5 darwin/arm64"), service.ProcessDescription)
+
+		_, err = store.redis.Del(context.TODO(), cacheKey)
+		assert.NoError(t, err)
 
 		service, err = store.UpsertService(ctx, project, "public-graph", map[string]string{
 			"process.runtime.name":        "ruby",

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -255,11 +255,11 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 	for _, logRow := range logRows {
 		// create service record for any services found in ingested logs
 		if logRow.ServiceName != "" {
-			spanX, ctxX := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.findOrCreateService", k.Name)))
+			spanX, ctxX := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.UpsertService", k.Name)))
 
 			project, err := k.Worker.Resolver.Store.GetProject(ctx, int(logRow.ProjectId))
 			if err == nil && project != nil {
-				_, err := k.Worker.Resolver.Store.FindOrCreateService(ctx, *project, logRow.ServiceName, logRow.LogAttributes)
+				_, err := k.Worker.Resolver.Store.UpsertService(ctx, *project, logRow.ServiceName, logRow.LogAttributes)
 
 				if err != nil {
 					log.WithContext(ctxX).Error(e.Wrap(err, "failed to create service"))


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

When we create a new service during ingestion (#6328), we aren't handling updates to `process.*` information. This is important because a lot of SDKs aren't currently including that information (#6465) and when they do start including it, we should update the existing service records.

This PR changes the logic to upsert that data.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Tests added

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
