### PR TITLE
live mode fixes

### DIFF
--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -3034,7 +3034,7 @@ func (r *Resolver) isBrotliAccepted(ctx context.Context) bool {
 }
 
 func (r *Resolver) getEvents(ctx context.Context, s *model.Session, cursor model.EventsCursor) ([]interface{}, error, *model.EventsCursor) {
-	isLive := cursor != model.EventsCursor{}
+	isLive := cursor.EventObjectIndex != nil
 	s3Events := map[int]string{}
 	if !isLive {
 		var err error

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7909,7 +7909,6 @@ GROUP BY
 func (r *subscriptionResolver) SessionPayloadAppended(ctx context.Context, sessionSecureID string, initialEventsCount int) (<-chan *model.SessionPayload, error) {
 	ch := make(chan *model.SessionPayload)
 	r.SubscriptionWorkerPool.SubmitRecover(func() {
-		ctx := context.Background()
 		defer close(ch)
 		log.WithContext(ctx).Infof("Polling for events on %s starting from index %d, number of waiting tasks %d",
 			sessionSecureID,
@@ -7929,7 +7928,7 @@ func (r *subscriptionResolver) SessionPayloadAppended(ctx context.Context, sessi
 				log.WithContext(ctx).Error(e.Wrap(err, "error fetching session for subscription"))
 				return
 			}
-			events, err, nextCursor := r.getEvents(ctx, session, cursor)
+			events, err, nextCursor := r.getEvents(context.Background(), session, cursor)
 			if err != nil {
 				log.WithContext(ctx).Error(e.Wrap(err, "error fetching events incrementally"))
 				return

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7928,6 +7928,8 @@ func (r *subscriptionResolver) SessionPayloadAppended(ctx context.Context, sessi
 				log.WithContext(ctx).Error(e.Wrap(err, "error fetching session for subscription"))
 				return
 			}
+			// Use context.Background() here as the original ctx seems to
+			// be cancelled after 30 seconds, which cancels the redis query.
 			events, err, nextCursor := r.getEvents(context.Background(), session, cursor)
 			if err != nil {
 				log.WithContext(ctx).Error(e.Wrap(err, "error fetching events incrementally"))

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -226,7 +226,7 @@ func (r *Client) GetSessionData(ctx context.Context, sessionId int, payloadType 
 
 func (r *Client) GetEventObjects(ctx context.Context, s *model.Session, cursor model.EventsCursor, events map[int]string) ([]model.EventsObject, error, *model.EventsCursor) {
 	// Session is live if the cursor is not the default
-	isLive := cursor != model.EventsCursor{}
+	isLive := cursor.EventObjectIndex != nil
 
 	eventObjectIndex := "-inf"
 	if cursor.EventObjectIndex != nil {
@@ -303,7 +303,7 @@ func (r *Client) GetEvents(ctx context.Context, s *model.Session, cursor model.E
 		allEvents = append(allEvents, subEvents["events"]...)
 	}
 
-	if cursor.EventIndex != 0 && cursor.EventIndex < len(allEvents) {
+	if cursor.EventIndex != 0 && cursor.EventIndex <= len(allEvents) {
 		allEvents = allEvents[cursor.EventIndex:]
 	}
 


### PR DESCRIPTION
## Summary
- use the original context instead of `context.Background()` in the live mode loop to avoid auth error
- load all events from s3 the first time events are queried in live mode
- fix `cursor.EventIndex <= len(allEvents)` check - if no new events have been added, should return nothing
- fixes #7250 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
