### PR TITLE
Remove overwriting sampling rate

### DIFF
--- a/.changeset/orange-ravens-explode.md
+++ b/.changeset/orange-ravens-explode.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+Fix bug with recording traces.

--- a/sdk/highlight-go/highlight.go
+++ b/sdk/highlight-go/highlight.go
@@ -2,7 +2,6 @@ package highlight
 
 import (
 	"context"
-	"go.opentelemetry.io/otel/trace"
 	"net/http"
 	"os"
 	"os/signal"
@@ -10,6 +9,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
@@ -154,7 +155,6 @@ func (d deadLog) Errorf(_ string, _ ...interface{}) {}
 func init() {
 	interruptChan = make(chan bool, 1)
 	signalChan = make(chan os.Signal, 1)
-	conf = &config{}
 
 	signal.Notify(signalChan, syscall.SIGABRT, syscall.SIGTERM, syscall.SIGINT)
 	SetOTLPEndpoint(OTLPDefaultEndpoint)


### PR DESCRIPTION
## Summary
We were reseting the config option, wiping out the defaults, resulting in no traces being recorded if `SamplingRateMap` was not set. Remove the unnecessary reinitialization .

## How did you test this change?
1) Remove the `WithSamplingRateMap` from `backend/main.go` 
2) Start your backend and hit some endpoints
3) View traces/logs and confirm that they appear (check `service_name EXISTS`)
- [ ] Logs are recorded
- [ ] Traces are recorded

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
