### PR TITLE
avoid showing sales email for aws mp plans

### DIFF
--- a/frontend/src/pages/Billing/BillingPageV2.tsx
+++ b/frontend/src/pages/Billing/BillingPageV2.tsx
@@ -419,21 +419,28 @@ const BillingPageV2 = ({}: BillingPageProps) => {
 			<Stack height="full" px="8" cssClass={style.pageWrapper} gap="0">
 				<Stack>
 					<Heading level="h4">Billing plans</Heading>
-					<Box display="inline-flex">
-						<Text size="small" color="weak">
-							Prices are flexible around your needs. Custom quote?{' '}
-							<a
-								href={getPlanChangeEmail({
-									workspaceID: workspace_id,
-									planType: PlanType.Enterprise,
-								})}
-							>
-								<Box display="inline-flex" alignItems="center">
-									Reach out to sales <IconSolidArrowSmRight />
-								</Box>
-							</a>
-						</Text>
-					</Box>
+					{isAWSMP ? null : (
+						<Box display="inline-flex">
+							<Text size="small" color="weak">
+								Prices are flexible around your needs. Custom
+								quote?{' '}
+								<a
+									href={getPlanChangeEmail({
+										workspaceID: workspace_id,
+										planType: PlanType.Enterprise,
+									})}
+								>
+									<Box
+										display="inline-flex"
+										alignItems="center"
+									>
+										Reach out to sales{' '}
+										<IconSolidArrowSmRight />
+									</Box>
+								</a>
+							</Text>
+						</Box>
+					)}
 					{billingIssue ? (
 						<Callout title="Update payment details" icon={false}>
 							<Box


### PR DESCRIPTION
## Summary

Per request from the AWS MP team, avoid showing our sales email for workspaces on an AWS MP subscription.

## How did you test this change?

reflame

## Are there any deployment considerations?

no
![image](https://github.com/highlight/highlight/assets/1351531/7aa35dbc-dc99-4350-a709-20ccfc1474f4)


## Does this work require review from our design team?

no
