### PR TITLE
Allow autojoin email input

### DIFF
--- a/frontend/src/pages/NewProject/AutoJoinInput.module.css
+++ b/frontend/src/pages/NewProject/AutoJoinInput.module.css
@@ -1,0 +1,21 @@
+.container {
+	align-items: flex-start;
+	row-gap: var(--size-xxSmall);
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	max-height: fit-content;
+	min-height: var(--size-xxLarge);
+}
+
+.select {
+	&:global(.ant-select-disabled .ant-select-selector) {
+		background-color: transparent !important;
+	}
+
+	:global(.ant-select-selector) {
+		padding: 0 !important;
+		border: 0px solid var(--color-gray-300) !important;
+		background-color: transparent !important;
+	}
+}

--- a/frontend/src/pages/NewProject/AutoJoinInput.tsx
+++ b/frontend/src/pages/NewProject/AutoJoinInput.tsx
@@ -1,0 +1,70 @@
+import { useAuthContext } from '@authentication/AuthContext'
+import Tooltip from '@components/Tooltip/Tooltip'
+import { Box, Text } from '@highlight-run/ui/components'
+import { Divider } from 'antd'
+import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
+import React from 'react'
+
+import styles from './AutoJoinInput.module.css'
+
+const COMMON_EMAIL_PROVIDERS = ['gmail', 'yahoo', 'hotmail']
+
+type Props = {
+	autoJoinDomains: string[]
+	setAutoJoinDomains: (domains: string[]) => void
+}
+
+export const AutoJoinInput: React.FC<Props> = ({
+	autoJoinDomains,
+	setAutoJoinDomains,
+}) => {
+	const { admin } = useAuthContext()
+	const adminsEmailDomain = getEmailDomain(admin?.email)
+
+	const handleMessageChecked = (event: CheckboxChangeEvent) => {
+		const domains = event.target.checked ? [adminsEmailDomain] : []
+		setAutoJoinDomains(domains)
+	}
+
+	// don't show if this is for workspace creation but admin is not a company email
+	if (
+		COMMON_EMAIL_PROVIDERS.some((p) => adminsEmailDomain.indexOf(p) !== -1)
+	) {
+		return null
+	}
+
+	return (
+		<Tooltip
+			title="Automatically share the workspace with all users on this domain."
+			align={{ offset: [0, 6] }}
+			mouseEnterDelay={0}
+		>
+			<div className={styles.container}>
+				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
+					<Checkbox
+						checked={autoJoinDomains.length > 0}
+						onChange={handleMessageChecked}
+					/>
+					<Text>Allowed email domains</Text>
+				</Box>
+				<Divider className="m-0 border-none pt-1" />
+				<Text color="n11">
+					Allow everyone with a <b>{getEmailDomain(admin?.email)}</b>{' '}
+					email to join your workspace.
+				</Text>
+				<Divider className="m-0 border-none pt-1" />
+			</div>
+		</Tooltip>
+	)
+}
+
+const getEmailDomain = (email?: string) => {
+	if (!email) {
+		return ''
+	}
+	if (!email.includes('@')) {
+		return ''
+	}
+	const [, domain] = email.split('@')
+	return domain
+}

--- a/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/frontend/src/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -2,7 +2,7 @@ import Alert from '@components/Alert/Alert'
 import { FieldsBox } from '@components/FieldsBox/FieldsBox'
 import { AdminRole } from '@graph/schemas'
 import { Box } from '@highlight-run/ui/components'
-import AutoJoinForm from '@pages/WorkspaceTeam/components/AutoJoinForm'
+import { AutoJoinForm } from '@pages/WorkspaceTeam/components/AutoJoinForm'
 import { Authorization } from '@util/authorization/authorization'
 import React from 'react'
 

--- a/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
+++ b/frontend/src/pages/WorkspaceTeam/WorkspaceTeam.tsx
@@ -9,7 +9,7 @@ import {
 	Stack,
 } from '@highlight-run/ui/components'
 import AllMembers from '@pages/WorkspaceTeam/components/AllMembers'
-import AutoJoinForm from '@pages/WorkspaceTeam/components/AutoJoinForm'
+import { AutoJoinForm } from '@pages/WorkspaceTeam/components/AutoJoinForm'
 import InviteMemberModal from '@pages/WorkspaceTeam/components/InviteMemberModal'
 import { PendingInvites } from '@pages/WorkspaceTeam/components/PendingInvites'
 import { Authorization } from '@util/authorization/authorization'
@@ -49,19 +49,7 @@ const WorkspaceTeam = () => {
 						roles!
 					</p>
 					<Authorization allowedRoles={[AdminRole.Admin]}>
-						<AutoJoinForm
-							label="Auto join"
-							labelFirst
-							allowedEmailOrigins={
-								data?.workspace?.allowed_auto_join_email_origins
-									?.length
-									? JSON.parse(
-											data?.workspace
-												?.allowed_auto_join_email_origins,
-									  )
-									: undefined
-							}
-						/>
+						<AutoJoinForm />
 					</Authorization>
 					<InviteMemberModal
 						workspaceId={workspace_id}

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css
@@ -13,12 +13,9 @@
 }
 
 .select {
+	width: 100%;
+
 	&:global(.ant-select-disabled .ant-select-selector) {
-		background-color: transparent !important;
-	}
-	:global(.ant-select-selector) {
-		padding: 0 !important;
-		border: 0px solid var(--color-gray-300) !important;
-		background-color: transparent !important;
+		background-color: var(--color-primary-background) !important;
 	}
 }

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.module.css
@@ -8,10 +8,6 @@
 	min-height: var(--size-xxLarge);
 }
 
-.switchClass {
-	flex-shrink: 0;
-}
-
 .select {
 	width: 100%;
 

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -17,6 +17,7 @@ import styles from './AutoJoinForm.module.css'
 export const AutoJoinForm: React.FC = () => {
 	const { workspace_id } = useParams<{ workspace_id: string }>()
 	const { admin } = useAuthContext()
+	const adminsEmailDomain = getEmailDomain(admin?.email)
 	const [updateAllowedEmailOrigins] = useUpdateAllowedEmailOriginsMutation()
 	const [autoJoinDomains, setAutoJoinDomains] = useState<string[]>([])
 	const [adminDomains, setAdminDomains] = useState<string[]>([])
@@ -69,8 +70,6 @@ export const AutoJoinForm: React.FC = () => {
 	const handleSelectChange = (domains: string[]) => {
 		onChangeMsg(domains, 'Successfully updated auto-join email domains!')
 	}
-
-	const adminsEmailDomain = getEmailDomain(admin?.email)
 
 	return (
 		<Tooltip

--- a/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/AutoJoinForm.tsx
@@ -1,38 +1,50 @@
 import { useAuthContext } from '@authentication/AuthContext'
+import Select from '@components/Select/Select'
 import Tooltip from '@components/Tooltip/Tooltip'
-import { useUpdateAllowedEmailOriginsMutation } from '@graph/hooks'
+import {
+	useGetWorkspaceAdminsQuery,
+	useUpdateAllowedEmailOriginsMutation,
+} from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
 import { Box, Text } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
-import { Divider, message } from 'antd'
-import Checkbox from 'antd/es/checkbox'
-import React, { useEffect, useState } from 'react'
+import { message } from 'antd'
+import Checkbox, { CheckboxChangeEvent } from 'antd/es/checkbox'
+import React, { useState } from 'react'
 
 import styles from './AutoJoinForm.module.css'
 
-const COMMON_EMAIL_PROVIDERS = ['gmail', 'yahoo', 'hotmail']
-
-function AutoJoinForm({
-	updateOrigins,
-	newWorkspace,
-	allowedEmailOrigins,
-}: {
-	updateOrigins?: (domains: string[]) => void
-	newWorkspace?: boolean
-	label?: string
-	labelFirst?: boolean
-	allowedEmailOrigins?: string[]
-}) {
-	const [origins, setOrigins] = useState<string[]>([])
+export const AutoJoinForm: React.FC = () => {
 	const { workspace_id } = useParams<{ workspace_id: string }>()
 	const { admin } = useAuthContext()
-
 	const [updateAllowedEmailOrigins] = useUpdateAllowedEmailOriginsMutation()
+	const [autoJoinDomains, setAutoJoinDomains] = useState<string[]>([])
+	const [adminDomains, setAdminDomains] = useState<string[]>([])
+
+	const { loading } = useGetWorkspaceAdminsQuery({
+		variables: { workspace_id: workspace_id! },
+		skip: !workspace_id,
+		onCompleted: (d) => {
+			const emailOrigins = d.workspace?.allowed_auto_join_email_origins
+				? JSON.parse(d.workspace.allowed_auto_join_email_origins)
+				: []
+
+			const allowedDomains = d.admins.reduce((acc: string[], wa) => {
+				const adminDomain = getEmailDomain(wa.admin?.email)
+				if (adminDomain.length && !acc.includes(adminDomain)) {
+					acc.push(adminDomain)
+				}
+				return acc
+			}, [])
+
+			setAutoJoinDomains(emailOrigins)
+			setAdminDomains(allowedDomains)
+		},
+	})
+
 	const onChangeMsg = (domains: string[], msg: string) => {
-		setOrigins(domains)
-		if (updateOrigins) {
-			updateOrigins(domains)
-		} else if (workspace_id) {
+		setAutoJoinDomains(domains)
+		if (workspace_id) {
 			updateAllowedEmailOrigins({
 				variables: {
 					allowed_auto_join_email_origins: JSON.stringify(domains),
@@ -45,27 +57,20 @@ function AutoJoinForm({
 		}
 	}
 
-	const adminsEmailDomain = getEmailDomain(admin?.email)
-
-	useEffect(() => {
-		if (allowedEmailOrigins) {
-			setOrigins(allowedEmailOrigins)
+	const handleCheckboxChange = (event: CheckboxChangeEvent) => {
+		const checked = event.target.checked
+		if (checked) {
+			onChangeMsg([adminsEmailDomain], 'Successfully enabled auto-join!')
+		} else {
+			onChangeMsg([], 'Successfully disabled auto-join!')
 		}
-	}, [allowedEmailOrigins])
-
-	useEffect(() => {
-		if (newWorkspace && adminsEmailDomain.length) {
-			setOrigins([adminsEmailDomain])
-		}
-	}, [newWorkspace, adminsEmailDomain])
-
-	// don't show if this is for workspace creation but admin is not a company email
-	if (
-		newWorkspace &&
-		COMMON_EMAIL_PROVIDERS.some((p) => adminsEmailDomain.indexOf(p) !== -1)
-	) {
-		return null
 	}
+
+	const handleSelectChange = (domains: string[]) => {
+		onChangeMsg(domains, 'Successfully updated auto-join email domains!')
+	}
+
+	const adminsEmailDomain = getEmailDomain(admin?.email)
 
 	return (
 		<Tooltip
@@ -76,36 +81,28 @@ function AutoJoinForm({
 			<div className={styles.container}>
 				<Box display="flex" alignItems="center" gap="8" p="0" m="0">
 					<Checkbox
-						checked={origins.length > 0}
-						onChange={(event) => {
-							const checked = event.target.checked
-							if (checked) {
-								onChangeMsg(
-									[adminsEmailDomain],
-									'Successfully enabled auto-join!',
-								)
-							} else {
-								onChangeMsg(
-									[],
-									'Successfully disabled auto-join!',
-								)
-							}
-						}}
+						checked={autoJoinDomains.length > 0}
+						onChange={handleCheckboxChange}
 					/>
-					<Text>Allowed email domains</Text>
+					<Text>Auto-approved email domains</Text>
 				</Box>
-				<Divider className="m-0 border-none pt-1" />
-				<Text color="n11">
-					Allow everyone with a <b>{getEmailDomain(admin?.email)}</b>{' '}
-					email to join your workspace.
-				</Text>
-				<Divider className="m-0 border-none pt-1" />
+				<Select
+					placeholder={`${adminsEmailDomain}, acme.corp, piedpiper.com`}
+					className={styles.select}
+					loading={loading}
+					value={autoJoinDomains}
+					mode="tags"
+					onChange={handleSelectChange}
+					options={adminDomains.map((emailOrigin) => ({
+						displayValue: emailOrigin,
+						id: emailOrigin,
+						value: emailOrigin,
+					}))}
+				/>
 			</div>
 		</Tooltip>
 	)
 }
-
-export default AutoJoinForm
 
 const getEmailDomain = (email?: string) => {
 	if (!email) {


### PR DESCRIPTION
## Summary
Update the workspace settings to allow users to input email domains they want to auto-approve for their workspace

## How did you test this change?
1) Try to create a new workspace
- [x] Checkbox is displayed to allow autojoin emails from the admin's domain
- [x] Workspace is created correctly with the option selected
2) Go to the workspace settings
- [x] Checkbox displayed to allow auto-approve email domains
- [x] Select displayed to change the auto-approved email domains
- [x] Can select domains
- [x] Can create new domain options
- [x] Allowing auto-approved email domains will default to admin's email domain
- [x] Consistent across reloads and pages (i.e. "Members" and "properties"

https://www.loom.com/share/5948481d3e4241c4bbce61587d0e3a1a?sid=04b1be01-2da0-4601-be66-cd6bfc2f8817

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
Sure
