### PR TITLE
Add autoinstrumentation for redis and boto libraries

### DIFF
--- a/sdk/highlight-py/CHANGELOG.md
+++ b/sdk/highlight-py/CHANGELOG.md
@@ -74,7 +74,7 @@
 - Optimizations for requests auto-instrumentation tracing.
 - Removes `tracing_origins` configuration for requests library and passes by default.
 
-## v0.6.11 (2024-01-09)
+## v0.6.12 (2024-01-09)
 
 ### Fix
 

--- a/sdk/highlight-py/CHANGELOG.md
+++ b/sdk/highlight-py/CHANGELOG.md
@@ -73,3 +73,9 @@
 - Support tracing auto-instrumention for the celery library.
 - Optimizations for requests auto-instrumentation tracing.
 - Removes `tracing_origins` configuration for requests library and passes by default.
+
+## v0.6.11 (2024-01-09)
+
+### Fix
+
+- Support tracing auto-instrumention for boto, boto3 (sqs), and redis libraries.

--- a/sdk/highlight-py/README.md
+++ b/sdk/highlight-py/README.md
@@ -31,6 +31,9 @@ Start Redis:
 * `cd docker`
 * `./start_infra` (in order to start Redis)
 
+Using Boto/Boto3 endpoints:
+* Add `E2E_AWS_ACCESS_KEY`, `E2E_AWS_SECRET_KEY`, and `SQS_QUEUE_URL` env variables
+
 Running the main app:
 * `cd e2e/highlight_fastapi`
 * `poetry run uvicorn main:app`

--- a/sdk/highlight-py/README.md
+++ b/sdk/highlight-py/README.md
@@ -32,7 +32,10 @@ Start Redis:
 * `./start_infra` (in order to start Redis)
 
 Using Boto/Boto3 endpoints:
-* Add `E2E_AWS_ACCESS_KEY`, `E2E_AWS_SECRET_KEY`, and `SQS_QUEUE_URL` env variables
+* Update the have the following environment variables (edit Run Confirguration in PyCharm)
+* `E2E_AWS_ACCESS_KEY` (from IAM account)
+* `E2E_AWS_SECRET_KEY` (from IAM account)
+* `SQS_QUEUE_URL` (from SQS queue information)
 
 Running the main app:
 * `cd e2e/highlight_fastapi`

--- a/sdk/highlight-py/e2e/highlight_fastapi/main.py
+++ b/sdk/highlight-py/e2e/highlight_fastapi/main.py
@@ -103,10 +103,7 @@ async def boto3sqs(request: Request):
 @app.get("/boto3sqs_receive")
 @app.post("/boto3sqs_receive")
 async def boto3sqs(request: Request):
-    response = sqs.receive_message(
-        QueueUrl=sqs_queue_url,
-        MaxNumberOfMessages=10
-    )
+    response = sqs.receive_message(QueueUrl=sqs_queue_url, MaxNumberOfMessages=10)
     return response
 
 

--- a/sdk/highlight-py/e2e/highlight_fastapi/main.py
+++ b/sdk/highlight-py/e2e/highlight_fastapi/main.py
@@ -13,7 +13,7 @@ import highlight_io
 from highlight_io.integrations.fastapi import FastAPIMiddleware
 
 H = highlight_io.H(
-    "3",
+    "1",
     instrument_logging=True,
     otlp_endpoint="http://localhost:4318",
     service_name="my-fastapi-app",
@@ -27,18 +27,21 @@ app.add_middleware(FastAPIMiddleware)
 router = APIRouter()
 r = redis.Redis(host="localhost", port=6379, decode_responses=True)
 
-aws_key = os.getenv("E2E_AWS_ACCESS_KEY")
-aws_secret = os.getenv("E2E_AWS_SECRET_KEY")
-aws_region = os.getenv("E2E_AWS_REGION", "us-east-2")
-sqs_queue_url = os.getenv("SQS_QUEUE_URL")
+try:
+    aws_key = os.getenv("E2E_AWS_ACCESS_KEY")
+    aws_secret = os.getenv("E2E_AWS_SECRET_KEY")
+    aws_region = os.getenv("E2E_AWS_REGION", "us-east-2")
+    sqs_queue_url = os.getenv("SQS_QUEUE_URL")
 
-s3 = boto.connect_s3(aws_key, aws_secret)
-sqs = boto3.client(
-    "sqs",
-    aws_access_key_id=aws_key,
-    aws_secret_access_key=aws_secret,
-    region_name=aws_region,
-)
+    s3 = boto.connect_s3(aws_key, aws_secret)
+    sqs = boto3.client(
+        "sqs",
+        aws_access_key_id=aws_key,
+        aws_secret_access_key=aws_secret,
+        region_name=aws_region,
+    )
+except:
+    logging.warning("Not able to connect to AWS. Check credentials")
 
 
 @app.get("/")

--- a/sdk/highlight-py/highlight_io/integrations/boto.py
+++ b/sdk/highlight-py/highlight_io/integrations/boto.py
@@ -1,21 +1,21 @@
 from highlight_io.integrations import Integration
 
 try:
-    import boto3
-    from opentelemetry.instrumentation.boto3sqs import Boto3SQSInstrumentor
+    import boto
+    from opentelemetry.instrumentation.boto import BotoInstrumentor
 
     instrumentation_available = True
 except ImportError:
     instrumentation_available = False
 
 
-class Boto3Integration(Integration):
-    INTEGRATION_KEY = "boto3"
+class BotoIntegration(Integration):
+    INTEGRATION_KEY = "boto"
 
     def enable(self):
         if instrumentation_available:
-            Boto3SQSInstrumentor().instrument()
+            BotoInstrumentor().instrument()
 
     def disable(self):
         if instrumentation_available:
-            Boto3SQSInstrumentor().uninstrument()
+            BotoInstrumentor().uninstrument()

--- a/sdk/highlight-py/highlight_io/integrations/boto3.py
+++ b/sdk/highlight-py/highlight_io/integrations/boto3.py
@@ -1,0 +1,21 @@
+from highlight_io.integrations import Integration
+
+try:
+    import boto3
+    from opentelemetry.instrumentation.boto3sqs import Boto3SQSInstrumentor
+
+    instrumentation_available = True
+except ImportError:
+    instrumentation_available = False
+
+
+class Boto3Integration(Integration):
+    INTEGRATION_KEY = "boto3"
+
+    def enable(self):
+        if instrumentation_available:
+            Boto3SQSInstrumentor().instrument()
+
+    def disable(self):
+        if instrumentation_available:
+            Boto3SQSInstrumentor().uninstrument()

--- a/sdk/highlight-py/highlight_io/integrations/boto3sqs.py
+++ b/sdk/highlight-py/highlight_io/integrations/boto3sqs.py
@@ -1,0 +1,21 @@
+from highlight_io.integrations import Integration
+
+try:
+    import boto3
+    from opentelemetry.instrumentation.boto3sqs import Boto3SQSInstrumentor
+
+    instrumentation_available = True
+except ImportError:
+    instrumentation_available = False
+
+
+class Boto3SQSIntegration(Integration):
+    INTEGRATION_KEY = "boto3sqs"
+
+    def enable(self):
+        if instrumentation_available:
+            Boto3SQSInstrumentor().instrument()
+
+    def disable(self):
+        if instrumentation_available:
+            Boto3SQSInstrumentor().uninstrument()

--- a/sdk/highlight-py/highlight_io/integrations/redis.py
+++ b/sdk/highlight-py/highlight_io/integrations/redis.py
@@ -1,0 +1,21 @@
+from highlight_io.integrations import Integration
+
+try:
+    import redis
+    from opentelemetry.instrumentation.redis import RedisInstrumentor
+
+    instrumentation_available = True
+except ImportError:
+    instrumentation_available = False
+
+
+class RedisIntegration(Integration):
+    INTEGRATION_KEY = "redis"
+
+    def enable(self):
+        if instrumentation_available:
+            RedisInstrumentor().instrument()
+
+    def disable(self):
+        if instrumentation_available:
+            RedisInstrumentor().uninstrument()

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -23,14 +23,16 @@ from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import INVALID_SPAN
 
 from highlight_io.integrations import Integration
-from highlight_io.integrations.boto3 import Boto3Integration
+from highlight_io.integrations.boto import BotoIntegration
+from highlight_io.integrations.boto3sqs import Boto3SQSIntegration
 from highlight_io.integrations.celery import CeleryIntegration
 from highlight_io.integrations.redis import RedisIntegration
 from highlight_io.integrations.requests import RequestsIntegration
 from highlight_io.utils.lru_cache import LRUCache
 
 DEFAULT_INTEGRATIONS = [
-    Boto3Integration,
+    BotoIntegration,
+    Boto3SQSIntegration,
     CeleryIntegration,
     RedisIntegration,
     RequestsIntegration,

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -23,11 +23,18 @@ from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import INVALID_SPAN
 
 from highlight_io.integrations import Integration
+from highlight_io.integrations.boto3 import Boto3Integration
 from highlight_io.integrations.celery import CeleryIntegration
+from highlight_io.integrations.redis import RedisIntegration
 from highlight_io.integrations.requests import RequestsIntegration
 from highlight_io.utils.lru_cache import LRUCache
 
-DEFAULT_INTEGRATIONS = [RequestsIntegration, CeleryIntegration]
+DEFAULT_INTEGRATIONS = [
+    Boto3Integration,
+    CeleryIntegration,
+    RedisIntegration,
+    RequestsIntegration,
+]
 
 
 class LogHandler(logging.Handler):

--- a/sdk/highlight-py/poetry.lock
+++ b/sdk/highlight-py/poetry.lock
@@ -70,7 +70,7 @@ tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 name = "async-timeout"
 version = "4.0.3"
 description = "Timeout context manager for asyncio programs"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
@@ -202,10 +202,21 @@ files = [
 ]
 
 [[package]]
+name = "boto"
+version = "2.49.0"
+description = "Amazon Web Services Library"
+optional = false
+python-versions = "*"
+files = [
+    {file = "boto-2.49.0-py2.py3-none-any.whl", hash = "sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8"},
+    {file = "boto-2.49.0.tar.gz", hash = "sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a"},
+]
+
+[[package]]
 name = "boto3"
 version = "1.34.15"
 description = "The AWS SDK for Python"
-optional = false
+optional = true
 python-versions = ">= 3.8"
 files = [
     {file = "boto3-1.34.15-py3-none-any.whl", hash = "sha256:f8f16c2d0ec1dca291857f1c138d5c30e01e40f653443cc2679e2f6ae71b05a6"},
@@ -224,7 +235,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 name = "botocore"
 version = "1.34.15"
 description = "Low-level, data-driven core of boto 3."
-optional = false
+optional = true
 python-versions = ">= 3.8"
 files = [
     {file = "botocore-1.34.15-py3-none-any.whl", hash = "sha256:16bcf871e67ef0177593f06e9e5bae4db51c9a9a2e953cb14feeb42d53441a85"},
@@ -928,7 +939,7 @@ i18n = ["Babel (>=2.7)"]
 name = "jmespath"
 version = "1.0.1"
 description = "JSON Matching Expressions"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
@@ -1197,10 +1208,30 @@ setuptools = ">=16.0"
 wrapt = ">=1.0.0,<2.0.0"
 
 [[package]]
+name = "opentelemetry-instrumentation-boto"
+version = "0.43b0"
+description = "OpenTelemetry Boto instrumentation"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "opentelemetry_instrumentation_boto-0.43b0-py3-none-any.whl", hash = "sha256:58dc44f14f1823e2373af69f85e7c653a208a289449cdd30a634bc2f7f76b1fe"},
+    {file = "opentelemetry_instrumentation_boto-0.43b0.tar.gz", hash = "sha256:ecf544829180aee599995dccd48b9cc9b08cbb0a6b9a5fb835c903a09a25f975"},
+]
+
+[package.dependencies]
+opentelemetry-api = ">=1.12,<2.0"
+opentelemetry-instrumentation = "0.43b0"
+opentelemetry-semantic-conventions = "0.43b0"
+
+[package.extras]
+instruments = ["boto (>=2.0,<3.0)"]
+test = ["markupsafe (==2.0.1)", "moto (>=2.0,<3.0)", "opentelemetry-instrumentation-boto[instruments]", "opentelemetry-test-utils (==0.43b0)"]
+
+[[package]]
 name = "opentelemetry-instrumentation-boto3sqs"
 version = "0.43b0"
 description = "Boto3 SQS service tracing for OpenTelemetry"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "opentelemetry_instrumentation_boto3sqs-0.43b0-py3-none-any.whl", hash = "sha256:182c76616ed053b5389f8dc87be6a1db16013fe537b58628f3ec964e44a3102c"},
@@ -1259,7 +1290,7 @@ test = ["opentelemetry-test-utils (==0.43b0)"]
 name = "opentelemetry-instrumentation-redis"
 version = "0.43b0"
 description = "OpenTelemetry Redis instrumentation"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "opentelemetry_instrumentation_redis-0.43b0-py3-none-any.whl", hash = "sha256:4045754717185cf05a3e48b6f17a279481a726850e753e30a4c781c4b9ec6c31"},
@@ -1650,7 +1681,7 @@ dev = ["pre-commit", "pytest-asyncio", "tox"]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -1737,7 +1768,7 @@ files = [
 name = "redis"
 version = "5.0.1"
 description = "Python client for Redis database and key-value store"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "redis-5.0.1-py3-none-any.whl", hash = "sha256:ed4802971884ae19d640775ba3b03aa2e7bd5e8fb8dfaed2decce4d0fc48391f"},
@@ -1776,7 +1807,7 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 name = "s3transfer"
 version = "0.10.0"
 description = "An Amazon S3 Transfer Manager"
-optional = false
+optional = true
 python-versions = ">= 3.8"
 files = [
     {file = "s3transfer-0.10.0-py3-none-any.whl", hash = "sha256:3cdb40f5cfa6966e812209d0994f2a4709b561c88e90cf00c2696d2df4e56b2e"},
@@ -1809,7 +1840,7 @@ testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jar
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 files = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -2367,12 +2398,15 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [extras]
+boto = ["opentelemetry-instrumentation-boto"]
+boto3sqs = ["boto3", "opentelemetry-instrumentation-boto3sqs"]
 celery = ["celery", "opentelemetry-instrumentation-celery"]
 django = ["django"]
 fastapi = ["fastapi", "uvicorn"]
 flask = ["blinker", "flask"]
+redis = ["opentelemetry-instrumentation-redis", "redis"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "ddc90213993079b9ea63101d73e99a4d435b54d4ad4cbaeec620360b1b818072"
+content-hash = "6dab41065109741916760d2ef749086f2001b28dc5528f9cb67b753af6f1d0b6"

--- a/sdk/highlight-py/poetry.lock
+++ b/sdk/highlight-py/poetry.lock
@@ -202,6 +202,47 @@ files = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.34.15"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">= 3.8"
+files = [
+    {file = "boto3-1.34.15-py3-none-any.whl", hash = "sha256:f8f16c2d0ec1dca291857f1c138d5c30e01e40f653443cc2679e2f6ae71b05a6"},
+    {file = "boto3-1.34.15.tar.gz", hash = "sha256:2b74c58f475ff0dcf2f3637da9367a9465d29fad971ff5d8dc54ac39554e9022"},
+]
+
+[package.dependencies]
+botocore = ">=1.34.15,<1.35.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.10.0,<0.11.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.34.15"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">= 3.8"
+files = [
+    {file = "botocore-1.34.15-py3-none-any.whl", hash = "sha256:16bcf871e67ef0177593f06e9e5bae4db51c9a9a2e953cb14feeb42d53441a85"},
+    {file = "botocore-1.34.15.tar.gz", hash = "sha256:c3c3404962a6d9d5e1634bd70ed53b8eff1ff17ee9d7a6240e9e8c94db48ad6f"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = [
+    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
+    {version = ">=1.25.4,<2.1", markers = "python_version >= \"3.10\""},
+]
+
+[package.extras]
+crt = ["awscrt (==0.19.19)"]
+
+[[package]]
 name = "celery"
 version = "5.3.6"
 description = "Distributed Task Queue."
@@ -884,6 +925,17 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
+
+[[package]]
 name = "kombu"
 version = "5.3.4"
 description = "Messaging library for Python."
@@ -1145,10 +1197,31 @@ setuptools = ">=16.0"
 wrapt = ">=1.0.0,<2.0.0"
 
 [[package]]
+name = "opentelemetry-instrumentation-boto3sqs"
+version = "0.43b0"
+description = "Boto3 SQS service tracing for OpenTelemetry"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "opentelemetry_instrumentation_boto3sqs-0.43b0-py3-none-any.whl", hash = "sha256:182c76616ed053b5389f8dc87be6a1db16013fe537b58628f3ec964e44a3102c"},
+    {file = "opentelemetry_instrumentation_boto3sqs-0.43b0.tar.gz", hash = "sha256:75776222b12f7798d462a5d7c2486da8253f0faa78efbabe830a68fb339bc782"},
+]
+
+[package.dependencies]
+opentelemetry-api = ">=1.12,<2.0"
+opentelemetry-instrumentation = "0.43b0"
+opentelemetry-semantic-conventions = "0.43b0"
+wrapt = ">=1.0.0,<2.0.0"
+
+[package.extras]
+instruments = ["boto3 (>=1.0,<2.0)"]
+test = ["opentelemetry-instrumentation-boto3sqs[instruments]", "opentelemetry-test-utils (==0.43b0)"]
+
+[[package]]
 name = "opentelemetry-instrumentation-celery"
 version = "0.43b0"
 description = "OpenTelemetry Celery Instrumentation"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "opentelemetry_instrumentation_celery-0.43b0-py3-none-any.whl", hash = "sha256:17bc235aeb3db54495ccec68222ff5106ef4df1c7f227447acd5038f5dc2667c"},
@@ -1181,6 +1254,27 @@ opentelemetry-instrumentation = "0.43b0"
 
 [package.extras]
 test = ["opentelemetry-test-utils (==0.43b0)"]
+
+[[package]]
+name = "opentelemetry-instrumentation-redis"
+version = "0.43b0"
+description = "OpenTelemetry Redis instrumentation"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "opentelemetry_instrumentation_redis-0.43b0-py3-none-any.whl", hash = "sha256:4045754717185cf05a3e48b6f17a279481a726850e753e30a4c781c4b9ec6c31"},
+    {file = "opentelemetry_instrumentation_redis-0.43b0.tar.gz", hash = "sha256:0d495da05f78ac4403626c4911eb0212dca6b38fd1298b5aeacfa0d167a47d2c"},
+]
+
+[package.dependencies]
+opentelemetry-api = ">=1.12,<2.0"
+opentelemetry-instrumentation = "0.43b0"
+opentelemetry-semantic-conventions = "0.43b0"
+wrapt = ">=1.12.1"
+
+[package.extras]
+instruments = ["redis (>=2.6)"]
+test = ["opentelemetry-instrumentation-redis[instruments]", "opentelemetry-sdk (>=1.3,<2.0)", "opentelemetry-test-utils (==0.43b0)"]
 
 [[package]]
 name = "opentelemetry-instrumentation-requests"
@@ -1556,7 +1650,7 @@ dev = ["pre-commit", "pytest-asyncio", "tox"]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
-optional = true
+optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -1679,6 +1773,23 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "s3transfer"
+version = "0.10.0"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">= 3.8"
+files = [
+    {file = "s3transfer-0.10.0-py3-none-any.whl", hash = "sha256:3cdb40f5cfa6966e812209d0994f2a4709b561c88e90cf00c2696d2df4e56b2e"},
+    {file = "s3transfer-0.10.0.tar.gz", hash = "sha256:d0c8bbf672d5eebbe4e57945e23b972d963f07d82f661cabf678a5c88831595b"},
+]
+
+[package.dependencies]
+botocore = ">=1.33.2,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
+
+[[package]]
 name = "setuptools"
 version = "69.0.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1698,7 +1809,7 @@ testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jar
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 files = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -1800,17 +1911,34 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.1.0"
+version = "1.26.18"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-2.1.0-py3-none-any.whl", hash = "sha256:55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3"},
-    {file = "urllib3-2.1.0.tar.gz", hash = "sha256:df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"},
+    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
+    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
+]
+
+[package.extras]
+brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "urllib3"
+version = "2.0.7"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
+    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
 ]
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
@@ -2239,7 +2367,7 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy (>=0.9.1)", "pytest-ruff"]
 
 [extras]
-celery = ["celery"]
+celery = ["celery", "opentelemetry-instrumentation-celery"]
 django = ["django"]
 fastapi = ["fastapi", "uvicorn"]
 flask = ["blinker", "flask"]
@@ -2247,4 +2375,4 @@ flask = ["blinker", "flask"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "f9157328ba7fa59047e15b9f5048f135694a844159e373576b732e243cff65a0"
+content-hash = "ddc90213993079b9ea63101d73e99a4d435b54d4ad4cbaeec620360b1b818072"

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -35,6 +35,8 @@ celery = { version = ">=5", optional = true }
 opentelemetry-instrumentation-celery = { version = "0.43b0", optional = true }
 redis = { version = ">=5", optional = true }
 opentelemetry-instrumentation-redis = { version = "0.43b0", optional = true }
+boto = { version = ">=2", optional = true }
+opentelemetry-instrumentation-boto = { version = "0.43b0", optional = true }
 boto3 = { version = ">=1", optional = true }
 opentelemetry-instrumentation-boto3sqs = { version = "0.43b0", optional = true }
 opentelemetry-api = "1.22.0"
@@ -58,7 +60,8 @@ loguru = ">=0"
 stripe = ">=6"
 
 [tool.poetry.extras]
-Boto3 = ["boto3", "opentelemetry-instrumentation-boto3sqs"]
+Boto = ["boto", "opentelemetry-instrumentation-boto"]
+Boto3SQS = ["boto3", "opentelemetry-instrumentation-boto3sqs"]
 Celery = ["celery", "opentelemetry-instrumentation-celery"]
 Django = ["django"]
 FastAPI = ["fastapi", "uvicorn"]

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -33,6 +33,10 @@ fastapi = { version = ">=0", optional = true }
 uvicorn = {version = ">=0", extras = ["standard"], optional = true }
 celery = { version = ">=5", optional = true }
 opentelemetry-instrumentation-celery = { version = "0.43b0", optional = true }
+redis = { version = ">=5", optional = true }
+opentelemetry-instrumentation-redis = { version = "0.43b0", optional = true }
+boto3 = { version = ">=1", optional = true }
+opentelemetry-instrumentation-boto3sqs = { version = "0.43b0", optional = true }
 opentelemetry-api = "1.22.0"
 opentelemetry-distro = { extras = ["otlp"], version = "0.43b0" }
 opentelemetry-exporter-otlp-proto-http = "1.22.0"
@@ -52,13 +56,14 @@ pytest-cov = ">=4"
 pytest-asyncio = ">=0"
 loguru = ">=0"
 stripe = ">=6"
-redis = "^5.0.1"
 
 [tool.poetry.extras]
+Boto3 = ["boto3", "opentelemetry-instrumentation-boto3sqs"]
 Celery = ["celery", "opentelemetry-instrumentation-celery"]
 Django = ["django"]
 FastAPI = ["fastapi", "uvicorn"]
 Flask = ["blinker", "flask"]
+Redis = ["redis", "opentelemetry-instrumentation-redis"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.6.11"
+version = "0.6.12"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [

--- a/sdk/highlight-py/tests/test_boto.py
+++ b/sdk/highlight-py/tests/test_boto.py
@@ -1,0 +1,7 @@
+from highlight_io.integrations.boto import BotoIntegration
+
+
+def test_boto():
+    integration = BotoIntegration()
+    integration.enable()
+    integration.disable()

--- a/sdk/highlight-py/tests/test_boto3sqs.py
+++ b/sdk/highlight-py/tests/test_boto3sqs.py
@@ -1,0 +1,7 @@
+from highlight_io.integrations.boto3sqs import Boto3SQSIntegration
+
+
+def test_boto3sqs():
+    integration = Boto3SQSIntegration()
+    integration.enable()
+    integration.disable()

--- a/sdk/highlight-py/tests/test_redis.py
+++ b/sdk/highlight-py/tests/test_redis.py
@@ -1,0 +1,7 @@
+from highlight_io.integrations.redis import RedisIntegration
+
+
+def test_redis():
+    integration = RedisIntegration()
+    integration.enable()
+    integration.disable()


### PR DESCRIPTION
## Summary
Add tracing auto-instrumentation support for python libraries:
- Redis
- Boto
- Boto3 (sqs only)

## How did you test this change?
1) Add your AWS credentials as environment variables
2) Start the fastapi app (make sure Redis is running)
3) Hit the redis endpoint (`/redis`)
- [ ] Redis set span created
- [ ] Redis get span created
- [ ] Spans linked to correct trace and session
4) Hit the boto endpoint (`/boto`)
- [ ] Boto action span created
- [ ] Span linked to correct trace and session
5) Hit the boto3 send endpoint (`/boto3sqs_send`)
- [ ] SQS send span created
- [ ] Span linked to correct trace and session
6) Hit the boto3 receive endpoint (`/boto3sqs_receive`)
- [ ] SQS receive span created
- [ ] Span linked to correct trace and session

https://www.loom.com/share/f0d12fef893b43b39df54b0e6e723081?sid=5baa9042-5957-4151-9be4-b8b5e87f7e91

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
