### PR TITLE
Fix python SDK for python versions 3.9 and lower

### DIFF
--- a/sdk/highlight-py/CHANGELOG.md
+++ b/sdk/highlight-py/CHANGELOG.md
@@ -57,3 +57,10 @@
 
 - Support tracing auto-instrumentation for the requests library.
 - Add `tracing_origins` configuration to pass X-Highlight-Request header to outgoing requests.
+
+## v0.6.9 (2023-12-19)
+
+### Fix
+
+- Add support for Python versions 3.9 and lower for sdk v0.6.8.
+- Optimization of LRU cache

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -50,6 +50,7 @@ class H(object):
     _logging_instrumented = False
     # context is a LRU cache to avoid storing too many trace ids in memory
     # we should not need more than 1000 since Python processes are single-threaded
+    # context map is a cache of trace ids to (session_id, request_id) tuples
     _context_map = LRUCache(1000)
 
     @classmethod

--- a/sdk/highlight-py/highlight_io/utils/lru_cache.py
+++ b/sdk/highlight-py/highlight_io/utils/lru_cache.py
@@ -12,7 +12,7 @@ class LRUCache:
     # don't find the key in out dict / cache.
     # And also move the key to the end
     # to show that it was recently used.
-    def get(self, key, default_value):        
+    def get(self, key, default_value):
         if not key or key not in self.cache:
             return default_value
         else:

--- a/sdk/highlight-py/highlight_io/utils/lru_cache.py
+++ b/sdk/highlight-py/highlight_io/utils/lru_cache.py
@@ -12,8 +12,8 @@ class LRUCache:
     # don't find the key in out dict / cache.
     # And also move the key to the end
     # to show that it was recently used.
-    def get(self, key: int, default_value: tuple[str, str]) -> tuple[str, str]:
-        if key not in self.cache:
+    def get(self, key, default_value):        
+        if not key or key not in self.cache:
             return default_value
         else:
             self.cache.move_to_end(key)
@@ -24,7 +24,10 @@ class LRUCache:
     # But here we will also check whether the length of our
     # ordered dictionary has exceeded our capacity,
     # If so we remove the first key (least recently used)
-    def put(self, key: int, value: tuple[str, str]) -> None:
+    def put(self, key, value) -> None:
+        if not key:
+            return
+
         self.cache[key] = value
         self.cache.move_to_end(key)
         if len(self.cache) > self.capacity:

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.6.8"
+version = "0.6.9"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary
Usage of `tuple[str, str]` in method definitions is only supported in Python 3.10+. Remove the usage


## How did you test this change?
Used the following program to test
```
def main():
    print("Starting program")
    lru = LRUCache(4)

    lru.put(1, ("1", "2"))
    lru.put(2, ("3", "4")) 
    lru.put(3, ("5", "6")) 
    lru.put(4, ("7", "8")) 
    lru.get(1, ("", ""))
    lru.put(5, ("9", "10"))
    lru.put(None, ("11", "12"))

    print(lru.get(1, ("", "")))
    print(lru.get(2, ("", "")))
    print(lru.get(3, ("", "")))
    print(lru.get(4, ("", "")))
    print(lru.get(5, ("", "")))
    print(lru.get(None, ("", "")))
    print("Ending program")


if __name__ == "__main__":
    main()
```

1. Run the original LRUCache class with python 3.8
- [ ] Program exits with type error
2. Run the new LRUCache class with python 3.8
- [ ] Program executes correctly

<img width="956" alt="Screenshot 2023-12-19 at 10 23 43 AM" src="https://github.com/highlight/highlight/assets/17744174/e5f2c87f-e668-4780-8414-bb02aa31802f">


## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A