### PR TITLE
Fix relative stylesheets

### DIFF
--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -119,7 +119,7 @@ func (n networkFetcher) fetchStylesheetData(href string, s *Snapshot) ([]byte, e
 
 	resp, err := http.Get(href)
 	if err != nil {
-		return nil, errors.Wrap(err, "error fetching styles")
+		return nil, errors.Wrapf(err, "error fetching styles from %s", href)
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
@@ -324,7 +324,7 @@ func escapeNodeWithJSAttrs(ctx context.Context, node map[string]interface{}) {
 }
 
 // InjectStylesheets injects custom stylesheets into a given snapshot event.
-func (s *Snapshot) InjectStylesheets() error {
+func (s *Snapshot) InjectStylesheets(ctx context.Context) error {
 	node, ok := s.data["node"].(map[string]interface{})
 	if !ok {
 		return errors.New("error converting to node")
@@ -390,6 +390,7 @@ func (s *Snapshot) InjectStylesheets() error {
 		}
 		data, err := fetch.fetchStylesheetData(href, s)
 		if err != nil {
+			log.WithContext(ctx).Error(err)
 			continue
 		}
 		if len(data) <= 0 {

--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -3,6 +3,11 @@ package parse
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/redis"
 	"github.com/highlight-run/highlight/backend/storage"
@@ -11,10 +16,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
-	"os"
-	"strings"
-	"testing"
-	"time"
 
 	"github.com/go-test/deep"
 	"github.com/kylelemons/godebug/pretty"
@@ -135,7 +136,7 @@ func TestEventsFromString(t *testing.T) {
 
 type fetcherMock struct{}
 
-func (u fetcherMock) fetchStylesheetData(href string) ([]byte, error) {
+func (u fetcherMock) fetchStylesheetData(href string, s *Snapshot) ([]byte, error) {
 	return []byte("/*highlight-inject*/\n.highlight {\n    color: black;\n}"), nil
 }
 
@@ -147,7 +148,7 @@ func TestInjectStyleSheets(t *testing.T) {
 		t.Fatalf("error reading: %v", err)
 	}
 
-	snapshot, err := NewSnapshot(inputBytes)
+	snapshot, err := NewSnapshot(inputBytes, nil)
 	if err != nil {
 		t.Fatalf("error parsing: %v", err)
 	}
@@ -192,7 +193,7 @@ func TestEscapeJavascript(t *testing.T) {
 		t.Fatalf("error reading: %v", err)
 	}
 
-	snapshot, err := NewSnapshot(inputBytes)
+	snapshot, err := NewSnapshot(inputBytes, nil)
 	if err != nil {
 		t.Fatalf("error parsing: %v", err)
 	}
@@ -220,7 +221,7 @@ func TestSnapshot_ReplaceAssets(t *testing.T) {
 		t.Fatalf("error reading: %v", err)
 	}
 
-	snapshot, err := NewSnapshot(inputBytes)
+	snapshot, err := NewSnapshot(inputBytes, nil)
 	if err != nil {
 		t.Fatalf("error parsing: %v", err)
 	}

--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -155,7 +155,7 @@ func TestInjectStyleSheets(t *testing.T) {
 	}
 
 	// Pass sample set to `injectStylesheets` and convert to interface.
-	err = snapshot.InjectStylesheets()
+	err = snapshot.InjectStylesheets(context.TODO())
 	if err != nil {
 		t.Fatalf("error injecting: %v", err)
 	}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2548,7 +2548,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 						stylesheetsSpan, _ := util.StartSpanFromContext(ctx, "public-graph.pushPayload",
 							util.ResourceName("go.parseEvents.InjectStylesheets"), util.Tag("project_id", projectID))
 						// If we see a snapshot event, attempt to inject CORS stylesheets.
-						err := snapshot.InjectStylesheets()
+						err := snapshot.InjectStylesheets(ctx)
 						stylesheetsSpan.Finish(err)
 						if err != nil {
 							log.WithContext(ctx).Error(e.Wrap(err, "Error injecting snapshot stylesheets"))

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2519,9 +2519,11 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 
 			var lastUserInteractionTimestamp time.Time
 			hasFullSnapshot := false
+			hostUrl := parse.GetHostUrlFromEvents(parsedEvents.Events)
+
 			for _, event := range parsedEvents.Events {
 				if event.Type == parse.FullSnapshot || event.Type == parse.IncrementalSnapshot {
-					snapshot, err := parse.NewSnapshot(event.Data)
+					snapshot, err := parse.NewSnapshot(event.Data, hostUrl)
 					if err != nil {
 						log.WithContext(ctx).Error(e.Wrap(err, "Error unmarshalling snapshot"))
 						continue


### PR DESCRIPTION
## Summary
Some CSS stylesheets have relative path references from which they need to be fetched. Previously, this would be fetched from `app.highlight.io`, but we should use the url of the site in the snapshot.

![Screenshot 2023-10-19 at 2 13 52 PM](https://github.com/highlight/highlight/assets/17744174/23a8b89f-e7c8-4a0b-94f3-a5a5e4295f1c)

## How did you test this change?
I am not currently able to test on their site (waiting for an invite), but confirmed that Highlight sessions with absolute urls are not broken.

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
