### PR TITLE
Allow clicking openings on canvas to update time

### DIFF
--- a/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/TimelineIndicatorsBarGraph.tsx
+++ b/frontend/src/pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/TimelineIndicatorsBarGraph.tsx
@@ -451,10 +451,27 @@ const TimelineIndicatorsBarGraph = ({
 		timeIndicatorTopDiv.style.cursor = 'grabbing'
 	}, [])
 
+	const onCanvasDrag = useCallback((e: PointerEvent) => {
+		const canvasDiv = canvasRef.current
+		if (!canvasDiv) {
+			return
+		}
+
+		const el = e.target as HTMLDivElement
+		// Only set dragging when the user clicks on the canvas, but not one of the
+		// bars in the histogram.
+		if (el === canvasDiv || el.parentNode === canvasDiv) {
+			setIsDragging(true)
+		}
+	}, [])
+
 	useHTMLElementEvent(timeIndicatorHairRef.current, 'pointerdown', onDrag, {
 		passive: true,
 	})
 	useHTMLElementEvent(timeIndicatorTopRef.current, 'pointerdown', onDrag, {
+		passive: true,
+	})
+	useHTMLElementEvent(canvasRef.current, 'pointerdown', onCanvasDrag, {
 		passive: true,
 	})
 


### PR DESCRIPTION
## Summary

Allows you to click on empty spaces on the canvas to move to that point in the timeline.

https://www.loom.com/share/eee16dfd1bd946bda39015baac1f8881

## How did you test this change?

Local + PR preview click test.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

Got Julian's sign off on a click test on the PR preview.

<img width="400" alt="Screenshot 2023-09-22 at 9 46 30 AM" src="https://github.com/highlight/highlight/assets/308182/09564254-b788-4f0e-aa14-d5d9f29883d0">