### PR TITLE
Fixed broken php log ingestion link 

### DIFF
--- a/highlight.io/components/QuickstartContent/backend/php/shared-snippets.tsx
+++ b/highlight.io/components/QuickstartContent/backend/php/shared-snippets.tsx
@@ -69,6 +69,6 @@ export const verifyErrors: QuickStartStep = {
 export const setUpLogging: (slug: string) => QuickStartStep = (slug) => ({
 	title: 'Set up logging.',
 	content: `Start sending logs to Highlight! Follow the [logging setup guide](${siteUrl(
-		`/docs/getting-started/backend-logging/php/overview`,
+		`/docs/getting-started/backend-logging/php`,
 	)}) to get started.`,
 })


### PR DESCRIPTION
## Summary

<!--
 Ideally, there is an attached GitHub issue that will describe the "why".

 If relevant, use this section to call out any additional information you'd like to _highlight_ to the reviewer.
-->

Original report from Arffeh viewed on discord.
Redirect link for the `logging setup guide` is broken on [this page](https://www.highlight.io/docs/getting-started/backend-sdk/php/other).

## How did you test this change?

<!--
 Frontend - Leave a screencast or a screenshot to visually describe the changes.
-->
Checked that the new page redirection was working well

## Are there any deployment considerations?

<!--
 Backend - Do we need to consider migrations or backfilling data?
-->
No

## Does this work require review from our design team?

<!--
 Request review from julian-highlight / our design team 
-->
No