### PR TITLE
Demonstrating onShellReady and onShellError handlers

### DIFF
--- a/docs-content/getting-started/fullstack-frameworks/remix.md
+++ b/docs-content/getting-started/fullstack-frameworks/remix.md
@@ -176,7 +176,24 @@ function handleBrowserRequest(
 				abortDelay={ABORT_DELAY}
 			/>,
 			{
-				// onShellReady and onShellError handlers...
+				onShellReady() {
+					shellRendered = true
+					const body = new PassThrough()
+
+					responseHeaders.set('Content-Type', 'text/html')
+
+					resolve(
+						new Response(body, {
+							headers: responseHeaders,
+							status: responseStatusCode,
+						}),
+					)
+
+					pipe(body)
+				},
+				onShellError(error: unknown) {
+					reject(error)
+				},
 				onError(error: unknown) {
 					if (shellRendered) {
 						logError(error, request)


### PR DESCRIPTION
closes #6834 

## Summary

Adding `onShellReady` and `onShellError` example code.