### PR TITLE
docs(changeset): Make Next a peer dependency to @highlight-run/next

### DIFF
--- a/.changeset/nervous-clocks-bathe.md
+++ b/.changeset/nervous-clocks-bathe.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/next': patch
+---
+
+Make Next a peer dependency to @highlight-run/next

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -53,6 +53,7 @@
 		"hoistingLimits": "workspaces"
 	},
 	"peerDependencies": {
+		"next": ">=11",
 		"react": ">=17"
 	},
 	"dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12512,6 +12512,7 @@ __metadata:
     ts-jest: ^29.0.3
     typescript: ^5.0.4
   peerDependencies:
+    next: ">=11"
     react: ">=17"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

I suspect this is the source of our recent bugs where users with fancy monorepos are having trouble importing `@highlight-run/next`.