### PR TITLE
Improve error alerts with no sessions

### DIFF
--- a/backend/alerts/alerts.go
+++ b/backend/alerts/alerts.go
@@ -37,6 +37,7 @@ func SendErrorAlert(ctx context.Context, event SendErrorAlertEvent) error {
 		ErrorIgnoreURL:  getErrorIgnoreURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
 		ErrorSnoozeURL:  getErrorSnoozeURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
 		SessionURL:      getSessionURL(event.ErrorAlert.ProjectID, event.Session),
+		SessionExcluded: event.Session.Excluded,
 		VisitedURL:      event.VisitedURL,
 	}
 

--- a/backend/alerts/integrations/discord/messages.go
+++ b/backend/alerts/integrations/discord/messages.go
@@ -47,6 +47,11 @@ func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlert
 	embed.Description = payload.UserIdentifier
 	embed.Fields = fields
 
+	sessionLabel := "View Session"
+	if payload.SessionExcluded {
+		sessionLabel = "No recorded session"
+	}
+
 	messageSend := discordgo.MessageSend{
 		Embeds: []*discordgo.MessageEmbed{
 			embed,
@@ -55,9 +60,9 @@ func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlert
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{
 					discordgo.Button{
-						Label:    "View Session",
+						Label:    sessionLabel,
 						Style:    discordgo.LinkButton,
-						Disabled: false,
+						Disabled: payload.SessionExcluded,
 						URL:      payload.SessionURL,
 					},
 					discordgo.Button{

--- a/backend/alerts/integrations/discord/messages_test.go
+++ b/backend/alerts/integrations/discord/messages_test.go
@@ -50,6 +50,7 @@ func (suite *DiscordChannelsTestSuite) TestSendErrorAlert() {
 		ErrorCount:      12,
 		ErrorTitle:      "something bad happened",
 		SessionURL:      "https://localhost:3000/1/sessions/uJgf8EvTHPbwCfnFMcWx3tnjW7sc?page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue%2Cfalse%7C%7Ccustom_created_at%2Cbetween_date%2C30%20days",
+		SessionExcluded: false,
 		ErrorURL:        "https://localhost:3000/1/errors/8y4uezKfrGgvMZNAMt1Z4lpJq2bt?page=1",
 		ErrorResolveURL: "https://localhost:3000/1/errors/8y4uezKfrGgvMZNAMt1Z4lpJq2bt?action=resolved",
 		ErrorIgnoreURL:  "https://localhost:3000/1/errors/8y4uezKfrGgvMZNAMt1Z4lpJq2bt?action=ignore",

--- a/backend/alerts/integrations/integrations.go
+++ b/backend/alerts/integrations/integrations.go
@@ -10,6 +10,7 @@ type ErrorAlertPayload struct {
 	ErrorCount      int64
 	ErrorTitle      string
 	SessionURL      string
+	SessionExcluded bool
 	ErrorURL        string
 	ErrorResolveURL string
 	ErrorIgnoreURL  string

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2676,6 +2676,8 @@ type SendSlackAlertInput struct {
 	Workspace *Workspace
 	// SessionSecureID is a required parameter
 	SessionSecureID string
+	// SessionExluded is a required parameter to tell if the session is playable
+	SessionExcluded bool
 	// UserIdentifier is a required parameter for New User, Error, and SessionFeedback alerts
 	UserIdentifier string
 	// UserObject is a required parameter for alerts that relate to a session
@@ -2786,8 +2788,13 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 			suffix += fmt.Sprintf("%s=%s", k, v)
 		}
 	}
-	sessionLink := fmt.Sprintf("<%s/%d/sessions/%s%s|View>", frontendURL, obj.ProjectID, input.SessionSecureID, suffix)
-	messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*Session:*\n"+sessionLink, false, false))
+
+	if input.SessionSecureID == "" || input.SessionExcluded {
+		messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*Session:*\nNo recorded session", false, false))
+	} else {
+		sessionLink := fmt.Sprintf("<%s/%d/sessions/%s%s|View>", frontendURL, obj.ProjectID, input.SessionSecureID, suffix)
+		messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*Session:*\n"+sessionLink, false, false))
+	}
 
 	identifier := input.UserIdentifier
 	if val, ok := input.UserObject["email"].(string); ok && len(val) > 0 {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1344,7 +1344,7 @@ func (r *Resolver) AddSessionFeedbackImpl(ctx context.Context, input *kafka_queu
 	metadata["timestamp"] = input.Timestamp
 
 	session := &model.Session{}
-	if err := r.DB.Select("project_id", "environment", "id", "secure_id", "created_at").Where(&model.Session{SecureID: input.SessionSecureID}).Take(&session).Error; err != nil {
+	if err := r.DB.Select("project_id", "environment", "id", "secure_id", "created_at", "excluded").Where(&model.Session{SecureID: input.SessionSecureID}).Take(&session).Error; err != nil {
 		return e.Wrap(err, "error querying session by sessionSecureID for adding session feedback")
 	}
 
@@ -1406,6 +1406,7 @@ func (r *Resolver) AddSessionFeedbackImpl(ctx context.Context, input *kafka_queu
 		errorAlert.SendAlertFeedback(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: session.SecureID,
+			SessionExcluded: session.Excluded,
 			UserIdentifier:  identifier,
 			CommentID:       &feedbackComment.ID,
 			CommentText:     feedbackComment.Text,
@@ -1877,7 +1878,17 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 				log.WithContext(ctx).Error(err)
 			}
 
-			errorAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{Workspace: workspace, SessionSecureID: sessionObj.SecureID, UserIdentifier: sessionObj.Identifier, Group: group, ErrorObject: errorObject, URL: &visitedUrl, ErrorsCount: &numErrors, UserObject: sessionObj.UserObject})
+			errorAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
+				Workspace:       workspace,
+				SessionSecureID: sessionObj.SecureID,
+				SessionExcluded: sessionObj.Excluded,
+				UserIdentifier:  sessionObj.Identifier,
+				Group:           group,
+				ErrorObject:     errorObject,
+				URL:             &visitedUrl,
+				ErrorsCount:     &numErrors,
+				UserObject:      sessionObj.UserObject,
+			})
 		}
 	}()
 }
@@ -3030,7 +3041,15 @@ func (r *Resolver) SendSessionInitAlert(ctx context.Context, workspace *model.Wo
 			log.WithContext(ctx).Error(e.Wrapf(err, "[project_id: %d] error sending new session alert to zapier", sessionObj.ProjectID))
 		}
 
-		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{Workspace: workspace, SessionSecureID: sessionObj.SecureID, UserIdentifier: sessionObj.Identifier, UserObject: sessionObj.UserObject, UserProperties: userProperties, URL: visitedUrl})
+		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
+			Workspace:       workspace,
+			SessionSecureID: sessionObj.SecureID,
+			SessionExcluded: sessionObj.Excluded,
+			UserIdentifier:  sessionObj.Identifier,
+			UserObject:      sessionObj.UserObject,
+			UserProperties:  userProperties,
+			URL:             visitedUrl,
+		})
 		if err = alerts.SendNewSessionAlert(alerts.SendNewSessionAlertEvent{
 			Session:      sessionObj,
 			SessionAlert: sessionAlert,
@@ -3133,7 +3152,15 @@ func (r *Resolver) SendSessionTrackPropertiesAlert(ctx context.Context, workspac
 			log.WithContext(ctx).Error(e.Wrapf(err, "error notifying zapier (session alert id: %d)", sessionAlert.ID))
 		}
 
-		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{Workspace: workspace, SessionSecureID: session.SecureID, UserIdentifier: session.Identifier, MatchedFields: matchedFields, RelatedFields: relatedFields, UserObject: session.UserObject})
+		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
+			Workspace:       workspace,
+			SessionSecureID: session.SecureID,
+			SessionExcluded: session.Excluded,
+			UserIdentifier:  session.Identifier,
+			MatchedFields:   matchedFields,
+			RelatedFields:   relatedFields,
+			UserObject:      session.UserObject,
+		})
 		if err = alerts.SendTrackPropertiesAlert(alerts.TrackPropertiesAlertEvent{
 			Session:       session,
 			SessionAlert:  sessionAlert,
@@ -3204,7 +3231,14 @@ func (r *Resolver) SendSessionIdentifiedAlert(ctx context.Context, workspace *mo
 			log.WithContext(ctx).Error(e.Wrapf(err, "[project_id: %d] error sending alert to zapier", session.ProjectID))
 		}
 
-		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{Workspace: workspace, SessionSecureID: refetchedSession.SecureID, UserIdentifier: refetchedSession.Identifier, UserProperties: userProperties, UserObject: refetchedSession.UserObject})
+		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
+			Workspace:       workspace,
+			SessionSecureID: refetchedSession.SecureID,
+			SessionExcluded: refetchedSession.Excluded,
+			UserIdentifier:  refetchedSession.Identifier,
+			UserProperties:  userProperties,
+			UserObject:      refetchedSession.UserObject,
+		})
 		if err = alerts.SendNewUserAlert(alerts.SendNewUserAlertEvent{
 			Session:      session,
 			SessionAlert: sessionAlert,
@@ -3284,7 +3318,14 @@ func (r *Resolver) SendSessionUserPropertiesAlert(ctx context.Context, workspace
 			log.WithContext(ctx).Error(e.Wrapf(err, "error notifying zapier (session alert id: %d)", sessionAlert.ID))
 		}
 
-		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{Workspace: workspace, SessionSecureID: session.SecureID, UserIdentifier: session.Identifier, MatchedFields: matchedFields, UserObject: session.UserObject})
+		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
+			Workspace:       workspace,
+			SessionSecureID: session.SecureID,
+			SessionExcluded: session.Excluded,
+			UserIdentifier:  session.Identifier,
+			MatchedFields:   matchedFields,
+			UserObject:      session.UserObject,
+		})
 		if err = alerts.SendUserPropertiesAlert(alerts.UserPropertiesAlertEvent{
 			SessionAlert:  sessionAlert,
 			Session:       session,

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -994,9 +994,15 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 			}
 
 			count64 := int64(count)
-			slackAlertPayload := model.SendSlackAlertInput{Workspace: workspace,
-				SessionSecureID: s.SecureID, UserIdentifier: s.Identifier, UserObject: s.UserObject, RageClicksCount: &count64,
-				QueryParams: map[string]string{"tsAbs": fmt.Sprintf("%d", accumulator.RageClickSets[0].StartTimestamp.UnixNano()/int64(time.Millisecond))}}
+			slackAlertPayload := model.SendSlackAlertInput{
+				Workspace:       workspace,
+				SessionSecureID: s.SecureID,
+				SessionExcluded: s.Excluded,
+				UserIdentifier:  s.Identifier,
+				UserObject:      s.UserObject,
+				RageClicksCount: &count64,
+				QueryParams:     map[string]string{"tsAbs": fmt.Sprintf("%d", accumulator.RageClickSets[0].StartTimestamp.UnixNano()/int64(time.Millisecond))},
+			}
 
 			hookPayload := zapier.HookPayload{
 				UserIdentifier: s.Identifier, UserObject: s.UserObject, RageClicksCount: &count64,


### PR DESCRIPTION
## Summary
Some errors will not have sessions associated with them since they are not recorded. Update the Slack, Discord, and Email alerts to handle this case.

**Slack**
<img width="429" alt="slack-alert" src="https://github.com/highlight/highlight/assets/17744174/ab236cc3-4114-4de3-9b7d-bc7a1873f3d2">

**Discord**
<img width="452" alt="discord-alert" src="https://github.com/highlight/highlight/assets/17744174/cbe2d5ab-1667-4892-9503-a1d2f294adcf">

**Email**
<img width="1361" alt="Screenshot 2023-09-06 at 1 35 56 PM" src="https://github.com/highlight/highlight/assets/17744174/3fca160c-4e87-4735-bf80-3b0542d65532">

## How did you test this change?
1. Add integrations for Slack and Discord
2. Create an Error alert with the following attributes (feel free to update with your channels/email):
  a. Slack channel: #chris-errors-test
  b. Discord channel: #spencer-test-alerts
  c. Email: spencer@highlight.io
  d. Alert threshold: 1
  e. Alert frequency: 30 seconds
3. Kick off an error
- [ ] Alert received in Slack channel with **link** to session
- [ ] Alert received in Discord channel with **link** to session
- [ ] Email received **with** link to session
3. In the `H.init` in `frontend/src/index.tsx` set `options.disableSessionRecording = true` to disable recording
5. Restart your frontend
6. Kick off an error again
- [ ] Alert received in Slack channel **without** link to session
- [ ] Alert received in Discord channel **without** link to session
- [ ] Email received **without** link to session

## Are there any deployment considerations?
N/A