### PR TITLE
report more client events

### DIFF
--- a/.changeset/cuddly-carrots-eat.md
+++ b/.changeset/cuddly-carrots-eat.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+report more custom events from the client

--- a/frontend/src/pages/Player/PlayerHook/PlayerState.ts
+++ b/frontend/src/pages/Player/PlayerHook/PlayerState.ts
@@ -11,7 +11,10 @@ import {
 	SessionResults,
 	TimelineIndicatorEvent,
 } from '@graph/schemas'
-import { usefulEvent } from '@pages/Player/components/EventStreamV2/utils'
+import {
+	NavigationEvent,
+	usefulEvent,
+} from '@pages/Player/components/EventStreamV2/utils'
 import {
 	HighlightEvent,
 	HighlightJankPayload,
@@ -496,7 +499,13 @@ export const PlayerReducer = (
 				switch (action.event.data.tag) {
 					case 'Navigate':
 					case 'Reload':
-						s.currentUrl = action.event.data.payload as string
+						if (typeof action.event.data.payload === 'object') {
+							s.currentUrl = (
+								action.event.data.payload as NavigationEvent
+							).url
+						} else {
+							s.currentUrl = action.event.data.payload as string
+						}
 						break
 				}
 			}
@@ -604,7 +613,12 @@ const initReplayer = (
 
 	const onlyUrlEvents = getAllUrlEvents(events)
 	if (onlyUrlEvents.length >= 1) {
-		s.currentUrl = onlyUrlEvents[0].data.payload
+		const event = onlyUrlEvents[0].data.payload
+		if (typeof event === 'object') {
+			s.currentUrl = event.url
+		} else {
+			s.currentUrl = event
+		}
 	}
 	s.performancePayloads = getAllPerformanceEvents(events)
 	s.jankPayloads = getAllJankEvents(events)

--- a/frontend/src/pages/Player/SessionLevelBar/utils/utils.ts
+++ b/frontend/src/pages/Player/SessionLevelBar/utils/utils.ts
@@ -1,3 +1,4 @@
+import { NavigationEvent } from '@pages/Player/components/EventStreamV2/utils'
 import { customEvent } from '@rrweb/types'
 
 import {
@@ -25,7 +26,7 @@ export const findFirstEventOfType = (
 }
 
 export const findLatestUrl = (
-	urlEvents: customEvent<string>[],
+	urlEvents: customEvent<string | NavigationEvent>[],
 	currentTime: number,
 ) => {
 	if (urlEvents.length === 0) {
@@ -45,6 +46,10 @@ export const findLatestUrl = (
 		i++
 	}
 
+	if (typeof latestUrl === 'object') {
+		return (latestUrl as NavigationEvent).url
+	}
+
 	return latestUrl
 }
 
@@ -59,7 +64,7 @@ export const getAllUrlEvents = (events: HighlightEvent[]) => {
 		}
 	})
 
-	return urlEvents as customEvent<string>[]
+	return urlEvents as customEvent<string | NavigationEvent>[]
 }
 
 export const getBrowserExtensionScriptURLs = (events: HighlightEvent[]) => {

--- a/frontend/src/pages/Player/StreamElement/StreamElement.tsx
+++ b/frontend/src/pages/Player/StreamElement/StreamElement.tsx
@@ -1,5 +1,6 @@
 /// <reference types="vite-plugin-svgr/client" />
 
+import { CustomEventPayload } from '@pages/Player/components/EventStreamV2/utils'
 import WebVitalSimpleRenderer from '@pages/Player/StreamElement/Renderers/WebVitals/WebVitalRender'
 import React from 'react'
 import { EventType } from 'rrweb'
@@ -20,7 +21,7 @@ export const getEventRenderDetails = (
 		displayValue: '',
 	}
 	if (e.type === EventType.Custom) {
-		const payload = e.data.payload as any
+		const payload = e.data.payload as CustomEventPayload
 
 		details.title = e.data.tag
 		switch (e.data.tag) {
@@ -65,10 +66,10 @@ export const getEventRenderDetails = (
 				details.displayValue = `Total clicks: ${payload}`
 				break
 			default:
-				details.displayValue = payload
+				details.displayValue = JSON.stringify(payload)
 				break
 		}
-		details.payload = e.data.payload as string
+		details.payload = JSON.stringify(e.data.payload)
 	}
 
 	return details

--- a/frontend/src/pages/Player/components/EventStreamV2/utils.ts
+++ b/frontend/src/pages/Player/components/EventStreamV2/utils.ts
@@ -2,6 +2,25 @@ import { HighlightEvent } from '@pages/Player/HighlightEvent'
 import { eventWithTime } from '@rrweb/types'
 import { EventType } from 'rrweb'
 
+export type NavigationEvent = {
+	'visited-url': string
+	url: string
+	reload: boolean
+}
+export type ClickEvent = {
+	clickTextContent: string
+	clickSelector: string
+	clickTarget: string
+}
+export type ReferrerEvent = {
+	referrer: string
+}
+export type CustomEventPayload =
+	| string
+	| NavigationEvent
+	| ClickEvent
+	| ReferrerEvent
+
 // used in filter() type methods to fetch events we want
 export const usefulEvent = (e: eventWithTime): boolean => {
 	if (e.type === EventType.Custom) {
@@ -120,18 +139,37 @@ export const getFilteredEvents = (
 					})
 				case 'Navigate':
 					return searchTokens.some((searchToken) => {
+						if (typeof event.data.payload === 'object') {
+							return (event.data.payload as NavigationEvent).url
+								.toLowerCase()
+								.includes(searchToken)
+						}
 						return (event.data.payload as string)
 							.toLowerCase()
 							.includes(searchToken)
 					})
 				case 'Referrer':
 					return searchTokens.some((searchToken) => {
+						if (typeof event.data.payload === 'object') {
+							return (
+								event.data.payload as ReferrerEvent
+							).referrer
+								.toLowerCase()
+								.includes(searchToken)
+						}
 						return (event.data.payload as string)
 							.toLowerCase()
 							.includes(searchToken)
 					})
 				case 'Click':
 					return searchTokens.some((searchToken) => {
+						if (typeof event.data.payload === 'object') {
+							return (
+								event.data.payload as ClickEvent
+							).clickTextContent
+								.toLowerCase()
+								.includes(searchToken)
+						}
 						return (event.data.payload as string)
 							.toLowerCase()
 							.includes(searchToken)

--- a/sdk/client/src/index.tsx
+++ b/sdk/client/src/index.tsx
@@ -491,6 +491,7 @@ export class Highlight {
 				delete obj[key]
 			}
 		})
+		this.addCustomEvent<object>(typeArg?.eventName || 'Custom', obj)
 		this._worker.postMessage({
 			message: {
 				type: MessageType.Properties,
@@ -773,10 +774,9 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 						document.referrer.includes(window.location.origin)
 					)
 				) {
-					this.addCustomEvent<string>('Referrer', document.referrer)
 					this.addProperties(
 						{ referrer: document.referrer },
-						{ type: 'session' },
+						{ type: 'session', eventName: 'Referrer' },
 					)
 				}
 			}
@@ -904,18 +904,14 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			this.listeners.push(
 				PathListener((url: string) => {
 					if (this.reloaded) {
-						this.addCustomEvent<string>('Reload', url)
 						this.reloaded = false
-						highlightThis.addProperties(
-							{ reload: true },
-							{ type: 'session' },
-						)
-					} else {
-						this.addCustomEvent<string>('Navigate', url)
 					}
 					highlightThis.addProperties(
-						{ 'visited-url': url },
-						{ type: 'session' },
+						{ 'visited-url': url, url, reload: this.reloaded },
+						{
+							type: 'session',
+							eventName: this.reloaded ? 'Reload' : 'Navigate',
+						},
 					)
 				}),
 			)
@@ -928,9 +924,6 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 			)
 			this.listeners.push(
 				ClickListener((clickTarget, event) => {
-					if (clickTarget) {
-						this.addCustomEvent('Click', clickTarget)
-					}
 					let selector = null
 					let textContent = null
 					if (event && event.target) {
@@ -946,8 +939,9 @@ SessionSecureID: ${this.sessionData.sessionSecureID}`,
 						{
 							clickTextContent: textContent,
 							clickSelector: selector,
+							clickTarget,
 						},
-						{ type: 'session' },
+						{ type: 'session', eventName: 'Click' },
 					)
 				}),
 			)

--- a/sdk/client/src/workers/types.ts
+++ b/sdk/client/src/workers/types.ts
@@ -7,6 +7,21 @@ export type Source = 'segment' | undefined
 export type PropertyType = {
 	type?: 'track' | 'session'
 	source?: Source
+	eventName?:
+		| 'Click'
+		| 'Focus'
+		| 'Reload'
+		| 'Navigate'
+		| 'Segment'
+		| 'Track'
+		| 'Comments'
+		| 'Viewport'
+		| 'Identify'
+		| 'Web Vitals'
+		| 'Referrer'
+		| 'RageClicks'
+		| 'TabHidden'
+		| 'Custom'
 }
 
 export enum MessageType {


### PR DESCRIPTION
## Summary

A customer suggested that our client sdk should report additional track events
depending on certain user actions. The change ensures that automatically reported attributes
such as `clickTextContent` become session attributes that can be visible in the replay events.

## How did you test this change?

loom

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
