### PR TITLE
fix frontend auth logic failing to persist across tabs

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -46,7 +46,7 @@ import {
 import { QueryParamProvider } from 'use-query-params'
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6'
 
-import { AUTH_MODE, PUBLIC_GRAPH_URI } from '@/constants'
+import { PUBLIC_GRAPH_URI } from '@/constants'
 import { SIGN_IN_ROUTE } from '@/pages/Auth/AuthRouter'
 import { authRedirect } from '@/pages/Auth/utils'
 import { onlyAllowHighlightStaff } from '@/util/authorization/authorizationUtils'
@@ -286,14 +286,6 @@ const AuthenticationRoleRouter = () => {
 	const firebaseInitialized = useRef(false)
 	const isAuthLoading = authRole === AuthRole.LOADING
 	const isLoggedIn = authRole === AuthRole.AUTHENTICATED
-
-	useEffect(() => {
-		const hasPasswordAuthorization = sessionStorage.getItem('passwordToken')
-		if (AUTH_MODE === 'password' && !hasPasswordAuthorization) {
-			auth.signOut()
-			navigate('/sign_in')
-		}
-	}, [navigate])
 
 	useEffect(() => {
 		if (adminData && user) {


### PR DESCRIPTION
## Summary

Fixes issues with password auth mode.
* Auth logic would use sessionStorage which would prevent it from persisting across tabs
* Auth logic would fail to validate the token on refresh, causing failed network requests if the token expired. 

Closes HIG-4358
Closes HIG-4356

## How did you test this change?

only affects hobby password auth
https://www.loom.com/share/d97916a494e44cb4aa07d327f1e74fea

## Are there any deployment considerations?

new docker release

## Does this work require review from our design team?

no