### PR TITLE
Fix duration renderer on traces

### DIFF
--- a/frontend/src/pages/Traces/CustomColumns/renderers.tsx
+++ b/frontend/src/pages/Traces/CustomColumns/renderers.tsx
@@ -155,7 +155,7 @@ const DurationRenderer: React.FC<ColumnRendererProps> = ({
 	first,
 }) => {
 	// currently receiving in ms
-	const duration = getTraceDurationString(getValue() * 1000)
+	const duration = getTraceDurationString(getValue())
 	return (
 		<ColumnWrapper first={first} row={row}>
 			<Text lines="1" title={duration}>


### PR DESCRIPTION
## Summary
Trace durations are being received as `ns` but being treated as `ms`

## How did you test this change?
1) View traces
2) Add duration column
- [ ] Correct duration length

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
