### PR TITLE
update kafka rack names

### DIFF
--- a/backend/kafka-queue/aws.go
+++ b/backend/kafka-queue/aws.go
@@ -9,6 +9,12 @@ import (
 	"time"
 )
 
+var availabilityZoneMap = map[string]string{
+	"us-east-2a": "use2-az1",
+	"us-east-2b": "use2-az2",
+	"us-east-2c": "use2-az3",
+}
+
 // findRack is the basic rack resolver strategy for use in AWS.  It supports
 //   - ECS with the task metadata endpoint enabled (returns the container
 //     instance's availability zone)
@@ -55,5 +61,6 @@ func ecsAvailabilityZone() string {
 	if err := json.NewDecoder(r.Body).Decode(&md); err != nil {
 		return ""
 	}
-	return md.AvailabilityZone
+	// AWS MSK sets the `broker.rack` to AZ IDs rather than AZ names
+	return availabilityZoneMap[md.AvailabilityZone]
 }


### PR DESCRIPTION
## Summary

Our rack naming from the AWS ECS metadata endpoint would return an `AvailabilityZone` value of  `us-east-2c`
However, AWS MSK sets the `broker.rack` to availability zone IDs, like `use2-az3`.

```bash
[ec2-user@ip-YYY bin]$ ./kafka-configs.sh --broker 1 --all --describe --bootstrap-server XXX.amazonaws.com:9096 --command-config client.properties | grep rack
  broker.rack=use2-az3 sensitive=false synonyms={STATIC_BROKER_CONFIG:broker.rack=use2-az3}
```

## How did you test this change?

N/A

## Are there any deployment considerations?

Will monitor deploy and then the network transfer costs in ECS

## Does this work require review from our design team?

No
