### PR TITLE
use request id when set for the trace id

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -3003,7 +3003,10 @@ func (r *Resolver) submitFrontendNetworkMetric(sessionObj *model.Session, resour
 			}
 		}
 
-		span, _ := highlight.StartTraceWithTimestamp(context.Background(), strings.Join([]string{method, re.Name}, " "), start, attributes...)
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, highlight.ContextKeys.SessionSecureID, sessionObj.SecureID)
+		ctx = context.WithValue(ctx, highlight.ContextKeys.RequestID, re.RequestResponsePairs.Request.ID)
+		span, _ := highlight.StartTraceWithTimestamp(ctx, strings.Join([]string{method, re.Name}, " "), start, attributes...)
 		span.End(trace.WithTimestamp(end))
 	}
 	return nil

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -3,7 +3,6 @@ package highlight
 import (
 	"context"
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -121,12 +120,8 @@ func StartTraceWithTimestamp(ctx context.Context, name string, t time.Time, tags
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if requestID != "" {
 		data, _ := base64.StdEncoding.DecodeString(requestID)
-		s := hex.EncodeToString(data)
-		add := 32 - len(s)
-		for i := 0; i < add; i++ {
-			s += "0"
-		}
-		tid, _ := trace.TraceIDFromHex(s)
+		hex := fmt.Sprintf("%032x", data)
+		tid, _ := trace.TraceIDFromHex(hex)
 		spanCtx = spanCtx.WithTraceID(tid)
 	}
 	ctx, span := tracer.Start(trace.ContextWithSpanContext(ctx, spanCtx), name, trace.WithTimestamp(t))


### PR DESCRIPTION
## Summary

Fixes frontend network trace recording to store the request ID as the trace ID.
Propagates the request ID to the child span context to associate backend traces 
with the frontend network request by using the request ID as a trace ID.

## How did you test this change?

Backend traces correctly associated with network request trace.
![image](https://github.com/highlight/highlight/assets/1351531/b42ebdec-9d2a-4839-81f6-30563aff4730)

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
