### PR TITLE
update pushpayload chunking for logs and websocket events

### DIFF
--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -111,7 +111,7 @@ func (r *mutationResolver) PushPayload(ctx context.Context, sessionSecureID stri
 		payloadID = pointy.Int(0)
 	}
 
-	const smallChunkSize = 64
+	const smallChunkSize = 1024
 	const largeChunkSize = 1
 
 	var logRows []*hlog.Message
@@ -159,7 +159,7 @@ func (r *mutationResolver) PushPayload(ctx context.Context, sessionSecureID stri
 		entry.resources = chunk
 		chunks[idx] = entry
 	}
-	for idx, chunk := range lo.Chunk(webSocketEventsParsed.WebSocketEvents, largeChunkSize) {
+	for idx, chunk := range lo.Chunk(webSocketEventsParsed.WebSocketEvents, smallChunkSize) {
 		if _, ok := chunks[idx]; !ok {
 			chunks[idx] = PushPayloadChunk{}
 		}


### PR DESCRIPTION
## Summary

Back on MSK, we can have messages up to 128MB. Chunk logs and websocket events
from push payload in larger batches of messages to avoid overhead of processing individual updates.

## How did you test this change?

CI - will monitor in production.

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
