### PR TITLE
autocreate frontend service

### DIFF
--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -615,3 +615,30 @@ func Test_WithinQuota_CommittedPricing(t *testing.T) {
 		assert.False(t, usageBasedWithinBillingQuota)
 	})
 }
+
+func TestInitializeSessionImpl(t *testing.T) {
+	ctx := context.TODO()
+
+	util.RunTestWithDBWipe(t, resolver.DB, func(t *testing.T) {
+		workspace := model.Workspace{}
+		resolver.DB.Create(&workspace)
+
+		project := model.Project{
+			WorkspaceID: workspace.ID,
+		}
+
+		resolver.DB.Create(&project)
+
+		session, err := resolver.InitializeSessionImpl(ctx, &kafka_queue.InitializeSessionArgs{
+			ProjectVerboseID: project.VerboseID(),
+			ServiceName:      "my-frontend-app",
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, session.ID)
+
+		service, err := resolver.Store.FindService(ctx, project.ID, "my-frontend-app")
+
+		assert.NoError(t, err)
+		assert.NotNil(t, service.ID)
+	})
+}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR ensures that when using service name in the client config (#6453), a service is autocreated.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Ran a react app locally with this config:

```js
H.init('1xdn0e03', {
    backendUrl: 'https://localhost:8082/public',
    serviceName: 'my-frontend-app',
    tracingOrigins: true,
	  networkRecording: {
		enabled: true,
		recordHeadersAndBody: true,
	},
});
```

and confirmed a new service was created for my project:
<img width="1512" alt="Screenshot 2023-08-31 at 3 50 55 PM" src="https://github.com/highlight/highlight/assets/58678/6d21d183-383d-4c08-a30c-1f2fb36b1328">


## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
