### PR TITLE
correctly report logs and traces overages

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,6 +1,6 @@
 # options for analysis running
 run:
-    timeout: 2m
+    timeout: 5m
     skip-dirs:
         - private-graph/graph/generated
         - public-graph/graph/generated

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -6606,7 +6606,7 @@ func (r *queryResolver) BillingDetails(ctx context.Context, workspaceID int) (*m
 	})
 
 	g.Go(func() error {
-		membersMeter = pricing.GetWorkspaceMembersMeter(r.DB, workspaceID)
+		membersMeter, err = r.Store.GetWorkspaceAdminCount(ctx, workspaceID)
 		if err != nil {
 			return e.Wrap(err, "error querying members meter")
 		}

--- a/backend/store/workspaces.go
+++ b/backend/store/workspaces.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/redis"
+	"github.com/openlyinc/pointy"
 )
 
 func (store *Store) GetWorkspace(ctx context.Context, id int) (*model.Workspace, error) {
 	return redis.CachedEval(ctx, store.redis, fmt.Sprintf("workspace-id-%d", id), 150*time.Millisecond, time.Minute, func() (*model.Workspace, error) {
 		var workspace model.Workspace
 
-		err := store.db.WithContext(ctx).Where(&model.Workspace{
+		err := store.db.WithContext(ctx).Preload("Projects").Where(&model.Workspace{
 			Model: model.Model{
 				ID: id,
 			},
@@ -21,4 +22,12 @@ func (store *Store) GetWorkspace(ctx context.Context, id int) (*model.Workspace,
 
 		return &workspace, err
 	})
+}
+
+func (store *Store) GetWorkspaceAdminCount(ctx context.Context, id int) (int64, error) {
+	value, err := redis.CachedEval(ctx, store.redis, fmt.Sprintf("workspace-id-%d", id), 150*time.Millisecond, time.Minute, func() (*int64, error) {
+		tx := store.db.WithContext(ctx).Model(&model.Workspace{Model: model.Model{ID: id}}).Association("Admins")
+		return pointy.Int64(tx.Count()), tx.Error
+	})
+	return pointy.Int64Value(value, 0), err
 }

--- a/backend/worker/worker_test.go
+++ b/backend/worker/worker_test.go
@@ -29,7 +29,7 @@ var chClient *clickhouse.Client
 
 // Gets run once; M.run() calls the tests in this file.
 func TestMain(m *testing.M) {
-	DB, _ = util.CreateAndMigrateTestDB("highlight_testing_db")
+	DB, _ = util.CreateAndMigrateTestDB("highlight_testing_db_worker")
 	redisClient = redis.NewClient()
 	chClient, _ = clickhouse.NewClient(clickhouse.TestDatabase)
 	clickhouse.RunMigrations(context.TODO(), clickhouse.TestDatabase)

--- a/backend/worker/worker_test.go
+++ b/backend/worker/worker_test.go
@@ -2,16 +2,40 @@ package worker
 
 import (
 	"context"
-	"io"
-	"testing"
-	"time"
-
-	log "github.com/sirupsen/logrus"
-
 	"github.com/go-test/deep"
+	"github.com/highlight-run/highlight/backend/clickhouse"
 	parse "github.com/highlight-run/highlight/backend/event-parse"
 	"github.com/highlight-run/highlight/backend/model"
+	"github.com/highlight-run/highlight/backend/pricing"
+	"github.com/highlight-run/highlight/backend/private-graph/graph"
+	model2 "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/highlight-run/highlight/backend/redis"
+	"github.com/highlight-run/highlight/backend/store"
+	"github.com/highlight-run/highlight/backend/util"
+	"github.com/openlyinc/pointy"
+	e "github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+	"io"
+	"os"
+	"testing"
+	"time"
 )
+
+var DB *gorm.DB
+var redisClient *redis.Client
+var chClient *clickhouse.Client
+
+// Gets run once; M.run() calls the tests in this file.
+func TestMain(m *testing.M) {
+	DB, _ = util.CreateAndMigrateTestDB("highlight_testing_db")
+	redisClient = redis.NewClient()
+	chClient, _ = clickhouse.NewClient(clickhouse.TestDatabase)
+	clickhouse.RunMigrations(context.TODO(), clickhouse.TestDatabase)
+	code := m.Run()
+	os.Exit(code)
+}
 
 func TestCalculateSessionLength(t *testing.T) {
 	tables := map[string]struct {
@@ -812,5 +836,154 @@ func TestFullSnapshotProcessed(t *testing.T) {
 				t.Errorf("expected success, actual error: %v", a.Error)
 			}
 		})
+	}
+}
+
+func TestCalculateOverages(t *testing.T) {
+	defer func(inclSessions, inclErrors, inclLogs, inclTraces int64) {
+		pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeSessions] = pricing.ProductPricing{
+			Included: inclSessions,
+			Items:    pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeSessions].Items,
+		}
+		pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeErrors] = pricing.ProductPricing{
+			Included: inclErrors,
+			Items:    pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeErrors].Items,
+		}
+		pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeLogs] = pricing.ProductPricing{
+			Included: inclLogs,
+			Items:    pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeLogs].Items,
+		}
+		pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeTraces] = pricing.ProductPricing{
+			Included: inclTraces,
+			Items:    pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeTraces].Items,
+		}
+	}(
+		pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeSessions].Included,
+		pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeErrors].Included,
+		pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeLogs].Included,
+		pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeTraces].Included,
+	)
+
+	pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeSessions] = pricing.ProductPricing{
+		Included: 2,
+		Items:    pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeSessions].Items,
+	}
+	pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeErrors] = pricing.ProductPricing{
+		Included: 3,
+		Items:    pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeErrors].Items,
+	}
+	pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeLogs] = pricing.ProductPricing{
+		Included: 4,
+		Items:    pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeLogs].Items,
+	}
+	pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeTraces] = pricing.ProductPricing{
+		Included: 5,
+		Items:    pricing.ProductPrices[model2.PlanTypeGraduated][model.PricingProductTypeTraces].Items,
+	}
+
+	ctx := context.TODO()
+	s := store.NewStore(DB, redisClient, nil, nil, nil, chClient)
+	pWorker := pricing.NewWorker(DB, redisClient, s, chClient, nil, nil, nil)
+	worker := Worker{
+		Resolver: &graph.Resolver{
+			DB:               DB,
+			ClickhouseClient: chClient,
+		},
+	}
+
+	now := time.Now().AddDate(0, 0, -14)
+	end := now.AddDate(0, 1, 0)
+
+	w := model.Workspace{
+		BillingPeriodStart: &now,
+		BillingPeriodEnd:   &end,
+		PlanTier:           string(model2.PlanTypeGraduated),
+	}
+	if err := DB.Create(&w).Error; err != nil {
+		t.Fatal(e.Wrap(err, "error inserting workspace"))
+	}
+	wMP := model.Workspace{
+		BillingPeriodStart: &now,
+		BillingPeriodEnd:   &end,
+		PlanTier:           string(model2.PlanTypeGraduated),
+		AWSMarketplaceCustomer: &model.AWSMarketplaceCustomer{
+			CustomerIdentifier:   pointy.String("customer"),
+			CustomerAWSAccountID: pointy.String("aws-account"),
+			ProductCode:          pointy.String("product"),
+		},
+	}
+	if err := DB.Create(&wMP).Error; err != nil {
+		t.Fatal(e.Wrap(err, "error inserting workspace"))
+	}
+
+	for _, w := range []model.Workspace{w, wMP} {
+		for i := 0; i < 5; i++ {
+			p := model.Project{
+				Name:        pointy.String("normal-workspace"),
+				WorkspaceID: w.ID,
+			}
+			if err := DB.Create(&p).Error; err != nil {
+				t.Fatal(e.Wrap(err, "error inserting project"))
+			}
+			a := model.Admin{
+				Name:       pointy.String("bob-normal"),
+				Workspaces: []model.Workspace{w},
+			}
+			if err := DB.Create(&a).Error; err != nil {
+				t.Fatal(e.Wrap(err, "error inserting project"))
+			}
+
+			var sessions []*model.Session
+			for idx := 0; idx < 10; idx++ {
+				sessions = append(sessions, &model.Session{
+					ProjectID:    p.ID,
+					Excluded:     false,
+					Processed:    pointy.Bool(true),
+					ActiveLength: int64(1000 * idx),
+				})
+			}
+			if err := DB.Model(&model.Session{}).CreateInBatches(&sessions, 1000).Error; err != nil {
+				t.Fatal(e.Wrap(err, "error inserting sessions"))
+			}
+
+			var errors []*model.ErrorObject
+			for idx := 0; idx < 11; idx++ {
+				errors = append(errors, &model.ErrorObject{
+					ProjectID: p.ID,
+				})
+			}
+			if err := DB.Model(&model.ErrorObject{}).CreateInBatches(&errors, 1000).Error; err != nil {
+				t.Fatal(e.Wrap(err, "error inserting errors"))
+			}
+
+			var logs []*clickhouse.LogRow
+			for idx := 0; idx < 12; idx++ {
+				logs = append(logs, clickhouse.NewLogRow(time.Now(), uint32(p.ID)))
+			}
+			if err := chClient.BatchWriteLogRows(ctx, logs); err != nil {
+				t.Error(e.Wrap(err, "error inserting logs"))
+				return
+			}
+
+			for idx := 0; idx < 13; idx++ {
+				var traces []*clickhouse.TraceRow
+				traces = append(traces, clickhouse.NewTraceRow(time.Now(), p.ID))
+				if err := chClient.BatchWriteTraceRows(ctx, traces); err != nil {
+					t.Error(e.Wrap(err, "error inserting traces"))
+					return
+				}
+			}
+		}
+	}
+
+	worker.RefreshMaterializedViews(ctx)
+
+	for _, w := range []*model.Workspace{&w, &wMP} {
+		overages, err := pWorker.CalculateOverages(ctx, w.ID)
+		assert.NoError(t, err)
+		assert.Len(t, overages, 5)
+		for product, overage := range overages {
+			assert.Greaterf(t, overage, int64(1), "expected an overage for %d %s", w.ID, product)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

https://github.com/highlight/highlight/pull/7638 introduced a bug with reporting logic that 
resulted us in under-reporting logs and traces overages for billing. This was caused
by a consolidation of shared [code](https://github.com/highlight/highlight/blob/8cb08386685dfeb287bbe1793228638279cd90a5/backend/pricing/pricing.go#L843-L846) used for overage calculation to a new function. We had previously queried workspaces
while [fetching their associated projects manually](https://github.com/highlight/highlight/blob/8cb08386685dfeb287bbe1793228638279cd90a5/backend/pricing/pricing.go#L909-L913), 
but the refactor failed to include the secondary loading.

This PR refactores the querying to use the `Store` object with a `Preload` statement to efficiently query projects.

## How did you test this change?

after
![Screenshot from 2024-04-08 17-19-12](https://github.com/highlight/highlight/assets/1351531/b78e02d0-c2e8-46f3-83e4-ef82d7ae3681)
before
![Screenshot from 2024-04-08 17-19-30](https://github.com/highlight/highlight/assets/1351531/d99f762b-c09c-40f6-bb2f-b94980c40244)


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
