### PR TITLE
Test vercel deployment

### DIFF
--- a/e2e/nextjs/package.json
+++ b/e2e/nextjs/package.json
@@ -9,6 +9,9 @@
 		"start": "next start",
 		"lint": "next lint"
 	},
+	"installConfig": {
+		"hoistingLimits": "dependencies"
+	},
 	"dependencies": {
 		"@highlight-run/cloudflare": "workspace:*",
 		"@highlight-run/next": "workspace:*",

--- a/e2e/nextjs/package.json
+++ b/e2e/nextjs/package.json
@@ -34,10 +34,8 @@
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"typescript": "5.0.4",
+		"vercel": "^31.0.2",
 		"winston": "^3.8.2",
 		"zod": "^3.21.4"
-	},
-	"devDependencies": {
-		"vercel": "^31.0.2"
 	}
 }

--- a/e2e/nextjs/package.json
+++ b/e2e/nextjs/package.json
@@ -9,9 +9,6 @@
 		"start": "next start",
 		"lint": "next lint"
 	},
-	"installConfig": {
-		"hoistingLimits": "workspaces"
-	},
 	"dependencies": {
 		"@highlight-run/cloudflare": "workspace:*",
 		"@highlight-run/next": "workspace:*",
@@ -34,8 +31,10 @@
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"typescript": "5.0.4",
-		"vercel": "^31.0.2",
 		"winston": "^3.8.2",
 		"zod": "^3.21.4"
+	},
+	"devDependencies": {
+		"vercel": "^31.0.2"
 	}
 }


### PR DESCRIPTION
## Summary
The dependencies are not hoisted into the root level of the node modules, causing Vercel to error out when looking for the first none highlight workspace dependencie (e.g. `@next/env`). Update the hoistingLimits to include dependencies.

## How did you test this change?
1) Vercel build passes
- [ ] Build passes
2) Able to deploy Next E2E app
- [ ] Deploy works

## Are there any deployment considerations?
N/A
