### PR TITLE
add GOMEMLIMIT values to all containers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
     push:
         branches:
             - 'main'
+            - 'vadim/mem-limit'
         paths:
             - 'go.work'
             - 'go.work.sum'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
     push:
         branches:
             - 'main'
-            - 'vadim/mem-limit'
         paths:
             - 'go.work'
             - 'go.work.sum'

--- a/deploy/collector-task.json
+++ b/deploy/collector-task.json
@@ -51,7 +51,7 @@
 			"environment": [
 				{
 					"name": "GOMEMLIMIT",
-					"value": "14336"
+					"value": "12GiB"
 				}
 			],
 			"mountPoints": [],

--- a/deploy/log-alerts-task.json
+++ b/deploy/log-alerts-task.json
@@ -31,7 +31,12 @@
 			],
 			"linuxParameters": null,
 			"cpu": 0,
-			"environment": [],
+			"environment": [
+				{
+					"name": "GOMEMLIMIT",
+					"value": "3GiB"
+				}
+			],
 			"resourceRequirements": null,
 			"ulimits": null,
 			"dnsServers": null,

--- a/deploy/metric-monitor-task.json
+++ b/deploy/metric-monitor-task.json
@@ -31,7 +31,12 @@
 			],
 			"linuxParameters": null,
 			"cpu": 0,
-			"environment": [],
+			"environment": [
+				{
+					"name": "GOMEMLIMIT",
+					"value": "3GiB"
+				}
+			],
 			"resourceRequirements": null,
 			"ulimits": null,
 			"dnsServers": null,

--- a/deploy/private-graph-task.json
+++ b/deploy/private-graph-task.json
@@ -15,7 +15,12 @@
 				}
 			],
 			"essential": true,
-			"environment": [],
+			"environment": [
+				{
+					"name": "GOMEMLIMIT",
+					"value": "6GiB"
+				}
+			],
 			"mountPoints": [],
 			"volumesFrom": [],
 			"secrets": [

--- a/deploy/public-graph-task.json
+++ b/deploy/public-graph-task.json
@@ -31,7 +31,12 @@
 			],
 			"linuxParameters": null,
 			"cpu": 0,
-			"environment": [],
+			"environment": [
+				{
+					"name": "GOMEMLIMIT",
+					"value": "12GiB"
+				}
+			],
 			"resourceRequirements": null,
 			"ulimits": [
 				{ "name": "nofile", "softLimit": 65535, "hardLimit": 65535 }

--- a/deploy/public-worker-batched-service.json
+++ b/deploy/public-worker-batched-service.json
@@ -15,7 +15,12 @@
 				"-runtime=worker",
 				"-worker-handler=public-worker-batched"
 			],
-			"environment": [],
+			"environment": [
+				{
+					"name": "GOMEMLIMIT",
+					"value": "3GiB"
+				}
+			],
 			"mountPoints": [],
 			"volumesFrom": [],
 			"secrets": [

--- a/deploy/public-worker-datasync-service.json
+++ b/deploy/public-worker-datasync-service.json
@@ -15,7 +15,12 @@
 				"-runtime=worker",
 				"-worker-handler=public-worker-datasync"
 			],
-			"environment": [],
+			"environment": [
+				{
+					"name": "GOMEMLIMIT",
+					"value": "3GiB"
+				}
+			],
 			"mountPoints": [],
 			"volumesFrom": [],
 			"secrets": [

--- a/deploy/public-worker-main-service.json
+++ b/deploy/public-worker-main-service.json
@@ -15,7 +15,12 @@
 				"-runtime=worker",
 				"-worker-handler=public-worker-main"
 			],
-			"environment": [],
+			"environment": [
+				{
+					"name": "GOMEMLIMIT",
+					"value": "3GiB"
+				}
+			],
 			"mountPoints": [],
 			"volumesFrom": [],
 			"secrets": [

--- a/deploy/public-worker-traces-service.json
+++ b/deploy/public-worker-traces-service.json
@@ -15,7 +15,12 @@
 				"-runtime=worker",
 				"-worker-handler=public-worker-traces"
 			],
-			"environment": [],
+			"environment": [
+				{
+					"name": "GOMEMLIMIT",
+					"value": "3GiB"
+				}
+			],
 			"mountPoints": [],
 			"volumesFrom": [],
 			"secrets": [

--- a/deploy/worker-task.json
+++ b/deploy/worker-task.json
@@ -14,7 +14,12 @@
 				"/bin/backend",
 				"-runtime=worker"
 			],
-			"environment": [],
+			"environment": [
+				{
+					"name": "GOMEMLIMIT",
+					"value": "12GiB"
+				}
+			],
 			"mountPoints": [
 				{
 					"sourceVolume": "worker-volume",


### PR DESCRIPTION
## Summary

* GOMEMLIMIT allows triggering GC at a given memory usage to help with avoiding OOMs.
* Configurable via a GiB suffix to each service tasks' size.

## How did you test this change?

Deploying to prod and monitoring memory usage having scaled clickhouse batch sizes.

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
