### PR TITLE
ensure session report works for large number of sessions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -118,6 +118,7 @@ jobs:
             CLICKHOUSE_USERNAME: 'default'
             CLICKHOUSE_PASSWORD: ''
             PSQL_HOST: 'localhost'
+            PSQL_DOCKER_HOST: 'postgres'
             PSQL_PORT: '5432'
             PSQL_USER: 'postgres'
             PSQL_DB: 'postgres'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
 		"CLICKHOUSE_PASSWORD": "",
 		"LOG_LEVEL": "debug",
 		"PSQL_HOST": "localhost",
+		"PSQL_DOCKER_HOST": "postgres",
 		"PSQL_PORT": "5432",
 		"PSQL_USER": "postgres",
 		"PSQL_PASSWORD": "postgres",

--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -33,7 +33,6 @@ var (
 )
 
 func GetPostgresConnectionString() string {
-	// TODO(vkorolik) PSQL_DOCKER_HOST
 	return fmt.Sprintf("postgresql('%s:%s', '%s', 'sessions', '%s', '%s')", os.Getenv("PSQL_DOCKER_HOST"), os.Getenv("PSQL_PORT"), os.Getenv("PSQL_DB"), os.Getenv("PSQL_USER"), os.Getenv("PSQL_PASSWORD"))
 }
 

--- a/backend/clickhouse/clickhouse.go
+++ b/backend/clickhouse/clickhouse.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,6 +31,11 @@ var (
 	Username        = os.Getenv("CLICKHOUSE_USERNAME")
 	Password        = os.Getenv("CLICKHOUSE_PASSWORD")
 )
+
+func GetPostgresConnectionString() string {
+	// TODO(vkorolik) PSQL_DOCKER_HOST
+	return fmt.Sprintf("postgresql('%s:%s', '%s', 'sessions', '%s', '%s')", os.Getenv("PSQL_DOCKER_HOST"), os.Getenv("PSQL_PORT"), os.Getenv("PSQL_DB"), os.Getenv("PSQL_USER"), os.Getenv("PSQL_PASSWORD"))
+}
 
 func NewClient(dbName string) (*Client, error) {
 	opts := getClickhouseOptions(dbName)

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/highlight-run/highlight/backend/queryparser"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/huandu/go-sqlbuilder"
@@ -220,7 +221,7 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 	return g.Wait()
 }
 
-func getSessionsQueryImpl(admin *model.Admin, query modelInputs.ClickhouseQuery, projectId int, retentionDate time.Time, selectColumns string, groupBy *string, orderBy *string, limit *int, offset *int) (string, []interface{}, bool, error) {
+func GetSessionsQueryImpl(admin *model.Admin, query modelInputs.ClickhouseQuery, projectId int, retentionDate time.Time, selectColumns string, groupBy *string, orderBy *string, limit *int, offset *int) (string, []interface{}, bool, error) {
 	rules, err := deserializeRules(query.Rules)
 	if err != nil {
 		return "", nil, false, err
@@ -320,7 +321,7 @@ func (client *Client) QuerySessionIds(ctx context.Context, admin *model.Admin, p
 	}
 	offset := (pageInt - 1) * count
 
-	sql, args, sampleRuleFound, err := getSessionsQueryImpl(admin, query, projectId, retentionDate, "ID, count() OVER() AS total", nil, pointy.String(sortField), pointy.Int(count), pointy.Int(offset))
+	sql, args, sampleRuleFound, err := GetSessionsQueryImpl(admin, query, projectId, retentionDate, "ID, count() OVER() AS total", nil, pointy.String(sortField), pointy.Int(count), pointy.Int(offset))
 	if err != nil {
 		return nil, 0, false, err
 	}
@@ -358,7 +359,7 @@ func (client *Client) QuerySessionHistogram(ctx context.Context, admin *model.Ad
 
 	orderBy := fmt.Sprintf("1 WITH FILL FROM %s(?, '%s') TO %s(?, '%s') STEP 1", aggFn, location.String(), aggFn, location.String())
 
-	sql, args, _, err := getSessionsQueryImpl(admin, query, projectId, retentionDate, selectCols, pointy.String("1"), &orderBy, nil, nil)
+	sql, args, _, err := GetSessionsQueryImpl(admin, query, projectId, retentionDate, selectCols, pointy.String("1"), &orderBy, nil, nil)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -522,4 +523,8 @@ func (client *Client) QuerySessionCustomMetrics(ctx context.Context, projectId i
 	}
 
 	return metrics, nil
+}
+
+func (client *Client) GetConn() driver.Conn {
+	return client.conn
 }

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -10608,9 +10608,9 @@ type SessionInterval {
 
 type SessionsReportRow {
 	key: String!
-	num_sessions: Int!
-	num_days_visited: Int!
-	num_months_visited: Int!
+	num_sessions: UInt64!
+	num_days_visited: UInt64!
+	num_months_visited: UInt64!
 	avg_active_length_mins: Float!
 	max_active_length_mins: Float!
 	total_active_length_mins: Float!
@@ -65621,9 +65621,9 @@ func (ec *executionContext) _SessionsReportRow_num_sessions(ctx context.Context,
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(uint64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNUInt642uint64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SessionsReportRow_num_sessions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -65633,7 +65633,7 @@ func (ec *executionContext) fieldContext_SessionsReportRow_num_sessions(ctx cont
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type UInt64 does not have child fields")
 		},
 	}
 	return fc, nil
@@ -65665,9 +65665,9 @@ func (ec *executionContext) _SessionsReportRow_num_days_visited(ctx context.Cont
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(uint64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNUInt642uint64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SessionsReportRow_num_days_visited(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -65677,7 +65677,7 @@ func (ec *executionContext) fieldContext_SessionsReportRow_num_days_visited(ctx 
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type UInt64 does not have child fields")
 		},
 	}
 	return fc, nil
@@ -65709,9 +65709,9 @@ func (ec *executionContext) _SessionsReportRow_num_months_visited(ctx context.Co
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(uint64)
 	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
+	return ec.marshalNUInt642uint64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SessionsReportRow_num_months_visited(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -65721,7 +65721,7 @@ func (ec *executionContext) fieldContext_SessionsReportRow_num_months_visited(ct
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
+			return nil, errors.New("field of type UInt64 does not have child fields")
 		},
 	}
 	return fc, nil

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -756,9 +756,9 @@ type SessionQuery struct {
 
 type SessionsReportRow struct {
 	Key                   string  `json:"key"`
-	NumSessions           int     `json:"num_sessions"`
-	NumDaysVisited        int     `json:"num_days_visited"`
-	NumMonthsVisited      int     `json:"num_months_visited"`
+	NumSessions           uint64  `json:"num_sessions"`
+	NumDaysVisited        uint64  `json:"num_days_visited"`
+	NumMonthsVisited      uint64  `json:"num_months_visited"`
 	AvgActiveLengthMins   float64 `json:"avg_active_length_mins"`
 	MaxActiveLengthMins   float64 `json:"max_active_length_mins"`
 	TotalActiveLengthMins float64 `json:"total_active_length_mins"`

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -95,9 +95,9 @@ type SessionInterval {
 
 type SessionsReportRow {
 	key: String!
-	num_sessions: Int!
-	num_days_visited: Int!
-	num_months_visited: Int!
+	num_sessions: UInt64!
+	num_days_visited: UInt64!
+	num_months_visited: UInt64!
 	avg_active_length_mins: Float!
 	max_active_length_mins: Float!
 	total_active_length_mins: Float!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5606,16 +5606,12 @@ func (r *queryResolver) SessionsReport(ctx context.Context, projectID int, query
 		return nil, err
 	}
 
-	ids, total, _, err := r.ClickhouseClient.QuerySessionIds(ctx, admin, projectID, 1_000_000, query, "ID", nil, retentionDate)
+	sql, args, _, err := clickhouse.GetSessionsQueryImpl(admin, query, projectID, retentionDate, "ID", nil, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	if total >= 1_000_000 {
-		return nil, e.New("too many sessions to generate report, adjust the query to return fewer sessions")
-	}
 
-	var results []*modelInputs.SessionsReportRow
-	if err := r.DB.Raw(`
+	rows, err := r.ClickhouseClient.GetConn().Query(ctx, fmt.Sprintf(`
 select coalesce(email, ip, client_id, identifier)                              as key,
        max(user_properties::text) filter ( where user_properties is not null ) as user_properties,
        count(*)                                                                as num_sessions,
@@ -5628,12 +5624,19 @@ select coalesce(email, ip, client_id, identifier)                              a
        max(length) / 1000 / 60                                                 as max_length_mins,
        sum(length) / 1000 / 60                                                 as total_length_mins,
        max(case when state is not null then state || '|' || city end)          as location
-from sessions
-where id in (?)
-group by 1
-order by num_sessions desc;
-`, ids).Scan(&results).Error; err != nil {
+from %s where id in (%s) group by 1 order by num_sessions desc;
+`, clickhouse.GetPostgresConnectionString(), sql), args...)
+	if err != nil {
 		return nil, err
+	}
+
+	var results []*modelInputs.SessionsReportRow
+	for rows.Next() {
+		var result modelInputs.SessionsReportRow
+		if err := rows.Scan(&result.Key, &result.UserProperties, &result.NumSessions, &result.NumDaysVisited, &result.NumMonthsVisited, &result.AvgActiveLengthMins, &result.MaxActiveLengthMins, &result.TotalActiveLengthMins, &result.AvgLengthMins, &result.MaxLengthMins, &result.TotalLengthMins, &result.Location); err != nil {
+			return nil, err
+		}
+		results = append(results, &result)
 	}
 
 	return results, nil

--- a/docker/.env
+++ b/docker/.env
@@ -16,6 +16,7 @@ OTLP_ENDPOINT=http://collector:4318
 TZ=America/Los_Angeles
 PSQL_DB=postgres
 PSQL_HOST=postgres
+PSQL_DOCKER_HOST=postgres
 PSQL_PASSWORD=
 PSQL_PORT=5432
 PSQL_USER=postgres

--- a/docker/compose.hobby.yml
+++ b/docker/compose.hobby.yml
@@ -32,6 +32,7 @@ x-backend-env: &backend-env
         - OTLP_ENDPOINT
         - PSQL_DB
         - PSQL_HOST
+        - PSQL_DOCKER_HOST
         - PSQL_PASSWORD
         - PSQL_PORT
         - PSQL_USER

--- a/docker/env.sh
+++ b/docker/env.sh
@@ -17,6 +17,7 @@ else
     export CLICKHOUSE_ADDRESS=localhost:9000
     export KAFKA_SERVERS=localhost:9092
     export PSQL_HOST=localhost
+    export PSQL_DOCKER_HOST=postgres
     export REDIS_EVENTS_STAGING_ENDPOINT=localhost:6379
 fi
 export BUILD_ARGS="--build-arg GOARCH=${GOARCH}

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -3115,9 +3115,9 @@ export type SessionsReportRow = {
 	location: Scalars['String']
 	max_active_length_mins: Scalars['Float']
 	max_length_mins: Scalars['Float']
-	num_days_visited: Scalars['Int']
-	num_months_visited: Scalars['Int']
-	num_sessions: Scalars['Int']
+	num_days_visited: Scalars['UInt64']
+	num_months_visited: Scalars['UInt64']
+	num_sessions: Scalars['UInt64']
 	total_active_length_mins: Scalars['Float']
 	total_length_mins: Scalars['Float']
 	user_properties?: Maybe<Scalars['String']>


### PR DESCRIPTION
## Summary

Session reports feature would break for large projects because we would be feeding
a list of IDs from ClickHouse to postgres.

```jsx
Uncaught (in promise) Error: No sessions data: extended protocol limited to 65535 parameters
    at report.ts:131:17
    at async Promise.all (/762/index 0)
    at async generateSessionsReportCSV (report.ts:119:39)
    at async onClick (SessionFeedConfigurationV2.tsx:398:9)
```

Replace the query with a nested CH query that also hits postgres for some of the session data.

## How did you test this change?

Local deploy producing the report.

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
