### PR TITLE
add dnd dashboard organization, edit name

### DIFF
--- a/backend/clickhouse/logs.go
+++ b/backend/clickhouse/logs.go
@@ -454,8 +454,9 @@ func (client *Client) LogsKeys(ctx context.Context, projectID int, startDate tim
 	if query == nil || *query == "" {
 		logKeys = append(logKeys, defaultLogKeys...)
 	} else {
+		queryLower := strings.ToLower(*query)
 		for _, key := range defaultLogKeys {
-			if strings.Contains(key.Name, *query) {
+			if strings.Contains(key.Name, queryLower) {
 				logKeys = append(logKeys, key)
 			}
 		}

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -250,7 +250,7 @@ func KeysAggregated(ctx context.Context, client *Client, tableName string, proje
 		Where(fmt.Sprintf("Day <= toStartOfDay(%s)", sb.Var(endDate)))
 
 	if query != nil && *query != "" {
-		sb.Where(fmt.Sprintf("Key LIKE %s", sb.Var("%"+*query+"%")))
+		sb.Where(fmt.Sprintf("Key ILIKE %s", sb.Var("%"+*query+"%")))
 	}
 
 	if typeArg != nil && *typeArg == modelInputs.KeyTypeNumeric {

--- a/backend/clickhouse/sessions.go
+++ b/backend/clickhouse/sessions.go
@@ -518,8 +518,9 @@ func (client *Client) SessionsKeys(ctx context.Context, projectID int, startDate
 	if query == nil || *query == "" {
 		sessionKeys = append(sessionKeys, defaultSessionsKeys...)
 	} else {
+		queryLower := strings.ToLower(*query)
 		for _, key := range defaultSessionsKeys {
-			if strings.Contains(key.Name, *query) {
+			if strings.Contains(key.Name, queryLower) {
 				sessionKeys = append(sessionKeys, key)
 			}
 		}

--- a/backend/clickhouse/traces.go
+++ b/backend/clickhouse/traces.go
@@ -443,8 +443,9 @@ func (client *Client) TracesKeys(ctx context.Context, projectID int, startDate t
 	if query == nil || *query == "" {
 		traceKeys = append(traceKeys, defaultTraceKeys...)
 	} else {
+		queryLower := strings.ToLower(*query)
 		for _, key := range defaultTraceKeys {
-			if strings.Contains(key.Name, *query) {
+			if strings.Contains(key.Name, queryLower) {
 				traceKeys = append(traceKeys, key)
 			}
 		}

--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -1458,7 +1458,8 @@ type Visualization struct {
 	ProjectID        int `gorm:"index"`
 	Name             string
 	UpdatedByAdminId *int
-	UpdatedByAdmin   *Admin `gorm:"foreignKey:UpdatedByAdminId"`
+	UpdatedByAdmin   *Admin        `gorm:"foreignKey:UpdatedByAdminId"`
+	GraphIds         pq.Int32Array `gorm:"type:integer[]"`
 	Graphs           []Graph
 }
 

--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -13212,6 +13212,7 @@ input VisualizationInput {
 	id: ID
 	projectId: ID!
 	name: String!
+	graphIds: [ID!]
 }
 
 scalar Upload
@@ -82049,7 +82050,7 @@ func (ec *executionContext) unmarshalInputVisualizationInput(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "projectId", "name"}
+	fieldsInOrder := [...]string{"id", "projectId", "name", "graphIds"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -82077,6 +82078,13 @@ func (ec *executionContext) unmarshalInputVisualizationInput(ctx context.Context
 				return it, err
 			}
 			it.Name = data
+		case "graphIds":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("graphIds"))
+			data, err := ec.unmarshalOID2ᚕintᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.GraphIds = data
 		}
 	}
 
@@ -103149,6 +103157,44 @@ func (ec *executionContext) unmarshalOID2int(ctx context.Context, v interface{})
 func (ec *executionContext) marshalOID2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
 	res := graphql.MarshalIntID(v)
 	return res
+}
+
+func (ec *executionContext) unmarshalOID2ᚕintᚄ(ctx context.Context, v interface{}) ([]int, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]int, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNID2int(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOID2ᚕintᚄ(ctx context.Context, sel ast.SelectionSet, v []int) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNID2int(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalOID2ᚖint(ctx context.Context, v interface{}) (*int, error) {

--- a/backend/private-graph/graph/model/models_gen.go
+++ b/backend/private-graph/graph/model/models_gen.go
@@ -995,6 +995,7 @@ type VisualizationInput struct {
 	ID        *int   `json:"id,omitempty"`
 	ProjectID int    `json:"projectId"`
 	Name      string `json:"name"`
+	GraphIds  []int  `json:"graphIds,omitempty"`
 }
 
 type WebSocketEvent struct {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -1911,6 +1911,7 @@ input VisualizationInput {
 	id: ID
 	projectId: ID!
 	name: String!
+	graphIds: [ID!]
 }
 
 scalar Upload

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4733,13 +4733,18 @@ func (r *mutationResolver) UpsertVisualization(ctx context.Context, visualizatio
 		return 0, err
 	}
 
+	graphIds := lo.Map(visualization.GraphIds, func(i int, _ int) int32 {
+		return int32(i)
+	})
+
 	toSave := model.Visualization{
 		Model:            model.Model{ID: id},
 		ProjectID:        visualization.ProjectID,
 		Name:             visualization.Name,
 		UpdatedByAdminId: &admin.ID,
+		GraphIds:         graphIds,
 	}
-	if err := r.DB.WithContext(ctx).Save(&toSave).Error; err != nil {
+	if err := r.DB.WithContext(ctx).Debug().Save(&toSave).Error; err != nil {
 		return 0, err
 	}
 
@@ -9109,6 +9114,27 @@ func (r *queryResolver) Visualization(ctx context.Context, id int) (*model.Visua
 	if err := r.DB.WithContext(ctx).Model(&viz).Where("id = ?", id).Preload("Graphs").Preload("UpdatedByAdmin").Find(&viz).Error; err != nil {
 		return nil, err
 	}
+
+	// Reorder the graphs according to the ordering in viz.GraphIds.
+	// If the ordering includes ids not present in viz.Graphs, disregard those.
+	// If the ordering does not include ids present in viz.Graphs, append those at the end in order.
+	graphsById := lo.SliceToMap(viz.Graphs, func(g model.Graph) (int32, model.Graph) { return int32(g.ID), g })
+	orderedGraphs := []model.Graph{}
+	for _, id := range viz.GraphIds {
+		graph, found := graphsById[id]
+		if !found {
+			continue
+		}
+		orderedGraphs = append(orderedGraphs, graph)
+	}
+	graphIds := lo.SliceToMap(viz.GraphIds, func(id int32) (int32, struct{}) { return id, struct{}{} })
+	for _, graph := range viz.Graphs {
+		_, found := graphIds[int32(graph.ID)]
+		if !found {
+			orderedGraphs = append(orderedGraphs, graph)
+		}
+	}
+	viz.Graphs = orderedGraphs
 
 	_, err := r.isAdminInProjectOrDemoProject(ctx, viz.ProjectID)
 	if err != nil {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4744,7 +4744,7 @@ func (r *mutationResolver) UpsertVisualization(ctx context.Context, visualizatio
 		UpdatedByAdminId: &admin.ID,
 		GraphIds:         graphIds,
 	}
-	if err := r.DB.WithContext(ctx).Debug().Save(&toSave).Error; err != nil {
+	if err := r.DB.WithContext(ctx).Save(&toSave).Error; err != nil {
 		return 0, err
 	}
 
@@ -9160,7 +9160,7 @@ func (r *queryResolver) Visualizations(ctx context.Context, projectID int, input
 	}
 
 	var viz []vizWithCount
-	if err := r.DB.WithContext(ctx).Model(&model.Visualization{}).Debug().Preload("UpdatedByAdmin").
+	if err := r.DB.WithContext(ctx).Model(&model.Visualization{}).Preload("UpdatedByAdmin").
 		Where("project_id = ?", projectID).Where("name ILIKE ?", searchStr).
 		Order("updated_at DESC").Select("*, COUNT(*) OVER () as count").Limit(count).Offset(offset).Find(&viz).Error; err != nil {
 		return nil, err

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -9160,7 +9160,7 @@ func (r *queryResolver) Visualizations(ctx context.Context, projectID int, input
 	}
 
 	var viz []vizWithCount
-	if err := r.DB.WithContext(ctx).Model(&model.Visualization{}).Preload("UpdatedByAdmin").
+	if err := r.DB.WithContext(ctx).Model(&model.Visualization{}).Preload("Graphs").Preload("UpdatedByAdmin").
 		Where("project_id = ?", projectID).Where("name ILIKE ?", searchStr).
 		Order("updated_at DESC").Select("*, COUNT(*) OVER () as count").Limit(count).Offset(offset).Find(&viz).Error; err != nil {
 		return nil, err

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
 		"@dinero.js/currencies": "2.0.0-alpha.14",
 		"@dnd-kit/core": "^6.1.0",
 		"@dnd-kit/sortable": "^8.0.0",
+		"@dnd-kit/utilities": "^3.2.2",
 		"@fontsource/poppins": "^4.5.9",
 		"@frontapp/plugin-sdk": "^1.1.2",
 		"@highlight-run/client": "workspace:*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,8 @@
 		"@apollo/client": "^3.7.0",
 		"@ctrl/tinycolor": "^3.4.1",
 		"@dinero.js/currencies": "2.0.0-alpha.14",
+		"@dnd-kit/core": "^6.1.0",
+		"@dnd-kit/sortable": "^8.0.0",
 		"@fontsource/poppins": "^4.5.9",
 		"@frontapp/plugin-sdk": "^1.1.2",
 		"@highlight-run/client": "workspace:*",

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7422,6 +7422,46 @@ body {
   bottom: 0;
   width: 4px;
 }
+._11t98zr0 {
+  border-bottom: var(--_1pyqka9k) solid 1px;
+  height: 280px;
+}
+._11t98zr1 {
+  height: 100%;
+  background-color: #ffffff;
+}
+._11t98zr2 {
+  cursor: grab;
+  border-bottom: none;
+}
+._11t98zr3 {
+  cursor: grabbing;
+  z-index: 1;
+}
+@media (width <= 850px) {
+  ._11t98zr0:nth-child(n+1):nth-last-child(-n+3) {
+    border-bottom: none;
+  }
+  ._11t98zr0:nth-child(n+1):nth-last-child(-n+3) ~ ._11t98zr0 {
+    border-bottom: none;
+  }
+}
+@media (850px < width <= 1250px) {
+  ._11t98zr0:nth-child(2n+1):nth-last-child(-n+4) {
+    border-bottom: none;
+  }
+  ._11t98zr0:nth-child(2n+1):nth-last-child(-n+4) ~ ._11t98zr0 {
+    border-bottom: none;
+  }
+}
+@media (1250px < width) {
+  ._11t98zr0:nth-child(3n+1):nth-last-child(-n+5) {
+    border-bottom: none;
+  }
+  ._11t98zr0:nth-child(3n+1):nth-last-child(-n+5) ~ ._11t98zr0 {
+    border-bottom: none;
+  }
+}
 ._1s4anja0 {
   margin-left: -8px;
   margin-right: -8px;
@@ -7554,46 +7594,6 @@ body {
 @media (1250px < width) {
   ._1a4jm568 {
     grid-template-columns: 1fr 1fr 1fr;
-  }
-}
-._11t98zr0 {
-  border-bottom: var(--_1pyqka9k) solid 1px;
-  height: 280px;
-}
-._11t98zr1 {
-  height: 100%;
-  background-color: #ffffff;
-}
-._11t98zr2 {
-  cursor: grab;
-  border-bottom: none;
-}
-._11t98zr3 {
-  cursor: grabbing;
-  z-index: 1;
-}
-@media (width <= 850px) {
-  ._11t98zr0:nth-child(n+1):nth-last-child(-n+3) {
-    border-bottom: none;
-  }
-  ._11t98zr0:nth-child(n+1):nth-last-child(-n+3) ~ ._11t98zr0 {
-    border-bottom: none;
-  }
-}
-@media (850px < width <= 1250px) {
-  ._11t98zr0:nth-child(2n+1):nth-last-child(-n+4) {
-    border-bottom: none;
-  }
-  ._11t98zr0:nth-child(2n+1):nth-last-child(-n+4) ~ ._11t98zr0 {
-    border-bottom: none;
-  }
-}
-@media (1250px < width) {
-  ._11t98zr0:nth-child(3n+1):nth-last-child(-n+5) {
-    border-bottom: none;
-  }
-  ._11t98zr0:nth-child(3n+1):nth-last-child(-n+5) ~ ._11t98zr0 {
-    border-bottom: none;
   }
 }
 ._1y9te7a0 {

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -4765,9 +4765,12 @@ body {
   }
 }
 .n4pjg80 {
-  display: none;
+  flex: 1;
 }
 .n4pjg81 {
+  display: none;
+}
+.n4pjg82 {
   align-items: center;
   background-color: #ffffff;
   border: var(--_1pyqka91o) solid 1px;
@@ -4779,36 +4782,36 @@ body {
   height: 20px;
   padding: 0 6px;
 }
-.n4pjg81:hover {
+.n4pjg82:hover {
   cursor: pointer;
   background: var(--_1pyqka91x);
 }
-.n4pjg82 {
+.n4pjg83 {
   width: 100%;
   border: none;
   font-size: 13px;
   font-weight: 500 !important;
 }
-.n4pjg82:focus-visible {
+.n4pjg83:focus-visible {
   outline: none;
 }
-.n4pjg82::placeholder {
+.n4pjg83::placeholder {
   color: var(--_1pyqka9x);
 }
-.n4pjg83 {
+.n4pjg84 {
   padding: 6px 8px;
   display: flex;
   gap: 4px;
   align-items: center;
 }
-.n4pjg84 {
+.n4pjg85 {
   border-bottom: 1px solid #dcdbdd;
 }
-.n4pjg85 {
+.n4pjg86 {
   max-height: 380px;
   overflow-y: auto;
 }
-.n4pjg86 {
+.n4pjg87 {
   background-color: #ffffff;
   border: var(--_1pyqka91o) solid 1px;
   border-radius: 6px;
@@ -4817,33 +4820,33 @@ body {
   max-width: 50vw;
   box-shadow: 0 6px 12px -2px rgba(59, 59, 59, 0.12);
 }
-.n4pjg87 {
+.n4pjg88 {
   align-items: center;
   display: flex;
   font-size: 13px;
   gap: 6px;
   padding: 6px 8px;
 }
-.n4pjg87[data-active-item] {
+.n4pjg88[data-active-item] {
   background-color: #e9e8ea;
   color: var(--_1pyqka9b);
   cursor: pointer;
 }
-.n4pjg88 {
+.n4pjg89 {
   font-weight: 500;
   color: var(--_1pyqka9c);
   justify-content: center;
 }
-.n4pjg89 {
+.n4pjg8a {
   border: var(--_1pyqka91o) solid 1px;
   border-radius: 4px;
   display: flex;
   padding: 1px;
 }
-.n4pjg87[aria-selected=true] .n4pjg89 {
+.n4pjg88[aria-selected=true] .n4pjg8a {
   background-color: var(--_1pyqka9l);
 }
-.n4pjg87[aria-selected=false] .n4pjg89 {
+.n4pjg88[aria-selected=false] .n4pjg8a {
   background-color: white;
 }
 ._1ec5cce1 {
@@ -7627,20 +7630,29 @@ body {
   margin-bottom: 4px;
 }
 .gw96js7 {
-  border: var(--_1pyqka9j) solid 1px;
   width: 100%;
+  height: 28px;
+  border-radius: 6px;
 }
 .gw96js8 {
-  height: 28px;
+  line-height: 24px;
 }
 .gw96js9 {
+  border: var(--_1pyqka9j) solid 1px;
+  width: 100%;
+  flex: 1;
+}
+.gw96jsa {
+  height: 28px;
+}
+.gw96jsb {
   width: 720px;
   height: 360px;
   margin: auto;
   z-index: 1;
   background-color: #ffffff;
 }
-.gw96js7 > div {
+.gw96js9 > div {
   width: 100%;
 }
 ._1kp6do40 {

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7435,6 +7435,9 @@ body {
 ._1s4anja2::-webkit-scrollbar {
   display: none;
 }
+._1s4anja3 {
+  overflow-y: hidden;
+}
 .dg2vg60 {
   z-index: 2;
   backdrop-filter: grayscale(50%);
@@ -7469,6 +7472,8 @@ body {
 .dg2vg66 {
   line-height: 24px;
   height: 24px;
+  align-items: center;
+  display: flex;
 }
 .dg2vg67 {
   visibility: hidden;
@@ -7491,6 +7496,9 @@ body {
   margin-right: 4px;
   width: 8px;
   height: 8px;
+}
+.dg2vg6b {
+  pointer-events: none;
 }
 ._1a4jm560 {
   height: 40px;
@@ -7528,7 +7536,7 @@ body {
   grid-template-rows: repeat(auto-fill, 280px);
 }
 ._1a4jm569 {
-  border-bottom: var(--_1pyqka9k) solid 1px;
+  background-color: var(--_1pyqka92);
 }
 ._1a4jm566 > div {
   width: 100%;
@@ -7537,32 +7545,54 @@ body {
   ._1a4jm568 {
     grid-template-columns: 1fr;
   }
-  ._1a4jm569:nth-child(n+1):nth-last-child(-n+1) {
-    border-bottom: none;
-  }
-  ._1a4jm569:nth-child(n+1):nth-last-child(-n+1) ~ ._1a4jm569 {
-    border-bottom: none;
-  }
 }
 @media (850px < width <= 1250px) {
   ._1a4jm568 {
     grid-template-columns: 1fr 1fr;
-  }
-  ._1a4jm569:nth-child(2n+1):nth-last-child(-n+2) {
-    border-bottom: none;
-  }
-  ._1a4jm569:nth-child(2n+1):nth-last-child(-n+2) ~ ._1a4jm569 {
-    border-bottom: none;
   }
 }
 @media (1250px < width) {
   ._1a4jm568 {
     grid-template-columns: 1fr 1fr 1fr;
   }
-  ._1a4jm569:nth-child(3n+1):nth-last-child(-n+3) {
+}
+._11t98zr0 {
+  border-bottom: var(--_1pyqka9k) solid 1px;
+  height: 280px;
+}
+._11t98zr1 {
+  height: 100%;
+  background-color: #ffffff;
+}
+._11t98zr2 {
+  cursor: grab;
+  border-bottom: none;
+}
+._11t98zr3 {
+  cursor: grabbing;
+  z-index: 1;
+}
+@media (width <= 850px) {
+  ._11t98zr0:nth-child(n+1):nth-last-child(-n+3) {
     border-bottom: none;
   }
-  ._1a4jm569:nth-child(3n+1):nth-last-child(-n+3) ~ ._1a4jm569 {
+  ._11t98zr0:nth-child(n+1):nth-last-child(-n+3) ~ ._11t98zr0 {
+    border-bottom: none;
+  }
+}
+@media (850px < width <= 1250px) {
+  ._11t98zr0:nth-child(2n+1):nth-last-child(-n+4) {
+    border-bottom: none;
+  }
+  ._11t98zr0:nth-child(2n+1):nth-last-child(-n+4) ~ ._11t98zr0 {
+    border-bottom: none;
+  }
+}
+@media (1250px < width) {
+  ._11t98zr0:nth-child(3n+1):nth-last-child(-n+5) {
+    border-bottom: none;
+  }
+  ._11t98zr0:nth-child(3n+1):nth-last-child(-n+5) ~ ._11t98zr0 {
     border-bottom: none;
   }
 }

--- a/frontend/src/__generated/ve/pages/Graphing/Dashboard.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/Dashboard.css.js
@@ -4,8 +4,8 @@ var editGraphHeader = "_1a4jm560";
 var editGraphSidebar = "_1a4jm564";
 var editorLabel = "_1a4jm565";
 var graphBackground = "_1a4jm563";
-var graphDivider = "_1a4jm569";
 var graphGrid = "_1a4jm568";
+var gridEditing = "_1a4jm569";
 var headerDivider = "_1a4jm562";
 var input = "_1a4jm567";
 var menuButton = "_1a4jm566";
@@ -15,8 +15,8 @@ export {
   editGraphSidebar,
   editorLabel,
   graphBackground,
-  graphDivider,
   graphGrid,
+  gridEditing,
   headerDivider,
   input,
   menuButton

--- a/frontend/src/__generated/ve/pages/Graphing/GraphingEditor.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/GraphingEditor.css.js
@@ -1,15 +1,19 @@
 // src/pages/Graphing/GraphingEditor.css.ts
+var combobox = "gw96js7";
+var comboboxText = "gw96js8";
 var editGraphHeader = "gw96js0";
 var editGraphPanel = "gw96js1";
 var editGraphSidebar = "gw96js5";
 var editorLabel = "gw96js6";
 var graphBackground = "gw96js4";
-var graphWrapper = "gw96js9";
-var input = "gw96js8";
-var menuButton = "gw96js7";
+var graphWrapper = "gw96jsb";
+var input = "gw96jsa";
+var menuButton = "gw96js9";
 var previewWindow = "gw96js2";
 var tagSwitch = "gw96js3";
 export {
+  combobox,
+  comboboxText,
   editGraphHeader,
   editGraphPanel,
   editGraphSidebar,

--- a/frontend/src/__generated/ve/pages/Graphing/components/DashboardCard.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/components/DashboardCard.css.js
@@ -1,0 +1,11 @@
+// src/pages/Graphing/components/DashboardCard.css.ts
+var cardInner = "_11t98zr1";
+var dragging = "_11t98zr3";
+var editing = "_11t98zr2";
+var graphCard = "_11t98zr0";
+export {
+  cardInner,
+  dragging,
+  editing,
+  graphCard
+};

--- a/frontend/src/__generated/ve/pages/Graphing/components/Graph.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/components/Graph.css.js
@@ -1,4 +1,5 @@
 // src/pages/Graphing/components/Graph.css.ts
+var disabled = "dg2vg6b";
 var hiddenMenu = "dg2vg67";
 var legendDot = "dg2vg63";
 var legendTextButton = "dg2vg65";
@@ -11,6 +12,7 @@ var tooltipDot = "dg2vg6a";
 var tooltipText = "dg2vg69";
 var tooltipWrapper = "dg2vg68";
 export {
+  disabled,
   hiddenMenu,
   legendDot,
   legendTextButton,

--- a/frontend/src/__generated/ve/pages/Graphing/components/Table.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/components/Table.css.js
@@ -1,9 +1,11 @@
 // src/pages/Graphing/components/Table.css.ts
 var fullHeight = "_1s4anja1";
+var preventScroll = "_1s4anja3";
 var scrollableBody = "_1s4anja2";
 var tableWrapper = "_1s4anja0";
 export {
   fullHeight,
+  preventScroll,
   scrollableBody,
   tableWrapper
 };

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -3729,6 +3729,7 @@ export type Visualization = {
 }
 
 export type VisualizationInput = {
+	graphIds?: InputMaybe<Array<Scalars['ID']>>
 	id?: InputMaybe<Scalars['ID']>
 	name: Scalars['String']
 	projectId: Scalars['ID']

--- a/frontend/src/pages/Graphing/Dashboard.css.ts
+++ b/frontend/src/pages/Graphing/Dashboard.css.ts
@@ -57,41 +57,8 @@ export const graphGrid = style({
 	},
 })
 
-export const graphDivider = style({
-	borderBottom: vars.border.dividerWeak,
-
-	'@media': {
-		[`(width <= 850px)`]: {
-			selectors: {
-				'&:nth-child(1n + 1):nth-last-child(-n + 1)': {
-					borderBottom: 'none',
-				},
-				'&:nth-child(1n + 1):nth-last-child(-n + 1) ~ &': {
-					borderBottom: 'none',
-				},
-			},
-		},
-		[`(850px < width <= 1250px)`]: {
-			selectors: {
-				'&:nth-child(2n + 1):nth-last-child(-n + 2)': {
-					borderBottom: 'none',
-				},
-				'&:nth-child(2n + 1):nth-last-child(-n + 2) ~ &': {
-					borderBottom: 'none',
-				},
-			},
-		},
-		[`(1250px < width)`]: {
-			selectors: {
-				'&:nth-child(3n + 1):nth-last-child(-n + 3)': {
-					borderBottom: 'none',
-				},
-				'&:nth-child(3n + 1):nth-last-child(-n + 3) ~ &': {
-					borderBottom: 'none',
-				},
-			},
-		},
-	},
+export const gridEditing = style({
+	backgroundColor: vars.theme.static.surface.raised,
 })
 
 globalStyle(`${menuButton} > div`, {

--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -1,4 +1,18 @@
 import {
+	closestCenter,
+	DndContext,
+	KeyboardSensor,
+	PointerSensor,
+	useSensor,
+	useSensors,
+} from '@dnd-kit/core'
+import {
+	arrayMove,
+	rectSortingStrategy,
+	SortableContext,
+	sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable'
+import {
 	Box,
 	Button,
 	Form,
@@ -12,6 +26,8 @@ import {
 } from '@highlight-run/ui/components'
 import { vars } from '@highlight-run/ui/vars'
 import { message } from 'antd'
+import clsx from 'clsx'
+import { useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { Link, useNavigate } from 'react-router-dom'
 
@@ -27,28 +43,11 @@ import {
 } from '@/graph/generated/operations'
 import useDataTimeRange from '@/hooks/useDataTimeRange'
 import { useProjectId } from '@/hooks/useProjectId'
+import { DashboardCard } from '@/pages/Graphing/components/DashboardCard'
 import Graph, { getViewConfig } from '@/pages/Graphing/components/Graph'
 import { useParams } from '@/util/react-router/useParams'
 
 import * as style from './Dashboard.css'
-import { useState } from 'react'
-import clsx from 'clsx'
-import { DashboardCard } from '@/pages/Graphing/components/DashboardCard'
-
-import {
-	DndContext,
-	closestCenter,
-	KeyboardSensor,
-	PointerSensor,
-	useSensor,
-	useSensors,
-} from '@dnd-kit/core'
-import {
-	arrayMove,
-	SortableContext,
-	sortableKeyboardCoordinates,
-	rectSortingStrategy,
-} from '@dnd-kit/sortable'
 
 export const HeaderDivider = () => <Box cssClass={style.headerDivider} />
 
@@ -86,7 +85,7 @@ export const Dashboard = () => {
 	}
 
 	const { projectId } = useProjectId()
-	const { data } = useGetVisualizationQuery({
+	useGetVisualizationQuery({
 		variables: { id: dashboard_id! },
 		fetchPolicy: 'cache-and-network',
 		onCompleted: (d) => {

--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -1,9 +1,11 @@
 import {
 	Box,
 	Button,
+	Form,
 	IconSolidChartBar,
 	IconSolidCheveronRight,
 	IconSolidPlus,
+	IconSolidTemplate,
 	Stack,
 	Tag,
 	Text,
@@ -17,14 +19,36 @@ import TimeRangePicker from '@/components/TimeRangePicker/TimeRangePicker'
 import {
 	useDeleteGraphMutation,
 	useGetVisualizationQuery,
+	useUpsertVisualizationMutation,
 } from '@/graph/generated/hooks'
-import { namedOperations } from '@/graph/generated/operations'
+import {
+	GetVisualizationQuery,
+	namedOperations,
+} from '@/graph/generated/operations'
 import useDataTimeRange from '@/hooks/useDataTimeRange'
 import { useProjectId } from '@/hooks/useProjectId'
 import Graph, { getViewConfig } from '@/pages/Graphing/components/Graph'
 import { useParams } from '@/util/react-router/useParams'
 
 import * as style from './Dashboard.css'
+import { useState } from 'react'
+import clsx from 'clsx'
+import { DashboardCard } from '@/pages/Graphing/components/DashboardCard'
+
+import {
+	DndContext,
+	closestCenter,
+	KeyboardSensor,
+	PointerSensor,
+	useSensor,
+	useSensors,
+} from '@dnd-kit/core'
+import {
+	arrayMove,
+	SortableContext,
+	sortableKeyboardCoordinates,
+	rectSortingStrategy,
+} from '@dnd-kit/sortable'
 
 export const HeaderDivider = () => <Box cssClass={style.headerDivider} />
 
@@ -33,11 +57,45 @@ export const Dashboard = () => {
 		dashboard_id: string
 	}>()
 
+	const sensors = useSensors(
+		useSensor(PointerSensor),
+		useSensor(KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+		}),
+	)
+
+	const [editing, setEditing] = useState(false)
+	const [name, setName] = useState('')
+	const [graphs, setGraphs] =
+		useState<GetVisualizationQuery['visualization']['graphs']>()
+	const handleDragEnd = (event: any) => {
+		const { active, over } = event
+
+		if (active.id !== over.id) {
+			setGraphs((graphs) => {
+				if (graphs === undefined) {
+					return undefined
+				}
+
+				const oldIndex = graphs.findIndex((g) => g.id === active.id)
+				const newIndex = graphs.findIndex((g) => g.id === over.id)
+
+				return arrayMove(graphs, oldIndex, newIndex)
+			})
+		}
+	}
+
 	const { projectId } = useProjectId()
 	const { data } = useGetVisualizationQuery({
 		variables: { id: dashboard_id! },
 		fetchPolicy: 'cache-and-network',
+		onCompleted: (d) => {
+			setName(d.visualization.name)
+			setGraphs(d.visualization.graphs)
+		},
 	})
+
+	const [upsertViz] = useUpsertVisualizationMutation({})
 
 	const { timeRange } = useDataTimeRange()
 
@@ -50,7 +108,7 @@ export const Dashboard = () => {
 	return (
 		<>
 			<Helmet>
-				<title>{data?.visualization.name}</title>
+				<title>{name}</title>
 			</Helmet>
 			<Box
 				background="n2"
@@ -95,26 +153,85 @@ export const Dashboard = () => {
 							<IconSolidCheveronRight
 								color={vars.theme.static.content.weak}
 							/>
-							<Text size="small" weight="medium" color="default">
-								{data?.visualization.name}
-							</Text>
+							{editing ? (
+								<Form autoComplete="off">
+									<Form.Input
+										name="name"
+										value={name}
+										onChange={(e) => {
+											setName(e.target.value)
+										}}
+										placeholder="Untitled dashboard"
+									></Form.Input>
+								</Form>
+							) : (
+								<Text
+									size="small"
+									weight="medium"
+									color="default"
+								>
+									{name}
+								</Text>
+							)}
 						</Stack>
 						<Box display="flex" gap="4">
-							<Button emphasis="low" kind="secondary">
-								Share
-							</Button>
-							<TimeRangePicker emphasis="low" kind="secondary" />
-							<HeaderDivider />
-							<Button
-								emphasis="low"
-								kind="secondary"
-								iconLeft={<IconSolidPlus />}
-								onClick={() => {
-									navigate('new')
-								}}
-							>
-								Add graph
-							</Button>
+							{editing ? (
+								<Button
+									emphasis="high"
+									kind="primary"
+									onClick={() => {
+										setEditing(false)
+										const graphIds = graphs?.map(
+											(g) => g.id,
+										)
+										upsertViz({
+											variables: {
+												visualization: {
+													projectId,
+													id: dashboard_id,
+													name,
+													graphIds: graphIds,
+												},
+											},
+										}).then(() => {
+											message.success('Dashboard updated')
+										})
+									}}
+								>
+									Done
+								</Button>
+							) : (
+								<>
+									<Button emphasis="low" kind="secondary">
+										Share
+									</Button>
+									<TimeRangePicker
+										emphasis="low"
+										kind="secondary"
+									/>
+									<HeaderDivider />
+									<Button
+										emphasis="low"
+										kind="secondary"
+										iconLeft={<IconSolidTemplate />}
+										onClick={() => {
+											setEditing(true)
+										}}
+									>
+										Edit dashboard
+									</Button>
+									<Button
+										emphasis="low"
+										kind="secondary"
+										iconLeft={<IconSolidPlus />}
+										onClick={() => {
+											navigate('new')
+										}}
+									>
+										Add graph
+									</Button>
+								</>
+							)}
 						</Box>
 					</Box>
 					<Box
@@ -130,71 +247,109 @@ export const Dashboard = () => {
 							width="full"
 							height="full"
 						>
-							<Box cssClass={style.graphGrid}>
-								{data?.visualization.graphs.map((g) => {
-									return (
-										<Box
-											key={g.id}
-											px="16"
-											py="12"
-											cssClass={style.graphDivider}
-										>
-											<Graph
-												title={g.title}
-												viewConfig={getViewConfig(
-													g.type,
-													g.display ?? undefined,
-													g.nullHandling ?? undefined,
-												)}
-												productType={g.productType}
-												projectId={projectId}
-												startDate={timeRange.start_date}
-												endDate={timeRange.end_date}
-												query={g.query}
-												metric={g.metric}
-												functionType={g.functionType}
-												bucketByKey={
-													g.bucketByKey ?? undefined
-												}
-												bucketCount={
-													g.bucketCount ?? undefined
-												}
-												groupByKey={
-													g.groupByKey ?? undefined
-												}
-												limit={g.limit ?? undefined}
-												limitFunctionType={
-													g.limitFunctionType ??
-													undefined
-												}
-												limitMetric={
-													g.limitMetric ?? undefined
-												}
-												onDelete={() => {
-													deleteGraph({
-														variables: { id: g.id },
-													})
-														.then(() =>
-															message.success(
-																'Metric view deleted',
-															),
-														)
-														.catch(() =>
-															message.error(
-																'Failed to delete metric view',
-															),
-														)
-												}}
-												onExpand={() => {
-													navigate(`view/${g.id}`)
-												}}
-												onEdit={() => {
-													navigate(`edit/${g.id}`)
-												}}
-											/>
-										</Box>
-									)
+							<Box
+								cssClass={clsx(style.graphGrid, {
+									[style.gridEditing]: editing,
 								})}
+							>
+								<DndContext
+									sensors={sensors}
+									collisionDetection={closestCenter}
+									onDragEnd={handleDragEnd}
+								>
+									<SortableContext
+										items={graphs ?? []}
+										strategy={rectSortingStrategy}
+										disabled={!editing}
+									>
+										{graphs?.map((g) => {
+											return (
+												<DashboardCard
+													id={g.id}
+													key={g.id}
+													editing={editing}
+												>
+													<Graph
+														title={g.title}
+														viewConfig={getViewConfig(
+															g.type,
+															g.display ??
+																undefined,
+															g.nullHandling ??
+																undefined,
+														)}
+														productType={
+															g.productType
+														}
+														projectId={projectId}
+														startDate={
+															timeRange.start_date
+														}
+														endDate={
+															timeRange.end_date
+														}
+														query={g.query}
+														metric={g.metric}
+														functionType={
+															g.functionType
+														}
+														bucketByKey={
+															g.bucketByKey ??
+															undefined
+														}
+														bucketCount={
+															g.bucketCount ??
+															undefined
+														}
+														groupByKey={
+															g.groupByKey ??
+															undefined
+														}
+														limit={
+															g.limit ?? undefined
+														}
+														limitFunctionType={
+															g.limitFunctionType ??
+															undefined
+														}
+														limitMetric={
+															g.limitMetric ??
+															undefined
+														}
+														onDelete={() => {
+															deleteGraph({
+																variables: {
+																	id: g.id,
+																},
+															})
+																.then(() =>
+																	message.success(
+																		'Metric view deleted',
+																	),
+																)
+																.catch(() =>
+																	message.error(
+																		'Failed to delete metric view',
+																	),
+																)
+														}}
+														onExpand={() => {
+															navigate(
+																`view/${g.id}`,
+															)
+														}}
+														onEdit={() => {
+															navigate(
+																`edit/${g.id}`,
+															)
+														}}
+														disabled={editing}
+													/>
+												</DashboardCard>
+											)
+										})}
+									</SortableContext>
+								</DndContext>
 							</Box>
 						</Box>
 					</Box>

--- a/frontend/src/pages/Graphing/DashboardOverview.tsx
+++ b/frontend/src/pages/Graphing/DashboardOverview.tsx
@@ -66,7 +66,7 @@ export default function DashboardOverview() {
 	const [upsertViz, upsertContext] = useUpsertVisualizationMutation({
 		variables: {
 			visualization: {
-				name: 'Untitled Dashboard',
+				name: 'Untitled dashboard',
 				projectId: projectId,
 			},
 		},

--- a/frontend/src/pages/Graphing/GraphingEditor.css.ts
+++ b/frontend/src/pages/Graphing/GraphingEditor.css.ts
@@ -29,9 +29,20 @@ export const editorLabel = style({
 	marginBottom: 4,
 })
 
+export const combobox = style({
+	width: '100%',
+	height: 28,
+	borderRadius: 6,
+})
+
+export const comboboxText = style({
+	lineHeight: '24px',
+})
+
 export const menuButton = style({
 	border: vars.border.divider,
 	width: '100%',
+	flex: 1,
 })
 
 export const input = style({

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -18,7 +18,7 @@ import {
 } from '@highlight-run/ui/components'
 import { useParams } from '@util/react-router/useParams'
 import { Divider, message } from 'antd'
-import { PropsWithChildren, useEffect, useMemo, useState } from 'react'
+import { PropsWithChildren, useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
 import { useDebounce } from 'react-use'

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -46,6 +46,7 @@ import Graph, {
 	TIMESTAMP_KEY,
 	View,
 	VIEW_ICONS,
+	VIEW_LABELS,
 	VIEWS,
 } from '@/pages/Graphing/components/Graph'
 import {
@@ -174,14 +175,17 @@ const OptionDropdown = <T extends string>({
 	selection,
 	setSelection,
 	icons,
+	labels,
 }: {
 	options: T[]
 	selection: T
 	setSelection: (option: T) => void
 	icons?: JSX.Element[]
+	labels?: string[]
 }) => {
 	const selectedIndex = options.indexOf(selection)
 	const selectedIcon = icons?.at(selectedIndex)
+	const selectedLabel = labels?.at(selectedIndex)
 	return (
 		<Menu>
 			<Menu.Button
@@ -199,7 +203,7 @@ const OptionDropdown = <T extends string>({
 				>
 					<Stack direction="row" alignItems="center" gap="4">
 						{selectedIcon}
-						{selection}
+						{selectedLabel ?? selection}
 					</Stack>
 					<IconSolidCheveronDown />
 				</Box>
@@ -214,7 +218,7 @@ const OptionDropdown = <T extends string>({
 					>
 						<Stack direction="row" alignItems="center" gap="4">
 							{icons?.at(idx)}
-							{p}
+							{labels?.at(idx) ?? p}
 						</Stack>
 					</Menu.Item>
 				))}
@@ -732,6 +736,7 @@ export const GraphingEditor = () => {
 											selection={viewType}
 											setSelection={setViewType}
 											icons={VIEW_ICONS}
+											labels={VIEW_LABELS}
 										/>
 									</LabeledRow>
 									{viewType === 'Line chart' && (

--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -1,13 +1,13 @@
+import { useId } from 'react'
 import {
 	Bar,
 	BarChart as RechartsBarChart,
+	BarProps,
 	CartesianGrid,
 	ResponsiveContainer,
 	Tooltip,
 	XAxis,
 	YAxis,
-	Cell,
-	BarProps,
 } from 'recharts'
 
 import {
@@ -21,7 +21,6 @@ import {
 	isActive,
 	SeriesInfo,
 } from '@/pages/Graphing/components/Graph'
-import { useId } from 'react'
 
 export type BarDisplay = 'Grouped' | 'Stacked'
 export const BAR_DISPLAY: BarDisplay[] = ['Grouped', 'Stacked']

--- a/frontend/src/pages/Graphing/components/DashboardCard.css.ts
+++ b/frontend/src/pages/Graphing/components/DashboardCard.css.ts
@@ -1,0 +1,52 @@
+import { vars } from '@highlight-run/ui/vars'
+import { style } from '@vanilla-extract/css'
+
+export const graphCard = style({
+	borderBottom: vars.border.dividerWeak,
+
+	'@media': {
+		[`(width <= 850px)`]: {
+			selectors: {
+				'&:nth-child(1n + 1):nth-last-child(-n + 3)': {
+					borderBottom: 'none',
+				},
+				'&:nth-child(1n + 1):nth-last-child(-n + 3) ~ &': {
+					borderBottom: 'none',
+				},
+			},
+		},
+		[`(850px < width <= 1250px)`]: {
+			selectors: {
+				'&:nth-child(2n + 1):nth-last-child(-n + 4)': {
+					borderBottom: 'none',
+				},
+				'&:nth-child(2n + 1):nth-last-child(-n + 4) ~ &': {
+					borderBottom: 'none',
+				},
+			},
+		},
+		[`(1250px < width)`]: {
+			selectors: {
+				'&:nth-child(3n + 1):nth-last-child(-n + 5)': {
+					borderBottom: 'none',
+				},
+				'&:nth-child(3n + 1):nth-last-child(-n + 5) ~ &': {
+					borderBottom: 'none',
+				},
+			},
+		},
+	},
+
+	height: '280px',
+})
+
+export const cardInner = style({
+	height: '100%',
+	backgroundColor: vars.color.white,
+})
+
+export const editing = style({ cursor: 'grab', borderBottom: 'none' })
+export const dragging = style({
+	cursor: 'grabbing',
+	zIndex: 1,
+})

--- a/frontend/src/pages/Graphing/components/DashboardCard.tsx
+++ b/frontend/src/pages/Graphing/components/DashboardCard.tsx
@@ -1,10 +1,9 @@
-import { Box } from '@highlight-run/ui/components'
-
-import * as style from './DashboardCard.css'
-
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import { Box } from '@highlight-run/ui/components'
 import clsx from 'clsx'
+
+import * as style from './DashboardCard.css'
 
 export const DashboardCard = ({
 	id,

--- a/frontend/src/pages/Graphing/components/DashboardCard.tsx
+++ b/frontend/src/pages/Graphing/components/DashboardCard.tsx
@@ -1,0 +1,46 @@
+import { Box } from '@highlight-run/ui/components'
+
+import * as style from './DashboardCard.css'
+
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import clsx from 'clsx'
+
+export const DashboardCard = ({
+	id,
+	children,
+	editing,
+}: React.PropsWithChildren<{ id: string; editing: boolean }>) => {
+	const {
+		attributes,
+		listeners,
+		setNodeRef,
+		transform,
+		transition,
+		isDragging,
+	} = useSortable({ id })
+
+	const dndStyle = {
+		transform: CSS.Transform.toString(transform),
+		transition,
+	}
+
+	return (
+		<Box
+			px="8"
+			py="6"
+			cssClass={clsx(style.graphCard, {
+				[style.dragging]: isDragging,
+				[style.editing]: editing,
+			})}
+			ref={setNodeRef}
+			style={dndStyle}
+			{...attributes}
+			{...listeners}
+		>
+			<Box borderRadius="6" px="8" py="6" cssClass={style.cardInner}>
+				{children}
+			</Box>
+		</Box>
+	)
+}

--- a/frontend/src/pages/Graphing/components/Graph.css.ts
+++ b/frontend/src/pages/Graphing/components/Graph.css.ts
@@ -41,6 +41,8 @@ export const legendTextButton = style({
 export const titleText = style({
 	lineHeight: '24px',
 	height: '24px',
+	alignItems: 'center',
+	display: 'flex',
 })
 
 export const hiddenMenu = style({
@@ -67,4 +69,8 @@ export const tooltipDot = style({
 	marginRight: '4px',
 	width: 8,
 	height: 8,
+})
+
+export const disabled = style({
+	pointerEvents: 'none',
 })

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -88,6 +88,7 @@ export interface ChartProps<TConfig> {
 	limitFunctionType?: MetricAggregator
 	limitMetric?: string
 	viewConfig: TConfig
+	disabled?: boolean
 	onDelete?: () => void
 	onExpand?: () => void
 	onEdit?: () => void
@@ -101,6 +102,7 @@ export interface InnerChartProps<TConfig> {
 	title?: string
 	loading?: boolean
 	viewConfig: TConfig
+	disabled?: boolean
 }
 
 export interface SeriesInfo {
@@ -328,6 +330,7 @@ const Graph = ({
 	limitMetric,
 	title,
 	viewConfig,
+	disabled,
 	onDelete,
 	onExpand,
 	onEdit,
@@ -474,6 +477,7 @@ const Graph = ({
 						yAxisFunction={yAxisFunction}
 						viewConfig={viewConfig}
 						series={series}
+						disabled={disabled}
 					/>
 				)
 				break
@@ -522,13 +526,11 @@ const Graph = ({
 					>
 						{title || 'Untitled metric view'}
 					</Text>
-					{showMenu && graphHover && (
+					{showMenu && graphHover && !disabled && (
 						<Box
-							cssClass={
-								graphHover
-									? style.titleText
-									: clsx(style.titleText, style.hiddenMenu)
-							}
+							cssClass={clsx(style.titleText, {
+								[style.hiddenMenu]: !graphHover,
+							})}
 						>
 							{onExpand !== undefined && (
 								<Button
@@ -581,9 +583,9 @@ const Graph = ({
 						</Box>
 					)}
 				</Box>
-				<Box position="relative" cssClass={style.legendWrapper}>
-					{showLegend &&
-						series.map((key, idx) => {
+				{showLegend && (
+					<Box position="relative" cssClass={style.legendWrapper}>
+						{series.map((key, idx) => {
 							return (
 								<Button
 									kind="secondary"
@@ -643,12 +645,14 @@ const Graph = ({
 								</Button>
 							)
 						})}
-				</Box>
+					</Box>
+				)}
 			</Box>
 			<Box
 				height="full"
 				maxHeight="screen"
 				key={series.join(';')} // Hacky but recharts' ResponsiveContainer has issues when this height changes so just rerender the whole thing
+				cssClass={clsx({ [style.disabled]: disabled })}
 			>
 				{innerChart}
 			</Box>

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -50,6 +50,7 @@ export const VIEW_ICONS = [
 	<IconSolidChartSquareBar size={16} key="bar chart" />,
 	<IconSolidTable size={16} key="table" />,
 ]
+export const VIEW_LABELS = ['Line chart', 'Bar chart / histogram', 'Table']
 
 export const TIMESTAMP_KEY = 'Timestamp'
 export const GROUP_KEY = 'Group'
@@ -410,8 +411,6 @@ const Graph = ({
 	useEffect(() => {
 		setSpotlight(undefined)
 	}, [series])
-
-	console.log('data', data)
 
 	let isEmpty = data !== undefined
 	for (const d of data ?? []) {

--- a/frontend/src/pages/Graphing/components/Table.css.ts
+++ b/frontend/src/pages/Graphing/components/Table.css.ts
@@ -17,3 +17,7 @@ export const scrollableBody = style({
 		},
 	},
 })
+
+export const preventScroll = style({
+	overflowY: 'hidden',
+})

--- a/frontend/src/pages/Graphing/components/Table.tsx
+++ b/frontend/src/pages/Graphing/components/Table.tsx
@@ -1,4 +1,5 @@
 import { Box, Table, Text } from '@highlight-run/ui/components'
+import clsx from 'clsx'
 
 import {
 	getTickFormatter,
@@ -8,7 +9,6 @@ import {
 } from '@/pages/Graphing/components/Graph'
 
 import * as style from './Table.css'
-import clsx from 'clsx'
 
 export type TableNullHandling = 'Hide row' | 'Blank' | 'Zero'
 export const TABLE_NULL_HANDLING: TableNullHandling[] = [

--- a/frontend/src/pages/Graphing/components/Table.tsx
+++ b/frontend/src/pages/Graphing/components/Table.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/pages/Graphing/components/Graph'
 
 import * as style from './Table.css'
+import clsx from 'clsx'
 
 export type TableNullHandling = 'Hide row' | 'Blank' | 'Zero'
 export const TABLE_NULL_HANDLING: TableNullHandling[] = [
@@ -36,6 +37,7 @@ export const MetricTable = ({
 	yAxisFunction,
 	series,
 	viewConfig,
+	disabled,
 }: InnerChartProps<TableConfig> & SeriesInfo) => {
 	const xAxisTickFormatter = getTickFormatter(xAxisMetric)
 	const valueFormatter = getTickFormatter(yAxisMetric)
@@ -65,7 +67,12 @@ export const MetricTable = ({
 						))}
 					</Table.Row>
 				</Table.Head>
-				<Box height="full" cssClass={style.scrollableBody}>
+				<Box
+					height="full"
+					cssClass={clsx(style.scrollableBody, {
+						[style.preventScroll]: disabled,
+					})}
+				>
 					<Table.Body>
 						{data?.map((d, i) => {
 							// If every value for the bucket is null, skip this row

--- a/packages/ui/src/__generated/ve/components/ComboboxSelect/styles.css.js
+++ b/packages/ui/src/__generated/ve/components/ComboboxSelect/styles.css.js
@@ -1,15 +1,17 @@
 // ../packages/ui/src/components/ComboboxSelect/styles.css.ts
-var checkbox = "n4pjg89";
-var combobox = "n4pjg82";
-var comboboxHasResults = "n4pjg84";
-var comboboxList = "n4pjg85";
-var comboboxWrapper = "n4pjg83";
-var selectButton = "n4pjg81";
-var selectItem = "n4pjg87";
-var selectLabel = "n4pjg80";
-var selectPopover = "n4pjg86";
-var statePlaceholder = "n4pjg88";
+var buttonWrapper = "n4pjg80";
+var checkbox = "n4pjg8a";
+var combobox = "n4pjg83";
+var comboboxHasResults = "n4pjg85";
+var comboboxList = "n4pjg86";
+var comboboxWrapper = "n4pjg84";
+var selectButton = "n4pjg82";
+var selectItem = "n4pjg88";
+var selectLabel = "n4pjg81";
+var selectPopover = "n4pjg87";
+var statePlaceholder = "n4pjg89";
 export {
+  buttonWrapper,
   checkbox,
   combobox,
   comboboxHasResults,

--- a/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
+++ b/packages/ui/src/components/ComboboxSelect/ComboboxSelect.tsx
@@ -99,7 +99,7 @@ export const ComboboxSelect = <T extends string | string[]>({
 	const allOptions = queryOptions.concat(createdOptions).concat(options ?? [])
 
 	return (
-		<div>
+		<div className={styles.buttonWrapper}>
 			<SelectLabel store={select} className={styles.selectLabel}>
 				{label}
 			</SelectLabel>

--- a/packages/ui/src/components/ComboboxSelect/styles.css.ts
+++ b/packages/ui/src/components/ComboboxSelect/styles.css.ts
@@ -4,6 +4,10 @@ import { vars } from '@/vars'
 
 import { colors } from '../../css/colors'
 
+export const buttonWrapper = style({
+	flex: 1,
+})
+
 export const selectLabel = style({
 	display: 'none',
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10700,6 +10700,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dnd-kit/accessibility@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@dnd-kit/accessibility@npm:3.1.0"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 10/750a0537877d5dde3753e9ef59d19628b553567e90fc3e3b14a79bded08f47f4a7161bc0d003d7cd6b3bd9e10aa233628dca07d2aa5a2120cac84555ba1653d8
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/core@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@dnd-kit/core@npm:6.1.0"
+  dependencies:
+    "@dnd-kit/accessibility": "npm:^3.1.0"
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 10/cf9e99763fbd9220cb6fdde2950c19fdf6248391234f5ee835601814124445fd8a6e4b3f5bc35543c802d359db8cc47f07d87046577adc41952ae981a03fbda0
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/sortable@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@dnd-kit/sortable@npm:8.0.0"
+  dependencies:
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@dnd-kit/core": ^6.1.0
+    react: ">=16.8.0"
+  checksum: 10/e2e0d37ace13db2e6aceb65a803195ef29e1a33a37e7722a988d7a9c1aacce77472a93b2adcd8e6780ac98b3d5640c5481892f530177c2eb966df235726942ad
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/utilities@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@dnd-kit/utilities@npm:3.2.2"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 10/6cfe46a5fcdaced943982e7ae66b08b89235493e106eb5bc833737c25905e13375c6ecc3aa0c357d136cb21dae3966213dba063f19b7a60b1235a29a7b05ff84
+  languageName: node
+  linkType: hard
+
 "@docsearch/css@npm:3, @docsearch/css@npm:3.3.3":
   version: 3.3.3
   resolution: "@docsearch/css@npm:3.3.3"
@@ -14490,6 +14539,8 @@ __metadata:
     "@babel/core": "npm:^7.19.0"
     "@ctrl/tinycolor": "npm:^3.4.1"
     "@dinero.js/currencies": "npm:2.0.0-alpha.14"
+    "@dnd-kit/core": "npm:^6.1.0"
+    "@dnd-kit/sortable": "npm:^8.0.0"
     "@fontsource/poppins": "npm:^4.5.9"
     "@frontapp/plugin-sdk": "npm:^1.1.2"
     "@graphql-codegen/cli": "npm:^2.13.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14541,6 +14541,7 @@ __metadata:
     "@dinero.js/currencies": "npm:2.0.0-alpha.14"
     "@dnd-kit/core": "npm:^6.1.0"
     "@dnd-kit/sortable": "npm:^8.0.0"
+    "@dnd-kit/utilities": "npm:^3.2.2"
     "@fontsource/poppins": "npm:^4.5.9"
     "@frontapp/plugin-sdk": "npm:^1.1.2"
     "@graphql-codegen/cli": "npm:^2.13.7"


### PR DESCRIPTION
## Summary
- "edit dashboard" button turns on a mode for editing dashboard metadata and chart order
- adds the `dnd-kit` library to enable drag-and-drop ordering for charts
- saves ordering as a `graphIds` field on `Visualization`
- uses the `ComboboxSelect` component for group by / bucket by / metric keys in the editor
https://www.loom.com/share/b4e53ac2f1db42ce9d583c4d0ff533b9
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- @julian-highlight can review after deployment
<!--
 Request review from julian-highlight / our design team 
-->
