### PR TITLE
Prevent spans from overlapping in flame graph

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6889,6 +6889,7 @@ body {
 .essfm40::-webkit-scrollbar {
   -webkit-appearance: none;
   height: 7px;
+  width: 7px;
 }
 .essfm40::-webkit-scrollbar-thumb {
   border-radius: 4px;

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6886,6 +6886,15 @@ body {
   height: 24px;
   align-items: center;
 }
+.essfm40::-webkit-scrollbar {
+  -webkit-appearance: none;
+  height: 7px;
+}
+.essfm40::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  background-color: rgba(0, 0, 0, .5);
+  box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+}
 ._1h7r9xv0 {
   height: 100%;
   overflow-y: hidden;

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6886,15 +6886,11 @@ body {
   height: 24px;
   align-items: center;
 }
-.essfm40::-webkit-scrollbar {
-  -webkit-appearance: none;
-  height: 7px;
-  width: 7px;
+.essfm40 {
+  max-height: 400px;
 }
-.essfm40::-webkit-scrollbar-thumb {
-  border-radius: 4px;
-  background-color: rgba(0, 0, 0, .5);
-  box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+.essfm40::-webkit-scrollbar-corner {
+  background-color: transparent;
 }
 ._1h7r9xv0 {
   height: 100%;

--- a/frontend/src/__generated/ve/pages/Traces/TraceFlameGraph.css.js
+++ b/frontend/src/__generated/ve/pages/Traces/TraceFlameGraph.css.js
@@ -1,0 +1,5 @@
+// src/pages/Traces/TraceFlameGraph.css.ts
+var flameGraph = "essfm40";
+export {
+  flameGraph
+};

--- a/frontend/src/pages/Traces/TraceFlameGraph.css.ts
+++ b/frontend/src/pages/Traces/TraceFlameGraph.css.ts
@@ -1,0 +1,14 @@
+import { style } from '@vanilla-extract/css'
+
+export const flameGraph = style({
+	'::-webkit-scrollbar': {
+		WebkitAppearance: 'none',
+		height: 7,
+	},
+
+	'::-webkit-scrollbar-thumb': {
+		borderRadius: 4,
+		backgroundColor: 'rgba(0, 0, 0, .5)',
+		boxShadow: '0 0 1px rgba(255, 255, 255, .5)',
+	},
+})

--- a/frontend/src/pages/Traces/TraceFlameGraph.css.ts
+++ b/frontend/src/pages/Traces/TraceFlameGraph.css.ts
@@ -1,15 +1,8 @@
 import { style } from '@vanilla-extract/css'
 
 export const flameGraph = style({
-	'::-webkit-scrollbar': {
-		WebkitAppearance: 'none',
-		height: 7,
-		width: 7,
-	},
-
-	'::-webkit-scrollbar-thumb': {
-		borderRadius: 4,
-		backgroundColor: 'rgba(0, 0, 0, .5)',
-		boxShadow: '0 0 1px rgba(255, 255, 255, .5)',
+	maxHeight: 400,
+	'::-webkit-scrollbar-corner': {
+		backgroundColor: 'transparent',
 	},
 })

--- a/frontend/src/pages/Traces/TraceFlameGraph.css.ts
+++ b/frontend/src/pages/Traces/TraceFlameGraph.css.ts
@@ -4,6 +4,7 @@ export const flameGraph = style({
 	'::-webkit-scrollbar': {
 		WebkitAppearance: 'none',
 		height: 7,
+		width: 7,
 	},
 
 	'::-webkit-scrollbar-thumb': {

--- a/frontend/src/pages/Traces/TraceFlameGraph.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraph.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from '@highlight-run/ui'
+import clsx from 'clsx'
 import { throttle } from 'lodash'
 import {
 	Fragment,
@@ -14,6 +15,10 @@ import { useHTMLElementEvent } from '@/hooks/useHTMLElementEvent'
 import { TraceFlameGraphNode } from '@/pages/Traces/TraceFlameGraphNode'
 import { useTrace } from '@/pages/Traces/TraceProvider'
 import { getTraceDurationString } from '@/pages/Traces/utils'
+import {
+	styledHorizontalScrollbar,
+	styledVerticalScrollbar,
+} from '@/style/common.css'
 
 import * as styles from './TraceFlameGraph.css'
 
@@ -144,10 +149,11 @@ export const TraceFlameGraph: React.FC = () => {
 			<Box
 				ref={svgContainerRef}
 				overflowX="scroll"
-				cssClass={styles.flameGraph}
-				style={{
-					maxHeight: 400,
-				}}
+				cssClass={clsx(
+					styledVerticalScrollbar,
+					styledHorizontalScrollbar,
+					styles.flameGraph,
+				)}
 			>
 				{width && (
 					<svg

--- a/frontend/src/pages/Traces/TraceFlameGraph.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraph.tsx
@@ -15,6 +15,8 @@ import { TraceFlameGraphNode } from '@/pages/Traces/TraceFlameGraphNode'
 import { useTrace } from '@/pages/Traces/TraceProvider'
 import { getTraceDurationString } from '@/pages/Traces/utils'
 
+import * as styles from './TraceFlameGraph.css'
+
 const MAX_TICKS = 6
 export const ticksHeight = 24
 export const outsidePadding = 4
@@ -142,6 +144,7 @@ export const TraceFlameGraph: React.FC = () => {
 			<Box
 				ref={svgContainerRef}
 				overflowX="scroll"
+				cssClass={styles.flameGraph}
 				style={{
 					maxHeight: 400,
 				}}

--- a/frontend/src/pages/Traces/TraceFlameGraph.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraph.tsx
@@ -19,7 +19,6 @@ const MAX_TICKS = 6
 export const ticksHeight = 24
 export const outsidePadding = 4
 export const lineHeight = 18
-export const depthMultiplier = lineHeight + 3 + (ticksHeight + outsidePadding)
 const timeUnits = [
 	{ unit: 'h', divider: 1e9 * 60 * 60 },
 	{ unit: 'm', divider: 1e9 * 60 },
@@ -144,7 +143,7 @@ export const TraceFlameGraph: React.FC = () => {
 				ref={svgContainerRef}
 				overflowX="scroll"
 				style={{
-					maxHeight: 300,
+					maxHeight: 400,
 				}}
 			>
 				{width && (

--- a/frontend/src/pages/Traces/TraceFlameGraph.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraph.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from '@highlight-run/ui'
 import { throttle } from 'lodash'
 import {
+	Fragment,
 	useCallback,
 	useEffect,
 	useLayoutEffect,
@@ -13,7 +14,7 @@ import LoadingBox from '@/components/LoadingBox'
 import { useHTMLElementEvent } from '@/hooks/useHTMLElementEvent'
 import { TraceFlameGraphNode } from '@/pages/Traces/TraceFlameGraphNode'
 import { useTrace } from '@/pages/Traces/TraceProvider'
-import { getMaxDepth, getTraceDurationString } from '@/pages/Traces/utils'
+import { getTraceDurationString } from '@/pages/Traces/utils'
 
 const MAX_TICKS = 6
 export const ticksHeight = 24
@@ -29,8 +30,7 @@ const timeUnits = [
 ]
 
 export const TraceFlameGraph: React.FC = () => {
-	const { hoveredSpan, loading, selectedSpan, totalDuration, traces } =
-		useTrace()
+	const { hoveredSpan, loading, totalDuration, traces } = useTrace()
 	const svgContainerRef = useRef<HTMLDivElement>(null)
 	const [zoom, setZoom] = useState(1)
 	const [width, setWidth] = useState(defaultCanvasWidth)
@@ -49,7 +49,7 @@ export const TraceFlameGraph: React.FC = () => {
 	const height = useMemo(() => {
 		if (!traces.length) return 260
 
-		const maxDepth = getMaxDepth(traces)
+		const maxDepth = traces.length
 		const lineHeightWithPadding = lineHeight + 4
 		return maxDepth * lineHeightWithPadding + ticksHeight + outsidePadding
 	}, [traces])
@@ -202,20 +202,24 @@ export const TraceFlameGraph: React.FC = () => {
 							</g>
 						)
 					})}
-					{Object.entries(traces).map(([index, span]) => {
+					{traces.map((spans, index) => {
 						return (
-							<TraceFlameGraphNode
-								key={index}
-								span={span}
-								depth={0}
-								height={height}
-								width={width - outsidePadding * 2}
-								zoom={zoom}
-								selectedSpanID={selectedSpan?.spanID}
-								setTooltipCoordinates={
-									setTooltipCoordinatesImpl
-								}
-							/>
+							<Fragment key={index}>
+								{spans.map((span) => {
+									return (
+										<TraceFlameGraphNode
+											key={span.spanID}
+											span={span}
+											depth={index}
+											width={width - outsidePadding * 2}
+											zoom={zoom}
+											setTooltipCoordinates={
+												setTooltipCoordinatesImpl
+											}
+										/>
+									)
+								})}
+							</Fragment>
 						)
 					})}
 				</svg>

--- a/frontend/src/pages/Traces/TraceFlameGraph.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraph.tsx
@@ -19,7 +19,7 @@ const MAX_TICKS = 6
 export const ticksHeight = 24
 export const outsidePadding = 4
 export const lineHeight = 18
-const defaultCanvasWidth = 660
+const depthMultiplier = lineHeight + 3 + (ticksHeight + outsidePadding)
 const timeUnits = [
 	{ unit: 'h', divider: 1e9 * 60 * 60 },
 	{ unit: 'm', divider: 1e9 * 60 },
@@ -54,6 +54,7 @@ export const TraceFlameGraph: React.FC = () => {
 			timeUnits.find(
 				({ divider }) => totalDuration / length / divider > 1,
 			) ?? timeUnits[timeUnits.length - 2]
+
 		return Array.from({ length }).map((_, index) => {
 			const percent = index / (length - 1)
 			const tickDuration = totalDuration * percent
@@ -206,7 +207,6 @@ export const TraceFlameGraph: React.FC = () => {
 											<TraceFlameGraphNode
 												key={span.spanID}
 												span={span}
-												depth={index}
 												width={
 													width - outsidePadding * 2
 												}

--- a/frontend/src/pages/Traces/TraceFlameGraph.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraph.tsx
@@ -19,7 +19,7 @@ const MAX_TICKS = 6
 export const ticksHeight = 24
 export const outsidePadding = 4
 export const lineHeight = 18
-const depthMultiplier = lineHeight + 3 + (ticksHeight + outsidePadding)
+export const depthMultiplier = lineHeight + 3 + (ticksHeight + outsidePadding)
 const timeUnits = [
 	{ unit: 'h', divider: 1e9 * 60 * 60 },
 	{ unit: 'm', divider: 1e9 * 60 },

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -11,7 +11,6 @@ import { FlameGraphSpan, getTraceDurationString } from '@/pages/Traces/utils'
 type Props = {
 	depth: number
 	span: FlameGraphSpan
-	height: number
 	width: number
 	zoom: number
 	selectedSpanID?: string
@@ -63,15 +62,7 @@ const minWidthToDisplayText = 20
 const fontSize = 12
 
 export const TraceFlameGraphNode = memo<Props>(
-	({
-		depth,
-		span,
-		height,
-		selectedSpanID,
-		width,
-		zoom,
-		setTooltipCoordinates,
-	}) => {
+	({ depth, span, width, zoom, setTooltipCoordinates }) => {
 		const {
 			errors,
 			totalDuration,
@@ -160,19 +151,6 @@ export const TraceFlameGraphNode = memo<Props>(
 						</foreignObject>
 					)}
 				</g>
-
-				{span.children?.map((childSpan: FlameGraphSpan) => (
-					<TraceFlameGraphNode
-						key={`${childSpan.parentSpanID}-${childSpan.spanID}`}
-						depth={depth + 1}
-						span={childSpan}
-						height={height}
-						selectedSpanID={selectedSpanID}
-						width={width}
-						zoom={zoom}
-						setTooltipCoordinates={setTooltipCoordinates}
-					/>
-				))}
 			</>
 		)
 	},

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -64,6 +64,7 @@ export const TraceFlameGraphNode = memo<Props>(
 	({ span, width, zoom, setTooltipCoordinates }) => {
 		const {
 			errors,
+			hoveredSpan,
 			totalDuration,
 			selectedSpan,
 			setHoveredSpan,
@@ -103,8 +104,8 @@ export const TraceFlameGraphNode = memo<Props>(
 					3 +
 					(ticksHeight + outsidePadding))
 			: undefined
+		const isHoveredSpan = hoveredSpan?.spanID === span.spanID
 
-		console.log(distanceFromParent)
 		return (
 			<>
 				<g
@@ -130,7 +131,8 @@ export const TraceFlameGraphNode = memo<Props>(
 
 					{distanceFromParent > 1 &&
 						parentOffsetX &&
-						parentOffsetY && (
+						parentOffsetY &&
+						isHoveredSpan && (
 							<line
 								x1={1}
 								y1={1}

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -103,7 +103,8 @@ export const TraceFlameGraphNode = memo<Props>(
 		const parentOffsetY = span.parent?.depth
 			? offsetY -
 			  (span.parent.depth * (lineHeight + 3) +
-					(ticksHeight + outsidePadding))
+					(ticksHeight + outsidePadding) -
+					lineHeight / 2)
 			: undefined
 
 		return (

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -132,8 +132,7 @@ export const TraceFlameGraphNode = memo<Props>(
 
 					{distanceFromParent > 1 &&
 						parentOffsetX &&
-						parentOffsetY &&
-						(isHoveredSpan || isSelectedSpan) && (
+						parentOffsetY && (
 							<line
 								x1={1}
 								y1={1}

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -130,18 +130,15 @@ export const TraceFlameGraphNode = memo<Props>(
 									((span.parent.startTime / totalDuration) *
 										width *
 										zoom +
-										outsidePadding -
-										((span.parent.duration /
-											totalDuration) *
-											width *
-											zoom) /
-											2)
+										outsidePadding) *
+										-1
 								}
 								y2={
 									offsetY -
 									(span.parent.depth * (lineHeight + 3) +
 										(ticksHeight + outsidePadding) -
-										lineHeight / 2)
+										lineHeight / 2) *
+										-1
 								}
 								stroke={stroke}
 								strokeWidth="1"

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -92,20 +92,9 @@ export const TraceFlameGraphNode = memo<Props>(
 		const color = isSelectedSpan ? theme.selectedColor : theme.color
 		const stroke = isSelectedSpan ? theme.selectedBackend : theme.border
 
-		const distanceFromParent = span.parent?.depth
+		const distanceFromParent = span.parent
 			? span.depth - span.parent.depth
 			: 0
-		const parentOffsetX = span.parent?.startTime
-			? offsetX -
-			  ((span.parent.startTime / totalDuration) * width * zoom +
-					outsidePadding)
-			: undefined
-		const parentOffsetY = span.parent?.depth
-			? offsetY -
-			  (span.parent.depth * (lineHeight + 3) +
-					(ticksHeight + outsidePadding) -
-					lineHeight / 2)
-			: undefined
 
 		return (
 			<>
@@ -130,15 +119,30 @@ export const TraceFlameGraphNode = memo<Props>(
 						data-parent-id={span.parentSpanID}
 					/>
 
-					{distanceFromParent > 1 &&
-						parentOffsetX &&
-						parentOffsetY &&
+					{span.parent &&
+						distanceFromParent > 1 &&
 						(isHoveredSpan || isSelectedSpan) && (
 							<line
 								x1={1}
 								y1={1}
-								x2={-parentOffsetX}
-								y2={-parentOffsetY}
+								x2={
+									offsetX -
+									((span.parent.startTime / totalDuration) *
+										width *
+										zoom +
+										outsidePadding -
+										((span.parent.duration /
+											totalDuration) *
+											width *
+											zoom) /
+											2)
+								}
+								y2={
+									offsetY -
+									(span.parent.depth * (lineHeight + 3) +
+										(ticksHeight + outsidePadding) -
+										lineHeight / 2)
+								}
 								stroke={stroke}
 								strokeWidth="1"
 								data-attrs={JSON.stringify({})}

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -92,9 +92,20 @@ export const TraceFlameGraphNode = memo<Props>(
 		const color = isSelectedSpan ? theme.selectedColor : theme.color
 		const stroke = isSelectedSpan ? theme.selectedBackend : theme.border
 
-		const distanceFromParent = span.parent
+		const distanceFromParent = span.parent?.depth
 			? span.depth - span.parent.depth
 			: 0
+		const parentOffsetX = span.parent?.startTime
+			? offsetX -
+			  ((span.parent.startTime / totalDuration) * width * zoom +
+					outsidePadding)
+			: undefined
+		const parentOffsetY = span.parent?.depth
+			? offsetY -
+			  (span.parent.depth * (lineHeight + 3) +
+					(ticksHeight + outsidePadding) -
+					lineHeight / 2)
+			: undefined
 
 		return (
 			<>
@@ -119,31 +130,15 @@ export const TraceFlameGraphNode = memo<Props>(
 						data-parent-id={span.parentSpanID}
 					/>
 
-					{span.parent &&
-						distanceFromParent > 1 &&
+					{distanceFromParent > 1 &&
+						parentOffsetX &&
+						parentOffsetY &&
 						(isHoveredSpan || isSelectedSpan) && (
 							<line
 								x1={1}
 								y1={1}
-								x2={
-									Math.abs(
-										offsetX -
-											((span.parent.startTime /
-												totalDuration) *
-												width *
-												zoom +
-												outsidePadding),
-									) * -1
-								}
-								y2={
-									Math.abs(
-										offsetY -
-											span.parent.depth *
-												(lineHeight + 3) +
-											(ticksHeight + outsidePadding) -
-											lineHeight / 2,
-									) * -1
-								}
+								x2={-parentOffsetX}
+								y2={-parentOffsetY}
 								stroke={stroke}
 								strokeWidth="1"
 								data-attrs={JSON.stringify({})}

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -105,10 +105,10 @@ export const TraceFlameGraphNode = memo<Props>(
 						fill={fill}
 						stroke={stroke}
 						strokeDasharray={
-							hasError && !isSelectedSpan ? '4' : undefined
+							hasError && !isSelectedSpan ? '3' : undefined
 						}
 						strokeWidth="1"
-						rx="4"
+						rx="3"
 						height={lineHeight}
 						width={spanWidth}
 						data-parent-id={span.parentSpanID}

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -1,7 +1,6 @@
 import { memo } from 'react'
 
 import {
-	depthMultiplier,
 	lineHeight,
 	outsidePadding,
 	ticksHeight,
@@ -74,7 +73,7 @@ export const TraceFlameGraphNode = memo<Props>(
 		const offsetX =
 			(span.startTime / totalDuration) * width * zoom + outsidePadding
 		const offsetY = span.depth
-			? span.depth * depthMultiplier
+			? span.depth * (lineHeight + 3) + (ticksHeight + outsidePadding)
 			: ticksHeight + outsidePadding
 		const isSelectedSpan = selectedSpan?.spanID === span.spanID
 		const hasError = errors.find((error) => error.span_id === span.spanID)
@@ -90,14 +89,20 @@ export const TraceFlameGraphNode = memo<Props>(
 		const fill = isSelectedSpan ? theme.selectedBackend : theme.background
 		const color = isSelectedSpan ? theme.selectedColor : theme.color
 		const stroke = isSelectedSpan ? theme.selectedBackend : theme.border
-		const distanceFromParent = span.depth - (span.parent?.depth ?? 0)
-		const parentOffsetX = span.parent?.depth
-			? offsetX - span.parent.depth * depthMultiplier
+		const distanceFromParent = span.parent?.depth
+			? span.depth - span.parent.depth
+			: 0
+		const parentOffsetX = span.parent?.startTime
+			? (span.parent?.startTime / totalDuration) * width * zoom +
+			  outsidePadding
 			: undefined
 		const parentOffsetY = span.parent?.depth
-			? offsetY - span.parent.depth * depthMultiplier
+			? span.parent.depth * lineHeight +
+			  3 +
+			  (ticksHeight + outsidePadding)
 			: undefined
 
+		console.log(distanceFromParent)
 		return (
 			<>
 				<g
@@ -124,11 +129,12 @@ export const TraceFlameGraphNode = memo<Props>(
 					{distanceFromParent > 1 && (
 						<line
 							x1={0}
-							y1="-4px"
+							y1={0}
 							x2={parentOffsetX}
 							y2={parentOffsetY}
 							stroke={stroke}
 							strokeWidth="1"
+							data-attrs={JSON.stringify({})}
 						/>
 					)}
 

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -93,13 +93,15 @@ export const TraceFlameGraphNode = memo<Props>(
 			? span.depth - span.parent.depth
 			: 0
 		const parentOffsetX = span.parent?.startTime
-			? (span.parent?.startTime / totalDuration) * width * zoom +
-			  outsidePadding
+			? offsetX -
+			  ((span.parent?.startTime / totalDuration) * width * zoom +
+					outsidePadding)
 			: undefined
 		const parentOffsetY = span.parent?.depth
-			? span.parent.depth * lineHeight +
-			  3 +
-			  (ticksHeight + outsidePadding)
+			? offsetY -
+			  (span.parent.depth * lineHeight +
+					3 +
+					(ticksHeight + outsidePadding))
 			: undefined
 
 		console.log(distanceFromParent)

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -132,8 +132,8 @@ export const TraceFlameGraphNode = memo<Props>(
 						parentOffsetX &&
 						parentOffsetY && (
 							<line
-								x1={0}
-								y1={0}
+								x1={-1}
+								y1={-1}
 								x2={-parentOffsetX}
 								y2={-parentOffsetY}
 								stroke={stroke}

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -128,17 +128,19 @@ export const TraceFlameGraphNode = memo<Props>(
 						data-parent-id={span.parentSpanID}
 					/>
 
-					{distanceFromParent > 1 && (
-						<line
-							x1={0}
-							y1={0}
-							x2={parentOffsetX}
-							y2={parentOffsetY}
-							stroke={stroke}
-							strokeWidth="1"
-							data-attrs={JSON.stringify({})}
-						/>
-					)}
+					{distanceFromParent > 1 &&
+						parentOffsetX &&
+						parentOffsetY && (
+							<line
+								x1={0}
+								y1={0}
+								x2={-parentOffsetX}
+								y2={-parentOffsetY}
+								stroke={stroke}
+								strokeWidth="1"
+								data-attrs={JSON.stringify({})}
+							/>
+						)}
 
 					{spanWidth > minWidthToDisplayText && (
 						<foreignObject

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -136,13 +136,13 @@ export const TraceFlameGraphNode = memo<Props>(
 									) * -1
 								}
 								y2={
-									offsetY -
 									Math.abs(
-										span.parent.depth * (lineHeight + 3) +
+										offsetY -
+											span.parent.depth *
+												(lineHeight + 3) +
 											(ticksHeight + outsidePadding) -
 											lineHeight / 2,
-									) *
-										-1
+									) * -1
 								}
 								stroke={stroke}
 								strokeWidth="1"

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -141,9 +141,9 @@ export const TraceFlameGraphNode = memo<Props>(
 								stroke={stroke}
 								strokeWidth="1"
 								opacity={
-									isHoveredSpan || isSelectedSpan ? 1 : 0.5
+									isHoveredSpan || isSelectedSpan ? 1 : 0.15
 								}
-								data-attrs={JSON.stringify({})}
+								pointerEvents="none"
 							/>
 						)}
 

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -140,6 +140,9 @@ export const TraceFlameGraphNode = memo<Props>(
 								y2={-parentOffsetY}
 								stroke={stroke}
 								strokeWidth="1"
+								opacity={
+									isHoveredSpan || isSelectedSpan ? 1 : 0.5
+								}
 								data-attrs={JSON.stringify({})}
 							/>
 						)}

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -94,7 +94,7 @@ export const TraceFlameGraphNode = memo<Props>(
 			: 0
 		const parentOffsetX = span.parent?.startTime
 			? offsetX -
-			  ((span.parent?.startTime / totalDuration) * width * zoom +
+			  ((span.parent.startTime / totalDuration) * width * zoom +
 					outsidePadding)
 			: undefined
 		const parentOffsetY = span.parent?.depth

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -132,8 +132,8 @@ export const TraceFlameGraphNode = memo<Props>(
 						parentOffsetX &&
 						parentOffsetY && (
 							<line
-								x1={-1}
-								y1={-1}
+								x1={1}
+								y1={1}
 								x2={-parentOffsetX}
 								y2={-parentOffsetY}
 								stroke={stroke}

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -140,7 +140,7 @@ export const TraceFlameGraphNode = memo<Props>(
 								x2={-parentOffsetX}
 								y2={-parentOffsetY}
 								stroke={stroke}
-								strokeWidth="2"
+								strokeWidth="1"
 								data-attrs={JSON.stringify({})}
 							/>
 						)}

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -77,6 +77,7 @@ export const TraceFlameGraphNode = memo<Props>(
 			? span.depth * (lineHeight + 3) + (ticksHeight + outsidePadding)
 			: ticksHeight + outsidePadding
 		const isSelectedSpan = selectedSpan?.spanID === span.spanID
+		const isHoveredSpan = hoveredSpan?.spanID === span.spanID
 		const hasError = errors.find((error) => error.span_id === span.spanID)
 		const isDbSpan = !!span.traceAttributes?.db?.system
 		const isFrontendSpan =
@@ -90,6 +91,7 @@ export const TraceFlameGraphNode = memo<Props>(
 		const fill = isSelectedSpan ? theme.selectedBackend : theme.background
 		const color = isSelectedSpan ? theme.selectedColor : theme.color
 		const stroke = isSelectedSpan ? theme.selectedBackend : theme.border
+
 		const distanceFromParent = span.parent?.depth
 			? span.depth - span.parent.depth
 			: 0
@@ -100,11 +102,9 @@ export const TraceFlameGraphNode = memo<Props>(
 			: undefined
 		const parentOffsetY = span.parent?.depth
 			? offsetY -
-			  (span.parent.depth * lineHeight +
-					3 +
+			  (span.parent.depth * (lineHeight + 3) +
 					(ticksHeight + outsidePadding))
 			: undefined
-		const isHoveredSpan = hoveredSpan?.spanID === span.spanID
 
 		return (
 			<>
@@ -132,7 +132,7 @@ export const TraceFlameGraphNode = memo<Props>(
 					{distanceFromParent > 1 &&
 						parentOffsetX &&
 						parentOffsetY &&
-						isHoveredSpan && (
+						(isHoveredSpan || isSelectedSpan) && (
 							<line
 								x1={1}
 								y1={1}

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -126,18 +126,22 @@ export const TraceFlameGraphNode = memo<Props>(
 								x1={1}
 								y1={1}
 								x2={
-									offsetX -
-									((span.parent.startTime / totalDuration) *
-										width *
-										zoom +
-										outsidePadding) *
-										-1
+									Math.abs(
+										offsetX -
+											((span.parent.startTime /
+												totalDuration) *
+												width *
+												zoom +
+												outsidePadding),
+									) * -1
 								}
 								y2={
 									offsetY -
-									(span.parent.depth * (lineHeight + 3) +
-										(ticksHeight + outsidePadding) -
-										lineHeight / 2) *
+									Math.abs(
+										span.parent.depth * (lineHeight + 3) +
+											(ticksHeight + outsidePadding) -
+											lineHeight / 2,
+									) *
 										-1
 								}
 								stroke={stroke}

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -92,7 +92,10 @@ export const TraceFlameGraphNode = memo<Props>(
 		const stroke = isSelectedSpan ? theme.selectedBackend : theme.border
 		const distanceFromParent = span.depth - (span.parent?.depth ?? 0)
 		const parentOffsetX = span.parent?.depth
-			? span.parent.depth * depthMultiplier
+			? offsetX - span.parent.depth * depthMultiplier
+			: undefined
+		const parentOffsetY = span.parent?.depth
+			? offsetY - span.parent.depth * depthMultiplier
 			: undefined
 
 		return (
@@ -120,12 +123,10 @@ export const TraceFlameGraphNode = memo<Props>(
 
 					{distanceFromParent > 1 && (
 						<line
-							x1={parentOffsetX}
-							y1="-3px"
+							x1={0}
+							y1="-4px"
 							x2={parentOffsetX}
-							y2={`-${
-								(distanceFromParent - 1) * lineHeight + 6
-							}px`}
+							y2={parentOffsetY}
 							stroke={stroke}
 							strokeWidth="1"
 						/>

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -103,8 +103,8 @@ export const TraceFlameGraphNode = memo<Props>(
 		const parentOffsetY = span.parent?.depth
 			? offsetY -
 			  (span.parent.depth * (lineHeight + 3) +
-					(ticksHeight + outsidePadding) -
-					lineHeight / 2)
+					(ticksHeight + outsidePadding)) -
+			  lineHeight / 2
 			: undefined
 
 		return (

--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -140,7 +140,7 @@ export const TraceFlameGraphNode = memo<Props>(
 								x2={-parentOffsetX}
 								y2={-parentOffsetY}
 								stroke={stroke}
-								strokeWidth="1"
+								strokeWidth="2"
 								data-attrs={JSON.stringify({})}
 							/>
 						)}

--- a/frontend/src/pages/Traces/TraceProvider.tsx
+++ b/frontend/src/pages/Traces/TraceProvider.tsx
@@ -8,7 +8,7 @@ import {
 	getFirstSpan,
 	getTraceDurationString,
 	getTraceTimes,
-	organizeSpans,
+	organizeSpansForFlameGraph,
 } from '@/pages/Traces/utils'
 
 type TraceContext = {
@@ -21,7 +21,7 @@ type TraceContext = {
 	selectedSpan: FlameGraphSpan | undefined
 	highlightedSpan: FlameGraphSpan | undefined
 	loading: boolean
-	traces: FlameGraphSpan[]
+	traces: FlameGraphSpan[][]
 	error?: ApolloError
 	traceId?: string
 	setHoveredSpan: (span?: FlameGraphSpan) => void
@@ -107,7 +107,7 @@ export const TraceProvider: React.FC<React.PropsWithChildren<Props>> = ({
 			setSelectedSpan(firstSpan as FlameGraphSpan)
 		}
 
-		return organizeSpans(sortableTraces)
+		return organizeSpansForFlameGraph(sortableTraces)
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [data?.trace?.trace])
 

--- a/frontend/src/pages/Traces/utils.test.ts
+++ b/frontend/src/pages/Traces/utils.test.ts
@@ -107,12 +107,12 @@ const flattenSpans = (spans: any) => {
 }
 
 const spans = {
-	a: { startTime: 10, duration: 100, spanID: 'a', parentSpanID: undefined }, // 1
-	b: { startTime: 15, duration: 10, spanID: 'b', parentSpanID: 'a' }, // 2
-	c: { startTime: 20, duration: 10, spanID: 'c', parentSpanID: 'b' }, // 3
-	d: { startTime: 26, duration: 10, spanID: 'd', parentSpanID: 'a' }, // 2
-	e: { startTime: 50, duration: 10, spanID: 'e', parentSpanID: 'd' }, // 3 - child of 2
-	f: { startTime: 60, duration: 10, spanID: 'f', parentSpanID: 'e' }, // 4 - child of 3
+	a: { startTime: 10, duration: 100, spanID: 'a', parentSpanID: undefined }, // 0
+	b: { startTime: 15, duration: 10, spanID: 'b', parentSpanID: 'a' }, // 1
+	c: { startTime: 20, duration: 10, spanID: 'c', parentSpanID: 'b' }, // 2
+	d: { startTime: 26, duration: 10, spanID: 'd', parentSpanID: 'a' }, // 1
+	e: { startTime: 50, duration: 10, spanID: 'e', parentSpanID: 'd' }, // 2 - child of 1
+	f: { startTime: 60, duration: 10, spanID: 'f', parentSpanID: 'e' }, // 3 - child of 2
 }
 
 const unsortedSpansWithOverlaps = [

--- a/frontend/src/pages/Traces/utils.test.ts
+++ b/frontend/src/pages/Traces/utils.test.ts
@@ -1,6 +1,11 @@
 import { Trace } from '@/graph/generated/schemas'
 
-import { getTraceTimes, organizeSpans } from './utils'
+import {
+	getTraceTimes,
+	organizeSpansForFlameGraph,
+	organizeSpansWithChildren,
+	spanOverlaps,
+} from './utils'
 import { trace } from './utils.fixture'
 
 describe('getTraceDuration', () => {
@@ -61,68 +66,102 @@ const unsortedSpans = [
 const expectedSortedTrace = [
 	{
 		spanID: 'a',
-		spanName: 'a',
-		parentSpanID: null,
-		duration: 100,
-		name: 'a',
 		children: [
 			{
 				spanID: 'b',
-				spanName: 'b',
-				parentSpanID: 'a',
-				duration: 200,
-				name: 'b',
-				children: [
-					{
-						spanID: 'g',
-						spanName: 'g',
-						parentSpanID: 'b',
-						duration: 600,
-						name: 'g',
-					},
-				],
+				children: [{ spanID: 'g' }],
 			},
 			{
 				spanID: 'd',
-				spanName: 'd',
-				parentSpanID: 'a',
-				duration: 400,
 				children: [
-					{
-						spanID: 'c',
-						spanName: 'c',
-						parentSpanID: 'd',
-						duration: 300,
-						name: 'c',
-					},
-					{
-						spanID: 'e',
-						spanName: 'e',
-						parentSpanID: 'd',
-						duration: 500,
-						name: 'e',
-						children: [
-							{
-								spanID: 'f',
-								spanName: 'f',
-								parentSpanID: 'e',
-								duration: 600,
-								name: 'f',
-							},
-						],
-					},
+					{ spanID: 'c' },
+					{ spanID: 'e', children: [{ spanID: 'f' }] },
 				],
-				name: 'd',
 			},
 		],
 	},
 ]
 
-describe('organizeSpans', () => {
+describe('organizeSpansWithChildren', () => {
 	it('organizes spans by parent span ID', () => {
-		const sortedSpans = organizeSpans(unsortedSpans)
-		expect(JSON.stringify(sortedSpans)).toEqual(
+		const sortedSpans = organizeSpansWithChildren(unsortedSpans)
+		const sortedSpanIDs = flattenSpans(sortedSpans)
+		expect(JSON.stringify(sortedSpanIDs)).toEqual(
 			JSON.stringify(expectedSortedTrace),
 		)
+	})
+})
+
+const flattenSpans = (spans: any) => {
+	return spans.reduce((acc: any, span: any) => {
+		return span.children
+			? [
+					...acc,
+					{
+						spanID: span.spanID,
+						children: flattenSpans(span.children),
+					},
+			  ]
+			: [...acc, { spanID: span.spanID }]
+	}, [])
+}
+
+const spans = {
+	a: { startTime: 10, duration: 100, spanID: 'a', parentSpanID: undefined }, // 1
+	b: { startTime: 15, duration: 10, spanID: 'b', parentSpanID: 'a' }, // 2
+	c: { startTime: 20, duration: 10, spanID: 'c', parentSpanID: 'b' }, // 3
+	d: { startTime: 26, duration: 10, spanID: 'd', parentSpanID: 'a' }, // 2
+	e: { startTime: 50, duration: 10, spanID: 'e', parentSpanID: 'd' }, // 3 - child of 2
+	f: { startTime: 60, duration: 10, spanID: 'f', parentSpanID: 'e' }, // 4 - child of 3
+}
+
+const unsortedSpansWithOverlaps = [
+	spans.a,
+	spans.b,
+	spans.c,
+	spans.d,
+	spans.e,
+	spans.f,
+]
+
+const expectedSortedSpansWithOverlaps = [['a'], ['b', 'd'], ['c', 'e'], ['f']]
+
+describe('organizeSpansForFlameGraph', () => {
+	it('organizes spans by parent span ID and ensures that all spans do not overlap', () => {
+		const sortedSpans = organizeSpansForFlameGraph(
+			unsortedSpansWithOverlaps,
+		)
+
+		const sortedSpansWithOverlaps = sortedSpans.map((spans) =>
+			spans.map((span: Trace) => span.spanID),
+		)
+
+		expect(JSON.stringify(sortedSpansWithOverlaps)).toEqual(
+			JSON.stringify(expectedSortedSpansWithOverlaps),
+		)
+	})
+})
+
+describe('spanOverlaps', () => {
+	it('returns true when a span overlaps another span', () => {
+		let span1 = { spanID: 'a', startTime: 100, duration: 200 } as Trace
+		let span2 = { spanID: 'b', startTime: 50, duration: 100 } as Trace
+		expect(spanOverlaps(span1, span2)).toEqual(true)
+
+		span1 = { spanID: 'a', startTime: 100, duration: 200 } as Trace
+		span2 = { spanID: 'b', startTime: 50, duration: 50 } as Trace
+		expect(spanOverlaps(span1, span2)).toEqual(true)
+
+		span1 = { spanID: 'a', startTime: 100, duration: 200 } as Trace
+		span2 = { spanID: 'b', startTime: 50, duration: 49 } as Trace
+		expect(spanOverlaps(span1, span2)).toEqual(false)
+
+		span1 = { spanID: 'a', startTime: 100, duration: 200 } as Trace
+		span2 = { spanID: 'b', startTime: 150, duration: 49 } as Trace
+		expect(spanOverlaps(span1, span2)).toEqual(true)
+
+		span1 = { spanID: 'a', startTime: 100, duration: 200 } as Trace
+		span2 = { spanID: 'b', startTime: 50, duration: 300 } as Trace
+		expect(spanOverlaps(span1, span2)).toEqual(true)
 	})
 })

--- a/frontend/src/pages/Traces/utils.ts
+++ b/frontend/src/pages/Traces/utils.ts
@@ -133,7 +133,10 @@ const organizeSpanInLevel = (
 
 	if (children.length > 0) {
 		children.forEach((child) => {
-			organizeSpanInLevel(child, trace, spans, depthIndex + 1, span)
+			organizeSpanInLevel(child, trace, spans, depthIndex + 1, {
+				...span,
+				depth: depthIndex,
+			})
 		})
 	}
 }

--- a/frontend/src/pages/Traces/utils.ts
+++ b/frontend/src/pages/Traces/utils.ts
@@ -110,7 +110,7 @@ const organizeSpanInLevel = (
 	trace: Partial<FlameGraphSpan>[],
 	spans: Partial<FlameGraphSpan>[][],
 	depthIndex: number,
-	parent?: FlameGraphSpan,
+	parent?: Partial<FlameGraphSpan>,
 ) => {
 	spans[depthIndex] = spans[depthIndex] ?? []
 

--- a/frontend/src/pages/Traces/utils.ts
+++ b/frontend/src/pages/Traces/utils.ts
@@ -97,10 +97,12 @@ export const organizeSpansWithChildren = (spans: Partial<FlameGraphSpan>[]) => {
 export const organizeSpansForFlameGraph = (
 	trace: Partial<FlameGraphSpan>[],
 ) => {
-	const rootSpan = trace.find((span) => !span.parentSpanID)
+	const rootSpans = trace.filter((span) => !span.parentSpanID)
 	const spans = [[]]
 
-	organizeSpanInLevel(rootSpan!, trace, spans, 0)
+	rootSpans.forEach((rootSpan) =>
+		organizeSpanInLevel(rootSpan!, trace, spans, 0),
+	)
 
 	return spans as FlameGraphSpan[][]
 }


### PR DESCRIPTION
## Summary

Updates the logic for displaying spans so that if there are multiple spans overlapping on the same level they will be spread out vertically to so they are easier to parse. Because children could be more than one level away from their parent now, we also show a line connecting the parent and child if they are more than one level apart.

**Before**
<img width="658" alt="Screenshot 2023-11-21 at 12 45 04 PM" src="https://github.com/highlight/highlight/assets/308182/75852896-36e0-4057-a543-566162aecfd1">


**After**
<img width="663" alt="Screenshot 2023-11-21 at 12 44 37 PM" src="https://github.com/highlight/highlight/assets/308182/d8509422-a492-41d8-beb5-28883093359c">

Also fixes a bug where the spans were overflowing the graph on render.

Note that I tried to connect spans with lines visually, similar to how Datadog handles this, but it didn't look very good. I think we'll need to think about how we want to lay this out + work with Julian to design it if we want this feature.

## How did you test this change?

Local and PR preview click test.

## Are there any deployment considerations?

N/A - all client-side changes. Should check in with Lewis at Reflame to see if this resolves his issue parsing spans.

## Does this work require review from our design team?

Should get Julian's thoughts on how the spans are connected with the line.
