### PR TITLE
fix vercel log spam

### DIFF
--- a/backend/vercel/vercel.go
+++ b/backend/vercel/vercel.go
@@ -371,11 +371,10 @@ func HandleLog(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		if l.Message != "" {
-			logs = append(logs, l)
-		} else {
-			log.WithContext(r.Context()).WithField("log", l).Warn("received empty log message from vercel")
+		if l.Message == "" {
+			l.Message = fmt.Sprintf("%s %s://%s/%s", l.Proxy.Method, l.Proxy.Scheme, l.Proxy.Host, l.Proxy.Path)
 		}
+		logs = append(logs, l)
 	}
 
 	projectVerboseID := r.Header.Get(LogDrainProjectHeader)


### PR DESCRIPTION
## Summary

Getting a lot of log spam recently from vercel empty messages which incurs quite a bit of cloudwatch processing cost.
Rather than emitting the warning log, we should write a log message for vercel requests.

<img width="1062" alt="Screenshot 2023-12-21 at 6 37 36 PM" src="https://github.com/highlight/highlight/assets/1351531/dc55a745-e5f4-4997-a1a1-661dc5e796f9">
<img width="1568" alt="Screenshot 2023-12-21 at 6 37 26 PM" src="https://github.com/highlight/highlight/assets/1351531/63752464-975b-4d82-869b-412da183daf2">

## How did you test this change?

CI

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No