### PR TITLE
add banners for launch week 5

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1007,8 +1007,8 @@ const BillingBanner: React.FC = () => {
 
 	if (!bannerMessage && !hasTrial) {
 		const isLaunchWeek = moment().isBetween(
-			'2024-01-29T16:00:00Z', // 9AM PST
-			'2024-02-03T16:00:00Z',
+			'2024-04-29T16:00:00Z', // 9AM PST
+			'2024-05-04T16:00:00Z',
 		)
 		if (isLaunchWeek) {
 			return <LaunchWeekBanner />
@@ -1116,10 +1116,10 @@ const LaunchWeekBanner = () => {
 
 	const bannerMessage = (
 		<span>
-			Launch Week 4 is here.{' '}
+			Launch Week 5 is here.{' '}
 			<a
 				target="_blank"
-				href="https://www.highlight.io/launch/week-4"
+				href="https://www.highlight.io/blog/tag/launch-week-5"
 				className={styles.trialLink}
 				rel="noreferrer"
 			>

--- a/highlight.io/components/common/Navbar/Navbar.tsx
+++ b/highlight.io/components/common/Navbar/Navbar.tsx
@@ -21,17 +21,12 @@ import Banner from '../Banner/Banner'
 import FeatureDropdown from './FeatureDropdown'
 
 const LaunchWeekBanner = () => {
-	const day = moment().diff(moment('2023-07-17T16:00:00Z'), 'days') + 1
-	if (day < 1 || day > 5) {
-		return null
-	}
-
 	const bannerMessage = (
 		<div className={styles.launchWeekText}>
-			Launch Week 2 is here.{' '}
+			Launch Week 5 is here.{' '}
 			<a
 				target="_blank"
-				href="https://www.highlight.io/launch-week-2"
+				href="https://www.highlight.io/blog/tag/launch-week-5"
 				rel="noreferrer"
 			>
 				Follow along
@@ -101,9 +96,9 @@ const Navbar = ({
 		setPrevY(currentScrollPos)
 	}
 
-	const isLivestreamWeek = moment().isBetween(
-		'2024-04-16T00:00:00Z',
-		'2024-05-16T00:00:00Z',
+	const isLaunchWeek = moment().isBetween(
+		'2024-04-29T16:00:00Z',
+		'2024-05-04T16:00:00Z',
 	)
 
 	useEffect(() => {
@@ -115,8 +110,8 @@ const Navbar = ({
 		<>
 			{!hideGitHubPopup && <GithubPopup />}
 			{!hideBanner ? (
-				isLivestreamWeek ? (
-					<LivestreamBanner />
+				isLaunchWeek ? (
+					<LaunchWeekBanner />
 				) : (
 					<Link
 						href="/startups"


### PR DESCRIPTION
## Summary
- adds banners in app and site linking to blog posts with tag `launch-week-5`
<img width="1512" alt="Screen Shot 2024-04-29 at 4 43 47 PM" src="https://github.com/highlight/highlight/assets/86132398/a6b031d5-f693-45da-8d51-ae3ab7800967">
<img width="1512" alt="Screen Shot 2024-04-28 at 4 43 13 PM" src="https://github.com/highlight/highlight/assets/86132398/c4bb7bd3-dedf-49cd-bbb4-8816253bb64e">

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- should be deployed after blog content is added
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- @julian-highlight feel free to review in preview
<!--
 Request review from julian-highlight / our design team 
-->
