### PR TITLE
use numeric project_id instead of obfuscated id

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -5,12 +5,12 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
+
+	highlightChi "github.com/highlight/highlight/sdk/highlight-go/middleware/chi"
 
 	model2 "github.com/highlight-run/highlight/backend/model"
 	privateModel "github.com/highlight-run/highlight/backend/private-graph/graph/model"
@@ -534,12 +534,11 @@ func (o *Handler) getQuotaExceededByProject(ctx context.Context, projectIds map[
 
 func (o *Handler) submitProjectLogs(ctx context.Context, projectLogs map[string][]*clickhouse.LogRow) error {
 	projectIds := map[uint32]struct{}{}
-	for projectId := range projectLogs {
-		id, err := strconv.Atoi(projectId)
-		if err != nil || id < 0 {
-			continue
+	for _, logRows := range projectLogs {
+		for _, logRow := range logRows {
+			projectIds[logRow.ProjectId] = struct{}{}
+			break
 		}
-		projectIds[uint32(id)] = struct{}{}
 	}
 
 	quotaExceededByProject, err := o.getQuotaExceededByProject(ctx, projectIds, model2.PricingProductTypeLogs)


### PR DESCRIPTION
## Summary
- fixes a bug with the quota lookup - use logRow.ProjectId instead of the map key (the obfuscated project id)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally with different quota settings to trigger filtering
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
