### PR TITLE
additional tracing for slow append session properties

### DIFF
--- a/backend/store/workspaces.go
+++ b/backend/store/workspaces.go
@@ -1,0 +1,24 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/redis"
+)
+
+func (store *Store) GetWorkspace(ctx context.Context, id int) (*model.Workspace, error) {
+	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("workspace-id-%d", id), 150*time.Millisecond, time.Minute, func() (*model.Workspace, error) {
+		var workspace model.Workspace
+
+		err := store.db.Where(&model.Workspace{
+			Model: model.Model{
+				ID: id,
+			},
+		}).Take(&workspace).Error
+
+		return &workspace, err
+	})
+}

--- a/backend/store/workspaces_test.go
+++ b/backend/store/workspaces_test.go
@@ -1,0 +1,25 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/highlight-run/highlight/backend/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetWorkspace(t *testing.T) {
+	ctx := context.Background()
+
+	defer teardown(t)
+
+	_, err := store.GetWorkspace(ctx, 1)
+	assert.Error(t, err)
+
+	workspace := model.Workspace{}
+	store.db.Create(&workspace)
+
+	foundWorkspace, err := store.GetWorkspace(ctx, workspace.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, workspace.ID, foundWorkspace.ID)
+}


### PR DESCRIPTION
## Summary

Append session properties is processing slowly for a customer who's app seems to send
many consecutive `AddSessionProperties` messages into the same partition.
<img width="1113" alt="Screenshot 2023-09-12 at 3 35 53 PM" src="https://github.com/highlight/highlight/assets/1351531/9e5dd76a-25b1-4739-9fe8-3265113e2637">

Adding some additional tracing here and using the store for project / workspace queries.

## How did you test this change?

Local deploy processing visited url correctly.
<img width="590" alt="Screenshot 2023-09-12 at 3 42 13 PM" src="https://github.com/highlight/highlight/assets/1351531/5a4d49f4-59c8-4640-9ff2-aad94eb81c4d">


## Are there any deployment considerations?

Monitoring new traces.

## Does this work require review from our design team?

No