### PR TITLE
correct graduated pricing frontend calculation

### DIFF
--- a/frontend/src/pages/Billing/UpdatePlanPage.tsx
+++ b/frontend/src/pages/Billing/UpdatePlanPage.tsx
@@ -91,23 +91,35 @@ const UNIT_QUANTITY = {
 
 export const getCostCents = (
 	productType: ProductType,
-	rateCents: number | undefined,
+	rate: number | undefined,
 	retentionPeriod: RetentionPeriod,
 	quantity: number,
 	includedQuantity: number,
 ): number => {
-	const unitCost = BASE_UNIT_COST_CENTS[productType]
-	return Math.floor(
-		((rateCents || unitCost) *
+	if (!rate) {
+		rate = BASE_UNIT_COST_CENTS[productType] / UNIT_QUANTITY[productType]
+	}
+	const result = Math.floor(
+		rate *
 			RETENTION_MULTIPLIER[retentionPeriod] *
-			Math.max(quantity - includedQuantity, 0)) /
-			UNIT_QUANTITY[productType],
+			Math.max(quantity - includedQuantity, 0),
 	)
+	console.log('vadim', {
+		result,
+		productType,
+		rate,
+		retentionPeriod,
+		quantity,
+		includedQuantity,
+		unit: UNIT_QUANTITY[productType],
+		ret: RETENTION_MULTIPLIER[retentionPeriod],
+	})
+	return result
 }
 
 export const getQuantity = (
 	productType: ProductType,
-	rateCents: number | undefined,
+	rate: number | undefined,
 	retentionPeriod: RetentionPeriod,
 	totalCents: number | undefined,
 	includedQuantity: number,
@@ -116,12 +128,12 @@ export const getQuantity = (
 		return undefined
 	}
 
-	const unitCost = BASE_UNIT_COST_CENTS[productType]
+	if (!rate) {
+		rate = BASE_UNIT_COST_CENTS[productType] / UNIT_QUANTITY[productType]
+	}
 	return Math.floor(
-		(totalCents * UNIT_QUANTITY[productType]) /
-			((rateCents || unitCost) *
-				100 *
-				RETENTION_MULTIPLIER[retentionPeriod]) +
+		((totalCents / 100) * UNIT_QUANTITY[productType]) /
+			(rate * RETENTION_MULTIPLIER[retentionPeriod]) +
 			includedQuantity,
 	)
 }

--- a/highlight.io/pages/pricing/index.tsx
+++ b/highlight.io/pages/pricing/index.tsx
@@ -249,6 +249,121 @@ const retentionMultipliers: Record<Retention, number> = {
 	'2 years': 2.5,
 } as const
 
+interface GraduatedPriceItem {
+	rate: number
+	usage?: number
+}
+const prices = {
+	Sessions: {
+		free: 500,
+		unit: 1_000,
+		items: [
+			{
+				usage: 15_000,
+				rate: 20 / 1_000,
+			},
+			{
+				usage: 50_000,
+				rate: 15 / 1_000,
+			},
+			{
+				usage: 150_000,
+				rate: 12 / 1_000,
+			},
+			{
+				usage: 500_000,
+				rate: 6.5 / 1_000,
+			},
+			{
+				usage: 1_000_000,
+				rate: 3.5 / 1_000,
+			},
+			{
+				rate: 2.5 / 1_000,
+			},
+		] as GraduatedPriceItem[],
+	},
+	Errors: {
+		free: 1_000,
+		unit: 1_000,
+		items: [
+			{
+				usage: 50_000,
+				rate: 2 / 1_000,
+			},
+			{
+				usage: 100_000,
+				rate: 0.5 / 1_000,
+			},
+			{
+				usage: 200_000,
+				rate: 0.25 / 1_000,
+			},
+			{
+				usage: 500_000,
+				rate: 0.2 / 1_000,
+			},
+			{
+				usage: 5_000_000,
+				rate: 0.1 / 1_000,
+			},
+			{
+				rate: 0.05 / 1_000,
+			},
+		] as GraduatedPriceItem[],
+	},
+	Logs: {
+		free: 1_000_000,
+		unit: 1_000_000,
+		items: [
+			{
+				usage: 1_000_000,
+				rate: 2.5 / 1_000_000,
+			},
+			{
+				usage: 10_000_000,
+				rate: 2 / 1_000_000,
+			},
+			{
+				usage: 100_000_000,
+				rate: 1.5 / 1_000_000,
+			},
+			{
+				usage: 1_000_000_000,
+				rate: 1 / 1_000_000,
+			},
+			{
+				rate: 0.5 / 1_000_000,
+			},
+		] as GraduatedPriceItem[],
+	},
+	Traces: {
+		free: 25_000_000,
+		unit: 1_000_000,
+		items: [
+			{
+				usage: 1_000_000,
+				rate: 2.5 / 1_000_000,
+			},
+			{
+				usage: 10_000_000,
+				rate: 2 / 1_000_000,
+			},
+			{
+				usage: 100_000_000,
+				rate: 1.5 / 1_000_000,
+			},
+			{
+				usage: 1_000_000_000,
+				rate: 1 / 1_000_000,
+			},
+			{
+				rate: 0.5 / 1_000_000,
+			},
+		] as GraduatedPriceItem[],
+	},
+} as const
+
 const tierOptions = ['Free', 'UsageBased', 'Enterprise'] as const
 type TierName = typeof tierOptions[number]
 
@@ -269,16 +384,16 @@ const priceTiers: Record<TierName, PricingTier> = {
 		label: 'Free forever',
 		features: [
 			{
-				feature: '500 monthly sessions',
+				feature: `${prices.Sessions.free.toLocaleString()} monthly sessions`,
 			},
 			{
-				feature: '1,000 monthly errors',
+				feature: `${prices.Errors.free.toLocaleString()} monthly errors`,
 			},
 			{
-				feature: '1,000,000 monthly logs',
+				feature: `${prices.Logs.free.toLocaleString()} monthly logs`,
 			},
 			{
-				feature: '1,000,000 monthly traces',
+				feature: `${prices.Traces.free.toLocaleString()} monthly traces`,
 			},
 			{
 				feature: 'Unlimited seats',
@@ -291,16 +406,16 @@ const priceTiers: Record<TierName, PricingTier> = {
 		label: 'Pay as you go',
 		features: [
 			{
-				feature: '500+ monthly sessions',
+				feature: `${prices.Sessions.free.toLocaleString()}+ monthly sessions`,
 			},
 			{
-				feature: '1,000+ monthly errors',
+				feature: `${prices.Errors.free.toLocaleString()}+ monthly errors`,
 			},
 			{
-				feature: '1,000,000+ monthly logs',
+				feature: `${prices.Logs.free.toLocaleString()}+ monthly logs`,
 			},
 			{
-				feature: '1,000,000+ monthly traces',
+				feature: `${prices.Traces.free.toLocaleString()}+ monthly traces`,
 			},
 			{
 				feature: 'Unlimited seats',
@@ -442,121 +557,6 @@ const PlanTier = ({ name, tier }: { name: string; tier: PricingTier }) => {
 		</div>
 	)
 }
-
-interface GraduatedPriceItem {
-	rate: number
-	usage?: number
-}
-const prices = {
-	Sessions: {
-		free: 500,
-		unit: 1_000,
-		items: [
-			{
-				usage: 15_000,
-				rate: 20 / 1_000,
-			},
-			{
-				usage: 50_000,
-				rate: 15 / 1_000,
-			},
-			{
-				usage: 150_000,
-				rate: 12 / 1_000,
-			},
-			{
-				usage: 500_000,
-				rate: 6.5 / 1_000,
-			},
-			{
-				usage: 1_000_000,
-				rate: 3.5 / 1_000,
-			},
-			{
-				rate: 2.5 / 1_000,
-			},
-		] as GraduatedPriceItem[],
-	},
-	Errors: {
-		free: 1_000,
-		unit: 1_000,
-		items: [
-			{
-				usage: 50_000,
-				rate: 2 / 1_000,
-			},
-			{
-				usage: 100_000,
-				rate: 0.5 / 1_000,
-			},
-			{
-				usage: 200_000,
-				rate: 0.25 / 1_000,
-			},
-			{
-				usage: 500_000,
-				rate: 0.2 / 1_000,
-			},
-			{
-				usage: 5_000_000,
-				rate: 0.1 / 1_000,
-			},
-			{
-				rate: 0.05 / 1_000,
-			},
-		] as GraduatedPriceItem[],
-	},
-	Logs: {
-		free: 1_000_000,
-		unit: 1_000_000,
-		items: [
-			{
-				usage: 1_000_000,
-				rate: 2.5 / 1_000_000,
-			},
-			{
-				usage: 10_000_000,
-				rate: 2 / 1_000_000,
-			},
-			{
-				usage: 100_000_000,
-				rate: 1.5 / 1_000_000,
-			},
-			{
-				usage: 1_000_000_000,
-				rate: 1 / 1_000_000,
-			},
-			{
-				rate: 0.5 / 1_000_000,
-			},
-		] as GraduatedPriceItem[],
-	},
-	Traces: {
-		free: 25_000_000,
-		unit: 1_000_000,
-		items: [
-			{
-				usage: 1_000_000,
-				rate: 2.5 / 1_000_000,
-			},
-			{
-				usage: 10_000_000,
-				rate: 2 / 1_000_000,
-			},
-			{
-				usage: 100_000_000,
-				rate: 1.5 / 1_000_000,
-			},
-			{
-				usage: 1_000_000_000,
-				rate: 1 / 1_000_000,
-			},
-			{
-				rate: 0.5 / 1_000_000,
-			},
-		] as GraduatedPriceItem[],
-	},
-} as const
 
 const formatNumber = (num: number, digits?: number) => {
 	let si = [


### PR DESCRIPTION
## Summary

Graduated cost estimates on the frontend were off
due to an issue with how we were calculating unit costs.

Updates the highlight.io pricing page free tier values as well.

## How did you test this change?

Reflame

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No