### PR TITLE
fix incorrect billing limit variable reference

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5664,7 +5664,7 @@ func (r *queryResolver) BillingDetails(ctx context.Context, workspaceID int) (*m
 	tracesIncluded := pricing.IncludedAmount(planType, model.PricingProductTypeTraces)
 	// use monthly traces limit if it exists
 	if workspace.MonthlyTracesLimit != nil {
-		tracesIncluded = int64(*workspace.MonthlyLogsLimit)
+		tracesIncluded = int64(*workspace.MonthlyTracesLimit)
 	}
 
 	sessionsRetentionPeriod := modelInputs.RetentionPeriodSixMonths


### PR DESCRIPTION
## Summary

* Fixes [panic](https://app.highlight.io/1/errors/azvH5U1kf7z0aZJ1cMiuQOrPsk4j/instances/228406210) related to loading the trace billing limit.

## How did you test this change?

Local deploy with `MonthlyTracesLimit` set to not null

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
