### PR TITLE
fix docker compose hobby envs duplicates

### DIFF
--- a/docker/compose.hobby.yml
+++ b/docker/compose.hobby.yml
@@ -29,8 +29,6 @@ x-backend-env: &backend-env
         - IN_DOCKER
         - IN_DOCKER_GO
         - JIRA_CLIENT_ID
-        - JIRA_CLIENT_ID
-        - JIRA_CLIENT_SECRET
         - JIRA_CLIENT_SECRET
         - KAFKA_SERVERS
         - KAFKA_TOPIC


### PR DESCRIPTION
## Summary
Fixes error thrown during running `run-hobby.sh`
```
Highlight infrastructure started
+ docker compose -f compose.hobby.yml pull
/highlight/docker/compose.hobby.yml: services.backend.environment array items[31,32] must be unique
```
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
Running `run-hobby.sh` locally again
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
no
<!--
 Request review from julian-highlight / our design team 
-->
