### PR TITLE
fixup! fix count distinct for metrics api (#8413)

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -622,7 +622,11 @@ func readWorkspaceMetrics[T ~string](ctx context.Context, client *Client, sample
 	}
 	var metricExpr = col
 	if !isCountDistinct {
-		metricExpr = fmt.Sprintf("toFloat64OrNull(%s)", col)
+		if reservedCol, found := keysToColumns[T(strings.ToLower(column))]; found {
+			metricExpr = fmt.Sprintf("toFloat64(%s)", reservedCol)
+		} else {
+			metricExpr = fmt.Sprintf("toFloat64OrNull(%s)", col)
+		}
 	}
 
 	switch column {


### PR DESCRIPTION
## Summary

`toFloat64OrNull(...)` in clickhouse does not accept `int` or `float` values as arguments.

## How did you test this change?

broken charts loading
![Screenshot from 2024-05-02 12-13-07](https://github.com/highlight/highlight/assets/1351531/735d942e-5bdc-4479-83e3-2bb510729d23)

count distinct still works
![Screenshot from 2024-05-02 12-13-46](https://github.com/highlight/highlight/assets/1351531/22564e82-9265-4d36-8f70-3ef3c838bca3)


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no
