### PR TITLE
add example for running journald

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -203,7 +203,7 @@ jobs:
 
                   # run opentelemetry file watcher
                   pushd e2e/opentelemetry/filelog;
-                  EXAMPLE_LOG_FILE_PATH=/tmp/highlight.log docker compose run -d collector;
+                  EXAMPLE_LOG_FILE_PATH=/tmp/highlight.log docker compose run -d file-collector;
                   popd;
 
                   # wait for highlight to be ready

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -173,6 +173,12 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 	if len(fields.logBody) > 0 && fields.logBody[0] == '<' {
 		extractSyslog(fields)
 	}
+	// process potential systemd message
+	if params.logRecord != nil && params.logRecord.Body().Type().String() == "Map" {
+		if m := params.logRecord.Body().Map().AsRaw(); len(m) > 0 {
+			extractSystemd(fields, m)
+		}
+	}
 
 	if val, ok := fields.attrs[highlight.DeprecatedProjectIDAttribute]; ok {
 		fields.projectID = val

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -373,7 +373,7 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	
+
 	var projectLogs = make(map[string][]*clickhouse.LogRow)
 
 	resourceLogs := req.Logs().ResourceLogs()

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -374,13 +373,7 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	j, _ := req.MarshalJSON()
-	s := string(j)
-	if strings.Contains(s, "systemd") {
-		fmt.Printf("%s\n", s)
-	}
-
+	
 	var projectLogs = make(map[string][]*clickhouse.LogRow)
 
 	resourceLogs := req.Logs().ResourceLogs()

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -372,6 +373,12 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 		log.WithContext(ctx).WithError(err).Error("invalid log protobuf")
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+
+	j, _ := req.MarshalJSON()
+	s := string(j)
+	if strings.Contains(s, "systemd") {
+		fmt.Printf("%s\n", s)
 	}
 
 	var projectLogs = make(map[string][]*clickhouse.LogRow)

--- a/backend/otel/systemd.go
+++ b/backend/otel/systemd.go
@@ -1,33 +1,14 @@
 package otel
 
-import "time"
-
 type SystemdKey = string
 
-const UID SystemdKey = "_UID"
-const Cursor SystemdKey = "__CURSOR"
-const MachineID SystemdKey = "_MACHINE_ID"
-const Timestamp SystemdKey = "__MONOTONIC_TIMESTAMP"
-const Transport SystemdKey = "_TRANSPORT"
-const BootID SystemdKey = "_BOOT_ID"
-const PID SystemdKey = "_PID"
-const Hostname SystemdKey = "_HOSTNAME"
-const GID SystemdKey = "_GID"
-const Priority SystemdKey = "PRIORITY"
 const Message SystemdKey = "MESSAGE"
-const StreamID SystemdKey = "_STREAM_ID"
 
 func extractSystemd(fields *extractedFields, m map[string]any) {
 	fields.logBody = m[Message].(string)
-	fields.timestamp = m[Timestamp].(time.Time)
-	fields.attrs["BootID"] = m[BootID].(string)
-	fields.attrs["Cursor"] = m[Cursor].(string)
-	fields.attrs["GID"] = m[GID].(string)
-	fields.attrs["Hostname"] = m[Hostname].(string)
-	fields.attrs["MachineID"] = m[MachineID].(string)
-	fields.attrs["PID"] = m[PID].(string)
-	fields.attrs["Priority"] = m[Priority].(string)
-	fields.attrs["StreamID"] = m[StreamID].(string)
-	fields.attrs["Transport"] = m[Transport].(string)
-	fields.attrs["UID"] = m[UID].(string)
+	for k, v := range m {
+		if str, ok := v.(string); ok {
+			fields.attrs[k] = str
+		}
+	}
 }

--- a/backend/otel/systemd.go
+++ b/backend/otel/systemd.go
@@ -1,11 +1,37 @@
 package otel
 
+import (
+	"go.opentelemetry.io/collector/pdata/plog"
+	"strconv"
+)
+
 type SystemdKey = string
 
 const Message SystemdKey = "MESSAGE"
+const Priority SystemdKey = "PRIORITY"
 
 func extractSystemd(fields *extractedFields, m map[string]any) {
 	fields.logBody = m[Message].(string)
+	if priority, err := strconv.ParseInt(m[Priority].(string), 10, 4); err == nil {
+		switch priority {
+		case 0:
+			fields.logSeverity = plog.SeverityNumberFatal.String()
+		case 1:
+			fields.logSeverity = plog.SeverityNumberFatal.String()
+		case 2:
+			fields.logSeverity = plog.SeverityNumberError.String()
+		case 3:
+			fields.logSeverity = plog.SeverityNumberError.String()
+		case 4:
+			fields.logSeverity = plog.SeverityNumberWarn.String()
+		case 5:
+			fields.logSeverity = plog.SeverityNumberWarn.String()
+		case 6:
+			fields.logSeverity = plog.SeverityNumberInfo.String()
+		case 7:
+			fields.logSeverity = plog.SeverityNumberDebug.String()
+		}
+	}
 	for k, v := range m {
 		if str, ok := v.(string); ok {
 			fields.attrs[k] = str

--- a/backend/otel/systemd.go
+++ b/backend/otel/systemd.go
@@ -1,0 +1,33 @@
+package otel
+
+import "time"
+
+type SystemdKey = string
+
+const UID SystemdKey = "_UID"
+const Cursor SystemdKey = "__CURSOR"
+const MachineID SystemdKey = "_MACHINE_ID"
+const Timestamp SystemdKey = "__MONOTONIC_TIMESTAMP"
+const Transport SystemdKey = "_TRANSPORT"
+const BootID SystemdKey = "_BOOT_ID"
+const PID SystemdKey = "_PID"
+const Hostname SystemdKey = "_HOSTNAME"
+const GID SystemdKey = "_GID"
+const Priority SystemdKey = "PRIORITY"
+const Message SystemdKey = "MESSAGE"
+const StreamID SystemdKey = "_STREAM_ID"
+
+func extractSystemd(fields *extractedFields, m map[string]any) {
+	fields.logBody = m[Message].(string)
+	fields.timestamp = m[Timestamp].(time.Time)
+	fields.attrs["BootID"] = m[BootID].(string)
+	fields.attrs["Cursor"] = m[Cursor].(string)
+	fields.attrs["GID"] = m[GID].(string)
+	fields.attrs["Hostname"] = m[Hostname].(string)
+	fields.attrs["MachineID"] = m[MachineID].(string)
+	fields.attrs["PID"] = m[PID].(string)
+	fields.attrs["Priority"] = m[Priority].(string)
+	fields.attrs["StreamID"] = m[StreamID].(string)
+	fields.attrs["Transport"] = m[Transport].(string)
+	fields.attrs["UID"] = m[UID].(string)
+}

--- a/backend/otel/systemd.go
+++ b/backend/otel/systemd.go
@@ -14,17 +14,11 @@ func extractSystemd(fields *extractedFields, m map[string]any) {
 	fields.logBody = m[Message].(string)
 	if priority, err := strconv.ParseInt(m[Priority].(string), 10, 4); err == nil {
 		switch priority {
-		case 0:
+		case 0, 1:
 			fields.logSeverity = plog.SeverityNumberFatal.String()
-		case 1:
-			fields.logSeverity = plog.SeverityNumberFatal.String()
-		case 2:
+		case 2, 3:
 			fields.logSeverity = plog.SeverityNumberError.String()
-		case 3:
-			fields.logSeverity = plog.SeverityNumberError.String()
-		case 4:
-			fields.logSeverity = plog.SeverityNumberWarn.String()
-		case 5:
+		case 4, 5:
 			fields.logSeverity = plog.SeverityNumberWarn.String()
 		case 6:
 			fields.logSeverity = plog.SeverityNumberInfo.String()

--- a/backend/otel/systemd_test.go
+++ b/backend/otel/systemd_test.go
@@ -11,11 +11,11 @@ func Test_extractSystemd(t *testing.T) {
 		"MESSAGE":               "msg king of flavor",
 		"__CURSOR":              "abc123",
 		"__MONOTONIC_TIMESTAMP": "2353958120941",
-		"PRIORITY":              "Info",
+		"PRIORITY":              "6",
 	}
 	extractSystemd(fields, m)
 	assert.Equal(t, "msg king of flavor", fields.logBody)
-	assert.Equal(t, "priority", fields.logSeverity)
+	assert.Equal(t, "Info", fields.logSeverity)
 	assert.Equal(t, "abc123", fields.attrs["__CURSOR"])
 	assert.Equal(t, "2353958120941", fields.attrs["__MONOTONIC_TIMESTAMP"])
 }

--- a/backend/otel/systemd_test.go
+++ b/backend/otel/systemd_test.go
@@ -11,9 +11,11 @@ func Test_extractSystemd(t *testing.T) {
 		"MESSAGE":               "msg king of flavor",
 		"__CURSOR":              "abc123",
 		"__MONOTONIC_TIMESTAMP": "2353958120941",
+		"PRIORITY":              "Info",
 	}
 	extractSystemd(fields, m)
 	assert.Equal(t, "msg king of flavor", fields.logBody)
+	assert.Equal(t, "priority", fields.logSeverity)
 	assert.Equal(t, "abc123", fields.attrs["__CURSOR"])
 	assert.Equal(t, "2353958120941", fields.attrs["__MONOTONIC_TIMESTAMP"])
 }

--- a/backend/otel/systemd_test.go
+++ b/backend/otel/systemd_test.go
@@ -1,0 +1,19 @@
+package otel
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_extractSystemd(t *testing.T) {
+	fields := newExtractedFields()
+	m := map[string]any{
+		"MESSAGE":               "msg king of flavor",
+		"__CURSOR":              "abc123",
+		"__MONOTONIC_TIMESTAMP": "2353958120941",
+	}
+	extractSystemd(fields, m)
+	assert.Equal(t, "msg king of flavor", fields.logBody)
+	assert.Equal(t, "abc123", fields.attrs["__CURSOR"])
+	assert.Equal(t, "2353958120941", fields.attrs["__MONOTONIC_TIMESTAMP"])
+}

--- a/docs-content/getting-started/backend-logging/10_systemd.md
+++ b/docs-content/getting-started/backend-logging/10_systemd.md
@@ -1,0 +1,9 @@
+---
+title: Systemd / Journald
+slug: systemd
+createdAt: 2022-03-28T20:31:15.000Z
+updatedAt: 2022-04-06T20:22:54.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["backend-logging"]["other"]["systemd"]}/>

--- a/docs-content/getting-started/backend-logging/11_syslog.md
+++ b/docs-content/getting-started/backend-logging/11_syslog.md
@@ -1,0 +1,9 @@
+---
+title: Syslog RFC5424
+slug: syslog
+createdAt: 2022-03-28T20:31:15.000Z
+updatedAt: 2022-04-06T20:22:54.000Z
+quickstart: true
+---
+
+<QuickStart content={quickStartContent["backend-logging"]["other"]["syslog"]}/>

--- a/docs-content/getting-started/backend-logging/6_http.md
+++ b/docs-content/getting-started/backend-logging/6_http.md
@@ -6,4 +6,4 @@ updatedAt: 2022-04-06T20:22:54.000Z
 quickstart: true
 ---
 
-<QuickStart content={quickStartContent["backend-logging"]["http"]["curl"]}/>
+<QuickStart content={quickStartContent["backend-logging"]["other"]["curl"]}/>

--- a/e2e/opentelemetry/filelog/compose.yml
+++ b/e2e/opentelemetry/filelog/compose.yml
@@ -1,5 +1,5 @@
 services:
-    collector:
+    file-collector:
         extra_hosts:
             - 'host.docker.internal:host-gateway'
         container_name: filelog-collector

--- a/e2e/opentelemetry/journald/Dockerfile
+++ b/e2e/opentelemetry/journald/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:latest
+
+RUN apt update
+RUN apt -y install curl systemd rsyslog
+RUN apt clean
+
+RUN curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.86.0/otelcol-contrib_0.86.0_linux_arm64.tar.gz
+RUN tar -xvf otelcol-contrib_0.86.0_linux_arm64.tar.gz
+RUN systemd-tmpfiles --create --prefix /var/log/journal
+
+COPY ./otel-collector.yaml /etc/otel-collector-config.yaml
+
+#CMD ["/otelcol-contrib", "--config=/etc/otel-collector-config.yaml"]

--- a/e2e/opentelemetry/journald/compose.yml
+++ b/e2e/opentelemetry/journald/compose.yml
@@ -1,0 +1,6 @@
+services:
+    journal-collector:
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
+        container_name: filelog-collector
+        build: .

--- a/e2e/opentelemetry/journald/otel-collector.yaml
+++ b/e2e/opentelemetry/journald/otel-collector.yaml
@@ -1,0 +1,31 @@
+receivers:
+    journald:
+        directory: /var/log/journal
+        units:
+            - stratopi-battery
+            - stratopi-location
+            - stratopi-environmental
+        priority: info
+exporters:
+    logging:
+        sampling_initial: 10
+        sampling_thereafter: 1000
+    otlp:
+        endpoint: 'http://host.docker.internal:4317'
+        tls:
+            insecure: true
+    otlp/highlight:
+        endpoint: 'https://otel.highlight.io:4317'
+processors:
+    attributes/highlight-project:
+        actions:
+            - key: highlight.project_id
+              value: '1jdkoe52'
+              action: insert
+    batch:
+service:
+    pipelines:
+        logs:
+            receivers: [journald]
+            processors: [attributes/highlight-project, batch]
+            exporters: [otlp, otlp/highlight, logging]

--- a/e2e/opentelemetry/journald/otel-collector.yaml
+++ b/e2e/opentelemetry/journald/otel-collector.yaml
@@ -1,19 +1,10 @@
 receivers:
     journald:
         directory: /var/log/journal
-        units:
-            - stratopi-battery
-            - stratopi-location
-            - stratopi-environmental
-        priority: info
 exporters:
     logging:
         sampling_initial: 10
         sampling_thereafter: 1000
-    otlp:
-        endpoint: 'http://host.docker.internal:4317'
-        tls:
-            insecure: true
     otlp/highlight:
         endpoint: 'https://otel.highlight.io:4317'
 processors:
@@ -28,4 +19,4 @@ service:
         logs:
             receivers: [journald]
             processors: [attributes/highlight-project, batch]
-            exporters: [otlp, otlp/highlight, logging]
+            exporters: [otlp/highlight, logging]

--- a/go.work.sum
+++ b/go.work.sum
@@ -251,6 +251,7 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/Shopify/sarama v1.22.0 h1:rtiODsvY4jW6nUV6n3K+0gx/8WlAwVt+Ixt6RIvpYyo=
 github.com/Shopify/sarama v1.22.0/go.mod h1:lm3THZ8reqBDBQKQyb5HB3sY1lKp3grEbQ81aWSgPp4=
+github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af h1:wVe6/Ea46ZMeNkQjjBW6xcqyQA/j5e0D6GytH95g0gQ=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
@@ -263,6 +264,7 @@ github.com/armon/go-metrics v0.3.0 h1:B7AQgHi8QSEi4uHu7Sbsga+IJDU+CENgjxoo81vDUq
 github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD+gJD3GYs=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
+github.com/aws/aws-sdk-go v1.34.28 h1:sscPpn/Ns3i0F4HPEWAVcwdIRaZZCuL7llJ2/60yPIk=
 github.com/aws/aws-sdk-go v1.42.27 h1:kxsBXQg3ee6LLbqjp5/oUeDgG7TENFrWYDmEVnd7spU=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.5.4 h1:TnU1cY51027j/MQeFy7DIgk1UuzJY+wLFYqXceY/fiE=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.0.0 h1:k+iXUEMp688JqUcxb4/bzt7xgJX4TLqahrwgWA/qO6E=
@@ -292,6 +294,7 @@ github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054 h1:uH66TXeswKn5P
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0 h1:WW2B2uxx9KWF6bGlHqhm8Okiafwwx7Y2kcpn8lCpjgo=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0 h1:wpFFOoomK3389ue2lAb0Boag6XPht5QYpipxmSNL4d8=
+github.com/cheggaaa/pb/v3 v3.1.0 h1:3uouEsl32RL7gTiQsuaXD4Bzbfl5tGztXGUvXbs4O04=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
@@ -567,6 +570,7 @@ github.com/opencontainers/runc v1.1.3 h1:vIXrkId+0/J2Ymu2m7VjGvbSlAId9XNRPhn2p4b
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39 h1:H7DMc6FAjgwZZi8BRqjrAAHWoqEr5e5L6pS4V0ezet4=
 github.com/opencontainers/selinux v1.10.0 h1:rAiKF8hTcgLI3w0DHm6i0ylVVcOrlgR1kK99DRLDhyU=
+github.com/opensearch-project/opensearch-go v1.0.0 h1:8Gh7B7Un5BxuxWAgmzleEF7lpOtC71pCgPp7lKr3ca8=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c h1:Lgl0gzECD8GnQ5QCWA8o6BtfL6mDH5rQgM4/fX3avOs=
 github.com/pascaldekloe/name v1.0.1 h1:9lnXOHeqeHHnWLbKfH6X98+4+ETVqFqxN09UXSjcMb0=
 github.com/paulmach/protoscan v0.2.1 h1:rM0FpcTjUMvPUNk2BhPJrreDKetq43ChnL+x1sRg8O8=

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -237,22 +237,6 @@ export const quickStartContent = {
 			[QuickStartType.JSPino]: JSPinoHTTPJSONLogContent,
 			[QuickStartType.JSCloudflare]: JSCloudflareLoggingContent,
 		},
-		http: {
-			title: 'HTTPS curl',
-			subtitle:
-				'Get started with logging in your application via HTTP or OTLP.',
-			[QuickStartType.HTTPOTLP]: HTTPContent,
-		},
-		syslog: {
-			title: 'Syslog RFC5424',
-			subtitle: 'Send syslog RFC5424 logs to highlight.io.',
-			[QuickStartType.Syslog]: SyslogContent,
-		},
-		systemd: {
-			title: 'Systemd / Journald',
-			subtitle: 'Send systemd(ctl) / journald(ctl) logs to highlight.io.',
-			[QuickStartType.Systemd]: SystemdContent,
-		},
 		other: {
 			title: 'Infrastructure / Other',
 			subtitle:
@@ -260,6 +244,9 @@ export const quickStartContent = {
 			[QuickStartType.FluentForward]: FluentForwardContent,
 			[QuickStartType.File]: FileContent,
 			[QuickStartType.Docker]: DockerContent,
+			[QuickStartType.HTTPOTLP]: HTTPContent,
+			[QuickStartType.Syslog]: SyslogContent,
+			[QuickStartType.Systemd]: SystemdContent,
 		},
 		ruby: {
 			title: 'Ruby',

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -51,6 +51,7 @@ import { DevDeploymentContent } from './self-host/dev-deploy'
 import { SelfHostContent } from './self-host/self-host'
 import { HostingRenderLogContent } from './logging/hosting/render'
 import { SyslogContent } from './logging/syslog'
+import { SystemdContent } from './logging/systemd'
 import { JSPinoHTTPJSONLogContent } from './logging/js/pino'
 
 export type QuickStartOptions = {
@@ -121,6 +122,7 @@ export enum QuickStartType {
 	JStRPC = 'trpc',
 	HTTPOTLP = 'curl',
 	Syslog = 'syslog',
+	Systemd = 'systemd',
 	FluentForward = 'fluent-forward',
 	Docker = 'docker',
 	File = 'file',
@@ -245,6 +247,11 @@ export const quickStartContent = {
 			title: 'Syslog RFC5424',
 			subtitle: 'Send syslog RFC5424 logs to highlight.io.',
 			[QuickStartType.Syslog]: SyslogContent,
+		},
+		systemd: {
+			title: 'Systemd / Journald',
+			subtitle: 'Send systemd(ctl) / journald(ctl) logs to highlight.io.',
+			[QuickStartType.Systemd]: SystemdContent,
 		},
 		other: {
 			title: 'Infrastructure / Other',

--- a/highlight.io/components/QuickstartContent/logging/systemd.tsx
+++ b/highlight.io/components/QuickstartContent/logging/systemd.tsx
@@ -1,0 +1,63 @@
+import { QuickStartContent } from '../QuickstartContent'
+import { verifyLogs } from './shared-snippets'
+
+export const SystemdContent: QuickStartContent = {
+	title: 'Shipping Systemd Structured Logs',
+	subtitle: 'Configure Systemd to ship logs to highlight.',
+	entries: [
+		{
+			title: 'Install OpenTelemetry Collector Contrib locally',
+			content:
+				'[See here](https://opentelemetry.io/docs/collector/getting-started/#linux-packaging) for instructions on installing the collector. ' +
+				'We assume that systemd/systemctl are already set up. ' +
+				'Check out the following [OpenTelemetry journald receiver docs](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/189a64b21cfd67998b334228a423595591dedae0/receiver/journaldreceiver#setup-and-deployment) ' +
+				'that provide additional guidance on installation.',
+		},
+		{
+			title: 'Define your OpenTelemetry configuration.',
+			content:
+				'Setup the Contrib OpenTelemetry collector. Check out our [example here](https://github.com/highlight/highlight/tree/main/e2e/opentelemetry/journald). ' +
+				'Make sure that the journald directory is correct for your systemd/systemctl setup.',
+			code: [
+				{
+					text: `receivers:
+    journald:
+        directory: /var/log/journal
+exporters:
+    logging:
+        sampling_initial: 10
+        sampling_thereafter: 1000
+    otlp/highlight:
+        endpoint: 'https://otel.highlight.io:4317'
+processors:
+    attributes/highlight-project:
+        actions:
+            - key: highlight.project_id
+              value: '<YOUR_PROJECT_ID>'
+              action: insert
+    batch:
+service:
+    pipelines:
+        logs:
+            receivers: [journald]
+            processors: [attributes/highlight-project, batch]
+            exporters: [otlp/highlight, logging]
+`,
+					language: 'yaml',
+				},
+			],
+		},
+		{
+			title: 'Run the collector',
+			content:
+				'Run the [OpenTelemetry collector](https://opentelemetry.io/docs/collector/getting-started/) to start streaming the logs to highlight.',
+			code: [
+				{
+					text: `./otelcol-contrib --config=config.yaml`,
+					language: 'bash',
+				},
+			],
+		},
+		verifyLogs,
+	],
+}


### PR DESCRIPTION
## Summary

Adds support for ingesting systemd / systemctl logs via the journald receiver.
Adds new documentation for the supported feature.

## How did you test this change?

Docs here https://highlight-landing-git-vadim-journald-highlight-run.vercel.app/docs/getting-started/backend-logging/systemd

<img width="571" alt="Screenshot 2023-09-28 at 5 24 38 PM" src="https://github.com/highlight/highlight/assets/1351531/d209020b-f67c-40f3-aa46-12a690433bd6">

https://www.loom.com/share/35b2e1d1645e4a39baaed2a42097905c

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
