### PR TITLE
improvement to errors_joined_vw perf

### DIFF
--- a/backend/clickhouse/migrations/000099_errors_joined_vw_perf.down.sql
+++ b/backend/clickhouse/migrations/000099_errors_joined_vw_perf.down.sql
@@ -1,0 +1,16 @@
+DROP VIEW IF EXISTS errors_joined_vw;
+CREATE VIEW IF NOT EXISTS errors_joined_vw AS
+SELECT ProjectID as ProjectId,
+    *
+FROM error_objects eo FINAL
+    INNER JOIN (
+        SELECT *
+        FROM error_groups FINAL
+        WHERE (ID, CreatedAt) IN (
+                SELECT ID,
+                    max(CreatedAt)
+                FROM error_groups
+                GROUP BY ID
+            )
+    ) eg ON eg.ID = eo.ErrorGroupID
+    AND eg.ProjectID = eo.ProjectID;

--- a/backend/clickhouse/migrations/000099_errors_joined_vw_perf.up.sql
+++ b/backend/clickhouse/migrations/000099_errors_joined_vw_perf.up.sql
@@ -1,0 +1,16 @@
+DROP VIEW IF EXISTS errors_joined_vw;
+CREATE VIEW IF NOT EXISTS errors_joined_vw AS
+SELECT ProjectID as ProjectId,
+    *
+FROM error_objects eo FINAL
+    INNER JOIN (
+        SELECT *
+        FROM error_groups FINAL
+        WHERE (ID, CreatedAt) IN (
+                SELECT ID,
+                    max(CreatedAt)
+                FROM error_groups
+                GROUP BY ID
+            )
+    ) eg ON eg.ID = eo.ErrorGroupID
+    AND eg.ProjectID = eo.ProjectID;


### PR DESCRIPTION
## Summary
- small change to `errors_joined_vw` replaces the line
`SELECT eg.ProjectID as ProjectId,` with `SELECT ProjectID as ProjectId,`
- this filters using the error_objects' primary key, and since it is the larger table in the join this makes a big perf difference
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- applied this in prod after testing
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
