### PR TITLE
switch to hnsw embeddings index

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1699,7 +1699,7 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 
 		if err := DB.Exec(fmt.Sprintf(`
 			CREATE INDEX ON error_object_embeddings_partitioned_%d
-			USING ivfflat (gte_large_embedding vector_l2_ops) WITH (lists = 1000);
+			USING hnsw (gte_large_embedding vector_l2_ops) WITH (lists = 1000);
 		`, i)).Error; err != nil {
 			return false, e.Wrapf(err, "Error creating index error_object_embeddings for index %d", i)
 		}

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1698,8 +1698,7 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 		}
 
 		if err := DB.Exec(fmt.Sprintf(`
-			CREATE INDEX ON error_object_embeddings_partitioned_%d
-			USING hnsw (gte_large_embedding vector_l2_ops) WITH (lists = 1000);
+			CREATE INDEX ON error_object_embeddings_partitioned_%d USING hnsw (gte_large_embedding vector_l2_ops);
 		`, i)).Error; err != nil {
 			return false, e.Wrapf(err, "Error creating index error_object_embeddings for index %d", i)
 		}


### PR DESCRIPTION
## Summary

Once we upgrade PG Aurora to 15.5, switch to [HNSW indexes](https://supabase.com/blog/increase-performance-pgvector-hnsw) for better embeddings search accuracy and performance.

## How did you test this change? 

Creating new index locally.

## Are there any deployment considerations?

Check that index creation will work first in prod for project 1.
Will need to create new / drop old indexes manually.

## Does this work require review from our design team?

No
