### PR TITLE
fixup! fix nil ptr reference in stripe update (#6780)

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2560,8 +2560,8 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			return e.Wrap(err, "error saving resources data")
 		}
 
-		settings, _ := r.Store.GetAllWorkspaceSettingsByProject(ctx, projectID)
-		if settings.EnableNetworkTraces {
+		settings, err := r.Store.GetAllWorkspaceSettingsByProject(ctx, projectID)
+		if err == nil && settings.EnableNetworkTraces {
 			resourcesParsed := make(map[string][]NetworkResource)
 			if err := json.Unmarshal([]byte(resources), &resourcesParsed); err != nil {
 				return nil

--- a/backend/util/recovery.go
+++ b/backend/util/recovery.go
@@ -1,30 +1,25 @@
 package util
 
 import (
-	"github.com/highlight/highlight/sdk/highlight-go"
 	"os"
 	"runtime"
 
+	"github.com/highlight/highlight/sdk/highlight-go"
 	log "github.com/sirupsen/logrus"
 )
 
-func formatRecover() (any, []byte) {
+func Recover() {
 	if rec := recover(); rec != nil {
 		buf := make([]byte, 64<<10)
 		buf = buf[:runtime.Stack(buf, false)]
-		return rec, buf
-	}
-	return nil, nil
-}
-
-func Recover() {
-	if rec, buf := formatRecover(); rec != nil {
 		log.Errorf("panic: %+v\n%s", rec, buf)
 	}
 }
 
 func RecoverAndCrash() {
-	if rec, buf := formatRecover(); rec != nil {
+	if rec := recover(); rec != nil {
+		buf := make([]byte, 64<<10)
+		buf = buf[:runtime.Stack(buf, false)]
 		log.Errorf("panic: %+v\n%s", rec, buf)
 		highlight.Stop()
 		os.Exit(1)


### PR DESCRIPTION
## Summary

`recover()` must be called directly by the deferred fn, or else the panic is not recovered.
https://go.dev/ref/spec#Handling_panics

Fixes panic in the main push payload processing.

## How did you test this change?

N/A

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
