### PR TITLE
ensure sourcemap uploading does not break next build

### DIFF
--- a/.changeset/swift-rules-draw.md
+++ b/.changeset/swift-rules-draw.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/next': patch
+---
+
+ensure sourcemap uploading does not break next build

--- a/sdk/highlight-next/src/util/highlight-webpack-plugin.ts
+++ b/sdk/highlight-next/src/util/highlight-webpack-plugin.ts
@@ -19,14 +19,18 @@ export default class HighlightWebpackPlugin {
 	}
 
 	apply(compiler: any) {
-		compiler.hooks.afterEmit.tap('HighlightWebpackPlugin', () => {
-			uploadSourcemaps({
-				apiKey: this.apiKey,
-				appVersion: this.appVersion,
-				path: this.path,
-				basePath: this.basePath,
-				allowNoop: true,
-			})
+		compiler.hooks.afterEmit.tap('HighlightWebpackPlugin', async () => {
+			try {
+				await uploadSourcemaps({
+					apiKey: this.apiKey,
+					appVersion: this.appVersion,
+					path: this.path,
+					basePath: this.basePath,
+					allowNoop: true,
+				})
+			} catch (e) {
+				console.error(`Highlight Failed to upload sourcemaps: ${e}`)
+			}
 		})
 		return compiler
 	}


### PR DESCRIPTION
## Summary

Prevent network errors or other problems during sourcemap uploading from failing a next.js build.

Closes #7334

## How did you test this change?

E2E test

## Are there any deployment considerations?

Changeset

## Does this work require review from our design team?

No
