### PR TITLE
Don't redirect to projects outside workspace

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -123,8 +123,11 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 	const { projectId: localStorageProjectId } = useLocalStorageProjectId()
 	const { isLoggedIn, signOut } = useAuthContext()
 	const showAnalytics = useFeatureFlag(Feature.Analytics)
-	const { currentProject, currentWorkspace } = useApplicationContext()
+	const { allProjects, currentWorkspace } = useApplicationContext()
 	const workspaceId = currentWorkspace?.id
+	const localStorageProject = allProjects?.find(
+		(p) => String(p?.id) === String(localStorageProjectId),
+	)
 
 	const goBackPath =
 		location.state?.previousPath ?? `/${localStorageProjectId}/sessions`
@@ -221,7 +224,7 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 					py="8"
 					justifyContent="space-between"
 				>
-					{isSetup || isSettings ? (
+					{isSetup || (isSettings && localStorageProjectId) ? (
 						<LinkButton
 							to={goBackPath}
 							kind="secondary"
@@ -236,7 +239,8 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 							>
 								<IconSolidArrowSmLeft />{' '}
 								<Text>
-									Back to {currentProject?.name ?? 'Project'}
+									Back to{' '}
+									{localStorageProject?.name ?? 'Project'}
 								</Text>
 							</Box>
 						</LinkButton>

--- a/frontend/src/routers/ProjectRouter/WorkspaceRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/WorkspaceRouter.tsx
@@ -14,6 +14,7 @@ import React, { useEffect } from 'react'
 import { Route, Routes } from 'react-router-dom'
 import { useToggle } from 'react-use'
 
+import { useLocalStorageProjectId } from '@/hooks/useProjectId'
 import { SettingsRouter } from '@/pages/SettingsRouter/SettingsRouter'
 
 import commonStyles from '../../Common.module.css'
@@ -22,6 +23,10 @@ export const WorkspaceRouter = () => {
 	const { isLoggedIn } = useAuthContext()
 	const [showKeyboardShortcutsGuide, toggleShowKeyboardShortcutsGuide] =
 		useToggle(false)
+	const {
+		projectId: localStorageProjectId,
+		setProjectId: setLocalStorageProjectId,
+	} = useLocalStorageProjectId()
 	const [showBanner, toggleShowBanner] = useToggle(false)
 
 	const { workspace_id } = useParams<{
@@ -39,6 +44,21 @@ export const WorkspaceRouter = () => {
 			setLoadingState(AppLoadingState.LOADED)
 		}
 	}, [isLoggedIn, setLoadingState])
+
+	useEffect(() => {
+		const projectsLoaded = data?.workspace?.projects.length
+		const projectInWorkspace = data?.workspace?.projects?.find(
+			(p) => String(p?.id) === String(localStorageProjectId),
+		)
+
+		if (projectsLoaded && !projectInWorkspace) {
+			setLocalStorageProjectId('')
+		}
+	}, [
+		data?.workspace?.projects,
+		localStorageProjectId,
+		setLocalStorageProjectId,
+	])
 
 	const commandBarDialog = Ariakit.useDialogStore()
 


### PR DESCRIPTION
## Summary

Fixes a bug where we would redirect a user to a project from a different workspace after switching workspaces. The new logic ensures we wipe the project ID we store in local storage if it doesn't not exist in the current workspace. It also enhances the back button by showing the project name references in local storage even if you are on a workspace settings page.

https://www.loom.com/share/d91b88e3c9a943a39e0221513d930460

## How did you test this change?

Local + PR preview click test.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A