### PR TITLE
Errors: add link to related trace

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -50,6 +50,7 @@ import { ErrorSessionMissingOrExcluded } from '@/pages/ErrorsV2/ErrorInstance/Er
 import { PreviousNextInstance } from '@/pages/ErrorsV2/ErrorInstance/PreviousNextInstance'
 import { RelatedLogs } from '@/pages/ErrorsV2/ErrorInstance/RelatedLogs'
 import { RelatedSession } from '@/pages/ErrorsV2/ErrorInstance/RelatedSession'
+import { RelatedTrace } from '@/pages/ErrorsV2/ErrorInstance/RelatedTrace'
 import { SeeAllInstances } from '@/pages/ErrorsV2/ErrorInstance/SeeAllInstances'
 import { isSessionAvailable } from '@/pages/ErrorsV2/ErrorInstance/utils'
 import { useSearchContext } from '@/pages/Sessions/SearchContext/SearchContext'
@@ -151,6 +152,7 @@ export const ErrorInstance: React.FC<Props> = ({ errorGroup }) => {
 				<Stack direction="row" gap="4">
 					<RelatedSession data={data} />
 					<RelatedLogs data={data} />
+					<RelatedTrace data={data} />
 				</Stack>
 			</Stack>
 

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/RelatedTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/RelatedTrace.tsx
@@ -1,0 +1,52 @@
+import { IconSolidSparkles, Tag } from '@highlight-run/ui/components'
+import moment from 'moment'
+import { createSearchParams } from 'react-router-dom'
+
+import { useAuthContext } from '@/authentication/AuthContext'
+import { Link } from '@/components/Link'
+import { DEFAULT_OPERATOR } from '@/components/Search/SearchForm/utils'
+import { GetErrorInstanceQuery } from '@/graph/generated/operations'
+import { ReservedTraceKey } from '@/graph/generated/schemas'
+
+const getTraceLink = (data: GetErrorInstanceQuery | undefined): string => {
+	const errorObject = data?.error_instance?.error_object
+
+	if (!errorObject || !errorObject.trace_id) {
+		return ''
+	}
+
+	const params = createSearchParams({
+		query: `${ReservedTraceKey.TraceId}${DEFAULT_OPERATOR}${errorObject.trace_id}`,
+		start_date: moment(errorObject.timestamp)
+			.add(-5, 'minutes')
+			.toISOString(),
+		end_date: moment(errorObject.timestamp).add(5, 'minutes').toISOString(),
+	})
+
+	return `/${errorObject.project_id}/traces/${errorObject.trace_id}?${params}`
+}
+
+type Props = {
+	data: GetErrorInstanceQuery | undefined
+}
+
+export const RelatedTrace = ({ data }: Props) => {
+	const { isLoggedIn } = useAuthContext()
+
+	const traceLink = getTraceLink(data)
+
+	return (
+		<Link to={traceLink}>
+			<Tag
+				kind="secondary"
+				emphasis="high"
+				size="medium"
+				shape="basic"
+				disabled={!isLoggedIn || traceLink === ''}
+				iconLeft={<IconSolidSparkles size={11} />}
+			>
+				Related trace
+			</Tag>
+		</Link>
+	)
+}


### PR DESCRIPTION
## Summary
Allow users to see the related trace from the error details

## How did you test this change?
1) View an error
- [ ] Errors without a trace id (i.e. frontend errors) have a disabled button
- [ ] Errors with a trace id are linked to the trace page

https://www.loom.com/share/cea8e54253d54edab83e9c8e3bedc6ef?sid=252e4aa7-ee7d-4519-a63d-5bbc0454b66b

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
