### PR TITLE
Fix performance issue with query editor on logs

### DIFF
--- a/frontend/src/components/RelatedResources/LogsPanel.tsx
+++ b/frontend/src/components/RelatedResources/LogsPanel.tsx
@@ -11,6 +11,7 @@ import {
 import { Panel } from '@/components/RelatedResources/Panel'
 import { SearchContext } from '@/components/Search/SearchContext'
 import { SearchForm } from '@/components/Search/SearchForm/SearchForm'
+import { parseSearch } from '@/components/Search/utils'
 import { ProductType } from '@/graph/generated/schemas'
 import { useNumericProjectId } from '@/hooks/useProjectId'
 import { LogsTable } from '@/pages/LogsPage/LogsTable/LogsTable'
@@ -21,6 +22,7 @@ export const LogsPanel: React.FC<{ resource: RelatedLogs }> = ({
 }) => {
 	const { set } = useRelatedResource()
 	const [query, setQuery] = useState(resource.query ?? '')
+	const { queryParts } = parseSearch(query)
 	const handleSubmit = (query: string) => set({ ...resource, query })
 	const { projectId } = useNumericProjectId()
 
@@ -118,6 +120,8 @@ export const LogsPanel: React.FC<{ resource: RelatedLogs }> = ({
 							</Box>
 						) : (
 							<LogsTable
+								query={query}
+								queryParts={queryParts}
 								logEdges={logEdges}
 								loading={loading}
 								error={error}

--- a/frontend/src/pages/LogsPage/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage/LogsPage.tsx
@@ -29,6 +29,7 @@ import {
 	QueryParam,
 	SearchForm,
 } from '@/components/Search/SearchForm/SearchForm'
+import { parseSearch } from '@/components/Search/utils'
 import { useGetLogsHistogramQuery } from '@/graph/generated/hooks'
 import { useNumericProjectId } from '@/hooks/useProjectId'
 import { useSearchTime } from '@/hooks/useSearchTime'
@@ -68,6 +69,7 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 		project_id: string
 	}>()
 	const [query, setQuery] = useQueryParam('query', QueryParam)
+	const { queryParts } = parseSearch(query)
 	const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
 
 	const [selectedColumns, setSelectedColumns] = useLocalStorage(
@@ -210,6 +212,8 @@ const LogsPageInner = ({ timeMode, logCursor, presetDefault }: Props) => {
 						<LogsOverageCard />
 						<IntegrationCta />
 						<LogsTable
+							query={query}
+							queryParts={queryParts}
 							logEdges={logEdges}
 							loading={loading}
 							error={error}

--- a/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
+++ b/frontend/src/pages/LogsPage/LogsTable/LogsTable.tsx
@@ -43,7 +43,6 @@ import {
 } from '@/components/CustomColumnHeader'
 import { findMatchingAttributes } from '@/components/JsonViewer/utils'
 import { SearchExpression } from '@/components/Search/Parser/listener'
-import { useSearchContext } from '@/components/Search/SearchContext'
 import { LogEdge, ProductType } from '@/graph/generated/schemas'
 import { MAX_LOGS } from '@/pages/LogsPage/useGetLogs'
 import analytics from '@/util/analytics'
@@ -119,6 +118,8 @@ type LogsTableInnerProps = {
 	loadingAfter: boolean
 	logEdges: LogEdgeWithResources[]
 	selectedCursor: string | undefined
+	query: string
+	queryParts: SearchExpression[]
 	fetchMoreWhenScrolled: (target: HTMLDivElement) => void
 	// necessary for loading most recent loads
 	moreLogs?: number
@@ -135,6 +136,8 @@ const LogsTableInner = ({
 	logEdges,
 	loadingAfter,
 	selectedCursor,
+	query,
+	queryParts,
 	moreLogs,
 	bodyHeight,
 	clearMoreLogs,
@@ -143,7 +146,6 @@ const LogsTableInner = ({
 	selectedColumns = DEFAULT_LOG_COLUMNS,
 	setSelectedColumns,
 }: LogsTableInnerProps) => {
-	const { query, queryParts } = useSearchContext()
 	const bodyRef = useRef<HTMLDivElement>(null)
 	const enableFetchMoreLogs =
 		!!moreLogs && !!clearMoreLogs && !!handleAdditionalLogsDateChange

--- a/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
+++ b/frontend/src/pages/Player/RightPlayerPanel/components/NetworkResourcePanel/NetworkResourceLogs.tsx
@@ -17,6 +17,7 @@ import {
 	SearchFormProps,
 } from '@/components/Search/SearchForm/SearchForm'
 import { DEFAULT_OPERATOR } from '@/components/Search/SearchForm/utils'
+import { parseSearch } from '@/components/Search/utils'
 import { ProductType } from '@/graph/generated/schemas'
 import { useProjectId } from '@/hooks/useProjectId'
 import { FullScreenContainer } from '@/pages/LogsPage/LogsTable/FullScreenContainer'
@@ -41,6 +42,7 @@ export const NetworkResourceLogs: React.FC<{
 	}>()
 	const requestId = resource.requestResponsePairs?.request?.id
 	const [query, setQuery] = useState('')
+	const { queryParts } = parseSearch(query)
 	const startDate = useMemo(() => {
 		// startTime used in highlight.run <8.8.0 for websocket events and <7.5.4 for requests
 		const resourceStart =
@@ -126,6 +128,8 @@ export const NetworkResourceLogs: React.FC<{
 							<NoLogsFound />
 						) : (
 							<LogsTable
+								query={query}
+								queryParts={queryParts}
 								logEdges={logEdges}
 								loading={loading}
 								error={error}


### PR DESCRIPTION
## Summary

Editing a search query on the logs page is sluggish and causes some jank in the UI. This is because we try to update the text highlight for query matches on every log row with every keystroke. This PR works around this issue by passing the needed query data down via props to the logs table and only passing the top-level `query` variable that is updated when the form is actually submitted.

## How did you test this change?

* Open the logs page in production and enter some query data. Note the sluggishness when typing in the input.
* Open the PR preview for this branch. Things should be much more responsive now!

## Are there any deployment considerations?

N/A - all client-side changes.

## Does this work require review from our design team?

N/A - no visual change from this.