### PR TITLE
Make header of trace panel fixed to top

### DIFF
--- a/frontend/src/__generated/ve/pages/Traces/TracePanel.css.js
+++ b/frontend/src/__generated/ve/pages/Traces/TracePanel.css.js
@@ -1,5 +1,5 @@
 // src/pages/Traces/TracePanel.css.ts
-var dialog = "_12wekn71 mt0ih29o mt0ih220 mt0ih2t0 mt0ih2fq mt0ih2c mt0ih2n8 mt0ih28s";
+var dialog = "_12wekn71 mt0ih29o mt0ih220 mt0ih2t0 mt0ih2fq mt0ih2c mt0ih2n8 mt0ih28q";
 export {
   dialog
 };

--- a/frontend/src/pages/Traces/TracePage.tsx
+++ b/frontend/src/pages/Traces/TracePage.tsx
@@ -53,7 +53,7 @@ export const TracePage: React.FC = () => {
 	}
 
 	return (
-		<Box cssClass={styles.container}>
+		<Box cssClass={styles.container} overflowY="scroll">
 			<Stack direction="column" gap="12" pt="16" pb="12" px="20">
 				<Heading level="h4">{traceName}</Heading>
 				<Stack gap="4" direction="row">

--- a/frontend/src/pages/Traces/TracePanel.css.ts
+++ b/frontend/src/pages/Traces/TracePanel.css.ts
@@ -9,7 +9,7 @@ export const dialog = style([
 		border: 'dividerWeak',
 		borderRadius: '6',
 		boxShadow: 'small',
-		overflow: 'scroll',
+		overflow: 'hidden',
 	}),
 	{
 		width: '45%',


### PR DESCRIPTION
## Summary

Makes the header of the trace details panel stick to the top rather than scroll with the main content.

**Before**
<img width="617" alt="Screenshot 2024-02-05 at 2 51 12 PM" src="https://github.com/highlight/highlight/assets/308182/e88e03a4-0cfc-4d5a-b77a-976ddd2ff763">

**After**
<img width="618" alt="Screenshot 2024-02-05 at 2 50 09 PM" src="https://github.com/highlight/highlight/assets/308182/5880ea59-f612-4658-b67d-1ccda898d50f">

## How did you test this change?

Local + PR preview click test.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

No - this change was requested by the @julian-highlight himself!
