### PR TITLE
fix session metadata persisting when switching sessions

### DIFF
--- a/frontend/src/components/TableList/TableList.tsx
+++ b/frontend/src/components/TableList/TableList.tsx
@@ -4,6 +4,7 @@ import TextViewer from '@components/TextViewer'
 import { Box, Tag, Text } from '@highlight-run/ui/components'
 import { Props as TruncateProps } from '@highlight-run/ui/src/components/private/Truncate/Truncate'
 import { copyToClipboard } from '@util/string'
+import _ from 'lodash'
 import React, { isValidElement, ReactElement } from 'react'
 
 import * as style from './TableList.css'
@@ -30,7 +31,10 @@ export const TableList = ({
 	noDataMessage?: string | React.ReactNode
 }) => {
 	const [truncated, setTruncated] = React.useState(true)
-	const filtered = data.filter((x) => x.valueDisplayValue)
+	const filtered = _.uniqBy(
+		data.filter((x) => x.valueDisplayValue),
+		(x) => x.keyDisplayValue,
+	)
 	const items =
 		truncateable && truncated
 			? filtered.slice(0, TRUNCATED_ITEMS_LIMIT)

--- a/frontend/src/components/TableList/TableList.tsx
+++ b/frontend/src/components/TableList/TableList.tsx
@@ -42,7 +42,7 @@ export const TableList = ({
 	return (
 		<Box display="flex" flexDirection="column" width="full">
 			<Box display="flex" flexDirection="column" gap="4" width="full">
-				{items.map((item) => {
+				{_.sortBy(items, (x) => x.keyDisplayValue).map((item) => {
 					if (!item.valueDisplayValue) {
 						return null
 					}

--- a/frontend/src/components/TableList/TableList.tsx
+++ b/frontend/src/components/TableList/TableList.tsx
@@ -4,7 +4,6 @@ import TextViewer from '@components/TextViewer'
 import { Box, Tag, Text } from '@highlight-run/ui/components'
 import { Props as TruncateProps } from '@highlight-run/ui/src/components/private/Truncate/Truncate'
 import { copyToClipboard } from '@util/string'
-import _ from 'lodash'
 import React, { isValidElement, ReactElement } from 'react'
 
 import * as style from './TableList.css'
@@ -31,10 +30,7 @@ export const TableList = ({
 	noDataMessage?: string | React.ReactNode
 }) => {
 	const [truncated, setTruncated] = React.useState(true)
-	const filtered = _.uniqBy(
-		data.filter((x) => x.valueDisplayValue),
-		(x) => x.keyDisplayValue,
-	)
+	const filtered = data.filter((x) => x.valueDisplayValue)
 	const items =
 		truncateable && truncated
 			? filtered.slice(0, TRUNCATED_ITEMS_LIMIT)
@@ -42,7 +38,7 @@ export const TableList = ({
 	return (
 		<Box display="flex" flexDirection="column" width="full">
 			<Box display="flex" flexDirection="column" gap="4" width="full">
-				{_.sortBy(items, (x) => x.keyDisplayValue).map((item) => {
+				{items.map((item) => {
 					if (!item.valueDisplayValue) {
 						return null
 					}

--- a/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
+++ b/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
@@ -7,7 +7,7 @@ import { getChromeExtensionURL } from '@pages/Player/SessionLevelBar/utils/utils
 import { bytesToPrettyString } from '@util/string'
 import { buildQueryStateString } from '@util/url/params'
 import { message } from 'antd'
-import { capitalize } from 'lodash'
+import _, { capitalize } from 'lodash'
 
 import CollapsibleSection from '@/components/CollapsibleSection'
 import { styledVerticalScrollbar } from '@/style/common.css'
@@ -274,15 +274,25 @@ const MetadataPanel = () => {
 			</Box>
 		)
 	}
+
+	const data = Object.entries({
+		[MetadataSection.Session]: sessionData,
+		[MetadataSection.User]: userData,
+		[MetadataSection.Device]: deviceData,
+		[MetadataSection.Environment]: environmentData,
+	}).map(([key, values]) => {
+		return [
+			key,
+			_.sortBy(
+				_.uniqBy(values, (x) => x.keyDisplayValue),
+				(x) => x.keyDisplayValue,
+			),
+		] as const
+	})
 	return (
 		<Box cssClass={style.container}>
 			<Box cssClass={[style.metadataPanel, styledVerticalScrollbar]}>
-				{Object.entries({
-					[MetadataSection.Session]: sessionData,
-					[MetadataSection.User]: userData,
-					[MetadataSection.Device]: deviceData,
-					[MetadataSection.Environment]: environmentData,
-				}).map(([key, value]) => {
+				{data.map(([key, value]) => {
 					return (
 						<CollapsibleSection title={key} key={key}>
 							<Box

--- a/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
+++ b/frontend/src/pages/Player/MetadataPanel/MetadataPanel.tsx
@@ -267,34 +267,37 @@ const MetadataPanel = () => {
 				"Highlight detected a browser extension is installed and might interfere with your app's behavior.",
 		}),
 	)
-
+	if (!session) {
+		return (
+			<Box cssClass={style.container}>
+				<LoadingBox />
+			</Box>
+		)
+	}
 	return (
 		<Box cssClass={style.container}>
-			{!session ? (
-				<LoadingBox />
-			) : (
-				<Box cssClass={[style.metadataPanel, styledVerticalScrollbar]}>
-					{Object.entries({
-						[MetadataSection.Session]: sessionData,
-						[MetadataSection.User]: userData,
-						[MetadataSection.Device]: deviceData,
-						[MetadataSection.Environment]: environmentData,
-					}).map(([key, value]) => {
-						return (
-							<CollapsibleSection key={key} title={key}>
-								<Box
-									px="12"
-									display="flex"
-									justifyContent="space-between"
-									alignItems="center"
-								>
-									<TableList data={value} />
-								</Box>
-							</CollapsibleSection>
-						)
-					})}
-				</Box>
-			)}
+			<Box cssClass={[style.metadataPanel, styledVerticalScrollbar]}>
+				{Object.entries({
+					[MetadataSection.Session]: sessionData,
+					[MetadataSection.User]: userData,
+					[MetadataSection.Device]: deviceData,
+					[MetadataSection.Environment]: environmentData,
+				}).map(([key, value]) => {
+					return (
+						<CollapsibleSection title={key} key={key}>
+							<Box
+								key={`${session.secure_id}-${key}`}
+								px="12"
+								display="flex"
+								justifyContent="space-between"
+								alignItems="center"
+							>
+								<TableList data={value} />
+							</Box>
+						</CollapsibleSection>
+					)
+				})}
+			</Box>
 		</Box>
 	)
 }


### PR DESCRIPTION
## Summary

Session metadata would be carried over when switching sessions because the keys of the rendered
react components would be shared across sessions, so react wouldn't know to rerender the DOM.

## How did you test this change?

Before
![Screenshot from 2023-11-28 17-47-22](https://github.com/highlight/highlight/assets/1351531/e6e5b4de-983d-4e9c-8c75-58b1bba9ad24)

After
![Screenshot from 2023-11-28 17-54-28](https://github.com/highlight/highlight/assets/1351531/1ea3d731-80da-4fac-b0ca-218bda389b2a)


## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
