### PR TITLE
query trace errors w/ project id to use index

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7610,7 +7610,7 @@ func (r *queryResolver) Trace(ctx context.Context, projectID int, traceID string
 	var errors = []*modelInputs.TraceError{}
 	err = r.DB.Model(&model.ErrorObject{}).
 		Joins("JOIN error_groups ON error_objects.error_group_id = error_groups.id").
-		Where("error_objects.trace_id = ?", traceID).
+		Where("error_objects.trace_id = ? AND error_objects.project_id = ?", traceID, project.ID).
 		Order("error_objects.timestamp DESC").
 		Select("error_objects.*, error_groups.secure_id as error_group_secure_id").
 		Find(&errors).Error


### PR DESCRIPTION
## Summary
- added an index to query error_objects by project_id + trace_id faster: `create index concurrently idx_error_objects_trace_id on error_objects (project_id, trace_id)`. this change adds project_id to the query so it can use the index.
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested query in prod, ran in <100ms
```
select * from error_objects where trace_id = 'X' and project_id = 1
 ```
- clicktested individual trace view to confirm it was still working
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
