### PR TITLE
Animate related resource panel transitions

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7423,13 +7423,26 @@ body {
   bottom: 0;
   z-index: 30000;
   position: fixed;
+  transition: transform 0.2s;
+  transform: translateX(100%);
+  will-change: transform;
+}
+._10o9hoe1[data-enter] {
+  transform: translateX(0);
 }
 ._10o9hoe2 {
   background-color: rgba(0, 0, 0, 0.05);
+  opacity: 0;
   transition: opacity 0.2s;
 }
+._10o9hoe2[data-enter] {
+  opacity: 1;
+}
+._10o9hoe2[data-leave] {
+  opacity: 0;
+}
 ._10o9hoe3 {
-  cursor: ew-resize;
+  cursor: col-resize;
   position: absolute;
   left: -2px;
   top: 0;

--- a/frontend/src/components/RelatedResources/ErrorPanel.tsx
+++ b/frontend/src/components/RelatedResources/ErrorPanel.tsx
@@ -56,7 +56,7 @@ export const ErrorPanel: React.FC<{ resource: RelatedError }> = ({
 	}, [resource.id])
 
 	return (
-		<Panel open={true}>
+		<>
 			<Panel.Header path={path}>
 				{!showLoading && (
 					<>
@@ -96,6 +96,6 @@ export const ErrorPanel: React.FC<{ resource: RelatedError }> = ({
 					</Box>
 				</Box>
 			)}
-		</Panel>
+		</>
 	)
 }

--- a/frontend/src/components/RelatedResources/Panel.css.ts
+++ b/frontend/src/components/RelatedResources/Panel.css.ts
@@ -17,16 +17,34 @@ export const panel = style([
 		bottom: 0,
 		zIndex: 30000,
 		position: 'fixed',
+		transition: 'transform 0.2s',
+		transform: 'translateX(100%)',
+		willChange: 'transform',
+		selectors: {
+			'&[data-enter]': {
+				transform: 'translateX(0)',
+			},
+			'&[data-leave]': {},
+		},
 	},
 ])
 
 export const backdrop = style({
 	backgroundColor: 'rgba(0, 0, 0, 0.05)',
+	opacity: 0,
 	transition: 'opacity 0.2s',
+	selectors: {
+		'&[data-enter]': {
+			opacity: 1,
+		},
+		'&[data-leave]': {
+			opacity: 0,
+		},
+	},
 })
 
 export const panelDragHandle = style({
-	cursor: 'ew-resize',
+	cursor: 'col-resize',
 	position: 'absolute',
 	left: -2,
 	top: 0,

--- a/frontend/src/components/RelatedResources/Panel.tsx
+++ b/frontend/src/components/RelatedResources/Panel.tsx
@@ -7,7 +7,9 @@ import { PanelHeader } from '@/components/RelatedResources/PanelHeader'
 
 import * as styles from './Panel.css'
 
+// Numbers are percentages
 const MIN_PANEL_WIDTH = 40
+const MAX_PANEL_WIDTH = 85
 
 type Props = React.PropsWithChildren<{
 	open: boolean
@@ -38,7 +40,10 @@ export const Panel: PanelComponent = ({ children, open }) => {
 					((window.innerWidth - e.clientX) / window.innerWidth) * 100
 
 				setPanelWidth(
-					newWidth > MIN_PANEL_WIDTH ? newWidth : MIN_PANEL_WIDTH,
+					Math.min(
+						Math.max(newWidth, MIN_PANEL_WIDTH),
+						MAX_PANEL_WIDTH,
+					),
 				)
 			}
 		},
@@ -76,14 +81,21 @@ export const Panel: PanelComponent = ({ children, open }) => {
 			store={dialogStore}
 			modal={false}
 			autoFocusOnShow={false}
+			hideOnEscape={true}
 			backdrop={<Box cssClass={styles.backdrop} />}
 			className={styles.panel}
 			style={{ width: `${panelWidth}%` }}
+			// unmountOnHide is required for this to work as expected when it's being
+			// rendered on top of another dialog.
+			unmountOnHide
 		>
 			<Box
 				ref={dragHandleRef}
 				cssClass={styles.panelDragHandle}
-				onMouseDown={() => setDragging(true)}
+				onMouseDown={(e) => {
+					e.preventDefault()
+					setDragging(true)
+				}}
 			/>
 
 			{children}

--- a/frontend/src/components/RelatedResources/RelatedResourcePanel.tsx
+++ b/frontend/src/components/RelatedResources/RelatedResourcePanel.tsx
@@ -3,6 +3,7 @@ import {
 	RelatedResource,
 	useRelatedResource,
 } from '@/components/RelatedResources/hooks'
+import { Panel } from '@/components/RelatedResources/Panel'
 import { SessionPanel } from '@/components/RelatedResources/SessionPanel'
 import { TracePanel } from '@/components/RelatedResources/TracePanel'
 
@@ -12,31 +13,17 @@ export type ResourcePanelProps = { resource: RelatedResource }
 export const RelatedResourcePanel: React.FC<Props> = ({}) => {
 	const { resource } = useRelatedResource()
 
-	if (!resource) {
-		return null
-	}
-
-	switch (resource.type) {
-		case 'session':
-			return (
-				<SessionPanel
-					key={`${resource.type}-${resource.id}`}
-					resource={resource}
-				/>
-			)
-		case 'error':
-			return (
-				<ErrorPanel
-					key={`${resource.type}-${resource.id}`}
-					resource={resource}
-				/>
-			)
-		case 'trace':
-			return (
-				<TracePanel
-					key={`${resource.type}-${resource.id}`}
-					resource={resource}
-				/>
-			)
-	}
+	return (
+		<Panel open={!!resource}>
+			{resource && resource.type === 'session' && (
+				<SessionPanel resource={resource} />
+			)}
+			{resource && resource.type === 'error' && (
+				<ErrorPanel resource={resource} />
+			)}
+			{resource && resource.type === 'trace' && (
+				<TracePanel resource={resource} />
+			)}
+		</Panel>
+	)
 }

--- a/frontend/src/pages/Traces/TraceErrors.tsx
+++ b/frontend/src/pages/Traces/TraceErrors.tsx
@@ -56,6 +56,7 @@ export const TraceErrors: React.FC = () => {
 							}}
 							size="small"
 							trackingId="trace-error_see-more"
+							style={{ flexShrink: 0 }}
 						>
 							See more
 						</Button>

--- a/frontend/src/pages/Traces/TracePanel.tsx
+++ b/frontend/src/pages/Traces/TracePanel.tsx
@@ -11,7 +11,6 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { useLocation, useNavigate, useOutletContext } from 'react-router-dom'
 
 import { PreviousNextGroup } from '@/components/PreviousNextGroup/PreviousNextGroup'
-import { useRelatedResource } from '@/components/RelatedResources/hooks'
 import { Trace } from '@/graph/generated/schemas'
 import { TracePage } from '@/pages/Traces/TracePage'
 import { TraceProvider } from '@/pages/Traces/TraceProvider'
@@ -39,7 +38,6 @@ export const TracePanel: React.FC = () => {
 	)
 	const nextTrace = traces[currentTraceIndex + 1]
 	const previousTrace = traces[currentTraceIndex - 1]
-	const { resource } = useRelatedResource()
 
 	const traceDialogStore = Dialog.useStore({
 		open: true,
@@ -85,7 +83,6 @@ export const TracePanel: React.FC = () => {
 			store={traceDialogStore}
 			modal={false}
 			autoFocusOnShow={false}
-			hideOnInteractOutside={!resource}
 			className={styles.dialog}
 		>
 			<Box borderBottom="dividerWeak" py="6" pl="12" pr="8">

--- a/frontend/src/pages/Traces/TracePanel.tsx
+++ b/frontend/src/pages/Traces/TracePanel.tsx
@@ -85,6 +85,7 @@ export const TracePanel: React.FC = () => {
 			store={traceDialogStore}
 			modal={false}
 			autoFocusOnShow={false}
+			hideOnInteractOutside={!resource}
 			className={styles.dialog}
 		>
 			<Box borderBottom="dividerWeak" py="6" pl="12" pr="8">

--- a/frontend/src/pages/Traces/TracePanel.tsx
+++ b/frontend/src/pages/Traces/TracePanel.tsx
@@ -11,6 +11,7 @@ import { useHotkeys } from 'react-hotkeys-hook'
 import { useLocation, useNavigate, useOutletContext } from 'react-router-dom'
 
 import { PreviousNextGroup } from '@/components/PreviousNextGroup/PreviousNextGroup'
+import { useRelatedResource } from '@/components/RelatedResources/hooks'
 import { Trace } from '@/graph/generated/schemas'
 import { TracePage } from '@/pages/Traces/TracePage'
 import { TraceProvider } from '@/pages/Traces/TraceProvider'
@@ -38,6 +39,7 @@ export const TracePanel: React.FC = () => {
 	)
 	const nextTrace = traces[currentTraceIndex + 1]
 	const previousTrace = traces[currentTraceIndex - 1]
+	const { resource } = useRelatedResource()
 
 	const traceDialogStore = Dialog.useStore({
 		open: true,
@@ -55,10 +57,6 @@ export const TracePanel: React.FC = () => {
 			`/${projectId}/traces/${trace.traceID}/${trace.spanID}${location.search}`,
 		)
 	}
-
-	useHotkeys('esc', () => {
-		traceDialogStore.hide()
-	})
 
 	useHotkeys(
 		'j',


### PR DESCRIPTION
## Summary

Adds an animation to the related resource panel transitioning it in/out from the right side of the screen. There are also a couple bug fixes going out in this PR:

1. Prevents the text on related error buttons from spanning multiple lines in the errors list on a trace.
2. Fixes an issue where the hotkeys weren't behaving as expected when the trace dialog + the related resource dialog were being shown.
3. Updates the cursor on the reside handle to be `col-resize` instead of `ew-resize`.
4. Sets a max width you can drag the panel to.

**Before**
https://www.loom.com/share/2a01aa8400264fd9bf4884b051c65d5b

**After**
https://www.loom.com/share/d8951dff3e884546b468a3e492494ee0

## How did you test this change?

Screen shared with Julian and click tested the until we were happy with the animation. Also click tested in PR preview to ensure it was looking good across all areas of the product and that keyboard shortcuts were behaving as expected.

## Are there any deployment considerations?

N/A - client-side only change.

## Does this work require review from our design team?

Paired w/ Julian on these changes so he has seen them already.