### PR TITLE
Fix instance link

### DIFF
--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -4648,7 +4648,7 @@ var CanvasManager = class {
         return hadLoadingTime;
       };
       const promises = [];
-      promises.push(...getCanvas(timestamp).filter(filterElementStartTime).map(this.snapshot));
+      promises.push(...getCanvas(timestamp).filter(filterElementStartTime).map((canvas) => this.snapshot(canvas)));
       promises.push(...getVideos(timestamp).filter(filterElementStartTime).map((video) => __awaiter(this, void 0, void 0, function* () {
         this.debug(video, "starting video snapshotting");
         const id = this.mirror.getId(video);

--- a/__generated/rr/rrweb/rr.js
+++ b/__generated/rr/rrweb/rr.js
@@ -4648,7 +4648,7 @@ var CanvasManager = class {
         return hadLoadingTime;
       };
       const promises = [];
-      promises.push(...getCanvas(timestamp).filter(filterElementStartTime).map((canvas) => this.snapshot(canvas)));
+      promises.push(...getCanvas(timestamp).filter(filterElementStartTime).map(this.snapshot));
       promises.push(...getVideos(timestamp).filter(filterElementStartTime).map((video) => __awaiter(this, void 0, void 0, function* () {
         this.debug(video, "starting video snapshotting");
         const id = this.mirror.getId(video);

--- a/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstances/ErrorInstancesTable.tsx
@@ -151,7 +151,10 @@ export const ErrorInstancesTable = ({ edges, searchedEmail }: Props) => {
 				return (
 					<Link
 						key={row.id}
-						to={`/${projectId}/errors/${row.original.node.errorGroupSecureID}/instances/${row.original.cursor}`}
+						to={{
+							pathname: `/${projectId}/errors/${row.original.node.errorGroupSecureID}/instances/${row.original.cursor}`,
+							search: location.search,
+						}}
 						className={styles.rowLink}
 					>
 						<Stack


### PR DESCRIPTION
## Summary
When clicking an error instance, the search gets cleared.

## How did you test this change?
1) View the error search
2) Modify the search to not be the default search
3) Click into an error and view all instances
4) Click on an instance
- [ ] Instance loads
- [ ] Search does not change
- [ ] No new search requests made

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
