### PR TITLE
support count distinct in grafana

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -508,7 +508,7 @@ func getFnStr(aggregator modelInputs.MetricAggregator, column string, useSamplin
 		} else {
 			return "round(count() * 1.0)"
 		}
-	case modelInputs.MetricAggregatorCountDistinctKey:
+	case modelInputs.MetricAggregatorCountDistinctKey, modelInputs.MetricAggregatorCountDistinct:
 		if useSampling {
 			return fmt.Sprintf("round(count(distinct %s) * any(_sample_factor))", column)
 		} else {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -12045,6 +12045,7 @@ type LogsHistogram {
 
 enum MetricAggregator {
 	Count
+	CountDistinct
 	CountDistinctKey
 	Min
 	Avg

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1401,6 +1401,7 @@ type MetricAggregator string
 
 const (
 	MetricAggregatorCount            MetricAggregator = "Count"
+	MetricAggregatorCountDistinct    MetricAggregator = "CountDistinct"
 	MetricAggregatorCountDistinctKey MetricAggregator = "CountDistinctKey"
 	MetricAggregatorMin              MetricAggregator = "Min"
 	MetricAggregatorAvg              MetricAggregator = "Avg"
@@ -1414,6 +1415,7 @@ const (
 
 var AllMetricAggregator = []MetricAggregator{
 	MetricAggregatorCount,
+	MetricAggregatorCountDistinct,
 	MetricAggregatorCountDistinctKey,
 	MetricAggregatorMin,
 	MetricAggregatorAvg,
@@ -1427,7 +1429,7 @@ var AllMetricAggregator = []MetricAggregator{
 
 func (e MetricAggregator) IsValid() bool {
 	switch e {
-	case MetricAggregatorCount, MetricAggregatorCountDistinctKey, MetricAggregatorMin, MetricAggregatorAvg, MetricAggregatorP50, MetricAggregatorP90, MetricAggregatorP95, MetricAggregatorP99, MetricAggregatorMax, MetricAggregatorSum:
+	case MetricAggregatorCount, MetricAggregatorCountDistinct, MetricAggregatorCountDistinctKey, MetricAggregatorMin, MetricAggregatorAvg, MetricAggregatorP50, MetricAggregatorP90, MetricAggregatorP95, MetricAggregatorP99, MetricAggregatorMax, MetricAggregatorSum:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1081,6 +1081,7 @@ type LogsHistogram {
 
 enum MetricAggregator {
 	Count
+	CountDistinct
 	CountDistinctKey
 	Min
 	Avg

--- a/sdk/highlightinc-highlight-datasource/pkg/plugin/datasource.go
+++ b/sdk/highlightinc-highlight-datasource/pkg/plugin/datasource.go
@@ -223,6 +223,7 @@ type MetricAggregator string
 
 const (
 	MetricAggregatorCount            MetricAggregator = "Count"
+	MetricAggregatorCountDistinct    MetricAggregator = "CountDistinct"
 	MetricAggregatorCountDistinctKey MetricAggregator = "CountDistinctKey"
 	MetricAggregatorMin              MetricAggregator = "Min"
 	MetricAggregatorAvg              MetricAggregator = "Avg"

--- a/sdk/highlightinc-highlight-datasource/src/datasource.ts
+++ b/sdk/highlightinc-highlight-datasource/src/datasource.ts
@@ -19,6 +19,7 @@ export const bucketByOptions: { value: string; label: string }[] = [
 
 export const metricOptions: { value: string; label: string; tables: Table[] }[] = [
   { value: 'Count', label: 'Count', tables: ['traces', 'logs', 'errors', 'sessions'] },
+  { value: 'CountDistinct', label: 'CountDistinct', tables: ['traces', 'logs', 'errors', 'sessions'] },
   { value: 'Min', label: 'Min', tables: ['traces', 'logs', 'sessions'] },
   { value: 'Avg', label: 'Avg', tables: ['traces', 'logs', 'sessions'] },
   { value: 'P50', label: 'P50', tables: ['traces', 'logs', 'sessions'] },


### PR DESCRIPTION
## Summary
- `CountDistinct` should operate almost exactly how `CountDistinctKey` does, but instead of using `highlight.key` should use a custom key
<img width="686" alt="Screen Shot 2024-04-02 at 6 13 58 PM" src="https://github.com/highlight/highlight/assets/86132398/a1fef5fe-92f8-4692-bea9-ef3446b4640c">

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- click tested in grafana plugin locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
