### PR TITLE
validate oauth access by graphql field

### DIFF
--- a/backend/private-graph/graph/oauth.go
+++ b/backend/private-graph/graph/oauth.go
@@ -10,7 +10,7 @@ import (
 
 type OAuthValidator interface {
 	graphql.HandlerExtension
-	graphql.OperationInterceptor
+	graphql.FieldInterceptor
 }
 
 type Tracer struct {
@@ -29,8 +29,7 @@ func (t Tracer) Validate(graphql.ExecutableSchema) error {
 	return nil
 }
 
-// InterceptOperation is called for each incoming query
-func (t Tracer) InterceptOperation(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
+func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (interface{}, error) {
 	clientID, _ := ctx.Value(model.ContextKeys.OAuthClientID).(string)
 	if clientID == "" {
 		return next(ctx)
@@ -42,21 +41,18 @@ func (t Tracer) InterceptOperation(ctx context.Context, next graphql.OperationHa
 
 	client, err := t.store.GetOAuth(ctx, clientID)
 	if err != nil {
-		return func(ctx context.Context) *graphql.Response {
-			return graphql.ErrorResponse(ctx, "unauthorized")
-		}
+		return nil, AuthorizationError
 	}
 
-	operation := graphql.GetOperationContext(ctx).OperationName
+	fc := graphql.GetFieldContext(ctx)
+	fieldName := fc.Field.Name
 	// TODO(vkorolik) rate limit based on opConfig
 	_, found := lo.Find(client.Operations, func(item *model.OAuthOperation) bool {
-		return item.AuthorizedGraphQLOperation == operation
+		return item.AuthorizedGraphQLOperation == fieldName
 	})
 
 	if !found {
-		return func(ctx context.Context) *graphql.Response {
-			return graphql.ErrorResponse(ctx, "unauthorized to perform operation %s", operation)
-		}
+		return nil, AuthorizationError
 	}
 
 	return next(ctx)

--- a/scripts/migrations/init.sql
+++ b/scripts/migrations/init.sql
@@ -38,4 +38,8 @@ VALUES (1, '2023-09-26 01:01:33.718911 +00:00', '2023-09-26 01:01:33.718911 +00:
 INSERT INTO o_auth_client_stores (id, created_at, secret, domains, app_name, admin_id)
 VALUES ('abc123', now(), 'def456', '{example.com}', 'Test', 1);
 INSERT INTO o_auth_operations (created_at, client_id, authorized_graph_ql_operation)
-VALUES (now(), 'abc123', 'GetSessionsClickhouse');
+VALUES (now(), 'abc123', 'sessions_clickhouse');
+INSERT INTO o_auth_operations (created_at, client_id, authorized_graph_ql_operation)
+VALUES (now(), 'abc123', 'sessions');
+INSERT INTO o_auth_operations (created_at, client_id, authorized_graph_ql_operation)
+VALUES (now(), 'abc123', 'session');


### PR DESCRIPTION
## Summary

Operation name isn't a good way to validate the request
since it is client-determined.
Instead, changes the OAuth operation validation to use the field name.

## How did you test this change?

Updates e2e test on `test_oauth_graphql.py`

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
