### PR TITLE
Fix dialog story & try out reflame test update

### DIFF
--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -8,11 +8,11 @@ export default {
 	component: Dialog,
 } as ComponentMeta<typeof Dialog>
 
-export const Basic = () => {
+export const Basic = ({ rootRef }: { rootRef: React.Ref<HTMLDivElement> }) => {
 	const store = Dialog.useStore({ defaultOpen: true })
 	return (
 		<Dialog store={store}>
-			<div>Hello!! 👋</div>
+			<div ref={rootRef}>Hello!! 👋</div>
 		</Dialog>
 	)
 }

--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -9,6 +9,10 @@ export default {
 } as ComponentMeta<typeof Dialog>
 
 export const Basic = () => {
-	const store = Dialog.useStore()
-	return <Dialog store={store}>Hello!! 👋</Dialog>
+	const store = Dialog.useStore({ defaultOpen: true })
+	return (
+		<Dialog store={store}>
+			<div>Hello!! 👋</div>
+		</Dialog>
+	)
 }

--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -9,5 +9,5 @@ export default {
 } as ComponentMeta<typeof Dialog>
 
 export const Basic = () => {
-	return <Dialog>Hello! 👋</Dialog>
+	return <Dialog>Hello!! 👋</Dialog>
 }

--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -9,11 +9,11 @@ export default {
 } as ComponentMeta<typeof Dialog>
 
 export const Basic = ({ rootRef }: { rootRef: React.Ref<HTMLDivElement> }) => {
-	console.log({ rootRef })
 	const store = Dialog.useStore({ defaultOpen: true })
 	return (
 		<Dialog store={store}>
-			<div ref={rootRef}>Hello!! 👋</div>
+			{/* rootRef tells Reflame to screenshot this portal'ed element instead of the empty root element */}
+			<div ref={rootRef}>Hello!!! 👋</div>
 		</Dialog>
 	)
 }

--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -9,5 +9,6 @@ export default {
 } as ComponentMeta<typeof Dialog>
 
 export const Basic = () => {
-	return <Dialog>Hello!! 👋</Dialog>
+	const store = Dialog.useStore()
+	return <Dialog store={store}>Hello!! 👋</Dialog>
 }

--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -9,6 +9,7 @@ export default {
 } as ComponentMeta<typeof Dialog>
 
 export const Basic = ({ rootRef }: { rootRef: React.Ref<HTMLDivElement> }) => {
+	console.log({ rootRef })
 	const store = Dialog.useStore({ defaultOpen: true })
 	return (
 		<Dialog store={store}>

--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -8,4 +8,6 @@ export default {
 	component: Dialog,
 } as ComponentMeta<typeof Dialog>
 
-export const Basic = () => <Dialog>Hello! 👋</Dialog>
+export const Basic = () => {
+	return <Dialog>Hello! 👋</Dialog>
+}

--- a/packages/ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.stories.tsx
@@ -13,7 +13,7 @@ export const Basic = ({ rootRef }: { rootRef: React.Ref<HTMLDivElement> }) => {
 	return (
 		<Dialog store={store}>
 			{/* rootRef tells Reflame to screenshot this portal'ed element instead of the empty root element */}
-			<div ref={rootRef}>Hello!!! 👋</div>
+			<div ref={rootRef}>Hello! 👋</div>
 		</Dialog>
 	)
 }


### PR DESCRIPTION
## Summary

New version of Reflame tests can now reuse results from a previous test when it finds one with an identical dependency graph, a critical cost-savings measure for large test suites.

I also updated the test results display to use markdown content with embedded images directly instead of the images field in github checks, and split tests results into failed, completed, skipped sections, which should make test results a lot easier to digest.

While testing this out I actually found a bug with one of the stories and fixed it here. :)

Check out the new test results display [here](https://github.com/highlight/highlight/pull/6816/checks?check_run_id=17488390451), and let me know what you think!

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
