### PR TITLE
fix lack of redirection on login

### DIFF
--- a/frontend/src/pages/Auth/SignInRedirect.tsx
+++ b/frontend/src/pages/Auth/SignInRedirect.tsx
@@ -6,9 +6,10 @@ import { authRedirect } from '@/pages/Auth/utils'
 export const SignInRedirect: React.FC = () => {
 	if (!authRedirect.get()) {
 		// Store the original path so we can redirect back to it later.
-		authRedirect.set(
-			window.location.href.replace(window.location.origin, ''),
-		)
+		const dest = window.location.href.replace(window.location.origin, '')
+		if (dest !== '/') {
+			authRedirect.set(dest)
+		}
 	}
 
 	return <Navigate to={SIGN_IN_ROUTE} replace />

--- a/frontend/src/routers/ProjectRouter/ProjectRedirectionRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ProjectRedirectionRouter.tsx
@@ -36,7 +36,7 @@ export const ProjectRedirectionRouter = () => {
 	}
 
 	let redirectTo
-	if (authRedirectRoute) {
+	if (authRedirectRoute && authRedirectRoute !== '/') {
 		redirectTo = authRedirectRoute
 	} else if (data?.projects?.length) {
 		redirectTo = `/${data!.projects[0]!.id}${location.pathname}`


### PR DESCRIPTION
## Summary

Visiting `app.highlight.io` on a new incognito tab and logging in to a
existing account would cause a redirection back to `/` rather than to the default project,
resulting in a blank screen.

## How did you test this change?

Broken in production if you visit https://app.highlight.io and sign in.
Tested by visiting [reflame](https://preview.highlight.io?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HCZ6H069VV7ZSXGCDBDXTMM9%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Ffix-redirection%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D) in incognito and signing in.

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No