### PR TITLE
Support duration prefixes

### DIFF
--- a/backend/parser/parser_test.go
+++ b/backend/parser/parser_test.go
@@ -26,7 +26,7 @@ func TestBasicSqlForSearch(t *testing.T) {
 }
 
 func TestComplexSqlForSearch(t *testing.T) {
-	sql, _ := buildSqlForQuery("span_name=\"Chris Schmitz\" duration>1000 level:info source=(backend OR frontend) OR (service_name!=private-graph span_name=gorm.Query span_name!=(testing OR testing2)) AND (\"body query\" asdf)")
+	sql, _ := buildSqlForQuery("span_name=\"Chris Schmitz\" duration>1us level:info source=(backend OR frontend) OR (service_name!=private-graph span_name=gorm.Query span_name!=(testing OR testing2)) AND (\"body query\" asdf)")
 
 	assert.Equal(
 		t,


### PR DESCRIPTION
## Summary
Typing the duration in nanoseconds is burdensome on the user. Support using time suffixes to search numbers.

Supported suffixes:
```
h
m
s
ms
us
ns
```

https://www.loom.com/share/7c85288923864082bb9ce183fb39660b?sid=1a242ffd-02f6-467a-9354-6bb08191d45d

## How did you test this change?
1) Visit the traces page (`/traces`)
2) Ensure duration is displayed on the table
3) Search using the numerical operators -> `>`, `>=`, `<`, `<=`, 
- [ ] Correctly applies operator

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
