### PR TITLE
truncate large chunks

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -27,6 +27,7 @@ import {
 	PlayerReducer,
 	SessionViewability,
 	THROTTLED_UPDATE_MS,
+	truncate,
 } from '@pages/Player/PlayerHook/PlayerState'
 import { useTimelineIndicators } from '@pages/Player/TimelineIndicatorsContext/TimelineIndicatorsContext'
 import analytics from '@util/analytics'
@@ -281,15 +282,17 @@ export const usePlayer = (): ReplayerContextInterface => {
 
 	const getLastLoadedEventTimestamp = useCallback(() => {
 		const lastLoadedChunk = Math.max(
-			...[...chunkEventsRef.current.entries()]
+			...[...truncate(chunkEventsRef.current.entries())]
 				.filter(([, v]) => !!v.length)
 				.map(([k]) => k),
 		)
 		return (
 			Math.max(
-				...(chunkEventsRef.current
-					.get(lastLoadedChunk)
-					?.map((e) => e.timestamp) || []),
+				...truncate(
+					chunkEventsRef.current
+						.get(lastLoadedChunk)
+						?.map((e) => e.timestamp) || [],
+				),
 			) - state.sessionMetadata.startTime
 		)
 	}, [chunkEventsRef, state.sessionMetadata.startTime])

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -755,7 +755,7 @@ export const usePlayer = (): ReplayerContextInterface => {
 						const newEvents = sd!.session_payload_appended.events!
 						if (newEvents.length) {
 							const events = [
-								...(chunkEventsRef.current.get(0) || []),
+								...getEvents(chunkEventsRef.current),
 								...toHighlightEvents(newEvents),
 							]
 							chunkEventsSet(0, events)

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -912,7 +912,8 @@ export const getTimeFromReplayer = function (
 	)
 }
 
-const MAX_SHORT_INT_SIZE = 65536
+// 65536
+const MAX_SHORT_INT_SIZE = 1_000
 
 // events are passed into an functions which does an array.splice or Math.max
 // When the number of events is greater than MAX_SHORT_INT_SIZE, the browser can crash.

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -316,7 +316,6 @@ export const PlayerReducer = (
 	action: PlayerAction,
 ): PlayerState => {
 	const events = getEvents(state.chunkEventsRef.current)
-	console.log('vadim', 'num events', { len: events.length })
 	let s = { ...state }
 	switch (action.type) {
 		case PlayerActionType.play:

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -316,6 +316,7 @@ export const PlayerReducer = (
 	action: PlayerAction,
 ): PlayerState => {
 	const events = getEvents(state.chunkEventsRef.current)
+	console.log('vadim', 'num events', { len: events.length })
 	let s = { ...state }
 	switch (action.type) {
 		case PlayerActionType.play:
@@ -912,7 +913,7 @@ export const getTimeFromReplayer = function (
 	)
 }
 
-const MAX_SHORT_INT_SIZE = 65536 / 2
+const MAX_SHORT_INT_SIZE = 10_000
 
 // events are passed into an functions which does an array.splice or Math.max
 // When the number of events is greater than MAX_SHORT_INT_SIZE, the browser can crash.

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -912,7 +912,7 @@ export const getTimeFromReplayer = function (
 	)
 }
 
-const MAX_SHORT_INT_SIZE = 65536
+const MAX_SHORT_INT_SIZE = 65536 / 2
 
 // events are passed into an functions which does an array.splice or Math.max
 // When the number of events is greater than MAX_SHORT_INT_SIZE, the browser can crash.

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -912,13 +912,12 @@ export const getTimeFromReplayer = function (
 	)
 }
 
-// 65536
-const MAX_SHORT_INT_SIZE = 1_000
+const MAX_SHORT_INT_SIZE = 65536
 
 // events are passed into an functions which does an array.splice or Math.max
 // When the number of events is greater than MAX_SHORT_INT_SIZE, the browser can crash.
 // Hence, we instead take a sample of events to ensure we stay under MAX_SHORT_INT_SIZE.
-export const truncate = function* <T>(data: IterableIterator<T>) {
+export const truncate = function* <T>(data: IterableIterator<T> | T[]) {
 	let idx = 0
 	for (const obj of data) {
 		if (idx++ >= MAX_SHORT_INT_SIZE) {

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -913,7 +913,7 @@ export const getTimeFromReplayer = function (
 	)
 }
 
-const MAX_SHORT_INT_SIZE = 10_000
+const MAX_SHORT_INT_SIZE = 65536
 
 // events are passed into an functions which does an array.splice or Math.max
 // When the number of events is greater than MAX_SHORT_INT_SIZE, the browser can crash.
@@ -934,12 +934,16 @@ export const getEvents = (
 		'clear' | 'set' | 'delete'
 	>,
 ) => {
+	let numEvents = 0
 	const events = []
-	for (const [, v] of [...truncate(chunkEvents.entries())].sort(
+	for (const [, v] of [...chunkEvents.entries()].sort(
 		(a, b) => a[0] - b[0],
 	)) {
 		for (const val of v) {
 			if (val) {
+				if (numEvents++ >= MAX_SHORT_INT_SIZE) {
+					return events
+				}
 				events.push(val)
 			}
 		}


### PR DESCRIPTION
## Summary

Having too many events in one chunk (typically in live mode where the number
of events in the main chunk can be unbounded) can crash JS array operations.
Try to salvage the session by truncating the chunk correctly to a size that works.

## How did you test this change?

https://www.loom.com/share/8446c85775a84784bea65442b3d27003

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
