### PR TITLE
use clickhouse for session metrics

### DIFF
--- a/backend/clickhouse/migrations/000070_add_session_metrics.down.sql
+++ b/backend/clickhouse/migrations/000070_add_session_metrics.down.sql
@@ -1,0 +1,2 @@
+DROP VIEW IF EXISTS session_metrics_mv;
+DROP TABLE IF EXISTS session_metrics;

--- a/backend/clickhouse/migrations/000070_add_session_metrics.up.sql
+++ b/backend/clickhouse/migrations/000070_add_session_metrics.up.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS session_metrics (
+    `ProjectId` Int32,
+    `SecureSessionId` String,
+    `Name` String,
+    `Value` Float64,
+    `Timestamp` DateTime64(9)
+) ENGINE = MergeTree
+ORDER BY (ProjectId, SecureSessionId);
+CREATE MATERIALIZED VIEW IF NOT EXISTS session_metrics_mv TO session_metrics (
+    `ProjectId` Int32,
+    `SecureSessionId` String,
+    `Name` String,
+    `Value` Float64,
+    `Timestamp` DateTime64(9)
+) AS
+SELECT ProjectId,
+    SecureSessionId,
+    Events.Attributes [1] ['metric.name'] AS Name,
+    toFloat64OrNull(Events.Attributes [1] ['metric.value']) AS Value,
+    Timestamp
+FROM traces
+WHERE SpanName = 'highlight-metric'
+    AND SecureSessionId <> ''
+    AND Name is not null
+    AND Value is not null;


### PR DESCRIPTION
## Summary
- device memory and web vitals are the last two types of metrics being read from postgres
- add a clickhouse materialized view indexed on session secure id to look up these metrics efficiently from clickhouse
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally to make sure migration created the table/mv and the resolver was behaving correctly
<img width="334" alt="Screen Shot 2024-01-09 at 3 39 41 PM" src="https://github.com/highlight/highlight/assets/86132398/ce91010d-7a9d-4f9c-a582-9f4947d3025f">

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- table / mv already created in prod, will remove the code for saving to the metrics table once this is looking good
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
