### PR TITLE
allow loading traces for publicly-shared sessions

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1036,7 +1036,7 @@ type ComplexityRoot struct {
 		SystemConfiguration              func(childComplexity int) int
 		TimelineIndicatorEvents          func(childComplexity int, sessionSecureID string) int
 		TopUsers                         func(childComplexity int, projectID int, lookbackDays float64) int
-		Trace                            func(childComplexity int, projectID int, traceID string) int
+		Trace                            func(childComplexity int, projectID int, traceID string, sessionSecureID *string) int
 		Traces                           func(childComplexity int, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection) int
 		TracesIntegration                func(childComplexity int, projectID int) int
 		TracesKeyValues                  func(childComplexity int, projectID int, keyName string, dateRange model.DateRangeRequiredInput) int
@@ -1855,7 +1855,7 @@ type QueryResolver interface {
 	ErrorTags(ctx context.Context) ([]*model1.ErrorTag, error)
 	MatchErrorTag(ctx context.Context, query string) ([]*model.MatchedErrorTag, error)
 	FindSimilarErrors(ctx context.Context, query string) ([]*model1.MatchedErrorObject, error)
-	Trace(ctx context.Context, projectID int, traceID string) (*model.TracePayload, error)
+	Trace(ctx context.Context, projectID int, traceID string, sessionSecureID *string) (*model.TracePayload, error)
 	Traces(ctx context.Context, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection) (*model.TraceConnection, error)
 	TracesMetrics(ctx context.Context, projectID int, params model.QueryInput, column string, metricTypes []model.MetricAggregator, groupBy []string, bucketBy *string, bucketCount *int, limit *int, limitAggregator *model.MetricAggregator, limitColumn *string) (*model.MetricsBuckets, error)
 	TracesKeys(ctx context.Context, projectID int, dateRange model.DateRangeRequiredInput, query *string, typeArg *model.KeyType) ([]*model.QueryKey, error)
@@ -7920,7 +7920,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Trace(childComplexity, args["project_id"].(int), args["trace_id"].(string)), true
+		return e.complexity.Query.Trace(childComplexity, args["project_id"].(int), args["trace_id"].(string), args["session_secure_id"].(*string)), true
 
 	case "Query.traces":
 		if e.complexity.Query.Traces == nil {
@@ -12727,7 +12727,7 @@ type Query {
 	error_tags: [ErrorTag]
 	match_error_tag(query: String!): [MatchedErrorTag]
 	find_similar_errors(query: String!): [MatchedErrorObject]
-	trace(project_id: ID!, trace_id: String!): TracePayload
+	trace(project_id: ID!, trace_id: String!, session_secure_id: String): TracePayload
 	traces(
 		project_id: ID!
 		params: QueryInput!
@@ -19539,6 +19539,15 @@ func (ec *executionContext) field_Query_trace_args(ctx context.Context, rawArgs 
 		}
 	}
 	args["trace_id"] = arg1
+	var arg2 *string
+	if tmp, ok := rawArgs["session_secure_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_secure_id"))
+		arg2, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["session_secure_id"] = arg2
 	return args, nil
 }
 
@@ -57671,7 +57680,7 @@ func (ec *executionContext) _Query_trace(ctx context.Context, field graphql.Coll
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Trace(rctx, fc.Args["project_id"].(int), fc.Args["trace_id"].(string))
+		return ec.resolvers.Query().Trace(rctx, fc.Args["project_id"].(int), fc.Args["trace_id"].(string), fc.Args["session_secure_id"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -12727,7 +12727,11 @@ type Query {
 	error_tags: [ErrorTag]
 	match_error_tag(query: String!): [MatchedErrorTag]
 	find_similar_errors(query: String!): [MatchedErrorObject]
-	trace(project_id: ID!, trace_id: String!, session_secure_id: String): TracePayload
+	trace(
+		project_id: ID!
+		trace_id: String!
+		session_secure_id: String
+	): TracePayload
 	traces(
 		project_id: ID!
 		params: QueryInput!

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2088,7 +2088,11 @@ type Query {
 	error_tags: [ErrorTag]
 	match_error_tag(query: String!): [MatchedErrorTag]
 	find_similar_errors(query: String!): [MatchedErrorObject]
-	trace(project_id: ID!, trace_id: String!): TracePayload
+	trace(
+		project_id: ID!
+		trace_id: String!
+		session_secure_id: String
+	): TracePayload
 	traces(
 		project_id: ID!
 		params: QueryInput!

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -14512,8 +14512,16 @@ export type FindSimilarErrorsQueryResult = Apollo.QueryResult<
 	Types.FindSimilarErrorsQueryVariables
 >
 export const GetTraceDocument = gql`
-	query GetTrace($project_id: ID!, $trace_id: String!) {
-		trace(project_id: $project_id, trace_id: $trace_id) {
+	query GetTrace(
+		$project_id: ID!
+		$trace_id: String!
+		$session_secure_id: String
+	) {
+		trace(
+			project_id: $project_id
+			trace_id: $trace_id
+			session_secure_id: $session_secure_id
+		) {
 			trace {
 				timestamp
 				traceID
@@ -14562,6 +14570,7 @@ export const GetTraceDocument = gql`
  *   variables: {
  *      project_id: // value for 'project_id'
  *      trace_id: // value for 'trace_id'
+ *      session_secure_id: // value for 'session_secure_id'
  *   },
  * });
  */

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4831,6 +4831,7 @@ export type FindSimilarErrorsQuery = { __typename?: 'Query' } & {
 export type GetTraceQueryVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	trace_id: Types.Scalars['String']
+	session_secure_id?: Types.Maybe<Types.Scalars['String']>
 }>
 
 export type GetTraceQuery = { __typename?: 'Query' } & {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2592,6 +2592,7 @@ export type QueryTopUsersArgs = {
 
 export type QueryTraceArgs = {
 	project_id: Scalars['ID']
+	session_secure_id?: InputMaybe<Scalars['String']>
 	trace_id: Scalars['String']
 }
 

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2375,8 +2375,16 @@ query FindSimilarErrors($query: String!) {
 	}
 }
 
-query GetTrace($project_id: ID!, $trace_id: String!) {
-	trace(project_id: $project_id, trace_id: $trace_id) {
+query GetTrace(
+	$project_id: ID!
+	$trace_id: String!
+	$session_secure_id: String
+) {
+	trace(
+		project_id: $project_id
+		trace_id: $trace_id
+		session_secure_id: $session_secure_id
+	) {
 		trace {
 			timestamp
 			traceID

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
@@ -54,6 +54,7 @@ export const NetworkResourcePanel = () => {
 	const { activeNetworkResourceId, setActiveNetworkResourceId } =
 		useActiveNetworkResourceId()
 
+	const { session } = useReplayerContext()
 	const { resources } = useResourcesContext()
 	const resourceIdx = resources.findIndex(
 		(r) => activeNetworkResourceId === r.id,
@@ -126,7 +127,11 @@ export const NetworkResourcePanel = () => {
 				(resource.initiatorType === 'websocket' ? (
 					<WebSocketDetails resource={resource} hide={hide} />
 				) : (
-					<TraceProvider projectId={projectId} traceId={traceId}>
+					<TraceProvider
+						projectId={projectId}
+						traceId={traceId}
+						session_secure_id={session?.secure_id}
+					>
 						<NetworkResourceDetails
 							resource={resource}
 							hide={hide}

--- a/frontend/src/pages/Traces/TraceProvider.tsx
+++ b/frontend/src/pages/Traces/TraceProvider.tsx
@@ -33,6 +33,7 @@ export const TraceContext = createContext<TraceContext>({} as TraceContext)
 type Props = {
 	projectId: string
 	traceId?: string
+	session_secure_id?: string
 	spanId?: string
 }
 
@@ -40,6 +41,7 @@ export const TraceProvider: React.FC<React.PropsWithChildren<Props>> = ({
 	children,
 	projectId,
 	traceId,
+	session_secure_id,
 	spanId,
 }) => {
 	const [hoveredSpan, setHoveredSpan] = useState<FlameGraphSpan>()
@@ -50,6 +52,7 @@ export const TraceProvider: React.FC<React.PropsWithChildren<Props>> = ({
 		variables: {
 			project_id: projectId!,
 			trace_id: traceId!,
+			session_secure_id,
 		},
 		onCompleted: (data) => {
 			if (spanId) {


### PR DESCRIPTION
## Summary

Our ShowHN links a [session](https://app.highlight.io/1383/sessions/COu90Th4Qc3PVYTXbx9Xee7xbQqN?network-resource-id=25&page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue&ts=5.243) that has a flame graph,
but the flame graph does not load despite the session being public.
Update the Trace resolver to consider whether the session is public when loading data.

## How did you test this change?

Local deploy

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
