### PR TITLE
fix potential bugs in otel.go, better logging in resolver.go

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -324,7 +324,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 				keyedErrorMessages[sessionID] = append(keyedErrorMessages[sessionID], &kafkaqueue.Message{
 					Type: kafkaqueue.PushBackendPayload,
 					PushBackendPayload: &kafkaqueue.PushBackendPayloadArgs{
-						ProjectVerboseID: &projectID,
+						ProjectVerboseID: pointy.String(projectID),
 						Errors:           []*model.BackendErrorObjectInput{errorObject},
 					}})
 			}
@@ -339,9 +339,9 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	var messages []*kafkaqueue.Message
 	for projectID, traceMetrics := range projectTraceMetrics {
 		for sessionID, metrics := range traceMetrics {
+			var messages []*kafkaqueue.Message
 			for _, metric := range metrics {
 				messages = append(messages, &kafkaqueue.Message{
 					Type: kafkaqueue.PushMetrics,

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2109,11 +2109,16 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 		}
 	}
 
+	verboseIdDeref := ""
+	if projectVerboseID != nil {
+		verboseIdDeref = *projectVerboseID
+	}
+
 	if projectID == 0 {
 		log.WithContext(ctx).
-			WithError(e.New("No project id found for error")).
 			WithField("sessionSecureID", sessionSecureID).
-			WithField("projectVerboseID", projectVerboseID)
+			WithField("projectVerboseID", verboseIdDeref).
+			Error("No project id found for error")
 		return
 	}
 
@@ -2121,7 +2126,11 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 
 	var project model.Project
 	if err := r.DB.WithContext(ctx).Model(&model.Project{}).Where("id = ?", projectID).Take(&project).Error; err != nil {
-		log.WithContext(ctx).WithError(err).WithField("project", project).WithField("projectVerboseID", projectVerboseID).Error("failed to find project")
+		log.WithContext(ctx).WithError(err).
+			WithField("projectId", projectID).
+			WithField("project", project).
+			WithField("projectVerboseID", verboseIdDeref).
+			Error("failed to find project")
 		return
 	}
 


### PR DESCRIPTION
## Summary
- pointer reference in loop points to last project id
- declare `messages` in loop to prevent duplicate metrics
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor logs in prod after deploying
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
