### PR TITLE
metrics tooltips

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7473,6 +7473,25 @@ body {
 .dg2vg67 {
   visibility: hidden;
 }
+.dg2vg68 {
+  background-color: white;
+  border: var(--_1pyqka9j) solid 1px;
+  border-radius: 6px;
+  min-width: 100px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+}
+.dg2vg69 {
+  line-height: 16px;
+}
+.dg2vg6a {
+  border-radius: 50%;
+  margin-right: 4px;
+  width: 8px;
+  height: 8px;
+}
 ._1a4jm560 {
   height: 40px;
 }

--- a/frontend/src/__generated/ve/pages/Graphing/components/Graph.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/components/Graph.css.js
@@ -7,6 +7,9 @@ var legendWrapper = "dg2vg62";
 var loadingOverlay = "dg2vg60";
 var loadingText = "dg2vg61";
 var titleText = "dg2vg66";
+var tooltipDot = "dg2vg6a";
+var tooltipText = "dg2vg69";
+var tooltipWrapper = "dg2vg68";
 export {
   hiddenMenu,
   legendDot,
@@ -15,5 +18,8 @@ export {
   legendWrapper,
   loadingOverlay,
   loadingText,
-  titleText
+  titleText,
+  tooltipDot,
+  tooltipText,
+  tooltipWrapper
 };

--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -3,6 +3,7 @@ import {
 	BarChart as RechartsBarChart,
 	CartesianGrid,
 	ResponsiveContainer,
+	Tooltip,
 	XAxis,
 	YAxis,
 } from 'recharts'
@@ -10,7 +11,8 @@ import {
 import {
 	CustomXAxisTick,
 	CustomYAxisTick,
-	getFormatter,
+	getCustomTooltip,
+	getTickFormatter,
 	GROUP_KEY,
 	InnerChartProps,
 	isActive,
@@ -52,8 +54,8 @@ export const BarChart = ({
 	spotlight,
 	viewConfig,
 }: InnerChartProps<BarChartConfig> & SeriesInfo) => {
-	const xAxisTickFormatter = getFormatter(xAxisMetric, data?.length)
-	const yAxisTickFormatter = getFormatter(yAxisMetric)
+	const xAxisTickFormatter = getTickFormatter(xAxisMetric, data?.length)
+	const yAxisTickFormatter = getTickFormatter(yAxisMetric)
 
 	return (
 		<ResponsiveContainer>
@@ -75,6 +77,11 @@ export const BarChart = ({
 					height={12}
 					type={xAxisMetric === GROUP_KEY ? 'category' : 'number'}
 					domain={['auto', 'auto']}
+				/>
+
+				<Tooltip
+					content={getCustomTooltip(xAxisMetric, yAxisMetric)}
+					cursor={{ fill: '#C8C7CB', fillOpacity: 0.5 }}
 				/>
 
 				<YAxis

--- a/frontend/src/pages/Graphing/components/Graph.css.ts
+++ b/frontend/src/pages/Graphing/components/Graph.css.ts
@@ -46,3 +46,25 @@ export const titleText = style({
 export const hiddenMenu = style({
 	visibility: 'hidden',
 })
+
+export const tooltipWrapper = style({
+	backgroundColor: 'white',
+	border: vars.border.divider,
+	borderRadius: '6px',
+	minWidth: '100px',
+	display: 'flex',
+	flexDirection: 'column',
+	gap: '6px',
+	padding: '8px',
+})
+
+export const tooltipText = style({
+	lineHeight: '16px',
+})
+
+export const tooltipDot = style({
+	borderRadius: '50%',
+	marginRight: '4px',
+	width: 8,
+	height: 8,
+})

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -128,7 +128,7 @@ const durationUnitMap: [number, string][] = [
 	[24, 'd'],
 ]
 
-export const getFormatter = (metric: string, bucketCount?: number) => {
+export const getTickFormatter = (metric: string, bucketCount?: number) => {
 	if (metric === 'Timestamp') {
 		return (value: any) => moment(value * 1000).format('HH:mm')
 	} else if (metric === 'duration') {
@@ -156,6 +156,51 @@ export const getFormatter = (metric: string, bucketCount?: number) => {
 		return (value: any) => formatNumber(value)
 	}
 }
+
+export const getCustomTooltip =
+	(xAxisMetric: any, yAxisMetric: any) =>
+	({ active, payload, label }: any) => {
+		if (active && payload && payload.length) {
+			return (
+				<Box cssClass={style.tooltipWrapper}>
+					<Text
+						size="xxSmall"
+						weight="medium"
+						color="default"
+						cssClass={style.tooltipText}
+					>
+						{getTickFormatter(xAxisMetric)(label)}
+					</Text>
+					{payload.map((p: any, idx: number) => (
+						<Box
+							display="flex"
+							flexDirection="row"
+							alignItems="center"
+							key={idx}
+						>
+							<Box
+								style={{
+									backgroundColor:
+										strokeColors[idx % strokeColors.length],
+								}}
+								cssClass={style.tooltipDot}
+							></Box>
+							<Text
+								size="xxSmall"
+								weight="medium"
+								color="default"
+								cssClass={style.tooltipText}
+							>
+								{getTickFormatter(yAxisMetric)(p.value)}
+							</Text>
+						</Box>
+					))}
+				</Box>
+			)
+		}
+
+		return null
+	}
 
 export const CustomYAxisTick = ({
 	y,

--- a/frontend/src/pages/Graphing/components/LineChart.tsx
+++ b/frontend/src/pages/Graphing/components/LineChart.tsx
@@ -4,6 +4,7 @@ import {
 	AreaChart,
 	CartesianGrid,
 	ResponsiveContainer,
+	Tooltip,
 	XAxis,
 	YAxis,
 } from 'recharts'
@@ -11,7 +12,8 @@ import {
 import {
 	CustomXAxisTick,
 	CustomYAxisTick,
-	getFormatter,
+	getCustomTooltip,
+	getTickFormatter,
 	InnerChartProps,
 	isActive,
 	SeriesInfo,
@@ -43,8 +45,8 @@ export const LineChart = ({
 	spotlight,
 	viewConfig,
 }: InnerChartProps<LineChartConfig> & SeriesInfo) => {
-	const xAxisTickFormatter = getFormatter(xAxisMetric, data?.length)
-	const yAxisTickFormatter = getFormatter(yAxisMetric)
+	const xAxisTickFormatter = getTickFormatter(xAxisMetric, data?.length)
+	const yAxisTickFormatter = getTickFormatter(yAxisMetric)
 
 	// Fill nulls
 	if (viewConfig.nullHandling === 'Zero' && data !== undefined) {
@@ -75,6 +77,12 @@ export const LineChart = ({
 					height={12}
 					type="number"
 					domain={['auto', 'auto']}
+				/>
+
+				<Tooltip
+					content={getCustomTooltip(xAxisMetric, yAxisMetric)}
+					cursor={{ stroke: '#C8C7CB', strokeDasharray: 4 }}
+					isAnimationActive={false}
 				/>
 
 				<YAxis

--- a/frontend/src/pages/Graphing/components/Table.tsx
+++ b/frontend/src/pages/Graphing/components/Table.tsx
@@ -1,7 +1,7 @@
 import { Box, Table, Text } from '@highlight-run/ui/components'
 
 import {
-	getFormatter,
+	getTickFormatter,
 	GROUP_KEY,
 	InnerChartProps,
 	SeriesInfo,
@@ -37,8 +37,8 @@ export const MetricTable = ({
 	series,
 	viewConfig,
 }: InnerChartProps<TableConfig> & SeriesInfo) => {
-	const xAxisTickFormatter = getFormatter(xAxisMetric)
-	const valueFormatter = getFormatter(yAxisMetric)
+	const xAxisTickFormatter = getTickFormatter(xAxisMetric)
+	const valueFormatter = getTickFormatter(yAxisMetric)
 
 	const showXAxisColumn =
 		xAxisMetric !== GROUP_KEY || (data && data?.length > 1)


### PR DESCRIPTION
## Summary
- adds a tooltip for line and bar charts matching figma design
![Screen Shot 2024-04-08 at 10 12 40 AM](https://github.com/highlight/highlight/assets/86132398/c717b8a1-c43b-4dca-9bd6-692914605d08)

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will merge in after `zane/dashboards` branch is merged
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- @julian-highlight to review after deployment
<!--
 Request review from julian-highlight / our design team 
-->
