### PR TITLE
Optimize polling resources

### DIFF
--- a/frontend/src/components/FeedResults/FeedResults.tsx
+++ b/frontend/src/components/FeedResults/FeedResults.tsx
@@ -9,12 +9,18 @@ import { AnimatePresence, motion } from 'framer-motion'
 import * as style from './FeedResults.css'
 
 interface Props {
+	maxResults: number
 	more: number
 	type: 'sessions' | 'errors' | 'logs' | 'traces'
 	onClick: () => void
 }
 
-export const AdditionalFeedResults = function ({ more, type, onClick }: Props) {
+export const AdditionalFeedResults = function ({
+	maxResults,
+	more,
+	type,
+	onClick,
+}: Props) {
 	const rounded = ['sessions', 'errors'].includes(type)
 
 	return (
@@ -48,8 +54,8 @@ export const AdditionalFeedResults = function ({ more, type, onClick }: Props) {
 							<Box display="flex" alignItems="center" gap="8">
 								<IconOutlineArrowNarrowUp />
 								<Text>
-									{more}
-									{more >= 50 ? '+' : ''} new{' '}
+									{Math.min(more, maxResults)}
+									{more >= maxResults ? '+' : ''} new{' '}
 									{more === 1
 										? type.slice(0, type.length - 1)
 										: type}

--- a/frontend/src/components/FeedResults/FeedResults.tsx
+++ b/frontend/src/components/FeedResults/FeedResults.tsx
@@ -23,6 +23,9 @@ export const AdditionalFeedResults = function ({
 }: Props) {
 	const rounded = ['sessions', 'errors'].includes(type)
 
+	const countText = more >= maxResults ? `${maxResults}+` : more
+	const resourceText = more === 1 ? type.slice(0, type.length - 1) : type
+
 	return (
 		<AnimatePresence>
 			{more > 0 ? (
@@ -54,11 +57,7 @@ export const AdditionalFeedResults = function ({
 							<Box display="flex" alignItems="center" gap="8">
 								<IconOutlineArrowNarrowUp />
 								<Text>
-									{Math.min(more, maxResults)}
-									{more >= maxResults ? '+' : ''} new{' '}
-									{more === 1
-										? type.slice(0, type.length - 1)
-										: type}
+									{countText} new {resourceText}
 								</Text>
 							</Box>
 						</Button>

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -115,6 +115,7 @@ export const SearchPanel = () => {
 				</Box>
 			)}
 			<AdditionalFeedResults
+				maxResults={PAGE_SIZE}
 				more={moreErrors}
 				type="errors"
 				onClick={() => {

--- a/frontend/src/pages/ErrorsV2/useGetErrors.ts
+++ b/frontend/src/pages/ErrorsV2/useGetErrors.ts
@@ -74,6 +74,7 @@ export const useGetErrors = ({
 			[],
 		),
 		skip: disablePolling,
+		maxResults: PAGE_SIZE,
 	})
 
 	return {

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -45,6 +45,7 @@ import { findMatchingAttributes } from '@/components/JsonViewer/utils'
 import { SearchExpression } from '@/components/Search/Parser/listener'
 import { useSearchContext } from '@/components/Search/SearchContext'
 import { LogEdge, ProductType } from '@/graph/generated/schemas'
+import { MAX_LOGS } from '@/pages/LogsPage/useGetLogs'
 import analytics from '@/util/analytics'
 
 import { LogDetails } from './LogDetails'
@@ -328,6 +329,7 @@ const LogsTableInner = ({
 					<Table.Row>
 						<Box width="full">
 							<AdditionalFeedResults
+								maxResults={MAX_LOGS}
 								more={moreLogs}
 								type="logs"
 								onClick={() => {

--- a/frontend/src/pages/LogsPage/useGetLogs.ts
+++ b/frontend/src/pages/LogsPage/useGetLogs.ts
@@ -27,6 +27,8 @@ const initialWindowInfo: PageInfo = {
 	endCursor: '', // unused but needed for typedef
 }
 
+export const MAX_LOGS = 50
+
 export const useGetLogs = ({
 	query,
 	project_id,
@@ -114,6 +116,7 @@ export const useGetLogs = ({
 		GetLogsQuery,
 		GetLogsQueryVariables
 	>({
+		maxResults: MAX_LOGS,
 		skip: disablePolling,
 		variableFn: useCallback(
 			() => ({

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -234,6 +234,7 @@ export const SessionFeedV3 = React.memo(() => {
 			[],
 		),
 		skip: !selectedPreset,
+		maxResults: DEFAULT_PAGE_SIZE,
 	})
 
 	// Used to determine if we need to show the loading skeleton.
@@ -323,6 +324,7 @@ export const SessionFeedV3 = React.memo(() => {
 					</Box>
 				)}
 				<AdditionalFeedResults
+					maxResults={DEFAULT_PAGE_SIZE}
 					more={moreSessions}
 					type="sessions"
 					onClick={() => {

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -28,6 +28,7 @@ import { LinkButton } from '@/components/LinkButton'
 import LoadingBox from '@/components/LoadingBox'
 import { DEFAULT_INPUT_HEIGHT } from '@/components/Search/SearchForm/SearchForm'
 import { ProductType, TraceEdge } from '@/graph/generated/schemas'
+import { MAX_TRACES } from '@/pages/Traces/useGetTraces'
 import { useParams } from '@/util/react-router/useParams'
 
 import {
@@ -254,6 +255,7 @@ export const TracesList: React.FC<Props> = ({
 					<Table.Row>
 						<Box width="full">
 							<AdditionalFeedResults
+								maxResults={MAX_TRACES}
 								more={numMoreTraces}
 								type="traces"
 								onClick={() => {

--- a/frontend/src/pages/Traces/useGetTraces.ts
+++ b/frontend/src/pages/Traces/useGetTraces.ts
@@ -15,6 +15,8 @@ const initialWindowInfo: PageInfo = {
 	endCursor: '', // unused but needed for typedef
 }
 
+export const MAX_TRACES = 50
+
 export const useGetTraces = ({
 	query,
 	projectId,
@@ -102,6 +104,7 @@ export const useGetTraces = ({
 		GetTracesQuery,
 		GetTracesQueryVariables
 	>({
+		maxResults: MAX_TRACES,
 		skip: skipPolling,
 		variableFn: useCallback(
 			() => ({

--- a/frontend/src/util/search.ts
+++ b/frontend/src/util/search.ts
@@ -67,7 +67,6 @@ export function usePollQuery<T, U>({
 			pollTimeout.current = undefined
 		}
 	}, [getResultCount, moreDataQuery, variableFn, skip])
-
 	return {
 		numMore,
 		reset: () => {

--- a/frontend/src/util/search.ts
+++ b/frontend/src/util/search.ts
@@ -10,17 +10,19 @@ export function usePollQuery<T, U>({
 	moreDataQuery,
 	getResultCount,
 	skip,
+	maxResults,
 }: {
 	variableFn: () => U | undefined
 	moreDataQuery: LazyQueryExecFunction<T, U>
 	getResultCount: (variables: QueryResult<T, U>) => number | undefined
 	skip?: boolean
+	maxResults: number
 }) {
 	const pollTimeout = useRef<number>()
 	const [numMore, setNumMore] = useState<number>(0)
 
 	useEffect(() => {
-		if (skip) {
+		if (skip || numMore >= maxResults) {
 			return
 		}
 
@@ -53,11 +55,11 @@ export function usePollQuery<T, U>({
 			POLL_INTERVAL,
 		) as unknown as number
 		return () => {
-			setNumMore(0)
 			clearTimeout(pollTimeout.current)
 			pollTimeout.current = undefined
 		}
-	}, [getResultCount, moreDataQuery, variableFn, skip])
+	}, [getResultCount, moreDataQuery, variableFn, skip, numMore, maxResults])
+
 	return {
 		numMore,
 		reset: () => {

--- a/frontend/src/util/search.ts
+++ b/frontend/src/util/search.ts
@@ -22,7 +22,14 @@ export function usePollQuery<T, U>({
 	const [numMore, setNumMore] = useState<number>(0)
 
 	useEffect(() => {
-		if (skip || numMore >= maxResults) {
+		if (numMore >= maxResults) {
+			clearTimeout(pollTimeout.current)
+			pollTimeout.current = undefined
+		}
+	}, [numMore, maxResults])
+
+	useEffect(() => {
+		if (skip) {
 			return
 		}
 
@@ -55,10 +62,11 @@ export function usePollQuery<T, U>({
 			POLL_INTERVAL,
 		) as unknown as number
 		return () => {
+			setNumMore(0)
 			clearTimeout(pollTimeout.current)
 			pollTimeout.current = undefined
 		}
-	}, [getResultCount, moreDataQuery, variableFn, skip, numMore, maxResults])
+	}, [getResultCount, moreDataQuery, variableFn, skip])
 
 	return {
 		numMore,


### PR DESCRIPTION
## Summary
Stop polling once we hit the max number of results to show

Max resources per resource:
- Sessions: 10
- Errors: 10
- Logs: 50
- Traces: 50

https://www.loom.com/share/a909cf0fa1ba41b081b0d5dc6f67888f?sid=607e0452-e802-4905-9a18-2ee98ae4a396

## How did you test this change?
1) Load a resource page and open the network tab
- [ ] Polling begins
- [ ] Once the max number of resources is hit, the polling stops
- [ ] No polling for absolute time ranges

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
