### PR TITLE
update license of npm packages based on repo license

### DIFF
--- a/experiments/performance/package.json
+++ b/experiments/performance/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"version": "1.0.0",
 	"main": "index.js",
-	"license": "MIT",
+	"license": "Apache-2.0",
 	"dependencies": {
 		"playwright": "^1.22.2"
 	}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"version": "1.0.0",
 	"repository": "git@github.com:highlight-run/highlight.git",
 	"author": "Highlight",
-	"license": "MIT",
+	"license": "Apache-2.0",
 	"workspaces": [
 		"docs-content",
 		"e2e/*",

--- a/sdk/client/package.json
+++ b/sdk/client/package.json
@@ -25,7 +25,7 @@
 	},
 	"keywords": [],
 	"author": "",
-	"license": "ISC",
+	"license": "Apache-2.0",
 	"bugs": {
 		"url": "https://github.com/highlight-run/highlight/issues"
 	},

--- a/sdk/highlight-apollo/package.json
+++ b/sdk/highlight-apollo/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@highlight-run/apollo",
 	"version": "3.3.0",
-	"license": "MIT",
+	"license": "Apache-2.0",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",

--- a/sdk/highlight-nest/package.json
+++ b/sdk/highlight-nest/package.json
@@ -17,7 +17,7 @@
 		"build": "tsup src/index.ts --format cjs,esm --dts"
 	},
 	"author": "",
-	"license": "MIT",
+	"license": "Apache-2.0",
 	"peerDependencies": {
 		"@nestjs/core": ">=8",
 		"rxjs": ">=7"

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -39,7 +39,7 @@
 		"test": "jest"
 	},
 	"author": "",
-	"license": "ISC",
+	"license": "Apache-2.0",
 	"peerDependencies": {
 		"@highlight-run/node": "workspace:^",
 		"highlight.run": "workspace:^",

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@highlight-run/node",
 	"version": "3.3.0",
-	"license": "MIT",
+	"license": "Apache-2.0",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",

--- a/sdk/highlight-react/package.json
+++ b/sdk/highlight-react/package.json
@@ -2,7 +2,7 @@
 	"name": "@highlight-run/react",
 	"version": "3.2.1",
 	"description": "The official Highlight SDK for React",
-	"license": "MIT",
+	"license": "Apache-2.0",
 	"peerDependencies": {
 		"react": ">=16",
 		"react-dom": ">=16"

--- a/sourcemap-uploader/package.json
+++ b/sourcemap-uploader/package.json
@@ -4,7 +4,7 @@
   "description": "Command line tool to upload source maps to Highlight",
   "bin": "./dist/index.js",
   "author": "Highlight",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Our npm packages had inconsistent `license` values that differed from the repo `LICENCE.md`

## How did you test this change?

N/A

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A