### PR TITLE
refactor node sdk highlight context types

### DIFF
--- a/.changeset/quick-planes-hug.md
+++ b/.changeset/quick-planes-hug.md
@@ -1,5 +1,0 @@
----
-'@highlight-run/next': patch
----
-
-fix incorrect setting of highlight context in edge runtime

--- a/.changeset/quick-planes-hug.md
+++ b/.changeset/quick-planes-hug.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/next': patch
+---
+
+fix incorrect setting of highlight context in edge runtime

--- a/.changeset/shaggy-olives-invite.md
+++ b/.changeset/shaggy-olives-invite.md
@@ -1,0 +1,7 @@
+---
+'@highlight-run/nest': patch
+'@highlight-run/next': patch
+'@highlight-run/node': patch
+---
+
+refactor types for highlight session context

--- a/sdk/highlight-nest/src/index.ts
+++ b/sdk/highlight-nest/src/index.ts
@@ -1,7 +1,6 @@
 import { H as NodeH, NodeOptions } from '@highlight-run/node'
 import type { OnApplicationShutdown } from '@nestjs/common'
 import {
-	BadGatewayException,
 	CallHandler,
 	ConsoleLogger,
 	ExecutionContext,
@@ -98,7 +97,7 @@ export class HighlightInterceptor
 		const ctx = context.switchToHttp()
 		const request = ctx.getRequest()
 		const highlightCtx = NodeH.parseHeaders(request.headers)
-		return NodeH.runWithHeaders(highlightCtx, () => {
+		return NodeH.runWithHeaders(request.headers, () => {
 			return next.handle().pipe(
 				catchError((err) => {
 					NodeH.consumeError(

--- a/sdk/highlight-next/src/util/highlight-edge.ts
+++ b/sdk/highlight-next/src/util/highlight-edge.ts
@@ -134,12 +134,12 @@ export const H: HighlightInterface = {
 
 		return cb()
 	},
-    setHeaders(headers: IncomingHttpHeaders) {
-        const highlightCtx = this.parseHeaders(headers)
-        if (highlightCtx) {
-            asyncLocalStorage.enterWith(highlightCtx)
-        }
-    },
+	setHeaders(headers: IncomingHttpHeaders) {
+		const highlightCtx = this.parseHeaders(headers)
+		if (highlightCtx) {
+			asyncLocalStorage.enterWith(highlightCtx)
+		}
+	},
 }
 
 function polyfillWaitUntil(ctx: ExtendedExecutionContext) {

--- a/sdk/highlight-next/src/util/highlight-edge.ts
+++ b/sdk/highlight-next/src/util/highlight-edge.ts
@@ -113,8 +113,7 @@ export const H: HighlightInterface = {
 		requestId: string | undefined
 	} {
 		const highlightCtx = asyncLocalStorage.getStore()
-
-		if (highlightCtx) {
+        if (highlightCtx?.secureSessionId && highlightCtx?.requestId) {
 			return highlightCtx
 		} else if (headers && headers[HIGHLIGHT_REQUEST_HEADER]) {
 			const [secureSessionId, requestId] =

--- a/sdk/highlight-next/src/util/highlight-node.ts
+++ b/sdk/highlight-next/src/util/highlight-node.ts
@@ -1,5 +1,5 @@
 import { H as NodeH, NodeOptions } from '@highlight-run/node'
-import { HighlightInterface, HighlightGlobal, RequestMetadata } from './types'
+import { HighlightInterface, RequestMetadata } from './types'
 
 export type HighlightEnv = NodeOptions
 
@@ -29,10 +29,6 @@ export const H: HighlightInterface = {
 	},
 	isInitialized: () => NodeH.isInitialized(),
 	metrics: (metrics: Metric[], opts?: RequestMetadata) => {
-		const h = (global as typeof globalThis & HighlightGlobal).__HIGHLIGHT__
-		if (h && !opts) {
-			opts = h
-		}
 		if (!opts?.secureSessionId) {
 			return console.warn(
 				'H.metrics session could not be inferred the handler context.',

--- a/sdk/highlight-next/src/util/highlight-node.ts
+++ b/sdk/highlight-next/src/util/highlight-node.ts
@@ -1,5 +1,6 @@
-import { H as NodeH, NodeOptions } from '@highlight-run/node'
-import { HighlightInterface, RequestMetadata } from './types'
+import { H as NodeH } from '@highlight-run/node'
+import type { HighlightContext, NodeOptions } from '@highlight-run/node'
+import { HighlightInterface } from './types'
 
 export type HighlightEnv = NodeOptions
 
@@ -28,7 +29,7 @@ export const H: HighlightInterface = {
 		)
 	},
 	isInitialized: () => NodeH.isInitialized(),
-	metrics: (metrics: Metric[], opts?: RequestMetadata) => {
+	metrics: (metrics: Metric[], opts?: HighlightContext) => {
 		if (!opts?.secureSessionId) {
 			return console.warn(
 				'H.metrics session could not be inferred the handler context.',

--- a/sdk/highlight-next/src/util/instrument-server.ts
+++ b/sdk/highlight-next/src/util/instrument-server.ts
@@ -1,6 +1,5 @@
 import { default as createNextServer } from 'next'
 import { H } from '@highlight-run/node'
-import { HighlightGlobal } from './types'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type PlainObject<T = any> = { [key: string]: T }
@@ -63,8 +62,7 @@ function wrap(name: string) {
 		): Promise<any> {
 			const start = performance.now()
 			const result = origMethod.call(this, parameterizedPath, ...args)
-			const h = (global as typeof globalThis & HighlightGlobal)
-				.__HIGHLIGHT__
+			const h = H.parseHeaders({})
 			if (h?.secureSessionId) {
 				H.recordMetric(
 					h?.secureSessionId,

--- a/sdk/highlight-next/src/util/types.ts
+++ b/sdk/highlight-next/src/util/types.ts
@@ -3,6 +3,7 @@ import type { ResourceAttributes } from '@opentelemetry/resources/build/src/type
 import type { ExecutionContext } from '@cloudflare/workers-types'
 import type { WorkersSDK } from '@highlight-run/opentelemetry-sdk-workers'
 import type { Attributes } from '@opentelemetry/api'
+import type { HighlightContext } from '@highlight-run/node'
 import { IncomingHttpHeaders } from 'http'
 
 export type HighlightEnv = NodeOptions
@@ -29,10 +30,7 @@ export interface HighlightInterface {
 	) => WorkersSDK
 	isInitialized: () => boolean
 	metrics: (metrics: Metric[]) => void
-	parseHeaders: (headers: IncomingHttpHeaders) => {
-		secureSessionId: string | undefined
-		requestId: string | undefined
-	}
+	parseHeaders: (headers: IncomingHttpHeaders) => HighlightContext
 	runWithHeaders: <T>(headers: IncomingHttpHeaders, cb: () => T) => T
 	consumeError: (
 		error: Error,

--- a/sdk/highlight-next/src/util/types.ts
+++ b/sdk/highlight-next/src/util/types.ts
@@ -32,6 +32,7 @@ export interface HighlightInterface {
 	metrics: (metrics: Metric[]) => void
 	parseHeaders: (headers: IncomingHttpHeaders) => HighlightContext
 	runWithHeaders: <T>(headers: IncomingHttpHeaders, cb: () => T) => T
+	setHeaders: (headers: IncomingHttpHeaders) => void
 	consumeError: (
 		error: Error,
 		secureSessionId?: string,

--- a/sdk/highlight-next/src/util/types.ts
+++ b/sdk/highlight-next/src/util/types.ts
@@ -12,10 +12,6 @@ export interface RequestMetadata {
 	requestId: string
 }
 
-export interface HighlightGlobal {
-	__HIGHLIGHT__?: RequestMetadata
-}
-
 export declare interface Metric {
 	name: string
 	value: number

--- a/sdk/highlight-next/src/util/types.ts
+++ b/sdk/highlight-next/src/util/types.ts
@@ -7,11 +7,6 @@ import { IncomingHttpHeaders } from 'http'
 
 export type HighlightEnv = NodeOptions
 
-export interface RequestMetadata {
-	secureSessionId: string
-	requestId: string
-}
-
 export declare interface Metric {
 	name: string
 	value: number

--- a/sdk/highlight-next/src/util/with-highlight-nodejs-app-router.ts
+++ b/sdk/highlight-next/src/util/with-highlight-nodejs-app-router.ts
@@ -13,7 +13,7 @@ export function Highlight(options: NodeOptions) {
 	return (originalHandler: NextHandler) =>
 		async (request: NextRequest, context: NextContext) => {
 			const headers: IncomingHttpHeaders = {}
-			request.headers.forEach((k, v) => (headers[k] = v))
+			request.headers.forEach((value, key) => (headers[key] = value))
 			try {
 				H.init(options)
 

--- a/sdk/highlight-next/tsup.config.ts
+++ b/sdk/highlight-next/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
 		'src/config.ts',
 		'src/server.edge.ts',
 		'src/server.ts',
-		'src/ssr.ts',
+		'src/ssr.tsx',
 	],
 	format: ['cjs', 'esm'],
 	target: 'es6',

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -8,15 +8,15 @@ import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base'
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 import { processDetectorSync, Resource } from '@opentelemetry/resources'
+import { IncomingHttpHeaders } from 'http'
 import { AsyncLocalStorage } from 'node:async_hooks'
 
 import { clearInterval } from 'timers'
 
-import { NodeOptions } from './types'
-import { hookConsole } from './hooks'
-import log from './log'
-import { IncomingHttpHeaders } from 'http'
-import { HIGHLIGHT_REQUEST_HEADER } from './sdk'
+import type { HighlightContext, NodeOptions } from './types.js'
+import { hookConsole } from './hooks.js'
+import log from './log.js'
+import { HIGHLIGHT_REQUEST_HEADER } from './sdk.js'
 
 const OTLP_HTTP = 'https://otel.highlight.io:4318'
 
@@ -60,10 +60,7 @@ export class Highlight {
 	otel: NodeSDK
 	private tracer: Tracer
 	private processor: CustomSpanProcessor
-	private asyncLocalStorage = new AsyncLocalStorage<{
-		secureSessionId: string | undefined
-		requestId: string | undefined
-	}>()
+	private asyncLocalStorage = new AsyncLocalStorage<HighlightContext>()
 
 	constructor(options: NodeOptions) {
 		this._debug = !!options.debug
@@ -320,10 +317,7 @@ export class Highlight {
 		return this.otel.addResource(new Resource(attributes))
 	}
 
-	parseHeaders(headers: IncomingHttpHeaders): {
-		secureSessionId: string | undefined
-		requestId: string | undefined
-	} {
+	parseHeaders(headers: IncomingHttpHeaders): HighlightContext {
 		try {
 			const highlightCtx = this.asyncLocalStorage.getStore()
 			if (highlightCtx) {

--- a/sdk/highlight-node/src/index.ts
+++ b/sdk/highlight-node/src/index.ts
@@ -1,4 +1,4 @@
 export { H, HIGHLIGHT_REQUEST_HEADER } from './sdk'
 export { Highlight } from './client'
-export type { NodeOptions } from './types'
+export type { HighlightContext, NodeOptions } from './types'
 export * as Handlers from './handlers'

--- a/sdk/highlight-node/src/sdk.ts
+++ b/sdk/highlight-node/src/sdk.ts
@@ -1,9 +1,9 @@
 import { IncomingHttpHeaders } from 'http'
 import { Highlight } from '.'
-import { NodeOptions } from './types.js'
 import log from './log'
 import { ResourceAttributes } from '@opentelemetry/resources'
 import type { Attributes } from '@opentelemetry/api'
+import type { NodeOptions, HighlightContext } from './types.js'
 
 export const HIGHLIGHT_REQUEST_HEADER = 'x-highlight-request'
 
@@ -12,10 +12,7 @@ export interface HighlightInterface {
 	stop: () => Promise<void>
 	isInitialized: () => boolean
 	// Use parseHeaders to extract the headers from the current context or from the headers.
-	parseHeaders: (headers: IncomingHttpHeaders) => {
-		secureSessionId: string | undefined
-		requestId: string | undefined
-	}
+	parseHeaders: (headers: IncomingHttpHeaders) => HighlightContext
 	// Use setHeaders to define the highlight context for the entire async request
 	setHeaders: (headers: IncomingHttpHeaders) => void
 	// Use runWithHeaders to execute a method with a highlight context
@@ -139,12 +136,7 @@ export const H: HighlightInterface = {
 			console.warn('highlight-node log error: ', e)
 		}
 	},
-	parseHeaders: (
-		headers: IncomingHttpHeaders,
-	): {
-		secureSessionId: string | undefined
-		requestId: string | undefined
-	} => {
+	parseHeaders: (headers: IncomingHttpHeaders): HighlightContext => {
 		return highlight_obj.parseHeaders(headers)
 	},
 	runWithHeaders: (headers, cb) => {


### PR DESCRIPTION
## Summary

Removes our usage of `global.__HIGHLIGHT__` which does not work in edge runtime.
Consolidates duplicate types that expose the highlight session / request context.

## How did you test this change?

Vercel deploy of highlight.io edge runtime methods.

## Are there any deployment considerations?

Changeset

## Does this work require review from our design team?

No
