### PR TITLE
Add position indicator in session logs

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7299,7 +7299,7 @@ body {
   background-color: #e9e8ea;
 }
 .izessr3 {
-  background-color: #eeedef;
+  border-bottom: 2px solid var(--_1pyqka9l);
 }
 ._1eq64x70 {
   align-items: center;

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -46,7 +46,7 @@ export const ConsolePage = ({
 	levels: LogLevel[]
 }) => {
 	const { projectId } = useProjectId()
-	const [selectedCursor, setSelectedCursor] = useState(logCursor)
+	const [, setSelectedCursor] = useState(logCursor)
 	const { session, time, setTime, sessionMetadata, isPlayerReady } =
 		useReplayerContext()
 
@@ -91,7 +91,7 @@ export const ConsolePage = ({
 		return message.node
 	})
 
-	let lastActiveLogIndex = useMemo(() => {
+	const lastActiveLogIndex = useMemo(() => {
 		return findLastActiveEventIndex(
 			time,
 			sessionMetadata.startTime,

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -11,7 +11,7 @@ import { useProjectId } from '@hooks/useProjectId'
 import { COLOR_MAPPING } from '@pages/LogsPage/constants'
 import { THROTTLED_UPDATE_MS } from '@pages/Player/PlayerHook/PlayerState'
 import { EmptyDevToolsCallout } from '@pages/Player/Toolbar/DevToolsWindowV2/EmptyDevToolsCallout/EmptyDevToolsCallout'
-import { Tab } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
+import { Tab, findLastActiveEventIndex } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import clsx from 'clsx'
 import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -84,40 +84,23 @@ export const ConsolePage = ({
 		return data.sessionLogs
 	}, [filter, data?.sessionLogs])
 
-	// Logic for scrolling to current entry.
-	useEffect(() => {
-		if (!autoScroll) {
-			return
-		}
-		if (messagesToRender.length) {
-			let cursor = ''
-			let msgDiff: number = Number.MAX_VALUE
-			for (let i = 0; i < messagesToRender.length; i++) {
-				const currentDiff: number =
-					time -
-					(new Date(messagesToRender[i].node.timestamp).getTime() -
-						new Date(messagesToRender[0].node.timestamp).getTime())
-				if (currentDiff < 0) break
-				if (currentDiff < msgDiff) {
-					cursor = messagesToRender[i].cursor
-					msgDiff = currentDiff
-				}
-			}
-			setSelectedCursor(cursor)
-		}
-	}, [time, messagesToRender, autoScroll])
+	const messageNodes = messagesToRender.map((message) => {
+		return message.node
+	})
+
+	let lastActiveLogIndex = useMemo(() => {
+		return findLastActiveEventIndex(
+			time,
+			sessionMetadata.startTime,
+			messageNodes,
+		)
+	}, [time, sessionMetadata.startTime, messageNodes])
 
 	useEffect(() => {
 		analytics.track('session_view-console-logs')
 	}, [])
 
 	const virtuoso = useRef<VirtuosoHandle>(null)
-
-	const foundIndex = useMemo(() => {
-		return messagesToRender.findIndex(
-			(logEdge) => logEdge.cursor === selectedCursor,
-		)
-	}, [messagesToRender, selectedCursor])
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const scrollFunction = useCallback(
@@ -140,11 +123,19 @@ export const ConsolePage = ({
 			virtuoso.current &&
 			messagesToRender
 		) {
-			if (foundIndex >= 0) {
-				scrollFunction(foundIndex)
+			if (autoScroll) {
+				if (lastActiveLogIndex >= 0) {
+					scrollFunction(lastActiveLogIndex)
+				}
 			}
 		}
-	}, [foundIndex, isPlayerReady, messagesToRender, scrollFunction])
+	}, [
+		lastActiveLogIndex,
+		isPlayerReady,
+		messagesToRender,
+		scrollFunction,
+		autoScroll,
+	])
 
 	return (
 		<Box cssClass={styles.consoleBox}>
@@ -161,13 +152,11 @@ export const ConsolePage = ({
 						<MessageRow
 							key={logEdge.cursor}
 							logEdge={logEdge}
-							current={selectedCursor === logEdge.cursor}
+							current={_index === lastActiveLogIndex}
+							past={_index <= lastActiveLogIndex}
 							onSelect={() => {
 								setSelectedCursor(logEdge.cursor)
-								const timestamp =
-									new Date(
-										messagesToRender[_index].node.timestamp,
-									).getTime() - sessionMetadata.startTime
+								const timestamp = new Date(logEdge.node.timestamp).getTime() - sessionMetadata.startTime
 								setTime(timestamp)
 								analytics.track('session_go-to-log_click')
 							}}
@@ -185,11 +174,14 @@ const MessageRow = React.memo(function ({
 	logEdge,
 	onSelect,
 	current,
+	past,
 }: {
 	logEdge: SessionLogEdge
 	onSelect: () => void
 	current?: boolean
+	past: boolean
 }) {
+
 	return (
 		<Box
 			cssClass={clsx(
@@ -200,6 +192,9 @@ const MessageRow = React.memo(function ({
 			)}
 			borderBottom="dividerWeak"
 			py="8"
+			style={{
+				opacity: past ? 1 : 0.4,
+			}}
 		>
 			<Stack direction="row">
 				<Box flexGrow={1}>

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -12,8 +12,8 @@ import { COLOR_MAPPING } from '@pages/LogsPage/constants'
 import { THROTTLED_UPDATE_MS } from '@pages/Player/PlayerHook/PlayerState'
 import { EmptyDevToolsCallout } from '@pages/Player/Toolbar/DevToolsWindowV2/EmptyDevToolsCallout/EmptyDevToolsCallout'
 import {
-	Tab,
 	findLastActiveEventIndex,
+	Tab,
 } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import clsx from 'clsx'
 import _ from 'lodash'

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/ConsolePage.tsx
@@ -11,7 +11,10 @@ import { useProjectId } from '@hooks/useProjectId'
 import { COLOR_MAPPING } from '@pages/LogsPage/constants'
 import { THROTTLED_UPDATE_MS } from '@pages/Player/PlayerHook/PlayerState'
 import { EmptyDevToolsCallout } from '@pages/Player/Toolbar/DevToolsWindowV2/EmptyDevToolsCallout/EmptyDevToolsCallout'
-import { Tab, findLastActiveEventIndex } from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
+import {
+	Tab,
+	findLastActiveEventIndex,
+} from '@pages/Player/Toolbar/DevToolsWindowV2/utils'
 import clsx from 'clsx'
 import _ from 'lodash'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -156,7 +159,9 @@ export const ConsolePage = ({
 							past={_index <= lastActiveLogIndex}
 							onSelect={() => {
 								setSelectedCursor(logEdge.cursor)
-								const timestamp = new Date(logEdge.node.timestamp).getTime() - sessionMetadata.startTime
+								const timestamp =
+									new Date(logEdge.node.timestamp).getTime() -
+									sessionMetadata.startTime
 								setTime(timestamp)
 								analytics.track('session_go-to-log_click')
 							}}
@@ -181,7 +186,6 @@ const MessageRow = React.memo(function ({
 	current?: boolean
 	past: boolean
 }) {
-
 	return (
 		<Box
 			cssClass={clsx(

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/style.css.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/ConsolePage/style.css.ts
@@ -1,4 +1,5 @@
 import { colors } from '@highlight-run/ui/colors'
+import { vars } from '@highlight-run/ui/vars'
 import { style } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
 
@@ -19,7 +20,7 @@ export const messageRowVariants = recipe({
 	variants: {
 		current: {
 			true: {
-				backgroundColor: colors.n4,
+				borderBottom: `2px solid ${vars.theme.interactive.fill.primary.enabled}`,
 			},
 			false: {},
 		},

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -23,21 +23,24 @@ export const findLastActiveEventIndex = (
 
 	let start = 0
 	let end = events.length - 1
+	let lastMatchIndex = -1
 
 	while (start <= end) {
 		const mid = Math.floor(start + (end - start) / 2)
 		const event = events[mid]
-		const eventTimestamp =
-			new Date(event.timestamp).getTime() - sessionStartTime
+		const eventTimestamp = new Date(event.timestamp).getTime() - sessionStartTime
+
 		if (eventTimestamp === currentTimestamp) {
-			return mid
+			lastMatchIndex = mid
+			start = mid + 1
 		} else if (eventTimestamp < currentTimestamp) {
 			start = mid + 1
 		} else {
 			end = mid - 1
 		}
 	}
-	return Math.min(end, events.length - 1)
+
+	return lastMatchIndex !== -1 ? lastMatchIndex : Math.min(end, events.length - 1);
 }
 
 interface Request {

--- a/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
+++ b/frontend/src/pages/Player/Toolbar/DevToolsWindowV2/utils.ts
@@ -28,7 +28,8 @@ export const findLastActiveEventIndex = (
 	while (start <= end) {
 		const mid = Math.floor(start + (end - start) / 2)
 		const event = events[mid]
-		const eventTimestamp = new Date(event.timestamp).getTime() - sessionStartTime
+		const eventTimestamp =
+			new Date(event.timestamp).getTime() - sessionStartTime
 
 		if (eventTimestamp === currentTimestamp) {
 			lastMatchIndex = mid
@@ -40,7 +41,9 @@ export const findLastActiveEventIndex = (
 		}
 	}
 
-	return lastMatchIndex !== -1 ? lastMatchIndex : Math.min(end, events.length - 1);
+	return lastMatchIndex !== -1
+		? lastMatchIndex
+		: Math.min(end, events.length - 1)
 }
 
 interface Request {


### PR DESCRIPTION
## Summary
closes #4872 
/claim #4872
I noticed that the arrow icon in the network logs doesn't function, whereas it works as a 'go-to' button in error logs. Is this intentional or does it need fixing?
I also noticed that when switching tabs, if I'm at a certain timestamp in one tab and then switch to another tab, the new tab doesn't automatically scroll to the current active log.(By tab i mean console, error and network tabs)
[Screencast from 17-04-2024 10:58:45.webm](https://github.com/highlight/highlight/assets/112156147/8d35835e-14d1-4584-a32c-ac59886fa6d3)


## How did you test this change?
[Screencast from 17-04-2024 10:27:46.webm](https://github.com/highlight/highlight/assets/112156147/45d0e7b7-e476-4f3a-87bd-24e495952177)

## Are there any deployment considerations?
None

## Does this work require review from our design team?
No
