### PR TITLE
Show tooltip when unexpectedly no errors

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6634,6 +6634,9 @@ body {
 ._1ubqgtn3 {
   padding: 6px;
 }
+.gmz6t00 {
+  display: inline-block;
+}
 .gmz6t00:first-of-type > button {
   border-right: none;
 }

--- a/frontend/src/components/TagGroup/index.tsx
+++ b/frontend/src/components/TagGroup/index.tsx
@@ -1,6 +1,5 @@
-import { Box, IconProps, Tag } from '@highlight-run/ui/components'
-
-import { Link } from '@/components/Link'
+import { Link } from '@components/Link'
+import { Box, IconProps, Tag, Tooltip } from '@highlight-run/ui/components'
 
 import * as styles from './style.css'
 
@@ -16,6 +15,7 @@ type TagLink = {
 	disabled: boolean
 	icon: React.ReactElement<IconProps>
 	label: string
+	tooltip?: string
 }
 
 type Props = {
@@ -36,15 +36,12 @@ export const TagGroup: React.FC<Props> = ({ tagLinks }) => {
 					shape = 'rightBasic'
 				}
 
-				const href = tag.disabled ? '' : tag.href
-
 				return (
-					<Link
-						to={href}
-						className={styles.tagLink}
+					<TagContainer
 						key={tag.key}
-						// reload document to avoid removing time parameters from the URL
-						reloadDocument
+						disabled={tag.disabled}
+						tooltip={tag.tooltip}
+						href={tag.href}
 					>
 						<Tag
 							{...TAG_PROPS}
@@ -54,9 +51,32 @@ export const TagGroup: React.FC<Props> = ({ tagLinks }) => {
 						>
 							{tag.label}
 						</Tag>
-					</Link>
+					</TagContainer>
 				)
 			})}
 		</Box>
+	)
+}
+
+const TagContainer: React.FC<any> = ({ children, tooltip, disabled, href }) => {
+	const tagWithTooltip = tooltip ? (
+		<Tooltip trigger={children}>{tooltip}</Tooltip>
+	) : (
+		children
+	)
+
+	if (disabled) {
+		return <span className={styles.tagLink}>{tagWithTooltip}</span>
+	}
+
+	return (
+		<Link
+			to={href}
+			className={styles.tagLink}
+			// reload document to avoid removing time parameters from the URL
+			reloadDocument
+		>
+			{tagWithTooltip}
+		</Link>
 	)
 }

--- a/frontend/src/components/TagGroup/style.css.ts
+++ b/frontend/src/components/TagGroup/style.css.ts
@@ -1,6 +1,8 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 
-export const tagLink = style({})
+export const tagLink = style({
+	display: 'inline-block',
+})
 
 globalStyle(`${tagLink}:first-of-type > button`, {
 	borderRight: 'none',

--- a/frontend/src/pages/Traces/RelatedResourceButtons/index.tsx
+++ b/frontend/src/pages/Traces/RelatedResourceButtons/index.tsx
@@ -13,6 +13,7 @@ type Props = {
 	traceId?: string
 	secureSessionId?: string
 	disableErrors: boolean
+	displayErrorTooltip?: boolean
 	startDate: Date
 	endDate: Date
 }
@@ -21,6 +22,7 @@ export const RelatedResourceButtons: React.FC<Props> = ({
 	traceId,
 	secureSessionId,
 	disableErrors,
+	displayErrorTooltip,
 	startDate,
 	endDate,
 }) => {
@@ -47,6 +49,9 @@ export const RelatedResourceButtons: React.FC<Props> = ({
 					disabled: errorLinkDisabled,
 					icon: <IconSolidLightningBolt />,
 					label: 'View errors',
+					tooltip: displayErrorTooltip
+						? 'Some errors may be filtered out due to your ingestion filter settings or exceeding your billing quota. Please reach out with any questions.'
+						: '',
 				},
 				{
 					key: 'session',

--- a/frontend/src/pages/Traces/TracePage.tsx
+++ b/frontend/src/pages/Traces/TracePage.tsx
@@ -39,6 +39,7 @@ export const TracePage: React.FC = () => {
 		traceName,
 		traceId,
 		secureSessionId,
+		selectedSpan,
 	} = useTrace()
 
 	useEffect(() => {
@@ -76,6 +77,9 @@ export const TracePage: React.FC = () => {
 						traceId={traceId}
 						secureSessionId={secureSessionId}
 						disableErrors={!errors?.length}
+						displayErrorTooltip={
+							selectedSpan?.hasErrors && !errors?.length
+						}
 						startDate={new Date(startTime)}
 						endDate={new Date(endTime)}
 					/>


### PR DESCRIPTION
## Summary
We determine if a trace has an error on the client, but these errors could have gotten dropped down the process due to filters, quotas, etc. We don't currently have a way to update the trace, but we want to give the user a little more information due to the mismatch in info. In the meantime, give the user a tooltip with more info if the trace has errors but none were found.

More relevant for Highlight project than customers

Long term fix: https://linear.app/highlight/issue/HIG-4300/some-traces-have-has-errors=true-but-no-linked-errors-when-clicking-in

## How did you test this change?
1) View traces
2) Click on a trace with no errors
- [ ] "See errors" link is disabled and unclickable
- [ ] Tooltip is NOT displayed on hover
3) Click on a trace that `has_errors-true` but no attached errors
- [ ] "See errors" link is disabled and unclickable
- [ ] Tooltip is displayed on hover
4) Click on a trace that has_errors=true` and an attached error
- [ ] "See error" link is enabled and clickable
- [ ] Tooltip is NOT displayed on hover

https://www.loom.com/share/4e0c1e5d76d84540b64148c31f9ed689?sid=50cd786f-fc27-4505-b53a-5c8d969b6bf8

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
