### PR TITLE
node.js should associate console logs with session context

### DIFF
--- a/.changeset/fuzzy-rules-press.md
+++ b/.changeset/fuzzy-rules-press.md
@@ -1,0 +1,8 @@
+---
+'@highlight-run/apollo': minor
+'@highlight-run/nest': minor
+'@highlight-run/next': minor
+'@highlight-run/node': minor
+---
+
+Support highlight request context globally to associate async console logs / errors with highlight sessions.

--- a/highlight.io/components/Home/SnippetTab/SnippetTab.tsx
+++ b/highlight.io/components/Home/SnippetTab/SnippetTab.tsx
@@ -202,8 +202,11 @@ func main() {
 const app = express();
 
 const highlightOptions = {projectID: '<YOUR_PROJECT_ID>'};
+const highlightMiddleware = Handlers.middleware(highlightOptions);
 const highlightHandler = Handlers.errorHandler(highlightOptions);
 
+// This should be before any other error middleware and after all controllers
+app.use(highlightMiddleware);
 // This should be before any other error middleware and after all controllers
 app.use(highlightHandler);`}
 					/>

--- a/sdk/highlight-apollo/src/apollo.ts
+++ b/sdk/highlight-apollo/src/apollo.ts
@@ -4,31 +4,29 @@ import type {
 	GraphQLRequestContextDidEncounterErrors,
 	GraphQLRequestListener,
 } from '@apollo/server'
-import { H, HIGHLIGHT_REQUEST_HEADER } from '@highlight-run/node'
 import type { NodeOptions } from '@highlight-run/node'
+import { H } from '@highlight-run/node'
+import { IncomingHttpHeaders } from 'http'
 
 export const ApolloServerHighlightPlugin = function <T extends BaseContext>(
 	options: NodeOptions,
 ): ApolloServerPlugin<T> {
 	return {
 		async requestDidStart(req): Promise<GraphQLRequestListener<T> | void> {
-			let secureSessionId: string | undefined
-			let requestId: string | undefined
-			if (req.request.http?.headers?.get(HIGHLIGHT_REQUEST_HEADER)) {
-				;[secureSessionId, requestId] =
-					`${req.request.http.headers?.get(
-						HIGHLIGHT_REQUEST_HEADER,
-					)}`.split('/')
+			if (!H.isInitialized()) {
+				H.init(options)
+				H._debug('initialized H in apollo server')
 			}
+
+			const headers: IncomingHttpHeaders = {}
+			req.request.http?.headers?.forEach((k, v) => (headers[k] = v))
+			const { secureSessionId, requestId } = H.parseHeaders(headers)
 			H._debug('processError', 'extracted from headers', {
 				secureSessionId,
 				requestId,
 			})
 
-			if (!H.isInitialized()) {
-				H.init(options)
-				H._debug('initialized H in apollo server')
-			}
+			H.setHeaders({ secureSessionId, requestId })
 			return {
 				async didEncounterErrors(
 					requestContext: GraphQLRequestContextDidEncounterErrors<T>,

--- a/sdk/highlight-nest/src/index.ts
+++ b/sdk/highlight-nest/src/index.ts
@@ -98,17 +98,18 @@ export class HighlightInterceptor
 		const ctx = context.switchToHttp()
 		const request = ctx.getRequest()
 		const highlightCtx = NodeH.parseHeaders(request.headers)
-
-		return next.handle().pipe(
-			catchError((err) => {
-				NodeH.consumeError(
-					err,
-					highlightCtx?.secureSessionId,
-					highlightCtx?.requestId,
-				)
-				return throwError(() => err)
-			}),
-		)
+		return NodeH.runWithHeaders(highlightCtx, () => {
+			return next.handle().pipe(
+				catchError((err) => {
+					NodeH.consumeError(
+						err,
+						highlightCtx?.secureSessionId,
+						highlightCtx?.requestId,
+					)
+					return throwError(() => err)
+				}),
+			)
+		})
 	}
 }
 

--- a/sdk/highlight-next/src/util/highlight-edge.ts
+++ b/sdk/highlight-next/src/util/highlight-edge.ts
@@ -6,13 +6,13 @@ import {
 import type { NodeOptions } from '@highlight-run/node'
 import {
 	ExtendedExecutionContext,
+	HIGHLIGHT_REQUEST_HEADER,
 	HighlightGlobal,
 	HighlightInterface,
 	Metric,
 	RequestMetadata,
 } from './types'
 import { IncomingHttpHeaders } from 'http'
-import { HIGHLIGHT_REQUEST_HEADER } from '@highlight-run/node/src'
 
 export type HighlightEnv = NodeOptions
 

--- a/sdk/highlight-next/src/util/highlight-edge.ts
+++ b/sdk/highlight-next/src/util/highlight-edge.ts
@@ -6,10 +6,13 @@ import {
 import type { NodeOptions } from '@highlight-run/node'
 import {
 	ExtendedExecutionContext,
+	HighlightGlobal,
 	HighlightInterface,
 	Metric,
 	RequestMetadata,
 } from './types'
+import { IncomingHttpHeaders } from 'http'
+import { HIGHLIGHT_REQUEST_HEADER } from '@highlight-run/node/src'
 
 export type HighlightEnv = NodeOptions
 
@@ -102,6 +105,38 @@ export const H: HighlightInterface = {
 			requestId,
 			tags,
 		})
+	},
+	parseHeaders(headers: IncomingHttpHeaders): {
+		secureSessionId: string | undefined
+		requestId: string | undefined
+	} {
+		const highlightCtx = (global as typeof globalThis & HighlightGlobal)
+			.__HIGHLIGHT__
+		if (highlightCtx?.secureSessionId && highlightCtx?.requestId) {
+			return highlightCtx
+		}
+		if (headers && headers[HIGHLIGHT_REQUEST_HEADER]) {
+			const [secureSessionId, requestId] =
+				`${headers[HIGHLIGHT_REQUEST_HEADER]}`.split('/')
+			return { secureSessionId, requestId }
+		}
+		return { secureSessionId: undefined, requestId: undefined }
+	},
+	runWithHeaders<T>(headers: IncomingHttpHeaders, cb: () => T) {
+		const highlightCtx = this.parseHeaders(headers)
+		if (highlightCtx) {
+			const { secureSessionId, requestId } = highlightCtx
+			if (secureSessionId && requestId) {
+				// set the global __HIGHLIGHT__ variables before running the handler, so that
+				// the values are available in the handler
+				;(global as typeof globalThis & HighlightGlobal).__HIGHLIGHT__ =
+					{
+						secureSessionId,
+						requestId,
+					}
+			}
+		}
+		return cb()
 	},
 }
 

--- a/sdk/highlight-next/src/util/types.ts
+++ b/sdk/highlight-next/src/util/types.ts
@@ -3,6 +3,7 @@ import type { ResourceAttributes } from '@opentelemetry/resources/build/src/type
 import type { ExecutionContext } from '@cloudflare/workers-types'
 import type { WorkersSDK } from '@highlight-run/opentelemetry-sdk-workers'
 import type { Attributes } from '@opentelemetry/api'
+import { IncomingHttpHeaders } from 'http'
 
 export type HighlightEnv = NodeOptions
 
@@ -37,6 +38,11 @@ export interface HighlightInterface {
 	) => WorkersSDK
 	isInitialized: () => boolean
 	metrics: (metrics: Metric[]) => void
+	parseHeaders: (headers: IncomingHttpHeaders) => {
+		secureSessionId: string | undefined
+		requestId: string | undefined
+	}
+	runWithHeaders: <T>(headers: IncomingHttpHeaders, cb: () => T) => T
 	consumeError: (
 		error: Error,
 		secureSessionId?: string,

--- a/sdk/highlight-next/src/util/with-highlight-edge.ts
+++ b/sdk/highlight-next/src/util/with-highlight-edge.ts
@@ -1,7 +1,8 @@
 import { H } from './highlight-edge'
 import type { NodeOptions } from '@highlight-run/node'
-import type { NextFetchEvent, NextRequest, NextResponse } from 'next/server'
+import type { NextFetchEvent, NextRequest } from 'next/server'
 import { ExtendedExecutionContext } from './types'
+import { IncomingHttpHeaders } from 'http'
 
 export type HighlightEnv = NodeOptions
 
@@ -17,16 +18,21 @@ export function Highlight(env: HighlightEnv) {
 			event: NextFetchEvent & ExtendedExecutionContext,
 		) {
 			H.initEdge(request, env, event)
+			const headers: IncomingHttpHeaders = {}
+			request.headers.forEach((k, v) => (headers[k] = v))
 
 			try {
-				const response = await handler(request, event)
+				const response = await H.runWithHeaders(headers, async () => {
+					return await handler(request, event)
+				})
 
 				H.sendResponse(response)
 
 				return response
 			} catch (error) {
+				const { secureSessionId, requestId } = H.parseHeaders(headers)
 				if (error instanceof Error) {
-					H.consumeError(error)
+					H.consumeError(error, secureSessionId, requestId)
 				}
 
 				/**

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -327,7 +327,6 @@ export class Highlight {
 		return this.otel.addResource(new Resource(attributes))
 	}
 
-	// TODO(vkorolik) look for usage elsewhere and use runWithHeaders
 	parseHeaders(headers: IncomingHttpHeaders): {
 		secureSessionId: string | undefined
 		requestId: string | undefined

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -8,12 +8,15 @@ import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base'
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 import { processDetectorSync, Resource } from '@opentelemetry/resources'
+import { AsyncLocalStorage } from 'node:async_hooks'
 
 import { clearInterval } from 'timers'
 
 import { NodeOptions } from './types'
 import { hookConsole } from './hooks'
 import log from './log'
+import { IncomingHttpHeaders } from 'http'
+import { HIGHLIGHT_REQUEST_HEADER } from './sdk'
 
 const OTLP_HTTP = 'https://otel.highlight.io:4318'
 
@@ -57,6 +60,10 @@ export class Highlight {
 	otel: NodeSDK
 	private tracer: Tracer
 	private processor: CustomSpanProcessor
+	private asyncLocalStorage = new AsyncLocalStorage<{
+		secureSessionId: string
+		requestId: string
+	}>()
 
 	constructor(options: NodeOptions) {
 		this._debug = !!options.debug
@@ -69,13 +76,17 @@ export class Highlight {
 
 		if (!options.disableConsoleRecording) {
 			hookConsole(options.consoleMethodsToRecord, (c) => {
+				const { secureSessionId, requestId } = this.parseHeaders(
+					// look for the context in asyncLocalStorage only
+					{},
+				) ?? { secureSessionId: undefined, requestId: undefined }
 				this.log(
 					c.date,
 					c.message,
 					c.level,
 					c.stack,
-					undefined,
-					undefined,
+					secureSessionId,
+					requestId,
 					c.attributes,
 				)
 			})
@@ -314,5 +325,33 @@ export class Highlight {
 
 	setAttributes(attributes: Attributes) {
 		return this.otel.addResource(new Resource(attributes))
+	}
+
+	parseHeaders(
+		headers: IncomingHttpHeaders,
+	): { secureSessionId: string; requestId: string } | undefined {
+		try {
+			const highlightCtx = this.asyncLocalStorage.getStore()
+			if (highlightCtx) {
+				return highlightCtx
+			}
+			if (headers && headers[HIGHLIGHT_REQUEST_HEADER]) {
+				const [secureSessionId, requestId] =
+					`${headers[HIGHLIGHT_REQUEST_HEADER]}`.split('/')
+				return { secureSessionId, requestId }
+			}
+		} catch (e) {
+			this._log('parseHeaders error: ', e)
+		}
+		return undefined
+	}
+
+	runWithHeaders<T>(headers: IncomingHttpHeaders, cb: () => T) {
+		const highlightCtx = this.parseHeaders(headers)
+		if (highlightCtx) {
+			return this.asyncLocalStorage.run(highlightCtx, cb)
+		} else {
+			return cb()
+		}
 	}
 }

--- a/sdk/highlight-node/src/handlers.ts
+++ b/sdk/highlight-node/src/handlers.ts
@@ -2,6 +2,7 @@ import * as http from 'http'
 import { NodeOptions } from '.'
 import { H } from './sdk.js'
 import type { Attributes } from '@opentelemetry/api'
+import { IncomingHttpHeaders } from 'http'
 
 /** JSDoc */
 interface MiddlewareError extends Error {
@@ -19,18 +20,17 @@ function processErrorImpl(
 	error: Error,
 	metadata?: Attributes,
 ): void {
-	const { secureSessionId, requestId } = H.parseHeaders(
-		req.headers ?? {},
-	) ?? { secureSessionId: undefined, requestId: undefined }
+	if (!H.isInitialized()) {
+		H.init(options)
+		H._debug('initialized H')
+	}
+
+	const { secureSessionId, requestId } = H.parseHeaders(req.headers ?? {})
 	H._debug('processError', 'extracted from headers', {
 		secureSessionId,
 		requestId,
 	})
 
-	if (!H.isInitialized()) {
-		H.init(options)
-		H._debug('initialized H')
-	}
 	H.consumeError(error, secureSessionId, requestId, metadata)
 	H._debug('consumed error', error)
 }
@@ -125,20 +125,24 @@ const makeHandler = (
 	headersExtractor: (...args: any) => Headers | undefined,
 ) => {
 	return async (...args: any) => {
+		if (!H.isInitialized()) {
+			H.init(options)
+		}
+		const headers: IncomingHttpHeaders = {}
+		const h = headersExtractor(args)
+		if (h) {
+			for (const [k, v] of Object.entries(h)) {
+				headers[k] = v
+			}
+		}
 		try {
-			return await origHandler(...args)
+			return await H.runWithHeaders(headers, async () => {
+				return await origHandler(...args)
+			})
 		} catch (e) {
 			try {
 				if (e instanceof Error) {
-					if (!H.isInitialized()) {
-						H.init(options)
-					}
-					processErrorImpl(
-						options,
-						{ headers: headersExtractor(args) },
-						e,
-						metadata,
-					)
+					processErrorImpl(options, { headers }, e, metadata)
 					await H.flush()
 				}
 			} catch (e) {

--- a/sdk/highlight-node/src/sdk.test.ts
+++ b/sdk/highlight-node/src/sdk.test.ts
@@ -10,7 +10,10 @@ describe('parseHeaders', () => {
 	})
 
 	it('returns undefined if headers is empty', async () => {
-		expect(H.parseHeaders({})).toBeUndefined()
+		expect(H.parseHeaders({})).toMatchObject({
+			secureSessionId: undefined,
+			requestId: undefined,
+		})
 	})
 
 	it('returns session if request is invalid', async () => {

--- a/sdk/highlight-node/src/sdk.test.ts
+++ b/sdk/highlight-node/src/sdk.test.ts
@@ -1,6 +1,8 @@
 import { H, HIGHLIGHT_REQUEST_HEADER } from './sdk.js'
 
 describe('parseHeaders', () => {
+	H.init({ projectID: '1' })
+
 	it('returns session id and request id from the headers', () => {
 		expect(
 			H.parseHeaders({ [HIGHLIGHT_REQUEST_HEADER]: '1234/5678' }),

--- a/sdk/highlight-node/src/sdk.ts
+++ b/sdk/highlight-node/src/sdk.ts
@@ -11,9 +11,14 @@ export interface HighlightInterface {
 	init: (options: NodeOptions) => void
 	stop: () => Promise<void>
 	isInitialized: () => boolean
-	parseHeaders: (
-		headers: IncomingHttpHeaders,
-	) => { secureSessionId: string; requestId: string } | undefined
+	// Use parseHeaders to extract the headers from the current context or from the headers.
+	parseHeaders: (headers: IncomingHttpHeaders) => {
+		secureSessionId: string | undefined
+		requestId: string | undefined
+	}
+	// Use setHeaders to define the highlight context for the entire async request
+	setHeaders: (headers: IncomingHttpHeaders) => void
+	// Use runWithHeaders to execute a method with a highlight context
 	runWithHeaders: <T>(headers: IncomingHttpHeaders, cb: () => T) => T
 	consumeError: (
 		error: Error,
@@ -136,11 +141,17 @@ export const H: HighlightInterface = {
 	},
 	parseHeaders: (
 		headers: IncomingHttpHeaders,
-	): { secureSessionId: string; requestId: string } | undefined => {
+	): {
+		secureSessionId: string | undefined
+		requestId: string | undefined
+	} => {
 		return highlight_obj.parseHeaders(headers)
 	},
 	runWithHeaders: (headers, cb) => {
 		return highlight_obj.runWithHeaders(headers, cb)
+	},
+	setHeaders: (headers: IncomingHttpHeaders) => {
+		return highlight_obj.setHeaders(headers)
 	},
 	consumeAndFlush: async function (...args) {
 		const waitPromise = highlight_obj.waitForFlush()


### PR DESCRIPTION
## Summary

Support highlight request context globally to associate async console logs / errors with highlight.
In backend node.js, our console method instrumentation was never associated with
frontend sessions because we were not tracking request context globally.
This is now accomplished thru the use of `AsyncLocalStorage` (when supported) and a global
attribute when now (for instance, in edge runtime). Closes #6996

## How did you test this change?

Express E2E sending logs locally with the associated session / request

otel reported attributes
```json
{
  "result": 499447.28171779995,
  "value": 220.68512975204024,
  "exception.stacktrace": "\"Error\\n    at console.<computed> [as info] (/hom.../dist/index.cjs:63:921668\"",
  "highlight.project_id": "1",
  "log.severity": "info",
  "log.message": "some work happening {\"result\":499447.28171779995,\"value\":220.68512975204024}",
  "highlight.session_id": "mNM7vzVeV8kNvaTZNWNVqyIUdVtP",
  "highlight.trace_id": "qIEbIhImpy"
}
```

![Screenshot from 2023-11-01 17-48-17](https://github.com/highlight/highlight/assets/1351531/dcc9cc40-5bfc-4cbe-8b2a-6956f18f2804)


## Are there any deployment considerations?

Changeset

## Does this work require review from our design team?

Yes
