### PR TITLE
add category to session insights emails for analytics

### DIFF
--- a/backend/lambda-functions/sessionInsights/handlers/handlers.go
+++ b/backend/lambda-functions/sessionInsights/handlers/handlers.go
@@ -310,6 +310,7 @@ func (h *handlers) SendSessionInsightsEmails(ctx context.Context, input utils.Se
 		to := &mail.Email{Address: toAddr.Email}
 		subject := fmt.Sprintf("[Highlight] Session Insights - %s", input.ProjectName)
 		m := mail.NewV3MailInit(from, subject, to, mail.NewContent("text/html", html))
+		m.AddCategories("session-insights")
 
 		for imageId, img := range images {
 			log.WithContext(ctx).Infof("attaching image %s", imageId)


### PR DESCRIPTION
## Summary
- session insights emails are generated with react email so there's no sendgrid template id to use, add a category to these emails so we can filter when looking at analytics
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will validate with a dry run in prod
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
