### PR TITLE
evict redis on session processing

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4630,7 +4630,12 @@ func (r *queryResolver) Resources(ctx context.Context, sessionSecureID string) (
 		return nil, err
 	}
 
-	resources, err := r.Redis.GetResources(ctx, s)
+	s3Resources, err := r.StorageClient.GetRawData(ctx, s.ID, s.ProjectID, model.PayloadTypeResources)
+	if err != nil {
+		return nil, e.Wrap(err, "error retrieving events objects from S3")
+	}
+
+	resources, err := r.Redis.GetResources(ctx, s, s3Resources)
 	if err != nil {
 		return nil, e.Wrap(err, "error getting resources from redis")
 	}

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -311,34 +311,9 @@ func (r *Client) GetEvents(ctx context.Context, s *model.Session, cursor model.E
 
 func (r *Client) GetResources(ctx context.Context, s *model.Session, resources map[int]string) ([]interface{}, error) {
 	allResources := make([]interface{}, 0)
-
-	redisData, err := r.Client.ZRangeByScoreWithScores(ctx, NetworkResourcesKey(s.ID), &redis.ZRangeBy{
-		Min: "-inf",
-		Max: "+inf",
-	}).Result()
+	results, err := r.GetSessionData(ctx, s.ID, model.PayloadTypeResources, resources)
 	if err != nil {
-		return nil, errors.Wrap(err, "error retrieving network resources from Redis")
-	}
-
-	for _, z := range redisData {
-		intScore := int(z.Score)
-		// Skip beacon events
-		if z.Score != float64(intScore) {
-			continue
-		}
-
-		resources[intScore] = z.Member.(string)
-	}
-
-	keys := make([]int, 0, len(resources))
-	for k := range resources {
-		keys = append(keys, k)
-	}
-	sort.Ints(keys)
-
-	results := []string{}
-	for _, key := range keys {
-		results = append(results, resources[key])
+		return nil, err
 	}
 
 	for _, result := range results {

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -192,6 +192,10 @@ func (w *Worker) writeSessionDataFromRedis(ctx context.Context, manager *payload
 
 	writeChunks := os.Getenv("ENABLE_OBJECT_STORAGE") == "true" && payloadType == model.PayloadTypeEvents
 
+	if err := w.PublicResolver.MoveSessionDataToStorage(ctx, s.ID, nil, s.ProjectID, payloadType); err != nil {
+		return err
+	}
+
 	s3Events, err := w.Resolver.StorageClient.GetRawData(ctx, s.ID, s.ProjectID, payloadType)
 	if err != nil {
 		return errors.Wrap(err, "error retrieving objects from S3")


### PR DESCRIPTION
## Summary
- when processing a session, move all data (events, network, websocket) out of redis to storage
- make the `RemoveValues` and `GetRawZRange` functions generic to work with all payload types
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally by processing a session multiple times + live mode
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will monitor redis usage after deployment
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
