### PR TITLE
correctly generate session reports for large projects

### DIFF
--- a/frontend/src/util/session/report.ts
+++ b/frontend/src/util/session/report.ts
@@ -199,15 +199,17 @@ export const useGenerateSessionsReportCSV = () => {
 				...getSessionRows(sessions),
 			]
 
-			let csvContent = 'data:text/csv;charset=utf-8,'
-			rows.forEach((rowArray) => {
-				const row = rowArray
-					.map((col) =>
-						col ? col.toString().replaceAll(/[,;\t]/gi, '|') : '',
-					)
-					.join(',')
-				csvContent += row + '\r\n'
-			})
+			const csvContent = rows
+				.map((rowArray) =>
+					rowArray
+						.map((col) =>
+							col
+								? col.toString().replaceAll(/[,;\t]/gi, '|')
+								: '',
+						)
+						.join(','),
+				)
+				.join('\r\n')
 			console.info(
 				`collected sessions report with ${rows.length} rows, ${csvContent.length} long string.`,
 			)

--- a/frontend/src/util/session/report.ts
+++ b/frontend/src/util/session/report.ts
@@ -11,7 +11,6 @@ import {
 } from '@graph/schemas'
 import { useProjectId } from '@hooks/useProjectId'
 import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext'
-import { H } from 'highlight.run'
 import moment from 'moment/moment'
 
 const processRows = <
@@ -33,10 +32,7 @@ const processRows = <
 	for (let input of inputs) {
 		try {
 			input = { ...input, ...JSON.parse(input.user_properties ?? '') }
-		} catch (e: any) {
-			console.error(`Failed to parse user input: ${e}`)
-			H.consumeError(e)
-		}
+		} catch (e) {}
 		Object.keys(input).forEach((key, idx) => {
 			if (!keys.hasOwnProperty(key)) {
 				keys[key as keyof T] = idx
@@ -51,10 +47,7 @@ const processRows = <
 		let data = session
 		try {
 			data = { ...data, ...JSON.parse(session.user_properties ?? '') }
-		} catch (e: any) {
-			console.error(`Failed to parse session user input: ${e}`)
-			H.consumeError(e)
-		}
+		} catch (e) {}
 		rows.push(
 			Object.entries(keys)
 				.filter(([k]) => !ignoreKeys.has(k as keyof T))

--- a/frontend/src/util/session/report.ts
+++ b/frontend/src/util/session/report.ts
@@ -11,6 +11,7 @@ import {
 } from '@graph/schemas'
 import { useProjectId } from '@hooks/useProjectId'
 import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext'
+import { H } from 'highlight.run'
 import moment from 'moment/moment'
 
 const processRows = <
@@ -32,7 +33,10 @@ const processRows = <
 	for (let input of inputs) {
 		try {
 			input = { ...input, ...JSON.parse(input.user_properties ?? '') }
-		} catch (e) {}
+		} catch (e: any) {
+			console.error(`Failed to parse user input: ${e}`)
+			H.consumeError(e)
+		}
 		Object.keys(input).forEach((key, idx) => {
 			if (!keys.hasOwnProperty(key)) {
 				keys[key as keyof T] = idx
@@ -47,7 +51,10 @@ const processRows = <
 		let data = session
 		try {
 			data = { ...data, ...JSON.parse(session.user_properties ?? '') }
-		} catch (e) {}
+		} catch (e: any) {
+			console.error(`Failed to parse session user input: ${e}`)
+			H.consumeError(e)
+		}
 		rows.push(
 			Object.entries(keys)
 				.filter(([k]) => !ignoreKeys.has(k as keyof T))

--- a/frontend/src/util/session/report.ts
+++ b/frontend/src/util/session/report.ts
@@ -99,9 +99,10 @@ const getSessionRows = (sessions: Session[]) => {
 	return processRows(sessions, new Set<keyof Session>(['id', 'event_counts']))
 }
 
-const exportFile = async (name: string, encodedUri: string) => {
+const exportFile = async (name: string, content: string) => {
+	const blob = new Blob([content], { type: 'text/csv' })
 	const link = document.createElement('a')
-	link.setAttribute('href', encodedUri)
+	link.setAttribute('href', window.URL.createObjectURL(blob))
 	link.setAttribute('download', name)
 	document.body.appendChild(link) // Required for FF
 
@@ -197,7 +198,6 @@ export const useGenerateSessionsReportCSV = () => {
 				[],
 				...getSessionRows(sessions),
 			]
-			console.info(`collected sessions report with ${rows} rows.`)
 
 			let csvContent = 'data:text/csv;charset=utf-8,'
 			rows.forEach((rowArray) => {
@@ -208,7 +208,10 @@ export const useGenerateSessionsReportCSV = () => {
 					.join(',')
 				csvContent += row + '\r\n'
 			})
-			await exportFile('sessions_results.csv', encodeURI(csvContent))
+			console.info(
+				`collected sessions report with ${rows.length} rows, ${csvContent.length} long string.`,
+			)
+			await exportFile('sessions_results.csv', csvContent)
 		},
 	}
 }

--- a/frontend/src/util/session/report.ts
+++ b/frontend/src/util/session/report.ts
@@ -179,8 +179,14 @@ export const useGenerateSessionsReportCSV = () => {
 			) {
 				promises.push(getSessions(page))
 			}
-			const results = await Promise.all(promises)
-			sessions.push(...results.map((r) => r.sessions).flat())
+			const results = await Promise.allSettled(promises)
+			sessions.push(
+				...results
+					.map((r) =>
+						r.status === 'fulfilled' ? r.value.sessions : [],
+					)
+					.flat(),
+			)
 
 			const rows: any[][] = [
 				...getQueryRows(startDate, endDate, query, sessions),

--- a/frontend/src/util/session/report.ts
+++ b/frontend/src/util/session/report.ts
@@ -197,6 +197,7 @@ export const useGenerateSessionsReportCSV = () => {
 				[],
 				...getSessionRows(sessions),
 			]
+			console.info(`collected sessions report with ${rows} rows.`)
 
 			let csvContent = 'data:text/csv;charset=utf-8,'
 			rows.forEach((rowArray) => {


### PR DESCRIPTION
## Summary

Fixes frontend session export report generation for large reports.

## How did you test this change?

before, report was truncated. now, full report is downloaded
<img width="279" alt="Screenshot 2024-03-11 at 17 15 40" src="https://github.com/highlight/highlight/assets/1351531/1131a8e8-724d-4206-b438-68c92a4d6236">

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
