### PR TITLE
move flushLogs logic to otel.go

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -7,10 +7,12 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	model2 "github.com/highlight-run/highlight/backend/model"
+	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 
 	"github.com/samber/lo"
 
@@ -468,22 +470,128 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func (o *Handler) getQuotaExceededByProject(ctx context.Context, projectIds map[uint32]struct{}, productType model2.PricingProductType) (map[uint32]bool, error) {
+	// If it's saved in Redis that a project has exceeded / not exceeded
+	// its quota, use that value. Else, add the projectId to a list of
+	// projects to query.
+	quotaExceededByProject := map[uint32]bool{}
+	projectsToQuery := []uint32{}
+	for projectId := range projectIds {
+		exceeded, err := o.resolver.Redis.IsBillingQuotaExceeded(ctx, int(projectId), productType)
+		if err != nil {
+			log.WithContext(ctx).Error(err)
+			continue
+		}
+		if exceeded != nil {
+			quotaExceededByProject[projectId] = *exceeded
+		} else {
+			projectsToQuery = append(projectsToQuery, projectId)
+		}
+	}
+
+	// For any projects to query, get the associated workspace,
+	// check if that workspace is within the quota,
+	// and write the result to redis.
+	for _, projectId := range projectsToQuery {
+		project, err := o.resolver.Store.GetProject(ctx, int(projectId))
+		if err != nil {
+			log.WithContext(ctx).Error(e.Wrap(err, "error querying project"))
+			continue
+		}
+
+		var workspace model2.Workspace
+		if err := o.resolver.DB.WithContext(ctx).Model(&workspace).
+			Where("id = ?", project.WorkspaceID).Find(&workspace).Error; err != nil {
+			log.WithContext(ctx).Error(e.Wrap(err, "error querying workspace"))
+			continue
+		}
+
+		projects := []model2.Project{}
+		if err := o.resolver.DB.WithContext(ctx).Order("name ASC").Model(&workspace).Association("Projects").Find(&projects); err != nil {
+			log.WithContext(ctx).Error(e.Wrap(err, "error querying associated projects"))
+			continue
+		}
+		workspace.Projects = projects
+
+		withinBillingQuota, _ := o.resolver.IsWithinQuota(ctx, productType, &workspace, time.Now())
+		quotaExceededByProject[projectId] = !withinBillingQuota
+		if err := o.resolver.Redis.SetBillingQuotaExceeded(ctx, int(projectId), productType, !withinBillingQuota); err != nil {
+			log.WithContext(ctx).Error(err)
+			return nil, err
+		}
+	}
+
+	return quotaExceededByProject, nil
+}
+
 func (o *Handler) submitProjectLogs(ctx context.Context, projectLogs map[string][]*clickhouse.LogRow) error {
+	projectIds := map[uint32]struct{}{}
+	for projectId := range projectLogs {
+		id, err := strconv.Atoi(projectId)
+		if err != nil || id < 0 {
+			continue
+		}
+		projectIds[uint32(id)] = struct{}{}
+	}
+
+	quotaExceededByProject, err := o.getQuotaExceededByProject(ctx, projectIds, model2.PricingProductTypeLogs)
+	if err != nil {
+		log.WithContext(ctx).Error(err)
+		quotaExceededByProject = map[uint32]bool{}
+	}
+
+	var markBackendSetupProjectIds []uint32
+	var filteredRows []*clickhouse.LogRow
 	for _, logRows := range projectLogs {
-		var messages []kafkaqueue.RetryableMessage
 		for _, logRow := range logRows {
-			if !o.resolver.IsLogIngested(ctx, logRow) {
+			// create service record for any services found in ingested logs
+			if logRow.ServiceName != "" {
+				project, err := o.resolver.Store.GetProject(ctx, int(logRow.ProjectId))
+				if err == nil && project != nil {
+					_, err := o.resolver.Store.UpsertService(ctx, *project, logRow.ServiceName, logRow.LogAttributes)
+					if err != nil {
+						log.WithContext(ctx).Error(e.Wrap(err, "failed to create service"))
+					}
+				}
+			}
+
+			if logRow.Source == privateModel.LogSourceBackend {
+				markBackendSetupProjectIds = append(markBackendSetupProjectIds, logRow.ProjectId)
+			}
+
+			// Filter out any log rows for projects where the log quota has been exceeded
+			if quotaExceededByProject[logRow.ProjectId] {
 				continue
 			}
-			messages = append(messages, &kafkaqueue.LogRowMessage{
-				Type:   kafkaqueue.PushLogsFlattened,
-				LogRow: logRow,
-			})
+
+			// Temporarily filter NextJS logs
+			// TODO - remove this condition when https://github.com/highlight/highlight/issues/6181 is fixed
+			if !strings.HasPrefix(logRow.Body, "ENOENT: no such file or directory") && !strings.HasPrefix(logRow.Body, "connect ECONNREFUSED") {
+				filteredRows = append(filteredRows, logRow)
+			}
 		}
-		err := o.resolver.BatchedQueue.Submit(ctx, "", messages...)
+	}
+
+	for _, projectId := range markBackendSetupProjectIds {
+		err := o.resolver.MarkBackendSetupImpl(ctx, int(projectId), model2.MarkBackendSetupTypeLogs)
 		if err != nil {
-			return e.Wrap(err, "failed to submit otel project logs to public worker queue")
+			log.WithContext(ctx).WithError(err).Error("failed to mark backend logs setup")
 		}
+	}
+
+	var messages []kafkaqueue.RetryableMessage
+	for _, logRow := range filteredRows {
+		if !o.resolver.IsLogIngested(ctx, logRow) {
+			continue
+		}
+		messages = append(messages, &kafkaqueue.LogRowMessage{
+			Type:   kafkaqueue.PushLogsFlattened,
+			LogRow: logRow,
+		})
+	}
+	err = o.resolver.BatchedQueue.Submit(ctx, "", messages...)
+	if err != nil {
+		return e.Wrap(err, "failed to submit otel project logs to public worker queue")
 	}
 	return nil
 }

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -279,23 +279,10 @@ func (k *KafkaBatchWorker) getQuotaExceededByProject(ctx context.Context, projec
 }
 
 func (k *KafkaBatchWorker) flushLogs(ctx context.Context, logRows []*clickhouse.LogRow) error {
-	timestampByProject := map[uint32]time.Time{}
 	projectIds := map[uint32]struct{}{}
 	for _, row := range logRows {
-		if row.Timestamp.After(timestampByProject[row.ProjectId]) {
-			timestampByProject[row.ProjectId] = row.Timestamp
-			projectIds[row.ProjectId] = struct{}{}
-		}
+		projectIds[row.ProjectId] = struct{}{}
 	}
-
-	spanTs, ctxTs := util.StartSpanFromContext(ctx, util.KafkaBatchWorkerOp, util.ResourceName(fmt.Sprintf("worker.kafka.%s.flush.setTimestamps", k.Name)))
-	for projectId, timestamp := range timestampByProject {
-		err := k.Worker.Resolver.Redis.SetLastLogTimestamp(ctxTs, int(projectId), timestamp)
-		if err != nil {
-			log.WithContext(ctxTs).WithError(err).Errorf("failed to set last log timestamp for project %d", projectId)
-		}
-	}
-	spanTs.Finish()
 
 	quotaExceededByProject, err := k.getQuotaExceededByProject(ctx, projectIds, model.PricingProductTypeLogs)
 	if err != nil {


### PR DESCRIPTION
## Summary
- as part of using Kafka connect to send logs to Clickhouse, move logic for service upsert and quota exceeding to the otel collector
- log but don't throw on any errors to prevent data loss
- also removes the `LastLogTimestamp` functions as we don't use this anymore
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested locally to ensure logs were flowing through normally and monitored for any errors
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, can revert if issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
