### PR TITLE
add materialized views to aggregate distinct keys + values, query these for logs

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -19,6 +19,8 @@ import (
 
 const LogsTable = "logs"
 const LogsSamplingTable = "logs_sampling"
+const LogKeysTable = "log_keys"
+const LogKeyValuesTable = "log_key_values"
 const SamplingRows = 20_000_000
 
 var logsTableConfig = tableConfig[modelInputs.ReservedLogKey]{
@@ -413,9 +415,9 @@ func (client *Client) ReadLogsHistogram(ctx context.Context, projectID int, para
 }
 
 func (client *Client) LogsKeys(ctx context.Context, projectID int, startDate time.Time, endDate time.Time) ([]*modelInputs.QueryKey, error) {
-	return KeysAggregated(ctx, client, "log_keys", projectID, startDate, endDate)
+	return KeysAggregated(ctx, client, LogKeysTable, projectID, startDate, endDate)
 }
 
 func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName string, startDate time.Time, endDate time.Time) ([]string, error) {
-	return KeyValuesAggregated(ctx, client, "log_key_values", projectID, keyName, startDate, endDate)
+	return KeyValuesAggregated(ctx, client, LogKeyValuesTable, projectID, keyName, startDate, endDate)
 }

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -413,9 +413,9 @@ func (client *Client) ReadLogsHistogram(ctx context.Context, projectID int, para
 }
 
 func (client *Client) LogsKeys(ctx context.Context, projectID int, startDate time.Time, endDate time.Time) ([]*modelInputs.QueryKey, error) {
-	return Keys(ctx, client, logsTableConfig, projectID, startDate, endDate)
+	return KeysAggregated(ctx, client, "log_keys", projectID, startDate, endDate)
 }
 
 func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName string, startDate time.Time, endDate time.Time) ([]string, error) {
-	return KeyValues(ctx, client, logsTableConfig, projectID, keyName, startDate, endDate)
+	return KeyValuesAggregated(ctx, client, "log_key_values", projectID, keyName, startDate, endDate)
 }

--- a/backend/clickhouse/migrations/000025_create_logs_sampling_mv.down copy.sql
+++ b/backend/clickhouse/migrations/000025_create_logs_sampling_mv.down copy.sql
@@ -1,0 +1,1 @@
+DROP MATERIALIZED VIEW IF EXISTS logs_sampling_mv;

--- a/backend/clickhouse/migrations/000026_create_log_attributes.down.sql
+++ b/backend/clickhouse/migrations/000026_create_log_attributes.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS default.log_attributes;
+DROP TABLE IF EXISTS log_attributes;

--- a/backend/clickhouse/migrations/000026_create_log_attributes.down.sql
+++ b/backend/clickhouse/migrations/000026_create_log_attributes.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS default.log_attributes;

--- a/backend/clickhouse/migrations/000026_create_log_attributes.up.sql
+++ b/backend/clickhouse/migrations/000026_create_log_attributes.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS default.log_attributes (
+CREATE TABLE IF NOT EXISTS log_attributes (
     `ProjectId` Int32,
     `Key` LowCardinality(String),
     `LogTimestamp` DateTime,

--- a/backend/clickhouse/migrations/000026_create_log_attributes.up.sql
+++ b/backend/clickhouse/migrations/000026_create_log_attributes.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS default.log_attributes (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) ENGINE = ReplacingMergeTree
+ORDER BY (ProjectId, Key, LogTimestamp, LogUUID, Value) TTL LogTimestamp + toIntervalDay(30);

--- a/backend/clickhouse/migrations/000027_create_log_key_values.down.sql
+++ b/backend/clickhouse/migrations/000027_create_log_key_values.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS default.log_key_values;

--- a/backend/clickhouse/migrations/000027_create_log_key_values.down.sql
+++ b/backend/clickhouse/migrations/000027_create_log_key_values.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS default.log_key_values;
+DROP TABLE IF EXISTS log_key_values;

--- a/backend/clickhouse/migrations/000027_create_log_key_values.up.sql
+++ b/backend/clickhouse/migrations/000027_create_log_key_values.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS default.log_key_values (
+CREATE TABLE IF NOT EXISTS log_key_values (
     `ProjectId` Int32,
     `Key` LowCardinality(String),
     `Day` DateTime,

--- a/backend/clickhouse/migrations/000027_create_log_key_values.up.sql
+++ b/backend/clickhouse/migrations/000027_create_log_key_values.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS default.log_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) ENGINE = SummingMergeTree
+ORDER BY (ProjectId, Key, Day, Value) TTL Day + toIntervalDay(31);

--- a/backend/clickhouse/migrations/000028_create_log_keys.down.sql
+++ b/backend/clickhouse/migrations/000028_create_log_keys.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS default.log_keys;

--- a/backend/clickhouse/migrations/000028_create_log_keys.down.sql
+++ b/backend/clickhouse/migrations/000028_create_log_keys.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS default.log_keys;
+DROP TABLE IF EXISTS log_keys;

--- a/backend/clickhouse/migrations/000028_create_log_keys.up.sql
+++ b/backend/clickhouse/migrations/000028_create_log_keys.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS default.log_keys (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Count` UInt64
+) ENGINE = SummingMergeTree
+ORDER BY (ProjectId, Key, Day) TTL Day + toIntervalDay(31);

--- a/backend/clickhouse/migrations/000028_create_log_keys.up.sql
+++ b/backend/clickhouse/migrations/000028_create_log_keys.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS default.log_keys (
+CREATE TABLE IF NOT EXISTS log_keys (
     `ProjectId` Int32,
     `Key` LowCardinality(String),
     `Day` DateTime,

--- a/backend/clickhouse/migrations/000029_create_log_keys_mv.down.sql
+++ b/backend/clickhouse/migrations/000029_create_log_keys_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS default.log_keys_mv;

--- a/backend/clickhouse/migrations/000029_create_log_keys_mv.down.sql
+++ b/backend/clickhouse/migrations/000029_create_log_keys_mv.down.sql
@@ -1,1 +1,1 @@
-DROP VIEW IF EXISTS default.log_keys_mv;
+DROP VIEW IF EXISTS log_keys_mv;

--- a/backend/clickhouse/migrations/000029_create_log_keys_mv.up.sql
+++ b/backend/clickhouse/migrations/000029_create_log_keys_mv.up.sql
@@ -1,0 +1,14 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_keys_mv TO default.log_keys (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Count` UInt64
+) AS
+SELECT ProjectId,
+    Key,
+    Day,
+    sum(Count) AS Count
+FROM default.log_key_values
+GROUP BY ProjectId,
+    Key,
+    Day;

--- a/backend/clickhouse/migrations/000029_create_log_keys_mv.up.sql
+++ b/backend/clickhouse/migrations/000029_create_log_keys_mv.up.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_keys_mv TO default.log_keys (
+CREATE MATERIALIZED VIEW IF NOT EXISTS log_keys_mv TO log_keys (
     `ProjectId` Int32,
     `Key` LowCardinality(String),
     `Day` DateTime,
@@ -8,7 +8,7 @@ SELECT ProjectId,
     Key,
     Day,
     sum(Count) AS Count
-FROM default.log_key_values
+FROM log_key_values
 GROUP BY ProjectId,
     Key,
     Day;

--- a/backend/clickhouse/migrations/000030_create_log_key_values_mv.down.sql
+++ b/backend/clickhouse/migrations/000030_create_log_key_values_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS default.log_key_values_mv;

--- a/backend/clickhouse/migrations/000030_create_log_key_values_mv.down.sql
+++ b/backend/clickhouse/migrations/000030_create_log_key_values_mv.down.sql
@@ -1,1 +1,1 @@
-DROP VIEW IF EXISTS default.log_key_values_mv;
+DROP VIEW IF EXISTS log_key_values_mv;

--- a/backend/clickhouse/migrations/000030_create_log_key_values_mv.up.sql
+++ b/backend/clickhouse/migrations/000030_create_log_key_values_mv.up.sql
@@ -1,0 +1,17 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_key_values_mv TO default.log_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId AS ProjectId,
+    Key,
+    toStartOfDay(LogTimestamp) AS Day,
+    Value,
+    count() AS Count
+FROM default.log_attributes
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;

--- a/backend/clickhouse/migrations/000030_create_log_key_values_mv.up.sql
+++ b/backend/clickhouse/migrations/000030_create_log_key_values_mv.up.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_key_values_mv TO default.log_key_values (
+CREATE MATERIALIZED VIEW IF NOT EXISTS log_key_values_mv TO log_key_values (
     `ProjectId` Int32,
     `Key` LowCardinality(String),
     `Day` DateTime,
@@ -10,7 +10,7 @@ SELECT ProjectId AS ProjectId,
     toStartOfDay(LogTimestamp) AS Day,
     Value,
     count() AS Count
-FROM default.log_attributes
+FROM log_attributes
 GROUP BY ProjectId,
     Key,
     Day,

--- a/backend/clickhouse/migrations/000031_create_log_attributes_mv.down.sql
+++ b/backend/clickhouse/migrations/000031_create_log_attributes_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS default.log_attributes_mv;

--- a/backend/clickhouse/migrations/000031_create_log_attributes_mv.down.sql
+++ b/backend/clickhouse/migrations/000031_create_log_attributes_mv.down.sql
@@ -1,1 +1,1 @@
-DROP VIEW IF EXISTS default.log_attributes_mv;
+DROP VIEW IF EXISTS log_attributes_mv;

--- a/backend/clickhouse/migrations/000031_create_log_attributes_mv.up.sql
+++ b/backend/clickhouse/migrations/000031_create_log_attributes_mv.up.sql
@@ -1,0 +1,14 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_attributes_mv TO default.log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    arrayJoin(LogAttributes).1 AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    arrayJoin(LogAttributes).2 AS Value
+FROM default.logs
+WHERE (Value != '');

--- a/backend/clickhouse/migrations/000031_create_log_attributes_mv.up.sql
+++ b/backend/clickhouse/migrations/000031_create_log_attributes_mv.up.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_attributes_mv TO default.log_attributes (
+CREATE MATERIALIZED VIEW IF NOT EXISTS log_attributes_mv TO log_attributes (
     `ProjectId` UInt32,
     `Key` String,
     `LogTimestamp` DateTime,
@@ -10,5 +10,17 @@ SELECT ProjectId AS ProjectId,
     Timestamp AS LogTimestamp,
     UUID AS LogUUID,
     arrayJoin(LogAttributes).2 AS Value
-FROM default.logs
-WHERE (Value != '');
+FROM logs
+WHERE (
+        Key NOT IN (
+            'level',
+            'secure_session_id',
+            'service_name',
+            'service_version',
+            'source',
+            'span_id',
+            'trace_id',
+            'message'
+        )
+    )
+    AND (Value != '');

--- a/backend/clickhouse/migrations/000032_create_log_secure_session_id_mv.down.sql
+++ b/backend/clickhouse/migrations/000032_create_log_secure_session_id_mv.down.sql
@@ -1,1 +1,1 @@
-DROP VIEW IF EXISTS default.log_secure_session_id_mv;
+DROP VIEW IF EXISTS log_secure_session_id_mv;

--- a/backend/clickhouse/migrations/000032_create_log_secure_session_id_mv.down.sql
+++ b/backend/clickhouse/migrations/000032_create_log_secure_session_id_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS default.log_secure_session_id_mv;

--- a/backend/clickhouse/migrations/000032_create_log_secure_session_id_mv.up.sql
+++ b/backend/clickhouse/migrations/000032_create_log_secure_session_id_mv.up.sql
@@ -1,0 +1,14 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_secure_session_id_mv TO default.log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'secure_session_id' AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    SecureSessionId AS Value
+FROM default.logs
+WHERE (SecureSessionId != '');

--- a/backend/clickhouse/migrations/000033_create_log_service_name_mv.down.sql
+++ b/backend/clickhouse/migrations/000033_create_log_service_name_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS default.log_service_name_mv;

--- a/backend/clickhouse/migrations/000033_create_log_service_name_mv.down.sql
+++ b/backend/clickhouse/migrations/000033_create_log_service_name_mv.down.sql
@@ -1,1 +1,1 @@
-DROP VIEW IF EXISTS default.log_service_name_mv;
+DROP VIEW IF EXISTS log_service_name_mv;

--- a/backend/clickhouse/migrations/000033_create_log_service_name_mv.up.sql
+++ b/backend/clickhouse/migrations/000033_create_log_service_name_mv.up.sql
@@ -1,0 +1,14 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_service_name_mv TO default.log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'service_name' AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    ServiceName AS Value
+FROM default.logs
+WHERE (ServiceName != '');

--- a/backend/clickhouse/migrations/000033_create_log_service_name_mv.up.sql
+++ b/backend/clickhouse/migrations/000033_create_log_service_name_mv.up.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_service_name_mv TO default.log_attributes (
+CREATE MATERIALIZED VIEW IF NOT EXISTS log_service_name_mv TO log_attributes (
     `ProjectId` UInt32,
     `Key` String,
     `LogTimestamp` DateTime,
@@ -10,5 +10,5 @@ SELECT ProjectId AS ProjectId,
     Timestamp AS LogTimestamp,
     UUID AS LogUUID,
     ServiceName AS Value
-FROM default.logs
+FROM logs
 WHERE (ServiceName != '');

--- a/backend/clickhouse/migrations/000034_create_log_service_version_mv.down.sql
+++ b/backend/clickhouse/migrations/000034_create_log_service_version_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS default.log_service_version_mv;

--- a/backend/clickhouse/migrations/000034_create_log_service_version_mv.down.sql
+++ b/backend/clickhouse/migrations/000034_create_log_service_version_mv.down.sql
@@ -1,1 +1,1 @@
-DROP VIEW IF EXISTS default.log_service_version_mv;
+DROP VIEW IF EXISTS log_service_version_mv;

--- a/backend/clickhouse/migrations/000034_create_log_service_version_mv.up.sql
+++ b/backend/clickhouse/migrations/000034_create_log_service_version_mv.up.sql
@@ -1,0 +1,14 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_service_version_mv TO default.log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'service_version' AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    ServiceVersion AS Value
+FROM default.logs
+WHERE (ServiceVersion != '');

--- a/backend/clickhouse/migrations/000034_create_log_service_version_mv.up.sql
+++ b/backend/clickhouse/migrations/000034_create_log_service_version_mv.up.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_service_version_mv TO default.log_attributes (
+CREATE MATERIALIZED VIEW IF NOT EXISTS log_service_version_mv TO log_attributes (
     `ProjectId` UInt32,
     `Key` String,
     `LogTimestamp` DateTime,
@@ -10,5 +10,5 @@ SELECT ProjectId AS ProjectId,
     Timestamp AS LogTimestamp,
     UUID AS LogUUID,
     ServiceVersion AS Value
-FROM default.logs
+FROM logs
 WHERE (ServiceVersion != '');

--- a/backend/clickhouse/migrations/000035_create_log_source_mv.down.sql
+++ b/backend/clickhouse/migrations/000035_create_log_source_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS default.log_source_mv;

--- a/backend/clickhouse/migrations/000035_create_log_source_mv.down.sql
+++ b/backend/clickhouse/migrations/000035_create_log_source_mv.down.sql
@@ -1,1 +1,1 @@
-DROP VIEW IF EXISTS default.log_source_mv;
+DROP VIEW IF EXISTS log_source_mv;

--- a/backend/clickhouse/migrations/000035_create_log_source_mv.up.sql
+++ b/backend/clickhouse/migrations/000035_create_log_source_mv.up.sql
@@ -1,0 +1,14 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_source_mv TO default.log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'source' AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    Source AS Value
+FROM default.logs
+WHERE (Source != '')

--- a/backend/clickhouse/migrations/000035_create_log_source_mv.up.sql
+++ b/backend/clickhouse/migrations/000035_create_log_source_mv.up.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_source_mv TO default.log_attributes (
+CREATE MATERIALIZED VIEW IF NOT EXISTS log_source_mv TO log_attributes (
     `ProjectId` UInt32,
     `Key` String,
     `LogTimestamp` DateTime,
@@ -10,5 +10,5 @@ SELECT ProjectId AS ProjectId,
     Timestamp AS LogTimestamp,
     UUID AS LogUUID,
     Source AS Value
-FROM default.logs
+FROM logs
 WHERE (Source != '')

--- a/backend/clickhouse/migrations/000036_create_log_span_id_mv.down.sql
+++ b/backend/clickhouse/migrations/000036_create_log_span_id_mv.down.sql
@@ -1,1 +1,1 @@
-DROP VIEW IF EXISTS default.log_span_id_mv;
+DROP VIEW IF EXISTS log_span_id_mv;

--- a/backend/clickhouse/migrations/000036_create_log_span_id_mv.down.sql
+++ b/backend/clickhouse/migrations/000036_create_log_span_id_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS default.log_span_id_mv;

--- a/backend/clickhouse/migrations/000036_create_log_span_id_mv.up.sql
+++ b/backend/clickhouse/migrations/000036_create_log_span_id_mv.up.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_span_id_mv TO default.log_attributes (
+CREATE MATERIALIZED VIEW IF NOT EXISTS log_span_id_mv TO log_attributes (
     `ProjectId` UInt32,
     `Key` String,
     `LogTimestamp` DateTime,
@@ -10,5 +10,5 @@ SELECT ProjectId AS ProjectId,
     Timestamp AS LogTimestamp,
     UUID AS LogUUID,
     SpanId AS Value
-FROM default.logs
+FROM logs
 WHERE (SpanId != '');

--- a/backend/clickhouse/migrations/000036_create_log_span_id_mv.up.sql
+++ b/backend/clickhouse/migrations/000036_create_log_span_id_mv.up.sql
@@ -1,0 +1,14 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_span_id_mv TO default.log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'span_id' AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    SpanId AS Value
+FROM default.logs
+WHERE (SpanId != '');

--- a/backend/clickhouse/migrations/000037_create_log_trace_id_mv.down.sql
+++ b/backend/clickhouse/migrations/000037_create_log_trace_id_mv.down.sql
@@ -1,1 +1,1 @@
-DROP VIEW IF EXISTS default.log_trace_id_mv;
+DROP VIEW IF EXISTS log_trace_id_mv;

--- a/backend/clickhouse/migrations/000037_create_log_trace_id_mv.down.sql
+++ b/backend/clickhouse/migrations/000037_create_log_trace_id_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS default.log_trace_id_mv;

--- a/backend/clickhouse/migrations/000037_create_log_trace_id_mv.up.sql
+++ b/backend/clickhouse/migrations/000037_create_log_trace_id_mv.up.sql
@@ -1,0 +1,14 @@
+CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_trace_id_mv TO default.log_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `LogTimestamp` DateTime,
+    `LogUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'trace_id' AS Key,
+    Timestamp AS LogTimestamp,
+    UUID AS LogUUID,
+    TraceId AS Value
+FROM default.logs
+WHERE (TraceId != '');

--- a/backend/clickhouse/migrations/000037_create_log_trace_id_mv.up.sql
+++ b/backend/clickhouse/migrations/000037_create_log_trace_id_mv.up.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS default.log_trace_id_mv TO default.log_attributes (
+CREATE MATERIALIZED VIEW IF NOT EXISTS log_trace_id_mv TO log_attributes (
     `ProjectId` UInt32,
     `Key` String,
     `LogTimestamp` DateTime,
@@ -10,5 +10,5 @@ SELECT ProjectId AS ProjectId,
     Timestamp AS LogTimestamp,
     UUID AS LogUUID,
     TraceId AS Value
-FROM default.logs
+FROM logs
 WHERE (TraceId != '');

--- a/backend/clickhouse/migrations/000038_create_log_body_mv.down.sql
+++ b/backend/clickhouse/migrations/000038_create_log_body_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS log_body_mv;

--- a/backend/clickhouse/migrations/000038_create_log_body_mv.up.sql
+++ b/backend/clickhouse/migrations/000038_create_log_body_mv.up.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS log_secure_session_id_mv TO log_attributes (
+CREATE MATERIALIZED VIEW IF NOT EXISTS log_body_mv TO log_attributes (
     `ProjectId` UInt32,
     `Key` String,
     `LogTimestamp` DateTime,
@@ -6,9 +6,9 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS log_secure_session_id_mv TO log_attribute
     `Value` String
 ) AS
 SELECT ProjectId AS ProjectId,
-    'secure_session_id' AS Key,
+    'message' AS Key,
     Timestamp AS LogTimestamp,
     UUID AS LogUUID,
-    SecureSessionId AS Value
+    Body AS Value
 FROM logs
-WHERE (SecureSessionId != '');
+WHERE (Body != '');

--- a/backend/clickhouse/migrations/000039_create_log_severity_text_mv.down.sql
+++ b/backend/clickhouse/migrations/000039_create_log_severity_text_mv.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS log_severity_text_mv;

--- a/backend/clickhouse/migrations/000039_create_log_severity_text_mv.up.sql
+++ b/backend/clickhouse/migrations/000039_create_log_severity_text_mv.up.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS log_secure_session_id_mv TO log_attributes (
+CREATE MATERIALIZED VIEW IF NOT EXISTS log_severity_text_mv TO log_attributes (
     `ProjectId` UInt32,
     `Key` String,
     `LogTimestamp` DateTime,
@@ -6,9 +6,9 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS log_secure_session_id_mv TO log_attribute
     `Value` String
 ) AS
 SELECT ProjectId AS ProjectId,
-    'secure_session_id' AS Key,
+    'level' AS Key,
     Timestamp AS LogTimestamp,
     UUID AS LogUUID,
-    SecureSessionId AS Value
+    SeverityText AS Value
 FROM logs
-WHERE (SecureSessionId != '');
+WHERE (SeverityText != '');

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/queryparser"
@@ -399,5 +400,98 @@ func KeyValues[T ~string](ctx context.Context, client *Client, config tableConfi
 
 	rows.Close()
 
+	return values, rows.Err()
+}
+
+func KeysAggregated(ctx context.Context, client *Client, tableName string, projectID int, startDate time.Time, endDate time.Time) ([]*modelInputs.QueryKey, error) {
+	chCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"max_rows_to_read": 1_000_000,
+	}))
+
+	sb := sqlbuilder.NewSelectBuilder()
+	sb.Select("Key, sum(Count)").
+		From(tableName).
+		Where(sb.Equal("ProjectId", projectID)).
+		Where(fmt.Sprintf("Day >= toStartOfDay(%s)", sb.Var(startDate))).
+		Where(fmt.Sprintf("Day <= toStartOfDay(%s)", sb.Var(endDate))).
+		GroupBy("1").
+		OrderBy("2 DESC").
+		Limit(500)
+
+	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+
+	span, _ := util.StartSpanFromContext(chCtx, "readKeys", util.ResourceName(tableName))
+	span.SetAttribute("Query", sql)
+
+	rows, err := client.conn.Query(chCtx, sql, args...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	keys := []*modelInputs.QueryKey{}
+	for rows.Next() {
+		var (
+			key   string
+			count uint64
+		)
+		if err := rows.Scan(&key, &count); err != nil {
+			return nil, err
+		}
+
+		keys = append(keys, &modelInputs.QueryKey{
+			Name: key,
+			Type: modelInputs.KeyTypeString, // For now, assume everything is a string
+		})
+	}
+
+	rows.Close()
+
+	span.Finish(rows.Err())
+	return keys, rows.Err()
+}
+
+func KeyValuesAggregated(ctx context.Context, client *Client, tableName string, projectID int, keyName string, startDate time.Time, endDate time.Time) ([]string, error) {
+	chCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
+		"max_rows_to_read": 1_000_000,
+	}))
+
+	sb := sqlbuilder.NewSelectBuilder()
+	sb.Select("Value, sum(Count)").
+		From(tableName).
+		Where(sb.Equal("ProjectId", projectID)).
+		Where(sb.Equal("Key", keyName)).
+		Where(fmt.Sprintf("Day >= toStartOfDay(%s)", sb.Var(startDate))).
+		Where(fmt.Sprintf("Day <= toStartOfDay(%s)", sb.Var(endDate))).
+		GroupBy("1").
+		OrderBy("2 DESC").
+		Limit(500)
+
+	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+
+	span, _ := util.StartSpanFromContext(chCtx, "readKeyValues", util.ResourceName(tableName))
+	span.SetAttribute("Query", sql)
+
+	rows, err := client.conn.Query(chCtx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	values := []string{}
+	for rows.Next() {
+		var (
+			value string
+			count uint64
+		)
+		if err := rows.Scan(&value, &count); err != nil {
+			return nil, err
+		}
+
+		values = append(values, value)
+	}
+
+	rows.Close()
+
+	span.Finish(rows.Err())
 	return values, rows.Err()
 }

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -415,7 +415,7 @@ func KeysAggregated(ctx context.Context, client *Client, tableName string, proje
 		Where(fmt.Sprintf("Day >= toStartOfDay(%s)", sb.Var(startDate))).
 		Where(fmt.Sprintf("Day <= toStartOfDay(%s)", sb.Var(endDate))).
 		GroupBy("1").
-		OrderBy("2 DESC").
+		OrderBy("2 DESC, 1").
 		Limit(500)
 
 	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
@@ -464,7 +464,7 @@ func KeyValuesAggregated(ctx context.Context, client *Client, tableName string, 
 		Where(fmt.Sprintf("Day >= toStartOfDay(%s)", sb.Var(startDate))).
 		Where(fmt.Sprintf("Day <= toStartOfDay(%s)", sb.Var(endDate))).
 		GroupBy("1").
-		OrderBy("2 DESC").
+		OrderBy("2 DESC, 1").
 		Limit(500)
 
 	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)


### PR DESCRIPTION
## Summary
- add new tables and associated materialized views for:
  - `log_attributes` - all queryable log attributes
  - `log_key_values` - distinct key value pairs and their counts
  - `log_keys` - distinct keys and their counts
- query the `log_keys` and `log_key_values` tables for logs key and value suggestions
- right now, the frontend doesn't pass the current query as a filter and is just applied on the frontend. should change this to filter down the keys / values based on the query in case there are more than 500 keys or 500 values for a key
- limits the max rows scanned to 1m to avoid an expensive operation if a key has high cardinality or there are too many keys for a project
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally, ran queries against prod
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, tables already exist in prod so expecting the migration to have no effect
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
