### PR TITLE
fix(sdk/rust): fix publish CI failing

### DIFF
--- a/.github/workflows/rust-sdk.yml
+++ b/.github/workflows/rust-sdk.yml
@@ -37,19 +37,11 @@ jobs:
                   toolchain: stable
                   override: true
 
-            - name: Build highlightio
+            - name: Build crates
               uses: katyo/publish-crates@v2
               with:
                   path: ./sdk/highlight-rust/
                   dry-run: true
-                  args: -p highlightio
-
-            - name: Build highlightio-actix
-              uses: katyo/publish-crates@v2
-              with:
-                  path: ./sdk/highlight-rust/
-                  dry-run: true
-                  args: -p highlightio-actix
     publish:
         name: Publish
         runs-on: ubuntu-latest
@@ -69,16 +61,8 @@ jobs:
                   toolchain: stable
                   override: true
 
-            - name: Publish highlightio
+            - name: Publish crates
               uses: katyo/publish-crates@v2
               with:
                   path: ./sdk/highlight-rust/
-                  args: -p highlightio
-                  registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-            - name: Publish highlightio-actix
-              uses: katyo/publish-crates@v2
-              with:
-                  path: ./sdk/highlight-rust/
-                  args: -p highlightio-actix
                   registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/sdk/highlight-rust/Cargo.toml
+++ b/sdk/highlight-rust/Cargo.toml
@@ -1,10 +1,7 @@
 [workspace]
 members = [
     "highlightio",
-    "highlightio/examples/sync",
-    "highlightio/examples/tokio",
     "highlightio-actix",
-    "highlightio-actix/examples/hello-world",
 ]
 resolver = "2"
 

--- a/sdk/highlight-rust/highlightio-actix/Cargo.toml
+++ b/sdk/highlight-rust/highlightio-actix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "highlightio-actix"
-version = "1.0.1"
+version = "1.0.2"
 license = "Apache-2.0"
 description = """
 hightlight.io crate for actix-web 4.

--- a/sdk/highlight-rust/highlightio/Cargo.toml
+++ b/sdk/highlight-rust/highlightio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "highlightio"
-version = "1.0.1"
+version = "1.0.2"
 license = "Apache-2.0"
 description = """
 hightlight.io SDK for Rust


### PR DESCRIPTION
## Summary
This is a hotfix. Publishing CI failed because of unexpected behaviour of the used GitHub action (it iterates through every crate in the workspace instead of only publishing the ones we provide in the config). I've changed the Rust workspace to be compatible with this behaviour.