### PR TITLE
add github action runner IP to RDS security group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
     push:
         branches:
             - 'main'
+            - 'zane/action_ip'
         paths:
             - 'go.work'
             - 'go.work.sum'
@@ -25,6 +26,17 @@ jobs:
                   cache-dependency-path: 'backend/go.sum'
             - name: Install Doppler CLI
               uses: dopplerhq/cli-action@v2
+            - name: Add public IP to AWS security group
+              uses: sohelamin/aws-security-group-add-ip-action@master
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: 'us-east-2'
+                  aws-security-group-id: ${{ secrets.AWS_RDS_SECURITY_GROUP_ID }}
+                  port: '5432'
+                  to-port: ''
+                  protocol: 'tcp'
+                  description: 'GitHub Action for migrate-database'
             - name: Migrate database
               run: |
                   cd backend/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
     push:
         branches:
             - 'main'
-            - 'zane/action_ip'
         paths:
             - 'go.work'
             - 'go.work.sum'

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -86,6 +86,18 @@ jobs:
                   NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID: 1jdkoe52
                   REACT_APP_COMMIT_SHA: abcdef1234567890a1b2c3d4e5f6fedcba098765
 
+            - name: Add public IP to AWS security group
+              uses: sohelamin/aws-security-group-add-ip-action@master
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: 'us-east-2'
+                  aws-security-group-id: ${{ secrets.AWS_RDS_SECURITY_GROUP_ID }}
+                  port: '5432'
+                  to-port: ''
+                  protocol: 'tcp'
+                  description: 'GitHub Action for Monorepo'
+
             - name: Test session screenshot lambda
               if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
               run: doppler run -- yarn test:render


### PR DESCRIPTION
## Summary
- need to allowlist the Github action runner's IP address in the security group rules to allow db access
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- added branch to action for testing, ran successfully; confirmed IP was added and later removed from security group
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
