### PR TITLE
skip exception events with no message

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -204,6 +204,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 							lg(ctx, fields).
 								WithField("event", event.Attributes().AsRaw()).
 								Info("unexpected empty exception message")
+							continue
 						}
 
 						var logCursor *string


### PR DESCRIPTION
## Summary
- these events have only happened 27 times in the past 2 hours and all of the Next.js ones are related to a `DevServer.handleCatchallMiddlewareRequest` error - it doesn't seem like this error has user impact as all the associated requests have status code 200 and looking at https://github.com/vercel/next.js/blob/d0e92b19af6672c44533eb8b6826007f645a943d/packages/next/src/server/next-server.ts#L1644 it doesn't seem like a real error but I don't really know what that's for
- examples:
```
map[exception.stacktrace:Error at DevServer.handleCatchallMiddlewareRequest (.../node_modules/next/dist/server/next-server.js:1067:33) at async DevServer.handleRequestImpl (.../node_modules/next/dist/server/base-server.js:735:32) exception.type:Error]
```
```
map[exception.stacktrace:Error at DevServer.handleCatchallMiddlewareRequest (.../node_modules/.pnpm/next@13.5.2_@babel+core@7.22.20_@opentelemetry+api@1.4.1_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/next-server.js:1067:33) at async DevServer.handleRequestImpl (.../node_modules/.pnpm/next@13.5.2_@babel+core@7.22.20_@opentelemetry+api@1.4.1_react-dom@18.2.0_react@18.2.0/node_modules/next/dist/server/base-server.js:735:32) exception.type:Error]
```
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- built locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
