### PR TITLE
use level field for Vercel log drain

### DIFF
--- a/sdk/highlight-go/log/util.go
+++ b/sdk/highlight-go/log/util.go
@@ -64,6 +64,7 @@ type VercelLog struct {
 	Host         string `json:"host"`
 
 	Type       string `json:"type"`
+	Level      string `json:"level"`
 	Entrypoint string `json:"entrypoint"`
 
 	RequestId   string      `json:"requestId"`
@@ -80,8 +81,19 @@ func submitVercelLog(ctx context.Context, tracer trace.Tracer, projectID int, lo
 	)
 	defer highlight.EndTrace(span)
 
+	var level string
+	if log.Type == "stdout" {
+		level = "INFO"
+	} else if log.Type == "stderr" {
+		level = "ERROR"
+	} else if log.Level == "warning" {
+		level = "WARN"
+	} else {
+		level = strings.ToUpper(log.Level)
+	}
+
 	attrs := []attribute.KeyValue{
-		LogSeverityKey.String(log.Type),
+		LogSeverityKey.String(level),
 		LogMessageKey.String(log.Message),
 		semconv.ServiceNameKey.String("vercel-log-drain-" + log.ProjectId),
 		semconv.ServiceVersionKey.String(log.DeploymentId),


### PR DESCRIPTION
## Summary
- following https://vercel.com/docs/observability/log-drains/log-drains-reference#:~:text=The%20logs%20are%20buffered%20and%20submitted%20as%20batches%20with%20the%20following%20formats%3A , use the `level` field if `type` is not defined
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- testing locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
