### PR TITLE
Add calendly widget for enterprise pricing tier

### DIFF
--- a/highlight.io/components/Home/CalendlyPopover.tsx
+++ b/highlight.io/components/Home/CalendlyPopover.tsx
@@ -3,9 +3,9 @@
 import { Popover } from '@headlessui/react'
 import { ArrowRightCircleIcon, XMarkIcon } from '@heroicons/react/20/solid'
 import classNames from 'classnames'
+import { useSearchParams } from 'next/navigation'
 import { InlineWidget } from 'react-calendly'
 import { Typography } from '../common/Typography/Typography'
-import { useSearchParams } from 'next/navigation'
 
 export const CalendlyPopover = () => {
 	const query = useSearchParams()

--- a/highlight.io/pages/pricing/index.tsx
+++ b/highlight.io/pages/pricing/index.tsx
@@ -233,7 +233,7 @@ const Faqs: { question: string; answer: string; icon: string }[] = [
 ]
 
 const billingPeriodOptions = ['Monthly', 'Annual'] as const
-type BillingPeriod = (typeof billingPeriodOptions)[number]
+type BillingPeriod = typeof billingPeriodOptions[number]
 
 const retentionOptions = [
 	'30 days',
@@ -242,7 +242,7 @@ const retentionOptions = [
 	'1 year',
 	'2 years',
 ] as const
-type Retention = (typeof retentionOptions)[number]
+type Retention = typeof retentionOptions[number]
 const retentionMultipliers: Record<Retention, number> = {
 	'30 days': 1,
 	'3 months': 1,
@@ -367,7 +367,7 @@ const prices = {
 } as const
 
 const tierOptions = ['Free', 'UsageBased', 'Enterprise'] as const
-type TierName = (typeof tierOptions)[number]
+type TierName = typeof tierOptions[number]
 
 type PricingTier = {
 	label: string

--- a/highlight.io/pages/pricing/index.tsx
+++ b/highlight.io/pages/pricing/index.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon } from '@heroicons/react/20/solid'
+import { ChevronDownIcon, XMarkIcon } from '@heroicons/react/20/solid'
 import { NextPage } from 'next'
 import Image from 'next/image'
 import { PrimaryButton } from '../../components/common/Buttons/PrimaryButton'
@@ -20,10 +20,11 @@ import Stopwatch from '../../public/images/stopwatch.svg'
 import TagLoyalty from '../../public/images/tag-loyalty.svg'
 import Wallet from '../../public/images/wallet.svg'
 
-import { RadioGroup } from '@headlessui/react'
+import { Popover, RadioGroup } from '@headlessui/react'
 import * as Slider from '@radix-ui/react-slider'
 import classNames from 'classnames'
 import { useState } from 'react'
+import { InlineWidget } from 'react-calendly'
 import Collapsible from 'react-collapsible'
 import { Section } from '../../components/common/Section/Section'
 import { HeadlessTooltip } from '../../components/Competitors/ComparisonTable'
@@ -232,7 +233,7 @@ const Faqs: { question: string; answer: string; icon: string }[] = [
 ]
 
 const billingPeriodOptions = ['Monthly', 'Annual'] as const
-type BillingPeriod = typeof billingPeriodOptions[number]
+type BillingPeriod = (typeof billingPeriodOptions)[number]
 
 const retentionOptions = [
 	'30 days',
@@ -241,7 +242,7 @@ const retentionOptions = [
 	'1 year',
 	'2 years',
 ] as const
-type Retention = typeof retentionOptions[number]
+type Retention = (typeof retentionOptions)[number]
 const retentionMultipliers: Record<Retention, number> = {
 	'30 days': 1,
 	'3 months': 1,
@@ -366,7 +367,7 @@ const prices = {
 } as const
 
 const tierOptions = ['Free', 'UsageBased', 'Enterprise'] as const
-type TierName = typeof tierOptions[number]
+type TierName = (typeof tierOptions)[number]
 
 type PricingTier = {
 	label: string
@@ -458,8 +459,8 @@ const priceTiers: Record<TierName, PricingTier> = {
 					'Exposure to a Grafana instance for visualization of traces/metrics/logs',
 			},
 		],
-		buttonLabel: 'Contact us',
-		buttonLink: 'mailto:sales@highlight.io',
+		buttonLabel: 'Contact Us',
+		buttonLink: '',
 	},
 }
 
@@ -487,6 +488,7 @@ const PlanTable = () => {
 
 const PlanTier = ({ name, tier }: { name: string; tier: PricingTier }) => {
 	const { features, badgeText, calculateUsage } = tier
+	const [calendlyOpen, setCalendlyOpen] = useState(false)
 
 	return (
 		<div
@@ -526,13 +528,46 @@ const PlanTier = ({ name, tier }: { name: string; tier: PricingTier }) => {
 					</div>
 				))}
 			</div>
+			<Popover className="relative inline-flex flex-col items-center">
+				{({ open, close }) => (
+					<Popover.Panel
+						static
+						className={classNames(
+							'fixed inset-0 z-50 grid place-items-center w-screen h-screen pointer-events-none',
+							!calendlyOpen && 'hidden',
+						)}
+					>
+						<div className="min-w-[320px] w-screen max-w-5xl min-[1000px]:h-[700px] h-[900px] transition-opacity max-[652px]:pt-14 pointer-events-auto">
+							<InlineWidget
+								url="https://calendly.com/d/2gt-rw5-qg5/highlight-demo-call"
+								styles={{ width: '100%', height: '100%' }}
+							/>
+						</div>
+						<button
+							className="absolute grid w-10 h-10 rounded-full place-content-center bg-divider-on-dark max-[652px]:right-2 max-[652px]:top-2 right-10 top-10 hover:brightness-150 transition-all pointer-events-auto"
+							onClick={() => setCalendlyOpen(false)}
+						>
+							<XMarkIcon className="w-5 h-5" />
+						</button>
+					</Popover.Panel>
+				)}
+			</Popover>
 			<div className="px-5 pb-5 flex flex-col gap-2.5">
-				<PrimaryButton
-					href={tier.buttonLink}
-					className={homeStyles.hollowButton}
-				>
-					{tier.buttonLabel}
-				</PrimaryButton>
+				{tier.buttonLink === '' ? (
+					<PrimaryButton
+						className={homeStyles.hollowButton}
+						onClick={() => setCalendlyOpen(true)}
+					>
+						{tier.buttonLabel}
+					</PrimaryButton>
+				) : (
+					<PrimaryButton
+						href={tier.buttonLink}
+						className={homeStyles.hollowButton}
+					>
+						{tier.buttonLabel}
+					</PrimaryButton>
+				)}
 				{calculateUsage && (
 					<div
 						onClick={(e) => {


### PR DESCRIPTION
## Summary

Add calendly widget for enterprise pricing tier

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
clicktest

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
n/a

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
n/a

<!--
 Request review from julian-highlight / our design team 
-->
