### PR TITLE
avoid reporting negative session active time

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6239,12 +6239,12 @@ select coalesce(email.Value, nullif(IP, ''), device.Value, Identifier) as key,
        count(distinct ID)                                              as num_sessions,
        count(distinct date_trunc('day', CreatedAt))                    as num_days_visited,
        count(distinct date_trunc('month', CreatedAt))                  as num_months_visited,
-       avg(ActiveLength) / 1000 / 60                                   as avg_active_length_mins,
-       max(ActiveLength) / 1000 / 60                                   as max_active_length_mins,
-       sum(ActiveLength) / 1000 / 60                                   as total_active_length_mins,
-       avg(Length) / 1000 / 60                                         as avg_length_mins,
-       max(Length) / 1000 / 60                                         as max_length_mins,
-       sum(Length) / 1000 / 60                                         as total_length_mins,
+       avg(greatest(0, ActiveLength)) / 1000 / 60                      as avg_active_length_mins,
+       max(greatest(0, ActiveLength)) / 1000 / 60                      as max_active_length_mins,
+       sum(greatest(0, ActiveLength)) / 1000 / 60                      as total_active_length_mins,
+       avg(greatest(0, Length)) / 1000 / 60                            as avg_length_mins,
+       max(greatest(0, Length)) / 1000 / 60                            as max_length_mins,
+       sum(greatest(0, Length)) / 1000 / 60                            as total_length_mins,
        max(City)                                                       as location
 from sessions final
          left join (select *

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -1502,7 +1502,7 @@ func processEventChunk(ctx context.Context, a EventProcessingAccumulator, events
 			var diff time.Duration
 			if !a.LastEventTimestamp.IsZero() {
 				diff = event.Timestamp.Sub(a.LastEventTimestamp)
-				if diff.Seconds() <= MIN_INACTIVE_DURATION {
+				if diff > 0 && diff.Seconds() <= MIN_INACTIVE_DURATION {
 					a.ActiveDuration += diff
 				}
 			}


### PR DESCRIPTION
## Summary

For the sessions data export report, avoid including sessions with a negative active/total time.
Correct the root cause of reporting negative time caused by out of order session events.

## How did you test this change?

![image](https://github.com/highlight/highlight/assets/1351531/eec55bc7-df38-4726-ab34-0e51e3e3101a)

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
