### PR TITLE
ensure only one error is sent for the trace context manager

### DIFF
--- a/e2e/express/src/index.mjs
+++ b/e2e/express/src/index.mjs
@@ -1,16 +1,25 @@
-/* const express = require('express')
-const highlight = require('@highlight-run/node')
-const H = highlight.H */
-
 import express from 'express'
 import { H } from '@highlight-run/node'
 
 H.init({ projectID: '1' })
 
 const app = express()
-const port = 3001
+const port = 3003
 
 app.get('/', (req, res) => {
+	const err = new Error('this is a test error')
+	const highlightHeader = req.headers?.['x-highlight-request']
+	if (highlightHeader) {
+		const [secureSessionId, requestId] = highlightHeader.split('/')
+		if (secureSessionId && requestId) {
+			console.info(
+				'Sending error to highlight',
+				secureSessionId,
+				requestId,
+			)
+			H.consumeError(err, secureSessionId, requestId)
+		}
+	}
 	res.send('Hello World!')
 })
 

--- a/sdk/highlight-py/e2e/highlight_fastapi/main_2.py
+++ b/sdk/highlight-py/e2e/highlight_fastapi/main_2.py
@@ -1,0 +1,38 @@
+import asyncio
+import sys
+import highlight_io
+import uvicorn
+from fastapi import FastAPI, Request
+from highlight_io.integrations.fastapi import FastAPIMiddleware
+
+# `instrument_logging=True` sets up logging instrumentation.
+# if you do not want to send logs or are using `loguru`, pass `instrument_logging=False`
+H = highlight_io.H(
+    11983,
+    instrument_logging=False,
+    service_name="my-app",
+    service_version="git-sha",
+)
+# logger.add(H.logging_handler, level="INFO", serialize=False)
+
+app = FastAPI()
+app.add_middleware(FastAPIMiddleware)
+
+
+@app.get("/")
+async def read_root(request: Request):
+    result = 1 / 0
+    return {"Hello": "World"}
+
+
+async def main():
+    "Run scheduler and the API"
+    server = uvicorn.Server(config=uvicorn.Config(app, workers=1, loop="asyncio"))
+
+    api = asyncio.create_task(server.serve())
+
+    await asyncio.wait([api])
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -157,7 +157,9 @@ class H(object):
             yield
             return
 
-        with self.tracer.start_as_current_span("highlight-ctx", record_exception=False, set_status_on_exception=False) as span:
+        with self.tracer.start_as_current_span(
+            "highlight-ctx", record_exception=False, set_status_on_exception=False
+        ) as span:
             span.set_attributes({"highlight.project_id": self._project_id})
             span.set_attributes({"highlight.session_id": session_id})
             span.set_attributes({"highlight.trace_id": request_id})

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -157,7 +157,7 @@ class H(object):
             yield
             return
 
-        with self.tracer.start_as_current_span("highlight-ctx") as span:
+        with self.tracer.start_as_current_span("highlight-ctx", record_exception=False, set_status_on_exception=False) as span:
             span.set_attributes({"highlight.project_id": self._project_id})
             span.set_attributes({"highlight.session_id": session_id})
             span.set_attributes({"highlight.trace_id": request_id})

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.6.3"
+version = "0.6.4"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [

--- a/sdk/highlight-py/tests/test_sdk.py
+++ b/sdk/highlight-py/tests/test_sdk.py
@@ -4,7 +4,6 @@ import time
 import pytest
 from opentelemetry.sdk._logs._internal.export import BatchLogRecordProcessor
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.sdk.trace import Tracer
 
 import highlight_io
 
@@ -42,7 +41,7 @@ def test_record_exception(mocker, mock_otlp, project_id, session_id, request_id)
     h = highlight_io.H(
         project_id, integrations=integrations, instrument_logging=instrument_logging
     )
-    spy = mocker.spy(Tracer, "start_as_current_span")
+    spy = mocker.spy(h.tracer, "start_as_current_span")
 
     for i in range(10):
         logging.info(f"hey there! {i}")

--- a/sdk/highlight-py/tests/test_sdk.py
+++ b/sdk/highlight-py/tests/test_sdk.py
@@ -1,8 +1,10 @@
 import logging
+import time
 
 import pytest
 from opentelemetry.sdk._logs._internal.export import BatchLogRecordProcessor
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace import Tracer
 
 import highlight_io
 
@@ -35,11 +37,12 @@ def mock_otlp(mocker, request, integrations):
 @pytest.mark.parametrize("project_id", [None, "", "a123"])
 @pytest.mark.parametrize("session_id", ["", "a1b2c3d4e5"])
 @pytest.mark.parametrize("request_id", ["", "a123"])
-def test_record_exception(mock_otlp, project_id, session_id, request_id):
+def test_record_exception(mocker, mock_otlp, project_id, session_id, request_id):
     integrations, instrument_logging = mock_otlp
     h = highlight_io.H(
         project_id, integrations=integrations, instrument_logging=instrument_logging
     )
+    spy = mocker.spy(Tracer, "start_as_current_span")
 
     for i in range(10):
         logging.info(f"hey there! {i}")
@@ -48,6 +51,8 @@ def test_record_exception(mock_otlp, project_id, session_id, request_id):
         h.record_exception(
             FileNotFoundError(f"test! {i}"), attributes={"hello": "there"}
         )
+
+    assert len(spy.call_args_list) == 10
 
 
 def test_log_no_trace(mocker):


### PR DESCRIPTION
## Summary

Turns out the opentelemetry `self.tracer.start_as_current_span` contextmanager
already reports an exception if the inner contents raise an error. Since we want
to `raise` there to propagate the exception to the outer web framework, we
set `record_exception=False` to avoid having the opentelemetry context manager
reporting the exception event a second time (in addition to our manual time that reports custom attributes).

## How did you test this change?

Unit test
Local testing

one error recorded with fix, two duplicate errors without the fix
<img width="382" alt="Screenshot 2023-10-27 at 4 21 44 PM" src="https://github.com/highlight/highlight/assets/1351531/d624d66b-8e3b-4bde-a429-78475c1c2dad">


## Are there any deployment considerations?

New python patch version.

## Does this work require review from our design team?

No