### PR TITLE
truncate trace values > 65536

### DIFF
--- a/backend/clickhouse/trace_row.go
+++ b/backend/clickhouse/trace_row.go
@@ -7,6 +7,15 @@ import (
 	"github.com/google/uuid"
 )
 
+const TraceAttributeValueLengthLimit = 2 << 15
+
+func truncateValue(input string) string {
+	if len(input) > TraceAttributeValueLengthLimit {
+		return input[:TraceAttributeValueLengthLimit] + "..."
+	}
+	return input
+}
+
 type TraceRow struct {
 	Timestamp       time.Time
 	UUID            string
@@ -79,7 +88,7 @@ func (t *TraceRow) WithTraceState(traceState string) *TraceRow {
 }
 
 func (t *TraceRow) WithSpanName(spanName string) *TraceRow {
-	t.SpanName = spanName
+	t.SpanName = truncateValue(spanName)
 	return t
 }
 
@@ -119,11 +128,14 @@ func (t *TraceRow) WithStatusCode(statusCode string) *TraceRow {
 }
 
 func (t *TraceRow) WithStatusMessage(statusMessage string) *TraceRow {
-	t.StatusMessage = statusMessage
+	t.StatusMessage = truncateValue(statusMessage)
 	return t
 }
 
 func (t *TraceRow) WithTraceAttributes(attributes map[string]string) *TraceRow {
+	for k, v := range attributes {
+		attributes[k] = truncateValue(v)
+	}
 	t.TraceAttributes = attributes
 	return t
 }
@@ -160,7 +172,7 @@ func (t *TraceRow) WithLinks(links []map[string]any) *TraceRow {
 func attributesToMap(attributes map[string]any) map[string]string {
 	newAttrMap := make(map[string]string)
 	for k, v := range attributes {
-		newAttrMap[k] = fmt.Sprintf("%v", v)
+		newAttrMap[k] = truncateValue(fmt.Sprintf("%v", v))
 	}
 	return newAttrMap
 }


### PR DESCRIPTION
## Summary
- uses some logic for truncating large log values to apply to traces as well
- expecting this to solve our current issue with trace uploads where certain values are very large >10mb and failing to write to clickhouse
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested the happy path locally to make sure traces are still ingested, will monitor the prod traces backlog after deployment
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
