### PR TITLE
Fix Github enhanced stacktraces for backend errors

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2219,7 +2219,7 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 			mapped, structured, err := r.getMappedStackTraceString(ctx, stackFrameInput, projectID, errorToInsert, pointy.String(fmt.Sprintf("%s-%s", v.Service.Name, v.Service.Version)))
 			if err != nil {
 				log.WithContext(ctx).Errorf("Error generating mapped stack trace: %v", v.StackTrace)
-			} else if mapped != nil {
+			} else if mapped != nil && *mapped != "null" {
 				errorToInsert.MappedStackTrace = mapped
 				structuredStackTrace = structured
 			}


### PR DESCRIPTION
## Summary
Backend stacktraces were not being enhanced because the mapped stacktrace was `"null"`. Add a check to make sure we don't overwrite any stacktrace in this condition.

## How did you test this change?
1) Integrate with Github (make sure not to connect to the prod app, reachout if you need to use my personal GitHub app)
2) Cause a backend error
- [ ] Error was enhanced successfully

https://www.loom.com/share/e9cc85b49734403988efd6b5e48d965b

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
