### PR TITLE
Add trace_id and span_id as trace key suggestions

### DIFF
--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -61,6 +61,11 @@ var traceColumns = []string{
 	"StatusMessage",
 }
 
+var defaultTraceKeys = []*modelInputs.QueryKey{
+	{Name: "trace_id", Type: modelInputs.KeyTypeString},
+	{Name: "span_id", Type: modelInputs.KeyTypeString},
+}
+
 var tracesTableConfig = tableConfig[modelInputs.ReservedTraceKey]{
 	tableName:        TracesTable,
 	keysToColumns:    traceKeysToColumns,
@@ -476,18 +481,7 @@ func (client *Client) TracesKeys(ctx context.Context, projectID int, startDate t
 		return nil, err
 	}
 
-	defaultTraceKeys := []*modelInputs.QueryKey{}
-	defaultTraceKeys = append(defaultTraceKeys, &modelInputs.QueryKey{
-		Name: "trace_id",
-		Type: modelInputs.KeyTypeString,
-	})
-	defaultTraceKeys = append(defaultTraceKeys, &modelInputs.QueryKey{
-		Name: "span_id",
-		Type: modelInputs.KeyTypeString,
-	})
-
 	traceKeys = append(traceKeys, defaultTraceKeys...)
-
 	return traceKeys, nil
 }
 

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -471,7 +471,24 @@ func (client *Client) ReadTracesMetrics(ctx context.Context, projectID int, para
 }
 
 func (client *Client) TracesKeys(ctx context.Context, projectID int, startDate time.Time, endDate time.Time) ([]*modelInputs.QueryKey, error) {
-	return KeysAggregated(ctx, client, TraceKeysTable, projectID, startDate, endDate)
+	traceKeys, err := KeysAggregated(ctx, client, TraceKeysTable, projectID, startDate, endDate)
+	if err != nil {
+		return nil, err
+	}
+
+	defaultTraceKeys := []*modelInputs.QueryKey{}
+	defaultTraceKeys = append(defaultTraceKeys, &modelInputs.QueryKey{
+		Name: "trace_id",
+		Type: modelInputs.KeyTypeString,
+	})
+	defaultTraceKeys = append(defaultTraceKeys, &modelInputs.QueryKey{
+		Name: "span_id",
+		Type: modelInputs.KeyTypeString,
+	})
+
+	traceKeys = append(traceKeys, defaultTraceKeys...)
+
+	return traceKeys, nil
 }
 
 func (client *Client) TracesKeyValues(ctx context.Context, projectID int, keyName string, startDate time.Time, endDate time.Time) ([]string, error) {


### PR DESCRIPTION
## Summary

We don't populate suggestions for `trace_id` and `span_id` in the `trace_keys` table because the results are so unique. However, this means these keys also don't show up in the typeahead for suggestions when creating filters on the traces search.

This PR manually adds `trace_id` and `span_id` to the suggestions for trace keys.

<img width="636" alt="Screenshot 2023-12-07 at 11 22 37 AM" src="https://github.com/highlight/highlight/assets/308182/cc7af21e-c8b8-4d41-9e26-1e17bc55bf69">

## How did you test this change?

Local click test. Couldn't test in the PR preview because the backend changes aren't deployed.

## Are there any deployment considerations?

Should verify functionality in prod.

## Does this work require review from our design team?

N/A
