### PR TITLE
Fix sessions polling

### DIFF
--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -149,7 +149,7 @@ export const SessionFeedV3 = React.memo(() => {
 	const {
 		searchQuery,
 		setSearchQuery,
-		selectedSegment,
+		selectedPreset,
 		endDate,
 		page,
 		setPage,
@@ -233,7 +233,7 @@ export const SessionFeedV3 = React.memo(() => {
 			(result) => result?.data?.sessions_clickhouse.totalCount,
 			[],
 		),
-		skip: !selectedSegment,
+		skip: !selectedPreset,
 	})
 
 	// Used to determine if we need to show the loading skeleton.


### PR DESCRIPTION
## Summary
Typo - `selectedSegment` -> `selectedPreset` to start polling

## How did you test this change?
1) Load the sessions page and clear the filters
2) Start a new session in another window, and complete some actions
3) View the sessions page on the original window
- [ ] Session is polled
- [ ] Clicking to load more sessions shows the new session

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A