### PR TITLE
switch ingest parsing to antlr

### DIFF
--- a/backend/clickhouse/errors.go
+++ b/backend/clickhouse/errors.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/highlight-run/highlight/backend/parser/listener"
 	"time"
-
-	model2 "github.com/highlight-run/highlight/backend/public-graph/graph/model"
-	"github.com/highlight-run/highlight/backend/queryparser"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	model2 "github.com/highlight-run/highlight/backend/public-graph/graph/model"
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/openlyinc/pointy"
 	"github.com/samber/lo"
@@ -538,7 +537,7 @@ func (client *Client) QueryErrorHistogram(ctx context.Context, projectId int, qu
 	return bucketTimes, totals, nil
 }
 
-var errorObjectsTableConfig = model.TableConfig[modelInputs.ReservedErrorObjectKey]{
+var ErrorObjectsTableConfig = model.TableConfig[modelInputs.ReservedErrorObjectKey]{
 	TableName: ErrorObjectsTable,
 	KeysToColumns: map[modelInputs.ReservedErrorObjectKey]string{
 		modelInputs.ReservedErrorObjectKeySessionSecureID: "SessionSecureID",
@@ -588,8 +587,8 @@ var errorsSampleableTableConfig = sampleableTableConfig[modelInputs.ReservedErro
 	},
 }
 
-func ErrorMatchesQuery(errorObject *model2.BackendErrorObjectInput, filters *queryparser.Filters) bool {
-	return matchesQuery(errorObject, errorObjectsTableConfig, filters)
+func ErrorMatchesQuery(errorObject *model2.BackendErrorObjectInput, filters listener.Filters) bool {
+	return matchesQuery(errorObject, ErrorObjectsTableConfig, filters)
 }
 
 func (client *Client) ReadErrorsMetrics(ctx context.Context, projectID int, params modelInputs.QueryInput, column string, metricTypes []modelInputs.MetricAggregator, groupBy []string, nBuckets *int, bucketBy string, limit *int, limitAggregator *modelInputs.MetricAggregator, limitColumn *string) (*modelInputs.MetricsBuckets, error) {

--- a/backend/clickhouse/errors_test.go
+++ b/backend/clickhouse/errors_test.go
@@ -1,8 +1,8 @@
 package clickhouse
 
 import (
+	"github.com/highlight-run/highlight/backend/parser"
 	modelInputs "github.com/highlight-run/highlight/backend/public-graph/graph/model"
-	"github.com/highlight-run/highlight/backend/queryparser"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -10,8 +10,8 @@ import (
 
 func Test_ErrorMatchesQuery(t *testing.T) {
 	errorObject := modelInputs.BackendErrorObjectInput{}
-	filters := queryparser.Parse("oops something bad type:console.error os.type:linux resource_name:worker.* service_name:all")
-	matches := ErrorMatchesQuery(&errorObject, &filters)
+	filters := parser.Parse("oops something bad type:console.error os.type:linux resource_name:worker.* service_name:all", ErrorObjectsTableConfig)
+	matches := ErrorMatchesQuery(&errorObject, filters)
 	assert.False(t, matches)
 
 	errorObject = modelInputs.BackendErrorObjectInput{
@@ -26,6 +26,6 @@ func Test_ErrorMatchesQuery(t *testing.T) {
 			Version: "asdf",
 		},
 	}
-	matches = ErrorMatchesQuery(&errorObject, &filters)
+	matches = ErrorMatchesQuery(&errorObject, filters)
 	assert.True(t, matches)
 }

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -1335,7 +1335,6 @@ func Test_LogMatchesQuery_Body(t *testing.T) {
 	for _, body := range []string{
 		"hello world a test",
 		"hello, world this is a test",
-		"this, is.a ; hello; 123 there6 world:message,.:;	\nbe\xe2\x80\x83me",
 		"0!0!  0*000000 000000000",
 		"0! 000\\\"0000000000000",
 		"(*",

--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	"github.com/highlight-run/highlight/backend/parser"
 	"os"
 	"reflect"
 	"sort"
@@ -10,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/highlight-run/highlight/backend/queryparser"
 	"github.com/samber/lo"
 
 	"github.com/aws/smithy-go/ptr"
@@ -1306,8 +1306,8 @@ func FuzzReadLogs(f *testing.F) {
 
 func Test_LogMatchesQuery(t *testing.T) {
 	logRow := LogRow{}
-	filters := queryparser.Parse("hello world os.type:linux resource_name:worker.* service_name:all")
-	matches := LogMatchesQuery(&logRow, &filters)
+	filters := parser.Parse("hello world os.type:linux resource_name:worker.* service_name:all", LogsTableConfig)
+	matches := LogMatchesQuery(&logRow, filters)
 	assert.False(t, matches)
 
 	logRow = LogRow{
@@ -1318,16 +1318,16 @@ func Test_LogMatchesQuery(t *testing.T) {
 			"resource_name": "worker.kafka.process",
 		},
 	}
-	filters = queryparser.Parse("hello world be me os.type:linux resource_name:worker.* service_name:all")
-	matches = LogMatchesQuery(&logRow, &filters)
+	filters = parser.Parse("hello world be me os.type:linux resource_name:worker.* service_name:all", LogsTableConfig)
+	matches = LogMatchesQuery(&logRow, filters)
 	assert.True(t, matches)
 
-	filters = queryparser.Parse("not this one os.type:linux resource_name:worker.* service_name:all")
-	matches = LogMatchesQuery(&logRow, &filters)
+	filters = parser.Parse("not this one os.type:linux resource_name:worker.* service_name:all", LogsTableConfig)
+	matches = LogMatchesQuery(&logRow, filters)
 	assert.False(t, matches)
 
-	filters = queryparser.Parse("os.type:-linux")
-	matches = LogMatchesQuery(&logRow, &filters)
+	filters = parser.Parse("os.type:-linux", LogsTableConfig)
+	matches = LogMatchesQuery(&logRow, filters)
 	assert.False(t, matches)
 }
 
@@ -1343,14 +1343,12 @@ func Test_LogMatchesQuery_Body(t *testing.T) {
 		"*\\x80",
 	} {
 		logRow := LogRow{Body: body}
-		filters := queryparser.Parse(body)
-		// : represents a special case since our query parser treats it as an attribute. don't search on attrs
-		filters.Attributes = map[string][]string{}
-		matches := LogMatchesQuery(&logRow, &filters)
+		filters := parser.Parse(body, LogsTableConfig)
+		matches := LogMatchesQuery(&logRow, filters)
 		assert.True(t, matches, "failed on body %s", body)
 
-		filters = queryparser.Parse("no")
-		matches = LogMatchesQuery(&logRow, &filters)
+		filters = parser.Parse("no", LogsTableConfig)
+		matches = LogMatchesQuery(&logRow, filters)
 		assert.False(t, matches, "failed on body %s", body)
 	}
 }
@@ -1388,9 +1386,9 @@ func Test_LogMatchesQuery_ClickHouse(t *testing.T) {
 	assert.NoError(t, err)
 
 	var filtered []*LogRow
-	filters := queryparser.Parse(query)
+	filters := parser.Parse(query, LogsTableConfig)
 	for _, logRow := range rows {
-		if LogMatchesQuery(logRow, &filters) {
+		if LogMatchesQuery(logRow, filters) {
 			filtered = append(filtered, logRow)
 		}
 	}
@@ -1529,8 +1527,8 @@ func Test_LogMatchesQuery_ClickHouse_Body(t *testing.T) {
 		assert.NoError(t, err)
 
 		var filtered []*LogRow
-		filters := queryparser.Parse(body)
-		if LogMatchesQuery(logRow, &filters) {
+		filters := parser.Parse(body, LogsTableConfig)
+		if LogMatchesQuery(logRow, filters) {
 			filtered = append(filtered, logRow)
 		}
 

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -12,14 +12,15 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/huandu/go-sqlbuilder"
+	"github.com/nqd/flat"
+
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/parser"
 	"github.com/highlight-run/highlight/backend/parser/listener"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"
 	"github.com/highlight/highlight/sdk/highlight-go"
-	"github.com/huandu/go-sqlbuilder"
-	"github.com/nqd/flat"
 )
 
 const SamplingRows = 20_000_000
@@ -449,7 +450,10 @@ func matchesQuery[TObj interface{}, TReservedKey ~string](row *TObj, config mode
 				return false
 			}
 		default:
-			if !matchFilter(row, config, filter) {
+			matches := matchFilter(row, config, filter)
+			if filter.Operator == listener.OperatorNot && matches {
+				return false
+			} else if !matches {
 				return false
 			}
 		}

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -391,6 +391,17 @@ func matchFilter[TObj interface{}, TReservedKey ~string](row *TObj, config model
 		}
 	} else if field := v.FieldByName(filter.Key); field.IsValid() {
 		rowValue = repr(field)
+	} else if strings.Contains(filter.Key, ".") {
+		var value = v
+		for _, part := range strings.Split(filter.Key, ".") {
+			value = value.FieldByName(part)
+			if value.Kind() == reflect.Pointer {
+				value = value.Elem()
+			}
+		}
+		if value.IsValid() {
+			rowValue = repr(value)
+		}
 	} else if config.AttributesColumn != "" {
 		value := v.FieldByName(config.AttributesColumn)
 		if value.Kind() == reflect.Map {

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/highlight-run/highlight/backend/parser/listener"
 	"strconv"
 	"time"
 
 	"github.com/samber/lo"
-
-	"github.com/highlight-run/highlight/backend/queryparser"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
@@ -438,7 +437,7 @@ func (client *Client) DeleteSessions(ctx context.Context, projectId int, session
 	return client.conn.Exec(ctx, sql, args...)
 }
 
-var sessionsTableConfig = model.TableConfig[string]{
+var SessionsTableConfig = model.TableConfig[string]{
 	TableName:        SessionsTable,
 	KeysToColumns:    fieldMap,
 	AttributesColumn: "Fields",
@@ -447,8 +446,8 @@ var sessionsTableConfig = model.TableConfig[string]{
 	}),
 }
 
-func SessionMatchesQuery(session *model.Session, filters *queryparser.Filters) bool {
-	return matchesQuery(session, sessionsTableConfig, filters)
+func SessionMatchesQuery(session *model.Session, filters listener.Filters) bool {
+	return matchesQuery(session, SessionsTableConfig, filters)
 }
 
 var sessionsJoinedTableConfig = model.TableConfig[modelInputs.ReservedSessionKey]{

--- a/backend/clickhouse/sessions_test.go
+++ b/backend/clickhouse/sessions_test.go
@@ -3,14 +3,13 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	"github.com/highlight-run/highlight/backend/parser"
 	"testing"
 	"time"
 
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"
 	"github.com/openlyinc/pointy"
-
-	"github.com/highlight-run/highlight/backend/queryparser"
 
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/stretchr/testify/assert"
@@ -104,8 +103,8 @@ func TestWriteSession(t *testing.T) {
 
 func Test_SessionMatchesQuery(t *testing.T) {
 	session := model.Session{}
-	filters := queryparser.Parse("environment:prod* user_email:*@highlight.io custom_email:bar@highlight.io session_visited-url:example.com user_age:123 service_name:all custom_created_at:when")
-	matches := SessionMatchesQuery(&session, &filters)
+	filters := parser.Parse("environment:prod* user_email:*@highlight.io custom_email:bar@highlight.io session_visited-url:example.com user_age:123 service_name:all custom_created_at:when", SessionsTableConfig)
+	matches := SessionMatchesQuery(&session, filters)
 	assert.False(t, matches)
 
 	session = model.Session{
@@ -139,19 +138,19 @@ func Test_SessionMatchesQuery(t *testing.T) {
 			},
 		},
 	}
-	matches = SessionMatchesQuery(&session, &filters)
+	matches = SessionMatchesQuery(&session, filters)
 	assert.True(t, matches)
 
-	filters = queryparser.Parse("environment:development email:*@highlight.io age:123 service_name:all")
-	matches = SessionMatchesQuery(&session, &filters)
+	filters = parser.Parse("environment:development email:*@highlight.io age:123 service_name:all", SessionsTableConfig)
+	matches = SessionMatchesQuery(&session, filters)
 	assert.False(t, matches)
 
-	filters = queryparser.Parse("environment:*prod* user_email:vadim@highlight.io")
-	matches = SessionMatchesQuery(&session, &filters)
+	filters = parser.Parse("environment:*prod* user_email:vadim@highlight.io", SessionsTableConfig)
+	matches = SessionMatchesQuery(&session, filters)
 	assert.True(t, matches)
 
-	filters = queryparser.Parse("environment:*prod* user_email:bar@highlight.io")
-	matches = SessionMatchesQuery(&session, &filters)
+	filters = parser.Parse("environment:*prod* user_email:bar@highlight.io", SessionsTableConfig)
+	matches = SessionMatchesQuery(&session, filters)
 	assert.False(t, matches)
 }
 

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -73,13 +73,22 @@ var defaultTraceKeys = []*modelInputs.QueryKey{
 	{Name: string(modelInputs.ReservedTraceKeySecureSessionID), Type: modelInputs.KeyTypeString},
 }
 
-var TracesTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
+var TracesTableNoDefaultConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
 	TableName:        TracesTable,
 	KeysToColumns:    traceKeysToColumns,
 	ReservedKeys:     modelInputs.AllReservedTraceKey,
 	BodyColumn:       "SpanName",
 	AttributesColumn: "TraceAttributes",
 	SelectColumns:    traceColumns,
+}
+
+var TracesTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
+	TableName:        TracesTableNoDefaultConfig.TableName,
+	KeysToColumns:    TracesTableNoDefaultConfig.KeysToColumns,
+	ReservedKeys:     TracesTableNoDefaultConfig.ReservedKeys,
+	BodyColumn:       TracesTableNoDefaultConfig.BodyColumn,
+	AttributesColumn: TracesTableNoDefaultConfig.AttributesColumn,
+	SelectColumns:    TracesTableNoDefaultConfig.SelectColumns,
 	DefaultFilter:    fmt.Sprintf("%s!=%s", highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 }
 

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -3,13 +3,13 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	"github.com/highlight-run/highlight/backend/parser/listener"
 	"strings"
 	"time"
 
 	"github.com/highlight/highlight/sdk/highlight-go"
 
 	"github.com/highlight-run/highlight/backend/model"
-	"github.com/highlight-run/highlight/backend/queryparser"
 	"golang.org/x/exp/slices"
 
 	"github.com/huandu/go-sqlbuilder"
@@ -363,6 +363,6 @@ func (client *Client) TracesMetrics(ctx context.Context, projectID int, startDat
 	return KeysAggregated(ctx, client, TraceMetricsTable, projectID, startDate, endDate, query, nil)
 }
 
-func TraceMatchesQuery(trace *TraceRow, filters *queryparser.Filters) bool {
+func TraceMatchesQuery(trace *TraceRow, filters listener.Filters) bool {
 	return matchesQuery(trace, TracesTableConfig, filters)
 }

--- a/backend/clickhouse/traces_test.go
+++ b/backend/clickhouse/traces_test.go
@@ -27,7 +27,7 @@ func TestBatchWriteTraceRows(t *testing.T) {
 
 func Test_TraceMatchesQuery(t *testing.T) {
 	trace := TraceRow{}
-	filters := parser.Parse("os.type:linux resource_name:worker.* service_name:all", TracesTableConfig)
+	filters := parser.Parse("os.type:linux resource_name:worker.* service_name:all", TracesTableNoDefaultConfig)
 	matches := TraceMatchesQuery(&trace, filters)
 	assert.False(t, matches)
 
@@ -38,16 +38,19 @@ func Test_TraceMatchesQuery(t *testing.T) {
 			"resource_name": "worker.kafka.process",
 		},
 	}
-	filters = parser.Parse("os.type:linux resource_name:worker.* service_name:all", TracesTableConfig)
+	filters = parser.Parse("os.type:linux resource_name:worker.* service_name:all", TracesTableNoDefaultConfig)
 	matches = TraceMatchesQuery(&trace, filters)
 	assert.True(t, matches)
 }
 
 func Test_TraceMatchesQuery_v2(t *testing.T) {
 	trace := TraceRow{}
-	filters := parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableConfig)
+	filters := parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableNoDefaultConfig)
 	matches := TraceMatchesQuery(&trace, filters)
 	assert.False(t, matches)
+	filters = parser.Parse("", TracesTableNoDefaultConfig)
+	matches = TraceMatchesQuery(&trace, filters)
+	assert.True(t, matches)
 
 	trace = TraceRow{
 		UUID:            "ac6e7d25-c70c-4ed0-9c7d-b9653f1b3f07",
@@ -63,9 +66,15 @@ func Test_TraceMatchesQuery_v2(t *testing.T) {
 		Environment:     "prod",
 		StatusCode:      "Unset",
 	}
-	filters = parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableConfig)
+	filters = parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableNoDefaultConfig)
 	matches = TraceMatchesQuery(&trace, filters)
 	assert.True(t, matches)
+	filters = parser.Parse("span_name=*bean-fs* OR highlight.type=oof OR span_name=swag", TracesTableNoDefaultConfig)
+	matches = TraceMatchesQuery(&trace, filters)
+	assert.False(t, matches)
+	filters = parser.Parse("span_name=*fs* AND highlight.type=highlight.internal AND span_name=highlight-metric", TracesTableNoDefaultConfig)
+	matches = TraceMatchesQuery(&trace, filters)
+	assert.False(t, matches)
 
 	trace = TraceRow{
 		UUID:            "3f25ebd5-a0db-457e-8230-e098eb57725b",
@@ -87,9 +96,12 @@ func Test_TraceMatchesQuery_v2(t *testing.T) {
 			},
 		},
 	}
-	filters = parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableConfig)
+	filters = parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableNoDefaultConfig)
 	matches = TraceMatchesQuery(&trace, filters)
 	assert.True(t, matches)
+	filters = parser.Parse("span_name=fs* AND highlight.type=highlight.internal AND span_name=highlight-metric", TracesTableNoDefaultConfig)
+	matches = TraceMatchesQuery(&trace, filters)
+	assert.False(t, matches)
 
 	trace = TraceRow{
 		UUID:            "069e75d3-047a-4b6a-9047-a397d0cfc71a",
@@ -106,7 +118,10 @@ func Test_TraceMatchesQuery_v2(t *testing.T) {
 		Environment:     "production",
 		StatusCode:      "Unset",
 	}
-	filters = parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableConfig)
+	filters = parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableNoDefaultConfig)
+	matches = TraceMatchesQuery(&trace, filters)
+	assert.True(t, matches)
+	filters = parser.Parse("span_name=(\"fs statSync\" OR the OR oo)", TracesTableNoDefaultConfig)
 	matches = TraceMatchesQuery(&trace, filters)
 	assert.True(t, matches)
 }

--- a/backend/clickhouse/traces_test.go
+++ b/backend/clickhouse/traces_test.go
@@ -96,7 +96,7 @@ func Test_TraceMatchesQuery_v2(t *testing.T) {
 			},
 		},
 	}
-	filters = parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableNoDefaultConfig)
+	filters = parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR highlight-metric", TracesTableNoDefaultConfig)
 	matches = TraceMatchesQuery(&trace, filters)
 	assert.True(t, matches)
 	filters = parser.Parse("span_name=fs* AND highlight.type=highlight.internal AND span_name=highlight-metric", TracesTableNoDefaultConfig)
@@ -121,7 +121,7 @@ func Test_TraceMatchesQuery_v2(t *testing.T) {
 	filters = parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableNoDefaultConfig)
 	matches = TraceMatchesQuery(&trace, filters)
 	assert.True(t, matches)
-	filters = parser.Parse("span_name=(\"fs statSync\" OR the OR oo)", TracesTableNoDefaultConfig)
+	filters = parser.Parse("fs statSync", TracesTableNoDefaultConfig)
 	matches = TraceMatchesQuery(&trace, filters)
 	assert.True(t, matches)
 }

--- a/backend/clickhouse/traces_test.go
+++ b/backend/clickhouse/traces_test.go
@@ -2,11 +2,11 @@ package clickhouse
 
 import (
 	"context"
+	"github.com/highlight-run/highlight/backend/parser"
 	"testing"
 	"time"
 
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
-	"github.com/highlight-run/highlight/backend/queryparser"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -27,8 +27,8 @@ func TestBatchWriteTraceRows(t *testing.T) {
 
 func Test_TraceMatchesQuery(t *testing.T) {
 	trace := TraceRow{}
-	filters := queryparser.Parse("os.type:linux resource_name:worker.* service_name:all")
-	matches := TraceMatchesQuery(&trace, &filters)
+	filters := parser.Parse("os.type:linux resource_name:worker.* service_name:all", TracesTableConfig)
+	matches := TraceMatchesQuery(&trace, filters)
 	assert.False(t, matches)
 
 	trace = TraceRow{
@@ -38,8 +38,76 @@ func Test_TraceMatchesQuery(t *testing.T) {
 			"resource_name": "worker.kafka.process",
 		},
 	}
-	filters = queryparser.Parse("os.type:linux resource_name:worker.* service_name:all")
-	matches = TraceMatchesQuery(&trace, &filters)
+	filters = parser.Parse("os.type:linux resource_name:worker.* service_name:all", TracesTableConfig)
+	matches = TraceMatchesQuery(&trace, filters)
+	assert.True(t, matches)
+}
+
+func Test_TraceMatchesQuery_v2(t *testing.T) {
+	trace := TraceRow{}
+	filters := parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableConfig)
+	matches := TraceMatchesQuery(&trace, filters)
+	assert.False(t, matches)
+
+	trace = TraceRow{
+		UUID:            "ac6e7d25-c70c-4ed0-9c7d-b9653f1b3f07",
+		TraceId:         "2660bbaa10e9844e5a78969b8bff841b",
+		SpanId:          "f9f2d4ebb43431dd",
+		ProjectId:       33452,
+		SpanName:        "IsIngestedBy",
+		SpanKind:        "Server",
+		Duration:        172148,
+		ServiceName:     "public-worker-main",
+		ServiceVersion:  "721c213bdc1246f7326e779bb161cb7d0098a401",
+		TraceAttributes: map[string]string{"host.name": "b00872087f9c", "os.type": "linux", "os.description": "Alpine Linux 3.19.0 (Linux b00872087f9c 6.1.61-85.141.amzn2023.aarch64 #1 SMP Wed Nov  8 00:38:50 UTC 2023 aarch64)", "process.owner": "root", "product": "Sessions", "process.executable.name": "backend", "process.executable.path": "/bin/backend", "process.runtime.description": "go version go1.21.6 linux/arm64", "highlight.key": "524533657", "process.pid": "20", "highlight.type": "highlight.internal", "resource_name": "sampling", "ingested": "true", "process.runtime.version": "go1.21.6", "process.runtime.name": "go"},
+		Environment:     "prod",
+		StatusCode:      "Unset",
+	}
+	filters = parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableConfig)
+	matches = TraceMatchesQuery(&trace, filters)
+	assert.True(t, matches)
+
+	trace = TraceRow{
+		UUID:            "3f25ebd5-a0db-457e-8230-e098eb57725b",
+		TraceId:         "37f80926-36d0-4ba0-b1a6-b5ca258e44e7",
+		SpanId:          "c58a9be5-2d81-4d44-b0fe-3d68d93424a6",
+		SecureSessionId: "eny2Cdx3iMAwMKLfC7a4JVAvSHod",
+		ProjectId:       33452,
+		SpanName:        "highlight-metric",
+		SpanKind:        "Server",
+		Duration:        0,
+		ServiceVersion:  "0.1",
+		TraceAttributes: map[string]string{"group": "body.started", "category": "WebVital"},
+		Environment:     "production",
+		Events: []*Event{
+			{
+				Timestamp:  time.Now(),
+				Name:       "metric",
+				Attributes: map[string]string{"metric.value": "-4.830000000000018", "metric.name": "Jank"},
+			},
+		},
+	}
+	filters = parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableConfig)
+	matches = TraceMatchesQuery(&trace, filters)
+	assert.True(t, matches)
+
+	trace = TraceRow{
+		UUID:            "069e75d3-047a-4b6a-9047-a397d0cfc71a",
+		TraceId:         "901392a3232bad26e00c94a6f2effe63",
+		SpanId:          "0f1590bfa35889dc",
+		ParentSpanId:    "51592a8743c7c5c0",
+		ProjectId:       33452,
+		SpanName:        "fs statSync",
+		SpanKind:        "Internal",
+		Duration:        54890,
+		ServiceName:     "xxx",
+		ServiceVersion:  "0.1",
+		TraceAttributes: map[string]string{"process.executable.path": "/var/lang/bin/node", "process.runtime.version": "18.18.2", "telemetry.sdk.language": "nodejs", "process.runtime.description": "Node.js", "process.runtime.name": "nodejs", "telemetry.sdk.version": "1.17.1", "process.command": "/var/runtime/index.mjs", "process.executable.name": "/var/lang/bin/node", "process.owner": "sbx_user1051", "telemetry.sdk.name": "opentelemetry", "process.pid": "8"},
+		Environment:     "production",
+		StatusCode:      "Unset",
+	}
+	filters = parser.Parse("span_name=fs* OR highlight.type=highlight.internal OR span_name=highlight-metric", TracesTableConfig)
+	matches = TraceMatchesQuery(&trace, filters)
 	assert.True(t, matches)
 }
 

--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -304,6 +304,10 @@ func (p *Queue) Stop(ctx context.Context) {
 }
 
 func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...*Message) error {
+	if len(messages) == 0 {
+		return nil
+	}
+
 	start := time.Now()
 	if partitionKey == "" {
 		partitionKey = util.GenerateRandomString(32)

--- a/backend/parser/listener/listener.go
+++ b/backend/parser/listener/listener.go
@@ -225,8 +225,14 @@ func (s *searchListener[T]) EnterEveryRule(ctx antlr.ParserRuleContext) {}
 func (s *searchListener[T]) ExitEveryRule(ctx antlr.ParserRuleContext)  {}
 
 func (s *searchListener[T]) appendRules(value string) {
+	filterKey, ok := s.tableConfig.KeysToColumns[T(s.currentKey)]
+	traceAttributeKey := false
+	if !ok {
+		traceAttributeKey = true
+	}
+
 	// Body column filters
-	if s.currentKey == s.tableConfig.BodyColumn {
+	if filterKey == s.tableConfig.BodyColumn {
 		containsSpecialChars, _ := regexp.MatchString(`[^a-zA-Z0-9]`, value)
 
 		if containsSpecialChars {
@@ -247,12 +253,6 @@ func (s *searchListener[T]) appendRules(value string) {
 		}
 
 		return
-	}
-
-	traceAttributeKey := false
-	filterKey, ok := s.tableConfig.KeysToColumns[T(s.currentKey)]
-	if !ok {
-		traceAttributeKey = true
 	}
 
 	// Special case for non-string columns

--- a/backend/parser/listener/listener.go
+++ b/backend/parser/listener/listener.go
@@ -225,14 +225,8 @@ func (s *searchListener[T]) EnterEveryRule(ctx antlr.ParserRuleContext) {}
 func (s *searchListener[T]) ExitEveryRule(ctx antlr.ParserRuleContext)  {}
 
 func (s *searchListener[T]) appendRules(value string) {
-	filterKey, ok := s.tableConfig.KeysToColumns[T(s.currentKey)]
-	traceAttributeKey := false
-	if !ok {
-		traceAttributeKey = true
-	}
-
 	// Body column filters
-	if filterKey == s.tableConfig.BodyColumn {
+	if s.currentKey == s.tableConfig.BodyColumn {
 		containsSpecialChars, _ := regexp.MatchString(`[^a-zA-Z0-9]`, value)
 
 		if containsSpecialChars {
@@ -253,6 +247,12 @@ func (s *searchListener[T]) appendRules(value string) {
 		}
 
 		return
+	}
+
+	traceAttributeKey := false
+	filterKey, ok := s.tableConfig.KeysToColumns[T(s.currentKey)]
+	if !ok {
+		traceAttributeKey = true
 	}
 
 	// Special case for non-string columns

--- a/backend/parser/listener/listener.go
+++ b/backend/parser/listener/listener.go
@@ -6,10 +6,37 @@ import (
 	"strings"
 
 	"github.com/antlr4-go/antlr/v4"
+	"github.com/huandu/go-sqlbuilder"
+
 	"github.com/highlight-run/highlight/backend/model"
 	parser "github.com/highlight-run/highlight/backend/parser/antlr"
-	"github.com/huandu/go-sqlbuilder"
 )
+
+type Operator string
+
+var OperatorEqual Operator = "="
+var OperatorNotEqual Operator = "!="
+var OperatorLike Operator = "LIKE"
+var OperatorNotLike Operator = "NOT LIKE"
+var OperatorILike Operator = "ILIKE"
+var OperatorNotILike Operator = "NOT ILIKE"
+var OperatorContains Operator = "hasTokenCaseInsensitive"
+var OperatorGreaterThan Operator = ">"
+var OperatorGreaterThanOrEqualTo Operator = ">="
+var OperatorLessThan Operator = "<"
+var OperatorLessThanOrEqualTo Operator = "<="
+var OperatorAnd Operator = "AND"
+var OperatorOr Operator = "OR"
+
+type FilterOperation struct {
+	Column   string
+	Key      string
+	Operator Operator
+	Filters  Filters
+	Values   []string
+}
+
+type Filters []*FilterOperation
 
 type searchListener[T ~string] struct {
 	parser.SearchGrammarListener
@@ -17,9 +44,14 @@ type searchListener[T ~string] struct {
 	currentKey       string
 	currentOp        string
 	rules            []string
+	ops              Filters
 	sb               *sqlbuilder.SelectBuilder
 	attributesColumn string
 	tableConfig      model.TableConfig[T]
+}
+
+func (s *searchListener[T]) GetFilters() Filters {
+	return s.ops
 }
 
 func NewSearchListener[T ~string](sqlBuilder *sqlbuilder.SelectBuilder, tableConfig model.TableConfig[T]) *searchListener[T] {
@@ -27,6 +59,7 @@ func NewSearchListener[T ~string](sqlBuilder *sqlbuilder.SelectBuilder, tableCon
 		currentKey:       tableConfig.TableName,
 		currentOp:        "=",
 		rules:            []string{},
+		ops:              []*FilterOperation{},
 		sb:               sqlBuilder,
 		attributesColumn: tableConfig.AttributesColumn,
 		tableConfig:      tableConfig,
@@ -62,6 +95,13 @@ func (s *searchListener[T]) ExitAnd_col_expr(ctx *parser.And_col_exprContext) {
 	rules := s.rules[len(s.rules)-2:]
 	s.rules = s.rules[:len(s.rules)-2]
 	s.rules = append(s.rules, s.sb.And(rules...))
+
+	ops := s.ops[len(s.ops)-2:]
+	s.ops = s.ops[:len(s.ops)-2]
+	s.ops = append(s.ops, &FilterOperation{
+		Operator: OperatorAnd,
+		Filters:  Filters{ops[0], ops[1]},
+	})
 }
 
 func (s *searchListener[T]) EnterOr_col_expr(ctx *parser.Or_col_exprContext) {}
@@ -69,6 +109,13 @@ func (s *searchListener[T]) ExitOr_col_expr(ctx *parser.Or_col_exprContext) {
 	rules := s.rules[len(s.rules)-2:]
 	s.rules = s.rules[:len(s.rules)-2]
 	s.rules = append(s.rules, s.sb.Or(rules...))
+
+	ops := s.ops[len(s.ops)-2:]
+	s.ops = s.ops[:len(s.ops)-2]
+	s.ops = append(s.ops, &FilterOperation{
+		Operator: OperatorOr,
+		Filters:  Filters{ops[0], ops[1]},
+	})
 }
 
 func (s *searchListener[T]) EnterCol_search_value(ctx *parser.Col_search_valueContext) {}
@@ -95,6 +142,13 @@ func (s *searchListener[T]) ExitAnd_search_expr(ctx *parser.And_search_exprConte
 	rules := s.rules[len(s.rules)-2:]
 	s.rules = s.rules[:len(s.rules)-2]
 	s.rules = append(s.rules, s.sb.And(rules...))
+
+	ops := s.ops[len(s.ops)-2:]
+	s.ops = s.ops[:len(s.ops)-2]
+	s.ops = append(s.ops, &FilterOperation{
+		Operator: OperatorAnd,
+		Filters:  Filters{ops[0], ops[1]},
+	})
 }
 
 func (s *searchListener[T]) EnterImplicit_and_search_expr(ctx *parser.Implicit_and_search_exprContext) {
@@ -107,6 +161,13 @@ func (s *searchListener[T]) ExitOr_search_expr(ctx *parser.Or_search_exprContext
 	rules := s.rules[len(s.rules)-2:]
 	s.rules = s.rules[:len(s.rules)-2]
 	s.rules = append(s.rules, s.sb.Or(rules...))
+
+	ops := s.ops[len(s.ops)-2:]
+	s.ops = s.ops[:len(s.ops)-2]
+	s.ops = append(s.ops, &FilterOperation{
+		Operator: OperatorOr,
+		Filters:  Filters{ops[0], ops[1]},
+	})
 }
 
 func (s *searchListener[T]) EnterKey_val_search_expr(ctx *parser.Key_val_search_exprContext) {}
@@ -171,8 +232,18 @@ func (s *searchListener[T]) appendRules(value string) {
 		if containsSpecialChars {
 			value = wildcardValue(value)
 			s.rules = append(s.rules, s.tableConfig.BodyColumn+" ILIKE "+s.sb.Var(value))
+			s.ops = append(s.ops, &FilterOperation{
+				Key:      s.tableConfig.BodyColumn,
+				Operator: OperatorILike,
+				Values:   []string{value},
+			})
 		} else {
 			s.rules = append(s.rules, "hasTokenCaseInsensitive("+s.tableConfig.BodyColumn+", "+s.sb.Var(value)+")")
+			s.ops = append(s.ops, &FilterOperation{
+				Key:      s.tableConfig.BodyColumn,
+				Operator: OperatorContains,
+				Values:   []string{value},
+			})
 		}
 
 		return
@@ -195,14 +266,36 @@ func (s *searchListener[T]) appendRules(value string) {
 
 			if traceAttributeKey {
 				s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf(s.attributesColumn+"[%s] ILIKE %s", s.currentKey, value)))
+				s.ops = append(s.ops, &FilterOperation{
+					Key:      s.currentKey,
+					Column:   s.attributesColumn,
+					Operator: OperatorLike,
+					Values:   []string{value},
+				})
 			} else {
 				s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf(filterKey+" ILIKE %s", value)))
+				s.ops = append(s.ops, &FilterOperation{
+					Key:      filterKey,
+					Operator: OperatorILike,
+					Values:   []string{value},
+				})
 			}
 		} else {
 			if traceAttributeKey {
 				s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf(s.attributesColumn+"[%s] = %s", s.currentKey, value)))
+				s.ops = append(s.ops, &FilterOperation{
+					Key:      s.currentKey,
+					Column:   s.attributesColumn,
+					Operator: OperatorEqual,
+					Values:   []string{value},
+				})
 			} else {
 				s.rules = append(s.rules, s.sb.Equal(filterKey, value))
+				s.ops = append(s.ops, &FilterOperation{
+					Key:      filterKey,
+					Operator: OperatorEqual,
+					Values:   []string{value},
+				})
 			}
 		}
 	} else if s.currentOp == "!=" {
@@ -211,39 +304,105 @@ func (s *searchListener[T]) appendRules(value string) {
 
 			if traceAttributeKey {
 				s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf(s.attributesColumn+"[%s] NOT ILIKE %s", s.currentKey, value)))
+				s.ops = append(s.ops, &FilterOperation{
+					Key:      s.currentKey,
+					Column:   s.attributesColumn,
+					Operator: OperatorNotLike,
+					Values:   []string{value},
+				})
 			} else {
 				s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf(filterKey+" NOT ILIKE %s", value)))
+				s.ops = append(s.ops, &FilterOperation{
+					Key:      filterKey,
+					Operator: OperatorNotILike,
+					Values:   []string{value},
+				})
 			}
 		} else {
 			if traceAttributeKey {
 				s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf(s.attributesColumn+"[%s] <> %s", s.currentKey, value)))
+				s.ops = append(s.ops, &FilterOperation{
+					Key:      s.currentKey,
+					Column:   s.attributesColumn,
+					Operator: OperatorNotEqual,
+					Values:   []string{value},
+				})
 			} else {
 				s.rules = append(s.rules, s.sb.NotEqual(filterKey, value))
+				s.ops = append(s.ops, &FilterOperation{
+					Key:      filterKey,
+					Operator: OperatorNotEqual,
+					Values:   []string{value},
+				})
 			}
 		}
 	} else if s.currentOp == ">" {
 		if traceAttributeKey {
 			s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf("toFloat64OrNull("+s.attributesColumn+"[%s]) > %s", s.currentKey, value)))
+			s.ops = append(s.ops, &FilterOperation{
+				Key:      s.currentKey,
+				Column:   s.attributesColumn,
+				Operator: OperatorGreaterThan,
+				Values:   []string{value},
+			})
 		} else {
 			s.rules = append(s.rules, s.sb.GreaterThan(filterKey, value))
+			s.ops = append(s.ops, &FilterOperation{
+				Key:      filterKey,
+				Operator: OperatorGreaterThan,
+				Values:   []string{value},
+			})
 		}
 	} else if s.currentOp == ">=" {
 		if traceAttributeKey {
 			s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf("toFloat64OrNull("+s.attributesColumn+"[%s]) >= %s", s.currentKey, value)))
+			s.ops = append(s.ops, &FilterOperation{
+				Key:      s.currentKey,
+				Column:   s.attributesColumn,
+				Operator: OperatorGreaterThanOrEqualTo,
+				Values:   []string{value},
+			})
 		} else {
 			s.rules = append(s.rules, s.sb.GreaterEqualThan(filterKey, value))
+			s.ops = append(s.ops, &FilterOperation{
+				Key:      filterKey,
+				Operator: OperatorGreaterThanOrEqualTo,
+				Values:   []string{value},
+			})
 		}
 	} else if s.currentOp == "<" {
 		if traceAttributeKey {
 			s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf("toFloat64OrNull("+s.attributesColumn+"[%s]) < %s", s.currentKey, value)))
+			s.ops = append(s.ops, &FilterOperation{
+				Key:      s.currentKey,
+				Column:   s.attributesColumn,
+				Operator: OperatorLessThan,
+				Values:   []string{value},
+			})
 		} else {
 			s.rules = append(s.rules, s.sb.LessThan(filterKey, value))
+			s.ops = append(s.ops, &FilterOperation{
+				Key:      filterKey,
+				Operator: OperatorLessThan,
+				Values:   []string{value},
+			})
 		}
 	} else if s.currentOp == "<=" {
 		if traceAttributeKey {
 			s.rules = append(s.rules, s.sb.Var(sqlbuilder.Buildf("toFloat64OrNull("+s.attributesColumn+"[%s]) <= %s", s.currentKey, value)))
+			s.ops = append(s.ops, &FilterOperation{
+				Key:      s.currentKey,
+				Column:   s.attributesColumn,
+				Operator: OperatorLessThanOrEqualTo,
+				Values:   []string{value},
+			})
 		} else {
 			s.rules = append(s.rules, s.sb.LessEqualThan(filterKey, value))
+			s.ops = append(s.ops, &FilterOperation{
+				Key:      filterKey,
+				Operator: OperatorLessThanOrEqualTo,
+				Values:   []string{value},
+			})
 		}
 	} else {
 		fmt.Printf("Unknown search operator: %s\n", s.currentOp)

--- a/backend/parser/listener/listener.go
+++ b/backend/parser/listener/listener.go
@@ -16,6 +16,7 @@ type Operator string
 
 var OperatorEqual Operator = "="
 var OperatorNotEqual Operator = "!="
+var OperatorNot Operator = "NOT"
 var OperatorLike Operator = "LIKE"
 var OperatorNotLike Operator = "NOT LIKE"
 var OperatorILike Operator = "ILIKE"
@@ -88,6 +89,13 @@ func (s *searchListener[T]) ExitNegated_col_expr(ctx *parser.Negated_col_exprCon
 	rule := s.rules[len(s.rules)-1]
 	s.rules = s.rules[:len(s.rules)-1]
 	s.rules = append(s.rules, fmt.Sprintf("NOT (%s)", rule))
+
+	op := s.ops[len(s.ops)-1]
+	s.ops = s.ops[:len(s.ops)-1]
+	s.ops = append(s.ops, &FilterOperation{
+		Operator: OperatorNot,
+		Filters:  Filters{op},
+	})
 }
 
 func (s *searchListener[T]) EnterAnd_col_expr(ctx *parser.And_col_exprContext) {}
@@ -126,6 +134,13 @@ func (s *searchListener[T]) ExitNegated_search_expr(ctx *parser.Negated_search_e
 	rule := s.rules[len(s.rules)-1]
 	s.rules = s.rules[:len(s.rules)-1]
 	s.rules = append(s.rules, fmt.Sprintf("NOT (%s)", rule))
+
+	op := s.ops[len(s.ops)-1]
+	s.ops = s.ops[:len(s.ops)-1]
+	s.ops = append(s.ops, &FilterOperation{
+		Operator: OperatorNot,
+		Filters:  Filters{op},
+	})
 }
 
 func (s *searchListener[T]) EnterBody_search_expr(ctx *parser.Body_search_exprContext) {

--- a/backend/parser/parser.go
+++ b/backend/parser/parser.go
@@ -6,10 +6,14 @@ import (
 	parser "github.com/highlight-run/highlight/backend/parser/antlr"
 	"github.com/highlight-run/highlight/backend/parser/listener"
 	"github.com/huandu/go-sqlbuilder"
+	"strings"
 )
 
 func AssignSearchFilters[T ~string](sqlBuilder *sqlbuilder.SelectBuilder, query string, tableConfig model.TableConfig[T]) listener.Filters {
-	is := antlr.NewInputStream(query + " " + tableConfig.DefaultFilter)
+	if !strings.Contains(query, "IsIngestedBy") {
+		query = query + " " + tableConfig.DefaultFilter
+	}
+	is := antlr.NewInputStream(query)
 	lexer := parser.NewSearchGrammarLexer(is)
 	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
 	p := parser.NewSearchGrammarParser(stream)

--- a/backend/parser/parser.go
+++ b/backend/parser/parser.go
@@ -6,14 +6,10 @@ import (
 	parser "github.com/highlight-run/highlight/backend/parser/antlr"
 	"github.com/highlight-run/highlight/backend/parser/listener"
 	"github.com/huandu/go-sqlbuilder"
-	"strings"
 )
 
 func AssignSearchFilters[T ~string](sqlBuilder *sqlbuilder.SelectBuilder, query string, tableConfig model.TableConfig[T]) listener.Filters {
-	if !strings.Contains(query, "IsIngestedBy") {
-		query = query + " " + tableConfig.DefaultFilter
-	}
-	is := antlr.NewInputStream(query)
+	is := antlr.NewInputStream(query + " " + tableConfig.DefaultFilter)
 	lexer := parser.NewSearchGrammarLexer(is)
 	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
 	p := parser.NewSearchGrammarParser(stream)

--- a/backend/parser/parser_test.go
+++ b/backend/parser/parser_test.go
@@ -53,7 +53,7 @@ func TestWildcardSearch(t *testing.T) {
 func buildSqlForQuery(query string) (string, error) {
 	sqlBuilder := sqlbuilder.NewSelectBuilder()
 	sb := sqlBuilder.Select("*").From("t")
-	AssignSearchFilters(sb, query, tableConfig)
+	_ = AssignSearchFilters(sb, query, tableConfig)
 	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
 	return sqlbuilder.ClickHouse.Interpolate(sql, args)
 }

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2146,15 +2146,6 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 		return
 	}
 
-	// Filter out ignored errors
-	var filteredErrors []*publicModel.BackendErrorObjectInput
-	for _, errorObject := range errorObjects {
-		if r.IsErrorIngested(ctx, project.ID, errorObject) {
-			filteredErrors = append(filteredErrors, errorObject)
-		}
-	}
-	errorObjects = filteredErrors
-
 	if len(errorObjects) == 0 {
 		return
 	}

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2038,6 +2038,9 @@ func (r *Resolver) PushMetricsImpl(ctx context.Context, projectVerboseID *string
 	// TODO(vkorolik) write to an actual metrics table
 	var messages []*kafka_queue.Message
 	for _, traceRow := range traceRows {
+		if !r.IsTraceIngested(ctx, traceRow) {
+			continue
+		}
 		messages = append(messages, &kafka_queue.Message{
 			Type: kafka_queue.PushTraces,
 			PushTraces: &kafka_queue.PushTracesArgs{

--- a/backend/public-graph/graph/sampling.go
+++ b/backend/public-graph/graph/sampling.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/parser"
 	"hash/fnv"
 	"regexp"
 	"time"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/highlight-run/highlight/backend/clickhouse"
 	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/parser"
 	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	modelInputs "github.com/highlight-run/highlight/backend/public-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"

--- a/backend/public-graph/graph/sampling.go
+++ b/backend/public-graph/graph/sampling.go
@@ -395,7 +395,7 @@ func (r *Resolver) isItemIngestedByFilter(ctx context.Context, product privateMo
 			filters := parser.Parse(query, clickhouse.LogsTableConfig)
 			return clickhouse.LogMatchesQuery(object.(*clickhouse.LogRow), filters)
 		case privateModel.ProductTypeTraces:
-			filters := parser.Parse(query, clickhouse.TracesTableConfig)
+			filters := parser.Parse(query, clickhouse.TracesTableNoDefaultConfig)
 			return clickhouse.TraceMatchesQuery(object.(*clickhouse.TraceRow), filters)
 		}
 		return false

--- a/backend/stacktraces/enhancer.go
+++ b/backend/stacktraces/enhancer.go
@@ -346,6 +346,7 @@ func processStackFrame(ctx context.Context, projectId int, version *string, stac
 	if len(stackTraceFilePath) > 0 && stackTraceFilePath[0:1] == "/" {
 		stackTraceFilePath = stackTraceFilePath[1:]
 	}
+	// TODO(vkorolik) keep the querystring so that add to the .map requests
 	// ensure reflame query string is preserved, as it is necessary to load the file
 	isReflame := strings.Contains(stackTraceFileURL, "~r_rid=")
 	if !isReflame {

--- a/frontend/src/pages/ProjectSettings/ProjectFilters/ProjectFilters.tsx
+++ b/frontend/src/pages/ProjectSettings/ProjectFilters/ProjectFilters.tsx
@@ -274,17 +274,17 @@ export const ProjectProductFilters: React.FC<{
 		) {
 			const params = {} as { [key: string]: string }
 			for (const pair of (c?.exclusion_query ?? '').split(' ')) {
-				const [key, value] = pair.split(':')
+				const [key, value] = pair.split('=')
 				if (key && value) {
 					let op: Operator = 'is'
-					let v = value
-					if (value.startsWith('-')) {
+					let k = key
+					if (k.endsWith('!')) {
 						op = 'is_not'
-						v = value.slice(1)
+						k = k.slice(0, -1)
 					}
 					params[
-						`${product.toLowerCase().slice(0, -1)}_${key}`
-					] = `${op}:${v}`
+						`${product.toLowerCase().slice(0, -1)}_${k}`
+					] = `${op}:${value}`
 				}
 			}
 			;(product === ProductType.Sessions
@@ -319,9 +319,9 @@ export const ProjectProductFilters: React.FC<{
 				if (product === ProductType.Errors && k === 'timestamp')
 					continue
 				if (v.indexOf(' ') !== -1) {
-					rules.push(`${k}:${op === 'is_not' ? '-' : ''}"${v}"`)
+					rules.push(`${k}${op === 'is_not' ? '!' : ''}="${v}"`)
 				} else {
-					rules.push(`${k}:${op === 'is_not' ? '-' : ''}${v}`)
+					rules.push(`${k}${op === 'is_not' ? '!' : ''}=${v}`)
 				}
 			}
 			formStore.setValue('exclusionQuery', rules.join(' '))


### PR DESCRIPTION
## Summary

Our ingest filters would not work with the new traces / logs syntax
as they were built for parsing the older syntax used for sessions and errors. 
Switches the ingestion filters to use the new syntax.
Closes #7269

## How did you test this change?

Unit testing / local deploy
https://www.loom.com/share/0fc5aad6a04842f6b3b562a804b2381b

## Are there any deployment considerations?

We may need to convert old exclusion queries to the new syntax, but there are only a handful configured right now so I'll do it manually once this is deployed.

## Does this work require review from our design team?

No
