### PR TITLE
support custom and graduated pricing

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -245,13 +245,11 @@ type Int64Model struct {
 
 type Organization struct {
 	Model
-	Name             *string
-	StripeCustomerID *string
-	StripePriceID    *string
-	BillingEmail     *string
-	Secret           *string    `json:"-"`
-	Admins           []Admin    `gorm:"many2many:organization_admins;"`
-	TrialEndDate     *time.Time `json:"trial_end_date"`
+	Name         *string
+	BillingEmail *string
+	Secret       *string    `json:"-"`
+	Admins       []Admin    `gorm:"many2many:organization_admins;"`
+	TrialEndDate *time.Time `json:"trial_end_date"`
 	// Slack API Interaction.
 	SlackAccessToken      *string
 	SlackWebhookURL       *string
@@ -281,7 +279,6 @@ type Workspace struct {
 	MigratedFromProjectID       *int // Column can be removed after migration is done
 	HubspotCompanyID            *int
 	StripeCustomerID            *string
-	StripePriceID               *string
 	PlanTier                    string `gorm:"default:Free"`
 	UnlimitedMembers            bool   `gorm:"default:false"`
 	BillingPeriodStart          *time.Time
@@ -296,6 +293,9 @@ type Workspace struct {
 	SessionsMaxCents            *int
 	ErrorsMaxCents              *int
 	LogsMaxCents                *int
+	StripeSessionOveragePriceID *string
+	StripeErrorOveragePriceID   *string
+	StripeLogOveragePriceID     *string
 	TrialEndDate                *time.Time `json:"trial_end_date"`
 	AllowMeterOverage           bool       `gorm:"default:true"`
 	AllowedAutoJoinEmailOrigins *string    `json:"allowed_auto_join_email_origins"`
@@ -339,8 +339,6 @@ type WorkspaceAccessRequest struct {
 type Project struct {
 	Model
 	Name                *string
-	StripeCustomerID    *string
-	StripePriceID       *string
 	ZapierAccessToken   *string
 	FrontAccessToken    *string
 	FrontRefreshToken   *string

--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -443,7 +443,7 @@ func FillProducts(stripeClient *client.API, subscriptions []*stripe.Subscription
 }
 
 // Returns the Stripe Prices for the associated tier and interval
-func GetStripePrices(stripeClient *client.API, productTier backend.PlanType, interval model.PricingSubscriptionInterval, unlimitedMembers bool, retentionPeriod *backend.RetentionPeriod) (map[model.PricingProductType]*stripe.Price, error) {
+func GetStripePrices(stripeClient *client.API, workspace *model.Workspace, productTier backend.PlanType, interval model.PricingSubscriptionInterval, unlimitedMembers bool, retentionPeriod *backend.RetentionPeriod) (map[model.PricingProductType]*stripe.Price, error) {
 	// Default to the `RetentionPeriodThreeMonths` prices for customers grandfathered into 6 month retention
 	rp := backend.RetentionPeriodThreeMonths
 	if retentionPeriod != nil {
@@ -486,6 +486,21 @@ func GetStripePrices(stripeClient *client.API, productTier backend.PlanType, int
 			priceMap[model.PricingProductTypeErrors] = price
 		case logsLookupKey:
 			priceMap[model.PricingProductTypeLogs] = price
+		}
+	}
+
+	// fill values for custom price overrides
+	for product, priceID := range map[model.PricingProductType]*string{
+		model.PricingProductTypeSessions: workspace.StripeSessionOveragePriceID,
+		model.PricingProductTypeErrors:   workspace.StripeErrorOveragePriceID,
+		model.PricingProductTypeLogs:     workspace.StripeLogOveragePriceID,
+	} {
+		if priceID != nil {
+			price, err := stripeClient.Prices.Get(*priceID, &stripe.PriceParams{})
+			if err != nil {
+				return nil, err
+			}
+			priceMap[product] = price
 		}
 	}
 
@@ -576,7 +591,9 @@ func (w *Worker) reportUsage(ctx context.Context, workspaceID int, productType *
 
 	subscription := subscriptions[0]
 
-	if len(subscription.Items.Data) != 1 {
+	if len(lo.Filter(subscription.Items.Data, func(item *stripe.SubscriptionItem, _ int) bool {
+		return item.Price.Recurring.UsageType != stripe.PriceRecurringUsageTypeMetered
+	})) != 1 {
 		return e.New("STRIPE_INTEGRATION_ERROR cannot report usage - subscription has multiple products")
 	}
 	subscriptionItem := subscription.Items.Data[0]
@@ -627,7 +644,7 @@ func (w *Worker) reportUsage(ctx context.Context, workspaceID int, productType *
 		}
 	}
 
-	prices, err := GetStripePrices(w.stripeClient, *productTier, interval, workspace.UnlimitedMembers, workspace.RetentionPeriod)
+	prices, err := GetStripePrices(w.stripeClient, &workspace, *productTier, interval, workspace.UnlimitedMembers, workspace.RetentionPeriod)
 	if err != nil {
 		return e.Wrap(err, "STRIPE_INTEGRATION_ERROR cannot report usage - failed to get Stripe prices")
 	}
@@ -651,9 +668,21 @@ func (w *Worker) reportUsage(ctx context.Context, workspaceID int, productType *
 	}
 
 	invoiceLines := map[model.PricingProductType]*stripe.InvoiceLine{}
-	for _, line := range invoice.Lines.Data {
+	for _, line := range lo.FindUniquesBy(invoice.Lines.Data, func(item *stripe.InvoiceLine) string {
+		return item.InvoiceItem
+	}) {
 		productType, _, _, _, _ := GetProductMetadata(line.Price)
 		if productType != nil {
+			if invoiceLines[*productType] != nil {
+				if invoiceLines[*productType].Price.ID != prices[*productType].ID {
+					log.WithContext(ctx).Warnf("STRIPE_INTEGRATION_WARN deleting old invoice item %s for customer %s", invoiceLines[*productType].InvoiceItem, c.ID)
+					if _, err := w.stripeClient.InvoiceItems.Del(invoiceLines[*productType].InvoiceItem, &stripe.InvoiceItemParams{}); err != nil {
+						return e.Wrap(err, "STRIPE_INTEGRATION_ERROR failed to add usage record item")
+					}
+				} else {
+					return e.New(fmt.Sprintf("STRIPE_INTEGRATION_ERROR multiple invoice lines for the same product %s for customer %s", *productType, c.ID))
+				}
+			}
 			invoiceLines[*productType] = line
 		}
 	}
@@ -721,23 +750,52 @@ func AddOrUpdateOverageItem(stripeClient *client.API, workspace *model.Workspace
 		overage = meter - int64(*limit)
 	}
 
-	if invoiceLine != nil {
-		if _, err := stripeClient.InvoiceItems.Update(invoiceLine.InvoiceItem, &stripe.InvoiceItemParams{
-			Price:    &newPrice.ID,
-			Quantity: stripe.Int64(overage),
-		}); err != nil {
-			return e.Wrap(err, "STRIPE_INTEGRATION_ERROR failed to update invoice item")
+	// if the price is a metered recurring subscription, use subscription items and usage records
+	if newPrice.Recurring != nil && newPrice.Recurring.UsageType == stripe.PriceRecurringUsageTypeMetered {
+		var subscriptionItemID string
+		// if the subscription item doesn't create for this price, create it
+		if invoiceLine == nil || invoiceLine.SubscriptionItem == "" {
+			params := &stripe.SubscriptionItemParams{
+				Subscription: &subscription.ID,
+				Price:        &newPrice.ID,
+			}
+			params.SetIdempotencyKey(subscription.ID + ":" + newPrice.ID + ":item")
+			subscriptionItem, err := stripeClient.SubscriptionItems.New(params)
+			if err != nil {
+				return e.Wrap(err, "STRIPE_INTEGRATION_ERROR failed to add invoice item for usage record item")
+			}
+			subscriptionItemID = subscriptionItem.ID
+		} else {
+			subscriptionItemID = invoiceLine.SubscriptionItem
+		}
+		// set the usage for this product, replacing existing values
+		params := &stripe.UsageRecordParams{
+			SubscriptionItem: stripe.String(subscriptionItemID),
+			Action:           stripe.String("set"),
+			Quantity:         stripe.Int64(overage),
+		}
+		if _, err := stripeClient.UsageRecords.New(params); err != nil {
+			return e.Wrap(err, "STRIPE_INTEGRATION_ERROR failed to add usage record item")
 		}
 	} else {
-		params := &stripe.InvoiceItemParams{
-			Customer:     &customer.ID,
-			Subscription: &subscription.ID,
-			Price:        &newPrice.ID,
-			Quantity:     stripe.Int64(overage),
-		}
-		params.SetIdempotencyKey(customer.ID + ":" + subscription.ID + ":" + newPrice.ID)
-		if _, err := stripeClient.InvoiceItems.New(params); err != nil {
-			return e.Wrap(err, "STRIPE_INTEGRATION_ERROR failed to add invoice item")
+		if invoiceLine != nil {
+			if _, err := stripeClient.InvoiceItems.Update(invoiceLine.InvoiceItem, &stripe.InvoiceItemParams{
+				Price:    &newPrice.ID,
+				Quantity: stripe.Int64(overage),
+			}); err != nil {
+				return e.Wrap(err, "STRIPE_INTEGRATION_ERROR failed to update invoice item")
+			}
+		} else {
+			params := &stripe.InvoiceItemParams{
+				Customer:     &customer.ID,
+				Subscription: &subscription.ID,
+				Price:        &newPrice.ID,
+				Quantity:     stripe.Int64(overage),
+			}
+			params.SetIdempotencyKey(customer.ID + ":" + subscription.ID + ":" + newPrice.ID)
+			if _, err := stripeClient.InvoiceItems.New(params); err != nil {
+				return e.Wrap(err, "STRIPE_INTEGRATION_ERROR failed to add invoice item")
+			}
 		}
 	}
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1235,7 +1235,7 @@ func (r *mutationResolver) CreateOrUpdateStripeSubscription(ctx context.Context,
 	}
 
 	// default to unlimited members pricing
-	prices, err := pricing.GetStripePrices(r.StripeClient, planType, pricingInterval, true, &retentionPeriod)
+	prices, err := pricing.GetStripePrices(r.StripeClient, workspace, planType, pricingInterval, true, &retentionPeriod)
 	if err != nil {
 		return nil, e.Wrap(err, "STRIPE_INTEGRATION_ERROR cannot update stripe subscription - failed to get Stripe prices")
 	}

--- a/scripts/migrations/init.sql
+++ b/scripts/migrations/init.sql
@@ -1,19 +1,19 @@
 INSERT INTO workspaces (id, created_at, updated_at, deleted_at, name, secret, slack_access_token, slack_webhook_url,
                         slack_webhook_channel, slack_webhook_channel_id, slack_channels, linear_access_token,
-                        migrated_from_project_id, hubspot_company_id, stripe_customer_id, stripe_price_id, plan_tier,
+                        migrated_from_project_id, hubspot_company_id, stripe_customer_id, plan_tier,
                         unlimited_members, billing_period_start, billing_period_end, next_invoice_date,
                         monthly_session_limit, monthly_members_limit, trial_end_date, allow_meter_overage,
                         allowed_auto_join_email_origins, eligible_for_trial_extension, trial_extension_enabled,
                         clearbit_enabled)
 VALUES (1, '2022-09-13 01:22:33.433339 +00:00', '2022-09-13 01:22:33.934553 +00:00', null, 'w1', 'asdf',
-        null, null, null, null, null, null, null, null, 'cus_a1b2c3d4', null, 'Free', false, null, null, null,
+        null, null, null, null, null, null, null, null, 'cus_a1b2c3d4', 'Free', false, null, null, null,
         null, null, '2022-09-27 01:22:33.433245 +00:00', false, null, true, false, false);
 
-INSERT INTO projects (id, created_at, updated_at, deleted_at, name, stripe_customer_id, stripe_price_id,
+INSERT INTO projects (id, created_at, updated_at, deleted_at, name,
                       zapier_access_token, billing_email, secret, trial_end_date, monthly_session_limit, workspace_id,
                       free_tier, excluded_users, error_json_paths, backend_setup,
                       rage_click_window_seconds, rage_click_radius_pixels, rage_click_count)
-VALUES (1, '2022-09-13 01:22:35.758964 +00:00', '2022-09-14 05:00:53.763444 +00:00', null, 'p1', null, null, null,
+VALUES (1, '2022-09-13 01:22:35.758964 +00:00', '2022-09-14 05:00:53.763444 +00:00', null, 'p1', null,
         'swag@highlight.run', 'ccftmmv6i1e1m780kh20', null, null, 1, false, null, null,
         true, 5, 8, 5);
 


### PR DESCRIPTION
## Summary

Adds support for custom overage price IDs that will be used when attaching
overage invoice items. Can work alongside the existing pricing model or can replace
existing default prices.

* new workspace model columns allow setting a custom overage price id
* the billing logic now supports metered prices (recurring prices) that are usage-billed.

Closes #6381

## How did you test this change?

![Screenshot from 2023-10-31 13-35-42](https://github.com/highlight/highlight/assets/1351531/ce58db33-3d09-49cb-bb65-df846bc300c9)

tested on a stripe subscription that previously had a default non-graduated invoice item for sessions to make sure the new path will remove the existing invoice item.

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No