### PR TITLE
increase max network payload that can be previewed

### DIFF
--- a/frontend/src/util/preload.ts
+++ b/frontend/src/util/preload.ts
@@ -42,7 +42,7 @@ const CONCURRENT_ERROR_PRELOADS = 10
 const PREVIOUS_ERROR_OBJECTS_TO_FETCH = 3
 // Max brotlied resource file allowed. Note that a brotli file with some binary data
 // has a compression ratio of >5x, so unbrotlied this file will take up much more memory.
-const RESOURCE_FILE_SIZE_LIMIT_BYTES = 16 * 1024 * 1024
+const RESOURCE_FILE_SIZE_LIMIT_BYTES = 64 * 1024 * 1024
 
 export const usePreloadSessions = function ({
 	query,


### PR DESCRIPTION
## Summary

frontend network resource loading seems stable even with larger payloads.
since we don't preload session data and don't use indexeddb, increase this limit.

## How did you test this change?

testing on a large customer [session](https://app.highlight.io/5403/sessions/614lzC3JdfJTJ3lu0GJs5rMvSKvI?page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue&%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HPFD0RQAG1P3BC7W9PEA78SN%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Fnetwork-resource-limit%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D) that has a large network payload

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no