### PR TITLE
ensure batched workers flush correctly if no new messages are arriving

### DIFF
--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -479,6 +479,7 @@ func (w *Worker) PublicWorker(ctx context.Context, topic kafkaqueue.TopicType) {
 		for i := 0; i < cfg.Workers; i++ {
 			if cfg.Topic == kafkaqueue.TopicTypeDefault {
 				go func(workerId int) {
+					ctx := context.Background()
 					k := KafkaWorker{
 						KafkaQueue:   kafkaqueue.New(ctx, kafkaqueue.GetTopic(kafkaqueue.GetTopicOptions{Type: kafkaqueue.TopicTypeDefault}), kafkaqueue.Consumer, nil),
 						Worker:       w,

--- a/e2e/express-ts/src/index.ts
+++ b/e2e/express-ts/src/index.ts
@@ -18,9 +18,8 @@ const port = 3003
 app.use(Handlers.middleware(config))
 app.get('/', (req, res) => {
 	const err = new Error('this is a test error')
-	const highlightCtx = H.parseHeaders(req.headers)
-	if (highlightCtx) {
-		const { secureSessionId, requestId } = highlightCtx
+	const { secureSessionId, requestId } = H.parseHeaders(req.headers)
+	if (secureSessionId && requestId) {
 		console.info('Sending error to highlight', secureSessionId, requestId)
 		H.consumeError(err, secureSessionId, requestId)
 	}

--- a/e2e/express/src/index.mjs
+++ b/e2e/express/src/index.mjs
@@ -18,9 +18,8 @@ const port = 3003
 app.use(Handlers.middleware(config))
 app.get('/', (req, res) => {
 	const err = new Error('this is a test error')
-	const highlightCtx = H.parseHeaders(req.headers)
-	if (highlightCtx) {
-		const { secureSessionId, requestId } = highlightCtx
+	const { secureSessionId, requestId } = H.parseHeaders(req.headers)
+	if (secureSessionId && requestId) {
 		console.info('Sending error to highlight', secureSessionId, requestId)
 		H.consumeError(err, secureSessionId, requestId)
 	}

--- a/e2e/tests/src/test_sdk.py
+++ b/e2e/tests/src/test_sdk.py
@@ -53,7 +53,6 @@ def query(
         raise exc
 
 
-@pytest.mark.skip(reason="test is not yet stable")
 @pytest.mark.parametrize("success", ["true", "false"])
 @pytest.mark.parametrize(
     "endpoint,expected_error",
@@ -73,17 +72,14 @@ def query(
 )
 def test_next_js(next_app, oauth_api, endpoint, expected_error, success):
     start = datetime.utcnow()
-    # TODO(vkorolik) figure out why our backend always holds on to the last error rather than writing it
-    # for now, send 3 requests to ensure errors are written to highlight
-    for _ in range(3):
-        r = requests.get(
-            f"http://localhost:3005{endpoint}", params={"success": success}, timeout=30
-        )
-        logging.info(f"GET {r.url} {r.status_code} {r.text}")
-        if success == "true":
-            assert r.ok
-        else:
-            assert not r.ok
+    r = requests.get(
+        f"http://localhost:3005{endpoint}", params={"success": success}, timeout=30
+    )
+    logging.info(f"GET {r.url} {r.status_code} {r.text}")
+    if success == "true":
+        assert r.ok
+    else:
+        assert not r.ok
 
     # check that the error came thru to highlight
     if success == "false":
@@ -107,7 +103,6 @@ def test_next_js(next_app, oauth_api, endpoint, expected_error, success):
                 "query": {
                     "isAnd": True,
                     "rules": [
-                        # TODO(vkorolik) figure out why error filter returns no results
                         [
                             "error-field_timestamp",
                             "between_date",

--- a/scripts/migrations/init.sql
+++ b/scripts/migrations/init.sql
@@ -25,9 +25,31 @@ VALUES (1, now(), now(), null, 'Hobby Highlighter', 'Hobby',
         'https://avatars.githubusercontent.com/u/1351531?s=40&v=4', 'Hobby Highlighter', null, '', 'eng',
         'ENGINEERING');
 
-INSERT INTO admins (id, created_at, updated_at, deleted_at, name, first_name, last_name, hubspot_contact_id, email, about_you_details_filled, phone, number_of_sessions_viewed, number_of_error_groups_viewed, number_of_logs_viewed, email_verified, photo_url, uid, slack_im_channel_id, referral, user_defined_role, user_defined_team_size, user_defined_persona, heard_about, phone_home_contact_allowed) VALUES (1, '2023-12-08 20:59:28.019967 +00:00', '2023-12-08 20:59:28.019967 +00:00', null, 'Hobby Highlighter', 'Hobby', 'Highlighter', null, 'demo@example.com', true, '+14081234567', null, null, null, true, 'https://avatars.githubusercontent.com/u/1351531?s=40&v=4', 'Hobby Highlighter', null, '', 'eng', null, 'ENGINEERING', null, null);
-INSERT INTO admins (id, created_at, updated_at, deleted_at, name, first_name, last_name, hubspot_contact_id, email, about_you_details_filled, phone, number_of_sessions_viewed, number_of_error_groups_viewed, number_of_logs_viewed, email_verified, photo_url, uid, slack_im_channel_id, referral, user_defined_role, user_defined_team_size, user_defined_persona, heard_about, phone_home_contact_allowed) VALUES (2, '2023-12-08 20:59:47.788060 +00:00', '2023-12-08 20:59:47.788060 +00:00', null, 'Hobby Highlighter', null, null, null, 'demo@example.com', true, '+14081234567', null, null, null, true, 'https://picsum.photos/200', '<nil>', null, null, null, null, null, null, null);
-INSERT INTO admins (id, created_at, updated_at, deleted_at, name, first_name, last_name, hubspot_contact_id, email, about_you_details_filled, phone, number_of_sessions_viewed, number_of_error_groups_viewed, number_of_logs_viewed, email_verified, photo_url, uid, slack_im_channel_id, referral, user_defined_role, user_defined_team_size, user_defined_persona, heard_about, phone_home_contact_allowed) VALUES (3, '2023-12-08 21:06:03.546024 +00:00', '2023-12-08 21:06:03.546024 +00:00', null, 'Hobby Highlighter', null, null, null, 'demo@example.com', true, '+14081234567', null, null, null, true, 'https://picsum.photos/200', '12345abcdef09876a1b2c3d4e5f', null, null, null, null, null, null, null);
+INSERT INTO admins (id, created_at, updated_at, deleted_at, name, first_name, last_name, hubspot_contact_id, email,
+                    about_you_details_filled, phone, number_of_sessions_viewed, number_of_error_groups_viewed,
+                    number_of_logs_viewed, email_verified, photo_url, uid, slack_im_channel_id, referral,
+                    user_defined_role, user_defined_team_size, user_defined_persona, heard_about,
+                    phone_home_contact_allowed)
+VALUES (1, '2023-12-08 20:59:28.019967 +00:00', '2023-12-08 20:59:28.019967 +00:00', null, 'Hobby Highlighter', 'Hobby',
+        'Highlighter', null, 'demo@example.com', true, '+14081234567', null, null, null, true,
+        'https://avatars.githubusercontent.com/u/1351531?s=40&v=4', 'Hobby Highlighter', null, '', 'eng', null,
+        'ENGINEERING', null, null);
+INSERT INTO admins (id, created_at, updated_at, deleted_at, name, first_name, last_name, hubspot_contact_id, email,
+                    about_you_details_filled, phone, number_of_sessions_viewed, number_of_error_groups_viewed,
+                    number_of_logs_viewed, email_verified, photo_url, uid, slack_im_channel_id, referral,
+                    user_defined_role, user_defined_team_size, user_defined_persona, heard_about,
+                    phone_home_contact_allowed)
+VALUES (2, '2023-12-08 20:59:47.788060 +00:00', '2023-12-08 20:59:47.788060 +00:00', null, 'Hobby Highlighter', null,
+        null, null, 'demo@example.com', true, '+14081234567', null, null, null, true, 'https://picsum.photos/200',
+        '<nil>', null, null, null, null, null, null, null);
+INSERT INTO admins (id, created_at, updated_at, deleted_at, name, first_name, last_name, hubspot_contact_id, email,
+                    about_you_details_filled, phone, number_of_sessions_viewed, number_of_error_groups_viewed,
+                    number_of_logs_viewed, email_verified, photo_url, uid, slack_im_channel_id, referral,
+                    user_defined_role, user_defined_team_size, user_defined_persona, heard_about,
+                    phone_home_contact_allowed)
+VALUES (3, '2023-12-08 21:06:03.546024 +00:00', '2023-12-08 21:06:03.546024 +00:00', null, 'Hobby Highlighter', null,
+        null, null, 'demo@example.com', true, '+14081234567', null, null, null, true, 'https://picsum.photos/200',
+        '12345abcdef09876a1b2c3d4e5f', null, null, null, null, null, null, null);
 
 INSERT INTO workspace_admins (admin_id, workspace_id, created_at, updated_at, deleted_at, role)
 VALUES (1, 1, NOW(), NOW(), null, 'ADMIN');
@@ -41,6 +63,27 @@ INSERT INTO all_workspace_settings (id, created_at, updated_at, deleted_at, work
                                     replace_assets, store_ip, enable_session_export, enable_network_traces)
 VALUES (1, now(), now(), null, 1,
         true, false, false, false, 0.2, true, true, true, true);
+
+INSERT INTO sessions (created_at, updated_at, deleted_at, secure_id, client_id, identified, fingerprint, identifier,
+                      organization_id, project_id, email, ip, city, state, postal, country, latitude, longitude,
+                      os_name, os_version, browser_name, browser_version, language, has_unloaded, processed,
+                      has_rage_clicks, has_errors, has_out_of_order_events, resumed_after_processed_time, length,
+                      active_length, environment, app_version, service_name, user_object, first_time,
+                      payload_updated_at, last_user_interaction_time, beacon_time, viewed, starred, field_group,
+                      enable_strict_privacy, privacy_setting, enable_recording_network_contents, client_version,
+                      firstload_version, within_billing_quota, is_public, pages_visited,
+                      object_storage_enabled, direct_download_enabled, all_objects_compressed, payload_size, verbose_id,
+                      excluded, excluded_reason, lock, retry_count, chunked, process_with_redis, avoid_postgres_storage,
+                      normalness)
+VALUES (now(), now(), null,
+        'abc123', 'T0kuxw2zpGbtE96A1x0Qxg1ivs48', true, 1334974370, '6', 0, 1,
+        'vadim@highlight.run', '[::1]:64684', '', '', '', 'United States', 37.751, -97.822, 'Mac OS X', '10.15.7',
+        'Chrome', '119.0.0.0', 'en-US,en;q=0.9,ru;q=0.8,ko;q=0.7', true, true, false, true, false,
+        '2023-11-23 00:09:20.020096 +00:00', 1654849, 986625, 'boba-localhost', 'asdf', 'frontend', 'null',
+        false, '2023-11-23 00:34:12.909101 +00:00', '2023-11-23 00:34:12.766000 +00:00',
+        '2023-11-23 00:34:12.909101 +00:00', false, null, null, false, 'none', true, '8.2.3', '8.2.3',
+        true, false,
+        5, true, true, true, 1716704, '1', false, null, null, 0, true, true, true, 0);
 
 -- Set up oauth for testing
 INSERT INTO o_auth_client_stores (id, created_at, secret, domains, app_name, admin_id)


### PR DESCRIPTION
## Summary

A bug in the batched queue flush logic is causing the last message to never get flushed.

- datasync batch worker receives the error object update
- datasync batch worker sets the last message timestamp and waits for more messages to flush
- on the next kafka receive(), there are no more messages so the call returns nil
- we return without ever calling flush()

The change ensures we keep trying to flush (to purge previously received messages) even if we stop receiving a message.
The change also sets a receive timeout in the batched worker to wait for no more than the flush timeout
for a new message, to avoid delaying flushes.

## How did you test this change?

e2e test

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No