### PR TITLE
Redirect Unknown paths to `/sessions`

### DIFF
--- a/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
@@ -11,7 +11,7 @@ import { useSearchContext } from '@pages/Sessions/SearchContext/SearchContext'
 import { SetupRouter } from '@pages/Setup/SetupRouter/SetupRouter'
 import { usePreloadErrors, usePreloadSessions } from '@util/preload'
 import React, { Suspense } from 'react'
-import { Route, Routes } from 'react-router-dom'
+import { Navigate, Route, Routes } from 'react-router-dom'
 
 import { DEMO_PROJECT_ID } from '@/components/DemoWorkspaceButton/DemoWorkspaceButton'
 import { RelatedResourcePanel } from '@/components/RelatedResources/RelatedResourcePanel'
@@ -24,6 +24,8 @@ import { TracesPage } from '@/pages/Traces/TracesPage'
 
 const Buttons = React.lazy(() => import('../../pages/Buttons/Buttons'))
 const HitTargets = React.lazy(() => import('../../pages/Buttons/HitTargets'))
+
+const BASE_PATH = 'sessions'
 
 const ApplicationRouter: React.FC = () => {
 	const { projectId } = useNumericProjectId()
@@ -104,6 +106,10 @@ const ApplicationRouter: React.FC = () => {
 								element={<DashboardRouter />}
 							/>
 						)}
+						<Route
+							path="*"
+							element={<Navigate to={BASE_PATH} replace />}
+						/>
 					</>
 				) : (
 					<Route path="*" element={<SignInRedirect />} />


### PR DESCRIPTION
## Summary
We used to direct unknown paths to the dashboards router, but that was [recently changed](https://github.com/highlight/highlight/pull/8212/files#diff-fac0964fe369c7d6e76340f7efb67834b3cc1442e4ecece6acb3f28026b8bbc0L109). Update any unknown routes to redirect to sessions.

## How did you test this change?
1. Navigate to `/`
- [ ] Sessions page loads
2. Navigate to `/unknown-route/5`
- [ ] Sessions page loads
3. Navigate to `/errors`
- [ ] Errors page loads

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
