### PR TITLE
feature flag billing issue banner

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -385,12 +385,13 @@ type AllWorkspaceSettings struct {
 	// store embeddings for errors in this workspace
 	ErrorEmbeddingsWrite bool `gorm:"default:false"`
 	// use embeddings to group errors in this workspace
-	ErrorEmbeddingsGroup     bool    `gorm:"default:false"`
-	ErrorEmbeddingsThreshold float64 `gorm:"default:0.2"`
-	ReplaceAssets            bool    `gorm:"default:false"`
-	StoreIP                  bool    `gorm:"default:false"`
-	EnableSessionExport      bool    `gorm:"default:false"`
-	EnableNetworkTraces      bool    `gorm:"default:false"`
+	ErrorEmbeddingsGroup      bool    `gorm:"default:false"`
+	ErrorEmbeddingsThreshold  float64 `gorm:"default:0.2"`
+	ReplaceAssets             bool    `gorm:"default:false"`
+	StoreIP                   bool    `gorm:"default:false"`
+	EnableSessionExport       bool    `gorm:"default:false"`
+	EnableNetworkTraces       bool    `gorm:"default:false"`
+	CanShowBillingIssueBanner bool    `gorm:"default:true"`
 }
 
 type HasSecret interface {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1257,6 +1257,7 @@ type ComplexityRoot struct {
 
 	SubscriptionDetails struct {
 		BaseAmount      func(childComplexity int) int
+		BillingIssue    func(childComplexity int) int
 		DiscountAmount  func(childComplexity int) int
 		DiscountPercent func(childComplexity int) int
 		LastInvoice     func(childComplexity int) int
@@ -8906,6 +8907,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SubscriptionDetails.BaseAmount(childComplexity), true
 
+	case "SubscriptionDetails.billingIssue":
+		if e.complexity.SubscriptionDetails.BillingIssue == nil {
+			break
+		}
+
+		return e.complexity.SubscriptionDetails.BillingIssue(childComplexity), true
+
 	case "SubscriptionDetails.discountAmount":
 		if e.complexity.SubscriptionDetails.DiscountAmount == nil {
 			break
@@ -9885,6 +9893,7 @@ type SubscriptionDetails {
 	discountPercent: Float!
 	discountAmount: Int64!
 	lastInvoice: Invoice
+	billingIssue: Boolean!
 }
 
 type Plan {
@@ -50984,6 +50993,8 @@ func (ec *executionContext) fieldContext_Query_subscription_details(ctx context.
 				return ec.fieldContext_SubscriptionDetails_discountAmount(ctx, field)
 			case "lastInvoice":
 				return ec.fieldContext_SubscriptionDetails_lastInvoice(ctx, field)
+			case "billingIssue":
+				return ec.fieldContext_SubscriptionDetails_billingIssue(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SubscriptionDetails", field.Name)
 		},
@@ -62255,6 +62266,50 @@ func (ec *executionContext) fieldContext_SubscriptionDetails_lastInvoice(ctx con
 				return ec.fieldContext_Invoice_status(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Invoice", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SubscriptionDetails_billingIssue(ctx context.Context, field graphql.CollectedField, obj *model.SubscriptionDetails) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SubscriptionDetails_billingIssue(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BillingIssue, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SubscriptionDetails_billingIssue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SubscriptionDetails",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -80455,6 +80510,13 @@ func (ec *executionContext) _SubscriptionDetails(ctx context.Context, sel ast.Se
 
 			out.Values[i] = ec._SubscriptionDetails_lastInvoice(ctx, field, obj)
 
+		case "billingIssue":
+
+			out.Values[i] = ec._SubscriptionDetails_billingIssue(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -736,6 +736,7 @@ type SubscriptionDetails struct {
 	DiscountPercent float64  `json:"discountPercent"`
 	DiscountAmount  int64    `json:"discountAmount"`
 	LastInvoice     *Invoice `json:"lastInvoice"`
+	BillingIssue    bool     `json:"billingIssue"`
 }
 
 type TopUsersPayload struct {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -149,6 +149,7 @@ type SubscriptionDetails {
 	discountPercent: Float!
 	discountAmount: Int64!
 	lastInvoice: Invoice
+	billingIssue: Boolean!
 }
 
 type Plan {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6799,6 +6799,11 @@ func (r *queryResolver) SubscriptionDetails(ctx context.Context, workspaceID int
 			Status:       &status,
 			URL:          &invoice.HostedInvoiceURL,
 		}
+		settings, err := r.Store.GetAllWorkspaceSettings(ctx, workspaceID)
+		if err != nil {
+			return nil, err
+		}
+		details.BillingIssue = settings.CanShowBillingIssueBanner && details.LastInvoice.Status != nil && lo.Contains([]string{"paid", "void", "draft"}, *details.LastInvoice.Status)
 	}
 
 	return details, nil

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6803,7 +6803,7 @@ func (r *queryResolver) SubscriptionDetails(ctx context.Context, workspaceID int
 		if err != nil {
 			return nil, err
 		}
-		details.BillingIssue = settings.CanShowBillingIssueBanner && details.LastInvoice.Status != nil && lo.Contains([]string{"paid", "void", "draft"}, *details.LastInvoice.Status)
+		details.BillingIssue = settings.CanShowBillingIssueBanner && details.LastInvoice.Status != nil && !lo.Contains([]string{"paid", "void", "draft"}, *details.LastInvoice.Status)
 	}
 
 	return details, nil

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -901,11 +901,12 @@ const BillingBanner: React.FC = () => {
 	})
 	const [hasReportedTrialExtension, setHasReportedTrialExtension] =
 		useLocalStorage('highlightReportedTrialExtension', false)
-	const { loading, subscriptionData } = useBillingHook({
+	const { loading: subscriptionLoading, subscriptionData } = useBillingHook({
 		project_id: projectId,
 	})
 	const billingIssues =
-		!loading && subscriptionData.subscription_details?.billingIssue
+		!subscriptionLoading &&
+		subscriptionData?.subscription_details.billingIssue
 
 	useEffect(() => {
 		if (

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -111,13 +111,6 @@ export const useBillingHook = ({
 		loading: subscriptionLoading,
 		subscriptionData: subscriptionData,
 		refetchSubscription: refetchSubscription,
-		issues:
-			!subscriptionLoading &&
-			subscriptionData?.subscription_details.lastInvoice?.status
-				?.length &&
-			!['paid', 'void', 'draft'].includes(
-				subscriptionData.subscription_details.lastInvoice.status,
-			),
 	}
 }
 
@@ -908,7 +901,11 @@ const BillingBanner: React.FC = () => {
 	})
 	const [hasReportedTrialExtension, setHasReportedTrialExtension] =
 		useLocalStorage('highlightReportedTrialExtension', false)
-	const { issues: billingIssues } = useBillingHook({ project_id: projectId })
+	const { loading, subscriptionData } = useBillingHook({
+		project_id: projectId,
+	})
+	const billingIssues =
+		!loading && subscriptionData.subscription_details?.billingIssue
 
 	useEffect(() => {
 		if (

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -8520,6 +8520,7 @@ export const GetSubscriptionDetailsDocument = gql`
 				url
 				status
 			}
+			billingIssue
 		}
 	}
 `

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2882,7 +2882,7 @@ export type GetSubscriptionDetailsQueryVariables = Types.Exact<{
 export type GetSubscriptionDetailsQuery = { __typename?: 'Query' } & {
 	subscription_details: { __typename?: 'SubscriptionDetails' } & Pick<
 		Types.SubscriptionDetails,
-		'baseAmount' | 'discountAmount' | 'discountPercent'
+		'baseAmount' | 'discountAmount' | 'discountPercent' | 'billingIssue'
 	> & {
 			lastInvoice?: Types.Maybe<
 				{ __typename?: 'Invoice' } & Pick<

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2955,6 +2955,7 @@ export type SubscriptionSession_Payload_AppendedArgs = {
 export type SubscriptionDetails = {
 	__typename?: 'SubscriptionDetails'
 	baseAmount: Scalars['Int64']
+	billingIssue: Scalars['Boolean']
 	discountAmount: Scalars['Int64']
 	discountPercent: Scalars['Float']
 	lastInvoice?: Maybe<Invoice>

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1042,6 +1042,7 @@ query GetSubscriptionDetails($workspace_id: ID!) {
 			url
 			status
 		}
+		billingIssue
 	}
 }
 


### PR DESCRIPTION
## Summary

Show the billing issue banner only if the workspace feature flag is set to true (default).
This allows overriding the billing issue banner for a customer who has an invoice issue that cannot be immediately resolved.

## How did you test this change?

feature flag default on

![image](https://github.com/highlight/highlight/assets/1351531/b617f1b9-0a35-439b-90ec-3c23e85a465c)

feature flag off

![image](https://github.com/highlight/highlight/assets/1351531/612b602a-490a-4535-b0c7-298e23b2e390)


## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
