### PR TITLE
Fix the width of the traces column popover

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7418,6 +7418,17 @@ body {
 ._1rw9tha0 {
   border: none;
 }
+._1rw9tha1 {
+  width: 300px;
+}
+._1rw9tha2 {
+  line-height: 25px;
+  overflow: hidden;
+  width: 250px;
+}
+._1rw9tha3 {
+  overflow-wrap: break-word;
+}
 ._14l2j9r1 {
   font-size: 12px;
 }

--- a/frontend/src/__generated/ve/pages/Traces/CustomColumns/Popover/styles.css.js
+++ b/frontend/src/__generated/ve/pages/Traces/CustomColumns/Popover/styles.css.js
@@ -1,5 +1,11 @@
 // src/pages/Traces/CustomColumns/Popover/styles.css.ts
 var selectButton = "_1rw9tha0";
+var selectOption = "_1rw9tha2";
+var selectOptionTooltip = "_1rw9tha3";
+var selectPopover = "_1rw9tha1";
 export {
-  selectButton
+  selectButton,
+  selectOption,
+  selectOptionTooltip,
+  selectPopover
 };

--- a/frontend/src/pages/Traces/CustomColumns/Popover/index.tsx
+++ b/frontend/src/pages/Traces/CustomColumns/Popover/index.tsx
@@ -1,8 +1,11 @@
 import { useGetTracesKeysLazyQuery } from '@graph/hooks'
 import {
+	Box,
 	ComboboxSelect,
 	DEFAULT_TIME_PRESETS,
 	IconSolidDotsHorizontal,
+	Text,
+	Tooltip,
 } from '@highlight-run/ui/components'
 import { useDebouncedValue } from '@hooks/useDebouncedValue'
 import { useParams } from '@util/react-router/useParams'
@@ -111,18 +114,29 @@ export const CustomColumnPopover: React.FC<Props> = ({
 		? []
 		: columnOptions.map((o) => ({
 				key: o.id,
-				render: o.id,
+				render: (
+					<Tooltip
+						trigger={
+							<Text lines="1" cssClass={styles.selectOption}>
+								{o.id}
+							</Text>
+						}
+					>
+						<Box cssClass={styles.selectOptionTooltip}>{o.id}</Box>
+					</Tooltip>
+				),
 		  }))
 
 	return (
 		<ComboboxSelect
 			label="Selected columns"
-			queryPlaceholder="Search..."
+			queryPlaceholder="Search attributes..."
 			onChange={handleColumnValueChange}
 			icon={<IconSolidDotsHorizontal />}
 			value={value}
 			options={options}
 			cssClass={styles.selectButton}
+			popoverCssClass={styles.selectPopover}
 			onChangeQuery={setQuery}
 		/>
 	)

--- a/frontend/src/pages/Traces/CustomColumns/Popover/styles.css.ts
+++ b/frontend/src/pages/Traces/CustomColumns/Popover/styles.css.ts
@@ -1,5 +1,21 @@
 import { style } from '@vanilla-extract/css'
 
+const POPOVER_WIDTH = 300
+
 export const selectButton = style({
 	border: 'none',
+})
+
+export const selectPopover = style({
+	width: POPOVER_WIDTH,
+})
+
+export const selectOption = style({
+	lineHeight: '25px',
+	overflow: 'hidden',
+	width: POPOVER_WIDTH - 50,
+})
+
+export const selectOptionTooltip = style({
+	overflowWrap: 'break-word',
 })

--- a/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
@@ -34,6 +34,7 @@ type Props<T extends string | string[]> = {
 	onChangeQuery?: (value: string) => void
 	queryPlaceholder?: string
 	cssClass?: ClassValue | ClassValue[]
+	popoverCssClass?: ClassValue | ClassValue[]
 	creatableRender?: (key: string) => React.ReactNode | undefined
 	defaultOpen?: boolean
 	disabled?: boolean
@@ -50,6 +51,7 @@ export const ComboboxSelect = <T extends string | string[]>({
 	onChangeQuery,
 	queryPlaceholder,
 	cssClass,
+	popoverCssClass,
 	creatableRender,
 	defaultOpen,
 	disabled,
@@ -114,7 +116,7 @@ export const ComboboxSelect = <T extends string | string[]>({
 			</Select>
 			<SelectPopover
 				store={select}
-				className={styles.selectPopover}
+				className={clsx([styles.selectPopover, popoverCssClass])}
 				gutter={4}
 				autoFocusOnHide={false}
 			>


### PR DESCRIPTION
## Summary
The traces popover changes width based on the longest attribute name.
- fix the width to 300px
- hide any text that is more than the 300px width
- add a popover to show the full text

## How did you test this change?
![Screenshot 2024-01-26 at 1 48 57 PM](https://github.com/highlight/highlight/assets/17744174/7097f406-9531-4f63-b99b-3d3c59c6f463)
![Screenshot 2024-01-26 at 1 48 20 PM](https://github.com/highlight/highlight/assets/17744174/3b2693d8-dfa4-4e2e-875e-c185072c6b92)


## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
Sure