### PR TITLE
[hotfix] Forms using getState to access values incorrectly

### DIFF
--- a/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
+++ b/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
@@ -401,7 +401,7 @@ export const ErrorAlertPage = () => {
 
 const ErrorAlertForm = () => {
 	const formStore = useForm() as FormState<ErrorAlertFormItem>
-	const formState = formStore.getState()
+	const errors = formStore.useState('errors')
 
 	const { alertsPayload } = useAlertsContext()
 	const environments = dedupeEnvironments(
@@ -461,7 +461,7 @@ const ErrorAlertForm = () => {
 									/>
 								}
 								style={{
-									borderColor: formState.errors.threshold
+									borderColor: errors.threshold
 										? 'var(--color-red-500)'
 										: undefined,
 								}}
@@ -550,11 +550,10 @@ const ErrorAlertForm = () => {
 }
 
 const ThresholdTypeConfiguration = () => {
-	const form = useForm() as FormState<ErrorAlertFormItem>
-	const formState = form.getState()
+	const formStore = useForm() as FormState<ErrorAlertFormItem>
+	const belowThreshold = formStore.useValue('belowThreshold')
 	const menu = useMenu()
 	const menuState = menu.getState()
-	const belowThreshold = formState.values.belowThreshold
 	return (
 		<>
 			<Menu.Button
@@ -575,14 +574,14 @@ const ThresholdTypeConfiguration = () => {
 			<Menu.List>
 				<Menu.Item
 					onClick={() => {
-						form.setValue('belowThreshold', false)
+						formStore.setValue('belowThreshold', false)
 					}}
 				>
 					Above threshold
 				</Menu.Item>
 				<Menu.Item
 					onClick={() => {
-						form.setValue('belowThreshold', true)
+						formStore.setValue('belowThreshold', true)
 					}}
 				>
 					Below threshold

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -493,7 +493,7 @@ export const LogAlertPage = () => {
 const LogAlertForm = () => {
 	const { projectId } = useProjectId()
 	const formStore = useForm() as Ariakit.FormStore<LogMonitorForm>
-	const formState = formStore.getState()
+	const errors = formStore.useState('errors')
 
 	const { alertsPayload } = useLogAlertsContext()
 	const { slackLoading, syncSlack } = useSlackSync()
@@ -563,7 +563,7 @@ const LogAlertForm = () => {
 									/>
 								}
 								style={{
-									borderColor: formState.errors.threshold
+									borderColor: errors.threshold
 										? 'var(--color-red-500)'
 										: undefined,
 								}}

--- a/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
+++ b/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
@@ -109,7 +109,7 @@ export const SessionAlertPage = () => {
 			loaded: false,
 		},
 	})
-	const formState = formStore.getState()
+	const values = formStore.useState('values')
 
 	useEffect(() => {
 		if (alert) {
@@ -238,24 +238,22 @@ export const SessionAlertPage = () => {
 								formStore.names.threshold,
 							),
 							disabled: false,
-							discord_channels:
-								formState.values.discordChannels.map((c) => ({
+							discord_channels: values.discordChannels.map(
+								(c) => ({
 									name: c.name,
 									id: c.id,
-								})),
+								}),
+							),
 							emails: formStore.getValue(formStore.names.emails),
 							environments: formStore.getValue(
 								formStore.names.excludedEnvironments,
 							),
 							name: formStore.getValue(formStore.names.name),
 							project_id: project_id || '0',
-							slack_channels: formState.values.slackChannels.map(
-								(c) => ({
-									webhook_channel_id: c.webhook_channel_id,
-									webhook_channel_name:
-										c.webhook_channel_name,
-								}),
-							),
+							slack_channels: values.slackChannels.map((c) => ({
+								webhook_channel_id: c.webhook_channel_id,
+								webhook_channel_name: c.webhook_channel_name,
+							})),
 							webhook_destinations: formStore
 								.getValue(formStore.names.webhookDestinations)
 								.map((d: string) => ({ url: d })),
@@ -381,7 +379,7 @@ export const SessionAlertPage = () => {
 		</Box>
 	)
 
-	const isLoading = !isCreate && !formState.values.loaded
+	const isLoading = !isCreate && !values.loaded
 
 	return (
 		<Box width="full" background="raised" p="8">
@@ -502,7 +500,7 @@ const SessionAlertForm = ({
 	configuration: AlertConfiguration
 }) => {
 	const formStore = useForm() as FormState<SessionAlertFormItem>
-	const formState = formStore.getState()
+	const errors = formStore.useState('errors')
 	const { project_id } = useParams<{
 		project_id: string
 	}>()
@@ -626,8 +624,7 @@ const SessionAlertForm = ({
 											/>
 										}
 										style={{
-											borderColor: formState.errors
-												.threshold
+											borderColor: errors.threshold
 												? 'var(--color-red-500)'
 												: undefined,
 										}}
@@ -636,17 +633,7 @@ const SessionAlertForm = ({
 								<Column>
 									<Form.Select
 										label="Alert threshold window"
-										name={formStore.names.threshold_window.toString()}
-										value={
-											formState.values.threshold_window
-										}
-										onChange={(e) =>
-											formStore.setValue(
-												formStore.names
-													.threshold_window,
-												e.target.value,
-											)
-										}
+										name={formStore.names.threshold_window}
 									>
 										<option value="" disabled>
 											Select alert threshold window
@@ -769,10 +756,9 @@ const SessionAlertForm = ({
 
 const ThresholdTypeConfiguration = () => {
 	const formStore = useForm()
-	const formState = formStore.getState()
+	const belowThreshold = formStore.useValue('belowThreshold')
 	const menuStore = useMenu()
 	const menuState = menuStore.getState()
-	const belowThreshold = formState.values.belowThreshold
 	return (
 		<>
 			<Menu.Button

--- a/frontend/src/pages/Alerts/components/AlertTitleField/AlertTitleField.tsx
+++ b/frontend/src/pages/Alerts/components/AlertTitleField/AlertTitleField.tsx
@@ -6,14 +6,14 @@ import * as styles from './styles.css'
 
 const AlertTitleField = () => {
 	const formStore = useForm() as FormState<AlertForm>
-	const formState = formStore.getState()
+	const errors = formStore.useState('errors')
 
 	return (
 		<Form.Input
 			name={formStore.names.name}
 			placeholder="Type name..."
 			style={{
-				borderColor: formState.errors.name
+				borderColor: errors.name
 					? 'var(--color-red-500)'
 					: 'transparent',
 			}}

--- a/frontend/src/pages/Auth/AdminForm.tsx
+++ b/frontend/src/pages/Auth/AdminForm.tsx
@@ -47,6 +47,7 @@ enum TeamSize {
 
 export const AdminForm: React.FC = () => {
 	const [showPromoCodeField, setShowPromoCodeField] = useState(false)
+	const [error, setError] = useState('')
 	const { setLoadingState } = useAppLoadingContext()
 	const { admin, fetchAdmin } = useAuthContext()
 	const navigate = useNavigate()
@@ -85,21 +86,18 @@ export const AdminForm: React.FC = () => {
 			teamSize: '',
 		},
 	})
-	const formState = formStore.getState()
 
-	const disableForm = loading || formState.submitSucceed > 0
+	const submitSucceeded = formStore.useState('submitSucceed')
+	const disableForm = loading || submitSucceeded > 0
 
-	formStore.useSubmit(async () => {
+	formStore.useSubmit(async (formState) => {
 		if (disableForm) {
 			return
 		}
 
 		if (!formState.valid) {
 			analytics.track('About you submission failed')
-			formStore.setError(
-				'__error',
-				'Please fill out all form fields correctly.',
-			)
+			setError('Please fill out all form fields correctly.')
 			return
 		}
 
@@ -165,7 +163,7 @@ export const AdminForm: React.FC = () => {
 				errorMessage = 'Something went wrong. Please try again.'
 			}
 
-			formStore.setError('__error', errorMessage)
+			setError(errorMessage)
 		}
 	})
 
@@ -269,11 +267,7 @@ export const AdminForm: React.FC = () => {
 									</ButtonLink>
 								</Box>
 							))}
-						{(formState.errors as any).__error && (
-							<Callout kind="error">
-								{(formState.errors as any).__error}
-							</Callout>
-						)}
+						{error && <Callout kind="error">{error}</Callout>}
 					</Stack>
 				</AuthBody>
 				<AuthFooter>

--- a/frontend/src/pages/Auth/InviteTeam.tsx
+++ b/frontend/src/pages/Auth/InviteTeam.tsx
@@ -67,6 +67,8 @@ export const InviteTeamForm: React.FC = () => {
 		},
 	})
 	const formState = formStore.getState()
+	const autoJoinDomain = formStore.useValue(formStore.names.autoJoinDomain)
+	const numTeamEmails = formStore.useValue(formStore.names.numTeamEmails)
 
 	const disableForm = loading || formState.submitSucceed > 0
 
@@ -190,7 +192,7 @@ export const InviteTeamForm: React.FC = () => {
 								autoFocus
 								autoComplete="email"
 							/>
-							{Array(formState.values.numTeamEmails - 1)
+							{Array(numTeamEmails - 1)
 								.fill(0)
 								.map((_, idx) => (
 									<Form.Input
@@ -244,16 +246,12 @@ export const InviteTeamForm: React.FC = () => {
 															size={12}
 														/>
 													}
-													checked={
-														formState.values
-															.autoJoinDomain
-													}
+													checked={autoJoinDomain}
 													onChange={() => {
 														formStore.setValue(
 															formStore.names
 																.autoJoinDomain,
-															!formState.values
-																.autoJoinDomain,
+															!autoJoinDomain,
 														)
 													}}
 												/>

--- a/frontend/src/pages/Auth/InviteTeam.tsx
+++ b/frontend/src/pages/Auth/InviteTeam.tsx
@@ -45,6 +45,7 @@ export const InviteTeamForm: React.FC = () => {
 	const { setLoadingState } = useAppLoadingContext()
 	const { admin, role } = useAuthContext()
 	const navigate = useNavigate()
+	const [error, setError] = React.useState<string>()
 
 	const { data: workspacesData, loading: workspacesLoading } =
 		useGetWorkspacesQuery({ fetchPolicy: 'network-only' })
@@ -66,23 +67,19 @@ export const InviteTeamForm: React.FC = () => {
 			numTeamEmails: 1,
 		},
 	})
-	const formState = formStore.getState()
 	const autoJoinDomain = formStore.useValue(formStore.names.autoJoinDomain)
 	const numTeamEmails = formStore.useValue(formStore.names.numTeamEmails)
+	const submitSucceed = formStore.useState('submitSucceed')
+	const disableForm = loading || submitSucceed > 0
 
-	const disableForm = loading || formState.submitSucceed > 0
-
-	formStore.useSubmit(async () => {
+	formStore.useSubmit(async (formState) => {
 		if (disableForm) {
 			return
 		}
 
 		if (!formState.valid) {
 			analytics.track('Invite team submission failed')
-			formStore.setError(
-				'__error',
-				'Please fill out all form fields correctly.',
-			)
+			setError('Please fill out all form fields correctly.')
 			return
 		}
 
@@ -150,7 +147,7 @@ export const InviteTeamForm: React.FC = () => {
 				errorMessage = 'Something went wrong. Please try again.'
 			}
 
-			formStore.setError('__error', errorMessage)
+			setError(errorMessage)
 		}
 	})
 
@@ -219,11 +216,7 @@ export const InviteTeamForm: React.FC = () => {
 								Add another
 							</Button>
 						</Box>
-						{(formState.errors as any).__error && (
-							<Callout kind="error">
-								{(formState.errors as any).__error}
-							</Callout>
-						)}
+						{error && <Callout kind="error">{error}</Callout>}
 					</Stack>
 				</AuthBody>
 				<AuthFooter>

--- a/frontend/src/pages/Auth/JoinWorkspace.tsx
+++ b/frontend/src/pages/Auth/JoinWorkspace.tsx
@@ -42,9 +42,9 @@ export const JoinWorkspace = () => {
 			workspaceId: '',
 		},
 	})
-	const formState = formStore.getState()
+	const workspaceId = formStore.useValue('workspaceId')
 
-	formStore.useSubmit(async () => {
+	formStore.useSubmit(async (formState) => {
 		const response = await joinWorkspace({
 			variables: {
 				workspace_id: formState.values.workspaceId,
@@ -98,7 +98,6 @@ export const JoinWorkspace = () => {
 
 						<select
 							className={styles.select}
-							value={formState.values.workspaceId}
 							onChange={(e) => {
 								const selectedWorkspace =
 									data?.joinable_workspaces?.find(
@@ -131,7 +130,7 @@ export const JoinWorkspace = () => {
 					<Button
 						type="submit"
 						kind="primary"
-						disabled={!formState.values.workspaceId}
+						disabled={!workspaceId}
 						onClick={() => null}
 						trackingId="join-workspace_submit"
 						loading={joinLoading}

--- a/frontend/src/pages/Auth/MultiFactor.tsx
+++ b/frontend/src/pages/Auth/MultiFactor.tsx
@@ -40,7 +40,7 @@ export const MultiFactor: React.FC<Props> = ({ resolver }) => {
 			code: '',
 		},
 	})
-	const formState = formStore.getState()
+	const code = formStore.useValue('code')
 
 	useEffect(() => {
 		recaptchaVerifier.current = new firebase.auth.RecaptchaVerifier(
@@ -88,7 +88,7 @@ export const MultiFactor: React.FC<Props> = ({ resolver }) => {
 			try {
 				const cred = firebase.auth.PhoneAuthProvider.credential(
 					verificationId,
-					formState.values.code,
+					code,
 				)
 				const multiFactorAssertion =
 					firebase.auth.PhoneMultiFactorGenerator.assertion(cred)
@@ -104,14 +104,14 @@ export const MultiFactor: React.FC<Props> = ({ resolver }) => {
 				setLoading(false)
 			}
 		},
-		[resolver, verificationId, formState.values.code, signIn],
+		[resolver, verificationId, code, signIn],
 	)
 
 	useEffect(() => {
-		if (formState.values.code.length >= 6) {
+		if (code.length >= 6) {
 			handleSubmit()
 		}
-	}, [handleSubmit, formState.values.code])
+	}, [handleSubmit, code])
 
 	useEffect(() => {
 		setLoadingState(AppLoadingState.LOADED)

--- a/frontend/src/pages/Auth/ResetPassword.tsx
+++ b/frontend/src/pages/Auth/ResetPassword.tsx
@@ -28,7 +28,7 @@ export const ResetPassword: React.FC = () => {
 			email: initialEmail ?? '',
 		},
 	})
-	const formState = formStore.getState()
+	const email = formStore.useValue('email')
 
 	useEffect(() => analytics.page(), [])
 
@@ -39,7 +39,7 @@ export const ResetPassword: React.FC = () => {
 			onSubmit={() => {
 				analytics.track('Reset password submission')
 
-				if (!validateEmail(formState.values.email)) {
+				if (!validateEmail(email)) {
 					message.warning('Please enter a valid email.')
 					analytics.track('Reset password submission error')
 					setLoading(false)
@@ -47,7 +47,7 @@ export const ResetPassword: React.FC = () => {
 				}
 
 				setLoading(true)
-				auth.sendPasswordResetEmail(formState.values.email)
+				auth.sendPasswordResetEmail(email)
 					.catch(() => {
 						// swallow error if user does not exist
 						analytics.track('Reset password submission error')
@@ -60,7 +60,7 @@ export const ResetPassword: React.FC = () => {
 
 						setTimeout(() => {
 							navigate(SIGN_IN_ROUTE, {
-								state: { email: formState.values.email },
+								state: { email },
 							})
 						}, 1000)
 					})
@@ -81,7 +81,7 @@ export const ResetPassword: React.FC = () => {
 							onClick={() => {
 								navigate(SIGN_IN_ROUTE, {
 									state: {
-										email: formState.values.email,
+										email,
 									},
 								})
 							}}

--- a/frontend/src/pages/Auth/SignIn.tsx
+++ b/frontend/src/pages/Auth/SignIn.tsx
@@ -38,6 +38,7 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 	const [loading, setLoading] = React.useState(false)
 	const [error, setError] = React.useState('')
 	const location = useLocation()
+
 	const initialEmail: string = location.state?.email ?? ''
 	const formStore = useFormStore({
 		defaultValues: {
@@ -45,7 +46,18 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 			password: '',
 		},
 	})
-	const formState = formStore.getState()
+	const email = formStore.useValue('email')
+	formStore.useSubmit(async (formState) => {
+		setLoading(true)
+
+		auth.signInWithEmailAndPassword(
+			formState.values.email,
+			formState.values.password,
+		)
+			.then(handleAuth)
+			.catch(handleAuthError)
+	})
+
 	const [createAdmin] = useCreateAdminMutation()
 	const { data } = useGetWorkspaceForInviteLinkQuery({
 		variables: {
@@ -104,20 +116,7 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 	useEffect(() => analytics.page(), [])
 
 	return (
-		<Form
-			store={formStore}
-			resetOnSubmit={false}
-			onSubmit={() => {
-				setLoading(true)
-
-				auth.signInWithEmailAndPassword(
-					formState.values.email,
-					formState.values.password,
-				)
-					.then(handleAuth)
-					.catch(handleAuthError)
-			}}
-		>
+		<Form store={formStore} resetOnSubmit={false}>
 			<AuthHeader>
 				<Box mb="4">
 					<Stack direction="column" gap="16" align="center">
@@ -129,10 +128,7 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 						</Heading>
 						<Text>
 							New here?{' '}
-							<Link
-								to={SIGN_UP_ROUTE}
-								state={{ email: formState.values.email }}
-							>
+							<Link to={SIGN_UP_ROUTE} state={{ email }}>
 								Create an account
 							</Link>
 							.
@@ -155,10 +151,7 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 						type="password"
 						autoComplete="current-password"
 					/>
-					<Link
-						to="/reset_password"
-						state={{ email: formState.values.email }}
-					>
+					<Link to="/reset_password" state={{ email }}>
 						<Text size="xSmall">Forgot your password?</Text>
 					</Link>
 					{error && <AuthError>{error}</AuthError>}

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
@@ -41,7 +41,7 @@ export const ErrorInstances = ({ errorGroup }: Props) => {
 			email: '',
 		},
 	})
-	const formState = formStore.getState()
+	const email = formStore.useValue('email')
 	const [query, setQuery] = useState('')
 
 	const [pagination, setPagination] = useState<Pagination>({
@@ -60,8 +60,8 @@ export const ErrorInstances = ({ errorGroup }: Props) => {
 
 	const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault()
-		setQuery(`email:${formState.values.email}`)
-		setCurrentSearchEmail(formState.values.email)
+		setQuery(`email:${email}`)
+		setCurrentSearchEmail(email)
 	}
 
 	if (loading) {

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
@@ -118,7 +118,7 @@ export const NewCommentForm = ({
 			issueDescription: '',
 		},
 	})
-	const formState = formStore.getState()
+	const formValues = formStore.useState('values')
 
 	const integrationMap = useMemo(() => {
 		const ret: { [key: string]: IssueTrackerIntegration } = {}
@@ -173,7 +173,7 @@ export const NewCommentForm = ({
 		})
 		setIsCreatingComment(true)
 
-		const { issueTitle, issueDescription } = formState.values
+		const { issueTitle, issueDescription } = formValues
 
 		try {
 			await createErrorComment({
@@ -217,7 +217,7 @@ export const NewCommentForm = ({
 		})
 		setIsCreatingComment(true)
 
-		const { issueTitle, issueDescription } = formState.values
+		const { issueTitle, issueDescription } = formValues
 
 		try {
 			await createComment({
@@ -501,7 +501,7 @@ export const NewCommentForm = ({
 								trackingId="new-comment-attach-issue_cancel"
 								onClick={() => {
 									formStore.setValues({
-										...formState.values,
+										...formValues,
 										issueTitle: '',
 										issueDescription: '',
 									})

--- a/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
+++ b/frontend/src/pages/Player/components/EventStreamV2/EventStreamV2.tsx
@@ -53,8 +53,7 @@ const EventStreamV2 = function () {
 			search: searchItem,
 		},
 	})
-	const formState = formStore.getState()
-	const searchQuery = formState.values.search
+	const searchQuery = formStore.useValue('search')
 	const eventTypeFilters = useEventTypeFilters()
 	const virtuoso = useRef<VirtuosoHandle>(null)
 	const { data } = useGetWebVitalsQuery({

--- a/frontend/src/pages/Setup/SetupRouter/AlertsSetup.tsx
+++ b/frontend/src/pages/Setup/SetupRouter/AlertsSetup.tsx
@@ -671,8 +671,7 @@ const EmailPicker = function ({
 			email: '',
 		},
 	})
-	const formState = formStore.getState()
-	formStore.useSubmit(async () => {
+	formStore.useSubmit(async (formState) => {
 		onSubmit(formState.values.email)
 	})
 	return (

--- a/packages/ui/src/__generated/ve/components/HStack/styles.css.js
+++ b/packages/ui/src/__generated/ve/components/HStack/styles.css.js
@@ -1,0 +1,1 @@
+import{createRuntimeFn as a}from"@vanilla-extract/recipes/createRuntimeFn";var i=a({defaultClassName:"",variantClassNames:{size:{small:"mt0ih24d mt0ih24u mt0ih23g mt0ih23x",large:"mt0ih24e mt0ih24v mt0ih23i mt0ih23z"}},defaultVariants:{size:"small"},compoundVariants:[]});export{i as variants};

--- a/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
@@ -78,7 +78,7 @@ export const ComboboxSelect = <T extends string | string[]>({
 
 	const valueSet = new Set(value)
 
-	const query = combobox.getState().value
+	const query = combobox.useState('value')
 
 	const isLoading = options === undefined
 

--- a/packages/ui/src/components/Form/Form.tsx
+++ b/packages/ui/src/components/Form/Form.tsx
@@ -1,18 +1,6 @@
 import React, { forwardRef, ReactNode, useRef } from 'react'
 
-import {
-	Form as AriaKitForm,
-	FormProps as AriaKitFormProps,
-	FormInput as AriaKitFormInput,
-	FormLabel as AriaKitFormLabel,
-	FormError as AriaKitFormError,
-	FormErrorProps as AriaKitFormErrorProps,
-	FormInputProps as AriaKitFormInputProps,
-	FormField as AriaKitFormField,
-	FormFieldProps as AriaKitFormFieldProps,
-	FormStore as AriaKitFormStore,
-	useFormStore as useAriaKitFormStore,
-} from '@ariakit/react'
+import * as Ariakit from '@ariakit/react'
 
 import * as styles from './styles.css'
 import { Box } from '../Box/Box'
@@ -22,6 +10,7 @@ import { Button, ButtonProps } from '../Button/Button'
 import clsx, { ClassValue } from 'clsx'
 import { Variants } from './styles.css'
 import { Badge } from '../Badge/Badge'
+import { Callout } from '../Callout/Callout'
 
 type FormComponent = React.FC<Props> & {
 	Input: typeof Input
@@ -31,12 +20,12 @@ type FormComponent = React.FC<Props> & {
 	Select: typeof Select
 	NamedSection: typeof NamedSection
 	Label: typeof Label
-	useFormStore: typeof useAriaKitFormStore
+	useFormStore: typeof Ariakit.useFormStore
 }
 
 interface LabelProps {
 	label: string
-	name: AriaKitFormInputProps['name']
+	name: Ariakit.FormInputProps['name']
 	tag?: ReactNode
 	optional?: boolean
 }
@@ -51,7 +40,7 @@ export const Label: React.FC<LabelProps> = ({ label, name, tag, optional }) => {
 					gap="6"
 					style={{ height: 16 }}
 				>
-					<AriaKitFormLabel name={name}>
+					<Ariakit.FormLabel name={name}>
 						<Text
 							userSelect="none"
 							size="xSmall"
@@ -60,7 +49,7 @@ export const Label: React.FC<LabelProps> = ({ label, name, tag, optional }) => {
 						>
 							{label}
 						</Text>
-					</AriaKitFormLabel>
+					</Ariakit.FormLabel>
 					{tag}
 				</Box>
 			)}
@@ -70,7 +59,7 @@ export const Label: React.FC<LabelProps> = ({ label, name, tag, optional }) => {
 }
 
 type HasLabel = {
-	name: AriaKitFormInputProps['name']
+	name: Ariakit.FormInputProps['name']
 	label?: string
 	optional?: boolean
 	tag?: ReactNode
@@ -100,29 +89,29 @@ export const NamedSection = ({
 	)
 }
 
-const FormContext = React.createContext<AriaKitFormStore>(
-	{} as AriaKitFormStore,
+const FormContext = React.createContext<Ariakit.FormStore>(
+	{} as Ariakit.FormStore,
 )
 export const useForm = () => React.useContext(FormContext)
 
-type Props = AriaKitFormProps
+type Props = Ariakit.FormProps
 export const Form: FormComponent = ({ children, ...props }: Props) => {
 	return (
 		<FormContext.Provider value={props.store}>
-			<AriaKitForm {...props}>{children}</AriaKitForm>
+			<Ariakit.Form {...props}>{children}</Ariakit.Form>
 		</FormContext.Provider>
 	)
 }
 
-export const Error = ({ ...props }: AriaKitFormErrorProps) => {
-	return <AriaKitFormError {...props} />
+export const Error = ({ ...props }: Ariakit.FormErrorProps) => {
+	return <Ariakit.FormError {...props} render={<Box color="bad" />} />
 }
 
 export const Submit = ({ ...props }: ButtonProps) => {
 	return <Button type="submit" {...props} />
 }
 
-export type InputProps = Omit<AriaKitFormInputProps, 'size'> &
+export type InputProps = Omit<Ariakit.FormInputProps, 'size'> &
 	Variants &
 	HasLabel & {
 		cssClass?: ClassValue | ClassValue[]
@@ -157,7 +146,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 		}
 		return (
 			<NamedSection label={label} name={name} icon={icon}>
-				<AriaKitFormInput
+				<Ariakit.FormInput
 					ref={ref}
 					name={name}
 					className={clsx(
@@ -172,12 +161,13 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 					)}
 					{...props}
 				/>
+				{/* TODO: Consider adding <Error /> here. */}
 			</NamedSection>
 		)
 	},
 )
 
-type FormFieldProps = AriaKitFormFieldProps &
+type FormFieldProps = Ariakit.FormFieldProps &
 	React.PropsWithChildren &
 	Variants &
 	HasLabel & {
@@ -196,7 +186,7 @@ export const Field = ({
 }: FormFieldProps) => {
 	return (
 		<NamedSection label={label} name={props.name}>
-			<AriaKitFormField
+			<Ariakit.FormField
 				className={clsx(
 					styles.inputVariants({
 						size,
@@ -209,12 +199,13 @@ export const Field = ({
 				{...props}
 			>
 				{children}
-			</AriaKitFormField>
+			</Ariakit.FormField>
 		</NamedSection>
 	)
 }
 
-type FormSelectProps = AriaKitFormInputProps & React.PropsWithChildren<HasLabel>
+type FormSelectProps = Ariakit.FormInputProps &
+	React.PropsWithChildren<HasLabel>
 
 export const Select = ({
 	children,
@@ -231,9 +222,9 @@ export const Select = ({
 				tag={tag}
 				optional={optional}
 			/>
-			<AriaKitFormInput as="select" className={styles.select} {...props}>
+			<Ariakit.FormInput as="select" className={styles.select} {...props}>
 				{children}
-			</AriaKitFormInput>
+			</Ariakit.FormInput>
 		</Stack>
 	)
 }
@@ -246,9 +237,9 @@ Form.Label = Label
 Form.Select = Select
 Form.NamedSection = NamedSection
 
-export const useFormStore = useAriaKitFormStore
+export const useFormStore = Ariakit.useFormStore
 Form.useFormStore = useFormStore
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export declare type FormState<T extends Record<string, any>> =
-	AriaKitFormStore<T>
+	Ariakit.FormStore<T>

--- a/packages/ui/src/components/SwitchButton/SwitchButton.tsx
+++ b/packages/ui/src/components/SwitchButton/SwitchButton.tsx
@@ -29,7 +29,7 @@ export const SwitchButton: React.FC<React.PropsWithChildren<Props>> = ({
 
 	return (
 		<Checkbox
-			as="button"
+			render={<button />}
 			className={className}
 			store={checkbox}
 			onChange={onChange}


### PR DESCRIPTION
## Summary

Many of our forms were using `getState` to access form store values and reference them in the UI or `onSubmit` hooks. However, these values often weren't updating the UI as expected and were still empty when we attempt to access them in our submit handlers because we were pulling them from a stale copy of the form state.

This PR updates all the places we used `formStore.getState` and makes sure we are using `useValue` and `useState` wherever we are trying to access values from the store/state in our UI or submit logic.

## How did you test this change?

Local click test. You can jump to this page in a preview by going to `/invite_team` and repro the error in prod if you're logged in at https://app.highlight.io/invite_team.

## Are there any deployment considerations?

N/A - client-side only change.

## Does this work require review from our design team?

Nope!