### PR TITLE
Fixes log alert query not saving

### DIFF
--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -132,8 +132,9 @@ export const LogAlertPage = () => {
 	const formValues = formStore.useState().values
 
 	const [query, setQuery] = useState(initialQuery)
-	const handleSearchSubmit = (query: string) => {
+	const handleUpdateInputQuery = (query: string) => {
 		setSubmittedQuery(query)
+    formStore.setValue(formStore.names.query, query)
 	}
 
 	formStore.useSubmit(() => {
@@ -452,7 +453,7 @@ export const LogAlertPage = () => {
 												query={query}
 												setQuery={setQuery}
 												onFormSubmit={
-													handleSearchSubmit
+													handleUpdateInputQuery
 												}
 												fetchValuesLazyQuery={
 													useGetLogsKeyValuesLazyQuery

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -134,7 +134,7 @@ export const LogAlertPage = () => {
 	const [query, setQuery] = useState(initialQuery)
 	const handleUpdateInputQuery = (query: string) => {
 		setSubmittedQuery(query)
-    formStore.setValue(formStore.names.query, query)
+		formStore.setValue(formStore.names.query, query)
 	}
 
 	formStore.useSubmit(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -24879,8 +24879,8 @@ __metadata:
 
 "ansi-color@file:./forks/ansi-color::locator=highlight%40workspace%3A.":
   version: 0.0.0
-  resolution: "ansi-color@file:./forks/ansi-color#./forks/ansi-color::hash=291f6b&locator=highlight%40workspace%3A."
-  checksum: ebc4eb866ee788f9088fd981ccec71a0aca50f8b7f798a6ab31e628b917e4554f6bc5f4c9f8119622901e59350b9bead56c69076d8b09af812c3e9111a10547a
+  resolution: "ansi-color@file:./forks/ansi-color#./forks/ansi-color::hash=c927b0&locator=highlight%40workspace%3A."
+  checksum: aa289fbc57d65d36be132553179f8f14eb045cf349bd05369da0f5002756210fd2bff49cc249a514de42515e93957a1b041bf8f4fbc2c639ca71588d66adbe3d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24879,8 +24879,8 @@ __metadata:
 
 "ansi-color@file:./forks/ansi-color::locator=highlight%40workspace%3A.":
   version: 0.0.0
-  resolution: "ansi-color@file:./forks/ansi-color#./forks/ansi-color::hash=c927b0&locator=highlight%40workspace%3A."
-  checksum: aa289fbc57d65d36be132553179f8f14eb045cf349bd05369da0f5002756210fd2bff49cc249a514de42515e93957a1b041bf8f4fbc2c639ca71588d66adbe3d
+  resolution: "ansi-color@file:./forks/ansi-color#./forks/ansi-color::hash=291f6b&locator=highlight%40workspace%3A."
+  checksum: ebc4eb866ee788f9088fd981ccec71a0aca50f8b7f798a6ab31e628b917e4554f6bc5f4c9f8119622901e59350b9bead56c69076d8b09af812c3e9111a10547a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This resolves an issue when defining a log alert query. When a user inputs a log query the value was being set into a local variable to update the histogram but was not updating the formStore that was being used to populate the mutation input variables. This PR should resolve this issue and allow for query to be sent along to the mutation.

Related Issue: #6630 

## How did you test this change?

Test both locally and in self deployed version

## Are there any deployment considerations?

None, purely frontend changes

## Does this work require review from our design team?

No