### PR TITLE
use nanosecond precision for traces timestamp

### DIFF
--- a/backend/clickhouse/migrations/000041_create_traces_table_new.down.sql
+++ b/backend/clickhouse/migrations/000041_create_traces_table_new.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS traces_new;

--- a/backend/clickhouse/migrations/000041_create_traces_table_new.up.sql
+++ b/backend/clickhouse/migrations/000041_create_traces_table_new.up.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS traces_new (
+    Timestamp DateTime64(9),
+    UUID UUID,
+    TraceId String,
+    SpanId String,
+    ParentSpanId String,
+    ProjectId UInt32,
+    SecureSessionId String,
+    TraceState String,
+    SpanName LowCardinality(String),
+    SpanKind LowCardinality(String),
+    Duration Int64,
+    ServiceName LowCardinality(String),
+    ServiceVersion String,
+    TraceAttributes Map(LowCardinality(String), String),
+    StatusCode LowCardinality(String),
+    StatusMessage String,
+    Events Nested (
+        Timestamp DateTime64(9),
+        Name LowCardinality(String),
+        Attributes Map(LowCardinality(String), String)
+    ),
+    Links Nested (
+        TraceId String,
+        SpanId String,
+        TraceState String,
+        Attributes Map(LowCardinality(String), String)
+    ),
+    INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_res_attr_key mapKeys(TraceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_value mapValues(TraceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_duration Duration TYPE minmax GRANULARITY 1
+) ENGINE = MergeTree PARTITION BY toDate(Timestamp)
+ORDER BY (ProjectId, Timestamp, UUID) TTL toDateTime(Timestamp) + toIntervalDay(30) SETTINGS index_granularity = 8192,
+    ttl_only_drop_parts = 1,
+    min_age_to_force_merge_seconds = 3600;

--- a/backend/clickhouse/migrations/000042_exchange_traces_tables.down.sql
+++ b/backend/clickhouse/migrations/000042_exchange_traces_tables.down.sql
@@ -1,0 +1,2 @@
+EXCHANGE TABLES traces
+AND traces_new;

--- a/backend/clickhouse/migrations/000042_exchange_traces_tables.up.sql
+++ b/backend/clickhouse/migrations/000042_exchange_traces_tables.up.sql
@@ -1,0 +1,2 @@
+EXCHANGE TABLES traces
+AND traces_new;


### PR DESCRIPTION
## Summary
- replaces timestamp columns with DateTime64(9) for nanosecond precision
  - it seems we save with microsecond (6) precision right now, not sure if this can/will change in the future, but the only downside to using a higher precision column is a more limited range of dates (up to `2262-04-11 23:47:16`)
- copies the partitioning and `min_age_to_force_merge_seconds` settings from logs table as this seems to improve performance compared to no partitioning
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran migration scripts, validated data was inserted and queryable without code changes
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, old traces can be copied to this new table after deploying
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
