### PR TITLE
add support for @highlight-run/next flush and wait

### DIFF
--- a/.changeset/popular-kangaroos-repeat.md
+++ b/.changeset/popular-kangaroos-repeat.md
@@ -1,0 +1,6 @@
+---
+'@highlight-run/next': patch
+'@highlight-run/node': patch
+---
+
+allow arbitrarily waiting for flush to wait for logs to be sent to highlight

--- a/sdk/highlight-next/src/util/highlight-edge.ts
+++ b/sdk/highlight-next/src/util/highlight-edge.ts
@@ -83,12 +83,14 @@ export const H: HighlightInterface = {
 			}
 		}
 	},
-	consumeAndFlush: async (error: Error) => {
-		CloudflareH.consumeError(error)
-
+	waitForFlush: async () => {
 		if (executionContext?.waitUntilFinished) {
 			await executionContext.waitUntilFinished()
 		}
+	},
+	consumeAndFlush: async function (error: Error) {
+		CloudflareH.consumeError(error)
+		await this.waitForFlush()
 	},
 	stop: async () => {
 		throw new Error('H.stop is not supported by the Edge runtime.')

--- a/sdk/highlight-next/src/util/highlight-edge.ts
+++ b/sdk/highlight-next/src/util/highlight-edge.ts
@@ -83,22 +83,17 @@ export const H: HighlightInterface = {
 			}
 		}
 	},
-	waitForFlush: async () => {
+	flush: async () => {
 		if (executionContext?.waitUntilFinished) {
 			await executionContext.waitUntilFinished()
 		}
 	},
 	consumeAndFlush: async function (error: Error) {
 		CloudflareH.consumeError(error)
-		await this.waitForFlush()
+		await this.flush()
 	},
 	stop: async () => {
 		throw new Error('H.stop is not supported by the Edge runtime.')
-	},
-	flush: async () => {
-		throw new Error(
-			'H.flush is not supported by the Edge runtime. try H.consumeAndFlush instead.',
-		)
 	},
 	recordMetric: (
 		secureSessionId: string,

--- a/sdk/highlight-next/src/util/types.ts
+++ b/sdk/highlight-next/src/util/types.ts
@@ -39,7 +39,6 @@ export interface HighlightInterface {
 		requestId?: string,
 		metadata?: Attributes,
 	) => void
-	waitForFlush: () => Promise<void>
 	consumeAndFlush: (
 		error: Error,
 		secureSessionId?: string,

--- a/sdk/highlight-next/src/util/types.ts
+++ b/sdk/highlight-next/src/util/types.ts
@@ -39,6 +39,7 @@ export interface HighlightInterface {
 		requestId?: string,
 		metadata?: Attributes,
 	) => void
+	waitForFlush: () => Promise<void>
 	consumeAndFlush: (
 		error: Error,
 		secureSessionId?: string,


### PR DESCRIPTION
## Summary

Allows explicitly waiting to flush to ensure console logs are shipped to highlight.

## How did you test this change?

Vercel deploy

## Are there any deployment considerations?

Changeset

## Does this work require review from our design team?

No
