### PR TITLE
remove @highlight-run/node dependency on highlight.run for types

### DIFF
--- a/.changeset/chilly-rats-leave.md
+++ b/.changeset/chilly-rats-leave.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': patch
+---
+
+remove @highlight-run/node dependency on highlight.run for types

--- a/sdk/highlight-node/package.json
+++ b/sdk/highlight-node/package.json
@@ -24,9 +24,6 @@
 	"publishConfig": {
 		"access": "public"
 	},
-	"dependencies": {
-		"highlight.run": "workspace:*"
-	},
 	"devDependencies": {
 		"@opentelemetry/api": "^1.6.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.39.2",
@@ -45,6 +42,7 @@
 		"@types/lru-cache": "^7.10.10",
 		"@types/node": "17.0.13",
 		"encoding": "^0.1.13",
+		"highlight.run": "workspace:*",
 		"jest": "^29.2.2",
 		"rollup": "^4.1.4",
 		"ts-jest": "^29.0.3",

--- a/sdk/highlight-node/src/types.ts
+++ b/sdk/highlight-node/src/types.ts
@@ -1,4 +1,4 @@
-import { HighlightOptions } from 'highlight.run'
+import type { HighlightOptions } from 'highlight.run'
 
 export interface NodeOptions extends HighlightOptions {
 	/**


### PR DESCRIPTION
## Summary

As reported on [discord](https://discord.com/channels/1026884757667188757/1178754207600349215),
our @highlight-run/node sdk depends on highlight.run for types but can lead to node.js runtime
typescript errors when lib checking is on.

## How did you test this change?

CI

## Are there any deployment considerations?

Changeset

## Does this work require review from our design team?

No
