### PR TITLE
segment trace sampling by span kind to ingest all customer logs / metrics

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"go.opentelemetry.io/otel/trace"
 	"html/template"
 	"io"
 	"math/rand"
@@ -213,8 +214,14 @@ func main() {
 	highlight.Start(
 		highlight.WithProjectID("1jdkoe52"),
 		highlight.WithEnvironment(util.EnvironmentName()),
-		highlight.WithMetricSamplingRate(1./100),
-		highlight.WithSamplingRate(1.),
+		highlight.WithMetricSamplingRate(1./1000),
+		highlight.WithSamplingRateMap(map[trace.SpanKind]float64{
+			trace.SpanKindUnspecified: 1. / 1000,
+			// report `sampling` and other important internal metrics as internal
+			trace.SpanKindInternal: 1.,
+			// keep all `Client` traces which we set for customer logs
+			trace.SpanKindClient: 1.,
+		}),
 		highlight.WithServiceName(serviceName),
 		highlight.WithServiceVersion(os.Getenv("REACT_APP_COMMIT_SHA")),
 	)

--- a/backend/main.go
+++ b/backend/main.go
@@ -217,8 +217,8 @@ func main() {
 		highlight.WithMetricSamplingRate(1./1000),
 		highlight.WithSamplingRateMap(map[trace.SpanKind]float64{
 			trace.SpanKindUnspecified: 1. / 1000,
-			// report `sampling` and other important internal metrics as internal
-			trace.SpanKindInternal: 1.,
+			// report `sampling` and other important internal metrics / sdk logs as server
+			trace.SpanKindServer: 1.,
 			// keep all `Client` traces which we set for customer logs
 			trace.SpanKindClient: 1.,
 		}),

--- a/backend/main.go
+++ b/backend/main.go
@@ -217,9 +217,10 @@ func main() {
 		highlight.WithMetricSamplingRate(1./1000),
 		highlight.WithSamplingRateMap(map[trace.SpanKind]float64{
 			trace.SpanKindUnspecified: 1. / 1000,
-			// report `sampling` and other important internal metrics / sdk logs as server
+			trace.SpanKindInternal:    1. / 1000,
+			// report `sampling`
 			trace.SpanKindServer: 1.,
-			// keep all `Client` traces which we set for customer logs
+			// report all customer data
 			trace.SpanKindClient: 1.,
 		}),
 		highlight.WithServiceName(serviceName),

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -3115,7 +3115,7 @@ func (r *Resolver) submitFrontendNetworkMetric(sessionObj *model.Session, resour
 		ctx := context.Background()
 		ctx = context.WithValue(ctx, highlight.ContextKeys.SessionSecureID, sessionObj.SecureID)
 		ctx = context.WithValue(ctx, highlight.ContextKeys.RequestID, re.RequestResponsePairs.Request.ID)
-		span, _ := highlight.StartTraceWithTimestamp(ctx, strings.Join([]string{method, re.Name}, " "), start, attributes...)
+		span, _ := highlight.StartTraceWithTimestamp(ctx, strings.Join([]string{method, re.Name}, " "), start, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, attributes...)
 		span.End(trace.WithTimestamp(end))
 	}
 	return nil

--- a/backend/public-graph/graph/sampling.go
+++ b/backend/public-graph/graph/sampling.go
@@ -23,7 +23,7 @@ import (
 
 func (r *Resolver) IsTraceIngested(ctx context.Context, trace *clickhouse.TraceRow) bool {
 	span := util.StartSpan(
-		"IsIngestedBy", util.ResourceName("sampling"), util.WithHighlightTracingDisabled(true), util.WithSpanKind(trace2.SpanKindInternal),
+		"IsIngestedBy", util.ResourceName("sampling"), util.WithHighlightTracingDisabled(true), util.WithSpanKind(trace2.SpanKindServer),
 		util.Tag(highlight.ProjectIDAttribute, trace.ProjectId),
 		util.Tag(highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 		util.Tag(highlight.TraceKeyAttribute, trace.UUID),
@@ -64,7 +64,7 @@ func (r *Resolver) IsTraceIngestedByFilter(ctx context.Context, trace *clickhous
 
 func (r *Resolver) IsLogIngested(ctx context.Context, logRow *clickhouse.LogRow) bool {
 	span := util.StartSpan(
-		"IsIngestedBy", util.ResourceName("sampling"), util.WithSpanKind(trace2.SpanKindInternal),
+		"IsIngestedBy", util.ResourceName("sampling"), util.WithSpanKind(trace2.SpanKindServer),
 		util.Tag(highlight.ProjectIDAttribute, logRow.ProjectId),
 		util.Tag(highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 		util.Tag(highlight.TraceKeyAttribute, logRow.UUID),
@@ -133,7 +133,7 @@ func (r *Resolver) IsFrontendErrorIngested(ctx context.Context, projectID int, s
 
 func (r *Resolver) IsErrorIngested(ctx context.Context, projectID int, errorObject *modelInputs.BackendErrorObjectInput) bool {
 	span := util.StartSpan(
-		"IsIngestedBy", util.ResourceName("sampling"), util.WithSpanKind(trace2.SpanKindInternal),
+		"IsIngestedBy", util.ResourceName("sampling"), util.WithSpanKind(trace2.SpanKindServer),
 		util.Tag(highlight.ProjectIDAttribute, projectID),
 		util.Tag(highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 		util.Tag(highlight.TraceKeyAttribute, getErrorObjectID(errorObject)),
@@ -195,7 +195,7 @@ func (r *Resolver) IsErrorIngestedByFilter(ctx context.Context, projectID int, e
 
 func (r *Resolver) IsSessionExcluded(ctx context.Context, s *model.Session, sessionHasErrors bool) (bool, *privateModel.SessionExcludedReason) {
 	span := util.StartSpan(
-		"IsIngestedBy", util.ResourceName("sampling"), util.WithSpanKind(trace2.SpanKindInternal),
+		"IsIngestedBy", util.ResourceName("sampling"), util.WithSpanKind(trace2.SpanKindServer),
 		util.Tag(highlight.ProjectIDAttribute, s.ProjectID),
 		util.Tag(highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 		util.Tag(highlight.TraceKeyAttribute, s.ID),

--- a/backend/public-graph/graph/sampling.go
+++ b/backend/public-graph/graph/sampling.go
@@ -15,6 +15,7 @@ import (
 	"github.com/highlight/highlight/sdk/highlight-go"
 	e "github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	trace2 "go.opentelemetry.io/otel/trace"
 	"hash/fnv"
 	"regexp"
 	"time"
@@ -22,7 +23,7 @@ import (
 
 func (r *Resolver) IsTraceIngested(ctx context.Context, trace *clickhouse.TraceRow) bool {
 	span := util.StartSpan(
-		"IsIngestedBy", util.ResourceName("sampling"), util.WithHighlightTracingDisabled(true),
+		"IsIngestedBy", util.ResourceName("sampling"), util.WithHighlightTracingDisabled(true), util.WithSpanKind(trace2.SpanKindInternal),
 		util.Tag(highlight.ProjectIDAttribute, trace.ProjectId),
 		util.Tag(highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 		util.Tag(highlight.TraceKeyAttribute, trace.UUID),
@@ -63,7 +64,7 @@ func (r *Resolver) IsTraceIngestedByFilter(ctx context.Context, trace *clickhous
 
 func (r *Resolver) IsLogIngested(ctx context.Context, logRow *clickhouse.LogRow) bool {
 	span := util.StartSpan(
-		"IsIngestedBy", util.ResourceName("sampling"),
+		"IsIngestedBy", util.ResourceName("sampling"), util.WithSpanKind(trace2.SpanKindInternal),
 		util.Tag(highlight.ProjectIDAttribute, logRow.ProjectId),
 		util.Tag(highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 		util.Tag(highlight.TraceKeyAttribute, logRow.UUID),
@@ -132,7 +133,7 @@ func (r *Resolver) IsFrontendErrorIngested(ctx context.Context, projectID int, s
 
 func (r *Resolver) IsErrorIngested(ctx context.Context, projectID int, errorObject *modelInputs.BackendErrorObjectInput) bool {
 	span := util.StartSpan(
-		"IsIngestedBy", util.ResourceName("sampling"),
+		"IsIngestedBy", util.ResourceName("sampling"), util.WithSpanKind(trace2.SpanKindInternal),
 		util.Tag(highlight.ProjectIDAttribute, projectID),
 		util.Tag(highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 		util.Tag(highlight.TraceKeyAttribute, getErrorObjectID(errorObject)),
@@ -194,7 +195,7 @@ func (r *Resolver) IsErrorIngestedByFilter(ctx context.Context, projectID int, e
 
 func (r *Resolver) IsSessionExcluded(ctx context.Context, s *model.Session, sessionHasErrors bool) (bool, *privateModel.SessionExcludedReason) {
 	span := util.StartSpan(
-		"IsIngestedBy", util.ResourceName("sampling"),
+		"IsIngestedBy", util.ResourceName("sampling"), util.WithSpanKind(trace2.SpanKindInternal),
 		util.Tag(highlight.ProjectIDAttribute, s.ProjectID),
 		util.Tag(highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 		util.Tag(highlight.TraceKeyAttribute, s.ID),

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	log "github.com/sirupsen/logrus"
+	"time"
 
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"go.opentelemetry.io/otel/attribute"
@@ -59,7 +60,7 @@ func StartSpanFromContext(ctx context.Context, operationName string, options ...
 
 	var hSpan trace.Span
 	if !hTracingDisabled {
-		hSpan, _ = highlight.StartTrace(ctx, operationName, cfg.Tags...)
+		hSpan, _ = highlight.StartTraceWithTimestamp(ctx, operationName, time.Now(), []trace.SpanStartOption{trace.WithSpanKind(cfg.SpanKind)}, cfg.Tags...)
 		ctx = trace.ContextWithSpan(ctx, hSpan)
 	}
 
@@ -76,7 +77,7 @@ func StartSpan(operationName string, options ...SpanOption) MultiSpan {
 
 	var hSpan trace.Span
 	if !cfg.HighlightTracingDisabled {
-		hSpan, _ = highlight.StartTrace(context.Background(), operationName, cfg.Tags...)
+		hSpan, _ = highlight.StartTraceWithTimestamp(context.Background(), operationName, time.Now(), []trace.SpanStartOption{trace.WithSpanKind(cfg.SpanKind)}, cfg.Tags...)
 	}
 
 	return MultiSpan{

--- a/backend/util/tracer.go
+++ b/backend/util/tracer.go
@@ -87,6 +87,7 @@ func StartSpan(operationName string, options ...SpanOption) MultiSpan {
 type SpanConfig struct {
 	Tags                     []attribute.KeyValue
 	HighlightTracingDisabled bool
+	SpanKind                 trace.SpanKind
 }
 
 type SpanOption func(cfg *SpanConfig)
@@ -107,5 +108,11 @@ func ResourceName(name string) SpanOption {
 func WithHighlightTracingDisabled(disabled bool) SpanOption {
 	return func(cfg *SpanConfig) {
 		cfg.HighlightTracingDisabled = disabled
+	}
+}
+
+func WithSpanKind(kind trace.SpanKind) SpanOption {
+	return func(cfg *SpanConfig) {
+		cfg.SpanKind = kind
 	}
 }

--- a/sdk/highlight-go/log/logrus.go
+++ b/sdk/highlight-go/log/logrus.go
@@ -59,7 +59,7 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 		ctx = context.TODO()
 	}
 
-	span, _ := highlight.StartTraceWithTimestamp(ctx, "highlight.go.log", entry.Time, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)})
+	span, _ := highlight.StartTraceWithTimestamp(ctx, "highlight.go.log", entry.Time, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindServer)})
 	defer highlight.EndTrace(span)
 
 	attrs := []attribute.KeyValue{

--- a/sdk/highlight-go/log/logrus.go
+++ b/sdk/highlight-go/log/logrus.go
@@ -59,7 +59,7 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 		ctx = context.TODO()
 	}
 
-	span, _ := highlight.StartTraceWithTimestamp(ctx, "highlight.go.log", entry.Time, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindServer)})
+	span, _ := highlight.StartTraceWithTimestamp(ctx, "highlight.go.log", entry.Time, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)})
 	defer highlight.EndTrace(span)
 
 	attrs := []attribute.KeyValue{

--- a/sdk/highlight-go/log/logrus.go
+++ b/sdk/highlight-go/log/logrus.go
@@ -3,12 +3,11 @@ package hlog
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"github.com/highlight/highlight/sdk/highlight-go"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
@@ -60,7 +59,7 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 		ctx = context.TODO()
 	}
 
-	span, _ := highlight.StartTrace(ctx, "highlight-go/log")
+	span, _ := highlight.StartTraceWithTimestamp(ctx, "highlight.go.log", entry.Time, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)})
 	defer highlight.EndTrace(span)
 
 	attrs := []attribute.KeyValue{

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -83,7 +83,7 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 
 	for _, row := range logRows {
 		span, _ := highlight.StartTraceWithoutResourceAttributes(
-			ctx, "highlight-ctx", []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)},
+			ctx, "highlight-ctx", []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)},
 			// modelInputs.LogSourceFrontend
 			attribute.String(highlight.SourceAttribute, "frontend"),
 			attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
@@ -149,7 +149,7 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 
 func submitVercelLog(ctx context.Context, projectID int, log VercelLog) {
 	span, _ := highlight.StartTraceWithoutResourceAttributes(
-		ctx, "highlight-ctx", []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)},
+		ctx, "highlight-ctx", []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)},
 		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
 	)
 	defer highlight.EndTrace(span)
@@ -195,7 +195,7 @@ func SubmitVercelLogs(ctx context.Context, projectID int, logs []VercelLog) {
 
 func SubmitHTTPLog(ctx context.Context, projectID int, lg Log) error {
 	span, _ := highlight.StartTraceWithoutResourceAttributes(
-		ctx, "highlight-ctx", []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)},
+		ctx, "highlight-ctx", []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)},
 		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
 	)
 	defer highlight.EndTrace(span)

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -83,7 +83,7 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 
 	for _, row := range logRows {
 		span, _ := highlight.StartTraceWithoutResourceAttributes(
-			ctx, "highlight-ctx",
+			ctx, "highlight-ctx", []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)},
 			// modelInputs.LogSourceFrontend
 			attribute.String(highlight.SourceAttribute, "frontend"),
 			attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
@@ -149,7 +149,7 @@ func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSe
 
 func submitVercelLog(ctx context.Context, projectID int, log VercelLog) {
 	span, _ := highlight.StartTraceWithoutResourceAttributes(
-		ctx, "highlight-ctx",
+		ctx, "highlight-ctx", []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)},
 		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
 	)
 	defer highlight.EndTrace(span)
@@ -195,7 +195,7 @@ func SubmitVercelLogs(ctx context.Context, projectID int, logs []VercelLog) {
 
 func SubmitHTTPLog(ctx context.Context, projectID int, lg Log) error {
 	span, _ := highlight.StartTraceWithoutResourceAttributes(
-		ctx, "highlight-ctx",
+		ctx, "highlight-ctx", []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)},
 		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
 	)
 	defer highlight.EndTrace(span)

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -214,7 +214,7 @@ func EndTrace(span trace.Span) {
 // as a metric that you would like to graph and monitor. You'll be able to view the metric
 // in the context of the session and network request and recorded it.
 func RecordMetric(ctx context.Context, name string, value float64, tags ...attribute.KeyValue) {
-	span, _ := StartTraceWithTimestamp(ctx, "highlight-metric", time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindServer)}, tags...)
+	span, _ := StartTraceWithTimestamp(ctx, "highlight-metric", time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, tags...)
 	defer EndTrace(span)
 	span.AddEvent(MetricEvent, trace.WithAttributes(attribute.String(MetricEventName, name), attribute.Float64(MetricEventValue, value)))
 }
@@ -223,7 +223,7 @@ func RecordMetric(ctx context.Context, name string, value float64, tags ...attri
 // Highlight session and trace are inferred from the context.
 // If no sessionID is set, then the error is associated with the project without a session context.
 func RecordError(ctx context.Context, err error, tags ...attribute.KeyValue) context.Context {
-	span, ctx := StartTraceWithTimestamp(ctx, "highlight-ctx", time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindServer)}, tags...)
+	span, ctx := StartTraceWithTimestamp(ctx, "highlight-ctx", time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, tags...)
 	defer EndTrace(span)
 	RecordSpanError(span, err)
 	return ctx

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -3,7 +3,9 @@ package highlight
 import (
 	"context"
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
+	"github.com/samber/lo"
 	"net/url"
 	"reflect"
 	"strings"
@@ -57,6 +59,44 @@ type ErrorWithStack interface {
 	StackTrace() errors.StackTrace
 }
 
+type highlightSampler struct {
+	traceIDUpperBounds map[trace.SpanKind]uint64
+	description        string
+}
+
+func (ts highlightSampler) ShouldSample(p sdktrace.SamplingParameters) sdktrace.SamplingResult {
+	psc := trace.SpanContextFromContext(p.ParentContext)
+	x := binary.BigEndian.Uint64(p.TraceID[8:16]) >> 1
+	bound, ok := ts.traceIDUpperBounds[p.Kind]
+	if !ok {
+		bound = ts.traceIDUpperBounds[trace.SpanKindUnspecified]
+	}
+	if x < bound {
+		return sdktrace.SamplingResult{
+			Decision:   sdktrace.RecordAndSample,
+			Tracestate: psc.TraceState(),
+		}
+	}
+	return sdktrace.SamplingResult{
+		Decision:   sdktrace.Drop,
+		Tracestate: psc.TraceState(),
+	}
+}
+
+func (ts highlightSampler) Description() string {
+	return ts.description
+}
+
+// creates a per-span-kind sampler that samples each kind at a provided fraction.
+func getSampler() highlightSampler {
+	return highlightSampler{
+		description: fmt.Sprintf("TraceIDRatioBased{%+v}", conf.samplingRateMap),
+		traceIDUpperBounds: lo.MapEntries(conf.samplingRateMap, func(key trace.SpanKind, value float64) (trace.SpanKind, uint64) {
+			return key, uint64(value * (1 << 63))
+		}),
+	}
+}
+
 var (
 	tracer = otel.GetTracerProvider().Tracer(
 		"github.com/highlight/highlight/sdk/highlight-go",
@@ -93,7 +133,7 @@ func StartOTLP() (*OTLP, error) {
 	}
 	h := &OTLP{
 		tracerProvider: sdktrace.NewTracerProvider(
-			sdktrace.WithSampler(sdktrace.TraceIDRatioBased(conf.samplingRate)),
+			sdktrace.WithSampler(getSampler()),
 			sdktrace.WithBatcher(
 				exporter,
 				sdktrace.WithBatchTimeout(1000*time.Millisecond),
@@ -117,7 +157,7 @@ func (o *OTLP) shutdown() {
 	}
 }
 
-func StartTraceWithTimestamp(ctx context.Context, name string, t time.Time, tags ...attribute.KeyValue) (trace.Span, context.Context) {
+func StartTraceWithTimestamp(ctx context.Context, name string, t time.Time, opts []trace.SpanStartOption, tags ...attribute.KeyValue) (trace.Span, context.Context) {
 	sessionID, requestID, _ := validateRequest(ctx)
 	spanCtx := trace.SpanContextFromContext(ctx)
 	if requestID != "" {
@@ -126,7 +166,8 @@ func StartTraceWithTimestamp(ctx context.Context, name string, t time.Time, tags
 		tid, _ := trace.TraceIDFromHex(hex)
 		spanCtx = spanCtx.WithTraceID(tid)
 	}
-	ctx, span := tracer.Start(trace.ContextWithSpanContext(ctx, spanCtx), name, trace.WithTimestamp(t))
+	opts = append(opts, trace.WithTimestamp(t))
+	ctx, span := tracer.Start(trace.ContextWithSpanContext(ctx, spanCtx), name, opts...)
 	span.SetAttributes(
 		attribute.String(ProjectIDAttribute, conf.projectID),
 		attribute.String(SessionIDAttribute, sessionID),
@@ -138,10 +179,10 @@ func StartTraceWithTimestamp(ctx context.Context, name string, t time.Time, tags
 }
 
 func StartTrace(ctx context.Context, name string, tags ...attribute.KeyValue) (trace.Span, context.Context) {
-	return StartTraceWithTimestamp(ctx, name, time.Now(), tags...)
+	return StartTraceWithTimestamp(ctx, name, time.Now(), nil, tags...)
 }
 
-func StartTraceWithoutResourceAttributes(ctx context.Context, name string, tags ...attribute.KeyValue) (trace.Span, context.Context) {
+func StartTraceWithoutResourceAttributes(ctx context.Context, name string, opts []trace.SpanStartOption, tags ...attribute.KeyValue) (trace.Span, context.Context) {
 	resourceAttributes := []attribute.KeyValue{
 		semconv.ServiceNameKey.String(""),
 		semconv.ServiceVersionKey.String(""),
@@ -160,7 +201,7 @@ func StartTraceWithoutResourceAttributes(ctx context.Context, name string, tags 
 
 	attrs := append(resourceAttributes, tags...)
 
-	return StartTrace(ctx, name, attrs...)
+	return StartTraceWithTimestamp(ctx, name, time.Now(), opts, attrs...)
 }
 
 func EndTrace(span trace.Span) {
@@ -173,7 +214,7 @@ func EndTrace(span trace.Span) {
 // as a metric that you would like to graph and monitor. You'll be able to view the metric
 // in the context of the session and network request and recorded it.
 func RecordMetric(ctx context.Context, name string, value float64, tags ...attribute.KeyValue) {
-	span, _ := StartTrace(ctx, "highlight-metric", tags...)
+	span, _ := StartTraceWithTimestamp(ctx, "highlight-metric", time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)}, tags...)
 	defer EndTrace(span)
 	span.AddEvent(MetricEvent, trace.WithAttributes(attribute.String(MetricEventName, name), attribute.Float64(MetricEventValue, value)))
 }
@@ -182,7 +223,7 @@ func RecordMetric(ctx context.Context, name string, value float64, tags ...attri
 // Highlight session and trace are inferred from the context.
 // If no sessionID is set, then the error is associated with the project without a session context.
 func RecordError(ctx context.Context, err error, tags ...attribute.KeyValue) context.Context {
-	span, ctx := StartTrace(ctx, "highlight-ctx", tags...)
+	span, ctx := StartTraceWithTimestamp(ctx, "highlight-ctx", time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)}, tags...)
 	defer EndTrace(span)
 	RecordSpanError(span, err)
 	return ctx

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -214,7 +214,7 @@ func EndTrace(span trace.Span) {
 // as a metric that you would like to graph and monitor. You'll be able to view the metric
 // in the context of the session and network request and recorded it.
 func RecordMetric(ctx context.Context, name string, value float64, tags ...attribute.KeyValue) {
-	span, _ := StartTraceWithTimestamp(ctx, "highlight-metric", time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)}, tags...)
+	span, _ := StartTraceWithTimestamp(ctx, "highlight-metric", time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindServer)}, tags...)
 	defer EndTrace(span)
 	span.AddEvent(MetricEvent, trace.WithAttributes(attribute.String(MetricEventName, name), attribute.Float64(MetricEventValue, value)))
 }
@@ -223,7 +223,7 @@ func RecordMetric(ctx context.Context, name string, value float64, tags ...attri
 // Highlight session and trace are inferred from the context.
 // If no sessionID is set, then the error is associated with the project without a session context.
 func RecordError(ctx context.Context, err error, tags ...attribute.KeyValue) context.Context {
-	span, ctx := StartTraceWithTimestamp(ctx, "highlight-ctx", time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindInternal)}, tags...)
+	span, ctx := StartTraceWithTimestamp(ctx, "highlight-ctx", time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindServer)}, tags...)
 	defer EndTrace(span)
 	RecordSpanError(span, err)
 	return ctx


### PR DESCRIPTION
## Summary

Ensure we ingest all customer logs / metrics that come from the frontend data or other
logging ingest endpoints by sampling our own traces but ensuring the traces emitted to record
a log or a metric are sampled

## How did you test this change?

still doing a bit more testing, but

frontend logs volume looks right

<img width="1130" alt="Screenshot 2023-12-15 at 12 07 13 AM" src="https://github.com/highlight/highlight/assets/1351531/af24fe2a-5ab0-4829-8b48-eb7d8b3bed94">

trace distribution coming thru

<img width="1394" alt="Screenshot 2023-12-15 at 12 23 48 AM" src="https://github.com/highlight/highlight/assets/1351531/f9aeb45b-2190-4dd1-8144-6c189d5f76ff">


## Are there any deployment considerations?

Will monitor prod logs ingest

## Does this work require review from our design team?

No