### PR TITLE
Set width for flame graph

### DIFF
--- a/frontend/src/pages/Traces/TraceFlameGraph.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraph.tsx
@@ -20,7 +20,6 @@ import {
 } from 'react'
 
 import LoadingBox from '@/components/LoadingBox'
-import { useRelatedResource } from '@/components/RelatedResources/hooks'
 import { useHTMLElementEvent } from '@/hooks/useHTMLElementEvent'
 import { ZOOM_SCALING_FACTOR } from '@/pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/TimelineIndicatorsBarGraph'
 import {
@@ -68,7 +67,6 @@ export const TraceFlameGraph: React.FC = () => {
 		x: 0,
 		y: 0,
 	})
-	const { panelWidth } = useRelatedResource()
 
 	const height = useMemo(() => {
 		if (!traces.length) return 260
@@ -234,7 +232,7 @@ export const TraceFlameGraph: React.FC = () => {
 			setWidth(svgContainerRef.current?.clientWidth)
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [loading, panelWidth])
+	}, [loading, svgContainerRef.current?.clientWidth])
 
 	const [dragging, setDragging] = useState(false)
 	const [initialDragX, setInitialDragX] = useState(0)


### PR DESCRIPTION
## Summary
For network resources, it appears the width is not being updated when the ref component is mounted, resulting in missing flame graph data.

Video TBD

## How did you test this change?
1) View [this trace](https://app.highlight.io/1/sessions/o1yhwFT9CRWjM7xYdvtI2Gt51guS?network-resource-id=264&page=1&query=and%7C%7Ccustom_processed%2Cis%2Ctrue&segment=%22undefined%22), and confirm the flame graph is correctly displayed
2) Confirm the trace can be viewed from the traces search page
3) Confirm the trace can be viewed from the logs search page

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A