### PR TITLE
tweak export settings

### DIFF
--- a/sdk/highlight-java/highlight-sdk/src/main/java/io/highlight/sdk/HighlightOpenTelemetry.java
+++ b/sdk/highlight-java/highlight-sdk/src/main/java/io/highlight/sdk/HighlightOpenTelemetry.java
@@ -75,9 +75,11 @@ public class HighlightOpenTelemetry implements OpenTelemetry {
 		SpanExporter tracerExporter = OtlpHttpSpanExporter.builder()
 				.setEndpoint(HighlightRoute.buildTraceRoute(options.backendUrl()))
 				.setCompression("gzip")
+				.setTimeout(Duration.ofSeconds(30))
 				.build();
 
 		BatchSpanProcessor tracerProcessor = BatchSpanProcessor.builder(tracerExporter)
+				.setExporterTimeout(Duration.ofSeconds(30))
 		        .setScheduleDelay(Duration.ofSeconds(1))
 		        .setMaxExportBatchSize(128)
 		        .setMaxQueueSize(1024)
@@ -92,9 +94,15 @@ public class HighlightOpenTelemetry implements OpenTelemetry {
 		// Log
 		LogRecordExporter logExporter = OtlpHttpLogRecordExporter.builder()
 				.setEndpoint(HighlightRoute.buildLogRoute(options.backendUrl()))
+				.setCompression("gzip")
+				.setTimeout(Duration.ofSeconds(30))
 				.build();
 
 		LogRecordProcessor logProcessor = BatchLogRecordProcessor.builder(logExporter)
+				.setExporterTimeout(Duration.ofSeconds(30))
+				.setScheduleDelay(Duration.ofSeconds(1))
+				.setMaxExportBatchSize(128)
+				.setMaxQueueSize(1024)
 				.build();
 
 		this.loggerProvider = SdkLoggerProvider.builder()


### PR DESCRIPTION
## Summary

Tune OTLP export for the Java SDK.

* Turns on gzip compression for logs
* Decreases frequency of export and increases batching.
* Increases export timeouts.

## How did you test this change?

Local deploy
<img width="1102" alt="Screenshot 2023-11-09 at 11 08 32 PM" src="https://github.com/highlight/highlight/assets/1351531/755c3ebf-ff47-4adc-8ed5-0686926bf73e">


## Are there any deployment considerations?

Releasing new java tag.

## Does this work require review from our design team?

No