### PR TITLE
address alerts setup flow feedback

### DIFF
--- a/frontend/src/pages/Setup/SetupRouter/AlertsSetup.tsx
+++ b/frontend/src/pages/Setup/SetupRouter/AlertsSetup.tsx
@@ -111,6 +111,15 @@ const alertOptions: AlertOption[] = [
 	},
 ]
 
+const AlertsSetupHeader: React.FC = function () {
+	return (
+		<Header
+			title="Create alerts for your app"
+			subtitle="Don’t search for interesting activity; get alerted proactively."
+		/>
+	)
+}
+
 export const AlertsSetup: React.FC = function () {
 	const { projectId } = useProjectId()
 	const [alertsSetup] = useIntegratedLocalStorage(projectId, 'alerts')
@@ -130,17 +139,10 @@ export const AlertsSetup: React.FC = function () {
 		}
 	}, [alertsSetup, hidden])
 
-	const header = (
-		<Header
-			title="Create alerts for your app"
-			subtitle="Don’t search for interesting activity; get alerted proactively."
-		/>
-	)
-
 	if (hidden) {
 		return (
 			<Box style={{ maxWidth: 560, marginTop: 80 }} margin="auto">
-				{header}
+				<AlertsSetupHeader />
 				<Callout title="You have already created alerts.">
 					<Stack gap="16">
 						<Text size="small" weight="medium" color="moderate">
@@ -174,7 +176,7 @@ export const AlertsSetup: React.FC = function () {
 	return (
 		<Box>
 			<Box style={{ maxWidth: 560 }} my="40" mx="auto">
-				{header}
+				<AlertsSetupHeader />
 				{platform ? (
 					<AlertPicker platform={platform} />
 				) : (
@@ -346,9 +348,9 @@ const AlertPicker = function ({
 	const hasDefaultErrorAlert = data?.error_alerts.find((a) => a?.default)
 	const hasDefaultLogAlert = data?.log_alerts.find((a) => a?.default)
 	const hasChanges =
-		(alertsSelected.indexOf('Session') === -1) != !hasDefaultSessionAlert ||
-		(alertsSelected.indexOf('Error') === -1) != !hasDefaultErrorAlert ||
-		(alertsSelected.indexOf('Log') === -1) != !hasDefaultLogAlert
+		alertsSelected.includes('Session') !== !!hasDefaultSessionAlert ||
+		alertsSelected.includes('Error') !== !!hasDefaultErrorAlert ||
+		alertsSelected.includes('Log') !== !!hasDefaultLogAlert
 
 	useEffect(() => {
 		onAlertsSelected([
@@ -566,10 +568,9 @@ const AlertPicker = function ({
 											)
 										}
 									}}
-									checked={
-										alertsSelected.indexOf(option.name) !==
-										-1
-									}
+									checked={alertsSelected.includes(
+										option.name,
+									)}
 								/>
 								<Text size="medium" color="strong">
 									{option.name} Alert
@@ -582,14 +583,12 @@ const AlertPicker = function ({
 									kind="secondary"
 									emphasis="medium"
 									iconLeft={
-										alertsSelected.indexOf(option.name) ===
-										-1
+										!alertsSelected.includes(option.name)
 											? notificationOption?.logoDisabled
 											: notificationOption?.logo
 									}
 									disabled={
-										alertsSelected.indexOf(option.name) ===
-										-1
+										!alertsSelected.includes(option.name)
 									}
 								>
 									{emailDestination

--- a/frontend/src/pages/Setup/SetupRouter/AlertsSetup.tsx
+++ b/frontend/src/pages/Setup/SetupRouter/AlertsSetup.tsx
@@ -16,6 +16,7 @@ import { SessionAlertType } from '@graph/schemas'
 import {
 	Badge,
 	Box,
+	Callout,
 	Form,
 	IconSolidCheck,
 	IconSolidCheveronRight,
@@ -129,20 +130,51 @@ export const AlertsSetup: React.FC = function () {
 		}
 	}, [alertsSetup, hidden])
 
+	const header = (
+		<Header
+			title="Create alerts for your app"
+			subtitle="Don’t search for interesting activity; get alerted proactively."
+		/>
+	)
+
 	if (hidden) {
-		return null
+		return (
+			<Box style={{ maxWidth: 560, marginTop: 80 }} margin="auto">
+				{header}
+				<Callout title="You have already created alerts.">
+					<Stack gap="16">
+						<Text size="small" weight="medium" color="moderate">
+							Go to the alerts page to create new alerts, or
+							configure existing ones. If you want to learn more
+							about alerts, be sure to read the docs!
+						</Text>
+						<Box display="flex" alignItems="center" gap="8">
+							<Button
+								kind="secondary"
+								size="small"
+								emphasis="high"
+								trackingId="setup-alerts-configure"
+							>
+								Go to alerts
+							</Button>
+							<Button
+								kind="secondary"
+								emphasis="low"
+								trackingId="setup-alerts-learn-more"
+							>
+								Learn more
+							</Button>
+						</Box>
+					</Stack>
+				</Callout>
+			</Box>
+		)
 	}
 
 	return (
 		<Box>
 			<Box style={{ maxWidth: 560 }} my="40" mx="auto">
-				<Header
-					title="Create alerts for your app"
-					subtitle={
-						'Don’t search for interesting activity, get alerted proactively. ' +
-						'Connect your messaging platform of choice.'
-					}
-				/>
+				{header}
 				{platform ? (
 					<AlertPicker platform={platform} />
 				) : (

--- a/frontend/src/pages/Setup/SetupRouter/AlertsSetup.tsx
+++ b/frontend/src/pages/Setup/SetupRouter/AlertsSetup.tsx
@@ -30,6 +30,7 @@ import {
 	vars,
 } from '@highlight-run/ui'
 import { useProjectId } from '@hooks/useProjectId'
+import { DEFAULT_FREQUENCY } from '@pages/Alerts/AlertConfigurationCard/AlertConfigurationConstants'
 import { getDiscordOauthUrl } from '@pages/IntegrationsPage/components/DiscordIntegration/DiscordIntegrationConfig'
 import { Header } from '@pages/Setup/Header'
 import useLocalStorage from '@rehooks/local-storage'
@@ -368,9 +369,11 @@ const AlertPicker = function ({
 						projectId,
 					})
 
+					const a = alertOptions.find((a) => a.name === alert)
 					const requestVariables = {
 						project_id: projectId,
-						count_threshold: 1,
+						count_threshold: a?.thresholdPerMinute ?? 1,
+						threshold_window: Number(DEFAULT_FREQUENCY),
 						slack_channels:
 							platform === 'slack'
 								? [
@@ -402,7 +405,6 @@ const AlertPicker = function ({
 									input: {
 										...requestVariables,
 										name: 'New Session Alert',
-										threshold_window: 1,
 										exclude_rules: [],
 										user_properties: [],
 										track_properties: [],
@@ -418,7 +420,6 @@ const AlertPicker = function ({
 								variables: {
 									...requestVariables,
 									name: 'Error Alert',
-									threshold_window: 1,
 									regex_groups: [],
 									frequency: 3600,
 								},
@@ -431,7 +432,6 @@ const AlertPicker = function ({
 									input: {
 										...requestVariables,
 										name: 'Error Log Alert',
-										threshold_window: 1,
 										below_threshold: false,
 										disabled: false,
 										query: 'level:error',
@@ -568,7 +568,13 @@ const AlertPicker = function ({
 									size="medium"
 									shape="rounded"
 									variant="gray"
-									label={`${option.thresholdPerMinute} alerts/min`}
+									label={`${
+										option.thresholdPerMinute
+									} ${option.name.toLowerCase()}${
+										option.thresholdPerMinute <= 1
+											? ''
+											: 's'
+									}/min`}
 								/>
 							</Box>
 						</Box>


### PR DESCRIPTION
## Summary

* fixes sequential toggle of alerts switches and race condition with updating UI
* shows `save` for the action, disabled when there are no changes
* updates empty state for setup alerts page if alerts exist

## How did you test this change?

[Reflame preview](https://preview.highlight.io/1/setup/alerts?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HAQT6PEW8CXZDJEZRJZ3EXMH%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%226657-add-empty-state-for-alerts-onboarding-when-people-already-created-alerts%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

## Are there any deployment considerations?

No

## Does this work require review from our design team?

Yes
