### PR TITLE
Fix cursor confusion in dev tools

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6206,7 +6206,6 @@ body {
   background-color: var(--_1pyqka91o);
   border-radius: 40px;
   bottom: 0;
-  cursor: grab;
   display: flex;
   height: 100%;
   justify-content: space-between;
@@ -6215,6 +6214,9 @@ body {
   z-index: 2;
 }
 ._13m092k1 {
+  cursor: grab;
+}
+._13m092k2 {
   background-color: var(--_1pyqka9i);
   border-radius: 40px;
   cursor: ew-resize;
@@ -6225,18 +6227,18 @@ body {
   padding: 0 2px;
   user-select: none;
 }
-._13m092k2 {
+._13m092k3 {
   background-color: #ffffff;
   border-radius: 3px;
   height: 50%;
   user-select: none;
   width: 3px;
 }
-._13m092k3 {
+._13m092k4 {
   height: 100%;
   width: 100%;
 }
-._13m092k4 {
+._13m092k5 {
   transition: width 0.17s linear;
 }
 ._2maxeq0 {

--- a/frontend/src/__generated/ve/pages/Player/Toolbar/TimelineIndicators/ZoomArea/ZoomArea.css.js
+++ b/frontend/src/__generated/ve/pages/Player/Toolbar/TimelineIndicators/ZoomArea/ZoomArea.css.js
@@ -1,1 +1,1 @@
-var a="_13m092k4",r="_13m092k0",e="_13m092k2",o="_13m092k3",m="_13m092k1";export{a as animated,r as zoomArea,e as zoomAreaHandle,o as zoomAreaPanSpace,m as zoomAreaSide};
+var a="_13m092k5",r="_13m092k0",e="_13m092k1",o="_13m092k3",m="_13m092k4",p="_13m092k2";export{a as animated,r as zoomArea,e as zoomAreaDraggable,o as zoomAreaHandle,m as zoomAreaPanSpace,p as zoomAreaSide};

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -126,7 +126,7 @@ const DevToolsWindowV2: React.FC<
 					<Box
 						ref={handleRef}
 						p="4"
-						style={{ cursor: 'grab', width: 'auto' }}
+						style={{ cursor: 'ns-resize', width: 'auto' }}
 					>
 						<Box
 							style={{

--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/ZoomArea/ZoomArea.css.ts
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/ZoomArea/ZoomArea.css.ts
@@ -7,13 +7,16 @@ export const zoomArea = style({
 	backgroundColor: themeVars.interactive.outline.secondary.enabled,
 	borderRadius: 40,
 	bottom: 0,
-	cursor: 'grab',
 	display: 'flex',
 	height: '100%',
 	justifyContent: 'space-between',
 	opacity: 0.8,
 	position: 'absolute',
 	zIndex: 2,
+})
+
+export const zoomAreaDraggable = style({
+	cursor: 'grab',
 })
 
 export const zoomAreaSide = style({

--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/ZoomArea/ZoomArea.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/ZoomArea/ZoomArea.tsx
@@ -70,8 +70,6 @@ const ZoomArea = ({
 			setIsPanning(true)
 			setPanX(getRelativeX(event))
 		}
-
-		containerDiv.style.cursor = 'grabbing'
 	}
 
 	useHTMLElementEvent(
@@ -96,8 +94,6 @@ const ZoomArea = ({
 		if (!containerDiv) {
 			return
 		}
-
-		containerDiv.style.cursor = 'grab'
 	}
 
 	useWindowEvent('pointerup', onPointerUp, { passive: true })
@@ -158,6 +154,7 @@ const ZoomArea = ({
 		(percentWidth * containerWidth) / 100 > 2 * ZOOM_AREA_SIDE + 1
 	const sideWidth = isWide ? ZOOM_AREA_SIDE : 0
 	const handleWidth = isWide ? 3 : 0
+	const canDrag = percentWidth < 100
 
 	return (
 		<div
@@ -166,6 +163,7 @@ const ZoomArea = ({
 				width: `${percentWidth}%`,
 			}}
 			className={clsx(style.zoomArea, {
+				[style.zoomAreaDraggable]: canDrag,
 				[style.animated]: !doesNoAction,
 			})}
 		>


### PR DESCRIPTION
## Summary

There has been some confusion around what you can click and drag in the devtools. This PR updates the cursor type to make it more clear what interactions you can perform.

1. Changes the cursor on the handle for resizing the devtools to `ns-resize` to make it clear it's something you can drag up and down.
2. Only makes the cursor of the zoom bar a `grab` when you can actually drag it (you are not zoomed out all the way).

https://www.loom.com/share/2a6c8cada1cc45a291031464ca166aac

## How did you test this change?

Local + PR preview click test.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

Will have @julian-highlight click test to confirm the UX.