### PR TITLE
auto join users should default to member role

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -939,9 +939,11 @@ func (r *mutationResolver) JoinWorkspace(ctx context.Context, workspaceID int) (
 	if err := r.DB.WithContext(ctx).Model(&workspace).Where("jsonb_exists(allowed_auto_join_email_origins::jsonb, LOWER(?))", domain).First(workspace).Error; err != nil {
 		return nil, e.Wrap(err, "error querying workspace")
 	}
-	if err := r.DB.WithContext(ctx).Model(&workspace).Association("Admins").Append(admin); err != nil {
-		return nil, e.Wrap(err, "error adding admin to association")
+
+	if err := r.DB.WithContext(ctx).Create(&model.WorkspaceAdmin{AdminID: admin.ID, WorkspaceID: workspace.ID, Role: pointy.String("MEMBER")}).Error; err != nil {
+		return nil, e.Wrap(err, "error adding admin to workspace")
 	}
+
 	return &workspace.ID, nil
 }
 


### PR DESCRIPTION
## Summary
- some customers use the auto-join feature and roles, should enforce that new auto-join users are members until manually upgraded
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- went through the auto-join workflow locally, validated created user had role = member
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
