### PR TITLE
Updates to individual trace view

### DIFF
--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -3,8 +3,9 @@ package clickhouse
 import (
 	"context"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/queryparser"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/queryparser"
 
 	"github.com/huandu/go-sqlbuilder"
 	e "github.com/pkg/errors"

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1337,6 +1337,19 @@ type ComplexityRoot struct {
 		Node   func(childComplexity int) int
 	}
 
+	TraceError struct {
+		CreatedAt          func(childComplexity int) int
+		ErrorGroupSecureID func(childComplexity int) int
+		Event              func(childComplexity int) int
+		LogCursor          func(childComplexity int) int
+		SecureID           func(childComplexity int) int
+		Source             func(childComplexity int) int
+		SpanID             func(childComplexity int) int
+		Timestamp          func(childComplexity int) int
+		TraceID            func(childComplexity int) int
+		Type               func(childComplexity int) int
+	}
+
 	TraceEvent struct {
 		Attributes func(childComplexity int) int
 		Name       func(childComplexity int) int
@@ -1348,6 +1361,11 @@ type ComplexityRoot struct {
 		SpanID     func(childComplexity int) int
 		TraceID    func(childComplexity int) int
 		TraceState func(childComplexity int) int
+	}
+
+	TracePayload struct {
+		Errors func(childComplexity int) int
+		Trace  func(childComplexity int) int
 	}
 
 	TracesMetricBucket struct {
@@ -1740,7 +1758,7 @@ type QueryResolver interface {
 	ErrorTags(ctx context.Context) ([]*model1.ErrorTag, error)
 	MatchErrorTag(ctx context.Context, query string) ([]*model.MatchedErrorTag, error)
 	FindSimilarErrors(ctx context.Context, query string) ([]*model1.MatchedErrorObject, error)
-	Trace(ctx context.Context, projectID int, traceID string) ([]*model.Trace, error)
+	Trace(ctx context.Context, projectID int, traceID string) (*model.TracePayload, error)
 	Traces(ctx context.Context, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection) (*model.TraceConnection, error)
 	TracesMetrics(ctx context.Context, projectID int, params model.QueryInput, metricTypes []model.TracesMetricType) (*model.TracesMetrics, error)
 	TracesKeys(ctx context.Context, projectID int, dateRange model.DateRangeRequiredInput) ([]*model.QueryKey, error)
@@ -9347,6 +9365,76 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TraceEdge.Node(childComplexity), true
 
+	case "TraceError.created_at":
+		if e.complexity.TraceError.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.TraceError.CreatedAt(childComplexity), true
+
+	case "TraceError.error_group_secure_id":
+		if e.complexity.TraceError.ErrorGroupSecureID == nil {
+			break
+		}
+
+		return e.complexity.TraceError.ErrorGroupSecureID(childComplexity), true
+
+	case "TraceError.event":
+		if e.complexity.TraceError.Event == nil {
+			break
+		}
+
+		return e.complexity.TraceError.Event(childComplexity), true
+
+	case "TraceError.log_cursor":
+		if e.complexity.TraceError.LogCursor == nil {
+			break
+		}
+
+		return e.complexity.TraceError.LogCursor(childComplexity), true
+
+	case "TraceError.secure_id":
+		if e.complexity.TraceError.SecureID == nil {
+			break
+		}
+
+		return e.complexity.TraceError.SecureID(childComplexity), true
+
+	case "TraceError.source":
+		if e.complexity.TraceError.Source == nil {
+			break
+		}
+
+		return e.complexity.TraceError.Source(childComplexity), true
+
+	case "TraceError.span_id":
+		if e.complexity.TraceError.SpanID == nil {
+			break
+		}
+
+		return e.complexity.TraceError.SpanID(childComplexity), true
+
+	case "TraceError.timestamp":
+		if e.complexity.TraceError.Timestamp == nil {
+			break
+		}
+
+		return e.complexity.TraceError.Timestamp(childComplexity), true
+
+	case "TraceError.trace_id":
+		if e.complexity.TraceError.TraceID == nil {
+			break
+		}
+
+		return e.complexity.TraceError.TraceID(childComplexity), true
+
+	case "TraceError.type":
+		if e.complexity.TraceError.Type == nil {
+			break
+		}
+
+		return e.complexity.TraceError.Type(childComplexity), true
+
 	case "TraceEvent.attributes":
 		if e.complexity.TraceEvent.Attributes == nil {
 			break
@@ -9395,6 +9483,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.TraceLink.TraceState(childComplexity), true
+
+	case "TracePayload.errors":
+		if e.complexity.TracePayload.Errors == nil {
+			break
+		}
+
+		return e.complexity.TracePayload.Errors(childComplexity), true
+
+	case "TracePayload.trace":
+		if e.complexity.TracePayload.Trace == nil {
+			break
+		}
+
+		return e.complexity.TracePayload.Trace(childComplexity), true
 
 	case "TracesMetricBucket.bucket_id":
 		if e.complexity.TracesMetricBucket.BucketID == nil {
@@ -10685,6 +10787,24 @@ type Trace {
 	links: [TraceLink]
 }
 
+type TracePayload {
+	trace: [Trace!]!
+	errors: [TraceError!]!
+}
+
+type TraceError {
+	created_at: Timestamp!
+	trace_id: String
+	span_id: String
+	log_cursor: String
+	secure_id: String!
+	error_group_secure_id: String!
+	event: String!
+	type: String!
+	source: String!
+	timestamp: Timestamp!
+}
+
 type TraceEvent {
 	timestamp: Timestamp!
 	name: String!
@@ -11944,7 +12064,7 @@ type Query {
 	error_tags: [ErrorTag]
 	match_error_tag(query: String!): [MatchedErrorTag]
 	find_similar_errors(query: String!): [MatchedErrorObject]
-	trace(project_id: ID!, trace_id: String!): [Trace!]
+	trace(project_id: ID!, trace_id: String!): TracePayload
 	traces(
 		project_id: ID!
 		params: QueryInput!
@@ -53587,9 +53707,9 @@ func (ec *executionContext) _Query_trace(ctx context.Context, field graphql.Coll
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.([]*model.Trace)
+	res := resTmp.(*model.TracePayload)
 	fc.Result = res
-	return ec.marshalOTrace2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTraceᚄ(ctx, field.Selections, res)
+	return ec.marshalOTracePayload2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracePayload(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_trace(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -53600,42 +53720,12 @@ func (ec *executionContext) fieldContext_Query_trace(ctx context.Context, field 
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "timestamp":
-				return ec.fieldContext_Trace_timestamp(ctx, field)
-			case "traceID":
-				return ec.fieldContext_Trace_traceID(ctx, field)
-			case "spanID":
-				return ec.fieldContext_Trace_spanID(ctx, field)
-			case "parentSpanID":
-				return ec.fieldContext_Trace_parentSpanID(ctx, field)
-			case "projectID":
-				return ec.fieldContext_Trace_projectID(ctx, field)
-			case "secureSessionID":
-				return ec.fieldContext_Trace_secureSessionID(ctx, field)
-			case "traceState":
-				return ec.fieldContext_Trace_traceState(ctx, field)
-			case "spanName":
-				return ec.fieldContext_Trace_spanName(ctx, field)
-			case "spanKind":
-				return ec.fieldContext_Trace_spanKind(ctx, field)
-			case "duration":
-				return ec.fieldContext_Trace_duration(ctx, field)
-			case "serviceName":
-				return ec.fieldContext_Trace_serviceName(ctx, field)
-			case "serviceVersion":
-				return ec.fieldContext_Trace_serviceVersion(ctx, field)
-			case "traceAttributes":
-				return ec.fieldContext_Trace_traceAttributes(ctx, field)
-			case "statusCode":
-				return ec.fieldContext_Trace_statusCode(ctx, field)
-			case "statusMessage":
-				return ec.fieldContext_Trace_statusMessage(ctx, field)
-			case "events":
-				return ec.fieldContext_Trace_events(ctx, field)
-			case "links":
-				return ec.fieldContext_Trace_links(ctx, field)
+			case "trace":
+				return ec.fieldContext_TracePayload_trace(ctx, field)
+			case "errors":
+				return ec.fieldContext_TracePayload_errors(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type Trace", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type TracePayload", field.Name)
 		},
 	}
 	defer func() {
@@ -65119,6 +65209,437 @@ func (ec *executionContext) fieldContext_TraceEdge_node(ctx context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _TraceError_created_at(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TraceError_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTimestamp2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TraceError_created_at(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TraceError",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Timestamp does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TraceError_trace_id(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TraceError_trace_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TraceID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TraceError_trace_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TraceError",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TraceError_span_id(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TraceError_span_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SpanID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TraceError_span_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TraceError",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TraceError_log_cursor(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TraceError_log_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LogCursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TraceError_log_cursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TraceError",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TraceError_secure_id(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TraceError_secure_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SecureID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TraceError_secure_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TraceError",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TraceError_error_group_secure_id(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TraceError_error_group_secure_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ErrorGroupSecureID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TraceError_error_group_secure_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TraceError",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TraceError_event(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TraceError_event(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Event, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TraceError_event(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TraceError",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TraceError_type(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TraceError_type(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Type, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TraceError_type(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TraceError",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TraceError_source(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TraceError_source(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Source, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TraceError_source(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TraceError",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TraceError_timestamp(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TraceError_timestamp(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Timestamp, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTimestamp2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TraceError_timestamp(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TraceError",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Timestamp does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TraceEvent_timestamp(ctx context.Context, field graphql.CollectedField, obj *model.TraceEvent) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TraceEvent_timestamp(ctx, field)
 	if err != nil {
@@ -65422,6 +65943,152 @@ func (ec *executionContext) fieldContext_TraceLink_attributes(ctx context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Map does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracePayload_trace(ctx context.Context, field graphql.CollectedField, obj *model.TracePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracePayload_trace(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Trace, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Trace)
+	fc.Result = res
+	return ec.marshalNTrace2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTraceᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracePayload_trace(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracePayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "timestamp":
+				return ec.fieldContext_Trace_timestamp(ctx, field)
+			case "traceID":
+				return ec.fieldContext_Trace_traceID(ctx, field)
+			case "spanID":
+				return ec.fieldContext_Trace_spanID(ctx, field)
+			case "parentSpanID":
+				return ec.fieldContext_Trace_parentSpanID(ctx, field)
+			case "projectID":
+				return ec.fieldContext_Trace_projectID(ctx, field)
+			case "secureSessionID":
+				return ec.fieldContext_Trace_secureSessionID(ctx, field)
+			case "traceState":
+				return ec.fieldContext_Trace_traceState(ctx, field)
+			case "spanName":
+				return ec.fieldContext_Trace_spanName(ctx, field)
+			case "spanKind":
+				return ec.fieldContext_Trace_spanKind(ctx, field)
+			case "duration":
+				return ec.fieldContext_Trace_duration(ctx, field)
+			case "serviceName":
+				return ec.fieldContext_Trace_serviceName(ctx, field)
+			case "serviceVersion":
+				return ec.fieldContext_Trace_serviceVersion(ctx, field)
+			case "traceAttributes":
+				return ec.fieldContext_Trace_traceAttributes(ctx, field)
+			case "statusCode":
+				return ec.fieldContext_Trace_statusCode(ctx, field)
+			case "statusMessage":
+				return ec.fieldContext_Trace_statusMessage(ctx, field)
+			case "events":
+				return ec.fieldContext_Trace_events(ctx, field)
+			case "links":
+				return ec.fieldContext_Trace_links(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Trace", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TracePayload_errors(ctx context.Context, field graphql.CollectedField, obj *model.TracePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TracePayload_errors(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Errors, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.TraceError)
+	fc.Result = res
+	return ec.marshalNTraceError2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTraceErrorᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TracePayload_errors(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TracePayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "created_at":
+				return ec.fieldContext_TraceError_created_at(ctx, field)
+			case "trace_id":
+				return ec.fieldContext_TraceError_trace_id(ctx, field)
+			case "span_id":
+				return ec.fieldContext_TraceError_span_id(ctx, field)
+			case "log_cursor":
+				return ec.fieldContext_TraceError_log_cursor(ctx, field)
+			case "secure_id":
+				return ec.fieldContext_TraceError_secure_id(ctx, field)
+			case "error_group_secure_id":
+				return ec.fieldContext_TraceError_error_group_secure_id(ctx, field)
+			case "event":
+				return ec.fieldContext_TraceError_event(ctx, field)
+			case "type":
+				return ec.fieldContext_TraceError_type(ctx, field)
+			case "source":
+				return ec.fieldContext_TraceError_source(ctx, field)
+			case "timestamp":
+				return ec.fieldContext_TraceError_timestamp(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TraceError", field.Name)
 		},
 	}
 	return fc, nil
@@ -82727,6 +83394,88 @@ func (ec *executionContext) _TraceEdge(ctx context.Context, sel ast.SelectionSet
 	return out
 }
 
+var traceErrorImplementors = []string{"TraceError"}
+
+func (ec *executionContext) _TraceError(ctx context.Context, sel ast.SelectionSet, obj *model.TraceError) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, traceErrorImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TraceError")
+		case "created_at":
+
+			out.Values[i] = ec._TraceError_created_at(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "trace_id":
+
+			out.Values[i] = ec._TraceError_trace_id(ctx, field, obj)
+
+		case "span_id":
+
+			out.Values[i] = ec._TraceError_span_id(ctx, field, obj)
+
+		case "log_cursor":
+
+			out.Values[i] = ec._TraceError_log_cursor(ctx, field, obj)
+
+		case "secure_id":
+
+			out.Values[i] = ec._TraceError_secure_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "error_group_secure_id":
+
+			out.Values[i] = ec._TraceError_error_group_secure_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "event":
+
+			out.Values[i] = ec._TraceError_event(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "type":
+
+			out.Values[i] = ec._TraceError_type(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "source":
+
+			out.Values[i] = ec._TraceError_source(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "timestamp":
+
+			out.Values[i] = ec._TraceError_timestamp(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var traceEventImplementors = []string{"TraceEvent"}
 
 func (ec *executionContext) _TraceEvent(ctx context.Context, sel ast.SelectionSet, obj *model.TraceEvent) graphql.Marshaler {
@@ -82803,6 +83552,41 @@ func (ec *executionContext) _TraceLink(ctx context.Context, sel ast.SelectionSet
 		case "attributes":
 
 			out.Values[i] = ec._TraceLink_attributes(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var tracePayloadImplementors = []string{"TracePayload"}
+
+func (ec *executionContext) _TracePayload(ctx context.Context, sel ast.SelectionSet, obj *model.TracePayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tracePayloadImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TracePayload")
+		case "trace":
+
+			out.Values[i] = ec._TracePayload_trace(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "errors":
+
+			out.Values[i] = ec._TracePayload_errors(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -87995,6 +88779,50 @@ func (ec *executionContext) marshalNTopUsersPayload2ᚕᚖgithubᚗcomᚋhighlig
 	return ret
 }
 
+func (ec *executionContext) marshalNTrace2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTraceᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Trace) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTrace2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTrace(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNTrace2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTrace(ctx context.Context, sel ast.SelectionSet, v *model.Trace) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -88071,6 +88899,60 @@ func (ec *executionContext) marshalNTraceEdge2ᚖgithubᚗcomᚋhighlightᚑrun�
 		return graphql.Null
 	}
 	return ec._TraceEdge(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTraceError2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTraceErrorᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.TraceError) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTraceError2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTraceError(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTraceError2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTraceError(ctx context.Context, sel ast.SelectionSet, v *model.TraceError) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TraceError(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNTracesMetricBucket2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracesMetricBucketᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.TracesMetricBucket) graphql.Marshaler {
@@ -90608,53 +91490,6 @@ func (ec *executionContext) marshalOTopUsersPayload2ᚖgithubᚗcomᚋhighlight�
 	return ec._TopUsersPayload(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalOTrace2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTraceᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Trace) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNTrace2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTrace(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
 func (ec *executionContext) marshalOTraceEvent2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTraceEvent(ctx context.Context, sel ast.SelectionSet, v []*model.TraceEvent) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -90749,6 +91584,13 @@ func (ec *executionContext) marshalOTraceLink2ᚖgithubᚗcomᚋhighlightᚑrun�
 		return graphql.Null
 	}
 	return ec._TraceLink(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOTracePayload2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐTracePayload(ctx context.Context, sel ast.SelectionSet, v *model.TracePayload) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._TracePayload(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOTrackProperty2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐTrackProperty(ctx context.Context, sel ast.SelectionSet, v *model1.TrackProperty) graphql.Marshaler {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1342,7 +1342,6 @@ type ComplexityRoot struct {
 		ErrorGroupSecureID func(childComplexity int) int
 		Event              func(childComplexity int) int
 		LogCursor          func(childComplexity int) int
-		SecureID           func(childComplexity int) int
 		Source             func(childComplexity int) int
 		SpanID             func(childComplexity int) int
 		Timestamp          func(childComplexity int) int
@@ -9393,13 +9392,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TraceError.LogCursor(childComplexity), true
 
-	case "TraceError.secure_id":
-		if e.complexity.TraceError.SecureID == nil {
-			break
-		}
-
-		return e.complexity.TraceError.SecureID(childComplexity), true
-
 	case "TraceError.source":
 		if e.complexity.TraceError.Source == nil {
 			break
@@ -10797,11 +10789,10 @@ type TraceError {
 	trace_id: String
 	span_id: String
 	log_cursor: String
-	secure_id: String!
-	error_group_secure_id: String!
 	event: String!
 	type: String!
 	source: String!
+	error_group_secure_id: String!
 	timestamp: Timestamp!
 }
 
@@ -65376,94 +65367,6 @@ func (ec *executionContext) fieldContext_TraceError_log_cursor(ctx context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _TraceError_secure_id(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_TraceError_secure_id(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.SecureID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_TraceError_secure_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "TraceError",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _TraceError_error_group_secure_id(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_TraceError_error_group_secure_id(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ErrorGroupSecureID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_TraceError_error_group_secure_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "TraceError",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _TraceError_event(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TraceError_event(ctx, field)
 	if err != nil {
@@ -65584,6 +65487,50 @@ func (ec *executionContext) _TraceError_source(ctx context.Context, field graphq
 }
 
 func (ec *executionContext) fieldContext_TraceError_source(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TraceError",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TraceError_error_group_secure_id(ctx context.Context, field graphql.CollectedField, obj *model.TraceError) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TraceError_error_group_secure_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ErrorGroupSecureID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TraceError_error_group_secure_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "TraceError",
 		Field:      field,
@@ -66075,16 +66022,14 @@ func (ec *executionContext) fieldContext_TracePayload_errors(ctx context.Context
 				return ec.fieldContext_TraceError_span_id(ctx, field)
 			case "log_cursor":
 				return ec.fieldContext_TraceError_log_cursor(ctx, field)
-			case "secure_id":
-				return ec.fieldContext_TraceError_secure_id(ctx, field)
-			case "error_group_secure_id":
-				return ec.fieldContext_TraceError_error_group_secure_id(ctx, field)
 			case "event":
 				return ec.fieldContext_TraceError_event(ctx, field)
 			case "type":
 				return ec.fieldContext_TraceError_type(ctx, field)
 			case "source":
 				return ec.fieldContext_TraceError_source(ctx, field)
+			case "error_group_secure_id":
+				return ec.fieldContext_TraceError_error_group_secure_id(ctx, field)
 			case "timestamp":
 				return ec.fieldContext_TraceError_timestamp(ctx, field)
 			}
@@ -83423,20 +83368,6 @@ func (ec *executionContext) _TraceError(ctx context.Context, sel ast.SelectionSe
 
 			out.Values[i] = ec._TraceError_log_cursor(ctx, field, obj)
 
-		case "secure_id":
-
-			out.Values[i] = ec._TraceError_secure_id(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "error_group_secure_id":
-
-			out.Values[i] = ec._TraceError_error_group_secure_id(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "event":
 
 			out.Values[i] = ec._TraceError_event(ctx, field, obj)
@@ -83454,6 +83385,13 @@ func (ec *executionContext) _TraceError(ctx context.Context, sel ast.SelectionSe
 		case "source":
 
 			out.Values[i] = ec._TraceError_source(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "error_group_secure_id":
+
+			out.Values[i] = ec._TraceError_error_group_secure_id(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -824,11 +824,10 @@ type TraceError struct {
 	TraceID            *string   `json:"trace_id"`
 	SpanID             *string   `json:"span_id"`
 	LogCursor          *string   `json:"log_cursor"`
-	SecureID           string    `json:"secure_id"`
-	ErrorGroupSecureID string    `json:"error_group_secure_id"`
 	Event              string    `json:"event"`
 	Type               string    `json:"type"`
 	Source             string    `json:"source"`
+	ErrorGroupSecureID string    `json:"error_group_secure_id"`
 	Timestamp          time.Time `json:"timestamp"`
 }
 

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -819,6 +819,19 @@ type TraceEdge struct {
 func (TraceEdge) IsEdge()                {}
 func (this TraceEdge) GetCursor() string { return this.Cursor }
 
+type TraceError struct {
+	CreatedAt          time.Time `json:"created_at"`
+	TraceID            *string   `json:"trace_id"`
+	SpanID             *string   `json:"span_id"`
+	LogCursor          *string   `json:"log_cursor"`
+	SecureID           string    `json:"secure_id"`
+	ErrorGroupSecureID string    `json:"error_group_secure_id"`
+	Event              string    `json:"event"`
+	Type               string    `json:"type"`
+	Source             string    `json:"source"`
+	Timestamp          time.Time `json:"timestamp"`
+}
+
 type TraceEvent struct {
 	Timestamp  time.Time              `json:"timestamp"`
 	Name       string                 `json:"name"`
@@ -830,6 +843,11 @@ type TraceLink struct {
 	SpanID     string                 `json:"spanID"`
 	TraceState string                 `json:"traceState"`
 	Attributes map[string]interface{} `json:"attributes"`
+}
+
+type TracePayload struct {
+	Trace  []*Trace      `json:"trace"`
+	Errors []*TraceError `json:"errors"`
 }
 
 type TracesMetricBucket struct {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -717,6 +717,23 @@ type Trace {
 	links: [TraceLink]
 }
 
+type TracePayload {
+	trace: [Trace!]!
+	errors: [TraceError!]!
+}
+
+type TraceError {
+	created_at: Timestamp!
+	trace_id: String
+	span_id: String
+	log_cursor: String
+	event: String!
+	type: String!
+	source: String!
+	error_group_secure_id: String!
+	timestamp: Timestamp!
+}
+
 type TraceEvent {
 	timestamp: Timestamp!
 	name: String!
@@ -1976,7 +1993,7 @@ type Query {
 	error_tags: [ErrorTag]
 	match_error_tag(query: String!): [MatchedErrorTag]
 	find_similar_errors(query: String!): [MatchedErrorObject]
-	trace(project_id: ID!, trace_id: String!): [Trace!]
+	trace(project_id: ID!, trace_id: String!): TracePayload
 	traces(
 		project_id: ID!
 		params: QueryInput!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7587,13 +7587,32 @@ func (r *queryResolver) FindSimilarErrors(ctx context.Context, query string) ([]
 }
 
 // Trace is the resolver for the trace field.
-func (r *queryResolver) Trace(ctx context.Context, projectID int, traceID string) ([]*modelInputs.Trace, error) {
+func (r *queryResolver) Trace(ctx context.Context, projectID int, traceID string) (*modelInputs.TracePayload, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 
-	return r.ClickhouseClient.ReadTrace(ctx, project.ID, traceID)
+	trace, err := r.ClickhouseClient.ReadTrace(ctx, project.ID, traceID)
+	if err != nil {
+		return nil, err
+	}
+
+	var errors = []*modelInputs.TraceError{}
+	err = r.DB.Model(&model.ErrorObject{}).
+		Joins("JOIN error_groups ON error_objects.error_group_id = error_groups.id").
+		Where("error_objects.trace_id = ?", traceID).
+		Order("error_objects.timestamp DESC").
+		Select("error_objects.*, error_groups.secure_id as error_group_secure_id").
+		Find(&errors).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &modelInputs.TracePayload{
+		Trace:  trace,
+		Errors: errors,
+	}, nil
 }
 
 // Traces is the resolver for the traces field.

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7234,6 +7234,7 @@ body {
 }
 ._1r8lbz42 {
   background-color: var(--_1pyqka91k);
+  border: 1px solid transparent;
   color: var(--_1pyqka9h);
   cursor: default;
 }
@@ -7241,11 +7242,19 @@ body {
   background-color: var(--_1pyqka91l);
 }
 ._1r8lbz43 {
+  border: 1px solid var(--_1pyqka9g);
+  border-left: 4px solid var(--_1pyqka9g);
+}
+._1r8lbz44 {
   background-color: var(--_1pyqka9l);
   color: white;
 }
-._1r8lbz42._1r8lbz41._1r8lbz43 {
+._1r8lbz42._1r8lbz41._1r8lbz44 {
   background-color: var(--_1pyqka9n);
+}
+._1r8lbz45 {
+  height: 100%;
+  overflow-y: hidden;
 }
 ._12wekn71 {
   width: 45%;

--- a/frontend/src/__generated/ve/pages/Traces/TraceErrors.css.js
+++ b/frontend/src/__generated/ve/pages/Traces/TraceErrors.css.js
@@ -1,0 +1,1 @@
+var r="fym6t40";export{r as container};

--- a/frontend/src/__generated/ve/pages/Traces/TraceLogs.css.js
+++ b/frontend/src/__generated/ve/pages/Traces/TraceLogs.css.js
@@ -1,0 +1,1 @@
+var r="_1cfd3gl0";export{r as container};

--- a/frontend/src/__generated/ve/pages/Traces/TracePage.css.js
+++ b/frontend/src/__generated/ve/pages/Traces/TracePage.css.js
@@ -1,1 +1,1 @@
-var r="_1r8lbz40",e="_1r8lbz41",a="_1r8lbz43",p="_1r8lbz42";export{r as container,e as hoveredSpan,a as selectedSpan,p as span};
+var r="_1r8lbz40",t="_1r8lbz43",a="_1r8lbz41",e="_1r8lbz44",o="_1r8lbz42",p="_1r8lbz45",n="mt0ih2h1",b="mt0ih27t mt0ih28g mt0ih227";export{r as container,t as errorSpan,a as hoveredSpan,e as selectedSpan,o as span,p as tabs,n as tabsContainer,b as tabsPageContainer};

--- a/frontend/src/__generated/ve/pages/Traces/TraceSpanAttributes.css.js
+++ b/frontend/src/__generated/ve/pages/Traces/TraceSpanAttributes.css.js
@@ -1,0 +1,1 @@
+var r="_7ms4060";export{r as container};

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -13891,21 +13891,34 @@ export type FindSimilarErrorsQueryResult = Apollo.QueryResult<
 export const GetTraceDocument = gql`
 	query GetTrace($project_id: ID!, $trace_id: String!) {
 		trace(project_id: $project_id, trace_id: $trace_id) {
-			timestamp
-			traceID
-			spanID
-			parentSpanID
-			projectID
-			secureSessionID
-			traceState
-			spanName
-			spanKind
-			duration
-			serviceName
-			serviceVersion
-			traceAttributes
-			statusCode
-			statusMessage
+			trace {
+				timestamp
+				traceID
+				spanID
+				parentSpanID
+				projectID
+				secureSessionID
+				traceState
+				spanName
+				spanKind
+				duration
+				serviceName
+				serviceVersion
+				traceAttributes
+				statusCode
+				statusMessage
+			}
+			errors {
+				created_at
+				trace_id
+				span_id
+				log_cursor
+				event
+				type
+				source
+				timestamp
+				error_group_secure_id
+			}
 		}
 	}
 `

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4691,26 +4691,42 @@ export type GetTraceQueryVariables = Types.Exact<{
 
 export type GetTraceQuery = { __typename?: 'Query' } & {
 	trace?: Types.Maybe<
-		Array<
-			{ __typename?: 'Trace' } & Pick<
-				Types.Trace,
-				| 'timestamp'
-				| 'traceID'
-				| 'spanID'
-				| 'parentSpanID'
-				| 'projectID'
-				| 'secureSessionID'
-				| 'traceState'
-				| 'spanName'
-				| 'spanKind'
-				| 'duration'
-				| 'serviceName'
-				| 'serviceVersion'
-				| 'traceAttributes'
-				| 'statusCode'
-				| 'statusMessage'
+		{ __typename?: 'TracePayload' } & {
+			trace: Array<
+				{ __typename?: 'Trace' } & Pick<
+					Types.Trace,
+					| 'timestamp'
+					| 'traceID'
+					| 'spanID'
+					| 'parentSpanID'
+					| 'projectID'
+					| 'secureSessionID'
+					| 'traceState'
+					| 'spanName'
+					| 'spanKind'
+					| 'duration'
+					| 'serviceName'
+					| 'serviceVersion'
+					| 'traceAttributes'
+					| 'statusCode'
+					| 'statusMessage'
+				>
 			>
-		>
+			errors: Array<
+				{ __typename?: 'TraceError' } & Pick<
+					Types.TraceError,
+					| 'created_at'
+					| 'trace_id'
+					| 'span_id'
+					| 'log_cursor'
+					| 'event'
+					| 'type'
+					| 'source'
+					| 'timestamp'
+					| 'error_group_secure_id'
+				>
+			>
+		}
 	>
 }
 

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1828,7 +1828,7 @@ export type Query = {
 	system_configuration: SystemConfiguration
 	timeline_indicator_events: Array<TimelineIndicatorEvent>
 	topUsers: Array<Maybe<TopUsersPayload>>
-	trace?: Maybe<Array<Trace>>
+	trace?: Maybe<TracePayload>
 	traces: TraceConnection
 	traces_key_values: Array<Scalars['String']>
 	traces_keys: Array<QueryKey>
@@ -3097,6 +3097,19 @@ export type TraceEdge = Edge & {
 	node: Trace
 }
 
+export type TraceError = {
+	__typename?: 'TraceError'
+	created_at: Scalars['Timestamp']
+	error_group_secure_id: Scalars['String']
+	event: Scalars['String']
+	log_cursor?: Maybe<Scalars['String']>
+	source: Scalars['String']
+	span_id?: Maybe<Scalars['String']>
+	timestamp: Scalars['Timestamp']
+	trace_id?: Maybe<Scalars['String']>
+	type: Scalars['String']
+}
+
 export type TraceEvent = {
 	__typename?: 'TraceEvent'
 	attributes: Scalars['Map']
@@ -3110,6 +3123,12 @@ export type TraceLink = {
 	spanID: Scalars['String']
 	traceID: Scalars['String']
 	traceState: Scalars['String']
+}
+
+export type TracePayload = {
+	__typename?: 'TracePayload'
+	errors: Array<TraceError>
+	trace: Array<Trace>
 }
 
 export type TracesMetricBucket = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2262,21 +2262,34 @@ query FindSimilarErrors($query: String!) {
 
 query GetTrace($project_id: ID!, $trace_id: String!) {
 	trace(project_id: $project_id, trace_id: $trace_id) {
-		timestamp
-		traceID
-		spanID
-		parentSpanID
-		projectID
-		secureSessionID
-		traceState
-		spanName
-		spanKind
-		duration
-		serviceName
-		serviceVersion
-		traceAttributes
-		statusCode
-		statusMessage
+		trace {
+			timestamp
+			traceID
+			spanID
+			parentSpanID
+			projectID
+			secureSessionID
+			traceState
+			spanName
+			spanKind
+			duration
+			serviceName
+			serviceVersion
+			traceAttributes
+			statusCode
+			statusMessage
+		}
+		errors {
+			created_at
+			trace_id
+			span_id
+			log_cursor
+			event
+			type
+			source
+			timestamp
+			error_group_secure_id
+		}
 	}
 }
 

--- a/frontend/src/pages/Traces/TraceErrors.css.ts
+++ b/frontend/src/pages/Traces/TraceErrors.css.ts
@@ -1,3 +1,0 @@
-import { style } from '@vanilla-extract/css'
-
-export const container = style({})

--- a/frontend/src/pages/Traces/TraceErrors.css.ts
+++ b/frontend/src/pages/Traces/TraceErrors.css.ts
@@ -1,0 +1,3 @@
+import { style } from '@vanilla-extract/css'
+
+export const container = style({})

--- a/frontend/src/pages/Traces/TraceErrors.tsx
+++ b/frontend/src/pages/Traces/TraceErrors.tsx
@@ -1,0 +1,44 @@
+import { Box, Text } from '@highlight-run/ui'
+import React from 'react'
+
+import { LinkButton } from '@/components/LinkButton'
+import { TraceError } from '@/graph/generated/schemas'
+
+type Props = {
+	errors: TraceError[]
+}
+
+export const TraceErrors: React.FC<Props> = ({ errors }) => {
+	if (!errors.length) {
+		return <Box>No errors...</Box>
+	}
+
+	return (
+		<Box my="10">
+			<Box display="flex" gap="2" flexDirection="column">
+				{errors?.map((error, idx) => (
+					<Box
+						key={idx}
+						borderRadius="6"
+						border="secondary"
+						padding="8"
+						display="flex"
+						alignItems="center"
+						gap="8"
+						flexDirection="row"
+						justifyContent="space-between"
+					>
+						<Text>{error.event}</Text>
+						<LinkButton
+							to={`/errors/${error.error_group_secure_id}`}
+							size="small"
+							trackingId="trace-error_see-more"
+						>
+							See more
+						</LinkButton>
+					</Box>
+				))}
+			</Box>
+		</Box>
+	)
+}

--- a/frontend/src/pages/Traces/TraceErrors.tsx
+++ b/frontend/src/pages/Traces/TraceErrors.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from '@highlight-run/ui'
+import moment from 'moment'
 import React from 'react'
 
 import { LinkButton } from '@/components/LinkButton'
@@ -15,7 +16,7 @@ export const TraceErrors: React.FC<Props> = ({ errors }) => {
 
 	return (
 		<Box my="10">
-			<Box display="flex" gap="2" flexDirection="column">
+			<Box display="flex" gap="4" flexDirection="column">
 				{errors?.map((error, idx) => (
 					<Box
 						key={idx}
@@ -28,7 +29,12 @@ export const TraceErrors: React.FC<Props> = ({ errors }) => {
 						flexDirection="row"
 						justifyContent="space-between"
 					>
-						<Text>{error.event}</Text>
+						<Box display="flex" gap="12" flexDirection="column">
+							<Text size="medium">{error.event}</Text>
+							<Text color="weak">
+								{moment(error.timestamp).format()}
+							</Text>
+						</Box>
 						<LinkButton
 							to={`/errors/${error.error_group_secure_id}`}
 							size="small"

--- a/frontend/src/pages/Traces/TraceLogs.tsx
+++ b/frontend/src/pages/Traces/TraceLogs.tsx
@@ -1,0 +1,182 @@
+import { Box, Callout, IconSolidExternalLink, Text } from '@highlight-run/ui'
+import moment from 'moment'
+import React, { useEffect, useRef, useState } from 'react'
+import { DateTimeParam, encodeQueryParams, StringParam } from 'use-query-params'
+
+import { LinkButton } from '@/components/LinkButton'
+import {
+	SearchForm,
+	SearchFormProps,
+} from '@/components/Search/SearchForm/SearchForm'
+import {
+	DEFAULT_OPERATOR,
+	stringifySearchQuery,
+} from '@/components/Search/SearchForm/utils'
+import {
+	useGetLogsKeysQuery,
+	useGetLogsKeyValuesLazyQuery,
+} from '@/graph/generated/hooks'
+import { useProjectId } from '@/hooks/useProjectId'
+import { LogsTable } from '@/pages/LogsPage/LogsTable/LogsTable'
+import { useGetLogs } from '@/pages/LogsPage/useGetLogs'
+import { useParams } from '@/util/react-router/useParams'
+
+type Props = {
+	traceId: string
+}
+
+export const TraceLogs: React.FC<Props> = ({ traceId }) => {
+	const { project_id } = useParams<{
+		project_id: string
+	}>()
+	const [query, setQuery] = useState('')
+	const tableContainerRef = useRef<HTMLDivElement>(null)
+	const startDate = moment().subtract(30, 'days').toDate()
+	const endDate = moment().toDate()
+
+	const { logEdges, loading, error, loadingAfter, refetch } = useGetLogs({
+		query,
+		project_id,
+		logCursor: undefined,
+		startDate,
+		endDate,
+	})
+
+	useEffect(() => {
+		setQuery(
+			traceId
+				? stringifySearchQuery([
+						{
+							key: 'trace_id',
+							operator: DEFAULT_OPERATOR,
+							value: traceId,
+							offsetStart: 0,
+						},
+				  ])
+				: '',
+		)
+	}, [traceId])
+
+	return (
+		<>
+			<Box
+				padding="8"
+				flex="stretch"
+				justifyContent="stretch"
+				display="flex"
+				overflow="hidden"
+				maxHeight="full"
+			>
+				<Box
+					borderRadius="6"
+					flexDirection="column"
+					display="flex"
+					flexGrow={1}
+					border="dividerWeak"
+					shadow="medium"
+				>
+					<SearchForm
+						initialQuery={query}
+						onFormSubmit={(value) => setQuery(value)}
+						startDate={startDate}
+						endDate={endDate}
+						onDatesChange={() => null}
+						presets={[]}
+						minDate={startDate}
+						timeMode="permalink"
+						disableSearch
+						actions={SearchFormActions}
+						hideDatePicker
+						hideCreateAlert
+						fetchKeys={useGetLogsKeysQuery}
+						fetchValuesLazyQuery={useGetLogsKeyValuesLazyQuery}
+					/>
+					<Box
+						height="screen"
+						pt="4"
+						px="12"
+						pb="12"
+						overflowY="auto"
+						ref={tableContainerRef}
+					>
+						{(!loading && logEdges.length === 0) || !traceId ? (
+							<NoLogsFound />
+						) : (
+							<LogsTable
+								logEdges={logEdges}
+								loading={loading}
+								error={error}
+								refetch={refetch}
+								loadingAfter={loadingAfter}
+								query={query}
+								tableContainerRef={tableContainerRef}
+								selectedCursor={undefined}
+							/>
+						)}
+					</Box>
+				</Box>
+			</Box>
+		</>
+	)
+}
+
+const NoLogsFound = () => {
+	return (
+		<Box mx="auto" style={{ maxWidth: 300 }}>
+			<Callout title="No associated logs found">
+				<Box
+					display="flex"
+					flexDirection="column"
+					gap="16"
+					alignItems="flex-start"
+				>
+					<Text color="moderate">
+						To match backend logs to traces, make sure to enable
+						"full stack mapping."
+					</Text>
+
+					<LinkButton
+						trackingId="logs-empty-state_specification-docs"
+						kind="secondary"
+						to="https://www.highlight.io/docs/getting-started/frontend-backend-mapping"
+						target="_blank"
+					>
+						Learn more
+					</LinkButton>
+				</Box>
+			</Callout>
+		</Box>
+	)
+}
+
+const SearchFormActions: SearchFormProps['actions'] = ({
+	query,
+	startDate,
+	endDate,
+}) => {
+	const { projectId } = useProjectId()
+	const encodedQuery = encodeQueryParams(
+		{
+			query: StringParam,
+			start_date: DateTimeParam,
+			end_date: DateTimeParam,
+		},
+		{
+			query: query,
+			start_date: startDate,
+			end_date: endDate,
+		},
+	)
+
+	return (
+		<LinkButton
+			kind="secondary"
+			trackingId="view-in-log-viewer"
+			to={`/${projectId}/logs?${encodedQuery}`}
+			emphasis="medium"
+			iconLeft={<IconSolidExternalLink />}
+		>
+			View in log viewer
+		</LinkButton>
+	)
+}

--- a/frontend/src/pages/Traces/TraceLogs.tsx
+++ b/frontend/src/pages/Traces/TraceLogs.tsx
@@ -1,5 +1,6 @@
 import { Box, Callout, IconSolidExternalLink, Text } from '@highlight-run/ui'
 import moment from 'moment'
+import { stringify } from 'query-string'
 import React, { useEffect, useRef, useState } from 'react'
 import { DateTimeParam, encodeQueryParams, StringParam } from 'use-query-params'
 
@@ -199,7 +200,7 @@ const SearchFormActions: SearchFormProps['actions'] = ({
 		<LinkButton
 			kind="secondary"
 			trackingId="view-in-log-viewer"
-			to={`/${projectId}/logs?${encodedQuery}`}
+			to={`/${projectId}/logs?${stringify(encodedQuery)}`}
 			emphasis="medium"
 			iconLeft={<IconSolidExternalLink />}
 		>

--- a/frontend/src/pages/Traces/TracePage.css.ts
+++ b/frontend/src/pages/Traces/TracePage.css.ts
@@ -1,3 +1,4 @@
+import { sprinkles } from '@highlight-run/ui'
 import { themeVars } from '@highlight-run/ui/src/css/theme.css'
 import { style } from '@vanilla-extract/css'
 
@@ -7,6 +8,7 @@ export const hoveredSpan = style({})
 
 export const span = style({
 	backgroundColor: themeVars.interactive.outline.primary.enabled,
+	border: `1px solid transparent`,
 	color: themeVars.static.content.sentiment.informative,
 	cursor: 'default',
 	selectors: {
@@ -14,6 +16,11 @@ export const span = style({
 			backgroundColor: themeVars.interactive.outline.primary.hover,
 		},
 	},
+})
+
+export const errorSpan = style({
+	border: `1px solid ${themeVars.static.content.sentiment.bad}`,
+	borderLeft: `4px solid ${themeVars.static.content.sentiment.bad}`,
 })
 
 export const selectedSpan = style({
@@ -24,4 +31,22 @@ export const selectedSpan = style({
 			backgroundColor: themeVars.interactive.fill.primary.pressed,
 		},
 	},
+})
+
+// Custom tab styles we had to override to get scrolling behavior to work. These
+// should be removed once we upgrade our Tabs component:
+// https://github.com/highlight/highlight/issues/5771
+export const tabs = style({
+	height: '100%',
+	overflowY: 'hidden',
+})
+
+export const tabsContainer = sprinkles({
+	borderBottom: 'secondary',
+})
+
+export const tabsPageContainer = sprinkles({
+	height: 'full',
+	overflowY: 'scroll',
+	position: 'relative',
 })

--- a/frontend/src/pages/Traces/TracePage.tsx
+++ b/frontend/src/pages/Traces/TracePage.tsx
@@ -1,13 +1,23 @@
-import { Box, Heading, Stack, Text, Tooltip } from '@highlight-run/ui'
+import {
+	Badge,
+	Box,
+	Heading,
+	Stack,
+	Tabs,
+	Text,
+	Tooltip,
+} from '@highlight-run/ui'
 import { themeVars } from '@highlight-run/ui/src/css/theme.css'
 import clsx from 'clsx'
 import moment from 'moment'
 import React, { useState } from 'react'
 
-import JsonViewer from '@/components/JsonViewer/JsonViewer'
 import LoadingBox from '@/components/LoadingBox'
 import { useGetTraceQuery } from '@/graph/generated/hooks'
-import { Trace } from '@/graph/generated/schemas'
+import { Trace, TraceError } from '@/graph/generated/schemas'
+import { TraceErrors } from '@/pages/Traces/TraceErrors'
+import { TraceLogs } from '@/pages/Traces/TraceLogs'
+import { TraceSpanAttributes } from '@/pages/Traces/TraceSpanAttributes'
 import {
 	getFirstSpan,
 	getTraceDuration,
@@ -18,31 +28,52 @@ import { useParams } from '@/util/react-router/useParams'
 
 import * as styles from './TracePage.css'
 
+enum TraceTabs {
+	Info = 'Info',
+	Errors = 'Errors',
+	Logs = 'Logs',
+}
+
 type Props = {}
 
 const MAX_TICKS = 6
 
 export const TracePage: React.FC<Props> = () => {
+	const {
+		project_id: projectId,
+		trace_id: traceId,
+		span_id: spanId,
+	} = useParams<{
+		project_id: string
+		trace_id: string
+		span_id?: string
+	}>()
+	const [activeTab, setActiveTab] = useState<TraceTabs>(TraceTabs.Info)
 	const [selectedSpan, setSelectedSpan] = useState<Trace>()
 	const [hoveredSpan, setHoveredSpan] = useState<Trace>()
 	const highlightedSpan = hoveredSpan || selectedSpan
-
-	const { project_id: projectId, trace_id: traceId } = useParams<{
-		project_id: string
-		trace_id: string
-	}>()
 
 	const { data, loading } = useGetTraceQuery({
 		variables: {
 			project_id: projectId!,
 			trace_id: traceId!,
 		},
+		onCompleted: (data) => {
+			if (spanId) {
+				const span = data.trace?.trace.find(
+					(span) => span.spanID === spanId,
+				)
+				if (span) {
+					setSelectedSpan(span)
+				}
+			}
+		},
 		skip: !projectId || !traceId,
 	})
 
 	const traces = React.useMemo(() => {
-		if (!data?.trace) return []
-		const sortableTraces = [...data.trace]
+		if (!data?.trace?.trace) return []
+		const sortableTraces = [...data.trace.trace]
 
 		if (!selectedSpan) {
 			const firstSpan = getFirstSpan(sortableTraces)
@@ -53,7 +84,7 @@ export const TracePage: React.FC<Props> = () => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data?.trace])
 
-	if (!data?.trace || !data?.trace?.length) {
+	if (!data?.trace || !data?.trace?.trace?.length) {
 		return loading ? (
 			<LoadingBox />
 		) : (
@@ -63,10 +94,11 @@ export const TracePage: React.FC<Props> = () => {
 		)
 	}
 
-	const totalDuration = getTraceDuration(data.trace)
-	const firstSpan = getFirstSpan(data.trace)
+	const totalDuration = getTraceDuration(data.trace.trace)
+	const firstSpan = getFirstSpan(data.trace.trace)
 	const traceName = firstSpan?.spanName
 	const startTime = moment(firstSpan.timestamp)
+	const errors = data.trace?.errors
 	const durationString = getTraceDurationString(totalDuration)
 	const ticks = Array.from({ length: MAX_TICKS }).map((_, index) => {
 		const percent = index / (MAX_TICKS - 1)
@@ -153,6 +185,9 @@ export const TracePage: React.FC<Props> = () => {
 								.diff(startTime, 'ms')
 								.valueOf()
 							const marginLeft = (diff / totalDuration) * 100
+							const error = data.trace?.errors.find(
+								(error) => error.span_id === span.spanID,
+							)
 
 							return (
 								<Box
@@ -169,7 +204,7 @@ export const TracePage: React.FC<Props> = () => {
 										trigger={
 											<Box
 												borderRadius="3"
-												p="4"
+												p="3"
 												py="6"
 												mb="2"
 												display="flex"
@@ -182,6 +217,7 @@ export const TracePage: React.FC<Props> = () => {
 														span === selectedSpan,
 													[styles.hoveredSpan]:
 														span === hoveredSpan,
+													[styles.errorSpan]: !!error,
 												})}
 											>
 												<Text size="xSmall" lines="1">
@@ -223,20 +259,46 @@ export const TracePage: React.FC<Props> = () => {
 				</Box>
 
 				{highlightedSpan && (
-					<Box mt="10">
-						<SpanAttributes span={highlightedSpan} />
+					<Box mt="12">
+						<Tabs<TraceTabs>
+							tab={activeTab}
+							setTab={(tab) => setActiveTab(tab)}
+							containerClass={styles.tabs}
+							tabsContainerClass={styles.tabsContainer}
+							pageContainerClass={styles.tabsPageContainer}
+							pages={{
+								[TraceTabs.Info]: {
+									page: (
+										<TraceSpanAttributes
+											span={highlightedSpan}
+										/>
+									),
+								},
+								[TraceTabs.Errors]: {
+									badge:
+										errors?.length > 0 ? (
+											<Badge
+												variant="gray"
+												label={String(errors.length)}
+											/>
+										) : undefined,
+									page: (
+										<TraceErrors
+											errors={
+												(errors ?? []) as TraceError[]
+											}
+										/>
+									),
+								},
+								[TraceTabs.Logs]: {
+									page: <TraceLogs traceId={traceId!} />,
+								},
+							}}
+							noHandle
+						/>
 					</Box>
 				)}
 			</Box>
 		</Box>
 	)
-}
-
-const SpanAttributes: React.FC<{ span: Trace }> = ({ span }) => {
-	const attributes = { ...span }
-
-	// Drop any attributes we don't want to display
-	delete attributes.__typename
-
-	return <JsonViewer src={attributes} collapsed={false} />
 }

--- a/frontend/src/pages/Traces/TracePage.tsx
+++ b/frontend/src/pages/Traces/TracePage.tsx
@@ -258,46 +258,42 @@ export const TracePage: React.FC<Props> = () => {
 					</Box>
 				</Box>
 
-				{highlightedSpan && (
-					<Box mt="12">
-						<Tabs<TraceTabs>
-							tab={activeTab}
-							setTab={(tab) => setActiveTab(tab)}
-							containerClass={styles.tabs}
-							tabsContainerClass={styles.tabsContainer}
-							pageContainerClass={styles.tabsPageContainer}
-							pages={{
-								[TraceTabs.Info]: {
-									page: (
-										<TraceSpanAttributes
-											span={highlightedSpan}
+				<Box mt="12">
+					<Tabs<TraceTabs>
+						tab={activeTab}
+						setTab={(tab) => setActiveTab(tab)}
+						containerClass={styles.tabs}
+						tabsContainerClass={styles.tabsContainer}
+						pageContainerClass={styles.tabsPageContainer}
+						pages={{
+							[TraceTabs.Info]: {
+								page: (
+									<TraceSpanAttributes
+										span={highlightedSpan!}
+									/>
+								),
+							},
+							[TraceTabs.Errors]: {
+								badge:
+									errors?.length > 0 ? (
+										<Badge
+											variant="gray"
+											label={String(errors.length)}
 										/>
-									),
-								},
-								[TraceTabs.Errors]: {
-									badge:
-										errors?.length > 0 ? (
-											<Badge
-												variant="gray"
-												label={String(errors.length)}
-											/>
-										) : undefined,
-									page: (
-										<TraceErrors
-											errors={
-												(errors ?? []) as TraceError[]
-											}
-										/>
-									),
-								},
-								[TraceTabs.Logs]: {
-									page: <TraceLogs traceId={traceId!} />,
-								},
-							}}
-							noHandle
-						/>
-					</Box>
-				)}
+									) : undefined,
+								page: (
+									<TraceErrors
+										errors={(errors ?? []) as TraceError[]}
+									/>
+								),
+							},
+							[TraceTabs.Logs]: {
+								page: <TraceLogs />,
+							},
+						}}
+						noHandle
+					/>
+				</Box>
 			</Box>
 		</Box>
 	)

--- a/frontend/src/pages/Traces/TraceSpanAttributes.tsx
+++ b/frontend/src/pages/Traces/TraceSpanAttributes.tsx
@@ -1,0 +1,20 @@
+import { Box } from '@highlight-run/ui'
+import React from 'react'
+
+import JsonViewer from '@/components/JsonViewer/JsonViewer'
+import { Trace } from '@/graph/generated/schemas'
+
+type Props = { span: Trace }
+
+export const TraceSpanAttributes: React.FC<Props> = ({ span }) => {
+	const attributes = { ...span }
+
+	// Drop any attributes we don't want to display
+	delete attributes.__typename
+
+	return (
+		<Box mt="10">
+			<JsonViewer src={attributes} collapsed={false} />
+		</Box>
+	)
+}

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -31,7 +31,9 @@ export const TracesList: React.FC<Props> = ({ loading, traces }) => {
 	const location = useLocation()
 
 	const viewTrace = (trace: Trace) => {
-		navigate(`/${projectId}/traces/${trace.traceID}${location.search}`)
+		navigate(
+			`/${projectId}/traces/${trace.traceID}/${trace.spanID}${location.search}`,
+		)
 	}
 
 	return (

--- a/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
@@ -52,7 +52,10 @@ const ApplicationRouter: React.FC = () => {
 				<>
 					{isHighlightAdmin && (
 						<Route path="traces" element={<TracesPage />}>
-							<Route path=":trace_id" element={<TracePanel />} />
+							<Route
+								path=":trace_id/:span_id?"
+								element={<TracePanel />}
+							/>
 						</Route>
 					)}
 					<Route path="logs/:log_cursor?" element={<LogsPage />} />

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -84,13 +84,15 @@ export const Tabs = function <T extends string>({
 									selected: t === tab,
 								})}
 							>
-								<Text
-									color={t === tab ? 'p9' : 'n11'}
-									cssClass={styles.tabText}
-								>
-									{t}
+								<Box display="flex" gap="6">
+									<Text
+										color={t === tab ? 'p9' : 'n11'}
+										cssClass={styles.tabText}
+									>
+										{t}
+									</Text>
 									{pages[t].badge}
-								</Text>
+								</Box>
 							</Button>
 							<Box
 								cssClass={styles.controlBarBottomVariants({


### PR DESCRIPTION
## Summary

* Highlights the selected span from the traces list in the flame graph on the trace detail page
* Adds an "Errors" tab to view the errors related with the trace
* Adds a "Logs" tab to view logs related with the trace

https://www.loom.com/share/375f3125baf84450b8b82c4e5556cc46

## How did you test this change?

Local + PR preview click test

## Are there any deployment considerations?

Need to confirm backend changes work in prod, but any new backend logic is only hit when making requests from the new traces pages, which are only available to Highlight admins at the moment.

## Does this work require review from our design team?

Yes, I'm planning to do some polish work w/ Julian once this goes out and people get to play with it a little.
