### PR TITLE
fix ruby publish failing on main

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,7 +36,7 @@ jobs:
             - name: Rubocop
               run: bundle exec rubocop
             - name: Publish to RubyGems
-              if: github.ref == 'refs/heads/main' && steps.filter.outputs.ruby-changed
+              if: github.ref == 'refs/heads/main' && steps.filter.outputs.ruby-changed == 'true'
               run: |
                   mkdir -p $HOME/.gem
                   touch $HOME/.gem/credentials

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -98,7 +98,7 @@ jobs:
 
             - name: Validate project is ready to be published
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight'
-              run: yarn validate --has-sdk-changes=${{ steps.filter.outputs.npm-changed }}
+              run: yarn validate --has-sdk-changes=${{ steps.filter.outputs.npm-changed == 'true' }}
 
             - name: Publish client bundle (preview)
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' && github.ref != 'refs/heads/main'


### PR DESCRIPTION
## Summary

Ruby github action on main is still trying to publish on every push.
Make sure the github action filter action is checked correctly.

## How did you test this change?

Temporarily running the github action in this branch.

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
