### PR TITLE
correctly serialize node console messages

### DIFF
--- a/sdk/highlight-apollo/CHANGELOG.md
+++ b/sdk/highlight-apollo/CHANGELOG.md
@@ -17,3 +17,9 @@
 ### 3.1.7
 
 - Bumping to match `@highlight-run/node`
+
+## 3.3.1
+
+### Minor Changes
+
+-   Ensure console serialization works with `BigInteger` and other unserializeable types.

--- a/sdk/highlight-apollo/package.json
+++ b/sdk/highlight-apollo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/apollo",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"license": "Apache-2.0",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-nest/CHANGELOG.md
+++ b/sdk/highlight-nest/CHANGELOG.md
@@ -23,3 +23,9 @@
 ### 3.1.7
 
 - Bumping to match `@highlight-run/node`
+
+## 3.3.1
+
+### Minor Changes
+
+-   Ensure console serialization works with `BigInteger` and other unserializeable types.

--- a/sdk/highlight-nest/package.json
+++ b/sdk/highlight-nest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/nest",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"description": "Client for interfacing with Highlight in nestjs",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -63,7 +63,7 @@
 
 - Added support for setting `serviceName`
 
-## 3.3.1
+## 4.3.1
 
 ### Minor Changes
 

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -62,3 +62,9 @@
 ### Minor changes
 
 - Added support for setting `serviceName`
+
+## 3.3.1
+
+### Minor Changes
+
+-   Ensure console serialization works with `BigInteger` and other unserializeable types.

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "4.3.0",
+	"version": "4.3.1",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-node/CHANGELOG.md
+++ b/sdk/highlight-node/CHANGELOG.md
@@ -91,3 +91,9 @@
 ### Minor Changes
 
 -   Disables node fs instrumentation by default, can by enabled by passing `enableFsInstrumentation: true` to client option.
+
+## 3.3.1
+
+### Minor Changes
+
+-   Ensure console serialization works with `BigInteger` and other unserializeable types.

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"license": "Apache-2.0",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-node/src/hooks.test.ts
+++ b/sdk/highlight-node/src/hooks.test.ts
@@ -1,0 +1,24 @@
+import { safeStringify } from './hooks'
+
+describe('safeStringify', () => {
+	it('ensure safeStringify can handle bigints', async () => {
+		const obj = {
+			hello: 'world',
+			foo: BigInt(9007199254740991),
+			bar: Symbol('symbolTest'),
+			another: {
+				hello: 'world',
+				foo: BigInt(123),
+				deep: { deeper: BigInt(456) },
+			},
+			arrayTest: [1, 2, 3, BigInt(789)],
+		}
+		const result = safeStringify(obj)
+		expect(JSON.parse(result)).toStrictEqual({
+			another: { deep: { deeper: '456' }, foo: '123', hello: 'world' },
+			arrayTest: [1, 2, 3, '789'],
+			foo: '9007199254740991',
+			hello: 'world',
+		})
+	})
+})

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -23,3 +23,9 @@
 ### Minor changes
 
 - Added support for setting `serviceName`
+
+## 3.3.1
+
+### Minor Changes
+
+-   Ensure console serialization works with `BigInteger` and other unserializeable types.

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - Added support for setting `serviceName`
 
-## 3.3.1
+## 0.4.1
 
 ### Minor Changes
 

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@3.5.0",
 	"author": "",

--- a/sdk/pino/CHANGELOG.md
+++ b/sdk/pino/CHANGELOG.md
@@ -3,3 +3,9 @@
 ## 0.1.0
 
 ### Initial Release
+
+## 0.1.3
+
+### Minor Changes
+
+-   Ensure console serialization works with `BigInteger` and other unserializeable types.

--- a/sdk/pino/package.json
+++ b/sdk/pino/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/pino",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"packageManager": "yarn@3.5.0",
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Summary

We've received a report that our node sdk would not serialize `BigInteger` messages correctly.
Relates to existing discord report.

## How did you test this change?

New unit test

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
