### PR TITLE
remove store from popover to fix hanging

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace.tsx
@@ -428,15 +428,7 @@ const StackTraceSectionCollapsible: React.FC<
 const SourcemapError: React.FC<{
 	errorObjectId: string
 	metadata?: Maybe<SourceMappingError>
-}> = ({ errorObjectId, metadata }) => {
-	const popoverStore = Popover.useStore({ placement: 'bottom-start' })
-
-	// Ensures the popover is closed when the error instance changes.
-	React.useEffect(() => {
-		popoverStore.setOpen(false)
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [errorObjectId])
-
+}> = ({ metadata }) => {
 	if (!metadata) {
 		return null
 	}
@@ -448,7 +440,7 @@ const SourcemapError: React.FC<{
 			onClick={(e) => e.stopPropagation()}
 			display="flex"
 		>
-			<Popover store={popoverStore}>
+			<Popover>
 				<Popover.TagTrigger
 					kind="secondary"
 					shape="basic"


### PR DESCRIPTION
## Summary
- error instance view hanging indefinitely whenever there's a sourcemap error
- not ideal to remove the store here but better than hanging, trying to see if there's a workaround
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
