### PR TITLE
Deep stringify body objects

### DIFF
--- a/.changeset/orange-cougars-admire.md
+++ b/.changeset/orange-cougars-admire.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+Deep stringify network request and response bodies

--- a/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
@@ -1,3 +1,5 @@
+import stringify from 'json-stringify-safe'
+
 import { NetworkListenerCallback } from '../network-listener'
 import { Headers, Request, RequestResponsePair, Response } from './models'
 import {
@@ -237,7 +239,7 @@ const getBodyData = (postData: any, url: string | undefined) => {
 		typeof postData === 'number' ||
 		typeof postData === 'boolean'
 	) {
-		return JSON.stringify(postData)
+		return stringify(postData)
 	}
 
 	return null

--- a/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/xhr-listener.ts
@@ -237,7 +237,7 @@ const getBodyData = (postData: any, url: string | undefined) => {
 		typeof postData === 'number' ||
 		typeof postData === 'boolean'
 	) {
-		return postData.toString()
+		return JSON.stringify(postData)
 	}
 
 	return null


### PR DESCRIPTION
## Summary
The XHR headers were being stringified with `toString()`, which does not do a deep stringify for objects, resulting in loss of info. Use `JSON.parse` to deep stringify the objects

## How did you test this change?
https://www.loom.com/share/c98209ea9ce447008ff1caf5e6ceea03

1) In the browser console, test with the following variables: `JSON.parse(a)`
- [ ] `let a = 1`
- [ ] `let a = true`
- [ ] `let a = { b: 2 }`
- [ ] `let a = { { b: 2 } }`

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
