### PR TITLE
report cors network request failures

### DIFF
--- a/sdk/client/src/listeners/network-listener/utils/fetch-listener.ts
+++ b/sdk/client/src/listeners/network-listener/utils/fetch-listener.ts
@@ -140,6 +140,7 @@ const logRequest = (
 			size: 0,
 		}
 		let requestHandled = false
+		let urlBlocked = !shouldRecordHeaderAndBody
 
 		if ('stack' in response || response instanceof Error) {
 			responsePayload = {
@@ -199,6 +200,17 @@ const logRequest = (
 				responsePayload.size = text.length * 8
 			}
 
+			if (
+				response.type === 'opaque' ||
+				response.type === 'opaqueredirect'
+			) {
+				urlBlocked = true
+				responsePayload = {
+					...responsePayload,
+					body: 'CORS blocked request',
+				}
+			}
+
 			requestHandled = true
 		}
 
@@ -206,7 +218,7 @@ const logRequest = (
 			const event: RequestResponsePair = {
 				request: requestPayload,
 				response: responsePayload,
-				urlBlocked: !shouldRecordHeaderAndBody,
+				urlBlocked,
 			}
 
 			callback(event)


### PR DESCRIPTION
## Summary

Customers have asked to capture CORS and other failed network requests in the session
network devtools tab. Ensure that we do not miss fetch errors by reporting additional metadata.

Closes WHO-2

## How did you test this change?

<img width="1343" alt="image" src="https://github.com/highlight/highlight/assets/1351531/8733b3a3-bf04-4880-9f4b-7af657cdcdf9">

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no


