### PR TITLE
fix: datepicker bug in selecting previous date for the date range

### DIFF
--- a/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
+++ b/frontend/src/pages/LogsPage/SearchForm/SearchForm.tsx
@@ -87,9 +87,7 @@ const SearchForm = ({
 	})
 
 	const handleDatesChange = (dates: Date[]) => {
-		if (dates.length == 2) {
-			onDatesChange(dates[0], dates[1])
-		}
+			onDatesChange(dates[0] || startDate, dates[1] || endDate)
 	}
 
 	return (


### PR DESCRIPTION
## Summary

Removed the if condition that verifies If the date picker is giving us array of Date with length of 2. Instead I added the prev value if the dates of index 0 is null or undefined or if the dates of index 1 is null or undefined

## How did you test this change?

Tested on local machine and also ran the test:all script

## Are there any deployment considerations?

N/A

fix: #6490 
/claim #6490 

@Vadman97 