### PR TITLE
enable group-level matching for all projects

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -503,7 +503,7 @@ func (r *Resolver) GetTopErrorGroupMatchByEmbedding(ctx context.Context, project
 
 	if method == model.ErrorGroupingMethodGteLargeEmbeddingV3 {
 		if err := r.DB.WithContext(ctx).Raw(`
-			select gte_large_embedding <=> @embedding as score,
+			select (gte_large_embedding <=> @embedding) * 10 as score,
 				error_group_id
 			from error_group_embeddings
 			where project_id = @projectID

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -789,10 +789,7 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 			errorObj.ErrorGroupingMethod = model.ErrorGroupingMethodClassic
 		} else {
 			embedding = emb[0]
-			embeddingType := model.ErrorGroupingMethodGteLargeEmbeddingV2
-			if errorObj.ProjectID == 1 {
-				embeddingType = model.ErrorGroupingMethodGteLargeEmbeddingV3
-			}
+			embeddingType := model.ErrorGroupingMethodGteLargeEmbeddingV3
 			errorGroup, err = r.GetOrCreateErrorGroup(ctx, errorObj, func() (*int, error) {
 				match, err := r.GetTopErrorGroupMatchByEmbedding(ctx, errorObj.ProjectID, embeddingType, embedding.GteLargeEmbedding, settings.ErrorEmbeddingsThreshold)
 				if err != nil {
@@ -800,17 +797,14 @@ func (r *Resolver) HandleErrorAndGroup(ctx context.Context, errorObj *model.Erro
 				}
 				return match, err
 			}, func(errorGroupId int) error {
-				if errorObj.ProjectID == 1 {
-					newEmbedding := model.ErrorGroupEmbeddings{
-						ProjectID:         errorObj.ProjectID,
-						ErrorGroupID:      errorGroupId,
-						Count:             1,
-						GteLargeEmbedding: embedding.GteLargeEmbedding,
-					}
-
-					return r.DB.WithContext(ctx).Create(&newEmbedding).Error
+				newEmbedding := model.ErrorGroupEmbeddings{
+					ProjectID:         errorObj.ProjectID,
+					ErrorGroupID:      errorGroupId,
+					Count:             1,
+					GteLargeEmbedding: embedding.GteLargeEmbedding,
 				}
-				return nil
+
+				return r.DB.WithContext(ctx).Create(&newEmbedding).Error
 			}, settings.ErrorEmbeddingsTagGroup)
 			if err != nil {
 				return nil, e.Wrap(err, "Error getting or creating error group")


### PR DESCRIPTION
## Summary
- enable new group-level matching for all projects by removing the project_id == 1 check
- updated migration script for better batching performance
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- error group matching working well for project_id 1 in production
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will deploy after running the object -> group migration script once more
- can revert if issues as we're still writing object embeddings
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
