### PR TITLE
Update log alerts

### DIFF
--- a/backend/alerts/integrations/discord/messages.go
+++ b/backend/alerts/integrations/discord/messages.go
@@ -441,6 +441,7 @@ func (bot *Bot) SendLogAlert(channelId string, payload integrations.LogAlertPayl
 
 	embed := newMessageEmbed()
 	embed.Title = "Highlight Log Alert"
+	embed.Color = RED_ALERT
 	embed.Description = fmt.Sprintf("*%s* is currently %s the threshold.", payload.Name, aboveStr)
 	embed.Fields = fields
 

--- a/backend/jobs/log-alerts/log-alerts.go
+++ b/backend/jobs/log-alerts/log-alerts.go
@@ -152,19 +152,18 @@ func processLogAlert(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, MailCl
 		if alert.Query != "" {
 			queryStr = fmt.Sprintf(`for query *%s* `, alert.Query)
 		}
-		message := fmt.Sprintf(
-			"🚨 *%s* fired!\nLog count %swas %s the threshold.\n"+
+		body := fmt.Sprintf(
+			"Log count %swas %s the threshold.\n"+
 				"_Count_: %d | _Threshold_: %d",
-			alert.Name,
 			queryStr,
 			aboveStr,
 			count,
 			alert.CountThreshold,
 		)
 
-		log.WithContext(ctx).Info(message)
+		log.WithContext(ctx).WithField("alert_id", alert.ID).Info(fmt.Sprintf("Firing alert for %s", alert.Name))
 
-		if err := alert.SendSlackAlert(ctx, DB, &model.SendSlackAlertForLogAlertInput{Message: message, Workspace: &workspace, StartDate: start, EndDate: end}); err != nil {
+		if err := alert.SendSlackAlert(ctx, DB, &model.SendSlackAlertForLogAlertInput{Body: body, Workspace: &workspace, StartDate: start, EndDate: end}); err != nil {
 			log.WithContext(ctx).Error("error sending slack alert for metric monitor", err)
 		}
 
@@ -190,7 +189,7 @@ func processLogAlert(ctx context.Context, DB *gorm.DB, TDB timeseries.DB, MailCl
 			if alert.Query != "" {
 				queryStr = fmt.Sprintf(`for query <b>%s</b> `, alert.Query)
 			}
-			message = fmt.Sprintf(
+			message := fmt.Sprintf(
 				"<b>%s</b> fired! Log count %sis currently %s the threshold.<br>"+
 					"<em>Count</em>: %d | <em>Threshold</em>: %d"+
 					"<br><br>"+

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2581,7 +2581,7 @@ func (obj *MetricMonitor) SendSlackAlert(ctx context.Context, input *SendSlackAl
 }
 
 type SendSlackAlertForLogAlertInput struct {
-	Message   string
+	Body      string
 	Workspace *Workspace
 	StartDate time.Time
 	EndDate   time.Time
@@ -2619,12 +2619,42 @@ func (obj *LogAlert) SendSlackAlert(ctx context.Context, db *gorm.DB, input *Sen
 
 	alertUrl := GetLogAlertURL(obj.ProjectID, obj.Query, input.StartDate, input.EndDate)
 
+	previewText := fmt.Sprintf("%s fired!", obj.Name)
+
+	var headerBlockSet []slack.Block
+	headerBlock := slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*%s* fired!", obj.Name), false, false)
+	headerBlockSet = append(headerBlockSet, slack.NewSectionBlock(headerBlock, nil, nil))
+
+	var bodyBlockSet []slack.Block
+	logBlock := slack.NewTextBlockObject(slack.MarkdownType, input.Body, false, false)
+
+	var actionBlocks []slack.BlockElement
+	button := slack.NewButtonBlockElement(
+		"",
+		"click",
+		slack.NewTextBlockObject(
+			slack.PlainTextType,
+			"View Logs",
+			false,
+			false,
+		),
+	)
+	button.URL = alertUrl
+	actionBlocks = append(actionBlocks, button)
+
+	bodyBlockSet = append(bodyBlockSet, slack.NewSectionBlock(logBlock, nil, nil))
+	bodyBlockSet = append(bodyBlockSet, slack.NewActionBlock("", actionBlocks...))
+
+	attachment := &slack.Attachment{
+		Color:  RED_ALERT,
+		Blocks: slack.Blocks{BlockSet: bodyBlockSet},
+	}
+
 	log.WithContext(ctx).Info("Sending Slack Alert for Log Alert")
 
 	// send message
 	for _, channel := range channels {
 		if channel.WebhookChannel != nil {
-			message := fmt.Sprintf("%s\n<%s|View Logs>", input.Message, alertUrl)
 			slackChannelId := *channel.WebhookChannelID
 			slackChannelName := *channel.WebhookChannel
 
@@ -2637,12 +2667,12 @@ func (obj *LogAlert) SendSlackAlert(ctx context.Context, db *gorm.DB, input *Sen
 						log.WithContext(ctx).WithFields(log.Fields{"project_id": obj.ProjectID}).Error(e.Wrap(err, "failed to join slack channel while sending welcome message"))
 					}
 				}
-				_, _, err := slackClient.PostMessage(slackChannelId, slack.MsgOptionText(message, false),
+				_, _, err := slackClient.PostMessage(slackChannelId, slack.MsgOptionText(previewText, false), slack.MsgOptionBlocks(headerBlockSet...), slack.MsgOptionAttachments(*attachment),
 					slack.MsgOptionDisableLinkUnfurl(),  /** Disables showing a preview of any links that are in the Slack message.*/
 					slack.MsgOptionDisableMediaUnfurl(), /** Disables showing a preview of any links that are in the Slack message.*/
 				)
 				if err != nil {
-					log.WithContext(ctx).WithFields(log.Fields{"workspace_id": input.Workspace.ID, "message": fmt.Sprintf("%+v", message)}).
+					log.WithContext(ctx).WithFields(log.Fields{"workspace_id": input.Workspace.ID, "message": previewText}).
 						Error(e.Wrap(err, "error sending slack msg via bot api for welcome message"))
 				}
 
@@ -2864,7 +2894,7 @@ func (obj *Alert) sendSlackAlert(ctx context.Context, db *gorm.DB, alertID int, 
 		var headerBlock *slack.TextBlockObject
 		if input.FirstErrorAlert {
 			previewText = fmt.Sprintf("New Error Alert: %s", previewEvent)
-			headerBlock = slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*❇️ New Error Alert: %d Recent Occurrences*", *input.ErrorsCount), false, false)
+			headerBlock = slack.NewTextBlockObject(slack.MarkdownType, fmt.Sprintf("*New Error Alert: %d Recent Occurrences ❇️*", *input.ErrorsCount), false, false)
 			attachmentColor = YELLOW_ALERT
 		} else {
 			previewText = fmt.Sprintf("Error Alert: %s", previewEvent)


### PR DESCRIPTION
## Summary
The log alerts and comment alerts were not updated to the new styling. Give them an update:

Log alert
<img width="508" alt="Screenshot 2023-10-11 at 2 25 12 PM" src="https://github.com/highlight/highlight/assets/17744174/b7db5636-4aa1-4c75-ad55-2b0fcb6ad5ce">

<img width="542" alt="Screenshot 2023-10-11 at 2 33 16 PM" src="https://github.com/highlight/highlight/assets/17744174/22654ea6-7d0b-48d3-b1c2-01fea43ddc60">

Comment alert
<img width="499" alt="Screenshot 2023-10-11 at 2 59 34 PM" src="https://github.com/highlight/highlight/assets/17744174/72103b49-d8c7-4655-b933-27f6c45ee4bb">

## How did you test this change?
1) Create a new log alert that is easy to fire
2) Add a Discord and Slack channel to alert
3) Run the log alert watcher locally: `make start-log-alerts-watch`
- [ ] Confirm alert is sent to Slack
- [ ] Confirm alert is sent to Discord
4) Comment on a session
- [ ] Confirm alert is sent to appropriate Slack channel
5) Reply to comment
- [ ] Confirm alert is sent to appropriate Slack channel

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
Yes
