### PR TITLE
Fix alert form initial state

### DIFF
--- a/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
+++ b/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
@@ -79,7 +79,7 @@ export const ErrorAlertPage = () => {
 
 	const { alertsPayload } = useAlertsContext()
 	const alert = alert_id
-		? (findAlert(alert_id, alertsPayload) as any)
+		? (findAlert(alert_id, 'error', alertsPayload) as any)
 		: undefined
 
 	const formStore = useFormStore<ErrorAlertFormItem>({
@@ -444,6 +444,9 @@ const ErrorAlertForm = () => {
 							}
 							className={styles.selectContainer}
 							mode="tags"
+							value={formStore.getValue(
+								formStore.names.regex_groups,
+							)}
 						/>
 					</Form.NamedSection>
 					<Column.Container gap="12">
@@ -540,6 +543,9 @@ const ErrorAlertForm = () => {
 							notFoundContent={<p>No environment suggestions</p>}
 							className={styles.selectContainer}
 							mode="multiple"
+							value={formStore.getValue(
+								formStore.names.excludedEnvironments,
+							)}
 						/>
 					</Form.NamedSection>
 				</Stack>

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -627,6 +627,9 @@ const LogAlertForm = () => {
 							notFoundContent={<p>No environment suggestions</p>}
 							className={styles.selectContainer}
 							mode="multiple"
+							value={formStore.getValue(
+								formStore.names.excludedEnvironments,
+							)}
 						/>
 					</Form.NamedSection>
 				</Stack>
@@ -677,6 +680,9 @@ const LogAlertForm = () => {
 							className={styles.selectContainer}
 							mode="multiple"
 							labelInValue
+							value={formStore.getValue(
+								formStore.names.slackChannels,
+							)}
 						/>
 					</Form.NamedSection>
 
@@ -711,6 +717,9 @@ const LogAlertForm = () => {
 							className={styles.selectContainer}
 							mode="multiple"
 							labelInValue
+							value={formStore.getValue(
+								formStore.names.discordChannels,
+							)}
 						/>
 					</Form.NamedSection>
 
@@ -731,12 +740,13 @@ const LogAlertForm = () => {
 							notFoundContent={<p>No email suggestions</p>}
 							className={styles.selectContainer}
 							mode="multiple"
+							value={formStore.getValue(formStore.names.emails)}
 						/>
 					</Form.NamedSection>
 
 					<Form.NamedSection
 						label="Webhooks to notify"
-						name={formStore.names.emails}
+						name={formStore.names.webhookDestinations}
 					>
 						<Select
 							aria-label="Webhooks to notify"
@@ -750,6 +760,9 @@ const LogAlertForm = () => {
 							notFoundContent={null}
 							className={styles.selectContainer}
 							mode="tags"
+							value={formStore.getValue(
+								formStore.names.webhookDestinations,
+							)}
 						/>
 					</Form.NamedSection>
 				</Stack>

--- a/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
+++ b/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
@@ -92,7 +92,7 @@ export const SessionAlertPage = () => {
 
 	const { alertsPayload } = useAlertsContext()
 	const alert = alert_id
-		? (findAlert(alert_id, alertsPayload) as any)
+		? (findAlert(alert_id, 'session', alertsPayload) as any)
 		: undefined
 	const [alertType, setAlertType] = useState(
 		alert?.Type || SessionAlertType.NewSessionAlert,
@@ -672,6 +672,9 @@ const SessionAlertForm = ({
 										)
 									}}
 									className={styles.selectContainer}
+									value={formStore.getValue(
+										formStore.names.excludeRules,
+									)}
 								/>
 							</Form.NamedSection>
 						)}
@@ -693,6 +696,9 @@ const SessionAlertForm = ({
 											values,
 										)
 									}
+									value={formStore.getValue(
+										formStore.names.userProperties,
+									)}
 								/>
 							</Form.NamedSection>
 						)}
@@ -713,6 +719,9 @@ const SessionAlertForm = ({
 											values,
 										)
 									}
+									value={formStore.getValue(
+										formStore.names.trackProperties,
+									)}
 								/>
 							</Form.NamedSection>
 						)}
@@ -745,6 +754,9 @@ const SessionAlertForm = ({
 							notFoundContent={<p>No environment suggestions</p>}
 							className={styles.selectContainer}
 							mode="multiple"
+							value={formStore.getValue(
+								formStore.names.excludedEnvironments,
+							)}
 						/>
 					</Form.NamedSection>
 				</Stack>

--- a/frontend/src/pages/Alerts/components/AlertNotifyForm/AlertNotifyForm.tsx
+++ b/frontend/src/pages/Alerts/components/AlertNotifyForm/AlertNotifyForm.tsx
@@ -85,6 +85,7 @@ const AlertNotifyForm = () => {
 					className={styles.selectContainer}
 					mode="multiple"
 					labelInValue
+					value={formStore.getValue(formStore.names.slackChannels)}
 				/>
 			</Form.NamedSection>
 
@@ -119,6 +120,7 @@ const AlertNotifyForm = () => {
 					className={styles.selectContainer}
 					mode="multiple"
 					labelInValue
+					value={formStore.getValue(formStore.names.discordChannels)}
 				/>
 			</Form.NamedSection>
 
@@ -136,12 +138,13 @@ const AlertNotifyForm = () => {
 					notFoundContent={<p>No email suggestions</p>}
 					className={styles.selectContainer}
 					mode="multiple"
+					value={formStore.getValue(formStore.names.emails)}
 				/>
 			</Form.NamedSection>
 
 			<Form.NamedSection
 				label="Webhooks to notify"
-				name={formStore.names.emails}
+				name={formStore.names.webhookDestinations}
 			>
 				<Select
 					aria-label="Webhooks to notify"
@@ -155,6 +158,9 @@ const AlertNotifyForm = () => {
 					notFoundContent={null}
 					className={styles.selectContainer}
 					mode="tags"
+					value={formStore.getValue(
+						formStore.names.webhookDestinations,
+					)}
 				/>
 			</Form.NamedSection>
 		</Stack>

--- a/frontend/src/pages/Alerts/utils/AlertsUtils.ts
+++ b/frontend/src/pages/Alerts/utils/AlertsUtils.ts
@@ -58,14 +58,18 @@ export interface AlertForm {
  */
 export const findAlert = (
 	id: string,
+	type: 'error' | 'session',
 	alertsPayload?: GetAlertsPagePayloadQuery,
 ) => {
 	if (!alertsPayload) {
 		return undefined
 	}
 
-	const allAlerts = [
-		...alertsPayload.error_alerts,
+	if (type === 'error') {
+		return alertsPayload.error_alerts.find((alert: any) => alert?.id === id)
+	}
+
+	const possibleAlerts = [
 		...alertsPayload.new_session_alerts,
 		...(alertsPayload.new_user_alerts || []),
 		...alertsPayload.track_properties_alerts,
@@ -73,7 +77,7 @@ export const findAlert = (
 		...alertsPayload.rage_click_alerts,
 	]
 
-	return allAlerts.find((alert) => alert?.id === id)
+	return possibleAlerts.find((alert: any) => alert?.id === id)
 }
 
 export const getFrequencyOption = (seconds = DEFAULT_FREQUENCY): any => {


### PR DESCRIPTION
## Summary
Any value on the alert form that uses the select component is missing the initial state when configuring a form

## How did you test this change?
1) Create a new session, log, and error alert - adding values to the select components
2) When editing the alert, the correct information is displayed as an initial value

https://www.loom.com/share/2a355d8a5ea84a4e8c1f4e20cc246d0d?sid=6b7edd38-7212-4487-a5f1-d83492e7b380

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
