### PR TITLE
Redirect to originally request page after sign up/in

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5395,7 +5395,11 @@ body {
   border: var(--_1pyqka91q) solid 1px;
 }
 ._17v45he1 {
-  border-top: none;
+  border-top: 0;
+}
+._17v45he1:focus,
+._17v45he1:hover {
+  border-top: 0 !important;
 }
 ._1ta0zd10 {
   width: 280px;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -48,6 +48,7 @@ import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6'
 
 import { PUBLIC_GRAPH_URI } from '@/constants'
 import { SIGN_IN_ROUTE } from '@/pages/Auth/AuthRouter'
+import { authRedirect } from '@/pages/Auth/utils'
 import { onlyAllowHighlightStaff } from '@/util/authorization/authorizationUtils'
 
 document.body.className = 'highlight-light-theme'
@@ -393,6 +394,7 @@ const AuthenticationRoleRouter = () => {
 					analytics.track('Sign out')
 					setUser(null)
 					setAuthRole(AuthRole.UNAUTHENTICATED)
+					authRedirect.clear()
 				},
 			}}
 		>

--- a/frontend/src/pages/Auth/AdminForm.css.ts
+++ b/frontend/src/pages/Auth/AdminForm.css.ts
@@ -32,5 +32,10 @@ export const select = style({
 })
 
 export const lastName = style({
-	borderTop: 'none',
+	borderTop: 0,
+	selectors: {
+		'&:focus, &:hover': {
+			borderTop: `0 !important`,
+		},
+	},
 })

--- a/frontend/src/pages/Auth/AuthRouter.tsx
+++ b/frontend/src/pages/Auth/AuthRouter.tsx
@@ -7,7 +7,7 @@ import { SignUp } from '@pages/Auth/SignUp'
 import { Landing } from '@pages/Landing/Landing'
 import firebase from 'firebase/compat/app'
 import React, { useState } from 'react'
-import { Navigate, Route, Routes } from 'react-router-dom'
+import { Route, Routes } from 'react-router-dom'
 
 import { SignInRedirect } from '@/pages/Auth/SignInRedirect'
 
@@ -18,7 +18,6 @@ export const SIGN_UP_ROUTE = '/sign_up'
 
 export const AuthRouter: React.FC = () => {
 	const { isAuthLoading } = useAuthContext()
-	debugger
 
 	const [resolver, setResolver] =
 		useState<firebase.auth.MultiFactorResolver>()

--- a/frontend/src/pages/Auth/AuthRouter.tsx
+++ b/frontend/src/pages/Auth/AuthRouter.tsx
@@ -9,6 +9,8 @@ import firebase from 'firebase/compat/app'
 import React, { useState } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 
+import { SignInRedirect } from '@/pages/Auth/SignInRedirect'
+
 import * as styles from './AuthRouter.css'
 
 export const SIGN_IN_ROUTE = '/sign_in'
@@ -16,6 +18,7 @@ export const SIGN_UP_ROUTE = '/sign_up'
 
 export const AuthRouter: React.FC = () => {
 	const { isAuthLoading } = useAuthContext()
+	debugger
 
 	const [resolver, setResolver] =
 		useState<firebase.auth.MultiFactorResolver>()
@@ -38,10 +41,7 @@ export const AuthRouter: React.FC = () => {
 						element={<MultiFactor resolver={resolver} />}
 					/>
 					<Route path="/reset_password" element={<ResetPassword />} />
-					<Route
-						path="/*"
-						element={<Navigate to={SIGN_IN_ROUTE} replace />}
-					/>
+					<Route path="/*" element={<SignInRedirect />} />
 				</Routes>
 			</Box>
 		</Landing>

--- a/frontend/src/pages/Auth/InviteTeam.tsx
+++ b/frontend/src/pages/Auth/InviteTeam.tsx
@@ -29,6 +29,8 @@ import { message } from 'antd'
 import React, { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { authRedirect } from '@/pages/Auth/utils'
+
 import * as authRouterStyles from './AuthRouter.css'
 import * as styles from './InviteTeam.css'
 
@@ -63,6 +65,8 @@ export const InviteTeamForm: React.FC = () => {
 		projects?.length && projects[0]
 			? `/${projects[0].id}${SETUP_ROUTE}`
 			: SETUP_ROUTE
+	const authRedirectRoute = authRedirect.get()
+	const redirectRoute = authRedirectRoute ?? setupRoute
 	const workspace = data?.workspaces && data.workspaces[0]
 	const inWorkspace = !!workspace
 
@@ -128,7 +132,8 @@ export const InviteTeamForm: React.FC = () => {
 					message.error(
 						`An error occurred inviting your team. Please try again later.`,
 					)
-					return navigate(setupRoute)
+					authRedirect.clear()
+					return navigate(redirectRoute)
 				}
 
 				if (emails.length) {
@@ -138,7 +143,8 @@ export const InviteTeamForm: React.FC = () => {
 				}
 			}
 
-			navigate(setupRoute)
+			authRedirect.clear()
+			navigate(redirectRoute)
 		} catch (e: any) {
 			if (import.meta.env.DEV) {
 				console.error(e)

--- a/frontend/src/pages/Auth/InviteTeam.tsx
+++ b/frontend/src/pages/Auth/InviteTeam.tsx
@@ -132,7 +132,6 @@ export const InviteTeamForm: React.FC = () => {
 					message.error(
 						`An error occurred inviting your team. Please try again later.`,
 					)
-					authRedirect.clear()
 					return navigate(redirectRoute)
 				}
 
@@ -143,7 +142,6 @@ export const InviteTeamForm: React.FC = () => {
 				}
 			}
 
-			authRedirect.clear()
 			navigate(redirectRoute)
 		} catch (e: any) {
 			if (import.meta.env.DEV) {

--- a/frontend/src/pages/Auth/SignIn.tsx
+++ b/frontend/src/pages/Auth/SignIn.tsx
@@ -22,6 +22,10 @@ import React, { useCallback, useEffect } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import { useAuthContext } from '@/authentication/AuthContext'
+import {
+	AppLoadingState,
+	useAppLoadingContext,
+} from '@/context/AppLoadingContext'
 import { SIGN_UP_ROUTE } from '@/pages/Auth/AuthRouter'
 import analytics from '@/util/analytics'
 
@@ -34,6 +38,7 @@ type Props = {
 export const SignIn: React.FC<Props> = ({ setResolver }) => {
 	const navigate = useNavigate()
 	const { fetchAdmin, signIn } = useAuthContext()
+	const { setLoadingState } = useAppLoadingContext()
 	const [inviteCode] = useLocalStorage('highlightInviteCode')
 	const [loading, setLoading] = React.useState(false)
 	const [error, setError] = React.useState('')
@@ -59,12 +64,13 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 	})
 
 	const [createAdmin] = useCreateAdminMutation()
-	const { data } = useGetWorkspaceForInviteLinkQuery({
-		variables: {
-			secret: inviteCode!,
-		},
-		skip: !inviteCode,
-	})
+	const { data, loading: loadingWorkspaceForInvite } =
+		useGetWorkspaceForInviteLinkQuery({
+			variables: {
+				secret: inviteCode!,
+			},
+			skip: !inviteCode,
+		})
 	const workspaceInvite = data?.workspace_for_invite_link
 
 	const handleAuth = useCallback(
@@ -114,6 +120,11 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 	}
 
 	useEffect(() => analytics.page(), [])
+	useEffect(() => {
+		if (!loadingWorkspaceForInvite) {
+			setLoadingState(AppLoadingState.LOADED)
+		}
+	}, [loadingWorkspaceForInvite, setLoadingState])
 
 	return (
 		<Form store={formStore} resetOnSubmit={false}>

--- a/frontend/src/pages/Auth/SignInRedirect.tsx
+++ b/frontend/src/pages/Auth/SignInRedirect.tsx
@@ -1,0 +1,15 @@
+import { Navigate } from 'react-router-dom'
+
+import { SIGN_IN_ROUTE } from '@/pages/Auth/AuthRouter'
+import { authRedirect } from '@/pages/Auth/utils'
+
+export const SignInRedirect: React.FC = () => {
+	if (!authRedirect.get()) {
+		// Store the original path so we can redirect back to it later.
+		authRedirect.set(
+			window.location.href.replace(window.location.origin, ''),
+		)
+	}
+
+	return <Navigate to={SIGN_IN_ROUTE} replace />
+}

--- a/frontend/src/pages/Auth/utils.ts
+++ b/frontend/src/pages/Auth/utils.ts
@@ -1,13 +1,18 @@
+import Cookies from 'js-cookie'
+import moment from 'moment'
+
 export const REDIRECT_LOCAL_STORAGE_KEY = 'highlight-auth-redirect'
 
 export const authRedirect = {
 	set: (path: string) => {
-		window.localStorage.setItem(REDIRECT_LOCAL_STORAGE_KEY, path)
+		Cookies.set(REDIRECT_LOCAL_STORAGE_KEY, path, {
+			expires: moment().add(15, 'minutes').toDate(),
+		})
 	},
 	get: () => {
-		return window.localStorage.getItem(REDIRECT_LOCAL_STORAGE_KEY)
+		return Cookies.get(REDIRECT_LOCAL_STORAGE_KEY)
 	},
 	clear: () => {
-		window.localStorage.removeItem(REDIRECT_LOCAL_STORAGE_KEY)
+		Cookies.remove(REDIRECT_LOCAL_STORAGE_KEY)
 	},
 }

--- a/frontend/src/pages/Auth/utils.ts
+++ b/frontend/src/pages/Auth/utils.ts
@@ -3,10 +3,11 @@ import moment from 'moment'
 
 export const REDIRECT_LOCAL_STORAGE_KEY = 'highlight-auth-redirect'
 
+// Storing in a cookie so we can set an expiration.
 export const authRedirect = {
 	set: (path: string) => {
 		Cookies.set(REDIRECT_LOCAL_STORAGE_KEY, path, {
-			expires: moment().add(15, 'minutes').toDate(),
+			expires: moment().add(10, 'minutes').toDate(),
 		})
 	},
 	get: () => {

--- a/frontend/src/pages/Auth/utils.ts
+++ b/frontend/src/pages/Auth/utils.ts
@@ -1,0 +1,13 @@
+export const REDIRECT_LOCAL_STORAGE_KEY = 'highlight-auth-redirect'
+
+export const authRedirect = {
+	set: (path: string) => {
+		window.localStorage.setItem(REDIRECT_LOCAL_STORAGE_KEY, path)
+	},
+	get: () => {
+		return window.localStorage.getItem(REDIRECT_LOCAL_STORAGE_KEY)
+	},
+	clear: () => {
+		window.localStorage.removeItem(REDIRECT_LOCAL_STORAGE_KEY)
+	},
+}

--- a/frontend/src/pages/NewProject/NewProjectPage.tsx
+++ b/frontend/src/pages/NewProject/NewProjectPage.tsx
@@ -26,6 +26,8 @@ import { Helmet } from 'react-helmet'
 import { Navigate, useLocation } from 'react-router-dom'
 import { StringParam, useQueryParams } from 'use-query-params'
 
+import { authRedirect } from '@/pages/Auth/utils'
+
 import Button from '../../components/Button/Button/Button'
 import styles from './NewProject.module.css'
 
@@ -67,8 +69,7 @@ const NewProjectPage = () => {
 	const { data, loading } = useGetWorkspacesCountQuery()
 
 	const { search } = useLocation()
-	const [{ next, promo }] = useQueryParams({
-		next: StringParam,
+	const [{ promo }] = useQueryParams({
 		promo: StringParam,
 	})
 	const [promoCode, setPromoCode] = useState(promo ?? '')
@@ -132,8 +133,9 @@ const NewProjectPage = () => {
 
 	// When a project is created, redirect to the 'project setup' page
 	if (projectData?.createProject?.id) {
-		if (!!next) {
-			return <Navigate replace to={next} />
+		const authRedirectRoute = authRedirect.get()
+		if (!!authRedirectRoute) {
+			return <Navigate replace to={authRedirectRoute} />
 		} else {
 			return (
 				<Navigate

--- a/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
@@ -12,7 +12,7 @@ import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext'
 import { SetupRouter } from '@pages/Setup/SetupRouter/SetupRouter'
 import { usePreloadErrors, usePreloadSessions } from '@util/preload'
 import React, { Suspense } from 'react'
-import { Navigate, Route, Routes } from 'react-router-dom'
+import { Route, Routes } from 'react-router-dom'
 
 import { DEMO_PROJECT_ID } from '@/components/DemoWorkspaceButton/DemoWorkspaceButton'
 import { useNumericProjectId } from '@/hooks/useProjectId'

--- a/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
@@ -16,6 +16,7 @@ import { Navigate, Route, Routes } from 'react-router-dom'
 
 import { DEMO_PROJECT_ID } from '@/components/DemoWorkspaceButton/DemoWorkspaceButton'
 import { useNumericProjectId } from '@/hooks/useProjectId'
+import { SignInRedirect } from '@/pages/Auth/SignInRedirect'
 import { SettingsRouter } from '@/pages/SettingsRouter/SettingsRouter'
 import { TracesPage } from '@/pages/Traces/TracesPage'
 
@@ -90,7 +91,7 @@ const ApplicationRouter: React.FC = () => {
 					<Route path="*" element={<DashboardsRouter />} />
 				</>
 			) : (
-				<Route path="*" element={<Navigate to="/" replace />} />
+				<Route path="*" element={<SignInRedirect />} />
 			)}
 		</Routes>
 	)

--- a/frontend/src/routers/ProjectRouter/ProjectRedirectionRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ProjectRedirectionRouter.tsx
@@ -7,6 +7,8 @@ import { useGetProjectsAndWorkspacesQuery } from '@graph/hooks'
 import React, { useEffect } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 
+import { authRedirect } from '@/pages/Auth/utils'
+
 export const ProjectRedirectionRouter = () => {
 	const { loading, error, data } = useGetProjectsAndWorkspacesQuery({
 		fetchPolicy: 'network-only',
@@ -14,6 +16,7 @@ export const ProjectRedirectionRouter = () => {
 	const { admin } = useAuthContext()
 	const { setLoadingState } = useAppLoadingContext()
 	const location = useLocation()
+	const authRedirectRoute = authRedirect.get()
 
 	useEffect(() => {
 		if (loading) {
@@ -33,7 +36,9 @@ export const ProjectRedirectionRouter = () => {
 	}
 
 	let redirectTo
-	if (data?.projects?.length) {
+	if (authRedirectRoute) {
+		redirectTo = authRedirectRoute
+	} else if (data?.projects?.length) {
 		redirectTo = `/${data!.projects[0]!.id}${location.pathname}`
 	} else {
 		redirectTo = '/new'
@@ -44,7 +49,11 @@ export const ProjectRedirectionRouter = () => {
 	// redirect the user to /${firstProjectId}/sessions.
 	return (
 		<Navigate
-			to={{ pathname: redirectTo, search: location.search }}
+			to={
+				redirectTo.indexOf('?') > -1
+					? redirectTo
+					: { pathname: redirectTo, search: location.search }
+			}
 			replace
 		/>
 	)


### PR DESCRIPTION
## Summary

We noticed a couple issues with people going through the setup flow of our Vercel integration.

1. They were getting stuck in the loading state once redirect to the `/sign_in` page.
2. They weren't being redirected back to the Vercel integration page after signing up/in.

This PR fixes both issues and adds general support for redirecting to the originally request page after a user authenticates.

I also addressed a minor issue I saw on the admin form where a top border was being applied to the last name field when hovered or focused.

## How did you test this change?

Local click test. I just hit the callback URL manually locally since I couldn't trigger the real auth redirect from Vercel. We should verify the behavior initiating it from Vercel once this goes live.

## Are there any deployment considerations?

Need to verify the full flow starting from Vercel once deployed to production.

## Does this work require review from our design team?

Nope!