### PR TITLE
Fix nested != queries

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -376,7 +376,8 @@ func matchFilter[TObj interface{}, TReservedKey ~string](row *TObj, config model
 			}
 		}
 		for _, bodyFilter := range filter.Values {
-			if filter.Operator == listener.OperatorRegExp || filter.Operator == listener.OperatorNotRegExp {
+			// TODO(spenny): make sure this works for NOT
+			if filter.Operator == listener.OperatorRegExp {
 				pat, err := regexp.Compile(bodyFilter)
 				if err == nil {
 					matches := pat.MatchString(body)
@@ -433,7 +434,8 @@ func matchFilter[TObj interface{}, TReservedKey ~string](row *TObj, config model
 	}
 	if !bodyFilter {
 		for _, v := range filter.Values {
-			if filter.Operator == listener.OperatorRegExp || filter.Operator == listener.OperatorNotRegExp {
+			// TODO(spenny): make sure this works for NOT
+			if filter.Operator == listener.OperatorRegExp {
 				pat, err := regexp.Compile(v)
 				if err == nil {
 					matches := pat.MatchString(rowValue)

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -376,7 +376,6 @@ func matchFilter[TObj interface{}, TReservedKey ~string](row *TObj, config model
 			}
 		}
 		for _, bodyFilter := range filter.Values {
-			// TODO(spenny): make sure this works for NOT
 			if filter.Operator == listener.OperatorRegExp {
 				pat, err := regexp.Compile(bodyFilter)
 				if err == nil {
@@ -434,7 +433,6 @@ func matchFilter[TObj interface{}, TReservedKey ~string](row *TObj, config model
 	}
 	if !bodyFilter {
 		for _, v := range filter.Values {
-			// TODO(spenny): make sure this works for NOT
 			if filter.Operator == listener.OperatorRegExp {
 				pat, err := regexp.Compile(v)
 				if err == nil {

--- a/backend/parser/parser_test.go
+++ b/backend/parser/parser_test.go
@@ -30,7 +30,7 @@ func TestComplexSqlForSearch(t *testing.T) {
 
 	assert.Equal(
 		t,
-		"SELECT * FROM t WHERE toString(SpanName) = 'Chris Schmitz' AND Duration > '1000' AND toString(Level) = 'info' AND (toString(Source) = 'backend' OR toString(Source) = 'frontend') AND ServiceName <> 'private-graph' AND toString(SpanName) = 'gorm.Query' AND ((SpanName <> 'testing' OR SpanName <> 'testing2') OR (SpanName ILIKE '%body query%' AND hasTokenCaseInsensitive(SpanName, 'asdf')))",
+		"SELECT * FROM t WHERE toString(SpanName) = 'Chris Schmitz' AND Duration > '1000' AND toString(Level) = 'info' AND (toString(Source) = 'backend' OR toString(Source) = 'frontend') AND NOT (toString(ServiceName) = 'private-graph') AND toString(SpanName) = 'gorm.Query' AND (NOT ((toString(SpanName) = 'testing' OR toString(SpanName) = 'testing2')) OR (SpanName ILIKE '%body query%' AND hasTokenCaseInsensitive(SpanName, 'asdf')))",
 		sql,
 	)
 }


### PR DESCRIPTION
## Summary
Nested `!=` queries distribute the `!=` incorrectly.
For example, `environment!=(prod OR "on-prem")` => `environment NOT ILIKE 'prod' OR environment NOT ILIKE 'on-prem'`

Pull out the `NOT` keyword to spot in the tree in which it is written in the query.
`environment!=(prod OR "on-prem")` => `NOT (environment ILIKE 'prod' OR environment ILIKE 'on-prem')`

https://www.loom.com/share/c781d608aac54d1892a9436c7662cee5?sid=04a2d978-8d25-4f0f-a493-803d45de2596

## How did you test this change?
1) Load the logs page
2) Make sure the following cases work:
- [ ] Simple `=` query
- [ ] Simple `!=` query
- [ ] Matches query `=//`
- [ ] Not matches query `!=//` 
- [ ] Combined `= [val1] OR [val2]` query
- [ ] Combined `!= [val1] OR [val2]` query
- [ ] `EXISTS` query
- [ ] `NOT EXISTS` query

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
