### PR TITLE
Fix alert welcome message

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -2779,7 +2779,7 @@ func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, 
 		ID:                   newAlert.ID,
 		Project:              project,
 		IncludeEditLink:      true,
-		URLSlug:              "alerts",
+		URLSlug:              "alerts/errors",
 	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
@@ -2875,7 +2875,7 @@ func (r *mutationResolver) UpdateErrorAlert(ctx context.Context, projectID int, 
 		ID:                   errorAlertID,
 		Project:              project,
 		IncludeEditLink:      true,
-		URLSlug:              "alerts",
+		URLSlug:              "alerts/errors",
 	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
@@ -2908,7 +2908,7 @@ func (r *mutationResolver) DeleteErrorAlert(ctx context.Context, projectID int, 
 		ID:                   errorAlertID,
 		Project:              project,
 		IncludeEditLink:      false,
-		URLSlug:              "alerts",
+		URLSlug:              "alerts/errors",
 	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
@@ -3051,7 +3051,7 @@ func (r *mutationResolver) UpdateSessionAlert(ctx context.Context, id int, input
 		ID:                   id,
 		Project:              project,
 		IncludeEditLink:      true,
-		URLSlug:              "alerts",
+		URLSlug:              "alerts/session",
 	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
@@ -3084,7 +3084,7 @@ func (r *mutationResolver) CreateSessionAlert(ctx context.Context, input modelIn
 		ID:                   sessionAlert.ID,
 		Project:              project,
 		IncludeEditLink:      true,
-		URLSlug:              "alerts",
+		URLSlug:              "alerts/session",
 	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
@@ -3118,7 +3118,7 @@ func (r *mutationResolver) DeleteSessionAlert(ctx context.Context, projectID int
 		ID:                   sessionAlertID,
 		Project:              project,
 		IncludeEditLink:      false,
-		URLSlug:              "alerts",
+		URLSlug:              "alerts/session",
 	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}
@@ -3232,7 +3232,7 @@ func (r *mutationResolver) DeleteLogAlert(ctx context.Context, projectID int, id
 		ID:                   id,
 		Project:              project,
 		IncludeEditLink:      false,
-		URLSlug:              "alerts",
+		URLSlug:              "alerts/logs",
 	}); err != nil {
 		log.WithContext(ctx).Error(err)
 	}


### PR DESCRIPTION
## Summary
"Welcome" messages are sent when an alert is created/updated/deleted to let the Slack message know to expect messages to start or stop receiving messages. These include a link to the alert, which is some cases was broken due to a bad slug. Update the slugs of the alerts to fix the links.

## How did you test this change?
1) Create an error alert that is sent to a slack channel
- [ ] Slack channel receives a welcome message with a valid link to the alert
2) Update the error alert
- [ ] Slack channel receives a welcome message with a valid link to the alert
3) Delete the error alert
- [ ] Slack channel receives a welcome message with NO link
4) Create an session alert that is sent to a slack channel
- [ ] Slack channel receives a welcome message with a valid link to the alert
5) Update the session alert
- [ ] Slack channel receives a welcome message with a valid link to the alert
6) Delete the session alert
- [ ] Slack channel receives a welcome message with NO link


https://www.loom.com/share/d8b3c2a711674faeb72f3021cc023098?sid=935c013d-0ebf-4a0a-b593-b68c24439572

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
