### PR TITLE
correctly show base fee for plans already subscribed

### DIFF
--- a/frontend/src/pages/Billing/BillingPageV2.tsx
+++ b/frontend/src/pages/Billing/BillingPageV2.tsx
@@ -415,7 +415,15 @@ const BillingPageV2 = ({}: BillingPageProps) => {
 
 	return (
 		<Box width="full" display="flex" justifyContent="center">
-			<UpdatePlanModal step={step} setStep={setStep} />
+			<UpdatePlanModal
+				currentPlanType={
+					data?.billingDetails.plan.type === PlanType.Free
+						? PlanType.Graduated
+						: data?.billingDetails.plan.type ?? PlanType.Graduated
+				}
+				step={step}
+				setStep={setStep}
+			/>
 			<Stack height="full" px="8" cssClass={style.pageWrapper} gap="0">
 				<Stack>
 					<Heading level="h4">Billing plans</Heading>

--- a/frontend/src/pages/Billing/UpdatePlanPage.tsx
+++ b/frontend/src/pages/Billing/UpdatePlanPage.tsx
@@ -775,7 +775,8 @@ const UpdatePlanPage = ({
 	}
 	predictedTracesCost = Math.max(predictedTracesCost, actualTracesCost)
 
-	const baseAmount = PLAN_BASE_FEES[selectedPlanType] * 100
+	const baseAmount =
+		PLAN_BASE_FEES[selectedPlanType as keyof typeof PLAN_BASE_FEES] * 100
 	const discountPercent = data?.subscription_details.discount?.percent ?? 0
 	const discountAmount = data?.subscription_details.discount?.amount ?? 0
 
@@ -1204,7 +1205,7 @@ const PLAN_BASE_FEES = {
 	[PlanType.Basic]: 150,
 	[PlanType.Startup]: 400,
 	[PlanType.Graduated]: 50,
-}
+} as const
 
 const PLANS = {
 	[PlanType.Free]: {

--- a/frontend/src/pages/Billing/UpdatePlanPage.tsx
+++ b/frontend/src/pages/Billing/UpdatePlanPage.tsx
@@ -1557,10 +1557,10 @@ const UpdatePlanFooter: React.FC<{
 export const UpdatePlanModal: React.FC<{
 	step: PlanSelectStep
 	setStep: (step: PlanSelectStep) => void
-}> = ({ step, setStep }) => {
-	const [selectedPlanType, setSelectedPlanType] = React.useState<PlanType>(
-		PlanType.Graduated,
-	)
+	currentPlanType: Exclude<PlanType, PlanType.Free>
+}> = ({ step, setStep, currentPlanType }) => {
+	const [selectedPlanType, setSelectedPlanType] =
+		React.useState<PlanType>(currentPlanType)
 	const [hasChanges, setHasChanges] = React.useState<boolean>(false)
 	const [showConfirmCloseModal, setShowConfirmCloseModal] =
 		React.useState<boolean>(false)

--- a/frontend/src/pages/Billing/UpdatePlanPage.tsx
+++ b/frontend/src/pages/Billing/UpdatePlanPage.tsx
@@ -775,7 +775,7 @@ const UpdatePlanPage = ({
 	}
 	predictedTracesCost = Math.max(predictedTracesCost, actualTracesCost)
 
-	const baseAmount = PLANS[selectedPlanType].price * 100
+	const baseAmount = PLAN_BASE_FEES[selectedPlanType] * 100
 	const discountPercent = data?.subscription_details.discount?.percent ?? 0
 	const discountAmount = data?.subscription_details.discount?.amount ?? 0
 
@@ -1195,6 +1195,15 @@ type Plan = {
 	descriptions: string[]
 	icon: React.ReactNode
 	price: number
+}
+
+const PLAN_BASE_FEES = {
+	[PlanType.Free]: 0,
+	[PlanType.UsageBased]: 0,
+	[PlanType.Lite]: 50,
+	[PlanType.Basic]: 150,
+	[PlanType.Startup]: 400,
+	[PlanType.Graduated]: 50,
 }
 
 const PLANS = {


### PR DESCRIPTION
## Summary

Fixes base fee display for customers on an existing (non-graduated) pricing plan.

## How did you test this change?

![image](https://github.com/highlight/highlight/assets/1351531/286adcb6-c724-4244-8d2a-422a2a921d5a)

## Are there any deployment considerations?

No

## Does this work require review from our design team?

No