### PR TITLE
Metric polling

### DIFF
--- a/frontend/src/pages/Graphing/Dashboard.tsx
+++ b/frontend/src/pages/Graphing/Dashboard.tsx
@@ -369,6 +369,9 @@ export const Dashboard = () => {
 															projectId={
 																projectId
 															}
+															selectedPreset={
+																selectedPreset
+															}
 															startDate={
 																startDate
 															}

--- a/frontend/src/pages/Graphing/ExpandedGraph.tsx
+++ b/frontend/src/pages/Graphing/ExpandedGraph.tsx
@@ -160,6 +160,7 @@ export const ExpandedGraph = () => {
 								projectId={projectId}
 								startDate={startDate}
 								endDate={endDate}
+								selectedPreset={selectedPreset}
 								query={g.query}
 								metric={g.metric}
 								functionType={g.functionType}

--- a/frontend/src/pages/Graphing/GraphingEditor.tsx
+++ b/frontend/src/pages/Graphing/GraphingEditor.tsx
@@ -762,6 +762,7 @@ export const GraphingEditor = () => {
 										productType={productType}
 										projectId={projectId}
 										startDate={startDate}
+										selectedPreset={selectedPreset}
 										endDate={endDate}
 										query={debouncedQuery}
 										metric={metric}

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -681,7 +681,7 @@ const Graph = ({
 					>
 						{title || 'Untitled metric view'}
 					</Text>
-					{showMenu && graphHover && !disabled && !called && (
+					{showMenu && graphHover && !disabled && called && (
 						<Box
 							cssClass={clsx(style.titleText, {
 								[style.hiddenMenu]: !graphHover,

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -803,7 +803,7 @@ const Graph = ({
 					</Box>
 				)}
 			</Box>
-			{!called && (
+			{called && (
 				<Box
 					height="full"
 					maxHeight="screen"

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -376,9 +376,7 @@ const Graph = ({
 	const [fetchStart, setFetchStart] = useState<Date>()
 	const [fetchEnd, setFetchEnd] = useState<Date>()
 
-	const [getMetrics, { data: metrics, loading, called, previousData }] =
-		useGetMetricsLazyQuery()
-	const metricsLoading = !called || (!previousData && loading)
+	const [getMetrics, { data: metrics, called }] = useGetMetricsLazyQuery()
 
 	const rebaseFetchTime = useCallback(() => {
 		if (!selectedPreset) {
@@ -657,7 +655,7 @@ const Graph = ({
 				setGraphHover(false)
 			}}
 		>
-			{metricsLoading && (
+			{!called && (
 				<Box
 					position="absolute"
 					width="full"
@@ -683,7 +681,7 @@ const Graph = ({
 					>
 						{title || 'Untitled metric view'}
 					</Text>
-					{showMenu && graphHover && !disabled && !metricsLoading && (
+					{showMenu && graphHover && !disabled && !called && (
 						<Box
 							cssClass={clsx(style.titleText, {
 								[style.hiddenMenu]: !graphHover,
@@ -805,7 +803,7 @@ const Graph = ({
 					</Box>
 				)}
 			</Box>
-			{!metricsLoading && (
+			{!called && (
 				<Box
 					height="full"
 					maxHeight="screen"

--- a/frontend/src/pages/Graphing/components/Graph.tsx
+++ b/frontend/src/pages/Graphing/components/Graph.tsx
@@ -341,7 +341,8 @@ export const getViewConfig = (
 	return viewConfig
 }
 
-const POLL_INTERVAL_VALUE = 60000
+const POLL_INTERVAL_VALUE = 1000 * 60
+const LONGER_POLL_INTERVAL_VALUE = 1000 * 60 * 5
 
 const Graph = ({
 	productType,
@@ -386,8 +387,14 @@ const Graph = ({
 			return
 		}
 
-		setPollInterval(POLL_INTERVAL_VALUE)
-		setFetchStart(presetStartDate(selectedPreset))
+		const newStartFetch = presetStartDate(selectedPreset)
+		const newPollInterval =
+			moment().diff(newStartFetch, 'hours') > 5
+				? LONGER_POLL_INTERVAL_VALUE
+				: POLL_INTERVAL_VALUE
+
+		setPollInterval(newPollInterval)
+		setFetchStart(newStartFetch)
 		setFetchEnd(moment().toDate())
 	}, [selectedPreset, startDate, endDate])
 


### PR DESCRIPTION
## Summary
Add polling to the metrics page to refresh data every minute

https://www.loom.com/share/d520058cc11d4437929ab0acdf8c779c

## How did you test this change?
1. Load the metrics page with a preset time (i.e. "Last 15 minutes")
- [ ] Metrics are refreshed after ~1 minute (starts after successfully receiving metrics)
- [ ] Metrics are refreshed after another ~1 minute (starts after successfully receiving metrics)
2. Change the time to a fixed time range
- [ ] Metrics are not refreshed after a minute
3. Change time back to a preset time 
- [ ] Metrics are refreshed after ~1 minute (starts after successfully receiving metrics)
4. Expanded a graph
- [ ] Metrics are refreshed after ~1 minute (starts after successfully receiving metrics)
5. Edit a graph
- [ ] Metrics are refreshed after ~1 minute (starts after successfully receiving metrics)

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
