### PR TITLE
Don't allow inviting existing admins or invitees

### DIFF
--- a/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
@@ -46,8 +46,15 @@ function InviteMemberModal({
 
 	const [
 		sendInviteEmail,
-		{ loading: sendLoading, data: sendInviteEmailData, reset: sendReset },
-	] = useSendAdminWorkspaceInviteMutation()
+		{
+			loading: sendLoading,
+			data: sendData,
+			error: sendError,
+			reset: sendReset,
+		},
+	] = useSendAdminWorkspaceInviteMutation({
+		fetchPolicy: 'no-cache',
+	})
 
 	const onSubmit = (e: { preventDefault: () => void }) => {
 		e.preventDefault()
@@ -143,7 +150,7 @@ function InviteMemberModal({
 					</Button>
 				</div>
 			</form>
-			{sendInviteEmailData?.sendAdminWorkspaceInvite && (
+			{sendData?.sendAdminWorkspaceInvite && (
 				<Alert
 					shouldAlwaysShow
 					trackingId="InviteAdminToWorkspaceConfirmation"
@@ -154,15 +161,22 @@ function InviteMemberModal({
 							You can also share with them this link:{' '}
 							<span>
 								<CopyText
-									text={
-										sendInviteEmailData.sendAdminWorkspaceInvite
-									}
+									text={sendData.sendAdminWorkspaceInvite}
 									onCopyTooltipText="Copied invite link to clipboard!"
 									inline
 								/>
 							</span>
 						</>
 					}
+				/>
+			)}
+			{sendError && (
+				<Alert
+					shouldAlwaysShow
+					trackingId="InviteAdminToWorkspaceError"
+					message="Couldn't send workspace invite"
+					type="error"
+					description={sendError.message}
 				/>
 			)}
 			<hr className={styles.hr} />

--- a/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/WorkspaceTeam/components/InviteMemberModal.tsx
@@ -101,6 +101,7 @@ function InviteMemberModal({
 						className={styles.emailInput}
 						placeholder="Email"
 						type="email"
+						required
 						name="invitedEmail"
 						autoFocus
 						value={email}


### PR DESCRIPTION
## Summary

We currently allow people to send invites to existing admins and people who have already been invited to a workspace. This PR adds some validations and error handling to ensure this doesn't happen. The checks for existing emails are case-insensitive.

<img width="615" alt="Screenshot 2024-05-01 at 2 31 06 PM" src="https://github.com/highlight/highlight/assets/308182/5b1d3946-ec92-4bea-8cd5-71b8a9751527">

<img width="617" alt="Screenshot 2024-05-01 at 2 31 24 PM" src="https://github.com/highlight/highlight/assets/308182/2841906b-cdfb-48fd-8fca-8c4357ad8fe2">

## How did you test this change?

* Try inviting an existing admin and ensure you get an error.
* Try inviting someone who has already been invited and ensure you get an error.
* Ensure emails that don't match admins or existing invitees are created correctly.

## Are there any deployment considerations?

Adds some DB load when creating a workspace invite, but only a few reads.

## Does this work require review from our design team?

N/A