### PR TITLE
add service name to nextjs and remix

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     yarn-monorepo:
         name: Build Yarn Turborepo
-        timeout-minutes: 30
+        timeout-minutes: 45
         runs-on: ubuntu-latest
         # configures turborepo Remote Caching
         env:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     yarn-monorepo:
         name: Build Yarn Turborepo
-        timeout-minutes: 45
+        timeout-minutes: 30
         runs-on: ubuntu-latest
         # configures turborepo Remote Caching
         env:
@@ -18,6 +18,12 @@ jobs:
             TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
         steps:
+            # See https://github.com/actions/runner/issues/2468#issuecomment-1651313943
+            - name: Set Swap Space
+              uses: pierotofy/set-swap-space@master
+              with:
+                  swap-size-gb: 10
+
             - name: Checkout
               uses: actions/checkout@v3
               with:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -11,19 +11,13 @@ jobs:
     yarn-monorepo:
         name: Build Yarn Turborepo
         timeout-minutes: 30
-        runs-on: ubuntu-latest
+        runs-on: buildjet-4vcpu-ubuntu-2204
         # configures turborepo Remote Caching
         env:
             TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
             TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
         steps:
-            # See https://github.com/actions/runner/issues/2468#issuecomment-1651313943
-            - name: Set Swap Space
-              uses: pierotofy/set-swap-space@master
-              with:
-                  swap-size-gb: 10
-
             - name: Checkout
               uses: actions/checkout@v3
               with:

--- a/docs-content/getting-started/fullstack-frameworks/next-js.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js.md
@@ -88,7 +88,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 			<HighlightInit
 				excludedHostnames={['localhost']}
 				projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
-				serviceName="my-nextjs-app"
+				serviceName="my-nextjs-frontend"
 				tracingOrigins
 				networkRecording={{
 					enabled: true,
@@ -117,7 +117,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 			<HighlightInit
 				excludedHostnames={['localhost']}
 				projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
-				serviceName="my-nextjs-app"
+				serviceName="my-nextjs-frontend"
 				tracingOrigins
 				networkRecording={{
 					enabled: true,
@@ -168,7 +168,7 @@ Alternatively, you could manually call `H.start()` and `H.stop()` to manage invo
 <HighlightInit
 	manualStart
 	projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
-	serviceName="my-nextjs-app"
+	serviceName="my-nextjs-frontend"
 />
 <CustomHighlightStart />
 

--- a/docs-content/getting-started/fullstack-frameworks/next-js.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js.md
@@ -88,6 +88,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 			<HighlightInit
 				excludedHostnames={['localhost']}
 				projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
+				serviceName="my-nextjs-app"
 				tracingOrigins
 				networkRecording={{
 					enabled: true,
@@ -116,6 +117,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 			<HighlightInit
 				excludedHostnames={['localhost']}
 				projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
+				serviceName="my-nextjs-app"
 				tracingOrigins
 				networkRecording={{
 					enabled: true,
@@ -166,6 +168,7 @@ Alternatively, you could manually call `H.start()` and `H.stop()` to manage invo
 <HighlightInit
 	manualStart
 	projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
+	serviceName="my-nextjs-app"
 />
 <CustomHighlightStart />
 

--- a/docs-content/getting-started/fullstack-frameworks/remix.md
+++ b/docs-content/getting-started/fullstack-frameworks/remix.md
@@ -53,6 +53,7 @@ export default function App() {
 			<HighlightInit
 				excludedHostnames={['localhost']}
 				projectId={ENV.HIGHLIGHT_PROJECT_ID}
+				serviceName="my-remix-frontend"
 				tracingOrigins
 				networkRecording={{ enabled: true, recordHeadersAndBody: true }}
 			/>

--- a/docs-content/sdk/nextjs.md
+++ b/docs-content/sdk/nextjs.md
@@ -82,6 +82,10 @@ quickstart: true
       <p>App version used when uploading source maps.</p>
     </aside>
     <aside className="parameter">
+      <h5>serviceName <code>string</code> <code>optional</code></h5>
+      <p>Name of your app.</p>
+    </aside>
+    <aside className="parameter">
       <h5>sourceMapsPath <code>string</code> <code>optional</code></h5>
       <p>The file system root directory containing all your source map files.</p>
     </aside>

--- a/e2e/nextjs/README.md
+++ b/e2e/nextjs/README.md
@@ -158,7 +158,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 		<>
 			<HighlightInit
 				projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
-				serviceName="my-nextjs-app"
+				serviceName="my-nextjs-frontend"
 				tracingOrigins
 				networkRecording={{
 					enabled: true,
@@ -192,7 +192,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 		<>
 			<HighlightInit
 				projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
-				serviceName="my-nextjs-app"
+				serviceName="my-nextjs-frontend"
 				tracingOrigins
 				networkRecording={{
 					enabled: true,

--- a/e2e/nextjs/README.md
+++ b/e2e/nextjs/README.md
@@ -158,6 +158,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 		<>
 			<HighlightInit
 				projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
+				serviceName="my-nextjs-app"
 				tracingOrigins
 				networkRecording={{
 					enabled: true,
@@ -191,6 +192,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 		<>
 			<HighlightInit
 				projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
+				serviceName="my-nextjs-app"
 				tracingOrigins
 				networkRecording={{
 					enabled: true,

--- a/e2e/nextjs/highlight.config.ts
+++ b/e2e/nextjs/highlight.config.ts
@@ -8,6 +8,7 @@ export const withHighlight = Highlight({
 	debug: true,
 	backendUrl: 'https://localhost:8082/public',
 	otlpEndpoint: 'http://localhost:4318',
+	serviceName: 'my-nextjs-backend',
 })
 
 const highlightTransport = new winston.transports.Http({

--- a/e2e/nextjs/instrumentation.ts
+++ b/e2e/nextjs/instrumentation.ts
@@ -14,6 +14,7 @@ export async function register() {
 		registerHighlight({
 			projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
 			otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
+			serviceName: 'my-nextjs-backend',
 		})
 	}
 }

--- a/e2e/nextjs/src/app/layout.tsx
+++ b/e2e/nextjs/src/app/layout.tsx
@@ -19,6 +19,7 @@ export default function RootLayout({
 			<HighlightInit
 				debug={{ clientInteractions: true, domRecording: true }}
 				projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
+				serviceName="my-nextjs-app"
 				tracingOrigins
 				networkRecording={{
 					enabled: true,

--- a/e2e/nextjs/src/app/layout.tsx
+++ b/e2e/nextjs/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
 			<HighlightInit
 				debug={{ clientInteractions: true, domRecording: true }}
 				projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
-				serviceName="my-nextjs-app"
+				serviceName="my-nextjs-frontend"
 				tracingOrigins
 				networkRecording={{
 					enabled: true,

--- a/e2e/nextjs/src/app/utils/highlight.config.ts
+++ b/e2e/nextjs/src/app/utils/highlight.config.ts
@@ -11,4 +11,5 @@ export const withHighlight = Highlight({
 	projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
 	otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
 	backendUrl: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_BACKEND_URL,
+	serviceName: 'my-nextjs-backend',
 })

--- a/e2e/remix/README.md
+++ b/e2e/remix/README.md
@@ -10,7 +10,7 @@ From your terminal:
 npm run dev
 ```
 
-This starts your app in development mode, rebuilding assets on file changes.
+This starts your app in development mode running at http://localhost:4352, rebuilding assets on file changes.
 
 ## Deployment
 

--- a/e2e/remix/app/entry.server.tsx
+++ b/e2e/remix/app/entry.server.tsx
@@ -17,8 +17,14 @@ import { RemixServer } from '@remix-run/react'
 import { Response } from '@remix-run/node'
 import isbot from 'isbot'
 import { renderToPipeableStream } from 'react-dom/server'
+import type { NodeOptions } from '@highlight-run/node'
 
-const nodeOptions = { projectID: CONSTANTS.HIGHLIGHT_PROJECT_ID }
+const nodeOptions: NodeOptions = {
+	projectID: CONSTANTS.HIGHLIGHT_PROJECT_ID,
+	otlpEndpoint: 'http://localhost:4318',
+	serviceName: 'my-remix-backend',
+	serviceVersion: '1.0.0',
+}
 
 export function handleError(
 	error: unknown,

--- a/e2e/remix/app/root.tsx
+++ b/e2e/remix/app/root.tsx
@@ -34,8 +34,8 @@ export default function App() {
 	return (
 		<html lang="en">
 			<HighlightInit
-				excludedHostnames={['localhost']}
 				projectId={ENV.HIGHLIGHT_PROJECT_ID}
+				backendUrl="https://localhost:8082/public"
 				serviceName="my-remix-frontend"
 				tracingOrigins
 				networkRecording={{ enabled: true, recordHeadersAndBody: true }}

--- a/e2e/remix/app/root.tsx
+++ b/e2e/remix/app/root.tsx
@@ -36,6 +36,7 @@ export default function App() {
 			<HighlightInit
 				excludedHostnames={['localhost']}
 				projectId={ENV.HIGHLIGHT_PROJECT_ID}
+				serviceName="my-remix-app"
 				tracingOrigins
 				networkRecording={{ enabled: true, recordHeadersAndBody: true }}
 				// scriptUrl="http://localhost:8080/dist/index.js"

--- a/e2e/remix/app/root.tsx
+++ b/e2e/remix/app/root.tsx
@@ -36,7 +36,7 @@ export default function App() {
 			<HighlightInit
 				excludedHostnames={['localhost']}
 				projectId={ENV.HIGHLIGHT_PROJECT_ID}
-				serviceName="my-remix-app"
+				serviceName="my-remix-frontend"
 				tracingOrigins
 				networkRecording={{ enabled: true, recordHeadersAndBody: true }}
 				// scriptUrl="http://localhost:8080/dist/index.js"

--- a/e2e/remix/package.json
+++ b/e2e/remix/package.json
@@ -4,7 +4,7 @@
 	"sideEffects": false,
 	"scripts": {
 		"build": "remix build",
-		"dev": "remix dev",
+		"dev": "PORT=4352 remix dev",
 		"start": "remix-serve build",
 		"typecheck": "tsc"
 	},

--- a/highlight.io/components/QuickstartContent/frontend/next.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/next.tsx
@@ -63,7 +63,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 		<>
 			<HighlightInit
 				projectId={'<YOUR_PROJECT_ID>'}
-				serviceName="my-nextjs-app"
+				serviceName="my-nextjs-frontend"
 				tracingOrigins
 				networkRecording={{
 					enabled: true,

--- a/highlight.io/components/QuickstartContent/frontend/next.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/next.tsx
@@ -63,6 +63,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 		<>
 			<HighlightInit
 				projectId={'<YOUR_PROJECT_ID>'}
+				serviceName="my-nextjs-app"
 				tracingOrigins
 				networkRecording={{
 					enabled: true,

--- a/highlight.io/components/QuickstartContent/frontend/remix.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/remix.tsx
@@ -74,7 +74,7 @@ export default function App() {
 		<html lang="en">
 			<HighlightInit
 				projectId={ENV.HIGHLIGHT_PROJECT_ID}
-				erviceName="my-remix-app"
+				serviceName="my-remix-frontend"
 				tracingOrigins
 				networkRecording={{ enabled: true, recordHeadersAndBody: true }}
 			/>

--- a/highlight.io/components/QuickstartContent/frontend/remix.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/remix.tsx
@@ -74,6 +74,7 @@ export default function App() {
 		<html lang="en">
 			<HighlightInit
 				projectId={ENV.HIGHLIGHT_PROJECT_ID}
+				erviceName="my-remix-app"
 				tracingOrigins
 				networkRecording={{ enabled: true, recordHeadersAndBody: true }}
 			/>

--- a/highlight.io/highlight.config.ts
+++ b/highlight.io/highlight.config.ts
@@ -3,4 +3,5 @@ import { Highlight } from '@highlight-run/next/server'
 export const withHighlight = Highlight({
 	projectID: '4d7k1xeo',
 	debug: false,
+	serviceName: 'highlight.io',
 })

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -50,3 +50,14 @@
 
 - Removing exports for `@highlight-run/next` and `@highlight-run/next/highlight-init`. Import from `@highlight-run/next/server` and `@highlight-run/next/client` instead.
 - Adding `excludedHostnames?: string[]` to `HighlightInit` props. Pass in a list of full or partial hostnames to prevent tracking: `excludedHostnames={['localhost', 'staging']}`.
+
+### 4.1.0
+
+### Minor changes
+
+- Added support for setting metadata on `consumeError`
+### 4.2.0
+
+### Minor changes
+
+- Added support for setting `serviceName`

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -56,6 +56,7 @@
 ### Minor changes
 
 - Added support for setting metadata on `consumeError`
+
 ### 4.2.0
 
 ### Minor changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "4.1.0",
+	"version": "4.2.0",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-next/src/util/withHighlightConfig.ts
+++ b/sdk/highlight-next/src/util/withHighlightConfig.ts
@@ -8,6 +8,7 @@ interface HighlightConfigOptionsDefault {
 	configureHighlightProxy: boolean
 	apiKey: string
 	appVersion: string
+	serviceName: string
 	sourceMapsPath: string
 	sourceMapsBasePath: string
 }
@@ -35,6 +36,10 @@ export interface HighlightConfigOptions {
 	 * App version used when uploading source maps.
 	 */
 	appVersion?: string
+	/**
+	 * Name of your app.
+	 */
+	serviceName?: string
 	/**
 	 * File system root directory containing all your source map files.
 	 * @default '.next/'
@@ -73,6 +78,7 @@ const getDefaultOpts = async (
 		configureHighlightProxy: highlightOpts?.configureHighlightProxy ?? true,
 		apiKey: highlightOpts?.apiKey ?? '',
 		appVersion: highlightOpts?.appVersion ?? version ?? '',
+		serviceName: highlightOpts?.serviceName ?? '',
 		sourceMapsPath: highlightOpts?.sourceMapsPath ?? '.next/',
 		sourceMapsBasePath: highlightOpts?.sourceMapsBasePath ?? '_next/',
 	}

--- a/sdk/highlight-node/src/client.test.ts
+++ b/sdk/highlight-node/src/client.test.ts
@@ -1,0 +1,17 @@
+import { Highlight } from './client.js'
+
+describe('client', () => {
+	it('returns session id and request id from the headers', () => {
+		const client = new Highlight({
+			projectID: 'abc123',
+		})
+
+		const sdk = client.otel
+		const resource = sdk['_resource']
+
+		expect(resource.attributes['process.runtime.name']).toEqual('nodejs')
+		expect(resource.attributes['process.runtime.description']).toEqual(
+			'Node.js',
+		)
+	})
+})

--- a/sdk/highlight-node/src/client.test.ts
+++ b/sdk/highlight-node/src/client.test.ts
@@ -2,7 +2,7 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 import { Highlight } from './client.js'
 
 describe('client', () => {
-	it('returns session id and request id from the headers', () => {
+	it('includes process information in the resource', () => {
 		const client = new Highlight({
 			projectID: 'abc123',
 		})
@@ -25,5 +25,23 @@ describe('client', () => {
 				SemanticResourceAttributes.PROCESS_RUNTIME_VERSION
 			],
 		).toBeDefined()
+	})
+
+	it('includes service config if provided', () => {
+		const client = new Highlight({
+			projectID: 'abc123',
+			serviceName: 'my-service',
+			serviceVersion: 'abc123',
+		})
+
+		const sdk = client.otel
+		const resource = sdk['_resource']
+
+		expect(
+			resource.attributes[SemanticResourceAttributes.SERVICE_NAME],
+		).toEqual('my-service')
+		expect(
+			resource.attributes[SemanticResourceAttributes.SERVICE_VERSION],
+		).toEqual('abc123')
 	})
 })

--- a/sdk/highlight-node/src/client.test.ts
+++ b/sdk/highlight-node/src/client.test.ts
@@ -1,3 +1,4 @@
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 import { Highlight } from './client.js'
 
 describe('client', () => {
@@ -9,9 +10,20 @@ describe('client', () => {
 		const sdk = client.otel
 		const resource = sdk['_resource']
 
-		expect(resource.attributes['process.runtime.name']).toEqual('nodejs')
-		expect(resource.attributes['process.runtime.description']).toEqual(
-			'Node.js',
-		)
+		expect(
+			resource.attributes[
+				SemanticResourceAttributes.PROCESS_RUNTIME_NAME
+			],
+		).toEqual('nodejs')
+		expect(
+			resource.attributes[
+				SemanticResourceAttributes.PROCESS_RUNTIME_DESCRIPTION
+			],
+		).toEqual('Node.js')
+		expect(
+			resource.attributes[
+				SemanticResourceAttributes.PROCESS_RUNTIME_VERSION
+			],
+		).toBeDefined()
 	})
 })

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -13,13 +13,7 @@ import { hookConsole } from './hooks'
 import log from './log'
 import { clearInterval } from 'timers'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
-import {
-	Resource,
-	envDetector,
-	envDetectorSync,
-	processDetector,
-	processDetectorSync,
-} from '@opentelemetry/resources'
+import { Resource, processDetectorSync } from '@opentelemetry/resources'
 
 const OTLP_HTTP = 'https://otel.highlight.io:4318'
 

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -13,7 +13,13 @@ import { hookConsole } from './hooks'
 import log from './log'
 import { clearInterval } from 'timers'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
-import { Resource } from '@opentelemetry/resources'
+import {
+	Resource,
+	envDetector,
+	envDetectorSync,
+	processDetector,
+	processDetectorSync,
+} from '@opentelemetry/resources'
 
 const OTLP_HTTP = 'https://otel.highlight.io:4318'
 
@@ -23,7 +29,7 @@ export class Highlight {
 	_projectID: string
 	_options: NodeOptions
 	_debug: boolean
-	private otel: NodeSDK
+	otel: NodeSDK
 	private tracer: Tracer
 	private processor: SpanProcessor
 
@@ -60,6 +66,7 @@ export class Highlight {
 
 		this.otel = new NodeSDK({
 			autoDetectResources: true,
+			resourceDetectors: [envDetectorSync, processDetectorSync],
 			resource: {
 				attributes,
 				merge: (resource) =>

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -60,7 +60,7 @@ export class Highlight {
 
 		this.otel = new NodeSDK({
 			autoDetectResources: true,
-			resourceDetectors: [envDetectorSync, processDetectorSync],
+			resourceDetectors: [processDetectorSync],
 			resource: {
 				attributes,
 				merge: (resource) =>

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -186,26 +186,11 @@ export class Highlight {
 		if (metadata != undefined) {
 			span.setAttributes(metadata)
 		}
-		span.setAttributes({ ['highlight.project_id']: this._projectID })
 		if (secureSessionId) {
 			span.setAttributes({ ['highlight.session_id']: secureSessionId })
 		}
 		if (requestId) {
 			span.setAttributes({ ['highlight.trace_id']: requestId })
-		}
-
-		if (this._options.serviceName) {
-			span.setAttributes({
-				[SemanticResourceAttributes.SERVICE_NAME]:
-					this._options.serviceName,
-			})
-		}
-
-		if (this._options.serviceVersion) {
-			span.setAttributes({
-				[SemanticResourceAttributes.SERVICE_VERSION]:
-					this._options.serviceVersion,
-			})
 		}
 
 		this._log('created error span', span)

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -21,7 +21,6 @@ export class Highlight {
 	readonly FLUSH_TIMEOUT = 10
 	_intervalFunction: ReturnType<typeof setInterval>
 	_projectID: string
-	_options: NodeOptions
 	_debug: boolean
 	otel: NodeSDK
 	private tracer: Tracer
@@ -30,7 +29,6 @@ export class Highlight {
 	constructor(options: NodeOptions) {
 		this._debug = !!options.debug
 		this._projectID = options.projectID
-		this._options = options
 		if (!options.disableConsoleRecording) {
 			hookConsole(options.consoleMethodsToRecord, (c) => {
 				this.log(c.date, c.message, c.level, c.stack)
@@ -193,7 +191,6 @@ export class Highlight {
 		if (requestId) {
 			span.setAttributes({ ['highlight.trace_id']: requestId })
 		}
-
 		this._log('created error span', span)
 		span.end()
 	}

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -21,6 +21,7 @@ export class Highlight {
 	readonly FLUSH_TIMEOUT = 10
 	_intervalFunction: ReturnType<typeof setInterval>
 	_projectID: string
+	_options: NodeOptions
 	_debug: boolean
 	private otel: NodeSDK
 	private tracer: Tracer
@@ -29,6 +30,7 @@ export class Highlight {
 	constructor(options: NodeOptions) {
 		this._debug = !!options.debug
 		this._projectID = options.projectID
+		this._options = options
 		if (!options.disableConsoleRecording) {
 			hookConsole(options.consoleMethodsToRecord, (c) => {
 				this.log(c.date, c.message, c.level, c.stack)
@@ -191,6 +193,21 @@ export class Highlight {
 		if (requestId) {
 			span.setAttributes({ ['highlight.trace_id']: requestId })
 		}
+
+		if (this._options.serviceName) {
+			span.setAttributes({
+				[SemanticResourceAttributes.SERVICE_NAME]:
+					this._options.serviceName,
+			})
+		}
+
+		if (this._options.serviceVersion) {
+			span.setAttributes({
+				[SemanticResourceAttributes.SERVICE_VERSION]:
+					this._options.serviceVersion,
+			})
+		}
+
 		this._log('created error span', span)
 		span.end()
 	}

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Minor changes
 
 - Added support for setting metadata on `consumeError`
+
 ### 0.3.0
 
 ### Minor changes

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -11,3 +11,14 @@
 ### Patch Changes
 
 -   Added `excludedHostnames` prop to `<HighlightInit />`
+
+### 0.2.0
+
+### Minor changes
+
+- Added support for setting metadata on `consumeError`
+### 0.3.0
+
+### Minor changes
+
+- Added support for setting `serviceName`

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@3.5.0",
 	"author": "",


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Allows service name to be set for nextjs and remix backends. Note: the frontend could already set this since `<HighlightInit />` uses `H.init` under the hood.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Using the nextjs e2e app (`yarn run e2e:nextjs`), confirmed NextJS errors have a service name attached:

<img width="989" alt="Screenshot 2023-08-31 at 2 33 34 PM" src="https://github.com/highlight/highlight/assets/58678/f680daf3-a66e-4c11-aebd-3bc554eae246">
<img width="1021" alt="Screenshot 2023-08-31 at 2 34 17 PM" src="https://github.com/highlight/highlight/assets/58678/ab93ba57-fd40-4743-a218-b0ab434b7f27">
<img width="1015" alt="Screenshot 2023-08-31 at 2 34 20 PM" src="https://github.com/highlight/highlight/assets/58678/7d2bde48-f48a-4218-8ab1-0c27c1241e43">

Using the remix e2e app (`yarn run e2e:remix`), confirmed Remix errors have a service name attached:
<img width="1027" alt="Screenshot 2023-08-31 at 2 35 30 PM" src="https://github.com/highlight/highlight/assets/58678/168ba131-79d0-46c1-8b39-ffbe3a33a0d9">
<img width="1055" alt="Screenshot 2023-08-31 at 2 38 27 PM" src="https://github.com/highlight/highlight/assets/58678/7f31ba10-5a1f-449f-9db5-3e5e3e409a1a">


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

Bumped versions for the remix and nextjs sdks