### PR TITLE
ignore ruby republish error

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -37,6 +37,6 @@ jobs:
                   chmod 0600 $HOME/.gem/credentials
                   printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
                   gem build *.gemspec
-                  gem push *.gem
+                  gem push *.gem || exit 0
               env:
                   RUBYGEMS_API_KEY: '${{secrets.RUBYGEMS_API_KEY}}'

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,6 +19,12 @@ jobs:
                 working-directory: ./sdk/highlight-ruby/highlight
         steps:
             - uses: actions/checkout@v3
+            - uses: dorny/paths-filter@v2
+              id: filter
+              with:
+                  filters: |
+                      ruby-changed:
+                        - 'sdk/highlight-ruby/**'
             - name: Install Ruby 2.6
               uses: ruby/setup-ruby@v1
               with:
@@ -30,13 +36,13 @@ jobs:
             - name: Rubocop
               run: bundle exec rubocop
             - name: Publish to RubyGems
-              if: github.ref == 'refs/heads/main'
+              if: github.ref == 'refs/heads/main' && steps.filter.outputs.ruby-changed
               run: |
                   mkdir -p $HOME/.gem
                   touch $HOME/.gem/credentials
                   chmod 0600 $HOME/.gem/credentials
                   printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
                   gem build *.gemspec
-                  gem push *.gem || exit 0
+                  gem push *.gem
               env:
                   RUBYGEMS_API_KEY: '${{secrets.RUBYGEMS_API_KEY}}'


### PR DESCRIPTION
## Summary

Our main branch is failing the ruby check because
the publish command does not like that we are republishing existing versions.

This makes sure that the github action will pass even if the publish fails (because the version exists).
The downside of the change is that an actual new version bump that fails to publish for another reason
will not be obvious, but it seems like a proper solution would require migrating to 

## How did you test this change?

Github Action

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No