### PR TITLE
remove highlight admin guard for Teams integration

### DIFF
--- a/frontend/src/pages/IntegrationsPage/Integrations.tsx
+++ b/frontend/src/pages/IntegrationsPage/Integrations.tsx
@@ -86,7 +86,6 @@ export const MICROSOFT_TEAMS_INTEGRATION: Integration = {
 	icon: MicrosoftTeamsLogo,
 	configurationPage: (opts) => <MicrosoftTeamsIntegrationConfig {...opts} />,
 	hasSettings: false,
-	onlyShowForHighlightAdmin: true,
 }
 
 export const LINEAR_INTEGRATION: IssueTrackerIntegration = {


### PR DESCRIPTION
## Summary
- already validated that MS Teams integration works correctly with our manually uploaded app in Prod
- submitted MS Teams plugin for approval, need to remove this so they are able to test
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ensured teams was visible on integrations page
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
