### PR TITLE
Custom columns: popover updates

### DIFF
--- a/frontend/src/components/CustomColumnPopover/index.tsx
+++ b/frontend/src/components/CustomColumnPopover/index.tsx
@@ -3,18 +3,17 @@ import {
 	useGetTracesKeysLazyQuery,
 } from '@graph/hooks'
 import {
-	Box,
 	ComboboxSelect,
 	DEFAULT_TIME_PRESETS,
 	IconSolidDotsHorizontal,
 	Text,
-	Tooltip,
 } from '@highlight-run/ui/components'
 import { useDebouncedValue } from '@hooks/useDebouncedValue'
 import { useParams } from '@util/react-router/useParams'
 import moment from 'moment'
 import React, { useEffect, useMemo, useState } from 'react'
 
+import LoadingBox from '@/components/LoadingBox'
 import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
 import { FixedRangePreset } from '@/components/Search/SearchForm/SearchForm'
 import { useSearchTime } from '@/hooks/useSearchTime'
@@ -142,19 +141,13 @@ export const CustomColumnPopover: React.FC<Props> = ({
 	}
 
 	const options = loading
-		? []
+		? undefined
 		: columnOptions.map((o) => ({
 				key: o.id,
 				render: (
-					<Tooltip
-						trigger={
-							<Text lines="1" cssClass={styles.selectOption}>
-								{o.id}
-							</Text>
-						}
-					>
-						<Box cssClass={styles.selectOptionTooltip}>{o.id}</Box>
-					</Tooltip>
+					<Text lines="1" cssClass={styles.selectOption} title={o.id}>
+						{o.id}
+					</Text>
 				),
 		  }))
 
@@ -164,6 +157,8 @@ export const CustomColumnPopover: React.FC<Props> = ({
 			queryPlaceholder="Search attributes..."
 			onChange={handleColumnValueChange}
 			icon={<IconSolidDotsHorizontal />}
+			loadingRender={<LoadingBox />}
+			emptyStateRender="No keys found"
 			value={value}
 			options={options}
 			cssClass={styles.selectButton}

--- a/packages/ui/src/__generated/ve/components/ComboboxSelect/styles.css.js
+++ b/packages/ui/src/__generated/ve/components/ComboboxSelect/styles.css.js
@@ -4,20 +4,20 @@ var combobox = "n4pjg82";
 var comboboxHasResults = "n4pjg84";
 var comboboxList = "n4pjg85";
 var comboboxWrapper = "n4pjg83";
-var loadingPlaceholder = "n4pjg88";
 var selectButton = "n4pjg81";
 var selectItem = "n4pjg87";
 var selectLabel = "n4pjg80";
 var selectPopover = "n4pjg86";
+var statePlaceholder = "n4pjg88";
 export {
   checkbox,
   combobox,
   comboboxHasResults,
   comboboxList,
   comboboxWrapper,
-  loadingPlaceholder,
   selectButton,
   selectItem,
   selectLabel,
-  selectPopover
+  selectPopover,
+  statePlaceholder
 };

--- a/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
@@ -126,7 +126,9 @@ export const ComboboxSelect = <T extends string | string[]>({
 				<div
 					className={clsx(styles.comboboxWrapper, {
 						[styles.comboboxHasResults]:
-							allOptions.length > 0 || isLoading,
+							allOptions.length > 0 ||
+							isLoading ||
+							emptyStateRender,
 					})}
 				>
 					<IconSolidSearch />

--- a/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
@@ -128,7 +128,7 @@ export const ComboboxSelect = <T extends string | string[]>({
 						[styles.comboboxHasResults]:
 							allOptions.length > 0 ||
 							isLoading ||
-							emptyStateRender,
+							!!emptyStateRender,
 					})}
 				>
 					<IconSolidSearch />

--- a/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
@@ -39,6 +39,7 @@ type Props<T extends string | string[]> = {
 	defaultOpen?: boolean
 	disabled?: boolean
 	loadingRender?: React.ReactNode
+	emptyStateRender?: React.ReactNode
 }
 
 export const ComboboxSelect = <T extends string | string[]>({
@@ -56,6 +57,7 @@ export const ComboboxSelect = <T extends string | string[]>({
 	defaultOpen,
 	disabled,
 	loadingRender,
+	emptyStateRender,
 }: Props<T>) => {
 	const isMultiselect = typeof value === 'object'
 
@@ -145,12 +147,24 @@ export const ComboboxSelect = <T extends string | string[]>({
 						<div
 							className={clsx([
 								styles.selectItem,
-								styles.loadingPlaceholder,
+								styles.statePlaceholder,
 							])}
 						>
 							{loadingRender}
 						</div>
 					)}
+					{emptyStateRender &&
+						!isLoading &&
+						allOptions.length === 0 && (
+							<div
+								className={clsx([
+									styles.selectItem,
+									styles.statePlaceholder,
+								])}
+							>
+								{emptyStateRender}
+							</div>
+						)}
 					{select.useState('open') &&
 						allOptions.map((option: Option) => (
 							<ComboboxItem

--- a/packages/ui/src/components/ComboboxSelect/styles.css.ts
+++ b/packages/ui/src/components/ComboboxSelect/styles.css.ts
@@ -84,7 +84,7 @@ export const selectItem = style({
 	},
 })
 
-export const loadingPlaceholder = style({
+export const statePlaceholder = style({
 	fontWeight: 500,
 	color: vars.theme.static.content.moderate,
 	justifyContent: 'center',


### PR DESCRIPTION
## Summary
Make the following updates to the custom column popover:
- add loading state
- add empty state
- remove tooltip and rely on title

## How did you test this change?
1) Load the traces or logs page
2) Open the custom column selector on the far right of the table
3) Hover over a key
- [ ] More discrete tooltip is displayed
3) Type in a query
- [ ] Loading state shown
4) Type in a key that does not exist
- [ ] Empty state shown

General
- [ ] No changes to PopoverSelect on Query builder

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
Sure
