### PR TITLE
Infinite scrolling for traces

### DIFF
--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -78,7 +78,6 @@ const LogsPageInner = ({ timeMode, logCursor, startDateDefault }: Props) => {
 		error,
 		loadingAfter,
 		fetchMoreForward,
-		fetchMoreBackward,
 		refetch,
 	} = useGetLogs({
 		query,
@@ -102,22 +101,17 @@ const LogsPageInner = ({ timeMode, logCursor, startDateDefault }: Props) => {
 	}
 
 	const fetchMoreWhenScrolled = React.useCallback(
-		(
-			containerRefElement?: HTMLDivElement | null,
-			disableBackward?: boolean,
-		) => {
+		(containerRefElement?: HTMLDivElement | null) => {
 			if (containerRefElement) {
 				const { scrollHeight, scrollTop, clientHeight } =
 					containerRefElement
 				//once the user has scrolled within 100px of the bottom of the table, fetch more data if there is any
 				if (scrollHeight - scrollTop - clientHeight < 100) {
 					fetchMoreForward()
-				} else if (!disableBackward && scrollTop === 0) {
-					fetchMoreBackward()
 				}
 			}
 		},
-		[fetchMoreForward, fetchMoreBackward],
+		[fetchMoreForward],
 	)
 
 	const { projectId } = useNumericProjectId()

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -104,10 +104,7 @@ type LogsTableInnerProps = {
 	logEdges: LogEdgeWithError[]
 	query: string
 	selectedCursor: string | undefined
-	fetchMoreWhenScrolled: (
-		target: HTMLDivElement,
-		disableBackwards?: boolean,
-	) => void
+	fetchMoreWhenScrolled: (target: HTMLDivElement) => void
 	// necessary for loading most recent loads
 	moreLogs?: number
 	bodyHeight: string
@@ -282,7 +279,7 @@ const LogsTableInner = ({
 	useEffect(() => {
 		setTimeout(() => {
 			if (!loadingAfter && bodyRef?.current) {
-				fetchMoreWhenScrolled(bodyRef.current, true)
+				fetchMoreWhenScrolled(bodyRef.current)
 			}
 		}, 0)
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
@@ -60,7 +60,6 @@ export const NetworkResourceLogs: React.FC<{
 		error,
 		loadingAfter,
 		fetchMoreForward,
-		fetchMoreBackward,
 		refetch,
 	} = useGetLogs({
 		query,
@@ -71,22 +70,17 @@ export const NetworkResourceLogs: React.FC<{
 	})
 
 	const fetchMoreWhenScrolled = React.useCallback(
-		(
-			containerRefElement?: HTMLDivElement | null,
-			disableBackwards?: boolean,
-		) => {
+		(containerRefElement?: HTMLDivElement | null) => {
 			if (containerRefElement) {
 				const { scrollHeight, scrollTop, clientHeight } =
 					containerRefElement
 
 				if (scrollHeight - scrollTop - clientHeight < 100) {
 					fetchMoreForward()
-				} else if (!disableBackwards && scrollTop === 0) {
-					fetchMoreBackward()
 				}
 			}
 		},
-		[fetchMoreForward, fetchMoreBackward],
+		[fetchMoreForward],
 	)
 
 	useEffect(() => {

--- a/frontend/src/pages/Traces/TraceLogs.tsx
+++ b/frontend/src/pages/Traces/TraceLogs.tsx
@@ -35,38 +35,27 @@ export const TraceLogs: React.FC = () => {
 	const { projectId } = useProjectId()
 	const [query, setQuery] = useState('')
 
-	const {
-		logEdges,
-		loading,
-		error,
-		loadingAfter,
-		fetchMoreForward,
-		fetchMoreBackward,
-	} = useGetLogs({
-		query,
-		project_id: projectId,
-		logCursor: undefined,
-		startDate,
-		endDate,
-	})
+	const { logEdges, loading, error, loadingAfter, fetchMoreForward } =
+		useGetLogs({
+			query,
+			project_id: projectId,
+			logCursor: undefined,
+			startDate,
+			endDate,
+		})
 
 	const fetchMoreWhenScrolled = React.useCallback(
-		(
-			containerRefElement?: HTMLDivElement | null,
-			disableBackwards?: boolean,
-		) => {
+		(containerRefElement?: HTMLDivElement | null) => {
 			if (containerRefElement) {
 				const { scrollHeight, scrollTop, clientHeight } =
 					containerRefElement
 
 				if (scrollHeight - scrollTop - clientHeight < 100) {
 					fetchMoreForward()
-				} else if (!disableBackwards && scrollTop === 0) {
-					fetchMoreBackward()
 				}
 			}
 		},
-		[fetchMoreForward, fetchMoreBackward],
+		[fetchMoreForward],
 	)
 
 	// Making this a noop since there shouldn't be additional logs to fetch

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -9,33 +9,44 @@ import {
 	Tag,
 	Text,
 } from '@highlight-run/ui/components'
-import React from 'react'
+import {
+	createColumnHelper,
+	flexRender,
+	getCoreRowModel,
+	useReactTable,
+} from '@tanstack/react-table'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import React, { Key, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { AdditionalFeedResults } from '@/components/FeedResults/FeedResults'
 import { LinkButton } from '@/components/LinkButton'
 import LoadingBox from '@/components/LoadingBox'
-import { GetTracesQuery } from '@/graph/generated/operations'
-import { Trace } from '@/graph/generated/schemas'
+import { Trace, TraceEdge } from '@/graph/generated/schemas'
 import { useProjectId } from '@/hooks/useProjectId'
 import { useParams } from '@/util/react-router/useParams'
 
 type Props = {
 	loading: boolean
 	numMoreTraces?: number
-	traces?: GetTracesQuery['traces']
+	traceEdges: TraceEdge[]
 	handleAdditionalTracesDateChange?: () => void
 	resetMoreTraces?: () => void
+	fetchMoreWhenScrolled: (target: HTMLDivElement) => void
+	loadingAfter: boolean
 }
 
-const gridColumns = ['2fr', '1fr', '2fr', '1fr', '2fr', '1.2fr']
+const LOADING_AFTER_HEIGHT = 28
+const GRID_COLUMNS = ['2fr', '1fr', '2fr', '1fr', '2fr', '1.2fr']
 
 export const TracesList: React.FC<Props> = ({
 	loading,
 	numMoreTraces,
-	traces,
+	traceEdges,
 	handleAdditionalTracesDateChange,
 	resetMoreTraces,
+	fetchMoreWhenScrolled,
+	loadingAfter,
 }) => {
 	const { projectId } = useProjectId()
 	const { span_id } = useParams<{ span_id?: string }>()
@@ -48,210 +59,317 @@ export const TracesList: React.FC<Props> = ({
 		)
 	}
 
-	return (
-		<>
-			{loading ? (
-				<LoadingBox />
-			) : traces && traces.edges.length > 0 ? (
-				<Table height="full" noBorder>
-					<Table.Head>
-						<Table.Row gridColumns={gridColumns}>
-							<Table.Header>Span</Table.Header>
-							<Table.Header>Service</Table.Header>
-							<Table.Header>Trace ID</Table.Header>
-							<Table.Header>Parent Span ID</Table.Header>
-							<Table.Header>Secure Session ID</Table.Header>
-							<Table.Header>Timestamp</Table.Header>
-						</Table.Row>
-						{numMoreTraces !== undefined && numMoreTraces > 0 && (
-							<Table.Row>
-								<Box width="full">
-									<AdditionalFeedResults
-										more={numMoreTraces}
-										type="traces"
-										onClick={() => {
-											resetMoreTraces && resetMoreTraces()
-											handleAdditionalTracesDateChange &&
-												handleAdditionalTracesDateChange()
-										}}
-									/>
-								</Box>
-							</Table.Row>
-						)}
-					</Table.Head>
-					<Table.Body
-						height="full"
-						overflowY="auto"
-						style={{
-							// Subtract height of search filters + table header + charts
-							height:
-								numMoreTraces && numMoreTraces > 0
-									? `calc(100% - 191px)`
-									: `calc(100% - 163px)`,
-						}}
-					>
-						{traces.edges
-							.map((edge) => edge.node)
-							.map((trace, index) => {
-								const isSelected = trace.spanID === span_id
+	const bodyRef = useRef<HTMLDivElement>(null)
+	const enableFetchMoreTraces =
+		!!numMoreTraces &&
+		!!resetMoreTraces &&
+		!!handleAdditionalTracesDateChange
 
-								return (
-									<Table.Row
-										key={index}
-										gridColumns={gridColumns}
-										selected={isSelected}
-									>
-										<Table.Cell
-											onClick={() => viewTrace(trace)}
-										>
-											<Box
-												display="flex"
-												alignItems="center"
-												justifyContent="space-between"
-												width="full"
-											>
-												<Stack
-													direction="row"
-													align="center"
-												>
-													<Badge
-														variant="outlineGray"
-														shape="basic"
-														size="medium"
-														iconStart={
-															<IconSolidMenuAlt_2 size="12" />
-														}
-													/>
-													<Text
-														lines="1"
-														color="strong"
-													>
-														{trace.spanName}
-													</Text>
-												</Stack>
-												<Table.Discoverable>
-													<Badge
-														variant="outlineGray"
-														label="Open"
-														size="medium"
-													/>
-												</Table.Discoverable>
-											</Box>
-										</Table.Cell>
-										<Table.Cell>
-											<Text
-												lines="1"
-												title={trace.serviceName}
-											>
-												{trace.serviceName}
-											</Text>
-										</Table.Cell>
-										<Table.Cell>{trace.traceID}</Table.Cell>
-										<Table.Cell>
-											{trace.parentSpanID ? (
-												<Text lines="1">
-													{trace.parentSpanID}
-												</Text>
-											) : (
-												<Text color="secondaryContentOnDisabled">
-													empty
-												</Text>
-											)}
-										</Table.Cell>
-										<Table.Cell
-											onClick={
-												trace.secureSessionID
-													? () => {
-															navigate(
-																`/${projectId}/sessions/${trace.secureSessionID}`,
-															)
-													  }
-													: undefined
-											}
-										>
-											{trace.secureSessionID ? (
-												<Tag
-													kind="secondary"
-													shape="basic"
-													iconLeft={
-														<IconSolidPlayCircle />
-													}
-												>
-													{trace.secureSessionID}
-												</Tag>
-											) : (
-												<Text color="secondaryContentOnDisabled">
-													empty
-												</Text>
-											)}
-										</Table.Cell>
-										<Table.Cell>
-											<Text lines="1">
-												{new Date(
-													trace.timestamp,
-												).toLocaleDateString('en-US', {
-													month: 'short',
-													day: 'numeric',
-													year: 'numeric',
-													hour: 'numeric',
-													minute: 'numeric',
-													second: 'numeric',
-												})}
-											</Text>
-										</Table.Cell>
-									</Table.Row>
-								)
-							})}
-					</Table.Body>
-				</Table>
-			) : (
-				<Box px="12" py="8">
+	const columnHelper = createColumnHelper<TraceEdge>()
+
+	const columns = [
+		columnHelper.accessor('node.spanName', {
+			cell: ({ row, getValue }) => (
+				<Table.Cell onClick={() => viewTrace(row.original.node)}>
 					<Box
-						border="secondary"
-						borderRadius="6"
 						display="flex"
-						flexDirection="row"
-						gap="6"
-						p="8"
 						alignItems="center"
+						justifyContent="space-between"
 						width="full"
 					>
-						<Box alignSelf="flex-start">
+						<Stack direction="row" align="center">
 							<Badge
-								size="medium"
+								variant="outlineGray"
 								shape="basic"
-								variant="gray"
-								iconStart={<IconSolidAcademicCap size="12" />}
+								size="medium"
+								iconStart={<IconSolidMenuAlt_2 size="12" />}
 							/>
-						</Box>
-						<Stack
-							gap="12"
-							flexGrow={1}
-							style={{ padding: '5px 0' }}
-						>
-							<Text color="strong" weight="bold" size="small">
-								Set up traces
-							</Text>
-							<Text color="moderate">
-								No traces found. Have you finished setting up
-								tracing in your app yet?
+							<Text lines="1" color="strong">
+								{getValue()}
 							</Text>
 						</Stack>
-
-						<Box alignSelf="center" display="flex">
-							<LinkButton
-								to="https://www.highlight.io/docs/getting-started/tracing/overview"
-								kind="primary"
-								size="small"
-								trackingId="tracing-empty-state_learn-more-setup"
-								target="_blank"
+						<Table.Discoverable>
+							<Badge
+								variant="outlineGray"
+								label="Open"
+								size="medium"
+							/>
+						</Table.Discoverable>
+					</Box>
+				</Table.Cell>
+			),
+		}),
+		columnHelper.accessor('node.serviceName', {
+			cell: ({ getValue }) => {
+				const serviceName = getValue()
+				return (
+					<Table.Cell>
+						<Text lines="1" title={serviceName}>
+							{serviceName}
+						</Text>
+					</Table.Cell>
+				)
+			},
+		}),
+		columnHelper.accessor('node.traceID', {
+			cell: ({ getValue }) => <Table.Cell>{getValue()}</Table.Cell>,
+		}),
+		columnHelper.accessor('node.parentSpanID', {
+			cell: ({ getValue }) => {
+				const parentSpanID = getValue()
+				return (
+					<Table.Cell>
+						{parentSpanID ? (
+							<Text lines="1">{parentSpanID}</Text>
+						) : (
+							<Text color="secondaryContentOnDisabled">
+								empty
+							</Text>
+						)}
+					</Table.Cell>
+				)
+			},
+		}),
+		columnHelper.accessor('node.secureSessionID', {
+			cell: ({ getValue }) => {
+				const secureSessionID = getValue()
+				return (
+					<Table.Cell
+						onClick={
+							secureSessionID
+								? () => {
+										navigate(
+											`/${projectId}/sessions/${getValue()}`,
+										)
+								  }
+								: undefined
+						}
+					>
+						{secureSessionID ? (
+							<Tag
+								kind="secondary"
+								shape="basic"
+								iconLeft={<IconSolidPlayCircle />}
 							>
-								Learn more
-							</LinkButton>
-						</Box>
+								{secureSessionID}
+							</Tag>
+						) : (
+							<Text color="secondaryContentOnDisabled">
+								empty
+							</Text>
+						)}
+					</Table.Cell>
+				)
+			},
+		}),
+		columnHelper.accessor('node.timestamp', {
+			cell: ({ getValue }) => (
+				<Table.Cell>
+					<Text lines="1">
+						{new Date(getValue()).toLocaleDateString('en-US', {
+							month: 'short',
+							day: 'numeric',
+							year: 'numeric',
+							hour: 'numeric',
+							minute: 'numeric',
+							second: 'numeric',
+						})}
+					</Text>
+				</Table.Cell>
+			),
+		}),
+	]
+
+	const table = useReactTable({
+		data: traceEdges,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+	})
+
+	const { rows } = table.getRowModel()
+
+	const rowVirtualizer = useVirtualizer({
+		count: rows.length,
+		estimateSize: () => 38,
+		getScrollElement: () => bodyRef.current,
+		overscan: 50,
+	})
+
+	const totalSize = rowVirtualizer.getTotalSize()
+	const virtualRows = rowVirtualizer.getVirtualItems()
+	const paddingTop = virtualRows.length > 0 ? virtualRows[0]?.start || 0 : 0
+	let paddingBottom =
+		virtualRows.length > 0
+			? totalSize - (virtualRows[virtualRows.length - 1]?.end || 0)
+			: 0
+
+	if (!loadingAfter) {
+		paddingBottom += LOADING_AFTER_HEIGHT
+	}
+
+	const handleFetchMoreWhenScrolled = (
+		e: React.UIEvent<HTMLDivElement, UIEvent>,
+	) => {
+		setTimeout(() => {
+			fetchMoreWhenScrolled(e.target as HTMLDivElement)
+		}, 0)
+	}
+
+	if (loading) {
+		return <LoadingBox />
+	}
+
+	if (!traceEdges.length) {
+		return (
+			<Box px="12" py="8">
+				<Box
+					border="secondary"
+					borderRadius="6"
+					display="flex"
+					flexDirection="row"
+					gap="6"
+					p="8"
+					alignItems="center"
+					width="full"
+				>
+					<Box alignSelf="flex-start">
+						<Badge
+							size="medium"
+							shape="basic"
+							variant="gray"
+							iconStart={<IconSolidAcademicCap size="12" />}
+						/>
+					</Box>
+					<Stack gap="12" flexGrow={1} style={{ padding: '5px 0' }}>
+						<Text color="strong" weight="bold" size="small">
+							Set up traces
+						</Text>
+						<Text color="moderate">
+							No traces found. Have you finished setting up
+							tracing in your app yet?
+						</Text>
+					</Stack>
+
+					<Box alignSelf="center" display="flex">
+						<LinkButton
+							to="https://www.highlight.io/docs/getting-started/tracing/overview"
+							kind="primary"
+							size="small"
+							trackingId="tracing-empty-state_learn-more-setup"
+							target="_blank"
+						>
+							Learn more
+						</LinkButton>
 					</Box>
 				</Box>
-			)}
-		</>
+			</Box>
+		)
+	}
+
+	return (
+		<Table height="full" noBorder>
+			<Table.Head>
+				<Table.Row gridColumns={GRID_COLUMNS}>
+					<Table.Header>Span</Table.Header>
+					<Table.Header>Service</Table.Header>
+					<Table.Header>Trace ID</Table.Header>
+					<Table.Header>Parent Span ID</Table.Header>
+					<Table.Header>Secure Session ID</Table.Header>
+					<Table.Header>Timestamp</Table.Header>
+				</Table.Row>
+				{enableFetchMoreTraces && (
+					<Table.Row>
+						<Box width="full">
+							<AdditionalFeedResults
+								more={numMoreTraces}
+								type="traces"
+								onClick={() => {
+									resetMoreTraces()
+									handleAdditionalTracesDateChange()
+								}}
+							/>
+						</Box>
+					</Table.Row>
+				)}
+			</Table.Head>
+			<Table.Body
+				ref={bodyRef}
+				height="full"
+				overflowY="auto"
+				onScroll={handleFetchMoreWhenScrolled}
+				style={{
+					// Subtract height of search filters + table header + charts
+					height:
+						numMoreTraces && numMoreTraces > 0
+							? `calc(100% - 191px)`
+							: `calc(100% - 163px)`,
+				}}
+			>
+				{paddingTop > 0 && <Box style={{ height: paddingTop }} />}
+				{virtualRows.map((virtualRow) => {
+					const row = rows[virtualRow.index]
+					const isSelected = row.original.node.spanID === span_id
+
+					return (
+						<TracesTableRow
+							key={virtualRow.key}
+							row={row}
+							rowVirtualizer={rowVirtualizer}
+							virtualRowKey={virtualRow.key}
+							isSelected={isSelected}
+						/>
+					)
+				})}
+
+				{paddingBottom > 0 && <Box style={{ height: paddingBottom }} />}
+
+				{loadingAfter && (
+					<Box
+						style={{
+							height: `${LOADING_AFTER_HEIGHT}px`,
+						}}
+					>
+						<LoadingBox />
+					</Box>
+				)}
+			</Table.Body>
+		</Table>
 	)
 }
+
+type TracesTableRowProps = {
+	row: any
+	rowVirtualizer: any
+	virtualRowKey: Key
+	isSelected: boolean
+}
+
+const TracesTableRow = React.memo<TracesTableRowProps>(
+	({ row, rowVirtualizer, virtualRowKey, isSelected }) => {
+		return (
+			<Table.Row
+				data-index={virtualRowKey}
+				gridColumns={GRID_COLUMNS}
+				forwardRef={rowVirtualizer.measureElement}
+				selected={isSelected}
+			>
+				{row.getVisibleCells().map((cell: any) => {
+					return (
+						<React.Fragment key={cell.column.id}>
+							{flexRender(
+								cell.column.columnDef.cell,
+								cell.getContext(),
+							)}
+						</React.Fragment>
+					)
+				})}
+			</Table.Row>
+		)
+	},
+	(prevProps, nextProps) => {
+		return (
+			prevProps.virtualRowKey === nextProps.virtualRowKey &&
+			prevProps.isSelected === nextProps.isSelected
+		)
+	},
+)

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -1,0 +1,183 @@
+import { useGetTracesLazyQuery, useGetTracesQuery } from '@graph/hooks'
+import { GetTracesQuery, GetTracesQueryVariables } from '@graph/operations'
+import { PageInfo, TraceEdge } from '@graph/schemas'
+import * as Types from '@graph/schemas'
+import { usePollQuery } from '@util/search'
+import moment from 'moment'
+import { useCallback, useEffect, useState } from 'react'
+
+import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
+import {
+	buildSearchQueryForServer,
+	parseSearchQuery,
+} from '@/components/Search/SearchForm/utils'
+
+const initialWindowInfo: PageInfo = {
+	hasNextPage: true,
+	hasPreviousPage: true,
+	startCursor: '', // unused but needed for typedef
+	endCursor: '', // unused but needed for typedef
+}
+
+export const useGetTraces = ({
+	query,
+	projectId,
+	traceCursor,
+	startDate,
+	endDate,
+}: {
+	query: string
+	projectId: string | undefined
+	traceCursor: string | undefined
+	startDate: Date
+	endDate: Date
+}) => {
+	// The backend can only tell us page info about a single page.
+	// It has no idea what pages have already been loaded.
+	//
+	// For example: say we make the initial request for 100 traces and hasNextPage=true and hasPreviousPage=false
+	// That means that we should not make any requests when going backwards.
+	//
+	// If the user scrolls forward to get the next 100 traces, the server will say that hasPreviousPage is `true` since we're on page 2.
+	// Hence, we track the initial information (where "window" is effectively multiple pages) to ensure we aren't making requests unnecessarily.
+	const [windowInfo, setWindowInfo] = useState<PageInfo>(initialWindowInfo)
+	const [loadingAfter, setLoadingAfter] = useState(false)
+	const [loadingBefore, setLoadingBefore] = useState(false)
+	const queryTerms = parseSearchQuery(query)
+	const serverQuery = buildSearchQueryForServer(queryTerms)
+
+	useEffect(() => {
+		setWindowInfo(initialWindowInfo)
+	}, [query, startDate, endDate])
+
+	const { data, loading, error, refetch, fetchMore } = useGetTracesQuery({
+		variables: {
+			project_id: projectId!,
+			at: traceCursor,
+			direction: Types.SortDirection.Desc,
+			params: {
+				query: serverQuery,
+				date_range: {
+					start_date: moment(startDate).format(TIME_FORMAT),
+					end_date: moment(endDate).format(TIME_FORMAT),
+				},
+			},
+		},
+		fetchPolicy: 'cache-and-network',
+	})
+
+	const [moreDataQuery] = useGetTracesLazyQuery({
+		fetchPolicy: 'network-only',
+	})
+
+	const { numMore, reset } = usePollQuery<
+		GetTracesQuery,
+		GetTracesQueryVariables
+	>({
+		variableFn: useCallback(
+			() => ({
+				project_id: projectId!,
+				at: traceCursor,
+				direction: Types.SortDirection.Desc,
+				params: {
+					query: serverQuery,
+					date_range: {
+						start_date: moment(endDate).format(TIME_FORMAT),
+						end_date: moment(endDate)
+							.add(1, 'hour')
+							.format(TIME_FORMAT),
+					},
+				},
+			}),
+			[endDate, traceCursor, projectId, serverQuery],
+		),
+		moreDataQuery,
+		getResultCount: useCallback((result) => {
+			if (result?.data?.traces.edges.length !== undefined) {
+				return result?.data?.traces.edges.length
+			}
+		}, []),
+	})
+
+	const fetchMoreForward = useCallback(async () => {
+		if (!windowInfo.hasNextPage || loadingAfter) {
+			return
+		}
+
+		const lastItem = data && data.traces.edges[data.traces.edges.length - 1]
+		const lastCursor = lastItem?.cursor
+
+		if (!lastCursor) {
+			return
+		}
+
+		setLoadingAfter(true)
+
+		await fetchMore({
+			variables: { after: lastCursor },
+			updateQuery: (prevResult, { fetchMoreResult }) => {
+				const newData = fetchMoreResult.traces.edges
+				setWindowInfo({
+					...windowInfo,
+					hasNextPage: fetchMoreResult.traces.pageInfo.hasNextPage,
+				})
+				setLoadingAfter(false)
+				return {
+					traces: {
+						...prevResult.traces,
+						edges: [...prevResult.traces.edges, ...newData],
+						pageInfo: fetchMoreResult.traces.pageInfo,
+					},
+				}
+			},
+		})
+	}, [data, fetchMore, loadingAfter, windowInfo])
+
+	const fetchMoreBackward = useCallback(async () => {
+		if (!windowInfo.hasPreviousPage || loadingBefore) {
+			return
+		}
+
+		const firstItem = data && data.traces.edges[0]
+		const firstCursor = firstItem?.cursor
+
+		if (!firstCursor) {
+			return
+		}
+
+		setLoadingBefore(true)
+
+		await fetchMore({
+			variables: { before: firstCursor },
+			updateQuery: (prevResult, { fetchMoreResult }) => {
+				const newData = fetchMoreResult.traces.edges
+				setWindowInfo({
+					...windowInfo,
+					hasPreviousPage:
+						fetchMoreResult.traces.pageInfo.hasPreviousPage,
+				})
+				setLoadingBefore(false)
+				return {
+					traces: {
+						...prevResult.traces,
+						edges: [...prevResult.traces.edges, ...newData],
+						pageInfo: fetchMoreResult.traces.pageInfo,
+					},
+				}
+			},
+		})
+	}, [data, fetchMore, loadingBefore, windowInfo])
+
+	return {
+		traceEdges: (data?.traces.edges || []) as TraceEdge[],
+		moreTraces: numMore,
+		clearMoreTraces: reset,
+		loading,
+		loadingAfter,
+		loadingBefore,
+		error,
+		fetchMoreForward,
+		fetchMoreBackward,
+		refetch,
+	}
+}


### PR DESCRIPTION
## Summary
Update the traces table to have an infinite scroll

Note: I also removed the "backwards" infinite scroll on the logs page since this it is not really used in favor of the "Load more" option

## How did you test this change?
1. View the traces page
2. Scroll down to the bottom of the table
- [ ] More traces loaded
- [ ] Can select a span/trace
- [ ] Can load more when polled

https://www.loom.com/share/ff7c9ac5b00e4f468289f154df0efba7?sid=f4efff9d-c624-463d-9d5b-d9757b72b1d3

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
