### PR TITLE
Add manual css vendor prefixing for harold gradient

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6143,6 +6143,8 @@ body {
   inset: 0;
   mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
   mask-composite: exclude;
+  -webkit-mask: linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
   position: absolute;
   z-index: -1;
 }

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/AiErrorSuggestion.css.ts
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/AiErrorSuggestion.css.ts
@@ -20,6 +20,10 @@ export const aiSuggestion = style({
 			inset: 0,
 			mask: 'linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0)',
 			maskComposite: 'exclude',
+			// Manual vendor prefixing for Reflame css bundle
+			WebkitMask:
+				'linear-gradient(#fff 0 0) padding-box, linear-gradient(#fff 0 0)',
+			WebkitMaskComposite: 'xor',
 			position: 'absolute',
 			zIndex: -1,
 		},


### PR DESCRIPTION
## Summary

<img width="1357" alt="Screenshot 2023-11-27 at 9 30 30 AM" src="https://github.com/highlight/highlight/assets/6934200/bffbe6a0-67ed-4ffb-8b94-d0aded9c4d0d">


<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
