### PR TITLE
Fix stacktrace tooltip

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -219,7 +219,7 @@ const StackSection: React.FC<React.PropsWithChildren<StackSectionProps>> = ({
 					linesAfter={linesAfter}
 				/>
 			) : (
-				<Text family="monospace" as="div" display="inline-flex">
+				<Text family="monospace" as="div" display="flex">
 					<Box
 						as="span"
 						cssClass={styles.lineNumber}

--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -219,7 +219,7 @@ const StackSection: React.FC<React.PropsWithChildren<StackSectionProps>> = ({
 					linesAfter={linesAfter}
 				/>
 			) : (
-				<Text family="monospace" as="div">
+				<Text family="monospace" as="div" display="inline-flex">
 					<Box
 						as="span"
 						cssClass={styles.lineNumber}


### PR DESCRIPTION
## Summary
UI component tooltip swap causes the function and line number to render on different lines

See https://app.highlight.io/1/sessions/HojiAyriw9l4eE7Q7JWPowdlKswl?commentId=12451&page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue%7C%7Ccustom_created_at%2Cbetween_date%2C2023-08-08T20%3A00%3A05.339Z_2023-09-07T20%3A00%3A05.339Z&ts=3.478

## How did you test this change?
1. View an error that has not been enhanced
- [ ] Line number and function rendered in line
- [ ] Tooltip rendered in correct location

![Screenshot 2023-09-07 at 4 26 34 PM](https://github.com/highlight/highlight/assets/17744174/fd3b7d76-d3db-4bce-baee-4bf6eb61592f)

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
