### PR TITLE
update internal metrics

### DIFF
--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -83,7 +83,7 @@ func (client *Client) BatchWriteTraceRows(ctx context.Context, traceRows []*Trac
 		return nil
 	}
 
-	span, _ := util.StartSpanFromContext(ctx, "kafkaBatchWorker", util.ResourceName("worker.kafka.batched.flushTraces.prepareRows"))
+	span, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName("worker.kafka.batched.flushTraces.prepareRows"))
 	span.SetAttribute("BatchSize", len(traceRows))
 	rows := lo.Map(traceRows, func(traceRow *TraceRow, _ int) *ClickhouseTraceRow {
 		traceTimes, traceNames, traceAttrs := convertEvents(traceRow)

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -12,6 +12,8 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
+const KafkaBatchWorkerOp = "KafkaBatchWorker"
+
 type MultiSpan struct {
 	ddSpan tracer.Span
 	hSpan  trace.Span

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -22,8 +22,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const KafkaBatchWorkerOp = "KafkaBatchWorker"
-
 func (k *KafkaWorker) processWorkerError(ctx context.Context, task *kafkaqueue.Message, err error, start time.Time) {
 	log.WithContext(ctx).
 		WithError(err).
@@ -101,7 +99,7 @@ type KafkaWorker struct {
 }
 
 func (k *KafkaBatchWorker) flush(ctx context.Context) error {
-	s, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush", k.Name)))
+	s, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush", k.Name)))
 	s.SetAttribute("BatchSize", len(k.messages))
 	defer s.Finish()
 
@@ -113,7 +111,7 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 
 	var lastMsg *kafkaqueue.Message
 	var oldestMsg = time.Now()
-	readSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readMessages", k.Name)))
+	readSpan, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readMessages", k.Name)))
 	for _, lastMsg = range k.messages {
 		if lastMsg.KafkaMessage.Time.Before(oldestMsg) {
 			oldestMsg = lastMsg.KafkaMessage.Time
@@ -142,7 +140,7 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 	readSpan.SetAttribute("MaxIngestDelay", time.Since(oldestMsg))
 	readSpan.Finish()
 
-	workSpan, wCtx := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.work", k.Name)))
+	workSpan, wCtx := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.work", k.Name)))
 	if len(syncSessionIds) > 0 || len(syncErrorGroupIds) > 0 || len(syncErrorObjectIds) > 0 {
 		if err := k.flushDataSync(wCtx, syncSessionIds, syncErrorGroupIds, syncErrorObjectIds); err != nil {
 			workSpan.Finish(err)
@@ -163,7 +161,7 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 	}
 	workSpan.Finish()
 
-	commitSpan, cCtx := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.commit", k.Name)))
+	commitSpan, cCtx := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.commit", k.Name)))
 	if lastMsg != nil {
 		k.KafkaQueue.Commit(cCtx, lastMsg.KafkaMessage)
 	}
@@ -182,7 +180,7 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 		}
 	}
 
-	spanTs, ctxTs := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.setTimestamps", k.Name)))
+	spanTs, ctxTs := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.setTimestamps", k.Name)))
 	for projectId, timestamp := range timestampByProject {
 		err := k.Worker.Resolver.Redis.SetLastLogTimestamp(ctxTs, int(projectId), timestamp)
 		if err != nil {
@@ -191,7 +189,7 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 	}
 	spanTs.Finish()
 
-	spanW, ctxW := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.checkBillingQuotas", k.Name)))
+	spanW, ctxW := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.checkBillingQuotas", k.Name)))
 
 	// If it's saved in Redis that a project has exceeded / not exceeded
 	// its quota, use that value. Else, add the projectId to a list of
@@ -264,7 +262,7 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 	for _, logRow := range logRows {
 		// create service record for any services found in ingested logs
 		if logRow.ServiceName != "" {
-			spanX, ctxX := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.UpsertService", k.Name)))
+			spanX, ctxX := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.UpsertService", k.Name)))
 
 			project, err := k.Worker.Resolver.Store.GetProject(ctx, int(logRow.ProjectId))
 			if err == nil && project != nil {
@@ -294,7 +292,7 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 		}
 	}
 
-	wSpan, wCtx := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.process", k.Name)))
+	wSpan, wCtx := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.process", k.Name)))
 	wSpan.SetAttribute("BatchSize", len(k.messages))
 	wSpan.SetAttribute("NumProjects", len(workspaceByProject))
 	for _, projectId := range markBackendSetupProjectIds {
@@ -305,7 +303,7 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 		}
 	}
 
-	span, ctxT := util.StartSpanFromContext(wCtx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse.logs", k.Name)))
+	span, ctxT := util.StartSpanFromContext(wCtx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse.logs", k.Name)))
 	span.SetAttribute("NumLogRows", len(logRows))
 	span.SetAttribute("NumFilteredRows", len(filteredRows))
 	err := k.Worker.PublicResolver.Clickhouse.BatchWriteLogRows(ctxT, filteredRows)
@@ -319,7 +317,7 @@ func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.
 }
 
 func (k *KafkaBatchWorker) flushTraces(ctx context.Context, traceRows []*clickhouse.TraceRow) error {
-	span, ctxT := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse", k.Name)), util.WithHighlightTracingDisabled(true))
+	span, ctxT := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse", k.Name)), util.WithHighlightTracingDisabled(true))
 	span.SetAttribute("NumTraceRows", len(traceRows))
 	span.SetAttribute("PayloadSizeBytes", binary.Size(traceRows))
 	err := k.Worker.PublicResolver.Clickhouse.BatchWriteTraceRows(ctxT, traceRows)
@@ -338,7 +336,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 		allSessionObjs := []*model.Session{}
 		for _, chunk := range sessionIdChunks {
 			sessionObjs := []*model.Session{}
-			sessionSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readSessions", k.Name)))
+			sessionSpan, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readSessions", k.Name)))
 			if err := k.Worker.PublicResolver.DB.Model(&model.Session{}).Preload("ViewedByAdmins").Where("id in ?", chunk).Find(&sessionObjs).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -346,7 +344,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 			sessionSpan.Finish()
 
 			fieldObjs := []*model.Field{}
-			fieldSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readFields", k.Name)))
+			fieldSpan, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readFields", k.Name)))
 			if err := k.Worker.PublicResolver.DB.Model(&model.Field{}).Where("id IN (SELECT field_id FROM session_fields sf WHERE sf.session_id IN ?)", chunk).Find(&fieldObjs).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -361,7 +359,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 				FieldID   int64
 			}
 			sessionFieldObjs := []*sessionField{}
-			sessionFieldSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readSessionFields", k.Name)))
+			sessionFieldSpan, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.readSessionFields", k.Name)))
 			if err := k.Worker.PublicResolver.DB.Table("session_fields").Where("session_id IN ?", chunk).Find(&sessionFieldObjs).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -380,7 +378,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 			allSessionObjs = append(allSessionObjs, sessionObjs...)
 		}
 
-		chSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse", k.Name)))
+		chSpan, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.clickhouse", k.Name)))
 		err := k.Worker.PublicResolver.Clickhouse.WriteSessions(ctx, allSessionObjs)
 		defer chSpan.Finish(err)
 		if err != nil {
@@ -394,7 +392,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 		allErrorGroups := []*model.ErrorGroup{}
 		for _, chunk := range errorGroupIdChunks {
 			errorGroups := []*model.ErrorGroup{}
-			errorGroupSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName("worker.kafka.datasync.readErrorGroups"))
+			errorGroupSpan, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName("worker.kafka.datasync.readErrorGroups"))
 			if err := k.Worker.PublicResolver.DB.Model(&model.ErrorGroup{}).Where("id in ?", chunk).Find(&errorGroups).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -404,7 +402,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 			allErrorGroups = append(allErrorGroups, errorGroups...)
 		}
 
-		chSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName("worker.kafka.datasync.writeClickhouse.errorGroups"))
+		chSpan, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName("worker.kafka.datasync.writeClickhouse.errorGroups"))
 		if err := k.Worker.PublicResolver.Clickhouse.WriteErrorGroups(ctx, allErrorGroups); err != nil {
 			log.WithContext(ctx).Error(err)
 			return err
@@ -417,7 +415,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 		allErrorObjects := []*model.ErrorObject{}
 		for _, chunk := range errorObjectIdChunks {
 			errorObjects := []*model.ErrorObject{}
-			errorObjectSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName("worker.kafka.datasync.readErrorObjects"))
+			errorObjectSpan, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName("worker.kafka.datasync.readErrorObjects"))
 			if err := k.Worker.PublicResolver.DB.Model(&model.ErrorObject{}).Where("id in ?", chunk).Find(&errorObjects).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -436,7 +434,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 		allSessions := []*model.Session{}
 		for _, chunk := range sessionIdChunks {
 			sessions := []*model.Session{}
-			sessionSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName("worker.kafka.datasync.readErrorObjectSessions"))
+			sessionSpan, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName("worker.kafka.datasync.readErrorObjectSessions"))
 			if err := k.Worker.PublicResolver.DB.Model(&model.Session{}).Where("id in ?", chunk).Find(&sessions).Error; err != nil {
 				log.WithContext(ctx).Error(err)
 				return err
@@ -446,7 +444,7 @@ func (k *KafkaBatchWorker) flushDataSync(ctx context.Context, sessionIds []int, 
 			allSessions = append(allSessions, sessions...)
 		}
 
-		chSpan, _ := util.StartSpanFromContext(ctx, KafkaBatchWorkerOp, util.ResourceName("worker.kafka.datasync.writeClickhouse.errorObjects"))
+		chSpan, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName("worker.kafka.datasync.writeClickhouse.errorObjects"))
 		if err := k.Worker.PublicResolver.Clickhouse.WriteErrorObjects(ctx, allErrorObjects, allSessions); err != nil {
 			log.WithContext(ctx).Error(err)
 			return err
@@ -467,12 +465,12 @@ func (k *KafkaBatchWorker) ProcessMessages(ctx context.Context) {
 	for {
 		func() {
 			defer util.Recover()
-			s, ctx := util.StartSpanFromContext(ctx, "KafkaWorker", util.ResourceName(fmt.Sprintf("worker.kafka.%s.process", k.Name)), util.WithHighlightTracingDisabled(k.TracingDisabled))
+			s, ctx := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.process", k.Name)), util.WithHighlightTracingDisabled(k.TracingDisabled))
 			s.SetAttribute("worker.goroutine", k.WorkerThread)
 			s.SetAttribute("BatchSize", len(k.messages))
 			defer s.Finish()
 
-			s1, _ := util.StartSpanFromContext(ctx, "KafkaWorker", util.ResourceName(fmt.Sprintf("worker.kafka.%s.receive", k.Name)))
+			s1, _ := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.receive", k.Name)))
 			task := k.KafkaQueue.Receive(ctx)
 			s1.Finish()
 			if task == nil {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -870,12 +870,14 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 		ctx, mgraph.SessionActiveMetricName, float64(accumulator.ActiveDuration),
 		attribute.Bool("Excluded", false),
 		attribute.Bool("Processed", true),
+		attribute.Int(highlight.ProjectIDAttribute, s.ProjectID),
 		attribute.String(highlight.SessionIDAttribute, s.SecureID),
 	)
 	highlight.RecordMetric(
 		ctx, mgraph.SessionProcessedMetricName, float64(s.ID),
 		attribute.Bool("Excluded", false),
 		attribute.Bool("Processed", true),
+		attribute.Int(highlight.ProjectIDAttribute, s.ProjectID),
 		attribute.String(highlight.SessionIDAttribute, s.SecureID),
 	)
 	if err := w.PublicResolver.PushMetricsImpl(ctx, s.SecureID, []*publicModel.MetricInput{

--- a/deploy/public-worker-service.json
+++ b/deploy/public-worker-service.json
@@ -226,7 +226,7 @@
 	"requiresCompatibilities": ["FARGATE"],
 	"networkMode": "awsvpc",
 	"cpu": "4096",
-	"memory": "16384",
+	"memory": "30720",
 	"ephemeralStorage": {
 		"sizeInGiB": 200
 	},

--- a/docker/otel-collector.yaml
+++ b/docker/otel-collector.yaml
@@ -10,6 +10,9 @@ receivers:
     tcplog:
         listen_address: '0.0.0.0:34302'
 exporters:
+    logging:
+        sampling_initial: 10
+        sampling_thereafter: 1000
     otlphttp:
         endpoint: 'https://host.docker.internal:8082/otel'
         compression: gzip
@@ -39,15 +42,15 @@ service:
         traces:
             receivers: [otlp]
             processors: [memory_limiter, batch]
-            exporters: [otlphttp]
+            exporters: [otlphttp, logging]
         metrics:
             receivers: [otlp]
             processors: [memory_limiter, batch]
-            exporters: [otlphttp]
+            exporters: [otlphttp, logging]
         logs:
             receivers: [otlp, fluentforward, tcplog]
             processors: [memory_limiter, batch]
-            exporters: [otlphttp]
+            exporters: [otlphttp, logging]
 extensions:
     health_check:
         endpoint: '0.0.0.0:4319'


### PR DESCRIPTION
## Summary

* update trace operation name constant for kafka batch worker operations
* report project id for internal metrics to track which project they come from
* add debug logging for local dev otel collector

## How did you test this change?

Local deploy working.

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No