### PR TITLE
remove redundant error logs from python sdk

### DIFF
--- a/backend/clickhouse/log_row_test.go
+++ b/backend/clickhouse/log_row_test.go
@@ -30,7 +30,7 @@ func TestNewLogRowWithLongBody(t *testing.T) {
 		body += "a"
 	}
 	lr := NewLogRow(now, 1, WithBody(ctx, body))
-	assert.Equal(t, 2048+3, len(lr.Body))
+	assert.Equal(t, 65536+3, len(lr.Body))
 }
 
 func TestNewLogRowWithSource(t *testing.T) {

--- a/backend/otel/extract_test.go
+++ b/backend/otel/extract_test.go
@@ -341,7 +341,7 @@ func TestExtractFields_TrimLongFields(t *testing.T) {
 	})
 	fields, err := extractFields(context.TODO(), extractFieldsParams{resource: &resource})
 	assert.NoError(t, err)
-	assert.Equal(t, 2048+3, len(fields.attrs["foo"]))
+	assert.Equal(t, 65536+3, len(fields.attrs["foo"]))
 }
 
 func TestMergeMaps(t *testing.T) {

--- a/backend/util/logs.go
+++ b/backend/util/logs.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 )
 
-const LogAttributeValueLengthLimit = 2 << 10
-const LogAttributeValueWarningLengthLimit = 2 << 8
+const LogAttributeValueLengthLimit = 2 << 15
+const LogAttributeValueWarningLengthLimit = 2 << 9
 
 func FormatLogAttributes(ctx context.Context, k string, v interface{}) map[string]string {
 	if vStr, ok := v.(string); ok {

--- a/sdk/highlight-py/CHANGELOG.md
+++ b/sdk/highlight-py/CHANGELOG.md
@@ -38,3 +38,9 @@
 ### Fix
 
 - Update queue export settings to reduce possibility of OOM due to large number of traces / logs.
+
+## v0.6.2 (2023-09-20)
+
+### Fix
+
+- Remove `Highlight caught a ...` log messages as error logs are generated server side.

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -232,9 +232,6 @@ class H(object):
             if type(v) in [bool, str, bytes, int, float]:
                 attrs[f"http.headers.{k}"] = v
         span.add_event(name="exception", attributes=attrs)
-        logging.exception(
-            f"Highlight caught an http error (status_code={status_code}, detail={detail})"
-        )
 
     @staticmethod
     def record_exception(
@@ -264,7 +261,6 @@ class H(object):
         if not span:
             raise RuntimeError("H.record_exception called without a span context")
         span.record_exception(e, attributes)
-        logging.exception("Highlight caught an error", exc_info=e)
 
     @property
     def logging_handler(self) -> logging.Handler:

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.6.1"
+version = "0.6.2"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary

* Removes redundant `Highlight caught a ...` logs from our python SDK as they are failing to clean up the stacktrace correctly from our SDK. Our ingest will produce error logs for the ingested exceptions in any case.
* Increases the max log line limit to help with formatting larger messages / attributes.

## How did you test this change?

Python SDK unit tests.

## Are there any deployment considerations?

New python sdk patch version released.

## Does this work require review from our design team?

No