### PR TITLE
interpolate query variables

### DIFF
--- a/sdk/highlightinc-highlight-datasource/src/datasource.ts
+++ b/sdk/highlightinc-highlight-datasource/src/datasource.ts
@@ -1,7 +1,7 @@
-import { CoreApp, DataSourceInstanceSettings } from '@grafana/data';
+import { CoreApp, DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
 
 import { HighlightDataSourceOptions, HighlightQuery, Table } from './types';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 
 export const tableOptions: { value: Table; label: string }[] = [
   { value: 'traces', label: 'traces' },
@@ -37,6 +37,15 @@ export class DataSource extends DataSourceWithBackend<HighlightQuery, HighlightD
     super(instanceSettings);
     this.url = instanceSettings.url;
     this.projectID = instanceSettings.jsonData.projectID;
+  }
+
+  applyTemplateVariables(query: HighlightQuery, scopedVars: ScopedVars): Record<string, any> {
+    const interpolatedQuery: HighlightQuery = {
+      ...query,
+      queryText: getTemplateSrv().replace(query.queryText, scopedVars),
+    };
+
+    return interpolatedQuery;
   }
 
   getDefaultQuery(app: CoreApp): Partial<HighlightQuery> {


### PR DESCRIPTION
## Summary
- interpolate variables in `queryText` before sending to backend datasource
<img width="1105" alt="Screen Shot 2024-04-02 at 12 57 54 PM" src="https://github.com/highlight/highlight/assets/86132398/889598c6-2030-4c03-ac00-23b425cc8319">

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested in local grafana instance
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, will submit new plugin version to marketplace after some of the other planned Grafana changes
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
