### PR TITLE
add backendUrl in setup docs for frontend SDKs

### DIFF
--- a/frontend/src/pages/Setup/SetupDocs.tsx
+++ b/frontend/src/pages/Setup/SetupDocs.tsx
@@ -27,15 +27,24 @@ export type OptionListItem = {
 
 type Props = {
 	projectVerboseId: string
+	backendUrl: string
 	integrationData?: IntegrationStatus
 }
 
-export const SetupDocs: React.FC<Props> = ({ projectVerboseId }) => {
+export const SetupDocs: React.FC<Props> = ({
+	projectVerboseId,
+	backendUrl,
+}) => {
 	const match = useMatch('/:project_id/setup/:area/:language/:framework')
 	const { area, framework, language } = match!.params
 	const guide = (quickStartContent as any)[area!][language!][
 		framework!
 	] as QuickStartContent
+
+	const replacements = [
+		['<YOUR_PROJECT_ID>', projectVerboseId],
+		['<YOUR_BACKEND_URL>', backendUrl],
+	]
 
 	return (
 		<Box>
@@ -66,9 +75,14 @@ export const SetupDocs: React.FC<Props> = ({ projectVerboseId }) => {
 													},
 												)
 											}}
-											text={codeBlock.text.replaceAll(
-												'<YOUR_PROJECT_ID>',
-												projectVerboseId,
+											text={replacements.reduce(
+												(acc, [search, replace]) => {
+													return acc.replaceAll(
+														search,
+														replace,
+													)
+												},
+												codeBlock.text,
 											)}
 											className={clsx(styles.codeBlock)}
 											customStyle={{}} // removes unwanted bottom padding

--- a/frontend/src/pages/Setup/SetupDocs.tsx
+++ b/frontend/src/pages/Setup/SetupDocs.tsx
@@ -46,6 +46,33 @@ export const SetupDocs: React.FC<Props> = ({
 		['<YOUR_BACKEND_URL>', backendUrl],
 	]
 
+	if (backendUrl !== 'https://pub.highlight.io') {
+		// Remove last element since we need to remove the entire line
+		replacements.pop()
+
+		// For Angular, Vue, SvelteKit, React, HTML/JS
+		replacements.push([
+			"[\r\n]+[ \t]*backendUrl: '<YOUR_BACKEND_URL>',",
+			'',
+		])
+
+		// For Next
+		replacements.push([
+			"[\r\n]+[ \t]*backendUrl={'<YOUR_BACKEND_URL>'}",
+			'',
+		])
+
+		// For Remix
+		replacements.push([
+			'[\r\n]+[ \t]*HIGHLIGHT_BACKEND_URL: process.env.HIGHLIGHT_BACKEND_URL,',
+			'',
+		])
+		replacements.push([
+			'[\r\n]+[ \t]*backendUrl={ENV.HIGHLIGHT_BACKEND_URL}',
+			'',
+		])
+	}
+
 	return (
 		<Box>
 			<Box style={{ maxWidth: 560 }} my="40" mx="auto">
@@ -77,8 +104,8 @@ export const SetupDocs: React.FC<Props> = ({
 											}}
 											text={replacements.reduce(
 												(acc, [search, replace]) => {
-													return acc.replaceAll(
-														search,
+													return acc.replace(
+														new RegExp(search, 'g'),
 														replace,
 													)
 												},

--- a/frontend/src/pages/Setup/SetupRouter/SetupRouter.tsx
+++ b/frontend/src/pages/Setup/SetupRouter/SetupRouter.tsx
@@ -35,6 +35,7 @@ import {
 	useMatch,
 } from 'react-router-dom'
 
+import { PUBLIC_GRAPH_URI } from '@/constants'
 import { IntegrationBar } from '@/pages/Setup/IntegrationBar'
 import {
 	useAlertsIntegration,
@@ -297,6 +298,7 @@ export const SetupRouter = () => {
 								element={
 									<SetupDocs
 										projectVerboseId={projectVerboseId}
+										backendUrl={PUBLIC_GRAPH_URI}
 									/>
 								}
 							/>

--- a/highlight.io/components/QuickstartContent/frontend/angular.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/angular.tsx
@@ -17,6 +17,7 @@ const angularInitCodeSnippet = `// app.module.ts
 import { H } from 'highlight.run';
 
 H.init('<YOUR_PROJECT_ID>', {
+    backendUrl: '<YOUR_BACKEND_URL>',
     environment: 'production',
     version: 'commit:abcdefg12345',
 	networkRecording: {

--- a/highlight.io/components/QuickstartContent/frontend/next.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/next.tsx
@@ -63,6 +63,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 		<>
 			<HighlightInit
 				projectId={'<YOUR_PROJECT_ID>'}
+				backendUrl={'<YOUR_BACKEND_URL>'}
 				serviceName="my-nextjs-frontend"
 				tracingOrigins
 				networkRecording={{

--- a/highlight.io/components/QuickstartContent/frontend/other.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/other.tsx
@@ -46,6 +46,7 @@ To get started, we recommend setting \`environment\`, \`version\`, and \`network
     <script src="https://unpkg.com/highlight.run"></script>
     <script>
         H.init('<YOUR_PROJECT_ID>', { // Get your project ID from https://app.highlight.io/setup
+            backendUrl: '<YOUR_BACKEND_URL>',
             environment: 'production',
             version: 'commit:abcdefg12345',
             networkRecording: {

--- a/highlight.io/components/QuickstartContent/frontend/remix.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/remix.tsx
@@ -63,6 +63,7 @@ export async function loader() {
 	return json({
 		ENV: {
 			HIGHLIGHT_PROJECT_ID: process.env.HIGHLIGHT_PROJECT_ID,
+			HIGHLIGHT_BACKEND_URL: process.env.HIGHLIGHT_BACKEND_URL,
 		},
 	})
 }
@@ -74,6 +75,7 @@ export default function App() {
 		<html lang="en">
 			<HighlightInit
 				projectId={ENV.HIGHLIGHT_PROJECT_ID}
+				backendUrl={ENV.HIGHLIGHT_BACKEND_URL}
 				serviceName="my-remix-frontend"
 				tracingOrigins
 				networkRecording={{ enabled: true, recordHeadersAndBody: true }}

--- a/highlight.io/components/QuickstartContent/frontend/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/shared-snippets.tsx
@@ -74,6 +74,7 @@ To get started, we recommend setting \`tracingOrigins\` and \`networkRecording\`
 import { H } from 'highlight.run';
 
 H.init('<YOUR_PROJECT_ID>', {
+	backendUrl: '<YOUR_BACKEND_URL>',
 	serviceName: "frontend-app",
 	tracingOrigins: true,
 	networkRecording: {

--- a/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
@@ -16,6 +16,7 @@ const svelteKitInitCodeSnippet = `// hooks.client.ts
 import { H } from 'highlight.run';
 
 H.init('<YOUR_PROJECT_ID>', {
+    backendUrl: '<YOUR_BACKEND_URL>',
     environment: 'production',
     version: 'commit:abcdefg12345',
     tracingOrigins: true,

--- a/highlight.io/components/QuickstartContent/frontend/vue.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/vue.tsx
@@ -24,6 +24,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 
 H.init('<YOUR_PROJECT_ID>', {
+    backendUrl: '<YOUR_BACKEND_URL>',
     environment: 'production',
     version: 'commit:abcdefg12345',
 	networkRecording: {


### PR DESCRIPTION
## Summary

This PR addresses issue #5742 with the goal of streamlining the setup process for users deploying Highlight on their own infrastructure or local machine. Specifically, the PR auto-populates the `backendUrl` attribute in the SDK initialization code snippets across all frontend SDKs supported by Highlight.

## How did you test this change?

Frontend

- Local testing involved setting up various types of frontend applications supported by Highlight. Subsequently, I followed the initialization steps for the Highlight SDK, verifying that the `backendUrl` attribute was correctly auto-populated in each case.

Example - for Next.js:
![Screenshot 2023-09-01 at 1 52 11 PM](https://github.com/highlight/highlight/assets/39665675/d6eedca2-5fed-41a2-8e25-7154564368ff)

## Are there any deployment considerations?

- No database migrations or data backfilling are required for this change.