### PR TITLE
prefer nearby brokers to avoid cross-az kafka network traffic

### DIFF
--- a/backend/kafka-queue/aws.go
+++ b/backend/kafka-queue/aws.go
@@ -1,0 +1,59 @@
+package kafka_queue
+
+// based on https://github.com/segmentio/kafka-go/blob/e0af1cfbb8dd463571748e350262e2c81754bb73/example_groupbalancer_test.go#L37 and https://github.com/segmentio/kafka-go/issues/415
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"time"
+)
+
+// findRack is the basic rack resolver strategy for use in AWS.  It supports
+//   - ECS with the task metadata endpoint enabled (returns the container
+//     instance's availability zone)
+//   - Linux EC2 (returns the instance's availability zone)
+func findRack() string {
+	switch whereAmI() {
+	case "ecs":
+		return ecsAvailabilityZone()
+	}
+	return ""
+}
+
+const ecsContainerMetadataURI = "ECS_CONTAINER_METADATA_URI_V4"
+
+// whereAmI determines which strategy the rack resolver should use.
+func whereAmI() string {
+	// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html
+	if os.Getenv(ecsContainerMetadataURI) != "" {
+		return "ecs"
+	}
+	return "somewhere"
+}
+
+// ecsAvailabilityZone queries the task endpoint for the metadata URI that ECS
+// injects into the ECS_CONTAINER_METADATA_URI variable in order to retrieve
+// the availability zone where the task is running.
+func ecsAvailabilityZone() string {
+	client := http.Client{
+		Timeout: time.Second,
+		Transport: &http.Transport{
+			DisableCompression: true,
+			DisableKeepAlives:  true,
+		},
+	}
+	r, err := client.Get(os.Getenv(ecsContainerMetadataURI) + "/task")
+	if err != nil {
+		return ""
+	}
+	defer r.Body.Close()
+
+	var md struct {
+		AvailabilityZone string
+	}
+	if err := json.NewDecoder(r.Body).Decode(&md); err != nil {
+		return ""
+	}
+	return md.AvailabilityZone
+}

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -162,7 +162,6 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 
 	pool := &Queue{Topic: topic, ConsumerGroup: groupID, Client: client}
 	if mode&1 == 1 {
-		log.WithContext(ctx).Debugf("initializing kafka producer for %s", topic)
 		pool.kafkaP = &kafka.Writer{
 			Addr:         kafka.TCP(brokers...),
 			Transport:    transport,
@@ -188,9 +187,15 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 				pool.kafkaP.Async = *deref.Async
 			}
 		}
+
+		if !util.IsDevOrTestEnv() {
+			log.WithContext(ctx).
+				WithField("topic", topic).
+				Infof("initializing kafka producer %+v", pool.kafkaP)
+		}
 	}
 	if (mode>>1)&1 == 1 {
-		log.WithContext(ctx).Debugf("initializing kafka consumer for %s", topic)
+		rack := findRack()
 		config := kafka.ReaderConfig{
 			Brokers:           brokers,
 			Dialer:            dialer,
@@ -209,8 +214,8 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 			MaxAttempts:           10,
 			WatchPartitionChanges: true,
 			GroupBalancers: []kafka.GroupBalancer{
-				kafka.RackAffinityGroupBalancer{Rack: findRack()},
-				kafka.RangeGroupBalancer{},
+				kafka.RackAffinityGroupBalancer{Rack: rack},
+				kafka.RoundRobinGroupBalancer{},
 			},
 		}
 
@@ -225,6 +230,13 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 			if deref.MaxWait != nil {
 				config.MaxWait = *deref.MaxWait
 			}
+		}
+
+		if !util.IsDevOrTestEnv() {
+			log.WithContext(ctx).
+				WithField("topic", topic).
+				WithField("rack", rack).
+				Infof("initializing kafka consumer %+v", config)
 		}
 
 		pool.kafkaC = kafka.NewReader(config)

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -208,6 +208,10 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 			CommitInterval:        time.Second,
 			MaxAttempts:           10,
 			WatchPartitionChanges: true,
+			GroupBalancers: []kafka.GroupBalancer{
+				kafka.RackAffinityGroupBalancer{Rack: findRack()},
+				kafka.RangeGroupBalancer{},
+			},
 		}
 
 		if configOverride != nil {


### PR DESCRIPTION
## Summary

Turns out that we've had the ability to have our consumers prefer the nearest broker 
since we have been on [kafka 2.4 ](https://cwiki.apache.org/confluence/display/KAFKA/KIP-392%3A+Allow+consumers+to+fetch+from+closest+replica), but we have not been using the feature.

This change is based on segment io tickets https://github.com/segmentio/kafka-go/issues/415 and https://github.com/segmentio/kafka-go/issues/984 which describe a way to provide the AZ name to the client
to have the consumer groups prefer the nearest rack (avoiding cross-az traffic). 

## How did you test this change?

Local deploy continues to work.
![Screenshot from 2023-09-05 22-33-31](https://github.com/highlight/highlight/assets/1351531/fee7a086-e635-47a4-ae5b-da900420078b)


Testing the ECS rack preference is challenging locally, but should be safe to rollback with no data loss (we might just have a small delay in ingesting data).

## Are there any deployment considerations?

Will be monitoring the release. Only readers should be affected, so worst case we would have an ingest delay.
Will be following up about billing costs for cross-az traffic.
