### PR TITLE
add backend setup logic for traces, add quickstart guide for go

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -377,6 +377,7 @@ const (
 	MarkBackendSetupTypeSession MarkBackendSetupType = "session"
 	MarkBackendSetupTypeError   MarkBackendSetupType = "error"
 	MarkBackendSetupTypeLogs    MarkBackendSetupType = "logs"
+	MarkBackendSetupTypeTraces  MarkBackendSetupType = "traces"
 )
 
 type SetupEvent struct {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -960,6 +960,7 @@ type ComplexityRoot struct {
 		TopUsers                     func(childComplexity int, projectID int, lookBackPeriod int) int
 		Trace                        func(childComplexity int, projectID int, traceID string) int
 		Traces                       func(childComplexity int, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection) int
+		TracesIntegration            func(childComplexity int, projectID int) int
 		TracesKeyValues              func(childComplexity int, projectID int, keyName string, dateRange model.DateRangeRequiredInput) int
 		TracesKeys                   func(childComplexity int, projectID int, dateRange model.DateRangeRequiredInput) int
 		TracesMetrics                func(childComplexity int, projectID int, params model.QueryInput, metricTypes []model.TracesMetricType) int
@@ -1654,6 +1655,7 @@ type QueryResolver interface {
 	ClientIntegration(ctx context.Context, projectID int) (*model.IntegrationStatus, error)
 	ServerIntegration(ctx context.Context, projectID int) (*model.IntegrationStatus, error)
 	LogsIntegration(ctx context.Context, projectID int) (*model.IntegrationStatus, error)
+	TracesIntegration(ctx context.Context, projectID int) (*model.IntegrationStatus, error)
 	UnprocessedSessionsCount(ctx context.Context, projectID int) (*int64, error)
 	LiveUsersCount(ctx context.Context, projectID int) (*int64, error)
 	AdminHasCreatedComment(ctx context.Context, adminID int) (*bool, error)
@@ -7397,6 +7399,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Traces(childComplexity, args["project_id"].(int), args["params"].(model.QueryInput), args["after"].(*string), args["before"].(*string), args["at"].(*string), args["direction"].(model.SortDirection)), true
 
+	case "Query.tracesIntegration":
+		if e.complexity.Query.TracesIntegration == nil {
+			break
+		}
+
+		args, err := ec.field_Query_tracesIntegration_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.TracesIntegration(childComplexity, args["project_id"].(int)), true
+
 	case "Query.traces_key_values":
 		if e.complexity.Query.TracesKeyValues == nil {
 			break
@@ -11850,6 +11864,7 @@ type Query {
 	clientIntegration(project_id: ID!): IntegrationStatus!
 	serverIntegration(project_id: ID!): IntegrationStatus!
 	logsIntegration(project_id: ID!): IntegrationStatus!
+	tracesIntegration(project_id: ID!): IntegrationStatus!
 	unprocessedSessionsCount(project_id: ID!): Int64
 	liveUsersCount(project_id: ID!): Int64
 	adminHasCreatedComment(admin_id: ID!): Boolean
@@ -18206,6 +18221,21 @@ func (ec *executionContext) field_Query_trace_args(ctx context.Context, rawArgs 
 		}
 	}
 	args["trace_id"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_tracesIntegration_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
 	return args, nil
 }
 
@@ -46886,6 +46916,68 @@ func (ec *executionContext) fieldContext_Query_logsIntegration(ctx context.Conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_logsIntegration_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_tracesIntegration(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_tracesIntegration(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().TracesIntegration(rctx, fc.Args["project_id"].(int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.IntegrationStatus)
+	fc.Result = res
+	return ec.marshalNIntegrationStatus2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐIntegrationStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_tracesIntegration(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "integrated":
+				return ec.fieldContext_IntegrationStatus_integrated(ctx, field)
+			case "resourceType":
+				return ec.fieldContext_IntegrationStatus_resourceType(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_IntegrationStatus_createdAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type IntegrationStatus", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_tracesIntegration_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -78696,6 +78788,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_logsIntegration(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "tracesIntegration":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_tracesIntegration(ctx, field)
 				return res
 			}
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1779,6 +1779,7 @@ type Query {
 	clientIntegration(project_id: ID!): IntegrationStatus!
 	serverIntegration(project_id: ID!): IntegrationStatus!
 	logsIntegration(project_id: ID!): IntegrationStatus!
+	tracesIntegration(project_id: ID!): IntegrationStatus!
 	unprocessedSessionsCount(project_id: ID!): Int64
 	liveUsersCount(project_id: ID!): Int64
 	adminHasCreatedComment(admin_id: ID!): Boolean

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -10004,6 +10004,64 @@ export type GetLogsIntegrationQueryResult = Apollo.QueryResult<
 	Types.GetLogsIntegrationQuery,
 	Types.GetLogsIntegrationQueryVariables
 >
+export const GetTracesIntegrationDocument = gql`
+	query GetTracesIntegration($project_id: ID!) {
+		tracesIntegration(project_id: $project_id) {
+			integrated
+			resourceType
+			createdAt
+		}
+	}
+`
+
+/**
+ * __useGetTracesIntegrationQuery__
+ *
+ * To run a query within a React component, call `useGetTracesIntegrationQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetTracesIntegrationQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetTracesIntegrationQuery({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *   },
+ * });
+ */
+export function useGetTracesIntegrationQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetTracesIntegrationQuery,
+		Types.GetTracesIntegrationQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetTracesIntegrationQuery,
+		Types.GetTracesIntegrationQueryVariables
+	>(GetTracesIntegrationDocument, baseOptions)
+}
+export function useGetTracesIntegrationLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetTracesIntegrationQuery,
+		Types.GetTracesIntegrationQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetTracesIntegrationQuery,
+		Types.GetTracesIntegrationQueryVariables
+	>(GetTracesIntegrationDocument, baseOptions)
+}
+export type GetTracesIntegrationQueryHookResult = ReturnType<
+	typeof useGetTracesIntegrationQuery
+>
+export type GetTracesIntegrationLazyQueryHookResult = ReturnType<
+	typeof useGetTracesIntegrationLazyQuery
+>
+export type GetTracesIntegrationQueryResult = Apollo.QueryResult<
+	Types.GetTracesIntegrationQuery,
+	Types.GetTracesIntegrationQueryVariables
+>
 export const GetKeyPerformanceIndicatorsDocument = gql`
 	query GetKeyPerformanceIndicators($project_id: ID!, $lookBackPeriod: Int!) {
 		unprocessedSessionsCount(project_id: $project_id)

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -3480,6 +3480,17 @@ export type GetLogsIntegrationQuery = { __typename?: 'Query' } & {
 	>
 }
 
+export type GetTracesIntegrationQueryVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+}>
+
+export type GetTracesIntegrationQuery = { __typename?: 'Query' } & {
+	tracesIntegration: { __typename?: 'IntegrationStatus' } & Pick<
+		Types.IntegrationStatus,
+		'integrated' | 'resourceType' | 'createdAt'
+	>
+}
+
 export type GetKeyPerformanceIndicatorsQueryVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	lookBackPeriod: Types.Scalars['Int']
@@ -4904,6 +4915,7 @@ export const namedOperations = {
 		GetClientIntegration: 'GetClientIntegration' as const,
 		GetServerIntegration: 'GetServerIntegration' as const,
 		GetLogsIntegration: 'GetLogsIntegration' as const,
+		GetTracesIntegration: 'GetTracesIntegration' as const,
 		GetKeyPerformanceIndicators: 'GetKeyPerformanceIndicators' as const,
 		GetReferrersCount: 'GetReferrersCount' as const,
 		GetNewUsersCount: 'GetNewUsersCount' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1831,6 +1831,7 @@ export type Query = {
 	topUsers: Array<Maybe<TopUsersPayload>>
 	trace?: Maybe<TracePayload>
 	traces: TraceConnection
+	tracesIntegration: IntegrationStatus
 	traces_key_values: Array<Scalars['String']>
 	traces_keys: Array<QueryKey>
 	traces_metrics: TracesMetrics
@@ -2411,6 +2412,10 @@ export type QueryTracesArgs = {
 	before?: InputMaybe<Scalars['String']>
 	direction: SortDirection
 	params: QueryInput
+	project_id: Scalars['ID']
+}
+
+export type QueryTracesIntegrationArgs = {
 	project_id: Scalars['ID']
 }
 

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1407,6 +1407,14 @@ query GetLogsIntegration($project_id: ID!) {
 	}
 }
 
+query GetTracesIntegration($project_id: ID!) {
+	tracesIntegration(project_id: $project_id) {
+		integrated
+		resourceType
+		createdAt
+	}
+}
+
 query GetKeyPerformanceIndicators($project_id: ID!, $lookBackPeriod: Int!) {
 	unprocessedSessionsCount(project_id: $project_id)
 	liveUsersCount(project_id: $project_id)

--- a/frontend/src/pages/Setup/IntegrationBar.tsx
+++ b/frontend/src/pages/Setup/IntegrationBar.tsx
@@ -33,13 +33,14 @@ type Props = React.PropsWithChildren & {
 	integrationData?: IntegrationStatus
 }
 
-type Area = 'client' | 'backend' | 'backend-logging' | 'alerts'
+type Area = 'client' | 'backend' | 'backend-logging' | 'alerts' | 'traces'
 
 const AREA_TITLE_MAP: { [key in Area]: string } = {
 	client: 'Frontend monitoring + session replay',
 	backend: 'Backend monitoring',
 	'backend-logging': 'Backend logging',
 	alerts: 'Alerts',
+	traces: 'Traces',
 }
 
 const CTA_TITLE_MAP: { [key in Area]: string } = {
@@ -47,6 +48,7 @@ const CTA_TITLE_MAP: { [key in Area]: string } = {
 	backend: 'View an error',
 	'backend-logging': 'View logs',
 	alerts: 'Configure an alert',
+	traces: 'View traces',
 }
 
 const CTA_PATH_MAP: { [key in Area]: string } = {
@@ -54,6 +56,7 @@ const CTA_PATH_MAP: { [key in Area]: string } = {
 	backend: 'errors',
 	'backend-logging': 'logs',
 	alerts: 'alerts',
+	traces: 'traces',
 }
 
 export const IntegrationBar: React.FC<Props> = ({ integrationData }) => {
@@ -189,7 +192,7 @@ const buildResourcePath = (
 
 	if (resource?.secure_id) {
 		path = `${basePath}/${resource.secure_id}`
-	} else if (area === 'backend-logging') {
+	} else if (area === 'backend-logging' || area === 'traces') {
 		const logDate = moment(resource?.created_at)
 		// Show logs with a 2 minute buffer of when the setup event was created.
 		const startDate = moment(logDate).subtract(2, 'minutes')

--- a/frontend/src/pages/Setup/SetupRouter/SetupRouter.tsx
+++ b/frontend/src/pages/Setup/SetupRouter/SetupRouter.tsx
@@ -1,6 +1,7 @@
 import LoadingBox from '@components/LoadingBox'
 import { useGetProjectQuery } from '@graph/hooks'
 import {
+	Badge,
 	Box,
 	ButtonIcon,
 	IconSolidBell,
@@ -9,6 +10,7 @@ import {
 	IconSolidDesktopComputer,
 	IconSolidGlobe,
 	IconSolidLogs,
+	IconSolidSparkles,
 	IconSolidTerminal,
 	IconSolidUserAdd,
 	IconSolidViewGridAdd,
@@ -35,6 +37,7 @@ import {
 	useMatch,
 } from 'react-router-dom'
 
+import { useAuthContext } from '@/authentication/AuthContext'
 import { IntegrationBar } from '@/pages/Setup/IntegrationBar'
 import {
 	useAlertsIntegration,
@@ -42,18 +45,21 @@ import {
 	useLogsIntegration,
 	useServerIntegration,
 	useTeamIntegration,
+	useTracesIntegration,
 } from '@/util/integrated'
 
 import { AlertsSetup } from './AlertsSetup'
 import * as styles from './SetupRouter.css'
 
 export const SetupRouter = () => {
+	const { isHighlightAdmin } = useAuthContext()
 	const { toggleShowBanner } = useGlobalContext()
 	const areaMatch = useMatch('/:project_id/setup/:area/*')
 	const area = areaMatch?.params.area || 'client'
 	const clientIntegration = useClientIntegration()
 	const serverIntegration = useServerIntegration()
 	const logsIntegration = useLogsIntegration()
+	const tracesIntegration = useTracesIntegration()
 	const alertsIntegration = useAlertsIntegration()
 	const teamIntegration = useTeamIntegration()
 	const integrationData =
@@ -67,6 +73,8 @@ export const SetupRouter = () => {
 			? alertsIntegration
 			: area === 'team'
 			? teamIntegration
+			: area === 'traces'
+			? tracesIntegration
 			: undefined
 	const { projectId } = useProjectId()
 	const { data } = useGetProjectQuery({ variables: { id: projectId! } })
@@ -187,6 +195,37 @@ export const SetupRouter = () => {
 							)}
 						</Stack>
 					</NavLink>
+					{isHighlightAdmin && (
+						<NavLink
+							to="traces"
+							className={({ isActive }) =>
+								clsx(styles.menuItem, {
+									[styles.menuItemActive]: isActive,
+								})
+							}
+						>
+							<Stack
+								direction="row"
+								align="center"
+								justify="space-between"
+								pr="8"
+							>
+								<Stack direction="row" align="center" gap="4">
+									<IconSolidSparkles />
+									<Text>Traces</Text>
+									<Badge
+										size="small"
+										shape="basic"
+										label="Beta"
+										variant="purple"
+									/>
+								</Stack>
+								{tracesIntegration?.integrated && (
+									<IconSolidCheckCircle />
+								)}
+							</Stack>
+						</NavLink>
+					)}
 					<NavLink
 						to="alerts"
 						className={({ isActive }) =>

--- a/highlight.io/components/QuickstartContent/QuickstartContent.tsx
+++ b/highlight.io/components/QuickstartContent/QuickstartContent.tsx
@@ -5,6 +5,7 @@ import { GoFiberContent } from './backend/go/fiber'
 import { GoGinContent } from './backend/go/gin'
 import { GoGqlgenContent } from './backend/go/go-gqlgen'
 import { GoMuxContent } from './backend/go/mux'
+import { JavaOtherContent } from './backend/java/other'
 import { JSApolloContent } from './backend/js/apollo'
 import { JSCloudflareContent } from './backend/js/cloudflare'
 import { JSExpressContent } from './backend/js/express'
@@ -21,7 +22,6 @@ import { PythonGCPContext } from './backend/python/gcp'
 import { PythonOtherContext } from './backend/python/other'
 import { RubyOtherContent } from './backend/ruby/other'
 import { RubyRailsContent } from './backend/ruby/rails'
-import { JavaOtherContent } from './backend/java/other'
 import { AngularContent } from './frontend/angular'
 import { GatsbyContent } from './frontend/gatsby'
 import { NextContent } from './frontend/next'
@@ -42,19 +42,20 @@ import { DockerContent } from './logging/docker'
 import { FileContent } from './logging/file'
 import { FluentForwardContent } from './logging/fluentd'
 import { HostingFlyIOLogContent } from './logging/hosting/fly-io'
+import { HostingRenderLogContent } from './logging/hosting/render'
+import { JavaOtherLogContent } from './logging/java/other'
 import { JSCloudflareLoggingContent } from './logging/js/cloudflare'
+import { JSPinoHTTPJSONLogContent } from './logging/js/pino'
 import { JSWinstonHTTPJSONLogContent } from './logging/js/winston'
 import { PythonLoguruLogContent } from './logging/python/loguru'
 import { PythonOtherLogContent } from './logging/python/other'
 import { RubyOtherLogContent } from './logging/ruby/other'
 import { RubyRailsLogContent } from './logging/ruby/rails'
-import { JavaOtherLogContent } from './logging/java/other'
-import { DevDeploymentContent } from './self-host/dev-deploy'
-import { SelfHostContent } from './self-host/self-host'
-import { HostingRenderLogContent } from './logging/hosting/render'
 import { SyslogContent } from './logging/syslog'
 import { SystemdContent } from './logging/systemd'
-import { JSPinoHTTPJSONLogContent } from './logging/js/pino'
+import { DevDeploymentContent } from './self-host/dev-deploy'
+import { SelfHostContent } from './self-host/self-host'
+import { GoTracesContent } from './traces/go/go'
 
 export type QuickStartOptions = {
 	title: string
@@ -280,6 +281,17 @@ export const quickStartContent = {
 			[QuickStartType.HostingVercel]: HostingVercelLogContent,
 			[QuickStartType.HostingFlyIO]: HostingFlyIOLogContent,
 			[QuickStartType.HostingRender]: HostingRenderLogContent,
+		},
+	},
+	traces: {
+		title: 'Select your language',
+		subtitle:
+			'Tracing is supported with the Highlight Go SDK or via the OpenTelemetry protocol (OTLP).',
+		go: {
+			title: 'Go',
+			subtitle: 'Install tracing in your Go application.',
+			logoUrl: siteUrl('/images/quickstart/go.svg'),
+			[QuickStartType.GoOther]: GoTracesContent,
 		},
 	},
 	other: {

--- a/highlight.io/components/QuickstartContent/traces/go/go.tsx
+++ b/highlight.io/components/QuickstartContent/traces/go/go.tsx
@@ -1,0 +1,41 @@
+import { siteUrl } from '../../../../utils/urls'
+import { QuickStartContent } from '../../QuickstartContent'
+import { verifyTraces } from '../shared-snippets'
+
+export const GoTracesContent: QuickStartContent = {
+	title: 'Tracing from a Go App',
+	subtitle:
+		'Learn how to set up highlight.io tracing for your Go application.',
+	logoUrl: siteUrl('/images/quickstart/go.svg'),
+	entries: [
+		{
+			title: 'Wrap your traced code using the Go SDK.',
+			content:
+				'By wrapping your code with `StartTrace` and `EndTrace`, the Highlight Go SDK will record trace duration, parent/child relationships, and service properties.',
+			code: [
+				{
+					text: `import (
+	highlight "github.com/highlight/highlight/sdk/highlight-go"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func functionToTrace(ctx context.Context, input int) {
+	s, childContext := highlight.StartTrace(ctx, "functionToTrace", attribute.Int("custom_property", input))
+	// ...
+	anotherFunction(childContext)
+	// ...
+	highlight.EndTrace(s)
+}
+
+func anotherFunction(ctx context.Context) {
+	s, _ := highlight.StartTrace(ctx, "anotherFunction")
+	// ...
+	highlight.EndTrace(s)
+}`,
+					language: 'go',
+				},
+			],
+		},
+		verifyTraces,
+	],
+}

--- a/highlight.io/components/QuickstartContent/traces/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/traces/shared-snippets.tsx
@@ -1,0 +1,7 @@
+import { QuickStartStep } from '../QuickstartContent'
+
+export const verifyTraces: QuickStartStep = {
+	title: 'Verify your backend traces are being recorded.',
+	content:
+		'Visit the [highlight traces portal](http://app.highlight.io/traces) and check that backend traces are coming in.',
+}


### PR DESCRIPTION
## Summary
- adds logic to private graph / trace ingest to record and query when backend traces are being sent
- add traces quickstart step guarded by `isHighlightAdmin`
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will add guide for OLTP and add to docs page later
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
