### PR TITLE
increase session processing wait time to 2 min

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -189,8 +189,8 @@ var ErrUserFilteredError = e.New("User filtered error")
 // metrics that should be stored in postgres for session lookup
 var MetricCategoriesForDB = map[string]bool{"Device": true, "WebVital": true}
 
-var SessionProcessDelaySeconds = 60 // a session will be processed after not receiving events for this time
-var SessionProcessLockMinutes = 30  // a session marked as processing can be reprocessed after this time
+var SessionProcessDelaySeconds = 120 // a session will be processed after not receiving events for this time
+var SessionProcessLockMinutes = 30   // a session marked as processing can be reprocessed after this time
 func init() {
 	if util.IsDevEnv() {
 		SessionProcessDelaySeconds = 8


### PR DESCRIPTION
## Summary
- sessions are being processed at roughly 4x the rate after switching to redis for the worker queue
- if the Redis logic is correct, this could be caused by the redis implementation returning faster than the SQL query
- try increasing the session processing delay to 2 mins to see how this reduces the number of sessions being processed
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor in prod after deployment
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
