### PR TITLE
add gorm type for JSONB fields

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -190,7 +190,6 @@ var Models = []interface{}{
 	&IntegrationWorkspaceMapping{},
 	&EmailOptOut{},
 	&BillingEmailHistory{},
-	&Retryable{},
 	&Service{},
 	&SetupEvent{},
 	&SessionAdminsView{},
@@ -713,7 +712,7 @@ type Session struct {
 	Environment    string   `json:"environment"`
 	AppVersion     *string  `json:"app_version"`
 	ServiceName    string
-	UserObject     JSONB  `json:"user_object" sql:"type:jsonb"`
+	UserObject     JSONB  `json:"user_object" sql:"type:jsonb" gorm:"type:jsonb"`
 	UserProperties string `json:"user_properties"`
 	// Whether this is the first session created by this user.
 	FirstTime               *bool      `json:"first_time" gorm:"default:false"`
@@ -733,7 +732,7 @@ type Session struct {
 	// The version of Highlight's Firstload.
 	FirstloadVersion string `json:"firstload_version"`
 	// The client configuration that the end-user sets up. This is used for debugging purposes.
-	ClientConfig *string `json:"client_config" sql:"type:jsonb"`
+	ClientConfig *string `json:"client_config" sql:"type:jsonb" gorm:"type:jsonb"`
 	// Determines whether this session should be viewable. This enforces billing.
 	WithinBillingQuota *bool `json:"within_billing_quota" gorm:"default:true"`
 	// Used for shareable links. No authentication is needed if IsPublic is true
@@ -1266,7 +1265,7 @@ type TimelineIndicatorEvent struct {
 	Timestamp       float64
 	Type            int
 	SID             float64
-	Data            JSONB `json:"data" sql:"type:jsonb"`
+	Data            JSONB `json:"data" sql:"type:jsonb" gorm:"type:jsonb"`
 }
 
 type RageClickEvent struct {
@@ -1404,7 +1403,7 @@ type Retryable struct {
 	Type        RetryableType
 	PayloadType string
 	PayloadID   string
-	Payload     JSONB `sql:"type:jsonb"`
+	Payload     JSONB `sql:"type:jsonb" gorm:"type:jsonb"`
 	Error       string
 }
 

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -657,6 +657,7 @@ func TestInitializeSessionImpl(t *testing.T) {
 		session, err := resolver.InitializeSessionImpl(ctx, &kafka_queue.InitializeSessionArgs{
 			ProjectVerboseID: project.VerboseID(),
 			ServiceName:      "my-frontend-app",
+			ClientConfig:     "{}",
 		})
 		assert.NoError(t, err)
 		assert.NotNil(t, session.ID)


### PR DESCRIPTION
## Summary
- newer version of GORM wants to migrate these fields to `type:text`, explicitly tag to make sure automigrate doesn't happen
- remove `Retryable` from automigrated models as it is unused, it also has `type:text` on this field
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran `make start` locally to automigrate, made sure all of these columns had `jsonb` type
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- want to deploy this to fix automigrate in previous GORM PR, can revert this and previous commit if issues
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
