### PR TITLE
Update Slack alerts

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2990,7 +2990,7 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 		bodyBlockSet = append(bodyBlockSet, slack.NewSectionBlock(sessionBlock, attributeBlocks, accessory))
 	}
 
-	// move body within red line attachment
+	// move body within line attachment
 	attachment = &slack.Attachment{
 		Color:  getAlertColor(*obj.Type),
 		Blocks: slack.Blocks{BlockSet: bodyBlockSet},

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -938,16 +938,22 @@ func (r *Resolver) CreateSlackBlocks(admin *model.Admin, viewLink, commentText, 
 	}
 
 	// Header
-	message := fmt.Sprintf("You were %s in %s %s comment.", action, determiner, subjectScope)
+	message := fmt.Sprintf("*You were %s in %s %s comment.*", action, determiner, subjectScope)
 	if admin.Email != nil && *admin.Email != "" {
-		message = fmt.Sprintf("%s %s you in %s %s comment.", *admin.Email, action, determiner, subjectScope)
+		message = fmt.Sprintf("*%s %s you in %s %s comment.*", *admin.Email, action, determiner, subjectScope)
 	}
 	if admin.Name != nil && *admin.Name != "" {
-		message = fmt.Sprintf("%s %s you in %s %s comment.", *admin.Name, action, determiner, subjectScope)
+		message = fmt.Sprintf("*%s %s you in %s %s comment.*", *admin.Name, action, determiner, subjectScope)
 	}
 
+	blockSet.BlockSet = append(blockSet.BlockSet,
+		slack.NewSectionBlock(
+			&slack.TextBlockObject{Type: slack.MarkdownType, Text: message},
+			nil, nil,
+		),
+	)
+
 	// comment message
-	blockSet.BlockSet = append(blockSet.BlockSet, slack.NewHeaderBlock(&slack.TextBlockObject{Type: slack.PlainTextType, Text: message}))
 	blockSet.BlockSet = append(blockSet.BlockSet,
 		slack.NewSectionBlock(
 			&slack.TextBlockObject{Type: slack.MarkdownType, Text: fmt.Sprintf("> %s", commentText)},
@@ -959,14 +965,14 @@ func (r *Resolver) CreateSlackBlocks(admin *model.Admin, viewLink, commentText, 
 	if subjectScope == "error" {
 		blockSet.BlockSet = append(blockSet.BlockSet,
 			slack.NewSectionBlock(
-				&slack.TextBlockObject{Type: slack.MarkdownType, Text: fmt.Sprintf("*Error*: %s\n %s", viewLink, *additionalContext)},
+				&slack.TextBlockObject{Type: slack.MarkdownType, Text: fmt.Sprintf("*Error* %s\n %s", viewLink, *additionalContext)},
 				nil, nil,
 			),
 		)
 	} else if subjectScope == "session" {
 		blockSet.BlockSet = append(blockSet.BlockSet,
 			slack.NewSectionBlock(
-				&slack.TextBlockObject{Type: slack.MarkdownType, Text: fmt.Sprintf("*Session*: %s\n%s", viewLink, *additionalContext)},
+				&slack.TextBlockObject{Type: slack.MarkdownType, Text: fmt.Sprintf("*Session* %s\n%s", viewLink, *additionalContext)},
 				nil, nil,
 			),
 		)

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1817,6 +1817,7 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 
 			errorAlert.SendAlerts(ctx, r.DB, r.MailClient, &model.SendSlackAlertInput{
 				Workspace:       workspace,
+				Project:         &project,
 				SessionSecureID: sessionObj.SecureID,
 				SessionExcluded: sessionObj.Excluded && *sessionObj.Processed,
 				UserIdentifier:  sessionObj.Identifier,

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
@@ -244,7 +244,7 @@ export const NewCommentForm = ({
 						? issueDescription
 						: null,
 					additional_context: currentUrl
-						? `*User\'s URL:* <${currentUrl}|${currentUrl}>`
+						? `*User\'s URL* <${currentUrl}|${currentUrl}>`
 						: null,
 				},
 				refetchQueries: [namedOperations.Query.GetSessionComments],


### PR DESCRIPTION
## Summary
Slack alerts are not standardized and can be hard to decipher. Update the Slack alerts to use different colors to signify level and standardize how they are displayed.

## How did you test this change?
1) Create each of the alert and view in #spencer-error-test channel

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
Yes
