### PR TITLE
Allow users to pass in sanitize method for XHR/fetch requests

### DIFF
--- a/.changeset/old-waves-deny.md
+++ b/.changeset/old-waves-deny.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+Adds support for `requestResponseSanitizer` to allow users to modify data from the request/response headers and body, as well as prevent the entire request/response from being logged.

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/recording-network-requests-and-responses.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/recording-network-requests-and-responses.md
@@ -2,7 +2,7 @@
 title: Recording Network Requests and Responses
 slug: recording-network-requests-and-responses
 createdAt: 2021-09-14T00:14:21.000Z
-updatedAt: 2022-03-07T22:43:17.000Z
+updatedAt: 2023-10-25T15:40:08.873Z
 ---
 
 Highlight out of the box shows you all the network requests durations, response codes, and sizes for a session. If you'd like more data such as the headers and bodies, you can enable recording of network requests and responses by setting `networkRecording.recordHeadersAndBody` (see [NetworkRecordingOptions](../../../sdk/client.md#Hinit)) to `true` when initializing Highlight.
@@ -59,6 +59,38 @@ If you are dealing with sensitive data or want to go the allowlist approach then
 You can also redact specific headers by using `networkRecording.networkHeadersToRedact` and redact specific keys in the request/response body with `networkRecoding.networkBodyKeysToRedact`.
 
 This configuration is only available for `highlight.run` versions newer than `4.1.0`.
+
+## Custom Sanitizing of Response and Requests
+
+If you need more granular control over managing and ignoring data in request and responses, then you can create a sanitize function to process every recorded request/response pair. This is configured by using the `networkRecording.requestResponseSanitizer` option.
+
+The `networkRecording.requestResponseSanitizer` method receives a RequestResponsePair, and should return an object of the same type or a `null` value. Returning a `null` value means that Highlight will drop the request, and no related network logs will be seen in the session replay.
+
+Dropping logs is not recommended unless necessary, as it can cause issues with debugging due to the missing requests. Rather, it is recommended to delete or redact header and body fields in this method.
+
+This configuration is only available for `highlight.run` versions newer than `8.1.0`.
+
+```typescript
+H.init('<YOUR_PROJECT_ID>', {
+  networkRecording: {
+    enabled: true,
+    recordHeadersAndBody: true,
+    requestResponseSanitizer: (pair) => {
+      if (pair.request.url.toLowerCase().indexOf('ignore') !== -1) {
+        // ignore the entire request/response pair (no network logs)
+        return null
+      }
+	 
+      if (pair.response.body.indexOf('secret') !== -1) {
+        // remove the body in the response
+        delete pair.response.body;
+      }
+	 
+      return pair
+    }
+  },
+})
+```
 
 ## API
 

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/recording-network-requests-and-responses.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/recording-network-requests-and-responses.md
@@ -62,9 +62,9 @@ This configuration is only available for `highlight.run` versions newer than `4.
 
 ## Custom Sanitizing of Response and Requests
 
-If you need more granular control over managing and ignoring data in request and responses, then you can create a sanitize function to process every recorded request/response pair. This is configured by using the `networkRecording.requestResponseSanitizer` option.
+Create a sanitize function to gain granular control of the data that your client sends to Highlight. The sanitize function is defined in the second argument of `H.init` under `networkRecording.requestResponseSanitizer`.
 
-The `networkRecording.requestResponseSanitizer` method receives a RequestResponsePair, and should return an object of the same type or a `null` value. Returning a `null` value means that Highlight will drop the request, and no related network logs will be seen in the session replay.
+The `networkRecording.requestResponseSanitizer` method receives a Request/Response pair, and should return an object of the same type or a `null` value. Returning a `null` value means that Highlight will drop the request, and no related network logs will be seen in the session replay.
 
 Dropping logs is not recommended unless necessary, as it can cause issues with debugging due to the missing requests. Rather, it is recommended to delete or redact header and body fields in this method.
 

--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -8,6 +8,8 @@ import { HighlightClassOptions } from '../index'
 import stringify from 'json-stringify-safe'
 import { DEFAULT_URL_BLOCKLIST } from './network-listener/utils/network-sanitizer'
 import {
+	Request,
+	Response,
 	RequestResponsePair,
 	WebSocketEvent,
 	WebSocketRequest,
@@ -44,8 +46,8 @@ export class FirstLoadListeners {
 	networkBodyKeysToRecord: string[] | undefined
 	networkHeaderKeysToRecord: string[] | undefined
 	urlBlocklist!: string[]
-	requestSanitizer?: (
-		requestResponsePair: RequestResponsePair,
+	requestResponseSanitizer?: (
+		pair: RequestResponsePair,
 	) => RequestResponsePair | null
 
 	constructor(options: HighlightClassOptions) {
@@ -203,7 +205,8 @@ export class FirstLoadListeners {
 				...DEFAULT_URL_BLOCKLIST,
 			]
 
-			sThis.requestSanitizer = options.networkRecording?.requestSanitizer
+			sThis.requestResponseSanitizer =
+				options.networkRecording?.requestResponseSanitizer
 
 			sThis.networkHeaderKeysToRecord =
 				options.networkRecording?.headerKeysToRecord
@@ -258,7 +261,6 @@ export class FirstLoadListeners {
 					sessionSecureID: options.sessionSecureID,
 					headerKeysToRecord: sThis.networkHeaderKeysToRecord,
 					bodyKeysToRecord: sThis.networkBodyKeysToRecord,
-					requestSanitizer: sThis.requestSanitizer,
 				}),
 			)
 		}
@@ -304,11 +306,13 @@ export class FirstLoadListeners {
 					httpResources,
 					sThis.xhrNetworkContents,
 					'xmlhttprequest',
+					sThis.requestResponseSanitizer,
 				)
 				httpResources = matchPerformanceTimingsWithRequestResponsePair(
 					httpResources,
 					sThis.fetchNetworkContents,
 					'fetch',
+					sThis.requestResponseSanitizer,
 				)
 			}
 		}

--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -44,6 +44,9 @@ export class FirstLoadListeners {
 	networkBodyKeysToRecord: string[] | undefined
 	networkHeaderKeysToRecord: string[] | undefined
 	urlBlocklist!: string[]
+	requestSanitizer?: (
+		requestResponsePair: RequestResponsePair,
+	) => RequestResponsePair | null
 
 	constructor(options: HighlightClassOptions) {
 		this.options = options
@@ -200,6 +203,8 @@ export class FirstLoadListeners {
 				...DEFAULT_URL_BLOCKLIST,
 			]
 
+			sThis.requestSanitizer = options.networkRecording?.requestSanitizer
+
 			sThis.networkHeaderKeysToRecord =
 				options.networkRecording?.headerKeysToRecord
 			// `headerKeysToRecord` override `networkHeadersToRedact`.
@@ -253,6 +258,7 @@ export class FirstLoadListeners {
 					sessionSecureID: options.sessionSecureID,
 					headerKeysToRecord: sThis.networkHeaderKeysToRecord,
 					bodyKeysToRecord: sThis.networkBodyKeysToRecord,
+					requestSanitizer: sThis.requestSanitizer,
 				}),
 			)
 		}

--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -253,13 +253,11 @@ export class FirstLoadListeners {
 					},
 					disableWebSocketRecording:
 						sThis.disableRecordingWebSocketContents,
-					headersToRedact: sThis.networkHeadersToRedact,
 					bodyKeysToRedact: sThis.networkBodyKeysToRedact,
 					backendUrl: sThis._backendUrl,
 					tracingOrigins: sThis.tracingOrigins,
 					urlBlocklist: sThis.urlBlocklist,
 					sessionSecureID: options.sessionSecureID,
-					headerKeysToRecord: sThis.networkHeaderKeysToRecord,
 					bodyKeysToRecord: sThis.networkBodyKeysToRecord,
 				}),
 			)
@@ -302,17 +300,23 @@ export class FirstLoadListeners {
 				})
 
 			if (sThis.enableRecordingNetworkContents) {
+				const sanitizeOptions = {
+					headersToRedact: sThis.networkHeadersToRedact,
+					headersToRecord: sThis.networkHeaderKeysToRecord,
+					requestResponseSanitizer: sThis.requestResponseSanitizer,
+				}
+
 				httpResources = matchPerformanceTimingsWithRequestResponsePair(
 					httpResources,
 					sThis.xhrNetworkContents,
 					'xmlhttprequest',
-					sThis.requestResponseSanitizer,
+					sanitizeOptions,
 				)
 				httpResources = matchPerformanceTimingsWithRequestResponsePair(
 					httpResources,
 					sThis.fetchNetworkContents,
 					'fetch',
-					sThis.requestResponseSanitizer,
+					sanitizeOptions,
 				)
 			}
 		}

--- a/sdk/client/src/listeners/network-listener/network-listener.ts
+++ b/sdk/client/src/listeners/network-listener/network-listener.ts
@@ -1,7 +1,6 @@
 import { NetworkRecordingOptions } from '../../types/client'
 import { FetchListener } from './utils/fetch-listener'
 import { RequestResponsePair } from './utils/models'
-import { sanitizeResource } from './utils/network-sanitizer'
 import { XHRListener } from './utils/xhr-listener'
 import {
 	WebSocketEventListenerCallback,
@@ -19,13 +18,12 @@ type NetworkListenerArguments = {
 	webSocketRequestCallback: WebSocketRequestListenerCallback
 	webSocketEventCallback: WebSocketEventListenerCallback
 	disableWebSocketRecording: boolean
-	headersToRedact: string[]
 	bodyKeysToRedact: string[]
 	backendUrl: string
 	tracingOrigins: boolean | (string | RegExp)[]
 	urlBlocklist: string[]
 	sessionSecureID: string
-} & Pick<NetworkRecordingOptions, 'bodyKeysToRecord' | 'headerKeysToRecord'>
+} & Pick<NetworkRecordingOptions, 'bodyKeysToRecord'>
 
 export const NetworkListener = ({
 	xhrCallback,
@@ -33,25 +31,15 @@ export const NetworkListener = ({
 	webSocketRequestCallback,
 	webSocketEventCallback,
 	disableWebSocketRecording,
-	headersToRedact,
 	bodyKeysToRedact,
 	backendUrl,
 	tracingOrigins,
 	urlBlocklist,
 	sessionSecureID,
 	bodyKeysToRecord,
-	headerKeysToRecord,
 }: NetworkListenerArguments) => {
 	const removeXHRListener = XHRListener(
-		(requestResponsePair) => {
-			xhrCallback(
-				sanitizeRequestResponsePair(
-					requestResponsePair,
-					headersToRedact,
-					headerKeysToRecord,
-				),
-			)
-		},
+		xhrCallback,
 		backendUrl,
 		tracingOrigins,
 		urlBlocklist,
@@ -60,15 +48,7 @@ export const NetworkListener = ({
 		bodyKeysToRecord,
 	)
 	const removeFetchListener = FetchListener(
-		(requestResponsePair) => {
-			fetchCallback(
-				sanitizeRequestResponsePair(
-					requestResponsePair,
-					headersToRedact,
-					headerKeysToRecord,
-				),
-			)
-		},
+		fetchCallback,
 		backendUrl,
 		tracingOrigins,
 		urlBlocklist,
@@ -89,17 +69,5 @@ export const NetworkListener = ({
 		removeXHRListener()
 		removeFetchListener()
 		removeWebSocketListener()
-	}
-}
-
-const sanitizeRequestResponsePair = (
-	{ request, response, ...rest }: RequestResponsePair,
-	headersToRedact: string[],
-	headersToRecord?: string[],
-): RequestResponsePair => {
-	return {
-		request: sanitizeResource(request, headersToRedact, headersToRecord),
-		response: sanitizeResource(response, headersToRedact, headersToRecord),
-		...rest,
 	}
 }

--- a/sdk/client/src/listeners/network-listener/utils/network-sanitizer.ts
+++ b/sdk/client/src/listeners/network-listener/utils/network-sanitizer.ts
@@ -1,35 +1,18 @@
 import { Request, Response, Headers } from './models'
 
-export const sanitizeRequest = (
-	request: Request,
+export const sanitizeResource = <T extends Request | Response>(
+	resource: T,
 	headersToRedact: string[],
 	headersToRecord?: string[],
-): Request => {
+): T => {
 	const newHeaders = sanitizeHeaders(
 		headersToRedact,
-		request.headers,
+		resource.headers,
 		headersToRecord,
 	)
 
 	return {
-		...request,
-		headers: newHeaders,
-	}
-}
-
-export const sanitizeResponse = (
-	response: Response,
-	headersToRedact: string[],
-	headersToRecord?: string[],
-): Response => {
-	const newHeaders = sanitizeHeaders(
-		headersToRedact,
-		response.headers,
-		headersToRecord,
-	)
-
-	return {
-		...response,
+		...resource,
 		headers: newHeaders,
 	}
 }

--- a/sdk/client/src/listeners/network-listener/utils/utils.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.ts
@@ -62,7 +62,7 @@ const sanitizeRequestResponsePair = (
 	}
 
 	// step 2: redact any specified headers
-	const { request, response, ...rest } = pair
+	const { request, response, ...rest } = sanitizedPair
 
 	return {
 		request: sanitizeResource(request, headersToRedact, headersToRecord),

--- a/sdk/client/src/listeners/network-listener/utils/utils.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.ts
@@ -32,7 +32,7 @@ type PerformanceResourceTimingWithRequestResponsePair =
 		requestResponsePair: RequestResponsePair
 	}
 
-type SanatizeOptions = {
+type SanitizeOptions = {
 	headersToRedact: string[]
 	headersToRecord?: string[]
 	requestResponseSanitizer?: (
@@ -46,7 +46,7 @@ const sanitizeRequestResponsePair = (
 		headersToRedact,
 		headersToRecord,
 		requestResponseSanitizer,
-	}: SanatizeOptions,
+	}: SanitizeOptions,
 ): RequestResponsePair | null => {
 	let sanitizedPair: RequestResponsePair | null = pair
 
@@ -75,7 +75,7 @@ export const matchPerformanceTimingsWithRequestResponsePair = (
 	performanceTimings: PerformanceResourceTiming[],
 	requestResponsePairs: RequestResponsePair[],
 	type: 'xmlhttprequest' | 'fetch',
-	sanatizeOptions: SanatizeOptions,
+	sanitizeOptions: SanitizeOptions,
 ) => {
 	// Request response pairs are sorted by end time; sort performance timings the same way
 	performanceTimings.sort((a, b) => a.responseEnd - b.responseEnd)
@@ -160,7 +160,7 @@ export const matchPerformanceTimingsWithRequestResponsePair = (
 				if (requestResponsePair) {
 					requestResponsePair = sanitizeRequestResponsePair(
 						performanceTiming.requestResponsePair,
-						sanatizeOptions,
+						sanitizeOptions,
 					)
 
 					// ignore request if it was filtered out by the user defined sanitizer

--- a/sdk/client/src/types/client.ts
+++ b/sdk/client/src/types/client.ts
@@ -117,25 +117,24 @@ export declare type NetworkRecordingOptions = {
 	 * Function to edit/remove data in request/response pairs or ignore the pair entirely.
 	 * @example
 	 * ```
-	 * requestSanitizer: requestResponsePair => {
-	 *   if (requestResponsePair.request.url.toLowerCase().indexOf('ignore') !== -1) {
-	 *      // ignore the request response pair
+	 * requestResponseSanitizer: pair => {
+	 *   if (pair.request.url.toLowerCase().indexOf('ignore') !== -1) {
+	 *      // ignore the entire request/response pair (no network logs)
 	 *      return null
 	 *    }
 	 *
-	 *    let updatedRequestResponsePair
-	 *    if (requestResponsePair.response.body.indexOf('secret') !== -1) {
-	 *        // edit the data in the response
-	 *        updatedRequestResponsePair.response.body = null
+	 *    if (pair.response.body.indexOf('secret') !== -1) {
+	 *        // remove the body in the response
+	 * 				delete pair.response.body;
 	 *    }
 	 *
-	 *    return updatedRequestResponsePair
+	 *    return pair
 	 * }
 	 * ```
 	 *
 	 */
-	requestSanitizer?: (
-		requestResponsePair: RequestResponsePair,
+	requestResponseSanitizer?: (
+		pair: RequestResponsePair,
 	) => RequestResponsePair | null
 }
 

--- a/sdk/client/src/types/client.ts
+++ b/sdk/client/src/types/client.ts
@@ -1,3 +1,5 @@
+import { RequestResponsePair } from '../listeners/network-listener/utils/models'
+
 export const ALL_CONSOLE_METHODS = [
 	'assert',
 	'count',
@@ -111,6 +113,30 @@ export declare type NetworkRecordingOptions = {
 	 * // if your frontend makes requests to `backend.example.com` that you would like to record
 	 */
 	destinationDomains?: string[]
+	/**
+	 * Function to edit/remove data in request/response pairs or ignore the pair entirely.
+	 * @example
+	 * ```
+	 * requestSanitizer: requestResponsePair => {
+	 *   if (requestResponsePair.request.url.toLowerCase().indexOf('ignore') !== -1) {
+	 *      // ignore the request response pair
+	 *      return null
+	 *    }
+	 *
+	 *    let updatedRequestResponsePair
+	 *    if (requestResponsePair.response.body.indexOf('secret') !== -1) {
+	 *        // edit the data in the response
+	 *        updatedRequestResponsePair.response.body = null
+	 *    }
+	 *
+	 *    return updatedRequestResponsePair
+	 * }
+	 * ```
+	 *
+	 */
+	requestSanitizer?: (
+		requestResponsePair: RequestResponsePair,
+	) => RequestResponsePair | null
 }
 
 export declare type IntegrationOptions = {


### PR DESCRIPTION
## Summary
While Highlight does provide whitelisting to [redact network header and body](https://www.highlight.io/docs/getting-started/client-sdk/replay-configuration/recording-network-requests-and-responses#redacting-headers-and-bodies), the current functionality is very limiting. It is a non-trival job to whitelist all sort of data types and keys for PIIs, tokens, passwords and so on by hand. It's specially harder when using graphql due to the single endpoint nature of the protocol.

Instead of having a rigid list of keywords and url rules, I'd like to be able to modify the entire network data to my liking based on my application needs and privacy rules. Allow for the client application to customize the request/response right before sending any data to its platform.

One can for instance, modify data from request/response headers, body etc as well as prevent the entire request/response to even be logged.

## How did you test this change?
1) Add in a `requestResponseSanitizer` to the `networkRecording` hash in the frontend's Highlight options. Example:
```
requestResponseSanitizer: (pair) => {
    if (pair.request.verb === 'POST') {
        console.log('blocking request', pair)
	return null
    } else {
	console.log('allowing request', pair)
	pair.request.headers ||= {}
	pair.request.headers['editTest'] = 'true'
    }

    return pair
}
```
2) Build the SDK and start a Highlight session
3) Click around to get different types of requests
4) Close the session, and let it process
5) View the processed sessions network logs
- [ ] Requests ignored appropriately
- [ ] Requests updated appropriately
- [ ] No known missing requests

https://www.loom.com/share/47ce07c349f14e9aa3fb802b21221167?sid=7153b018-f6ba-46a5-bff8-6c635b269607

## Are there any deployment considerations?
Monitor that Highlight records properly without the `requestResponseSanitizer` method

## Does this work require review from our design team?
N/A
