### PR TITLE
add alert creation buttons to sessions and errors

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5800,6 +5800,11 @@ body {
   display: flex;
   align-items: center;
 }
+.xaifbz0 {
+  border-right: var(--_1pyqka9j) solid 1px;
+  height: 16px;
+  width: 1px;
+}
 ._10haslo0 {
   display: flex;
   flex-direction: column;

--- a/frontend/src/__generated/ve/components/CreateAlertButton/style.css.js
+++ b/frontend/src/__generated/ve/components/CreateAlertButton/style.css.js
@@ -1,0 +1,1 @@
+var i="xaifbz0";export{i as divider};

--- a/frontend/src/components/CreateAlertButton/CreateAlertButton.tsx
+++ b/frontend/src/components/CreateAlertButton/CreateAlertButton.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@components/Button'
+import { Box, IconSolidBell } from '@highlight-run/ui'
+import { useProjectId } from '@hooks/useProjectId'
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import * as styles from './style.css'
+
+export const CreateAlertButton = function ({
+	type,
+}: {
+	type: 'session' | 'errors'
+}) {
+	const { projectId } = useProjectId()
+	const navigate = useNavigate()
+	return (
+		<Button
+			size="small"
+			kind="primary"
+			emphasis="high"
+			trackingId={`${type}-player-bar-alerts`}
+			iconLeft={<IconSolidBell />}
+			onClick={() => {
+				navigate(`/${projectId}/alerts/${type}/new`)
+			}}
+		>
+			Turn on alerts
+		</Button>
+	)
+}
+export const Divider: React.FC = () => {
+	return <Box className={styles.divider}></Box>
+}

--- a/frontend/src/components/CreateAlertButton/style.css.ts
+++ b/frontend/src/components/CreateAlertButton/style.css.ts
@@ -1,0 +1,8 @@
+import { vars } from '@highlight-run/ui'
+import { style } from '@vanilla-extract/css'
+
+export const divider = style({
+	borderRight: vars.border.divider,
+	height: 16,
+	width: 1,
+})

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -1,9 +1,14 @@
 import { useAuthContext } from '@authentication/AuthContext'
+import {
+	CreateAlertButton,
+	Divider,
+} from '@components/CreateAlertButton/CreateAlertButton'
 import { ErrorState } from '@components/ErrorState/ErrorState'
 import { KeyboardShortcut } from '@components/KeyboardShortcut/KeyboardShortcut'
 import LoadingBox from '@components/LoadingBox'
 import { PreviousNextGroup } from '@components/PreviousNextGroup/PreviousNextGroup'
 import {
+	useGetAlertsPagePayloadQuery,
 	useGetErrorGroupQuery,
 	useGetProjectDropdownOptionsQuery,
 	useMarkErrorGroupAsViewedMutation,
@@ -37,7 +42,7 @@ import analytics from '@util/analytics'
 import { useParams } from '@util/react-router/useParams'
 import { message } from 'antd'
 import clsx from 'clsx'
-import { useCallback, useEffect, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 import { Helmet } from 'react-helmet'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -194,6 +199,14 @@ function TopBar({
 	projectId,
 	navigation,
 }: TopBarProps) {
+	const { data: alertsData } = useGetAlertsPagePayloadQuery({
+		variables: {
+			project_id: projectId!,
+		},
+		skip: !projectId,
+	})
+	const showCreateAlertButton = alertsData?.error_alerts?.length === 0
+
 	const {
 		showLeftPanel,
 		setShowLeftPanel,
@@ -242,8 +255,12 @@ function TopBar({
 			</Box>
 			<Box>
 				{errorGroup && (
-					<Box display="flex" gap="8">
+					<Box display="flex" gap="8" alignItems="center">
 						<ErrorShareButton errorGroup={errorGroup} />
+						{showCreateAlertButton ? (
+							<CreateAlertButton type="errors" />
+						) : null}
+						<Divider />
 						<ErrorStateSelect
 							state={errorGroup.state}
 							snoozedUntil={errorGroup.snoozed_until}

--- a/frontend/src/pages/Player/SessionLevelBar/SessionLevelBarV2.tsx
+++ b/frontend/src/pages/Player/SessionLevelBar/SessionLevelBarV2.tsx
@@ -1,7 +1,14 @@
 import { useAuthContext } from '@authentication/AuthContext'
+import {
+	CreateAlertButton,
+	Divider,
+} from '@components/CreateAlertButton/CreateAlertButton'
 import { DEFAULT_PAGE_SIZE } from '@components/Pagination/Pagination'
 import { PreviousNextGroup } from '@components/PreviousNextGroup/PreviousNextGroup'
-import { useGetSessionsOpenSearchQuery } from '@graph/hooks'
+import {
+	useGetAlertsPagePayloadQuery,
+	useGetSessionsOpenSearchQuery,
+} from '@graph/hooks'
 import {
 	Badge,
 	Box,
@@ -76,6 +83,14 @@ export const SessionLevelBarV2: React.FC<
 		fetchPolicy: 'cache-first',
 		skip: !projectId || !backendSearchQuery?.searchQuery,
 	})
+	const { data: alertsData } = useGetAlertsPagePayloadQuery({
+		variables: {
+			project_id: projectId!,
+		},
+		skip: !projectId,
+	})
+	const showCreateAlertButton = alertsData?.new_session_alerts?.length === 0
+
 	const isDefaultView = DEFAULT_RIGHT_PANEL_VIEWS.includes(rightPanelView)
 
 	const sessionIdx = sessionResults.sessions.findIndex(
@@ -286,6 +301,10 @@ export const SessionLevelBarV2: React.FC<
 					{session && (
 						<>
 							<SessionShareButtonV2 />
+							{showCreateAlertButton ? (
+								<CreateAlertButton type="session" />
+							) : null}
+							<Divider />
 							<PlayerModeSwitch />
 							<SwitchButton
 								size="small"


### PR DESCRIPTION
## Summary

Adds new buttons to link to creating alerts from the sessions and errors pages.

## How did you test this change?

[Reflame preview on our project](https://preview.highlight.io/1/errors/VBdaIpZpjLHI4iewzsz7LlTAeEav?page=1&query=and%7C%7Cerror_state%2Cis%2COPEN%7C%7Cerror-field_timestamp%2Cbetween_date%2C2023-08-15T23%3A06%3A38.376Z_2023-09-14T23%3A06%3A38.376Z&%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HAAZ1WSXSX97PNTR2QMG1MCK%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%226078-turn-on-error-session-alerts-from-the-errors-sessions-pages%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D).
<img width="1794" alt="Screenshot 2023-09-14 at 4 06 55 PM" src="https://github.com/highlight/highlight/assets/1351531/c1bf5827-226f-4b64-aba1-db670613b386">

[Reflame preview](https://preview.highlight.io/11983/sessions?page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue%7C%7Ccustom_created_at%2Cbetween_date%2C2023-08-15T23%3A06%3A32.944Z_2023-09-14T23%3A06%3A32.944Z&%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HAAZ1WSXSX97PNTR2QMG1MCK%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%226078-turn-on-error-session-alerts-from-the-errors-sessions-pages%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D) on another project without alerts.
<img width="1800" alt="Screenshot 2023-09-14 at 4 07 19 PM" src="https://github.com/highlight/highlight/assets/1351531/bbd8e2af-b83c-465e-a87c-819f6fb04e98">


## Are there any deployment considerations?

No

## Does this work require review from our design team?

Yes
