### PR TITLE
Fix issues with invite modal

### DIFF
--- a/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
@@ -46,7 +46,7 @@ function InviteMemberModal({
 
 	const [
 		sendInviteEmail,
-		{ loading: sendLoading, data: sendInviteEmailData },
+		{ loading: sendLoading, data: sendInviteEmailData, reset: sendReset },
 	] = useSendAdminWorkspaceInviteMutation()
 
 	const onSubmit = (e: { preventDefault: () => void }) => {
@@ -64,6 +64,7 @@ function InviteMemberModal({
 				role: newAdminRole,
 			},
 		}).then(() => {
+			setEmail('')
 			message.success(`Invite email sent to ${email}!`, 5)
 			emailRef.current?.focus()
 		})
@@ -76,7 +77,11 @@ function InviteMemberModal({
 			title="Invite Member"
 			visible={showModal}
 			width={600}
-			onCancel={() => toggleShowModal(false)}
+			onCancel={() => {
+				toggleShowModal(false)
+				setEmail('')
+				sendReset()
+			}}
 		>
 			<form onSubmit={onSubmit}>
 				<p className={styles.boxSubTitle}>
@@ -85,6 +90,7 @@ function InviteMemberModal({
 				</p>
 				<div className={styles.buttonRow}>
 					<Input
+						ref={emailRef}
 						className={styles.emailInput}
 						placeholder="Email"
 						type="email"


### PR DESCRIPTION
## Summary

Fixes a few issues with our member invite modal.

* Resets the form after successful submission
* Fixes the auto focus on the email input after successful submission
* Removes the alert if you close and reopen the modal

## How did you test this change?

Click tested the following locally and in the PR preview.

* Invite a team member and ensure
  * Email input was reset
  * Email input was focused
  * Closing and reopening the modal does not show the alert

## Are there any deployment considerations?

N/A - all minor client-side changes

## Does this work require review from our design team?

N/A
