### PR TITLE
Allow searching logs by `message` key

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -34,6 +34,7 @@ var logKeysToColumns = map[modelInputs.ReservedLogKey]string{
 	modelInputs.ReservedLogKeyServiceName:     "ServiceName",
 	modelInputs.ReservedLogKeyServiceVersion:  "ServiceVersion",
 	modelInputs.ReservedLogKeyEnvironment:     "Environment",
+	modelInputs.ReservedLogKeyMessage:         "Body",
 }
 
 // These keys show up as recommendations, but with no recommended values due to high cardinality


### PR DESCRIPTION
## Summary

You can't search logs using the `message` key on a filter. This is confusing because people see `message` in the log attributes and try to filter on it. This PR fixes that.

## How did you test this change?

Performed a number of searches using the `message` key and confirmed the value was being mapped properly using a breakpoint in my IDE and checking the values.

<img width="792" alt="Screenshot 2024-04-04 at 3 44 26 PM" src="https://github.com/highlight/highlight/assets/308182/cc92ef93-3f1f-490b-9f1a-15848e8657f8">

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A