### PR TITLE
use optimistic cache updates in metrics ui

### DIFF
--- a/backend/private-graph/graph/generated/generated.go
+++ b/backend/private-graph/graph/generated/generated.go
@@ -1799,7 +1799,7 @@ type MutationResolver interface {
 	TestErrorEnhancement(ctx context.Context, errorObjectID int, githubRepoPath string, githubPrefix *string, buildPrefix *string, saveError *bool) (*model1.ErrorObject, error)
 	UpsertVisualization(ctx context.Context, visualization model.VisualizationInput) (int, error)
 	DeleteVisualization(ctx context.Context, id int) (bool, error)
-	UpsertGraph(ctx context.Context, graph model.GraphInput) (int, error)
+	UpsertGraph(ctx context.Context, graph model.GraphInput) (*model1.Graph, error)
 	DeleteGraph(ctx context.Context, id int) (bool, error)
 }
 type QueryResolver interface {
@@ -14206,7 +14206,7 @@ type Mutation {
 	): ErrorObject
 	upsertVisualization(visualization: VisualizationInput!): ID!
 	deleteVisualization(id: ID!): Boolean!
-	upsertGraph(graph: GraphInput!): ID!
+	upsertGraph(graph: GraphInput!): Graph!
 	deleteGraph(id: ID!): Boolean!
 }
 
@@ -50142,9 +50142,9 @@ func (ec *executionContext) _Mutation_upsertGraph(ctx context.Context, field gra
 		}
 		return graphql.Null
 	}
-	res := resTmp.(int)
+	res := resTmp.(*model1.Graph)
 	fc.Result = res
-	return ec.marshalNID2int(ctx, field.Selections, res)
+	return ec.marshalNGraph2ᚖgithubᚗcomᚋhighlightᚑrunᚋhighlightᚋbackendᚋmodelᚐGraph(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Mutation_upsertGraph(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -50154,7 +50154,39 @@ func (ec *executionContext) fieldContext_Mutation_upsertGraph(ctx context.Contex
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type ID does not have child fields")
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Graph_id(ctx, field)
+			case "type":
+				return ec.fieldContext_Graph_type(ctx, field)
+			case "title":
+				return ec.fieldContext_Graph_title(ctx, field)
+			case "productType":
+				return ec.fieldContext_Graph_productType(ctx, field)
+			case "query":
+				return ec.fieldContext_Graph_query(ctx, field)
+			case "metric":
+				return ec.fieldContext_Graph_metric(ctx, field)
+			case "functionType":
+				return ec.fieldContext_Graph_functionType(ctx, field)
+			case "groupByKey":
+				return ec.fieldContext_Graph_groupByKey(ctx, field)
+			case "bucketByKey":
+				return ec.fieldContext_Graph_bucketByKey(ctx, field)
+			case "bucketCount":
+				return ec.fieldContext_Graph_bucketCount(ctx, field)
+			case "limit":
+				return ec.fieldContext_Graph_limit(ctx, field)
+			case "limitFunctionType":
+				return ec.fieldContext_Graph_limitFunctionType(ctx, field)
+			case "limitMetric":
+				return ec.fieldContext_Graph_limitMetric(ctx, field)
+			case "display":
+				return ec.fieldContext_Graph_display(ctx, field)
+			case "nullHandling":
+				return ec.fieldContext_Graph_nullHandling(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Graph", field.Name)
 		},
 	}
 	defer func() {

--- a/backend/private-graph/graph/schema.graphqls
+++ b/backend/private-graph/graph/schema.graphqls
@@ -2856,7 +2856,7 @@ type Mutation {
 	): ErrorObject
 	upsertVisualization(visualization: VisualizationInput!): ID!
 	deleteVisualization(id: ID!): Boolean!
-	upsertGraph(graph: GraphInput!): ID!
+	upsertGraph(graph: GraphInput!): Graph!
 	deleteGraph(id: ID!): Boolean!
 }
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -4768,20 +4768,20 @@ func (r *mutationResolver) DeleteVisualization(ctx context.Context, id int) (boo
 }
 
 // UpsertGraph is the resolver for the upsertGraph field.
-func (r *mutationResolver) UpsertGraph(ctx context.Context, graph modelInputs.GraphInput) (int, error) {
+func (r *mutationResolver) UpsertGraph(ctx context.Context, graph modelInputs.GraphInput) (*model.Graph, error) {
 	var viz model.Visualization
 	if err := r.DB.WithContext(ctx).Model(&viz).Where("id = ?", graph.VisualizationID).Take(&viz).Error; err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	_, err := r.isAdminInProject(ctx, viz.ProjectID)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	admin, err := r.getCurrentAdmin(ctx)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	id := 0
@@ -4826,10 +4826,10 @@ func (r *mutationResolver) UpsertGraph(ctx context.Context, graph modelInputs.Gr
 		}
 		return nil
 	}); err != nil {
-		return 0, nil
+		return nil, err
 	}
 
-	return toSave.ID, nil
+	return &toSave, nil
 }
 
 // DeleteGraph is the resolver for the deleteGraph field.

--- a/frontend/src/graph/generated/hooks.tsx
+++ b/frontend/src/graph/generated/hooks.tsx
@@ -5777,7 +5777,23 @@ export type DeleteVisualizationMutationOptions = Apollo.BaseMutationOptions<
 >
 export const UpsertGraphDocument = gql`
 	mutation UpsertGraph($graph: GraphInput!) {
-		upsertGraph(graph: $graph)
+		upsertGraph(graph: $graph) {
+			id
+			type
+			title
+			productType
+			query
+			metric
+			functionType
+			groupByKey
+			bucketByKey
+			bucketCount
+			limit
+			limitFunctionType
+			limitMetric
+			display
+			nullHandling
+		}
 	}
 `
 export type UpsertGraphMutationFn = Apollo.MutationFunction<

--- a/frontend/src/graph/generated/operations.tsx
+++ b/frontend/src/graph/generated/operations.tsx
@@ -1645,10 +1645,26 @@ export type UpsertGraphMutationVariables = Types.Exact<{
 	graph: Types.GraphInput
 }>
 
-export type UpsertGraphMutation = { __typename?: 'Mutation' } & Pick<
-	Types.Mutation,
-	'upsertGraph'
->
+export type UpsertGraphMutation = { __typename?: 'Mutation' } & {
+	upsertGraph: { __typename?: 'Graph' } & Pick<
+		Types.Graph,
+		| 'id'
+		| 'type'
+		| 'title'
+		| 'productType'
+		| 'query'
+		| 'metric'
+		| 'functionType'
+		| 'groupByKey'
+		| 'bucketByKey'
+		| 'bucketCount'
+		| 'limit'
+		| 'limitFunctionType'
+		| 'limitMetric'
+		| 'display'
+		| 'nullHandling'
+	>
+}
 
 export type DeleteGraphMutationVariables = Types.Exact<{
 	id: Types.Scalars['ID']

--- a/frontend/src/graph/generated/schemas.tsx
+++ b/frontend/src/graph/generated/schemas.tsx
@@ -1208,7 +1208,7 @@ export type Mutation = {
 	updateVercelProjectMappings: Scalars['Boolean']
 	upsertDashboard: Scalars['ID']
 	upsertDiscordChannel: DiscordChannel
-	upsertGraph: Scalars['ID']
+	upsertGraph: Graph
 	upsertSlackChannel: SanitizedSlackChannel
 	upsertVisualization: Scalars['ID']
 }

--- a/frontend/src/graph/operators/mutation.gql
+++ b/frontend/src/graph/operators/mutation.gql
@@ -1437,7 +1437,23 @@ mutation DeleteVisualization($id: ID!) {
 }
 
 mutation UpsertGraph($graph: GraphInput!) {
-	upsertGraph(graph: $graph)
+	upsertGraph(graph: $graph) {
+		id
+		type
+		title
+		productType
+		query
+		metric
+		functionType
+		groupByKey
+		bucketByKey
+		bucketCount
+		limit
+		limitFunctionType
+		limitMetric
+		display
+		nullHandling
+	}
 }
 
 mutation DeleteGraph($id: ID!) {

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -35,7 +35,7 @@ import {
 	useGetVisualizationQuery,
 	useUpsertGraphMutation,
 } from '@/graph/generated/hooks'
-import { GetKeysQuery, namedOperations } from '@/graph/generated/operations'
+import { GetKeysQuery } from '@/graph/generated/operations'
 import {
 	GraphInput,
 	MetricAggregator,
@@ -65,7 +65,6 @@ import {
 import { HeaderDivider } from '@/pages/Graphing/Dashboard'
 
 import * as style from './GraphingEditor.css'
-import { client } from '@/util/graph'
 
 const DEFAULT_BUCKET_COUNT = 50
 

--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -42,10 +42,10 @@ const RoundedBar = (id: string, isLast: boolean) => (props: BarProps) => {
 				height={Math.max((height ?? 0) - 1.5, 0)}
 				stroke="none"
 				fill={fill}
-				mask={`url(#barmask-${id}-${x})`}
+				clipPath={`url(#barmask-${id}-${x})`}
 			/>
 			{isLast && (
-				<mask id={`barmask-${id}-${x}`}>
+				<clipPath id={`barmask-${id}-${x}`}>
 					<rect
 						rx={Math.min((width ?? 0) / 3, 5)}
 						x={x}
@@ -54,7 +54,7 @@ const RoundedBar = (id: string, isLast: boolean) => (props: BarProps) => {
 						height="10000"
 						fill="white"
 					/>
-				</mask>
+				</clipPath>
 			)}
 		</>
 	)

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -361,8 +361,12 @@ const Graph = ({
 			project_id: projectId,
 			params: {
 				date_range: {
-					start_date: moment(startDate).format(TIME_FORMAT),
-					end_date: moment(endDate).format(TIME_FORMAT),
+					start_date: moment(startDate)
+						.startOf('minute')
+						.format(TIME_FORMAT),
+					end_date: moment(endDate)
+						.startOf('minute')
+						.format(TIME_FORMAT),
 				},
 				query: query,
 			},


### PR DESCRIPTION
## Summary
- fixes a bug where a new graph may not be shown until refreshing the page
- uses apollo's `cache.modify` when creating/editing/deleting graphs and reordering or renaming a dashboard
  - this optimistically modifies the cache with the updated state, while making another query to `GetVisualization` in case of an issue (similar to apollo's 'cache-and-network' mode)
https://www.loom.com/share/e8db544807ed430681450afef840887f
- svg mask seems to be a source of perf issues - replace with clipPath
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
