### PR TITLE
Refactor Docs titles

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,1 @@
+reports

--- a/bin/generate-content-report.ts
+++ b/bin/generate-content-report.ts
@@ -1,0 +1,126 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+const folderPath = path.resolve(__dirname, '../docs-content')
+
+interface Frontmatter {
+	filePath: string
+	url: string
+	localhost: string
+	toc: string
+	title: string
+	heading: string
+	keyValues: [string, string][]
+}
+
+function extractFrontmatterFromMarkdownFiles(
+	folderPath: string,
+): Frontmatter[] {
+	const frontmatters: Frontmatter[] = []
+
+	function crawlFolder(folderPath: string) {
+		const files = fs.readdirSync(folderPath)
+
+		files.forEach((file) => {
+			const filePath = path.join(folderPath, file)
+			const stats = fs.statSync(filePath)
+
+			if (stats.isDirectory()) {
+				crawlFolder(filePath)
+			} else if (stats.isFile() && file.endsWith('.md')) {
+				const content = fs.readFileSync(filePath, 'utf-8')
+				const frontmatterRegex = /^---\n([\s\S]*?)\n---/
+				const match = content.match(frontmatterRegex)
+				const lines = match[1].split('\n')
+				const keyValues = lines.map((line) =>
+					line.split(':').map((s) => s.trim()),
+				) as Frontmatter['keyValues']
+				const url = filePath
+					.replace(/\.md$/, '')
+					.replace(/\d_/, '')
+					.replace(/index$/g, '')
+				const [, toc] = keyValues.find(([key]) => key === 'toc') || []
+				const [, title] =
+					keyValues.find(([key]) => key === 'title') || []
+				const [, heading] =
+					keyValues.find(([key]) => key === 'heading') || []
+
+				frontmatters.push({
+					filePath,
+					url: url.replace(
+						/^.+docs-content/,
+						'https://www.highlight.io/docs',
+					),
+					localhost: url.replace(
+						/^.+docs-content/,
+						'http://localhost:4000/docs',
+					),
+					toc,
+					title,
+					heading,
+					keyValues,
+				})
+			}
+		})
+	}
+
+	crawlFolder(folderPath)
+
+	return frontmatters
+}
+
+const frontmatters = extractFrontmatterFromMarkdownFiles(folderPath)
+const frontmatterByTitles = frontmatters.reduce<Record<string, Frontmatter[]>>(
+	(acc, frontmatter) => {
+		const title = frontmatter.keyValues.find(
+			([key]) => key === 'title',
+		)?.[1]
+
+		if (!acc[title]) {
+			acc[title] = []
+		}
+
+		acc[title].push(frontmatter)
+
+		return acc
+	},
+	{},
+)
+const sortedFrontmatterByTitles = Object.entries(frontmatterByTitles)
+	.filter((entries) => entries[1].length > 1)
+	.sort((a, b) => (a[1].length > b[1].length ? 1 : -1))
+	.map(([title, frontmatters]) => ({
+		title,
+		filePaths: frontmatters.map(({ filePath }) => filePath),
+	}))
+
+fs.rmdirSync(path.resolve(__dirname, './reports'), { recursive: true })
+fs.mkdirSync(path.resolve(__dirname, './reports'))
+
+const duplicateTitlesFilepath = path.resolve(
+	__dirname,
+	'./reports/duplicate-title.json',
+)
+fs.writeFileSync(
+	duplicateTitlesFilepath,
+	JSON.stringify(sortedFrontmatterByTitles, null, 2),
+)
+
+console.info(`Duplicate titles report generated at ${duplicateTitlesFilepath}`)
+
+const frontmatterFilepath = path.resolve(
+	__dirname,
+	'./reports/frontmatter.json',
+)
+fs.writeFileSync(
+	frontmatterFilepath,
+	JSON.stringify(
+		frontmatters
+			.sort((a, b) => (a.url.length < b.url.length ? -1 : 1))
+			.map(({ keyValues: _, ...record }) => record),
+		null,
+		2,
+	),
+)
+
+console.info(`Frontmatter report generated at ${frontmatterFilepath}`)

--- a/bin/generate-content-report.ts
+++ b/bin/generate-content-report.ts
@@ -1,6 +1,13 @@
 import * as fs from 'fs'
 import * as path from 'path'
 
+/**
+ * Esplin 2023.11.20
+ * We have a problem with duplicate titles in our docs.
+ * Delete this file whenever we've either refactored our docs
+ * or settled into a better pattern for doc titles.
+ */
+
 const folderPath = path.resolve(__dirname, '../docs-content')
 
 interface Frontmatter {

--- a/docs-content/general/2_getting-started.md
+++ b/docs-content/general/2_getting-started.md
@@ -1,5 +1,6 @@
 ---
-title: Get Started
+toc: Get Started
+title: Get Started Overview
 slug: welcome-to-highlight
 createdAt: 2021-09-10T17:54:08.000Z
 updatedAt: 2022-08-18T22:36:12.000Z

--- a/docs-content/general/4_company/open-source/contributing/1_getting-started.md
+++ b/docs-content/general/4_company/open-source/contributing/1_getting-started.md
@@ -1,5 +1,6 @@
 ---
-title: Overview
+toc: Overview
+title: Open Source Contributing Overview
 heading: Contributing Overview
 slug: getting-started
 createdAt: 2023-01-24T20:28:14.000Z

--- a/docs-content/general/6_product-features/1_session-replay/1_overview.md
+++ b/docs-content/general/6_product-features/1_session-replay/1_overview.md
@@ -1,6 +1,6 @@
 ---
-heading: Session Replay Features
-title: Overview
+toc: Overview
+title: Session Replay Features
 slug: overview
 createdAt: 2021-09-10T17:54:08.000Z
 updatedAt: 2022-08-18T22:36:12.000Z

--- a/docs-content/general/6_product-features/2_error-monitoring/1_overview.md
+++ b/docs-content/general/6_product-features/2_error-monitoring/1_overview.md
@@ -1,6 +1,6 @@
 ---
-title: Overview
-heading: Error Monitoring Features
+toc: Overview
+title: Error Monitoring Features
 slug: overview
 createdAt: 2021-09-10T17:54:08.000Z
 updatedAt: 2022-08-18T22:36:12.000Z

--- a/docs-content/general/6_product-features/3_general-features/1_overview.md
+++ b/docs-content/general/6_product-features/3_general-features/1_overview.md
@@ -1,6 +1,6 @@
 ---
-title: Overview
-heading: General Features
+toc: Overview
+title: General Features
 slug: overview
 createdAt: 2021-09-10T17:54:08.000Z
 updatedAt: 2022-08-18T22:36:12.000Z

--- a/docs-content/general/6_product-features/3_general-features/index.md
+++ b/docs-content/general/6_product-features/3_general-features/index.md
@@ -1,5 +1,6 @@
 ---
-title: General Features
+toc: General Features
+title: Backend General Features
 slug: general-features
 createdAt: 2021-09-13T23:56:14.000Z
 updatedAt: 2022-08-03T19:08:25.000Z

--- a/docs-content/general/6_product-features/4_logging/1_overview.md
+++ b/docs-content/general/6_product-features/4_logging/1_overview.md
@@ -1,6 +1,6 @@
 ---
-heading: Logging Features
-title: Overview
+toc: Overview
+title: Logging Features
 slug: overview
 ---
 

--- a/docs-content/general/changelog/1_overview.md
+++ b/docs-content/general/changelog/1_overview.md
@@ -1,6 +1,6 @@
 ---
-heading: Changelog Overview
-title: Overview
+toc: Overview
+title: Changelog Overview
 slug: getting-started
 ---
 

--- a/docs-content/getting-started/1_overview.md
+++ b/docs-content/getting-started/1_overview.md
@@ -1,6 +1,5 @@
 ---
-heading: Getting Started - highlight.io
-title: Get Started
+title: Getting Started with Highlight
 slug: getting-started
 createdAt: 2021-09-13T22:07:04.000Z
 updatedAt: 2022-04-01T19:52:59.000Z

--- a/docs-content/getting-started/3_client-sdk/2_nextjs.md
+++ b/docs-content/getting-started/3_client-sdk/2_nextjs.md
@@ -1,7 +1,7 @@
 ---
+toc: Next.js
 title: Next.js Quick Start
 slug: nextjs
-heading: Next.js Quick Start
 quickstart: true
 ---
 

--- a/docs-content/getting-started/3_client-sdk/2_remix.md
+++ b/docs-content/getting-started/3_client-sdk/2_remix.md
@@ -1,7 +1,7 @@
 ---
-title: Remix
+toc: Remix
 slug: remix
-heading: Using highlight.io with Remix
+title: Using highlight.io with Remix
 quickstart: true
 ---
 

--- a/docs-content/getting-started/3_client-sdk/3_vuejs.md
+++ b/docs-content/getting-started/3_client-sdk/3_vuejs.md
@@ -1,7 +1,7 @@
 ---
-title: Vue.js
+toc: Vue.js
 slug: vuejs
-headline: Using highlight.io in Vue.js
+title: Using highlight.io in Vue.js
 quickstart: true
 ---
 

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/1_overview.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/1_overview.md
@@ -1,4 +1,5 @@
 ---
+toc: Overview
 title: SDK Configuration Overview
 slug: welcome-to-highlight
 ---

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/8_changelog/1_overview.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/8_changelog/1_overview.md
@@ -1,6 +1,0 @@
----
-title: SDK Configuration Overview
-slug: welcome-to-highlight
----
-
-Check out our [Github repo SDKs](https://github.com/highlight/highlight/tree/main/sdk) to see individual SDK changelogs.

--- a/docs-content/getting-started/3_client-sdk/7_replay-configuration/8_changelog/index.md
+++ b/docs-content/getting-started/3_client-sdk/7_replay-configuration/8_changelog/index.md
@@ -1,6 +1,0 @@
----
-title: Client SDK Changelog
-slug: client-changelog
-createdAt: 2022-11-01T21:15:18.000Z
-updatedAt: 2022-11-01T21:15:18.000Z
----

--- a/docs-content/getting-started/4_backend-sdk/go/1_overview.md
+++ b/docs-content/getting-started/4_backend-sdk/go/1_overview.md
@@ -1,5 +1,5 @@
 ---
-heading: Error Monitoring in Go
+toc: Overview
 title: Error Monitoring in Go
 slug: go
 createdAt: 2021-09-13T22:07:04.000Z

--- a/docs-content/getting-started/4_backend-sdk/go/fiber.md
+++ b/docs-content/getting-started/4_backend-sdk/go/fiber.md
@@ -1,5 +1,6 @@
 ---
-title: fiber
+toc: fiber
+title: Fiber Quick Start
 slug: fiber
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z

--- a/docs-content/getting-started/4_backend-sdk/go/index.md
+++ b/docs-content/getting-started/4_backend-sdk/go/index.md
@@ -1,4 +1,5 @@
 ---
-title: Go
+toc: Go
+title: Backend Error Monitoring in Go
 slug: go
 ---

--- a/docs-content/getting-started/4_backend-sdk/index.md
+++ b/docs-content/getting-started/4_backend-sdk/index.md
@@ -1,5 +1,6 @@
 ---
-title: 'Backend: Error Monitoring'
+toc: 'Backend: Error Monitoring'
+title: 'Backend Error Monitoring'
 slug: 4_backend-sdk
 createdAt: 2022-03-28T20:05:46.000Z
 updatedAt: 2022-04-01T20:40:53.000Z

--- a/docs-content/getting-started/4_backend-sdk/java/index.md
+++ b/docs-content/getting-started/4_backend-sdk/java/index.md
@@ -1,5 +1,6 @@
 ---
-title: Java
+toc: Java
+title: Backend Error Monitoring in Java
 slug: Java
 createdAt: 2023-05-41T21:51:15.000Z
 updatedAt: 2023-05-41T21:51:54.000Z

--- a/docs-content/getting-started/4_backend-sdk/java/other.md
+++ b/docs-content/getting-started/4_backend-sdk/java/other.md
@@ -1,6 +1,6 @@
 ---
-title: Java App
-heading: Using highlight.io with Other Java Frameworks
+toc: Java App
+title: Using highlight.io with Java Frameworks
 slug: other
 quickstart: true
 ---

--- a/docs-content/getting-started/4_backend-sdk/js/1_overview.md
+++ b/docs-content/getting-started/4_backend-sdk/js/1_overview.md
@@ -1,7 +1,7 @@
 ---
-heading: Error Monitoring in Javascript / Typescript
+toc: Overview
 title: Error Monitoring in Javascript / Typescript
-slug: go
+slug: js
 createdAt: 2021-09-13T22:07:04.000Z
 updatedAt: 2022-04-01T19:52:59.000Z
 ---

--- a/docs-content/getting-started/4_backend-sdk/js/apollo.md
+++ b/docs-content/getting-started/4_backend-sdk/js/apollo.md
@@ -1,5 +1,6 @@
 ---
-title: Apollo Server
+toc: Apollo Server
+title: Apollo Server Error Monitoring
 slug: apollo
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z

--- a/docs-content/getting-started/4_backend-sdk/js/aws-lambda.md
+++ b/docs-content/getting-started/4_backend-sdk/js/aws-lambda.md
@@ -1,5 +1,6 @@
 ---
-title: AWS Lambda Node.JS
+toc: AWS Lambda Node.JS
+title: AWS Lambda Node.JS Error Monitoring
 slug: aws-lambda-node
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z

--- a/docs-content/getting-started/4_backend-sdk/js/cloudflare.md
+++ b/docs-content/getting-started/4_backend-sdk/js/cloudflare.md
@@ -1,5 +1,6 @@
 ---
-title: Cloudflare Workers
+toc: Cloudflare Workers
+title: Cloudflare Workers Error Monitoring
 slug: cloudflare
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z

--- a/docs-content/getting-started/4_backend-sdk/js/express.md
+++ b/docs-content/getting-started/4_backend-sdk/js/express.md
@@ -1,5 +1,6 @@
 ---
-title: Express.js
+toc: Express.js
+title: Express.js Error Monitoring
 slug: express
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z

--- a/docs-content/getting-started/4_backend-sdk/js/firebase.md
+++ b/docs-content/getting-started/4_backend-sdk/js/firebase.md
@@ -1,5 +1,6 @@
 ---
-title: Firebase
+toc: Firebase
+title: Firebase Error Monitoring
 slug: firebase
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z

--- a/docs-content/getting-started/4_backend-sdk/js/index.md
+++ b/docs-content/getting-started/4_backend-sdk/js/index.md
@@ -1,4 +1,5 @@
 ---
-title: JS
+toc: JS
+title: JS Error Monitoring
 slug: js
 ---

--- a/docs-content/getting-started/4_backend-sdk/js/nestjs.md
+++ b/docs-content/getting-started/4_backend-sdk/js/nestjs.md
@@ -1,5 +1,6 @@
 ---
-title: Nest.js
+toc: Nest.js
+title: Nest.js Error Monitoring
 slug: nestjs
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z

--- a/docs-content/getting-started/4_backend-sdk/js/nodejs.md
+++ b/docs-content/getting-started/4_backend-sdk/js/nodejs.md
@@ -1,5 +1,6 @@
 ---
-title: Node.js
+toc: Node.js
+title: Node.js Error Monitoring
 slug: nodejs
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z

--- a/docs-content/getting-started/4_backend-sdk/js/trpc.md
+++ b/docs-content/getting-started/4_backend-sdk/js/trpc.md
@@ -1,5 +1,6 @@
 ---
-title: tRPC
+toc: tRPC
+title: tRPC Error Monitoring
 slug: trpc
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z

--- a/docs-content/getting-started/4_backend-sdk/python/1_overview.md
+++ b/docs-content/getting-started/4_backend-sdk/python/1_overview.md
@@ -1,5 +1,5 @@
 ---
-heading: Error Monitoring in Python
+toc: Overview
 title: Error Monitoring in Python
 slug: python
 createdAt: 2021-09-13T22:07:04.000Z

--- a/docs-content/getting-started/4_backend-sdk/python/index.md
+++ b/docs-content/getting-started/4_backend-sdk/python/index.md
@@ -1,5 +1,6 @@
 ---
-title: Python
+toc: Python
+title: Backend Error Monitoring in Python
 slug: python
 createdAt: 2022-03-28T20:05:46.000Z
 updatedAt: 2022-04-01T20:40:53.000Z

--- a/docs-content/getting-started/4_backend-sdk/ruby/1_overview.md
+++ b/docs-content/getting-started/4_backend-sdk/ruby/1_overview.md
@@ -1,5 +1,5 @@
 ---
-heading: Error Monitoring in Ruby
+toc: Overview
 title: Error Monitoring in Ruby
 slug: ruby
 createdAt: 2021-09-13T22:07:04.000Z

--- a/docs-content/getting-started/4_backend-sdk/ruby/index.md
+++ b/docs-content/getting-started/4_backend-sdk/ruby/index.md
@@ -1,5 +1,6 @@
 ---
-title: Ruby
+toc: Ruby
+title: Backend Error Monitoring in Ruby
 slug: ruby
 createdAt: 2022-03-28T20:05:46.000Z
 updatedAt: 2022-04-01T20:40:53.000Z

--- a/docs-content/getting-started/4_backend-sdk/ruby/other.md
+++ b/docs-content/getting-started/4_backend-sdk/ruby/other.md
@@ -1,6 +1,6 @@
 ---
-title: Ruby App
-heading: Using highlight.io with Other Ruby Frameworks
+toc: Ruby App
+title: Using highlight.io with Other Ruby Frameworks
 slug: other
 quickstart: true
 ---

--- a/docs-content/getting-started/4_backend-sdk/ruby/rails.md
+++ b/docs-content/getting-started/4_backend-sdk/ruby/rails.md
@@ -1,6 +1,6 @@
 ---
-title: Rails
-heading: Using highlight.io with Ruby on Rails
+toc: Rails
+title: Using highlight.io with Ruby on Rails
 slug: rails
 quickstart: true
 ---

--- a/docs-content/getting-started/5_backend-logging/01_go/1_overview.md
+++ b/docs-content/getting-started/5_backend-logging/01_go/1_overview.md
@@ -1,6 +1,6 @@
 ---
-title: Overview
-headline: Logging in Go
+toc: Overview
+title: Logging in Go
 slug: logging-in-go
 ---
 

--- a/docs-content/getting-started/5_backend-logging/01_go/fiber.md
+++ b/docs-content/getting-started/5_backend-logging/01_go/fiber.md
@@ -1,6 +1,6 @@
 ---
-title: fiber
-heading: Logging in Go / Fiber
+toc: fiber
+title: Logging in Go / Fiber
 quickstart: true
 ---
 

--- a/docs-content/getting-started/5_backend-logging/01_go/index.md
+++ b/docs-content/getting-started/5_backend-logging/01_go/index.md
@@ -1,4 +1,5 @@
 ---
-title: Go
+toc: Go
+title: Backend Logging in Go
 slug: go
 ---

--- a/docs-content/getting-started/5_backend-logging/02_js/1_overview.md
+++ b/docs-content/getting-started/5_backend-logging/02_js/1_overview.md
@@ -1,6 +1,6 @@
 ---
-title: Overview
-headline: Logging in Typescript / Javascript
+toc: Overview
+title: Logging in Typescript / Javascript
 slug: logging-in-js
 ---
 

--- a/docs-content/getting-started/5_backend-logging/02_js/cloudflare.md
+++ b/docs-content/getting-started/5_backend-logging/02_js/cloudflare.md
@@ -1,6 +1,6 @@
 ---
-title: Cloudflare Workers
-heading: Logging in Cloudflare Workers
+toc: Cloudflare Workers
+title: Logging in Cloudflare Workers
 slug: cloudflare
 quickstart: true
 ---

--- a/docs-content/getting-started/5_backend-logging/02_js/nestjs.md
+++ b/docs-content/getting-started/5_backend-logging/02_js/nestjs.md
@@ -1,6 +1,6 @@
 ---
-title: Nest.js
-heading: Logging in Nest.js
+toc: Nest.js
+title: Logging in Nest.js
 slug: nestjs
 quickstart: true
 ---

--- a/docs-content/getting-started/5_backend-logging/02_js/nodejs.md
+++ b/docs-content/getting-started/5_backend-logging/02_js/nodejs.md
@@ -1,6 +1,6 @@
 ---
-title: Node.js
-heading: Logging in Node.js
+toc: Node.js
+title: Logging in Node.js
 slug: nodejs
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z

--- a/docs-content/getting-started/5_backend-logging/03_python/1_overview.md
+++ b/docs-content/getting-started/5_backend-logging/03_python/1_overview.md
@@ -1,6 +1,6 @@
 ---
-title: Overview
-headline: Logging in Python
+toc: Overview
+title: Logging in Python
 slug: logging-in-python
 ---
 

--- a/docs-content/getting-started/5_backend-logging/03_python/index.md
+++ b/docs-content/getting-started/5_backend-logging/03_python/index.md
@@ -1,4 +1,5 @@
 ---
-title: Python
+toc: Python
+title: Backend Logging in Python
 slug: python
 ---

--- a/docs-content/getting-started/5_backend-logging/03_python/other.md
+++ b/docs-content/getting-started/5_backend-logging/03_python/other.md
@@ -1,6 +1,6 @@
 ---
-title: Python
-heading: Logging in Python
+toc: Python
+title: Python Logging Quick Start
 slug: other
 quickstart: true
 ---

--- a/docs-content/getting-started/5_backend-logging/04_ruby/1_overview.md
+++ b/docs-content/getting-started/5_backend-logging/04_ruby/1_overview.md
@@ -1,6 +1,6 @@
 ---
-title: Overview
-headline: Logging in Ruby
+toc: Overview
+title: Logging in Ruby
 slug: logging-in-ruby
 ---
 

--- a/docs-content/getting-started/5_backend-logging/04_ruby/index.md
+++ b/docs-content/getting-started/5_backend-logging/04_ruby/index.md
@@ -1,4 +1,5 @@
 ---
-title: Ruby
+toc: Ruby
+title: Backend Logging in Ruby
 slug: ruby
 ---

--- a/docs-content/getting-started/5_backend-logging/04_ruby/other.md
+++ b/docs-content/getting-started/5_backend-logging/04_ruby/other.md
@@ -1,5 +1,6 @@
 ---
-title: Ruby App
+toc: Ruby App
+title: Logging with Other Ruby Frameworks
 slug: other
 createdAt: 2022-03-28T20:31:15.000Z
 updatedAt: 2022-04-06T20:22:54.000Z

--- a/docs-content/getting-started/5_backend-logging/04_ruby/rails.md
+++ b/docs-content/getting-started/5_backend-logging/04_ruby/rails.md
@@ -1,4 +1,5 @@
 ---
+toc: Rails
 title: Rails
 slug: rails
 createdAt: 2022-03-28T20:31:15.000Z

--- a/docs-content/getting-started/5_backend-logging/05_java/1_overview.md
+++ b/docs-content/getting-started/5_backend-logging/05_java/1_overview.md
@@ -1,6 +1,6 @@
 ---
-title: Overview
-headline: Logging in Java
+toc: Overview
+title: Logging in Java
 slug: logging-in-java
 ---
 

--- a/docs-content/getting-started/5_backend-logging/05_java/index.md
+++ b/docs-content/getting-started/5_backend-logging/05_java/index.md
@@ -1,4 +1,5 @@
 ---
-title: Java
+toc: Java
+title: Backend Logging in Java
 slug: java
 ---

--- a/docs-content/getting-started/5_backend-logging/05_java/other.md
+++ b/docs-content/getting-started/5_backend-logging/05_java/other.md
@@ -1,5 +1,6 @@
 ---
-title: Java App
+toc: Java App
+title: Logging in Java Quick Start
 slug: other
 createdAt: 2023-05-41T21:51:15.000Z
 updatedAt: 2023-05-41T21:51:54.000Z

--- a/docs-content/getting-started/5_backend-logging/06_hosting/1_overview.md
+++ b/docs-content/getting-started/5_backend-logging/06_hosting/1_overview.md
@@ -1,7 +1,7 @@
 ---
-title: Overview
-headline: Logging in Python
-slug: logging-in-python
+toc: Overview
+title: Hosting Providers Overview
+slug: overview
 ---
 
 Highlight.io supports logging in most cloud providers. For common hosting solutions, we've written guides or integrations that simplify the setup.

--- a/docs-content/getting-started/5_backend-logging/index.md
+++ b/docs-content/getting-started/5_backend-logging/index.md
@@ -1,5 +1,6 @@
 ---
-title: 'Backend: Logging'
+toc: 'Backend: Logging'
+title: 'Backend Logging'
 slug: backend-logging
 createdAt: 2022-03-28T20:05:46.000Z
 updatedAt: 2022-04-01T20:40:53.000Z

--- a/docs-content/getting-started/6_tracing/1_overview.md
+++ b/docs-content/getting-started/6_tracing/1_overview.md
@@ -1,5 +1,6 @@
 ---
-title: Overview
+toc: Overview
+title: Tracing Overview
 slug: overview
 createdAt: 2023-10-16T00:00:00.000Z
 updatedAt: 2023-10-16T00:00:00.000Z

--- a/docs-content/getting-started/6_tracing/2_go.md
+++ b/docs-content/getting-started/6_tracing/2_go.md
@@ -1,7 +1,7 @@
 ---
-title: Go
+toc: Go
+title: Tracing in Go
 slug: go
-heading: Tracing in Go
 createdAt: 2023-10-16T00:00:00.000Z
 updatedAt: 2023-10-16T00:00:00.000Z
 quickstart: true

--- a/docs-content/getting-started/fullstack-frameworks/next-js/index.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/index.md
@@ -1,5 +1,6 @@
 ---
-title: Next.js Fullstack Overview
+toc: Overview
+title: Next.js Fullstack Walkthrough
 slug: next-js
 createdAt: 2021-09-13T22:07:04.000Z
 updatedAt: 2022-04-01T19:52:59.000Z

--- a/docs-content/getting-started/self-host/1_overview.md
+++ b/docs-content/getting-started/self-host/1_overview.md
@@ -1,6 +1,6 @@
 ---
-headline: Self Host & Local Development
-title: Overview
+toc: Overview
+title: Self Host & Local Development
 slug: self-host
 ---
 

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -364,7 +364,10 @@ export const getStaticProps: GetStaticProps<DocData> = async (context) => {
 			}
 			if (d.array_path.indexOf(a) == d.array_path.length - 1) {
 				foundEntry.docPathId = docid
-				foundEntry.tocHeading = docPaths[docid].metadata.title || 'test'
+				foundEntry.tocHeading =
+					docPaths[docid].metadata.toc ||
+					docPaths[docid].metadata.title ||
+					'missing metadata.toc'
 			}
 			currentEntry = foundEntry
 		}


### PR DESCRIPTION
## Summary

We've long suffered from duplicate page titles in our docs. It shows up in our Algolia crawler results. Searches sometimes return stacks of similarly-named pages. For instance, search for "overview" and you'll see over a dozen identical results.

I created a new `toc` frontmatter field that we can use to force the Table of Contents title to stay the same, while modifying the titles for each file.

I wrote a script to report on duplicate titles and to dump frontmatter to a file. Fire off `bun bin/generate-content-report.ts`.

![image](https://github.com/highlight/highlight/assets/878947/8ba5e469-4ef3-4a53-b351-d3c72e8b171c)

![image](https://github.com/highlight/highlight/assets/878947/372b1f52-59ee-4e48-8227-9989aecfdb37)
