### PR TITLE
improvements to self hosted stack

### DIFF
--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -998,8 +998,9 @@ func (w *Worker) reportStripeUsage(ctx context.Context, workspaceID int) error {
 		}
 	}
 
-	// For annual subscriptions, set PendingInvoiceItemInterval to 'month' if not set
-	if interval == model.PricingSubscriptionIntervalAnnual &&
+	// For non-monthly subscriptions, set PendingInvoiceItemInterval to 'month' if not set
+	// so that overage is reported via monthly invoice items.
+	if interval != model.PricingSubscriptionIntervalMonthly &&
 		subscription.PendingInvoiceItemInterval != nil &&
 		subscription.PendingInvoiceItemInterval.Interval != stripe.SubscriptionPendingInvoiceItemIntervalIntervalMonth {
 		updated, err := w.stripeClient.Subscriptions.Update(subscription.ID, &stripe.SubscriptionParams{

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -284,9 +284,8 @@ func (r *Resolver) isWhitelistedAccount(ctx context.Context) bool {
 	uid := fmt.Sprintf("%v", ctx.Value(model.ContextKeys.UID))
 	email := fmt.Sprintf("%v", ctx.Value(model.ContextKeys.Email))
 	// Allow access to engineering@highlight.run or any verified @highlight.run / @runhighlight.com email.
-	_, isAdmin := lo.Find(HighlightAdminEmailDomains, func(domain string) bool { return strings.Contains(email, domain) })
-	isDockerDefaultAccount := util.IsInDocker() && !util.IsProduction()
-	return isAdmin || uid == WhitelistedUID || isDockerDefaultAccount
+	_, isHighlightAdmin := lo.Find(HighlightAdminEmailDomains, func(domain string) bool { return strings.Contains(email, domain) })
+	return !util.IsInDocker() && isHighlightAdmin || uid == WhitelistedUID
 }
 
 func (r *Resolver) isDemoProject(ctx context.Context, project_id int) bool {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -486,6 +486,11 @@ func (r *mutationResolver) CreateWorkspace(ctx context.Context, name string, pro
 		PromoCode:                 promoCode,
 	}
 
+	if util.IsOnPrem() {
+		// unlock self hosted usage
+		workspace.PlanTier = modelInputs.PlanTypeEnterprise.String()
+	}
+
 	if err := r.DB.WithContext(ctx).Create(workspace).Error; err != nil {
 		return nil, e.Wrap(err, "error creating workspace")
 	}

--- a/docker/collector.Dockerfile
+++ b/docker/collector.Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine as collector-build
+
+COPY ./collector.yml /collector.yml
+COPY ./configure-collector.sh /configure-collector.sh
+
+ARG IN_DOCKER_GO
+ARG SSL
+RUN /configure-collector.sh
+
+FROM otel/opentelemetry-collector-contrib as collector
+
+COPY --from=collector-build /collector.yml /etc/otel-collector-config.yaml
+CMD ["--config=/etc/otel-collector-config.yaml"]

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,18 +1,10 @@
 x-local-logging: &local-logging
     driver: local
 
-x-highlight-logging: &highlight-logging
-    driver: fluentd
-    options:
-        fluentd-address: '127.0.0.1:24224'
-        fluentd-async: 'true'
-        fluentd-sub-second-precision: 'true'
-        tag: 'highlight.project_id=1'
-
 # Highlight.io services for the development deployment.
 services:
     zookeeper:
-        logging: *highlight-logging
+        logging: *local-logging
         image: confluentinc/cp-zookeeper
         container_name: zookeeper
         restart: on-failure
@@ -24,7 +16,7 @@ services:
             ZOOKEEPER_TICK_TIME: 2000
 
     kafka:
-        logging: *highlight-logging
+        logging: *local-logging
         image: confluentinc/cp-kafka
         container_name: kafka
         volumes:
@@ -50,7 +42,7 @@ services:
             KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
 
     redis:
-        logging: *highlight-logging
+        logging: *local-logging
         container_name: redis
         image: redis
         restart: on-failure
@@ -64,7 +56,7 @@ services:
             - --loglevel warning
 
     postgres:
-        logging: *highlight-logging
+        logging: *local-logging
         container_name: postgres
         # a postgres image with pgvector installed
         image: ankane/pgvector
@@ -83,7 +75,7 @@ services:
             retries: 5
 
     clickhouse:
-        logging: *highlight-logging
+        logging: *local-logging
         container_name: clickhouse
         image: clickhouse/clickhouse-server
         restart: on-failure
@@ -96,8 +88,16 @@ services:
             - clickhouse-logs:/var/log/clickhouse-server
 
     collector:
-        logging: *highlight-logging
+        logging: *local-logging
         restart: on-failure
+        build:
+            dockerfile: collector.Dockerfile
+            pull: true
+            target: collector
+            args:
+                - IN_DOCKER_GO
+                - SSL
+        container_name: collector
         extra_hosts:
             - 'host.docker.internal:host-gateway'
         ports:
@@ -107,12 +107,6 @@ services:
             - '0.0.0.0:8888:8888'
             - '0.0.0.0:24224:24224'
             - '0.0.0.0:34302:34302'
-        container_name: collector
-        image: otel/opentelemetry-collector-contrib
-        command:
-            - '--config=/etc/collector.yml'
-        volumes:
-            - ./collector.yml:/etc/collector.yml
 
 volumes:
     postgres-data:

--- a/docker/configure-collector.sh
+++ b/docker/configure-collector.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -ex
+
+COLLECTOR_CONFIG="./collector.yml"
+if [[ "$IN_DOCKER_GO" == "true" ]]; then
+  if grep -q 'https://host.docker.internal' "$COLLECTOR_CONFIG"; then
+    sed -i'' -e 's/https:\/\/host\.docker\.internal:8082/http:\/\/backend:8082/g' $COLLECTOR_CONFIG
+  fi
+  if grep -q 'insecure_skip_verify' "$COLLECTOR_CONFIG"; then
+    sed -i'' -e '18d;19d' $COLLECTOR_CONFIG
+  fi
+elif [[ "$SSL" != "true" ]]; then
+  if grep -q 'https://host.docker.internal' "$COLLECTOR_CONFIG"; then
+    sed -i'' -e 's/https:\/\/host\.docker/http:\/\/host\.docker/g' $COLLECTOR_CONFIG
+  fi
+  if grep -q 'insecure_skip_verify' "$COLLECTOR_CONFIG"; then
+    sed -i'' -e '18d;19d' $COLLECTOR_CONFIG
+  fi
+fi

--- a/docker/start-infra.sh
+++ b/docker/start-infra.sh
@@ -6,29 +6,8 @@ source env.sh
 
 SERVICES="clickhouse kafka postgres redis zookeeper collector"
 
-BASE_COMPOSE="./compose.yml"
-COLLECTOR_CONFIG="./collector.yml"
-if [[ "$IN_DOCKER_GO" == "true" ]]; then
-  if grep -q '*highlight-logging' "$BASE_COMPOSE"; then
-    sed -i "s/\*highlight-logging/\*local-logging/g" $BASE_COMPOSE
-  fi
-  if grep -q 'https://host.docker.internal' "$COLLECTOR_CONFIG"; then
-    sed -i "s/https:\/\/host\.docker\.internal:8082/http:\/\/backend:8082/g" $COLLECTOR_CONFIG
-  fi
-  if grep -q 'insecure_skip_verify' "$COLLECTOR_CONFIG"; then
-    sed -i "18d;19d" $COLLECTOR_CONFIG
-  fi
-elif [[ "$SSL" != "true" ]]; then
-  if grep -q 'https://host.docker.internal' "$COLLECTOR_CONFIG"; then
-    sed -i "s/https:\/\/host\.docker/http:\/\/host\.docker/g" $COLLECTOR_CONFIG
-  fi
-  if grep -q 'insecure_skip_verify' "$COLLECTOR_CONFIG"; then
-    sed -i "18d;19d" $COLLECTOR_CONFIG
-  fi
-fi
-
 docker compose pull $SERVICES
-docker compose up --detach --wait --remove-orphans $SERVICES
+docker compose up --detach --wait --remove-orphans --build $SERVICES
 
 if [[ "$*" != *"--go-docker"* ]]; then
   pushd ../backend


### PR DESCRIPTION
## Summary

* Fixes billing issue for overage customers on a non-monthly and non-annual plan (ie. 6-month plan)
* Fixes self hosted cross-workspace access
* Simplifies collector deployment via `./start-infra.sh` in a docker container to avoid depending on `sed`
* Cleans up logging in the docker compose to avoid requiring `sed`.
* Defaults self hosted stack to `enterprise` quota to avoid ingestion limits.

## How did you test this change?

local hobby testing, ec2 box docker image testing

## Are there any deployment considerations?

no, will be released with new docker image

## Does this work require review from our design team?

no
