### PR TITLE
instrument highlight.io nextjs backend

### DIFF
--- a/highlight.io/pages/api/docs/search/[searchValue].ts
+++ b/highlight.io/pages/api/docs/search/[searchValue].ts
@@ -1,9 +1,9 @@
 import { promises as fsp } from 'fs'
-import path from 'path'
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { getDocsPaths, readMarkdown } from '../../../docs/[[...doc]]'
-import RangeTuple from 'fuse.js'
+import path from 'path'
 import removeMd from 'remove-markdown'
+import { withHighlight } from '../../../../highlight.config'
+import { getDocsPaths, readMarkdown } from '../../../docs/[[...doc]]'
 
 export const SEARCH_RESULT_BLURB_LENGTH = 100
 
@@ -17,7 +17,7 @@ export interface SearchResult {
 	contentMatch?: Array<[number, number]> | undefined
 }
 
-export default async function handler(
+export default withHighlight(async function handler(
 	req: NextApiRequest,
 	res: NextApiResponse,
 ) {
@@ -63,4 +63,4 @@ export default async function handler(
 	})
 
 	return res.json(searchResults)
-}
+})


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Per the [docs](https://www.highlight.io/docs/getting-started/fullstack-frameworks/next-js#api-route-instrumentation-page-router), instrument the highlight.io nextjs backend.

We have a `withHighlight` function defined but it looked like it was unused:

https://github.com/highlight/highlight/blob/18ea6ad970bcc549146f93573a36fc5bb370fcf4/highlight.io/highlight.config.ts#L1-L7

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
