### PR TITLE
support additional fastapi attributes on http errors

### DIFF
--- a/sdk/highlight-py/e2e/highlight_fastapi/main.py
+++ b/sdk/highlight-py/e2e/highlight_fastapi/main.py
@@ -22,6 +22,7 @@ router = APIRouter()
 
 
 @app.get("/")
+@app.post("/")
 async def root(request: Request):
     logging.info(
         "hello, world", {"customer": request.headers.get("customer") or "unknown"}

--- a/sdk/highlight-py/highlight_io/integrations/fastapi.py
+++ b/sdk/highlight-py/highlight_io/integrations/fastapi.py
@@ -35,6 +35,10 @@ class FastAPIMiddleware(BaseHTTPMiddleware):
                     status_code=resp.status_code,
                     headers=resp.headers.__dict__,
                     detail=body.decode(),
+                    attributes={
+                        "http.method": request.method,
+                        "http.url": request.url,
+                    },
                 )
                 return Response(
                     content=body,

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -13,10 +13,12 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider, LogRecord
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider, Span
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.semconv.resource import ResourceAttributes
+from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import INVALID_SPAN
-from opentelemetry.sdk.resources import Attributes, Resource
 
 from highlight_io.integrations import Integration
 
@@ -173,7 +175,6 @@ class H(object):
     def record_http_error(
         status_code: int,
         detail: str,
-        headers: typing.Dict[str, str],
         attributes: typing.Optional[typing.Dict[str, any]] = None,
     ) -> None:
         """
@@ -201,7 +202,6 @@ class H(object):
 
         :param status_code: the http status code to report
         :param detail: the error status details
-        :param headers: the headers of the http request
         :param attributes: additional metadata to attribute to this error.
         :return: None
         """
@@ -224,17 +224,21 @@ class H(object):
         # relies there being an exception raised. we manually `traceback.format_stack()` to get the current
         # execution stack for recording an http exception.
         attrs = {
-            "exception.type": "HTTPException",
-            "exception.message": detail,
-            "exception.stacktrace": "".join(traceback.format_stack()),
-            "http.status_code": status_code,
-            "http.headers": headers,
-            "http.detail": detail,
+            SpanAttributes.EXCEPTION_TYPE: "HTTPException",
+            SpanAttributes.EXCEPTION_MESSAGE: detail,
+            SpanAttributes.EXCEPTION_STACKTRACE: "".join(traceback.format_stack()),
+            SpanAttributes.HTTP_STATUS_CODE: status_code,
+            "http.response.detail": detail,
         }
-        attrs.update(attributes or dict())
-        for k, v in headers.items():
-            if type(v) in [bool, str, bytes, int, float]:
-                attrs[f"http.headers.{k}"] = v
+        if attributes:
+            attrs.update(attributes)
+        for req in ("request", "response"):
+            headers = attrs.pop(f"http.{req}.headers", None)
+            if not headers:
+                continue
+            for k, v in headers.items():
+                if type(v) in [bool, str, bytes, int, float]:
+                    attrs[f"http.{req}.headers.{k}"] = v
         span.add_event(name="exception", attributes=attrs)
 
     @staticmethod
@@ -292,10 +296,10 @@ class H(object):
             # record.created is sec but timestamp should be ns
             ts = int(record.created * 1000.0 * 1000.0 * 1000.0)
             attributes = span.attributes.copy()
-            attributes["code.function"] = record.funcName
-            attributes["code.namespace"] = record.module
-            attributes["code.filepath"] = record.pathname
-            attributes["code.lineno"] = record.lineno
+            attributes[SpanAttributes.CODE_FUNCTION] = record.funcName
+            attributes[SpanAttributes.CODE_NAMESPACE] = record.module
+            attributes[SpanAttributes.CODE_FILEPATH] = record.pathname
+            attributes[SpanAttributes.CODE_LINENO] = record.lineno
             attributes.update(record.args or {})
 
             message = record.getMessage()
@@ -363,8 +367,8 @@ def _build_resource(
     attrs = {}
 
     if service_name:
-        attrs["service.name"] = service_name
+        attrs[ResourceAttributes.SERVICE_NAME] = service_name
     if service_version:
-        attrs["service.version"] = service_version
+        attrs[ResourceAttributes.SERVICE_VERSION] = service_version
 
     return Resource.create(attrs)

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -228,6 +228,8 @@ class H(object):
             "exception.message": detail,
             "exception.stacktrace": "".join(traceback.format_stack()),
             "http.status_code": status_code,
+            "http.headers": headers,
+            "http.detail": detail,
         }
         attrs.update(attributes or dict())
         for k, v in headers.items():

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.6.5"
+version = "0.6.6"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [

--- a/sdk/highlight-py/tests/test_fastapi.py
+++ b/sdk/highlight-py/tests/test_fastapi.py
@@ -4,6 +4,7 @@ from contextlib import nullcontext
 from fastapi import Request, Response, HTTPException
 
 import pytest
+from opentelemetry.trace import Span, SpanContext
 from starlette.responses import StreamingResponse
 
 from highlight_io import H
@@ -38,9 +39,12 @@ def highlight_setup(request):
 )
 @pytest.mark.asyncio
 async def test_fastapi(mocker, highlight_setup, exception, response):
+    mock_trace = mocker.patch("highlight_io.sdk.trace.get_current_span", autospec=Span)
+    mock_trace.return_value.get_span_context.return_value = SpanContext(123, 456, False)
     app = mocker.MagicMock()
     middleware = FastAPIMiddleware(app)
-    request = mocker.MagicMock()
+    request = mocker.MagicMock(autospec=Request)
+    request.url = "https://localhost:8080/api/foo"
 
     async def call_next(_: Request) -> Response:
         if exception:
@@ -55,3 +59,26 @@ async def test_fastapi(mocker, highlight_setup, exception, response):
 
     with ctx:
         await middleware.dispatch(request, call_next)
+
+    if highlight_setup and response.status_code >= 400 and not exception:
+        mock_trace.return_value.add_event.assert_called()
+        assert set(
+            mock_trace.return_value.add_event.call_args_list[0][1]["attributes"].keys()
+        ) == {
+            "exception.type",
+            "exception.message",
+            "exception.stacktrace",
+            "http.status_code",
+            "http.headers",
+            "http.detail",
+            "http.method",
+            "http.url",
+        }
+        assert (
+            mock_trace.return_value.add_event.call_args_list[0][1]["attributes"][
+                "http.url"
+            ]
+            == request.url
+        )
+    else:
+        mock_trace.return_value.add_event.assert_not_called()


### PR DESCRIPTION
## Summary

A customer brought up that our [FastAPI integration](https://app.intercom.com/a/inbox/gm6369ty/inbox/shared/all/conversation/41483?view=List) does not report
much detail on HTTP errors, with a stacktrace that is not useful since
it will be pointing to FastAPI internal code.

This change introduces additional attributes to the FastAPI integration.

## How did you test this change?

Unit test

<img width="519" alt="Screenshot 2023-11-22 at 12 01 12 PM" src="https://github.com/highlight/highlight/assets/1351531/9251b973-74b6-4ce0-9550-e9095a494d1a">

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No