### PR TITLE
add exists operators to suggestions

### DIFF
--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -73,8 +73,9 @@ type SearchResult = Keys[0] | { name: string; type: 'Operator' | 'Value' }
 
 const MAX_ITEMS = 25
 
-const NUMERIC_OPERATORS = ['>', '>=', '<', '<=']
-const BOOLEAN_OPERATORS = ['=', '!=']
+const EXISTS_OPERATORS = ['EXISTS', 'NOT EXISTS']
+const NUMERIC_OPERATORS = ['>', '>=', '<', '<='].concat(EXISTS_OPERATORS)
+const BOOLEAN_OPERATORS = ['=', '!='].concat(EXISTS_OPERATORS)
 export const SEARCH_OPERATORS = [...BOOLEAN_OPERATORS, ...NUMERIC_OPERATORS]
 
 export type SearchFormProps = {
@@ -386,11 +387,14 @@ export const Search: React.FC<{
 
 	const handleItemSelect = (item: SearchResult) => {
 		const isValueSelect = item.type === 'Value'
-		const value = item.name
+		let value = item.name
 		const isLastPart =
 			activePart.stop >= (queryParts[queryParts.length - 1]?.stop ?? 0)
 
 		if (item.type === 'Operator') {
+			if (EXISTS_OPERATORS.includes(item.name)) {
+				value = ' ' + value
+			}
 			activePart.operator = value
 			activePart.text =
 				activePart.key === BODY_KEY
@@ -842,6 +846,10 @@ const getSearchResultBadgeText = (key: SearchResult) => {
 				return 'smaller'
 			case '<=':
 				return 'smaller or equal'
+			case 'EXISTS':
+				return 'exists'
+			case 'NOT EXISTS':
+				return 'does not exist'
 		}
 	} else if (key.type === 'Value') {
 		return undefined


### PR DESCRIPTION
## Summary
- adds `EXISTS` / `NOT EXISTS` to suggested operators for logs/traces search
<img width="628" alt="Screen Shot 2024-01-26 at 10 16 04 AM" src="https://github.com/highlight/highlight/assets/86132398/b19dc834-eb32-41ae-9526-28d16665d0eb">

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
