### PR TITLE
switch args serializer

### DIFF
--- a/sdk/highlight-go/trace/tracer.go
+++ b/sdk/highlight-go/trace/tracer.go
@@ -55,8 +55,7 @@ func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 		attribute.String("graphql.field.name", fieldName),
 		attribute.String("graphql.object.type", fc.Object),
 	)
-	args := fmt.Sprintf("%+v", fc.Args)
-	if len(args) < 2048 {
+	if args := serializeVars(fc.Args); len(args) < 2048 {
 		span.SetAttributes(attribute.String("graphql.field.arguments", args))
 	}
 	res, err := next(ctx)
@@ -80,8 +79,7 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	variables := ""
 	if oc != nil {
 		opName = oc.OperationName
-		vars := fmt.Sprintf("%#+v", oc.Variables)
-		if len(vars) < 2048 {
+		if vars := serializeVars(oc.Variables); len(vars) < 2048 {
 			variables = vars
 		}
 	}
@@ -135,4 +133,11 @@ func GraphQLErrorPresenter(service string) func(ctx context.Context, e error) *g
 		}
 		return gqlerr
 	}
+}
+
+func serializeVars(vars map[string]interface{}) string {
+	if vars == nil {
+		return ""
+	}
+	return fmt.Sprintf("%#+v", vars)
 }

--- a/sdk/highlight-go/trace/tracer.go
+++ b/sdk/highlight-go/trace/tracer.go
@@ -4,7 +4,6 @@ package htrace
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/highlight/highlight/sdk/highlight-go"
@@ -56,10 +55,9 @@ func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 		attribute.String("graphql.field.name", fieldName),
 		attribute.String("graphql.object.type", fc.Object),
 	)
-	if b, err := json.MarshalIndent(fc.Args, "", ""); err == nil {
-		if bs := string(b); len(bs) < 2048 {
-			span.SetAttributes(attribute.String("graphql.field.arguments", bs))
-		}
+	args := fmt.Sprintf("%+v", fc.Args)
+	if len(args) < 2048 {
+		span.SetAttributes(attribute.String("graphql.field.arguments", args))
 	}
 	res, err := next(ctx)
 	highlight.RecordSpanError(
@@ -82,10 +80,9 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	variables := ""
 	if oc != nil {
 		opName = oc.OperationName
-		if b, err := json.MarshalIndent(oc.Variables, "", ""); err == nil {
-			if bs := string(b); len(bs) < 2048 {
-				variables = bs
-			}
+		vars := fmt.Sprintf("%#+v", oc.Variables)
+		if len(vars) < 2048 {
+			variables = vars
 		}
 	}
 	name := fmt.Sprintf("graphql.operation.%s", opName)

--- a/sdk/highlight-go/trace/tracer.go
+++ b/sdk/highlight-go/trace/tracer.go
@@ -139,5 +139,5 @@ func serializeVars(vars map[string]interface{}) string {
 	if vars == nil {
 		return ""
 	}
-	return fmt.Sprintf("%#+v", vars)
+	return fmt.Sprintf("%+v", vars)
 }

--- a/sdk/highlight-go/trace/tracer_test.go
+++ b/sdk/highlight-go/trace/tracer_test.go
@@ -50,7 +50,7 @@ func BenchmarkOld(b *testing.B) {
 		out, err = json.MarshalIndent(data, "", "")
 		assert.NoError(b, err)
 	}
-	b.Log(out)
+	b.Log(string(out))
 }
 
 func BenchmarkNew(b *testing.B) {

--- a/sdk/highlight-go/trace/tracer_test.go
+++ b/sdk/highlight-go/trace/tracer_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/highlight/highlight/sdk/highlight-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/vektah/gqlparser/v2/ast"
 	"testing"
 )
@@ -43,15 +44,21 @@ func TestTracer(t *testing.T) {
 func BenchmarkOld(b *testing.B) {
 	data := map[string]interface{}{"direction": "DESC", "params": map[string]interface{}{"date_range": map[string]interface{}{"end_date": "2023-12-15T00:28:37.564391000-00:00", "start_date": "2023-12-15T00:28:37.522161000-00:00"}, "query": "work happening"}, "project_id": "1"}
 
+	var err error
+	var out []byte
 	for i := 0; i < b.N; i++ {
-		json.MarshalIndent(data, "", "")
+		out, err = json.MarshalIndent(data, "", "")
+		assert.NoError(b, err)
 	}
+	b.Log(out)
 }
 
 func BenchmarkNew(b *testing.B) {
 	data := map[string]interface{}{"direction": "DESC", "params": map[string]interface{}{"date_range": map[string]interface{}{"end_date": "2023-12-15T00:28:37.564391000-00:00", "start_date": "2023-12-15T00:28:37.522161000-00:00"}, "query": "work happening"}, "project_id": "1"}
 
+	var out string
 	for i := 0; i < b.N; i++ {
-		serializeVars(data)
+		out = serializeVars(data)
 	}
+	b.Log(out)
 }

--- a/sdk/highlight-go/trace/tracer_test.go
+++ b/sdk/highlight-go/trace/tracer_test.go
@@ -2,6 +2,7 @@ package htrace
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -37,4 +38,20 @@ func TestTracer(t *testing.T) {
 		}
 	})
 	highlight.Stop()
+}
+
+func BenchmarkOld(b *testing.B) {
+	data := map[string]interface{}{"direction": "DESC", "params": map[string]interface{}{"date_range": map[string]interface{}{"end_date": "2023-12-15T00:28:37.564391000-00:00", "start_date": "2023-12-15T00:28:37.522161000-00:00"}, "query": "work happening"}, "project_id": "1"}
+
+	for i := 0; i < b.N; i++ {
+		json.MarshalIndent(data, "", "")
+	}
+}
+
+func BenchmarkNew(b *testing.B) {
+	data := map[string]interface{}{"direction": "DESC", "params": map[string]interface{}{"date_range": map[string]interface{}{"end_date": "2023-12-15T00:28:37.564391000-00:00", "start_date": "2023-12-15T00:28:37.522161000-00:00"}, "query": "work happening"}, "project_id": "1"}
+
+	for i := 0; i < b.N; i++ {
+		serializeVars(data)
+	}
 }


### PR DESCRIPTION
## Summary

@mayberryzane aptly discovered that our sdk wastes a lot of cpu marshalling the graphql args / vars for each request.
<img width="1800" alt="Screenshot 2023-12-14 at 4 25 38 PM" src="https://github.com/highlight/highlight/assets/1351531/0fadc34c-bddb-41af-8859-91226f61106b">

Switch to go format with `%+v` syntax to serialize much faster.
example vars output:
```
map[direction:DESC params:map[date_range:map[end_date:2023-12-15T00:28:37.564391000-00:00 start_date:2023-12-15T00:28:37.522161000-00:00] query:work happening] project_id:1]
```


## How did you test this change?

Local deploy

```go

// old
func BenchmarkName(b *testing.B) {
	data := map[string]interface{}{"direction": "DESC", "params": map[string]interface{}{"date_range": map[string]interface{}{"end_date": "2023-12-15T00:28:37.564391000-00:00", "start_date": "2023-12-15T00:28:37.522161000-00:00"}, "query": "work happening"}, "project_id": "1"}

	for i := 0; i < b.N; i++ {
		json.MarshalIndent(data, "", "")
	}
}

// BenchmarkName-10    	  452685	      2871 ns/op

// new
func BenchmarkNew(b *testing.B) {
	data := map[string]interface{}{"direction": "DESC", "params": map[string]interface{}{"date_range": map[string]interface{}{"end_date": "2023-12-15T00:28:37.564391000-00:00", "start_date": "2023-12-15T00:28:37.522161000-00:00"}, "query": "work happening"}, "project_id": "1"}

	for i := 0; i < b.N; i++ {
		serializeVars(data)
	}
}

// BenchmarkNew-10    	  732698	      1798 ns/op

```

## Are there any deployment considerations?

Will monitor performance profiling (oops might need to bring that back in dd)

## Does this work require review from our design team?

No