### PR TITLE
Fix file name word breaks

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -312,9 +312,7 @@ const StackSection: React.FC<React.PropsWithChildren<StackSectionProps>> = ({
 									copyToClipboard(fileName)
 								}}
 							/>
-							<Text cssClass={styles.fileName} wrap="breakWord">
-								{fileName}
-							</Text>
+							<Text cssClass={styles.fileName}>{fileName}</Text>
 						</Box>
 					</Tooltip>
 				)}


### PR DESCRIPTION
## Summary
Fix the word breaks in the filename to look more natural

![image (1)](https://github.com/highlight/highlight/assets/17744174/b5fb157e-f25b-47f7-8e5e-2abd41d0733a)

## How did you test this change?
View an error and however over the file name in the stacktrace

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
