### PR TITLE
document fluentforward tls configuration

### DIFF
--- a/highlight.io/components/QuickstartContent/logging/docker.tsx
+++ b/highlight.io/components/QuickstartContent/logging/docker.tsx
@@ -26,7 +26,7 @@ export const DockerContent: QuickStartContent = {
   &highlight-logging
     driver: fluentd
     options:
-        fluentd-address: "otel.highlight.io:24224"
+        fluentd-address: "tls://otel.highlight.io:24284"
         fluentd-async: "true"
         fluentd-sub-second-precision: "true"
         tag: "highlight.project_id=<YOUR_PROJECT_ID>"

--- a/highlight.io/components/QuickstartContent/logging/fluentd.tsx
+++ b/highlight.io/components/QuickstartContent/logging/fluentd.tsx
@@ -52,6 +52,24 @@ export const FluentForwardContent: QuickStartContent = {
 			],
 		},
 		{
+			title: '(Optional) Configure Fluent Forward over TLS.',
+			content:
+				'If you want to transfer data over a secure TLS connection, change the `[OUTPUT]` to the following (using port 24284)',
+			code: [
+				{
+					text: `[OUTPUT]
+    Name                forward
+    Match               *
+    Host                otel.highlight.io
+    Port                24284
+    tls                 on
+    tls.verify          on
+`,
+					language: 'yaml',
+				},
+			],
+		},
+		{
 			title: 'Setting up for AWS ECS?',
 			content:
 				'If you are setting up for AWS Elastic Container Services, check out our dedicated [docs for AWS ECS.](/docs/getting-started/backend-logging/hosting/aws#aws-ecs-containers) .',


### PR DESCRIPTION
## Summary

Set up new TLS listener for fluentforward on port 24284

## How did you test this change?

Local docker deploy sending to new port

![image](https://github.com/highlight/highlight/assets/1351531/e5bb88ee-f58a-4c1e-a84d-358676602e76)

![image](https://github.com/highlight/highlight/assets/1351531/6ee45eee-ddad-4714-a24f-e3a045880d1e)


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no