### PR TITLE
Fix flame graph error

### DIFF
--- a/frontend/src/pages/Traces/utils.ts
+++ b/frontend/src/pages/Traces/utils.ts
@@ -131,7 +131,9 @@ const organizeSpanInLevel = (
 		})
 	}
 
-	const children = trace.filter((s) => s.parentSpanID === span.spanID)
+	const children = trace.filter(
+		(s) => s.parentSpanID && s.parentSpanID === span.spanID,
+	)
 
 	if (children.length > 0) {
 		children.forEach((child) => {


### PR DESCRIPTION
## Summary

Fixes a bug where we could get in an infinite loop on a trace with a single span.

## How did you test this change?

Reflame preview click test of [the page which rendered an error](https://preview.highlight.io/22330/traces/76145821-502e-4eff-b983-93b231912a99?end_date=2023-11-28T19%3A55%3A40.475Z&start_date=2023-11-27T19%3A55%3A40.475Z&%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HGBVE03QH0DGXYZWJDRCXWF4%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22hotfix%2Fflame-graph-error%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D).

## Are there any deployment considerations?

Should let customer know it's resolved if they noticed the issue.

## Does this work require review from our design team?

N/A
