### PR TITLE
cache GitHub client fetching installation login

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2377,7 +2377,7 @@ func (r *Resolver) RemoveIntegrationFromWorkspaceAndProjects(ctx context.Context
 	}
 
 	// uninstall the app in github
-	if c, err := github.NewClient(ctx, workspaceMapping.AccessToken); err == nil {
+	if c, err := github.NewClient(ctx, r.Redis, workspaceMapping.AccessToken); err == nil {
 		if err := c.DeleteInstallation(ctx, workspaceMapping.AccessToken); err != nil {
 			return e.Wrap(err, "failed to delete github app installation")
 		}
@@ -2778,7 +2778,7 @@ func (r *Resolver) CreateGitHubTaskAndAttachment(
 		return errors.New("No GitHub integration access token found.")
 	}
 	var task *github2.Issue
-	if c, err := github.NewClient(ctx, *accessToken); err == nil {
+	if c, err := github.NewClient(ctx, r.Redis, *accessToken); err == nil {
 		task, err = c.CreateIssue(ctx, *repo, &github2.IssueRequest{
 			Title:  pointy.String(issueTitle),
 			Body:   pointy.String(issueDescription),
@@ -2812,7 +2812,7 @@ func (r *Resolver) GetGitHubRepos(
 		return nil, nil
 	}
 	var repos []*github2.Repository
-	if c, err := github.NewClient(ctx, *accessToken); err == nil {
+	if c, err := github.NewClient(ctx, r.Redis, *accessToken); err == nil {
 		repos, err = c.ListRepos(ctx)
 		if err != nil {
 			return nil, err
@@ -2844,7 +2844,7 @@ func (r *Resolver) GetGitHubIssueLabels(
 		return nil, nil
 	}
 	var labels []*github2.Label
-	if c, err := github.NewClient(ctx, *accessToken); err == nil {
+	if c, err := github.NewClient(ctx, r.Redis, *accessToken); err == nil {
 		labels, err = c.ListLabels(ctx, repository)
 		if err != nil {
 			return nil, err

--- a/backend/store/stacktraces.go
+++ b/backend/store/stacktraces.go
@@ -185,7 +185,7 @@ func (store *Store) GitHubEnhancedStackTrace(ctx context.Context, stackTrace []*
 		return nil, err
 	}
 
-	client, err := github.NewClient(ctx, *gitHubAccessToken)
+	client, err := github.NewClient(ctx, store.redis, *gitHubAccessToken)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -11,6 +11,9 @@ services:
         logging: *highlight-logging
         image: confluentinc/cp-zookeeper:7.3.0
         container_name: zookeeper
+        volumes:
+            - zoo-data:/var/lib/zookeeper/data
+            - zoo-log:/var/lib/zookeeper/log
         environment:
             ZOOKEEPER_CLIENT_PORT: 2181
             ZOOKEEPER_TICK_TIME: 2000
@@ -19,6 +22,8 @@ services:
         logging: *highlight-logging
         image: confluentinc/cp-kafka:7.3.0
         container_name: kafka
+        volumes:
+            - kafka-data:/var/lib/kafka/data
         ports:
             - 9092:9092
         depends_on:
@@ -146,3 +151,6 @@ volumes:
     redis-data:
     opensearch-data:
     influxdb-data:
+    kafka-data:
+    zoo-log:
+    zoo-data:


### PR DESCRIPTION
## Summary

As noted in [discord](https://discord.com/channels/1026884757667188757/1073708995556147340/1151600206274629642), we would make 
requests to the github `GetInstallation` api to fetch the login name every time we enhanced an error,
which resulted in us hitting the api far too frequently.

This change adds a redis cache step  to fetching the installation to make sure we reuse the result.
The result should not change for a given installation id.

cc @hpsin

## How did you test this change?

Unit test for stacktraces.go, running enhancement locally.
![image](https://github.com/highlight/highlight/assets/1351531/f178ab4a-83d8-4303-9b71-c3cb3ace5e45)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
