### PR TITLE
Support NOT filters for logs and traces

### DIFF
--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -1336,6 +1336,60 @@ func Test_LogMatchesQuery_ClickHouse(t *testing.T) {
 	}
 }
 
+func Test_ReadLogsWithMultipleAttributeFilters_Clickhouse(t *testing.T) {
+	ctx := context.Background()
+	client, teardown := setupTest(t)
+	defer teardown(t)
+
+	now := time.Now()
+	oneSecondAgo := now.Add(-time.Second * 1)
+	var rows []*LogRow
+	for i := 1; i <= 10; i++ {
+		row := NewLogRow(oneSecondAgo, 1,
+			WithBody(ctx, "this is a test"),
+			WithSeverityText(modelInputs.LogLevelInfo.String()),
+			WithServiceName("frontend"),
+			WithTraceID(uuid.New().String()),
+			WithLogAttributes(map[string]string{
+				"os": "linux",
+			}))
+
+		row.LogAttributes["os"] = fmt.Sprintf("linux-%d", i)
+
+		rows = append(rows, row)
+	}
+
+	err := client.BatchWriteLogRows(ctx, rows)
+	assert.NoError(t, err)
+
+	// Test OR query
+	query := "os:linux-1 os:linux-2"
+	params := modelInputs.QueryInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     query,
+	}
+	conn, err := client.ReadLogs(ctx, 1, params, Pagination{})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(conn.Edges))
+	possibleValues := []string{"linux-1", "linux-2"}
+	for _, edge := range conn.Edges {
+		assert.Contains(t, possibleValues, edge.Node.LogAttributes["os"])
+	}
+
+	// Test AND query - using AND because of the NOT operator (-)
+	query = "os:linux-* os:-linux-4"
+	params = modelInputs.QueryInput{
+		DateRange: makeDateWithinRange(now),
+		Query:     query,
+	}
+	conn, err = client.ReadLogs(ctx, 1, params, Pagination{})
+	assert.NoError(t, err)
+	assert.Equal(t, 9, len(conn.Edges))
+	for _, edge := range conn.Edges {
+		assert.NotEqual(t, "linux-4", edge.Node.LogAttributes["os"])
+	}
+}
+
 func Test_LogMatchesNotQuery_ClickHouse(t *testing.T) {
 	ctx := context.Background()
 	client, teardown := setupTest(t)
@@ -1348,27 +1402,33 @@ func Test_LogMatchesNotQuery_ClickHouse(t *testing.T) {
 		row := NewLogRow(oneSecondAgo, 1,
 			WithBody(ctx, "this is a hello world message"),
 			WithSeverityText(modelInputs.LogLevelInfo.String()),
-			WithServiceName("all"),
+			WithServiceName("frontend"),
 			WithTraceID(uuid.New().String()),
 			WithLogAttributes(map[string]string{
-				"service":       "foo",
-				"os.type":       "linux",
-				"resource_name": "worker.kafka.process"}))
-		if i <= 6 {
-			row.ServiceName = "frontend"
-		}
+				"os.type": "linux",
+			}))
+
+		row.ServiceName = fmt.Sprintf("frontend-%d", i)
+		row.LogAttributes["os.type"] = fmt.Sprintf("linux-%d", i)
+
 		rows = append(rows, row)
 	}
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
 
-	query := "service_name:-frontend"
+	query := "service_name:frontend-* service_name:-frontend-2 service_name:-frontend-4 os.type:linu* os.type:-linux-3 os.type:-linux-5"
 	result, err := client.ReadLogs(ctx, 1, modelInputs.QueryInput{
 		DateRange: makeDateWithinRange(now),
 		Query:     query,
 	}, Pagination{})
 	assert.NoError(t, err)
 
-	assert.Equal(t, 4, len(result.Edges))
+	assert.Equal(t, 6, len(result.Edges))
+	for _, edge := range result.Edges {
+		assert.NotEqual(t, "frontend-2", *edge.Node.ServiceName)
+		assert.NotEqual(t, "frontend-4", *edge.Node.ServiceName)
+		assert.NotEqual(t, "linux-3", edge.Node.LogAttributes["os.type"])
+		assert.NotEqual(t, "linux-5", edge.Node.LogAttributes["os.type"])
+	}
 }
 
 func Test_LogMatchesQuery_ClickHouse_Body(t *testing.T) {

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -310,6 +310,8 @@ func makeFilterConditions(sb *sqlbuilder.SelectBuilder, filters []string, column
 	for _, filter := range filters {
 		if strings.Contains(filter, "%") {
 			conditions = append(conditions, sb.Like(column, filter))
+		} else if strings.HasPrefix(filter, "-") {
+			conditions = append(conditions, sb.NotEqual(column, strings.Replace(filter, "-", "", 1)))
 		} else {
 			conditions = append(conditions, sb.Equal(column, filter))
 		}
@@ -497,6 +499,10 @@ func matchesQuery[TObj interface{}, TReservedKey ~string](row *TObj, config tabl
 		for _, v := range values {
 			if strings.Contains(v, "%") {
 				if matched, _ := regexp.Match(strings.ReplaceAll(v, "%", ".*"), []byte(rowValue)); !matched {
+					return false
+				}
+			} else if strings.HasPrefix(v, "-") {
+				if rowValue == strings.Replace(v, "-", "", 1) {
 					return false
 				}
 			} else if v != rowValue {

--- a/docs-content/general/6_product-features/4_logging/log-search.md
+++ b/docs-content/general/6_product-features/4_logging/log-search.md
@@ -46,6 +46,11 @@ We can search for it via:
 - `user_id:42` matches every log where `user_id` is `42`
 - `level:info` matches every log where `level` is `info`
 
+We can exclude logs that match an attribute by prefixing it with `-`:
+
+- `user_id:-42` matches every log _except_ logs where `user_id` is `42`
+- `level:-info` matches every log _except_ logs where `level` is `info`
+
 #### AND vs OR
 
 When multiple attributes are included, they work as an `AND` operator:

--- a/docs-content/general/6_product-features/4_logging/log-search.md
+++ b/docs-content/general/6_product-features/4_logging/log-search.md
@@ -48,8 +48,8 @@ We can search for it via:
 
 We can exclude logs that match an attribute by prefixing it with `-`:
 
-- `user_id:-42` matches every log _except_ logs where `user_id` is `42`
-- `level:-info` matches every log _except_ logs where `level` is `info`
+- `user_id:-42` matches every log where `user_id` _is not_ `42`
+- `level:-info` matches every log where `level` _is not_ `info`
 
 #### AND vs OR
 

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -12,6 +12,7 @@ import {
 	Combobox,
 	defaultPresets,
 	getNow,
+	IconSolidExternalLink,
 	IconSolidPlus,
 	IconSolidSearch,
 	IconSolidSwitchVertical,
@@ -36,6 +37,7 @@ import {
 } from 'use-query-params'
 
 import { Button } from '@/components/Button'
+import { LinkButton } from '@/components/LinkButton'
 import {
 	TIME_FORMAT,
 	TIME_MODE,
@@ -321,12 +323,12 @@ export const Search: React.FC<{
 		const isValueSelect = typeof key === 'string'
 		const activeTermKey = queryTerms[activeTermIndex].key
 		const isLastTerm = activeTermIndex === queryTerms.length - 1
+		const prefix = activeTerm.value.startsWith('-') ? '-' : ''
 
-		// If string, it's a value not a key
 		if (isValueSelect) {
 			queryTerms[activeTermIndex].value = !!noQuotes
-				? key
-				: quoteQueryValue(key)
+				? `${prefix}${key}`
+				: `${prefix}${quoteQueryValue(key)}`
 		} else {
 			if (activeTermKey === BODY_KEY && activeTerm.value.endsWith(' ')) {
 				queryTerms[activeTermIndex].value =
@@ -573,10 +575,20 @@ export const Search: React.FC<{
 							alignItems="center"
 							gap="6"
 						>
-							<Badge variant="gray" size="small" label="*" />
-							<Text color="weak" size="xSmall">
-								Wildcard
-							</Text>
+							<LinkButton
+								trackingId="search-form_docs"
+								// TODO: Create docs + update link
+								// TODO: Update typeahead to remove prefixes like "-" so
+								// typeahead still filters results correctly.
+								to="https://highlight.io/docs/search"
+								target="_blank"
+								size="xSmall"
+								kind="secondary"
+								emphasis="high"
+								iconRight={<IconSolidExternalLink />}
+							>
+								View docs
+							</LinkButton>
 						</Box>
 					</Box>
 				</Combobox.Popover>
@@ -661,15 +673,17 @@ const getVisibleKeys = (
 }
 
 const getVisibleValues = (activeQueryTerm: SearchParam, values?: string[]) => {
+	const activeTerm = activeQueryTerm.value.replace('-', '')
+
 	return (
 		values?.filter(
 			(v) =>
 				// Don't filter if no value has been typed
-				!activeQueryTerm.value.length ||
+				!activeTerm.length ||
 				// Exclude the current term since that is given special treatment
-				(v !== activeQueryTerm.value &&
+				(v !== activeTerm &&
 					// Return values that match the query term
-					v.indexOf(activeQueryTerm.value) > -1),
+					v.indexOf(activeTerm) > -1),
 		) || []
 	)
 }

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -327,7 +327,7 @@ export const Search: React.FC<{
 
 		if (isValueSelect) {
 			queryTerms[activeTermIndex].value = !!noQuotes
-				? `${prefix}${key}`
+				? key
 				: `${prefix}${quoteQueryValue(key)}`
 		} else {
 			if (activeTermKey === BODY_KEY && activeTerm.value.endsWith(' ')) {
@@ -578,8 +578,6 @@ export const Search: React.FC<{
 							<LinkButton
 								trackingId="search-form_docs"
 								// TODO: Create docs + update link
-								// TODO: Update typeahead to remove prefixes like "-" so
-								// typeahead still filters results correctly.
 								to="https://highlight.io/docs/search"
 								target="_blank"
 								size="xSmall"

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -576,9 +576,8 @@ export const Search: React.FC<{
 							gap="6"
 						>
 							<LinkButton
-								trackingId="search-form_docs"
-								// TODO: Create docs + update link
-								to="https://highlight.io/docs/search"
+								trackingId="search-form_search-specification-docs-link"
+								to="https://www.highlight.io/docs/general/product-features/logging/log-search#attributes-search"
 								target="_blank"
 								size="xSmall"
 								kind="secondary"


### PR DESCRIPTION
## Summary

Adds support for `NOT` clauses on logs and traces by prefixing attributes with `-`. Also updates the docs and adds a link to view the docs for the search specification.

https://www.loom.com/share/e8482f8dc3f54d27bf0caaac330e879c

Note that this maintains the ability to assign multiple filters on the same attribute as OR queries, but any NOT filters will be applied using an AND.

## How did you test this change?

Local click test.

## Are there any deployment considerations?

Should keep an eye on performance of queries, especially on traces, otherwise just need to ensure filters continue to work as expected.

## Does this work require review from our design team?

N/A
