### PR TITLE
Don't use time fields in segments

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5613,6 +5613,24 @@ body {
 ._1vb6x0p0:hover {
   color: var(--_1pyqka9y);
 }
+._1ukfp2a0 {
+  border-radius: 0;
+  border: 0 !important;
+}
+._1ukfp2a0:focus,
+._1ukfp2a0:active {
+  background: inherit;
+}
+._1ukfp2a1 {
+  border-right: var(--_1pyqka91o) solid 1px !important;
+}
+._1ukfp2a2 {
+  background: var(--_1pyqka9t);
+}
+._1ukfp2a2:focus,
+._1ukfp2a2:active {
+  background: var(--_1pyqka9u);
+}
 ._1hht64e1 {
   height: 20px;
 }
@@ -6163,24 +6181,6 @@ body {
 .ccrj1p2 {
   border: 0;
   border-radius: 0;
-}
-._1ukfp2a0 {
-  border-radius: 0;
-  border: 0 !important;
-}
-._1ukfp2a0:focus,
-._1ukfp2a0:active {
-  background: inherit;
-}
-._1ukfp2a1 {
-  border-right: var(--_1pyqka91o) solid 1px !important;
-}
-._1ukfp2a2 {
-  background: var(--_1pyqka9t);
-}
-._1ukfp2a2:focus,
-._1ukfp2a2:active {
-  background: var(--_1pyqka9u);
 }
 ._3dlaof0 {
   height: 20px;

--- a/frontend/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder/QueryBuilder.tsx
@@ -1536,12 +1536,12 @@ function QueryBuilder(props: QueryBuilderProps) {
 	// Not sure if this is desired behavior in the long term, but
 	// this matches the current prod behavior.
 	useEffect(() => {
-		if (setDefault !== false) {
-			return () => {
+		return () => {
+			if (selectedSegment && setDefault !== false) {
 				removeSelectedSegment()
 			}
 		}
-	}, [removeSelectedSegment, setDefault])
+	}, [removeSelectedSegment, setDefault, selectedSegment])
 
 	const { setShowLeftPanel } = usePlayerConfiguration()
 

--- a/frontend/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder/QueryBuilder.tsx
@@ -1537,11 +1537,11 @@ function QueryBuilder(props: QueryBuilderProps) {
 	// this matches the current prod behavior.
 	useEffect(() => {
 		return () => {
-			if (selectedSegment && setDefault !== false) {
+			if (selectedSegment && !readonly && setDefault !== false) {
 				removeSelectedSegment()
 			}
 		}
-	}, [removeSelectedSegment, setDefault, selectedSegment])
+	}, [removeSelectedSegment, setDefault, selectedSegment, readonly])
 
 	const { setShowLeftPanel } = usePlayerConfiguration()
 

--- a/frontend/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder/QueryBuilder.tsx
@@ -73,6 +73,7 @@ import { useLocation } from 'react-router-dom'
 import { useToggle } from 'react-use'
 
 import LoadingBox from '@/components/LoadingBox'
+import { searchesAreEqual } from '@/components/QueryBuilder/utils'
 import CreateErrorSegmentModal from '@/pages/Errors/ErrorSegmentSidebar/SegmentButtons/CreateErrorSegmentModal'
 import DeleteErrorSegmentModal from '@/pages/Errors/ErrorSegmentSidebar/SegmentPicker/DeleteErrorSegmentModal/DeleteErrorSegmentModal'
 import usePlayerConfiguration from '@/pages/Player/PlayerHook/utils/usePlayerConfiguration'
@@ -1546,10 +1547,10 @@ function QueryBuilder(props: QueryBuilderProps) {
 
 	const mode = (() => {
 		if (selectedSegment !== undefined) {
-			if (searchQuery !== existingQuery) {
-				return QueryBuilderMode.SEGMENT_UPDATE
-			} else {
+			if (searchesAreEqual(searchQuery, existingQuery, timeRangeField)) {
 				return QueryBuilderMode.SEGMENT
+			} else {
+				return QueryBuilderMode.SEGMENT_UPDATE
 			}
 		}
 		return QueryBuilderMode.CUSTOM
@@ -1802,6 +1803,7 @@ function QueryBuilder(props: QueryBuilderProps) {
 		<>
 			<CreateAnySegmentModal
 				showModal={segmentModalState !== SegmentModalState.HIDDEN}
+				timeRangeField={timeRangeField}
 				onHideModal={() => {
 					setSegmentModalState(SegmentModalState.HIDDEN)
 				}}

--- a/frontend/src/components/QueryBuilder/utils.ts
+++ b/frontend/src/components/QueryBuilder/utils.ts
@@ -14,6 +14,10 @@ export const searchesAreEqual = (
 	const { rules } = searchObjectFromString(search)
 	const { rules: newRules } = searchObjectFromString(newSearch)
 
+	if (rules.length !== newRules.length) {
+		return false
+	}
+
 	return rules.every((rule) => {
 		if (rule.field?.value === timeRangeField.value) {
 			return true

--- a/frontend/src/components/QueryBuilder/utils.ts
+++ b/frontend/src/components/QueryBuilder/utils.ts
@@ -1,0 +1,36 @@
+import { deserializeRules } from '@/components/QueryBuilder/QueryBuilder'
+import { SearchOption } from '@/components/Select/SearchSelect/SearchSelect'
+
+export type SearchObject = {
+	isAnd: boolean
+	rules: string[][]
+}
+
+export const searchesAreEqual = (
+	search: string,
+	newSearch: string,
+	timeRangeField: SearchOption,
+) => {
+	const { rules } = searchObjectFromString(search)
+	const { rules: newRules } = searchObjectFromString(newSearch)
+
+	return rules.every((rule) => {
+		if (rule.field?.value === timeRangeField.value) {
+			return true
+		}
+
+		const newRule = newRules.find(
+			(r) => r.field?.value === rule.field?.value,
+		)
+		return JSON.stringify(rule) === JSON.stringify(newRule)
+	})
+}
+
+export const searchObjectFromString = (search: string) => {
+	const searchJSON: SearchObject = JSON.parse(search)
+
+	return {
+		isAnd: searchJSON.isAnd,
+		rules: deserializeRules(searchJSON.rules),
+	}
+}

--- a/frontend/src/pages/Errors/ErrorSegmentSidebar/SegmentButtons/CreateErrorSegmentModal.tsx
+++ b/frontend/src/pages/Errors/ErrorSegmentSidebar/SegmentButtons/CreateErrorSegmentModal.tsx
@@ -14,10 +14,14 @@ import { useParams } from '@util/react-router/useParams'
 import { message } from 'antd'
 import React, { useEffect, useState } from 'react'
 
+import { SearchOption } from '@/components/Select/SearchSelect/SearchSelect'
+import { removeTimeField } from '@/context/SearchState'
+
 import styles from './SegmentButtons.module.css'
 
 interface Props {
 	showModal: boolean
+	timeRangeField: SearchOption
 	onHideModal: () => void
 	/** Called after a segment is created. */
 	afterCreateHandler?: (segmentId: string, segmentValue: string) => void
@@ -26,6 +30,7 @@ interface Props {
 
 const CreateErrorSegmentModal = ({
 	showModal,
+	timeRangeField,
 	onHideModal,
 	afterCreateHandler,
 	currentSegment,
@@ -71,13 +76,18 @@ const CreateErrorSegmentModal = ({
 			return
 		}
 
+		const queryWithoutTimeRange = removeTimeField(
+			searchQuery,
+			timeRangeField,
+		)
+
 		if (shouldUpdate) {
 			editErrorSegment({
 				variables: {
 					project_id: project_id!,
 					id: currentSegment.id!,
 					name: newSegmentName,
-					params: { query: searchQuery },
+					params: { query: queryWithoutTimeRange },
 				},
 				onCompleted: () => {
 					message.success(

--- a/frontend/src/pages/Sessions/SearchSidebar/SegmentButtons/CreateSegmentModal.tsx
+++ b/frontend/src/pages/Sessions/SearchSidebar/SegmentButtons/CreateSegmentModal.tsx
@@ -11,10 +11,14 @@ import { useParams } from '@util/react-router/useParams'
 import { message } from 'antd'
 import React, { useEffect, useState } from 'react'
 
+import { SearchOption } from '@/components/Select/SearchSelect/SearchSelect'
+import { removeTimeField } from '@/context/SearchState'
+
 import styles from './SegmentButtons.module.css'
 
 interface Props {
 	showModal: boolean
+	timeRangeField: SearchOption
 	onHideModal: () => void
 	/** Called after a segment is created. */
 	afterCreateHandler?: (segmentId: string, segmentValue: string) => void
@@ -23,6 +27,7 @@ interface Props {
 
 const CreateSegmentModal = ({
 	showModal,
+	timeRangeField,
 	onHideModal,
 	afterCreateHandler,
 	currentSegment,
@@ -61,13 +66,18 @@ const CreateSegmentModal = ({
 			return
 		}
 
+		const queryWithoutTimeRange = removeTimeField(
+			searchQuery,
+			timeRangeField,
+		)
+
 		if (shouldUpdate) {
 			editSegment({
 				variables: {
 					project_id,
 					id: currentSegment.id!,
 					name: newSegmentName,
-					params: { query: searchQuery },
+					params: { query: queryWithoutTimeRange },
 				},
 				onCompleted: () => {
 					message.success(
@@ -91,7 +101,7 @@ const CreateSegmentModal = ({
 				variables: {
 					project_id,
 					name: newSegmentName,
-					params: { query: searchQuery },
+					params: { query: queryWithoutTimeRange },
 				},
 				refetchQueries: [namedOperations.Query.GetSegments],
 				onCompleted: (r) => {


### PR DESCRIPTION
## Summary

Segments currently persist the date filters that are being used when they are created/updated. This isn't the expected behavior and it's even more problematic because after 30 days there's a good chance a segment will show empty search results because there isn't any data to show anymore.

This PR prevents us from persisting the time range for the query and also filters it out when applying a segment so that existing segments will work as expected.

I also uncovered a bug where the query would be reset to the default when toggling the segment create/edit modal - that is fixed as well.

## How did you test this change?

Ensure the date field isn't applied in the following scenarios:

- [ ] While on `main`, create a segment. This should persist with the date range field.
- [ ] Check out this branch and then apply that segment. The time range should not be applied.
- [ ] Create a new segment and ensure the time range is not persisted.
- [ ] Edit a segment and ensure the time range is not persisted.

## Are there any deployment considerations?

N/A - all client-side changes

## Does this work require review from our design team?

Nope!
