### PR TITLE
resolve stripe rate limiting

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/slack-go/slack v0.12.5
 	github.com/speps/go-hashids v2.0.0+incompatible
-	github.com/stripe/stripe-go/v76 v76.20.0
+	github.com/stripe/stripe-go/v78 v78.5.0
 	github.com/urfave/cli/v2 v2.27.1
 	github.com/vektah/gqlparser/v2 v2.5.11
 	go.opentelemetry.io/collector/pdata v1.3.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -568,8 +568,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stripe/stripe-go/v76 v76.20.0 h1:EKxpA+c3+snZlEqZsr6ZQHx684jOAOWkKXurcillVqA=
-github.com/stripe/stripe-go/v76 v76.20.0/go.mod h1:rw1MxjlAKKcZ+3FOXgTHgwiOa2ya6CPq6ykpJ0Q6Po4=
+github.com/stripe/stripe-go/v78 v78.5.0 h1:DH07mXBdyztTwiqEUwzsGAGj28Xz3XT4f4CrkjYI8sk=
+github.com/stripe/stripe-go/v78 v78.5.0/go.mod h1:GjncxVLUc1xoIOidFqVwq+y3pYiG7JLVWiVQxTsLrvQ=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
 github.com/tdewolff/parse v2.3.4+incompatible h1:x05/cnGwIMf4ceLuDMBOdQ1qGniMoxpP46ghf0Qzh38=

--- a/backend/main.go
+++ b/backend/main.go
@@ -38,7 +38,7 @@ import (
 	"github.com/rs/cors"
 	"github.com/sendgrid/sendgrid-go"
 	log "github.com/sirupsen/logrus"
-	"github.com/stripe/stripe-go/v76/client"
+	"github.com/stripe/stripe-go/v78/client"
 	"gorm.io/gorm"
 
 	dd "github.com/highlight-run/highlight/backend/datadog"

--- a/backend/migrations/cmd/add-stripe-prices/main.go
+++ b/backend/migrations/cmd/add-stripe-prices/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/stripe/stripe-go/v78"
 	"math"
 	"os"
 
@@ -10,8 +11,7 @@ import (
 	"github.com/openlyinc/pointy"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
-	"github.com/stripe/stripe-go/v76"
-	"github.com/stripe/stripe-go/v76/price"
+	"github.com/stripe/stripe-go/v78/price"
 )
 
 var (

--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -1007,7 +1007,7 @@ func (w *Worker) reportStripeUsage(ctx context.Context, workspaceID int) error {
 
 	// For non-monthly subscriptions, set PendingInvoiceItemInterval to 'month' if not set
 	// so that overage is reported via monthly invoice items.
-	if interval != model.PricingSubscriptionIntervalMonthly {
+	if interval != model.PricingSubscriptionIntervalMonthly && (subscription.PendingInvoiceItemInterval == nil || subscription.PendingInvoiceItemInterval.Interval != stripe.SubscriptionPendingInvoiceItemIntervalIntervalMonth) {
 		log.WithContext(ctx).WithField("workspaceID", workspaceID).Info("configuring monthly invoices for non-monthly subscription")
 		updated, err := w.stripeClient.Subscriptions.Update(subscription.ID, &stripe.SubscriptionParams{
 			PendingInvoiceItemInterval: &stripe.SubscriptionPendingInvoiceItemIntervalParams{

--- a/backend/pricing/pricing.go
+++ b/backend/pricing/pricing.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/marketplacemetering/types"
 	"github.com/aws/smithy-go/ptr"
 	"github.com/google/uuid"
-	"github.com/stripe/stripe-go/v76"
+	"github.com/stripe/stripe-go/v78"
 
 	"github.com/highlight-run/highlight/backend/redis"
 	"github.com/highlight-run/highlight/backend/store"
@@ -25,7 +25,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/sendgrid/sendgrid-go"
 	log "github.com/sirupsen/logrus"
-	"github.com/stripe/stripe-go/v76/client"
+	"github.com/stripe/stripe-go/v78/client"
 	"gorm.io/gorm"
 
 	"github.com/highlight-run/highlight/backend/clickhouse"

--- a/backend/private-graph/graph/middleware.go
+++ b/backend/private-graph/graph/middleware.go
@@ -13,7 +13,6 @@ import (
 
 	firebase "firebase.google.com/go"
 	"firebase.google.com/go/auth"
-	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 
@@ -217,7 +216,7 @@ func getSourcemapRequestToken(r *http.Request) string {
 func PrivateMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		span, ctx := util.StartSpanFromContext(ctx, "middleware.private", util.WithSpanKind(trace.SpanKindServer))
+		span, ctx := util.StartSpanFromContext(ctx, "middleware.private")
 		defer span.Finish()
 		var err error
 		if token := r.Header.Get("token"); token != "" {

--- a/backend/private-graph/graph/oauth.go
+++ b/backend/private-graph/graph/oauth.go
@@ -6,8 +6,10 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/highlight-run/highlight/backend/model"
 	"github.com/highlight-run/highlight/backend/store"
+	"github.com/highlight-run/highlight/backend/util"
 	e "github.com/pkg/errors"
 	"github.com/samber/lo"
+	"go.opentelemetry.io/otel/trace"
 )
 
 type OAuthValidator interface {
@@ -32,10 +34,14 @@ func (t Tracer) Validate(graphql.ExecutableSchema) error {
 }
 
 func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (interface{}, error) {
+	span, _ := util.StartSpanFromContext(ctx, "private.oauth.field", util.WithSpanKind(trace.SpanKindServer))
+	defer span.Finish()
+
 	clientID, _ := ctx.Value(model.ContextKeys.OAuthClientID).(string)
 	if clientID == "" {
 		return next(ctx)
 	}
+	span.SetAttribute("client_id", clientID)
 
 	if !graphql.HasOperationContext(ctx) {
 		return next(ctx)
@@ -52,6 +58,7 @@ func (t Tracer) InterceptField(ctx context.Context, next graphql.Resolver) (inte
 	}
 
 	fieldName := fc.Field.Name
+	span.SetAttribute("field_name", fieldName)
 	// TODO(vkorolik) rate limit based on opConfig
 	_, found := lo.Find(client.Operations, func(item *model.OAuthOperation) bool {
 		return item.AuthorizedGraphQLOperation == fieldName

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -1379,11 +1379,6 @@ func (r *Resolver) updateStripeBillingDetails(ctx context.Context, stripeCustome
 	return nil
 }
 
-type SubscriptionDetails struct {
-	details *modelInputs.SubscriptionDetails
-	invoice *stripe.Invoice
-}
-
 type planDetails struct {
 	tier               modelInputs.PlanType
 	unlimitedMembers   bool

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -1738,8 +1738,8 @@ func (r *Resolver) StripeWebhook(ctx context.Context, endpointSecret string) fun
 			return
 		}
 
-		event, err := webhook.ConstructEvent(payload, req.Header.Get("Stripe-Signature"),
-			endpointSecret)
+		event, err := webhook.ConstructEventWithOptions(payload, req.Header.Get("Stripe-Signature"),
+			endpointSecret, webhook.ConstructEventOptions{IgnoreAPIVersionMismatch: true})
 		if err != nil {
 			log.WithContext(ctx).Error(e.Wrap(err, "error verifying webhook signature"))
 			w.WriteHeader(http.StatusBadRequest)

--- a/backend/private-graph/graph/resolver.go
+++ b/backend/private-graph/graph/resolver.go
@@ -64,9 +64,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
-	"github.com/stripe/stripe-go/v76"
-	"github.com/stripe/stripe-go/v76/client"
-	"github.com/stripe/stripe-go/v76/webhook"
+	"github.com/stripe/stripe-go/v78"
+	"github.com/stripe/stripe-go/v78/client"
+	"github.com/stripe/stripe-go/v78/webhook"
 
 	"github.com/highlight-run/workerpool"
 

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -58,7 +58,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/sashabaranov/go-openai"
 	log "github.com/sirupsen/logrus"
-	stripe "github.com/stripe/stripe-go/v76"
+	stripe "github.com/stripe/stripe-go/v78"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"golang.org/x/sync/errgroup"

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -8176,76 +8176,81 @@ func (r *queryResolver) CustomerPortalURL(ctx context.Context, workspaceID int) 
 
 // SubscriptionDetails is the resolver for the subscription_details field.
 func (r *queryResolver) SubscriptionDetails(ctx context.Context, workspaceID int) (*modelInputs.SubscriptionDetails, error) {
-	workspace, err := r.isAdminInWorkspace(ctx, workspaceID)
-	if err != nil {
-		return nil, nil
-	}
-	if workspace.StripeCustomerID == nil {
-		return nil, e.New("workspace has no stripe customer ID")
-	}
+	span, _ := util.StartSpanFromContext(ctx, "SubscriptionDetails", util.Tag("workspaceID", workspaceID))
+	defer span.Finish()
 
-	if err := r.validateAdminRole(ctx, workspaceID); err != nil {
-		return nil, err
-	}
-
-	customerParams := &stripe.CustomerParams{}
-	customerParams.AddExpand("subscriptions")
-	c, err := r.StripeClient.Customers.Get(*workspace.StripeCustomerID, customerParams)
-	if err != nil {
-		return nil, e.Wrap(err, "error querying stripe customer")
-	}
-
-	if len(c.Subscriptions.Data) == 0 {
-		return &modelInputs.SubscriptionDetails{}, nil
-	}
-
-	amount := c.Subscriptions.Data[0].Items.Data[0].Price.UnitAmount
-	details := &modelInputs.SubscriptionDetails{BaseAmount: amount}
-
-	discount := c.Subscriptions.Data[0].Discount
-	if discount != nil && discount.Coupon != nil {
-		details.Discount = &modelInputs.SubscriptionDiscount{
-			Name:    discount.Coupon.Name,
-			Percent: discount.Coupon.PercentOff,
-			Amount:  discount.Coupon.AmountOff,
-		}
-		if discount.Coupon.Duration != stripe.CouponDurationForever {
-			t := time.Unix(discount.Start, 0).AddDate(0, int(discount.Coupon.DurationInMonths), 0)
-			details.Discount.Until = &t
-		}
-	}
-
-	invoiceID := c.Subscriptions.Data[0].LatestInvoice.ID
-	invoiceParams := &stripe.InvoiceParams{}
-	customerParams.AddExpand("invoice_items")
-	invoice, err := r.StripeClient.Invoices.Get(invoiceID, invoiceParams)
-	if err != nil {
-		return nil, e.Wrap(err, "error querying stripe invoice")
-	}
-
-	if invoice != nil {
-		invoiceDue := time.Unix(invoice.Created, 0)
-		status := string(invoice.Status)
-		details.LastInvoice = &modelInputs.Invoice{
-			Date:         &invoiceDue,
-			AmountDue:    &invoice.AmountDue,
-			AmountPaid:   &invoice.AmountPaid,
-			AttemptCount: &invoice.AttemptCount,
-			Status:       &status,
-			URL:          &invoice.HostedInvoiceURL,
-		}
-		warningSent, err := r.Redis.GetCustomerBillingWarning(ctx, ptr.ToString(workspace.StripeCustomerID))
+	return redis.CachedEval(ctx, r.Redis, fmt.Sprintf(`workspace-subscription-details-%d`, workspaceID), time.Minute, time.Minute, func() (*modelInputs.SubscriptionDetails, error) {
+		workspace, err := r.isAdminInWorkspace(ctx, workspaceID)
 		if err != nil {
+			return nil, nil
+		}
+		if workspace.StripeCustomerID == nil {
+			return nil, e.New("workspace has no stripe customer ID")
+		}
+
+		if err := r.validateAdminRole(ctx, workspaceID); err != nil {
 			return nil, err
 		}
-		details.BillingIssue = !warningSent.IsZero()
-	}
 
-	if details.BillingIngestBlocked, err = r.Redis.GetCustomerBillingInvalid(ctx, ptr.ToString(workspace.StripeCustomerID)); err != nil {
-		return nil, err
-	}
+		customerParams := &stripe.CustomerParams{}
+		customerParams.AddExpand("subscriptions")
+		c, err := r.StripeClient.Customers.Get(*workspace.StripeCustomerID, customerParams)
+		if err != nil {
+			return nil, e.Wrap(err, "error querying stripe customer")
+		}
 
-	return details, nil
+		if len(c.Subscriptions.Data) == 0 {
+			return &modelInputs.SubscriptionDetails{}, nil
+		}
+
+		amount := c.Subscriptions.Data[0].Items.Data[0].Price.UnitAmount
+		details := &modelInputs.SubscriptionDetails{BaseAmount: amount}
+
+		discount := c.Subscriptions.Data[0].Discount
+		if discount != nil && discount.Coupon != nil {
+			details.Discount = &modelInputs.SubscriptionDiscount{
+				Name:    discount.Coupon.Name,
+				Percent: discount.Coupon.PercentOff,
+				Amount:  discount.Coupon.AmountOff,
+			}
+			if discount.Coupon.Duration != stripe.CouponDurationForever {
+				t := time.Unix(discount.Start, 0).AddDate(0, int(discount.Coupon.DurationInMonths), 0)
+				details.Discount.Until = &t
+			}
+		}
+
+		invoiceID := c.Subscriptions.Data[0].LatestInvoice.ID
+		invoiceParams := &stripe.InvoiceParams{}
+		customerParams.AddExpand("invoice_items")
+		invoice, err := r.StripeClient.Invoices.Get(invoiceID, invoiceParams)
+		if err != nil {
+			return nil, e.Wrap(err, "error querying stripe invoice")
+		}
+
+		if invoice != nil {
+			invoiceDue := time.Unix(invoice.Created, 0)
+			status := string(invoice.Status)
+			details.LastInvoice = &modelInputs.Invoice{
+				Date:         &invoiceDue,
+				AmountDue:    &invoice.AmountDue,
+				AmountPaid:   &invoice.AmountPaid,
+				AttemptCount: &invoice.AttemptCount,
+				Status:       &status,
+				URL:          &invoice.HostedInvoiceURL,
+			}
+			warningSent, err := r.Redis.GetCustomerBillingWarning(ctx, ptr.ToString(workspace.StripeCustomerID))
+			if err != nil {
+				return nil, err
+			}
+			details.BillingIssue = !warningSent.IsZero()
+		}
+
+		if details.BillingIngestBlocked, err = r.Redis.GetCustomerBillingInvalid(ctx, ptr.ToString(workspace.StripeCustomerID)); err != nil {
+			return nil, err
+		}
+
+		return details, nil
+	})
 }
 
 // DashboardDefinitions is the resolver for the dashboard_definitions field.

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -8200,7 +8200,7 @@ func (r *queryResolver) SubscriptionDetails(ctx context.Context, workspaceID int
 		}
 
 		if len(c.Subscriptions.Data) == 0 {
-			return &SubscriptionDetails{&modelInputs.SubscriptionDetails{}, nil}, nil
+			return nil, nil
 		}
 
 		amount := c.Subscriptions.Data[0].Items.Data[0].Price.UnitAmount
@@ -8231,6 +8231,9 @@ func (r *queryResolver) SubscriptionDetails(ctx context.Context, workspaceID int
 	})
 	if err != nil {
 		return nil, err
+	}
+	if result == nil {
+		result = &SubscriptionDetails{&modelInputs.SubscriptionDetails{}, nil}
 	}
 
 	if result.invoice != nil {

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -8191,19 +8191,7 @@ func (r *queryResolver) SubscriptionDetails(ctx context.Context, workspaceID int
 		return nil, err
 	}
 
-	return redis.CachedEval(ctx, r.Redis, redis.GetSubscriptionDetailsKey(workspaceID), time.Minute, time.Hour, func() (*modelInputs.SubscriptionDetails, error) {
-		workspace, err := r.isAdminInWorkspace(ctx, workspaceID)
-		if err != nil {
-			return nil, nil
-		}
-		if workspace.StripeCustomerID == nil {
-			return nil, e.New("workspace has no stripe customer ID")
-		}
-
-		if err := r.validateAdminRole(ctx, workspaceID); err != nil {
-			return nil, err
-		}
-
+	return redis.CachedEval(ctx, r.Redis, redis.GetSubscriptionDetailsKey(workspaceID), time.Minute, time.Minute, func() (*modelInputs.SubscriptionDetails, error) {
 		customerParams := &stripe.CustomerParams{}
 		customerParams.AddExpand("subscriptions")
 		c, err := r.StripeClient.Customers.Get(*workspace.StripeCustomerID, customerParams)

--- a/backend/private-graph/graph/schema.resolvers.go
+++ b/backend/private-graph/graph/schema.resolvers.go
@@ -8191,7 +8191,7 @@ func (r *queryResolver) SubscriptionDetails(ctx context.Context, workspaceID int
 		return nil, err
 	}
 
-	return redis.CachedEval(ctx, r.Redis, redis.GetSubscriptionDetailsKey(workspaceID), time.Minute, time.Minute, func() (*modelInputs.SubscriptionDetails, error) {
+	return redis.CachedEval(ctx, r.Redis, redis.GetSubscriptionDetailsKey(workspaceID), time.Minute, time.Hour, func() (*modelInputs.SubscriptionDetails, error) {
 		workspace, err := r.isAdminInWorkspace(ctx, workspaceID)
 		if err != nil {
 			return nil, nil

--- a/backend/redis/utils.go
+++ b/backend/redis/utils.go
@@ -187,6 +187,10 @@ func GetKey(sessionId int, payloadType model.RawPayloadType) string {
 	}
 }
 
+func GetSubscriptionDetailsKey(workspaceID int) string {
+	return fmt.Sprintf(`workspace-subscription-details-%d`, workspaceID)
+}
+
 func (r *Client) GetSessionData(ctx context.Context, sessionId int, payloadType model.RawPayloadType, objects map[int]string) ([]string, error) {
 	key := GetKey(sessionId, payloadType)
 


### PR DESCRIPTION
## Summary

* upgrades stripe API to latest version, supporting cross-api-version webhooks to ensure we do not miss events that recently failed that are retrying on the old api version
* adds caching to stripe API call used by the frontend `Header` component that is causing us to be rate limited
* fixes private graph span sampling to make sure we don't record all private graph traces

## How did you test this change?

manual deploy to prod
<img width="448" alt="Screenshot 2024-05-08 at 18 48 29" src="https://github.com/highlight/highlight/assets/1351531/9baebf89-aa95-4ddd-9952-e2974f5135c1">


## Are there any deployment considerations?

no

## Does this work require review from our design team?

no