### PR TITLE
skip trace_attributes table, write directly to trace_key_values

### DIFF
--- a/backend/clickhouse/migrations/000084_rewrite_trace_attributes_mv.down.sql
+++ b/backend/clickhouse/migrations/000084_rewrite_trace_attributes_mv.down.sql
@@ -1,0 +1,31 @@
+DROP VIEW IF EXISTS trace_attributes_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_attributes_mv TO trace_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `TraceTimestamp` DateTime,
+    `TraceUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    arrayJoin(TraceAttributes).1 AS Key,
+    Timestamp AS TraceTimestamp,
+    UUID AS TraceUUID,
+    arrayJoin(TraceAttributes).2 AS Value
+FROM traces
+WHERE (
+        Key NOT IN (
+            'level',
+            'trace_state',
+            'span_name',
+            'span_kind',
+            'service_name',
+            'service_version',
+            'message',
+            'secure_session_id',
+            'span_id',
+            'trace_id',
+            'parent_span_id',
+            'duration'
+        )
+    )
+    AND (Value != '');

--- a/backend/clickhouse/migrations/000084_rewrite_trace_attributes_mv.up.sql
+++ b/backend/clickhouse/migrations/000084_rewrite_trace_attributes_mv.up.sql
@@ -14,7 +14,6 @@ SELECT ProjectId,
 FROM traces
 WHERE (
         Key NOT IN (
-            'level',
             'trace_state',
             'span_name',
             'span_kind',

--- a/backend/clickhouse/migrations/000084_rewrite_trace_attributes_mv.up.sql
+++ b/backend/clickhouse/migrations/000084_rewrite_trace_attributes_mv.up.sql
@@ -1,0 +1,35 @@
+DROP VIEW IF EXISTS trace_attributes_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_attributes_mv TO trace_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId,
+    arrayJoin(TraceAttributes).1 AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    arrayJoin(TraceAttributes).2 AS Value,
+    count() AS Count
+FROM traces
+WHERE (
+        Key NOT IN (
+            'level',
+            'trace_state',
+            'span_name',
+            'span_kind',
+            'service_name',
+            'service_version',
+            'message',
+            'secure_session_id',
+            'span_id',
+            'trace_id',
+            'parent_span_id',
+            'duration'
+        )
+    )
+    AND (Value != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;

--- a/backend/clickhouse/migrations/000085_rewrite_trace_state_mv.down.sql
+++ b/backend/clickhouse/migrations/000085_rewrite_trace_state_mv.down.sql
@@ -1,0 +1,15 @@
+DROP VIEW IF EXISTS trace_state_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_state_mv TO trace_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `TraceTimestamp` DateTime,
+    `TraceUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'trace_state' AS Key,
+    Timestamp AS TraceTimestamp,
+    UUID AS TraceUUID,
+    TraceState AS Value
+FROM traces
+WHERE (TraceState != '');

--- a/backend/clickhouse/migrations/000085_rewrite_trace_state_mv.up.sql
+++ b/backend/clickhouse/migrations/000085_rewrite_trace_state_mv.up.sql
@@ -1,0 +1,19 @@
+DROP VIEW IF EXISTS trace_state_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_state_mv TO trace_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId,
+    'trace_state' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    TraceState AS Value,
+    count() AS Count
+FROM traces
+WHERE (TraceState != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;

--- a/backend/clickhouse/migrations/000086_rewrite_trace_span_name.down.sql
+++ b/backend/clickhouse/migrations/000086_rewrite_trace_span_name.down.sql
@@ -1,0 +1,15 @@
+DROP VIEW IF EXISTS trace_span_name_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_span_name_mv TO trace_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `TraceTimestamp` DateTime,
+    `TraceUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'span_name' AS Key,
+    Timestamp AS TraceTimestamp,
+    UUID AS TraceUUID,
+    SpanName AS Value
+FROM traces
+WHERE (SpanName != '');

--- a/backend/clickhouse/migrations/000086_rewrite_trace_span_name.up.sql
+++ b/backend/clickhouse/migrations/000086_rewrite_trace_span_name.up.sql
@@ -1,0 +1,19 @@
+DROP VIEW IF EXISTS trace_span_name_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_span_name_mv TO trace_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId,
+    'span_name' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    SpanName AS Value,
+    count() AS Count
+FROM traces
+WHERE (SpanName != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;

--- a/backend/clickhouse/migrations/000087_rewrite_trace_span_kind.down.sql
+++ b/backend/clickhouse/migrations/000087_rewrite_trace_span_kind.down.sql
@@ -1,0 +1,15 @@
+DROP VIEW IF EXISTS trace_span_kind_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_span_kind_mv TO trace_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `TraceTimestamp` DateTime,
+    `TraceUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'span_kind' AS Key,
+    Timestamp AS TraceTimestamp,
+    UUID AS TraceUUID,
+    SpanKind AS Value
+FROM traces
+WHERE (SpanKind != '');

--- a/backend/clickhouse/migrations/000087_rewrite_trace_span_kind.up.sql
+++ b/backend/clickhouse/migrations/000087_rewrite_trace_span_kind.up.sql
@@ -1,0 +1,19 @@
+DROP VIEW IF EXISTS trace_span_kind_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_span_kind_mv TO trace_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId,
+    'span_kind' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    SpanKind AS Value,
+    count() AS Count
+FROM traces
+WHERE (SpanKind != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;

--- a/backend/clickhouse/migrations/000088_rewrite_trace_service_name.down.sql
+++ b/backend/clickhouse/migrations/000088_rewrite_trace_service_name.down.sql
@@ -1,0 +1,15 @@
+DROP VIEW IF EXISTS trace_service_name_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_service_name_mv TO trace_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `TraceTimestamp` DateTime,
+    `TraceUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'service_name' AS Key,
+    Timestamp AS TraceTimestamp,
+    UUID AS TraceUUID,
+    ServiceName AS Value
+FROM traces
+WHERE (ServiceName != '');

--- a/backend/clickhouse/migrations/000088_rewrite_trace_service_name.up.sql
+++ b/backend/clickhouse/migrations/000088_rewrite_trace_service_name.up.sql
@@ -1,0 +1,19 @@
+DROP VIEW IF EXISTS trace_service_name_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_service_name_mv TO trace_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId,
+    'service_name' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    ServiceName AS Value,
+    count() AS Count
+FROM traces
+WHERE (ServiceName != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;

--- a/backend/clickhouse/migrations/000089_rewrite_trace_service_version.down.sql
+++ b/backend/clickhouse/migrations/000089_rewrite_trace_service_version.down.sql
@@ -1,0 +1,15 @@
+DROP VIEW IF EXISTS trace_service_version_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_service_version_mv TO trace_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `TraceTimestamp` DateTime,
+    `TraceUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'service_version' AS Key,
+    Timestamp AS TraceTimestamp,
+    UUID AS TraceUUID,
+    ServiceVersion AS Value
+FROM traces
+WHERE (ServiceVersion != '');

--- a/backend/clickhouse/migrations/000089_rewrite_trace_service_version.up.sql
+++ b/backend/clickhouse/migrations/000089_rewrite_trace_service_version.up.sql
@@ -1,0 +1,19 @@
+DROP VIEW IF EXISTS trace_service_version_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_service_version_mv TO trace_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId,
+    'service_version' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    ServiceVersion AS Value,
+    count() AS Count
+FROM traces
+WHERE (ServiceVersion != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;

--- a/backend/clickhouse/migrations/000090_rewrite_trace_environment.down.sql
+++ b/backend/clickhouse/migrations/000090_rewrite_trace_environment.down.sql
@@ -1,0 +1,15 @@
+DROP VIEW IF EXISTS trace_environment_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_environment_mv TO trace_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `TraceTimestamp` DateTime,
+    `TraceUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'environment' AS Key,
+    Timestamp AS TraceTimestamp,
+    UUID AS TraceUUID,
+    Environment AS Value
+FROM traces
+WHERE (Environment != '');

--- a/backend/clickhouse/migrations/000090_rewrite_trace_environment.up.sql
+++ b/backend/clickhouse/migrations/000090_rewrite_trace_environment.up.sql
@@ -1,0 +1,19 @@
+DROP VIEW IF EXISTS trace_environment_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_environment_mv TO trace_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId,
+    'environment' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    Environment AS Value,
+    count() AS Count
+FROM traces
+WHERE (Environment != '')
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;

--- a/backend/clickhouse/migrations/000091_rewrite_trace_has_errors.down.sql
+++ b/backend/clickhouse/migrations/000091_rewrite_trace_has_errors.down.sql
@@ -1,0 +1,15 @@
+DROP VIEW IF EXISTS trace_has_errors_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_has_errors_mv TO trace_attributes (
+    `ProjectId` UInt32,
+    `Key` String,
+    `TraceTimestamp` DateTime,
+    `TraceUUID` UUID,
+    `Value` String
+) AS
+SELECT ProjectId AS ProjectId,
+    'has_errors' AS Key,
+    Timestamp AS TraceTimestamp,
+    UUID AS TraceUUID,
+    HasErrors AS Value
+FROM traces
+WHERE HasErrors IS NOT NULL;

--- a/backend/clickhouse/migrations/000091_rewrite_trace_has_errors.up.sql
+++ b/backend/clickhouse/migrations/000091_rewrite_trace_has_errors.up.sql
@@ -1,0 +1,19 @@
+DROP VIEW IF EXISTS trace_has_errors_mv;
+CREATE MATERIALIZED VIEW IF NOT EXISTS trace_has_errors_mv TO trace_key_values (
+    `ProjectId` Int32,
+    `Key` LowCardinality(String),
+    `Day` DateTime,
+    `Value` String,
+    `Count` UInt64
+) AS
+SELECT ProjectId,
+    'has_errors' AS Key,
+    toStartOfDay(Timestamp) AS Day,
+    HasErrors AS Value,
+    count() AS Count
+FROM traces
+WHERE HasErrors IS NOT NULL
+GROUP BY ProjectId,
+    Key,
+    Day,
+    Value;


### PR DESCRIPTION
## Summary
- we don't use `trace_attributes` for anything and it uses a large number of parts, contributing to performance issues for trace ingest
- write key/value counts directly to `trace_key_values` (about 1000x fewer data)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran migration locally, ensured no new rows in `trace_attributes`, new rows for static and custom keys in `trace_key_values`
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
