### PR TITLE
correctly report project for internal metrics

### DIFF
--- a/backend/embeddings/embeddings.go
+++ b/backend/embeddings/embeddings.go
@@ -88,7 +88,7 @@ func (c *OpenAIClient) GetEmbeddings(ctx context.Context, errors []*model.ErrorO
 		}
 		log.WithContext(ctx).
 			WithField("num_inputs", len(inputs.inputs)).
-			WithField("time", time.Since(start)).
+			WithField("time", time.Since(start).Seconds()).
 			WithField("embedding", inputs.embedding).
 			Info("AI embedding generated.")
 
@@ -219,7 +219,7 @@ func (c *HuggingfaceModelClient) GetEmbeddings(ctx context.Context, errors []*mo
 	}
 
 	log.WithContext(ctx).
-		WithField("time", time.Since(start)).
+		WithField("time", time.Since(start).Seconds()).
 		WithField("errors", len(errors)).
 		WithField("type", "huggingface").
 		Info("AI embedding generated.")

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -85,26 +85,29 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 	if params.span != nil {
 		spanAttributes = params.span.Attributes().AsRaw()
 
-		spanEvents := params.span.Events()
-		fields.events = make([]map[string]any, spanEvents.Len())
-		for i := 0; i < spanEvents.Len(); i++ {
-			event := spanEvents.At(i)
-			fields.events[i] = map[string]any{
-				"Timestamp":  event.Timestamp().AsTime(),
-				"Name":       event.Name(),
-				"Attributes": event.Attributes().AsRaw(),
+		// for a specific event, do not aggregate span events / links
+		if params.event == nil {
+			spanEvents := params.span.Events()
+			fields.events = make([]map[string]any, spanEvents.Len())
+			for i := 0; i < spanEvents.Len(); i++ {
+				event := spanEvents.At(i)
+				fields.events[i] = map[string]any{
+					"Timestamp":  event.Timestamp().AsTime(),
+					"Name":       event.Name(),
+					"Attributes": event.Attributes().AsRaw(),
+				}
 			}
-		}
 
-		spanLinks := params.span.Links()
-		fields.links = make([]map[string]any, spanLinks.Len())
-		for i := 0; i < spanLinks.Len(); i++ {
-			link := spanLinks.At(i)
-			fields.links[i] = map[string]any{
-				"TraceId":    link.TraceID().String(),
-				"SpanId":     link.SpanID().String(),
-				"TraceState": link.TraceState().AsRaw(),
-				"Attributes": link.Attributes().AsRaw(),
+			spanLinks := params.span.Links()
+			fields.links = make([]map[string]any, spanLinks.Len())
+			for i := 0; i < spanLinks.Len(); i++ {
+				link := spanLinks.At(i)
+				fields.links[i] = map[string]any{
+					"TraceId":    link.TraceID().String(),
+					"SpanId":     link.SpanID().String(),
+					"TraceState": link.TraceState().AsRaw(),
+					"Attributes": link.Attributes().AsRaw(),
+				}
 			}
 		}
 	}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2967,6 +2967,7 @@ func (r *Resolver) submitFrontendNetworkMetric(sessionObj *model.Session, resour
 		end := re.End(sessionObj.CreatedAt)
 		attributes := []attribute.KeyValue{
 			attribute.String(highlight.TraceTypeAttribute, string(highlight.TraceTypeNetworkRequest)),
+			attribute.Int(highlight.ProjectIDAttribute, sessionObj.ProjectID),
 			attribute.String(highlight.SessionIDAttribute, sessionObj.SecureID),
 			attribute.String(highlight.RequestIDAttribute, re.RequestResponsePairs.Request.ID),
 			semconv.ServiceNameKey.String(sessionObj.ServiceName),

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1157,7 +1157,7 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 		attribute.String("OSVersion", session.OSVersion),
 		attribute.String("Postal", session.Postal),
 		attribute.String("State", session.State),
-		attribute.Int(highlight.ProjectIDAttribute, session.ProjectID),
+		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(session.ProjectID)),
 		attribute.String(highlight.SessionIDAttribute, session.SecureID),
 	)
 	if err := r.PushMetricsImpl(initCtx, session.SecureID, []*publicModel.MetricInput{
@@ -1479,7 +1479,7 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 		attribute.String("Identifier", session.Identifier),
 		attribute.Bool("Identified", session.Identified),
 		attribute.Bool("FirstTime", *session.FirstTime),
-		attribute.Int(highlight.ProjectIDAttribute, session.ProjectID),
+		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(session.ProjectID)),
 		attribute.String(highlight.SessionIDAttribute, session.SecureID),
 	}
 	for k, v := range allUserProperties {
@@ -2007,7 +2007,7 @@ func (r *Resolver) updateErrorsCount(ctx context.Context, projectID int, errorsB
 	defer dailyErrorCountSpan.Finish()
 
 	for sessionSecureId, count := range errorsBySession {
-		highlight.RecordMetric(ctx, "errors", float64(count), attribute.Int(highlight.ProjectIDAttribute, projectID), attribute.String(highlight.SessionIDAttribute, sessionSecureId))
+		highlight.RecordMetric(ctx, "errors", float64(count), attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)), attribute.String(highlight.SessionIDAttribute, sessionSecureId))
 		if err := r.PushMetricsImpl(context.Background(), sessionSecureId, []*publicModel.MetricInput{
 			{
 				SessionSecureID: sessionSecureId,
@@ -2967,6 +2967,7 @@ func (r *Resolver) submitFrontendNetworkMetric(sessionObj *model.Session, resour
 		end := re.End(sessionObj.CreatedAt)
 		attributes := []attribute.KeyValue{
 			attribute.String(highlight.TraceTypeAttribute, string(highlight.TraceTypeNetworkRequest)),
+			attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(sessionObj.ProjectID)),
 			attribute.String(highlight.SessionIDAttribute, sessionObj.SecureID),
 			attribute.String(highlight.RequestIDAttribute, re.RequestResponsePairs.Request.ID),
 			semconv.ServiceNameKey.String(sessionObj.ServiceName),

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1157,7 +1157,7 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 		attribute.String("OSVersion", session.OSVersion),
 		attribute.String("Postal", session.Postal),
 		attribute.String("State", session.State),
-		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(session.ProjectID)),
+		attribute.Int(highlight.ProjectIDAttribute, session.ProjectID),
 		attribute.String(highlight.SessionIDAttribute, session.SecureID),
 	)
 	if err := r.PushMetricsImpl(initCtx, session.SecureID, []*publicModel.MetricInput{
@@ -1479,7 +1479,7 @@ func (r *Resolver) IdentifySessionImpl(ctx context.Context, sessionSecureID stri
 		attribute.String("Identifier", session.Identifier),
 		attribute.Bool("Identified", session.Identified),
 		attribute.Bool("FirstTime", *session.FirstTime),
-		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(session.ProjectID)),
+		attribute.Int(highlight.ProjectIDAttribute, session.ProjectID),
 		attribute.String(highlight.SessionIDAttribute, session.SecureID),
 	}
 	for k, v := range allUserProperties {
@@ -2007,7 +2007,7 @@ func (r *Resolver) updateErrorsCount(ctx context.Context, projectID int, errorsB
 	defer dailyErrorCountSpan.Finish()
 
 	for sessionSecureId, count := range errorsBySession {
-		highlight.RecordMetric(ctx, "errors", float64(count), attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)), attribute.String(highlight.SessionIDAttribute, sessionSecureId))
+		highlight.RecordMetric(ctx, "errors", float64(count), attribute.Int(highlight.ProjectIDAttribute, projectID), attribute.String(highlight.SessionIDAttribute, sessionSecureId))
 		if err := r.PushMetricsImpl(context.Background(), sessionSecureId, []*publicModel.MetricInput{
 			{
 				SessionSecureID: sessionSecureId,
@@ -2967,7 +2967,6 @@ func (r *Resolver) submitFrontendNetworkMetric(sessionObj *model.Session, resour
 		end := re.End(sessionObj.CreatedAt)
 		attributes := []attribute.KeyValue{
 			attribute.String(highlight.TraceTypeAttribute, string(highlight.TraceTypeNetworkRequest)),
-			attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(sessionObj.ProjectID)),
 			attribute.String(highlight.SessionIDAttribute, sessionObj.SecureID),
 			attribute.String(highlight.RequestIDAttribute, re.RequestResponsePairs.Request.ID),
 			semconv.ServiceNameKey.String(sessionObj.ServiceName),

--- a/backend/util/tracer-graphql.go
+++ b/backend/util/tracer-graphql.go
@@ -47,7 +47,7 @@ func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 
 	if t.serverType == PrivateGraph {
 		fields := log.Fields{
-			"duration":        time.Since(start),
+			"duration":        time.Since(start).Seconds(),
 			"operation.field": fc.Field.Name,
 			"graph":           t.serverType,
 		}
@@ -86,7 +86,7 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	}
 	if t.serverType == PrivateGraph {
 		fields := log.Fields{
-			"duration":          time.Since(start),
+			"duration":          time.Since(start).Seconds(),
 			"graphql.operation": opName,
 			"graph":             t.serverType,
 		}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -870,14 +870,14 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 		ctx, mgraph.SessionActiveMetricName, float64(accumulator.ActiveDuration),
 		attribute.Bool("Excluded", false),
 		attribute.Bool("Processed", true),
-		attribute.Int(highlight.ProjectIDAttribute, s.ProjectID),
+		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(s.ProjectID)),
 		attribute.String(highlight.SessionIDAttribute, s.SecureID),
 	)
 	highlight.RecordMetric(
 		ctx, mgraph.SessionProcessedMetricName, float64(s.ID),
 		attribute.Bool("Excluded", false),
 		attribute.Bool("Processed", true),
-		attribute.Int(highlight.ProjectIDAttribute, s.ProjectID),
+		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(s.ProjectID)),
 		attribute.String(highlight.SessionIDAttribute, s.SecureID),
 	)
 	if err := w.PublicResolver.PushMetricsImpl(ctx, s.SecureID, []*publicModel.MetricInput{

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -870,14 +870,14 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 		ctx, mgraph.SessionActiveMetricName, float64(accumulator.ActiveDuration),
 		attribute.Bool("Excluded", false),
 		attribute.Bool("Processed", true),
-		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(s.ProjectID)),
+		attribute.Int(highlight.ProjectIDAttribute, s.ProjectID),
 		attribute.String(highlight.SessionIDAttribute, s.SecureID),
 	)
 	highlight.RecordMetric(
 		ctx, mgraph.SessionProcessedMetricName, float64(s.ID),
 		attribute.Bool("Excluded", false),
 		attribute.Bool("Processed", true),
-		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(s.ProjectID)),
+		attribute.Int(highlight.ProjectIDAttribute, s.ProjectID),
 		attribute.String(highlight.SessionIDAttribute, s.SecureID),
 	)
 	if err := w.PublicResolver.PushMetricsImpl(ctx, s.SecureID, []*publicModel.MetricInput{

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -163,10 +163,10 @@ func EndTrace(span trace.Span) {
 // as a metric that you would like to graph and monitor. You'll be able to view the metric
 // in the context of the session and network request and recorded it.
 func RecordMetric(ctx context.Context, name string, value float64, tags ...attribute.KeyValue) {
-	span, _ := StartTrace(ctx, "highlight-ctx")
+	span, _ := StartTrace(ctx, "highlight-ctx", tags...)
 	defer EndTrace(span)
 	tags = append(tags, attribute.String(MetricEventName, name), attribute.Float64(MetricEventValue, value))
-	span.AddEvent(MetricEvent, trace.WithAttributes(tags...))
+	span.AddEvent(MetricEvent)
 }
 
 // RecordError processes `err` to be recorded as a part of the session or network request.


### PR DESCRIPTION
## Summary

The project for internal metrics was not being saved correctly because we would be
overriding the project id with the project id for our backend.

<img width="1067" alt="Screenshot 2023-09-27 at 12 25 17 AM" src="https://github.com/highlight/highlight/assets/1351531/d3838f31-f3cc-47d5-9a10-80ebf617d197">

* correctly prioritize passed in tags for metrics and spans
* key traces by trace id to preserve child trace ordering
* record random duration logs with a numeric seconds value

## How did you test this change?

Local deploy.
<img width="1134" alt="Screenshot 2023-09-27 at 1 51 51 PM" src="https://github.com/highlight/highlight/assets/1351531/b91939b7-763c-41f9-82ac-ef1def73a51a">


## Are there any deployment considerations?

No

## Does this work require review from our design team?

No