### PR TITLE
draw dots at line chart discontinuities

### DIFF
--- a/frontend/src/pages/Graphing/components/LineChart.tsx
+++ b/frontend/src/pages/Graphing/components/LineChart.tsx
@@ -120,6 +120,37 @@ export const LineChart = ({
 							return null
 						}
 
+						const CustomizedDot = (props: any) => {
+							if (
+								viewConfig.nullHandling !== 'Hidden' &&
+								viewConfig.nullHandling !== undefined
+							) {
+								return null
+							}
+
+							const { cx, cy, stroke, index } = props
+
+							const prev = (data?.at(index - 1) ?? {})[key]
+							const cur = (data?.at(index) ?? {})[key]
+							const next = (data?.at(index + 1) ?? {})[key]
+
+							// Draw a dot if discontinuous at this point
+							if (
+								cur !== null &&
+								(prev === null || next === null)
+							) {
+								return (
+									<svg x={cx - 2} y={cy - 2}>
+										<g transform="translate(2 2)">
+											<circle r="2" fill={stroke} />
+										</g>
+									</svg>
+								)
+							}
+
+							return null
+						}
+
 						return (
 							<Area
 								isAnimationActive={false}
@@ -141,6 +172,7 @@ export const LineChart = ({
 								connectNulls={
 									viewConfig.nullHandling === 'Connected'
 								}
+								dot={<CustomizedDot />}
 							/>
 						)
 					})}


### PR DESCRIPTION
## Summary
- adds to the line charts when data is missing on either side (avoids confusing invisible points on the graphs)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- @julian-highlight if you have any style recommendation for these dots, right now they're just 2px filled circles
<!--
 Request review from julian-highlight / our design team 
-->
