### PR TITLE
Improve default privacy mode

### DIFF
--- a/.changeset/empty-cherries-pay.md
+++ b/.changeset/empty-cherries-pay.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+Update default privacy mode to obfuscate all inputs by default. Allow user to override ofuscation with data-hl-record attribute. Fix regex expressions for telephone numbers and addresses.

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -441,6 +441,7 @@ export const Search: React.FC<{
 					style={{
 						paddingLeft: hideIcon ? undefined : 40,
 					}}
+					data-hl-record
 				/>
 
 				{isDirty && !disableSearch && (

--- a/sdk/client/src/utils/privacy.ts
+++ b/sdk/client/src/utils/privacy.ts
@@ -1,53 +1,6 @@
 import { MaskInputOptions } from '@highlight-run/rrweb-snapshot'
 import { PrivacySettingOption } from '../types/types'
 
-const DEFAULT_MASK_INPUT_OPTIONS: MaskInputOptions = {
-	password: true,
-	email: true,
-	tel: true,
-	name: true,
-	'given-name': true,
-	'family-name': true,
-	'additional-name': true,
-	'one-time-code': true,
-	'street-address': true,
-	address: true,
-	'address-line1': true,
-	'address-line2': true,
-	'address-line3': true,
-	'address-level4': true,
-	'address-level3': true,
-	'address-level2': true,
-	'address-level1': true,
-	city: true,
-	state: true,
-	country: true,
-	zip: true,
-	'country-name': true,
-	'postal-code': true,
-	'cc-name': true,
-	'cc-given-name': true,
-	'cc-additional-name': true,
-	'cc-family-name': true,
-	'cc-number': true,
-	'cc-exp': true,
-	'cc-exp-month': true,
-	'cc-exp-year': true,
-	'cc-csc': true,
-	'cc-type': true,
-	bday: true,
-	'bday-day': true,
-	'bday-month': true,
-	'bday-year': true,
-	sex: true,
-	'tel-country-code': true,
-	'tel-national': true,
-	'tel-area-code': true,
-	'tel-local': true,
-	'tel-extension': true,
-	ssn: true,
-}
-
 // returns (1) whether all inputs should be masked and (2) which inputs should be masked
 export const determineMaskInputOptions = (
 	privacyPolicy: PrivacySettingOption,
@@ -56,7 +9,7 @@ export const determineMaskInputOptions = (
 		case 'strict':
 			return [true, undefined]
 		case 'default':
-			return [false, DEFAULT_MASK_INPUT_OPTIONS]
+			return [true, undefined]
 		case 'none': {
 			return [false, { password: true }]
 		}


### PR DESCRIPTION
## Summary
Default privacy mode is missing a few fields and inputs. More aggressively obfuscate these fields for default privacy mode:
- obfuscate all inputs
- allow inputs to be recorded with `data-hl-record` attribute

## How did you test this change?
1) Set the privacy mode of the Highlight app to be "default"
2) Click around the app, touch inputs and fields
3) Close out session
4) View session

https://www.loom.com/share/2473e236e70b424c9779ff76a242edec?sid=0707d37e-8799-4740-946a-191dcb8dc0cf

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
