### PR TITLE
search sessions / errors by service name / version

### DIFF
--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/queryparser"
 	"strings"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/queryparser"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/highlight-run/highlight/backend/model"
@@ -52,6 +53,7 @@ var fieldMap map[string]string = map[string]string{
 	"timestamp":       "Timestamp",
 	"secure_id":       "ErrorGroupSecureID",
 	"service_name":    "ServiceName",
+	"service_version": "ServiceVersion",
 	"Tag":             "ErrorTagTitle",
 }
 

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -995,6 +995,10 @@ func (r *Resolver) IndexSessionClickhouse(ctx context.Context, session *model.Se
 		"city":            session.City,
 		"country":         session.Country,
 		"ip":              session.IP,
+		"service_name":    session.ServiceName,
+	}
+	if session.AppVersion != nil {
+		sessionProperties["service_version"] = *session.AppVersion
 	}
 	if err := r.AppendProperties(ctx, session.ID, sessionProperties, PropertyType.SESSION); err != nil {
 		log.WithContext(ctx).Error(e.Wrap(err, "error adding set of properties to db"))

--- a/frontend/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder/QueryBuilder.tsx
@@ -842,6 +842,7 @@ const LABEL_MAP: { [key: string]: string } = {
 	exit_page: 'Exit Page',
 	has_comments: 'Has Comments',
 	service_name: 'Service',
+	service_version: 'Service Version',
 }
 
 const getOperator = (
@@ -967,6 +968,10 @@ const getIcon = (value: string): JSX.Element | undefined => {
 	switch (value) {
 		case 'custom_app_version':
 			return <IconSolidDesktopComputer />
+		case 'session_service_name':
+			return <IconSolidCubeTransparent />
+		case 'session_service_version':
+			return <IconSolidCubeTransparent />
 		case 'session_browser_name':
 			return <IconSolidGlobeAlt />
 		case 'session_browser_version':
@@ -1030,6 +1035,8 @@ const getIcon = (value: string): JSX.Element | undefined => {
 		case 'error-field_visited_url':
 			return <IconSolidLink />
 		case 'error-field_service_name':
+			return <IconSolidCubeTransparent />
+		case 'error-field_service_version':
 			return <IconSolidCubeTransparent />
 		case 'error-field_has_session':
 			return <IconSolidDesktopComputer />

--- a/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/ErrorQueryBuilder.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/ErrorQueryBuilder.tsx
@@ -90,6 +90,13 @@ export const CUSTOM_FIELDS: CustomField[] = [
 	},
 	{
 		type: ERROR_FIELD_TYPE,
+		name: 'service_version',
+		options: {
+			type: 'text',
+		},
+	},
+	{
+		type: ERROR_FIELD_TYPE,
 		name: 'has_session',
 		options: {
 			operators: ['is', 'is_not'],


### PR DESCRIPTION
## Summary
- adds service name + version to session search UI
- adds service version to error search UI
- indexes service name and version as session fields when a session is initialized
- Q: is a session's app version equivalent to service version? the way I implemented it it's pretty much an alias, do we want to remove app version from the query builder?
- https://www.loom.com/share/55eeabed43a84e81a263936bac848294
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- can backfill service name and version fields for existing sessions if we want to 
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
