### PR TITLE
add timeout for embedding generation

### DIFF
--- a/backend/embeddings/embeddings.go
+++ b/backend/embeddings/embeddings.go
@@ -156,7 +156,10 @@ type HuggingfaceModelInputs struct {
 }
 
 func (c *HuggingfaceModelClient) makeRequest(ctx context.Context, b []byte) ([]byte, error) {
-	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(b))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Add("Authorization", "Bearer "+c.token)
 	req.Header.Add("Content-Type", "application/json")
 	response, err := c.client.Do(req)

--- a/backend/embeddings/embeddings.go
+++ b/backend/embeddings/embeddings.go
@@ -76,7 +76,7 @@ func (c *OpenAIClient) GetEmbeddings(ctx context.Context, errors []*model.ErrorO
 			return item
 		})
 		resp, err := c.client.CreateEmbeddings(
-			context.Background(),
+			ctx,
 			openai.EmbeddingRequest{
 				Input: inputs.inputs,
 				Model: openai.AdaEmbeddingV2,
@@ -132,7 +132,7 @@ func (c *HuggingfaceModelClient) GetStringEmbedding(ctx context.Context, input s
 		return nil, err
 	}
 
-	body, err := c.makeRequest(b)
+	body, err := c.makeRequest(ctx, b)
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +155,8 @@ type HuggingfaceModelInputs struct {
 	Inputs string `json:"inputs"`
 }
 
-func (c *HuggingfaceModelClient) makeRequest(b []byte) ([]byte, error) {
-	req, _ := http.NewRequest(http.MethodPost, c.url, bytes.NewReader(b))
+func (c *HuggingfaceModelClient) makeRequest(ctx context.Context, b []byte) ([]byte, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(b))
 	req.Header.Add("Authorization", "Bearer "+c.token)
 	req.Header.Add("Content-Type", "application/json")
 	response, err := c.client.Do(req)
@@ -201,7 +201,7 @@ func (c *HuggingfaceModelClient) GetEmbeddings(ctx context.Context, errors []*mo
 		if err != nil {
 			return nil, err
 		}
-		body, err := c.makeRequest(b)
+		body, err := c.makeRequest(ctx, b)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -766,7 +766,7 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 		emb, err := r.EmbeddingsClient.GetEmbeddings(eCtx, []*model.ErrorObject{errorObj})
 		if err != nil || len(emb) == 0 {
 			log.WithContext(ctx).WithError(err).WithField("error_object_id", errorObj.ID).Error("failed to get embeddings")
-			errorObj.ErrorGroupID = errorGroupAlt.ID
+			errorGroup, errorGroupAlt = errorGroupAlt, nil
 			errorObj.ErrorGroupingMethod = model.ErrorGroupingMethodClassic
 		} else {
 			embedding = emb[0]
@@ -780,14 +780,13 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 			if err != nil {
 				return nil, e.Wrap(err, "Error getting or creating error group")
 			}
-			errorObj.ErrorGroupID = errorGroup.ID
 			errorObj.ErrorGroupIDAlternative = errorGroupAlt.ID
 			errorObj.ErrorGroupingMethod = model.ErrorGroupingMethodGteLargeEmbeddingV2
 		}
 	} else {
-		errorObj.ErrorGroupID = errorGroup.ID
 		errorObj.ErrorGroupingMethod = model.ErrorGroupingMethodClassic
 	}
+	errorObj.ErrorGroupID = errorGroup.ID
 
 	if err := r.DB.Create(errorObj).Error; err != nil {
 		return nil, e.Wrap(err, "Error performing error insert for error")

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -760,8 +760,9 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 	if settings != nil && settings.ErrorEmbeddingsGroup {
 		// keep the classic match as the alternative error group
 		errorGroup, errorGroupAlt = nil, errorGroup
-		// timeout to generate embeddings in case endpoint is slow
-		eCtx, _ := context.WithTimeout(ctx, time.Second)
+		// timeout to generate embeddings in case endpoint is slow. p95 ~ 0.3s
+		eCtx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
 		emb, err := r.EmbeddingsClient.GetEmbeddings(eCtx, []*model.ErrorObject{errorObj})
 		if err != nil || len(emb) == 0 {
 			log.WithContext(ctx).WithError(err).WithField("error_object_id", errorObj.ID).Error("failed to get embeddings")

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -760,7 +760,9 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 	if settings != nil && settings.ErrorEmbeddingsGroup {
 		// keep the classic match as the alternative error group
 		errorGroup, errorGroupAlt = nil, errorGroup
-		emb, err := r.EmbeddingsClient.GetEmbeddings(ctx, []*model.ErrorObject{errorObj})
+		// timeout to generate embeddings in case endpoint is slow
+		eCtx, _ := context.WithTimeout(ctx, time.Second)
+		emb, err := r.EmbeddingsClient.GetEmbeddings(eCtx, []*model.ErrorObject{errorObj})
 		if err != nil || len(emb) == 0 {
 			log.WithContext(ctx).WithError(err).WithField("error_object_id", errorObj.ID).Error("failed to get embeddings")
 			errorObj.ErrorGroupID = errorGroupAlt.ID

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -761,7 +761,7 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 		// keep the classic match as the alternative error group
 		errorGroup, errorGroupAlt = nil, errorGroup
 		// timeout to generate embeddings in case endpoint is slow. p95 ~ 0.3s
-		eCtx, cancel := context.WithTimeout(ctx, time.Second)
+		eCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		emb, err := r.EmbeddingsClient.GetEmbeddings(eCtx, []*model.ErrorObject{errorObj})
 		if err != nil || len(emb) == 0 {


### PR DESCRIPTION
## Summary

The embeddings inference endpoint may slow down dramatically under heavy load but never time out.
In this case, each request takes >30 seconds and may take much longer, with the increasing load
preventing any requests from completing. This introduces a timeout to make sure we
will fail requests that take too long (longer than 1 second, where the normal p95 request time is 250ms)

## How did you test this change?

local testing with a fake sleep inserted
```ERRO[0009]/Users/vkorolik/work/highlight/backend/public-graph/graph/resolver.go:768 github.com/highlight-run/highlight/backend/public-graph/graph.(*Resolver).HandleErrorAndGroup() failed to get embeddings                      error="Post \"https://rxti97k7hsleuekl.us-east-1.aws.endpoints.huggingface.cloud\": context deadline exceeded" error_object_id=0```

objects stored with classic method when the timeout is exceeded
<img width="503" alt="Screenshot 2023-09-27 at 2 15 29 PM" src="https://github.com/highlight/highlight/assets/1351531/d861015a-05c9-4912-b088-51f2edb6a6f7">


## Are there any deployment considerations?

No

## Does this work require review from our design team?

No