### PR TITLE
Fix logging for slack alerts

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2886,7 +2886,7 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 	if input.Workspace.SlackAccessToken != nil {
 		slackClient = slack.New(*input.Workspace.SlackAccessToken)
 	}
-	log.WithContext(ctx).Printf("Sending Slack Alert for project: %d session: %s", input.Workspace.ID, input.SessionSecureID)
+	log.WithContext(ctx).Printf("Sending Slack Alert for project: %d session: %s", obj.ProjectID, input.SessionSecureID)
 
 	// send message
 	for _, channel := range channels {
@@ -2940,7 +2940,7 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 					if strings.Contains(slackChannelName, "#") {
 						_, _, _, err := slackClient.JoinConversation(slackChannelId)
 						if err != nil {
-							log.WithContext(ctx).Error(e.Wrap(err, "failed to join slack channel"))
+							log.WithContext(ctx).WithFields(log.Fields{"session_secure_id": input.SessionSecureID, "project_id": obj.ProjectID}).Error(e.Wrap(err, "failed to join slack channel"))
 							return
 						}
 					}


### PR DESCRIPTION
## Summary
A customer reached out about not receiving any alerts via errors or session alerts. The alert event is created, and we log that the slack alert is being sent, but then nothing reports back on the status.

Add some additional fields to help determine where the alerts, and correct a field

## How did you test this change?
Logs are sent when a alert event is sent to slack

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
