### PR TITLE
fix meter query if no rows in materialized view

### DIFF
--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -345,7 +345,11 @@ func GetWorkspaceSessionsMeter(ctx context.Context, DB *gorm.DB, ccClient *click
 		SELECT SUM(count) as currentPeriodSessionCount from (
 			SELECT COUNT(*) FROM sessions
 			WHERE project_id IN (SELECT id FROM projects WHERE workspace_id=@workspace_id)
-			AND created_at >= (SELECT MAX(date) FROM materialized_rows)
+			AND (created_at < (SELECT MAX(date) FROM materialized_rows)) IS NOT TRUE
+            AND created_at >= (
+				SELECT COALESCE(next_invoice_date - interval '1 month', billing_period_start, date_trunc('month', now(), 'UTC'))
+				FROM workspaces
+				WHERE id=@workspace_id)
 			AND created_at < (
 			SELECT COALESCE(next_invoice_date, billing_period_end, date_trunc('month', now(), 'UTC') + interval '1 month')
 			FROM workspaces
@@ -400,7 +404,11 @@ func GetWorkspaceErrorsMeter(ctx context.Context, DB *gorm.DB, ccClient *clickho
 		SELECT SUM(count) as currentPeriodErrorsCount from (
 			SELECT COUNT(*) FROM error_objects
 			WHERE project_id IN (SELECT id FROM projects WHERE workspace_id=@workspace_id)
-			AND created_at >= (SELECT MAX(date) FROM materialized_rows)
+			AND (created_at < (SELECT MAX(date) FROM materialized_rows)) IS NOT TRUE
+            AND created_at >= (
+				SELECT COALESCE(next_invoice_date - interval '1 month', billing_period_start, date_trunc('month', now(), 'UTC'))
+				FROM workspaces
+				WHERE id=@workspace_id)
 			AND created_at < (
 				SELECT COALESCE(next_invoice_date, billing_period_end, date_trunc('month', now(), 'UTC') + interval '1 month')
 				FROM workspaces


### PR DESCRIPTION
## Summary
- query was reporting 0 if no rows in the materialized view during the current billing period
- start date of the fallback query should be either
  - last date in the materialized view
  - start date of the billing period if no rows in the materialized view
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran updated query against prod for the Highlight project, confirmed accurate sessions and errors count
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
