### PR TITLE
Fix traversal order for reflame vanilla extract script

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -1,24 +1,4 @@
-/* vanilla-extract-css-ns:src/components/Button/style.css.ts.vanilla.css?source=QGtleWZyYW1lcyBfMXdkaDNzajAgewogIDAlIHsKICAgIHRyYW5zZm9ybTogcm90YXRlKDBkZWcpOwogIH0KICAxMDAlIHsKICAgIHRyYW5zZm9ybTogcm90YXRlKDM2MGRlZyk7CiAgfQp9Ci5fMXdkaDNzajEgewogIGFuaW1hdGlvbi1uYW1lOiBfMXdkaDNzajA7CiAgYW5pbWF0aW9uLWR1cmF0aW9uOiAxczsKICBhbmltYXRpb24taXRlcmF0aW9uLWNvdW50OiBpbmZpbml0ZTsKICBhbmltYXRpb24tdGltaW5nLWZ1bmN0aW9uOiBsaW5lYXI7Cn0= */
-@keyframes _1wdh3sj0 {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-._1wdh3sj1 {
-  animation-name: _1wdh3sj0;
-  animation-duration: 1s;
-  animation-iteration-count: infinite;
-  animation-timing-function: linear;
-}
-._2hsj210 {
-  margin-bottom: 6px;
-}
-._2hsj211 {
-  width: 100%;
-}
+/* vanilla-extract-css-ns:../packages/ui/src/css/theme.css.ts.vanilla.css?source=#H4sIAAAAAAAAE41V227bMAx931cY6MsGJIWoiyV1HzPYlpSk1yTNuqbD/n2kHRcQawIJED8ckxJ5eA59u91tto/4P62n52mbn3Lz91vTrNe/YH8+PHRR3TU3JZWhpJ8VDoSPvxrXhMcSSqxxQ7gtutgat3fNcdN333W7ajSsGuNWjbr1+kcd5jA9pWIyS2/HMvLQDzXuJ9xlV+MB8ZyyL7nGI+EZ37B2OsShA6dNjffXlT1gelva7H2Np0s6AOYCKHpEOiGwAzLdH3y0rN6CeJecV6rGN4gPSfcGanxLhRjbdqy/HcWHwQ99jd8T30PqExv7A/HU55hZ/CPi3tqc2Hye6N7e4g01/izU8/JJDBLrA5GriRdtGTF7QX+HywEG08YzPKWblqUfhftfBR2cCI855K7GfxNus+a6fBPk/uc63bwLYzkLevqgMpwNlrtUjXM0yTL9AghCAT1XqFGQXs8MfhkAGGECMFvaYY+kaq0XRwBOKmEyda81Iw8mV3cKmNthtHWOeBh7EeduHBINJCjTLrdDTsdBKsUWF8xWH5OxlbjczSA4EtDrN0Z1tuVFk7d1jL7lbRbB9LC5lGIDidviQ4XlbrbScHYzISg+h3vHhOV27qUaaAOkOCS+4IFWwBD7WLjUaAd0JYbMCXieTKK+FPkibB/YC76Ag/TiKBgRXmciDOpbG6RDO0tcKE7FSfhmwGh+j7uCN/Z29dmf+4DmcAmPi5HvwmaCs7Ca4OPas7WSIlsuLA1SaKDQf/8BMFngD1QIAAA= */
 .highlight-light-theme {
   --_1pyqka90: #fdfcfd;
   --_1pyqka91: #ffffff;
@@ -94,101 +74,6 @@
   --_1pyqka91z: rgba(238, 237, 239, 0.0);
   --_1pyqka920: rgba(238, 237, 239, 0.64);
   --_1pyqka921: rgba(238, 237, 239, 0.84);
-}
-._17v45he0 {
-  border-radius: 6px;
-  border: var(--_1pyqka91o) solid 1px;
-  cursor: pointer;
-  display: block;
-  padding: 4px 6px;
-  font-size: 13px;
-  color: var(--_1pyqka9c);
-  outline: 0;
-  width: 100%;
-  appearance: none;
-  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="1.1em" height="1.1em" fill="none" viewBox="0 0 20 20" focusable="false" > <path fill="grey" fillRule="evenodd" d="M5.293 7.293a1 1 0 0 1 1.414 0L10 10.586l3.293-3.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 0-1.414Z" clipRule="evenodd" /> </svg>');
-  background-repeat: no-repeat;
-  background-position: right 6px center;
-}
-._17v45he0::placeholder {
-  color: var(--_1pyqka9x);
-}
-._17v45he0:disabled {
-  background: #e9e8ea;
-}
-._17v45he0:focus {
-  border: var(--_1pyqka91q) solid 1px;
-}
-._17v45he1 {
-  border-top: 0;
-}
-._17v45he1:focus,
-._17v45he1:hover {
-  border-top: 0 !important;
-}
-._1ta0zd10 {
-  width: 280px;
-}
-.u25ybo0 {
-  width: 100%;
-}
-.ti67jy0 {
-  padding: 2px 4px;
-  background: #eeedef;
-  box-shadow: inset 0 -1px #0000001a;
-  border: none;
-  border-radius: 5px;
-}
-.ti67jy1 {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-.ti67jy2 {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-.ti67jy3 {
-  display: inline-flex;
-  height: 20px;
-}
-.ti67jy4 {
-  padding: 2px 4px;
-  border: none;
-  border-radius: 5px;
-}
-.ti67jy5 {
-  word-break: normal;
-  white-space: nowrap;
-}
-.ti67jy6 {
-  flex-shrink: 0;
-}
-.ti67jy7 {
-  max-width: 50%;
-}
-.ti67jy8 {
-  align-items: center;
-  display: flex;
-  overflow: hidden;
-  position: relative;
-  text-overflow: ellipsis;
-  width: 100%;
-  padding: 0;
-  color: #6f6e77;
-  gap: 6px;
-  font-weight: 500;
-}
-.ti67jy9 {
-  background-color: #ffffff;
-  border: var(--_1pyqka91o) solid 1px;
-  border-radius: 6px;
-  min-width: 150px;
-  z-index: 10;
-  max-width: 50vw;
-}
-.ti67jya {
-  height: 20px;
-  pointer-events: none;
 }
 .mt0ih20 {
   align-items: stretch;
@@ -3490,281 +3375,6 @@
     gap: 40px;
   }
 }
-._1ek953u0 {
-  z-index: 99999;
-  height: 100vh;
-  width: 100vw;
-  display: flex;
-  justify-content: center;
-  position: fixed;
-  top: 0;
-  left: 0;
-}
-._1ek953u1 {
-  background-color: rgba(111, 110, 119, 0.48);
-  z-index: 99999;
-}
-._1ek953u2 {
-  width: 580px;
-  top: 25vh;
-}
-._1ek953u3 {
-  width: 100%;
-}
-._1ek953u4 {
-  flex-shrink: 0;
-}
-._1ek953u5 {
-  flex-shrink: 0;
-}
-._1ek953u6 {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-._1ek953u7 {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-}
-._1ek953u8 {
-  flex: 1;
-}
-._1ek953u9:hover {
-  cursor: pointer;
-}
-.bsyaa20 {
-  text-decoration: none;
-  color: var(--_1pyqka9y);
-}
-.bsyaa20:hover {
-  color: var(--_1pyqka9y);
-}
-.bsyaa21 {
-  margin-left: 4px;
-  padding-left: 4px;
-  padding-right: 4px;
-  background-color: #e7defc;
-  color: #6346af;
-  font-size: 11px;
-  height: 16px;
-  line-height: 16px;
-  border-radius: 3px;
-  align-self: center;
-}
-._1kpm5g60 {
-  text-decoration: none;
-}
-._1kpm5g60:focus-visible {
-  outline: revert !important;
-}
-._1vb6x0p0 {
-  text-decoration: none;
-  color: var(--_1pyqka9y);
-}
-._1vb6x0p0:hover {
-  color: var(--_1pyqka9y);
-}
-._1ukfp2a0 {
-  border-radius: 0;
-  border: 0 !important;
-}
-._1ukfp2a0:focus,
-._1ukfp2a0:active {
-  background: inherit;
-}
-._1ukfp2a1 {
-  border-right: var(--_1pyqka91o) solid 1px !important;
-}
-._1ukfp2a2 {
-  background: var(--_1pyqka9t);
-}
-._1ukfp2a2:focus,
-._1ukfp2a2:active {
-  background: var(--_1pyqka9u);
-}
-._1hht64e1 {
-  height: 20px;
-}
-._1hht64e2 {
-  color: var(--_1pyqka9b) !important;
-}
-._1hht64e2:hover {
-  background: var(--_1pyqka91x);
-}
-._1hht64e2 .ant-select-selector {
-  padding: 0 6px !important;
-  border-radius: 6px !important;
-  border: var(--_1pyqka91o) solid 1px !important;
-  box-shadow: none !important;
-}
-._1hht64e2 .ant-select-selector:hover {
-  background: var(--_1pyqka91x) !important;
-}
-._1hht64e2 .ant-select-selection-item {
-  display: flex;
-  align-items: center;
-}
-._9wfl880 {
-  font-size: 36px;
-  font-weight: 700 !important;
-  color: var(--_1pyqka9b);
-}
-._9wfl880:focus {
-  outline: 0;
-}
-._9wfl880::placeholder {
-  color: var(--_1pyqka9x);
-}
-._4ocsjw0 {
-  height: 40px;
-}
-._4ocsjw1 {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: auto auto;
-  grid-column-gap: 40px;
-  grid-row-gap: 40px;
-}
-._4ocsjw5 {
-  border: 0;
-  background: transparent;
-  color: var(--_1pyqka9b);
-  display: flex;
-  font-size: 13px;
-  width: 100%;
-}
-._4ocsjw5:focus {
-  outline: 0;
-}
-._4ocsjw5::placeholder {
-  color: var(--_1pyqka9x);
-}
-._4ocsjw7 {
-  height: 20px;
-}
-._4ocsjw9 {
-  height: 20px;
-}
-._4ocsjwa {
-  color: var(--_1pyqka9b) !important;
-}
-._4ocsjwa:hover {
-  background: var(--_1pyqka91x);
-}
-._4ocsjwa .ant-select-selector {
-  padding: 0 6px !important;
-  border-radius: 6px !important;
-  border: var(--_1pyqka91o) solid 1px !important;
-  box-shadow: none !important;
-}
-._4ocsjwa .ant-select-selector:hover {
-  background: var(--_1pyqka91x) !important;
-}
-._4ocsjwa .ant-select-selection-item {
-  display: flex;
-  align-items: center;
-}
-._1un2bsj0 {
-  height: 40px;
-}
-._1un2bsj1 {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: auto auto;
-  grid-column-gap: 40px;
-  grid-row-gap: 40px;
-}
-._1un2bsj5 {
-  border: 0;
-  background: transparent;
-  color: var(--_1pyqka9b);
-  display: flex;
-  font-size: 13px;
-  width: 100%;
-}
-._1un2bsj5:focus {
-  outline: 0;
-}
-._1un2bsj5::placeholder {
-  color: var(--_1pyqka9x);
-}
-._1un2bsj7 {
-  height: 20px;
-}
-._1un2bsj9 {
-  height: 20px;
-}
-._1un2bsja {
-  color: var(--_1pyqka9b) !important;
-}
-._1un2bsja:hover {
-  background: var(--_1pyqka91x);
-}
-._1un2bsja .ant-select-selector {
-  padding: 0 6px !important;
-  border-radius: 6px !important;
-  border: var(--_1pyqka91o) solid 1px !important;
-  box-shadow: none !important;
-}
-._1un2bsja .ant-select-selector:hover {
-  background: var(--_1pyqka91x) !important;
-}
-._1un2bsja .ant-select-selection-item {
-  display: flex;
-  align-items: center;
-}
-@keyframes _5ouxf40 {
-  0% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-._155k3sw0 {
-  height: 4.16rem;
-}
-._155k3sw1 {
-  height: 120px;
-}
-._155k3sw2 {
-  height: 98px;
-}
-._155k3sw3 {
-  cursor: pointer;
-}
-._155k3sw3:hover {
-  background-color: var(--_1pyqka91x);
-}
-._155k3sw4 {
-  background-color: var(--_1pyqka91);
-  z-index: 10 !important;
-  border: var(--_1pyqka9j) solid 1px;
-  box-shadow: 0 6px 12px -2px rgba(59, 59, 59, 0.12);
-  border-radius: 6px;
-  width: 224px;
-}
-._155k3sw5 {
-  height: 28px;
-}
-._155k3sw6 {
-  background-color: #dcdbdd;
-  opacity: 0.5;
-}
-._155k3sw7 {
-  opacity: 0.2;
-  left: 0;
-  width: calc(100% - 4px);
-  pointer-events: none;
-}
-._155k3sw8 {
-  animation: _5ouxf40;
-  animation-duration: 1.25s;
-  animation-iteration-count: infinite;
-  animation-timing-function: ease-out;
-}
 ._19y1zt60 {
   -ms-overflow-style: none;
   scrollbar-width: none;
@@ -5803,6 +5413,396 @@ body {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
   row-gap: 0.5rem;
+}
+@keyframes _1wdh3sj0 {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+._1wdh3sj1 {
+  animation-name: _1wdh3sj0;
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+  animation-timing-function: linear;
+}
+._2hsj210 {
+  margin-bottom: 6px;
+}
+._2hsj211 {
+  width: 100%;
+}
+._17v45he0 {
+  border-radius: 6px;
+  border: var(--_1pyqka91o) solid 1px;
+  cursor: pointer;
+  display: block;
+  padding: 4px 6px;
+  font-size: 13px;
+  color: var(--_1pyqka9c);
+  outline: 0;
+  width: 100%;
+  appearance: none;
+  background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="1.1em" height="1.1em" fill="none" viewBox="0 0 20 20" focusable="false" > <path fill="grey" fillRule="evenodd" d="M5.293 7.293a1 1 0 0 1 1.414 0L10 10.586l3.293-3.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 0-1.414Z" clipRule="evenodd" /> </svg>');
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+}
+._17v45he0::placeholder {
+  color: var(--_1pyqka9x);
+}
+._17v45he0:disabled {
+  background: #e9e8ea;
+}
+._17v45he0:focus {
+  border: var(--_1pyqka91q) solid 1px;
+}
+._17v45he1 {
+  border-top: 0;
+}
+._17v45he1:focus,
+._17v45he1:hover {
+  border-top: 0 !important;
+}
+._1ta0zd10 {
+  width: 280px;
+}
+.u25ybo0 {
+  width: 100%;
+}
+.ti67jy0 {
+  padding: 2px 4px;
+  background: #eeedef;
+  box-shadow: inset 0 -1px #0000001a;
+  border: none;
+  border-radius: 5px;
+}
+.ti67jy1 {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.ti67jy2 {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.ti67jy3 {
+  display: inline-flex;
+  height: 20px;
+}
+.ti67jy4 {
+  padding: 2px 4px;
+  border: none;
+  border-radius: 5px;
+}
+.ti67jy5 {
+  word-break: normal;
+  white-space: nowrap;
+}
+.ti67jy6 {
+  flex-shrink: 0;
+}
+.ti67jy7 {
+  max-width: 50%;
+}
+.ti67jy8 {
+  align-items: center;
+  display: flex;
+  overflow: hidden;
+  position: relative;
+  text-overflow: ellipsis;
+  width: 100%;
+  padding: 0;
+  color: #6f6e77;
+  gap: 6px;
+  font-weight: 500;
+}
+.ti67jy9 {
+  background-color: #ffffff;
+  border: var(--_1pyqka91o) solid 1px;
+  border-radius: 6px;
+  min-width: 150px;
+  z-index: 10;
+  max-width: 50vw;
+}
+.ti67jya {
+  height: 20px;
+  pointer-events: none;
+}
+._1ek953u0 {
+  z-index: 99999;
+  height: 100vh;
+  width: 100vw;
+  display: flex;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+}
+._1ek953u1 {
+  background-color: rgba(111, 110, 119, 0.48);
+  z-index: 99999;
+}
+._1ek953u2 {
+  width: 580px;
+  top: 25vh;
+}
+._1ek953u3 {
+  width: 100%;
+}
+._1ek953u4 {
+  flex-shrink: 0;
+}
+._1ek953u5 {
+  flex-shrink: 0;
+}
+._1ek953u6 {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+._1ek953u7 {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+._1ek953u8 {
+  flex: 1;
+}
+._1ek953u9:hover {
+  cursor: pointer;
+}
+.bsyaa20 {
+  text-decoration: none;
+  color: var(--_1pyqka9y);
+}
+.bsyaa20:hover {
+  color: var(--_1pyqka9y);
+}
+.bsyaa21 {
+  margin-left: 4px;
+  padding-left: 4px;
+  padding-right: 4px;
+  background-color: #e7defc;
+  color: #6346af;
+  font-size: 11px;
+  height: 16px;
+  line-height: 16px;
+  border-radius: 3px;
+  align-self: center;
+}
+._1kpm5g60 {
+  text-decoration: none;
+}
+._1kpm5g60:focus-visible {
+  outline: revert !important;
+}
+._1vb6x0p0 {
+  text-decoration: none;
+  color: var(--_1pyqka9y);
+}
+._1vb6x0p0:hover {
+  color: var(--_1pyqka9y);
+}
+._1ukfp2a0 {
+  border-radius: 0;
+  border: 0 !important;
+}
+._1ukfp2a0:focus,
+._1ukfp2a0:active {
+  background: inherit;
+}
+._1ukfp2a1 {
+  border-right: var(--_1pyqka91o) solid 1px !important;
+}
+._1ukfp2a2 {
+  background: var(--_1pyqka9t);
+}
+._1ukfp2a2:focus,
+._1ukfp2a2:active {
+  background: var(--_1pyqka9u);
+}
+._1hht64e1 {
+  height: 20px;
+}
+._1hht64e2 {
+  color: var(--_1pyqka9b) !important;
+}
+._1hht64e2:hover {
+  background: var(--_1pyqka91x);
+}
+._1hht64e2 .ant-select-selector {
+  padding: 0 6px !important;
+  border-radius: 6px !important;
+  border: var(--_1pyqka91o) solid 1px !important;
+  box-shadow: none !important;
+}
+._1hht64e2 .ant-select-selector:hover {
+  background: var(--_1pyqka91x) !important;
+}
+._1hht64e2 .ant-select-selection-item {
+  display: flex;
+  align-items: center;
+}
+._9wfl880 {
+  font-size: 36px;
+  font-weight: 700 !important;
+  color: var(--_1pyqka9b);
+}
+._9wfl880:focus {
+  outline: 0;
+}
+._9wfl880::placeholder {
+  color: var(--_1pyqka9x);
+}
+._4ocsjw0 {
+  height: 40px;
+}
+._4ocsjw1 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto;
+  grid-column-gap: 40px;
+  grid-row-gap: 40px;
+}
+._4ocsjw5 {
+  border: 0;
+  background: transparent;
+  color: var(--_1pyqka9b);
+  display: flex;
+  font-size: 13px;
+  width: 100%;
+}
+._4ocsjw5:focus {
+  outline: 0;
+}
+._4ocsjw5::placeholder {
+  color: var(--_1pyqka9x);
+}
+._4ocsjw7 {
+  height: 20px;
+}
+._4ocsjw9 {
+  height: 20px;
+}
+._4ocsjwa {
+  color: var(--_1pyqka9b) !important;
+}
+._4ocsjwa:hover {
+  background: var(--_1pyqka91x);
+}
+._4ocsjwa .ant-select-selector {
+  padding: 0 6px !important;
+  border-radius: 6px !important;
+  border: var(--_1pyqka91o) solid 1px !important;
+  box-shadow: none !important;
+}
+._4ocsjwa .ant-select-selector:hover {
+  background: var(--_1pyqka91x) !important;
+}
+._4ocsjwa .ant-select-selection-item {
+  display: flex;
+  align-items: center;
+}
+._1un2bsj0 {
+  height: 40px;
+}
+._1un2bsj1 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto;
+  grid-column-gap: 40px;
+  grid-row-gap: 40px;
+}
+._1un2bsj5 {
+  border: 0;
+  background: transparent;
+  color: var(--_1pyqka9b);
+  display: flex;
+  font-size: 13px;
+  width: 100%;
+}
+._1un2bsj5:focus {
+  outline: 0;
+}
+._1un2bsj5::placeholder {
+  color: var(--_1pyqka9x);
+}
+._1un2bsj7 {
+  height: 20px;
+}
+._1un2bsj9 {
+  height: 20px;
+}
+._1un2bsja {
+  color: var(--_1pyqka9b) !important;
+}
+._1un2bsja:hover {
+  background: var(--_1pyqka91x);
+}
+._1un2bsja .ant-select-selector {
+  padding: 0 6px !important;
+  border-radius: 6px !important;
+  border: var(--_1pyqka91o) solid 1px !important;
+  box-shadow: none !important;
+}
+._1un2bsja .ant-select-selector:hover {
+  background: var(--_1pyqka91x) !important;
+}
+._1un2bsja .ant-select-selection-item {
+  display: flex;
+  align-items: center;
+}
+@keyframes _5ouxf40 {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+._155k3sw0 {
+  height: 4.16rem;
+}
+._155k3sw1 {
+  height: 120px;
+}
+._155k3sw2 {
+  height: 98px;
+}
+._155k3sw3 {
+  cursor: pointer;
+}
+._155k3sw3:hover {
+  background-color: var(--_1pyqka91x);
+}
+._155k3sw4 {
+  background-color: var(--_1pyqka91);
+  z-index: 10 !important;
+  border: var(--_1pyqka9j) solid 1px;
+  box-shadow: 0 6px 12px -2px rgba(59, 59, 59, 0.12);
+  border-radius: 6px;
+  width: 224px;
+}
+._155k3sw5 {
+  height: 28px;
+}
+._155k3sw6 {
+  background-color: #dcdbdd;
+  opacity: 0.5;
+}
+._155k3sw7 {
+  opacity: 0.2;
+  left: 0;
+  width: calc(100% - 4px);
+  pointer-events: none;
+}
+._155k3sw8 {
+  animation: _5ouxf40;
+  animation-duration: 1.25s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-out;
 }
 ._14ud0dc0::-webkit-scrollbar {
   width: 9px;


### PR DESCRIPTION
## Summary

The changes I made in https://github.com/highlight/highlight/pull/7204 ended up subtly changing the traversal order for vanilla extract CSS, because we were ignoring UI package entry points on the 1st pass JS traversal (through the externals option), and only encountering them on the individual traversals for vanilla extract css compilation. This lead to the CSS classes output also being subtly out-of-order.

This PR removes the externals for `@highlight-run/ui` so we traverse vanilla extract scripts in the exact order they're encountered in the JS dependency graph.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
