### PR TITLE
Show trace even if no root span

### DIFF
--- a/frontend/src/pages/Traces/utils.ts
+++ b/frontend/src/pages/Traces/utils.ts
@@ -3,7 +3,14 @@ import moment from 'moment'
 import { Trace } from '@/graph/generated/schemas'
 
 export const getFirstSpan = (trace: Trace[]) => {
-	return trace.find((span) => !span.parentSpanID)
+	const rootSpans = trace.filter((span) => !span.parentSpanID)
+	const spans = rootSpans.length > 0 ? rootSpans : trace
+	const sortedTrace = spans.sort(
+		(a, b) =>
+			new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+	)
+
+	return sortedTrace[0]
 }
 
 // Returns the trace duration in nanoseconds
@@ -101,6 +108,10 @@ export const organizeSpansForFlameGraph = (
 ) => {
 	const rootSpans = trace.filter((span) => !span.parentSpanID)
 	const spans = [[]]
+
+	if (rootSpans.length === 0) {
+		rootSpans.push(getFirstSpan(trace as Trace[]))
+	}
 
 	rootSpans.forEach((rootSpan) =>
 		organizeSpanInLevel(rootSpan!, trace, spans, 0),


### PR DESCRIPTION
## Summary

Falls back to a span in a trace even if there is no root span. This makes it possible to render a trace even if the root span isn't available, which we've noticed happening because of issues with our sampling logic.

## How did you test this change?

Local + PR preview click test. I viewed [a problematic trace](https://app.highlight.io/1/traces/84964c51a1df8e9ae344b60dbd5ddeeb/c78b971eb0bcb4ac) in prod and in the PR preview to ensure it was working as expected.

<img width="670" alt="Screenshot 2024-02-02 at 2 06 49 PM" src="https://github.com/highlight/highlight/assets/308182/f82b5eb2-23b6-4a2f-84f7-d52128d3a805">

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A