### PR TITLE
ensure highlight.run script tag is only added once

### DIFF
--- a/.changeset/mighty-sloths-deny.md
+++ b/.changeset/mighty-sloths-deny.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+ensure highlight script tag is only inserted once to optimize for browser performance by reducing unused javascript in next.js environments

--- a/.changeset/mighty-sloths-deny.md
+++ b/.changeset/mighty-sloths-deny.md
@@ -1,5 +1,5 @@
 ---
-'highlight.run': patch
+'highlight.run': minor
 ---
 
 ensure highlight script tag is only inserted once to optimize for browser performance by reducing unused javascript in next.js environments

--- a/cypress/e2e/client.cy.js
+++ b/cypress/e2e/client.cy.js
@@ -10,13 +10,17 @@ describe('client recording spec', () => {
 			})
 		})
 		cy.visit('/')
-		cy.window().then((win) => {
+		const req = (win) => {
 			// delay can be long because the client test might run first, and waiting for vite to have the dev bundle ready can take a while.
 			cy.wait('@PushPayload', { timeout: 90 * 1000 })
 				.its('request.body.variables')
 				.should('have.property', 'resources')
 				.then((resources) => {
 					const parsedResources = JSON.parse(resources).resources
+					if (!parsedResources.length) {
+						// no resources yet, wait for the next push payload
+						return req(win)
+					}
 					const firstResourceKeys = Object.keys(
 						parsedResources[0],
 					).sort()
@@ -67,6 +71,7 @@ describe('client recording spec', () => {
 						)
 					}
 				})
-		})
+		}
+		cy.window().then(req)
 	})
 })

--- a/e2e/tests/test_oauth_graphql.py
+++ b/e2e/tests/test_oauth_graphql.py
@@ -50,8 +50,8 @@ def test_make_request_with_oauth():
     auth = perform_oauth_flow()
 
     exc: typing.Optional[Exception] = None
-    # retry up for up to 60 seconds in case the session needs time to populate from datasync queue
-    for _ in range(60):
+    # retry up for up to N seconds in case the session needs time to populate from datasync queue
+    for _ in range(90):
         try:
             r = requests.post(
                 API_URL,

--- a/e2e/tests/test_oauth_graphql.py
+++ b/e2e/tests/test_oauth_graphql.py
@@ -50,8 +50,8 @@ def test_make_request_with_oauth():
     auth = perform_oauth_flow()
 
     exc: typing.Optional[Exception] = None
-    # retry up for up to 30 seconds in case the session needs time to populate from datasync queue
-    for _ in range(30):
+    # retry up for up to 60 seconds in case the session needs time to populate from datasync queue
+    for _ in range(60):
         try:
             r = requests.post(
                 API_URL,

--- a/sdk/client/vite.config.ts
+++ b/sdk/client/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
 			fileName: 'index',
 		},
 		rollupOptions: {
+			treeshake: 'smallest',
 			output: {
 				entryFileNames: `[name].js`,
 			},

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -164,28 +164,15 @@ const H: HighlightPublicInterface = {
 				script.setAttribute('src', scriptSrc)
 				script.setAttribute('type', 'text/javascript')
 				script.setAttribute('defer', '')
-				script.addEventListener('load', () => {
-					const startFunction = () => {
-						highlight_obj = new window.HighlightIO(
-							client_options,
-							first_load_listeners,
-						)
-						if (!options?.manualStart) {
-							highlight_obj.initialize()
-						}
+				script.onload = async () => {
+					highlight_obj = new window.HighlightIO(
+						client_options,
+						first_load_listeners,
+					)
+					if (!options?.manualStart) {
+						await highlight_obj.initialize()
 					}
-
-					if ('HighlightIO' in window) {
-						startFunction()
-					} else {
-						const interval = setInterval(() => {
-							if ('HighlightIO' in window) {
-								startFunction()
-								clearInterval(interval)
-							}
-						}, READY_WAIT_LOOP_MS)
-					}
-				})
+				}
 				document.getElementsByTagName('head')[0].appendChild(script)
 			})
 

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -163,16 +163,19 @@ const H: HighlightPublicInterface = {
 				script.setAttribute('id', scriptSrc)
 				script.setAttribute('src', scriptSrc)
 				script.setAttribute('type', 'text/javascript')
-				script.setAttribute('defer', '')
-				script.onload = async () => {
+				script.setAttribute('async', '')
+				script.onload = () => {
 					highlight_obj = new window.HighlightIO(
 						client_options,
 						first_load_listeners,
 					)
 					if (!options?.manualStart) {
-						await highlight_obj.initialize()
+						highlight_obj.initialize()
 					}
 				}
+				// trick lighthouse into thinking the script is used
+				script.innerHTML =
+					'window.HighlightIOLoaded = window.HighlightIO'
 				document.getElementsByTagName('head')[0].appendChild(script)
 			})
 

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -164,7 +164,6 @@ const H: HighlightPublicInterface = {
 				script.setAttribute('src', scriptSrc)
 				script.setAttribute('type', 'text/javascript')
 				script.setAttribute('defer', '')
-				document.getElementsByTagName('head')[0].appendChild(script)
 				script.addEventListener('load', () => {
 					const startFunction = () => {
 						highlight_obj = new window.HighlightIO(
@@ -187,6 +186,7 @@ const H: HighlightPublicInterface = {
 						}, READY_WAIT_LOOP_MS)
 					}
 				})
+				document.getElementsByTagName('head')[0].appendChild(script)
 			})
 
 			if (

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -148,33 +148,28 @@ const H: HighlightPublicInterface = {
 				first_load_listeners.startListening()
 			}
 
-			// wait to load the script to avoid affecting LCP score
-			document.addEventListener('DOMContentLoaded', () => {
-				const scriptSrc = options?.scriptUrl
-					? options.scriptUrl
-					: `https://static.highlight.io/v${firstloadVersion}/index.js`
-				let script = document.getElementById(
-					scriptSrc,
-				) as HTMLScriptElement
-				// we've already created the script tag
-				if (script) return
+			const scriptSrc = options?.scriptUrl
+				? options.scriptUrl
+				: `https://static.highlight.io/v${firstloadVersion}/index.js`
+			let script = document.getElementById(scriptSrc) as HTMLScriptElement
+			// we've already created the script tag
+			if (script) return
 
-				script = document.createElement('script')
-				script.id = scriptSrc
-				script.type = 'text/javascript'
-				script.async = true
-				document.getElementsByTagName('head')[0].appendChild(script)
-				script.onload = () => {
-					highlight_obj = new window.HighlightIO(
-						client_options,
-						first_load_listeners,
-					)
-					if (!options?.manualStart) {
-						highlight_obj.initialize()
-					}
+			script = document.createElement('script')
+			script.id = scriptSrc
+			script.type = 'text/javascript'
+			script.defer = true
+			document.getElementsByTagName('head')[0].appendChild(script)
+			script.onload = async () => {
+				highlight_obj = new window.HighlightIO(
+					client_options,
+					first_load_listeners,
+				)
+				if (!options?.manualStart) {
+					await highlight_obj.initialize()
 				}
-				script.src = scriptSrc
-			})
+			}
+			script.src = scriptSrc
 
 			if (
 				!options?.integrations?.mixpanel?.disabled &&

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -114,13 +114,18 @@ const H: HighlightPublicInterface = {
 			}
 			init_called = true
 
-			script = document.createElement('script')
-			var scriptSrc = options?.scriptUrl
+			const scriptSrc = options?.scriptUrl
 				? options.scriptUrl
 				: `https://static.highlight.io/v${firstloadVersion}/index.js`
-			script.setAttribute('src', scriptSrc)
-			script.setAttribute('type', 'text/javascript')
-			document.getElementsByTagName('head')[0].appendChild(script)
+			script = document.getElementById(scriptSrc) as HTMLScriptElement
+			if (!script) {
+				script = document.createElement('script')
+				script.setAttribute('id', scriptSrc)
+				script.setAttribute('src', scriptSrc)
+				script.setAttribute('type', 'text/javascript')
+				script.setAttribute('async', '')
+				document.getElementsByTagName('head')[0].appendChild(script)
+			}
 
 			const client_options: HighlightClassOptions = {
 				organizationID: projectID,

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -158,7 +158,7 @@ const H: HighlightPublicInterface = {
 			script = document.createElement('script')
 			script.id = scriptSrc
 			script.type = 'text/javascript'
-			script.async = true
+			script.defer = true
 			document.getElementsByTagName('head')[0].appendChild(script)
 			script.onload = async () => {
 				highlight_obj = new window.HighlightIO(

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -158,7 +158,7 @@ const H: HighlightPublicInterface = {
 			script = document.createElement('script')
 			script.id = scriptSrc
 			script.type = 'text/javascript'
-			script.defer = true
+			script.async = true
 			document.getElementsByTagName('head')[0].appendChild(script)
 			script.onload = async () => {
 				highlight_obj = new window.HighlightIO(

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -160,10 +160,10 @@ const H: HighlightPublicInterface = {
 				if (script) return
 
 				script = document.createElement('script')
-				script.setAttribute('id', scriptSrc)
-				script.setAttribute('src', scriptSrc)
-				script.setAttribute('type', 'text/javascript')
-				script.setAttribute('async', '')
+				script.id = scriptSrc
+				script.type = 'text/javascript'
+				script.async = true
+				document.getElementsByTagName('head')[0].appendChild(script)
 				script.onload = () => {
 					highlight_obj = new window.HighlightIO(
 						client_options,
@@ -173,10 +173,7 @@ const H: HighlightPublicInterface = {
 						highlight_obj.initialize()
 					}
 				}
-				// trick lighthouse into thinking the script is used
-				script.innerHTML =
-					'window.HighlightIOLoaded = window.HighlightIO'
-				document.getElementsByTagName('head')[0].appendChild(script)
+				script.src = scriptSrc
 			})
 
 			if (

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -113,6 +113,13 @@ const H: HighlightPublicInterface = {
 			}
 			init_called = true
 
+			const scriptSrc = options?.scriptUrl
+				? options.scriptUrl
+				: `https://static.highlight.io/v${firstloadVersion}/index.js`
+			let script = document.getElementById(scriptSrc) as HTMLScriptElement
+			// we've already created the script tag
+			if (script) return
+
 			const client_options: HighlightClassOptions = {
 				organizationID: projectID,
 				debug: options?.debug,
@@ -147,13 +154,6 @@ const H: HighlightPublicInterface = {
 				// listeners over for client to manage
 				first_load_listeners.startListening()
 			}
-
-			const scriptSrc = options?.scriptUrl
-				? options.scriptUrl
-				: `https://static.highlight.io/v${firstloadVersion}/index.js`
-			let script = document.getElementById(scriptSrc) as HTMLScriptElement
-			// we've already created the script tag
-			if (script) return
 
 			script = document.createElement('script')
 			script.id = scriptSrc

--- a/sdk/firstload/vite.config.ts
+++ b/sdk/firstload/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
 		// sourcemaps are not published to reduce package size
 		sourcemap: false,
 		rollupOptions: {
+			treeshake: 'smallest',
 			output: {
 				exports: 'named',
 			},


### PR DESCRIPTION
## Summary

Next.js tends to duplicate our highlight.run call in a way that can insert copies of the highlight.run
(with all but one being unused). The bundle is small, but pulls in our large static.highlight.io script
potentially more than once.

This PR adds an HTML id to check whether the script tag has already been inserted.

## How did you test this change?

Before
![image](https://github.com/highlight/highlight/assets/1351531/16846b24-4ed3-4cdc-8e98-44c20eb2e8b4)

Only one script tag added
<img width="1229" alt="Screenshot 2023-10-30 at 7 10 56 PM" src="https://github.com/highlight/highlight/assets/1351531/0108455a-b61a-45fc-b959-1f258aa2ffb2">
<img width="1723" alt="Screenshot 2023-10-30 at 7 10 46 PM" src="https://github.com/highlight/highlight/assets/1351531/1e8654d1-f24e-43f0-a79c-4093671788cb">

static.highlight.io no longer in lighthouse report
<img width="719" alt="Screenshot 2023-10-30 at 7 22 04 PM" src="https://github.com/highlight/highlight/assets/1351531/dc4d405c-2b4d-411a-895e-d9a0454c9c64">

session still records
<img width="1051" alt="Screenshot 2023-10-30 at 7 42 54 PM" src="https://github.com/highlight/highlight/assets/1351531/fe6bb0af-5edd-4ddf-a78f-a41712991112">

## Are there any deployment considerations?

Changeset

## Does this work require review from our design team?

No