### PR TITLE
Add Support for PHP among Highlight SDKs

### DIFF
--- a/sdk/highlight-php/README.md
+++ b/sdk/highlight-php/README.md
@@ -1,0 +1,29 @@
+# Highlight PHP SDK
+
+Below are some examples demonstrating usage of the PHP SDK:
+```php
+    use Highlight\SDK\Common\HighlightOptions;
+    use Highlight\SDK\Highlight;
+
+
+    $projectId = '1jdkeo52';
+
+    // Use only a projectId to bootstrap Highlight
+    if (!Highlight::isInitialized()) {
+        Highlight::init($projectId);
+    }
+
+    // Use a HighlightOptions instance to bootstrap Highlight
+    $options = HighlightOptions::builder($projectId)->build();
+    if (!Highlight::isInitialized()) {
+        Highlight::initWithOptions($options);
+    }
+
+    // Use a HighlightOptions instance prepped with a serviceName to bootstrap Highlight
+    $options = HighlightOptions::builder($projectId)->serviceName('test-service-01')->build();
+
+    if (!Highlight::isInitialized()) {
+        Highlight::initWithOptions($options);
+    }
+
+```

--- a/sdk/highlight-php/composer.json
+++ b/sdk/highlight-php/composer.json
@@ -1,0 +1,75 @@
+{
+  "name": "highlight/php-sdk",
+  "description": "Highlight's OpenTelemetry SDK for PHP.",
+  "keywords": ["opentelemetry", "otel", "open-telemetry", "tracing", "logging", "metrics", "highlight", "sdk"],
+  "type": "library",
+  "homepage": "https://github.com/highlight/highlight",
+  "readme": "./README.md",
+  "license": "Apache-2.0",
+  "require": {
+    "php": "^8.2",
+    "open-telemetry/api": "@stable",
+    "open-telemetry/context": "@stable",
+    "open-telemetry/sem-conv": "@stable",
+    "open-telemetry/sdk": "@stable",
+    "open-telemetry/exporter-otlp": "@stable",
+    "open-telemetry/gen-otlp-protobuf": "@stable"
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "composer/package-versions-deprecated": true,
+      "php-http/discovery": true,
+      "symfony/runtime": true
+    }
+  },
+  "authors": [
+    {
+      "name": "ayewo Saïd",
+      "homepage": "https://github.com/ayewo"
+    }
+  ],
+  "autoload": {
+    "psr-4": {
+      "Highlight\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Highlight\\Tests\\": "tests/"
+    }
+  },
+  "require-dev": {
+    
+    "assertwell/phpunit-global-state": "^0.2.2",
+    "composer/xdebug-handler": "^2.0",
+    "dg/bypass-finals": "^1.4",
+    "friendsofphp/php-cs-fixer": "^3.4",
+    "guzzlehttp/guzzle": "^7.4",
+    "guzzlehttp/psr7": "^2.1",
+    "mikey179/vfsstream": "^1.6.11",
+    "mockery/mockery": "^1.5.1",
+    "monolog/monolog": "^2.3",
+    "nikic/php-parser": "^4.15.4",
+    "nyholm/psr7": "^1.4",
+    "open-telemetry/dev-tools": "dev-main",
+    "phan/phan": "^5.4",
+    "php-http/mock-client": "^1.5",
+    "phpbench/phpbench": "^1.2",
+    "phpdocumentor/reflection-docblock": "^5.3",
+    "phpmetrics/phpmetrics": "^2.8",
+    "phpspec/prophecy": "^1.17.0",
+    "phpspec/prophecy-phpunit": "2.0.1",
+    "phpstan/phpstan": "^1.10.13",
+    "phpstan/phpstan-mockery": "^1.1",
+    "phpstan/phpstan-phpunit": "^1.3",
+    "phpunit/phpunit": "^9.6",
+    "psalm/plugin-mockery": "^0.11",
+    "psalm/plugin-phpunit": "^0.18.4",
+    "psalm/psalm": "^4.30",
+    "qossmic/deptrac-shim": "^0.24 || ^1",
+    "rector/rector": ">=0.15.20",
+    "symfony/http-client": "^5.2",
+    "symfony/yaml": "^6 || ^5"
+  }
+}

--- a/sdk/highlight-php/composer.json
+++ b/sdk/highlight-php/composer.json
@@ -1,75 +1,83 @@
 {
-  "name": "highlight/php-sdk",
-  "description": "Highlight's OpenTelemetry SDK for PHP.",
-  "keywords": ["opentelemetry", "otel", "open-telemetry", "tracing", "logging", "metrics", "highlight", "sdk"],
-  "type": "library",
-  "homepage": "https://github.com/highlight/highlight",
-  "readme": "./README.md",
-  "license": "Apache-2.0",
-  "require": {
-    "php": "^8.2",
-    "open-telemetry/api": "@stable",
-    "open-telemetry/context": "@stable",
-    "open-telemetry/sem-conv": "@stable",
-    "open-telemetry/sdk": "@stable",
-    "open-telemetry/exporter-otlp": "@stable",
-    "open-telemetry/gen-otlp-protobuf": "@stable"
-  },
-  "config": {
-    "sort-packages": true,
-    "allow-plugins": {
-      "composer/package-versions-deprecated": true,
-      "php-http/discovery": true,
-      "symfony/runtime": true
-    }
-  },
-  "authors": [
-    {
-      "name": "ayewo Saïd",
-      "homepage": "https://github.com/ayewo"
-    }
-  ],
-  "autoload": {
-    "psr-4": {
-      "Highlight\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Highlight\\Tests\\": "tests/"
-    }
-  },
-  "require-dev": {
-    
-    "assertwell/phpunit-global-state": "^0.2.2",
-    "composer/xdebug-handler": "^2.0",
-    "dg/bypass-finals": "^1.4",
-    "friendsofphp/php-cs-fixer": "^3.4",
-    "guzzlehttp/guzzle": "^7.4",
-    "guzzlehttp/psr7": "^2.1",
-    "mikey179/vfsstream": "^1.6.11",
-    "mockery/mockery": "^1.5.1",
-    "monolog/monolog": "^2.3",
-    "nikic/php-parser": "^4.15.4",
-    "nyholm/psr7": "^1.4",
-    "open-telemetry/dev-tools": "dev-main",
-    "phan/phan": "^5.4",
-    "php-http/mock-client": "^1.5",
-    "phpbench/phpbench": "^1.2",
-    "phpdocumentor/reflection-docblock": "^5.3",
-    "phpmetrics/phpmetrics": "^2.8",
-    "phpspec/prophecy": "^1.17.0",
-    "phpspec/prophecy-phpunit": "2.0.1",
-    "phpstan/phpstan": "^1.10.13",
-    "phpstan/phpstan-mockery": "^1.1",
-    "phpstan/phpstan-phpunit": "^1.3",
-    "phpunit/phpunit": "^9.6",
-    "psalm/plugin-mockery": "^0.11",
-    "psalm/plugin-phpunit": "^0.18.4",
-    "psalm/psalm": "^4.30",
-    "qossmic/deptrac-shim": "^0.24 || ^1",
-    "rector/rector": ">=0.15.20",
-    "symfony/http-client": "^5.2",
-    "symfony/yaml": "^6 || ^5"
-  }
+	"name": "highlight/php-sdk",
+	"description": "Highlight's OpenTelemetry SDK for PHP.",
+	"keywords": [
+		"opentelemetry",
+		"otel",
+		"open-telemetry",
+		"tracing",
+		"logging",
+		"metrics",
+		"highlight",
+		"sdk"
+	],
+	"type": "library",
+	"homepage": "https://github.com/highlight/highlight",
+	"readme": "./README.md",
+	"license": "Apache-2.0",
+	"require": {
+		"php": "^8.2",
+		"open-telemetry/api": "@stable",
+		"open-telemetry/context": "@stable",
+		"open-telemetry/sem-conv": "@stable",
+		"open-telemetry/sdk": "@stable",
+		"open-telemetry/exporter-otlp": "@stable",
+		"open-telemetry/gen-otlp-protobuf": "@stable"
+	},
+	"config": {
+		"sort-packages": true,
+		"allow-plugins": {
+			"composer/package-versions-deprecated": true,
+			"php-http/discovery": true,
+			"symfony/runtime": true
+		}
+	},
+	"authors": [
+		{
+			"name": "ayewo Saïd",
+			"homepage": "https://github.com/ayewo"
+		}
+	],
+	"autoload": {
+		"psr-4": {
+			"Highlight\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Highlight\\Tests\\": "tests/"
+		}
+	},
+	"require-dev": {
+		"assertwell/phpunit-global-state": "^0.2.2",
+		"composer/xdebug-handler": "^2.0",
+		"dg/bypass-finals": "^1.4",
+		"friendsofphp/php-cs-fixer": "^3.4",
+		"guzzlehttp/guzzle": "^7.4",
+		"guzzlehttp/psr7": "^2.1",
+		"mikey179/vfsstream": "^1.6.11",
+		"mockery/mockery": "^1.5.1",
+		"monolog/monolog": "^2.3",
+		"nikic/php-parser": "^4.15.4",
+		"nyholm/psr7": "^1.4",
+		"open-telemetry/dev-tools": "dev-main",
+		"phan/phan": "^5.4",
+		"php-http/mock-client": "^1.5",
+		"phpbench/phpbench": "^1.2",
+		"phpdocumentor/reflection-docblock": "^5.3",
+		"phpmetrics/phpmetrics": "^2.8",
+		"phpspec/prophecy": "^1.17.0",
+		"phpspec/prophecy-phpunit": "2.0.1",
+		"phpstan/phpstan": "^1.10.13",
+		"phpstan/phpstan-mockery": "^1.1",
+		"phpstan/phpstan-phpunit": "^1.3",
+		"phpunit/phpunit": "^9.6",
+		"psalm/plugin-mockery": "^0.11",
+		"psalm/plugin-phpunit": "^0.18.4",
+		"psalm/psalm": "^4.30",
+		"qossmic/deptrac-shim": "^0.24 || ^1",
+		"rector/rector": ">=0.15.20",
+		"symfony/http-client": "^5.2",
+		"symfony/yaml": "^6 || ^5"
+	}
 }

--- a/sdk/highlight-php/src/SDK/Common/HighlightAttributes.php
+++ b/sdk/highlight-php/src/SDK/Common/HighlightAttributes.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Highlight\SDK\Common;
+
+/**
+ * This class defines the attribute keys used in the Highlight SDK.
+ */
+final class HighlightAttributes
+{
+    /**
+     * The attribute key for the Highlight project ID.
+     */
+    public const HIGHLIGHT_PROJECT_ID = 'highlight.project_id';
+
+    /**
+     * The attribute key for the Highlight session ID.
+     */
+    public const HIGHLIGHT_SESSION_ID = 'highlight.session_id';
+
+    /**
+     * The attribute key for the Highlight trace ID.
+     */
+    public const HIGHLIGHT_TRACE_ID = 'highlight.trace_id';
+
+    /**
+     * The attribute key for the log severity.
+     */
+    public const LOG_SEVERITY = 'log.severity';
+
+    /**
+     * The attribute key for the PHP version.
+     */
+    public const TELEMETRY_PHP_VERSION = 'telemetry.php.version';
+
+    /**
+     * The attribute key for the PHP vendor.
+     */
+    public const TELEMETRY_PHP_VENDOR = 'telemetry.php.vendor';
+
+    /**
+     * The attribute key for the PHP vendor date.
+     */
+    public const TELEMETRY_PHP_VERSION_DATE = 'telemetry.php.date';
+
+    /**
+     * Non-accessible constructor because this class just provides static fields.
+     */
+    private function __construct()
+    {
+    }
+}

--- a/sdk/highlight-php/src/SDK/Common/HighlightHeader.php
+++ b/sdk/highlight-php/src/SDK/Common/HighlightHeader.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common;
+
+class HighlightHeader
+{
+    public const X_HIGHLIGHT_REQUEST = 'x-highlight-request';
+    private string $sessionId;
+    private string $requestId;
+
+    public function __construct($sessionId, $requestId)
+    {
+        $this->sessionId = $sessionId;
+        $this->requestId = $requestId;
+    }
+
+    public static function parse($header): HighlightHeader
+    {
+        $split = explode('/', $header);
+        if (count($split) == 2) {
+            return new HighlightHeader($split[0], $split[1]);
+        }
+        return null;
+    }
+
+    public function sessionId(): string
+    {
+        return $this->sessionId;
+    }
+
+    public function requestId(): string
+    {
+        return $this->requestId;
+    }
+
+    public function __toString()
+    {
+        return 'HighlightHeader[' .
+            'sessionId=' . $this->sessionId . ', ' .
+            'requestId=' . $this->requestId . ']';
+    }
+}
+

--- a/sdk/highlight-php/src/SDK/Common/HighlightOptions.php
+++ b/sdk/highlight-php/src/SDK/Common/HighlightOptions.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common;
+
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+
+/**
+ * Represents the options for highlighting in a project, including project ID,
+ * backend URL, environment, version, and default attributes.
+ */
+final class HighlightOptions
+{
+    private string $projectId;
+    private string $backendUrl;
+    private string $environment;
+    private string $version;
+    private string $serviceName;
+    private bool $metric;
+    private Attributes $defaultAttributes;
+
+    /**
+     * Creates a new instance of HighlightOptions.
+     *
+     * @param string $projectId       the project ID to use
+     * @param string $backendUrl      the backend URL to set
+     * @param string $environment     the environment to set
+     * @param string $version         the version to set
+     * @param string $serviceName     the service name to set
+     * @param bool   $metric          whether to enable metric or not
+     * @param Attributes $defaultAttributes the default attributes to set
+     */
+    public function __construct(
+        string $projectId,
+        string $backendUrl,
+        string $environment,
+        string $version,
+        string $serviceName,
+        bool $metric,
+        Attributes $defaultAttributes
+    ) {
+        $this->projectId = $projectId;
+        $this->backendUrl = $backendUrl;
+        $this->environment = $environment;
+        $this->version = $version;
+        $this->serviceName = $serviceName;
+        $this->metric = $metric;
+        $this->defaultAttributes = $defaultAttributes;
+    }
+
+    /**
+     * Returns a new builder for constructing HighlightOptions with the specified project ID.
+     *
+     * @param string $projectId the project ID to use
+     * @return HighlightOptionsBuilder a new builder for constructing HighlightOptions
+     */
+    public static function builder(string $projectId): HighlightOptionsBuilder
+    {
+        return new HighlightOptionsBuilder($projectId);
+    }
+
+    /**
+     * Gets the project ID.
+     *
+     * @return string the project ID
+     */
+    public function getProjectId(): string
+    {
+        return $this->projectId;
+    }
+
+    /**
+     * Gets the backend URL.
+     *
+     * @return string the backend URL
+     */
+    public function getBackendUrl(): string
+    {
+        return $this->backendUrl;
+    }
+
+    /**
+     * Gets the environment.
+     *
+     * @return string the environment
+     */
+    public function getEnvironment(): string
+    {
+        return $this->environment;
+    }
+
+    /**
+     * Gets the version.
+     *
+     * @return string the version
+     */
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    /**
+     * Gets the service name.
+     *
+     * @return string the service name
+     */
+    public function getServiceName(): string
+    {
+        return $this->serviceName;
+    }
+
+    /**
+     * Checks whether metric is enabled.
+     *
+     * @return bool true if metric is enabled, false otherwise
+     */
+    public function isMetricEnabled(): bool
+    {
+        return $this->metric;
+    }
+
+    /**
+     * Gets the default attributes.
+     *
+     * @return Attributes the default attributes
+     */
+    public function getDefaultAttributes(): Attributes
+    {
+        return $this->defaultAttributes;
+    }
+
+    /**
+     * Produce a string representation of the class.
+     * 
+     * @return string representing the properties of this object.
+     */
+    public function __toString()
+    {
+        return "HighlightOptions[" .
+                "projectId=" . $this->projectId . ", " .
+                "backendUrl=" . $this->backendUrl . ", " .
+                "enviroment=" . $this->environment . ", " .
+                "version=" . $this->version . ", " .
+                "serviceName=" . $this->serviceName . ", " .
+                "metric=" . $this->metric . ", " .
+                "defaultAttributes=" . implode(" ", $this->defaultAttributes->toArray()) . ']';
+
+    }
+}

--- a/sdk/highlight-php/src/SDK/Common/HighlightOptionsBuilder.php
+++ b/sdk/highlight-php/src/SDK/Common/HighlightOptionsBuilder.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common;
+
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Common\Attribute\AttributesBuilder;
+
+/**
+ * A builder class for constructing HighlightOptions.
+ */
+class HighlightOptionsBuilder
+{
+    private string $projectId;
+    private ?string $backendUrl = null;
+    private ?string $environment = null;
+    private ?string $version = null;
+    private ?string $serviceName = null;
+    private bool $metric = true;
+    private AttributesBuilder $defaultAttributes;
+
+    private const DEFAULT_URL = "https://otel.highlight.io:4318";
+    private const DEFAULT_ENVIRONMENT = "development";
+    private const DEFAULT_VERSION = "unknown";
+    private const DEFAULT_SERVICE_NAME = "unknown";
+
+    /**
+     * Creates a new builder for constructing HighlightOptions with the specified project ID.
+     *
+     * @param string $projectId the project ID to use
+     */
+    public function __construct(string $projectId)
+    {
+        $this->projectId = $projectId;
+        $this->defaultAttributes = Attributes::factory()->builder([]);
+    }
+
+    /**
+     * Sets the backend URL for the highlight options being constructed.
+     *
+     * @param string $backendUrl the backend URL to set
+     * @return $this this builder
+     */
+    public function backendUrl(string $backendUrl): HighlightOptionsBuilder
+    {
+        $this->backendUrl = $backendUrl;
+        return $this;
+    }
+
+    /**
+     * Sets the environment for the highlight options being constructed.
+     *
+     * @param string $environment the environment to set
+     * @return $this this builder
+     */
+    public function environment(string $environment): HighlightOptionsBuilder
+    {
+        $this->environment = $environment;
+        return $this;
+    }
+
+    /**
+     * Sets the version for the highlight options being constructed.
+     *
+     * @param string $version the version to set
+     * @return $this this builder
+     */
+    public function version(string $version): HighlightOptionsBuilder
+    {
+        $this->version = $version;
+        return $this;
+    }
+
+    /**
+     * Sets the service name for the highlight options being constructed.
+     *
+     * @param string $serviceName the service name to set
+     * @return $this this builder
+     */
+    public function serviceName(string $serviceName): HighlightOptionsBuilder
+    {
+        $this->serviceName = $serviceName;
+        return $this;
+    }
+
+    /**
+     * Sets whether metric is enabled or not for the highlight options being constructed.
+     *
+     * @param bool $enabled whether to enable metric or not
+     * @return $this this builder
+     */
+    public function metric(bool $enabled): HighlightOptionsBuilder
+    {
+        $this->metric = $enabled;
+        return $this;
+    }
+
+    /**
+     * Sets the default attributes for the highlight options being constructed using
+     * the specified consumer function.
+     *
+     * @param callable $attributes a consumer function that accepts an
+     *                            AttributesBuilder
+     * @return $this this builder
+     */
+    public function attributes(callable $attributes): HighlightOptionsBuilder
+    {
+        $attributes($this->defaultAttributes);
+        return $this;
+    }
+
+    /**
+     * Builds the HighlightOptions using the specified project ID, backend URL, environment,
+     * version, metric, and default attributes.
+     *
+     * @return HighlightOptions the constructed HighlightOptions
+     */
+    public function build(): HighlightOptions
+    {
+        return new HighlightOptions(
+            $this->projectId,
+            $this->backendUrl ?? self::DEFAULT_URL,
+            $this->environment ?? self::DEFAULT_ENVIRONMENT,
+            $this->version ?? self::DEFAULT_VERSION, 
+            $this->serviceName ?? self::DEFAULT_SERVICE_NAME,
+            $this->metric,
+            $this->defaultAttributes->build()
+        );
+    }
+}

--- a/sdk/highlight-php/src/SDK/Common/HighlightSessionId.php
+++ b/sdk/highlight-php/src/SDK/Common/HighlightSessionId.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common;
+
+/**
+ * The HighlightSessionId defines a method to retrieve a sessionId which
+ * represents the current session.
+ */
+interface HighlightSessionId
+{
+    /**
+     * Returns the current sessionId.
+     *
+     * @return string the sessionId as a string
+     */
+    public function sessionId(): string;
+}

--- a/sdk/highlight-php/src/SDK/Common/HighlightVersion.php
+++ b/sdk/highlight-php/src/SDK/Common/HighlightVersion.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common;
+
+/**
+ * The HighlightVersion class provides static methods to retrieve information
+ * about the current version of the Highlight SDK, the PHP environment, and the
+ * operating system on which the SDK is running.
+ */
+class HighlightVersion
+{
+    // SDK version information
+    private const SDK_NAME = "highlight-php-sdk";
+    private const SDK_VERSION = "1.0";
+    private const SDK_LANGUAGE = "php";
+
+    // PHP version information
+    private static $phpVersion;
+    private static $phpOsName;
+    private static $phpOsVersion;
+    private static $phpOsArch;
+
+    /**
+     * Returns the name of the Highlight SDK.
+     *
+     * @return string the name of the SDK
+     */
+    public static function getSdkName(): string
+    {
+        return self::SDK_NAME;
+    }
+
+    /**
+     * Returns the version of the Highlight SDK.
+     *
+     * @return string the version of the SDK
+     */
+    public static function getSdkVersion(): string
+    {
+        return self::SDK_VERSION;
+    }
+
+    /**
+     * Returns the programming language used to implement the Highlight SDK.
+     *
+     * @return string the programming language of the SDK
+     */
+    public static function getSdkLanguage(): string
+    {
+        return self::SDK_LANGUAGE;
+    }
+
+    /**
+     * Returns the version of PHP running the Highlight SDK.
+     *
+     * @return string the version of PHP
+     */
+    public static function getPhpVersion(): string
+    {
+        if (self::$phpVersion === null) {
+            self::$phpVersion = phpversion();
+        }
+        return self::$phpVersion;
+    }
+
+    /**
+     * Returns the name of the operating system on which PHP is running.
+     *
+     * @return string the operating system name
+     */
+    public static function getPhpOsName(): string
+    {
+        if (self::$phpOsName === null) {
+            self::$phpOsName = php_uname("s");
+        }
+        return self::$phpOsName;
+    }
+
+    /**
+     * Returns the version of the operating system on which PHP is running.
+     *
+     * @return string the operating system version
+     */
+    public static function getPhpOsVersion(): string
+    {
+        if (self::$phpOsVersion === null) {
+            self::$phpOsVersion = php_uname("r");
+        }
+        return self::$phpOsVersion;
+    }
+
+    /**
+     * Returns the architecture of the operating system on which PHP is running.
+     *
+     * @return string the operating system architecture
+     */
+    public static function getPhpOsArch(): string
+    {
+        if (self::$phpOsArch === null) {
+            self::$phpOsArch = php_uname("m");
+        }
+        return self::$phpOsArch;
+    }
+}

--- a/sdk/highlight-php/src/SDK/Common/Priority.php
+++ b/sdk/highlight-php/src/SDK/Common/Priority.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common;
+
+/**
+ * Represents the priority of a log message.
+ * The priority can be one of LOW, NORMAL, MEDIUM, or HIGH.
+ */
+final class Priority
+{
+    private int $difference;
+
+    public const LOW = 0;
+    public const NORMAL = 1;
+    public const MEDIUM = 2;
+    public const HIGH = 3;
+
+    public function __construct(int $difference)
+    {
+        $this->difference = $difference;
+    }
+
+    public function difference(): int
+    {
+        return $this->difference;
+    }
+
+    public static function LOW()
+    {
+        return new Priority(self::LOW);
+    }
+
+    public static function NORMAL()
+    {
+        return new Priority(self::NORMAL);
+    }
+
+    public static function MEDIUM()
+    {
+        return new Priority(self::MEDIUM);
+    }
+
+    public static function HIGH()
+    {
+        return new Priority(self::HIGH);
+    }    
+}

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightErrorRecord.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightErrorRecord.php
@@ -21,7 +21,7 @@ final class HighlightErrorRecord extends HighlightRecord
      * @param HighlightRecord $record the record
      * @param \Throwable $throwable the throwable of the error record
      */
-    private function __construct(HighlightRecord $record, \Throwable $throwable)
+    public function __construct(HighlightRecord $record, \Throwable $throwable)
     {
         parent::__construct($record->timeOccurred, $record->attributes, $record->userSession, $record->requestId);
         $this->throwable = $throwable;

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightErrorRecord.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightErrorRecord.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common\Record;
+
+/**
+ * Represents an error record.
+ *
+ * An error record is a specific type of `HighlightRecord` that contains
+ * information about a thrown exception.
+ */
+final class HighlightErrorRecord extends HighlightRecord
+{
+    private \Throwable $throwable;
+
+    /**
+     * Constructs a new `HighlightErrorRecord` with the specified throwable
+     * based on `HighlightRecord`.
+     *
+     * @param HighlightRecord $record the record
+     * @param \Throwable $throwable the throwable of the error record
+     */
+    private function __construct(HighlightRecord $record, \Throwable $throwable)
+    {
+        parent::__construct($record->timeOccurred, $record->attributes, $record->userSession, $record->requestId);
+        $this->throwable = $throwable;
+    }
+
+    /**
+     * Returns the throwable associated with the record.
+     *
+     * @return \Throwable the throwable associated with the record
+     */
+    public function getThrowable(): \Throwable
+    {
+        return $this->throwable;
+    }
+}

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightErrorRecordBuilder.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightErrorRecordBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Highlight\SDK\Common\Record;
 
+use InvalidArgumentException;
 
 /**
  * Builder class for `HighlightErrorRecord`.
@@ -27,10 +28,11 @@ class HighlightErrorRecordBuilder extends HighlightRecordBuilder
      * @param HighlightErrorRecord $record the existing `HighlightErrorRecord` to use as the basis
      *                                      for the new builder
      */
-    public function fromRecord(HighlightErrorRecord $record)
+    public function fromRecord(HighlightErrorRecord $record): self
     {
-        parent::__constructFromRecord($record);
+        parent::__construct($record);
         $this->throwable = $record->getThrowable();
+        return $this;
     }
 
     /**
@@ -52,6 +54,9 @@ class HighlightErrorRecordBuilder extends HighlightRecordBuilder
      */
     public function build(): HighlightErrorRecord
     {
+        if (!isset($this->throwable)) {
+            throw new InvalidArgumentException("Throwable cannot be null");
+        }
         return new HighlightErrorRecord(parent::build(), $this->throwable);
     }
 }

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightErrorRecordBuilder.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightErrorRecordBuilder.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common\Record;
+
+
+/**
+ * Builder class for `HighlightErrorRecord`.
+ */
+class HighlightErrorRecordBuilder extends HighlightRecordBuilder
+{
+    private \Throwable $throwable;
+
+    /**
+     * Constructs a new instance of `Builder`.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Constructs a new instance of `Builder` based on an existing
+     * `HighlightErrorRecord`.
+     *
+     * @param HighlightErrorRecord $record the existing `HighlightErrorRecord` to use as the basis
+     *                                      for the new builder
+     */
+    public function fromRecord(HighlightErrorRecord $record)
+    {
+        parent::__constructFromRecord($record);
+        $this->throwable = $record->getThrowable();
+    }
+
+    /**
+     * Sets the throwable that caused the error.
+     *
+     * @param \Throwable $throwable the throwable that caused the error.
+     * @return static this builder instance.
+     */
+    public function throwable(\Throwable $throwable): self
+    {
+        $this->throwable = $throwable;
+        return $this;
+    }
+
+    /**
+     * Builds a new `HighlightErrorRecord` instance.
+     *
+     * @return HighlightErrorRecord the new instance.
+     */
+    public function build(): HighlightErrorRecord
+    {
+        return new HighlightErrorRecord(parent::build(), $this->throwable);
+    }
+}
+

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightLogRecord.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightLogRecord.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common\Record;
+
+use Highlight\SDK\Common\Severity;
+
+/**
+ * Represents a log record.
+ *
+ * A log record is a specific type of `HighlightRecord` that contains
+ * information about a log message, including the severity of the message.
+ */
+final class HighlightLogRecord extends HighlightRecord
+{
+    private Severity $severity;
+    private string $message;
+
+    /**
+     * Constructs a new `HighlightLogRecord` with the specified severity and
+     * message based on `HighlightRecord`.
+     *
+     * @param HighlightRecord $record the record
+     * @param Severity $severity the severity of the log record
+     * @param string $message the message of the log record
+     */
+    private function __construct(HighlightRecord $record, Severity $severity, string $message)
+    {
+        parent::__construct($record->timeOccurred, $record->attributes, $record->userSession, $record->requestId);
+        $this->severity = $severity;
+        $this->message = $message;
+    }
+
+    /**
+     * Returns the severity level associated with the log.
+     *
+     * @return Severity the severity level associated with the log
+     */
+    public function getSeverity(): Severity
+    {
+        return $this->severity;
+    }
+
+    /**
+     * Returns the log message associated with the record.
+     *
+     * @return string the log message associated with the record
+     */
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightLogRecord.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightLogRecord.php
@@ -25,7 +25,7 @@ final class HighlightLogRecord extends HighlightRecord
      * @param Severity $severity the severity of the log record
      * @param string $message the message of the log record
      */
-    private function __construct(HighlightRecord $record, Severity $severity, string $message)
+    public function __construct(HighlightRecord $record, Severity $severity, string $message)
     {
         parent::__construct($record->timeOccurred, $record->attributes, $record->userSession, $record->requestId);
         $this->severity = $severity;

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightLogRecordBuilder.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightLogRecordBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Highlight\SDK\Common\Record;
 
 use Highlight\SDK\Common\Severity;
+use InvalidArgumentException;
 
 
 /**
@@ -30,9 +31,9 @@ class HighlightLogRecordBuilder extends HighlightRecordBuilder
      * @param HighlightLogRecord $record the existing `HighlightLogRecord` to use as the basis for
      *                                   the new builder
      */
-    public function fromRecord(HighlightLogRecord $record)
+    public function fromRecord(HighlightLogRecord $record): self
     {
-        parent::__constructFromRecord($record);
+        parent::__construct($record);
         $this->severity = $record->getSeverity();
         $this->message = $record->getMessage();
         return $this;
@@ -70,7 +71,7 @@ class HighlightLogRecordBuilder extends HighlightRecordBuilder
     public function build(): HighlightLogRecord
     {
         if (!isset($this->severity)) {
-            throw new \RuntimeException("Severity can't be null");
+            throw new InvalidArgumentException("Severity cannot be null");
         }
         $this->message = $this->message ?? $this->severity->text();
 

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightLogRecordBuilder.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightLogRecordBuilder.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common\Record;
+
+use Highlight\SDK\Common\Severity;
+
+
+/**
+ * Builder class for `HighlightLogRecord`.
+ */
+class HighlightLogRecordBuilder extends HighlightRecordBuilder
+{
+    private Severity $severity;
+    private ?string $message;
+
+    /**
+     * Constructs a new instance of `Builder`.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Constructs a new instance of `Builder` based on an existing
+     * `HighlightLogRecord`.
+     *
+     * @param HighlightLogRecord $record the existing `HighlightLogRecord` to use as the basis for
+     *                                   the new builder
+     */
+    public function fromRecord(HighlightLogRecord $record)
+    {
+        parent::__constructFromRecord($record);
+        $this->severity = $record->getSeverity();
+        $this->message = $record->getMessage();
+        return $this;
+    }
+
+    /**
+     * Sets the severity of the log record.
+     *
+     * @param Severity $severity the severity of the log record.
+     * @return static this builder instance.
+     */
+    public function severity(Severity $severity): self
+    {
+        $this->severity = $severity;
+        return $this;
+    }
+
+    /**
+     * Sets the message of the log record.
+     *
+     * @param string $message the message of the log record.
+     * @return static this builder instance.
+     */
+    public function message(string $message): self
+    {
+        $this->message = $message;
+        return $this;
+    }
+
+    /**
+     * Builds a new `HighlightLogRecord` instance.
+     *
+     * @return HighlightLogRecord the new instance.
+     */
+    public function build(): HighlightLogRecord
+    {
+        if (!isset($this->severity)) {
+            throw new \RuntimeException("Severity can't be null");
+        }
+        $this->message = $this->message ?? $this->severity->text();
+
+        return new HighlightLogRecord(parent::build(), $this->severity, $this->message);
+    }
+}

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightRecord.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightRecord.php
@@ -15,7 +15,7 @@ use OpenTelemetry\SDK\Common\Attribute\Attributes;
  * including attributes for its declarations, and a trace id. It can also
  * contain a session id.
  */
-abstract class HighlightRecord
+class HighlightRecord
 {
     protected DateTimeImmutable $timeOccurred;
     protected Attributes $attributes;
@@ -30,7 +30,7 @@ abstract class HighlightRecord
      * @param HighlightSessionId|null $userSession the user session associated with the record, may be null
      * @param string|null $requestId the ID of the request associated with the record, may be null
      */
-    protected function __construct(DateTimeImmutable $timeOccurred, Attributes $attributes, ?HighlightSessionId $userSession, ?string $requestId)
+    public function __construct(DateTimeImmutable $timeOccurred, Attributes $attributes, ?HighlightSessionId $userSession, ?string $requestId)
     {
         $this->timeOccurred = $timeOccurred;
         $this->attributes = $attributes;
@@ -120,7 +120,7 @@ abstract class HighlightRecord
      */
     public static function errorFromRecord(HighlightErrorRecord $record): HighlightErrorRecordBuilder
     {
-        return new HighlightErrorRecordBuilder($record);
+        return (new HighlightErrorRecordBuilder())->fromRecord($record);
     }
 
     /**
@@ -141,6 +141,6 @@ abstract class HighlightRecord
      */
     public static function logFromRecord(HighlightLogRecord $record): HighlightLogRecordBuilder
     {
-        return new HighlightLogRecordBuilder($record);
+        return (new HighlightLogRecordBuilder())->fromRecord($record);
     }
 }

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightRecord.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightRecord.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common\Record;
+
+use DateTimeImmutable;
+use Highlight\SDK\Common\HighlightSessionId;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+
+/**
+ * Represents a record.
+ *
+ * A `HighlightRecord` class contains information about a timestamp,
+ * including attributes for its declarations, and a trace id. It can also
+ * contain a session id.
+ */
+abstract class HighlightRecord
+{
+    protected DateTimeImmutable $timeOccurred;
+    protected Attributes $attributes;
+    protected ?HighlightSessionId $userSession;
+    protected ?string $requestId;
+
+    /**
+     * Constructs a new `HighlightRecord` instance.
+     *
+     * @param DateTimeImmutable $timeOccurred the instant when the record occurred
+     * @param Attributes $attributes the attributes associated with the record
+     * @param HighlightSessionId|null $userSession the user session associated with the record, may be null
+     * @param string|null $requestId the ID of the request associated with the record, may be null
+     */
+    protected function __construct(DateTimeImmutable $timeOccurred, Attributes $attributes, ?HighlightSessionId $userSession, ?string $requestId)
+    {
+        $this->timeOccurred = $timeOccurred;
+        $this->attributes = $attributes;
+        $this->userSession = $userSession;
+        $this->requestId = $requestId;
+    }
+
+    /**
+     * Returns the instant when the record occurred.
+     *
+     * @return DateTimeImmutable the instant when the record occurred
+     */
+    public function getTimeOccurred(): DateTimeImmutable
+    {
+        return $this->timeOccurred;
+    }
+
+    /**
+     * Returns the attributes associated with the record.
+     *
+     * @return Attribute the attributes associated with the record
+     */
+    public function getAttributes(): Attributes
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * Returns the user session associated with the record.
+     *
+     * @return HighlightSessionId|null the user session associated with the record, may be null
+     */
+    public function getUserSession(): ?HighlightSessionId
+    {
+        return $this->userSession;
+    }
+
+    /**
+     * Returns whether the record has a user session associated with it.
+     *
+     * @return bool true if the record has a user session, otherwise false
+     */
+    public function hasUserSession(): bool
+    {
+        return $this->userSession !== null && $this->userSession->sessionId() !== null;
+    }
+
+    /**
+     * Returns the ID of the request associated with the record.
+     *
+     * @return string|null the ID of the request associated with the record, may be null
+     */
+    public function getRequestId(): ?string
+    {
+        return $this->requestId;
+    }
+
+    /**
+     * Returns whether the record has an ID of the request associated with it.
+     *
+     * @return bool true if the record has an ID of the request, otherwise false
+     */
+    public function hasRequestId(): bool
+    {
+        return $this->requestId !== null;
+    }
+
+
+
+    // Static methods
+
+    /**
+     * Returns a builder for creating a new error record.
+     *
+     * @return HighlightErrorRecordBuilder A builder for creating a new error record.
+     */
+    public static function error(): HighlightErrorRecordBuilder
+    {
+        return new HighlightErrorRecordBuilder();
+    }
+
+    /**
+     * Returns a builder for creating a new error record based on an existing record.
+     *
+     * @param HighlightErrorRecord $record The existing record to base the new record on.
+     * @return HighlightErrorRecordBuilder A builder for creating a new error record based on an existing record.
+     */
+    public static function errorFromRecord(HighlightErrorRecord $record): HighlightErrorRecordBuilder
+    {
+        return new HighlightErrorRecordBuilder($record);
+    }
+
+    /**
+     * Returns a builder for creating a new log record.
+     *
+     * @return HighlightLogRecordBuilder A builder for creating a new log record.
+     */
+    public static function log(): HighlightLogRecordBuilder
+    {
+        return new HighlightLogRecordBuilder();
+    }
+
+    /**
+     * Returns a builder for creating a new log record based on an existing record.
+     *
+     * @param HighlightLogRecord $record The existing record to base the new record on.
+     * @return HighlightLogRecordBuilder A builder for creating a new log record based on an existing record.
+     */
+    public static function logFromRecord(HighlightLogRecord $record): HighlightLogRecordBuilder
+    {
+        return new HighlightLogRecordBuilder($record);
+    }
+}

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightRecordBuilder.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightRecordBuilder.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common\Record;
+
+use DateTimeImmutable;
+use Highlight\SDK\Common\HighlightSessionId;
+use Highlight\SDK\Common\HighlightHeader;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use OpenTelemetry\SDK\Common\Attribute\AttributesBuilder;
+use OpenTelemetry\SDK\Common\Attribute\AttributesFactory;
+
+/**
+ * A builder class for creating instances of `HighlightRecord`.
+ */
+class HighlightRecordBuilder
+{
+    protected DateTimeImmutable $timeOccurred;
+    protected AttributesBuilder $attributesBuilder;
+    protected ?HighlightSessionId $userSession;
+    protected ?string $requestId;
+
+    /**
+     * Constructs a new instance of `Builder`.
+     */
+    protected function __construct()
+    {
+        $this->attributesBuilder = Attributes::factory()->builder([]);
+    }
+
+    /**
+     * Constructs a new instance of `Builder`.
+     */
+    protected function __constructFromRecord(HighlightRecord $record)
+    {
+        $this->timeOccurred = $record->getTimeOccurred();
+        $this->attributesBuilder = (new AttributesFactory())->builder($record->getAttributes()->toArray());
+        $this->userSession = $record->getUserSession();
+        $this->requestId = $record->getRequestId();
+    }
+
+    /**
+     * Sets the time the record occurred.
+     *
+     * @param DateTimeImmutable $timeOccurred the time the record occurred
+     * @return this `Builder` instance
+     */
+    public function timeOccurred(DateTimeImmutable $timeOccurred): self
+    {
+        $this->timeOccurred = $timeOccurred;
+        return $this;
+    }
+
+    /**
+     * Sets the user session and request id associated with the record.
+     *
+     * @param HighlightHeader $header associated with the record.
+     * @return this `Builder` instance
+     */
+    public function requestHeader(HighlightHeader $header): self
+    {
+        $this->userSessionString($header->sessionId());
+        $this->requestId($header->requestId());
+        return $this;
+    }
+
+    /**
+     * Sets the user session associated with the record using a session ID string.
+     *
+     * @param string|null $sessionId the session ID string to use as the user session ID
+     * @return this `Builder` instance
+     */
+    public function userSessionString(?string $sessionId): self
+    {
+        $this->userSession($sessionId !== null && !empty($sessionId) ? new HighlightSession($sessionId) : null);
+        return $this;
+    }
+
+    /**
+     * Sets the user session associated with the record.
+     *
+     * @param HighlightSessionId|null $userSession the user session associated with the record
+     * @return this `Builder` instance
+     */
+    public function userSession(?HighlightSessionId $userSession): self
+    {
+        $this->userSession = $userSession;
+        return $this;
+    }
+
+    /**
+     * Sets the request ID associated with the record.
+     *
+     * @param string|null $requestId the request ID associated with the record
+     * @return this `Builder` instance
+     */
+    public function requestId(?string $requestId): self
+    {
+        $this->requestId = $requestId !== null && !empty($requestId) ? $requestId : null;
+        return $this;
+    }
+
+    /**
+     * Applies the specified closure to the attributes builder.
+     *
+     * @param callable $function the closure to apply to the attributes builder
+     * @return this `Builder` instance
+     */
+    public function attributes(callable $function): self
+    {
+        $function($this->attributesBuilder);
+        return $this;
+    }
+
+    /**
+     * Builds a new instance of `HighlightRecord` using the values specified
+     * in the builder.
+     *
+     * @return HighlightRecord a new instance of `HighlightRecord`
+     */
+    public function build(): HighlightRecord
+    {
+        return new HighlightRecord(
+            $this->timeOccurred ?? new DateTimeImmutable(),
+            $this->attributesBuilder->build(), 
+            $this->userSession,
+            $this->requestId
+        );
+    }
+}
+
+

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightRecordBuilder.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightRecordBuilder.php
@@ -14,7 +14,7 @@ use OpenTelemetry\SDK\Common\Attribute\AttributesFactory;
 /**
  * A builder class for creating instances of `HighlightRecord`.
  */
-class HighlightRecordBuilder
+abstract class HighlightRecordBuilder
 {
     protected DateTimeImmutable $timeOccurred;
     protected AttributesBuilder $attributesBuilder;
@@ -24,20 +24,19 @@ class HighlightRecordBuilder
     /**
      * Constructs a new instance of `Builder`.
      */
-    protected function __construct()
+    protected function __construct(?HighlightRecord $record = null)
     {
-        $this->attributesBuilder = Attributes::factory()->builder([]);
-    }
-
-    /**
-     * Constructs a new instance of `Builder`.
-     */
-    protected function __constructFromRecord(HighlightRecord $record)
-    {
-        $this->timeOccurred = $record->getTimeOccurred();
-        $this->attributesBuilder = (new AttributesFactory())->builder($record->getAttributes()->toArray());
-        $this->userSession = $record->getUserSession();
-        $this->requestId = $record->getRequestId();
+        if (isset($record)) {
+            $this->timeOccurred = $record->getTimeOccurred();
+            $this->attributesBuilder = (new AttributesFactory())->builder($record->getAttributes()->toArray());
+            $this->userSession = $record->getUserSession();
+            $this->requestId = $record->getRequestId();
+        } else {
+            $this->timeOccurred = new DateTimeImmutable();
+            $this->attributesBuilder = Attributes::factory()->builder([]);
+            $this->userSession = null;
+            $this->requestId = null;
+        }
     }
 
     /**
@@ -124,10 +123,8 @@ class HighlightRecordBuilder
         return new HighlightRecord(
             $this->timeOccurred ?? new DateTimeImmutable(),
             $this->attributesBuilder->build(), 
-            $this->userSession,
-            $this->requestId
+            $this->userSession ?? null,
+            $this->requestId ?? ""
         );
     }
 }
-
-

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightSession.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightSession.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common\Record;
+
+use Highlight\SDK\Common\HighlightSessionId;
+
+
+class HighlightSession implements HighlightSessionId
+{
+    private string $sessionId;
+
+    public function __constructor(string $sessionId)
+    {
+        $this->sessionId = $sessionId;
+    }
+
+    public function sessionId(): string 
+    {
+        return $this->sessionId;
+    }
+}

--- a/sdk/highlight-php/src/SDK/Common/Record/HighlightSession.php
+++ b/sdk/highlight-php/src/SDK/Common/Record/HighlightSession.php
@@ -18,6 +18,6 @@ class HighlightSession implements HighlightSessionId
 
     public function sessionId(): string 
     {
-        return $this->sessionId;
+        return $this->sessionId ?? "";
     }
 }

--- a/sdk/highlight-php/src/SDK/Common/Severity.php
+++ b/sdk/highlight-php/src/SDK/Common/Severity.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Highlight\SDK\Common;
 
-use OpenTelemetry\Logs\Severity as OpenTelemetrySeverity;
-
 /**
  * Represents the severity of a log message, along with its text and priority.
  * 
@@ -124,17 +122,4 @@ class Severity
         $name = $this->name();
         return $name . ($this->priority === Priority::LOW ? "" : $this->priority->difference());
     }
-
-    // public function toOpenTelemetry(): OpenTelemetrySeverity
-    // {
-    //     $severities = [
-    //         self::TRACE_ID => OpenTelemetrySeverity::TRACE(),
-    //         self::DEBUG_ID => OpenTelemetrySeverity::DEBUG(),
-    //         self::INFO_ID => OpenTelemetrySeverity::INFO(),
-    //         self::WARN_ID => OpenTelemetrySeverity::WARNING(),
-    //         self::ERROR_ID => OpenTelemetrySeverity::ERROR(),
-    //         self::FATAL_ID => OpenTelemetrySeverity::FATAL(),
-    //     ];
-    //     return $severities[$this->id];
-    // }
 }

--- a/sdk/highlight-php/src/SDK/Common/Severity.php
+++ b/sdk/highlight-php/src/SDK/Common/Severity.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK\Common;
+
+use OpenTelemetry\Logs\Severity as OpenTelemetrySeverity;
+
+/**
+ * Represents the severity of a log message, along with its text and priority.
+ * 
+ * See: <a href=
+ * "https://opentelemetry.io/docs/reference/specification/logs/data-model/#severity-fields">severity-fields</a>
+ */
+class Severity
+{
+    private string $text;
+    private int $id;
+    private Priority $priority;
+
+    // ID values for the different severity levels.
+    private const TRACE_ID = 1;
+    private const DEBUG_ID = 5;
+    private const INFO_ID = 9;
+    private const WARN_ID = 13;
+    private const ERROR_ID = 17;
+    private const FATAL_ID = 21;
+
+    // Predefined instances of Severity for each severity level.
+    public static Severity $TRACE;
+    public static Severity $DEBUG;
+    public static Severity $INFO;
+    public static Severity $WARN;
+    public static Severity $ERROR;
+    public static Severity $FATAL;
+
+    public function __construct(string $text, int $id, Priority $priority)
+    {
+        $this->text = $text;
+        $this->id = $id;
+        $this->priority = $priority;
+    }
+
+    public static function trace(string $text = null, Priority $priority = null): Severity
+    {
+        if ($text === null) {
+            $priority = $priority ?? Priority::LOW;
+        }
+        return new Severity($text, self::TRACE_ID, $priority);
+    }
+
+    public static function debug(string $text = null, Priority $priority = null): Severity
+    {
+        if ($text === null) {
+            $priority = $priority ?? Priority::LOW;
+        }
+        return new Severity($text, self::DEBUG_ID, $priority);
+    }
+
+    public static function info(string $text = null, Priority $priority = null): Severity
+    {
+        if ($text === null) {
+            $priority = $priority ?? Priority::LOW;
+        }
+        return new Severity($text, self::INFO_ID, $priority);
+    }
+
+    public static function warn(string $text = null, Priority $priority = null): Severity
+    {
+        if ($text === null) {
+            $priority = $priority ?? Priority::LOW;
+        }
+        return new Severity($text, self::WARN_ID, $priority);
+    }
+
+    public static function error(string $text = null, Priority $priority = null): Severity
+    {
+        if ($text === null) {
+            $priority = $priority ?? Priority::LOW;
+        }
+        return new Severity($text, self::ERROR_ID, $priority);
+    }
+
+    public static function fatal(string $text = null, Priority $priority = null): Severity
+    {
+        if ($text === null) {
+            $priority = $priority ?? Priority::LOW;
+        }
+        return new Severity($text, self::FATAL_ID, $priority);
+    }
+
+    public function id(): int
+    {
+        return $this->id + $this->priority->difference();
+    }
+
+    public function text(): string
+    {
+        return $this->text;
+    }
+
+    public function name(): string
+    {
+        switch ($this->id) {
+            case self::TRACE_ID:
+                return "TRACE";
+            case self::DEBUG_ID:
+                return "DEBUG";
+            case self::INFO_ID:
+                return "INFO";
+            case self::WARN_ID:
+                return "WARN";
+            case self::ERROR_ID:
+                return "ERROR";
+            case self::FATAL_ID:
+                return "FATAL";
+            default:
+                throw new \InvalidArgumentException("Unexpected value: " . $this->id);
+        }
+    }
+
+    public function shortName(): string
+    {
+        $name = $this->name();
+        return $name . ($this->priority === Priority::LOW ? "" : $this->priority->difference());
+    }
+
+    // public function toOpenTelemetry(): OpenTelemetrySeverity
+    // {
+    //     $severities = [
+    //         self::TRACE_ID => OpenTelemetrySeverity::TRACE(),
+    //         self::DEBUG_ID => OpenTelemetrySeverity::DEBUG(),
+    //         self::INFO_ID => OpenTelemetrySeverity::INFO(),
+    //         self::WARN_ID => OpenTelemetrySeverity::WARNING(),
+    //         self::ERROR_ID => OpenTelemetrySeverity::ERROR(),
+    //         self::FATAL_ID => OpenTelemetrySeverity::FATAL(),
+    //     ];
+    //     return $severities[$this->id];
+    // }
+}

--- a/sdk/highlight-php/src/SDK/Exception/HighlightIllegalStateException.php
+++ b/sdk/highlight-php/src/SDK/Exception/HighlightIllegalStateException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Highlight\SDK\Exception;
+
+class HighlightIllegalStateException extends \RuntimeException
+{
+    public function __construct($message)
+    {
+        parent::__construct($message);
+    }
+}
+
+?>

--- a/sdk/highlight-php/src/SDK/Exception/HighlightInvalidOptionException.php
+++ b/sdk/highlight-php/src/SDK/Exception/HighlightInvalidOptionException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Highlight\SDK\Exception;
+
+class HighlightInvalidOptionException extends \InvalidArgumentException
+{
+    public function __construct($message)
+    {
+        parent::__construct($message);
+    }
+}
+
+?>

--- a/sdk/highlight-php/src/SDK/Exception/HighlightInvalidRecordException.php
+++ b/sdk/highlight-php/src/SDK/Exception/HighlightInvalidRecordException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Highlight\SDK\Exception;
+
+class HighlightInvalidRecordException extends \InvalidArgumentException
+{
+    private $record;
+
+    public function __construct($message, $record)
+    {
+        parent::__construct($message);
+        $this->record = $record;
+    }
+
+    public function getRecord()
+    {
+        return $this->record;
+    }
+}
+
+?>

--- a/sdk/highlight-php/src/SDK/Highlight.php
+++ b/sdk/highlight-php/src/SDK/Highlight.php
@@ -15,10 +15,6 @@ use Highlight\SDK\HighlightOpenTelemetry;
 use Highlight\SDK\HighlightTracer;
 use Highlight\SDK\Common\HighlightHeader;
 
-// use Highlight\SDK\State;
-// use React\Promise\Promise;
-// use React\Promise\Timer\TimeoutException;
-
 /**
  * The Highlight class is the main entry point for Highlight.
  * It provides methods to initialize the library and capture logs and errors.
@@ -26,91 +22,21 @@ use Highlight\SDK\Common\HighlightHeader;
 class Highlight
 {
     private static ?Highlight $highlight = null;
-    private bool $initialized = false;
-
     private HighlightOptions $options;
     private HighlightOpenTelemetry $openTelemetry;
     private HighlightTracer $tracer;
     private HighlightLogger $logger;
 
-    // private \React\EventLoop\LoopInterface $loop;
-    // private \React\EventLoop\Timer\Timer $shutdownTimer;
-
     private function __construct(HighlightOptions $options)
     {
         echo "Highlight is initializing..." . PHP_EOL;
         $this->options = $options;
-        // $this->loop = \React\EventLoop\Factory::create();
-
+        
         $this->openTelemetry = new HighlightOpenTelemetry($this);
         $this->tracer = new HighlightTracer($this);
         $this->logger = new HighlightLogger($this);
 
-        // $this->loop->addSignal(\SIGINT, function () {
-        //     $this->shutdown();
-        // });
-
-        // $this->loop->addSignal(\SIGTERM, function () {
-        //     $this->shutdown();
-        // });
-
-        // $this->loop->addSignal(\SIGHUP, function () {
-        //     $this->shutdown();
-        // });
-
-        // $this->state = State::INITIALIZE;
-        $this->initialized = true;
-
         echo "Highlight was initialized." . PHP_EOL;
-    }
-
-    private function shutdown(): void
-    {
-        // if ($this->state === State::SHUTDOWN) {
-        //     return;
-        // }
-
-        if (!$this->initialized) {
-            return;
-        }
-
-        echo "Highlight is shutting down..." . PHP_EOL;
-
-        // $this->state = State::SHUTDOWN;
-        $this->initialized = false;
-
-        // if ($this->shutdownTimer === null) {
-        //     $this->shutdownTimer = $this->loop->addTimer(10.0, function () {
-        //         echo "Highlight was forcefully shut down." . PHP_EOL;
-        //         $this->loop->stop();
-        //     });
-        // }
-
-        # TODO:
-
-        // try {
-        //     $this->openTelemetry->shutdown()->then(function () {
-        //         $this->loop->cancelTimer($this->shutdownTimer);
-        //         echo "Highlight was successfully shut down." . PHP_EOL;
-        //         $this->loop->stop();
-        //     })->otherwise(function (\Throwable $e) {
-        //         if ($e instanceof TimeoutException) {
-        //             $this->loop->cancelTimer($this->shutdownTimer);
-        //             echo "Highlight was forcefully shut down." . PHP_EOL;
-        //         } else {
-        //             echo "Error while shutting down Highlight: " . $e->getMessage() . PHP_EOL;
-        //             $this->loop->cancelTimer($this->shutdownTimer);
-        //             echo "Highlight was forcefully shut down." . PHP_EOL;
-        //         }
-
-        //         $this->loop->stop();
-        //     });
-        // } catch (\Throwable $e) {
-        //     echo "Error while shutting down Highlight: " . $e->getMessage() . PHP_EOL;
-        //     $this->loop->cancelTimer($this->shutdownTimer);
-        //     echo "Highlight was forcefully shut down." . PHP_EOL;
-        //     $this->loop->stop();
-        // }
     }
 
     public function captureRecord(HighlightRecord $record): void

--- a/sdk/highlight-php/src/SDK/Highlight.php
+++ b/sdk/highlight-php/src/SDK/Highlight.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Highlight\SDK;
 
 use Highlight\SDK\Common\HighlightOptions;
@@ -41,7 +43,6 @@ class Highlight
 
     public function captureRecord(HighlightRecord $record): void
     {
-        // if ($this->state !== State::RUNNING) {
         if (!self::isInitialized()) {
             throw new HighlightIllegalStateException("Highlight state is not running");
         }
@@ -76,10 +77,12 @@ class Highlight
      *
      * @throws HighlightIllegalStateException if Highlight is already initialized
      */
-    public static function init(string $projectId, callable $options): void
+    public static function init(string $projectId, ?callable $options = null): void
     {
         $builder = HighlightOptions::builder($projectId);
-        $options($builder);
+        if ($options !== null) {
+            $options($builder);
+        }
 
         self::initWithOptions($builder->build());
     }

--- a/sdk/highlight-php/src/SDK/Highlight.php
+++ b/sdk/highlight-php/src/SDK/Highlight.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace Highlight\SDK;
+
+use Highlight\SDK\Common\HighlightOptions;
+use Highlight\SDK\Common\Severity;
+use Highlight\SDK\Common\Record\HighlightRecord;
+use Highlight\SDK\Common\Record\HighlightLogRecord;
+use Highlight\SDK\Common\Record\HighlightErrorRecord;
+
+use Highlight\SDK\Common\Record\HighlightRecordBuilder;
+use Highlight\SDK\Exception\HighlightIllegalStateException;
+use Highlight\SDK\Exception\HighlightInvalidRecordException;
+use Highlight\SDK\HighlightOpenTelemetry;
+use Highlight\SDK\HighlightTracer;
+use Highlight\SDK\Common\HighlightHeader;
+
+// use Highlight\SDK\State;
+// use React\Promise\Promise;
+// use React\Promise\Timer\TimeoutException;
+
+/**
+ * The Highlight class is the main entry point for Highlight.
+ * It provides methods to initialize the library and capture logs and errors.
+ */
+class Highlight
+{
+    private static ?Highlight $highlight = null;
+    private bool $initialized = false;
+
+    private HighlightOptions $options;
+    private HighlightOpenTelemetry $openTelemetry;
+    private HighlightTracer $tracer;
+    private HighlightLogger $logger;
+
+    // private \React\EventLoop\LoopInterface $loop;
+    // private \React\EventLoop\Timer\Timer $shutdownTimer;
+
+    private function __construct(HighlightOptions $options)
+    {
+        echo "Highlight is initializing..." . PHP_EOL;
+        $this->options = $options;
+        // $this->loop = \React\EventLoop\Factory::create();
+
+        $this->openTelemetry = new HighlightOpenTelemetry($this);
+        $this->tracer = new HighlightTracer($this);
+        $this->logger = new HighlightLogger($this);
+
+        // $this->loop->addSignal(\SIGINT, function () {
+        //     $this->shutdown();
+        // });
+
+        // $this->loop->addSignal(\SIGTERM, function () {
+        //     $this->shutdown();
+        // });
+
+        // $this->loop->addSignal(\SIGHUP, function () {
+        //     $this->shutdown();
+        // });
+
+        // $this->state = State::INITIALIZE;
+        $this->initialized = true;
+
+        echo "Highlight was initialized." . PHP_EOL;
+    }
+
+    private function shutdown(): void
+    {
+        // if ($this->state === State::SHUTDOWN) {
+        //     return;
+        // }
+
+        if (!$this->initialized) {
+            return;
+        }
+
+        echo "Highlight is shutting down..." . PHP_EOL;
+
+        // $this->state = State::SHUTDOWN;
+        $this->initialized = false;
+
+        // if ($this->shutdownTimer === null) {
+        //     $this->shutdownTimer = $this->loop->addTimer(10.0, function () {
+        //         echo "Highlight was forcefully shut down." . PHP_EOL;
+        //         $this->loop->stop();
+        //     });
+        // }
+
+        # TODO:
+
+        // try {
+        //     $this->openTelemetry->shutdown()->then(function () {
+        //         $this->loop->cancelTimer($this->shutdownTimer);
+        //         echo "Highlight was successfully shut down." . PHP_EOL;
+        //         $this->loop->stop();
+        //     })->otherwise(function (\Throwable $e) {
+        //         if ($e instanceof TimeoutException) {
+        //             $this->loop->cancelTimer($this->shutdownTimer);
+        //             echo "Highlight was forcefully shut down." . PHP_EOL;
+        //         } else {
+        //             echo "Error while shutting down Highlight: " . $e->getMessage() . PHP_EOL;
+        //             $this->loop->cancelTimer($this->shutdownTimer);
+        //             echo "Highlight was forcefully shut down." . PHP_EOL;
+        //         }
+
+        //         $this->loop->stop();
+        //     });
+        // } catch (\Throwable $e) {
+        //     echo "Error while shutting down Highlight: " . $e->getMessage() . PHP_EOL;
+        //     $this->loop->cancelTimer($this->shutdownTimer);
+        //     echo "Highlight was forcefully shut down." . PHP_EOL;
+        //     $this->loop->stop();
+        // }
+    }
+
+    public function captureRecord(HighlightRecord $record): void
+    {
+        // if ($this->state !== State::RUNNING) {
+        if (!self::isInitialized()) {
+            throw new HighlightIllegalStateException("Highlight state is not running");
+        }
+
+        if ($record instanceof HighlightLogRecord) {
+            $this->logger->process($record);
+        } elseif ($record instanceof HighlightErrorRecord) {
+            $this->tracer->process($record);
+        } else {
+            throw new HighlightInvalidRecordException("Invalid record type", $record);
+        }
+    }
+
+    /**
+     * Check if highlight was initialized else throw a
+     * {@code HighlightIllegalStateException} exception
+     *
+     * @throws HighlightIllegalStateException if Highlight is not initialized
+     */
+    private static function requireInitialization(): void
+    {
+        if (!self::isInitialized()) {
+            throw new HighlightIllegalStateException("Highlight instance is not initialized");
+        }
+    }
+
+    /**
+     * Initializes Highlight with the provided options and the given projectId.
+     *
+     * @param string              $projectId the projectId to use
+     * @param callable            $options   the options to use for initialization
+     *
+     * @throws HighlightIllegalStateException if Highlight is already initialized
+     */
+    public static function init(string $projectId, callable $options): void
+    {
+        $builder = HighlightOptions::builder($projectId);
+        $options($builder);
+
+        self::initWithOptions($builder->build());
+    }
+
+    /**
+     * Initializes Highlight with the provided options.
+     *
+     * @param HighlightOptions $options the options to use for initialization
+     *
+     * @throws HighlightIllegalStateException if Highlight is already initialized
+     */
+    public static function initWithOptions(HighlightOptions $options): void
+    {
+        if (self::$highlight !== null) {
+            throw new HighlightIllegalStateException("Highlight is already initialized");
+        }
+
+        self::$highlight = new Highlight($options);
+    }
+
+    /**
+     * Returns true if Highlight is already initialized.
+     *
+     * @return bool true if Highlight is already initialized, false otherwise
+     */
+    public static function isInitialized(): bool
+    {
+        return self::$highlight !== null;
+    }
+
+    /**
+     * Captures an exception and sends it to Highlight.
+     *
+     * @param \Throwable $throwable the throwable to capture
+     *
+     * @throws HighlightIllegalStateException  if Highlight is not initialized
+     * @throws HighlightInvalidRecordException if the record is invalid
+     */
+    public static function captureException(\Throwable $throwable): void
+    {
+        self::captureExceptionWithSessionAndRequest($throwable);
+    }
+
+    /**
+     * Captures an exception and sends it to Highlight.
+     *
+     * @param \Throwable $throwable the throwable to capture
+     * @param string     $sessionId the session ID associated with the record
+     * @param string     $requestId the request ID associated with the record
+     *
+     * @throws HighlightIllegalStateException  if Highlight is not initialized
+     * @throws HighlightInvalidRecordException if the record is invalid
+     */
+    public static function captureExceptionWithSessionAndRequest(
+        \Throwable $throwable,
+        ?string $sessionId = null,
+        ?string $requestId = null
+    ): void {
+        self::requireInitialization();
+
+        self::captureRecord(
+            HighlightRecord::error()
+                ->throwable($throwable)
+                ->requestId($requestId)
+                ->userSession($sessionId)
+                ->build()
+        );
+    }
+
+    /**
+     * Captures an exception and sends it to Highlight.
+     *
+     * @param \Throwable $throwable the throwable to capture
+     * @param string     $sessionId the session ID associated with the record
+     * @param string     $requestId the request ID associated with the record
+     *
+     * @throws HighlightIllegalStateException  if Highlight is not initialized
+     * @throws HighlightInvalidRecordException if the record is invalid
+     */
+    public static function captureExceptionWithHighlightHeader(
+        \Throwable $throwable,
+        HighlightHeader $header
+    ): void {
+        self::requireInitialization();
+
+        self::captureRecord(
+            HighlightRecord::error()
+                ->throwable($throwable)
+                ->requestHeader($header)
+                ->build()
+        );
+    }
+
+    /**
+     * Captures a log and sends it to Highlight.
+     *
+     * @param Severity $severity the severity of the log
+     * @param string   $message  the message to log
+     *
+     * @throws HighlightIllegalStateException  if Highlight is not initialized
+     * @throws HighlightInvalidRecordException if the record is invalid
+     */
+    public static function captureLog(Severity $severity, string $message): void
+    {
+        self::captureLogWithSessionAndRequest($severity, $message);
+    }
+
+    /**
+     * Captures a log and sends it to Highlight.
+     *
+     * @param Severity $severity  the severity of the log
+     * @param string   $message   the message to log
+     * @param string   $sessionId the session ID associated with the record
+     * @param string   $requestId the request ID associated with the record
+     *
+     * @throws HighlightIllegalStateException  if Highlight is not initialized
+     * @throws HighlightInvalidRecordException if the record is invalid
+     */
+    public static function captureLogWithSessionAndRequest(
+        Severity $severity,
+        string $message,
+        ?string $sessionId = null,
+        ?string $requestId = null
+    ): void {
+        self::requireInitialization();
+
+        self::captureRecord(
+            HighlightRecord::log()
+                ->severity($severity)
+                ->message($message)
+                ->requestId($requestId)
+                ->userSession($sessionId)
+                ->build()
+        );
+    }
+
+    /**
+     * Captures a record using a record builder and sends it to Highlight.
+     *
+     * @param HighlightRecord\Builder $builder the builder to use for the record
+     *
+     * @throws HighlightIllegalStateException  if Highlight is not initialized
+     * @throws HighlightInvalidRecordException if the record is invalid
+     */
+    public static function captureRecordFromBuilder(HighlightRecordBuilder $builder): void
+    {
+        self::requireInitialization();
+
+        self::captureRecord($builder->build());
+    }
+
+    /**
+     * Captures a record and sends it to Highlight.
+     *
+     * @param HighlightRecord $record the record to capture
+     *
+     * @throws HighlightIllegalStateException  if Highlight is not initialized
+     * @throws HighlightInvalidRecordException if the record is invalid
+     */
+    public static function capture(HighlightRecord $record): void
+    {
+        self::requireInitialization();
+
+        self::$highlight->captureRecord($record);
+    }
+
+    /**
+     * Returns the options.
+     *
+     * @return HighlightOptions the options
+     */
+    public function getOptions(): HighlightOptions
+    {
+        return $this->options;
+    }
+
+    /**
+     * Returns the {@code HighlightOpenTelemetry}
+     *
+     * @return \Highlight\SDK\HighlightOpenTelemetry the {@code HighlightOpenTelemetry} instance
+     */
+    public function getOpenTelemetry(): HighlightOpenTelemetry
+    {
+        return $this->openTelemetry;
+    }
+
+    /**
+     * Returns the {@code HighlightTracer}
+     *
+     * @return \Highlight\SDK\HighlightTracer the {@code HighlightTracer} instance
+     */
+    public function getTracer(): HighlightTracer
+    {
+        return $this->tracer;
+    }
+
+    /**
+     * Returns the {@code HighlightLogger} instance.
+     *
+     * @return HighlightLogger the {@code HighlightLogger} instance
+     */
+    public function getLogger(): HighlightLogger
+    {
+        return $this->logger;
+    }
+}
+

--- a/sdk/highlight-php/src/SDK/HighlightLogger.php
+++ b/sdk/highlight-php/src/SDK/HighlightLogger.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Highlight\SDK;
+
+use Highlight\SDK\Highlight;
+use Highlight\SDK\Common\Record\HighlightLogRecord;
+use Highlight\SDK\Common\HighlightAttributes;
+use OpenTelemetry\API\Logs\LogRecord;
+use OpenTelemetry\SDK\Logs\Logger;
+
+class HighlightLogger {
+
+    private Logger $logger;
+
+    public function __construct(Highlight $highlight) {
+        $openTelemetry = $highlight->getOpenTelemetry();
+		$this->logger = $openTelemetry->getLogger("highlight-php");
+    }
+
+    public function process(HighlightLogRecord $record) {
+        $severity = $record->getSeverity();
+        $logRecord = new LogRecord($record->getMessage());
+
+        $logRecord->setTimestamp($record->getTimeOccurred()->getTimestamp())
+        ->setSeverityNumber($severity->toOpenTelemetry())
+        ->setSeverityText($severity->text())
+        ->setAttributes($record->getAttributes()->toArray());
+
+        if ($record->hasUserSession()) {
+            $logRecord->setAttribute(HighlightAttributes::HIGHLIGHT_SESSION_ID, $record->getUserSession()->sessionId());
+        }
+
+        if ($record->hasRequestId()) {
+            $logRecord->setAttribute(HighlightAttributes::HIGHLIGHT_TRACE_ID, $record->getRequestId());
+        }
+
+        $this->logger->emit($logRecord);
+
+        // $builder = $this->logger->logRecordBuilder()
+        //     ->setAllAttributes($record->getAttributes())
+        //     ->setEpoch($record->getTimeOccured())
+        //     ->setSeverity($severity->toOpenTelemetry())
+        //     ->setSeverityText($severity->text())
+        //     ->setBody($record->getMessage());
+
+        // if ($record->hasUserSession()) {
+        //     $builder->setAttribute(HighlightAttributes::HIGHLIGHT_SESSION_ID, $record->getUserSession()->sessionId());
+        // }
+
+        // if ($record->hasRequestId()) {
+        //     $builder->setAttribute(HighlightAttributes::HIGHLIGHT_TRACE_ID, $record->getRequestId());
+        // }
+
+        // $builder->emit();
+
+    }
+}

--- a/sdk/highlight-php/src/SDK/HighlightLogger.php
+++ b/sdk/highlight-php/src/SDK/HighlightLogger.php
@@ -22,7 +22,7 @@ class HighlightLogger {
         $logRecord = new LogRecord($record->getMessage());
 
         $logRecord->setTimestamp($record->getTimeOccurred()->getTimestamp())
-        ->setSeverityNumber($severity->toOpenTelemetry())
+        ->setSeverityNumber($severity->id())
         ->setSeverityText($severity->text())
         ->setAttributes($record->getAttributes()->toArray());
 
@@ -35,23 +35,5 @@ class HighlightLogger {
         }
 
         $this->logger->emit($logRecord);
-
-        // $builder = $this->logger->logRecordBuilder()
-        //     ->setAllAttributes($record->getAttributes())
-        //     ->setEpoch($record->getTimeOccured())
-        //     ->setSeverity($severity->toOpenTelemetry())
-        //     ->setSeverityText($severity->text())
-        //     ->setBody($record->getMessage());
-
-        // if ($record->hasUserSession()) {
-        //     $builder->setAttribute(HighlightAttributes::HIGHLIGHT_SESSION_ID, $record->getUserSession()->sessionId());
-        // }
-
-        // if ($record->hasRequestId()) {
-        //     $builder->setAttribute(HighlightAttributes::HIGHLIGHT_TRACE_ID, $record->getRequestId());
-        // }
-
-        // $builder->emit();
-
     }
 }

--- a/sdk/highlight-php/src/SDK/HighlightOpenTelemetry.php
+++ b/sdk/highlight-php/src/SDK/HighlightOpenTelemetry.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Highlight\SDK;
+
+use Highlight\SDK\Common\HighlightAttributes;
+use Highlight\SDK\HighlightRoute;
+use Highlight\SDK\Highlight;
+use Highlight\SDK\SessionId;
+use Highlight\SDK\Common\HighlightVersion;
+
+use OpenTelemetry\SDK\Trace\TracerProvider;
+use OpenTelemetry\SDK\Trace\TracerProviderBuilder;
+use OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor;
+use OpenTelemetry\SDK\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\SDK\Logs\Logger;
+use OpenTelemetry\SDK\Logs\LoggerProvider;
+use OpenTelemetry\SDK\Logs\Processor\BatchLogRecordProcessor;
+
+use OpenTelemetry\Context\Propagation\TextMapPropagatorInterface;
+use OpenTelemetry\Context\Propagation\NoopTextMapPropagator;
+
+use OpenTelemetry\Contrib\Otlp\SpanExporter;
+use OpenTelemetry\Contrib\Otlp\LogsExporter;
+use OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory;
+use OpenTelemetry\SDK\Common\Time\ClockFactory;
+use OpenTelemetry\SDK\Common\Util\ShutdownHandler;
+
+use OpenTelemetry\SDK\Resource\ResourceInfo;
+use OpenTelemetry\SDK\Common\Attribute\AttributesFactory;
+use OpenTelemetry\SDK\Logs\LoggerProviderBuilder;
+use OpenTelemetry\Semconv\ResourceAttributes;
+
+// use OpenTelemetry\SDK\Logs\LogRecordLimitsBuilder;
+// use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeFactory;
+
+/**
+ * In the Java SDK, the HighlightOpenTelemetry class implements the io.opentelemetry.api.OpenTelemetry interface
+ * but the closest PHP equivalent is perhaps OpenTelemetry\SDK\SdkBuilder.php.
+ * 
+ * This class is therefore loosely modeled on OpenTelemetry\SDK\SdkBuilder
+ * @see https://github.com/open-telemetry/opentelemetry-php/blob/main/src/SDK/SdkBuilder.php 
+ */
+class HighlightOpenTelemetry
+{
+    private TracerProvider $tracerProvider;
+    private LoggerProvider $loggerProvider;
+
+    // OTLP Tracer params
+    private static array $headers = [];
+    private static string $compression = 'gzip';
+    private static float $timeout = 30.;
+        
+
+    public function __construct(Highlight $highlight)
+    {
+        $options = $highlight->getOptions();
+
+        $attributes = [
+            HighlightAttributes::HIGHLIGHT_PROJECT_ID => $options->getProjectId(),
+            ResourceAttributes::DEPLOYMENT_ENVIRONMENT => $options->getEnvironment(),
+            ResourceAttributes::SERVICE_INSTANCE_ID => SessionId::get()->__toString(),
+            ResourceAttributes::SERVICE_VERSION => $options->getVersion(),
+            ResourceAttributes::SERVICE_NAME => $options->getServiceName()    
+        ];
+
+        if ($options->isMetricEnabled()) {
+            $attributes[ResourceAttributes::TELEMETRY_SDK_NAME] = HighlightVersion::getSdkName();
+            $attributes[ResourceAttributes::TELEMETRY_SDK_VERSION] = HighlightVersion::getSdkVersion();
+            $attributes[ResourceAttributes::TELEMETRY_SDK_LANGUAGE] = HighlightVersion::getSdkLanguage();
+            
+            $attributes[ResourceAttributes::TELEMETRY_DISTRO_NAME] = 'highlight-opentelemetry-php-sdk';
+            $attributes[ResourceAttributes::TELEMETRY_DISTRO_VERSION] = phpversion('opentelemetry');
+
+            $attributes[HighlightAttributes::TELEMETRY_PHP_VERSION] = HighlightVersion::getPhpVersion();
+            $attributes[HighlightAttributes::TELEMETRY_PHP_VENDOR] = HighlightVersion::getPhpOsName();
+            $attributes[HighlightAttributes::TELEMETRY_PHP_VERSION_DATE] = HighlightVersion::getPhpOsVersion();
+            $attributes[ResourceAttributes::OS_NAME] = HighlightVersion::getPhpOsName();
+            $attributes[ResourceAttributes::OS_VERSION] = HighlightVersion::getPhpOsVersion();
+            $attributes[ResourceAttributes::OS_TYPE] = HighlightVersion::getPhpOsArch();
+        }
+
+        foreach ($options->getDefaultAttributes() as $key => $value) {
+            $attributes[$key] = $value;
+        }
+        $attributesFactory = new AttributesFactory();
+        $attributesBuilder = $attributesFactory->builder($attributes);
+        
+
+        $resource = ResourceInfo::create($attributesBuilder->build());
+
+        // Tracer
+        $transport = (new OtlpHttpTransportFactory())
+            ->create(HighlightRoute::buildTraceRoute($options->getBackendUrl()), 
+                'application/json', 
+                self::$headers, 
+                self::$compression, 
+                self::$timeout);
+        
+        $exporter = new SpanExporter($transport);
+        $spanProcessor = new BatchSpanProcessor($exporter, ClockFactory::getDefault());
+        $sampler = new AlwaysOnSampler();
+
+        $this->tracerProvider = (new TracerProviderBuilder())
+            ->addSpanProcessor($spanProcessor)
+            ->setResource($resource)->setSampler($sampler);
+
+
+        // Log
+        $transport = (new OtlpHttpTransportFactory())->create(HighlightRoute::buildLogRoute($options->getBackendUrl()), 'application/json');
+        $exporter = new LogsExporter($transport);
+        $logProcessor = new BatchLogRecordProcessor($exporter, ClockFactory::getDefault());
+
+        $this->loggerProvider = (new LoggerProviderBuilder())
+            ->addLogRecordProcessor($logProcessor)
+            ->setResource($resource);
+
+        // new LoggerProvider($logProcessor,
+        //     new InstrumentationScopeFactory(
+        //         (new LogRecordLimitsBuilder())->build()->getAttributeFactory()
+        //     )
+        // );
+
+        ShutdownHandler::register([$this->tracerProvider, 'shutdown']);
+        ShutdownHandler::register([$this->loggerProvider, 'shutdown']);
+    }
+
+    public function getLogger(string $instrumentationScopeName): Logger
+    {
+        return $this->loggerProvider->getLogger($instrumentationScopeName);
+    }
+
+    public function getTracerProvider(): TracerProvider
+    {
+        return $this->tracerProvider;
+    }
+
+    public function getLoggerProvider(): LoggerProvider
+    {
+        return $this->loggerProvider;
+    }
+    
+    public function getPropagators(): TextMapPropagatorInterface
+    {
+        return NoopTextMapPropagator::getInstance();
+    }
+
+    public function shutdown(): bool
+    {
+        return ($this->tracerProvider->shutdown() && $this->loggerProvider->shutdown());
+    }
+}

--- a/sdk/highlight-php/src/SDK/HighlightRoute.php
+++ b/sdk/highlight-php/src/SDK/HighlightRoute.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Highlight\SDK;
+
+class HighlightRoute {
+    // The default backend URL's.
+    const DEFAULT_BACKEND = "https://otel.highlight.io:4318";
+
+    // The default routes for sending.
+    const ROUTE_LOGS = "v1/logs";
+    const ROUTE_TRACES = "v1/traces";
+
+    /**
+     * Builds a route for sending logs to Highlight, based on the provided backend
+     * URL. If no backend URL is provided, the default backend URL is used.
+     *
+     * @param string $backend The backend URL to use.
+     * @return string The route for sending logs to Highlight.
+     */
+    public static function buildLogRoute($backend = null) {
+        if ($backend === null || trim($backend) === "") {
+            return self::DEFAULT_BACKEND . "/" . self::ROUTE_LOGS;
+        }
+
+        if (substr($backend, -strlen(self::ROUTE_LOGS)) === self::ROUTE_LOGS) {
+            return $backend;
+        }
+
+        if (substr($backend, -1) === "/") {
+            return $backend . self::ROUTE_LOGS;
+        }
+
+        return $backend . "/" . self::ROUTE_LOGS;
+    }
+
+    /**
+     * Builds a route for sending traces to Highlight, based on the provided backend
+     * URL. If no backend URL is provided, the default backend URL is used.
+     *
+     * @param string $backend The backend URL to use.
+     * @return string The route for sending traces to Highlight.
+     */
+    public static function buildTraceRoute($backend = null) {
+        if ($backend === null || trim($backend) === "") {
+            return self::DEFAULT_BACKEND . "/" . self::ROUTE_TRACES;
+        }
+
+        if (substr($backend, -strlen(self::ROUTE_TRACES)) === self::ROUTE_TRACES) {
+            return $backend;
+        }
+
+        if (substr($backend, -1) === "/") {
+            return $backend . self::ROUTE_TRACES;
+        }
+
+        return $backend . "/" . self::ROUTE_TRACES;
+    }
+
+    /**
+     * Get the default backend URL.
+     *
+     * @return string The default backend URL.
+     */
+    public static function getDefaultBackend() {
+        return self::DEFAULT_BACKEND;
+    }
+
+    // Private constructor to prevent instantiation
+    private function __construct() {
+    }
+}

--- a/sdk/highlight-php/src/SDK/HighlightSession.php
+++ b/sdk/highlight-php/src/SDK/HighlightSession.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK;
+
+use Highlight\SDK\Common\HighlightSessionId;
+use Highlight\SDK\Common\Severity;
+use Highlight\SDK\Common\Record\HighlightRecord;
+use Highlight\SDK\Common\Record\HighlightLogRecord;
+use Highlight\SDK\Common\Record\HighlightErrorRecord;
+use Highlight\SDK\Common\Record\HighlightRecordBuilder;
+use Highlight\SDK\Exception\HighlightInvalidRecordException;
+
+class HighlightSession implements HighlightSessionId
+{
+    private string $sessionId;
+
+    public function __construct(string $sessionId)
+    {
+        $this->sessionId = $sessionId;
+    }
+
+    /**
+     * Returns the current sessionId.
+     *
+     * @return string the sessionId as a string
+     */
+    public function sessionId(): string
+    {
+        return $this->sessionId;
+    }
+
+    public function captureRecordFromBuilder(HighlightRecordBuilder $builder): void
+    {
+        $builder->userSession($this);
+
+        Highlight::capture($builder->build());
+    }
+
+    public function captureRecord(HighlightRecord $record): void
+    {
+        if ($record instanceof HighlightLogRecord) {
+            $this->captureRecordFromBuilder(HighlightRecord::logFromRecord($record));
+
+        } elseif ($record instanceof HighlightErrorRecord) {
+            $this->captureRecordFromBuilder(HighlightRecord::errorFromRecord($record));
+
+        } else {
+            throw new HighlightInvalidRecordException("Invalid record type", $record);
+        }
+    }
+
+    public function captureException(\Throwable $error): void
+    {
+        $errorRecordBuilder = HighlightRecord::error();
+        $errorRecordBuilder->throwable($error);
+        $this->captureRecordFromBuilder($errorRecordBuilder);
+    }
+
+    public function captureLog(Severity $severity, string $message = null): void
+    {
+        $logRecordBuilder = HighlightRecord::log();
+        $logRecordBuilder->severity($severity);
+        if ($message !== null) {
+            $logRecordBuilder->message($message);
+        }
+        $this->captureRecordFromBuilder($logRecordBuilder);
+    }
+
+    public function __toString(): string
+    {
+        return 'HighlightSession[' .
+            'sessionId=' . $this->sessionId . ']';
+    }
+}

--- a/sdk/highlight-php/src/SDK/HighlightTracer.php
+++ b/sdk/highlight-php/src/SDK/HighlightTracer.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Highlight\SDK;
+
+use Highlight\SDK\Common\HighlightAttributes;
+use Highlight\SDK\Common\Record\HighlightErrorRecord;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\API\Trace\TracerInterface;
+use OpenTelemetry\Context\Context;
+
+class HighlightTracer
+{
+
+    private TracerInterface $tracer;
+
+    public function __construct(Highlight $highlight)
+    {
+		$this->tracer = $highlight->getTracer();
+    }
+
+    public function process(HighlightErrorRecord $record)
+    {
+        $spanBuilder = $this->tracer->spanBuilder('highlight-ctx');
+
+        $spanBuilder->setAttributes($record->getAttributes()->toArray())
+            ->setStartTimestamp($record->getTimeOccurred()->getTimestamp())
+            ->setParent(null);
+
+        $span = $spanBuilder->startSpan();
+
+        try {
+            $context = $this->tracer->getActiveSpan()->storeInContext(Context::getCurrent());
+            $context = $context->withContextValue($span);
+
+            if ($record->hasUserSession()) {
+                $span->setAttribute(HighlightAttributes::HIGHLIGHT_SESSION_ID, $record->getUserSession()->sessionId());
+            }
+
+            if ($record->hasRequestId()) {
+                $span->setAttribute(HighlightAttributes::HIGHLIGHT_TRACE_ID, $record->getRequestId());
+            }
+
+            $span->recordException($record->getThrowable());
+
+            // You can add additional logic here to handle exceptions, set status codes, and more.
+
+        } finally {
+            $span->end();
+        }
+    }
+}

--- a/sdk/highlight-php/src/SDK/HighlightTracer.php
+++ b/sdk/highlight-php/src/SDK/HighlightTracer.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Highlight\SDK;
 
 use Highlight\SDK\Common\HighlightAttributes;
 use Highlight\SDK\Common\Record\HighlightErrorRecord;
-use OpenTelemetry\API\Trace\Span;
 use OpenTelemetry\API\Trace\TracerInterface;
 use OpenTelemetry\Context\Context;
 
@@ -15,7 +16,8 @@ class HighlightTracer
 
     public function __construct(Highlight $highlight)
     {
-		$this->tracer = $highlight->getTracer();
+        $highlightOpenTelemetry = $highlight->getOpenTelemetry();
+		$this->tracer = $highlightOpenTelemetry->getTracerProvider()->getTracer('highlight-php'); 
     }
 
     public function process(HighlightErrorRecord $record)
@@ -29,8 +31,7 @@ class HighlightTracer
         $span = $spanBuilder->startSpan();
 
         try {
-            $context = $this->tracer->getActiveSpan()->storeInContext(Context::getCurrent());
-            $context = $context->withContextValue($span);
+            Context::storage()->attach($span->storeInContext(Context::getCurrent()));
 
             if ($record->hasUserSession()) {
                 $span->setAttribute(HighlightAttributes::HIGHLIGHT_SESSION_ID, $record->getUserSession()->sessionId());

--- a/sdk/highlight-php/src/SDK/SessionId.php
+++ b/sdk/highlight-php/src/SDK/SessionId.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\SDK;
+
+class SessionId
+{
+
+    private string $bytes;
+
+    private function __construct($bytes)
+    {
+        $this->bytes = $bytes;
+    }
+
+    public static function get(): self
+    {
+        return new SessionId('' . self::createMachineIdentifier() . '' . self::createProcessIdentifier());
+    }
+
+    private static function createMachineIdentifier(): int
+    {
+        try {
+            $machinePiece = crc32(php_uname('n'));
+        } catch (\Exception $e) {
+            $machinePiece = mt_rand();
+        }
+    
+        $machinePiece &= 0xFFFFFF;
+        return $machinePiece;
+    }
+
+    private static function createProcessIdentifier(): int
+    {
+        $processId = 0;
+    
+        $processName = php_uname('n');
+        if (strpos($processName, '@') !== false) {
+            $processId = (int) explode('@', $processName, 2)[0];
+        } else {
+            $processId = (int) crc32($processName);
+        }
+    
+        return (int) $processId;
+    }
+
+    public function __toString(): string
+    {
+        return $this->bytes;
+    }
+}

--- a/sdk/highlight-php/tests/Integration/SDK/HighlightSessionTest.php
+++ b/sdk/highlight-php/tests/Integration/SDK/HighlightSessionTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\Tests\Integration\SDK;
+
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use Highlight\SDK\Common\Priority;
+use Highlight\SDK\Common\Record\HighlightRecord;
+use Highlight\SDK\Common\Record\HighlightLogRecordBuilder;
+use Highlight\SDK\Common\Record\HighlightErrorRecordBuilder;
+use Highlight\SDK\Common\Severity;
+use Highlight\SDK\Exception\HighlightInvalidRecordException;
+use Highlight\SDK\Highlight;
+use Highlight\SDK\HighlightSession;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use DateTimeImmutable;
+use Highlight\SDK\Common\Record\HighlightErrorRecord;
+use Highlight\SDK\Common\Record\HighlightLogRecord;
+use InvalidArgumentException;
+use RuntimeException;
+
+class HighlightSessionTest extends TestCase
+{
+    private static string $projectId = 'test-project-01';
+
+    protected function tearDown(): void
+    {
+        $reflectionClass = new ReflectionClass('Highlight\SDK\Highlight');
+        $highlightProperty = $reflectionClass->getProperty('highlight');
+        $highlightProperty->setAccessible(true);
+        // set the singleton to null
+        $highlightProperty->setValue(null);
+    }
+
+    public function test_captureRecordFromBuilder()
+    {
+        $this->assertSame(false, Highlight::isInitialized());
+        Highlight::init(self::$projectId);
+        $this->assertSame(true, Highlight::isInitialized());
+
+        $sessionId = 'test-session-01';
+        $highlightSession = new HighlightSession($sessionId);
+
+
+        // log:
+        $logBuilder1 = HighlightRecord::log();
+        $logBuilder1->severity(new Severity("severity test", 20, new Priority(4)));
+        $highlightSession->captureRecordFromBuilder($logBuilder1);
+
+        $logBuilder2 = (new HighlightLogRecordBuilder())->fromRecord(
+            new HighlightLogRecord(
+                new HighlightRecord(new DateTimeImmutable(), Attributes::create([]), new HighlightSession($sessionId), 'request-log-01'), 
+                new Severity("severity test", 20, new Priority(4)),
+                'Test log message'));
+        $highlightSession->captureRecordFromBuilder($logBuilder2);
+
+        // capture(...)
+        $logRecordFromBuilder2 = (HighlightRecord::logFromRecord($logBuilder2->build()))->requestId('request-log-02')->build();
+        $highlightSession->captureRecord($logRecordFromBuilder2);
+
+
+        // error:
+        $errorBuilder1 = HighlightRecord::error();
+        $errorBuilder1->throwable(new RuntimeException('Test runtime exception'));
+        $highlightSession->captureRecordFromBuilder($errorBuilder1);
+
+        $errorBuilder2 = (new HighlightErrorRecordBuilder())->fromRecord(
+            new HighlightErrorRecord(
+                new HighlightRecord(new DateTimeImmutable(), Attributes::create([]), new HighlightSession($sessionId), 'request-error-01'),
+                new RuntimeException('Test runtime exception')));
+        $highlightSession->captureRecordFromBuilder($errorBuilder2);
+
+        // capture(...)
+        $errorRecordFromBuilder2 = (HighlightRecord::errorFromRecord($errorBuilder2->build()))->requestId('request-error-02')->build();
+        $highlightSession->captureRecord($errorRecordFromBuilder2);
+    }
+
+    public function test_captureRecord()
+    {
+        if (!Highlight::isInitialized()) {
+            Highlight::init(self::$projectId);
+        }
+        $this->assertSame(true, Highlight::isInitialized());
+
+        $sessionId = 'test-session-01';
+        $highlightSession = new HighlightSession($sessionId);
+
+        // 1:
+        $logRecord1 = (HighlightRecord::log())
+            ->severity(new Severity("test", 5, new Priority(5)))
+            ->message('Test log message')
+            ->timeOccurred(new DateTimeImmutable())
+            ->userSessionString($sessionId)
+            ->requestId('test-request-01')
+            ->build();
+        $highlightSession->captureRecord($logRecord1);
+
+        // 2:
+        $errorRecord2 = (HighlightRecord::error())
+            ->throwable(new InvalidArgumentException('Testing invalid argument throwable'))
+            ->timeOccurred(new DateTimeImmutable())
+            ->userSessionString($sessionId)
+            ->build();
+        $highlightSession->captureRecord($errorRecord2);
+
+        // 3:
+        $invalidRecord = new HighlightRecord(new DateTimeImmutable(), Attributes::create([]), new HighlightSession($sessionId), 'request-error-01');
+        try {
+            $highlightSession->captureRecord($invalidRecord);
+        } catch (HighlightInvalidRecordException $e) {
+            $this->assertTrue($e instanceof HighlightInvalidRecordException);
+            $this->assertEquals("Invalid record type", $e->getMessage());
+        }
+    }
+
+    public function test_captureException()
+    {
+        if (!Highlight::isInitialized()) {
+            Highlight::init(self::$projectId);
+        }
+        $this->assertSame(true, Highlight::isInitialized());
+
+        $sessionId = 'test-session-01';
+        $highlightSession = new HighlightSession($sessionId);
+
+        $throwable = new InvalidArgumentException('Invalid argument provided.');
+        $highlightSession->captureException($throwable);
+    }
+
+    public function test_captureLog()
+    {
+        if (!Highlight::isInitialized()) {
+            Highlight::init(self::$projectId);
+        }
+        $this->assertSame(true, Highlight::isInitialized());
+
+        $sessionId = 'test-session-01';
+        $highlightSession = new HighlightSession($sessionId);
+
+        $severity = new Severity("test", 1, new Priority(1));
+        $message = 'test message 01';
+        $highlightSession->captureLog($severity, $message);
+    }
+
+    public function test_toString()
+    {
+        $sessionId = 'test-session-01';
+        $highlightSession = new HighlightSession($sessionId);
+        $this->assertStringContainsString($sessionId, $highlightSession->__toString());
+    }
+}

--- a/sdk/highlight-php/tests/Integration/SDK/HighlightTest.php
+++ b/sdk/highlight-php/tests/Integration/SDK/HighlightTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\Tests\Integration\SDK;
+
+use DateTimeImmutable;
+use Highlight\SDK\Common\HighlightHeader;
+use Highlight\SDK\Common\HighlightOptions;
+use Highlight\SDK\Common\Priority;
+use Highlight\SDK\Common\Record\HighlightRecord;
+use Highlight\SDK\Common\Severity;
+use Highlight\SDK\Exception\HighlightIllegalStateException;
+use Highlight\SDK\Exception\HighlightInvalidOptionException;
+use Highlight\SDK\Highlight;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use InvalidArgumentException;
+
+class HighlightTest extends TestCase
+{
+    private static string $projectId = 'test-project-01';
+
+    protected function tearDown(): void
+    {
+        $reflectionClass = new ReflectionClass('Highlight\SDK\Highlight');
+        $highlightProperty = $reflectionClass->getProperty('highlight');
+        $highlightProperty->setAccessible(true);
+        // set the singleton to null
+        $highlightProperty->setValue(null);
+    }
+
+    public function test_init()
+    {
+        $this->assertSame(false, Highlight::isInitialized());
+        Highlight::init(self::$projectId);
+        $this->assertSame(true, Highlight::isInitialized());
+    }
+
+    public function test_initWithOptions()
+    {
+        $options = HighlightOptions::builder(self::$projectId)->build();
+
+        $this->assertSame(false, Highlight::isInitialized());
+        Highlight::initWithOptions($options);
+        $this->assertSame(true, Highlight::isInitialized());
+        $this->assertEquals("unknown", $options->getServiceName());
+    }
+
+    public function test_initWithOptions_and_ServiceName() 
+    {
+        $serviceName = 'test-service-03'; 
+        $options = HighlightOptions::builder(self::$projectId)->serviceName($serviceName)->build();
+
+        $this->assertSame(false, Highlight::isInitialized());
+        Highlight::initWithOptions($options);
+        $this->assertSame(true, Highlight::isInitialized());
+        $this->assertNotEmpty($options->getServiceName());
+        $this->assertEquals($serviceName, $options->getServiceName());
+
+        // subsequent invocations of Highlight::init() should throw an exception
+        try {
+            Highlight::init(self::$projectId);
+        } catch (HighlightIllegalStateException $e) {
+            $this->assertTrue($e instanceof HighlightIllegalStateException);
+            $this->assertEquals("Highlight is already initialized", $e->getMessage());
+        }
+
+        // subsequent invocations of Highlight::initWithOptions() should throw an exception
+        try {
+            Highlight::initWithOptions($options);
+        } catch (HighlightIllegalStateException $e) {
+            $this->assertTrue($e instanceof HighlightIllegalStateException);
+            $this->assertEquals("Highlight is already initialized", $e->getMessage());
+        }
+    }
+
+    public function test_capture_negative() 
+    {
+        $requestId = "test-request-04";
+        $sessionId = "test-session-id";
+        $message = "test-message";
+        $severity = new Severity("test", 1, new Priority(1));
+
+        // capture() - log
+        try {
+            $logRecord = (HighlightRecord::log())->requestId($requestId)->build();
+        } catch (InvalidArgumentException $e) {
+            $this->assertTrue($e instanceof InvalidArgumentException);
+            $this->assertEquals("Severity cannot be null", $e->getMessage());
+        }
+
+        $logRecordBuilder = HighlightRecord::log();
+        $logRecord = $logRecordBuilder->severity($severity)->requestId($requestId)->build();
+
+        try {
+            Highlight::capture($logRecord);
+        } catch (HighlightIllegalStateException $e) {
+            $this->assertTrue($e instanceof HighlightIllegalStateException);
+            $this->assertEquals("Highlight instance is not initialized", $e->getMessage());
+        }
+
+        // capture() - error
+        try {
+            $errorRecord = (HighlightRecord::error())->build();
+        } catch (InvalidArgumentException $e) {
+            $this->assertTrue($e instanceof InvalidArgumentException);
+            $this->assertEquals("Throwable cannot be null", $e->getMessage());
+        }
+
+        $errorRecordBuilder = HighlightRecord::error();
+        $throwable = new HighlightInvalidOptionException("Test throwable");
+        $errorRecord = $errorRecordBuilder->throwable($throwable)->build();
+
+        try {
+            Highlight::capture($errorRecord);
+        } catch (HighlightIllegalStateException $e) {
+            $this->assertTrue($e instanceof HighlightIllegalStateException);
+            $this->assertEquals("Highlight instance is not initialized", $e->getMessage());
+        }
+        // captureLog()
+        try {
+            Highlight::captureLog($severity, $message);
+        } catch (HighlightIllegalStateException $e) {
+            $this->assertTrue($e instanceof HighlightIllegalStateException);
+            $this->assertEquals("Highlight instance is not initialized", $e->getMessage());
+        }
+        // captureLogWithSessionAndRequest()
+        try {
+            Highlight::captureLogWithSessionAndRequest($severity, $message, $sessionId, $requestId);
+        } catch (HighlightIllegalStateException $e) {
+            $this->assertTrue($e instanceof HighlightIllegalStateException);
+            $this->assertEquals("Highlight instance is not initialized", $e->getMessage());
+        }
+        // captureException()
+        try {
+            Highlight::captureException($throwable);
+        } catch (HighlightIllegalStateException $e) {
+            $this->assertTrue($e instanceof HighlightIllegalStateException);
+            $this->assertEquals("Highlight instance is not initialized", $e->getMessage());
+        }
+        // captureExceptionWithHighlightHeader()
+        try {
+            Highlight::captureExceptionWithHighlightHeader($throwable, new HighlightHeader($sessionId, $requestId));
+        } catch (HighlightIllegalStateException $e) {
+            $this->assertTrue($e instanceof HighlightIllegalStateException);
+            $this->assertEquals("Highlight instance is not initialized", $e->getMessage());
+        }
+        // captureRecordFromBuilder()
+        try {
+            Highlight::captureRecordFromBuilder(HighlightRecord::error());
+        } catch (HighlightIllegalStateException $e) {
+            $this->assertTrue($e instanceof HighlightIllegalStateException);
+            $this->assertEquals("Highlight instance is not initialized", $e->getMessage());
+        }
+    }
+
+    public function test_capture_positive() 
+    {
+        $sessionId = "test-session-string";
+        $requestId1 = "test-request-01";
+        $requestId2 = "test-request-02";
+
+        $severity = new Severity("test", 1, new Priority(1));
+        $message = "Test log message";
+        $throwable = new HighlightInvalidOptionException("Test throwable");
+
+        if (!Highlight::isInitialized()) {
+            Highlight::init(self::$projectId);
+        }
+        $this->assertSame(true, Highlight::isInitialized());
+
+        $logRecord1 = (HighlightRecord::log())
+            ->severity($severity)
+            ->message($message)
+            ->timeOccurred(new DateTimeImmutable())
+            ->userSessionString($sessionId)
+            ->requestId($requestId1)
+            ->build();
+        Highlight::capture($logRecord1);
+
+        $logRecord2 = (HighlightRecord::logFromRecord($logRecord1))->requestId($requestId2)->build();
+        Highlight::capture($logRecord2);
+
+        $errorRecord1 = (HighlightRecord::error())
+            ->throwable($throwable)
+            ->timeOccurred(new DateTimeImmutable())
+            ->userSessionString($sessionId)
+            ->build();
+        Highlight::capture($errorRecord1);
+        $errorRecord2 = (HighlightRecord::errorFromRecord($errorRecord1))->requestId($requestId2)->build();
+        Highlight::capture($errorRecord2);
+
+    }
+}

--- a/sdk/highlight-php/tests/Unit/SDK/Common/HighlightOptionsBuilderTest.php
+++ b/sdk/highlight-php/tests/Unit/SDK/Common/HighlightOptionsBuilderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\Tests\Unit\SDK\Common;
+
+use Highlight\SDK\Common\HighlightOptions;
+use Highlight\SDK\Common\HighlightOptionsBuilder as Builder;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use PHPUnit\Framework\TestCase;
+
+class HighlightOptionsBuilderTest extends TestCase
+{
+    private static string $projectId = 'test-project-01';
+    private static string $dev = 'development';
+    private static string $unknown = 'unknown';
+
+    public function test_HighlightOptions_Constructor() 
+    {
+        $optionsBuilder = new Builder(self::$projectId);
+                
+        $metricEnabled = false;
+        $optionsBuilder->metric($metricEnabled);
+        $this->assertSame($metricEnabled, $optionsBuilder->build()->isMetricEnabled());
+
+        $metricEnabled = true;
+        $optionsBuilder->metric($metricEnabled);
+        $this->assertSame($metricEnabled, $optionsBuilder->build()->isMetricEnabled());
+    }
+
+    public function test_Equality()
+    {
+        $options1 = (HighlightOptions::builder(self::$projectId))->build();
+        $options2 = (new Builder(self::$projectId))->build();
+
+        $this->assertEquals($options1, $options2);        
+    }
+}

--- a/sdk/highlight-php/tests/Unit/SDK/Common/HighlightOptionsTest.php
+++ b/sdk/highlight-php/tests/Unit/SDK/Common/HighlightOptionsTest.php
@@ -57,5 +57,4 @@ class HighlightOptionsTest extends TestCase
         $this->assertSame(true, $options->isMetricEnabled());
         $this->assertEmpty($options->getDefaultAttributes());
     }
-
 }

--- a/sdk/highlight-php/tests/Unit/SDK/Common/HighlightOptionsTest.php
+++ b/sdk/highlight-php/tests/Unit/SDK/Common/HighlightOptionsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Highlight\Tests\Unit\SDK\Common;
+
+use Highlight\SDK\Common\HighlightOptions;
+use Highlight\SDK\Common\HighlightOptionsBuilder as Builder;
+use OpenTelemetry\SDK\Common\Attribute\Attributes;
+use PHPUnit\Framework\TestCase;
+
+class HighlightOptionsTest extends TestCase
+{
+    private static string $projectId = 'test-project-01';
+    private static string $defaultEnv = 'development';
+    private static string $defaultVersion = 'unknown';
+    private static string $defaultServiceName = 'unknown';
+
+    public function test_HighlightOptions_Constructor() 
+    {
+        $serviceName = 'test-service-01'; 
+        $options = new HighlightOptions(self::$projectId, '', '', '', $serviceName, false, Attributes::create([]));
+
+        $this->assertSame(self::$projectId, $options->getProjectId());
+        $this->assertSame('', $options->getBackendUrl());
+        $this->assertSame('', $options->getEnvironment());
+        $this->assertSame('', $options->getVersion());
+        $this->assertSame($serviceName, $options->getServiceName()); 
+        $this->assertSame(false, $options->isMetricEnabled());
+        $this->assertEmpty($options->getDefaultAttributes());
+        $this->assertStringContainsString(self::$projectId, $options->__toString());
+        $this->assertStringContainsString($serviceName, $options->__toString());
+    }
+
+    public function test_HighlightOptions_Builder()
+    {
+        $optionsBuilder = HighlightOptions::builder(self::$projectId);
+        $options = $optionsBuilder->build();
+
+        $this->testHighlightOptions($options);
+    }
+
+    public function test_HighlightOptionsBuilder_Build()
+    {
+        $optionsBuilder = new Builder(self::$projectId);
+        $options = $optionsBuilder->build();
+
+        $this->testHighlightOptions($options);
+    }
+
+    private function testHighlightOptions(HighlightOptions $options) 
+    {
+        $this->assertSame(self::$projectId, $options->getProjectId());
+        $this->assertSame(self::$defaultEnv, $options->getEnvironment());
+        $this->assertSame(self::$defaultVersion, $options->getVersion());
+        $this->assertSame(self::$defaultServiceName, $options->getServiceName()); 
+        $this->assertSame(true, $options->isMetricEnabled());
+        $this->assertEmpty($options->getDefaultAttributes());
+    }
+
+}

--- a/sdk/highlight-php/tests/bootstrap.php
+++ b/sdk/highlight-php/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
## Summary

The PHP SDK closely follows the design of Java SDK mentioned in the original issue: https://github.com/highlight/highlight/issues/4225

## How did you test this change?

Automated tests.

## Are there any deployment considerations?

Requires a minimum of PHP v8.2+ as some Otel dependencies wont work with older versions like PHP v7.4.

## Does this work require review from our design team?

Nope.

/claim #4225