### PR TITLE
fix rrweb merge conflict breaking canvas recording

### DIFF
--- a/.changeset/proud-lobsters-rescue.md
+++ b/.changeset/proud-lobsters-rescue.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+fix rrweb merge conflict breaking canvas recording

--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -4648,7 +4648,7 @@ var CanvasManager = class {
         return hadLoadingTime;
       };
       const promises = [];
-      promises.push(...getCanvas(timestamp).filter(filterElementStartTime).map(this.snapshot));
+      promises.push(...getCanvas(timestamp).filter(filterElementStartTime).map((canvas) => this.snapshot(canvas)));
       promises.push(...getVideos(timestamp).filter(filterElementStartTime).map((video) => __awaiter(this, void 0, void 0, function* () {
         this.debug(video, "starting video snapshotting");
         const id = this.mirror.getId(video);


### PR DESCRIPTION
## Summary

fixes incorrect `this` scoping breaking canvas snapshotting
merge conflict from latest rrweb upgrade

## How did you test this change?

![Screenshot from 2024-04-23 16-19-44](https://github.com/highlight/highlight/assets/1351531/4a3aeaa9-4114-4952-9d72-899450a2853c)

![Screenshot from 2024-04-23 16-19-47](https://github.com/highlight/highlight/assets/1351531/3da3e6e5-9e6b-44fe-ac83-4284fff8e31a)

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
