### PR TITLE
filter out metric spans

### DIFF
--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -10,17 +10,19 @@ import (
 
 	"github.com/highlight/highlight/sdk/highlight-go"
 
-	"github.com/highlight-run/highlight/backend/model"
 	"golang.org/x/exp/slices"
+
+	"github.com/highlight-run/highlight/backend/model"
 
 	"github.com/huandu/go-sqlbuilder"
 	e "github.com/pkg/errors"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/samber/lo"
+
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"
-	"github.com/samber/lo"
 )
 
 const TracesTable = "traces"
@@ -93,7 +95,7 @@ var TracesTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
 	BodyColumn:       TracesTableNoDefaultConfig.BodyColumn,
 	AttributesColumn: TracesTableNoDefaultConfig.AttributesColumn,
 	SelectColumns:    TracesTableNoDefaultConfig.SelectColumns,
-	DefaultFilter:    fmt.Sprintf("%s!=%s", highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
+	DefaultFilter:    fmt.Sprintf("span_name!=%s %s!=%s", highlight.MetricSpanName, highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 }
 
 var tracesSamplingTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
@@ -103,7 +105,7 @@ var tracesSamplingTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
 	ReservedKeys:     modelInputs.AllReservedTraceKey,
 	AttributesColumn: "TraceAttributes",
 	SelectColumns:    traceColumns,
-	DefaultFilter:    fmt.Sprintf("%s!=%s", highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
+	DefaultFilter:    fmt.Sprintf("span_name!=%s %s!=%s", highlight.MetricSpanName, highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 }
 
 var tracesSampleableTableConfig = sampleableTableConfig[modelInputs.ReservedTraceKey]{

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -95,7 +95,7 @@ var TracesTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
 	BodyColumn:       TracesTableNoDefaultConfig.BodyColumn,
 	AttributesColumn: TracesTableNoDefaultConfig.AttributesColumn,
 	SelectColumns:    TracesTableNoDefaultConfig.SelectColumns,
-	DefaultFilter:    fmt.Sprintf("span_name!=%s %s!=%s", highlight.MetricSpanName, highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
+	DefaultFilter:    fmt.Sprintf("%s!=%s %s!=%s", modelInputs.ReservedTraceKeySpanName, highlight.MetricSpanName, highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 }
 
 var tracesSamplingTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
@@ -105,7 +105,7 @@ var tracesSamplingTableConfig = model.TableConfig[modelInputs.ReservedTraceKey]{
 	ReservedKeys:     modelInputs.AllReservedTraceKey,
 	AttributesColumn: "TraceAttributes",
 	SelectColumns:    traceColumns,
-	DefaultFilter:    fmt.Sprintf("span_name!=%s %s!=%s", highlight.MetricSpanName, highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
+	DefaultFilter:    fmt.Sprintf("%s!=%s %s!=%s", modelInputs.ReservedTraceKeySpanName, highlight.MetricSpanName, highlight.TraceTypeAttribute, highlight.TraceTypeHighlightInternal),
 }
 
 var tracesSampleableTableConfig = sampleableTableConfig[modelInputs.ReservedTraceKey]{

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2030,7 +2030,7 @@ func (r *Resolver) PushMetricsImpl(ctx context.Context, projectVerboseID *string
 			WithSpanId(spanID).
 			WithParentSpanId(parentSpanID).
 			WithTraceId(traceID).
-			WithSpanName("highlight-metric").
+			WithSpanName(highlight.MetricSpanName).
 			WithServiceName(serviceName).
 			WithServiceVersion(serviceVersion).
 			WithEnvironment(session.Environment).

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -43,6 +43,7 @@ const LogSeverityAttribute = "log.severity"
 const LogMessageAttribute = "log.message"
 
 const MetricEvent = "metric"
+const MetricSpanName = "highlight-metric"
 const MetricEventName = "metric.name"
 const MetricEventValue = "metric.value"
 
@@ -216,7 +217,7 @@ func EndTrace(span trace.Span) {
 // as a metric that you would like to graph and monitor. You'll be able to view the metric
 // in the context of the session and network request and recorded it.
 func RecordMetric(ctx context.Context, name string, value float64, tags ...attribute.KeyValue) {
-	span, _ := StartTraceWithTimestamp(ctx, "highlight-metric", time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, tags...)
+	span, _ := StartTraceWithTimestamp(ctx, MetricSpanName, time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, tags...)
 	defer EndTrace(span)
 	span.AddEvent(MetricEvent, trace.WithAttributes(attribute.String(MetricEventName, name), attribute.Float64(MetricEventValue, value)))
 }


### PR DESCRIPTION
## Summary

highlight-metric spans should be handled differently for time-series visualization.
since there isn't a reason to show them in the trace viewer, filter them out from the normal trace results

## How did you test this change?

no highlight-metric spans shown
![Screenshot from 2024-02-13 12-17-58](https://github.com/highlight/highlight/assets/1351531/9ab51182-26f6-4bef-856f-8c65de0ff320)


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no