### PR TITLE
Remove matched attributes from logs table

### DIFF
--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -47,7 +47,7 @@ import { LogEdge, ProductType } from '@/graph/generated/schemas'
 import { findMatchingLogAttributes } from '@/pages/LogsPage/utils'
 import analytics from '@/util/analytics'
 
-import { LogDetails, LogValue } from './LogDetails'
+import { LogDetails } from './LogDetails'
 import * as styles from './LogsTable.css'
 
 type Props = {
@@ -422,7 +422,6 @@ const LogsTableRow = React.memo<LogsTableRowProps>(
 				span_id: log.spanID,
 				trace_id: log.traceID,
 			})
-			const hasAttributes = Object.entries(matchedAttributes).length > 0
 
 			return (
 				<Table.Row
@@ -430,50 +429,10 @@ const LogsTableRow = React.memo<LogsTableRowProps>(
 					className={styles.attributesRow}
 					gridColumns={['32px', '1fr']}
 				>
-					{(rowExpanded || hasAttributes) && (
+					{rowExpanded && (
 						<>
 							<Table.Cell py="4" />
 							<Table.Cell py="4" borderTop="dividerWeak">
-								{!rowExpanded && (
-									<Box display="flex" flexWrap="wrap">
-										{Object.entries(matchedAttributes).map(
-											(
-												[key, { match, value }],
-												index,
-											) => {
-												return (
-													<>
-														{index > 0 && (
-															<Box
-																display="flex"
-																alignItems="center"
-																pr="8"
-															>
-																<Text
-																	weight="bold"
-																	color="weak"
-																>
-																	;
-																</Text>
-															</Box>
-														)}
-														<LogValue
-															key={key}
-															label={key}
-															value={value}
-															queryKey={key}
-															queryMatch={match}
-															queryParts={
-																queryParts
-															}
-															hideActions
-														/>
-													</>
-												)
-											},
-										)}
-									</Box>
-								)}
 								<LogDetails
 									matchedAttributes={matchedAttributes}
 									row={row}

--- a/frontend/src/pages/LogsPage/utils.ts
+++ b/frontend/src/pages/LogsPage/utils.ts
@@ -28,8 +28,6 @@ export const isSignificantDateRange = (startDate: Date, endDate: Date) => {
 
 const bodyKey = ReservedLogKey['Message']
 
-const EXISTS_PLACEHOLDER_VALUE = 'EXISTS'
-
 export const findMatchingLogAttributes = (
 	queryParts: Array<SearchExpression | AndOrExpression>,
 	logAttributes: object | string,
@@ -75,17 +73,10 @@ export const findMatchingLogAttributes = (
 				}
 
 				const queryKey = term.key.toLowerCase()
-				const queryOpertor = term.operator
 				const queryValue = term.value?.toLowerCase()
 
 				if (queryKey === fullKey) {
-					// TODO: figure out why operator is 'NOTEXISTS' without spaces
-					// so we can use the constants
-					matchingAttribute = ['EXISTS', 'NOTEXISTS'].includes(
-						queryOpertor.toUpperCase(),
-					)
-						? EXISTS_PLACEHOLDER_VALUE
-						: queryValue
+					matchingAttribute = queryValue?.replace(/^\"|\"$/g, '')
 				}
 			})
 		}


### PR DESCRIPTION
## Summary
The matching attributes under the logs row takes up space and is not helpful. This is repetitive as the user knows what is being searched for, can add the column to the table, and can expand the row.

https://www.loom.com/share/da0a81a2ba434386b771edc07d586d0e?sid=10e7e374-afb4-4b34-8ef7-72a3bfdad596

## How did you test this change?
1) Load the logs table
2) Search an attribute
- [ ] Matching attribute does not show up by default under row
- [ ] Matching attribute is highlighted when expanded
3) Update the search value to be in quotes
- [ ] Matching attribute does not show up by default under row
- [ ] Matching attribute is highlighted when expanded

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
