### PR TITLE
update sveltekit docs for relative paths

### DIFF
--- a/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
+++ b/highlight.io/components/QuickstartContent/frontend/sveltekit.tsx
@@ -53,6 +53,25 @@ export const SvelteKitContent: QuickStartContent = {
 				},
 			],
 		},
+		{
+			title: 'Confirm CSS is served by absolute path.',
+			content:
+				'SvelteKit may generate CSS paths that are relative ' +
+				'which may interfere with our logic to fetch stylesheets. ' +
+				'Update your `svelte.config.js` to disable relative paths. ' +
+				'[See the SvelteKit docs here for more details](https://kit.svelte.dev/docs/configuration#paths).',
+			code: [
+				{
+					language: 'js',
+					text: `/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  paths: { relative: false }
+};
+
+export default config;`,
+				},
+			],
+		},
 		identifySnippet,
 		verifySnippet,
 		configureSourcemapsCI(),


### PR DESCRIPTION
## Summary

Per a customer email, we've learned that sveltekit may generate relative CSS paths
for stylesheets which are not always valid (relying on some weird browser path behavior
to load correctly). This adds a note to the SvelteKit docs about disabling relative paths.

## How did you test this change?

[Vercel preview](https://highlight-landing-du7eloxoc-highlight-run.vercel.app/docs/getting-started/client-sdk/sveltekit).

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
