### PR TITLE
Update error instance padding

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6270,7 +6270,7 @@ body {
 }
 .ofc9fn3 {
   display: inline-block;
-  text-align: center;
+  text-align: right;
   width: 46px;
 }
 .ofc9fn4 {

--- a/frontend/src/pages/ErrorsV2/ErrorBody/ErrorBody.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorBody/ErrorBody.tsx
@@ -161,7 +161,7 @@ const Stat: React.FC<
 		<Box
 			display="flex"
 			flexDirection="column"
-			gap="12"
+			gap="6"
 			justifyContent="space-between"
 			style={{ height: '100%' }}
 		>

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -154,9 +154,9 @@ export const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 				</Stack>
 			</Stack>
 
-			<Box py="16" px="16" mb="40" border="secondary" borderRadius="8">
+			<Box py="12" px="16" mb="40" border="secondary" borderRadius="8">
 				<Box
-					mb="20"
+					mb="8"
 					display="flex"
 					gap="6"
 					alignItems="center"

--- a/frontend/src/pages/ErrorsV2/ErrorSourcePreview/ErrorSourcePreview.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorSourcePreview/ErrorSourcePreview.tsx
@@ -36,7 +36,6 @@ const LANGUAGE_MAP: { [K in string]: string } = {
 
 const baseLineStyles = {
 	display: 'block',
-	padding: '0 12px',
 }
 
 const ErrorSourcePreview: React.FC<
@@ -93,7 +92,7 @@ const ErrorSourcePreview: React.FC<
 				fontSize: 13,
 				fontWeight: 500,
 				lineHeight: 20,
-				margin: 0,
+				margin: '0 0',
 			}}
 			lineProps={(ln) => {
 				return ln === lineNumber

--- a/frontend/src/pages/ErrorsV2/ErrorSourcePreview/ErrorSourcePreview.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorSourcePreview/ErrorSourcePreview.tsx
@@ -92,7 +92,7 @@ const ErrorSourcePreview: React.FC<
 				fontSize: 13,
 				fontWeight: 500,
 				lineHeight: 20,
-				margin: '0 0',
+				margin: '0 0 0 0',
 			}}
 			lineProps={(ln) => {
 				return ln === lineNumber

--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.css.ts
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.css.ts
@@ -23,7 +23,7 @@ export const collapsibleContent = recipe({
 
 export const lineNumber = style({
 	display: 'inline-block',
-	textAlign: 'center',
+	textAlign: 'right',
 	width: 46,
 })
 

--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -284,6 +284,7 @@ const StackSection: React.FC<React.PropsWithChildren<StackSectionProps>> = ({
 			display="flex"
 			justifyContent="space-between"
 			alignItems="center"
+			style={{ height: '36px' }}
 		>
 			<Box display="flex" gap="4" alignItems="center">
 				{fileName && (
@@ -323,7 +324,7 @@ const StackSection: React.FC<React.PropsWithChildren<StackSectionProps>> = ({
 						to={externalLink}
 						target="_blank"
 						trackingId="stacktrace-external-link-click"
-						size="small"
+						size="xSmall"
 					>
 						<IconSolidExternalLink size={16} />
 					</LinkButton>

--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -224,7 +224,7 @@ const StackSection: React.FC<React.PropsWithChildren<StackSectionProps>> = ({
 	}
 
 	const trigger = (
-		<Box p="12" backgroundColor="n2">
+		<Box py="4" backgroundColor="n2">
 			{!!lineContent ? (
 				<ErrorSourcePreview
 					fileName={fileName}


### PR DESCRIPTION
## Summary
Theres a few places where we could make the layouts be more compact. 

Examples:
- Distance in between 'Instance Title' & 'Instance Body' is much bigger than in the designs
- Distance in between error group data (the squares on top) & their respective title is bigger than in the designs
- Our Stacktrace is using weird paddings both on the headers as well as on the trace content. Make sure that all headers have the same height, while the trace content should be as compact as seen in the designs

## How did you test this change?
1) Load the error page and select an error

![Screenshot 2024-02-05 at 12 08 46 PM](https://github.com/highlight/highlight/assets/17744174/c742cb97-7049-4ad4-acf2-bc696c84ded1)

2) Open a stacktrace

![Screenshot 2024-02-05 at 1 09 48 PM](https://github.com/highlight/highlight/assets/17744174/ca195dba-ecba-40b9-8204-2e98121182c6)

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
Sure
