### PR TITLE
use replaceIn to stop erasing other query params

### DIFF
--- a/frontend/src/hooks/useSearchTime.ts
+++ b/frontend/src/hooks/useSearchTime.ts
@@ -101,7 +101,7 @@ export function useSearchTime({
 					start_date: undefined,
 					end_date: undefined,
 				},
-				'replace',
+				'replaceIn',
 			)
 		} else {
 			setParams(
@@ -110,7 +110,7 @@ export function useSearchTime({
 					start_date: startDate,
 					end_date: endDate,
 				},
-				'replace',
+				'replaceIn',
 			)
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
- query param erased when changing the date - use `replaceIn` instead here
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- preview env
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
