### PR TITLE
Add CI check for WithContext on GORM calls

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Check for GORM Debug
               run: if [ "$(grep --exclude-dir migrations -rE 'DB.[\s\n]*Debug\(\)' ./backend | wc -l)" -gt 0 ]; then grep --exclude-dir migrations -rE 'DB.[\s\n]*Debug\(\)' ./backend && exit 1; fi
             - name: Check for GORM usage without context
-              run: if [ "$(grep --exclude "*_test.go" -rE -i 'db\.(Where|Model|Raw|Create|Update|Preload)' ./backend/{public-graph,private-graph,worker} | grep -v 'WithContext' | wc -l)" -gt 0 ]; then grep --exclude "*_test.go" -rE -i 'db\.(Where|Model|Raw|Create|Update|Preload)' ./backend/{public-graph,private-graph,worker} | grep -v 'WithContext' && exit 1; fi
+              run: if [ "$(grep --exclude "*_test.go" -rE '(?i:db)\.(Where|Model|Raw|Create|Update|Preload)' ./backend/{public-graph,private-graph,worker,store,pricing} | grep -v 'WithContext' | wc -l)" -gt 0 ]; then grep --exclude "*_test.go" -rE '(?i:db)\.(Where|Model|Raw|Create|Update|Preload)' ./backend/{public-graph,private-graph,worker,store,pricing} | grep -v 'WithContext' && exit 1; fi
             - name: Check for logrus without context
               run: if [ "$(grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | grep -v 'Level' | wc -l)" -gt 0 ]; then grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | grep -v 'Level' && exit 1; fi
             - name: Run linter

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -32,6 +32,8 @@ jobs:
               run: if [ "$(gofmt -l -d ./backend | wc -l)" -gt 0 ]; then gofmt -l -d ./backend && exit 1; fi
             - name: Check for GORM Debug
               run: if [ "$(grep --exclude-dir migrations -rE 'DB.[\s\n]*Debug\(\)' ./backend | wc -l)" -gt 0 ]; then grep --exclude-dir migrations -rE 'DB.[\s\n]*Debug\(\)' ./backend && exit 1; fi
+            - name: Check for GORM usage without context
+              run: if [ "$(grep --exclude-dir migrations -rE -i 'db\.(Where|Model|Raw|Create|Update|Preload)' ./backend | grep -v 'WithContext' | wc -l)" -gt 0 ]; then grep --exclude-dir migrations -rE -i 'db\.(Where|Model|Raw|Create|Update|Preload)' ./backend | grep -v 'WithContext' && exit 1; fi
             - name: Check for logrus without context
               run: if [ "$(grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | grep -v 'Level' | wc -l)" -gt 0 ]; then grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | grep -v 'Level' && exit 1; fi
             - name: Run linter

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Check for GORM Debug
               run: if [ "$(grep --exclude-dir migrations -rE 'DB.[\s\n]*Debug\(\)' ./backend | wc -l)" -gt 0 ]; then grep --exclude-dir migrations -rE 'DB.[\s\n]*Debug\(\)' ./backend && exit 1; fi
             - name: Check for GORM usage without context
-              run: if [ "$(grep --exclude "*_test.go" -rE '(?i:db)\.(Where|Model|Raw|Create|Update|Preload)' ./backend/{public-graph,private-graph,worker,store,pricing} | grep -v 'WithContext' | wc -l)" -gt 0 ]; then grep --exclude "*_test.go" -rE '(?i:db)\.(Where|Model|Raw|Create|Update|Preload)' ./backend/{public-graph,private-graph,worker,store,pricing} | grep -v 'WithContext' && exit 1; fi
+              run: if [ "$(grep --exclude="*_test.go" --exclude-dir={integrations,jobs,lambda-functions,migrations,model,oauth,retryables,zapier} -rEI '(?i:db)\.(Where|Model|Raw|Create|Update|Preload)' ./backend | grep -v 'WithContext' | wc -l)" -gt 0 ]; then grep --exclude="*_test.go" --exclude-dir={integrations,jobs,lambda-functions,migrations,model,oauth,retryables,zapier} -rEI '(?i:db)\.(Where|Model|Raw|Create|Update|Preload)' ./backend | grep -v 'WithContext' && exit 1; fi
             - name: Check for logrus without context
               run: if [ "$(grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | grep -v 'Level' | wc -l)" -gt 0 ]; then grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | grep -v 'Level' && exit 1; fi
             - name: Run linter

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Check for GORM Debug
               run: if [ "$(grep --exclude-dir migrations -rE 'DB.[\s\n]*Debug\(\)' ./backend | wc -l)" -gt 0 ]; then grep --exclude-dir migrations -rE 'DB.[\s\n]*Debug\(\)' ./backend && exit 1; fi
             - name: Check for GORM usage without context
-              run: if [ "$(grep --exclude "*_test.go" -rE -i 'db\.(Where|Model|Raw|Create|Update|Preload)' ./backend/{public-graph,private-graph,model,worker} | grep -v 'WithContext' | wc -l)" -gt 0 ]; then grep --exclude "*_test.go" -rE -i 'db\.(Where|Model|Raw|Create|Update|Preload)' ./backend/{public-graph,private-graph,model,worker} | grep -v 'WithContext' && exit 1; fi
+              run: if [ "$(grep --exclude "*_test.go" -rE -i 'db\.(Where|Model|Raw|Create|Update|Preload)' ./backend/{public-graph,private-graph,worker} | grep -v 'WithContext' | wc -l)" -gt 0 ]; then grep --exclude "*_test.go" -rE -i 'db\.(Where|Model|Raw|Create|Update|Preload)' ./backend/{public-graph,private-graph,worker} | grep -v 'WithContext' && exit 1; fi
             - name: Check for logrus without context
               run: if [ "$(grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | grep -v 'Level' | wc -l)" -gt 0 ]; then grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | grep -v 'Level' && exit 1; fi
             - name: Run linter

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Check for GORM Debug
               run: if [ "$(grep --exclude-dir migrations -rE 'DB.[\s\n]*Debug\(\)' ./backend | wc -l)" -gt 0 ]; then grep --exclude-dir migrations -rE 'DB.[\s\n]*Debug\(\)' ./backend && exit 1; fi
             - name: Check for GORM usage without context
-              run: if [ "$(grep --exclude-dir migrations -rE -i 'db\.(Where|Model|Raw|Create|Update|Preload)' ./backend | grep -v 'WithContext' | wc -l)" -gt 0 ]; then grep --exclude-dir migrations -rE -i 'db\.(Where|Model|Raw|Create|Update|Preload)' ./backend | grep -v 'WithContext' && exit 1; fi
+              run: if [ "$(grep --exclude "*_test.go" -rE -i 'db\.(Where|Model|Raw|Create|Update|Preload)' ./backend/{public-graph,private-graph,model,worker} | grep -v 'WithContext' | wc -l)" -gt 0 ]; then grep --exclude "*_test.go" -rE -i 'db\.(Where|Model|Raw|Create|Update|Preload)' ./backend/{public-graph,private-graph,model,worker} | grep -v 'WithContext' && exit 1; fi
             - name: Check for logrus without context
               run: if [ "$(grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | grep -v 'Level' | wc -l)" -gt 0 ]; then grep --exclude-dir migrations --exclude main.go --exclude recovery.go --exclude logging.go -rE '\s+log\.(Debug|Info|Warn|Error|Fatal)' ./backend | grep -v 'WithContext' | grep -v 'Level' && exit 1; fi
             - name: Run linter

--- a/backend/embeddings/embeddings.go
+++ b/backend/embeddings/embeddings.go
@@ -6,14 +6,15 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
-	"gorm.io/gorm"
 	"io"
 	"math"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"gorm.io/gorm"
 
 	"github.com/highlight-run/highlight/backend/model"
 	e "github.com/pkg/errors"
@@ -238,7 +239,7 @@ func MatchErrorTag(ctx context.Context, db *gorm.DB, c Client, query string) ([]
 	}
 
 	var matchedErrorTags []*modelInputs.MatchedErrorTag
-	if err := db.Raw(`
+	if err := db.WithContext(ctx).Raw(`
 		select error_tags.embedding <-> @string_embedding as score,
 					error_tags.id as id,
 					error_tags.title as title,

--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -460,7 +460,7 @@ func getOrCreateUrls(ctx context.Context, projectId int, originalUrls []string, 
 			dateTrunc,
 		}
 	})
-	if err := db.Where("(project_id, original_url, date) IN ?", keys).Find(&results).Error; err != nil {
+	if err := db.WithContext(ctx).Where("(project_id, original_url, date) IN ?", keys).Find(&results).Error; err != nil {
 		return nil, errors.Wrap(err, "error querying saved assets")
 	}
 

--- a/backend/store/error_group_activity_logs.go
+++ b/backend/store/error_group_activity_logs.go
@@ -8,13 +8,13 @@ import (
 
 func (store *Store) CreateErrorGroupActivityLog(ctx context.Context,
 	params model.ErrorGroupActivityLog) error {
-	return store.db.Create(&params).Error
+	return store.db.WithContext(ctx).Create(&params).Error
 }
 
 func (store *Store) GetErrorGroupActivityLogs(errorGroupID int) ([]model.ErrorGroupActivityLog, error) {
 	errorGroupActivityLogs := []model.ErrorGroupActivityLog{}
 
-	err := store.db.Where(&model.ErrorGroupActivityLog{
+	err := store.db.WithContext(context.TODO()).Where(&model.ErrorGroupActivityLog{
 		ErrorGroupID: errorGroupID,
 	}).Find(&errorGroupActivityLogs).Error
 

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -31,7 +31,7 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 
 	var errorObjects []model.ErrorObject
 
-	query := store.db.Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).Limit(LIMIT + 1)
+	query := store.db.WithContext(context.TODO()).Where(&model.ErrorObject{ErrorGroupID: errorGroup.ID}).Limit(LIMIT + 1)
 
 	if params.Query != "" {
 		filters := queryparser.Parse(params.Query)
@@ -105,7 +105,7 @@ func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErr
 
 	// Preload sessions for non-null session IDs
 	var sessions []model.Session
-	err := store.db.Where("id IN (?)", sessionIDs).Find(&sessions).Error
+	err := store.db.WithContext(context.TODO()).Where("id IN (?)", sessionIDs).Find(&sessions).Error
 	if err != nil {
 		return privateModel.ErrorObjectConnection{}, errors.New("Failed to preload sessions for error objects")
 	}
@@ -207,7 +207,7 @@ func (store *Store) updateErrorGroupState(ctx context.Context,
 
 	var errorGroup model.ErrorGroup
 
-	if err := store.db.Where(&model.ErrorGroup{
+	if err := store.db.WithContext(ctx).Where(&model.ErrorGroup{
 		Model: model.Model{
 			ID: params.ID,
 		},

--- a/backend/store/project_filter_settings.go
+++ b/backend/store/project_filter_settings.go
@@ -3,9 +3,10 @@ package store
 import (
 	"context"
 	"fmt"
+	"time"
+
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/redis"
-	"time"
 
 	"github.com/highlight-run/highlight/backend/model"
 )
@@ -17,7 +18,7 @@ func getKey(projectID int) string {
 func (store *Store) GetProjectFilterSettings(ctx context.Context, projectID int, opts ...redis.Option) (*model.ProjectFilterSettings, error) {
 	return redis.CachedEval(ctx, store.redis, getKey(projectID), 250*time.Millisecond, time.Minute, func() (*model.ProjectFilterSettings, error) {
 		var projectFilterSettings model.ProjectFilterSettings
-		if err := store.db.Where(&model.ProjectFilterSettings{ProjectID: projectID}).FirstOrCreate(&projectFilterSettings).Error; err != nil {
+		if err := store.db.WithContext(ctx).Where(&model.ProjectFilterSettings{ProjectID: projectID}).FirstOrCreate(&projectFilterSettings).Error; err != nil {
 			return nil, err
 		}
 		return &projectFilterSettings, nil
@@ -100,7 +101,7 @@ func (store *Store) UpdateProjectFilterSettings(ctx context.Context, projectID i
 
 func (store *Store) FindProjectsWithAutoResolveSetting() ([]*model.ProjectFilterSettings, error) {
 	var projectFilterSettings []*model.ProjectFilterSettings
-	if err := store.db.Where("auto_resolve_stale_errors_day_interval > ?", 0).Find(&projectFilterSettings).Error; err != nil {
+	if err := store.db.WithContext(context.TODO()).Where("auto_resolve_stale_errors_day_interval > ?", 0).Find(&projectFilterSettings).Error; err != nil {
 		return nil, err
 	}
 	return projectFilterSettings, nil

--- a/backend/store/projects.go
+++ b/backend/store/projects.go
@@ -13,7 +13,7 @@ func (store *Store) GetProject(ctx context.Context, id int) (*model.Project, err
 	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("project-id-%d", id), 150*time.Millisecond, time.Minute, func() (*model.Project, error) {
 		var project model.Project
 
-		err := store.db.Where(&model.Project{
+		err := store.db.WithContext(ctx).Where(&model.Project{
 			Model: model.Model{
 				ID: id,
 			},

--- a/backend/store/services.go
+++ b/backend/store/services.go
@@ -43,7 +43,7 @@ func (store *Store) UpsertService(ctx context.Context, project model.Project, na
 			return nil, err
 		}
 
-		err = store.db.Model(&model.Service{}).Where(model.Service{
+		err = store.db.WithContext(ctx).Model(&model.Service{}).Where(model.Service{
 			Name:      name,
 			ProjectID: project.ID,
 		}).Take(&service).Error
@@ -56,7 +56,7 @@ func (store *Store) FindService(ctx context.Context, projectID int, name string)
 	return redis.CachedEval(ctx, store.redis, CacheServiceKey(name, projectID), 150*time.Millisecond, time.Minute, func() (*model.Service, error) {
 		service := model.Service{}
 
-		err := store.db.Where(&model.Service{
+		err := store.db.WithContext(ctx).Where(&model.Service{
 			ProjectID: projectID,
 			Name:      name,
 		}).Take(&service).Error
@@ -66,7 +66,7 @@ func (store *Store) FindService(ctx context.Context, projectID int, name string)
 }
 
 func (store *Store) UpdateServiceErrorState(ctx context.Context, serviceID int, errorDetails []string) error {
-	err := store.db.Model(&model.Service{Model: model.Model{ID: serviceID}}).Updates(&model.Service{
+	err := store.db.WithContext(ctx).Model(&model.Service{Model: model.Model{ID: serviceID}}).Updates(&model.Service{
 		Status: "error", ErrorDetails: errorDetails}).Error
 
 	return err
@@ -93,7 +93,7 @@ func (store *Store) ListServices(project model.Project, params ListServicesParam
 
 	var services []model.Service
 
-	query := store.db.Where(&model.Service{ProjectID: project.ID}).Limit(SERVICE_LIMIT + 1)
+	query := store.db.WithContext(context.TODO()).Where(&model.Service{ProjectID: project.ID}).Limit(SERVICE_LIMIT + 1)
 
 	if params.Query != nil {
 		filters := queryparser.Parse(*params.Query)

--- a/backend/store/sessions.go
+++ b/backend/store/sessions.go
@@ -3,16 +3,17 @@ package store
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/redis"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 func (store *Store) GetSessionFromSecureID(ctx context.Context, secureID string) (*model.Session, error) {
 	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("session-secure-%s", secureID), 150*time.Millisecond, time.Second, func() (*model.Session, error) {
 		var session model.Session
-		if err := store.db.Model(&session).Where(&model.Session{SecureID: secureID}).Take(&session).Error; err != nil {
+		if err := store.db.WithContext(ctx).Model(&session).Where(&model.Session{SecureID: secureID}).Take(&session).Error; err != nil {
 			log.WithContext(ctx).WithError(err).WithField("session_secure_id", secureID).Error("failed to get session by secure id")
 			return nil, err
 		}
@@ -23,7 +24,7 @@ func (store *Store) GetSessionFromSecureID(ctx context.Context, secureID string)
 func (store *Store) GetSession(ctx context.Context, sessionID int) (*model.Session, error) {
 	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("session-id-%d", sessionID), 150*time.Millisecond, time.Second, func() (*model.Session, error) {
 		var session model.Session
-		if err := store.db.Model(&session).Where(&model.Session{Model: model.Model{ID: sessionID}}).Take(&session).Error; err != nil {
+		if err := store.db.WithContext(ctx).Model(&session).Where(&model.Session{Model: model.Model{ID: sessionID}}).Take(&session).Error; err != nil {
 			log.WithContext(ctx).WithError(err).WithField("session_id", sessionID).Error("failed to get session by id")
 			return nil, err
 		}

--- a/backend/store/system_configuration.go
+++ b/backend/store/system_configuration.go
@@ -2,15 +2,16 @@ package store
 
 import (
 	"context"
+	"time"
+
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/redis"
-	"time"
 )
 
 func (store *Store) GetSystemConfiguration(ctx context.Context) (*model.SystemConfiguration, error) {
 	return redis.CachedEval(ctx, store.redis, "system-configuration", 250*time.Millisecond, time.Minute, func() (*model.SystemConfiguration, error) {
 		config := model.SystemConfiguration{Active: true}
-		if err := store.db.Model(&config).Where(&config).FirstOrCreate(&config).Error; err != nil {
+		if err := store.db.WithContext(ctx).Model(&config).Where(&config).FirstOrCreate(&config).Error; err != nil {
 			return nil, err
 		}
 		return &config, nil

--- a/backend/store/workspace_settings.go
+++ b/backend/store/workspace_settings.go
@@ -3,15 +3,16 @@ package store
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/redis"
-	"time"
 )
 
 func (store *Store) GetAllWorkspaceSettings(ctx context.Context, workspaceID int) (*model.AllWorkspaceSettings, error) {
 	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-workspace-%d", workspaceID), 250*time.Millisecond, time.Minute, func() (*model.AllWorkspaceSettings, error) {
 		var workspaceSettings model.AllWorkspaceSettings
-		if err := store.db.Where(model.AllWorkspaceSettings{WorkspaceID: workspaceID}).FirstOrCreate(&workspaceSettings).Error; err != nil {
+		if err := store.db.WithContext(ctx).Where(model.AllWorkspaceSettings{WorkspaceID: workspaceID}).FirstOrCreate(&workspaceSettings).Error; err != nil {
 			return nil, err
 		}
 		return &workspaceSettings, nil
@@ -21,7 +22,7 @@ func (store *Store) GetAllWorkspaceSettings(ctx context.Context, workspaceID int
 func (store *Store) GetAllWorkspaceSettingsByProject(ctx context.Context, projectID int) (*model.AllWorkspaceSettings, error) {
 	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("all-workspace-settings-project-%d", projectID), 250*time.Millisecond, time.Minute, func() (*model.AllWorkspaceSettings, error) {
 		var workspaceSettings model.AllWorkspaceSettings
-		if err := store.db.Model(&model.AllWorkspaceSettings{}).Joins("INNER JOIN projects ON projects.workspace_id = all_workspace_settings.workspace_id").Where("projects.id = ?", projectID).Take(&workspaceSettings).Error; err != nil {
+		if err := store.db.WithContext(ctx).Model(&model.AllWorkspaceSettings{}).Joins("INNER JOIN projects ON projects.workspace_id = all_workspace_settings.workspace_id").Where("projects.id = ?", projectID).Take(&workspaceSettings).Error; err != nil {
 			return nil, err
 		}
 		return &workspaceSettings, nil

--- a/backend/store/workspaces.go
+++ b/backend/store/workspaces.go
@@ -13,7 +13,7 @@ func (store *Store) GetWorkspace(ctx context.Context, id int) (*model.Workspace,
 	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("workspace-id-%d", id), 150*time.Millisecond, time.Minute, func() (*model.Workspace, error) {
 		var workspace model.Workspace
 
-		err := store.db.Where(&model.Workspace{
+		err := store.db.WithContext(ctx).Where(&model.Workspace{
 			Model: model.Model{
 				ID: id,
 			},

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1240,7 +1240,7 @@ func (w *Worker) RefreshMaterializedViews(ctx context.Context) {
 		c.ErrorCountLastDay += errorResults[idx].ErrorCountLastDay
 
 		workspace := &model.Workspace{}
-		if err := w.Resolver.DB.Preload("Projects").Model(&model.Workspace{}).Where("id = ?", c.WorkspaceID).Take(&workspace).Error; err != nil {
+		if err := w.Resolver.DB.WithContext(ctx).Preload("Projects").Model(&model.Workspace{}).Where("id = ?", c.WorkspaceID).Take(&workspace).Error; err != nil {
 			continue
 		}
 		c.TrialEndDate = workspace.TrialEndDate
@@ -1596,7 +1596,7 @@ func reportProcessSessionCount(ctx context.Context, db *gorm.DB, lookbackPeriod,
 	for {
 		time.Sleep(1*time.Minute + time.Duration(59*float64(time.Minute.Nanoseconds())*rand.Float64()))
 		var count int64
-		if err := db.Raw(`
+		if err := db.WithContext(ctx).Raw(`
 			SELECT COUNT(*)
 			FROM sessions
 			WHERE (processed = false)


### PR DESCRIPTION
## Summary

Adds a new CI rule checking that we call `WithContext` everywhere we perform certain GORM operations and fixes all the violations. Currently ignoring many areas of the codebase and many violations were fixed by using `context.TODO()`. We should look at filling in the missing contexts and expanding coverage of the linting rule over time, but the key areas of our background codebase are covered with this.

## How did you test this change?

Ran in CI + click tested locally.

## Are there any deployment considerations?

Should keep an eye on any new errors, but should be a fairly safe change if builds are clean.

## Does this work require review from our design team?

N/A
