### PR TITLE
enable clickhouse errors for all projects

### DIFF
--- a/backend/clickhouse/querybuilder.go
+++ b/backend/clickhouse/querybuilder.go
@@ -334,16 +334,18 @@ func parseErrorRules(tableName string, selectColumns string, isAnd bool, rules [
 		sb.Where(sb.Between("Timestamp", start, end))
 	}
 
-	conditions := []string{}
-	for _, rule := range outerRules {
-		str, err := parseColumnRule(nil, rule, projectId, sb)
-		if err != nil {
-			return nil, err
+	if len(outerRules) > 0 {
+		conditions := []string{}
+		for _, rule := range outerRules {
+			str, err := parseColumnRule(nil, rule, projectId, sb)
+			if err != nil {
+				return nil, err
+			}
+			conditions = append(conditions, str)
 		}
-		conditions = append(conditions, str)
-	}
 
-	sb.Where(joinFn(conditions...))
+		sb.Where(joinFn(conditions...))
+	}
 
 	if len(innerRules) > 0 {
 		sbInner := sqlbuilder.NewSelectBuilder()

--- a/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
@@ -8,7 +8,6 @@ import { roundFeedDate, serializeAbsoluteTimeRange } from '@util/time'
 import React, { useCallback } from 'react'
 import { useLocalStorage } from 'react-use'
 
-import { useAuthContext } from '@/authentication/AuthContext'
 import { updateQueriedTimeRange } from '@/components/QueryBuilder/QueryBuilder'
 
 import { TIME_RANGE_FIELD } from '../ErrorQueryBuilder/ErrorQueryBuilder'
@@ -17,11 +16,7 @@ const ErrorFeedHistogram = React.memo(() => {
 	const { project_id } = useParams<{ project_id: string }>()
 	const { searchQuery, backendSearchQuery, setSearchQuery } =
 		useErrorSearchContext()
-	const { isHighlightAdmin } = useAuthContext()
-	const [useClickhouse] = useLocalStorage(
-		'highlight-clickhouse-errors',
-		isHighlightAdmin,
-	)
+	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 	const { loading, data } = useGetErrorsHistogramQuery({
 		variables: {
 			query: backendSearchQuery?.childSearchQuery as string,

--- a/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
@@ -6,7 +6,6 @@ import { useErrorSearchContext } from '@pages/Errors/ErrorSearchContext/ErrorSea
 import { useParams } from '@util/react-router/useParams'
 import { roundFeedDate, serializeAbsoluteTimeRange } from '@util/time'
 import React, { useCallback } from 'react'
-import { useLocalStorage } from 'react-use'
 
 import { updateQueriedTimeRange } from '@/components/QueryBuilder/QueryBuilder'
 
@@ -16,13 +15,10 @@ const ErrorFeedHistogram = React.memo(() => {
 	const { project_id } = useParams<{ project_id: string }>()
 	const { searchQuery, backendSearchQuery, setSearchQuery } =
 		useErrorSearchContext()
-	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 	const { loading, data } = useGetErrorsHistogramQuery({
 		variables: {
 			query: backendSearchQuery?.childSearchQuery as string,
-			clickhouse_query: useClickhouse
-				? JSON.parse(searchQuery)
-				: undefined,
+			clickhouse_query: JSON.parse(searchQuery),
 			project_id: project_id!,
 			histogram_options: {
 				bucket_size:

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
@@ -12,8 +12,6 @@ import { Progress } from 'antd'
 import React, { useEffect, useState } from 'react'
 import { useLocalStorage } from 'react-use'
 
-import { useAuthContext } from '@/authentication/AuthContext'
-
 type Props = {
 	errorGroup: GetErrorGroupQuery['error_group']
 }
@@ -28,11 +26,7 @@ const ErrorDistributions = ({ errorGroup }: Props) => {
 	const [operatingSystems, setOperatingSystems] = useState<
 		ErrorGroupTagAggregation | undefined
 	>()
-	const { isHighlightAdmin } = useAuthContext()
-	const [useClickhouse] = useLocalStorage(
-		'highlight-clickhouse-errors',
-		isHighlightAdmin,
-	)
+	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 	const { loading, data } = useGetErrorGroupTagsQuery({
 		variables: {
 			error_group_secure_id: `${errorGroup?.secure_id}`,

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorDistributions.tsx
@@ -10,7 +10,6 @@ import { Badge, Box, Stack, Text } from '@highlight-run/ui'
 import { colors } from '@highlight-run/ui/src/css/colors'
 import { Progress } from 'antd'
 import React, { useEffect, useState } from 'react'
-import { useLocalStorage } from 'react-use'
 
 type Props = {
 	errorGroup: GetErrorGroupQuery['error_group']
@@ -26,11 +25,10 @@ const ErrorDistributions = ({ errorGroup }: Props) => {
 	const [operatingSystems, setOperatingSystems] = useState<
 		ErrorGroupTagAggregation | undefined
 	>()
-	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 	const { loading, data } = useGetErrorGroupTagsQuery({
 		variables: {
 			error_group_secure_id: `${errorGroup?.secure_id}`,
-			use_clickhouse: useClickhouse,
+			use_clickhouse: true,
 		},
 		skip: !errorGroup?.secure_id,
 	})

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorMetrics.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorMetrics.tsx
@@ -8,7 +8,6 @@ import useDataTimeRange from '@hooks/useDataTimeRange'
 import { ErrorDistributions } from '@pages/ErrorsV2/ErrorMetrics/ErrorDistributions'
 import moment from 'moment'
 import React, { useEffect, useState } from 'react'
-import { useLocalStorage } from 'react-use'
 
 import styles from './ErrorMetrics.module.css'
 
@@ -49,7 +48,6 @@ const ErrorMetrics: React.FC<Props> = ({ errorGroup }) => {
 		start: string
 		end: string
 	}>({ start: '', end: '' })
-	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 
 	const { data: frequencies } = useGetErrorGroupFrequenciesQuery({
 		variables: {
@@ -65,7 +63,7 @@ const ErrorMetrics: React.FC<Props> = ({ errorGroup }) => {
 				),
 			} as ErrorGroupFrequenciesParamsInput,
 			metric: 'count',
-			use_clickhouse: useClickhouse,
+			use_clickhouse: true,
 		},
 		skip: !errorGroup?.secure_id,
 	})

--- a/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorMetrics.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorMetrics/ErrorMetrics.tsx
@@ -10,8 +10,6 @@ import moment from 'moment'
 import React, { useEffect, useState } from 'react'
 import { useLocalStorage } from 'react-use'
 
-import { useAuthContext } from '@/authentication/AuthContext'
-
 import styles from './ErrorMetrics.module.css'
 
 type Props = {
@@ -51,11 +49,7 @@ const ErrorMetrics: React.FC<Props> = ({ errorGroup }) => {
 		start: string
 		end: string
 	}>({ start: '', end: '' })
-	const { isHighlightAdmin } = useAuthContext()
-	const [useClickhouse] = useLocalStorage(
-		'highlight-clickhouse-errors',
-		isHighlightAdmin,
-	)
+	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 
 	const { data: frequencies } = useGetErrorGroupFrequenciesQuery({
 		variables: {

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -410,11 +410,8 @@ function useErrorGroup() {
 		referrer: StringParam,
 	})
 	const [markErrorGroupAsViewed] = useMarkErrorGroupAsViewedMutation()
-	const { isLoggedIn, isHighlightAdmin } = useAuthContext()
-	const [useClickhouse] = useLocalStorage(
-		'highlight-clickhouse-errors',
-		isHighlightAdmin,
-	)
+	const { isLoggedIn } = useAuthContext()
+	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 	const {
 		data,
 		loading,

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -46,7 +46,6 @@ import React, { useCallback, useEffect, useMemo } from 'react'
 import { Helmet } from 'react-helmet'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { useLocalStorage } from 'react-use'
 import { apiObject } from 'rudder-sdk-js'
 import { StringParam, useQueryParams } from 'use-query-params'
 
@@ -411,7 +410,6 @@ function useErrorGroup() {
 	})
 	const [markErrorGroupAsViewed] = useMarkErrorGroupAsViewedMutation()
 	const { isLoggedIn } = useAuthContext()
-	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 	const {
 		data,
 		loading,
@@ -419,7 +417,7 @@ function useErrorGroup() {
 	} = useGetErrorGroupQuery({
 		variables: {
 			secure_id: error_secure_id!,
-			use_clickhouse: useClickhouse,
+			use_clickhouse: true,
 		},
 		skip: !error_secure_id,
 		onCompleted: () => {

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -29,7 +29,6 @@ import { usePollQuery } from '@util/search'
 import clsx from 'clsx'
 import moment from 'moment/moment'
 import React, { useCallback, useEffect, useState } from 'react'
-import { useLocalStorage } from 'react-use'
 
 import { OverageCard } from '@/pages/Sessions/SessionsFeedV3/OverageCard/OverageCard'
 import { styledVerticalScrollbar } from '@/style/common.css'
@@ -51,14 +50,10 @@ const SearchPanel = () => {
 	} = useErrorSearchContext()
 	const { project_id: projectId } = useParams<{ project_id: string }>()
 
-	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
-
 	const { data: fetchedData, loading } = useGetErrorGroupsOpenSearchQuery({
 		variables: {
 			query: backendSearchQuery?.searchQuery || '',
-			clickhouse_query: useClickhouse
-				? JSON.parse(searchQuery)
-				: undefined,
+			clickhouse_query: JSON.parse(searchQuery),
 			count: PAGE_SIZE,
 			page: page && page > 0 ? page : 1,
 			project_id: projectId!,
@@ -158,14 +153,9 @@ const SearchPanel = () => {
 				count: PAGE_SIZE,
 				page: 1,
 				project_id: projectId!,
-				clickhouse_query: useClickhouse ? clickhouseQuery : undefined,
+				clickhouse_query: clickhouseQuery,
 			}
-		}, [
-			backendSearchQuery?.searchQuery,
-			projectId,
-			searchQuery,
-			useClickhouse,
-		]),
+		}, [backendSearchQuery?.searchQuery, projectId, searchQuery]),
 		moreDataQuery,
 		getResultCount: useCallback(
 			(result) => result?.data?.error_groups_opensearch.totalCount,

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -31,7 +31,6 @@ import moment from 'moment/moment'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useLocalStorage } from 'react-use'
 
-import { useAuthContext } from '@/authentication/AuthContext'
 import { OverageCard } from '@/pages/Sessions/SessionsFeedV3/OverageCard/OverageCard'
 import { styledVerticalScrollbar } from '@/style/common.css'
 
@@ -52,11 +51,7 @@ const SearchPanel = () => {
 	} = useErrorSearchContext()
 	const { project_id: projectId } = useParams<{ project_id: string }>()
 
-	const { isHighlightAdmin } = useAuthContext()
-	const [useClickhouse] = useLocalStorage(
-		'highlight-clickhouse-errors',
-		isHighlightAdmin,
-	)
+	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 
 	const { data: fetchedData, loading } = useGetErrorGroupsOpenSearchQuery({
 		variables: {

--- a/frontend/src/pages/Player/RightPlayerPanel/components/ErrorDetails/ErrorDetails.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/ErrorDetails/ErrorDetails.tsx
@@ -55,7 +55,7 @@ const ErrorDetails = React.memo(({ error }: Props) => {
 		sessionMetadata: { startTime },
 	} = useReplayerContext()
 	const { setActiveError } = usePlayerUIContext()
-	const { isLoggedIn, isHighlightAdmin } = useAuthContext()
+	const { isLoggedIn } = useAuthContext()
 
 	const eventIdx = errors.findIndex((e) => e.id === error.id)
 	const [prev, next] = [eventIdx - 1, eventIdx + 1]
@@ -64,10 +64,7 @@ const ErrorDetails = React.memo(({ error }: Props) => {
 	const canMoveForward = !!errors[next]
 
 	const secureId = error.error_group_secure_id
-	const [useClickhouse] = useLocalStorage(
-		'highlight-clickhouse-errors',
-		isHighlightAdmin,
-	)
+	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 	const {
 		data,
 		loading,

--- a/frontend/src/pages/Player/RightPlayerPanel/components/ErrorDetails/ErrorDetails.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/ErrorDetails/ErrorDetails.tsx
@@ -42,7 +42,6 @@ import { message } from 'antd'
 import React, { useMemo } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 import { useNavigate } from 'react-router-dom'
-import { useLocalStorage } from 'react-use'
 
 interface Props {
 	error: ErrorObject
@@ -64,13 +63,12 @@ const ErrorDetails = React.memo(({ error }: Props) => {
 	const canMoveForward = !!errors[next]
 
 	const secureId = error.error_group_secure_id
-	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 	const {
 		data,
 		loading,
 		error: errorQueryingErrorGroup,
 	} = useGetErrorGroupQuery({
-		variables: { secure_id: secureId, use_clickhouse: useClickhouse },
+		variables: { secure_id: secureId, use_clickhouse: true },
 		skip: !secureId,
 		onCompleted: () => {
 			analytics.track('Viewed error', { is_guest: !isLoggedIn })

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceErrors.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceErrors.tsx
@@ -1,5 +1,4 @@
 import { Box, Callout, Text } from '@highlight-run/ui'
-import { useLocalStorage } from 'react-use'
 
 import LoadingBox from '@/components/LoadingBox'
 import { useGetErrorGroupsOpenSearchQuery } from '@/graph/generated/hooks'
@@ -26,7 +25,6 @@ export const NetworkResourceErrors: React.FC<{
 	const requestId = getHighlightRequestId(resource)
 	const errors = sessionErrors.filter((e) => e.request_id === requestId)
 	const errorGroupSecureIds = errors.map((e) => e.error_group_secure_id)
-	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 	const { data, loading } = useGetErrorGroupsOpenSearchQuery({
 		variables: {
 			query: `{
@@ -38,12 +36,10 @@ export const NetworkResourceErrors: React.FC<{
 					}
 				}
 			}`.replace(/\s+/g, ''),
-			clickhouse_query: useClickhouse
-				? {
-						isAnd: true,
-						rules: [['secure_id', 'is', ...errorGroupSecureIds]],
-				  }
-				: undefined,
+			clickhouse_query: {
+				isAnd: true,
+				rules: [['secure_id', 'is', ...errorGroupSecureIds]],
+			},
 			project_id: projectId,
 			count: errorGroupSecureIds.length,
 		},

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceErrors.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceErrors.tsx
@@ -1,7 +1,6 @@
 import { Box, Callout, Text } from '@highlight-run/ui'
 import { useLocalStorage } from 'react-use'
 
-import { useAuthContext } from '@/authentication/AuthContext'
 import LoadingBox from '@/components/LoadingBox'
 import { useGetErrorGroupsOpenSearchQuery } from '@/graph/generated/hooks'
 import { useProjectId } from '@/hooks/useProjectId'
@@ -27,11 +26,7 @@ export const NetworkResourceErrors: React.FC<{
 	const requestId = getHighlightRequestId(resource)
 	const errors = sessionErrors.filter((e) => e.request_id === requestId)
 	const errorGroupSecureIds = errors.map((e) => e.error_group_secure_id)
-	const { isHighlightAdmin } = useAuthContext()
-	const [useClickhouse] = useLocalStorage(
-		'highlight-clickhouse-errors',
-		isHighlightAdmin,
-	)
+	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 	const { data, loading } = useGetErrorGroupsOpenSearchQuery({
 		variables: {
 			query: `{

--- a/frontend/src/pages/Setup/IntegrationBar.tsx
+++ b/frontend/src/pages/Setup/IntegrationBar.tsx
@@ -20,7 +20,6 @@ import { useProjectId } from '@hooks/useProjectId'
 import moment from 'moment'
 import React from 'react'
 import { useLocation } from 'react-router-dom'
-import { useLocalStorage } from 'react-use'
 
 import {
 	useGetAlertsPagePayloadQuery,
@@ -77,15 +76,11 @@ export const IntegrationBar: React.FC<Props> = ({ integrationData }) => {
 		fetchPolicy: 'no-cache',
 	})
 
-	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
-
 	const { data: errorGroupData } = useGetErrorGroupsOpenSearchQuery({
 		variables: {
 			project_id: projectId,
 			query: '{"match_all": {}}',
-			clickhouse_query: useClickhouse
-				? { isAnd: true, rules: [] }
-				: undefined,
+			clickhouse_query: { isAnd: true, rules: [] },
 			count: 1,
 		},
 		skip: area !== 'backend' || !integrated,

--- a/frontend/src/pages/Setup/IntegrationBar.tsx
+++ b/frontend/src/pages/Setup/IntegrationBar.tsx
@@ -22,7 +22,6 @@ import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { useLocalStorage } from 'react-use'
 
-import { useAuthContext } from '@/authentication/AuthContext'
 import {
 	useGetAlertsPagePayloadQuery,
 	useGetErrorGroupsOpenSearchQuery,
@@ -78,11 +77,7 @@ export const IntegrationBar: React.FC<Props> = ({ integrationData }) => {
 		fetchPolicy: 'no-cache',
 	})
 
-	const { isHighlightAdmin } = useAuthContext()
-	const [useClickhouse] = useLocalStorage(
-		'highlight-clickhouse-errors',
-		isHighlightAdmin,
-	)
+	const [useClickhouse] = useLocalStorage('highlight-clickhouse-errors', true)
 
 	const { data: errorGroupData } = useGetErrorGroupsOpenSearchQuery({
 		variables: {


### PR DESCRIPTION
## Summary
- backend fix for query breaking when no `error_group` conditions applied
- remove local storage flag, enable clickhouse errors for all projects
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, can revert if there are issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
