### PR TITLE
support backend url for sourcemap uploader

### DIFF
--- a/.changeset/mighty-ads-pump.md
+++ b/.changeset/mighty-ads-pump.md
@@ -1,0 +1,6 @@
+---
+'@highlight-run/next': patch
+'@highlight-run/sourcemap-uploader': patch
+---
+
+support backend url for sourcemap uploader for self-hosted deployments

--- a/docs-content/sdk/nextjs.md
+++ b/docs-content/sdk/nextjs.md
@@ -93,6 +93,10 @@ quickstart: true
       <h5>sourceMapsBasePath <code>string</code> <code>optional</code></h5>
       <p>Base path to append to your source map URLs when uploaded to Highlight.</p>
     </aside>
+    <aside className="parameter">
+      <h5>sourceMapsBackendUrl <code>string</code> <code>optional</code></h5>
+      <p>Backend url for private graph to use for uploading (for self-hosted highlight deployments).</p>
+    </aside>
   </div>
   <div className="right">
     <code>

--- a/sdk/highlight-next/src/util/highlight-webpack-plugin.ts
+++ b/sdk/highlight-next/src/util/highlight-webpack-plugin.ts
@@ -5,17 +5,20 @@ export default class HighlightWebpackPlugin {
 	appVersion: string
 	path: string
 	basePath: string
+	backendUrl?: string
 
 	constructor(
 		apiKey: string,
 		appVersion: string,
 		path: string,
 		basePath: string,
+		backendUrl?: string,
 	) {
 		this.apiKey = apiKey
 		this.appVersion = appVersion
 		this.path = path
 		this.basePath = basePath
+		this.backendUrl = backendUrl
 	}
 
 	apply(compiler: any) {
@@ -26,6 +29,7 @@ export default class HighlightWebpackPlugin {
 					appVersion: this.appVersion,
 					path: this.path,
 					basePath: this.basePath,
+					backendUrl: this.backendUrl,
 					allowNoop: true,
 				})
 			} catch (e) {

--- a/sdk/highlight-next/src/util/with-highlight-config.ts
+++ b/sdk/highlight-next/src/util/with-highlight-config.ts
@@ -12,6 +12,7 @@ interface HighlightConfigOptionsDefault {
 	serviceName: string
 	sourceMapsPath: string
 	sourceMapsBasePath: string
+	sourceMapsBackendUrl?: string
 }
 
 export interface HighlightConfigOptions {
@@ -56,6 +57,10 @@ export interface HighlightConfigOptions {
 	 * @default '_next/'
 	 */
 	sourceMapsBasePath?: string
+	/**
+	 * Optional, backend url for private graph to use for uploading (for self-hosted highlight deployments).
+	 */
+	sourceMapsBackendUrl?: string
 }
 
 const getDefaultOpts = async (
@@ -88,6 +93,7 @@ const getDefaultOpts = async (
 		serviceName: highlightOpts?.serviceName ?? '',
 		sourceMapsPath: highlightOpts?.sourceMapsPath ?? '.next/',
 		sourceMapsBasePath: highlightOpts?.sourceMapsBasePath ?? '_next/',
+		sourceMapsBackendUrl: highlightOpts?.sourceMapsBackendUrl,
 	}
 }
 
@@ -169,6 +175,7 @@ const getHighlightConfig = async (
 					defaultOpts.appVersion,
 					defaultOpts.sourceMapsPath,
 					defaultOpts.sourceMapsBasePath,
+					defaultOpts.sourceMapsBackendUrl,
 				),
 			)
 

--- a/sourcemap-uploader/src/index.ts
+++ b/sourcemap-uploader/src/index.ts
@@ -17,8 +17,11 @@ program
   )
   .option(
     "-bp, --basePath [string]",
-    "An optional base path for the uploaded sourcemaps",
-    ""
+    "An optional base path for the uploaded sourcemaps"
+  )
+  .option(
+    "-bu, --backendUrl [string]",
+    "An optional backend url for self-hosted deployments"
   )
   .action(uploadSourcemaps);
 

--- a/sourcemap-uploader/src/lib.ts
+++ b/sourcemap-uploader/src/lib.ts
@@ -21,12 +21,14 @@ export const uploadSourcemaps = async ({
   appVersion,
   path,
   basePath,
+  backendUrl,
   allowNoop,
 }: {
   apiKey: string;
   appVersion: string;
   path: string;
-  basePath: string;
+  basePath?: string;
+  backendUrl?: string;
   allowNoop?: boolean;
 }) => {
   if (!apiKey || apiKey === "") {
@@ -37,11 +39,12 @@ export const uploadSourcemaps = async ({
     }
   }
 
+  const backend = backendUrl || "https://pri.highlight.io";
   const variables = {
     api_key: apiKey,
   };
 
-  const res = await fetch("https://pri.highlight.io", {
+  const res = await fetch(backend, {
     method: "post",
     headers: {
       "Content-Type": "application/json",
@@ -84,10 +87,10 @@ export const uploadSourcemaps = async ({
   }
 
   const s3Keys = fileList.map(({ name }) =>
-    getS3Key(organizationId, appVersion, basePath, name)
+    getS3Key(organizationId, appVersion, basePath || "", name)
   );
 
-  const urlRes = await fetch("https://pri.highlight.io", {
+  const urlRes = await fetch(backend, {
     method: "post",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

Self-hosted deploys may need to upload highlight sourcemaps to their local highlight.
Support that via a backend url option.

## How did you test this change?

Local invocation of sourcemap uploader
![image](https://github.com/highlight/highlight/assets/1351531/fba9bc55-6c6d-4098-9f70-6a924156f6ff)


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
