### PR TITLE
create new mv to for indexing traces by id

### DIFF
--- a/backend/clickhouse/migrations/000059_create_traces_by_id_mv.down.sql
+++ b/backend/clickhouse/migrations/000059_create_traces_by_id_mv.down.sql
@@ -1,0 +1,2 @@
+DROP VIEW IF EXISTS traces_by_id_mv;
+DROP TABLE IF EXISTS traces_by_id;

--- a/backend/clickhouse/migrations/000059_create_traces_by_id_mv.up.sql
+++ b/backend/clickhouse/migrations/000059_create_traces_by_id_mv.up.sql
@@ -1,0 +1,53 @@
+CREATE TABLE IF NOT EXISTS traces_by_id (
+    `Timestamp` DateTime64(9),
+    `UUID` UUID,
+    `TraceId` String,
+    `SpanId` String,
+    `ParentSpanId` String,
+    `ProjectId` UInt32,
+    `SecureSessionId` String,
+    `TraceState` String,
+    `SpanName` LowCardinality(String),
+    `SpanKind` LowCardinality(String),
+    `Duration` Int64,
+    `ServiceName` LowCardinality(String),
+    `ServiceVersion` String,
+    `TraceAttributes` Map(LowCardinality(String), String),
+    `StatusCode` LowCardinality(String),
+    `StatusMessage` String,
+    `Events.Timestamp` Array(DateTime64(9)),
+    `Events.Name` Array(LowCardinality(String)),
+    `Events.Attributes` Array(Map(LowCardinality(String), String)),
+    `Links.TraceId` Array(String),
+    `Links.SpanId` Array(String),
+    `Links.TraceState` Array(String),
+    `Links.Attributes` Array(Map(LowCardinality(String), String))
+) ENGINE = MergeTree
+ORDER BY (ProjectId, TraceId) TTL toDateTime(Timestamp) + toIntervalDay(30);
+CREATE MATERIALIZED VIEW IF NOT EXISTS traces_by_id_mv TO traces_by_id (
+    `Timestamp` DateTime64(9),
+    `UUID` UUID,
+    `TraceId` String,
+    `SpanId` String,
+    `ParentSpanId` String,
+    `ProjectId` UInt32,
+    `SecureSessionId` String,
+    `TraceState` String,
+    `SpanName` LowCardinality(String),
+    `SpanKind` LowCardinality(String),
+    `Duration` Int64,
+    `ServiceName` LowCardinality(String),
+    `ServiceVersion` String,
+    `TraceAttributes` Map(LowCardinality(String), String),
+    `StatusCode` LowCardinality(String),
+    `StatusMessage` String,
+    `Events.Timestamp` Array(DateTime64(9)),
+    `Events.Name` Array(LowCardinality(String)),
+    `Events.Attributes` Array(Map(LowCardinality(String), String)),
+    `Links.TraceId` Array(String),
+    `Links.SpanId` Array(String),
+    `Links.TraceState` Array(String),
+    `Links.Attributes` Array(Map(LowCardinality(String), String))
+) AS
+SELECT *
+FROM traces;

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -3,9 +3,10 @@ package clickhouse
 import (
 	"context"
 	"fmt"
-	"github.com/highlight/highlight/sdk/highlight-go"
 	"strconv"
 	"time"
+
+	"github.com/highlight/highlight/sdk/highlight-go"
 
 	"github.com/highlight-run/highlight/backend/queryparser"
 	"golang.org/x/exp/slices"
@@ -25,6 +26,7 @@ const TracesSamplingTable = "traces_sampling"
 const TraceKeysTable = "trace_keys"
 const TraceKeyValuesTable = "trace_key_values"
 const TraceMetricsTable = "trace_metrics"
+const TracesByIdTable = "traces_by_id"
 
 var traceKeysToColumns = map[modelInputs.ReservedTraceKey]string{
 	modelInputs.ReservedTraceKeySecureSessionID: "SecureSessionId",
@@ -245,7 +247,7 @@ func (client *Client) ReadTrace(ctx context.Context, projectID int, traceID stri
 	var err error
 	var args []interface{}
 
-	sb.From("traces").
+	sb.From(TracesByIdTable).
 		Select("Timestamp, UUID, TraceId, SpanId, ParentSpanId, ProjectId, SecureSessionId, TraceState, SpanName, SpanKind, Duration, ServiceName, ServiceVersion, TraceAttributes, StatusCode, StatusMessage").
 		Where(sb.Equal("ProjectId", projectID)).
 		Where(sb.Equal("TraceId", traceID))


### PR DESCRIPTION
## Summary
- currently using a projection for querying traces by their id, however it is a bit slow because it is partitioned by date like the parent table
- this creates a separate table + materialized view with the same `order by` 
- closes #7098 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- the materialized view has already been created in prod
- can drop the existing projection after this is deployed
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
