### PR TITLE
update otel collector export settings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -535,4 +535,4 @@ jobs:
               with:
                   task-definition: ${{ steps.image-opentelemetry-collector.outputs.task-definition }}
                   service: opentelemetry-collector-service
-                  cluster: highlight-ec2-prod
+                  cluster: highlight-production-cluster

--- a/backend/event-parse/parse.go
+++ b/backend/event-parse/parse.go
@@ -103,7 +103,7 @@ const (
 	ErrFetchNotOk       = "ErrFetchNotOk"
 	// MaxAssetSize = 200 GB storage per ECS node / 64 parallel kafka workers
 	MaxAssetSize    = 3 * 1e9
-	MaxSnapshotSize = 128 * 1024 * 1024
+	MaxSnapshotSize = 64 * 1024 * 1024
 )
 
 type fetcher interface {

--- a/deploy/otel-collector.yaml
+++ b/deploy/otel-collector.yaml
@@ -13,13 +13,14 @@ exporters:
     otlphttp:
         endpoint: 'https://pub.highlight.run/otel'
         compression: gzip
+        timeout: 30s
         sending_queue:
             num_consumers: 64
             queue_size: 16384
         retry_on_failure:
             initial_interval: 0.1s
             max_interval: 1s
-            max_elapsed_time: 10s
+            max_elapsed_time: 300s
 processors:
     memory_limiter:
         check_interval: 0.1s

--- a/docker/otel-collector.hobby.yaml
+++ b/docker/otel-collector.hobby.yaml
@@ -15,11 +15,14 @@ exporters:
         compression: gzip
         tls:
             insecure_skip_verify: true
+        timeout: 30s
         sending_queue:
             num_consumers: 64
             queue_size: 8192
         retry_on_failure:
-            initial_interval: 1s
+            initial_interval: 0.1s
+            max_interval: 1s
+            max_elapsed_time: 300s
 processors:
     memory_limiter:
         check_interval: 1s

--- a/docker/otel-collector.yaml
+++ b/docker/otel-collector.yaml
@@ -18,11 +18,14 @@ exporters:
         compression: gzip
         tls:
             insecure_skip_verify: true
+        timeout: 30s
         sending_queue:
             num_consumers: 64
             queue_size: 8192
         retry_on_failure:
-            initial_interval: 1s
+            initial_interval: 0.1s
+            max_interval: 1s
+            max_elapsed_time: 300s
 processors:
     memory_limiter:
         check_interval: 1s


### PR DESCRIPTION
## Summary

We've received reports of timeouts to the collector again recently.
Tuning the export timeout to see if public graph latency for large batches
may cause us to reject batches.

## How did you test this change?

Forcing prod deploy.

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No