### PR TITLE
remove request body reader in python sdk

### DIFF
--- a/sdk/highlight-py/e2e/highlight_fastapi/main.py
+++ b/sdk/highlight-py/e2e/highlight_fastapi/main.py
@@ -26,7 +26,11 @@ router = APIRouter()
 @app.post("/")
 async def root(request: Request):
     logging.info(
-        "hello, world", {"customer": request.headers.get("customer") or "unknown"}
+        "hello, world",
+        {
+            "customer": request.headers.get("customer") or "unknown",
+            "data": await request.json(),
+        },
     )
     for idx in range(100):
         logging.info(f"hello {idx}")

--- a/sdk/highlight-py/highlight_io/integrations/fastapi.py
+++ b/sdk/highlight-py/highlight_io/integrations/fastapi.py
@@ -38,7 +38,6 @@ class FastAPIMiddleware(BaseHTTPMiddleware):
                     attributes={
                         "http.response.headers": resp.headers,
                         "http.request.headers": request.headers,
-                        "http.request.detail": await request.body(),
                         SpanAttributes.HTTP_METHOD: request.method,
                         SpanAttributes.HTTP_URL: str(request.url),
                     },

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.6.9"
+version = "0.6.10"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [

--- a/sdk/highlight-py/tests/test_fastapi.py
+++ b/sdk/highlight-py/tests/test_fastapi.py
@@ -53,7 +53,7 @@ async def test_fastapi(mocker, highlight_setup, exception, response):
     request.url = "https://localhost:8080/api/foo"
 
     async def body():
-        return b"hello, world!"
+        yield "foo"
 
     request.body = body
 
@@ -81,7 +81,6 @@ async def test_fastapi(mocker, highlight_setup, exception, response):
             "http.request.headers.hello",
             "http.response.headers.hey",
             "http.response.headers.content-length",
-            "http.request.detail",
             "http.response.detail",
             "http.method",
             "http.url",


### PR DESCRIPTION
## Summary

Reading the request body in the SDK breaks application code that also reads the request body.
There isn't a way in fastapi to clone the request, so we should avoid reading one-shot attributes like the body.

## How did you test this change?

Local deploy with curl post body on a request not blocked by the SDK.
<img width="1777" alt="Screenshot 2024-01-02 at 10 26 33 AM" src="https://github.com/highlight/highlight/assets/1351531/0219ecb0-b1ca-4ce8-a8c8-1a11f9a90218">


## Are there any deployment considerations?

New 0.6.10 version released. Closes #7403

## Does this work require review from our design team?

No