### PR TITLE
limit kafka data prefetching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
     push:
         branches:
             - 'main'
+            - 'vadim/kafka-tuning-v2'
         paths:
             - 'go.work'
             - 'go.work.sum'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
     push:
         branches:
             - 'main'
-            - 'vadim/kafka-tuning-v2'
         paths:
             - 'go.work'
             - 'go.work.sum'

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -442,7 +442,7 @@ func (p *Queue) deserializeMessage(compressed []byte) (msg *Message, error error
 func (p *Queue) resetConsumerOffset(ctx context.Context, partitionOffsets map[int]int64) (error error) {
 	cfg := p.kafkaC.Config()
 	group, err := kafka.NewConsumerGroup(kafka.ConsumerGroupConfig{
-		ID:      ConsumerGroupName,
+		ID:      strings.Join([]string{ConsumerGroupName, p.Topic}, "_"),
 		Brokers: cfg.Brokers,
 		Dialer:  cfg.Dialer,
 		Topics:  []string{cfg.Topic},

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -25,9 +25,9 @@ const KafkaOperationTimeout = 25 * time.Second
 const ConsumerGroupName = "group-default"
 
 const (
-	TaskRetries           = 5
-	prefetchQueueCapacity = 64
-	MaxMessageSizeBytes   = 500 * 1000 * 1000 // MB
+	TaskRetries           = 2
+	prefetchQueueCapacity = 8
+	MaxMessageSizeBytes   = 128 * 1000 * 1000 // MB
 )
 
 var (
@@ -209,7 +209,7 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 			ReadBatchTimeout:  KafkaOperationTimeout,
 			Topic:             pool.Topic,
 			GroupID:           pool.ConsumerGroup,
-			MaxBytes:          64 * 1000 * 1000,
+			MaxBytes:          MaxMessageSizeBytes,
 			MaxWait:           time.Second,
 			QueueCapacity:     prefetchQueueCapacity,
 			// in the future, we would commit only on successful processing of a message.

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -99,7 +99,7 @@ type ConfigOverride struct {
 func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOverride) *Queue {
 	servers := os.Getenv("KAFKA_SERVERS")
 	brokers := strings.Split(servers, ",")
-	groupID := ConsumerGroupName
+	groupID := strings.Join([]string{ConsumerGroupName, topic}, "_")
 
 	tlsConfig := &tls.Config{}
 	var mechanism sasl.Mechanism
@@ -209,7 +209,7 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 			ReadBatchTimeout:  KafkaOperationTimeout,
 			Topic:             pool.Topic,
 			GroupID:           pool.ConsumerGroup,
-			MaxBytes:          MaxMessageSizeBytes,
+			MaxBytes:          64 * 1000 * 1000,
 			MaxWait:           time.Second,
 			QueueCapacity:     prefetchQueueCapacity,
 			// in the future, we would commit only on successful processing of a message.

--- a/deploy/public-worker-main-service.json
+++ b/deploy/public-worker-main-service.json
@@ -68,8 +68,8 @@
 	"placementConstraints": [],
 	"compatibilities": ["EXTERNAL", "EC2"],
 	"requiresCompatibilities": ["EC2"],
-	"cpu": "4096",
-	"memory": "8192",
+	"cpu": "2048",
+	"memory": "16384",
 	"runtimePlatform": {
 		"cpuArchitecture": "ARM64",
 		"operatingSystemFamily": "LINUX"


### PR DESCRIPTION
## Summary

Some more tuning to our kafka configuration.
Switches back to sync writes since MSK is fine with that and we want to make sure data isn't dropped by a client.
Adds per-topic consumer groups to avoid rebalances slowing down other topic consumers.

## How did you test this change?

Manually deploying.

## Are there any deployment considerations?

Watching kafka metrics.

## Does this work require review from our design team?

No