### PR TITLE
Show slack dropdown consistently

### DIFF
--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -137,7 +137,6 @@ const PlayerPage = () => {
 
 	const playerWrapperRef = useRef<HTMLDivElement>(null)
 
-	const newCommentModalRef = useRef<HTMLDivElement>(null)
 	const [commentModalPosition, setCommentModalPosition] = useState<
 		Coordinates2D | undefined
 	>(undefined)
@@ -414,7 +413,6 @@ const PlayerPage = () => {
 							{showSession ? sessionView : sessionFiller}
 						</div>
 						<NewCommentModal
-							newCommentModalRef={newCommentModalRef}
 							commentModalPosition={commentModalPosition}
 							commentPosition={commentPosition}
 							commentTime={time}

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/CommentTextBody/CommentTextBody.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/CommentTextBody/CommentTextBody.tsx
@@ -148,41 +148,20 @@ export const CommentTextBody = ({
 			}
 		>
 			<Mention
-				className={mentionsClassNames.mentionsMention}
 				trigger="@"
 				data={suggestions}
 				displayTransform={onDisplayTransformHandler}
 				appendSpaceOnAdd
 				suggestionLimit={15}
-				renderSuggestion={(
-					suggestion,
-					search,
-					highlightedDisplay,
-					index,
-					focused,
-				) => (
-					<Suggestion
-						focused={focused}
-						highlightedDisplay={highlightedDisplay}
-						index={index}
-						search={search}
-						suggestion={suggestion as AdminSuggestion}
-					/>
+				renderSuggestion={(suggestion) => (
+					<Suggestion suggestion={suggestion as AdminSuggestion} />
 				)}
 			/>
 		</MentionsInput>
 	)
 }
 
-const Suggestion = ({
-	suggestion,
-}: {
-	suggestion: AdminSuggestion
-	search: string
-	highlightedDisplay: React.ReactNode
-	index: number
-	focused: boolean
-}) => {
+const Suggestion = ({ suggestion }: { suggestion: AdminSuggestion }) => {
 	return (
 		<div className={styles.suggestionContainer}>
 			<div className={styles.avatarContainer}>

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/CommentTextBody/mentions.module.css
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/CommentTextBody/mentions.module.css
@@ -74,13 +74,3 @@
 .mentions__suggestions__item--focused {
 	background: var(--color-gray-300);
 }
-
-.mentions__mention {
-	color: var(--color-link);
-	font-weight: 400 !important;
-	pointer-events: none;
-	position: relative;
-	text-shadow: 1px 1px 1px var(--color-white), 1px -1px 1px var(--color-white),
-		-1px 1px 1px var(--color-white), -1px -1px 1px var(--color-white);
-	z-index: 1;
-}

--- a/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentForm/NewCommentForm.tsx
@@ -72,7 +72,6 @@ interface Props {
 	commentTime: number
 	onCloseHandler: () => void
 	commentPosition: Coordinates2D | undefined
-	parentRef?: React.RefObject<HTMLDivElement>
 	session?: Session
 	session_secure_id?: string
 	error_secure_id?: string
@@ -90,7 +89,6 @@ export const NewCommentForm = ({
 	commentTime,
 	onCloseHandler,
 	commentPosition,
-	parentRef,
 	session,
 	session_secure_id,
 	error_secure_id,
@@ -702,9 +700,6 @@ export const NewCommentForm = ({
 								placeholder={placeholder}
 								suggestions={adminSuggestions}
 								onDisplayTransformHandler={onDisplayTransform}
-								suggestionsPortalHost={
-									parentRef?.current as Element
-								}
 							/>
 						</Box>
 						<Stack

--- a/frontend/src/pages/Player/Toolbar/NewCommentModal/NewCommentModal.tsx
+++ b/frontend/src/pages/Player/Toolbar/NewCommentModal/NewCommentModal.tsx
@@ -8,7 +8,6 @@ import React from 'react'
 import * as styles from './styles.css'
 
 interface Props {
-	newCommentModalRef: React.RefObject<HTMLDivElement>
 	commentTime: number
 	onCancel: () => void
 	commentModalPosition?: Coordinates2D
@@ -22,7 +21,6 @@ interface Props {
 	currentUrl?: string
 }
 export function NewCommentModal({
-	newCommentModalRef,
 	commentModalPosition,
 	commentPosition,
 	commentTime,
@@ -70,20 +68,17 @@ export function NewCommentModal({
 				<div className={styles.modalContainer}>{node}</div>
 			)}
 		>
-			<div ref={newCommentModalRef}>
-				<NewCommentForm
-					commentTime={Math.floor(commentTime)}
-					onCloseHandler={onCancel}
-					commentPosition={commentPosition}
-					parentRef={newCommentModalRef}
-					session={session}
-					error_secure_id={error_secure_id}
-					session_secure_id={session_secure_id}
-					errorTitle={errorTitle}
-					modalHeader={title}
-					currentUrl={currentUrl}
-				/>
-			</div>
+			<NewCommentForm
+				commentTime={Math.floor(commentTime)}
+				onCloseHandler={onCancel}
+				commentPosition={commentPosition}
+				session={session}
+				error_secure_id={error_secure_id}
+				session_secure_id={session_secure_id}
+				errorTitle={errorTitle}
+				modalHeader={title}
+				currentUrl={currentUrl}
+			/>
 		</Modal>
 	)
 }


### PR DESCRIPTION
## Summary
The slack `@` dropdown does not consistently render to the correct place. Drop the parent ref, and let react mentions render the dropdown under the input.

https://www.loom.com/share/ca0f989351a5480097812917614f8b0e

## How did you test this change?
1) View a session
2) Click to add a comment
3) Type in the `@` symbol
- [ ] Dropdown is displayed under the comment input

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A