### PR TITLE
Bump @rehooks/local-storage to 2.4.5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
 		"@highlight-run/react-mentions": "4.4.2",
 		"@highlight-run/rrweb": "workspace:*",
 		"@highlight-run/ui": "workspace:*",
-		"@rehooks/local-storage": "^2.4.0",
+		"@rehooks/local-storage": "^2.4.5",
 		"@stripe/stripe-js": "^1.32.0",
 		"@tanstack/react-table": "^8.7.9",
 		"@tanstack/react-virtual": "3.0.0-beta.52",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12649,7 +12649,7 @@ __metadata:
     "@highlight-run/rrweb-types": "workspace:*"
     "@highlight-run/sourcemap-uploader": "workspace:*"
     "@highlight-run/ui": "workspace:*"
-    "@rehooks/local-storage": "npm:^2.4.0"
+    "@rehooks/local-storage": "npm:^2.4.5"
     "@stripe/stripe-js": "npm:^1.32.0"
     "@svgr/cli": "npm:^5.5.0"
     "@svgr/core": "npm:^7.0.0"
@@ -19204,12 +19204,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rehooks/local-storage@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "@rehooks/local-storage@npm:2.4.0"
+"@rehooks/local-storage@npm:^2.4.5":
+  version: 2.4.5
+  resolution: "@rehooks/local-storage@npm:2.4.5"
   peerDependencies:
-    react: "*"
-  checksum: 82cd6ac35bf8ecb66ee93f092abb94ee7d3c68b21a803a0268d635a171c773fd0612024f56a5c2559b4f2d9a9480bb1c1d90e7ac1d0a158c1e3a278fca105480
+    react: ">=16.8.0"
+  checksum: 6ee932cc83e9c6358df595f6b9cba9f4ccf3aeac2149632dcfcd12e09733430d65ec13d77baff98b689826efa8173abb178dc862063670fe6585db41572ea69c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Summary

Fixes a bug where browser builds references `global`: https://github.com/rehooks/local-storage/pull/93

Allows us to remove a default override to @lewisl9029/rehooks-local-storage on the Reflame side.

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
