### PR TITLE
Resolves issue with error monitoring inputs

### DIFF
--- a/frontend/src/pages/ProjectSettings/AutoresolveStaleErrorsForm/AutoresolveStaleErrorsForm.tsx
+++ b/frontend/src/pages/ProjectSettings/AutoresolveStaleErrorsForm/AutoresolveStaleErrorsForm.tsx
@@ -71,8 +71,8 @@ export const AutoresolveStaleErrorsForm = () => {
 								if (!isOptIn) {
 									setAutoResolveStaleErrorsDayInterval(0)
 								} else {
-                  setAutoResolveStaleErrorsDayInterval(1)
-                }
+									setAutoResolveStaleErrorsDayInterval(1)
+								}
 							},
 							false,
 						)}

--- a/frontend/src/pages/ProjectSettings/AutoresolveStaleErrorsForm/AutoresolveStaleErrorsForm.tsx
+++ b/frontend/src/pages/ProjectSettings/AutoresolveStaleErrorsForm/AutoresolveStaleErrorsForm.tsx
@@ -70,7 +70,9 @@ export const AutoresolveStaleErrorsForm = () => {
 
 								if (!isOptIn) {
 									setAutoResolveStaleErrorsDayInterval(0)
-								}
+								} else {
+                  setAutoResolveStaleErrorsDayInterval(1)
+                }
 							},
 							false,
 						)}

--- a/frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx
+++ b/frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx
@@ -50,7 +50,7 @@ export const FilterExtensionForm = () => {
 									? {
 											projectSettings: {
 												...currentProjectSettings.projectSettings,
-												filterChromeExtension: isOptIn,
+												filter_chrome_extension: isOptIn,
 											},
 									  }
 									: currentProjectSettings,

--- a/frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx
+++ b/frontend/src/pages/ProjectSettings/FilterExtensionForm/FilterExtensionForm.tsx
@@ -50,7 +50,8 @@ export const FilterExtensionForm = () => {
 									? {
 											projectSettings: {
 												...currentProjectSettings.projectSettings,
-												filter_chrome_extension: isOptIn,
+												filter_chrome_extension:
+													isOptIn,
 											},
 									  }
 									: currentProjectSettings,


### PR DESCRIPTION
## Summary
This resolves an issue with states being improperly updated for `Extension Error Filtering` and `Auto-Resolve Stale Errors` inside the project settings page.

Related Issue: #6631 

## How did you test this change?

Tested locally and on a self deployed version of highlight

## Are there any deployment considerations?

None, just frontend logic changes

## Does this work require review from our design team?

No
