### PR TITLE
Fix reflame build

### DIFF
--- a/frontend/src/pages/ErrorTags/ErrorTagsContainer.tsx
+++ b/frontend/src/pages/ErrorTags/ErrorTagsContainer.tsx
@@ -1,6 +1,5 @@
 import { LinkButton } from '@components/LinkButton'
 import { Box, IconSolidArrowSmLeft } from '@highlight-run/ui'
-import { content as containerContentStyles } from '@highlight-run/ui/src/components/Container/styles.css'
 import SvgHighlightLogoOnLight from '@icons/HighlightLogoOnLight'
 import { Outlet } from 'react-router-dom'
 
@@ -59,7 +58,6 @@ export function ErrorTagsContainer() {
 						minHeight: '100%',
 						width: '100%',
 					}}
-					className={containerContentStyles}
 				>
 					<Box style={{ width: 720 }}>
 						<Box

--- a/packages/ui/src/components/Table/Head/Head.tsx
+++ b/packages/ui/src/components/Table/Head/Head.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box } from '../../Box/Box'
-import classnames from 'classnames'
+import clsx from 'clsx'
 
 import * as styles from './styles.css'
 
@@ -10,5 +10,5 @@ export type Props = {
 }
 
 export const Head: React.FC<Props> = ({ children, className }) => {
-	return <Box cssClass={classnames(styles.head, className)}>{children}</Box>
+	return <Box cssClass={clsx(styles.head, className)}>{children}</Box>
 }


### PR DESCRIPTION
## Summary
Hit a couple errors on Reflame that are preventing merging. Fix these errors:
- use `clsx` > `classnames`
- Remove unused styles (width is already being set in styles)

## How did you test this change?
1. Navigate to `/error-tags` and play with responsiveness
2. Compare to production `/error-tags

https://github.com/highlight/highlight/assets/17744174/1cc78ff9-0b57-463a-8004-3bb12b8eb81e


## Are there any deployment considerations?
N/A
