### PR TITLE
tune otel export settings

### DIFF
--- a/sdk/highlight-apollo/CHANGELOG.md
+++ b/sdk/highlight-apollo/CHANGELOG.md
@@ -23,3 +23,10 @@
 ### Minor Changes
 
 -   Ensure console serialization works with `BigInteger` and other unserializeable types.
+
+## 3.3.2
+
+### Patch Changes
+
+- Tune settings of opentelemetry SDK to reduce memory usage.
+- Enable GZIP compression of exported data.

--- a/sdk/highlight-apollo/package.json
+++ b/sdk/highlight-apollo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/apollo",
-	"version": "3.3.1",
+	"version": "3.3.2",
 	"license": "Apache-2.0",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
@@ -65,6 +66,7 @@ func StartOTLP() (*OTLP, error) {
 	} else {
 		logger.Errorf("an invalid otlp endpoint was configured %s", conf.otlpEndpoint)
 	}
+	options = append(options, otlptracehttp.WithCompression(otlptracehttp.GzipCompression))
 	client := otlptracehttp.NewClient(options...)
 	exporter, err := otlptrace.New(context.Background(), client)
 	if err != nil {
@@ -84,7 +86,11 @@ func StartOTLP() (*OTLP, error) {
 	h := &OTLP{
 		tracerProvider: sdktrace.NewTracerProvider(
 			sdktrace.WithSampler(sdktrace.AlwaysSample()),
-			sdktrace.WithBatcher(exporter),
+			sdktrace.WithBatcher(
+				exporter,
+				sdktrace.WithBatchTimeout(1000*time.Millisecond),
+				sdktrace.WithMaxExportBatchSize(128),
+				sdktrace.WithMaxQueueSize(1024)),
 			sdktrace.WithResource(resources),
 		),
 	}

--- a/sdk/highlight-java/highlight-sdk/src/main/java/io/highlight/sdk/HighlightOpenTelemetry.java
+++ b/sdk/highlight-java/highlight-sdk/src/main/java/io/highlight/sdk/HighlightOpenTelemetry.java
@@ -1,5 +1,6 @@
 package io.highlight.sdk;
 
+import java.time.Duration;
 import java.util.Arrays;
 
 import io.highlight.sdk.common.HighlightAttributes;
@@ -72,9 +73,13 @@ public class HighlightOpenTelemetry implements OpenTelemetry {
 		// Tracer
 		SpanExporter tracerExporter = OtlpHttpSpanExporter.builder()
 				.setEndpoint(HighlightRoute.buildTraceRoute(options.backendUrl()))
+				.setCompression("gzip")
 				.build();
 
 		BatchSpanProcessor tracerProcessor = BatchSpanProcessor.builder(tracerExporter)
+		        .setScheduleDelay(Duration.ofSeconds(1))
+		        .setMaxExportBatchSize(128)
+		        .setMaxQueueSize(1024)
 				.build();
 
 		this.tracerProvider = SdkTracerProvider.builder()

--- a/sdk/highlight-java/pom.xml
+++ b/sdk/highlight-java/pom.xml
@@ -37,7 +37,7 @@
 	</issueManagement>
 
 	<properties>
-		<revision>0.0.0-b0</revision>
+		<revision>0.0.0-b1</revision>
 		<project.language.name>java</project.language.name>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>

--- a/sdk/highlight-nest/CHANGELOG.md
+++ b/sdk/highlight-nest/CHANGELOG.md
@@ -29,3 +29,10 @@
 ### Minor Changes
 
 -   Ensure console serialization works with `BigInteger` and other unserializeable types.
+
+## 3.3.2
+
+### Patch Changes
+
+- Tune settings of opentelemetry SDK to reduce memory usage.
+- Enable GZIP compression of exported data.

--- a/sdk/highlight-nest/package.json
+++ b/sdk/highlight-nest/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/nest",
-	"version": "3.3.1",
+	"version": "3.3.2",
 	"description": "Client for interfacing with Highlight in nestjs",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -68,3 +68,10 @@
 ### Minor Changes
 
 -   Ensure console serialization works with `BigInteger` and other unserializeable types.
+
+## 4.3.2
+
+### Patch Changes
+
+- Tune settings of opentelemetry SDK to reduce memory usage.
+- Enable GZIP compression of exported data.

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "4.3.1",
+	"version": "4.3.2",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-node/CHANGELOG.md
+++ b/sdk/highlight-node/CHANGELOG.md
@@ -97,3 +97,10 @@
 ### Minor Changes
 
 -   Ensure console serialization works with `BigInteger` and other unserializeable types.
+
+## 3.3.2
+
+### Patch Changes
+
+- Tune settings of opentelemetry SDK to reduce memory usage.
+- Enable GZIP compression of exported data.

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "3.3.1",
+	"version": "3.3.2",
 	"license": "Apache-2.0",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-py/CHANGELOG.md
+++ b/sdk/highlight-py/CHANGELOG.md
@@ -32,3 +32,9 @@
 ### Fix
 
 ### Tests
+
+## v0.6.1 (2023-09-18)
+
+### Fix
+
+- Update queue export settings to reduce possibility of OOM due to large number of traces / logs.

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -96,7 +96,8 @@ class H(object):
                     f"{self._otlp_endpoint}/v1/traces", compression=Compression.Gzip
                 ),
                 schedule_delay_millis=1000,
-                export_timeout_millis=5000,
+                max_export_batch_size=128,
+                max_queue_size=1024,
             )
         )
         trace.set_tracer_provider(self._trace_provider)
@@ -111,7 +112,8 @@ class H(object):
                     f"{self._otlp_endpoint}/v1/logs", compression=Compression.Gzip
                 ),
                 schedule_delay_millis=1000,
-                export_timeout_millis=5000,
+                max_export_batch_size=128,
+                max_queue_size=1024,
             )
         )
         _logs.set_logger_provider(self._log_provider)

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.6.0"
+version = "0.6.1"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -29,3 +29,10 @@
 ### Minor Changes
 
 -   Ensure console serialization works with `BigInteger` and other unserializeable types.
+
+## 0.4.2
+
+### Patch Changes
+
+- Tune settings of opentelemetry SDK to reduce memory usage.
+- Enable GZIP compression of exported data.

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@3.5.0",
 	"author": "",

--- a/sdk/highlight-ruby/highlight/CHANGELOG.md
+++ b/sdk/highlight-ruby/highlight/CHANGELOG.md
@@ -1,3 +1,11 @@
 ## 0.1.2
 
 - Add ability to set `service_name` and `service_version`
+
+## 0.1.4
+
+
+## 3.3.2
+
+- Tune settings of opentelemetry SDK to reduce memory usage.
+- Enable GZIP compression of exported data.

--- a/sdk/highlight-ruby/highlight/CHANGELOG.md
+++ b/sdk/highlight-ruby/highlight/CHANGELOG.md
@@ -4,8 +4,5 @@
 
 ## 0.1.4
 
-
-## 3.3.2
-
 - Tune settings of opentelemetry SDK to reduce memory usage.
 - Enable GZIP compression of exported data.

--- a/sdk/highlight-ruby/highlight/Gemfile.lock
+++ b/sdk/highlight-ruby/highlight/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    highlight_io (0.1.3)
+    highlight_io (0.1.4)
       grpc (~> 1.52)
       opentelemetry-exporter-otlp (~> 0.24.0)
       opentelemetry-instrumentation-all (~> 0.32.0)
@@ -12,7 +12,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    google-protobuf (3.24.1)
+    google-protobuf (3.24.1-arm64-darwin)
     googleapis-common-protos-types (1.8.0)
       google-protobuf (~> 3.18)
     grpc (1.57.0)
@@ -242,4 +242,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/sdk/highlight-ruby/highlight/lib/highlight.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight.rb
@@ -32,8 +32,8 @@ module Highlight
         c.add_span_processor(OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
                                OpenTelemetry::Exporter::OTLP::Exporter.new(
                                  endpoint: "#{@otlp_endpoint}/v1/traces", compression: 'gzip'
-                               )
-                             ), schedule_delay: 1000, max_export_batch_size: 128, max_queue_size: 1024)
+                               ), schedule_delay: 1000, max_export_batch_size: 128, max_queue_size: 1024
+                             ))
         yield c if block_given?
       end
 

--- a/sdk/highlight-ruby/highlight/lib/highlight.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight.rb
@@ -30,8 +30,10 @@ module Highlight
 
       OpenTelemetry::SDK.configure do |c|
         c.add_span_processor(OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
-                               OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: "#{@otlp_endpoint}/v1/traces")
-                             ))
+                               OpenTelemetry::Exporter::OTLP::Exporter.new(
+                                 endpoint: "#{@otlp_endpoint}/v1/traces", compression: 'gzip'
+                               )
+                             ), schedule_delay: 1000, max_export_batch_size: 128, max_queue_size: 1024)
         yield c if block_given?
       end
 

--- a/sdk/highlight-ruby/highlight/lib/highlight/version.rb
+++ b/sdk/highlight-ruby/highlight/lib/highlight/version.rb
@@ -1,3 +1,3 @@
 module Highlight
-  VERSION = '0.1.3'.freeze
+  VERSION = '0.1.4'.freeze
 end

--- a/sdk/pino/CHANGELOG.md
+++ b/sdk/pino/CHANGELOG.md
@@ -9,3 +9,10 @@
 ### Minor Changes
 
 -   Ensure console serialization works with `BigInteger` and other unserializeable types.
+
+## 0.1.4
+
+### Patch Changes
+
+- Tune settings of opentelemetry SDK to reduce memory usage.
+- Enable GZIP compression of exported data.

--- a/sdk/pino/package.json
+++ b/sdk/pino/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/pino",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"packageManager": "yarn@3.5.0",
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Summary

* Increase frequency of opentelemetry export 
* enable gzip compression for opentelemetry export

## How did you test this change?

Local go sdk testing
Python SDK unit testing
Ruby SDK unit testing
Java SDK unit testing

<img width="1786" alt="Screenshot 2023-09-18 at 10 46 20 PM" src="https://github.com/highlight/highlight/assets/1351531/51e97121-ef91-4925-b3e9-7a17e4fb410d">

## Are there any deployment considerations?

New package versions released

## Does this work require review from our design team?

No