### PR TITLE
use materialized views for trace perf, add trace histogram/metrics

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -21,19 +21,20 @@ const LogsTable = "logs"
 const LogsSamplingTable = "logs_sampling"
 const LogKeysTable = "log_keys"
 const LogKeyValuesTable = "log_key_values"
-const SamplingRows = 20_000_000
+
+var logKeysToColumns = map[modelInputs.ReservedLogKey]string{
+	modelInputs.ReservedLogKeyLevel:           "SeverityText",
+	modelInputs.ReservedLogKeySecureSessionID: "SecureSessionId",
+	modelInputs.ReservedLogKeySpanID:          "SpanId",
+	modelInputs.ReservedLogKeyTraceID:         "TraceId",
+	modelInputs.ReservedLogKeySource:          "Source",
+	modelInputs.ReservedLogKeyServiceName:     "ServiceName",
+	modelInputs.ReservedLogKeyServiceVersion:  "ServiceVersion",
+}
 
 var logsTableConfig = tableConfig[modelInputs.ReservedLogKey]{
-	tableName: LogsTable,
-	keysToColumns: map[modelInputs.ReservedLogKey]string{
-		modelInputs.ReservedLogKeyLevel:           "SeverityText",
-		modelInputs.ReservedLogKeySecureSessionID: "SecureSessionId",
-		modelInputs.ReservedLogKeySpanID:          "SpanId",
-		modelInputs.ReservedLogKeyTraceID:         "TraceId",
-		modelInputs.ReservedLogKeySource:          "Source",
-		modelInputs.ReservedLogKeyServiceName:     "ServiceName",
-		modelInputs.ReservedLogKeyServiceVersion:  "ServiceVersion",
-	},
+	tableName:        LogsTable,
+	keysToColumns:    logKeysToColumns,
 	reservedKeys:     modelInputs.AllReservedLogKey,
 	attributesColumn: "LogAttributes",
 	selectColumns: []string{
@@ -52,16 +53,8 @@ var logsTableConfig = tableConfig[modelInputs.ReservedLogKey]{
 }
 
 var logsSamplingTableConfig = tableConfig[modelInputs.ReservedLogKey]{
-	tableName: fmt.Sprintf("%s SAMPLE %d", LogsSamplingTable, SamplingRows),
-	keysToColumns: map[modelInputs.ReservedLogKey]string{
-		modelInputs.ReservedLogKeyLevel:           "SeverityText",
-		modelInputs.ReservedLogKeySecureSessionID: "SecureSessionId",
-		modelInputs.ReservedLogKeySpanID:          "SpanId",
-		modelInputs.ReservedLogKeyTraceID:         "TraceId",
-		modelInputs.ReservedLogKeySource:          "Source",
-		modelInputs.ReservedLogKeyServiceName:     "ServiceName",
-		modelInputs.ReservedLogKeyServiceVersion:  "ServiceVersion",
-	},
+	tableName:        fmt.Sprintf("%s SAMPLE %d", LogsSamplingTable, SamplingRows),
+	keysToColumns:    logKeysToColumns,
 	reservedKeys:     modelInputs.AllReservedLogKey,
 	attributesColumn: "LogAttributes",
 }

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -952,8 +952,10 @@ type ComplexityRoot struct {
 		TopUsers                     func(childComplexity int, projectID int, lookBackPeriod int) int
 		Trace                        func(childComplexity int, projectID int, traceID string) int
 		Traces                       func(childComplexity int, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection) int
+		TracesHistogram              func(childComplexity int, projectID int, params model.QueryInput) int
 		TracesKeyValues              func(childComplexity int, projectID int, keyName string, dateRange model.DateRangeRequiredInput) int
 		TracesKeys                   func(childComplexity int, projectID int, dateRange model.DateRangeRequiredInput) int
+		TracesMetrics                func(childComplexity int, projectID int, params model.QueryInput, metricTypes []model.TracesMetricType) int
 		TrackPropertiesAlerts        func(childComplexity int, projectID int) int
 		UnprocessedSessionsCount     func(childComplexity int, projectID int) int
 		UserFingerprintCount         func(childComplexity int, projectID int, lookBackPeriod int) int
@@ -1324,6 +1326,29 @@ type ComplexityRoot struct {
 		SpanID     func(childComplexity int) int
 		TraceID    func(childComplexity int) int
 		TraceState func(childComplexity int) int
+	}
+
+	TracesHistogram struct {
+		Buckets      func(childComplexity int) int
+		ObjectCount  func(childComplexity int) int
+		SampleFactor func(childComplexity int) int
+		TotalCount   func(childComplexity int) int
+	}
+
+	TracesHistogramBucket struct {
+		BucketID func(childComplexity int) int
+		Count    func(childComplexity int) int
+	}
+
+	TracesMetricBucket struct {
+		BucketID    func(childComplexity int) int
+		MetricType  func(childComplexity int) int
+		MetricValue func(childComplexity int) int
+	}
+
+	TracesMetrics struct {
+		Buckets      func(childComplexity int) int
+		SampleFactor func(childComplexity int) int
 	}
 
 	TrackProperty struct {
@@ -1706,6 +1731,8 @@ type QueryResolver interface {
 	FindSimilarErrors(ctx context.Context, query string) ([]*model1.MatchedErrorObject, error)
 	Trace(ctx context.Context, projectID int, traceID string) ([]*model.Trace, error)
 	Traces(ctx context.Context, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection) (*model.TraceConnection, error)
+	TracesHistogram(ctx context.Context, projectID int, params model.QueryInput) (*model.TracesHistogram, error)
+	TracesMetrics(ctx context.Context, projectID int, params model.QueryInput, metricTypes []model.TracesMetricType) (*model.TracesMetrics, error)
 	TracesKeys(ctx context.Context, projectID int, dateRange model.DateRangeRequiredInput) ([]*model.QueryKey, error)
 	TracesKeyValues(ctx context.Context, projectID int, keyName string, dateRange model.DateRangeRequiredInput) ([]string, error)
 }
@@ -7285,6 +7312,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Traces(childComplexity, args["project_id"].(int), args["params"].(model.QueryInput), args["after"].(*string), args["before"].(*string), args["at"].(*string), args["direction"].(model.SortDirection)), true
 
+	case "Query.traces_histogram":
+		if e.complexity.Query.TracesHistogram == nil {
+			break
+		}
+
+		args, err := ec.field_Query_traces_histogram_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.TracesHistogram(childComplexity, args["project_id"].(int), args["params"].(model.QueryInput)), true
+
 	case "Query.traces_key_values":
 		if e.complexity.Query.TracesKeyValues == nil {
 			break
@@ -7308,6 +7347,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.TracesKeys(childComplexity, args["project_id"].(int), args["date_range"].(model.DateRangeRequiredInput)), true
+
+	case "Query.traces_metrics":
+		if e.complexity.Query.TracesMetrics == nil {
+			break
+		}
+
+		args, err := ec.field_Query_traces_metrics_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.TracesMetrics(childComplexity, args["project_id"].(int), args["params"].(model.QueryInput), args["metric_types"].([]model.TracesMetricType)), true
 
 	case "Query.track_properties_alerts":
 		if e.complexity.Query.TrackPropertiesAlerts == nil {
@@ -9207,6 +9258,83 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TraceLink.TraceState(childComplexity), true
 
+	case "TracesHistogram.buckets":
+		if e.complexity.TracesHistogram.Buckets == nil {
+			break
+		}
+
+		return e.complexity.TracesHistogram.Buckets(childComplexity), true
+
+	case "TracesHistogram.objectCount":
+		if e.complexity.TracesHistogram.ObjectCount == nil {
+			break
+		}
+
+		return e.complexity.TracesHistogram.ObjectCount(childComplexity), true
+
+	case "TracesHistogram.sampleFactor":
+		if e.complexity.TracesHistogram.SampleFactor == nil {
+			break
+		}
+
+		return e.complexity.TracesHistogram.SampleFactor(childComplexity), true
+
+	case "TracesHistogram.totalCount":
+		if e.complexity.TracesHistogram.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.TracesHistogram.TotalCount(childComplexity), true
+
+	case "TracesHistogramBucket.bucketId":
+		if e.complexity.TracesHistogramBucket.BucketID == nil {
+			break
+		}
+
+		return e.complexity.TracesHistogramBucket.BucketID(childComplexity), true
+
+	case "TracesHistogramBucket.count":
+		if e.complexity.TracesHistogramBucket.Count == nil {
+			break
+		}
+
+		return e.complexity.TracesHistogramBucket.Count(childComplexity), true
+
+	case "TracesMetricBucket.bucketId":
+		if e.complexity.TracesMetricBucket.BucketID == nil {
+			break
+		}
+
+		return e.complexity.TracesMetricBucket.BucketID(childComplexity), true
+
+	case "TracesMetricBucket.metric_type":
+		if e.complexity.TracesMetricBucket.MetricType == nil {
+			break
+		}
+
+		return e.complexity.TracesMetricBucket.MetricType(childComplexity), true
+
+	case "TracesMetricBucket.metric_value":
+		if e.complexity.TracesMetricBucket.MetricValue == nil {
+			break
+		}
+
+		return e.complexity.TracesMetricBucket.MetricValue(childComplexity), true
+
+	case "TracesMetrics.buckets":
+		if e.complexity.TracesMetrics.Buckets == nil {
+			break
+		}
+
+		return e.complexity.TracesMetrics.Buckets(childComplexity), true
+
+	case "TracesMetrics.sampleFactor":
+		if e.complexity.TracesMetrics.SampleFactor == nil {
+			break
+		}
+
+		return e.complexity.TracesMetrics.SampleFactor(childComplexity), true
+
 	case "TrackProperty.id":
 		if e.complexity.TrackProperty.ID == nil {
 			break
@@ -10555,6 +10683,34 @@ type LogsHistogram {
 	sampleFactor: Float!
 }
 
+type TracesHistogramBucket {
+	bucketId: UInt64!
+	count: UInt64!
+}
+
+type TracesHistogram {
+	buckets: [TracesHistogramBucket!]!
+	totalCount: UInt64!
+	objectCount: UInt64!
+	sampleFactor: Float!
+}
+
+enum TracesMetricType {
+	p50
+	p90
+}
+
+type TracesMetricBucket {
+	bucketId: UInt64!
+	metric_type: TracesMetricType!
+	metric_value: Float!
+}
+
+type TracesMetrics {
+	buckets: [TracesMetricBucket!]!
+	sampleFactor: Float!
+}
+
 type QueryKey {
 	name: String!
 	type: KeyType!
@@ -11638,6 +11794,12 @@ type Query {
 		at: String
 		direction: SortDirection!
 	): TraceConnection!
+	traces_histogram(project_id: ID!, params: QueryInput!): TracesHistogram!
+	traces_metrics(
+		project_id: ID!
+		params: QueryInput!
+		metric_types: [TracesMetricType!]!
+	): TracesMetrics!
 	traces_keys(
 		project_id: ID!
 		date_range: DateRangeRequiredInput!
@@ -17808,6 +17970,30 @@ func (ec *executionContext) field_Query_traces_args(ctx context.Context, rawArgs
 	return args, nil
 }
 
+func (ec *executionContext) field_Query_traces_histogram_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 model.QueryInput
+	if tmp, ok := rawArgs["params"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+		arg1, err = ec.unmarshalNQueryInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐQueryInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["params"] = arg1
+	return args, nil
+}
+
 func (ec *executionContext) field_Query_traces_key_values_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -17862,6 +18048,39 @@ func (ec *executionContext) field_Query_traces_keys_args(ctx context.Context, ra
 		}
 	}
 	args["date_range"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_traces_metrics_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 model.QueryInput
+	if tmp, ok := rawArgs["params"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
+		arg1, err = ec.unmarshalNQueryInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐQueryInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["params"] = arg1
+	var arg2 []model.TracesMetricType
+	if tmp, ok := rawArgs["metric_types"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("metric_types"))
+		arg2, err = ec.unmarshalNTracesMetricType2ᚕgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricTypeᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["metric_types"] = arg2
 	return args, nil
 }
 
@@ -52982,6 +53201,130 @@ func (ec *executionContext) fieldContext_Query_traces(ctx context.Context, field
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_traces_histogram(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_traces_histogram(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().TracesHistogram(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.QueryInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.TracesHistogram)
+	fc.Result = res
+	return ec.marshalNTracesHistogram2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesHistogram(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_traces_histogram(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "buckets":
+				return ec.fieldContext_TracesHistogram_buckets(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_TracesHistogram_totalCount(ctx, field)
+			case "objectCount":
+				return ec.fieldContext_TracesHistogram_objectCount(ctx, field)
+			case "sampleFactor":
+				return ec.fieldContext_TracesHistogram_sampleFactor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TracesHistogram", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_traces_histogram_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_traces_metrics(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_traces_metrics(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().TracesMetrics(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.QueryInput), fc.Args["metric_types"].([]model.TracesMetricType))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.TracesMetrics)
+	fc.Result = res
+	return ec.marshalNTracesMetrics2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetrics(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_traces_metrics(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "buckets":
+				return ec.fieldContext_TracesMetrics_buckets(ctx, field)
+			case "sampleFactor":
+				return ec.fieldContext_TracesMetrics_sampleFactor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TracesMetrics", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_traces_metrics_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_traces_keys(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_traces_keys(ctx, field)
 	if err != nil {
@@ -64070,6 +64413,504 @@ func (ec *executionContext) fieldContext_TraceLink_attributes(ctx context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Map does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracesHistogram_buckets(ctx context.Context, field graphql.CollectedField, obj *model.TracesHistogram) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracesHistogram_buckets(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Buckets, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.TracesHistogramBucket)
+	fc.Result = res
+	return ec.marshalNTracesHistogramBucket2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesHistogramBucketᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracesHistogram_buckets(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracesHistogram",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "bucketId":
+				return ec.fieldContext_TracesHistogramBucket_bucketId(ctx, field)
+			case "count":
+				return ec.fieldContext_TracesHistogramBucket_count(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TracesHistogramBucket", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracesHistogram_totalCount(ctx context.Context, field graphql.CollectedField, obj *model.TracesHistogram) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracesHistogram_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TotalCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uint64)
+	fc.Result = res
+	return ec.marshalNUInt642uint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracesHistogram_totalCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracesHistogram",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type UInt64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracesHistogram_objectCount(ctx context.Context, field graphql.CollectedField, obj *model.TracesHistogram) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracesHistogram_objectCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ObjectCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uint64)
+	fc.Result = res
+	return ec.marshalNUInt642uint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracesHistogram_objectCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracesHistogram",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type UInt64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracesHistogram_sampleFactor(ctx context.Context, field graphql.CollectedField, obj *model.TracesHistogram) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracesHistogram_sampleFactor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SampleFactor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(float64)
+	fc.Result = res
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracesHistogram_sampleFactor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracesHistogram",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracesHistogramBucket_bucketId(ctx context.Context, field graphql.CollectedField, obj *model.TracesHistogramBucket) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracesHistogramBucket_bucketId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BucketID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uint64)
+	fc.Result = res
+	return ec.marshalNUInt642uint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracesHistogramBucket_bucketId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracesHistogramBucket",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type UInt64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracesHistogramBucket_count(ctx context.Context, field graphql.CollectedField, obj *model.TracesHistogramBucket) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracesHistogramBucket_count(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Count, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uint64)
+	fc.Result = res
+	return ec.marshalNUInt642uint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracesHistogramBucket_count(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracesHistogramBucket",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type UInt64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracesMetricBucket_bucketId(ctx context.Context, field graphql.CollectedField, obj *model.TracesMetricBucket) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracesMetricBucket_bucketId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BucketID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uint64)
+	fc.Result = res
+	return ec.marshalNUInt642uint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracesMetricBucket_bucketId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracesMetricBucket",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type UInt64 does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracesMetricBucket_metric_type(ctx context.Context, field graphql.CollectedField, obj *model.TracesMetricBucket) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracesMetricBucket_metric_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MetricType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.TracesMetricType)
+	fc.Result = res
+	return ec.marshalNTracesMetricType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricType(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracesMetricBucket_metric_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracesMetricBucket",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type TracesMetricType does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracesMetricBucket_metric_value(ctx context.Context, field graphql.CollectedField, obj *model.TracesMetricBucket) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracesMetricBucket_metric_value(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MetricValue, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(float64)
+	fc.Result = res
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracesMetricBucket_metric_value(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracesMetricBucket",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracesMetrics_buckets(ctx context.Context, field graphql.CollectedField, obj *model.TracesMetrics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracesMetrics_buckets(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Buckets, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.TracesMetricBucket)
+	fc.Result = res
+	return ec.marshalNTracesMetricBucket2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricBucketᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracesMetrics_buckets(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracesMetrics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "bucketId":
+				return ec.fieldContext_TracesMetricBucket_bucketId(ctx, field)
+			case "metric_type":
+				return ec.fieldContext_TracesMetricBucket_metric_type(ctx, field)
+			case "metric_value":
+				return ec.fieldContext_TracesMetricBucket_metric_value(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TracesMetricBucket", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracesMetrics_sampleFactor(ctx context.Context, field graphql.CollectedField, obj *model.TracesMetrics) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracesMetrics_sampleFactor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SampleFactor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(float64)
+	fc.Result = res
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracesMetrics_sampleFactor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracesMetrics",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -78383,6 +79224,46 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
+		case "traces_histogram":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_traces_histogram(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "traces_metrics":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_traces_metrics(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
 		case "traces_keys":
 			field := field
 
@@ -80897,6 +81778,167 @@ func (ec *executionContext) _TraceLink(ctx context.Context, sel ast.SelectionSet
 		case "attributes":
 
 			out.Values[i] = ec._TraceLink_attributes(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var tracesHistogramImplementors = []string{"TracesHistogram"}
+
+func (ec *executionContext) _TracesHistogram(ctx context.Context, sel ast.SelectionSet, obj *model.TracesHistogram) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tracesHistogramImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TracesHistogram")
+		case "buckets":
+
+			out.Values[i] = ec._TracesHistogram_buckets(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "totalCount":
+
+			out.Values[i] = ec._TracesHistogram_totalCount(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "objectCount":
+
+			out.Values[i] = ec._TracesHistogram_objectCount(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "sampleFactor":
+
+			out.Values[i] = ec._TracesHistogram_sampleFactor(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var tracesHistogramBucketImplementors = []string{"TracesHistogramBucket"}
+
+func (ec *executionContext) _TracesHistogramBucket(ctx context.Context, sel ast.SelectionSet, obj *model.TracesHistogramBucket) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tracesHistogramBucketImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TracesHistogramBucket")
+		case "bucketId":
+
+			out.Values[i] = ec._TracesHistogramBucket_bucketId(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "count":
+
+			out.Values[i] = ec._TracesHistogramBucket_count(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var tracesMetricBucketImplementors = []string{"TracesMetricBucket"}
+
+func (ec *executionContext) _TracesMetricBucket(ctx context.Context, sel ast.SelectionSet, obj *model.TracesMetricBucket) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tracesMetricBucketImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TracesMetricBucket")
+		case "bucketId":
+
+			out.Values[i] = ec._TracesMetricBucket_bucketId(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "metric_type":
+
+			out.Values[i] = ec._TracesMetricBucket_metric_type(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "metric_value":
+
+			out.Values[i] = ec._TracesMetricBucket_metric_value(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var tracesMetricsImplementors = []string{"TracesMetrics"}
+
+func (ec *executionContext) _TracesMetrics(ctx context.Context, sel ast.SelectionSet, obj *model.TracesMetrics) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tracesMetricsImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TracesMetrics")
+		case "buckets":
+
+			out.Values[i] = ec._TracesMetrics_buckets(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "sampleFactor":
+
+			out.Values[i] = ec._TracesMetrics_sampleFactor(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -86071,6 +87113,213 @@ func (ec *executionContext) marshalNTraceEdge2ᚖgithubᚗcomᚋhighlightᚑrun�
 		return graphql.Null
 	}
 	return ec._TraceEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTracesHistogram2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesHistogram(ctx context.Context, sel ast.SelectionSet, v model.TracesHistogram) graphql.Marshaler {
+	return ec._TracesHistogram(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTracesHistogram2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesHistogram(ctx context.Context, sel ast.SelectionSet, v *model.TracesHistogram) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TracesHistogram(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTracesHistogramBucket2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesHistogramBucketᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.TracesHistogramBucket) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTracesHistogramBucket2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesHistogramBucket(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTracesHistogramBucket2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesHistogramBucket(ctx context.Context, sel ast.SelectionSet, v *model.TracesHistogramBucket) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TracesHistogramBucket(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTracesMetricBucket2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricBucketᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.TracesMetricBucket) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTracesMetricBucket2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricBucket(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTracesMetricBucket2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricBucket(ctx context.Context, sel ast.SelectionSet, v *model.TracesMetricBucket) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TracesMetricBucket(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNTracesMetricType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricType(ctx context.Context, v interface{}) (model.TracesMetricType, error) {
+	var res model.TracesMetricType
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNTracesMetricType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricType(ctx context.Context, sel ast.SelectionSet, v model.TracesMetricType) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalNTracesMetricType2ᚕgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricTypeᚄ(ctx context.Context, v interface{}) ([]model.TracesMetricType, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]model.TracesMetricType, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNTracesMetricType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricType(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNTracesMetricType2ᚕgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricTypeᚄ(ctx context.Context, sel ast.SelectionSet, v []model.TracesMetricType) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTracesMetricType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricType(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTracesMetrics2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetrics(ctx context.Context, sel ast.SelectionSet, v model.TracesMetrics) graphql.Marshaler {
+	return ec._TracesMetrics(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTracesMetrics2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetrics(ctx context.Context, sel ast.SelectionSet, v *model.TracesMetrics) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TracesMetrics(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNTrackProperty2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐTrackProperty(ctx context.Context, sel ast.SelectionSet, v []*model1.TrackProperty) graphql.Marshaler {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -952,7 +952,6 @@ type ComplexityRoot struct {
 		TopUsers                     func(childComplexity int, projectID int, lookBackPeriod int) int
 		Trace                        func(childComplexity int, projectID int, traceID string) int
 		Traces                       func(childComplexity int, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection) int
-		TracesHistogram              func(childComplexity int, projectID int, params model.QueryInput) int
 		TracesKeyValues              func(childComplexity int, projectID int, keyName string, dateRange model.DateRangeRequiredInput) int
 		TracesKeys                   func(childComplexity int, projectID int, dateRange model.DateRangeRequiredInput) int
 		TracesMetrics                func(childComplexity int, projectID int, params model.QueryInput, metricTypes []model.TracesMetricType) int
@@ -1720,7 +1719,6 @@ type QueryResolver interface {
 	FindSimilarErrors(ctx context.Context, query string) ([]*model1.MatchedErrorObject, error)
 	Trace(ctx context.Context, projectID int, traceID string) ([]*model.Trace, error)
 	Traces(ctx context.Context, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection) (*model.TraceConnection, error)
-	TracesHistogram(ctx context.Context, projectID int, params model.QueryInput) (*model.TracesMetrics, error)
 	TracesMetrics(ctx context.Context, projectID int, params model.QueryInput, metricTypes []model.TracesMetricType) (*model.TracesMetrics, error)
 	TracesKeys(ctx context.Context, projectID int, dateRange model.DateRangeRequiredInput) ([]*model.QueryKey, error)
 	TracesKeyValues(ctx context.Context, projectID int, keyName string, dateRange model.DateRangeRequiredInput) ([]string, error)
@@ -7301,18 +7299,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Traces(childComplexity, args["project_id"].(int), args["params"].(model.QueryInput), args["after"].(*string), args["before"].(*string), args["at"].(*string), args["direction"].(model.SortDirection)), true
 
-	case "Query.traces_histogram":
-		if e.complexity.Query.TracesHistogram == nil {
-			break
-		}
-
-		args, err := ec.field_Query_traces_histogram_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.TracesHistogram(childComplexity, args["project_id"].(int), args["params"].(model.QueryInput)), true
-
 	case "Query.traces_key_values":
 		if e.complexity.Query.TracesKeyValues == nil {
 			break
@@ -11738,7 +11724,6 @@ type Query {
 		at: String
 		direction: SortDirection!
 	): TraceConnection!
-	traces_histogram(project_id: ID!, params: QueryInput!): TracesMetrics!
 	traces_metrics(
 		project_id: ID!
 		params: QueryInput!
@@ -17911,30 +17896,6 @@ func (ec *executionContext) field_Query_traces_args(ctx context.Context, rawArgs
 		}
 	}
 	args["direction"] = arg5
-	return args, nil
-}
-
-func (ec *executionContext) field_Query_traces_histogram_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 int
-	if tmp, ok := rawArgs["project_id"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
-		arg0, err = ec.unmarshalNID2int(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["project_id"] = arg0
-	var arg1 model.QueryInput
-	if tmp, ok := rawArgs["params"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("params"))
-		arg1, err = ec.unmarshalNQueryInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐQueryInput(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["params"] = arg1
 	return args, nil
 }
 
@@ -53145,68 +53106,6 @@ func (ec *executionContext) fieldContext_Query_traces(ctx context.Context, field
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_traces_histogram(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_traces_histogram(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().TracesHistogram(rctx, fc.Args["project_id"].(int), fc.Args["params"].(model.QueryInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.TracesMetrics)
-	fc.Result = res
-	return ec.marshalNTracesMetrics2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetrics(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_traces_histogram(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "buckets":
-				return ec.fieldContext_TracesMetrics_buckets(ctx, field)
-			case "bucket_count":
-				return ec.fieldContext_TracesMetrics_bucket_count(ctx, field)
-			case "sample_factor":
-				return ec.fieldContext_TracesMetrics_sample_factor(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type TracesMetrics", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_traces_histogram_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Query_traces_metrics(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_traces_metrics(ctx, field)
 	if err != nil {
@@ -78932,26 +78831,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_traces(ctx, field)
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return rrm(innerCtx)
-			})
-		case "traces_histogram":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_traces_histogram(ctx, field)
 				return res
 			}
 

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -795,27 +795,16 @@ type TraceLink struct {
 	Attributes map[string]interface{} `json:"attributes"`
 }
 
-type TracesHistogram struct {
-	Buckets      []*TracesHistogramBucket `json:"buckets"`
-	TotalCount   uint64                   `json:"totalCount"`
-	ObjectCount  uint64                   `json:"objectCount"`
-	SampleFactor float64                  `json:"sampleFactor"`
-}
-
-type TracesHistogramBucket struct {
-	BucketID uint64 `json:"bucketId"`
-	Count    uint64 `json:"count"`
-}
-
 type TracesMetricBucket struct {
-	BucketID    uint64           `json:"bucketId"`
+	BucketID    uint64           `json:"bucket_id"`
 	MetricType  TracesMetricType `json:"metric_type"`
 	MetricValue float64          `json:"metric_value"`
 }
 
 type TracesMetrics struct {
 	Buckets      []*TracesMetricBucket `json:"buckets"`
-	SampleFactor float64               `json:"sampleFactor"`
+	BucketCount  uint64                `json:"bucket_count"`
+	SampleFactor float64               `json:"sample_factor"`
 }
 
 type TrackPropertyInput struct {
@@ -2169,18 +2158,20 @@ func (e SubscriptionInterval) MarshalGQL(w io.Writer) {
 type TracesMetricType string
 
 const (
-	TracesMetricTypeP50 TracesMetricType = "p50"
-	TracesMetricTypeP90 TracesMetricType = "p90"
+	TracesMetricTypeCount TracesMetricType = "count"
+	TracesMetricTypeP50   TracesMetricType = "p50"
+	TracesMetricTypeP90   TracesMetricType = "p90"
 )
 
 var AllTracesMetricType = []TracesMetricType{
+	TracesMetricTypeCount,
 	TracesMetricTypeP50,
 	TracesMetricTypeP90,
 }
 
 func (e TracesMetricType) IsValid() bool {
 	switch e {
-	case TracesMetricTypeP50, TracesMetricTypeP90:
+	case TracesMetricTypeCount, TracesMetricTypeP50, TracesMetricTypeP90:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -795,6 +795,29 @@ type TraceLink struct {
 	Attributes map[string]interface{} `json:"attributes"`
 }
 
+type TracesHistogram struct {
+	Buckets      []*TracesHistogramBucket `json:"buckets"`
+	TotalCount   uint64                   `json:"totalCount"`
+	ObjectCount  uint64                   `json:"objectCount"`
+	SampleFactor float64                  `json:"sampleFactor"`
+}
+
+type TracesHistogramBucket struct {
+	BucketID uint64 `json:"bucketId"`
+	Count    uint64 `json:"count"`
+}
+
+type TracesMetricBucket struct {
+	BucketID    uint64           `json:"bucketId"`
+	MetricType  TracesMetricType `json:"metric_type"`
+	MetricValue float64          `json:"metric_value"`
+}
+
+type TracesMetrics struct {
+	Buckets      []*TracesMetricBucket `json:"buckets"`
+	SampleFactor float64               `json:"sampleFactor"`
+}
+
 type TrackPropertyInput struct {
 	ID    *int   `json:"id"`
 	Name  string `json:"name"`
@@ -2140,5 +2163,46 @@ func (e *SubscriptionInterval) UnmarshalGQL(v interface{}) error {
 }
 
 func (e SubscriptionInterval) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type TracesMetricType string
+
+const (
+	TracesMetricTypeP50 TracesMetricType = "p50"
+	TracesMetricTypeP90 TracesMetricType = "p90"
+)
+
+var AllTracesMetricType = []TracesMetricType{
+	TracesMetricTypeP50,
+	TracesMetricTypeP90,
+}
+
+func (e TracesMetricType) IsValid() bool {
+	switch e {
+	case TracesMetricTypeP50, TracesMetricTypeP90:
+		return true
+	}
+	return false
+}
+
+func (e TracesMetricType) String() string {
+	return string(e)
+}
+
+func (e *TracesMetricType) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = TracesMetricType(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid TracesMetricType", str)
+	}
+	return nil
+}
+
+func (e TracesMetricType) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -819,6 +819,34 @@ type LogsHistogram {
 	sampleFactor: Float!
 }
 
+type TracesHistogramBucket {
+	bucketId: UInt64!
+	count: UInt64!
+}
+
+type TracesHistogram {
+	buckets: [TracesHistogramBucket!]!
+	totalCount: UInt64!
+	objectCount: UInt64!
+	sampleFactor: Float!
+}
+
+enum TracesMetricType {
+	p50
+	p90
+}
+
+type TracesMetricBucket {
+	bucketId: UInt64!
+	metric_type: TracesMetricType!
+	metric_value: Float!
+}
+
+type TracesMetrics {
+	buckets: [TracesMetricBucket!]!
+	sampleFactor: Float!
+}
+
 type QueryKey {
 	name: String!
 	type: KeyType!
@@ -1902,6 +1930,12 @@ type Query {
 		at: String
 		direction: SortDirection!
 	): TraceConnection!
+	traces_histogram(project_id: ID!, params: QueryInput!): TracesHistogram!
+	traces_metrics(
+		project_id: ID!
+		params: QueryInput!
+		metric_types: [TracesMetricType!]!
+	): TracesMetrics!
 	traces_keys(
 		project_id: ID!
 		date_range: DateRangeRequiredInput!

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1920,7 +1920,6 @@ type Query {
 		at: String
 		direction: SortDirection!
 	): TraceConnection!
-	traces_histogram(project_id: ID!, params: QueryInput!): TracesMetrics!
 	traces_metrics(
 		project_id: ID!
 		params: QueryInput!

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -819,32 +819,22 @@ type LogsHistogram {
 	sampleFactor: Float!
 }
 
-type TracesHistogramBucket {
-	bucketId: UInt64!
-	count: UInt64!
-}
-
-type TracesHistogram {
-	buckets: [TracesHistogramBucket!]!
-	totalCount: UInt64!
-	objectCount: UInt64!
-	sampleFactor: Float!
-}
-
 enum TracesMetricType {
+	count
 	p50
 	p90
 }
 
 type TracesMetricBucket {
-	bucketId: UInt64!
+	bucket_id: UInt64!
 	metric_type: TracesMetricType!
 	metric_value: Float!
 }
 
 type TracesMetrics {
 	buckets: [TracesMetricBucket!]!
-	sampleFactor: Float!
+	bucket_count: UInt64!
+	sample_factor: Float!
 }
 
 type QueryKey {
@@ -1930,7 +1920,7 @@ type Query {
 		at: String
 		direction: SortDirection!
 	): TraceConnection!
-	traces_histogram(project_id: ID!, params: QueryInput!): TracesHistogram!
+	traces_histogram(project_id: ID!, params: QueryInput!): TracesMetrics!
 	traces_metrics(
 		project_id: ID!
 		params: QueryInput!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7576,13 +7576,13 @@ func (r *queryResolver) Traces(ctx context.Context, projectID int, params modelI
 }
 
 // TracesHistogram is the resolver for the traces_histogram field.
-func (r *queryResolver) TracesHistogram(ctx context.Context, projectID int, params modelInputs.QueryInput) (*modelInputs.TracesHistogram, error) {
+func (r *queryResolver) TracesHistogram(ctx context.Context, projectID int, params modelInputs.QueryInput) (*modelInputs.TracesMetrics, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 
-	return r.ClickhouseClient.ReadTracesHistogram(ctx, project.ID, params, 48)
+	return r.ClickhouseClient.ReadTracesMetrics(ctx, project.ID, params, []modelInputs.TracesMetricType{modelInputs.TracesMetricTypeCount}, 48)
 }
 
 // TracesMetrics is the resolver for the traces_metrics field.

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7575,6 +7575,26 @@ func (r *queryResolver) Traces(ctx context.Context, projectID int, params modelI
 	})
 }
 
+// TracesHistogram is the resolver for the traces_histogram field.
+func (r *queryResolver) TracesHistogram(ctx context.Context, projectID int, params modelInputs.QueryInput) (*modelInputs.TracesHistogram, error) {
+	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.ClickhouseClient.ReadTracesHistogram(ctx, project.ID, params, 48)
+}
+
+// TracesMetrics is the resolver for the traces_metrics field.
+func (r *queryResolver) TracesMetrics(ctx context.Context, projectID int, params modelInputs.QueryInput, metricTypes []modelInputs.TracesMetricType) (*modelInputs.TracesMetrics, error) {
+	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.ClickhouseClient.ReadTracesMetrics(ctx, project.ID, params, metricTypes, 48)
+}
+
 // TracesKeys is the resolver for the traces_keys field.
 func (r *queryResolver) TracesKeys(ctx context.Context, projectID int, dateRange modelInputs.DateRangeRequiredInput) ([]*modelInputs.QueryKey, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7575,16 +7575,6 @@ func (r *queryResolver) Traces(ctx context.Context, projectID int, params modelI
 	})
 }
 
-// TracesHistogram is the resolver for the traces_histogram field.
-func (r *queryResolver) TracesHistogram(ctx context.Context, projectID int, params modelInputs.QueryInput) (*modelInputs.TracesMetrics, error) {
-	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
-	if err != nil {
-		return nil, err
-	}
-
-	return r.ClickhouseClient.ReadTracesMetrics(ctx, project.ID, params, []modelInputs.TracesMetricType{modelInputs.TracesMetricTypeCount}, 48)
-}
-
 // TracesMetrics is the resolver for the traces_metrics field.
 func (r *queryResolver) TracesMetrics(ctx context.Context, projectID int, params modelInputs.QueryInput, metricTypes []modelInputs.TracesMetricType) (*modelInputs.TracesMetrics, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -14026,13 +14026,12 @@ export type GetTracesQueryResult = Apollo.QueryResult<
 export const GetTracesHistogramDocument = gql`
 	query GetTracesHistogram($project_id: ID!, $params: QueryInput!) {
 		traces_histogram(project_id: $project_id, params: $params) {
-			totalCount
 			buckets {
-				bucketId
-				count
+				bucket_id
+				metric_value
 			}
-			objectCount
-			sampleFactor
+			bucket_count
+			sample_factor
 		}
 	}
 `
@@ -14098,11 +14097,12 @@ export const GetTracesMetricsDocument = gql`
 			metric_types: $metric_types
 		) {
 			buckets {
-				bucketId
+				bucket_id
 				metric_type
 				metric_value
 			}
-			sampleFactor
+			bucket_count
+			sample_factor
 		}
 	}
 `

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -14023,6 +14023,140 @@ export type GetTracesQueryResult = Apollo.QueryResult<
 	Types.GetTracesQuery,
 	Types.GetTracesQueryVariables
 >
+export const GetTracesHistogramDocument = gql`
+	query GetTracesHistogram($project_id: ID!, $params: QueryInput!) {
+		traces_histogram(project_id: $project_id, params: $params) {
+			totalCount
+			buckets {
+				bucketId
+				count
+			}
+			objectCount
+			sampleFactor
+		}
+	}
+`
+
+/**
+ * __useGetTracesHistogramQuery__
+ *
+ * To run a query within a React component, call `useGetTracesHistogramQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetTracesHistogramQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetTracesHistogramQuery({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *      params: // value for 'params'
+ *   },
+ * });
+ */
+export function useGetTracesHistogramQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetTracesHistogramQuery,
+		Types.GetTracesHistogramQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetTracesHistogramQuery,
+		Types.GetTracesHistogramQueryVariables
+	>(GetTracesHistogramDocument, baseOptions)
+}
+export function useGetTracesHistogramLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetTracesHistogramQuery,
+		Types.GetTracesHistogramQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetTracesHistogramQuery,
+		Types.GetTracesHistogramQueryVariables
+	>(GetTracesHistogramDocument, baseOptions)
+}
+export type GetTracesHistogramQueryHookResult = ReturnType<
+	typeof useGetTracesHistogramQuery
+>
+export type GetTracesHistogramLazyQueryHookResult = ReturnType<
+	typeof useGetTracesHistogramLazyQuery
+>
+export type GetTracesHistogramQueryResult = Apollo.QueryResult<
+	Types.GetTracesHistogramQuery,
+	Types.GetTracesHistogramQueryVariables
+>
+export const GetTracesMetricsDocument = gql`
+	query GetTracesMetrics(
+		$project_id: ID!
+		$params: QueryInput!
+		$metric_types: [TracesMetricType!]!
+	) {
+		traces_metrics(
+			project_id: $project_id
+			params: $params
+			metric_types: $metric_types
+		) {
+			buckets {
+				bucketId
+				metric_type
+				metric_value
+			}
+			sampleFactor
+		}
+	}
+`
+
+/**
+ * __useGetTracesMetricsQuery__
+ *
+ * To run a query within a React component, call `useGetTracesMetricsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetTracesMetricsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetTracesMetricsQuery({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *      params: // value for 'params'
+ *      metric_types: // value for 'metric_types'
+ *   },
+ * });
+ */
+export function useGetTracesMetricsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetTracesMetricsQuery,
+		Types.GetTracesMetricsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetTracesMetricsQuery,
+		Types.GetTracesMetricsQueryVariables
+	>(GetTracesMetricsDocument, baseOptions)
+}
+export function useGetTracesMetricsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetTracesMetricsQuery,
+		Types.GetTracesMetricsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetTracesMetricsQuery,
+		Types.GetTracesMetricsQueryVariables
+	>(GetTracesMetricsDocument, baseOptions)
+}
+export type GetTracesMetricsQueryHookResult = ReturnType<
+	typeof useGetTracesMetricsQuery
+>
+export type GetTracesMetricsLazyQueryHookResult = ReturnType<
+	typeof useGetTracesMetricsLazyQuery
+>
+export type GetTracesMetricsQueryResult = Apollo.QueryResult<
+	Types.GetTracesMetricsQuery,
+	Types.GetTracesMetricsQueryVariables
+>
 export const GetTracesKeysDocument = gql`
 	query GetTracesKeys(
 		$project_id: ID!

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -14023,68 +14023,6 @@ export type GetTracesQueryResult = Apollo.QueryResult<
 	Types.GetTracesQuery,
 	Types.GetTracesQueryVariables
 >
-export const GetTracesHistogramDocument = gql`
-	query GetTracesHistogram($project_id: ID!, $params: QueryInput!) {
-		traces_histogram(project_id: $project_id, params: $params) {
-			buckets {
-				bucket_id
-				metric_value
-			}
-			bucket_count
-			sample_factor
-		}
-	}
-`
-
-/**
- * __useGetTracesHistogramQuery__
- *
- * To run a query within a React component, call `useGetTracesHistogramQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetTracesHistogramQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetTracesHistogramQuery({
- *   variables: {
- *      project_id: // value for 'project_id'
- *      params: // value for 'params'
- *   },
- * });
- */
-export function useGetTracesHistogramQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetTracesHistogramQuery,
-		Types.GetTracesHistogramQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetTracesHistogramQuery,
-		Types.GetTracesHistogramQueryVariables
-	>(GetTracesHistogramDocument, baseOptions)
-}
-export function useGetTracesHistogramLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetTracesHistogramQuery,
-		Types.GetTracesHistogramQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetTracesHistogramQuery,
-		Types.GetTracesHistogramQueryVariables
-	>(GetTracesHistogramDocument, baseOptions)
-}
-export type GetTracesHistogramQueryHookResult = ReturnType<
-	typeof useGetTracesHistogramQuery
->
-export type GetTracesHistogramLazyQueryHookResult = ReturnType<
-	typeof useGetTracesHistogramLazyQuery
->
-export type GetTracesHistogramQueryResult = Apollo.QueryResult<
-	Types.GetTracesHistogramQuery,
-	Types.GetTracesHistogramQueryVariables
->
 export const GetTracesMetricsDocument = gql`
 	query GetTracesMetrics(
 		$project_id: ID!

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4729,14 +4729,14 @@ export type GetTracesHistogramQueryVariables = Types.Exact<{
 }>
 
 export type GetTracesHistogramQuery = { __typename?: 'Query' } & {
-	traces_histogram: { __typename?: 'TracesHistogram' } & Pick<
-		Types.TracesHistogram,
-		'totalCount' | 'objectCount' | 'sampleFactor'
+	traces_histogram: { __typename?: 'TracesMetrics' } & Pick<
+		Types.TracesMetrics,
+		'bucket_count' | 'sample_factor'
 	> & {
 			buckets: Array<
-				{ __typename?: 'TracesHistogramBucket' } & Pick<
-					Types.TracesHistogramBucket,
-					'bucketId' | 'count'
+				{ __typename?: 'TracesMetricBucket' } & Pick<
+					Types.TracesMetricBucket,
+					'bucket_id' | 'metric_value'
 				>
 			>
 		}
@@ -4751,12 +4751,12 @@ export type GetTracesMetricsQueryVariables = Types.Exact<{
 export type GetTracesMetricsQuery = { __typename?: 'Query' } & {
 	traces_metrics: { __typename?: 'TracesMetrics' } & Pick<
 		Types.TracesMetrics,
-		'sampleFactor'
+		'bucket_count' | 'sample_factor'
 	> & {
 			buckets: Array<
 				{ __typename?: 'TracesMetricBucket' } & Pick<
 					Types.TracesMetricBucket,
-					'bucketId' | 'metric_type' | 'metric_value'
+					'bucket_id' | 'metric_type' | 'metric_value'
 				>
 			>
 		}

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4723,25 +4723,6 @@ export type GetTracesQuery = { __typename?: 'Query' } & {
 	}
 }
 
-export type GetTracesHistogramQueryVariables = Types.Exact<{
-	project_id: Types.Scalars['ID']
-	params: Types.QueryInput
-}>
-
-export type GetTracesHistogramQuery = { __typename?: 'Query' } & {
-	traces_histogram: { __typename?: 'TracesMetrics' } & Pick<
-		Types.TracesMetrics,
-		'bucket_count' | 'sample_factor'
-	> & {
-			buckets: Array<
-				{ __typename?: 'TracesMetricBucket' } & Pick<
-					Types.TracesMetricBucket,
-					'bucket_id' | 'metric_value'
-				>
-			>
-		}
-}
-
 export type GetTracesMetricsQueryVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	params: Types.QueryInput
@@ -4924,7 +4905,6 @@ export const namedOperations = {
 		FindSimilarErrors: 'FindSimilarErrors' as const,
 		GetTrace: 'GetTrace' as const,
 		GetTraces: 'GetTraces' as const,
-		GetTracesHistogram: 'GetTracesHistogram' as const,
 		GetTracesMetrics: 'GetTracesMetrics' as const,
 		GetTracesKeys: 'GetTracesKeys' as const,
 		GetTracesKeyValues: 'GetTracesKeyValues' as const,

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4723,6 +4723,45 @@ export type GetTracesQuery = { __typename?: 'Query' } & {
 	}
 }
 
+export type GetTracesHistogramQueryVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+	params: Types.QueryInput
+}>
+
+export type GetTracesHistogramQuery = { __typename?: 'Query' } & {
+	traces_histogram: { __typename?: 'TracesHistogram' } & Pick<
+		Types.TracesHistogram,
+		'totalCount' | 'objectCount' | 'sampleFactor'
+	> & {
+			buckets: Array<
+				{ __typename?: 'TracesHistogramBucket' } & Pick<
+					Types.TracesHistogramBucket,
+					'bucketId' | 'count'
+				>
+			>
+		}
+}
+
+export type GetTracesMetricsQueryVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+	params: Types.QueryInput
+	metric_types: Array<Types.TracesMetricType> | Types.TracesMetricType
+}>
+
+export type GetTracesMetricsQuery = { __typename?: 'Query' } & {
+	traces_metrics: { __typename?: 'TracesMetrics' } & Pick<
+		Types.TracesMetrics,
+		'sampleFactor'
+	> & {
+			buckets: Array<
+				{ __typename?: 'TracesMetricBucket' } & Pick<
+					Types.TracesMetricBucket,
+					'bucketId' | 'metric_type' | 'metric_value'
+				>
+			>
+		}
+}
+
 export type GetTracesKeysQueryVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	date_range: Types.DateRangeRequiredInput
@@ -4885,6 +4924,8 @@ export const namedOperations = {
 		FindSimilarErrors: 'FindSimilarErrors' as const,
 		GetTrace: 'GetTrace' as const,
 		GetTraces: 'GetTraces' as const,
+		GetTracesHistogram: 'GetTracesHistogram' as const,
+		GetTracesMetrics: 'GetTracesMetrics' as const,
 		GetTracesKeys: 'GetTracesKeys' as const,
 		GetTracesKeyValues: 'GetTracesKeyValues' as const,
 	},

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1820,7 +1820,7 @@ export type Query = {
 	topUsers: Array<Maybe<TopUsersPayload>>
 	trace?: Maybe<Array<Trace>>
 	traces: TraceConnection
-	traces_histogram: TracesHistogram
+	traces_histogram: TracesMetrics
 	traces_key_values: Array<Scalars['String']>
 	traces_keys: Array<QueryKey>
 	traces_metrics: TracesMetrics
@@ -3050,36 +3050,24 @@ export type TraceLink = {
 	traceState: Scalars['String']
 }
 
-export type TracesHistogram = {
-	__typename?: 'TracesHistogram'
-	buckets: Array<TracesHistogramBucket>
-	objectCount: Scalars['UInt64']
-	sampleFactor: Scalars['Float']
-	totalCount: Scalars['UInt64']
-}
-
-export type TracesHistogramBucket = {
-	__typename?: 'TracesHistogramBucket'
-	bucketId: Scalars['UInt64']
-	count: Scalars['UInt64']
-}
-
 export type TracesMetricBucket = {
 	__typename?: 'TracesMetricBucket'
-	bucketId: Scalars['UInt64']
+	bucket_id: Scalars['UInt64']
 	metric_type: TracesMetricType
 	metric_value: Scalars['Float']
 }
 
 export enum TracesMetricType {
+	Count = 'count',
 	P50 = 'p50',
 	P90 = 'p90',
 }
 
 export type TracesMetrics = {
 	__typename?: 'TracesMetrics'
+	bucket_count: Scalars['UInt64']
 	buckets: Array<TracesMetricBucket>
-	sampleFactor: Scalars['Float']
+	sample_factor: Scalars['Float']
 }
 
 export type TrackProperty = {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1820,7 +1820,6 @@ export type Query = {
 	topUsers: Array<Maybe<TopUsersPayload>>
 	trace?: Maybe<Array<Trace>>
 	traces: TraceConnection
-	traces_histogram: TracesMetrics
 	traces_key_values: Array<Scalars['String']>
 	traces_keys: Array<QueryKey>
 	traces_metrics: TracesMetrics
@@ -2400,11 +2399,6 @@ export type QueryTracesArgs = {
 	at?: InputMaybe<Scalars['String']>
 	before?: InputMaybe<Scalars['String']>
 	direction: SortDirection
-	params: QueryInput
-	project_id: Scalars['ID']
-}
-
-export type QueryTraces_HistogramArgs = {
 	params: QueryInput
 	project_id: Scalars['ID']
 }

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1820,8 +1820,10 @@ export type Query = {
 	topUsers: Array<Maybe<TopUsersPayload>>
 	trace?: Maybe<Array<Trace>>
 	traces: TraceConnection
+	traces_histogram: TracesHistogram
 	traces_key_values: Array<Scalars['String']>
 	traces_keys: Array<QueryKey>
+	traces_metrics: TracesMetrics
 	track_properties_alerts: Array<Maybe<SessionAlert>>
 	unprocessedSessionsCount?: Maybe<Scalars['Int64']>
 	userFingerprintCount?: Maybe<UserFingerprintCount>
@@ -2402,6 +2404,11 @@ export type QueryTracesArgs = {
 	project_id: Scalars['ID']
 }
 
+export type QueryTraces_HistogramArgs = {
+	params: QueryInput
+	project_id: Scalars['ID']
+}
+
 export type QueryTraces_Key_ValuesArgs = {
 	date_range: DateRangeRequiredInput
 	key_name: Scalars['String']
@@ -2410,6 +2417,12 @@ export type QueryTraces_Key_ValuesArgs = {
 
 export type QueryTraces_KeysArgs = {
 	date_range: DateRangeRequiredInput
+	project_id: Scalars['ID']
+}
+
+export type QueryTraces_MetricsArgs = {
+	metric_types: Array<TracesMetricType>
+	params: QueryInput
 	project_id: Scalars['ID']
 }
 
@@ -3035,6 +3048,38 @@ export type TraceLink = {
 	spanID: Scalars['String']
 	traceID: Scalars['String']
 	traceState: Scalars['String']
+}
+
+export type TracesHistogram = {
+	__typename?: 'TracesHistogram'
+	buckets: Array<TracesHistogramBucket>
+	objectCount: Scalars['UInt64']
+	sampleFactor: Scalars['Float']
+	totalCount: Scalars['UInt64']
+}
+
+export type TracesHistogramBucket = {
+	__typename?: 'TracesHistogramBucket'
+	bucketId: Scalars['UInt64']
+	count: Scalars['UInt64']
+}
+
+export type TracesMetricBucket = {
+	__typename?: 'TracesMetricBucket'
+	bucketId: Scalars['UInt64']
+	metric_type: TracesMetricType
+	metric_value: Scalars['Float']
+}
+
+export enum TracesMetricType {
+	P50 = 'p50',
+	P90 = 'p90',
+}
+
+export type TracesMetrics = {
+	__typename?: 'TracesMetrics'
+	buckets: Array<TracesMetricBucket>
+	sampleFactor: Scalars['Float']
 }
 
 export type TrackProperty = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2311,13 +2311,12 @@ query GetTraces(
 
 query GetTracesHistogram($project_id: ID!, $params: QueryInput!) {
 	traces_histogram(project_id: $project_id, params: $params) {
-		totalCount
 		buckets {
-			bucketId
-			count
+			bucket_id
+			metric_value
 		}
-		objectCount
-		sampleFactor
+		bucket_count
+		sample_factor
 	}
 }
 
@@ -2332,11 +2331,12 @@ query GetTracesMetrics(
 		metric_types: $metric_types
 	) {
 		buckets {
-			bucketId
+			bucket_id
 			metric_type
 			metric_value
 		}
-		sampleFactor
+		bucket_count
+		sample_factor
 	}
 }
 

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2309,6 +2309,37 @@ query GetTraces(
 	}
 }
 
+query GetTracesHistogram($project_id: ID!, $params: QueryInput!) {
+	traces_histogram(project_id: $project_id, params: $params) {
+		totalCount
+		buckets {
+			bucketId
+			count
+		}
+		objectCount
+		sampleFactor
+	}
+}
+
+query GetTracesMetrics(
+	$project_id: ID!
+	$params: QueryInput!
+	$metric_types: [TracesMetricType!]!
+) {
+	traces_metrics(
+		project_id: $project_id
+		params: $params
+		metric_types: $metric_types
+	) {
+		buckets {
+			bucketId
+			metric_type
+			metric_value
+		}
+		sampleFactor
+	}
+}
+
 query GetTracesKeys($project_id: ID!, $date_range: DateRangeRequiredInput!) {
 	keys: traces_keys(project_id: $project_id, date_range: $date_range) {
 		name

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2309,17 +2309,6 @@ query GetTraces(
 	}
 }
 
-query GetTracesHistogram($project_id: ID!, $params: QueryInput!) {
-	traces_histogram(project_id: $project_id, params: $params) {
-		buckets {
-			bucket_id
-			metric_value
-		}
-		bucket_count
-		sample_factor
-	}
-}
-
 query GetTracesMetrics(
 	$project_id: ID!
 	$params: QueryInput!

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -508,7 +508,14 @@ export const LogAlertPage = () => {
 											threshold={threshold}
 											belowThreshold={belowThreshold}
 											frequencySeconds={frequency}
-											histogramData={histogramData}
+											histogramBuckets={
+												histogramData?.logs_histogram
+													.buckets
+											}
+											bucketCount={
+												histogramData?.logs_histogram
+													.totalCount
+											}
 											loading={histogramLoading}
 										/>
 									</Box>

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -173,8 +173,9 @@ const LogsPageInner = ({ timeMode, logCursor, startDateDefault }: Props) => {
 						endDate={endDate}
 						onDatesChange={handleDatesChange}
 						onLevelChange={handleLevelChange}
-						histogramData={histogramData}
 						loading={histogramLoading}
+						histogramBuckets={histogramData?.logs_histogram.buckets}
+						bucketCount={histogramData?.logs_histogram.totalCount}
 					/>
 					<Box width="full">
 						<AdditionalFeedResults


### PR DESCRIPTION
## Summary
- queries the materialized views for trace keys / values
- adds queries for metrics (count, p50, p90)
  - these query the `traces_sampling` table for queries > 1 hour
- use metrics queries with a histogram and line chart on top of the traces list view
  - did not put much effort into styling here, would like to deploy as a first version to see what the performance is like in prod

https://www.loom.com/share/71dd9d8301ec493095d8dbbb90dfe19f
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, materialized views / sampling table have already been created in prod
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- eventually, but the traces page is feature flagged atm
<!--
 Request review from julian-highlight / our design team 
-->
