### PR TITLE
Fix ariakit menu z-index

### DIFF
--- a/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
@@ -10,6 +10,7 @@ import {
 	SelectLabel,
 	SelectPopover,
 	PopoverArrow,
+	Portal,
 } from '@ariakit/react'
 
 import { IconSolidCheckCircle, IconSolidSearch } from '../icons'
@@ -112,75 +113,82 @@ export const ComboboxSelect = <T extends string | string[]>({
 					</Text>
 				)}
 			</Select>
-			<SelectPopover
-				store={select}
-				className={styles.selectPopover}
-				gutter={4}
-				autoFocusOnHide={false}
-			>
-				<PopoverArrow size={0} />
-				<div
-					className={clsx(styles.comboboxWrapper, {
-						[styles.comboboxHasResults]:
-							allOptions.length > 0 || isLoading,
-					})}
+			<Portal>
+				<SelectPopover
+					store={select}
+					className={styles.selectPopover}
+					gutter={4}
+					autoFocusOnHide={false}
 				>
-					<IconSolidSearch />
-					<Combobox
+					<PopoverArrow size={0} />
+					<div
+						className={clsx(styles.comboboxWrapper, {
+							[styles.comboboxHasResults]:
+								allOptions.length > 0 || isLoading,
+						})}
+					>
+						<IconSolidSearch />
+						<Combobox
+							store={combobox}
+							type="text"
+							autoSelect
+							autoComplete="none"
+							placeholder={queryPlaceholder}
+							className={styles.combobox}
+						></Combobox>
+					</div>
+					<ComboboxList
 						store={combobox}
-						type="text"
-						autoSelect
-						autoComplete="none"
-						placeholder={queryPlaceholder}
-						className={styles.combobox}
-					></Combobox>
-				</div>
-				<ComboboxList
-					store={combobox}
-					className={clsx([styles.comboboxList, 'hide-scrollbar'])}
-				>
-					{isLoading && (
-						<div
-							className={clsx([
-								styles.selectItem,
-								styles.loadingPlaceholder,
-							])}
-						>
-							{loadingRender}
-						</div>
-					)}
-					{select.useState('open') &&
-						allOptions.map((option: Option) => (
-							<ComboboxItem
-								focusOnHover
-								key={option.key}
-								className={styles.selectItem}
-								render={
-									<SelectItem value={option.key}>
-										{isMultiselect && (
-											<div
-												className={styles.checkbox}
-												style={{
-													backgroundColor:
-														valueSet.has(option.key)
-															? vars.theme
-																	.interactive
-																	.fill
-																	.primary
-																	.enabled
-															: 'white',
-												}}
-											>
-												<IconSolidCheckCircle color="white" />
-											</div>
-										)}
-										{option.render}
-									</SelectItem>
-								}
-							></ComboboxItem>
-						))}
-				</ComboboxList>
-			</SelectPopover>
+						className={clsx([
+							styles.comboboxList,
+							'hide-scrollbar',
+						])}
+					>
+						{isLoading && (
+							<div
+								className={clsx([
+									styles.selectItem,
+									styles.loadingPlaceholder,
+								])}
+							>
+								{loadingRender}
+							</div>
+						)}
+						{select.useState('open') &&
+							allOptions.map((option: Option) => (
+								<ComboboxItem
+									focusOnHover
+									key={option.key}
+									className={styles.selectItem}
+									render={
+										<SelectItem value={option.key}>
+											{isMultiselect && (
+												<div
+													className={styles.checkbox}
+													style={{
+														backgroundColor:
+															valueSet.has(
+																option.key,
+															)
+																? vars.theme
+																		.interactive
+																		.fill
+																		.primary
+																		.enabled
+																: 'white',
+													}}
+												>
+													<IconSolidCheckCircle color="white" />
+												</div>
+											)}
+											{option.render}
+										</SelectItem>
+									}
+								></ComboboxItem>
+							))}
+					</ComboboxList>
+				</SelectPopover>
+			</Portal>
 		</div>
 	)
 }

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -64,21 +64,23 @@ const List: React.FC<ListProps> = ({ children, cssClass, ...props }) => {
 	const menu = useMenu()
 
 	return (
-		<Ariakit.Menu
-			store={menu}
-			gutter={4}
-			className={clsx(styles.menuList, cssClass)}
-			{...props}
-		>
-			{/*
+		<Ariakit.Portal>
+			<Ariakit.Menu
+				store={menu}
+				gutter={4}
+				className={clsx(styles.menuList, cssClass)}
+				{...props}
+			>
+				{/*
 			There is a bug in v0.2.17 of Ariakit where you need to have this arrow
 			rendered or else positioning of the popover breaks. We render it, but hide
 			it by setting size={0}. This is an issue with anything using a popover
 			coming from the floating-ui library.
 			*/}
-			<Ariakit.MenuArrow size={0} />
-			{children}
-		</Ariakit.Menu>
+				<Ariakit.MenuArrow size={0} />
+				{children}
+			</Ariakit.Menu>
+		</Ariakit.Portal>
 	)
 }
 


### PR DESCRIPTION
**Suggestion: Review hiding whitespace**

## Summary
Menu's are being displayed underneath relatively positioned components rendered further down in the down. Render the aria kit menu in a portal that will render the menu in the bottom of the dom.

<img width="588" alt="Screenshot 2023-09-29 at 11 12 53 AM" src="https://github.com/highlight/highlight/assets/17744174/1833a8d7-06df-4fd3-8547-60ef0e365f85">

## How did you test this change?
1) View the errors page
2) Make your screen width small enough so the error title is as close to the left panel as it can be
3) Open the segments popover
4) Scroll up and down with the popover open
- [ ] No components in the error details are displayed over the content
5) Add a filter and open the combobox to select a value
6) Scroll up and down with the combobox open
- [ ] No components in the error details are displayed over the content
7) Repeat for other menus (e.g. header menus)
- [ ] No difference in behavior/accessibility
- [ ] Menus are rendered over all other content

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
