### PR TITLE
Empty state for search filter values

### DIFF
--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -602,37 +602,40 @@ export const Search: React.FC<{
 					sameWidth
 				>
 					<Box cssClass={styles.comboboxResults}>
-						{activePart.key === BODY_KEY &&
-							activePart.value.length > 0 && (
-								<Combobox.Group
-									className={styles.comboboxGroup}
+						{activePart.value.length > 0 && (
+							<Combobox.Group
+								className={styles.comboboxGroup}
+								store={comboboxStore}
+							>
+								<Combobox.Item
+									className={styles.comboboxItem}
+									onClick={submitAndBlur}
 									store={comboboxStore}
 								>
-									<Combobox.Item
-										className={styles.comboboxItem}
-										onClick={submitAndBlur}
-										store={comboboxStore}
-									>
-										<Stack direction="row" gap="4">
-											<Text
-												lines="1"
-												color="weak"
-												size="small"
-											>
-												Show all results for
-											</Text>{' '}
-											<Text
-												color="secondaryContentText"
-												size="small"
-											>
+									<Stack direction="row" gap="4">
+										<Text
+											lines="1"
+											color="weak"
+											size="small"
+										>
+											Show all results for
+										</Text>{' '}
+										<Text
+											color="secondaryContentText"
+											size="small"
+										>
+											<>
 												&lsquo;
-												{activePart.value}
+												{activePart.key === BODY_KEY
+													? activePart.value
+													: activePart.text}
 												&rsquo;
-											</Text>
-										</Stack>
-									</Combobox.Item>
-								</Combobox.Group>
-							)}
+											</>
+										</Text>
+									</Stack>
+								</Combobox.Item>
+							</Combobox.Group>
+						)}
 						{loading && visibleItems.length === 0 && (
 							<Combobox.Group
 								className={styles.comboboxGroup}


### PR DESCRIPTION
## Summary

Adds an empty state for search filter values when there aren't any matches.

**Before**
<img width="658" alt="Screenshot 2024-02-09 at 5 08 19 PM" src="https://github.com/highlight/highlight/assets/308182/302d09e1-c756-4de2-9077-1b13405c24c9">

**After**
<img width="651" alt="Screenshot 2024-02-09 at 5 08 09 PM" src="https://github.com/highlight/highlight/assets/308182/8f270d24-8086-4690-bbef-95d2ff1ca1e1">

## How did you test this change?

Tested entering a search filter query that had no results in prod and on the PR preview to confirm things looked good and behaved as expected.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A