### PR TITLE
tag existing s3 objects w/ retention period

### DIFF
--- a/backend/migrations/cmd/tag-existing-session-data/main.go
+++ b/backend/migrations/cmd/tag-existing-session-data/main.go
@@ -16,18 +16,7 @@ import (
 
 	"github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
-	"github.com/pkg/errors"
 )
-
-const BatchSize = 100
-
-func createFile(name string) (*os.File, error) {
-	file, err := os.Create(name)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating file")
-	}
-	return file, nil
-}
 
 func main() {
 	ctx := context.Background()

--- a/backend/migrations/cmd/tag-existing-session-data/main.go
+++ b/backend/migrations/cmd/tag-existing-session-data/main.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/highlight-run/highlight/backend/storage"
+	"github.com/openlyinc/pointy"
+	"github.com/samber/lo"
+	"golang.org/x/exp/slices"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/highlight-run/highlight/backend/model"
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/pkg/errors"
+)
+
+const BatchSize = 100
+
+func createFile(name string) (*os.File, error) {
+	file, err := os.Create(name)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating file")
+	}
+	return file, nil
+}
+
+func main() {
+	ctx := context.Background()
+	log.WithContext(ctx).Info("setting up db")
+	db, err := model.SetupDB(ctx, os.Getenv("PSQL_DB"))
+	if err != nil {
+		log.WithContext(ctx).Fatal(err)
+	}
+
+	storageClient, err := storage.NewS3Client(ctx)
+	if err != nil {
+		log.WithContext(ctx).Fatal(err)
+	}
+
+	projects := []*model.Project{}
+	if err := db.Model(&model.Project{}).Find(&projects); err != nil {
+		log.WithContext(ctx).Fatal(err)
+	}
+
+	workspaces := []*model.Workspace{}
+	if err := db.Model(&model.Workspace{}).Find(&workspaces); err != nil {
+		log.WithContext(ctx).Fatal(err)
+	}
+
+	workspaceIdToRetentionPeriod := lo.Associate(workspaces, func(w *model.Workspace) (int, modelInputs.RetentionPeriod) {
+		retentionPeriod := modelInputs.RetentionPeriodSixMonths
+		if w.RetentionPeriod != nil {
+			retentionPeriod = *w.RetentionPeriod
+		}
+		return w.ID, retentionPeriod
+	})
+
+	projectIdToRetentionPeriod := lo.Associate(projects, func(p *model.Project) (int, modelInputs.RetentionPeriod) {
+		return p.ID, workspaceIdToRetentionPeriod[p.WorkspaceID]
+	})
+
+	projectIds := lo.Keys(projectIdToRetentionPeriod)
+	slices.Sort(projectIds)
+
+	for _, projectId := range projectIds {
+		log.WithContext(ctx).Infof("starting tagging for project %d", projectId)
+
+		retentionPeriod := projectIdToRetentionPeriod[projectId]
+
+		var continuationToken *string
+		for {
+			resp, err := storageClient.S3ClientEast2.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+				Bucket:            pointy.String(storage.S3SessionsPayloadBucketNameNew),
+				Prefix:            pointy.String(fmt.Sprintf("dev/%d/", projectId)),
+				ContinuationToken: continuationToken,
+			})
+			if err != nil {
+				log.WithContext(ctx).Fatal(err)
+			}
+
+			for _, item := range resp.Contents {
+				storageClient.S3ClientEast2.PutObjectTagging(ctx, &s3.PutObjectTaggingInput{
+					Bucket: pointy.String(storage.S3SessionsPayloadBucketNameNew),
+					Key:    item.Key,
+					Tagging: &types.Tagging{
+						TagSet: []types.Tag{
+							{
+								Key:   pointy.String("RetentionPeriod"),
+								Value: pointy.String(string(retentionPeriod))},
+						},
+					},
+				})
+			}
+
+			if !resp.IsTruncated {
+				break
+			}
+			continuationToken = resp.NextContinuationToken
+		}
+
+		log.WithContext(ctx).Infof("done tagging for project %d", projectId)
+	}
+}


### PR DESCRIPTION
## Summary
- iterates over the files in s3 by prefix to tag all session objects with the retention period
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran against dev bucket to make sure objects were tagged
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will run script in ec2 after it is merged in
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
