### PR TITLE
keep console object serialized as json for body with sdk

### DIFF
--- a/.changeset/chatty-colts-argue.md
+++ b/.changeset/chatty-colts-argue.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': minor
+---
+
+allow customizing log attribute serialization

--- a/e2e/express/src/index.mjs
+++ b/e2e/express/src/index.mjs
@@ -3,7 +3,7 @@ import { H, Handlers } from '@highlight-run/node'
 
 /** @type {import('@highlight-run/node').NodeOptions} */
 const config = {
-	projectID: '2',
+	projectID: '1',
 	debug: true,
 	serviceName: 'e2e-express',
 	serviceVersion: 'git-sha',

--- a/e2e/express/src/index.mjs
+++ b/e2e/express/src/index.mjs
@@ -7,7 +7,7 @@ const config = {
 	debug: true,
 	serviceName: 'e2e-express',
 	serviceVersion: 'git-sha',
-	// otlpEndpoint: 'http://localhost:4318',
+	otlpEndpoint: 'http://localhost:4318',
 	environment: 'e2e-test',
 	serializeConsoleAttributes: true,
 }

--- a/e2e/express/src/index.mjs
+++ b/e2e/express/src/index.mjs
@@ -3,14 +3,17 @@ import { H, Handlers } from '@highlight-run/node'
 
 /** @type {import('@highlight-run/node').NodeOptions} */
 const config = {
-	projectID: '1',
+	projectID: '2',
 	debug: true,
 	serviceName: 'e2e-express',
 	serviceVersion: 'git-sha',
-	otlpEndpoint: 'http://localhost:4318',
+	// otlpEndpoint: 'http://localhost:4318',
 	environment: 'e2e-test',
+	serializeConsoleAttributes: true,
 }
+console.log(`before init`, { hello: `hello` })
 H.init(config)
+console.log(`after init`, { hello: `hello` })
 
 const app = express()
 const port = 3003
@@ -18,6 +21,7 @@ const port = 3003
 // This should be before any controllers (route definitions)
 app.use(Handlers.middleware(config))
 app.get('/', (req, res) => {
+	console.info('info from /')
 	const err = new Error('this is a test error')
 	const { secureSessionId, requestId } = H.parseHeaders(req.headers)
 	if (secureSessionId && requestId) {
@@ -40,8 +44,10 @@ app.get('/good', (req, res) => {
 
 // This should be before any other error middleware and after all controllers (route definitions)
 app.use(Handlers.errorHandler(config))
+console.log(`listen`, { hello: `hello` })
+console.log({ message: 'world', hello: `hello`, number: '123' })
 app.listen(port, () => {
-	console.log(`Example app listening on port ${port}`)
+	console.log(`startServer`, { at: `0.0.0.0:${port}` })
 })
 
 process.on('SIGINT', function () {

--- a/e2e/tests/src/test_sdk.py
+++ b/e2e/tests/src/test_sdk.py
@@ -140,7 +140,7 @@ def test_express_log(express_app, oauth_api):
                 data["logs"]["edges"],
             )
         )
-        exp = "some work happening {\"result\":"
+        exp = 'some work happening {"result":'
         for msg in msgs:
             if exp in msg:
                 break

--- a/e2e/tests/src/test_sdk.py
+++ b/e2e/tests/src/test_sdk.py
@@ -140,8 +140,13 @@ def test_express_log(express_app, oauth_api):
                 data["logs"]["edges"],
             )
         )
-        exp = "some work happening"
-        assert exp in msgs
+        exp = "some work happening {\"result\":"
+        for msg in msgs:
+            if exp in msg:
+                break
+        else:
+            assert False, f"expected message not found: {msgs}"
+
         for item in filter(
             lambda eg: eg["node"]["message"] == exp, data["logs"]["edges"]
         ):

--- a/e2e/tests/src/test_sdk.py
+++ b/e2e/tests/src/test_sdk.py
@@ -141,7 +141,7 @@ def test_express_log(express_app, oauth_api):
             )
         )
 
-        exp = 'some work happening'
+        exp = "some work happening"
         if express_app_type == "express_js":
             exp = 'some work happening {"result":'
 

--- a/e2e/tests/src/test_sdk.py
+++ b/e2e/tests/src/test_sdk.py
@@ -140,12 +140,16 @@ def test_express_log(express_app, oauth_api):
                 data["logs"]["edges"],
             )
         )
-        exp = 'some work happening {"result":'
+
+        exp = 'some work happening'
+        if express_app_type == "express_js":
+            exp = 'some work happening {"result":'
+
         for msg in msgs:
             if exp in msg:
                 break
         else:
-            assert False, f"expected message not found: {msgs}"
+            assert False, f"expected message {exp} not found: {msgs}"
 
         for item in filter(
             lambda eg: eg["node"]["message"] == exp, data["logs"]["edges"]

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -154,7 +154,7 @@ export class Highlight {
 		}
 
 		if (!options.disableConsoleRecording) {
-			hookConsole(options.consoleMethodsToRecord, (c) => {
+			hookConsole(options, (c) => {
 				this.log(
 					c.date,
 					c.message,

--- a/sdk/highlight-node/src/hooks.ts
+++ b/sdk/highlight-node/src/hooks.ts
@@ -1,6 +1,6 @@
 // inspired by https://github.com/getsentry/sentry-javascript/issues/5639
 
-import { NodeOptions, SerializationMode } from './types'
+import { NodeOptions } from './types'
 
 // https://stackoverflow.com/a/2805230
 const MAX_RECURSION = 128

--- a/sdk/highlight-node/src/hooks.ts
+++ b/sdk/highlight-node/src/hooks.ts
@@ -1,5 +1,7 @@
 // inspired by https://github.com/getsentry/sentry-javascript/issues/5639
 
+import { NodeOptions, SerializationMode } from './types'
+
 // https://stackoverflow.com/a/2805230
 const MAX_RECURSION = 128
 
@@ -77,13 +79,16 @@ export function safeStringify(obj: any): string {
 }
 
 export function hookConsole(
-	methodsToRecord: string[] | undefined,
+	options: NodeOptions,
 	cb: (cb: ConsolePayload) => void,
 ) {
 	if (consoleHooked) return
 	consoleHooked = true
 	for (const [level, highlightLevel] of Object.entries(ConsoleLevels)) {
-		if (methodsToRecord?.length && methodsToRecord.indexOf(level) === -1) {
+		if (
+			options.consoleMethodsToRecord?.length &&
+			(options.consoleMethodsToRecord as string[]).indexOf(level) === -1
+		) {
 			continue
 		}
 		const origWrite = console[level as keyof Console] as ConsoleFn
@@ -96,13 +101,17 @@ export function hookConsole(
 			} finally {
 				const o: { stack: any } = { stack: {} }
 				Error.captureStackTrace(o)
+				const message = options.serializeConsoleAttributes
+					? data.map((o) =>
+							typeof o === 'object' ? safeStringify(o) : o,
+					  )
+					: data
+							.filter((d) => typeof d !== 'object')
+							.map((o) => `${o}`)
 				cb({
 					date,
 					level: highlightLevel,
-					message: data
-						.filter((d) => typeof d !== 'object')
-						.map((o) => `${o}`)
-						.join(' '),
+					message: message.join(' '),
 					attributes: data
 						.filter((d) => typeof d === 'object')
 						.reduce((a, b) => ({ ...a, ...b }), {}),

--- a/sdk/highlight-node/src/types.ts
+++ b/sdk/highlight-node/src/types.ts
@@ -40,6 +40,11 @@ export interface NodeOptions extends HighlightOptions {
 	 * Attributes to be added to the OpenTelemetry Resource.
 	 */
 	attributes?: Attributes
+
+	/**
+	 * Set to try to serialize console object arguments into the message body.
+	 */
+	serializeConsoleAttributes?: boolean
 }
 
 export interface HighlightContext {


### PR DESCRIPTION
## Summary

* Adds the `serializeConsoleAttributes` option to the node sdk `H.init` to allow serializing attributes into the message body.

## How did you test this change?

![image](https://github.com/highlight/highlight/assets/1351531/65b183e8-82bc-48b3-8de4-ec24ebb09dd3)

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
