### PR TITLE
Fix trace attributes not appearing

### DIFF
--- a/frontend/src/pages/Traces/TraceSpanAttributes.tsx
+++ b/frontend/src/pages/Traces/TraceSpanAttributes.tsx
@@ -5,11 +5,7 @@ import { JsonViewerV2 } from '@/components/JsonViewer/JsonViewerV2'
 import { findMatchingAttributes } from '@/components/JsonViewer/utils'
 import { QueryParam } from '@/components/Search/SearchForm/SearchForm'
 import { parseSearch } from '@/components/Search/utils'
-import {
-	FlameGraphSpan,
-	formatDateWithNanoseconds,
-	humanizeDuration,
-} from '@/pages/Traces/utils'
+import { FlameGraphSpan, formatTraceAttributes } from '@/pages/Traces/utils'
 import analytics from '@/util/analytics'
 
 type Props = {
@@ -21,25 +17,7 @@ export const TraceSpanAttributes: React.FC<Props> = ({ span }) => {
 	const queryParts = useMemo(() => parseSearch(query).queryParts, [query])
 	const attributes: { [key: string]: any } = { ...span }
 
-	const formattedSpan = cleanAttributes({
-		timestamp: formatDateWithNanoseconds(attributes.timestamp),
-		parent_span_id: attributes.parentSpanID,
-		secure_session_id: attributes.secureSessionID,
-		span_name: attributes.spanName,
-		duration: humanizeDuration(attributes.duration),
-		service_name: attributes.serviceName,
-		service_version: attributes.serviceVersion,
-		environment: attributes.environment,
-		start_time: attributes.startTime,
-		...attributes.traceAttributes,
-		trace_id: attributes.traceID,
-		span_id: attributes.spanID,
-		span_kind: attributes.spanKind,
-		status_code: attributes.statusCode,
-		host: attributes.host,
-		os: attributes.os,
-		process: attributes.process,
-	})
+	const formattedSpan = formatTraceAttributes(attributes)
 
 	const matchedAttributes = findMatchingAttributes(queryParts, formattedSpan)
 
@@ -55,25 +33,4 @@ export const TraceSpanAttributes: React.FC<Props> = ({ span }) => {
 			queryParts={queryParts}
 		/>
 	)
-}
-
-const cleanAttributes = (attributes: any): any => {
-	const copy = { ...attributes }
-
-	Object.keys(copy).forEach((key) => {
-		const value = copy[key as keyof typeof copy]
-
-		if (!value) {
-			// Remove empty attributes
-			delete copy[key]
-		} else if (typeof value === 'string' && !isNaN(Number(value))) {
-			// Convert all stringified numbers to numbers
-			copy[key] = Number(value)
-		} else if (typeof value === 'object' && value !== null) {
-			// If the value is an object, call the function again
-			copy[key] = cleanAttributes(value)
-		}
-	})
-
-	return copy
 }


### PR DESCRIPTION
## Summary

Fixes an issue where trace attributes weren't being shown on a trace ([more context in Slack](https://highlightcorp.slack.com/archives/C02N2AZS8BV/p1712175890638669)). Also tweaks the attribute cleaning logic so we don't filter out values like `0` or `null` which could be useful to the end user.

## How did you test this change?

Click tested [the problematic trace](https://app.highlight.io/29954/traces/a8a037c749e30845c9c4a8517d7255fa/d4de3069dd0405ca?query=service_name%21%3Dmagicsky-frontend%20process.executable.path%3D%2Fvar%2Flang%2Fbin%2Fnode) in the PR preview to confirm the changes. Also added some unit tests around the formatting/attribute cleaning logic.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A