### PR TITLE
Support filtering by HasComments

### DIFF
--- a/backend/clickhouse/migrations/000094_add_has_comments_to_sessions.down.sql
+++ b/backend/clickhouse/migrations/000094_add_has_comments_to_sessions.down.sql
@@ -1,0 +1,2 @@
+alter table sessions
+    drop column HasComments;

--- a/backend/clickhouse/migrations/000094_add_has_comments_to_sessions.up.sql
+++ b/backend/clickhouse/migrations/000094_add_has_comments_to_sessions.up.sql
@@ -1,0 +1,2 @@
+alter table sessions
+    add column HasComments Bool;

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -206,7 +206,7 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 				NewStruct(new(ClickhouseSession)).
 				InsertInto(SessionsTable, chSessions...).
 				BuildWithFlavor(sqlbuilder.ClickHouse)
-			sessionsSql, sessionsArgs = replaceTimestampInserts(sessionsSql, sessionsArgs, 32, map[int]bool{7: true, 8: true}, MicroSeconds)
+			sessionsSql, sessionsArgs = replaceTimestampInserts(sessionsSql, sessionsArgs, 33, map[int]bool{7: true, 8: true}, MicroSeconds)
 			return client.conn.Exec(chCtx, sessionsSql, sessionsArgs...)
 		})
 	}

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -472,6 +472,7 @@ var sessionsJoinedTableConfig = model.TableConfig[modelInputs.ReservedSessionKey
 		modelInputs.ReservedSessionKeyBrowserName:     "BrowserName",
 		modelInputs.ReservedSessionKeyBrowserVersion:  "BrowserVersion",
 		modelInputs.ReservedSessionKeyProcessed:       "Processed",
+		modelInputs.ReservedSessionKeyHasComments:     "HasComments",
 		modelInputs.ReservedSessionKeyHasRageClicks:   "HasRageClicks",
 		modelInputs.ReservedSessionKeyHasErrors:       "HasErrors",
 		modelInputs.ReservedSessionKeyLength:          "Length",

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -37,6 +37,7 @@ var fieldMap map[string]string = map[string]string{
 	"browser_name":      "BrowserName",
 	"browser_version":   "BrowserVersion",
 	"processed":         "Processed",
+	"has_comments":      "HasComments",
 	"has_rage_clicks":   "HasRageClicks",
 	"has_errors":        "HasErrors",
 	"has_session":       "HasSession",
@@ -82,6 +83,7 @@ type ClickhouseSession struct {
 	BrowserName        string
 	BrowserVersion     string
 	Processed          *bool
+	HasComments        bool
 	HasRageClicks      *bool
 	HasErrors          *bool
 	Length             int64
@@ -173,6 +175,7 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 			BrowserName:        session.BrowserName,
 			BrowserVersion:     session.BrowserVersion,
 			Processed:          session.Processed,
+			HasComments:        session.HasComments,
 			HasRageClicks:      session.HasRageClicks,
 			HasErrors:          session.HasErrors,
 			Length:             session.Length,

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -717,6 +717,7 @@ type Session struct {
 	HasUnloaded bool `gorm:"default:false"`
 	// Tells us if the session has been parsed by a worker.
 	Processed           *bool `json:"processed"`
+	HasComments         bool  `json:"has_comments" gorm:"default:false"`
 	HasRageClicks       *bool `json:"has_rage_clicks"`
 	HasErrors           *bool `json:"has_errors"`
 	HasOutOfOrderEvents bool  `gorm:"default:false"`

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -11948,6 +11948,7 @@ enum ReservedSessionKey {
 	browser_name
 	browser_version
 	processed
+	has_comments
 	has_rage_clicks
 	has_errors
 	length

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -2078,6 +2078,7 @@ const (
 	ReservedSessionKeyBrowserName     ReservedSessionKey = "browser_name"
 	ReservedSessionKeyBrowserVersion  ReservedSessionKey = "browser_version"
 	ReservedSessionKeyProcessed       ReservedSessionKey = "processed"
+	ReservedSessionKeyHasComments     ReservedSessionKey = "has_comments"
 	ReservedSessionKeyHasRageClicks   ReservedSessionKey = "has_rage_clicks"
 	ReservedSessionKeyHasErrors       ReservedSessionKey = "has_errors"
 	ReservedSessionKeyLength          ReservedSessionKey = "length"
@@ -2103,6 +2104,7 @@ var AllReservedSessionKey = []ReservedSessionKey{
 	ReservedSessionKeyBrowserName,
 	ReservedSessionKeyBrowserVersion,
 	ReservedSessionKeyProcessed,
+	ReservedSessionKeyHasComments,
 	ReservedSessionKeyHasRageClicks,
 	ReservedSessionKeyHasErrors,
 	ReservedSessionKeyLength,
@@ -2115,7 +2117,7 @@ var AllReservedSessionKey = []ReservedSessionKey{
 
 func (e ReservedSessionKey) IsValid() bool {
 	switch e {
-	case ReservedSessionKeyEnvironment, ReservedSessionKeyServiceName, ReservedSessionKeyAppVersion, ReservedSessionKeySecureSessionID, ReservedSessionKeyIdentified, ReservedSessionKeyFingerprint, ReservedSessionKeyIdentifier, ReservedSessionKeyCity, ReservedSessionKeyCountry, ReservedSessionKeyOsName, ReservedSessionKeyOsVersion, ReservedSessionKeyBrowserName, ReservedSessionKeyBrowserVersion, ReservedSessionKeyProcessed, ReservedSessionKeyHasRageClicks, ReservedSessionKeyHasErrors, ReservedSessionKeyLength, ReservedSessionKeyActiveLength, ReservedSessionKeyFirstTime, ReservedSessionKeyViewed, ReservedSessionKeyPagesVisited, ReservedSessionKeyNormalness:
+	case ReservedSessionKeyEnvironment, ReservedSessionKeyServiceName, ReservedSessionKeyAppVersion, ReservedSessionKeySecureSessionID, ReservedSessionKeyIdentified, ReservedSessionKeyFingerprint, ReservedSessionKeyIdentifier, ReservedSessionKeyCity, ReservedSessionKeyCountry, ReservedSessionKeyOsName, ReservedSessionKeyOsVersion, ReservedSessionKeyBrowserName, ReservedSessionKeyBrowserVersion, ReservedSessionKeyProcessed, ReservedSessionKeyHasComments, ReservedSessionKeyHasRageClicks, ReservedSessionKeyHasErrors, ReservedSessionKeyLength, ReservedSessionKeyActiveLength, ReservedSessionKeyFirstTime, ReservedSessionKeyViewed, ReservedSessionKeyPagesVisited, ReservedSessionKeyNormalness:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1040,6 +1040,7 @@ enum ReservedSessionKey {
 	browser_name
 	browser_version
 	processed
+	has_comments
 	has_rage_clicks
 	has_errors
 	length


### PR DESCRIPTION
## Summary
The `Has Comments` filter stopped working when we transitioned to Clickhouse. Add this column to the Clickhouse table to support filtering sessions by having comments.

Note: This also adds the column to the Sessions table to help keep the state to send to clickhouse.

https://www.loom.com/share/f0b0d21951b24c0a99aba41b46f0ad10

## How did you test this change?
1) Find a session
2) Add a comment
3) Filter out by sessions with comments
- [ ] Session is in results
4) Add another comment and re-search
- [ ] Session is in results
4) Delete one comment and re-search
- [ ] Session is in results
4) Delete the other comment
- [ ] Session is NOT in results

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
