### PR TITLE
Update slack and discord error alerts

### DIFF
--- a/backend/alerts/alerts.go
+++ b/backend/alerts/alerts.go
@@ -18,14 +18,14 @@ import (
 )
 
 type SendErrorAlertEvent struct {
-	Session     *model.Session
-	ErrorAlert  *model.ErrorAlert
-	ErrorGroup  *model.ErrorGroup
-	ErrorObject *model.ErrorObject
-	Workspace   *model.Workspace
-	ErrorCount  int64
-	VisitedURL  string
-	FirstAlert  bool
+	Session         *model.Session
+	ErrorAlert      *model.ErrorAlert
+	ErrorGroup      *model.ErrorGroup
+	ErrorObject     *model.ErrorObject
+	Workspace       *model.Workspace
+	ErrorCount      int64
+	VisitedURL      string
+	FirstErrorAlert bool
 }
 
 func SendErrorAlert(ctx context.Context, event SendErrorAlertEvent) error {
@@ -41,7 +41,7 @@ func SendErrorAlert(ctx context.Context, event SendErrorAlertEvent) error {
 		SessionURL:      getSessionURL(event.ErrorAlert.ProjectID, event.Session),
 		SessionExcluded: event.Session.Excluded && *event.Session.Processed,
 		VisitedURL:      event.VisitedURL,
-		FirstTimeAlert:  event.FirstAlert,
+		FirstTimeAlert:  event.FirstErrorAlert,
 	}
 
 	var g errgroup.Group

--- a/backend/alerts/alerts.go
+++ b/backend/alerts/alerts.go
@@ -25,6 +25,7 @@ type SendErrorAlertEvent struct {
 	Workspace   *model.Workspace
 	ErrorCount  int64
 	VisitedURL  string
+	FirstAlert  bool
 }
 
 func SendErrorAlert(ctx context.Context, event SendErrorAlertEvent) error {
@@ -40,6 +41,7 @@ func SendErrorAlert(ctx context.Context, event SendErrorAlertEvent) error {
 		SessionURL:      getSessionURL(event.ErrorAlert.ProjectID, event.Session),
 		SessionExcluded: event.Session.Excluded && *event.Session.Processed,
 		VisitedURL:      event.VisitedURL,
+		FirstTimeAlert:  event.FirstAlert,
 	}
 
 	var g errgroup.Group

--- a/backend/alerts/integrations/discord/messages.go
+++ b/backend/alerts/integrations/discord/messages.go
@@ -43,7 +43,12 @@ func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlert
 	})
 
 	embed := newMessageEmbed()
-	embed.Title = "Highlight Error Alert"
+	if payload.FirstTimeAlert {
+		embed.Title = "New Highlight Error Alert"
+	} else {
+		embed.Title = "Highlight Error Alert"
+	}
+
 	embed.Description = payload.UserIdentifier
 	embed.Fields = fields
 

--- a/backend/alerts/integrations/discord/messages.go
+++ b/backend/alerts/integrations/discord/messages.go
@@ -15,6 +15,9 @@ func newMessageEmbed() *discordgo.MessageEmbed {
 	}
 }
 
+var RED_ALERT = 0x961e13
+var YELLOW_ALERT = 0xf2c94c
+
 func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlertPayload) error {
 	fields := []*discordgo.MessageEmbedField{}
 
@@ -45,8 +48,10 @@ func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlert
 	embed := newMessageEmbed()
 	if payload.FirstTimeAlert {
 		embed.Title = "Highlight Error Alert (New Occurence ❇️)"
+		embed.Color = YELLOW_ALERT
 	} else {
 		embed.Title = "Highlight Error Alert"
+		embed.Color = RED_ALERT
 	}
 
 	embed.Description = payload.UserIdentifier

--- a/backend/alerts/integrations/discord/messages.go
+++ b/backend/alerts/integrations/discord/messages.go
@@ -44,7 +44,7 @@ func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlert
 
 	embed := newMessageEmbed()
 	if payload.FirstTimeAlert {
-		embed.Title = "New Highlight Error Alert"
+		embed.Title = "Highlight Error Alert (New Occurence ❇️)"
 	} else {
 		embed.Title = "Highlight Error Alert"
 	}

--- a/backend/alerts/integrations/discord/messages_test.go
+++ b/backend/alerts/integrations/discord/messages_test.go
@@ -58,6 +58,7 @@ func (suite *DiscordChannelsTestSuite) TestSendErrorAlert() {
 		ErrorSnoozeURL:  "https://localhost:3000/1/errors/8y4uezKfrGgvMZNAMt1Z4lpJq2bt?action=snooze",
 		VisitedURL:      "http://google.com",
 		UserIdentifier:  "chilly@mcwilly.com",
+		FirstTimeAlert:  false,
 	})
 
 	if err != nil {

--- a/backend/alerts/integrations/integrations.go
+++ b/backend/alerts/integrations/integrations.go
@@ -18,6 +18,7 @@ type ErrorAlertPayload struct {
 	ErrorSnoozeURL  string
 	UserIdentifier  string
 	VisitedURL      string
+	FirstTimeAlert  bool
 }
 
 type NewUserAlertPayload struct {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2863,7 +2863,7 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 		var headerBlock *slack.TextBlockObject
 		if input.FirstErrorAlert {
 			previewText = fmt.Sprintf("New Error Alert: %s", previewEvent)
-			headerBlock = slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*New Error Alert: %d Recent Occurrences*", *input.ErrorsCount), false, false)
+			headerBlock = slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*❇️ New Error Alert: %d Recent Occurrences*", *input.ErrorsCount), false, false)
 			attachmentColor = YELLOW_ALERT
 		} else {
 			previewText = fmt.Sprintf("Error Alert: %s", previewEvent)

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2673,6 +2673,8 @@ type SendSlackAlertInput struct {
 	URL *string
 	// ErrorsCount is a required parameter for Error alerts
 	ErrorsCount *int64
+	// FirstErrorAlert is a required parameter for Error alerts
+	FirstErrorAlert bool
 	// Project is a required parameter for Error alerts
 	Project *Project
 	// MatchedFields is a required parameter for Track Properties and User Properties alerts
@@ -2822,6 +2824,7 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 	}
 
 	previewText := getPreviewText(*obj.Type)
+	attachmentColor := getAlertColor(*obj.Type)
 
 	var headerBlockSet []slack.Block
 
@@ -2856,10 +2859,16 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 		errorLink = routing.AttachReferrer(ctx, errorLink, routing.Slack)
 
 		// construct Slack message
-		previewText = fmt.Sprintf("Error event: %s", previewEvent)
-
 		// header
-		headerBlock := slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Error Alert: %d Recent Occurrences*", *input.ErrorsCount), false, false)
+		var headerBlock *slack.TextBlockObject
+		if input.FirstErrorAlert {
+			previewText = fmt.Sprintf("New Error Alert: %s", previewEvent)
+			headerBlock = slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*New Error Alert: %d Recent Occurrences*", *input.ErrorsCount), false, false)
+			attachmentColor = YELLOW_ALERT
+		} else {
+			previewText = fmt.Sprintf("Error Alert: %s", previewEvent)
+			headerBlock = slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*Error Alert: %d Recent Occurrences*", *input.ErrorsCount), false, false)
+		}
 		headerBlockSet = append(headerBlockSet, slack.NewSectionBlock(headerBlock, nil, nil))
 
 		// body
@@ -2942,7 +2951,7 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 				}
 			}
 
-			stackTraceBlock = slack.NewTextBlockObject(slack.MarkdownType, fileLocation, false, false)
+			stackTraceBlock = slack.NewTextBlockObject(slack.PlainTextType, fileLocation, false, false)
 		}
 
 		bodyBlockSet = append(bodyBlockSet, slack.NewSectionBlock(eventBlock, nil, nil))
@@ -3046,7 +3055,7 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 
 	// move body within line attachment
 	attachment = &slack.Attachment{
-		Color:  getAlertColor(*obj.Type),
+		Color:  attachmentColor,
 		Blocks: slack.Blocks{BlockSet: bodyBlockSet},
 	}
 

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1671,6 +1671,11 @@ func (r *Resolver) IsWithinQuota(ctx context.Context, productType model.PricingP
 	return cost <= float64(*maxCostCents), cost / float64(*maxCostCents)
 }
 
+type AlertCountsGroupedByRecent struct {
+	Count       int64 `gorm:"column:count"`
+	RecentAlert bool  `gorm:"column:recent_alert"`
+}
+
 func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj *model.Session, group *model.ErrorGroup, errorObject *model.ErrorObject, visitedUrl string) {
 	func() {
 		var errorAlerts []*model.ErrorAlert
@@ -1764,9 +1769,9 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 				continue
 			}
 
-			numAlerts := int64(-1)
+			var alertCounts []AlertCountsGroupedByRecent
 			if err := r.DB.Raw(`
-				SELECT COUNT(*)
+				SELECT COUNT(*), ev.sent_at > NOW() - ? * (INTERVAL '1 SECOND') AS recent_alert
 				FROM error_alert_events ev
 				INNER JOIN error_objects obj
 				ON obj.id = ev.error_object_id
@@ -1774,12 +1779,30 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 					(obj.error_group_id IS NOT NULL
 						AND obj.error_group_id=?)
 					AND ev.error_alert_id=?
-					AND ev.sent_at > NOW() - ? * (INTERVAL '1 SECOND')
-			`, group.ID, errorAlert.ID, errorAlert.Frequency).Scan(&numAlerts).Error; err != nil {
+				GROUP BY recent_alert
+			`, errorAlert.Frequency, group.ID, errorAlert.ID).Scan(&alertCounts).Error; err != nil {
 				log.WithContext(ctx).Error(e.Wrapf(err, "error counting alert events from past %d seconds", errorAlert.Frequency))
 				continue
 			}
-			if numAlerts > 0 {
+
+			recentAlertCount := int64(-1)
+			totalAlertCount := int64(-1)
+
+			if len(alertCounts) >= 2 {
+				totalAlertCount = alertCounts[0].Count + alertCounts[1].Count
+				if alertCounts[0].RecentAlert {
+					recentAlertCount = alertCounts[0].Count
+				} else {
+					recentAlertCount = alertCounts[1].Count
+				}
+			} else if len(alertCounts) == 1 {
+				totalAlertCount = alertCounts[0].Count
+				if alertCounts[0].RecentAlert {
+					recentAlertCount = alertCounts[0].Count
+				}
+			}
+
+			if recentAlertCount > 0 {
 				log.WithContext(ctx).Warnf("num alerts > 0 for project_id=%d, error_group_id=%d", projectID, group.ID)
 				continue
 			}
@@ -1811,6 +1834,7 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 				ErrorObject: errorObject,
 				Workspace:   workspace,
 				ErrorCount:  numErrors,
+				FirstAlert:  totalAlertCount <= 0,
 				VisitedURL:  visitedUrl,
 			}); err != nil {
 				log.WithContext(ctx).Error(err)
@@ -1826,6 +1850,7 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 				ErrorObject:     errorObject,
 				URL:             &visitedUrl,
 				ErrorsCount:     &numErrors,
+				FirstErrorAlert: totalAlertCount <= 0,
 				UserObject:      sessionObj.UserObject,
 			})
 		}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1828,14 +1828,14 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 			}
 
 			if err := alerts.SendErrorAlert(ctx, alerts.SendErrorAlertEvent{
-				Session:     sessionObj,
-				ErrorAlert:  errorAlert,
-				ErrorGroup:  group,
-				ErrorObject: errorObject,
-				Workspace:   workspace,
-				ErrorCount:  numErrors,
-				FirstAlert:  totalAlertCount <= 0,
-				VisitedURL:  visitedUrl,
+				Session:         sessionObj,
+				ErrorAlert:      errorAlert,
+				ErrorGroup:      group,
+				ErrorObject:     errorObject,
+				Workspace:       workspace,
+				ErrorCount:      numErrors,
+				FirstErrorAlert: totalAlertCount <= 0,
+				VisitedURL:      visitedUrl,
 			}); err != nil {
 				log.WithContext(ctx).Error(err)
 			}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1771,7 +1771,7 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 
 			var alertCounts []AlertCountsGroupedByRecent
 			if err := r.DB.Raw(`
-				SELECT COUNT(*), ev.sent_at > NOW() - ? * (INTERVAL '1 SECOND') AS recent_alert
+				SELECT ev.sent_at > NOW() - ? * (INTERVAL '1 SECOND') AS recent_alert, COUNT(*)
 				FROM error_alert_events ev
 				INNER JOIN error_objects obj
 				ON obj.id = ev.error_object_id

--- a/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
@@ -146,6 +146,13 @@ export const ErrorFeedCard = ({ errorGroup, onClick }: Props) => {
 									</Box>
 								</Tooltip>
 							)}
+							{recentlyCreated(errorGroup) && (
+								<Badge
+									variant="yellow"
+									label="New"
+									iconStart={<IconSolidSparkles size={12} />}
+								/>
+							)}
 							<Tag
 								shape="basic"
 								kind="secondary"
@@ -174,13 +181,6 @@ export const ErrorFeedCard = ({ errorGroup, onClick }: Props) => {
 							>
 								{createdDate}
 							</Tag>
-							{recentlyCreated(errorGroup) && (
-								<Badge
-									variant="yellow"
-									label="New"
-									iconStart={<IconSolidSparkles size={12} />}
-								/>
-							)}
 						</Box>
 					</Box>
 					<Box paddingTop="2" display="flex" alignItems="flex-end">

--- a/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
@@ -3,7 +3,6 @@ import { ErrorGroup, ErrorState, Maybe } from '@graph/schemas'
 import {
 	Badge,
 	Box,
-	IconSolidClock,
 	IconSolidSparkles,
 	IconSolidUsers,
 	IconSolidViewGrid,
@@ -146,13 +145,6 @@ export const ErrorFeedCard = ({ errorGroup, onClick }: Props) => {
 									</Box>
 								</Tooltip>
 							)}
-							{recentlyCreated(errorGroup) && (
-								<Badge
-									variant="yellow"
-									label="New"
-									iconStart={<IconSolidSparkles size={12} />}
-								/>
-							)}
 							<Tag
 								shape="basic"
 								kind="secondary"
@@ -177,10 +169,17 @@ export const ErrorFeedCard = ({ errorGroup, onClick }: Props) => {
 							<Tag
 								shape="basic"
 								kind="secondary"
-								iconLeft={<IconSolidClock size={12} />}
+								iconLeft={<IconSolidSparkles size={12} />}
 							>
 								{createdDate}
 							</Tag>
+							{recentlyCreated(errorGroup) && (
+								<Badge
+									variant="yellow"
+									label="New"
+									size="medium"
+								/>
+							)}
 						</Box>
 					</Box>
 					<Box paddingTop="2" display="flex" alignItems="flex-end">

--- a/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
@@ -1,7 +1,9 @@
 import BarChart from '@components/BarChart/BarChart'
 import { ErrorGroup, ErrorState, Maybe } from '@graph/schemas'
 import {
+	Badge,
 	Box,
+	IconSolidClock,
 	IconSolidSparkles,
 	IconSolidUsers,
 	IconSolidViewGrid,
@@ -18,8 +20,10 @@ import moment from 'moment'
 import { Link } from 'react-router-dom'
 
 import * as style from './ErrorFeedCard.css'
+
+type ErrorGroupType = Maybe<Omit<ErrorGroup, 'metadata_log'>>
 interface Props {
-	errorGroup: Maybe<Omit<ErrorGroup, 'metadata_log'>>
+	errorGroup: ErrorGroupType
 	onClick?: React.MouseEventHandler<HTMLAnchorElement>
 }
 export const ErrorFeedCard = ({ errorGroup, onClick }: Props) => {
@@ -166,10 +170,17 @@ export const ErrorFeedCard = ({ errorGroup, onClick }: Props) => {
 							<Tag
 								shape="basic"
 								kind="secondary"
-								iconLeft={<IconSolidSparkles size={12} />}
+								iconLeft={<IconSolidClock size={12} />}
 							>
 								{createdDate}
 							</Tag>
+							{recentlyCreated(errorGroup) && (
+								<Badge
+									variant="yellow"
+									label="New"
+									iconStart={<IconSolidSparkles size={12} />}
+								/>
+							)}
 						</Box>
 					</Box>
 					<Box paddingTop="2" display="flex" alignItems="flex-end">
@@ -185,4 +196,9 @@ export const ErrorFeedCard = ({ errorGroup, onClick }: Props) => {
 			</Box>
 		</Link>
 	)
+}
+
+const recentlyCreated = (errorGroup: ErrorGroupType) => {
+	const createdAt = moment(errorGroup?.created_at)
+	return createdAt.isAfter(moment().subtract(3, 'day'))
 }


### PR DESCRIPTION
## Summary
Highlight new errors in the app and alerts to help developers quickly squash new bugs that occur.

Alert changes: New preview text and heading for Slack and Discord alerts to help users be able to search on their app. This can also be used to see when an alert first occurs.

<img width="840" alt="Screenshot 2023-10-10 at 4 10 19 PM" src="https://github.com/highlight/highlight/assets/17744174/c211c79f-cc3d-4033-983e-2d3c5eae7628">

<img width="673" alt="Screenshot 2023-10-11 at 9 40 10 AM" src="https://github.com/highlight/highlight/assets/17744174/d31bcbf1-7e81-4ef9-9201-e10bfc096325">

App changes: Add a "New" badge to the error search page to help point users to recently created error groups.

![Screenshot 2023-10-11 at 9 37 50 AM](https://github.com/highlight/highlight/assets/17744174/36dc66f5-69f8-400f-a678-5a2dc2e94cc3)

## How did you test this change?
1) Create an error alert that reports to a Slack and Discord channel. (Recommend setting threshold to 1)
2) Find a frontend file that is rendered
3) Add a `console.log(madeUpVariable)` to the file
4) Load the screen, and it should crash
- [ ] Confirm new Slack alert is sent
- [ ] Confirm new DIscord alert is sent
- [ ] Confirm error in error feed has "New" badge

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
Yes
