### PR TITLE
remove feed error card tags

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
@@ -3,7 +3,6 @@ import { ErrorGroup, ErrorState, Maybe } from '@graph/schemas'
 import {
 	Badge,
 	Box,
-	IconSolidDesktopComputer,
 	IconSolidSparkles,
 	IconSolidUsers,
 	IconSolidViewGrid,
@@ -179,22 +178,6 @@ export const ErrorFeedCard = ({ errorGroup, onClick }: Props) => {
 							>
 								{createdDate}
 							</Tag>
-							{errorGroup?.error_tag?.title ? (
-								<Tag
-									shape="basic"
-									kind="secondary"
-									iconLeft={
-										<IconSolidDesktopComputer size={12} />
-									}
-								>
-									<Text
-										cssClass={style.errorCardTagText}
-										lines="1"
-									>
-										{errorGroup.error_tag.title}
-									</Text>
-								</Tag>
-							) : null}
 						</Box>
 					</Box>
 					<Box paddingTop="2" display="flex" alignItems="flex-end">


### PR DESCRIPTION
## Summary

Error card tags are taking up too much space and make the feed look too busy.

## How did you test this change?

![image](https://github.com/highlight/highlight/assets/1351531/0e067fc6-4c21-4bc7-b64b-0bf11e928072)

[Reflame](https://preview.highlight.io/1/errors?page=1&query=and%7C%7Cerror_state%2Cis%2COPEN%7C%7Cerror-field_timestamp%2Cbetween_date%2C2023-09-11T21%3A53%3A32.316Z_2023-10-11T21%3A53%3A32.316Z&%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HCGBMHNTK8T87QXQDN1JZ3PW%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Fremove-error-feed-tags%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

## Are there any deployment considerations?

No

## Does this work require review from our design team?

Yes
