### PR TITLE
Add environment to python sdks

### DIFF
--- a/docs-content/sdk/python.md
+++ b/docs-content/sdk/python.md
@@ -50,6 +50,10 @@ slug: python
       <h5>service_version<code>string</code> <code>optional</code></h5>
       <p>The version of this app. We recommend setting this to the most recent deploy SHA of your app.</p>
     </aside>
+     <aside className="parameter">
+      <h5>environment<code>string</code> <code>optional</code></h5>
+      <p>Specifies the environment your application is running in. This helpful to differentiate if your project is running in production or locally.</p>
+    </aside>
   </div>
   <div className="right">
     In Flask, you'll add Highlight in your main app.py entrypoint.
@@ -63,6 +67,7 @@ slug: python
           instrument_logging=True,
           service_name="my-flask-app",
           service_version="git-sha", 
+          environment="production"
         )
     </code>
     In Django, you'll add Highlight to your settings.py file:
@@ -74,7 +79,8 @@ slug: python
           integrations=[DjangoIntegration()],
           instrument_logging=True,
           service_name="my-django-app",
-          service_version="git-sha", 
+          service_version="git-sha",
+          environment="production"
         )
     </code>
     In FastAPI, you'll add Highlight as a middleware:
@@ -85,7 +91,8 @@ slug: python
           "<YOUR_PROJECT_ID>",
           instrument_logging=True,
           service_name="my-fastapi-app",
-          service_version="git-sha", 
+          service_version="git-sha",
+          environment="production"
         )
         app = FastAPI()
         app.add_middleware(FastAPIMiddleware)

--- a/highlight.io/components/QuickstartContent/backend/python/django.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/django.tsx
@@ -31,6 +31,7 @@ H = highlight_io.H(
 	instrument_logging=True,
 	service_name="my-django-app",
 	service_version="git-sha",
+	environment="production",
 )`,
 					language: 'python',
 				},

--- a/highlight.io/components/QuickstartContent/backend/python/flask.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/flask.tsx
@@ -34,6 +34,7 @@ H = highlight_io.H(
 	instrument_logging=True,
 	service_name="my-flask-app",
 	service_version="git-sha",
+	environment="production",
 )`,
 					language: 'python',
 				},
@@ -84,6 +85,7 @@ H = highlight_io.H(
 	instrument_logging=True,
 	service_name="my-flask-app",
 	service_version="git-sha",
+	environment="production",
 )
 
 

--- a/highlight.io/components/QuickstartContent/backend/python/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/shared-snippets.tsx
@@ -58,4 +58,5 @@ H = highlight_io.H(
 	instrument_logging=True,
 	service_name="my-app",
 	service_version="git-sha",
+	environment="production",
 )`

--- a/highlight.io/components/QuickstartContent/logging/python/loguru.tsx
+++ b/highlight.io/components/QuickstartContent/logging/python/loguru.tsx
@@ -39,6 +39,7 @@ H = highlight_io.H(
 	instrument_logging=False,
 	service_name="my-app",
 	service_version="git-sha",
+	environment="production",
 )
 
 logger.add(

--- a/sdk/highlight-py/e2e/highlight_django/highlight_django/settings.py
+++ b/sdk/highlight-py/e2e/highlight_django/highlight_django/settings.py
@@ -132,4 +132,5 @@ H = highlight_io.H(
     otlp_endpoint="http://localhost:4318",
     service_name="my-django-app",
     service_version="git-sha",
+    environment="e2e-test",
 )

--- a/sdk/highlight-py/e2e/highlight_fastapi/main.py
+++ b/sdk/highlight-py/e2e/highlight_fastapi/main.py
@@ -13,6 +13,8 @@ H = highlight_io.H(
     otlp_endpoint="http://localhost:4318",
     service_name="my-fastapi-app",
     service_version="1.0.0",
+    environment="e2e-test",
+    
 )
 
 app = FastAPI()

--- a/sdk/highlight-py/e2e/highlight_flask/app.py
+++ b/sdk/highlight-py/e2e/highlight_flask/app.py
@@ -9,12 +9,13 @@ from highlight_io.integrations.flask import FlaskIntegration
 
 app = Flask(__name__)
 H = highlight_io.H(
-    "1",
+    "3",
     integrations=[FlaskIntegration()],
     instrument_logging=True,
     otlp_endpoint="http://localhost:4318",
     service_name="my-flask-app",
     service_version="1.0.0",
+    environment="e2e-test",
 )
 
 

--- a/sdk/highlight-py/e2e/highlight_loguru/main.py
+++ b/sdk/highlight-py/e2e/highlight_loguru/main.py
@@ -13,6 +13,7 @@ H = highlight_io.H(
     service_name="my-loguru-app",
     service_version="1.0.0",
     otlp_endpoint="http://localhost:4318",
+    environment="e2e-test",
 )
 
 logger.add(

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -62,6 +62,7 @@ class H(object):
         log_level=logging.DEBUG,
         service_name: str = "",
         service_version: str = "",
+        environment: str = "",
     ):
         """
         Setup Highlight backend instrumentation.
@@ -77,6 +78,7 @@ class H(object):
         :param otlp_endpoint: set to a custom otlp destination
         :param service_name: a string to name this app
         :param service_version: a string to set this app's version (typically a Git deploy sha).
+        :param environment: a string to set this app's environment (e.g. 'production', 'development').
         :return: a configured H instance
         """
         H._instance = self
@@ -90,6 +92,7 @@ class H(object):
         resource = _build_resource(
             service_name=service_name,
             service_version=service_version,
+            environment=environment,
         )
         self._trace_provider = TracerProvider(resource=resource)
         self._trace_provider.add_span_processor(
@@ -363,6 +366,7 @@ class H(object):
 def _build_resource(
     service_name: str,
     service_version: str,
+    environment: str,
 ) -> Resource:
     attrs = {}
 
@@ -370,5 +374,7 @@ def _build_resource(
         attrs[ResourceAttributes.SERVICE_NAME] = service_name
     if service_version:
         attrs[ResourceAttributes.SERVICE_VERSION] = service_version
+    if environment:
+        attrs[ResourceAttributes.DEPLOYMENT_ENVIRONMENT] = environment
 
     return Resource.create(attrs)


### PR DESCRIPTION
## Summary
Environment attribute is supported by highlight, but need to add it to the python sdk to allow users to take advantage of it.

## How did you test this change?
1) Start a python SDK
2) Hit the backend
- [ ] Any logs have the `e2e-test` environment attribute
- [ ] Any traces have the `e2e-test` environment attribute
- [ ] Any backend errors have the `e2e-test` environment attribute

Video tbd

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A