### PR TITLE
dashboard overview page

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1455,9 +1455,14 @@ type Graph struct {
 
 type Visualization struct {
 	Model
-	ProjectID int    `gorm:"uniqueIndex:visualization_project_id_name_idx"`
-	Name      string `gorm:"uniqueIndex:visualization_project_id_name_idx"`
+	ProjectID int `gorm:"index"`
+	Name      string
 	Graphs    []Graph
+}
+
+type VisualizationsResponse struct {
+	Count   int
+	Results []Visualization
 }
 
 func SetupDB(ctx context.Context, dbName string) (*gorm.DB, error) {

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1455,9 +1455,11 @@ type Graph struct {
 
 type Visualization struct {
 	Model
-	ProjectID int `gorm:"index"`
-	Name      string
-	Graphs    []Graph
+	ProjectID        int `gorm:"index"`
+	Name             string
+	UpdatedByAdminId *int
+	UpdatedByAdmin   *Admin `gorm:"foreignKey:UpdatedByAdminId"`
+	Graphs           []Graph
 }
 
 type VisualizationsResponse struct {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1108,6 +1108,7 @@ type ComplexityRoot struct {
 		VercelProjectMappings            func(childComplexity int, projectID int) int
 		VercelProjects                   func(childComplexity int, projectID int) int
 		Visualization                    func(childComplexity int, id int) int
+		Visualizations                   func(childComplexity int, projectID int, input string, count int, offset int) int
 		WebVitals                        func(childComplexity int, sessionSecureID string) int
 		WebsocketEvents                  func(childComplexity int, sessionSecureID string) int
 		Workspace                        func(childComplexity int, id int) int
@@ -1570,6 +1571,11 @@ type ComplexityRoot struct {
 		ProjectID func(childComplexity int) int
 	}
 
+	VisualizationsResponse struct {
+		Count   func(childComplexity int) int
+		Results func(childComplexity int) int
+	}
+
 	WebSocketEvent struct {
 		Message   func(childComplexity int) int
 		Name      func(childComplexity int) int
@@ -1952,6 +1958,7 @@ type QueryResolver interface {
 	Keys(ctx context.Context, productType model.ProductType, projectID int, dateRange model.DateRangeRequiredInput, query *string, typeArg *model.KeyType) ([]*model.QueryKey, error)
 	KeyValues(ctx context.Context, productType model.ProductType, projectID int, keyName string, dateRange model.DateRangeRequiredInput) ([]string, error)
 	Visualization(ctx context.Context, id int) (*model1.Visualization, error)
+	Visualizations(ctx context.Context, projectID int, input string, count int, offset int) (*model1.VisualizationsResponse, error)
 	Graph(ctx context.Context, id int) (*model1.Graph, error)
 	LogLines(ctx context.Context, productType model.ProductType, projectID int, params model.QueryInput) ([]*model.LogLine, error)
 }
@@ -8575,6 +8582,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Visualization(childComplexity, args["id"].(int)), true
 
+	case "Query.visualizations":
+		if e.complexity.Query.Visualizations == nil {
+			break
+		}
+
+		args, err := ec.field_Query_visualizations_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Visualizations(childComplexity, args["project_id"].(int), args["input"].(string), args["count"].(int), args["offset"].(int)), true
+
 	case "Query.web_vitals":
 		if e.complexity.Query.WebVitals == nil {
 			break
@@ -10778,6 +10797,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Visualization.ProjectID(childComplexity), true
+
+	case "VisualizationsResponse.count":
+		if e.complexity.VisualizationsResponse.Count == nil {
+			break
+		}
+
+		return e.complexity.VisualizationsResponse.Count(childComplexity), true
+
+	case "VisualizationsResponse.results":
+		if e.complexity.VisualizationsResponse.Results == nil {
+			break
+		}
+
+		return e.complexity.VisualizationsResponse.Results(childComplexity), true
 
 	case "WebSocketEvent.message":
 		if e.complexity.WebSocketEvent.Message == nil {
@@ -13129,6 +13162,11 @@ type Visualization {
 	graphs: [Graph!]!
 }
 
+type VisualizationsResponse {
+	count: Int!
+	results: [Visualization!]!
+}
+
 input GraphInput {
 	id: ID
 	visualizationId: ID!
@@ -13605,6 +13643,12 @@ type Query {
 		date_range: DateRangeRequiredInput!
 	): [String!]!
 	visualization(id: ID!): Visualization!
+	visualizations(
+		project_id: ID!
+		input: String!
+		count: Int!
+		offset: Int!
+	): VisualizationsResponse!
 	graph(id: ID!): Graph!
 	log_lines(
 		product_type: ProductType!
@@ -21881,6 +21925,48 @@ func (ec *executionContext) field_Query_visualization_args(ctx context.Context, 
 		}
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_visualizations_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int
+	if tmp, ok := rawArgs["project_id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("project_id"))
+		arg0, err = ec.unmarshalNID2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["project_id"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg1
+	var arg2 int
+	if tmp, ok := rawArgs["count"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("count"))
+		arg2, err = ec.unmarshalNInt2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["count"] = arg2
+	var arg3 int
+	if tmp, ok := rawArgs["offset"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("offset"))
+		arg3, err = ec.unmarshalNInt2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["offset"] = arg3
 	return args, nil
 }
 
@@ -62726,6 +62812,67 @@ func (ec *executionContext) fieldContext_Query_visualization(ctx context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_visualizations(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_visualizations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Visualizations(rctx, fc.Args["project_id"].(int), fc.Args["input"].(string), fc.Args["count"].(int), fc.Args["offset"].(int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model1.VisualizationsResponse)
+	fc.Result = res
+	return ec.marshalNVisualizationsResponse2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐVisualizationsResponse(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_visualizations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "count":
+				return ec.fieldContext_VisualizationsResponse_count(ctx, field)
+			case "results":
+				return ec.fieldContext_VisualizationsResponse_results(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type VisualizationsResponse", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_visualizations_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_graph(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_graph(ctx, field)
 	if err != nil {
@@ -76325,6 +76472,104 @@ func (ec *executionContext) fieldContext_Visualization_graphs(ctx context.Contex
 				return ec.fieldContext_Graph_nullHandling(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Graph", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _VisualizationsResponse_count(ctx context.Context, field graphql.CollectedField, obj *model1.VisualizationsResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_VisualizationsResponse_count(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Count, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_VisualizationsResponse_count(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "VisualizationsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _VisualizationsResponse_results(ctx context.Context, field graphql.CollectedField, obj *model1.VisualizationsResponse) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_VisualizationsResponse_results(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Results, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]model1.Visualization)
+	fc.Result = res
+	return ec.marshalNVisualization2ᚕgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐVisualizationᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_VisualizationsResponse_results(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "VisualizationsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Visualization_id(ctx, field)
+			case "projectId":
+				return ec.fieldContext_Visualization_projectId(ctx, field)
+			case "name":
+				return ec.fieldContext_Visualization_name(ctx, field)
+			case "graphs":
+				return ec.fieldContext_Visualization_graphs(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Visualization", field.Name)
 		},
 	}
 	return fc, nil
@@ -91953,6 +92198,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "visualizations":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_visualizations(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "graph":
 			field := field
 
@@ -95700,6 +95967,50 @@ func (ec *executionContext) _Visualization(ctx context.Context, sel ast.Selectio
 			}
 		case "graphs":
 			out.Values[i] = ec._Visualization_graphs(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var visualizationsResponseImplementors = []string{"VisualizationsResponse"}
+
+func (ec *executionContext) _VisualizationsResponse(ctx context.Context, sel ast.SelectionSet, obj *model1.VisualizationsResponse) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, visualizationsResponseImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("VisualizationsResponse")
+		case "count":
+			out.Values[i] = ec._VisualizationsResponse_count(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "results":
+			out.Values[i] = ec._VisualizationsResponse_results(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -101473,6 +101784,50 @@ func (ec *executionContext) marshalNVisualization2githubᚗcomᚋhighlightᚑrun
 	return ec._Visualization(ctx, sel, &v)
 }
 
+func (ec *executionContext) marshalNVisualization2ᚕgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐVisualizationᚄ(ctx context.Context, sel ast.SelectionSet, v []model1.Visualization) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNVisualization2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐVisualization(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNVisualization2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐVisualization(ctx context.Context, sel ast.SelectionSet, v *model1.Visualization) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -101486,6 +101841,20 @@ func (ec *executionContext) marshalNVisualization2ᚖgithubᚗcomᚋhighlightᚑ
 func (ec *executionContext) unmarshalNVisualizationInput2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐVisualizationInput(ctx context.Context, v interface{}) (model.VisualizationInput, error) {
 	res, err := ec.unmarshalInputVisualizationInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNVisualizationsResponse2githubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐVisualizationsResponse(ctx context.Context, sel ast.SelectionSet, v model1.VisualizationsResponse) graphql.Marshaler {
+	return ec._VisualizationsResponse(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNVisualizationsResponse2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐVisualizationsResponse(ctx context.Context, sel ast.SelectionSet, v *model1.VisualizationsResponse) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._VisualizationsResponse(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNWebhookDestination2ᚕᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐWebhookDestinationᚄ(ctx context.Context, sel ast.SelectionSet, v []*model1.WebhookDestination) graphql.Marshaler {

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -61,6 +61,7 @@ type ResolverRoot interface {
 	SessionComment() SessionCommentResolver
 	Subscription() SubscriptionResolver
 	TimelineIndicatorEvent() TimelineIndicatorEventResolver
+	Visualization() VisualizationResolver
 }
 
 type DirectiveRoot struct {
@@ -1565,10 +1566,12 @@ type ComplexityRoot struct {
 	}
 
 	Visualization struct {
-		Graphs    func(childComplexity int) int
-		ID        func(childComplexity int) int
-		Name      func(childComplexity int) int
-		ProjectID func(childComplexity int) int
+		Graphs         func(childComplexity int) int
+		ID             func(childComplexity int) int
+		Name           func(childComplexity int) int
+		ProjectID      func(childComplexity int) int
+		UpdatedAt      func(childComplexity int) int
+		UpdatedByAdmin func(childComplexity int) int
 	}
 
 	VisualizationsResponse struct {
@@ -2008,6 +2011,9 @@ type SubscriptionResolver interface {
 }
 type TimelineIndicatorEventResolver interface {
 	Data(ctx context.Context, obj *model1.TimelineIndicatorEvent) (interface{}, error)
+}
+type VisualizationResolver interface {
+	UpdatedByAdmin(ctx context.Context, obj *model1.Visualization) (*model.SanitizedAdmin, error)
 }
 
 type executableSchema struct {
@@ -10798,6 +10804,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Visualization.ProjectID(childComplexity), true
 
+	case "Visualization.updatedAt":
+		if e.complexity.Visualization.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.Visualization.UpdatedAt(childComplexity), true
+
+	case "Visualization.updatedByAdmin":
+		if e.complexity.Visualization.UpdatedByAdmin == nil {
+			break
+		}
+
+		return e.complexity.Visualization.UpdatedByAdmin(childComplexity), true
+
 	case "VisualizationsResponse.count":
 		if e.complexity.VisualizationsResponse.Count == nil {
 			break
@@ -13157,8 +13177,10 @@ type Graph {
 
 type Visualization {
 	id: ID!
+	updatedAt: Timestamp!
 	projectId: ID!
 	name: String!
+	updatedByAdmin: SanitizedAdmin
 	graphs: [Graph!]!
 }
 
@@ -62788,10 +62810,14 @@ func (ec *executionContext) fieldContext_Query_visualization(ctx context.Context
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Visualization_id(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Visualization_updatedAt(ctx, field)
 			case "projectId":
 				return ec.fieldContext_Visualization_projectId(ctx, field)
 			case "name":
 				return ec.fieldContext_Visualization_name(ctx, field)
+			case "updatedByAdmin":
+				return ec.fieldContext_Visualization_updatedByAdmin(ctx, field)
 			case "graphs":
 				return ec.fieldContext_Visualization_graphs(ctx, field)
 			}
@@ -76313,6 +76339,50 @@ func (ec *executionContext) fieldContext_Visualization_id(ctx context.Context, f
 	return fc, nil
 }
 
+func (ec *executionContext) _Visualization_updatedAt(ctx context.Context, field graphql.CollectedField, obj *model1.Visualization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Visualization_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTimestamp2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Visualization_updatedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Visualization",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Timestamp does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Visualization_projectId(ctx context.Context, field graphql.CollectedField, obj *model1.Visualization) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Visualization_projectId(ctx, field)
 	if err != nil {
@@ -76396,6 +76466,57 @@ func (ec *executionContext) fieldContext_Visualization_name(ctx context.Context,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Visualization_updatedByAdmin(ctx context.Context, field graphql.CollectedField, obj *model1.Visualization) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Visualization_updatedByAdmin(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Visualization().UpdatedByAdmin(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.SanitizedAdmin)
+	fc.Result = res
+	return ec.marshalOSanitizedAdmin2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋprivateᚑgraphᚋgraphᚋmodelᚐSanitizedAdmin(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Visualization_updatedByAdmin(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Visualization",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_SanitizedAdmin_id(ctx, field)
+			case "name":
+				return ec.fieldContext_SanitizedAdmin_name(ctx, field)
+			case "email":
+				return ec.fieldContext_SanitizedAdmin_email(ctx, field)
+			case "photo_url":
+				return ec.fieldContext_SanitizedAdmin_photo_url(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SanitizedAdmin", field.Name)
 		},
 	}
 	return fc, nil
@@ -76562,10 +76683,14 @@ func (ec *executionContext) fieldContext_VisualizationsResponse_results(ctx cont
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Visualization_id(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Visualization_updatedAt(ctx, field)
 			case "projectId":
 				return ec.fieldContext_Visualization_projectId(ctx, field)
 			case "name":
 				return ec.fieldContext_Visualization_name(ctx, field)
+			case "updatedByAdmin":
+				return ec.fieldContext_Visualization_updatedByAdmin(ctx, field)
 			case "graphs":
 				return ec.fieldContext_Visualization_graphs(ctx, field)
 			}
@@ -95953,22 +96078,60 @@ func (ec *executionContext) _Visualization(ctx context.Context, sel ast.Selectio
 		case "id":
 			out.Values[i] = ec._Visualization_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "updatedAt":
+			out.Values[i] = ec._Visualization_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "projectId":
 			out.Values[i] = ec._Visualization_projectId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "name":
 			out.Values[i] = ec._Visualization_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "updatedByAdmin":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Visualization_updatedByAdmin(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "graphs":
 			out.Values[i] = ec._Visualization_graphs(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1876,8 +1876,10 @@ type Graph {
 
 type Visualization {
 	id: ID!
+	updatedAt: Timestamp!
 	projectId: ID!
 	name: String!
+	updatedByAdmin: SanitizedAdmin
 	graphs: [Graph!]!
 }
 

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1881,6 +1881,11 @@ type Visualization {
 	graphs: [Graph!]!
 }
 
+type VisualizationsResponse {
+	count: Int!
+	results: [Visualization!]!
+}
+
 input GraphInput {
 	id: ID
 	visualizationId: ID!
@@ -2357,6 +2362,12 @@ type Query {
 		date_range: DateRangeRequiredInput!
 	): [String!]!
 	visualization(id: ID!): Visualization!
+	visualizations(
+		project_id: ID!
+		input: String!
+		count: Int!
+		offset: Int!
+	): VisualizationsResponse!
 	graph(id: ID!): Graph!
 	log_lines(
 		product_type: ProductType!

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4723,10 +4723,16 @@ func (r *mutationResolver) UpsertVisualization(ctx context.Context, visualizatio
 		return 0, err
 	}
 
+	admin, err := r.getCurrentAdmin(ctx)
+	if err != nil {
+		return 0, err
+	}
+
 	toSave := model.Visualization{
-		Model:     model.Model{ID: id},
-		ProjectID: visualization.ProjectID,
-		Name:      visualization.Name,
+		Model:            model.Model{ID: id},
+		ProjectID:        visualization.ProjectID,
+		Name:             visualization.Name,
+		UpdatedByAdminId: &admin.ID,
 	}
 	if err := r.DB.WithContext(ctx).Save(&toSave).Error; err != nil {
 		return 0, err
@@ -4756,11 +4762,16 @@ func (r *mutationResolver) DeleteVisualization(ctx context.Context, id int) (boo
 // UpsertGraph is the resolver for the upsertGraph field.
 func (r *mutationResolver) UpsertGraph(ctx context.Context, graph modelInputs.GraphInput) (int, error) {
 	var viz model.Visualization
-	if err := r.DB.WithContext(ctx).Model(&viz).Where("id = ?", graph.VisualizationID).Find(&viz).Error; err != nil {
+	if err := r.DB.WithContext(ctx).Model(&viz).Where("id = ?", graph.VisualizationID).Take(&viz).Error; err != nil {
 		return 0, err
 	}
 
 	_, err := r.isAdminInProject(ctx, viz.ProjectID)
+	if err != nil {
+		return 0, err
+	}
+
+	admin, err := r.getCurrentAdmin(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -4791,14 +4802,23 @@ func (r *mutationResolver) UpsertGraph(ctx context.Context, graph modelInputs.Gr
 		NullHandling:      graph.NullHandling,
 	}
 
-	if id == 0 {
-		if err := r.DB.WithContext(ctx).Create(&toSave).Error; err != nil {
-			return 0, err
+	if err := r.DB.Transaction(func(tx *gorm.DB) error {
+		if id == 0 {
+			if err := tx.WithContext(ctx).Create(&toSave).Error; err != nil {
+				return err
+			}
+		} else {
+			if err := tx.WithContext(ctx).Select("*").Updates(&toSave).Error; err != nil {
+				return err
+			}
 		}
-	} else {
-		if err := r.DB.WithContext(ctx).Select("*").Updates(&toSave).Error; err != nil {
-			return 0, err
+		if err := tx.WithContext(ctx).Model(&model.Visualization{}).Where("id = ?", graph.VisualizationID).
+			Update("UpdatedByAdminId", admin.ID).Error; err != nil {
+			return err
 		}
+		return nil
+	}); err != nil {
+		return 0, nil
 	}
 
 	return toSave.ID, nil
@@ -9081,7 +9101,7 @@ func (r *queryResolver) KeyValues(ctx context.Context, productType modelInputs.P
 // Visualization is the resolver for the visualization field.
 func (r *queryResolver) Visualization(ctx context.Context, id int) (*model.Visualization, error) {
 	var viz model.Visualization
-	if err := r.DB.WithContext(ctx).Model(&viz).Where("id = ?", id).Find(&viz).Error; err != nil {
+	if err := r.DB.WithContext(ctx).Model(&viz).Where("id = ?", id).Preload("Graphs").Preload("UpdatedByAdmin").Find(&viz).Error; err != nil {
 		return nil, err
 	}
 
@@ -9089,12 +9109,6 @@ func (r *queryResolver) Visualization(ctx context.Context, id int) (*model.Visua
 	if err != nil {
 		return nil, err
 	}
-
-	graphs := []model.Graph{}
-	if err := r.DB.WithContext(ctx).Order("id ASC").Model(&viz).Association("Graphs").Find(&graphs); err != nil {
-		return nil, err
-	}
-	viz.Graphs = graphs
 
 	return &viz, nil
 }
@@ -9109,15 +9123,31 @@ func (r *queryResolver) Visualizations(ctx context.Context, projectID int, input
 	// Escape any % or _, surround the input with %
 	searchStr := fmt.Sprintf("%%%s%%", strings.ReplaceAll(strings.ReplaceAll(input, "%", "\\%"), "_", "\\_"))
 
-	var viz []model.Visualization
-	if err := r.DB.WithContext(ctx).Model(&model.Visualization{}).Where("project_id = ?", projectID).Where("name ILIKE ?", searchStr).
-		Order("updated_at").Select("*, COUNT(*) OVER ()").Limit(count).Offset(offset).Find(&viz).Error; err != nil {
+	type vizWithCount struct {
+		model.Visualization
+		Count int
+	}
+
+	var viz []vizWithCount
+	if err := r.DB.WithContext(ctx).Model(&model.Visualization{}).Debug().Preload("UpdatedByAdmin").
+		Where("project_id = ?", projectID).Where("name ILIKE ?", searchStr).
+		Order("updated_at DESC").Select("*, COUNT(*) OVER () as count").Limit(count).Offset(offset).Find(&viz).Error; err != nil {
 		return nil, err
 	}
 
+	results := []model.Visualization{}
+	for _, v := range viz {
+		results = append(results, v.Visualization)
+	}
+
+	totalCount := 0
+	if len(viz) > 0 {
+		totalCount = viz[0].Count
+	}
+
 	return &model.VisualizationsResponse{
-		Count:   count,
-		Results: []model.Visualization{},
+		Count:   totalCount,
+		Results: results,
 	}, nil
 }
 
@@ -9485,6 +9515,25 @@ func (r *timelineIndicatorEventResolver) Data(ctx context.Context, obj *model.Ti
 	return obj.Data, nil
 }
 
+// UpdatedByAdmin is the resolver for the updatedByAdmin field.
+func (r *visualizationResolver) UpdatedByAdmin(ctx context.Context, obj *model.Visualization) (*modelInputs.SanitizedAdmin, error) {
+	if obj.UpdatedByAdmin == nil {
+		return nil, nil
+	}
+
+	email := ""
+	if obj.UpdatedByAdmin.Email != nil {
+		email = *obj.UpdatedByAdmin.Email
+	}
+
+	return &modelInputs.SanitizedAdmin{
+		ID:       obj.UpdatedByAdmin.ID,
+		Name:     obj.UpdatedByAdmin.Name,
+		Email:    email,
+		PhotoURL: obj.UpdatedByAdmin.PhotoURL,
+	}, nil
+}
+
 // CommentReply returns generated.CommentReplyResolver implementation.
 func (r *Resolver) CommentReply() generated.CommentReplyResolver { return &commentReplyResolver{r} }
 
@@ -9548,6 +9597,9 @@ func (r *Resolver) TimelineIndicatorEvent() generated.TimelineIndicatorEventReso
 	return &timelineIndicatorEventResolver{r}
 }
 
+// Visualization returns generated.VisualizationResolver implementation.
+func (r *Resolver) Visualization() generated.VisualizationResolver { return &visualizationResolver{r} }
+
 type commentReplyResolver struct{ *Resolver }
 type errorAlertResolver struct{ *Resolver }
 type errorCommentResolver struct{ *Resolver }
@@ -9567,3 +9619,4 @@ type sessionAlertResolver struct{ *Resolver }
 type sessionCommentResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }
 type timelineIndicatorEventResolver struct{ *Resolver }
+type visualizationResolver struct{ *Resolver }

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7558,6 +7558,25 @@ body {
     border-bottom: none;
   }
 }
+._1y9te7a0 {
+  cursor: auto;
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  max-width: 400px;
+  padding-bottom: 32px;
+  padding-top: 32px;
+}
+._1y9te7a1 {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+._1y9te7a2 {
+  border: none;
+}
+._1y9te7a2:hover {
+  border: none;
+}
 .gw96js0 {
   height: 40px;
 }

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7567,16 +7567,6 @@ body {
   padding-bottom: 32px;
   padding-top: 32px;
 }
-._1y9te7a1 {
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-}
-._1y9te7a2 {
-  border: none;
-}
-._1y9te7a2:hover {
-  border: none;
-}
 .gw96js0 {
   height: 40px;
 }

--- a/frontend/src/__generated/ve/pages/Graphing/DashboardOverview.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/DashboardOverview.css.js
@@ -1,9 +1,7 @@
 // src/pages/Graphing/DashboardOverview.css.ts
 var emptyContainer = "_1y9te7a0";
-var searchInput = "_1y9te7a2";
 var searchInputWrapper = "_1y9te7a1";
 export {
   emptyContainer,
-  searchInput,
   searchInputWrapper
 };

--- a/frontend/src/__generated/ve/pages/Graphing/DashboardOverview.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/DashboardOverview.css.js
@@ -1,0 +1,9 @@
+// src/pages/Graphing/DashboardOverview.css.ts
+var emptyContainer = "_1y9te7a0";
+var searchInput = "_1y9te7a2";
+var searchInputWrapper = "_1y9te7a1";
+export {
+  emptyContainer,
+  searchInput,
+  searchInputWrapper
+};

--- a/frontend/src/__generated/ve/pages/Graphing/DashboardOverview.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/DashboardOverview.css.js
@@ -1,7 +1,5 @@
 // src/pages/Graphing/DashboardOverview.css.ts
 var emptyContainer = "_1y9te7a0";
-var searchInputWrapper = "_1y9te7a1";
 export {
-  emptyContainer,
-  searchInputWrapper
+  emptyContainer
 };

--- a/frontend/src/components/TimeRangePicker/TimeRangePicker.tsx
+++ b/frontend/src/components/TimeRangePicker/TimeRangePicker.tsx
@@ -1,4 +1,5 @@
 import { PreviousDateRangePicker } from '@highlight-run/ui/components'
+import { MenuButtonProps } from '@highlight-run/ui/dist/components/Menu/Menu'
 import useDataTimeRange, {
 	defaultDataTimeRange,
 	FORMAT,
@@ -41,7 +42,9 @@ const minDate = moment(defaultDataTimeRange.end_date)
 	.subtract(90, 'days')
 	.toDate()
 
-const TimeRangePicker: React.FC<React.PropsWithChildren<unknown>> = () => {
+const TimeRangePicker: React.FC<
+	React.PropsWithChildren<Omit<MenuButtonProps, 'ref' | 'store'>>
+> = (props) => {
 	const [customDateRange, setCustomDateRange] = useState<Date[]>([
 		presets[5].startDate,
 		moment().toDate(),
@@ -65,6 +68,7 @@ const TimeRangePicker: React.FC<React.PropsWithChildren<unknown>> = () => {
 			selectedDates={customDateRange}
 			onDatesChange={setCustomDateRange}
 			minDate={minDate}
+			{...props}
 		/>
 	)
 }

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -15470,3 +15470,94 @@ export type GetVisualizationQueryResult = Apollo.QueryResult<
 	Types.GetVisualizationQuery,
 	Types.GetVisualizationQueryVariables
 >
+export const GetVisualizationsDocument = gql`
+	query GetVisualizations(
+		$project_id: ID!
+		$input: String!
+		$count: Int!
+		$offset: Int!
+	) {
+		visualizations(
+			project_id: $project_id
+			input: $input
+			count: $count
+			offset: $offset
+		) {
+			count
+			results {
+				id
+				projectId
+				name
+				graphs {
+					id
+					type
+					title
+					productType
+					query
+					metric
+					functionType
+					groupByKey
+					bucketByKey
+					bucketCount
+					limit
+					limitFunctionType
+					limitMetric
+					display
+					nullHandling
+				}
+			}
+		}
+	}
+`
+
+/**
+ * __useGetVisualizationsQuery__
+ *
+ * To run a query within a React component, call `useGetVisualizationsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetVisualizationsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetVisualizationsQuery({
+ *   variables: {
+ *      project_id: // value for 'project_id'
+ *      input: // value for 'input'
+ *      count: // value for 'count'
+ *      offset: // value for 'offset'
+ *   },
+ * });
+ */
+export function useGetVisualizationsQuery(
+	baseOptions: Apollo.QueryHookOptions<
+		Types.GetVisualizationsQuery,
+		Types.GetVisualizationsQueryVariables
+	>,
+) {
+	return Apollo.useQuery<
+		Types.GetVisualizationsQuery,
+		Types.GetVisualizationsQueryVariables
+	>(GetVisualizationsDocument, baseOptions)
+}
+export function useGetVisualizationsLazyQuery(
+	baseOptions?: Apollo.LazyQueryHookOptions<
+		Types.GetVisualizationsQuery,
+		Types.GetVisualizationsQueryVariables
+	>,
+) {
+	return Apollo.useLazyQuery<
+		Types.GetVisualizationsQuery,
+		Types.GetVisualizationsQueryVariables
+	>(GetVisualizationsDocument, baseOptions)
+}
+export type GetVisualizationsQueryHookResult = ReturnType<
+	typeof useGetVisualizationsQuery
+>
+export type GetVisualizationsLazyQueryHookResult = ReturnType<
+	typeof useGetVisualizationsLazyQuery
+>
+export type GetVisualizationsQueryResult = Apollo.QueryResult<
+	Types.GetVisualizationsQuery,
+	Types.GetVisualizationsQueryVariables
+>

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -15399,6 +15399,7 @@ export const GetVisualizationDocument = gql`
 	query GetVisualization($id: ID!) {
 		visualization(id: $id) {
 			id
+			updatedAt
 			projectId
 			name
 			graphs {
@@ -15417,6 +15418,12 @@ export const GetVisualizationDocument = gql`
 				limitMetric
 				display
 				nullHandling
+			}
+			updatedByAdmin {
+				id
+				name
+				email
+				photo_url
 			}
 		}
 	}
@@ -15486,6 +15493,7 @@ export const GetVisualizationsDocument = gql`
 			count
 			results {
 				id
+				updatedAt
 				projectId
 				name
 				graphs {
@@ -15504,6 +15512,12 @@ export const GetVisualizationsDocument = gql`
 					limitMetric
 					display
 					nullHandling
+				}
+				updatedByAdmin {
+					id
+					name
+					email
+					photo_url
 				}
 			}
 		}

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -5213,6 +5213,48 @@ export type GetVisualizationQuery = { __typename?: 'Query' } & {
 		}
 }
 
+export type GetVisualizationsQueryVariables = Types.Exact<{
+	project_id: Types.Scalars['ID']
+	input: Types.Scalars['String']
+	count: Types.Scalars['Int']
+	offset: Types.Scalars['Int']
+}>
+
+export type GetVisualizationsQuery = { __typename?: 'Query' } & {
+	visualizations: { __typename?: 'VisualizationsResponse' } & Pick<
+		Types.VisualizationsResponse,
+		'count'
+	> & {
+			results: Array<
+				{ __typename?: 'Visualization' } & Pick<
+					Types.Visualization,
+					'id' | 'projectId' | 'name'
+				> & {
+						graphs: Array<
+							{ __typename?: 'Graph' } & Pick<
+								Types.Graph,
+								| 'id'
+								| 'type'
+								| 'title'
+								| 'productType'
+								| 'query'
+								| 'metric'
+								| 'functionType'
+								| 'groupByKey'
+								| 'bucketByKey'
+								| 'bucketCount'
+								| 'limit'
+								| 'limitFunctionType'
+								| 'limitMetric'
+								| 'display'
+								| 'nullHandling'
+							>
+						>
+					}
+			>
+		}
+}
+
 export const namedOperations = {
 	Query: {
 		GetMetricsTimeline: 'GetMetricsTimeline' as const,
@@ -5362,6 +5404,7 @@ export const namedOperations = {
 		GetKeyValues: 'GetKeyValues' as const,
 		GetMetrics: 'GetMetrics' as const,
 		GetVisualization: 'GetVisualization' as const,
+		GetVisualizations: 'GetVisualizations' as const,
 	},
 	Mutation: {
 		MarkErrorGroupAsViewed: 'MarkErrorGroupAsViewed' as const,

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -5188,7 +5188,7 @@ export type GetVisualizationQueryVariables = Types.Exact<{
 export type GetVisualizationQuery = { __typename?: 'Query' } & {
 	visualization: { __typename?: 'Visualization' } & Pick<
 		Types.Visualization,
-		'id' | 'projectId' | 'name'
+		'id' | 'updatedAt' | 'projectId' | 'name'
 	> & {
 			graphs: Array<
 				{ __typename?: 'Graph' } & Pick<
@@ -5210,6 +5210,12 @@ export type GetVisualizationQuery = { __typename?: 'Query' } & {
 					| 'nullHandling'
 				>
 			>
+			updatedByAdmin?: Types.Maybe<
+				{ __typename?: 'SanitizedAdmin' } & Pick<
+					Types.SanitizedAdmin,
+					'id' | 'name' | 'email' | 'photo_url'
+				>
+			>
 		}
 }
 
@@ -5228,7 +5234,7 @@ export type GetVisualizationsQuery = { __typename?: 'Query' } & {
 			results: Array<
 				{ __typename?: 'Visualization' } & Pick<
 					Types.Visualization,
-					'id' | 'projectId' | 'name'
+					'id' | 'updatedAt' | 'projectId' | 'name'
 				> & {
 						graphs: Array<
 							{ __typename?: 'Graph' } & Pick<
@@ -5248,6 +5254,12 @@ export type GetVisualizationsQuery = { __typename?: 'Query' } & {
 								| 'limitMetric'
 								| 'display'
 								| 'nullHandling'
+							>
+						>
+						updatedByAdmin?: Types.Maybe<
+							{ __typename?: 'SanitizedAdmin' } & Pick<
+								Types.SanitizedAdmin,
+								'id' | 'name' | 'email' | 'photo_url'
 							>
 						>
 					}

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -2124,6 +2124,7 @@ export type Query = {
 	vercel_project_mappings: Array<VercelProjectMapping>
 	vercel_projects: Array<VercelProject>
 	visualization: Visualization
+	visualizations: VisualizationsResponse
 	web_vitals: Array<Metric>
 	websocket_events?: Maybe<Array<Maybe<Scalars['Any']>>>
 	workspace?: Maybe<Workspace>
@@ -2912,6 +2913,13 @@ export type QueryVercel_ProjectsArgs = {
 
 export type QueryVisualizationArgs = {
 	id: Scalars['ID']
+}
+
+export type QueryVisualizationsArgs = {
+	count: Scalars['Int']
+	input: Scalars['String']
+	offset: Scalars['Int']
+	project_id: Scalars['ID']
 }
 
 export type QueryWeb_VitalsArgs = {
@@ -3722,6 +3730,12 @@ export type VisualizationInput = {
 	id?: InputMaybe<Scalars['ID']>
 	name: Scalars['String']
 	projectId: Scalars['ID']
+}
+
+export type VisualizationsResponse = {
+	__typename?: 'VisualizationsResponse'
+	count: Scalars['Int']
+	results: Array<Visualization>
 }
 
 export type WebSocketEvent = {

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -3724,6 +3724,8 @@ export type Visualization = {
 	id: Scalars['ID']
 	name: Scalars['String']
 	projectId: Scalars['ID']
+	updatedAt: Scalars['Timestamp']
+	updatedByAdmin?: Maybe<SanitizedAdmin>
 }
 
 export type VisualizationInput = {

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2540,6 +2540,7 @@ query GetMetrics(
 query GetVisualization($id: ID!) {
 	visualization(id: $id) {
 		id
+		updatedAt
 		projectId
 		name
 		graphs {
@@ -2559,6 +2560,12 @@ query GetVisualization($id: ID!) {
 			display
 			nullHandling
 		}
+		updatedByAdmin {
+			id
+			name
+			email
+			photo_url
+		}
 	}
 }
 
@@ -2577,6 +2584,7 @@ query GetVisualizations(
 		count
 		results {
 			id
+			updatedAt
 			projectId
 			name
 			graphs {
@@ -2595,6 +2603,12 @@ query GetVisualizations(
 				limitMetric
 				display
 				nullHandling
+			}
+			updatedByAdmin {
+				id
+				name
+				email
+				photo_url
 			}
 		}
 	}

--- a/frontend/src/graph/operators/query.gql
+++ b/frontend/src/graph/operators/query.gql
@@ -2561,3 +2561,41 @@ query GetVisualization($id: ID!) {
 		}
 	}
 }
+
+query GetVisualizations(
+	$project_id: ID!
+	$input: String!
+	$count: Int!
+	$offset: Int!
+) {
+	visualizations(
+		project_id: $project_id
+		input: $input
+		count: $count
+		offset: $offset
+	) {
+		count
+		results {
+			id
+			projectId
+			name
+			graphs {
+				id
+				type
+				title
+				productType
+				query
+				metric
+				functionType
+				groupByKey
+				bucketByKey
+				bucketCount
+				limit
+				limitFunctionType
+				limitMetric
+				display
+				nullHandling
+			}
+		}
+	}
+}

--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -1,6 +1,15 @@
-import { Box, Button, IconSolidPlus, Text } from '@highlight-run/ui/components'
+import {
+	Badge,
+	Box,
+	Button,
+	IconSolidChartBar,
+	IconSolidCheveronRight,
+	IconSolidPlus,
+	Text,
+} from '@highlight-run/ui/components'
+import { vars } from '@highlight-run/ui/vars'
 import { Helmet } from 'react-helmet'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
 import TimeRangePicker from '@/components/TimeRangePicker/TimeRangePicker'
 import { useGetVisualizationQuery } from '@/graph/generated/hooks'
@@ -19,6 +28,7 @@ export const Dashboard = () => {
 	const { projectId } = useProjectId()
 	const { data } = useGetVisualizationQuery({
 		variables: { id: dashboard_id! },
+		fetchPolicy: 'cache-and-network',
 	})
 
 	const { timeRange } = useDataTimeRange()
@@ -57,14 +67,33 @@ export const Dashboard = () => {
 						paddingRight="8"
 						py="6"
 					>
-						<Text size="small" weight="medium">
-							{data?.visualization.name}
-						</Text>
+						<Box
+							display="flex"
+							flexDirection="row"
+							alignItems="center"
+							gap="4"
+						>
+							<Link to="..">
+								<Badge
+									shape="basic"
+									size="medium"
+									variant="gray"
+									iconStart={<IconSolidChartBar />}
+									label="Dashboards"
+								/>
+							</Link>
+							<IconSolidCheveronRight
+								color={vars.theme.static.content.weak}
+							/>
+							<Text size="small" weight="medium" color="default">
+								{data?.visualization.name}
+							</Text>
+						</Box>
 						<Box display="flex" gap="4">
 							<Button emphasis="low" kind="secondary">
 								Share
 							</Button>
-							<TimeRangePicker />
+							<TimeRangePicker emphasis="low" kind="secondary" />
 							<Button
 								emphasis="low"
 								kind="secondary"

--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -28,7 +28,7 @@ export const Dashboard = () => {
 	return (
 		<>
 			<Helmet>
-				<title>Edit Metric View</title>
+				<title>{data?.visualization.name}</title>
 			</Helmet>
 			<Box
 				background="n2"

--- a/frontend/src/pages/Graphing/DashboardOverview.css.ts
+++ b/frontend/src/pages/Graphing/DashboardOverview.css.ts
@@ -9,5 +9,3 @@ export const emptyContainer = style({
 	paddingBottom: '32px',
 	paddingTop: '32px',
 })
-
-export const searchInputWrapper = style({})

--- a/frontend/src/pages/Graphing/DashboardOverview.css.ts
+++ b/frontend/src/pages/Graphing/DashboardOverview.css.ts
@@ -10,16 +10,4 @@ export const emptyContainer = style({
 	paddingTop: '32px',
 })
 
-export const searchInputWrapper = style({
-	borderBottomLeftRadius: 0,
-	borderBottomRightRadius: 0,
-})
-
-export const searchInput = style({
-	border: 'none',
-	selectors: {
-		'&:hover': {
-			border: 'none',
-		},
-	},
-})
+export const searchInputWrapper = style({})

--- a/frontend/src/pages/Graphing/DashboardOverview.css.ts
+++ b/frontend/src/pages/Graphing/DashboardOverview.css.ts
@@ -1,0 +1,25 @@
+import { style } from '@vanilla-extract/css'
+
+export const emptyContainer = style({
+	cursor: 'auto',
+	display: 'flex',
+	flexDirection: 'column',
+	margin: '0 auto',
+	maxWidth: '400px',
+	paddingBottom: '32px',
+	paddingTop: '32px',
+})
+
+export const searchInputWrapper = style({
+	borderBottomLeftRadius: 0,
+	borderBottomRightRadius: 0,
+})
+
+export const searchInput = style({
+	border: 'none',
+	selectors: {
+		'&:hover': {
+			border: 'none',
+		},
+	},
+})

--- a/frontend/src/pages/Graphing/DashboardOverview.tsx
+++ b/frontend/src/pages/Graphing/DashboardOverview.tsx
@@ -1,0 +1,246 @@
+import { SearchEmptyState } from '@components/SearchEmptyState/SearchEmptyState'
+import {
+	Badge,
+	Box,
+	Button,
+	Container,
+	Form,
+	Heading,
+	IconSolidChartBar,
+	IconSolidCheveronRight,
+	IconSolidSearch,
+	Input,
+	Stack,
+	Tag,
+	Text,
+} from '@highlight-run/ui/components'
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useDebounce } from 'react-use'
+
+import {
+	useGetVisualizationsQuery,
+	useUpsertVisualizationMutation,
+} from '@/graph/generated/hooks'
+import { namedOperations } from '@/graph/generated/operations'
+import { useProjectId } from '@/hooks/useProjectId'
+
+import * as style from './DashboardOverview.css'
+
+const ITEMS_PER_PAGE = 10
+
+export default function DashboardOverview() {
+	const { projectId } = useProjectId()
+
+	const [query, setQuery] = useState('')
+	const [debouncedQuery, setDebouncedQuery] = useState('')
+	useDebounce(
+		() => {
+			setDebouncedQuery(query)
+		},
+		500,
+		[query],
+	)
+	const [page, setPage] = useState(0)
+
+	const { data, loading } = useGetVisualizationsQuery({
+		variables: {
+			project_id: projectId,
+			input: debouncedQuery,
+			count: ITEMS_PER_PAGE,
+			offset: page * ITEMS_PER_PAGE,
+		},
+	})
+
+	const [upsertViz] = useUpsertVisualizationMutation({
+		variables: {
+			visualization: {
+				name: 'Untitled Dashboard',
+				projectId: projectId,
+			},
+		},
+		refetchQueries: [namedOperations.Query.GetVisualizations],
+	})
+
+	const navigate = useNavigate()
+
+	const createDashboard = () => {
+		upsertViz().then((result) => {
+			if (result.data !== undefined && result.data !== null) {
+				navigate(result.data.upsertVisualization)
+			}
+		})
+	}
+
+	const rows = data?.visualizations?.results
+
+	return (
+		<Box width="full" background="raised" p="8">
+			<Box
+				border="dividerWeak"
+				borderRadius="6"
+				width="full"
+				shadow="medium"
+				background="default"
+				display="flex"
+				flexDirection="column"
+				height="full"
+			>
+				<Container display="flex" flexDirection="column" gap="24">
+					<Box
+						style={{ maxWidth: 560 }}
+						my="40"
+						mx="auto"
+						width="full"
+					>
+						<Stack gap="24" width="full">
+							<Stack gap="16" direction="column" width="full">
+								<Heading mt="16" level="h4">
+									Dashboards
+								</Heading>
+								<Text
+									weight="medium"
+									size="small"
+									color="default"
+								>
+									Dashboards allow you to visualize what's
+									happening in your app.
+								</Text>
+							</Stack>
+							<Stack gap="8" width="full">
+								<Box
+									display="flex"
+									justifyContent="space-between"
+									alignItems="center"
+									width="full"
+								>
+									<Text
+										weight="bold"
+										size="small"
+										color="strong"
+									>
+										All dashboards
+									</Text>
+									<Button onClick={createDashboard}>
+										Create new dashboard
+									</Button>
+								</Box>
+								<Stack
+									gap="0"
+									border="dividerWeak"
+									borderRadius="6"
+								>
+									<Form>
+										<Box
+											display="flex"
+											gap="6"
+											alignItems="center"
+											cssClass={style.searchInputWrapper}
+										>
+											<IconSolidSearch />
+											<Input
+												type="text"
+												name="title"
+												placeholder="Search..."
+												value={query}
+												onChange={(e) => {
+													setQuery(e.target.value)
+												}}
+												cssClass={style.searchInput}
+											/>
+										</Box>
+									</Form>
+									{rows && rows.length > 0 ? (
+										<>
+											{rows.map((row, idx) => (
+												<Box
+													width="full"
+													display="flex"
+													p="12"
+													gap="16"
+													key={idx}
+												>
+													<Box
+														display="flex"
+														alignItems="center"
+														justifyContent="space-between"
+														gap="8"
+														key={idx}
+													>
+														<Box
+															display="flex"
+															alignItems="center"
+															gap="4"
+														>
+															<Stack>
+																<Box
+																	display="flex"
+																	gap="6"
+																	alignItems="center"
+																>
+																	<Badge
+																		color="weak"
+																		iconStart={
+																			<IconSolidChartBar />
+																		}
+																	/>
+																	<Text
+																		weight="medium"
+																		size="small"
+																		color="strong"
+																	>
+																		{
+																			row.name
+																		}
+																	</Text>
+																</Box>
+																<Text
+																	weight="medium"
+																	size="small"
+																	color="default"
+																>
+																	{row.name}
+																</Text>
+															</Stack>
+														</Box>
+														<Box
+															display="flex"
+															gap="8"
+															flexShrink={0}
+														>
+															<Tag
+																kind="primary"
+																size="medium"
+																shape="basic"
+																emphasis="low"
+																iconRight={
+																	<IconSolidCheveronRight />
+																}
+																onClick={() =>
+																	navigate(
+																		`${row.id}`,
+																	)
+																}
+															>
+																View
+															</Tag>
+														</Box>
+													</Box>
+												</Box>
+											))}
+										</>
+									) : (
+										<SearchEmptyState
+											className={style.emptyContainer}
+											item="dashboards"
+										/>
+									)}
+								</Stack>
+							</Stack>
+						</Stack>
+					</Box>
+				</Container>
+			</Box>
+		</Box>
+	)
+}

--- a/frontend/src/pages/Graphing/DashboardOverview.tsx
+++ b/frontend/src/pages/Graphing/DashboardOverview.tsx
@@ -135,10 +135,7 @@ export default function DashboardOverview() {
 										Create new dashboard
 									</Button>
 								</Box>
-								<Table
-									withSearch
-									className={style.searchInputWrapper}
-								>
+								<Table withSearch>
 									<Table.Search
 										placeholder="Search..."
 										handleChange={(e) => {
@@ -221,33 +218,44 @@ const DashboardRows = ({
 		)
 	}
 
-	return rows.map((row, idx) => (
-		<Table.Row width="full" key={idx}>
-			<Link to={`${row.id}`}>
-				<Stack width="full" px="12" py="8" gap="2">
-					<Box display="flex" gap="6" alignItems="center">
-						<Badge color="weak" iconStart={<IconSolidChartBar />} />
-						<Text weight="medium" size="small" color="strong">
-							{row.name}
-						</Text>
-					</Box>
-					<Box>
-						<Text color="weak" display="inline-block">
-							Updated by&nbsp;
-						</Text>
-						<Text
-							color="secondaryContentText"
-							display="inline-block"
-						>
-							{row.updatedByAdmin?.name ?? 'Highlight'}
-							&nbsp;
-						</Text>
-						<Text color="weak" display="inline-block">
-							{moment(row.updatedAt).fromNow()}
-						</Text>
-					</Box>
-				</Stack>
-			</Link>
-		</Table.Row>
-	))
+	return (
+		<>
+			{rows.map((row, idx) => (
+				<Table.Row width="full" key={idx}>
+					<Link to={`${row.id}`}>
+						<Stack width="full" px="12" py="8" gap="2">
+							<Box display="flex" gap="6" alignItems="center">
+								<Badge
+									color="weak"
+									iconStart={<IconSolidChartBar />}
+								/>
+								<Text
+									weight="medium"
+									size="small"
+									color="strong"
+								>
+									{row.name}
+								</Text>
+							</Box>
+							<Box>
+								<Text color="weak" display="inline-block">
+									Updated by&nbsp;
+								</Text>
+								<Text
+									color="secondaryContentText"
+									display="inline-block"
+								>
+									{row.updatedByAdmin?.name ?? 'Highlight'}
+									&nbsp;
+								</Text>
+								<Text color="weak" display="inline-block">
+									{moment(row.updatedAt).fromNow()}
+								</Text>
+							</Box>
+						</Stack>
+					</Link>
+				</Table.Row>
+			))}
+		</>
+	)
 }

--- a/frontend/src/pages/Graphing/DashboardRouter.tsx
+++ b/frontend/src/pages/Graphing/DashboardRouter.tsx
@@ -1,13 +1,14 @@
-import { Navigate, Route, Routes } from 'react-router-dom'
+import { Route, Routes } from 'react-router-dom'
 
 import { Dashboard } from '@/pages/Graphing/Dashboard'
+import DashboardOverview from '@/pages/Graphing/DashboardOverview'
 import { ExpandedGraph } from '@/pages/Graphing/ExpandedGraph'
 import { GraphingEditor } from '@/pages/Graphing/GraphingEditor'
 
 const DashboardRouter = () => {
 	return (
 		<Routes>
-			<Route path="*" element={<Navigate to="1" replace />} />
+			<Route path="*" element={<DashboardOverview />} />
 			<Route path=":dashboard_id" element={<Dashboard />} />
 			<Route
 				path=":dashboard_id/edit/:graph_id"

--- a/frontend/src/pages/Graphing/ExpandedGraph.tsx
+++ b/frontend/src/pages/Graphing/ExpandedGraph.tsx
@@ -77,7 +77,7 @@ export const ExpandedGraph = () => {
 							>
 								Cancel
 							</Button>
-							<TimeRangePicker />
+							<TimeRangePicker emphasis="low" kind="secondary" />
 						</Box>
 					</Box>
 					<Box

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -513,7 +513,7 @@ export const GraphingEditor = () => {
 							>
 								Cancel
 							</Button>
-							<TimeRangePicker />
+							<TimeRangePicker emphasis="low" kind="secondary" />
 							{isEdit ? (
 								<Button
 									kind="danger"

--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -82,6 +82,7 @@ export const BarChart = ({
 				<Tooltip
 					content={getCustomTooltip(xAxisMetric, yAxisMetric)}
 					cursor={{ fill: '#C8C7CB', fillOpacity: 0.5 }}
+					isAnimationActive={false}
 				/>
 
 				<YAxis

--- a/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
@@ -2,7 +2,6 @@ import { useAuthContext } from '@authentication/AuthContext'
 import AlertsRouter from '@pages/Alerts/AlertsRouter'
 import LogAlertsRouter from '@pages/Alerts/LogAlert/LogAlertRouter'
 import { CanvasPage } from '@pages/Buttons/CanvasV2'
-import DashboardsRouter from '@pages/Dashboards/DashboardsRouter'
 import { useErrorSearchContext } from '@pages/Errors/ErrorSearchContext/ErrorSearchContext'
 import ErrorsV2 from '@pages/ErrorsV2/ErrorsV2'
 import IntegrationsPage from '@pages/IntegrationsPage/IntegrationsPage'
@@ -101,12 +100,10 @@ const ApplicationRouter: React.FC = () => {
 						/>
 						{isHighlightAdmin && (
 							<Route
-								path="metrics/*"
+								path="dashboards/*"
 								element={<DashboardRouter />}
 							/>
 						)}
-
-						<Route path="*" element={<DashboardsRouter />} />
 					</>
 				) : (
 					<Route path="*" element={<SignInRedirect />} />

--- a/frontend/src/util/graph.tsx
+++ b/frontend/src/util/graph.tsx
@@ -117,6 +117,14 @@ const cache = new InMemoryCache({
 				error_groups_clickhouse: {
 					keyArgs: ['project_id', 'count', 'query', 'page'],
 				},
+				visualization: {
+					read(_, { args, toReference }) {
+						return toReference({
+							__typename: 'Visualization',
+							id: args?.id,
+						})
+					},
+				},
 			},
 		},
 	},


### PR DESCRIPTION
## Summary
- adds visualizations resolver for fetching dashboard metadata for a project, queryable and paginated
- adds `DashboardOverview` page displaying a table of these dashboards, allowing users to click into or create a new one
- changed `/dashboards` endpoint to point at this new page
- some styling polish
- https://www.loom.com/share/9fa6b87cb8ef4be5aef898681054b497
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- need to drop `visualization_project_id_name_idx` after deployment (decided not to enforce a unique constraint on name as this is kind of annoying in the UI and not super necessary)
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- @julian-highlight can review after deployment
<!--
 Request review from julian-highlight / our design team 
-->
