### PR TITLE
Extend sessions and errors date range

### DIFF
--- a/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
+++ b/frontend/src/pages/Alerts/ErrorAlert/ErrorAlertPage.tsx
@@ -10,7 +10,7 @@ import {
 	Box,
 	Column,
 	Container,
-	DEFAULT_TIME_PRESETS,
+	EXTENDED_TIME_PRESETS,
 	Form,
 	FormState,
 	IconSolidCheveronDown,
@@ -424,8 +424,8 @@ const ErrorAlertForm = ({ hideRegexExpression }: ErrorAlertFormProps) => {
 	const errors = formStore.useState('errors')
 
 	const { startDate, endDate } = useSearchTime({
-		presets: DEFAULT_TIME_PRESETS,
-		initialPreset: DEFAULT_TIME_PRESETS[5],
+		presets: EXTENDED_TIME_PRESETS,
+		initialPreset: EXTENDED_TIME_PRESETS[5],
 	})
 
 	return (

--- a/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorsV2.tsx
@@ -18,7 +18,7 @@ import {
 	Box,
 	ButtonIcon,
 	Callout,
-	DEFAULT_TIME_PRESETS,
+	EXTENDED_TIME_PRESETS,
 	IconSolidExitRight,
 	Text,
 	Tooltip,
@@ -91,8 +91,8 @@ export default function ErrorsV2() {
 	const [page, setPage] = useQueryParam('page', PAGE_PARAM)
 
 	const searchTimeContext = useSearchTime({
-		presets: DEFAULT_TIME_PRESETS,
-		initialPreset: DEFAULT_TIME_PRESETS[5],
+		presets: EXTENDED_TIME_PRESETS,
+		initialPreset: EXTENDED_TIME_PRESETS[5],
 	})
 
 	const handleSubmit = useCallback(

--- a/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
+++ b/frontend/src/pages/ErrorsV2/SearchPanel/SearchPanel.tsx
@@ -11,7 +11,7 @@ import { ProductType, SavedSegmentEntityType } from '@graph/schemas'
 import {
 	Box,
 	ButtonIcon,
-	DEFAULT_TIME_PRESETS,
+	EXTENDED_TIME_PRESETS,
 	IconSolidLogout,
 	presetStartDate,
 } from '@highlight-run/ui/components'
@@ -95,8 +95,8 @@ export const SearchPanel = () => {
 				startDate={startDate!}
 				endDate={endDate!}
 				onDatesChange={updateSearchTime!}
-				presets={DEFAULT_TIME_PRESETS}
-				minDate={presetStartDate(DEFAULT_TIME_PRESETS[5])}
+				presets={EXTENDED_TIME_PRESETS}
+				minDate={presetStartDate(EXTENDED_TIME_PRESETS[6])}
 				selectedPreset={selectedPreset}
 				productType={ProductType.Errors}
 				timeMode="fixed-range"

--- a/frontend/src/pages/FrontPlugin/components/HighlightSessions.tsx
+++ b/frontend/src/pages/FrontPlugin/components/HighlightSessions.tsx
@@ -7,7 +7,7 @@ import {
 } from '@context/AppLoadingContext'
 import { useGetSessionsQuery } from '@graph/hooks'
 import {
-	DEFAULT_TIME_PRESETS,
+	EXTENDED_TIME_PRESETS,
 	presetStartDate,
 } from '@highlight-run/ui/components'
 import SvgShareIcon from '@icons/ShareIcon'
@@ -110,8 +110,8 @@ export function HighlightSessions() {
 					startDate={startDate!}
 					endDate={endDate!}
 					onDatesChange={updateSearchTime!}
-					presets={DEFAULT_TIME_PRESETS}
-					minDate={presetStartDate(DEFAULT_TIME_PRESETS[5])}
+					presets={EXTENDED_TIME_PRESETS}
+					minDate={presetStartDate(EXTENDED_TIME_PRESETS[5])}
 					selectedPreset={selectedPreset}
 					productType={ProductType.Sessions}
 					timeMode="fixed-range"

--- a/frontend/src/pages/Player/PlayerPage.tsx
+++ b/frontend/src/pages/Player/PlayerPage.tsx
@@ -1,7 +1,7 @@
 import 'rc-slider/assets/index.css'
 
 import { useAuthContext } from '@authentication/AuthContext'
-import { Box, DEFAULT_TIME_PRESETS } from '@highlight-run/ui/components'
+import { Box, EXTENDED_TIME_PRESETS } from '@highlight-run/ui/components'
 import { usePlayerUIContext } from '@pages/Player/context/PlayerUIContext'
 import { usePlayer } from '@pages/Player/PlayerHook/PlayerHook'
 import { SessionViewability } from '@pages/Player/PlayerHook/PlayerState'
@@ -230,8 +230,8 @@ export const PlayerPage = () => {
 	const sessionFeedConfiguration = useSessionFeedConfiguration()
 
 	const searchTimeContext = useSearchTime({
-		presets: DEFAULT_TIME_PRESETS,
-		initialPreset: DEFAULT_TIME_PRESETS[5],
+		presets: EXTENDED_TIME_PRESETS,
+		initialPreset: EXTENDED_TIME_PRESETS[5],
 	})
 
 	const getSessionsData = useGetSessions({

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionsFeedV3.tsx
@@ -14,7 +14,7 @@ import { Maybe, ProductType, Session } from '@graph/schemas'
 import {
 	Box,
 	ButtonIcon,
-	DEFAULT_TIME_PRESETS,
+	EXTENDED_TIME_PRESETS,
 	IconSolidLogout,
 	presetStartDate,
 	Stack,
@@ -183,8 +183,8 @@ export const SessionFeedV3 = React.memo(() => {
 					startDate={startDate!}
 					endDate={endDate!}
 					onDatesChange={updateSearchTime!}
-					presets={DEFAULT_TIME_PRESETS}
-					minDate={presetStartDate(DEFAULT_TIME_PRESETS[5])}
+					presets={EXTENDED_TIME_PRESETS}
+					minDate={presetStartDate(EXTENDED_TIME_PRESETS[6])}
 					selectedPreset={selectedPreset}
 					productType={ProductType.Sessions}
 					timeMode="fixed-range"

--- a/packages/ui/src/components/DatePicker/DateRangePicker/index.tsx
+++ b/packages/ui/src/components/DatePicker/DateRangePicker/index.tsx
@@ -73,6 +73,12 @@ export const DEFAULT_TIME_PRESETS: DateRangePreset[] = [
 	},
 ]
 
+export const EXTENDED_TIME_PRESETS: DateRangePreset[] =
+	DEFAULT_TIME_PRESETS.concat({
+		unit: 'months',
+		quantity: 3,
+	})
+
 export const presetLabel = (preset: DateRangePreset) => {
 	return preset.label || `Last ${preset.quantity} ${preset.unit}`
 }


### PR DESCRIPTION
## Summary
Allow errors and sessions to search back to 3 months.

https://www.loom.com/share/b168e296ea014fb5866cb1f2cacc6505?sid=619f9f32-945b-425e-bf4b-9caa6bd68ead

## How did you test this change?
1. View the sessions page
2. Select the "Last 3 months" prefix
3. Select custom and select dates more than 30 days ago

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A