### PR TITLE
also clamp dates for metrics values to avoid too many old / future parts

### DIFF
--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -10,6 +10,7 @@ import (
 
 	model "github.com/highlight-run/highlight/backend/model"
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/highlight-run/highlight/backend/public-graph/graph"
 	"github.com/highlight-run/highlight/backend/util"
 	"github.com/highlight/highlight/sdk/highlight-go"
 	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
@@ -297,25 +298,9 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 		}
 	}
 
-	fields.timestamp = clampTime(fields.timestamp, params.curTime)
+	fields.timestamp = graph.ClampTime(fields.timestamp, params.curTime)
 
 	return fields, err
-}
-
-// If curTime is provided and the input is different by more than 2 hours,
-// use curTime instead of the input.
-func clampTime(input time.Time, curTime time.Time) time.Time {
-	if curTime.IsZero() {
-		return input
-	}
-
-	minTime := curTime.Add(-2 * time.Hour)
-	maxTime := curTime.Add(2 * time.Hour)
-	if input.Before(minTime) || input.After(maxTime) {
-		return curTime
-	}
-
-	return input
 }
 
 func mergeMaps(maps ...map[string]any) map[string]any {

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -297,7 +297,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 				}
 
 				if shouldWriteTrace {
-					timestamp := clampTime(span.StartTimestamp().AsTime(), curTime)
+					timestamp := graph.ClampTime(span.StartTimestamp().AsTime(), curTime)
 					traceRow := clickhouse.NewTraceRow(timestamp, fields.projectIDInt).
 						WithSecureSessionId(fields.sessionID).
 						WithTraceId(traceID).


### PR DESCRIPTION
## Summary
- after some more investigation, noticed there was still data for past and future timestamps coming in, seemed to all be from highlight-metric traces
- apply the same `ClampTime` logic in `PushMetricsImpl`
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally to make sure traces / metrics were still ingested normally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
