### PR TITLE
match embedding at group level for project 1

### DIFF
--- a/backend/migrations/cmd/migrate-group-embeddings/main.go
+++ b/backend/migrations/cmd/migrate-group-embeddings/main.go
@@ -11,6 +11,8 @@ import (
 	"github.com/highlight-run/highlight/backend/model"
 )
 
+var step = 100000
+
 func main() {
 	ctx := context.Background()
 
@@ -55,6 +57,59 @@ func main() {
 		}
 		log.WithContext(ctx).Infof("maxEmbeddingId: %d", maxEmbeddingId)
 
+		for j := prevEmbeddingId; j < maxEmbeddingId; j += step {
+			start := j
+			end := j + step
+			if end > maxEmbeddingId {
+				end = maxEmbeddingId
+			}
+
+			log.WithContext(ctx).Infof("loop (%d, %d]", start, end)
+
+			if err := db.Transaction(func(tx *gorm.DB) error {
+				if err := tx.Exec(`
+					insert into error_group_embeddings (project_id, error_group_id, count, gte_large_embedding)
+					select a.* from (
+						select eo.project_id, eo.error_group_id, count(*) as count, AVG(eoe.gte_large_embedding) as gte_large_embedding
+						from error_object_embeddings_partitioned eoe
+						inner join error_objects eo
+						on eoe.error_object_id = eo.id
+						where eoe.project_id = ?
+						and eo.project_id = ?
+						and eoe.gte_large_embedding is not null
+						and eoe.id > ?
+						and eoe.id <= ?
+						group by eo.project_id, eo.error_group_id) a
+					on conflict (project_id, error_group_id)
+					do update set
+						gte_large_embedding = 
+							error_group_embeddings.gte_large_embedding * array_fill(error_group_embeddings.count::numeric / (error_group_embeddings.count + excluded.count), '{1024}')::vector
+							+ excluded.gte_large_embedding * array_fill(excluded.count::numeric / (error_group_embeddings.count + excluded.count), '{1024}')::vector,
+						count = error_group_embeddings.count + excluded.count
+				`, i, i, start, end).Error; err != nil {
+					return err
+				}
+
+				log.WithContext(ctx).Info("done upserting new embeddings")
+
+				if err := tx.Exec(`
+					insert into migrated_embeddings (project_id, embedding_id)
+					values (?, ?)
+					on conflict (project_id)
+					do update set embedding_id = excluded.embedding_id
+				`, i, end).Error; err != nil {
+					return err
+				}
+
+				log.WithContext(ctx).Info("done updating maxEmbeddingId")
+
+				return nil
+			}); err != nil {
+				log.WithContext(ctx).Fatal(err)
+			}
+			log.WithContext(ctx).Infof("done loop: %d", i)
+		}
+
 		if err := db.Transaction(func(tx *gorm.DB) error {
 			if err := tx.Exec(`
 				insert into error_group_embeddings (project_id, error_group_id, count, gte_large_embedding)
@@ -63,7 +118,9 @@ func main() {
 					from error_object_embeddings_partitioned eoe
 					inner join error_objects eo
 					on eoe.error_object_id = eo.id
-					where eoe.gte_large_embedding is not null
+					where eoe.project_id = ?
+					and eo.project_id = ?
+					and eoe.gte_large_embedding is not null
 					and eoe.id > ?
 					and eoe.id <= ?
 					group by eo.project_id, eo.error_group_id) a
@@ -73,7 +130,7 @@ func main() {
 						error_group_embeddings.gte_large_embedding * array_fill(error_group_embeddings.count::numeric / (error_group_embeddings.count + excluded.count), '{1024}')::vector
 						+ excluded.gte_large_embedding * array_fill(excluded.count::numeric / (error_group_embeddings.count + excluded.count), '{1024}')::vector,
 					count = error_group_embeddings.count + excluded.count
-			`, prevEmbeddingId, maxEmbeddingId).Error; err != nil {
+			`, i, i, prevEmbeddingId, maxEmbeddingId).Error; err != nil {
 				return err
 			}
 

--- a/backend/migrations/cmd/migrate-group-embeddings/main.go
+++ b/backend/migrations/cmd/migrate-group-embeddings/main.go
@@ -35,8 +35,7 @@ func main() {
 		log.WithContext(ctx).Fatal(err)
 	}
 
-	// Only running this migration on project_id = 1 for now
-	for i := 1; i <= 1; i++ {
+	for i := 0; i <= lastCreatedPart; i++ {
 		log.WithContext(ctx).Infof("beginning loop: %d", i)
 		tablename := fmt.Sprintf("error_object_embeddings_partitioned_%d", i)
 

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1032,6 +1032,7 @@ const (
 	ErrorGroupingMethodClassic             ErrorGroupingMethod = "Classic"
 	ErrorGroupingMethodAdaEmbeddingV2      ErrorGroupingMethod = "AdaV2"
 	ErrorGroupingMethodGteLargeEmbeddingV2 ErrorGroupingMethod = "thenlper/gte-large"
+	ErrorGroupingMethodGteLargeEmbeddingV3 ErrorGroupingMethod = "thenlper/gte-large.v3"
 )
 
 type ErrorObject struct {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -545,7 +545,7 @@ limit 1;`, column, column), map[string]interface{}{
 
 			// Update the error group's embedding as a weighted average of the previous embedding plus this new one
 			if method == model.ErrorGroupingMethodGteLargeEmbeddingV3 {
-				if err := r.DB.WithContext(ctx).Raw(`
+				if err := r.DB.WithContext(ctx).Exec(`
 					update error_group_embeddings
 					set gte_large_embedding = gte_large_embedding * array_fill(count::numeric / (count + 1), '{1024}')::vector 
 						+ @embedding * array_fill(1::numeric / (count + 1), '{1024}')::vector, 

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -523,12 +523,11 @@ select eoe.%s <-> @embedding as score,
        eo.error_group_id                              as error_group_id
 from error_object_embeddings_partitioned eoe
          inner join error_objects eo on eo.id = eoe.error_object_id
-where eoe.project_id = @projectID
+where eoe.project_id = %d
     and eoe.%s is not null
 order by 1
-limit 1;`, column, column), map[string]interface{}{
+limit 1;`, column, projectID, column), map[string]interface{}{
 			"embedding": embedding,
-			"projectID": projectID,
 		}).
 			Scan(&result).Error; err != nil {
 			return nil, e.Wrap(err, "error querying top error group match")

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -497,7 +497,7 @@ func (r *Resolver) GetTopErrorGroupMatchByEmbedding(ctx context.Context, project
 
 	if method == model.ErrorGroupingMethodGteLargeEmbeddingV3 {
 		if err := r.DB.WithContext(ctx).Raw(`
-			select gte_large_embedding <-> @embedding as score,
+			select gte_large_embedding <=> @embedding as score,
 				error_group_id
 			from error_group_embeddings
 			where project_id = @projectID

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -511,9 +511,6 @@ func (r *Resolver) GetTopErrorGroupMatchByEmbedding(ctx context.Context, project
 			return nil, e.Wrap(err, "error querying top error group match")
 		}
 	} else {
-		// an alternative query to consider: for M error objects of every error group,
-		// find the average score. then pick the error group
-		// with the lowest average score.
 		var column string
 		switch method {
 		case model.ErrorGroupingMethodAdaEmbeddingV2:


### PR DESCRIPTION
## Summary
- modify migration to run on batches of 100k embeddings (less memory use, can recover after crashing)
- for project_id = 1, use ErrorGroupingMethodGteLargeEmbeddingV3 as the matching method to match at the group level
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested from buttons page locally, ensured new errors used the new matching method
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will monitor error grouping for project_id = 1 after deploying and migrate all projects' embeddings to the new table
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
