### PR TITLE
pass query and filter to backend for traces_keys

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -431,8 +431,8 @@ func (client *Client) ReadLogsHistogram(ctx context.Context, projectID int, para
 	return histogram, err
 }
 
-func (client *Client) LogsKeys(ctx context.Context, projectID int, startDate time.Time, endDate time.Time, query *string) ([]*modelInputs.QueryKey, error) {
-	return KeysAggregated(ctx, client, LogKeysTable, projectID, startDate, endDate, query)
+func (client *Client) LogsKeys(ctx context.Context, projectID int, startDate time.Time, endDate time.Time, query *string, typeArg *modelInputs.KeyType) ([]*modelInputs.QueryKey, error) {
+	return KeysAggregated(ctx, client, LogKeysTable, projectID, startDate, endDate, query, typeArg)
 }
 
 func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName string, startDate time.Time, endDate time.Time) ([]string, error) {

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -1088,7 +1088,7 @@ func TestLogsKeys(t *testing.T) {
 
 	searchKey := "s"
 	assert.NoError(t, client.BatchWriteLogRows(ctx, rows))
-	keys, err := client.LogsKeys(ctx, 1, now, now, &searchKey)
+	keys, err := client.LogsKeys(ctx, 1, now, now, &searchKey, nil)
 	assert.NoError(t, err)
 
 	expected := []*modelInputs.QueryKey{

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -363,7 +363,7 @@ func expandJSON(logAttributes map[string]string) map[string]interface{} {
 	return out
 }
 
-func KeysAggregated(ctx context.Context, client *Client, tableName string, projectID int, startDate time.Time, endDate time.Time, query *string) ([]*modelInputs.QueryKey, error) {
+func KeysAggregated(ctx context.Context, client *Client, tableName string, projectID int, startDate time.Time, endDate time.Time, query *string, typeArg *modelInputs.KeyType) ([]*modelInputs.QueryKey, error) {
 	chCtx := clickhouse.Context(ctx, clickhouse.WithSettings(clickhouse.Settings{
 		"max_rows_to_read": KeysMaxRows,
 	}))
@@ -377,6 +377,10 @@ func KeysAggregated(ctx context.Context, client *Client, tableName string, proje
 
 	if query != nil && *query != "" {
 		sb.Where(fmt.Sprintf("Key LIKE %s", sb.Var("%"+*query+"%")))
+	}
+
+	if typeArg != nil {
+		sb.Where(sb.Equal("Type", typeArg))
 	}
 
 	sb.GroupBy("1").

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -559,8 +559,8 @@ func (client *Client) ReadTracesMetrics(ctx context.Context, projectID int, para
 	return metrics, err
 }
 
-func (client *Client) TracesKeys(ctx context.Context, projectID int, startDate time.Time, endDate time.Time, query *string) ([]*modelInputs.QueryKey, error) {
-	traceKeys, err := KeysAggregated(ctx, client, TraceKeysTable, projectID, startDate, endDate, query)
+func (client *Client) TracesKeys(ctx context.Context, projectID int, startDate time.Time, endDate time.Time, query *string, typeArg *modelInputs.KeyType) ([]*modelInputs.QueryKey, error) {
+	traceKeys, err := KeysAggregated(ctx, client, TraceKeysTable, projectID, startDate, endDate, query, typeArg)
 	if err != nil {
 		return nil, err
 	}
@@ -574,7 +574,7 @@ func (client *Client) TracesKeyValues(ctx context.Context, projectID int, keyNam
 }
 
 func (client *Client) TracesMetrics(ctx context.Context, projectID int, startDate time.Time, endDate time.Time, query *string) ([]*modelInputs.QueryKey, error) {
-	return KeysAggregated(ctx, client, TraceMetricsTable, projectID, startDate, endDate, query)
+	return KeysAggregated(ctx, client, TraceMetricsTable, projectID, startDate, endDate, query, nil)
 }
 
 func TraceMatchesQuery(trace *TraceRow, filters *queryparser.Filters) bool {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2059,6 +2059,7 @@ type Query {
 		project_id: ID!
 		date_range: DateRangeRequiredInput!
 		query: String
+		type: KeyType
 	): [QueryKey!]!
 	logs_key_values(
 		project_id: ID!
@@ -2105,6 +2106,7 @@ type Query {
 		project_id: ID!
 		date_range: DateRangeRequiredInput!
 		query: String
+		type: KeyType
 	): [QueryKey!]!
 	traces_key_values(
 		project_id: ID!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7146,7 +7146,7 @@ func (r *queryResolver) MetricTags(ctx context.Context, projectID int, metricNam
 		return nil, err
 	}
 
-	keys, err := r.ClickhouseClient.TracesKeys(ctx, projectID, time.Now().Add(-30*24*time.Hour), time.Now(), query)
+	keys, err := r.ClickhouseClient.TracesKeys(ctx, projectID, time.Now().Add(-30*24*time.Hour), time.Now(), query, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -7426,13 +7426,13 @@ func (r *queryResolver) LogsHistogram(ctx context.Context, projectID int, params
 }
 
 // LogsKeys is the resolver for the logs_keys field.
-func (r *queryResolver) LogsKeys(ctx context.Context, projectID int, dateRange modelInputs.DateRangeRequiredInput, query *string) ([]*modelInputs.QueryKey, error) {
+func (r *queryResolver) LogsKeys(ctx context.Context, projectID int, dateRange modelInputs.DateRangeRequiredInput, query *string, typeArg *modelInputs.KeyType) ([]*modelInputs.QueryKey, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 
-	return r.ClickhouseClient.LogsKeys(ctx, project.ID, dateRange.StartDate, dateRange.EndDate, query)
+	return r.ClickhouseClient.LogsKeys(ctx, project.ID, dateRange.StartDate, dateRange.EndDate, query, typeArg)
 }
 
 // LogsKeyValues is the resolver for the logs_key_values field.
@@ -7698,13 +7698,13 @@ func (r *queryResolver) TracesMetrics(ctx context.Context, projectID int, params
 }
 
 // TracesKeys is the resolver for the traces_keys field.
-func (r *queryResolver) TracesKeys(ctx context.Context, projectID int, dateRange modelInputs.DateRangeRequiredInput, query *string) ([]*modelInputs.QueryKey, error) {
+func (r *queryResolver) TracesKeys(ctx context.Context, projectID int, dateRange modelInputs.DateRangeRequiredInput, query *string, typeArg *modelInputs.KeyType) ([]*modelInputs.QueryKey, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 
-	return r.ClickhouseClient.TracesKeys(ctx, project.ID, dateRange.StartDate, dateRange.EndDate, query)
+	return r.ClickhouseClient.TracesKeys(ctx, project.ID, dateRange.StartDate, dateRange.EndDate, query, typeArg)
 }
 
 // TracesKeyValues is the resolver for the traces_key_values field.

--- a/go.work.sum
+++ b/go.work.sum
@@ -396,8 +396,6 @@ github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe/go.mod h1:6pvJx4me5XP
 github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/confluentinc/confluent-kafka-go v1.4.0/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
 github.com/denisenkom/go-mssqldb v0.11.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
-github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
-github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
@@ -439,7 +437,7 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tklauser/go-sysconf v0.3.10/go.mod h1:C8XykCvCb+Gn0oNCWPIlcb0RuglQTYaQ2hGm7jmxEFk=
@@ -455,9 +453,7 @@ github.com/zenazn/goji v1.0.1/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxt
 go.mongodb.org/mongo-driver v1.7.5/go.mod h1:VXEWRZ6URJIkUq2SCAyapmhH0ZLRBP+FT4xhp5Zvxng=
 go.opentelemetry.io/contrib v0.20.0 h1:ubFQUn0VCZ0gPwIoJfBJVpeBlyRMxu8Mm/huKWYd9p0=
 go.opentelemetry.io/otel/exporters/otlp v0.20.0 h1:PTNgq9MRmQqqJY0REVbZFvwkYOA85vbdQU/nVfxDyqg=
-go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
-golang.org/x/exp v0.0.0-20230206171751-46f607a40771/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
 golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/sdk/highlight-grafana-datasource/pkg/plugin/datasource.go
+++ b/sdk/highlight-grafana-datasource/pkg/plugin/datasource.go
@@ -107,7 +107,7 @@ func (d *Datasource) CallResource(ctx context.Context, req *backend.CallResource
 	switch req.Path {
 	case "traces-keys":
 		var q struct {
-			TracesKeys []QueryKey `graphql:"trace_keys(project_id: $project_id, date_range: $date_range, query: $query, type: $type)"`
+			TracesKeys []QueryKey `graphql:"traces_keys(project_id: $project_id, date_range: $date_range, query: $query, type: $type)"`
 		}
 
 		var dataSourceSettings DataSourceSettings

--- a/sdk/highlight-grafana-datasource/pkg/plugin/datasource.go
+++ b/sdk/highlight-grafana-datasource/pkg/plugin/datasource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/hasura/go-graphql-client"
+	"github.com/openlyinc/pointy"
 	"github.com/samber/lo"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -106,24 +107,18 @@ func (d *Datasource) CallResource(ctx context.Context, req *backend.CallResource
 	switch req.Path {
 	case "traces-keys":
 		var q struct {
-			TracesKeys []QueryKey `graphql:"traces_keys(project_id: $project_id, date_range: $date_range, query: $query, type: $type)"`
+			TracesKeys []QueryKey `graphql:"trace_keys(project_id: $project_id, date_range: $date_range, query: $query, type: $type)"`
 		}
 
 		var dataSourceSettings DataSourceSettings
 		err := json.Unmarshal(req.PluginContext.DataSourceInstanceSettings.JSONData, &dataSourceSettings)
 		if err != nil {
-			return sender.Send(&backend.CallResourceResponse{
-				Status: http.StatusInternalServerError,
-				Body:   []byte(err.Error()),
-			})
+			return err
 		}
 
 		u, err := url.Parse(req.URL)
 		if err != nil {
-			return sender.Send(&backend.CallResourceResponse{
-				Status: http.StatusInternalServerError,
-				Body:   []byte(err.Error()),
-			})
+			return err
 		}
 
 		queryParams := u.Query()
@@ -141,18 +136,12 @@ func (d *Datasource) CallResource(ctx context.Context, req *backend.CallResource
 			"type":  &keyType,
 		})
 		if err != nil {
-			return sender.Send(&backend.CallResourceResponse{
-				Status: http.StatusInternalServerError,
-				Body:   []byte(err.Error()),
-			})
+			return err
 		}
 
 		body, err := json.Marshal(q.TracesKeys)
 		if err != nil {
-			return sender.Send(&backend.CallResourceResponse{
-				Status: http.StatusInternalServerError,
-				Body:   []byte(err.Error()),
-			})
+			return err
 		}
 
 		return sender.Send(&backend.CallResourceResponse{
@@ -232,6 +221,10 @@ type DataSourceSecureSettings struct {
 
 type ID string
 
+type Admin struct {
+	Id ID
+}
+
 func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, query backend.DataQuery) backend.DataResponse {
 	from := query.TimeRange.From
 	to := query.TimeRange.To
@@ -305,13 +298,13 @@ func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, quer
 
 	for _, metricType := range metricTypes {
 		for _, metricGroup := range metricGroups {
-			values := make([]float64, q.TracesMetrics.BucketCount)
+			values := make([]*float64, q.TracesMetrics.BucketCount)
 			for _, bucket := range q.TracesMetrics.Buckets {
 				if bucket.MetricType != metricType || strings.Join(bucket.Group, "-") != metricGroup {
 					continue
 				}
 
-				values[bucket.BucketID] = bucket.MetricValue
+				values[bucket.BucketID] = pointy.Float64(bucket.MetricValue)
 			}
 
 			frame.Fields = append(frame.Fields, data.NewField(string(metricType)+"."+metricGroup, nil, values))
@@ -330,11 +323,17 @@ func (d *Datasource) query(ctx context.Context, pCtx backend.PluginContext, quer
 // datasource configuration page which allows users to verify that
 // a datasource is working as expected.
 func (d *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	var status = backend.HealthStatusOk
-	var message = "Data source is working"
+	var q struct {
+		Admin Admin `graphql:"admin"`
+	}
+
+	err := d.Client.Query(ctx, &q, map[string]interface{}{})
+	if err != nil {
+		return nil, err
+	}
 
 	return &backend.CheckHealthResult{
-		Status:  status,
-		Message: message,
+		Status:  backend.HealthStatusOk,
+		Message: "Data source is working",
 	}, nil
 }

--- a/sdk/highlight-grafana-datasource/src/components/QueryEditor.tsx
+++ b/sdk/highlight-grafana-datasource/src/components/QueryEditor.tsx
@@ -51,17 +51,13 @@ export function QueryEditor({ query, onChange, onRunQuery, datasource }: Props) 
   };
 
   const loadColumnOptions = async (query: string) => {
-    let keys: TraceKey[] = await datasource.getResource('traces-keys');
-    return columnOptions
-      .concat(keys.filter((k) => k.Type === 'Numeric').map((k) => ({ value: k.Name, label: k.Name })))
-      .filter((k) => k.label.toLowerCase().includes(query.toLowerCase()));
+    let keys: TraceKey[] = await datasource.getResource('traces-keys', { query, type: 'Numeric' });
+    return columnOptions.concat(keys.map((k) => ({ value: k.Name, label: k.Name })));
   };
 
   const loadGroupByOptions = async (query: string) => {
-    let keys: TraceKey[] = await datasource.getResource('traces-keys');
-    return keys
-      .map((k) => ({ value: k.Name, label: k.Name }))
-      .filter((k) => k.label.toLowerCase().includes(query.toLowerCase()));
+    let keys: TraceKey[] = await datasource.getResource('traces-keys', { query, type: 'String' });
+    return keys.map((k) => ({ value: k.Name, label: k.Name }));
   };
 
   return (


### PR DESCRIPTION
## Summary
- we're doing backend filtering now in the `traces_keys` resolver and limiting the number of results - add the filter query and type in Grafana
- adds to logs as well to keep them consistent, is backwards compatible without type filtering
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested in the grafana plugin
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
