### PR TITLE
team invite role should match inviter's

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -923,6 +923,18 @@ func (r *mutationResolver) SendAdminWorkspaceInvite(ctx context.Context, workspa
 		return nil, err
 	}
 
+	if role != model.AdminRole.ADMIN && role != model.AdminRole.MEMBER {
+		return nil, e.Errorf("invalid role %s", role)
+	}
+
+	// If the new invite is for an admin role, the inviter must be an admin
+	if role == model.AdminRole.ADMIN {
+		err := r.validateAdminRole(ctx, workspaceID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	inviteLink := r.CreateInviteLink(workspaceID, &email, role, false)
 
 	if err := r.DB.Create(inviteLink).Error; err != nil {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -326,7 +326,6 @@ const AuthenticationRoleRouter = () => {
 		const fetch = async () => {
 			if (user) {
 				await fetchAdmin()
-				setLoadingState(AppLoadingState.LOADED)
 			}
 		}
 		fetch()


### PR DESCRIPTION
## Summary
- fix issue where invite had role "0" instead of "MEMBER" / "ADMIN" - workspace_admins were created with this "0" role which led to some buggy behavior in places where "MEMBER" or "ADMIN" were expected
- sets the invitee role as the same as the inviter
  - should we add an option for ADMINs to invite MEMBERs or is this ok for now?
- hides the "Allow joining by email domain" option for non-ADMINs since the resolver throws an error
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally as both a MEMBER and ADMIN
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will run the following:
```
begin
update workspace_admins set role = 'MEMBER' where role not in ('ADMIN', 'MEMBER')
update workspace_invite_links set invitee_role = 'MEMBER' where invitee_role not in ('ADMIN', 'MEMBER')
commit
```
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
