### PR TITLE
fix trace ID encoding

### DIFF
--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -2,7 +2,6 @@ package highlight
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -120,7 +119,11 @@ func StartTraceWithTimestamp(ctx context.Context, name string, t time.Time, tags
 	sessionID, requestID, _ := validateRequest(ctx)
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if requestID != "" {
-		data, _ := base64.StdEncoding.DecodeString(requestID)
+		var data []byte
+		for _, c := range requestID {
+			offset := byte(c - '0')
+			data = append(data, offset)
+		}
 		hex := fmt.Sprintf("%032x", data)
 		tid, _ := trace.TraceIDFromHex(hex)
 		spanCtx = spanCtx.WithTraceID(tid)


### PR DESCRIPTION
## Summary

x-highlight-request network id encoding to trace id on spans would not encode
capital letters. Switch this to a encoding method that captures the entire a-z A-Z 0-9 range.

## How did you test this change?

Traces captured locally.
<img width="1397" alt="Screenshot 2023-10-26 at 5 38 37 PM" src="https://github.com/highlight/highlight/assets/1351531/8a5f7307-e44f-47aa-96f0-133a6aee8376">


## Are there any deployment considerations?

No

## Does this work require review from our design team?

No