### PR TITLE
fix more grafana bugs

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -246,17 +246,16 @@ func makeSelectBuilder[T ~string](config tableConfig[T], selectStr string, selec
 func appendWhereConditions[T ~string](sb *sqlbuilder.SelectBuilder, config tableConfig[T], query string) {
 	filters := makeFilters(query, lo.Keys(config.keysToColumns), config.defaultFilters)
 
-	bodyQuery := ""
 	for _, body := range filters.body {
+		bodyQuery := ""
 		if strings.Contains(body, "%") {
 			bodyQuery = config.bodyColumn + " ILIKE " + sb.Var(body)
 		} else {
 			bodyQuery = "hasTokenCaseInsensitive(" + config.bodyColumn + ", " + sb.Var(body) + ")"
 		}
-	}
-
-	if bodyQuery != "" {
-		sb.Where(bodyQuery)
+		if bodyQuery != "" {
+			sb.Where(bodyQuery)
+		}
 	}
 
 	for key, column := range config.keysToColumns {

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
-	"github.com/gofiber/fiber/v2/log"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/queryparser"
 	"github.com/highlight-run/highlight/backend/util"
@@ -173,7 +172,6 @@ func readObjects[TObj interface{}, TReservedKey ~string](ctx context.Context, cl
 
 func makeSelectBuilder[T ~string](config tableConfig[T], selectStr string, selectArgs []any,
 	groupBy []string, projectID int, params modelInputs.QueryInput, pagination Pagination, orderBackward string, orderForward string) (*sqlbuilder.SelectBuilder, error) {
-	filters := makeFilters(params.Query, lo.Keys(config.keysToColumns), config.defaultFilters)
 	sb := sqlbuilder.NewSelectBuilder()
 
 	// selectStr can contain %s format tokens as placeholders for argument placeholders
@@ -191,27 +189,6 @@ func makeSelectBuilder[T ~string](config tableConfig[T], selectStr string, selec
 	}
 	sb.Select(cols...)
 	sb.From(config.tableName)
-
-	// Clickhouse requires that PREWHERE clauses occur before WHERE clauses
-	// sql-builder doesn't support PREWHERE natively so we use `SQL` which sets a marker
-	// of where to place the raw SQL later when it is being built.
-	// In this case, we are placing the marker after the `FROM` clause
-	preWheres := []string{}
-	bodyQuery := ""
-	for _, body := range filters.body {
-		if strings.Contains(body, "%") {
-			bodyQuery = config.bodyColumn + " ILIKE " + sb.Var(body)
-		} else {
-			preWheres = append(preWheres, "hasTokenCaseInsensitive("+config.bodyColumn+", "+sb.Var(body)+")")
-		}
-	}
-
-	if len(preWheres) > 0 {
-		sb.SQL("PREWHERE " + strings.Join(preWheres, " AND "))
-	}
-	if bodyQuery != "" {
-		sb.Where(bodyQuery)
-	}
 
 	sb.Where(sb.Equal("ProjectId", projectID))
 
@@ -261,6 +238,27 @@ func makeSelectBuilder[T ~string](config tableConfig[T], selectStr string, selec
 		}
 	}
 
+	appendWhereConditions(sb, config, params.Query)
+
+	return sb, nil
+}
+
+func appendWhereConditions[T ~string](sb *sqlbuilder.SelectBuilder, config tableConfig[T], query string) {
+	filters := makeFilters(query, lo.Keys(config.keysToColumns), config.defaultFilters)
+
+	bodyQuery := ""
+	for _, body := range filters.body {
+		if strings.Contains(body, "%") {
+			bodyQuery = config.bodyColumn + " ILIKE " + sb.Var(body)
+		} else {
+			bodyQuery = "hasTokenCaseInsensitive(" + config.bodyColumn + ", " + sb.Var(body) + ")"
+		}
+	}
+
+	if bodyQuery != "" {
+		sb.Where(bodyQuery)
+	}
+
 	for key, column := range config.keysToColumns {
 		makeFilterConditions(sb, filters.reserved[key], column)
 	}
@@ -301,8 +299,6 @@ func makeSelectBuilder[T ~string](config tableConfig[T], selectStr string, selec
 	if len(conditions) > 0 {
 		sb.Where(sb.And(conditions...))
 	}
-
-	return sb, nil
 }
 
 type filtersWithReservedKeys[T ~string] struct {
@@ -390,7 +386,7 @@ func KeysAggregated(ctx context.Context, client *Client, tableName string, proje
 		sb.Where(fmt.Sprintf("Key LIKE %s", sb.Var("%"+*query+"%")))
 	}
 
-	if typeArg != nil {
+	if typeArg != nil && *typeArg == modelInputs.KeyTypeNumeric {
 		sb.Where(sb.Equal("Type", typeArg))
 	}
 
@@ -710,8 +706,9 @@ func readMetrics[T ~string](ctx context.Context, client *Client, sampleableConfi
 			Select(strings.Join(colStrs, ", ")).
 			Where(innerSb.Equal("ProjectId", projectID)).
 			Where(innerSb.GreaterEqualThan("Timestamp", startTimestamp)).
-			Where(innerSb.LessEqualThan("Timestamp", endTimestamp)).
-			GroupBy(groupByIndexes...)
+			Where(innerSb.LessEqualThan("Timestamp", endTimestamp))
+
+		appendWhereConditions(innerSb, config, params.Query)
 
 		limitFn := ""
 		col := ""
@@ -725,7 +722,8 @@ func readMetrics[T ~string](ctx context.Context, client *Client, sampleableConfi
 		}
 		limitFn = getFnStr(*limitAggregator, col, useSampling)
 
-		innerSb.OrderBy(fmt.Sprintf("%s DESC", limitFn)).
+		innerSb.GroupBy(groupByIndexes...).
+			OrderBy(fmt.Sprintf("%s DESC", limitFn)).
 			Limit(limitCount)
 
 		fromColStrs := []string{}
@@ -753,8 +751,6 @@ func readMetrics[T ~string](ctx context.Context, client *Client, sampleableConfi
 	fromSb.Limit(10000)
 
 	sql, args := fromSb.BuildWithFlavor(sqlbuilder.ClickHouse)
-	str, _ := sqlbuilder.ClickHouse.Interpolate(sql, args)
-	log.WithContext(ctx).Info(str)
 
 	metrics := &modelInputs.MetricsBuckets{
 		Buckets: []*modelInputs.MetricBucket{},

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/go-redsync/redsync/v4 v4.8.1
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible
 	github.com/go-test/deep v1.1.0
-	github.com/gofiber/fiber/v2 v2.51.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/golang/snappy v0.0.4
@@ -139,7 +138,6 @@ require (
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tidwall/rtred v0.1.2 // indirect
 	github.com/tidwall/tinyqueue v0.1.1 // indirect
-	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/vmihailenco/go-tinylfu v0.2.2 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.4 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -644,8 +644,6 @@ github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/gofiber/fiber/v2 v2.51.0 h1:JNACcZy5e2tGApWB2QrRpenTWn0fq0hkFm6k0C86gKQ=
-github.com/gofiber/fiber/v2 v2.51.0/go.mod h1:xaQRZQJGqnKOQnbQw+ltvku3/h8QxvNi8o6JiJ7Ll0U=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=


### PR DESCRIPTION
## Summary
- fixes bug where numeric keys would not show up as group by options (e.g. enum types), should handle those as both potential metric types and group by types
- applies `where` conditions before limiting the number of groups
- removes prewhere logic as clickhouse should handle this automatically, did not see any meaningful performance difference between the two
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- validated that the correct data was shown in the grafana plugin after applying a filter and limit = 1 
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
