### PR TITLE
track sessions to process in redis instead of postgres

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -184,6 +184,15 @@ var ErrUserFilteredError = e.New("User filtered error")
 // metrics that should be stored in postgres for session lookup
 var MetricCategoriesForDB = map[string]bool{"Device": true, "WebVital": true}
 
+var SessionProcessDelaySeconds = 60 // a session will be processed after not receiving events for this time
+var SessionProcessLockMinutes = 30  // a session marked as processing can be reprocessed after this time
+func init() {
+	if util.IsDevEnv() {
+		SessionProcessDelaySeconds = 8
+		SessionProcessLockMinutes = 1
+	}
+}
+
 // Change to AppendProperties(sessionId,properties,type)
 func (r *Resolver) AppendProperties(ctx context.Context, sessionID int, properties map[string]string, propType Property) error {
 	outerSpan, ctx := util.StartSpanFromContext(ctx, "public-graph.AppendProperties",
@@ -2857,6 +2866,10 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	// clear it so it is shown as live in OpenSearch since we now have data for it.
 	if (sessionObj.Processed != nil && *sessionObj.Processed) || (!excluded) {
 		if err := r.DataSyncQueue.Submit(ctx, strconv.Itoa(sessionObj.ID), &kafka_queue.Message{Type: kafka_queue.SessionDataSync, SessionDataSync: &kafka_queue.SessionDataSyncArgs{SessionID: sessionObj.ID}}); err != nil {
+			return err
+		}
+
+		if err := r.Redis.AddSessionToProcess(ctx, sessionID, SessionProcessDelaySeconds); err != nil {
 			return err
 		}
 	}

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -63,6 +63,8 @@ const EVENTS_READ_TIMEOUT = 300000
 // cancel refreshing materialized views after 30 minutes
 const REFRESH_MATERIALIZED_VIEW_TIMEOUT = 30 * 60 * 1000
 
+const processSessionLimit = 200
+
 type Worker struct {
 	Resolver       *mgraph.Resolver
 	PublicResolver *pubgraph.Resolver
@@ -557,6 +559,10 @@ func (w *Worker) excludeSession(ctx context.Context, s *model.Session, reason ba
 }
 
 func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
+	if s.Excluded {
+		return nil
+	}
+
 	project := &model.Project{}
 	if err := w.Resolver.DB.WithContext(ctx).Where(&model.Project{Model: model.Model{ID: s.ProjectID}}).Take(&project).Error; err != nil {
 		return e.Wrap(err, "error querying project")
@@ -1017,86 +1023,47 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 	return nil
 }
 
-// Start begins the worker's tasks.
-func (w *Worker) Start(ctx context.Context) {
-	payloadLookbackPeriod := 60 // a session must be stale for at least this long to be processed
-	lockPeriod := 30            // time in minutes
+func (w *Worker) GetSessionsToProcess(ctx context.Context, payloadLookbackPeriod int, lockPeriod int, limit int) ([]*model.Session, error) {
+	sessionsSpan, ctx := util.StartSpanFromContext(ctx, "worker.sessionsQuery", util.ResourceName("worker.sessionsQuery"))
+	defer sessionsSpan.Finish()
 
-	if util.IsDevEnv() {
-		payloadLookbackPeriod = 8
-		lockPeriod = 1
+	sessionIds, err := w.Resolver.Redis.GetSessionsToProcess(ctx, lockPeriod, limit)
+	if err != nil {
+		return nil, err
 	}
 
-	go reportProcessSessionCount(ctx, w.Resolver.DB, payloadLookbackPeriod, lockPeriod)
+	sessions := []*model.Session{}
+	if err := w.Resolver.DB.Model(&model.Session{}).Where("id in ?", sessionIds).Find(&sessions).Error; err != nil {
+		return nil, err
+	}
+
+	rand.New(rand.NewSource(time.Now().UnixNano()))
+	rand.Shuffle(len(sessions), func(i, j int) {
+		sessions[i], sessions[j] = sessions[j], sessions[i]
+	})
+
+	// Sends a "count" metric to datadog so that we can see how many sessions are being queried.
+	hlog.Histogram("worker.sessionsQuery.sessionCount", float64(len(sessions)), nil, 1) //nolint
+
+	return sessions, nil
+}
+
+// Start begins the worker's tasks.
+func (w *Worker) Start(ctx context.Context) {
+	go reportProcessSessionCount(ctx, w.Resolver.DB, pubgraph.SessionProcessDelaySeconds, pubgraph.SessionProcessLockMinutes)
 	maxWorkerCount := 10
-	processSessionLimit := 200
 	wp := workerpool.New(maxWorkerCount)
 	wp.SetPanicHandler(util.Recover)
 	for {
 		time.Sleep(1 * time.Second)
-		sessions := []*model.Session{}
-		sessionsSpan, ctx := util.StartSpanFromContext(ctx, "worker.sessionsQuery", util.ResourceName("worker.sessionsQuery"))
-		sessionLimitJitter := rand.Intn(100)
-		limit := processSessionLimit + sessionLimitJitter
-		txStart := time.Now()
-		if err := w.Resolver.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			transactionCtx, cancel := context.WithTimeout(ctx, 20*time.Minute)
-			defer cancel()
 
-			errs := make(chan error, 1)
-			go func() {
-				defer util.Recover()
-				if err := tx.Raw(`
-						WITH t AS (
-							UPDATE sessions
-							SET lock=NOW()
-							WHERE id in (
-								SELECT ID FROM (
-									SELECT id
-									FROM sessions
-									WHERE (processed = false)
-										AND (excluded = false)
-										AND (payload_updated_at < NOW() - (? * INTERVAL '1 SECOND'))
-										AND (lock is null OR lock < NOW() - (? * INTERVAL '1 MINUTE'))
-										AND (retry_count < ?)
-									LIMIT ?
-									FOR UPDATE SKIP LOCKED
-								) s
-								ORDER BY id
-								FOR UPDATE SKIP LOCKED
-							)
-							RETURNING *
-						)
-						SELECT * FROM t;
-					`, payloadLookbackPeriod, lockPeriod, MAX_RETRIES, limit). // why do we get payload_updated_at IS NULL?
-					Find(&sessions).Error; err != nil {
-					errs <- err
-					return
-				}
-				errs <- nil
-			}()
-
-			select {
-			case <-transactionCtx.Done():
-				return e.New("transaction timeout occurred")
-			case err := <-errs:
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
-			log.WithContext(ctx).Errorf("error querying unparsed, outdated sessions, took [%v]: %v", time.Since(txStart), err)
-			sessionsSpan.Finish()
+		limit := processSessionLimit + rand.Intn(100)
+		sessions, err := w.GetSessionsToProcess(ctx, pubgraph.SessionProcessDelaySeconds, pubgraph.SessionProcessLockMinutes, limit)
+		if err != nil {
+			log.WithContext(ctx).Error(err)
 			continue
 		}
-		rand.New(rand.NewSource(time.Now().UnixNano()))
-		rand.Shuffle(len(sessions), func(i, j int) {
-			sessions[i], sessions[j] = sessions[j], sessions[i]
-		})
-		// Sends a "count" metric to datadog so that we can see how many sessions are being queried.
-		hlog.Histogram("worker.sessionsQuery.sessionCount", float64(len(sessions)), nil, 1) //nolint
-		sessionsSpan.Finish()
+
 		type SessionLog struct {
 			SessionID int
 			ProjectID int
@@ -1134,6 +1101,9 @@ func (w *Worker) Start(ctx context.Context) {
 					var excluded bool
 					if nextCount >= MAX_RETRIES {
 						excluded = true
+						if err := w.Resolver.Redis.RemoveSessionToProcess(ctx, session.ID); err != nil {
+							log.WithContext(ctx).Error(err)
+						}
 					}
 
 					if err := w.Resolver.DB.WithContext(ctx).Model(&model.Session{}).
@@ -1156,6 +1126,10 @@ func (w *Worker) Start(ctx context.Context) {
 					}
 
 					return
+				}
+
+				if err := w.Resolver.Redis.RemoveSessionToProcess(ctx, session.ID); err != nil {
+					log.WithContext(ctx).Error(err)
 				}
 				hlog.Incr("sessionsProcessed", nil, 1)
 				span.Finish()


### PR DESCRIPTION
## Summary
- during periods of high DB load, the worker "get sessions to process" query is consistently the most expensive query. redis makes more sense for frequent polling
<img width="1051" alt="Screen Shot 2023-11-17 at 1 41 33 PM" src="https://github.com/highlight/highlight/assets/86132398/3641117b-dc67-40b5-a487-4e91650bc1b0">
- add 3 methods to add, remove, and get sessions to process from redis
- can remove `payload_updated_at` in the future to reduce some more DB load
## How did you test this change?
- interacted w/ Highlight locally while observing the state in redis
<img width="430" alt="Screen Shot 2023-11-17 at 5 04 30 PM" src="https://github.com/highlight/highlight/assets/86132398/aed3d23f-2985-4bd1-b4ab-1aaeed37866b">

## Are there any deployment considerations?
- will create a `sessions-to-process` key in redis and add all current unprocessed sessions to it
- can revert if there are issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
