### PR TITLE
update error instances table to fetch version off of error object

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -435,12 +435,12 @@ type ComplexityRoot struct {
 		ErrorGroupSecureID func(childComplexity int) int
 		Event              func(childComplexity int) int
 		ID                 func(childComplexity int) int
+		ServiceVersion     func(childComplexity int) int
 		Session            func(childComplexity int) int
 		Timestamp          func(childComplexity int) int
 	}
 
 	ErrorObjectNodeSession struct {
-		AppVersion  func(childComplexity int) int
 		Email       func(childComplexity int) int
 		Excluded    func(childComplexity int) int
 		Fingerprint func(childComplexity int) int
@@ -3565,6 +3565,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ErrorObjectNode.ID(childComplexity), true
 
+	case "ErrorObjectNode.serviceVersion":
+		if e.complexity.ErrorObjectNode.ServiceVersion == nil {
+			break
+		}
+
+		return e.complexity.ErrorObjectNode.ServiceVersion(childComplexity), true
+
 	case "ErrorObjectNode.session":
 		if e.complexity.ErrorObjectNode.Session == nil {
 			break
@@ -3578,13 +3585,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ErrorObjectNode.Timestamp(childComplexity), true
-
-	case "ErrorObjectNodeSession.appVersion":
-		if e.complexity.ErrorObjectNodeSession.AppVersion == nil {
-			break
-		}
-
-		return e.complexity.ErrorObjectNodeSession.AppVersion(childComplexity), true
 
 	case "ErrorObjectNodeSession.email":
 		if e.complexity.ErrorObjectNodeSession.Email == nil {
@@ -10506,7 +10506,6 @@ type TraceConnection implements Connection {
 
 type ErrorObjectNodeSession {
 	secureID: String!
-	appVersion: String
 	email: String
 	fingerprint: Int
 	excluded: Boolean!
@@ -10519,6 +10518,7 @@ type ErrorObjectNode {
 	timestamp: Timestamp!
 	session: ErrorObjectNodeSession
 	errorGroupSecureID: String!
+	serviceVersion: String!
 }
 
 type ErrorObjectEdge implements Edge {
@@ -29942,6 +29942,8 @@ func (ec *executionContext) fieldContext_ErrorObjectEdge_node(ctx context.Contex
 				return ec.fieldContext_ErrorObjectNode_session(ctx, field)
 			case "errorGroupSecureID":
 				return ec.fieldContext_ErrorObjectNode_errorGroupSecureID(ctx, field)
+			case "serviceVersion":
+				return ec.fieldContext_ErrorObjectNode_serviceVersion(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorObjectNode", field.Name)
 		},
@@ -30163,8 +30165,6 @@ func (ec *executionContext) fieldContext_ErrorObjectNode_session(ctx context.Con
 			switch field.Name {
 			case "secureID":
 				return ec.fieldContext_ErrorObjectNodeSession_secureID(ctx, field)
-			case "appVersion":
-				return ec.fieldContext_ErrorObjectNodeSession_appVersion(ctx, field)
 			case "email":
 				return ec.fieldContext_ErrorObjectNodeSession_email(ctx, field)
 			case "fingerprint":
@@ -30222,6 +30222,50 @@ func (ec *executionContext) fieldContext_ErrorObjectNode_errorGroupSecureID(ctx 
 	return fc, nil
 }
 
+func (ec *executionContext) _ErrorObjectNode_serviceVersion(ctx context.Context, field graphql.CollectedField, obj *model.ErrorObjectNode) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ErrorObjectNode_serviceVersion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ServiceVersion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ErrorObjectNode_serviceVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ErrorObjectNode",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ErrorObjectNodeSession_secureID(ctx context.Context, field graphql.CollectedField, obj *model.ErrorObjectNodeSession) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ErrorObjectNodeSession_secureID(ctx, field)
 	if err != nil {
@@ -30254,47 +30298,6 @@ func (ec *executionContext) _ErrorObjectNodeSession_secureID(ctx context.Context
 }
 
 func (ec *executionContext) fieldContext_ErrorObjectNodeSession_secureID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ErrorObjectNodeSession",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _ErrorObjectNodeSession_appVersion(ctx context.Context, field graphql.CollectedField, obj *model.ErrorObjectNodeSession) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ErrorObjectNodeSession_appVersion(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.AppVersion, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ErrorObjectNodeSession_appVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ErrorObjectNodeSession",
 		Field:      field,
@@ -73556,6 +73559,13 @@ func (ec *executionContext) _ErrorObjectNode(ctx context.Context, sel ast.Select
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "serviceVersion":
+
+			out.Values[i] = ec._ErrorObjectNode_serviceVersion(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -73584,10 +73594,6 @@ func (ec *executionContext) _ErrorObjectNodeSession(ctx context.Context, sel ast
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "appVersion":
-
-			out.Values[i] = ec._ErrorObjectNodeSession_appVersion(ctx, field, obj)
-
 		case "email":
 
 			out.Values[i] = ec._ErrorObjectNodeSession_email(ctx, field, obj)

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -329,11 +329,11 @@ type ErrorObjectNode struct {
 	Timestamp          time.Time               `json:"timestamp"`
 	Session            *ErrorObjectNodeSession `json:"session"`
 	ErrorGroupSecureID string                  `json:"errorGroupSecureID"`
+	ServiceVersion     string                  `json:"serviceVersion"`
 }
 
 type ErrorObjectNodeSession struct {
 	SecureID    string  `json:"secureID"`
-	AppVersion  *string `json:"appVersion"`
 	Email       *string `json:"email"`
 	Fingerprint *int    `json:"fingerprint"`
 	Excluded    bool    `json:"excluded"`

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -703,7 +703,6 @@ type TraceConnection implements Connection {
 
 type ErrorObjectNodeSession {
 	secureID: String!
-	appVersion: String
 	email: String
 	fingerprint: Int
 	excluded: Boolean!
@@ -716,6 +715,7 @@ type ErrorObjectNode {
 	timestamp: Timestamp!
 	session: ErrorObjectNodeSession
 	errorGroupSecureID: String!
+	serviceVersion: String!
 }
 
 type ErrorObjectEdge implements Edge {

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -113,6 +113,7 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 				CreatedAt:          errorObject.CreatedAt,
 				Event:              errorObject.Event,
 				Timestamp:          errorObject.Timestamp,
+				ServiceVersion:     errorObject.ServiceVersion,
 				ErrorGroupSecureID: errorGroup.SecureID,
 			},
 		}
@@ -124,7 +125,6 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 				edge.Node.Session = &privateModel.ErrorObjectNodeSession{
 					SecureID:    session.SecureID,
 					Email:       session.Email,
-					AppVersion:  session.AppVersion,
 					Fingerprint: &session.Fingerprint,
 					Excluded:    session.Excluded,
 				}

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -86,8 +86,9 @@ func TestListErrorObjectsOneObjectWithSession(t *testing.T) {
 	store.db.Create(&session)
 
 	errorObject := model.ErrorObject{
-		ErrorGroupID: errorGroup.ID,
-		SessionID:    &session.ID,
+		ErrorGroupID:   errorGroup.ID,
+		SessionID:      &session.ID,
+		ServiceVersion: "1.0.0",
 	}
 	store.db.Create(&errorObject)
 	connection, err := store.ListErrorObjects(errorGroup, ListErrorObjectsParams{})
@@ -101,11 +102,11 @@ func TestListErrorObjectsOneObjectWithSession(t *testing.T) {
 	assert.Equal(t, errorObject.ID, edge.Node.ID)
 	assert.WithinDuration(t, errorObject.CreatedAt, edge.Node.CreatedAt, 10*time.Second)
 	assert.Equal(t, errorObject.Event, edge.Node.Event)
+	assert.Equal(t, errorObject.ServiceVersion, edge.Node.ServiceVersion)
 	assert.Equal(t, errorGroup.SecureID, edge.Node.ErrorGroupSecureID)
 	assert.Equal(t, &privateModel.ErrorObjectNodeSession{
 		SecureID:    session.SecureID,
 		Email:       session.Email,
-		AppVersion:  session.AppVersion,
 		Fingerprint: &session.Fingerprint,
 		Excluded:    session.Excluded,
 	}, edge.Node.Session)

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -13478,10 +13478,10 @@ export const GetErrorObjectsDocument = gql`
 					event
 					timestamp
 					errorGroupSecureID
+					serviceVersion
 					session {
 						secureID
 						email
-						appVersion
 						fingerprint
 						excluded
 					}

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4513,6 +4513,7 @@ export type GetErrorObjectsQuery = { __typename?: 'Query' } & {
 						| 'event'
 						| 'timestamp'
 						| 'errorGroupSecureID'
+						| 'serviceVersion'
 					> & {
 							session?: Types.Maybe<
 								{
@@ -4521,7 +4522,6 @@ export type GetErrorObjectsQuery = { __typename?: 'Query' } & {
 									Types.ErrorObjectNodeSession,
 									| 'secureID'
 									| 'email'
-									| 'appVersion'
 									| 'fingerprint'
 									| 'excluded'
 								>

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -556,13 +556,13 @@ export type ErrorObjectNode = {
 	errorGroupSecureID: Scalars['String']
 	event: Scalars['String']
 	id: Scalars['ID']
+	serviceVersion: Scalars['String']
 	session?: Maybe<ErrorObjectNodeSession>
 	timestamp: Scalars['Timestamp']
 }
 
 export type ErrorObjectNodeSession = {
 	__typename?: 'ErrorObjectNodeSession'
-	appVersion?: Maybe<Scalars['String']>
 	email?: Maybe<Scalars['String']>
 	excluded: Scalars['Boolean']
 	fingerprint?: Maybe<Scalars['Int']>

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2175,10 +2175,10 @@ query GetErrorObjects(
 				event
 				timestamp
 				errorGroupSecureID
+				serviceVersion
 				session {
 					secureID
 					email
-					appVersion
 					fingerprint
 					excluded
 				}

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -55,16 +55,16 @@ export const ErrorInstancesTable = ({ edges, searchedEmail }: Props) => {
 				</Tag>
 			),
 		}),
-		columnHelper.accessor('node.session', {
+		columnHelper.accessor('node.serviceVersion', {
 			cell: ({ getValue }) => {
-				const session = getValue()
-				if (!session?.appVersion) {
+				const serviceVersion = getValue()
+				if (!serviceVersion) {
 					return null
 				}
 
 				return (
 					<Tag shape="basic" kind="secondary">
-						{truncateVersion(session.appVersion)}
+						{truncateVersion(serviceVersion)}
 					</Tag>
 				)
 			},


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

This PR updates the error instances table to fetch the version off of the error object instead of the session. 
Previously, backend only errors wouldn't have a version visible because they lacked a session. Per #6108, backend errors write their version to the error object and per #6453, frontend errors write the version onto the error object (in addition to the session).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

* Run the go fiber e2e app ([README](https://github.com/highlight/highlight/blob/6446-ensure-error-instances-table-uses-error_object-version/e2e/go/README.md))
* Confirmed error instances table has the version shown

![Screenshot 2023-09-05 at 10 58 29 AM](https://github.com/highlight/highlight/assets/58678/3b02538f-cf78-4f57-b393-25b0d1b686b4)


* Simulated a frontend error from the buttons page
* Confirmed version is visible


![Screenshot 2023-09-05 at 10 56 57 AM](https://github.com/highlight/highlight/assets/58678/62bc3d66-1577-433f-8771-ec1053d00b14)

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
