### PR TITLE
enable clickhouse errors for highlight admins

### DIFF
--- a/frontend/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder/QueryBuilder.tsx
@@ -67,6 +67,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { useLocalStorage, useToggle } from 'react-use'
 
+import { useAuthContext } from '@/authentication/AuthContext'
 import LoadingBox from '@/components/LoadingBox'
 import CreateErrorSegmentModal from '@/pages/Errors/ErrorSegmentSidebar/SegmentButtons/CreateErrorSegmentModal'
 import DeleteErrorSegmentModal from '@/pages/Errors/ErrorSegmentSidebar/SegmentPicker/DeleteErrorSegmentModal/DeleteErrorSegmentModal'
@@ -1388,9 +1389,10 @@ function QueryBuilder(props: QueryBuilderProps) {
 		}
 	}
 
+	const { isHighlightAdmin } = useAuthContext()
 	const [chLocalStorage] = useLocalStorage(
 		'highlight-clickhouse-errors',
-		false,
+		isHighlightAdmin,
 	)
 
 	const getValueOptionsCallback = useCallback(

--- a/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
@@ -8,6 +8,7 @@ import { roundFeedDate, serializeAbsoluteTimeRange } from '@util/time'
 import React, { useCallback } from 'react'
 import { useLocalStorage } from 'react-use'
 
+import { useAuthContext } from '@/authentication/AuthContext'
 import { updateQueriedTimeRange } from '@/components/QueryBuilder/QueryBuilder'
 
 import { TIME_RANGE_FIELD } from '../ErrorQueryBuilder/ErrorQueryBuilder'
@@ -16,9 +17,10 @@ const ErrorFeedHistogram = React.memo(() => {
 	const { project_id } = useParams<{ project_id: string }>()
 	const { searchQuery, backendSearchQuery, setSearchQuery } =
 		useErrorSearchContext()
+	const { isHighlightAdmin } = useAuthContext()
 	const [useClickhouse] = useLocalStorage(
 		'highlight-clickhouse-errors',
-		false,
+		isHighlightAdmin,
 	)
 	const { loading, data } = useGetErrorsHistogramQuery({
 		variables: {

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
@@ -12,6 +12,8 @@ import { Progress } from 'antd'
 import React, { useEffect, useState } from 'react'
 import { useLocalStorage } from 'react-use'
 
+import { useAuthContext } from '@/authentication/AuthContext'
+
 type Props = {
 	errorGroup: GetErrorGroupQuery['error_group']
 }
@@ -26,9 +28,10 @@ const ErrorDistributions = ({ errorGroup }: Props) => {
 	const [operatingSystems, setOperatingSystems] = useState<
 		ErrorGroupTagAggregation | undefined
 	>()
+	const { isHighlightAdmin } = useAuthContext()
 	const [useClickhouse] = useLocalStorage(
 		'highlight-clickhouse-errors',
-		false,
+		isHighlightAdmin,
 	)
 	const { loading, data } = useGetErrorGroupTagsQuery({
 		variables: {

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorMetrics.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorMetrics.tsx
@@ -10,6 +10,8 @@ import moment from 'moment'
 import React, { useEffect, useState } from 'react'
 import { useLocalStorage } from 'react-use'
 
+import { useAuthContext } from '@/authentication/AuthContext'
+
 import styles from './ErrorMetrics.module.css'
 
 type Props = {
@@ -49,9 +51,10 @@ const ErrorMetrics: React.FC<Props> = ({ errorGroup }) => {
 		start: string
 		end: string
 	}>({ start: '', end: '' })
+	const { isHighlightAdmin } = useAuthContext()
 	const [useClickhouse] = useLocalStorage(
 		'highlight-clickhouse-errors',
-		false,
+		isHighlightAdmin,
 	)
 
 	const { data: frequencies } = useGetErrorGroupFrequenciesQuery({

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -393,10 +393,10 @@ function useErrorGroup() {
 		referrer: StringParam,
 	})
 	const [markErrorGroupAsViewed] = useMarkErrorGroupAsViewedMutation()
-	const { isLoggedIn } = useAuthContext()
+	const { isLoggedIn, isHighlightAdmin } = useAuthContext()
 	const [useClickhouse] = useLocalStorage(
 		'highlight-clickhouse-errors',
-		false,
+		isHighlightAdmin,
 	)
 	const {
 		data,

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -31,6 +31,7 @@ import moment from 'moment/moment'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useLocalStorage } from 'react-use'
 
+import { useAuthContext } from '@/authentication/AuthContext'
 import { OverageCard } from '@/pages/Sessions/SessionsFeedV3/OverageCard/OverageCard'
 import { styledVerticalScrollbar } from '@/style/common.css'
 
@@ -51,9 +52,10 @@ const SearchPanel = () => {
 	} = useErrorSearchContext()
 	const { project_id: projectId } = useParams<{ project_id: string }>()
 
+	const { isHighlightAdmin } = useAuthContext()
 	const [useClickhouse] = useLocalStorage(
 		'highlight-clickhouse-errors',
-		false,
+		isHighlightAdmin,
 	)
 
 	const { data: fetchedData, loading } = useGetErrorGroupsOpenSearchQuery({

--- a/frontend/src/pages/Player/RightPlayerPanel/components/ErrorDetails/ErrorDetails.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/ErrorDetails/ErrorDetails.tsx
@@ -55,7 +55,7 @@ const ErrorDetails = React.memo(({ error }: Props) => {
 		sessionMetadata: { startTime },
 	} = useReplayerContext()
 	const { setActiveError } = usePlayerUIContext()
-	const { isLoggedIn } = useAuthContext()
+	const { isLoggedIn, isHighlightAdmin } = useAuthContext()
 
 	const eventIdx = errors.findIndex((e) => e.id === error.id)
 	const [prev, next] = [eventIdx - 1, eventIdx + 1]
@@ -66,7 +66,7 @@ const ErrorDetails = React.memo(({ error }: Props) => {
 	const secureId = error.error_group_secure_id
 	const [useClickhouse] = useLocalStorage(
 		'highlight-clickhouse-errors',
-		false,
+		isHighlightAdmin,
 	)
 	const {
 		data,

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceErrors.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceErrors.tsx
@@ -1,6 +1,7 @@
 import { Box, Callout, Text } from '@highlight-run/ui'
 import { useLocalStorage } from 'react-use'
 
+import { useAuthContext } from '@/authentication/AuthContext'
 import LoadingBox from '@/components/LoadingBox'
 import { useGetErrorGroupsOpenSearchQuery } from '@/graph/generated/hooks'
 import { useProjectId } from '@/hooks/useProjectId'
@@ -26,9 +27,10 @@ export const NetworkResourceErrors: React.FC<{
 	const requestId = getHighlightRequestId(resource)
 	const errors = sessionErrors.filter((e) => e.request_id === requestId)
 	const errorGroupSecureIds = errors.map((e) => e.error_group_secure_id)
+	const { isHighlightAdmin } = useAuthContext()
 	const [useClickhouse] = useLocalStorage(
 		'highlight-clickhouse-errors',
-		false,
+		isHighlightAdmin,
 	)
 	const { data, loading } = useGetErrorGroupsOpenSearchQuery({
 		variables: {

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/SessionQueryBuilder.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/SessionQueryBuilder.tsx
@@ -7,7 +7,6 @@ import {
 import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext'
 import { useParams } from '@util/react-router/useParams'
 import React, { useCallback } from 'react'
-import { useLocalStorage } from 'react-use'
 
 import QueryBuilder, {
 	BOOLEAN_OPERATORS,
@@ -156,11 +155,6 @@ const SessionQueryBuilder = React.memo((props: { readonly?: boolean }) => {
 		(rule) => rule.field?.value === TIME_RANGE_FIELD.value,
 	)
 
-	const [useClickhouse] = useLocalStorage(
-		'highlight-session-search-use-clickhouse-v2',
-		false,
-	)
-
 	const startDate = getAbsoluteStartTime(timeRange?.val?.options[0].value)
 	const endDate = getAbsoluteEndTime(timeRange?.val?.options[0].value)
 	const { data: fieldData } = useGetFieldTypesQuery({
@@ -168,7 +162,7 @@ const SessionQueryBuilder = React.memo((props: { readonly?: boolean }) => {
 			project_id: project_id!,
 			start_date: startDate,
 			end_date: endDate,
-			use_clickhouse: useClickhouse,
+			use_clickhouse: true,
 		},
 		skip: !project_id,
 	})

--- a/frontend/src/pages/Setup/IntegrationBar.tsx
+++ b/frontend/src/pages/Setup/IntegrationBar.tsx
@@ -22,6 +22,7 @@ import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { useLocalStorage } from 'react-use'
 
+import { useAuthContext } from '@/authentication/AuthContext'
 import {
 	useGetAlertsPagePayloadQuery,
 	useGetErrorGroupsOpenSearchQuery,
@@ -77,9 +78,10 @@ export const IntegrationBar: React.FC<Props> = ({ integrationData }) => {
 		fetchPolicy: 'no-cache',
 	})
 
+	const { isHighlightAdmin } = useAuthContext()
 	const [useClickhouse] = useLocalStorage(
 		'highlight-clickhouse-errors',
-		false,
+		isHighlightAdmin,
 	)
 
 	const { data: errorGroupData } = useGetErrorGroupsOpenSearchQuery({


### PR DESCRIPTION
## Summary
- error data is backfilled - want to roll this out over the next few days, start by turning on clickhouse for all highlight admins
- `highlight-session-search-use-clickhouse-v2` was still being referenced for the field types query, remove this
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- testing in preview environment
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, should only affect Highlight admins and can revert if there are issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
