### PR TITLE
support looping sessions for demoing

### DIFF
--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -1045,7 +1045,9 @@ export const usePlayer = (): ReplayerContextInterface => {
 	useEffect(() => {
 		if (state.replayerState === ReplayerState.SessionEnded && loopSession) {
 			log('PlayerHook.tsx', 'Looping session')
-			play(0).then(() => log('PlayerHook.tsx', 'Looped session'))
+			setTimeout(() => {
+				play(0).then(() => log('PlayerHook.tsx', 'Looped session'))
+			}, FRAME_MS * 120)
 		}
 	}, [play, loopSession, state.replayerState])
 

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -381,8 +381,7 @@ export const usePlayer = (): ReplayerContextInterface => {
 			log(
 				'PlayerHook.tsx:ensureChunksLoaded',
 				'checking chunk loaded status range',
-				startIdx,
-				endIdx,
+				{ startIdx, endIdx, stack: new Error().stack },
 			)
 			for (let i = startIdx; i <= endIdx; i++) {
 				log('PlayerHook.tsx:ensureChunksLoaded', 'has', i, {
@@ -509,7 +508,6 @@ export const usePlayer = (): ReplayerContextInterface => {
 			}
 
 			timerStart('timelineChangeTime')
-			dispatch({ type: PlayerActionType.setTime, time: newTime })
 			return new Promise<void>((r) =>
 				ensureChunksLoaded(
 					newTime,
@@ -1043,11 +1041,9 @@ export const usePlayer = (): ReplayerContextInterface => {
 	useEffect(() => {
 		if (state.replayerState === ReplayerState.SessionEnded && loopSession) {
 			log('PlayerHook.tsx', 'Looping session')
-			ensureChunksLoaded(0, undefined).then(() =>
-				log('PlayerHook.tsx', 'Looped session'),
-			)
+			play(0).then(() => log('PlayerHook.tsx', 'Looped session'))
 		}
-	}, [ensureChunksLoaded, loopSession, state.replayerState])
+	}, [play, loopSession, state.replayerState])
 
 	return {
 		...state,

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -381,7 +381,7 @@ export const usePlayer = (): ReplayerContextInterface => {
 			log(
 				'PlayerHook.tsx:ensureChunksLoaded',
 				'checking chunk loaded status range',
-				{ startIdx, endIdx, stack: new Error().stack },
+				{ action, startIdx, endIdx, stack: new Error() },
 			)
 			for (let i = startIdx; i <= endIdx; i++) {
 				log('PlayerHook.tsx:ensureChunksLoaded', 'has', i, {
@@ -414,10 +414,14 @@ export const usePlayer = (): ReplayerContextInterface => {
 					promises.push(loadEventChunk(i))
 				}
 			}
-			log('PlayerHook.tsx:ensureChunksLoaded', {
-				action,
-				promises: promises.length,
-			})
+			log(
+				'PlayerHook.tsx:ensureChunksLoaded',
+				'gathered chunk promises',
+				{
+					action,
+					promises: promises.length,
+				},
+			)
 			if (promises.length) {
 				const toRemove = getChunksToRemove(
 					chunkEventsRef.current,

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -36,6 +36,7 @@ import { H } from 'highlight.run'
 import _ from 'lodash'
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useLocalStorage } from 'react-use'
 import { EventType } from 'rrweb'
 import { BooleanParam, useQueryParam } from 'use-query-params'
 
@@ -67,6 +68,10 @@ export const usePlayer = (): ReplayerContextInterface => {
 		setShowRightPanel,
 		skipInactive,
 	} = usePlayerConfiguration()
+	const [loopSession] = useLocalStorage<boolean>(
+		'highlight-player-loop-session',
+		false,
+	)
 
 	const [markSessionAsViewed] = useMarkSessionAsViewedMutation()
 	const { refetch: rawFetchEventChunkURL } = useGetEventChunkUrlQuery({
@@ -1034,6 +1039,16 @@ export const usePlayer = (): ReplayerContextInterface => {
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [autoPlayVideo, state.eventsLoaded])
+
+	useEffect(() => {
+		if (state.replayerState === ReplayerState.SessionEnded && loopSession) {
+			log('PlayerHook.tsx', 'Looping session')
+			dispatch({
+				type: PlayerActionType.play,
+				time: 0,
+			})
+		}
+	}, [loopSession, state.replayerState])
 
 	return {
 		...state,

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -381,7 +381,7 @@ export const usePlayer = (): ReplayerContextInterface => {
 			log(
 				'PlayerHook.tsx:ensureChunksLoaded',
 				'checking chunk loaded status range',
-				{ action, startIdx, endIdx, stack: new Error() },
+				{ action, startIdx, endIdx },
 			)
 			for (let i = startIdx; i <= endIdx; i++) {
 				log('PlayerHook.tsx:ensureChunksLoaded', 'has', i, {

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -415,6 +415,10 @@ export const usePlayer = (): ReplayerContextInterface => {
 					promises.push(loadEventChunk(i))
 				}
 			}
+			log('PlayerHook.tsx:ensureChunksLoaded', {
+				action,
+				promises: promises.length,
+			})
 			if (promises.length) {
 				const toRemove = getChunksToRemove(
 					chunkEventsRef.current,
@@ -1039,9 +1043,11 @@ export const usePlayer = (): ReplayerContextInterface => {
 	useEffect(() => {
 		if (state.replayerState === ReplayerState.SessionEnded && loopSession) {
 			log('PlayerHook.tsx', 'Looping session')
-			play(0).then(() => log('PlayerHook.tsx', 'Looped session'))
+			ensureChunksLoaded(0, undefined).then(() =>
+				log('PlayerHook.tsx', 'Looped session'),
+			)
 		}
-	}, [loopSession, play, state.replayerState])
+	}, [ensureChunksLoaded, loopSession, state.replayerState])
 
 	return {
 		...state,

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -327,11 +327,7 @@ export const usePlayer = (): ReplayerContextInterface => {
 				log('PlayerHook.tsx', 'chunk data', {
 					chunkResponse,
 				})
-				log(
-					'PlayerHook.tsx:ensureChunksLoaded',
-					'set data for chunk',
-					_i,
-				)
+				log('PlayerHook.tsx:loadEventChunk', 'set data for chunk', _i)
 				return {
 					idx: _i,
 					events: toHighlightEvents(await chunkResponse.json()),
@@ -1043,12 +1039,9 @@ export const usePlayer = (): ReplayerContextInterface => {
 	useEffect(() => {
 		if (state.replayerState === ReplayerState.SessionEnded && loopSession) {
 			log('PlayerHook.tsx', 'Looping session')
-			dispatch({
-				type: PlayerActionType.play,
-				time: 0,
-			})
+			play(0).then(() => log('PlayerHook.tsx', 'Looped session'))
 		}
-	}, [loopSession, state.replayerState])
+	}, [loopSession, play, state.replayerState])
 
 	return {
 		...state,

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -984,7 +984,6 @@ export const usePlayer = (): ReplayerContextInterface => {
 	// ensures that chunks are loaded in advance during playback
 	// ensures we skip over inactivity periods
 	useEffect(() => {
-		return
 		if (
 			state.sessionMetadata.startTime === 0 ||
 			state.replayerState !== ReplayerState.Playing ||

--- a/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
+++ b/frontend/src/pages/Player/PlayerHook/PlayerHook.tsx
@@ -984,6 +984,7 @@ export const usePlayer = (): ReplayerContextInterface => {
 	// ensures that chunks are loaded in advance during playback
 	// ensures we skip over inactivity periods
 	useEffect(() => {
+		return
 		if (
 			state.sessionMetadata.startTime === 0 ||
 			state.replayerState !== ReplayerState.Playing ||

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -692,7 +692,11 @@ const updatePlayerTime = (s: PlayerState): PlayerState => {
 	// Compute the string rather than number here, so that dependencies don't
 	// have to re-render on every tick
 	if (s.isLiveMode && s.lastActiveTimestamp != 0) {
-		s.lastActiveString = moment(s.lastActiveTimestamp).from(time)
+		if (s.lastActiveTimestamp > time - 1000 * 60) {
+			s.lastActiveString = 'less than 1 minute ago'
+		} else {
+			s.lastActiveString = moment(s.lastActiveTimestamp).from(time)
+		}
 	} else if (s.lastActiveString !== null) {
 		s.lastActiveString = null
 	}

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -692,11 +692,7 @@ const updatePlayerTime = (s: PlayerState): PlayerState => {
 	// Compute the string rather than number here, so that dependencies don't
 	// have to re-render on every tick
 	if (s.isLiveMode && s.lastActiveTimestamp != 0) {
-		if (s.lastActiveTimestamp > time - 1000 * 60) {
-			s.lastActiveString = 'less than 1 minute ago'
-		} else {
-			s.lastActiveString = moment(s.lastActiveTimestamp).from(time)
-		}
+		s.lastActiveString = moment(s.lastActiveTimestamp).from(time)
 	} else if (s.lastActiveString !== null) {
 		s.lastActiveString = null
 	}


### PR DESCRIPTION
## Summary

Support looping session playback via localstorage variable to allow easier demoing.

## How did you test this change?

reflame

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
