### PR TITLE
append default filter to input query, add where clause back to metrics

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -598,6 +598,8 @@ func readMetrics[T ~string](ctx context.Context, client *Client, sampleableConfi
 			Where(innerSb.GreaterEqualThan("Timestamp", startTimestamp)).
 			Where(innerSb.LessEqualThan("Timestamp", endTimestamp))
 
+		parser.AssignSearchFilters[T](innerSb, params.Query, config)
+
 		limitFn := ""
 		col := ""
 		if limitColumn != nil {

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -77,9 +77,7 @@ var TracesTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
 	BodyColumn:       "SpanName",
 	AttributesColumn: "TraceAttributes",
 	SelectColumns:    traceColumns,
-	DefaultFilters: map[string]string{
-		highlight.TraceTypeAttribute: fmt.Sprintf("!%s", highlight.TraceTypeHighlightInternal),
-	},
+	DefaultFilter:    fmt.Sprintf("%s!=%s", highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 }
 
 var tracesSamplingTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
@@ -89,6 +87,7 @@ var tracesSamplingTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
 	ReservedKeys:     modelInputs.AllReservedTraceKey,
 	AttributesColumn: "TraceAttributes",
 	SelectColumns:    traceColumns,
+	DefaultFilter:    fmt.Sprintf("%s!=%s", highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 }
 
 var tracesSampleableTableConfig = sampleableTableConfig[modelInputs.ReservedTraceKey]{

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -2454,5 +2454,5 @@ type TableConfig[TReservedKey ~string] struct {
 	KeysToColumns    map[TReservedKey]string
 	ReservedKeys     []TReservedKey
 	SelectColumns    []string
-	DefaultFilters   map[string]string
+	DefaultFilter    string
 }

--- a/backend/parser/parser.go
+++ b/backend/parser/parser.go
@@ -9,7 +9,7 @@ import (
 )
 
 func AssignSearchFilters[T ~string](sqlBuilder *sqlbuilder.SelectBuilder, query string, tableConfig model.TableConfig[T]) {
-	is := antlr.NewInputStream(query)
+	is := antlr.NewInputStream(query + " " + tableConfig.DefaultFilter)
 	lexer := parser.NewSearchGrammarLexer(is)
 	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
 	p := parser.NewSearchGrammarParser(stream)


### PR DESCRIPTION
## Summary
- change `DefaultFilter` to be a string appended to the input query
- add filter to sampling table too
- add filtering back to metrics `limit by` clause
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested traces search to check that `IsIngestedBy` results were excluded and there was no conflict with another `highlight.type` query
- clicktested in grafana plugin
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
