### PR TITLE
Support matching regex in searches

### DIFF
--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -80,11 +80,13 @@ const EXISTS_OPERATORS = ['EXISTS', 'NOT EXISTS'] as const
 const NUMERIC_OPERATORS = ['>', '>=', '<', '<='] as const
 const BOOLEAN_OPERATORS = ['=', '!='] as const
 const CONTAINS_OPERATOR = ['=**', '!=**'] as const
+const MATCHES_OPERATOR = ['=//', '!=//'] as const
 export const SEARCH_OPERATORS = [
 	...BOOLEAN_OPERATORS,
 	...NUMERIC_OPERATORS,
 	...EXISTS_OPERATORS,
 	...CONTAINS_OPERATOR,
+	...MATCHES_OPERATOR,
 ] as const
 export type SearchOperator = typeof SEARCH_OPERATORS[number]
 
@@ -311,6 +313,7 @@ export const Search: React.FC<{
 						...BOOLEAN_OPERATORS,
 						...EXISTS_OPERATORS,
 						...CONTAINS_OPERATOR,
+						...MATCHES_OPERATOR,
 				  ]
 
 		visibleItems = operators.map((operator) => ({
@@ -435,8 +438,11 @@ export const Search: React.FC<{
 			const isExists = !!EXISTS_OPERATORS.find((eo) => eo === item.name)
 			const space = isExists ? ' ' : ''
 
-			const isContains = !!CONTAINS_OPERATOR.find((c) => c === item.name)
-			if (isContains) {
+			const isContainsOrMatches = !![
+				...CONTAINS_OPERATOR,
+				...MATCHES_OPERATOR,
+			].find((o) => o === item.name)
+			if (isContainsOrMatches) {
 				cursorShift = -1
 			}
 
@@ -892,6 +898,10 @@ const getSearchResultBadgeText = (key: SearchResult) => {
 				return 'contains'
 			case '!=**':
 				return 'does not contain'
+			case '=//':
+				return 'matches'
+			case '!=//':
+				return 'does not match'
 		}
 	} else if (key.type === 'Value') {
 		return undefined


### PR DESCRIPTION
## Summary
Support matching regex in the logs and traces search, and add a shortcut operator.

https://www.loom.com/share/acd783b81a1d4df6825a8bb4f31f56e8?sid=75469963-6482-42bc-becd-710f19e87ea8

## How did you test this change?
1) Navigate to the logs/traces page
2) Select a string key to search by
- [ ] "Matches" operator is displayed
- [ ] "Does not match" operator is displayed
4) Click on the "Contains" operator
- [ ] Correct operator is displayed `=//`
- [ ] Cursor is placed between `/`
5) Search for part of a string
- [ ] Correct results
6) Repeat for "does not match"
- [ ] "Does not contain" works as aspected

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
