### PR TITLE
Allow users to use the key multiple times

### DIFF
--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -294,7 +294,7 @@ export const Search: React.FC<{
 
 	let visibleItems: SearchResult[] = showValues
 		? getVisibleValues(activePart, values)
-		: getVisibleKeys(query, queryParts, activePart, keys)
+		: getVisibleKeys(query, activePart, keys)
 	const comboboxItems = comboboxStore.useState('items')
 
 	// Show operators when we have an exact match for a key
@@ -813,13 +813,10 @@ const getActivePart = (
 
 const getVisibleKeys = (
 	queryText: string,
-	queryParts: SearchExpression[],
 	activeQueryPart?: SearchExpression,
 	keys?: Keys,
 ) => {
 	const startingNewPart = queryText.endsWith(' ')
-	const activePartKeys = queryParts.map((part) => part.key)
-	keys = keys?.filter((key) => activePartKeys.indexOf(key.name) === -1)
 
 	return (
 		keys?.filter(


### PR DESCRIPTION
## Summary
With the use of `or` and `and`, users may want to use the same filter key more than once. Don't filter out keys that the user already used.

## How did you test this change?
1) Load the logs/traces page
2) Start searching by an attribute
3) Try to search by the same attribute using "and" or "or"
- [ ] Search key is in results 

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
