### PR TITLE
Some new error query fixes

### DIFF
--- a/backend/clickhouse/errors.go
+++ b/backend/clickhouse/errors.go
@@ -714,7 +714,6 @@ func (client *Client) QueryErrorGroups(ctx context.Context, projectId int, count
 
 func readErrorGroups(params modelInputs.QueryInput, projectId int) (*sqlbuilder.SelectBuilder, error) {
 	sb := sqlbuilder.NewSelectBuilder()
-	sb.From(ErrorGroupsTableConfig.TableName)
 	sb.From(fmt.Sprintf("%s FINAL", ErrorGroupsTableConfig.TableName))
 	sb.Select("ID, count() OVER() AS total")
 


### PR DESCRIPTION
## Summary
Fix some backend bugs with the new error queries:
- Add order by to error group search
- Use `FINAL` tables
- Add timestamp clauses to error object search
- Pull out order by, group by, and select to higher level functions

## How did you test this change?
Confirmed working in https://github.com/highlight/highlight/pull/8179

## Are there any deployment considerations?
N/A - not used in prod

## Does this work require review from our design team?
N/A
