### PR TITLE
export highlight state on sdk

### DIFF
--- a/.changeset/slow-lizards-begin.md
+++ b/.changeset/slow-lizards-begin.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': patch
+---
+
+export highlight state on sdk

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -282,6 +282,7 @@ export declare interface HighlightPublicInterface {
 		func: () => void | Promise<void>,
 		options?: OnHighlightReadyOptions,
 	) => Promise<void>
+	get: () => 'NotRecording' | 'Recording'
 	options: HighlightOptions | undefined
 	/**
 	 * Calling this will add a feedback comment to the session.

--- a/sdk/client/src/types/types.ts
+++ b/sdk/client/src/types/types.ts
@@ -282,7 +282,7 @@ export declare interface HighlightPublicInterface {
 		func: () => void | Promise<void>,
 		options?: OnHighlightReadyOptions,
 	) => Promise<void>
-	get: () => 'NotRecording' | 'Recording'
+	getRecordingState: () => 'NotRecording' | 'Recording'
 	options: HighlightOptions | undefined
 	/**
 	 * Calling this will add a feedback comment to the session.

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -403,6 +403,9 @@ const H: HighlightPublicInterface = {
 			})
 		})
 	},
+	get: () => {
+		return highlight_obj.state
+	},
 	onHighlightReady: async (func, options) => {
 		onHighlightReadyQueue.push({ options, func })
 		if (onHighlightReadyTimeout === undefined) {

--- a/sdk/firstload/src/index.tsx
+++ b/sdk/firstload/src/index.tsx
@@ -403,7 +403,7 @@ const H: HighlightPublicInterface = {
 			})
 		})
 	},
-	get: () => {
+	getRecordingState: () => {
 		return highlight_obj.state
 	},
 	onHighlightReady: async (func, options) => {


### PR DESCRIPTION
## Summary

* expose the highlight recording state via an accessor method

## How did you test this change?

local deploy
![Screenshot from 2024-05-02 18-33-08](https://github.com/highlight/highlight/assets/1351531/4ab2ffe1-5212-4dcb-840d-20247e4b9a1c)

## Are there any deployment considerations?

changeset

## Does this work require review from our design team?

no