### PR TITLE
enforce alert threshold >= 1

### DIFF
--- a/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
+++ b/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
@@ -245,7 +245,8 @@ export const ErrorAlertPage = () => {
 						}
 
 						const nameErr = !input.name
-						const thresholdErr = !input.count_threshold
+						const thresholdErr =
+							!input.count_threshold || input.count_threshold < 1
 						if (nameErr || thresholdErr) {
 							const errs = []
 							if (nameErr) {
@@ -259,7 +260,7 @@ export const ErrorAlertPage = () => {
 							if (thresholdErr) {
 								formStore.setError(
 									formStore.names.threshold,
-									'Threshold is required',
+									'Threshold cannot be less than 1',
 								)
 								errs.push('threshold')
 							}

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -287,7 +287,8 @@ export const LogAlertPage = () => {
 						}
 
 						const nameErr = !input.name
-						const thresholdErr = !input.count_threshold
+						const thresholdErr =
+							!input.count_threshold || input.count_threshold < 1
 						const queryErr = !input.query
 						if (nameErr || thresholdErr || queryErr) {
 							const errs = []
@@ -302,7 +303,7 @@ export const LogAlertPage = () => {
 							if (thresholdErr) {
 								formStore.setError(
 									formStore.names.threshold,
-									'Threshold is required',
+									'Threshold cannot be less than 1',
 								)
 								errs.push('threshold')
 							}

--- a/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
+++ b/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
@@ -299,7 +299,8 @@ export const SessionAlertPage = () => {
 						const nameErr = !input.name
 						const thresholdErr =
 							configuration.canControlThreshold &&
-							!input.count_threshold
+							(!input.count_threshold ||
+								input.count_threshold < 1)
 						if (nameErr || thresholdErr) {
 							const errs = []
 							if (nameErr) {
@@ -313,7 +314,7 @@ export const SessionAlertPage = () => {
 							if (thresholdErr) {
 								formStore.setError(
 									formStore.names.threshold,
-									'Threshold is required',
+									'Threshold cannot be less than 1',
 								)
 								errs.push('threshold')
 							}


### PR DESCRIPTION
## Summary
- fixes #6792 by validating alert thresholds >= 1
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested creating session/log/error alerts
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
