### PR TITLE
Add error segment migration task:

### DIFF
--- a/backend/scripts/migrate-error-segments/main.go
+++ b/backend/scripts/migrate-error-segments/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	confirm = flag.Bool("confirm", false, "confirm migration")
+	confirm = flag.Bool("confirm", false, "confirm migration or run in dry run mode")
 )
 
 func init() {

--- a/backend/scripts/migrate-error-segments/main.go
+++ b/backend/scripts/migrate-error-segments/main.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/highlight-run/highlight/backend/model"
+	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
+	"github.com/highlight-run/highlight/backend/util"
+	"github.com/highlight/highlight/sdk/highlight-go"
+	hlog "github.com/highlight/highlight/sdk/highlight-go/log"
+	log "github.com/sirupsen/logrus"
+)
+
+func main() {
+	highlight.SetProjectID("1jdkoe52")
+	highlight.Start(
+		highlight.WithServiceName("task--migrate-error-segments"),
+		highlight.WithServiceVersion(os.Getenv("REACT_APP_COMMIT_SHA")),
+		highlight.WithEnvironment(util.EnvironmentName()),
+	)
+	defer highlight.Stop()
+	hlog.Init()
+
+	ctx := context.TODO()
+	dryRun := os.Getenv("CONFIRM") != "true"
+
+	if dryRun {
+		log.WithContext(ctx).Info("Running in dry run mode")
+	} else {
+		log.WithContext(ctx).Info("Running in migration mode")
+	}
+
+	db, err := model.SetupDB(ctx, os.Getenv("PSQL_DB"))
+	if err != nil {
+		log.WithContext(ctx).Fatalf("error setting up DB: %v", err)
+	}
+
+	segments := []*model.ErrorSegment{}
+	if err := db.WithContext(ctx).Model(model.ErrorSegment{}).Find(&segments).Error; err != nil {
+		log.WithContext(ctx).Fatalf("error querying error segments: %v", err)
+	}
+
+	log.WithContext(ctx).Infof("migrating %d error segments", len(segments))
+
+	migratedCount := 0
+	skipCount := 0
+	errorCount := 0
+
+	for _, segment := range segments {
+		name := segment.Name
+		if name == nil {
+			name = ptr.String("Untitled Segment")
+		}
+
+		params, err := translateParams(segment.Params)
+		if err != nil {
+			log.WithContext(ctx).Errorf("error translating params for segment %d, %v", segment.ID, err)
+			errorCount++
+			continue
+		}
+		if params == nil || *params == "" {
+			log.WithContext(ctx).Infof("skipping segment %d, empty query", segment.ID)
+			skipCount++
+			continue
+		}
+
+		savedSegment := model.SavedSegment{
+			Name:       *name,
+			EntityType: modelInputs.SavedSegmentEntityTypeError,
+			ProjectID:  segment.ProjectID,
+			Params:     *params,
+		}
+
+		// check if segment already exists
+		// NOTE: n+1 query here, but this is a one-off migration with <100 segments
+		var exists bool
+		if err := db.WithContext(ctx).Model(savedSegment).Select("COUNT(*) > 0").Find(&exists).Error; err != nil {
+			log.WithContext(ctx).Errorf("error checking for existing saved segment %v", err)
+			errorCount++
+			continue
+		}
+		if exists {
+			log.WithContext(ctx).Infof("skipping segment %d, already exists", segment.ID)
+			skipCount++
+			continue
+		}
+
+		// create new saved segment
+		if !dryRun {
+			if err := db.WithContext(ctx).Create(&savedSegment).Error; err != nil {
+				log.WithContext(ctx).Errorf("error migrating error segment %d, %v", segment.ID, err)
+				errorCount++
+				continue
+			}
+		}
+
+		migratedCount++
+	}
+
+	if dryRun {
+		log.WithContext(ctx).Infof("Dry run complete: %d TO BE migrated, %d skipped, %d errored", migratedCount, skipCount, errorCount)
+	} else {
+		log.WithContext(ctx).Infof("Migration complete: %d migrated, %d skipped, %d errored", migratedCount, skipCount, errorCount)
+	}
+}
+
+func translateParams(params *string) (*string, error) {
+	if params == nil {
+		return nil, nil
+	}
+
+	var paramsObject map[string]*string
+	if err := json.Unmarshal([]byte(*params), &paramsObject); err != nil {
+		return nil, fmt.Errorf("error unmarshalling params: %v", err)
+	}
+
+	queryString := paramsObject["Query"]
+	if queryString == nil || *queryString == "" {
+		queryString = paramsObject["query"]
+		if queryString == nil || *queryString == "" {
+			return nil, nil
+		}
+	}
+
+	var clickhouseQuery modelInputs.ClickhouseQuery
+	if err := json.Unmarshal([]byte(*queryString), &clickhouseQuery); err != nil {
+		return nil, fmt.Errorf("error unmarshalling query: %v", err)
+	}
+	if clickhouseQuery.Rules == nil || len(clickhouseQuery.Rules) == 0 {
+		return nil, nil
+	}
+
+	isAnd := clickhouseQuery.IsAnd
+
+	// parse params
+	rules, err := deserializeRules(clickhouseQuery.Rules)
+	if err != nil {
+		return nil, err
+	}
+	if len(rules) == 0 {
+		return nil, nil
+	}
+
+	queryParts := []string{}
+	for _, rule := range rules {
+		_, field, found := strings.Cut(rule.Field, "_")
+		if !found {
+			continue
+		}
+
+		// translate field
+		fieldName, valid := validFieldMap[field]
+		if !valid {
+			continue
+		}
+
+		_, valid = validOpMap[rule.Op]
+		if !valid {
+			continue
+		}
+
+		queryPart := buildStringQuery(fieldName, rule.Op, rule.Val)
+
+		queryParts = append(queryParts, queryPart)
+	}
+
+	var query *string
+	if isAnd {
+		query = ptr.String(strings.Join(queryParts, " "))
+	} else {
+		query = ptr.String(strings.Join(queryParts, " OR "))
+	}
+
+	return query, nil
+}
+
+type Rule struct {
+	Field string
+	Op    string
+	Val   []string
+}
+
+func deserializeRules(rules [][]string) ([]Rule, error) {
+	ret := []Rule{}
+	for _, r := range rules {
+		if len(r) < 2 {
+			return nil, fmt.Errorf("expecting >= 2 fields in rule %#v", r)
+		}
+		ret = append(ret, Rule{
+			Field: r[0],
+			Op:    r[1],
+			Val:   r[2:],
+		})
+	}
+	return ret, nil
+}
+
+func buildStringQuery(fieldName modelInputs.ReservedErrorsJoinedKey, op string, val []string) string {
+	queryArray := []string{}
+	switch op {
+	case "is":
+		value := strings.Join(val, " OR ")
+		if len(val) > 1 {
+			value = fmt.Sprintf("(%s)", value)
+		}
+		queryArray = append(queryArray, fmt.Sprintf("%s=%s", fieldName, value))
+	case "is_not":
+		value := strings.Join(val, " OR ")
+		if len(val) > 1 {
+			value = fmt.Sprintf("(%s)", value)
+		}
+		queryArray = append(queryArray, fmt.Sprintf("%s!=%s", fieldName, value))
+	case "contains":
+		containsValues := []string{}
+		for _, v := range val {
+			containsValues = append(containsValues, fmt.Sprintf("*%s*", v))
+		}
+
+		value := strings.Join(containsValues, " OR ")
+		if len(val) > 1 {
+			value = fmt.Sprintf("(%s)", value)
+		}
+		queryArray = append(queryArray, fmt.Sprintf("%s=%s", fieldName, value))
+	case "not_contains":
+		containsValues := []string{}
+		for _, v := range val {
+			containsValues = append(containsValues, fmt.Sprintf("*%s*", v))
+		}
+
+		value := strings.Join(containsValues, " OR ")
+		if len(val) > 1 {
+			value = fmt.Sprintf("(%s)", value)
+		}
+		queryArray = append(queryArray, fmt.Sprintf("%s!=%s", fieldName, value))
+	case "matches":
+		for _, v := range val {
+			value := fmt.Sprintf("\\%s\\", v)
+			queryArray = append(queryArray, fmt.Sprintf("%s=%s", fieldName, value))
+		}
+	case "not_matches":
+		for _, v := range val {
+			value := fmt.Sprintf("\\%s\\", v)
+			queryArray = append(queryArray, fmt.Sprintf("%s!=%s", fieldName, value))
+		}
+	}
+
+	queryString := strings.Join(queryArray, " OR ")
+	if len(queryArray) > 1 {
+		queryString = fmt.Sprintf("(%s)", queryString)
+	}
+
+	return queryString
+}
+
+var validFieldMap = map[string]modelInputs.ReservedErrorsJoinedKey{
+	"os_name":           modelInputs.ReservedErrorsJoinedKeyOsName,
+	"has_session":       modelInputs.ReservedErrorsJoinedKeyHasSession,
+	"environment":       modelInputs.ReservedErrorsJoinedKeyEnvironment,
+	"Type":              modelInputs.ReservedErrorsJoinedKeyType,
+	"Event":             modelInputs.ReservedErrorsJoinedKeyEvent,
+	"state":             modelInputs.ReservedErrorsJoinedKeyStatus,
+	"browser":           modelInputs.ReservedErrorsJoinedKeyBrowser,
+	"visited_url":       modelInputs.ReservedErrorsJoinedKeyVisitedURL,
+	"service_name":      modelInputs.ReservedErrorsJoinedKeyServiceName,
+	"service_version":   modelInputs.ReservedErrorsJoinedKeyServiceVersion,
+	"Tag":               modelInputs.ReservedErrorsJoinedKeyTag,
+	"secure_session_id": modelInputs.ReservedErrorsJoinedKeySecureSessionID,
+	"trace_id":          modelInputs.ReservedErrorsJoinedKeyTraceID,
+}
+
+var validOpMap = map[string]string{
+	"is":           "=",
+	"is_not":       "!=",
+	"contains":     "=",
+	"not_contains": "!=",
+	"matches":      "=",
+	"not_matches":  "!=",
+}

--- a/backend/scripts/migrate-error-segments/main.go
+++ b/backend/scripts/migrate-error-segments/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -16,6 +17,17 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var (
+	confirm = flag.Bool("confirm", false, "confirm migration")
+)
+
+func init() {
+	flag.Parse()
+	if confirm == nil {
+		confirm = ptr.Bool(false)
+	}
+}
+
 func main() {
 	highlight.SetProjectID("1jdkoe52")
 	highlight.Start(
@@ -27,7 +39,7 @@ func main() {
 	hlog.Init()
 
 	ctx := context.TODO()
-	dryRun := os.Getenv("CONFIRM") != "true"
+	dryRun := !*confirm
 
 	if dryRun {
 		log.WithContext(ctx).Info("Running in dry run mode")

--- a/backend/scripts/migrate-error-segments/main.go
+++ b/backend/scripts/migrate-error-segments/main.go
@@ -91,7 +91,7 @@ func main() {
 		// check if segment already exists
 		// NOTE: n+1 query here, but this is a one-off migration with <100 segments
 		var exists bool
-		if err := db.WithContext(ctx).Model(savedSegment).Select("COUNT(*) > 0").Find(&exists).Error; err != nil {
+		if err := db.WithContext(ctx).Model(model.SavedSegment{}).Select("COUNT(*) > 0").Where(savedSegment).Find(&exists).Error; err != nil {
 			log.WithContext(ctx).Errorf("error checking for existing saved segment %v", err)
 			errorCount++
 			continue

--- a/backend/scripts/migrate-error-segments/main.go
+++ b/backend/scripts/migrate-error-segments/main.go
@@ -91,7 +91,9 @@ func main() {
 		}
 
 		// create new saved segment
-		if !dryRun {
+		if dryRun {
+			log.WithContext(ctx).Infof("would migrate segment %d: %s", segment.ID, savedSegment.Params)
+		} else {
 			if err := db.WithContext(ctx).Create(&savedSegment).Error; err != nil {
 				log.WithContext(ctx).Errorf("error migrating error segment %d, %v", segment.ID, err)
 				errorCount++

--- a/backend/scripts/migrate-error-segments/main_test.go
+++ b/backend/scripts/migrate-error-segments/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/stretchr/testify/assert"
+)
+
+// Note: no between or matches cases for errors
+var testCases = []struct {
+	input          *string
+	expectedOutput *string
+}{
+	{
+		nil,
+		nil,
+	},
+	{
+		ptr.String(`{"date_range":null,"browser":null,"os":null,"visited_url":null,"event":null,"state":"OPEN"}`),
+		nil,
+	},
+	{
+		ptr.String(`{"Query":"{\"isAnd\":true,\"rules\":[[\"error_state\",\"is\",\"OPEN\"]],\"dateRange\":{\"start_date\":\"2023-12-30T03:49:22.475Z\",\"end_date\":\"2024-01-29T03:49:22.475Z\"}}"}`),
+		ptr.String("status=OPEN"),
+	},
+	{
+		ptr.String(`{"date_range":null,"browser":null,"os":null,"visited_url":null,"event":null,"state":null,"query":"{\"isAnd\":true,\"rules\":[[\"error_state\",\"is\",\"OPEN\"],[\"error-field_timestamp\",\"between_date\",\"30 days\"],[\"error_state\",\"is\",\"RESOLVED\"]]}"}`),
+		ptr.String("status=OPEN status=RESOLVED"),
+	},
+	{
+		ptr.String(`{"date_range":null,"browser":null,"os":null,"visited_url":null,"event":null,"state":"OPEN","query":"{\"isAnd\":true,\"rules\":[[\"error_state\",\"is\",\"OPEN\"],[\"error-field_timestamp\",\"between_date\",\"30 days\"],[\"error-field_browser\",\"is\",\"Chrome\"],[\"error-field_browser\",\"is\",\"Chrome\"],[\"error-field_environment\",\"is_not\",\"production\"]]}"}`),
+		ptr.String("status=OPEN browser=Chrome browser=Chrome environment!=production"),
+	},
+	{
+		ptr.String(`{"date_range":null,"browser":null,"os":null,"visited_url":null,"event":null,"state":null,"query":"{\"isAnd\":true,\"rules\":[[\"error_state\",\"is\",\"OPEN\"],[\"error-field_visited_url\",\"not_contains\",\"localhost\"]]}"}`),
+		ptr.String("status=OPEN visited_url!=*localhost*"),
+	},
+	{
+		ptr.String(`{"date_range":null,"browser":null,"os":null,"visited_url":null,"event":null,"state":null,"query":"{\"isAnd\":false,\"rules\":[[\"error_state\",\"is\",\"OPEN\"],[\"error-field_visited_url\",\"not_contains\",\"localhost\"],[\"error-field_browser\",\"matches\",\".+\\\\d\"]]}"}`),
+		ptr.String("status=OPEN OR visited_url!=*localhost* OR browser=\\.+\\d\\"),
+	},
+	{
+		ptr.String(`{"Query":"{\"isAnd\":true,\"rules\":[[\"error_state\",\"is\",\"OPEN\"],[\"error-field_browser\",\"is\",\"Chrome\"],[\"error-field_browser\",\"is\",\"Chrome\"],[\"error-field_environment\",\"is\",\"production\",\"prod\"]],\"dateRange\":{\"start_date\":\"2024-03-11T17:28:20.610Z\",\"end_date\":\"2024-04-10T17:28:20.610Z\"}}"}`),
+		ptr.String("status=OPEN browser=Chrome browser=Chrome environment=(production OR prod)"),
+	},
+	{
+		ptr.String(`{"Query":"{\"isAnd\":true,\"rules\":[[\"error_state\",\"is\",\"OPEN\"],[\"error-field_browser\",\"matches\",\".+\\\\d\"],[\"error-field_browser\",\"matches\",\".+\\\\s\"],[\"error-field_environment\",\"is\",\"production\",\"prod\"]],\"dateRange\":{\"start_date\":\"2024-03-11T20:04:35.411Z\",\"end_date\":\"2024-04-10T20:04:35.411Z\"}}"}`),
+		ptr.String("status=OPEN browser=\\.+\\d\\ browser=\\.+\\s\\ environment=(production OR prod)"),
+	},
+	{
+		ptr.String(`{"Query":"{\"isAnd\":true,\"rules\":[[\"error_state\",\"is\",\"OPEN\"],[\"error-field_browser\",\"matches\",\".+\\\\d\",\".+\\\\s\"],[\"error-field_environment\",\"is\",\"production\",\"prod\"]],\"dateRange\":{\"start_date\":\"2024-03-11T20:12:54.219Z\",\"end_date\":\"2024-04-10T20:12:54.219Z\"}}"}`),
+		ptr.String("status=OPEN (browser=\\.+\\d\\ OR browser=\\.+\\s\\) environment=(production OR prod)"),
+	},
+}
+
+func TestTranslateParams(t *testing.T) {
+	for _, tc := range testCases {
+		// Call the function with the test case
+		output, err := translateParams(tc.input)
+		assert.Nil(t, err)
+
+		if tc.expectedOutput == nil {
+			assert.Nil(t, output)
+		} else {
+			assert.Equal(t, *tc.expectedOutput, *output)
+		}
+	}
+}

--- a/backend/scripts/migrate-error-segments/main_test.go
+++ b/backend/scripts/migrate-error-segments/main_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// workaround for setting flag
+var _ = func() bool {
+	testing.Init()
+	return true
+}()
+
 // Note: no between or matches cases for errors
 var testCases = []struct {
 	input          *string
@@ -51,6 +57,10 @@ var testCases = []struct {
 	{
 		ptr.String(`{"Query":"{\"isAnd\":true,\"rules\":[[\"error_state\",\"is\",\"OPEN\"],[\"error-field_browser\",\"matches\",\".+\\\\d\",\".+\\\\s\"],[\"error-field_environment\",\"is\",\"production\",\"prod\"]],\"dateRange\":{\"start_date\":\"2024-03-11T20:12:54.219Z\",\"end_date\":\"2024-04-10T20:12:54.219Z\"}}"}`),
 		ptr.String("status=OPEN (browser=\\.+\\d\\ OR browser=\\.+\\s\\) environment=(production OR prod)"),
+	},
+	{
+		ptr.String(`{"Query":"{\"isAnd\":true,\"rules\":[[\"error_state\",\"is\",\"OPEN\"],[\"error-field_browser\",\"is\",\"Chrome\"],[\"error-field_environment\",\"is\",\"dev\",\"cameron-localhost\"],[\"error-field_secure_session_id\",\"contains\",\"a\",\"b\"],[\"error-field_os_name\",\"matches\",\".+\\\\d.+\",\".+\\\\s.+\"]],\"dateRange\":{\"start_date\":\"2024-03-11T20:56:06.523Z\",\"end_date\":\"2024-04-10T20:56:06.523Z\"}}"}`),
+		ptr.String("status=OPEN browser=Chrome environment=(dev OR cameron-localhost) secure_session_id=(*a* OR *b*) (os_name=\\.+\\d.+\\ OR os_name=\\.+\\s.+\\)"),
 	},
 }
 


### PR DESCRIPTION
## Summary
Add a task to convert the error segments to the new saved segment table.

https://www.loom.com/share/75b6865fb9734967ba04744e9db86f4e

## How did you test this change?
1) Create a saved search for errors
2) Run the task in dry run mode (`doppler run -- go run backend/scripts/migrate-error-segments/main.go`)
- [ ] No queries created
- [ ] Correct number of queries to be updated
3) Run the task in confirm mode (`doppler run -- go run backend/scripts/migrate-error-segments/main.go -confirm=true`)
- [ ] Correct queries created
4) Run again in confirm mode
- [ ] No duplicate queries created

## Are there any deployment considerations?
1. Run a dry run to confirm working
2. Run the task

## Does this work require review from our design team?
N/A
