### PR TITLE
handling process.env.NEXT_RUNTIME as 'undefined'

### DIFF
--- a/.changeset/wicked-bugs-type.md
+++ b/.changeset/wicked-bugs-type.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/next': patch
+---
+
+Handling undefined NEXT_RUNTIME

--- a/sdk/highlight-cloudflare/package.json
+++ b/sdk/highlight-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/cloudflare",
-	"version": "2.1.2",
+	"version": "2.1.3",
 	"packageManager": "yarn@3.2.3",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "5.0.4",
+	"version": "5.0.5",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "5.0.1",
+	"version": "5.0.4",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-next/src/server.ts
+++ b/sdk/highlight-next/src/server.ts
@@ -20,7 +20,7 @@ export const Highlight = PageRouterHighlight
 export function PageRouterHighlight(
 	env: HighlightEnv,
 ): PageRouterHighlightHandler {
-	if (process.env.NEXT_RUNTIME === 'nodejs') {
+	if (isNodeJs()) {
 		return withHighlightNodeJsPageRouter.Highlight(env)
 	} else {
 		throw new Error(
@@ -30,7 +30,7 @@ export function PageRouterHighlight(
 }
 
 export function AppRouterHighlight(env: HighlightEnv) {
-	if (process.env.NEXT_RUNTIME === 'nodejs') {
+	if (isNodeJs()) {
 		return withHighlightNodeJsAppRouter.Highlight(env)
 	} else {
 		throw new Error(
@@ -48,4 +48,11 @@ export function EdgeHighlight(
 	event: NextFetchEvent & ExtendedExecutionContext,
 ) => Promise<Response> {
 	throw new Error(`unsupported NEXT_RUNTIME: ${process.env.NEXT_RUNTIME}`)
+}
+
+function isNodeJs() {
+	return (
+		typeof process.env.NEXT_RUNTIME === 'undefined' ||
+		process.env.NEXT_RUNTIME === 'nodejs'
+	)
 }

--- a/sdk/highlight-next/src/util/highlight-node.ts
+++ b/sdk/highlight-next/src/util/highlight-node.ts
@@ -12,7 +12,7 @@ export declare interface Metric {
 export const H: HighlightInterface = {
 	...NodeH,
 	init: (options: NodeOptions) => {
-		if (process.env.NEXT_RUNTIME === 'nodejs') {
+		if (isNodeJs()) {
 			if (!NodeH.isInitialized()) {
 				NodeH.init(options)
 			}
@@ -53,4 +53,11 @@ export const H: HighlightInterface = {
 			'H.sendResponse is not implemented for the Node runtime.',
 		)
 	},
+}
+
+function isNodeJs() {
+	return (
+		typeof process.env.NEXT_RUNTIME === 'undefined' ||
+		process.env.NEXT_RUNTIME === 'nodejs'
+	)
 }


### PR DESCRIPTION
Turns out that NEXT_RUNTIME can be undefined 😢 