### PR TITLE
docs: fix the duplicate env-variable in the self-hosting guide

### DIFF
--- a/highlight.io/components/QuickstartContent/self-host/self-host.tsx
+++ b/highlight.io/components/QuickstartContent/self-host/self-host.tsx
@@ -20,7 +20,6 @@ PUBLIC_GRAPH_URI=https://your-ip-address:8082/public
 REACT_APP_PRIVATE_GRAPH_URI=https://your-ip-address:8082/private
 REACT_APP_PUBLIC_GRAPH_URI=https://your-ip-address:8082/public
 REACT_APP_FRONTEND_URI=https://your-ip-address:3000
-REACT_APP_FRONTEND_URI=https://your-ip-address:3000
 `,
 					language: 'bash',
 				},


### PR DESCRIPTION
## Summary
I noticed, that the [Hobby deployment guide](https://www.highlight.io/docs/getting-started/self-host/self-hosted-hobby-guide) had a minor mistake (without any consequences, should be purely cosmetic), and showed the env-variable `REACT_APP_FRONTEND_URI=https://your-ip-address:3000` twice in Step 3.

## How did you test this change?

**Before:**
![CleanShot 2023-09-07 at 00 02 21@2x](https://github.com/highlight/highlight/assets/72219526/2d466c6c-e4bf-4deb-8e38-0be0e050029c)

**After:**
![CleanShot 2023-09-07 at 00 03 37@2x](https://github.com/highlight/highlight/assets/72219526/7538918d-afdd-4cd1-95d6-9859ad685a87)

## Are there any deployment considerations?
No, this is just a single line of text in a multi-line string removed on the frontend.