### PR TITLE
Allow filter errors by service for Clickhouse

### DIFF
--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -49,6 +49,7 @@ var fieldMap map[string]string = map[string]string{
 	"visited_url":     "VisitedURL",
 	"timestamp":       "Timestamp",
 	"secure_id":       "ErrorGroupSecureID",
+	"service_name":    "ServiceName",
 }
 
 type ClickhouseSession struct {

--- a/frontend/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder/QueryBuilder.tsx
@@ -22,6 +22,7 @@ import {
 	IconSolidClock,
 	IconSolidCloudUpload,
 	IconSolidCube,
+	IconSolidCubeTransparent,
 	IconSolidCursorClick,
 	IconSolidDesktopComputer,
 	IconSolidDocumentAdd,
@@ -833,6 +834,7 @@ const LABEL_MAP: { [key: string]: string } = {
 	landing_page: 'Landing Page',
 	exit_page: 'Exit Page',
 	has_comments: 'Has Comments',
+	service_name: 'Service',
 }
 
 const getOperator = (
@@ -1018,6 +1020,8 @@ const getIcon = (value: string): JSX.Element | undefined => {
 			return <IconSolidCube />
 		case 'error-field_visited_url':
 			return <IconSolidLink />
+		case 'error-field_service_name':
+			return <IconSolidCubeTransparent />
 	}
 	const type = getType(value)
 	const mapped = type === CUSTOM_TYPE ? 'session' : type

--- a/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/ErrorQueryBuilder.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/ErrorQueryBuilder.tsx
@@ -72,6 +72,13 @@ export const CUSTOM_FIELDS: CustomField[] = [
 			type: 'text',
 		},
 	},
+	{
+		type: ERROR_FIELD_TYPE,
+		name: 'service_name',
+		options: {
+			type: 'text',
+		},
+	},
 ]
 
 const ErrorQueryBuilder = (props: { readonly?: boolean }) => {


### PR DESCRIPTION
## Summary
Errors will start coming in with an associated service, and we want to allow users to filter by this service name/

## How did you test this change?
1) Navigate to the errors page
2) Add a new filter
- [ ] Service filter is displayed
3) Click on the service filter
- [ ] Correct options are displayed
4) Select an option
- [ ] Correct errors are displayed

https://www.loom.com/share/Errors-unknown-column-servicename-13-September-2023-6270eed6ece14fe59f08bf94c07b4b2b?sid=a746ac6f-ebc3-456f-a65b-672b6bf78471

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
