### PR TITLE
fall back to unversioned sourcemaps

### DIFF
--- a/.changeset/sixty-pandas-travel.md
+++ b/.changeset/sixty-pandas-travel.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/sourcemap-uploader': patch
+---
+
+update sourcemap uploader log line

--- a/.changeset/wild-chairs-melt.md
+++ b/.changeset/wild-chairs-melt.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/next': minor
+---
+
+generate server sourcemaps for next.js code

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -361,8 +361,8 @@ func (r *Resolver) GetErrorAppVersion(ctx context.Context, errorObj *model.Error
 	}
 
 	// guess version from error service
-	if errorObj.ServiceName != "" && errorObj.ServiceVersion != "" {
-		return pointy.String(fmt.Sprintf("%s-%s", errorObj.ServiceName, errorObj.ServiceVersion))
+	if errorObj.ServiceVersion != "" {
+		return pointy.String(errorObj.ServiceVersion)
 	}
 
 	return nil

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -356,17 +356,21 @@ func (r *Resolver) GetErrorAppVersion(ctx context.Context, errorObj *model.Error
 	var session *model.Session
 	if err := r.DB.WithContext(ctx).Model(&session).
 		Where("id = ?", errorObj.SessionID).
-		Pluck("app_version", &session).Error; err != nil {
-		if !e.Is(err, gorm.ErrRecordNotFound) {
-			return nil
-		}
+		Pluck("app_version", &session).Error; err == nil && session.AppVersion != nil {
+		return session.AppVersion
 	}
-	return session.AppVersion
+
+	// guess version from error service
+	if errorObj.ServiceName != "" && errorObj.ServiceVersion != "" {
+		return pointy.String(fmt.Sprintf("%s-%s", errorObj.ServiceName, errorObj.ServiceVersion))
+	}
+
+	return nil
 }
 
-func (r *Resolver) getMappedStackTraceString(ctx context.Context, stackTrace []*publicModel.StackFrameInput, projectID int, errorObj *model.ErrorObject, version *string) (*string, []*privateModel.ErrorTrace, error) {
+func (r *Resolver) getMappedStackTraceString(ctx context.Context, stackTrace []*publicModel.StackFrameInput, projectID int, errorObj *model.ErrorObject) (*string, []*privateModel.ErrorTrace, error) {
 	var newMappedStackTraceString *string
-	mappedStackTrace, err := stacktraces.EnhanceStackTrace(ctx, stackTrace, projectID, version, r.StorageClient)
+	mappedStackTrace, err := stacktraces.EnhanceStackTrace(ctx, stackTrace, projectID, r.GetErrorAppVersion(ctx, errorObj), r.StorageClient)
 	if err != nil {
 		log.WithContext(ctx).Error(e.Wrapf(err, "error object: %+v", errorObj))
 	} else {
@@ -2189,11 +2193,7 @@ func (r *Resolver) ProcessBackendPayloadImpl(ctx context.Context, sessionSecureI
 		var stackFrameInput []*publicModel.StackFrameInput
 
 		if err := json.Unmarshal([]byte(v.StackTrace), &stackFrameInput); err == nil {
-			var version *string
-			if v.Service.Name != "" && v.Service.Version != "" {
-				version = pointy.String(fmt.Sprintf("%s-%s", v.Service.Name, v.Service.Version))
-			}
-			mapped, structured, err := r.getMappedStackTraceString(ctx, stackFrameInput, projectID, errorToInsert, version)
+			mapped, structured, err := r.getMappedStackTraceString(ctx, stackFrameInput, projectID, errorToInsert)
 			if err != nil {
 				log.WithContext(ctx).Errorf("Error generating mapped stack trace: %v", v.StackTrace)
 			} else if mapped != nil && *mapped != "null" {
@@ -2757,7 +2757,7 @@ func (r *Resolver) ProcessPayload(ctx context.Context, sessionSecureID string, e
 			}
 
 			var structuredStackTrace []*privateModel.ErrorTrace
-			mapped, structured, err := r.getMappedStackTraceString(ctx, v.StackTrace, projectID, errorToInsert, r.GetErrorAppVersion(ctx, errorToInsert))
+			mapped, structured, err := r.getMappedStackTraceString(ctx, v.StackTrace, projectID, errorToInsert)
 
 			if err != nil {
 				log.WithContext(ctx).Errorf("Error generating mapped stack trace: %v", v.StackTrace)

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -367,8 +367,7 @@ func TestHandleErrorAndGroup(t *testing.T) {
 					}
 				}
 
-				version := resolver.GetErrorAppVersion(context.Background(), &errorObj)
-				_, structuredStackTrace, err := resolver.getMappedStackTraceString(context.Background(), frames, 1, &errorObj, version)
+				_, structuredStackTrace, err := resolver.getMappedStackTraceString(context.Background(), frames, 1, &errorObj)
 				if err != nil {
 					t.Fatal(e.Wrap(err, "error making mapped stacktrace"))
 				}
@@ -715,5 +714,35 @@ func TestErrorIngestFilters(t *testing.T) {
 		matches = clickhouse.ErrorMatchesQuery(&errorObject, filters)
 		assert.True(t, matches)
 		assert.False(t, resolver.IsErrorIngested(ctx, project.ID, &errorObject))
+	})
+}
+
+func TestGetErrorAppVersion(t *testing.T) {
+	ctx := context.TODO()
+
+	util.RunTestWithDBWipe(t, resolver.DB, func(t *testing.T) {
+		session := &model.Session{
+			ServiceName: "foo",
+			AppVersion:  pointy.String("bar"),
+			Environment: "production",
+		}
+		assert.NoError(t, resolver.DB.Create(session).Error)
+
+		errorObject := model.ErrorObject{
+			Event: "Dang a React Minified error has occurred.",
+		}
+		version := resolver.GetErrorAppVersion(ctx, &errorObject)
+		assert.Nil(t, version)
+
+		errorObject.ServiceName = "yo"
+		errorObject.ServiceVersion = "dawg"
+		version = resolver.GetErrorAppVersion(ctx, &errorObject)
+		assert.NotNil(t, version)
+		assert.Equal(t, *version, "yo-dawg")
+
+		errorObject.SessionID = pointy.Int(session.ID)
+		version = resolver.GetErrorAppVersion(ctx, &errorObject)
+		assert.NotNil(t, version)
+		assert.Equal(t, *version, "bar")
 	})
 }

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -738,7 +738,7 @@ func TestGetErrorAppVersion(t *testing.T) {
 		errorObject.ServiceVersion = "dawg"
 		version = resolver.GetErrorAppVersion(ctx, &errorObject)
 		assert.NotNil(t, version)
-		assert.Equal(t, *version, "yo-dawg")
+		assert.Equal(t, *version, "dawg")
 
 		errorObject.SessionID = pointy.Int(session.ID)
 		version = resolver.GetErrorAppVersion(ctx, &errorObject)

--- a/backend/stacktraces/enhancer.go
+++ b/backend/stacktraces/enhancer.go
@@ -388,17 +388,20 @@ func processStackFrame(ctx context.Context, projectId int, version *string, stac
 
 	var sourceMapURL string
 	var sourceMapFileBytes []byte
-	if u.Scheme == "file" {
-		// if this is an electron file reference, treat it as a path so we can match a subdirectory
-		sourceMapURL, sourceMapFileBytes, err = getFileSourcemap(ctx, projectId, version, u.Path, storageClient, &stackTraceError)
-		if err != nil {
-			return nil, err, stackTraceError
+	var versions = []*string{version}
+	if versions[0] != nil {
+		versions = append(versions, nil)
+	}
+	for _, v := range versions {
+		if u.Scheme == "file" {
+			// if this is an electron file reference, treat it as a path so we can match a subdirectory
+			sourceMapURL, sourceMapFileBytes, err = getFileSourcemap(ctx, projectId, v, u.Path, storageClient, &stackTraceError)
+		} else {
+			sourceMapURL, sourceMapFileBytes, err = getURLSourcemap(ctx, projectId, v, stackTraceFileURL, stackTraceFilePath, stackFileNameIndex, storageClient, &stackTraceError)
 		}
-	} else {
-		sourceMapURL, sourceMapFileBytes, err = getURLSourcemap(ctx, projectId, version, stackTraceFileURL, stackTraceFilePath, stackFileNameIndex, storageClient, &stackTraceError)
-		if err != nil {
-			return nil, err, stackTraceError
-		}
+	}
+	if err != nil {
+		return nil, err, stackTraceError
 	}
 	sourceMapFileSize := len(sourceMapFileBytes)
 	stackTraceError.SourcemapFileSize = &sourceMapFileSize

--- a/backend/stacktraces/enhancer_test.go
+++ b/backend/stacktraces/enhancer_test.go
@@ -3,6 +3,7 @@ package stacktraces
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -20,6 +21,7 @@ type Testcase struct {
 	expectedStackTrace []modelInput.ErrorTrace
 	fetcher            fetcher
 	version            string
+	projectID          int
 	err                error
 }
 
@@ -217,6 +219,29 @@ func TestEnhanceStackTrace(t *testing.T) {
 			fetcher: DiskFetcher{},
 			err:     e.New(""),
 		},
+		"test map file resolution mapping": {
+			stackFrameInput: []*publicModelInput.StackFrameInput{
+				{
+					FileName:     ptr.String("/_next/server/app/(route-group-test)/[slug]/page-router-edge-test.js"),
+					LineNumber:   ptr.Int(1),
+					ColumnNumber: ptr.Int(422367),
+				},
+			},
+			expectedStackTrace: []modelInput.ErrorTrace{
+				{
+					FileName:     ptr.String("webpack://_N_E/./node_modules/next/dist/compiled/cookie/index.js"),
+					LineNumber:   ptr.Int(2),
+					ColumnNumber: ptr.Int(0),
+					FunctionName: ptr.String(""),
+					LineContent:  ptr.String("/*!\n"),
+					LinesBefore:  ptr.String("(()=>{\"use strict\";if(typeof __nccwpck_require__!==\"undefined\")__nccwpck_require__.ab=__dirname+\"/\";var e={};(()=>{var r=e;\n"),
+					LinesAfter:   ptr.String(" * cookie\n * Copyright(c) 2012-2014 Roman Shtylman\n * Copyright(c) 2015 Douglas Christopher Wilson\n * MIT Licensed\n */r.parse=parse;r.serialize=serialize;var i=decodeURIComponent;var t=encodeURIComponent;var a=/; */;var n=/^[\\u0009\\u0020-\\u007e\\u0080-\\u00ff]+$/;function parse(e,r){if(typeof e!==\"string\"){throw new TypeError(\"argument str must be a string\")}var t={};var n=r||{};var o=e.split(a);var s=n.decode||i;for(var p=0;p<o.length;p++){var f=o[p];var u=f.indexOf(\"=\");if(u<0){continue}var v=f.substr(0,u).trim();var c=f.substr(++u,f.length).trim();if('\"'==c[0]){c=c.slice(1,-1)}if(undefined==t[v]){t[v]=tryDecode(c,s)}}return t}function serialize(e,r,i){var a=i||{};var o=a.encode||t;if(typeof o!==\"function\"){throw new TypeError(\"option encode is invalid\")}if(!n.test(e)){throw new TypeError(\"argument name is invalid\")}var s=o(r);if(s&&!n.test(s)){throw new TypeError(\"argument val is invalid\")}var p=e+\"=\"+s;if(null!=a.maxAge){var f=a.maxAge-0;if(isNaN(f)||!isFinite(f)){throw new TypeError"),
+				},
+			},
+			version:   "version-a1b2c3",
+			projectID: 29954,
+			fetcher:   DiskFetcher{},
+		},
 		"test reflame": {
 			stackFrameInput: []*publicModelInput.StackFrameInput{
 				{
@@ -243,7 +268,7 @@ func TestEnhanceStackTrace(t *testing.T) {
 		t.Fatalf("error creating storage client: %v", err)
 	}
 
-	fsClient, err := storage.NewFSClient(ctx, "http://localhost:8082/public", "")
+	fsClient, err := storage.NewFSClient(ctx, "http://localhost:8082/public", "./test-files")
 	if err != nil {
 		t.Fatalf("error creating storage client: %v", err)
 	}
@@ -251,13 +276,18 @@ func TestEnhanceStackTrace(t *testing.T) {
 	// run tests
 	for _, client := range []storage.Client{s3Client, fsClient} {
 		for name, tc := range tests {
-			t.Run(name, func(t *testing.T) {
+			t.Run(fmt.Sprintf("%s/%v", name, client), func(t *testing.T) {
+				if tc.projectID == 0 {
+					tc.projectID = 1
+				} else if client == s3Client {
+					t.Skip("skipping project-specific test for s3 client")
+				}
 				var v *string
 				if tc.version != "" {
 					v = &tc.version
 				}
 				fetch = tc.fetcher
-				mappedStackTrace, err := EnhanceStackTrace(ctx, tc.stackFrameInput, 1, v, client)
+				mappedStackTrace, err := EnhanceStackTrace(ctx, tc.stackFrameInput, tc.projectID, v, client)
 				if err != nil {
 					if err.Error() == tc.err.Error() {
 						return

--- a/sdk/highlight-next/src/util/with-highlight-config.ts
+++ b/sdk/highlight-next/src/util/with-highlight-config.ts
@@ -82,10 +82,10 @@ const getDefaultOpts = async (
 	}
 
 	return {
+		// upload source maps even if config.productionBrowserSourceMaps is set to upload server maps
 		uploadSourceMaps:
 			isProdBuild &&
-			(highlightOpts?.uploadSourceMaps ??
-				(!config.productionBrowserSourceMaps && hasSourcemapApiKey)),
+			(highlightOpts?.uploadSourceMaps ?? hasSourcemapApiKey),
 		configureHighlightProxy: highlightOpts?.configureHighlightProxy ?? true,
 		apiKey: highlightOpts?.apiKey ?? '',
 		appVersion: highlightOpts?.appVersion ?? version ?? '',

--- a/sdk/highlight-next/src/util/with-highlight-config.ts
+++ b/sdk/highlight-next/src/util/with-highlight-config.ts
@@ -168,6 +168,9 @@ const getHighlightConfig = async (
 			if (config.webpack) {
 				originalConfig = config.webpack(webpackConfig, opts)
 			}
+			if (opts.isServer) {
+				originalConfig.devtool = 'source-map'
+			}
 
 			originalConfig.plugins.push(
 				new HighlightWebpackPlugin(

--- a/sourcemap-uploader/src/lib.ts
+++ b/sourcemap-uploader/src/lib.ts
@@ -208,5 +208,5 @@ function getS3Key(
 async function uploadFile(filePath: string, uploadUrl: string, name: string) {
   const fileContent = readFileSync(filePath);
   await fetch(uploadUrl, { method: "put", body: fileContent });
-  console.log(`Uploaded ${filePath} to ${name}`);
+  console.log(`[Highlight] Uploaded ${filePath} to ${name}`);
 }


### PR DESCRIPTION
## Summary

Closes HIG-2599
Closes HIG-4506

## How did you test this change?

new unit testing

testing the sourcemap generation

before:
![Screenshot from 2024-04-16 14-23-00](https://github.com/highlight/highlight/assets/1351531/93ea396c-0f2e-45ee-9a10-76802d3e5903)

after:
![Screenshot from 2024-04-16 14-28-29](https://github.com/highlight/highlight/assets/1351531/1e019aa3-f24b-4130-838f-2f2450484dcc)
![Screenshot from 2024-04-16 14-27-47](https://github.com/highlight/highlight/assets/1351531/547033e6-3113-484c-8929-94eb1090cb53)

## Are there any deployment considerations?

will be looking at % of errors enhanced with sourcemap before/after merging this change

## Does this work require review from our design team?

no
