### PR TITLE
fix percentage calculation for error metrics

### DIFF
--- a/backend/clickhouse/errors.go
+++ b/backend/clickhouse/errors.go
@@ -455,8 +455,15 @@ func (client *Client) QueryErrorGroupTags(ctx context.Context, projectId int, er
 			aggs[key].Buckets = append(aggs[key].Buckets, &modelInputs.ErrorGroupTagAggregationBucket{
 				Key:      bucket,
 				DocCount: int64(count),
-				Percent:  float64(count) / float64(total),
 			})
+		}
+	}
+
+	// In some versions of ClickHouse, the total result will not always be returned first,
+	// so calculate each bucket's percentage after iterating through the results.
+	for _, value := range aggs {
+		for _, bucket := range value.Buckets {
+			bucket.Percent = float64(bucket.DocCount) / float64(total)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- despite being first in the `UNION ALL` statement, the total row might not be returned first for certain versions of clickhouse
- fixes #7786 
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- was able to repro the original issue locally, confirmed that this change fixes it
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
