### PR TITLE
remove incorrect payment method checks

### DIFF
--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -1110,12 +1110,6 @@ func (w *Worker) GetBillingIssue(ctx context.Context, workspace *model.Workspace
 			if paymentMethod.Card.Checks.CVCCheck == stripe.PaymentMethodCardChecksCVCCheckFail {
 				log.WithContext(ctx).WithField("customer", customer.ID).Info("stripe cvc check failed")
 				failures += 1
-			} else if paymentMethod.Card.Checks.AddressPostalCodeCheck == stripe.PaymentMethodCardChecksAddressPostalCodeCheckFail {
-				log.WithContext(ctx).WithField("customer", customer.ID).Info("stripe address postal check failed")
-				failures += 1
-			} else if paymentMethod.Card.Checks.AddressLine1Check == stripe.PaymentMethodCardChecksAddressLine1CheckFail {
-				log.WithContext(ctx).WithField("customer", customer.ID).Info("stripe address line1 check failed")
-				failures += 1
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

CVC and address checks may fail even if the payment method is valid, esp. for international customers.
Avoid using those checks to avoid incorrect billing warning notifications.

## How did you test this change?

CI

## Are there any deployment considerations?

Will be monitoring [logs](https://app.highlight.io/1/logs?end_date=2024-01-03T17%3A39%3A44.744Z&query=stripe%20check%20failed%20%20&start_date=2024-01-03T17%3A24%3A44.744Z) for this.

## Does this work require review from our design team?

No