### PR TITLE
save traces that contain events

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -218,19 +218,24 @@ func main() {
 		}
 	}
 
-	// setup highlight
-	highlight.Start(
-		highlight.WithProjectID("1jdkoe52"),
-		highlight.WithEnvironment(util.EnvironmentName()),
-		highlight.WithMetricSamplingRate(1./1000),
-		highlight.WithSamplingRateMap(map[trace.SpanKind]float64{
+	var samplingMap = map[trace.SpanKind]float64{}
+	if util.IsProduction() {
+		samplingMap = map[trace.SpanKind]float64{
 			trace.SpanKindUnspecified: 1. / 1000,
 			trace.SpanKindInternal:    1. / 1000,
 			// report `sampling`
 			trace.SpanKindServer: 1.,
 			// report all customer data
 			trace.SpanKindClient: 1.,
-		}),
+		}
+	}
+
+	// setup highlight
+	highlight.Start(
+		highlight.WithProjectID("1jdkoe52"),
+		highlight.WithEnvironment(util.EnvironmentName()),
+		highlight.WithMetricSamplingRate(1./1000),
+		highlight.WithSamplingRateMap(samplingMap),
 		highlight.WithServiceName(serviceName),
 		highlight.WithServiceVersion(os.Getenv("REACT_APP_COMMIT_SHA")),
 	)

--- a/backend/otel/extract.go
+++ b/backend/otel/extract.go
@@ -212,11 +212,19 @@ func extractFields(params extractFieldsParams) (*extractedFields, error) {
 		fields.logSeverity = val
 		delete(fields.attrs, highlight.LogSeverityDefaultAttribute)
 	}
+	if val, ok := fields.attrs[highlight.LogSeverityLegacyAttribute]; ok {
+		fields.logSeverity = val
+		delete(fields.attrs, highlight.LogSeverityLegacyAttribute)
+	}
 	if val, ok := fields.attrs[highlight.LogSeverityAttribute]; ok {
 		fields.logSeverity = val
 		delete(fields.attrs, highlight.LogSeverityAttribute)
 	}
 
+	if val, ok := fields.attrs[highlight.LogMessageLegacyAttribute]; ok {
+		fields.logMessage = val
+		delete(fields.attrs, highlight.LogMessageLegacyAttribute)
+	}
 	if val, ok := fields.attrs[highlight.LogMessageAttribute]; ok {
 		fields.logMessage = val
 		delete(fields.attrs, highlight.LogMessageAttribute)

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -201,7 +201,6 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 				spanID := span.SpanID().String()
 
 				spanHasErrors := false
-				shouldWriteTrace := true
 				for l := 0; l < events.Len(); l++ {
 					if skipped {
 						break
@@ -256,7 +255,6 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 							projectSessionErrors[fields.projectID][fields.sessionID] = append(projectSessionErrors[fields.projectID][fields.sessionID], backendError)
 						}
 					} else if event.Name() == highlight.LogEvent {
-						shouldWriteTrace = false
 						if fields.logMessage == "" {
 							lg(ctx, fields).Warn("otel received log with no message")
 							continue
@@ -281,7 +279,6 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 
 						projectLogs[fields.projectID] = append(projectLogs[fields.projectID], logRow)
 					} else if event.Name() == highlight.MetricEvent {
-						shouldWriteTrace = false
 						metric, err := getMetric(ctx, fields.timestamp, fields, spanID, span.ParentSpanID().String(), traceID)
 						if err != nil {
 							lg(ctx, fields).WithError(err).Error("failed to create metric")
@@ -296,28 +293,26 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 
-				if shouldWriteTrace {
-					timestamp := graph.ClampTime(span.StartTimestamp().AsTime(), curTime)
-					traceRow := clickhouse.NewTraceRow(timestamp, fields.projectIDInt).
-						WithSecureSessionId(fields.sessionID).
-						WithTraceId(traceID).
-						WithSpanId(spanID).
-						WithParentSpanId(span.ParentSpanID().String()).
-						WithTraceState(span.TraceState().AsRaw()).
-						WithSpanName(span.Name()).
-						WithSpanKind(span.Kind().String()).
-						WithDuration(span.StartTimestamp().AsTime(), span.EndTimestamp().AsTime()).
-						WithServiceName(fields.serviceName).
-						WithServiceVersion(fields.serviceVersion).
-						WithEnvironment(fields.environment).
-						WithHasErrors(spanHasErrors).
-						WithStatusCode(span.Status().Code().String()).
-						WithStatusMessage(span.Status().Message()).
-						WithTraceAttributes(fields.attrs).
-						WithEvents(fields.events).
-						WithLinks(fields.links)
-					traceSpans[traceID] = append(traceSpans[traceID], traceRow)
-				}
+				timestamp := graph.ClampTime(span.StartTimestamp().AsTime(), curTime)
+				traceRow := clickhouse.NewTraceRow(timestamp, fields.projectIDInt).
+					WithSecureSessionId(fields.sessionID).
+					WithTraceId(traceID).
+					WithSpanId(spanID).
+					WithParentSpanId(span.ParentSpanID().String()).
+					WithTraceState(span.TraceState().AsRaw()).
+					WithSpanName(span.Name()).
+					WithSpanKind(span.Kind().String()).
+					WithDuration(span.StartTimestamp().AsTime(), span.EndTimestamp().AsTime()).
+					WithServiceName(fields.serviceName).
+					WithServiceVersion(fields.serviceVersion).
+					WithEnvironment(fields.environment).
+					WithHasErrors(spanHasErrors).
+					WithStatusCode(span.Status().Code().String()).
+					WithStatusMessage(span.Status().Message()).
+					WithTraceAttributes(fields.attrs).
+					WithEvents(fields.events).
+					WithLinks(fields.links)
+				traceSpans[traceID] = append(traceSpans[traceID], traceRow)
 			}
 		}
 	}

--- a/backend/otel/otel_test.go
+++ b/backend/otel/otel_test.go
@@ -106,7 +106,7 @@ func TestHandler_HandleTrace(t *testing.T) {
 			expectedMessageCounts: map[kafkaqueue.PayloadType]int{
 				kafkaqueue.PushBackendPayload:  4,   // 4 exceptions, pushed as individual messages
 				kafkaqueue.PushLogsFlattened:   15,  // 4 exceptions, 11 logs
-				kafkaqueue.PushTracesFlattened: 501, // 512 spans - 11 logs
+				kafkaqueue.PushTracesFlattened: 512, // 512 spans, of which 11 are logs that also save a span
 			},
 			expectedLogCounts: map[privateModel.LogSource]int{
 				privateModel.LogSourceFrontend: 1,
@@ -117,7 +117,7 @@ func TestHandler_HandleTrace(t *testing.T) {
 			expectedMessageCounts: map[kafkaqueue.PayloadType]int{
 				// no errors expected
 				kafkaqueue.PushLogsFlattened:   11,  // 11 logs
-				kafkaqueue.PushTracesFlattened: 501, // 512 spans - 11 logs
+				kafkaqueue.PushTracesFlattened: 512, // 512 spans, of which 11 are logs that also save a span
 			},
 			external: true,
 		},

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -321,6 +321,7 @@ func (r *Resolver) demoProjectID(ctx context.Context) int {
 // and laymen in the demo project to have access to.
 func (r *Resolver) isAdminInProjectOrDemoProject(ctx context.Context, project_id int) (*model.Project, error) {
 	authSpan, ctx := util.StartSpanFromContext(ctx, "isAdminInProjectOrDemoProject", util.ResourceName("resolver.internal.auth"))
+	log.WithContext(ctx).WithField("project_id", project_id).Info("checking if admin is in project or demo workspace")
 	defer authSpan.Finish()
 	start := time.Now()
 	defer func() {
@@ -345,6 +346,7 @@ func (r *Resolver) isAdminInProjectOrDemoProject(ctx context.Context, project_id
 
 func (r *Resolver) isAdminInWorkspaceOrDemoWorkspace(ctx context.Context, workspace_id int) (*model.Workspace, error) {
 	authSpan, ctx := util.StartSpanFromContext(ctx, "isAdminInWorkspaceOrDemoWorkspace", util.ResourceName("resolver.internal.auth"))
+	log.WithContext(ctx).WithField("workspace_id", workspace_id).Info("checking if admin is in workspace or demo workspace")
 	defer authSpan.Finish()
 	start := time.Now()
 	defer func() {

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -99,6 +99,11 @@ func (ts highlightSampler) Description() string {
 
 // creates a per-span-kind sampler that samples each kind at a provided fraction.
 func getSampler() highlightSampler {
+	if len(conf.samplingRateMap) == 0 {
+		conf.samplingRateMap = map[trace.SpanKind]float64{
+			trace.SpanKindUnspecified: 1.,
+		}
+	}
 	return highlightSampler{
 		description: fmt.Sprintf("TraceIDRatioBased{%+v}", conf.samplingRateMap),
 		traceIDUpperBounds: lo.MapEntries(conf.samplingRateMap, func(key trace.SpanKind, value float64) (trace.SpanKind, uint64) {

--- a/sdk/highlight-go/otel.go
+++ b/sdk/highlight-go/otel.go
@@ -42,6 +42,8 @@ const LogEvent = "log"
 const LogSeverityAttribute = "log.severity"
 const LogMessageAttribute = "log.message"
 const LogSeverityDefaultAttribute = "level"
+const LogSeverityLegacyAttribute = "severity"
+const LogMessageLegacyAttribute = "message"
 
 const MetricEvent = "metric"
 const MetricSpanName = "highlight-metric"


### PR DESCRIPTION
## Summary

next.js and other customers may send traces that contain standard events (exception, log)
where they still want to record the trace which may contain other metadata and should be 
part of a larger flame graph.

start to capture those spans

* updates opentelemetry ingest processing to support some additional message keys
* fixes go sdk failing to sampling traces in if an empty sampling map was provided

## How did you test this change?

local deploy

go logs coming thru
![Screenshot from 2024-03-29 13-49-00](https://github.com/highlight/highlight/assets/1351531/4c8826f2-c6f0-4f37-9e01-e5cbee6d4a4d)

![Screenshot from 2024-03-29 14-37-49](https://github.com/highlight/highlight/assets/1351531/c2b10053-e33e-479c-a23c-3634f4090d14)
![Screenshot from 2024-03-29 14-39-05](https://github.com/highlight/highlight/assets/1351531/66335cea-1938-47c3-87eb-98d47d861cee)
![Screenshot from 2024-03-29 14-39-26](https://github.com/highlight/highlight/assets/1351531/82f69f97-7fab-4ddd-93fa-64674becdf82)



## Are there any deployment considerations?

no

## Does this work require review from our design team?

no