### PR TITLE
Attempting to repair npm published package

### DIFF
--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -90,3 +90,13 @@
 
 - Excised `@protobufjs/inquire` from the build to eliminate console warnings and repair the Edge runtime wrapper
 - Exported `getHighlightErrorInitialProps` to streamline configuring `pages/_error.tsx`
+
+### 4.4.2
+
+### Patch changes
+
+- Export types.
+- Downgrade `@opentelemetry/api` to avoid peer dependency issue. Also, it turns out that v1.4.1 is identical to v1.6.0 due to a revert.
+- Move `@opentelemetry/api` and `@opentelemetry/resources` to `devDependencies`
+- Repair `use-client` declaration
+- Bundle `@highlight-run/sourcemap-uploader`

--- a/sdk/highlight-next/bin/clean-dist.sh
+++ b/sdk/highlight-next/bin/clean-dist.sh
@@ -1,5 +1,5 @@
-sed -i '' '/"use client";/d' dist/next-client.js
-sed -i '' '/"use client";/d' dist/next-client.cjs
+sed -i '/"use client";/d;' dist/next-client.js
+sed -i '/"use client";/d;' dist/next-client.cjs
 
 printf '%s \n%s' '"use client";' "$(cat dist/next-client.js)" > dist/next-client.js
 printf '%s \n%s' '"use client";' "$(cat dist/next-client.cjs)" > dist/next-client.cjs

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,11 +1,12 @@
 {
 	"name": "@highlight-run/next",
-	"version": "4.4.1",
+	"version": "4.4.2",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",
-		"next-client.d.ts",
-		"server.d.ts"
+		"client.d.ts",
+		"server.d.ts",
+		"types.d.ts"
 	],
 	"exports": {
 		"./server": {
@@ -51,11 +52,11 @@
 		"@highlight-run/opentelemetry-sdk-workers": "workspace:*",
 		"@highlight-run/react": "workspace:*",
 		"@highlight-run/sourcemap-uploader": "workspace:*",
-		"@opentelemetry/api": "^1.6.0",
-		"@opentelemetry/resources": "1.17.0",
 		"highlight.run": "workspace:*"
 	},
 	"devDependencies": {
+		"@opentelemetry/api": "1.4.1",
+		"@opentelemetry/resources": "1.17.0",
 		"@trpc/server": "^9.27.4",
 		"@types/jest": "27.4.1",
 		"chokidar-cli": "^3.0.0",

--- a/sdk/highlight-next/tsup.config.ts
+++ b/sdk/highlight-next/tsup.config.ts
@@ -5,4 +5,5 @@ export default defineConfig({
 	format: ['cjs', 'esm'],
 	dts: true,
 	sourcemap: true,
+	noExternal: ['@highlight-run/sourcemap-uploader'],
 })

--- a/sdk/highlight-node/CHANGELOG.md
+++ b/sdk/highlight-node/CHANGELOG.md
@@ -117,3 +117,9 @@
 
 - Excised `@protobufjs/inquire` from the build to eliminate console warnings
 - Included `@opentelemetry/*` packages in build to bundle the `ansi-color` patch and create a more deterministic build.
+
+## 3.4.2
+
+### Patch Changes
+
+- Downgrade `@opentelemetry/api` to avoid peer dependency issue. Also, it turns out that v1.4.1 is identical to v1.6.0 due to a revert.

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/node",
-	"version": "3.4.1",
+	"version": "3.4.2",
 	"license": "Apache-2.0",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -25,7 +25,7 @@
 		"access": "public"
 	},
 	"dependencies": {
-		"@opentelemetry/api": "1.6.0",
+		"@opentelemetry/api": "1.4.1",
 		"@opentelemetry/auto-instrumentations-node": "0.39.2",
 		"@opentelemetry/core": "1.17.0",
 		"@opentelemetry/exporter-trace-otlp-http": "0.43.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12529,7 +12529,7 @@ __metadata:
     "@highlight-run/opentelemetry-sdk-workers": "workspace:*"
     "@highlight-run/react": "workspace:*"
     "@highlight-run/sourcemap-uploader": "workspace:*"
-    "@opentelemetry/api": ^1.6.0
+    "@opentelemetry/api": 1.4.1
     "@opentelemetry/resources": 1.17.0
     "@trpc/server": ^9.27.4
     "@types/jest": 27.4.1
@@ -12553,7 +12553,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@highlight-run/node@workspace:sdk/highlight-node"
   dependencies:
-    "@opentelemetry/api": 1.6.0
+    "@opentelemetry/api": 1.4.1
     "@opentelemetry/auto-instrumentations-node": 0.39.2
     "@opentelemetry/core": 1.17.0
     "@opentelemetry/exporter-trace-otlp-http": 0.43.0


### PR DESCRIPTION
- Repairing the client import by publishing `client.d.ts`
- Repair `clean-dist.sh`
- Internalize `@highlight-run/sourcemap-uploader`
- Downgrade `@opentelemetry/api`


closes #6747 closes #6692 