### PR TITLE
fix stripe pricing updates

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -4,7 +4,7 @@ on:
     push:
         branches: ['main']
     pull_request:
-        types: [opened, reopened, synchronize, assigned, review_requested]
+        types: [opened, synchronize]
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:


### PR DESCRIPTION
## Summary

Fixes two issues
* Plans on non-3-month session retention would apply the session retention to traces / logs, failing to find a price
* Plans manually subscribed from the startup discount would have a different product ordering, failing to find the base product.

![Screenshot from 2023-11-30 17-10-18](https://github.com/highlight/highlight/assets/1351531/68821fc5-b1a2-4b6a-a997-7492741f84fe)


## How did you test this change?

Locally testing with stripe test mode.

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No