### PR TITLE
tRPC mutation error thrower

### DIFF
--- a/e2e/nextjs/next.config.mjs
+++ b/e2e/nextjs/next.config.mjs
@@ -4,7 +4,7 @@ import { withHighlightConfig } from '@highlight-run/next/config'
 const nextConfig = {
 	experimental: {
 		appDir: true,
-		instrumentationHook: true,
+		instrumentationHook: false,
 	},
 	productionBrowserSourceMaps: true,
 	images: { domains: ['i.travelapi.com'] },

--- a/e2e/nextjs/pages/api/trpc/[trpc].ts
+++ b/e2e/nextjs/pages/api/trpc/[trpc].ts
@@ -2,8 +2,12 @@ import * as trpcNext from '@trpc/server/adapters/next'
 
 import { initTRPC } from '@trpc/server'
 import { z } from 'zod'
+import { H, Handlers } from '@highlight-run/node'
+import CONSTANTS from '@/app/constants'
 
 const t = initTRPC.create()
+
+H.init({ projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID })
 
 export const router = t.router
 export const publicProcedure = t.procedure
@@ -14,11 +18,25 @@ const appRouter = router({
 		.query(async ({ input }) => {
 			return { hello: 'world', ...input }
 		}),
+	throwError: publicProcedure.mutation(() => {
+		throw new Error('🤖 tRPC error! ⚠️')
+	}),
 })
 
 export default trpcNext.createNextApiHandler({
 	router: appRouter,
 	createContext: () => ({}),
+	onError: ({ error, req }) => {
+		Handlers.trpcOnError(
+			{ error, req },
+			{
+				projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
+				serviceName: 'my-trpc-app',
+				serviceVersion: 'test-git-sha',
+			},
+		)
+		console.error(error)
+	},
 })
 
 export type AppRouter = typeof appRouter

--- a/e2e/nextjs/src/app/components/trpc-queries.tsx
+++ b/e2e/nextjs/src/app/components/trpc-queries.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import { trpc } from '@/app/_utils/trpc'
+import { Button } from '@/app/components/button'
 
 export const TrpcQueries = trpc.withTRPC(function TrpcQueries() {
 	const helloWorld = trpc.helloWorld.useQuery({ message: 'Hello Chris' })
+	const throwError = trpc.throwError.useMutation()
 
-	return !helloWorld.data ? (
-		<div>loading...</div>
-	) : (
+	return (
 		<div
 			className="trpc-buttons"
 			style={{
@@ -26,7 +26,19 @@ export const TrpcQueries = trpc.withTRPC(function TrpcQueries() {
 				`,
 				}}
 			/>
-			<p>Hello World payload: {JSON.stringify(helloWorld.data)}</p>
+			{!helloWorld.data ? (
+				<p>Hello World payload: {JSON.stringify(helloWorld.data)}</p>
+			) : (
+				<div>loading...</div>
+			)}
+
+			<Button
+				onClick={() => {
+					throwError.mutateAsync()
+				}}
+			>
+				Throw tRPC Mutation Error
+			</Button>
 		</div>
 	)
 })


### PR DESCRIPTION
I couldn't reproduce the TS error from #6849.

I added a tRPC mutation error handler to test that, just in case I was missing something. It worked first try.

closes #6849 

![image](https://github.com/highlight/highlight/assets/878947/795a2491-00f4-426a-9a1a-9c77bc6a09eb)
