### PR TITLE
Fix over fetching and wrong status on setup

### DIFF
--- a/frontend/src/pages/Setup/IntegrationBar.tsx
+++ b/frontend/src/pages/Setup/IntegrationBar.tsx
@@ -18,7 +18,7 @@ import {
 } from '@highlight-run/ui/components'
 import { useProjectId } from '@hooks/useProjectId'
 import moment from 'moment'
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import {
@@ -66,10 +66,16 @@ export const IntegrationBar: React.FC<Props> = ({ integrationData }) => {
 	const integrated = integrationData?.integrated
 	const ctaText = CTA_TITLE_MAP[area!]
 
+	const POLLING_INTERVAL = 15000
 	const start = useMemo(() => moment().subtract(30, 'days').toISOString(), [])
-	const end = useMemo(() => moment().toISOString(), [])
+	// Adding a day so that polling returns fresh data.
+	const end = useMemo(() => moment().add(1, 'day').toISOString(), [])
 
-	const { data: sessionData } = useGetSessionsClickhouseQuery({
+	const {
+		data: sessionData,
+		startPolling: startSessionPolling,
+		stopPolling: stopSessionPolling,
+	} = useGetSessionsClickhouseQuery({
 		variables: {
 			project_id: projectId,
 			query: {
@@ -84,11 +90,20 @@ export const IntegrationBar: React.FC<Props> = ({ integrationData }) => {
 			page: 1,
 			sort_desc: true,
 		},
+		onCompleted: (data) => {
+			if (data.sessions_clickhouse.sessions.length) {
+				stopSessionPolling()
+			}
+		},
 		skip: area !== 'client' || !integrated,
 		fetchPolicy: 'no-cache',
 	})
 
-	const { data: errorGroupData } = useGetErrorGroupsClickhouseQuery({
+	const {
+		data: errorGroupData,
+		startPolling: startErrorPolling,
+		stopPolling: stopErrorPolling,
+	} = useGetErrorGroupsClickhouseQuery({
 		variables: {
 			project_id: projectId,
 			query: {
@@ -100,6 +115,11 @@ export const IntegrationBar: React.FC<Props> = ({ integrationData }) => {
 				},
 			},
 			count: 1,
+		},
+		onCompleted: (data) => {
+			if (data.error_groups_clickhouse.error_groups.length) {
+				stopErrorPolling()
+			}
 		},
 		skip: area !== 'backend' || !integrated,
 		fetchPolicy: 'no-cache',
@@ -126,6 +146,34 @@ export const IntegrationBar: React.FC<Props> = ({ integrationData }) => {
 			: undefined
 	const path = buildResourcePath(area!, projectId, resource, alert)
 	const complete = path && integrated
+
+	useEffect(() => {
+		if (integrated) {
+			if (
+				area === 'client' &&
+				!sessionData?.sessions_clickhouse.sessions.length
+			) {
+				startSessionPolling(POLLING_INTERVAL)
+			} else if (
+				area === 'backend' &&
+				!errorGroupData?.error_groups_clickhouse.error_groups.length
+			) {
+				startErrorPolling(POLLING_INTERVAL)
+			}
+		} else {
+			stopSessionPolling()
+			stopErrorPolling()
+		}
+	}, [
+		area,
+		errorGroupData?.error_groups_clickhouse.error_groups.length,
+		integrated,
+		sessionData?.sessions_clickhouse.sessions.length,
+		startErrorPolling,
+		startSessionPolling,
+		stopErrorPolling,
+		stopSessionPolling,
+	])
 
 	return (
 		<Box

--- a/frontend/src/pages/Setup/IntegrationBar.tsx
+++ b/frontend/src/pages/Setup/IntegrationBar.tsx
@@ -18,7 +18,7 @@ import {
 } from '@highlight-run/ui/components'
 import { useProjectId } from '@hooks/useProjectId'
 import moment from 'moment'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import {
@@ -66,6 +66,9 @@ export const IntegrationBar: React.FC<Props> = ({ integrationData }) => {
 	const integrated = integrationData?.integrated
 	const ctaText = CTA_TITLE_MAP[area!]
 
+	const start = useMemo(() => moment().subtract(30, 'days').toISOString(), [])
+	const end = useMemo(() => moment().toISOString(), [])
+
 	const { data: sessionData } = useGetSessionsClickhouseQuery({
 		variables: {
 			project_id: projectId,
@@ -73,8 +76,8 @@ export const IntegrationBar: React.FC<Props> = ({ integrationData }) => {
 				isAnd: true,
 				rules: [],
 				dateRange: {
-					start_date: moment().subtract(30, 'days').toISOString(),
-					end_date: moment().toISOString(),
+					start_date: start,
+					end_date: end,
 				},
 			},
 			count: 1,
@@ -92,8 +95,8 @@ export const IntegrationBar: React.FC<Props> = ({ integrationData }) => {
 				isAnd: true,
 				rules: [],
 				dateRange: {
-					start_date: moment().subtract(30, 'days').toISOString(),
-					end_date: moment().toISOString(),
+					start_date: start,
+					end_date: end,
 				},
 			},
 			count: 1,


### PR DESCRIPTION
## Summary

Fixes two issues:

1. The integration status in the top bar on the setup pages for sessions and errors was always saying "pending" and never said setup was complete.
2. We had an infinite loop fetching sessions and errors to figure out what to display in the integration bar.

This fixes the problem by ensuring the variables don't change for the session and error queries from one query to the next.

## How did you test this change?

* Went to `/setup` locally and opened the network inspector. Note the continuous stream of requests hitting the sessions table in Clickhouse.
* Introduced my changes and reloaded to confirm there was only 1 request and that the status actually updates from pending to integrated.
* Same thing for errors.
* Ran the same checks on the Reflame preview.

## Are there any deployment considerations?

N/A - this should reduce the number of queries we're seeing to sessions and errors from setup pages.

@Vadman97 this gave me a thought... do you think we should have any sort of alerting for spikes in requests like we probably saw from the setup page? If someone was sitting on the setup page I think we would have received hundreds of requests from them to the same endpoint.

## Does this work require review from our design team?

N/A
