### PR TITLE
Default Github rate limit hit cache to 1 hour

### DIFF
--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -492,7 +492,12 @@ func (r *Client) GetHubspotCompanies(ctx context.Context, companies interface{})
 }
 
 func (r *Client) SetGithubRateLimitExceeded(ctx context.Context, gitHubRepo string, expirationTime time.Time) error {
-	return r.setFlag(ctx, GithubRateLimitKey(gitHubRepo), true, time.Until(expirationTime))
+	expirationDuration := time.Until(expirationTime)
+	if expirationDuration < 0 {
+		expirationDuration = time.Hour
+	}
+
+	return r.setFlag(ctx, GithubRateLimitKey(gitHubRepo), true, expirationDuration)
 }
 
 func (r *Client) GetGithubRateLimitExceeded(ctx context.Context, gitHubRepo string) (bool, error) {

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -544,3 +544,7 @@ func (r *Client) Del(ctx context.Context, key string) error {
 	}
 	return nil
 }
+
+func (r *Client) TTL(ctx context.Context, key string) time.Duration {
+	return r.redisClient.TTL(ctx, key).Val()
+}

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -493,7 +493,7 @@ func (r *Client) GetHubspotCompanies(ctx context.Context, companies interface{})
 
 func (r *Client) SetGithubRateLimitExceeded(ctx context.Context, gitHubRepo string, expirationTime time.Time) error {
 	expirationDuration := time.Until(expirationTime)
-	if expirationDuration < 0 {
+	if expirationDuration <= 0 {
 		expirationDuration = time.Hour
 	}
 


### PR DESCRIPTION
## Summary
The `github-rate-limit-exceeded-%s` key is being set indefinitely, causing errors to never be enhanced when the rate limit is hit. Default this time to one hour

## How did you test this change?
Test code logic in sandbox

## Are there any deployment considerations?
Monitor rate limits hit

## Does this work require review from our design team?
N/A
