### PR TITLE
create hnsw indexes for all partitions of the error_object_embeddings_partitioned table

### DIFF
--- a/backend/migrations/cmd/add-hnsw-indexes/main.go
+++ b/backend/migrations/cmd/add-hnsw-indexes/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+
+	"github.com/highlight-run/highlight/backend/model"
+)
+
+func main() {
+	ctx := context.Background()
+
+	db, err := model.SetupDB(ctx, os.Getenv("PSQL_DB"))
+	if err != nil {
+		log.WithContext(ctx).Fatalf("error setting up db: %+v", err)
+	}
+
+	var lastCreatedPart int
+	db.Raw("select split_part(relname, '_', 5) from pg_stat_all_tables where relname like 'error_object_embeddings_partitioned%' order by relid desc limit 1").Scan(&lastCreatedPart)
+
+	for i := 0; i <= lastCreatedPart; i++ {
+		tablename := fmt.Sprintf("error_object_embeddings_partitioned_%d", i)
+
+		var exists int
+		if err := db.Raw("select 1 from pg_indexes where indexdef ilike '%hnsw%' and tablename = ?", tablename).Scan(&exists).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			log.WithContext(ctx).Fatalf("error querying hnsw index for table %s: %+v", tablename, err)
+		}
+
+		if exists == 1 {
+			log.WithContext(ctx).Infof("hnsw index exists for %d, skipping", i)
+			continue
+		}
+
+		log.WithContext(ctx).Infof("creating hnsw index for %d", i)
+		if err := db.Exec(fmt.Sprintf("CREATE INDEX CONCURRENTLY ON %s USING hnsw (gte_large_embedding vector_l2_ops)", tablename)).Error; err != nil {
+			log.WithContext(ctx).Fatalf("error creating hnsw index for %d: %+v", i, err)
+		}
+		log.WithContext(ctx).Infof("created hnsw index for %d", i)
+	}
+
+}


### PR DESCRIPTION
## Summary
- hnsw is a new vector index type introduced in pgvector v0.5.0 with better performance than ivfflat
- this migration adds hnsw indexes for all partitions of error_object_embeddings_partitioned
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran script locally, currently running in prod
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- new partitions are already using hnsw indexes
- will remove the existing ivfflat indexes after confirming these new indexes are created for all partitions and working as expected
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
