### PR TITLE
Fix out of order session requests

### DIFF
--- a/.changeset/thin-files-knock.md
+++ b/.changeset/thin-files-knock.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+Update websocket events to use absolute timestamps. Remove relative timestamps from all requests.

--- a/cypress/e2e/client.cy.js
+++ b/cypress/e2e/client.cy.js
@@ -28,9 +28,7 @@ describe('client recording spec', () => {
 						'encodedBodySize',
 						'initiatorType',
 						'name',
-						'responseEnd',
 						'responseEndAbs',
-						'startTime',
 						'startTimeAbs',
 						'transferSize',
 					])

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -68,7 +68,7 @@ const buildResources = (resources: NetworkResource[]) => {
 			if (!!a.startTimeAbs && !!b.startTimeAbs) {
 				return a.startTimeAbs - b.startTimeAbs
 			} else {
-				// used in older versions of the SDK
+				// used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
 				return a.startTime - b.startTime
 			}
 		})
@@ -85,6 +85,7 @@ const buildResources = (resources: NetworkResource[]) => {
 				updatedResource.duration =
 					resource.responseEndAbs - resource.startTimeAbs
 			} else if (resource.responseEnd && resource.startTime) {
+				// used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
 				updatedResource.duration =
 					resource.responseEnd - resource.startTime
 			}

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -24,6 +24,8 @@ interface ResourcesContext {
 }
 
 interface NetworkResource extends PerformanceResourceTiming {
+	startTimeAbs?: number
+	endTimeAbs?: number
 	// http specific
 	requestResponsePairs?: RequestResponsePair
 	displayName?: string

--- a/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
+++ b/frontend/src/pages/Player/ResourcesContext/ResourcesContext.tsx
@@ -25,7 +25,7 @@ interface ResourcesContext {
 
 interface NetworkResource extends PerformanceResourceTiming {
 	startTimeAbs: number
-	responseEndAbs?: number
+	responseEndAbs: number
 	// http specific
 	requestResponsePairs?: RequestResponsePair
 	displayName?: string

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceInfo.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceInfo.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from '@highlight-run/ui/components'
 import { getResponseStatusCode } from '@pages/Player/helpers'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { TableList, TableListItem } from '@/components/TableList/TableList'
 import { ErrorObject } from '@/graph/generated/schemas'
@@ -44,6 +44,27 @@ export const NetworkResourceInfo = ({
 		})
 	}, [selectedNetworkResource?.initiatorType])
 
+	const duration = useMemo(() => {
+		if (
+			selectedNetworkResource?.responseEndAbs &&
+			selectedNetworkResource?.startTimeAbs
+		) {
+			return (
+				selectedNetworkResource.responseEndAbs -
+				selectedNetworkResource.startTimeAbs
+			)
+		} else if (
+			selectedNetworkResource?.responseEnd &&
+			selectedNetworkResource?.startTime
+		) {
+			// used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
+			return (
+				selectedNetworkResource.responseEnd -
+				selectedNetworkResource.startTime
+			)
+		}
+	}, [selectedNetworkResource])
+
 	const generalData: TableListItem[] = [
 		{
 			keyDisplayValue: 'Request URL',
@@ -74,13 +95,7 @@ export const NetworkResourceInfo = ({
 		},
 		{
 			keyDisplayValue: 'Time',
-			valueDisplayValue:
-				selectedNetworkResource?.responseEnd &&
-				selectedNetworkResource?.startTime &&
-				formatTime(
-					selectedNetworkResource.responseEnd -
-						selectedNetworkResource.startTime,
-				),
+			valueDisplayValue: !!duration && formatTime(duration),
 		},
 		{
 			keyDisplayValue: 'Type',

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
@@ -40,14 +40,20 @@ export const NetworkResourceLogs: React.FC<{
 	}>()
 	const requestId = resource.requestResponsePairs?.request?.id
 	const [query, setQuery] = useState('')
-	const startDate = useMemo(
-		() => new Date(sessionStartTime + resource.startTime - TIME_BUFFER),
-		[sessionStartTime, resource.startTime],
-	)
-	const endDate = useMemo(
-		() => new Date(sessionStartTime + resource.responseEnd + TIME_BUFFER),
-		[resource.responseEnd, sessionStartTime],
-	)
+	const startDate = useMemo(() => {
+		// startTime used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
+		const resourceStart =
+			resource.startTimeAbs ?? sessionStartTime + resource.startTime
+
+		return new Date(resourceStart - TIME_BUFFER)
+	}, [sessionStartTime, resource.startTimeAbs, resource.startTime])
+	const endDate = useMemo(() => {
+		// responseEnd used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
+		const resourceEnd =
+			resource.responseEndAbs ?? sessionStartTime + resource.responseEnd
+
+		return new Date(resourceEnd - TIME_BUFFER)
+	}, [sessionStartTime, resource.responseEndAbs, resource.responseEnd])
 
 	const {
 		logEdges,

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
@@ -486,9 +486,7 @@ function WebSocketDetails({
 					<Badge
 						label={
 							showPlayerAbsoluteTime
-								? moment(new Date(resource.timestamp)).format(
-										'h:mm:ss A',
-								  )
+								? moment(resource.timestamp).format('h:mm:ss A')
 								: MillisToMinutesAndSeconds(
 										resource.relativeStartTime,
 								  )

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
@@ -17,8 +17,8 @@ import { useReplayerContext } from '@pages/Player/ReplayerContext'
 import { useResourcesContext } from '@pages/Player/ResourcesContext/ResourcesContext'
 import { NetworkResource } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import analytics from '@util/analytics'
-import { playerTimeToSessionAbsoluteTime } from '@util/session/utils'
 import { MillisToMinutesAndSeconds } from '@util/time'
+import moment from 'moment'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
@@ -302,14 +302,13 @@ function NetworkResourceDetails({
 
 				<Box display="flex" alignItems="center" gap="4">
 					<Badge
-						label={String(
+						label={
 							showPlayerAbsoluteTime
-								? playerTimeToSessionAbsoluteTime({
-										sessionStartTime: startTime,
-										relativeTime: timestamp,
-								  })
-								: MillisToMinutesAndSeconds(timestamp),
-						)}
+								? moment(resource.timestamp).format('h:mm:ss A')
+								: MillisToMinutesAndSeconds(
+										resource.relativeStartTime,
+								  )
+						}
 						size="medium"
 						shape="basic"
 						variant="gray"
@@ -358,11 +357,7 @@ function WebSocketDetails({
 	const [activeTab, setActiveTab] = useState<WebSocketTabs>(
 		WebSocketTabs.Headers,
 	)
-	const {
-		sessionMetadata: { startTime },
-		setTime,
-		session,
-	} = useReplayerContext()
+	const { setTime, session } = useReplayerContext()
 	const { activeNetworkResourceId, setActiveNetworkResourceId } =
 		useActiveNetworkResourceId()
 
@@ -489,14 +484,15 @@ function WebSocketDetails({
 
 				<Box display="flex" alignItems="center" gap="4">
 					<Badge
-						label={String(
+						label={
 							showPlayerAbsoluteTime
-								? playerTimeToSessionAbsoluteTime({
-										sessionStartTime: startTime,
-										relativeTime: timestamp,
-								  })
-								: MillisToMinutesAndSeconds(timestamp),
-						)}
+								? moment(new Date(resource.timestamp)).format(
+										'h:mm:ss A',
+								  )
+								: MillisToMinutesAndSeconds(
+										resource.relativeStartTime,
+								  )
+						}
 						size="medium"
 						shape="basic"
 						variant="gray"

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
@@ -164,12 +164,19 @@ function NetworkResourceDetails({
 
 	const networkResources = useMemo(() => {
 		return (
-			(resources.map((event) => ({
-				...event,
-				timestamp: event.startTime,
-			})) as NetworkResource[]) ?? []
+			(resources.map((event) => {
+				// startTime used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
+				const resourceStartTime = event.startTimeAbs
+					? event.startTimeAbs - startTime
+					: event.startTime
+
+				return {
+					...event,
+					timestamp: resourceStartTime,
+				}
+			}) as NetworkResource[]) ?? []
 		)
-	}, [resources])
+	}, [resources, startTime])
 
 	const resourceIdx = resources.findIndex(
 		(r) => activeNetworkResourceId === r.id,
@@ -181,8 +188,11 @@ function NetworkResourceDetails({
 
 	const { showPlayerAbsoluteTime } = usePlayerConfiguration()
 	const timestamp = useMemo(() => {
-		return new Date(resource.startTime).getTime()
-	}, [resource.startTime])
+		// startTime used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
+		return resource.startTimeAbs
+			? resource.startTimeAbs - startTime
+			: new Date(resource.startTime).getTime()
+	}, [resource.startTime, resource.startTimeAbs, startTime])
 
 	const pages = useMemo(() => {
 		const tabPages: any = {
@@ -357,18 +367,29 @@ function WebSocketDetails({
 	const [activeTab, setActiveTab] = useState<WebSocketTabs>(
 		WebSocketTabs.Headers,
 	)
-	const { setTime, session } = useReplayerContext()
+	const {
+		sessionMetadata: { startTime },
+		setTime,
+		session,
+	} = useReplayerContext()
 	const { activeNetworkResourceId, setActiveNetworkResourceId } =
 		useActiveNetworkResourceId()
 
 	const networkResources = useMemo(() => {
 		return (
-			(resources.map((event) => ({
-				...event,
-				timestamp: event.startTime,
-			})) as NetworkResource[]) ?? []
+			(resources.map((event) => {
+				// startTime used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
+				const resourceStartTime = event.startTimeAbs
+					? event.startTimeAbs - startTime
+					: event.startTime
+
+				return {
+					...event,
+					timestamp: resourceStartTime,
+				}
+			}) as NetworkResource[]) ?? []
 		)
-	}, [resources])
+	}, [resources, startTime])
 
 	const resourceIdx = resources.findIndex(
 		(r) => activeNetworkResourceId === r.id,
@@ -380,8 +401,11 @@ function WebSocketDetails({
 
 	const { showPlayerAbsoluteTime } = usePlayerConfiguration()
 	const timestamp = useMemo(() => {
-		return new Date(resource.startTime).getTime()
-	}, [resource.startTime])
+		// startTime used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
+		return resource.startTimeAbs
+			? resource.startTimeAbs - startTime
+			: new Date(resource.startTime).getTime()
+	}, [resource.startTime, resource.startTimeAbs, startTime])
 
 	const { webSocketEvents, webSocketLoading } = useWebSocket(session)
 

--- a/frontend/src/pages/Player/RightPlayerPanel/components/WebSocketMessages/WebSocketMessages.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/WebSocketMessages/WebSocketMessages.tsx
@@ -8,6 +8,7 @@ import {
 	Text,
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
+import moment from 'moment'
 import { useRef } from 'react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
 
@@ -15,7 +16,6 @@ import LoadingBox from '@/components/LoadingBox'
 import usePlayerConfiguration from '@/pages/Player/PlayerHook/utils/usePlayerConfiguration'
 import { useReplayerContext } from '@/pages/Player/ReplayerContext'
 import { styledVerticalScrollbar } from '@/style/common.css'
-import { playerTimeToSessionAbsoluteTime } from '@/util/session/utils'
 import { MillisToMinutesAndSeconds } from '@/util/time'
 
 import * as styles from './WebSocketMessages.css'
@@ -102,11 +102,11 @@ const WebSocketRequestTypeIcon: { [k: string]: JSX.Element } = {
 	error: <IconSolidExclamation size={14} />,
 }
 
-const getWebSocketEventTime = (event: any) => {
+const getWebSocketEventTime = (event: any, sessionStart: number) => {
 	return event.type === 'open'
-		? event.startTime
+		? event.startTimeAbs ?? event.startTime + sessionStart
 		: event.type === 'close'
-		? event.requestEnd
+		? event.requestEndAbs ?? event.requestEnd + sessionStart
 		: event.timeStamp
 }
 
@@ -151,13 +151,17 @@ const WebSocketRow = ({
 				<Box color="secondaryContentText" px="8">
 					<Text size="small" weight="medium" lines="1">
 						{showPlayerAbsoluteTime
-							? playerTimeToSessionAbsoluteTime({
-									sessionStartTime: playerStartTime,
-									relativeTime:
-										getWebSocketEventTime(resource),
-							  })
+							? moment(
+									getWebSocketEventTime(
+										resource,
+										playerStartTime,
+									),
+							  ).format('h:mm:ss A')
 							: MillisToMinutesAndSeconds(
-									getWebSocketEventTime(resource),
+									getWebSocketEventTime(
+										resource,
+										playerStartTime,
+									) - playerStartTime,
 							  )}
 					</Text>
 				</Box>

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/components/RequestMetrics/RequestMetrics.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/components/RequestMetrics/RequestMetrics.tsx
@@ -72,10 +72,9 @@ const RequestMetrics: React.FC<Props> = ({ resource }) => {
 	const duration = useMemo(() => {
 		if (resource?.responseEndAbs && resource?.startTimeAbs) {
 			return resource.responseEndAbs - resource.startTimeAbs
-		} else if (resource?.responseEnd && resource?.startTime) {
-			// used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
-			return resource.responseEnd - resource.startTime
 		}
+		// used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
+		return resource.responseEnd - resource.startTime
 	}, [resource])
 
 	const metricConfig = {

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/components/RequestMetrics/RequestMetrics.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindow/ResourcePage/components/RequestMetrics/RequestMetrics.tsx
@@ -16,7 +16,7 @@ import { getGraphQLResolverName } from '@pages/Player/utils/utils'
 import { useParams } from '@util/react-router/useParams'
 import { Dropdown, Menu } from 'antd'
 import moment from 'moment'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 
 import styles from './RequestMetrics.module.css'
@@ -69,7 +69,15 @@ const RequestMetrics: React.FC<Props> = ({ resource }) => {
 		skip: !project_id,
 	})
 
-	const duration = resource.responseEnd - resource.startTime
+	const duration = useMemo(() => {
+		if (resource?.responseEndAbs && resource?.startTimeAbs) {
+			return resource.responseEndAbs - resource.startTimeAbs
+		} else if (resource?.responseEnd && resource?.startTime) {
+			// used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
+			return resource.responseEnd - resource.startTime
+		}
+	}, [resource])
+
 	const metricConfig = {
 		name: 'latency',
 		description: `Latency (${graphQlOperation || resource.name})`,

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -27,6 +27,7 @@ import {
 import { useParams } from '@util/react-router/useParams'
 import { formatTime, MillisToMinutesAndSeconds } from '@util/time'
 import _ from 'lodash'
+import moment from 'moment'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso'
 
@@ -39,7 +40,6 @@ import TextHighlighter from '../../../../../components/TextHighlighter/TextHighl
 import Tooltip from '../../../../../components/Tooltip/Tooltip'
 import { ReplayerState, useReplayerContext } from '../../../ReplayerContext'
 import * as styles from './style.css'
-import moment from 'moment'
 
 export const NetworkPage = ({
 	time,
@@ -400,9 +400,7 @@ const ResourceRow = ({
 					lines="1"
 				>
 					{showPlayerAbsoluteTime
-						? moment(new Date(resource.timestamp)).format(
-								'h:mm:ss A',
-						  )
+						? moment(resource.timestamp).format('h:mm:ss A')
 						: MillisToMinutesAndSeconds(resource.relativeStartTime)}
 				</Text>
 				<Text size="small" weight={showingDetails ? 'bold' : 'medium'}>

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -140,7 +140,9 @@ export const NetworkPage = ({
 
 		// Need to have timestamp for findLastActiveEventIndex.
 		current.forEach((resource) => {
-			resource.timestamp = resource.startTime + startTime
+			resource.timestamp =
+				// TODO(spenny): check for websockets and old versions
+				resource.startTimeAbs ?? resource.startTime + startTime
 		})
 
 		if (filter !== '') {

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -40,6 +40,7 @@ import TextHighlighter from '../../../../../components/TextHighlighter/TextHighl
 import Tooltip from '../../../../../components/Tooltip/Tooltip'
 import { ReplayerState, useReplayerContext } from '../../../ReplayerContext'
 import * as styles from './style.css'
+import moment from 'moment'
 
 export const NetworkPage = ({
 	time,
@@ -392,12 +393,16 @@ const ResourceRow = ({
 					weight={showingDetails ? 'bold' : 'medium'}
 					lines="1"
 				>
+					{/* TODO(spenny): use abolute times */}
 					{showPlayerAbsoluteTime
-						? playerTimeToSessionAbsoluteTime({
-								sessionStartTime: playerStartTime,
-								relativeTime: resource.startTime,
-						  })
-						: MillisToMinutesAndSeconds(resource.startTime)}
+						? moment(new Date(resource.startTimeAbs!)).format(
+								'h:mm:ss A',
+						  )
+						: moment(
+								new Date(
+									resource.startTimeAbs! - playerStartTime,
+								),
+						  ).format('h:mm:ss A')}
 				</Text>
 				<Text size="small" weight={showingDetails ? 'bold' : 'medium'}>
 					{resource.responseEnd && resource.startTime

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/NetworkPage/NetworkPage.tsx
@@ -142,7 +142,6 @@ export const NetworkPage = ({
 		// Need to have timestamp for findLastActiveEventIndex.
 		current.forEach((resource) => {
 			resource.timestamp =
-				// TODO(spenny): check for websockets and old versions
 				resource.startTimeAbs ?? resource.startTime + startTime
 		})
 
@@ -393,20 +392,21 @@ const ResourceRow = ({
 					weight={showingDetails ? 'bold' : 'medium'}
 					lines="1"
 				>
-					{/* TODO(spenny): use abolute times */}
 					{showPlayerAbsoluteTime
-						? moment(new Date(resource.startTimeAbs!)).format(
+						? moment(new Date(resource.timestamp)).format(
 								'h:mm:ss A',
 						  )
-						: moment(
-								new Date(
-									resource.startTimeAbs! - playerStartTime,
+						: MillisToMinutesAndSeconds(
+								Math.max(
+									new Date(resource.timestamp).getTime() -
+										playerStartTime,
+									0,
 								),
-						  ).format('h:mm:ss A')}
+						  )}
 				</Text>
 				<Text size="small" weight={showingDetails ? 'bold' : 'medium'}>
-					{resource.responseEnd && resource.startTime
-						? formatTime(resource.responseEnd - resource.startTime)
+					{!!resource.duration
+						? formatTime(resource.duration)
 						: 'N/A'}
 				</Text>
 				<Box cssClass={styles.timingBarWrapper}>

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -67,6 +67,7 @@ export type NetworkResource = NetworkResourceWithID &
 		requestResponsePairs?: RequestResponsePair
 		errors?: ErrorObject[]
 		offsetStartTime?: number
+		relativeStartTime: number
 	}
 
 /**

--- a/sdk/client/src/listeners/network-listener/utils/models.ts
+++ b/sdk/client/src/listeners/network-listener/utils/models.ts
@@ -30,8 +30,10 @@ export interface WebSocketRequest {
 	initiatorType: 'websocket'
 	type: 'open' | 'close'
 	name: string
-	startTime?: number
-	requestEnd?: number
+	// provided in open event type
+	startTimeAbs?: number
+	// provided in close event type (may not exist)
+	responseEndAbs?: number
 }
 
 export interface WebSocketEvent {

--- a/sdk/client/src/listeners/network-listener/utils/utils.ts
+++ b/sdk/client/src/listeners/network-listener/utils/utils.ts
@@ -206,9 +206,6 @@ export const matchPerformanceTimingsWithRequestResponsePair = (
 				performanceTiming.toJSON = function () {
 					return {
 						initiatorType: this.initiatorType,
-						// deprecated, use the absolute versions instead
-						startTime: this.startTime,
-						responseEnd: this.responseEnd,
 						// offset by `window.performance.timeOrigin` to get absolute timestamps
 						startTimeAbs:
 							window.performance.timeOrigin + this.startTime,

--- a/sdk/firstload/src/listeners/web-socket/index.ts
+++ b/sdk/firstload/src/listeners/web-socket/index.ts
@@ -23,23 +23,25 @@ export const initializeWebSocketListener = () => {
 				const socketId = createNetworkRequestId()
 				const webSocket = new target(...args)
 
+				// TODO(spenny): check that timestamp is absolute or relative
 				const openHandler = (event: Event) => {
 					window._highlightWebSocketRequestCallback({
 						socketId,
 						initiatorType: 'websocket',
 						type: 'open',
 						name: webSocket.url,
-						startTime: event.timeStamp,
+						startTimeAbs: event.timeStamp,
 					})
 				}
 
+				// TODO(spenny): check that timestamp is absolute or relative
 				const closeHandler = (event: CloseEvent) => {
 					window._highlightWebSocketRequestCallback({
 						socketId,
 						initiatorType: 'websocket',
 						type: 'close',
 						name: webSocket.url,
-						requestEnd: event.timeStamp,
+						responseEndAbs: event.timeStamp,
 					})
 
 					webSocket.removeEventListener('open', openHandler)

--- a/sdk/firstload/src/listeners/web-socket/index.ts
+++ b/sdk/firstload/src/listeners/web-socket/index.ts
@@ -23,25 +23,24 @@ export const initializeWebSocketListener = () => {
 				const socketId = createNetworkRequestId()
 				const webSocket = new target(...args)
 
-				// TODO(spenny): check that timestamp is absolute or relative
 				const openHandler = (event: Event) => {
 					window._highlightWebSocketRequestCallback({
 						socketId,
 						initiatorType: 'websocket',
 						type: 'open',
 						name: webSocket.url,
-						startTimeAbs: event.timeStamp,
+						startTimeAbs: performance.timeOrigin + event.timeStamp,
 					})
 				}
 
-				// TODO(spenny): check that timestamp is absolute or relative
 				const closeHandler = (event: CloseEvent) => {
 					window._highlightWebSocketRequestCallback({
 						socketId,
 						initiatorType: 'websocket',
 						type: 'close',
 						name: webSocket.url,
-						responseEndAbs: event.timeStamp,
+						responseEndAbs:
+							performance.timeOrigin + event.timeStamp,
 					})
 
 					webSocket.removeEventListener('open', openHandler)
@@ -68,7 +67,7 @@ export const initializeWebSocketListener = () => {
 						socketId,
 						type: 'received',
 						name: webSocket.url,
-						timeStamp: event.timeStamp,
+						timeStamp: performance.timeOrigin + event.timeStamp,
 						size,
 						message,
 					})
@@ -79,7 +78,7 @@ export const initializeWebSocketListener = () => {
 						socketId,
 						type: 'error',
 						name: webSocket.url,
-						timeStamp: event.timeStamp,
+						timeStamp: performance.timeOrigin + event.timeStamp,
 						size: 0,
 					})
 				}
@@ -112,7 +111,8 @@ export const initializeWebSocketListener = () => {
 							socketId,
 							type: 'sent',
 							name: webSocket.url,
-							timeStamp: performance.now(),
+							timeStamp:
+								performance.timeOrigin + performance.now(),
 							size,
 							message,
 						})


### PR DESCRIPTION
## Summary
Currently network resources and websocket events use relative times to the start of the performance api. This time is based on the the window's start time, which is reset when the page is navigated to or refreshed. This causes the events to be out of order when viewing a session.

Update the events to use an absolute time to be placed in the correct spot in the session.

https://www.loom.com/share/af1ebe59557648abaa28c38945abefd1?sid=a65948e2-938a-4f9c-8fb2-3c2c94011879

## How did you test this change?
1) Start a session
2) Let the page idle, navigate to and away, refresh the page
3) Complete some network requests in the window
4) Close the tab to let the session process
5) View the processed session
6) Test viewing in absolute and relative times
- [ ] All network requests are in correct order
- [ ] Jumping to a network request jumps tot he right place
- [ ] All labels for session length and event timestamps are correct 

## Are there any deployment considerations?
Let knows about how old versions of the SDK will be using `startTime` and `requestEnd`, but should no longer be used in code

## Does this work require review from our design team?
N/A
