### PR TITLE
Add types for reflame component tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
 		"@inkeep/uikit": "^0.3.8",
 		"@mux/mux-player": "^2.4.1",
 		"@mux/mux-player-react": "^2.4.1",
+		"@reflame/testing": "^0.0.2",
 		"@rehooks/local-storage": "^2.4.5",
 		"@stripe/stripe-js": "^1.32.0",
 		"@tanstack/react-table": "^8.7.9",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,6 +66,7 @@
 	},
 	"dependencies": {
 		"@ariakit/react": "^0.4.5",
+		"@reflame/testing": "^0.0.2",
 		"@rehookify/datepicker": "^6.6.1",
 		"@storybook/test": "^8.2.6",
 		"@vanilla-extract/css": "^1.13.0",

--- a/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
@@ -24,6 +24,7 @@ import { ButtonIcon } from '../ButtonIcon/ButtonIcon'
 import { Stack } from '../Stack/Stack'
 import { Text } from '../Text/Text'
 import * as styles from './styles.css'
+import type { ComponentTest } from '@reflame/testing'
 
 type Option = {
 	key: string
@@ -247,7 +248,7 @@ export const ComboboxSelect = <T extends string | string[]>({
 	)
 }
 
-export const ComboboxSelect_test = () => {
+export const ComboboxSelect_test: ComponentTest = () => {
 	const [value, setValue] = useState('')
 	const options = [
 		{ key: 'red', render: 'Red' },
@@ -270,12 +271,7 @@ export const ComboboxSelect_test = () => {
 	)
 }
 
-// Will add a TS type package for this stuff soon!
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 ComboboxSelect_test.run = async ({ step }) => {
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore
 	await step('open dialog', async ({ screen, user }) => {
 		const combobox = await screen.findByRole('combobox')
 		await user.click(combobox)
@@ -287,8 +283,6 @@ ComboboxSelect_test.run = async ({ step }) => {
 		}
 	})
 
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore
 	await step('enter filter text', async ({ screen, user }) => {
 		const filterInput = await screen.findByPlaceholderText('Filter...')
 		await user.type(filterInput, 're')
@@ -299,8 +293,6 @@ ComboboxSelect_test.run = async ({ step }) => {
 		}
 	})
 
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore
 	await step('select option', async ({ screen, user }) => {
 		const redOption = await screen.findByText('Red')
 		await user.click(redOption)

--- a/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
@@ -271,8 +271,8 @@ export const ComboboxSelect_test: ComponentTest = () => {
 	)
 }
 
-ComboboxSelect_test.run = async ({ step }) => {
-	await step('open dialog', async ({ screen, user }) => {
+ComboboxSelect_test.run = async ({ step, screen, user }) => {
+	await step('open dialog', async () => {
 		const combobox = await screen.findByRole('combobox')
 		await user.click(combobox)
 		const dialog = await screen.findByRole('dialog')
@@ -283,7 +283,7 @@ ComboboxSelect_test.run = async ({ step }) => {
 		}
 	})
 
-	await step('enter filter text', async ({ screen, user }) => {
+	await step('enter filter text', async () => {
 		const filterInput = await screen.findByPlaceholderText('Filter...')
 		await user.type(filterInput, 're')
 		return {
@@ -293,7 +293,7 @@ ComboboxSelect_test.run = async ({ step }) => {
 		}
 	})
 
-	await step('select option', async ({ screen, user }) => {
+	await step('select option', async () => {
 		const redOption = await screen.findByText('Red')
 		await user.click(redOption)
 	})

--- a/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
@@ -10,6 +10,7 @@ import {
 	useComboboxStore,
 	useSelectStore,
 } from '@ariakit/react'
+import type { ComponentTest } from '@reflame/testing'
 import clsx, { ClassValue } from 'clsx'
 import React, { useState } from 'react'
 
@@ -24,7 +25,6 @@ import { ButtonIcon } from '../ButtonIcon/ButtonIcon'
 import { Stack } from '../Stack/Stack'
 import { Text } from '../Text/Text'
 import * as styles from './styles.css'
-import type { ComponentTest } from '@reflame/testing'
 
 type Option = {
 	key: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -9707,6 +9707,7 @@ __metadata:
     "@mux/mux-player": "npm:^2.4.1"
     "@mux/mux-player-react": "npm:^2.4.1"
     "@parcel/watcher": "npm:^2.4.1"
+    "@reflame/testing": "npm:^0.0.2"
     "@rehooks/local-storage": "npm:^2.4.5"
     "@rrweb/types": "workspace:*"
     "@stripe/stripe-js": "npm:^1.32.0"
@@ -10079,6 +10080,7 @@ __metadata:
     "@capsizecss/core": "npm:^3.0.0"
     "@capsizecss/metrics": "npm:^0.3.0"
     "@mdx-js/react": "npm:^1.6.22"
+    "@reflame/testing": "npm:^0.0.2"
     "@rehookify/datepicker": "npm:^6.6.1"
     "@storybook/addon-essentials": "npm:^8.2.6"
     "@storybook/addon-interactions": "npm:^8.2.6"
@@ -16034,6 +16036,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@reflame/testing@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "@reflame/testing@npm:0.0.2"
+  dependencies:
+    "@testing-library/dom": "npm:^9.3.3"
+    "@testing-library/user-event": "npm:^14.5.1"
+    "@types/react": "npm:^18.2.45"
+  checksum: 10/11f1d30becd86fba17af0d8e7b305ff2d060a1a1ef5682674a7adb0cb6e5883fefe8b0825212cb7b64cfd62d91e3c40193eb5cee6e658f4511d4434c757c8808
+  languageName: node
+  linkType: hard
+
 "@rehookify/datepicker@npm:^6.6.1":
   version: 6.6.1
   resolution: "@rehookify/datepicker@npm:6.6.1"
@@ -19032,6 +19045,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^9.3.3":
+  version: 9.3.4
+  resolution: "@testing-library/dom@npm:9.3.4"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^5.0.1"
+    aria-query: "npm:5.1.3"
+    chalk: "npm:^4.1.0"
+    dom-accessibility-api: "npm:^0.5.9"
+    lz-string: "npm:^1.5.0"
+    pretty-format: "npm:^27.0.2"
+  checksum: 10/510da752ea76f4a10a0a4e3a77917b0302cf03effe576cd3534cab7e796533ee2b0e9fb6fb11b911a1ebd7c70a0bb6f235bf4f816c9b82b95b8fe0cddfd10975
+  languageName: node
+  linkType: hard
+
 "@testing-library/jest-dom@npm:6.4.5":
   version: 6.4.5
   resolution: "@testing-library/jest-dom@npm:6.4.5"
@@ -19132,7 +19161,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/user-event@npm:14.5.2":
+"@testing-library/user-event@npm:14.5.2, @testing-library/user-event@npm:^14.5.1":
   version: 14.5.2
   resolution: "@testing-library/user-event@npm:14.5.2"
   peerDependencies:
@@ -20712,13 +20741,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:>=16, @types/react@npm:^16.8.0 || ^17.0.0 || ^18.0.0, @types/react@npm:^18.2.25, @types/react@npm:^18.2.56, @types/react@npm:^18.3.3":
-  version: 18.3.3
-  resolution: "@types/react@npm:18.3.3"
+"@types/react@npm:*, @types/react@npm:>=16, @types/react@npm:^16.8.0 || ^17.0.0 || ^18.0.0, @types/react@npm:^18.2.25, @types/react@npm:^18.2.45, @types/react@npm:^18.2.56, @types/react@npm:^18.3.3":
+  version: 18.3.11
+  resolution: "@types/react@npm:18.3.11"
   dependencies:
     "@types/prop-types": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: 10/68e203b7f1f91d6cf21f33fc7af9d6d228035a26c83f514981e54aa3da695d0ec6af10c277c6336de1dd76c4adbe9563f3a21f80c4462000f41e5f370b46e96c
+  checksum: 10/a36f0707fdfe9fe19cbe5892bcdab0f042ecadb501ea4e1c39519943f3e74cffbd31e892d3860f5c87cf33f5f223552b246a552bed0087b95954f2cb39d5cf65
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Adds the [`@reflame/testing`](https://github.com/reflame/testing) package to provide better types for Reflame component tests, and provide some inline documentation.

![Screenshot 2023-12-19 at 7 03 29 PM](https://github.com/highlight/highlight/assets/6934200/024f3ac7-8581-40cf-9e01-c467588eff86)


## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
