### PR TITLE
Improve experience of viewing an error without sessions

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -440,6 +440,7 @@ type ComplexityRoot struct {
 	ErrorObjectNodeSession struct {
 		AppVersion  func(childComplexity int) int
 		Email       func(childComplexity int) int
+		Excluded    func(childComplexity int) int
 		Fingerprint func(childComplexity int) int
 		SecureID    func(childComplexity int) int
 	}
@@ -3541,6 +3542,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ErrorObjectNodeSession.Email(childComplexity), true
+
+	case "ErrorObjectNodeSession.excluded":
+		if e.complexity.ErrorObjectNodeSession.Excluded == nil {
+			break
+		}
+
+		return e.complexity.ErrorObjectNodeSession.Excluded(childComplexity), true
 
 	case "ErrorObjectNodeSession.fingerprint":
 		if e.complexity.ErrorObjectNodeSession.Fingerprint == nil {
@@ -10251,6 +10259,7 @@ type ErrorObjectNodeSession {
 	appVersion: String
 	email: String
 	fingerprint: Int
+	excluded: Boolean!
 }
 
 type ErrorObjectNode {
@@ -29374,6 +29383,8 @@ func (ec *executionContext) fieldContext_ErrorObjectNode_session(ctx context.Con
 				return ec.fieldContext_ErrorObjectNodeSession_email(ctx, field)
 			case "fingerprint":
 				return ec.fieldContext_ErrorObjectNodeSession_fingerprint(ctx, field)
+			case "excluded":
+				return ec.fieldContext_ErrorObjectNodeSession_excluded(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorObjectNodeSession", field.Name)
 		},
@@ -29587,6 +29598,50 @@ func (ec *executionContext) fieldContext_ErrorObjectNodeSession_fingerprint(ctx 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ErrorObjectNodeSession_excluded(ctx context.Context, field graphql.CollectedField, obj *model.ErrorObjectNodeSession) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ErrorObjectNodeSession_excluded(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Excluded, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ErrorObjectNodeSession_excluded(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ErrorObjectNodeSession",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -71715,6 +71770,13 @@ func (ec *executionContext) _ErrorObjectNodeSession(ctx context.Context, sel ast
 
 			out.Values[i] = ec._ErrorObjectNodeSession_fingerprint(ctx, field, obj)
 
+		case "excluded":
+
+			out.Values[i] = ec._ErrorObjectNodeSession_excluded(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -336,6 +336,7 @@ type ErrorObjectNodeSession struct {
 	AppVersion  *string `json:"appVersion"`
 	Email       *string `json:"email"`
 	Fingerprint *int    `json:"fingerprint"`
+	Excluded    bool    `json:"excluded"`
 }
 
 type ErrorSearchParamsInput struct {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -687,6 +687,7 @@ type ErrorObjectNodeSession {
 	appVersion: String
 	email: String
 	fingerprint: Int
+	excluded: Boolean!
 }
 
 type ErrorObjectNode {

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -126,6 +126,7 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 					Email:       session.Email,
 					AppVersion:  session.AppVersion,
 					Fingerprint: &session.Fingerprint,
+					Excluded:    session.Excluded,
 				}
 			}
 		}

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -107,6 +107,7 @@ func TestListErrorObjectsOneObjectWithSession(t *testing.T) {
 		Email:       session.Email,
 		AppVersion:  session.AppVersion,
 		Fingerprint: &session.Fingerprint,
+		Excluded:    session.Excluded,
 	}, edge.Node.Session)
 
 	assert.Equal(t, &privateModel.PageInfo{

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -13346,6 +13346,7 @@ export const GetErrorObjectsDocument = gql`
 						email
 						appVersion
 						fingerprint
+						excluded
 					}
 				}
 			}

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4490,6 +4490,7 @@ export type GetErrorObjectsQuery = { __typename?: 'Query' } & {
 									| 'email'
 									| 'appVersion'
 									| 'fingerprint'
+									| 'excluded'
 								>
 							>
 						}

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -558,6 +558,7 @@ export type ErrorObjectNodeSession = {
 	__typename?: 'ErrorObjectNodeSession'
 	appVersion?: Maybe<Scalars['String']>
 	email?: Maybe<Scalars['String']>
+	excluded: Scalars['Boolean']
 	fingerprint?: Maybe<Scalars['Int']>
 	secureID: Scalars['String']
 }

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2147,6 +2147,7 @@ query GetErrorObjects(
 					email
 					appVersion
 					fingerprint
+					excluded
 				}
 			}
 		}

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -78,7 +78,7 @@ export const ErrorInstancesTable = ({ edges, searchedEmail }: Props) => {
 				let content = <>no session</>
 				let sessionLink = ''
 
-				if (session) {
+				if (session && !session.excluded) {
 					if (session.email) {
 						content = (
 							<TextHighlighter


### PR DESCRIPTION
## Summary
Some errors on the instances page have a session attached, but they are not playable. Check the `excluded` value on the session to conditionally render the link

## How did you test this change?
1) View an error with instances in which there it is not playable (can update an `errorObject` in Postgres by setting `excluded = true`
- [ ] Errors with excluded sessions don't have a link to a session
- [ ] Errors with sessions that are not excluded link to the session

<img width="1724" alt="Screenshot 2023-09-06 at 10 11 00 AM" src="https://github.com/highlight/highlight/assets/17744174/8a5aa997-7056-4f91-b7e3-166d63e65301">


## Are there any deployment considerations?
N/A
