### PR TITLE
Update backend with supporting changes for query

### DIFF
--- a/backend/clickhouse/errors.go
+++ b/backend/clickhouse/errors.go
@@ -473,24 +473,26 @@ func (client *Client) QueryErrorGroupTags(ctx context.Context, projectId int, er
 	return lo.Values(aggs), nil
 }
 
-func (client *Client) QueryErrorFieldValues(ctx context.Context, projectId int, count int, fieldType string, fieldName string, query string, start time.Time, end time.Time) ([]string, error) {
-	mappedName, found := fieldMap[fieldName]
-	if !found {
-		return nil, fmt.Errorf("unknown column %s", fieldName)
-	}
+func (client *Client) QueryErrorFieldValues(ctx context.Context, projectId int, count int, fieldName string, query string, start time.Time, end time.Time) ([]string, error) {
+	var table string
+	var mappedName string
+	var ok bool
 
-	table := ErrorGroupsTable
-	if fieldType == "error-field" {
+	if mappedName, ok = ErrorGroupsTableConfig.KeysToColumns[modelInputs.ReservedErrorGroupKey(fieldName)]; ok {
+		table = ErrorGroupsTable
+	} else if mappedName, ok = ErrorObjectsTableConfig.KeysToColumns[modelInputs.ReservedErrorObjectKey(fieldName)]; ok {
 		table = ErrorObjectsTable
+	} else {
+		return nil, fmt.Errorf("unknown column %s", fieldName)
 	}
 
 	sb := sqlbuilder.NewSelectBuilder()
 	sb = sb.
-		Select(mappedName).
+		Select(fmt.Sprintf("toString(%s)", mappedName)).
 		From(table).
 		Where(sb.Equal("ProjectID", projectId)).
-		Where(fmt.Sprintf("%s ILIKE %s", mappedName, sb.Var("%"+query+"%"))).
-		Where(fmt.Sprintf("%s <> ''", mappedName))
+		Where(fmt.Sprintf("toString(%s) ILIKE %s", mappedName, sb.Var("%"+query+"%"))).
+		Where(fmt.Sprintf("toString(%s) <> ''", mappedName))
 
 	if table == ErrorGroupsTable {
 		sb = sb.Where(sb.Or(
@@ -626,16 +628,7 @@ func (client *Client) ReadErrorsMetrics(ctx context.Context, projectID int, para
 }
 
 func (client *Client) ErrorsKeyValues(ctx context.Context, projectID int, keyName string, startDate time.Time, endDate time.Time) ([]string, error) {
-	var tableName string
-	if ok := modelInputs.ReservedErrorGroupKey(keyName).IsValid(); ok {
-		tableName = ErrorGroupsTable
-	} else if ok := modelInputs.ReservedErrorObjectKey(keyName).IsValid(); ok {
-		tableName = ErrorObjectsTable
-	} else {
-		return nil, fmt.Errorf("unknown error key %s", keyName)
-	}
-
-	return client.QueryErrorFieldValues(ctx, projectID, 10, tableName, keyName, "", startDate, endDate)
+	return client.QueryErrorFieldValues(ctx, projectID, 10, keyName, "", startDate, endDate)
 }
 
 func (client *Client) QueryErrorObjectsHistogram(ctx context.Context, projectId int, params modelInputs.QueryInput, options modelInputs.DateHistogramOptions) ([]time.Time, []int64, error) {
@@ -648,7 +641,7 @@ func (client *Client) QueryErrorObjectsHistogram(ctx context.Context, projectId 
 
 	orderBy := fmt.Sprintf("1 WITH FILL FROM %s(?, '%s') TO %s(?, '%s') STEP 1", aggFn, location.String(), aggFn, location.String())
 
-	sb, err := readErrorsObjects(selectCols, params, projectId, orderBy)
+	sb, err := readErrorsObjects(selectCols, params, projectId, "1", orderBy)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -684,7 +677,9 @@ func (client *Client) QueryErrorGroups(ctx context.Context, projectId int, count
 	}
 	offset := (pageInt - 1) * count
 
-	sb, err := readErrorGroups(params, projectId)
+	var sb *sqlbuilder.SelectBuilder
+	var err error
+	sb, err = readErrorGroups(params, projectId)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -720,10 +715,10 @@ func readErrorGroups(params modelInputs.QueryInput, projectId int) (*sqlbuilder.
 	sbInner := sqlbuilder.NewSelectBuilder()
 	sbInner.Select("ErrorGroupID")
 	sbInner.From(ErrorsJoinedTableConfig.TableName)
-	sbInner.Where(sb.Equal("ProjectId", projectId))
+	sbInner.Where(sbInner.Equal("ProjectId", projectId))
 
-	sbInner.Where(sb.LessEqualThan("Timestamp", params.DateRange.EndDate)).
-		Where(sb.GreaterEqualThan("Timestamp", params.DateRange.StartDate))
+	sbInner.Where(sbInner.LessEqualThan("Timestamp", params.DateRange.EndDate)).
+		Where(sbInner.GreaterEqualThan("Timestamp", params.DateRange.StartDate))
 
 	parser.AssignSearchFilters(sbInner, params.Query, ErrorsJoinedTableConfig)
 
@@ -732,13 +727,16 @@ func readErrorGroups(params modelInputs.QueryInput, projectId int) (*sqlbuilder.
 	return sb, nil
 }
 
-func readErrorsObjects(selectCols string, params modelInputs.QueryInput, projectId int, orderBy string) (*sqlbuilder.SelectBuilder, error) {
+func readErrorsObjects(selectCols string, params modelInputs.QueryInput, projectId int, groupBy string, orderBy string) (*sqlbuilder.SelectBuilder, error) {
 	sb := sqlbuilder.NewSelectBuilder()
 	sb.Select(selectCols)
 	sb.From(fmt.Sprintf("%s FINAL", ErrorsJoinedTableConfig.TableName))
 	sb.Where(sb.Equal("ProjectId", projectId))
 
 	parser.AssignSearchFilters(sb, params.Query, ErrorsJoinedTableConfig)
+
+	sb.OrderBy(orderBy)
+	sb.GroupBy(groupBy)
 
 	return sb, nil
 }

--- a/backend/clickhouse/errors.go
+++ b/backend/clickhouse/errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/highlight-run/highlight/backend/parser"
@@ -477,6 +478,8 @@ func (client *Client) QueryErrorFieldValues(ctx context.Context, projectId int, 
 	var table string
 	var mappedName string
 	var ok bool
+	// needed to support "Tag" for backwards compatibility (can remove with new query language)
+	fieldName = strings.ToLower(fieldName)
 
 	if mappedName, ok = ErrorGroupsTableConfig.KeysToColumns[modelInputs.ReservedErrorGroupKey(fieldName)]; ok {
 		table = ErrorGroupsTable

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -12002,6 +12002,7 @@ enum ReservedErrorObjectKey {
 enum ReservedErrorGroupKey {
 	event
 	status
+	tag
 	Tag
 	type
 }

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -11496,6 +11496,7 @@ enum SortDirection {
 enum SavedSegmentEntityType {
 	Log
 	Trace
+	Error
 }
 
 type Project {
@@ -12001,7 +12002,7 @@ enum ReservedErrorObjectKey {
 enum ReservedErrorGroupKey {
 	event
 	status
-	tag
+	Tag
 	type
 }
 

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -12003,7 +12003,6 @@ enum ReservedErrorGroupKey {
 	event
 	status
 	tag
-	Tag
 	type
 }
 

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1847,7 +1847,7 @@ type ReservedErrorGroupKey string
 const (
 	ReservedErrorGroupKeyEvent  ReservedErrorGroupKey = "event"
 	ReservedErrorGroupKeyStatus ReservedErrorGroupKey = "status"
-	ReservedErrorGroupKeyTag    ReservedErrorGroupKey = "tag"
+	ReservedErrorGroupKeyTag    ReservedErrorGroupKey = "Tag"
 	ReservedErrorGroupKeyType   ReservedErrorGroupKey = "type"
 )
 
@@ -2277,16 +2277,18 @@ type SavedSegmentEntityType string
 const (
 	SavedSegmentEntityTypeLog   SavedSegmentEntityType = "Log"
 	SavedSegmentEntityTypeTrace SavedSegmentEntityType = "Trace"
+	SavedSegmentEntityTypeError SavedSegmentEntityType = "Error"
 )
 
 var AllSavedSegmentEntityType = []SavedSegmentEntityType{
 	SavedSegmentEntityTypeLog,
 	SavedSegmentEntityTypeTrace,
+	SavedSegmentEntityTypeError,
 }
 
 func (e SavedSegmentEntityType) IsValid() bool {
 	switch e {
-	case SavedSegmentEntityTypeLog, SavedSegmentEntityTypeTrace:
+	case SavedSegmentEntityTypeLog, SavedSegmentEntityTypeTrace, SavedSegmentEntityTypeError:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1848,7 +1848,6 @@ const (
 	ReservedErrorGroupKeyEvent  ReservedErrorGroupKey = "event"
 	ReservedErrorGroupKeyStatus ReservedErrorGroupKey = "status"
 	ReservedErrorGroupKeyTag    ReservedErrorGroupKey = "tag"
-	ReservedErrorGroupKeyTag0   ReservedErrorGroupKey = "Tag"
 	ReservedErrorGroupKeyType   ReservedErrorGroupKey = "type"
 )
 
@@ -1856,13 +1855,12 @@ var AllReservedErrorGroupKey = []ReservedErrorGroupKey{
 	ReservedErrorGroupKeyEvent,
 	ReservedErrorGroupKeyStatus,
 	ReservedErrorGroupKeyTag,
-	ReservedErrorGroupKeyTag0,
 	ReservedErrorGroupKeyType,
 }
 
 func (e ReservedErrorGroupKey) IsValid() bool {
 	switch e {
-	case ReservedErrorGroupKeyEvent, ReservedErrorGroupKeyStatus, ReservedErrorGroupKeyTag, ReservedErrorGroupKeyTag0, ReservedErrorGroupKeyType:
+	case ReservedErrorGroupKeyEvent, ReservedErrorGroupKeyStatus, ReservedErrorGroupKeyTag, ReservedErrorGroupKeyType:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -1847,7 +1847,8 @@ type ReservedErrorGroupKey string
 const (
 	ReservedErrorGroupKeyEvent  ReservedErrorGroupKey = "event"
 	ReservedErrorGroupKeyStatus ReservedErrorGroupKey = "status"
-	ReservedErrorGroupKeyTag    ReservedErrorGroupKey = "Tag"
+	ReservedErrorGroupKeyTag    ReservedErrorGroupKey = "tag"
+	ReservedErrorGroupKeyTag0   ReservedErrorGroupKey = "Tag"
 	ReservedErrorGroupKeyType   ReservedErrorGroupKey = "type"
 )
 
@@ -1855,12 +1856,13 @@ var AllReservedErrorGroupKey = []ReservedErrorGroupKey{
 	ReservedErrorGroupKeyEvent,
 	ReservedErrorGroupKeyStatus,
 	ReservedErrorGroupKeyTag,
+	ReservedErrorGroupKeyTag0,
 	ReservedErrorGroupKeyType,
 }
 
 func (e ReservedErrorGroupKey) IsValid() bool {
 	switch e {
-	case ReservedErrorGroupKeyEvent, ReservedErrorGroupKeyStatus, ReservedErrorGroupKeyTag, ReservedErrorGroupKeyType:
+	case ReservedErrorGroupKeyEvent, ReservedErrorGroupKeyStatus, ReservedErrorGroupKeyTag, ReservedErrorGroupKeyTag0, ReservedErrorGroupKeyType:
 		return true
 	}
 	return false

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -492,6 +492,7 @@ enum SortDirection {
 enum SavedSegmentEntityType {
 	Log
 	Trace
+	Error
 }
 
 type Project {
@@ -997,7 +998,7 @@ enum ReservedErrorObjectKey {
 enum ReservedErrorGroupKey {
 	event
 	status
-	tag
+	Tag
 	type
 }
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -998,7 +998,7 @@ enum ReservedErrorObjectKey {
 enum ReservedErrorGroupKey {
 	event
 	status
-	Tag
+	tag
 	type
 }
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6542,7 +6542,7 @@ func (r *queryResolver) ErrorFieldsClickhouse(ctx context.Context, projectID int
 	if err != nil {
 		return nil, nil
 	}
-	return r.ClickhouseClient.QueryErrorFieldValues(ctx, projectID, count, fieldType, fieldName, query, startDate, endDate)
+	return r.ClickhouseClient.QueryErrorFieldValues(ctx, projectID, count, fieldName, query, startDate, endDate)
 }
 
 // BillingDetailsForProject is the resolver for the billingDetailsForProject field.

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2923,9 +2923,9 @@ export type ReferrerTablePayload = {
 }
 
 export enum ReservedErrorGroupKey {
-	Tag = 'Tag',
 	Event = 'event',
 	Status = 'status',
+	Tag = 'tag',
 	Type = 'type',
 }
 

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2923,9 +2923,9 @@ export type ReferrerTablePayload = {
 }
 
 export enum ReservedErrorGroupKey {
+	Tag = 'Tag',
 	Event = 'event',
 	Status = 'status',
-	Tag = 'tag',
 	Type = 'type',
 }
 
@@ -3101,6 +3101,7 @@ export type SavedSegment = {
 }
 
 export enum SavedSegmentEntityType {
+	Error = 'Error',
 	Log = 'Log',
 	Trace = 'Trace',
 }


### PR DESCRIPTION
## Summary
Make some backend updates to support swapping out the error search query in https://github.com/highlight/highlight/pull/8179, while being backwards compatible.

Updates:
- Group error objects for histogram
- Correct some sql bugs for using an inner query
- Support Error saved segment types
- Look up table to query when fetching key values
- Support non-string key values 

## How did you test this change?
1. Ensure searching for errors works as anticipated

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
