### PR TITLE
support ingesting logs from fluent bit

### DIFF
--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -272,6 +272,8 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 			project := fluentProjectPattern.FindStringSubmatch(tag)
 			if project != nil {
 				fields.projectID = project[1]
+			} else {
+				fields.projectID = tag
 			}
 			delete(fields.attrs, "fluent.tag")
 		}

--- a/highlight.io/components/QuickstartContent/logging/fluentd.tsx
+++ b/highlight.io/components/QuickstartContent/logging/fluentd.tsx
@@ -39,7 +39,7 @@ export const FluentForwardContent: QuickStartContent = {
 [FILTER]
     Name                record_modifier
     Match               *
-    Record              hostname ${HOSTNAME}
+    Record              hostname my-hostname
 
 [OUTPUT]
     Name                forward

--- a/highlight.io/components/QuickstartContent/logging/fluentd.tsx
+++ b/highlight.io/components/QuickstartContent/logging/fluentd.tsx
@@ -19,6 +19,39 @@ export const FluentForwardContent: QuickStartContent = {
 			],
 		},
 		{
+			title: 'Running the fluent agent.',
+			content:
+				'You may be running a fluent agent locally or [in docker](https://hub.docker.com/r/fluent/fluent-bit/). In that case, you would use the fluent-bit.conf',
+			code: [
+				{
+					text: `[INPUT]
+    name                tail
+    tag                 <YOUR_PROJECT_ID>
+    path                /var/log/your_log_file.log
+    path_key            file_path
+
+[INPUT]
+    name                tail
+    tag                 <YOUR_PROJECT_ID>
+    path                /var/log/nginx/another_log_file.txt
+    path_key            file_path
+
+[FILTER]
+    Name                record_modifier
+    Match               *
+    Record              hostname ${HOSTNAME}
+
+[OUTPUT]
+    Name                forward
+    Match               *
+    Host                otel.highlight.io
+    Port                24224
+`,
+					language: 'yaml',
+				},
+			],
+		},
+		{
 			title: 'Setting up for AWS ECS?',
 			content:
 				'If you are setting up for AWS Elastic Container Services, check out our dedicated [docs for AWS ECS.](/docs/getting-started/backend-logging/hosting/aws#aws-ecs-containers) .',


### PR DESCRIPTION
## Summary

Fixes fluent bit ingest for other non-docker agents that report the tag without a wrapper.
Adds documentation for running the fluent bit agent with a configuration file.

## How did you test this change?

Running fluent bit docker image locally with config file.
<img width="726" alt="Screenshot 2023-09-29 at 2 14 45 PM" src="https://github.com/highlight/highlight/assets/1351531/87b2d953-d9b3-49e3-9af2-6990c2431f3d">


## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
