### PR TITLE
cleanup unused fields

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -47,8 +47,6 @@ backfill-stack-frames:
 		(go build; doppler run -- ./backend -runtime=worker -worker-handler=backfill-stack-frames)
 refresh-materialized-views:
 		(go build; doppler run -- ./backend -runtime=worker -worker-handler=refresh-materialized-views)
-delete-completed-sessions:
-		(go build; doppler run -- ./backend -runtime=worker -worker-handler=delete-completed-sessions)
 public-worker:
 		(go build; doppler run -- ./backend -runtime=worker -worker-handler=public-worker)
 auto-resolve-stale-errors:

--- a/backend/alerts/logalerts.go
+++ b/backend/alerts/logalerts.go
@@ -33,7 +33,6 @@ func BuildLogAlert(project *model.Project, workspace *model.Workspace, admin *mo
 	return &model.LogAlert{
 		Alert: model.Alert{
 			ProjectID:            input.ProjectID,
-			OrganizationID:       input.ProjectID,
 			ExcludedEnvironments: envString,
 			CountThreshold:       input.CountThreshold,
 			ThresholdWindow:      &input.ThresholdWindow,

--- a/backend/alerts/sessionalerts.go
+++ b/backend/alerts/sessionalerts.go
@@ -93,7 +93,6 @@ func BuildSessionAlert(project *model.Project, workspace *model.Workspace, admin
 	return &model.SessionAlert{
 		Alert: model.Alert{
 			ProjectID:            input.ProjectID,
-			OrganizationID:       input.ProjectID,
 			ExcludedEnvironments: envString,
 			CountThreshold:       input.CountThreshold,
 			ThresholdWindow:      &input.ThresholdWindow,

--- a/backend/clickhouse/sessions_test.go
+++ b/backend/clickhouse/sessions_test.go
@@ -3,9 +3,10 @@ package clickhouse
 import (
 	"context"
 	"fmt"
-	"github.com/highlight-run/highlight/backend/parser"
 	"testing"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/parser"
 
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 	"github.com/highlight-run/highlight/backend/util"
@@ -43,7 +44,6 @@ func TestWriteSession(t *testing.T) {
 		Identified:                     false,
 		Fingerprint:                    0,
 		Identifier:                     "",
-		OrganizationID:                 0,
 		ProjectID:                      0,
 		Email:                          new(string),
 		IP:                             "",
@@ -96,7 +96,6 @@ func TestWriteSession(t *testing.T) {
 		ViewedByAdmins:                 []model.Admin{},
 		Chunked:                        new(bool),
 		ProcessWithRedis:               false,
-		AvoidPostgresStorage:           false,
 		Normalness:                     new(float64),
 	}}))
 }

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -136,8 +136,6 @@ var ContextKeys = struct {
 
 var Models = []interface{}{
 	&AWSMarketplaceCustomer{},
-	&MessagesObject{},
-	&EventsObject{},
 	&ErrorObject{},
 	&ErrorObjectEmbeddings{},
 	&ErrorGroup{},
@@ -150,12 +148,10 @@ var Models = []interface{}{
 	&Session{},
 	&SessionInterval{},
 	&SessionExport{},
-	&TimelineIndicatorEvent{},
 	&DailySessionCount{},
 	&DailyErrorCount{},
 	&Field{},
 	&EmailSignup{},
-	&ResourcesObject{},
 	&ExternalAttachment{},
 	&SessionComment{},
 	&SessionCommentTag{},
@@ -685,10 +681,9 @@ type Session struct {
 	Identified  bool `json:"identified" gorm:"default:false;not null"`
 	Fingerprint int  `json:"fingerprint"`
 	// User provided identifier (see IdentifySession)
-	Identifier     string  `json:"identifier"`
-	OrganizationID int     `json:"organization_id"`
-	ProjectID      int     `json:"project_id" gorm:"index:idx_project_id_email"`
-	Email          *string `json:"email" gorm:"index:idx_project_id_email"`
+	Identifier string  `json:"identifier"`
+	ProjectID  int     `json:"project_id" gorm:"index:idx_project_id_email"`
+	Email      *string `json:"email" gorm:"index:idx_project_id_email"`
 	// Location data based off user ip (see InitializeSession)
 	IP        string  `json:"ip"`
 	City      string  `json:"city"`
@@ -769,10 +764,9 @@ type Session struct {
 	// Represents the admins that have viewed this session.
 	ViewedByAdmins []Admin `json:"viewed_by_admins" gorm:"many2many:session_admins_views;"`
 
-	Chunked              *bool
-	ProcessWithRedis     bool
-	AvoidPostgresStorage bool
-	Normalness           *float64
+	Chunked          *bool
+	ProcessWithRedis bool
+	Normalness       *float64
 }
 
 type SessionAdminsView struct {
@@ -857,18 +851,16 @@ type SearchParams struct {
 }
 type Segment struct {
 	Model
-	Name           *string
-	Params         *string `json:"params"`
-	OrganizationID int
-	ProjectID      int `json:"project_id"`
+	Name      *string
+	Params    *string `json:"params"`
+	ProjectID int     `json:"project_id"`
 }
 
 type DailySessionCount struct {
 	Model
-	Date           *time.Time `json:"date"`
-	Count          int64      `json:"count"`
-	OrganizationID int
-	ProjectID      int `json:"project_id"`
+	Date      *time.Time `json:"date"`
+	Count     int64      `json:"count"`
+	ProjectID int        `json:"project_id"`
 }
 
 const (
@@ -879,11 +871,10 @@ const (
 
 type DailyErrorCount struct {
 	Model
-	Date           *time.Time `json:"date"`
-	Count          int64      `json:"count"`
-	OrganizationID int
-	ProjectID      int    `json:"project_id"`
-	ErrorType      string `gorm:"default:FRONTEND"`
+	Date      *time.Time `json:"date"`
+	Count     int64      `json:"count"`
+	ProjectID int        `json:"project_id"`
+	ErrorType string     `gorm:"default:FRONTEND"`
 }
 
 func (s *SearchParams) GormDataType() string {
@@ -1014,10 +1005,9 @@ type ErrorSearchParams struct {
 }
 type ErrorSegment struct {
 	Model
-	Name           *string
-	Params         *string `json:"params"`
-	OrganizationID int
-	ProjectID      int `json:"project_id"`
+	Name      *string
+	Params    *string `json:"params"`
+	ProjectID int     `json:"project_id"`
 }
 type ErrorGroupingMethod string
 
@@ -1029,14 +1019,13 @@ const (
 
 type ErrorObject struct {
 	Model
-	ID                      int `gorm:"primary_key;type:serial;index:idx_error_group_id_id,priority:2,option:CONCURRENTLY" json:"id" deep:"-"`
-	OrganizationID          int
-	ProjectID               int `json:"project_id"`
-	SessionID               *int
+	ID                      int  `gorm:"primary_key;type:serial;index:idx_error_group_id_id,priority:2,option:CONCURRENTLY" json:"id" deep:"-"`
+	ProjectID               int  `json:"project_id"`
+	SessionID               *int `gorm:"type:integer"`
 	TraceID                 *string
 	SpanID                  *string
 	LogCursor               *string `gorm:"index:idx_error_object_log_cursor,option:CONCURRENTLY"`
-	ErrorGroupID            int     `gorm:"index:idx_error_group_id_id,priority:1,option:CONCURRENTLY"`
+	ErrorGroupID            int     `gorm:"index:idx_error_group_id_id,priority:1,option:CONCURRENTLY;type:integer"`
 	ErrorGroupIDAlternative int     // the alternative algorithm for grouping the object
 	ErrorGroupingMethod     ErrorGroupingMethod
 	ErrorGroup              ErrorGroup
@@ -1044,8 +1033,8 @@ type ErrorObject struct {
 	Type                    string
 	URL                     string
 	Source                  string
-	LineNumber              int
-	ColumnNumber            int
+	LineNumber              int `gorm:"type:integer"`
+	ColumnNumber            int `gorm:"type:integer"`
 	OS                      string
 	Browser                 string
 	Trace                   *string `json:"trace"` //DEPRECATED, USE STACKTRACE INSTEAD
@@ -1072,8 +1061,7 @@ type ErrorGroup struct {
 	Model
 	// The ID used publicly for the URL on the client; used for sharing
 	SecureID         string `json:"secure_id" gorm:"uniqueIndex;not null;default:secure_id_generator()"`
-	OrganizationID   int
-	ProjectID        int `json:"project_id"`
+	ProjectID        int    `json:"project_id"`
 	Event            string
 	Type             string
 	Trace            string //DEPRECATED, USE STACKTRACE INSTEAD
@@ -1145,11 +1133,10 @@ type ErrorInstance struct {
 
 type ErrorField struct {
 	Model
-	OrganizationID int
-	ProjectID      int `json:"project_id"`
-	Name           string
-	Value          string
-	ErrorGroups    []ErrorGroup `gorm:"many2many:error_group_fields;"`
+	ProjectID   int `json:"project_id"`
+	Name        string
+	Value       string
+	ErrorGroups []ErrorGroup `gorm:"many2many:error_group_fields;"`
 }
 
 type LogAdminsView struct {
@@ -1202,13 +1189,12 @@ type SessionCommentTag struct {
 type SessionComment struct {
 	Model
 	Admins          []Admin `gorm:"many2many:session_comment_admins;"`
-	OrganizationID  int
-	ProjectID       int `json:"project_id"`
-	AdminId         int
-	SessionId       int
-	SessionSecureId string `gorm:"index;not null;default:''"`
+	ProjectID       int     `json:"project_id"`
+	AdminId         int     `gorm:"type:integer"`
+	SessionId       int     `gorm:"type:integer"`
+	SessionSecureId string  `gorm:"index;not null;default:''"`
 	SessionImage    string
-	Timestamp       int
+	Timestamp       int `gorm:"type:integer"`
 	Text            string
 	XCoordinate     float64
 	YCoordinate     float64
@@ -1223,17 +1209,16 @@ type SessionComment struct {
 
 type ErrorComment struct {
 	Model
-	Admins         []Admin `gorm:"many2many:error_comment_admins;"`
-	OrganizationID int
-	ProjectID      int `json:"project_id"`
-	AdminId        int
-	ErrorId        int
-	ErrorSecureId  string `gorm:"index;not null;default:''"`
-	Text           string
-	Attachments    []*ExternalAttachment `gorm:"foreignKey:ErrorCommentID"`
-	Replies        []*CommentReply       `gorm:"foreignKey:ErrorCommentID"`
-	Followers      []*CommentFollower    `gorm:"foreignKey:ErrorCommentID"`
-	Threads        []*CommentSlackThread `gorm:"foreignKey:ErrorCommentID"`
+	Admins        []Admin `gorm:"many2many:error_comment_admins;"`
+	ProjectID     int     `json:"project_id"`
+	AdminId       int
+	ErrorId       int
+	ErrorSecureId string `gorm:"index;not null;default:''"`
+	Text          string
+	Attachments   []*ExternalAttachment `gorm:"foreignKey:ErrorCommentID"`
+	Replies       []*CommentReply       `gorm:"foreignKey:ErrorCommentID"`
+	Followers     []*CommentFollower    `gorm:"foreignKey:ErrorCommentID"`
+	Threads       []*CommentSlackThread `gorm:"foreignKey:ErrorCommentID"`
 }
 
 type CommentReply struct {
@@ -1515,6 +1500,8 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 	if err := DB.Exec(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`).Error; err != nil {
 		return false, e.Wrap(err, "failed to configure uuid extension")
 	}
+
+	time.Sleep(10 * time.Second)
 
 	if err := DB.AutoMigrate(
 		Models...,
@@ -1989,7 +1976,6 @@ func (s *Session) GetUserProperties() (map[string]string, error) {
 }
 
 type Alert struct {
-	OrganizationID       int
 	ProjectID            int
 	ExcludedEnvironments *string
 	CountThreshold       int

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -3419,7 +3419,6 @@ func (r *mutationResolver) CreateErrorAlert(ctx context.Context, projectID int, 
 	newAlert := &model.ErrorAlert{
 		Alert: model.Alert{
 			ProjectID:            projectID,
-			OrganizationID:       projectID,
 			ExcludedEnvironments: envString,
 			CountThreshold:       countThreshold,
 			ThresholdWindow:      &thresholdWindow,
@@ -4981,15 +4980,9 @@ func (r *queryResolver) TimelineIndicatorEvents(ctx context.Context, sessionSecu
 	}
 
 	var timelineIndicatorEvents []*model.TimelineIndicatorEvent
-	if session.AvoidPostgresStorage {
-		timelineIndicatorEvents, err = r.StorageClient.ReadTimelineIndicatorEvents(ctx, session.ID, session.ProjectID)
-		if err != nil {
-			return nil, e.Wrap(err, "failed to get timeline indicator events from S3")
-		}
-	} else {
-		if res := r.DB.Order("timestamp ASC").Where(&model.TimelineIndicatorEvent{SessionSecureID: sessionSecureID}).Find(&timelineIndicatorEvents); res.Error != nil {
-			return nil, e.Wrap(res.Error, "failed to get timeline indicator events from Postgres")
-		}
+	timelineIndicatorEvents, err = r.StorageClient.ReadTimelineIndicatorEvents(ctx, session.ID, session.ProjectID)
+	if err != nil {
+		return nil, e.Wrap(err, "failed to get timeline indicator events from S3")
 	}
 
 	return timelineIndicatorEvents, nil

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -1076,7 +1076,6 @@ func (r *Resolver) InitializeSessionImpl(ctx context.Context, input *kafka_queue
 		Excluded:                       true, // A session is excluded by default until it receives events
 		ExcludedReason:                 &excludedReason,
 		ProcessWithRedis:               true,
-		AvoidPostgresStorage:           true,
 	}
 
 	// mark recording-less sessions as processed so they are considered excluded

--- a/backend/public-graph/graph/schema.resolvers.go
+++ b/backend/public-graph/graph/schema.resolvers.go
@@ -288,11 +288,20 @@ func (r *queryResolver) Ignore(ctx context.Context, id int) (interface{}, error)
 	return nil, nil
 }
 
+// OrganizationID is the resolver for the organization_id field.
+func (r *sessionResolver) OrganizationID(ctx context.Context, obj *model.Session) (int, error) {
+	return obj.ProjectID, nil
+}
+
 // Mutation returns generated1.MutationResolver implementation.
 func (r *Resolver) Mutation() generated1.MutationResolver { return &mutationResolver{r} }
 
 // Query returns generated1.QueryResolver implementation.
 func (r *Resolver) Query() generated1.QueryResolver { return &queryResolver{r} }
 
+// Session returns generated1.SessionResolver implementation.
+func (r *Resolver) Session() generated1.SessionResolver { return &sessionResolver{r} }
+
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
+type sessionResolver struct{ *Resolver }

--- a/backend/worker/worker.go
+++ b/backend/worker/worker.go
@@ -537,31 +537,6 @@ func (w *Worker) PublicWorker(ctx context.Context, topic kafkaqueue.TopicType) {
 	wg.Wait()
 }
 
-// Delete data for any sessions created > 4 hours ago
-// if all session data has been written to s3
-func (w *Worker) DeleteCompletedSessions(ctx context.Context) {
-	lookbackPeriod := 4*60 + 10 // 4h10m
-
-	baseQuery := `
-				DELETE
-				FROM %s o
-				USING sessions s
-				WHERE o.session_id = s.id
-				AND s.object_storage_enabled = True
-				AND s.payload_updated_at < s.lock
-				AND s.created_at < NOW() - (? * INTERVAL '1 MINUTE')
-				AND s.created_at > NOW() - INTERVAL '1 WEEK'`
-
-	for _, table := range []string{"resources_objects", "messages_objects"} {
-		deleteSpan, ctx := util.StartSpanFromContext(ctx, "worker.deleteObjects",
-			util.ResourceName("worker.deleteObjects"), util.Tag("table", table))
-		if err := w.Resolver.DB.WithContext(ctx).Exec(fmt.Sprintf(baseQuery, table), lookbackPeriod).Error; err != nil {
-			log.WithContext(ctx).Error(e.Wrapf(err, "error deleting expired objects from %s", table))
-		}
-		deleteSpan.Finish()
-	}
-}
-
 // Autoresolves error groups that have not had any recent instances
 func (w *Worker) AutoResolveStaleErrors(ctx context.Context) {
 	autoResolver := NewAutoResolver(w.PublicResolver.Store, w.PublicResolver.DB)
@@ -609,14 +584,6 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 		return errors.Wrap(err, "error creating payload manager")
 	}
 	defer payloadManager.Close()
-
-	if !s.AvoidPostgresStorage {
-		// Delete any timeline indicator events which were previously written for this session
-		if err := w.Resolver.DB.WithContext(ctx).Where("session_secure_id = ?", s.SecureID).
-			Delete(&model.TimelineIndicatorEvent{}).Error; err != nil {
-			log.WithContext(ctx).Error(e.Wrap(err, "error deleting outdated timeline indicator events"))
-		}
-	}
 
 	// Delete any event chunks which were previously written for this session
 	if err := w.Resolver.DB.WithContext(ctx).Where("session_id = ?", s.ID).
@@ -669,30 +636,25 @@ func (w *Worker) processSession(ctx context.Context, s *model.Session) error {
 				Data:            parsedData,
 			})
 		}
-		if s.AvoidPostgresStorage {
-			eventBytes, err := json.Marshal(eventsForTimelineIndicator)
-			if err != nil {
-				log.WithContext(ctx).Error(e.Wrap(err, "error marshalling eventsForTimelineIndicator"))
-			}
-			if err := payloadManager.TimelineIndicatorEvents.WriteString(string(eventBytes)); err != nil {
-				log.WithContext(ctx).Error(e.Wrap(err, "error writing to TimelineIndicatorEvents"))
-			}
-			if err := payloadManager.TimelineIndicatorEvents.Close(); err != nil {
-				log.WithContext(ctx).Error(e.Wrap(err, "error closing TimelineIndicatorEvents writer"))
-			}
 
-			// Extract and save the user journey steps from the timeline indicator events
-			userJourneySteps, err := journey_handlers.GetUserJourneySteps(s.ProjectID, s.ID, eventBytes)
-			if err != nil {
-				return err
-			}
-			if err := w.Resolver.DB.WithContext(ctx).Model(&model.UserJourneyStep{}).Save(&userJourneySteps).Error; err != nil {
-				return err
-			}
-		} else {
-			if err := w.Resolver.DB.WithContext(ctx).Create(eventsForTimelineIndicator).Error; err != nil {
-				log.WithContext(ctx).Error(e.Wrap(err, "error creating events for timeline indicator"))
-			}
+		eventBytes, err := json.Marshal(eventsForTimelineIndicator)
+		if err != nil {
+			log.WithContext(ctx).Error(e.Wrap(err, "error marshalling eventsForTimelineIndicator"))
+		}
+		if err := payloadManager.TimelineIndicatorEvents.WriteString(string(eventBytes)); err != nil {
+			log.WithContext(ctx).Error(e.Wrap(err, "error writing to TimelineIndicatorEvents"))
+		}
+		if err := payloadManager.TimelineIndicatorEvents.Close(); err != nil {
+			log.WithContext(ctx).Error(e.Wrap(err, "error closing TimelineIndicatorEvents writer"))
+		}
+
+		// Extract and save the user journey steps from the timeline indicator events
+		userJourneySteps, err := journey_handlers.GetUserJourneySteps(s.ProjectID, s.ID, eventBytes)
+		if err != nil {
+			return err
+		}
+		if err := w.Resolver.DB.WithContext(ctx).Model(&model.UserJourneyStep{}).Save(&userJourneySteps).Error; err != nil {
+			return err
 		}
 	}
 
@@ -1379,8 +1341,6 @@ func (w *Worker) GetHandler(ctx context.Context, handlerFlag string) func(ctx co
 		return w.BackfillStackFrames
 	case "refresh-materialized-views":
 		return w.RefreshMaterializedViews
-	case "delete-completed-sessions":
-		return w.DeleteCompletedSessions
 	case "public-worker-main":
 		return w.GetPublicWorker(kafkaqueue.TopicTypeDefault)
 	case "public-worker-batched":


### PR DESCRIPTION
## Summary
- removes `OrganizationID` fields - some of these were being migrated from int to bigint causing blocking
- manually tag current integer fields as `gorm:"type:integer"` to prevent attempted migration to bigint
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- compared output against prod for the following to confirm int fields were created:
```select distinct table_name, column_name, column_default from information_schema.columns where table_schema = 'public' and table_name not
 like 'error_object_embeddings_partitioned_%' and udt_name ilike 'int4' and column_default is null and table_name not ilike 'vadim%' and table_name
  not ilike 'zane%' and column_name <> 'organization_id' and table_name not in ('events_objects_partitioned', 'awsdms_ddl_audit', 'pg_buffercache',
  'organization_admins', 'spatial_ref_sys', 'geography_columns', 'geometry_columns')
  ```
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will re-deploy the gorm upgrade after this succeeds
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
