### PR TITLE
Node SDK Resource merge

### DIFF
--- a/.changeset/healthy-dancers-swim.md
+++ b/.changeset/healthy-dancers-swim.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': patch
+---
+
+Repaired a bad resource merge to persist Highlight session data across all spans.

--- a/e2e/nextjs/next.config.mjs
+++ b/e2e/nextjs/next.config.mjs
@@ -3,7 +3,6 @@ import { withHighlightConfig } from '@highlight-run/next/config'
 
 const nextConfig = {
 	experimental: {
-		appDir: true,
 		instrumentationHook: false,
 	},
 	productionBrowserSourceMaps: true,

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -134,14 +134,7 @@ export class Highlight {
 		this.otel = new NodeSDK({
 			autoDetectResources: true,
 			resourceDetectors: [processDetectorSync],
-			resource: {
-				attributes,
-				merge: (resource) =>
-					new Resource({
-						...(resource?.attributes ?? {}),
-						...attributes,
-					}),
-			},
+			resource: new Resource(attributes),
 			spanProcessor: this.processor,
 			traceExporter: exporter,
 			instrumentations: [


### PR DESCRIPTION
It looks like I broke a resource merge a few months back. It didn't appear to break anything, because we were setting session data on every span manually.

BUT, with this resource fixed, we can get automatic tracing data straight from Next.js.

HT to @Vadman97 for finding the bug!