### PR TITLE
Fix table width and height

### DIFF
--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -62,7 +62,7 @@ type Props = {
 	presetDefault: DateRangePreset
 }
 
-const HEADERS_AND_CHARTS_HEIGHT = 228
+const HEADERS_AND_CHARTS_HEIGHT = 221
 const LOAD_MORE_HEIGHT = 28
 
 const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -347,6 +347,7 @@ const LogsTableInner = ({
 				overflowY="auto"
 				style={{ height: bodyHeight }}
 				onScroll={handleFetchMoreWhenScrolled}
+				hiddenScroll
 			>
 				{paddingTop > 0 && <Box style={{ height: paddingTop }} />}
 				{virtualRows.map((virtualRow) => {

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -255,9 +255,10 @@ export const TracesList: React.FC<Props> = ({
 					// Subtract height of search filters + table header + charts
 					height:
 						numMoreTraces && numMoreTraces > 0
-							? `calc(100% - 191px)`
-							: `calc(100% - 163px)`,
+							? `calc(100% - 182px)`
+							: `calc(100% - 154px)`,
 				}}
+				hiddenScroll
 			>
 				{paddingTop > 0 && <Box style={{ height: paddingTop }} />}
 				{virtualRows.map((virtualRow) => {


### PR DESCRIPTION
## Summary
The logs' table and traces' table use fixed heights and were looking off in their demensions

Fixes:
- tweak heights
- remove scroll bar visibility on right (causing weird misaligning of columns and headers)

## How did you test this change?
1) View logs table
- [ ] Column headers align with rows
- [ ] Table not cutoff at bottom
- [ ] No text visible over end of table
2) View traces table
- [ ] Column headers align with rows
- [ ] Table not cutoff at bottom
- [ ] No text visible over end of table

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
