### PR TITLE
allow reporting span_name on H.trace

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -172,9 +172,10 @@ func New(ctx context.Context, topic string, mode Mode, configOverride *ConfigOve
 			Balancer:     &kafka.Hash{},
 			RequiredAcks: kafka.RequireOne,
 			Compression:  kafka.Zstd,
-			Async:        true,
+			// synchronous mode so that we can ensure messages are sent before we return
+			Async:        false,
+			BatchSize:    1,
 			BatchBytes:   MaxMessageSizeBytes,
-			BatchSize:    1_000,
 			BatchTimeout: time.Second,
 			ReadTimeout:  KafkaOperationTimeout,
 			WriteTimeout: KafkaOperationTimeout,

--- a/docs-content/sdk/python.md
+++ b/docs-content/sdk/python.md
@@ -160,7 +160,7 @@ the error will be associated with the project ID passed to H().</p>
   </div>
   <div className="right">
     <code>
-        with H.trace():
+        with H.trace(span_name="my_span"):
             for idx in range(1000):
                 logging.info(f"hello {idx}")
                 time.sleep(0.001)

--- a/highlight.io/components/QuickstartContent/backend/python/other.tsx
+++ b/highlight.io/components/QuickstartContent/backend/python/other.tsx
@@ -45,7 +45,7 @@ ${init}
 
 
 def main():
-    with H.trace():
+    with H.trace(span_name="my_span"):
         logging.info('hello, world!', {'favorite_number': 7})
         return f"<h1>bad idea { 5/0 }</h1>"
 

--- a/highlight.io/components/QuickstartContent/traces/python/manual.tsx
+++ b/highlight.io/components/QuickstartContent/traces/python/manual.tsx
@@ -35,7 +35,7 @@ ${init}`,
 					text: `import logging
 
 def main():
-    with H.trace():
+    with H.trace(span_name="my_span"):
         logging.info('hello, world!', {'favorite_number': 7})
         return f"<h1>Hello world</h1>"
 

--- a/sdk/highlight-py/highlight_io/sdk.py
+++ b/sdk/highlight-py/highlight_io/sdk.py
@@ -201,6 +201,7 @@ class H(object):
         self,
         session_id: typing.Optional[str] = "",
         request_id: typing.Optional[str] = "",
+        span_name: typing.Optional[str] = "highlight-ctx",
         attributes: typing.Optional[typing.Dict[str, any]] = None,
     ) -> Span:
         """
@@ -220,6 +221,7 @@ class H(object):
         :param session_id: the highlight session that initiated this network request.
         :param request_id: the identifier of the current network request.
         :param attributes: additional attributes to attribute to this error.
+        :param span_name: span name to record.
         :return: Span
         """
         # in case the otel library is in a non-recording context, do nothing
@@ -228,7 +230,7 @@ class H(object):
             return
 
         with self.tracer.start_as_current_span(
-            "highlight-ctx", record_exception=False, set_status_on_exception=False
+            span_name, record_exception=False, set_status_on_exception=False
         ) as span:
             span.set_attributes({"highlight.project_id": self._project_id})
             span.set_attributes({"highlight.session_id": session_id})

--- a/sdk/highlight-py/pyproject.toml
+++ b/sdk/highlight-py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "highlight-io"
-version = "0.6.13"
+version = "0.6.14"
 description = "Session replay and error monitoring: stop guessing why bugs happen!"
 license = "Apache-2.0"
 authors = [


### PR DESCRIPTION
## Summary

Allow reporting a `span_name` attribute in the python SDK
to label traces when manually reported.

## How did you test this change?

Local deploy, CI

## Are there any deployment considerations?

New python SDK version

## Does this work require review from our design team?

No
