### PR TITLE
Update insights lambda to handle multiple requested emails

### DIFF
--- a/backend/lambda/lambda.go
+++ b/backend/lambda/lambda.go
@@ -165,10 +165,21 @@ func (s *Client) GetSessionInsightRequest(ctx context.Context, url string, proje
 	return req
 }
 
+type TemplateDataWithTemplate struct {
+	Template string
+	Data     interface{}
+}
+
 func (s *Client) GetSessionInsightEmailHtml(ctx context.Context, toEmail string, unsubscribeUrl string, data utils.SessionInsightsData) (string, error) {
 	data.ToEmail = toEmail
 	data.UnsubscribeUrl = unsubscribeUrl
-	b, err := json.Marshal(data)
+
+	templateData := TemplateDataWithTemplate{
+		Template: "session-insights",
+		Data:     data,
+	}
+
+	b, err := json.Marshal(templateData)
 	if err != nil {
 		return "", err
 	}

--- a/packages/react-email-templates/components/alerts.tsx
+++ b/packages/react-email-templates/components/alerts.tsx
@@ -33,22 +33,29 @@ const subtitleText = {
 	color: '#9d97aa',
 }
 
-export const AlertContainer: React.FC<React.PropsWithChildren> = ({
+interface AlertContainerProps extends React.PropsWithChildren<{}> {
+	hideBorder?: boolean
+}
+
+export const AlertContainer: React.FC<AlertContainerProps> = ({
 	children,
+	hideBorder,
 }) => {
 	return (
-		<Section align="center" style={alertContainer}>
+		<Section align="center" style={alertContainer(hideBorder)}>
 			{children}
 		</Section>
 	)
 }
 
-const alertContainer = {
-	border: '1px solid #30294e',
-	borderRadius: '6px',
-	fontSize: '14px',
-	margin: '36px 0',
-	padding: '12px',
+const alertContainer = (hideBorder?: boolean) => {
+	return {
+		border: hideBorder ? 'none' : '1px solid #30294e',
+		borderRadius: '6px',
+		fontSize: '14px',
+		margin: '36px 0',
+		padding: '12px',
+	}
 }
 
 export const Break: React.FC = () => {

--- a/packages/react-email-templates/emails/index.tsx
+++ b/packages/react-email-templates/emails/index.tsx
@@ -1,0 +1,19 @@
+import { ErrorAlertEmail } from './error-alert'
+import { LogAlertEmail } from './log-alert'
+import { NewSessionAlertEmail } from './new-session-alert'
+import { NewUserAlertEmail } from './new-user-alert'
+import { RageClickAlertEmail } from './rage-click-alert'
+import { SessionInsightsEmail } from './session-insights'
+import { TrackEventPropertiesAlertEmail } from './track-event-properties-alert'
+import { TrackUserPropertiesAlertEmail } from './track-user-properties-alert'
+
+export {
+	ErrorAlertEmail,
+	LogAlertEmail,
+	NewSessionAlertEmail,
+	NewUserAlertEmail,
+	RageClickAlertEmail,
+	SessionInsightsEmail,
+	TrackEventPropertiesAlertEmail,
+	TrackUserPropertiesAlertEmail,
+}

--- a/packages/react-email-templates/emails/new-session-alert.tsx
+++ b/packages/react-email-templates/emails/new-session-alert.tsx
@@ -10,31 +10,18 @@ import {
 	Subtitle,
 	Title,
 } from '../components/alerts'
-import { Session, SessionPreview } from '../components/sessions'
 
 export interface NewSessionAlertEmailProps {
 	alertLink?: string
 	projectName?: string
-	session?: Session
+	sessionLink?: string
 	userIdentifier?: string
-}
-
-const sessionExample = {
-	url: 'https://app.highlight.io/1/sessions/123',
-	identifier: 'jay@highlight.io',
-	screenshotUrl: 'https://zane.test/404',
-	activityGraphUrl:
-		'https://static.highlight.io/assets/session-insights/activity.png',
-	avatarUrl:
-		'https://lh3.googleusercontent.com/a-/AOh14Gg3zY3_wfixRrZjjMuj2eTrBAOKDZrDWeYlHsjL=s96-c',
-	country: 'Germany',
-	activeLength: '1h 25m',
 }
 
 export const NewSessionAlertEmail = ({
 	alertLink = 'https://localhost:3000/1/alerts/sessions/1',
 	projectName = 'Highlight Production (app.highlight.io)',
-	session = sessionExample,
+	sessionLink = 'https://localhost:3000/1/sessions/6r5FU4u4SYs4AG4kZjnLHyU5K2N7',
 	userIdentifier = '1',
 }: NewSessionAlertEmailProps) => (
 	<EmailHtml previewText={`${userIdentifier} just started a new session`}>
@@ -45,9 +32,8 @@ export const NewSessionAlertEmail = ({
 		</Title>
 		<Subtitle>{projectName}</Subtitle>
 
-		<AlertContainer>
-			<SessionPreview session={session} hideViewSessionButton />
-			<CtaLink href={session.url} label="Open" />
+		<AlertContainer hideBorder>
+			<CtaLink href={sessionLink} label="View session" />
 		</AlertContainer>
 
 		<Break />

--- a/packages/react-email-templates/emails/new-user-alert.tsx
+++ b/packages/react-email-templates/emails/new-user-alert.tsx
@@ -10,31 +10,18 @@ import {
 	Subtitle,
 	Title,
 } from '../components/alerts'
-import { Session, SessionPreview } from '../components/sessions'
 
 export interface NewUserAlertEmailProps {
 	alertLink?: string
 	projectName?: string
-	session?: Session
+	sessionLink?: string
 	userIdentifier?: string
-}
-
-const sessionExample = {
-	url: 'https://app.highlight.io/1/sessions/123',
-	identifier: 'jay@highlight.io',
-	screenshotUrl: 'https://zane.test/404',
-	activityGraphUrl:
-		'https://static.highlight.io/assets/session-insights/activity.png',
-	avatarUrl:
-		'https://lh3.googleusercontent.com/a-/AOh14Gg3zY3_wfixRrZjjMuj2eTrBAOKDZrDWeYlHsjL=s96-c',
-	country: 'Germany',
-	activeLength: '1h 25m',
 }
 
 export const NewUserAlertEmail = ({
 	alertLink = 'https://localhost:3000/1/alerts/sessions/1',
 	projectName = 'Highlight Production (app.highlight.io)',
-	session = sessionExample,
+	sessionLink = 'https://localhost:3000/1/sessions/6r5FU4u4SYs4AG4kZjnLHyU5K2N7',
 	userIdentifier = '1',
 }: NewUserAlertEmailProps) => (
 	<EmailHtml
@@ -47,9 +34,8 @@ export const NewUserAlertEmail = ({
 		</Title>
 		<Subtitle>{projectName}</Subtitle>
 
-		<AlertContainer>
-			<SessionPreview session={session} hideViewSessionButton />s
-			<CtaLink href={session.url} label="Open" />
+		<AlertContainer hideBorder>
+			<CtaLink href={sessionLink} label="View session" />
 		</AlertContainer>
 
 		<Break />

--- a/packages/react-email-templates/emails/rage-click-alert.tsx
+++ b/packages/react-email-templates/emails/rage-click-alert.tsx
@@ -14,11 +14,11 @@ import {
 } from '../components/alerts'
 
 export interface RageClickAlertEmailProps {
+	alertLink?: string
 	alertName?: string
 	projectName?: string
 	userIdentifier?: string
 	sessionLink?: string
-	alertLink?: string
 }
 
 export const RageClickAlertEmail = ({

--- a/packages/react-email-templates/emails/track-event-properties-alert.tsx
+++ b/packages/react-email-templates/emails/track-event-properties-alert.tsx
@@ -21,18 +21,15 @@ type EventProperty = {
 export interface TrackEventPropertiesAlertEmailProps {
 	alertLink?: string
 	alertName?: string
+	eventProperties?: EventProperty[]
 	projectName?: string
 	sessionLink?: string
 	userIdentifier?: string
-	eventProperties?: EventProperty[]
 }
 
 export const TrackEventPropertiesAlertEmail = ({
 	alertLink = 'https://localhost:3000/1/alerts/sessions/1',
 	alertName = 'Track User Alert',
-	projectName = 'Highlight Production (app.highlight.io)',
-	sessionLink = 'https://localhost:3000/1/sessions/6r5FU4u4SYs4AG4kZjnLHyU5K2N7',
-	userIdentifier = '1',
 	eventProperties = [
 		{
 			key: 'Event',
@@ -43,6 +40,9 @@ export const TrackEventPropertiesAlertEmail = ({
 			value: '/sessions',
 		},
 	],
+	projectName = 'Highlight Production (app.highlight.io)',
+	sessionLink = 'https://localhost:3000/1/sessions/6r5FU4u4SYs4AG4kZjnLHyU5K2N7',
+	userIdentifier = '1',
 }: TrackEventPropertiesAlertEmailProps) => (
 	<EmailHtml previewText={`${alertName} alert fired`}>
 		<HighlightLogo />

--- a/packages/react-email-templates/package.json
+++ b/packages/react-email-templates/package.json
@@ -6,7 +6,7 @@
 	"module": "./dist/index.js",
 	"scripts": {
 		"build": "tsup",
-		"dev": "email dev",
+		"dev": "email dev -p 3001",
 		"zip": "zip -r function.zip node_modules package.json -x node_modules/typescript/\\* -x node_modules/tsup/\\* -x node_modules/@types/\\* -x node_modules/@highlight-run/node/node_modules/typescript/\\* && cd dist && zip ../function.zip * && cd ..",
 		"publish": "yarn zip && aws s3 cp function.zip s3://highlight-lambda-code/session-insights-email.zip && rm function.zip && aws lambda update-function-code --function-name session-insights-email --s3-bucket highlight-lambda-code --s3-key session-insights-email.zip"
 	},

--- a/packages/react-email-templates/src/index.ts
+++ b/packages/react-email-templates/src/index.ts
@@ -1,13 +1,28 @@
 import { render } from '@react-email/render'
 import { APIGatewayEvent } from 'aws-lambda'
 import {
+	ErrorAlertEmail,
+	LogAlertEmail,
+	NewSessionAlertEmail,
+	NewUserAlertEmail,
+	RageClickAlertEmail,
 	SessionInsightsEmail,
-	SessionInsightsEmailProps,
-} from '../emails/session-insights'
+	TrackEventPropertiesAlertEmail,
+	TrackUserPropertiesAlertEmail,
+} from '../emails'
 
 export const handler = async (event?: APIGatewayEvent) => {
-	const args = JSON.parse(event?.body ?? '{}') as SessionInsightsEmailProps
-	const html = render(SessionInsightsEmail(args))
+	const args = JSON.parse(event?.body ?? '{}')
+
+	const EmailTemplate = getEmailTemplate(args.template)
+	if (!EmailTemplate) {
+		return {
+			statusCode: 400,
+			body: 'Request is missing a valid "template" property',
+		}
+	}
+
+	const html = render(EmailTemplate(args.data))
 	return {
 		statusCode: 200,
 		body: html,
@@ -15,4 +30,29 @@ export const handler = async (event?: APIGatewayEvent) => {
 			'content-type': 'text/html',
 		},
 	}
+}
+
+const getEmailTemplate = (template: string) => {
+	switch (template) {
+		case 'error-alert':
+			return ErrorAlertEmail
+		case 'log-alert':
+			return LogAlertEmail
+		case 'new-session-alert':
+			return NewSessionAlertEmail
+		case 'new-user-alert':
+			return NewUserAlertEmail
+		case 'rage-click-alert':
+			return RageClickAlertEmail
+		case 'session-insights':
+			return SessionInsightsEmail
+		case 'track-event-properties-alert':
+			return TrackEventPropertiesAlertEmail
+		case 'track-user-properties-alert':
+			return TrackUserPropertiesAlertEmail
+		default:
+			console.error('No email template found for ', template)
+	}
+
+	return null
 }


### PR DESCRIPTION
## Summary
The previously created lambda was handling one email format, but will need to respond to multiple email template requests. Allow a parameter to be passed to determine which template should be used.

Also updates the session alerts to not show unavailable data (i.e. these alerts are sent out for live sessions)

## How did you test this change?
Step function test on AWS

## Are there any deployment considerations?
Breaking change to previous lambda function

## Does this work require review from our design team?
N/A
