### PR TITLE
support selecting a random subset of sessions

### DIFF
--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -265,7 +265,7 @@ func getSessionsQueryImpl(admin *model.Admin, query modelInputs.ClickhouseQuery,
 		if err != nil {
 			return "", nil, false, err
 		}
-		selectColumns = fmt.Sprintf("%s, farmHash64(SecureID) %% %d as hash", selectColumns, salt)
+		selectColumns = fmt.Sprintf("%s, toUInt64(farmHash64(SecureID) %% %d) as hash", selectColumns, salt)
 		orderBy = pointy.String("hash")
 	}
 	sb := sqlbuilder.NewSelectBuilder()

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/samber/lo"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,7 +16,6 @@ import (
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/openlyinc/pointy"
-	"github.com/samber/lo"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -104,6 +105,7 @@ type ClickhouseField struct {
 const SessionsTable = "sessions"
 const FieldsTable = "fields"
 const timeRangeField = "custom_created_at"
+const sampleField = "custom_sample"
 
 func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Session) error {
 	chFields := []interface{}{}
@@ -215,11 +217,19 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 	return g.Wait()
 }
 
-func getSessionsQueryImpl(admin *model.Admin, query modelInputs.ClickhouseQuery, projectId int, retentionDate time.Time, selectColumns string, groupBy *string, orderBy *string, limit *int, offset *int) (string, []interface{}, error) {
+func getSessionsQueryImpl(admin *model.Admin, query modelInputs.ClickhouseQuery, projectId int, retentionDate time.Time, selectColumns string, groupBy *string, orderBy *string, limit *int, offset *int) (string, []interface{}, bool, error) {
 	rules, err := deserializeRules(query.Rules)
 	if err != nil {
-		return "", nil, err
+		return "", nil, false, err
 	}
+
+	sampleRule, sampleRuleIdx, sampleRuleFound := lo.FindIndexOf(rules, func(r Rule) bool {
+		return r.Field == sampleField
+	})
+	if sampleRuleFound {
+		rules = append(rules[:sampleRuleIdx], rules[sampleRuleIdx+1:]...)
+	}
+	useRandomSample := sampleRuleFound && groupBy == nil
 
 	timeRangeRule, found := lo.Find(rules, func(r Rule) bool {
 		return r.Field == timeRangeField
@@ -235,21 +245,29 @@ func getSessionsQueryImpl(admin *model.Admin, query modelInputs.ClickhouseQuery,
 		rules = append(rules, timeRangeRule)
 	}
 	if len(timeRangeRule.Val) != 1 {
-		return "", nil, fmt.Errorf("unexpected length of time range value: %s", timeRangeRule.Val)
+		return "", nil, false, fmt.Errorf("unexpected length of time range value: %s", timeRangeRule.Val)
 	}
 	start, end, found := strings.Cut(timeRangeRule.Val[0], "_")
 	if !found {
-		return "", nil, fmt.Errorf("separator not found for time range: %s", timeRangeRule.Val[0])
+		return "", nil, false, fmt.Errorf("separator not found for time range: %s", timeRangeRule.Val[0])
 	}
 	startTime, err := time.Parse(timeFormat, start)
 	if err != nil {
-		return "", nil, err
+		return "", nil, false, err
 	}
 	endTime, err := time.Parse(timeFormat, end)
 	if err != nil {
-		return "", nil, err
+		return "", nil, false, err
 	}
 
+	if useRandomSample {
+		salt, err := strconv.ParseUint(sampleRule.Val[0], 16, 64)
+		if err != nil {
+			return "", nil, false, err
+		}
+		selectColumns = fmt.Sprintf("%s, farmHash64(SecureID) %% %d as hash", selectColumns, salt)
+		orderBy = pointy.String("hash")
+	}
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select(selectColumns).
 		From("sessions FINAL").
@@ -264,7 +282,7 @@ func getSessionsQueryImpl(admin *model.Admin, query modelInputs.ClickhouseQuery,
 
 	conditions, err := parseSessionRules(admin, query.IsAnd, rules, projectId, startTime, endTime, sb)
 	if err != nil {
-		return "", nil, err
+		return "", nil, false, err
 	}
 
 	sb = sb.Where(conditions)
@@ -281,39 +299,50 @@ func getSessionsQueryImpl(admin *model.Admin, query modelInputs.ClickhouseQuery,
 		sb = sb.Offset(*offset)
 	}
 
-	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+	if useRandomSample {
+		sbOuter := sqlbuilder.NewSelectBuilder()
+		sb = sbOuter.
+			Select("*").
+			From(sbOuter.BuilderAs(sb, "inner"))
+	}
 
-	return sql, args, nil
+	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+	return sql, args, useRandomSample, nil
 }
 
-func (client *Client) QuerySessionIds(ctx context.Context, admin *model.Admin, projectId int, count int, query modelInputs.ClickhouseQuery, sortField string, page *int, retentionDate time.Time) ([]int64, int64, error) {
+func (client *Client) QuerySessionIds(ctx context.Context, admin *model.Admin, projectId int, count int, query modelInputs.ClickhouseQuery, sortField string, page *int, retentionDate time.Time) ([]int64, int64, bool, error) {
 	pageInt := 1
 	if page != nil {
 		pageInt = *page
 	}
 	offset := (pageInt - 1) * count
 
-	sql, args, err := getSessionsQueryImpl(admin, query, projectId, retentionDate, "ID, count() OVER() AS total", nil, pointy.String(sortField), pointy.Int(count), pointy.Int(offset))
+	sql, args, sampleRuleFound, err := getSessionsQueryImpl(admin, query, projectId, retentionDate, "ID, count() OVER() AS total", nil, pointy.String(sortField), pointy.Int(count), pointy.Int(offset))
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 
 	rows, err := client.conn.Query(ctx, sql, args...)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 
-	ids := []int64{}
+	var ids []int64
 	var total uint64
 	for rows.Next() {
 		var id int64
-		if err := rows.Scan(&id, &total); err != nil {
-			return nil, 0, err
+		columns := []interface{}{&id, &total}
+		if sampleRuleFound {
+			var hash uint64
+			columns = append(columns, &hash)
+		}
+		if err := rows.Scan(columns...); err != nil {
+			return nil, 0, false, err
 		}
 		ids = append(ids, id)
 	}
 
-	return ids, int64(total), nil
+	return ids, int64(total), sampleRuleFound, nil
 }
 
 func (client *Client) QuerySessionHistogram(ctx context.Context, admin *model.Admin, projectId int, query modelInputs.ClickhouseQuery, retentionDate time.Time, options modelInputs.DateHistogramOptions) ([]time.Time, []int64, []int64, []int64, error) {
@@ -326,7 +355,7 @@ func (client *Client) QuerySessionHistogram(ctx context.Context, admin *model.Ad
 
 	orderBy := fmt.Sprintf("1 WITH FILL FROM %s(?, '%s') TO %s(?, '%s') STEP 1", aggFn, location.String(), aggFn, location.String())
 
-	sql, args, err := getSessionsQueryImpl(admin, query, projectId, retentionDate, selectCols, pointy.String("1"), &orderBy, nil, nil)
+	sql, args, _, err := getSessionsQueryImpl(admin, query, projectId, retentionDate, selectCols, pointy.String("1"), &orderBy, nil, nil)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/backend/clickhouse/sessions_test.go
+++ b/backend/clickhouse/sessions_test.go
@@ -3,6 +3,9 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/highlight-run/highlight/backend/util"
+	"github.com/openlyinc/pointy"
 	"testing"
 	"time"
 
@@ -152,6 +155,108 @@ func Test_SessionMatchesQuery(t *testing.T) {
 }
 
 func Test_QuerySessionIds(t *testing.T) {
-	client := &Client{}
-	client.QuerySessionIds(context.Background(), nil, nil)
+	ctx := context.Background()
+
+	dbName := "highlight_testing_db"
+	DB, err := util.CreateAndMigrateTestDB(dbName)
+	assert.NoError(t, err)
+
+	client, teardown := setupSessionsTest(t)
+	defer teardown(t)
+
+	s1 := &model.Session{
+		Model: model.Model{
+			CreatedAt: time.Now(),
+		},
+		ViewedByAdmins: []model.Admin{},
+		Fields: []*model.Field{
+			{
+				Int64Model: model.Int64Model{
+					CreatedAt: time.Now(),
+				},
+				Type:      "session",
+				Name:      "environment",
+				Value:     "production",
+				ProjectID: 1,
+			},
+		},
+		Environment: "production",
+		SecureID:    "abc123",
+		ProjectID:   1,
+	}
+	s2 := &model.Session{
+		Model: model.Model{
+			CreatedAt: time.Now(),
+		},
+		ViewedByAdmins: []model.Admin{},
+		Fields: []*model.Field{
+			{
+				Int64Model: model.Int64Model{
+					CreatedAt: time.Now(),
+				},
+				Type:      "session",
+				Name:      "environment",
+				Value:     "dev",
+				ProjectID: 1,
+			},
+		},
+		Environment: "dev",
+		SecureID:    "abc124",
+		ProjectID:   1,
+	}
+	s3 := &model.Session{
+		Model: model.Model{
+			CreatedAt: time.Now(),
+		},
+		ViewedByAdmins: []model.Admin{},
+		Fields: []*model.Field{
+			{
+				Int64Model: model.Int64Model{
+					CreatedAt: time.Now(),
+				},
+				Type:      "session",
+				Name:      "environment",
+				Value:     "production",
+				ProjectID: 1,
+			},
+		},
+		Environment: "production",
+		SecureID:    "abc125",
+		ProjectID:   1,
+	}
+	assert.NoError(t, DB.Create(s1).Error)
+	assert.NoError(t, DB.Create(s2).Error)
+	assert.NoError(t, DB.Create(s3).Error)
+	assert.NoError(t, client.WriteSessions(ctx, []*model.Session{s1, s2, s3}))
+
+	for name, tc := range map[string]struct {
+		Query modelInputs.ClickhouseQuery
+	}{
+		"default": {
+			Query: modelInputs.ClickhouseQuery{
+				IsAnd: true,
+				Rules: [][]string{
+					{"session_environment", "is", "production"},
+					{"custom_created_at", "between_date", fmt.Sprintf("%s.000Z_%s.000Z", s1.CreatedAt.UTC().Add(-time.Hour).Format(time.RFC3339)[:19], s1.CreatedAt.UTC().Add(time.Hour).Format(time.RFC3339)[:19])},
+					{"custom_sample", "matches", "281cce18b609606b"},
+				},
+			},
+		},
+		"max hex": {
+			Query: modelInputs.ClickhouseQuery{
+				IsAnd: true,
+				Rules: [][]string{
+					{"custom_sample", "matches", "FFFFFFFFFFFFFFFF"},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ids, total, sampleRuleFound, err := client.QuerySessionIds(ctx, nil, 1, 10, tc.Query, "CreatedAt DESC, ID DESC", pointy.Int(1), time.Now().Add(-time.Hour))
+			assert.NoError(t, err)
+			assert.True(t, sampleRuleFound)
+			assert.Greater(t, total, int64(0))
+			assert.Greater(t, len(ids), 0)
+		})
+	}
 }

--- a/backend/clickhouse/sessions_test.go
+++ b/backend/clickhouse/sessions_test.go
@@ -150,3 +150,8 @@ func Test_SessionMatchesQuery(t *testing.T) {
 	matches = SessionMatchesQuery(&session, &filters)
 	assert.False(t, matches)
 }
+
+func Test_QuerySessionIds(t *testing.T) {
+	client := &Client{}
+	client.QuerySessionIds(context.Background(), nil, nil)
+}

--- a/backend/lambda-functions/deleteSessions/handlers/handlers.go
+++ b/backend/lambda-functions/deleteSessions/handlers/handlers.go
@@ -175,7 +175,7 @@ func (h *handlers) GetSessionIdsByQuery(ctx context.Context, event utils.QuerySe
 		batchId := uuid.New().String()
 		toDelete := []model.DeleteSessionsTask{}
 
-		ids, _, err := h.clickhouseClient.QuerySessionIds(ctx, nil, event.ProjectId, 10000, event.Query, "CreatedAt DESC, ID DESC", pointy.Int(page), time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+		ids, _, _, err := h.clickhouseClient.QuerySessionIds(ctx, nil, event.ProjectId, 10000, event.Query, "CreatedAt DESC, ID DESC", pointy.Int(page), time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
 		if err != nil {
 			return nil, err
 		}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5418,18 +5418,31 @@ func (r *queryResolver) SessionsClickhouse(ctx context.Context, projectID int, c
 		return nil, err
 	}
 
-	ids, total, err := r.ClickhouseClient.QuerySessionIds(ctx, admin, projectID, count, query, chSortStr, page, retentionDate)
+	ids, total, ordered, err := r.ClickhouseClient.QuerySessionIds(ctx, admin, projectID, count, query, chSortStr, page, retentionDate)
 	if err != nil {
 		return nil, err
 	}
 
-	var results []model.Session
-	if err := r.DB.WithContext(ctx).Model(&model.Session{}).
+	q := r.DB.WithContext(ctx).Model(&model.Session{}).
 		Where("id in ?", ids).
-		Where("project_id = ?", projectID).
-		Order(pgSortStr).
-		Find(&results).Error; err != nil {
+		Where("project_id = ?", projectID)
+	if !ordered {
+		q = q.Order(pgSortStr)
+	}
+
+	var results []model.Session
+	if err := q.Find(&results).Error; err != nil {
 		return nil, err
+	}
+
+	if ordered {
+		positions := make(map[int64]int)
+		for idx, id := range ids {
+			positions[id] = idx
+		}
+		sort.Slice(results, func(i, j int) bool {
+			return positions[int64(results[i].ID)] < positions[int64(results[j].ID)]
+		})
 	}
 
 	return &model.SessionResults{

--- a/frontend/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder/QueryBuilder.tsx
@@ -441,6 +441,7 @@ const MultiselectPopout = ({
 
 	let multiValue: string[] = []
 	switch (type) {
+		case 'creatable':
 		case 'multiselect':
 			multiValue = value?.options.map((o) => o.value) ?? []
 			return (
@@ -452,33 +453,6 @@ const MultiselectPopout = ({
 						key: o.value,
 						render: getOption(o, lastQuery),
 					}))}
-					onChange={(val: string[]) => {
-						onChange({
-							kind: 'multi',
-							options: val.map((i) => ({
-								label: i,
-								value: i,
-							})),
-						})
-					}}
-					onChangeQuery={(val: string) => {
-						setQuery(val)
-					}}
-					cssClass={cssClass}
-					queryPlaceholder="Filter..."
-					defaultOpen={invalid}
-					disabled={disabled}
-					loadingRender={loadingBox}
-				/>
-			)
-		case 'creatable':
-			multiValue = value?.options.map((o) => o.value) ?? []
-			return (
-				<ComboboxSelect
-					label="value"
-					value={multiValue}
-					valueRender={label}
-					options={[]}
 					onChange={(val: string[]) => {
 						onChange({
 							kind: 'multi',
@@ -1468,7 +1442,7 @@ function QueryBuilder(props: QueryBuilderProps) {
 				} else if (getCustomFieldOptions(field)?.type === 'sample') {
 					options = [
 						{
-							label: 'Random Seed',
+							label: 'New Random Seed',
 							value: [...Array(16)]
 								.map(() =>
 									Math.floor(Math.random() * 16).toString(16),

--- a/frontend/src/components/QueryBuilder/QueryBuilder.tsx
+++ b/frontend/src/components/QueryBuilder/QueryBuilder.tsx
@@ -843,6 +843,7 @@ const LABEL_MAP: { [key: string]: string } = {
 	has_comments: 'Has Comments',
 	service_name: 'Service',
 	service_version: 'Service Version',
+	sample: 'Sample',
 }
 
 const getOperator = (
@@ -866,7 +867,7 @@ const isSingle = (val: MultiselectOption | undefined) =>
 
 interface FieldOptions {
 	operators?: Operator[]
-	type?: string
+	type?: 'text' | 'long' | 'boolean' | 'sample'
 }
 
 interface HasOptions {
@@ -1000,6 +1001,8 @@ const getIcon = (value: string): JSX.Element | undefined => {
 			return <IconSolidLightningBolt />
 		case 'custom_has_rage_clicks':
 			return <IconSolidCursorClick />
+		case 'custom_sample':
+			return <IconSolidPencil />
 		case 'session_landing_page':
 			return <IconSolidDocumentAdd />
 		case 'custom_active_length':
@@ -1462,6 +1465,17 @@ function QueryBuilder(props: QueryBuilderProps) {
 						label: v,
 						value: v,
 					}))
+				} else if (getCustomFieldOptions(field)?.type === 'sample') {
+					options = [
+						{
+							label: 'Random Seed',
+							value: [...Array(16)]
+								.map(() =>
+									Math.floor(Math.random() * 16).toString(16),
+								)
+								.join(''),
+						},
+					]
 				}
 
 				if (options.length > 0) {

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/SessionQueryBuilder.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/SessionQueryBuilder.tsx
@@ -130,6 +130,14 @@ export const CUSTOM_FIELDS: CustomField[] = [
 			operators: BOOLEAN_OPERATORS,
 		},
 	},
+	{
+		type: CUSTOM_TYPE,
+		name: 'sample',
+		options: {
+			type: 'sample',
+			operators: ['is'],
+		},
+	},
 ]
 
 const SessionQueryBuilder = React.memo((props: Partial<QueryBuilderProps>) => {

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/SessionQueryBuilder.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/SessionQueryBuilder.tsx
@@ -135,7 +135,7 @@ export const CUSTOM_FIELDS: CustomField[] = [
 		name: 'sample',
 		options: {
 			type: 'sample',
-			operators: ['is'],
+			operators: ['matches'],
 		},
 	},
 ]


### PR DESCRIPTION
## Summary

Adds a new `sample` session filter that allows picking a random subset of sessions
based on a randomly generated (or set) hex string.
The subset does not have a given count limit but sets the order of
sessions that are returned, so that a given page number identifies the sample.

## How did you test this change?

v0 https://www.loom.com/share/289a58d71f664e329dd73509887df035

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No