### PR TITLE
Notify users when there are more traces to load

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6160,9 +6160,8 @@ body {
   width: 100%;
   border: var(--_1pyqka91o) solid 1px;
 }
-.ccrj1p3 {
-  border: none;
-  border-top: var(--_1pyqka9k) solid 1px;
+.ccrj1p2 {
+  border: 0;
   border-radius: 0;
 }
 ._1ukfp2a0 {

--- a/frontend/src/__generated/ve/components/FeedResults/FeedResults.css.js
+++ b/frontend/src/__generated/ve/components/FeedResults/FeedResults.css.js
@@ -1,1 +1,1 @@
-import{createRuntimeFn as a}from"@vanilla-extract/recipes/createRuntimeFn";var s=a({defaultClassName:"ccrj1p0",variantClassNames:{type:{sessions:"ccrj1p1",errors:"ccrj1p2",logs:"ccrj1p3"}},defaultVariants:{},compoundVariants:[]});export{s as variants};
+import{createRuntimeFn as a}from"@vanilla-extract/recipes/createRuntimeFn";var e=a({defaultClassName:"ccrj1p0",variantClassNames:{type:{rounded:"ccrj1p1",square:"ccrj1p2"}},defaultVariants:{},compoundVariants:[]});export{e as variants};

--- a/frontend/src/components/FeedResults/FeedResults.css.ts
+++ b/frontend/src/components/FeedResults/FeedResults.css.ts
@@ -8,11 +8,9 @@ export const variants = recipe({
 	},
 	variants: {
 		type: {
-			sessions: {},
-			errors: {},
-			logs: {
-				border: 'none',
-				borderTop: vars.border.dividerWeak,
+			rounded: {},
+			square: {
+				border: 0,
 				borderRadius: 0,
 			},
 		},

--- a/frontend/src/components/FeedResults/FeedResults.tsx
+++ b/frontend/src/components/FeedResults/FeedResults.tsx
@@ -7,11 +7,13 @@ import * as style from './FeedResults.css'
 
 interface Props {
 	more: number
-	type: 'sessions' | 'errors' | 'logs'
+	type: 'sessions' | 'errors' | 'logs' | 'traces'
 	onClick: () => void
 }
 
 export const AdditionalFeedResults = function ({ more, type, onClick }: Props) {
+	const rounded = ['sessions', 'errors'].includes(type)
+
 	return (
 		<AnimatePresence>
 			{more > 0 ? (
@@ -23,8 +25,8 @@ export const AdditionalFeedResults = function ({ more, type, onClick }: Props) {
 					transition={{ duration: 0.1 }}
 				>
 					<Box
-						paddingTop={type === 'logs' ? undefined : '8'}
-						px={type === 'logs' ? undefined : '8'}
+						paddingTop={rounded ? '8' : undefined}
+						px={rounded ? '8' : undefined}
 						width="full"
 						display="flex"
 						alignItems="center"
@@ -33,21 +35,18 @@ export const AdditionalFeedResults = function ({ more, type, onClick }: Props) {
 						<Button
 							kind="secondary"
 							size="small"
-							emphasis={type === 'logs' ? 'low' : 'medium'}
+							emphasis={rounded ? 'medium' : 'low'}
 							trackingId="SessionsFeedMore"
-							className={style.variants({ type })}
+							className={style.variants({
+								type: rounded ? 'rounded' : 'square',
+							})}
 							onClick={onClick}
 						>
 							<Box display="flex" alignItems="center" gap="8">
 								<IconOutlineArrowNarrowUp />
 								<Text>
 									{more}
-									{type === 'logs'
-										? more === 50
-											? '+'
-											: ''
-										: ''}{' '}
-									new{' '}
+									{more >= 50 ? '+' : ''} new{' '}
 									{more === 1
 										? type.slice(0, type.length - 1)
 										: type}

--- a/frontend/src/pages/Traces/TracePage.tsx
+++ b/frontend/src/pages/Traces/TracePage.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, Heading, Stack, Tabs, Text } from '@highlight-run/ui'
+import { Badge, Box, Callout, Heading, Stack, Tabs } from '@highlight-run/ui'
 import moment from 'moment'
 import React, { useState } from 'react'
 
@@ -35,8 +35,8 @@ export const TracePage: React.FC<Props> = () => {
 		return loading ? (
 			<LoadingBox />
 		) : (
-			<Box>
-				<Text>Trace not found</Text>
+			<Box p="8">
+				<Callout kind="error" title="Trace not found" />
 			</Box>
 		)
 	}

--- a/frontend/src/pages/Traces/TracePanel.tsx
+++ b/frontend/src/pages/Traces/TracePanel.tsx
@@ -21,13 +21,8 @@ import { useParams } from '@/util/react-router/useParams'
 import * as styles from './TracePanel.css'
 
 export const TracePanel: React.FC = () => {
-	const {
-		project_id: projectId,
-		trace_id: traceId,
-		span_id: spanId,
-	} = useParams<{
+	const { project_id: projectId, span_id: spanId } = useParams<{
 		project_id: string
-		trace_id: string
 		span_id?: string
 	}>()
 	const navigate = useNavigate()
@@ -36,6 +31,7 @@ export const TracePanel: React.FC = () => {
 	const currentTraceIndex = traces.findIndex(
 		(trace) => trace.spanID === spanId,
 	)
+	const currentTrace = traces[currentTraceIndex]
 	const nextTrace = traces[currentTraceIndex + 1]
 	const previousTrace = traces[currentTraceIndex - 1]
 
@@ -127,7 +123,7 @@ export const TracePanel: React.FC = () => {
 			</Box>
 			<TraceProvider
 				projectId={projectId!}
-				traceId={traceId!}
+				traceId={currentTrace?.traceID}
 				spanId={spanId}
 			>
 				<TracePage />

--- a/frontend/src/pages/Traces/TracePanel.tsx
+++ b/frontend/src/pages/Traces/TracePanel.tsx
@@ -21,8 +21,13 @@ import { useParams } from '@/util/react-router/useParams'
 import * as styles from './TracePanel.css'
 
 export const TracePanel: React.FC = () => {
-	const { project_id: projectId, span_id: spanId } = useParams<{
+	const {
+		project_id: projectId,
+		trace_id: traceId,
+		span_id: spanId,
+	} = useParams<{
 		project_id: string
+		trace_id: string
 		span_id?: string
 	}>()
 	const navigate = useNavigate()
@@ -31,7 +36,6 @@ export const TracePanel: React.FC = () => {
 	const currentTraceIndex = traces.findIndex(
 		(trace) => trace.spanID === spanId,
 	)
-	const currentTrace = traces[currentTraceIndex]
 	const nextTrace = traces[currentTraceIndex + 1]
 	const previousTrace = traces[currentTraceIndex - 1]
 
@@ -123,7 +127,7 @@ export const TracePanel: React.FC = () => {
 			</Box>
 			<TraceProvider
 				projectId={projectId!}
-				traceId={currentTrace?.traceID}
+				traceId={traceId!}
 				spanId={spanId}
 			>
 				<TracePage />

--- a/frontend/src/pages/Traces/TraceProvider.tsx
+++ b/frontend/src/pages/Traces/TraceProvider.tsx
@@ -63,6 +63,7 @@ export const TraceProvider: React.FC<React.PropsWithChildren<Props>> = ({
 			}
 		},
 		skip: !projectId || !traceId,
+		fetchPolicy: 'cache-and-network',
 	})
 
 	const { startTime, duration: totalDuration } = useMemo(() => {

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -12,6 +12,7 @@ import {
 import React from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
+import { AdditionalFeedResults } from '@/components/FeedResults/FeedResults'
 import { LinkButton } from '@/components/LinkButton'
 import LoadingBox from '@/components/LoadingBox'
 import { GetTracesQuery } from '@/graph/generated/operations'
@@ -21,12 +22,21 @@ import { useParams } from '@/util/react-router/useParams'
 
 type Props = {
 	loading: boolean
+	numMoreTraces?: number
 	traces?: GetTracesQuery['traces']
+	handleAdditionalTracesDateChange?: () => void
+	resetMoreTraces?: () => void
 }
 
 const gridColumns = ['2fr', '1fr', '2fr', '1fr', '2fr', '1.2fr']
 
-export const TracesList: React.FC<Props> = ({ loading, traces }) => {
+export const TracesList: React.FC<Props> = ({
+	loading,
+	numMoreTraces,
+	traces,
+	handleAdditionalTracesDateChange,
+	resetMoreTraces,
+}) => {
 	const { projectId } = useProjectId()
 	const { span_id } = useParams<{ span_id?: string }>()
 	const navigate = useNavigate()
@@ -53,13 +63,31 @@ export const TracesList: React.FC<Props> = ({ loading, traces }) => {
 							<Table.Header>Secure Session ID</Table.Header>
 							<Table.Header>Timestamp</Table.Header>
 						</Table.Row>
+						{numMoreTraces !== undefined && numMoreTraces > 0 && (
+							<Table.Row>
+								<Box width="full">
+									<AdditionalFeedResults
+										more={numMoreTraces}
+										type="traces"
+										onClick={() => {
+											resetMoreTraces && resetMoreTraces()
+											handleAdditionalTracesDateChange &&
+												handleAdditionalTracesDateChange()
+										}}
+									/>
+								</Box>
+							</Table.Row>
+						)}
 					</Table.Head>
 					<Table.Body
 						height="full"
 						overflowY="auto"
 						style={{
 							// Subtract height of search filters + table header + charts
-							height: `calc(100% - 163px)`,
+							height:
+								numMoreTraces && numMoreTraces > 0
+									? `calc(100% - 191px)`
+									: `calc(100% - 163px)`,
 						}}
 					>
 						{traces.edges

--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -141,8 +141,6 @@ export const TracesPage: React.FC = () => {
 		}, []),
 	})
 
-	console.log('::: moreTraces', numMoreTraces)
-
 	const histogramBuckets = metricsData?.traces_metrics.buckets
 		.filter((b) => b.metric_type === MetricAggregator.Count)
 		.map((b) => ({

--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -1,7 +1,7 @@
-import { Box, defaultPresets, Text } from '@highlight-run/ui'
+import { Box, defaultPresets, getNow, Text } from '@highlight-run/ui'
 import _ from 'lodash'
 import moment from 'moment'
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { Helmet } from 'react-helmet'
 import { Outlet } from 'react-router-dom'
 import { useQueryParam } from 'use-query-params'
@@ -24,9 +24,14 @@ import {
 import {
 	useGetTracesKeysQuery,
 	useGetTracesKeyValuesLazyQuery,
+	useGetTracesLazyQuery,
 	useGetTracesMetricsQuery,
 	useGetTracesQuery,
 } from '@/graph/generated/hooks'
+import {
+	GetTracesQuery,
+	GetTracesQueryVariables,
+} from '@/graph/generated/operations'
 import {
 	MetricAggregator,
 	SortDirection,
@@ -38,6 +43,7 @@ import LogsHistogram from '@/pages/LogsPage/LogsHistogram/LogsHistogram'
 import { LatencyChart } from '@/pages/Traces/LatencyChart'
 import { TracesList } from '@/pages/Traces/TracesList'
 import { formatNumber } from '@/util/numbers'
+import { usePollQuery } from '@/util/search'
 
 import * as styles from './TracesPage.css'
 
@@ -59,6 +65,10 @@ export const TracesPage: React.FC = () => {
 	const handleDatesChange = (newStartDate: Date, newEndDate: Date) => {
 		setStartDate(newStartDate)
 		setEndDate(newEndDate)
+	}
+
+	const handleAdditionTracesDateChange = () => {
+		handleDatesChange(defaultPresets[0].startDate, getNow().toDate())
 	}
 
 	const { data, loading } = useGetTracesQuery({
@@ -96,7 +106,42 @@ export const TracesPage: React.FC = () => {
 				],
 			},
 			skip: !projectId,
+			fetchPolicy: 'cache-and-network',
 		})
+
+	const [moreDataQuery] = useGetTracesLazyQuery({
+		fetchPolicy: 'network-only',
+	})
+
+	const { numMore: numMoreTraces, reset: resetMoreTraces } = usePollQuery<
+		GetTracesQuery,
+		GetTracesQueryVariables
+	>({
+		variableFn: useCallback(
+			() => ({
+				project_id: projectId!,
+				direction: SortDirection.Desc,
+				params: {
+					query: serverQuery,
+					date_range: {
+						start_date: moment(endDate).format(TIME_FORMAT),
+						end_date: moment(endDate)
+							.add(1, 'hour')
+							.format(TIME_FORMAT),
+					},
+				},
+			}),
+			[endDate, projectId, serverQuery],
+		),
+		moreDataQuery,
+		getResultCount: useCallback((result) => {
+			if (result?.data?.traces.edges.length !== undefined) {
+				return result?.data?.traces.edges.length
+			}
+		}, []),
+	})
+
+	console.log('::: moreTraces', numMoreTraces)
 
 	const histogramBuckets = metricsData?.traces_metrics.buckets
 		.filter((b) => b.metric_type === MetricAggregator.Count)
@@ -255,7 +300,15 @@ export const TracesPage: React.FC = () => {
 						</Box>
 					</Box>
 
-					<TracesList traces={data?.traces} loading={loading} />
+					<TracesList
+						loading={loading}
+						numMoreTraces={numMoreTraces}
+						traces={data?.traces}
+						handleAdditionalTracesDateChange={
+							handleAdditionTracesDateChange
+						}
+						resetMoreTraces={resetMoreTraces}
+					/>
 				</Box>
 			</Box>
 


### PR DESCRIPTION
## Summary

Fetches more traces in the background and notifies users when there are more traces to load.

https://www.loom.com/share/0a43bec8b3064716931527a2f1955e00

## How did you test this change?

Local + PR preview click test.

## Are there any deployment considerations?

N/A - all client-side changes.

## Does this work require review from our design team?

Nope!