### PR TITLE
logging for empty exceptions

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -5,11 +5,12 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	model2 "github.com/highlight-run/highlight/backend/model"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	model2 "github.com/highlight-run/highlight/backend/model"
 
 	"github.com/samber/lo"
 
@@ -197,6 +198,12 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						if fields.external {
 							lg(ctx, fields).WithError(err).Info("dropping external exception")
 							continue
+						}
+
+						if fields.exceptionMessage == "" {
+							lg(ctx, fields).
+								WithField("event", event.Attributes().AsRaw()).
+								Info("unexpected empty exception message")
 						}
 
 						var logCursor *string


### PR DESCRIPTION
## Summary
- it seems like the `exceptionMessage` field is blank for certain exception events coming from Next.js - add some logging here to see 1. if this codepath is the cause of the blank error logs and 2. what the other event fields are when this occurs to see if there's another field we should extract
- related to #6916 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor this log in prod after deployment
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
