### PR TITLE
Small updates for Reflame

### DIFF
--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -3,9 +3,9 @@
   // It's basically JSON, with the addition of comments, and looser syntax
   // (trailing commas!).
   // Reflame uses this to identify your app.
-  "appId": "01GVH35S71FJP26W72V3K7CB2N", // prod
+  // "appId": "01GVH35S71FJP26W72V3K7CB2N", // prod
   // "appId": "01GSXZYQT1W0TZDJAG94P9S4BZ", // prod fork
-  // "appId": "01GR550WASJY2G2NSYZ4P54JJV", // dev
+  "appId": "01GR550WASJY2G2NSYZ4P54JJV", // dev
   // This is what shows up in the browser's tab bar.
   "title": "highlight.io",
   // This is the description that shows up in Google search.

--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -272,6 +272,9 @@
         "./components": "./components/index.ts",
         "./styles.css": "./noop.ts",
       },
+      "storybookCompatibility": {
+        "testStories": true,
+      },
       "npmPackages": {
         "ariakit": {
           "entryPoints": [

--- a/.reflame.config.jsonc
+++ b/.reflame.config.jsonc
@@ -3,9 +3,9 @@
   // It's basically JSON, with the addition of comments, and looser syntax
   // (trailing commas!).
   // Reflame uses this to identify your app.
-  // "appId": "01GVH35S71FJP26W72V3K7CB2N", // prod
+  "appId": "01GVH35S71FJP26W72V3K7CB2N", // prod
   // "appId": "01GSXZYQT1W0TZDJAG94P9S4BZ", // prod fork
-  "appId": "01GR550WASJY2G2NSYZ4P54JJV", // dev
+  // "appId": "01GR550WASJY2G2NSYZ4P54JJV", // dev
   // This is what shows up in the browser's tab bar.
   "title": "highlight.io",
   // This is the description that shows up in Google search.

--- a/frontend/src/pages/Auth/SignIn.tsx
+++ b/frontend/src/pages/Auth/SignIn.tsx
@@ -136,7 +136,7 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 						<Heading level="h4">
 							{workspaceInvite
 								? `You're invited to join ‘${workspaceInvite.workspace_name}’`
-								: 'Welcome bacasdasdsasdsasdsk!!.'}
+								: 'Welcome back.'}
 						</Heading>
 						<Text>
 							New here?{' '}

--- a/frontend/src/pages/Auth/SignIn.tsx
+++ b/frontend/src/pages/Auth/SignIn.tsx
@@ -136,7 +136,7 @@ export const SignIn: React.FC<Props> = ({ setResolver }) => {
 						<Heading level="h4">
 							{workspaceInvite
 								? `You're invited to join ‘${workspaceInvite.workspace_name}’`
-								: 'Welcome back.'}
+								: 'Welcome bacasdasdsasdsasdsk!!.'}
 						</Heading>
 						<Text>
 							New here?{' '}

--- a/packages/ui/src/components/DatePicker/DateRangePicker/helpers.ts
+++ b/packages/ui/src/components/DatePicker/DateRangePicker/helpers.ts
@@ -1,6 +1,11 @@
 import moment from 'moment'
 
-import { DateRangePreset, DateRangeValue, presetLabel, presetValue } from '.'
+import {
+	DateRangePreset,
+	DateRangeValue,
+	presetLabel,
+	presetValue,
+} from './index'
 import { TIME_DISPLAY_FORMAT, TIME_INPUT_FORMAT } from './constants'
 
 export const formatDisplayedDate = (date?: Date) => {


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

I just shipped an update that makes the storybookCompatibility configurable per app/library instead of globally. This PR updates the config to make sure all existing stories are still covered.

Also fixes an `import x from '.'` that breaks dev mode deploys from the VSCode extension. I'm planning to add some lightweight url rewriting to support this to avoid having to do this in the future.

## How did you test this change?

Reflame previews.

Component tests in frontend/src were [detected as new tests](https://github.com/highlight/highlight/pull/7748/checks?check_run_id=21552648479) because of some internal refactors I made to prep for supporting multiple apps deployed from the same repo. Should only happen this one time 🙏 

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
