### PR TITLE
Fix command bar click

### DIFF
--- a/frontend/src/components/CommandBar/CommandBar.tsx
+++ b/frontend/src/components/CommandBar/CommandBar.tsx
@@ -249,7 +249,7 @@ const SectionRow = ({
 				searchAttribute(attribute, {
 					withDate:
 						formStore
-							.useValue(formStore.names.selectedDates)[0]
+							.getValue(formStore.names.selectedDates)[0]
 							.getTime() !== last30Days.startDate.getTime(),
 					newTab: e.metaKey || e.ctrlKey,
 				})
@@ -283,7 +283,7 @@ const SectionRow = ({
 				lines="1"
 				cssClass={styles.query}
 			>
-				{formStore.useValue(formStore.names.search).trim()}
+				{formStore.getValue(formStore.names.search).trim()}
 			</Text>
 			{selected ? (
 				<Badge

--- a/frontend/src/components/CommandBar/CommandBar.tsx
+++ b/frontend/src/components/CommandBar/CommandBar.tsx
@@ -283,7 +283,7 @@ const SectionRow = ({
 				lines="1"
 				cssClass={styles.query}
 			>
-				{formStore.getValue(formStore.names.search).trim()}
+				{formStore.useValue(formStore.names.search).trim()}
 			</Text>
 			{selected ? (
 				<Badge


### PR DESCRIPTION
## Summary
Ariakit's `useValue` is a hook that cannot be called inside the bodu of a function component, and causing the `onClick` method to exit early. Update to use `getValue` here, since it will fetch the value when called.

![Screenshot 2023-09-28 at 1 47 29 PM](https://github.com/highlight/highlight/assets/17744174/10a21463-8cc6-4b84-bf83-15422629656e)

## How did you test this change?
1) Open the command bar with `command-k`
2) Search for a field
3) Select the time frame
4) Click on the appropriate option
- [ ] Page is redirected
- [ ] Filter is applied
- [ ] Time is correctly accepted
- [ ] Modal disappears

https://www.loom.com/share/3c15513a77194841b5b7fd05094671e9?sid=d1213027-ef9c-4214-8824-0b35e0a0ab7d

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
