### PR TITLE
Revert to postcss transformer

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -88,7 +88,7 @@ export default defineConfig(({ mode }) => {
 			setupFiles: ['./src/setupTests.ts'],
 		},
 		css: {
-			transformer: 'lightningcss',
+			transformer: 'postcss',
 			devSourcemap: true,
 		},
 	}


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Vite doesn't support tailwind with lightningcss transformer yet, because tailwind depends on postcss: https://github.com/vitejs/vite/discussions/13835#discussioncomment-6534835

Reflame works around this by implementing its tailwindcss compat on top of unocss, but in the long term i recall the tailwind folks are moving towards a rust based compiler that also leverages lightningcss. Should probably wait until then to switch over.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
The m-0 class now properly applies to the divider in this modal locally:

![Screenshot 2023-12-19 at 2 43 29 PM](https://github.com/highlight/highlight/assets/6934200/36374a00-e3e4-4ba1-97af-21e1701a08a4)

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
