### PR TITLE
Fix player right panel height

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6933,18 +6933,15 @@ body {
   max-height: calc(100vh - 160px - 32px - 42px - 32px - var(--header-height) - var(--banner-height));
 }
 .ltrwrc0 {
-  height: calc(100vh - 108px);
-}
-.ltrwrc1 {
   position: fixed;
   left: 100%;
   transform: translateX(300px);
 }
-.ltrwrc2 {
+.ltrwrc1 {
   height: 100%;
   padding: 0;
 }
-.ltrwrc3 {
+.ltrwrc2 {
   border-radius: 8px;
 }
 ._1l6nlco0 {

--- a/frontend/src/__generated/ve/pages/Player/RightPlayerPanel/style.css.js
+++ b/frontend/src/__generated/ve/pages/Player/RightPlayerPanel/style.css.js
@@ -1,12 +1,10 @@
 // src/pages/Player/RightPlayerPanel/style.css.ts
 var RIGHT_PANEL_WIDTH = 300;
-var playerRightColumn = "ltrwrc0";
-var playerRightPanelContainerHidden = "ltrwrc1";
-var tabContentContainer = "ltrwrc2";
-var tabs = "ltrwrc3";
+var playerRightPanelContainerHidden = "ltrwrc0";
+var tabContentContainer = "ltrwrc1";
+var tabs = "ltrwrc2";
 export {
   RIGHT_PANEL_WIDTH,
-  playerRightColumn,
   playerRightPanelContainerHidden,
   tabContentContainer,
   tabs

--- a/frontend/src/pages/Player/RightPlayerPanel/RightPlayerPanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/RightPlayerPanel.tsx
@@ -88,7 +88,7 @@ const RightPlayerPanel = () => {
 			flexShrink={0}
 			bt="dividerWeak"
 			bl="dividerWeak"
-			cssClass={clsx(style.playerRightColumn, {
+			cssClass={clsx({
 				[style.playerRightPanelContainerHidden]: !showRightPanel,
 			})}
 			overflowY="scroll"

--- a/frontend/src/pages/Player/RightPlayerPanel/style.css.ts
+++ b/frontend/src/pages/Player/RightPlayerPanel/style.css.ts
@@ -2,10 +2,6 @@ import { style } from '@vanilla-extract/css'
 
 export const RIGHT_PANEL_WIDTH = 300
 
-export const playerRightColumn = style({
-	height: `calc(100vh - 108px)`,
-})
-
 export const playerRightPanelContainerHidden = style({
 	position: 'fixed',
 	left: '100%',


### PR DESCRIPTION
## Summary

Fixes an issue with the right panel height being taller than it should and cutting off some of the UI.

https://www.loom.com/share/bc62b4d1bcd94ca39501678896646df8

## How did you test this change?

Local + PR preview click testing.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A