### PR TITLE
remove ingested by traces by default

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -244,6 +244,8 @@ func makeSelectBuilder[T ~string](config tableConfig[T], selectStr string,
 			value := values[0]
 			if strings.Contains(value, "%") {
 				conditions = append(conditions, sb.Var(sqlbuilder.Buildf(config.attributesColumn+"[%s] LIKE %s", key, value)))
+			} else if strings.HasPrefix(value, "!") {
+				conditions = append(conditions, sb.Var(sqlbuilder.Buildf(config.attributesColumn+"[%s] != %s", key, value[1:])))
 			} else {
 				conditions = append(conditions, sb.Var(sqlbuilder.Buildf(config.attributesColumn+"[%s] = %s", key, value)))
 			}
@@ -252,6 +254,8 @@ func makeSelectBuilder[T ~string](config tableConfig[T], selectStr string,
 			for _, value := range values {
 				if strings.Contains(value, "%") {
 					innerConditions = append(innerConditions, sb.Var(sqlbuilder.Buildf(config.attributesColumn+"[%s] LIKE %s", key, value)))
+				} else if strings.HasPrefix(value, "!") {
+					conditions = append(conditions, sb.Var(sqlbuilder.Buildf(config.attributesColumn+"[%s] != %s", key, value[1:])))
 				} else {
 					innerConditions = append(innerConditions, sb.Var(sqlbuilder.Buildf(config.attributesColumn+"[%s] = %s", key, value)))
 				}

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -29,6 +29,7 @@ type tableConfig[TReservedKey ~string] struct {
 	keysToColumns    map[TReservedKey]string
 	reservedKeys     []TReservedKey
 	selectColumns    []string
+	defaultFilters   map[string]string
 }
 
 func readObjects[TObj interface{}, TReservedKey ~string](ctx context.Context, client *Client, config tableConfig[TReservedKey], projectID int, params modelInputs.QueryInput, pagination Pagination, scanObject func(driver.Rows) (*Edge[TObj], error)) (*Connection[TObj], error) {
@@ -155,7 +156,7 @@ func readObjects[TObj interface{}, TReservedKey ~string](ctx context.Context, cl
 
 func makeSelectBuilder[T ~string](config tableConfig[T], selectStr string,
 	groupBy []string, projectID int, params modelInputs.QueryInput, pagination Pagination, orderBackward string, orderForward string) (*sqlbuilder.SelectBuilder, error) {
-	filters := makeFilters(params.Query, lo.Keys(config.keysToColumns))
+	filters := makeFilters(params.Query, lo.Keys(config.keysToColumns), config.defaultFilters)
 	sb := sqlbuilder.NewSelectBuilder()
 	cols := []string{selectStr}
 	for _, group := range groupBy {
@@ -271,7 +272,7 @@ type filtersWithReservedKeys[T ~string] struct {
 	reserved   map[T][]string
 }
 
-func makeFilters[T ~string](query string, reservedKeys []T) filtersWithReservedKeys[T] {
+func makeFilters[T ~string](query string, reservedKeys []T, defaultFilters map[string]string) filtersWithReservedKeys[T] {
 	filters := queryparser.Parse(query)
 	filtersWithReservedKeys := filtersWithReservedKeys[T]{
 		reserved:   make(map[T][]string),
@@ -285,6 +286,12 @@ func makeFilters[T ~string](query string, reservedKeys []T) filtersWithReservedK
 			filtersWithReservedKeys.reserved[key] = val
 			delete(filters.Attributes, string(key))
 		}
+	}
+	for key, value := range defaultFilters {
+		if filters.Attributes[key] == nil {
+			filters.Attributes[key] = []string{}
+		}
+		filters.Attributes[key] = append(filters.Attributes[key], value)
 	}
 
 	filtersWithReservedKeys.attributes = filters.Attributes

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -63,7 +63,7 @@ var tracesTableConfig = tableConfig[modelInputs.ReservedTraceKey]{
 		"StatusMessage",
 	},
 	defaultFilters: map[string]string{
-		highlight.TraceTypeAttribute: string(highlight.TraceTypeHighlightInternal),
+		highlight.TraceTypeAttribute: fmt.Sprintf("!%s", highlight.TraceTypeHighlightInternal),
 	},
 }
 

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	"github.com/highlight/highlight/sdk/highlight-go"
 	"strconv"
 	"time"
 
@@ -60,6 +61,9 @@ var tracesTableConfig = tableConfig[modelInputs.ReservedTraceKey]{
 		"TraceAttributes",
 		"StatusCode",
 		"StatusMessage",
+	},
+	defaultFilters: map[string]string{
+		highlight.TraceTypeAttribute: string(highlight.TraceTypeHighlightInternal),
 	},
 }
 


### PR DESCRIPTION
## Summary

Filter out `IsIngestedBy` and other internal traces from our queries (listing traces, showing trace metrics).

## How did you test this change?

Local deploy shows no internal traces
<img width="1752" alt="Screenshot 2023-11-02 at 12 11 16 AM" src="https://github.com/highlight/highlight/assets/1351531/738422ed-b42a-42cd-97f7-e48a34425338">

generates query
```sql
SELECT Timestamp, ...
FROM traces
WHERE ProjectId = 1
  AND (Timestamp, UUID) IN (SELECT Timestamp, UUID
                            FROM traces
                            WHERE ProjectId = 1
                              AND Timestamp ...
                              AND (TraceAttributes['highlight.type'] != 'highlight.internal')
                            ORDER BY Timestamp DESC, UUID DESC
                            LIMIT 51)
ORDER BY Timestamp DESC, UUID DESC

```

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
