### PR TITLE
skip adding to security group for external contributions

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -87,6 +87,7 @@ jobs:
                   REACT_APP_COMMIT_SHA: abcdef1234567890a1b2c3d4e5f6fedcba098765
 
             - name: Add public IP to AWS security group
+              if: github.event.pull_request.head.repo.full_name == 'highlight/highlight' || github.ref == 'refs/heads/main'
               uses: sohelamin/aws-security-group-add-ip-action@master
               with:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary
- the other steps that rely on RDS access already have this same check - add it so it will not break workflows for external contributions
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- will monitor this for future contributions
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
