### PR TITLE
fix incorrect logic for adding absolute url to relative stylesheet

### DIFF
--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -141,7 +141,7 @@ func TestEventsFromString(t *testing.T) {
 type fetcherMock struct{}
 
 func (u fetcherMock) fetchStylesheetData(href string, s *Snapshot) ([]byte, error) {
-	body := []byte("@font-face {\n\tfont-display: swap;\n\tfont-family: 'Inter';\n\tfont-style: normal;\n\tfont-weight: bold;\n\tsrc: local('Inter Bold'), local('InterBold'),\n\t\turl('font/Inter-Bold.woff2') format('woff2');\n}")
+	body := []byte("@font-face {\n\tfont-display: swap;\n\tfont-family: 'Inter';\n\tfont-style: normal;\n\tfont-weight: bold;\n\tsrc: local('Inter Bold'), local('InterBold'),\n\t\turl('font/Inter-Bold.woff2') format('woff2'), url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAE0lEQVQImWP4////f4bdu3f/BwAlfgctduB85QAAAABJRU5ErkJggg==\"), url(\"https://testing.psx-staging.energid.net/assets/fonts/roboto_medium_latin-ext.woff2\");\n}")
 	body = replaceRelativePaths(body, href)
 	body = append([]byte("/*highlight-inject*/\n"), body...)
 

--- a/backend/event-parse/parse_test.go
+++ b/backend/event-parse/parse_test.go
@@ -141,7 +141,11 @@ func TestEventsFromString(t *testing.T) {
 type fetcherMock struct{}
 
 func (u fetcherMock) fetchStylesheetData(href string, s *Snapshot) ([]byte, error) {
-	return []byte("/*highlight-inject*/\n.highlight {\n    color: black;\n}"), nil
+	body := []byte("@font-face {\n\tfont-display: swap;\n\tfont-family: 'Inter';\n\tfont-style: normal;\n\tfont-weight: bold;\n\tsrc: local('Inter Bold'), local('InterBold'),\n\t\turl('font/Inter-Bold.woff2') format('woff2');\n}")
+	body = replaceRelativePaths(body, href)
+	body = append([]byte("/*highlight-inject*/\n"), body...)
+
+	return body, nil
 }
 
 func TestInjectStyleSheets(t *testing.T) {

--- a/backend/event-parse/sample-events/output.json
+++ b/backend/event-parse/sample-events/output.json
@@ -96,7 +96,7 @@
 							},
 							{
 								"attributes": {
-									"_cssText": "/*highlight-inject*/\n.highlight {\n    color: black;\n}"
+									"_cssText": "/*highlight-inject*/\n@font-face {\n\tfont-display: swap;\n\tfont-family: 'Inter';\n\tfont-style: normal;\n\tfont-weight: bold;\n\tsrc: local('Inter Bold'), local('InterBold'),\n\t\turl('https://replay-cors-proxy.highlightrun.workers.dev?url=https://app.highlight.run/font/Inter-Bold.woff2') format('woff2');\n}"
 								},
 								"childNodes": [],
 								"id": 16,
@@ -110,7 +110,7 @@
 							},
 							{
 								"attributes": {
-									"_cssText": "/*highlight-inject*/\n.highlight {\n    color: black;\n}"
+									"_cssText": "/*highlight-inject*/\n@font-face {\n\tfont-display: swap;\n\tfont-family: 'Inter';\n\tfont-style: normal;\n\tfont-weight: bold;\n\tsrc: local('Inter Bold'), local('InterBold'),\n\t\turl('https://replay-cors-proxy.highlightrun.workers.dev?url=https://unpkg.com/font/Inter-Bold.woff2') format('woff2');\n}"
 								},
 								"childNodes": [],
 								"id": 18,

--- a/backend/event-parse/sample-events/output.json
+++ b/backend/event-parse/sample-events/output.json
@@ -96,7 +96,7 @@
 							},
 							{
 								"attributes": {
-									"_cssText": "/*highlight-inject*/\n@font-face {\n\tfont-display: swap;\n\tfont-family: 'Inter';\n\tfont-style: normal;\n\tfont-weight: bold;\n\tsrc: local('Inter Bold'), local('InterBold'),\n\t\turl('https://replay-cors-proxy.highlightrun.workers.dev?url=https://app.highlight.run/font/Inter-Bold.woff2') format('woff2');\n}"
+									"_cssText": "/*highlight-inject*/\n@font-face {\n\tfont-display: swap;\n\tfont-family: 'Inter';\n\tfont-style: normal;\n\tfont-weight: bold;\n\tsrc: local('Inter Bold'), local('InterBold'),\n\t\turl('https://replay-cors-proxy.highlightrun.workers.dev?url=https://app.highlight.run/font/Inter-Bold.woff2') format('woff2'), url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAE0lEQVQImWP4////f4bdu3f/BwAlfgctduB85QAAAABJRU5ErkJggg==\"), url(\"https://testing.psx-staging.energid.net/assets/fonts/roboto_medium_latin-ext.woff2\");\n}"
 								},
 								"childNodes": [],
 								"id": 16,
@@ -110,7 +110,7 @@
 							},
 							{
 								"attributes": {
-									"_cssText": "/*highlight-inject*/\n@font-face {\n\tfont-display: swap;\n\tfont-family: 'Inter';\n\tfont-style: normal;\n\tfont-weight: bold;\n\tsrc: local('Inter Bold'), local('InterBold'),\n\t\turl('https://replay-cors-proxy.highlightrun.workers.dev?url=https://unpkg.com/font/Inter-Bold.woff2') format('woff2');\n}"
+									"_cssText": "/*highlight-inject*/\n@font-face {\n\tfont-display: swap;\n\tfont-family: 'Inter';\n\tfont-style: normal;\n\tfont-weight: bold;\n\tsrc: local('Inter Bold'), local('InterBold'),\n\t\turl('https://replay-cors-proxy.highlightrun.workers.dev?url=https://unpkg.com/font/Inter-Bold.woff2') format('woff2'), url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAE0lEQVQImWP4////f4bdu3f/BwAlfgctduB85QAAAABJRU5ErkJggg==\"), url(\"https://testing.psx-staging.energid.net/assets/fonts/roboto_medium_latin-ext.woff2\");\n}"
 								},
 								"childNodes": [],
 								"id": 18,


### PR DESCRIPTION
## Summary

When inlining stylesheets, we try to update relative assets to point to the absolute host to make sure
they resolve correctly at replay time (rather than remaining relative but to the wrong host, app.highlight.io).
The regex pattern for matching relative assets was incorrect (would not match valid relative assets such as
`url(hello.woff2)`. 

Note: we update the url to our CORS worker rather than to the absolute url since the assets will be served to app.highlight.io cross origin.

## How did you test this change?

unit test
see updated output.json for correct payload

## Are there any deployment considerations?

monitoring affected customer

## Does this work require review from our design team?

no
