### PR TITLE
enforce +/- 2 hour difference for ingested logs and traces

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -414,6 +414,12 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 
 	var projectLogs = make(map[string][]*clickhouse.LogRow)
 
+	// Allow timestamps +/- 1 hour from the current time.
+	// If the timestamp is outside of this window, set it to the current time.
+	var curTime = time.Now()
+	var minTime = curTime.Add(-1 * time.Hour)
+	var maxTime = curTime.Add(time.Hour)
+
 	resourceLogs := req.Logs().ResourceLogs()
 	for i := 0; i < resourceLogs.Len(); i++ {
 		resource := resourceLogs.At(i).Resource()
@@ -433,8 +439,13 @@ func (o *Handler) HandleLog(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 
+				timestamp := fields.timestamp
+				if timestamp.Before(minTime) || timestamp.After(maxTime) {
+					timestamp = curTime
+				}
+
 				logRow := clickhouse.NewLogRow(
-					fields.timestamp, uint32(fields.projectIDInt),
+					timestamp, uint32(fields.projectIDInt),
 					clickhouse.WithTraceID(logRecord.TraceID().String()),
 					clickhouse.WithSecureSessionID(fields.sessionID),
 					clickhouse.WithBody(ctx, fields.logBody),


### PR DESCRIPTION
## Summary
- this revives a PR from a few months ago that was applying this to logs
- changed limit to 2 hour to account for any potential daylight savings time weirdness
- expecting this to help clickhouse merge performance as effort won't have to be spent merging large parts in old partitions as new data won't be ingested for those partitions anymore
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- unit test, clicktested locally to make sure new logs + traces were ingested
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, can revert if issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
