### PR TITLE
more dashboard polish items

### DIFF
--- a/backend/clickhouse/query.go
+++ b/backend/clickhouse/query.go
@@ -684,7 +684,7 @@ func readWorkspaceMetrics[T ~string](ctx context.Context, client *Client, sample
 	for idx, group := range groupBy {
 		groupCol := ""
 		if col, found := keysToColumns[T(group)]; found {
-			groupCol = col
+			groupCol = fmt.Sprintf("toString(%s)", col)
 		} else {
 			groupCol = fmt.Sprintf("toString(%s[%s])", attributesColumn, fromSb.Var(group))
 		}

--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7461,6 +7461,8 @@ body {
   flex-direction: column;
   gap: 6px;
   padding: 8px;
+  max-height: 180px;
+  overflow-y: auto;
 }
 .dg2vg69 {
   line-height: 16px;

--- a/frontend/src/pages/Graphing/components/Graph.css.ts
+++ b/frontend/src/pages/Graphing/components/Graph.css.ts
@@ -63,6 +63,8 @@ export const tooltipWrapper = style({
 	flexDirection: 'column',
 	gap: '6px',
 	padding: '8px',
+	maxHeight: '180px',
+	overflowY: 'auto',
 })
 
 export const tooltipText = style({


### PR DESCRIPTION
## Summary
- constrain tooltip to max height 180px to avoid escaping the graph when there are lots of series
- fix issue grouping on top-level non-string columns (e.g. errors.has_session)
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
