### PR TITLE
reduce kafka message size to help with broker load

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
     push:
         branches:
             - 'main'
-            - 'vadim/kafka-tuning-v3'
         paths:
             - 'go.work'
             - 'go.work.sum'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
     push:
         branches:
             - 'main'
+            - 'vadim/kafka-tuning-v3'
         paths:
             - 'go.work'
             - 'go.work.sum'

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -27,7 +27,7 @@ const ConsumerGroupName = "group-default"
 const (
 	TaskRetries           = 2
 	prefetchQueueCapacity = 8
-	MaxMessageSizeBytes   = 128 * 1000 * 1000 // MB
+	MaxMessageSizeBytes   = 16 * 1000 * 1000 // MB
 )
 
 var (


### PR DESCRIPTION
## Summary

Change the max message size to avoid broker preload overloading
when the main topic workers try to join and prefetch too much data.

## How did you test this change?

before -> after of disk throughput
<img width="274" alt="Screenshot 2024-01-16 at 10 23 44 AM" src="https://github.com/highlight/highlight/assets/1351531/0a17f82d-9aca-421e-92ca-cae51d82e6b6">


## Are there any deployment considerations?

Monitoring kafka in production. Potential to have message too large errors, will look for those.

## Does this work require review from our design team?

No
