### PR TITLE
Fetch future logs and traces exclusively

### DIFF
--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -123,9 +123,9 @@ export const useGetLogs = ({
 				params: {
 					query,
 					date_range: {
-						start_date: moment(logResultMetadata.endDate).format(
-							TIME_FORMAT,
-						),
+						start_date: moment(logResultMetadata.endDate)
+							.add(1, 'second')
+							.format(TIME_FORMAT),
 						end_date: moment().format(TIME_FORMAT),
 					},
 				},

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -111,9 +111,9 @@ export const useGetTraces = ({
 				params: {
 					query,
 					date_range: {
-						start_date: moment(traceResultMetadata.endDate).format(
-							TIME_FORMAT,
-						),
+						start_date: moment(traceResultMetadata.endDate)
+							.add(1, 'second')
+							.format(TIME_FORMAT),
 						end_date: moment().format(TIME_FORMAT),
 					},
 				},


### PR DESCRIPTION
## Summary
When checking if more logs/traces exists, we use the timestamp of the last log/trace, which will include it in the query. Add one second to exclude this last log/trace

## How did you test this change?
1) Load the logs/traces page
2) In the network request, check that the start time is after the last log/trace that is dispayed
- [ ] Correct argument passed in as start time
- [ ] No duplicate logs returned in response that are already displayed

https://www.loom.com/share/ea6aa1e5feb647e1acdeb0a44074d24a?sid=7dcce538-e1ba-4b19-bbeb-3a6c1ac20b54

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
