### PR TITLE
record structured attributes as message for empty logrus logs

### DIFF
--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -290,7 +290,7 @@ func escapeNodeScriptTags(ctx context.Context, node map[string]interface{}) {
 					log.WithContext(ctx).
 						WithField("node", node).
 						WithField("TextContent", txt).
-						Warnf("potential js attack, dropping script tag in session events")
+						Debugf("potential js attack, dropping script tag in session events")
 				}
 			}
 		}
@@ -315,7 +315,7 @@ func escapeNodeWithJSAttrs(ctx context.Context, node map[string]interface{}) {
 						WithField("tagName", tagName).
 						WithField("disallowedTagAttribute", key).
 						WithField("value", value).
-						Warnf("potential js attack, dropping disallowed attribute on session events tag")
+						Debugf("potential js attack, dropping disallowed attribute on session events tag")
 					a[key] = ScriptPlaceholder
 					break
 				}


### PR DESCRIPTION
## Summary

`logrus.WithContext(ctx).WithError(err)` is valid to record an error log to logrus, but won't have a message.
This change defaults to the structured data (such as the error object) to be reported.

## How did you test this change?

Local deploy.

## Are there any deployment considerations?

Will be released with next go sdk tag.

## Does this work require review from our design team?

No
