### PR TITLE
[HIG-4610] use dataMin, dataMax for x-axis, dot fixes

### DIFF
--- a/frontend/src/pages/Graphing/components/BarChart.tsx
+++ b/frontend/src/pages/Graphing/components/BarChart.tsx
@@ -105,7 +105,7 @@ export const BarChart = ({
 					axisLine={{ visibility: 'hidden' }}
 					height={12}
 					type={xAxisMetric === GROUP_KEY ? 'category' : 'number'}
-					domain={['auto', 'auto']}
+					domain={['dataMin', 'dataMax']}
 				/>
 
 				<Tooltip

--- a/frontend/src/pages/Graphing/components/LineChart.tsx
+++ b/frontend/src/pages/Graphing/components/LineChart.tsx
@@ -16,6 +16,7 @@ import {
 	getColor,
 	getCustomTooltip,
 	getTickFormatter,
+	GROUP_KEY,
 	InnerChartProps,
 	isActive,
 	SeriesInfo,
@@ -91,8 +92,8 @@ export const LineChart = ({
 					tickLine={{ visibility: 'hidden' }}
 					axisLine={{ visibility: 'hidden' }}
 					height={12}
-					type="number"
-					domain={['auto', 'auto']}
+					type={xAxisMetric === GROUP_KEY ? 'category' : 'number'}
+					domain={['dataMin', 'dataMax']}
 				/>
 
 				<Tooltip
@@ -132,23 +133,31 @@ export const LineChart = ({
 
 						const CustomizedDot = (props: any) => {
 							if (
-								viewConfig.nullHandling !== 'Hidden' &&
-								viewConfig.nullHandling !== undefined
+								(viewConfig.nullHandling !== 'Hidden' &&
+									viewConfig.nullHandling !== undefined) ||
+								data === undefined
 							) {
 								return null
 							}
 
 							const { cx, cy, stroke, index } = props
 
-							const prev = (data?.at(index - 1) ?? {})[key]
-							const cur = (data?.at(index) ?? {})[key]
-							const next = (data?.at(index + 1) ?? {})[key]
+							const hasPrev =
+								index === 0 ||
+								![null, undefined].includes(
+									data[index - 1][key],
+								)
+							const hasCur = ![null, undefined].includes(
+								data[index][key],
+							)
+							const hasNext =
+								index === data.length - 1 ||
+								![null, undefined].includes(
+									data[index + 1][key],
+								)
 
 							// Draw a dot if discontinuous at this point
-							if (
-								cur !== null &&
-								(prev === null || next === null)
-							) {
+							if (hasCur && (!hasPrev || !hasNext)) {
 								return (
 									<svg x={cx - 2} y={cy - 2}>
 										<g transform="translate(2 2)">


### PR DESCRIPTION
## Summary
- change line and bar chart components to use `dataMin, dataMax` as the x-axis domain instead of `auto, auto`
- fix dot logic which had bugs when multiple series were displayed (needed to check both undefined and null)
- fix categorical line charts not showing data
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- clicktested locally
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
