### PR TITLE
ensure we set up cross origin iframe recording correctly

### DIFF
--- a/.changeset/short-moons-applaud.md
+++ b/.changeset/short-moons-applaud.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+ensure cross origin iframe recording works even if the iframe reloads

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -895,7 +895,7 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			`highlight setting up cross origin iframe parent notification`,
 		)
 		// notify iframes that highlight is ready
-		const iframeInterval = setInterval(() => {
+		setInterval(() => {
 			window.document.querySelectorAll('iframe').forEach((iframe) => {
 				iframe.contentWindow?.postMessage(
 					{
@@ -906,20 +906,14 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 					'*',
 				)
 			})
-		}, 100) as unknown as number
-		// once an iframe responds that it got our message and it ready, clear the interval
-		const listener = (message: MessageEvent) => {
+		}, FIRST_SEND_FREQUENCY)
+		window.addEventListener('message', (message: MessageEvent) => {
 			if (message.data.highlight === IFRAME_PARENT_RESPONSE) {
 				this.logger.log(
 					`highlight got response from initialized iframe`,
 				)
-				// stop sending iframe messages
-				window.clearInterval(iframeInterval)
-				// stop listening to parent messages
-				window.removeEventListener('message', listener)
 			}
-		}
-		window.addEventListener('message', listener)
+		})
 	}
 
 	_setupWindowListeners() {


### PR DESCRIPTION
## Summary

A web app may have issues with cross origin iframe recording when the iframe
would be reloaded because the parent window would stop sending setup events
to child iframes.

This change ensures we continue to send setup events to potential highlight-instrumented
iframes so that iframe reloading would successfully record.

## How did you test this change?

Reflame preview continuing to record correctly.

## Are there any deployment considerations?

Changeset

## Does this work require review from our design team?

No