### PR TITLE
fallback to main traces table if traces_by_id does not contain trace yet

### DIFF
--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -320,26 +320,7 @@ func (client *Client) ExistingTraceIds(ctx context.Context, projectID int, trace
 	return existingTraceIds, rows.Err()
 }
 
-func (client *Client) ReadTrace(ctx context.Context, projectID int, traceID string) ([]*modelInputs.Trace, error) {
-	sb := sqlbuilder.NewSelectBuilder()
-	var err error
-	var args []interface{}
-
-	sb.From(TracesByIdTable).
-		Select("Timestamp, UUID, TraceId, SpanId, ParentSpanId, ProjectId, SecureSessionId, TraceState, SpanName, SpanKind, Duration, ServiceName, ServiceVersion, Environment, HasErrors, TraceAttributes, StatusCode, StatusMessage").
-		Where(sb.Equal("ProjectId", projectID)).
-		Where(sb.Equal("TraceId", traceID))
-
-	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
-
-	span, _ := util.StartSpanFromContext(ctx, "traces", util.ResourceName("ReadTrace"))
-
-	rows, err := client.conn.Query(ctx, sql, args...)
-	if err != nil {
-		span.Finish(err)
-		return nil, err
-	}
-
+func getTracesFromRows(rows driver.Rows) ([]*modelInputs.Trace, error) {
 	var seenUUIDs = map[string]struct{}{}
 	var traces []*modelInputs.Trace
 	for rows.Next() {
@@ -381,9 +362,70 @@ func (client *Client) ReadTrace(ctx context.Context, projectID int, traceID stri
 		return a.Timestamp.Before(b.Timestamp)
 	})
 
-	span.Finish(rows.Err())
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
 
-	return traces, rows.Err()
+	return traces, nil
+}
+
+func (client *Client) ReadTrace(ctx context.Context, projectID int, traceID string) ([]*modelInputs.Trace, error) {
+	sb := sqlbuilder.NewSelectBuilder()
+	var err error
+	var args []interface{}
+
+	sb.From(TracesByIdTable).
+		Select("Timestamp, UUID, TraceId, SpanId, ParentSpanId, ProjectId, SecureSessionId, TraceState, SpanName, SpanKind, Duration, ServiceName, ServiceVersion, Environment, HasErrors, TraceAttributes, StatusCode, StatusMessage").
+		Where(sb.Equal("ProjectId", projectID)).
+		Where(sb.Equal("TraceId", traceID))
+
+	sql, args := sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+
+	span, _ := util.StartSpanFromContext(ctx, "traces", util.ResourceName("ReadTrace"))
+
+	rows, err := client.conn.Query(ctx, sql, args...)
+	if err != nil {
+		span.Finish(err)
+		return nil, err
+	}
+
+	traces, err := getTracesFromRows(rows)
+	if err != nil {
+		span.Finish(err)
+		return nil, err
+	}
+
+	span.Finish()
+
+	if len(traces) > 0 {
+		return traces, nil
+	}
+
+	span, _ = util.StartSpanFromContext(ctx, "traces", util.ResourceName("ReadTraceFallback"))
+
+	sb.From(TracesTable).
+		Select("Timestamp, UUID, TraceId, SpanId, ParentSpanId, ProjectId, SecureSessionId, TraceState, SpanName, SpanKind, Duration, ServiceName, ServiceVersion, Environment, HasErrors, TraceAttributes, StatusCode, StatusMessage").
+		Where(sb.Equal("ProjectId", projectID)).
+		Where(sb.Equal("TraceId", traceID)).
+		Where(sb.GE("Timestamp", time.Now().Add(-5*time.Minute))).
+		Where(sb.LE("Timestamp", time.Now()))
+
+	sql, args = sb.BuildWithFlavor(sqlbuilder.ClickHouse)
+
+	rows, err = client.conn.Query(ctx, sql, args...)
+	if err != nil {
+		span.Finish(err)
+		return nil, err
+	}
+
+	traces, err = getTracesFromRows(rows)
+	if err != nil {
+		span.Finish(err)
+		return nil, err
+	}
+
+	span.Finish()
+	return traces, nil
 }
 
 func (client *Client) ReadTracesMetrics(ctx context.Context, projectID int, params modelInputs.QueryInput, column string, metricTypes []modelInputs.MetricAggregator, groupBy []string, nBuckets *int, bucketBy string, limit *int, limitAggregator *modelInputs.MetricAggregator, limitColumn *string) (*modelInputs.MetricsBuckets, error) {


### PR DESCRIPTION
## Summary
- fixes issue where traces may be visible on the traces page but not possible to load from the `traces_by_id` table due to MV propagation delay
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- manually tested the fallback path locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
