### PR TITLE
Optimize GitHub requests

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2377,7 +2377,7 @@ func (r *Resolver) RemoveIntegrationFromWorkspaceAndProjects(ctx context.Context
 	}
 
 	// uninstall the app in github
-	if c, err := github.NewClient(ctx, workspaceMapping.AccessToken); err == nil {
+	if c, err := github.NewClient(ctx, workspaceMapping.AccessToken, r.Redis); err == nil {
 		if err := c.DeleteInstallation(ctx, workspaceMapping.AccessToken); err != nil {
 			return e.Wrap(err, "failed to delete github app installation")
 		}
@@ -2778,7 +2778,7 @@ func (r *Resolver) CreateGitHubTaskAndAttachment(
 		return errors.New("No GitHub integration access token found.")
 	}
 	var task *github2.Issue
-	if c, err := github.NewClient(ctx, *accessToken); err == nil {
+	if c, err := github.NewClient(ctx, *accessToken, r.Redis); err == nil {
 		task, err = c.CreateIssue(ctx, *repo, &github2.IssueRequest{
 			Title:  pointy.String(issueTitle),
 			Body:   pointy.String(issueDescription),
@@ -2812,7 +2812,7 @@ func (r *Resolver) GetGitHubRepos(
 		return nil, nil
 	}
 	var repos []*github2.Repository
-	if c, err := github.NewClient(ctx, *accessToken); err == nil {
+	if c, err := github.NewClient(ctx, *accessToken, r.Redis); err == nil {
 		repos, err = c.ListRepos(ctx)
 		if err != nil {
 			return nil, err
@@ -2844,7 +2844,7 @@ func (r *Resolver) GetGitHubIssueLabels(
 		return nil, nil
 	}
 	var labels []*github2.Label
-	if c, err := github.NewClient(ctx, *accessToken); err == nil {
+	if c, err := github.NewClient(ctx, *accessToken, r.Redis); err == nil {
 		labels, err = c.ListLabels(ctx, repository)
 		if err != nil {
 			return nil, err

--- a/backend/store/stacktraces.go
+++ b/backend/store/stacktraces.go
@@ -185,7 +185,7 @@ func (store *Store) GitHubEnhancedStackTrace(ctx context.Context, stackTrace []*
 		return nil, err
 	}
 
-	client, err := github.NewClient(ctx, *gitHubAccessToken)
+	client, err := github.NewClient(ctx, *gitHubAccessToken, store.redis)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Every time we enhance an error, we make a request to GitHub to get the owner's username, even though it isn't used. Move this request out of the installation request, and cache this value for a day since it should never change.

## How did you test this change?
1) Create an issue locally with GitHub
2) View a newly created backend error and confirm it is still enhanced

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
