### PR TITLE
show error boundary feedback on error instances

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1189,7 +1189,7 @@ type ComplexityRoot struct {
 		Processed                      func(childComplexity int) int
 		ResourcesURL                   func(childComplexity int) int
 		SecureID                       func(childComplexity int) int
-		SessionComments                func(childComplexity int) int
+		SessionFeedback                func(childComplexity int) int
 		Starred                        func(childComplexity int) int
 		State                          func(childComplexity int) int
 		TimelineIndicatorsURL          func(childComplexity int) int
@@ -1827,7 +1827,7 @@ type SessionResolver interface {
 	TimelineIndicatorsURL(ctx context.Context, obj *model1.Session) (*string, error)
 	DeviceMemory(ctx context.Context, obj *model1.Session) (*int, error)
 
-	SessionComments(ctx context.Context, obj *model1.Session) ([]*model1.SessionComment, error)
+	SessionFeedback(ctx context.Context, obj *model1.Session) ([]*model1.SessionComment, error)
 }
 type SessionAlertResolver interface {
 	ChannelsToNotify(ctx context.Context, obj *model1.SessionAlert) ([]*model.SanitizedSlackChannel, error)
@@ -8713,12 +8713,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Session.SecureID(childComplexity), true
 
-	case "Session.session_comments":
-		if e.complexity.Session.SessionComments == nil {
+	case "Session.session_feedback":
+		if e.complexity.Session.SessionFeedback == nil {
 			break
 		}
 
-		return e.complexity.Session.SessionComments(childComplexity), true
+		return e.complexity.Session.SessionFeedback(childComplexity), true
 
 	case "Session.starred":
 		if e.complexity.Session.Starred == nil {
@@ -10400,7 +10400,7 @@ type Session {
 	deviceMemory: Int
 	last_user_interaction_time: Timestamp!
 	chunked: Boolean
-	session_comments: [SessionComment]
+	session_feedback: [SessionComment!]
 }
 
 type SessionInterval {
@@ -30393,8 +30393,8 @@ func (ec *executionContext) fieldContext_ErrorObject_session(ctx context.Context
 				return ec.fieldContext_Session_last_user_interaction_time(ctx, field)
 			case "chunked":
 				return ec.fieldContext_Session_chunked(ctx, field)
-			case "session_comments":
-				return ec.fieldContext_Session_session_comments(ctx, field)
+			case "session_feedback":
+				return ec.fieldContext_Session_session_feedback(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 		},
@@ -39696,8 +39696,8 @@ func (ec *executionContext) fieldContext_Mutation_markSessionAsViewed(ctx contex
 				return ec.fieldContext_Session_last_user_interaction_time(ctx, field)
 			case "chunked":
 				return ec.fieldContext_Session_chunked(ctx, field)
-			case "session_comments":
-				return ec.fieldContext_Session_session_comments(ctx, field)
+			case "session_feedback":
+				return ec.fieldContext_Session_session_feedback(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 		},
@@ -43307,8 +43307,8 @@ func (ec *executionContext) fieldContext_Mutation_updateSessionIsPublic(ctx cont
 				return ec.fieldContext_Session_last_user_interaction_time(ctx, field)
 			case "chunked":
 				return ec.fieldContext_Session_chunked(ctx, field)
-			case "session_comments":
-				return ec.fieldContext_Session_session_comments(ctx, field)
+			case "session_feedback":
+				return ec.fieldContext_Session_session_feedback(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 		},
@@ -46024,8 +46024,8 @@ func (ec *executionContext) fieldContext_Query_session(ctx context.Context, fiel
 				return ec.fieldContext_Session_last_user_interaction_time(ctx, field)
 			case "chunked":
 				return ec.fieldContext_Session_chunked(ctx, field)
-			case "session_comments":
-				return ec.fieldContext_Session_session_comments(ctx, field)
+			case "session_feedback":
+				return ec.fieldContext_Session_session_feedback(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 		},
@@ -48648,8 +48648,8 @@ func (ec *executionContext) fieldContext_Query_projectHasViewedASession(ctx cont
 				return ec.fieldContext_Session_last_user_interaction_time(ctx, field)
 			case "chunked":
 				return ec.fieldContext_Session_chunked(ctx, field)
-			case "session_comments":
-				return ec.fieldContext_Session_session_comments(ctx, field)
+			case "session_feedback":
+				return ec.fieldContext_Session_session_feedback(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 		},
@@ -61204,8 +61204,8 @@ func (ec *executionContext) fieldContext_Session_chunked(ctx context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _Session_session_comments(ctx context.Context, field graphql.CollectedField, obj *model1.Session) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Session_session_comments(ctx, field)
+func (ec *executionContext) _Session_session_feedback(ctx context.Context, field graphql.CollectedField, obj *model1.Session) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Session_session_feedback(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -61218,7 +61218,7 @@ func (ec *executionContext) _Session_session_comments(ctx context.Context, field
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Session().SessionComments(rctx, obj)
+		return ec.resolvers.Session().SessionFeedback(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -61229,10 +61229,10 @@ func (ec *executionContext) _Session_session_comments(ctx context.Context, field
 	}
 	res := resTmp.([]*model1.SessionComment)
 	fc.Result = res
-	return ec.marshalOSessionComment2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, field.Selections, res)
+	return ec.marshalOSessionComment2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionCommentᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Session_session_comments(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Session_session_feedback(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Session",
 		Field:      field,
@@ -64117,8 +64117,8 @@ func (ec *executionContext) fieldContext_SessionResults_sessions(ctx context.Con
 				return ec.fieldContext_Session_last_user_interaction_time(ctx, field)
 			case "chunked":
 				return ec.fieldContext_Session_chunked(ctx, field)
-			case "session_comments":
-				return ec.fieldContext_Session_session_comments(ctx, field)
+			case "session_feedback":
+				return ec.fieldContext_Session_session_feedback(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 		},
@@ -83955,7 +83955,7 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Values[i] = ec._Session_chunked(ctx, field, obj)
 
-		case "session_comments":
+		case "session_feedback":
 			field := field
 
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
@@ -83964,7 +83964,7 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Session_session_comments(ctx, field, obj)
+				res = ec._Session_session_feedback(ctx, field, obj)
 				return res
 			}
 
@@ -90164,6 +90164,16 @@ func (ec *executionContext) marshalNSessionComment2ᚕᚖgithubᚗcomᚋhighligh
 	return ret
 }
 
+func (ec *executionContext) marshalNSessionComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx context.Context, sel ast.SelectionSet, v *model1.SessionComment) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SessionComment(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNSessionCommentTag2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionCommentTagᚄ(ctx context.Context, sel ast.SelectionSet, v []*model1.SessionCommentTag) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -93298,7 +93308,7 @@ func (ec *executionContext) marshalOSessionComment2githubᚗcomᚋhighlightᚑru
 	return ec._SessionComment(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalOSessionComment2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx context.Context, sel ast.SelectionSet, v []*model1.SessionComment) graphql.Marshaler {
+func (ec *executionContext) marshalOSessionComment2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionCommentᚄ(ctx context.Context, sel ast.SelectionSet, v []*model1.SessionComment) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -93325,7 +93335,7 @@ func (ec *executionContext) marshalOSessionComment2ᚕᚖgithubᚗcomᚋhighligh
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalOSessionComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, sel, v[i])
+			ret[i] = ec.marshalNSessionComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -93335,6 +93345,12 @@ func (ec *executionContext) marshalOSessionComment2ᚕᚖgithubᚗcomᚋhighligh
 
 	}
 	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
 
 	return ret
 }

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1189,6 +1189,7 @@ type ComplexityRoot struct {
 		Processed                      func(childComplexity int) int
 		ResourcesURL                   func(childComplexity int) int
 		SecureID                       func(childComplexity int) int
+		SessionComments                func(childComplexity int) int
 		Starred                        func(childComplexity int) int
 		State                          func(childComplexity int) int
 		TimelineIndicatorsURL          func(childComplexity int) int
@@ -1825,6 +1826,8 @@ type SessionResolver interface {
 	WebSocketEventsURL(ctx context.Context, obj *model1.Session) (*string, error)
 	TimelineIndicatorsURL(ctx context.Context, obj *model1.Session) (*string, error)
 	DeviceMemory(ctx context.Context, obj *model1.Session) (*int, error)
+
+	SessionComments(ctx context.Context, obj *model1.Session) ([]*model1.SessionComment, error)
 }
 type SessionAlertResolver interface {
 	ChannelsToNotify(ctx context.Context, obj *model1.SessionAlert) ([]*model.SanitizedSlackChannel, error)
@@ -8710,6 +8713,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Session.SecureID(childComplexity), true
 
+	case "Session.session_comments":
+		if e.complexity.Session.SessionComments == nil {
+			break
+		}
+
+		return e.complexity.Session.SessionComments(childComplexity), true
+
 	case "Session.starred":
 		if e.complexity.Session.Starred == nil {
 			break
@@ -10390,6 +10400,7 @@ type Session {
 	deviceMemory: Int
 	last_user_interaction_time: Timestamp!
 	chunked: Boolean
+	session_comments: [SessionComment]
 }
 
 type SessionInterval {
@@ -30382,6 +30393,8 @@ func (ec *executionContext) fieldContext_ErrorObject_session(ctx context.Context
 				return ec.fieldContext_Session_last_user_interaction_time(ctx, field)
 			case "chunked":
 				return ec.fieldContext_Session_chunked(ctx, field)
+			case "session_comments":
+				return ec.fieldContext_Session_session_comments(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 		},
@@ -39683,6 +39696,8 @@ func (ec *executionContext) fieldContext_Mutation_markSessionAsViewed(ctx contex
 				return ec.fieldContext_Session_last_user_interaction_time(ctx, field)
 			case "chunked":
 				return ec.fieldContext_Session_chunked(ctx, field)
+			case "session_comments":
+				return ec.fieldContext_Session_session_comments(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 		},
@@ -43292,6 +43307,8 @@ func (ec *executionContext) fieldContext_Mutation_updateSessionIsPublic(ctx cont
 				return ec.fieldContext_Session_last_user_interaction_time(ctx, field)
 			case "chunked":
 				return ec.fieldContext_Session_chunked(ctx, field)
+			case "session_comments":
+				return ec.fieldContext_Session_session_comments(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 		},
@@ -46007,6 +46024,8 @@ func (ec *executionContext) fieldContext_Query_session(ctx context.Context, fiel
 				return ec.fieldContext_Session_last_user_interaction_time(ctx, field)
 			case "chunked":
 				return ec.fieldContext_Session_chunked(ctx, field)
+			case "session_comments":
+				return ec.fieldContext_Session_session_comments(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 		},
@@ -48629,6 +48648,8 @@ func (ec *executionContext) fieldContext_Query_projectHasViewedASession(ctx cont
 				return ec.fieldContext_Session_last_user_interaction_time(ctx, field)
 			case "chunked":
 				return ec.fieldContext_Session_chunked(ctx, field)
+			case "session_comments":
+				return ec.fieldContext_Session_session_comments(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 		},
@@ -61183,6 +61204,81 @@ func (ec *executionContext) fieldContext_Session_chunked(ctx context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _Session_session_comments(ctx context.Context, field graphql.CollectedField, obj *model1.Session) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Session_session_comments(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Session().SessionComments(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model1.SessionComment)
+	fc.Result = res
+	return ec.marshalOSessionComment2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Session_session_comments(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Session",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SessionComment_id(ctx, field)
+			case "project_id":
+				return ec.fieldContext_SessionComment_project_id(ctx, field)
+			case "timestamp":
+				return ec.fieldContext_SessionComment_timestamp(ctx, field)
+			case "created_at":
+				return ec.fieldContext_SessionComment_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_SessionComment_updated_at(ctx, field)
+			case "session_id":
+				return ec.fieldContext_SessionComment_session_id(ctx, field)
+			case "session_secure_id":
+				return ec.fieldContext_SessionComment_session_secure_id(ctx, field)
+			case "author":
+				return ec.fieldContext_SessionComment_author(ctx, field)
+			case "text":
+				return ec.fieldContext_SessionComment_text(ctx, field)
+			case "x_coordinate":
+				return ec.fieldContext_SessionComment_x_coordinate(ctx, field)
+			case "y_coordinate":
+				return ec.fieldContext_SessionComment_y_coordinate(ctx, field)
+			case "type":
+				return ec.fieldContext_SessionComment_type(ctx, field)
+			case "metadata":
+				return ec.fieldContext_SessionComment_metadata(ctx, field)
+			case "tags":
+				return ec.fieldContext_SessionComment_tags(ctx, field)
+			case "attachments":
+				return ec.fieldContext_SessionComment_attachments(ctx, field)
+			case "replies":
+				return ec.fieldContext_SessionComment_replies(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SessionComment", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SessionAlert_id(ctx context.Context, field graphql.CollectedField, obj *model1.SessionAlert) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_SessionAlert_id(ctx, field)
 	if err != nil {
@@ -64021,6 +64117,8 @@ func (ec *executionContext) fieldContext_SessionResults_sessions(ctx context.Con
 				return ec.fieldContext_Session_last_user_interaction_time(ctx, field)
 			case "chunked":
 				return ec.fieldContext_Session_chunked(ctx, field)
+			case "session_comments":
+				return ec.fieldContext_Session_session_comments(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 		},
@@ -83857,6 +83955,23 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Values[i] = ec._Session_chunked(ctx, field, obj)
 
+		case "session_comments":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Session_session_comments(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -93181,6 +93296,47 @@ func (ec *executionContext) marshalOSessionAlert2ᚖgithubᚗcomᚋhighlightᚑr
 
 func (ec *executionContext) marshalOSessionComment2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx context.Context, sel ast.SelectionSet, v model1.SessionComment) graphql.Marshaler {
 	return ec._SessionComment(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOSessionComment2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx context.Context, sel ast.SelectionSet, v []*model1.SessionComment) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOSessionComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
 }
 
 func (ec *executionContext) marshalOSessionComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx context.Context, sel ast.SelectionSet, v *model1.SessionComment) graphql.Marshaler {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -10400,7 +10400,7 @@ type Session {
 	deviceMemory: Int
 	last_user_interaction_time: Timestamp!
 	chunked: Boolean
-	session_comments: [SessionComment]
+	session_comments: [SessionComment]!
 }
 
 type SessionInterval {
@@ -61225,11 +61225,14 @@ func (ec *executionContext) _Session_session_comments(ctx context.Context, field
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]*model1.SessionComment)
 	fc.Result = res
-	return ec.marshalOSessionComment2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, field.Selections, res)
+	return ec.marshalNSessionComment2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Session_session_comments(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -83965,6 +83968,9 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 					}
 				}()
 				res = ec._Session_session_comments(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -93296,47 +93302,6 @@ func (ec *executionContext) marshalOSessionAlert2ᚖgithubᚗcomᚋhighlightᚑr
 
 func (ec *executionContext) marshalOSessionComment2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx context.Context, sel ast.SelectionSet, v model1.SessionComment) graphql.Marshaler {
 	return ec._SessionComment(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalOSessionComment2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx context.Context, sel ast.SelectionSet, v []*model1.SessionComment) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalOSessionComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	return ret
 }
 
 func (ec *executionContext) marshalOSessionComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx context.Context, sel ast.SelectionSet, v *model1.SessionComment) graphql.Marshaler {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -10400,7 +10400,7 @@ type Session {
 	deviceMemory: Int
 	last_user_interaction_time: Timestamp!
 	chunked: Boolean
-	session_comments: [SessionComment]!
+	session_comments: [SessionComment]
 }
 
 type SessionInterval {
@@ -61225,14 +61225,11 @@ func (ec *executionContext) _Session_session_comments(ctx context.Context, field
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.([]*model1.SessionComment)
 	fc.Result = res
-	return ec.marshalNSessionComment2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, field.Selections, res)
+	return ec.marshalOSessionComment2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Session_session_comments(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -83968,9 +83965,6 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 					}
 				}()
 				res = ec._Session_session_comments(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
 				return res
 			}
 
@@ -93302,6 +93296,47 @@ func (ec *executionContext) marshalOSessionAlert2ᚖgithubᚗcomᚋhighlightᚑr
 
 func (ec *executionContext) marshalOSessionComment2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx context.Context, sel ast.SelectionSet, v model1.SessionComment) graphql.Marshaler {
 	return ec._SessionComment(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOSessionComment2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx context.Context, sel ast.SelectionSet, v []*model1.SessionComment) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOSessionComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
 }
 
 func (ec *executionContext) marshalOSessionComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx context.Context, sel ast.SelectionSet, v *model1.SessionComment) graphql.Marshaler {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -81,7 +81,7 @@ type Session {
 	deviceMemory: Int
 	last_user_interaction_time: Timestamp!
 	chunked: Boolean
-	session_comments: [SessionComment]
+	session_comments: [SessionComment]!
 }
 
 type SessionInterval {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -81,6 +81,7 @@ type Session {
 	deviceMemory: Int
 	last_user_interaction_time: Timestamp!
 	chunked: Boolean
+	session_comments: [SessionComment]
 }
 
 type SessionInterval {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -81,7 +81,7 @@ type Session {
 	deviceMemory: Int
 	last_user_interaction_time: Timestamp!
 	chunked: Boolean
-	session_comments: [SessionComment]
+	session_feedback: [SessionComment!]
 }
 
 type SessionInterval {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -81,7 +81,7 @@ type Session {
 	deviceMemory: Int
 	last_user_interaction_time: Timestamp!
 	chunked: Boolean
-	session_comments: [SessionComment]!
+	session_comments: [SessionComment]
 }
 
 type SessionInterval {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3117,7 +3117,7 @@ func (r *mutationResolver) UpdateLogAlert(ctx context.Context, id int, input mod
 
 	if err := r.DB.Model(&model.LogAlert{Model: model.Model{ID: id}}).
 		Where("project_id = ?", input.ProjectID).
-		Save(alert).Error; err != nil {
+		Updates(alert).Error; err != nil {
 		return nil, e.Wrap(err, "error updating log alert")
 	}
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7876,7 +7876,7 @@ func (r *sessionResolver) SessionComments(ctx context.Context, obj *model.Sessio
 	}
 	sessionComments := []*model.SessionComment{}
 
-	if err := r.DB.Preload("Attachments").Preload("Replies").Where(model.SessionComment{SessionId: s.ID, SessionCommentType: SessionCommentType.Feedback}).Order("timestamp asc").Find(&sessionComments).Error; err != nil {
+	if err := r.DB.Preload("Attachments").Preload("Replies").Where(model.SessionComment{SessionId: s.ID}).Order("timestamp asc").Find(&sessionComments).Error; err != nil {
 		return nil, e.Wrap(err, "error querying session comments for session")
 	}
 	return sessionComments, nil

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7864,22 +7864,22 @@ func (r *sessionResolver) DeviceMemory(ctx context.Context, obj *model.Session) 
 	return deviceMemory, nil
 }
 
-// SessionComments is the resolver for the session_comments field.
-func (r *sessionResolver) SessionComments(ctx context.Context, obj *model.Session) ([]*model.SessionComment, error) {
+// SessionFeedback is the resolver for the session_feedback field.
+func (r *sessionResolver) SessionFeedback(ctx context.Context, obj *model.Session) ([]*model.SessionComment, error) {
 	if util.IsDevEnv() && obj.SecureID == "repro" {
-		sessionComments := []*model.SessionComment{}
-		return sessionComments, nil
+		sessionFeedback := []*model.SessionComment{}
+		return sessionFeedback, nil
 	}
 	s, err := r.canAdminViewSession(ctx, obj.SecureID)
 	if err != nil {
 		return nil, err
 	}
-	sessionComments := []*model.SessionComment{}
+	sessionFeedback := []*model.SessionComment{}
 
-	if err := r.DB.Preload("Attachments").Preload("Replies").Where(model.SessionComment{SessionId: s.ID, Type: model.SessionCommentTypes.FEEDBACK}).Order("timestamp asc").Find(&sessionComments).Error; err != nil {
+	if err := r.DB.Where(model.SessionComment{SessionId: s.ID, Type: model.SessionCommentTypes.FEEDBACK}).Order("timestamp asc").Find(&sessionFeedback).Error; err != nil {
 		return nil, e.Wrap(err, "error querying session comments for session")
 	}
-	return sessionComments, nil
+	return sessionFeedback, nil
 }
 
 // ChannelsToNotify is the resolver for the ChannelsToNotify field.

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7864,6 +7864,24 @@ func (r *sessionResolver) DeviceMemory(ctx context.Context, obj *model.Session) 
 	return deviceMemory, nil
 }
 
+// SessionComments is the resolver for the session_comments field.
+func (r *sessionResolver) SessionComments(ctx context.Context, s *model.Session) ([]*model.SessionComment, error) {
+	if util.IsDevEnv() && s.sessionSecureID == "repro" {
+		sessionComments := []*model.SessionComment{}
+		return sessionComments, nil
+	}
+	s, err := r.canAdminViewSession(ctx, sessionSecureID)
+	if err != nil {
+		return nil, err
+	}
+	sessionComments := []*model.SessionComment{}
+
+	if err := r.DB.Preload("Attachments").Preload("Replies").Where(model.SessionComment{SessionId: s.ID}).Order("timestamp asc").Find(&sessionComments).Error; err != nil {
+		return nil, e.Wrap(err, "error querying session comments for session")
+	}
+	return sessionComments, nil
+}
+
 // ChannelsToNotify is the resolver for the ChannelsToNotify field.
 func (r *sessionAlertResolver) ChannelsToNotify(ctx context.Context, obj *model.SessionAlert) ([]*modelInputs.SanitizedSlackChannel, error) {
 	return obj.GetChannelsToNotify()

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -8151,13 +8151,3 @@ type sessionAlertResolver struct{ *Resolver }
 type sessionCommentResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }
 type timelineIndicatorEventResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
-func (r *errorObjectResolver) SessionComments(ctx context.Context, obj *model.ErrorObject) ([]*model.SessionComment, error) {
-	panic(fmt.Errorf("not implemented: SessionComments - session_comments"))
-}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7865,18 +7865,18 @@ func (r *sessionResolver) DeviceMemory(ctx context.Context, obj *model.Session) 
 }
 
 // SessionComments is the resolver for the session_comments field.
-func (r *sessionResolver) SessionComments(ctx context.Context, s *model.Session) ([]*model.SessionComment, error) {
-	if util.IsDevEnv() && s.sessionSecureID == "repro" {
+func (r *sessionResolver) SessionComments(ctx context.Context, obj *model.Session) ([]*model.SessionComment, error) {
+	if util.IsDevEnv() && obj.SecureID == "repro" {
 		sessionComments := []*model.SessionComment{}
 		return sessionComments, nil
 	}
-	s, err := r.canAdminViewSession(ctx, sessionSecureID)
+	s, err := r.canAdminViewSession(ctx, obj.SecureID)
 	if err != nil {
 		return nil, err
 	}
 	sessionComments := []*model.SessionComment{}
 
-	if err := r.DB.Preload("Attachments").Preload("Replies").Where(model.SessionComment{SessionId: s.ID}).Order("timestamp asc").Find(&sessionComments).Error; err != nil {
+	if err := r.DB.Preload("Attachments").Preload("Replies").Where(model.SessionComment{SessionId: s.ID, SessionCommentType: SessionCommentType.Feedback}).Order("timestamp asc").Find(&sessionComments).Error; err != nil {
 		return nil, e.Wrap(err, "error querying session comments for session")
 	}
 	return sessionComments, nil
@@ -8151,3 +8151,13 @@ type sessionAlertResolver struct{ *Resolver }
 type sessionCommentResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }
 type timelineIndicatorEventResolver struct{ *Resolver }
+
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//     it when you're done.
+//   - You have helper methods in this file. Move them out to keep these resolver files clean.
+func (r *errorObjectResolver) SessionComments(ctx context.Context, obj *model.ErrorObject) ([]*model.SessionComment, error) {
+	panic(fmt.Errorf("not implemented: SessionComments - session_comments"))
+}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7876,7 +7876,7 @@ func (r *sessionResolver) SessionComments(ctx context.Context, obj *model.Sessio
 	}
 	sessionComments := []*model.SessionComment{}
 
-	if err := r.DB.Preload("Attachments").Preload("Replies").Where(model.SessionComment{SessionId: s.ID}).Order("timestamp asc").Find(&sessionComments).Error; err != nil {
+	if err := r.DB.Preload("Attachments").Preload("Replies").Where(model.SessionComment{SessionId: s.ID, Type: model.SessionCommentTypes.FEEDBACK}).Order("timestamp asc").Find(&sessionComments).Error; err != nil {
 		return nil, e.Wrap(err, "error querying session comments for session")
 	}
 	return sessionComments, nil

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -121,7 +121,7 @@ export const ErrorObjectFragmentDoc = gql`
 			processed
 			excluded
 			excluded_reason
-			session_comments {
+			session_feedback {
 				id
 				timestamp
 				created_at

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -145,7 +145,6 @@ export const ErrorObjectFragmentDoc = gql`
 				y_coordinate
 				type
 				metadata
-				tags
 			}
 		}
 		error_group_id

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -124,27 +124,10 @@ export const ErrorObjectFragmentDoc = gql`
 			session_comments {
 				id
 				timestamp
-				session_id
-				session_secure_id
 				created_at
 				updated_at
 				project_id
 				text
-				author {
-					id
-					name
-					email
-					photo_url
-				}
-				attachments {
-					integration_type
-					external_id
-					title
-				}
-				x_coordinate
-				y_coordinate
-				type
-				metadata
 			}
 		}
 		error_group_id

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -121,6 +121,32 @@ export const ErrorObjectFragmentDoc = gql`
 			processed
 			excluded
 			excluded_reason
+			session_comments {
+				id
+				timestamp
+				session_id
+				session_secure_id
+				created_at
+				updated_at
+				project_id
+				text
+				author {
+					id
+					name
+					email
+					photo_url
+				}
+				attachments {
+					integration_type
+					external_id
+					title
+				}
+				x_coordinate
+				y_coordinate
+				type
+				metadata
+				tags
+			}
 		}
 		error_group_id
 		error_group_secure_id

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -3051,50 +3051,48 @@ export type ErrorObjectFragment = { __typename?: 'ErrorObject' } & Pick<
 				| 'excluded'
 				| 'excluded_reason'
 			> & {
-					session_comments?: Types.Maybe<
-						Array<
-							Types.Maybe<
-								{ __typename?: 'SessionComment' } & Pick<
-									Types.SessionComment,
-									| 'id'
-									| 'timestamp'
-									| 'session_id'
-									| 'session_secure_id'
-									| 'created_at'
-									| 'updated_at'
-									| 'project_id'
-									| 'text'
-									| 'x_coordinate'
-									| 'y_coordinate'
-									| 'type'
-									| 'metadata'
-									| 'tags'
-								> & {
-										author?: Types.Maybe<
+					session_comments: Array<
+						Types.Maybe<
+							{ __typename?: 'SessionComment' } & Pick<
+								Types.SessionComment,
+								| 'id'
+								| 'timestamp'
+								| 'session_id'
+								| 'session_secure_id'
+								| 'created_at'
+								| 'updated_at'
+								| 'project_id'
+								| 'text'
+								| 'x_coordinate'
+								| 'y_coordinate'
+								| 'type'
+								| 'metadata'
+								| 'tags'
+							> & {
+									author?: Types.Maybe<
+										{
+											__typename?: 'SanitizedAdmin'
+										} & Pick<
+											Types.SanitizedAdmin,
+											| 'id'
+											| 'name'
+											| 'email'
+											| 'photo_url'
+										>
+									>
+									attachments: Array<
+										Types.Maybe<
 											{
-												__typename?: 'SanitizedAdmin'
+												__typename?: 'ExternalAttachment'
 											} & Pick<
-												Types.SanitizedAdmin,
-												| 'id'
-												| 'name'
-												| 'email'
-												| 'photo_url'
+												Types.ExternalAttachment,
+												| 'integration_type'
+												| 'external_id'
+												| 'title'
 											>
 										>
-										attachments: Array<
-											Types.Maybe<
-												{
-													__typename?: 'ExternalAttachment'
-												} & Pick<
-													Types.ExternalAttachment,
-													| 'integration_type'
-													| 'external_id'
-													| 'title'
-												>
-											>
-										>
-									}
-							>
+									>
+								}
 						>
 					>
 				}

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -3058,41 +3058,11 @@ export type ErrorObjectFragment = { __typename?: 'ErrorObject' } & Pick<
 									Types.SessionComment,
 									| 'id'
 									| 'timestamp'
-									| 'session_id'
-									| 'session_secure_id'
 									| 'created_at'
 									| 'updated_at'
 									| 'project_id'
 									| 'text'
-									| 'x_coordinate'
-									| 'y_coordinate'
-									| 'type'
-									| 'metadata'
-								> & {
-										author?: Types.Maybe<
-											{
-												__typename?: 'SanitizedAdmin'
-											} & Pick<
-												Types.SanitizedAdmin,
-												| 'id'
-												| 'name'
-												| 'email'
-												| 'photo_url'
-											>
-										>
-										attachments: Array<
-											Types.Maybe<
-												{
-													__typename?: 'ExternalAttachment'
-												} & Pick<
-													Types.ExternalAttachment,
-													| 'integration_type'
-													| 'external_id'
-													| 'title'
-												>
-											>
-										>
-									}
+								>
 							>
 						>
 					>

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -3050,7 +3050,54 @@ export type ErrorObjectFragment = { __typename?: 'ErrorObject' } & Pick<
 				| 'processed'
 				| 'excluded'
 				| 'excluded_reason'
-			>
+			> & {
+					session_comments?: Types.Maybe<
+						Array<
+							Types.Maybe<
+								{ __typename?: 'SessionComment' } & Pick<
+									Types.SessionComment,
+									| 'id'
+									| 'timestamp'
+									| 'session_id'
+									| 'session_secure_id'
+									| 'created_at'
+									| 'updated_at'
+									| 'project_id'
+									| 'text'
+									| 'x_coordinate'
+									| 'y_coordinate'
+									| 'type'
+									| 'metadata'
+									| 'tags'
+								> & {
+										author?: Types.Maybe<
+											{
+												__typename?: 'SanitizedAdmin'
+											} & Pick<
+												Types.SanitizedAdmin,
+												| 'id'
+												| 'name'
+												| 'email'
+												| 'photo_url'
+											>
+										>
+										attachments: Array<
+											Types.Maybe<
+												{
+													__typename?: 'ExternalAttachment'
+												} & Pick<
+													Types.ExternalAttachment,
+													| 'integration_type'
+													| 'external_id'
+													| 'title'
+												>
+											>
+										>
+									}
+							>
+						>
+					>
+				}
 		>
 		structured_stack_trace: Array<
 			Types.Maybe<

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -3051,18 +3051,16 @@ export type ErrorObjectFragment = { __typename?: 'ErrorObject' } & Pick<
 				| 'excluded'
 				| 'excluded_reason'
 			> & {
-					session_comments?: Types.Maybe<
+					session_feedback?: Types.Maybe<
 						Array<
-							Types.Maybe<
-								{ __typename?: 'SessionComment' } & Pick<
-									Types.SessionComment,
-									| 'id'
-									| 'timestamp'
-									| 'created_at'
-									| 'updated_at'
-									| 'project_id'
-									| 'text'
-								>
+							{ __typename?: 'SessionComment' } & Pick<
+								Types.SessionComment,
+								| 'id'
+								| 'timestamp'
+								| 'created_at'
+								| 'updated_at'
+								| 'project_id'
+								| 'text'
 							>
 						>
 					>

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -3051,48 +3051,49 @@ export type ErrorObjectFragment = { __typename?: 'ErrorObject' } & Pick<
 				| 'excluded'
 				| 'excluded_reason'
 			> & {
-					session_comments: Array<
-						Types.Maybe<
-							{ __typename?: 'SessionComment' } & Pick<
-								Types.SessionComment,
-								| 'id'
-								| 'timestamp'
-								| 'session_id'
-								| 'session_secure_id'
-								| 'created_at'
-								| 'updated_at'
-								| 'project_id'
-								| 'text'
-								| 'x_coordinate'
-								| 'y_coordinate'
-								| 'type'
-								| 'metadata'
-								| 'tags'
-							> & {
-									author?: Types.Maybe<
-										{
-											__typename?: 'SanitizedAdmin'
-										} & Pick<
-											Types.SanitizedAdmin,
-											| 'id'
-											| 'name'
-											| 'email'
-											| 'photo_url'
-										>
-									>
-									attachments: Array<
-										Types.Maybe<
+					session_comments?: Types.Maybe<
+						Array<
+							Types.Maybe<
+								{ __typename?: 'SessionComment' } & Pick<
+									Types.SessionComment,
+									| 'id'
+									| 'timestamp'
+									| 'session_id'
+									| 'session_secure_id'
+									| 'created_at'
+									| 'updated_at'
+									| 'project_id'
+									| 'text'
+									| 'x_coordinate'
+									| 'y_coordinate'
+									| 'type'
+									| 'metadata'
+								> & {
+										author?: Types.Maybe<
 											{
-												__typename?: 'ExternalAttachment'
+												__typename?: 'SanitizedAdmin'
 											} & Pick<
-												Types.ExternalAttachment,
-												| 'integration_type'
-												| 'external_id'
-												| 'title'
+												Types.SanitizedAdmin,
+												| 'id'
+												| 'name'
+												| 'email'
+												| 'photo_url'
 											>
 										>
-									>
-								}
+										attachments: Array<
+											Types.Maybe<
+												{
+													__typename?: 'ExternalAttachment'
+												} & Pick<
+													Types.ExternalAttachment,
+													| 'integration_type'
+													| 'external_id'
+													| 'title'
+												>
+											>
+										>
+									}
+							>
 						>
 					>
 				}

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2848,6 +2848,7 @@ export type Session = {
 	processed?: Maybe<Scalars['Boolean']>
 	resources_url?: Maybe<Scalars['String']>
 	secure_id: Scalars['String']
+	session_comments?: Maybe<Array<Maybe<SessionComment>>>
 	starred?: Maybe<Scalars['Boolean']>
 	state: Scalars['String']
 	timeline_indicators_url?: Maybe<Scalars['String']>

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2848,7 +2848,7 @@ export type Session = {
 	processed?: Maybe<Scalars['Boolean']>
 	resources_url?: Maybe<Scalars['String']>
 	secure_id: Scalars['String']
-	session_comments?: Maybe<Array<Maybe<SessionComment>>>
+	session_feedback?: Maybe<Array<SessionComment>>
 	starred?: Maybe<Scalars['Boolean']>
 	state: Scalars['String']
 	timeline_indicators_url?: Maybe<Scalars['String']>

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2848,7 +2848,7 @@ export type Session = {
 	processed?: Maybe<Scalars['Boolean']>
 	resources_url?: Maybe<Scalars['String']>
 	secure_id: Scalars['String']
-	session_comments?: Maybe<Array<Maybe<SessionComment>>>
+	session_comments: Array<Maybe<SessionComment>>
 	starred?: Maybe<Scalars['Boolean']>
 	state: Scalars['String']
 	timeline_indicators_url?: Maybe<Scalars['String']>

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2848,7 +2848,7 @@ export type Session = {
 	processed?: Maybe<Scalars['Boolean']>
 	resources_url?: Maybe<Scalars['String']>
 	secure_id: Scalars['String']
-	session_comments: Array<Maybe<SessionComment>>
+	session_comments?: Maybe<Array<Maybe<SessionComment>>>
 	starred?: Maybe<Scalars['Boolean']>
 	state: Scalars['String']
 	timeline_indicators_url?: Maybe<Scalars['String']>

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1153,7 +1153,6 @@ fragment ErrorObject on ErrorObject {
 			y_coordinate
 			type
 			metadata
-			tags
 		}
 	}
 	error_group_id

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1129,7 +1129,7 @@ fragment ErrorObject on ErrorObject {
 		processed
 		excluded
 		excluded_reason
-		session_comments {
+		session_feedback {
 			id
 			timestamp
 			created_at

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1129,6 +1129,32 @@ fragment ErrorObject on ErrorObject {
 		processed
 		excluded
 		excluded_reason
+		session_comments {
+			id
+			timestamp
+			session_id
+			session_secure_id
+			created_at
+			updated_at
+			project_id
+			text
+			author {
+				id
+				name
+				email
+				photo_url
+			}
+			attachments {
+				integration_type
+				external_id
+				title
+			}
+			x_coordinate
+			y_coordinate
+			type
+			metadata
+			tags
+		}
 	}
 	error_group_id
 	error_group_secure_id

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1132,27 +1132,10 @@ fragment ErrorObject on ErrorObject {
 		session_comments {
 			id
 			timestamp
-			session_id
-			session_secure_id
 			created_at
 			updated_at
 			project_id
 			text
-			author {
-				id
-				name
-				email
-				photo_url
-			}
-			attachments {
-				integration_type
-				external_id
-				title
-			}
-			x_coordinate
-			y_coordinate
-			type
-			metadata
 		}
 	}
 	error_group_id

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -348,6 +348,7 @@ export const LogAlertPage = () => {
 							})
 								.then(() => {
 									message.success(`Log alert ${createStr}d!`)
+									navigate(`/${project_id}/alerts`)
 								})
 								.catch(() => {
 									message.error(

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback.tsx
@@ -56,24 +56,35 @@ const SessionComment = ({
 		</Link>
 	)
 	const timeAgo = moment(sessionComment.created_at).fromNow()
+	const feebackNumber = index + 1
+	const feedbackNumberPrefix = feebackNumber < 10 ? '0' : ''
+	const formattedFeedbackNumber = `#${feedbackNumberPrefix}${feebackNumber}`
+
 	return (
 		<Box
-			bt={index !== 0 ? 'secondary' : undefined}
-			pb="8"
+			bt="secondary"
+			backgroundColor="nested"
+			pt="8"
+			pb="12"
+			px="12"
 			display="flex"
 			justifyContent="center"
 			flexDirection="column"
 		>
 			<Box
-				py="4"
+				pb="4"
 				alignItems="center"
 				display="flex"
 				justifyContent="space-between"
-				gap="4"
 			>
-				<Box alignItems="flex-start" display="flex" gap="8">
+				<Box
+					alignItems="flex-start"
+					display="flex"
+					gap="6"
+					flexGrow={1}
+				>
 					<Text lines="1" color="weak" size="small">
-						Feedback #{index + 1}
+						Feedback {formattedFeedbackNumber}
 					</Text>
 					<Text
 						size="small"
@@ -88,7 +99,7 @@ const SessionComment = ({
 					{tag}
 				</Box>
 			</Box>
-			<Text lines="1" align="left" size="xSmall">
+			<Text lines="1" align="left" size="small">
 				{sessionComment.text}
 			</Text>
 		</Box>
@@ -116,11 +127,7 @@ export const ErrorBoundaryFeedback = ({ data: errorObject }: Props) => {
 					/>
 				),
 		)
-		return (
-			<Box px="12" bb="secondary" bt="secondary">
-				{comments}
-			</Box>
-		)
+		return <>{comments}</>
 	}
 	return null
 }

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback.tsx
@@ -1,9 +1,9 @@
 import { Box, IconSolidArrowCircleRight, Tag, Text } from '@highlight-run/ui'
 import { buildQueryURLString } from '@util/url/params'
 import moment from 'moment'
+import { useNavigate } from 'react-router-dom'
 
 import { useAuthContext } from '@/authentication/AuthContext'
-import { Link } from '@/components/Link'
 import { ErrorObjectFragment } from '@/graph/generated/operations'
 import { SessionComment } from '@/graph/generated/schemas'
 import { PlayerSearchParameters } from '@/pages/Player/PlayerHook/utils'
@@ -40,20 +40,19 @@ const SessionComment = ({
 	index,
 }: SessionCommentProps) => {
 	const sessionLink = getSessionLink(errorObject)
-
+	const navigate = useNavigate()
 	const tag = (
-		<Link to={sessionLink}>
-			<Tag
-				kind="secondary"
-				emphasis="low"
-				size="medium"
-				shape="basic"
-				disabled={!isLoggedIn || sessionLink === ''}
-				iconRight={<IconSolidArrowCircleRight />}
-			>
-				Go to
-			</Tag>
-		</Link>
+		<Tag
+			kind="secondary"
+			emphasis="low"
+			size="medium"
+			shape="basic"
+			disabled={!isLoggedIn || sessionLink === ''}
+			iconRight={<IconSolidArrowCircleRight />}
+			onClick={() => navigate(sessionLink)}
+		>
+			Go to
+		</Tag>
 	)
 	const timeAgo = moment(sessionComment.created_at).fromNow()
 	const feebackNumber = index + 1
@@ -70,19 +69,11 @@ const SessionComment = ({
 			display="flex"
 			justifyContent="center"
 			flexDirection="column"
+			borderBottomLeftRadius="6"
+			borderBottomRightRadius="6"
 		>
-			<Box
-				pb="4"
-				alignItems="center"
-				display="flex"
-				justifyContent="space-between"
-			>
-				<Box
-					alignItems="flex-start"
-					display="flex"
-					gap="6"
-					flexGrow={1}
-				>
+			<Box pb="4" display="flex" justifyContent="space-between">
+				<Box alignItems="center" display="flex" gap="6" flexGrow={1}>
 					<Text lines="1" color="weak" size="small">
 						Feedback {formattedFeedbackNumber}
 					</Text>
@@ -95,9 +86,7 @@ const SessionComment = ({
 					</Text>
 				</Box>
 
-				<Box flexShrink={0} display="flex">
-					{tag}
-				</Box>
+				{tag}
 			</Box>
 			<Text lines="1" align="left" size="small" color="default">
 				{sessionComment.text}

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback.tsx
@@ -60,38 +60,45 @@ const SessionComment = ({
 	const formattedFeedbackNumber = `#${feedbackNumberPrefix}${feebackNumber}`
 
 	return (
-		<Box
-			bt="secondary"
-			backgroundColor="nested"
-			pt="8"
-			pb="12"
-			px="12"
-			display="flex"
-			justifyContent="center"
-			flexDirection="column"
-			borderBottomLeftRadius="6"
-			borderBottomRightRadius="6"
-		>
-			<Box pb="4" display="flex" justifyContent="space-between">
-				<Box alignItems="center" display="flex" gap="6" flexGrow={1}>
-					<Text lines="1" color="weak" size="small">
-						Feedback {formattedFeedbackNumber}
-					</Text>
-					<Text
-						size="small"
-						color="secondaryContentOnDisabled"
-						lines="1"
+		<>
+			{index !== 0 && <Box borderTop="dividerWeak" mx="12" />}
+			<Box
+				backgroundColor="nested"
+				pt="8"
+				pb="12"
+				px="12"
+				display="flex"
+				justifyContent="center"
+				flexDirection="column"
+				borderBottomLeftRadius="6"
+				borderBottomRightRadius="6"
+			>
+				<Box pb="4" display="flex" justifyContent="space-between">
+					<Box
+						alignItems="center"
+						display="flex"
+						gap="6"
+						flexGrow={1}
 					>
-						{timeAgo}
-					</Text>
-				</Box>
+						<Text lines="1" color="weak" size="small">
+							Feedback {formattedFeedbackNumber}
+						</Text>
+						<Text
+							size="small"
+							color="secondaryContentOnDisabled"
+							lines="1"
+						>
+							{timeAgo}
+						</Text>
+					</Box>
 
-				{tag}
+					{tag}
+				</Box>
+				<Text lines="1" align="left" size="small" color="default">
+					{sessionComment.text}
+				</Text>
 			</Box>
-			<Text lines="1" align="left" size="small" color="default">
-				{sessionComment.text}
-			</Text>
-		</Box>
+		</>
 	)
 }
 
@@ -116,7 +123,7 @@ export const ErrorBoundaryFeedback = ({ data: errorObject }: Props) => {
 					/>
 				),
 		)
-		return <>{comments}</>
+		return <Box bt="secondary">{comments}</Box>
 	}
 	return null
 }

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback.tsx
@@ -99,7 +99,7 @@ const SessionComment = ({
 					{tag}
 				</Box>
 			</Box>
-			<Text lines="1" align="left" size="small">
+			<Text lines="1" align="left" size="small" color="default">
 				{sessionComment.text}
 			</Text>
 		</Box>

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback.tsx
@@ -1,0 +1,126 @@
+import { Box, IconSolidArrowCircleRight, Tag, Text } from '@highlight-run/ui'
+import { buildQueryURLString } from '@util/url/params'
+import moment from 'moment'
+
+import { useAuthContext } from '@/authentication/AuthContext'
+import { Link } from '@/components/Link'
+import { ErrorObjectFragment } from '@/graph/generated/operations'
+import { SessionComment } from '@/graph/generated/schemas'
+import { PlayerSearchParameters } from '@/pages/Player/PlayerHook/utils'
+
+type Props = {
+	data: ErrorObjectFragment
+}
+
+type SessionCommentProps = {
+	sessionComment: Partial<Omit<SessionComment, 'attachments'>>
+	isLoggedIn: boolean
+	errorObject: ErrorObjectFragment
+	index: number
+}
+
+const getSessionLink = (
+	errorObject: ErrorObjectFragment | undefined,
+): string => {
+	if (!errorObject?.session) {
+		return ''
+	}
+
+	const params = buildQueryURLString({
+		tsAbs: errorObject.timestamp,
+		[PlayerSearchParameters.errorId]: errorObject.id,
+	})
+	return `/${errorObject.project_id}/sessions/${errorObject.session?.secure_id}?${params}`
+}
+
+const SessionComment = ({
+	sessionComment,
+	isLoggedIn,
+	errorObject,
+	index,
+}: SessionCommentProps) => {
+	const sessionLink = getSessionLink(errorObject)
+
+	const tag = (
+		<Link to={sessionLink}>
+			<Tag
+				kind="secondary"
+				emphasis="low"
+				size="medium"
+				shape="basic"
+				disabled={!isLoggedIn || sessionLink === ''}
+				iconRight={<IconSolidArrowCircleRight />}
+			>
+				Go to
+			</Tag>
+		</Link>
+	)
+	const timeAgo = moment(sessionComment.created_at).fromNow()
+	return (
+		<Box
+			bt={index !== 0 ? 'secondary' : undefined}
+			pb="8"
+			display="flex"
+			justifyContent="center"
+			flexDirection="column"
+		>
+			<Box
+				py="4"
+				alignItems="center"
+				display="flex"
+				justifyContent="space-between"
+				gap="4"
+			>
+				<Box alignItems="flex-start" display="flex" gap="8">
+					<Text lines="1" color="weak" size="small">
+						Feedback #{index + 1}
+					</Text>
+					<Text
+						size="small"
+						color="secondaryContentOnDisabled"
+						lines="1"
+					>
+						{timeAgo}
+					</Text>
+				</Box>
+
+				<Box flexShrink={0} display="flex">
+					{tag}
+				</Box>
+			</Box>
+			<Text lines="1" align="left" size="xSmall">
+				{sessionComment.text}
+			</Text>
+		</Box>
+	)
+}
+
+export const ErrorBoundaryFeedback = ({ data: errorObject }: Props) => {
+	const { isLoggedIn } = useAuthContext()
+	const { session } = errorObject
+
+	if (session) {
+		const { session_comments = [] } = session
+		if (!session_comments?.length) {
+			return null
+		}
+		const comments = session_comments.map(
+			(sessionComment, index) =>
+				sessionComment && (
+					<SessionComment
+						key={sessionComment.id}
+						isLoggedIn={isLoggedIn}
+						sessionComment={sessionComment}
+						errorObject={errorObject}
+						index={index}
+					/>
+				),
+		)
+		return (
+			<Box px="12" bb="secondary" bt="secondary">
+				{comments}
+			</Box>
+		)
+	}
+	return null
+}

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback.tsx
@@ -33,7 +33,7 @@ const getSessionLink = (
 	return `/${errorObject.project_id}/sessions/${errorObject.session?.secure_id}?${params}`
 }
 
-const SessionComment = ({
+const SessionFeedback = ({
 	sessionComment,
 	isLoggedIn,
 	errorObject,
@@ -107,22 +107,19 @@ export const ErrorBoundaryFeedback = ({ data: errorObject }: Props) => {
 	const { session } = errorObject
 
 	if (session) {
-		const { session_comments = [] } = session
-		if (!session_comments?.length) {
+		const { session_feedback = [] } = session
+		if (!session_feedback?.length) {
 			return null
 		}
-		const comments = session_comments.map(
-			(sessionComment, index) =>
-				sessionComment && (
-					<SessionComment
-						key={sessionComment.id}
-						isLoggedIn={isLoggedIn}
-						sessionComment={sessionComment}
-						errorObject={errorObject}
-						index={index}
-					/>
-				),
-		)
+		const comments = session_feedback.map((sessionComment, index) => (
+			<SessionFeedback
+				key={sessionComment.id}
+				isLoggedIn={isLoggedIn}
+				sessionComment={sessionComment}
+				errorObject={errorObject}
+				index={index}
+			/>
+		))
 		return <Box bt="secondary">{comments}</Box>
 	}
 	return null

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -45,6 +45,7 @@ import { useNavigate } from 'react-router-dom'
 import { useGetWorkspaceSettingsQuery } from '@/graph/generated/hooks'
 import ErrorBodyText from '@/pages/ErrorsV2/ErrorBody/components/ErrorBodyText'
 import { AiErrorSuggestion } from '@/pages/ErrorsV2/ErrorInstance/AiErrorSuggestion'
+import { ErrorBoundaryFeedback } from '@/pages/ErrorsV2/ErrorInstance/ErrorBoundaryFeedback'
 import { ErrorSessionMissingOrExcluded } from '@/pages/ErrorsV2/ErrorInstance/ErrorSessionMissingOrExcluded'
 import { PreviousNextInstance } from '@/pages/ErrorsV2/ErrorInstance/PreviousNextInstance'
 import { RelatedLogs } from '@/pages/ErrorsV2/ErrorInstance/RelatedLogs'
@@ -571,6 +572,7 @@ const User: React.FC<{
 						)}
 					</Box>
 				</Box>
+				<ErrorBoundaryFeedback data={errorObject} />
 			</Box>
 		</Box>
 	)

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -572,7 +572,7 @@ const User: React.FC<{
 						)}
 					</Box>
 				</Box>
-				<ErrorBoundaryFeedback data={errorObject} />
+				{errorObject && <ErrorBoundaryFeedback data={errorObject} />}
 			</Box>
 		</Box>
 	)

--- a/frontend/src/pages/Sessions/SessionsFeedV3/MinimalSessionCard/utils/utils.ts
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/MinimalSessionCard/utils/utils.ts
@@ -2,8 +2,13 @@ import { Maybe, Session } from '@graph/schemas'
 import { H } from 'highlight.run'
 import validator from 'validator'
 
+type SessionWithIdentityInformation = Pick<
+	Session,
+	'user_properties' | 'identifier' | 'fingerprint'
+>
+
 export const getIdentifiedUserProfileImage = (
-	session?: Maybe<Partial<Session>>,
+	session?: Maybe<SessionWithIdentityInformation>,
 ): string | undefined => {
 	if (!session || !session.user_properties) {
 		return undefined
@@ -37,7 +42,7 @@ export const getUserProperties = (
 
 // Fallback logic for the display name shown for the session card
 export const getDisplayNameAndField = (
-	session?: Maybe<Partial<Session>>,
+	session?: Maybe<SessionWithIdentityInformation>,
 ): [string, string | null] => {
 	const userProperties = getUserProperties(session?.user_properties)
 
@@ -55,6 +60,8 @@ export const getDisplayNameAndField = (
 }
 
 // Fallback logic for the display name shown for the session card
-export const getDisplayName = (session?: Maybe<Partial<Session>>): string => {
+export const getDisplayName = (
+	session?: Maybe<SessionWithIdentityInformation>,
+): string => {
 	return getDisplayNameAndField(session)[0]
 }


### PR DESCRIPTION
## Summary
Adds support for querying session comments on the error_instance
Shows error boundary session comment feedback on UI as [per design](https://www.figma.com/file/rdBPNzn7Klk6RG1LHUCE5B/Screen-Designs?node-id=11613%3A575444&mode=dev)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
I made a page crush and the error boundary feedback component was shown
I filled the form and submitted
On the error instance, I checked to make sure the feedback is shows
And the link on the feedback component takes me to the related session
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
No
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
Yes
<!--
 Request review from julian-highlight / our design team 
-->

## LOOM VIDEO
This shows the feedback on the error instance under user details
Also demonstrates the link to related session
https://www.loom.com/share/b357e312b57d4b5cb362ec4c816d029e?sid=1fd0eac7-b127-4030-9f25-0da9597f4eaf

### SCREENSHOT
<img width="1007" alt="Screenshot 2023-10-17 at 2 30 37 PM" src="https://github.com/highlight/highlight/assets/119384208/dce51176-018e-4bb0-934d-24983d396f02">

/claim #6642
fixes #6642
