### PR TITLE
add express.js typescript example

### DIFF
--- a/e2e/express-ts/package.json
+++ b/e2e/express-ts/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "e2e-express-ts",
+	"version": "1.0.0",
+	"private": true,
+	"description": "",
+	"main": "dist/index.js",
+	"scripts": {
+		"build": "tsc",
+		"start": "node dist/index.js"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"dependencies": {
+		"@highlight-run/node": "workspace:*",
+		"express": "^4.18.2"
+	},
+	"devDependencies": {
+		"typescript": "^5.3.2"
+	}
+}

--- a/e2e/express-ts/package.json
+++ b/e2e/express-ts/package.json
@@ -10,7 +10,7 @@
 	},
 	"keywords": [],
 	"author": "",
-	"license": "ISC",
+	"license": "Apache-2.0",
 	"dependencies": {
 		"@highlight-run/node": "workspace:*",
 		"express": "^4.18.2"

--- a/e2e/express-ts/src/index.ts
+++ b/e2e/express-ts/src/index.ts
@@ -1,0 +1,49 @@
+import express from 'express'
+import { H, Handlers } from '@highlight-run/node'
+
+/** @type {import('@highlight-run/node').NodeOptions} */
+const config = {
+	projectID: '1',
+	debug: true,
+	serviceName: 'e2e-express',
+	serviceVersion: 'git-sha',
+	otlpEndpoint: 'http://localhost:4318',
+}
+H.init(config)
+
+const app = express()
+const port = 3003
+
+// This should be before any controllers (route definitions)
+app.use(Handlers.middleware(config))
+app.get('/', (req, res) => {
+	const err = new Error('this is a test error')
+	const highlightCtx = H.parseHeaders(req.headers)
+	if (highlightCtx) {
+		const { secureSessionId, requestId } = highlightCtx
+		console.info('Sending error to highlight', secureSessionId, requestId)
+		H.consumeError(err, secureSessionId, requestId)
+	}
+	res.send('Hello World!')
+})
+
+app.get('/good', (req, res) => {
+	console.warn('doing some heavy work!')
+	let result = 0
+	for (let i = 0; i < 1000; i++) {
+		const value = Math.random() * 1000
+		result += value
+		console.info('some work happening', { result, value })
+	}
+	res.send('yay!')
+})
+
+// This should be before any other error middleware and after all controllers (route definitions)
+app.use(Handlers.errorHandler(config))
+app.listen(port, () => {
+	console.log(`Example app listening on port ${port}`)
+})
+
+process.on('SIGINT', function () {
+	process.exit()
+})

--- a/e2e/express-ts/tsconfig.json
+++ b/e2e/express-ts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"target": "es6",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"strict": true,
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"skipLibCheck": true,
+		"outDir": "dist",
+		"sourceMap": true,
+	},
+	"include": [
+		"src/*.ts",
+	],
+}

--- a/e2e/express/package.json
+++ b/e2e/express/package.json
@@ -9,7 +9,7 @@
 	},
 	"keywords": [],
 	"author": "",
-	"license": "ISC",
+	"license": "Apache-2.0",
 	"dependencies": {
 		"@highlight-run/node": "workspace:*",
 		"express": "^4.18.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -33949,6 +33949,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"e2e-express-ts@workspace:e2e/express-ts":
+  version: 0.0.0-use.local
+  resolution: "e2e-express-ts@workspace:e2e/express-ts"
+  dependencies:
+    "@highlight-run/node": "workspace:*"
+    express: ^4.18.2
+    typescript: ^5.3.2
+  languageName: unknown
+  linkType: soft
+
 "e2e-express@workspace:e2e/express":
   version: 0.0.0-use.local
   resolution: "e2e-express@workspace:e2e/express"


### PR DESCRIPTION
## Summary

Add express server example in typescript
for testing sourcemap backend error enhancement.

## How did you test this change?

Local deploy of express server with `yarn build && yarn start`

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No