### PR TITLE
remove hubspot retry looping

### DIFF
--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -489,7 +489,7 @@ func (h *Client) updateWorkspaceHubspotCompanyID(ctx context.Context, workspace 
 	}
 	workspace.HubspotCompanyID = hubspotCompanyId
 	err := fn(workspace.HubspotCompanyID)
-	// clear the admin hubspot contact id if it is not correct
+	// clear the workspace hubspot company id if it is not correct
 	if err != nil {
 		h.db.Model(&model.Workspace{Model: model.Model{ID: workspace.ID}}).Select("hubspot_company_id").Updates(&model.Workspace{})
 		workspace.HubspotCompanyID = nil

--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -5,9 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"io"
-	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -22,13 +20,13 @@ import (
 	"github.com/leonelquinteros/hubspot"
 	"github.com/openlyinc/pointy"
 	e "github.com/pkg/errors"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
 const PartitionKey = "hubspot"
-const Retries = 5
 
 // ClientSideContactCreationTimeout is the time we will wait for the object to be created by the hubspot client-side snippet
 const ClientSideContactCreationTimeout = time.Minute
@@ -44,8 +42,6 @@ const ClientSideAssociationTimeout = 3 * ClientSideContactCreationTimeout
 
 const ClientSideCreationPollInterval = 5 * time.Second
 
-const DefaultLockTimeout = 15 * time.Second
-
 var (
 	OAuthToken = os.Getenv("HUBSPOT_OAUTH_TOKEN")
 	APIKey     = os.Getenv("HUBSPOT_API_KEY")
@@ -55,19 +51,8 @@ var (
 	CSRFToken = os.Getenv("HUBSPOT_CSRF_TOKEN")
 )
 
-func retry[T any](fn func() (T, error)) (ret T, err error) {
-	for i := 0; i < Retries; i++ {
-		ret, err = fn()
-		if err == nil {
-			return
-		}
-		time.Sleep(16 * time.Millisecond * time.Duration(math.Pow(2, float64(i))))
-	}
-	return
-}
-
 func pollHubspot[T any](fn func() (*T, error), timeout time.Duration) (result *T, err error) {
-	span := tracer.StartSpan("hubspot.pollHubspot")
+	span := tracer.StartSpan("pollHubspot", tracer.ResourceName("hubspot"), tracer.Tag("timeout", timeout))
 	defer span.Finish()
 	start := time.Now()
 	ticker := time.NewTicker(ClientSideCreationPollInterval)
@@ -314,8 +299,8 @@ func (h *Client) mergeContacts(keepID, mergeID int) error {
 }
 
 func (h *Client) getAllCompanies(ctx context.Context) (companies []*CompanyResponse, err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "hubspot.getAllCompanies")
-	defer span.Finish()
+	span := tracer.StartSpan("getAllCompanies", tracer.ResourceName("hubspot"))
+	defer span.Finish(tracer.WithError(err))
 	if h.redisClient != nil {
 		err = h.redisClient.GetHubspotCompanies(ctx, &companies)
 		if err == nil && len(companies) > 0 {
@@ -342,57 +327,65 @@ func (h *Client) getAllCompanies(ctx context.Context) (companies []*CompanyRespo
 }
 
 func (h *Client) getCompany(ctx context.Context, name, domain string) (*int, error) {
-	r := struct {
-		Results []struct {
-			CompanyId int `json:"companyId"`
-		} `json:"results"`
-	}{}
-	body, _ := json.Marshal(struct {
-		Limit          int `json:"limit"`
-		RequestOptions struct {
+	span := tracer.StartSpan("getCompany", tracer.ResourceName("hubspot"))
+	defer span.Finish()
+	return redis.CachedEval(ctx, h.redisClient, fmt.Sprintf("hubspot-company-%s-%s", name, domain), time.Second, ClientSideContactCreationTimeout/4, func() (*int, error) {
+		r := struct {
+			Results []struct {
+				CompanyId int `json:"companyId"`
+			} `json:"results"`
+		}{}
+		body, _ := json.Marshal(struct {
+			Limit          int `json:"limit"`
+			RequestOptions struct {
+				Properties []string `json:"properties"`
+			} `json:"requestOptions"`
+		}{100, struct {
 			Properties []string `json:"properties"`
-		} `json:"requestOptions"`
-	}{100, struct {
-		Properties []string `json:"properties"`
-	}{[]string{"domain", "name", "createdate", "hs_lastmodifieddate"}}})
-	err := h.doRequest(fmt.Sprintf("/companies/v2/domains/%s/companies", domain), &r, nil, "POST", bytes.NewReader(body))
-	if err == nil && len(r.Results) > 0 {
-		return pointy.Int(r.Results[0].CompanyId), nil
-	}
+		}{[]string{"domain", "name", "createdate", "hs_lastmodifieddate"}}})
+		err := h.doRequest(fmt.Sprintf("/companies/v2/domains/%s/companies", domain), &r, nil, "POST", bytes.NewReader(body))
+		if err == nil && len(r.Results) > 0 {
+			return pointy.Int(r.Results[0].CompanyId), nil
+		}
 
-	if name == "" {
-		return nil, e.New(fmt.Sprintf("failed to find company based on domain alone %s", domain))
-	}
+		if name == "" {
+			return nil, e.New(fmt.Sprintf("failed to find company based on domain alone %s", domain))
+		}
 
-	companies, err := h.getAllCompanies(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var nameCompany *CompanyResponse
-	for _, company := range companies {
-		for prop, data := range company.Properties {
-			if prop == "name" {
-				if strings.EqualFold(data.Value, name) {
-					nameCompany = company
+		companies, err := h.getAllCompanies(ctx)
+		if err != nil {
+			return nil, err
+		}
+		var nameCompany *CompanyResponse
+		for _, company := range companies {
+			for prop, data := range company.Properties {
+				if prop == "name" {
+					if strings.EqualFold(data.Value, name) {
+						nameCompany = company
+					}
 				}
 			}
 		}
-	}
-	if nameCompany != nil {
-		log.WithContext(ctx).WithField("name", name).WithField("domain", "domain").WithField("company_id", nameCompany.CompanyID).Info("hubspot found company based on name")
-		return pointy.Int(nameCompany.CompanyID), nil
-	} else {
-		return nil, e.New(fmt.Sprintf("failed to find company with name %s domain %s", name, domain))
-	}
+		if nameCompany != nil {
+			log.WithContext(ctx).WithField("name", name).WithField("domain", "domain").WithField("company_id", nameCompany.CompanyID).Info("hubspot found company based on name")
+			return pointy.Int(nameCompany.CompanyID), nil
+		} else {
+			return nil, e.New(fmt.Sprintf("failed to find company with name %s domain %s", name, domain))
+		}
+	})
 }
 
-func (h *Client) getContactForAdmin(email string) (contactId *int, err error) {
-	r := CustomContactsResponse{}
-	if err := h.hubspotClient.Contacts().Client.Request("GET", "/contacts/v1/contact/email/"+email+"/profile", nil, &r); err != nil {
-		return nil, err
-	} else {
-		return pointy.Int(r.Vid), nil
-	}
+func (h *Client) getContactForAdmin(ctx context.Context, email string) (contactId *int, err error) {
+	span := tracer.StartSpan("getContactForAdmin", tracer.ResourceName("hubspot"))
+	defer span.Finish(tracer.WithError(err))
+	return redis.CachedEval(ctx, h.redisClient, fmt.Sprintf("hubspot-email-%s", email), time.Second, ClientSideContactCreationTimeout/4, func() (*int, error) {
+		r := CustomContactsResponse{}
+		if err = h.hubspotClient.Contacts().Client.Request("GET", "/contacts/v1/contact/email/"+email+"/profile", nil, &r); err != nil {
+			return nil, err
+		} else {
+			return pointy.Int(r.Vid), nil
+		}
+	})
 }
 
 func (h *Client) createContactForAdmin(ctx context.Context, email string, userDefinedRole, userDefinedPersona, userDefinedTeamSize string, first string, last string, phone string, referral string) (contactId *int, err error) {
@@ -442,7 +435,7 @@ func (h *Client) createContactForAdmin(ctx context.Context, email string, userDe
 		},
 	}); err != nil {
 		// If there's an error creating the contact, assume its a conflict and try to get the existing user.
-		if contact, err := h.getContactForAdmin(email); err == nil {
+		if contact, err := h.getContactForAdmin(ctx, email); err == nil {
 			return contact, nil
 		}
 	} else {
@@ -453,48 +446,42 @@ func (h *Client) createContactForAdmin(ctx context.Context, email string, userDe
 	return &hubspotContactId, nil
 }
 
-func (h *Client) updateAdminHubspotContactID(admin *model.Admin, fn func(hubspotContactID *int) error) error {
+func (h *Client) updateAdminHubspotContactID(ctx context.Context, admin *model.Admin, fn func(hubspotContactID *int) error) error {
 	hubspotContactID := admin.HubspotContactID
-	_, err := retry(func() (*int, error) {
-		if ptr.ToInt(hubspotContactID) == 0 {
-			var err error
-			hubspotContactID, err = h.getContactForAdmin(ptr.ToString(admin.Email))
-			if err != nil {
-				return nil, err
-			}
-			err = h.db.Model(&model.Admin{Model: model.Model{ID: admin.ID}}).Updates(&model.Admin{HubspotContactID: hubspotContactID}).Error
-			if err != nil {
-				return nil, err
-			}
+	if ptr.ToInt(hubspotContactID) == 0 {
+		var err error
+		hubspotContactID, err = h.getContactForAdmin(ctx, ptr.ToString(admin.Email))
+		if err != nil {
+			return err
 		}
-		admin.HubspotContactID = hubspotContactID
-		return nil, fn(hubspotContactID)
-	})
-	return err
+		err = h.db.Model(&model.Admin{Model: model.Model{ID: admin.ID}}).Updates(&model.Admin{HubspotContactID: hubspotContactID}).Error
+		if err != nil {
+			return err
+		}
+	}
+	admin.HubspotContactID = hubspotContactID
+	return fn(hubspotContactID)
 }
 
 func (h *Client) updateWorkspaceHubspotCompanyID(ctx context.Context, workspace *model.Workspace, fn func(hubspotCompanyID *int) error) error {
 	hubspotCompanyId := workspace.HubspotCompanyID
-	_, err := retry(func() (*int, error) {
-		if ptr.ToInt(hubspotCompanyId) == 0 {
-			var err error
-			var domain string
-			if len(workspace.Admins) > 0 {
-				domain = getDomain(ptr.ToString(workspace.Admins[0].Email))
-			}
-			hubspotCompanyId, err = h.getCompany(ctx, ptr.ToString(workspace.Name), domain)
-			if err != nil {
-				return nil, err
-			}
-			err = h.db.Model(&model.Workspace{Model: model.Model{ID: workspace.ID}}).Updates(&model.Workspace{HubspotCompanyID: hubspotCompanyId}).Error
-			if err != nil {
-				return nil, err
-			}
+	if ptr.ToInt(hubspotCompanyId) == 0 {
+		var err error
+		var domain string
+		if len(workspace.Admins) > 0 {
+			domain = getDomain(ptr.ToString(workspace.Admins[0].Email))
 		}
-		workspace.HubspotCompanyID = hubspotCompanyId
-		return nil, fn(hubspotCompanyId)
-	})
-	return err
+		hubspotCompanyId, err = h.getCompany(ctx, ptr.ToString(workspace.Name), domain)
+		if err != nil {
+			return err
+		}
+		err = h.db.Model(&model.Workspace{Model: model.Model{ID: workspace.ID}}).Updates(&model.Workspace{HubspotCompanyID: hubspotCompanyId}).Error
+		if err != nil {
+			return err
+		}
+	}
+	workspace.HubspotCompanyID = hubspotCompanyId
+	return fn(hubspotCompanyId)
 }
 
 func (h *Client) CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int) error {
@@ -508,22 +495,13 @@ func (h *Client) CreateContactCompanyAssociation(ctx context.Context, adminID in
 }
 
 func (h *Client) CreateContactCompanyAssociationImpl(ctx context.Context, adminID int, workspaceID int) error {
-	key := fmt.Sprintf("hubspot-CreateContactCompanyAssociationImpl-%d-%d", adminID, workspaceID)
-	if mutex, err := h.redisClient.AcquireLock(ctx, key, ClientSideAssociationTimeout); err == nil {
-		defer func() {
-			if _, err := mutex.Unlock(); err != nil {
-				log.WithContext(ctx).WithError(err).WithField("key", key).Error("failed to release hubspot lock")
-			}
-		}()
-	}
-
 	data, err := pollHubspot(func() (*struct{ companyID, contactID int }, error) {
 		admin := &model.Admin{}
 		if err := h.db.Model(&model.Admin{}).Where("id = ?", adminID).Take(&admin).Error; err != nil {
 			return nil, err
 		}
 
-		if err := h.updateAdminHubspotContactID(admin, func(hubspotContactID *int) error {
+		if err := h.updateAdminHubspotContactID(ctx, admin, func(hubspotContactID *int) error {
 			return h.db.Model(&model.Admin{Model: model.Model{ID: adminID}}).Updates(&model.Admin{HubspotContactID: hubspotContactID}).Error
 		}); err != nil {
 			return nil, e.New("failed to update hubspot contact id")
@@ -592,25 +570,13 @@ func (h *Client) CreateContactForAdmin(ctx context.Context, adminID int, email s
 }
 
 func (h *Client) CreateContactForAdminImpl(ctx context.Context, adminID int, email string, userDefinedRole, userDefinedPersona, userDefinedTeamSize string, first string, last string, phone string, referral string) (contactId *int, err error) {
-	key := fmt.Sprintf("hubspot-CreateContactForAdminImpl-%d", adminID)
-	if mutex, err := h.redisClient.AcquireLock(ctx, key, ClientSideContactCreationTimeout); err == nil {
-		defer func() {
-			if _, err := mutex.Unlock(); err != nil {
-				log.WithContext(ctx).WithError(err).WithField("key", key).Error("failed to release hubspot lock")
-			}
-		}()
-	}
-
 	if contactId, err = pollHubspot(func() (*int, error) {
-		return h.getContactForAdmin(email)
+		return h.getContactForAdmin(ctx, email)
 	}, ClientSideContactCreationTimeout); contactId == nil {
 		log.WithContext(ctx).
 			WithField("email", email).
 			Warnf("failed to get client-side hubspot contact. creating")
-		contactId, err = retry(func() (*int, error) {
-			return h.createContactForAdmin(ctx, email, userDefinedRole, userDefinedPersona, userDefinedTeamSize, first, last, phone, referral)
-		})
-
+		contactId, err = h.createContactForAdmin(ctx, email, userDefinedRole, userDefinedPersona, userDefinedTeamSize, first, last, phone, referral)
 		if err != nil || contactId == nil {
 			return nil, err
 		}
@@ -636,15 +602,6 @@ func (h *Client) CreateCompanyForWorkspace(ctx context.Context, workspaceID int,
 }
 
 func (h *Client) CreateCompanyForWorkspaceImpl(ctx context.Context, workspaceID int, adminEmail, name string) (companyID *int, err error) {
-	key := fmt.Sprintf("hubspot-CreateCompanyForWorkspaceImpl-%d-%s-%s", workspaceID, adminEmail, name)
-	if mutex, err := h.redisClient.AcquireLock(ctx, key, ClientSideCompanyCreationTimeout); err == nil {
-		defer func() {
-			if _, err := mutex.Unlock(); err != nil {
-				log.WithContext(ctx).WithError(err).WithField("key", key).Error("failed to release hubspot lock")
-			}
-		}()
-	}
-
 	// Don't create for Demo account
 	if workspaceID == 0 {
 		return
@@ -716,21 +673,12 @@ func (h *Client) UpdateContactProperty(ctx context.Context, adminID int, propert
 }
 
 func (h *Client) UpdateContactPropertyImpl(ctx context.Context, adminID int, properties []hubspot.Property) error {
-	key := fmt.Sprintf("hubspot-UpdateContactPropertyImpl-%d", adminID)
-	if mutex, err := h.redisClient.AcquireLock(ctx, key, DefaultLockTimeout); err == nil {
-		defer func() {
-			if _, err := mutex.Unlock(); err != nil {
-				log.WithContext(ctx).WithError(err).WithField("key", key).Error("failed to release hubspot lock")
-			}
-		}()
-	}
-
 	admin := &model.Admin{}
 	if err := h.db.Model(&model.Admin{}).Where("id = ?", adminID).Take(&admin).Error; err != nil {
 		return err
 	}
 
-	return h.updateAdminHubspotContactID(admin, func(hubspotContactID *int) error {
+	return h.updateAdminHubspotContactID(ctx, admin, func(hubspotContactID *int) error {
 		return h.hubspotClient.Contacts().Update(ptr.ToInt(hubspotContactID), hubspot.ContactsRequest{
 			Properties: properties,
 		})
@@ -748,15 +696,6 @@ func (h *Client) UpdateCompanyProperty(ctx context.Context, workspaceID int, pro
 }
 
 func (h *Client) UpdateCompanyPropertyImpl(ctx context.Context, workspaceID int, properties []hubspot.Property) error {
-	key := fmt.Sprintf("hubspot-UpdateCompanyPropertyImpl-%d", workspaceID)
-	if mutex, err := h.redisClient.AcquireLock(ctx, key, DefaultLockTimeout); err == nil {
-		defer func() {
-			if _, err := mutex.Unlock(); err != nil {
-				log.WithContext(ctx).WithError(err).WithField("key", key).Error("failed to release hubspot lock")
-			}
-		}()
-	}
-
 	workspace := &model.Workspace{}
 	if err := h.db.Model(&model.Workspace{}).Preload("Admins").Where("id = ?", workspaceID).Take(&workspace).Error; err != nil {
 		return err

--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -460,7 +460,14 @@ func (h *Client) updateAdminHubspotContactID(ctx context.Context, admin *model.A
 		}
 	}
 	admin.HubspotContactID = hubspotContactID
-	return fn(hubspotContactID)
+	err := fn(admin.HubspotContactID)
+	// clear the admin hubspot contact id if it is not correct
+	if err != nil {
+		h.db.Model(&model.Admin{Model: model.Model{ID: admin.ID}}).Select("hubspot_contact_id").Updates(&model.Admin{})
+		admin.HubspotContactID = nil
+		return err
+	}
+	return err
 }
 
 func (h *Client) updateWorkspaceHubspotCompanyID(ctx context.Context, workspace *model.Workspace, fn func(hubspotCompanyID *int) error) error {
@@ -481,7 +488,14 @@ func (h *Client) updateWorkspaceHubspotCompanyID(ctx context.Context, workspace 
 		}
 	}
 	workspace.HubspotCompanyID = hubspotCompanyId
-	return fn(hubspotCompanyId)
+	err := fn(workspace.HubspotCompanyID)
+	// clear the admin hubspot contact id if it is not correct
+	if err != nil {
+		h.db.Model(&model.Workspace{Model: model.Model{ID: workspace.ID}}).Select("hubspot_company_id").Updates(&model.Workspace{})
+		workspace.HubspotCompanyID = nil
+		return err
+	}
+	return err
 }
 
 func (h *Client) CreateContactCompanyAssociation(ctx context.Context, adminID int, workspaceID int) error {


### PR DESCRIPTION
## Summary

* Remove locking since all hubspot tasks are processed serially (same partition key).
* Remove retry logic here since the tasks are retried at the kafka level.
* Add redis caching to slow hubspot requests (`getContact` and `getCompany`)

## How did you test this change?

hubspot tasks are slow with a bunch of retries to fetching contacts
![image](https://github.com/highlight/highlight/assets/1351531/123ee431-85ac-4bc6-b30c-101f6e95ebb5)
![image](https://github.com/highlight/highlight/assets/1351531/1e2602eb-5354-47b5-9335-afd5bd94b43f)
![image](https://github.com/highlight/highlight/assets/1351531/1bf1562b-9b95-4756-a342-9bae5b84a634)

setting invalid hubspot ids locally, then checking they are reset 
![image](https://github.com/highlight/highlight/assets/1351531/4fef843d-ec77-4de9-96d6-7c4ffa65b882)

![image](https://github.com/highlight/highlight/assets/1351531/861bef3c-97bb-48e1-81ec-1df5aba3058b)

![image](https://github.com/highlight/highlight/assets/1351531/3f133129-1c51-449d-9733-ad41efd1d732)
turned into
![image](https://github.com/highlight/highlight/assets/1351531/34f0e91b-97b2-4661-8894-ee2097e25e3a)

![Screenshot from 2023-09-07 14-57-49](https://github.com/highlight/highlight/assets/1351531/f7388a9d-15ee-4589-9615-8b3d3617b722)
![image](https://github.com/highlight/highlight/assets/1351531/94655f27-29b8-43b4-9a7d-b436016da16c)


## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
