### PR TITLE
caching for sourcemaps

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -553,7 +553,6 @@ func readMetrics[T ~string](ctx context.Context, client *Client, sampleableConfi
 	span, ctx := util.StartSpanFromContext(ctx, "clickhouse.readMetrics")
 	span.SetAttribute("project_id", projectID)
 	span.SetAttribute("table", sampleableConfig.tableConfig.TableName)
-	span.SetAttribute("config", sampleableConfig)
 	span.SetAttribute("params", params)
 	span.SetAttribute("column", column)
 	span.SetAttribute("metric_types", metricTypes)

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/openlyinc/pointy"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -549,6 +550,23 @@ func getFnStr(aggregator modelInputs.MetricAggregator, column string, useSamplin
 }
 
 func readMetrics[T ~string](ctx context.Context, client *Client, sampleableConfig sampleableTableConfig[T], projectID int, params modelInputs.QueryInput, column string, metricTypes []modelInputs.MetricAggregator, groupBy []string, bucketCount *int, bucketBy string, limit *int, limitAggregator *modelInputs.MetricAggregator, limitColumn *string) (*modelInputs.MetricsBuckets, error) {
+	span, ctx := util.StartSpanFromContext(ctx, "clickhouse.readMetrics")
+	span.SetAttribute("project_id", projectID)
+	span.SetAttribute("table", sampleableConfig.tableConfig.TableName)
+	span.SetAttribute("config", sampleableConfig)
+	span.SetAttribute("params", params)
+	span.SetAttribute("column", column)
+	span.SetAttribute("metric_types", metricTypes)
+	span.SetAttribute("group_by", groupBy)
+	span.SetAttribute("bucket_count", pointy.IntValue(bucketCount, 0))
+	span.SetAttribute("bucket_by", bucketBy)
+	span.SetAttribute("limit", pointy.IntValue(limit, 0))
+	span.SetAttribute("limit_column", pointy.StringValue(limitColumn, ""))
+	if limitAggregator != nil {
+		span.SetAttribute("limit_aggregator", limitAggregator.String())
+	}
+	defer span.Finish()
+
 	if len(metricTypes) == 0 {
 		return nil, errors.New("no metric types provided")
 	}
@@ -758,11 +776,15 @@ func readMetrics[T ~string](ctx context.Context, client *Client, sampleableConfi
 		Buckets: []*modelInputs.MetricBucket{},
 	}
 
+	span, ctx = util.StartSpanFromContext(ctx, "readMetrics.query")
+	span.SetAttribute("sql", sql)
+	span.SetAttribute("args", args)
 	rows, err := client.conn.Query(
 		ctx,
 		sql,
 		args...,
 	)
+	span.Finish(err)
 
 	if err != nil {
 		return nil, err

--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/openlyinc/pointy"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -553,17 +552,6 @@ func readMetrics[T ~string](ctx context.Context, client *Client, sampleableConfi
 	span, ctx := util.StartSpanFromContext(ctx, "clickhouse.readMetrics")
 	span.SetAttribute("project_id", projectID)
 	span.SetAttribute("table", sampleableConfig.tableConfig.TableName)
-	span.SetAttribute("params", params)
-	span.SetAttribute("column", column)
-	span.SetAttribute("metric_types", metricTypes)
-	span.SetAttribute("group_by", groupBy)
-	span.SetAttribute("bucket_count", pointy.IntValue(bucketCount, 0))
-	span.SetAttribute("bucket_by", bucketBy)
-	span.SetAttribute("limit", pointy.IntValue(limit, 0))
-	span.SetAttribute("limit_column", pointy.StringValue(limitColumn, ""))
-	if limitAggregator != nil {
-		span.SetAttribute("limit_aggregator", limitAggregator.String())
-	}
 	defer span.Finish()
 
 	if len(metricTypes) == 0 {

--- a/backend/main.go
+++ b/backend/main.go
@@ -475,7 +475,7 @@ func main() {
 			})
 			privateServer.Use(private.NewGraphqlOAuthValidator(privateResolver.Store))
 			privateServer.Use(util.NewTracer(util.PrivateGraph))
-			privateServer.Use(htrace.NewGraphqlTracer(string(util.PrivateGraph)).WithRequestFieldLogging())
+			privateServer.Use(htrace.NewGraphqlTracer(string(util.PrivateGraph), trace.WithSpanKind(trace.SpanKindServer)).WithRequestFieldLogging())
 			privateServer.SetErrorPresenter(htrace.GraphQLErrorPresenter(string(util.PrivateGraph)))
 			privateServer.SetRecoverFunc(htrace.GraphQLRecoverFunc())
 			r.Handle("/",

--- a/backend/redis/cache.go
+++ b/backend/redis/cache.go
@@ -10,6 +10,7 @@ import (
 
 type Config struct {
 	BypassCache bool
+	IgnoreError bool
 	StoreNil    bool
 }
 
@@ -18,6 +19,12 @@ type Option func(cfg *Config)
 func WithBypassCache(bypass bool) Option {
 	return func(cfg *Config) {
 		cfg.BypassCache = bypass
+	}
+}
+
+func WithIgnoreError(ignoreError bool) Option {
+	return func(cfg *Config) {
+		cfg.IgnoreError = ignoreError
 	}
 }
 
@@ -50,7 +57,7 @@ func CachedEval[T any](ctx context.Context, redis *Client, cacheKey string, lock
 				}
 			}()
 		}
-		if value, err = fn(); (!cfg.StoreNil && value == nil) || err != nil {
+		if value, err = fn(); (!cfg.StoreNil && value == nil) || (!cfg.IgnoreError && err != nil) {
 			return
 		}
 		if err = redis.Cache.Set(&cache.Item{

--- a/backend/redis/cache.go
+++ b/backend/redis/cache.go
@@ -10,6 +10,7 @@ import (
 
 type Config struct {
 	BypassCache bool
+	StoreNil    bool
 }
 
 type Option func(cfg *Config)
@@ -17,6 +18,12 @@ type Option func(cfg *Config)
 func WithBypassCache(bypass bool) Option {
 	return func(cfg *Config) {
 		cfg.BypassCache = bypass
+	}
+}
+
+func WithStoreNil(storeNil bool) Option {
+	return func(cfg *Config) {
+		cfg.StoreNil = storeNil
 	}
 }
 
@@ -43,7 +50,7 @@ func CachedEval[T any](ctx context.Context, redis *Client, cacheKey string, lock
 				}
 			}()
 		}
-		if value, err = fn(); value == nil || err != nil {
+		if value, err = fn(); (!cfg.StoreNil && value == nil) || err != nil {
 			return
 		}
 		if err = redis.Cache.Set(&cache.Item{

--- a/backend/redis/cache.go
+++ b/backend/redis/cache.go
@@ -60,13 +60,13 @@ func CachedEval[T any](ctx context.Context, redis *Client, cacheKey string, lock
 		if value, err = fn(); (!cfg.StoreNil && value == nil) || (!cfg.IgnoreError && err != nil) {
 			return
 		}
-		if err = redis.Cache.Set(&cache.Item{
+		if setError := redis.Cache.Set(&cache.Item{
 			Ctx:   ctx,
 			Key:   cacheKey,
 			Value: &value,
 			TTL:   cacheExpiration,
-		}); err != nil {
-			return
+		}); setError != nil {
+			return nil, setError
 		}
 	}
 

--- a/backend/redis/utils_test.go
+++ b/backend/redis/utils_test.go
@@ -45,10 +45,10 @@ func Test_CachedEval(t *testing.T) {
 	key, _ = randomString()
 	v1, e1 = CachedEval(ctx, r, *key, time.Minute, time.Minute, randomError, WithStoreNil(true), WithIgnoreError(true))
 	v2, e2 = CachedEval(ctx, r, *key, time.Minute, time.Minute, randomError, WithStoreNil(true), WithIgnoreError(true))
-	assert.NoError(t, e1)
+	assert.Error(t, e1)
 	assert.NoError(t, e2)
 	assert.EqualValues(t, v1, v2)
-	assert.EqualValues(t, e1, e2)
+	assert.NotEqualValues(t, e1, e2)
 }
 
 func TestLock(t *testing.T) {

--- a/backend/redis/utils_test.go
+++ b/backend/redis/utils_test.go
@@ -3,10 +3,53 @@ package redis
 import (
 	"context"
 	"github.com/go-redsync/redsync/v4"
+	"github.com/openlyinc/pointy"
+	e "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"math/rand"
 	"testing"
 	"time"
 )
+
+func randomString() (*string, error) {
+	b := make([]byte, 32)
+	for i := range b {
+		b[i] = byte(rand.Intn(26) + 65)
+	}
+	return pointy.String(string(b)), nil
+}
+func randomError() (*string, error) {
+	s, _ := randomString()
+	return nil, e.New(*s)
+}
+
+func Test_CachedEval(t *testing.T) {
+	ctx := context.TODO()
+	r := NewClient()
+	key, _ := randomString()
+	v1, e1 := CachedEval(ctx, r, *key, time.Minute, time.Minute, randomString)
+	v2, e2 := CachedEval(ctx, r, *key, time.Minute, time.Minute, randomString)
+	assert.NoError(t, e1)
+	assert.NoError(t, e2)
+	assert.EqualValues(t, v1, v2)
+	assert.EqualValues(t, e1, e2)
+
+	key, _ = randomString()
+	v1, e1 = CachedEval(ctx, r, *key, time.Minute, time.Minute, randomError)
+	v2, e2 = CachedEval(ctx, r, *key, time.Minute, time.Minute, randomError)
+	assert.Error(t, e1)
+	assert.Error(t, e2)
+	assert.EqualValues(t, v1, v2)
+	assert.NotEqualValues(t, e1, e2)
+
+	key, _ = randomString()
+	v1, e1 = CachedEval(ctx, r, *key, time.Minute, time.Minute, randomError, WithStoreNil(true), WithIgnoreError(true))
+	v2, e2 = CachedEval(ctx, r, *key, time.Minute, time.Minute, randomError, WithStoreNil(true), WithIgnoreError(true))
+	assert.NoError(t, e1)
+	assert.NoError(t, e2)
+	assert.EqualValues(t, v1, v2)
+	assert.EqualValues(t, e1, e2)
+}
 
 func TestLock(t *testing.T) {
 	r := NewClient()

--- a/backend/stacktraces/enhancer.go
+++ b/backend/stacktraces/enhancer.go
@@ -212,7 +212,7 @@ func getURLSourcemap(ctx context.Context, projectId int, version *string, stackT
 		minifiedFileBytes, err = fetch.fetchFile(ctx, stackTraceFileURL)
 		minifiedFetchStrategy = "URL"
 		stackTraceError.MinifiedFetchStrategy = &minifiedFetchStrategy
-		if err != nil {
+		if minifiedFileBytes == nil || err != nil {
 			// fallback if we can't get the source file at all
 			// SOURCEMAP_ERROR: minified file does not exist in S3 and could not be found at the URL
 			// (user-facing error message can include the S3 path and URL that was searched)
@@ -309,7 +309,7 @@ func getURLSourcemap(ctx context.Context, projectId int, version *string, stackT
 			sourceMapFileBytes, err = fetch.fetchFile(ctx, sourceMapURL)
 			sourcemapFetchStrategy = "URL"
 			stackTraceError.SourcemapFetchStrategy = &sourcemapFetchStrategy
-			if err != nil {
+			if sourceMapFileBytes == nil || err != nil {
 				// fallback if we can't get the source file at all
 				// SOURCEMAP_ERROR: source map file does not exist in S3 and could not be found at the URL
 				// (user-facing error message can include the S3 path and URL that was searched)

--- a/backend/stacktraces/enhancer.go
+++ b/backend/stacktraces/enhancer.go
@@ -182,7 +182,7 @@ func getFileSourcemap(ctx context.Context, projectId int, version *string, stack
 	stackTraceError.SourcemapFetchStrategy = &sourcemapFetchStrategy
 	for sourceMapFileBytes == nil {
 		sourceMapFileBytes, err = storageClient.ReadSourceMapFileCached(ctx, projectId, version, pathSubpath)
-		if err != nil {
+		if sourceMapFileBytes == nil || err != nil {
 			if pathSubpath == "" {
 				// SOURCEMAP_ERROR: could not find source map file in s3
 				// (user-facing error message can include all the paths searched)
@@ -207,7 +207,7 @@ func getURLSourcemap(ctx context.Context, projectId int, version *string, stackT
 	stackTraceError.MinifiedFetchStrategy = &minifiedFetchStrategy
 	stackTraceError.ActualMinifiedFetchedPath = &stackTraceFilePath
 
-	if err != nil {
+	if minifiedFileBytes == nil || err != nil {
 		// if not in s3, get from url and put in s3
 		minifiedFileBytes, err = fetch.fetchFile(ctx, stackTraceFileURL)
 		minifiedFetchStrategy = "URL"
@@ -304,7 +304,7 @@ func getURLSourcemap(ctx context.Context, projectId int, version *string, stackT
 		sourceMapFileBytes, err = storageClient.ReadSourceMapFileCached(ctx, projectId, version, sourceMapFilePath)
 		sourcemapFetchStrategy := "S3"
 		stackTraceError.SourcemapFetchStrategy = &sourcemapFetchStrategy
-		if err != nil {
+		if sourceMapFileBytes == nil || err != nil {
 			// if not in s3, get from url and put in s3
 			sourceMapFileBytes, err = fetch.fetchFile(ctx, sourceMapURL)
 			sourcemapFetchStrategy = "URL"

--- a/backend/stacktraces/enhancer_test.go
+++ b/backend/stacktraces/enhancer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/highlight-run/highlight/backend/redis"
 	"github.com/openlyinc/pointy"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -107,7 +108,7 @@ func TestEnhanceStackTrace(t *testing.T) {
 					FunctionName: ptr.String("arrayIncludesWith"),
 				},
 			},
-			fetcher: NetworkFetcher{},
+			fetcher: NetworkFetcher{redis: redis.NewClient()},
 			err:     e.New(""),
 		},
 		"test source mapping invalid trace:no related source map": {
@@ -157,7 +158,7 @@ func TestEnhanceStackTrace(t *testing.T) {
 					},
 				},
 			},
-			fetcher: NetworkFetcher{},
+			fetcher: NetworkFetcher{redis: redis.NewClient()},
 			err:     e.New(""),
 		},
 		"test source mapping invalid trace:filename is not a url": {
@@ -182,7 +183,7 @@ func TestEnhanceStackTrace(t *testing.T) {
 					},
 				},
 			},
-			fetcher: NetworkFetcher{},
+			fetcher: NetworkFetcher{redis: redis.NewClient()},
 			err:     e.New(""),
 		},
 		"test source mapping invalid trace:trace is nil": {
@@ -258,7 +259,7 @@ func TestEnhanceStackTrace(t *testing.T) {
 					FunctionName: ptr.String("Error"),
 				},
 			},
-			fetcher: NetworkFetcher{},
+			fetcher: NetworkFetcher{redis: redis.NewClient()},
 			err:     e.New(""),
 		},
 	}
@@ -313,7 +314,7 @@ func TestEnhanceBackendNextServerlessTrace(t *testing.T) {
 		t.Fatalf("error creating storage client: %v", err)
 	}
 
-	fetch = NetworkFetcher{}
+	fetch = NetworkFetcher{redis: redis.NewClient()}
 
 	var stackFrameInput []*publicModelInput.StackFrameInput
 	err = json.Unmarshal([]byte(`[{"fileName":"/var/task/apps/magicsky/.next/server/app/(route-group-test)/[slug]/page-router-edge-test.js","lineNumber":1,"functionName":"s","columnNumber":3344,"error":"Error: 🎉 SSR Error with use-server: src/app-router/ssr/page.tsx"}]`), &stackFrameInput)
@@ -351,7 +352,7 @@ func TestEnhanceStackTraceProd(t *testing.T) {
 		t.Fatalf("error creating storage client: %v", err)
 	}
 
-	fetch = NetworkFetcher{}
+	fetch = NetworkFetcher{redis: redis.NewClient()}
 	mappedStackTrace, err := EnhanceStackTrace(ctx, []*publicModelInput.StackFrameInput{
 		{
 			FunctionName: nil,

--- a/backend/stacktraces/enhancer_test.go
+++ b/backend/stacktraces/enhancer_test.go
@@ -275,9 +275,11 @@ func TestEnhanceStackTrace(t *testing.T) {
 	}
 
 	// run tests
+	redisClient := redis.NewClient()
 	for _, client := range []storage.Client{s3Client, fsClient} {
 		for name, tc := range tests {
 			t.Run(fmt.Sprintf("%s/%v", name, client), func(t *testing.T) {
+				_ = redisClient.FlushDB(ctx)
 				if tc.projectID == 0 {
 					tc.projectID = 1
 				} else if client == s3Client {

--- a/backend/storage/storage.go
+++ b/backend/storage/storage.go
@@ -474,7 +474,7 @@ func (f *FilesystemClient) SetupHTTPSListener(r chi.Router) {
 }
 
 func NewFSClient(_ context.Context, origin, fsRoot string) (*FilesystemClient, error) {
-	return &FilesystemClient{origin: origin, fsRoot: fsRoot}, nil
+	return &FilesystemClient{origin: origin, fsRoot: fsRoot, redis: hredis.NewClient()}, nil
 }
 
 type S3Client struct {
@@ -500,6 +500,7 @@ func NewS3Client(ctx context.Context) (*S3Client, error) {
 		S3ClientEast2:   clientEast2,
 		S3PresignClient: s3.NewPresignClient(clientEast2),
 		URLSigner:       getURLSigner(ctx),
+		Redis:           hredis.NewClient(),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

adds granular trace ingestion for private graph requests.
sourcemap processing has been slow due to repeated failing queries.

<img width="864" alt="Screenshot 2024-04-26 at 10 46 23" src="https://github.com/highlight/highlight/assets/1351531/48f3bc44-f5ee-405f-aea5-49fec11f6288">

caching for 1 minute will help with perf while still updating frequently when sourcemaps / js files are uploaded

## How did you test this change?

manual testing locally, unit tests
![Uploading image.png…]()


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
