### PR TITLE
fix: Prevent className prop to Box component #6521

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -902,7 +902,7 @@ const MaintenanceBanner = () => {
 
 	return (
 		<Box
-			className={clsx(styles.trialWrapper)}
+			cssClass={styles.trialWrapper}
 			style={{ backgroundColor: vars.color.y9 }}
 		>
 			<Text color="black">

--- a/frontend/src/components/TableList/TableList.tsx
+++ b/frontend/src/components/TableList/TableList.tsx
@@ -57,7 +57,7 @@ export const TableList = ({
 					return (
 						<Box
 							key={item.keyDisplayValue}
-							className={style.sessionAttributeRow({
+							cssClass={style.sessionAttributeRow({
 								json:
 									(typeof item.valueDisplayValue ===
 										'object' &&

--- a/frontend/src/pages/Alerts/AlertConfigurationCard/SlackLoadOrConnect.tsx
+++ b/frontend/src/pages/Alerts/AlertConfigurationCard/SlackLoadOrConnect.tsx
@@ -1,6 +1,5 @@
 import { CircularSpinner } from '@components/Loading/Loading'
 import { Box } from '@highlight-run/ui'
-import clsx from 'clsx'
 import { Link } from 'react-router-dom'
 
 import styles from './SlackLoadOrConnect.module.css'
@@ -22,7 +21,7 @@ const SlackLoadOrConnect = ({
 		return <Link to={slackUrl}>Connect Highlight with Slack</Link>
 	}
 	return (
-		<Box className={clsx(styles.selectMessage, styles.notFoundMessage)}>
+		<Box cssClass={[styles.selectMessage, styles.notFoundMessage]}>
 			{!isLoading && searchQuery
 				? `No results for "${searchQuery}"`
 				: null}

--- a/frontend/src/pages/Buttons/Buttons.tsx
+++ b/frontend/src/pages/Buttons/Buttons.tsx
@@ -554,7 +554,7 @@ export const Buttons = () => {
 								key={c}
 								display="flex"
 								flexDirection="column"
-								className={c}
+								cssClass={c}
 								id={`video-test-${c}`}
 								data-id={`video-test-${c}`}
 							>

--- a/frontend/src/pages/ErrorTags/ErrorTagsContainer.tsx
+++ b/frontend/src/pages/ErrorTags/ErrorTagsContainer.tsx
@@ -59,7 +59,7 @@ export function ErrorTagsContainer() {
 						minHeight: '100%',
 						width: '100%',
 					}}
-					className={containerContentStyles}
+					cssClass={containerContentStyles}
 				>
 					<Box style={{ width: 720 }}>
 						<Box

--- a/frontend/src/pages/ErrorTags/ErrorTagsContainer.tsx
+++ b/frontend/src/pages/ErrorTags/ErrorTagsContainer.tsx
@@ -4,7 +4,6 @@ import SvgHighlightLogoOnLight from '@icons/HighlightLogoOnLight'
 import { Outlet } from 'react-router-dom'
 
 import headerStyles from '../../components/Header/Header.module.css'
-import { containerContentStyles } from './style.css'
 
 export function ErrorTagsContainer() {
 	return (
@@ -59,7 +58,6 @@ export function ErrorTagsContainer() {
 						minHeight: '100%',
 						width: '100%',
 					}}
-					cssClass={containerContentStyles}
 				>
 					<Box style={{ width: 720 }}>
 						<Box

--- a/frontend/src/pages/ErrorTags/ErrorTagsSearch.tsx
+++ b/frontend/src/pages/ErrorTags/ErrorTagsSearch.tsx
@@ -212,7 +212,7 @@ function roundScore(score: number) {
 }
 
 function NoResults() {
-	return <Box className={styles.noResults}>No results</Box>
+	return <Box cssClass={styles.noResults}>No results</Box>
 }
 
 function ShareButton() {
@@ -228,7 +228,7 @@ function ShareButton() {
 	return (
 		<>
 			{isPopoverOpen && (
-				<Box className={styles.alert}>
+				<Box cssClass={styles.alert}>
 					<Box>Copied URL</Box>
 				</Box>
 			)}

--- a/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
+++ b/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
@@ -7,7 +7,6 @@ import { getChromeExtensionURL } from '@pages/Player/SessionLevelBar/utils/utils
 import { bytesToPrettyString } from '@util/string'
 import { buildQueryStateString } from '@util/url/params'
 import { message } from 'antd'
-import clsx from 'clsx'
 
 import CollapsibleSection from '@/components/CollapsibleSection'
 import { styledVerticalScrollbar } from '@/style/common.css'
@@ -267,16 +266,11 @@ const MetadataPanel = () => {
 	)
 
 	return (
-		<Box className={style.container}>
+		<Box cssClass={style.container}>
 			{!session ? (
 				<LoadingBox />
 			) : (
-				<Box
-					className={clsx(
-						style.metadataPanel,
-						styledVerticalScrollbar,
-					)}
-				>
+				<Box cssClass={[style.metadataPanel, styledVerticalScrollbar]}>
 					{Object.entries({
 						[MetadataSection.Session]: sessionData,
 						[MetadataSection.User]: userData,

--- a/frontend/src/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/SessionInsights/SessionInsights.tsx
@@ -90,7 +90,7 @@ const SessionInsights = () => {
 								return (
 									<Box cursor="pointer" key={idx}>
 										<Box
-											className={style.insight}
+											cssClass={style.insight}
 											onClick={() => {
 												setTime(timeSinceStart)
 											}}

--- a/frontend/src/pages/Player/RightPlayerPanel/components/WebSocketMessages/WebSocketMessages.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/WebSocketMessages/WebSocketMessages.tsx
@@ -29,8 +29,8 @@ export const WebSocketMessages = ({ events, eventsLoading }: any) => {
 	return eventsLoading ? (
 		<LoadingBox />
 	) : (
-		<Box className={styles.container}>
-			<Box className={styles.websocketHeader}>
+		<Box cssClass={styles.container}>
+			<Box cssClass={styles.websocketHeader}>
 				<Box></Box>
 				<Box color="weak" py="6" px="8" borderRight="dividerWeak">
 					<Text size="xxSmall">Data</Text>
@@ -42,7 +42,7 @@ export const WebSocketMessages = ({ events, eventsLoading }: any) => {
 					<Text size="xxSmall">Time</Text>
 				</Box>
 			</Box>
-			<Box className={styles.networkBox}>
+			<Box cssClass={styles.networkBox}>
 				<Virtuoso
 					ref={virtuoso}
 					overscan={1024}

--- a/frontend/src/pages/Player/SessionLevelBar/SessionLevelBarV2.tsx
+++ b/frontend/src/pages/Player/SessionLevelBar/SessionLevelBarV2.tsx
@@ -136,10 +136,7 @@ export const SessionLevelBarV2: React.FC<
 	)
 
 	return (
-		<Box
-			className={styles.sessionLevelBarV2}
-			style={{ width: props.width }}
-		>
+		<Box cssClass={styles.sessionLevelBarV2} style={{ width: props.width }}>
 			<Box
 				p="6"
 				gap="12"
@@ -223,7 +220,7 @@ export const SessionLevelBarV2: React.FC<
 						</Stack>
 					)}
 					<Box
-						className={styles.currentUrl}
+						cssClass={styles.currentUrl}
 						onMouseEnter={() => {
 							if (delayRef.current) {
 								window.clearTimeout(delayRef.current)
@@ -282,7 +279,7 @@ export const SessionLevelBarV2: React.FC<
 						</Box>
 					)}
 				</Box>
-				<Box className={styles.rightButtons}>
+				<Box cssClass={styles.rightButtons}>
 					{session && (
 						<>
 							<SessionShareButtonV2 />

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -152,7 +152,7 @@ export const ConsolePage = ({
 	])
 
 	return (
-		<Box className={styles.consoleBox}>
+		<Box cssClass={styles.consoleBox}>
 			{loading || !isPlayerReady ? (
 				<LoadingBox />
 			) : messagesToRender?.length ? (

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ErrorsPage/ErrorsPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ErrorsPage/ErrorsPage.tsx
@@ -93,7 +93,7 @@ const ErrorsPage = ({
 	}, [activeError, errors])
 
 	return (
-		<Box className={styles.errorsContainer}>
+		<Box cssClass={styles.errorsContainer}>
 			{loading || !isPlayerReady ? (
 				<LoadingBox />
 			) : !session || !errorsToRender.length ? (
@@ -175,7 +175,7 @@ const ErrorRow = React.memo(
 		return (
 			<Box key={error.id} mx="4">
 				<Box
-					className={styles.errorRowVariants({
+					cssClass={styles.errorRowVariants({
 						current,
 						selected: selectedError,
 					})}

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -194,14 +194,14 @@ export const NetworkPage = ({
 	}, [autoScroll, currentResourceIdx, scrollFunction, state, time])
 
 	return (
-		<Box className={styles.container}>
+		<Box cssClass={styles.container}>
 			{resourceLoadingError ? (
 				<ResourceLoadingErrorCallout error={resourceLoadingError} />
 			) : !isPlayerReady || loading || !session ? (
 				<LoadingBox />
 			) : resourcesToRender.length > 0 ? (
-				<Box className={styles.container}>
-					<Box className={styles.networkHeader}>
+				<Box cssClass={styles.container}>
+					<Box cssClass={styles.networkHeader}>
 						<Text color="n11">Status</Text>
 						<Text color="n11">Type</Text>
 						<Text color="n11">Name</Text>
@@ -209,7 +209,7 @@ export const NetworkPage = ({
 						<Text color="n11">Latency</Text>
 						<Text color="n11">Waterfall</Text>
 					</Box>
-					<Box className={styles.networkBox}>
+					<Box cssClass={styles.networkBox}>
 						<Virtuoso
 							ref={virtuoso}
 							overscan={1024}
@@ -397,15 +397,15 @@ const ResourceRow = ({
 						? formatTime(resource.responseEnd - resource.startTime)
 						: 'N/A'}
 				</Text>
-				<Box className={styles.timingBarWrapper}>
+				<Box cssClass={styles.timingBarWrapper}>
 					<Box
 						style={{
 							width: `${leftPaddingPercent}%`,
 						}}
-						className={styles.timingBarEmptySection}
+						cssClass={styles.timingBarEmptySection}
 					/>
 					<Box
-						className={styles.timingBar}
+						cssClass={styles.timingBar}
 						style={{
 							width: `${actualPercent}%`,
 						}}
@@ -414,7 +414,7 @@ const ResourceRow = ({
 						style={{
 							width: `${rightPaddingPercent}%`,
 						}}
-						className={styles.timingBarEmptySection}
+						cssClass={styles.timingBarEmptySection}
 					/>
 				</Box>
 				<Tag

--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/TimelineIndicatorsBarGraph.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/TimelineIndicatorsBarGraph.tsx
@@ -1019,9 +1019,12 @@ const TimelineIndicatorsBarGraph = ({
 								/>
 								<Box
 									as="span"
-									className={clsx(style.timeIndicatorHair, {
-										[style.hairHidden]: !showHistogram,
-									})}
+									cssClass={[
+										style.timeIndicatorHair,
+										{
+											[style.hairHidden]: !showHistogram,
+										},
+									]}
 									ref={timeIndicatorHairRef}
 								/>
 							</div>

--- a/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
@@ -124,7 +124,7 @@ const EventStreamV2 = function () {
 		!replayer || state === ReplayerState.Loading || events.length === 0
 
 	return (
-		<Box className={style.container}>
+		<Box cssClass={style.container}>
 			{isLoading ? (
 				<LoadingBox />
 			) : (

--- a/packages/ui/src/components/Box/Box.tsx
+++ b/packages/ui/src/components/Box/Box.tsx
@@ -6,7 +6,10 @@ import { hiddenScroll } from './Box.css'
 
 export type BoxProps = Sprinkles &
 	React.PropsWithChildren &
-	Omit<React.AllHTMLAttributes<HTMLElement>, 'color' | 'height' | 'width'> & {
+	Omit<
+		React.AllHTMLAttributes<HTMLElement>,
+		'color' | 'height' | 'width' | 'className'
+	> & {
 		as?: React.ElementType
 		// Can't use className because it does some conversion on its values and
 		// breaks values like arrays, which would otherwise be valid for clsx.

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -101,7 +101,7 @@ export const ButtonContent: React.FC<ButtonContentProps> = ({
 					as="span"
 					display="inline-flex"
 					disabled={disabled}
-					className={styles.iconVariants({
+					cssClass={styles.iconVariants({
 						size,
 						emphasis,
 						kind,
@@ -125,7 +125,7 @@ export const ButtonContent: React.FC<ButtonContentProps> = ({
 					as="span"
 					display="inline-flex"
 					disabled={disabled}
-					className={styles.iconVariants({
+					cssClass={styles.iconVariants({
 						size,
 						emphasis,
 						kind,

--- a/packages/ui/src/components/Tag/Tag.tsx
+++ b/packages/ui/src/components/Tag/Tag.tsx
@@ -63,7 +63,7 @@ export const Tag: React.FC<React.PropsWithChildren<Props>> = ({
 				<Box
 					as="span"
 					display="inline-flex"
-					className={styles.iconVariants({ size })}
+					cssClass={styles.iconVariants({ size })}
 					onClick={onIconLeftClick}
 				>
 					{icon}
@@ -85,7 +85,7 @@ export const Tag: React.FC<React.PropsWithChildren<Props>> = ({
 				<Box
 					as="span"
 					display="inline-flex"
-					className={styles.iconVariants({ size })}
+					cssClass={styles.iconVariants({ size })}
 					onClick={onIconRightClick}
 				>
 					{iconRight}


### PR DESCRIPTION
closes #6521 

## Summary

* Added className in Omit<T,K> key of BoxProps. This enables type errors on the use of the className prop
![Screenshot from 2023-09-07 00-47-32](https://github.com/highlight/highlight/assets/54364088/cbaae5ce-1727-4eb5-85a2-8850321ec5f0)

* Manually replaced all instances of className props used in Box component with cssClass, modified the contents to an array of ClassValue where clsx used

## How did you test this change?

* Local `npm run build:frontend` passed successfully
* Verified a few instances on local build. No visual changes were noticed

## Are there any deployment considerations?
* A full render test for checking all instances is required

