### PR TITLE
Update IsIntegrated logic to pull from setup_events table

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -969,7 +969,6 @@ type ComplexityRoot struct {
 		HeightWorkspaces                 func(childComplexity int, workspaceID int) int
 		IdentifierSuggestion             func(childComplexity int, projectID int, query string) int
 		IntegrationProjectMappings       func(childComplexity int, workspaceID int, integrationType *model.IntegrationType) int
-		IsIntegrated                     func(childComplexity int, projectID int) int
 		IsIntegratedWith                 func(childComplexity int, integrationType model.IntegrationType, projectID int) int
 		IsProjectIntegratedWith          func(childComplexity int, integrationType model.IntegrationType, projectID int) int
 		IsSessionPending                 func(childComplexity int, sessionSecureID string) int
@@ -1742,7 +1741,6 @@ type QueryResolver interface {
 	ErrorCommentsForProject(ctx context.Context, projectID int) ([]*model1.ErrorComment, error)
 	WorkspaceAdmins(ctx context.Context, workspaceID int) ([]*model1.WorkspaceAdminRole, error)
 	WorkspaceAdminsByProjectID(ctx context.Context, projectID int) ([]*model1.WorkspaceAdminRole, error)
-	IsIntegrated(ctx context.Context, projectID int) (*bool, error)
 	ClientIntegration(ctx context.Context, projectID int) (*model.IntegrationStatus, error)
 	ServerIntegration(ctx context.Context, projectID int) (*model.IntegrationStatus, error)
 	LogsIntegration(ctx context.Context, projectID int) (*model.IntegrationStatus, error)
@@ -7129,18 +7127,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.IntegrationProjectMappings(childComplexity, args["workspace_id"].(int), args["integration_type"].(*model.IntegrationType)), true
 
-	case "Query.isIntegrated":
-		if e.complexity.Query.IsIntegrated == nil {
-			break
-		}
-
-		args, err := ec.field_Query_isIntegrated_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.IsIntegrated(childComplexity, args["project_id"].(int)), true
-
 	case "Query.is_integrated_with":
 		if e.complexity.Query.IsIntegratedWith == nil {
 			break
@@ -12524,7 +12510,6 @@ type Query {
 	error_comments_for_project(project_id: ID!): [ErrorComment]!
 	workspace_admins(workspace_id: ID!): [WorkspaceAdminRole!]!
 	workspace_admins_by_project_id(project_id: ID!): [WorkspaceAdminRole!]!
-	isIntegrated(project_id: ID!): Boolean
 	clientIntegration(project_id: ID!): IntegrationStatus!
 	serverIntegration(project_id: ID!): IntegrationStatus!
 	logsIntegration(project_id: ID!): IntegrationStatus!
@@ -18055,21 +18040,6 @@ func (ec *executionContext) field_Query_integration_project_mappings_args(ctx co
 		}
 	}
 	args["integration_type"] = arg1
-	return args, nil
-}
-
-func (ec *executionContext) field_Query_isIntegrated_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 int
-	if tmp, ok := rawArgs["project_id"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
-		arg0, err = ec.unmarshalNID2int(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["project_id"] = arg0
 	return args, nil
 }
 
@@ -50250,57 +50220,6 @@ func (ec *executionContext) fieldContext_Query_workspace_admins_by_project_id(ct
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_workspace_admins_by_project_id_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Query_isIntegrated(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_isIntegrated(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().IsIntegrated(rctx, fc.Args["project_id"].(int))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*bool)
-	fc.Result = res
-	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_isIntegrated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_isIntegrated_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -83340,26 +83259,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_workspace_admins_by_project_id(ctx, field)
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return rrm(innerCtx)
-			})
-		case "isIntegrated":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_isIntegrated(ctx, field)
 				return res
 			}
 

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -969,7 +969,6 @@ type ComplexityRoot struct {
 		HeightWorkspaces                 func(childComplexity int, workspaceID int) int
 		IdentifierSuggestion             func(childComplexity int, projectID int, query string) int
 		IntegrationProjectMappings       func(childComplexity int, workspaceID int, integrationType *model.IntegrationType) int
-		IsBackendIntegrated              func(childComplexity int, projectID int) int
 		IsIntegrated                     func(childComplexity int, projectID int) int
 		IsIntegratedWith                 func(childComplexity int, integrationType model.IntegrationType, projectID int) int
 		IsProjectIntegratedWith          func(childComplexity int, integrationType model.IntegrationType, projectID int) int
@@ -1744,7 +1743,6 @@ type QueryResolver interface {
 	WorkspaceAdmins(ctx context.Context, workspaceID int) ([]*model1.WorkspaceAdminRole, error)
 	WorkspaceAdminsByProjectID(ctx context.Context, projectID int) ([]*model1.WorkspaceAdminRole, error)
 	IsIntegrated(ctx context.Context, projectID int) (*bool, error)
-	IsBackendIntegrated(ctx context.Context, projectID int) (*bool, error)
 	ClientIntegration(ctx context.Context, projectID int) (*model.IntegrationStatus, error)
 	ServerIntegration(ctx context.Context, projectID int) (*model.IntegrationStatus, error)
 	LogsIntegration(ctx context.Context, projectID int) (*model.IntegrationStatus, error)
@@ -7130,18 +7128,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.IntegrationProjectMappings(childComplexity, args["workspace_id"].(int), args["integration_type"].(*model.IntegrationType)), true
-
-	case "Query.isBackendIntegrated":
-		if e.complexity.Query.IsBackendIntegrated == nil {
-			break
-		}
-
-		args, err := ec.field_Query_isBackendIntegrated_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.IsBackendIntegrated(childComplexity, args["project_id"].(int)), true
 
 	case "Query.isIntegrated":
 		if e.complexity.Query.IsIntegrated == nil {
@@ -12539,7 +12525,6 @@ type Query {
 	workspace_admins(workspace_id: ID!): [WorkspaceAdminRole!]!
 	workspace_admins_by_project_id(project_id: ID!): [WorkspaceAdminRole!]!
 	isIntegrated(project_id: ID!): Boolean
-	isBackendIntegrated(project_id: ID!): Boolean
 	clientIntegration(project_id: ID!): IntegrationStatus!
 	serverIntegration(project_id: ID!): IntegrationStatus!
 	logsIntegration(project_id: ID!): IntegrationStatus!
@@ -18070,21 +18055,6 @@ func (ec *executionContext) field_Query_integration_project_mappings_args(ctx co
 		}
 	}
 	args["integration_type"] = arg1
-	return args, nil
-}
-
-func (ec *executionContext) field_Query_isBackendIntegrated_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 int
-	if tmp, ok := rawArgs["project_id"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
-		arg0, err = ec.unmarshalNID2int(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["project_id"] = arg0
 	return args, nil
 }
 
@@ -50331,57 +50301,6 @@ func (ec *executionContext) fieldContext_Query_isIntegrated(ctx context.Context,
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_isIntegrated_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Query_isBackendIntegrated(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_isBackendIntegrated(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().IsBackendIntegrated(rctx, fc.Args["project_id"].(int))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*bool)
-	fc.Result = res
-	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_isBackendIntegrated(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_isBackendIntegrated_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -83441,26 +83360,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_isIntegrated(ctx, field)
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return rrm(innerCtx)
-			})
-		case "isBackendIntegrated":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_isBackendIntegrated(ctx, field)
 				return res
 			}
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1864,7 +1864,6 @@ type Query {
 	workspace_admins(workspace_id: ID!): [WorkspaceAdminRole!]!
 	workspace_admins_by_project_id(project_id: ID!): [WorkspaceAdminRole!]!
 	isIntegrated(project_id: ID!): Boolean
-	isBackendIntegrated(project_id: ID!): Boolean
 	clientIntegration(project_id: ID!): IntegrationStatus!
 	serverIntegration(project_id: ID!): IntegrationStatus!
 	logsIntegration(project_id: ID!): IntegrationStatus!

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1863,7 +1863,6 @@ type Query {
 	error_comments_for_project(project_id: ID!): [ErrorComment]!
 	workspace_admins(workspace_id: ID!): [WorkspaceAdminRole!]!
 	workspace_admins_by_project_id(project_id: ID!): [WorkspaceAdminRole!]!
-	isIntegrated(project_id: ID!): Boolean
 	clientIntegration(project_id: ID!): IntegrationStatus!
 	serverIntegration(project_id: ID!): IntegrationStatus!
 	logsIntegration(project_id: ID!): IntegrationStatus!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5191,24 +5191,6 @@ func (r *queryResolver) WorkspaceAdminsByProjectID(ctx context.Context, projectI
 	return r.WorkspaceAdmins(ctx, workspace.ID)
 }
 
-// IsIntegrated is the resolver for the isIntegrated field.
-func (r *queryResolver) IsIntegrated(ctx context.Context, projectID int) (*bool, error) {
-	if _, err := r.isAdminInProjectOrDemoProject(ctx, projectID); err != nil {
-		return nil, nil
-	}
-
-	firstSetupEvent := model.SetupEvent{}
-	err := r.DB.WithContext(ctx).Model(&model.SetupEvent{}).Where("project_id = ?", projectID).Take(&firstSetupEvent).Error
-	if e.Is(err, gorm.ErrRecordNotFound) {
-		return &model.F, nil
-	}
-	if err != nil {
-		return nil, e.Wrap(err, "error querying setup event for project")
-	}
-
-	return &model.T, nil
-}
-
 // ClientIntegration is the resolver for the clientIntegration field.
 func (r *queryResolver) ClientIntegration(ctx context.Context, projectID int) (*modelInputs.IntegrationStatus, error) {
 	integration := &modelInputs.IntegrationStatus{

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5209,22 +5209,6 @@ func (r *queryResolver) IsIntegrated(ctx context.Context, projectID int) (*bool,
 	return &model.T, nil
 }
 
-// IsBackendIntegrated is the resolver for the isBackendIntegrated field.
-func (r *queryResolver) IsBackendIntegrated(ctx context.Context, projectID int) (*bool, error) {
-	if _, err := r.isAdminInProjectOrDemoProject(ctx, projectID); err != nil {
-		return nil, nil
-	}
-	var count int64
-	err := r.DB.WithContext(ctx).Model(&model.Project{}).Where("id = ? AND backend_setup=true", projectID).Count(&count).Error
-	if err != nil {
-		return nil, e.Wrap(err, "error getting projects with backend flag")
-	}
-	if count > 0 {
-		return &model.T, nil
-	}
-	return &model.F, nil
-}
-
 // ClientIntegration is the resolver for the clientIntegration field.
 func (r *queryResolver) ClientIntegration(ctx context.Context, projectID int) (*modelInputs.IntegrationStatus, error) {
 	integration := &modelInputs.IntegrationStatus{

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -5197,13 +5197,13 @@ func (r *queryResolver) IsIntegrated(ctx context.Context, projectID int) (*bool,
 		return nil, nil
 	}
 
-	firstSession := model.Session{}
-	err := r.DB.WithContext(ctx).Model(&model.Session{}).Where("project_id = ?", projectID).Take(&firstSession).Error
+	firstSetupEvent := model.SetupEvent{}
+	err := r.DB.WithContext(ctx).Model(&model.SetupEvent{}).Where("project_id = ?", projectID).Take(&firstSetupEvent).Error
 	if e.Is(err, gorm.ErrRecordNotFound) {
 		return &model.F, nil
 	}
 	if err != nil {
-		return nil, e.Wrap(err, "error querying session for project")
+		return nil, e.Wrap(err, "error querying setup event for project")
 	}
 
 	return &model.T, nil

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -6765,77 +6765,6 @@ export type GetEnhancedUserDetailsQueryResult = Apollo.QueryResult<
 	Types.GetEnhancedUserDetailsQuery,
 	Types.GetEnhancedUserDetailsQueryVariables
 >
-export const GetOnboardingStepsDocument = gql`
-	query GetOnboardingSteps($project_id: ID!, $admin_id: ID!) {
-		workspace: workspace_for_project(project_id: $project_id) {
-			id
-			slack_channels
-		}
-		admins: workspace_admins_by_project_id(project_id: $project_id) {
-			admin {
-				id
-			}
-		}
-		isIntegrated(project_id: $project_id)
-		adminHasCreatedComment(admin_id: $admin_id)
-		projectHasViewedASession(project_id: $project_id) {
-			secure_id
-		}
-		admin {
-			slack_im_channel_id
-		}
-	}
-`
-
-/**
- * __useGetOnboardingStepsQuery__
- *
- * To run a query within a React component, call `useGetOnboardingStepsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetOnboardingStepsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetOnboardingStepsQuery({
- *   variables: {
- *      project_id: // value for 'project_id'
- *      admin_id: // value for 'admin_id'
- *   },
- * });
- */
-export function useGetOnboardingStepsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.GetOnboardingStepsQuery,
-		Types.GetOnboardingStepsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.GetOnboardingStepsQuery,
-		Types.GetOnboardingStepsQueryVariables
-	>(GetOnboardingStepsDocument, baseOptions)
-}
-export function useGetOnboardingStepsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.GetOnboardingStepsQuery,
-		Types.GetOnboardingStepsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.GetOnboardingStepsQuery,
-		Types.GetOnboardingStepsQueryVariables
-	>(GetOnboardingStepsDocument, baseOptions)
-}
-export type GetOnboardingStepsQueryHookResult = ReturnType<
-	typeof useGetOnboardingStepsQuery
->
-export type GetOnboardingStepsLazyQueryHookResult = ReturnType<
-	typeof useGetOnboardingStepsLazyQuery
->
-export type GetOnboardingStepsQueryResult = Apollo.QueryResult<
-	Types.GetOnboardingStepsQuery,
-	Types.GetOnboardingStepsQueryVariables
->
 export const SendAdminWorkspaceInviteDocument = gql`
 	mutation SendAdminWorkspaceInvite(
 		$workspace_id: ID!
@@ -9984,60 +9913,6 @@ export type GetSavedSegmentsLazyQueryHookResult = ReturnType<
 export type GetSavedSegmentsQueryResult = Apollo.QueryResult<
 	Types.GetSavedSegmentsQuery,
 	Types.GetSavedSegmentsQueryVariables
->
-export const IsIntegratedDocument = gql`
-	query IsIntegrated($project_id: ID!) {
-		isIntegrated(project_id: $project_id)
-	}
-`
-
-/**
- * __useIsIntegratedQuery__
- *
- * To run a query within a React component, call `useIsIntegratedQuery` and pass it any options that fit your needs.
- * When your component renders, `useIsIntegratedQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useIsIntegratedQuery({
- *   variables: {
- *      project_id: // value for 'project_id'
- *   },
- * });
- */
-export function useIsIntegratedQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.IsIntegratedQuery,
-		Types.IsIntegratedQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.IsIntegratedQuery,
-		Types.IsIntegratedQueryVariables
-	>(IsIntegratedDocument, baseOptions)
-}
-export function useIsIntegratedLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.IsIntegratedQuery,
-		Types.IsIntegratedQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.IsIntegratedQuery,
-		Types.IsIntegratedQueryVariables
-	>(IsIntegratedDocument, baseOptions)
-}
-export type IsIntegratedQueryHookResult = ReturnType<
-	typeof useIsIntegratedQuery
->
-export type IsIntegratedLazyQueryHookResult = ReturnType<
-	typeof useIsIntegratedLazyQuery
->
-export type IsIntegratedQueryResult = Apollo.QueryResult<
-	Types.IsIntegratedQuery,
-	Types.IsIntegratedQueryVariables
 >
 export const GetClientIntegrationDocument = gql`
 	query GetClientIntegration($project_id: ID!) {

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -10039,60 +10039,6 @@ export type IsIntegratedQueryResult = Apollo.QueryResult<
 	Types.IsIntegratedQuery,
 	Types.IsIntegratedQueryVariables
 >
-export const IsBackendIntegratedDocument = gql`
-	query IsBackendIntegrated($project_id: ID!) {
-		isBackendIntegrated(project_id: $project_id)
-	}
-`
-
-/**
- * __useIsBackendIntegratedQuery__
- *
- * To run a query within a React component, call `useIsBackendIntegratedQuery` and pass it any options that fit your needs.
- * When your component renders, `useIsBackendIntegratedQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useIsBackendIntegratedQuery({
- *   variables: {
- *      project_id: // value for 'project_id'
- *   },
- * });
- */
-export function useIsBackendIntegratedQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.IsBackendIntegratedQuery,
-		Types.IsBackendIntegratedQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.IsBackendIntegratedQuery,
-		Types.IsBackendIntegratedQueryVariables
-	>(IsBackendIntegratedDocument, baseOptions)
-}
-export function useIsBackendIntegratedLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.IsBackendIntegratedQuery,
-		Types.IsBackendIntegratedQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.IsBackendIntegratedQuery,
-		Types.IsBackendIntegratedQueryVariables
-	>(IsBackendIntegratedDocument, baseOptions)
-}
-export type IsBackendIntegratedQueryHookResult = ReturnType<
-	typeof useIsBackendIntegratedQuery
->
-export type IsBackendIntegratedLazyQueryHookResult = ReturnType<
-	typeof useIsBackendIntegratedLazyQuery
->
-export type IsBackendIntegratedQueryResult = Apollo.QueryResult<
-	Types.IsBackendIntegratedQuery,
-	Types.IsBackendIntegratedQueryVariables
->
 export const GetClientIntegrationDocument = gql`
 	query GetClientIntegration($project_id: ID!) {
 		clientIntegration(project_id: $project_id) {

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -2169,34 +2169,6 @@ export type GetEnhancedUserDetailsQuery = { __typename?: 'Query' } & {
 	>
 }
 
-export type GetOnboardingStepsQueryVariables = Types.Exact<{
-	project_id: Types.Scalars['ID']
-	admin_id: Types.Scalars['ID']
-}>
-
-export type GetOnboardingStepsQuery = { __typename?: 'Query' } & Pick<
-	Types.Query,
-	'isIntegrated' | 'adminHasCreatedComment'
-> & {
-		workspace?: Types.Maybe<
-			{ __typename?: 'Workspace' } & Pick<
-				Types.Workspace,
-				'id' | 'slack_channels'
-			>
-		>
-		admins: Array<
-			{ __typename?: 'WorkspaceAdminRole' } & {
-				admin: { __typename?: 'Admin' } & Pick<Types.Admin, 'id'>
-			}
-		>
-		projectHasViewedASession?: Types.Maybe<
-			{ __typename?: 'Session' } & Pick<Types.Session, 'secure_id'>
-		>
-		admin?: Types.Maybe<
-			{ __typename?: 'Admin' } & Pick<Types.Admin, 'slack_im_channel_id'>
-		>
-	}
-
 export type SendAdminWorkspaceInviteMutationVariables = Types.Exact<{
 	workspace_id: Types.Scalars['ID']
 	email: Types.Scalars['String']
@@ -3444,15 +3416,6 @@ export type GetSavedSegmentsQuery = { __typename?: 'Query' } & {
 		>
 	>
 }
-
-export type IsIntegratedQueryVariables = Types.Exact<{
-	project_id: Types.Scalars['ID']
-}>
-
-export type IsIntegratedQuery = { __typename?: 'Query' } & Pick<
-	Types.Query,
-	'isIntegrated'
->
 
 export type GetClientIntegrationQueryVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
@@ -4996,7 +4959,6 @@ export const namedOperations = {
 		GetErrorComments: 'GetErrorComments' as const,
 		GetErrorIssues: 'GetErrorIssues' as const,
 		GetEnhancedUserDetails: 'GetEnhancedUserDetails' as const,
-		GetOnboardingSteps: 'GetOnboardingSteps' as const,
 		GetSessionIntervals: 'GetSessionIntervals' as const,
 		GetTimelineIndicatorEvents: 'GetTimelineIndicatorEvents' as const,
 		GetWebSocketEvents: 'GetWebSocketEvents' as const,
@@ -5043,7 +5005,6 @@ export const namedOperations = {
 		GetSegments: 'GetSegments' as const,
 		GetErrorSegments: 'GetErrorSegments' as const,
 		GetSavedSegments: 'GetSavedSegments' as const,
-		IsIntegrated: 'IsIntegrated' as const,
 		GetClientIntegration: 'GetClientIntegration' as const,
 		GetServerIntegration: 'GetServerIntegration' as const,
 		GetLogsIntegration: 'GetLogsIntegration' as const,

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -3454,15 +3454,6 @@ export type IsIntegratedQuery = { __typename?: 'Query' } & Pick<
 	'isIntegrated'
 >
 
-export type IsBackendIntegratedQueryVariables = Types.Exact<{
-	project_id: Types.Scalars['ID']
-}>
-
-export type IsBackendIntegratedQuery = { __typename?: 'Query' } & Pick<
-	Types.Query,
-	'isBackendIntegrated'
->
-
 export type GetClientIntegrationQueryVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 }>
@@ -5053,7 +5044,6 @@ export const namedOperations = {
 		GetErrorSegments: 'GetErrorSegments' as const,
 		GetSavedSegments: 'GetSavedSegments' as const,
 		IsIntegrated: 'IsIntegrated' as const,
-		IsBackendIntegrated: 'IsBackendIntegrated' as const,
 		GetClientIntegration: 'GetClientIntegration' as const,
 		GetServerIntegration: 'GetServerIntegration' as const,
 		GetLogsIntegration: 'GetLogsIntegration' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1884,7 +1884,6 @@ export type Query = {
 	height_workspaces: Array<HeightWorkspace>
 	identifier_suggestion: Array<Scalars['String']>
 	integration_project_mappings: Array<IntegrationProjectMapping>
-	isBackendIntegrated?: Maybe<Scalars['Boolean']>
 	isIntegrated?: Maybe<Scalars['Boolean']>
 	isSessionPending?: Maybe<Scalars['Boolean']>
 	is_integrated_with: Scalars['Boolean']
@@ -2275,10 +2274,6 @@ export type QueryIdentifier_SuggestionArgs = {
 export type QueryIntegration_Project_MappingsArgs = {
 	integration_type?: InputMaybe<IntegrationType>
 	workspace_id: Scalars['ID']
-}
-
-export type QueryIsBackendIntegratedArgs = {
-	project_id: Scalars['ID']
 }
 
 export type QueryIsIntegratedArgs = {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1884,7 +1884,6 @@ export type Query = {
 	height_workspaces: Array<HeightWorkspace>
 	identifier_suggestion: Array<Scalars['String']>
 	integration_project_mappings: Array<IntegrationProjectMapping>
-	isIntegrated?: Maybe<Scalars['Boolean']>
 	isSessionPending?: Maybe<Scalars['Boolean']>
 	is_integrated_with: Scalars['Boolean']
 	is_project_integrated_with: Scalars['Boolean']
@@ -2274,10 +2273,6 @@ export type QueryIdentifier_SuggestionArgs = {
 export type QueryIntegration_Project_MappingsArgs = {
 	integration_type?: InputMaybe<IntegrationType>
 	workspace_id: Scalars['ID']
-}
-
-export type QueryIsIntegratedArgs = {
-	project_id: Scalars['ID']
 }
 
 export type QueryIsSessionPendingArgs = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -480,26 +480,6 @@ query GetEnhancedUserDetails($session_secure_id: String!) {
 	}
 }
 
-query GetOnboardingSteps($project_id: ID!, $admin_id: ID!) {
-	workspace: workspace_for_project(project_id: $project_id) {
-		id
-		slack_channels
-	}
-	admins: workspace_admins_by_project_id(project_id: $project_id) {
-		admin {
-			id
-		}
-	}
-	isIntegrated(project_id: $project_id)
-	adminHasCreatedComment(admin_id: $admin_id)
-	projectHasViewedASession(project_id: $project_id) {
-		secure_id
-	}
-	admin {
-		slack_im_channel_id
-	}
-}
-
 mutation SendAdminWorkspaceInvite(
 	$workspace_id: ID!
 	$email: String!
@@ -1382,10 +1362,6 @@ query GetSavedSegments(
 			query
 		}
 	}
-}
-
-query IsIntegrated($project_id: ID!) {
-	isIntegrated(project_id: $project_id)
 }
 
 query GetClientIntegration($project_id: ID!) {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -1388,10 +1388,6 @@ query IsIntegrated($project_id: ID!) {
 	isIntegrated(project_id: $project_id)
 }
 
-query IsBackendIntegrated($project_id: ID!) {
-	isBackendIntegrated(project_id: $project_id)
-}
-
 query GetClientIntegration($project_id: ID!) {
 	clientIntegration(project_id: $project_id) {
 		integrated

--- a/frontend/src/pages/Home/HomePageV2.tsx
+++ b/frontend/src/pages/Home/HomePageV2.tsx
@@ -3,7 +3,7 @@ import LoadingBox from '@components/LoadingBox'
 import { useProjectId } from '@hooks/useProjectId'
 import DashboardPage from '@pages/Dashboards/pages/Dashboard/DashboardPage'
 import analytics from '@util/analytics'
-import { useIntegrated } from '@util/integrated'
+import { useClientIntegration } from '@util/integrated'
 import Lottie from 'lottie-react'
 import React, { useEffect } from 'react'
 import { Helmet } from 'react-helmet'
@@ -17,7 +17,7 @@ const HomePageV2 = () => {
 	useEffect(() => analytics.page('Analytics'), [])
 
 	const { projectId } = useProjectId()
-	const { integrated, loading: integratedLoading } = useIntegrated()
+	const { integrated, loading: integratedLoading } = useClientIntegration()
 
 	if (integratedLoading) {
 		return <LoadingBox />

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -36,7 +36,7 @@ import { Box } from '@highlight-run/ui/components'
 import { SessionFeedCard } from '@pages/Sessions/SessionsFeedV3/SessionFeedCard/SessionFeedCard'
 import SessionQueryBuilder from '@pages/Sessions/SessionsFeedV3/SessionQueryBuilder/SessionQueryBuilder'
 import { useGlobalContext } from '@routers/ProjectRouter/context/GlobalContext'
-import { useIntegrated } from '@util/integrated'
+import { useClientIntegration } from '@util/integrated'
 import { useParams } from '@util/react-router/useParams'
 import { usePollQuery } from '@util/search'
 import { roundFeedDate } from '@util/time'
@@ -159,7 +159,7 @@ export const SessionFeedV3 = React.memo(() => {
 		setSearchResultsCount,
 		rebaseTime,
 	} = useSearchContext()
-	const { integrated } = useIntegrated()
+	const { integrated } = useClientIntegration()
 	const { showLeftPanel } = usePlayerConfiguration()
 	const { showBanner } = useGlobalContext()
 	const searchParamsChanged = useRef<Date>()


### PR DESCRIPTION
## Summary

While pairing w/ @Vadman97 we noticed that the logic for `IsIntegrated` was only checking if we had any sessions for a project to determine if they are integrated at all. This logic is incorrect, and we determined we wanted to check if we had _any_ setup events for the project to say whether they have integrated.

Once I started looking at this I realized it doesn't seems like we need the `IsIntegrated` method at all anymore since we are using more specific checks to determine whether a project has integrated sessions/errors/logs. I ended up doing a brief audit of the usage of `IsIntegrated` and determined it would be more appropriate to use `useClientIntegration` instead and remove it entirely. I also cleaned up the logic for `IsBackendIntegrated` since we are using the `(Client|Server)Integration` methods instead now.

Also, while click testing the logic changes here, I noticed an issue with how we fetch data for our integration bar on the setup page. I filed [a ticket](https://linear.app/highlight/issue/HIG-4396/integration-bar-re-rendering-too-often-and-triggering-tons-of-queries) to follow up on that next cycle.

## How did you test this change?

I did some local click testing on the sessions, analytics, and setup pages, since those are the places where this logic was being hit.

## Are there any deployment considerations?

Don't believe there is anything we need to monitor here. Just want to make sure that all integration status checks are still working as expected.

## Does this work require review from our design team?

Nope!
