### PR TITLE
fix opensearch migrate blog link

### DIFF
--- a/highlight.io/components/Launch/Week3/DayFour.tsx
+++ b/highlight.io/components/Launch/Week3/DayFour.tsx
@@ -110,7 +110,7 @@ const DayFour = () => {
 						<CardOverlay
 							header="Clickhouse migration."
 							buttonText="View Blog Post"
-							buttonLink="/blog/migrating-opensearch-to-clickhouse.md"
+							buttonLink="/blog/migrating-opensearch-to-clickhouse"
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary
- should link to `https://www.highlight.io/blog/migrating-opensearch-to-clickhouse` without .md 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
