### PR TITLE
Fix # in search params

### DIFF
--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -380,7 +380,7 @@ const User: React.FC<{
 	const searchQuery = useMemo(() => {
 		if (!displayName) return ''
 
-		const userParam = validateEmail(displayName) ? 'email' : 'identifier'
+		const userParam = validateEmail(displayName) ? 'email' : 'device_id'
 		return encodeURIComponent(`${userParam}=${displayName}`)
 	}, [displayName])
 

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -29,7 +29,6 @@ import ErrorStackTrace from '@pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace'
 import { GitHubEnhancementSettings } from '@pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettings'
 import {
 	getDisplayName,
-	getDisplayNameAndField,
 	getIdentifiedUserProfileImage,
 	getUserProperties,
 } from '@pages/Sessions/SessionsFeedV3/MinimalSessionCard/utils/utils'
@@ -376,15 +375,16 @@ const User: React.FC<{
 	const { projectId } = useProjectId()
 	const { isLoggedIn } = useAuthContext()
 	const [truncated, setTruncated] = useState(true)
+	const displayName = getDisplayName(errorObject?.session)
+
+	console.log('window.location.search', window.location.search)
 
 	const searchQuery = useMemo(() => {
-		if (!errorObject?.session) return
+		if (!displayName) return ''
 
-		const displayName = getDisplayName(errorObject?.session)
 		const userParam = validateEmail(displayName) ? 'email' : 'identifier'
-
-		return `query=${userParam}=${displayName}`
-	}, [errorObject?.session])
+		return encodeURIComponent(`${userParam}=${displayName}`)
+	}, [displayName])
 
 	const userDetailsBox = (
 		<Box pb="12">
@@ -406,7 +406,6 @@ const User: React.FC<{
 	const userProperties = getUserProperties(
 		errorObject?.session?.user_properties,
 	)
-	const [displayName, field] = getDisplayNameAndField(errorObject?.session)
 	const avatarImage = getIdentifiedUserProfileImage(errorObject?.session)
 	const userDisplayPropertyKeys = Object.keys(userProperties)
 		.filter((k) => k !== 'avatar')
@@ -460,21 +459,9 @@ const User: React.FC<{
 									return
 								}
 
-								const searchParams: any = {}
-								if (
-									errorObject?.session?.identifier &&
-									field !== null
-								) {
-									searchParams[`user_${field}`] = displayName
-								} else if (errorObject?.session?.fingerprint) {
-									searchParams.device_id = String(
-										errorObject?.session.fingerprint,
-									)
-								}
-
 								navigate({
 									pathname: `/${projectId}/sessions`,
-									search: searchQuery,
+									search: `query=${searchQuery}`,
 								})
 							}}
 							trackingId="error_all-sessions-for-user_click"

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -377,8 +377,6 @@ const User: React.FC<{
 	const [truncated, setTruncated] = useState(true)
 	const displayName = getDisplayName(errorObject?.session)
 
-	console.log('window.location.search', window.location.search)
-
 	const searchQuery = useMemo(() => {
 		if (!displayName) return ''
 

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -379,11 +379,9 @@ const User: React.FC<{
 
 	const searchQuery = useMemo(() => {
 		if (errorObject?.session?.identifier && field !== null) {
-			return encodeURIComponent(`${field}=${displayName}`)
+			return `${field}=${displayName}`
 		} else if (errorObject?.session?.fingerprint) {
-			return encodeURIComponent(
-				`device_id=${errorObject?.session.fingerprint}`,
-			)
+			return `device_id=${errorObject?.session.fingerprint}`
 		}
 
 		return ''

--- a/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
+++ b/frontend/src/pages/ErrorsV2/ErrorInstance/ErrorInstance.tsx
@@ -28,14 +28,14 @@ import { useProjectId } from '@hooks/useProjectId'
 import ErrorStackTrace from '@pages/ErrorsV2/ErrorStackTrace/ErrorStackTrace'
 import { GitHubEnhancementSettings } from '@pages/ErrorsV2/GitHubEnhancementSettings/GitHubEnhancementSettings'
 import {
-	getDisplayName,
+	getDisplayNameAndField,
 	getIdentifiedUserProfileImage,
 	getUserProperties,
 } from '@pages/Sessions/SessionsFeedV3/MinimalSessionCard/utils/utils'
 import analytics from '@util/analytics'
 import { loadSession } from '@util/preload'
 import { useParams } from '@util/react-router/useParams'
-import { copyToClipboard, validateEmail } from '@util/string'
+import { copyToClipboard } from '@util/string'
 import moment from 'moment'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -375,14 +375,24 @@ const User: React.FC<{
 	const { projectId } = useProjectId()
 	const { isLoggedIn } = useAuthContext()
 	const [truncated, setTruncated] = useState(true)
-	const displayName = getDisplayName(errorObject?.session)
+	const [displayName, field] = getDisplayNameAndField(errorObject?.session)
 
 	const searchQuery = useMemo(() => {
-		if (!displayName) return ''
+		if (errorObject?.session?.identifier && field !== null) {
+			return encodeURIComponent(`${field}=${displayName}`)
+		} else if (errorObject?.session?.fingerprint) {
+			return encodeURIComponent(
+				`device_id=${errorObject?.session.fingerprint}`,
+			)
+		}
 
-		const userParam = validateEmail(displayName) ? 'email' : 'device_id'
-		return encodeURIComponent(`${userParam}=${displayName}`)
-	}, [displayName])
+		return ''
+	}, [
+		displayName,
+		errorObject?.session?.fingerprint,
+		errorObject?.session?.identifier,
+		field,
+	])
 
 	const userDetailsBox = (
 		<Box pb="12">


### PR DESCRIPTION
## Summary
Fixes https://app.highlight.io/1/errors/FqTuzfLnrx1D23fyJzawqLIFE0iE

Where button was erroring because their was a `#` in the search query
e.g. `query=identifier=#123456789`

Video: TBD

## How did you test this change?
1) Load an error with a session
2) Click on "All sessions for this user" button
- [ ] Correctly links to session search

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
