### PR TITLE
fix length filter, skip cache for sessions/errors query/histogram

### DIFF
--- a/backend/clickhouse/querybuilder.go
+++ b/backend/clickhouse/querybuilder.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -228,13 +229,18 @@ func parseColumnRule(admin *model.Admin, rule Rule, projectId int, sb *sqlbuilde
 			if !found {
 				return "", fmt.Errorf("separator not found for between query %s", v)
 			}
-			start, err := strconv.ParseInt(before, 10, 64)
+			start, err := strconv.ParseFloat(before, 64)
 			if err != nil {
 				return "", err
 			}
-			end, err := strconv.ParseInt(after, 10, 64)
+			start *= 1000
+			end, err := strconv.ParseFloat(after, 64)
 			if err != nil {
 				return "", err
+			}
+			end *= 1000
+			if after == "60" {
+				end = math.Inf(1)
 			}
 			conditions = append(conditions, sb.Between(mappedName, start, end))
 		case BetweenDate:

--- a/backend/clickhouse/querybuilder.go
+++ b/backend/clickhouse/querybuilder.go
@@ -239,6 +239,7 @@ func parseColumnRule(admin *model.Admin, rule Rule, projectId int, sb *sqlbuilde
 				return "", err
 			}
 			end *= 1000
+			// If the slider is at the maximum, allow any length length greater than the min
 			if after == "60" {
 				end = math.Inf(1)
 			}

--- a/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedHistogram/ErrorFeedHistogram.tsx
@@ -36,7 +36,7 @@ const ErrorFeedHistogram = React.memo(() => {
 			},
 		},
 		skip: !backendSearchQuery?.childSearchQuery || !project_id,
-		fetchPolicy: 'cache-first',
+		fetchPolicy: 'network-only',
 	})
 
 	const histogram: {

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -72,6 +72,7 @@ const SearchPanel = () => {
 			)
 		},
 		skip: !backendSearchQuery || !projectId,
+		fetchPolicy: 'network-only',
 	})
 
 	const [moreDataQuery] = useGetErrorGroupsOpenSearchLazyQuery({

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -93,6 +93,7 @@ export const SessionsHistogram: React.FC = React.memo(() => {
 			clickhouse_query: JSON.parse(searchQuery),
 		},
 		skip: !backendSearchQuery || !project_id,
+		fetchPolicy: 'network-only',
 	})
 
 	const histogram: {
@@ -206,6 +207,7 @@ export const SessionFeedV3 = React.memo(() => {
 		},
 		onCompleted: addSessions,
 		skip: !backendSearchQuery?.searchQuery || !project_id,
+		fetchPolicy: 'network-only',
 	})
 
 	const [moreDataQuery] = useGetSessionsOpenSearchLazyQuery({


### PR DESCRIPTION
## Summary
- length filter should be multiplied by 1000, max value should be treated as infinity
- parse as float because "advanced mode" passes in float values
- fetch results and histogram using 'network-only' to skip cache
- fixes #6647 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
