### PR TITLE
Repairing withHighlightConfig

### DIFF
--- a/docs-content/getting-started/fullstack-frameworks/next-js.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js.md
@@ -393,7 +393,7 @@ If you use a `next.config.js` file:
 
 ```javascript
 // next.config.js
-const { withHighlightConfig } = require('@highlight-run/next/server')
+const { withHighlightConfig } = require('@highlight-run/next/config')
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/docs-content/sdk/nextjs.md
+++ b/docs-content/sdk/nextjs.md
@@ -44,18 +44,18 @@ quickstart: true
   </div>
   <div className="right">
     <code>
-      import { Highlight } from "@highlight-run/next";
+      import { PageRouterHighlight } from "@highlight-run/next/server";
  
-      export const withHighlight = Highlight({projectID: '<YOUR_PROJECT_ID>'});
+      export const withPageRouterHighlight = PageRouterHighlight({projectID: '<YOUR_PROJECT_ID>'});
     </code>
     <code>
-      import { withHighlight } from "../highlight.config";
+      import { withPageRouterHighlight } from "../highlight.config";
  
       const handler = async (req, res) => {
         res.status(200).json({ name: "Jay" });
       };
  
-      export default withHighlight(handler);
+      export default withPageRouterHighlight(handler);
     </code>
   </div>
 </section>
@@ -97,7 +97,7 @@ quickstart: true
   <div className="right">
     <code>
       
-      import { withHighlightConfig } from "@highlight-run/next";
+      import { withHighlightConfig } from "@highlight-run/next/config";
       export default withHighlightConfig({
         // your next.config.js options here
 

--- a/e2e/nextjs/README.md
+++ b/e2e/nextjs/README.md
@@ -228,7 +228,7 @@ Make sure to implement `nextConfig.generateBuildId` so that our sourcemap upload
 ```javascript
 // next.config.js
 const nextBuildId = require('next-build-id')
-const { withHighlightConfig } = require('@highlight-run/next/server')
+const { withHighlightConfig } = require('@highlight-run/next/config')
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/e2e/nextjs/next.config.mjs
+++ b/e2e/nextjs/next.config.mjs
@@ -1,4 +1,6 @@
 // next.config.mjs
+import { withHighlightConfig } from '@highlight-run/next/config'
+
 const nextConfig = {
 	experimental: {
 		appDir: true,
@@ -8,4 +10,4 @@ const nextConfig = {
 	images: { domains: ['i.travelapi.com'] },
 }
 
-export default nextConfig
+export default withHighlightConfig(nextConfig)

--- a/highlight.io/next.config.js
+++ b/highlight.io/next.config.js
@@ -1,5 +1,5 @@
 const { withAxiom } = require('next-axiom')
-const { withHighlightConfig } = require('@highlight-run/next/server')
+const { withHighlightConfig } = require('@highlight-run/next/config')
 const getStaticPages = require('./scripts/get-static-pages')
 
 /** @type {import('next').NextConfig} */

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -100,3 +100,9 @@
 - Move `@opentelemetry/api` and `@opentelemetry/resources` to `devDependencies`
 - Repair `use-client` declaration
 - Bundle `@highlight-run/sourcemap-uploader`
+
+### 5.0.0
+
+### Major changes
+
+-Moved `withHighlightConfig` to `@highlight-run/next/config` to repair bundle issues

--- a/sdk/highlight-next/config.d.ts
+++ b/sdk/highlight-next/config.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/server'

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -5,6 +5,7 @@
 	"files": [
 		"dist",
 		"client.d.ts",
+		"config.d.ts",
 		"server.d.ts",
 		"types.d.ts"
 	],
@@ -22,6 +23,11 @@
 			"types": "./dist/next-client.d.ts",
 			"import": "./dist/next-client.js",
 			"require": "./dist/next-client.cjs"
+		},
+		"./config": {
+			"types": "./dist/config.d.ts",
+			"import": "./dist/config.js",
+			"require": "./dist/config.cjs"
 		}
 	},
 	"type": "module",
@@ -60,6 +66,7 @@
 		"@trpc/server": "^9.27.4",
 		"@types/jest": "27.4.1",
 		"chokidar-cli": "^3.0.0",
+		"cross-fetch": "^3.1.5",
 		"eslint": "8.39.0",
 		"jest": "^29.2.0",
 		"next": "^13.3.4",

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "4.4.2",
+	"version": "5.0.0",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -66,7 +66,6 @@
 		"@trpc/server": "^9.27.4",
 		"@types/jest": "27.4.1",
 		"chokidar-cli": "^3.0.0",
-		"cross-fetch": "^3.1.5",
 		"eslint": "8.39.0",
 		"jest": "^29.2.0",
 		"next": "^13.3.4",

--- a/sdk/highlight-next/src/config.ts
+++ b/sdk/highlight-next/src/config.ts
@@ -1,0 +1,1 @@
+export { withHighlightConfig } from './util/withHighlightConfig'

--- a/sdk/highlight-next/src/server.ts
+++ b/sdk/highlight-next/src/server.ts
@@ -4,7 +4,6 @@ import * as withHighlightNodeJsAppRouter from './util/with-highlight-nodejs-app-
 import type { HighlightEnv } from './util/types'
 
 export { registerHighlight } from './util/registerHighlight'
-export { withHighlightConfig } from './util/withHighlightConfig'
 export type { HighlightEnv } from './util/types'
 import type {
 	EdgeHandler,

--- a/sdk/highlight-next/tsup.config.ts
+++ b/sdk/highlight-next/tsup.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-	entry: ['src/server.edge.ts', 'src/server.ts', 'src/next-client.tsx'],
+	entry: [
+		'src/next-client.tsx',
+		'src/config.ts',
+		'src/server.edge.ts',
+		'src/server.ts',
+	],
 	format: ['cjs', 'esm'],
 	dts: true,
 	sourcemap: true,
-	noExternal: ['@highlight-run/sourcemap-uploader'],
+	noExternal: [],
 })

--- a/sourcemap-uploader/package.json
+++ b/sourcemap-uploader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@highlight-run/sourcemap-uploader",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Command line tool to upload source maps to Highlight",
   "bin": "./dist/index.js",
   "author": "Highlight",

--- a/sourcemap-uploader/package.json
+++ b/sourcemap-uploader/package.json
@@ -6,23 +6,24 @@
   "author": "Highlight",
   "license": "Apache-2.0",
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
     "./dist/lib": {
-      "require": "./dist/lib.js",
-      "import": "./dist/lib.mjs",
+      "require": "./dist/lib.cjs",
+      "import": "./dist/lib.js",
       "types": "./dist/lib.d.ts"
     }
   },
   "scripts": {
     "typegen": "tsup src/index.ts src/lib.ts --dts-only",
-    "build": "tsup src/index.ts src/lib.ts --format cjs,esm --dts"
+    "build": "tsup"
   },
   "installConfig": {
     "hoistingLimits": "workspaces"

--- a/sourcemap-uploader/tsup.config.ts
+++ b/sourcemap-uploader/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/lib.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  sourcemap: true,
+  noExternal: ["glob"],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -12534,6 +12534,7 @@ __metadata:
     "@trpc/server": ^9.27.4
     "@types/jest": 27.4.1
     chokidar-cli: ^3.0.0
+    cross-fetch: ^3.1.5
     eslint: 8.39.0
     highlight.run: "workspace:*"
     jest: ^29.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -12534,7 +12534,6 @@ __metadata:
     "@trpc/server": ^9.27.4
     "@types/jest": 27.4.1
     chokidar-cli: ^3.0.0
-    cross-fetch: ^3.1.5
     eslint: 8.39.0
     highlight.run: "workspace:*"
     jest: ^29.2.0


### PR DESCRIPTION
## Summary

Closes #6747 

`withHighlightConfig` was exported by `@highlight-run/next/server`, which also exported some Node packages that were incompatible with `next.config.js`.

This PR moves `withHighlightConfig` to ``@highlight-run/next/config` to remove those excess dependencies. 

`withHighlightConfig` also relies on `@highlight-run/sourcemap-uploader`, which had some bundling issues that are also resovled in this PR.

## How did you test this change?

Local test with `yarn e2e:nextjs`. Vercel test with `cd e2e/nextjs && yarn deploy`.

## Are there any deployment considerations?

Major bump to `@highlight-run/next` and minor bump to `@highlight-run/sourcemap-uploader`

## Does this work require review from our design team?

Nope.