### PR TITLE
change serialization for node to avoid reporting objects as the message

### DIFF
--- a/.changeset/witty-geckos-cough.md
+++ b/.changeset/witty-geckos-cough.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': patch
+---
+
+change serialization for node to avoid reporting objects as the message

--- a/sdk/highlight-node/src/hooks.ts
+++ b/sdk/highlight-node/src/hooks.ts
@@ -100,12 +100,10 @@ export function hookConsole(
 					date,
 					level: highlightLevel,
 					message: data
-						.map((o) =>
-							typeof o === 'object' ? safeStringify(o) : o,
-						)
+						.filter((d) => typeof d !== 'object')
+						.map((o) => o.toString())
 						.join(' '),
 					attributes: data
-						.slice(1)
 						.filter((d) => typeof d === 'object')
 						.reduce((a, b) => ({ ...a, ...b }), {}),
 					stack: o.stack,

--- a/sdk/highlight-node/src/hooks.ts
+++ b/sdk/highlight-node/src/hooks.ts
@@ -101,7 +101,7 @@ export function hookConsole(
 					level: highlightLevel,
 					message: data
 						.filter((d) => typeof d !== 'object')
-						.map((o) => o.toString())
+						.map((o) => `${o}`)
 						.join(' '),
 					attributes: data
 						.filter((d) => typeof d === 'object')


### PR DESCRIPTION
## Summary

Objects were sent as the structured message attributes and serialized.
Avoid serializing them to the message to avoid verbose message bodies.

## How did you test this change?

Local deploy recording a log from @highlight-run/node
<img width="1692" alt="Screenshot 2023-11-13 at 4 13 57 PM" src="https://github.com/highlight/highlight/assets/1351531/370ab27d-5e70-4b00-80c6-f045e09de85d">


## Are there any deployment considerations?

Changeset

## Does this work require review from our design team?

No
