### PR TITLE
ensure pino transport works correctly in non-node environments  @Vadman97

### DIFF
--- a/.changeset/pink-baboons-look.md
+++ b/.changeset/pink-baboons-look.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/pino': patch
+---
+
+ensure pino transport works correctly in non-node environments

--- a/highlight.io/components/QuickstartContent/logging/js/pino.tsx
+++ b/highlight.io/components/QuickstartContent/logging/js/pino.tsx
@@ -21,20 +21,21 @@ export const JSPinoHTTPJSONLogContent: QuickStartContent = {
   serviceVersion: 'git-sha',
 } as NodeOptions
 
-let pinoConfig = {
+
+const pinoConfig = {
   level: 'debug',
+  transport: {
+    target: '@highlight-run/pino',
+    options: highlightConfig,
+  },
 } as LoggerOptions
 
-if (process.env.NEXT_RUNTIME === 'nodejs') {
+if (
+  typeof process.env.NEXT_RUNTIME === 'undefined' ||
+  process.env.NEXT_RUNTIME === 'nodejs'
+) {
   const { H } = require('@highlight-run/node')
   H.init(highlightConfig)
-  pinoConfig = {
-    ...pinoConfig,
-    transport: {
-      target: '@highlight-run/pino',
-      options: highlightConfig,
-    },
-  }
 }
 
 import type { LoggerOptions } from 'pino'

--- a/highlight.io/components/QuickstartContent/logging/js/pino.tsx
+++ b/highlight.io/components/QuickstartContent/logging/js/pino.tsx
@@ -15,31 +15,34 @@ export const JSPinoHTTPJSONLogContent: QuickStartContent = {
 				'Make sure to set the `project` and `service` query string parameters.',
 			code: [
 				{
-					text: `import { H, Handlers } from '@highlight-run/node'
-
-/** @type {import('@highlight-run/node').NodeOptions} */
-const config = {
+					text: `const highlightConfig = {
   projectID: '<YOUR_PROJECT_ID>',
-  serviceName: 'my-pino-app',
-  serviceVersion: 'git-sha'
-}
-// the H.init call must be invoked before importing pino to attribute logs to the current context
-H.init(config)
+  serviceName: 'my-pino-logger',
+  serviceVersion: 'git-sha',
+} as NodeOptions
 
-import pino from 'pino'
+let pinoConfig = {
+  level: 'debug',
+} as LoggerOptions
 
-const logger = pino({
-    level: 'info',
+if (process.env.NEXT_RUNTIME === 'nodejs') {
+  const { H } = require('@highlight-run/node')
+  H.init(highlightConfig)
+  pinoConfig = {
+    ...pinoConfig,
     transport: {
-        targets: [
-            {
-                target: '@highlight-run/pino',
-                options: config,
-                level: 'info'
-            },
-        ],
+      target: '@highlight-run/pino',
+      options: highlightConfig,
     },
-})
+  }
+}
+
+import type { LoggerOptions } from 'pino'
+import pino from 'pino'
+import type { NodeOptions } from '@highlight-run/node'
+
+const logger = pino(pinoConfig)
+
 
 logger.info({ key: 'my-value' }, 'hello, highlight.io!')`,
 					language: 'js',

--- a/highlight.io/highlight.logger.ts
+++ b/highlight.io/highlight.logger.ts
@@ -1,21 +1,29 @@
-import pino from 'pino'
+const highlightConfig = {
+	projectID: '1',
+	serviceName: 'highlight-io-pino',
+	serviceVersion: 'git-sha',
+} as NodeOptions
 
-// returns a pino logger. to be called after highlight is initialized
-export const getLogger = () => {
-	const env = {
-		projectID: '4d7k1xeo',
-		debug: false,
-		serviceName: 'highlight.io',
-	}
-	return pino({
+let pinoConfig = {
+	level: 'debug',
+} as LoggerOptions
+
+if (process.env.NEXT_RUNTIME === 'nodejs') {
+	const { H } = require('@highlight-run/node')
+	H.init(highlightConfig)
+	pinoConfig = {
+		...pinoConfig,
 		transport: {
-			targets: [
-				{
-					target: '@highlight-run/pino',
-					options: env,
-					level: 'trace',
-				},
-			],
+			target: '@highlight-run/pino',
+			options: highlightConfig,
 		},
-	})
+	}
 }
+
+import type { LoggerOptions } from 'pino'
+import pino from 'pino'
+import type { NodeOptions } from '@highlight-run/node'
+
+const logger = pino(pinoConfig)
+
+export default logger

--- a/highlight.io/highlight.logger.ts
+++ b/highlight.io/highlight.logger.ts
@@ -6,6 +6,10 @@ const highlightConfig = {
 
 let pinoConfig = {
 	level: 'debug',
+	transport: {
+		target: '@highlight-run/pino',
+		options: highlightConfig,
+	},
 } as LoggerOptions
 
 if (
@@ -14,13 +18,6 @@ if (
 ) {
 	const { H } = require('@highlight-run/node')
 	H.init(highlightConfig)
-	pinoConfig = {
-		...pinoConfig,
-		transport: {
-			target: '@highlight-run/pino',
-			options: highlightConfig,
-		},
-	}
 }
 
 import type { LoggerOptions } from 'pino'

--- a/highlight.io/highlight.logger.ts
+++ b/highlight.io/highlight.logger.ts
@@ -8,7 +8,10 @@ let pinoConfig = {
 	level: 'debug',
 } as LoggerOptions
 
-if (process.env.NEXT_RUNTIME === 'nodejs') {
+if (
+	typeof process.env.NEXT_RUNTIME === 'undefined' ||
+	process.env.NEXT_RUNTIME === 'nodejs'
+) {
 	const { H } = require('@highlight-run/node')
 	H.init(highlightConfig)
 	pinoConfig = {

--- a/highlight.io/pages/api/docs/github.ts
+++ b/highlight.io/pages/api/docs/github.ts
@@ -1,6 +1,6 @@
 import yaml from 'js-yaml'
 import path from 'path'
-import { getLogger } from '../../../highlight.logger'
+import logger from '../../../highlight.logger'
 
 // ignored files from docs
 export const IGNORED_DOCS_PATHS = new Set<string>([
@@ -87,7 +87,6 @@ export const processDocPath = function (
 }
 
 export const getGithubDocsPaths = async (path: string = 'docs-content/') => {
-	const logger = getLogger()
 	logger.info({ path }, 'getGithubDocsPaths')
 	const url = `https://api.github.com/repos/highlight/highlight/contents/${path}`
 	const response = await fetch(url, {
@@ -138,7 +137,6 @@ export const getGithubDoc = async (
 	meta: DocMeta
 	content: string
 } | null> => {
-	const logger = getLogger()
 	logger.info({ slug }, 'getGithubDoc')
 	const response = await fetch(
 		`https://api.github.com/repos/highlight/highlight/contents/docs-content/${slug}.md`,

--- a/highlight.io/pages/api/docs/search/[searchValue].ts
+++ b/highlight.io/pages/api/docs/search/[searchValue].ts
@@ -4,7 +4,7 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import { getDocsPaths, readMarkdown } from '../../../docs/[[...doc]]'
 import removeMd from 'remove-markdown'
 import { withPageRouterHighlight } from '../../../../highlight.config'
-import { getLogger } from '../../../../highlight.logger'
+import logger from '../../../../highlight.logger'
 
 export const SEARCH_RESULT_BLURB_LENGTH = 100
 
@@ -23,7 +23,6 @@ const handler = withPageRouterHighlight(async function handler(
 	req: NextApiRequest,
 	res: NextApiResponse,
 ) {
-	const logger = getLogger()
 	const searchValue = [req.query.searchValue].flat().join('').toLowerCase()
 	logger.info('running api docs search query', { searchValue })
 	const docPaths = await getDocsPaths(fsp, undefined)

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -46,6 +46,7 @@ import { HighlightCodeBlock } from '../../components/Docs/HighlightCodeBlock/Hig
 import { useMediaQuery } from '../../components/MediaQuery/MediaQuery'
 import ChevronDown from '../../public/images/ChevronDownIcon'
 import Minus from '../../public/images/MinusIcon'
+import logger from '../../highlight.logger'
 
 const DOCS_CONTENT_PATH = path.join(process.cwd(), '../docs-content')
 const DOCS_GITUB_LINK = `https://github.com/highlight/highlight/blob/main/docs-content`
@@ -320,6 +321,10 @@ interface TocEntry {
 }
 
 export const getStaticProps: GetStaticProps<DocData> = async (context) => {
+	logger.info(
+		{ params: context?.params },
+		`docs getStaticProps ${context?.params?.doc}`,
+	)
 	const docPaths = sortBySlashLength(await getDocsPaths(fsp, undefined))
 
 	// const sdkPaths = await getSdkPaths(fsp, undefined);


### PR DESCRIPTION
## Summary

When using the pino transport in next-js, the import would cause errors in the browser
because client code would try to use the transport.
Detect next runtimes and avoid importing the node-specific SDK.

## How did you test this change?

Testing on highlight.io and in the e2e app.
https://www.loom.com/share/bdcc5faf75db45c8bbf0e8d12c3d9981

## Are there any deployment considerations?

Changeset

## Does this work require review from our design team?

No
