### PR TITLE
auto inline css on 127.0.0.1

### DIFF
--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -341,7 +341,10 @@ export class Highlight {
 	_initMembers(options: HighlightClassOptions) {
 		this.sessionShortcut = false
 		this._recordingStartTime = 0
-		this._isOnLocalHost = window.location.hostname === 'localhost'
+		this._isOnLocalHost =
+			window.location.hostname === 'localhost' ||
+			window.location.hostname === '127.0.0.1' ||
+			window.location.hostname === ''
 
 		this.ready = false
 		this.state = 'NotRecording'

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -384,3 +384,9 @@ Reserved for the Boeing 737
 ### Patch Changes
 
 - Remove canvas recording logging (not only enabled if the `debug` setting is provided).
+
+## 7.5.2
+
+### Patch Changes
+
+- Auto-inline CSS on 127.0.0.1 (a common alias for localhost).

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.5.1",
+	"version": "7.5.2",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.5.1"
+export default "7.5.2"


### PR DESCRIPTION
## Summary

Per a customer report, `127.0.0.1` stylesheets are not recorded automatically, though
they are not accessible over the network. This changes the setting to record for other
local references (where hostname is `''`).

## How did you test this change?

E2E test

## Are there any deployment considerations?

New client version bump.

## Does this work require review from our design team?

No
