### PR TITLE
Fix NOT filters

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -480,11 +480,11 @@ func matchesQuery[TObj interface{}, TReservedKey ~string](row *TObj, config mode
 			if !anyMatch {
 				return false
 			}
+		case listener.OperatorNot:
+			return !matchesQuery(row, config, listener.Filters{filter.Filters[0]})
 		default:
 			matches := matchFilter(row, config, filter)
-			if filter.Operator == listener.OperatorNot && matches {
-				return false
-			} else if !matches {
+			if !matches {
 				return false
 			}
 		}


### PR DESCRIPTION
## Summary
The `NOT` filter has a child filter with no values, so it was always returning true and then negated by the `NOT`. As a result, all logs, traces, etc were being included.

Update the `NOT` logic to return the negated version of the child filter.

https://www.loom.com/share/d39d84adf6d6402da8a5bd66dcc6c34d?sid=4ee2d652-caff-4838-b044-6153bc6a30af

## How did you test this change?
1) Update the workspace to be enterprise
2) Add a `[key]!=[value]` on one of the filters
- [ ] Confirm the only resources displayed pass the filter.
4) Repeat for `NOT [key]=[value]`
- [ ] Confirm the only resources displayed pass the filter.

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
