### PR TITLE
Playing around with parent spans

### DIFF
--- a/e2e/nextjs/next.config.mjs
+++ b/e2e/nextjs/next.config.mjs
@@ -3,8 +3,7 @@ import { withHighlightConfig } from '@highlight-run/next/config'
 
 const nextConfig = {
 	experimental: {
-		appDir: true,
-		instrumentationHook: false,
+		instrumentationHook: true,
 	},
 	productionBrowserSourceMaps: true,
 	images: { domains: ['i.travelapi.com'] },

--- a/sdk/highlight-node/src/sdk.ts
+++ b/sdk/highlight-node/src/sdk.ts
@@ -19,7 +19,7 @@ export interface HighlightInterface {
 	// Use setHeaders to define the highlight context for the entire async request
 	setHeaders: (headers: IncomingHttpHeaders) => void
 	// Use runWithHeaders to execute a method with a highlight context
-	runWithHeaders: <T>(headers: IncomingHttpHeaders, cb: () => T) => T
+	runWithHeaders: <T>(headers: IncomingHttpHeaders, cb: () => T) => void
 	consumeError: (
 		error: Error,
 		secureSessionId?: string,


### PR DESCRIPTION
## Summary

We need to let `@highlight-run/node` users create their own spans... but with Highlight's custom attributes set automatically.