### PR TITLE
synchronously apply user-driven error group updates

### DIFF
--- a/backend/clickhouse/cursor_test.go
+++ b/backend/clickhouse/cursor_test.go
@@ -181,7 +181,7 @@ func TestEncodeDecode(t *testing.T) {
 
 func TestClickhouseDecode(t *testing.T) {
 	ctx := context.Background()
-	client, err := setupClickhouseTestDB()
+	client, err := SetupClickhouseTestDB()
 
 	assert.NoError(t, err)
 

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -3,14 +3,15 @@ package clickhouse
 import (
 	"context"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/highlight-run/highlight/backend/queryparser"
-	"github.com/samber/lo"
 	"os"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/highlight-run/highlight/backend/queryparser"
+	"github.com/samber/lo"
 
 	"github.com/aws/smithy-go/ptr"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
@@ -18,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	_, err := setupClickhouseTestDB()
+	_, err := SetupClickhouseTestDB()
 	if err != nil {
 		panic("Failed to setup clickhouse test database")
 	}

--- a/backend/clickhouse/test_utils.go
+++ b/backend/clickhouse/test_utils.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func setupClickhouseTestDB() (*Client, error) {
+func SetupClickhouseTestDB() (*Client, error) {
 	client, err := NewClient(PrimaryDatabase)
 	if err != nil {
 		return nil, err

--- a/backend/main.go
+++ b/backend/main.go
@@ -359,7 +359,7 @@ func main() {
 		OAuthServer:            oauthSrv,
 		IntegrationsClient:     integrationsClient,
 		ClickhouseClient:       clickhouseClient,
-		Store:                  store.NewStore(db, redisClient, integrationsClient, storageClient, kafkaDataSyncProducer),
+		Store:                  store.NewStore(db, redisClient, integrationsClient, storageClient, kafkaDataSyncProducer, clickhouseClient),
 		DataSyncQueue:          kafkaDataSyncProducer,
 		TracesQueue:            kafkaTracesProducer,
 	}
@@ -488,7 +488,7 @@ func main() {
 			HubspotApi:       hubspotApi.NewHubspotAPI(hubspot.NewClient(hubspot.NewClientConfig()), db, redisClient, kafkaProducer),
 			Redis:            redisClient,
 			RH:               &rh,
-			Store:            store.NewStore(db, redisClient, integrationsClient, storageClient, kafkaDataSyncProducer),
+			Store:            store.NewStore(db, redisClient, integrationsClient, storageClient, kafkaDataSyncProducer, clickhouseClient),
 		}
 		publicEndpoint := "/public"
 		if runtimeParsed == util.PublicGraph {
@@ -580,7 +580,7 @@ func main() {
 			Redis:            redisClient,
 			Clickhouse:       clickhouseClient,
 			RH:               &rh,
-			Store:            store.NewStore(db, redisClient, integrationsClient, storageClient, kafkaDataSyncProducer),
+			Store:            store.NewStore(db, redisClient, integrationsClient, storageClient, kafkaDataSyncProducer, clickhouseClient),
 		}
 		w := &worker.Worker{Resolver: privateResolver, PublicResolver: publicResolver, StorageClient: storageClient}
 		if runtimeParsed == util.Worker {

--- a/backend/migrations/cmd/backfill-session-properties-clickhouse/main.go
+++ b/backend/migrations/cmd/backfill-session-properties-clickhouse/main.go
@@ -36,7 +36,7 @@ func main() {
 	publicResolver := &public.Resolver{
 		DB:            db,
 		DataSyncQueue: kafkaDataSyncProducer,
-		Store:         store.NewStore(db, redisClient, nil, nil, kafkaDataSyncProducer),
+		Store:         store.NewStore(db, redisClient, nil, nil, kafkaDataSyncProducer, nil),
 	}
 
 	var sessionIds []int

--- a/backend/otel/otel_test.go
+++ b/backend/otel/otel_test.go
@@ -5,6 +5,11 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/highlight-run/highlight/backend/integrations"
 	model2 "github.com/highlight-run/highlight/backend/public-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/redis"
@@ -14,10 +19,6 @@ import (
 	"github.com/openlyinc/pointy"
 	e "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"net/http"
-	"os"
-	"strings"
-	"testing"
 
 	kafkaqueue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/private-graph/graph/model"
@@ -139,7 +140,7 @@ func TestHandler_HandleTrace(t *testing.T) {
 		producer := MockKafkaProducer{}
 		resolver := &public.Resolver{
 			Redis:         red,
-			Store:         store.NewStore(db, red, integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &producer),
+			Store:         store.NewStore(db, red, integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &producer, nil),
 			ProducerQueue: &producer,
 			BatchedQueue:  &producer,
 			TracesQueue:   &producer,

--- a/backend/private-graph/graph/resolver_test.go
+++ b/backend/private-graph/graph/resolver_test.go
@@ -460,7 +460,7 @@ func TestResolver_canAdminViewSession(t *testing.T) {
 			if err := redisClient.Cache.Delete(ctx, "session-secure-abc123"); err != nil {
 				t.Fatal(err)
 			}
-			r := &queryResolver{Resolver: &Resolver{DB: DB, Store: store.NewStore(DB, redisClient, integrations.NewIntegrationsClient(DB), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{})}}
+			r := &queryResolver{Resolver: &Resolver{DB: DB, Store: store.NewStore(DB, redisClient, integrations.NewIntegrationsClient(DB), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{}, nil)}}
 
 			w := model.Workspace{}
 			if err := DB.Create(&w).Error; err != nil {

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -87,7 +87,7 @@ func TestMain(m *testing.M) {
 		DB:               db,
 		TDB:              timeseries.New(context.TODO()),
 		Redis:            redisClient,
-		Store:            store.NewStore(db, redisClient, integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{}),
+		Store:            store.NewStore(db, redisClient, integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{}, nil),
 		EmbeddingsClient: &mockEmbeddingsClient{},
 		DataSyncQueue:    &kafka_queue.MockMessageQueue{},
 	}

--- a/backend/store/main_test.go
+++ b/backend/store/main_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/highlight-run/highlight/backend/clickhouse"
 	"github.com/highlight-run/highlight/backend/integrations"
 	kafka_queue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/redis"
@@ -21,13 +22,18 @@ var store *Store
 func TestMain(m *testing.M) {
 	dbName := "highlight_testing_db"
 	testLogger := log.WithContext(context.TODO()).WithFields(log.Fields{"DB_HOST": os.Getenv("PSQL_HOST"), "DB_NAME": dbName})
-	var err error
+
 	db, err := util.CreateAndMigrateTestDB(dbName)
 	if err != nil {
 		testLogger.Error(e.Wrap(err, "error creating testdb"))
 	}
 
-	store = NewStore(db, redis.NewClient(), integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{}, nil)
+	clickhouseClient, err := clickhouse.SetupClickhouseTestDB()
+	if err != nil {
+		testLogger.Error(e.Wrap(err, "error creating clickhouse test db"))
+	}
+
+	store = NewStore(db, redis.NewClient(), integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{}, clickhouseClient)
 	code := m.Run()
 	os.Exit(code)
 }

--- a/backend/store/main_test.go
+++ b/backend/store/main_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 		testLogger.Error(e.Wrap(err, "error creating testdb"))
 	}
 
-	store = NewStore(db, redis.NewClient(), integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{})
+	store = NewStore(db, redis.NewClient(), integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{}, nil)
 	code := m.Run()
 	os.Exit(code)
 }

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"github.com/highlight-run/highlight/backend/clickhouse"
 	"github.com/highlight-run/highlight/backend/integrations"
 	kafka_queue "github.com/highlight-run/highlight/backend/kafka-queue"
 	"github.com/highlight-run/highlight/backend/redis"
@@ -15,14 +16,16 @@ type Store struct {
 	integrationsClient *integrations.Client
 	storageClient      storage.Client
 	dataSyncQueue      kafka_queue.MessageQueue
+	clickhouseClient   *clickhouse.Client
 }
 
-func NewStore(db *gorm.DB, redis *redis.Client, integrationsClient *integrations.Client, storageClient storage.Client, dataSyncQueue kafka_queue.MessageQueue) *Store {
+func NewStore(db *gorm.DB, redis *redis.Client, integrationsClient *integrations.Client, storageClient storage.Client, dataSyncQueue kafka_queue.MessageQueue, clickhouseClient *clickhouse.Client) *Store {
 	return &Store{
 		db:                 db,
 		redis:              redis,
 		integrationsClient: integrationsClient,
 		storageClient:      storageClient,
 		dataSyncQueue:      dataSyncQueue,
+		clickhouseClient:   clickhouseClient,
 	}
 }

--- a/backend/worker/autoresolver_test.go
+++ b/backend/worker/autoresolver_test.go
@@ -30,7 +30,7 @@ func createAutoResolver() *AutoResolver {
 		testLogger.Error(e.Wrap(err, "error creating testdb"))
 	}
 
-	store := store.NewStore(db, redis.NewClient(), integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{})
+	store := store.NewStore(db, redis.NewClient(), integrations.NewIntegrationsClient(db), &storage.FilesystemClient{}, &kafka_queue.MockMessageQueue{}, nil)
 	return NewAutoResolver(store, db)
 }
 


### PR DESCRIPTION
## Summary
- when an error group's state is updated by the user, apply that update synchronously in clickhouse so there's no delay
- fixes #6688 
- https://www.loom.com/share/e2a1343ac7f84e73b2aeec8e3fd616c4
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
