### PR TITLE
Remove unnecessary privacy doc

### DIFF
--- a/docs-content/general/6_product-features/1_session-replay/1_overview.md
+++ b/docs-content/general/6_product-features/1_session-replay/1_overview.md
@@ -51,7 +51,7 @@ Read more about the features we support in Session Replay below:
     <DocsCard title="Performance Impact."  href="./performance-impact.md">
         {"The performance impact of the highlight.io snippet."}
     </DocsCard>
-    <DocsCard title="Privacy & Redaction."  href="./privacy.md">
+    <DocsCard title="Privacy & Redaction."  href="../../../getting-started/3_client-sdk/7_replay-configuration/privacy.md">
         {"Options to redact specific data being recorded in your frontend."}
     </DocsCard>
     <DocsCard title="Rage Clicks."  href="./rage-clicks.md">

--- a/docs-content/general/6_product-features/1_session-replay/privacy.md
+++ b/docs-content/general/6_product-features/1_session-replay/privacy.md
@@ -1,8 +1,0 @@
----
-title: Privacy
-slug: privacy
-createdAt: 2021-09-14T17:47:33.000Z
-updatedAt: 2022-08-03T23:29:08.000Z
----
-
-Due to the nature of Highlight's core product, we keep privacy a top priority. [highlight.io](https://highlight.io) has the necessary [compliance measures](../../4_company/compliance-and-security.md) in place to support your business and beyond that, we've built several ways to redact/mask certain DOM elements while still preserving the structure of your DOM recording. It is important to note that for all of our solutions, all data is sanitized on the client, so sensitive data never reaches our servers/platform. Read more about configuring privacy settings in our [SDK Configuration](../../../getting-started/3_client-sdk/7_replay-configuration/1_overview.md) section.

--- a/docs-content/sdk/client.md
+++ b/docs-content/sdk/client.md
@@ -77,7 +77,7 @@ slug: client
           1. 'strict' - Redact all text and images on the page. This is the safest way to ensure you are not recording any personally identifiable information without having to manually add annotations to elements you don't want to be recorded.
           2. 'default' - Highlight will redact any text or input data that matches common regex expressions and input names of personally identifiable information. No images or media will be redacted.
           3. 'none' - All text and content will be recorded as it is displayed on the page.  
-          See [Privacy](../general/6_product-features/1_session-replay/privacy.md) to learn more about the privacy options. The default value is 'default'.</p>
+          See [Privacy](../getting-started/3_client-sdk/7_replay-configuration/privacy.md) to learn more about the privacy options. The default value is 'default'.</p>
         </aside>
         <aside className="parameter">
           <h5>integrations <code>IntegrationOptions</code> <code>optional</code></h5>


### PR DESCRIPTION
## Summary

Removes an unnecessary privacy doc here: https://www.highlight.io/docs/general/product-features/session-replay/privacy.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

Click test.

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
no

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
no
<!--
 Request review from julian-highlight / our design team 
-->
