### PR TITLE
perf tuning for logs histogram query

### DIFF
--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -164,5 +165,23 @@ func getSeverityNumber(logLevel modelInputs.LogLevel) int32 {
 	default:
 		return int32(log.InfoLevel)
 	}
+}
 
+func getLogLevel(level logrus.Level) modelInputs.LogLevel {
+	switch level {
+	case log.TraceLevel:
+		return modelInputs.LogLevelTrace
+	case log.DebugLevel:
+		return modelInputs.LogLevelDebug
+	case log.InfoLevel:
+		return modelInputs.LogLevelInfo
+	case log.WarnLevel:
+		return modelInputs.LogLevelWarn
+	case log.ErrorLevel:
+		return modelInputs.LogLevelError
+	case log.FatalLevel:
+		return modelInputs.LogLevelFatal
+	default:
+		return modelInputs.LogLevelInfo
+	}
 }


### PR DESCRIPTION
## Summary
- tune the histogram query by:
  - removing ordering
  - avoiding the nested select
  - reducing the number of function calls per row
  - grouping on one column instead of two, and avoiding grouping on the string column
- seeing speedup on a 1 day query in prod from about ~30s execution time to ~7s
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
- generated the 30 day query and ran in prod
```
SELECT intDiv(48 * (toRelativeSecondNum(Timestamp) - 1692199700), (1694791700 - 1692199700)) * 8 + SeverityNumber, count() FROM logs WHERE ProjectId = 1 AND Timestamp <= '2023-09-15 11:28:20' AND Timestamp >= '2023-08-16 11:28:20' GROUP BY 1
```
Took 32s, read 5B rows / 61GB
It's unlikely to get much better performance without either increasing the number of threads (which could have an impact when many of these queries are running at the same time) or implementing sampling
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
