### PR TITLE
remove daily session count in worker

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -892,24 +892,6 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 		log.WithContext(ctx).Errorf("failed to submit session processing metric for %s: %s", s.SecureID, err)
 	}
 
-	// Update session count on dailydb
-	currentDate := time.Date(s.CreatedAt.UTC().Year(), s.CreatedAt.UTC().Month(), s.CreatedAt.UTC().Day(), 0, 0, 0, 0, time.UTC)
-	dailySession := &model.DailySessionCount{}
-	if err := w.Resolver.DB.WithContext(ctx).
-		Where(&model.DailySessionCount{
-			ProjectID: s.ProjectID,
-			Date:      &currentDate,
-		}).Attrs(&model.DailySessionCount{Count: 0}).
-		FirstOrCreate(&dailySession).Error; err != nil {
-		return e.Wrap(err, "Error creating new daily session")
-	}
-
-	if err := w.Resolver.DB.WithContext(ctx).
-		Where(&model.DailySessionCount{Model: model.Model{ID: dailySession.ID}}).
-		Updates(&model.DailySessionCount{Count: dailySession.Count + 1}).Error; err != nil {
-		return e.Wrap(err, "Error incrementing session count in db")
-	}
-
 	var g errgroup.Group
 	projectID := s.ProjectID
 


### PR DESCRIPTION
## Summary
- `daily_sessions_count_view` is used instead, stop reading/writing to the old table in the worker
- this was showing up in the RDS top queries
<img width="668" alt="Screen Shot 2023-11-17 at 11 25 06 AM" src="https://github.com/highlight/highlight/assets/86132398/e381e6e7-29ba-4089-83b5-e7dee053b4e2">

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- confirmed session processing still working locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
