### PR TITLE
Remove beta for traces

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5595,18 +5595,6 @@ body {
 .bsyaa20:hover {
   color: var(--_1pyqka9y);
 }
-.bsyaa21 {
-  margin-left: 4px;
-  padding-left: 4px;
-  padding-right: 4px;
-  background-color: #e7defc;
-  color: #6346af;
-  font-size: 11px;
-  height: 16px;
-  line-height: 16px;
-  border-radius: 3px;
-  align-self: center;
-}
 ._1kpm5g60 {
   text-decoration: none;
 }

--- a/frontend/src/__generated/ve/components/Header/styles.css.js
+++ b/frontend/src/__generated/ve/components/Header/styles.css.js
@@ -1,7 +1,5 @@
 // src/components/Header/styles.css.ts
-var betaTag = "bsyaa21";
 var linkStyle = "bsyaa20";
 export {
-  betaTag,
   linkStyle
 };

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import { Button } from '@components/Button'
 import CommandBar from '@components/CommandBar/CommandBar'
 import { DEMO_WORKSPACE_PROXY_APPLICATION_ID } from '@components/DemoWorkspaceButton/DemoWorkspaceButton'
 import ProjectPicker from '@components/Header/components/ProjectPicker/ProjectPicker'
-import { betaTag, linkStyle } from '@components/Header/styles.css'
+import { linkStyle } from '@components/Header/styles.css'
 import { OpenCommandBarShortcut } from '@components/KeyboardShortcutsEducation/KeyboardShortcutsEducation'
 import { LinkButton } from '@components/LinkButton'
 import {
@@ -148,7 +148,6 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 		{
 			key: 'traces',
 			icon: IconSolidSparkles,
-			isBeta: true,
 		},
 		{
 			key: 'alerts',
@@ -251,11 +250,6 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 												trackingId={`header-link-click-${p.key}`}
 											>
 												{titleCaseString(p.key)}
-												{p.isBeta ? (
-													<Box cssClass={betaTag}>
-														Beta
-													</Box>
-												) : null}
 											</LinkButton>
 										)
 									})}

--- a/frontend/src/components/Header/styles.css.ts
+++ b/frontend/src/components/Header/styles.css.ts
@@ -10,16 +10,3 @@ export const linkStyle = style({
 		},
 	},
 })
-
-export const betaTag = style({
-	marginLeft: '4px',
-	paddingLeft: '4px',
-	paddingRight: '4px',
-	backgroundColor: vars.color.p5,
-	color: vars.color.p11,
-	fontSize: '11px',
-	height: '16px',
-	lineHeight: '16px',
-	borderRadius: '3px',
-	alignSelf: 'center',
-})

--- a/frontend/src/pages/Setup/SetupRouter/SetupRouter.tsx
+++ b/frontend/src/pages/Setup/SetupRouter/SetupRouter.tsx
@@ -1,7 +1,6 @@
 import LoadingBox from '@components/LoadingBox'
 import { useGetProjectQuery } from '@graph/hooks'
 import {
-	Badge,
 	Box,
 	ButtonIcon,
 	IconSolidBell,
@@ -210,12 +209,6 @@ export const SetupRouter = () => {
 							<Stack direction="row" align="center" gap="4">
 								<IconSolidSparkles />
 								<Text>Traces</Text>
-								<Badge
-									size="small"
-									shape="basic"
-									label="Beta"
-									variant="purple"
-								/>
 							</Stack>
 							{tracesIntegration?.integrated && (
 								<IconSolidCheckCircle />

--- a/highlight.io/components/Home/FeatureCarousel/FeatureCarousel.tsx
+++ b/highlight.io/components/Home/FeatureCarousel/FeatureCarousel.tsx
@@ -126,14 +126,14 @@ const features: Feature[] = [
 		mobileImage: tracesscreenshot,
 		right: true,
 		shortenWidth: true,
-		beta: true,
 		feature1: 'Powerful Visualization Capabilities',
 		featureImage1: <HiTemplate className="h-[20px] w-[20px]" />,
 		feature2: 'Distributed Tracing Support',
 		featureImage2: <HiGlobe className="h-[20px] w-[20px]" />,
 		feature3: 'OpenTelemetry Support',
 		featureImage3: <HiExclamationCircle className="h-[20px] w-[20px]" />,
-		link: '/docs/getting-started/tracing',
+		// TODO: update this link to new landing page when ready
+		link: '/docs/general/product-features/tracing/overview',
 	},
 
 	{


### PR DESCRIPTION
## Summary
Remove the `beta` tag from traces in the docs and product.

Temporarily fix the link to the traces docs while the new landing page is in progress.

## How did you test this change?
1) Load the product
- Traces no longer in beta
2) View the setup doc
- [ ] Traces no longer in beta
3) Load the Highlight landing page
- [ ] Trace no longer in beta
- [ ] Trace link works

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
