### PR TITLE
Spenny/add regex expression documentation

### DIFF
--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/privacy.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/privacy.md
@@ -44,12 +44,12 @@ By default, Highlight will obfuscate any text or input data that matches commonl
 Here are a list of the regex expressions used in default privacy mode:
 ```
 Email: "[a-zA-Z0-9.!#$%&'*+=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:.[a-zA-Z0-9-]+)*"
-SSNs: '[0-9]{3}-?[0-9]{2}-?[0-9]{4}'
-Phone numbers: '[+]?[(]?[0-9]{3}[)]?[-s.]?[0-9]{3}[-s.]?[0-9]{4,6}'
-Credit cards: '[0-9]{4}-?[0-9]{4}-?[0-9]{4}-?[0-9]{4}'
-Unformatted SSN, phone number, credit cards: '[0-9]{9,16}'
-Addresses: '[0-9]{1,5}.?[0-9]{0,3}s[a-zA-Z]{2,30}s[a-zA-Z]{2,15}'
-IP addresses: '(?:[0-9]{1,3}.){3}[0-9]{1,3}'
+SSN: '[0-9]{3}-?[0-9]{2}-?[0-9]{4}'
+Phone number: '[+]?[(]?[0-9]{3}[)]?[-s.]?[0-9]{3}[-s.]?[0-9]{4,6}'
+Credit card: '[0-9]{4}-?[0-9]{4}-?[0-9]{4}-?[0-9]{4}'
+Unformatted SSN, phone number, credit card: '[0-9]{9,16}'
+Address: '[0-9]{1,5}.?[0-9]{0,3}s[a-zA-Z]{2,30}s[a-zA-Z]{2,15}'
+IP address: '(?:[0-9]{1,3}.){3}[0-9]{1,3}'
 ```
 
 ## Strict Privacy Mode

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/privacy.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/privacy.md
@@ -41,6 +41,8 @@ For sensitive input fields that your team would like to ignore user input for, y
 
 By default, Highlight will obfuscate any text or input data that matches commonly used Regex expressions and input names of personally identifiable information. This offers a base level protection from recording info such as addresses, phone numbers, social security numbers, and more. It will not obfuscate any images or media content. It is possible that other, non PII text is obfuscated if it matches the expressions for larger number, or contact information on the site. If you want to turn this off, you can set `privacySetting` to `none` when calling [`H.init()`](../../../sdk/client.md#Hinit).
 
+Note: This mode is only available in SDK versions 8.0.0 and later.
+
 Here are a list of the regex expressions used in default privacy mode:
 ```
 Email: "[a-zA-Z0-9.!#$%&'*+=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:.[a-zA-Z0-9-]+)*"

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/privacy.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/privacy.md
@@ -43,7 +43,7 @@ By default, Highlight will obfuscate any text or input data that matches commonl
 
 Note: This mode is only available in SDK versions 8.0.0 and later.
 
-Here are a list of the regex expressions used in default privacy mode:
+Here are a list of the [regex expressions used in default privacy mode](https://github.com/highlight/rrweb/blob/e6a375a554dac9de984a18bfb8ba6e3beb4bd961/packages/rrweb-snapshot/src/utils.ts#L267-L295):
 ```
 Email: "[a-zA-Z0-9.!#$%&'*+=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:.[a-zA-Z0-9-]+)*"
 SSN: '[0-9]{3}-?[0-9]{2}-?[0-9]{4}'

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/privacy.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/privacy.md
@@ -39,7 +39,18 @@ For sensitive input fields that your team would like to ignore user input for, y
 
 ## Default Privacy Mode
 
-By default, Highlight will obfuscate any text or input data that matches commonly used Regex expressions and input names of personally identifiable information. This offers a base level protection from recording info such as addresses, phone numbers, social security numbers, and more. It will not obfuscate any images or media content. It is possible that other, non PII text is obfuscated if it matches the expressions for larger number, or contact information on the site. If you want to turn this off, you can set `privacySetting` to `none` when calling [`H.init()`](../../../sdk/client.md#Hinit). 
+By default, Highlight will obfuscate any text or input data that matches commonly used Regex expressions and input names of personally identifiable information. This offers a base level protection from recording info such as addresses, phone numbers, social security numbers, and more. It will not obfuscate any images or media content. It is possible that other, non PII text is obfuscated if it matches the expressions for larger number, or contact information on the site. If you want to turn this off, you can set `privacySetting` to `none` when calling [`H.init()`](../../../sdk/client.md#Hinit).
+
+Here are a list of the regex expressions used in default privacy mode:
+```
+Email: "[a-zA-Z0-9.!#$%&'*+=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:.[a-zA-Z0-9-]+)*"
+SSNs: '[0-9]{3}-?[0-9]{2}-?[0-9]{4}'
+Phone numbers: '[+]?[(]?[0-9]{3}[)]?[-s.]?[0-9]{3}[-s.]?[0-9]{4,6}'
+Credit cards: '[0-9]{4}-?[0-9]{4}-?[0-9]{4}-?[0-9]{4}'
+Unformatted SSN, phone number, credit cards: '[0-9]{9,16}'
+Addresses: '[0-9]{1,5}.?[0-9]{0,3}s[a-zA-Z]{2,30}s[a-zA-Z]{2,15}'
+IP addresses: '(?:[0-9]{1,3}.){3}[0-9]{1,3}'
+```
 
 ## Strict Privacy Mode
 


### PR DESCRIPTION
## Summary
Add regex expressions to replay configuration's privacy documentation

![Screenshot 2023-10-18 at 1 51 08 PM](https://github.com/highlight/highlight/assets/17744174/9c786956-3229-4177-a8e6-9f95cbe7ef50)

## How did you test this change?
1) View the `/docs/getting-started/client-sdk/replay-configuration/privacy` in the Vercel environment

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A