### PR TITLE
e2e/remix cleanup

### DIFF
--- a/e2e/remix/app/components/highlight-buttons.tsx
+++ b/e2e/remix/app/components/highlight-buttons.tsx
@@ -19,6 +19,14 @@ export function HighlightButtons() {
 				Throw client-side error
 			</button>
 
+			<button
+				onClick={() => {
+					console.log('Remix console.log test')
+				}}
+			>
+				Test console.log
+			</button>
+
 			<ThrowerOfErrors />
 
 			<hr />

--- a/e2e/remix/app/entry.server.tsx
+++ b/e2e/remix/app/entry.server.tsx
@@ -21,7 +21,7 @@ import type { NodeOptions } from '@highlight-run/node'
 
 const nodeOptions: NodeOptions = {
 	projectID: CONSTANTS.HIGHLIGHT_PROJECT_ID,
-	otlpEndpoint: 'http://localhost:4318',
+	// otlpEndpoint: 'http://localhost:4318',
 	serviceName: 'my-remix-backend',
 	serviceVersion: '1.0.0',
 }

--- a/e2e/remix/app/root.tsx
+++ b/e2e/remix/app/root.tsx
@@ -35,7 +35,7 @@ export default function App() {
 		<html lang="en">
 			<HighlightInit
 				projectId={ENV.HIGHLIGHT_PROJECT_ID}
-				backendUrl="https://localhost:8082/public"
+				// backendUrl="https://localhost:8082/public"
 				serviceName="my-remix-frontend"
 				tracingOrigins
 				networkRecording={{ enabled: true, recordHeadersAndBody: true }}


### PR DESCRIPTION
## Summary

The `e2e/remix` test project was sending errors to a local Highlight instance, which made it harder to test quickly.