### PR TITLE
allow customizing log attribute serialization

### DIFF
--- a/.changeset/honest-trees-greet.md
+++ b/.changeset/honest-trees-greet.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+support custom serialization for log attributes to display cleaner message bodies

--- a/sdk/client/src/listeners/console-listener.tsx
+++ b/sdk/client/src/listeners/console-listener.tsx
@@ -21,6 +21,10 @@ export type StringifyOptions = {
 export type LogRecordOptions = {
 	level: ConsoleMethods[]
 	stringifyOptions: StringifyOptions
+	/**
+	 * Set to try to serialize console object arguments into the message body.
+	 */
+	serializeConsoleAttributes?: boolean
 	logger: Logger | 'console'
 }
 
@@ -106,23 +110,31 @@ export function ConsoleListener(
 		}
 		// replace the logger.{level}. return a restore function
 		return patch(_logger, level, (original) => {
-			return (...args: Array<any>) => {
+			return (...data: Array<any>) => {
 				// @ts-expect-error
-				original.apply(this, args)
+				original.apply(this, data)
 				try {
 					const trace = ErrorStackParser.parse(new Error())
-					const payload = args.map((s) =>
-						stringify(s, logOptions.stringifyOptions),
-					)
-
+					const message = logOptions.serializeConsoleAttributes
+						? data.map((o) =>
+								typeof o === 'object'
+									? stringify(o, logOptions.stringifyOptions)
+									: o,
+						  )
+						: data
+								.filter((d) => typeof d !== 'object')
+								.map((o) => `${o}`)
 					callback({
 						type: level,
 						trace: trace.slice(1),
-						value: payload,
+						value: message,
+						attributes: data
+							.filter((d) => typeof d === 'object')
+							.reduce((a, b) => ({ ...a, ...b }), {}),
 						time: Date.now(),
 					})
 				} catch (error) {
-					original('highlight logger error:', error, ...args)
+					original('highlight logger error:', error, ...data)
 				}
 			}
 		})

--- a/sdk/highlight-go/log/console_messages_parser.go
+++ b/sdk/highlight-go/log/console_messages_parser.go
@@ -38,7 +38,10 @@ func ParseConsoleMessages(messages string) ([]*Message, error) {
 			Type:       message.Type,
 			Trace:      message.Trace,
 			Time:       message.Time,
-			Attributes: map[string]any{},
+			Attributes: message.Attributes,
+		}
+		if msg.Attributes == nil {
+			msg.Attributes = map[string]any{}
 		}
 		var messageValue []string
 		for _, v := range message.Value {


### PR DESCRIPTION
## Summary

As with our Node.js SDK, allow our browser instrumentation to avoid serializing attributes into the
message body and instead report them only as structured attributes to produce cleaner log rows.

## How did you test this change?

local deploy
![image](https://github.com/highlight/highlight/assets/1351531/9f092762-aa05-432c-a442-8b8b71fdbb8e)


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no