### PR TITLE
Add privacy documentation link to network options

### DIFF
--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/privacy.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/privacy.md
@@ -37,6 +37,9 @@ For sensitive input fields that your team would like to ignore user input for, y
 <input class="highlight-ignore" name="social security number" />
 ```
 
+## Network Request Redaction
+Interested in redacting particular requests, responses, or the data within them? Highlight will redact certain headers out of the box, but provides a few ways to customize the redaction process to suit your specific needs and preferences. Take a look at our documentation on [Recording Network Requests and Responses](./recording-network-requests-and-responses.md) to learn more.
+
 ## Default Privacy Mode
 
 By default, Highlight will obfuscate any text or input data that matches commonly used Regex expressions and input names of personally identifiable information. This offers a base level protection from recording info such as addresses, phone numbers, social security numbers, and more. It will not obfuscate any images or media content. It is possible that other, non PII text is obfuscated if it matches the expressions for larger number, or contact information on the site. If you want to turn this off, you can set `privacySetting` to `none` when calling [`H.init()`](../../../sdk/client.md#Hinit).


### PR DESCRIPTION
## Summary
Call out the privacy settings in `Recording Network Requests and Responses` in our overall privacy document

## How did you test this change?
1. View https://highlight-landing-ar4rc84b4-highlight-run.vercel.app/docs/getting-started/client-sdk/replay-configuration/privacy#network-request-redaction

![Screenshot 2023-10-27 at 2 10 48 PM](https://github.com/highlight/highlight/assets/17744174/37274a9c-ce95-4c81-b743-d569d5a9eba0)

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
