### PR TITLE
round billing cents to avoid dinero errors

### DIFF
--- a/frontend/src/pages/Billing/BillingPageV2.tsx
+++ b/frontend/src/pages/Billing/BillingPageV2.tsx
@@ -98,11 +98,17 @@ const UsageCard = ({
 	)
 
 	const costFormatted =
-		'$ ' + toDecimal(dinero({ amount: costCents, currency: USD }))
+		'$ ' +
+		toDecimal(dinero({ amount: Math.round(costCents), currency: USD }))
 	const limitFormatted =
 		billingLimitCents !== undefined
 			? '$ ' +
-			  toDecimal(dinero({ amount: billingLimitCents, currency: USD }))
+			  toDecimal(
+					dinero({
+						amount: Math.round(billingLimitCents),
+						currency: USD,
+					}),
+			  )
 			: undefined
 	const usageRatio = usageLimitAmount && usageAmount / usageLimitAmount
 	const isOverage = usageRatio ? usageRatio >= 1 : false
@@ -344,7 +350,8 @@ const BillingPageV2 = ({}: BillingPageProps) => {
 		: 0
 
 	const totalFormatted =
-		'$ ' + toDecimal(dinero({ amount: totalCents, currency: USD }))
+		'$ ' +
+		toDecimal(dinero({ amount: Math.round(totalCents), currency: USD }))
 
 	const sessionsLimit = isPaying
 		? data?.workspace?.sessions_max_cents ?? undefined
@@ -363,9 +370,11 @@ const BillingPageV2 = ({}: BillingPageProps) => {
 	const hasExtras =
 		baseAmount !== 0 || discountAmount !== 0 || discountPercent !== 0
 	const baseAmountFormatted =
-		'$' + toDecimal(dinero({ amount: baseAmount, currency: USD }))
+		'$' +
+		toDecimal(dinero({ amount: Math.round(baseAmount), currency: USD }))
 	const discountAmountFormatted =
-		'$' + toDecimal(dinero({ amount: discountAmount, currency: USD }))
+		'$' +
+		toDecimal(dinero({ amount: Math.round(discountAmount), currency: USD }))
 
 	return (
 		<Box width="full" display="flex" justifyContent="center">

--- a/frontend/src/pages/Billing/UpdatePlanPage.tsx
+++ b/frontend/src/pages/Billing/UpdatePlanPage.tsx
@@ -257,7 +257,8 @@ const ProductCard = ({
 	const quantityFormatted = formatNumber(unitQuantity)
 
 	const unitCostFormatted =
-		'$ ' + toDecimal(dinero({ amount: unitCostCents, currency: USD }))
+		'$ ' +
+		toDecimal(dinero({ amount: Math.round(unitCostCents), currency: USD }))
 
 	const netUsageAmount = Math.max(predictedUsageAmount - includedQuantity, 0)
 
@@ -286,7 +287,8 @@ const ProductCard = ({
 			: predictedCostCents
 
 	const totalCostFormatted =
-		'est. $ ' + toDecimal(dinero({ amount: totalCostCents, currency: USD }))
+		'est. $ ' +
+		toDecimal(dinero({ amount: Math.round(totalCostCents), currency: USD }))
 
 	return (
 		<Box
@@ -681,15 +683,19 @@ const UpdatePlanPage = ({}: BillingPageProps) => {
 
 	const predictedTotalFormatted =
 		'est. $ ' +
-		toDecimal(dinero({ amount: predictedTotalCents, currency: USD }))
+		toDecimal(
+			dinero({ amount: Math.round(predictedTotalCents), currency: USD }),
+		)
 
 	const hasExtras =
 		baseAmount !== 0 || discountAmount !== 0 || discountPercent !== 0
 	const enableBillingLimits = data?.billingDetails.plan.enableBillingLimits
 	const baseAmountFormatted =
-		'$' + toDecimal(dinero({ amount: baseAmount, currency: USD }))
+		'$' +
+		toDecimal(dinero({ amount: Math.round(baseAmount), currency: USD }))
 	const discountAmountFormatted =
-		'$' + toDecimal(dinero({ amount: discountAmount, currency: USD }))
+		'$' +
+		toDecimal(dinero({ amount: Math.round(discountAmount), currency: USD }))
 
 	return (
 		<Box


### PR DESCRIPTION
## Summary

Fixes https://app.highlight.io/1/errors/0E5xN9i7FIIjAP4z9g7S111IGIc3
to avoid crashing the billing page when the price was not an even number of cents.

## How did you test this change?

Reflame preview.

before
![Screenshot from 2023-11-29 10-47-57](https://github.com/highlight/highlight/assets/1351531/8e9db294-a775-4f58-8386-bb6091fdd6f8)

after, vising the same page on reflame preview
![Screenshot from 2023-11-29 10-48-24](https://github.com/highlight/highlight/assets/1351531/2325731b-ec1d-408c-8759-ff139e130b37)


## Are there any deployment considerations?

No

## Does this work require review from our design team?

No