### PR TITLE
Repair Next.js Edge SDK

### DIFF
--- a/.changeset/small-glasses-sit.md
+++ b/.changeset/small-glasses-sit.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/next': patch
+---
+
+Using AsyncLocalStorage in Edge Runtime to track headers.

--- a/docs-content/getting-started/fullstack-frameworks/next-js/2_page-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/2_page-router.md
@@ -139,11 +139,52 @@ function ThrowerOfErrors({
 }
 ```
 
-## Catch server-side render (SSR) errors (optional)
+## Enable server-side tracing
+
+We use `experimental.instrumentationHook` to capture [Next.js's automatic instrumentation](https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry). This method captures detailed API route tracing as well as server-side errors.
+
+1. Enable `experimental.instrumentationHook` in `next.config.js`.
+```javascript
+// next.config.mjs
+import { withHighlightConfig } from '@highlight-run/next/config'
+
+const nextConfig = {
+	experimental: {
+		instrumentationHook: true,
+	},
+	// ...additional config
+}
+
+export default withHighlightConfig(nextConfig)
+```
+
+2. Call `registerHighlight` in `instrumentation.ts`
+```jsx
+// instrumentation.ts
+import { CONSTANTS } from './constants'
+
+export async function register() {
+	const { registerHighlight } = await import('@highlight-run/next/server')
+
+	registerHighlight({
+		projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
+		serviceName: 'my-nextjs-backend',
+	})
+}
+```
+
+3. App Router instrumentation requires `app/instrumentation.ts` to be defined, so re-export your handler from `./instrumentation.ts`
+```typescript
+// src/instrumentation.ts:
+export { register } from '../instrumentation'
+
+```
+
+## Catch server-side render (SSR) errors
 
 Page Router uses [pages/_error.tsx](https://nextjs.org/docs/pages/building-your-application/routing/custom-error#more-advanced-error-page-customizing) to send server-side render errors to the client. We can catch and consume those errors with a custom error page.
 
-All SSR error will display as client errors on your Highlight dashboard.
+These SSR error will display as client errors on your Highlight dashboard.
 
 ```jsx
 // pages/_error.tsx

--- a/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
@@ -132,7 +132,47 @@ function ThrowerOfErrors({
 }
 ```
 
-## Catch server-side render (SSR) errors (optional)
+## Enable server-side tracing
+
+We use `experimental.instrumentationHook` to capture [Next.js's automatic instrumentation](https://nextjs.org/docs/app/building-your-application/optimizing/open-telemetry). This method captures detailed API route tracing as well as server-side errors.
+
+1. Enable `experimental.instrumentationHook` in `next.config.js`.
+```javascript
+// next.config.mjs
+import { withHighlightConfig } from '@highlight-run/next/config'
+
+const nextConfig = {
+	experimental: {
+		instrumentationHook: true,
+	},
+	// ...additional config
+}
+
+export default withHighlightConfig(nextConfig)
+```
+
+2. Call `registerHighlight` in `instrumentation.ts`
+```jsx
+// instrumentation.ts
+import { CONSTANTS } from './constants'
+
+export async function register() {
+	const { registerHighlight } = await import('@highlight-run/next/server')
+
+	registerHighlight({
+		projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
+		serviceName: 'my-nextjs-backend',
+	})
+}
+```
+
+3. App Router instrumentation requires `app/instrumentation.ts` to be defined, so re-export your handler from `./instrumentation.ts`
+```typescript
+// src/instrumentation.ts:
+export { register } from '../instrumentation'
+```
+
+## Catch server-side render (SSR) errors
 
 App Router uses [app/error.tsx](https://nextjs.org/docs/app/api-reference/file-conventions/error) to send server-side render errors to the client. We can catch and consume those errors with a custom error page.
 

--- a/e2e/nextjs/instrumentation.ts
+++ b/e2e/nextjs/instrumentation.ts
@@ -2,13 +2,11 @@
 import { CONSTANTS } from '@/constants'
 
 export async function register() {
-	if (process.env.NEXT_RUNTIME === 'nodejs') {
-		const { registerHighlight } = await import('@highlight-run/next/server')
+	const { registerHighlight } = await import('@highlight-run/next/server')
 
-		registerHighlight({
-			projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
-			otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
-			serviceName: 'my-nextjs-backend',
-		})
-	}
+	registerHighlight({
+		projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
+		otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
+		serviceName: 'my-nextjs-backend',
+	})
 }

--- a/e2e/nextjs/next.config.mjs
+++ b/e2e/nextjs/next.config.mjs
@@ -3,7 +3,7 @@ import { withHighlightConfig } from '@highlight-run/next/config'
 
 const nextConfig = {
 	experimental: {
-		instrumentationHook: false,
+		instrumentationHook: true,
 	},
 	productionBrowserSourceMaps: true,
 	images: { domains: ['i.travelapi.com'] },

--- a/e2e/nextjs/pages/redirect.tsx
+++ b/e2e/nextjs/pages/redirect.tsx
@@ -5,7 +5,7 @@ type Props = {
 }
 export default function RedirectPage({ shouldRedirect }: Props) {
 	if (shouldRedirect) {
-		return redirect(`/isr`)
+		return redirect(`/ssr`)
 	}
 
 	return (

--- a/e2e/nextjs/pages/ssr.tsx
+++ b/e2e/nextjs/pages/ssr.tsx
@@ -4,17 +4,17 @@ type Props = {
 	date: string
 	random: number
 }
-export default function IsrPage({ date, random }: Props) {
+export default function SsrPage({ date, random }: Props) {
 	const router = useRouter()
 	const isError = router.asPath.includes('error')
 
 	if (isError) {
-		throw new Error('ISR Error: src/pages/isr.tsx')
+		throw new Error('🎉 SSR Error: src/pages/ssr.tsx')
 	}
 
 	return (
 		<div>
-			<h1>ISR Lives</h1>
+			<h1>SSR Lives</h1>
 			<p>The random number is {random}</p>
 			<p>The date is {date}</p>
 		</div>
@@ -22,7 +22,7 @@ export default function IsrPage({ date, random }: Props) {
 }
 
 export async function getStaticProps() {
-	console.info('getStaticProps pages/isr')
+	console.info('getStaticProps pages/ssr')
 
 	return {
 		props: {

--- a/e2e/nextjs/src/app/_utils/page-router-highlight.config.ts
+++ b/e2e/nextjs/src/app/_utils/page-router-highlight.config.ts
@@ -14,6 +14,4 @@ const env: HighlightEnv = {
 	serviceName: 'my-nextjs-backend',
 }
 
-console.log('app/utils/highlight.config.ts env', JSON.stringify(env, null, 2))
-
 export const withPageRouterHighlight = PageRouterHighlight(env)

--- a/e2e/nextjs/src/app/app-router/redirect/page.tsx
+++ b/e2e/nextjs/src/app/app-router/redirect/page.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export default function RedirectPage({ searchParams }: Props) {
 	if (searchParams.shouldRedirect) {
-		return redirect(`/isr`)
+		return redirect(`/ssr`)
 	}
 
 	return (

--- a/e2e/nextjs/src/app/app-router/ssr/page.tsx
+++ b/e2e/nextjs/src/app/app-router/ssr/page.tsx
@@ -2,14 +2,14 @@ type Props = {
 	searchParams: { error?: string }
 }
 
-export default function IsrPage({ searchParams }: Props) {
+export default function SsrPage({ searchParams }: Props) {
 	if (searchParams.error) {
-		throw new Error('ISR Error: src/app-router/isr/page.tsx')
+		throw new Error('🎉 SSR Error: src/app-router/ssr/page.tsx')
 	}
 
 	return (
 		<div>
-			<h1>App Router ISR: Success</h1>
+			<h1>App Router SSR: Success</h1>
 			<p>The random number is {Math.random()}</p>
 			<p>The date is {new Date().toLocaleTimeString()}</p>
 		</div>

--- a/e2e/nextjs/src/app/components/path-buttons.tsx
+++ b/e2e/nextjs/src/app/components/path-buttons.tsx
@@ -27,19 +27,19 @@ export function PathButtons() {
 				}}
 			/>
 			<ErrorBoundary>
-				<Link href="/isr">
+				<Link href="/ssr">
 					<Button>Standard ISR: Success</Button>
 				</Link>
 				<hr />
-				<Link href="/isr?error=true">
+				<Link href="/ssr?error=true">
 					<Button>Standard ISR: Error</Button>
 				</Link>
 				<hr />
-				<Link href="/app-router/isr">
+				<Link href="/app-router/ssr">
 					<Button>App Router: Success</Button>
 				</Link>
 				<hr />
-				<Link href="/app-router/isr?error=true">
+				<Link href="/app-router/ssr?error=true">
 					<Button>App Router: Error</Button>
 				</Link>
 				<hr />

--- a/sdk/highlight-next/src/util/register-highlight.ts
+++ b/sdk/highlight-next/src/util/register-highlight.ts
@@ -1,4 +1,4 @@
-import { NodeOptions } from '@highlight-run/node'
+import type { NodeOptions } from '@highlight-run/node'
 
 export async function registerHighlight(nodeOptions: NodeOptions) {
 	if (process.env.NEXT_RUNTIME === 'nodejs') {

--- a/sdk/highlight-next/src/util/types.ts
+++ b/sdk/highlight-next/src/util/types.ts
@@ -71,4 +71,4 @@ export interface HighlightInterface {
 	flush: () => Promise<void>
 }
 
-export const HIGHLIGHT_REQUEST_HEADER = 'X-Highlight-Request'
+export const HIGHLIGHT_REQUEST_HEADER = 'x-highlight-request'

--- a/sdk/highlight-next/src/util/with-highlight-edge.ts
+++ b/sdk/highlight-next/src/util/with-highlight-edge.ts
@@ -19,7 +19,7 @@ export function Highlight(env: HighlightEnv) {
 		) {
 			H.initEdge(request, env, event)
 			const headers: IncomingHttpHeaders = {}
-			request.headers.forEach((k, v) => (headers[k] = v))
+			request.headers.forEach((v, k) => (headers[k] = v))
 
 			try {
 				const response = await H.runWithHeaders(headers, async () => {

--- a/sdk/highlight-node/src/types.ts
+++ b/sdk/highlight-node/src/types.ts
@@ -28,3 +28,8 @@ export interface NodeOptions extends HighlightOptions {
 	 */
 	enableFsInstrumentation?: boolean
 }
+
+export interface HighlightContext {
+	secureSessionId: string | undefined
+	requestId: string | undefined
+}


### PR DESCRIPTION
## Summary

Edge doesn't provide `global`, so we're using `AsyncLocalStorage` instead.  

Testing also revealed that the header parsing logic was inverted, causing headers to get lost on all Edge requests. 

## How did you test this change?

Deploys to Vercel

## Are there any deployment considerations?

No.

## Does this work require review from our design team?

Batch bump to Next SDK