### PR TITLE
add scrollable prop to tabs to allow scrolling within individual tab panels

### DIFF
--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourcePanel.tsx
@@ -303,6 +303,7 @@ function NetworkResourceDetails({
 				onChange={(id) => {
 					setActiveTab(id as NetworkRequestTabs)
 				}}
+				scrollable
 			>
 				<Tabs.List px="8" gap="12">
 					<Tabs.Tab id={NetworkRequestTabs.Info}>Info</Tabs.Tab>
@@ -312,7 +313,7 @@ function NetworkResourceDetails({
 						<Tabs.Tab id={NetworkRequestTabs.Trace}>Trace</Tabs.Tab>
 					)}
 				</Tabs.List>
-				<Tabs.Panel id={NetworkRequestTabs.Info}>
+				<Tabs.Panel id={NetworkRequestTabs.Info} scrollable>
 					<NetworkResourceInfo
 						selectedNetworkResource={resource}
 						networkRecordingEnabledForSession={
@@ -320,17 +321,17 @@ function NetworkResourceDetails({
 						}
 					/>
 				</Tabs.Panel>
-				<Tabs.Panel id={NetworkRequestTabs.Errors}>
+				<Tabs.Panel id={NetworkRequestTabs.Errors} scrollable>
 					<NetworkResourceErrors resource={resource} />
 				</Tabs.Panel>
-				<Tabs.Panel id={NetworkRequestTabs.Logs}>
+				<Tabs.Panel id={NetworkRequestTabs.Logs} scrollable>
 					<NetworkResourceLogs
 						resource={resource}
 						sessionStartTime={startTime}
 					/>
 				</Tabs.Panel>
 				{isNetworkRequest && (
-					<Tabs.Panel id={NetworkRequestTabs.Trace}>
+					<Tabs.Panel id={NetworkRequestTabs.Trace} scrollable>
 						<TraceProvider
 							projectId={projectId}
 							traceId={traceId}

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -15,6 +15,7 @@ type Props<T = string> = React.PropsWithChildren & {
 	selectedId?: T
 	size?: 'xs' | 'sm'
 	onChange?: (id: T) => void
+	scrollable?: boolean
 }
 
 export const Tabs = <T extends string = string>({
@@ -23,6 +24,7 @@ export const Tabs = <T extends string = string>({
 	selectedId,
 	size = 'sm',
 	onChange,
+	scrollable,
 }: Props<T>) => {
 	const tabsStore = Ariakit.useTabStore({
 		defaultSelectedId,
@@ -36,7 +38,13 @@ export const Tabs = <T extends string = string>({
 	return (
 		<TabsContext.Provider value={{ size }}>
 			<Ariakit.TabProvider store={tabsStore} selectedId={selectedId}>
-				<Stack direction="column" flexGrow={1} gap="0" width="full">
+				<Stack
+					direction="column"
+					flexGrow={1}
+					gap="0"
+					width="full"
+					overflowY={scrollable ? 'hidden' : undefined}
+				>
 					{children}
 				</Stack>
 			</Ariakit.TabProvider>
@@ -141,10 +149,13 @@ const Tab: React.FC<TabProps> = ({ badgeText, children, icon, ...props }) => {
 	)
 }
 
-type TabPanelProps = React.PropsWithChildren<Ariakit.TabPanelProps>
+type TabPanelProps = React.PropsWithChildren<Ariakit.TabPanelProps> & {
+	scrollable?: boolean
+}
 
 const TabPanel: React.FC<TabPanelProps> = ({
 	children,
+	scrollable,
 	unmountOnHide = true,
 	...props
 }) => {
@@ -153,7 +164,12 @@ const TabPanel: React.FC<TabPanelProps> = ({
 			{...props}
 			unmountOnHide={unmountOnHide}
 			render={
-				<Stack direction="column" flexGrow={1} id={props.id}>
+				<Stack
+					direction="column"
+					flexGrow={1}
+					id={props.id}
+					overflowY={scrollable ? 'auto' : undefined}
+				>
 					{children}
 				</Stack>
 			}


### PR DESCRIPTION
## Summary
- fixes issue where a tab panel within flex layout (network resources) had its overflow cut off and not scrollable
https://www.loom.com/share/d0b4c60e88ae4289b98797ee3dc7dcef
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
