### PR TITLE
use content type setting when saving s3 asset

### DIFF
--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -894,6 +894,7 @@ func (s *S3Client) UploadAsset(ctx context.Context, uuid string, contentType str
 		Metadata: map[string]string{
 			"Content-Type": contentType,
 		},
+		ContentType: pointy.String(contentType),
 	}, s3.WithAPIOptions(
 		v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware,
 	))


### PR DESCRIPTION
## Summary
- `PutObjectInput` has a `ContentType` field - set this when saving session resources
- fixes #6658 
- fixes #6924 
https://www.loom.com/share/9c64f110b40440b89814451765fb57da
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally w/ S3 object storage
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
