### PR TITLE
Error UI tweaks

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -316,18 +316,26 @@ const StackSection: React.FC<React.PropsWithChildren<StackSectionProps>> = ({
 						<IconSolidExternalLink size={16} />
 					</LinkButton>
 				)}
-				<Text cssClass={styles.name} color="n11" as="span">
-					{functionName ? ' in ' : ''}
-				</Text>
-				<Text cssClass={styles.name} as="span">
-					{functionName}
-				</Text>
-				<Text cssClass={styles.name} color="n11" as="span">
-					{lineNumber ? ' at line ' : ''}
-				</Text>
-				<Text cssClass={styles.name} as="span">
-					{lineNumber}
-				</Text>
+				{!!functionName && (
+					<>
+						<Text cssClass={styles.name} color="n11" as="span">
+							{' in '}
+						</Text>
+						<Text cssClass={styles.name} as="span">
+							{functionName}
+						</Text>
+					</>
+				)}
+				{!!lineNumber && (
+					<>
+						<Text cssClass={styles.name} color="n11" as="span">
+							{' at line '}
+						</Text>
+						<Text cssClass={styles.name} as="span">
+							{lineNumber}
+						</Text>
+					</>
+				)}
 			</Box>
 
 			<Box display="flex" gap="4" alignItems="center">

--- a/frontend/src/pages/ErrorsV2/ErrorTag/ErrorTag.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorTag/ErrorTag.tsx
@@ -35,11 +35,14 @@ const ErrorTag = React.memo(
 					shape="basic"
 					lines="1"
 				>
-					<Text>
-						{errorGroup.serviceName && errorGroup.serviceName != ''
-							? errorGroup.serviceName
-							: errorGroup.type}
-					</Text>
+					<Box display="inline-block">
+						<Text>
+							{errorGroup.serviceName &&
+							errorGroup.serviceName != ''
+								? errorGroup.serviceName
+								: errorGroup.type}
+						</Text>
+					</Box>
 				</Tag>
 
 				<IconSolidCheveronRight />
@@ -50,7 +53,9 @@ const ErrorTag = React.memo(
 						emphasis="medium"
 						iconLeft={<IconSolidDesktopComputer size={12} />}
 					>
-						<Text>{errorGroup.error_tag.title}</Text>
+						<Box display="inline-block">
+							<Text>{errorGroup.error_tag.title}</Text>
+						</Box>
 					</Tag>
 				) : null}
 				<Text size="small" weight="medium" color="moderate" lines="1">


### PR DESCRIPTION
## Summary
Make a couple tweaks to the error UI:
- remove the 0 line number from the stack trace
![Screenshot 2023-10-24 at 5 14 56 PM](https://github.com/highlight/highlight/assets/17744174/f2fbcdd9-e2dd-4edc-a2c1-73fa4eeb65dd)
- Add "padding" to the error tags
![Screenshot 2023-10-24 at 5 08 17 PM](https://github.com/highlight/highlight/assets/17744174/81e77b36-1d4b-492b-9565-0f89f9142072)

## How did you test this change?
https://www.loom.com/share/85b14b9e4fb14fb08b0f4825985df9dc?sid=fa17c519-8bae-472a-81c5-bbf86a2cb590

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
