### PR TITLE
Fix fetching more errors and sessions

### DIFF
--- a/frontend/src/context/BaseSearchContext.tsx
+++ b/frontend/src/context/BaseSearchContext.tsx
@@ -44,4 +44,5 @@ export type BaseSearchContext = {
 		endDate?: Date,
 		preset?: DateRangePreset,
 	) => void
+	rebaseTime: () => void
 }

--- a/frontend/src/context/SearchState.ts
+++ b/frontend/src/context/SearchState.ts
@@ -261,6 +261,7 @@ export const useGetBaseSearchContext = (
 		updateSearchTime,
 		selectedPreset,
 		resetSearchTime,
+		rebaseSearchTime,
 	} = useSearchTime({
 		initialPreset: defaultPreset,
 		presets: DEFAULT_TIME_PRESETS,
@@ -386,6 +387,34 @@ export const useGetBaseSearchContext = (
 		[admin, customFields, state.searchQuery, updateSearchTime],
 	)
 
+	const rebaseTime = useCallback(() => {
+		if (selectedPreset) {
+			rebaseSearchTime()
+
+			const end = moment().toDate()
+			const start = presetStartDate(selectedPreset)
+
+			const queryWithTimes = overwriteQueryDates(
+				state.searchQuery,
+				start,
+				end,
+			)
+
+			dispatch({
+				type: SearchActionType.setSearchQuery,
+				searchQuery: queryWithTimes,
+				admin,
+				customFields,
+			})
+		}
+	}, [
+		admin,
+		customFields,
+		rebaseSearchTime,
+		selectedPreset,
+		state.searchQuery,
+	])
+
 	const resetTime = useCallback(() => {
 		resetSearchTime()
 		const end = moment().toDate()
@@ -441,6 +470,7 @@ export const useGetBaseSearchContext = (
 		setSearchTime,
 		resetTime,
 		createNewSearch,
+		rebaseTime,
 	}
 }
 

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -48,6 +48,7 @@ const SearchPanel = () => {
 		searchResultsCount,
 		setSearchResultsCount,
 		setSearchResultSecureIds,
+		rebaseTime,
 	} = useErrorSearchContext()
 	const { project_id: projectId } = useParams<{ project_id: string }>()
 
@@ -149,7 +150,10 @@ const SearchPanel = () => {
 			<AdditionalFeedResults
 				more={moreErrors}
 				type="errors"
-				onClick={resetMoreErrors}
+				onClick={() => {
+					resetMoreErrors()
+					rebaseTime()
+				}}
 			/>
 			<Box
 				paddingTop="4"

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -157,6 +157,7 @@ export const SessionFeedV3 = React.memo(() => {
 		setSearchResultsLoading,
 		searchResultsCount,
 		setSearchResultsCount,
+		rebaseTime,
 	} = useSearchContext()
 	const { integrated } = useIntegrated()
 	const { showLeftPanel } = usePlayerConfiguration()
@@ -324,7 +325,10 @@ export const SessionFeedV3 = React.memo(() => {
 				<AdditionalFeedResults
 					more={moreSessions}
 					type="sessions"
-					onClick={resetMoreSessions}
+					onClick={() => {
+						resetMoreSessions()
+						rebaseTime()
+					}}
 				/>
 				<Box
 					paddingTop="4"


### PR DESCRIPTION
## Summary
The relative time changes broke the fetching more errors and sessions. Rebase the time to refetch

## How did you test this change?
1) Load the errors or sessions  page
2) Change the preset to the none default time
3) Create a new error or session
4) Click to load the new error(s) or session(s) button
- [ ] The new resources are loaded
- [ ] The correct time is fetched
- [ ] No changes to the time range or url

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
