### PR TITLE
fix backend test running out of disk space

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -6,7 +6,6 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/util"
 	"net/url"
 	"os"
 	"regexp"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/aws/smithy-go/ptr"
 	Email "github.com/highlight-run/highlight/backend/email"
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/routing"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
@@ -40,9 +40,25 @@ import (
 	"github.com/pkg/errors"
 	e "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-
-	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 )
+
+var (
+	env     = os.Getenv("ENVIRONMENT")
+	DevEnv  = "dev"
+	TestEnv = "test"
+)
+
+func IsDevEnv() bool {
+	return env == DevEnv
+}
+
+func IsTestEnv() bool {
+	return env == TestEnv
+}
+
+func IsDevOrTestEnv() bool {
+	return IsTestEnv() || IsDevEnv()
+}
 
 var (
 	DB                *gorm.DB
@@ -1592,7 +1608,7 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 	DB.Raw("select split_part(relname, '_', 5) from pg_stat_all_tables where relname like 'error_object_embeddings_partitioned%' order by relid desc limit 1").Scan(&lastCreatedPart)
 
 	endPart := lastVal + 1000
-	if util.IsDevOrTestEnv() {
+	if IsDevOrTestEnv() {
 		// limit the number of partitions created in dev or test to limit disk usage
 		endPart = lastVal + 10
 	}

--- a/backend/util/environment.go
+++ b/backend/util/environment.go
@@ -1,14 +1,12 @@
 package util
 
 import (
+	"github.com/highlight-run/highlight/backend/model"
 	"os"
 	"strings"
 )
 
 var (
-	env           = os.Getenv("ENVIRONMENT")
-	DevEnv        = "dev"
-	TestEnv       = "test"
 	OnPrem        = os.Getenv("ON_PREM")
 	DopplerConfig = os.Getenv("DOPPLER_CONFIG")
 	InDocker      = os.Getenv("IN_DOCKER")
@@ -16,20 +14,20 @@ var (
 	Version       = os.Getenv("REACT_APP_COMMIT_SHA")
 )
 
-func IsHubspotEnabled() bool {
-	return !IsDevEnv() && !IsTestEnv()
-}
-
 func IsDevEnv() bool {
-	return env == DevEnv
+	return model.IsDevEnv()
 }
 
 func IsTestEnv() bool {
-	return env == TestEnv
+	return model.IsTestEnv()
 }
 
 func IsDevOrTestEnv() bool {
-	return IsTestEnv() || IsDevEnv()
+	return model.IsDevOrTestEnv()
+}
+
+func IsHubspotEnabled() bool {
+	return !IsDevOrTestEnv()
 }
 
 func IsOnPrem() bool {


### PR DESCRIPTION
## Summary

We saw out-of-disk errors from test invocation due to the number of partition indexes created as part of #6805 
```
2023-10-06T19:54:32.9732974Z time="2023-10-06T19:54:32Z" level=error msg="error creating testdb: error migrating test db: Error creating index error_object_embeddings for index 885: ERROR: could not extend file \"base/23587/30785\": No space left on device (SQLSTATE 53100)" DB_HOST=localhost DB_NAME=highlight_testing_db
2023-10-06T19:54:32.9735255Z === RUN   TestIsProjectIntegrated
2023-10-06T19:54:32.9735884Z === RUN   TestIsProjectIntegrated/TestIsProjectIntegrated
2023-10-06T19:54:32.9736486Z --- FAIL: TestIsProjectIntegrated (0.00s)
2023-10-06T19:54:32.9737181Z     --- FAIL: TestIsProjectIntegrated/TestIsProjectIntegrated (0.00s)
2023-10-06T19:54:32.9745917Z panic: runtime error: invalid memory address or nil pointer dereference [recovered]
2023-10-06T19:54:32.9747094Z 	panic: runtime error: invalid memory address or nil pointer dereference
2023-10-06T19:54:32.9851545Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8b7902]
2023-10-06T19:54:32.9852196Z 
2023-10-06T19:54:32.9852542Z goroutine 13 [running]:
2023-10-06T19:54:32.9853733Z testing.tRunner.func1.2({0xcaf320, 0x1408890})
2023-10-06T19:54:32.9928440Z 	/opt/hostedtoolcache/go/1.20.8/x64/src/testing/testing.go:1526 +0x24e
2023-10-06T19:54:32.9930124Z testing.tRunner.func1()
2023-10-06T19:54:32.9939687Z 	/opt/hostedtoolcache/go/1.20.8/x64/src/testing/testing.go:1529 +0x39f
2023-10-06T19:54:32.9940078Z panic({0xcaf320, 0x1408890})
2023-10-06T19:54:32.9940493Z 	/opt/hostedtoolcache/go/1.20.8/x64/src/runtime/panic.go:884 +0x213
2023-10-06T19:54:32.9940866Z gorm.io/gorm.(*DB).Create(0xf35c40?, {0xcc86c0?, 0xc0003b2160?})
2023-10-06T19:54:32.9941331Z 	/home/runner/go/pkg/mod/gorm.io/gorm@v1.21.9/finisher_api.go:18 +0x22
2023-10-06T19:54:32.9942170Z github.com/highlight-run/highlight/backend/integrations.TestIsProjectIntegrated.func1(0x0?)
2023-10-06T19:54:32.9942742Z 	/home/runner/work/highlight/highlight/backend/integrations/integrations_test.go:16 +0x5b
2023-10-06T19:54:32.9943140Z testing.tRunner(0xc00035c9c0, 0xe0b540)
2023-10-06T19:54:32.9943538Z 	/opt/hostedtoolcache/go/1.20.8/x64/src/testing/testing.go:1576 +0x10b
2023-10-06T19:54:32.9943872Z created by testing.(*T).Run
2023-10-06T19:54:32.9944232Z 	/opt/hostedtoolcache/go/1.20.8/x64/src/testing/testing.go:1629 +0x3ea
2023-10-06T19:54:32.9944735Z FAIL	github.com/highlight-run/highlight/backend/integrations	167.696s
2023-10-06T19:54:32.9945284Z ?   	github.com/highlight-run/highlight/backend/integrations/github	[no test files]
2023-10-06T19:54:32.9945840Z ?   	github.com/highlight-run/highlight/backend/integrations/height	[no test files]
2023-10-06T19:54:32.9946387Z ?   	github.com/highlight-run/highlight/backend/jobs/log-alerts	[no test files]
2023-10-06T19:54:32.9946936Z ?   	github.com/highlight-run/highlight/backend/jobs/metric-monitor	[no test files]
2023-10-06T19:54:34.4623731Z # github.com/highlight-run/highlight/backend/kafka-queue.test
2023-10-06T19:54:34.4624668Z /opt/hostedtoolcache/go/1.20.8/x64/pkg/tool/linux_amd64/link: mapping output file failed: no space left on device
2023-10-06T19:54:34.5257117Z FAIL	github.com/highlight-run/highlight/backend/kafka-queue [build failed]
```

## How did you test this change?

CI

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
