### PR TITLE
Fix histogram dates

### DIFF
--- a/frontend/src/pages/LogsPage/LogsCount/LogsCount.tsx
+++ b/frontend/src/pages/LogsPage/LogsCount/LogsCount.tsx
@@ -23,9 +23,9 @@ const LogsCount = ({
 		if (presetSelected) {
 			return `${formatDate(startDate)} to Now`
 		}
-		return `${moment(startDate).format('M/D/YY H:MM:SS')} to ${moment(
+		return `${moment(startDate).format('M/D/YY h:mm:ss')} to ${formatDate(
 			endDate,
-		).format('H:MM:SS A')}`
+		)}`
 	}, [endDate, startDate, presetSelected])
 
 	if (loading) {

--- a/frontend/src/pages/Traces/TracesPage.tsx
+++ b/frontend/src/pages/Traces/TracesPage.tsx
@@ -250,18 +250,18 @@ export const TracesPage: React.FC = () => {
 											{selectedPreset ? (
 												<>
 													{moment(startDate).format(
-														'M/D/YY H:MM:SS A',
+														'M/D/YY h:mm:ss A',
 													)}{' '}
 													to Now
 												</>
 											) : (
 												<>
 													{moment(startDate).format(
-														'M/D/YY H:MM:SS',
+														'M/D/YY h:mm:ss',
 													)}{' '}
 													to{' '}
 													{moment(endDate).format(
-														'H:MM:SS A',
+														'h:mm:ss A',
 													)}
 												</>
 											)}


### PR DESCRIPTION
## Summary
The histogram dates are using incorrect formatting:
- `MM` -> `mm`
- `SS` -> `ss`
- `H` -> `h`

More info [here](https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format/)

![Screenshot 2024-02-08 at 3 16 21 PM](https://github.com/highlight/highlight/assets/17744174/c9b641fa-dd7d-4cea-857a-c4f2e40a6687)

## How did you test this change?
1) View the logs page
2) Manually set the date for logs
- [ ] Histogram dates are correct
3) View the traces page
4) Manually set the date for traces
- [ ] Histogram dates are correct

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
