### PR TITLE
fix python warning log level handling

### DIFF
--- a/backend/clickhouse/log_row.go
+++ b/backend/clickhouse/log_row.go
@@ -2,14 +2,16 @@ package clickhouse
 
 import (
 	"context"
-	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
 	"strings"
 	"time"
 
+	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
+
 	"github.com/google/uuid"
-	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
+
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 )
 
 type LogRow struct {
@@ -140,6 +142,8 @@ func makeLogLevel(severityText string) modelInputs.LogLevel {
 	case "debug":
 		return modelInputs.LogLevelDebug
 	case "warn":
+		return modelInputs.LogLevelWarn
+	case "warning":
 		return modelInputs.LogLevelWarn
 	case "error":
 		return modelInputs.LogLevelError

--- a/sdk/highlight-py/tests/test_loguru.py
+++ b/sdk/highlight-py/tests/test_loguru.py
@@ -5,6 +5,7 @@ import pytest
 from loguru import logger
 
 import highlight_io
+from opentelemetry._logs import SeverityNumber
 
 H = highlight_io.H("1", instrument_logging=False)
 
@@ -20,7 +21,20 @@ def test_loguru(mocker):
     )
 
     logger.info("welcome to this test test_loguru", {"hello": "world", "vadim": 12.34})
+    logger.warning("this is a warning", {"hello": "world", "vadim": 23.45})
+    logger.error("and now for an error", {"hello": "world", "vadim": 34.56})
     mock.emit.assert_called()
+    for call, (level, number) in zip(
+        mock.emit.call_args_list,
+        (
+            ("INFO", SeverityNumber.INFO),
+            ("WARNING", SeverityNumber.WARN),
+            ("ERROR", SeverityNumber.ERROR),
+        ),
+    ):
+        record = call[0][0]
+        assert record.severity_text == level
+        assert record.severity_number == number
 
 
 def test_loguru_session_request(mocker):


### PR DESCRIPTION
## Summary

Python logging would report a log level string of `warning` which out backend was not mapping correctly
to the `WARN` log level. Correct the issue and add a python unit test for loguru to validate the SDK-side.

## How did you test this change?

before
![Screenshot from 2024-02-07 14-57-29](https://github.com/highlight/highlight/assets/1351531/c08bd3b3-340b-4c89-a8f8-1c8be7a7cfbc)

after
![Screenshot from 2024-02-07 14-57-29](https://github.com/highlight/highlight/assets/1351531/d8607c9c-1b16-4eec-955e-55c5fe3eab54)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no