### PR TITLE
Add Tunnelmole as an open source local testing option

### DIFF
--- a/backend/vercel/README.md
+++ b/backend/vercel/README.md
@@ -1,8 +1,34 @@
 ## Testing locally
 
-Start ngrok: `ngrok http https://localhost:8082`
+Use either [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client), an open source tunneling tool, or ngrok, a popular closed source tunnelling tool, to start your local server.
 
-Grab the generated URL, example: `https://c0fd-75-166-97-48.ngrok-free.app`
+#### With Tunnelmole
+
+Install Tunnelmole with one of the following options:
+- NPM:  `npm install -g tunnelmole`
+- Linux: `curl -s https://tunnelmole.com/sh/install-linux.sh | sudo bash`
+- Mac:  `curl -s https://tunnelmole.com/sh/install-mac.sh --output install-mac.sh && sudo bash install-mac.sh`
+- Windows: Install with NPM, or if you don't have NodeJS installed, download the `exe` file for Windows [here](https://tunnelmole.com/downloads/tmole.exe) and put it somewhere in your PATH.
+
+Then, start Tunnelmole using:
+
+`tmole 8082`
+
+Grab the generated URL. For example:
+
+`https://bvdo5f-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:8082`
+
+#### With ngrok
+
+Start ngrok:
+
+`ngrok http https://localhost:8082`
+
+Grab the generated URL. For example:
+
+`https://c0fd-75-166-97-48.ngrok-free.app`
+
+## Modifications
 
 Modify the projectID check in `vercel.HandleLog`
 
@@ -25,6 +51,7 @@ Modify the projectID check in `vercel.HandleLog`
 +       projectID := 3
 ```
 
+## Setting up logs
 
 Set up a log drain using the following config
 


### PR DESCRIPTION
This PR adds [Tunnelmole](https://github.com/robbie-cahill/tunnelmole-client) as an open source local testing option.

Tunnelmole is a FOSS tunneling solution with a growing community. It works out of the box and can be optionally self hosted with the [Tunnelmole Service](https://github.com/robbie-cahill/tunnelmole-service). Both the client and service are open source.

Example:
```
➜  ~ tmole 8000
http://bvdo5f-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:8000
https://bvdo5f-ip-49-183-170-144.tunnelmole.net is forwarding to localhost:8000
```