### PR TITLE
Fix log alert saving logic to use update, prevent duplication

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3070,7 +3070,7 @@ func (r *mutationResolver) UpdateLogAlert(ctx context.Context, id int, input mod
 
 	if err := r.DB.Model(&model.LogAlert{Model: model.Model{ID: id}}).
 		Where("project_id = ?", input.ProjectID).
-		Save(alert).Error; err != nil {
+		Updates(alert).Error; err != nil {
 		return nil, e.Wrap(err, "error updating log alert")
 	}
 

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -348,6 +348,7 @@ export const LogAlertPage = () => {
 							})
 								.then(() => {
 									message.success(`Log alert ${createStr}d!`)
+									navigate(`/${project_id}/alerts`)
 								})
 								.catch(() => {
 									message.error(


### PR DESCRIPTION
## Summary

Fix: https://www.loom.com/share/2020b947f0fc4dd28eb9e4ee9507388b

Did some deep dive into it because I had trouble repo'ing. It looks like it only affects Log Alerts, as I tried it on all alerts in prod and only that one cause duplication. 

Solution: Change save() to updates() because save creates a new object if it doesn't exist already for a primary key. 
Also bug fix by adding a redirect to alerts home after updating log alert

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
