### PR TITLE
Track error trace clicks

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -22,6 +22,7 @@ import { useProjectId } from '@hooks/useProjectId'
 import ErrorSourcePreview from '@pages/ErrorsV2/ErrorSourcePreview/ErrorSourcePreview'
 import { SourcemapErrorDetails } from '@pages/ErrorsV2/SourcemapErrorDetails/SourcemapErrorDetails'
 import { UnstructuredStackTrace } from '@pages/ErrorsV2/UnstructuredStackTrace/UnstructuredStackTrace'
+import analytics from '@util/analytics'
 import { copyToClipboard } from '@util/string'
 import clsx from 'clsx'
 import React from 'react'
@@ -211,6 +212,17 @@ const StackSection: React.FC<React.PropsWithChildren<StackSectionProps>> = ({
 }) => {
 	const [expanded, setExpanded] = React.useState(isFirst)
 
+	const handleExpandedChange = (value: boolean) => {
+		setExpanded(value)
+
+		const trackingProperties = {
+			expanded: value,
+			errorObjectId,
+			enhancementSource: enhancementSource ?? 'none',
+		}
+		analytics.track('error-stack-trace-clicked', trackingProperties)
+	}
+
 	const trigger = (
 		<Box p="12" backgroundColor="n2">
 			{!!lineContent ? (
@@ -380,7 +392,7 @@ const StackSection: React.FC<React.PropsWithChildren<StackSectionProps>> = ({
 			<StackTraceSectionCollapsible
 				title={stackTraceTitle}
 				expanded={expanded}
-				setExpanded={setExpanded}
+				setExpanded={handleExpandedChange}
 				isLast={isLast}
 			>
 				{trigger}


### PR DESCRIPTION
## Summary
We do not have a good idea of what users are viewing in the error traces. Add an event, `error-stack-trace-clicked` when a user clicks to expand/hide the error stack trace, so we can filter sessions with this event name.

![Screenshot 2023-11-08 at 12 06 55 PM](https://github.com/highlight/highlight/assets/17744174/172329b4-d928-4934-a427-b0d0ce6e82ae)

## How did you test this change?
1) View an error
2) Click to expand an error trace. Click to hide it
3) Close your session and let process
4) Filter sessions out by the `error-stack-trace-clicked` event
- [ ] Session is returned in results
- [ ] The expected `error-stack-trace-clicked` event(s) are seen in the event log
- [ ] The event is recorded with the correct attributes

![Screenshot 2023-11-08 at 12 09 59 PM](https://github.com/highlight/highlight/assets/17744174/e41a0266-8eb0-466f-a4d3-98a68890b552)


## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
