### PR TITLE
rename dashboard -> metric in places, fix spacing in legend

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7473,12 +7473,13 @@ body {
 }
 .dg2vg62 {
   left: -6px;
-  max-height: 48px;
+  max-height: 40px;
   padding-top: 2px;
   padding-bottom: 2px;
   overflow-y: auto;
   display: flex;
   flex-wrap: wrap;
+  row-gap: 4px;
 }
 .dg2vg63 {
   border-radius: 50%;

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -123,7 +123,7 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 	const { projectId: localStorageProjectId } = useLocalStorageProjectId()
 	const { isLoggedIn, signOut } = useAuthContext()
 	const showAnalytics = useFeatureFlag(Feature.Analytics)
-	const showDashboards = useFeatureFlag(Feature.Dashboards)
+	const showMetrics = useFeatureFlag(Feature.Metrics)
 	const { allProjects, currentWorkspace } = useApplicationContext()
 	const workspaceId = currentWorkspace?.id
 	const localStorageProject = allProjects?.find(
@@ -165,10 +165,10 @@ export const Header: React.FC<Props> = ({ fullyIntegrated }) => {
 			icon: IconSolidSparkles,
 		},
 		{
-			key: 'dashboards',
+			key: 'metrics',
 			icon: IconSolidChartBar,
 			isBeta: true,
-			hidden: !showDashboards,
+			hidden: !showMetrics,
 		},
 		{
 			key: 'alerts',

--- a/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
+++ b/frontend/src/hooks/useFeatureFlag/useFeatureFlag.ts
@@ -17,7 +17,7 @@ export enum Feature {
 	HistogramTimelineV2,
 	AiSessionInsights,
 	Analytics,
-	Dashboards,
+	Metrics,
 }
 
 // configures the criteria and percentage of population for which the feature is active.
@@ -53,7 +53,7 @@ export const FeatureConfig: { [key: number]: Config } = {
 			'9634',
 		]),
 	},
-	[Feature.Dashboards]: {
+	[Feature.Metrics]: {
 		workspace: true,
 		percent: 100,
 	},

--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -152,7 +152,7 @@ export const Dashboard = () => {
 										kind="secondary"
 										iconLeft={<IconSolidChartBar />}
 									>
-										Dashboards
+										Metrics
 									</Tag>
 								</Stack>
 							</Link>
@@ -247,9 +247,6 @@ export const Dashboard = () => {
 								</>
 							) : (
 								<>
-									<Button emphasis="low" kind="secondary">
-										Share
-									</Button>
 									<DateRangePicker
 										emphasis="low"
 										kind="secondary"

--- a/frontend/src/pages/Graphing/DashboardOverview.tsx
+++ b/frontend/src/pages/Graphing/DashboardOverview.tsx
@@ -107,14 +107,14 @@ export default function DashboardOverview() {
 						<Stack gap="24" width="full">
 							<Stack gap="16" direction="column" width="full">
 								<Heading mt="16" level="h4">
-									Dashboards
+									Metrics
 								</Heading>
 								<Text
 									weight="medium"
 									size="small"
 									color="default"
 								>
-									Dashboards allow you to visualize what's
+									Metrics allow you to visualize what's
 									happening in your app.
 								</Text>
 							</Stack>

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -632,12 +632,6 @@ export const GraphingEditor = () => {
 								onClick={onSave}
 							>
 								Save&nbsp;
-								<Badge
-									variant="outlinePurple"
-									shape="basic"
-									size="small"
-									label={[cmdKey, 'S'].join('+')}
-								/>
 							</Button>
 						</Box>
 					</Box>

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -1,5 +1,4 @@
 import {
-	Badge,
 	Box,
 	Button,
 	ComboboxSelect,
@@ -27,7 +26,6 @@ import { Helmet } from 'react-helmet'
 import { useNavigate } from 'react-router-dom'
 import { useDebounce } from 'react-use'
 
-import { cmdKey } from '@/components/KeyboardShortcutsEducation/KeyboardShortcutsEducation'
 import { SearchContext } from '@/components/Search/SearchContext'
 import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
 import { Search } from '@/components/Search/SearchForm/SearchForm'

--- a/frontend/src/pages/Graphing/components/Graph.css.ts
+++ b/frontend/src/pages/Graphing/components/Graph.css.ts
@@ -15,12 +15,13 @@ export const loadingText = style({
 
 export const legendWrapper = style({
 	left: -6,
-	maxHeight: 48,
+	maxHeight: 40,
 	paddingTop: 2,
 	paddingBottom: 2,
 	overflowY: 'auto',
 	display: 'flex',
 	flexWrap: 'wrap',
+	rowGap: 4,
 })
 
 export const legendDot = style({

--- a/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
+++ b/frontend/src/routers/ProjectRouter/ApplicationRouter.tsx
@@ -90,10 +90,7 @@ const ApplicationRouter: React.FC = () => {
 								</Suspense>
 							}
 						/>
-						<Route
-							path="dashboards/*"
-							element={<DashboardRouter />}
-						/>
+						<Route path="metrics/*" element={<DashboardRouter />} />
 						<Route
 							path="*"
 							element={<Navigate to={BASE_PATH} replace />}


### PR DESCRIPTION
## Summary
- renames `Dashboard` to `Metrics` a few places in the UI and in the route
- legend is max 2 rows, row spacing increased so it doesn't feel so crowded
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- @julian-highlight fyi
<!--
 Request review from julian-highlight / our design team 
-->
