### PR TITLE
Improve logs related resource query

### DIFF
--- a/backend/clickhouse/migrations/000092_drop_new_traces_by_id_mv.down.sql
+++ b/backend/clickhouse/migrations/000092_drop_new_traces_by_id_mv.down.sql
@@ -1,0 +1,64 @@
+DROP TABLE IF EXISTS traces_by_id_new;
+DROP VIEW IF EXISTS traces_by_id_new_mv;
+
+CREATE TABLE IF NOT EXISTS traces_by_id_new (
+    `Timestamp` DateTime64(9),
+    `UUID` UUID,
+    `TraceId` String,
+    `SpanId` String,
+    `ParentSpanId` String,
+    `ProjectId` UInt32,
+    `SecureSessionId` String,
+    `TraceState` String,
+    `SpanName` LowCardinality(String),
+    `SpanKind` LowCardinality(String),
+    `Duration` Int64,
+    `ServiceName` LowCardinality(String),
+    `ServiceVersion` String,
+    `TraceAttributes` Map(LowCardinality(String), String),
+    `StatusCode` LowCardinality(String),
+    `StatusMessage` String,
+    `Environment` String,
+    `HasErrors` Bool,
+    `Events.Timestamp` Array(DateTime64(9)),
+    `Events.Name` Array(LowCardinality(String)),
+    `Events.Attributes` Array(Map(LowCardinality(String), String)),
+    `Links.TraceId` Array(String),
+    `Links.SpanId` Array(String),
+    `Links.TraceState` Array(String),
+    `Links.Attributes` Array(Map(LowCardinality(String), String))
+)
+    ENGINE = MergeTree
+        PARTITION BY farmHash64(TraceId) % 16
+        ORDER BY (ProjectId, TraceId)
+        TTL toDateTime(Timestamp) + toIntervalDay(30);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS traces_by_id_new_mv TO traces_by_id_new (
+    `Timestamp` DateTime64(9),
+    `UUID` UUID,
+    `TraceId` String,
+    `SpanId` String,
+    `ParentSpanId` String,
+    `ProjectId` UInt32,
+    `SecureSessionId` String,
+    `TraceState` String,
+    `SpanName` LowCardinality(String),
+    `SpanKind` LowCardinality(String),
+    `Duration` Int64,
+    `ServiceName` LowCardinality(String),
+    `ServiceVersion` String,
+    `TraceAttributes` Map(LowCardinality(String), String),
+    `StatusCode` LowCardinality(String),
+    `StatusMessage` String,
+    `Environment` String,
+    `HasErrors` Bool,
+    `Events.Timestamp` Array(DateTime64(9)),
+    `Events.Name` Array(LowCardinality(String)),
+    `Events.Attributes` Array(Map(LowCardinality(String), String)),
+    `Links.TraceId` Array(String),
+    `Links.SpanId` Array(String),
+    `Links.TraceState` Array(String),
+    `Links.Attributes` Array(Map(LowCardinality(String), String))
+) AS
+SELECT *
+FROM traces;

--- a/backend/clickhouse/migrations/000092_drop_new_traces_by_id_mv.up.sql
+++ b/backend/clickhouse/migrations/000092_drop_new_traces_by_id_mv.up.sql
@@ -1,0 +1,64 @@
+DROP TABLE IF EXISTS traces_by_id_new;
+DROP VIEW IF EXISTS traces_by_id_new_mv;
+
+CREATE TABLE IF NOT EXISTS traces_by_id_new (
+    `Timestamp` DateTime64(9),
+    `UUID` UUID,
+    `TraceId` String,
+    `SpanId` String,
+    `ParentSpanId` String,
+    `ProjectId` UInt32,
+    `SecureSessionId` String,
+    `TraceState` String,
+    `SpanName` LowCardinality(String),
+    `SpanKind` LowCardinality(String),
+    `Duration` Int64,
+    `ServiceName` LowCardinality(String),
+    `ServiceVersion` String,
+    `TraceAttributes` Map(LowCardinality(String), String),
+    `StatusCode` LowCardinality(String),
+    `StatusMessage` String,
+    `Environment` String,
+    `HasErrors` Bool,
+    `Events.Timestamp` Array(DateTime64(9)),
+    `Events.Name` Array(LowCardinality(String)),
+    `Events.Attributes` Array(Map(LowCardinality(String), String)),
+    `Links.TraceId` Array(String),
+    `Links.SpanId` Array(String),
+    `Links.TraceState` Array(String),
+    `Links.Attributes` Array(Map(LowCardinality(String), String))
+)
+    ENGINE = MergeTree
+        PARTITION BY farmHash64(TraceId) % 16
+        ORDER BY (ProjectId, TraceId)
+        TTL toDateTime(Timestamp) + toIntervalDay(30);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS traces_by_id_new_mv TO traces_by_id_new (
+    `Timestamp` DateTime64(9),
+    `UUID` UUID,
+    `TraceId` String,
+    `SpanId` String,
+    `ParentSpanId` String,
+    `ProjectId` UInt32,
+    `SecureSessionId` String,
+    `TraceState` String,
+    `SpanName` LowCardinality(String),
+    `SpanKind` LowCardinality(String),
+    `Duration` Int64,
+    `ServiceName` LowCardinality(String),
+    `ServiceVersion` String,
+    `TraceAttributes` Map(LowCardinality(String), String),
+    `StatusCode` LowCardinality(String),
+    `StatusMessage` String,
+    `Environment` String,
+    `HasErrors` Bool,
+    `Events.Timestamp` Array(DateTime64(9)),
+    `Events.Name` Array(LowCardinality(String)),
+    `Events.Attributes` Array(Map(LowCardinality(String), String)),
+    `Links.TraceId` Array(String),
+    `Links.SpanId` Array(String),
+    `Links.TraceState` Array(String),
+    `Links.Attributes` Array(Map(LowCardinality(String), String))
+) AS
+SELECT *
+FROM traces;

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -285,7 +285,7 @@ func (client *Client) ReadTraces(ctx context.Context, projectID int, params mode
 	}, nil
 }
 
-func (client *Client) ExistingTraceIds(ctx context.Context, projectID int, traceIDs []string) ([]string, error) {
+func (client *Client) ExistingTraceIds(ctx context.Context, projectID int, traceIDs []string, startDate time.Time, endDate time.Time) ([]string, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	var err error
 	var args []interface{}
@@ -293,7 +293,9 @@ func (client *Client) ExistingTraceIds(ctx context.Context, projectID int, trace
 	sb.From(TracesByIdTable).
 		Select("DISTINCT TraceId").
 		Where(sb.Equal("ProjectId", projectID)).
-		Where(sb.In("TraceId", traceIDs))
+		Where(sb.In("TraceId", traceIDs)).
+		Where(sb.GreaterThan("Timestamp", startDate)).
+		Where(sb.LessThan("Timestamp", endDate))
 
 	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
 

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -955,7 +955,7 @@ type ComplexityRoot struct {
 		EventChunkURL                    func(childComplexity int, secureID string, index int) int
 		EventChunks                      func(childComplexity int, secureID string) int
 		Events                           func(childComplexity int, sessionSecureID string) int
-		ExistingLogsTraces               func(childComplexity int, projectID int, traceIds []string) int
+		ExistingLogsTraces               func(childComplexity int, projectID int, traceIds []string, dateRange model.DateRangeRequiredInput) int
 		FieldSuggestion                  func(childComplexity int, projectID int, name string, query string) int
 		FieldTypesClickhouse             func(childComplexity int, projectID int, startDate time.Time, endDate time.Time) int
 		FieldsClickhouse                 func(childComplexity int, projectID int, count int, fieldType string, fieldName string, query string, startDate time.Time, endDate time.Time) int
@@ -1850,7 +1850,7 @@ type QueryResolver interface {
 	LogsKeys(ctx context.Context, projectID int, dateRange model.DateRangeRequiredInput, query *string, typeArg *model.KeyType) ([]*model.QueryKey, error)
 	LogsKeyValues(ctx context.Context, projectID int, keyName string, dateRange model.DateRangeRequiredInput) ([]string, error)
 	LogsErrorObjects(ctx context.Context, logCursors []string) ([]*model1.ErrorObject, error)
-	ExistingLogsTraces(ctx context.Context, projectID int, traceIds []string) ([]string, error)
+	ExistingLogsTraces(ctx context.Context, projectID int, traceIds []string, dateRange model.DateRangeRequiredInput) ([]string, error)
 	ErrorResolutionSuggestion(ctx context.Context, errorObjectID int) (string, error)
 	SessionInsight(ctx context.Context, secureID string) (*model1.SessionInsight, error)
 	SessionExports(ctx context.Context, projectID int) ([]*model.SessionExportWithSession, error)
@@ -6973,7 +6973,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ExistingLogsTraces(childComplexity, args["project_id"].(int), args["trace_ids"].([]string)), true
+		return e.complexity.Query.ExistingLogsTraces(childComplexity, args["project_id"].(int), args["trace_ids"].([]string), args["date_range"].(model.DateRangeRequiredInput)), true
 
 	case "Query.field_suggestion":
 		if e.complexity.Query.FieldSuggestion == nil {
@@ -12750,7 +12750,11 @@ type Query {
 		date_range: DateRangeRequiredInput!
 	): [String!]!
 	logs_error_objects(log_cursors: [String!]!): [ErrorObject!]!
-	existing_logs_traces(project_id: ID!, trace_ids: [String!]!): [String!]!
+	existing_logs_traces(
+		project_id: ID!
+		trace_ids: [String!]!
+		date_range: DateRangeRequiredInput!
+	): [String!]!
 	error_resolution_suggestion(error_object_id: ID!): String!
 	session_insight(secure_id: String!): SessionInsight
 	session_exports(project_id: ID!): [SessionExportWithSession!]!
@@ -17717,6 +17721,15 @@ func (ec *executionContext) field_Query_existing_logs_traces_args(ctx context.Co
 		}
 	}
 	args["trace_ids"] = arg1
+	var arg2 model.DateRangeRequiredInput
+	if tmp, ok := rawArgs["date_range"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("date_range"))
+		arg2, err = ec.unmarshalNDateRangeRequiredInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐDateRangeRequiredInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["date_range"] = arg2
 	return args, nil
 }
 
@@ -57291,7 +57304,7 @@ func (ec *executionContext) _Query_existing_logs_traces(ctx context.Context, fie
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().ExistingLogsTraces(rctx, fc.Args["project_id"].(int), fc.Args["trace_ids"].([]string))
+		return ec.resolvers.Query().ExistingLogsTraces(rctx, fc.Args["project_id"].(int), fc.Args["trace_ids"].([]string), fc.Args["date_range"].(model.DateRangeRequiredInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2075,7 +2075,11 @@ type Query {
 		date_range: DateRangeRequiredInput!
 	): [String!]!
 	logs_error_objects(log_cursors: [String!]!): [ErrorObject!]!
-	existing_logs_traces(project_id: ID!, trace_ids: [String!]!): [String!]!
+	existing_logs_traces(
+		project_id: ID!
+		trace_ids: [String!]!
+		date_range: DateRangeRequiredInput!
+	): [String!]!
 	error_resolution_suggestion(error_object_id: ID!): String!
 	session_insight(secure_id: String!): SessionInsight
 	session_exports(project_id: ID!): [SessionExportWithSession!]!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -7797,13 +7797,13 @@ func (r *queryResolver) LogsErrorObjects(ctx context.Context, logCursors []strin
 }
 
 // ExistingLogsTraces is the resolver for the existing_logs_traces field.
-func (r *queryResolver) ExistingLogsTraces(ctx context.Context, projectID int, traceIds []string) ([]string, error) {
+func (r *queryResolver) ExistingLogsTraces(ctx context.Context, projectID int, traceIds []string, dateRange modelInputs.DateRangeRequiredInput) ([]string, error) {
 	project, err := r.isAdminInProjectOrDemoProject(ctx, projectID)
 	if err != nil {
 		return nil, err
 	}
 
-	return r.ClickhouseClient.ExistingTraceIds(ctx, project.ID, traceIds)
+	return r.ClickhouseClient.ExistingTraceIds(ctx, project.ID, traceIds, dateRange.StartDate, dateRange.EndDate)
 }
 
 // ErrorResolutionSuggestion is the resolver for the error_resolution_suggestion field.

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -13776,13 +13776,18 @@ export const GetLogsRelatedResourcesDocument = gql`
 		$project_id: ID!
 		$log_cursors: [String!]!
 		$trace_ids: [String!]!
+		$date_range: DateRangeRequiredInput!
 	) {
 		logs_error_objects(log_cursors: $log_cursors) {
 			log_cursor
 			error_group_secure_id
 			id
 		}
-		existing_logs_traces(project_id: $project_id, trace_ids: $trace_ids)
+		existing_logs_traces(
+			project_id: $project_id
+			trace_ids: $trace_ids
+			date_range: $date_range
+		)
 	}
 `
 
@@ -13801,6 +13806,7 @@ export const GetLogsRelatedResourcesDocument = gql`
  *      project_id: // value for 'project_id'
  *      log_cursors: // value for 'log_cursors'
  *      trace_ids: // value for 'trace_ids'
+ *      date_range: // value for 'date_range'
  *   },
  * });
  */

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4582,6 +4582,7 @@ export type GetLogsRelatedResourcesQueryVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	log_cursors: Array<Types.Scalars['String']> | Types.Scalars['String']
 	trace_ids: Array<Types.Scalars['String']> | Types.Scalars['String']
+	date_range: Types.DateRangeRequiredInput
 }>
 
 export type GetLogsRelatedResourcesQuery = { __typename?: 'Query' } & Pick<

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2206,6 +2206,7 @@ export type QueryEventsArgs = {
 }
 
 export type QueryExisting_Logs_TracesArgs = {
+	date_range: DateRangeRequiredInput
 	project_id: Scalars['ID']
 	trace_ids: Array<Scalars['String']>
 }

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2188,13 +2188,18 @@ query GetLogsRelatedResources(
 	$project_id: ID!
 	$log_cursors: [String!]!
 	$trace_ids: [String!]!
+	$date_range: DateRangeRequiredInput!
 ) {
 	logs_error_objects(log_cursors: $log_cursors) {
 		log_cursor
 		error_group_secure_id
 		id
 	}
-	existing_logs_traces(project_id: $project_id, trace_ids: $trace_ids)
+	existing_logs_traces(
+		project_id: $project_id
+		trace_ids: $trace_ids
+		date_range: $date_range
+	)
 }
 
 query GetProjectSettings($projectId: ID!) {

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -119,6 +119,12 @@ export const useGetLogs = ({
 			project_id: project_id!,
 			log_cursors: data?.logs.edges.map((e) => e.cursor) || [],
 			trace_ids: logTraceIds,
+			date_range: {
+				start_date: moment(startDate)
+					.subtract(5, 'minutes')
+					.format(TIME_FORMAT),
+				end_date: moment(endDate).add(5, 'minutes').format(TIME_FORMAT),
+			},
 		},
 		skip: !data?.logs.edges.length,
 	})


### PR DESCRIPTION
## Summary
Update the `useGetLogsRelatedResourcesQuery` query to be more efficient
- switch from `traces_by_id` to `traces` table
- provide a date range to limit the number of partitions needed to be searched

## How did you test this change?
1) Load the logs page
- [ ] the `useGetLogsRelatedResourcesQuery` returns with no errors
- [ ] Any logs with related correctly show the related trace button

## Are there any deployment considerations?
Monitor performance in production

## Does this work require review from our design team?
N/A