### PR TITLE
fix "between time" label and ms conversion

### DIFF
--- a/backend/clickhouse/querybuilder.go
+++ b/backend/clickhouse/querybuilder.go
@@ -239,12 +239,12 @@ func parseColumnRule(admin *model.Admin, rule Rule, projectId int, sb *sqlbuilde
 			if err != nil {
 				return "", err
 			}
-			start *= 1000
+			start *= 60000
 			end, err := strconv.ParseFloat(after, 64)
 			if err != nil {
 				return "", err
 			}
-			end *= 1000
+			end *= 60000
 			// If the slider is at the maximum, allow any length length greater than the min
 			if after == "60" {
 				end = math.Inf(1)

--- a/frontend/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder/QueryBuilder.tsx
@@ -913,7 +913,7 @@ export const serializeRules = (rules: RuleProps[]): QueryBuilderRule[] => {
 const LABEL_FUNC_MAP: { [K in string]: (x: string) => string } = {
 	custom_processed: getProcessedLabel,
 	custom_created_at: getDateLabel,
-	custom_active_length: getLengthLabel,
+	custom_active_length: getTimeLabel,
 	custom_pages_visited: getLengthLabel,
 	error_state: getStateLabel,
 	'error-field_timestamp': getDateLabel,


### PR DESCRIPTION
## Summary
- active length should use the `getTimeLabel` label function
- length needs to be converted from minutes to ms (`*= 60000`)
- fixes #6899 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
https://www.loom.com/share/63b231d9f1744b0a9213057c19ff8a5c
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
