### PR TITLE
fix ingest graphs, ignore column if count metric is used

### DIFF
--- a/frontend/src/pages/ProjectSettings/ProjectFilters/ProjectFilters.tsx
+++ b/frontend/src/pages/ProjectSettings/ProjectFilters/ProjectFilters.tsx
@@ -730,7 +730,8 @@ const IngestTimeline: React.FC<{
 					(100 *
 						(groupedByBucket[b.bucket_id][0]?.metric_value ?? 0)) /
 					((groupedByBucket[b.bucket_id][0]?.metric_value ?? 0) +
-						(groupedByBucket[b.bucket_id][1]?.metric_value ?? 0)),
+						(groupedByBucket[b.bucket_id][1]?.metric_value ?? 0) ||
+						1),
 				unit: '%',
 			},
 		],


### PR DESCRIPTION
## Summary
- fixes graphs shown on ingest filters page
- fixes "count" query if a metric is provided by ignoring that metric
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested ingest page + grafana
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
