### PR TITLE
Fix error instance overflow

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6038,9 +6038,6 @@ body {
 ._1068vpp6 {
   animation: 1s _1068vpp5 linear infinite;
 }
-._33eaux0 {
-  max-height: 16em;
-}
 ._2tuxi80 {
   background: linear-gradient(45deg, rgba(162, 138, 220, 0.08) 0%, rgba(216, 165, 216, 0.08) 50%, rgba(233, 192, 186, 0.08) 100%);
 }
@@ -6639,18 +6636,22 @@ body {
   max-height: calc(100vh - 160px - 32px - 42px - 32px - var(--header-height) - var(--banner-height));
 }
 .ltrwrc0 {
-  height: calc(100vh - 108px - var(--banner-height));
+  height: calc(100vh - 108px);
+  overflow-y: scroll;
 }
 .ltrwrc1 {
+  height: calc(100vh - 108px - var(--banner-height));
+}
+.ltrwrc2 {
   position: fixed;
   left: 100%;
   transform: translateX(300px);
 }
-.ltrwrc2 {
+.ltrwrc3 {
   height: 100%;
   padding: 0;
 }
-.ltrwrc3 {
+.ltrwrc4 {
   border-radius: 8px;
 }
 ._1l6nlco0 {

--- a/frontend/src/__generated/ve/pages/ErrorsV2/ErrorBody/components/ErrorBodyText/style.css.js
+++ b/frontend/src/__generated/ve/pages/ErrorsV2/ErrorBody/components/ErrorBodyText/style.css.js
@@ -1,1 +1,0 @@
-var r="_33eaux0";export{r as errorBodyContainer};

--- a/frontend/src/__generated/ve/pages/Player/RightPlayerPanel/style.css.js
+++ b/frontend/src/__generated/ve/pages/Player/RightPlayerPanel/style.css.js
@@ -1,1 +1,1 @@
-var r=300,t="ltrwrc0",a="ltrwrc1",e="ltrwrc2",n="ltrwrc3";export{r as RIGHT_PANEL_WIDTH,t as playerRightPanelContainerBannerShown,a as playerRightPanelContainerHidden,e as tabContentContainer,n as tabs};
+var r=300,t="ltrwrc0",a="ltrwrc1",e="ltrwrc2",n="ltrwrc3",o="ltrwrc4";export{r as RIGHT_PANEL_WIDTH,t as playerRightColumn,a as playerRightPanelContainerBannerShown,e as playerRightPanelContainerHidden,n as tabContentContainer,o as tabs};

--- a/frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorBodyText/index.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorBodyText/index.tsx
@@ -3,8 +3,6 @@ import { Box, Tag, Text } from '@highlight-run/ui'
 import { getErrorBody } from '@util/errors/errorUtils'
 import { useEffect, useRef, useState } from 'react'
 
-import * as style from './style.css'
-
 interface Props {
 	errorBody: Maybe<string>[]
 }
@@ -25,7 +23,7 @@ const ErrorBodyText = ({ errorBody }: Props) => {
 
 	return (
 		<Box display="flex" flexDirection="column" gap="8">
-			<Box py="8" cssClass={style.errorBodyContainer}>
+			<Box py="8">
 				<Text
 					family="monospace"
 					lines={truncated ? '3' : undefined}

--- a/frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorBodyText/style.css.ts
+++ b/frontend/src/pages/ErrorsV2/ErrorBody/components/ErrorBodyText/style.css.ts
@@ -1,5 +1,0 @@
-import { style } from '@vanilla-extract/css'
-
-export const errorBodyContainer = style({
-	maxHeight: '16em',
-})

--- a/frontend/src/pages/Player/RightPlayerPanel/RightPlayerPanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/RightPlayerPanel.tsx
@@ -11,6 +11,7 @@ import { useReplayerContext } from '@pages/Player/ReplayerContext'
 import ErrorDetails from '@pages/Player/RightPlayerPanel/components/ErrorDetails/ErrorDetails'
 import EventDetails from '@pages/Player/RightPlayerPanel/components/EventDetails/EventDetails'
 import RightPanelTabs from '@pages/Player/RightPlayerPanel/components/Tabs'
+import clsx from 'clsx'
 import { useEffect, useMemo } from 'react'
 
 import SessionFullCommentList from '@/pages/Player/SessionFullCommentList/SessionFullCommentList'
@@ -85,15 +86,15 @@ const RightPlayerPanel = () => {
 			flexShrink={0}
 			bt="dividerWeak"
 			bl="dividerWeak"
-			cssClass={[
-				{
-					[style.playerRightPanelContainerHidden]: !showRightPanel,
-				},
-			]}
+			cssClass={clsx(style.playerRightColumn, {
+				[style.playerRightPanelContainerHidden]: !showRightPanel,
+			})}
 		>
 			{content}
 		</Box>
 	)
 }
+
+// calc(100vh - 108px);
 
 export default RightPlayerPanel

--- a/frontend/src/pages/Player/RightPlayerPanel/RightPlayerPanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/RightPlayerPanel.tsx
@@ -95,6 +95,4 @@ const RightPlayerPanel = () => {
 	)
 }
 
-// calc(100vh - 108px);
-
 export default RightPlayerPanel

--- a/frontend/src/pages/Player/RightPlayerPanel/style.css.ts
+++ b/frontend/src/pages/Player/RightPlayerPanel/style.css.ts
@@ -2,6 +2,11 @@ import { style } from '@vanilla-extract/css'
 
 export const RIGHT_PANEL_WIDTH = 300
 
+export const playerRightColumn = style({
+	height: `calc(100vh - 108px)`,
+	overflowY: 'scroll',
+})
+
 export const playerRightPanelContainerBannerShown = style({
 	height: `calc(100vh - 108px - var(--banner-height))`,
 })


### PR DESCRIPTION
## Summary
When the error instance event is over a certain amount of lines, it overflows into the other content. Allow the container to grow and scroll when necessary.

https://www.loom.com/share/aa4c61e67d52492cb8b40d354ca34896?sid=91820b21-6462-4fc8-a414-5a179953aba5

## How did you test this change?
1) Fix the error event to a long excerpt of text
2) View the error instance on the error show page
- [ ] Clicking see more shows the entire error event with no overflow
3) View a session with an error, and click to display an error in the right panel
- [ ] Clicking see more shows the entire error event with no overflow

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
