### PR TITLE
avoid using setTimeout in H.snapshot

### DIFF
--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -390,3 +390,9 @@ Reserved for the Boeing 737
 ### Patch Changes
 
 - Auto-inline CSS on 127.0.0.1 (a common alias for localhost).
+
+## 7.5.3
+
+### Patch Changes
+
+- Ensure `H.snapshot()` does not use `setTimeout` to avoid blocking the event loop.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.5.2",
+	"version": "7.5.3",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.5.2"
+export default "7.5.3"

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -37,7 +37,7 @@ enum MetricCategory {
 }
 
 const HighlightWarning = (context: string, msg: any) => {
-	console.warn(`Highlight Warning: (${context}): `, msg)
+	console.warn(`highlight.run warning: (${context}): `, msg)
 }
 
 interface HighlightWindow extends Window {
@@ -188,7 +188,9 @@ const H: HighlightPublicInterface = {
 	},
 	snapshot: async (element: HTMLCanvasElement) => {
 		try {
-			H.onHighlightReady(() => highlight_obj.snapshot(element))
+			if (highlight_obj && highlight_obj.ready) {
+				return await highlight_obj.snapshot(element)
+			}
 		} catch (e) {
 			HighlightWarning('snapshot', e)
 		}


### PR DESCRIPTION
## Summary

Per [discord discussion](https://discord.com/channels/1026884757667188757/1126647034380824606), using `H.onHighlightReady` can cause issues with `H.snapshot`
usage which can be called frequently as we have a chance to block the event loop
by queueing too many timeouts.

Changes the `H.snapshot` behavior to do nothing if highlight is not initialized.

## How did you test this change?

`/1/canvas` recording

## Are there any deployment considerations?

New highlight.run version 7.5.3

## Does this work require review from our design team?

No
