### PR TITLE
reduce object storage brotli level from 9 to 5

### DIFF
--- a/backend/payload/payload.go
+++ b/backend/payload/payload.go
@@ -20,7 +20,7 @@ type CompressedWriter struct {
 	hasUnclosedArray bool
 }
 
-const BROTLI_COMPRESSION_LEVEL = 9
+const BROTLI_COMPRESSION_LEVEL = 5
 
 // Initializes a new writer with the configured compression level
 func NewCompressedWriter(brFile *os.File) *CompressedWriter {


### PR DESCRIPTION
## Summary
- looking at a few benchmarks, brotli level 5 is about 3x faster than level 9 while having only a percent or two better compression (e.g. https://blog.cloudflare.com/results-experimenting-brotli/)
- if the same ratios hold for our data, the cost of this extra computation outweighs the ~1% extra storage cost for session payloads
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor the rate of growth in s3
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, can revert if necessary
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
