### PR TITLE
add metrics video to docs

### DIFF
--- a/docs-content/general/6_product-features/6_metrics/1_overview.md
+++ b/docs-content/general/6_product-features/6_metrics/1_overview.md
@@ -4,6 +4,12 @@ title: Metrics
 slug: overview
 ---
 
+<EmbeddedVideo 
+  src="https://www.youtube.com/embed/MzJMCcgf6iU"
+  title="Metrics"
+  allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+/>
+
 Metrics are representations of your sessions, errors, logs, and traces that you can graph, analyze, and monitor. When understanding your business or application, the reality is that a lot of the data you need is already in highlight.io.
 
 You can find our metrics product at [app.highlight.io/metrics](https://app.highlight.io/metrics).


### PR DESCRIPTION
## Summary
- adds the launch week metrics video to the metrics overview docs
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
