### PR TITLE
allow all alerts to notify for a single instance

### DIFF
--- a/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
+++ b/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
@@ -261,7 +261,7 @@ export const ErrorAlertPage = () => {
 
 						const nameErr = !input.name
 						const thresholdErr =
-							!input.count_threshold || input.count_threshold < 1
+							!input.count_threshold || input.count_threshold < 0
 						if (nameErr || thresholdErr) {
 							const errs = []
 							if (nameErr) {
@@ -275,7 +275,7 @@ export const ErrorAlertPage = () => {
 							if (thresholdErr) {
 								formStore.setError(
 									formStore.names.threshold,
-									'Threshold cannot be less than 1',
+									'Threshold cannot be less than 0',
 								)
 								errs.push('threshold')
 							}

--- a/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
+++ b/frontend/src/pages/Alerts/LogAlert/LogAlertPage.tsx
@@ -293,7 +293,7 @@ export const LogAlertPage = () => {
 
 						const nameErr = !input.name
 						const thresholdErr =
-							!input.count_threshold || input.count_threshold < 1
+							!input.count_threshold || input.count_threshold < 0
 						const queryErr = !input.query
 						if (nameErr || thresholdErr || queryErr) {
 							const errs = []
@@ -308,7 +308,7 @@ export const LogAlertPage = () => {
 							if (thresholdErr) {
 								formStore.setError(
 									formStore.names.threshold,
-									'Threshold cannot be less than 1',
+									'Threshold cannot be less than 0',
 								)
 								errs.push('threshold')
 							}

--- a/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
+++ b/frontend/src/pages/Alerts/SessionAlert/SessionAlertPage.tsx
@@ -330,7 +330,7 @@ export const SessionAlertPage = () => {
 						const thresholdErr =
 							configuration.canControlThreshold &&
 							(!input.count_threshold ||
-								input.count_threshold < 1)
+								input.count_threshold < 0)
 						if (nameErr || thresholdErr) {
 							const errs = []
 							if (nameErr) {
@@ -344,7 +344,7 @@ export const SessionAlertPage = () => {
 							if (thresholdErr) {
 								formStore.setError(
 									formStore.names.threshold,
-									'Threshold cannot be less than 1',
+									'Threshold cannot be less than 0',
 								)
 								errs.push('threshold')
 							}


### PR DESCRIPTION
## Summary

Allow `0` as a value for alert threshold since `greater than 0` would be 1 instance of a log.

## How did you test this change?

https://www.loom.com/share/8f3987f0de12408d93a4a3b30154fec7

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
