### PR TITLE
Fix duplicate network requests

### DIFF
--- a/.changeset/khaki-dolls-peel.md
+++ b/.changeset/khaki-dolls-peel.md
@@ -1,0 +1,5 @@
+---
+'highlight.run': minor
+---
+
+Fix duplicate network requests when performance.clearResourceTimings has been monkeypatched by external libraries

--- a/.changeset/khaki-dolls-peel.md
+++ b/.changeset/khaki-dolls-peel.md
@@ -1,5 +1,5 @@
 ---
-'highlight.run': minor
+'highlight.run': patch
 ---
 
 Fix duplicate network requests when performance.clearResourceTimings has been monkeypatched by external libraries

--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -291,7 +291,7 @@ export class FirstLoadListeners {
 
 			httpResources = httpResources
 				.filter((r) => {
-					if (r.startTime < sThis.lastNetworkRequestTimestamp) {
+					if (r.responseEnd < sThis.lastNetworkRequestTimestamp) {
 						return false
 					}
 
@@ -311,7 +311,7 @@ export class FirstLoadListeners {
 				})
 
 			sThis.lastNetworkRequestTimestamp =
-				httpResources.at(-1)?.startTime ||
+				httpResources.at(-1)?.responseEnd ||
 				sThis.lastNetworkRequestTimestamp
 
 			if (sThis.enableRecordingNetworkContents) {

--- a/sdk/client/src/listeners/first-load-listeners.tsx
+++ b/sdk/client/src/listeners/first-load-listeners.tsx
@@ -46,7 +46,7 @@ export class FirstLoadListeners {
 	networkBodyKeysToRedact: string[] | undefined
 	networkBodyKeysToRecord: string[] | undefined
 	networkHeaderKeysToRecord: string[] | undefined
-	lastNetworkRequestResponsePairTimestamp?: number
+	lastNetworkRequestTimestamp: number
 	urlBlocklist!: string[]
 	requestResponseSanitizer?: (
 		pair: RequestResponsePair,
@@ -63,6 +63,7 @@ export class FirstLoadListeners {
 		this.listeners = []
 		this.errors = []
 		this.messages = []
+		this.lastNetworkRequestTimestamp = 0
 	}
 
 	isListening() {
@@ -290,11 +291,7 @@ export class FirstLoadListeners {
 
 			httpResources = httpResources
 				.filter((r) => {
-					if (
-						sThis.lastNetworkRequestResponsePairTimestamp &&
-						r.startTime <
-							sThis.lastNetworkRequestResponsePairTimestamp
-					) {
+					if (r.startTime < sThis.lastNetworkRequestTimestamp) {
 						return false
 					}
 
@@ -313,8 +310,9 @@ export class FirstLoadListeners {
 					}
 				})
 
-			sThis.lastNetworkRequestResponsePairTimestamp =
-				httpResources.at(-1)?.startTime
+			sThis.lastNetworkRequestTimestamp =
+				httpResources.at(-1)?.startTime ||
+				sThis.lastNetworkRequestTimestamp
 
 			if (sThis.enableRecordingNetworkContents) {
 				const sanitizeOptions = {


### PR DESCRIPTION
## Summary
Some external libraries (e.g. dynatrace) monkey patch `performance.clearResourceTimings()` to not clear the network resources, resulting in customers seeing duplicate network resources. Keep track of the last processed resource time, and filter out any resources before this time.

Before
![Screenshot 2024-05-10 at 3 16 50 PM](https://github.com/highlight/highlight/assets/17744174/6e465a82-1f29-427a-bd59-c30bf8abd6b6)

After
![Screenshot 2024-05-10 at 3 17 19 PM](https://github.com/highlight/highlight/assets/17744174/d716eab4-0d91-407a-b0c2-f037ba2ab3b2)

## How did you test this change?
1) Load main
2) Comment out the `performance.clearResourceTimings()` in `clearRecordedNetworkResources`
3) Complete a session for about a minute
4) View that sessions
- [ ] There are duplicate network requests 
5) Check out this branch
6) Complete a session for about a minute
7) View that sessions
- [ ] There are NO duplicate network requests 

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
