### PR TITLE
Fix flame graph not appearing on network resources

### DIFF
--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
@@ -46,22 +46,17 @@ enum WebSocketTabs {
 }
 
 export const NetworkResourcePanel = () => {
-	const { projectId } = useProjectId()
 	const { inPanel } = useSessionParams()
 	const networkResourceDialog = Ariakit.useDialogStore()
 	const networkResourceDialogState = networkResourceDialog.getState()
 	const { activeNetworkResourceId, setActiveNetworkResourceId } =
 		useActiveNetworkResourceId()
 
-	const { session } = useReplayerContext()
 	const { resources } = useResourcesContext()
 	const resourceIdx = resources.findIndex(
 		(r) => activeNetworkResourceId === r.id,
 	)
 	const resource = resources[resourceIdx] as NetworkResource | undefined
-	const traceId = useMemo(() => {
-		return resource?.requestResponsePairs?.request?.id
-	}, [resource?.requestResponsePairs?.request?.id])
 
 	const hide = useCallback(() => {
 		setActiveNetworkResourceId(undefined)
@@ -126,16 +121,7 @@ export const NetworkResourcePanel = () => {
 				(resource.initiatorType === 'websocket' ? (
 					<WebSocketDetails resource={resource} hide={hide} />
 				) : (
-					<TraceProvider
-						projectId={projectId}
-						traceId={traceId}
-						session_secure_id={session?.secure_id}
-					>
-						<NetworkResourceDetails
-							resource={resource}
-							hide={hide}
-						/>
-					</TraceProvider>
+					<NetworkResourceDetails resource={resource} hide={hide} />
 				))}
 		</Ariakit.Dialog>
 	)
@@ -148,6 +134,10 @@ function NetworkResourceDetails({
 	resource: NetworkResource
 	hide: () => void
 }) {
+	const { projectId } = useProjectId()
+	const traceId = useMemo(() => {
+		return resource?.requestResponsePairs?.request?.id
+	}, [resource?.requestResponsePairs?.request?.id])
 	const { resources } = useResourcesContext()
 	const [activeTab, setActiveTab] = useState<NetworkRequestTabs>(
 		NetworkRequestTabs.Info,
@@ -341,7 +331,13 @@ function NetworkResourceDetails({
 				</Tabs.Panel>
 				{isNetworkRequest && (
 					<Tabs.Panel id={NetworkRequestTabs.Trace}>
-						<NetworkResourceTrace />
+						<TraceProvider
+							projectId={projectId}
+							traceId={traceId}
+							secureSessionId={session?.secure_id}
+						>
+							<NetworkResourceTrace />
+						</TraceProvider>
 					</Tabs.Panel>
 				)}
 			</Tabs>

--- a/frontend/src/pages/Traces/TraceFlameGraph.tsx
+++ b/frontend/src/pages/Traces/TraceFlameGraph.tsx
@@ -20,7 +20,6 @@ import {
 } from 'react'
 
 import LoadingBox from '@/components/LoadingBox'
-import { useRelatedResource } from '@/components/RelatedResources/hooks'
 import { useHTMLElementEvent } from '@/hooks/useHTMLElementEvent'
 import { ZOOM_SCALING_FACTOR } from '@/pages/Player/Toolbar/TimelineIndicators/TimelineIndicatorsBarGraph/TimelineIndicatorsBarGraph'
 import {
@@ -68,7 +67,6 @@ export const TraceFlameGraph: React.FC = () => {
 		x: 0,
 		y: 0,
 	})
-	const { panelWidth } = useRelatedResource()
 
 	const height = useMemo(() => {
 		if (!traces.length) return 260
@@ -231,10 +229,18 @@ export const TraceFlameGraph: React.FC = () => {
 
 	useEffect(() => {
 		if (svgContainerRef.current) {
-			setWidth(svgContainerRef.current?.clientWidth)
+			const handleResize = debounce((entries: ResizeObserverEntry[]) => {
+				setWidth(entries[0].contentRect.width)
+			}, 50)
+
+			const resizeObserver = new ResizeObserver(handleResize)
+			resizeObserver.observe(svgContainerRef.current)
+
+			return () => {
+				resizeObserver.disconnect()
+			}
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [loading, panelWidth])
+	}, [])
 
 	const [dragging, setDragging] = useState(false)
 	const [initialDragX, setInitialDragX] = useState(0)

--- a/frontend/src/pages/Traces/TraceProvider.tsx
+++ b/frontend/src/pages/Traces/TraceProvider.tsx
@@ -35,7 +35,7 @@ export const TraceContext = createContext<TraceContext>({} as TraceContext)
 type Props = {
 	projectId: string
 	traceId?: string
-	session_secure_id?: string
+	secureSessionId?: string
 	spanId?: string
 }
 
@@ -43,7 +43,7 @@ export const TraceProvider: React.FC<React.PropsWithChildren<Props>> = ({
 	children,
 	projectId,
 	traceId,
-	session_secure_id,
+	secureSessionId,
 	spanId,
 }) => {
 	const [hoveredSpan, setHoveredSpan] = useState<FlameGraphSpan>()
@@ -54,7 +54,7 @@ export const TraceProvider: React.FC<React.PropsWithChildren<Props>> = ({
 		variables: {
 			project_id: projectId!,
 			trace_id: traceId!,
-			session_secure_id,
+			session_secure_id: secureSessionId,
 		},
 		onCompleted: (data) => {
 			if (spanId) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -65,7 +65,7 @@
 		}
 	},
 	"dependencies": {
-		"@ariakit/react": "^0.4.2",
+		"@ariakit/react": "^0.4.5",
 		"@rehookify/datepicker": "^4.1.5",
 		"@storybook/test": "^8.0.4",
 		"@vanilla-extract/css": "^1.13.0",

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -74,7 +74,6 @@ const TabList: React.FC<TabListProps> = ({
 
 type TabProps = Ariakit.TabProps & {
 	children: string
-	id: string
 	badgeText?: string
 	icon?: TagProps['icon']
 }
@@ -144,10 +143,15 @@ const Tab: React.FC<TabProps> = ({ badgeText, children, icon, ...props }) => {
 
 type TabPanelProps = React.PropsWithChildren<Ariakit.TabPanelProps>
 
-const TabPanel: React.FC<TabPanelProps> = ({ children, ...props }) => {
+const TabPanel: React.FC<TabPanelProps> = ({
+	children,
+	unmountOnHide = true,
+	...props
+}) => {
 	return (
 		<Ariakit.TabPanel
 			{...props}
+			unmountOnHide={unmountOnHide}
 			render={
 				<Stack direction="column" flexGrow={1} id={props.id}>
 					{children}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,36 +1046,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ariakit/core@npm:0.4.2":
-  version: 0.4.2
-  resolution: "@ariakit/core@npm:0.4.2"
-  checksum: 10/68ac1d7759fd887e2e0944e767fadefe8518c4e58cd6ff37524ca2700354948d89607ac47c54cdf53d9348be99c703d1d16e8d170085795e79fe3f18a9bb5012
+"@ariakit/core@npm:0.4.5":
+  version: 0.4.5
+  resolution: "@ariakit/core@npm:0.4.5"
+  checksum: 10/9feeeef854fd69902845e8ae1dfe297e42fe88d9d6ff001f296b7cb5bf94a46b8c9ba973b45afe5306a5c8e6cc67bbce57ba715b30659769c427e0fe244c95d7
   languageName: node
   linkType: hard
 
-"@ariakit/react-core@npm:0.4.2":
-  version: 0.4.2
-  resolution: "@ariakit/react-core@npm:0.4.2"
+"@ariakit/react-core@npm:0.4.5":
+  version: 0.4.5
+  resolution: "@ariakit/react-core@npm:0.4.5"
   dependencies:
-    "@ariakit/core": "npm:0.4.2"
+    "@ariakit/core": "npm:0.4.5"
     "@floating-ui/dom": "npm:^1.0.0"
     use-sync-external-store: "npm:^1.2.0"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 10/2af0f9d8d4822304a2d3109f87fb84151ff0a6ed0eb916d6093f1f1700c5ed73ab82315957511a353895ef129d1a57d9fd2afa8b15a3ab7835b69da252ffc0d8
+  checksum: 10/9e2ad03ca9c1fbe7e56762243c8e4825a555ad8453f8e8f73b7f84e1acd6b8580550e0b7c9d69293539dc6ee92c87b10bdca9490bf9442a1247913d5ddb1af6a
   languageName: node
   linkType: hard
 
-"@ariakit/react@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "@ariakit/react@npm:0.4.2"
+"@ariakit/react@npm:^0.4.5":
+  version: 0.4.5
+  resolution: "@ariakit/react@npm:0.4.5"
   dependencies:
-    "@ariakit/react-core": "npm:0.4.2"
+    "@ariakit/react-core": "npm:0.4.5"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 10/21b4f1de04f3cac82fc3f6929ee2163db6844f8eaad47c5f394592a02f5c0a4045eb5103fe3e78b7ffc4e89c8d67000e98ea064487c6400053b8aec9cde94450
+  checksum: 10/829855669048978e1e6729f7322c0239468da57ada4f693fcea190138a75e696d9eaf24968f3cd50acb9ec96357a8383c99e7279f49cfcf6cd6ec4cd49eee2d4
   languageName: node
   linkType: hard
 
@@ -14870,7 +14870,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@highlight-run/ui@workspace:packages/ui"
   dependencies:
-    "@ariakit/react": "npm:^0.4.2"
+    "@ariakit/react": "npm:^0.4.5"
     "@babel/core": "npm:^7.19.3"
     "@capsizecss/core": "npm:^3.0.0"
     "@capsizecss/metrics": "npm:^0.3.0"


### PR DESCRIPTION
## Summary

Updates the behavior of tab content to not be mounted until the tab is shown. This is consistent with the behavior we had in our old `Tabs` component and fixes a bug where we don't calculate the `width` property on the trace flame graph when put behind a tab on the network resource panel.

In order to get this behavior working we also needed to upgrade Ariakit because there was a bug where the tabs would _never_ render when using the `unmountOnHide` prop.

## How did you test this change?

View a fetch network resource in the session dev tools and ensure the trace flame graph is rendered correctly.

## Are there any deployment considerations?

N/A

## Does this work require review from our design team?

N/A