### PR TITLE
Support numeric operators on custom attributes

### DIFF
--- a/backend/parser/listener/listener.go
+++ b/backend/parser/listener/listener.go
@@ -207,25 +207,25 @@ func (s *searchListener[T]) appendRules(value string) {
 		}
 	} else if s.currentOp == ">" {
 		if traceAttributeKey {
-			s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf(s.attributesColumn+"[%s] > %s", s.currentKey, value)))
+			s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf("toFloat64OrNull("+s.attributesColumn+"[%s]) > %s", s.currentKey, value)))
 		} else {
 			s.rules = append(s.rules, s.sb.GreaterThan(filterKey, value))
 		}
 	} else if s.currentOp == ">=" {
 		if traceAttributeKey {
-			s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf(s.attributesColumn+"[%s] >= %s", s.currentKey, value)))
+			s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf("toFloat64OrNull("+s.attributesColumn+"[%s]) >= %s", s.currentKey, value)))
 		} else {
 			s.rules = append(s.rules, s.sb.GreaterEqualThan(filterKey, value))
 		}
 	} else if s.currentOp == "<" {
 		if traceAttributeKey {
-			s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf(s.attributesColumn+"[%s] < %s", s.currentKey, value)))
+			s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf("toFloat64OrNull("+s.attributesColumn+"[%s]) < %s", s.currentKey, value)))
 		} else {
 			s.rules = append(s.rules, s.sb.LessThan(filterKey, value))
 		}
 	} else if s.currentOp == "<=" {
 		if traceAttributeKey {
-			s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf(s.attributesColumn+"[%s] <= %s", s.currentKey, value)))
+			s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf("toFloat64OrNull("+s.attributesColumn+"[%s]) <= %s", s.currentKey, value)))
 		} else {
 			s.rules = append(s.rules, s.sb.LessEqualThan(filterKey, value))
 		}


### PR DESCRIPTION
## Summary

All custom attributes sent on traces are stored as strings and we're unable to use the numeric operators (`>`, `<=`, etc.) to query on them correctly. This PR uses `toFloat64OrNull` to coerce the value to an integer for the comparison on custom attributes, which makes the numeric operators behave as expected.

## How did you test this change?

Local click test searching on numeric attributes (e.g. `process.pid`) and string attributes (e.g. `process.owner`).

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A