### PR TITLE
Enable Edge tracking with startActiveSpan and tracing support

### DIFF
--- a/docs-content/getting-started/fullstack-frameworks/next-js/2_page-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/2_page-router.md
@@ -308,14 +308,23 @@ export default withPageRouterHighlight(function handler(req: NextApiRequest, res
 
 ```typescript
 // middleware.ts
-import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
-import { highlightMiddleware } from '@highlight-run/next/server'
+import type { NextFetchEvent, NextRequest } from 'next/server'
+import { highlightMiddleware, HighlightEnv } from '@highlight-run/next/server'
 
-export function middleware(request: NextRequest) {
-	highlightMiddleware(request)
+import { CONSTANTS } from '@/constants'
 
-	return NextResponse.next()
+const highlightConfig = {
+	projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
+	otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
+	serviceName: 'my-nextjs-backend',
+	environment: 'e2e-test',
+} as HighlightEnv
+
+export function middleware(request: NextRequest, event: NextFetchEvent) {
+	const { headers } = highlightMiddleware(request, highlightConfig, event)
+
+	return NextResponse.next({ headers })
 }
 ```
 

--- a/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
+++ b/docs-content/getting-started/fullstack-frameworks/next-js/3_app-router.md
@@ -395,14 +395,23 @@ export const GET = withAppRouterHighlight(async function GET(request: NextReques
 
 ```typescript
 // middleware.ts
-import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
-import { highlightMiddleware } from '@highlight-run/next/server'
+import type { NextFetchEvent, NextRequest } from 'next/server'
+import { highlightMiddleware, HighlightEnv } from '@highlight-run/next/server'
 
-export function middleware(request: NextRequest) {
-	highlightMiddleware(request)
+import { CONSTANTS } from '@/constants'
 
-	return NextResponse.next()
+const highlightConfig = {
+	projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
+	otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
+	serviceName: 'my-nextjs-backend',
+	environment: 'e2e-test',
+} as HighlightEnv
+
+export function middleware(request: NextRequest, event: NextFetchEvent) {
+	const { headers } = highlightMiddleware(request, highlightConfig, event)
+
+	return NextResponse.next({ headers })
 }
 ```
 

--- a/e2e/nextjs/middleware.ts
+++ b/e2e/nextjs/middleware.ts
@@ -1,9 +1,18 @@
-import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
-import { highlightMiddleware } from '@highlight-run/next/server'
+import type { NextFetchEvent, NextRequest } from 'next/server'
+import { highlightMiddleware, HighlightEnv } from '@highlight-run/next/server'
 
-export function middleware(request: NextRequest) {
-	highlightMiddleware(request)
+import { CONSTANTS } from '@/constants'
 
-	return NextResponse.next()
+const highlightConfig = {
+	projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
+	otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
+	serviceName: 'my-nextjs-backend',
+	environment: 'e2e-test',
+} as HighlightEnv
+
+export function middleware(request: NextRequest, event: NextFetchEvent) {
+	const { headers } = highlightMiddleware(request, highlightConfig, event)
+
+	return NextResponse.next({ headers })
 }

--- a/e2e/nextjs/next.config.mjs
+++ b/e2e/nextjs/next.config.mjs
@@ -5,6 +5,7 @@ import { withHighlightConfig } from '@highlight-run/next/config'
 const nextConfig = {
 	productionBrowserSourceMaps: true,
 	experimental: {
+		instrumentationHook: true,
 		serverComponentsExternalPackages: ['pino', 'pino-pretty'],
 	},
 	images: {

--- a/e2e/nextjs/src/app/app-router/ssr/page.tsx
+++ b/e2e/nextjs/src/app/app-router/ssr/page.tsx
@@ -1,4 +1,3 @@
-'use server'
 import logger from '@/highlight.logger'
 
 type Props = {

--- a/e2e/nextjs/src/app/layout.tsx
+++ b/e2e/nextjs/src/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata = {
 	description: 'Check out how Highlight works with Next.js',
 }
 
-export default function RootLayout({
+export default async function RootLayout({
 	children,
 }: {
 	children: React.ReactNode
@@ -48,3 +48,5 @@ export default function RootLayout({
 		</>
 	)
 }
+
+export const runtime = 'edge' // 'nodejs' (default) | 'edge'

--- a/e2e/nextjs/src/highlight.logger.ts
+++ b/e2e/nextjs/src/highlight.logger.ts
@@ -1,28 +1,34 @@
-import { highlightConfig } from '@/instrumentation'
-import type { LoggerOptions } from 'pino'
-import { isNodeJsRuntime } from '@highlight-run/next/server'
+// import { highlightConfig } from '@/instrumentation'
+// import type { LoggerOptions } from 'pino'
+// import { isNodeJsRuntime } from '@highlight-run/next/server'
 
-const pinoConfig = {
-	level: 'debug',
-	transport: {
-		targets: [
-			// {
-			// 	target: 'pino-pretty',
-			// 	level: 'debug',
-			// },
-			// {
-			// 	target: '@highlight-run/pino',
-			// 	options: highlightConfig,
-			// 	level: 'debug',
-			// },
-		],
-	},
-} as LoggerOptions
+// const pinoConfig = {
+// 	level: 'debug',
+// 	transport: {
+// 		targets: [
+// 			// {
+// 			// 	target: 'pino-pretty',
+// 			// 	level: 'debug',
+// 			// },
+// 			// {
+// 			// 	target: '@highlight-run/pino',
+// 			// 	options: highlightConfig,
+// 			// 	level: 'debug',
+// 			// },
+// 		],
+// 	},
+// } as LoggerOptions
 
-if (isNodeJsRuntime()) {
-	const { H } = require('@highlight-run/node')
-	H.init(highlightConfig)
+// if (isNodeJsRuntime()) {
+// 	const { H } = require('@highlight-run/node')
+// 	H.init(highlightConfig)
+// }
+
+// const logger = require('pino')(pinoConfig)
+// export default logger
+
+const logger = {
+	info: (...args: unknown[]) => console.info(args),
 }
 
-const logger = require('pino')(pinoConfig)
 export default logger

--- a/e2e/nextjs/src/instrumentation.ts
+++ b/e2e/nextjs/src/instrumentation.ts
@@ -2,7 +2,7 @@
 import { CONSTANTS } from '@/constants'
 import type { NodeOptions } from '@highlight-run/node'
 
-export const highlightConfig = {
+const highlightConfig = {
 	projectID: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID,
 	otlpEndpoint: CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_OTLP_ENDPOINT,
 	serviceName: 'my-nextjs-backend',
@@ -11,5 +11,6 @@ export const highlightConfig = {
 
 export async function register() {
 	const { registerHighlight } = await import('@highlight-run/next/server')
+
 	registerHighlight(highlightConfig)
 }

--- a/sdk/highlight-next/src/server.ts
+++ b/sdk/highlight-next/src/server.ts
@@ -5,16 +5,29 @@ import type { ExtendedExecutionContext, HighlightEnv } from './util/types'
 import type { EdgeHandler } from './util/with-highlight-edge'
 import type { NextFetchEvent, NextRequest } from 'next/server'
 import { isNodeJsRuntime } from './util/is-node-js-runtime'
+import type { WorkersSDK } from '@highlight-run/opentelemetry-sdk-workers'
+import type { HighlightEnv as CloudflareHighlightEnv } from '@highlight-run/cloudflare'
 
 export { isNodeJsRuntime } from './util/is-node-js-runtime'
 export { registerHighlight } from './util/register-highlight'
 export type { HighlightEnv } from './util/types'
-export { H } from '@highlight-run/node' // Imports from server.edge.ts for the edge runtime
+import { H as NodeH } from '@highlight-run/node' // Imports from server.edge.ts for the edge runtime
 export { highlightMiddleware } from './util/highlight-middleware'
 
 type PageRouterHighlightHandler = ReturnType<
 	typeof withHighlightNodeJsPageRouter.Highlight
 >
+
+export const H = {
+	...NodeH,
+	initEdge: (
+		request: Request,
+		env: CloudflareHighlightEnv,
+		ctx: ExtendedExecutionContext,
+	): WorkersSDK => {
+		throw new Error('H.initEdge not implemented in nodejs runtime')
+	},
+}
 
 export const Highlight = PageRouterHighlight
 export function PageRouterHighlight(

--- a/sdk/highlight-next/src/util/highlight-middleware.ts
+++ b/sdk/highlight-next/src/util/highlight-middleware.ts
@@ -1,9 +1,31 @@
 import type { NextRequest } from 'next/server'
+import { H, HighlightEnv } from './highlight-edge'
+import { ExtendedExecutionContext } from './types'
 
-export function highlightMiddleware(request: NextRequest) {
+export function highlightMiddleware(
+	request: NextRequest,
+	env?: HighlightEnv,
+	ctx?: ExtendedExecutionContext,
+) {
 	const sessionSecureID = request.cookies.get('sessionSecureID')?.value
-	const xHighlightRequest = request.headers.get('x-highlight-request')
+	let xHighlightRequest = request.headers.get('x-highlight-request')
+
 	if (!xHighlightRequest && sessionSecureID) {
-		request.headers.set('x-highlight-request', `${sessionSecureID}/`)
+		xHighlightRequest = `${sessionSecureID}/`
+		request.headers.set('x-highlight-request', xHighlightRequest)
+	}
+
+	if (env && ctx) {
+		try {
+			H.initEdge(request, env, ctx)
+		} catch (error) {
+			console.log('🤬 H.initEdge error', error)
+		}
+	}
+
+	return {
+		headers: {
+			'x-highlight-request': xHighlightRequest ?? '',
+		},
 	}
 }

--- a/sdk/highlight-next/src/util/is-node-js-runtime.ts
+++ b/sdk/highlight-next/src/util/is-node-js-runtime.ts
@@ -1,6 +1,13 @@
+interface MyGlobal extends Window {
+	EdgeRuntime?: string
+}
+
+declare var globalThis: MyGlobal
+
 export function isNodeJsRuntime() {
 	return (
-		typeof process.env.NEXT_RUNTIME === 'undefined' ||
-		process.env.NEXT_RUNTIME === 'nodejs'
+		typeof globalThis.EdgeRuntime !== 'string' &&
+		(typeof process.env.NEXT_RUNTIME === 'undefined' ||
+			process.env.NEXT_RUNTIME === 'nodejs')
 	)
 }

--- a/sdk/highlight-next/src/util/types.ts
+++ b/sdk/highlight-next/src/util/types.ts
@@ -2,7 +2,12 @@ import type { NodeOptions, Highlight } from '@highlight-run/node'
 import type { ResourceAttributes } from '@opentelemetry/resources/build/src/types'
 import type { ExecutionContext } from '@cloudflare/workers-types'
 import type { WorkersSDK } from '@highlight-run/opentelemetry-sdk-workers'
-import type { Attributes } from '@opentelemetry/api'
+import type {
+	Attributes,
+	SpanOptions,
+	Span as OTelSpan,
+	Context,
+} from '@opentelemetry/api'
 import type { HighlightContext } from '@highlight-run/node'
 import { IncomingHttpHeaders } from 'http'
 
@@ -61,6 +66,11 @@ export interface HighlightInterface {
 	) => void
 	stop: () => Promise<void>
 	flush: () => Promise<void>
+	startActiveSpan: (
+		name: string,
+		options?: SpanOptions,
+		ctx?: Context,
+	) => Promise<OTelSpan>
 }
 
 export const HIGHLIGHT_REQUEST_HEADER = 'x-highlight-request'

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -5,6 +5,7 @@ import type {
 	Tracer,
 	Span as OtelSpan,
 	SpanOptions,
+	Context,
 } from '@opentelemetry/api'
 import { trace } from '@opentelemetry/api'
 import { NodeSDK } from '@opentelemetry/sdk-node'
@@ -466,10 +467,14 @@ export class Highlight {
 		})
 	}
 
-	startActiveSpan(name: string, options?: SpanOptions) {
-		return new Promise<OtelSpan>((resolve) =>
-			this.tracer.startActiveSpan(name, options || {}, resolve),
-		)
+	startActiveSpan(name: string, options: SpanOptions = {}, ctx?: Context) {
+		return new Promise<OtelSpan>((resolve) => {
+			if (ctx) {
+				this.tracer.startActiveSpan(name, options, ctx, resolve)
+			} else {
+				this.tracer.startActiveSpan(name, options, resolve)
+			}
+		})
 	}
 }
 function parseHeaders(

--- a/sdk/highlight-node/src/sdk.ts
+++ b/sdk/highlight-node/src/sdk.ts
@@ -5,7 +5,7 @@ import { ResourceAttributes } from '@opentelemetry/resources'
 import type { NodeOptions, HighlightContext } from './types.js'
 import type {
 	Attributes,
-	Tracer,
+	Context,
 	Span as OtelSpan,
 	SpanOptions,
 } from '@opentelemetry/api'
@@ -54,7 +54,7 @@ export interface HighlightInterface {
 		metadata?: Attributes,
 	) => Promise<void>
 	setAttributes: (attributes: ResourceAttributes) => void
-	startActiveSpan: (name: string, options: SpanOptions) => Promise<OtelSpan>
+	startActiveSpan: (name: string, options?: SpanOptions) => Promise<OtelSpan>
 	_debug: (...data: any[]) => void
 }
 
@@ -173,8 +173,8 @@ export const H: HighlightInterface = {
 	setAttributes: (attributes: ResourceAttributes) => {
 		return highlight_obj.setAttributes(attributes)
 	},
-	startActiveSpan: (name: string, options: SpanOptions) => {
-		return highlight_obj.startActiveSpan(name, options)
+	startActiveSpan: (name: string, options?: SpanOptions, ctx?: Context) => {
+		return highlight_obj.startActiveSpan(name, options, ctx)
 	},
 
 	_debug: (...data: any[]) => {


### PR DESCRIPTION
## Summary

Closes #8048 

1. Uses a more robust checker for the Node.js vs Edge runtimes.
2. Implements session-spreading for Edge spans.
3. Enabled `startActiveSpan` support on Edge and Cloudflare.
