### PR TITLE
add a view in context button to log rows

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -281,7 +281,6 @@ export const LogDetails: React.FC<Props> = ({
 						onClick={(e) => {
 							e.stopPropagation()
 							const url = getLogURL(projectId, row)
-							console.log('url', { url })
 							navigate(url.path)
 						}}
 						trackingId="logs_view-in-context_click"

--- a/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogDetails.tsx
@@ -16,6 +16,7 @@ import {
 	IconSolidFilter,
 	IconSolidLightningBolt,
 	IconSolidLink,
+	IconSolidLocationMarker,
 	IconSolidPlayCircle,
 	IconSolidSparkles,
 	Stack,
@@ -33,7 +34,7 @@ import { Row } from '@tanstack/react-table'
 import { message as antdMessage } from 'antd'
 import moment from 'moment'
 import React, { useEffect, useState } from 'react'
-import { createSearchParams, generatePath } from 'react-router-dom'
+import { createSearchParams, generatePath, useNavigate } from 'react-router-dom'
 import { useQueryParam } from 'use-query-params'
 
 import { SearchExpression } from '@/components/Search/Parser/listener'
@@ -62,7 +63,7 @@ export const getLogURL = (projectId: string, row: Row<LogEdge>) => {
 		project_id: projectId,
 		log_cursor: row.original.cursor,
 	})
-	return currentUrl.origin + path
+	return { origin: currentUrl.origin, path }
 }
 
 const getSessionLink = (
@@ -98,6 +99,7 @@ export const LogDetails: React.FC<Props> = ({
 	queryParts,
 }) => {
 	const { projectId } = useProjectId()
+	const navigate = useNavigate()
 	const [allExpanded, setAllExpanded] = useState(false)
 	const {
 		environment,
@@ -258,7 +260,7 @@ export const LogDetails: React.FC<Props> = ({
 						onClick={(e) => {
 							const url = getLogURL(projectId, row)
 							e.stopPropagation()
-							navigator.clipboard.writeText(url)
+							navigator.clipboard.writeText(url.origin + url.path)
 							antdMessage.success('Copied link!')
 						}}
 						trackingId="logs_copy-link_click"
@@ -271,6 +273,27 @@ export const LogDetails: React.FC<Props> = ({
 						>
 							<IconSolidLink />
 							Copy link
+						</Box>
+					</Button>
+					<Button
+						kind="secondary"
+						emphasis="low"
+						onClick={(e) => {
+							e.stopPropagation()
+							const url = getLogURL(projectId, row)
+							console.log('url', { url })
+							navigate(url.path)
+						}}
+						trackingId="logs_view-in-context_click"
+					>
+						<Box
+							display="flex"
+							alignItems="center"
+							flexDirection="row"
+							gap="4"
+						>
+							<IconSolidLocationMarker />
+							View in Context
 						</Box>
 					</Button>
 				</Box>

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/DevToolsWindowV2.tsx
@@ -326,7 +326,6 @@ const DevToolsWindowV2: React.FC<
 													levels: relevantLevelsForRequest,
 													sources,
 												})}
-												target="_blank"
 												style={{ display: 'flex' }}
 											>
 												<Button


### PR DESCRIPTION
## Summary

Adds a `view in context` button to log rows to show the log among other logs

## How did you test this change?

https://www.loom.com/share/6b8ad0c97dd9494a856a6b9adc9b943f

## Are there any deployment considerations?

no

## Does this work require review from our design team?

yes @julian-highlight 