### PR TITLE
only blur player when player ready

### DIFF
--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -310,7 +310,8 @@ const PlayerPage = () => {
 							<div className={style.playerWrapperV2}>
 								<div
 									className={clsx(style.rrwebPlayerWrapper, {
-										[style.blurBackground]: isLoadingEvents,
+										[style.blurBackground]:
+											isLoadingEvents && isPlayerReady,
 									})}
 									ref={playerWrapperRef}
 								>


### PR DESCRIPTION
## Summary

Loading state would sometimes be blurred before if the session was loading.

## How did you test this change?

[reflame preview](https://preview.highlight.io/1/sessions/hRIgH0DgjDvHfOoVx8ye2giXg7Rq?page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue%7C%7Ccustom_created_at%2Cbetween_date%2C2023-08-17T00%3A00%3A42.024Z_2023-09-16T00%3A00%3A42.024Z&%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HADMHEHBVYYWASD8586QKXBW%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Ffix-player-loading-blur%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)
https://www.loom.com/share/5a86094a72254136bfa1c3c64347428b

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
