### PR TITLE
use ReplacingMergeTree for logs engine

### DIFF
--- a/backend/clickhouse/migrations/000077_create_logs_replacing_merge_tree.down.sql
+++ b/backend/clickhouse/migrations/000077_create_logs_replacing_merge_tree.down.sql
@@ -1,0 +1,3 @@
+EXCHANGE TABLES logs
+AND logs_new;
+DROP TABLE IF EXISTS logs_new;

--- a/backend/clickhouse/migrations/000077_create_logs_replacing_merge_tree.up.sql
+++ b/backend/clickhouse/migrations/000077_create_logs_replacing_merge_tree.up.sql
@@ -2,5 +2,73 @@ CREATE TABLE IF NOT EXISTS logs_new AS logs ENGINE = ReplacingMergeTree PARTITIO
 ORDER BY (ProjectId, Timestamp, UUID) TTL Timestamp + toIntervalDay(30) SETTINGS ttl_only_drop_parts = 1,
     index_granularity = 8192,
     min_age_to_force_merge_seconds = 3600;
+alter table logs_new attach partition '20240104'
+from logs;
+alter table logs_new attach partition '20240105'
+from logs;
+alter table logs_new attach partition '20240106'
+from logs;
+alter table logs_new attach partition '20240107'
+from logs;
+alter table logs_new attach partition '20240108'
+from logs;
+alter table logs_new attach partition '20240109'
+from logs;
+alter table logs_new attach partition '20240110'
+from logs;
+alter table logs_new attach partition '20240111'
+from logs;
+alter table logs_new attach partition '20240112'
+from logs;
+alter table logs_new attach partition '20240113'
+from logs;
+alter table logs_new attach partition '20240114'
+from logs;
+alter table logs_new attach partition '20240115'
+from logs;
+alter table logs_new attach partition '20240116'
+from logs;
+alter table logs_new attach partition '20240117'
+from logs;
+alter table logs_new attach partition '20240118'
+from logs;
+alter table logs_new attach partition '20240119'
+from logs;
+alter table logs_new attach partition '20240120'
+from logs;
+alter table logs_new attach partition '20240121'
+from logs;
+alter table logs_new attach partition '20240122'
+from logs;
+alter table logs_new attach partition '20240123'
+from logs;
+alter table logs_new attach partition '20240124'
+from logs;
+alter table logs_new attach partition '20240125'
+from logs;
+alter table logs_new attach partition '20240126'
+from logs;
+alter table logs_new attach partition '20240127'
+from logs;
+alter table logs_new attach partition '20240128'
+from logs;
+alter table logs_new attach partition '20240129'
+from logs;
+alter table logs_new attach partition '20240130'
+from logs;
+alter table logs_new attach partition '20240131'
+from logs;
+alter table logs_new attach partition '20240201'
+from logs;
+alter table logs_new attach partition '20240202'
+from logs;
+alter table logs_new attach partition '20240203'
+from logs;
+alter table logs_new attach partition '20240204'
+from logs;
+alter table logs_new attach partition '20240205'
+from logs;
+alter table logs_new attach partition '20240206'
+from logs;
 EXCHANGE TABLES logs
 AND logs_new;

--- a/backend/clickhouse/migrations/000077_create_logs_replacing_merge_tree.up.sql
+++ b/backend/clickhouse/migrations/000077_create_logs_replacing_merge_tree.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS logs_new AS logs ENGINE = ReplacingMergeTree PARTITION BY toDate(Timestamp)
+ORDER BY (ProjectId, Timestamp, UUID) TTL Timestamp + toIntervalDay(30) SETTINGS ttl_only_drop_parts = 1,
+    index_granularity = 8192,
+    min_age_to_force_merge_seconds = 3600;
+EXCHANGE TABLES logs
+AND logs_new;


### PR DESCRIPTION
## Summary
- creates a separate logs_new table using a ReplacingMergeTree for deduplication
- attaches all partitions of logs to logs_new
- exchanges the table names
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran migration locally
- made sure dropping the old table after exchanging doesn't affect the new table
- confirmed queries against the new table were being deduplicated with FINAL
- confirmed data was being ingested and dependent materialized views were correctly updated
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- once this is approved, will temporarily disable the public workers and run these scripts manually against prod
- scripts should complete very quickly (< 5s), after which we can restart the public workers
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
