### PR TITLE
feat: support services in Java SDK

### DIFF
--- a/docs-content/sdk/java.md
+++ b/docs-content/sdk/java.md
@@ -44,6 +44,10 @@ slug: java
           <p>The current version of your application</p>
         </aside>
         <aside className="parameter">
+          <h5>serviceName <code>string</code> <code>optional</code></h5>
+          <p>The service name of your application</p>
+        </aside>
+        <aside className="parameter">
           <h5>metric <code>boolean</code> <code>optional</code></h5>
           <p>Should certain metrics, such as the Java version and architecture being used, be logged?</p>
         </aside>

--- a/sdk/highlight-java/highlight-common/src/main/java/io/highlight/sdk/common/HighlightOptions.java
+++ b/sdk/highlight-java/highlight-common/src/main/java/io/highlight/sdk/common/HighlightOptions.java
@@ -9,7 +9,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
  * Represents the options for highlighting in a project, including project ID,
  * backend URL, environment, version, and default attributes.
  */
-public record HighlightOptions(String projectId, String backendUrl, String enviroment, String version, boolean metric,
+public record HighlightOptions(String projectId, String backendUrl, String enviroment, String version, String serviceName, boolean metric,
 		Attributes defaultAttributes) {
 
 	/**
@@ -30,6 +30,7 @@ public record HighlightOptions(String projectId, String backendUrl, String envir
 
 		private static final String DEFAULT_ENVIROMENT = "development";
 		private static final String DEFAULT_VERSION = "unknown";
+		private static final String DEFAULT_SERVICE_NAME = "unknown";
 
 		private final String projectId;
 
@@ -37,6 +38,7 @@ public record HighlightOptions(String projectId, String backendUrl, String envir
 
 		private String environment = null;
 		private String version = null;
+		private String serviceName = null;
 
 		private boolean metric = true;
 
@@ -88,6 +90,19 @@ public record HighlightOptions(String projectId, String backendUrl, String envir
 			return this;
 		}
 
+
+		/**
+		 * Sets the service name for the highlight options being constructed. <br>
+		 * If not set, the default value is <b>"unknown"</b>.
+		 *
+		 * @param serviceName the service name to set
+		 * @return this builder
+		 */
+		public Builder serviceName(String serviceName) {
+			this.serviceName = serviceName;
+			return this;
+		}
+
 		/**
 		 * Sets whether metric is enabled or not for the highlight options being
 		 * constructed. <br>
@@ -128,7 +143,11 @@ public record HighlightOptions(String projectId, String backendUrl, String envir
 				this.version = DEFAULT_VERSION;
 			}
 
-			return new HighlightOptions(this.projectId, this.backendUrl, this.environment, this.version, this.metric,
+			if (this.serviceName == null) {
+				this.serviceName = DEFAULT_SERVICE_NAME;
+			}
+
+			return new HighlightOptions(this.projectId, this.backendUrl, this.environment, this.version, this.serviceName, this.metric,
 					this.defaultAttributes.build());
 		}
 	}

--- a/sdk/highlight-java/highlight-sdk/src/main/java/io/highlight/sdk/HighlightOpenTelemetry.java
+++ b/sdk/highlight-java/highlight-sdk/src/main/java/io/highlight/sdk/HighlightOpenTelemetry.java
@@ -49,7 +49,8 @@ public class HighlightOpenTelemetry implements OpenTelemetry {
 				.put(HighlightAttributes.HIGHLIGHT_PROJECT_ID, options.projectId())
 				.put(ResourceAttributes.DEPLOYMENT_ENVIRONMENT, options.enviroment())
 				.put(ResourceAttributes.SERVICE_INSTANCE_ID, SessionId.get().toString())
-				.put(ResourceAttributes.SERVICE_VERSION, options.version());
+				.put(ResourceAttributes.SERVICE_VERSION, options.version())
+				.put(ResourceAttributes.SERVICE_NAME, options.serviceName());
 
 		if (options.metric()) {
 			attributesBuilder

--- a/sdk/highlight-java/highlight-sdk/src/test/java/io/highlight/sdk/test/HighlightOptionsTest.java
+++ b/sdk/highlight-java/highlight-sdk/src/test/java/io/highlight/sdk/test/HighlightOptionsTest.java
@@ -16,6 +16,7 @@ public class HighlightOptionsTest {
 	private static final String PROJECT_ID = "projectId";
 	private static final String PROJECT_ENVIRONMENT = "production";
 	private static final String PROJECT_VERSION = "04.27.20-b605";
+	private static final String PROJECT_NAME = "java-test";
 
 	private static final AttributeKey<String> ATTRIBUTE_JUNIT_TEST = AttributeKey.stringKey("junit.test.2");
 	private static final String ATTRIBUTE_JUNIT_TEST_VALUE = "test2";
@@ -27,6 +28,7 @@ public class HighlightOptionsTest {
 		this.options = HighlightOptions.builder(PROJECT_ID)
 				.environment(PROJECT_ENVIRONMENT)
 				.version(PROJECT_VERSION)
+				.serviceName(PROJECT_NAME)
 				.metric(false)
 				.attributes(attribute -> attribute
 						.put("junit.test.1", true)
@@ -50,6 +52,12 @@ public class HighlightOptionsTest {
 	@DisplayName("Version was correctly set")
 	void testVersion() {
 		assertEquals(PROJECT_VERSION, this.options.version());
+	}
+
+	@Test
+	@DisplayName("Service name was correctly set")
+	void testServiceName() {
+		assertEquals(PROJECT_NAME, this.options.serviceName());
 	}
 
 	@Test

--- a/sdk/highlight-java/pom.xml
+++ b/sdk/highlight-java/pom.xml
@@ -37,7 +37,7 @@
 	</issueManagement>
 
 	<properties>
-		<revision>0.0.0-b1</revision>
+		<revision>1.0.0-b1</revision>
 		<project.language.name>java</project.language.name>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
adds `service_name` to Java SDK



<img width="1608" alt="Screenshot 2023-09-22 at 2 23 00 AM" src="https://github.com/highlight/highlight/assets/62795688/6a9a162f-df1a-4241-ae2b-16c25617bb3f">


<img width="1608" alt="Screenshot 2023-09-22 at 2 23 13 AM" src="https://github.com/highlight/highlight/assets/62795688/3ae3a6d4-2672-444f-b845-5efdd67d4f49">

/closes #6449
/claim #6449