### PR TITLE
use 'message' instead of body in logs UI, use dynamic body column

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -172,9 +172,9 @@ func makeSelectBuilder[T ~string](config tableConfig[T], selectStr string,
 	bodyQuery := ""
 	for _, body := range filters.body {
 		if strings.Contains(body, "%") {
-			bodyQuery = "Body ILIKE" + sb.Var(body)
+			bodyQuery = config.bodyColumn + " ILIKE " + sb.Var(body)
 		} else {
-			preWheres = append(preWheres, "hasTokenCaseInsensitive(Body, "+sb.Var(body)+")")
+			preWheres = append(preWheres, "hasTokenCaseInsensitive("+config.bodyColumn+", "+sb.Var(body)+")")
 		}
 	}
 

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -41,7 +41,7 @@ var tracesTableConfig = tableConfig[modelInputs.ReservedTraceKey]{
 	tableName:        TracesTable,
 	keysToColumns:    traceKeysToColumns,
 	reservedKeys:     modelInputs.AllReservedTraceKey,
-	bodyColumn:       "Body",
+	bodyColumn:       "SpanName",
 	attributesColumn: "TraceAttributes",
 	selectColumns: []string{
 		"Timestamp",
@@ -65,6 +65,7 @@ var tracesTableConfig = tableConfig[modelInputs.ReservedTraceKey]{
 
 var tracesSamplingTableConfig = tableConfig[modelInputs.ReservedTraceKey]{
 	tableName:        fmt.Sprintf("%s SAMPLE %d", TracesSamplingTable, SamplingRows),
+	bodyColumn:       "SpanName",
 	keysToColumns:    traceKeysToColumns,
 	reservedKeys:     modelInputs.AllReservedTraceKey,
 	attributesColumn: "TraceAttributes",

--- a/frontend/src/components/Search/SearchForm/utils.ts
+++ b/frontend/src/components/Search/SearchForm/utils.ts
@@ -7,7 +7,7 @@ export type SearchParam = {
 
 const SEPARATOR = ':'
 export const DEFAULT_OPERATOR = '='
-export const BODY_KEY = 'body'
+export const BODY_KEY = 'message'
 
 // Inspired by search-query-parser:
 // https://github.com/nepsilon/search-query-parser/blob/8158d09c70b66168440e93ffabd720f4c8314c9b/lib/search-query-parser.js#L40


### PR DESCRIPTION
## Summary
- use "message" as `BODY_KEY` in the UI for consistency
- use `bodyColumn` when querying instead of hardcoding "Body"
- fixes #6859 
- https://www.loom.com/share/3dc2f8dc061b45f8a010386566d133c6
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
