### PR TITLE
Support for searching issues when creating them - Search and link existing issues with error or session comments.

### DIFF
--- a/backend/integrations/github/github.go
+++ b/backend/integrations/github/github.go
@@ -61,6 +61,7 @@ type ClientInterface interface {
 	GetRepoContent(ctx context.Context, githubPath string, path string, version string) (fileContent *github.RepositoryContent, directoryContent []*github.RepositoryContent, resp *github.Response, err error)
 	GetRepoBlob(ctx context.Context, githubPath string, blobSHA string) (*github.Blob, *github.Response, error)
 	GetLatestCommitHash(ctx context.Context, githubPath string) (string, *github.Response, error)
+	SearchIssues(ctx context.Context, rawQuery string) ([]*github.Issue, error)
 }
 
 type Client struct {
@@ -206,4 +207,16 @@ func (c *Client) GetRepoBlob(ctx context.Context, githubPath string, blobSHA str
 func (c *Client) GetLatestCommitHash(ctx context.Context, githubPath string) (string, *github.Response, error) {
 	repoPath := strings.Split(githubPath, "/")
 	return c.client.Repositories.GetCommitSHA1(ctx, repoPath[0], repoPath[1], "HEAD", "")
+}
+
+func (c *Client) SearchIssues(ctx context.Context, rawQuery string) ([]*github.Issue, error) {
+	owner, err := c.GetInstallationOwner(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	query := fmt.Sprintf("owner:%s %s", *owner, rawQuery)
+
+	rearch_result, _, err := c.client.Search.Issues(ctx, query, &github.SearchOptions{})
+	return rearch_result.Issues, err
 }

--- a/backend/integrations/gitlab/gitlab.go
+++ b/backend/integrations/gitlab/gitlab.go
@@ -319,17 +319,6 @@ func CreateGitlabTask(accessToken string, projectId string, payload NewGitlabIss
 	return res, nil
 }
 
-func GetGitlabTask(accessToken string, taskId string) (*GitlabIssue, error) {
-	url := fmt.Sprintf("%s/issues/%s", GitlabApiBaseUrl, taskId)
-
-	res, err := doGitlabGetRequest[*GitlabIssue](accessToken, url)
-	if err != nil {
-		return nil, err
-	}
-
-	return res, nil
-}
-
 func GetRefreshToken(ctx context.Context, oldToken *oauth2.Token) (*oauth2.Token, error) {
 	conf, _, err := GetOAuthConfig()
 	if err != nil {

--- a/backend/integrations/gitlab/gitlab.go
+++ b/backend/integrations/gitlab/gitlab.go
@@ -287,6 +287,22 @@ func GetGitlabProjects(workspace *model.Workspace, accessToken string) ([]*model
 	}), nil
 }
 
+func SearchGitlabIssues(accessToken string, query string) ([]*modelInputs.IssuesSearchResult, error) {
+	url := fmt.Sprintf("%s/issues?search=%s", GitlabApiBaseUrl, url.QueryEscape(query))
+	res, err := doGitlabGetRequest[[]GitlabIssue](accessToken, url)
+	if err != nil {
+		return nil, err
+	}
+
+	return lo.Map(res, func(res GitlabIssue, _ int) *modelInputs.IssuesSearchResult {
+		return &modelInputs.IssuesSearchResult{
+			ID:       fmt.Sprint(res.ID),
+			Title:    res.Title,
+			IssueURL: res.WebURL,
+		}
+	}), nil
+}
+
 type NewGitlabIssuePayload struct {
 	Title       string `json:"title"`
 	Description string `json:"description"`
@@ -296,6 +312,17 @@ func CreateGitlabTask(accessToken string, projectId string, payload NewGitlabIss
 	url := fmt.Sprintf("%s/projects/%s/issues", GitlabApiBaseUrl, projectId)
 
 	res, err := doGitlabPostRequest[*GitlabIssue](accessToken, url, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func GetGitlabTask(accessToken string, taskId string) (*GitlabIssue, error) {
+	url := fmt.Sprintf("%s/issues/%s", GitlabApiBaseUrl, taskId)
+
+	res, err := doGitlabGetRequest[*GitlabIssue](accessToken, url)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/integrations/gitlab/gitlab.go
+++ b/backend/integrations/gitlab/gitlab.go
@@ -297,7 +297,7 @@ func SearchGitlabIssues(accessToken string, query string) ([]*modelInputs.Issues
 	return lo.Map(res, func(res GitlabIssue, _ int) *modelInputs.IssuesSearchResult {
 		return &modelInputs.IssuesSearchResult{
 			ID:       fmt.Sprint(res.ID),
-			Title:    res.Title,
+			Title:    fmt.Sprintf("#%d - %s", res.IID, res.Title),
 			IssueURL: res.WebURL,
 		}
 	}), nil

--- a/backend/integrations/height/height.go
+++ b/backend/integrations/height/height.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/pkg/errors"
@@ -245,4 +246,66 @@ func CreateTask(accessToken string, listId string, name string, description stri
 		// The external attachment data model prepends the URL on the frontend.
 		ID: strings.TrimPrefix(res.URL, "https://height.app/"),
 	}, nil
+}
+
+func makeQueryParams(query string) string {
+	lastActivity := time.Now().AddDate(-5, 0, 0).UTC().Format("2006-01-02T15:04:05Z")
+
+	order := []struct {
+		Column    string `json:"column"`
+		Direction string `json:"direction"`
+	}{
+		{Column: "lastActivityAt", Direction: "DESC"},
+	}
+
+	orderStr, _ := json.Marshal(order)
+	filter := map[string]interface{}{
+		"lastActivityAt": map[string]interface{}{
+			"gt": map[string]string{
+				"date": lastActivity,
+			},
+		},
+	}
+
+	filterStr, _ := json.Marshal(filter)
+
+	params := map[string]interface{}{
+		"query":   query,
+		"order":   string(orderStr),
+		"filters": string(filterStr),
+	}
+
+	queryParams := url.Values{}
+	for key, value := range params {
+		queryParams.Set(key, fmt.Sprintf("%v", value))
+	}
+	return queryParams.Encode()
+}
+
+func SearchTask(accessToken string, query string) ([]*model.IssuesSearchResult, error) {
+	type HeightTask struct {
+		Name string `json:"name"`
+		URL  string `json:"url"`
+		ID   string `json:"id"`
+	}
+
+	type HeightTaskSearchResponse struct {
+		List []HeightTask `json:"list"`
+	}
+
+	url := fmt.Sprintf("/tasks?%s", makeQueryParams(query))
+	fmt.Println("URL", url)
+	results, err := doGetRequest[HeightTaskSearchResponse](accessToken, url)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return lo.Map(results.List, func(res HeightTask, _ int) *model.IssuesSearchResult {
+		return &model.IssuesSearchResult{
+			ID:       res.ID,
+			Title:    res.Name,
+			IssueURL: res.URL,
+		}
+	}), nil
 }

--- a/backend/integrations/height/height.go
+++ b/backend/integrations/height/height.go
@@ -284,9 +284,10 @@ func makeQueryParams(query string) string {
 
 func SearchTask(accessToken string, query string) ([]*model.IssuesSearchResult, error) {
 	type HeightTask struct {
-		Name string `json:"name"`
-		URL  string `json:"url"`
-		ID   string `json:"id"`
+		Name  string `json:"name"`
+		URL   string `json:"url"`
+		ID    string `json:"id"`
+		Index int    `json:"index"`
 	}
 
 	type HeightTaskSearchResponse struct {
@@ -294,7 +295,6 @@ func SearchTask(accessToken string, query string) ([]*model.IssuesSearchResult, 
 	}
 
 	url := fmt.Sprintf("/tasks?%s", makeQueryParams(query))
-	fmt.Println("URL", url)
 	results, err := doGetRequest[HeightTaskSearchResponse](accessToken, url)
 
 	if err != nil {
@@ -304,7 +304,7 @@ func SearchTask(accessToken string, query string) ([]*model.IssuesSearchResult, 
 	return lo.Map(results.List, func(res HeightTask, _ int) *model.IssuesSearchResult {
 		return &model.IssuesSearchResult{
 			ID:       res.ID,
-			Title:    res.Name,
+			Title:    fmt.Sprintf("#%d - %s", res.Index, res.Name),
 			IssueURL: res.URL,
 		}
 	}), nil

--- a/backend/integrations/jira/jira.go
+++ b/backend/integrations/jira/jira.go
@@ -236,7 +236,7 @@ func SearchJiraIssues(accessToken string, workspace *model.Workspace, query stri
 	return lo.Map(results, func(res JiraIssuesAutoCompleteResponse, _ int) *modelInputs.IssuesSearchResult {
 		return &modelInputs.IssuesSearchResult{
 			ID:       fmt.Sprint(res.ID),
-			Title:    res.SummaryText,
+			Title:    fmt.Sprintf("[%s] %s", res.Key, res.SummaryText),
 			IssueURL: MakeExternalIdForJiraTask(workspace, res.Key),
 		}
 	}), nil

--- a/backend/integrations/jira/jira.go
+++ b/backend/integrations/jira/jira.go
@@ -209,7 +209,7 @@ func GetJiraSite(accessToken string) (*modelInputs.AccessibleJiraResources, erro
 }
 
 func SearchJiraIssues(accessToken string, workspace *model.Workspace, query string) ([]*modelInputs.IssuesSearchResult, error) {
-	url := fmt.Sprintf("/ex/jira/%s/rest/api/2/issue/picker?currentJQL=text~timeout", *workspace.JiraCloudID)
+	url := fmt.Sprintf("/ex/jira/%s/rest/api/2/issue/picker?currentJQL=text~%s", *workspace.JiraCloudID, query)
 	res, err := doJiraGetRequest[JiraAutoCompleteSearchResponse](accessToken, url)
 	if err != nil {
 		return nil, err

--- a/backend/integrations/jira/jira.go
+++ b/backend/integrations/jira/jira.go
@@ -234,11 +234,10 @@ func SearchJiraIssues(accessToken string, workspace *model.Workspace, query stri
 	}
 
 	return lo.Map(results, func(res JiraIssuesAutoCompleteResponse, _ int) *modelInputs.IssuesSearchResult {
-		issueUrl := MakeExternalIdForJiraTask(workspace, res.Key)
 		return &modelInputs.IssuesSearchResult{
 			ID:       fmt.Sprint(res.ID),
 			Title:    res.SummaryText,
-			IssueURL: issueUrl,
+			IssueURL: MakeExternalIdForJiraTask(workspace, res.Key),
 		}
 	}), nil
 }

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -583,6 +583,12 @@ type ComplexityRoot struct {
 		URL          func(childComplexity int) int
 	}
 
+	IssuesSearchResult struct {
+		ID       func(childComplexity int) int
+		IssueURL func(childComplexity int) int
+		Title    func(childComplexity int) int
+	}
+
 	JiraIssueType struct {
 		Description      func(childComplexity int) int
 		ID               func(childComplexity int) int
@@ -762,93 +768,94 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		AddAdminToWorkspace              func(childComplexity int, workspaceID int, inviteID string) int
-		AddIntegrationToProject          func(childComplexity int, integrationType *model.IntegrationType, projectID int, code string) int
-		AddIntegrationToWorkspace        func(childComplexity int, integrationType *model.IntegrationType, workspaceID int, code string) int
-		ChangeAdminRole                  func(childComplexity int, workspaceID int, adminID int, newRole string) int
-		CreateAdmin                      func(childComplexity int) int
-		CreateErrorAlert                 func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency int, defaultArg *bool) int
-		CreateErrorComment               func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
-		CreateErrorSegment               func(childComplexity int, projectID int, name string, query string) int
-		CreateErrorTag                   func(childComplexity int, title string, description string) int
-		CreateIssueForErrorComment       func(childComplexity int, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
-		CreateIssueForSessionComment     func(childComplexity int, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
-		CreateLogAlert                   func(childComplexity int, input model.LogAlertInput) int
-		CreateMetricMonitor              func(childComplexity int, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) int
-		CreateOrUpdateStripeSubscription func(childComplexity int, workspaceID int) int
-		CreateProject                    func(childComplexity int, name string, workspaceID int) int
-		CreateSavedSegment               func(childComplexity int, projectID int, name string, entityType model.SavedSegmentEntityType, query string) int
-		CreateSegment                    func(childComplexity int, projectID int, name string, query string) int
-		CreateSessionAlert               func(childComplexity int, input model.SessionAlertInput) int
-		CreateSessionComment             func(childComplexity int, projectID int, sessionSecureID string, sessionTimestamp int, text string, textForEmail string, xCoordinate float64, yCoordinate float64, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, sessionURL string, time float64, authorName string, sessionImage *string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType, tags []*model.SessionCommentTagInput, additionalContext *string) int
-		CreateWorkspace                  func(childComplexity int, name string, promoCode *string) int
-		DeleteAdminFromProject           func(childComplexity int, projectID int, adminID int) int
-		DeleteAdminFromWorkspace         func(childComplexity int, workspaceID int, adminID int) int
-		DeleteDashboard                  func(childComplexity int, id int) int
-		DeleteErrorAlert                 func(childComplexity int, projectID int, errorAlertID int) int
-		DeleteErrorComment               func(childComplexity int, id int) int
-		DeleteErrorSegment               func(childComplexity int, segmentID int) int
-		DeleteInviteLinkFromWorkspace    func(childComplexity int, workspaceID int, workspaceInviteLinkID int) int
-		DeleteLogAlert                   func(childComplexity int, projectID int, id int) int
-		DeleteMetricMonitor              func(childComplexity int, projectID int, metricMonitorID int) int
-		DeleteProject                    func(childComplexity int, id int) int
-		DeleteSavedSegment               func(childComplexity int, segmentID int) int
-		DeleteSegment                    func(childComplexity int, segmentID int) int
-		DeleteSessionAlert               func(childComplexity int, projectID int, sessionAlertID int) int
-		DeleteSessionComment             func(childComplexity int, id int) int
-		DeleteSessions                   func(childComplexity int, projectID int, query model.ClickhouseQuery, sessionCount int) int
-		EditErrorSegment                 func(childComplexity int, id int, projectID int, query string, name string) int
-		EditProject                      func(childComplexity int, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool) int
-		EditProjectSettings              func(childComplexity int, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool, filterSessionsWithoutError *bool, autoResolveStaleErrorsDayInterval *int, sampling *model.SamplingInput) int
-		EditSavedSegment                 func(childComplexity int, id int, projectID int, name string, entityType model.SavedSegmentEntityType, query string) int
-		EditSegment                      func(childComplexity int, id int, projectID int, query string, name string) int
-		EditServiceGithubSettings        func(childComplexity int, id int, projectID int, githubRepoPath *string, buildPrefix *string, githubPrefix *string) int
-		EditWorkspace                    func(childComplexity int, id int, name *string) int
-		EditWorkspaceSettings            func(childComplexity int, workspaceID int, aiApplication *bool, aiInsights *bool) int
-		EmailSignup                      func(childComplexity int, email string) int
-		ExportSession                    func(childComplexity int, sessionSecureID string) int
-		HandleAWSMarketplace             func(childComplexity int, workspaceID int, code string) int
-		JoinWorkspace                    func(childComplexity int, workspaceID int) int
-		MarkErrorGroupAsViewed           func(childComplexity int, errorSecureID string, viewed *bool) int
-		MarkSessionAsViewed              func(childComplexity int, secureID string, viewed *bool) int
-		ModifyClearbitIntegration        func(childComplexity int, workspaceID int, enabled bool) int
-		MuteErrorCommentThread           func(childComplexity int, id int, hasMuted *bool) int
-		MuteSessionCommentThread         func(childComplexity int, id int, hasMuted *bool) int
-		RemoveErrorIssue                 func(childComplexity int, errorIssueID int) int
-		RemoveIntegrationFromProject     func(childComplexity int, integrationType *model.IntegrationType, projectID int) int
-		RemoveIntegrationFromWorkspace   func(childComplexity int, integrationType model.IntegrationType, workspaceID int) int
-		ReplyToErrorComment              func(childComplexity int, commentID int, text string, textForEmail string, errorURL string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput) int
-		ReplyToSessionComment            func(childComplexity int, commentID int, text string, textForEmail string, sessionURL string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput) int
-		RequestAccess                    func(childComplexity int, projectID int) int
-		SaveBillingPlan                  func(childComplexity int, workspaceID int, sessionsLimitCents *int, sessionsRetention model.RetentionPeriod, errorsLimitCents *int, errorsRetention model.RetentionPeriod, logsLimitCents *int, logsRetention model.RetentionPeriod, tracesLimitCents *int, tracesRetention model.RetentionPeriod) int
-		SendAdminWorkspaceInvite         func(childComplexity int, workspaceID int, email string, baseURL string, role string) int
-		SubmitRegistrationForm           func(childComplexity int, workspaceID int, teamSize string, role string, useCase string, heardAbout string, pun *string) int
-		SyncSlackIntegration             func(childComplexity int, projectID int) int
-		TestErrorEnhancement             func(childComplexity int, errorObjectID int, githubRepoPath string, githubPrefix *string, buildPrefix *string, saveError *bool) int
-		UpdateAdminAboutYouDetails       func(childComplexity int, adminDetails model.AdminAboutYouDetails) int
-		UpdateAdminAndCreateWorkspace    func(childComplexity int, adminAndWorkspaceDetails model.AdminAndWorkspaceDetails) int
-		UpdateAllowMeterOverage          func(childComplexity int, workspaceID int, allowMeterOverage bool) int
-		UpdateAllowedEmailOrigins        func(childComplexity int, workspaceID int, allowedAutoJoinEmailOrigins string) int
-		UpdateBillingDetails             func(childComplexity int, workspaceID int) int
-		UpdateClickUpProjectMappings     func(childComplexity int, workspaceID int, projectMappings []*model.ClickUpProjectMappingInput) int
-		UpdateEmailOptOut                func(childComplexity int, token *string, adminID *int, category model.EmailOptOutCategory, isOptOut bool, projectID *int) int
-		UpdateErrorAlert                 func(childComplexity int, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) int
-		UpdateErrorAlertIsDisabled       func(childComplexity int, id int, projectID int, disabled bool) int
-		UpdateErrorGroupIsPublic         func(childComplexity int, errorGroupSecureID string, isPublic bool) int
-		UpdateErrorGroupState            func(childComplexity int, secureID string, state model.ErrorState, snoozedUntil *time.Time) int
-		UpdateErrorTags                  func(childComplexity int) int
-		UpdateIntegrationProjectMappings func(childComplexity int, workspaceID int, integrationType model.IntegrationType, projectMappings []*model.IntegrationProjectMappingInput) int
-		UpdateLogAlert                   func(childComplexity int, id int, input model.LogAlertInput) int
-		UpdateLogAlertIsDisabled         func(childComplexity int, id int, projectID int, disabled bool) int
-		UpdateMetricMonitor              func(childComplexity int, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) int
-		UpdateMetricMonitorIsDisabled    func(childComplexity int, id int, projectID int, disabled bool) int
-		UpdateSessionAlert               func(childComplexity int, id int, input model.SessionAlertInput) int
-		UpdateSessionAlertIsDisabled     func(childComplexity int, id int, projectID int, disabled bool) int
-		UpdateSessionIsPublic            func(childComplexity int, sessionSecureID string, isPublic bool) int
-		UpdateVercelProjectMappings      func(childComplexity int, projectID int, projectMappings []*model.VercelProjectMappingInput) int
-		UpsertDashboard                  func(childComplexity int, id *int, projectID int, name string, metrics []*model.DashboardMetricConfigInput, layout *string, isDefault *bool) int
-		UpsertDiscordChannel             func(childComplexity int, projectID int, name string) int
-		UpsertSlackChannel               func(childComplexity int, projectID int, name string) int
+		AddAdminToWorkspace                func(childComplexity int, workspaceID int, inviteID string) int
+		AddIntegrationToProject            func(childComplexity int, integrationType *model.IntegrationType, projectID int, code string) int
+		AddIntegrationToWorkspace          func(childComplexity int, integrationType *model.IntegrationType, workspaceID int, code string) int
+		ChangeAdminRole                    func(childComplexity int, workspaceID int, adminID int, newRole string) int
+		CreateAdmin                        func(childComplexity int) int
+		CreateErrorAlert                   func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency int, defaultArg *bool) int
+		CreateErrorComment                 func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
+		CreateErrorCommentForExistingIssue func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueURL string, issueTitle string, issueID string, integrations []*model.IntegrationType) int
+		CreateErrorSegment                 func(childComplexity int, projectID int, name string, query string) int
+		CreateErrorTag                     func(childComplexity int, title string, description string) int
+		CreateIssueForErrorComment         func(childComplexity int, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
+		CreateIssueForSessionComment       func(childComplexity int, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
+		CreateLogAlert                     func(childComplexity int, input model.LogAlertInput) int
+		CreateMetricMonitor                func(childComplexity int, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) int
+		CreateOrUpdateStripeSubscription   func(childComplexity int, workspaceID int) int
+		CreateProject                      func(childComplexity int, name string, workspaceID int) int
+		CreateSavedSegment                 func(childComplexity int, projectID int, name string, entityType model.SavedSegmentEntityType, query string) int
+		CreateSegment                      func(childComplexity int, projectID int, name string, query string) int
+		CreateSessionAlert                 func(childComplexity int, input model.SessionAlertInput) int
+		CreateSessionComment               func(childComplexity int, projectID int, sessionSecureID string, sessionTimestamp int, text string, textForEmail string, xCoordinate float64, yCoordinate float64, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, sessionURL string, time float64, authorName string, sessionImage *string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType, tags []*model.SessionCommentTagInput, additionalContext *string) int
+		CreateWorkspace                    func(childComplexity int, name string, promoCode *string) int
+		DeleteAdminFromProject             func(childComplexity int, projectID int, adminID int) int
+		DeleteAdminFromWorkspace           func(childComplexity int, workspaceID int, adminID int) int
+		DeleteDashboard                    func(childComplexity int, id int) int
+		DeleteErrorAlert                   func(childComplexity int, projectID int, errorAlertID int) int
+		DeleteErrorComment                 func(childComplexity int, id int) int
+		DeleteErrorSegment                 func(childComplexity int, segmentID int) int
+		DeleteInviteLinkFromWorkspace      func(childComplexity int, workspaceID int, workspaceInviteLinkID int) int
+		DeleteLogAlert                     func(childComplexity int, projectID int, id int) int
+		DeleteMetricMonitor                func(childComplexity int, projectID int, metricMonitorID int) int
+		DeleteProject                      func(childComplexity int, id int) int
+		DeleteSavedSegment                 func(childComplexity int, segmentID int) int
+		DeleteSegment                      func(childComplexity int, segmentID int) int
+		DeleteSessionAlert                 func(childComplexity int, projectID int, sessionAlertID int) int
+		DeleteSessionComment               func(childComplexity int, id int) int
+		DeleteSessions                     func(childComplexity int, projectID int, query model.ClickhouseQuery, sessionCount int) int
+		EditErrorSegment                   func(childComplexity int, id int, projectID int, query string, name string) int
+		EditProject                        func(childComplexity int, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool) int
+		EditProjectSettings                func(childComplexity int, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool, filterSessionsWithoutError *bool, autoResolveStaleErrorsDayInterval *int, sampling *model.SamplingInput) int
+		EditSavedSegment                   func(childComplexity int, id int, projectID int, name string, entityType model.SavedSegmentEntityType, query string) int
+		EditSegment                        func(childComplexity int, id int, projectID int, query string, name string) int
+		EditServiceGithubSettings          func(childComplexity int, id int, projectID int, githubRepoPath *string, buildPrefix *string, githubPrefix *string) int
+		EditWorkspace                      func(childComplexity int, id int, name *string) int
+		EditWorkspaceSettings              func(childComplexity int, workspaceID int, aiApplication *bool, aiInsights *bool) int
+		EmailSignup                        func(childComplexity int, email string) int
+		ExportSession                      func(childComplexity int, sessionSecureID string) int
+		HandleAWSMarketplace               func(childComplexity int, workspaceID int, code string) int
+		JoinWorkspace                      func(childComplexity int, workspaceID int) int
+		MarkErrorGroupAsViewed             func(childComplexity int, errorSecureID string, viewed *bool) int
+		MarkSessionAsViewed                func(childComplexity int, secureID string, viewed *bool) int
+		ModifyClearbitIntegration          func(childComplexity int, workspaceID int, enabled bool) int
+		MuteErrorCommentThread             func(childComplexity int, id int, hasMuted *bool) int
+		MuteSessionCommentThread           func(childComplexity int, id int, hasMuted *bool) int
+		RemoveErrorIssue                   func(childComplexity int, errorIssueID int) int
+		RemoveIntegrationFromProject       func(childComplexity int, integrationType *model.IntegrationType, projectID int) int
+		RemoveIntegrationFromWorkspace     func(childComplexity int, integrationType model.IntegrationType, workspaceID int) int
+		ReplyToErrorComment                func(childComplexity int, commentID int, text string, textForEmail string, errorURL string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput) int
+		ReplyToSessionComment              func(childComplexity int, commentID int, text string, textForEmail string, sessionURL string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput) int
+		RequestAccess                      func(childComplexity int, projectID int) int
+		SaveBillingPlan                    func(childComplexity int, workspaceID int, sessionsLimitCents *int, sessionsRetention model.RetentionPeriod, errorsLimitCents *int, errorsRetention model.RetentionPeriod, logsLimitCents *int, logsRetention model.RetentionPeriod, tracesLimitCents *int, tracesRetention model.RetentionPeriod) int
+		SendAdminWorkspaceInvite           func(childComplexity int, workspaceID int, email string, baseURL string, role string) int
+		SubmitRegistrationForm             func(childComplexity int, workspaceID int, teamSize string, role string, useCase string, heardAbout string, pun *string) int
+		SyncSlackIntegration               func(childComplexity int, projectID int) int
+		TestErrorEnhancement               func(childComplexity int, errorObjectID int, githubRepoPath string, githubPrefix *string, buildPrefix *string, saveError *bool) int
+		UpdateAdminAboutYouDetails         func(childComplexity int, adminDetails model.AdminAboutYouDetails) int
+		UpdateAdminAndCreateWorkspace      func(childComplexity int, adminAndWorkspaceDetails model.AdminAndWorkspaceDetails) int
+		UpdateAllowMeterOverage            func(childComplexity int, workspaceID int, allowMeterOverage bool) int
+		UpdateAllowedEmailOrigins          func(childComplexity int, workspaceID int, allowedAutoJoinEmailOrigins string) int
+		UpdateBillingDetails               func(childComplexity int, workspaceID int) int
+		UpdateClickUpProjectMappings       func(childComplexity int, workspaceID int, projectMappings []*model.ClickUpProjectMappingInput) int
+		UpdateEmailOptOut                  func(childComplexity int, token *string, adminID *int, category model.EmailOptOutCategory, isOptOut bool, projectID *int) int
+		UpdateErrorAlert                   func(childComplexity int, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) int
+		UpdateErrorAlertIsDisabled         func(childComplexity int, id int, projectID int, disabled bool) int
+		UpdateErrorGroupIsPublic           func(childComplexity int, errorGroupSecureID string, isPublic bool) int
+		UpdateErrorGroupState              func(childComplexity int, secureID string, state model.ErrorState, snoozedUntil *time.Time) int
+		UpdateErrorTags                    func(childComplexity int) int
+		UpdateIntegrationProjectMappings   func(childComplexity int, workspaceID int, integrationType model.IntegrationType, projectMappings []*model.IntegrationProjectMappingInput) int
+		UpdateLogAlert                     func(childComplexity int, id int, input model.LogAlertInput) int
+		UpdateLogAlertIsDisabled           func(childComplexity int, id int, projectID int, disabled bool) int
+		UpdateMetricMonitor                func(childComplexity int, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) int
+		UpdateMetricMonitorIsDisabled      func(childComplexity int, id int, projectID int, disabled bool) int
+		UpdateSessionAlert                 func(childComplexity int, id int, input model.SessionAlertInput) int
+		UpdateSessionAlertIsDisabled       func(childComplexity int, id int, projectID int, disabled bool) int
+		UpdateSessionIsPublic              func(childComplexity int, sessionSecureID string, isPublic bool) int
+		UpdateVercelProjectMappings        func(childComplexity int, projectID int, projectMappings []*model.VercelProjectMappingInput) int
+		UpsertDashboard                    func(childComplexity int, id *int, projectID int, name string, metrics []*model.DashboardMetricConfigInput, layout *string, isDefault *bool) int
+		UpsertDiscordChannel               func(childComplexity int, projectID int, name string) int
+		UpsertSlackChannel                 func(childComplexity int, projectID int, name string) int
 	}
 
 	NamedCount struct {
@@ -1012,6 +1019,7 @@ type ComplexityRoot struct {
 		Referrers                        func(childComplexity int, projectID int, lookbackDays float64) int
 		Resources                        func(childComplexity int, sessionSecureID string) int
 		SavedSegments                    func(childComplexity int, projectID int, entityType model.SavedSegmentEntityType) int
+		SearchIssues                     func(childComplexity int, integrationType model.IntegrationType, projectID int, query string) int
 		Segments                         func(childComplexity int, projectID int) int
 		ServerIntegration                func(childComplexity int, projectID int) int
 		ServiceByName                    func(childComplexity int, projectID int, name string) int
@@ -1665,6 +1673,7 @@ type MutationResolver interface {
 	MuteSessionCommentThread(ctx context.Context, id int, hasMuted *bool) (*bool, error)
 	ReplyToSessionComment(ctx context.Context, commentID int, text string, textForEmail string, sessionURL string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput) (*model1.CommentReply, error)
 	CreateErrorComment(ctx context.Context, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) (*model1.ErrorComment, error)
+	CreateErrorCommentForExistingIssue(ctx context.Context, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueURL string, issueTitle string, issueID string, integrations []*model.IntegrationType) (*model1.ErrorComment, error)
 	RemoveErrorIssue(ctx context.Context, errorIssueID int) (*bool, error)
 	MuteErrorCommentThread(ctx context.Context, id int, hasMuted *bool) (*bool, error)
 	CreateIssueForErrorComment(ctx context.Context, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) (*model1.ErrorComment, error)
@@ -1794,6 +1803,7 @@ type QueryResolver interface {
 	MicrosoftTeamsChannelSuggestions(ctx context.Context, projectID int) ([]*model1.MicrosoftTeamsChannel, error)
 	DiscordChannelSuggestions(ctx context.Context, projectID int) ([]*model1.DiscordChannel, error)
 	GenerateZapierAccessToken(ctx context.Context, projectID int) (string, error)
+	SearchIssues(ctx context.Context, integrationType model.IntegrationType, projectID int, query string) ([]*model.IssuesSearchResult, error)
 	IsIntegratedWith(ctx context.Context, integrationType model.IntegrationType, projectID int) (bool, error)
 	IsWorkspaceIntegratedWith(ctx context.Context, integrationType model.IntegrationType, workspaceID int) (bool, error)
 	IsProjectIntegratedWith(ctx context.Context, integrationType model.IntegrationType, projectID int) (bool, error)
@@ -4341,6 +4351,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Invoice.URL(childComplexity), true
 
+	case "IssuesSearchResult.id":
+		if e.complexity.IssuesSearchResult.ID == nil {
+			break
+		}
+
+		return e.complexity.IssuesSearchResult.ID(childComplexity), true
+
+	case "IssuesSearchResult.issue_url":
+		if e.complexity.IssuesSearchResult.IssueURL == nil {
+			break
+		}
+
+		return e.complexity.IssuesSearchResult.IssueURL(childComplexity), true
+
+	case "IssuesSearchResult.title":
+		if e.complexity.IssuesSearchResult.Title == nil {
+			break
+		}
+
+		return e.complexity.IssuesSearchResult.Title(childComplexity), true
+
 	case "JiraIssueType.description":
 		if e.complexity.JiraIssueType.Description == nil {
 			break
@@ -5182,6 +5213,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.CreateErrorComment(childComplexity, args["project_id"].(int), args["error_group_secure_id"].(string), args["text"].(string), args["text_for_email"].(string), args["tagged_admins"].([]*model.SanitizedAdminInput), args["tagged_slack_users"].([]*model.SanitizedSlackChannelInput), args["error_url"].(string), args["author_name"].(string), args["issue_title"].(*string), args["issue_description"].(*string), args["issue_team_id"].(*string), args["issue_type_id"].(*string), args["integrations"].([]*model.IntegrationType)), true
+
+	case "Mutation.createErrorCommentForExistingIssue":
+		if e.complexity.Mutation.CreateErrorCommentForExistingIssue == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createErrorCommentForExistingIssue_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateErrorCommentForExistingIssue(childComplexity, args["project_id"].(int), args["error_group_secure_id"].(string), args["text"].(string), args["text_for_email"].(string), args["tagged_admins"].([]*model.SanitizedAdminInput), args["tagged_slack_users"].([]*model.SanitizedSlackChannelInput), args["error_url"].(string), args["author_name"].(string), args["issue_url"].(string), args["issue_title"].(string), args["issue_id"].(string), args["integrations"].([]*model.IntegrationType)), true
 
 	case "Mutation.createErrorSegment":
 		if e.complexity.Mutation.CreateErrorSegment == nil {
@@ -7636,6 +7679,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.SavedSegments(childComplexity, args["project_id"].(int), args["entity_type"].(model.SavedSegmentEntityType)), true
+
+	case "Query.search_issues":
+		if e.complexity.Query.SearchIssues == nil {
+			break
+		}
+
+		args, err := ec.field_Query_search_issues_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.SearchIssues(childComplexity, args["integration_type"].(model.IntegrationType), args["project_id"].(int), args["query"].(string)), true
 
 	case "Query.segments":
 		if e.complexity.Query.Segments == nil {
@@ -12157,6 +12212,12 @@ type MicrosoftTeamsChannel {
 	name: String!
 }
 
+type IssuesSearchResult {
+	id: String!
+	title: String!
+	issue_url: String!
+}
+
 input MicrosoftTeamsChannelInput {
 	name: String!
 	id: String!
@@ -12637,6 +12698,11 @@ type Query {
 	): [MicrosoftTeamsChannel!]!
 	discord_channel_suggestions(project_id: ID!): [DiscordChannel!]!
 	generate_zapier_access_token(project_id: ID!): String!
+	search_issues(
+		integration_type: IntegrationType!
+		project_id: ID!
+		query: String!
+	): [IssuesSearchResult!]!
 	is_integrated_with(
 		integration_type: IntegrationType!
 		project_id: ID!
@@ -13025,6 +13091,20 @@ type Mutation {
 		issue_description: String
 		issue_team_id: String
 		issue_type_id: String
+		integrations: [IntegrationType]!
+	): ErrorComment
+	createErrorCommentForExistingIssue(
+		project_id: ID!
+		error_group_secure_id: String!
+		text: String!
+		text_for_email: String!
+		tagged_admins: [SanitizedAdminInput]!
+		tagged_slack_users: [SanitizedSlackChannelInput]!
+		error_url: String!
+		author_name: String!
+		issue_url: String!
+		issue_title: String!
+		issue_id: String!
 		integrations: [IntegrationType]!
 	): ErrorComment
 	removeErrorIssue(error_issue_id: ID!): Boolean
@@ -13493,6 +13573,120 @@ func (ec *executionContext) field_Mutation_createErrorAlert_args(ctx context.Con
 		}
 	}
 	args["default"] = arg12
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_createErrorCommentForExistingIssue_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["error_group_secure_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_group_secure_id"))
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["error_group_secure_id"] = arg1
+	var arg2 string
+	if tmp, ok := rawArgs["text"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("text"))
+		arg2, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["text"] = arg2
+	var arg3 string
+	if tmp, ok := rawArgs["text_for_email"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("text_for_email"))
+		arg3, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["text_for_email"] = arg3
+	var arg4 []*model.SanitizedAdminInput
+	if tmp, ok := rawArgs["tagged_admins"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tagged_admins"))
+		arg4, err = ec.unmarshalNSanitizedAdminInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSanitizedAdminInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["tagged_admins"] = arg4
+	var arg5 []*model.SanitizedSlackChannelInput
+	if tmp, ok := rawArgs["tagged_slack_users"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tagged_slack_users"))
+		arg5, err = ec.unmarshalNSanitizedSlackChannelInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSanitizedSlackChannelInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["tagged_slack_users"] = arg5
+	var arg6 string
+	if tmp, ok := rawArgs["error_url"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_url"))
+		arg6, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["error_url"] = arg6
+	var arg7 string
+	if tmp, ok := rawArgs["author_name"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("author_name"))
+		arg7, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["author_name"] = arg7
+	var arg8 string
+	if tmp, ok := rawArgs["issue_url"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_url"))
+		arg8, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_url"] = arg8
+	var arg9 string
+	if tmp, ok := rawArgs["issue_title"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_title"))
+		arg9, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_title"] = arg9
+	var arg10 string
+	if tmp, ok := rawArgs["issue_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_id"))
+		arg10, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_id"] = arg10
+	var arg11 []*model.IntegrationType
+	if tmp, ok := rawArgs["integrations"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("integrations"))
+		arg11, err = ec.unmarshalNIntegrationType2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐIntegrationType(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["integrations"] = arg11
 	return args, nil
 }
 
@@ -18995,6 +19189,39 @@ func (ec *executionContext) field_Query_saved_segments_args(ctx context.Context,
 		}
 	}
 	args["entity_type"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_search_issues_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.IntegrationType
+	if tmp, ok := rawArgs["integration_type"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("integration_type"))
+		arg0, err = ec.unmarshalNIntegrationType2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐIntegrationType(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["integration_type"] = arg0
+	var arg1 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg1, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg1
+	var arg2 string
+	if tmp, ok := rawArgs["query"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
+		arg2, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["query"] = arg2
 	return args, nil
 }
 
@@ -35579,6 +35806,138 @@ func (ec *executionContext) fieldContext_Invoice_status(ctx context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _IssuesSearchResult_id(ctx context.Context, field graphql.CollectedField, obj *model.IssuesSearchResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IssuesSearchResult_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_IssuesSearchResult_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "IssuesSearchResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _IssuesSearchResult_title(ctx context.Context, field graphql.CollectedField, obj *model.IssuesSearchResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IssuesSearchResult_title(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Title, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_IssuesSearchResult_title(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "IssuesSearchResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _IssuesSearchResult_issue_url(ctx context.Context, field graphql.CollectedField, obj *model.IssuesSearchResult) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IssuesSearchResult_issue_url(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IssueURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_IssuesSearchResult_issue_url(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "IssuesSearchResult",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _JiraIssueType_self(ctx context.Context, field graphql.CollectedField, obj *model.JiraIssueType) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_JiraIssueType_self(ctx, field)
 	if err != nil {
@@ -43211,6 +43570,79 @@ func (ec *executionContext) fieldContext_Mutation_createErrorComment(ctx context
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_createErrorComment_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_createErrorCommentForExistingIssue(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createErrorCommentForExistingIssue(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateErrorCommentForExistingIssue(rctx, fc.Args["project_id"].(int), fc.Args["error_group_secure_id"].(string), fc.Args["text"].(string), fc.Args["text_for_email"].(string), fc.Args["tagged_admins"].([]*model.SanitizedAdminInput), fc.Args["tagged_slack_users"].([]*model.SanitizedSlackChannelInput), fc.Args["error_url"].(string), fc.Args["author_name"].(string), fc.Args["issue_url"].(string), fc.Args["issue_title"].(string), fc.Args["issue_id"].(string), fc.Args["integrations"].([]*model.IntegrationType))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model1.ErrorComment)
+	fc.Result = res
+	return ec.marshalOErrorComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐErrorComment(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createErrorCommentForExistingIssue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ErrorComment_id(ctx, field)
+			case "project_id":
+				return ec.fieldContext_ErrorComment_project_id(ctx, field)
+			case "created_at":
+				return ec.fieldContext_ErrorComment_created_at(ctx, field)
+			case "error_id":
+				return ec.fieldContext_ErrorComment_error_id(ctx, field)
+			case "error_secure_id":
+				return ec.fieldContext_ErrorComment_error_secure_id(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_ErrorComment_updated_at(ctx, field)
+			case "author":
+				return ec.fieldContext_ErrorComment_author(ctx, field)
+			case "text":
+				return ec.fieldContext_ErrorComment_text(ctx, field)
+			case "attachments":
+				return ec.fieldContext_ErrorComment_attachments(ctx, field)
+			case "replies":
+				return ec.fieldContext_ErrorComment_replies(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ErrorComment", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createErrorCommentForExistingIssue_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -53736,6 +54168,68 @@ func (ec *executionContext) fieldContext_Query_generate_zapier_access_token(ctx 
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_generate_zapier_access_token_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_search_issues(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_search_issues(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().SearchIssues(rctx, fc.Args["integration_type"].(model.IntegrationType), fc.Args["project_id"].(int), fc.Args["query"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.IssuesSearchResult)
+	fc.Result = res
+	return ec.marshalNIssuesSearchResult2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐIssuesSearchResultᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_search_issues(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_IssuesSearchResult_id(ctx, field)
+			case "title":
+				return ec.fieldContext_IssuesSearchResult_title(ctx, field)
+			case "issue_url":
+				return ec.fieldContext_IssuesSearchResult_issue_url(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type IssuesSearchResult", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_search_issues_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -80508,6 +81002,48 @@ func (ec *executionContext) _Invoice(ctx context.Context, sel ast.SelectionSet, 
 	return out
 }
 
+var issuesSearchResultImplementors = []string{"IssuesSearchResult"}
+
+func (ec *executionContext) _IssuesSearchResult(ctx context.Context, sel ast.SelectionSet, obj *model.IssuesSearchResult) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, issuesSearchResultImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("IssuesSearchResult")
+		case "id":
+
+			out.Values[i] = ec._IssuesSearchResult_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "title":
+
+			out.Values[i] = ec._IssuesSearchResult_title(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "issue_url":
+
+			out.Values[i] = ec._IssuesSearchResult_issue_url(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var jiraIssueTypeImplementors = []string{"JiraIssueType"}
 
 func (ec *executionContext) _JiraIssueType(ctx context.Context, sel ast.SelectionSet, obj *model.JiraIssueType) graphql.Marshaler {
@@ -82140,6 +82676,12 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createErrorComment(ctx, field)
+			})
+
+		case "createErrorCommentForExistingIssue":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createErrorCommentForExistingIssue(ctx, field)
 			})
 
 		case "removeErrorIssue":
@@ -84409,6 +84951,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_generate_zapier_access_token(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
+		case "search_issues":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_search_issues(ctx, field)
 				return res
 			}
 
@@ -91959,6 +92521,60 @@ func (ec *executionContext) marshalNIntegrationType2ᚕᚖgithubᚗcomᚋhighlig
 	wg.Wait()
 
 	return ret
+}
+
+func (ec *executionContext) marshalNIssuesSearchResult2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐIssuesSearchResultᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.IssuesSearchResult) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNIssuesSearchResult2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐIssuesSearchResult(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNIssuesSearchResult2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐIssuesSearchResult(ctx context.Context, sel ast.SelectionSet, v *model.IssuesSearchResult) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._IssuesSearchResult(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNJiraProject2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐJiraProject(ctx context.Context, sel ast.SelectionSet, v *model.JiraProject) graphql.Marshaler {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -768,94 +768,97 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		AddAdminToWorkspace                func(childComplexity int, workspaceID int, inviteID string) int
-		AddIntegrationToProject            func(childComplexity int, integrationType *model.IntegrationType, projectID int, code string) int
-		AddIntegrationToWorkspace          func(childComplexity int, integrationType *model.IntegrationType, workspaceID int, code string) int
-		ChangeAdminRole                    func(childComplexity int, workspaceID int, adminID int, newRole string) int
-		CreateAdmin                        func(childComplexity int) int
-		CreateErrorAlert                   func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency int, defaultArg *bool) int
-		CreateErrorComment                 func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
-		CreateErrorCommentForExistingIssue func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueURL string, issueTitle string, issueID string, integrations []*model.IntegrationType) int
-		CreateErrorSegment                 func(childComplexity int, projectID int, name string, query string) int
-		CreateErrorTag                     func(childComplexity int, title string, description string) int
-		CreateIssueForErrorComment         func(childComplexity int, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
-		CreateIssueForSessionComment       func(childComplexity int, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
-		CreateLogAlert                     func(childComplexity int, input model.LogAlertInput) int
-		CreateMetricMonitor                func(childComplexity int, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) int
-		CreateOrUpdateStripeSubscription   func(childComplexity int, workspaceID int) int
-		CreateProject                      func(childComplexity int, name string, workspaceID int) int
-		CreateSavedSegment                 func(childComplexity int, projectID int, name string, entityType model.SavedSegmentEntityType, query string) int
-		CreateSegment                      func(childComplexity int, projectID int, name string, query string) int
-		CreateSessionAlert                 func(childComplexity int, input model.SessionAlertInput) int
-		CreateSessionComment               func(childComplexity int, projectID int, sessionSecureID string, sessionTimestamp int, text string, textForEmail string, xCoordinate float64, yCoordinate float64, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, sessionURL string, time float64, authorName string, sessionImage *string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType, tags []*model.SessionCommentTagInput, additionalContext *string) int
-		CreateWorkspace                    func(childComplexity int, name string, promoCode *string) int
-		DeleteAdminFromProject             func(childComplexity int, projectID int, adminID int) int
-		DeleteAdminFromWorkspace           func(childComplexity int, workspaceID int, adminID int) int
-		DeleteDashboard                    func(childComplexity int, id int) int
-		DeleteErrorAlert                   func(childComplexity int, projectID int, errorAlertID int) int
-		DeleteErrorComment                 func(childComplexity int, id int) int
-		DeleteErrorSegment                 func(childComplexity int, segmentID int) int
-		DeleteInviteLinkFromWorkspace      func(childComplexity int, workspaceID int, workspaceInviteLinkID int) int
-		DeleteLogAlert                     func(childComplexity int, projectID int, id int) int
-		DeleteMetricMonitor                func(childComplexity int, projectID int, metricMonitorID int) int
-		DeleteProject                      func(childComplexity int, id int) int
-		DeleteSavedSegment                 func(childComplexity int, segmentID int) int
-		DeleteSegment                      func(childComplexity int, segmentID int) int
-		DeleteSessionAlert                 func(childComplexity int, projectID int, sessionAlertID int) int
-		DeleteSessionComment               func(childComplexity int, id int) int
-		DeleteSessions                     func(childComplexity int, projectID int, query model.ClickhouseQuery, sessionCount int) int
-		EditErrorSegment                   func(childComplexity int, id int, projectID int, query string, name string) int
-		EditProject                        func(childComplexity int, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool) int
-		EditProjectSettings                func(childComplexity int, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool, filterSessionsWithoutError *bool, autoResolveStaleErrorsDayInterval *int, sampling *model.SamplingInput) int
-		EditSavedSegment                   func(childComplexity int, id int, projectID int, name string, entityType model.SavedSegmentEntityType, query string) int
-		EditSegment                        func(childComplexity int, id int, projectID int, query string, name string) int
-		EditServiceGithubSettings          func(childComplexity int, id int, projectID int, githubRepoPath *string, buildPrefix *string, githubPrefix *string) int
-		EditWorkspace                      func(childComplexity int, id int, name *string) int
-		EditWorkspaceSettings              func(childComplexity int, workspaceID int, aiApplication *bool, aiInsights *bool) int
-		EmailSignup                        func(childComplexity int, email string) int
-		ExportSession                      func(childComplexity int, sessionSecureID string) int
-		HandleAWSMarketplace               func(childComplexity int, workspaceID int, code string) int
-		JoinWorkspace                      func(childComplexity int, workspaceID int) int
-		MarkErrorGroupAsViewed             func(childComplexity int, errorSecureID string, viewed *bool) int
-		MarkSessionAsViewed                func(childComplexity int, secureID string, viewed *bool) int
-		ModifyClearbitIntegration          func(childComplexity int, workspaceID int, enabled bool) int
-		MuteErrorCommentThread             func(childComplexity int, id int, hasMuted *bool) int
-		MuteSessionCommentThread           func(childComplexity int, id int, hasMuted *bool) int
-		RemoveErrorIssue                   func(childComplexity int, errorIssueID int) int
-		RemoveIntegrationFromProject       func(childComplexity int, integrationType *model.IntegrationType, projectID int) int
-		RemoveIntegrationFromWorkspace     func(childComplexity int, integrationType model.IntegrationType, workspaceID int) int
-		ReplyToErrorComment                func(childComplexity int, commentID int, text string, textForEmail string, errorURL string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput) int
-		ReplyToSessionComment              func(childComplexity int, commentID int, text string, textForEmail string, sessionURL string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput) int
-		RequestAccess                      func(childComplexity int, projectID int) int
-		SaveBillingPlan                    func(childComplexity int, workspaceID int, sessionsLimitCents *int, sessionsRetention model.RetentionPeriod, errorsLimitCents *int, errorsRetention model.RetentionPeriod, logsLimitCents *int, logsRetention model.RetentionPeriod, tracesLimitCents *int, tracesRetention model.RetentionPeriod) int
-		SendAdminWorkspaceInvite           func(childComplexity int, workspaceID int, email string, baseURL string, role string) int
-		SubmitRegistrationForm             func(childComplexity int, workspaceID int, teamSize string, role string, useCase string, heardAbout string, pun *string) int
-		SyncSlackIntegration               func(childComplexity int, projectID int) int
-		TestErrorEnhancement               func(childComplexity int, errorObjectID int, githubRepoPath string, githubPrefix *string, buildPrefix *string, saveError *bool) int
-		UpdateAdminAboutYouDetails         func(childComplexity int, adminDetails model.AdminAboutYouDetails) int
-		UpdateAdminAndCreateWorkspace      func(childComplexity int, adminAndWorkspaceDetails model.AdminAndWorkspaceDetails) int
-		UpdateAllowMeterOverage            func(childComplexity int, workspaceID int, allowMeterOverage bool) int
-		UpdateAllowedEmailOrigins          func(childComplexity int, workspaceID int, allowedAutoJoinEmailOrigins string) int
-		UpdateBillingDetails               func(childComplexity int, workspaceID int) int
-		UpdateClickUpProjectMappings       func(childComplexity int, workspaceID int, projectMappings []*model.ClickUpProjectMappingInput) int
-		UpdateEmailOptOut                  func(childComplexity int, token *string, adminID *int, category model.EmailOptOutCategory, isOptOut bool, projectID *int) int
-		UpdateErrorAlert                   func(childComplexity int, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) int
-		UpdateErrorAlertIsDisabled         func(childComplexity int, id int, projectID int, disabled bool) int
-		UpdateErrorGroupIsPublic           func(childComplexity int, errorGroupSecureID string, isPublic bool) int
-		UpdateErrorGroupState              func(childComplexity int, secureID string, state model.ErrorState, snoozedUntil *time.Time) int
-		UpdateErrorTags                    func(childComplexity int) int
-		UpdateIntegrationProjectMappings   func(childComplexity int, workspaceID int, integrationType model.IntegrationType, projectMappings []*model.IntegrationProjectMappingInput) int
-		UpdateLogAlert                     func(childComplexity int, id int, input model.LogAlertInput) int
-		UpdateLogAlertIsDisabled           func(childComplexity int, id int, projectID int, disabled bool) int
-		UpdateMetricMonitor                func(childComplexity int, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) int
-		UpdateMetricMonitorIsDisabled      func(childComplexity int, id int, projectID int, disabled bool) int
-		UpdateSessionAlert                 func(childComplexity int, id int, input model.SessionAlertInput) int
-		UpdateSessionAlertIsDisabled       func(childComplexity int, id int, projectID int, disabled bool) int
-		UpdateSessionIsPublic              func(childComplexity int, sessionSecureID string, isPublic bool) int
-		UpdateVercelProjectMappings        func(childComplexity int, projectID int, projectMappings []*model.VercelProjectMappingInput) int
-		UpsertDashboard                    func(childComplexity int, id *int, projectID int, name string, metrics []*model.DashboardMetricConfigInput, layout *string, isDefault *bool) int
-		UpsertDiscordChannel               func(childComplexity int, projectID int, name string) int
-		UpsertSlackChannel                 func(childComplexity int, projectID int, name string) int
+		AddAdminToWorkspace                   func(childComplexity int, workspaceID int, inviteID string) int
+		AddIntegrationToProject               func(childComplexity int, integrationType *model.IntegrationType, projectID int, code string) int
+		AddIntegrationToWorkspace             func(childComplexity int, integrationType *model.IntegrationType, workspaceID int, code string) int
+		ChangeAdminRole                       func(childComplexity int, workspaceID int, adminID int, newRole string) int
+		CreateAdmin                           func(childComplexity int) int
+		CreateErrorAlert                      func(childComplexity int, projectID int, name string, countThreshold int, thresholdWindow int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency int, defaultArg *bool) int
+		CreateErrorComment                    func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
+		CreateErrorCommentForExistingIssue    func(childComplexity int, projectID int, errorGroupSecureID string, text string, textForEmail string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, errorURL string, authorName string, issueURL string, issueTitle string, issueID string, integrations []*model.IntegrationType) int
+		CreateErrorSegment                    func(childComplexity int, projectID int, name string, query string) int
+		CreateErrorTag                        func(childComplexity int, title string, description string) int
+		CreateIssueForErrorComment            func(childComplexity int, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
+		CreateIssueForSessionComment          func(childComplexity int, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) int
+		CreateLogAlert                        func(childComplexity int, input model.LogAlertInput) int
+		CreateMetricMonitor                   func(childComplexity int, projectID int, name string, aggregator model.MetricAggregator, periodMinutes *int, threshold float64, units *string, metricToMonitor string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, filters []*model.MetricTagFilterInput) int
+		CreateOrUpdateStripeSubscription      func(childComplexity int, workspaceID int) int
+		CreateProject                         func(childComplexity int, name string, workspaceID int) int
+		CreateSavedSegment                    func(childComplexity int, projectID int, name string, entityType model.SavedSegmentEntityType, query string) int
+		CreateSegment                         func(childComplexity int, projectID int, name string, query string) int
+		CreateSessionAlert                    func(childComplexity int, input model.SessionAlertInput) int
+		CreateSessionComment                  func(childComplexity int, projectID int, sessionSecureID string, sessionTimestamp int, text string, textForEmail string, xCoordinate float64, yCoordinate float64, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, sessionURL string, time float64, authorName string, sessionImage *string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType, tags []*model.SessionCommentTagInput, additionalContext *string) int
+		CreateSessionCommentWithExistingIssue func(childComplexity int, projectID int, sessionSecureID string, sessionTimestamp int, text string, textForEmail string, xCoordinate float64, yCoordinate float64, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, sessionURL string, time float64, authorName string, sessionImage *string, tags []*model.SessionCommentTagInput, integrations []*model.IntegrationType, issueTitle *string, issueURL string, issueID string, additionalContext *string) int
+		CreateWorkspace                       func(childComplexity int, name string, promoCode *string) int
+		DeleteAdminFromProject                func(childComplexity int, projectID int, adminID int) int
+		DeleteAdminFromWorkspace              func(childComplexity int, workspaceID int, adminID int) int
+		DeleteDashboard                       func(childComplexity int, id int) int
+		DeleteErrorAlert                      func(childComplexity int, projectID int, errorAlertID int) int
+		DeleteErrorComment                    func(childComplexity int, id int) int
+		DeleteErrorSegment                    func(childComplexity int, segmentID int) int
+		DeleteInviteLinkFromWorkspace         func(childComplexity int, workspaceID int, workspaceInviteLinkID int) int
+		DeleteLogAlert                        func(childComplexity int, projectID int, id int) int
+		DeleteMetricMonitor                   func(childComplexity int, projectID int, metricMonitorID int) int
+		DeleteProject                         func(childComplexity int, id int) int
+		DeleteSavedSegment                    func(childComplexity int, segmentID int) int
+		DeleteSegment                         func(childComplexity int, segmentID int) int
+		DeleteSessionAlert                    func(childComplexity int, projectID int, sessionAlertID int) int
+		DeleteSessionComment                  func(childComplexity int, id int) int
+		DeleteSessions                        func(childComplexity int, projectID int, query model.ClickhouseQuery, sessionCount int) int
+		EditErrorSegment                      func(childComplexity int, id int, projectID int, query string, name string) int
+		EditProject                           func(childComplexity int, id int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool) int
+		EditProjectSettings                   func(childComplexity int, projectID int, name *string, billingEmail *string, excludedUsers pq.StringArray, errorFilters pq.StringArray, errorJSONPaths pq.StringArray, rageClickWindowSeconds *int, rageClickRadiusPixels *int, rageClickCount *int, filterChromeExtension *bool, filterSessionsWithoutError *bool, autoResolveStaleErrorsDayInterval *int, sampling *model.SamplingInput) int
+		EditSavedSegment                      func(childComplexity int, id int, projectID int, name string, entityType model.SavedSegmentEntityType, query string) int
+		EditSegment                           func(childComplexity int, id int, projectID int, query string, name string) int
+		EditServiceGithubSettings             func(childComplexity int, id int, projectID int, githubRepoPath *string, buildPrefix *string, githubPrefix *string) int
+		EditWorkspace                         func(childComplexity int, id int, name *string) int
+		EditWorkspaceSettings                 func(childComplexity int, workspaceID int, aiApplication *bool, aiInsights *bool) int
+		EmailSignup                           func(childComplexity int, email string) int
+		ExportSession                         func(childComplexity int, sessionSecureID string) int
+		HandleAWSMarketplace                  func(childComplexity int, workspaceID int, code string) int
+		JoinWorkspace                         func(childComplexity int, workspaceID int) int
+		LinkIssueForErrorComment              func(childComplexity int, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueURL string, issueID string, integrations []*model.IntegrationType) int
+		LinkIssueForSessionComment            func(childComplexity int, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueURL string, issueID string, integrations []*model.IntegrationType) int
+		MarkErrorGroupAsViewed                func(childComplexity int, errorSecureID string, viewed *bool) int
+		MarkSessionAsViewed                   func(childComplexity int, secureID string, viewed *bool) int
+		ModifyClearbitIntegration             func(childComplexity int, workspaceID int, enabled bool) int
+		MuteErrorCommentThread                func(childComplexity int, id int, hasMuted *bool) int
+		MuteSessionCommentThread              func(childComplexity int, id int, hasMuted *bool) int
+		RemoveErrorIssue                      func(childComplexity int, errorIssueID int) int
+		RemoveIntegrationFromProject          func(childComplexity int, integrationType *model.IntegrationType, projectID int) int
+		RemoveIntegrationFromWorkspace        func(childComplexity int, integrationType model.IntegrationType, workspaceID int) int
+		ReplyToErrorComment                   func(childComplexity int, commentID int, text string, textForEmail string, errorURL string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput) int
+		ReplyToSessionComment                 func(childComplexity int, commentID int, text string, textForEmail string, sessionURL string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput) int
+		RequestAccess                         func(childComplexity int, projectID int) int
+		SaveBillingPlan                       func(childComplexity int, workspaceID int, sessionsLimitCents *int, sessionsRetention model.RetentionPeriod, errorsLimitCents *int, errorsRetention model.RetentionPeriod, logsLimitCents *int, logsRetention model.RetentionPeriod, tracesLimitCents *int, tracesRetention model.RetentionPeriod) int
+		SendAdminWorkspaceInvite              func(childComplexity int, workspaceID int, email string, baseURL string, role string) int
+		SubmitRegistrationForm                func(childComplexity int, workspaceID int, teamSize string, role string, useCase string, heardAbout string, pun *string) int
+		SyncSlackIntegration                  func(childComplexity int, projectID int) int
+		TestErrorEnhancement                  func(childComplexity int, errorObjectID int, githubRepoPath string, githubPrefix *string, buildPrefix *string, saveError *bool) int
+		UpdateAdminAboutYouDetails            func(childComplexity int, adminDetails model.AdminAboutYouDetails) int
+		UpdateAdminAndCreateWorkspace         func(childComplexity int, adminAndWorkspaceDetails model.AdminAndWorkspaceDetails) int
+		UpdateAllowMeterOverage               func(childComplexity int, workspaceID int, allowMeterOverage bool) int
+		UpdateAllowedEmailOrigins             func(childComplexity int, workspaceID int, allowedAutoJoinEmailOrigins string) int
+		UpdateBillingDetails                  func(childComplexity int, workspaceID int) int
+		UpdateClickUpProjectMappings          func(childComplexity int, workspaceID int, projectMappings []*model.ClickUpProjectMappingInput) int
+		UpdateEmailOptOut                     func(childComplexity int, token *string, adminID *int, category model.EmailOptOutCategory, isOptOut bool, projectID *int) int
+		UpdateErrorAlert                      func(childComplexity int, projectID int, name *string, errorAlertID int, countThreshold *int, thresholdWindow *int, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, microsoftTeamsChannels []*model.MicrosoftTeamsChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, environments []*string, regexGroups []*string, frequency *int, disabled *bool) int
+		UpdateErrorAlertIsDisabled            func(childComplexity int, id int, projectID int, disabled bool) int
+		UpdateErrorGroupIsPublic              func(childComplexity int, errorGroupSecureID string, isPublic bool) int
+		UpdateErrorGroupState                 func(childComplexity int, secureID string, state model.ErrorState, snoozedUntil *time.Time) int
+		UpdateErrorTags                       func(childComplexity int) int
+		UpdateIntegrationProjectMappings      func(childComplexity int, workspaceID int, integrationType model.IntegrationType, projectMappings []*model.IntegrationProjectMappingInput) int
+		UpdateLogAlert                        func(childComplexity int, id int, input model.LogAlertInput) int
+		UpdateLogAlertIsDisabled              func(childComplexity int, id int, projectID int, disabled bool) int
+		UpdateMetricMonitor                   func(childComplexity int, metricMonitorID int, projectID int, name *string, aggregator *model.MetricAggregator, periodMinutes *int, threshold *float64, units *string, metricToMonitor *string, slackChannels []*model.SanitizedSlackChannelInput, discordChannels []*model.DiscordChannelInput, webhookDestinations []*model.WebhookDestinationInput, emails []*string, disabled *bool, filters []*model.MetricTagFilterInput) int
+		UpdateMetricMonitorIsDisabled         func(childComplexity int, id int, projectID int, disabled bool) int
+		UpdateSessionAlert                    func(childComplexity int, id int, input model.SessionAlertInput) int
+		UpdateSessionAlertIsDisabled          func(childComplexity int, id int, projectID int, disabled bool) int
+		UpdateSessionIsPublic                 func(childComplexity int, sessionSecureID string, isPublic bool) int
+		UpdateVercelProjectMappings           func(childComplexity int, projectID int, projectMappings []*model.VercelProjectMappingInput) int
+		UpsertDashboard                       func(childComplexity int, id *int, projectID int, name string, metrics []*model.DashboardMetricConfigInput, layout *string, isDefault *bool) int
+		UpsertDiscordChannel                  func(childComplexity int, projectID int, name string) int
+		UpsertSlackChannel                    func(childComplexity int, projectID int, name string) int
 	}
 
 	NamedCount struct {
@@ -1668,7 +1671,9 @@ type MutationResolver interface {
 	UpdateBillingDetails(ctx context.Context, workspaceID int) (*bool, error)
 	SaveBillingPlan(ctx context.Context, workspaceID int, sessionsLimitCents *int, sessionsRetention model.RetentionPeriod, errorsLimitCents *int, errorsRetention model.RetentionPeriod, logsLimitCents *int, logsRetention model.RetentionPeriod, tracesLimitCents *int, tracesRetention model.RetentionPeriod) (*bool, error)
 	CreateSessionComment(ctx context.Context, projectID int, sessionSecureID string, sessionTimestamp int, text string, textForEmail string, xCoordinate float64, yCoordinate float64, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, sessionURL string, time float64, authorName string, sessionImage *string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType, tags []*model.SessionCommentTagInput, additionalContext *string) (*model1.SessionComment, error)
+	CreateSessionCommentWithExistingIssue(ctx context.Context, projectID int, sessionSecureID string, sessionTimestamp int, text string, textForEmail string, xCoordinate float64, yCoordinate float64, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput, sessionURL string, time float64, authorName string, sessionImage *string, tags []*model.SessionCommentTagInput, integrations []*model.IntegrationType, issueTitle *string, issueURL string, issueID string, additionalContext *string) (*model1.SessionComment, error)
 	CreateIssueForSessionComment(ctx context.Context, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) (*model1.SessionComment, error)
+	LinkIssueForSessionComment(ctx context.Context, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueURL string, issueID string, integrations []*model.IntegrationType) (*model1.SessionComment, error)
 	DeleteSessionComment(ctx context.Context, id int) (*bool, error)
 	MuteSessionCommentThread(ctx context.Context, id int, hasMuted *bool) (*bool, error)
 	ReplyToSessionComment(ctx context.Context, commentID int, text string, textForEmail string, sessionURL string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput) (*model1.CommentReply, error)
@@ -1677,6 +1682,7 @@ type MutationResolver interface {
 	RemoveErrorIssue(ctx context.Context, errorIssueID int) (*bool, error)
 	MuteErrorCommentThread(ctx context.Context, id int, hasMuted *bool) (*bool, error)
 	CreateIssueForErrorComment(ctx context.Context, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*model.IntegrationType) (*model1.ErrorComment, error)
+	LinkIssueForErrorComment(ctx context.Context, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueURL string, issueID string, integrations []*model.IntegrationType) (*model1.ErrorComment, error)
 	DeleteErrorComment(ctx context.Context, id int) (*bool, error)
 	ReplyToErrorComment(ctx context.Context, commentID int, text string, textForEmail string, errorURL string, taggedAdmins []*model.SanitizedAdminInput, taggedSlackUsers []*model.SanitizedSlackChannelInput) (*model1.CommentReply, error)
 	AddIntegrationToProject(ctx context.Context, integrationType *model.IntegrationType, projectID int, code string) (bool, error)
@@ -5370,6 +5376,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.CreateSessionComment(childComplexity, args["project_id"].(int), args["session_secure_id"].(string), args["session_timestamp"].(int), args["text"].(string), args["text_for_email"].(string), args["x_coordinate"].(float64), args["y_coordinate"].(float64), args["tagged_admins"].([]*model.SanitizedAdminInput), args["tagged_slack_users"].([]*model.SanitizedSlackChannelInput), args["session_url"].(string), args["time"].(float64), args["author_name"].(string), args["session_image"].(*string), args["issue_title"].(*string), args["issue_description"].(*string), args["issue_team_id"].(*string), args["issue_type_id"].(*string), args["integrations"].([]*model.IntegrationType), args["tags"].([]*model.SessionCommentTagInput), args["additional_context"].(*string)), true
 
+	case "Mutation.createSessionCommentWithExistingIssue":
+		if e.complexity.Mutation.CreateSessionCommentWithExistingIssue == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_createSessionCommentWithExistingIssue_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CreateSessionCommentWithExistingIssue(childComplexity, args["project_id"].(int), args["session_secure_id"].(string), args["session_timestamp"].(int), args["text"].(string), args["text_for_email"].(string), args["x_coordinate"].(float64), args["y_coordinate"].(float64), args["tagged_admins"].([]*model.SanitizedAdminInput), args["tagged_slack_users"].([]*model.SanitizedSlackChannelInput), args["session_url"].(string), args["time"].(float64), args["author_name"].(string), args["session_image"].(*string), args["tags"].([]*model.SessionCommentTagInput), args["integrations"].([]*model.IntegrationType), args["issue_title"].(*string), args["issue_url"].(string), args["issue_id"].(string), args["additional_context"].(*string)), true
+
 	case "Mutation.createWorkspace":
 		if e.complexity.Mutation.CreateWorkspace == nil {
 			break
@@ -5705,6 +5723,30 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.JoinWorkspace(childComplexity, args["workspace_id"].(int)), true
+
+	case "Mutation.linkIssueForErrorComment":
+		if e.complexity.Mutation.LinkIssueForErrorComment == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_linkIssueForErrorComment_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.LinkIssueForErrorComment(childComplexity, args["project_id"].(int), args["error_url"].(string), args["error_comment_id"].(int), args["author_name"].(string), args["text_for_attachment"].(string), args["issue_title"].(*string), args["issue_description"].(*string), args["issue_url"].(string), args["issue_id"].(string), args["integrations"].([]*model.IntegrationType)), true
+
+	case "Mutation.linkIssueForSessionComment":
+		if e.complexity.Mutation.LinkIssueForSessionComment == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_linkIssueForSessionComment_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.LinkIssueForSessionComment(childComplexity, args["project_id"].(int), args["session_url"].(string), args["session_comment_id"].(int), args["author_name"].(string), args["text_for_attachment"].(string), args["time"].(float64), args["issue_title"].(*string), args["issue_url"].(string), args["issue_id"].(string), args["integrations"].([]*model.IntegrationType)), true
 
 	case "Mutation.markErrorGroupAsViewed":
 		if e.complexity.Mutation.MarkErrorGroupAsViewed == nil {
@@ -13055,6 +13097,27 @@ type Mutation {
 		tags: [SessionCommentTagInput]!
 		additional_context: String
 	): SessionComment
+	createSessionCommentWithExistingIssue(
+		project_id: ID!
+		session_secure_id: String!
+		session_timestamp: Int!
+		text: String!
+		text_for_email: String!
+		x_coordinate: Float!
+		y_coordinate: Float!
+		tagged_admins: [SanitizedAdminInput]!
+		tagged_slack_users: [SanitizedSlackChannelInput]!
+		session_url: String!
+		time: Float!
+		author_name: String!
+		session_image: String
+		tags: [SessionCommentTagInput]!
+		integrations: [IntegrationType]!
+		issue_title: String
+		issue_url: String!
+		issue_id: String!
+		additional_context: String
+	): SessionComment
 	createIssueForSessionComment(
 		project_id: ID!
 		session_url: String!
@@ -13066,6 +13129,18 @@ type Mutation {
 		issue_description: String
 		issue_team_id: String
 		issue_type_id: String
+		integrations: [IntegrationType]!
+	): SessionComment
+	linkIssueForSessionComment(
+		project_id: ID!
+		session_url: String!
+		session_comment_id: Int!
+		author_name: String!
+		text_for_attachment: String!
+		time: Float!
+		issue_title: String
+		issue_url: String!
+		issue_id: String!
 		integrations: [IntegrationType]!
 	): SessionComment
 	deleteSessionComment(id: ID!): Boolean
@@ -13119,6 +13194,18 @@ type Mutation {
 		issue_description: String
 		issue_team_id: String
 		issue_type_id: String
+		integrations: [IntegrationType]!
+	): ErrorComment
+	linkIssueForErrorComment(
+		project_id: ID!
+		error_url: String!
+		error_comment_id: Int!
+		author_name: String!
+		text_for_attachment: String!
+		issue_title: String
+		issue_description: String
+		issue_url: String!
+		issue_id: String!
 		integrations: [IntegrationType]!
 	): ErrorComment
 	deleteErrorComment(id: ID!): Boolean
@@ -14329,6 +14416,183 @@ func (ec *executionContext) field_Mutation_createSessionAlert_args(ctx context.C
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_createSessionCommentWithExistingIssue_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["session_secure_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_secure_id"))
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["session_secure_id"] = arg1
+	var arg2 int
+	if tmp, ok := rawArgs["session_timestamp"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_timestamp"))
+		arg2, err = ec.unmarshalNInt2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["session_timestamp"] = arg2
+	var arg3 string
+	if tmp, ok := rawArgs["text"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("text"))
+		arg3, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["text"] = arg3
+	var arg4 string
+	if tmp, ok := rawArgs["text_for_email"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("text_for_email"))
+		arg4, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["text_for_email"] = arg4
+	var arg5 float64
+	if tmp, ok := rawArgs["x_coordinate"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("x_coordinate"))
+		arg5, err = ec.unmarshalNFloat2float64(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["x_coordinate"] = arg5
+	var arg6 float64
+	if tmp, ok := rawArgs["y_coordinate"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("y_coordinate"))
+		arg6, err = ec.unmarshalNFloat2float64(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["y_coordinate"] = arg6
+	var arg7 []*model.SanitizedAdminInput
+	if tmp, ok := rawArgs["tagged_admins"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tagged_admins"))
+		arg7, err = ec.unmarshalNSanitizedAdminInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSanitizedAdminInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["tagged_admins"] = arg7
+	var arg8 []*model.SanitizedSlackChannelInput
+	if tmp, ok := rawArgs["tagged_slack_users"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tagged_slack_users"))
+		arg8, err = ec.unmarshalNSanitizedSlackChannelInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSanitizedSlackChannelInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["tagged_slack_users"] = arg8
+	var arg9 string
+	if tmp, ok := rawArgs["session_url"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_url"))
+		arg9, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["session_url"] = arg9
+	var arg10 float64
+	if tmp, ok := rawArgs["time"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("time"))
+		arg10, err = ec.unmarshalNFloat2float64(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["time"] = arg10
+	var arg11 string
+	if tmp, ok := rawArgs["author_name"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("author_name"))
+		arg11, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["author_name"] = arg11
+	var arg12 *string
+	if tmp, ok := rawArgs["session_image"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_image"))
+		arg12, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["session_image"] = arg12
+	var arg13 []*model.SessionCommentTagInput
+	if tmp, ok := rawArgs["tags"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tags"))
+		arg13, err = ec.unmarshalNSessionCommentTagInput2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSessionCommentTagInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["tags"] = arg13
+	var arg14 []*model.IntegrationType
+	if tmp, ok := rawArgs["integrations"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("integrations"))
+		arg14, err = ec.unmarshalNIntegrationType2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐIntegrationType(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["integrations"] = arg14
+	var arg15 *string
+	if tmp, ok := rawArgs["issue_title"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_title"))
+		arg15, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_title"] = arg15
+	var arg16 string
+	if tmp, ok := rawArgs["issue_url"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_url"))
+		arg16, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_url"] = arg16
+	var arg17 string
+	if tmp, ok := rawArgs["issue_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_id"))
+		arg17, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_id"] = arg17
+	var arg18 *string
+	if tmp, ok := rawArgs["additional_context"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("additional_context"))
+		arg18, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["additional_context"] = arg18
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_createSessionComment_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -15373,6 +15637,198 @@ func (ec *executionContext) field_Mutation_joinWorkspace_args(ctx context.Contex
 		}
 	}
 	args["workspace_id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_linkIssueForErrorComment_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["error_url"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_url"))
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["error_url"] = arg1
+	var arg2 int
+	if tmp, ok := rawArgs["error_comment_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("error_comment_id"))
+		arg2, err = ec.unmarshalNInt2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["error_comment_id"] = arg2
+	var arg3 string
+	if tmp, ok := rawArgs["author_name"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("author_name"))
+		arg3, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["author_name"] = arg3
+	var arg4 string
+	if tmp, ok := rawArgs["text_for_attachment"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("text_for_attachment"))
+		arg4, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["text_for_attachment"] = arg4
+	var arg5 *string
+	if tmp, ok := rawArgs["issue_title"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_title"))
+		arg5, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_title"] = arg5
+	var arg6 *string
+	if tmp, ok := rawArgs["issue_description"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_description"))
+		arg6, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_description"] = arg6
+	var arg7 string
+	if tmp, ok := rawArgs["issue_url"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_url"))
+		arg7, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_url"] = arg7
+	var arg8 string
+	if tmp, ok := rawArgs["issue_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_id"))
+		arg8, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_id"] = arg8
+	var arg9 []*model.IntegrationType
+	if tmp, ok := rawArgs["integrations"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("integrations"))
+		arg9, err = ec.unmarshalNIntegrationType2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐIntegrationType(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["integrations"] = arg9
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_linkIssueForSessionComment_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["session_url"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_url"))
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["session_url"] = arg1
+	var arg2 int
+	if tmp, ok := rawArgs["session_comment_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("session_comment_id"))
+		arg2, err = ec.unmarshalNInt2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["session_comment_id"] = arg2
+	var arg3 string
+	if tmp, ok := rawArgs["author_name"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("author_name"))
+		arg3, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["author_name"] = arg3
+	var arg4 string
+	if tmp, ok := rawArgs["text_for_attachment"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("text_for_attachment"))
+		arg4, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["text_for_attachment"] = arg4
+	var arg5 float64
+	if tmp, ok := rawArgs["time"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("time"))
+		arg5, err = ec.unmarshalNFloat2float64(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["time"] = arg5
+	var arg6 *string
+	if tmp, ok := rawArgs["issue_title"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_title"))
+		arg6, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_title"] = arg6
+	var arg7 string
+	if tmp, ok := rawArgs["issue_url"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_url"))
+		arg7, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_url"] = arg7
+	var arg8 string
+	if tmp, ok := rawArgs["issue_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("issue_id"))
+		arg8, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["issue_id"] = arg8
+	var arg9 []*model.IntegrationType
+	if tmp, ok := rawArgs["integrations"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("integrations"))
+		arg9, err = ec.unmarshalNIntegrationType2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐIntegrationType(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["integrations"] = arg9
 	return args, nil
 }
 
@@ -43253,6 +43709,91 @@ func (ec *executionContext) fieldContext_Mutation_createSessionComment(ctx conte
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_createSessionCommentWithExistingIssue(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_createSessionCommentWithExistingIssue(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CreateSessionCommentWithExistingIssue(rctx, fc.Args["project_id"].(int), fc.Args["session_secure_id"].(string), fc.Args["session_timestamp"].(int), fc.Args["text"].(string), fc.Args["text_for_email"].(string), fc.Args["x_coordinate"].(float64), fc.Args["y_coordinate"].(float64), fc.Args["tagged_admins"].([]*model.SanitizedAdminInput), fc.Args["tagged_slack_users"].([]*model.SanitizedSlackChannelInput), fc.Args["session_url"].(string), fc.Args["time"].(float64), fc.Args["author_name"].(string), fc.Args["session_image"].(*string), fc.Args["tags"].([]*model.SessionCommentTagInput), fc.Args["integrations"].([]*model.IntegrationType), fc.Args["issue_title"].(*string), fc.Args["issue_url"].(string), fc.Args["issue_id"].(string), fc.Args["additional_context"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model1.SessionComment)
+	fc.Result = res
+	return ec.marshalOSessionComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_createSessionCommentWithExistingIssue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SessionComment_id(ctx, field)
+			case "project_id":
+				return ec.fieldContext_SessionComment_project_id(ctx, field)
+			case "timestamp":
+				return ec.fieldContext_SessionComment_timestamp(ctx, field)
+			case "created_at":
+				return ec.fieldContext_SessionComment_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_SessionComment_updated_at(ctx, field)
+			case "session_id":
+				return ec.fieldContext_SessionComment_session_id(ctx, field)
+			case "session_secure_id":
+				return ec.fieldContext_SessionComment_session_secure_id(ctx, field)
+			case "author":
+				return ec.fieldContext_SessionComment_author(ctx, field)
+			case "text":
+				return ec.fieldContext_SessionComment_text(ctx, field)
+			case "x_coordinate":
+				return ec.fieldContext_SessionComment_x_coordinate(ctx, field)
+			case "y_coordinate":
+				return ec.fieldContext_SessionComment_y_coordinate(ctx, field)
+			case "type":
+				return ec.fieldContext_SessionComment_type(ctx, field)
+			case "metadata":
+				return ec.fieldContext_SessionComment_metadata(ctx, field)
+			case "tags":
+				return ec.fieldContext_SessionComment_tags(ctx, field)
+			case "attachments":
+				return ec.fieldContext_SessionComment_attachments(ctx, field)
+			case "replies":
+				return ec.fieldContext_SessionComment_replies(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SessionComment", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_createSessionCommentWithExistingIssue_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_createIssueForSessionComment(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_createIssueForSessionComment(ctx, field)
 	if err != nil {
@@ -43332,6 +43873,91 @@ func (ec *executionContext) fieldContext_Mutation_createIssueForSessionComment(c
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_createIssueForSessionComment_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_linkIssueForSessionComment(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_linkIssueForSessionComment(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().LinkIssueForSessionComment(rctx, fc.Args["project_id"].(int), fc.Args["session_url"].(string), fc.Args["session_comment_id"].(int), fc.Args["author_name"].(string), fc.Args["text_for_attachment"].(string), fc.Args["time"].(float64), fc.Args["issue_title"].(*string), fc.Args["issue_url"].(string), fc.Args["issue_id"].(string), fc.Args["integrations"].([]*model.IntegrationType))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model1.SessionComment)
+	fc.Result = res
+	return ec.marshalOSessionComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐSessionComment(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_linkIssueForSessionComment(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SessionComment_id(ctx, field)
+			case "project_id":
+				return ec.fieldContext_SessionComment_project_id(ctx, field)
+			case "timestamp":
+				return ec.fieldContext_SessionComment_timestamp(ctx, field)
+			case "created_at":
+				return ec.fieldContext_SessionComment_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_SessionComment_updated_at(ctx, field)
+			case "session_id":
+				return ec.fieldContext_SessionComment_session_id(ctx, field)
+			case "session_secure_id":
+				return ec.fieldContext_SessionComment_session_secure_id(ctx, field)
+			case "author":
+				return ec.fieldContext_SessionComment_author(ctx, field)
+			case "text":
+				return ec.fieldContext_SessionComment_text(ctx, field)
+			case "x_coordinate":
+				return ec.fieldContext_SessionComment_x_coordinate(ctx, field)
+			case "y_coordinate":
+				return ec.fieldContext_SessionComment_y_coordinate(ctx, field)
+			case "type":
+				return ec.fieldContext_SessionComment_type(ctx, field)
+			case "metadata":
+				return ec.fieldContext_SessionComment_metadata(ctx, field)
+			case "tags":
+				return ec.fieldContext_SessionComment_tags(ctx, field)
+			case "attachments":
+				return ec.fieldContext_SessionComment_attachments(ctx, field)
+			case "replies":
+				return ec.fieldContext_SessionComment_replies(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SessionComment", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_linkIssueForSessionComment_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -43818,6 +44444,79 @@ func (ec *executionContext) fieldContext_Mutation_createIssueForErrorComment(ctx
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_createIssueForErrorComment_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_linkIssueForErrorComment(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_linkIssueForErrorComment(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().LinkIssueForErrorComment(rctx, fc.Args["project_id"].(int), fc.Args["error_url"].(string), fc.Args["error_comment_id"].(int), fc.Args["author_name"].(string), fc.Args["text_for_attachment"].(string), fc.Args["issue_title"].(*string), fc.Args["issue_description"].(*string), fc.Args["issue_url"].(string), fc.Args["issue_id"].(string), fc.Args["integrations"].([]*model.IntegrationType))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model1.ErrorComment)
+	fc.Result = res
+	return ec.marshalOErrorComment2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐErrorComment(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_linkIssueForErrorComment(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ErrorComment_id(ctx, field)
+			case "project_id":
+				return ec.fieldContext_ErrorComment_project_id(ctx, field)
+			case "created_at":
+				return ec.fieldContext_ErrorComment_created_at(ctx, field)
+			case "error_id":
+				return ec.fieldContext_ErrorComment_error_id(ctx, field)
+			case "error_secure_id":
+				return ec.fieldContext_ErrorComment_error_secure_id(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_ErrorComment_updated_at(ctx, field)
+			case "author":
+				return ec.fieldContext_ErrorComment_author(ctx, field)
+			case "text":
+				return ec.fieldContext_ErrorComment_text(ctx, field)
+			case "attachments":
+				return ec.fieldContext_ErrorComment_attachments(ctx, field)
+			case "replies":
+				return ec.fieldContext_ErrorComment_replies(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ErrorComment", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_linkIssueForErrorComment_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -82648,10 +83347,22 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 				return ec._Mutation_createSessionComment(ctx, field)
 			})
 
+		case "createSessionCommentWithExistingIssue":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_createSessionCommentWithExistingIssue(ctx, field)
+			})
+
 		case "createIssueForSessionComment":
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createIssueForSessionComment(ctx, field)
+			})
+
+		case "linkIssueForSessionComment":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_linkIssueForSessionComment(ctx, field)
 			})
 
 		case "deleteSessionComment":
@@ -82700,6 +83411,12 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createIssueForErrorComment(ctx, field)
+			})
+
+		case "linkIssueForErrorComment":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_linkIssueForErrorComment(ctx, field)
 			})
 
 		case "deleteErrorComment":

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -428,6 +428,12 @@ type Invoice struct {
 	Status       *string    `json:"status"`
 }
 
+type IssuesSearchResult struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	IssueURL string `json:"issue_url"`
+}
+
 type JiraIssueType struct {
 	Self             string              `json:"self"`
 	ID               string              `json:"id"`

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2560,7 +2560,7 @@ type LinearCreateAttachmentResponse struct {
 		AttachmentCreate struct {
 			Attachment struct {
 				ID string `json:"id"`
-			} `json:"Attachment"`
+			} `json:"attachment"`
 			Success bool `json:"success"`
 		} `json:"attachmentCreate"`
 	} `json:"data"`
@@ -2590,6 +2590,14 @@ func (r *Resolver) CreateLinearAttachment(accessToken string, issueID string, ti
 		Query     string      `json:"query"`
 		Variables GraphQLVars `json:"variables"`
 	}
+
+	fmt.Println("LINVARIABLES", GraphQLVars{
+		IssueID:  issueID,
+		Title:    title,
+		Subtitle: subtitle,
+		Url:      url,
+		IconUrl:  fmt.Sprintf("%s/logo_with_gradient_bg.png", os.Getenv("FRONTEND_URI")),
+	})
 
 	req := GraphQLReq{
 		Query: requestQuery,

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2847,53 +2847,8 @@ func (r *Resolver) CreateJiraTaskAndAttachment(
 	return nil
 }
 
-func (r *Resolver) CreateJiraIssueAttachment(
+func (r *Resolver) CreateIssueAttachment(
 	ctx context.Context,
-	workspace *model.Workspace,
-	attachment *model.ExternalAttachment,
-	issueTitle string,
-	issueURL string,
-) error {
-	attachment.ExternalID = issueURL
-	attachment.Title = issueTitle
-	if err := r.DB.WithContext(ctx).Create(attachment).Error; err != nil {
-		return e.Wrap(err, "error creating external attachment")
-	}
-	return nil
-}
-
-func (r *Resolver) CreateHeightIssueAttachment(
-	ctx context.Context,
-	attachment *model.ExternalAttachment,
-	issueTitle string,
-	issueURL string,
-) error {
-	attachment.ExternalID = issueURL
-	attachment.Title = issueTitle
-	if err := r.DB.WithContext(ctx).Create(attachment).Error; err != nil {
-		return e.Wrap(err, "error creating external attachment")
-	}
-	return nil
-}
-
-func (r *Resolver) CreateGitHubIssueAttachment(
-	ctx context.Context,
-	workspace *model.Workspace,
-	attachment *model.ExternalAttachment,
-	issueTitle string,
-	issueURL string,
-) error {
-	attachment.ExternalID = issueURL
-	attachment.Title = issueTitle
-	if err := r.DB.WithContext(ctx).Create(attachment).Error; err != nil {
-		return e.Wrap(err, "error creating external attachment")
-	}
-	return nil
-}
-
-func (r *Resolver) CreateGitlabTaskAttachment(
-	ctx context.Context,
-	workspace *model.Workspace,
 	attachment *model.ExternalAttachment,
 	issueTitle string,
 	issueURL string,

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2797,7 +2797,7 @@ func (r *Resolver) SearchGitlabIssues(
 	}
 
 	if accessToken == nil {
-		return nil, errors.New("No Jira integration access token found.")
+		return nil, errors.New("No GitLab integration access token found.")
 	}
 
 	return gitlab.SearchGitlabIssues(*accessToken, query)
@@ -3014,9 +3014,9 @@ func (r *Resolver) SearchGitHubIssues(
 	if accessToken == nil {
 		return nil, nil
 	}
-	var repos []*github2.Issue
+	var issues []*github2.Issue
 	if c, err := github.NewClient(ctx, *accessToken, r.Redis); err == nil {
-		repos, err = c.SearchIssues(ctx, query)
+		issues, err = c.SearchIssues(ctx, query)
 		if err != nil {
 			return nil, err
 		}
@@ -3024,7 +3024,7 @@ func (r *Resolver) SearchGitHubIssues(
 		return nil, e.Wrap(err, "failed to create github client")
 	}
 
-	return lo.Map(repos, func(t *github2.Issue, i int) *modelInputs.IssuesSearchResult {
+	return lo.Map(issues, func(t *github2.Issue, i int) *modelInputs.IssuesSearchResult {
 		return &modelInputs.IssuesSearchResult{
 			ID:       strconv.FormatInt(t.GetID(), 10),
 			Title:    t.GetTitle(),

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2549,7 +2549,7 @@ func (r *Resolver) SearchLinearIssues(accessToken string, searchTerm string) ([]
 	return lo.Map(searchIssuesResponse.Data.SearchIssues.Nodes, func(res LinearIssue, _ int) *modelInputs.IssuesSearchResult {
 		return &modelInputs.IssuesSearchResult{
 			ID:       res.Id,
-			Title:    res.Title,
+			Title:    fmt.Sprintf("%s - %s", res.Identifier, res.Title),
 			IssueURL: res.Identifier,
 		}
 	}), nil
@@ -3027,7 +3027,7 @@ func (r *Resolver) SearchGitHubIssues(
 	return lo.Map(issues, func(t *github2.Issue, i int) *modelInputs.IssuesSearchResult {
 		return &modelInputs.IssuesSearchResult{
 			ID:       strconv.FormatInt(t.GetID(), 10),
-			Title:    t.GetTitle(),
+			Title:    fmt.Sprintf("#%d %s", t.GetNumber(), t.GetTitle()),
 			IssueURL: t.GetHTMLURL(),
 		}
 	}), nil

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -2767,6 +2767,24 @@ func (r *Resolver) SearchJiraIssues(
 	return jira.SearchJiraIssues(*accessToken, workspace, query)
 }
 
+func (r *Resolver) SearchHeightIssues(
+	ctx context.Context,
+	workspace *model.Workspace,
+	query string,
+) ([]*modelInputs.IssuesSearchResult, error) {
+	accessToken, err := r.IntegrationsClient.GetWorkspaceAccessToken(ctx, workspace, modelInputs.IntegrationTypeHeight)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if accessToken == nil {
+		return nil, errors.New("No Height integration access token found.")
+	}
+
+	return height.SearchTask(*accessToken, query)
+}
+
 func (r *Resolver) SearchGitlabIssues(
 	ctx context.Context,
 	workspace *model.Workspace,
@@ -2832,6 +2850,20 @@ func (r *Resolver) CreateJiraTaskAndAttachment(
 func (r *Resolver) CreateJiraIssueAttachment(
 	ctx context.Context,
 	workspace *model.Workspace,
+	attachment *model.ExternalAttachment,
+	issueTitle string,
+	issueURL string,
+) error {
+	attachment.ExternalID = issueURL
+	attachment.Title = issueTitle
+	if err := r.DB.WithContext(ctx).Create(attachment).Error; err != nil {
+		return e.Wrap(err, "error creating external attachment")
+	}
+	return nil
+}
+
+func (r *Resolver) CreateHeightIssueAttachment(
+	ctx context.Context,
 	attachment *model.ExternalAttachment,
 	issueTitle string,
 	issueURL string,

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2325,6 +2325,27 @@ type Mutation {
 		tags: [SessionCommentTagInput]!
 		additional_context: String
 	): SessionComment
+	createSessionCommentWithExistingIssue(
+		project_id: ID!
+		session_secure_id: String!
+		session_timestamp: Int!
+		text: String!
+		text_for_email: String!
+		x_coordinate: Float!
+		y_coordinate: Float!
+		tagged_admins: [SanitizedAdminInput]!
+		tagged_slack_users: [SanitizedSlackChannelInput]!
+		session_url: String!
+		time: Float!
+		author_name: String!
+		session_image: String
+		tags: [SessionCommentTagInput]!
+		integrations: [IntegrationType]!
+		issue_title: String
+		issue_url: String!
+		issue_id: String!
+		additional_context: String
+	): SessionComment
 	createIssueForSessionComment(
 		project_id: ID!
 		session_url: String!
@@ -2336,6 +2357,18 @@ type Mutation {
 		issue_description: String
 		issue_team_id: String
 		issue_type_id: String
+		integrations: [IntegrationType]!
+	): SessionComment
+	linkIssueForSessionComment(
+		project_id: ID!
+		session_url: String!
+		session_comment_id: Int!
+		author_name: String!
+		text_for_attachment: String!
+		time: Float!
+		issue_title: String
+		issue_url: String!
+		issue_id: String!
 		integrations: [IntegrationType]!
 	): SessionComment
 	deleteSessionComment(id: ID!): Boolean
@@ -2389,6 +2422,18 @@ type Mutation {
 		issue_description: String
 		issue_team_id: String
 		issue_type_id: String
+		integrations: [IntegrationType]!
+	): ErrorComment
+	linkIssueForErrorComment(
+		project_id: ID!
+		error_url: String!
+		error_comment_id: Int!
+		author_name: String!
+		text_for_attachment: String!
+		issue_title: String
+		issue_description: String
+		issue_url: String!
+		issue_id: String!
 		integrations: [IntegrationType]!
 	): ErrorComment
 	deleteErrorComment(id: ID!): Boolean

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1482,6 +1482,12 @@ type MicrosoftTeamsChannel {
 	name: String!
 }
 
+type IssuesSearchResult {
+	id: String!
+	title: String!
+	issue_url: String!
+}
+
 input MicrosoftTeamsChannelInput {
 	name: String!
 	id: String!
@@ -1962,6 +1968,11 @@ type Query {
 	): [MicrosoftTeamsChannel!]!
 	discord_channel_suggestions(project_id: ID!): [DiscordChannel!]!
 	generate_zapier_access_token(project_id: ID!): String!
+	search_issues(
+		integration_type: IntegrationType!
+		project_id: ID!
+		query: String!
+	): [IssuesSearchResult!]!
 	is_integrated_with(
 		integration_type: IntegrationType!
 		project_id: ID!
@@ -2350,6 +2361,20 @@ type Mutation {
 		issue_description: String
 		issue_team_id: String
 		issue_type_id: String
+		integrations: [IntegrationType]!
+	): ErrorComment
+	createErrorCommentForExistingIssue(
+		project_id: ID!
+		error_group_secure_id: String!
+		text: String!
+		text_for_email: String!
+		tagged_admins: [SanitizedAdminInput]!
+		tagged_slack_users: [SanitizedSlackChannelInput]!
+		error_url: String!
+		author_name: String!
+		issue_url: String!
+		issue_title: String!
+		issue_id: String!
 		integrations: [IntegrationType]!
 	): ErrorComment
 	removeErrorIssue(error_issue_id: ID!): Boolean

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -2004,6 +2004,18 @@ func (r *mutationResolver) CreateSessionCommentWithExistingIssue(ctx context.Con
 			}
 
 			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
+		} else if *s == modelInputs.IntegrationTypeHeight {
+
+			if err := r.CreateHeightIssueAttachment(
+				ctx,
+				attachment,
+				title,
+				issueURL,
+			); err != nil {
+				return nil, e.Wrap(err, "error creating GitHub issue attachment")
+			}
+
+			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
 		}
 	}
 
@@ -7007,6 +7019,14 @@ func (r *queryResolver) SearchIssues(ctx context.Context, integrationType modelI
 
 	if integrationType == modelInputs.IntegrationTypeJira {
 		results, err := r.SearchJiraIssues(ctx, workspace, query)
+		if err != nil {
+			return ret, err
+		}
+		return results, nil
+	}
+
+	if integrationType == modelInputs.IntegrationTypeHeight {
+		results, err := r.SearchHeightIssues(ctx, workspace, query)
 		if err != nil {
 			return ret, err
 		}

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1966,53 +1966,9 @@ func (r *mutationResolver) CreateSessionCommentWithExistingIssue(ctx context.Con
 			}
 
 			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
-		} else if *s == modelInputs.IntegrationTypeJira {
-
-			if err := r.CreateJiraIssueAttachment(
-				ctx,
-				workspace,
-				attachment,
-				title,
-				issueURL,
-			); err != nil {
-				return nil, e.Wrap(err, "error creating Jira task")
-			}
-
-			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
-		} else if *s == modelInputs.IntegrationTypeGitLab {
-			if err := r.CreateGitlabTaskAttachment(
-				ctx,
-				workspace,
-				attachment,
-				title,
-				issueURL,
-			); err != nil {
-				return nil, e.Wrap(err, "error creating GitLab task")
-			}
-
-			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
-		} else if *s == modelInputs.IntegrationTypeJira {
-
-			if err := r.CreateGitHubIssueAttachment(
-				ctx,
-				workspace,
-				attachment,
-				title,
-				issueURL,
-			); err != nil {
-				return nil, e.Wrap(err, "error creating GitHub issue attachment")
-			}
-
-			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
-		} else if *s == modelInputs.IntegrationTypeHeight {
-
-			if err := r.CreateHeightIssueAttachment(
-				ctx,
-				attachment,
-				title,
-				issueURL,
-			); err != nil {
-				return nil, e.Wrap(err, "error creating GitHub issue attachment")
+		} else {
+			if err := r.CreateIssueAttachment(ctx, attachment, title, issueURL); err != nil {
+				return nil, e.Wrap(err, fmt.Sprintf("error creating %s task attachment", *s))
 			}
 
 			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
@@ -2145,16 +2101,9 @@ func (r *mutationResolver) LinkIssueForSessionComment(ctx context.Context, proje
 			}
 
 			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
-		} else if *s == modelInputs.IntegrationTypeJira {
-
-			if err := r.CreateJiraIssueAttachment(ctx, workspace, attachment, title, issueURL); err != nil {
-				return nil, e.Wrap(err, "error creating Jira task")
-			}
-
-			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
-		} else if *s == modelInputs.IntegrationTypeGitLab {
-			if err := r.CreateGitlabTaskAttachment(ctx, workspace, attachment, title, issueURL); err != nil {
-				return nil, e.Wrap(err, "error creating GitLab task")
+		} else {
+			if err := r.CreateIssueAttachment(ctx, attachment, title, issueURL); err != nil {
+				return nil, e.Wrap(err, fmt.Sprintf("error creating %s issue attachment", *s))
 			}
 
 			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
@@ -2605,22 +2554,6 @@ func (r *mutationResolver) CreateErrorCommentForExistingIssue(ctx context.Contex
 			ErrorCommentID:  errorComment.ID,
 		}
 
-		if *s == modelInputs.IntegrationTypeJira {
-			if err := r.CreateJiraIssueAttachment(ctx, workspace, attachment, issueTitle, issueURL); err != nil {
-				return nil, e.Wrap(err, "error creating Jira issue attachment")
-			}
-
-			errorComment.Attachments = append(errorComment.Attachments, attachment)
-		}
-
-		if *s == modelInputs.IntegrationTypeGitLab {
-			if err := r.CreateGitlabTaskAttachment(ctx, workspace, attachment, issueTitle, issueURL); err != nil {
-				return nil, e.Wrap(err, "error creating GitLab issue attachment")
-			}
-
-			errorComment.Attachments = append(errorComment.Attachments, attachment)
-		}
-
 		if *s == modelInputs.IntegrationTypeLinear {
 			if err := r.CreateLinearAttachmentForExistingIssue(
 				ctx,
@@ -2635,6 +2568,11 @@ func (r *mutationResolver) CreateErrorCommentForExistingIssue(ctx context.Contex
 				return nil, e.Wrap(err, "error creating linear issue attachment")
 			}
 
+			errorComment.Attachments = append(errorComment.Attachments, attachment)
+		} else {
+			if err := r.CreateIssueAttachment(ctx, attachment, issueTitle, issueURL); err != nil {
+				return nil, e.Wrap(err, fmt.Sprintf("error creating %s issue attachment", *s))
+			}
 			errorComment.Attachments = append(errorComment.Attachments, attachment)
 		}
 	}
@@ -2877,16 +2815,9 @@ func (r *mutationResolver) LinkIssueForErrorComment(ctx context.Context, project
 			}
 
 			errorComment.Attachments = append(errorComment.Attachments, attachment)
-		} else if *s == modelInputs.IntegrationTypeJira {
-
-			if err := r.CreateJiraIssueAttachment(ctx, workspace, attachment, title, issueURL); err != nil {
-				return nil, e.Wrap(err, "error creating Jira task attachment")
-			}
-
-			errorComment.Attachments = append(errorComment.Attachments, attachment)
-		} else if *s == modelInputs.IntegrationTypeGitLab {
-			if err := r.CreateGitlabTaskAttachment(ctx, workspace, attachment, title, issueURL); err != nil {
-				return nil, e.Wrap(err, "error creating GitLab task attachment")
+		} else {
+			if err := r.CreateIssueAttachment(ctx, attachment, title, issueURL); err != nil {
+				return nil, e.Wrap(err, fmt.Sprintf("error creating %s task attachment", *s))
 			}
 
 			errorComment.Attachments = append(errorComment.Attachments, attachment)

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1788,6 +1788,230 @@ func (r *mutationResolver) CreateSessionComment(ctx context.Context, projectID i
 	return sessionComment, nil
 }
 
+// CreateSessionCommentWithExistingIssue is the resolver for the createSessionCommentWithExistingIssue field.
+func (r *mutationResolver) CreateSessionCommentWithExistingIssue(ctx context.Context, projectID int, sessionSecureID string, sessionTimestamp int, text string, textForEmail string, xCoordinate float64, yCoordinate float64, taggedAdmins []*modelInputs.SanitizedAdminInput, taggedSlackUsers []*modelInputs.SanitizedSlackChannelInput, sessionURL string, time float64, authorName string, sessionImage *string, tags []*modelInputs.SessionCommentTagInput, integrations []*modelInputs.IntegrationType, issueTitle *string, issueURL string, issueID string, additionalContext *string) (*model.SessionComment, error) {
+	admin, isGuest := r.getCurrentAdminOrGuest(ctx)
+
+	// All viewers can leave a comment, including guests
+	session, err := r.canAdminViewSession(ctx, sessionSecureID)
+	if err != nil {
+		return nil, err
+	}
+
+	var project model.Project
+	if err := r.DB.WithContext(ctx).Where(&model.Project{Model: model.Model{ID: projectID}}).Take(&project).Error; err != nil {
+		return nil, err
+	}
+
+	workspace, err := r.GetWorkspace(project.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	admins := r.getTaggedAdmins(taggedAdmins, isGuest)
+
+	sessionImageStr := ""
+	if sessionImage != nil {
+		sessionImageStr = *sessionImage
+	}
+
+	if sessionTimestamp >= math.MaxInt32 {
+		log.WithContext(ctx).Warnf("attempted to create session with invalid timestamp %d", sessionTimestamp)
+		sessionTimestamp = 0
+	}
+	sessionComment := &model.SessionComment{
+		Admins:          admins,
+		ProjectID:       projectID,
+		AdminId:         admin.Model.ID,
+		SessionId:       session.ID,
+		SessionSecureId: session.SecureID,
+		SessionImage:    sessionImageStr,
+		Timestamp:       sessionTimestamp,
+		Text:            text,
+		XCoordinate:     xCoordinate,
+		YCoordinate:     yCoordinate,
+	}
+	createSessionCommentSpan, _ := util.StartSpanFromContext(ctx, "db.createSessionComment",
+		util.ResourceName("resolver.createSessionComment"), util.Tag("project_id", projectID))
+	if err := r.DB.WithContext(ctx).Create(sessionComment).Error; err != nil {
+		return nil, e.Wrap(err, "error creating session comment")
+	}
+	createSessionCommentSpan.Finish()
+
+	// Create associations between tags and comments.
+	if len(tags) > 0 {
+		// Create the tag if it's a new tag
+		newTags := []*model.SessionCommentTag{}
+		existingTags := []*model.SessionCommentTag{}
+		sessionComments := []model.SessionComment{*sessionComment}
+
+		for _, tag := range tags {
+			if tag.ID == nil {
+				newSessionCommentTag := model.SessionCommentTag{
+					ProjectID:       projectID,
+					Name:            tag.Name,
+					SessionComments: sessionComments,
+				}
+				newTags = append(newTags, &newSessionCommentTag)
+			} else {
+				newSessionCommentTag := model.SessionCommentTag{
+					ProjectID: projectID,
+					Name:      tag.Name,
+					Model: model.Model{
+						ID: *tag.ID,
+					},
+					SessionComments: sessionComments,
+				}
+				existingTags = append(existingTags, &newSessionCommentTag)
+			}
+		}
+
+		if len(newTags) > 0 {
+			if err := r.DB.WithContext(ctx).Create(&newTags).Error; err != nil {
+				log.WithContext(ctx).Error("Failed to create new session tags", err)
+			}
+		}
+
+		if len(existingTags) > 0 {
+			if err := r.DB.Save(&existingTags).Error; err != nil {
+				log.WithContext(ctx).Error("Failed to update existing session tags", err)
+			}
+		}
+	}
+
+	viewLink := fmt.Sprintf("%v?commentId=%v&ts=%v", sessionURL, sessionComment.ID, time)
+	muteLink := fmt.Sprintf("%v?commentId=%v&ts=%v&muted=1", sessionURL, sessionComment.ID, time)
+
+	r.PrivateWorkerPool.SubmitRecover(func() {
+		ctx := context.Background()
+		chunkIdx, chunkTs := r.GetSessionChunk(ctx, session.ID, sessionTimestamp)
+		log.WithContext(ctx).Infof("got chunk %d ts %d for session %d ts %d", chunkIdx, chunkTs, session.ID, sessionTimestamp)
+		format := model.SessionExportFormatPng
+		resp, err := r.LambdaClient.GetSessionScreenshot(ctx, projectID, session.ID, pointy.Int(chunkTs), pointy.Int(chunkIdx), &format)
+		if err != nil {
+			log.WithContext(ctx).Errorf("failed to render screenshot for %d %d %d %s", projectID, session.ID, sessionTimestamp, err)
+		} else {
+			sessionImageStr = base64.StdEncoding.EncodeToString(resp.Image)
+			sessionImage = &sessionImageStr
+			if err := r.DB.WithContext(ctx).Model(&model.SessionComment{}).Where(
+				&model.SessionComment{Model: model.Model{ID: sessionComment.ID}},
+			).Updates(
+				model.SessionComment{
+					SessionImage: sessionImageStr,
+				},
+			).Error; err != nil {
+				log.WithContext(ctx).Error(e.Wrap(err, fmt.Sprintf("failed to update image for comment %d", sessionComment.ID)))
+			}
+		}
+		if len(taggedAdmins) > 0 && !isGuest {
+			r.sendCommentPrimaryNotification(
+				ctx,
+				admin,
+				*admin.Name,
+				taggedAdmins,
+				workspace,
+				project.ID,
+				&sessionComment.ID,
+				nil,
+				textForEmail,
+				viewLink,
+				muteLink,
+				sessionImage,
+				"tagged",
+				"session",
+				additionalContext,
+				&Email.SessionCommentMentionsAsmId,
+			)
+		}
+		if len(taggedSlackUsers) > 0 && !isGuest {
+			r.sendCommentMentionNotification(
+				ctx,
+				admin,
+				taggedSlackUsers,
+				workspace,
+				project.ID,
+				&sessionComment.ID,
+				nil,
+				textForEmail,
+				viewLink,
+				sessionImage,
+				"tagged",
+				"session",
+				additionalContext,
+			)
+		}
+	})
+
+	for _, s := range integrations {
+		attachment := &model.ExternalAttachment{
+			IntegrationType:  *s,
+			SessionCommentID: sessionComment.ID,
+		}
+		title, _ := r.Store.BuildIssueTitleAndDescription(*issueTitle, ptr.String(""))
+
+		if *s == modelInputs.IntegrationTypeLinear &&
+			workspace.LinearAccessToken != nil &&
+			*workspace.LinearAccessToken != "" {
+			if err := r.CreateLinearAttachmentForExistingIssue(
+				ctx,
+				workspace,
+				attachment,
+				title,
+				authorName,
+				viewLink,
+				issueID,
+				issueURL,
+			); err != nil {
+				return nil, e.Wrap(err, "error creating linear issue attachment")
+			}
+
+			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
+		} else if *s == modelInputs.IntegrationTypeJira {
+
+			if err := r.CreateJiraIssueAttachment(
+				ctx,
+				workspace,
+				attachment,
+				title,
+				issueURL,
+			); err != nil {
+				return nil, e.Wrap(err, "error creating Jira task")
+			}
+
+			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
+		} else if *s == modelInputs.IntegrationTypeGitLab {
+			if err := r.CreateGitlabTaskAttachment(
+				ctx,
+				workspace,
+				attachment,
+				title,
+				issueURL,
+			); err != nil {
+				return nil, e.Wrap(err, "error creating GitLab task")
+			}
+
+			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
+		}
+	}
+
+	taggedUsers := append(taggedAdmins, &modelInputs.SanitizedAdminInput{
+		ID:    admin.ID,
+		Name:  admin.Name,
+		Email: *admin.Email,
+	})
+	newFollowers := r.findNewFollowers(taggedUsers, taggedSlackUsers, nil, nil)
+	for _, f := range newFollowers {
+		f.SessionCommentID = sessionComment.ID
+	}
+	if len(newFollowers) > 0 {
+		if err := r.DB.WithContext(ctx).Create(&newFollowers).Error; err != nil {
+			log.WithContext(ctx).Error("Failed to create new session comment followers", err)
+		}
+	}
+
+	return sessionComment, nil
+}
+
 // CreateIssueForSessionComment is the resolver for the createIssueForSessionComment field.
 func (r *mutationResolver) CreateIssueForSessionComment(ctx context.Context, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueDescription *string, issueTeamID *string, issueTypeID *string, integrations []*modelInputs.IntegrationType) (*model.SessionComment, error) {
 	var project model.Project
@@ -1853,6 +2077,58 @@ func (r *mutationResolver) CreateIssueForSessionComment(ctx context.Context, pro
 			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
 		} else if *s == modelInputs.IntegrationTypeGitLab {
 			if err := r.CreateGitlabTaskAndAttachment(ctx, workspace, attachment, title, desc, *issueTeamID); err != nil {
+				return nil, e.Wrap(err, "error creating GitLab task")
+			}
+
+			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
+		}
+	}
+
+	return sessionComment, nil
+}
+
+// LinkIssueForSessionComment is the resolver for the linkIssueForSessionComment field.
+func (r *mutationResolver) LinkIssueForSessionComment(ctx context.Context, projectID int, sessionURL string, sessionCommentID int, authorName string, textForAttachment string, time float64, issueTitle *string, issueURL string, issueID string, integrations []*modelInputs.IntegrationType) (*model.SessionComment, error) {
+	var project model.Project
+	if err := r.DB.WithContext(ctx).Where("id = ?", projectID).Take(&project).Error; err != nil {
+		return nil, err
+	}
+
+	workspace, err := r.GetWorkspace(project.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionComment := &model.SessionComment{}
+	if err := r.DB.WithContext(ctx).Preload("Attachments").Where(&model.SessionComment{Model: model.Model{ID: sessionCommentID}}).Find(sessionComment).Error; err != nil {
+		return nil, err
+	}
+
+	viewLink := fmt.Sprintf("%v?commentId=%v&ts=%v", sessionURL, sessionComment.ID, time)
+
+	for _, s := range integrations {
+		attachment := &model.ExternalAttachment{
+			IntegrationType:  *s,
+			SessionCommentID: sessionComment.ID,
+		}
+
+		title, _ := r.Store.BuildIssueTitleAndDescription(*issueTitle, ptr.String(""))
+
+		if *s == modelInputs.IntegrationTypeLinear && workspace.LinearAccessToken != nil && *workspace.LinearAccessToken != "" {
+			if err := r.CreateLinearAttachmentForExistingIssue(ctx, workspace, attachment, sessionComment.Text, authorName, viewLink, issueID, issueURL); err != nil {
+				return nil, e.Wrap(err, "error creating linear issue attachment")
+			}
+
+			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
+		} else if *s == modelInputs.IntegrationTypeJira {
+
+			if err := r.CreateJiraIssueAttachment(ctx, workspace, attachment, title, issueURL); err != nil {
+				return nil, e.Wrap(err, "error creating Jira task")
+			}
+
+			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
+		} else if *s == modelInputs.IntegrationTypeGitLab {
+			if err := r.CreateGitlabTaskAttachment(ctx, workspace, attachment, title, issueURL); err != nil {
 				return nil, e.Wrap(err, "error creating GitLab task")
 			}
 
@@ -2320,7 +2596,7 @@ func (r *mutationResolver) CreateErrorCommentForExistingIssue(ctx context.Contex
 			errorComment.Attachments = append(errorComment.Attachments, attachment)
 		}
 
-		if *s == modelInputs.IntegrationTypeGitLab {
+		if *s == modelInputs.IntegrationTypeLinear {
 			if err := r.CreateLinearAttachmentForExistingIssue(
 				ctx,
 				workspace,
@@ -2521,6 +2797,71 @@ func (r *mutationResolver) CreateIssueForErrorComment(ctx context.Context, proje
 		} else if *s == modelInputs.IntegrationTypeGitLab {
 			if err := r.CreateGitlabTaskAndAttachment(ctx, workspace, attachment, title, desc, *issueTeamID); err != nil {
 				return nil, e.Wrap(err, "error creating GitLab task")
+			}
+
+			errorComment.Attachments = append(errorComment.Attachments, attachment)
+		}
+	}
+
+	return errorComment, nil
+}
+
+// LinkIssueForErrorComment is the resolver for the linkIssueForErrorComment field.
+func (r *mutationResolver) LinkIssueForErrorComment(ctx context.Context, projectID int, errorURL string, errorCommentID int, authorName string, textForAttachment string, issueTitle *string, issueDescription *string, issueURL string, issueID string, integrations []*modelInputs.IntegrationType) (*model.ErrorComment, error) {
+	var project model.Project
+	if err := r.DB.WithContext(ctx).Where(&model.Project{Model: model.Model{ID: projectID}}).Take(&project).Error; err != nil {
+		return nil, err
+	}
+
+	workspace, err := r.GetWorkspace(project.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	errorComment := &model.ErrorComment{}
+	if err := r.DB.WithContext(ctx).Preload("Attachments").Where(&model.ErrorComment{Model: model.Model{ID: errorCommentID}}).Find(errorComment).Error; err != nil {
+		return nil, err
+	}
+
+	viewLink := fmt.Sprintf("%v", errorURL)
+
+	if issueDescription == nil {
+		return nil, e.New("issue description cannot be nil")
+	}
+
+	title, _ := r.Store.BuildIssueTitleAndDescription(*issueTitle, ptr.String(""))
+
+	for _, s := range integrations {
+		attachment := &model.ExternalAttachment{
+			IntegrationType: *s,
+			ErrorCommentID:  errorComment.ID,
+		}
+
+		if *s == modelInputs.IntegrationTypeLinear && workspace.LinearAccessToken != nil && *workspace.LinearAccessToken != "" {
+			if err := r.CreateLinearAttachmentForExistingIssue(
+				ctx,
+				workspace,
+				attachment,
+				errorComment.Text,
+				authorName,
+				viewLink,
+				issueID,
+				issueURL,
+			); err != nil {
+				return nil, e.Wrap(err, "error creating linear issue attachment")
+			}
+
+			errorComment.Attachments = append(errorComment.Attachments, attachment)
+		} else if *s == modelInputs.IntegrationTypeJira {
+
+			if err := r.CreateJiraIssueAttachment(ctx, workspace, attachment, title, issueURL); err != nil {
+				return nil, e.Wrap(err, "error creating Jira task attachment")
+			}
+
+			errorComment.Attachments = append(errorComment.Attachments, attachment)
+		} else if *s == modelInputs.IntegrationTypeGitLab {
+			if err := r.CreateGitlabTaskAttachment(ctx, workspace, attachment, title, issueURL); err != nil {
+				return nil, e.Wrap(err, "error creating GitLab task attachment")
 			}
 
 			errorComment.Attachments = append(errorComment.Attachments, attachment)

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -1991,6 +1991,19 @@ func (r *mutationResolver) CreateSessionCommentWithExistingIssue(ctx context.Con
 			}
 
 			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
+		} else if *s == modelInputs.IntegrationTypeJira {
+
+			if err := r.CreateGitHubIssueAttachment(
+				ctx,
+				workspace,
+				attachment,
+				title,
+				issueURL,
+			); err != nil {
+				return nil, e.Wrap(err, "error creating GitHub issue attachment")
+			}
+
+			sessionComment.Attachments = append(sessionComment.Attachments, attachment)
 		}
 	}
 
@@ -7010,6 +7023,14 @@ func (r *queryResolver) SearchIssues(ctx context.Context, integrationType modelI
 
 	if integrationType == modelInputs.IntegrationTypeLinear {
 		results, err := r.SearchLinearIssues(*workspace.LinearAccessToken, query)
+		if err != nil {
+			return ret, err
+		}
+		return results, nil
+	}
+
+	if integrationType == modelInputs.IntegrationTypeGitHub {
+		results, err := r.SearchGitHubIssues(ctx, workspace, query)
 		if err != nil {
 			return ret, err
 		}

--- a/backend/store/stacktraces_test.go
+++ b/backend/store/stacktraces_test.go
@@ -411,3 +411,7 @@ func (c *MockGithubClient) ListRepos(ctx context.Context) ([]*github2.Repository
 func (c *MockGithubClient) DeleteInstallation(ctx context.Context, installation string) error {
 	return nil
 }
+
+func (c *MockGithubClient) SearchIssues(ctx context.Context, rawQuery string) ([]*github2.Issue, error) {
+	return nil, nil
+}

--- a/frontend/src/components/Comment/AttachmentList/AttachmentList.tsx
+++ b/frontend/src/components/Comment/AttachmentList/AttachmentList.tsx
@@ -41,6 +41,9 @@ export const getAttachmentUrl = (a: Maybe<ExternalAttachment>) => {
 		case IntegrationType.ClickUp:
 			return `https://app.clickup.com/t/${a.external_id}`
 		case IntegrationType.Height:
+			if (a.external_id.startsWith('https:')) {
+				return a.external_id
+			}
 			return `https://height.app/${a.external_id}`
 		case IntegrationType.GitHub:
 			return a.external_id

--- a/frontend/src/components/NewIssueModal/NewIssueModal.tsx
+++ b/frontend/src/components/NewIssueModal/NewIssueModal.tsx
@@ -32,6 +32,7 @@ import {
 	GITLAB_INTEGRATION,
 	JIRA_INTEGRATION,
 	LINEAR_INTEGRATION,
+	NewIntegrationIssueType,
 } from '@pages/IntegrationsPage/Integrations'
 import { IssueTrackerIntegration } from '@pages/IntegrationsPage/IssueTrackerIntegrations'
 import { useParams } from '@util/react-router/useParams'
@@ -111,7 +112,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 		],
 	})
 
-	const [mode, setMode] = React.useState('Create Issue')
+	const [mode, setMode] = React.useState(NewIntegrationIssueType.CreateIssue)
 	const [linkedIssue, setLinkedIssue] = useState({
 		id: '',
 		url: '',
@@ -142,7 +143,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 			const author = admin?.name || admin?.email || 'Someone'
 			const integrations = [selectedIntegration.name] as IntegrationType[]
 			if (commentType === 'SessionComment' && commentId) {
-				if (mode === 'Create Issue') {
+				if (mode === NewIntegrationIssueType.CreateIssue) {
 					await createIssueForSessionComment({
 						variables: {
 							project_id: project_id!,
@@ -176,7 +177,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 				}
 			} else if (commentType === 'ErrorComment') {
 				if (commentId) {
-					if (mode === 'Create Issue') {
+					if (mode === NewIntegrationIssueType.CreateIssue) {
 						await createIssueForErrorComment({
 							variables: {
 								project_id: project_id!,
@@ -207,7 +208,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 						})
 					}
 				} else if (errorSecureId) {
-					if (mode === 'Create Issue') {
+					if (mode === NewIntegrationIssueType.CreateIssue) {
 						await createErrorComment({
 							variables: {
 								project_id: project_id!,
@@ -259,7 +260,9 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 			form.reset()
 
 			const toastMessage =
-				mode === 'Create Issue' ? 'New Issue Created!' : 'Issue Linked'
+				mode === NewIntegrationIssueType.CreateIssue
+					? 'New Issue Created!'
+					: 'Issue Linked!'
 			message.success(toastMessage)
 		} catch (e: any) {
 			H.consumeError(e)
@@ -334,14 +337,20 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 					<Box px="12" py="8" gap="12" display="flex" align="center">
 						<RadioGroup
 							labels={['Create Issue', 'Link Issue']}
-							selectedLabel={mode}
-							onSelect={(label: any) => setMode(label)}
-							style={{
-								width: '100%',
-								display: 'flex',
-								justifyContent: 'center',
-								alignItems: 'center',
-							}}
+							selectedLabel={
+								mode === NewIntegrationIssueType.CreateIssue
+									? 'Create Issue'
+									: 'Link Issue'
+							}
+							onSelect={(label: string) =>
+								setMode(
+									label === 'Create Issue'
+										? NewIntegrationIssueType.CreateIssue
+										: NewIntegrationIssueType.LinkIssue,
+								)
+							}
+							labelStyle={{ width: '100%' }}
+							wrapperStyle={{ width: '100%' }}
 						/>
 					</Box>
 				)}
@@ -353,13 +362,7 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 						display="flex"
 						flexDirection="column"
 					>
-						{mode === 'Create Issue' &&
-							selectedIntegration.containerSelection({
-								setSelectionId: setContainerId,
-								setIssueTypeId: setIssueTypeId,
-								disabled: loading,
-							})}
-						{mode === 'Link Issue' && (
+						{mode === NewIntegrationIssueType.LinkIssue && (
 							<SearchIssues
 								onSelect={(value: any) => {
 									if (value) {
@@ -370,29 +373,36 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 								project_id={project_id!}
 							/>
 						)}
-						{mode === 'Create Issue' && (
-							<Form.Input
-								name={form.names.issueTitle}
-								label="Issue Title"
-								placeholder="Add a concise summary of the issue"
-								outline
-								truncate
-								required
-								disabled={loading}
-							/>
-						)}
-						{mode === 'Create Issue' && (
-							<Form.Input
-								name={form.names.issueDescription}
-								label="Issue Description"
-								placeholder="Hey, check this out!"
-								// @ts-expect-error
-								as="textarea"
-								outline
-								aria-multiline
-								rows={5}
-								disabled={loading}
-							/>
+						{mode === NewIntegrationIssueType.CreateIssue && (
+							<>
+								{selectedIntegration.containerSelection({
+									setSelectionId: setContainerId,
+									setIssueTypeId: setIssueTypeId,
+									disabled: loading,
+								})}
+
+								<Form.Input
+									name={form.names.issueTitle}
+									label="Issue Title"
+									placeholder="Add a concise summary of the issue"
+									outline
+									truncate
+									required
+									disabled={loading}
+								/>
+
+								<Form.Input
+									name={form.names.issueDescription}
+									label="Issue Description"
+									placeholder="Hey, check this out!"
+									// @ts-expect-error
+									as="textarea"
+									outline
+									aria-multiline
+									rows={5}
+									disabled={loading}
+								/>
+							</>
 						)}
 					</Box>
 					<Box

--- a/frontend/src/components/NewIssueModal/NewIssueModal.tsx
+++ b/frontend/src/components/NewIssueModal/NewIssueModal.tsx
@@ -357,16 +357,9 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 			width="324px"
 		>
 			<ModalBody>
-				{/* ClickUp doesn't support linking issues, so we don't need to show this section. */}
+				{/* ClickUp doesn't support searching issues, so we don't need to show this section. */}
 				{selectedIntegration.name !== 'ClickUp' && (
-					<Box
-						px="12"
-						py="8"
-						gap="12"
-						display="flex"
-						align="center"
-						background="contentBad"
-					>
+					<Box px="12" py="8" gap="12" display="flex" align="center">
 						<RadioGroup
 							labels={['Create Issue', 'Link Issue']}
 							selectedLabel={mode}

--- a/frontend/src/components/NewIssueModal/NewIssueModal.tsx
+++ b/frontend/src/components/NewIssueModal/NewIssueModal.tsx
@@ -3,7 +3,6 @@ import { Button } from '@components/Button'
 import Modal from '@components/Modal/Modal'
 import ModalBody from '@components/ModalBody/ModalBody'
 import { RadioGroup } from '@components/RadioGroup/RadioGroup'
-import { SearchSelect } from '@components/Select/SearchSelect/SearchSelect'
 import {
 	useCreateErrorCommentForExistingIssueMutation,
 	useCreateErrorCommentMutation,
@@ -11,7 +10,6 @@ import {
 	useCreateIssueForSessionCommentMutation,
 	useLinkIssueForErrorCommentMutation,
 	useLinkIssueForSessionCommentMutation,
-	useSearchIssuesLazyQuery,
 } from '@graph/hooks'
 import { namedOperations } from '@graph/operations'
 import { IntegrationType } from '@graph/schemas'
@@ -42,7 +40,7 @@ import { message } from 'antd'
 import { H } from 'highlight.run'
 import React, { useMemo, useState } from 'react'
 
-import { useDebouncedValue } from '@/hooks/useDebouncedValue'
+import { SearchIssues } from '@/components/SearchIssues/SearchIssues'
 
 interface NewIssueModalProps {
 	visible: boolean
@@ -114,40 +112,11 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 	})
 
 	const [mode, setMode] = React.useState('Create Issue')
-	const [query, setQuery] = useState<string>('')
 	const [linkedIssue, setLinkedIssue] = useState({
 		id: '',
 		url: '',
 		title: '',
 	})
-	const debouncedQuery = useDebouncedValue(query) || ''
-	const [searchIssues, { data, loading: loadingIssues }] =
-		useSearchIssuesLazyQuery()
-
-	React.useEffect(() => {
-		debouncedQuery &&
-			searchIssues({
-				variables: {
-					project_id: project_id!,
-					query: debouncedQuery,
-					integration_type:
-						selectedIntegration.name as IntegrationType,
-				},
-				fetchPolicy: 'no-cache',
-			})
-	}, [searchIssues, project_id, debouncedQuery, selectedIntegration])
-
-	const matchedIssues = React.useMemo(() => {
-		return (
-			data?.search_issues.map((s) => ({
-				displayValue: s.title,
-				id: s.id,
-				key: s.id,
-				value: s.issue_url,
-				label: s.title,
-			})) || []
-		)
-	}, [data])
 
 	React.useEffect(() => {
 		if (!defaultIssueTitle && !commentText) return
@@ -391,33 +360,15 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 								disabled: loading,
 							})}
 						{mode === 'Link Issue' && (
-							<Form.NamedSection
-								label="Link an issue"
-								name="issue_id"
-							>
-								<SearchSelect
-									loading={loadingIssues}
-									placeholder="Search Issues ..."
-									options={matchedIssues}
-									onSelect={(value: string) => {
-										const matchedValue = matchedIssues.find(
-											(v: { value: string }) =>
-												v.value == value,
-										)
-										if (value) {
-											setLinkedIssue({
-												id: value,
-												url: value || '',
-												title: matchedValue
-													? matchedValue.label
-													: '',
-											})
-										}
-									}}
-									value={linkedIssue.id}
-									loadOptions={setQuery}
-								/>
-							</Form.NamedSection>
+							<SearchIssues
+								onSelect={(value: any) => {
+									if (value) {
+										setLinkedIssue(value)
+									}
+								}}
+								integration={selectedIntegration}
+								project_id={project_id!}
+							/>
 						)}
 						{mode === 'Create Issue' && (
 							<Form.Input

--- a/frontend/src/components/NewIssueModal/NewIssueModal.tsx
+++ b/frontend/src/components/NewIssueModal/NewIssueModal.tsx
@@ -288,7 +288,10 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 			}
 			onClose()
 			form.reset()
-			message.success('New Issue Created!')
+
+			const toastMessage =
+				mode === 'Create Issue' ? 'New Issue Created!' : 'Issue Linked'
+			message.success(toastMessage)
 		} catch (e: any) {
 			H.consumeError(e)
 			console.error(e)

--- a/frontend/src/components/NewIssueModal/NewIssueModal.tsx
+++ b/frontend/src/components/NewIssueModal/NewIssueModal.tsx
@@ -357,19 +357,29 @@ const NewIssueModal: React.FC<React.PropsWithChildren<NewIssueModalProps>> = ({
 			width="324px"
 		>
 			<ModalBody>
-				<Box px="12" py="8" gap="12" display="flex" align="center">
-					<RadioGroup
-						labels={['Create Issue', 'Link Issue']}
-						selectedLabel={mode}
-						onSelect={(label: any) => setMode(label)}
-						style={{
-							width: '100%',
-							display: 'flex',
-							justifyContent: 'center',
-							alignItems: 'center',
-						}}
-					/>
-				</Box>
+				{/* ClickUp doesn't support linking issues, so we don't need to show this section. */}
+				{selectedIntegration.name !== 'ClickUp' && (
+					<Box
+						px="12"
+						py="8"
+						gap="12"
+						display="flex"
+						align="center"
+						background="contentBad"
+					>
+						<RadioGroup
+							labels={['Create Issue', 'Link Issue']}
+							selectedLabel={mode}
+							onSelect={(label: any) => setMode(label)}
+							style={{
+								width: '100%',
+								display: 'flex',
+								justifyContent: 'center',
+								alignItems: 'center',
+							}}
+						/>
+					</Box>
+				)}
 				<Form aria-labelledBy="newComment" store={form}>
 					<Box
 						px="12"

--- a/frontend/src/components/RadioGroup/RadioGroup.tsx
+++ b/frontend/src/components/RadioGroup/RadioGroup.tsx
@@ -21,6 +21,7 @@ export const RadioGroup = <T extends string | number>({
 					borderColor: 'var(--color-purple)',
 					backgroundColor: 'var(--color-purple)',
 					color: 'var(--text-primary-inverted)',
+					...style,
 				}}
 				className={styles.platformOption}
 				onClick={() => onSelect(label)}
@@ -34,6 +35,7 @@ export const RadioGroup = <T extends string | number>({
 				style={{
 					borderColor: 'var(--color-gray-300)',
 					color: 'var(--text-primary)',
+					...style,
 				}}
 				className={styles.platformOption}
 				onClick={() => onSelect(label)}

--- a/frontend/src/components/RadioGroup/RadioGroup.tsx
+++ b/frontend/src/components/RadioGroup/RadioGroup.tsx
@@ -6,12 +6,14 @@ export const RadioGroup = <T extends string | number>({
 	onSelect,
 	labels,
 	selectedLabel,
-	style,
+	labelStyle,
+	wrapperStyle,
 }: {
 	onSelect: (p: T) => void
 	labels: T[]
 	selectedLabel: T
-	style?: React.CSSProperties
+	labelStyle?: React.CSSProperties
+	wrapperStyle?: React.CSSProperties
 }) => {
 	const labelDivs = labels.map((label, i) => {
 		return label === selectedLabel ? (
@@ -21,7 +23,7 @@ export const RadioGroup = <T extends string | number>({
 					borderColor: 'var(--color-purple)',
 					backgroundColor: 'var(--color-purple)',
 					color: 'var(--text-primary-inverted)',
-					...style,
+					...labelStyle,
 				}}
 				className={styles.platformOption}
 				onClick={() => onSelect(label)}
@@ -35,7 +37,7 @@ export const RadioGroup = <T extends string | number>({
 				style={{
 					borderColor: 'var(--color-gray-300)',
 					color: 'var(--text-primary)',
-					...style,
+					...labelStyle,
 				}}
 				className={styles.platformOption}
 				onClick={() => onSelect(label)}
@@ -46,7 +48,7 @@ export const RadioGroup = <T extends string | number>({
 		)
 	})
 	return (
-		<div style={style} className={styles.radioGroupWrapper}>
+		<div style={wrapperStyle} className={styles.radioGroupWrapper}>
 			{labelDivs}
 		</div>
 	)

--- a/frontend/src/components/SearchIssues/SearchIssues.module.css
+++ b/frontend/src/components/SearchIssues/SearchIssues.module.css
@@ -1,0 +1,33 @@
+.select {
+	border-radius: var(--border-radius) !important;
+	height: 40px;
+	width: 100%;
+
+	:global(.ant-select-selection-search) {
+		align-items: center !important;
+		display: flex !important;
+	}
+
+	:global(.ant-select-selector) {
+		background-color: var(--color-primary-background) !important;
+		border: 1px solid var(--color-gray-300) !important;
+		border-radius: var(--border-radius) !important;
+		font-family: var(--body-font-family) !important;
+		font-size: 16px !important;
+	}
+
+	:global(.ant-select-selection-placeholder) {
+		color: var(--color-gray-500) !important;
+		left: var(--size-small);
+	}
+
+	:global(.ant-select-selector:hover),
+	:global(.ant-select-open) {
+		background: var(--color-gray-300) !important;
+
+		& .ant-select-selector {
+			background-color: var(--color-gray-300) !important;
+			border-radius: var(--border-radius) !important;
+		}
+	}
+}

--- a/frontend/src/components/SearchIssues/SearchIssues.tsx
+++ b/frontend/src/components/SearchIssues/SearchIssues.tsx
@@ -1,0 +1,94 @@
+import { Form } from '@highlight-run/ui/components'
+import { Select } from 'antd'
+import { useState } from 'react'
+import React from 'react'
+
+import { useSearchIssuesLazyQuery } from '@/graph/generated/hooks'
+import { IntegrationType } from '@/graph/generated/schemas'
+import { useDebouncedValue } from '@/hooks/useDebouncedValue'
+import { IssueTrackerIntegration } from '@/pages/IntegrationsPage/IssueTrackerIntegrations'
+
+import styles from './SearchIssues.module.css'
+export interface SearchOption {
+	value: string
+	label: string
+	id: string
+	url: string
+}
+
+export interface SearchIssuesProps {
+	onSelect: (option: SearchOption) => void
+	integration: IssueTrackerIntegration
+	project_id: string
+}
+
+export const SearchIssues = ({
+	onSelect,
+	integration,
+	project_id,
+}: SearchIssuesProps) => {
+	const [selectedOption, setSelectOption] = React.useState<
+		SearchOption | undefined
+	>({
+		label: '',
+		value: '',
+		id: '',
+		url: '',
+	})
+	const [query, setQuery] = useState<string>('')
+
+	const debouncedQuery = useDebouncedValue(query) || ''
+	const [searchIssues, { data, loading }] = useSearchIssuesLazyQuery()
+
+	React.useEffect(() => {
+		debouncedQuery &&
+			searchIssues({
+				variables: {
+					project_id,
+					query: debouncedQuery,
+					integration_type: integration.name as IntegrationType,
+				},
+				fetchPolicy: 'no-cache',
+			})
+	}, [searchIssues, project_id, debouncedQuery, integration])
+
+	const options = React.useMemo(() => {
+		return (
+			data?.search_issues.map((s) => ({
+				id: s.id,
+				url: s.issue_url,
+				value: s.issue_url,
+				label: s.title,
+			})) || []
+		)
+	}, [data]) as SearchOption[]
+
+	return (
+		<Form.NamedSection label="Link an issue" name="issue_id">
+			<Select
+				className={styles.select}
+				// this mode allows using the select component as a single searchable input
+				// @ts-ignore
+				placeholder="Search Issues"
+				autoFocus
+				size="middle"
+				// @ts-ignore
+				onSelect={(newValue: string) => {
+					const option = options.find((o) => o.value === newValue)
+					if (option) {
+						onSelect(option)
+						setSelectOption(option)
+					}
+				}}
+				defaultValue={selectedOption as unknown as SearchOption}
+				options={options}
+				notFoundContent={<span>`No issues found`</span>}
+				filterOption={false}
+				loading={loading}
+				onSearch={setQuery}
+				showSearch
+				showArrow={loading}
+			/>
+		</Form.NamedSection>
+	)
+}

--- a/frontend/src/components/Select/SearchSelect/SearchSelect.tsx
+++ b/frontend/src/components/Select/SearchSelect/SearchSelect.tsx
@@ -14,11 +14,19 @@ export const SearchSelect = ({
 	options,
 	loadOptions,
 	value,
+	valueLable,
+	labelInValue = true,
+	loading = false,
+	placeholder = 'graphql.operation.users',
 }: {
 	onSelect: (name: string) => void
 	options: SearchOption[]
 	loadOptions: (input: string) => void
 	value?: string
+	placeholder?: string
+	valueLable?: string
+	labelInValue?: boolean
+	loading?: boolean
 }) => {
 	return (
 		<Select
@@ -26,16 +34,19 @@ export const SearchSelect = ({
 			// this mode allows using the select component as a single searchable input
 			// @ts-ignore
 			mode="SECRET_COMBOBOX_MODE_DO_NOT_USE"
-			placeholder="graphql.operation.users"
+			placeholder={placeholder}
 			autoFocus
 			onSelect={(newValue: SearchOption) => {
 				onSelect(newValue?.value || '')
 			}}
-			defaultValue={{ label: value, value: value } as SearchOption}
+			defaultValue={
+				{ label: valueLable || value, value: value } as SearchOption
+			}
 			options={options}
 			notFoundContent={<span>`No results found`</span>}
-			labelInValue
+			labelInValue={labelInValue}
 			filterOption={false}
+			loading={loading}
 			onSearch={loadOptions}
 		/>
 	)

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -2079,6 +2079,131 @@ export type CreateSessionCommentMutationOptions = Apollo.BaseMutationOptions<
 	Types.CreateSessionCommentMutation,
 	Types.CreateSessionCommentMutationVariables
 >
+export const CreateSessionCommentWithExistingIssueDocument = gql`
+	mutation CreateSessionCommentWithExistingIssue(
+		$project_id: ID!
+		$session_secure_id: String!
+		$session_timestamp: Int!
+		$text: String!
+		$text_for_email: String!
+		$x_coordinate: Float!
+		$y_coordinate: Float!
+		$tagged_admins: [SanitizedAdminInput]!
+		$tagged_slack_users: [SanitizedSlackChannelInput]!
+		$session_url: String!
+		$time: Float!
+		$author_name: String!
+		$session_image: String
+		$tags: [SessionCommentTagInput]!
+		$integrations: [IntegrationType]!
+		$issue_title: String
+		$issue_url: String!
+		$issue_id: String!
+		$additional_context: String
+	) {
+		createSessionCommentWithExistingIssue(
+			project_id: $project_id
+			session_secure_id: $session_secure_id
+			session_timestamp: $session_timestamp
+			text: $text
+			text_for_email: $text_for_email
+			x_coordinate: $x_coordinate
+			y_coordinate: $y_coordinate
+			tagged_admins: $tagged_admins
+			tagged_slack_users: $tagged_slack_users
+			session_url: $session_url
+			time: $time
+			author_name: $author_name
+			session_image: $session_image
+			tags: $tags
+			integrations: $integrations
+			issue_title: $issue_title
+			issue_url: $issue_url
+			issue_id: $issue_id
+			additional_context: $additional_context
+		) {
+			id
+			timestamp
+			created_at
+			updated_at
+			author {
+				id
+				name
+				email
+			}
+			text
+			x_coordinate
+			y_coordinate
+			attachments {
+				id
+				integration_type
+				external_id
+				title
+			}
+		}
+	}
+`
+export type CreateSessionCommentWithExistingIssueMutationFn =
+	Apollo.MutationFunction<
+		Types.CreateSessionCommentWithExistingIssueMutation,
+		Types.CreateSessionCommentWithExistingIssueMutationVariables
+	>
+
+/**
+ * __useCreateSessionCommentWithExistingIssueMutation__
+ *
+ * To run a mutation, you first call `useCreateSessionCommentWithExistingIssueMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateSessionCommentWithExistingIssueMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createSessionCommentWithExistingIssueMutation, { data, loading, error }] = useCreateSessionCommentWithExistingIssueMutation({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *      session_secure_id: // value for 'session_secure_id'
+ *      session_timestamp: // value for 'session_timestamp'
+ *      text: // value for 'text'
+ *      text_for_email: // value for 'text_for_email'
+ *      x_coordinate: // value for 'x_coordinate'
+ *      y_coordinate: // value for 'y_coordinate'
+ *      tagged_admins: // value for 'tagged_admins'
+ *      tagged_slack_users: // value for 'tagged_slack_users'
+ *      session_url: // value for 'session_url'
+ *      time: // value for 'time'
+ *      author_name: // value for 'author_name'
+ *      session_image: // value for 'session_image'
+ *      tags: // value for 'tags'
+ *      integrations: // value for 'integrations'
+ *      issue_title: // value for 'issue_title'
+ *      issue_url: // value for 'issue_url'
+ *      issue_id: // value for 'issue_id'
+ *      additional_context: // value for 'additional_context'
+ *   },
+ * });
+ */
+export function useCreateSessionCommentWithExistingIssueMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateSessionCommentWithExistingIssueMutation,
+		Types.CreateSessionCommentWithExistingIssueMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateSessionCommentWithExistingIssueMutation,
+		Types.CreateSessionCommentWithExistingIssueMutationVariables
+	>(CreateSessionCommentWithExistingIssueDocument, baseOptions)
+}
+export type CreateSessionCommentWithExistingIssueMutationHookResult =
+	ReturnType<typeof useCreateSessionCommentWithExistingIssueMutation>
+export type CreateSessionCommentWithExistingIssueMutationResult =
+	Apollo.MutationResult<Types.CreateSessionCommentWithExistingIssueMutation>
+export type CreateSessionCommentWithExistingIssueMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.CreateSessionCommentWithExistingIssueMutation,
+		Types.CreateSessionCommentWithExistingIssueMutationVariables
+	>
 export const CreateIssueForSessionCommentDocument = gql`
 	mutation CreateIssueForSessionComment(
 		$project_id: ID!
@@ -2179,6 +2304,104 @@ export type CreateIssueForSessionCommentMutationOptions =
 	Apollo.BaseMutationOptions<
 		Types.CreateIssueForSessionCommentMutation,
 		Types.CreateIssueForSessionCommentMutationVariables
+	>
+export const LinkIssueForSessionCommentDocument = gql`
+	mutation LinkIssueForSessionComment(
+		$project_id: ID!
+		$session_comment_id: Int!
+		$text_for_attachment: String!
+		$session_url: String!
+		$time: Float!
+		$author_name: String!
+		$integrations: [IntegrationType]!
+		$issue_title: String
+		$issue_id: String!
+		$issue_url: String!
+	) {
+		linkIssueForSessionComment(
+			project_id: $project_id
+			session_url: $session_url
+			session_comment_id: $session_comment_id
+			author_name: $author_name
+			text_for_attachment: $text_for_attachment
+			time: $time
+			issue_title: $issue_title
+			issue_id: $issue_id
+			integrations: $integrations
+			issue_url: $issue_url
+		) {
+			id
+			timestamp
+			created_at
+			updated_at
+			author {
+				id
+				name
+				email
+			}
+			text
+			x_coordinate
+			y_coordinate
+			attachments {
+				id
+				integration_type
+				external_id
+				title
+			}
+		}
+	}
+`
+export type LinkIssueForSessionCommentMutationFn = Apollo.MutationFunction<
+	Types.LinkIssueForSessionCommentMutation,
+	Types.LinkIssueForSessionCommentMutationVariables
+>
+
+/**
+ * __useLinkIssueForSessionCommentMutation__
+ *
+ * To run a mutation, you first call `useLinkIssueForSessionCommentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useLinkIssueForSessionCommentMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [linkIssueForSessionCommentMutation, { data, loading, error }] = useLinkIssueForSessionCommentMutation({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *      session_comment_id: // value for 'session_comment_id'
+ *      text_for_attachment: // value for 'text_for_attachment'
+ *      session_url: // value for 'session_url'
+ *      time: // value for 'time'
+ *      author_name: // value for 'author_name'
+ *      integrations: // value for 'integrations'
+ *      issue_title: // value for 'issue_title'
+ *      issue_id: // value for 'issue_id'
+ *      issue_url: // value for 'issue_url'
+ *   },
+ * });
+ */
+export function useLinkIssueForSessionCommentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.LinkIssueForSessionCommentMutation,
+		Types.LinkIssueForSessionCommentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.LinkIssueForSessionCommentMutation,
+		Types.LinkIssueForSessionCommentMutationVariables
+	>(LinkIssueForSessionCommentDocument, baseOptions)
+}
+export type LinkIssueForSessionCommentMutationHookResult = ReturnType<
+	typeof useLinkIssueForSessionCommentMutation
+>
+export type LinkIssueForSessionCommentMutationResult =
+	Apollo.MutationResult<Types.LinkIssueForSessionCommentMutation>
+export type LinkIssueForSessionCommentMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.LinkIssueForSessionCommentMutation,
+		Types.LinkIssueForSessionCommentMutationVariables
 	>
 export const DeleteSessionCommentDocument = gql`
 	mutation DeleteSessionComment($id: ID!) {
@@ -2593,6 +2816,98 @@ export type CreateIssueForErrorCommentMutationOptions =
 	Apollo.BaseMutationOptions<
 		Types.CreateIssueForErrorCommentMutation,
 		Types.CreateIssueForErrorCommentMutationVariables
+	>
+export const LinkIssueForErrorCommentDocument = gql`
+	mutation LinkIssueForErrorComment(
+		$project_id: ID!
+		$error_comment_id: Int!
+		$text_for_attachment: String!
+		$error_url: String!
+		$author_name: String!
+		$integrations: [IntegrationType]!
+		$issue_title: String
+		$issue_id: String!
+		$issue_url: String!
+	) {
+		linkIssueForErrorComment(
+			project_id: $project_id
+			error_url: $error_url
+			error_comment_id: $error_comment_id
+			author_name: $author_name
+			text_for_attachment: $text_for_attachment
+			issue_title: $issue_title
+			integrations: $integrations
+			issue_id: $issue_id
+			issue_url: $issue_url
+		) {
+			id
+			created_at
+			updated_at
+			author {
+				id
+				name
+				email
+			}
+			text
+			attachments {
+				id
+				integration_type
+				external_id
+				title
+			}
+		}
+	}
+`
+export type LinkIssueForErrorCommentMutationFn = Apollo.MutationFunction<
+	Types.LinkIssueForErrorCommentMutation,
+	Types.LinkIssueForErrorCommentMutationVariables
+>
+
+/**
+ * __useLinkIssueForErrorCommentMutation__
+ *
+ * To run a mutation, you first call `useLinkIssueForErrorCommentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useLinkIssueForErrorCommentMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [linkIssueForErrorCommentMutation, { data, loading, error }] = useLinkIssueForErrorCommentMutation({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *      error_comment_id: // value for 'error_comment_id'
+ *      text_for_attachment: // value for 'text_for_attachment'
+ *      error_url: // value for 'error_url'
+ *      author_name: // value for 'author_name'
+ *      integrations: // value for 'integrations'
+ *      issue_title: // value for 'issue_title'
+ *      issue_id: // value for 'issue_id'
+ *      issue_url: // value for 'issue_url'
+ *   },
+ * });
+ */
+export function useLinkIssueForErrorCommentMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.LinkIssueForErrorCommentMutation,
+		Types.LinkIssueForErrorCommentMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.LinkIssueForErrorCommentMutation,
+		Types.LinkIssueForErrorCommentMutationVariables
+	>(LinkIssueForErrorCommentDocument, baseOptions)
+}
+export type LinkIssueForErrorCommentMutationHookResult = ReturnType<
+	typeof useLinkIssueForErrorCommentMutation
+>
+export type LinkIssueForErrorCommentMutationResult =
+	Apollo.MutationResult<Types.LinkIssueForErrorCommentMutation>
+export type LinkIssueForErrorCommentMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.LinkIssueForErrorCommentMutation,
+		Types.LinkIssueForErrorCommentMutationVariables
 	>
 export const DeleteErrorCommentDocument = gql`
 	mutation DeleteErrorComment($id: ID!) {

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -2401,6 +2401,104 @@ export type CreateErrorCommentMutationOptions = Apollo.BaseMutationOptions<
 	Types.CreateErrorCommentMutation,
 	Types.CreateErrorCommentMutationVariables
 >
+export const CreateErrorCommentForExistingIssueDocument = gql`
+	mutation CreateErrorCommentForExistingIssue(
+		$project_id: ID!
+		$error_group_secure_id: String!
+		$text: String!
+		$text_for_email: String!
+		$tagged_admins: [SanitizedAdminInput]!
+		$tagged_slack_users: [SanitizedSlackChannelInput]!
+		$error_url: String!
+		$author_name: String!
+		$integrations: [IntegrationType]!
+		$issue_title: String!
+		$issue_url: String!
+		$issue_id: String!
+	) {
+		createErrorCommentForExistingIssue(
+			project_id: $project_id
+			error_group_secure_id: $error_group_secure_id
+			text: $text
+			text_for_email: $text_for_email
+			tagged_admins: $tagged_admins
+			tagged_slack_users: $tagged_slack_users
+			error_url: $error_url
+			author_name: $author_name
+			integrations: $integrations
+			issue_title: $issue_title
+			issue_url: $issue_url
+			issue_id: $issue_id
+		) {
+			id
+			created_at
+			updated_at
+			author {
+				id
+				name
+				email
+				__typename
+			}
+			text
+			__typename
+		}
+	}
+`
+export type CreateErrorCommentForExistingIssueMutationFn =
+	Apollo.MutationFunction<
+		Types.CreateErrorCommentForExistingIssueMutation,
+		Types.CreateErrorCommentForExistingIssueMutationVariables
+	>
+
+/**
+ * __useCreateErrorCommentForExistingIssueMutation__
+ *
+ * To run a mutation, you first call `useCreateErrorCommentForExistingIssueMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateErrorCommentForExistingIssueMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createErrorCommentForExistingIssueMutation, { data, loading, error }] = useCreateErrorCommentForExistingIssueMutation({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *      error_group_secure_id: // value for 'error_group_secure_id'
+ *      text: // value for 'text'
+ *      text_for_email: // value for 'text_for_email'
+ *      tagged_admins: // value for 'tagged_admins'
+ *      tagged_slack_users: // value for 'tagged_slack_users'
+ *      error_url: // value for 'error_url'
+ *      author_name: // value for 'author_name'
+ *      integrations: // value for 'integrations'
+ *      issue_title: // value for 'issue_title'
+ *      issue_url: // value for 'issue_url'
+ *      issue_id: // value for 'issue_id'
+ *   },
+ * });
+ */
+export function useCreateErrorCommentForExistingIssueMutation(
+	baseOptions?: Apollo.MutationHookOptions<
+		Types.CreateErrorCommentForExistingIssueMutation,
+		Types.CreateErrorCommentForExistingIssueMutationVariables
+	>,
+) {
+	return Apollo.useMutation<
+		Types.CreateErrorCommentForExistingIssueMutation,
+		Types.CreateErrorCommentForExistingIssueMutationVariables
+	>(CreateErrorCommentForExistingIssueDocument, baseOptions)
+}
+export type CreateErrorCommentForExistingIssueMutationHookResult = ReturnType<
+	typeof useCreateErrorCommentForExistingIssueMutation
+>
+export type CreateErrorCommentForExistingIssueMutationResult =
+	Apollo.MutationResult<Types.CreateErrorCommentForExistingIssueMutation>
+export type CreateErrorCommentForExistingIssueMutationOptions =
+	Apollo.BaseMutationOptions<
+		Types.CreateErrorCommentForExistingIssueMutation,
+		Types.CreateErrorCommentForExistingIssueMutationVariables
+	>
 export const CreateIssueForErrorCommentDocument = gql`
 	mutation CreateIssueForErrorComment(
 		$project_id: ID!
@@ -13167,6 +13265,74 @@ export type GetOAuthClientMetadataLazyQueryHookResult = ReturnType<
 export type GetOAuthClientMetadataQueryResult = Apollo.QueryResult<
 	Types.GetOAuthClientMetadataQuery,
 	Types.GetOAuthClientMetadataQueryVariables
+>
+export const SearchIssuesDocument = gql`
+	query SearchIssues(
+		$project_id: ID!
+		$query: String!
+		$integration_type: IntegrationType!
+	) {
+		search_issues(
+			integration_type: $integration_type
+			query: $query
+			project_id: $project_id
+		) {
+			id
+			title
+			issue_url
+		}
+	}
+`
+
+/**
+ * __useSearchIssuesQuery__
+ *
+ * To run a query within a React component, call `useSearchIssuesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSearchIssuesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSearchIssuesQuery({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *      query: // value for 'query'
+ *      integration_type: // value for 'integration_type'
+ *   },
+ * });
+ */
+export function useSearchIssuesQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.SearchIssuesQuery,
+		Types.SearchIssuesQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.SearchIssuesQuery,
+		Types.SearchIssuesQueryVariables
+	>(SearchIssuesDocument, baseOptions)
+}
+export function useSearchIssuesLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.SearchIssuesQuery,
+		Types.SearchIssuesQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.SearchIssuesQuery,
+		Types.SearchIssuesQueryVariables
+	>(SearchIssuesDocument, baseOptions)
+}
+export type SearchIssuesQueryHookResult = ReturnType<
+	typeof useSearchIssuesQuery
+>
+export type SearchIssuesLazyQueryHookResult = ReturnType<
+	typeof useSearchIssuesLazyQuery
+>
+export type SearchIssuesQueryResult = Apollo.QueryResult<
+	Types.SearchIssuesQuery,
+	Types.SearchIssuesQueryVariables
 >
 export const GetErrorGroupFrequenciesDocument = gql`
 	query GetErrorGroupFrequencies(

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -575,6 +575,43 @@ export type CreateErrorCommentMutation = { __typename?: 'Mutation' } & {
 	>
 }
 
+export type CreateErrorCommentForExistingIssueMutationVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+	error_group_secure_id: Types.Scalars['String']
+	text: Types.Scalars['String']
+	text_for_email: Types.Scalars['String']
+	tagged_admins:
+		| Array<Types.Maybe<Types.SanitizedAdminInput>>
+		| Types.Maybe<Types.SanitizedAdminInput>
+	tagged_slack_users:
+		| Array<Types.Maybe<Types.SanitizedSlackChannelInput>>
+		| Types.Maybe<Types.SanitizedSlackChannelInput>
+	error_url: Types.Scalars['String']
+	author_name: Types.Scalars['String']
+	integrations:
+		| Array<Types.Maybe<Types.IntegrationType>>
+		| Types.Maybe<Types.IntegrationType>
+	issue_title: Types.Scalars['String']
+	issue_url: Types.Scalars['String']
+	issue_id: Types.Scalars['String']
+}>
+
+export type CreateErrorCommentForExistingIssueMutation = {
+	__typename?: 'Mutation'
+} & {
+	createErrorCommentForExistingIssue?: Types.Maybe<
+		{ __typename: 'ErrorComment' } & Pick<
+			Types.ErrorComment,
+			'id' | 'created_at' | 'updated_at' | 'text'
+		> & {
+				author: { __typename: 'SanitizedAdmin' } & Pick<
+					Types.SanitizedAdmin,
+					'id' | 'name' | 'email'
+				>
+			}
+	>
+}
+
 export type CreateIssueForErrorCommentMutationVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	error_comment_id: Types.Scalars['Int']
@@ -4415,6 +4452,21 @@ export type GetOAuthClientMetadataQuery = { __typename?: 'Query' } & {
 	>
 }
 
+export type SearchIssuesQueryVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+	query: Types.Scalars['String']
+	integration_type: Types.IntegrationType
+}>
+
+export type SearchIssuesQuery = { __typename?: 'Query' } & {
+	search_issues: Array<
+		{ __typename?: 'IssuesSearchResult' } & Pick<
+			Types.IssuesSearchResult,
+			'id' | 'title' | 'issue_url'
+		>
+	>
+}
+
 export type GetErrorGroupFrequenciesQueryVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	error_group_secure_ids:
@@ -5109,6 +5161,7 @@ export const namedOperations = {
 		GetSourcemapFiles: 'GetSourcemapFiles' as const,
 		GetSourcemapVersions: 'GetSourcemapVersions' as const,
 		GetOAuthClientMetadata: 'GetOAuthClientMetadata' as const,
+		SearchIssues: 'SearchIssues' as const,
 		GetErrorGroupFrequencies: 'GetErrorGroupFrequencies' as const,
 		GetErrorGroupTags: 'GetErrorGroupTags' as const,
 		GetEmailOptOuts: 'GetEmailOptOuts' as const,
@@ -5175,6 +5228,8 @@ export const namedOperations = {
 		DeleteSessionComment: 'DeleteSessionComment' as const,
 		ReplyToSessionComment: 'ReplyToSessionComment' as const,
 		CreateErrorComment: 'CreateErrorComment' as const,
+		CreateErrorCommentForExistingIssue:
+			'CreateErrorCommentForExistingIssue' as const,
 		CreateIssueForErrorComment: 'CreateIssueForErrorComment' as const,
 		DeleteErrorComment: 'DeleteErrorComment' as const,
 		MuteErrorCommentThread: 'MuteErrorCommentThread' as const,

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -455,6 +455,69 @@ export type CreateSessionCommentMutation = { __typename?: 'Mutation' } & {
 	>
 }
 
+export type CreateSessionCommentWithExistingIssueMutationVariables =
+	Types.Exact<{
+		project_id: Types.Scalars['ID']
+		session_secure_id: Types.Scalars['String']
+		session_timestamp: Types.Scalars['Int']
+		text: Types.Scalars['String']
+		text_for_email: Types.Scalars['String']
+		x_coordinate: Types.Scalars['Float']
+		y_coordinate: Types.Scalars['Float']
+		tagged_admins:
+			| Array<Types.Maybe<Types.SanitizedAdminInput>>
+			| Types.Maybe<Types.SanitizedAdminInput>
+		tagged_slack_users:
+			| Array<Types.Maybe<Types.SanitizedSlackChannelInput>>
+			| Types.Maybe<Types.SanitizedSlackChannelInput>
+		session_url: Types.Scalars['String']
+		time: Types.Scalars['Float']
+		author_name: Types.Scalars['String']
+		session_image?: Types.Maybe<Types.Scalars['String']>
+		tags:
+			| Array<Types.Maybe<Types.SessionCommentTagInput>>
+			| Types.Maybe<Types.SessionCommentTagInput>
+		integrations:
+			| Array<Types.Maybe<Types.IntegrationType>>
+			| Types.Maybe<Types.IntegrationType>
+		issue_title?: Types.Maybe<Types.Scalars['String']>
+		issue_url: Types.Scalars['String']
+		issue_id: Types.Scalars['String']
+		additional_context?: Types.Maybe<Types.Scalars['String']>
+	}>
+
+export type CreateSessionCommentWithExistingIssueMutation = {
+	__typename?: 'Mutation'
+} & {
+	createSessionCommentWithExistingIssue?: Types.Maybe<
+		{ __typename?: 'SessionComment' } & Pick<
+			Types.SessionComment,
+			| 'id'
+			| 'timestamp'
+			| 'created_at'
+			| 'updated_at'
+			| 'text'
+			| 'x_coordinate'
+			| 'y_coordinate'
+		> & {
+				author?: Types.Maybe<
+					{ __typename?: 'SanitizedAdmin' } & Pick<
+						Types.SanitizedAdmin,
+						'id' | 'name' | 'email'
+					>
+				>
+				attachments: Array<
+					Types.Maybe<
+						{ __typename?: 'ExternalAttachment' } & Pick<
+							Types.ExternalAttachment,
+							'id' | 'integration_type' | 'external_id' | 'title'
+						>
+					>
+				>
+			}
+	>
+}
+
 export type CreateIssueForSessionCommentMutationVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	session_comment_id: Types.Scalars['Int']
@@ -475,6 +538,51 @@ export type CreateIssueForSessionCommentMutation = {
 	__typename?: 'Mutation'
 } & {
 	createIssueForSessionComment?: Types.Maybe<
+		{ __typename?: 'SessionComment' } & Pick<
+			Types.SessionComment,
+			| 'id'
+			| 'timestamp'
+			| 'created_at'
+			| 'updated_at'
+			| 'text'
+			| 'x_coordinate'
+			| 'y_coordinate'
+		> & {
+				author?: Types.Maybe<
+					{ __typename?: 'SanitizedAdmin' } & Pick<
+						Types.SanitizedAdmin,
+						'id' | 'name' | 'email'
+					>
+				>
+				attachments: Array<
+					Types.Maybe<
+						{ __typename?: 'ExternalAttachment' } & Pick<
+							Types.ExternalAttachment,
+							'id' | 'integration_type' | 'external_id' | 'title'
+						>
+					>
+				>
+			}
+	>
+}
+
+export type LinkIssueForSessionCommentMutationVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+	session_comment_id: Types.Scalars['Int']
+	text_for_attachment: Types.Scalars['String']
+	session_url: Types.Scalars['String']
+	time: Types.Scalars['Float']
+	author_name: Types.Scalars['String']
+	integrations:
+		| Array<Types.Maybe<Types.IntegrationType>>
+		| Types.Maybe<Types.IntegrationType>
+	issue_title?: Types.Maybe<Types.Scalars['String']>
+	issue_id: Types.Scalars['String']
+	issue_url: Types.Scalars['String']
+}>
+
+export type LinkIssueForSessionCommentMutation = { __typename?: 'Mutation' } & {
+	linkIssueForSessionComment?: Types.Maybe<
 		{ __typename?: 'SessionComment' } & Pick<
 			Types.SessionComment,
 			| 'id'
@@ -629,6 +737,42 @@ export type CreateIssueForErrorCommentMutationVariables = Types.Exact<{
 
 export type CreateIssueForErrorCommentMutation = { __typename?: 'Mutation' } & {
 	createIssueForErrorComment?: Types.Maybe<
+		{ __typename?: 'ErrorComment' } & Pick<
+			Types.ErrorComment,
+			'id' | 'created_at' | 'updated_at' | 'text'
+		> & {
+				author: { __typename?: 'SanitizedAdmin' } & Pick<
+					Types.SanitizedAdmin,
+					'id' | 'name' | 'email'
+				>
+				attachments: Array<
+					Types.Maybe<
+						{ __typename?: 'ExternalAttachment' } & Pick<
+							Types.ExternalAttachment,
+							'id' | 'integration_type' | 'external_id' | 'title'
+						>
+					>
+				>
+			}
+	>
+}
+
+export type LinkIssueForErrorCommentMutationVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+	error_comment_id: Types.Scalars['Int']
+	text_for_attachment: Types.Scalars['String']
+	error_url: Types.Scalars['String']
+	author_name: Types.Scalars['String']
+	integrations:
+		| Array<Types.Maybe<Types.IntegrationType>>
+		| Types.Maybe<Types.IntegrationType>
+	issue_title?: Types.Maybe<Types.Scalars['String']>
+	issue_id: Types.Scalars['String']
+	issue_url: Types.Scalars['String']
+}>
+
+export type LinkIssueForErrorCommentMutation = { __typename?: 'Mutation' } & {
+	linkIssueForErrorComment?: Types.Maybe<
 		{ __typename?: 'ErrorComment' } & Pick<
 			Types.ErrorComment,
 			'id' | 'created_at' | 'updated_at' | 'text'
@@ -5224,13 +5368,17 @@ export const namedOperations = {
 		EditSegment: 'EditSegment' as const,
 		CreateSegment: 'CreateSegment' as const,
 		CreateSessionComment: 'CreateSessionComment' as const,
+		CreateSessionCommentWithExistingIssue:
+			'CreateSessionCommentWithExistingIssue' as const,
 		CreateIssueForSessionComment: 'CreateIssueForSessionComment' as const,
+		LinkIssueForSessionComment: 'LinkIssueForSessionComment' as const,
 		DeleteSessionComment: 'DeleteSessionComment' as const,
 		ReplyToSessionComment: 'ReplyToSessionComment' as const,
 		CreateErrorComment: 'CreateErrorComment' as const,
 		CreateErrorCommentForExistingIssue:
 			'CreateErrorCommentForExistingIssue' as const,
 		CreateIssueForErrorComment: 'CreateIssueForErrorComment' as const,
+		LinkIssueForErrorComment: 'LinkIssueForErrorComment' as const,
 		DeleteErrorComment: 'DeleteErrorComment' as const,
 		MuteErrorCommentThread: 'MuteErrorCommentThread' as const,
 		RemoveErrorIssue: 'RemoveErrorIssue' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1081,6 +1081,7 @@ export type Mutation = {
 	createSegment?: Maybe<Segment>
 	createSessionAlert?: Maybe<SessionAlert>
 	createSessionComment?: Maybe<SessionComment>
+	createSessionCommentWithExistingIssue?: Maybe<SessionComment>
 	createWorkspace?: Maybe<Workspace>
 	deleteAdminFromProject?: Maybe<Scalars['ID']>
 	deleteAdminFromWorkspace?: Maybe<Scalars['ID']>
@@ -1109,6 +1110,8 @@ export type Mutation = {
 	exportSession: Scalars['Boolean']
 	handleAWSMarketplace?: Maybe<Scalars['Boolean']>
 	joinWorkspace?: Maybe<Scalars['ID']>
+	linkIssueForErrorComment?: Maybe<ErrorComment>
+	linkIssueForSessionComment?: Maybe<SessionComment>
 	markErrorGroupAsViewed?: Maybe<ErrorGroup>
 	markSessionAsViewed?: Maybe<Session>
 	modifyClearbitIntegration?: Maybe<Scalars['Boolean']>
@@ -1327,6 +1330,28 @@ export type MutationCreateSessionCommentArgs = {
 	y_coordinate: Scalars['Float']
 }
 
+export type MutationCreateSessionCommentWithExistingIssueArgs = {
+	additional_context?: InputMaybe<Scalars['String']>
+	author_name: Scalars['String']
+	integrations: Array<InputMaybe<IntegrationType>>
+	issue_id: Scalars['String']
+	issue_title?: InputMaybe<Scalars['String']>
+	issue_url: Scalars['String']
+	project_id: Scalars['ID']
+	session_image?: InputMaybe<Scalars['String']>
+	session_secure_id: Scalars['String']
+	session_timestamp: Scalars['Int']
+	session_url: Scalars['String']
+	tagged_admins: Array<InputMaybe<SanitizedAdminInput>>
+	tagged_slack_users: Array<InputMaybe<SanitizedSlackChannelInput>>
+	tags: Array<InputMaybe<SessionCommentTagInput>>
+	text: Scalars['String']
+	text_for_email: Scalars['String']
+	time: Scalars['Float']
+	x_coordinate: Scalars['Float']
+	y_coordinate: Scalars['Float']
+}
+
 export type MutationCreateWorkspaceArgs = {
 	name: Scalars['String']
 	promo_code?: InputMaybe<Scalars['String']>
@@ -1486,6 +1511,32 @@ export type MutationHandleAwsMarketplaceArgs = {
 
 export type MutationJoinWorkspaceArgs = {
 	workspace_id: Scalars['ID']
+}
+
+export type MutationLinkIssueForErrorCommentArgs = {
+	author_name: Scalars['String']
+	error_comment_id: Scalars['Int']
+	error_url: Scalars['String']
+	integrations: Array<InputMaybe<IntegrationType>>
+	issue_description?: InputMaybe<Scalars['String']>
+	issue_id: Scalars['String']
+	issue_title?: InputMaybe<Scalars['String']>
+	issue_url: Scalars['String']
+	project_id: Scalars['ID']
+	text_for_attachment: Scalars['String']
+}
+
+export type MutationLinkIssueForSessionCommentArgs = {
+	author_name: Scalars['String']
+	integrations: Array<InputMaybe<IntegrationType>>
+	issue_id: Scalars['String']
+	issue_title?: InputMaybe<Scalars['String']>
+	issue_url: Scalars['String']
+	project_id: Scalars['ID']
+	session_comment_id: Scalars['Int']
+	session_url: Scalars['String']
+	text_for_attachment: Scalars['String']
+	time: Scalars['Float']
 }
 
 export type MutationMarkErrorGroupAsViewedArgs = {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -760,6 +760,13 @@ export type Invoice = {
 	url?: Maybe<Scalars['String']>
 }
 
+export type IssuesSearchResult = {
+	__typename?: 'IssuesSearchResult'
+	id: Scalars['String']
+	issue_url: Scalars['String']
+	title: Scalars['String']
+}
+
 export type JiraIssueType = {
 	__typename?: 'JiraIssueType'
 	description: Scalars['String']
@@ -1061,6 +1068,7 @@ export type Mutation = {
 	createAdmin: Admin
 	createErrorAlert?: Maybe<ErrorAlert>
 	createErrorComment?: Maybe<ErrorComment>
+	createErrorCommentForExistingIssue?: Maybe<ErrorComment>
 	createErrorSegment?: Maybe<ErrorSegment>
 	createErrorTag: ErrorTag
 	createIssueForErrorComment?: Maybe<ErrorComment>
@@ -1191,6 +1199,21 @@ export type MutationCreateErrorCommentArgs = {
 	issue_team_id?: InputMaybe<Scalars['String']>
 	issue_title?: InputMaybe<Scalars['String']>
 	issue_type_id?: InputMaybe<Scalars['String']>
+	project_id: Scalars['ID']
+	tagged_admins: Array<InputMaybe<SanitizedAdminInput>>
+	tagged_slack_users: Array<InputMaybe<SanitizedSlackChannelInput>>
+	text: Scalars['String']
+	text_for_email: Scalars['String']
+}
+
+export type MutationCreateErrorCommentForExistingIssueArgs = {
+	author_name: Scalars['String']
+	error_group_secure_id: Scalars['String']
+	error_url: Scalars['String']
+	integrations: Array<InputMaybe<IntegrationType>>
+	issue_id: Scalars['String']
+	issue_title: Scalars['String']
+	issue_url: Scalars['String']
 	project_id: Scalars['ID']
 	tagged_admins: Array<InputMaybe<SanitizedAdminInput>>
 	tagged_slack_users: Array<InputMaybe<SanitizedSlackChannelInput>>
@@ -1927,6 +1950,7 @@ export type Query = {
 	referrers: Array<Maybe<ReferrerTablePayload>>
 	resources?: Maybe<Array<Maybe<Scalars['Any']>>>
 	saved_segments?: Maybe<Array<Maybe<SavedSegment>>>
+	search_issues: Array<IssuesSearchResult>
 	segments?: Maybe<Array<Maybe<Segment>>>
 	serverIntegration: IntegrationStatus
 	serviceByName?: Maybe<Service>
@@ -2476,6 +2500,12 @@ export type QueryResourcesArgs = {
 export type QuerySaved_SegmentsArgs = {
 	entity_type: SavedSegmentEntityType
 	project_id: Scalars['ID']
+}
+
+export type QuerySearch_IssuesArgs = {
+	integration_type: IntegrationType
+	project_id: Scalars['ID']
+	query: Scalars['String']
 }
 
 export type QuerySegmentsArgs = {

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -525,6 +525,49 @@ mutation CreateErrorComment(
 		text
 	}
 }
+
+mutation CreateErrorCommentForExistingIssue(
+	$project_id: ID!
+	$error_group_secure_id: String!
+	$text: String!
+	$text_for_email: String!
+	$tagged_admins: [SanitizedAdminInput]!
+	$tagged_slack_users: [SanitizedSlackChannelInput]!
+	$error_url: String!
+	$author_name: String!
+	$integrations: [IntegrationType]!
+	$issue_title: String!
+	$issue_url: String!
+	$issue_id: String!
+) {
+	createErrorCommentForExistingIssue(
+		project_id: $project_id
+		error_group_secure_id: $error_group_secure_id
+		text: $text
+		text_for_email: $text_for_email
+		tagged_admins: $tagged_admins
+		tagged_slack_users: $tagged_slack_users
+		error_url: $error_url
+		author_name: $author_name
+		integrations: $integrations
+		issue_title: $issue_title
+		issue_url: $issue_url
+		issue_id: $issue_id
+	) {
+		id
+		created_at
+		updated_at
+		author {
+			id
+			name
+			email
+			__typename
+		}
+		text
+		__typename
+	}
+}
+
 mutation CreateIssueForErrorComment(
 	$project_id: ID!
 	$error_comment_id: Int!

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -404,6 +404,69 @@ mutation CreateSessionComment(
 	}
 }
 
+mutation CreateSessionCommentWithExistingIssue(
+	$project_id: ID!
+	$session_secure_id: String!
+	$session_timestamp: Int!
+	$text: String!
+	$text_for_email: String!
+	$x_coordinate: Float!
+	$y_coordinate: Float!
+	$tagged_admins: [SanitizedAdminInput]!
+	$tagged_slack_users: [SanitizedSlackChannelInput]!
+	$session_url: String!
+	$time: Float!
+	$author_name: String!
+	$session_image: String
+	$tags: [SessionCommentTagInput]!
+	$integrations: [IntegrationType]!
+	$issue_title: String
+	$issue_url: String!
+	$issue_id: String!
+	$additional_context: String
+) {
+	createSessionCommentWithExistingIssue(
+		project_id: $project_id
+		session_secure_id: $session_secure_id
+		session_timestamp: $session_timestamp
+		text: $text
+		text_for_email: $text_for_email
+		x_coordinate: $x_coordinate
+		y_coordinate: $y_coordinate
+		tagged_admins: $tagged_admins
+		tagged_slack_users: $tagged_slack_users
+		session_url: $session_url
+		time: $time
+		author_name: $author_name
+		session_image: $session_image
+		tags: $tags
+		integrations: $integrations
+		issue_title: $issue_title
+		issue_url: $issue_url
+		issue_id: $issue_id
+		additional_context: $additional_context
+	) {
+		id
+		timestamp
+		created_at
+		updated_at
+		author {
+			id
+			name
+			email
+		}
+		text
+		x_coordinate
+		y_coordinate
+		attachments {
+			id
+			integration_type
+			external_id
+			title
+		}
+	}
+}
+
 mutation CreateIssueForSessionComment(
 	$project_id: ID!
 	$session_comment_id: Int!
@@ -429,6 +492,51 @@ mutation CreateIssueForSessionComment(
 		issue_team_id: $issue_team_id
 		integrations: $integrations
 		issue_type_id: $issue_type_id
+	) {
+		id
+		timestamp
+		created_at
+		updated_at
+		author {
+			id
+			name
+			email
+		}
+		text
+		x_coordinate
+		y_coordinate
+		attachments {
+			id
+			integration_type
+			external_id
+			title
+		}
+	}
+}
+
+mutation LinkIssueForSessionComment(
+	$project_id: ID!
+	$session_comment_id: Int!
+	$text_for_attachment: String!
+	$session_url: String!
+	$time: Float!
+	$author_name: String!
+	$integrations: [IntegrationType]!
+	$issue_title: String
+	$issue_id: String!
+	$issue_url: String!
+) {
+	linkIssueForSessionComment(
+		project_id: $project_id
+		session_url: $session_url
+		session_comment_id: $session_comment_id
+		author_name: $author_name
+		text_for_attachment: $text_for_attachment
+		time: $time
+		issue_title: $issue_title
+		issue_id: $issue_id
+		integrations: $integrations
+		issue_url: $issue_url
 	) {
 		id
 		timestamp
@@ -591,6 +699,46 @@ mutation CreateIssueForErrorComment(
 		issue_description: $issue_description
 		integrations: $integrations
 		issue_type_id: $issue_type_id
+	) {
+		id
+		created_at
+		updated_at
+		author {
+			id
+			name
+			email
+		}
+		text
+		attachments {
+			id
+			integration_type
+			external_id
+			title
+		}
+	}
+}
+
+mutation LinkIssueForErrorComment(
+	$project_id: ID!
+	$error_comment_id: Int!
+	$text_for_attachment: String!
+	$error_url: String!
+	$author_name: String!
+	$integrations: [IntegrationType]!
+	$issue_title: String
+	$issue_id: String!
+	$issue_url: String!
+) {
+	linkIssueForErrorComment(
+		project_id: $project_id
+		error_url: $error_url
+		error_comment_id: $error_comment_id
+		author_name: $author_name
+		text_for_attachment: $text_for_attachment
+		issue_title: $issue_title
+		integrations: $integrations
+		issue_id: $issue_id
+		issue_url: $issue_url
 	) {
 		id
 		created_at

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2043,6 +2043,22 @@ query GetOAuthClientMetadata($client_id: String!) {
 	}
 }
 
+query SearchIssues(
+	$project_id: ID!
+	$query: String!
+	$integration_type: IntegrationType!
+) {
+	search_issues(
+		integration_type: $integration_type
+		query: $query
+		project_id: $project_id
+	) {
+		id
+		title
+		issue_url
+	}
+}
+
 query GetErrorGroupFrequencies(
 	$project_id: ID!
 	$error_group_secure_ids: [String!]!

--- a/frontend/src/pages/IntegrationsPage/Integrations.tsx
+++ b/frontend/src/pages/IntegrationsPage/Integrations.tsx
@@ -46,6 +46,12 @@ import ZapierLogo from '@/static/integrations/zapier.png'
 import GitHubIntegrationConfig from './components/GitHubIntegration/GitHubIntegrationConfig'
 import GitHubRepoSelector from './components/GitHubIntegration/GitHubRepoSelector'
 
+export type NewIntegrationIssueMode = 'create_issue' | 'link_issue'
+export enum NewIntegrationIssueType {
+	CreateIssue = 'create_issue',
+	LinkIssue = 'link_issue',
+}
+
 export interface Integration {
 	key: string
 	name: string

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
@@ -605,25 +605,30 @@ export const NewCommentForm = ({
 							</Stack>
 						</Box>
 						<Stack direction="column" gap="12" p="12">
-							<Box
-								px="12"
-								py="8"
-								gap="12"
-								display="flex"
-								align="center"
-							>
-								<RadioGroup
-									labels={['Create Issue', 'Link Issue']}
-									selectedLabel={mode}
-									onSelect={(label: any) => setMode(label)}
-									style={{
-										width: '100%',
-										display: 'flex',
-										justifyContent: 'center',
-										alignItems: 'center',
-									}}
-								/>
-							</Box>
+							{/* ClickUp doesn't support linking issues, so we don't need to show this section. */}
+							{integrationName !== 'ClickUp' && (
+								<Box
+									px="12"
+									py="8"
+									gap="12"
+									display="flex"
+									align="center"
+								>
+									<RadioGroup
+										labels={['Create Issue', 'Link Issue']}
+										selectedLabel={mode}
+										onSelect={(label: any) =>
+											setMode(label)
+										}
+										style={{
+											width: '100%',
+											display: 'flex',
+											justifyContent: 'center',
+											alignItems: 'center',
+										}}
+									/>
+								</Box>
+							)}
 							{mode === 'Create Issue' &&
 								issueServiceDetail?.containerSelection({
 									disabled: isCreatingComment,

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
@@ -61,6 +61,10 @@ import { CommentMentionButton } from '@/components/Comment/CommentMentionButton'
 import { SearchIssues } from '@/components/SearchIssues/SearchIssues'
 import { useGitlabIntegration } from '@/pages/IntegrationsPage/components/GitlabIntegration/utils'
 import { useJiraIntegration } from '@/pages/IntegrationsPage/components/JiraIntegration/utils'
+import {
+	NewIntegrationIssueMode,
+	NewIntegrationIssueType,
+} from '@/pages/IntegrationsPage/Integrations'
 
 import { Coordinates2D } from '../../PlayerCommentCanvas/PlayerCommentCanvas'
 import usePlayerConfiguration from '../../PlayerHook/utils/usePlayerConfiguration'
@@ -141,7 +145,9 @@ export const NewCommentForm = ({
 	const formValues = formStore.useState('values')
 
 	// issue linking support
-	const [mode, setMode] = React.useState('Create Issue')
+	const [mode, setMode] = React.useState<NewIntegrationIssueMode>(
+		NewIntegrationIssueType.CreateIssue,
+	)
 	const [linkedIssue, setLinkedIssue] = useState({
 		id: '',
 		url: '',
@@ -204,7 +210,7 @@ export const NewCommentForm = ({
 		const { issueTitle, issueDescription } = formValues
 
 		try {
-			if (mode === 'Create Issue') {
+			if (mode === NewIntegrationIssueType.CreateIssue) {
 				await createErrorComment({
 					variables: {
 						project_id: project_id!,
@@ -272,7 +278,7 @@ export const NewCommentForm = ({
 		const { issueTitle, issueDescription } = formValues
 
 		try {
-			if (mode === 'Create Issue') {
+			if (mode === NewIntegrationIssueType.CreateIssue) {
 				await createComment({
 					variables: {
 						project_id: project_id!,
@@ -587,26 +593,25 @@ export const NewCommentForm = ({
 								>
 									<RadioGroup
 										labels={['Create Issue', 'Link Issue']}
-										selectedLabel={mode}
-										onSelect={(label: any) =>
-											setMode(label)
+										selectedLabel={
+											mode ===
+											NewIntegrationIssueType.CreateIssue
+												? 'Create Issue'
+												: 'Link Issue'
 										}
-										style={{
-											width: '100%',
-											display: 'flex',
-											justifyContent: 'center',
-											alignItems: 'center',
-										}}
+										onSelect={(label: string) =>
+											setMode(
+												label === 'Create Issue'
+													? NewIntegrationIssueType.CreateIssue
+													: NewIntegrationIssueType.LinkIssue,
+											)
+										}
+										labelStyle={{ width: '100%' }}
+										wrapperStyle={{ width: '100%' }}
 									/>
 								</Box>
 							)}
-							{mode === 'Create Issue' &&
-								issueServiceDetail?.containerSelection({
-									disabled: isCreatingComment,
-									setSelectionId: setContainerId,
-									setIssueTypeId,
-								})}
-							{mode === 'Link Issue' && (
+							{mode === NewIntegrationIssueType.LinkIssue && (
 								<SearchIssues
 									onSelect={(value: any) => {
 										if (value) {
@@ -617,22 +622,29 @@ export const NewCommentForm = ({
 									project_id={project_id!}
 								/>
 							)}
-							{mode === 'Create Issue' && (
-								<Form.Input
-									name="issueTitle"
-									label="Title"
-									placeholder="Title"
-									disabled={isCreatingComment}
-								/>
-							)}
-							{mode === 'Create Issue' && (
-								<Form.Input
-									name="issueDescription"
-									label="Description"
-									// @ts-expect-error
-									as="textarea"
-									disabled={isCreatingComment}
-								/>
+							{mode === NewIntegrationIssueType.CreateIssue && (
+								<>
+									{issueServiceDetail?.containerSelection({
+										disabled: isCreatingComment,
+										setSelectionId: setContainerId,
+										setIssueTypeId,
+									})}
+
+									<Form.Input
+										name="issueTitle"
+										label="Title"
+										placeholder="Title"
+										disabled={isCreatingComment}
+									/>
+
+									<Form.Input
+										name="issueDescription"
+										label="Description"
+										// @ts-expect-error
+										as="textarea"
+										disabled={isCreatingComment}
+									/>
+								</>
 							)}
 						</Stack>
 						<Stack

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
@@ -605,7 +605,7 @@ export const NewCommentForm = ({
 							</Stack>
 						</Box>
 						<Stack direction="column" gap="12" p="12">
-							{/* ClickUp doesn't support linking issues, so we don't need to show this section. */}
+							{/* ClickUp doesn't support searching issues, so we don't need to show this section. */}
 							{integrationName !== 'ClickUp' && (
 								<Box
 									px="12"


### PR DESCRIPTION
Fixes  #4460
/claim #4460

## Summary
Introduce 'Link Issue' mode when creating issue for an error or session comment. 
All issue integrations are supported except **ClickUp**. According to [this](https://clickup.canny.io/public-api/p/using-api-get-tasks-to-search-by-title) and api documentation, they do not support searching issues via their rest api.

### UI
**On UI** this just means another radio button to determine whether the user prefers to create a new issue
or link an existing one. A search-select is provided for the user to search and choose an existing issue from their
selected issue integration.
![Screenshot 2024-02-27 at 9 42 28 AM](https://github.com/highlight/highlight/assets/119384208/293c3026-5907-47e8-9432-25547ca81a2d)
![Screenshot 2024-02-27 at 9 42 48 AM](https://github.com/highlight/highlight/assets/119384208/0bdb3c04-7d05-406c-a67f-7a09249a789c)

### DEMO
https://github.com/highlight/highlight/assets/119384208/b0116ef5-6b9d-4d97-aff0-5839986bcde5

### Backend
We needed a way to create attachment for existing issue and to search issues based on integration and a
search term/query. A sample mutation is below
```graphql
createErrorCommentForExistingIssue(
	project_id: ID!
	error_group_secure_id: String!
	text: String!
	text_for_email: String!
	tagged_admins: [SanitizedAdminInput]!
	tagged_slack_users: [SanitizedSlackChannelInput]!
	error_url: String!
	author_name: String!
	issue_url: String!
	issue_title: String!
	issue_id: String!
	integrations: [IntegrationType]!
): ErrorComment
```

Our search query also looks like this
```graphql
search_issues(
	integration_type: IntegrationType!
	project_id: ID!
	query: String!
): [IssuesSearchResult!]!
```

Introduce a toggle to allow searching and selecting of existing issues to be "attached" to
error or session comments.
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## WIP

- [X] Support remaining issue integrations - Github, Height,
- [x] Discuss clickup exception - there is currently no available rest api to search clickup tasks
- [x] Support session comment issue linking
- [X] Improve Jira search results
- [X] Fix select search UI glitch
- [X] Complete self-review and e2e click-testing

## How did you test this change?

- Go to an error and start creating an issue for the error for any of the issue integrations
- Verify that you can now see to Radio options to 'Create Issue' or 'Link Issue'
- Verify that when the 'Link Issue' button is clicked the form changes to enable you to search for and select an existing issue to be linked with the error or session comment

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
No. Our current issue integrations have the relevant permissions.

It might be time to consider "documenting" the required permissions for every
integration however.
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
Yes. @julian-highlight checkout the screenshots above and comment.
The goal is to support

- selecting whether the user wants to link an existing issue or create a new one
- searching for and linking an existing issue.

<!--
 Request review from julian-highlight / our design team 
-->
