### PR TITLE
fix: resolves issue with string replacement for migrations folder

### DIFF
--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -3,8 +3,8 @@ package clickhouse
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -67,8 +67,9 @@ func RunMigrations(ctx context.Context, dbName string) {
 		log.WithContext(ctx).Fatalf("Error creating clickhouse db instance for migrations: %v", err)
 	}
 
+	migrationsPath := filepath.Join(projectpath.GetRoot(), "clickhouse/migrations")
 	m, err := migrate.NewWithDatabaseInstance(
-		fmt.Sprintf("file:///%s/clickhouse/migrations", projectpath.GetRoot()),
+		"file://"+migrationsPath,
 		dbName,
 		driver,
 	)

--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -67,7 +67,7 @@ func RunMigrations(ctx context.Context, dbName string) {
 		log.WithContext(ctx).Fatalf("Error creating clickhouse db instance for migrations: %v", err)
 	}
 
-	migrationsPath := filepath.Join(projectpath.GetRoot(), "clickhouse/migrations")
+	migrationsPath := filepath.Join(projectpath.GetRoot(), "clickhouse", "migrations")
 	m, err := migrate.NewWithDatabaseInstance(
 		"file://"+migrationsPath,
 		dbName,


### PR DESCRIPTION
## Summary

The old string replacement path could result in a double slash being prepended to the folder location for the clickhouse migrations folder. The new solution utilizes filepath join to cleanly build the path,

## How did you test this change?

Deployed locally using docker