### PR TITLE
feat: solve #6538 by fetching for the new OTLP_ENDPOINT env-variable

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -77,6 +77,7 @@ var (
 	stripeApiKey        = os.Getenv("STRIPE_API_KEY")
 	stripeWebhookSecret = os.Getenv("STRIPE_WEBHOOK_SECRET")
 	slackSigningSecret  = os.Getenv("SLACK_SIGNING_SECRET")
+	otlpEndpoint        = os.Getenv("OTLP_ENDPOINT")
 	runtimeFlag         = flag.String("runtime", "all", "the runtime of the backend; either 1) dev (all runtimes) 2) worker 3) public-graph 4) private-graph")
 	handlerFlag         = flag.String("worker-handler", "", "applies for runtime=worker; if specified, a handler function will be called instead of Start")
 )
@@ -232,9 +233,12 @@ func main() {
 	highlight.SetProjectID("1jdkoe52")
 	if !util.IsOnPrem() && util.IsDevOrTestEnv() {
 		log.WithContext(ctx).Info("overwriting highlight-go graphql / otlp client address...")
-		highlight.SetOTLPEndpoint("http://localhost:4318")
-		if util.IsBackendInDocker() {
+		if otlpEndpoint != "" {
+			highlight.SetOTLPEndpoint(otlpEndpoint)
+		} else if util.IsBackendInDocker() {
 			highlight.SetOTLPEndpoint("http://collector:4318")
+		} else {
+			highlight.SetOTLPEndpoint("http://localhost:4318")
 		}
 	}
 

--- a/docker/.env
+++ b/docker/.env
@@ -21,6 +21,7 @@ OPENSEARCH_DOMAIN=http://opensearch:9200
 OPENSEARCH_DOMAIN_READ=http://opensearch:9200
 OPENSEARCH_PASSWORD=admin
 OPENSEARCH_USERNAME=admin
+OTLP_ENDPOINT=http://collector:4318
 TZ=America/Los_Angeles
 PSQL_DB=postgres
 PSQL_HOST=postgres

--- a/docker/compose.hobby.yml
+++ b/docker/compose.hobby.yml
@@ -41,6 +41,7 @@ x-backend-env: &backend-env
         - OPENSEARCH_DOMAIN_READ
         - OPENSEARCH_PASSWORD
         - OPENSEARCH_USERNAME
+        - OTLP_ENDPOINT
         - PSQL_DB
         - PSQL_HOST
         - PSQL_PASSWORD


### PR DESCRIPTION
## Summary

This PR solves #6538, therefore it also solves one of the prerequisites for #6545

## How did you test this change?

Locally. The changes provided by this PR are easy to verify.

## Are there any deployment considerations?

If the variable isn't defined or if it is empty, the code will proceed just as before and either use `http://collector:4318` on Docker Compose environments, or `http://localhost:4318` everywhere else.  
Hence, no adjustments are needed for pre-existing installations.

## Does this work require review from our design team?

No
