### PR TITLE
fix log timestamp clamping

### DIFF
--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -210,6 +210,7 @@ func (o *Handler) HandleTrace(w http.ResponseWriter, r *http.Request) {
 						resource: &resource,
 						span:     &span,
 						event:    &event,
+						curTime:  curTime,
 					})
 					if err != nil {
 						lg(ctx, fields).WithError(err).Info("failed to extract fields from trace")


### PR DESCRIPTION
## Summary
- saw more merge activity for the `logs` table than expected. was seeing old logs partitions with multiple parts, seemingly from recent inserts to the logs table.
- digging into the code, it looks like I missed setting `curTime` in one of the places we call `extractFields`. when this is not set, clamping is not applied
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran backend locally to make sure traces/logs were still ingested
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no, will monitor 
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
