### PR TITLE
fix datadog trace resource names

### DIFF
--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -57,7 +57,6 @@ const (
 
 func StartSpanFromContext(ctx context.Context, operationName string, options ...SpanOption) (MultiSpan, context.Context) {
 	var cfg SpanConfig
-	var ddOptions []tracer.StartSpanOption
 	for _, opt := range options {
 		opt(&cfg)
 	}
@@ -66,8 +65,9 @@ func StartSpanFromContext(ctx context.Context, operationName string, options ...
 	hTracingDisabled = hTracingDisabled || cfg.HighlightTracingDisabled
 	ctx = context.WithValue(ctx, ContextKeyHighlightTracingDisabled, hTracingDisabled)
 
+	var ddOptions []tracer.StartSpanOption
 	for _, tag := range cfg.Tags {
-		ddOptions = append(ddOptions, tracer.Tag(string(tag.Key), tag.Value))
+		ddOptions = append(ddOptions, tracer.Tag(string(tag.Key), tag.Value.AsString()))
 	}
 
 	ddSpan, mergedCtx := tracer.StartSpanFromContext(ctx, operationName, ddOptions...)
@@ -85,12 +85,13 @@ func StartSpanFromContext(ctx context.Context, operationName string, options ...
 
 func StartSpan(operationName string, options ...SpanOption) MultiSpan {
 	var cfg SpanConfig
-	var ddOptions []tracer.StartSpanOption
 	for _, opt := range options {
 		opt(&cfg)
 	}
+
+	var ddOptions []tracer.StartSpanOption
 	for _, tag := range cfg.Tags {
-		ddOptions = append(ddOptions, tracer.Tag(string(tag.Key), tag.Value))
+		ddOptions = append(ddOptions, tracer.Tag(string(tag.Key), tag.Value.AsString()))
 	}
 
 	ddSpan := tracer.StartSpan(operationName, ddOptions...)


### PR DESCRIPTION
## Summary

Noticed our datadog traces had the `resource_name` in a strange format.
<img width="495" alt="Screenshot 2023-09-26 at 6 16 29 PM" src="https://github.com/highlight/highlight/assets/1351531/19085817-fcac-4e97-b624-00c083457c01">

Turns out the opentelemetry `attribute.Value()` returns a struct rather than a string, so an `AsString()` conversion
is needed for string tags.

## How did you test this change?

Will monitor datadog traces.

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No