### PR TITLE
Fix stacktraces interation

### DIFF
--- a/backend/store/stacktraces.go
+++ b/backend/store/stacktraces.go
@@ -210,11 +210,16 @@ func (store *Store) GitHubEnhancedStakeTrace(ctx context.Context, stackTrace []*
 		}
 
 		fileName := store.GitHubFilePath(ctx, *trace.FileName, service.BuildPrefix, service.GithubPrefix)
+		shouldIgnoreFile := false
 		for _, fileExpr := range cfg.IgnoredFiles {
 			if regexp.MustCompile(fileExpr).MatchString(fileName) {
-				newMappedStackTrace = append(newMappedStackTrace, trace)
-				continue
+				shouldIgnoreFile = true
+				break
 			}
+		}
+		if shouldIgnoreFile {
+			newMappedStackTrace = append(newMappedStackTrace, trace)
+			continue
 		}
 
 		enhancedTrace, err := store.EnhanceTraceWithGitHub(ctx, trace, service, *validServiceVersion, fileName, client)


### PR DESCRIPTION
## Summary
When we updated the StackTraces to iterate through more than the first 5 files, our `continue` condition only exited the inner loop, but really needed to continue though the outer loop

## How did you test this change?
1. Set a break point in the GitHub fetch method, and ensure this is not fired when the file is a Golang package

## Are there any deployment considerations?
Reset the Highlight services to start enhancing from GitHub again
