### PR TITLE
disable indexeddb by default

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/ErrorQueryBuilder.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorQueryBuilder/ErrorQueryBuilder.tsx
@@ -109,6 +109,7 @@ const ErrorQueryBuilder = (props: Partial<QueryBuilderProps>) => {
 	const { data } = useGetErrorTagsQuery()
 	const { refetch } = useGetErrorFieldsClickhouseQuery({
 		skip: true,
+		fetchPolicy: 'cache-and-network',
 	})
 	const fetchFields = useCallback(
 		(variables: FetchFieldVariables) =>

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/SessionQueryBuilder.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionQueryBuilder/SessionQueryBuilder.tsx
@@ -4,8 +4,8 @@ import {
 	useGetFieldTypesClickhouseQuery,
 	useGetSegmentsQuery,
 } from '@graph/hooks'
+import { useProjectId } from '@hooks/useProjectId'
 import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext'
-import { useParams } from '@util/react-router/useParams'
 import React, { useCallback } from 'react'
 
 import QueryBuilder, {
@@ -143,6 +143,7 @@ export const CUSTOM_FIELDS: CustomField[] = [
 const SessionQueryBuilder = React.memo((props: Partial<QueryBuilderProps>) => {
 	const { refetch } = useGetFieldsClickhouseQuery({
 		skip: true,
+		fetchPolicy: 'cache-and-network',
 	})
 	const fetchFields = useCallback(
 		(variables: FetchFieldVariables) =>
@@ -150,9 +151,7 @@ const SessionQueryBuilder = React.memo((props: Partial<QueryBuilderProps>) => {
 		[refetch],
 	)
 
-	const { project_id } = useParams<{
-		project_id: string
-	}>()
+	const { projectId } = useProjectId()
 
 	const searchContext = useSearchContext()
 
@@ -168,11 +167,12 @@ const SessionQueryBuilder = React.memo((props: Partial<QueryBuilderProps>) => {
 	const endDate = getAbsoluteEndTime(timeRange?.val?.options[0].value)
 	const { data: fieldData } = useGetFieldTypesClickhouseQuery({
 		variables: {
-			project_id: project_id!,
+			project_id: projectId,
 			start_date: startDate!,
 			end_date: endDate!,
 		},
-		skip: !project_id,
+		skip: !projectId,
+		fetchPolicy: 'cache-and-network',
 	})
 
 	return (

--- a/frontend/src/util/db.ts
+++ b/frontend/src/util/db.ts
@@ -15,7 +15,7 @@ const CLEANUP_CHECK_MS = 1000
 const CLEANUP_DELAY_MS = 10000
 const CLEANUP_THRESHOLD_MB = 4000
 export const INDEXEDDB_ENABLED_LOCAL_STORAGE_PREFIX =
-	'highlight-indexeddb-enabled-'
+	'highlight-indexeddb-enabled-v2-'
 
 const getLocalStorage = function (): Storage | undefined {
 	try {
@@ -34,7 +34,7 @@ export const isIndexedDBEnabled = function () {
 	if (!navigator?.storage?.estimate) {
 		return false
 	}
-	const defaultEnabled = import.meta.env.MODE !== 'development'
+	const defaultEnabled = false
 	const storage = getLocalStorage()
 	if (!storage) {
 		return defaultEnabled


### PR DESCRIPTION
## Summary

We've been seeing more indexeddb errors recently and it seems in some cases they prevent our app from loading.
The session preloading often causes browser crashes for larger projects, so we should try
and turn off indexeddb caching by default for now to see if it could help for now.

## How did you test this change?

[Reflame preview](https://preview.highlight.io/1/errors?page=1&query=and%7C%7Cerror_state%2Cis%2COPEN%7C%7Cerror-field_timestamp%2Cbetween_date%2C2023-12-06T14%3A53%3A49.366Z_2024-01-05T14%3A53%3A49.366Z&%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HKBQ4EAR5WYZAAGFWP305CWS%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Findexeddb-disable%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No