### PR TITLE
Fixed "Suggested Edits" Docs link

### DIFF
--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -44,12 +44,12 @@ import DocSelect from '../../components/Docs/DocSelect/DocSelect'
 import { generateIdFromProps } from '../../components/Docs/DocsTypographyRenderer/DocsTypographyRenderer'
 import { HighlightCodeBlock } from '../../components/Docs/HighlightCodeBlock/HighlightCodeBlock'
 import { useMediaQuery } from '../../components/MediaQuery/MediaQuery'
+import logger from '../../highlight.logger'
 import ChevronDown from '../../public/images/ChevronDownIcon'
 import Minus from '../../public/images/MinusIcon'
-import logger from '../../highlight.logger'
 
 const DOCS_CONTENT_PATH = path.join(process.cwd(), '../docs-content')
-const DOCS_GITUB_LINK = `https://github.com/highlight/highlight/blob/main/docs-content`
+const DOCS_GITHUB_LINK = `https://github.com/highlight/highlight/blob/main/docs-content`
 export interface DocPath {
 	// e.g. '[tips, sessions-search-deep-linking.md]'
 	array_path: string[]
@@ -588,9 +588,9 @@ const PageRightBar = ({
 					<FaDiscord style={{ height: 20, width: 20 }}></FaDiscord>
 					<Typography type="copy3">Community / Support</Typography>
 				</Link>
-				<Link
+				<a
 					className={styles.socialItem}
-					href={`${DOCS_GITUB_LINK}${relativePath}`.replaceAll(
+					href={`${DOCS_GITHUB_LINK}${relativePath}`.replaceAll(
 						/\/+/g,
 						'/',
 					)}
@@ -598,7 +598,7 @@ const PageRightBar = ({
 				>
 					<FaGithub style={{ height: 20, width: 20 }}></FaGithub>
 					<Typography type="copy3">Suggest Edits?</Typography>
-				</Link>
+				</a>
 				<Link
 					style={{ borderTop: '1px solid #30294E' }}
 					className={styles.socialItem}

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -581,6 +581,8 @@ const PageRightBar = ({
 		'/',
 	)
 
+	console.log(suggestLink)
+
 	return (
 		<div className={styles.rightBarWrap}>
 			<div className={styles.resourcesSideBar}>

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -576,6 +576,11 @@ const PageRightBar = ({
 	const [activeId, setActiveId] = useState<string>()
 	useIntersectionObserver(setActiveId)
 
+	const suggestLink = `${DOCS_GITHUB_LINK}${relativePath}`.replaceAll(
+		/\/+/g,
+		'/',
+	)
+
 	return (
 		<div className={styles.rightBarWrap}>
 			<div className={styles.resourcesSideBar}>
@@ -590,10 +595,7 @@ const PageRightBar = ({
 				</Link>
 				<a
 					className={styles.socialItem}
-					href={`${DOCS_GITHUB_LINK}${relativePath}`.replaceAll(
-						/\/+/g,
-						'/',
-					)}
+					href={suggestLink}
 					target="_blank"
 				>
 					<FaGithub style={{ height: 20, width: 20 }}></FaGithub>

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -577,7 +577,7 @@ const PageRightBar = ({
 	useIntersectionObserver(setActiveId)
 
 	const suggestLink =
-		'https:// ' +
+		'https://' +
 		`${DOCS_GITHUB_LINK}${relativePath}`.replaceAll(/\/+/g, '/')
 
 	return (

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -49,7 +49,7 @@ import ChevronDown from '../../public/images/ChevronDownIcon'
 import Minus from '../../public/images/MinusIcon'
 
 const DOCS_CONTENT_PATH = path.join(process.cwd(), '../docs-content')
-const DOCS_GITHUB_LINK = `https://github.com/highlight/highlight/blob/main/docs-content`
+const DOCS_GITHUB_LINK = `github.com/highlight/highlight/blob/main/docs-content`
 export interface DocPath {
 	// e.g. '[tips, sessions-search-deep-linking.md]'
 	array_path: string[]
@@ -576,12 +576,9 @@ const PageRightBar = ({
 	const [activeId, setActiveId] = useState<string>()
 	useIntersectionObserver(setActiveId)
 
-	const suggestLink = `${DOCS_GITHUB_LINK}${relativePath}`.replaceAll(
-		/\/+/g,
-		'/',
-	)
-
-	console.log(suggestLink)
+	const suggestLink =
+		'https:// ' +
+		`${DOCS_GITHUB_LINK}${relativePath}`.replaceAll(/\/+/g, '/')
 
 	return (
 		<div className={styles.rightBarWrap}>


### PR DESCRIPTION
## Summary

Fix for "Suggest Edits" docs button not linking properly in prod. When merging the github docs link with the relative docs path, precautions were taken to prevent double slashes. The links would replace every '//' with '/'. However, this also applied to the '//' in 'https://', which broke the link.

## How did you test this change?

Click-testing

## Are there any deployment considerations?

No.

## Does this work require review from our design team?

No.
