### PR TITLE
throttle rrweb logging

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -111,7 +111,6 @@ const options: HighlightOptions = {
 	},
 	enableSegmentIntegration: true,
 	enableCanvasRecording: true,
-	disableConsoleRecording: true,
 	samplingStrategy: {
 		canvas: 1,
 		canvasMaxSnapshotDimension: 480,

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -111,6 +111,7 @@ const options: HighlightOptions = {
 	},
 	enableSegmentIntegration: true,
 	enableCanvasRecording: true,
+	disableConsoleRecording: true,
 	samplingStrategy: {
 		canvas: 1,
 		canvasMaxSnapshotDimension: 480,

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -51,6 +51,7 @@ import analytics from '@util/analytics'
 import log from '@util/log'
 import { timedCall } from '@util/perf/instrument'
 import { H } from 'highlight.run'
+import { throttle } from 'lodash'
 import moment from 'moment/moment'
 import { MutableRefObject, SetStateAction } from 'react'
 
@@ -589,6 +590,10 @@ const initReplayer = (
 		liveMode: s.isLiveMode,
 		useVirtualDom: false,
 		pauseAnimation: !PROJECTS_WITH_CSS_ANIMATIONS.includes(s.project_id),
+		logger: {
+			log: throttle(console.log, 100),
+			warn: throttle(console.warn, 100),
+		},
 	})
 
 	s.browserExtensionScriptURLs = getBrowserExtensionScriptURLs(events)


### PR DESCRIPTION
## Summary

Per [customer thread](https://highlightcorp.slack.com/archives/C05DXNT5L8L/p1706318071001079), discovered that the rrweb `node not found` when a session is missing some data
(due to a broken data upload or rejected large message, which may not break the session) can cause the
browser to crash because of the number of logs emitted, even if the session is playable.

Throttle rrweb logging to fix the issue.

## How did you test this change?

[reflame preview](https://app.highlight.io/1419/sessions/yv7NCvVGKLpyKCuZO7GoFWZLEkeZ?page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue&%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HNBWQVKYD3WY6SAW28NPC2EJ%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Frrweb-update%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D) plays correctly at 56:13

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
