### PR TITLE
Remove duplicate sessions in sessions_joined_vw

### DIFF
--- a/backend/clickhouse/migrations/000100_recreate_sessions_joined_vw.down.sql
+++ b/backend/clickhouse/migrations/000100_recreate_sessions_joined_vw.down.sql
@@ -1,0 +1,13 @@
+DROP VIEW IF EXISTS sessions_joined_vw;
+CREATE VIEW IF NOT EXISTS sessions_joined_vw AS
+select ProjectID as ProjectId,
+    CreatedAt as Timestamp,
+    mapFromArrays(
+        arrayMap(x->splitByChar('_', x, 2) [2], FieldKeys),
+        arrayMap(
+            (k, kv)->substring(kv, length(k) + 2),
+            arrayZip(FieldKeys, FieldKeyValues)
+        )
+    ) as SessionAttributes,
+    *
+from sessions SETTINGS splitby_max_substrings_includes_remaining_string = 1;

--- a/backend/clickhouse/migrations/000100_recreate_sessions_joined_vw.up.sql
+++ b/backend/clickhouse/migrations/000100_recreate_sessions_joined_vw.up.sql
@@ -1,0 +1,13 @@
+DROP VIEW IF EXISTS sessions_joined_vw;
+CREATE VIEW IF NOT EXISTS sessions_joined_vw AS
+select ProjectID as ProjectId,
+    CreatedAt as Timestamp,
+    mapFromArrays(
+        arrayMap(x->splitByChar('_', x, 2) [2], FieldKeys),
+        arrayMap(
+            (k, kv)->substring(kv, length(k) + 2),
+            arrayZip(FieldKeys, FieldKeyValues)
+        )
+    ) as SessionAttributes,
+    *
+from sessions FINAL SETTINGS splitby_max_substrings_includes_remaining_string = 1;


### PR DESCRIPTION
## Summary
The `sessions_joined_vw` has duplicates because it is not using the `FINAL` keyword when creating the view. Recreate the view with the `FINAL` keyword 

## How did you test this change?
1) Load the sessions search
- [ ] Search works with filters
- [ ] 10 sessions per page when appropriate
- [ ] Results match filters

## Are there any deployment considerations?
N/A

## Does this work require review from our design team?
N/A
