### PR TITLE
Improve GitHubstacktrace enhancement UI

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -404,6 +404,7 @@ type ComplexityRoot struct {
 		Payload              func(childComplexity int) int
 		ProjectID            func(childComplexity int) int
 		RequestID            func(childComplexity int) int
+		ServiceName          func(childComplexity int) int
 		ServiceVersion       func(childComplexity int) int
 		Session              func(childComplexity int) int
 		SessionID            func(childComplexity int) int
@@ -3383,6 +3384,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ErrorObject.RequestID(childComplexity), true
+
+	case "ErrorObject.serviceName":
+		if e.complexity.ErrorObject.ServiceName == nil {
+			break
+		}
+
+		return e.complexity.ErrorObject.ServiceName(childComplexity), true
 
 	case "ErrorObject.serviceVersion":
 		if e.complexity.ErrorObject.ServiceVersion == nil {
@@ -10137,6 +10145,7 @@ type ErrorObject {
 	environment: String
 	session: Session
 	serviceVersion: String
+	serviceName: String
 }
 
 type ErrorInstance {
@@ -27465,6 +27474,8 @@ func (ec *executionContext) fieldContext_ErrorInstance_error_object(ctx context.
 				return ec.fieldContext_ErrorObject_session(ctx, field)
 			case "serviceVersion":
 				return ec.fieldContext_ErrorObject_serviceVersion(ctx, field)
+			case "serviceName":
+				return ec.fieldContext_ErrorObject_serviceName(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorObject", field.Name)
 		},
@@ -29316,6 +29327,47 @@ func (ec *executionContext) _ErrorObject_serviceVersion(ctx context.Context, fie
 }
 
 func (ec *executionContext) fieldContext_ErrorObject_serviceVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ErrorObject",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ErrorObject_serviceName(ctx context.Context, field graphql.CollectedField, obj *model1.ErrorObject) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ErrorObject_serviceName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ServiceName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ErrorObject_serviceName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ErrorObject",
 		Field:      field,
@@ -44509,6 +44561,8 @@ func (ec *executionContext) fieldContext_Query_error_object(ctx context.Context,
 				return ec.fieldContext_ErrorObject_session(ctx, field)
 			case "serviceVersion":
 				return ec.fieldContext_ErrorObject_serviceVersion(ctx, field)
+			case "serviceName":
+				return ec.fieldContext_ErrorObject_serviceName(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorObject", field.Name)
 		},
@@ -44674,6 +44728,8 @@ func (ec *executionContext) fieldContext_Query_error_object_for_log(ctx context.
 				return ec.fieldContext_ErrorObject_session(ctx, field)
 			case "serviceVersion":
 				return ec.fieldContext_ErrorObject_serviceVersion(ctx, field)
+			case "serviceName":
+				return ec.fieldContext_ErrorObject_serviceName(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorObject", field.Name)
 		},
@@ -44903,6 +44959,8 @@ func (ec *executionContext) fieldContext_Query_errors(ctx context.Context, field
 				return ec.fieldContext_ErrorObject_session(ctx, field)
 			case "serviceVersion":
 				return ec.fieldContext_ErrorObject_serviceVersion(ctx, field)
+			case "serviceName":
+				return ec.fieldContext_ErrorObject_serviceName(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorObject", field.Name)
 		},
@@ -52790,6 +52848,8 @@ func (ec *executionContext) fieldContext_Query_logs_error_objects(ctx context.Co
 				return ec.fieldContext_ErrorObject_session(ctx, field)
 			case "serviceVersion":
 				return ec.fieldContext_ErrorObject_serviceVersion(ctx, field)
+			case "serviceName":
+				return ec.fieldContext_ErrorObject_serviceName(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorObject", field.Name)
 		},
@@ -60447,6 +60507,8 @@ func (ec *executionContext) fieldContext_SessionPayload_errors(ctx context.Conte
 				return ec.fieldContext_ErrorObject_session(ctx, field)
 			case "serviceVersion":
 				return ec.fieldContext_ErrorObject_serviceVersion(ctx, field)
+			case "serviceName":
+				return ec.fieldContext_ErrorObject_serviceName(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorObject", field.Name)
 		},
@@ -72274,6 +72336,10 @@ func (ec *executionContext) _ErrorObject(ctx context.Context, sel ast.SelectionS
 		case "serviceVersion":
 
 			out.Values[i] = ec._ErrorObject_serviceVersion(ctx, field, obj)
+
+		case "serviceName":
+
+			out.Values[i] = ec._ErrorObject_serviceName(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -474,7 +474,10 @@ type ComplexityRoot struct {
 
 	ErrorTrace struct {
 		ColumnNumber               func(childComplexity int) int
+		EnhancementSource          func(childComplexity int) int
+		EnhancementVersion         func(childComplexity int) int
 		Error                      func(childComplexity int) int
+		ExternalLink               func(childComplexity int) int
 		FileName                   func(childComplexity int) int
 		FunctionName               func(childComplexity int) int
 		LineContent                func(childComplexity int) int
@@ -3682,12 +3685,33 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ErrorTrace.ColumnNumber(childComplexity), true
 
+	case "ErrorTrace.enhancementSource":
+		if e.complexity.ErrorTrace.EnhancementSource == nil {
+			break
+		}
+
+		return e.complexity.ErrorTrace.EnhancementSource(childComplexity), true
+
+	case "ErrorTrace.enhancementVersion":
+		if e.complexity.ErrorTrace.EnhancementVersion == nil {
+			break
+		}
+
+		return e.complexity.ErrorTrace.EnhancementVersion(childComplexity), true
+
 	case "ErrorTrace.error":
 		if e.complexity.ErrorTrace.Error == nil {
 			break
 		}
 
 		return e.complexity.ErrorTrace.Error(childComplexity), true
+
+	case "ErrorTrace.externalLink":
+		if e.complexity.ErrorTrace.ExternalLink == nil {
+			break
+		}
+
+		return e.complexity.ErrorTrace.ExternalLink(childComplexity), true
 
 	case "ErrorTrace.fileName":
 		if e.complexity.ErrorTrace.FileName == nil {
@@ -10190,6 +10214,11 @@ type MatchedErrorObject {
 	score: Float!
 }
 
+enum EnhancementSource {
+	github
+	sourcemap
+}
+
 type ErrorTrace {
 	fileName: String
 	lineNumber: Int
@@ -10200,6 +10229,9 @@ type ErrorTrace {
 	lineContent: String
 	linesBefore: String
 	linesAfter: String
+	externalLink: String
+	enhancementSource: EnhancementSource
+	enhancementVersion: String
 }
 
 type SourceMappingError {
@@ -26466,6 +26498,12 @@ func (ec *executionContext) fieldContext_ErrorGroup_structured_stack_trace(ctx c
 				return ec.fieldContext_ErrorTrace_linesBefore(ctx, field)
 			case "linesAfter":
 				return ec.fieldContext_ErrorTrace_linesAfter(ctx, field)
+			case "externalLink":
+				return ec.fieldContext_ErrorTrace_externalLink(ctx, field)
+			case "enhancementSource":
+				return ec.fieldContext_ErrorTrace_enhancementSource(ctx, field)
+			case "enhancementVersion":
+				return ec.fieldContext_ErrorTrace_enhancementVersion(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorTrace", field.Name)
 		},
@@ -28842,6 +28880,12 @@ func (ec *executionContext) fieldContext_ErrorObject_structured_stack_trace(ctx 
 				return ec.fieldContext_ErrorTrace_linesBefore(ctx, field)
 			case "linesAfter":
 				return ec.fieldContext_ErrorTrace_linesAfter(ctx, field)
+			case "externalLink":
+				return ec.fieldContext_ErrorTrace_externalLink(ctx, field)
+			case "enhancementSource":
+				return ec.fieldContext_ErrorTrace_enhancementSource(ctx, field)
+			case "enhancementVersion":
+				return ec.fieldContext_ErrorTrace_enhancementVersion(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ErrorTrace", field.Name)
 		},
@@ -31102,6 +31146,129 @@ func (ec *executionContext) _ErrorTrace_linesAfter(ctx context.Context, field gr
 }
 
 func (ec *executionContext) fieldContext_ErrorTrace_linesAfter(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ErrorTrace",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ErrorTrace_externalLink(ctx context.Context, field graphql.CollectedField, obj *model.ErrorTrace) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ErrorTrace_externalLink(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ExternalLink, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ErrorTrace_externalLink(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ErrorTrace",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ErrorTrace_enhancementSource(ctx context.Context, field graphql.CollectedField, obj *model.ErrorTrace) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ErrorTrace_enhancementSource(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EnhancementSource, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.EnhancementSource)
+	fc.Result = res
+	return ec.marshalOEnhancementSource2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐEnhancementSource(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ErrorTrace_enhancementSource(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ErrorTrace",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type EnhancementSource does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ErrorTrace_enhancementVersion(ctx context.Context, field graphql.CollectedField, obj *model.ErrorTrace) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ErrorTrace_enhancementVersion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EnhancementVersion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ErrorTrace_enhancementVersion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ErrorTrace",
 		Field:      field,
@@ -72524,6 +72691,18 @@ func (ec *executionContext) _ErrorTrace(ctx context.Context, sel ast.SelectionSe
 
 			out.Values[i] = ec._ErrorTrace_linesAfter(ctx, field, obj)
 
+		case "externalLink":
+
+			out.Values[i] = ec._ErrorTrace_externalLink(ctx, field, obj)
+
+		case "enhancementSource":
+
+			out.Values[i] = ec._ErrorTrace_enhancementSource(ctx, field, obj)
+
+		case "enhancementVersion":
+
+			out.Values[i] = ec._ErrorTrace_enhancementVersion(ctx, field, obj)
+
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -86332,6 +86511,22 @@ func (ec *executionContext) marshalOEnhancedUserDetailsResult2ᚖgithubᚗcomᚋ
 		return graphql.Null
 	}
 	return ec._EnhancedUserDetailsResult(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOEnhancementSource2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐEnhancementSource(ctx context.Context, v interface{}) (*model.EnhancementSource, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(model.EnhancementSource)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOEnhancementSource2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐEnhancementSource(ctx context.Context, sel ast.SelectionSet, v *model.EnhancementSource) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) marshalOErrorAlert2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐErrorAlert(ctx context.Context, sel ast.SelectionSet, v *model1.ErrorAlert) graphql.Marshaler {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -359,6 +359,9 @@ type ErrorTrace struct {
 	LineContent                *string             `json:"lineContent"`
 	LinesBefore                *string             `json:"linesBefore"`
 	LinesAfter                 *string             `json:"linesAfter"`
+	ExternalLink               *string             `json:"externalLink"`
+	EnhancementSource          *EnhancementSource  `json:"enhancementSource"`
+	EnhancementVersion         *string             `json:"enhancementVersion"`
 }
 
 type GitHubRepo struct {
@@ -916,6 +919,47 @@ func (e *EmailOptOutCategory) UnmarshalGQL(v interface{}) error {
 }
 
 func (e EmailOptOutCategory) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type EnhancementSource string
+
+const (
+	EnhancementSourceGithub    EnhancementSource = "github"
+	EnhancementSourceSourcemap EnhancementSource = "sourcemap"
+)
+
+var AllEnhancementSource = []EnhancementSource{
+	EnhancementSourceGithub,
+	EnhancementSourceSourcemap,
+}
+
+func (e EnhancementSource) IsValid() bool {
+	switch e {
+	case EnhancementSourceGithub, EnhancementSourceSourcemap:
+		return true
+	}
+	return false
+}
+
+func (e EnhancementSource) String() string {
+	return string(e)
+}
+
+func (e *EnhancementSource) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = EnhancementSource(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid EnhancementSource", str)
+	}
+	return nil
+}
+
+func (e EnhancementSource) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -578,6 +578,11 @@ type MatchedErrorObject {
 	score: Float!
 }
 
+enum EnhancementSource {
+	github
+	sourcemap
+}
+
 type ErrorTrace {
 	fileName: String
 	lineNumber: Int
@@ -588,6 +593,9 @@ type ErrorTrace {
 	lineContent: String
 	linesBefore: String
 	linesAfter: String
+	externalLink: String
+	enhancementSource: EnhancementSource
+	enhancementVersion: String
 }
 
 type SourceMappingError {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -501,6 +501,7 @@ type ErrorObject {
 	environment: String
 	session: Session
 	serviceVersion: String
+	serviceName: String
 }
 
 type ErrorInstance {

--- a/backend/store/stacktraces.go
+++ b/backend/store/stacktraces.go
@@ -152,12 +152,17 @@ func (store *Store) EnhanceTraceWithGitHub(ctx context.Context, trace *privateMo
 		return nil, err
 	}
 
+	gitHubLink := fmt.Sprintf("https://github.com/%s/blob/%s%s#L%d", *service.GithubRepoPath, serviceVersion, fileName, *lineNumber)
+	enhancementSource := privateModel.EnhancementSourceGithub
 	newStackTraceInput := privateModel.ErrorTrace{
 		FileName:                   trace.FileName,
 		LineNumber:                 trace.LineNumber,
 		FunctionName:               trace.FunctionName,
 		Error:                      trace.Error,
 		SourceMappingErrorMetadata: trace.SourceMappingErrorMetadata,
+		EnhancementSource:          &enhancementSource,
+		EnhancementVersion:         &serviceVersion,
+		ExternalLink:               &gitHubLink,
 		LineContent:                lineContent,
 		LinesBefore:                beforeContent,
 		LinesAfter:                 afterContent,

--- a/frontend/src/components/LinkButton/index.tsx
+++ b/frontend/src/components/LinkButton/index.tsx
@@ -53,7 +53,8 @@ export const LinkButton: React.FC<Props> = ({
 					emphasis,
 				}),
 			)}
-			onClick={() => {
+			onClick={(e) => {
+				e.stopPropagation()
 				analytics.track(trackingId, trackingProperties)
 			}}
 		>

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -166,6 +166,7 @@ export const ErrorObjectFragmentDoc = gql`
 		browser
 		environment
 		serviceVersion
+		serviceName
 	}
 `
 export const ErrorTagFragmentDoc = gql`

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -140,6 +140,9 @@ export const ErrorObjectFragmentDoc = gql`
 			linesBefore
 			linesAfter
 			error
+			enhancementSource
+			enhancementVersion
+			externalLink
 			sourceMappingErrorMetadata {
 				errorCode
 				stackTraceFileURL

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2991,6 +2991,9 @@ export type ErrorObjectFragment = { __typename?: 'ErrorObject' } & Pick<
 					| 'linesBefore'
 					| 'linesAfter'
 					| 'error'
+					| 'enhancementSource'
+					| 'enhancementVersion'
+					| 'externalLink'
 				> & {
 						sourceMappingErrorMetadata?: Types.Maybe<
 							{ __typename?: 'SourceMappingError' } & Pick<

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2963,6 +2963,7 @@ export type ErrorObjectFragment = { __typename?: 'ErrorObject' } & Pick<
 	| 'browser'
 	| 'environment'
 	| 'serviceVersion'
+	| 'serviceName'
 > & {
 		session?: Types.Maybe<
 			{ __typename?: 'Session' } & Pick<

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -383,6 +383,11 @@ export type EnhancedUserDetailsResult = {
 	socials?: Maybe<Array<Maybe<SocialLink>>>
 }
 
+export enum EnhancementSource {
+	Github = 'github',
+	Sourcemap = 'sourcemap',
+}
+
 export type ErrorAlert = {
 	__typename?: 'ErrorAlert'
 	ChannelsToNotify: Array<Maybe<SanitizedSlackChannel>>
@@ -614,7 +619,10 @@ export type ErrorTag = {
 export type ErrorTrace = {
 	__typename?: 'ErrorTrace'
 	columnNumber?: Maybe<Scalars['Int']>
+	enhancementSource?: Maybe<EnhancementSource>
+	enhancementVersion?: Maybe<Scalars['String']>
 	error?: Maybe<Scalars['String']>
+	externalLink?: Maybe<Scalars['String']>
 	fileName?: Maybe<Scalars['String']>
 	functionName?: Maybe<Scalars['String']>
 	lineContent?: Maybe<Scalars['String']>

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -523,6 +523,7 @@ export type ErrorObject = {
 	payload?: Maybe<Scalars['String']>
 	project_id: Scalars['Int']
 	request_id?: Maybe<Scalars['String']>
+	serviceName?: Maybe<Scalars['String']>
 	serviceVersion?: Maybe<Scalars['String']>
 	session?: Maybe<Session>
 	session_id?: Maybe<Scalars['Int']>

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1150,6 +1150,9 @@ fragment ErrorObject on ErrorObject {
 		linesBefore
 		linesAfter
 		error
+		enhancementSource
+		enhancementVersion
+		externalLink
 		sourceMappingErrorMetadata {
 			errorCode
 			stackTraceFileURL

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1176,6 +1176,7 @@ fragment ErrorObject on ErrorObject {
 	browser
 	environment
 	serviceVersion
+	serviceName
 }
 
 query GetErrorObject($id: ID!) {

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -242,6 +242,7 @@ const Metadata: React.FC<{
 		{ key: 'environment', label: errorObject?.environment },
 		{ key: 'browser', label: errorObject?.browser },
 		{ key: 'os', label: errorObject?.os },
+		{ key: 'service', label: errorObject?.serviceName },
 		{ key: 'version', label: errorObject?.serviceVersion },
 		{ key: 'url', label: errorObject?.url },
 		{ key: 'timestamp', label: errorObject?.timestamp },

--- a/frontend/src/pages/ErrorsV2/ErrorSourcePreview/ErrorSourcePreview.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorSourcePreview/ErrorSourcePreview.tsx
@@ -10,6 +10,9 @@ type ErrorSourcePreviewProps = {
 	lineNumber?: StackSectionProps['lineNumber']
 	columnNumber?: StackSectionProps['columnNumber']
 	functionName?: StackSectionProps['functionName']
+	enhancementSource?: StackSectionProps['enhancementSource']
+	enhancementVersion?: StackSectionProps['enhancementVersion']
+	externalLink?: StackSectionProps['externalLink']
 	linesBefore?: StackSectionProps['linesBefore']
 	linesAfter?: StackSectionProps['linesAfter']
 	showLineNumbers?: boolean


### PR DESCRIPTION
## Summary
Improve the UI of the stacktraces when enhanced with GitHub to:
- show user stacktrace was enhanced with GitHub
- show version used to enhance GitHub
- Add link to file in GitHub

Next steps:
- documentation
- call out for setting up GitHub enhanced stacktraces

## How did you test this change?
https://www.loom.com/share/06acd075d9304ee0b3972f83be8d54fb?sid=dae2f570-740a-46e3-8d53-6cfd2aa2c6b9

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
No - https://www.figma.com/file/rdBPNzn7Klk6RG1LHUCE5B/Screen-Designs?type=design&node-id=11353-341142&mode=design&t=asncmzI0KAT02ukl-0
