### PR TITLE
Fixing Sitemap

### DIFF
--- a/highlight.io/highlight.logger.ts
+++ b/highlight.io/highlight.logger.ts
@@ -1,21 +1,10 @@
 import pino from 'pino'
+import { createWriteStream } from 'pino-http-send'
 
-// returns a pino logger. to be called after highlight is initialized
 export const getLogger = () => {
-	const env = {
-		projectID: '4d7k1xeo',
-		debug: false,
-		serviceName: 'highlight.io',
-	}
-	return pino({
-		transport: {
-			targets: [
-				{
-					target: '@highlight-run/pino',
-					options: env,
-					level: 'trace',
-				},
-			],
-		},
+	const stream = createWriteStream({
+		url: 'https://pub.highlight.io/v1/logs/json?project=4d7k1xeo&service=highlight-io-next-frontend',
 	})
+
+	return pino({ level: 'trace' }, stream)
 }

--- a/highlight.io/pages/api/sitemap.tsx
+++ b/highlight.io/pages/api/sitemap.tsx
@@ -1,21 +1,16 @@
 import { promises as fsp } from 'fs'
 import { gql } from 'graphql-request'
 import { NextApiRequest, NextApiResponse } from 'next'
-import pino from 'pino'
-import { createWriteStream } from 'pino-http-send'
 import { COMPETITORS } from '../../components/Competitors/competitors'
 import { FEATURES, iFeature } from '../../components/Features/features'
 import { iProduct, PRODUCTS } from '../../components/Products/products'
 import { withPageRouterHighlight } from '../../highlight.config'
+import { getLogger } from '../../highlight.logger'
 import { GraphQLRequest } from '../../utils/graphql'
 import { getBlogPaths } from '../blog'
 import { getGithubDocsPaths } from './docs/github'
 
-const stream = createWriteStream({
-	url: 'https://pub.highlight.io/v1/logs/json?project=4d7k1xeo&service=highlight-io-next-frontend',
-})
-
-const logger = pino({ level: 'trace' }, stream)
+const logger = getLogger()
 
 async function generateXML(): Promise<string> {
 	logger.info('generating sitemap')

--- a/highlight.io/pages/api/sitemap.tsx
+++ b/highlight.io/pages/api/sitemap.tsx
@@ -1,15 +1,15 @@
 import { promises as fsp } from 'fs'
 import { gql } from 'graphql-request'
 import { NextApiRequest, NextApiResponse } from 'next'
+import pino from 'pino'
+import { createWriteStream } from 'pino-http-send'
 import { COMPETITORS } from '../../components/Competitors/competitors'
 import { FEATURES, iFeature } from '../../components/Features/features'
 import { iProduct, PRODUCTS } from '../../components/Products/products'
+import { withPageRouterHighlight } from '../../highlight.config'
+import { GraphQLRequest } from '../../utils/graphql'
 import { getBlogPaths } from '../blog'
 import { getGithubDocsPaths } from './docs/github'
-import pino from 'pino'
-import { GraphQLRequest } from '../../utils/graphql'
-import { createWriteStream } from 'pino-http-send'
-import { withPageRouterHighlight } from '../../highlight.config'
 
 const stream = createWriteStream({
 	url: 'https://pub.highlight.io/v1/logs/json?project=4d7k1xeo&service=highlight-io-next-frontend',


### PR DESCRIPTION
## Summary

Sitemap was bugged and throwing an error due to Pino not being initialized properly. I modified how Pino was initialized in highlight.logger.ts. That file had a getLogger() function that was used throughout the application, but it was failing to initialize properly. It was also initialized in sitemap.tsx as follows:

```
const stream = createWriteStream({
	url: 'https://pub.highlight.io/v1/logs/json?project=4d7k1xeo&service=highlight-io-next-frontend',
})

const logger = pino({ level: 'trace' }, stream)
```

This version worked properly, so I used this snippet in getLogger() and consolidated the initialization. 

## How did you test this change?

Refreshed localhost:4000/sitemap.xml until it rendered properly

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
