### PR TITLE
Show shorter sessions

### DIFF
--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -256,10 +256,7 @@ func GetSessionsQueryImpl(admin *model.Admin, query modelInputs.ClickhouseQuery,
 		From("sessions FINAL").
 		Where(sb.And(sb.Equal("ProjectID", projectId),
 			"NOT Excluded",
-			"WithinBillingQuota",
-			sb.Or("NOT Processed",
-				sb.GreaterEqualThan("ActiveLength", 1000),
-				sb.And(sb.IsNull("ActiveLength"), sb.GreaterEqualThan("Length", 1000)))),
+			"WithinBillingQuota"),
 			sb.GreaterThan("CreatedAt", retentionDate),
 		)
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5688,8 +5688,7 @@ from sessions final
 WHERE sessions.ProjectID = %d
   AND NOT Excluded
   AND WithinBillingQuota
-  AND (NOT Processed OR ActiveLength >= 1000 OR (ActiveLength IS NULL AND Length >= 1000))
-  and ID in (%s)
+  AND ID in (%s)
 group by 1 order by num_sessions desc;
 `, project.ID, project.ID, project.ID, sql)
 	rows, err := r.ClickhouseClient.GetConn().Query(ctx, q, args...)


### PR DESCRIPTION
## Summary
Sessions that are less than a second but not excluded are not showing up on session search, but can be navigated to via the url.

## How did you test this change?
N/A

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A