### PR TITLE
fix trace events and links

### DIFF
--- a/backend/clickhouse/trace_row.go
+++ b/backend/clickhouse/trace_row.go
@@ -169,6 +169,10 @@ func (t *TraceRow) WithLinks(links []map[string]any) *TraceRow {
 	return t
 }
 
+func (t *TraceRow) AsClickhouseTraceRow() *ClickhouseTraceRow {
+	return ConvertTraceRow(t)
+}
+
 func attributesToMap(attributes map[string]any) map[string]string {
 	newAttrMap := make(map[string]string)
 	for k, v := range attributes {

--- a/backend/clickhouse/traces_test.go
+++ b/backend/clickhouse/traces_test.go
@@ -2,9 +2,10 @@ package clickhouse
 
 import (
 	"context"
-	"github.com/highlight-run/highlight/backend/parser"
 	"testing"
 	"time"
+
+	"github.com/highlight-run/highlight/backend/parser"
 
 	modelInputs "github.com/highlight-run/highlight/backend/private-graph/graph/model"
 
@@ -18,8 +19,8 @@ func TestBatchWriteTraceRows(t *testing.T) {
 
 	now := time.Now()
 
-	rows := []*TraceRow{
-		NewTraceRow(now, 1).WithServiceName("gqlgen"),
+	rows := []*ClickhouseTraceRow{
+		NewTraceRow(now, 1).WithServiceName("gqlgen").AsClickhouseTraceRow(),
 	}
 
 	assert.NoError(t, client.BatchWriteTraceRows(ctx, rows))
@@ -159,10 +160,10 @@ func TestReadTracesWithEnvironmentFilter(t *testing.T) {
 	defer teardown(t)
 
 	now := time.Now()
-	rows := []*TraceRow{
-		NewTraceRow(now, 1),
-		NewTraceRow(now, 1).WithEnvironment("production"),
-		NewTraceRow(now, 1).WithEnvironment("development"),
+	rows := []*ClickhouseTraceRow{
+		NewTraceRow(now, 1).AsClickhouseTraceRow(),
+		NewTraceRow(now, 1).WithEnvironment("production").AsClickhouseTraceRow(),
+		NewTraceRow(now, 1).WithEnvironment("development").AsClickhouseTraceRow(),
 	}
 
 	assert.NoError(t, client.BatchWriteTraceRows(ctx, rows))

--- a/backend/kafka-queue/types.go
+++ b/backend/kafka-queue/types.go
@@ -233,7 +233,7 @@ type TraceRowMessage struct {
 	Failures     int
 	MaxRetries   int
 	KafkaMessage *kafka.Message `json:",omitempty"`
-	*clickhouse.TraceRow
+	*clickhouse.ClickhouseTraceRow
 }
 
 func (m *TraceRowMessage) GetType() PayloadType {

--- a/backend/otel/otel.go
+++ b/backend/otel/otel.go
@@ -665,8 +665,8 @@ func (o *Handler) submitTraceSpans(ctx context.Context, traceRows map[string][]*
 				continue
 			}
 			messages = append(messages, &kafkaqueue.TraceRowMessage{
-				Type:     kafkaqueue.PushTracesFlattened,
-				TraceRow: traceRow,
+				Type:               kafkaqueue.PushTracesFlattened,
+				ClickhouseTraceRow: clickhouse.ConvertTraceRow(traceRow),
 			})
 		}
 

--- a/backend/public-graph/graph/resolver.go
+++ b/backend/public-graph/graph/resolver.go
@@ -2047,8 +2047,8 @@ func (r *Resolver) PushMetricsImpl(ctx context.Context, projectVerboseID *string
 			continue
 		}
 		messages = append(messages, &kafka_queue.TraceRowMessage{
-			Type:     kafka_queue.PushTracesFlattened,
-			TraceRow: traceRow,
+			Type:               kafka_queue.PushTracesFlattened,
+			ClickhouseTraceRow: clickhouse.ConvertTraceRow(traceRow),
 		})
 	}
 	return r.TracesQueue.Submit(ctx, "", messages...)

--- a/backend/worker/worker_test.go
+++ b/backend/worker/worker_test.go
@@ -2,6 +2,11 @@ package worker
 
 import (
 	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/go-test/deep"
 	"github.com/highlight-run/highlight/backend/clickhouse"
 	parse "github.com/highlight-run/highlight/backend/event-parse"
@@ -17,10 +22,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
-	"io"
-	"os"
-	"testing"
-	"time"
 )
 
 var DB *gorm.DB
@@ -966,8 +967,8 @@ func TestCalculateOverages(t *testing.T) {
 			}
 
 			for idx := 0; idx < 13; idx++ {
-				var traces []*clickhouse.TraceRow
-				traces = append(traces, clickhouse.NewTraceRow(time.Now(), p.ID))
+				var traces []*clickhouse.ClickhouseTraceRow
+				traces = append(traces, clickhouse.NewTraceRow(time.Now(), p.ID).AsClickhouseTraceRow())
 				if err := chClient.BatchWriteTraceRows(ctx, traces); err != nil {
 					t.Error(e.Wrap(err, "error inserting traces"))
 					return


### PR DESCRIPTION
## Summary
- convert to `ClickhouseTraceRow` before writing to kafka in order to match the Clickhouse schema (flattened Events and Links columns). the link and event columns were being sent to Clickhouse but ignored because they didn't match the schema
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- ran locally to make sure traces were being saved correctly w/ events
- will monitor in prod after deploying
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
