### PR TITLE
Improve small span display on flame graph

### DIFF
--- a/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraphNode.tsx
@@ -82,7 +82,10 @@ export const TraceFlameGraphNode = memo<Props>(
 			setHoveredSpan,
 			setSelectedSpan,
 		} = useTrace()
-		const spanWidth = (span.duration / totalDuration) * width * zoom
+		const spanWidth = Math.max(
+			(span.duration / totalDuration) * width * zoom,
+			3,
+		)
 		const offsetX =
 			(span.startTime / totalDuration) * width * zoom + outsidePadding
 		const offsetY = span.depth

--- a/frontend/src/pages/Traces/utils.ts
+++ b/frontend/src/pages/Traces/utils.ts
@@ -58,8 +58,10 @@ export const getTraceDurationString = (duration: number) => {
 		return `${secondString} ${millisecondString}`
 	} else if (millisecondString) {
 		return millisecondString
-	} else {
+	} else if (microsecondString) {
 		return microsecondString
+	} else {
+		return `${nanoseconds}ns`
 	}
 }
 


### PR DESCRIPTION
## Summary

Tweaks the display of really small spans on the trace flame graph.

* Sets a minimum width for a span on the flame graph to make it easier to see and interact with spans that have a very short duration.
* Fixes the duration display for spans that report a `0` duration.

The previews below are looking at [this trace](https://app.highlight.io/1/traces/UGNvAHtaX3/ae30c0e32967e662) for reference.

**Before**
![2024-04-08 16 09 57](https://github.com/highlight/highlight/assets/308182/caf116fd-7939-4b8e-a782-171d4b4b081e)

**After**
![2024-04-08 16 07 58](https://github.com/highlight/highlight/assets/308182/8b4234a4-d03e-453b-b1d3-885202342819)

## How did you test this change?

Click tested some traces in prod and contrasted them with the PR preview for the same trace (see before and after above).

## Are there any deployment considerations?

N/A - client-side change only.

## Does this work require review from our design team?

Will review the changes w/ Julian before merging.
