### PR TITLE
fix log alerts not firing, add welcome message

### DIFF
--- a/backend/alerts/alerts.go
+++ b/backend/alerts/alerts.go
@@ -530,7 +530,7 @@ type LogAlertEvent struct {
 
 func SendLogAlert(event LogAlertEvent) error {
 	payload := integrations.LogAlertPayload{
-		Name:           *event.LogAlert.Name,
+		Name:           event.LogAlert.Name,
 		Query:          event.LogAlert.Query,
 		Count:          event.Count,
 		StartDate:      event.StartDate,

--- a/backend/alerts/logalerts.go
+++ b/backend/alerts/logalerts.go
@@ -39,7 +39,7 @@ func BuildLogAlert(project *model.Project, workspace *model.Workspace, admin *mo
 			Type:                 pointy.String("LogAlert"),
 			ChannelsToNotify:     channelsString,
 			EmailsToNotify:       emailsString,
-			Name:                 &input.Name,
+			Name:                 input.Name,
 			LastAdminToEditID:    admin.ID,
 			Disabled:             &input.Disabled,
 			Default:              *defaultArg,

--- a/backend/alerts/sessionalerts.go
+++ b/backend/alerts/sessionalerts.go
@@ -2,6 +2,7 @@ package alerts
 
 import (
 	"encoding/json"
+
 	"github.com/highlight-run/highlight/backend/alerts/integrations/webhook"
 	"github.com/openlyinc/pointy"
 
@@ -98,7 +99,7 @@ func BuildSessionAlert(project *model.Project, workspace *model.Workspace, admin
 			Type:                 &inputType,
 			ChannelsToNotify:     channelsString,
 			EmailsToNotify:       emailsString,
-			Name:                 &input.Name,
+			Name:                 input.Name,
 			LastAdminToEditID:    admin.ID,
 			Disabled:             &input.Disabled,
 			Default:              *defaultArg,

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -25130,9 +25130,9 @@ func (ec *executionContext) _ErrorAlert_Name(ctx context.Context, field graphql.
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_ErrorAlert_Name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -34504,9 +34504,9 @@ func (ec *executionContext) _LogAlert_Name(ctx context.Context, field graphql.Co
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_LogAlert_Name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -59168,9 +59168,9 @@ func (ec *executionContext) _SessionAlert_Name(ctx context.Context, field graphq
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SessionAlert_Name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -2571,7 +2571,16 @@ func (r *mutationResolver) CreateMetricMonitor(ctx context.Context, projectID in
 	if err := r.DB.Create(newMetricMonitor).Error; err != nil {
 		return nil, e.Wrap(err, "error creating a new error alert")
 	}
-	if err := newMetricMonitor.SendWelcomeSlackMessage(ctx, &model.SendWelcomeSlackMessageForMetricMonitorInput{Workspace: workspace, Admin: admin, MonitorID: &newMetricMonitor.ID, Project: project, OperationName: "created", OperationDescription: "Monitor alerts will be sent here", IncludeEditLink: true}); err != nil {
+	if err := model.SendWelcomeSlackMessage(ctx, newMetricMonitor, &model.SendWelcomeSlackMessageInput{
+		Workspace:            workspace,
+		Admin:                admin,
+		OperationName:        "created",
+		OperationDescription: "Monitor alerts will be sent here",
+		ID:                   newMetricMonitor.ID,
+		Project:              project,
+		IncludeEditLink:      true,
+		URLSlug:              "alerts/monitors",
+	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
 
@@ -2659,7 +2668,16 @@ func (r *mutationResolver) UpdateMetricMonitor(ctx context.Context, metricMonito
 		return nil, e.Wrap(err, "error updating metric monitor")
 	}
 
-	if err := metricMonitor.SendWelcomeSlackMessage(ctx, &model.SendWelcomeSlackMessageForMetricMonitorInput{Workspace: workspace, Admin: admin, MonitorID: &metricMonitorID, Project: project, OperationName: "updated", OperationDescription: "Monitor alerts will now be sent to this channel.", IncludeEditLink: true}); err != nil {
+	if err := model.SendWelcomeSlackMessage(ctx, metricMonitor, &model.SendWelcomeSlackMessageInput{
+		Workspace:            workspace,
+		Admin:                admin,
+		OperationName:        "updated",
+		OperationDescription: "Monitor alerts will now be sent to this channel.",
+		ID:                   metricMonitorID,
+		Project:              project,
+		IncludeEditLink:      true,
+		URLSlug:              "alerts/monitors",
+	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
 	return metricMonitor, nil
@@ -2709,7 +2727,7 @@ func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, 
 			Type:                 &model.AlertType.ERROR,
 			ChannelsToNotify:     channelsString,
 			EmailsToNotify:       emailsString,
-			Name:                 &name,
+			Name:                 name,
 			LastAdminToEditID:    admin.ID,
 			Frequency:            frequency,
 			Default:              *defaultArg,
@@ -2724,7 +2742,16 @@ func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, 
 	if err := r.DB.Create(newAlert).Error; err != nil {
 		return nil, e.Wrap(err, "error creating a new error alert")
 	}
-	if err := newAlert.SendWelcomeSlackMessage(ctx, &model.SendWelcomeSlackMessageInput{Workspace: workspace, Admin: admin, AlertID: &newAlert.ID, Project: project, OperationName: "created", OperationDescription: "Alerts will now be sent to this channel.", IncludeEditLink: true}); err != nil {
+	if err := model.SendWelcomeSlackMessage(ctx, newAlert, &model.SendWelcomeSlackMessageInput{
+		Workspace:            workspace,
+		Admin:                admin,
+		OperationName:        "created",
+		OperationDescription: "Alerts will now be sent to this channel.",
+		ID:                   newAlert.ID,
+		Project:              project,
+		IncludeEditLink:      true,
+		URLSlug:              "alerts",
+	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
 
@@ -2786,7 +2813,7 @@ func (r *mutationResolver) UpdateErrorAlert(ctx context.Context, projectID int, 
 		projectAlert.ThresholdWindow = thresholdWindow
 	}
 	if name != nil {
-		projectAlert.Name = name
+		projectAlert.Name = *name
 	}
 
 	projectAlert.LastAdminToEditID = admin.ID
@@ -2811,7 +2838,16 @@ func (r *mutationResolver) UpdateErrorAlert(ctx context.Context, projectID int, 
 		return nil, e.Wrap(err, "error updating org fields")
 	}
 
-	if err := projectAlert.SendWelcomeSlackMessage(ctx, &model.SendWelcomeSlackMessageInput{Workspace: workspace, Admin: admin, AlertID: &errorAlertID, Project: project, OperationName: "updated", OperationDescription: "Alerts will now be sent to this channel.", IncludeEditLink: true}); err != nil {
+	if err := model.SendWelcomeSlackMessage(ctx, projectAlert, &model.SendWelcomeSlackMessageInput{
+		Workspace:            workspace,
+		Admin:                admin,
+		OperationName:        "updated",
+		OperationDescription: "Alerts will now be sent to this channel.",
+		ID:                   errorAlertID,
+		Project:              project,
+		IncludeEditLink:      true,
+		URLSlug:              "alerts",
+	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
 	return projectAlert, nil
@@ -2835,7 +2871,16 @@ func (r *mutationResolver) DeleteErrorAlert(ctx context.Context, projectID int, 
 		return nil, e.Wrap(err, "error trying to delete error alert")
 	}
 
-	if err := projectAlert.SendWelcomeSlackMessage(ctx, &model.SendWelcomeSlackMessageInput{Workspace: workspace, Admin: admin, AlertID: &errorAlertID, Project: project, OperationName: "deleted", OperationDescription: "Alerts will no longer be sent to this channel.", IncludeEditLink: false}); err != nil {
+	if err := model.SendWelcomeSlackMessage(ctx, projectAlert, &model.SendWelcomeSlackMessageInput{
+		Workspace:            workspace,
+		Admin:                admin,
+		OperationName:        "deleted",
+		OperationDescription: "Alerts will no longer be sent to this channel.",
+		ID:                   errorAlertID,
+		Project:              project,
+		IncludeEditLink:      false,
+		URLSlug:              "alerts",
+	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
 
@@ -2860,7 +2905,16 @@ func (r *mutationResolver) DeleteMetricMonitor(ctx context.Context, projectID in
 		return nil, e.Wrap(err, "error trying to delete metric monitor")
 	}
 
-	if err := metricMonitor.SendWelcomeSlackMessage(ctx, &model.SendWelcomeSlackMessageForMetricMonitorInput{Workspace: workspace, Admin: admin, MonitorID: &metricMonitorID, Project: project, OperationName: "deleted", OperationDescription: "Monitor alerts will no longer be sent to this channel.", IncludeEditLink: false}); err != nil {
+	if err := model.SendWelcomeSlackMessage(ctx, metricMonitor, &model.SendWelcomeSlackMessageInput{
+		Workspace:            workspace,
+		Admin:                admin,
+		OperationName:        "deleted",
+		OperationDescription: "Monitor alerts will no longer be sent to this channel.",
+		ID:                   metricMonitorID,
+		Project:              project,
+		IncludeEditLink:      false,
+		URLSlug:              "alerts/monitors",
+	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
 
@@ -2960,7 +3014,16 @@ func (r *mutationResolver) UpdateSessionAlert(ctx context.Context, id int, input
 		return nil, e.Wrap(err, "error updating session alert")
 	}
 
-	if err := sessionAlert.SendWelcomeSlackMessage(ctx, &model.SendWelcomeSlackMessageInput{Workspace: workspace, Admin: admin, AlertID: &id, Project: project, OperationName: "updated", OperationDescription: "Alerts will now be sent to this channel.", IncludeEditLink: true}); err != nil {
+	if err := model.SendWelcomeSlackMessage(ctx, sessionAlert, &model.SendWelcomeSlackMessageInput{
+		Workspace:            workspace,
+		Admin:                admin,
+		OperationName:        "updated",
+		OperationDescription: "Alerts will now be sent to this channel.",
+		ID:                   id,
+		Project:              project,
+		IncludeEditLink:      true,
+		URLSlug:              "alerts",
+	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
 	return sessionAlert, nil
@@ -2984,7 +3047,16 @@ func (r *mutationResolver) CreateSessionAlert(ctx context.Context, input modelIn
 	if err := r.DB.Create(sessionAlert).Error; err != nil {
 		return nil, e.Wrap(err, "error creating a new session feedback alert")
 	}
-	if err := sessionAlert.SendWelcomeSlackMessage(ctx, &model.SendWelcomeSlackMessageInput{Workspace: workspace, Admin: admin, AlertID: &sessionAlert.ID, Project: project, OperationName: "created", OperationDescription: "Alerts will now be sent to this channel.", IncludeEditLink: true}); err != nil {
+	if err := model.SendWelcomeSlackMessage(ctx, sessionAlert, &model.SendWelcomeSlackMessageInput{
+		Workspace:            workspace,
+		Admin:                admin,
+		OperationName:        "created",
+		OperationDescription: "Alerts will now be sent to this channel.",
+		ID:                   sessionAlert.ID,
+		Project:              project,
+		IncludeEditLink:      true,
+		URLSlug:              "alerts",
+	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
 
@@ -3009,7 +3081,16 @@ func (r *mutationResolver) DeleteSessionAlert(ctx context.Context, projectID int
 		return nil, e.Wrap(err, "error trying to delete session alert")
 	}
 
-	if err := projectAlert.SendWelcomeSlackMessage(ctx, &model.SendWelcomeSlackMessageInput{Workspace: workspace, Admin: admin, AlertID: &sessionAlertID, Project: project, OperationName: "deleted", OperationDescription: "Alerts will no longer be sent to this channel.", IncludeEditLink: false}); err != nil {
+	if err := model.SendWelcomeSlackMessage(ctx, projectAlert, &model.SendWelcomeSlackMessageInput{
+		Workspace:            workspace,
+		Admin:                admin,
+		OperationName:        "deleted",
+		OperationDescription: "Alerts will no longer be sent to this channel.",
+		ID:                   sessionAlertID,
+		Project:              project,
+		IncludeEditLink:      false,
+		URLSlug:              "alerts",
+	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
 
@@ -3029,12 +3110,24 @@ func (r *mutationResolver) UpdateLogAlert(ctx context.Context, id int, input mod
 	if err != nil {
 		return nil, e.Wrap(err, "failed to build log alert")
 	}
-	alert.ID = id
 
 	if err := r.DB.Model(&model.LogAlert{Model: model.Model{ID: id}}).
 		Where("project_id = ?", input.ProjectID).
 		Save(alert).Error; err != nil {
 		return nil, e.Wrap(err, "error updating log alert")
+	}
+
+	if err := model.SendWelcomeSlackMessage(ctx, alert, &model.SendWelcomeSlackMessageInput{
+		Workspace:            workspace,
+		Admin:                admin,
+		OperationName:        "updated",
+		OperationDescription: "Log alerts will now be sent to this channel.",
+		ID:                   id,
+		Project:              project,
+		IncludeEditLink:      true,
+		URLSlug:              "alerts/logs",
+	}); err != nil {
+		log.WithContext(ctx).Error(err)
 	}
 
 	return alert, nil
@@ -3058,12 +3151,25 @@ func (r *mutationResolver) CreateLogAlert(ctx context.Context, input modelInputs
 		return nil, e.Wrap(err, "error creating a new log alert")
 	}
 
+	if err := model.SendWelcomeSlackMessage(ctx, alert, &model.SendWelcomeSlackMessageInput{
+		Workspace:            workspace,
+		Admin:                admin,
+		OperationName:        "created",
+		OperationDescription: "Log alerts will now be sent to this channel.",
+		ID:                   alert.ID,
+		Project:              project,
+		IncludeEditLink:      true,
+		URLSlug:              "alerts/logs",
+	}); err != nil {
+		log.WithContext(ctx).Error(err)
+	}
+
 	return alert, nil
 }
 
 // DeleteLogAlert is the resolver for the deleteLogAlert field.
 func (r *mutationResolver) DeleteLogAlert(ctx context.Context, projectID int, id int) (*model.LogAlert, error) {
-	_, err := r.isAdminInProject(ctx, projectID)
+	project, err := r.isAdminInProject(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
@@ -3078,6 +3184,28 @@ func (r *mutationResolver) DeleteLogAlert(ctx context.Context, projectID int, id
 
 	if err := r.DB.Delete("id = ?", id).Error; err != nil {
 		return nil, e.Wrap(err, "error trying to delete log alert")
+	}
+
+	admin, err := r.getCurrentAdmin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	workspace, err := r.GetWorkspace(project.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := model.SendWelcomeSlackMessage(ctx, alert, &model.SendWelcomeSlackMessageInput{
+		Workspace:            workspace,
+		Admin:                admin,
+		OperationName:        "deleted",
+		OperationDescription: "Log alerts will no longer be sent to this channel.",
+		ID:                   id,
+		Project:              project,
+		IncludeEditLink:      false,
+		URLSlug:              "alerts",
+	}); err != nil {
+		log.WithContext(ctx).Error(err)
 	}
 
 	return alert, nil

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3182,7 +3182,7 @@ func (r *mutationResolver) DeleteLogAlert(ctx context.Context, projectID int, id
 		return nil, e.Wrap(err, "this log alert does not exist in this project.")
 	}
 
-	if err := r.DB.Delete("id = ?", id).Error; err != nil {
+	if err := r.DB.Where("id = ?", id).Delete(&model.LogAlert{}).Error; err != nil {
 		return nil, e.Wrap(err, "error trying to delete log alert")
 	}
 


### PR DESCRIPTION
## Summary
- log alerts were not firing for certain projects because the "latest log timestamp" was in the future. there's quite a few more edge cases where latest log timestamp doesn't quite work, e.g.:
  - kafka partitions unbalanced
  - log processing backlog catching up 
  - no logs for a project for some amount of time causing the alert to be stuck alerting
- I think it would be better to remove this logic for now and just use the current time minus 1 minute since under normal circumstances our expected latency is only a few seconds, can revisit if we want to move to a "evaluate alert on log ingest" model
- refactor welcome message code and add to log alerts
- fixes #6630 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
- validated log alerts were being triggered with `make start-log-alerts-watch`
- validated slack welcome messages were sent for various alert types:
<img width="971" alt="Screen Shot 2023-09-19 at 6 23 59 PM" src="https://github.com/highlight/highlight/assets/86132398/69d8650b-6d4f-4739-a604-56714576ab6a">

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
