### PR TITLE
[SUP-9] fix vercel workflow for unauthed users

### DIFF
--- a/frontend/src/pages/IntegrationAuthCallback/IntegrationAuthCallbackPage.tsx
+++ b/frontend/src/pages/IntegrationAuthCallback/IntegrationAuthCallbackPage.tsx
@@ -235,7 +235,7 @@ const VercelIntegrationCallback = ({ code }: Props) => {
 	}
 
 	// If there are no projects, redirect to create one
-	if (data?.projects?.length === 0) {
+	if ((data?.projects?.length ?? 0) === 0) {
 		const callbackPath = `/callback/vercel${search}`
 
 		if (!isLoggedIn) {
@@ -636,6 +636,10 @@ const IntegrationAuthCallbackPage = () => {
 	})
 	const currentWorkspaceId = workspacesData?.workspaces?.at(0)?.id ?? ''
 
+	if (name === 'vercel') {
+		return <VercelIntegrationCallback code={code} />
+	}
+
 	log('IntegrationAuthCallback.tsx', { workspaceId, currentWorkspaceId })
 	if (!workspaceId && !currentWorkspaceId) {
 		return null
@@ -740,8 +744,6 @@ const IntegrationAuthCallbackPage = () => {
 			return (
 				<FrontIntegrationCallback code={code} projectId={projectId} />
 			)
-		case 'vercel':
-			return <VercelIntegrationCallback code={code} />
 		case 'discord':
 			return (
 				<DiscordIntegrationCallback


### PR DESCRIPTION
## Summary
- users who need to log in / sign up to highlight see a blank screen while going through the Vercel integration installation starting in Vercel
- fix this by going through the auth workflow, then redirecting back to the callback
<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

## How did you test this change?
- tested these cases in preview:
  - already signed in - shown vercel settings in modal
  - not signed in, account created - sign in, then redirected to vercel settings
  - not signed in, no account - sign up, go through onboarding, then redirected to vercel settings
<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->

## Are there any deployment considerations?
- no
<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?
- no
<!--
 Request review from julian-highlight / our design team 
-->
