### PR TITLE
Logs: add link to related trace

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -263,7 +263,6 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						logRow := clickhouse.NewLogRow(
 							fields.timestamp, uint32(fields.projectIDInt),
 							clickhouse.WithTraceID(traceID),
-							clickhouse.WithSpanID(spanID),
 							clickhouse.WithSecureSessionID(fields.sessionID),
 							clickhouse.WithBody(ctx, fields.logMessage),
 							clickhouse.WithLogAttributes(fields.attrs),
@@ -437,7 +436,6 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 				logRow := clickhouse.NewLogRow(
 					fields.timestamp, uint32(fields.projectIDInt),
 					clickhouse.WithTraceID(logRecord.TraceID().String()),
-					clickhouse.WithSpanID(logRecord.SpanID().String()),
 					clickhouse.WithSecureSessionID(fields.sessionID),
 					clickhouse.WithBody(ctx, fields.logBody),
 					clickhouse.WithLogAttributes(fields.attrs),

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -955,6 +955,7 @@ type ComplexityRoot struct {
 		EventChunkURL                    func(childComplexity int, secureID string, index int) int
 		EventChunks                      func(childComplexity int, secureID string) int
 		Events                           func(childComplexity int, sessionSecureID string) int
+		ExistingLogsTraces               func(childComplexity int, projectID int, traceIds []string) int
 		FieldSuggestion                  func(childComplexity int, projectID int, name string, query string) int
 		FieldTypesClickhouse             func(childComplexity int, projectID int, startDate time.Time, endDate time.Time) int
 		FieldsClickhouse                 func(childComplexity int, projectID int, count int, fieldType string, fieldName string, query string, startDate time.Time, endDate time.Time) int
@@ -1849,6 +1850,7 @@ type QueryResolver interface {
 	LogsKeys(ctx context.Context, projectID int, dateRange model.DateRangeRequiredInput, query *string, typeArg *model.KeyType) ([]*model.QueryKey, error)
 	LogsKeyValues(ctx context.Context, projectID int, keyName string, dateRange model.DateRangeRequiredInput) ([]string, error)
 	LogsErrorObjects(ctx context.Context, logCursors []string) ([]*model1.ErrorObject, error)
+	ExistingLogsTraces(ctx context.Context, projectID int, traceIds []string) ([]string, error)
 	ErrorResolutionSuggestion(ctx context.Context, errorObjectID int) (string, error)
 	SessionInsight(ctx context.Context, secureID string) (*model1.SessionInsight, error)
 	SessionExports(ctx context.Context, projectID int) ([]*model.SessionExportWithSession, error)
@@ -6960,6 +6962,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Events(childComplexity, args["session_secure_id"].(string)), true
+
+	case "Query.existing_logs_traces":
+		if e.complexity.Query.ExistingLogsTraces == nil {
+			break
+		}
+
+		args, err := ec.field_Query_existing_logs_traces_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.ExistingLogsTraces(childComplexity, args["project_id"].(int), args["trace_ids"].([]string)), true
 
 	case "Query.field_suggestion":
 		if e.complexity.Query.FieldSuggestion == nil {
@@ -12736,6 +12750,7 @@ type Query {
 		date_range: DateRangeRequiredInput!
 	): [String!]!
 	logs_error_objects(log_cursors: [String!]!): [ErrorObject!]!
+	existing_logs_traces(project_id: ID!, trace_ids: [String!]!): [String!]!
 	error_resolution_suggestion(error_object_id: ID!): String!
 	session_insight(secure_id: String!): SessionInsight
 	session_exports(project_id: ID!): [SessionExportWithSession!]!
@@ -17678,6 +17693,30 @@ func (ec *executionContext) field_Query_events_args(ctx context.Context, rawArgs
 		}
 	}
 	args["session_secure_id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_existing_logs_traces_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 []string
+	if tmp, ok := rawArgs["trace_ids"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("trace_ids"))
+		arg1, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["trace_ids"] = arg1
 	return args, nil
 }
 
@@ -57238,6 +57277,60 @@ func (ec *executionContext) fieldContext_Query_logs_error_objects(ctx context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_existing_logs_traces(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_existing_logs_traces(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ExistingLogsTraces(rctx, fc.Args["project_id"].(int), fc.Args["trace_ids"].([]string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_existing_logs_traces(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_existing_logs_traces_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_error_resolution_suggestion(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_error_resolution_suggestion(ctx, field)
 	if err != nil {
@@ -85436,6 +85529,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_logs_error_objects(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "existing_logs_traces":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_existing_logs_traces(ctx, field)
 				return res
 			}
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2075,6 +2075,7 @@ type Query {
 		date_range: DateRangeRequiredInput!
 	): [String!]!
 	logs_error_objects(log_cursors: [String!]!): [ErrorObject!]!
+	existing_logs_traces(project_id: ID!, trace_ids: [String!]!): [String!]!
 	error_resolution_suggestion(error_object_id: ID!): String!
 	session_insight(secure_id: String!): SessionInsight
 	session_exports(project_id: ID!): [SessionExportWithSession!]!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7796,6 +7796,16 @@ func (r *queryResolver) LogsErrorObjects(ctx context.Context, logCursors []strin
 	return errorObjects, nil
 }
 
+// ExistingLogsTraces is the resolver for the existing_logs_traces field.
+func (r *queryResolver) ExistingLogsTraces(ctx context.Context, projectID int, traceIds []string) ([]string, error) {
+	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.ClickhouseClient.ExistingTraceIds(ctx, project.ID, traceIds)
+}
+
 // ErrorResolutionSuggestion is the resolver for the error_resolution_suggestion field.
 func (r *queryResolver) ErrorResolutionSuggestion(ctx context.Context, errorObjectID int) (string, error) {
 	apiKey := os.Getenv("OPENAI_API_KEY")

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -13771,63 +13771,70 @@ export type GetLogsKeyValuesQueryResult = Apollo.QueryResult<
 	Types.GetLogsKeyValuesQuery,
 	Types.GetLogsKeyValuesQueryVariables
 >
-export const GetLogsErrorObjectsDocument = gql`
-	query GetLogsErrorObjects($log_cursors: [String!]!) {
+export const GetLogsRelatedResourcesDocument = gql`
+	query GetLogsRelatedResources(
+		$project_id: ID!
+		$log_cursors: [String!]!
+		$trace_ids: [String!]!
+	) {
 		logs_error_objects(log_cursors: $log_cursors) {
 			log_cursor
 			error_group_secure_id
 			id
 		}
+		existing_logs_traces(project_id: $project_id, trace_ids: $trace_ids)
 	}
 `
 
 /**
- * __useGetLogsErrorObjectsQuery__
+ * __useGetLogsRelatedResourcesQuery__
  *
- * To run a query within a React component, call `useGetLogsErrorObjectsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetLogsErrorObjectsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetLogsRelatedResourcesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetLogsRelatedResourcesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetLogsErrorObjectsQuery({
+ * const { data, loading, error } = useGetLogsRelatedResourcesQuery({
  *   variables: {
+ *      project_id: // value for 'project_id'
  *      log_cursors: // value for 'log_cursors'
+ *      trace_ids: // value for 'trace_ids'
  *   },
  * });
  */
-export function useGetLogsErrorObjectsQuery(
+export function useGetLogsRelatedResourcesQuery(
 	baseOptions: Apollo.QueryHookOptions<
-		Types.GetLogsErrorObjectsQuery,
-		Types.GetLogsErrorObjectsQueryVariables
+		Types.GetLogsRelatedResourcesQuery,
+		Types.GetLogsRelatedResourcesQueryVariables
 	>,
 ) {
 	return Apollo.useQuery<
-		Types.GetLogsErrorObjectsQuery,
-		Types.GetLogsErrorObjectsQueryVariables
-	>(GetLogsErrorObjectsDocument, baseOptions)
+		Types.GetLogsRelatedResourcesQuery,
+		Types.GetLogsRelatedResourcesQueryVariables
+	>(GetLogsRelatedResourcesDocument, baseOptions)
 }
-export function useGetLogsErrorObjectsLazyQuery(
+export function useGetLogsRelatedResourcesLazyQuery(
 	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetLogsErrorObjectsQuery,
-		Types.GetLogsErrorObjectsQueryVariables
+		Types.GetLogsRelatedResourcesQuery,
+		Types.GetLogsRelatedResourcesQueryVariables
 	>,
 ) {
 	return Apollo.useLazyQuery<
-		Types.GetLogsErrorObjectsQuery,
-		Types.GetLogsErrorObjectsQueryVariables
-	>(GetLogsErrorObjectsDocument, baseOptions)
+		Types.GetLogsRelatedResourcesQuery,
+		Types.GetLogsRelatedResourcesQueryVariables
+	>(GetLogsRelatedResourcesDocument, baseOptions)
 }
-export type GetLogsErrorObjectsQueryHookResult = ReturnType<
-	typeof useGetLogsErrorObjectsQuery
+export type GetLogsRelatedResourcesQueryHookResult = ReturnType<
+	typeof useGetLogsRelatedResourcesQuery
 >
-export type GetLogsErrorObjectsLazyQueryHookResult = ReturnType<
-	typeof useGetLogsErrorObjectsLazyQuery
+export type GetLogsRelatedResourcesLazyQueryHookResult = ReturnType<
+	typeof useGetLogsRelatedResourcesLazyQuery
 >
-export type GetLogsErrorObjectsQueryResult = Apollo.QueryResult<
-	Types.GetLogsErrorObjectsQuery,
-	Types.GetLogsErrorObjectsQueryVariables
+export type GetLogsRelatedResourcesQueryResult = Apollo.QueryResult<
+	Types.GetLogsRelatedResourcesQuery,
+	Types.GetLogsRelatedResourcesQueryVariables
 >
 export const GetProjectSettingsDocument = gql`
 	query GetProjectSettings($projectId: ID!) {

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4578,18 +4578,23 @@ export type GetLogsKeyValuesQuery = { __typename?: 'Query' } & {
 	key_values: Types.Query['logs_key_values']
 }
 
-export type GetLogsErrorObjectsQueryVariables = Types.Exact<{
+export type GetLogsRelatedResourcesQueryVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
 	log_cursors: Array<Types.Scalars['String']> | Types.Scalars['String']
+	trace_ids: Array<Types.Scalars['String']> | Types.Scalars['String']
 }>
 
-export type GetLogsErrorObjectsQuery = { __typename?: 'Query' } & {
-	logs_error_objects: Array<
-		{ __typename?: 'ErrorObject' } & Pick<
-			Types.ErrorObject,
-			'log_cursor' | 'error_group_secure_id' | 'id'
+export type GetLogsRelatedResourcesQuery = { __typename?: 'Query' } & Pick<
+	Types.Query,
+	'existing_logs_traces'
+> & {
+		logs_error_objects: Array<
+			{ __typename?: 'ErrorObject' } & Pick<
+				Types.ErrorObject,
+				'log_cursor' | 'error_group_secure_id' | 'id'
+			>
 		>
-	>
-}
+	}
 
 export type GetProjectSettingsQueryVariables = Types.Exact<{
 	projectId: Types.Scalars['ID']
@@ -5113,7 +5118,7 @@ export const namedOperations = {
 		GetLogsHistogram: 'GetLogsHistogram' as const,
 		GetLogsKeys: 'GetLogsKeys' as const,
 		GetLogsKeyValues: 'GetLogsKeyValues' as const,
-		GetLogsErrorObjects: 'GetLogsErrorObjects' as const,
+		GetLogsRelatedResources: 'GetLogsRelatedResources' as const,
 		GetProjectSettings: 'GetProjectSettings' as const,
 		GetWorkspacePendingInvites: 'GetWorkspacePendingInvites' as const,
 		GetErrorResolutionSuggestion: 'GetErrorResolutionSuggestion' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1870,6 +1870,7 @@ export type Query = {
 	event_chunk_url: Scalars['String']
 	event_chunks: Array<EventChunk>
 	events?: Maybe<Array<Maybe<Scalars['Any']>>>
+	existing_logs_traces: Array<Scalars['String']>
 	field_suggestion?: Maybe<Array<Maybe<Field>>>
 	field_types_clickhouse: Array<Field>
 	fields_clickhouse: Array<Scalars['String']>
@@ -2202,6 +2203,11 @@ export type QueryEvent_ChunksArgs = {
 
 export type QueryEventsArgs = {
 	session_secure_id: Scalars['String']
+}
+
+export type QueryExisting_Logs_TracesArgs = {
+	project_id: Scalars['ID']
+	trace_ids: Array<Scalars['String']>
 }
 
 export type QueryField_SuggestionArgs = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2184,12 +2184,17 @@ query GetLogsKeyValues(
 	)
 }
 
-query GetLogsErrorObjects($log_cursors: [String!]!) {
+query GetLogsRelatedResources(
+	$project_id: ID!
+	$log_cursors: [String!]!
+	$trace_ids: [String!]!
+) {
 	logs_error_objects(log_cursors: $log_cursors) {
 		log_cursor
 		error_group_secure_id
 		id
 	}
+	existing_logs_traces(project_id: $project_id, trace_ids: $trace_ids)
 }
 
 query GetProjectSettings($projectId: ID!) {

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -1,6 +1,12 @@
 import { Button } from '@components/Button'
 import { LinkButton } from '@components/LinkButton'
-import { LogEdge, LogLevel, Maybe, ReservedLogKey } from '@graph/schemas'
+import {
+	LogEdge,
+	LogLevel,
+	Maybe,
+	ReservedLogKey,
+	ReservedTraceKey,
+} from '@graph/schemas'
 import {
 	Box,
 	IconSolidChevronDoubleDown,
@@ -11,6 +17,7 @@ import {
 	IconSolidLightningBolt,
 	IconSolidLink,
 	IconSolidPlayCircle,
+	IconSolidSparkles,
 	Stack,
 	Text,
 	Tooltip,
@@ -24,6 +31,7 @@ import { LogEdgeWithError } from '@pages/LogsPage/useGetLogs'
 import { PlayerSearchParameters } from '@pages/Player/PlayerHook/utils'
 import { Row } from '@tanstack/react-table'
 import { message as antdMessage } from 'antd'
+import moment from 'moment'
 import React, { useEffect, useState } from 'react'
 import { createSearchParams, generatePath } from 'react-router-dom'
 import { useQueryParam } from 'use-query-params'
@@ -68,6 +76,16 @@ const getErrorLink = (projectId: string, log: LogEdgeWithError): string => {
 		[PlayerSearchParameters.log]: log.cursor,
 	})
 	return `/errors/${log.error_object?.error_group_secure_id}/instances/${log.error_object?.id}?${params}`
+}
+
+const getTraceLink = (projectId: string, log: LogEdgeWithError): string => {
+	const params = createSearchParams({
+		query: `${ReservedTraceKey.TraceId}${DEFAULT_OPERATOR}${log.node.traceID}`,
+		start_date: moment(log.node.timestamp).add(-5, 'minutes').toISOString(),
+		end_date: moment(log.node.timestamp).add(5, 'minutes').toISOString(),
+	})
+
+	return `/${projectId}/traces?${params}`
 }
 
 export const LogDetails: React.FC<Props> = ({
@@ -299,6 +317,25 @@ export const LogDetails: React.FC<Props> = ({
 							</Box>
 						</LinkButton>
 					)}
+					{row.original.node.traceID &&
+						row.original.node.source === 'backend' && (
+							<LinkButton
+								kind="secondary"
+								emphasis="low"
+								to={getTraceLink(projectId, row.original)}
+								trackingId="logs-related_trace_link"
+							>
+								<Box
+									display="flex"
+									alignItems="center"
+									flexDirection="row"
+									gap="4"
+								>
+									<IconSolidSparkles />
+									Related Trace
+								</Box>
+							</LinkButton>
+						)}
 				</Box>
 			</Box>
 		</Stack>

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -27,7 +27,7 @@ import {
 	IconCollapsed,
 	IconExpanded,
 } from '@pages/LogsPage/LogsTable/LogsTable'
-import { LogEdgeWithError } from '@pages/LogsPage/useGetLogs'
+import { LogEdgeWithResources } from '@pages/LogsPage/useGetLogs'
 import { PlayerSearchParameters } from '@pages/Player/PlayerHook/utils'
 import { Row } from '@tanstack/react-table'
 import { message as antdMessage } from 'antd'
@@ -50,7 +50,7 @@ import * as styles from './LogDetails.css'
 import * as logsTableStyles from './LogsTable.css'
 
 type Props = {
-	row: Row<LogEdgeWithError>
+	row: Row<LogEdgeWithResources>
 	queryParts: SearchExpression[]
 	matchedAttributes: ReturnType<typeof findMatchingLogAttributes>
 }
@@ -64,21 +64,24 @@ export const getLogURL = (projectId: string, row: Row<LogEdge>) => {
 	return currentUrl.origin + path
 }
 
-const getSessionLink = (projectId: string, log: LogEdgeWithError): string => {
+const getSessionLink = (
+	projectId: string,
+	log: LogEdgeWithResources,
+): string => {
 	const params = createSearchParams({
 		[PlayerSearchParameters.log]: log.cursor,
 	})
 	return `/${projectId}/sessions/${log.node.secureSessionID}?${params}`
 }
 
-const getErrorLink = (projectId: string, log: LogEdgeWithError): string => {
+const getErrorLink = (projectId: string, log: LogEdgeWithResources): string => {
 	const params = createSearchParams({
 		[PlayerSearchParameters.log]: log.cursor,
 	})
 	return `/errors/${log.error_object?.error_group_secure_id}/instances/${log.error_object?.id}?${params}`
 }
 
-const getTraceLink = (projectId: string, log: LogEdgeWithError): string => {
+const getTraceLink = (projectId: string, log: LogEdgeWithResources): string => {
 	const params = createSearchParams({
 		query: `${ReservedTraceKey.TraceId}${DEFAULT_OPERATOR}${log.node.traceID}`,
 		start_date: moment(log.node.timestamp).add(-5, 'minutes').toISOString(),
@@ -317,25 +320,24 @@ export const LogDetails: React.FC<Props> = ({
 							</Box>
 						</LinkButton>
 					)}
-					{row.original.node.traceID &&
-						row.original.node.source === 'backend' && (
-							<LinkButton
-								kind="secondary"
-								emphasis="low"
-								to={getTraceLink(projectId, row.original)}
-								trackingId="logs-related_trace_link"
+					{row.original.traceExist && (
+						<LinkButton
+							kind="secondary"
+							emphasis="low"
+							to={getTraceLink(projectId, row.original)}
+							trackingId="logs-related_trace_link"
+						>
+							<Box
+								display="flex"
+								alignItems="center"
+								flexDirection="row"
+								gap="4"
 							>
-								<Box
-									display="flex"
-									alignItems="center"
-									flexDirection="row"
-									gap="4"
-								>
-									<IconSolidSparkles />
-									Related Trace
-								</Box>
-							</LinkButton>
-						)}
+								<IconSolidSparkles />
+								Related Trace
+							</Box>
+						</LinkButton>
+					)}
 				</Box>
 			</Box>
 		</Stack>

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -88,7 +88,7 @@ const getTraceLink = (projectId: string, log: LogEdgeWithResources): string => {
 		end_date: moment(log.node.timestamp).add(5, 'minutes').toISOString(),
 	})
 
-	return `/${projectId}/traces?${params}`
+	return `/${projectId}/traces/${log.node.traceID}?${params}`
 }
 
 export const LogDetails: React.FC<Props> = ({

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -23,7 +23,7 @@ import {
 import { ColumnRenderers } from '@pages/LogsPage/LogsTable/CustomColumns/renderers'
 import { FullScreenContainer } from '@pages/LogsPage/LogsTable/FullScreenContainer'
 import { NoLogsFound } from '@pages/LogsPage/LogsTable/NoLogsFound'
-import { LogEdgeWithError } from '@pages/LogsPage/useGetLogs'
+import { LogEdgeWithResources } from '@pages/LogsPage/useGetLogs'
 import {
 	ColumnDef,
 	createColumnHelper,
@@ -116,7 +116,7 @@ export const LogsTable = (props: Props) => {
 
 type LogsTableInnerProps = {
 	loadingAfter: boolean
-	logEdges: LogEdgeWithError[]
+	logEdges: LogEdgeWithResources[]
 	query: string
 	selectedCursor: string | undefined
 	fetchMoreWhenScrolled: (target: HTMLDivElement) => void

--- a/frontend/src/pages/Traces/CustomColumns/columns.ts
+++ b/frontend/src/pages/Traces/CustomColumns/columns.ts
@@ -40,6 +40,14 @@ const PARENT_SPAN_ID_COLUMN: TraceCustomColumn = {
 	accessKey: 'parentSpanID',
 }
 
+const SPAN_ID_COLUMN: TraceCustomColumn = {
+	id: 'span_id',
+	label: 'Span ID',
+	type: 'string',
+	size: '1fr',
+	accessKey: 'spanID',
+}
+
 const SECURE_SESSION_ID_COLUMN: TraceCustomColumn = {
 	id: 'secure_session_id',
 	label: 'Secure Session ID',
@@ -103,6 +111,7 @@ export const HIGHLIGHT_STANDARD_COLUMNS: Record<string, TraceCustomColumn> = {
 	service_version: SERVICE_VERSION_COLUMN,
 	trace_id: TRACE_ID_COLUMN,
 	parent_span_id: PARENT_SPAN_ID_COLUMN,
+	span_id: SPAN_ID_COLUMN,
 	secure_session_id: SECURE_SESSION_ID_COLUMN,
 	has_errors: HAS_ERRORS_COLUMN,
 	duration: DURATION_COLUMN,

--- a/frontend/src/pages/Traces/utils.ts
+++ b/frontend/src/pages/Traces/utils.ts
@@ -4,7 +4,7 @@ import { Trace } from '@/graph/generated/schemas'
 
 export const getFirstSpan = (trace: Trace[]) => {
 	const rootSpans = trace.filter((span) => !span.parentSpanID)
-	const spans = rootSpans.length > 0 ? rootSpans : trace
+	const spans = rootSpans.length > 0 ? rootSpans : [...trace]
 	const sortedTrace = spans.sort(
 		(a, b) =>
 			new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),


### PR DESCRIPTION
## Summary
Allow users to see the related trace from the logs

## How did you test this change?
1) View a log
2) Expand the row
3) Click on related trace link
- [ ] Opens traces search page with relevant filters

https://www.loom.com/share/d6c0739dbf684aec8d6949eca7a3c291?sid=67b9efd5-c305-4a22-b158-101ed649b486

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
