### PR TITLE
add nextjs example of suspense loading

### DIFF
--- a/e2e/nextjs/src/app/layout.tsx
+++ b/e2e/nextjs/src/app/layout.tsx
@@ -2,7 +2,7 @@
 import './globals.css'
 
 import { CONSTANTS } from '@/constants'
-import { HighlightInit } from '@highlight-run/next/client'
+import { ErrorBoundary, HighlightInit } from '@highlight-run/next/client'
 
 export const metadata = {
 	title: 'Highlight Next Demo',
@@ -15,7 +15,7 @@ export default function RootLayout({
 	children: React.ReactNode
 }) {
 	return (
-		<>
+		<ErrorBoundary>
 			<HighlightInit
 				debug={{ clientInteractions: true, domRecording: true }}
 				projectId={CONSTANTS.NEXT_PUBLIC_HIGHLIGHT_PROJECT_ID}
@@ -44,6 +44,6 @@ export default function RootLayout({
 					<div>{children}</div>
 				</body>
 			</html>
-		</>
+		</ErrorBoundary>
 	)
 }

--- a/e2e/nextjs/src/app/loading.tsx
+++ b/e2e/nextjs/src/app/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+	return <div>Loading...</div>
+}

--- a/e2e/nextjs/src/app/suspense/page.tsx
+++ b/e2e/nextjs/src/app/suspense/page.tsx
@@ -1,0 +1,20 @@
+export default async function Page() {
+	const response = await fetch('https://pub.highlight.io/v1/logs/json', {
+		method: 'POST',
+		body: JSON.stringify({}),
+		headers: {
+			'x-highlight-project': '2',
+			'x-highlight-service': 'next-suspense',
+		},
+	})
+	const data = await response.text()
+	await new Promise((resolve) =>
+		setTimeout(resolve, Math.random() * 3 * 1000),
+	)
+	return (
+		<div>
+			<p>YO THIS IS AN ASYNC PAGE</p>
+			<p>{data}</p>
+		</div>
+	)
+}

--- a/highlight.io/app/api/sitemap/route.ts
+++ b/highlight.io/app/api/sitemap/route.ts
@@ -1,17 +1,21 @@
 import { promises as fsp } from 'fs'
 import { gql } from 'graphql-request'
+import pino from 'pino'
+import { createWriteStream } from 'pino-http-send'
 import { COMPETITORS } from '../../../components/Competitors/competitors'
 import { FEATURES, iFeature } from '../../../components/Features/features'
 import { iProduct, PRODUCTS } from '../../../components/Products/products'
-import pino from 'pino'
-import { GraphQLRequest } from '../../../utils/graphql'
-import { createWriteStream } from 'pino-http-send'
 import { withAppRouterHighlight } from '../../../highlight.app.config'
 import { getGithubDocsPaths } from '../../../pages/api/docs/github'
 import { getBlogPaths } from '../../../shared/blog'
+import { GraphQLRequest } from '../../../utils/graphql'
 
 const stream = createWriteStream({
-	url: 'https://pub.highlight.io/v1/logs/json?project=4d7k1xeo&service=highlight-io-next-frontend',
+	url: 'https://pub.highlight.io/v1/logs/json',
+	headers: {
+		'x-highlight-project': '2',
+		'x-highlight-service': 'next-suspense',
+	},
 })
 
 const logger = pino({ level: 'trace' }, stream)


### PR DESCRIPTION
## Summary

Add an example of an async page to our e2e next app to test highlight's impact on suspense page loading per customer request.

## How did you test this change?

local deploy

## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
