### PR TITLE
Send traces to Highlight + Datadog

### DIFF
--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -27,7 +27,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/tdewolff/parse/css"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -638,10 +637,10 @@ lexerLoop:
 
 func (s *Snapshot) ReplaceAssets(ctx context.Context, projectId int, s3 storage.Client, db *gorm.DB, redis *redis.Client) error {
 	urls := getAssetUrlsFromTree(ctx, projectId, s.data, map[string]string{})
-	span, _ := tracer.StartSpanFromContext(ctx, "event-parse.parse.ReplaceAssets", tracer.ResourceName("getOrCreateUrls"), tracer.Tag("project_id", projectId))
-	span.SetTag("numberOfURLs", len(urls))
+	span, _ := util.StartSpanFromContext(ctx, "event-parse.parse.ReplaceAssets", util.ResourceName("getOrCreateUrls"), util.Tag("project_id", projectId))
+	span.SetAttribute("numberOfURLs", len(urls))
 	replacements, err := getOrCreateUrls(ctx, projectId, urls, s3, db, redis)
-	span.Finish(tracer.WithError(err))
+	span.Finish(err)
 	if err != nil {
 		return errors.Wrap(err, "error creating replacement urls")
 	}

--- a/backend/hubspot/hubspot.go
+++ b/backend/hubspot/hubspot.go
@@ -17,10 +17,10 @@ import (
 	kafka_queue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/redis"
+	"github.com/highlight-run/highlight/backend/util"
 	"github.com/leonelquinteros/hubspot"
 	"github.com/openlyinc/pointy"
 	e "github.com/pkg/errors"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
@@ -48,7 +48,7 @@ var (
 )
 
 func pollHubspot[T any](fn func() (*T, error), timeout time.Duration) (result *T, err error) {
-	span := tracer.StartSpan("pollHubspot", tracer.ResourceName("hubspot"), tracer.Tag("timeout", timeout))
+	span := util.StartSpan("pollHubspot", util.ResourceName("hubspot"), util.Tag("timeout", timeout))
 	defer span.Finish()
 	start := time.Now()
 	ticker := time.NewTicker(ClientSideCreationPollInterval)
@@ -322,8 +322,8 @@ func (h *Client) mergeContacts(keepID, mergeID int) error {
 }
 
 func (h *Client) getAllCompanies(ctx context.Context) (companies []*CompanyResponse, err error) {
-	span := tracer.StartSpan("getAllCompanies", tracer.ResourceName("hubspot"))
-	defer span.Finish(tracer.WithError(err))
+	span := util.StartSpan("getAllCompanies", util.ResourceName("hubspot"))
+	defer span.Finish(err)
 	if h.redisClient != nil {
 		err = h.redisClient.GetHubspotCompanies(ctx, &companies)
 		if err == nil && len(companies) > 0 {
@@ -357,7 +357,7 @@ func (h *Client) getAllCompanies(ctx context.Context) (companies []*CompanyRespo
 }
 
 func (h *Client) getCompany(ctx context.Context, name, domain string) (*int, error) {
-	span := tracer.StartSpan("getCompany", tracer.ResourceName("hubspot"))
+	span := util.StartSpan("getCompany", util.ResourceName("hubspot"))
 	defer span.Finish()
 	return redis.CachedEval(ctx, h.redisClient, fmt.Sprintf("hubspot-company-%s-%s", name, domain), time.Second, ClientSideContactCreationTimeout/4, func() (*int, error) {
 		r := struct {
@@ -406,8 +406,8 @@ func (h *Client) getCompany(ctx context.Context, name, domain string) (*int, err
 }
 
 func (h *Client) getContactForAdmin(ctx context.Context, email string) (contactId *int, err error) {
-	span := tracer.StartSpan("getContactForAdmin", tracer.ResourceName("hubspot"))
-	defer span.Finish(tracer.WithError(err))
+	span := util.StartSpan("getContactForAdmin", util.ResourceName("hubspot"))
+	defer span.Finish(err)
 	return redis.CachedEval(ctx, h.redisClient, fmt.Sprintf("hubspot-email-%s", email), time.Second, ClientSideContactCreationTimeout/4, func() (*int, error) {
 		r := CustomContactsResponse{}
 		if err = h.hubspotClient.Contacts().Client.Request("GET", "/contacts/v1/contact/email/"+email+"/profile", nil, &r); err != nil {

--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -21,7 +21,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stripe/stripe-go/v72"
 	"github.com/stripe/stripe-go/v72/client"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gorm.io/gorm"
 )
 
@@ -51,9 +50,9 @@ func GetSessions7DayAverage(ctx context.Context, DB *gorm.DB, ccClient *clickhou
 }
 
 func GetWorkspaceSessionsMeter(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, workspace *model.Workspace) (int64, error) {
-	meterSpan, _ := tracer.StartSpanFromContext(ctx, "pricing.GetWorkspaceSessionsMeter",
-		tracer.ResourceName("GetWorkspaceSessionsMeter"),
-		tracer.Tag("workspace_id", workspace.ID))
+	meterSpan, _ := util.StartSpanFromContext(ctx, "pricing.GetWorkspaceSessionsMeter",
+		util.ResourceName("GetWorkspaceSessionsMeter"),
+		util.Tag("workspace_id", workspace.ID))
 	defer meterSpan.Finish()
 
 	var meter int64
@@ -106,9 +105,9 @@ func GetErrors7DayAverage(ctx context.Context, DB *gorm.DB, ccClient *clickhouse
 }
 
 func GetWorkspaceErrorsMeter(ctx context.Context, DB *gorm.DB, ccClient *clickhouse.Client, workspace *model.Workspace) (int64, error) {
-	meterSpan, _ := tracer.StartSpanFromContext(ctx, "pricing.GetWorkspaceErrorsMeter",
-		tracer.ResourceName("GetWorkspaceErrorsMeter"),
-		tracer.Tag("workspace_id", workspace.ID))
+	meterSpan, _ := util.StartSpanFromContext(ctx, "pricing.GetWorkspaceErrorsMeter",
+		util.ResourceName("GetWorkspaceErrorsMeter"),
+		util.Tag("workspace_id", workspace.ID))
 	defer meterSpan.Finish()
 
 	var meter int64

--- a/backend/private-graph/graph/middleware.go
+++ b/backend/private-graph/graph/middleware.go
@@ -16,11 +16,11 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/oauth"
+	"github.com/highlight-run/highlight/backend/util"
 	e "github.com/pkg/errors"
 )
 
@@ -162,7 +162,7 @@ func getSourcemapRequestToken(r *http.Request) string {
 func PrivateMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		span, _ := tracer.StartSpanFromContext(ctx, "middleware.private")
+		span, _ := util.StartSpanFromContext(ctx, "middleware.private")
 		defer span.Finish()
 		var err error
 		if token := r.Header.Get("token"); token != "" {

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -59,7 +59,6 @@ import (
 	"github.com/stripe/stripe-go/v72"
 	"github.com/stripe/stripe-go/v72/client"
 	"github.com/stripe/stripe-go/v72/webhook"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gorm.io/gorm"
 
 	"github.com/highlight-run/workerpool"
@@ -163,17 +162,17 @@ func (r *mutationResolver) Transaction(body func(txnR *mutationResolver) error) 
 
 func (r *Resolver) createAdmin(ctx context.Context) (*model.Admin, error) {
 	adminUID := pointy.String(fmt.Sprintf("%v", ctx.Value(model.ContextKeys.UID)))
-	firebaseSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.createAdmin", tracer.ResourceName("db.createAdminFromFirebase"),
-		tracer.Tag("admin_uid", adminUID))
+	firebaseSpan, _ := util.StartSpanFromContext(ctx, "resolver.createAdmin", util.ResourceName("db.createAdminFromFirebase"),
+		util.Tag("admin_uid", adminUID))
 	firebaseUser, err := AuthClient.GetUser(context.Background(), *adminUID)
 	if err != nil {
 		spanError := e.Wrap(err, "error retrieving user from firebase api")
-		firebaseSpan.Finish(tracer.WithError(spanError))
+		firebaseSpan.Finish(spanError)
 		return nil, spanError
 	}
 	firebaseSpan.Finish()
 
-	adminSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.createAdmin", tracer.ResourceName("db.admin"))
+	adminSpan, _ := util.StartSpanFromContext(ctx, "resolver.createAdmin", util.ResourceName("db.admin"))
 	admin := &model.Admin{
 		UID:                   adminUID,
 		Name:                  &firebaseUser.DisplayName,
@@ -189,7 +188,7 @@ func (r *Resolver) createAdmin(ctx context.Context) (*model.Admin, error) {
 		Attrs(&admin)
 	if tx.Error != nil {
 		spanError := e.Wrap(tx.Error, "error retrieving user from db")
-		adminSpan.Finish(tracer.WithError(spanError))
+		adminSpan.Finish(spanError)
 		return nil, spanError
 	}
 	adminSpan.Finish()
@@ -312,7 +311,7 @@ func (r *Resolver) demoProjectID(ctx context.Context) int {
 // isAdminInProjectOrDemoProject should be used for actions that you want admins in all projects
 // and laymen in the demo project to have access to.
 func (r *Resolver) isAdminInProjectOrDemoProject(ctx context.Context, project_id int) (*model.Project, error) {
-	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("isAdminInProjectOrDemoProject"))
+	authSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal.auth", util.ResourceName("isAdminInProjectOrDemoProject"))
 	defer authSpan.Finish()
 	start := time.Now()
 	defer func() {
@@ -336,7 +335,7 @@ func (r *Resolver) isAdminInProjectOrDemoProject(ctx context.Context, project_id
 }
 
 func (r *Resolver) isAdminInWorkspaceOrDemoWorkspace(ctx context.Context, workspace_id int) (*model.Workspace, error) {
-	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("isAdminInWorkspaceOrDemoWorkspace"))
+	authSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal.auth", util.ResourceName("isAdminInWorkspaceOrDemoWorkspace"))
 	defer authSpan.Finish()
 	start := time.Now()
 	defer func() {
@@ -451,10 +450,10 @@ func (r *Resolver) DeleteAdminAssociation(ctx context.Context, obj interface{}, 
 }
 
 func (r *Resolver) isAdminInWorkspace(ctx context.Context, workspaceID int) (*model.Workspace, error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("isAdminInWorkspace"))
+	span, _ := util.StartSpanFromContext(ctx, "resolver.internal.auth", util.ResourceName("isAdminInWorkspace"))
 	defer span.Finish()
 
-	span.SetTag("WorkspaceID", workspaceID)
+	span.SetAttribute("WorkspaceID", workspaceID)
 
 	if r.isWhitelistedAccount(ctx) {
 		return r.GetWorkspace(workspaceID)
@@ -465,7 +464,7 @@ func (r *Resolver) isAdminInWorkspace(ctx context.Context, workspaceID int) (*mo
 		return nil, err
 	}
 
-	span.SetTag("AdminID", admin.ID)
+	span.SetAttribute("AdminID", admin.ID)
 
 	workspace := model.Workspace{}
 	if err := r.DB.Order("name asc").
@@ -484,10 +483,10 @@ func (r *Resolver) isAdminInWorkspace(ctx context.Context, workspaceID int) (*mo
 // isAdminInProject should be used for actions that you only want admins in all projects to have access to.
 // Use this on actions that you don't want laymen in the demo project to have access to.
 func (r *Resolver) isAdminInProject(ctx context.Context, project_id int) (*model.Project, error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("isAdminInProject"))
+	span, _ := util.StartSpanFromContext(ctx, "resolver.internal.auth", util.ResourceName("isAdminInProject"))
 	defer span.Finish()
 
-	span.SetTag("ProjectID", project_id)
+	span.SetAttribute("ProjectID", project_id)
 
 	if r.isWhitelistedAccount(ctx) {
 		project := &model.Project{}
@@ -506,7 +505,7 @@ func (r *Resolver) isAdminInProject(ctx context.Context, project_id int) (*model
 
 	for _, p := range projects {
 		if p.ID == project_id {
-			span.SetTag("WorkspaceID", p.WorkspaceID)
+			span.SetAttribute("WorkspaceID", p.WorkspaceID)
 			return p, nil
 		}
 	}
@@ -530,9 +529,9 @@ func (r *Resolver) GetErrorGroupOccurrences(ctx context.Context, eg *model.Error
       union(tables:[query() |> first(), query() |> last()])
         |> sort(columns: ["ErrorGroupID", "_field", "_time"])
 	`, bucket, measurement, eg.ID, filter)
-	span, _ := tracer.StartSpanFromContext(ctx, "tdb.errorGroupOccurrences")
-	span.SetTag("projectID", eg.ProjectID)
-	span.SetTag("errorGroupID", eg.ID)
+	span, _ := util.StartSpanFromContext(ctx, "tdb.errorGroupOccurrences")
+	span.SetAttribute("projectID", eg.ProjectID)
+	span.SetAttribute("errorGroupID", eg.ID)
 	results, err := r.TDB.Query(ctx, query)
 	if err != nil {
 		log.WithContext(ctx).WithError(err).Error("failed to perform tdb query for error group occurrences")
@@ -618,9 +617,9 @@ func (r *Resolver) GetErrorFrequenciesOpensearch(errorGroups []*model.ErrorGroup
 func (r *Resolver) GetErrorGroupFrequenciesUnsampled(ctx context.Context, projectID int, errorGroupID int) ([]*modelInputs.ErrorDistributionItem, error) {
 	bucket, _ := r.TDB.GetSampledMeasurement(r.TDB.GetBucket(strconv.Itoa(projectID), timeseries.Errors), timeseries.Errors, time.Minute)
 	query := timeseries.GetDownsampleQuery(bucket, timeseries.Error, fmt.Sprintf(`|> filter(fn: (r) => r.ErrorGroupID == "%d")`, errorGroupID), true)
-	span, _ := tracer.StartSpanFromContext(ctx, "tdb.errorGroupFrequencies")
-	span.SetTag("projectID", projectID)
-	span.SetTag("errorGroupID", errorGroupID)
+	span, _ := util.StartSpanFromContext(ctx, "tdb.errorGroupFrequencies")
+	span.SetAttribute("projectID", projectID)
+	span.SetAttribute("errorGroupID", errorGroupID)
 	results, err := r.TDB.Query(ctx, query)
 	if err != nil {
 		log.WithContext(ctx).Error(err, "failed to perform tdb query for error group frequencies")
@@ -666,9 +665,9 @@ func (r *Resolver) GetErrorGroupFrequencies(ctx context.Context, projectID int, 
 		|> aggregateWindow(every: %[7]dm, fn: sum, createEmpty: true)
 		|> sort(columns: ["ErrorGroupID", "_field", "_time"])
 	`, bucket, params.DateRange.StartDate.Format(time.RFC3339), params.DateRange.EndDate.Format(time.RFC3339), measurement, errorGroupFilter, extraFilter, params.ResolutionMinutes)
-	span, _ := tracer.StartSpanFromContext(ctx, "tdb.errorGroupFrequencies")
-	span.SetTag("projectID", projectID)
-	span.SetTag("errorGroupIDs", errorGroupIDs)
+	span, _ := util.StartSpanFromContext(ctx, "tdb.errorGroupFrequencies")
+	span.SetAttribute("projectID", projectID)
+	span.SetAttribute("errorGroupIDs", errorGroupIDs)
 	results, err := r.TDB.Query(ctx, query)
 	if err != nil {
 		log.WithContext(ctx).Error(err, "failed to perform tdb query for error group frequencies")
@@ -946,7 +945,7 @@ func (r *Resolver) loadErrorGroupFrequenciesClickhouse(ctx context.Context, eg *
 }
 
 func (r *Resolver) canAdminViewErrorObject(ctx context.Context, errorObjectID int) (*model.ErrorObject, error) {
-	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("canAdminViewErrorObject"))
+	authSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal.auth", util.ResourceName("canAdminViewErrorObject"))
 	defer authSpan.Finish()
 
 	errorObject := model.ErrorObject{}
@@ -964,7 +963,7 @@ func (r *Resolver) canAdminViewErrorObject(ctx context.Context, errorObjectID in
 }
 
 func (r *Resolver) canAdminViewErrorGroup(ctx context.Context, errorGroupSecureID string) (*model.ErrorGroup, error) {
-	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("canAdminViewErrorGroup"))
+	authSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal.auth", util.ResourceName("canAdminViewErrorGroup"))
 	defer authSpan.Finish()
 	errorGroup, isOwner, err := r.doesAdminOwnErrorGroup(ctx, errorGroupSecureID)
 	if err == nil && isOwner {
@@ -977,7 +976,7 @@ func (r *Resolver) canAdminViewErrorGroup(ctx context.Context, errorGroupSecureI
 }
 
 func (r *Resolver) canAdminModifyErrorGroup(ctx context.Context, errorGroupSecureID string) (*model.ErrorGroup, error) {
-	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("canAdminModifyErrorGroup"))
+	authSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal.auth", util.ResourceName("canAdminModifyErrorGroup"))
 	defer authSpan.Finish()
 	errorGroup, isOwner, err := r.doesAdminOwnErrorGroup(ctx, errorGroupSecureID)
 	if err == nil && isOwner {
@@ -998,7 +997,7 @@ func (r *Resolver) _doesAdminOwnSession(ctx context.Context, sessionSecureId str
 }
 
 func (r *Resolver) canAdminViewSession(ctx context.Context, session_secure_id string) (*model.Session, error) {
-	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("canAdminViewSession"))
+	authSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal.auth", util.ResourceName("canAdminViewSession"))
 	defer authSpan.Finish()
 	session, isOwner, err := r._doesAdminOwnSession(ctx, session_secure_id)
 	if err != nil {
@@ -1022,7 +1021,7 @@ func (r *Resolver) canAdminViewSession(ctx context.Context, session_secure_id st
 }
 
 func (r *Resolver) canAdminModifySession(ctx context.Context, session_secure_id string) (*model.Session, error) {
-	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("canAdminModifySession"))
+	authSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal.auth", util.ResourceName("canAdminModifySession"))
 	defer authSpan.Finish()
 	session, isOwner, err := r._doesAdminOwnSession(ctx, session_secure_id)
 	if err == nil && isOwner {
@@ -1032,7 +1031,7 @@ func (r *Resolver) canAdminModifySession(ctx context.Context, session_secure_id 
 }
 
 func (r *Resolver) isAdminSegmentOwner(ctx context.Context, segment_id int) (*model.Segment, error) {
-	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("isAdminSegmentOwner"))
+	authSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal.auth", util.ResourceName("isAdminSegmentOwner"))
 	defer authSpan.Finish()
 	segment := &model.Segment{}
 	if err := r.DB.Where(&model.Segment{Model: model.Model{ID: segment_id}}).Take(&segment).Error; err != nil {
@@ -1046,7 +1045,7 @@ func (r *Resolver) isAdminSegmentOwner(ctx context.Context, segment_id int) (*mo
 }
 
 func (r *Resolver) isAdminErrorSegmentOwner(ctx context.Context, error_segment_id int) (*model.ErrorSegment, error) {
-	authSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal.auth", tracer.ResourceName("isAdminErrorSegmentOwner"))
+	authSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal.auth", util.ResourceName("isAdminErrorSegmentOwner"))
 	defer authSpan.Finish()
 	segment := &model.ErrorSegment{}
 	if err := r.DB.Where(&model.ErrorSegment{Model: model.Model{ID: error_segment_id}}).Take(&segment).Error; err != nil {
@@ -1336,7 +1335,7 @@ func (r *Resolver) getSessionInsightPrompt(ctx context.Context, events []interfa
 	}
 
 	userPrompt := fmt.Sprintf(`
-	Input: 
+	Input:
 	%v
 	`, string(b))
 
@@ -1358,7 +1357,7 @@ func (r *Resolver) getSessionInsight(ctx context.Context, session *model.Session
 	- Insights must be different to each other
 	- Do not mention identification or authentication events
 	- Don't mention timestamps in <insight>, insights should be interesting inferences from the input
-	- Output timestamp that best represents the insight in <timestamp> of output	
+	- Output timestamp that best represents the insight in <timestamp> of output
 	- Sort the insights by timestamp
 
 	You must respond ONLY with JSON that looks like this:
@@ -3038,8 +3037,8 @@ func (r *Resolver) sendFollowedCommentNotification(
 	if len(threadIDs) > 0 {
 		r.PrivateWorkerPool.SubmitRecover(func() {
 			ctx := context.Background()
-			commentMentionSlackSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.sendFollowedCommentNotification",
-				tracer.ResourceName("slackBot.sendCommentFollowerUpdate"), tracer.Tag("project_id", projectID), tracer.Tag("count", len(followers)), tracer.Tag("subjectScope", subjectScope))
+			commentMentionSlackSpan, _ := util.StartSpanFromContext(ctx, "resolver.sendFollowedCommentNotification",
+				util.ResourceName("slackBot.sendCommentFollowerUpdate"), util.Tag("project_id", projectID), util.Tag("count", len(followers)), util.Tag("subjectScope", subjectScope))
 			defer commentMentionSlackSpan.Finish()
 
 			err := r.SendSlackThreadReply(ctx, workspace, admin, viewLink, textForEmail, action, subjectScope, threadIDs)
@@ -3052,8 +3051,8 @@ func (r *Resolver) sendFollowedCommentNotification(
 	if len(tos) > 0 {
 		r.PrivateWorkerPool.SubmitRecover(func() {
 			ctx := context.Background()
-			commentMentionEmailSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.sendFollowedCommentNotification",
-				tracer.ResourceName("sendgrid.sendFollowerEmail"), tracer.Tag("project_id", projectID), tracer.Tag("count", len(followers)), tracer.Tag("action", action), tracer.Tag("subjectScope", subjectScope))
+			commentMentionEmailSpan, _ := util.StartSpanFromContext(ctx, "resolver.sendFollowedCommentNotification",
+				util.ResourceName("sendgrid.sendFollowerEmail"), util.Tag("project_id", projectID), util.Tag("count", len(followers)), util.Tag("action", action), util.Tag("subjectScope", subjectScope))
 			defer commentMentionEmailSpan.Finish()
 
 			err := r.SendEmailAlert(
@@ -3078,8 +3077,8 @@ func (r *Resolver) sendFollowedCommentNotification(
 func (r *Resolver) sendCommentMentionNotification(ctx context.Context, admin *model.Admin, taggedSlackUsers []*modelInputs.SanitizedSlackChannelInput, workspace *model.Workspace, projectID int, sessionCommentID *int, errorCommentID *int, textForEmail string, viewLink string, sessionImage *string, action string, subjectScope string, additionalContext *string) {
 	r.PrivateWorkerPool.SubmitRecover(func() {
 		ctx := context.Background()
-		commentMentionSlackSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.sendCommentMentionNotification",
-			tracer.ResourceName("slackBot.sendCommentMention"), tracer.Tag("project_id", projectID), tracer.Tag("count", len(taggedSlackUsers)), tracer.Tag("subjectScope", subjectScope))
+		commentMentionSlackSpan, _ := util.StartSpanFromContext(ctx, "resolver.sendCommentMentionNotification",
+			util.ResourceName("slackBot.sendCommentMention"), util.Tag("project_id", projectID), util.Tag("count", len(taggedSlackUsers)), util.Tag("subjectScope", subjectScope))
 		defer commentMentionSlackSpan.Finish()
 
 		err := r.SendSlackAlertToUser(ctx, workspace, admin, taggedSlackUsers, viewLink, textForEmail, action, subjectScope, sessionImage, sessionCommentID, errorCommentID, additionalContext)
@@ -3139,8 +3138,8 @@ func (r *Resolver) sendCommentPrimaryNotification(
 
 	r.PrivateWorkerPool.SubmitRecover(func() {
 		ctx := context.Background()
-		commentMentionEmailSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.sendCommentPrimaryNotification",
-			tracer.ResourceName("sendgrid.sendCommentMention"), tracer.Tag("project_id", projectID), tracer.Tag("count", len(taggedAdmins)), tracer.Tag("action", action), tracer.Tag("subjectScope", subjectScope))
+		commentMentionEmailSpan, _ := util.StartSpanFromContext(ctx, "resolver.sendCommentPrimaryNotification",
+			util.ResourceName("sendgrid.sendCommentMention"), util.Tag("project_id", projectID), util.Tag("count", len(taggedAdmins)), util.Tag("action", action), util.Tag("subjectScope", subjectScope))
 		defer commentMentionEmailSpan.Finish()
 
 		err := r.SendEmailAlert(
@@ -3162,8 +3161,8 @@ func (r *Resolver) sendCommentPrimaryNotification(
 
 	r.PrivateWorkerPool.SubmitRecover(func() {
 		ctx := context.Background()
-		commentMentionSlackSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.sendCommentPrimaryNotification",
-			tracer.ResourceName("slack.sendCommentMention"), tracer.Tag("project_id", projectID), tracer.Tag("count", len(adminIds)), tracer.Tag("action", action), tracer.Tag("subjectScope", subjectScope))
+		commentMentionSlackSpan, _ := util.StartSpanFromContext(ctx, "resolver.sendCommentPrimaryNotification",
+			util.ResourceName("slack.sendCommentMention"), util.Tag("project_id", projectID), util.Tag("count", len(adminIds)), util.Tag("action", action), util.Tag("subjectScope", subjectScope))
 		defer commentMentionSlackSpan.Finish()
 
 		var admins []*model.Admin
@@ -3509,10 +3508,10 @@ func GetMetricTimeline(ctx context.Context, tdb timeseries.DB, projectID int, me
 		agg = *params.Aggregator
 	}
 	query += GetAggregateFluxStatement(ctx, agg, resMins)
-	timelineQuerySpan, _ := tracer.StartSpanFromContext(ctx, "tdb.queryTimeline")
-	timelineQuerySpan.SetTag("projectID", projectID)
-	timelineQuerySpan.SetTag("metricName", metricName)
-	timelineQuerySpan.SetTag("resMins", resMins)
+	timelineQuerySpan, _ := util.StartSpanFromContext(ctx, "tdb.queryTimeline")
+	timelineQuerySpan.SetAttribute("projectID", projectID)
+	timelineQuerySpan.SetAttribute("metricName", metricName)
+	timelineQuerySpan.SetAttribute("resMins", resMins)
 	results, err := tdb.Query(ctx, query)
 	timelineQuerySpan.Finish()
 	if err != nil {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -61,7 +61,6 @@ import (
 	stripe "github.com/stripe/stripe-go/v72"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -1462,8 +1461,8 @@ func (r *mutationResolver) CreateSessionComment(ctx context.Context, projectID i
 		XCoordinate:     xCoordinate,
 		YCoordinate:     yCoordinate,
 	}
-	createSessionCommentSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.createSessionComment",
-		tracer.ResourceName("db.createSessionComment"), tracer.Tag("project_id", projectID))
+	createSessionCommentSpan, _ := util.StartSpanFromContext(ctx, "resolver.createSessionComment",
+		util.ResourceName("db.createSessionComment"), util.Tag("project_id", projectID))
 	if err := r.DB.Create(sessionComment).Error; err != nil {
 		return nil, e.Wrap(err, "error creating session comment")
 	}
@@ -1836,8 +1835,8 @@ func (r *mutationResolver) ReplyToSessionComment(ctx context.Context, commentID 
 		AdminId:          admin.ID,
 		Text:             text,
 	}
-	createSessionCommentReplySpan, _ := tracer.StartSpanFromContext(ctx, "resolver.createSessionCommentReply",
-		tracer.ResourceName("db.createSessionCommentReply"), tracer.Tag("project_id", sessionComment.ProjectID))
+	createSessionCommentReplySpan, _ := util.StartSpanFromContext(ctx, "resolver.createSessionCommentReply",
+		util.ResourceName("db.createSessionCommentReply"), util.Tag("project_id", sessionComment.ProjectID))
 	if err := r.DB.Create(commentReply).Error; err != nil {
 		return nil, e.Wrap(err, "error creating session comment reply")
 	}
@@ -1945,8 +1944,8 @@ func (r *mutationResolver) CreateErrorComment(ctx context.Context, projectID int
 		Text:          text,
 	}
 
-	createErrorCommentSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.createErrorComment",
-		tracer.ResourceName("db.createErrorComment"), tracer.Tag("project_id", projectID))
+	createErrorCommentSpan, _ := util.StartSpanFromContext(ctx, "resolver.createErrorComment",
+		util.ResourceName("db.createErrorComment"), util.Tag("project_id", projectID))
 
 	if err := r.DB.Create(errorComment).Error; err != nil {
 		return nil, e.Wrap(err, "error creating error comment")
@@ -2275,8 +2274,8 @@ func (r *mutationResolver) ReplyToErrorComment(ctx context.Context, commentID in
 		AdminId:        admin.ID,
 		Text:           text,
 	}
-	createErrorCommentReplySpan, _ := tracer.StartSpanFromContext(ctx, "resolver.createErrorCommentReply",
-		tracer.ResourceName("db.createErrorCommentReply"), tracer.Tag("project_id", errorComment.ProjectID))
+	createErrorCommentReplySpan, _ := util.StartSpanFromContext(ctx, "resolver.createErrorCommentReply",
+		util.ResourceName("db.createErrorCommentReply"), util.Tag("project_id", errorComment.ProjectID))
 	if err := r.DB.Create(commentReply).Error; err != nil {
 		return nil, e.Wrap(err, "error creating error comment reply")
 	}
@@ -3191,7 +3190,7 @@ func (r *mutationResolver) RequestAccess(ctx context.Context, projectID int) (*b
 	// RequestAccessMinimumDelay is the minimum time required between requests from an admin (across workspaces)
 	const RequestAccessMinimumDelay = time.Minute * 10
 
-	span, _ := tracer.StartSpanFromContext(ctx, "private-graph.RequestAccess", tracer.ResourceName("handler"), tracer.Tag("project_id", projectID))
+	span, _ := util.StartSpanFromContext(ctx, "private-graph.RequestAccess", util.ResourceName("handler"), util.Tag("project_id", projectID))
 	defer span.Finish()
 	// sleep up to 10 ms to avoid leaking metadata about whether the project exists or not (how many queries deep we went).
 	time.Sleep(time.Millisecond * time.Duration(10*rand.Float64()))
@@ -4109,8 +4108,8 @@ func (r *queryResolver) RageClicksForProject(ctx context.Context, projectID int,
 
 	rageClicks := []*modelInputs.RageClickEventForProject{}
 
-	rageClicksSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal",
-		tracer.ResourceName("db.RageClicksForProject"), tracer.Tag("project_id", projectID))
+	rageClicksSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal",
+		util.ResourceName("db.RageClicksForProject"), util.Tag("project_id", projectID))
 	if err := r.DB.Raw(`
 	SELECT
 		COALESCE(NULLIF(identifier, ''), CONCAT('#', fingerprint)) as identifier,
@@ -4170,8 +4169,8 @@ func (r *queryResolver) ErrorGroupsOpensearch(ctx context.Context, projectID int
 		// page param is 1 indexed
 		options.ResultsFrom = ptr.Int((*page - 1) * count)
 	}
-	errorGroupsOpensearchSearchSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal",
-		tracer.ResourceName("resolver.errorGroupsOpensearchSearchQuery"), tracer.Tag("project_id", projectID))
+	errorGroupsOpensearchSearchSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal",
+		util.ResourceName("resolver.errorGroupsOpensearchSearchQuery"), util.Tag("project_id", projectID))
 	q := FormatErrorGroupsQuery(query, GetRetentionDate(workspace.ErrorsRetentionPeriod))
 	resultCount, _, err := r.OpenSearch.Search([]opensearch.Index{opensearch.IndexErrorsCombined}, projectID, q, options, &results)
 	errorGroupsOpensearchSearchSpan.Finish()
@@ -4185,8 +4184,8 @@ func (r *queryResolver) ErrorGroupsOpensearch(ctx context.Context, projectID int
 		asErrorGroups = append(asErrorGroups, result.ErrorGroup)
 	}
 
-	errorFrequencyInfluxSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal",
-		tracer.ResourceName("resolver.errorFrequencyInflux"), tracer.Tag("project_id", projectID))
+	errorFrequencyInfluxSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal",
+		util.ResourceName("resolver.errorFrequencyInflux"), util.Tag("project_id", projectID))
 
 	err = r.SetErrorFrequencies(ctx, projectID, asErrorGroups, ErrorGroupLookbackDays)
 	errorFrequencyInfluxSpan.Finish()
@@ -4480,9 +4479,9 @@ func (r *queryResolver) EnhancedUserDetails(ctx context.Context, sessionSecureID
 			}
 			log.WithContext(ctx).Infof("retrieving api response for clearbit lookup")
 			hlog.Incr("private-graph.enhancedDetails.miss", nil, 1)
-			clearbitApiRequestSpan, ctx := tracer.StartSpanFromContext(ctx, "private-graph.EnhancedUserDetails",
-				tracer.ResourceName("clearbit.api.request"),
-				tracer.Tag("session_id", s.ID), tracer.Tag("workspace_id", w.ID), tracer.Tag("project_id", p.ID), tracer.Tag("plan_tier", w.PlanTier))
+			clearbitApiRequestSpan, ctx := util.StartSpanFromContext(ctx, "private-graph.EnhancedUserDetails",
+				util.ResourceName("clearbit.api.request"),
+				util.Tag("session_id", s.ID), util.Tag("workspace_id", w.ID), util.Tag("project_id", p.ID), util.Tag("plan_tier", w.PlanTier))
 			pc, _, err := r.ClearbitClient.Person.FindCombined(clearbit.PersonFindParams{Email: email})
 			clearbitApiRequestSpan.Finish()
 			p, co = pc.Person, pc.Company
@@ -4565,8 +4564,8 @@ func (r *queryResolver) Errors(ctx context.Context, sessionSecureID string) ([]*
 	if err != nil {
 		return nil, err
 	}
-	eventsQuerySpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal",
-		tracer.ResourceName("db.errorObjectsQuery"), tracer.Tag("project_id", s.ProjectID))
+	eventsQuerySpan, _ := util.StartSpanFromContext(ctx, "resolver.internal",
+		util.ResourceName("db.errorObjectsQuery"), util.Tag("project_id", s.ProjectID))
 	defer eventsQuerySpan.Finish()
 	errorsObj := []*model.ErrorObject{}
 	if err := r.DB.Order("created_at asc").Where(&model.ErrorObject{SessionID: &s.ID}).Find(&errorsObj).Error; err != nil {
@@ -5197,8 +5196,8 @@ func (r *queryResolver) TopUsers(ctx context.Context, projectID int, lookBackPer
 	}
 
 	var topUsersPayload = []*modelInputs.TopUsersPayload{}
-	topUsersSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.internal",
-		tracer.ResourceName("db.topUsers"), tracer.Tag("project_id", projectID))
+	topUsersSpan, _ := util.StartSpanFromContext(ctx, "resolver.internal",
+		util.ResourceName("db.topUsers"), util.Tag("project_id", projectID))
 	if err := r.DB.Raw(`
 	SELECT *
 	FROM (
@@ -5307,8 +5306,8 @@ func (r *queryResolver) UserFingerprintCount(ctx context.Context, projectID int,
 	}
 
 	var count int64
-	span, _ := tracer.StartSpanFromContext(ctx, "resolver.internal",
-		tracer.ResourceName("db.userFingerprintCount"), tracer.Tag("project_id", projectID))
+	span, _ := util.StartSpanFromContext(ctx, "resolver.internal",
+		util.ResourceName("db.userFingerprintCount"), util.Tag("project_id", projectID))
 	if err := r.DB.Raw(`
 		SELECT
 			COUNT(DISTINCT fingerprint)
@@ -6925,8 +6924,8 @@ func (r *queryResolver) WorkspaceForProject(ctx context.Context, projectID int) 
 // Admin is the resolver for the admin field.
 func (r *queryResolver) Admin(ctx context.Context) (*model.Admin, error) {
 	admin := &model.Admin{UID: pointy.String(fmt.Sprintf("%v", ctx.Value(model.ContextKeys.UID)))}
-	adminSpan, ctx := tracer.StartSpanFromContext(ctx, "resolver.getAdmin", tracer.ResourceName("db.admin"),
-		tracer.Tag("admin_uid", admin.UID))
+	adminSpan, ctx := util.StartSpanFromContext(ctx, "resolver.getAdmin", util.ResourceName("db.admin"),
+		util.Tag("admin_uid", admin.UID))
 
 	if err := r.DB.Where(&model.Admin{UID: admin.UID}).Take(&admin).Error; err != nil {
 		if e.Is(err, gorm.ErrRecordNotFound) {
@@ -6935,33 +6934,33 @@ func (r *queryResolver) Admin(ctx context.Context) (*model.Admin, error) {
 			// create a new user in our DB.
 			if admin, err = r.createAdmin(ctx); err != nil {
 				spanError := e.Wrap(err, "error creating admin in postgres")
-				adminSpan.Finish(tracer.WithError(spanError))
+				adminSpan.Finish(spanError)
 				return nil, spanError
 			}
 		} else {
 			spanError := e.Wrap(err, "error retrieving admin from postgres")
-			adminSpan.Finish(tracer.WithError(spanError))
+			adminSpan.Finish(spanError)
 			return nil, spanError
 		}
 	}
 
 	// Check email verification status
 	if admin.EmailVerified != nil && !*admin.EmailVerified {
-		firebaseSpan, _ := tracer.StartSpanFromContext(ctx, "resolver.getAdmin", tracer.ResourceName("db.updateAdminFromFirebaseForEmailVerification"),
-			tracer.Tag("admin_uid", *admin.UID))
+		firebaseSpan, _ := util.StartSpanFromContext(ctx, "resolver.getAdmin", util.ResourceName("db.updateAdminFromFirebaseForEmailVerification"),
+			util.Tag("admin_uid", *admin.UID))
 		firebaseUser, err := AuthClient.GetUser(context.Background(), *admin.UID)
 		if err != nil {
 			spanError := e.Wrap(err, "error retrieving user from firebase api for email verification")
-			adminSpan.Finish(tracer.WithError(spanError))
-			firebaseSpan.Finish(tracer.WithError(spanError))
+			adminSpan.Finish(spanError)
+			firebaseSpan.Finish(spanError)
 			return nil, spanError
 		}
 		if err := r.DB.Where(&model.Admin{UID: admin.UID}).Updates(&model.Admin{
 			EmailVerified: &firebaseUser.EmailVerified,
 		}).Error; err != nil {
 			spanError := e.Wrap(err, "error updating admin fields")
-			adminSpan.Finish(tracer.WithError(spanError))
-			firebaseSpan.Finish(tracer.WithError(spanError))
+			adminSpan.Finish(spanError)
+			firebaseSpan.Finish(spanError)
 			return nil, spanError
 		}
 		admin.EmailVerified = &firebaseUser.EmailVerified
@@ -7250,8 +7249,8 @@ func (r *queryResolver) SuggestedMetrics(ctx context.Context, projectID int, pre
 		  |> distinct(column: "_field")
 		  |> yield(name: "distinct")
 	`, r.TDB.GetBucket(strconv.Itoa(projectID), timeseries.Metrics), timeseries.Metrics, filter)
-	tdbQuerySpan, _ := tracer.StartSpanFromContext(ctx, "tdb.querySuggestedMetrics")
-	tdbQuerySpan.SetTag("projectID", projectID)
+	tdbQuerySpan, _ := util.StartSpanFromContext(ctx, "tdb.querySuggestedMetrics")
+	tdbQuerySpan.SetAttribute("projectID", projectID)
 	results, err := r.TDB.Query(ctx, query)
 	tdbQuerySpan.Finish()
 	if err != nil {
@@ -7273,9 +7272,9 @@ func (r *queryResolver) MetricTags(ctx context.Context, projectID int, metricNam
 		import "influxdata/influxdb/schema"
 		schema.tagKeys(bucket: "%s", predicate: (r) => r["_measurement"] == "%s" and r["_field"] == "%s")
 	`, r.TDB.GetBucket(strconv.Itoa(projectID), timeseries.Metrics), timeseries.Metrics, metricName)
-	tdbQuerySpan, _ := tracer.StartSpanFromContext(ctx, "tdb.queryMetricTags")
-	tdbQuerySpan.SetTag("projectID", projectID)
-	tdbQuerySpan.SetTag("metricName", metricName)
+	tdbQuerySpan, _ := util.StartSpanFromContext(ctx, "tdb.queryMetricTags")
+	tdbQuerySpan.SetAttribute("projectID", projectID)
+	tdbQuerySpan.SetAttribute("metricName", metricName)
 	results, err := r.TDB.Query(ctx, query)
 	tdbQuerySpan.Finish()
 	if err != nil {
@@ -7303,10 +7302,10 @@ func (r *queryResolver) MetricTagValues(ctx context.Context, projectID int, metr
 		import "influxdata/influxdb/schema"
 		schema.tagValues(bucket: "%s", tag: "%s", predicate: (r) => r["_measurement"] == "%s" and r["_field"] == "%s")
 	`, r.TDB.GetBucket(strconv.Itoa(projectID), timeseries.Metrics), tagName, timeseries.Metrics, metricName)
-	tdbQuerySpan, _ := tracer.StartSpanFromContext(ctx, "tdb.queryMetricTagValues")
-	tdbQuerySpan.SetTag("projectID", projectID)
-	tdbQuerySpan.SetTag("metricName", metricName)
-	tdbQuerySpan.SetTag("tagName", tagName)
+	tdbQuerySpan, _ := util.StartSpanFromContext(ctx, "tdb.queryMetricTagValues")
+	tdbQuerySpan.SetAttribute("projectID", projectID)
+	tdbQuerySpan.SetAttribute("metricName", metricName)
+	tdbQuerySpan.SetAttribute("tagName", tagName)
 	results, err := r.TDB.Query(ctx, query)
 	tdbQuerySpan.Finish()
 	if err != nil {
@@ -7359,9 +7358,9 @@ func (r *queryResolver) MetricsHistogram(ctx context.Context, projectID int, met
 	  ])
 		  |> sort()
   `, bucket, params.DateRange.StartDate.Format(time.RFC3339), params.DateRange.EndDate.Format(time.RFC3339), measurement, metricName, tagFilters, div, minPercentile, maxPercentile)
-		histogramRangeQuerySpan, _ := tracer.StartSpanFromContext(ctx, "tdb.queryHistogram")
-		histogramRangeQuerySpan.SetTag("projectID", projectID)
-		histogramRangeQuerySpan.SetTag("metricName", metricName)
+		histogramRangeQuerySpan, _ := util.StartSpanFromContext(ctx, "tdb.queryHistogram")
+		histogramRangeQuerySpan.SetAttribute("projectID", projectID)
+		histogramRangeQuerySpan.SetAttribute("metricName", metricName)
 		results, err := r.TDB.Query(ctx, query)
 		histogramRangeQuerySpan.Finish()
 		if err != nil {
@@ -7405,10 +7404,10 @@ func (r *queryResolver) MetricsHistogram(ctx context.Context, projectID int, met
 		  |> histogram(bins: linearBins(start: %f, width: %f, count: %d, infinity: true))
           |> map(fn: (r) => ({r with le: r.le / %f}))
 	`, bucket, params.DateRange.StartDate.Format(time.RFC3339), params.DateRange.EndDate.Format(time.RFC3339), measurement, metricName, tagFilters, histogramPayload.Min*div, bucketSize*div, numBuckets, div)
-	histogramQuerySpan, _ := tracer.StartSpanFromContext(ctx, "tdb.queryHistogram")
-	histogramQuerySpan.SetTag("projectID", projectID)
-	histogramQuerySpan.SetTag("metricName", metricName)
-	histogramQuerySpan.SetTag("buckets", params.Buckets)
+	histogramQuerySpan, _ := util.StartSpanFromContext(ctx, "tdb.queryHistogram")
+	histogramQuerySpan.SetAttribute("projectID", projectID)
+	histogramQuerySpan.SetAttribute("metricName", metricName)
+	histogramQuerySpan.SetAttribute("buckets", params.Buckets)
 	results, err := r.TDB.Query(ctx, query)
 	histogramQuerySpan.Finish()
 	if err != nil {
@@ -7470,10 +7469,10 @@ func (r *queryResolver) NetworkHistogram(ctx context.Context, projectID int, par
           |> limit(n: 10)
 		  |> yield(name: "count")
 	`, r.TDB.GetBucket(strconv.Itoa(projectID), timeseries.Metrics), days, timeseries.Metrics, extraFiltersStr, params.Attribute.String())
-	networkHistogramSpan, _ := tracer.StartSpanFromContext(ctx, "tdb.queryTimeline")
-	networkHistogramSpan.SetTag("projectID", projectID)
-	networkHistogramSpan.SetTag("attribute", params.Attribute.String())
-	networkHistogramSpan.SetTag("lookbackDays", params.LookbackDays)
+	networkHistogramSpan, _ := util.StartSpanFromContext(ctx, "tdb.queryTimeline")
+	networkHistogramSpan.SetAttribute("projectID", projectID)
+	networkHistogramSpan.SetAttribute("attribute", params.Attribute.String())
+	networkHistogramSpan.SetAttribute("lookbackDays", params.LookbackDays)
 	results, err := r.TDB.Query(ctx, query)
 	networkHistogramSpan.Finish()
 	if err != nil {
@@ -7737,15 +7736,15 @@ func (r *queryResolver) LogsKeyValues(ctx context.Context, projectID int, keyNam
 
 // LogsErrorObjects is the resolver for the logs_error_objects field.
 func (r *queryResolver) LogsErrorObjects(ctx context.Context, logCursors []string) ([]*model.ErrorObject, error) {
-	ddS, _ := tracer.StartSpanFromContext(ctx, "resolver.LogsErrorObjects",
-		tracer.ResourceName("DB.Query"), tracer.Tag("NumLogCursors", len(logCursors)))
+	ddS, _ := util.StartSpanFromContext(ctx, "resolver.LogsErrorObjects",
+		util.ResourceName("DB.Query"), util.Tag("NumLogCursors", len(logCursors)))
 	s, ctx := highlight.StartTrace(ctx, "LogsErrorObjects.DB.Query", attribute.Int("NumLogCursors", len(logCursors)))
 
 	var errorObjects []*model.ErrorObject
 	if err := r.DB.Model(&model.ErrorObject{}).Where("log_cursor IN ?", logCursors).Scan(&errorObjects).Error; err != nil {
 		s.RecordError(err)
 		highlight.EndTrace(s)
-		ddS.Finish(tracer.WithError(err))
+		ddS.Finish(err)
 		return nil, e.Wrap(err, "failed to find errors for log cursors")
 	}
 	highlight.EndTrace(s)

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -33,7 +33,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
@@ -172,12 +171,12 @@ var MetricCategoriesForDB = map[string]bool{"Device": true, "WebVital": true}
 
 // Change to AppendProperties(sessionId,properties,type)
 func (r *Resolver) AppendProperties(ctx context.Context, sessionID int, properties map[string]string, propType Property) error {
-	outerSpan, ctx := tracer.StartSpanFromContext(ctx, "public-graph.AppendProperties",
-		tracer.ResourceName("go.sessions.AppendProperties"), tracer.Tag("sessionID", sessionID))
+	outerSpan, ctx := util.StartSpanFromContext(ctx, "public-graph.AppendProperties",
+		util.ResourceName("go.sessions.AppendProperties"), util.Tag("sessionID", sessionID))
 	defer outerSpan.Finish()
 
-	loadSessionSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.AppendProperties",
-		tracer.ResourceName("go.sessions.AppendProperties.loadSessions"), tracer.Tag("sessionID", sessionID))
+	loadSessionSpan, _ := util.StartSpanFromContext(ctx, "public-graph.AppendProperties",
+		util.ResourceName("go.sessions.AppendProperties.loadSessions"), util.Tag("sessionID", sessionID))
 	session := &model.Session{}
 	res := r.DB.Where(&model.Session{Model: model.Model{ID: sessionID}}).Take(&session)
 	if err := res.Error; err != nil {
@@ -185,8 +184,8 @@ func (r *Resolver) AppendProperties(ctx context.Context, sessionID int, properti
 	}
 	loadSessionSpan.Finish()
 
-	propsSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.AppendProperties",
-		tracer.ResourceName("processProperties"), tracer.Tag("num_properties", len(properties)))
+	propsSpan, _ := util.StartSpanFromContext(ctx, "public-graph.AppendProperties",
+		util.ResourceName("processProperties"), util.Tag("num_properties", len(properties)))
 	var modelFields []*model.Field
 	projectID := session.ProjectID
 	for k, fv := range properties {
@@ -236,8 +235,8 @@ func (r *Resolver) AppendProperties(ctx context.Context, sessionID int, properti
 }
 
 func (r *Resolver) AppendFields(ctx context.Context, fields []*model.Field, session *model.Session) error {
-	outerSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.AppendFields",
-		tracer.ResourceName("go.sessions.AppendFields"), tracer.Tag("sessionID", session.ID))
+	outerSpan, _ := util.StartSpanFromContext(ctx, "public-graph.AppendFields",
+		util.ResourceName("go.sessions.AppendFields"), util.Tag("sessionID", session.ID))
 	defer outerSpan.Finish()
 
 	result := r.DB.
@@ -467,7 +466,7 @@ func (r *Resolver) GetOrCreateErrorGroup(ctx context.Context, errorObj *model.Er
 }
 
 func (r *Resolver) GetTopErrorGroupMatchByEmbedding(ctx context.Context, projectID int, method model.ErrorGroupingMethod, embedding model.Vector, threshold float64) (*int, error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "public-resolver", tracer.ResourceName("GetTopErrorGroupMatchByEmbedding"))
+	span, _ := util.StartSpanFromContext(ctx, "public-resolver", util.ResourceName("GetTopErrorGroupMatchByEmbedding"))
 	defer span.Finish()
 
 	result := struct {
@@ -954,8 +953,8 @@ func (r *Resolver) AppendErrorFields(ctx context.Context, fields []*model.ErrorF
 }
 
 func GetLocationFromIP(ctx context.Context, ip string) (location *Location, err error) {
-	s, _ := tracer.StartSpanFromContext(ctx, "public-graph.GetLocationFromIP",
-		tracer.ResourceName("getLocationFromIP"))
+	s, _ := util.StartSpanFromContext(ctx, "public-graph.GetLocationFromIP",
+		util.ResourceName("getLocationFromIP"))
 	defer s.Finish()
 	url := fmt.Sprintf("http://geolocation-db.com/json/%s", ip)
 	method := "GET"
@@ -1029,7 +1028,7 @@ func (r *Resolver) getExistingSession(ctx context.Context, projectID int, secure
 }
 
 func (r *Resolver) IndexSessionOpensearch(ctx context.Context, session *model.Session) error {
-	osSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.InitializeSessionImpl", tracer.ResourceName("go.sessions.OSIndex"))
+	osSpan, _ := util.StartSpanFromContext(ctx, "public-graph.InitializeSessionImpl", util.ResourceName("go.sessions.OSIndex"))
 	defer osSpan.Finish()
 	if err := r.OpenSearch.IndexSynchronous(ctx,
 		opensearch.IndexParams{
@@ -1059,13 +1058,13 @@ func (r *Resolver) IndexSessionOpensearch(ctx context.Context, session *model.Se
 }
 
 func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue.InitializeSessionArgs) (*model.Session, error) {
-	initSpan, initCtx := tracer.StartSpanFromContext(ctx, "public-graph.InitializeSessionImpl",
-		tracer.ResourceName("go.sessions.InitializeSessionImpl"),
-		tracer.Tag("duplicate", true))
+	initSpan, initCtx := util.StartSpanFromContext(ctx, "public-graph.InitializeSessionImpl",
+		util.ResourceName("go.sessions.InitializeSessionImpl"),
+		util.Tag("duplicate", true))
 	defer initSpan.Finish()
 
 	defer func() {
-		redisSpan, redisCtx := tracer.StartSpanFromContext(initCtx, "public-graph.InitializeSessionImpl", tracer.ResourceName("go.sessions.setRedis"))
+		redisSpan, redisCtx := util.StartSpanFromContext(initCtx, "public-graph.InitializeSessionImpl", util.ResourceName("go.sessions.setRedis"))
 		defer redisSpan.Finish()
 		err := r.Redis.SetIsPendingSession(redisCtx, input.SessionSecureID, false)
 		if err != nil {
@@ -1090,9 +1089,9 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 		}
 		return existingSession, nil
 	}
-	initSpan.SetTag("duplicate", false)
+	initSpan.SetAttribute("duplicate", false)
 
-	setupSpan, _ := tracer.StartSpanFromContext(initCtx, "public-graph.InitializeSessionImpl", tracer.ResourceName("go.sessions.setup"))
+	setupSpan, _ := util.StartSpanFromContext(initCtx, "public-graph.InitializeSessionImpl", util.ResourceName("go.sessions.setup"))
 	project := &model.Project{}
 	if err := r.DB.Where(&model.Project{Model: model.Model{ID: projectID}}).Take(&project).Error; err != nil {
 		return nil, e.Wrapf(err, "project doesn't exist project_id:%d", projectID)
@@ -1193,8 +1192,8 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 			return nil, err
 		}
 		if existingSession != nil {
-			initSpan.SetTag("duplicate", true)
-			initSpan.SetTag("duplicateRace", true)
+			initSpan.SetAttribute("duplicate", true)
+			initSpan.SetAttribute("duplicateRace", true)
 			return existingSession, nil
 		}
 		return nil, e.New("failed to find duplicate session: " + input.SessionSecureID)
@@ -1431,8 +1430,8 @@ func (r *Resolver) AddSessionFeedbackImpl(ctx context.Context, input *kafka_queu
 	return nil
 }
 func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID string, userIdentifier string, userObject interface{}, backfill bool) error {
-	outerSpan, outerCtx := tracer.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
-		tracer.ResourceName("go.sessions.IdentifySessionImpl"), tracer.Tag("sessionSecureID", sessionSecureID))
+	outerSpan, outerCtx := util.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
+		util.ResourceName("go.sessions.IdentifySessionImpl"), util.Tag("sessionSecureID", sessionSecureID))
 	defer outerSpan.Finish()
 
 	obj, ok := userObject.(map[string]interface{})
@@ -1452,8 +1451,8 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 		newUserProperties["email"] = userIdentifier
 	}
 
-	getSessionSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
-		tracer.ResourceName("go.sessions.IdentifySessionImpl.getSession"), tracer.Tag("sessionSecureID", sessionSecureID))
+	getSessionSpan, _ := util.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
+		util.ResourceName("go.sessions.IdentifySessionImpl.getSession"), util.Tag("sessionSecureID", sessionSecureID))
 	if sessionSecureID == "" {
 		return e.New("IdentifySessionImpl called without secureID")
 	}
@@ -1464,8 +1463,8 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 	getSessionSpan.Finish()
 	sessionID := session.ID
 
-	setUserPropsSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
-		tracer.ResourceName("go.sessions.IdentifySessionImpl.SetUserProperties"), tracer.Tag("sessionID", sessionID))
+	setUserPropsSpan, _ := util.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
+		util.ResourceName("go.sessions.IdentifySessionImpl.SetUserProperties"), util.Tag("sessionID", sessionID))
 	allUserProperties := make(map[string]string)
 	// get existing session user properties in case of multiple identify calls
 	if existingUserProps, err := session.GetUserProperties(); err == nil {
@@ -1500,8 +1499,8 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 	}
 	setUserPropsSpan.Finish()
 
-	previousSessionSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
-		tracer.ResourceName("go.sessions.IdentifySessionImpl.PreviousSession"), tracer.Tag("sessionID", sessionID))
+	previousSessionSpan, _ := util.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
+		util.ResourceName("go.sessions.IdentifySessionImpl.PreviousSession"), util.Tag("sessionID", sessionID))
 	// Check if there is a session created by this user.
 	firstTime := &model.F
 	if err := r.DB.Where(&model.Session{Identifier: userIdentifier, ProjectID: session.ProjectID}).Take(&model.Session{}).Error; err != nil {
@@ -1526,8 +1525,8 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 		session.Identified = true
 	}
 
-	openSearchUpdateSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
-		tracer.ResourceName("go.sessions.IdentifySessionImpl.OpenSearchUpdate"), tracer.Tag("sessionID", sessionID))
+	openSearchUpdateSpan, _ := util.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
+		util.ResourceName("go.sessions.IdentifySessionImpl.OpenSearchUpdate"), util.Tag("sessionID", sessionID))
 	openSearchProperties := map[string]interface{}{
 		"user_properties": session.UserProperties,
 		"first_time":      session.FirstTime,
@@ -1573,8 +1572,8 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 	if !backfill && len(session.ClientID) > 0 {
 		// Find past unidentified sessions and identify them.
 		backfillSessions := []*model.Session{}
-		getToBackfillSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
-			tracer.ResourceName("go.sessions.IdentifySessionImpl.GetToBackfill"), tracer.Tag("sessionID", sessionID))
+		getToBackfillSpan, _ := util.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
+			util.ResourceName("go.sessions.IdentifySessionImpl.GetToBackfill"), util.Tag("sessionID", sessionID))
 		if err := r.DB.Where(&model.Session{ClientID: session.ClientID, ProjectID: session.ProjectID}).
 			Where("(identifier IS null OR identifier = '') AND (identified IS null OR identified = false)").
 			Not(&model.Session{Model: model.Model{ID: sessionID}}).Find(&backfillSessions).Error; err != nil {
@@ -1582,8 +1581,8 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 		}
 		getToBackfillSpan.Finish()
 
-		doBackfillSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
-			tracer.ResourceName("go.sessions.IdentifySessionImpl.DoBackfill"), tracer.Tag("sessionID", sessionID))
+		doBackfillSpan, _ := util.StartSpanFromContext(ctx, "public-graph.IdentifySessionImpl",
+			util.ResourceName("go.sessions.IdentifySessionImpl.DoBackfill"), util.Tag("sessionID", sessionID))
 		for _, session := range backfillSessions {
 			if err := r.IdentifySessionImpl(ctx, session.SecureID, userIdentifier, userObject, true); err != nil {
 				return e.Wrapf(err, "[IdentifySession] [client_id: %v] error identifying session {id: %d}", session.ClientID, session.ID)
@@ -1598,8 +1597,8 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 }
 
 func (r *Resolver) AddSessionPropertiesImpl(ctx context.Context, sessionID int, propertiesObject interface{}) error {
-	outerSpan, outerCtx := tracer.StartSpanFromContext(ctx, "public-graph.AddSessionPropertiesImpl",
-		tracer.ResourceName("go.sessions.AddSessionPropertiesImpl"))
+	outerSpan, outerCtx := util.StartSpanFromContext(ctx, "public-graph.AddSessionPropertiesImpl",
+		util.ResourceName("go.sessions.AddSessionPropertiesImpl"))
 	defer outerSpan.Finish()
 
 	obj, ok := propertiesObject.(map[string]interface{})
@@ -1922,9 +1921,9 @@ func (r *Resolver) AddLegacyMetric(ctx context.Context, sessionID int, name stri
 }
 
 func (r *Resolver) PushMetricsImpl(ctx context.Context, sessionSecureID string, metrics []*publicModel.MetricInput) error {
-	span, _ := tracer.StartSpanFromContext(ctx, "public-graph.PushMetricsImpl", tracer.ResourceName("go.push-metrics"))
-	span.SetTag("SessionSecureID", sessionSecureID)
-	span.SetTag("NumMetrics", len(metrics))
+	span, _ := util.StartSpanFromContext(ctx, "public-graph.PushMetricsImpl", util.ResourceName("go.push-metrics"))
+	span.SetAttribute("SessionSecureID", sessionSecureID)
+	span.SetAttribute("NumMetrics", len(metrics))
 	defer span.Finish()
 
 	if sessionSecureID == "" {
@@ -2063,9 +2062,9 @@ func extractErrorFields(sessionObj *model.Session, errorToProcess *model.ErrorOb
 }
 
 func (r *Resolver) updateErrorsCount(ctx context.Context, errorsBySession map[string]int64, errors int, errorType string) {
-	dailyErrorCountSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.processBackendPayload", tracer.ResourceName("db.updateDailyErrorCounts"))
-	dailyErrorCountSpan.SetTag("numberOfErrors", errors)
-	dailyErrorCountSpan.SetTag("numberOfSessions", len(errorsBySession))
+	dailyErrorCountSpan, _ := util.StartSpanFromContext(ctx, "public-graph.processBackendPayload", util.ResourceName("db.updateDailyErrorCounts"))
+	dailyErrorCountSpan.SetAttribute("numberOfErrors", errors)
+	dailyErrorCountSpan.SetAttribute("numberOfSessions", len(errorsBySession))
 	defer dailyErrorCountSpan.Finish()
 
 	for sessionSecureId, count := range errorsBySession {
@@ -2084,16 +2083,16 @@ func (r *Resolver) updateErrorsCount(ctx context.Context, errorsBySession map[st
 }
 
 func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureID *string, projectVerboseID *string, errorObjects []*publicModel.BackendErrorObjectInput) {
-	querySessionSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.processBackendPayload", tracer.ResourceName("db.querySessions"))
-	querySessionSpan.SetTag("numberOfErrors", len(errorObjects))
-	querySessionSpan.SetTag("numberOfSessions", 1)
+	querySessionSpan, _ := util.StartSpanFromContext(ctx, "public-graph.processBackendPayload", util.ResourceName("db.querySessions"))
+	querySessionSpan.SetAttribute("numberOfErrors", len(errorObjects))
+	querySessionSpan.SetAttribute("numberOfSessions", 1)
 
 	var sessionID *int
 	session := &model.Session{}
 	if sessionSecureID != nil {
 		if r.DB.Model(&session).Where(&model.Session{SecureID: *sessionSecureID}).Take(&session); session.ID == 0 {
 			retErr := e.New("ProcessBackendPayloadImpl failed to find session " + *sessionSecureID)
-			querySessionSpan.Finish(tracer.WithError(retErr))
+			querySessionSpan.Finish(retErr)
 			log.WithContext(ctx).Error(retErr)
 			return
 		}
@@ -2152,8 +2151,8 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 	}
 
 	// put errors in db
-	putErrorsToDBSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.processBackendPayload",
-		tracer.ResourceName("db.errors"))
+	putErrorsToDBSpan, putErrorsToDBCtx := util.StartSpanFromContext(ctx, "public-graph.processBackendPayload",
+		util.ResourceName("db.errors"))
 	groupedErrors := make(map[int][]*model.ErrorObject)
 	groups := make(map[int]struct {
 		Group      *model.ErrorGroup
@@ -2232,8 +2231,7 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 		r.sendErrorAlert(ctx, data.Group.ProjectID, data.SessionObj, data.Group, instance, data.VisitedURL)
 	}
 
-	influxSpan := tracer.StartSpan("public-graph.recordErrorGroupMetrics", tracer.ChildOf(putErrorsToDBSpan.Context()),
-		tracer.ResourceName("influx.errors"))
+	influxSpan, _ := util.StartSpanFromContext(putErrorsToDBCtx, "public-graph.recordErrorGroupMetrics", util.ResourceName("influx.errors"))
 	for groupID, errorObjects := range groupedErrors {
 		errorGroup := groups[groupID].Group
 		if err := r.RecordErrorGroupMetrics(ctx, errorGroup, errorObjects); err != nil {
@@ -2246,12 +2244,12 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 	influxSpan.Finish()
 
 	if settings, err := r.Store.GetAllWorkspaceSettings(ctx, workspace.ID); err == nil && settings.ErrorEmbeddingsWrite {
-		eSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.processBackendPayload",
-			tracer.ResourceName("BatchGenerateEmbeddings"))
+		eSpan, _ := util.StartSpanFromContext(ctx, "public-graph.processBackendPayload",
+			util.ResourceName("BatchGenerateEmbeddings"))
 		if err = r.BatchGenerateEmbeddings(ctx, newInstances); err != nil {
 			log.WithContext(ctx).WithError(err).WithField("project_id", projectID).Error("failed to generate embeddings")
 		}
-		eSpan.Finish(tracer.WithError(err))
+		eSpan.Finish(err)
 	}
 	putErrorsToDBSpan.Finish()
 }
@@ -2294,8 +2292,8 @@ func (r *Resolver) RecordErrorGroupMetrics(ctx context.Context, errorGroup *mode
 
 // Deprecated, left for backward compatibility with older client versions. Use AddTrackProperties instead
 func (r *Resolver) AddTrackPropertiesImpl(ctx context.Context, sessionID int, propertiesObject interface{}) error {
-	outerSpan, outerCtx := tracer.StartSpanFromContext(ctx, "public-graph.AddTrackPropertiesImpl",
-		tracer.ResourceName("go.sessions.AddTrackPropertiesImpl"))
+	outerSpan, outerCtx := util.StartSpanFromContext(ctx, "public-graph.AddTrackPropertiesImpl",
+		util.ResourceName("go.sessions.AddTrackPropertiesImpl"))
 	defer outerSpan.Finish()
 
 	obj, ok := propertiesObject.(map[string]interface{})
@@ -2317,8 +2315,8 @@ func (r *Resolver) AddTrackPropertiesImpl(ctx context.Context, sessionID int, pr
 }
 
 func (r *Resolver) AddTrackProperties(ctx context.Context, sessionID int, events *parse.ReplayEvents) error {
-	outerSpan, outerCtx := tracer.StartSpanFromContext(ctx, "public-graph.AddTrackProperties",
-		tracer.ResourceName("go.sessions.AddTrackProperties"))
+	outerSpan, outerCtx := util.StartSpanFromContext(ctx, "public-graph.AddTrackProperties",
+		util.ResourceName("go.sessions.AddTrackProperties"))
 	defer outerSpan.Finish()
 
 	fields := map[string]string{}
@@ -2377,8 +2375,8 @@ func (r *Resolver) AddTrackProperties(ctx context.Context, sessionID int, events
 }
 
 func (r *Resolver) SaveSessionData(ctx context.Context, projectId, sessionId, payloadId int, saveToS3, isBeacon bool, payloadType model.RawPayloadType, data []byte) error {
-	redisSpan, redisCtx := tracer.StartSpanFromContext(ctx, "public-graph.SaveSessionData",
-		tracer.ResourceName("go.parseEvents.processWithRedis"), tracer.Tag("project_id", projectId), tracer.Tag("payload_type", payloadType))
+	redisSpan, redisCtx := util.StartSpanFromContext(ctx, "public-graph.SaveSessionData",
+		util.ResourceName("go.parseEvents.processWithRedis"), util.Tag("project_id", projectId), util.Tag("payload_type", payloadType))
 	score := float64(payloadId)
 	// A little bit of a hack to encode
 	if isBeacon {
@@ -2386,8 +2384,8 @@ func (r *Resolver) SaveSessionData(ctx context.Context, projectId, sessionId, pa
 	}
 
 	if saveToS3 {
-		zRangeSpan, _ := tracer.StartSpanFromContext(redisCtx, "public-graph.SaveSessionData",
-			tracer.ResourceName("go.parseEvents.processWithRedis.getRawZRange"), tracer.Tag("project_id", projectId))
+		zRangeSpan, _ := util.StartSpanFromContext(redisCtx, "public-graph.SaveSessionData",
+			util.ResourceName("go.parseEvents.processWithRedis.getRawZRange"), util.Tag("project_id", projectId))
 		zRange, err := r.Redis.GetRawZRange(ctx, sessionId, payloadId)
 		if err != nil {
 			return e.Wrap(err, "error retrieving previous event objects")
@@ -2396,8 +2394,8 @@ func (r *Resolver) SaveSessionData(ctx context.Context, projectId, sessionId, pa
 
 		// If there are prior events, push them to S3 and remove them from Redis
 		if len(zRange) != 0 {
-			pushToS3Span, _ := tracer.StartSpanFromContext(redisCtx, "public-graph.SaveSessionData",
-				tracer.ResourceName("go.parseEvents.processWithRedis.pushToS3"), tracer.Tag("project_id", projectId))
+			pushToS3Span, _ := util.StartSpanFromContext(redisCtx, "public-graph.SaveSessionData",
+				util.ResourceName("go.parseEvents.processWithRedis.pushToS3"), util.Tag("project_id", projectId))
 			if err := r.StorageClient.PushRawEvents(ctx, sessionId, projectId, payloadType, zRange); err != nil {
 				return e.Wrap(err, "error pushing events to S3")
 			}
@@ -2408,8 +2406,8 @@ func (r *Resolver) SaveSessionData(ctx context.Context, projectId, sessionId, pa
 				values = append(values, z.Member)
 			}
 
-			removeValuesSpan, _ := tracer.StartSpanFromContext(redisCtx, "public-graph.SaveSessionData",
-				tracer.ResourceName("go.parseEvents.processWithRedis.removeValues"), tracer.Tag("project_id", projectId))
+			removeValuesSpan, _ := util.StartSpanFromContext(redisCtx, "public-graph.SaveSessionData",
+				util.ResourceName("go.parseEvents.processWithRedis.removeValues"), util.Tag("project_id", projectId))
 			if err := r.Redis.RemoveValues(ctx, sessionId, values); err != nil {
 				return e.Wrap(err, "error removing previous values")
 			}
@@ -2432,13 +2430,13 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	if webSocketEvents != nil {
 		webSocketEventsStr = *webSocketEvents
 	}
-	querySessionSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.pushPayload", tracer.ResourceName("db.querySession"))
-	querySessionSpan.SetTag("sessionSecureID", sessionSecureID)
-	querySessionSpan.SetTag("messagesLength", len(messages))
-	querySessionSpan.SetTag("resourcesLength", len(resources))
-	querySessionSpan.SetTag("webSocketEventsLength", len(webSocketEventsStr))
-	querySessionSpan.SetTag("numberOfErrors", len(errors))
-	querySessionSpan.SetTag("numberOfEvents", len(events.Events))
+	querySessionSpan, _ := util.StartSpanFromContext(ctx, "public-graph.pushPayload", util.ResourceName("db.querySession"))
+	querySessionSpan.SetAttribute("sessionSecureID", sessionSecureID)
+	querySessionSpan.SetAttribute("messagesLength", len(messages))
+	querySessionSpan.SetAttribute("resourcesLength", len(resources))
+	querySessionSpan.SetAttribute("webSocketEventsLength", len(webSocketEventsStr))
+	querySessionSpan.SetAttribute("numberOfErrors", len(errors))
+	querySessionSpan.SetAttribute("numberOfEvents", len(events.Events))
 	if highlightLogs != nil {
 		logsArray := strings.Split(*highlightLogs, "\n")
 		for _, clientLog := range logsArray {
@@ -2454,11 +2452,11 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	if err := r.DB.Where(&model.Session{SecureID: sessionSecureID}).Limit(1).Take(&sessionObj).Error; err != nil {
 		retErr := e.Wrapf(err, "error reading from session %v", sessionSecureID)
 		log.WithContext(ctx).Error(retErr)
-		querySessionSpan.Finish(tracer.WithError(retErr))
+		querySessionSpan.Finish(retErr)
 		return retErr
 	}
-	querySessionSpan.SetTag("secure_id", sessionObj.SecureID)
-	querySessionSpan.SetTag("project_id", sessionObj.ProjectID)
+	querySessionSpan.SetAttribute("secure_id", sessionObj.SecureID)
+	querySessionSpan.SetAttribute("project_id", sessionObj.ProjectID)
 	querySessionSpan.Finish()
 	sessionID := sessionObj.ID
 
@@ -2488,8 +2486,8 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 
 	g.Go(func() error {
 		defer util.Recover()
-		parseEventsSpan, parseEventsCtx := tracer.StartSpanFromContext(ctx, "public-graph.pushPayload",
-			tracer.ResourceName("go.parseEvents"), tracer.Tag("project_id", projectID))
+		parseEventsSpan, parseEventsCtx := util.StartSpanFromContext(ctx, "public-graph.pushPayload",
+			util.ResourceName("go.parseEvents"), util.Tag("project_id", projectID))
 		defer parseEventsSpan.Finish()
 		if evs := events.Events; len(evs) > 0 {
 			// TODO: this isn't very performant, as marshaling the whole event obj to a string is expensive;
@@ -2517,19 +2515,19 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 						continue
 					}
 
-					jsSpan, _ := tracer.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
-						tracer.ResourceName("go.parseEvents.EscapeJavascript"), tracer.Tag("project_id", projectID))
+					jsSpan, _ := util.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
+						util.ResourceName("go.parseEvents.EscapeJavascript"), util.Tag("project_id", projectID))
 					// escape script tags in any javascript
 					err = snapshot.EscapeJavascript(ctx)
-					jsSpan.Finish(tracer.WithError(err))
+					jsSpan.Finish(err)
 					if err != nil {
 						log.WithContext(ctx).Error(e.Wrap(err, "Error escaping snapshot javascript"))
 					}
 
 					// Replace any static resources with our own, hosted in S3
 					if settings != nil && settings.ReplaceAssets {
-						assetsSpan, _ := tracer.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
-							tracer.ResourceName("go.parseEvents.replaceAssets"), tracer.Tag("project_id", projectID), tracer.Tag("session_secure_id", sessionSecureID))
+						assetsSpan, _ := util.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
+							util.ResourceName("go.parseEvents.replaceAssets"), util.Tag("project_id", projectID), util.Tag("session_secure_id", sessionSecureID))
 						err = snapshot.ReplaceAssets(ctx, projectID, r.StorageClient, r.DB, r.Redis)
 						assetsSpan.Finish()
 						if err != nil {
@@ -2539,20 +2537,20 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 
 					if event.Type == parse.FullSnapshot {
 						hasFullSnapshot = true
-						stylesheetsSpan, _ := tracer.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
-							tracer.ResourceName("go.parseEvents.InjectStylesheets"), tracer.Tag("project_id", projectID))
+						stylesheetsSpan, _ := util.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
+							util.ResourceName("go.parseEvents.InjectStylesheets"), util.Tag("project_id", projectID))
 						// If we see a snapshot event, attempt to inject CORS stylesheets.
 						err := snapshot.InjectStylesheets()
-						stylesheetsSpan.Finish(tracer.WithError(err))
+						stylesheetsSpan.Finish(err)
 						if err != nil {
 							log.WithContext(ctx).Error(e.Wrap(err, "Error injecting snapshot stylesheets"))
 						}
 					}
 					if event.Type == parse.IncrementalSnapshot {
-						incrementalEventSpan, _ := tracer.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
-							tracer.ResourceName("go.parseEvents.incrementalEvent"), tracer.Tag("project_id", projectID))
+						incrementalEventSpan, _ := util.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
+							util.ResourceName("go.parseEvents.incrementalEvent"), util.Tag("project_id", projectID))
 						mouseInteractionEventData, err := parse.UnmarshallMouseInteractionEvent(event.Data)
-						incrementalEventSpan.Finish(tracer.WithError(err))
+						incrementalEventSpan.Finish(err)
 						if err != nil {
 							log.WithContext(ctx).Error(e.Wrap(err, "Error unmarshalling incremental event"))
 						}
@@ -2571,8 +2569,8 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 				}
 			}
 
-			remarshalSpan, _ := tracer.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
-				tracer.ResourceName("go.parseEvents.remarshalEvents"), tracer.Tag("project_id", projectID))
+			remarshalSpan, _ := util.StartSpanFromContext(parseEventsCtx, "public-graph.pushPayload",
+				util.ResourceName("go.parseEvents.remarshalEvents"), util.Tag("project_id", projectID))
 			// Re-format as a string to write to the db.
 			b, err := json.Marshal(parsedEvents)
 			if err != nil {
@@ -2598,8 +2596,8 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	// unmarshal messages
 	g.Go(func() error {
 		defer util.Recover()
-		unmarshalMessagesSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.pushPayload",
-			tracer.ResourceName("go.unmarshal.messages"), tracer.Tag("project_id", projectID))
+		unmarshalMessagesSpan, _ := util.StartSpanFromContext(ctx, "public-graph.pushPayload",
+			util.ResourceName("go.unmarshal.messages"), util.Tag("project_id", projectID))
 		defer unmarshalMessagesSpan.Finish()
 
 		if err := hlog.SubmitFrontendConsoleMessages(ctx, projectID, sessionSecureID, messages); err != nil {
@@ -2612,8 +2610,8 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	// unmarshal resources
 	g.Go(func() error {
 		defer util.Recover()
-		unmarshalResourcesSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.pushPayload",
-			tracer.ResourceName("go.unmarshal.resources"), tracer.Tag("project_id", projectID))
+		unmarshalResourcesSpan, _ := util.StartSpanFromContext(ctx, "public-graph.pushPayload",
+			util.ResourceName("go.unmarshal.resources"), util.Tag("project_id", projectID))
 		defer unmarshalResourcesSpan.Finish()
 
 		if err := r.SaveSessionData(ctx, projectID, sessionID, payloadIdDeref, false, isBeacon, model.PayloadTypeResources, []byte(resources)); err != nil {
@@ -2627,8 +2625,8 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	g.Go(func() error {
 		defer util.Recover()
 		if webSocketEventsStr != "" {
-			unmarshalWebSocketEventsSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.pushPayload",
-				tracer.ResourceName("go.unmarshal.web_socket_events"), tracer.Tag("project_id", projectID))
+			unmarshalWebSocketEventsSpan, _ := util.StartSpanFromContext(ctx, "public-graph.pushPayload",
+				util.ResourceName("go.unmarshal.web_socket_events"), util.Tag("project_id", projectID))
 			defer unmarshalWebSocketEventsSpan.Finish()
 
 			if err := r.SaveSessionData(ctx, projectID, sessionID, payloadIdDeref, false, isBeacon, model.PayloadTypeWebSocketEvents, []byte(webSocketEventsStr)); err != nil {
@@ -2672,8 +2670,8 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		}
 
 		// put errors in db
-		putErrorsToDBSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.pushPayload",
-			tracer.ResourceName("db.errors"), tracer.Tag("project_id", projectID))
+		putErrorsToDBSpan, putErrorsToDBCtx := util.StartSpanFromContext(ctx, "public-graph.pushPayload",
+			util.ResourceName("db.errors"), util.Tag("project_id", projectID))
 		groupedErrors := make(map[int][]*model.ErrorObject)
 		groups := make(map[int]struct {
 			Group      *model.ErrorGroup
@@ -2746,8 +2744,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			groupedErrors[group.ID] = append(groupedErrors[group.ID], errorToInsert)
 		}
 
-		influxSpan := tracer.StartSpan("public-graph.pushPayload", tracer.ChildOf(putErrorsToDBSpan.Context()),
-			tracer.ResourceName("influx.errors"))
+		influxSpan, _ := util.StartSpanFromContext(putErrorsToDBCtx, "public-graph.pushPayload", util.ResourceName("influx.errors"))
 		for groupID, errorObjects := range groupedErrors {
 			errorGroup := groups[groupID].Group
 			if err := r.RecordErrorGroupMetrics(ctx, errorGroup, errorObjects); err != nil {
@@ -2768,12 +2765,11 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		}
 
 		if settings, err := r.Store.GetAllWorkspaceSettings(ctx, workspace.ID); err == nil && settings.ErrorEmbeddingsWrite {
-			eSpan := tracer.StartSpan("public-graph.pushPayload", tracer.ChildOf(putErrorsToDBSpan.Context()),
-				tracer.ResourceName("BatchGenerateEmbeddings"))
+			eSpan, _ := util.StartSpanFromContext(putErrorsToDBCtx, "public-graph.pushPayload", util.ResourceName("BatchGenerateEmbeddings"))
 			if err = r.BatchGenerateEmbeddings(ctx, newInstances); err != nil {
 				log.WithContext(ctx).WithError(err).WithField("session_secure_id", sessionObj.SecureID).Error("failed to generate embeddings")
 			}
-			eSpan.Finish(tracer.WithError(err))
+			eSpan.Finish(err)
 		}
 
 		putErrorsToDBSpan.Finish()
@@ -2800,7 +2796,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		}
 	}
 
-	updateSpan, updateSpanCtx := tracer.StartSpanFromContext(ctx, "public-graph.pushPayload", tracer.ResourceName("doSessionFieldsUpdate"))
+	updateSpan, updateSpanCtx := util.StartSpanFromContext(ctx, "public-graph.pushPayload", util.ResourceName("doSessionFieldsUpdate"))
 	defer updateSpan.Finish()
 
 	excluded, reason := r.isSessionExcluded(ctx, sessionObj, sessionHasErrors)
@@ -2867,7 +2863,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 		}
 	}
 
-	opensearchSpan, osCtx := tracer.StartSpanFromContext(updateSpanCtx, "public-graph.pushPayload", tracer.ResourceName("opensearch.update"))
+	opensearchSpan, osCtx := util.StartSpanFromContext(updateSpanCtx, "public-graph.pushPayload", util.ResourceName("opensearch.update"))
 	defer opensearchSpan.Finish()
 	// If the session was previously marked as processed, clear this
 	// in OpenSearch so that it's treated as a live session again.
@@ -3041,8 +3037,8 @@ func (r *Resolver) SendSessionInitAlert(ctx context.Context, workspace *model.Wo
 }
 
 func (r *Resolver) SendSessionTrackPropertiesAlert(ctx context.Context, workspace *model.Workspace, session *model.Session, properties map[string]string) error {
-	alertWorkerSpan, _ := tracer.StartSpanFromContext(ctx, "public-graph.AppendProperties",
-		tracer.ResourceName("go.sessions.AppendProperties.alertWorker"), tracer.Tag("sessionID", session.ID))
+	alertWorkerSpan, _ := util.StartSpanFromContext(ctx, "public-graph.AppendProperties",
+		util.ResourceName("go.sessions.AppendProperties.alertWorker"), util.Tag("sessionID", session.ID))
 	defer alertWorkerSpan.Finish()
 	// Sending Track Properties Alert
 	var sessionAlerts []*model.SessionAlert
@@ -3230,7 +3226,7 @@ func (r *Resolver) SendSessionIdentifiedAlert(ctx context.Context, workspace *mo
 }
 
 func (r *Resolver) SendSessionUserPropertiesAlert(ctx context.Context, workspace *model.Workspace, session *model.Session) error {
-	alertSpan, _ := tracer.StartSpanFromContext(ctx, "SendSessionUserPropertiesAlert")
+	alertSpan, _ := util.StartSpanFromContext(ctx, "SendSessionUserPropertiesAlert")
 	defer alertSpan.Finish()
 	// Sending User Properties Alert
 	var sessionAlerts []*model.SessionAlert

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -17,18 +17,18 @@ import (
 	"github.com/highlight-run/highlight/backend/model"
 	generated1 "github.com/highlight-run/highlight/backend/public-graph/graph/generated"
 	customModels "github.com/highlight-run/highlight/backend/public-graph/graph/model"
+	"github.com/highlight-run/highlight/backend/util"
 	"github.com/openlyinc/pointy"
 	e "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 // InitializeSession is the resolver for the initializeSession field.
 func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureID string, organizationVerboseID string, enableStrictPrivacy bool, enableRecordingNetworkContents bool, clientVersion string, firstloadVersion string, clientConfig string, environment string, appVersion *string, serviceName *string, fingerprint string, clientID string, networkRecordingDomains []string, disableSessionRecording *bool) (*customModels.InitializeSessionResponse, error) {
-	s, _ := tracer.StartSpanFromContext(ctx, "InitializeSession", tracer.ResourceName("gql.initializeSession"))
-	s.SetTag("secure_id", sessionSecureID)
-	s.SetTag("client_version", clientVersion)
-	s.SetTag("firstload_version", firstloadVersion)
+	s, _ := util.StartSpanFromContext(ctx, "InitializeSession", util.ResourceName("gql.initializeSession"))
+	s.SetAttribute("secure_id", sessionSecureID)
+	s.SetAttribute("client_version", clientVersion)
+	s.SetAttribute("firstload_version", firstloadVersion)
 	defer s.Finish()
 	acceptLanguageString := ctx.Value(model.ContextKeys.AcceptLanguage).(string)
 	userAgentString := ctx.Value(model.ContextKeys.UserAgent).(string)
@@ -73,7 +73,7 @@ func (r *mutationResolver) InitializeSession(ctx context.Context, sessionSecureI
 	}
 
 	hlog.Incr("gql.initializeSession.count", []string{fmt.Sprintf("success:%t", err == nil), fmt.Sprintf("project_verbose_id:%q", organizationVerboseID), fmt.Sprintf("project_id:%d", projectID), fmt.Sprintf("secure_id:%s", sessionSecureID), fmt.Sprintf("firstload_version:%s", firstloadVersion), fmt.Sprintf("client_version:%s", clientVersion)}, 1)
-	s.SetTag("success", err == nil)
+	s.SetAttribute("success", err == nil)
 
 	return &customModels.InitializeSessionResponse{
 		SecureID:  sessionSecureID,

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openlyinc/pointy"
 	"github.com/pkg/errors"
 	"github.com/redis/go-redis/v9"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const CacheKeyHubspotCompanies = "hubspot-companies"
@@ -470,7 +469,7 @@ func (r *Client) SetLastLogTimestamp(ctx context.Context, projectId int, timesta
 }
 
 func (r *Client) SetHubspotCompanies(ctx context.Context, companies interface{}) error {
-	span, _ := tracer.StartSpanFromContext(ctx, "redis.cache.SetHubspotCompanies")
+	span, _ := util.StartSpanFromContext(ctx, "redis.cache.SetHubspotCompanies")
 	defer span.Finish()
 	if err := r.Cache.Set(&cache.Item{
 		Ctx:   ctx,
@@ -478,16 +477,16 @@ func (r *Client) SetHubspotCompanies(ctx context.Context, companies interface{})
 		Value: companies,
 		TTL:   time.Hour,
 	}); err != nil {
-		span.Finish(tracer.WithError(err))
+		span.Finish(err)
 		return err
 	}
 	return nil
 }
 
 func (r *Client) GetHubspotCompanies(ctx context.Context, companies interface{}) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "redis.cache.GetHubspotCompanies")
+	span, _ := util.StartSpanFromContext(ctx, "redis.cache.GetHubspotCompanies")
 	err = r.Cache.Get(ctx, CacheKeyHubspotCompanies, companies)
-	span.Finish(tracer.WithError(err))
+	span.Finish(err)
 	return
 }
 

--- a/backend/util/tracer-graphql.go
+++ b/backend/util/tracer-graphql.go
@@ -1,0 +1,101 @@
+package util
+
+// This schema/arch is taken from: https://github.com/99designs/gqlgen/blob/master/graphql/handler/apollotracing/tracer.go
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql"
+	log "github.com/sirupsen/logrus"
+)
+
+type Tracer struct {
+	graphql.HandlerExtension
+	graphql.ResponseInterceptor
+	graphql.FieldInterceptor
+
+	serverType Runtime
+}
+
+func NewTracer(backend Runtime) Tracer {
+	return Tracer{serverType: backend}
+}
+
+func (t Tracer) ExtensionName() string {
+	return "HighlightTracer"
+}
+
+func (t Tracer) Validate(graphql.ExecutableSchema) error {
+	return nil
+}
+
+func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (interface{}, error) {
+	start := time.Now()
+	// taken from: https://docs.datadoghq.com/tracing/setup_overview/custom_instrumentation/go/#manually-creating-a-new-span
+	fc := graphql.GetFieldContext(ctx)
+	fieldSpan, ctx := StartSpanFromContext(ctx, "operation.field", ResourceName(fc.Field.Name))
+	fieldSpan.SetAttribute("field.type", fc.Field.Definition.Type.String())
+	if b, err := json.MarshalIndent(fc.Args, "", ""); err == nil {
+		if bs := string(b); len(bs) <= 1000 {
+			fieldSpan.SetAttribute("field.arguments", bs)
+		}
+	}
+	res, err := next(ctx)
+	fieldSpan.Finish(err)
+
+	if t.serverType == PrivateGraph {
+		fields := log.Fields{
+			"duration":        time.Since(start),
+			"operation.field": fc.Field.Name,
+			"graph":           t.serverType,
+		}
+		if err != nil {
+			fields["error"] = err
+		}
+		log.WithContext(ctx).
+			WithFields(fields).
+			Debugf("graphql field")
+	}
+	return res, err
+}
+
+func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
+	start := time.Now()
+	var oc *graphql.OperationContext
+	if graphql.HasOperationContext(ctx) {
+		oc = graphql.GetOperationContext(ctx)
+	}
+	// NOTE: This gets called for the first time at the highest level. Creates the 'tracing' value, calls the next handler
+	// and returns the response.
+	opName := "undefined"
+	if oc != nil {
+		opName = oc.OperationName
+	}
+	span, ctx := StartSpanFromContext(ctx, "graphql.operation", ResourceName(opName))
+	span.SetAttribute("backend", t.serverType)
+	defer span.Finish()
+	resp := next(ctx)
+	if resp != nil {
+		var errs []error
+		for _, err := range resp.Errors {
+			errs = append(errs, err)
+		}
+		span.Finish(errs...)
+	}
+	if t.serverType == PrivateGraph {
+		fields := log.Fields{
+			"duration":          time.Since(start),
+			"graphql.operation": opName,
+			"graph":             t.serverType,
+		}
+		if resp != nil && len(resp.Errors) > 0 {
+			fields["errors"] = resp.Errors
+		}
+		log.WithContext(ctx).
+			WithFields(fields).
+			Infof("graphql request")
+	}
+	return resp
+}

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -57,7 +57,7 @@ func StartSpanFromContext(ctx context.Context, operationName string, options ...
 		opt(&cfg)
 	}
 
-	hTracingDisabled, _ := ctx.Value(string(ContextKeyHighlightTracingDisabled)).(bool)
+	hTracingDisabled, _ := ctx.Value(ContextKeyHighlightTracingDisabled).(bool)
 	hTracingDisabled = hTracingDisabled || cfg.HighlightTracingDisabled
 	ctx = context.WithValue(ctx, ContextKeyHighlightTracingDisabled, hTracingDisabled)
 

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -43,7 +43,9 @@ func (s *MultiSpan) SetOperationName(name string) {
 	}
 }
 
-const ContextKeyHighlightTracingDisabled = "HighlightTracingDisabled"
+type contextKeyType int
+
+const highlightTracingDisabled contextKeyType = iota
 
 func StartSpanFromContext(ctx context.Context, operationName string, options ...SpanOption) (MultiSpan, context.Context) {
 	var cfg SpanConfig
@@ -52,9 +54,9 @@ func StartSpanFromContext(ctx context.Context, operationName string, options ...
 		opt(&cfg)
 	}
 
-	hTracingDisabled, _ := ctx.Value(ContextKeyHighlightTracingDisabled).(bool)
+	hTracingDisabled, _ := ctx.Value(highlightTracingDisabled).(bool)
 	hTracingDisabled = hTracingDisabled || cfg.HighlightTracingDisabled
-	ctx = context.WithValue(ctx, ContextKeyHighlightTracingDisabled, hTracingDisabled)
+	ctx = context.WithValue(ctx, highlightTracingDisabled, hTracingDisabled)
 
 	for _, tag := range cfg.Tags {
 		ddOptions = append(ddOptions, tracer.Tag(string(tag.Key), tag.Value))

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -13,13 +13,14 @@ import (
 )
 
 type MultiSpan struct {
-	ddSpan tracer.Span
-	hSpan  trace.Span
+	ddSpan  tracer.Span
+	hSpan   trace.Span
+	context context.Context
 }
 
 func (s *MultiSpan) Finish(err ...error) {
 	if len(err) > 1 {
-		log.Warnf("Multiple errors passed to MultiSpan.Finish: %v", err)
+		log.WithContext(s.Context()).Warnf("multiple errors passed to MultiSpan.Finish: %v", err)
 	} else if len(err) > 0 && err[0] != nil {
 		s.ddSpan.Finish(tracer.WithError(err[0]))
 		if s.hSpan != nil {
@@ -45,6 +46,10 @@ func (s *MultiSpan) SetOperationName(name string) {
 	if s.hSpan != nil {
 		s.hSpan.SetName(name)
 	}
+}
+
+func (s *MultiSpan) Context() context.Context {
+	return s.context
 }
 
 type contextKey string
@@ -77,8 +82,9 @@ func StartSpanFromContext(ctx context.Context, operationName string, options ...
 	mergedCtx := trace.ContextWithSpan(ddCtx, hSpan)
 
 	return MultiSpan{
-		ddSpan: ddSpan,
-		hSpan:  hSpan,
+		ddSpan:  ddSpan,
+		hSpan:   hSpan,
+		context: mergedCtx,
 	}, mergedCtx
 }
 
@@ -99,8 +105,9 @@ func StartSpan(operationName string, options ...SpanOption) MultiSpan {
 	}
 
 	return MultiSpan{
-		ddSpan: ddSpan,
-		hSpan:  hSpan,
+		ddSpan:  ddSpan,
+		hSpan:   hSpan,
+		context: context.Background(),
 	}
 }
 

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -16,8 +18,9 @@ type MultiSpan struct {
 }
 
 func (s *MultiSpan) Finish(err ...error) {
-	// TODO: Clean this up
-	if len(err) > 0 && err[0] != nil {
+	if len(err) > 1 {
+		log.Warnf("Multiple errors passed to MultiSpan.Finish: %v", err)
+	} else if len(err) > 0 && err[0] != nil {
 		s.ddSpan.Finish(tracer.WithError(err[0]))
 		if s.hSpan != nil {
 			highlight.RecordSpanError(s.hSpan, err[0])

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"fmt"
+
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -43,9 +44,11 @@ func (s *MultiSpan) SetOperationName(name string) {
 	}
 }
 
-type contextKeyType int
+type contextKey string
 
-const highlightTracingDisabled contextKeyType = iota
+const (
+	ContextKeyHighlightTracingDisabled contextKey = "HighlightTracingDisabled"
+)
 
 func StartSpanFromContext(ctx context.Context, operationName string, options ...SpanOption) (MultiSpan, context.Context) {
 	var cfg SpanConfig
@@ -54,9 +57,9 @@ func StartSpanFromContext(ctx context.Context, operationName string, options ...
 		opt(&cfg)
 	}
 
-	hTracingDisabled, _ := ctx.Value(highlightTracingDisabled).(bool)
+	hTracingDisabled, _ := ctx.Value(string(ContextKeyHighlightTracingDisabled)).(bool)
 	hTracingDisabled = hTracingDisabled || cfg.HighlightTracingDisabled
-	ctx = context.WithValue(ctx, highlightTracingDisabled, hTracingDisabled)
+	ctx = context.WithValue(ctx, ContextKeyHighlightTracingDisabled, hTracingDisabled)
 
 	for _, tag := range cfg.Tags {
 		ddOptions = append(ddOptions, tracer.Tag(string(tag.Key), tag.Value))

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -13,14 +13,13 @@ import (
 )
 
 type MultiSpan struct {
-	ddSpan  tracer.Span
-	hSpan   trace.Span
-	context context.Context
+	ddSpan tracer.Span
+	hSpan  trace.Span
 }
 
 func (s *MultiSpan) Finish(err ...error) {
 	if len(err) > 1 {
-		log.WithContext(s.Context()).Warnf("multiple errors passed to MultiSpan.Finish: %v", err)
+		log.Warnf("Multiple errors passed to MultiSpan.Finish: %v", err)
 	} else if len(err) > 0 && err[0] != nil {
 		s.ddSpan.Finish(tracer.WithError(err[0]))
 		if s.hSpan != nil {
@@ -46,10 +45,6 @@ func (s *MultiSpan) SetOperationName(name string) {
 	if s.hSpan != nil {
 		s.hSpan.SetName(name)
 	}
-}
-
-func (s *MultiSpan) Context() context.Context {
-	return s.context
 }
 
 type contextKey string
@@ -82,9 +77,8 @@ func StartSpanFromContext(ctx context.Context, operationName string, options ...
 	mergedCtx := trace.ContextWithSpan(ddCtx, hSpan)
 
 	return MultiSpan{
-		ddSpan:  ddSpan,
-		hSpan:   hSpan,
-		context: mergedCtx,
+		ddSpan: ddSpan,
+		hSpan:  hSpan,
 	}, mergedCtx
 }
 
@@ -105,9 +99,8 @@ func StartSpan(operationName string, options ...SpanOption) MultiSpan {
 	}
 
 	return MultiSpan{
-		ddSpan:  ddSpan,
-		hSpan:   hSpan,
-		context: context.Background(),
+		ddSpan: ddSpan,
+		hSpan:  hSpan,
 	}
 }
 

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"go.opentelemetry.io/otel/attribute"
@@ -28,7 +29,7 @@ func (s *MultiSpan) Finish(err ...error) {
 
 func (s *MultiSpan) SetAttribute(key string, value interface{}) {
 	s.ddSpan.SetTag(key, value)
-	s.hSpan.SetAttributes(attribute.String(key, value.(string)))
+	s.hSpan.SetAttributes(attribute.String(key, fmt.Sprintf("%v", value)))
 }
 
 func (s *MultiSpan) SetOperationName(name string) {

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -19,7 +19,7 @@ type MultiSpan struct {
 
 func (s *MultiSpan) Finish(err ...error) {
 	if len(err) > 1 {
-		log.Warnf("Multiple errors passed to MultiSpan.Finish: %v", err)
+		log.WithContext(context.TODO()).Warnf("Multiple errors passed to MultiSpan.Finish: %v", err)
 	} else if len(err) > 0 && err[0] != nil {
 		s.ddSpan.Finish(tracer.WithError(err[0]))
 		if s.hSpan != nil {

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -10,9 +10,8 @@ import (
 )
 
 type MultiSpan struct {
-	ddSpan  tracer.Span
-	hSpan   trace.Span
-	context context.Context
+	ddSpan tracer.Span
+	hSpan  trace.Span
 }
 
 func (s *MultiSpan) Finish(err ...error) {
@@ -32,8 +31,9 @@ func (s *MultiSpan) SetAttribute(key string, value interface{}) {
 	s.hSpan.SetAttributes(attribute.String(key, value.(string)))
 }
 
-func (s *MultiSpan) Context() context.Context {
-	return s.context
+func (s *MultiSpan) SetOperationName(name string) {
+	s.ddSpan.SetOperationName(name)
+	s.hSpan.SetName(name)
 }
 
 func StartSpanFromContext(ctx context.Context, operationName string, tags ...attribute.KeyValue) (MultiSpan, context.Context) {
@@ -48,9 +48,8 @@ func StartSpanFromContext(ctx context.Context, operationName string, tags ...att
 	mergedCtx := trace.ContextWithSpan(ddCtx, hSpan)
 
 	return MultiSpan{
-		ddSpan:  ddSpan,
-		hSpan:   hSpan,
-		context: mergedCtx,
+		ddSpan: ddSpan,
+		hSpan:  hSpan,
 	}, mergedCtx
 }
 

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -19,7 +19,7 @@ type MultiSpan struct {
 
 func (s *MultiSpan) Finish(err ...error) {
 	if len(err) > 1 {
-		log.WithContext(context.TODO()).Warnf("Multiple errors passed to MultiSpan.Finish: %v", err)
+		log.WithContext(context.TODO()).Warnf("Multiple errors passed to MultiSpan.Finish: %+v", err)
 	} else if len(err) > 0 && err[0] != nil {
 		s.ddSpan.Finish(tracer.WithError(err[0]))
 		if s.hSpan != nil {

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -70,7 +70,7 @@ func StartSpan(operationName string, tags ...attribute.KeyValue) MultiSpan {
 }
 
 func Tag(key string, name interface{}) attribute.KeyValue {
-	return attribute.String(key, name.(string))
+	return attribute.String(key, fmt.Sprintf("%v", name))
 }
 
 func ResourceName(name string) attribute.KeyValue {

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -20,7 +20,6 @@ import (
 	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const KafkaBatchWorkerOp = "KafkaBatchWorker"
@@ -49,11 +48,11 @@ func (k *KafkaWorker) ProcessMessages(ctx context.Context) {
 		func() {
 			var err error
 			defer util.Recover()
-			s := tracer.StartSpan("processPublicWorkerMessage", tracer.ResourceName("worker.kafka.process"))
-			s.SetTag("worker.goroutine", k.WorkerThread)
-			defer s.Finish(tracer.WithError(err))
+			s, sCtx := util.StartSpanFromContext(ctx, "processPublicWorkerMessage", util.ResourceName("worker.kafka.process"))
+			s.SetAttribute("worker.goroutine", k.WorkerThread)
+			defer s.Finish(err)
 
-			s1 := tracer.StartSpan("worker.kafka.receiveMessage", tracer.ChildOf(s.Context()))
+			s1, _ := util.StartSpanFromContext(sCtx, "worker.kafka.receiveMessage")
 			task := k.KafkaQueue.Receive(ctx)
 			s1.Finish()
 
@@ -62,23 +61,23 @@ func (k *KafkaWorker) ProcessMessages(ctx context.Context) {
 			} else if task.Type == kafkaqueue.HealthCheck {
 				return
 			}
-			s.SetTag("taskType", task.Type)
-			s.SetTag("partition", task.KafkaMessage.Partition)
-			s.SetTag("partitionKey", string(task.KafkaMessage.Key))
+			s.SetAttribute("taskType", task.Type)
+			s.SetAttribute("partition", task.KafkaMessage.Partition)
+			s.SetAttribute("partitionKey", string(task.KafkaMessage.Key))
 
-			s2 := tracer.StartSpan("worker.kafka.processMessage", tracer.ChildOf(s.Context()))
+			s2, _ := util.StartSpanFromContext(sCtx, "worker.kafka.processMessage")
 			for i := 0; i <= task.MaxRetries; i++ {
 				start := time.Now()
-				if err = k.Worker.processPublicWorkerMessage(tracer.ContextWithSpan(ctx, s), task); err != nil {
+				if err = k.Worker.processPublicWorkerMessage(sCtx, task); err != nil {
 					k.processWorkerError(ctx, task, err, start)
 				} else {
 					break
 				}
 			}
-			s.SetTag("taskFailures", task.Failures)
-			s2.Finish(tracer.WithError(err))
+			s.SetAttribute("taskFailures", task.Failures)
+			s2.Finish(err)
 
-			s3 := tracer.StartSpan("worker.kafka.commitMessage", tracer.ChildOf(s.Context()))
+			s3, _ := util.StartSpanFromContext(sCtx, "worker.kafka.commitMessage")
 			k.KafkaQueue.Commit(ctx, task.KafkaMessage)
 			s3.Finish()
 
@@ -102,8 +101,8 @@ type KafkaWorker struct {
 }
 
 func (k *KafkaBatchWorker) flush(ctx context.Context) error {
-	s, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush", k.Name)))
-	s.SetTag("BatchSize", len(k.messages))
+	s, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush", k.Name)))
+	s.SetAttribute("BatchSize", len(k.messages))
 	defer s.Finish()
 
 	var syncSessionIds []int
@@ -114,7 +113,7 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 
 	var lastMsg *kafkaqueue.Message
 	var oldestMsg = time.Now()
-	readSpan, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readMessages", k.Name)))
+	readSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readMessages", k.Name)))
 	for _, lastMsg = range k.messages {
 		if lastMsg.KafkaMessage.Time.Before(oldestMsg) {
 			oldestMsg = lastMsg.KafkaMessage.Time
@@ -140,31 +139,31 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 	}
 	k.messages = []*kafkaqueue.Message{}
 
-	readSpan.SetTag("MaxIngestDelay", time.Since(oldestMsg))
+	readSpan.SetAttribute("MaxIngestDelay", time.Since(oldestMsg))
 	readSpan.Finish()
 
-	workSpan, wCtx := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.work", k.Name)))
+	workSpan, wCtx := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.work", k.Name)))
 	if len(syncSessionIds) > 0 || len(syncErrorGroupIds) > 0 || len(syncErrorObjectIds) > 0 {
 		if err := k.flushDataSync(wCtx, syncSessionIds, syncErrorGroupIds, syncErrorObjectIds); err != nil {
-			workSpan.Finish(tracer.WithError(err))
+			workSpan.Finish(err)
 			return err
 		}
 	}
 	if len(logRows) > 0 {
 		if err := k.flushLogs(wCtx, logRows); err != nil {
-			workSpan.Finish(tracer.WithError(err))
+			workSpan.Finish(err)
 			return err
 		}
 	}
 	if len(traceRows) > 0 {
 		if err := k.flushTraces(wCtx, traceRows); err != nil {
-			workSpan.Finish(tracer.WithError(err))
+			workSpan.Finish(err)
 			return err
 		}
 	}
 	workSpan.Finish()
 
-	commitSpan, cCtx := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.commit", k.Name)))
+	commitSpan, cCtx := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.commit", k.Name)))
 	if lastMsg != nil {
 		k.KafkaQueue.Commit(cCtx, lastMsg.KafkaMessage)
 	}
@@ -183,7 +182,7 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 		}
 	}
 
-	spanTs, ctxTs := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.setTimestamps", k.Name)))
+	spanTs, ctxTs := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.setTimestamps", k.Name)))
 	for projectId, timestamp := range timestampByProject {
 		err := k.Worker.Resolver.Redis.SetLastLogTimestamp(ctxTs, int(projectId), timestamp)
 		if err != nil {
@@ -192,7 +191,7 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 	}
 	spanTs.Finish()
 
-	spanW, ctxW := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.checkBillingQuotas", k.Name)))
+	spanW, ctxW := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.checkBillingQuotas", k.Name)))
 
 	// If it's saved in Redis that a project has exceeded / not exceeded
 	// its quota, use that value. Else, add the projectId to a list of
@@ -265,7 +264,7 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 	for _, logRow := range logRows {
 		// create service record for any services found in ingested logs
 		if logRow.ServiceName != "" {
-			spanX, ctxX := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.UpsertService", k.Name)))
+			spanX, ctxX := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.UpsertService", k.Name)))
 
 			project, err := k.Worker.Resolver.Store.GetProject(ctx, int(logRow.ProjectId))
 			if err == nil && project != nil {
@@ -295,9 +294,9 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 		}
 	}
 
-	wSpan, wCtx := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.process", k.Name)))
-	wSpan.SetTag("BatchSize", len(k.messages))
-	wSpan.SetTag("NumProjects", len(workspaceByProject))
+	wSpan, wCtx := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.process", k.Name)))
+	wSpan.SetAttribute("BatchSize", len(k.messages))
+	wSpan.SetAttribute("NumProjects", len(workspaceByProject))
 	for _, projectId := range markBackendSetupProjectIds {
 		err := k.Worker.PublicResolver.MarkBackendSetupImpl(wCtx, int(projectId), model.MarkBackendSetupTypeLogs)
 		if err != nil {
@@ -306,11 +305,11 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 		}
 	}
 
-	span, ctxT := tracer.StartSpanFromContext(wCtx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse.logs", k.Name)))
-	span.SetTag("NumLogRows", len(logRows))
-	span.SetTag("NumFilteredRows", len(filteredRows))
+	span, ctxT := util.StartSpanFromContext(wCtx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse.logs", k.Name)))
+	span.SetAttribute("NumLogRows", len(logRows))
+	span.SetAttribute("NumFilteredRows", len(filteredRows))
 	err := k.Worker.PublicResolver.Clickhouse.BatchWriteLogRows(ctxT, filteredRows)
-	span.Finish(tracer.WithError(err))
+	span.Finish(err)
 	if err != nil {
 		log.WithContext(ctxT).WithError(err).Error("failed to batch write logs to clickhouse")
 		return err
@@ -320,14 +319,14 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 }
 
 func (k *KafkaBatchWorker) flushTraces(ctx context.Context, traceRows []*clickhouse.TraceRow) error {
-	span, ctxT := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse", k.Name)))
-	span.SetTag("NumTraceRows", len(traceRows))
-	span.SetTag("PayloadSizeBytes", binary.Size(traceRows))
+	span, ctxT := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse", k.Name)))
+	span.SetAttribute("NumTraceRows", len(traceRows))
+	span.SetAttribute("PayloadSizeBytes", binary.Size(traceRows))
 	err := k.Worker.PublicResolver.Clickhouse.BatchWriteTraceRows(ctxT, traceRows)
-	defer span.Finish(tracer.WithError(err))
+	defer span.Finish(err)
 	if err != nil {
 		log.WithContext(ctxT).WithError(err).Error("failed to batch write traces to clickhouse")
-		span.Finish(tracer.WithError(err))
+		span.Finish(err)
 		return err
 	}
 	return nil
@@ -339,7 +338,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 		allSessionObjs := []*model.Session{}
 		for _, chunk := range sessionIdChunks {
 			sessionObjs := []*model.Session{}
-			sessionSpan, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readSessions", k.Name)))
+			sessionSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readSessions", k.Name)))
 			if err := k.Worker.PublicResolver.DB.Model(&model.Session{}).Preload("ViewedByAdmins").Where("id in ?", chunk).Find(&sessionObjs).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -347,7 +346,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 			sessionSpan.Finish()
 
 			fieldObjs := []*model.Field{}
-			fieldSpan, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readFields", k.Name)))
+			fieldSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readFields", k.Name)))
 			if err := k.Worker.PublicResolver.DB.Model(&model.Field{}).Where("id IN (SELECT field_id FROM session_fields sf WHERE sf.session_id IN ?)", chunk).Find(&fieldObjs).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -362,7 +361,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 				FieldID   int64
 			}
 			sessionFieldObjs := []*sessionField{}
-			sessionFieldSpan, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readSessionFields", k.Name)))
+			sessionFieldSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readSessionFields", k.Name)))
 			if err := k.Worker.PublicResolver.DB.Table("session_fields").Where("session_id IN ?", chunk).Find(&sessionFieldObjs).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -381,9 +380,9 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 			allSessionObjs = append(allSessionObjs, sessionObjs...)
 		}
 
-		chSpan, _ := tracer.StartSpanFromContext(ctx, KafkaBatchWorkerOp, tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse", k.Name)))
+		chSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse", k.Name)))
 		err := k.Worker.PublicResolver.Clickhouse.WriteSessions(ctx, allSessionObjs)
-		defer chSpan.Finish(tracer.WithError(err))
+		defer chSpan.Finish(err)
 		if err != nil {
 			log.WithContext(ctx).Error(err)
 			return err
@@ -395,7 +394,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 		allErrorGroups := []*model.ErrorGroup{}
 		for _, chunk := range errorGroupIdChunks {
 			errorGroups := []*model.ErrorGroup{}
-			errorGroupSpan, _ := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.datasync.readErrorGroups"))
+			errorGroupSpan, _ := util.StartSpanFromContext(ctx, "kafkaBatchWorker", util.ResourceName("worker.kafka.datasync.readErrorGroups"))
 			if err := k.Worker.PublicResolver.DB.Model(&model.ErrorGroup{}).Where("id in ?", chunk).Find(&errorGroups).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -405,7 +404,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 			allErrorGroups = append(allErrorGroups, errorGroups...)
 		}
 
-		chSpan, _ := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.datasync.writeClickhouse.errorGroups"))
+		chSpan, _ := util.StartSpanFromContext(ctx, "kafkaBatchWorker", util.ResourceName("worker.kafka.datasync.writeClickhouse.errorGroups"))
 		if err := k.Worker.PublicResolver.Clickhouse.WriteErrorGroups(ctx, allErrorGroups); err != nil {
 			log.WithContext(ctx).Error(err)
 			return err
@@ -418,7 +417,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 		allErrorObjects := []*model.ErrorObject{}
 		for _, chunk := range errorObjectIdChunks {
 			errorObjects := []*model.ErrorObject{}
-			errorObjectSpan, _ := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.datasync.readErrorObjects"))
+			errorObjectSpan, _ := util.StartSpanFromContext(ctx, "kafkaBatchWorker", util.ResourceName("worker.kafka.datasync.readErrorObjects"))
 			if err := k.Worker.PublicResolver.DB.Model(&model.ErrorObject{}).Where("id in ?", chunk).Find(&errorObjects).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -437,7 +436,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 		allSessions := []*model.Session{}
 		for _, chunk := range sessionIdChunks {
 			sessions := []*model.Session{}
-			sessionSpan, _ := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.datasync.readErrorObjectSessions"))
+			sessionSpan, _ := util.StartSpanFromContext(ctx, "kafkaBatchWorker", util.ResourceName("worker.kafka.datasync.readErrorObjectSessions"))
 			if err := k.Worker.PublicResolver.DB.Model(&model.Session{}).Where("id in ?", chunk).Find(&sessions).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -447,7 +446,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 			allSessions = append(allSessions, sessions...)
 		}
 
-		chSpan, _ := tracer.StartSpanFromContext(ctx, "kafkaBatchWorker", tracer.ResourceName("worker.kafka.datasync.writeClickhouse.errorObjects"))
+		chSpan, _ := util.StartSpanFromContext(ctx, "kafkaBatchWorker", util.ResourceName("worker.kafka.datasync.writeClickhouse.errorObjects"))
 		if err := k.Worker.PublicResolver.Clickhouse.WriteErrorObjects(ctx, allErrorObjects, allSessions); err != nil {
 			log.WithContext(ctx).Error(err)
 			return err
@@ -468,12 +467,12 @@ func (k *KafkaBatchWorker) ProcessMessages(ctx context.Context) {
 	for {
 		func() {
 			defer util.Recover()
-			s, ctx := tracer.StartSpanFromContext(ctx, "kafkaWorker", tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.process", k.Name)))
-			s.SetTag("worker.goroutine", k.WorkerThread)
-			s.SetTag("BatchSize", len(k.messages))
+			s, ctx := util.StartSpanFromContext(ctx, "kafkaWorker", util.ResourceName(fmt.Sprintf("worker.kafka.%s.process", k.Name)))
+			s.SetAttribute("worker.goroutine", k.WorkerThread)
+			s.SetAttribute("BatchSize", len(k.messages))
 			defer s.Finish()
 
-			s1, _ := tracer.StartSpanFromContext(ctx, "kafkaWorker", tracer.ResourceName(fmt.Sprintf("worker.kafka.%s.receive", k.Name)))
+			s1, _ := util.StartSpanFromContext(ctx, "kafkaWorker", util.ResourceName(fmt.Sprintf("worker.kafka.%s.receive", k.Name)))
 			task := k.KafkaQueue.Receive(ctx)
 			s1.Finish()
 			if task == nil {
@@ -485,7 +484,7 @@ func (k *KafkaBatchWorker) ProcessMessages(ctx context.Context) {
 			k.messages = append(k.messages, task)
 
 			if time.Since(k.lastFlush) > k.BatchedFlushTimeout || len(k.messages) >= k.BatchFlushSize {
-				s.SetTag("FlushDelay", time.Since(k.lastFlush))
+				s.SetAttribute("FlushDelay", time.Since(k.lastFlush))
 
 				for i := 0; i <= kafkaqueue.TaskRetries; i++ {
 					if err := k.flush(ctx); err != nil {

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -467,12 +467,12 @@ func (k *KafkaBatchWorker) ProcessMessages(ctx context.Context) {
 	for {
 		func() {
 			defer util.Recover()
-			s, ctx := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.process", k.Name)), util.WithHighlightTracingDisabled(k.TracingDisabled))
+			s, ctx := util.StartSpanFromContext(ctx, "KafkaWorker", util.ResourceName(fmt.Sprintf("worker.kafka.%s.process", k.Name)), util.WithHighlightTracingDisabled(k.TracingDisabled))
 			s.SetAttribute("worker.goroutine", k.WorkerThread)
 			s.SetAttribute("BatchSize", len(k.messages))
 			defer s.Finish()
 
-			s1, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.receive", k.Name)))
+			s1, _ := util.StartSpanFromContext(ctx, "KafkaWorker", util.ResourceName(fmt.Sprintf("worker.kafka.%s.receive", k.Name)))
 			task := k.KafkaQueue.Receive(ctx)
 			s1.Finish()
 			if task == nil {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -444,10 +444,11 @@ func (w *Worker) processPublicWorkerMessage(ctx context.Context, task *kafkaqueu
 }
 
 type WorkerConfig struct {
-	Workers      int
-	FlushSize    int
-	FlushTimeout time.Duration
-	Topic        kafkaqueue.TopicType
+	Workers         int
+	FlushSize       int
+	FlushTimeout    time.Duration
+	Topic           kafkaqueue.TopicType
+	TracingDisabled bool
 }
 
 func (w *Worker) PublicWorker(ctx context.Context) {
@@ -470,10 +471,11 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 	}
 
 	tracesConfig := WorkerConfig{
-		Topic:        kafkaqueue.TopicTypeTraces,
-		Workers:      sys.TraceWorkers,
-		FlushSize:    sys.TraceFlushSize,
-		FlushTimeout: sys.TraceFlushTimeout,
+		Topic:           kafkaqueue.TopicTypeTraces,
+		Workers:         sys.TraceWorkers,
+		FlushSize:       sys.TraceFlushSize,
+		FlushTimeout:    sys.TraceFlushTimeout,
+		TracingDisabled: true,
 	}
 
 	dataSyncConfig := WorkerConfig{
@@ -521,6 +523,7 @@ func (w *Worker) PublicWorker(ctx context.Context) {
 					BatchFlushSize:      config.FlushSize,
 					BatchedFlushTimeout: config.FlushTimeout,
 					Name:                string(config.Topic),
+					TracingDisabled:     config.TracingDisabled,
 				}
 				k.ProcessMessages(ctx)
 				wg.Done()

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -44,7 +44,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gorm.io/gorm"
 )
 
@@ -271,8 +270,8 @@ func (w *Worker) scanSessionPayload(ctx context.Context, manager *payload.Payloa
 }
 
 func (w *Worker) getSessionID(ctx context.Context, sessionSecureID string) (id int, err error) {
-	s, _ := tracer.StartSpanFromContext(ctx, "getSessionID", tracer.ResourceName("worker.getSessionID"))
-	s.SetTag("secure_id", sessionSecureID)
+	s, _ := util.StartSpanFromContext(ctx, "getSessionID", util.ResourceName("worker.getSessionID"))
+	s.SetAttribute("secure_id", sessionSecureID)
 	defer s.Finish()
 	if sessionSecureID == "" {
 		return 0, e.New("getSessionID called with no secure id")
@@ -548,8 +547,8 @@ func (w *Worker) DeleteCompletedSessions(ctx context.Context) {
 				AND s.created_at > NOW() - INTERVAL '1 WEEK'`
 
 	for _, table := range []string{"resources_objects", "messages_objects"} {
-		deleteSpan, ctx := tracer.StartSpanFromContext(ctx, "worker.deleteObjects",
-			tracer.ResourceName("worker.deleteObjects"), tracer.Tag("table", table))
+		deleteSpan, ctx := util.StartSpanFromContext(ctx, "worker.deleteObjects",
+			util.ResourceName("worker.deleteObjects"), util.Tag("table", table))
 		if err := w.Resolver.DB.Exec(fmt.Sprintf(baseQuery, table), lookbackPeriod).Error; err != nil {
 			log.WithContext(ctx).Error(e.Wrapf(err, "error deleting expired objects from %s", table))
 		}
@@ -1058,7 +1057,7 @@ func (w *Worker) Start(ctx context.Context) {
 	for {
 		time.Sleep(1 * time.Second)
 		sessions := []*model.Session{}
-		sessionsSpan, ctx := tracer.StartSpanFromContext(ctx, "worker.sessionsQuery", tracer.ResourceName("worker.sessionsQuery"))
+		sessionsSpan, ctx := util.StartSpanFromContext(ctx, "worker.sessionsQuery", util.ResourceName("worker.sessionsQuery"))
 		sessionLimitJitter := rand.Intn(100)
 		limit := processSessionLimit + sessionLimitJitter
 		txStart := time.Now()
@@ -1151,7 +1150,7 @@ func (w *Worker) Start(ctx context.Context) {
 					vmStat, _ = mem.VirtualMemory()
 				}
 
-				span, ctx := tracer.StartSpanFromContext(ctx, "worker.operation", tracer.ResourceName("worker.processSession"), tracer.Tag("project_id", session.ProjectID), tracer.Tag("session_secure_id", session.SecureID))
+				span, ctx := util.StartSpanFromContext(ctx, "worker.operation", util.ResourceName("worker.processSession"), util.Tag("project_id", session.ProjectID), util.Tag("session_secure_id", session.SecureID))
 				if err := w.processSession(ctx, session); err != nil {
 					nextCount := session.RetryCount + 1
 					var excluded bool
@@ -1178,7 +1177,7 @@ func (w *Worker) Start(ctx context.Context) {
 						span.Finish()
 					} else {
 						log.WithContext(ctx).WithField("session_secure_id", session.SecureID).Error(e.Wrap(err, "error processing main session"))
-						span.Finish(tracer.WithError(e.Wrapf(err, "error processing session: %v", session.ID)))
+						span.Finish(e.Wrapf(err, "error processing session: %v", session.ID))
 					}
 
 					return
@@ -1277,8 +1276,8 @@ func (w *Worker) StartLogAlertWatcher(ctx context.Context) {
 }
 
 func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
-	span, _ := tracer.StartSpanFromContext(ctx, "worker.refreshMaterializedViews",
-		tracer.ResourceName("worker.refreshMaterializedViews"))
+	span, _ := util.StartSpanFromContext(ctx, "worker.refreshMaterializedViews",
+		util.ResourceName("worker.refreshMaterializedViews"))
 	defer span.Finish()
 
 	if err := w.Resolver.DB.Transaction(func(tx *gorm.DB) error {

--- a/docker/otel-collector.hobby.yaml
+++ b/docker/otel-collector.hobby.yaml
@@ -26,8 +26,8 @@ processors:
         limit_percentage: 75
         spike_limit_percentage: 15
     batch:
-        send_batch_size: 1024
-        send_batch_max_size: 1024
+        send_batch_size: 512
+        send_batch_max_size: 512
         timeout: 1s
 service:
     telemetry:

--- a/docker/otel-collector.yaml
+++ b/docker/otel-collector.yaml
@@ -26,8 +26,8 @@ processors:
         limit_percentage: 75
         spike_limit_percentage: 15
     batch:
-        send_batch_size: 1024
-        send_batch_max_size: 1024
+        send_batch_size: 128
+        send_batch_max_size: 128
         timeout: 1s
 service:
     telemetry:

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -29,6 +29,7 @@ export const TracesList: React.FC<Props> = ({ loading, traces }) => {
 							<Table.Header>Parent Span ID</Table.Header>
 							<Table.Header>Secure Session ID</Table.Header>
 							<Table.Header>Status</Table.Header>
+							<Table.Header>Timestamp</Table.Header>
 						</Table.Row>
 					</Table.Head>
 					<Table.Body
@@ -72,6 +73,18 @@ export const TracesList: React.FC<Props> = ({ loading, traces }) => {
 									</Table.Cell>
 									<Table.Cell>
 										{trace.statusMessage}
+									</Table.Cell>
+									<Table.Cell>
+										{new Date(
+											trace.timestamp,
+										).toLocaleDateString('en-US', {
+											month: 'short',
+											day: 'numeric',
+											year: 'numeric',
+											hour: 'numeric',
+											minute: 'numeric',
+											second: 'numeric',
+										})}
 									</Table.Cell>
 								</Table.Row>
 							))}

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -25,10 +25,10 @@ export const TracesList: React.FC<Props> = ({ loading, traces }) => {
 						<Table.Row>
 							<Table.Header>Span</Table.Header>
 							<Table.Header>Service</Table.Header>
+							<Table.Header>Resource Name</Table.Header>
 							<Table.Header>Span ID</Table.Header>
 							<Table.Header>Parent Span ID</Table.Header>
 							<Table.Header>Secure Session ID</Table.Header>
-							<Table.Header>Status</Table.Header>
 							<Table.Header>Timestamp</Table.Header>
 						</Table.Row>
 					</Table.Head>
@@ -46,6 +46,9 @@ export const TracesList: React.FC<Props> = ({ loading, traces }) => {
 								<Table.Row key={index}>
 									<Table.Cell>{trace.spanName}</Table.Cell>
 									<Table.Cell>{trace.serviceName}</Table.Cell>
+									<Table.Cell>
+										{trace.traceAttributes?.resource_name}
+									</Table.Cell>
 									<Table.Cell>{trace.spanID}</Table.Cell>
 									<Table.Cell
 										onClick={
@@ -63,16 +66,17 @@ export const TracesList: React.FC<Props> = ({ loading, traces }) => {
 										{trace.parentSpanID}
 									</Table.Cell>
 									<Table.Cell
-										onClick={() => {
-											navigate(
-												`/${projectId}/sessions/${trace.secureSessionID}`,
-											)
-										}}
+										onClick={
+											trace.secureSessionID
+												? () => {
+														navigate(
+															`/${projectId}/sessions/${trace.secureSessionID}`,
+														)
+												  }
+												: undefined
+										}
 									>
 										{trace.secureSessionID}
-									</Table.Cell>
-									<Table.Cell>
-										{trace.statusMessage}
 									</Table.Cell>
 									<Table.Cell>
 										{new Date(

--- a/packages/ui/src/components/Callout/Callout.tsx
+++ b/packages/ui/src/components/Callout/Callout.tsx
@@ -17,7 +17,7 @@ export type Props = React.PropsWithChildren &
 	styles.Variants & {
 		title?: string
 		width?: number
-		style?: { [k: string]: any }
+		style?: React.CSSProperties
 		handleCloseClick?: () => void
 		icon?: false | (() => JSX.Element)
 	}

--- a/packages/ui/src/components/Form/Form.tsx
+++ b/packages/ui/src/components/Form/Form.tsx
@@ -10,7 +10,6 @@ import { Button, ButtonProps } from '../Button/Button'
 import clsx, { ClassValue } from 'clsx'
 import { Variants } from './styles.css'
 import { Badge } from '../Badge/Badge'
-import { Callout } from '../Callout/Callout'
 
 type FormComponent = React.FC<Props> & {
 	Input: typeof Input


### PR DESCRIPTION
## Summary

We are currently sending traces to Datadog for all of our manual tracing, but we want to start sending these to Highlight as well, and ultimately phase out DD for traces. This PR adds some new utility methods that can be used as alternatives to where we call `tracer.*`. All method calls to create spans will also send spans to Highlight.

## How did you test this change?

Local click test. Can't test in PR preview because of the backend changes.

Here is some data from my local machine showing traces coming into Clickhouse:

<img width="1512" alt="Screenshot 2023-09-14 at 5 09 04 PM" src="https://github.com/highlight/highlight/assets/308182/1487725c-50e9-452d-8ed0-ec0be8420c18">

## Are there any deployment considerations?

We should ensure that all tracing information is landing in both places by checking Clickhouse + the DD UI.

## Does this work require review from our design team?

N/A