### PR TITLE
Compare excluded env against error env

### DIFF
--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -527,8 +527,8 @@ func (r *Resolver) GetTopErrorGroupMatchByEmbedding(ctx context.Context, project
 			if method == model.ErrorGroupingMethodGteLargeEmbeddingV3 {
 				if err := r.DB.WithContext(ctx).Exec(`
 					update error_group_embeddings
-					set gte_large_embedding = gte_large_embedding * array_fill(count::numeric / (count + 1), '{1024}')::vector 
-						+ @embedding * array_fill(1::numeric / (count + 1), '{1024}')::vector, 
+					set gte_large_embedding = gte_large_embedding * array_fill(count::numeric / (count + 1), '{1024}')::vector
+						+ @embedding * array_fill(1::numeric / (count + 1), '{1024}')::vector,
 						count = count + 1
 					where project_id = @projectID
 					and error_group_id = @errorGroupID`,
@@ -1724,7 +1724,7 @@ func (r *Resolver) sendErrorAlert(ctx context.Context, projectID int, sessionObj
 			}
 			excluded := false
 			for _, env := range excludedEnvironments {
-				if env != nil && *env == sessionObj.Environment {
+				if env != nil && *env == errorObject.Environment {
 					excluded = true
 					break
 				}


### PR DESCRIPTION
## Summary

Fixes a bug where we would compare the excluded environments on an error alert against the session associated with the error rather than the error's environment. This can be problematic when there isn't an associated session.

## How did you test this change?

Click tested to confirm I was getting alerts and that they stopped once I added the excluded environments locally.

## Are there any deployment considerations?

Will follow up with customers impacted by this bug to let them know it should be resolved, but no major considerations here.

## Does this work require review from our design team?

N/A