### PR TITLE
use group by keys for count distinct

### DIFF
--- a/sdk/highlightinc-highlight-datasource/src/components/QueryEditor.tsx
+++ b/sdk/highlightinc-highlight-datasource/src/components/QueryEditor.tsx
@@ -90,14 +90,25 @@ export function QueryEditor({ query, onChange, datasource }: Props) {
             options={metricOptions.filter((o) => o.tables.includes(table ?? 'traces'))}
           />
         </InlineField>
-        {![undefined, 'Count', 'None'].includes(metric) && (
+        {![undefined, 'Count', 'None', 'CountDistinct'].includes(metric) && (
           <InlineField>
             <AsyncSelect
-              key={table}
+              key={`column-${table}`}
               defaultOptions
               value={{ name: column, label: column }}
               onChange={onColumnChange}
               loadOptions={(q) => loadColumnOptions(table, q)}
+            />
+          </InlineField>
+        )}
+        {metric === 'CountDistinct' && (
+          <InlineField>
+            <AsyncSelect
+              key={`group-${table}`}
+              defaultOptions
+              value={{ name: column, label: column }}
+              onChange={onColumnChange}
+              loadOptions={(q) => loadGroupByOptions(table, q)}
             />
           </InlineField>
         )}
@@ -107,7 +118,7 @@ export function QueryEditor({ query, onChange, datasource }: Props) {
           <InlineFieldRow>
             <InlineField label="Group by" labelWidth={10}>
               <AsyncMultiSelect
-                key={table}
+                key={`group-${table}`}
                 defaultOptions
                 value={groupBy?.map((g) => ({ name: g, label: g }))}
                 onChange={onGroupByChange}
@@ -125,7 +136,7 @@ export function QueryEditor({ query, onChange, datasource }: Props) {
                 {limitAggregator !== undefined && limitAggregator !== 'Count' && (
                   <InlineField>
                     <AsyncSelect
-                      key={table}
+                      key={`column-${table}`}
                       defaultOptions
                       value={{ name: limitColumn, label: limitColumn }}
                       onChange={onLimitColumnChange}


### PR DESCRIPTION
## Summary
- count distinct was only showing numeric values - should support categorical ones as well (e.g. count of unique identifiers)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested in local grafana instance
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will include this fix in grafana plugin release
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
