### PR TITLE
Fix aria kit menu z index

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6196,6 +6196,10 @@ body {
   width: 100%;
 }
 ._75g8nf1 {
+  position: relative;
+  z-index: 98;
+}
+._75g8nf2 {
   background-color: #f9f8f9;
   display: flex;
   flex-direction: column;
@@ -6203,7 +6207,7 @@ body {
   height: 100%;
   padding: 8px;
 }
-._75g8nf2 {
+._75g8nf3 {
   background: white;
   border-radius: 4px;
   display: flex;
@@ -6212,15 +6216,15 @@ body {
   overflow-y: scroll;
   width: 100%;
 }
-._75g8nf3 {
+._75g8nf4 {
   display: flex;
   gap: var(--size-medium);
   margin-top: var(--size-medium);
 }
-._75g8nf4 {
+._75g8nf5 {
   margin-left: 340px;
 }
-._75g8nf5 {
+._75g8nf6 {
   border: 0 !important;
   border-radius: 0;
 }

--- a/frontend/src/__generated/ve/pages/ErrorsV2/styles.css.js
+++ b/frontend/src/__generated/ve/pages/ErrorsV2/styles.css.js
@@ -1,1 +1,1 @@
-var r="_75g8nf0",e="_75g8nf1",t="_75g8nf2",o="_75g8nf3",n="_75g8nf4",a="_75g8nf5";export{r as container,e as detailsContainer,t as errorDetails,o as errorMetrics,n as moveDetailsRight,a as sessionSwitchButton};
+var r="_75g8nf0",e="_75g8nf2",t="_75g8nf3",n="_75g8nf4",a="_75g8nf5",o="_75g8nf1",i="_75g8nf6";export{r as container,e as detailsContainer,t as errorDetails,n as errorMetrics,a as moveDetailsRight,o as searchPanelContainer,i as sessionSwitchButton};

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -141,7 +141,11 @@ export default function ErrorsV2() {
 			</Helmet>
 
 			<Box cssClass={styles.container}>
-				{!isBlocked && <SearchPanel />}
+				{!isBlocked && (
+					<Box cssClass={styles.searchPanelContainer}>
+						<SearchPanel />
+					</Box>
+				)}
 
 				<div
 					className={clsx(styles.detailsContainer, {

--- a/frontend/src/pages/ErrorsV2/styles.css.ts
+++ b/frontend/src/pages/ErrorsV2/styles.css.ts
@@ -5,6 +5,11 @@ export const container = style({
 	width: '100%',
 })
 
+export const searchPanelContainer = style({
+	position: 'relative',
+	zIndex: 98,
+})
+
 export const detailsContainer = style({
 	backgroundColor: '#f9f8f9',
 	display: 'flex',

--- a/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
@@ -10,7 +10,6 @@ import {
 	SelectLabel,
 	SelectPopover,
 	PopoverArrow,
-	Portal,
 } from '@ariakit/react'
 
 import { IconSolidCheckCircle, IconSolidSearch } from '../icons'
@@ -113,82 +112,75 @@ export const ComboboxSelect = <T extends string | string[]>({
 					</Text>
 				)}
 			</Select>
-			<Portal>
-				<SelectPopover
-					store={select}
-					className={styles.selectPopover}
-					gutter={4}
-					autoFocusOnHide={false}
+			<SelectPopover
+				store={select}
+				className={styles.selectPopover}
+				gutter={4}
+				autoFocusOnHide={false}
+			>
+				<PopoverArrow size={0} />
+				<div
+					className={clsx(styles.comboboxWrapper, {
+						[styles.comboboxHasResults]:
+							allOptions.length > 0 || isLoading,
+					})}
 				>
-					<PopoverArrow size={0} />
-					<div
-						className={clsx(styles.comboboxWrapper, {
-							[styles.comboboxHasResults]:
-								allOptions.length > 0 || isLoading,
-						})}
-					>
-						<IconSolidSearch />
-						<Combobox
-							store={combobox}
-							type="text"
-							autoSelect
-							autoComplete="none"
-							placeholder={queryPlaceholder}
-							className={styles.combobox}
-						></Combobox>
-					</div>
-					<ComboboxList
+					<IconSolidSearch />
+					<Combobox
 						store={combobox}
-						className={clsx([
-							styles.comboboxList,
-							'hide-scrollbar',
-						])}
-					>
-						{isLoading && (
-							<div
-								className={clsx([
-									styles.selectItem,
-									styles.loadingPlaceholder,
-								])}
-							>
-								{loadingRender}
-							</div>
-						)}
-						{select.useState('open') &&
-							allOptions.map((option: Option) => (
-								<ComboboxItem
-									focusOnHover
-									key={option.key}
-									className={styles.selectItem}
-									render={
-										<SelectItem value={option.key}>
-											{isMultiselect && (
-												<div
-													className={styles.checkbox}
-													style={{
-														backgroundColor:
-															valueSet.has(
-																option.key,
-															)
-																? vars.theme
-																		.interactive
-																		.fill
-																		.primary
-																		.enabled
-																: 'white',
-													}}
-												>
-													<IconSolidCheckCircle color="white" />
-												</div>
-											)}
-											{option.render}
-										</SelectItem>
-									}
-								></ComboboxItem>
-							))}
-					</ComboboxList>
-				</SelectPopover>
-			</Portal>
+						type="text"
+						autoSelect
+						autoComplete="none"
+						placeholder={queryPlaceholder}
+						className={styles.combobox}
+					></Combobox>
+				</div>
+				<ComboboxList
+					store={combobox}
+					className={clsx([styles.comboboxList, 'hide-scrollbar'])}
+				>
+					{isLoading && (
+						<div
+							className={clsx([
+								styles.selectItem,
+								styles.loadingPlaceholder,
+							])}
+						>
+							{loadingRender}
+						</div>
+					)}
+					{select.useState('open') &&
+						allOptions.map((option: Option) => (
+							<ComboboxItem
+								focusOnHover
+								key={option.key}
+								className={styles.selectItem}
+								render={
+									<SelectItem value={option.key}>
+										{isMultiselect && (
+											<div
+												className={styles.checkbox}
+												style={{
+													backgroundColor:
+														valueSet.has(option.key)
+															? vars.theme
+																	.interactive
+																	.fill
+																	.primary
+																	.enabled
+															: 'white',
+												}}
+											>
+												<IconSolidCheckCircle color="white" />
+											</div>
+										)}
+										{option.render}
+									</SelectItem>
+								}
+							></ComboboxItem>
+						))}
+				</ComboboxList>
+			</SelectPopover>
 		</div>
 	)
 }

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -64,23 +64,21 @@ const List: React.FC<ListProps> = ({ children, cssClass, ...props }) => {
 	const menu = useMenu()
 
 	return (
-		<Ariakit.Portal>
-			<Ariakit.Menu
-				store={menu}
-				gutter={4}
-				className={clsx(styles.menuList, cssClass)}
-				{...props}
-			>
-				{/*
+		<Ariakit.Menu
+			store={menu}
+			gutter={4}
+			className={clsx(styles.menuList, cssClass)}
+			{...props}
+		>
+			{/*
 			There is a bug in v0.2.17 of Ariakit where you need to have this arrow
 			rendered or else positioning of the popover breaks. We render it, but hide
 			it by setting size={0}. This is an issue with anything using a popover
 			coming from the floating-ui library.
 			*/}
-				<Ariakit.MenuArrow size={0} />
-				{children}
-			</Ariakit.Menu>
-		</Ariakit.Portal>
+			<Ariakit.MenuArrow size={0} />
+			{children}
+		</Ariakit.Menu>
 	)
 }
 


### PR DESCRIPTION
## Summary
Had to https://github.com/highlight/highlight/pull/6762 since it caused issues with popovers rendering under the session search panel. Update the Error search panel to have a higher zIndex to match the session search panel.

Note: an alternative solution is to remove the zIndex of the session search panel, but unsure how this could break things

## How did you test this change?
1) View the sessions page
2) Open the popover by search for filters
- [ ] Popover is rendered above to the side panel
- [ ] Popover is rendered above any session details
3) View the errors page
4) Open the popover by search for filters
- [ ] Popover is rendered above to the side panel
- [ ] Popover is rendered above any session details

![Screenshot 2023-10-02 at 4 32 33 PM](https://github.com/highlight/highlight/assets/17744174/85c21564-16b7-4e71-885a-56987310cdfc)

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A