### PR TITLE
SessionAlertPage update

### DIFF
--- a/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
+++ b/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
@@ -244,6 +244,8 @@ export const SessionAlertPage = () => {
 							configuration.name ===
 							ALERT_NAMES.USER_PROPERTIES_ALERT
 
+						const excludeRules = configuration.supportsExcludeRules
+
 						const input: SessionAlertInput = {
 							count_threshold: formStore.getValue(
 								formStore.names.threshold,
@@ -271,10 +273,11 @@ export const SessionAlertPage = () => {
 							threshold_window: formStore.getValue(
 								formStore.names.threshold_window,
 							),
-							exclude_rules:
-								formStore.getValue(
-									formStore.names.excludeRules,
-								) || [],
+							exclude_rules: excludeRules
+								? formStore.getValue(
+										formStore.names.excludeRules,
+								  ) || []
+								: [],
 							user_properties: tracksUserProperties
 								? (
 										formStore.getValue(

--- a/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
+++ b/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
@@ -49,7 +49,11 @@ import LoadingBox from '@/components/LoadingBox'
 import TextHighlighter from '@/components/TextHighlighter/TextHighlighter'
 import { namedOperations } from '@/graph/generated/operations'
 import { SessionAlertInput, SessionAlertType } from '@/graph/generated/schemas'
-import { ALERT_CONFIGURATIONS, AlertConfiguration } from '@/pages/Alerts/Alerts'
+import {
+	ALERT_CONFIGURATIONS,
+	ALERT_NAMES,
+	AlertConfiguration,
+} from '@/pages/Alerts/Alerts'
 import { useAlertsContext } from '@/pages/Alerts/AlertsContext/AlertsContext'
 import AlertNotifyForm from '@/pages/Alerts/components/AlertNotifyForm/AlertNotifyForm'
 import AlertTitleField from '@/pages/Alerts/components/AlertTitleField/AlertTitleField'
@@ -160,7 +164,7 @@ export const SessionAlertPage = () => {
 			}))
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [alert, alertType])
+	}, [alert])
 
 	const [updateSessionAlertMutation] = useUpdateSessionAlertMutation({
 		refetchQueries: [namedOperations.Query.GetAlertsPagePayload],
@@ -233,6 +237,13 @@ export const SessionAlertPage = () => {
 					emphasis="high"
 					trackingId="saveErrorMonitoringAlert"
 					onClick={() => {
+						const tracksSessionProperties =
+							configuration.name ===
+							ALERT_NAMES.TRACK_PROPERTIES_ALERT
+						const tracksUserProperties =
+							configuration.name ===
+							ALERT_NAMES.USER_PROPERTIES_ALERT
+
 						const input: SessionAlertInput = {
 							count_threshold: formStore.getValue(
 								formStore.names.threshold,
@@ -264,35 +275,36 @@ export const SessionAlertPage = () => {
 								formStore.getValue(
 									formStore.names.excludeRules,
 								) || [],
-							user_properties: (
-								formStore.getValue(
-									formStore.names.userProperties,
-								) || []
-							).map((userProperty: any) => {
-								const [id, name, value] = userProperty.split(
-									SEPARATOR,
-									3,
-								)
-								return {
-									id,
-									value,
-									name,
-								}
-							}),
-							track_properties:
-								(
-									formStore.getValue(
-										formStore.names.trackProperties,
-									) || []
-								).map((trackProperty: any) => {
-									const [id, name, value] =
-										trackProperty.split(SEPARATOR, 3)
-									return {
-										id,
-										value,
-										name,
-									}
-								}) || [],
+							user_properties: tracksUserProperties
+								? (
+										formStore.getValue(
+											formStore.names.userProperties,
+										) || []
+								  ).map((userProperty: any) => {
+										const [id, name, value] =
+											userProperty.split(SEPARATOR, 3)
+										return {
+											id,
+											value,
+											name,
+										}
+								  })
+								: [],
+							track_properties: tracksSessionProperties
+								? (
+										formStore.getValue(
+											formStore.names.trackProperties,
+										) || []
+								  ).map((trackProperty: any) => {
+										const [id, name, value] =
+											trackProperty.split(SEPARATOR, 3)
+										return {
+											id,
+											value,
+											name,
+										}
+								  }) || []
+								: [],
 							type: alertType,
 						}
 


### PR DESCRIPTION
fixes #7128
@SpennyNDaJets, thought I'd try my hands on this.

## Summary
Update the SessionAlertPage to not update the session form when alertType changes

## DEMO
https://drive.google.com/file/d/1frNqhyQCxQHo5neDWvLjVS3ALBav9UlW/view?usp=sharing

# Filtering relevant fields
Since we were no longer resetting the form we needed to omit previously "filled" form data that 
is not relevant to the session type being created. I omitted fields based on the alert configuration.
Alert threshold and threshold window fields are however not omitted. 

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- Visit the new/edit session page and fill in some form like "excluded environments" or any of the channels to notify
- Change the alert type
- Observe that data in the channels to notify/excluded envs or any other field that is displayed for the form remains

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
NO

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
NO
<!--
 Request review from julian-highlight / our design team 
-->
