### PR TITLE
propagate session environment to network request traces

### DIFF
--- a/backend/clickhouse/logs_test.go
+++ b/backend/clickhouse/logs_test.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/aws/smithy-go/ptr"
 	"github.com/google/uuid"
-	"github.com/highlight-run/highlight/backend/parser"
-	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/highlight-run/highlight/backend/parser"
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 )
 
 func TestMain(m *testing.M) {
@@ -1415,7 +1416,7 @@ func Test_ReadLogsWithMultipleAttributeFilters_Clickhouse(t *testing.T) {
 		row := NewLogRow(oneSecondAgo, 1,
 			WithBody(ctx, "this is a test"),
 			WithSeverityText(modelInputs.LogLevelInfo.String()),
-			WithServiceName("frontend"),
+			WithServiceName(string(modelInputs.LogSourceFrontend)),
 			WithTraceID(uuid.New().String()),
 			WithLogAttributes(map[string]string{
 				"os": "linux",
@@ -1469,7 +1470,7 @@ func Test_LogMatchesNotQuery_ClickHouse(t *testing.T) {
 		row := NewLogRow(oneSecondAgo, 1,
 			WithBody(ctx, "this is a hello world message"),
 			WithSeverityText(modelInputs.LogLevelInfo.String()),
-			WithServiceName("frontend"),
+			WithServiceName(string(modelInputs.LogSourceFrontend)),
 			WithTraceID(uuid.New().String()),
 			WithLogAttributes(map[string]string{
 				"os.type": "linux",

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -3089,6 +3089,7 @@ func (r *Resolver) submitFrontendNetworkMetric(sessionObj *model.Session, resour
 			attribute.String(highlight.SessionIDAttribute, sessionObj.SecureID),
 			attribute.String(highlight.RequestIDAttribute, re.RequestResponsePairs.Request.ID),
 			attribute.String(highlight.TraceKeyAttribute, re.Name),
+			semconv.DeploymentEnvironmentKey.String(sessionObj.Environment),
 			semconv.ServiceNameKey.String(sessionObj.ServiceName),
 			semconv.ServiceVersionKey.String(ptr.ToString(sessionObj.AppVersion)),
 			semconv.HTTPURLKey.String(re.Name),

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
 
@@ -2604,7 +2605,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			util.ResourceName("go.unmarshal.messages"), util.Tag("project_id", projectID))
 		defer unmarshalMessagesSpan.Finish()
 
-		if err := hlog.SubmitFrontendConsoleMessages(ctx, projectID, sessionSecureID, messages); err != nil {
+		if err := r.submitFrontendConsoleMessages(ctx, sessionObj, messages); err != nil {
 			log.WithContext(ctx).WithError(err).Error("failed to parse console messages")
 		}
 
@@ -3114,6 +3115,92 @@ func (r *Resolver) submitFrontendNetworkMetric(sessionObj *model.Session, resour
 		span, _ := highlight.StartTraceWithTimestamp(ctx, strings.Join([]string{method, re.Name}, " "), start, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, attributes...)
 		span.End(trace.WithTimestamp(end))
 	}
+	return nil
+}
+
+func (r *Resolver) submitFrontendConsoleMessages(ctx context.Context, sessionObj *model.Session, messages string) error {
+	logRows, err := hlog.ParseConsoleMessages(messages)
+	if err != nil {
+		return err
+	}
+
+	if len(logRows) == 0 {
+		return nil
+	}
+
+	for _, row := range logRows {
+		attributes := []attribute.KeyValue{
+			attribute.String(highlight.TraceTypeAttribute, string(highlight.TraceTypeFrontendConsole)),
+			attribute.Int(highlight.ProjectIDAttribute, sessionObj.ProjectID),
+			attribute.String(highlight.SessionIDAttribute, sessionObj.SecureID),
+			attribute.String(highlight.SourceAttribute, string(privateModel.LogSourceFrontend)),
+			semconv.DeploymentEnvironmentKey.String(sessionObj.Environment),
+			semconv.ServiceNameKey.String(sessionObj.ServiceName),
+			semconv.ServiceVersionKey.String(ptr.ToString(sessionObj.AppVersion)),
+		}
+		span, _ := highlight.StartTraceWithoutResourceAttributes(ctx, highlight.UtilitySpanName, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, attributes...)
+		message := strings.Join(row.Value, " ")
+		attrs := []attribute.KeyValue{
+			hlog.LogSeverityKey.String(row.Type),
+			hlog.LogMessageKey.String(message),
+		}
+		for k, v := range row.Attributes {
+			for key, value := range hlog.FormatLogAttributes(ctx, k, v) {
+				if v != "" {
+					attrs = append(attrs, attribute.String(key, value))
+				}
+			}
+		}
+		if len(row.Trace) > 0 {
+			traceEnd := &row.Trace[len(row.Trace)-1]
+			attrs = append(
+				attrs,
+				semconv.CodeFunctionKey.String(traceEnd.FunctionName),
+				semconv.CodeNamespaceKey.String(traceEnd.Source),
+				semconv.CodeFilepathKey.String(traceEnd.FileName),
+			)
+
+			var ln int
+			if x, ok := traceEnd.LineNumber.(int); ok {
+				ln = x
+			} else if x, ok := traceEnd.LineNumber.(string); ok {
+				if i, err := strconv.ParseInt(x, 10, 32); err == nil {
+					ln = int(i)
+				}
+			}
+			if ln != 0 {
+				attrs = append(attrs, semconv.CodeLineNumberKey.Int(ln))
+			}
+
+			var cn int
+			if x, ok := traceEnd.ColumnNumber.(int); ok {
+				cn = x
+			} else if x, ok := traceEnd.ColumnNumber.(string); ok {
+				if i, err := strconv.ParseInt(x, 10, 32); err == nil {
+					cn = int(i)
+				}
+			}
+			if cn != 0 {
+				attrs = append(attrs, semconv.CodeColumnKey.Int(cn))
+			}
+			stackTrace := message
+			for _, t := range row.Trace {
+				if t.Source != "" {
+					stackTrace += "\n" + t.Source
+				} else {
+					stackTrace += fmt.Sprintf("\n\tat %s (%s:%+v:%+v)", t.FunctionName, t.FileName, t.LineNumber, t.ColumnNumber)
+				}
+			}
+			attrs = append(attrs, semconv.ExceptionStacktraceKey.String(stackTrace))
+		}
+
+		span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(row.Time)))
+		if row.Type == "error" {
+			span.SetStatus(codes.Error, message)
+		}
+		highlight.EndTrace(span)
+	}
+
 	return nil
 }
 

--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/highlight/highlight/sdk/highlight-go"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/highlight/highlight/sdk/highlight-go"
 )
 
 const TimestampFormat = "2006-01-02T15:04:05.000Z"
@@ -72,92 +73,9 @@ type VercelLog struct {
 	Proxy       VercelProxy `json:"proxy"`
 }
 
-func SubmitFrontendConsoleMessages(ctx context.Context, projectID int, sessionSecureID string, messages string) error {
-	logRows, err := ParseConsoleMessages(messages)
-	if err != nil {
-		return err
-	}
-
-	if len(logRows) == 0 {
-		return nil
-	}
-
-	for _, row := range logRows {
-		span, _ := highlight.StartTraceWithoutResourceAttributes(
-			ctx, "highlight-ctx", []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)},
-			// modelInputs.LogSourceFrontend
-			attribute.String(highlight.SourceAttribute, "frontend"),
-			attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
-			attribute.String(highlight.SessionIDAttribute, sessionSecureID),
-		)
-		message := strings.Join(row.Value, " ")
-		attrs := []attribute.KeyValue{
-			LogSeverityKey.String(row.Type),
-			LogMessageKey.String(message),
-		}
-		for k, v := range row.Attributes {
-			for key, value := range FormatLogAttributes(ctx, k, v) {
-				if v != "" {
-					attrs = append(attrs, attribute.String(key, value))
-				}
-			}
-		}
-		if len(row.Trace) > 0 {
-			traceEnd := &row.Trace[len(row.Trace)-1]
-			attrs = append(
-				attrs,
-				semconv.CodeFunctionKey.String(traceEnd.FunctionName),
-				semconv.CodeNamespaceKey.String(traceEnd.Source),
-				semconv.CodeFilepathKey.String(traceEnd.FileName),
-			)
-
-			var ln int
-			if x, ok := traceEnd.LineNumber.(int); ok {
-				ln = x
-			} else if x, ok := traceEnd.LineNumber.(string); ok {
-				if i, err := strconv.ParseInt(x, 10, 32); err == nil {
-					ln = int(i)
-				}
-			}
-			if ln != 0 {
-				attrs = append(attrs, semconv.CodeLineNumberKey.Int(ln))
-			}
-
-			var cn int
-			if x, ok := traceEnd.ColumnNumber.(int); ok {
-				cn = x
-			} else if x, ok := traceEnd.ColumnNumber.(string); ok {
-				if i, err := strconv.ParseInt(x, 10, 32); err == nil {
-					cn = int(i)
-				}
-			}
-			if cn != 0 {
-				attrs = append(attrs, semconv.CodeColumnKey.Int(cn))
-			}
-			stackTrace := message
-			for _, t := range row.Trace {
-				if t.Source != "" {
-					stackTrace += "\n" + t.Source
-				} else {
-					stackTrace += fmt.Sprintf("\n\tat %s (%s:%+v:%+v)", t.FunctionName, t.FileName, t.LineNumber, t.ColumnNumber)
-				}
-			}
-			attrs = append(attrs, semconv.ExceptionStacktraceKey.String(stackTrace))
-		}
-
-		span.AddEvent(highlight.LogEvent, trace.WithAttributes(attrs...), trace.WithTimestamp(time.UnixMilli(row.Time)))
-		if row.Type == "error" {
-			span.SetStatus(codes.Error, message)
-		}
-		highlight.EndTrace(span)
-	}
-
-	return nil
-}
-
 func submitVercelLog(ctx context.Context, projectID int, log VercelLog) {
 	span, _ := highlight.StartTraceWithoutResourceAttributes(
-		ctx, "highlight-ctx", []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)},
+		ctx, highlight.UtilitySpanName, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)},
 		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
 	)
 	defer highlight.EndTrace(span)
@@ -203,7 +121,7 @@ func SubmitVercelLogs(ctx context.Context, projectID int, logs []VercelLog) {
 
 func SubmitHTTPLog(ctx context.Context, projectID int, lg Log) error {
 	span, _ := highlight.StartTraceWithoutResourceAttributes(
-		ctx, "highlight-ctx", []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)},
+		ctx, highlight.UtilitySpanName, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)},
 		attribute.String(highlight.ProjectIDAttribute, strconv.Itoa(projectID)),
 	)
 	defer highlight.EndTrace(span)

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -47,9 +47,12 @@ const MetricSpanName = "highlight-metric"
 const MetricEventName = "metric.name"
 const MetricEventValue = "metric.value"
 
+const UtilitySpanName = "highlight-ctx"
+
 type TraceType string
 
 const TraceTypeNetworkRequest TraceType = "http.request"
+const TraceTypeFrontendConsole TraceType = "frontend.console"
 const TraceTypeHighlightInternal TraceType = "highlight.internal"
 const TraceTypePhoneHome TraceType = "highlight.phonehome"
 
@@ -226,7 +229,7 @@ func RecordMetric(ctx context.Context, name string, value float64, tags ...attri
 // Highlight session and trace are inferred from the context.
 // If no sessionID is set, then the error is associated with the project without a session context.
 func RecordError(ctx context.Context, err error, tags ...attribute.KeyValue) context.Context {
-	span, ctx := StartTraceWithTimestamp(ctx, "highlight-ctx", time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, tags...)
+	span, ctx := StartTraceWithTimestamp(ctx, UtilitySpanName, time.Now(), []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, tags...)
 	defer EndTrace(span)
 	RecordSpanError(span, err)
 	return ctx


### PR DESCRIPTION
## Summary

* Traces from the frontend would pass the wrong environment value rather than using the one on the session.
* Logs from the frontend would not pass session metadata to the log.

## How did you test this change?

before
![Screenshot from 2024-02-15 18-06-48](https://github.com/highlight/highlight/assets/1351531/5b4f296e-0303-4a26-a727-31dd7b6b85a5)

after
![Screenshot from 2024-02-15 18-06-35](https://github.com/highlight/highlight/assets/1351531/04807a01-5401-481c-8016-ad030daf9a93)

before
![Screenshot from 2024-02-15 18-04-39](https://github.com/highlight/highlight/assets/1351531/4dce57b6-d29a-4c8b-b05d-7344cb09fc54)

after
![Screenshot from 2024-02-15 18-05-03](https://github.com/highlight/highlight/assets/1351531/c113e5ea-405f-40e3-8156-7393dbc4a7c7)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no