### PR TITLE
correctly filter errors ingest

### DIFF
--- a/backend/clickhouse/errors.go
+++ b/backend/clickhouse/errors.go
@@ -603,15 +603,30 @@ var ErrorsJoinedTableConfig = model.TableConfig[modelInputs.ReservedErrorsJoined
 		modelInputs.ReservedErrorsJoinedKeyEvent:           "Event",
 		modelInputs.ReservedErrorsJoinedKeyHasSession:      "HasSession",
 		modelInputs.ReservedErrorsJoinedKeyOsName:          "OSName",
+		modelInputs.ReservedErrorsJoinedKeySecureSessionID: "SecureSessionID",
 		modelInputs.ReservedErrorsJoinedKeyServiceName:     "ServiceName",
 		modelInputs.ReservedErrorsJoinedKeyServiceVersion:  "ServiceVersion",
+		modelInputs.ReservedErrorsJoinedKeyStatus:          "Status",
 		modelInputs.ReservedErrorsJoinedKeyTag:             "ErrorTagTitle",
+		modelInputs.ReservedErrorsJoinedKeyTimestamp:       "Timestamp",
+		modelInputs.ReservedErrorsJoinedKeyTraceID:         "TraceID",
 		modelInputs.ReservedErrorsJoinedKeyType:            "Type",
 		modelInputs.ReservedErrorsJoinedKeyVisitedURL:      "VisitedURL",
-		modelInputs.ReservedErrorsJoinedKeyTimestamp:       "Timestamp",
-		modelInputs.ReservedErrorsJoinedKeyStatus:          "Status",
-		modelInputs.ReservedErrorsJoinedKeySecureSessionID: "SecureSessionID",
-		modelInputs.ReservedErrorsJoinedKeyTraceID:         "TraceID",
+	},
+	BodyColumn:   "Event",
+	ReservedKeys: modelInputs.AllReservedErrorsJoinedKey,
+}
+
+var BackendErrorObjectInputConfig = model.TableConfig[modelInputs.ReservedErrorsJoinedKey]{
+	KeysToColumns: map[modelInputs.ReservedErrorsJoinedKey]string{
+		modelInputs.ReservedErrorsJoinedKeyEnvironment:    "Environment",
+		modelInputs.ReservedErrorsJoinedKeyEvent:          "Event",
+		modelInputs.ReservedErrorsJoinedKeyHasSession:     "SessionSecureID",
+		modelInputs.ReservedErrorsJoinedKeyServiceName:    "Service.Name",
+		modelInputs.ReservedErrorsJoinedKeyServiceVersion: "Service.Version",
+		modelInputs.ReservedErrorsJoinedKeyTimestamp:      "Timestamp",
+		modelInputs.ReservedErrorsJoinedKeyType:           "Type",
+		modelInputs.ReservedErrorsJoinedKeyVisitedURL:     "URL",
 	},
 	BodyColumn:   "Event",
 	ReservedKeys: modelInputs.AllReservedErrorsJoinedKey,
@@ -625,7 +640,7 @@ var errorsSampleableTableConfig = sampleableTableConfig[modelInputs.ReservedErro
 }
 
 func ErrorMatchesQuery(errorObject *model2.BackendErrorObjectInput, filters listener.Filters) bool {
-	return matchesQuery(errorObject, ErrorsJoinedTableConfig, filters)
+	return matchesQuery(errorObject, BackendErrorObjectInputConfig, filters, listener.OperatorAnd)
 }
 
 func (client *Client) ReadErrorsMetrics(ctx context.Context, projectID int, params modelInputs.QueryInput, column string, metricTypes []modelInputs.MetricAggregator, groupBy []string, nBuckets *int, bucketBy string, limit *int, limitAggregator *modelInputs.MetricAggregator, limitColumn *string) (*modelInputs.MetricsBuckets, error) {

--- a/backend/clickhouse/errors_test.go
+++ b/backend/clickhouse/errors_test.go
@@ -1,17 +1,17 @@
 package clickhouse
 
 import (
-	"testing"
-	"time"
-
 	"github.com/highlight-run/highlight/backend/parser"
 	modelInputs "github.com/highlight-run/highlight/backend/public-graph/graph/model"
+	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
 )
 
 func Test_ErrorMatchesQuery(t *testing.T) {
 	errorObject := modelInputs.BackendErrorObjectInput{}
-	filters := parser.Parse("oops something bad type:console.error os.type:linux resource_name:worker.* service_name:all", ErrorObjectsTableConfig)
+	filters := parser.Parse("oops something bad type:console.error os.type:linux resource_name:worker.* service_name:all", BackendErrorObjectInputConfig)
 	matches := ErrorMatchesQuery(&errorObject, filters)
 	assert.False(t, matches)
 
@@ -27,6 +27,66 @@ func Test_ErrorMatchesQuery(t *testing.T) {
 			Version: "asdf",
 		},
 	}
+	matches = ErrorMatchesQuery(&errorObject, filters)
+	assert.True(t, matches)
+}
+
+func Test_ErrorMatchesQuery_v2(t *testing.T) {
+	errorObject := modelInputs.BackendErrorObjectInput{}
+	filters := parser.Parse("source=bean.js OR foo=bar OR type=console.error", BackendErrorObjectInputConfig)
+	matches := ErrorMatchesQuery(&errorObject, filters)
+	assert.False(t, matches)
+	filters = parser.Parse("source=bean.js OR foo=bar OR swag=console.error", BackendErrorObjectInputConfig)
+	matches = ErrorMatchesQuery(&errorObject, filters)
+	assert.False(t, matches)
+	filters = parser.Parse("", BackendErrorObjectInputConfig)
+	matches = ErrorMatchesQuery(&errorObject, filters)
+	assert.True(t, matches)
+
+	errorObject = modelInputs.BackendErrorObjectInput{
+		SessionSecureID: pointy.String("sess"),
+		RequestID:       pointy.String("abc123"),
+		TraceID:         pointy.String("def456"),
+		SpanID:          pointy.String("a1b2c3"),
+		LogCursor:       pointy.String("foobar"),
+		Event:           "yo this is the random error! 123456",
+		Type:            "window.onerror",
+		URL:             "",
+		Source:          "foo.js",
+		StackTrace:      "Error: oh no!\n    at Procedure.resolve [as resolver] (webpack-internal:///(api)/./src/server/routers/name.ts:18:19)\n    at Array.<anonymous> (/Users/vkorolik/work/web-test/trpc-nextjs-demo-internal/node_modules/@trpc/server/dist/router-ee876044.cjs.dev.js:101:36)\n",
+		Timestamp:       time.Now(),
+		Payload:         pointy.String("{\"foo\":\"bar\",\"key\":\"123\"}"),
+		Service: &modelInputs.ServiceInput{
+			Name:    "my-service",
+			Version: "my-service-version",
+		},
+		Environment: "production",
+	}
+	filters = parser.Parse(`service_name="not-my-service" visited_url=""`, BackendErrorObjectInputConfig)
+	matches = ErrorMatchesQuery(&errorObject, filters)
+	assert.False(t, matches)
+
+	filters = parser.Parse(`service_name=my-service visited_url=""`, BackendErrorObjectInputConfig)
+	matches = ErrorMatchesQuery(&errorObject, filters)
+	assert.True(t, matches)
+
+	filters = parser.Parse(`(service_name=my-service AND visited_url!="")`, BackendErrorObjectInputConfig)
+	matches = ErrorMatchesQuery(&errorObject, filters)
+	assert.False(t, matches)
+
+	errorObject.URL = "https://localhost:3000/foo/bar/baz"
+	matches = ErrorMatchesQuery(&errorObject, filters)
+	assert.True(t, matches)
+
+	filters = parser.Parse(`(service_name=my-service AND event="random error")`, BackendErrorObjectInputConfig)
+	matches = ErrorMatchesQuery(&errorObject, filters)
+	assert.False(t, matches)
+
+	filters = parser.Parse(`(service_name=my-service AND event="*not a substring*")`, BackendErrorObjectInputConfig)
+	matches = ErrorMatchesQuery(&errorObject, filters)
+	assert.False(t, matches)
+
+	filters = parser.Parse(`(service_name=my-service AND event="*random error*")`, BackendErrorObjectInputConfig)
 	matches = ErrorMatchesQuery(&errorObject, filters)
 	assert.True(t, matches)
 }

--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -469,7 +469,7 @@ func (client *Client) LogsKeyValues(ctx context.Context, projectID int, keyName 
 }
 
 func LogMatchesQuery(logRow *LogRow, filters listener.Filters) bool {
-	return matchesQuery(logRow, LogsTableConfig, filters)
+	return matchesQuery(logRow, LogsTableConfig, filters, listener.OperatorAnd)
 }
 
 func (client *Client) LogsLogLines(ctx context.Context, projectID int, params modelInputs.QueryInput) ([]*modelInputs.LogLine, error) {

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -464,7 +464,7 @@ var SessionsTableConfig = model.TableConfig[string]{
 }
 
 func SessionMatchesQuery(session *model.Session, filters listener.Filters) bool {
-	return matchesQuery(session, SessionsTableConfig, filters)
+	return matchesQuery(session, SessionsTableConfig, filters, listener.OperatorAnd)
 }
 
 var SessionsJoinedTableConfig = model.TableConfig[modelInputs.ReservedSessionKey]{

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -462,7 +462,7 @@ func (client *Client) TracesMetrics(ctx context.Context, projectID int, startDat
 }
 
 func TraceMatchesQuery(trace *TraceRow, filters listener.Filters) bool {
-	return matchesQuery(trace, TracesTableConfig, filters)
+	return matchesQuery(trace, TracesTableConfig, filters, listener.OperatorAnd)
 }
 
 func (client *Client) TracesLogLines(ctx context.Context, projectID int, params modelInputs.QueryInput) ([]*modelInputs.LogLine, error) {

--- a/backend/public-graph/graph/sampling.go
+++ b/backend/public-graph/graph/sampling.go
@@ -109,14 +109,15 @@ func (r *Resolver) IsLogIngestedByFilter(ctx context.Context, logRow *clickhouse
 func (r *Resolver) IsFrontendErrorIngested(ctx context.Context, projectID int, session *model.Session, frontendError *modelInputs.ErrorObjectInput) bool {
 	stack, _ := json.Marshal(frontendError.StackTrace)
 	errorObject := &modelInputs.BackendErrorObjectInput{
-		SessionSecureID: &session.SecureID,
+		Environment:     session.Environment,
 		Event:           frontendError.Event,
+		Payload:         frontendError.Payload,
+		SessionSecureID: &session.SecureID,
+		Source:          frontendError.Source,
+		StackTrace:      string(stack),
+		Timestamp:       frontendError.Timestamp,
 		Type:            frontendError.Type,
 		URL:             frontendError.URL,
-		Source:          frontendError.Source,
-		Timestamp:       frontendError.Timestamp,
-		Payload:         frontendError.Payload,
-		StackTrace:      string(stack),
 		Service: &modelInputs.ServiceInput{
 			Name:    session.ServiceName,
 			Version: ptr.ToString(session.AppVersion),

--- a/backend/public-graph/graph/sampling.go
+++ b/backend/public-graph/graph/sampling.go
@@ -113,15 +113,15 @@ func (r *Resolver) IsFrontendErrorIngested(ctx context.Context, projectID int, s
 		Event:           frontendError.Event,
 		Payload:         frontendError.Payload,
 		SessionSecureID: &session.SecureID,
-		Source:          frontendError.Source,
-		StackTrace:      string(stack),
-		Timestamp:       frontendError.Timestamp,
-		Type:            frontendError.Type,
-		URL:             frontendError.URL,
 		Service: &modelInputs.ServiceInput{
 			Name:    session.ServiceName,
 			Version: ptr.ToString(session.AppVersion),
 		},
+		Source:     frontendError.Source,
+		StackTrace: string(stack),
+		Timestamp:  frontendError.Timestamp,
+		Type:       frontendError.Type,
+		URL:        frontendError.URL,
 	}
 	if !r.IsErrorIngestedBySample(ctx, projectID, errorObject) {
 		return false


### PR DESCRIPTION
## Summary

Error ingest filters would not work because of a number of complications around sharing the
ingest logic with the search logic (which for errors isn't ported over to clickhouse fully).
Updates the ingest filter logic to using a new table config that is correctly mapping to the `BackendErrorObjectInput` model.
Fixes issue with ingest filters where an invalid filter would result in overmatching.

## How did you test this change?

new unit test

## Are there any deployment considerations?

will be manually setting necessary error filtering for affected customer

## Does this work require review from our design team?

no
