### PR TITLE
ensure opentelemetry is build for docker image

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -51,9 +51,6 @@ jobs:
             - name: Install js dependencies
               run: yarn
 
-            - name: Check for necessary changesets
-              run: yarn changeset status --since origin/main
-
             - name: Check generated files for Reflame
               run: yarn reflame-check
 

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -14,6 +14,7 @@ COPY ../blog-content ./blog-content
 COPY ../docs-content ./docs-content
 COPY ../frontend ./frontend
 COPY ../highlight.io ./highlight.io
+COPY ../opentelemetry-sdk-workers ./opentelemetry-sdk-workers
 COPY ../packages ./packages
 COPY ../render ./render
 COPY ../rrweb ./rrweb

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "ai",
 	"packageManager": "yarn@3.5.0",
+	"private": true,
 	"scripts": {
 		"build": "tsc --build ./",
 		"dev": "DEV=true nodemon",

--- a/sdk/highlight-cloudflare/package.json
+++ b/sdk/highlight-cloudflare/package.json
@@ -28,7 +28,7 @@
 		"@opentelemetry/resources": "1.17.0"
 	},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20230518.0",
+		"@cloudflare/workers-types": "^4.20230115.0",
 		"tsup": "^6.7.0"
 	}
 }

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -61,6 +61,7 @@
 		"highlight.run": "workspace:*"
 	},
 	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20230115.0",
 		"@opentelemetry/api": "1.4.1",
 		"@opentelemetry/resources": "1.17.0",
 		"@trpc/server": "^9.27.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8483,13 +8483,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cloudflare/workers-types@npm:^4.20230518.0":
-  version: 4.20230518.0
-  resolution: "@cloudflare/workers-types@npm:4.20230518.0"
-  checksum: 69c861437f1064b860b2a52129ed973f670090a8d2de9f4b205f86f8a2f40caec48b8c7614533c6531875d1fa254fc7d9da3ab52d7a6fff46be0f64079b394dc
-  languageName: node
-  linkType: hard
-
 "@colors/colors@npm:1.5.0":
   version: 1.5.0
   resolution: "@colors/colors@npm:1.5.0"
@@ -12589,7 +12582,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@highlight-run/cloudflare@workspace:sdk/highlight-cloudflare"
   dependencies:
-    "@cloudflare/workers-types": ^4.20230518.0
+    "@cloudflare/workers-types": ^4.20230115.0
     "@highlight-run/opentelemetry-sdk-workers": "workspace:*"
     "@opentelemetry/resources": 1.17.0
     tsup: ^6.7.0
@@ -12777,6 +12770,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@highlight-run/next@workspace:sdk/highlight-next"
   dependencies:
+    "@cloudflare/workers-types": ^4.20230115.0
     "@highlight-run/cloudflare": "workspace:*"
     "@highlight-run/node": "workspace:*"
     "@highlight-run/opentelemetry-sdk-workers": "workspace:*"


### PR DESCRIPTION
## Summary

Ensure that our docker image build can reference the opentelemetry-sdk-workers submodule.
Ensure cloudflare types are imported by our next SDK.

## How did you test this change?

CI

## Are there any deployment considerations?

Deploying new docker image release

## Does this work require review from our design team?

No
