### PR TITLE
use persistant storage for kafka

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -11,6 +11,9 @@ services:
         logging: *highlight-logging
         image: confluentinc/cp-zookeeper:7.3.0
         container_name: zookeeper
+        volumes:
+            - zoo-data:/var/lib/zookeeper/data
+            - zoo-log:/var/lib/zookeeper/log
         environment:
             ZOOKEEPER_CLIENT_PORT: 2181
             ZOOKEEPER_TICK_TIME: 2000
@@ -19,6 +22,8 @@ services:
         logging: *highlight-logging
         image: confluentinc/cp-kafka:7.3.0
         container_name: kafka
+        volumes:
+            - kafka-data:/var/lib/kafka/data
         ports:
             - 9092:9092
         depends_on:
@@ -146,3 +151,6 @@ volumes:
     redis-data:
     opensearch-data:
     influxdb-data:
+    kafka-data:
+    zoo-log:
+    zoo-data:


### PR DESCRIPTION
## Summary

Noticed that our kafka docker setup did not use persistent storage, which
would result in docker restarts breaking the docker cluster (because the volumes
would have some internal state that was incorrectly persisted).

## How did you test this change?

Local `./start-infra.sh` - stack running healthy.
e2e test

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No