### PR TITLE
Next.js tutorial embeds

### DIFF
--- a/docs-content/getting-started/fullstack-frameworks/next-js/1_overview.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/1_overview.md
@@ -7,8 +7,8 @@ updatedAt: 2023-05-10T00:00:00.000Z
 ---
 
 <EmbeddedVideo 
-  src="https://www.youtube.com/embed/Dyoba16wE-o"
-  title="Youtube Video Player"
+  src="https://www.youtube.com/embed/hHj4_X7Etdw"
+  title="Next.js Introduction"
   allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
 />
 

--- a/docs-content/getting-started/fullstack-frameworks/next-js/2_page-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/2_page-router.md
@@ -12,12 +12,6 @@ updatedAt: 2023-10-03T00:00:00.000Z
   allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
 />
 
-<EmbeddedVideo 
-  src="https://www.youtube.com/embed/4xDCu5jSBxo"
-  title="Next.js API Endpoints"
-  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-/>
-
 ## Installation
 
 ```shell
@@ -257,6 +251,13 @@ export async function getStaticProps() {
 ```
 
 ## API route instrumentation
+
+
+<EmbeddedVideo 
+  src="https://www.youtube.com/embed/4xDCu5jSBxo"
+  title="Next.js API Endpoints"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+/>
 
 ```hint
 This section applies to Next.js Page Router routes only. Each Page Router route must be wrapped individually.

--- a/docs-content/getting-started/fullstack-frameworks/next-js/2_page-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/2_page-router.md
@@ -6,6 +6,17 @@ createdAt: 2023-10-03T00:00:00.000Z
 updatedAt: 2023-10-03T00:00:00.000Z
 ---
 
+<EmbeddedVideo 
+  src="https://www.youtube.com/embed/QJkjrIvJ-YI"
+  title="Page Route for Next.js"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+/>
+
+<EmbeddedVideo 
+  src="https://www.youtube.com/embed/4xDCu5jSBxo"
+  title="Next.js API Endpoints"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+/>
 
 ## Installation
 

--- a/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
@@ -13,12 +13,6 @@ updatedAt: 2023-10-03T00:00:00.000Z
   allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
 />
 
-<EmbeddedVideo 
-  src="https://www.youtube.com/embed/4xDCu5jSBxo"
-  title="Next.js API Endpoints"
-  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-/>
-
 ## Installation
 
 ```shell
@@ -291,6 +285,12 @@ export function CustomHighlightStart() {
 ```
 
 ## API route instrumentation
+
+<EmbeddedVideo 
+  src="https://www.youtube.com/embed/4xDCu5jSBxo"
+  title="Next.js API Endpoints"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+/>
 
 Node.js 
 

--- a/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
@@ -7,6 +7,18 @@ updatedAt: 2023-10-03T00:00:00.000Z
 ---
 
 
+<EmbeddedVideo 
+  src="https://www.youtube.com/embed/g6mhBMMVdU0"
+  title="App Router for Next.js"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+/>
+
+<EmbeddedVideo 
+  src="https://www.youtube.com/embed/4xDCu5jSBxo"
+  title="Next.js API Endpoints"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+/>
+
 ## Installation
 
 ```shell

--- a/docs-content/getting-started/fullstack-frameworks/next-js/6_edge-runtime.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/6_edge-runtime.md
@@ -6,6 +6,12 @@ createdAt: 2023-10-03T00:00:00.000Z
 updatedAt: 2023-10-03T00:00:00.000Z
 ---
 
+<EmbeddedVideo 
+  src="https://www.youtube.com/embed/4xDCu5jSBxo"
+  title="Next.js API Endpoints"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+/>
+
 ## Installation
 
 ```shell


### PR DESCRIPTION
I'm curious how everyone feels about this layout.

Originally we had a separate page for API wrappers, but now that those pages are all rolled into one, I've embedded the API Endpoints video in the Page Router, App Router, and Edge Runtime pages.

![image](https://github.com/highlight/highlight/assets/878947/5b6b8a05-2436-4bf4-bbc8-78158de990dc)

![image](https://github.com/highlight/highlight/assets/878947/a380a80c-9ca5-45ed-9721-eb3c3e51da67)

![image](https://github.com/highlight/highlight/assets/878947/9bd1d9cd-2378-4adb-acbf-9a6c1fca1c67)
