### PR TITLE
Fix logs exists

### DIFF
--- a/frontend/src/pages/LogsPage/utils.ts
+++ b/frontend/src/pages/LogsPage/utils.ts
@@ -72,6 +72,7 @@ export const findMatchingLogAttributes = (
 				const queryKey = term.key.toLowerCase()
 				const queryValue = term.value?.toLowerCase()
 
+				// TODO: skips when using the exists operator, but we may want to support showing all values
 				if (queryValue && queryKey === fullKey) {
 					matchingAttribute = queryValue
 				}

--- a/frontend/src/pages/LogsPage/utils.ts
+++ b/frontend/src/pages/LogsPage/utils.ts
@@ -70,9 +70,9 @@ export const findMatchingLogAttributes = (
 				}
 
 				const queryKey = term.key.toLowerCase()
-				const queryValue = term.value.toLowerCase()
+				const queryValue = term.value?.toLowerCase()
 
-				if (queryKey === fullKey) {
+				if (queryKey && queryKey === fullKey) {
 					matchingAttribute = queryValue
 				}
 			})

--- a/frontend/src/pages/LogsPage/utils.ts
+++ b/frontend/src/pages/LogsPage/utils.ts
@@ -72,7 +72,7 @@ export const findMatchingLogAttributes = (
 				const queryKey = term.key.toLowerCase()
 				const queryValue = term.value?.toLowerCase()
 
-				if (queryKey && queryKey === fullKey) {
+				if (queryValue && queryKey === fullKey) {
 					matchingAttribute = queryValue
 				}
 			})


### PR DESCRIPTION
## Summary
The logs table doesn't know what to do with matching attributes when using the `exists` keyword. Skip trying to match when using `exists` and `not exists` for now.

## How did you test this change?
1) Complete a search on the logs table using `exists`
- [ ] Search is completed
- [ ] No crash
- [ ] Correct rows returned 
2) Complete a search on the logs table using `not exists`
- [ ] Search is completed
- [ ] No crash
- [ ] Correct rows returned 

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
