### PR TITLE
Clean up error tags component

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorTag/ErrorTag.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorTag/ErrorTag.tsx
@@ -33,6 +33,7 @@ const ErrorTag = React.memo(
 					kind="secondary"
 					size="medium"
 					shape="basic"
+					lines="1"
 				>
 					{errorGroup.serviceName && errorGroup.serviceName != ''
 						? errorGroup.serviceName

--- a/frontend/src/pages/ErrorsV2/ErrorTag/ErrorTag.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorTag/ErrorTag.tsx
@@ -33,31 +33,23 @@ const ErrorTag = React.memo(
 					kind="secondary"
 					size="medium"
 					shape="basic"
-					lines="1"
 				>
-					<Box display="inline-block">
-						<Text>
-							{errorGroup.serviceName &&
-							errorGroup.serviceName != ''
-								? errorGroup.serviceName
-								: errorGroup.type}
-						</Text>
-					</Box>
+					{errorGroup.serviceName && errorGroup.serviceName != ''
+						? errorGroup.serviceName
+						: errorGroup.type}
 				</Tag>
 
 				<IconSolidCheveronRight />
-				{errorGroup?.error_tag?.title ? (
+				{errorGroup?.error_tag?.title && (
 					<Tag
 						shape="basic"
 						kind="secondary"
 						emphasis="medium"
 						iconLeft={<IconSolidDesktopComputer size={12} />}
 					>
-						<Box display="inline-block">
-							<Text>{errorGroup.error_tag.title}</Text>
-						</Box>
+						{errorGroup.error_tag.title}
 					</Tag>
-				) : null}
+				)}
 				<Text size="small" weight="medium" color="moderate" lines="1">
 					{getProjectPrefix(projectData?.project)}-{errorGroup.id}
 				</Text>

--- a/frontend/src/pages/ErrorsV2/ErrorTag/ErrorTag.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorTag/ErrorTag.tsx
@@ -47,6 +47,7 @@ const ErrorTag = React.memo(
 						kind="secondary"
 						emphasis="medium"
 						iconLeft={<IconSolidDesktopComputer size={12} />}
+						lines="1"
 					>
 						{errorGroup.error_tag.title}
 					</Tag>


### PR DESCRIPTION
## Summary

We had [a ticket](https://github.com/highlight/highlight/issues/6898) for fixing an issue where text was being cut off. I dug in to investigate and found it was fixed in https://github.com/highlight/highlight/pull/6936, but realized the only reason we needed the fix was because we had an unnecessary `<Text>` element wrapping the contents of the tag. This PR cleans up the markup since `Tag` already wraps the contents with `<Text>`:

https://github.com/highlight/highlight/blob/c699d1944192267691b2ef5ff5a19bb2facb3f3f/packages/ui/src/components/Tag/Tag.tsx#L72-L83

## How did you test this change?

Local click test.

## Are there any deployment considerations?

N/A - small client-side tweak.

## Does this work require review from our design team?

Nope!