### PR TITLE
adjust where tracer records error spans

### DIFF
--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -227,6 +227,11 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 	if val, ok := eventAttributes[string(semconv.ExceptionMessageKey)]; ok { // we know that exception.message will be in the event attributes map
 		fields.exceptionMessage = val.(string)
 		delete(fields.attrs, string(semconv.ExceptionMessageKey))
+		// if this is a log that is emitted from an error,
+		// we should use the error text as the log body
+		if fields.logMessage == "" {
+			fields.logMessage = fields.exceptionMessage
+		}
 	}
 
 	if val, ok := eventAttributes[string(semconv.ExceptionStacktraceKey)]; ok { // we know that exception.stacktrace will be in the event attributes map

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -167,7 +167,8 @@ func RecordSpanError(span trace.Span, err error, tags ...attribute.KeyValue) {
 	}
 	span.SetAttributes(tags...)
 	// if this is an error with true stacktrace, then create the event directly since otel doesn't support saving a custom stacktrace
-	if stackErr, ok := err.(ErrorWithStack); ok {
+	var stackErr ErrorWithStack
+	if errors.As(err, &stackErr) {
 		RecordSpanErrorWithStack(span, stackErr)
 	} else {
 		span.RecordError(err, trace.WithStackTrace(true))

--- a/sdk/highlight-go/tracer.go
+++ b/sdk/highlight-go/tracer.go
@@ -114,13 +114,8 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	start := graphql.Now()
 	resp := next(ctx)
 	end := graphql.Now()
-
-	if resp != nil {
-		RecordSpanError(
-			span, resp.Errors,
-			attribute.String(SourceAttribute, "InterceptResponse"),
-		)
-	}
+	// though there is a resp.Errors, we should not record it because it will
+	// be a duplicate of errors on individual fields.
 	EndTrace(span)
 
 	RecordMetric(ctx, name+".duration", end.Sub(start).Seconds())


### PR DESCRIPTION
## Summary

* Uses the exception message for logs that are [produced from an error](https://github.com/highlight/highlight/blob/4d5e658dc3094badb9e722d73f64e5b9adce61d9/backend/otel/otel.go#L237-L248)
* Ensures our traces does not report duplicate errors / graphql schema errors from `InterceptResponse` as `InterceptField` already captures meaningful graph errors

## How did you test this change?

<img width="1014" alt="Screenshot 2023-09-14 at 11 42 53 AM" src="https://github.com/highlight/highlight/assets/1351531/8e408e84-de47-428a-83d6-be32f7a379f0">

<img width="1525" alt="Screenshot 2023-09-14 at 11 43 27 AM" src="https://github.com/highlight/highlight/assets/1351531/bffa1a91-9610-4b65-8ab3-c716cd5683cb">

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
