### PR TITLE
remove "or" in join for normalness

### DIFF
--- a/backend/lambda-functions/journeys/handlers/handlers.go
+++ b/backend/lambda-functions/journeys/handlers/handlers.go
@@ -295,7 +295,7 @@ func (h *handlers) UpdateNormalnessScores(ctx context.Context) error {
 					inner join user_journey_steps u
 						on s.id = u.session_id
 					inner join frequencies f
-						on (f.url = u.url or f.next_url = u.next_url) and f.project_id = u.project_id
+						on f.url = u.url and f.project_id = u.project_id
 				group by session_id, index
 				order by session_id, index) a
 				group by a.session_id


### PR DESCRIPTION
## Summary
- this "or" is not necessary, explain for this query is 10x faster, runs in about 20 mins for a full day
- fixes #6576 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran script on previous week of data
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
