### PR TITLE
fix release process for bundled highlight.run client

### DIFF
--- a/.changeset/curvy-crabs-tan.md
+++ b/.changeset/curvy-crabs-tan.md
@@ -1,5 +1,0 @@
----
-'highlight.run': minor
----
-
-lazy load client bundle from node modules to avoid ad blockers

--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -1674,29 +1674,6 @@ function buildNode(n2, options) {
         const isRemoteOrDynamicCss = tagName === "style" && name === "_cssText";
         if (isRemoteOrDynamicCss && hackCss && typeof value === "string") {
           value = addHoverClass(value, cache);
-          if (typeof value === "string") {
-            const regex = /url\("https:\/\/\S*(.eot|.woff2|.ttf|.woff)\S*"\)/gm;
-            let m;
-            const fontUrls = [];
-            const PROXY_URL = "https://replay-cors-proxy.highlightrun.workers.dev";
-            while ((m = regex.exec(value)) !== null) {
-              if (m.index === regex.lastIndex) {
-                regex.lastIndex++;
-              }
-              m.forEach((match, groupIndex) => {
-                if (groupIndex === 0) {
-                  const url = match.slice(5, match.length - 2);
-                  fontUrls.push({
-                    originalUrl: url,
-                    proxyUrl: url.replace(url, `${PROXY_URL}?url=${url}`)
-                  });
-                }
-              });
-            }
-            fontUrls.forEach((urlPair) => {
-              value = value.replace(urlPair.originalUrl, urlPair.proxyUrl);
-            });
-          }
         }
         if ((isTextarea || isRemoteOrDynamicCss) && typeof value === "string") {
           node.appendChild(doc.createTextNode(value));

--- a/sdk/firstload/CHANGELOG.md
+++ b/sdk/firstload/CHANGELOG.md
@@ -1,5 +1,11 @@
 # highlight.run
 
+## 8.11.0
+
+### Minor Changes
+
+-   4574c8dfa: lazy load client bundle from node modules to avoid ad blockers
+
 ## 8.10.1
 
 ### Patch Changes

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -52,7 +52,6 @@
 		"hoistingLimits": "workspaces"
 	},
 	"devDependencies": {
-		"@highlight-run/client": "workspace:*",
 		"@rollup/plugin-commonjs": "^25.0.7",
 		"@rollup/plugin-json": "^6.1.0",
 		"@rollup/plugin-node-resolve": "^15.2.3",

--- a/sdk/firstload/package.json
+++ b/sdk/firstload/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "highlight.run",
-	"version": "8.10.1",
+	"version": "8.11.0",
 	"description": "Open source, fullstack monitoring. Capture frontend errors, record server side logs, and visualize what broke with session replay.",
 	"keywords": [
 		"highlight",

--- a/sdk/firstload/src/__generated/version.ts
+++ b/sdk/firstload/src/__generated/version.ts
@@ -1,1 +1,1 @@
-export default "8.10.1"
+export default "8.11.0"

--- a/sdk/highlight-next/CHANGELOG.md
+++ b/sdk/highlight-next/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/next
 
+## 7.4.10
+
+### Patch Changes
+
+-   Updated dependencies [4574c8dfa]
+    -   highlight.run@8.11.0
+    -   @highlight-run/node@3.8.2
+
 ## 7.4.9
 
 ### Patch Changes

--- a/sdk/highlight-next/package.json
+++ b/sdk/highlight-next/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/next",
-	"version": "7.4.9",
+	"version": "7.4.10",
 	"description": "Client for interfacing with Highlight in next.js",
 	"files": [
 		"dist",

--- a/sdk/highlight-remix/CHANGELOG.md
+++ b/sdk/highlight-remix/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @highlight-run/remix
 
+## 2.0.28
+
+### Patch Changes
+
+-   Updated dependencies [4574c8dfa]
+    -   highlight.run@8.11.0
+    -   @highlight-run/node@3.8.2
+
 ## 2.0.27
 
 ### Patch Changes

--- a/sdk/highlight-remix/package.json
+++ b/sdk/highlight-remix/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@highlight-run/remix",
-	"version": "2.0.27",
+	"version": "2.0.28",
 	"description": "Client for interfacing with Highlight in Remix",
 	"packageManager": "yarn@4.0.2",
 	"author": "",

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,11 @@
 			"inputs": ["src/**/*.tsx", "src/**/*.ts", "tsconfig.json"],
 			"outputs": ["dist/**/*.d.ts"]
 		},
+		"highlight.run#build": {
+			"dependsOn": ["typegen", "@highlight-run/client#build"],
+			"inputs": ["src/**/*.tsx", "src/**/*.ts", "tsconfig.json"],
+			"outputs": ["dist/**"]
+		},
 		"highlight.io#build": {
 			"dependsOn": ["^build"],
 			"outputs": [".next/**"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -43612,7 +43612,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "highlight.run@workspace:sdk/firstload"
   dependencies:
-    "@highlight-run/client": "workspace:*"
     "@rollup/plugin-commonjs": "npm:^25.0.7"
     "@rollup/plugin-json": "npm:^6.1.0"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"


### PR DESCRIPTION
## Summary

Fixes js release pipeline after #8058 broke it due to a changeset configuration issue

Releases:
-   highlight.run@8.11.0
-   @highlight-run/next@7.4.10
-   @highlight-run/remix@2.0.28


## How did you test this change?

before
![Screenshot from 2024-04-02 11-10-27](https://github.com/highlight/highlight/assets/1351531/0a689ca8-2f2c-4a65-b7e9-9283a872a8ab)

after
![Screenshot from 2024-04-02 11-10-16](https://github.com/highlight/highlight/assets/1351531/a3a592ec-4322-4af3-8e82-54f398a3cfe1)

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
