### PR TITLE
send billing emails to role = admin only

### DIFF
--- a/backend/model/model.go
+++ b/backend/model/model.go
@@ -328,6 +328,7 @@ func (w *Workspace) AdminEmailAddresses(db *gorm.DB) ([]struct {
 			INNER JOIN admins a
 			ON wa.admin_id = a.id
 			WHERE wa.workspace_id = ?
+			AND wa.role = 'ADMIN'
 			AND NOT EXISTS (
 				SELECT *
 				FROM email_opt_outs eoo


### PR DESCRIPTION
## Summary
- `AdminEmailAddresses` used in billing should return only users with `wa.role = 'ADMIN'`
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- unit tested to ensure only admins in the input workspace are returned
- ran query against Highlight workspace to ensure non-admins were filtered out
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
