### PR TITLE
save session properties as fields

### DIFF
--- a/backend/migrations/cmd/backfill-session-properties-clickhouse/main.go
+++ b/backend/migrations/cmd/backfill-session-properties-clickhouse/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	kafka_queue "github.com/highlight-run/highlight/backend/kafka-queue"
+	"github.com/highlight-run/highlight/backend/model"
+	public "github.com/highlight-run/highlight/backend/public-graph/graph"
+	"github.com/highlight-run/highlight/backend/redis"
+	"github.com/highlight-run/highlight/backend/store"
+	"github.com/openlyinc/pointy"
+	"github.com/samber/lo"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const SessionsMaxRowsPostgres = 500
+
+func main() {
+	ctx := context.Background()
+
+	db, err := model.SetupDB(ctx, os.Getenv("PSQL_DB"))
+	if err != nil {
+		log.WithContext(ctx).Fatalf("error setting up db: %+v", err)
+	}
+
+	log.WithContext(ctx).Info("set up clients")
+
+	kafkaDataSyncProducer := kafka_queue.New(ctx,
+		kafka_queue.GetTopic(kafka_queue.GetTopicOptions{Type: kafka_queue.TopicTypeDataSync}),
+		kafka_queue.Producer, &kafka_queue.ConfigOverride{Async: pointy.Bool(true)})
+
+	redisClient := redis.NewClient()
+
+	publicResolver := &public.Resolver{
+		DB:            db,
+		DataSyncQueue: kafkaDataSyncProducer,
+		Store:         store.NewStore(db, redisClient, nil, nil, kafkaDataSyncProducer),
+	}
+
+	var sessionIds []int
+	if err := db.Raw(`
+		SELECT id
+		FROM sessions
+		WHERE created_at >= now() - interval '5 days'
+	`).Scan(&sessionIds).Error; err != nil {
+		log.WithContext(ctx).Fatal(err)
+	}
+
+	log.WithContext(ctx).Infof("got %d sessions", sessionIds)
+
+	sessionIdChunks := lo.Chunk(lo.Uniq(sessionIds), SessionsMaxRowsPostgres)
+	if len(sessionIdChunks) > 0 {
+		for idx, chunk := range sessionIdChunks {
+			log.WithContext(ctx).Infof("running chunk %d of %d", idx+1, len(sessionIdChunks))
+
+			sessionObjs := []*model.Session{}
+			if err := db.Model(&model.Session{}).Where("id in ?", chunk).Find(&sessionObjs).Error; err != nil {
+				log.WithContext(ctx).Fatal(err)
+			}
+
+			for _, session := range sessionObjs {
+				if err := publicResolver.IndexSessionClickhouse(ctx, session); err != nil {
+					log.WithContext(ctx).Fatal(err)
+				}
+			}
+		}
+	}
+}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
-	"go.opentelemetry.io/otel/trace"
 	"hash/fnv"
 	"io"
 	"net/http"
@@ -16,6 +14,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/PaesslerAG/jsonpath"
 	"github.com/aws/smithy-go/ptr"
@@ -956,6 +957,24 @@ func GetDeviceDetails(userAgentString string) (deviceDetails DeviceDetails) {
 	return deviceDetails
 }
 
+func (r *Resolver) IndexSessionClickhouse(ctx context.Context, session *model.Session) error {
+	sessionProperties := map[string]string{
+		"os_name":         session.OSName,
+		"os_version":      session.OSVersion,
+		"browser_name":    session.BrowserName,
+		"browser_version": session.BrowserVersion,
+		"environment":     session.Environment,
+		"device_id":       strconv.Itoa(session.Fingerprint),
+		"city":            session.City,
+		"country":         session.Country,
+		"ip":              session.IP,
+	}
+	if err := r.AppendProperties(ctx, session.ID, sessionProperties, PropertyType.SESSION); err != nil {
+		log.WithContext(ctx).Error(e.Wrap(err, "error adding set of properties to db"))
+	}
+	return r.DataSyncQueue.Submit(ctx, strconv.Itoa(session.ID), &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: session.ID}})
+}
+
 func (r *Resolver) getExistingSession(ctx context.Context, projectID int, secureID string) (*model.Session, error) {
 	existingSessionObj := &model.Session{}
 	if err := r.DB.Model(&existingSessionObj).Where(&model.Session{SecureID: secureID}).Take(&existingSessionObj).Error; err != nil {
@@ -1004,12 +1023,7 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 		return nil, err
 	}
 	if existingSession != nil {
-		if err := r.DataSyncQueue.Submit(ctx,
-			strconv.Itoa(existingSession.ID),
-			&kafka_queue.Message{
-				Type: kafka_queue.SessionDataSync,
-				SessionDataSync: &kafka_queue.SessionDataSyncArgs{
-					SessionID: existingSession.ID}}); err != nil {
+		if err := r.IndexSessionClickhouse(ctx, existingSession); err != nil {
 			return nil, err
 		}
 
@@ -1187,12 +1201,7 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 		log.WithContext(ctx).Errorf("failed to count sessions metric for %s: %s", session.SecureID, err)
 	}
 
-	if err := r.DataSyncQueue.Submit(ctx,
-		strconv.Itoa(session.ID),
-		&kafka_queue.Message{
-			Type: kafka_queue.SessionDataSync,
-			SessionDataSync: &kafka_queue.SessionDataSyncArgs{
-				SessionID: session.ID}}); err != nil {
+	if err := r.IndexSessionClickhouse(ctx, session); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
- this was inadvertently removed when removing opensearch
- session properties should be converted into fields and saved in the `session_fields` table
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested `country is United States` filter locally
- tested backfill script locally and verified more sessions were added with `country is United States`
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will run backfill script after deploying
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
