### PR TITLE
Don't set auth redirect if on homepage

### DIFF
--- a/frontend/src/pages/Auth/SignInRedirect.tsx
+++ b/frontend/src/pages/Auth/SignInRedirect.tsx
@@ -8,8 +8,8 @@ export const SignInRedirect: React.FC = () => {
 		// Store the original path so we can redirect back to it later.
 		const dest = window.location.href.replace(window.location.origin, '')
 
-		// Perform the comparison on pathname rather than dest because dest because
-		// we want to include search params in the redirect.
+		// Perform the comparison on pathname rather than dest because we want to
+		// include the search string in the redirect.
 		if (window.location.pathname !== '/') {
 			authRedirect.set(dest)
 		}

--- a/frontend/src/pages/Auth/SignInRedirect.tsx
+++ b/frontend/src/pages/Auth/SignInRedirect.tsx
@@ -7,7 +7,10 @@ export const SignInRedirect: React.FC = () => {
 	if (!authRedirect.get()) {
 		// Store the original path so we can redirect back to it later.
 		const dest = window.location.href.replace(window.location.origin, '')
-		if (dest !== '/') {
+
+		// Perform the comparison on pathname rather than dest because dest because
+		// we want to include search params in the redirect.
+		if (window.location.pathname !== '/') {
 			authRedirect.set(dest)
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes a bug where users could get stuck in the loading state of the app permanently. The problem was that we were storing the initial URL the user was supposed to be redirected to which included a search string in the URL. We would try to redirect back to this from the `ProjectRedirectionRouter` which would give precedence to any URL stored in the auth redirect cookie vs falling back to the default project.

This PR ensures we don't store a redirect URL for the root path (`/`) even if there is a search string after it.

## How did you test this change?

In the PR preview, I dropped a debugger in `SignInRedirect` to see if `authRedirect.set` was called. I confirmed that the new logic was avoiding storing the redirect URL and that I was able to get into the app after coming to it from the homepage.
 
## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A