### PR TITLE
fix nestjs sdk requiring endpoint to return

### DIFF
--- a/.changeset/chatty-adults-hammer.md
+++ b/.changeset/chatty-adults-hammer.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': minor
+---
+
+refactor highlight-run-with-headers to highlight-ctx

--- a/.changeset/curly-lobsters-bathe.md
+++ b/.changeset/curly-lobsters-bathe.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/node': patch
+---
+
+update node sdk to export in larger batches

--- a/.changeset/fuzzy-ties-repair.md
+++ b/.changeset/fuzzy-ties-repair.md
@@ -1,0 +1,6 @@
+---
+'@highlight-run/nest': minor
+'@highlight-run/node': minor
+---
+
+fix nestjs trace context propagation and update node sdk span names

--- a/.changeset/stale-poems-think.md
+++ b/.changeset/stale-poems-think.md
@@ -1,0 +1,5 @@
+---
+'@highlight-run/nest': patch
+---
+
+fix nest sdk breaking endpoints that do not return

--- a/backend/clickhouse/errors.go
+++ b/backend/clickhouse/errors.go
@@ -91,7 +91,7 @@ func (client *Client) WriteErrorGroups(ctx context.Context, groups []*model.Erro
 			NewStruct(new(ClickhouseErrorGroup)).
 			InsertInto(ErrorGroupsTable, chGroups...).
 			BuildWithFlavor(sqlbuilder.ClickHouse)
-		sql, args = replaceTimestampInserts(sql, args, 10, map[int]bool{1: true, 2: true}, MicroSeconds)
+		sql, args = replaceTimestampInserts(sql, args, map[int]bool{1: true, 2: true}, MicroSeconds)
 		return client.conn.Exec(chCtx, sql, args...)
 	}
 
@@ -157,7 +157,7 @@ func (client *Client) WriteErrorObjects(ctx context.Context, objects []*model.Er
 			NewStruct(new(ClickhouseErrorObject)).
 			InsertInto(ErrorObjectsTable, chObjects...).
 			BuildWithFlavor(sqlbuilder.ClickHouse)
-		sql, args = replaceTimestampInserts(sql, args, 14, map[int]bool{1: true}, MicroSeconds)
+		sql, args = replaceTimestampInserts(sql, args, map[int]bool{1: true}, MicroSeconds)
 		return client.conn.Exec(chCtx, sql, args...)
 	}
 

--- a/backend/clickhouse/insert_test.go
+++ b/backend/clickhouse/insert_test.go
@@ -11,7 +11,7 @@ func Benchmark_replaceTimestampInserts(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		replaceTimestampInserts("INSERT INTO error_groups (ProjectID, CreatedAt, UpdatedAt, ID, Event, Status, Type, ErrorTagID, ErrorTagTitle, ErrorTagDescription) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", []interface{}{
 			1, ts, ts + 1, 2, "event", "status", "type", 3, "title", "description",
-		}, 10, map[int]bool{0: true, 1: true, 2: true, 7: true, 9: true}, NanoSeconds)
+		}, map[int]bool{0: true, 1: true, 2: true, 7: true, 9: true}, NanoSeconds)
 	}
 	assert.Less(b, b.Elapsed()/time.Duration(b.N), time.Millisecond)
 }

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -217,7 +217,7 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 				NewStruct(new(ClickhouseSession)).
 				InsertInto(SessionsTable, chSessions...).
 				BuildWithFlavor(sqlbuilder.ClickHouse)
-			sessionsSql, sessionsArgs = replaceTimestampInserts(sessionsSql, sessionsArgs, 34, map[int]bool{7: true, 8: true}, MicroSeconds)
+			sessionsSql, sessionsArgs = replaceTimestampInserts(sessionsSql, sessionsArgs, map[int]bool{7: true, 8: true}, MicroSeconds)
 			return client.conn.Exec(chCtx, sessionsSql, sessionsArgs...)
 		})
 	}
@@ -228,7 +228,7 @@ func (client *Client) WriteSessions(ctx context.Context, sessions []*model.Sessi
 				NewStruct(new(ClickhouseField)).
 				InsertInto(FieldsTable, chFields...).
 				BuildWithFlavor(sqlbuilder.ClickHouse)
-			fieldsSql, fieldsArgs = replaceTimestampInserts(fieldsSql, fieldsArgs, 6, map[int]bool{3: true}, MicroSeconds)
+			fieldsSql, fieldsArgs = replaceTimestampInserts(fieldsSql, fieldsArgs, map[int]bool{3: true}, MicroSeconds)
 			return client.conn.Exec(chCtx, fieldsSql, fieldsArgs...)
 		})
 	}

--- a/docs-content/sdk/nodejs.md
+++ b/docs-content/sdk/nodejs.md
@@ -193,7 +193,7 @@ slug: nodejs
 <section className="section">
   <div className="left">
     <h3>H.runWithHeaders</h3>
-    <p>H.runWithHeaders() wraps its callback with a span named highlight-run-with-headers, and spreads Highlight's secureSessionId and requestId across all spans with matching a traceId.</p>
+    <p>H.runWithHeaders() wraps its callback with a span named highlight-ctx, and spreads Highlight's secureSessionId and requestId across all spans with matching a traceId.</p>
     <h6>Method Parameters</h6>
     <aside className="parameter">
       <h5>headers<code>IncomingHttpHeaders</code> <code>required</code></h5>

--- a/e2e/nestjs/src/app.controller.ts
+++ b/e2e/nestjs/src/app.controller.ts
@@ -7,11 +7,16 @@ export class AppController {
 
   @Get()
   async getHello(): Promise<string[]> {
-    return await this.appService.findAll();
+    return await this.appService.findAll({});
+  }
+
+  @Get('/empty')
+  async getEmpty() {
+    return await this.appService.findAll({ empty: true });
   }
 
   @Get('/error')
   async getError(): Promise<string[]> {
-    return await this.appService.findAll(true);
+    return await this.appService.findAll({ error: true });
   }
 }

--- a/e2e/nestjs/src/app.service.ts
+++ b/e2e/nestjs/src/app.service.ts
@@ -7,7 +7,13 @@ export class AppService {
   private readonly logger = new Logger(AppService.name);
   constructor(private readonly httpService: HttpService) {}
 
-  async findAll(throwError: boolean = false): Promise<string[]> {
+  async findAll({
+    error,
+    empty,
+  }: {
+    error?: true;
+    empty?: true;
+  }): Promise<string[]> {
     await firstValueFrom(
       this.httpService.post<any[]>(
         'https://pub.highlight.io/v1/logs/json',
@@ -27,10 +33,12 @@ export class AppService {
 
     this.logger.log('hello, world!');
     this.logger.warn('whoa there! ', Math.random());
-    if (throwError) {
+    if (error) {
       // error will be caught by the HighlightErrorFilter
       throw new Error(`a random error occurred!`);
     }
-    return [`Hello World!`];
+    if (!empty) {
+      return [`Hello World!`];
+    }
   }
 }

--- a/e2e/nestjs/src/app.service.ts
+++ b/e2e/nestjs/src/app.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { firstValueFrom } from 'rxjs';
 import { HttpService } from '@nestjs/axios';
+import { H } from '@highlight-run/nest';
 
 @Injectable()
 export class AppService {
@@ -14,6 +15,7 @@ export class AppService {
     error?: true;
     empty?: true;
   }): Promise<string[]> {
+    const span = await H.startActiveSpan('making request now', {});
     await firstValueFrom(
       this.httpService.post<any[]>(
         'https://pub.highlight.io/v1/logs/json',
@@ -30,10 +32,17 @@ export class AppService {
         },
       ),
     );
+    span.end();
 
-    console.log('hello, world!');
-    this.logger.log('hello, world!');
-    this.logger.warn('whoa there! ', Math.random());
+    for (let i = 0; i < 10; i++) {
+      const s = await H.startActiveSpan(`another request ${i}`, {
+        attributes: { i },
+      });
+      console.log('hello, world!');
+      this.logger.log('hello, world!');
+      this.logger.warn('whoa there! ', Math.random());
+      s.end();
+    }
     if (error) {
       // error will be caught by the HighlightErrorFilter
       throw new Error(`a random error occurred!`);

--- a/e2e/nestjs/src/app.service.ts
+++ b/e2e/nestjs/src/app.service.ts
@@ -31,6 +31,7 @@ export class AppService {
       ),
     );
 
+    console.log('hello, world!');
     this.logger.log('hello, world!');
     this.logger.warn('whoa there! ', Math.random());
     if (error) {

--- a/e2e/nestjs/src/main.ts
+++ b/e2e/nestjs/src/main.ts
@@ -1,6 +1,5 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { HighlightInterceptor, H } from '@highlight-run/nest';
 
 const env = {
   projectID: '2',
@@ -11,6 +10,7 @@ const env = {
 };
 
 async function bootstrap() {
+  const { HighlightInterceptor, H } = await import('@highlight-run/nest');
   H.init(env);
   const app = await NestFactory.create(AppModule);
   app.useGlobalInterceptors(new HighlightInterceptor(env));

--- a/sdk/highlight-apollo/src/apollo.test.ts
+++ b/sdk/highlight-apollo/src/apollo.test.ts
@@ -51,7 +51,7 @@ describe('ApolloServerHighlightPlugin', () => {
 		const { details } = await getResourceSpans(port)
 
 		const highlightRunWithHeadersSpan = details.find(({ spanNames }) =>
-			spanNames.includes('highlight-run-with-headers'),
+			spanNames.includes('highlight-ctx'),
 		)
 		const sessionId =
 			highlightRunWithHeadersSpan?.attributes['highlight.session_id']

--- a/sdk/highlight-apollo/src/apolloV3.test.ts
+++ b/sdk/highlight-apollo/src/apolloV3.test.ts
@@ -49,7 +49,7 @@ describe('ApolloServerV3HighlightPlugin', () => {
 		const { details } = await getResourceSpans(port)
 
 		const highlightRunWithHeadersSpan = details.find(({ spanNames }) =>
-			spanNames.includes('highlight-run-with-headers'),
+			spanNames.includes('highlight-ctx'),
 		)
 		const sessionId =
 			highlightRunWithHeadersSpan?.attributes['highlight.session_id']

--- a/sdk/highlight-nest/src/index.ts
+++ b/sdk/highlight-nest/src/index.ts
@@ -8,21 +8,9 @@ import {
 	Injectable,
 	NestInterceptor,
 } from '@nestjs/common'
-import {
-	bindCallback,
-	finalize,
-	from,
-	interval,
-	map,
-	mergeMap,
-	mergeWith,
-	Observable,
-	of,
-	tap,
-	throwError,
-} from 'rxjs'
+import { finalize, Observable, throwError } from 'rxjs'
 import { catchError } from 'rxjs/operators'
-import type { Span as OtelSpan } from '@opentelemetry/api'
+import api from '@opentelemetry/api'
 
 @Injectable()
 export class HighlightLogger
@@ -106,55 +94,36 @@ export class HighlightInterceptor
 		await NodeH.flush()
 	}
 
-	intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+	async intercept(
+		context: ExecutionContext,
+		next: CallHandler,
+	): Promise<Observable<any>> {
 		const ctx = context.switchToHttp()
 		const request = ctx.getRequest()
-		const highlightCtx = NodeH.parseHeaders(request.headers)
 
-		const ctxSpanPromise = bindCallback(
-			async (cb: (span: OtelSpan) => void) => {
-				await NodeH.runWithHeaders(request.headers, (ctxSpan) =>
-					cb(ctxSpan),
-				)
-			},
-		)
-		let requestSpan: OtelSpan
-		const requestSpanPromise = from(
-			NodeH.startActiveSpan(`${request.method} ${request.url}`, {
-				attributes: {
-					'http.method': request.method,
-					'http.url': request.url,
+		const { span: requestSpan, ctx: spanCtx } =
+			await NodeH.startWithHeaders(
+				`${request.method} ${request.url}`,
+				request.headers,
+				{
+					attributes: {
+						'http.method': request.method,
+						'http.url': request.url,
+					},
 				},
-			}),
-		).pipe(tap((span) => (requestSpan = span)))
-		return next.handle().pipe(
-			mergeWith(requestSpanPromise, ctxSpanPromise()),
-			catchError((err) => {
-				NodeH.consumeError(
-					err,
-					highlightCtx?.secureSessionId,
-					highlightCtx?.requestId,
-				)
-				return throwError(() => err)
-			}),
-			finalize(() => requestSpan.end()),
+			)
+		const fn = api.context.bind(spanCtx, () =>
+			next.handle().pipe(
+				catchError((err) => {
+					NodeH.consumeError(err)
+					return throwError(() => err)
+				}),
+				finalize(() => {
+					requestSpan.end()
+				}),
+			),
 		)
-		// return ctxSpanPromise().pipe(
-		// 	mergeWith(
-		// 		requestSpanPromise,
-		// 		next.handle().pipe(
-		// 			catchError((err) => {
-		// 				NodeH.consumeError(
-		// 					err,
-		// 					highlightCtx?.secureSessionId,
-		// 					highlightCtx?.requestId,
-		// 				)
-		// 				return throwError(() => err)
-		// 			}),
-		// 			finalize(() => requestSpan.end()),
-		// 		),
-		// 	),
-		// )
+		return fn()
 	}
 }
 

--- a/sdk/highlight-nest/src/index.ts
+++ b/sdk/highlight-nest/src/index.ts
@@ -100,7 +100,7 @@ export class HighlightInterceptor
 		const ctx = context.switchToHttp()
 		const request = ctx.getRequest()
 		const highlightCtx = NodeH.parseHeaders(request.headers)
-		return NodeH.runWithHeaders(request.headers, async () => {
+		return NodeH.runWithHeaders(request.headers, async (ctxSpan) => {
 			const span = await NodeH.startActiveSpan(
 				`${request.method} ${request.url}`,
 				{
@@ -121,6 +121,7 @@ export class HighlightInterceptor
 				}),
 				finalize(() => {
 					span.end()
+					ctxSpan.end()
 				}),
 			)
 		})

--- a/sdk/highlight-nest/src/index.ts
+++ b/sdk/highlight-nest/src/index.ts
@@ -94,24 +94,20 @@ export class HighlightInterceptor
 		await NodeH.flush()
 	}
 
-	async intercept(
-		context: ExecutionContext,
-		next: CallHandler,
-	): Promise<Observable<any>> {
+	intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
 		const ctx = context.switchToHttp()
 		const request = ctx.getRequest()
 
-		const { span: requestSpan, ctx: spanCtx } =
-			await NodeH.startWithHeaders(
-				`${request.method} ${request.url}`,
-				request.headers,
-				{
-					attributes: {
-						'http.method': request.method,
-						'http.url': request.url,
-					},
+		const { span: requestSpan, ctx: spanCtx } = NodeH.startWithHeaders(
+			`${request.method} ${request.url}`,
+			request.headers,
+			{
+				attributes: {
+					'http.method': request.method,
+					'http.url': request.url,
 				},
-			)
+			},
+		)
 		const fn = api.context.bind(spanCtx, () =>
 			next.handle().pipe(
 				catchError((err) => {

--- a/sdk/highlight-nest/src/index.ts
+++ b/sdk/highlight-nest/src/index.ts
@@ -111,7 +111,13 @@ export class HighlightInterceptor
 		const fn = api.context.bind(spanCtx, () =>
 			next.handle().pipe(
 				catchError((err) => {
-					NodeH.consumeError(err)
+					NodeH.consumeError(
+						err,
+						undefined,
+						undefined,
+						{},
+						{ span: requestSpan },
+					)
 					return throwError(() => err)
 				}),
 				finalize(() => {

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -439,7 +439,9 @@ export class Highlight {
 		headers: Headers | IncomingHttpHeaders,
 		cb: (span: OtelSpan) => T | Promise<T>,
 	) {
+		console.log('vadim', 'runWithHeaders', 'start')
 		return this.tracer.startActiveSpan('highlight-ctx', async (span) => {
+			console.log('vadim', 'runWithHeaders', 'cb')
 			const { secureSessionId, requestId } = this.parseHeaders(headers)
 
 			if (secureSessionId && requestId) {
@@ -466,11 +468,13 @@ export class Highlight {
 			} finally {
 				span.end()
 				await this.waitForFlush()
+				console.log('vadim', 'runWithHeaders', 'cb finally')
 			}
 		})
 	}
 
 	startActiveSpan(name: string, options?: SpanOptions) {
+		console.log('vadim', 'runWithHeaders', 'startActiveSpan')
 		return new Promise<OtelSpan>((resolve) =>
 			this.tracer.startActiveSpan(name, options || {}, resolve),
 		)

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -350,8 +350,9 @@ export class Highlight {
 		secureSessionId: string | undefined,
 		requestId: string | undefined,
 		metadata?: Attributes,
+		options?: { span: OtelSpan },
 	) {
-		let span = api.trace.getActiveSpan()
+		let span = options?.span ?? api.trace.getActiveSpan()
 		if (!span) {
 			span = this.tracer.startSpan('highlight.error')
 		}

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -286,7 +286,7 @@ export class Highlight {
 		tags?: { name: string; value: string }[],
 	) {
 		if (!this.tracer) return
-		const span = this.tracer.startSpan('highlight-ctx')
+		const span = this.tracer.startSpan('highlight.metric')
 		span.addEvent('metric', {
 			['highlight.project_id']: this._projectID,
 			['metric.name']: name,
@@ -318,7 +318,7 @@ export class Highlight {
 		metadata?: Attributes,
 	) {
 		if (!this.tracer) return
-		const span = this.tracer.startSpan('highlight-ctx')
+		const span = this.tracer.startSpan('highlight.log')
 		// log specific events from https://github.com/highlight/highlight/blob/19ea44c616c432ef977c73c888c6dfa7d6bc82f3/sdk/highlight-go/otel.go#L34-L36
 		span.addEvent(
 			'log',
@@ -353,7 +353,7 @@ export class Highlight {
 	) {
 		let span = api.trace.getActiveSpan()
 		if (!span) {
-			span = this.tracer.startSpan('highlight-ctx')
+			span = this.tracer.startSpan('highlight.error')
 		}
 		span.recordException(error)
 		if (metadata != undefined) {

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -437,45 +437,37 @@ export class Highlight {
 
 	async runWithHeaders<T>(
 		headers: Headers | IncomingHttpHeaders,
-		cb: () => T | Promise<T>,
+		cb: (span: OtelSpan) => T | Promise<T>,
 	) {
-		return this.tracer.startActiveSpan(
-			'highlight-run-with-headers',
-			async (span) => {
-				const { secureSessionId, requestId } =
-					this.parseHeaders(headers)
+		return this.tracer.startActiveSpan('highlight-ctx', async (span) => {
+			const { secureSessionId, requestId } = this.parseHeaders(headers)
 
-				if (secureSessionId && requestId) {
-					this.processor.setTraceMetadata(span, {
-						'highlight.session_id': secureSessionId,
-						'highlight.trace_id': requestId,
-					})
+			if (secureSessionId && requestId) {
+				this.processor.setTraceMetadata(span, {
+					'highlight.session_id': secureSessionId,
+					'highlight.trace_id': requestId,
+				})
 
-					propagation
-						.getActiveBaggage()
-						?.setEntry(HIGHLIGHT_REQUEST_HEADER, {
-							value: `${secureSessionId}/${requestId}`,
-						} as BaggageEntry)
+				propagation
+					.getActiveBaggage()
+					?.setEntry(HIGHLIGHT_REQUEST_HEADER, {
+						value: `${secureSessionId}/${requestId}`,
+					} as BaggageEntry)
+			}
+
+			try {
+				return await cb(span)
+			} catch (error) {
+				if (error instanceof Error) {
+					this.consumeCustomError(error, secureSessionId, requestId)
 				}
 
-				try {
-					return await cb()
-				} catch (error) {
-					if (error instanceof Error) {
-						this.consumeCustomError(
-							error,
-							secureSessionId,
-							requestId,
-						)
-					}
-
-					throw error
-				} finally {
-					span.end()
-					await this.waitForFlush()
-				}
-			},
-		)
+				throw error
+			} finally {
+				span.end()
+				await this.waitForFlush()
+			}
+		})
 	}
 
 	startActiveSpan(name: string, options?: SpanOptions) {

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -208,8 +208,8 @@ export class Highlight {
 
 		this.processor = new CustomSpanProcessor(exporter, {
 			scheduledDelayMillis: 1000,
-			maxExportBatchSize: 128,
-			maxQueueSize: 1024,
+			maxExportBatchSize: 1024 * 1024,
+			maxQueueSize: 1024 * 1024,
 			exportTimeoutMillis: this.FLUSH_TIMEOUT_MS,
 		})
 

--- a/sdk/highlight-node/src/client.ts
+++ b/sdk/highlight-node/src/client.ts
@@ -470,11 +470,11 @@ export class Highlight {
 		}
 	}
 
-	async startWithHeaders<T>(
+	startWithHeaders<T>(
 		spanName: string,
 		headers: Headers | IncomingHttpHeaders,
 		options?: SpanOptions,
-	): Promise<{ span: OtelSpan; ctx: Context }> {
+	): { span: OtelSpan; ctx: Context } {
 		const ctx = api.context.active()
 		const span = this.tracer.startSpan(spanName, options, ctx)
 		const contextWithSpanSet = api.trace.setSpan(ctx, span)

--- a/sdk/highlight-node/src/sdk.ts
+++ b/sdk/highlight-node/src/sdk.ts
@@ -2,10 +2,9 @@ import { IncomingHttpHeaders } from 'http'
 import { Highlight } from './client'
 import log from './log'
 import { ResourceAttributes } from '@opentelemetry/resources'
-import type { NodeOptions, HighlightContext } from './types.js'
+import type { HighlightContext, NodeOptions } from './types.js'
 import type {
 	Attributes,
-	Tracer,
 	Span as OtelSpan,
 	SpanOptions,
 } from '@opentelemetry/api'
@@ -23,7 +22,7 @@ export interface HighlightInterface {
 	// Use runWithHeaders to execute a method with a highlight context
 	runWithHeaders: <T>(
 		headers: Headers | IncomingHttpHeaders,
-		cb: () => T | Promise<T>,
+		cb: (span: OtelSpan) => T | Promise<T>,
 	) => Promise<T>
 
 	consumeError: (

--- a/sdk/highlight-node/src/sdk.ts
+++ b/sdk/highlight-node/src/sdk.ts
@@ -3,8 +3,9 @@ import { Highlight } from './client'
 import log from './log'
 import { ResourceAttributes } from '@opentelemetry/resources'
 import type { HighlightContext, NodeOptions } from './types.js'
-import type {
+import {
 	Attributes,
+	Context,
 	Span as OtelSpan,
 	SpanOptions,
 } from '@opentelemetry/api'
@@ -24,6 +25,11 @@ export interface HighlightInterface {
 		headers: Headers | IncomingHttpHeaders,
 		cb: (span: OtelSpan) => T | Promise<T>,
 	) => Promise<T>
+	startWithHeaders: (
+		name: string,
+		headers: Headers | IncomingHttpHeaders,
+		options: SpanOptions,
+	) => Promise<{ span: OtelSpan; ctx: Context }>
 
 	consumeError: (
 		error: Error,
@@ -159,6 +165,9 @@ export const H: HighlightInterface = {
 
 	runWithHeaders: (headers, cb) => {
 		return highlight_obj.runWithHeaders(headers, cb)
+	},
+	startWithHeaders: (spanName, headers, options) => {
+		return highlight_obj.startWithHeaders(spanName, headers, options)
 	},
 	consumeAndFlush: async function (...args) {
 		try {

--- a/sdk/highlight-node/src/sdk.ts
+++ b/sdk/highlight-node/src/sdk.ts
@@ -29,7 +29,7 @@ export interface HighlightInterface {
 		name: string,
 		headers: Headers | IncomingHttpHeaders,
 		options: SpanOptions,
-	) => Promise<{ span: OtelSpan; ctx: Context }>
+	) => { span: OtelSpan; ctx: Context }
 
 	consumeError: (
 		error: Error,

--- a/sdk/highlight-node/src/sdk.ts
+++ b/sdk/highlight-node/src/sdk.ts
@@ -36,6 +36,7 @@ export interface HighlightInterface {
 		secureSessionId?: string,
 		requestId?: string,
 		metadata?: Attributes,
+		options?: { span: OtelSpan },
 	) => void
 	recordMetric: (
 		secureSessionId: string,
@@ -95,6 +96,7 @@ export const H: HighlightInterface = {
 		secureSessionId?: string,
 		requestId?: string,
 		metadata?: Attributes,
+		options?: { span: OtelSpan },
 	) => {
 		try {
 			highlight_obj.consumeCustomError(
@@ -102,6 +104,7 @@ export const H: HighlightInterface = {
 				secureSessionId,
 				requestId,
 				metadata,
+				options,
 			)
 		} catch (e) {
 			console.warn('highlight-node consumeError error: ', e)


### PR DESCRIPTION
## Summary

* Updates node.js SDK export batch settings to help with dropped spans
* Fixes nestjs sdk crashing on endpoints where there was no returned data
* Improves nestjs spans and context propagation for parent->child spans
* Renames nodejs internal spans to make it easier to filter them out.

8844ac67c9b8a6f728a6b06168618c22420d9173 should fix HIG-4518

## How did you test this change?

![Screenshot from 2024-04-16 22-20-14](https://github.com/highlight/highlight/assets/1351531/d6b9fcb5-72cc-478c-82cb-0e93e71fcc36)

![Screenshot from 2024-04-17 11-27-06](https://github.com/highlight/highlight/assets/1351531/e7aec035-0a66-4fad-b6e3-228887d0351d)

![Screenshot from 2024-04-17 11-34-10](https://github.com/highlight/highlight/assets/1351531/942c0859-bc33-43fd-be63-3f981b2a0064)


## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no
