### PR TITLE
correct sessions report session overcounting

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5715,7 +5715,7 @@ func (r *queryResolver) SessionsReport(ctx context.Context, projectID int, query
 
 	q := fmt.Sprintf(`
 select coalesce(email.Value, nullif(IP, ''), device.Value, Identifier) as key,
-       count(*)                                                        as num_sessions,
+       count(distinct ID)                                              as num_sessions,
        count(distinct date_trunc('day', CreatedAt))                    as num_days_visited,
        count(distinct date_trunc('month', CreatedAt))                  as num_months_visited,
        avg(ActiveLength) / 1000 / 60                                   as avg_active_length_mins,


### PR DESCRIPTION
## Summary

Incorrect query resulted in over-counted sessions.

## How did you test this change?

correct number of sessions shown
![Screenshot from 2024-01-30 17-28-37](https://github.com/highlight/highlight/assets/1351531/8548ca7c-8e1f-4e43-b006-49a490316266)


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
