### PR TITLE
add app banner for launch week 3

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -975,8 +975,8 @@ const BillingBanner: React.FC = () => {
 
 	if (!bannerMessage && !hasTrial) {
 		const isLaunchWeek = moment().isBetween(
-			'2023-07-17T00:00:00Z',
-			'2023-07-22T00:00:00Z',
+			'2023-10-16T16:00:00Z', // 10/16/2023 9AM PST
+			'2023-10-21T16:00:00Z',
 		)
 		if (isLaunchWeek) {
 			return <LaunchWeekBanner />
@@ -1080,12 +1080,6 @@ const MaintenanceBanner = () => {
 
 const LaunchWeekBanner = () => {
 	const { toggleShowBanner } = useGlobalContext()
-
-	const day = moment().diff(moment('2023-07-17T16:00:00Z'), 'days') + 1
-	if (day < 1 || day > 5) {
-		toggleShowBanner(false)
-		return null
-	}
 	toggleShowBanner(true)
 
 	const bannerMessage = (
@@ -1093,7 +1087,7 @@ const LaunchWeekBanner = () => {
 			Launch Week 2 is here.{' '}
 			<a
 				target="_blank"
-				href="https://www.highlight.io/launch-week-2"
+				href="https://www.highlight.io/launch/week-3"
 				className={styles.trialLink}
 				rel="noreferrer"
 			>

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1084,7 +1084,7 @@ const LaunchWeekBanner = () => {
 
 	const bannerMessage = (
 		<span>
-			Launch Week 2 is here.{' '}
+			Launch Week 3 is here.{' '}
 			<a
 				target="_blank"
 				href="https://www.highlight.io/launch/week-3"


### PR DESCRIPTION
## Summary
- adds banner for launch week 3, active between 10/16 and 10/21 9am PST
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally and changed start/end dates
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- requires #6868 to be deployed first to add launch week 3 route
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
