### PR TITLE
new flattened format for log messages

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -60,8 +60,8 @@ type Queue struct {
 
 type MessageQueue interface {
 	Stop(context.Context)
-	Receive(context.Context) *Message
-	Submit(context.Context, string, ...*Message) error
+	Receive(context.Context) RetryableMessage
+	Submit(context.Context, string, ...RetryableMessage) error
 	LogStats()
 }
 
@@ -303,7 +303,7 @@ func (p *Queue) Stop(ctx context.Context) {
 	}
 }
 
-func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...*Message) error {
+func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...RetryableMessage) error {
 	if len(messages) == 0 {
 		return nil
 	}
@@ -315,7 +315,8 @@ func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...*Me
 
 	var kMessages []kafka.Message
 	for _, msg := range messages {
-		msg.MaxRetries = TaskRetries
+		msg.SetMaxRetries(TaskRetries)
+		// msg.MaxRetries = TaskRetries
 		msgBytes, err := p.serializeMessage(msg)
 		if err != nil {
 			log.WithContext(ctx).Error(errors.Wrap(err, "failed to serialize message"))
@@ -342,7 +343,7 @@ func (p *Queue) Submit(ctx context.Context, partitionKey string, messages ...*Me
 	return nil
 }
 
-func (p *Queue) Receive(ctx context.Context) (msg *Message) {
+func (p *Queue) Receive(ctx context.Context) (msg RetryableMessage) {
 	start := time.Now()
 	ctx, cancel := context.WithTimeout(ctx, KafkaOperationTimeout)
 	defer cancel()
@@ -358,7 +359,7 @@ func (p *Queue) Receive(ctx context.Context) (msg *Message) {
 		log.WithContext(ctx).WithField("topic", p.Topic).WithField("partition", m.Partition).WithField("msgBytes", len(m.Value)).Error(errors.Wrap(err, "failed to deserialize message"))
 		return nil
 	}
-	msg.KafkaMessage = &m
+	msg.SetKafkaMessage(&m)
 	hmetric.Incr(ctx, p.metricPrefix()+"consumeMessageCount", nil, 1)
 	hmetric.Histogram(ctx, p.metricPrefix()+"receiveSec", time.Since(start).Seconds(), nil, 1)
 	return
@@ -452,7 +453,7 @@ func (p *Queue) LogStats() {
 	}
 }
 
-func (p *Queue) serializeMessage(msg *Message) (compressed []byte, err error) {
+func (p *Queue) serializeMessage(msg RetryableMessage) (compressed []byte, err error) {
 	compressed, err = json.Marshal(&msg)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshall json")
@@ -460,14 +461,29 @@ func (p *Queue) serializeMessage(msg *Message) (compressed []byte, err error) {
 	return
 }
 
-func (p *Queue) deserializeMessage(compressed []byte) (msg *Message, error error) {
+func (p *Queue) deserializeMessage(compressed []byte) (RetryableMessage, error) {
 	if int64(len(compressed)) >= p.MessageSizeBytes {
 		return nil, errors.New("message too large")
 	}
-	if err := json.Unmarshal(compressed, &msg); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshall msg")
+	var msgType struct {
+		Type PayloadType
 	}
-	return
+	if err := json.Unmarshal(compressed, &msgType); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshall message type")
+	}
+
+	var msg RetryableMessage
+	if msgType.Type == PushLogsFlattened {
+		msg = &LogRowMessage{}
+	} else {
+		msg = &Message{}
+	}
+
+	if err := json.Unmarshal(compressed, &msg); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshall message")
+	}
+
+	return msg, nil
 }
 
 func (p *Queue) resetConsumerOffset(ctx context.Context, partitionOffsets map[int]int64) (error error) {

--- a/backend/kafka-queue/kafkaqueue_test.go
+++ b/backend/kafka-queue/kafkaqueue_test.go
@@ -80,10 +80,15 @@ func BenchmarkQueue_Submit(b *testing.B) {
 						b.Errorf("expected to get a message")
 					}
 					continue
-				} else if msg.Type != PushPayload {
+				} else if msg.GetType() != PushPayload {
 					b.Errorf("expected to consume dummy payload of PushPayload")
-				} else if msg.PushPayload.SessionSecureID != "" {
-					b.Errorf("expected to consume dummy session")
+				} else {
+					publicWorkerMessage, ok := msg.(*Message)
+					if !ok {
+						b.Errorf("failed type assertion")
+					} else if publicWorkerMessage.PushPayload.SessionSecureID != "" {
+						b.Errorf("expected to consume dummy session")
+					}
 				}
 			}
 			recWg.Done()

--- a/backend/otel/otel_test.go
+++ b/backend/otel/otel_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/highlight-run/highlight/backend/integrations"
+	kafka_queue "github.com/highlight-run/highlight/backend/kafka-queue"
 	model2 "github.com/highlight-run/highlight/backend/public-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/redis"
 	"github.com/highlight-run/highlight/backend/storage"
@@ -28,14 +29,14 @@ import (
 )
 
 type MockKafkaProducer struct {
-	messages []*kafkaqueue.Message
+	messages []kafkaqueue.RetryableMessage
 }
 
 func (m *MockKafkaProducer) Stop(_ context.Context) {}
 
-func (m *MockKafkaProducer) Receive(_ context.Context) *kafkaqueue.Message { return nil }
+func (m *MockKafkaProducer) Receive(_ context.Context) kafkaqueue.RetryableMessage { return nil }
 
-func (m *MockKafkaProducer) Submit(_ context.Context, _ string, messages ...*kafkaqueue.Message) error {
+func (m *MockKafkaProducer) Submit(_ context.Context, _ string, messages ...kafkaqueue.RetryableMessage) error {
 	m.messages = append(m.messages, messages...)
 	return nil
 }
@@ -81,7 +82,7 @@ func TestHandler_HandleTrace(t *testing.T) {
 		"./samples/traces.json": {
 			expectedMessageCounts: map[kafkaqueue.PayloadType]int{
 				kafkaqueue.PushBackendPayload: 4,   // 4 exceptions, pushed as individual messages
-				kafkaqueue.PushLogs:           15,  // 4 exceptions, 11 logs
+				kafkaqueue.PushLogsFlattened:  15,  // 4 exceptions, 11 logs
 				kafkaqueue.PushTraces:         501, // 512 spans - 11 logs
 			},
 			expectedLogCounts: map[model.LogSource]int{
@@ -92,8 +93,8 @@ func TestHandler_HandleTrace(t *testing.T) {
 		"./samples/external.json": {
 			expectedMessageCounts: map[kafkaqueue.PayloadType]int{
 				// no errors expected
-				kafkaqueue.PushLogs:   11,  // 11 logs
-				kafkaqueue.PushTraces: 501, // 512 spans - 11 logs
+				kafkaqueue.PushLogsFlattened: 11,  // 11 logs
+				kafkaqueue.PushTraces:        501, // 512 spans - 11 logs
 			},
 			external: true,
 		},
@@ -155,13 +156,15 @@ func TestHandler_HandleTrace(t *testing.T) {
 		logCountsBySource := map[model.LogSource]int{}
 		messageCountsByType := map[kafkaqueue.PayloadType]int{}
 		for _, message := range producer.messages {
-			messageCountsByType[message.Type]++
-			if message.Type == kafkaqueue.PushLogs {
-				lg := message.PushLogs.LogRow
+			messageCountsByType[message.GetType()]++
+			if message.GetType() == kafkaqueue.PushLogs {
+				pushPayloadMessage := message.(*kafka_queue.Message)
+				lg := pushPayloadMessage.PushLogs.LogRow
 				logCountsBySource[lg.Source]++
-			} else if message.Type == kafkaqueue.PushBackendPayload {
-				appDirError = message.PushBackendPayload.Errors[0]
-				numErrors += len(message.PushBackendPayload.Errors)
+			} else if message.GetType() == kafkaqueue.PushBackendPayload {
+				pushPayloadMessage := message.(*kafka_queue.Message)
+				appDirError = pushPayloadMessage.PushBackendPayload.Errors[0]
+				numErrors += len(pushPayloadMessage.PushBackendPayload.Errors)
 			}
 		}
 

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1937,7 +1937,7 @@ func (r *Resolver) SubmitMetricsMessage(ctx context.Context, metrics []*publicMo
 	}
 
 	for secureID, metrics := range sessionMetrics {
-		var messages []*kafka_queue.Message
+		var messages []kafka_queue.RetryableMessage
 		for _, metric := range metrics {
 			messages = append(messages, &kafka_queue.Message{
 				Type: kafka_queue.PushMetrics,
@@ -2036,7 +2036,7 @@ func (r *Resolver) PushMetricsImpl(ctx context.Context, projectVerboseID *string
 	}
 
 	// TODO(vkorolik) write to an actual metrics table
-	var messages []*kafka_queue.Message
+	var messages []kafka_queue.RetryableMessage
 	for _, traceRow := range traceRows {
 		if !r.IsTraceIngested(ctx, traceRow) {
 			continue

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -168,7 +168,7 @@ func (r *mutationResolver) PushPayload(ctx context.Context, sessionSecureID stri
 		chunks[idx] = entry
 	}
 
-	var msgs []*kafkaqueue.Message
+	var msgs []kafkaqueue.RetryableMessage
 	for _, chunk := range chunks {
 		logRowsB, err := json.Marshal(PushPayloadMessages{
 			Messages: chunk.logRows,
@@ -232,7 +232,7 @@ func (r *mutationResolver) PushBackendPayload(ctx context.Context, projectID *st
 	for _, backendError := range errors {
 		errorsBySecureID[backendError.SessionSecureID] = append(errorsBySecureID[backendError.SessionSecureID], backendError)
 	}
-	var messages []*kafkaqueue.Message
+	var messages []kafkaqueue.RetryableMessage
 	for secureID, backendErrors := range errorsBySecureID {
 		var partitionKey string
 		if secureID != nil {


### PR DESCRIPTION
## Summary
- creates a new `RetryableMessage` interface, implemented by `Message` and `LogRowMessage`
- `LogRowMessage` has a flattened format to make it easier to use with Kafka Connect
- includes consumer code to handle both new and old formats
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally to make sure logs and other kafka messages were being produced/consumed correctly
- ensured `LogRowMessage` format matched what was expected
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- new format messages will be dropped in case of revert, will quickly verify that logs are still being ingested properly after deployment
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
