### PR TITLE
Fix error group autoresolver data sync

### DIFF
--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -840,20 +840,11 @@ func (r *mutationResolver) UpdateErrorGroupState(ctx context.Context, secureID s
 	}
 	admin, err := r.getCurrentAdmin(ctx)
 
-	if err = r.Store.UpdateErrorGroupStateByAdmin(ctx, *admin, store.UpdateErrorGroupParams{
+	return r.Store.UpdateErrorGroupStateByAdmin(ctx, *admin, store.UpdateErrorGroupParams{
 		ID:           errorGroup.ID,
 		State:        state,
 		SnoozedUntil: snoozedUntil,
-	}); err != nil {
-		return nil, err
-	}
-
-	var updatedErrorGroup model.ErrorGroup
-	if err := r.DB.WithContext(ctx).Where(&model.ErrorGroup{Model: model.Model{ID: errorGroup.ID}}).First(&updatedErrorGroup).Error; err != nil {
-		return nil, e.Wrap(err, "error querying error group")
-	}
-
-	return &updatedErrorGroup, err
+	})
 }
 
 // DeleteProject is the resolver for the deleteProject field.

--- a/backend/public-graph/graph/resolver_test.go
+++ b/backend/public-graph/graph/resolver_test.go
@@ -465,8 +465,7 @@ func TestUpdatingErrorState(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, errorGroup.State, privateModel.ErrorStateOpen)
 
-		// Resolve
-		_, err = resolver.Store.UpdateErrorGroupStateBySystem(ctx, store.UpdateErrorGroupParams{
+		err = resolver.Store.UpdateErrorGroupStateBySystem(ctx, store.UpdateErrorGroupParams{
 			ID:    errorGroup.ID,
 			State: privateModel.ErrorStateResolved,
 		})
@@ -482,8 +481,7 @@ func TestUpdatingErrorState(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, errorGroup.State, privateModel.ErrorStateOpen)
 
-		// Ignore
-		_, err = resolver.Store.UpdateErrorGroupStateBySystem(ctx, store.UpdateErrorGroupParams{
+		err = resolver.Store.UpdateErrorGroupStateBySystem(ctx, store.UpdateErrorGroupParams{
 			ID:    errorGroup.ID,
 			State: privateModel.ErrorStateIgnored,
 		})

--- a/backend/store/error_groups.go
+++ b/backend/store/error_groups.go
@@ -190,34 +190,32 @@ type UpdateErrorGroupParams struct {
 }
 
 func (store *Store) UpdateErrorGroupStateByAdmin(ctx context.Context,
-	admin model.Admin, params UpdateErrorGroupParams) (model.ErrorGroup, error) {
+	admin model.Admin, params UpdateErrorGroupParams) error {
 	return store.updateErrorGroupState(ctx, &admin, params)
 }
 
 func (store *Store) UpdateErrorGroupStateBySystem(ctx context.Context,
-	params UpdateErrorGroupParams) (model.ErrorGroup, error) {
+	params UpdateErrorGroupParams) error {
 	return store.updateErrorGroupState(ctx, nil, params)
 }
 
 func (store *Store) updateErrorGroupState(ctx context.Context,
-	admin *model.Admin, params UpdateErrorGroupParams) (model.ErrorGroup, error) {
-
-	var errorGroup model.ErrorGroup
+	admin *model.Admin, params UpdateErrorGroupParams) error {
 
 	if err := AssertRecordFound(store.db.WithContext(ctx).Where(&model.ErrorGroup{
 		Model: model.Model{
 			ID: params.ID,
 		},
-	}).Model(&errorGroup).Clauses(clause.Returning{}).Updates(map[string]interface{}{
+	}).Model(&model.ErrorGroup{}).Clauses(clause.Returning{}).Updates(map[string]interface{}{
 		"State":        params.State,
 		"SnoozedUntil": params.SnoozedUntil,
 	})); err != nil {
-		return errorGroup, err
+		return err
 	}
 
 	eventType, err := getEventType(params.State)
 	if err != nil {
-		return errorGroup, err
+		return err
 	}
 
 	eventData := map[string]interface{}{}
@@ -229,28 +227,19 @@ func (store *Store) updateErrorGroupState(ctx context.Context,
 	err = store.CreateErrorGroupActivityLog(ctx, model.ErrorGroupActivityLog{
 		Admin:        admin,
 		EventType:    eventType,
-		ErrorGroupID: errorGroup.ID,
+		ErrorGroupID: params.ID,
 		EventData:    eventData,
 	})
 
 	if err != nil {
-		return errorGroup, err
+		return err
 	}
 
-	// For user-driven state updates, write the error group directly to Clickhouse.
-	// Write to the data sync queue as well to guarantee eventual consistency.
-	if admin != nil {
-		err = store.clickhouseClient.WriteErrorGroups(ctx, []*model.ErrorGroup{&errorGroup})
-		if err != nil {
-			return errorGroup, err
-		}
+	if err := store.dataSyncQueue.Submit(ctx, strconv.Itoa(params.ID), &kafka_queue.Message{Type: kafka_queue.ErrorGroupDataSync, ErrorGroupDataSync: &kafka_queue.ErrorGroupDataSyncArgs{ErrorGroupID: params.ID}}); err != nil {
+		return err
 	}
 
-	if err := store.dataSyncQueue.Submit(ctx, strconv.Itoa(errorGroup.ID), &kafka_queue.Message{Type: kafka_queue.ErrorGroupDataSync, ErrorGroupDataSync: &kafka_queue.ErrorGroupDataSyncArgs{ErrorGroupID: errorGroup.ID}}); err != nil {
-		return errorGroup, err
-	}
-
-	return errorGroup, nil
+	return nil
 
 }
 

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -354,15 +354,18 @@ func TestUpdateErrorGroupStateByAdmin(t *testing.T) {
 		SnoozedUntil: &now,
 	}
 
-	_, err := store.UpdateErrorGroupStateByAdmin(context.TODO(), admin, params)
+	err := store.UpdateErrorGroupStateByAdmin(context.TODO(), admin, params)
 	assert.EqualError(t, err, "record not found")
 
 	store.db.Create(&errorGroup)
 
 	params.ID = errorGroup.ID
 
-	updatedErrorGroup, err := store.UpdateErrorGroupStateByAdmin(context.TODO(), admin, params)
+	err = store.UpdateErrorGroupStateByAdmin(context.TODO(), admin, params)
 	assert.NoError(t, err)
+
+	var updatedErrorGroup *model.ErrorGroup
+	store.db.Model(model.ErrorGroup{}).Where("id = ?", params.ID).First(&updatedErrorGroup)
 
 	assert.Equal(t, params.State, updatedErrorGroup.State)
 	assert.Equal(t, params.SnoozedUntil.Format(time.RFC3339), updatedErrorGroup.SnoozedUntil.Format(time.RFC3339))
@@ -390,15 +393,18 @@ func TestUpdateErrorGroupStateBySystem(t *testing.T) {
 		SnoozedUntil: &now,
 	}
 
-	_, err := store.UpdateErrorGroupStateBySystem(context.TODO(), params)
+	err := store.UpdateErrorGroupStateBySystem(context.TODO(), params)
 	assert.EqualError(t, err, "record not found")
 
 	store.db.Create(&errorGroup)
 
 	params.ID = errorGroup.ID
 
-	updatedErrorGroup, err := store.UpdateErrorGroupStateBySystem(context.TODO(), params)
+	err = store.UpdateErrorGroupStateBySystem(context.TODO(), params)
 	assert.NoError(t, err)
+
+	var updatedErrorGroup *model.ErrorGroup
+	store.db.Model(model.ErrorGroup{}).Where("id = ?", params.ID).First(&updatedErrorGroup)
 
 	assert.Equal(t, params.State, updatedErrorGroup.State)
 	assert.Equal(t, params.SnoozedUntil.Format(time.RFC3339), updatedErrorGroup.SnoozedUntil.Format(time.RFC3339))

--- a/backend/store/error_groups_test.go
+++ b/backend/store/error_groups_test.go
@@ -354,18 +354,16 @@ func TestUpdateErrorGroupStateByAdmin(t *testing.T) {
 		SnoozedUntil: &now,
 	}
 
-	err := store.UpdateErrorGroupStateByAdmin(context.TODO(), admin, params)
+	unchangedErrorGroup, err := store.UpdateErrorGroupStateByAdmin(context.TODO(), admin, params)
 	assert.EqualError(t, err, "record not found")
+	assert.Nil(t, unchangedErrorGroup)
 
 	store.db.Create(&errorGroup)
 
 	params.ID = errorGroup.ID
 
-	err = store.UpdateErrorGroupStateByAdmin(context.TODO(), admin, params)
+	updatedErrorGroup, err := store.UpdateErrorGroupStateByAdmin(context.TODO(), admin, params)
 	assert.NoError(t, err)
-
-	var updatedErrorGroup *model.ErrorGroup
-	store.db.Model(model.ErrorGroup{}).Where("id = ?", params.ID).First(&updatedErrorGroup)
 
 	assert.Equal(t, params.State, updatedErrorGroup.State)
 	assert.Equal(t, params.SnoozedUntil.Format(time.RFC3339), updatedErrorGroup.SnoozedUntil.Format(time.RFC3339))

--- a/backend/worker/autoresolver.go
+++ b/backend/worker/autoresolver.go
@@ -81,21 +81,25 @@ func (autoResolver *AutoResolver) resolveStaleErrorsForProject(ctx context.Conte
 	}
 
 	for _, errorGroup := range errorGroups {
-		log.WithContext(ctx).WithFields(
-			log.Fields{
-				"project_id":     project.ID,
-				"error_group_id": errorGroup.ID,
-				"worker":         "autoresolver",
-			}).Info("Autoresolving error group")
+		logFields := log.Fields{
+			"project_id":     project.ID,
+			"error_group_id": errorGroup.ID,
+			"worker":         "autoresolver",
+		}
 
-		_, err := autoResolver.store.UpdateErrorGroupStateBySystem(ctx, store.UpdateErrorGroupParams{
+		log.WithContext(ctx).WithFields(logFields).Info("Autoresolving error group")
+
+		err := autoResolver.store.UpdateErrorGroupStateBySystem(ctx, store.UpdateErrorGroupParams{
 			ID:    errorGroup.ID,
 			State: privateModel.ErrorStateResolved,
 		})
 
 		if err != nil {
-			return err
+			log.WithContext(ctx).WithFields(logFields).Error(err)
+			continue
 		}
+
+		log.WithContext(ctx).WithFields(logFields).Info("Resolved error group")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
The error group auto resolver passes in `nil` ids to the data sync queue. Pass in the param id, and refactor to never use the error group.

https://www.loom.com/share/83f8b158e4be4a6a93ef6cc2dccab35e?sid=43bad0d2-ba8d-4cc8-8d92-632dce2bda74

## How did you test this change?
1) Search for `status=OPEN` errors
2) Update an error to be resolved
3) Refresh the search (may have a lag)
- [ ] Error no longer in search

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
