### PR TITLE
ensure error embeddings partitioned table runs migration without table level lock

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1591,7 +1591,7 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 	DB.Raw("select split_part(relname, '_', 5) from pg_stat_all_tables where relname like 'error_object_embeddings_partitioned%' order by relid desc limit 1").Scan(&lastCreatedPart)
 
 	// Make sure partitions are created for the next 1k projects, starting with the next partition needed
-	for i := lastCreatedPart + 1; i < lastVal+1002; i++ {
+	for i := lastCreatedPart + 1; i < lastVal+1000; i++ {
 		if err := DB.Exec(fmt.Sprintf(`
 			CREATE TABLE IF NOT EXISTS error_object_embeddings_partitioned_%d 
 			PARTITION OF error_object_embeddings_partitioned

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1593,7 +1593,7 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 	// Make sure partitions are created for the next 1k projects, starting with the next partition needed
 	for i := lastCreatedPart + 1; i < lastVal+1000; i++ {
 		if err := DB.Exec(fmt.Sprintf(`
-			CREATE TABLE IF NOT EXISTS error_object_embeddings_partitioned_%d 
+			CREATE TABLE IF NOT EXISTS error_object_embeddings_partitioned_%d
 			PARTITION OF error_object_embeddings_partitioned
 			FOR VALUES IN ('%d');
 		`, i, i)).Error; err != nil {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1595,7 +1595,7 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 		if err := DB.Exec(fmt.Sprintf(`
 			CREATE TABLE IF NOT EXISTS error_object_embeddings_partitioned_%d 
 			PARTITION OF error_object_embeddings_partitioned
-    		FOR VALUES IN ('%d');
+			FOR VALUES IN ('%d');
 		`, i, i)).Error; err != nil {
 			return false, e.Wrapf(err, "Error creating partitioned error_object_embeddings for index %d", i)
 		}

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1590,16 +1590,37 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 	// ignore errors - an error means that there are no partitions, so we can safely use the zero-value.
 	DB.Raw("select split_part(relname, '_', 5) from pg_stat_all_tables where relname like 'error_object_embeddings_partitioned%' order by relid desc limit 1").Scan(&lastCreatedPart)
 
-	// Make sure partitions are created for the next 1k projects
-	for i := lastCreatedPart; i < lastVal+1000; i++ {
-		sql := fmt.Sprintf(`
-			CREATE TABLE IF NOT EXISTS error_object_embeddings_partitioned_%d
+	// Make sure partitions are created for the next 1k projects, starting with the next partition needed
+	for i := lastCreatedPart + 1; i < lastVal+1002; i++ {
+		if err := DB.Exec(fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS error_object_embeddings_partitioned_%d 
 			PARTITION OF error_object_embeddings_partitioned
-			FOR VALUES IN ('%d');
-		`, i, i)
-
-		if err := DB.Exec(sql).Error; err != nil {
+    		FOR VALUES IN ('%d');
+		`, i, i)).Error; err != nil {
 			return false, e.Wrapf(err, "Error creating partitioned error_object_embeddings for index %d", i)
+		}
+
+		if err := DB.Exec(fmt.Sprintf(`
+			CREATE INDEX ON error_object_embeddings_partitioned_%d
+			USING ivfflat (gte_large_embedding vector_l2_ops) WITH (lists = 1000);
+		`, i)).Error; err != nil {
+			return false, e.Wrapf(err, "Error creating index error_object_embeddings for index %d", i)
+		}
+
+		// in case this partition was already attached by a previous failed migration, try detach first
+		if err := DB.Exec(fmt.Sprintf(`
+			ALTER TABLE error_object_embeddings_partitioned 
+			DETACH PARTITION error_object_embeddings_partitioned_%d;
+		`, i)).Error; err != nil {
+			return false, e.Wrapf(err, "Error detaching partitioned error_object_embeddings for index %d", i)
+		}
+
+		if err := DB.Exec(fmt.Sprintf(`
+			ALTER TABLE error_object_embeddings_partitioned 
+			ATTACH PARTITION error_object_embeddings_partitioned_%d
+			FOR VALUES IN ('%d');
+		`, i, i)).Error; err != nil {
+			return false, e.Wrapf(err, "Error attaching partitioned error_object_embeddings for index %d", i)
 		}
 	}
 

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1575,7 +1575,7 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 
 	if err := DB.Exec(`
 		CREATE TABLE IF NOT EXISTS error_object_embeddings_partitioned
-		(LIKE error_object_embeddings INCLUDING ALL)
+		(LIKE error_object_embeddings INCLUDING DEFAULTS INCLUDING IDENTITY)
 		PARTITION BY LIST (project_id);
 	`).Error; err != nil {
 		return false, e.Wrap(err, "Error creating error_object_embeddings_partitioned")
@@ -1594,7 +1594,7 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 	for i := lastCreatedPart + 1; i < lastVal+1000; i++ {
 		if err := DB.Exec(fmt.Sprintf(`
 			CREATE TABLE IF NOT EXISTS error_object_embeddings_partitioned_%d
-			(LIKE error_object_embeddings_partitioned INCLUDING ALL);
+			(LIKE error_object_embeddings_partitioned INCLUDING DEFAULTS INCLUDING IDENTITY);
 		`, i)).Error; err != nil {
 			return false, e.Wrapf(err, "Error creating partitioned error_object_embeddings for index %d", i)
 		}


### PR DESCRIPTION
## Summary

Ensures that partitions of `error_object_embeddings_partitioned` are attached 
[without requiring a table lock](https://www.postgresql.org/docs/current/ddl-partitioning.html#DDL-PARTITIONING-DECLARATIVE-MAINTENANCE).
Automates creating L2 distance indexes for new partitions.

## How did you test this change?

Local migration with debug
```
2023/10/05 11:45:39 /home/vkorolik/work/highlight/backend/model/model.go:1595
[1.964ms] [rows:0] 
			CREATE TABLE IF NOT EXISTS error_object_embeddings_partitioned_1007
			(LIKE error_object_embeddings_partitioned INCLUDING ALL);
		

2023/10/05 11:45:39 /home/vkorolik/work/highlight/backend/model/model.go:1602
[149.305ms] [rows:0] 
			CREATE INDEX ON error_object_embeddings_partitioned_1007
			USING ivfflat (gte_large_embedding vector_l2_ops) WITH (lists = 1000);
		

2023/10/05 11:45:39 /home/vkorolik/work/highlight/backend/model/model.go:1611
[2.417ms] [rows:0] 
			ALTER TABLE error_object_embeddings_partitioned 
			ATTACH PARTITION error_object_embeddings_partitioned_1007
			FOR VALUES IN ('1007');
```

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
