### PR TITLE
Password auth bugfixes and improvements

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -50,6 +50,7 @@ import { AUTH_MODE, PUBLIC_GRAPH_URI } from '@/constants'
 import { SIGN_IN_ROUTE } from '@/pages/Auth/AuthRouter'
 import { authRedirect } from '@/pages/Auth/utils'
 import { onlyAllowHighlightStaff } from '@/util/authorization/authorizationUtils'
+import { passwordAuthTokenManager } from '@/util/passowordAuthCookies'
 
 document.body.className = 'highlight-light-theme'
 
@@ -287,7 +288,7 @@ const AuthenticationRoleRouter = () => {
 	const isLoggedIn = authRole === AuthRole.AUTHENTICATED
 
 	useEffect(() => {
-		const hasPasswordAuthorization = sessionStorage.getItem('passwordToken')
+		const hasPasswordAuthorization = passwordAuthTokenManager.get()
 		if (AUTH_MODE === 'password' && !hasPasswordAuthorization) {
 			auth.signOut()
 			navigate('/sign_in')

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -291,6 +291,7 @@ const AuthenticationRoleRouter = () => {
 		const hasPasswordAuthorization = passwordAuthTokenManager.get()
 		if (AUTH_MODE === 'password' && !hasPasswordAuthorization) {
 			auth.signOut()
+			setAuthRole(AuthRole.UNAUTHENTICATED)
 			navigate('/sign_in')
 		}
 	}, [navigate])

--- a/frontend/src/util/auth.tsx
+++ b/frontend/src/util/auth.tsx
@@ -202,6 +202,7 @@ class PasswordAuth {
 	signOut(): Promise<void> {
 		passwordAuthTokenManager.clear()
 		localStorage.removeItem('currentUser')
+		this.currentUser = null
 		return Promise.resolve(undefined)
 	}
 }

--- a/frontend/src/util/passowordAuthCookies.ts
+++ b/frontend/src/util/passowordAuthCookies.ts
@@ -1,0 +1,19 @@
+import Cookies from 'js-cookie'
+import moment from 'moment'
+
+export const PASSWORD_AUTH_TOKEN = 'highlight-password-auth-token'
+
+// Storing in a cookie so we can set an expiration.
+export const passwordAuthTokenManager = {
+	set: (tokan: string) => {
+		Cookies.set(PASSWORD_AUTH_TOKEN, tokan, {
+			expires: moment().add(1, 'day').toDate(),
+		})
+	},
+	get: () => {
+		return Cookies.get(PASSWORD_AUTH_TOKEN)
+	},
+	clear: () => {
+		Cookies.remove(PASSWORD_AUTH_TOKEN)
+	},
+}

--- a/frontend/src/util/passowordAuthCookies.ts
+++ b/frontend/src/util/passowordAuthCookies.ts
@@ -5,8 +5,8 @@ export const PASSWORD_AUTH_TOKEN = 'highlight-password-auth-token'
 
 // Storing in a cookie so we can set an expiration.
 export const passwordAuthTokenManager = {
-	set: (tokan: string) => {
-		Cookies.set(PASSWORD_AUTH_TOKEN, tokan, {
+	set: (token: string) => {
+		Cookies.set(PASSWORD_AUTH_TOKEN, token, {
 			expires: moment().add(1, 'day').toDate(),
 		})
 	},


### PR DESCRIPTION
## Summary
fixes #7783
fixes #7781

This fixes the issue of auth state not accessible across tabs and redirecting to login after
token expires.

I moved the storage of the passwordToken to cookie instead of using sessionStorage.
This cookie is accessed client side and is thus not "secure". I'm trusting server side validation of the cookie to be enough. This resolves our current issues with session storage

I did consider using localStorage but cookies offered a better set of trade-offs
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## Demo of multi-tab auth context - 

https://github.com/highlight/highlight/assets/119384208/8fdeed2d-0d6d-49c1-8e02-29fea8eed533


## How did you test this change?
Click-testing
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
No
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
No
<!--
 Request review from julian-highlight / our design team 
-->
