### PR TITLE
create materialized column for TraceAttributes

### DIFF
--- a/backend/clickhouse/migrations/000097_materialized_column.down.sql
+++ b/backend/clickhouse/migrations/000097_materialized_column.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE traces RESET SETTING min_rows_for_wide_part,
+    min_bytes_for_wide_part;
+ALTER TABLE traces_by_id RESET SETTING min_rows_for_wide_part,
+    min_bytes_for_wide_part;
+ALTER TABLE traces_sampling RESET SETTING min_rows_for_wide_part,
+    min_bytes_for_wide_part;
+ALTER TABLE traces DROP COLUMN IF EXISTS HighlightType;

--- a/backend/clickhouse/migrations/000097_materialized_column.up.sql
+++ b/backend/clickhouse/migrations/000097_materialized_column.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE traces
+MODIFY SETTING min_rows_for_wide_part = 0,
+    min_bytes_for_wide_part = 0;
+ALTER TABLE traces_by_id
+MODIFY SETTING min_rows_for_wide_part = 0,
+    min_bytes_for_wide_part = 0;
+ALTER TABLE traces_sampling
+MODIFY SETTING min_rows_for_wide_part = 0,
+    min_bytes_for_wide_part = 0;
+ALTER TABLE traces
+ADD COLUMN IF NOT EXISTS HighlightType String MATERIALIZED TraceAttributes ['highlight.type'];


### PR DESCRIPTION
## Summary
- applies some settings to `traces` and related tables for new parts to be created as wide parts
- adds materialized column for HighlightType

https://highlightcorp.slack.com/archives/C02CJANPHQS/p1712941635157209
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran script locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- will backfill data for the materialized column after deployment, then will cut over code to refer to this column
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
