### PR TITLE
add range select, make time selector replace history

### DIFF
--- a/frontend/src/__generated/index.css
+++ b/frontend/src/__generated/index.css
@@ -7477,6 +7477,9 @@ body {
 .dg2vg6c {
   width: min-content;
 }
+.dg2vg6d {
+  user-select: none;
+}
 ._1a4jm560 {
   height: 40px;
 }

--- a/frontend/src/__generated/ve/pages/Graphing/components/Graph.css.js
+++ b/frontend/src/__generated/ve/pages/Graphing/components/Graph.css.js
@@ -8,6 +8,7 @@ var legendTextWrapper = "dg2vg64";
 var legendWrapper = "dg2vg62";
 var loadingOverlay = "dg2vg60";
 var loadingText = "dg2vg61";
+var tickText = "dg2vg6d";
 var titleText = "dg2vg66";
 var tooltipDot = "dg2vg6a";
 var tooltipText = "dg2vg69";
@@ -22,6 +23,7 @@ export {
   legendWrapper,
   loadingOverlay,
   loadingText,
+  tickText,
   titleText,
   tooltipDot,
   tooltipText,

--- a/frontend/src/hooks/useSearchTime.ts
+++ b/frontend/src/hooks/useSearchTime.ts
@@ -5,7 +5,7 @@ import {
 } from '@highlight-run/ui/components'
 import moment from 'moment'
 import { useCallback, useEffect, useState } from 'react'
-import { DateTimeParam, useQueryParam } from 'use-query-params'
+import { DateTimeParam, StringParam, useQueryParams } from 'use-query-params'
 
 export interface UseSearchTimeReturnValue {
 	startDate: Date
@@ -26,20 +26,14 @@ export function useSearchTime({
 	initialPreset,
 }: UseSearchTimeProps): UseSearchTimeReturnValue {
 	const defaultPreset = initialPreset ?? presets[0]
-	const [startDateParam, setStartDateParam] = useQueryParam(
-		'start_date',
-		DateTimeParam,
-	)
-	const [endDateParam, setEndDateParam] = useQueryParam(
-		'end_date',
-		DateTimeParam,
-	)
-	const [presetParam, setPresetParam] = useQueryParam<string | undefined>(
-		'relative_time',
-	)
+	const [params, setParams] = useQueryParams({
+		relative_time: StringParam,
+		start_date: DateTimeParam,
+		end_date: DateTimeParam,
+	})
 
 	const findPreset = useCallback(
-		(value?: string): DateRangePreset => {
+		(value?: string | null): DateRangePreset => {
 			if (!value) {
 				return defaultPreset
 			}
@@ -54,18 +48,19 @@ export function useSearchTime({
 	)
 
 	// initalize state to url params
-	const useRelativeTime = presetParam || !startDateParam || !endDateParam
+	const useRelativeTime =
+		params.relative_time || !params.start_date || !params.end_date
 	const [selectedPreset, setSelectedPreset] = useState<
 		DateRangePreset | undefined
-	>(useRelativeTime ? findPreset(presetParam) : undefined)
+	>(useRelativeTime ? findPreset(params.relative_time) : undefined)
 
 	const [endDate, setEndDate] = useState<Date>(
-		useRelativeTime ? moment().toDate() : new Date(endDateParam!),
+		useRelativeTime ? moment().toDate() : new Date(params.end_date!),
 	)
 	const [startDate, setStartDate] = useState<Date>(
 		useRelativeTime
 			? presetStartDate(selectedPreset ?? defaultPreset)
-			: new Date(startDateParam!),
+			: new Date(params.start_date!),
 	)
 
 	const updateSearchTime = (
@@ -100,13 +95,23 @@ export function useSearchTime({
 				selectedPresetValue = undefined
 			}
 
-			setPresetParam(selectedPresetValue)
-			setEndDateParam(undefined)
-			setStartDateParam(undefined)
+			setParams(
+				{
+					relative_time: selectedPresetValue,
+					start_date: undefined,
+					end_date: undefined,
+				},
+				'replace',
+			)
 		} else {
-			setPresetParam(undefined)
-			setEndDateParam(endDate)
-			setStartDateParam(startDate)
+			setParams(
+				{
+					relative_time: undefined,
+					start_date: startDate,
+					end_date: endDate,
+				},
+				'replace',
+			)
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [startDate, endDate, selectedPreset])

--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -498,6 +498,9 @@ export const Dashboard = () => {
 																	  }
 															}
 															disabled={editing}
+															setTimeRange={
+																updateSearchTime
+															}
 														/>
 													</DashboardCard>
 												)

--- a/frontend/src/pages/Graphing/ExpandedGraph.tsx
+++ b/frontend/src/pages/Graphing/ExpandedGraph.tsx
@@ -171,6 +171,7 @@ export const ExpandedGraph = () => {
 									g.limitFunctionType ?? undefined
 								}
 								limitMetric={g.limitMetric ?? undefined}
+								setTimeRange={updateSearchTime}
 							/>
 						</Box>
 					</Box>

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -794,6 +794,7 @@ export const GraphingEditor = () => {
 												? limitMetric
 												: undefined
 										}
+										setTimeRange={updateSearchTime}
 									/>
 								</Box>
 							</Box>

--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -68,7 +68,11 @@ export const BarChart = ({
 	spotlight,
 	strokeColors,
 	viewConfig,
-}: InnerChartProps<BarChartConfig> & SeriesInfo) => {
+	onMouseDown,
+	onMouseMove,
+	onMouseUp,
+	children,
+}: React.PropsWithChildren<InnerChartProps<BarChartConfig> & SeriesInfo>) => {
 	const xAxisTickFormatter = getTickFormatter(xAxisMetric, data)
 	const yAxisTickFormatter = getTickFormatter(yAxisMetric, data)
 
@@ -77,7 +81,14 @@ export const BarChart = ({
 
 	return (
 		<ResponsiveContainer>
-			<RechartsBarChart data={data} barCategoryGap={1}>
+			<RechartsBarChart
+				data={data}
+				barCategoryGap={1}
+				onMouseDown={onMouseDown}
+				onMouseMove={onMouseMove}
+				onMouseUp={onMouseUp}
+			>
+				{children}
 				<XAxis
 					dataKey={xAxisMetric}
 					fontSize={10}

--- a/frontend/src/pages/Graphing/components/Graph.css.ts
+++ b/frontend/src/pages/Graphing/components/Graph.css.ts
@@ -83,3 +83,7 @@ export const disabled = style({
 export const hoverCard = style({
 	width: 'min-content',
 })
+
+export const tickText = style({
+	userSelect: 'none',
+})

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -443,8 +443,6 @@ const Graph = ({
 	const [refAreaStart, setRefAreaStart] = useState<number | undefined>()
 	const [refAreaEnd, setRefAreaEnd] = useState<number | undefined>()
 
-	console.log('refAreas', refAreaStart, refAreaEnd)
-
 	const referenceArea =
 		refAreaStart && refAreaEnd ? (
 			<ReferenceArea

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -20,6 +20,8 @@ import clsx from 'clsx'
 import _ from 'lodash'
 import moment from 'moment'
 import { useEffect, useMemo, useState } from 'react'
+import { ReferenceArea } from 'recharts'
+import { CategoricalChartFunc } from 'recharts/types/chart/generateCategoricalChart'
 
 import { TIME_FORMAT } from '@/components/Search/SearchForm/constants'
 import { useGetMetricsQuery } from '@/graph/generated/hooks'
@@ -94,6 +96,7 @@ export interface ChartProps<TConfig> {
 	onDelete?: () => void
 	onExpand?: () => void
 	onEdit?: () => void
+	setTimeRange?: (startDate: Date, endDate: Date) => void
 }
 
 export interface InnerChartProps<TConfig> {
@@ -105,6 +108,9 @@ export interface InnerChartProps<TConfig> {
 	loading?: boolean
 	viewConfig: TConfig
 	disabled?: boolean
+	onMouseDown?: CategoricalChartFunc
+	onMouseMove?: CategoricalChartFunc
+	onMouseUp?: CategoricalChartFunc
 }
 
 export interface SeriesInfo {
@@ -260,6 +266,7 @@ export const CustomYAxisTick = ({
 			fill={vars.theme.static.content.weak}
 			textAnchor="start"
 			orientation="left"
+			className={style.tickText}
 		>
 			{tickFormatter(payload.value, payload.index)}
 		</text>
@@ -287,6 +294,7 @@ export const CustomXAxisTick = ({
 			textAnchor="middle"
 			orientation="bottom"
 			width={30}
+			className={style.tickText}
 		>
 			{tickFormatter(payload.value, payload.index)}
 		</text>
@@ -350,6 +358,7 @@ const Graph = ({
 	onDelete,
 	onExpand,
 	onEdit,
+	setTimeRange,
 }: ChartProps<ViewConfig>) => {
 	const [graphHover, setGraphHover] = useState(false)
 	const queriedBucketCount = bucketByKey !== undefined ? bucketCount : 1
@@ -431,6 +440,55 @@ const Graph = ({
 		setSpotlight(undefined)
 	}, [series])
 
+	const [refAreaStart, setRefAreaStart] = useState<number | undefined>()
+	const [refAreaEnd, setRefAreaEnd] = useState<number | undefined>()
+
+	console.log('refAreas', refAreaStart, refAreaEnd)
+
+	const referenceArea =
+		refAreaStart && refAreaEnd ? (
+			<ReferenceArea
+				x1={refAreaStart}
+				x2={refAreaEnd}
+				strokeOpacity={0.3}
+			/>
+		) : null
+
+	const allowDrag =
+		setTimeRange !== undefined && xAxisMetric === TIMESTAMP_KEY
+
+	const onMouseDown: CategoricalChartFunc | undefined = allowDrag
+		? (e) => {
+				if (e.activeLabel !== undefined) {
+					setRefAreaStart(Number(e.activeLabel))
+				}
+		  }
+		: undefined
+
+	const onMouseMove: CategoricalChartFunc | undefined = allowDrag
+		? (e) => {
+				if (refAreaStart !== undefined && e.activeLabel !== undefined) {
+					setRefAreaEnd(Number(e.activeLabel))
+				}
+		  }
+		: undefined
+
+	const onMouseUp: CategoricalChartFunc | undefined = allowDrag
+		? () => {
+				if (refAreaStart !== undefined && refAreaEnd !== undefined) {
+					const startDate = Math.min(refAreaStart, refAreaEnd)
+					const endDate = Math.max(refAreaStart, refAreaEnd)
+
+					setTimeRange(
+						new Date(startDate * 1000),
+						new Date(endDate * 1000),
+					)
+				}
+				setRefAreaStart(undefined)
+				setRefAreaEnd(undefined)
+		  }
+		: undefined
+
 	let isEmpty = data !== undefined
 	for (const d of data ?? []) {
 		for (const v of Object.values(d)) {
@@ -470,7 +528,12 @@ const Graph = ({
 						viewConfig={viewConfig}
 						series={series}
 						spotlight={spotlight}
-					/>
+						onMouseDown={onMouseDown}
+						onMouseMove={onMouseMove}
+						onMouseUp={onMouseUp}
+					>
+						{referenceArea}
+					</LineChart>
 				)
 				break
 			case 'Bar chart':
@@ -483,7 +546,12 @@ const Graph = ({
 						viewConfig={viewConfig}
 						series={series}
 						spotlight={spotlight}
-					/>
+						onMouseDown={onMouseDown}
+						onMouseMove={onMouseMove}
+						onMouseUp={onMouseUp}
+					>
+						{referenceArea}
+					</BarChart>
 				)
 				break
 			case 'Table':

--- a/frontend/src/pages/Graphing/components/LineChart.tsx
+++ b/frontend/src/pages/Graphing/components/LineChart.tsx
@@ -45,7 +45,11 @@ export const LineChart = ({
 	series,
 	spotlight,
 	viewConfig,
-}: InnerChartProps<LineChartConfig> & SeriesInfo) => {
+	onMouseDown,
+	onMouseMove,
+	onMouseUp,
+	children,
+}: React.PropsWithChildren<InnerChartProps<LineChartConfig> & SeriesInfo>) => {
 	const xAxisTickFormatter = getTickFormatter(xAxisMetric, data)
 	const yAxisTickFormatter = getTickFormatter(yAxisMetric, data)
 
@@ -65,7 +69,13 @@ export const LineChart = ({
 
 	return (
 		<ResponsiveContainer height="100%" width="100%">
-			<AreaChart data={filledData}>
+			<AreaChart
+				data={filledData}
+				onMouseDown={onMouseDown}
+				onMouseMove={onMouseMove}
+				onMouseUp={onMouseUp}
+			>
+				{children}
 				<XAxis
 					dataKey={xAxisMetric}
 					fontSize={10}


### PR DESCRIPTION
## Summary
- add the concept of a reference area to the common `Graph` file - when the x-axis is a timestamp, allow selecting a range in the graph to adjust the dates
- the date pickers were adding to the history whenever the date was changed, but pressing back would not revert to the previous date - for now, I'm making it replace the history
https://www.loom.com/share/59d9bb3c0af243f18bc161dd9f5b65c0
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- @julian-highlight to review range selecting functionality - I just used a recharts example as inspiration but let me know if I should adjust the colors or anything
<!--
 Request review from julian-highlight / our design team 
-->
