### PR TITLE
use variable delay for processing sessions

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2886,7 +2886,10 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	defer updateSpan.Finish()
 
 	excluded, reason := r.IsSessionExcluded(ctx, sessionObj, sessionHasErrors)
-	elapsedSinceUpdate := now.Sub(*sessionObj.PayloadUpdatedAt)
+	elapsedSinceUpdate := time.Hour
+	if sessionObj.PayloadUpdatedAt != nil {
+		elapsedSinceUpdate = now.Sub(*sessionObj.PayloadUpdatedAt)
+	}
 
 	// Update only if any of these fields are changing
 	// Update the PayloadUpdatedAt field only if it's been >15s since the last one

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2447,6 +2447,14 @@ func (r *Resolver) MoveSessionDataToStorage(ctx context.Context, sessionId int, 
 	return nil
 }
 
+// Returns a variable processing delay based on the session's last processing time
+func getSessionProcessingDelaySeconds(timeElapsed time.Duration) int {
+	if timeElapsed >= time.Minute {
+		return 600 // 10 minutes
+	}
+	return SessionProcessDelaySeconds
+}
+
 func (r *Resolver) SaveSessionData(ctx context.Context, projectId, sessionId, payloadId int, isBeacon bool, payloadType model.RawPayloadType, data []byte) error {
 	redisSpan, ctx := util.StartSpanFromContext(ctx, "public-graph.SaveSessionData",
 		util.ResourceName("go.parseEvents.processWithRedis"), util.Tag("project_id", projectId), util.Tag("payload_type", payloadType))
@@ -2858,11 +2866,12 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	defer updateSpan.Finish()
 
 	excluded, reason := r.IsSessionExcluded(ctx, sessionObj, sessionHasErrors)
+	elapsedSinceUpdate := now.Sub(*sessionObj.PayloadUpdatedAt)
 
 	// Update only if any of these fields are changing
 	// Update the PayloadUpdatedAt field only if it's been >15s since the last one
 	doUpdate := sessionObj.PayloadUpdatedAt == nil ||
-		now.Sub(*sessionObj.PayloadUpdatedAt) > 15*time.Second ||
+		elapsedSinceUpdate > 15*time.Second ||
 		beaconTime != nil ||
 		hasSessionUnloaded != sessionObj.HasUnloaded ||
 		(sessionObj.Processed != nil && *sessionObj.Processed) ||
@@ -2927,7 +2936,8 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 	}
 
 	if !excluded {
-		if err := r.Redis.AddSessionToProcess(ctx, sessionID, SessionProcessDelaySeconds); err != nil {
+		processingDelay := getSessionProcessingDelaySeconds(elapsedSinceUpdate)
+		if err := r.Redis.AddSessionToProcess(ctx, sessionID, processingDelay); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary
- in cases where a tab is minimized, there can be large delays between when payloads are sent, causing sessions to be reprocessed unnecessarily often due to the limited activity
- if it's been more than a minute since the last payload, wait longer before processing the session 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor metrics in prod after deployment
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
