### PR TITLE
update header parsing types for node / next SDKs

### DIFF
--- a/.changeset/tidy-plants-wink.md
+++ b/.changeset/tidy-plants-wink.md
@@ -1,0 +1,6 @@
+---
+'@highlight-run/next': patch
+'@highlight-run/node': patch
+---
+
+ensure header parsing is compatible with IncomingHTTPHeaders and Headers types

--- a/e2e/nextjs/src/app/api/edge-test/route.ts
+++ b/e2e/nextjs/src/app/api/edge-test/route.ts
@@ -1,10 +1,10 @@
 // src/app/api/edge-test/route.ts
 import { H } from '@highlight-run/next/server'
 import type { NextFetchEvent, NextRequest } from 'next/server'
-import { withEdgeHighlight } from '@/app/_utils/edge-highlight.config'
-
 import { NextResponse } from 'next/server'
+import { withEdgeHighlight } from '@/app/_utils/edge-highlight.config'
 import { z } from 'zod'
+import { withAppRouterHighlight } from '@/app/_utils/app-router-highlight.config'
 
 export const GET = withEdgeHighlight(async function GET(request: NextRequest) {
 	const { searchParams } = new URL(request.url)
@@ -30,6 +30,23 @@ export const POST = withEdgeHighlight(async function POST(
 	return NextResponse.json({
 		body: { headers },
 	})
+})
+
+export const PUT = withAppRouterHighlight(async function GET(
+	request: NextRequest,
+) {
+	try {
+		throw new Error('yo')
+	} catch (error: any) {
+		console.log(error)
+		const parsedHeaders = H.parseHeaders(request.headers)
+		H.consumeError(
+			error,
+			parsedHeaders.secureSessionId,
+			parsedHeaders.requestId,
+		)
+		return NextResponse.json({ hello: 'world' })
+	}
 })
 
 export const runtime = 'edge'

--- a/e2e/nextjs/src/app/api/edge-test/route.ts
+++ b/e2e/nextjs/src/app/api/edge-test/route.ts
@@ -32,9 +32,7 @@ export const POST = withEdgeHighlight(async function POST(
 	})
 })
 
-export const PUT = withAppRouterHighlight(async function GET(
-	request: NextRequest,
-) {
+export const PUT = withEdgeHighlight(async function GET(request: NextRequest) {
 	try {
 		throw new Error('yo')
 	} catch (error: any) {

--- a/sdk/highlight-next/src/util/highlight-edge.ts
+++ b/sdk/highlight-next/src/util/highlight-edge.ts
@@ -113,23 +113,35 @@ export const H: HighlightInterface = {
 			tags,
 		})
 	},
-	parseHeaders(headers: IncomingHttpHeaders): HighlightContext {
+	parseHeaders(
+		headers: Headers | IncomingHttpHeaders | undefined,
+	): HighlightContext {
 		const highlightCtx = globalHighlightContext
 		if (highlightCtx?.secureSessionId && highlightCtx?.requestId) {
 			return highlightCtx
-		} else if (headers && headers[HIGHLIGHT_REQUEST_HEADER]) {
-			const [secureSessionId, requestId] =
-				`${headers[HIGHLIGHT_REQUEST_HEADER]}`.split('/')
-			return { secureSessionId, requestId }
-		} else {
-			return { secureSessionId: undefined, requestId: undefined }
+		} else if (headers) {
+			let requestHeaders: IncomingHttpHeaders = {}
+			if (headers instanceof Headers) {
+				headers.forEach((k, v) => (requestHeaders[k] = v))
+			} else {
+				requestHeaders = headers
+			}
+			if (requestHeaders[HIGHLIGHT_REQUEST_HEADER]) {
+				const [secureSessionId, requestId] =
+					`${requestHeaders[HIGHLIGHT_REQUEST_HEADER]}`.split('/')
+				return { secureSessionId, requestId }
+			}
 		}
+		return { secureSessionId: undefined, requestId: undefined }
 	},
-	runWithHeaders<T>(headers: IncomingHttpHeaders, cb: () => T) {
+	runWithHeaders<T>(
+		headers: Headers | IncomingHttpHeaders | undefined,
+		cb: () => T,
+	) {
 		this.setHeaders(headers)
 		return cb()
 	},
-	setHeaders(headers: IncomingHttpHeaders) {
+	setHeaders(headers: Headers | IncomingHttpHeaders | undefined) {
 		const highlightCtx = this.parseHeaders(headers)
 		if (highlightCtx) {
 			globalHighlightContext = highlightCtx

--- a/sdk/highlight-next/src/util/types.ts
+++ b/sdk/highlight-next/src/util/types.ts
@@ -30,9 +30,14 @@ export interface HighlightInterface {
 	) => WorkersSDK
 	isInitialized: () => boolean
 	metrics: (metrics: Metric[]) => void
-	parseHeaders: (headers: IncomingHttpHeaders) => HighlightContext
-	runWithHeaders: <T>(headers: IncomingHttpHeaders, cb: () => T) => T
-	setHeaders: (headers: IncomingHttpHeaders) => void
+	parseHeaders: (
+		headers: Headers | IncomingHttpHeaders | undefined,
+	) => HighlightContext
+	runWithHeaders: <T>(
+		headers: Headers | IncomingHttpHeaders | undefined,
+		cb: () => T,
+	) => T
+	setHeaders: (headers: Headers | IncomingHttpHeaders | undefined) => void
 	consumeError: (
 		error: Error,
 		secureSessionId?: string,

--- a/sdk/highlight-next/src/util/with-highlight-edge.ts
+++ b/sdk/highlight-next/src/util/with-highlight-edge.ts
@@ -18,19 +18,21 @@ export function Highlight(env: HighlightEnv) {
 			event: NextFetchEvent & ExtendedExecutionContext,
 		) {
 			H.initEdge(request, env, event)
-			const headers: IncomingHttpHeaders = {}
-			request.headers.forEach((v, k) => (headers[k] = v))
-
 			try {
-				const response = await H.runWithHeaders(headers, async () => {
-					return await handler(request, event)
-				})
+				const response = await H.runWithHeaders(
+					request.headers,
+					async () => {
+						return await handler(request, event)
+					},
+				)
 
 				H.sendResponse(response)
 
 				return response
 			} catch (error) {
-				const { secureSessionId, requestId } = H.parseHeaders(headers)
+				const { secureSessionId, requestId } = H.parseHeaders(
+					request.headers,
+				)
 				if (error instanceof Error) {
 					H.consumeError(error, secureSessionId, requestId)
 				}

--- a/sdk/highlight-next/src/util/with-highlight-edge.ts
+++ b/sdk/highlight-next/src/util/with-highlight-edge.ts
@@ -2,7 +2,6 @@ import { H } from './highlight-edge'
 import type { NodeOptions } from '@highlight-run/node'
 import type { NextFetchEvent, NextRequest } from 'next/server'
 import { ExtendedExecutionContext } from './types'
-import { IncomingHttpHeaders } from 'http'
 
 export type HighlightEnv = NodeOptions
 

--- a/sdk/highlight-next/src/util/with-highlight-nodejs-app-router.ts
+++ b/sdk/highlight-next/src/util/with-highlight-nodejs-app-router.ts
@@ -1,7 +1,6 @@
 import type { NextRequest } from 'next/server'
 
 import { H, NodeOptions } from '@highlight-run/node'
-import { IncomingHttpHeaders } from 'http'
 
 type NextContext = { params: Record<string, string> }
 type NextHandler<Body = unknown> = (

--- a/sdk/highlight-next/src/util/with-highlight-nodejs-app-router.ts
+++ b/sdk/highlight-next/src/util/with-highlight-nodejs-app-router.ts
@@ -12,17 +12,17 @@ type NextHandler<Body = unknown> = (
 export function Highlight(options: NodeOptions) {
 	return (originalHandler: NextHandler) =>
 		async (request: NextRequest, context: NextContext) => {
-			const headers: IncomingHttpHeaders = {}
-			request.headers.forEach((value, key) => (headers[key] = value))
 			try {
 				H.init(options)
 
 				// Must await originalHandler to catch the error at this level
-				return await H.runWithHeaders(headers, async () => {
+				return await H.runWithHeaders(request.headers, async () => {
 					return await originalHandler(request, context)
 				})
 			} catch (error) {
-				const { secureSessionId, requestId } = H.parseHeaders(headers)
+				const { secureSessionId, requestId } = H.parseHeaders(
+					request.headers,
+				)
 
 				if (error instanceof Error) {
 					await H.consumeAndFlush(error, secureSessionId, requestId)

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -317,15 +317,23 @@ export class Highlight {
 		return this.otel.addResource(new Resource(attributes))
 	}
 
-	parseHeaders(headers: IncomingHttpHeaders): HighlightContext {
+	parseHeaders(
+		headers: Headers | IncomingHttpHeaders | undefined,
+	): HighlightContext {
+		let requestHeaders: IncomingHttpHeaders = {}
+		if (headers instanceof Headers) {
+			headers.forEach((k, v) => (requestHeaders[k] = v))
+		} else if (headers) {
+			requestHeaders = headers
+		}
 		try {
 			const highlightCtx = this.asyncLocalStorage.getStore()
 			if (highlightCtx) {
 				return highlightCtx
 			}
-			if (headers && headers[HIGHLIGHT_REQUEST_HEADER]) {
+			if (requestHeaders[HIGHLIGHT_REQUEST_HEADER]) {
 				const [secureSessionId, requestId] =
-					`${headers[HIGHLIGHT_REQUEST_HEADER]}`.split('/')
+					`${requestHeaders[HIGHLIGHT_REQUEST_HEADER]}`.split('/')
 				return { secureSessionId, requestId }
 			}
 		} catch (e) {
@@ -334,7 +342,10 @@ export class Highlight {
 		return { secureSessionId: undefined, requestId: undefined }
 	}
 
-	runWithHeaders<T>(headers: IncomingHttpHeaders, cb: () => T) {
+	runWithHeaders<T>(
+		headers: Headers | IncomingHttpHeaders | undefined,
+		cb: () => T,
+	) {
 		const highlightCtx = this.parseHeaders(headers)
 		if (highlightCtx) {
 			return this.asyncLocalStorage.run(highlightCtx, cb)
@@ -343,7 +354,7 @@ export class Highlight {
 		}
 	}
 
-	setHeaders(headers: IncomingHttpHeaders) {
+	setHeaders(headers: Headers | IncomingHttpHeaders | undefined) {
 		const highlightCtx = this.parseHeaders(headers)
 		if (highlightCtx) {
 			this.asyncLocalStorage.enterWith(highlightCtx)

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -322,7 +322,7 @@ export class Highlight {
 	): HighlightContext {
 		let requestHeaders: IncomingHttpHeaders = {}
 		if (headers instanceof Headers) {
-			headers.forEach((k, v) => (requestHeaders[k] = v))
+			headers.forEach((value, key) => (requestHeaders[key] = value))
 		} else if (headers) {
 			requestHeaders = headers
 		}

--- a/sdk/highlight-node/src/handlers.ts
+++ b/sdk/highlight-node/src/handlers.ts
@@ -2,7 +2,6 @@ import * as http from 'http'
 import { NodeOptions } from '.'
 import { H } from './sdk.js'
 import type { Attributes } from '@opentelemetry/api'
-import { IncomingHttpHeaders } from 'http'
 
 /** JSDoc */
 interface MiddlewareError extends Error {

--- a/sdk/highlight-node/src/handlers.ts
+++ b/sdk/highlight-node/src/handlers.ts
@@ -128,13 +128,7 @@ const makeHandler = (
 		if (!H.isInitialized()) {
 			H.init(options)
 		}
-		const headers: IncomingHttpHeaders = {}
-		const h = headersExtractor(args)
-		if (h) {
-			for (const [k, v] of Object.entries(h)) {
-				headers[k] = v
-			}
-		}
+		const headers = headersExtractor(args)
 		try {
 			return await H.runWithHeaders(headers, async () => {
 				return await origHandler(...args)

--- a/sdk/highlight-node/src/sdk.ts
+++ b/sdk/highlight-node/src/sdk.ts
@@ -12,11 +12,16 @@ export interface HighlightInterface {
 	stop: () => Promise<void>
 	isInitialized: () => boolean
 	// Use parseHeaders to extract the headers from the current context or from the headers.
-	parseHeaders: (headers: IncomingHttpHeaders) => HighlightContext
+	parseHeaders: (
+		headers: Headers | IncomingHttpHeaders | undefined,
+	) => HighlightContext
 	// Use setHeaders to define the highlight context for the entire async request
-	setHeaders: (headers: IncomingHttpHeaders) => void
+	setHeaders: (headers: Headers | IncomingHttpHeaders | undefined) => void
 	// Use runWithHeaders to execute a method with a highlight context
-	runWithHeaders: <T>(headers: IncomingHttpHeaders, cb: () => T) => T
+	runWithHeaders: <T>(
+		headers: Headers | IncomingHttpHeaders | undefined,
+		cb: () => T,
+	) => T
 	consumeError: (
 		error: Error,
 		secureSessionId?: string,
@@ -139,13 +144,13 @@ export const H: HighlightInterface = {
 			console.warn('highlight-node log error: ', e)
 		}
 	},
-	parseHeaders: (headers: IncomingHttpHeaders): HighlightContext => {
+	parseHeaders: (headers): HighlightContext => {
 		return highlight_obj.parseHeaders(headers)
 	},
 	runWithHeaders: (headers, cb) => {
 		return highlight_obj.runWithHeaders(headers, cb)
 	},
-	setHeaders: (headers: IncomingHttpHeaders) => {
+	setHeaders: (headers) => {
 		return highlight_obj.setHeaders(headers)
 	},
 	consumeAndFlush: async function (...args) {


### PR DESCRIPTION
## Summary

We've received a report in discord that our API router wrappers fail to
parse headers correctly because they expect an `IncomingHTTPHeaders` structure
while the `request.headers` there uses the `Headers` type.

Support both in the node / next SDKs.

## How did you test this change?

[Vercel e2e deploy](https://nextjs-highlight-demo-p1480gm3t-highlight-run.vercel.app/) & click testing for error ingestion.
![Screenshot from 2023-11-29 00-07-56](https://github.com/highlight/highlight/assets/1351531/e0a767c7-237b-468d-9954-90694b7384e9)

with fix in https://github.com/highlight/highlight/pull/7195/commits/5e3054854c2c067fac6b234ed23a87a3ea696da4
![Screenshot from 2023-11-29 00-15-41](https://github.com/highlight/highlight/assets/1351531/a7f06f29-650b-48a6-b7fe-b516d4056bae)


## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
