### PR TITLE
Fix cursor jumping in search

### DIFF
--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -280,6 +280,7 @@ export const Search: React.FC<{
 	const { queryParts, tokens } = parseSearch(query)
 	const tokenGroups = buildTokenGroups(tokens, queryParts, query)
 	const activePart = getActivePart(cursorIndex, queryParts)
+	console.log('aaaaa', 'activePart', activePart, cursorIndex)
 	const { debouncedValue, setDebouncedValue } = useDebounce<string>(
 		activePart.value,
 	)
@@ -331,6 +332,12 @@ export const Search: React.FC<{
 
 	const handleSetCursorIndex = () => {
 		if (!isPending) {
+			console.log(
+				'aaaaa',
+				'handleSetCursorIndex',
+				inputRef.current?.selectionStart,
+				query.length,
+			)
 			setCursorIndex(inputRef.current?.selectionStart || query.length)
 		}
 	}
@@ -415,6 +422,7 @@ export const Search: React.FC<{
 		const noActiveId = !activeId || !items.find((i) => i.id === activeId)
 
 		if (activePart.text.trim() !== '' && noActiveId && firstItem) {
+			console.log('aaaaa', 'setting activeId', firstItem)
 			comboboxStore.setActiveId(firstItem.id)
 			comboboxStore.setState('moves', 0)
 		}
@@ -445,15 +453,36 @@ export const Search: React.FC<{
 
 			activePart.operator = item.name
 			activePart.text = `${key}${space}${activePart.operator}`
+			console.log(
+				'aaaaa',
+				'creatingOperator',
+				activePart,
+				activePart.start,
+				activePart.text.length,
+			)
 			activePart.stop = activePart.start + activePart.text.length
 		} else if (isValueSelect) {
 			activePart.value = quoteQueryValue(item.name)
 			activePart.text = `${activePart.key}${activePart.operator}${activePart.value}`
+			console.log(
+				'aaaaa',
+				'creatingValue',
+				activePart,
+				activePart.start,
+				activePart.text.length,
+			)
 			activePart.stop = activePart.start + activePart.text.length
 		} else {
 			activePart.key = item.name
 			activePart.text = item.name
 			activePart.value = ''
+			console.log(
+				'aaaaa',
+				'creatingKey',
+				activePart,
+				activePart.start,
+				activePart.text.length,
+			)
 			activePart.stop = activePart.start + activePart.key.length
 		}
 
@@ -462,6 +491,12 @@ export const Search: React.FC<{
 
 		startTransition(() => {
 			setQuery(newQuery)
+			console.log(
+				'aaaaa',
+				'startTransition',
+				activePart,
+				newCursorPosition,
+			)
 			setCursorIndex(newCursorPosition)
 
 			if (isValueSelect) {
@@ -800,6 +835,7 @@ const getActivePart = (
 	let activePartIndex
 
 	queryParts.find((param, index) => {
+		console.log('aaaaa', 'param', param, cursorIndex)
 		if (param.stop < cursorIndex - 1) {
 			return false
 		}
@@ -808,14 +844,15 @@ const getActivePart = (
 		return true
 	})
 
+	console.log('aaaaa', 'activePartIndex', activePartIndex, queryParts)
 	if (activePartIndex === undefined) {
 		const activePart = {
 			key: BODY_KEY,
 			operator: DEFAULT_OPERATOR,
 			value: '',
 			text: '',
-			start: 1,
-			stop: 1,
+			start: cursorIndex,
+			stop: cursorIndex,
 		}
 		queryParts.push(activePart)
 		return activePart

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -280,7 +280,6 @@ export const Search: React.FC<{
 	const { queryParts, tokens } = parseSearch(query)
 	const tokenGroups = buildTokenGroups(tokens, queryParts, query)
 	const activePart = getActivePart(cursorIndex, queryParts)
-	console.log('aaaaa', 'activePart', activePart, cursorIndex)
 	const { debouncedValue, setDebouncedValue } = useDebounce<string>(
 		activePart.value,
 	)
@@ -332,12 +331,6 @@ export const Search: React.FC<{
 
 	const handleSetCursorIndex = () => {
 		if (!isPending) {
-			console.log(
-				'aaaaa',
-				'handleSetCursorIndex',
-				inputRef.current?.selectionStart,
-				query.length,
-			)
 			setCursorIndex(inputRef.current?.selectionStart || query.length)
 		}
 	}
@@ -422,7 +415,6 @@ export const Search: React.FC<{
 		const noActiveId = !activeId || !items.find((i) => i.id === activeId)
 
 		if (activePart.text.trim() !== '' && noActiveId && firstItem) {
-			console.log('aaaaa', 'setting activeId', firstItem)
 			comboboxStore.setActiveId(firstItem.id)
 			comboboxStore.setState('moves', 0)
 		}
@@ -453,36 +445,15 @@ export const Search: React.FC<{
 
 			activePart.operator = item.name
 			activePart.text = `${key}${space}${activePart.operator}`
-			console.log(
-				'aaaaa',
-				'creatingOperator',
-				activePart,
-				activePart.start,
-				activePart.text.length,
-			)
 			activePart.stop = activePart.start + activePart.text.length
 		} else if (isValueSelect) {
 			activePart.value = quoteQueryValue(item.name)
 			activePart.text = `${activePart.key}${activePart.operator}${activePart.value}`
-			console.log(
-				'aaaaa',
-				'creatingValue',
-				activePart,
-				activePart.start,
-				activePart.text.length,
-			)
 			activePart.stop = activePart.start + activePart.text.length
 		} else {
 			activePart.key = item.name
 			activePart.text = item.name
 			activePart.value = ''
-			console.log(
-				'aaaaa',
-				'creatingKey',
-				activePart,
-				activePart.start,
-				activePart.text.length,
-			)
 			activePart.stop = activePart.start + activePart.key.length
 		}
 
@@ -491,12 +462,6 @@ export const Search: React.FC<{
 
 		startTransition(() => {
 			setQuery(newQuery)
-			console.log(
-				'aaaaa',
-				'startTransition',
-				activePart,
-				newCursorPosition,
-			)
 			setCursorIndex(newCursorPosition)
 
 			if (isValueSelect) {
@@ -835,7 +800,6 @@ const getActivePart = (
 	let activePartIndex
 
 	queryParts.find((param, index) => {
-		console.log('aaaaa', 'param', param, cursorIndex)
 		if (param.stop < cursorIndex - 1) {
 			return false
 		}
@@ -844,7 +808,6 @@ const getActivePart = (
 		return true
 	})
 
-	console.log('aaaaa', 'activePartIndex', activePartIndex, queryParts)
 	if (activePartIndex === undefined) {
 		const activePart = {
 			key: BODY_KEY,

--- a/frontend/src/components/Search/utils.ts
+++ b/frontend/src/components/Search/utils.ts
@@ -37,13 +37,15 @@ export const parseSearch = (input: string) => {
 	ParseTreeWalker.DEFAULT.walk(listener, tree)
 
 	if (input.trim() === '') {
+		const bodyPosition = Math.max(0, input.length - 1)
+
 		queryParts.push({
 			key: BODY_KEY,
 			operator: DEFAULT_OPERATOR,
 			value: '',
 			text: '',
-			start: input.length - 1,
-			stop: input.length - 1,
+			start: bodyPosition,
+			stop: bodyPosition,
 		})
 	}
 


### PR DESCRIPTION
## Summary
There is some jumpiness in when selecting consecutive keys in search. Fix some of the logic to avoid jumping back in the search query

https://www.loom.com/share/243c2e5a7f7c4ffcbc12613d92e5a5a6?sid=7566fcb0-283d-419a-baca-1325336087ba

## How did you test this change?
1. Select a key (preferable a long one for the second part, e.g. `environment`)
- [ ] Cursor jumps to end of key
2. Select an operator
- [ ] Cursor jumps to correct position
3) Select a value
- [ ] Cursor jumps to end of value
4) Press space and select another key (shorter than current key + value length, e.g. `level`)
- [ ] Cursor jumps to end of active key

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
