### PR TITLE
fix trace panic when span does not exist in traces_by_id

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7928,7 +7928,7 @@ func (r *queryResolver) Trace(ctx context.Context, projectID int, traceID string
 		return nil, err
 	}
 
-	traceStartTime := trace[0].Timestamp
+	traceStartTime := time.Now()
 	for _, span := range trace {
 		if span.Timestamp.Before(traceStartTime) {
 			traceStartTime = span.Timestamp


### PR DESCRIPTION
## Summary

Fixes panic mentioned in HIG-4284 when loading a trace that is not yet in `traces_by_id`.

## How did you test this change?

CI

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No