### PR TITLE
remove message from large kafka message logs

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -294,7 +294,7 @@ func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...*Me
 			return err
 		}
 		if int64(len(msgBytes)) >= p.MessageSizeBytes/2 {
-			log.WithContext(ctx).WithField("topic", p.Topic).WithField("partitionKey", partitionKey).WithField("msgBytes", len(msgBytes)).WithField("msg", string(msgBytes)).Warn("large kafka message")
+			log.WithContext(ctx).WithField("topic", p.Topic).WithField("partitionKey", partitionKey).WithField("msgBytes", len(msgBytes)).Warn("large kafka message")
 		}
 		kMessages = append(kMessages, kafka.Message{
 			Key:   []byte(partitionKey),


### PR DESCRIPTION
## Summary
- these messages are pretty big and could be a cause for elevated cloudwatch ingest, removing them 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor cloudwatch ingest bytes for public graph after deploying
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
