### PR TITLE
Join workspace fixes

### DIFF
--- a/frontend/src/pages/Auth/InviteTeam.tsx
+++ b/frontend/src/pages/Auth/InviteTeam.tsx
@@ -128,15 +128,17 @@ export const InviteTeamForm: React.FC = () => {
 						},
 					}),
 				)
-				if (adminRole === AdminRole.Admin) {
+				if (
+					adminRole === AdminRole.Admin &&
+					formState.values.autoJoinDomain
+				) {
 					promises.push(
 						updateAllowedEmailOrigins({
 							variables: {
 								workspace_id: workspace.id,
-								allowed_auto_join_email_origins: formState
-									.values.autoJoinDomain
-									? getEmailDomain(admin?.email)
-									: '',
+								allowed_auto_join_email_origins: `["${getEmailDomain(
+									admin?.email,
+								)}"]`,
 							},
 						}),
 					)

--- a/frontend/src/pages/Auth/JoinWorkspace.tsx
+++ b/frontend/src/pages/Auth/JoinWorkspace.tsx
@@ -152,7 +152,7 @@ export const JoinWorkspace = () => {
 							navigate(ABOUT_YOU_ROUTE, { replace: true })
 						}}
 					>
-						<Text color="moderate">Cancel</Text>
+						<Text color="moderate">Create My Own Workspace</Text>
 					</Button>
 				</AuthFooter>
 			</Form>

--- a/frontend/src/pages/Auth/JoinWorkspace.tsx
+++ b/frontend/src/pages/Auth/JoinWorkspace.tsx
@@ -27,7 +27,14 @@ export const DISMISS_JOIN_WORKSPACE_LOCAL_STORAGE_KEY =
 	'highlightDismissedJoinWorkspace'
 
 export const JoinWorkspace = () => {
-	const { data, loading } = useGetWorkspacesQuery()
+	const { data, loading } = useGetWorkspacesQuery({
+		onCompleted: (data) => {
+			formStore.setValue(
+				formStore.names.workspaceId,
+				data?.joinable_workspaces?.[0]?.id,
+			)
+		},
+	})
 	const { data: adminData } = useGetAdminQuery()
 	const navigate = useNavigate()
 	const { setLoadingState } = useAppLoadingContext()

--- a/frontend/src/pages/Auth/SignUp.tsx
+++ b/frontend/src/pages/Auth/SignUp.tsx
@@ -42,7 +42,8 @@ export const SignUp: React.FC = () => {
 		},
 	})
 	const email = formStore.useValue('email')
-	const loading = formStore.useState('submitting')
+	const submitSucceeded = formStore.useState('submitSucceed')
+	const formLoading = formStore.useState('submitting') || submitSucceeded > 0
 	formStore.useSubmit(async (formState) => {
 		auth.createUserWithEmailAndPassword(
 			formState.values.email,
@@ -158,7 +159,7 @@ export const SignUp: React.FC = () => {
 					<Button
 						onClick={() => null}
 						trackingId="sign-up-submit"
-						loading={loading}
+						loading={formLoading}
 						type="submit"
 					>
 						Sign up


### PR DESCRIPTION
## Summary

1. Fixes a bug where the join workspace submit button was disabled until you interacted with the form. It would look like you had a workspace selected to join, but the button was disabled until you interacted with the workspace dropdown, which caused confusion for people joining workspaces.
1. Updates the CTA to dismiss the join workspace page when your able to join a workspace based on your email domain.
1. Fixes a bug where the `allowed_auto_join_email_origins` field wasn't being populated even when the checkbox was selected on the invite team page. This was because the server expected a string that could be parsed as JSON - an array of allowed email domains.
1. Updates the loading state of the form submit button on the sign up form so that it is always dismissed after a successful submission. It was previously flickering the disabled state, but clickable again before transitioning to the next page.

## How did you test this change?

Local click test with a new account. Used https://www.guerrillamail.com for generating some new email addresses with matching domains and confirming they were updated as expected.

## Are there any deployment considerations?

Should monitor folks signing up and joining a workspace to ensure they aren't running into these issues anymore.

## Does this work require review from our design team?

Nope!
