### PR TITLE
Display inline search result attributes

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -6575,6 +6575,7 @@ body {
 }
 .g2tqod2 {
   border-bottom: 1px solid var(--_1pyqka9k) !important;
+  background-color: var(--_1pyqka92);
 }
 .szxd8q0 .szxd8q0 {
   padding-left: 22px;

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -5354,10 +5354,6 @@ body {
   border: var(--_1pyqka91r) solid 1px;
   color: var(--_1pyqka9x);
 }
-.om6zxf0 {
-  padding: 8px;
-  border-radius: 6px;
-}
 .om6zxf0:hover {
   background: var(--_1pyqka91x);
 }

--- a/frontend/src/pages/LogsPage/LogsTable/CustomColumns/renderers.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/CustomColumns/renderers.tsx
@@ -52,11 +52,14 @@ const SessionColumnRenderer: React.FC<ColumnRendererProps> = ({
 				navigate(`/${log.projectID}/sessions/${secureSessionID}`)
 		  }
 		: undefined
+	const paddingProps = secureSessionID
+		? { pt: '4' as const, pb: '0' as const }
+		: null
 
 	return (
-		<Table.Cell alignItems="flex-start" onClick={onClick} py="4">
-			<span>
-				{secureSessionID ? (
+		<Table.Cell alignItems="flex-start" onClick={onClick} {...paddingProps}>
+			{secureSessionID ? (
+				<span>
 					<Tag
 						kind="secondary"
 						shape="basic"
@@ -64,10 +67,10 @@ const SessionColumnRenderer: React.FC<ColumnRendererProps> = ({
 					>
 						<Text lines="1">{secureSessionID}</Text>
 					</Tag>
-				) : (
-					<EmptyState />
-				)}
-			</span>
+				</span>
+			) : (
+				<EmptyState />
+			)}
 		</Table.Cell>
 	)
 }

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -424,7 +424,8 @@ export const LogValue: React.FC<{
 	queryParts: SearchExpression[]
 	queryKey: string
 	queryMatch?: string
-}> = ({ label, queryKey, queryParts, value, queryMatch }) => {
+	hideActions?: boolean
+}> = ({ label, queryKey, queryParts, value, queryMatch, hideActions }) => {
 	const [_, setQuery] = useQueryParam('query', QueryParam)
 
 	// replace wildcards for highlighting.
@@ -461,82 +462,84 @@ export const LogValue: React.FC<{
 						)}
 					</Text>
 				</Box>
-				<Box cssClass={styles.attributeActions}>
-					<Box>
-						<Tooltip
-							trigger={
-								<IconSolidFilter
-									className={styles.attributeAction}
-									size="12"
-									onClick={() => {
-										if (!queryParts) {
-											return
-										}
+				{!hideActions && (
+					<Box cssClass={styles.attributeActions}>
+						<Box>
+							<Tooltip
+								trigger={
+									<IconSolidFilter
+										className={styles.attributeAction}
+										size="12"
+										onClick={() => {
+											if (!queryParts) {
+												return
+											}
 
-										const index = queryParts.findIndex(
-											(term) => term.key === queryKey,
-										)
+											const index = queryParts.findIndex(
+												(term) => term.key === queryKey,
+											)
 
-										if (index !== -1) {
-											queryParts[index].value = value
-										}
+											if (index !== -1) {
+												queryParts[index].value = value
+											}
 
-										let newQuery =
-											stringifySearchQuery(queryParts)
+											let newQuery =
+												stringifySearchQuery(queryParts)
 
-										if (index === -1) {
-											newQuery += ` ${queryKey}${DEFAULT_OPERATOR}${quoteQueryValue(
-												value,
-											)}`
+											if (index === -1) {
+												newQuery += ` ${queryKey}${DEFAULT_OPERATOR}${quoteQueryValue(
+													value,
+												)}`
 
-											newQuery = newQuery.trim()
-										}
+												newQuery = newQuery.trim()
+											}
 
-										setQuery(newQuery)
-										analytics.track(
-											'logs_apply-filter_click',
-										)
-									}}
-								/>
-							}
-							delayed
-						>
-							<Box p="4">
-								<Text userSelect="none" color="n11">
-									Apply as filter
-								</Text>
-							</Box>
-						</Tooltip>
+											setQuery(newQuery)
+											analytics.track(
+												'logs_apply-filter_click',
+											)
+										}}
+									/>
+								}
+								delayed
+							>
+								<Box p="4">
+									<Text userSelect="none" color="n11">
+										Apply as filter
+									</Text>
+								</Box>
+							</Tooltip>
+						</Box>
+						<Box>
+							<Tooltip
+								trigger={
+									<IconSolidClipboardCopy
+										className={styles.attributeAction}
+										size="12"
+										onClick={() => {
+											navigator.clipboard.writeText(
+												quoteQueryValue(value),
+											)
+											antdMessage.success(
+												'Value copied to your clipboard',
+											)
+											analytics.track(
+												'logs_copy-to-clipboard_click',
+											)
+										}}
+									/>
+								}
+								delayed
+							>
+								<Box p="4">
+									<Text userSelect="none" color="n11">
+										Copy to your clipboard
+									</Text>
+								</Box>
+							</Tooltip>
+						</Box>
 					</Box>
-					<Box>
-						<Tooltip
-							trigger={
-								<IconSolidClipboardCopy
-									className={styles.attributeAction}
-									size="12"
-									onClick={() => {
-										navigator.clipboard.writeText(
-											quoteQueryValue(value),
-										)
-										antdMessage.success(
-											'Value copied to your clipboard',
-										)
-										analytics.track(
-											'logs_copy-to-clipboard_click',
-										)
-									}}
-								/>
-							}
-							delayed
-						>
-							<Box p="4">
-								<Text userSelect="none" color="n11">
-									Copy to your clipboard
-								</Text>
-							</Box>
-						</Tooltip>
-					</Box>
-				</Box>
+				)}
 			</Box>
 		</LogAttributeLine>
 	)

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.css.ts
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.css.ts
@@ -17,4 +17,5 @@ export const dataRow = style({
 
 export const attributesRow = style({
 	borderBottom: `1px solid ${vars.theme.static.divider.weak} !important`,
+	backgroundColor: vars.theme.static.surface.raised,
 })

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -429,18 +429,35 @@ const LogsTableRow = React.memo<LogsTableRowProps>(
 					{(rowExpanded || hasAttributes) && (
 						<Table.Cell py="4" pl="32">
 							{!rowExpanded && (
-								<Box>
+								<Box display="flex" flexWrap="wrap">
 									{Object.entries(matchedAttributes).map(
-										([key, { match, value }]) => {
+										([key, { match, value }], index) => {
 											return (
-												<LogValue
-													key={key}
-													label={key}
-													value={value}
-													queryKey={key}
-													queryMatch={match}
-													queryParts={queryParts}
-												/>
+												<>
+													{index > 0 && (
+														<Box
+															display="flex"
+															alignItems="center"
+															pr="8"
+														>
+															<Text
+																weight="bold"
+																color="weak"
+															>
+																;
+															</Text>
+														</Box>
+													)}
+													<LogValue
+														key={key}
+														label={key}
+														value={value}
+														queryKey={key}
+														queryMatch={match}
+														queryParts={queryParts}
+														hideActions
+													/>
+												</>
 											)
 										},
 									)}

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -425,50 +425,62 @@ const LogsTableRow = React.memo<LogsTableRowProps>(
 			const hasAttributes = Object.entries(matchedAttributes).length > 0
 
 			return (
-				<Table.Row selected={expanded} className={styles.attributesRow}>
+				<Table.Row
+					selected={expanded}
+					className={styles.attributesRow}
+					gridColumns={['32px', '1fr']}
+				>
 					{(rowExpanded || hasAttributes) && (
-						<Table.Cell py="4" pl="32">
-							{!rowExpanded && (
-								<Box display="flex" flexWrap="wrap">
-									{Object.entries(matchedAttributes).map(
-										([key, { match, value }], index) => {
-											return (
-												<>
-													{index > 0 && (
-														<Box
-															display="flex"
-															alignItems="center"
-															pr="8"
-														>
-															<Text
-																weight="bold"
-																color="weak"
+						<>
+							<Table.Cell />
+							<Table.Cell py="4" borderTop="dividerWeak">
+								{!rowExpanded && (
+									<Box display="flex" flexWrap="wrap">
+										{Object.entries(matchedAttributes).map(
+											(
+												[key, { match, value }],
+												index,
+											) => {
+												return (
+													<>
+														{index > 0 && (
+															<Box
+																display="flex"
+																alignItems="center"
+																pr="8"
 															>
-																;
-															</Text>
-														</Box>
-													)}
-													<LogValue
-														key={key}
-														label={key}
-														value={value}
-														queryKey={key}
-														queryMatch={match}
-														queryParts={queryParts}
-														hideActions
-													/>
-												</>
-											)
-										},
-									)}
-								</Box>
-							)}
-							<LogDetails
-								matchedAttributes={matchedAttributes}
-								row={row}
-								queryParts={queryParts}
-							/>
-						</Table.Cell>
+																<Text
+																	weight="bold"
+																	color="weak"
+																>
+																	;
+																</Text>
+															</Box>
+														)}
+														<LogValue
+															key={key}
+															label={key}
+															value={value}
+															queryKey={key}
+															queryMatch={match}
+															queryParts={
+																queryParts
+															}
+															hideActions
+														/>
+													</>
+												)
+											},
+										)}
+									</Box>
+								)}
+								<LogDetails
+									matchedAttributes={matchedAttributes}
+									row={row}
+									queryParts={queryParts}
+								/>
+							</Table.Cell>
+						</>
 					)}
 				</Table.Row>
 			)

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -432,7 +432,7 @@ const LogsTableRow = React.memo<LogsTableRowProps>(
 				>
 					{(rowExpanded || hasAttributes) && (
 						<>
-							<Table.Cell />
+							<Table.Cell py="4" />
 							<Table.Cell py="4" borderTop="dividerWeak">
 								{!rowExpanded && (
 									<Box display="flex" flexWrap="wrap">

--- a/frontend/src/pages/Traces/CustomColumns/renderers.tsx
+++ b/frontend/src/pages/Traces/CustomColumns/renderers.tsx
@@ -1,6 +1,7 @@
 import {
 	Badge,
 	Box,
+	BoxProps,
 	IconSolidMenuAlt_2,
 	IconSolidPlayCircle,
 	Stack,
@@ -15,16 +16,23 @@ import { Trace } from '@/graph/generated/schemas'
 import { getTraceDurationString } from '@/pages/Traces/utils'
 import analytics from '@/util/analytics'
 
+type PaddingProps = {
+	pt: BoxProps['p']
+	pb: BoxProps['p']
+}
+
 type ColumnWrapperProps = {
 	children: React.ReactNode
 	first: boolean
 	row: any
+	paddingProps?: PaddingProps
 	onClick?: () => void
 }
 
 const ColumnWrapper: React.FC<ColumnWrapperProps> = ({
 	children,
 	first,
+	paddingProps,
 	row,
 	onClick,
 }) => {
@@ -33,7 +41,7 @@ const ColumnWrapper: React.FC<ColumnWrapperProps> = ({
 
 	if (!first) {
 		return (
-			<Table.Cell onClick={onClick}>
+			<Table.Cell onClick={onClick} {...paddingProps}>
 				<span>{children}</span>
 			</Table.Cell>
 		)
@@ -48,7 +56,10 @@ const ColumnWrapper: React.FC<ColumnWrapperProps> = ({
 	}
 
 	return (
-		<Table.Cell onClick={() => viewTrace(row.original.node)}>
+		<Table.Cell
+			onClick={() => viewTrace(row.original.node)}
+			{...paddingProps}
+		>
 			<Box
 				display="flex"
 				alignItems="center"
@@ -135,9 +146,17 @@ const SessionColumnRenderer: React.FC<ColumnRendererProps> = ({
 				navigate(`/${trace.projectID}/sessions/${secureSessionID}`)
 		  }
 		: undefined
+	const paddingProps = secureSessionID
+		? { pt: '4' as const, pb: '0' as const }
+		: undefined
 
 	return (
-		<ColumnWrapper first={first} row={row} onClick={onClick}>
+		<ColumnWrapper
+			first={first}
+			row={row}
+			onClick={onClick}
+			paddingProps={paddingProps}
+		>
 			{secureSessionID ? (
 				<Tag
 					kind="secondary"

--- a/packages/ui/src/components/Table/Cell/Cell.tsx
+++ b/packages/ui/src/components/Table/Cell/Cell.tsx
@@ -17,8 +17,8 @@ export const Cell: React.FC<Props> = ({ children, icon, ...boxProps }) => {
 			alignItems="center"
 			cursor={boxProps.onClick ? 'pointer' : undefined}
 			gap="6"
-			cssClass={styles.cell}
 			{...boxProps}
+			cssClass={styles.cell}
 		>
 			{icon && (
 				<Box as="span" display="inline-flex">

--- a/packages/ui/src/components/Table/Cell/Cell.tsx
+++ b/packages/ui/src/components/Table/Cell/Cell.tsx
@@ -18,6 +18,8 @@ export const Cell: React.FC<Props> = ({ children, icon, ...boxProps }) => {
 			cursor={boxProps.onClick ? 'pointer' : undefined}
 			gap="6"
 			cssClass={styles.cell}
+			borderRadius="6"
+			p="8"
 			{...boxProps}
 		>
 			{icon && (

--- a/packages/ui/src/components/Table/Cell/Cell.tsx
+++ b/packages/ui/src/components/Table/Cell/Cell.tsx
@@ -5,7 +5,7 @@ import * as styles from './styles.css'
 
 export interface Props
 	extends Omit<BoxProps, 'display' | 'flexDirection' | 'gap' | 'cssClass'> {
-	children: React.ReactNode
+	children?: React.ReactNode
 	icon?: React.ReactNode
 }
 

--- a/packages/ui/src/components/Table/Cell/Cell.tsx
+++ b/packages/ui/src/components/Table/Cell/Cell.tsx
@@ -17,8 +17,8 @@ export const Cell: React.FC<Props> = ({ children, icon, ...boxProps }) => {
 			alignItems="center"
 			cursor={boxProps.onClick ? 'pointer' : undefined}
 			gap="6"
-			{...boxProps}
 			cssClass={styles.cell}
+			{...boxProps}
 		>
 			{icon && (
 				<Box as="span" display="inline-flex">

--- a/packages/ui/src/components/Table/Cell/styles.css.ts
+++ b/packages/ui/src/components/Table/Cell/styles.css.ts
@@ -2,8 +2,6 @@ import { style } from '@vanilla-extract/css'
 import { vars } from '../../../css/vars'
 
 export const cell = style({
-	padding: 8,
-	borderRadius: 6,
 	selectors: {
 		'&:hover': {
 			background: vars.theme.interactive.overlay.secondary.hover,


### PR DESCRIPTION
## Summary
Show the matched attributes in a single line underneath each row to use the space more efficiently.

https://www.loom.com/share/922a8d28067f4f1ab774dd67db5000aa?sid=e8b38230-9420-4b5a-a211-816d3a866b79

## How did you test this change?
1. View the logs table
2. Search by an attribute
- [ ] Attribute is displayed underneath each row
- [ ] No `;` is rendered
3. Add another search attribute
- [ ] Attribute is added underneath in the same row
- [ ] Separated by a `;`
4. Add another attribute
- [ ] Attribute is added underneath in the same row (breaks to new row if needed)
- [ ] Separated by a `;`

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
Yes - https://www.figma.com/file/rdBPNzn7Klk6RG1LHUCE5B/Screen-Designs?node-id=15015%3A163252&mode=dev