### PR TITLE
fix: network response payload display bugs

### DIFF
--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceInfo.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceInfo.tsx
@@ -158,46 +158,53 @@ export const NetworkResourceInfo = ({
 			try {
 				const parsedRequestBody = JSON.parse(request.body)
 
-				Object.keys(parsedRequestBody).forEach((key) => {
-					// `query` is a special for GraphQL requests.
-					// Check to see if the value for `query` is valid GraphQL, if so render it using a GraphQL formatter
-					if (key === 'query') {
-						const queryString = parsedRequestBody[key]
+				if (Array.isArray(parsedRequestBody)) {
+					requestPayloadData.push({
+						keyDisplayValue: 'json',
+						valueDisplayValue: parsedRequestBody,
+					})
+				} else {
+					Object.keys(parsedRequestBody).forEach((key) => {
+						// `query` is a special for GraphQL requests.
+						// Check to see if the value for `query` is valid GraphQL, if so render it using a GraphQL formatter
+						if (key === 'query') {
+							const queryString = parsedRequestBody[key]
 
-						requestPayloadData.push({
-							keyDisplayValue: key,
-							valueDisplayValue: (
-								<CodeBlock
-									language="graphql"
-									text={queryString}
-									wrapLines
-									wrapLongLines
-									hideCopy
-									customStyle={{
-										fontSize: '10px',
-									}}
-								/>
-							),
-							data: queryString,
-						})
-					} else {
-						const renderType =
-							typeof parsedRequestBody[key] === 'object'
-								? 'json'
-								: 'string'
-						requestPayloadData.push({
-							keyDisplayValue: key,
-							valueDisplayValue:
-								renderType === 'string'
-									? parsedRequestBody[key]?.toString()
-									: JSON.parse(
-											JSON.stringify(
-												parsedRequestBody[key],
-											),
-									  ),
-						})
-					}
-				})
+							requestPayloadData.push({
+								keyDisplayValue: key,
+								valueDisplayValue: (
+									<CodeBlock
+										language="graphql"
+										text={queryString}
+										wrapLines
+										wrapLongLines
+										hideCopy
+										customStyle={{
+											fontSize: '10px',
+										}}
+									/>
+								),
+								data: queryString,
+							})
+						} else {
+							const renderType =
+								typeof parsedRequestBody[key] === 'object'
+									? 'json'
+									: 'string'
+							requestPayloadData.push({
+								keyDisplayValue: key,
+								valueDisplayValue:
+									renderType === 'string'
+										? parsedRequestBody[key]?.toString()
+										: JSON.parse(
+												JSON.stringify(
+													parsedRequestBody[key],
+												),
+										  ),
+							})
+						}
+					})
+				}
 			} catch {
 				requestPayloadData.push({
 					keyDisplayValue: 'body',

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceInfo.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceInfo.tsx
@@ -232,20 +232,27 @@ export const NetworkResourceInfo = ({
 				} else {
 					parsedResponseBody = JSON.parse(response.body)
 				}
-				Object.keys(parsedResponseBody).forEach((key) => {
-					const renderType =
-						typeof parsedResponseBody[key] === 'object'
-							? 'json'
-							: 'string'
-
+				if (Array.isArray(parsedResponseBody)) {
 					responsePayloadData.push({
-						keyDisplayValue: key,
-						valueDisplayValue:
-							renderType === 'string'
-								? parsedResponseBody[key]?.toString()
-								: parsedResponseBody[key],
+						keyDisplayValue: 'json',
+						valueDisplayValue: parsedResponseBody,
 					})
-				})
+				} else {
+					Object.keys(parsedResponseBody).forEach((key) => {
+						const renderType =
+							typeof parsedResponseBody[key] === 'object'
+								? 'json'
+								: 'string'
+
+						responsePayloadData.push({
+							keyDisplayValue: key,
+							valueDisplayValue:
+								renderType === 'string'
+									? parsedResponseBody[key]?.toString()
+									: parsedResponseBody[key],
+						})
+					})
+				}
 			} catch (e) {
 				responsePayloadData.push({
 					keyDisplayValue: '-',


### PR DESCRIPTION
## Summary
Update Session Network Request View/Panel to show Array json payload together instead of splitting it down to
various objects. Did same for request and response payload

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
Check the network request payload (that is an array) under a session.
Observe that the formatting is as intended in the issue description.

For example that array payloads are shown as one ('json payload') instead of being broken down 
into separate objects and labeled by their index in the array.

## BEFORE: What was displayed for array - (The Bug)
<img width="481" alt="Screenshot 2024-01-31 at 3 50 23 PM" src="https://github.com/highlight/highlight/assets/119384208/6bf0817d-66dd-40f6-aaf0-23bd8903b031">


## AFTER: What we display.
<img width="480" alt="Screenshot 2024-01-31 at 3 59 47 PM" src="https://github.com/highlight/highlight/assets/119384208/a927417c-fb13-4548-9baf-ec6bfeefb3cb">
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
No
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
No
<!--
 Request review from julian-highlight / our design team 
-->
fixes #6267
/claim #6267
