### PR TITLE
EXISTS type error

### DIFF
--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -602,7 +602,7 @@ export const Search: React.FC<{
 					sameWidth
 				>
 					<Box cssClass={styles.comboboxResults}>
-						{activePart.value.length > 0 && (
+						{activePart.value?.length > 0 && (
 							<Combobox.Group
 								className={styles.comboboxGroup}
 								store={comboboxStore}


### PR DESCRIPTION
## Summary
Using the `EXISTS` keyword causes an type error.,

## How did you test this change?
1) Visit the logs or traces page
2) Type in that a key exists
- [ ] No page crash
- [ ] Correct behavior for empty state

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
