### PR TITLE
Publish react-email-templates via github actions

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -128,13 +128,13 @@ jobs:
               if: github.ref == 'refs/heads/main'
               run: yarn publish:render
 
+            - name: Publish session-insights-email lambda
+              if: github.ref == 'refs/heads/main'
+              run: yarn publish:react-email-templates
+
             - name: Publish client bundle
               if: github.ref == 'refs/heads/main'
               run: yarn publish:client
-
-            - name: Publish
-              if: github.ref == 'refs/heads/main'
-              run: yarn publish:react-email-templates
 
             - name: Publish changesets
               if: github.ref == 'refs/heads/main'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -132,6 +132,10 @@ jobs:
               if: github.ref == 'refs/heads/main'
               run: yarn publish:client
 
+            - name: Publish
+              if: github.ref == 'refs/heads/main'
+              run: yarn publish:react-email-templates
+
             - name: Publish changesets
               if: github.ref == 'refs/heads/main'
               id: changesets

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"publish:all": "run-p --print-label publish:ai publish:client publish:turbo publish:render",
 		"publish:ai": "yarn workspace @highlight-run/ai publish",
 		"publish:client": "yarn workspace scripts publish:client",
+		"publish:react-email-templates": "yarn workspace emails publish",
 		"publish:render": "yarn workspace render publish",
 		"publish:turbo": "yarn workspaces foreach --no-private --from '@highlight-run/*' npm publish --access public --tolerate-republish && yarn workspace highlight.run npm publish --access public --tolerate-republish && yarn workspace @highlight-run/opentelemetry-sdk-workers npm publish --access public --tolerate-republish",
 		"test:all": "yarn turbo run test --filter=!render --filter=!@highlight-run/rrweb --filter=!@highlight-run/rrweb-types --filter=!@highlight-run/rrweb-snapshot --filter=!@highlight-run/rrweb-player --filter=!@highlight-run/rrdom --filter=!@highlight-run/rrdom-nodejs --filter=!nextjs",


### PR DESCRIPTION
## Summary
Changes to ` react-email-templates` are not publishing via GitHub Actions. Add the publish to the script

## How did you test this change?
Able to run the publish command from the top level directory - `yarn publish:react-email-templates`

## Are there any deployment considerations?
Make sure deployments are not blocked

## Does this work require review from our design team?
N/A
