### PR TITLE
fixup! fix reporting of billing limits on frontend

### DIFF
--- a/frontend/src/pages/Billing/utils/utils.ts
+++ b/frontend/src/pages/Billing/utils/utils.ts
@@ -71,32 +71,32 @@ export const getMeterAmounts = (
 ): { [K in ProductType]: [number, number | undefined] } => {
 	const sessionsMeter = data.billingDetailsForProject?.meter ?? 0
 	const sessionsQuota =
-		data.billingDetailsForProject?.plan.sessionsLimit === undefined &&
+		data.billingDetailsForProject?.plan.sessionsLimit === undefined ||
 		data.billingDetailsForProject?.sessionsBillingLimit === undefined
 			? undefined
-			: (data.billingDetailsForProject?.plan.sessionsLimit ?? 0) +
-			  (data.billingDetailsForProject?.sessionsBillingLimit ?? 0)
+			: data.billingDetailsForProject.plan.sessionsLimit +
+			  (data.billingDetailsForProject.sessionsBillingLimit ?? 0)
 	const errorsMeter = data.billingDetailsForProject?.errorsMeter ?? 0
 	const errorsQuota =
-		data.billingDetailsForProject?.plan.errorsLimit === undefined &&
+		data.billingDetailsForProject?.plan.errorsLimit === undefined ||
 		data.billingDetailsForProject?.errorsBillingLimit === undefined
 			? undefined
-			: (data.billingDetailsForProject?.plan.errorsLimit ?? 0) +
-			  (data.billingDetailsForProject?.errorsBillingLimit ?? 0)
+			: data.billingDetailsForProject.plan.errorsLimit +
+			  (data.billingDetailsForProject.errorsBillingLimit ?? 0)
 	const logsMeter = data.billingDetailsForProject?.logsMeter ?? 0
 	const logsQuota =
-		data.billingDetailsForProject?.plan.logsLimit === undefined &&
+		data.billingDetailsForProject?.plan.logsLimit === undefined ||
 		data.billingDetailsForProject?.logsBillingLimit === undefined
 			? undefined
-			: (data.billingDetailsForProject?.plan.logsLimit ?? 0) +
-			  (data.billingDetailsForProject?.logsBillingLimit ?? 0)
+			: data.billingDetailsForProject.plan.logsLimit +
+			  (data.billingDetailsForProject.logsBillingLimit ?? 0)
 	const tracesMeter = data.billingDetailsForProject?.tracesMeter ?? 0
 	const tracesQuota =
-		data.billingDetailsForProject?.plan.tracesLimit === undefined &&
+		data.billingDetailsForProject?.plan.tracesLimit === undefined ||
 		data.billingDetailsForProject?.tracesBillingLimit === undefined
 			? undefined
-			: (data.billingDetailsForProject?.plan.tracesLimit ?? 0) +
-			  (data.billingDetailsForProject?.tracesBillingLimit ?? 0)
+			: data.billingDetailsForProject.plan.tracesLimit +
+			  (data.billingDetailsForProject.tracesBillingLimit ?? 0)
 	return {
 		[ProductType.Sessions]: [sessionsMeter, sessionsQuota],
 		[ProductType.Errors]: [errorsMeter, errorsQuota],

--- a/frontend/src/pages/Billing/utils/utils.ts
+++ b/frontend/src/pages/Billing/utils/utils.ts
@@ -70,33 +70,25 @@ export const getMeterAmounts = (
 	data: GetBillingDetailsForProjectQuery,
 ): { [K in ProductType]: [number, number | undefined] } => {
 	const sessionsMeter = data.billingDetailsForProject?.meter ?? 0
-	const sessionsQuota =
-		data.billingDetailsForProject?.plan.sessionsLimit === undefined ||
-		data.billingDetailsForProject?.sessionsBillingLimit === undefined
-			? undefined
-			: data.billingDetailsForProject.plan.sessionsLimit +
-			  (data.billingDetailsForProject.sessionsBillingLimit ?? 0)
+	const sessionsQuota = data.billingDetailsForProject?.sessionsBillingLimit
+		? data.billingDetailsForProject.plan.sessionsLimit +
+		  (data.billingDetailsForProject.sessionsBillingLimit ?? 0)
+		: undefined
 	const errorsMeter = data.billingDetailsForProject?.errorsMeter ?? 0
-	const errorsQuota =
-		data.billingDetailsForProject?.plan.errorsLimit === undefined ||
-		data.billingDetailsForProject?.errorsBillingLimit === undefined
-			? undefined
-			: data.billingDetailsForProject.plan.errorsLimit +
-			  (data.billingDetailsForProject.errorsBillingLimit ?? 0)
+	const errorsQuota = data.billingDetailsForProject?.errorsBillingLimit
+		? data.billingDetailsForProject.plan.errorsLimit +
+		  (data.billingDetailsForProject.errorsBillingLimit ?? 0)
+		: undefined
 	const logsMeter = data.billingDetailsForProject?.logsMeter ?? 0
-	const logsQuota =
-		data.billingDetailsForProject?.plan.logsLimit === undefined ||
-		data.billingDetailsForProject?.logsBillingLimit === undefined
-			? undefined
-			: data.billingDetailsForProject.plan.logsLimit +
-			  (data.billingDetailsForProject.logsBillingLimit ?? 0)
+	const logsQuota = data.billingDetailsForProject?.logsBillingLimit
+		? data.billingDetailsForProject.plan.logsLimit +
+		  (data.billingDetailsForProject.logsBillingLimit ?? 0)
+		: undefined
 	const tracesMeter = data.billingDetailsForProject?.tracesMeter ?? 0
-	const tracesQuota =
-		data.billingDetailsForProject?.plan.tracesLimit === undefined ||
-		data.billingDetailsForProject?.tracesBillingLimit === undefined
-			? undefined
-			: data.billingDetailsForProject.plan.tracesLimit +
-			  (data.billingDetailsForProject.tracesBillingLimit ?? 0)
+	const tracesQuota = data.billingDetailsForProject?.tracesBillingLimit
+		? data.billingDetailsForProject.plan.tracesLimit +
+		  (data.billingDetailsForProject.tracesBillingLimit ?? 0)
+		: undefined
 	return {
 		[ProductType.Sessions]: [sessionsMeter, sessionsQuota],
 		[ProductType.Errors]: [errorsMeter, errorsQuota],


### PR DESCRIPTION
## Summary

Ensures that backend changes to how billing limits are reported (breaking up the
plan included quota and the allowed overage quota) are correctly used on the frontend
to determine when a billing quota is exceeded.

Corrects issue in #7474 that would show plans with an allowed base quota as having the limit exceeded.

## How did you test this change?

[Reflame preview for customer](https://preview.highlight.io/14909/errors?page=1&query=and%7C%7Cerror_state%2Cis%2COPEN%7C%7Cerror-field_timestamp%2Cbetween_date%2C2023-12-17T19%3A21%3A30.547Z_2024-01-16T19%3A21%3A30.547Z&%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HM9VC4WB5VKB8K36VPH4G4KF%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Ffixup-7474%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D) and [preview for our workspace](https://preview.highlight.io/1/errors?page=1&query=and%7C%7Cerror_state%2Cis%2COPEN%7C%7Cerror-field_timestamp%2Cbetween_date%2C2023-12-17T19%3A21%3A46.785Z_2024-01-16T19%3A21%3A46.785Z&%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HM9VC4WB5VKB8K36VPH4G4KF%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Ffixup-7474%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D) correctly show no billing quota exceeded

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No