### PR TITLE
use level attribute on logs as the severity

### DIFF
--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -209,6 +209,10 @@ func extractFields(ctx context.Context, params extractFieldsParams) (*extractedF
 		delete(fields.attrs, highlight.RequestIDAttribute)
 	}
 
+	if val, ok := fields.attrs[highlight.LogSeverityDefaultAttribute]; ok {
+		fields.logSeverity = val
+		delete(fields.attrs, highlight.LogSeverityDefaultAttribute)
+	}
 	if val, ok := fields.attrs[highlight.LogSeverityAttribute]; ok {
 		fields.logSeverity = val
 		delete(fields.attrs, highlight.LogSeverityAttribute)

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -41,6 +41,7 @@ const TraceKeyAttribute = "highlight.key"
 const LogEvent = "log"
 const LogSeverityAttribute = "log.severity"
 const LogMessageAttribute = "log.message"
+const LogSeverityDefaultAttribute = "level"
 
 const MetricEvent = "metric"
 const MetricSpanName = "highlight-metric"


### PR DESCRIPTION
## Summary

Applies log `level` attributes when explicitly set to allow customizing log level.

## How did you test this change?

Before
<img width="887" alt="Screenshot 2024-03-12 at 16 28 01" src="https://github.com/highlight/highlight/assets/1351531/f2c9aed7-7bd9-4a12-8833-bb5caeca6beb">

After
<img width="762" alt="Screenshot 2024-03-12 at 16 28 17" src="https://github.com/highlight/highlight/assets/1351531/4d258aaf-cbf3-4b62-a730-f4988b05ff4e">

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no