### PR TITLE
fix panic when ingesting otel data without a project

### DIFF
--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -263,14 +263,6 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 		}
 	}
 
-	projectIDInt, err := projectToInt(fields.projectID)
-
-	if err != nil {
-		return nil, err
-	}
-
-	fields.projectIDInt = projectIDInt
-
 	if fields.projectIDInt == 1 && util.IsProduction() {
 		if fields.serviceName == "all" || fields.serviceName == "" {
 			fields.external = true
@@ -278,7 +270,9 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 		}
 	}
 
-	return fields, nil
+	var err error
+	fields.projectIDInt, err = projectToInt(fields.projectID)
+	return fields, err
 }
 
 func mergeMaps(maps ...map[string]any) map[string]any {

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -263,15 +263,16 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 		}
 	}
 
+	var err error
+	fields.projectIDInt, err = projectToInt(fields.projectID)
+
 	if fields.projectIDInt == 1 && util.IsProduction() {
 		if fields.serviceName == "all" || fields.serviceName == "" {
 			fields.external = true
 			fields.attrs["service.external"] = "true"
 		}
 	}
-
-	var err error
-	fields.projectIDInt, err = projectToInt(fields.projectID)
+	
 	return fields, err
 }
 

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -272,7 +272,7 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 			fields.attrs["service.external"] = "true"
 		}
 	}
-	
+
 	return fields, err
 }
 

--- a/backend/otel/extract_test.go
+++ b/backend/otel/extract_test.go
@@ -92,6 +92,15 @@ func TestExtractFields_ExtractProjectID(t *testing.T) {
 	assert.Equal(t, fields.attrs, map[string]string{})
 }
 
+func TestExtractFields_NoProject(t *testing.T) {
+	resource := newResource(t, map[string]any{
+		highlight.DeprecatedProjectIDAttribute: "asdf",
+	})
+	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
+	assert.NotNil(t, fields)
+	assert.Error(t, err)
+}
+
 func TestExtractFields_ExtractSessionID(t *testing.T) {
 	resource := newResource(t, map[string]any{
 		highlight.DeprecatedSessionIDAttribute: "session_abc",

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -36,6 +36,9 @@ type Handler struct {
 var IgnoredSpanNamePrefixes = []string{"fs "}
 
 func lg(ctx context.Context, fields *extractedFields) *log.Entry {
+	if fields == nil {
+		return log.WithContext(ctx)
+	}
 	return log.WithContext(ctx).
 		WithField("project_id", fields.projectID).
 		WithField("session_id", fields.sessionID).
@@ -185,7 +188,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						span:     &span,
 					})
 					if err != nil {
-						lg(ctx, fields).WithError(err).Error("failed to extract fields from span")
+						lg(ctx, fields).WithError(err).Info("failed to extract fields from span")
 						continue
 					}
 
@@ -218,7 +221,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						event:    &event,
 					})
 					if err != nil {
-						lg(ctx, fields).WithError(err).Error("failed to extract fields from span")
+						lg(ctx, fields).WithError(err).Info("failed to extract fields from span")
 						continue
 					}
 
@@ -402,7 +405,7 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 					logRecord: &logRecord,
 				})
 				if err != nil {
-					lg(ctx, fields).WithError(err).Error("failed to extract fields from log")
+					lg(ctx, fields).WithError(err).Info("failed to extract fields from log")
 					continue
 				}
 

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -35,6 +35,12 @@ export class Highlight {
 			})
 		}
 
+		if (!this._projectID) {
+			console.warn(
+				'Highlight project id was not provided. Data will not be recorded.',
+			)
+		}
+
 		this.tracer = trace.getTracer('highlight-node')
 
 		const exporter = new OTLPTraceExporter({


### PR DESCRIPTION
## Summary

Fix panic from log line when fields extraction would fail.

## How did you test this change?

New unit test.

## Are there any deployment considerations?

No
