### PR TITLE
stop auto-opening discord page

### DIFF
--- a/frontend/src/util/window.ts
+++ b/frontend/src/util/window.ts
@@ -9,7 +9,6 @@ export function GetBaseURL(): string {
 
 export const showSupportBubble = () => {
 	analytics.track('showSupportBubble')
-	window.open('https://highlight.io/community', '_blank')
 }
 
 export const showSupportMessage = async (msg = '') => {


### PR DESCRIPTION
## Summary

Support bubble is older intercom logic that would auto-open in 5 seconds
from the email verification page. Remove the discord opening logic to avoid
auto-opening discord.

## How did you test this change?

reflame

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no