### PR TITLE
fix race condition between client start and stop

### DIFF
--- a/cypress/pages/unpkg.html
+++ b/cypress/pages/unpkg.html
@@ -5,6 +5,8 @@
 		<title>unpkg.com highlight.run bundle</title>
 		<script src="https://unpkg.com/highlight.run"></script>
 		<script>
+			// should print console warning
+			H.stop()
 			H.init('1', {
 				backendUrl: 'https://localhost:8082/public',
 				scriptUrl: 'http://localhost:8080/dist/index.js',
@@ -14,6 +16,15 @@
 					recordHeadersAndBody: true,
 				},
 			})
+			// starts new session, even though `H.init` may not have yet completed loading the script
+			H.start({ forceNew: true })
+			H.identify('vadim@highlight.io', { id: 'abc123' })
+			// stops session
+			H.stop()
+			// forces a new session
+			H.start({ forceNew: true })
+			H.identify('jay@highlight.io', { id: 'def456' })
+			// should continue to recording, with PushPayloads being sent every 2 seconds
 		</script>
 	</head>
 	<body></body>

--- a/e2e/html/index.html
+++ b/e2e/html/index.html
@@ -11,21 +11,22 @@
 		<script src="http://localhost:8877/dist/index.umd.cjs"></script>
 		<script>
 			// See https://www.highlight.io/docs/getting-started/client-sdk/other
+			H.stop()
 			H.init('2', {
 				// Get your project ID from https://app.highlight.io/setup
 				environment: 'production',
 				scriptUrl: 'http://localhost:8080/dist/index.js',
+				manualStart: true,
 				networkRecording: {
 					enabled: true,
 					recordHeadersAndBody: true,
-					urlBlocklist: [
-						// insert full or partial urls that you don't want to record here
-						// Out of the box, Highlight will not record these URLs (they can be safely removed):
-						'https://www.googleapis.com/identitytoolkit',
-						'https://securetoken.googleapis.com',
-					],
 				},
 			})
+			H.start({ forceNew: true })
+			H.identify('vadim@highlight.io', { id: 'abc123' })
+			H.stop()
+			H.start({ forceNew: true })
+			H.identify('vadim@highlight.io', { id: 'def456' })
 		</script>
 	</head>
 

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -252,8 +252,11 @@ export declare interface HighlightPublicInterface {
 	getSessionDetails: () => Promise<SessionDetails>
 	start: (options?: StartOptions) => void
 	/** Stops the session and error recording. */
-	stop: () => void
-	onHighlightReady: (func: () => void) => void
+	stop: (options?: StartOptions) => void
+	onHighlightReady: (
+		func: () => void | Promise<void>,
+		options?: OnHighlightReadyOptions,
+	) => Promise<void>
 	options: HighlightOptions | undefined
 	/**
 	 * Calling this will add a feedback comment to the session.
@@ -287,4 +290,11 @@ export interface StartOptions {
 	 * Starts a new recording session even if one was stopped recently.
 	 */
 	forceNew?: boolean
+}
+
+export interface OnHighlightReadyOptions {
+	/**
+	 * Specifies whether to wait for recording to start
+	 */
+	waitForReady?: boolean
 }

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -402,3 +402,9 @@ Reserved for the Boeing 737
 ### Patch Changes
 
 - Record network request payloads with absolute timestamps.
+
+## 7.5.5
+
+### Patch Changes
+
+- Ensure `H.start()` and `H.stop()` behavior is async-race-safe to avoid inconsistent behavior when `H.stop()` or `H.start()` is called before recording is started.

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "7.5.4",
+	"version": "7.5.5",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "7.5.4"
+export default "7.5.5"

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -7,11 +7,12 @@ import type {
 	Highlight,
 	HighlightClassOptions,
 } from '@highlight-run/client/src'
-import type {
+import {
 	HighlightOptions,
 	HighlightPublicInterface,
 	Metadata,
 	Metric,
+	OnHighlightReadyOptions,
 	SessionDetails,
 } from '@highlight-run/client/src/types/types'
 import { MixpanelAPI, setupMixpanelIntegration } from './integrations/mixpanel'
@@ -52,6 +53,9 @@ interface HighlightWindow extends Window {
 }
 
 declare var window: HighlightWindow
+
+let onHighlightReadyQueue: (() => void | Promise<void>)[] = []
+let onHighlightReadyInterval: number | undefined = undefined
 
 let script: HTMLScriptElement
 let highlight_obj: Highlight
@@ -275,32 +279,31 @@ const H: HighlightPublicInterface = {
 		}
 	},
 	start: (options) => {
-		try {
-			if (highlight_obj?.state === 'Recording') {
-				if (!options?.silent) {
-					console.warn(
-						'Highlight is already recording. Please `H.stop()` the current session before starting a new one.',
-					)
-				}
-				return
-			} else {
-				first_load_listeners.startListening()
-				var interval = setInterval(function () {
-					if (highlight_obj) {
-						clearInterval(interval)
-						highlight_obj.initialize(options)
-					}
-				}, 200)
+		if (highlight_obj?.state === 'Recording') {
+			if (!options?.silent) {
+				console.warn(
+					'Highlight is already recording. Please `H.stop()` the current session before starting a new one.',
+				)
 			}
-		} catch (e) {
-			HighlightWarning('start', e)
+		} else {
+			H.onHighlightReady(
+				async () => {
+					first_load_listeners.startListening()
+					await highlight_obj.initialize(options)
+				},
+				{ waitForReady: false },
+			)
 		}
 	},
-	stop: () => {
-		try {
+	stop: (options) => {
+		if (highlight_obj?.state !== 'Recording') {
+			if (!options?.silent) {
+				console.warn(
+					'Highlight is already stopped. Please call `H.start()`.',
+				)
+			}
+		} else {
 			H.onHighlightReady(() => highlight_obj.stopRecording(true))
-		} catch (e) {
-			HighlightWarning('stop', e)
 		}
 	},
 	identify: (identifier: string, metadata: Metadata = {}) => {
@@ -397,17 +400,31 @@ const H: HighlightPublicInterface = {
 			})
 		})
 	},
-	onHighlightReady: (func: () => void) => {
+	onHighlightReady: async (func, options) => {
 		try {
-			if (highlight_obj && highlight_obj.ready) {
-				func()
+			if (
+				highlight_obj &&
+				(options?.waitForReady === false || highlight_obj.ready)
+			) {
+				await func()
 			} else {
-				var interval = setInterval(function () {
-					if (highlight_obj && highlight_obj.ready) {
-						clearInterval(interval)
-						func()
-					}
-				}, 200)
+				onHighlightReadyQueue.push(func)
+				if (onHighlightReadyInterval === undefined) {
+					onHighlightReadyInterval = setInterval(async () => {
+						if (
+							highlight_obj &&
+							(options?.waitForReady === false ||
+								highlight_obj.ready)
+						) {
+							for (const f of onHighlightReadyQueue) {
+								await f()
+							}
+							onHighlightReadyQueue = []
+							clearInterval(onHighlightReadyInterval)
+							onHighlightReadyInterval = undefined
+						}
+					}, 200) as unknown as number
+				}
 			}
 		} catch (e) {
 			HighlightWarning('onHighlightReady', e)


### PR DESCRIPTION
## Summary

A race condition in our client `H.start` and `H.stop` methods would mean that if someone called `H.stop()` before `H.init()`, the stop would be queued in an interval that would race with other methods called (like other `H.start()` calls), since the calls would each get their own interval.

This rewrites the `onHighlightReady` handler to run the functions serially in the order in which they were queued. 

## How did you test this change?

Expands a cypress test to validate the behavior.

with the following html script
```js
H.stop()
H.init('2', {
	// Get your project ID from https://app.highlight.io/setup
	environment: 'production',
	scriptUrl: 'http://localhost:8080/dist/index.js',
	manualStart: true,
	networkRecording: {
		enabled: true,
		recordHeadersAndBody: true,
	},
})
H.start({ forceNew: true })
H.identify('vadim@highlight.io', { id: 'abc123' })
H.stop()
H.start({ forceNew: true })
H.identify('vadim@highlight.io', { id: 'def456' })
```

Before, session would stop recording
<img width="1356" alt="Screenshot 2023-09-26 at 11 09 14 AM" src="https://github.com/highlight/highlight/assets/1351531/7aa52efc-a62f-44e0-9fa3-7c151e7fd756">


After, session started correctly
<img width="704" alt="Screenshot 2023-09-26 at 11 07 34 AM" src="https://github.com/highlight/highlight/assets/1351531/2c0c9534-86ed-496e-8483-58ad26592248">

<img width="952" alt="Screenshot 2023-09-26 at 11 07 23 AM" src="https://github.com/highlight/highlight/assets/1351531/e82b0931-e44f-44f9-b157-4eff3b43e4fb">


## Are there any deployment considerations?

New highlight.run client released

## Does this work require review from our design team?

No
