### PR TITLE
fix @highlight-run/node crashing due to encoding not being polyfilled

### DIFF
--- a/.changeset/five-stingrays-glow.md
+++ b/.changeset/five-stingrays-glow.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': patch
+---
+
+fix @highlight-run/node crashing due to encoding not being polyfilled

--- a/sdk/highlight-next/src/util/highlight-edge.ts
+++ b/sdk/highlight-next/src/util/highlight-edge.ts
@@ -93,10 +93,8 @@ export const H: HighlightInterface = {
 	stop: async () => {
 		throw new Error('H.stop is not supported by the Edge runtime.')
 	},
-	flush: async () => {
-		throw new Error(
-			'H.flush is not supported by the Edge runtime. try H.consumeAndFlush instead.',
-		)
+	flush: async function () {
+		await this.waitForFlush()
 	},
 	recordMetric: (
 		secureSessionId: string,

--- a/sdk/highlight-next/src/util/highlight-edge.ts
+++ b/sdk/highlight-next/src/util/highlight-edge.ts
@@ -93,8 +93,10 @@ export const H: HighlightInterface = {
 	stop: async () => {
 		throw new Error('H.stop is not supported by the Edge runtime.')
 	},
-	flush: async function () {
-		await this.waitForFlush()
+	flush: async () => {
+		throw new Error(
+			'H.flush is not supported by the Edge runtime. try H.consumeAndFlush instead.',
+		)
 	},
 	recordMetric: (
 		secureSessionId: string,

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -41,6 +41,7 @@
 		"@types/jest": "^29.2.0",
 		"@types/lru-cache": "^7.10.10",
 		"@types/node": "17.0.13",
+		"encoding": "^0.1.13",
 		"jest": "^29.2.2",
 		"rollup": "^4.1.4",
 		"ts-jest": "^29.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13632,6 +13632,7 @@ __metadata:
     "@types/jest": ^29.2.0
     "@types/lru-cache": ^7.10.10
     "@types/node": 17.0.13
+    encoding: ^0.1.13
     highlight.run: "workspace:*"
     jest: ^29.2.2
     rollup: ^4.1.4


### PR DESCRIPTION
## Summary

@highlight-run/node would crash in certain tRPC installations due to a missing `node:encoding` polyfill.
https://discord.com/channels/1026884757667188757/1168583618537472010

## How did you test this change?

Vercel deploy

## Are there any deployment considerations?

Changeset

## Does this work require review from our design team?

No