### PR TITLE
send attribution data from demo page signups

### DIFF
--- a/frontend/src/components/DemoModal/DemoModal.tsx
+++ b/frontend/src/components/DemoModal/DemoModal.tsx
@@ -9,6 +9,7 @@ import {
 } from '@highlight-run/ui/components'
 import useLocalStorage from '@rehooks/local-storage'
 import analytics from '@util/analytics'
+import { getAttributionData } from '@util/attribution'
 import { Divider } from 'antd'
 import React from 'react'
 import { Helmet } from 'react-helmet'
@@ -34,13 +35,15 @@ export const DemoModal = () => {
 			setError('Please use your work email')
 			return
 		}
+		const attribution = getAttributionData()
 		analytics.identify(email, {
 			// hubspot attribute to trigger sequence for this contact
 			demo_sign_up: true,
 			referral_url: window.location.href.split('?')[0],
 			event: 'demo-email-submit',
+			...attribution,
 		})
-		analytics.track('demo-email-submit', { email })
+		analytics.track('demo-email-submit', { email, ...attribution })
 		setVisible(false)
 	}
 

--- a/frontend/src/components/DemoModal/DemoModal.tsx
+++ b/frontend/src/components/DemoModal/DemoModal.tsx
@@ -35,7 +35,11 @@ export const DemoModal = () => {
 			setError('Please use your work email')
 			return
 		}
-		const attribution = getAttributionData()
+		let attribution = getAttributionData()
+		try {
+			const parsedReferral = JSON.parse(attribution.referral)
+			attribution = { ...attribution, ...parsedReferral }
+		} catch (e) {}
 		analytics.identify(email, {
 			// hubspot attribute to trigger sequence for this contact
 			demo_sign_up: true,


### PR DESCRIPTION
## Summary

Send attribution data coming from highlight.io as part of the 
analytics data sent with the highlight demo page user submission.

This will allow us to query clickhouse for demo signups' attribution data (such as gclick id)

## How did you test this change?

Reflame preview
![Screenshot from 2023-11-28 11-27-20](https://github.com/highlight/highlight/assets/1351531/706b46d6-9f44-401e-945a-57f9b905d7f9)


## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
