### PR TITLE
filter network request recording for highlight.io traffic

### DIFF
--- a/.changeset/eight-dingos-hammer.md
+++ b/.changeset/eight-dingos-hammer.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+filter network request recording for highlight.io traffic

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/mail"
+	url2 "net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -3100,6 +3101,9 @@ func (r *Resolver) submitFrontendNetworkMetric(sessionObj *model.Session, resour
 		}
 		start := re.Start(sessionObj.CreatedAt)
 		end := re.End(sessionObj.CreatedAt)
+		if url, err := url2.Parse(re.Name); err == nil && url.Host == "pub.highlight.io" {
+			continue
+		}
 		attributes := []attribute.KeyValue{}
 		attributes = append(attributes, highlight.EmptyResourceAttributes...)
 		attributes = append(attributes, attribute.String(highlight.TraceTypeAttribute, string(highlight.TraceTypeNetworkRequest)),

--- a/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
+++ b/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
@@ -1,6 +1,7 @@
 import { useAuthContext } from '@authentication/AuthContext'
 import { useGetProjectQuery } from '@graph/hooks'
 import analytics from '@util/analytics'
+import { isOnPrem } from '@util/onPrem/onPremUtils'
 import { useParams } from '@util/react-router/useParams'
 import { useEffect, useState } from 'react'
 
@@ -117,7 +118,7 @@ const useFeatureFlag = (feature: Feature, override?: boolean) => {
 		skip: !project_id,
 	})
 
-	const [isOn, setIsOn] = useState<boolean>(!!override)
+	const [isOn, setIsOn] = useState<boolean>(!isOnPrem && !!override)
 
 	useEffect(() => {
 		isFeatureOn(

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -140,7 +140,8 @@ if (dev) {
 	}
 } else if (
 	window.location.href.includes('onrender') ||
-	window.location.href.includes('preview')
+	window.location.href.includes('preview') ||
+	shouldDebugLog
 ) {
 	if (favicon) {
 		favicon.href = `/favicon-pr.ico`

--- a/sdk/client/src/listeners/network-listener/utils/utils.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.ts
@@ -236,9 +236,9 @@ const isHighlightNetworkResourceFilter = (name: string, backendUrl: string) =>
 	name
 		.toLocaleLowerCase()
 		.includes(
-			import.meta.env.REACT_APP_PUBLIC_GRAPH_URI ?? 'highlight.run',
+			import.meta.env.REACT_APP_PUBLIC_GRAPH_URI ?? 'highlight.io',
 		) ||
-	name.toLocaleLowerCase().includes('highlight.run') ||
+	name.toLocaleLowerCase().includes('highlight.io') ||
 	name.toLocaleLowerCase().includes(backendUrl)
 
 export const shouldNetworkRequestBeRecorded = (


### PR DESCRIPTION
## Summary

Avoid capturing traces / network request payloads for highlight.io traffic.

## How did you test this change?

reflame preview

before
<img width="799" alt="Screenshot 2024-02-27 at 07 50 10" src="https://github.com/highlight/highlight/assets/1351531/d0623984-89f5-41d9-bfba-2d36c95103d3">


after
![image](https://github.com/highlight/highlight/assets/1351531/591a8908-1fd3-48cf-b80b-0b589b371cdc)

closes HIG-4364

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
