### PR TITLE
Fix error group queries by secure ID

### DIFF
--- a/backend/clickhouse/errors.go
+++ b/backend/clickhouse/errors.go
@@ -22,6 +22,7 @@ type ClickhouseErrorGroup struct {
 	CreatedAt           int64
 	UpdatedAt           int64
 	ID                  int64
+	SecureID            string
 	Event               string
 	Status              string
 	Type                string
@@ -64,6 +65,7 @@ func (client *Client) WriteErrorGroups(ctx context.Context, groups []*model.Erro
 			CreatedAt: group.CreatedAt.UTC().UnixMicro(),
 			UpdatedAt: group.UpdatedAt.UTC().UnixMicro(),
 			ID:        int64(group.ID),
+			SecureID:  group.SecureID,
 			Event:     group.Event,
 			Status:    string(group.State),
 			Type:      group.Type,
@@ -160,7 +162,7 @@ func (client *Client) WriteErrorObjects(ctx context.Context, objects []*model.Er
 	return nil
 }
 
-func getErrorQueryImpl(tableName string, selectColumns string, query modelInputs.ClickhouseQuery, projectId int, retentionDate time.Time, groupBy *string, orderBy *string, limit *int, offset *int) (string, []interface{}, error) {
+func getErrorQueryImpl(tableName string, selectColumns string, query modelInputs.ClickhouseQuery, projectId int, groupBy *string, orderBy *string, limit *int, offset *int) (string, []interface{}, error) {
 	rules, err := deserializeRules(query.Rules)
 	if err != nil {
 		return "", nil, err
@@ -205,7 +207,7 @@ func (client *Client) QueryErrorGroupIds(ctx context.Context, projectId int, cou
 	}
 	offset := (pageInt - 1) * count
 
-	sql, args, err := getErrorQueryImpl(ErrorGroupsTable, "ID, count() OVER() AS total", query, projectId, retentionDate, nil, pointy.String("UpdatedAt DESC, ID DESC"), pointy.Int(count), pointy.Int(offset))
+	sql, args, err := getErrorQueryImpl(ErrorGroupsTable, "ID, count() OVER() AS total", query, projectId, nil, pointy.String("UpdatedAt DESC, ID DESC"), pointy.Int(count), pointy.Int(offset))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -522,7 +524,7 @@ func (client *Client) QueryErrorHistogram(ctx context.Context, projectId int, qu
 
 	orderBy := fmt.Sprintf("1 WITH FILL FROM %s(?, '%s') TO %s(?, '%s') STEP 1", aggFn, location.String(), aggFn, location.String())
 
-	sql, args, err := getErrorQueryImpl(ErrorObjectsTable, selectCols, query, projectId, retentionDate, pointy.String("1"), &orderBy, nil, nil)
+	sql, args, err := getErrorQueryImpl(ErrorObjectsTable, selectCols, query, projectId, pointy.String("1"), &orderBy, nil, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/backend/clickhouse/migrations/000093_add_secure_id_to_errors.down.sql
+++ b/backend/clickhouse/migrations/000093_add_secure_id_to_errors.down.sql
@@ -1,0 +1,2 @@
+alter table error_groups
+    drop column SecureID;

--- a/backend/clickhouse/migrations/000093_add_secure_id_to_errors.up.sql
+++ b/backend/clickhouse/migrations/000093_add_secure_id_to_errors.up.sql
@@ -1,0 +1,2 @@
+alter table error_groups
+    add column SecureID String;

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -53,7 +53,7 @@ var fieldMap map[string]string = map[string]string{
 	"browser":           "Browser",
 	"visited_url":       "VisitedURL",
 	"timestamp":         "Timestamp",
-	"secure_id":         "ErrorGroupSecureID",
+	"secure_id":         "SecureID",
 	"service_name":      "ServiceName",
 	"service_version":   "ServiceVersion",
 	"Tag":               "ErrorTagTitle",

--- a/frontend/src/components/CommandBar/context.tsx
+++ b/frontend/src/components/CommandBar/context.tsx
@@ -115,15 +115,18 @@ export const CommandBarContextProvider: React.FC<React.PropsWithChildren> = ({
 	})
 
 	const query = formStore.useValue('search').trim()
+	const startDate = formStore.useValue('selectedDates')[0]
+	const endDate = formStore.useValue('selectedDates')[1]
+	const selectedPreset = formStore.useValue('selectedPreset')
 	const searchAttribute = useAttributeSearch(formStore)
 
 	formStore.useSubmit(() => {
 		if (query) {
 			searchAttribute(currentAttribute, {
 				timeRange: {
-					startDate: formStore.useValue('selectedDates')[0],
-					endDate: formStore.useValue('selectedDates')[1],
-					selectedPreset: formStore.useValue('selectedPreset'),
+					startDate,
+					endDate,
+					selectedPreset,
 				},
 			})
 		}

--- a/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorFeedCard/ErrorFeedCard.tsx
@@ -43,7 +43,10 @@ export const ErrorFeedCard = ({ errorGroup, onClick }: Props) => {
 		<Link
 			to={
 				onClick
-					? {}
+					? {
+							pathname: location.pathname,
+							search: location.search,
+					  }
 					: {
 							pathname: `/${projectId}/errors/${errorGroup?.secure_id}`,
 							search: location.search,

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceErrors.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceErrors.tsx
@@ -29,8 +29,6 @@ export const NetworkResourceErrors: React.FC<{
 		variables: {
 			query: {
 				isAnd: true,
-				// TODO: Fix this query. Is broken after migrating to querying
-				// clickhouse because there's no secure_id on the error_groups table.
 				rules: [['error_secure_id', 'is', ...errorGroupSecureIds]],
 				dateRange: {
 					start_date: start,

--- a/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ProjectRouter.tsx
@@ -112,7 +112,7 @@ export const ProjectRouter = () => {
 		?.pop()
 
 	const [rightPanelView, setRightPanelView] = useLocalStorage<RightPanelView>(
-		'tabs-right-panel-view',
+		'active-right-panel-view',
 		RightPanelView.Session,
 	)
 


### PR DESCRIPTION
## Summary

* Populates the `SecureID` field on the `error_groups` Clickhouse table.
* Fixes the query fetching errors associated with a network resource ("Errors" tab on the network resource panel.
* Clean up an unused argument in `getErrorQueryImpl` (`retentionDate`).
* Fixes a bug with the "Enter" key not working or selecting a command bar item (an issue @Vadman97 and I noticed while pairing).
* Updates the local storage key for the active right panel when viewing a session (Closes HIG-4407).

## How did you test this change?

* Viewed an error
* View the related session
* Viewed the network resource associated with the error and confirmed the "Errors" tab was populated correctly
* Viewed the network panel and confirmed the `GetErrorGroupsClickhouse` query was errored on prod and working on this branch
* Opened the command bar, typed a query, and used the keyboard to navigate + press "Enter" to select an item
* Click tested to ensure the right panel on a session behaved as expected

## Are there any deployment considerations?

Need to confirm the changes to `fieldMap` won't break anything. Question out to @mayberryzane on this.

## Does this work require review from our design team?

N/A
