### PR TITLE
readd private graph request logging

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -454,6 +454,7 @@ func main() {
 				Cache: lru.New(10000),
 			})
 			privateServer.Use(private.NewGraphqlOAuthValidator(privateResolver.Store))
+			privateServer.Use(util.NewTracer(util.PrivateGraph))
 			privateServer.Use(htrace.NewGraphqlTracer(string(util.PrivateGraph)).WithRequestFieldLogging())
 			privateServer.SetErrorPresenter(htrace.GraphQLErrorPresenter(string(util.PrivateGraph)))
 			privateServer.SetRecoverFunc(htrace.GraphQLRecoverFunc())

--- a/backend/util/tracer-graphql.go
+++ b/backend/util/tracer-graphql.go
@@ -1,0 +1,78 @@
+package util
+
+// This schema/arch is taken from: https://github.com/99designs/gqlgen/blob/master/graphql/handler/apollotracing/tracer.go
+
+import (
+	"context"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql"
+	log "github.com/sirupsen/logrus"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+)
+
+type Tracer struct {
+	graphql.HandlerExtension
+	graphql.ResponseInterceptor
+	graphql.FieldInterceptor
+
+	serverType Runtime
+}
+
+func NewTracer(backend Runtime) Tracer {
+	return Tracer{serverType: backend}
+}
+
+func (t Tracer) ExtensionName() string {
+	return "HighlightTracer"
+}
+
+func (t Tracer) Validate(graphql.ExecutableSchema) error {
+	return nil
+}
+
+func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (interface{}, error) {
+	fc := graphql.GetFieldContext(ctx)
+	start := time.Now()
+	res, err := next(ctx)
+
+	fields := log.Fields{
+		"duration":                     time.Since(start).Seconds(),
+		"graph":                        t.serverType,
+		"graphql.operation.field.name": fc.Field.Name,
+	}
+	if err != nil {
+		fields["error"] = err
+	}
+	log.WithContext(ctx).
+		WithFields(fields).
+		Debugf("private-graph graphql field")
+	return res, err
+}
+
+func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
+	start := time.Now()
+	var oc *graphql.OperationContext
+	if graphql.HasOperationContext(ctx) {
+		oc = graphql.GetOperationContext(ctx)
+	}
+	// NOTE: This gets called for the first time at the highest level. Creates the 'tracing' value, calls the next handler
+	// and returns the response.
+	opName := "undefined"
+	if oc != nil {
+		opName = oc.OperationName
+	}
+	resp := next(ctx)
+	fields := log.Fields{
+		"duration":                              time.Since(start).Seconds(),
+		"graph":                                 t.serverType,
+		string(semconv.GraphqlOperationNameKey): opName,
+	}
+	if resp != nil && len(resp.Errors) > 0 {
+		fields["errors"] = resp.Errors
+	}
+	log.WithContext(ctx).
+		WithFields(fields).
+		Infof("private-graph graphql request")
+	return resp
+}

--- a/backend/util/tracer-graphql.go
+++ b/backend/util/tracer-graphql.go
@@ -32,22 +32,7 @@ func (t Tracer) Validate(graphql.ExecutableSchema) error {
 }
 
 func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (interface{}, error) {
-	fc := graphql.GetFieldContext(ctx)
-	start := time.Now()
-	res, err := next(ctx)
-
-	fields := log.Fields{
-		"duration":                     time.Since(start).Seconds(),
-		"graph":                        t.serverType,
-		"graphql.operation.field.name": fc.Field.Name,
-	}
-	if err != nil {
-		fields["error"] = err
-	}
-	log.WithContext(ctx).
-		WithFields(fields).
-		Debugf("private-graph graphql field")
-	return res, err
+	return next(ctx)
 }
 
 func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
@@ -73,6 +58,6 @@ func (t Tracer) InterceptResponse(ctx context.Context, next graphql.ResponseHand
 	}
 	log.WithContext(ctx).
 		WithFields(fields).
-		Infof("private-graph graphql request")
+		Infof("%s graphql request", t.serverType)
 	return resp
 }


### PR DESCRIPTION
## Summary

We used to have request logging from the backend to help demo logs association
with frontend sessions. This got accidentally removed in #7203. Noticed this when working on 
#7655 where I was not able to find backend logs associated to a frontend session.

## How did you test this change?

Local deploy.
![Screenshot from 2024-02-05 13-08-35](https://github.com/highlight/highlight/assets/1351531/41ba372a-38f9-4b03-8f86-2361a8d8efe2)
![Screenshot from 2024-02-05 13-08-49](https://github.com/highlight/highlight/assets/1351531/f8b90f01-d174-4632-bc93-d760e6e44fab)


## Are there any deployment considerations?

No

## Does this work require review from our design team?

No
