### PR TITLE
fix console dev tools goto button

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
@@ -223,11 +223,8 @@ const ErrorInstancesContainer: React.FC<
 								size="xxSmall"
 								iconLeft={<IconSolidCheckCircle size={12} />}
 								checked={hasSession}
-								onChange={() => {
-									form.setValue(
-										form.names.hasSession,
-										!hasSession,
-									)
+								onChange={(state) => {
+									form.setValue(form.names.hasSession, state)
 								}}
 							/>
 							<Text size="xSmall">

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstances.tsx
@@ -223,8 +223,11 @@ const ErrorInstancesContainer: React.FC<
 								size="xxSmall"
 								iconLeft={<IconSolidCheckCircle size={12} />}
 								checked={hasSession}
-								onChange={(state) => {
-									form.setValue(form.names.hasSession, state)
+								onChange={() => {
+									form.setValue(
+										form.names.hasSession,
+										!hasSession,
+									)
 								}}
 							/>
 							<Text size="xSmall">

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -43,7 +43,8 @@ export const ConsolePage = ({
 }) => {
 	const { projectId } = useProjectId()
 	const [selectedCursor, setSelectedCursor] = useState(logCursor)
-	const { session, time, isPlayerReady } = useReplayerContext()
+	const { session, time, setTime, sessionMetadata, isPlayerReady } =
+		useReplayerContext()
 
 	const params = buildSessionParams({ session, levels, sources })
 
@@ -158,6 +159,11 @@ export const ConsolePage = ({
 							current={selectedCursor === logEdge.cursor}
 							onSelect={() => {
 								setSelectedCursor(logEdge.cursor)
+								const timestamp =
+									new Date(
+										messagesToRender[_index].node.timestamp,
+									).getTime() - sessionMetadata.startTime
+								setTime(timestamp)
 							}}
 						/>
 					)}


### PR DESCRIPTION
## Summary

Fix console page of dev tools `go to` button not working.

## How did you test this change?

[Reflame preview](https://preview.highlight.io/1/sessions?page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue%7C%7Ccustom_created_at%2Cbetween_date%2C2023-08-29T18%3A45%3A17.134Z_2023-09-28T18%3A45%3A17.134Z&%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HBEH7FJJYG79YRZDJHNBJS1Z%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%226710-memory-issue-w-goto-button%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D) clicking goto.

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No