### PR TITLE
add form for name for new dashboards

### DIFF
--- a/frontend/src/pages/Graphing/DashboardOverview.tsx
+++ b/frontend/src/pages/Graphing/DashboardOverview.tsx
@@ -23,13 +23,13 @@ import { SearchEmptyState } from '@/components/SearchEmptyState/SearchEmptyState
 import {
 	useDeleteVisualizationMutation,
 	useGetVisualizationsQuery,
-	useUpsertVisualizationMutation,
 } from '@/graph/generated/hooks'
 import {
 	GetVisualizationsQuery,
 	namedOperations,
 } from '@/graph/generated/operations'
 import { useProjectId } from '@/hooks/useProjectId'
+import { CreateDashboardModal } from '@/pages/Graphing/components/CreateDashboardModal'
 
 import * as style from './DashboardOverview.css'
 
@@ -49,6 +49,7 @@ export default function DashboardOverview() {
 		[query],
 	)
 	const [page, setPage] = useState(0)
+	const [showModal, setShowModal] = useState(false)
 
 	const { data, loading } = useGetVisualizationsQuery({
 		variables: {
@@ -63,30 +64,19 @@ export default function DashboardOverview() {
 	const hasPrev = page > 0
 	const hasNext = (page + 1) * ITEMS_PER_PAGE < count
 
-	const [upsertViz, upsertContext] = useUpsertVisualizationMutation({
-		variables: {
-			visualization: {
-				name: 'Untitled dashboard',
-				projectId: projectId,
-			},
-		},
-		refetchQueries: [namedOperations.Query.GetVisualizations],
-	})
-
 	const navigate = useNavigate()
-
-	const createDashboard = () => {
-		upsertViz()
-			.then((result) => {
-				if (result.data !== undefined && result.data !== null) {
-					navigate(result.data.upsertVisualization)
-				}
-			})
-			.catch(() => message.error('Failed to create a new dashboard'))
-	}
 
 	return (
 		<Box width="full" background="raised" p="8">
+			<CreateDashboardModal
+				showModal={showModal}
+				onHideModal={() => {
+					setShowModal(false)
+				}}
+				afterCreateHandler={(id) => {
+					navigate(id)
+				}}
+			/>
 			<Box
 				border="dividerWeak"
 				borderRadius="6"
@@ -133,8 +123,9 @@ export default function DashboardOverview() {
 										All dashboards
 									</Text>
 									<Button
-										disabled={upsertContext.loading}
-										onClick={createDashboard}
+										onClick={() => {
+											setShowModal(true)
+										}}
 									>
 										Create new dashboard
 									</Button>

--- a/frontend/src/pages/Graphing/components/CreateDashboardModal.tsx
+++ b/frontend/src/pages/Graphing/components/CreateDashboardModal.tsx
@@ -1,0 +1,122 @@
+import { Button } from '@components/Button'
+import { Modal } from '@components/Modal/ModalV2'
+import { useUpsertVisualizationMutation } from '@graph/hooks'
+import { namedOperations } from '@graph/operations'
+import { Box, Form, Stack } from '@highlight-run/ui/components'
+import { message } from 'antd'
+import React from 'react'
+
+import { useProjectId } from '@/hooks/useProjectId'
+
+interface Props {
+	showModal: boolean
+	onHideModal: () => void
+	afterCreateHandler: (newDashboardId: string) => void
+}
+
+export const CreateDashboardModal: React.FC<Props> = ({
+	showModal,
+	onHideModal,
+	afterCreateHandler,
+}) => {
+	const { projectId } = useProjectId()
+
+	const [upsertViz, upsertContext] = useUpsertVisualizationMutation({
+		refetchQueries: [namedOperations.Query.GetVisualizations],
+	})
+
+	const onSubmit = (name: string) => {
+		upsertViz({
+			variables: {
+				visualization: {
+					name,
+					projectId,
+				},
+			},
+			onCompleted: (d) => {
+				if (afterCreateHandler) {
+					afterCreateHandler(d.upsertVisualization)
+				}
+				onHideModal()
+			},
+			onError: (e) => {
+				message.error(`Error creating dashboard: ${e.message}`)
+			},
+		})
+	}
+
+	if (!showModal) {
+		return null
+	}
+
+	return (
+		<InnerModal
+			loading={upsertContext.loading}
+			onHideModal={onHideModal}
+			onSubmit={onSubmit}
+		/>
+	)
+}
+
+interface ModalProps {
+	loading: boolean
+	onHideModal: () => void
+	onSubmit: (name: string) => void
+}
+
+const InnerModal = ({ loading, onHideModal, onSubmit }: ModalProps) => {
+	const formStore = Form.useStore({
+		defaultValues: {
+			name: '',
+			filters: '',
+		},
+	})
+
+	const handleSubmit = (e: { preventDefault: () => void }) => {
+		e.preventDefault()
+		const newName = formStore.getValue(formStore.names.name)
+		onSubmit(newName)
+	}
+
+	return (
+		<Modal title="Create new dashboard" onClose={onHideModal}>
+			<Stack py="8" px="12" style={{ minWidth: 300, maxWidth: 500 }}>
+				<Form onSubmit={handleSubmit} store={formStore}>
+					<Form.Input
+						name={formStore.names.name}
+						label="Dashboard name"
+						placeholder="Untitled dashboard"
+						type="name"
+						autoFocus
+					/>
+					<Box borderTop="dividerWeak" my="12" width="full" />
+
+					<Box
+						display="flex"
+						justifyContent="flex-end"
+						gap="8"
+						pt="12"
+					>
+						<Button
+							trackingId="cancel-create-dashboard"
+							kind="secondary"
+							emphasis="medium"
+							onClick={onHideModal}
+						>
+							Cancel
+						</Button>
+						<Button
+							trackingId="submit-create-dashboard"
+							kind="primary"
+							type="submit"
+							disabled={!formStore.useValue(formStore.names.name)}
+							loading={loading}
+						>
+							Create
+						</Button>
+					</Box>
+				</Form>
+			</Stack>
+		</Modal>
+	)
+}


### PR DESCRIPTION
## Summary
- instead of defaulting all new dashboards to "Untitled dashboard", open a form in a modal for entering the dashboard name
- https://www.loom.com/share/9d274d7de8fc488493ca9d105b9753f5
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- @julian-highlight 
<!--
 Request review from julian-highlight / our design team 
-->
