### PR TITLE
record contact info for self serve app

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -564,10 +564,10 @@ type Admin struct {
 	// How/where this user was referred from to sign up to Highlight.
 	Referral *string `json:"referral"`
 	// This is the role the Admin has specified. This is their role in their organization, not within Highlight. This should not be used for authorization checks.
-	UserDefinedRole     *string `json:"user_defined_role"`
-	UserDefinedTeamSize *string `json:"user_defined_team_size"`
-	UserDefinedPersona  *string `json:"user_defined_persona"`
-	HeardAbout          *string `json:"heard_about"`
+	UserDefinedRole         *string `json:"user_defined_role"`
+	UserDefinedTeamSize     *string `json:"user_defined_team_size"`
+	UserDefinedPersona      *string `json:"user_defined_persona"`
+	HeardAbout              *string `json:"heard_about"`
 	PhoneHomeContactAllowed *bool   `json:"phone_home_contact_allowed"`
 }
 

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -568,6 +568,7 @@ type Admin struct {
 	UserDefinedTeamSize *string `json:"user_defined_team_size"`
 	UserDefinedPersona  *string `json:"user_defined_persona"`
 	HeardAbout          *string `json:"heard_about"`
+	PhoneHomeContactAllowed *bool   `json:"phone_home_contact_allowed"`
 }
 
 type EmailSignup struct {

--- a/backend/phonehome/phonehome.go
+++ b/backend/phonehome/phonehome.go
@@ -2,6 +2,7 @@ package phonehome
 
 import (
 	"context"
+	"github.com/aws/smithy-go/ptr"
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/projectpath"
 	"github.com/highlight-run/highlight/backend/util"
@@ -29,6 +30,9 @@ const ErrorViewCount = "highlight-error-view-count"
 const LogViewCount = "highlight-log-view-count"
 
 const AboutYouSpanName = "highlight-about-you"
+const AboutYouSpanAdminFirstName = "highlight-about-you-admin-first-name"
+const AboutYouSpanAdminLastName = "highlight-about-you-admin-last-name"
+const AboutYouSpanAdminEmail = "highlight-about-you-admin-email"
 const AboutYouSpanReferral = "highlight-about-you-referral"
 const AboutYouSpanRole = "highlight-about-you-role"
 const AboutYouSpanTeamSize = "highlight-about-you-team-size"
@@ -103,17 +107,14 @@ func ReportAdminAboutYouDetails(ctx context.Context, admin *model.Admin) {
 	}
 
 	tags, _ := GetDefaultAttributes()
-	if admin.UserDefinedRole != nil {
-		tags = append(tags, attribute.String(AboutYouSpanRole, *admin.UserDefinedRole))
-	}
-	if admin.UserDefinedTeamSize != nil {
-		tags = append(tags, attribute.String(AboutYouSpanTeamSize, *admin.UserDefinedTeamSize))
-	}
-	if admin.HeardAbout != nil {
-		tags = append(tags, attribute.String(AboutYouSpanHeardAbout, *admin.HeardAbout))
-	}
-	if admin.Referral != nil {
-		tags = append(tags, attribute.String(AboutYouSpanReferral, *admin.Referral))
+	tags = append(tags, attribute.String(AboutYouSpanRole, ptr.ToString(admin.UserDefinedRole)))
+	tags = append(tags, attribute.String(AboutYouSpanTeamSize, ptr.ToString(admin.UserDefinedTeamSize)))
+	tags = append(tags, attribute.String(AboutYouSpanHeardAbout, ptr.ToString(admin.HeardAbout)))
+	tags = append(tags, attribute.String(AboutYouSpanReferral, ptr.ToString(admin.Referral)))
+	if ptr.ToBool(admin.PhoneHomeContactAllowed) {
+		tags = append(tags, attribute.String(AboutYouSpanAdminFirstName, ptr.ToString(admin.FirstName)))
+		tags = append(tags, attribute.String(AboutYouSpanAdminLastName, ptr.ToString(admin.LastName)))
+		tags = append(tags, attribute.String(AboutYouSpanAdminEmail, ptr.ToString(admin.Email)))
 	}
 
 	s, _ := highlight.StartTrace(ctx, AboutYouSpanName, tags...)

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -10811,6 +10811,7 @@ input AdminAboutYouDetails {
 	user_defined_persona: String!
 	user_defined_team_size: String!
 	heard_about: String!
+	phone_home_contact_allowed: Boolean!
 	referral: String!
 	phone: String
 }
@@ -10822,6 +10823,7 @@ input AdminAndWorkspaceDetails {
 	user_defined_role: String!
 	user_defined_team_size: String!
 	heard_about: String!
+	phone_home_contact_allowed: Boolean!
 	referral: String!
 
 	# Workspace
@@ -69374,7 +69376,7 @@ func (ec *executionContext) unmarshalInputAdminAboutYouDetails(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"first_name", "last_name", "user_defined_role", "user_defined_persona", "user_defined_team_size", "heard_about", "referral", "phone"}
+	fieldsInOrder := [...]string{"first_name", "last_name", "user_defined_role", "user_defined_persona", "user_defined_team_size", "heard_about", "phone_home_contact_allowed", "referral", "phone"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -69429,6 +69431,14 @@ func (ec *executionContext) unmarshalInputAdminAboutYouDetails(ctx context.Conte
 			if err != nil {
 				return it, err
 			}
+		case "phone_home_contact_allowed":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("phone_home_contact_allowed"))
+			it.PhoneHomeContactAllowed, err = ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "referral":
 			var err error
 
@@ -69458,7 +69468,7 @@ func (ec *executionContext) unmarshalInputAdminAndWorkspaceDetails(ctx context.C
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"first_name", "last_name", "user_defined_role", "user_defined_team_size", "heard_about", "referral", "workspace_name", "allowed_auto_join_email_origins", "promo_code"}
+	fieldsInOrder := [...]string{"first_name", "last_name", "user_defined_role", "user_defined_team_size", "heard_about", "phone_home_contact_allowed", "referral", "workspace_name", "allowed_auto_join_email_origins", "promo_code"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -69502,6 +69512,14 @@ func (ec *executionContext) unmarshalInputAdminAndWorkspaceDetails(ctx context.C
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("heard_about"))
 			it.HeardAbout, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "phone_home_contact_allowed":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("phone_home_contact_allowed"))
+			it.PhoneHomeContactAllowed, err = ec.unmarshalNBoolean2bool(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -58,14 +58,15 @@ type AccountDetailsMember struct {
 }
 
 type AdminAboutYouDetails struct {
-	FirstName           string  `json:"first_name"`
-	LastName            string  `json:"last_name"`
-	UserDefinedRole     string  `json:"user_defined_role"`
-	UserDefinedPersona  string  `json:"user_defined_persona"`
-	UserDefinedTeamSize string  `json:"user_defined_team_size"`
-	HeardAbout          string  `json:"heard_about"`
-	Referral            string  `json:"referral"`
-	Phone               *string `json:"phone"`
+	FirstName               string  `json:"first_name"`
+	LastName                string  `json:"last_name"`
+	UserDefinedRole         string  `json:"user_defined_role"`
+	UserDefinedPersona      string  `json:"user_defined_persona"`
+	UserDefinedTeamSize     string  `json:"user_defined_team_size"`
+	HeardAbout              string  `json:"heard_about"`
+	PhoneHomeContactAllowed bool    `json:"phone_home_contact_allowed"`
+	Referral                string  `json:"referral"`
+	Phone                   *string `json:"phone"`
 }
 
 type AdminAndWorkspaceDetails struct {
@@ -74,6 +75,7 @@ type AdminAndWorkspaceDetails struct {
 	UserDefinedRole             string  `json:"user_defined_role"`
 	UserDefinedTeamSize         string  `json:"user_defined_team_size"`
 	HeardAbout                  string  `json:"heard_about"`
+	PhoneHomeContactAllowed     bool    `json:"phone_home_contact_allowed"`
 	Referral                    string  `json:"referral"`
 	WorkspaceName               string  `json:"workspace_name"`
 	AllowedAutoJoinEmailOrigins *string `json:"allowed_auto_join_email_origins"`

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -984,6 +984,7 @@ input AdminAboutYouDetails {
 	user_defined_persona: String!
 	user_defined_team_size: String!
 	heard_about: String!
+	phone_home_contact_allowed: Boolean!
 	referral: String!
 	phone: String
 }
@@ -995,6 +996,7 @@ input AdminAndWorkspaceDetails {
 	user_defined_role: String!
 	user_defined_team_size: String!
 	heard_about: String!
+	phone_home_contact_allowed: Boolean!
 	referral: String!
 
 	# Workspace

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -354,13 +354,14 @@ func (r *mutationResolver) UpdateAdminAndCreateWorkspace(ctx context.Context, ad
 	if err := r.Transaction(func(transactionR *mutationResolver) error {
 		// Update admin details
 		if _, err := transactionR.UpdateAdminAboutYouDetails(ctx, modelInputs.AdminAboutYouDetails{
-			FirstName:           adminAndWorkspaceDetails.FirstName,
-			LastName:            adminAndWorkspaceDetails.LastName,
-			UserDefinedRole:     adminAndWorkspaceDetails.UserDefinedRole,
-			UserDefinedPersona:  "",
-			UserDefinedTeamSize: adminAndWorkspaceDetails.UserDefinedTeamSize,
-			HeardAbout:          adminAndWorkspaceDetails.HeardAbout,
-			Referral:            adminAndWorkspaceDetails.Referral,
+			FirstName:               adminAndWorkspaceDetails.FirstName,
+			LastName:                adminAndWorkspaceDetails.LastName,
+			UserDefinedRole:         adminAndWorkspaceDetails.UserDefinedRole,
+			UserDefinedPersona:      "",
+			UserDefinedTeamSize:     adminAndWorkspaceDetails.UserDefinedTeamSize,
+			HeardAbout:              adminAndWorkspaceDetails.HeardAbout,
+			Referral:                adminAndWorkspaceDetails.Referral,
+			PhoneHomeContactAllowed: adminAndWorkspaceDetails.PhoneHomeContactAllowed,
 		}); err != nil {
 			return e.Wrap(err, "error updating admin details")
 		}
@@ -412,6 +413,7 @@ func (r *mutationResolver) UpdateAdminAboutYouDetails(ctx context.Context, admin
 	admin.UserDefinedRole = &adminDetails.UserDefinedRole
 	admin.UserDefinedTeamSize = &adminDetails.UserDefinedTeamSize
 	admin.HeardAbout = &adminDetails.HeardAbout
+	admin.PhoneHomeContactAllowed = &adminDetails.PhoneHomeContactAllowed
 	admin.Referral = &adminDetails.Referral
 	admin.UserDefinedPersona = &adminDetails.UserDefinedPersona
 	admin.Phone = pointy.String("")

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5385,6 +5385,9 @@ body {
 ._17v45he0:focus {
   border: var(--_1pyqka91q) solid 1px;
 }
+._17v45he1 {
+  border-top: none;
+}
 ._1ta0zd10 {
   width: 280px;
 }

--- a/frontend/src/__generated/ve/pages/Auth/AdminForm.css.js
+++ b/frontend/src/__generated/ve/pages/Auth/AdminForm.css.js
@@ -1,1 +1,1 @@
-var e="_17v45he0";export{e as select};
+var e="_17v45he1",a="_17v45he0";export{e as lastName,a as select};

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -87,6 +87,7 @@ export type AdminAboutYouDetails = {
 	heard_about: Scalars['String']
 	last_name: Scalars['String']
 	phone?: InputMaybe<Scalars['String']>
+	phone_home_contact_allowed: Scalars['Boolean']
 	referral: Scalars['String']
 	user_defined_persona: Scalars['String']
 	user_defined_role: Scalars['String']
@@ -98,6 +99,7 @@ export type AdminAndWorkspaceDetails = {
 	first_name: Scalars['String']
 	heard_about: Scalars['String']
 	last_name: Scalars['String']
+	phone_home_contact_allowed: Scalars['Boolean']
 	promo_code?: InputMaybe<Scalars['String']>
 	referral: Scalars['String']
 	user_defined_role: Scalars['String']

--- a/frontend/src/pages/Auth/AdminForm.css.ts
+++ b/frontend/src/pages/Auth/AdminForm.css.ts
@@ -30,3 +30,7 @@ export const select = style({
 		},
 	},
 })
+
+export const lastName = style({
+	borderTop: 'none',
+})

--- a/frontend/src/pages/Auth/AdminForm.tsx
+++ b/frontend/src/pages/Auth/AdminForm.tsx
@@ -279,7 +279,7 @@ export const AdminForm: React.FC = () => {
 							required
 						>
 							<option value="" disabled>
-								Select where you heard about us
+								Select how you heard about us
 							</option>
 							{Object.entries(HeardAbout).map(([k, v]) => (
 								<option value={k} key={k}>
@@ -309,7 +309,7 @@ export const AdminForm: React.FC = () => {
 				</AuthBody>
 				<AuthFooter>
 					<Stack gap="12">
-						{isOnPrem || true ? (
+						{isOnPrem ? (
 							<Box width="full">
 								<Callout icon={false}>
 									<Stack gap="8">

--- a/frontend/src/pages/Auth/AdminForm.tsx
+++ b/frontend/src/pages/Auth/AdminForm.tsx
@@ -14,7 +14,9 @@ import {
 	ButtonLink,
 	Callout,
 	Form,
+	IconSolidCheckCircle,
 	Stack,
+	SwitchButton,
 	Text,
 	useFormStore,
 } from '@highlight-run/ui'
@@ -23,6 +25,7 @@ import { Landing } from '@pages/Landing/Landing'
 import { INVITE_TEAM_ROUTE } from '@routers/AppRouter/AppRouter'
 import analytics from '@util/analytics'
 import { getAttributionData } from '@util/attribution'
+import { isOnPrem } from '@util/onPrem/onPremUtils'
 import { message } from 'antd'
 import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -93,10 +96,14 @@ export const AdminForm: React.FC = () => {
 			promoCode: '',
 			teamSize: '',
 			heardAbout: '',
+			phoneHomeContactAllowed: true,
 		},
 	})
 
 	const submitSucceeded = formStore.useState('submitSucceed')
+	const phoneHomeContactAllowed = formStore.useValue(
+		formStore.names.phoneHomeContactAllowed,
+	)
 	const disableForm = loading || submitSucceeded > 0
 
 	formStore.useSubmit(async (formState) => {
@@ -129,6 +136,8 @@ export const AdminForm: React.FC = () => {
 							user_defined_persona: '',
 							user_defined_team_size: formState.values.teamSize,
 							heard_about: formState.values.heardAbout,
+							phone_home_contact_allowed:
+								formState.values.phoneHomeContactAllowed,
 							referral: attributionData.referral,
 						},
 					},
@@ -148,6 +157,8 @@ export const AdminForm: React.FC = () => {
 							workspace_name: formState.values.companyName,
 							promo_code: formState.values.promoCode || undefined,
 							heard_about: formState.values.heardAbout,
+							phone_home_contact_allowed:
+								formState.values.phoneHomeContactAllowed,
 							referral: attributionData.referral,
 						},
 					},
@@ -297,14 +308,60 @@ export const AdminForm: React.FC = () => {
 					</Stack>
 				</AuthBody>
 				<AuthFooter>
-					<Button
-						trackingId="about-you-submit"
-						disabled={disableForm}
-						loading={disableForm}
-						type="submit"
-					>
-						{inWorkspace ? 'Submit' : 'Create Workspace'}
-					</Button>
+					<Stack gap="12">
+						{isOnPrem || true ? (
+							<Box width="full">
+								<Callout icon={false}>
+									<Stack gap="8">
+										<Box
+											display="flex"
+											alignItems="center"
+											gap="6"
+										>
+											<SwitchButton
+												type="button"
+												size="xxSmall"
+												iconLeft={
+													<IconSolidCheckCircle
+														size={12}
+													/>
+												}
+												checked={
+													phoneHomeContactAllowed
+												}
+												onChange={() => {
+													formStore.setValue(
+														formStore.names
+															.phoneHomeContactAllowed,
+														!phoneHomeContactAllowed,
+													)
+												}}
+											/>
+											<Text
+												size="small"
+												weight="bold"
+												color="strong"
+											>
+												Help improve highlight.io
+											</Text>
+										</Box>
+										<Text size="small" weight="medium">
+											Allow us to reach out for feedback
+											about the self-hosted version.
+										</Text>
+									</Stack>
+								</Callout>
+							</Box>
+						) : null}
+						<Button
+							trackingId="about-you-submit"
+							disabled={disableForm}
+							loading={disableForm}
+							type="submit"
+						>
+							{inWorkspace ? 'Submit' : 'Create Workspace'}
+						</Button>
+					</Stack>
 				</AuthFooter>
 			</Form>
 		</Landing>

--- a/frontend/src/pages/Auth/AdminForm.tsx
+++ b/frontend/src/pages/Auth/AdminForm.tsx
@@ -248,7 +248,7 @@ export const AdminForm: React.FC = () => {
 							className={styles.select}
 							name={formStore.names.role}
 							label="Role"
-							optional
+							required
 						>
 							<option value="" disabled>
 								Select your role
@@ -261,7 +261,7 @@ export const AdminForm: React.FC = () => {
 							className={styles.select}
 							name={formStore.names.teamSize}
 							label="Team Size"
-							optional
+							required
 						>
 							<option value="" disabled>
 								Select your team size
@@ -276,7 +276,7 @@ export const AdminForm: React.FC = () => {
 							className={styles.select}
 							name={formStore.names.heardAbout}
 							label="Where did you hear about us?"
-							optional
+							required
 						>
 							<option value="" disabled>
 								Select where you heard about us

--- a/frontend/src/pages/Auth/AdminForm.tsx
+++ b/frontend/src/pages/Auth/AdminForm.tsx
@@ -234,6 +234,7 @@ export const AdminForm: React.FC = () => {
 									placeholder="Last Name"
 									required
 									rounded="last"
+									cssClass={styles.lastName}
 								/>
 							</Stack>
 						</Stack>


### PR DESCRIPTION
## Summary

* records contact info (with ability to opt-out) for self-hosted deployments
* makes `/about_you` page fields required ( cc @jay-khatri )

## How did you test this change?

<img width="336" alt="Screenshot 2023-09-19 at 1 45 01 PM" src="https://github.com/highlight/highlight/assets/1351531/a64f1455-6342-4b8b-ad49-ac7261e743e2">

<img width="613" alt="Screenshot 2023-09-19 at 1 44 40 PM" src="https://github.com/highlight/highlight/assets/1351531/9db81f19-fa1e-4e6f-86c8-3a8543301bf3">

with checkbox unchecked

<img width="611" alt="Screenshot 2023-09-19 at 1 45 38 PM" src="https://github.com/highlight/highlight/assets/1351531/61b321e5-7781-410f-9388-e5ad29fd1c11">

data stored when checked, not stored when not checked
![Screenshot 2023-09-19 at 1 50 40 PM](https://github.com/highlight/highlight/assets/1351531/85ec30c7-b1c3-4271-bd9f-7e46d4a25f2e)

## Are there any deployment considerations?

No

## Does this work require review from our design team?

Yes
