### PR TITLE
allow using only local storage

### DIFF
--- a/.changeset/violet-ducks-worry.md
+++ b/.changeset/violet-ducks-worry.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+support bypassing sessionStorage entirely with the storageMode option

--- a/.changeset/violet-ducks-worry.md
+++ b/.changeset/violet-ducks-worry.md
@@ -2,4 +2,4 @@
 'highlight.run': patch
 ---
 
-support bypassing sessionStorage entirely with the storageMode option
+support bypassing sessionStorage entirely with the storageMode option and provide a globalStorage fallback

--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -356,6 +356,7 @@
         "/src/utils/sessionStorage/highlightSession.js": "/utils/sessionStorage/highlightSession.ts",
         "/src/utils/sessionStorage/sessionStorageKeys": "/utils/sessionStorage/sessionStorageKeys.ts",
         "/src/utils/sessionStorage/sessionStorageKeys.js": "/utils/sessionStorage/sessionStorageKeys.ts",
+        "/src/utils/storage.js": "/utils/storage.ts",
       },
       "nodejsCompatibility": {
         "omitModuleExtension": true,

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -79,7 +79,7 @@ import {
 	IFRAME_PARENT_READY,
 	IFRAME_PARENT_RESPONSE,
 } from './types/iframe'
-import { getItem, setItem, setStorageMode } from './utils/storage'
+import { getItem, removeItem, setItem, setStorageMode } from './utils/storage'
 
 export const HighlightWarning = (context: string, msg: any) => {
 	console.warn(`Highlight Warning: (${context}): `, { output: msg })
@@ -275,7 +275,7 @@ export class Highlight {
 		} else {
 			// new session. we should clear any session storage data
 			for (const storageKeyName of Object.values(SESSION_STORAGE_KEYS)) {
-				window.sessionStorage.removeItem(storageKeyName)
+				removeItem(storageKeyName)
 			}
 			this.sessionData = {
 				sessionSecureID: this.options.sessionSecureID,
@@ -313,10 +313,8 @@ export class Highlight {
 		let user_identifier, user_object
 		if (!forceNew) {
 			try {
-				user_identifier = window.sessionStorage.getItem(
-					SESSION_STORAGE_KEYS.USER_IDENTIFIER,
-				)
-				const user_object_string = window.sessionStorage.getItem(
+				user_identifier = getItem(SESSION_STORAGE_KEYS.USER_IDENTIFIER)
+				const user_object_string = getItem(
 					SESSION_STORAGE_KEYS.USER_OBJECT,
 				)
 				if (user_object_string) {
@@ -325,7 +323,7 @@ export class Highlight {
 			} catch (err) {}
 		}
 		for (const storageKeyName of Object.values(SESSION_STORAGE_KEYS)) {
-			window.sessionStorage.removeItem(storageKeyName)
+			removeItem(storageKeyName)
 		}
 
 		// no need to set the sessionStorage value here since firstload won't call
@@ -427,14 +425,8 @@ export class Highlight {
 		this._eventBytesSinceSnapshot = 0
 		this._lastSnapshotTime = new Date().getTime()
 		this._lastVisibilityChangeTime = new Date().getTime()
-		this._payloadId =
-			Number(
-				window.sessionStorage.getItem(SESSION_STORAGE_KEYS.PAYLOAD_ID),
-			) ?? 1
-		window.sessionStorage.setItem(
-			SESSION_STORAGE_KEYS.PAYLOAD_ID,
-			this._payloadId.toString(),
-		)
+		this._payloadId = Number(getItem(SESSION_STORAGE_KEYS.PAYLOAD_ID)) ?? 1
+		setItem(SESSION_STORAGE_KEYS.PAYLOAD_ID, this._payloadId.toString())
 	}
 
 	identify(user_identifier: string, user_object = {}, source?: Source) {
@@ -447,14 +439,11 @@ export class Highlight {
 		}
 		this.sessionData.userIdentifier = user_identifier.toString()
 		this.sessionData.userObject = user_object
-		window.sessionStorage.setItem(
+		setItem(
 			SESSION_STORAGE_KEYS.USER_IDENTIFIER,
 			user_identifier.toString(),
 		)
-		window.sessionStorage.setItem(
-			SESSION_STORAGE_KEYS.USER_OBJECT,
-			JSON.stringify(user_object),
-		)
+		setItem(SESSION_STORAGE_KEYS.USER_OBJECT, JSON.stringify(user_object))
 		this._worker.postMessage({
 			message: {
 				type: MessageType.Identify,
@@ -542,12 +531,12 @@ export class Highlight {
 				return
 			}
 
-			const recordingStartTime = window.sessionStorage.getItem(
+			const recordingStartTime = getItem(
 				SESSION_STORAGE_KEYS.RECORDING_START_TIME,
 			)
 			if (!recordingStartTime) {
 				this._recordingStartTime = new Date().getTime()
-				window.sessionStorage.setItem(
+				setItem(
 					SESSION_STORAGE_KEYS.RECORDING_START_TIME,
 					this._recordingStartTime.toString(),
 				)
@@ -563,7 +552,7 @@ export class Highlight {
 			}
 
 			// To handle the 'Duplicate Tab' function, remove id from storage until page unload
-			window.sessionStorage.removeItem(SESSION_STORAGE_KEYS.SESSION_DATA)
+			removeItem(SESSION_STORAGE_KEYS.SESSION_DATA)
 
 			// Duplicate of logic inside FirstLoadListeners.setupNetworkListener,
 			// needed for initializeSession
@@ -651,7 +640,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 					recordingStartTime: this._recordingStartTime,
 				},
 			})
-			window.sessionStorage.setItem(
+			setItem(
 				SESSION_STORAGE_KEYS.SESSION_SECURE_ID,
 				this.sessionData.sessionSecureID,
 			)
@@ -1097,7 +1086,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 
 		const unloadListener = () => {
 			this.addCustomEvent('Page Unload', '')
-			window.sessionStorage.setItem(
+			setItem(
 				SESSION_STORAGE_KEYS.SESSION_DATA,
 				JSON.stringify(this.sessionData),
 			)
@@ -1114,7 +1103,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 		if (isOnIOS) {
 			const unloadListener = () => {
 				this.addCustomEvent('Page Unload', '')
-				window.sessionStorage.setItem(
+				setItem(
 					SESSION_STORAGE_KEYS.SESSION_DATA,
 					JSON.stringify(this.sessionData),
 				)
@@ -1381,10 +1370,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			})
 		}
 		this._payloadId++
-		window.sessionStorage.setItem(
-			SESSION_STORAGE_KEYS.PAYLOAD_ID,
-			this._payloadId.toString(),
-		)
+		setItem(SESSION_STORAGE_KEYS.PAYLOAD_ID, this._payloadId.toString())
 
 		// If sendFn throws an exception, the data below will not be cleared, and it will be re-uploaded on the next PushPayload.
 		// SendBeacon is not guaranteed to succeed, so we will treat it the same way.

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -231,11 +231,11 @@ export class Highlight {
 			this.debugOptions = this.options?.debug ?? {}
 		}
 		this.logger = new Logger(this.debugOptions.clientInteractions)
-		if (options.storageMode === 'sessionStorage') {
+		if (options.storageMode) {
 			this.logger.log(
-				'initializing in sessionStorage non-persistent session mode',
+				`initializing in ${options.storageMode} session mode`,
 			)
-			setStorageMode('sessionStorage')
+			setStorageMode(options.storageMode)
 		}
 
 		this._worker =

--- a/sdk/client/src/listeners/segment-integration-listener.tsx
+++ b/sdk/client/src/listeners/segment-integration-listener.tsx
@@ -1,5 +1,5 @@
 import { SESSION_STORAGE_KEYS } from '../utils/sessionStorage/sessionStorageKeys'
-import { getItem, monkeyPatchLocalStorage } from '../utils/storage'
+import { getItem, monkeyPatchLocalStorage, setItem } from '../utils/storage'
 
 enum SEGMENT_LOCAL_STORAGE_KEYS {
 	USER_ID = 'ajs_user_id',
@@ -122,23 +122,17 @@ const shouldSend = (payload: any) => {
 
 	const hashDigest = hashCode(hashMessage)
 
-	const lastSentHash = window.sessionStorage.getItem(
+	const lastSentHash = getItem(
 		SESSION_STORAGE_KEYS.SEGMENT_LAST_SENT_HASH_KEY,
 	)
 
 	if (lastSentHash === undefined) {
-		window.sessionStorage.setItem(
-			SESSION_STORAGE_KEYS.SEGMENT_LAST_SENT_HASH_KEY,
-			hashDigest,
-		)
+		setItem(SESSION_STORAGE_KEYS.SEGMENT_LAST_SENT_HASH_KEY, hashDigest)
 		return true
 	}
 
 	if (hashDigest !== lastSentHash) {
-		window.sessionStorage.setItem(
-			SESSION_STORAGE_KEYS.SEGMENT_LAST_SENT_HASH_KEY,
-			hashDigest,
-		)
+		setItem(SESSION_STORAGE_KEYS.SEGMENT_LAST_SENT_HASH_KEY, hashDigest)
 		return true
 	}
 

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -211,6 +211,12 @@ export declare type HighlightOptions = {
 	 * as the session ID will not persist.
 	 */
 	storageMode?: 'sessionStorage' | 'localStorage'
+	/**
+	 * By default, data is serialized and send by the Web Worker. Set to `local` to force
+	 * sending from the main js thread. Only use `local` for custom environments where Web Workers
+	 * are not available (ie. Figma plugins).
+	 */
+	sendMode?: 'webworker' | 'local'
 }
 
 export declare interface HighlightPublicInterface {

--- a/sdk/client/src/utils/sessionStorage/highlightSession.ts
+++ b/sdk/client/src/utils/sessionStorage/highlightSession.ts
@@ -1,4 +1,5 @@
 import { SESSION_STORAGE_KEYS } from './sessionStorageKeys'
+import { getItem } from '../storage'
 
 /**
  * The amount of time allowed after the last push before creating a new session.
@@ -17,8 +18,7 @@ export type SessionData = {
 
 export const getPreviousSessionData = (): SessionData | undefined => {
 	let storedSessionData = JSON.parse(
-		window.sessionStorage.getItem(SESSION_STORAGE_KEYS.SESSION_DATA) ||
-			'{}',
+		getItem(SESSION_STORAGE_KEYS.SESSION_DATA) || '{}',
 	)
 	if (
 		storedSessionData &&

--- a/sdk/client/src/utils/storage.ts
+++ b/sdk/client/src/utils/storage.ts
@@ -23,6 +23,10 @@ export const setItem = (key: string, value: string) => {
 	return getPersistentStorage().setItem(key, value)
 }
 
+export const removeItem = (key: string) => {
+	return getPersistentStorage().removeItem(key)
+}
+
 export const monkeyPatchLocalStorage = (
 	onSetItemHandler: ({
 		keyName,

--- a/sdk/client/src/utils/storage.ts
+++ b/sdk/client/src/utils/storage.ts
@@ -5,7 +5,7 @@ let mode: Mode = 'localStorage'
 class Storage {
 	private storage: { [key: string]: string } = {}
 	public getItem(key: string) {
-		return this.storage[key]
+		return this.storage[key] ?? ''
 	}
 	public setItem(key: string, value: string) {
 		this.storage[key] = value

--- a/sdk/client/src/utils/storage.ts
+++ b/sdk/client/src/utils/storage.ts
@@ -2,12 +2,31 @@ type Mode = 'localStorage' | 'sessionStorage'
 
 let mode: Mode = 'localStorage'
 
+class Storage {
+	private storage: { [key: string]: string } = {}
+	public getItem(key: string) {
+		return this.storage[key]
+	}
+	public setItem(key: string, value: string) {
+		this.storage[key] = value
+	}
+	public removeItem(key: string) {
+		delete this.storage[key]
+	}
+}
+
+let globalStorage = new Storage()
+
 const getPersistentStorage = () => {
-	switch (mode) {
-		case 'localStorage':
-			return window.localStorage
-		case 'sessionStorage':
-			return window.sessionStorage
+	try {
+		switch (mode) {
+			case 'localStorage':
+				return window.localStorage
+			case 'sessionStorage':
+				return window.sessionStorage
+		}
+	} catch (e) {
+		return globalStorage
 	}
 }
 

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -26,12 +26,13 @@ import { HighlightSegmentMiddleware } from './integrations/segment.js'
 import configureElectronHighlight from './environments/electron.js'
 import firstloadVersion from './__generated/version.js'
 import {
-	SessionData,
 	getPreviousSessionData,
+	SessionData,
 } from '@highlight-run/client/src/utils/sessionStorage/highlightSession.js'
 import { initializeFetchListener } from './listeners/fetch/index.js'
 import { initializeWebSocketListener } from './listeners/web-socket/index.js'
 import { listenToChromeExtensionMessage } from './browserExtension/extensionListener.js'
+import { setItem } from '@highlight-run/client/src/utils/storage.js'
 
 enum MetricCategory {
 	Device = 'Device',
@@ -102,7 +103,7 @@ const H: HighlightPublicInterface = {
 					sessionSecureID,
 				}
 
-				window.sessionStorage.setItem(
+				setItem(
 					SESSION_STORAGE_KEYS.SESSION_DATA,
 					JSON.stringify(sessionData),
 				)

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -150,6 +150,7 @@ const H: HighlightPublicInterface = {
 				sessionShortcut: options?.sessionShortcut,
 				sessionSecureID: sessionSecureID,
 				storageMode: options?.storageMode,
+				sendMode: options?.sendMode,
 			}
 			first_load_listeners = new FirstLoadListeners(client_options)
 			if (!options?.manualStart) {


### PR DESCRIPTION
## Summary

Support entirely bypassing sessionStorage for environments such as
figma plugins where `window.sessionStorage` may not be accessible.

## How did you test this change?

Reflame preview.
Recording a session from [figma](https://app.highlight.io/1/sessions/3VbfjNPILWcBYEcY4Xktp1Up952F).

## Are there any deployment considerations?

Changeset

## Does this work require review from our design team?

No
