### PR TITLE
remove error object embeddings

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -455,8 +455,6 @@ type AllWorkspaceSettings struct {
 	AIApplication bool `gorm:"default:true"`
 	AIInsights    bool `gorm:"default:false"`
 
-	// store embeddings for errors in this workspace
-	ErrorEmbeddingsWrite bool `gorm:"default:false"`
 	// use embeddings to group errors in this workspace
 	ErrorEmbeddingsGroup bool `gorm:"default:true"`
 	// use embeddings to tag error groups in this workspace
@@ -1684,58 +1682,6 @@ func MigrateDB(ctx context.Context, DB *gorm.DB) (bool, error) {
 		END;
 	`, PARTITION_SESSION_ID, PARTITION_SESSION_ID).Error; err != nil {
 		return false, e.Wrap(err, "Error setting session id sequence to 30000000")
-	}
-
-	if err := DB.Exec(`
-		CREATE TABLE IF NOT EXISTS error_object_embeddings_partitioned
-		(LIKE error_object_embeddings INCLUDING DEFAULTS INCLUDING IDENTITY)
-		PARTITION BY LIST (project_id);
-	`).Error; err != nil {
-		return false, e.Wrap(err, "Error creating error_object_embeddings_partitioned")
-	}
-
-	var lastVal int
-	if err := DB.Raw("SELECT coalesce(max(id), 1) FROM projects").Scan(&lastVal).Error; err != nil {
-		return false, e.Wrap(err, "Error selecting max project id")
-	}
-
-	var lastCreatedPart int
-	// ignore errors - an error means that there are no partitions, so we can safely use the zero-value.
-	DB.Raw("select split_part(relname, '_', 5) from pg_stat_all_tables where relname like 'error_object_embeddings_partitioned%' order by relid desc limit 1").Scan(&lastCreatedPart)
-
-	endPart := lastVal + 1000
-	if IsDevOrTestEnv() {
-		// limit the number of partitions created in dev or test to limit disk usage
-		endPart = lastVal + 10
-	}
-	if IsTestEnv() {
-		// create a 0 partition for tests
-		lastCreatedPart = -1
-	}
-
-	// Make sure partitions are created for the next N projects, starting with the next partition needed
-	for i := lastCreatedPart + 1; i < endPart; i++ {
-		if err := DB.Exec(fmt.Sprintf(`
-			CREATE TABLE IF NOT EXISTS error_object_embeddings_partitioned_%d
-			(LIKE error_object_embeddings_partitioned INCLUDING DEFAULTS INCLUDING IDENTITY);
-		`, i)).Error; err != nil {
-			return false, e.Wrapf(err, "Error creating partitioned error_object_embeddings for index %d", i)
-		}
-
-		if err := DB.Exec(fmt.Sprintf(`
-			CREATE INDEX ON error_object_embeddings_partitioned_%d
-			USING ivfflat (gte_large_embedding vector_l2_ops) WITH (lists = 1000);
-		`, i)).Error; err != nil {
-			return false, e.Wrapf(err, "Error creating index error_object_embeddings for index %d", i)
-		}
-
-		// in case this partition was already attached by a previous failed migration, this will fail.
-		// ignore errors
-		DB.Exec(fmt.Sprintf(`
-			ALTER TABLE error_object_embeddings_partitioned
-			ATTACH PARTITION error_object_embeddings_partitioned_%d
-			FOR VALUES IN ('%d');
-		`, i, i))
 	}
 
 	// Create sequence for session_fields.id manually. This started as a join

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -136,7 +136,6 @@ var ContextKeys = struct {
 var Models = []interface{}{
 	&AWSMarketplaceCustomer{},
 	&ErrorObject{},
-	&ErrorObjectEmbeddings{},
 	&ErrorGroup{},
 	&ErrorGroupEmbeddings{},
 	&ErrorField{},

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -981,7 +981,6 @@ type ComplexityRoot struct {
 		FieldSuggestion                  func(childComplexity int, projectID int, name string, query string) int
 		FieldTypesClickhouse             func(childComplexity int, projectID int, startDate time.Time, endDate time.Time) int
 		FieldsClickhouse                 func(childComplexity int, projectID int, count int, fieldType string, fieldName string, query string, startDate time.Time, endDate time.Time) int
-		FindSimilarErrors                func(childComplexity int, query string) int
 		GenerateZapierAccessToken        func(childComplexity int, projectID int) int
 		GetSourceMapUploadUrls           func(childComplexity int, apiKey string, paths []string) int
 		GithubIssueLabels                func(childComplexity int, workspaceID int, repository string) int
@@ -1891,7 +1890,6 @@ type QueryResolver interface {
 	ServiceByName(ctx context.Context, projectID int, name string) (*model1.Service, error)
 	ErrorTags(ctx context.Context) ([]*model1.ErrorTag, error)
 	MatchErrorTag(ctx context.Context, query string) ([]*model.MatchedErrorTag, error)
-	FindSimilarErrors(ctx context.Context, query string) ([]*model1.MatchedErrorObject, error)
 	Trace(ctx context.Context, projectID int, traceID string, sessionSecureID *string) (*model.TracePayload, error)
 	Traces(ctx context.Context, projectID int, params model.QueryInput, after *string, before *string, at *string, direction model.SortDirection) (*model.TraceConnection, error)
 	TracesMetrics(ctx context.Context, projectID int, params model.QueryInput, column string, metricTypes []model.MetricAggregator, groupBy []string, bucketBy *string, bucketCount *int, limit *int, limitAggregator *model.MetricAggregator, limitColumn *string) (*model.MetricsBuckets, error)
@@ -7184,18 +7182,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.FieldsClickhouse(childComplexity, args["project_id"].(int), args["count"].(int), args["field_type"].(string), args["field_name"].(string), args["query"].(string), args["start_date"].(time.Time), args["end_date"].(time.Time)), true
-
-	case "Query.find_similar_errors":
-		if e.complexity.Query.FindSimilarErrors == nil {
-			break
-		}
-
-		args, err := ec.field_Query_find_similar_errors_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.FindSimilarErrors(childComplexity, args["query"].(string)), true
 
 	case "Query.generate_zapier_access_token":
 		if e.complexity.Query.GenerateZapierAccessToken == nil {
@@ -13106,7 +13092,6 @@ type Query {
 	serviceByName(project_id: ID!, name: String!): Service
 	error_tags: [ErrorTag]
 	match_error_tag(query: String!): [MatchedErrorTag]
-	find_similar_errors(query: String!): [MatchedErrorObject]
 	trace(
 		project_id: ID!
 		trace_id: String!
@@ -18888,21 +18873,6 @@ func (ec *executionContext) field_Query_fields_clickhouse_args(ctx context.Conte
 		}
 	}
 	args["end_date"] = arg6
-	return args, nil
-}
-
-func (ec *executionContext) field_Query_find_similar_errors_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 string
-	if tmp, ok := rawArgs["query"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
-		arg0, err = ec.unmarshalNString2string(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["query"] = arg0
 	return args, nil
 }
 
@@ -60022,70 +59992,6 @@ func (ec *executionContext) fieldContext_Query_match_error_tag(ctx context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_find_similar_errors(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_find_similar_errors(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().FindSimilarErrors(rctx, fc.Args["query"].(string))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]*model1.MatchedErrorObject)
-	fc.Result = res
-	return ec.marshalOMatchedErrorObject2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐMatchedErrorObject(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_find_similar_errors(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_MatchedErrorObject_id(ctx, field)
-			case "event":
-				return ec.fieldContext_MatchedErrorObject_event(ctx, field)
-			case "type":
-				return ec.fieldContext_MatchedErrorObject_type(ctx, field)
-			case "stack_trace":
-				return ec.fieldContext_MatchedErrorObject_stack_trace(ctx, field)
-			case "score":
-				return ec.fieldContext_MatchedErrorObject_score(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type MatchedErrorObject", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_find_similar_errors_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Query_trace(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_trace(ctx, field)
 	if err != nil {
@@ -89101,25 +89007,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "find_similar_errors":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_find_similar_errors(ctx, field)
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx,
-					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "trace":
 			field := field
 
@@ -100125,54 +100012,6 @@ func (ec *executionContext) marshalOLogAlert2ᚖgithubᚗcomᚋhighlightᚑrun�
 		return graphql.Null
 	}
 	return ec._LogAlert(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOMatchedErrorObject2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐMatchedErrorObject(ctx context.Context, sel ast.SelectionSet, v []*model1.MatchedErrorObject) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalOMatchedErrorObject2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐMatchedErrorObject(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	return ret
-}
-
-func (ec *executionContext) marshalOMatchedErrorObject2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐMatchedErrorObject(ctx context.Context, sel ast.SelectionSet, v *model1.MatchedErrorObject) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._MatchedErrorObject(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOMatchedErrorTag2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐMatchedErrorTag(ctx context.Context, sel ast.SelectionSet, v []*model.MatchedErrorTag) graphql.Marshaler {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2170,7 +2170,6 @@ type Query {
 	serviceByName(project_id: ID!, name: String!): Service
 	error_tags: [ErrorTag]
 	match_error_tag(query: String!): [MatchedErrorTag]
-	find_similar_errors(query: String!): [MatchedErrorObject]
 	trace(
 		project_id: ID!
 		trace_id: String!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -8581,11 +8581,6 @@ func (r *queryResolver) MatchErrorTag(ctx context.Context, query string) ([]*mod
 	return r.Resolver.MatchErrorTag(ctx, query)
 }
 
-// FindSimilarErrors is the resolver for the find_similar_errors field.
-func (r *queryResolver) FindSimilarErrors(ctx context.Context, query string) ([]*model.MatchedErrorObject, error) {
-	return r.Resolver.FindSimilarErrors(ctx, query)
-}
-
 // Trace is the resolver for the trace field.
 func (r *queryResolver) Trace(ctx context.Context, projectID int, traceID string, sessionSecureID *string) (*modelInputs.TracePayload, error) {
 	if _, err := r.canAdminViewSession(ctx, pointy.StringValue(sessionSecureID, "")); err != nil {

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -516,28 +516,6 @@ func (r *Resolver) GetTopErrorGroupMatchByEmbedding(ctx context.Context, project
 			}).Scan(&result).Error; err != nil {
 			return nil, e.Wrap(err, "error querying top error group match")
 		}
-	} else {
-		var column string
-		switch method {
-		case model.ErrorGroupingMethodAdaEmbeddingV2:
-			column = "combined_embedding"
-		case model.ErrorGroupingMethodGteLargeEmbeddingV2:
-			column = "gte_large_embedding"
-		}
-		if err := r.DB.WithContext(ctx).Raw(fmt.Sprintf(`
-select eoe.%s <-> @embedding as score,
-       eo.error_group_id                              as error_group_id
-from error_object_embeddings_partitioned eoe
-         inner join error_objects eo on eo.id = eoe.error_object_id
-where eoe.project_id = %d
-    and eoe.%s is not null
-order by 1
-limit 1;`, column, projectID, column), map[string]interface{}{
-			"embedding": embedding,
-		}).
-			Scan(&result).Error; err != nil {
-			return nil, e.Wrap(err, "error querying top error group match")
-		}
 	}
 
 	if result.ErrorGroupID > 0 {

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -346,13 +346,6 @@ func TestHandleErrorAndGroup(t *testing.T) {
 				eo := model.ErrorObject{ErrorGroupID: createdErrorGroup.ID, ProjectID: projectID}
 				resolver.DB.Create(&eo)
 
-				embedding := model.ErrorObjectEmbeddings{
-					ProjectID:         projectID,
-					ErrorObjectID:     eo.ID,
-					GteLargeEmbedding: emb.GteLargeEmbedding,
-				}
-				resolver.DB.Table("error_object_embeddings_partitioned").Create(&embedding)
-
 				for i := range avgEmbedding {
 					avgEmbedding[i] += (emb.GteLargeEmbedding[i] / float32(len(tc.embeddingsToInsert)))
 				}

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -24,10 +24,6 @@ type ListErrorObjectsParams struct {
 // Number of results per page
 const LIMIT = 10
 
-func (store *Store) PutEmbeddings(embeddings []*model.ErrorObjectEmbeddings) error {
-	return store.db.Table("error_object_embeddings_partitioned").Model(&model.ErrorObjectEmbeddings{}).CreateInBatches(embeddings, 64).Error
-}
-
 func (store *Store) ListErrorObjects(errorGroup model.ErrorGroup, params ListErrorObjectsParams) (privateModel.ErrorObjectConnection, error) {
 
 	var errorObjects []model.ErrorObject

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -14697,66 +14697,6 @@ export type MatchErrorTagQueryResult = Apollo.QueryResult<
 	Types.MatchErrorTagQuery,
 	Types.MatchErrorTagQueryVariables
 >
-export const FindSimilarErrorsDocument = gql`
-	query FindSimilarErrors($query: String!) {
-		find_similar_errors(query: $query) {
-			id
-			type
-			event
-			stack_trace
-			score
-		}
-	}
-`
-
-/**
- * __useFindSimilarErrorsQuery__
- *
- * To run a query within a React component, call `useFindSimilarErrorsQuery` and pass it any options that fit your needs.
- * When your component renders, `useFindSimilarErrorsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useFindSimilarErrorsQuery({
- *   variables: {
- *      query: // value for 'query'
- *   },
- * });
- */
-export function useFindSimilarErrorsQuery(
-	baseOptions: Apollo.QueryHookOptions<
-		Types.FindSimilarErrorsQuery,
-		Types.FindSimilarErrorsQueryVariables
-	>,
-) {
-	return Apollo.useQuery<
-		Types.FindSimilarErrorsQuery,
-		Types.FindSimilarErrorsQueryVariables
-	>(FindSimilarErrorsDocument, baseOptions)
-}
-export function useFindSimilarErrorsLazyQuery(
-	baseOptions?: Apollo.LazyQueryHookOptions<
-		Types.FindSimilarErrorsQuery,
-		Types.FindSimilarErrorsQueryVariables
-	>,
-) {
-	return Apollo.useLazyQuery<
-		Types.FindSimilarErrorsQuery,
-		Types.FindSimilarErrorsQueryVariables
-	>(FindSimilarErrorsDocument, baseOptions)
-}
-export type FindSimilarErrorsQueryHookResult = ReturnType<
-	typeof useFindSimilarErrorsQuery
->
-export type FindSimilarErrorsLazyQueryHookResult = ReturnType<
-	typeof useFindSimilarErrorsLazyQuery
->
-export type FindSimilarErrorsQueryResult = Apollo.QueryResult<
-	Types.FindSimilarErrorsQuery,
-	Types.FindSimilarErrorsQueryVariables
->
 export const GetTraceDocument = gql`
 	query GetTrace(
 		$project_id: ID!

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -4977,23 +4977,6 @@ export type MatchErrorTagQuery = { __typename?: 'Query' } & {
 	>
 }
 
-export type FindSimilarErrorsQueryVariables = Types.Exact<{
-	query: Types.Scalars['String']
-}>
-
-export type FindSimilarErrorsQuery = { __typename?: 'Query' } & {
-	find_similar_errors?: Types.Maybe<
-		Array<
-			Types.Maybe<
-				{ __typename?: 'MatchedErrorObject' } & Pick<
-					Types.MatchedErrorObject,
-					'id' | 'type' | 'event' | 'stack_trace' | 'score'
-				>
-			>
-		>
-	>
-}
-
 export type GetTraceQueryVariables = Types.Exact<{
 	project_id: Types.Scalars['ID']
 	trace_id: Types.Scalars['String']
@@ -5313,7 +5296,6 @@ export const namedOperations = {
 		GetServiceByName: 'GetServiceByName' as const,
 		GetErrorTags: 'GetErrorTags' as const,
 		MatchErrorTag: 'MatchErrorTag' as const,
-		FindSimilarErrors: 'FindSimilarErrors' as const,
 		GetTrace: 'GetTrace' as const,
 		GetTraces: 'GetTraces' as const,
 		GetTracesMetrics: 'GetTracesMetrics' as const,

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1959,7 +1959,6 @@ export type Query = {
 	field_suggestion?: Maybe<Array<Maybe<Field>>>
 	field_types_clickhouse: Array<Field>
 	fields_clickhouse: Array<Scalars['String']>
-	find_similar_errors?: Maybe<Array<Maybe<MatchedErrorObject>>>
 	generate_zapier_access_token: Scalars['String']
 	get_source_map_upload_urls: Array<Scalars['String']>
 	github_issue_labels: Array<Scalars['String']>
@@ -2338,10 +2337,6 @@ export type QueryFields_ClickhouseArgs = {
 	project_id: Scalars['ID']
 	query: Scalars['String']
 	start_date: Scalars['Timestamp']
-}
-
-export type QueryFind_Similar_ErrorsArgs = {
-	query: Scalars['String']
 }
 
 export type QueryGenerate_Zapier_Access_TokenArgs = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2348,16 +2348,6 @@ query MatchErrorTag($query: String!) {
 	}
 }
 
-query FindSimilarErrors($query: String!) {
-	find_similar_errors(query: $query) {
-		id
-		type
-		event
-		stack_trace
-		score
-	}
-}
-
 query GetTrace(
 	$project_id: ID!
 	$trace_id: String!

--- a/frontend/src/pages/ErrorTags/ErrorTagsSearch.tsx
+++ b/frontend/src/pages/ErrorTags/ErrorTagsSearch.tsx
@@ -11,10 +11,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 
 import { Button } from '@/components/Button'
 import { Skeleton } from '@/components/Skeleton'
-import {
-	useFindSimilarErrorsQuery,
-	useMatchErrorTagQuery,
-} from '@/graph/generated/hooks'
+import { useMatchErrorTagQuery } from '@/graph/generated/hooks'
 
 import styles from './ErrorTags.module.css'
 
@@ -30,11 +27,6 @@ export function ErrorTagsSearch() {
 		variables: { query },
 		skip: !query,
 	})
-	const { data: similarData, loading: similarLoading } =
-		useFindSimilarErrorsQuery({
-			variables: { query },
-			skip: !query,
-		})
 
 	return (
 		<Stack py="32" gap="32">
@@ -112,50 +104,6 @@ export function ErrorTagsSearch() {
 									</Table.Cell>
 									<Table.Cell>
 										<Score score={tag?.score} />
-									</Table.Cell>
-								</Table.Row>
-							)) || <NoResults />}
-						</Table.Body>
-					</Table>
-				)}
-			</Box>
-			<Box>
-				<Text cssClass={styles.tableHeaderText}>Similar errors</Text>
-
-				{similarLoading ? (
-					<Skeleton height="10rem" width="100%" />
-				) : (
-					<Table>
-						<Table.Head className={styles.searchTableHead}>
-							<Table.Row gridColumns={GRID_COLUMNS}>
-								<Table.Cell>Title</Table.Cell>
-								<Table.Cell>Stack Trace</Table.Cell>
-								<Table.Cell>Score</Table.Cell>
-							</Table.Row>
-						</Table.Head>
-						<Table.Body>
-							{similarData?.find_similar_errors?.map((error) => (
-								<Table.Row
-									gridColumns={GRID_COLUMNS}
-									key={error?.id}
-								>
-									<Table.Cell>
-										<Text
-											cssClass={styles.titleText}
-											title={error?.event.join(', ')}
-										>
-											{error?.event.join(', ')}
-										</Text>
-									</Table.Cell>
-									<Table.Cell>
-										<Text
-											cssClass={styles.titleDescription}
-										>
-											{error?.stack_trace}
-										</Text>
-									</Table.Cell>
-									<Table.Cell>
-										<Score score={error?.score} />
 									</Table.Cell>
 								</Table.Row>
 							)) || <NoResults />}


### PR DESCRIPTION
## Summary
- remove table / partition creation for `error_object_embeddings_partitioned`
- remove reading / writing from `error_object_embeddings_partitioned`
- also removes the `find_similar_errors` resolver - this demo page doesn't seem to be working in prod?
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- created errors from the `buttons` page, made sure they were grouped to existing error groups
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- can revert if issues, will drop the `error_object_embeddings_partitioned` tables after all looks good
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
