### PR TITLE
enhance pino transport

### DIFF
--- a/.changeset/silent-ads-smash.md
+++ b/.changeset/silent-ads-smash.md
@@ -1,0 +1,6 @@
+---
+'@highlight-run/next': patch
+'@highlight-run/node': patch
+---
+
+fix app/page router blocking on errors in some cases

--- a/.changeset/unlucky-spoons-move.md
+++ b/.changeset/unlucky-spoons-move.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/next': patch
+---
+
+fix next/error import for ESNext module resolution

--- a/backend/private-graph/graph/middleware.go
+++ b/backend/private-graph/graph/middleware.go
@@ -13,6 +13,7 @@ import (
 	firebase "firebase.google.com/go"
 	"firebase.google.com/go/auth"
 	"github.com/segmentio/encoding/json"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 
@@ -223,7 +224,7 @@ func getSourcemapRequestToken(r *http.Request) string {
 func PrivateMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		span, ctx := util.StartSpanFromContext(ctx, "middleware.private")
+		span, ctx := util.StartSpanFromContext(ctx, "middleware.private", util.WithSpanKind(trace.SpanKindServer))
 		defer span.Finish()
 		var err error
 		if token := r.Header.Get("token"); token != "" {

--- a/e2e/nextjs/next.config.mjs
+++ b/e2e/nextjs/next.config.mjs
@@ -1,8 +1,12 @@
 // next.config.mjs
 import { withHighlightConfig } from '@highlight-run/next/config'
 
+/** @type {import('next').NextConfig} */
 const nextConfig = {
 	productionBrowserSourceMaps: true,
+	experimental: {
+		serverComponentsExternalPackages: ['pino', 'pino-pretty'],
+	},
 	images: {
 		remotePatterns: [{ protocol: 'https', hostname: 'i.travelapi.com' }],
 	},

--- a/e2e/nextjs/package.json
+++ b/e2e/nextjs/package.json
@@ -14,6 +14,7 @@
 	},
 	"dependencies": {
 		"@highlight-run/next": "workspace:*",
+		"@highlight-run/pino": "workspace:*",
 		"@next/env": "^13.5.4",
 		"@tanstack/react-query": "^4.35.7",
 		"@trpc/client": "^10.38.5",
@@ -32,6 +33,8 @@
 		"next": "13.5.4",
 		"next-build-id": "^3.0.0",
 		"pg": "^8.11.3",
+		"pino": "^8.17.2",
+		"pino-pretty": "^10.3.1",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",
 		"typescript": "5.2.2",

--- a/e2e/nextjs/pages/ssr.tsx
+++ b/e2e/nextjs/pages/ssr.tsx
@@ -35,13 +35,3 @@ export const getStaticProps: GetStaticProps = (props) => {
 		revalidate: 10, // seconds
 	}
 }
-
-export const getServerSideProps = async () => {
-	const res = await fetch('https://api.github.com/repos/vercel/next.js')
-	const repo = await res.json()
-
-	console.info('console.info getServerSideProps pages/ssr')
-	logger.info({ repo }, 'getServerSideProps pages/ssr')
-
-	return { props: { repo } }
-}

--- a/e2e/nextjs/pages/ssr.tsx
+++ b/e2e/nextjs/pages/ssr.tsx
@@ -1,4 +1,6 @@
+import logger from '@/highlight.logger'
 import { useRouter } from 'next/router'
+import { GetServerSideProps, GetStaticProps } from 'next'
 
 type Props = {
 	date: string
@@ -21,8 +23,9 @@ export default function SsrPage({ date, random }: Props) {
 	)
 }
 
-export async function getStaticProps() {
-	console.info('getStaticProps pages/ssr')
+export const getStaticProps: GetStaticProps = (props) => {
+	console.info('console.info getStaticProps pages/ssr')
+	logger.info({ props }, 'getStaticProps pages/ssr')
 
 	return {
 		props: {
@@ -31,4 +34,14 @@ export async function getStaticProps() {
 		},
 		revalidate: 10, // seconds
 	}
+}
+
+export const getServerSideProps = async () => {
+	const res = await fetch('https://api.github.com/repos/vercel/next.js')
+	const repo = await res.json()
+
+	console.info('console.info getServerSideProps pages/ssr')
+	logger.info({ repo }, 'getServerSideProps pages/ssr')
+
+	return { props: { repo } }
 }

--- a/e2e/nextjs/src/app/another-page/page.tsx
+++ b/e2e/nextjs/src/app/another-page/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
+import logger from '@/highlight.logger'
 
 export default function AnotherPage() {
+	logger.info({}, `another page!`)
 	return (
 		<div>
 			<h1>Another page</h1>

--- a/e2e/nextjs/src/app/api/app-router-test/route.ts
+++ b/e2e/nextjs/src/app/api/app-router-test/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { withAppRouterHighlight } from '@/app/_utils/app-router-highlight.config'
 import { Client } from 'pg'
 import { statfsSync } from 'node:fs'
+import logger from '@/highlight.logger'
 
 export const GET = withAppRouterHighlight(async function GET(
 	request: NextRequest,
@@ -14,7 +15,7 @@ export const GET = withAppRouterHighlight(async function GET(
 	let result: { rows: { message: string }[] } = { rows: [{ message: '' }] }
 
 	console.info('Here: /api/app-router-test/route.ts 💘💘💘', { sql, success })
-
+	logger.info({ sql, success }, `app router test get`)
 	if (sql === 'true') {
 		try {
 			console.info('😇 Connecting to Postgres...')
@@ -59,6 +60,7 @@ export const GET = withAppRouterHighlight(async function GET(
 export const POST = withAppRouterHighlight(async function POST(
 	request: Request,
 ) {
+	logger.info({}, `app router test post`)
 	const headers = Object.fromEntries(request.headers.entries())
 
 	return NextResponse.json({

--- a/e2e/nextjs/src/app/api/app-router-trace/route.ts
+++ b/e2e/nextjs/src/app/api/app-router-trace/route.ts
@@ -2,12 +2,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { withAppRouterHighlight } from '@/app/_utils/app-router-highlight.config'
 import { H } from '@highlight-run/next/server'
+import logger from '@/highlight.logger'
 
 export const GET = withAppRouterHighlight(async function GET(
 	request: NextRequest,
 ) {
 	return new Promise(async (resolve) => {
 		const span = await H.startActiveSpan('app-router-span', {})
+
+		logger.info({}, `app router trace get`)
 
 		console.info('Here: /pages/api/app-router-trace/route.ts ⏰⏰⏰')
 

--- a/e2e/nextjs/src/app/app-router/redirect/page.tsx
+++ b/e2e/nextjs/src/app/app-router/redirect/page.tsx
@@ -1,10 +1,13 @@
 import { redirect } from 'next/navigation'
+import logger from '@/highlight.logger'
 
 type Props = {
 	searchParams: { shouldRedirect?: boolean }
 }
 
 export default function RedirectPage({ searchParams }: Props) {
+	logger.info({}, `redirect page`)
+
 	if (searchParams.shouldRedirect) {
 		return redirect(`/ssr`)
 	}

--- a/e2e/nextjs/src/app/app-router/ssr/page.tsx
+++ b/e2e/nextjs/src/app/app-router/ssr/page.tsx
@@ -1,8 +1,12 @@
+import logger from '@/highlight.logger'
+
 type Props = {
 	searchParams: { error?: string }
 }
 
 export default function SsrPage({ searchParams }: Props) {
+	logger.info({}, `ssr page`)
+
 	if (searchParams.error) {
 		throw new Error('🎉 SSR Error: src/app-router/ssr/page.tsx')
 	}

--- a/e2e/nextjs/src/app/page.tsx
+++ b/e2e/nextjs/src/app/page.tsx
@@ -9,8 +9,10 @@ import Link from 'next/link'
 import { PathButtons } from '@/app/components/path-buttons'
 import { TrpcQueries } from '@/app/components/trpc-queries'
 import { Canvas } from '@/app/components/canvas'
+import logger from '@/highlight.logger'
 
 export default function Home() {
+	logger.info({}, `Home page component`)
 	return (
 		<main style={{ padding: '2rem' }}>
 			<HighlightIdentify />

--- a/e2e/nextjs/src/highlight.logger.ts
+++ b/e2e/nextjs/src/highlight.logger.ts
@@ -18,8 +18,7 @@ const pinoConfig = {
 	},
 } as LoggerOptions
 
-const node = process.env.NEXT_RUNTIME === 'nodejs'
-if (node) {
+if (process.env.NEXT_RUNTIME === 'nodejs') {
 	const { H } = require('@highlight-run/node')
 	H.init(highlightConfig)
 }

--- a/e2e/nextjs/src/highlight.logger.ts
+++ b/e2e/nextjs/src/highlight.logger.ts
@@ -1,0 +1,30 @@
+import { highlightConfig } from '@/instrumentation'
+
+let pinoConfig = {
+	level: 'debug',
+	transport: {
+		targets: [
+			{
+				target: 'pino/file',
+				options: { destination: 1 }, // this writes to STDOUT
+				level: 'debug',
+			},
+			{
+				target: '@highlight-run/pino',
+				options: highlightConfig,
+				level: 'debug',
+			},
+		],
+	},
+}
+
+if (
+	typeof process.env.NEXT_RUNTIME === 'undefined' ||
+	process.env.NEXT_RUNTIME === 'nodejs'
+) {
+	const { H } = require('@highlight-run/node')
+	H.init(highlightConfig)
+}
+
+const logger = require('pino')(pinoConfig)
+export default logger

--- a/e2e/nextjs/src/highlight.logger.ts
+++ b/e2e/nextjs/src/highlight.logger.ts
@@ -1,6 +1,7 @@
 import { highlightConfig } from '@/instrumentation'
+import type { LoggerOptions } from 'pino'
 
-let pinoConfig = {
+const pinoConfig = {
 	level: 'debug',
 	transport: {
 		targets: [
@@ -16,15 +17,15 @@ let pinoConfig = {
 			},
 		],
 	},
-}
+} as LoggerOptions
 
-if (
+const node =
 	typeof process.env.NEXT_RUNTIME === 'undefined' ||
 	process.env.NEXT_RUNTIME === 'nodejs'
-) {
+if (node) {
 	const { H } = require('@highlight-run/node')
 	H.init(highlightConfig)
 }
 
-const logger = require('pino')(pinoConfig)
+const logger = require('pino')(node ? {} : pinoConfig)
 export default logger

--- a/e2e/nextjs/src/highlight.logger.ts
+++ b/e2e/nextjs/src/highlight.logger.ts
@@ -6,8 +6,7 @@ const pinoConfig = {
 	transport: {
 		targets: [
 			{
-				target: 'pino/file',
-				options: { destination: 1 }, // this writes to STDOUT
+				target: 'pino-pretty',
 				level: 'debug',
 			},
 			{
@@ -19,13 +18,11 @@ const pinoConfig = {
 	},
 } as LoggerOptions
 
-const node =
-	typeof process.env.NEXT_RUNTIME === 'undefined' ||
-	process.env.NEXT_RUNTIME === 'nodejs'
+const node = process.env.NEXT_RUNTIME === 'nodejs'
 if (node) {
 	const { H } = require('@highlight-run/node')
 	H.init(highlightConfig)
 }
 
-const logger = require('pino')(node ? {} : pinoConfig)
+const logger = require('pino')(pinoConfig)
 export default logger

--- a/e2e/nextjs/src/instrumentation.ts
+++ b/e2e/nextjs/src/instrumentation.ts
@@ -11,5 +11,5 @@ export const highlightConfig = {
 
 export async function register() {
 	const { registerHighlight } = await import('@highlight-run/next/server')
-	await registerHighlight(highlightConfig)
+	registerHighlight(highlightConfig)
 }

--- a/e2e/nextjs/src/instrumentation.ts
+++ b/e2e/nextjs/src/instrumentation.ts
@@ -1,13 +1,15 @@
 // instrumentation.ts or src/instrumentation.ts
 import { CONSTANTS } from '@/constants'
+import type { NodeOptions } from '@highlight-run/node'
+
+export const highlightConfig = {
+	projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
+	otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
+	serviceName: 'my-nextjs-backend',
+	environment: 'e2e-test',
+} as NodeOptions
 
 export async function register() {
 	const { registerHighlight } = await import('@highlight-run/next/server')
-
-	registerHighlight({
-		projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
-		otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
-		serviceName: 'my-nextjs-backend',
-		environment: 'e2e-test',
-	})
+	await registerHighlight(highlightConfig)
 }

--- a/highlight.io/highlight.logger.ts
+++ b/highlight.io/highlight.logger.ts
@@ -1,10 +1,13 @@
+import type { LoggerOptions } from 'pino'
+import type { NodeOptions } from '@highlight-run/node'
+
 const highlightConfig = {
-	projectID: '1',
+	projectID: '4d7k1xeo',
 	serviceName: 'highlight-io-pino',
 	serviceVersion: 'git-sha',
 } as NodeOptions
 
-let pinoConfig = {
+const pinoConfig = {
 	level: 'debug',
 	transport: {
 		targets: [
@@ -20,20 +23,12 @@ let pinoConfig = {
 			},
 		],
 	},
-}
+} as LoggerOptions
 
-if (
-	typeof process.env.NEXT_RUNTIME === 'undefined' ||
-	process.env.NEXT_RUNTIME === 'nodejs'
-) {
+if (process.env.NEXT_RUNTIME === 'nodejs') {
 	const { H } = require('@highlight-run/node')
 	H.init(highlightConfig)
 }
 
-import type { LoggerOptions } from 'pino'
-import pino from 'pino'
-import type { NodeOptions } from '@highlight-run/node'
-
-const logger = pino(pinoConfig)
-
+const logger = require('pino')(pinoConfig)
 export default logger

--- a/highlight.io/highlight.logger.ts
+++ b/highlight.io/highlight.logger.ts
@@ -7,10 +7,20 @@ const highlightConfig = {
 let pinoConfig = {
 	level: 'debug',
 	transport: {
-		target: '@highlight-run/pino',
-		options: highlightConfig,
+		targets: [
+			{
+				target: 'pino/file',
+				options: { destination: 1 }, // this writes to STDOUT
+				level: 'debug',
+			},
+			{
+				target: '@highlight-run/pino',
+				options: highlightConfig,
+				level: 'debug',
+			},
+		],
 	},
-} as LoggerOptions
+}
 
 if (
 	typeof process.env.NEXT_RUNTIME === 'undefined' ||

--- a/highlight.io/next.config.js
+++ b/highlight.io/next.config.js
@@ -23,6 +23,9 @@ const nextConfig = {
 			'tamuhack.org',
 		],
 	},
+	experimental: {
+		serverComponentsExternalPackages: ['pino', 'pino-pretty'],
+	},
 	productionBrowserSourceMaps: true,
 	reactStrictMode: true,
 	swcMinify: true,

--- a/highlight.io/pages/api/docs/search/[searchValue].ts
+++ b/highlight.io/pages/api/docs/search/[searchValue].ts
@@ -4,6 +4,7 @@ import path from 'path'
 import removeMd from 'remove-markdown'
 import { withPageRouterHighlight } from '../../../../highlight.config'
 import { getDocsPaths, readMarkdown } from '../../../docs/[[...doc]]'
+import logger from '../../../../highlight.logger'
 
 export const SEARCH_RESULT_BLURB_LENGTH = 100
 
@@ -23,7 +24,7 @@ const handler = withPageRouterHighlight(async function handler(
 	res: NextApiResponse,
 ) {
 	const searchValue = [req.query.searchValue].flat().join('').toLowerCase()
-	// logger.info('running api docs search query', { searchValue })
+	logger.info('running api docs search query', { searchValue })
 	const docPaths = await getDocsPaths(fsp, undefined)
 	const paths: SearchResult[] = await Promise.all(
 		docPaths.map(async (doc) => {

--- a/highlight.io/pages/docs/[[...doc]].tsx
+++ b/highlight.io/pages/docs/[[...doc]].tsx
@@ -321,10 +321,10 @@ interface TocEntry {
 }
 
 export const getStaticProps: GetStaticProps<DocData> = async (context) => {
-	// logger.info(
-	// 	{ params: context?.params },
-	// 	`docs getStaticProps ${context?.params?.doc}`,
-	// )
+	logger.info(
+		{ params: context?.params },
+		`docs getStaticProps ${context?.params?.doc}`,
+	)
 	const docPaths = sortBySlashLength(await getDocsPaths(fsp, undefined))
 
 	// const sdkPaths = await getSdkPaths(fsp, undefined);

--- a/sdk/highlight-next/src/ssr.tsx
+++ b/sdk/highlight-next/src/ssr.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect } from 'react'
 import { HighlightOptions, H as localH } from 'highlight.run'
 import type { NextPageContext } from 'next'
-import NextError from 'next/error'
-
-import { ErrorProps } from 'next/error'
+import NextError, { ErrorProps } from 'next/error.js'
 
 export { localH as H }
 export { ErrorBoundary } from '@highlight-run/react'

--- a/sdk/highlight-next/src/util/with-highlight-nodejs-app-router.ts
+++ b/sdk/highlight-next/src/util/with-highlight-nodejs-app-router.ts
@@ -18,18 +18,14 @@ export function Highlight(options: NodeOptions) {
 			const start = new Date()
 
 			try {
-				const result = await H.runWithHeaders<Promise<Response>>(
+				return await H.runWithHeaders<Promise<Response>>(
 					request.headers,
 					async () => originalHandler(request, context),
 				)
-
-				recordLatency()
-
-				return result
 			} catch (e) {
-				recordLatency()
-
 				throw e
+			} finally {
+				recordLatency()
 			}
 
 			function recordLatency() {

--- a/sdk/highlight-next/src/util/with-highlight-nodejs-page-router.ts
+++ b/sdk/highlight-next/src/util/with-highlight-nodejs-page-router.ts
@@ -7,8 +7,6 @@ export declare type HasHeaders = { headers: IncomingHttpHeaders }
 export declare type HasStatus = {
 	readonly statusCode: number
 	readonly statusMessage: string
-	status: (statusCode: number) => HasStatus
-	send: (body: string) => void
 }
 export declare type ApiHandler<T extends HasHeaders, S extends HasStatus> = (
 	req: T,
@@ -32,7 +30,6 @@ export const Highlight =
 					return await originalHandler(req, res)
 				})
 			} catch (e) {
-				res.status(500).send('Internal Server Error')
 				throw e
 			} finally {
 				recordLatency()

--- a/sdk/highlight-next/src/util/with-highlight-nodejs-page-router.ts
+++ b/sdk/highlight-next/src/util/with-highlight-nodejs-page-router.ts
@@ -7,6 +7,8 @@ export declare type HasHeaders = { headers: IncomingHttpHeaders }
 export declare type HasStatus = {
 	readonly statusCode: number
 	readonly statusMessage: string
+	status: (statusCode: number) => HasStatus
+	send: (body: string) => void
 }
 export declare type ApiHandler<T extends HasHeaders, S extends HasStatus> = (
 	req: T,
@@ -30,6 +32,7 @@ export const Highlight =
 					return await originalHandler(req, res)
 				})
 			} catch (e) {
+				res.status(500).send('Internal Server Error')
 				throw e
 			} finally {
 				recordLatency()

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -455,7 +455,7 @@ export class Highlight {
 						span.end()
 
 						await Promise.allSettled([
-							this.waitForFlush(['highlight-run-with-headers']),
+							this.waitForFlush(),
 							this.flush(),
 						])
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -41348,6 +41348,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"help-me@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "help-me@npm:5.0.0"
+  checksum: 5f99bd91dae93d02867175c3856c561d7e3a24f16999b08f5fc79689044b938d7ed58457f4d8c8744c01403e6e0470b7896baa344d112b2355842fd935a75d69
+  languageName: node
+  linkType: hard
+
 "hex-color-regex@npm:^1.1.0":
   version: 1.1.0
   resolution: "hex-color-regex@npm:1.1.0"
@@ -50406,6 +50413,7 @@ __metadata:
   resolution: "nextjs@workspace:e2e/nextjs"
   dependencies:
     "@highlight-run/next": "workspace:*"
+    "@highlight-run/pino": "workspace:*"
     "@next/env": "npm:^13.5.4"
     "@tanstack/react-query": "npm:^4.35.7"
     "@trpc/client": "npm:^10.38.5"
@@ -50424,6 +50432,8 @@ __metadata:
     next: "npm:13.5.4"
     next-build-id: "npm:^3.0.0"
     pg: "npm:^8.11.3"
+    pino: "npm:^8.17.2"
+    pino-pretty: "npm:^10.3.1"
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
     typescript: "npm:5.2.2"
@@ -52691,6 +52701,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pino-pretty@npm:^10.3.1":
+  version: 10.3.1
+  resolution: "pino-pretty@npm:10.3.1"
+  dependencies:
+    colorette: "npm:^2.0.7"
+    dateformat: "npm:^4.6.3"
+    fast-copy: "npm:^3.0.0"
+    fast-safe-stringify: "npm:^2.1.1"
+    help-me: "npm:^5.0.0"
+    joycon: "npm:^3.1.1"
+    minimist: "npm:^1.2.6"
+    on-exit-leak-free: "npm:^2.1.0"
+    pino-abstract-transport: "npm:^1.0.0"
+    pump: "npm:^3.0.0"
+    readable-stream: "npm:^4.0.0"
+    secure-json-parse: "npm:^2.4.0"
+    sonic-boom: "npm:^3.0.0"
+    strip-json-comments: "npm:^3.1.1"
+  bin:
+    pino-pretty: bin.js
+  checksum: 4284f125f7e8a5a10e856c8fd591ba34c30c0a0071a0b265a9eda43c3e447ba11d40b06cc67108675586358a5d1213a6ac3a92f6abd2896abfbab9a5b4c17072
+  languageName: node
+  linkType: hard
+
 "pino-std-serializers@npm:^4.0.0":
   version: 4.0.0
   resolution: "pino-std-serializers@npm:4.0.0"
@@ -52764,6 +52798,27 @@ __metadata:
   bin:
     pino: bin.js
   checksum: d2860167dd5ce3322d5c007b6e88c4ef672316b193677dc637ba11d6af6ad57475380d2abdbc940a7a9f57c4fa1e5776ee7e43cb1b2c2ffcf9fa42e3af41da0f
+  languageName: node
+  linkType: hard
+
+"pino@npm:^8.17.2":
+  version: 8.17.2
+  resolution: "pino@npm:8.17.2"
+  dependencies:
+    atomic-sleep: "npm:^1.0.0"
+    fast-redact: "npm:^3.1.1"
+    on-exit-leak-free: "npm:^2.1.0"
+    pino-abstract-transport: "npm:v1.1.0"
+    pino-std-serializers: "npm:^6.0.0"
+    process-warning: "npm:^3.0.0"
+    quick-format-unescaped: "npm:^4.0.3"
+    real-require: "npm:^0.2.0"
+    safe-stable-stringify: "npm:^2.3.1"
+    sonic-boom: "npm:^3.7.0"
+    thread-stream: "npm:^2.0.0"
+  bin:
+    pino: bin.js
+  checksum: 90b74e4db3b3f8664b13def3eb4e39585a842396fd7a000ef00f2329076c889126f91bdaff0f653b9b5dd5a612dddde6ff87599ad046b47a264e8f7bfabb0ea8
   languageName: node
   linkType: hard
 
@@ -54136,6 +54191,13 @@ __metadata:
   version: 2.2.0
   resolution: "process-warning@npm:2.2.0"
   checksum: 3dcd606e31fd9bbd53e0ff62f4b3ab0786c64c9c1b8305b4bcb832cdbcd70d091747d708054e6eb8a92f2d2d391eb06f65ef4665d36975c091500b2ff4d470f6
+  languageName: node
+  linkType: hard
+
+"process-warning@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "process-warning@npm:3.0.0"
+  checksum: 2d82fa641e50a5789eaf0f2b33453760996e373d4591aac576a22d696186ab7e240a0592db86c264d4f28a46c2abbe9b94689752017db7dadc90f169f12b0924
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

* Fix @highlight-run/next importing `next/error` in a way that breaks with next 14
* Add pino transport usage to e2e example
* Update pino example to log to highlight and stdout.

## How did you test this change?

<img width="834" alt="Screenshot 2024-01-17 at 4 40 07 PM" src="https://github.com/highlight/highlight/assets/1351531/909df099-4d78-46a0-9ff7-a69eed3c70bf">

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

No