### PR TITLE
fix node sdk timeouts

### DIFF
--- a/.changeset/mighty-suns-grow.md
+++ b/.changeset/mighty-suns-grow.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': patch
+---
+
+ensure that console methods record structured attributes on logs

--- a/.changeset/serious-cooks-bathe.md
+++ b/.changeset/serious-cooks-bathe.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': patch
+---
+
+make object stringification more robust to prevent recursion errors

--- a/.changeset/stale-zebras-switch.md
+++ b/.changeset/stale-zebras-switch.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': patch
+---
+
+bundle all dependencies into @highlight-run/node

--- a/.changeset/thick-papayas-confess.md
+++ b/.changeset/thick-papayas-confess.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': patch
+---
+
+ensure opentelemetry export does not time out

--- a/e2e/express/src/index.mjs
+++ b/e2e/express/src/index.mjs
@@ -1,7 +1,7 @@
 import express from 'express'
 import { H } from '@highlight-run/node'
 
-H.init({ projectID: '1' })
+H.init({ projectID: '1', debug: true, serviceName: 'e2e-express' })
 
 const app = express()
 const port = 3003

--- a/e2e/express/src/index.mjs
+++ b/e2e/express/src/index.mjs
@@ -23,6 +23,17 @@ app.get('/', (req, res) => {
 	res.send('Hello World!')
 })
 
+app.get('/good', (req, res) => {
+	console.warn('doing some heavy work!')
+	let result = 0
+	for (let i = 0; i < 1000; i++) {
+		const value = Math.random() * 1000
+		result += value
+		console.info('some work happening', { result, value })
+	}
+	res.send('yay!')
+})
+
 app.listen(port, () => {
 	console.log(`Example app listening on port ${port}`)
 })

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -19,6 +19,9 @@
 		"access": "public"
 	},
 	"dependencies": {
+		"highlight.run": "workspace:*"
+	},
+	"devDependencies": {
 		"@opentelemetry/api": "^1.6.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.39.2",
 		"@opentelemetry/core": "^1.17.1",
@@ -27,10 +30,6 @@
 		"@opentelemetry/sdk-node": "^0.44.0",
 		"@opentelemetry/sdk-trace-base": "^1.17.1",
 		"@opentelemetry/semantic-conventions": "^1.17.1",
-		"highlight.run": "workspace:*"
-	},
-	"devDependencies": {
-		"@opentelemetry/exporter-jaeger": "^1.17.1",
 		"@rollup/plugin-commonjs": "^25.0.7",
 		"@rollup/plugin-json": "^6.0.1",
 		"@rollup/plugin-node-resolve": "^15.2.3",

--- a/sdk/highlight-node/rollup.config.js
+++ b/sdk/highlight-node/rollup.config.js
@@ -4,6 +4,7 @@ import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
 import terser from '@rollup/plugin-terser'
 
+/** @type {import('rollup').RollupOptions} */
 const config = {
 	input: 'src/index.ts',
 	context: 'global',
@@ -13,7 +14,10 @@ const config = {
 			// required for @opentelemetry/resources which pretends to be an ESM build while using dynamic `require()`
 			transformMixedEsModules: true,
 		}),
-		resolve(),
+		resolve({
+			browser: false,
+			preferBuiltins: true,
+		}),
 		typescript(),
 		terser(),
 	],
@@ -31,6 +35,7 @@ const config = {
 			exports: 'named',
 		},
 	],
+	treeshake: 'smallest',
 }
 
 export default config

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -69,7 +69,15 @@ export class Highlight {
 
 		if (!options.disableConsoleRecording) {
 			hookConsole(options.consoleMethodsToRecord, (c) => {
-				this.log(c.date, c.message, c.level, c.stack)
+				this.log(
+					c.date,
+					c.message,
+					c.level,
+					c.stack,
+					undefined,
+					undefined,
+					c.attributes,
+				)
 			})
 		}
 

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -4,6 +4,7 @@ import type { Attributes, Tracer } from '@opentelemetry/api'
 import { trace } from '@opentelemetry/api'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto'
+import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base'
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 import { processDetectorSync, Resource } from '@opentelemetry/resources'
@@ -50,8 +51,7 @@ class CustomSpanProcessor extends BatchSpanProcessorBase<BufferConfig> {
 }
 
 export class Highlight {
-	readonly FLUSH_TIMEOUT = 10
-	_intervalFunction: ReturnType<typeof setInterval>
+	readonly FLUSH_TIMEOUT_MS = 30 * 1000
 	_projectID: string
 	_debug: boolean
 	otel: NodeSDK
@@ -61,28 +61,42 @@ export class Highlight {
 	constructor(options: NodeOptions) {
 		this._debug = !!options.debug
 		this._projectID = options.projectID
-		if (!options.disableConsoleRecording) {
-			hookConsole(options.consoleMethodsToRecord, (c) => {
-				this.log(c.date, c.message, c.level, c.stack)
-			})
-		}
-
 		if (!this._projectID) {
 			console.warn(
 				'Highlight project id was not provided. Data will not be recorded.',
 			)
 		}
 
+		if (!options.disableConsoleRecording) {
+			hookConsole(options.consoleMethodsToRecord, (c) => {
+				this.log(c.date, c.message, c.level, c.stack)
+			})
+		}
+
 		this.tracer = trace.getTracer('highlight-node')
 
-		const exporter = new OTLPTraceExporter({
+		const config = {
 			url: `${options.otlpEndpoint ?? OTLP_HTTP}/v1/traces`,
-		})
+			compression:
+				!process.env.NEXT_RUNTIME ||
+				process.env.NEXT_RUNTIME === 'nodejs'
+					? CompressionAlgorithm.GZIP
+					: undefined,
+			keepAlive: true,
+			timeoutMillis: this.FLUSH_TIMEOUT_MS,
+			httpAgentOptions: {
+				timeout: this.FLUSH_TIMEOUT_MS,
+				keepAlive: true,
+			},
+		}
+		this._log('using otlp exporter settings', config)
+		const exporter = new OTLPTraceExporter(config)
 
 		this.processor = new CustomSpanProcessor(exporter, {
 			scheduledDelayMillis: 1000,
 			maxExportBatchSize: 128,
 			maxQueueSize: 1024,
+			exportTimeoutMillis: this.FLUSH_TIMEOUT_MS,
 		})
 
 		const attributes: Attributes = {}
@@ -121,11 +135,6 @@ export class Highlight {
 		})
 		this.otel.start()
 
-		this._intervalFunction = setInterval(
-			() => this.flush(),
-			this.FLUSH_TIMEOUT * 1000,
-		)
-
 		for (const event of [
 			'beforeExit',
 			'exit',
@@ -159,9 +168,6 @@ export class Highlight {
 	async stop() {
 		await this.flush()
 		await this.otel.shutdown()
-		if (this._intervalFunction) {
-			clearInterval(this._intervalFunction)
-		}
 	}
 
 	_log(...data: any[]) {
@@ -259,9 +265,11 @@ export class Highlight {
 	}
 
 	async flush() {
-		await this.processor
-			.forceFlush()
-			.catch((e) => console.warn('highlight-node failed to flush: ', e))
+		try {
+			await this.processor.forceFlush()
+		} catch (e) {
+			this._log('failed to flush: ', e)
+		}
 	}
 
 	async waitForFlush() {

--- a/sdk/highlight-node/src/hooks.ts
+++ b/sdk/highlight-node/src/hooks.ts
@@ -36,6 +36,7 @@ interface ConsolePayload {
 	level: keyof typeof ConsoleLevels
 	message: string
 	stack: object
+	attributes?: { [key: string]: any }
 }
 
 type ConsoleFn = (...data: any) => void
@@ -103,6 +104,10 @@ export function hookConsole(
 							typeof o === 'object' ? safeStringify(o) : o,
 						)
 						.join(' '),
+					attributes: data
+						.slice(1)
+						.filter((d) => typeof d === 'object')
+						.reduce((a, b) => ({ ...a, ...b }), {}),
 					stack: o.stack,
 				})
 			}

--- a/sdk/highlight-node/src/hooks.ts
+++ b/sdk/highlight-node/src/hooks.ts
@@ -1,5 +1,8 @@
 // inspired by https://github.com/getsentry/sentry-javascript/issues/5639
 
+// https://stackoverflow.com/a/2805230
+const MAX_RECURSION = 128
+
 export function hookOutput(
 	writer: 'stdout' | 'stderr',
 	callback: (buffer: string) => void,
@@ -40,11 +43,14 @@ type ConsoleFn = (...data: any) => void
 let consoleHooked = false
 
 export function safeStringify(obj: any): string {
-	function replacer(input: any): any {
+	function replacer(input: any, depth?: number): any {
+		if ((depth ?? 0) > MAX_RECURSION) {
+			throw new Error('max recursion exceeded')
+		}
 		if (input && typeof input === 'object') {
 			for (let k in input) {
 				if (typeof input[k] === 'object') {
-					replacer(input[k])
+					replacer(input[k], (depth ?? 0) + 1)
 				} else if (!canStringify(input[k])) {
 					input[k] = input[k].toString()
 				}
@@ -62,7 +68,11 @@ export function safeStringify(obj: any): string {
 		}
 	}
 
-	return JSON.stringify(replacer(obj))
+	try {
+		return JSON.stringify(replacer(obj))
+	} catch (e) {
+		return obj.toString()
+	}
 }
 
 export function hookConsole(

--- a/yarn.lock
+++ b/yarn.lock
@@ -12824,7 +12824,6 @@ __metadata:
     "@opentelemetry/api": ^1.6.0
     "@opentelemetry/auto-instrumentations-node": ^0.39.2
     "@opentelemetry/core": ^1.17.1
-    "@opentelemetry/exporter-jaeger": ^1.17.1
     "@opentelemetry/exporter-trace-otlp-proto": ^0.44.0
     "@opentelemetry/resources": ^1.17.1
     "@opentelemetry/sdk-node": ^0.44.0


### PR DESCRIPTION
## Summary

Our node SDK was throwing red-herring errors while shipping logs / traces because of
the interval flush logic. This logic was not needed as OTEL has it's own loop for flushing data.

* fixes recursion error during stringification of certain objects #6839 
* ensures console attributes are correctly reported correctly as structured attributes
* ensures we fully rely on bundling opentelemetry to help with #7010

Closes #6987

## How did you test this change?

tested locally by ingesting a network latency `tc qdisc add dev lo root netem delay 10000ms`

before
![Screenshot from 2023-10-31 14-25-11](https://github.com/highlight/highlight/assets/1351531/a2a83099-2399-423e-8aec-2ddc9886a307)

after
![Screenshot from 2023-10-31 14-29-55](https://github.com/highlight/highlight/assets/1351531/f2437944-2747-44fd-9c76-de9ee5636ab0)

Logs coming through correctly locally

![Screenshot from 2023-10-31 16-03-25](https://github.com/highlight/highlight/assets/1351531/b91ff3d2-7f16-48b7-b363-2df4df9bf1be)

tested in next js edge runtime as well

## Are there any deployment considerations?

No

## Does this work require review from our design team?

Changeset
