### PR TITLE
report usage as part of phonehome metrics

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -619,6 +619,9 @@ func main() {
 			go w.GetPublicWorker(kafkaqueue.TopicTypeBatched)(ctx)
 			go w.GetPublicWorker(kafkaqueue.TopicTypeDataSync)(ctx)
 			go w.GetPublicWorker(kafkaqueue.TopicTypeTraces)(ctx)
+			// for the 'All' worker, run alert / metric watchers
+			go w.StartLogAlertWatcher(ctx)
+			go w.StartMetricMonitorWatcher(ctx)
 			// in `all` mode, report stripe usage every hour
 			go func() {
 				w.ReportStripeUsage(ctx)
@@ -628,8 +631,6 @@ func main() {
 			}()
 			// in `all` mode, refresh materialized views every hour
 			go func() {
-				w.StartLogAlertWatcher(ctx)
-				w.StartMetricMonitorWatcher(ctx)
 				w.RefreshMaterializedViews(ctx)
 				for range time.Tick(time.Hour) {
 					w.RefreshMaterializedViews(ctx)


### PR DESCRIPTION
## Summary

Recent change to run metric monitor / alert monitor in self-hosted deploy (all workers mode)
would prevent refreshing materialized views from running, which would avoid reporting usage metrics.

## How did you test this change?

CI build of docker image + VM hobby deploy.

## Are there any deployment considerations?

new docker image release

## Does this work require review from our design team?

no
