### PR TITLE
remove unnecessary type query

### DIFF
--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -1094,19 +1094,15 @@ func TestLogsKeys(t *testing.T) {
 	expected := []*modelInputs.QueryKey{
 		{
 			Name: "workspace_id", // workspace_id has more hits so it should be ranked higher
-			Type: modelInputs.KeyTypeNumeric,
 		},
 		{
 			Name: "service_name",
-			Type: modelInputs.KeyTypeString,
 		},
 		{
 			Name: "source",
-			Type: modelInputs.KeyTypeString,
 		},
 		{
 			Name: "user_id",
-			Type: modelInputs.KeyTypeNumeric,
 		},
 	}
 	assert.Equal(t, expected, keys)

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -369,7 +369,7 @@ func KeysAggregated(ctx context.Context, client *Client, tableName string, proje
 	}))
 
 	sb := sqlbuilder.NewSelectBuilder()
-	sb.Select("Key, sum(Count), min(Type)").
+	sb.Select("Key, sum(Count)").
 		From(tableName).
 		Where(sb.Equal("ProjectId", projectID)).
 		Where(fmt.Sprintf("Day >= toStartOfDay(%s)", sb.Var(startDate))).
@@ -405,15 +405,13 @@ func KeysAggregated(ctx context.Context, client *Client, tableName string, proje
 		var (
 			key   string
 			count uint64
-			typ   string
 		)
-		if err := rows.Scan(&key, &count, &typ); err != nil {
+		if err := rows.Scan(&key, &count); err != nil {
 			return nil, err
 		}
 
 		keys = append(keys, &modelInputs.QueryKey{
 			Name: key,
-			Type: modelInputs.KeyType(typ),
 		})
 	}
 


### PR DESCRIPTION
## Summary
- moved type filter to the backend, not necessary to return the type as all records will match the passed-in type
- fixes a bug with the `trace_metrics` table which lacks a `type` column
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested metrics suggestions, log keys, trace keys
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
