### PR TITLE
Trim extra space on query string when applying log filter

### DIFF
--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -543,8 +543,9 @@ export const Search: React.FC<{
 
 						// Need to set this bit of React state to force a re-render of the
 						// component. For some reason the combobox value isn't updated until
-						// after a delay or blurring the input.
-						setQuery(e.target.value)
+						// after a delay or blurring the input. We also trim any leading
+						// space characters since this produces some UI jank.
+						setQuery(e.target.value.replace(/^\s+/, ''))
 					}}
 					onBlur={() => {
 						submitQuery(query)

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -558,6 +558,7 @@ export const Search: React.FC<{
 						}
 
 						if (
+							!isPending &&
 							e.key === 'Enter' &&
 							// Using isPending to prevent blurring when the user is selecting
 							// an item vs submitting the form.

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -445,7 +445,11 @@ export const LogValue: React.FC<{
 											stringifySearchQuery(queryParts)
 
 										if (index === -1) {
-											newQuery += ` ${queryKey}${DEFAULT_OPERATOR}"${value}"`
+											newQuery += ` ${queryKey}${DEFAULT_OPERATOR}${quoteQueryValue(
+												value,
+											)}`
+
+											newQuery = newQuery.trim()
 										}
 
 										setQuery(newQuery)


### PR DESCRIPTION
## Summary

Fixes an issue where the query string was being prefixed with an extra space character when applying a filter from a log attribute. This caused a bit of jank in the UI.

I also looked at fixing the jank in the UI, which is reproducible by entering a query with a leading space character. This happens because we are using `word-spacing` to control the space between the filters since the default width of the space character in the font we are using is very narrow. However, `word-spacing` only applies between words and doesn't update the width of a leading space character. I filed https://linear.app/highlight/issue/HIG-4307/cursor-position-off-on-query-filters-when-there-is-a-prefix to follow up on this in the future, but I also added some logic to trim the leading space when we update the query, so hopefully this won't be as big of an issue.

I also caught a bug where selecting an item from the dropdown would not update the query if you had recently deleted the entire query.

## How did you test this change?

Ran the following testing steps locally and in a PR preview.

* Applied a filter from a log attribute and confirmed the leading space was gone
* Typed a space into the input when there was no query and confirmed it wasn't inserted
* Pasted a query string with a leading space and confirmed it was trimmed
* Added a filter, deleted it, and confirmed that adding a filter using the typeahead worked as expected

## Are there any deployment considerations?

N/A - all client-side changes.

## Does this work require review from our design team?

N/A