### PR TITLE
Fix matching attribute highlight in logs

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -35,9 +35,11 @@ import {
 	SearchParam,
 	stringifySearchQuery,
 } from '@/components/Search/SearchForm/utils'
+import TextHighlighter from '@/components/TextHighlighter/TextHighlighter'
 import { findMatchingLogAttributes } from '@/pages/LogsPage/utils'
 
 import * as styles from './LogDetails.css'
+import * as logsTableStyles from './LogsTable.css'
 
 type Props = {
 	row: Row<LogEdgeWithError>
@@ -384,8 +386,7 @@ export const LogValue: React.FC<{
 	const [_, setQuery] = useQueryParam('query', QueryParam)
 
 	// replace wildcards for highlighting.
-	const matchPattern = queryMatch?.replace('*', '')
-	const stringParts = matchPattern ? value.split(matchPattern) : [value]
+	const matchPattern = queryMatch?.replaceAll('*', '')
 
 	return (
 		<LogAttributeLine>
@@ -406,22 +407,13 @@ export const LogValue: React.FC<{
 				<Box borderRadius="4" p="6">
 					<Text family="monospace" color="caution" break="word">
 						{matchPattern ? (
-							stringParts.map((part, index) => (
-								<React.Fragment key={index}>
-									{!!part && <Box as="span">{part}</Box>}
-									{index < stringParts.length - 1 && (
-										<Box
-											as="span"
-											display="inline-block"
-											backgroundColor="caution"
-											px="4"
-											borderRadius="4"
-										>
-											{matchPattern}
-										</Box>
-									)}
-								</React.Fragment>
-							))
+							<TextHighlighter
+								highlightClassName={
+									logsTableStyles.textHighlight
+								}
+								searchWords={[matchPattern]}
+								textToHighlight={value}
+							/>
 						) : (
 							<>{value ? value : '""'}</>
 						)}

--- a/frontend/src/pages/LogsPage/utils.ts
+++ b/frontend/src/pages/LogsPage/utils.ts
@@ -55,15 +55,15 @@ export const findMatchingLogAttributes = (
 		if (
 			bodyQueryValue &&
 			key === bodyKey &&
-			value.indexOf(bodyQueryValue) !== -1
+			value.toLowerCase().indexOf(bodyQueryValue.toLowerCase()) !== -1
 		) {
 			matchingAttribute = bodyQueryValue
 		} else {
 			const fullKey = [...attributeKeyBase, key].join('.')
 
 			queryTerms.some((term) => {
-				const queryKey = term.key
-				const queryValue = term.value
+				const queryKey = term.key.toLowerCase()
+				const queryValue = term.value.toLowerCase()
 
 				if (queryKey === fullKey) {
 					matchingAttribute = queryValue


### PR DESCRIPTION
## Summary

Fixes two issues in logs search:

1. The matching attribute wasn't being surfaced when a log line is not expanded.
2. The matched portion of the attribute value was not being highlighted because our matching logic on the client was case-sensitive while our backend logic was not.

Here is a before & after of click testing https://app.highlight.io/1/logs?end_date=2023-08-15T05%3A00%3A00.000Z&query=testing&start_date=2023-08-12T05%3A00%3A00.000Z.

**Before**
<img width="1507" alt="Screenshot 2023-09-11 at 12 49 13 PM" src="https://github.com/highlight/highlight/assets/308182/f3c8d152-2b0b-4162-aabe-800e7f401581">

**After**
<img width="1508" alt="Screenshot 2023-09-11 at 12 49 03 PM" src="https://github.com/highlight/highlight/assets/308182/71b10588-51b1-4daf-99ec-8a5875e27fdb">

## How did you test this change?

Local + PR preview click test.

## Are there any deployment considerations?

N/A - client-side only change.

## Does this work require review from our design team?

Nope!