### PR TITLE
Add view tracking for traces and network resources

### DIFF
--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
@@ -19,6 +19,7 @@ import { NetworkResource } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import analytics from '@util/analytics'
 import { playerTimeToSessionAbsoluteTime } from '@util/session/utils'
 import { MillisToMinutesAndSeconds } from '@util/time'
+import { camelCase } from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
@@ -155,6 +156,7 @@ function NetworkResourceDetails({
 		setTime,
 		session,
 	} = useReplayerContext()
+	const sessionSecureId = session?.secure_id
 	const { activeNetworkResourceId, setActiveNetworkResourceId } =
 		useActiveNetworkResourceId()
 
@@ -254,6 +256,14 @@ function NetworkResourceDetails({
 		setActiveTab(NetworkRequestTabs.Info)
 		initialized.current = false
 	}, [resource.id])
+
+	useEffect(() => {
+		analytics.page(
+			`/sessions/${sessionSecureId}/network-resource/${
+				resource.id
+			}/${camelCase(activeTab)}`,
+		)
+	}, [activeTab, resource.id, sessionSecureId])
 
 	return (
 		<>

--- a/frontend/src/pages/Traces/TracePage.tsx
+++ b/frontend/src/pages/Traces/TracePage.tsx
@@ -25,9 +25,7 @@ enum TraceTabs {
 	Logs = 'Logs',
 }
 
-type Props = {}
-
-export const TracePage: React.FC<Props> = () => {
+export const TracePage: React.FC = () => {
 	const [activeTab, setActiveTab] = useState<TraceTabs>(TraceTabs.Info)
 	const {
 		durationString,
@@ -41,7 +39,7 @@ export const TracePage: React.FC<Props> = () => {
 	} = useTrace()
 
 	useEffect(() => {
-		analytics.page(`/traces/${traceId}`)
+		analytics.page()
 	}, [traceId])
 
 	if (!traces?.length) {

--- a/frontend/src/pages/Traces/TracePage.tsx
+++ b/frontend/src/pages/Traces/TracePage.tsx
@@ -7,7 +7,7 @@ import {
 	Tabs,
 } from '@highlight-run/ui/components'
 import moment from 'moment'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import LoadingBox from '@/components/LoadingBox'
 import { TraceErrors } from '@/pages/Traces/TraceErrors'
@@ -15,6 +15,7 @@ import { TraceFlameGraph } from '@/pages/Traces/TraceFlameGraph'
 import { TraceLogs } from '@/pages/Traces/TraceLogs'
 import { useTrace } from '@/pages/Traces/TraceProvider'
 import { TraceSpanAttributes } from '@/pages/Traces/TraceSpanAttributes'
+import analytics from '@/util/analytics'
 
 import * as styles from './TracePage.css'
 
@@ -36,7 +37,12 @@ export const TracePage: React.FC<Props> = () => {
 		startTime,
 		traces,
 		traceName,
+		traceId,
 	} = useTrace()
+
+	useEffect(() => {
+		analytics.page(`/traces/${traceId}`)
+	}, [traceId])
 
 	if (!traces?.length) {
 		return loading ? (

--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -7,7 +7,7 @@ import {
 import { useParams } from '@util/react-router/useParams'
 import _ from 'lodash'
 import moment from 'moment'
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { Helmet } from 'react-helmet'
 import { Outlet } from 'react-router-dom'
 import { useQueryParam } from 'use-query-params'
@@ -42,6 +42,7 @@ import LogsHistogram from '@/pages/LogsPage/LogsHistogram/LogsHistogram'
 import { LatencyChart } from '@/pages/Traces/LatencyChart'
 import { TracesList } from '@/pages/Traces/TracesList'
 import { useGetTraces } from '@/pages/Traces/useGetTraces'
+import analytics from '@/util/analytics'
 import { formatNumber } from '@/util/numbers'
 
 import * as styles from './TracesPage.css'
@@ -167,6 +168,8 @@ export const TracesPage: React.FC = () => {
 
 		return traceEdges.map((edge) => edge.node)
 	}, [traceEdges])
+
+	useEffect(() => analytics.page(), [])
 
 	return (
 		<>

--- a/packages/ui/src/components/icons/IconSolidTraces.tsx
+++ b/packages/ui/src/components/icons/IconSolidTraces.tsx
@@ -5,10 +5,11 @@ export const IconSolidTraces = ({ size = '1em', ...props }: IconProps) => {
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
-			width="16"
-			height="16"
+			width={size}
+			height={size}
 			viewBox="0 0 16 16"
 			fill="none"
+			{...props}
 		>
 			<path
 				d="M1.60156 4.00039C1.60156 3.11674 2.31791 2.40039 3.20156 2.40039H12.8016C13.6852 2.40039 14.4016 3.11674 14.4016 4.00039C14.4016 4.88405 13.6852 5.60039 12.8016 5.60039H3.20156C2.31791 5.60039 1.60156 4.88405 1.60156 4.00039Z"


### PR DESCRIPTION
## Summary

Adds view tracking in the following areas:

* Traces page
* Individual traces
* Network request panel tabs

Also fixes an error I saw in the new traces icon.

## How did you test this change?

Local click test + observing network request data.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A