### PR TITLE
fix default canvas snapshotting

### DIFF
--- a/.changeset/lazy-dogs-smoke.md
+++ b/.changeset/lazy-dogs-smoke.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+ensure canvas recording works with auto snapshotting by default if no samplingStrategy is set

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -363,7 +363,9 @@ export class Highlight {
 			canvasFactor: 0.5,
 			canvasMaxSnapshotDimension: 360,
 			canvasClearWebGLBuffer: true,
-			...(options.samplingStrategy ?? {}),
+			...(options.samplingStrategy ?? {
+				canvas: 2,
+			}),
 		}
 		this._backendUrl = options?.backendUrl ?? 'https://pub.highlight.run'
 


### PR DESCRIPTION
## Summary

Manual canvas snapshotting broke the existing auto functionality by removing
the `canvas: 2` default we used to have.

This change ensures that when `enableCanvasRecording: true` is provided with no `samplingStrategy`,
auto snapshotting at 2FPS will be used.

## How did you test this change?

CI

## Are there any deployment considerations?

Changeset

## Does this work require review from our design team?

No