### PR TITLE
add extra whitespace to fix node.js code highlighting

### DIFF
--- a/docs-content/sdk/nodejs.md
+++ b/docs-content/sdk/nodejs.md
@@ -51,6 +51,7 @@ slug: nodejs
   </div>
   <div className="right">
     <code>
+
       import { H } from "@highlight-run/node";
 
       if (!H.isInitialized()) {
@@ -71,6 +72,7 @@ slug: nodejs
   </div>
   <div className="right">
     <code>
+    
       import { H } from "@highlight-run/node";
 
       if (!H.isInitialized()) {
@@ -149,6 +151,7 @@ slug: nodejs
   </div>
   <div className="right">
     <code>
+      
       import { H } from "@highlight-run/node";
 
       const handler = (request) => {


### PR DESCRIPTION
## Summary
- these specific scripts are being passed to the `HighlightCodeBlock` as a react component rather than text, not sure why this is but it's rendered as `[object Object]`
- adding extra whitespace is a workaround 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- local docs build
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
