### PR TITLE
flattened format for traces, add filtering logic to otel.go

### DIFF
--- a/backend/kafka-queue/kafkaqueue.go
+++ b/backend/kafka-queue/kafkaqueue.go
@@ -478,6 +478,8 @@ func (p *Queue) deserializeMessage(compressed []byte) (RetryableMessage, error) 
 	var msg RetryableMessage
 	if msgType.Type == PushLogsFlattened {
 		msg = &LogRowMessage{}
+	} else if msgType.Type == PushTracesFlattened {
+		msg = &TraceRowMessage{}
 	} else {
 		msg = &Message{}
 	}

--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -35,6 +35,7 @@ const (
 	ErrorObjectDataSync                    PayloadType = iota
 	PushCompressedPayload                  PayloadType = iota
 	PushLogsFlattened                      PayloadType = iota
+	PushTracesFlattened                    PayloadType = iota
 	HealthCheck                            PayloadType = math.MaxInt
 )
 
@@ -224,6 +225,41 @@ func (m *LogRowMessage) GetKafkaMessage() *kafka.Message {
 	return m.KafkaMessage
 }
 func (m *LogRowMessage) SetKafkaMessage(value *kafka.Message) {
+	m.KafkaMessage = value
+}
+
+type TraceRowMessage struct {
+	Type         PayloadType
+	Failures     int
+	MaxRetries   int
+	KafkaMessage *kafka.Message `json:",omitempty"`
+	*clickhouse.TraceRow
+}
+
+func (m *TraceRowMessage) GetType() PayloadType {
+	return PushTracesFlattened
+}
+
+func (m *TraceRowMessage) GetFailures() int {
+	return m.Failures
+}
+
+func (m *TraceRowMessage) SetFailures(value int) {
+	m.Failures = value
+}
+
+func (m *TraceRowMessage) GetMaxRetries() int {
+	return m.MaxRetries
+}
+
+func (m *TraceRowMessage) SetMaxRetries(value int) {
+	m.MaxRetries = value
+}
+
+func (m *TraceRowMessage) GetKafkaMessage() *kafka.Message {
+	return m.KafkaMessage
+}
+func (m *TraceRowMessage) SetKafkaMessage(value *kafka.Message) {
 	m.KafkaMessage = value
 }
 

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -600,23 +600,49 @@ func (o *Handler) submitProjectLogs(ctx context.Context, projectLogs map[string]
 }
 
 func (o *Handler) submitTraceSpans(ctx context.Context, traceRows map[string][]*clickhouse.TraceRow) error {
+	markBackendSetupProjectIds := map[uint32]struct{}{}
+	projectIds := map[uint32]struct{}{}
+	for _, traceRows := range traceRows {
+		for _, traceRow := range traceRows {
+			// Skip traces with a `http.method` attribute as likely autoinstrumented frontend traces
+			if _, found := traceRow.TraceAttributes["http.method"]; !found {
+				markBackendSetupProjectIds[traceRow.ProjectId] = struct{}{}
+			}
+			projectIds[traceRow.ProjectId] = struct{}{}
+		}
+	}
+
+	quotaExceededByProject, err := o.getQuotaExceededByProject(ctx, projectIds, model2.PricingProductTypeTraces)
+	if err != nil {
+		log.WithContext(ctx).Error(err)
+		quotaExceededByProject = map[uint32]bool{}
+	}
+
 	for traceID, traceRows := range traceRows {
 		var messages []kafkaqueue.RetryableMessage
 		for _, traceRow := range traceRows {
+			if quotaExceededByProject[traceRow.ProjectId] {
+				continue
+			}
 			if !o.resolver.IsTraceIngested(ctx, traceRow) {
 				continue
 			}
-			messages = append(messages, &kafkaqueue.Message{
-				Type: kafkaqueue.PushTraces,
-				PushTraces: &kafkaqueue.PushTracesArgs{
-					TraceRow: traceRow,
-				},
+			messages = append(messages, &kafkaqueue.TraceRowMessage{
+				Type:     kafkaqueue.PushTracesFlattened,
+				TraceRow: traceRow,
 			})
 		}
 
 		err := o.resolver.TracesQueue.Submit(ctx, traceID, messages...)
 		if err != nil {
 			return e.Wrap(err, "failed to submit otel project traces to public worker queue")
+		}
+	}
+
+	for projectId := range markBackendSetupProjectIds {
+		err := o.resolver.MarkBackendSetupImpl(ctx, int(projectId), model2.MarkBackendSetupTypeTraces)
+		if err != nil {
+			log.WithContext(ctx).WithError(err).Error("failed to mark backend traces setup")
 		}
 	}
 

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -604,8 +604,8 @@ func (o *Handler) submitTraceSpans(ctx context.Context, traceRows map[string][]*
 	projectIds := map[uint32]struct{}{}
 	for _, traceRows := range traceRows {
 		for _, traceRow := range traceRows {
-			// Skip traces with a `http.method` attribute as likely autoinstrumented frontend traces
-			if _, found := traceRow.TraceAttributes["http.method"]; !found {
+			// Don't mark backend setup for frontend or internal traces
+			if value := traceRow.TraceAttributes["highlight.type"]; value != "http.request" && value != "highlight.internal" {
 				markBackendSetupProjectIds[traceRow.ProjectId] = struct{}{}
 			}
 			projectIds[traceRow.ProjectId] = struct{}{}

--- a/backend/otel/otel_test.go
+++ b/backend/otel/otel_test.go
@@ -97,9 +97,9 @@ func TestHandler_HandleTrace(t *testing.T) {
 	}{
 		"./samples/traces.json": {
 			expectedMessageCounts: map[kafkaqueue.PayloadType]int{
-				kafkaqueue.PushBackendPayload: 4,   // 4 exceptions, pushed as individual messages
-				kafkaqueue.PushLogsFlattened:  15,  // 4 exceptions, 11 logs
-				kafkaqueue.PushTraces:         501, // 512 spans - 11 logs
+				kafkaqueue.PushBackendPayload:  4,   // 4 exceptions, pushed as individual messages
+				kafkaqueue.PushLogsFlattened:   15,  // 4 exceptions, 11 logs
+				kafkaqueue.PushTracesFlattened: 501, // 512 spans - 11 logs
 			},
 			expectedLogCounts: map[privateModel.LogSource]int{
 				privateModel.LogSourceFrontend: 1,
@@ -109,8 +109,8 @@ func TestHandler_HandleTrace(t *testing.T) {
 		"./samples/external.json": {
 			expectedMessageCounts: map[kafkaqueue.PayloadType]int{
 				// no errors expected
-				kafkaqueue.PushLogsFlattened: 11,  // 11 logs
-				kafkaqueue.PushTraces:        501, // 512 spans - 11 logs
+				kafkaqueue.PushLogsFlattened:   11,  // 11 logs
+				kafkaqueue.PushTracesFlattened: 501, // 512 spans - 11 logs
 			},
 			external: true,
 		},

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2044,11 +2044,9 @@ func (r *Resolver) PushMetricsImpl(ctx context.Context, projectVerboseID *string
 		if !r.IsTraceIngested(ctx, traceRow) {
 			continue
 		}
-		messages = append(messages, &kafka_queue.Message{
-			Type: kafka_queue.PushTraces,
-			PushTraces: &kafka_queue.PushTracesArgs{
-				TraceRow: traceRow,
-			},
+		messages = append(messages, &kafka_queue.TraceRowMessage{
+			Type:     kafka_queue.PushTracesFlattened,
+			TraceRow: traceRow,
 		})
 	}
 	return r.TracesQueue.Submit(ctx, "", messages...)

--- a/backend/worker/kafka_worker.go
+++ b/backend/worker/kafka_worker.go
@@ -125,7 +125,7 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 		}
 
 		publicWorkerMessage, ok := lastMsg.(*kafka_queue.Message)
-		if !ok && lastMsg.GetType() != kafkaqueue.PushLogsFlattened {
+		if !ok && lastMsg.GetType() != kafkaqueue.PushLogsFlattened && lastMsg.GetType() != kafkaqueue.PushTracesFlattened {
 			log.WithContext(ctx).Errorf("type assertion failed for *kafka_queue.Message")
 			continue
 		}
@@ -145,6 +145,15 @@ func (k *KafkaBatchWorker) flush(ctx context.Context) error {
 			}
 			if logRow != nil {
 				logRows = append(logRows, logRow.LogRow)
+			}
+		case kafkaqueue.PushTracesFlattened:
+			traceRow, ok := lastMsg.(*kafka_queue.TraceRowMessage)
+			if !ok {
+				log.WithContext(ctx).Errorf("type assertion failed for *kafka_queue.TraceRowMessage")
+				continue
+			}
+			if traceRow != nil {
+				traceRows = append(traceRows, traceRow.TraceRow)
 			}
 		case kafkaqueue.PushLogs:
 			logRow := publicWorkerMessage.PushLogs.LogRow


### PR DESCRIPTION
## Summary
- preparing to use Kafka Connect for writing traces to Clickhouse
- create a flattened traces format in Kafka, allow the current worker to read both the old and new formats
- copy trace filtering logic from `flushTraces` to `otel.go`
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally to make sure traces were still ingested properly
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, can revert if issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
