### PR TITLE
Fix search popover focus

### DIFF
--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -493,27 +493,30 @@ export const Search: React.FC<{
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [query])
 
-	const { items, open } = comboboxStore.getState()
+	const comboboxItems = comboboxStore.useState('items')
+	const comboboxOpen = comboboxStore.useState('open')
 
 	useEffect(() => {
-		if (!open) {
+		if (!comboboxOpen) {
 			return
 		}
 
 		const { activeId } = comboboxStore.getState()
-		const activeElement = activeId && items.find((i) => i.id === activeId)
+		const activeElement =
+			activeId && comboboxItems.find((i) => i.id === activeId)
 		if (activeElement) {
 			return
 		}
 
 		// Give preference to the first item with a value
-		const firstItem = items.find((i) => !!i.value) ?? items[0]
+		const firstItem =
+			comboboxItems.find((i) => !!i.value) ?? comboboxItems[0]
 		if (firstItem) {
 			comboboxStore.setActiveId(firstItem.id)
 			comboboxStore.setState('moves', 0)
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [items, open, query])
+	}, [comboboxItems, comboboxOpen, query])
 
 	useEffect(() => {
 		if (!showValues) {

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -329,7 +329,7 @@ export const Search: React.FC<{
 	const [getKeys, { loading: keysLoading }] = useGetKeysLazyQuery()
 	const [getKeyValues, { loading: valuesLoading }] =
 		useGetKeyValuesLazyQuery()
-	const [cursorIndex, setCursorIndex] = useState(0)
+	const [cursorIndex, setCursorIndex] = useState(query.length)
 	const [isPending, startTransition] = React.useTransition()
 
 	const activePart = getActivePart(cursorIndex, queryParts)
@@ -501,7 +501,7 @@ export const Search: React.FC<{
 		}
 
 		const { activeId } = comboboxStore.getState()
-		const activeElement = activeId && !items.find((i) => i.id === activeId)
+		const activeElement = activeId && items.find((i) => i.id === activeId)
 		if (activeElement) {
 			return
 		}

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -350,7 +350,6 @@ export const Search: React.FC<{
 	let visibleItems: SearchResult[] = showValues
 		? getVisibleValues(activePart, values)
 		: getVisibleKeys(query, activePart, keys)
-	const comboboxItems = comboboxStore.useState('items')
 
 	// Show operators when we have an exact match for a key
 	const keyMatch = visibleItems.find((item) => item.name === activePart.text)
@@ -494,21 +493,21 @@ export const Search: React.FC<{
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [query])
 
-	useEffect(() => {
-		// Logic for selecting a default item from the results. We don't want to
-		// select a value by default, but if there is a query, an item isn't
-		// currently selected, and there are items, select the first item.
-		const { activeId, items } = comboboxStore.getState()
-		// Give preference to the "Show all results for..." item if it exists.
-		const firstItem = items.find((i) => i.value === undefined) ?? items[0]
-		const noActiveId = !activeId || !items.find((i) => i.id === activeId)
+	const { items, open } = comboboxStore.getState()
 
-		if (activePart.text.trim() !== '' && noActiveId && firstItem) {
+	useEffect(() => {
+		if (!open) {
+			return
+		}
+
+		// Give preference to the first item with a value
+		const firstItem = items.find((i) => !!i.value) ?? items[0]
+		if (firstItem) {
 			comboboxStore.setActiveId(firstItem.id)
 			comboboxStore.setState('moves', 0)
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [comboboxItems, query])
+	}, [items, open, query])
 
 	useEffect(() => {
 		if (!showValues) {

--- a/frontend/src/components/Search/SearchForm/SearchForm.tsx
+++ b/frontend/src/components/Search/SearchForm/SearchForm.tsx
@@ -500,6 +500,12 @@ export const Search: React.FC<{
 			return
 		}
 
+		const { activeId } = comboboxStore.getState()
+		const activeElement = activeId && !items.find((i) => i.id === activeId)
+		if (activeElement) {
+			return
+		}
+
 		// Give preference to the first item with a value
 		const firstItem = items.find((i) => !!i.value) ?? items[0]
 		if (firstItem) {

--- a/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/index.tsx
+++ b/frontend/src/pages/Sessions/SessionsFeedV3/SessionFeedConfigDropdown/index.tsx
@@ -21,7 +21,7 @@ import { POLICY_NAMES } from '@util/authorization/authorizationPolicies'
 import { useGenerateSessionsReportCSV } from '@util/session/report'
 import { message } from 'antd'
 import { H } from 'highlight.run'
-import React, { useRef, useState } from 'react'
+import React, { useState } from 'react'
 
 import { useSearchContext } from '@/components/Search/SearchContext'
 import {
@@ -109,9 +109,6 @@ export const SessionFeedConfigDropdown = function () {
 		usePlayerConfiguration()
 	const sessionFeedConfiguration = useSessionFeedConfiguration()
 
-	const menuRef = useRef<HTMLDivElement>(null)
-	const buttonRef = useRef<HTMLButtonElement>(null)
-
 	return (
 		<Menu>
 			<Menu.Button
@@ -119,13 +116,8 @@ export const SessionFeedConfigDropdown = function () {
 				size="small"
 				emphasis="low"
 				iconRight={<IconSolidAdjustments size={14} />}
-				ref={buttonRef}
 			/>
-			<Menu.List
-				ref={menuRef}
-				style={{ minWidth: 264 }}
-				cssClass={styles.menuContents}
-			>
+			<Menu.List style={{ minWidth: 264 }} cssClass={styles.menuContents}>
 				<Section>
 					<Menu.Item
 						key="autoplay"


### PR DESCRIPTION
## Summary
Update the search popover to focus on the first item with a value (i.e. not "Show all results for [value]")

https://www.loom.com/share/f196d9a5d3e947f9b610170ed16886b2

## How did you test this change?
1) Navigate to one of the product pages
2) Click into the query
- [ ] First key is pre-selected
3) Start typing
- [ ] First key is pre-selected (not "Show all results for [key]")
4) Select a value
- [ ] First operator is pre-selected (not "Show all results for [key]")
5) Select an operator
- [ ] First value is pre-selected
6) Start typing
- [ ] First value is pre-selected (not "Show all results for [value]")

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
