### PR TITLE
fix discord notifications by adding emoji buttons

### DIFF
--- a/backend/alerts/integrations/discord/messages.go
+++ b/backend/alerts/integrations/discord/messages.go
@@ -18,6 +18,12 @@ func newMessageEmbed() *discordgo.MessageEmbed {
 var RED_ALERT = 0x961e13
 var YELLOW_ALERT = 0xf2c94c
 
+var highlightEmoji = discordgo.ComponentEmoji{
+	Name:     "highlight",
+	ID:       "1094349627953778788",
+	Animated: false,
+}
+
 func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlertPayload) error {
 	fields := []*discordgo.MessageEmbedField{}
 
@@ -71,12 +77,14 @@ func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlert
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{
 					discordgo.Button{
+						Emoji:    highlightEmoji,
 						Label:    sessionLabel,
 						Style:    discordgo.LinkButton,
 						Disabled: displayMissingSessionLabel,
 						URL:      payload.SessionURL,
 					},
 					discordgo.Button{
+						Emoji:    highlightEmoji,
 						Label:    "View Error",
 						Style:    discordgo.LinkButton,
 						Disabled: false,
@@ -87,18 +95,21 @@ func (bot *Bot) SendErrorAlert(channelId string, payload integrations.ErrorAlert
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{
 					discordgo.Button{
+						Emoji:    highlightEmoji,
 						Label:    "Resolve Error",
 						Style:    discordgo.LinkButton,
 						Disabled: false,
 						URL:      payload.ErrorResolveURL,
 					},
 					discordgo.Button{
+						Emoji:    highlightEmoji,
 						Label:    "Ignore Error",
 						Style:    discordgo.LinkButton,
 						Disabled: false,
 						URL:      payload.ErrorIgnoreURL,
 					},
 					discordgo.Button{
+						Emoji:    highlightEmoji,
 						Label:    "Snooze Error",
 						Style:    discordgo.LinkButton,
 						Disabled: false,
@@ -142,6 +153,7 @@ func (bot *Bot) SendNewUserAlert(channelId string, payload integrations.NewUserA
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{
 					discordgo.Button{
+						Emoji:    highlightEmoji,
 						Label:    "View Session",
 						Style:    discordgo.LinkButton,
 						Disabled: false,
@@ -194,6 +206,7 @@ func (bot *Bot) SendNewSessionAlert(channelId string, payload integrations.NewSe
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{
 					discordgo.Button{
+						Emoji:    highlightEmoji,
 						Label:    "View Session",
 						Style:    discordgo.LinkButton,
 						Disabled: false,
@@ -274,6 +287,7 @@ func (bot *Bot) SendUserPropertiesAlert(channelId string, payload integrations.U
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{
 					discordgo.Button{
+						Emoji:    highlightEmoji,
 						Label:    "View Session",
 						Style:    discordgo.LinkButton,
 						Disabled: false,
@@ -310,6 +324,7 @@ func (bot *Bot) SendErrorFeedbackAlert(channelId string, payload integrations.Er
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{
 					discordgo.Button{
+						Emoji:    highlightEmoji,
 						Label:    "View Comment",
 						Style:    discordgo.LinkButton,
 						Disabled: false,
@@ -353,6 +368,7 @@ func (bot *Bot) SendRageClicksAlert(channelId string, payload integrations.RageC
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{
 					discordgo.Button{
+						Emoji:    highlightEmoji,
 						Label:    "View Session",
 						Style:    discordgo.LinkButton,
 						Disabled: false,
@@ -396,6 +412,7 @@ func (bot *Bot) SendMetricMonitorAlert(channelId string, payload integrations.Me
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{
 					discordgo.Button{
+						Emoji:    highlightEmoji,
 						Label:    "View Monitor",
 						Style:    discordgo.LinkButton,
 						Disabled: false,
@@ -453,6 +470,7 @@ func (bot *Bot) SendLogAlert(channelId string, payload integrations.LogAlertPayl
 			discordgo.ActionsRow{
 				Components: []discordgo.MessageComponent{
 					discordgo.Button{
+						Emoji:    highlightEmoji,
 						Label:    "View Logs",
 						Style:    discordgo.LinkButton,
 						Disabled: false,

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/golang/snappy v0.0.4
 	github.com/google/go-github/v50 v50.2.0
 	github.com/google/uuid v1.4.0
-	github.com/gorilla/websocket v1.5.0
+	github.com/gorilla/websocket v1.5.1
 	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/highlight-run/workerpool v1.3.0
 	github.com/highlight/go-oauth2-redis/v4 v4.1.4
@@ -196,7 +196,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/sso v1.4.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.7.2 // indirect
-	github.com/bwmarrin/discordgo v0.26.1
+	github.com/bwmarrin/discordgo v0.27.1
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/dghubble/sling v1.1.0 // indirect
 	github.com/gammazero/deque v0.1.0 // indirect
@@ -227,10 +227,10 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tdewolff/parse v2.3.4+incompatible
 	go.opencensus.io v0.24.0 // indirect
-	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/crypto v0.18.0 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
-	golang.org/x/net v0.19.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/net v0.20.0 // indirect
+	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -276,6 +276,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3k
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/bwmarrin/discordgo v0.26.1 h1:AIrM+g3cl+iYBr4yBxCBp9tD9jR3K7upEjl0d89FRkE=
 github.com/bwmarrin/discordgo v0.26.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
+github.com/bwmarrin/discordgo v0.27.1 h1:ib9AIc/dom1E/fSIulrBwnez0CToJE113ZGt4HoliGY=
+github.com/bwmarrin/discordgo v0.27.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
@@ -818,6 +820,8 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -1875,6 +1879,8 @@ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -274,8 +274,6 @@ github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8n
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
-github.com/bwmarrin/discordgo v0.26.1 h1:AIrM+g3cl+iYBr4yBxCBp9tD9jR3K7upEjl0d89FRkE=
-github.com/bwmarrin/discordgo v0.26.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/bwmarrin/discordgo v0.27.1 h1:ib9AIc/dom1E/fSIulrBwnez0CToJE113ZGt4HoliGY=
 github.com/bwmarrin/discordgo v0.27.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -818,7 +816,6 @@ github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
@@ -1877,8 +1874,6 @@ golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
 golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/backend/jobs/log-alerts/log-alerts.go
+++ b/backend/jobs/log-alerts/log-alerts.go
@@ -176,7 +176,7 @@ func processLogAlert(ctx context.Context, DB *gorm.DB, MailClient *sendgrid.Clie
 			StartDate: start,
 			EndDate:   end,
 		}); err != nil {
-			log.WithContext(ctx).Error(err)
+			log.WithContext(ctx).WithError(err).Error("failed to send discord log alert")
 		}
 
 		emailsToNotify, err := model.GetEmailsToNotify(alert.EmailsToNotify)

--- a/backend/main.go
+++ b/backend/main.go
@@ -601,6 +601,8 @@ func main() {
 			}()
 			// in `all` mode, refresh materialized views every hour
 			go func() {
+				w.StartLogAlertWatcher(ctx)
+				w.StartMetricMonitorWatcher(ctx)
 				w.RefreshMaterializedViews(ctx)
 				for range time.Tick(time.Hour) {
 					w.RefreshMaterializedViews(ctx)


### PR DESCRIPTION
## Summary

Discord recently changed the API to cause our go client to get an error when sending a button component with no emoji.
This must be because our client does not have an `omitEmpty` on the json serialization for the `emoji` key, but discord
must have made the value required when the key is present.

```json
{"message": "Invalid Form Body", "code": 50035, "errors": {"components": {"0": {"components": {"0": {"emoji": {"name": {"_errors": [{"code": "BUTTON_COMPONENT_INVALID_EMOJI", "message": "Invalid emoji"}]}}}}}}}}
```

Fixes the error by adding a highlight emoji to the button.

## How did you test this change?

local testing
<img width="458" alt="Screenshot 2024-01-25 at 4 46 02 PM" src="https://github.com/highlight/highlight/assets/1351531/6b34f967-5529-431a-b9d5-4c7d81d420d0">

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
