### PR TITLE
React Server Components testbed + docs comments [HIG-4346]

### DIFF
--- a/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
@@ -176,6 +176,8 @@ export async function register() {
 
 App Router uses [app/error.tsx](https://nextjs.org/docs/app/api-reference/file-conventions/error) to send server-side render errors to the client. We can catch and consume those errors with a custom error page.
 
+This will captures any server-rendered error, including those generated from React Server Components, as sometimes identified with the `'use server'` directive.
+
 All SSR error will display as client errors on your Highlight dashboard.
 
 We don't call `H.init` in this example because we injected `<HighlightInit />` into the layout using `app/layout.tsx`.
@@ -218,25 +220,27 @@ export default appRouterSsrErrorHandler(
 
 ```jsx
 // app/app-router-ssr/page.tsx
+'use server'
+
 type Props = {
 	searchParams: { error?: string }
 }
 
-export default function SsrPage({ searchParams }: Props) {
-	if (typeof searchParams.error === 'string') {
-		throw new Error('SSR Error: app/app-router-ssr/page.tsx')
+export default async function SsrPage({ searchParams }: Props) {
+	if (searchParams.error) {
+		throw new Error(
+			'🎉 SSR Error with use-server: src/app-router/ssr/page.tsx',
+		)
 	}
 
 	return (
 		<div>
-			<h1>App Directory SSR: Success</h1>
+			<h1>App Router SSR with use-server: Success</h1>
 			<p>The random number is {Math.random()}</p>
 			<p>The date is {new Date().toLocaleTimeString()}</p>
 		</div>
 	)
 }
-
-export const revalidate = 30 // seconds
 ```
 
 ### Skip localhost tracking

--- a/e2e/nextjs/src/app/app-router/ssr/page.tsx
+++ b/e2e/nextjs/src/app/app-router/ssr/page.tsx
@@ -1,23 +1,24 @@
+'use server'
 import logger from '@/highlight.logger'
 
 type Props = {
 	searchParams: { error?: string }
 }
 
-export default function SsrPage({ searchParams }: Props) {
+export default async function SsrPage({ searchParams }: Props) {
 	logger.info({}, `ssr page`)
 
 	if (searchParams.error) {
-		throw new Error('🎉 SSR Error: src/app-router/ssr/page.tsx')
+		throw new Error(
+			'🎉 SSR Error with use-server: src/app-router/ssr/page.tsx',
+		)
 	}
 
 	return (
 		<div>
-			<h1>App Router SSR: Success</h1>
+			<h1>App Router SSR with use-server: Success</h1>
 			<p>The random number is {Math.random()}</p>
 			<p>The date is {new Date().toLocaleTimeString()}</p>
 		</div>
 	)
 }
-
-export const revalidate = 30 // seconds


### PR DESCRIPTION
It turns out that RSCs have worked for a long while. They get filtered through `app/error.tsx` and caught by `appRouterSsrErrorHandler` from `@highlight-run/next/ssr`.

![image](https://github.com/highlight/highlight/assets/878947/2548421a-91b2-4aba-9390-77a266d053a4)