### PR TITLE
check if teams id is nil

### DIFF
--- a/backend/alerts/integrations/microsoft-teams/bot_messages.go
+++ b/backend/alerts/integrations/microsoft-teams/bot_messages.go
@@ -85,6 +85,11 @@ func (bot *MicrosoftTeamsBot) SendMessageWithAdaptiveCard(channelId string, rawT
 }
 
 func SendLogAlertsWelcomeMessage(ctx context.Context, alert *model.LogAlert, input *WelcomeMessageData) error {
+	// Return if workspace is not integrated with Teams
+	if input.Workspace.MicrosoftTeamsTenantId == nil {
+		return nil
+	}
+
 	bot, err := NewMicrosoftTeamsBot(*input.Workspace.MicrosoftTeamsTenantId)
 	if err != nil {
 		return errors.New("microsoft teams bot installation not complete")


### PR DESCRIPTION
## Summary
- was causing a bug where a nil pointer would occur after creating a log alert
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested alert creating
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
