### PR TITLE
Fix empty flame graph

### DIFF
--- a/frontend/src/pages/Traces/TraceFlameGraph.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraph.tsx
@@ -348,7 +348,7 @@ export const TraceFlameGraph: React.FC = () => {
 					debounce(handleScroll, 50)(currentTarget)
 				}}
 			>
-				{width && (
+				{!!width && (
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
 						height={height + 20}
@@ -443,7 +443,7 @@ export const TraceFlameGraph: React.FC = () => {
 					</svg>
 				)}
 
-				{hoveredSpan && (
+				{!!hoveredSpan && (
 					<Box
 						ref={tooltipRef}
 						position="fixed"


### PR DESCRIPTION
## Summary
0 showing up in the flame graph
![image](https://github.com/highlight/highlight/assets/17744174/2697f8c8-cb8e-4cb6-98f5-bdb91a6c9cf8)


## How did you test this change?
1) View trace [here](https://app.highlight.io/1/sessions/o1yhwFT9CRWjM7xYdvtI2Gt51guS?network-resource-id=264&page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue&segment=%22undefined%22)

![Screenshot 2024-04-11 at 6 06 29 PM](https://github.com/highlight/highlight/assets/17744174/c44adc2d-2ada-4e9a-9340-6a5095ecc06b)

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
