### PR TITLE
limit kafka prefetching

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1294,12 +1294,15 @@ type SystemConfiguration struct {
 	MainWorkers       int            `gorm:"default:64"`
 	LogsWorkers       int            `gorm:"default:1"`
 	LogsFlushSize     int            `gorm:"type:bigint;default:10000"`
+	LogsQueueSize     int            `gorm:"type:bigint;default:10000"`
 	LogsFlushTimeout  time.Duration  `gorm:"type:bigint;default:5000000000"`
 	DataSyncWorkers   int            `gorm:"default:1"`
 	DataSyncFlushSize int            `gorm:"type:bigint;default:10000"`
+	DataSyncQueueSize int            `gorm:"type:bigint;default:10000"`
 	DataSyncTimeout   time.Duration  `gorm:"type:bigint;default:5000000000"`
 	TraceWorkers      int            `gorm:"default:1"`
 	TraceFlushSize    int            `gorm:"type:bigint;default:10000"`
+	TraceQueueSize    int            `gorm:"type:bigint;default:10000"`
 	TraceFlushTimeout time.Duration  `gorm:"type:bigint;default:5000000000"`
 }
 


### PR DESCRIPTION
## Summary

Kafka errors happening when a new trace worker is joining.
<img width="297" alt="Screenshot 2023-09-27 at 4 31 15 PM" src="https://github.com/highlight/highlight/assets/1351531/78d82d75-0f02-4664-a39b-0273db5cb70e">

For the trace workers, we want a high batch size for writing larger payloads to clickhouse.
However, a large pretech queue from kafka causes significant network load on kafka when the queue is being filled.
Limit the prefetch queue size using a separate parameter. 

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No