### PR TITLE
Use Reflame exports detection

### DIFF
--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -3,9 +3,9 @@
   // It's basically JSON, with the addition of comments, and looser syntax
   // (trailing commas!).
   // Reflame uses this to identify your app.
-  // "appId": "01GVH35S71FJP26W72V3K7CB2N", // prod
+  "appId": "01GVH35S71FJP26W72V3K7CB2N", // prod
   // "appId": "01GSXZYQT1W0TZDJAG94P9S4BZ", // prod fork
-  "appId": "01GR550WASJY2G2NSYZ4P54JJV", // dev
+  // "appId": "01GR550WASJY2G2NSYZ4P54JJV", // dev
   // This is what shows up in the browser's tab bar.
   "title": "highlight.io",
   // This is the description that shows up in Google search.

--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -3,9 +3,9 @@
   // It's basically JSON, with the addition of comments, and looser syntax
   // (trailing commas!).
   // Reflame uses this to identify your app.
-  "appId": "01GVH35S71FJP26W72V3K7CB2N", // prod
+  // "appId": "01GVH35S71FJP26W72V3K7CB2N", // prod
   // "appId": "01GSXZYQT1W0TZDJAG94P9S4BZ", // prod fork
-  // "appId": "01GR550WASJY2G2NSYZ4P54JJV", // dev
+  "appId": "01GR550WASJY2G2NSYZ4P54JJV", // dev
   // This is what shows up in the browser's tab bar.
   "title": "highlight.io",
   // This is the description that shows up in Google search.
@@ -167,12 +167,7 @@
     "testStories": true,
   },
   "nodejsCompatibility": {
-    "omitModuleExtension": true,
-    "mapIndexToDirectory": true,
-    "packageJson": {
-      "versionIncluded": true,
-      "dependenciesSynced": true,
-    },
+    "packageJson": true,
   },
   "tailwindCompatibility": {
     "stylesheetPathname": "/style/tailwind.css",
@@ -273,16 +268,9 @@
   "libraries": {
     "@highlight-run/ui": {
       "sourceDirectory": "packages/ui/src",
-      "entryPoints": {
-        "/components": "/components/index.ts",
-        "/css": "/css.ts",
-        "/keyframes": "/keyframes.ts",
-        "/sprinkles": "/sprinkles.ts",
-        "/vars": "/vars.ts",
-        "/theme": "/theme.ts",
-        "/colors": "/colors.ts",
-        "/borders": "/borders.ts",
-        "/styles.css": "/noop.ts",
+      "exports": {
+        "./components": "./components/index.ts",
+        "./styles.css": "./noop.ts",
       },
       "npmPackages": {
         "ariakit": {
@@ -306,10 +294,10 @@
         },
       },
       "nodejsCompatibility": {
-        "omitModuleExtension": true,
-        "mapIndexToDirectory": true,
         "packageJson": {
-          "dependenciesSynced": true,
+          "exportsDetection": {
+            "ignoreTopLevelDirectory": true
+          }
         },
       },
       "filesIgnored": [
@@ -322,19 +310,11 @@
     "highlight.run": {
       "sourceDirectory": "sdk/firstload/src",
       "entryPoint": "/index.tsx",
-      "nodejsCompatibility": {
-        "omitModuleExtension": true,
-        "mapIndexToDirectory": true,
-      },
       "npmPackages": {},
     },
     "highlight.io": {
       "sourceDirectory": "highlight.io",
       "entryPoint": "/index.ts",
-      "nodejsCompatibility": {
-        "omitModuleExtension": true,
-        "mapIndexToDirectory": true,
-      },
       "filesIgnored": [
         "**/**",
         "!components/**/**",
@@ -346,24 +326,20 @@
     },
     "@highlight-run/client": {
       "sourceDirectory": "sdk/client/src",
-      "entryPoints": {
-        "/src/listeners/first-load-listeners": "/listeners/first-load-listeners.tsx",
-        "/src/listeners/first-load-listeners.js": "/listeners/first-load-listeners.tsx",
-        "/src/listeners/network-listener/utils/utils": "/listeners/network-listener/utils/utils.ts",
-        "/src/utils/secure-id": "/utils/secure-id.ts",
-        "/src/utils/secure-id.js": "/utils/secure-id.ts",
-        "/src/utils/sessionStorage/highlightSession": "/utils/sessionStorage/highlightSession.ts",
-        "/src/utils/sessionStorage/highlightSession.js": "/utils/sessionStorage/highlightSession.ts",
-        "/src/utils/sessionStorage/sessionStorageKeys": "/utils/sessionStorage/sessionStorageKeys.ts",
-        "/src/utils/sessionStorage/sessionStorageKeys.js": "/utils/sessionStorage/sessionStorageKeys.ts",
-        "/src/utils/storage.js": "/utils/storage.ts",
+      "exports": {
+        "./src/listeners/first-load-listeners": "./listeners/first-load-listeners.tsx",
+        "./src/listeners/first-load-listeners.js": "./listeners/first-load-listeners.tsx",
+        "./src/listeners/network-listener/utils/utils": "./listeners/network-listener/utils/utils.ts",
+        "./src/utils/secure-id": "./utils/secure-id.ts",
+        "./src/utils/secure-id.js": "./utils/secure-id.ts",
+        "./src/utils/sessionStorage/highlightSession": "./utils/sessionStorage/highlightSession.ts",
+        "./src/utils/sessionStorage/highlightSession.js": "./utils/sessionStorage/highlightSession.ts",
+        "./src/utils/sessionStorage/sessionStorageKeys": "./utils/sessionStorage/sessionStorageKeys.ts",
+        "./src/utils/sessionStorage/sessionStorageKeys.js": "./utils/sessionStorage/sessionStorageKeys.ts",
+        "./src/utils/storage.js": "./utils/storage.ts",
       },
       "nodejsCompatibility": {
-        "omitModuleExtension": true,
-        "mapIndexToDirectory": true,
-        "packageJson": {
-          "dependenciesSynced": true,
-        },
+        "packageJson": true,
       },
       "specifierTransforms": {
         "/publicGraphURI.ts": "consts:publicGraphURI",

--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -316,7 +316,6 @@
           }
         },
       },
-      "npmPackages": {},
     },
     "highlight.io": {
       "sourceDirectory": "highlight.io",

--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -309,12 +309,18 @@
     },
     "highlight.run": {
       "sourceDirectory": "sdk/firstload/src",
-      "entryPoint": "/index.tsx",
+      "nodejsCompatibility": {
+        "packageJson": {
+          "exportsDetection": {
+            "ignoreTopLevelDirectory": true
+          }
+        },
+      },
       "npmPackages": {},
     },
     "highlight.io": {
       "sourceDirectory": "highlight.io",
-      "entryPoint": "/index.ts",
+      "exports": "./index.ts",
       "filesIgnored": [
         "**/**",
         "!components/**/**",


### PR DESCRIPTION
## Summary

Removes some redundant options that have been made default, and migrates to our new package.json exports compat where possible so there's a single source of truth for import resolution.

Left comments on each change for more context.

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

Reflame preview & tests still work.

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
