### PR TITLE
update setup page render logo

### DIFF
--- a/highlight.io/components/QuickstartContent/logging/hosting/render.tsx
+++ b/highlight.io/components/QuickstartContent/logging/hosting/render.tsx
@@ -8,7 +8,7 @@ export const HostingRenderLogContent: QuickStartContent = {
 		'Learn how to setup Highlight log ingestion on Render as a log stream. ' +
 		'As a prerequisite, we assume you already have an application ' +
 		'deployed on Render.',
-	logoUrl: siteUrl('/images/quickstart/render.svg'),
+	logoUrl: siteUrl('/images/quickstart/render.png'),
 	entries: [
 		{
 			title: 'Visit your Render settings and find the Log Streams tab.',


### PR DESCRIPTION
## Summary

Logo was rendering incorrectly due to a broken path.
![image](https://github.com/highlight/highlight/assets/1351531/78533766-5a23-4a0c-91fc-6b677238502e)

## How did you test this change?

Reflame preview.
<img width="626" alt="Screenshot 2023-09-18 at 3 58 02 PM" src="https://github.com/highlight/highlight/assets/1351531/9c2231b6-11d7-446b-bb37-8859c6327227">

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
