### PR TITLE
fix filtering for errors ingest based on project event filters

### DIFF
--- a/backend/public-graph/graph/sampling.go
+++ b/backend/public-graph/graph/sampling.go
@@ -442,6 +442,9 @@ func (r *Resolver) isExcludedError(ctx context.Context, projectID int, errorFilt
 	var err error
 	matchedRegexp := false
 	for _, errorFilter := range errorFilters {
+		if errorFilter == "" {
+			continue
+		}
 		matchedRegexp, err = regexp.MatchString(errorFilter, errorEvent)
 		if err != nil {
 			log.WithContext(ctx).

--- a/backend/public-graph/graph/sampling.go
+++ b/backend/public-graph/graph/sampling.go
@@ -143,12 +143,10 @@ func (r *Resolver) IsErrorIngestedByFilter(ctx context.Context, projectID int, e
 		return true
 	}
 
-	var errorFilters []string
 	if project, err := r.Store.GetProject(ctx, settings.ProjectID); err == nil {
-		errorFilters = append(errorFilters, project.ErrorFilters...)
-	}
-	if r.isExcludedError(ctx, projectID, errorFilters, errorObject.Event) {
-		return false
+		if r.isExcludedError(ctx, projectID, project.ErrorFilters, errorObject.Event) {
+			return false
+		}
 	}
 
 	return r.isItemIngestedByFilter(ctx, privateModel.ProductTypeErrors, settings.ProjectID, errorObject)

--- a/backend/public-graph/graph/sampling_test.go
+++ b/backend/public-graph/graph/sampling_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	model2 "github.com/highlight-run/highlight/backend/public-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/redis"
 	"github.com/highlight-run/highlight/backend/store"
 	"github.com/openlyinc/pointy"
@@ -126,4 +127,19 @@ func Test_IsSessionExcluded(t *testing.T) {
 			assert.Equal(t, modelInputs.SessionExcludedReasonRateLimitMinute, *reason)
 		}
 	}
+}
+
+func Test_isExcludedError(t *testing.T) {
+	ctx := context.TODO()
+	p1 := &model.Project{ErrorFilters: []string{".*a+.*"}}
+	p2 := &model.Project{ErrorFilters: []string{"("}}
+	resolver.DB.Create(p1)
+	resolver.DB.Create(p2)
+	if err := resolver.Redis.FlushDB(context.TODO()); err != nil {
+		t.Error(err)
+	}
+	assert.True(t, resolver.IsErrorIngestedByFilter(ctx, 1, &model2.BackendErrorObjectInput{Event: ""}))
+	assert.False(t, resolver.IsErrorIngestedByFilter(ctx, 2, &model2.BackendErrorObjectInput{Event: "[{}]"}))
+	assert.False(t, resolver.IsErrorIngestedByFilter(ctx, p1.ID, &model2.BackendErrorObjectInput{Event: "foo bar baz"}))
+	assert.True(t, resolver.IsErrorIngestedByFilter(ctx, p2.ID, &model2.BackendErrorObjectInput{Event: "foo bar baz"}))
 }

--- a/backend/public-graph/graph/sampling_test.go
+++ b/backend/public-graph/graph/sampling_test.go
@@ -131,15 +131,17 @@ func Test_IsSessionExcluded(t *testing.T) {
 
 func Test_isExcludedError(t *testing.T) {
 	ctx := context.TODO()
-	p1 := &model.Project{ErrorFilters: []string{".*a+.*"}}
-	p2 := &model.Project{ErrorFilters: []string{"("}}
+	p1 := &model.Project{ErrorFilters: []string{""}}
+	p2 := &model.Project{ErrorFilters: []string{".*a+.*"}}
+	p3 := &model.Project{ErrorFilters: []string{"("}}
 	resolver.DB.Create(p1)
 	resolver.DB.Create(p2)
+	resolver.DB.Create(p3)
 	if err := resolver.Redis.FlushDB(context.TODO()); err != nil {
 		t.Error(err)
 	}
-	assert.True(t, resolver.IsErrorIngestedByFilter(ctx, 1, &model2.BackendErrorObjectInput{Event: ""}))
-	assert.False(t, resolver.IsErrorIngestedByFilter(ctx, 2, &model2.BackendErrorObjectInput{Event: "[{}]"}))
-	assert.False(t, resolver.IsErrorIngestedByFilter(ctx, p1.ID, &model2.BackendErrorObjectInput{Event: "foo bar baz"}))
-	assert.True(t, resolver.IsErrorIngestedByFilter(ctx, p2.ID, &model2.BackendErrorObjectInput{Event: "foo bar baz"}))
+	assert.True(t, resolver.IsErrorIngestedByFilter(ctx, p1.ID, &model2.BackendErrorObjectInput{Event: ""}))
+	assert.False(t, resolver.IsErrorIngestedByFilter(ctx, p1.ID, &model2.BackendErrorObjectInput{Event: "[{}]"}))
+	assert.False(t, resolver.IsErrorIngestedByFilter(ctx, p2.ID, &model2.BackendErrorObjectInput{Event: "foo bar baz"}))
+	assert.True(t, resolver.IsErrorIngestedByFilter(ctx, p3.ID, &model2.BackendErrorObjectInput{Event: "foo bar baz"}))
 }


### PR DESCRIPTION
## Summary

Error exclusion with events was not using the project based filters
because we would be using the `query` criteria to skip the exclusion.

## How did you test this change?

New unit test.

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No