### PR TITLE
load more logs and traces from time of last row

### DIFF
--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -4,7 +4,7 @@ import { PageInfo, TraceEdge } from '@graph/schemas'
 import * as Types from '@graph/schemas'
 import { usePollQuery } from '@util/search'
 import moment from 'moment'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
 
@@ -66,6 +66,38 @@ export const useGetTraces = ({
 		fetchPolicy: 'network-only',
 	})
 
+	const traceResultMetadata = useMemo(() => {
+		const traceIdSet = new Set()
+		const cursors = []
+		let latestLogTime, earliestLogTime
+
+		if (data?.traces.edges.length) {
+			cursors.push(data.traces.edges[0].cursor)
+
+			for (const edge of data.traces.edges) {
+				if (edge.node.traceID) {
+					traceIdSet.add(edge.node.traceID)
+				}
+
+				if (!latestLogTime || latestLogTime < edge.node.timestamp) {
+					latestLogTime = edge.node.timestamp
+				}
+
+				if (!earliestLogTime || earliestLogTime > edge.node.timestamp) {
+					earliestLogTime = edge.node.timestamp
+				}
+			}
+		}
+
+		return {
+			cursors,
+			traceIds: Array.from(traceIdSet) as string[],
+			endDate: latestLogTime || endDate,
+			startDate: earliestLogTime || startDate,
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [data?.traces.edges])
+
 	const { numMore, reset } = usePollQuery<
 		GetTracesQuery,
 		GetTracesQueryVariables
@@ -79,12 +111,14 @@ export const useGetTraces = ({
 				params: {
 					query,
 					date_range: {
-						start_date: moment(endDate).format(TIME_FORMAT),
+						start_date: moment(traceResultMetadata.endDate).format(
+							TIME_FORMAT,
+						),
 						end_date: moment().format(TIME_FORMAT),
 					},
 				},
 			}),
-			[endDate, traceCursor, projectId, query],
+			[projectId, traceCursor, query, traceResultMetadata.endDate],
 		),
 		moreDataQuery,
 		getResultCount: useCallback((result) => {


### PR DESCRIPTION
## Summary

use the time of the last row to load more traces and logs

## How did you test this change?

![image](https://github.com/highlight/highlight/assets/1351531/9b89f2ff-5a30-421e-9434-30acd5f2633d)

[reflame](https://app.highlight.io/1/logs?%7Er_preview=%7B%22action%22%3A%22start%22%2C%22mode%22%3A%22production%22%2C%22region%22%3A%22ewr%22%2C%22variantId%22%3A%2201HQVRESJXRFPFNN5CSRS8JWY4%22%2C%22variantData%22%3A%22%7B%5C%22type%5C%22%3A%5C%22branch%5C%22%2C%5C%22branch%5C%22%3A%5C%22vadim%2Ffetch-more%5C%22%2C%5C%22githubOwnerName%5C%22%3A%5C%22highlight%5C%22%2C%5C%22githubRepositoryName%5C%22%3A%5C%22highlight%5C%22%7D%22%7D)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
