### PR TITLE
Remove feature flag for github enhancement

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -391,7 +391,6 @@ type AllWorkspaceSettings struct {
 	ErrorEmbeddingsThreshold float64 `gorm:"default:0.2"`
 	ReplaceAssets            bool    `gorm:"default:false"`
 	StoreIP                  bool    `gorm:"default:false"`
-	EnableEnhancedErrors     bool    `gorm:"default:false"`
 }
 
 type HasSecret interface {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -136,10 +136,9 @@ type ComplexityRoot struct {
 	}
 
 	AllWorkspaceSettings struct {
-		AIApplication        func(childComplexity int) int
-		AIInsights           func(childComplexity int) int
-		EnableEnhancedErrors func(childComplexity int) int
-		WorkspaceID          func(childComplexity int) int
+		AIApplication func(childComplexity int) int
+		AIInsights    func(childComplexity int) int
+		WorkspaceID   func(childComplexity int) int
 	}
 
 	AverageSessionLength struct {
@@ -2141,13 +2140,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AllWorkspaceSettings.AIInsights(childComplexity), true
-
-	case "AllWorkspaceSettings.enable_enhanced_errors":
-		if e.complexity.AllWorkspaceSettings.EnableEnhancedErrors == nil {
-			break
-		}
-
-		return e.complexity.AllWorkspaceSettings.EnableEnhancedErrors(childComplexity), true
 
 	case "AllWorkspaceSettings.workspace_id":
 		if e.complexity.AllWorkspaceSettings.WorkspaceID == nil {
@@ -9957,7 +9949,6 @@ type AllWorkspaceSettings {
 	workspace_id: ID!
 	ai_application: Boolean!
 	ai_insights: Boolean!
-	enable_enhanced_errors: Boolean!
 }
 
 type Account {
@@ -20519,50 +20510,6 @@ func (ec *executionContext) _AllWorkspaceSettings_ai_insights(ctx context.Contex
 }
 
 func (ec *executionContext) fieldContext_AllWorkspaceSettings_ai_insights(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "AllWorkspaceSettings",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _AllWorkspaceSettings_enable_enhanced_errors(ctx context.Context, field graphql.CollectedField, obj *model1.AllWorkspaceSettings) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_AllWorkspaceSettings_enable_enhanced_errors(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.EnableEnhancedErrors, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_AllWorkspaceSettings_enable_enhanced_errors(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AllWorkspaceSettings",
 		Field:      field,
@@ -36777,8 +36724,6 @@ func (ec *executionContext) fieldContext_Mutation_editWorkspaceSettings(ctx cont
 				return ec.fieldContext_AllWorkspaceSettings_ai_application(ctx, field)
 			case "ai_insights":
 				return ec.fieldContext_AllWorkspaceSettings_ai_insights(ctx, field)
-			case "enable_enhanced_errors":
-				return ec.fieldContext_AllWorkspaceSettings_enable_enhanced_errors(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AllWorkspaceSettings", field.Name)
 		},
@@ -50134,8 +50079,6 @@ func (ec *executionContext) fieldContext_Query_workspaceSettings(ctx context.Con
 				return ec.fieldContext_AllWorkspaceSettings_ai_application(ctx, field)
 			case "ai_insights":
 				return ec.fieldContext_AllWorkspaceSettings_ai_insights(ctx, field)
-			case "enable_enhanced_errors":
-				return ec.fieldContext_AllWorkspaceSettings_enable_enhanced_errors(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AllWorkspaceSettings", field.Name)
 		},
@@ -69601,13 +69544,6 @@ func (ec *executionContext) _AllWorkspaceSettings(ctx context.Context, sel ast.S
 		case "ai_insights":
 
 			out.Values[i] = ec._AllWorkspaceSettings_ai_insights(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "enable_enhanced_errors":
-
-			out.Values[i] = ec._AllWorkspaceSettings_enable_enhanced_errors(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -393,7 +393,6 @@ type AllWorkspaceSettings {
 	workspace_id: ID!
 	ai_application: Boolean!
 	ai_insights: Boolean!
-	enable_enhanced_errors: Boolean!
 }
 
 type Account {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2123,11 +2123,6 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 		log.WithContext(ctx).Error(e.Wrap(err, "error querying workspace"))
 	}
 
-	settings, err := r.Store.GetAllWorkspaceSettings(ctx, workspace.ID)
-	if err != nil {
-		log.WithContext(ctx).Error(e.Wrap(err, "error querying all_workspace_settings"))
-	}
-
 	// Filter out empty errors
 	var filteredErrors []*publicModel.BackendErrorObjectInput
 	for _, errorObject := range errorObjects {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2200,12 +2200,7 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 
 		var mappedStackTrace *string
 		var structuredStackTrace []*privateModel.ErrorTrace
-
-		if settings.EnableEnhancedErrors {
-			mappedStackTrace, structuredStackTrace, err = r.Store.EnhancedStackTrace(ctx, v.StackTrace, workspace, &project, errorToInsert)
-		} else {
-			structuredStackTrace, err = r.Store.StructuredStackTrace(ctx, v.StackTrace)
-		}
+		mappedStackTrace, structuredStackTrace, err = r.Store.EnhancedStackTrace(ctx, v.StackTrace, workspace, &project, errorToInsert)
 
 		if err != nil {
 			log.WithContext(ctx).Errorf("Failed to generate structured stacktrace %v", v.StackTrace)

--- a/backend/store/stacktraces.go
+++ b/backend/store/stacktraces.go
@@ -167,27 +167,17 @@ func (store *Store) EnhanceTraceWithGitHub(ctx context.Context, trace *privateMo
 
 func (store *Store) GitHubEnhancedStackTrace(ctx context.Context, stackTrace []*privateModel.ErrorTrace, workspace *model.Workspace, project *model.Project, errorObj *model.ErrorObject) ([]*privateModel.ErrorTrace, error) {
 	if errorObj.ServiceName == "" {
-		log.WithContext(ctx).WithField("error_object", errorObj).Info("Cannot enhance stacktrace for error without service name.")
 		return nil, nil
 	}
 
 	service, err := store.FindService(ctx, project.ID, errorObj.ServiceName)
-	if err != nil {
+	if err != nil || service == nil || service.GithubRepoPath == nil || service.Status != "healthy" {
 		return nil, err
-	} else if service == nil {
-		log.WithContext(ctx).WithField("error_object", errorObj).Info("No service found for error.")
-		return nil, nil
-	} else if service.GithubRepoPath == nil || service.Status != "healthy" {
-		log.WithContext(ctx).WithFields(log.Fields{"error_object": errorObj, "service": service}).Info("Cannot enhance errors for service.")
-		return nil, nil
 	}
 
 	gitHubAccessToken, err := store.integrationsClient.GetWorkspaceAccessToken(ctx, workspace, privateModel.IntegrationTypeGitHub)
-	if err != nil {
+	if err != nil || gitHubAccessToken == nil {
 		return nil, err
-	} else if gitHubAccessToken == nil {
-		log.WithContext(ctx).WithField("error_object", errorObj).Info("No GitHub token found for error workspace.")
-		return nil, nil
 	}
 
 	client, err := github.NewClient(ctx, *gitHubAccessToken)

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -13211,7 +13211,6 @@ export const GetWorkspaceSettingsDocument = gql`
 			workspace_id
 			ai_application
 			ai_insights
-			enable_enhanced_errors
 		}
 	}
 `

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4440,10 +4440,7 @@ export type GetWorkspaceSettingsQuery = { __typename?: 'Query' } & {
 	workspaceSettings?: Types.Maybe<
 		{ __typename?: 'AllWorkspaceSettings' } & Pick<
 			Types.AllWorkspaceSettings,
-			| 'workspace_id'
-			| 'ai_application'
-			| 'ai_insights'
-			| 'enable_enhanced_errors'
+			'workspace_id' | 'ai_application' | 'ai_insights'
 		>
 	>
 }

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -131,7 +131,6 @@ export type AllWorkspaceSettings = {
 	__typename?: 'AllWorkspaceSettings'
 	ai_application: Scalars['Boolean']
 	ai_insights: Scalars['Boolean']
-	enable_enhanced_errors: Scalars['Boolean']
 	workspace_id: Scalars['ID']
 }
 

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2111,7 +2111,6 @@ query GetWorkspaceSettings($workspace_id: ID!) {
 		workspace_id
 		ai_application
 		ai_insights
-		enable_enhanced_errors
 	}
 }
 

--- a/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings/ProjectSettings.tsx
@@ -25,7 +25,6 @@ import {
 	useEditProjectSettingsMutation,
 	useGetProjectQuery,
 	useGetProjectSettingsQuery,
-	useGetWorkspaceSettingsQuery,
 } from '@/graph/generated/hooks'
 import {
 	GetProjectSettingsQuery,
@@ -34,14 +33,12 @@ import {
 import { AutoresolveStaleErrorsForm } from '@/pages/ProjectSettings/AutoresolveStaleErrorsForm/AutoresolveStaleErrorsForm'
 import { FilterSessionsWithoutErrorForm } from '@/pages/ProjectSettings/FilterSessionsWithoutErrorForm/FilterSessionsWithoutErrorForm'
 import { ProjectSettingsContextProvider } from '@/pages/ProjectSettings/ProjectSettingsContext/ProjectSettingsContext'
-import { useApplicationContext } from '@/routers/AppRouter/context/ApplicationContext'
 
 import styles from './ProjectSettings.module.css'
 
 const ProjectSettings = () => {
 	const navigate = useNavigate()
 	const { project_id, ...params } = useParams()
-	const { currentWorkspace } = useApplicationContext()
 	const [allProjectSettings, setAllProjectSettings] =
 		useState<GetProjectSettingsQuery>()
 
@@ -56,10 +53,6 @@ const ProjectSettings = () => {
 			projectId: project_id!,
 		},
 		skip: !project_id,
-	})
-	const { data: workspaceSettingsData } = useGetWorkspaceSettingsQuery({
-		variables: { workspace_id: String(currentWorkspace?.id) },
-		skip: !currentWorkspace?.id,
 	})
 
 	const [editProjectSettings, { loading: editProjectSettingsLoading }] =
@@ -219,9 +212,6 @@ const ProjectSettings = () => {
 									key: 'services',
 									title: 'Services',
 									panelContent: <ServicesTable />,
-									hidden: !workspaceSettingsData
-										?.workspaceSettings
-										?.enable_enhanced_errors,
 								},
 							]}
 						/>


### PR DESCRIPTION
## Summary
We are going to rollout the GitHub stacktrace enhancements for everyone, so remove the feature flag

## How did you test this change?
1) The services page (`/1/settings/services`) can be viewed
2) Backend errors are enhanced

## Are there any deployment considerations?
Keep an eye on services to update the system config's `IgnoredFiles`
