### PR TITLE
Fix error alerts for errors in newly started sessions

### DIFF
--- a/backend/alerts/alerts.go
+++ b/backend/alerts/alerts.go
@@ -37,8 +37,8 @@ func SendErrorAlert(ctx context.Context, event SendErrorAlertEvent) error {
 		ErrorIgnoreURL:  getErrorIgnoreURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
 		ErrorSnoozeURL:  getErrorSnoozeURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
 		SessionSecureID: event.Session.SecureID,
-		SessionExcluded: event.Session.Excluded && *event.Session.Processed,
 		SessionURL:      getSessionURL(event.ErrorAlert.ProjectID, event.Session),
+		SessionExcluded: event.Session.Excluded && *event.Session.Processed,
 		VisitedURL:      event.VisitedURL,
 	}
 

--- a/backend/alerts/alerts.go
+++ b/backend/alerts/alerts.go
@@ -37,6 +37,7 @@ func SendErrorAlert(ctx context.Context, event SendErrorAlertEvent) error {
 		ErrorIgnoreURL:  getErrorIgnoreURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
 		ErrorSnoozeURL:  getErrorSnoozeURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
 		SessionSecureID: event.Session.SecureID,
+		SessionExcluded: event.Session.Excluded && *event.Session.Processed,
 		SessionURL:      getSessionURL(event.ErrorAlert.ProjectID, event.Session),
 		VisitedURL:      event.VisitedURL,
 	}

--- a/backend/alerts/alerts.go
+++ b/backend/alerts/alerts.go
@@ -36,8 +36,8 @@ func SendErrorAlert(ctx context.Context, event SendErrorAlertEvent) error {
 		ErrorResolveURL: getErrorResolveURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
 		ErrorIgnoreURL:  getErrorIgnoreURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
 		ErrorSnoozeURL:  getErrorSnoozeURL(event.ErrorAlert, event.ErrorGroup, event.ErrorObject),
+		SessionSecureID: event.Session.SecureID,
 		SessionURL:      getSessionURL(event.ErrorAlert.ProjectID, event.Session),
-		SessionExcluded: event.Session.Excluded,
 		VisitedURL:      event.VisitedURL,
 	}
 

--- a/backend/alerts/integrations/discord/messages.go
+++ b/backend/alerts/integrations/discord/messages.go
@@ -48,7 +48,7 @@ func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlert
 	embed.Fields = fields
 
 	sessionLabel := "View Session"
-	if payload.SessionExcluded {
+	if payload.SessionSecureID == "" {
 		sessionLabel = "No recorded session"
 	}
 
@@ -62,7 +62,7 @@ func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlert
 					discordgo.Button{
 						Label:    sessionLabel,
 						Style:    discordgo.LinkButton,
-						Disabled: payload.SessionExcluded,
+						Disabled: payload.SessionSecureID == "",
 						URL:      payload.SessionURL,
 					},
 					discordgo.Button{

--- a/backend/alerts/integrations/discord/messages.go
+++ b/backend/alerts/integrations/discord/messages.go
@@ -48,7 +48,8 @@ func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlert
 	embed.Fields = fields
 
 	sessionLabel := "View Session"
-	if payload.SessionSecureID == "" {
+	displayMissingSessionLabel := payload.SessionSecureID == "" || payload.SessionExcluded
+	if displayMissingSessionLabel {
 		sessionLabel = "No recorded session"
 	}
 
@@ -62,7 +63,7 @@ func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlert
 					discordgo.Button{
 						Label:    sessionLabel,
 						Style:    discordgo.LinkButton,
-						Disabled: payload.SessionSecureID == "",
+						Disabled: displayMissingSessionLabel,
 						URL:      payload.SessionURL,
 					},
 					discordgo.Button{

--- a/backend/alerts/integrations/discord/messages_test.go
+++ b/backend/alerts/integrations/discord/messages_test.go
@@ -51,6 +51,7 @@ func (suite *DiscordChannelsTestSuite) TestSendErrorAlert() {
 		ErrorTitle:      "something bad happened",
 		SessionSecureID: "uJgf8EvTHPbwCfnFMcWx3tnjW7sc",
 		SessionURL:      "https://localhost:3000/1/sessions/uJgf8EvTHPbwCfnFMcWx3tnjW7sc?page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue%2Cfalse%7C%7Ccustom_created_at%2Cbetween_date%2C30%20days",
+		SessionExcluded: false,
 		ErrorURL:        "https://localhost:3000/1/errors/8y4uezKfrGgvMZNAMt1Z4lpJq2bt?page=1",
 		ErrorResolveURL: "https://localhost:3000/1/errors/8y4uezKfrGgvMZNAMt1Z4lpJq2bt?action=resolved",
 		ErrorIgnoreURL:  "https://localhost:3000/1/errors/8y4uezKfrGgvMZNAMt1Z4lpJq2bt?action=ignore",

--- a/backend/alerts/integrations/discord/messages_test.go
+++ b/backend/alerts/integrations/discord/messages_test.go
@@ -49,8 +49,8 @@ func (suite *DiscordChannelsTestSuite) TestSendErrorAlert() {
 	err := suite.bot.SendErrorAlert(suite.ChannelID, integrations.ErrorAlertPayload{
 		ErrorCount:      12,
 		ErrorTitle:      "something bad happened",
+		SessionSecureID: "uJgf8EvTHPbwCfnFMcWx3tnjW7sc",
 		SessionURL:      "https://localhost:3000/1/sessions/uJgf8EvTHPbwCfnFMcWx3tnjW7sc?page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue%2Cfalse%7C%7Ccustom_created_at%2Cbetween_date%2C30%20days",
-		SessionExcluded: false,
 		ErrorURL:        "https://localhost:3000/1/errors/8y4uezKfrGgvMZNAMt1Z4lpJq2bt?page=1",
 		ErrorResolveURL: "https://localhost:3000/1/errors/8y4uezKfrGgvMZNAMt1Z4lpJq2bt?action=resolved",
 		ErrorIgnoreURL:  "https://localhost:3000/1/errors/8y4uezKfrGgvMZNAMt1Z4lpJq2bt?action=ignore",

--- a/backend/alerts/integrations/integrations.go
+++ b/backend/alerts/integrations/integrations.go
@@ -9,8 +9,8 @@ import (
 type ErrorAlertPayload struct {
 	ErrorCount      int64
 	ErrorTitle      string
+	SessionSecureID string
 	SessionURL      string
-	SessionExcluded bool
 	ErrorURL        string
 	ErrorResolveURL string
 	ErrorIgnoreURL  string

--- a/backend/alerts/integrations/integrations.go
+++ b/backend/alerts/integrations/integrations.go
@@ -11,6 +11,7 @@ type ErrorAlertPayload struct {
 	ErrorTitle      string
 	SessionSecureID string
 	SessionURL      string
+	SessionExcluded bool
 	ErrorURL        string
 	ErrorResolveURL string
 	ErrorIgnoreURL  string

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1901,7 +1901,7 @@ func (obj *ErrorAlert) SendAlerts(ctx context.Context, db *gorm.DB, mailClient *
 	errorURL = routing.AttachReferrer(ctx, errorURL, routing.Email)
 
 	message := fmt.Sprintf("<b>%s</b><br>The following error is being thrown on your app<br>%s<br><br><a href=\"%s\">View Error</a>", *obj.Name, input.Group.Event, errorURL)
-	if input.SessionExcluded {
+	if input.SessionSecureID == "" {
 		message += " (No recorded session)"
 	} else {
 		sessionURL := fmt.Sprintf("%s/%d/sessions/%s", frontendURL, obj.ProjectID, input.SessionSecureID)
@@ -2700,8 +2700,6 @@ type SendSlackAlertInput struct {
 	Workspace *Workspace
 	// SessionSecureID is a required parameter
 	SessionSecureID string
-	// SessionExluded is a required parameter to tell if the session is playable
-	SessionExcluded bool
 	// UserIdentifier is a required parameter for New User, Error, and SessionFeedback alerts
 	UserIdentifier string
 	// UserObject is a required parameter for alerts that relate to a session
@@ -2813,7 +2811,7 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 		}
 	}
 
-	if input.SessionSecureID == "" || input.SessionExcluded {
+	if input.SessionSecureID == "" {
 		messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*Session:*\nNo recorded session", false, false))
 	} else {
 		sessionLink := fmt.Sprintf("<%s/%d/sessions/%s%s|View>", frontendURL, obj.ProjectID, input.SessionSecureID, suffix)

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1901,7 +1901,7 @@ func (obj *ErrorAlert) SendAlerts(ctx context.Context, db *gorm.DB, mailClient *
 	errorURL = routing.AttachReferrer(ctx, errorURL, routing.Email)
 
 	message := fmt.Sprintf("<b>%s</b><br>The following error is being thrown on your app<br>%s<br><br><a href=\"%s\">View Error</a>", *obj.Name, input.Group.Event, errorURL)
-	if input.SessionSecureID == "" {
+	if input.SessionSecureID == "" || input.SessionExcluded {
 		message += " (No recorded session)"
 	} else {
 		sessionURL := fmt.Sprintf("%s/%d/sessions/%s", frontendURL, obj.ProjectID, input.SessionSecureID)
@@ -2700,6 +2700,8 @@ type SendSlackAlertInput struct {
 	Workspace *Workspace
 	// SessionSecureID is a required parameter
 	SessionSecureID string
+	// SessionExluded is a required parameter to tell if the session is playable
+	SessionExcluded bool
 	// UserIdentifier is a required parameter for New User, Error, and SessionFeedback alerts
 	UserIdentifier string
 	// UserObject is a required parameter for alerts that relate to a session
@@ -2811,7 +2813,7 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 		}
 	}
 
-	if input.SessionSecureID == "" {
+	if input.SessionSecureID == "" || input.SessionExcluded {
 		messageBlock = append(messageBlock, slack.NewTextBlockObject(slack.MarkdownType, "*Session:*\nNo recorded session", false, false))
 	} else {
 		sessionLink := fmt.Sprintf("<%s/%d/sessions/%s%s|View>", frontendURL, obj.ProjectID, input.SessionSecureID, suffix)

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1348,7 +1348,7 @@ func (r *Resolver) AddSessionFeedbackImpl(ctx context.Context, input *kafka_queu
 	metadata["timestamp"] = input.Timestamp
 
 	session := &model.Session{}
-	if err := r.DB.Select("project_id", "environment", "id", "secure_id", "created_at", "excluded").Where(&model.Session{SecureID: input.SessionSecureID}).Take(&session).Error; err != nil {
+	if err := r.DB.Select("project_id", "environment", "id", "secure_id", "created_at", "excluded", "processed").Where(&model.Session{SecureID: input.SessionSecureID}).Take(&session).Error; err != nil {
 		return e.Wrap(err, "error querying session by sessionSecureID for adding session feedback")
 	}
 
@@ -1410,7 +1410,7 @@ func (r *Resolver) AddSessionFeedbackImpl(ctx context.Context, input *kafka_queu
 		errorAlert.SendAlertFeedback(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: session.SecureID,
-			SessionExcluded: session.Excluded,
+			SessionExcluded: session.Excluded && *session.Processed,
 			UserIdentifier:  identifier,
 			CommentID:       &feedbackComment.ID,
 			CommentText:     feedbackComment.Text,
@@ -1869,7 +1869,7 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 			errorAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 				Workspace:       workspace,
 				SessionSecureID: sessionObj.SecureID,
-				SessionExcluded: sessionObj.Excluded,
+				SessionExcluded: sessionObj.Excluded && *sessionObj.Processed,
 				UserIdentifier:  sessionObj.Identifier,
 				Group:           group,
 				ErrorObject:     errorObject,
@@ -3022,7 +3022,7 @@ func (r *Resolver) SendSessionInitAlert(ctx context.Context, workspace *model.Wo
 		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: sessionObj.SecureID,
-			SessionExcluded: sessionObj.Excluded,
+			SessionExcluded: sessionObj.Excluded && *sessionObj.Processed,
 			UserIdentifier:  sessionObj.Identifier,
 			UserObject:      sessionObj.UserObject,
 			UserProperties:  userProperties,
@@ -3133,7 +3133,7 @@ func (r *Resolver) SendSessionTrackPropertiesAlert(ctx context.Context, workspac
 		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: session.SecureID,
-			SessionExcluded: session.Excluded,
+			SessionExcluded: session.Excluded && *session.Processed,
 			UserIdentifier:  session.Identifier,
 			MatchedFields:   matchedFields,
 			RelatedFields:   relatedFields,
@@ -3212,7 +3212,7 @@ func (r *Resolver) SendSessionIdentifiedAlert(ctx context.Context, workspace *mo
 		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: refetchedSession.SecureID,
-			SessionExcluded: refetchedSession.Excluded,
+			SessionExcluded: refetchedSession.Excluded && *refetchedSession.Processed,
 			UserIdentifier:  refetchedSession.Identifier,
 			UserProperties:  userProperties,
 			UserObject:      refetchedSession.UserObject,
@@ -3301,7 +3301,7 @@ func (r *Resolver) SendSessionUserPropertiesAlert(ctx context.Context, workspace
 		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: session.SecureID,
-			SessionExcluded: session.Excluded,
+			SessionExcluded: session.Excluded && *session.Processed,
 			UserIdentifier:  session.Identifier,
 			MatchedFields:   matchedFields,
 			UserObject:      session.UserObject,

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1348,7 +1348,7 @@ func (r *Resolver) AddSessionFeedbackImpl(ctx context.Context, input *kafka_queu
 	metadata["timestamp"] = input.Timestamp
 
 	session := &model.Session{}
-	if err := r.DB.Select("project_id", "environment", "id", "secure_id", "created_at", "excluded").Where(&model.Session{SecureID: input.SessionSecureID}).Take(&session).Error; err != nil {
+	if err := r.DB.Select("project_id", "environment", "id", "secure_id", "created_at").Where(&model.Session{SecureID: input.SessionSecureID}).Take(&session).Error; err != nil {
 		return e.Wrap(err, "error querying session by sessionSecureID for adding session feedback")
 	}
 
@@ -1410,7 +1410,6 @@ func (r *Resolver) AddSessionFeedbackImpl(ctx context.Context, input *kafka_queu
 		errorAlert.SendAlertFeedback(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: session.SecureID,
-			SessionExcluded: session.Excluded,
 			UserIdentifier:  identifier,
 			CommentID:       &feedbackComment.ID,
 			CommentText:     feedbackComment.Text,
@@ -1869,7 +1868,6 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 			errorAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 				Workspace:       workspace,
 				SessionSecureID: sessionObj.SecureID,
-				SessionExcluded: sessionObj.Excluded,
 				UserIdentifier:  sessionObj.Identifier,
 				Group:           group,
 				ErrorObject:     errorObject,
@@ -3022,7 +3020,6 @@ func (r *Resolver) SendSessionInitAlert(ctx context.Context, workspace *model.Wo
 		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: sessionObj.SecureID,
-			SessionExcluded: sessionObj.Excluded,
 			UserIdentifier:  sessionObj.Identifier,
 			UserObject:      sessionObj.UserObject,
 			UserProperties:  userProperties,
@@ -3133,7 +3130,6 @@ func (r *Resolver) SendSessionTrackPropertiesAlert(ctx context.Context, workspac
 		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: session.SecureID,
-			SessionExcluded: session.Excluded,
 			UserIdentifier:  session.Identifier,
 			MatchedFields:   matchedFields,
 			RelatedFields:   relatedFields,
@@ -3212,7 +3208,6 @@ func (r *Resolver) SendSessionIdentifiedAlert(ctx context.Context, workspace *mo
 		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: refetchedSession.SecureID,
-			SessionExcluded: refetchedSession.Excluded,
 			UserIdentifier:  refetchedSession.Identifier,
 			UserProperties:  userProperties,
 			UserObject:      refetchedSession.UserObject,
@@ -3301,7 +3296,6 @@ func (r *Resolver) SendSessionUserPropertiesAlert(ctx context.Context, workspace
 		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: session.SecureID,
-			SessionExcluded: session.Excluded,
 			UserIdentifier:  session.Identifier,
 			MatchedFields:   matchedFields,
 			UserObject:      session.UserObject,

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1348,7 +1348,7 @@ func (r *Resolver) AddSessionFeedbackImpl(ctx context.Context, input *kafka_queu
 	metadata["timestamp"] = input.Timestamp
 
 	session := &model.Session{}
-	if err := r.DB.Select("project_id", "environment", "id", "secure_id", "created_at").Where(&model.Session{SecureID: input.SessionSecureID}).Take(&session).Error; err != nil {
+	if err := r.DB.Select("project_id", "environment", "id", "secure_id", "created_at", "excluded").Where(&model.Session{SecureID: input.SessionSecureID}).Take(&session).Error; err != nil {
 		return e.Wrap(err, "error querying session by sessionSecureID for adding session feedback")
 	}
 
@@ -1410,6 +1410,7 @@ func (r *Resolver) AddSessionFeedbackImpl(ctx context.Context, input *kafka_queu
 		errorAlert.SendAlertFeedback(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: session.SecureID,
+			SessionExcluded: session.Excluded,
 			UserIdentifier:  identifier,
 			CommentID:       &feedbackComment.ID,
 			CommentText:     feedbackComment.Text,
@@ -1868,6 +1869,7 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 			errorAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 				Workspace:       workspace,
 				SessionSecureID: sessionObj.SecureID,
+				SessionExcluded: sessionObj.Excluded,
 				UserIdentifier:  sessionObj.Identifier,
 				Group:           group,
 				ErrorObject:     errorObject,
@@ -3020,6 +3022,7 @@ func (r *Resolver) SendSessionInitAlert(ctx context.Context, workspace *model.Wo
 		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: sessionObj.SecureID,
+			SessionExcluded: sessionObj.Excluded,
 			UserIdentifier:  sessionObj.Identifier,
 			UserObject:      sessionObj.UserObject,
 			UserProperties:  userProperties,
@@ -3130,6 +3133,7 @@ func (r *Resolver) SendSessionTrackPropertiesAlert(ctx context.Context, workspac
 		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: session.SecureID,
+			SessionExcluded: session.Excluded,
 			UserIdentifier:  session.Identifier,
 			MatchedFields:   matchedFields,
 			RelatedFields:   relatedFields,
@@ -3208,6 +3212,7 @@ func (r *Resolver) SendSessionIdentifiedAlert(ctx context.Context, workspace *mo
 		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: refetchedSession.SecureID,
+			SessionExcluded: refetchedSession.Excluded,
 			UserIdentifier:  refetchedSession.Identifier,
 			UserProperties:  userProperties,
 			UserObject:      refetchedSession.UserObject,
@@ -3296,6 +3301,7 @@ func (r *Resolver) SendSessionUserPropertiesAlert(ctx context.Context, workspace
 		sessionAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 			Workspace:       workspace,
 			SessionSecureID: session.SecureID,
+			SessionExcluded: session.Excluded,
 			UserIdentifier:  session.Identifier,
 			MatchedFields:   matchedFields,
 			UserObject:      session.UserObject,

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -997,7 +997,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 			slackAlertPayload := model.SendSlackAlertInput{
 				Workspace:       workspace,
 				SessionSecureID: s.SecureID,
-				SessionExcluded: s.Excluded,
+				SessionExcluded: s.Excluded && *s.Processed,
 				UserIdentifier:  s.Identifier,
 				UserObject:      s.UserObject,
 				RageClicksCount: &count64,

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -997,6 +997,7 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 			slackAlertPayload := model.SendSlackAlertInput{
 				Workspace:       workspace,
 				SessionSecureID: s.SecureID,
+				SessionExcluded: s.Excluded,
 				UserIdentifier:  s.Identifier,
 				UserObject:      s.UserObject,
 				RageClicksCount: &count64,

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -997,7 +997,6 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 			slackAlertPayload := model.SendSlackAlertInput{
 				Workspace:       workspace,
 				SessionSecureID: s.SecureID,
-				SessionExcluded: s.Excluded,
 				UserIdentifier:  s.Identifier,
 				UserObject:      s.UserObject,
 				RageClicksCount: &count64,

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -115,7 +115,7 @@ if (dev) {
 	options.scriptUrl = 'http://localhost:8080/dist/index.js'
 
 	options.integrations = undefined
-
+	options.disableSessionRecording = true
 	const sampleEnvironmentNames = ['john', 'jay', 'anthony', 'cameron', 'boba']
 	options.environment = `${
 		sampleEnvironmentNames[

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -115,7 +115,7 @@ if (dev) {
 	options.scriptUrl = 'http://localhost:8080/dist/index.js'
 
 	options.integrations = undefined
-	options.disableSessionRecording = true
+
 	const sampleEnvironmentNames = ['john', 'jay', 'anthony', 'cameron', 'boba']
 	options.environment = `${
 		sampleEnvironmentNames[


### PR DESCRIPTION
## Summary
If an error occurs at the start of the session, we are displaying that the session is excluded because there were no user events at the time of the error. However, the user can continue the session, leading to a session being linked on the error page UI.

Update the logic to check if the session has been processed, as well as excluded. This is the case when the user sets `disableSessionRecording`.

## How did you test this change?
1) Load an page with an error occurring on load
- [ ] Error alerts are created with a session link
2) Set `options.disableSessionRecording = true`
3) Load an page with an error occurring on load
- [ ] Error alerts are created without a session link

https://www.loom.com/share/Improve-error-alerts-with-no-sessions-by-SpennyNDaJets-Pull-Request-6532-highlig-ba3822796fb54c509ad10e163ef87acd?sid=e2427a4f-809d-4aa0-9ff9-14c119c0e992

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
