### PR TITLE
fix session player dev tools level and source filters

### DIFF
--- a/frontend/src/pages/LogsPage/utils.ts
+++ b/frontend/src/pages/LogsPage/utils.ts
@@ -108,13 +108,16 @@ export const buildSessionParams = ({
 		query += `${ReservedLogKey.SecureSessionId}${DEFAULT_OPERATOR}${session.secure_id}`
 	}
 
-	levels.forEach((level) => {
-		query += ` ${ReservedLogKey.Level}${DEFAULT_OPERATOR}${level}`
-	})
-
-	sources.forEach((source) => {
-		query += ` ${ReservedLogKey.Source}${DEFAULT_OPERATOR}${source}`
-	})
+	if (levels.length) {
+		query += ` ${ReservedLogKey.Level}${DEFAULT_OPERATOR}(${levels.join(
+			' OR ',
+		)})`
+	}
+	if (sources.length) {
+		query += ` ${ReservedLogKey.Source}${DEFAULT_OPERATOR}(${sources.join(
+			' OR ',
+		)})`
+	}
 
 	return {
 		query: query.trim(),

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -25,7 +25,6 @@ import {
 } from '@pages/Player/Toolbar/DevToolsWindowV2/ResizePanel'
 import {
 	LogLevelValue,
-	LogSourceValue,
 	RequestStatus,
 	RequestType,
 	Tab,
@@ -74,17 +73,14 @@ const DevToolsWindowV2: React.FC<
 	const [levels, setLevels] = React.useState<LogLevelValue[]>([
 		LogLevelValue.All,
 	])
-	const [sources, setSources] = React.useState<LogSourceValue[]>(
-		logCursor ? [] : [LogSourceValue.Frontend],
+	const [sources, setSources] = React.useState<LogSource[]>(
+		logCursor ? [] : [LogSource.Frontend],
 	)
 
 	// filter out All values to send to via request
 	const relevantLevelsForRequest = levels.filter(
 		(level) => level !== LogLevelValue.All,
 	) as unknown as LogLevel[]
-	const relevantSourcesForRequest = sources.filter(
-		(level) => level !== LogSourceValue.All,
-	) as unknown as LogSource[]
 
 	const formStore = useFormStore({
 		defaultValues: {
@@ -197,7 +193,7 @@ const DevToolsWindowV2: React.FC<
 											autoScroll={autoScroll}
 											logCursor={logCursor}
 											levels={relevantLevelsForRequest}
-											sources={relevantSourcesForRequest}
+											sources={sources}
 											filter={filter}
 										/>
 									),
@@ -328,8 +324,7 @@ const DevToolsWindowV2: React.FC<
 													projectId,
 													session,
 													levels: relevantLevelsForRequest,
-													sources:
-														relevantSourcesForRequest,
+													sources,
 												})}
 												target="_blank"
 												style={{ display: 'flex' }}

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/LogSourceFilter/LogSourceFilter.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/LogSourceFilter/LogSourceFilter.tsx
@@ -1,62 +1,43 @@
+import { LogSource } from '@graph/schemas'
 import {
 	Box,
 	IconSolidFilter,
 	MultiSelectButton,
 } from '@highlight-run/ui/components'
-import {
-	LogSourceValue,
-	titilize,
-} from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
+import { titilize } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import React from 'react'
 
 type Props = {
-	logSources: LogSourceValue[]
-	setLogSources: (values: LogSourceValue[]) => void
+	logSources: LogSource[]
+	setLogSources: (values: LogSource[]) => void
 }
 
 const FILTER_LABEL = 'Source'
 
 const LogSourceFilter = ({ logSources, setLogSources }: Props) => {
 	const handleRequestTypeChange = (valueNames: string[]) => {
-		const allPreviouslySelected = logSources.includes(LogSourceValue.All)
-		const allCurrentlySelected = valueNames.includes(LogSourceValue.All)
-		const clearOtherTypes = !allPreviouslySelected && allCurrentlySelected
-		const deselectAllType = allPreviouslySelected && valueNames.length > 1
-
-		if (!valueNames.length || clearOtherTypes) {
-			return setLogSources([LogSourceValue.All])
+		if (!valueNames.length) {
+			return setLogSources(logSources)
 		}
 
-		//-- Set type to be the logLevel value --//
-		const updatedLogSources = valueNames.filter(
-			(name) => !deselectAllType || name !== LogSourceValue.All,
-		) as LogSourceValue[]
-
-		setLogSources(updatedLogSources)
+		setLogSources(valueNames as LogSource[])
 	}
 
-	const options = Object.entries(LogSourceValue).map(
-		([logKey, logValue]) => ({
-			key: logValue,
-			clearsOnClick: logKey === LogSourceValue.All,
-			render: (
-				<Box
-					display="flex"
-					justifyContent="space-between"
-					width="full"
-					gap="8"
-				>
-					<span>{logKey}</span>
-				</Box>
-			),
-		}),
-	)
+	const options = Object.entries(LogSource).map(([logKey, logValue]) => ({
+		key: logValue,
+		render: (
+			<Box
+				display="flex"
+				justifyContent="space-between"
+				width="full"
+				gap="8"
+			>
+				<span>{logKey}</span>
+			</Box>
+		),
+	}))
 
 	const valueRender = () => {
-		if (logSources.includes(LogSourceValue.All)) {
-			return FILTER_LABEL
-		}
-
 		if (logSources.length === 1) {
 			return `${FILTER_LABEL}: ${titilize(logSources[0])}`
 		}

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -109,13 +109,6 @@ export enum LogLevelValue {
 	Warn = 'warn',
 }
 
-export enum LogSourceValue {
-	All = 'All',
-	// keep up to date with LogSource schema
-	Backend = 'backend',
-	Frontend = 'frontend',
-}
-
 export enum RequestType {
 	/* [displayName]: requestName */
 	All = 'All',


### PR DESCRIPTION
## Summary

Player dev tools level and source filters would apply an `AND` filter on multiple options which would never show results.
Removing `all` setting for sources as well as I've heard from customers that this causes confusion (and isn't really useful for the 2 sources we have).

## How did you test this change?

![Screenshot from 2024-02-05 12-06-30](https://github.com/highlight/highlight/assets/1351531/22b45dfa-05ab-4b58-a814-2b939cfaa516)

https://www.loom.com/share/88557d411054490fa5c3b2f41b918ee0

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no