### PR TITLE
replaced Community with Customers

### DIFF
--- a/highlight.io/components/common/Navbar/ResourceDropdown.tsx
+++ b/highlight.io/components/common/Navbar/ResourceDropdown.tsx
@@ -20,9 +20,9 @@ const ResourceDropdown = ({ isOpen }: { isOpen?: boolean }) => {
 			link: 'https://status.highlight.io/',
 		},
 		{
-			title: 'Community',
+			title: 'Customers',
 			icon: <Icons.HiUsers className={styles.copyOnLight} />,
-			link: 'https://discord.gg/yxaXEAqgwN',
+			link: '/customers',
 		},
 		{
 			title: 'Changelog',


### PR DESCRIPTION
## Summary

Replaced the community section in the resource dropdown with Customers, which links to /customers. I decided to remove community since it links to Discord, which is already linked elsewhere on the Navbar.

## How did you test this change?

Click-testing

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
